### PR TITLE
Introduce free functions for consensus algorithms.

### DIFF
--- a/include/deal.II/fe/fe_tools_extrapolate.templates.h
+++ b/include/deal.II/fe/fe_tools_extrapolate.templates.h
@@ -1177,12 +1177,11 @@ namespace FETools
         Assert(answer.size() == 0, ExcInternalError());
       };
 
-      Utilities::MPI::ConsensusAlgorithms::Selector<char, char>().run(
-        destinations,
-        create_request,
-        answer_request,
-        read_answer,
-        communicator);
+      Utilities::MPI::ConsensusAlgorithms::selector<char, char>(destinations,
+                                                                create_request,
+                                                                answer_request,
+                                                                read_answer,
+                                                                communicator);
     }
 
 

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -432,7 +432,7 @@ namespace Utilities
       if (Utilities::MPI::min((my_destinations_are_unique ? 1 : 0), mpi_comm) ==
           1)
         {
-          return ConsensusAlgorithms::NBX<char, char>().run(
+          return ConsensusAlgorithms::nbx<char, char>(
             destinations, {}, {}, {}, mpi_comm);
         }
         // If that was not the case, we need to use the remainder of the code
@@ -588,8 +588,8 @@ namespace Utilities
       if (Utilities::MPI::min((my_destinations_are_unique ? 1 : 0), mpi_comm) ==
           1)
         {
-          return ConsensusAlgorithms::NBX<char, char>()
-            .run(destinations, {}, {}, {}, mpi_comm)
+          return ConsensusAlgorithms::nbx<char, char>(
+                   destinations, {}, {}, {}, mpi_comm)
             .size();
         }
       else

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -6019,7 +6019,7 @@ namespace GridTools
           }
       };
 
-      Utilities::MPI::ConsensusAlgorithms::Selector<char, char>().run(
+      Utilities::MPI::ConsensusAlgorithms::selector<char, char>(
         potential_owners_ranks,
         create_request,
         answer_request,

--- a/source/grid/tria_description.cc
+++ b/source/grid/tria_description.cc
@@ -143,12 +143,12 @@ namespace TriangulationDescription
           };
 
 
-          dealii::Utilities::MPI::ConsensusAlgorithms::Selector<char, char>()
-            .run(relevant_processes,
-                 create_request,
-                 answer_request,
-                 process_answer,
-                 comm);
+          dealii::Utilities::MPI::ConsensusAlgorithms::selector<char, char>(
+            relevant_processes,
+            create_request,
+            answer_request,
+            process_answer,
+            comm);
         }
 
         /**

--- a/tests/base/consensus_algorithm_01.cc
+++ b/tests/base/consensus_algorithm_01.cc
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-// Test ConsensusAlgorithms::AnonymousProcess.
+// Test ConsensusAlgorithms::selection().
 
 #include <deal.II/base/mpi_consensus_algorithms.h>
 
@@ -30,31 +30,26 @@ test(const MPI_Comm &comm)
   using T1 = unsigned int;
   using T2 = unsigned int;
 
-  dealii::Utilities::MPI::ConsensusAlgorithms::AnonymousProcess<T1, T2> process(
-    [&]() {
-      std::vector<unsigned int> result{(my_rank + 1) % n_rank};
-      return result;
-    },
-    [&](const unsigned int other_rank, std::vector<T1> &send_buffer) {
-      send_buffer.push_back(my_rank);
-    },
-    [&](const unsigned int &   other_rank,
-        const std::vector<T1> &buffer_recv,
-        std::vector<T2> &      request_buffer) {
-      AssertDimension(other_rank, buffer_recv.front());
-      deallog << "ConsensusAlgorithmProcess::answer_request() passed!"
-              << std::endl;
-      request_buffer.push_back(my_rank);
-    },
-    [&](const unsigned int other_rank, const std::vector<T2> &recv_buffer) {
-      AssertDimension(other_rank, recv_buffer.front());
-      deallog << "ConsensusAlgorithmProcess::function_read_answer() passed!"
-              << std::endl;
-    });
-
   const auto sources =
-    dealii::Utilities::MPI::ConsensusAlgorithms::Selector<T1, T2>(process, comm)
-      .run();
+    dealii::Utilities::MPI::ConsensusAlgorithms::selector<T1, T2>(
+      /* target_processes: */
+      std::vector<unsigned int>{(my_rank + 1) % n_rank},
+      /* create_request: */
+      [my_rank](const unsigned int) { return std::vector<T1>({my_rank}); },
+      /* answer_request: */
+      [my_rank](const unsigned int other_rank, const std::vector<T1> &request) {
+        AssertDimension(other_rank, request.front());
+        deallog << "ConsensusAlgorithmProcess::answer_request() passed!"
+                << std::endl;
+        return std::vector<T2>({my_rank});
+      },
+      /* process_answer: */
+      [](const unsigned int other_rank, const std::vector<T2> &answer) {
+        AssertDimension(other_rank, answer.front());
+        deallog << "ConsensusAlgorithmProcess::function_read_answer() passed!"
+                << std::endl;
+      },
+      comm);
 
   for (const auto &i : sources)
     deallog << i << ' ';


### PR DESCRIPTION
This addresses #13358. It introduces free functions for the consensus algorithms and uses them in all of the places where we currently use the `run()` functions that get their information through a number of `std::function` arguments.

I took the liberty to move the main parts of the documentation from the base class to the namespace everything is in. The new functions and the old classes now refer to this main documentation place.

/rebuild