### PR TITLE
FEEval::check_vector_compatibility: improve assert message

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -3279,11 +3279,15 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
                           "FEEvaluation. In that case, you must pass an "
                           "std::vector<VectorType> or a BlockVector to " +
                           "read_dof_values and distribute_local_to_global."));
-        internal::check_vector_compatibility(*src[comp], *this->dof_info);
+        internal::check_vector_compatibility(*src[comp],
+                                             *this->matrix_free,
+                                             *this->dof_info);
       }
   else
     {
-      internal::check_vector_compatibility(*src[0], *this->dof_info);
+      internal::check_vector_compatibility(*src[0],
+                                           *this->matrix_free,
+                                           *this->dof_info);
     }
 
   // Case 2: contiguous indices which use reduced storage of indices and can

--- a/include/deal.II/matrix_free/vector_access_internal.h
+++ b/include/deal.II/matrix_free/vector_access_internal.h
@@ -22,8 +22,12 @@
 #include <deal.II/base/vectorization.h>
 
 #include <deal.II/matrix_free/dof_info.h>
+#include <deal.II/matrix_free/matrix_free.h>
 #include <deal.II/matrix_free/type_traits.h>
 
+#if DEBUG
+#  include <boost/algorithm/string/join.hpp>
+#endif
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -169,15 +173,20 @@ namespace internal
   // version below is when has_partitioners_are_compatible == false
   // FIXME: this is incorrect for PETSc/Trilinos MPI vectors
   template <
+    int dim,
+    typename Number,
+    typename VectorizedArrayType,
     typename VectorType,
     typename std::enable_if<!has_partitioners_are_compatible<VectorType>,
                             VectorType>::type * = nullptr>
   inline void
   check_vector_compatibility(
-    const VectorType &                            vec,
-    const internal::MatrixFreeFunctions::DoFInfo &dof_info)
+    const VectorType &                                  vec,
+    const MatrixFree<dim, Number, VectorizedArrayType> &matrix_free,
+    const internal::MatrixFreeFunctions::DoFInfo &      dof_info)
   {
     (void)vec;
+    (void)matrix_free;
     (void)dof_info;
 
     AssertDimension(vec.size(), dof_info.vector_partitioner->size());
@@ -186,25 +195,80 @@ namespace internal
 
 
   // same as above for has_partitioners_are_compatible == true
-  template <typename VectorType,
+  template <int dim,
+            typename Number,
+            typename VectorizedArrayType,
+            typename VectorType,
             typename std::enable_if<has_partitioners_are_compatible<VectorType>,
                                     VectorType>::type * = nullptr>
   inline void
   check_vector_compatibility(
-    const VectorType &                            vec,
-    const internal::MatrixFreeFunctions::DoFInfo &dof_info)
+    const VectorType &                                  vec,
+    const MatrixFree<dim, Number, VectorizedArrayType> &matrix_free,
+    const internal::MatrixFreeFunctions::DoFInfo &      dof_info)
   {
     (void)vec;
+    (void)matrix_free;
     (void)dof_info;
-    Assert(vec.partitioners_are_compatible(*dof_info.vector_partitioner),
-           ExcMessage(
-             "The parallel layout of the given vector is not "
-             "compatible with the parallel partitioning in MatrixFree. "
-             "A potential reason is that you did not use "
-             "MatrixFree::initialize_dof_vector() to get a "
-             "compatible vector. If you did, the dof_handler_index "
-             "used there and the one passed to the constructor of "
-             "FEEvaluation do not match."));
+
+#if DEBUG
+    if (vec.partitioners_are_compatible(*dof_info.vector_partitioner) == false)
+      {
+        unsigned int dof_index = numbers::invalid_unsigned_int;
+
+        for (unsigned int i = 0; i < matrix_free.n_components(); ++i)
+          if (&matrix_free.get_dof_info(i) == &dof_info)
+            {
+              dof_index = i;
+              break;
+            }
+
+        Assert(dof_index != numbers::invalid_unsigned_int, ExcInternalError());
+
+        std::vector<std::string> dof_indices_with_compatible_partitioners;
+
+        for (unsigned int i = 0; i < matrix_free.n_components(); ++i)
+          if (vec.partitioners_are_compatible(
+                *matrix_free.get_dof_info(i).vector_partitioner))
+            dof_indices_with_compatible_partitioners.push_back(
+              std::to_string(i));
+
+        if (dof_indices_with_compatible_partitioners.empty())
+          {
+            Assert(false,
+                   ExcMessage("The parallel layout of the given vector is "
+                              "compatible neither with the Partitioner of the "
+                              "current FEEvaluation with dof_handler_index=" +
+                              std::to_string(dof_index) +
+                              " nor with any Partitioner in MatrixFree. A "
+                              "potential reason is that you did not use "
+                              "MatrixFree::initialize_dof_vector() to get a "
+                              "compatible vector."));
+          }
+        else
+          {
+            Assert(
+              false,
+              ExcMessage(
+                "The parallel layout of the given vector is "
+                "not compatible with the Partitioner of the "
+                "current FEEvaluation with dof_handler_index=" +
+                std::to_string(dof_index) +
+                ". However, the underlying "
+                "MatrixFree contains Partitioner objects that are compatible. "
+                "They have the following dof_handler_index values: " +
+                boost::algorithm::join(dof_indices_with_compatible_partitioners,
+                                       ", ") +
+                ". Did you want to pass any of these values to the "
+                "constructor of the current FEEvaluation object or "
+                "did you not use MatrixFree::initialize_dof_vector() "
+                "with dof_handler_index=" +
+                std::to_string(dof_index) +
+                " to get a "
+                "compatible vector?"));
+          }
+      }
+#endif
   }
 
 


### PR DESCRIPTION
The assert message:
```
Additional information: 
    The parallel layout of the given vector is not compatible with the 
    parallel partitioning in MatrixFree. A potential reason is that 
    you did not use MatrixFree::initialize_dof_vector() to get a
    compatible vector. If you did, the dof_handler_index used there
    and the one passed to the constructor of FEEvaluation do not match.  
```
is a bit too general. In particular, the hints at the end could be improved by adding actual indices.

This PR tries to improve the assert message. For the following program:
```cpp
#include <deal.II/distributed/tria.h>

#include <deal.II/dofs/dof_handler.h>

#include <deal.II/fe/fe_q.h>

#include <deal.II/grid/grid_generator.h>

#include <deal.II/matrix_free/fe_evaluation.h>
#include <deal.II/matrix_free/matrix_free.h>

using namespace dealii;

int
main(int argc, char **argv)
{
  Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);

  AssertDimension(argc, 2);

  const unsigned int dim = 2;

  parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD);
  GridGenerator::hyper_cube(tria);

  FE_Q<dim>            fe_1(1);
  FE_Q<dim>            fe_2(2);
  QGauss<1>            quad(1);
  MappingQGeneric<dim> mapping(1);

  DoFHandler<dim> dof_handler_1(tria);
  dof_handler_1.distribute_dofs(fe_1);

  DoFHandler<dim> dof_handler_2(tria);
  dof_handler_2.distribute_dofs(fe_2);

  AffineConstraints<double> constraints;
  constraints.close();

  typename MatrixFree<dim, double>::AdditionalData additional_data;
  additional_data.mapping_update_flags = update_gradients | update_values;

  MatrixFree<dim, double> matrix_free;
  matrix_free.reinit(mapping,
                     std::vector<const DoFHandler<dim> *>{&dof_handler_1,
                                                          &dof_handler_2,
                                                          &dof_handler_1},
                     std::vector<const AffineConstraints<double> *>{
                       &constraints, &constraints, &constraints},
                     quad,
                     additional_data);

  using VectorType = LinearAlgebra::distributed::Vector<double>;

  switch (atoi(argv[1]))
    {
      case 0:
        {
          FEEvaluation<dim, -1, 0, 1, double> phi(matrix_free, 0);
          phi.reinit(0);

          VectorType vec;

          phi.read_dof_values(vec);
          break;
        }
      case 1:
        {
          FEEvaluation<dim, -1, 0, 1, double> phi(matrix_free, 1);
          phi.reinit(0);

          VectorType vec;

          phi.read_dof_values(vec);
          break;
        }
      case 2:
        {
          FEEvaluation<dim, -1, 0, 1, double> phi(matrix_free, 0);
          phi.reinit(0);

          VectorType vec;
          matrix_free.initialize_dof_vector(vec, 1);

          phi.read_dof_values(vec);
          break;
        }
      case 3:
        {
          FEEvaluation<dim, -1, 0, 1, double> phi(matrix_free, 1);
          phi.reinit(0);

          VectorType vec;
          matrix_free.initialize_dof_vector(vec, 0);

          phi.read_dof_values(vec);
          break;
        }
    }
}
```
the following assert messages are printed:
```
Additional information: 
    The parallel layout of the given vector is compatible neither with the
    Partitioner of the current FEEvaluation with dof_handler_index=0 nor
    with any Partioner in MatrixFree. A potential reason is that you did
    not use MatrixFree::initialize_dof_vector() to get a compatible
    vector.
    
Additional information: 
    The parallel layout of the given vector is compatible neither with the
    Partitioner of the current FEEvaluation with dof_handler_index=1 nor
    with any Partioner in MatrixFree. A potential reason is that you did
    not use MatrixFree::initialize_dof_vector() to get a compatible
    vector.
    
Additional information: 
    The parallel layout of the given vector is not compatible with the
    Partitioner of the current FEEvaluation with dof_handler_index=0.
    However, the underlying MatrixFree contais Partitioner objects that
    are compatible. They have the following dof_handler_index values: 1.
    Did you want to pass any of these values to the constructor of the
    current FEEvaluation object or did you not use
    MatrixFree::initialize_dof_vector() with dof_handler_index=0 to get a
    compatible vector.        
    
Additional information: 
    The parallel layout of the given vector is not compatible with the
    Partitioner of the current FEEvaluation with dof_handler_index=1.
    However, the underlying MatrixFree contais Partitioner objects that
    are compatible. They have the following dof_handler_index values: 0,
    2. Did you want to pass any of these values to the constructor of the
    current FEEvaluation object or did you not use
    MatrixFree::initialize_dof_vector() with dof_handler_index=1 to get a
    compatible vector.  
```

Written jointly with @mschreter.