### PR TITLE
Fixed bug in gmsh api.

### DIFF
--- a/doc/news/changes/minor/20220220LucaHeltai
+++ b/doc/news/changes/minor/20220220LucaHeltai
@@ -1,0 +1,3 @@
+Fixed: GridOut::write_msh() with gmsh api now works also with non standard combinations of boundary and manifold ids.
+<br>
+(Luca Heltai, 2022/02/20)

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -1595,10 +1595,6 @@ GridOut::write_msh(const Triangulation<dim, spacedim> &tria,
                                                all_element_nodes);
       }
 
-  // Make sure nodes belong to the right entities.
-  gmsh::model::mesh::reclassifyNodes();
-  gmsh::model::mesh::removeDuplicateNodes();
-
   // Now for each individual pair of dim and entry, add a physical group, if
   // necessary
   for (const auto &it : dim_entity_tag)

--- a/tests/gmsh/gmsh_api_05.cc
+++ b/tests/gmsh/gmsh_api_05.cc
@@ -1,0 +1,66 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Check that gmsh api correctly reads and writes a mesh with manifold
+// information, in all coordinate dimensions
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_in.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/reference_cell.h>
+#include <deal.II/grid/tria.h>
+
+#include "../tests.h"
+
+template <int dim, int spacedim>
+void
+test()
+{
+  deallog << "Testing hypercube in dimensions " << '<' << dim << ',' << spacedim
+          << '>' << std::endl;
+
+  Triangulation<dim, spacedim> tria;
+  GridGenerator::hyper_cube(tria, 0, 1, true);
+  tria.begin()->face(0)->set_manifold_id(1);
+
+  GridOut go;
+  go.write_msh(tria, "output.msh");
+
+  Triangulation<dim, spacedim> tria2;
+  GridIn<dim, spacedim>        gi(tria2);
+  gi.read_msh("output.msh");
+  go.write_msh(tria2, "output2.msh");
+
+  deallog << "Original mesh: " << std::endl;
+  cat_file("output.msh");
+  deallog << "Regenerated mesh: " << std::endl;
+  cat_file("output2.msh");
+}
+
+int
+main()
+{
+  initlog();
+
+  // Generate and print all hypercubes in all dimension combinations
+  test<1, 1>();
+  test<1, 2>();
+  test<1, 3>();
+
+  test<2, 2>();
+  test<2, 3>();
+
+  test<3, 3>();
+}

--- a/tests/gmsh/gmsh_api_05.with_gmsh_with_api=on.output
+++ b/tests/gmsh/gmsh_api_05.with_gmsh_with_api=on.output
@@ -1,0 +1,870 @@
+
+DEAL::Testing hypercube in dimensions <1,1>
+DEAL::Original mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+2
+0 1 "ManifoldID:1"
+0 2 "BoundaryID:1"
+$EndPhysicalNames
+$Entities
+2 1 0 0
+1 0 0 0 1 1 
+3 0 0 0 1 2 
+2 0 0 0 1 0 0 1 3 0 
+$EndEntities
+$Nodes
+3 6 1 2
+0 1 0 2
+1
+2
+0 0 0
+1 0 0
+0 3 0 2
+1
+2
+0 0 0
+1 0 0
+1 2 0 2
+1
+2
+0 0 0
+1 0 0
+$EndNodes
+$Elements
+1 1 1 1
+1 2 1 1
+1 1 2 
+$EndElements
+
+DEAL::Regenerated mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+1
+0 1 "BoundaryID:1"
+$EndPhysicalNames
+$Entities
+1 1 0 0
+2 0 0 0 1 1 
+1 0 0 0 1 0 0 1 2 0 
+$EndEntities
+$Nodes
+2 4 1 2
+0 2 0 2
+1
+2
+0 0 0
+1 0 0
+1 1 0 2
+1
+2
+0 0 0
+1 0 0
+$EndNodes
+$Elements
+1 1 1 1
+1 1 1 1
+1 1 2 
+$EndElements
+
+DEAL::Testing hypercube in dimensions <1,2>
+DEAL::Original mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+2
+0 1 "ManifoldID:1"
+0 2 "BoundaryID:1"
+$EndPhysicalNames
+$Entities
+2 1 0 0
+1 0 0 0 1 1 
+3 0 0 0 1 2 
+2 0 0 0 1 0 0 1 3 0 
+$EndEntities
+$Nodes
+3 6 1 2
+0 1 0 2
+1
+2
+0 0 0
+1 0 0
+0 3 0 2
+1
+2
+0 0 0
+1 0 0
+1 2 0 2
+1
+2
+0 0 0
+1 0 0
+$EndNodes
+$Elements
+1 1 1 1
+1 2 1 1
+1 1 2 
+$EndElements
+
+DEAL::Regenerated mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+1
+0 1 "BoundaryID:1"
+$EndPhysicalNames
+$Entities
+1 1 0 0
+2 0 0 0 1 1 
+1 0 0 0 1 0 0 1 2 0 
+$EndEntities
+$Nodes
+2 4 1 2
+0 2 0 2
+1
+2
+0 0 0
+1 0 0
+1 1 0 2
+1
+2
+0 0 0
+1 0 0
+$EndNodes
+$Elements
+1 1 1 1
+1 1 1 1
+1 1 2 
+$EndElements
+
+DEAL::Testing hypercube in dimensions <1,3>
+DEAL::Original mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+2
+0 1 "ManifoldID:1"
+0 2 "BoundaryID:1"
+$EndPhysicalNames
+$Entities
+2 1 0 0
+1 0 0 0 1 1 
+3 0 0 0 1 2 
+2 0 0 0 1 0 0 1 3 0 
+$EndEntities
+$Nodes
+3 6 1 2
+0 1 0 2
+1
+2
+0 0 0
+1 0 0
+0 3 0 2
+1
+2
+0 0 0
+1 0 0
+1 2 0 2
+1
+2
+0 0 0
+1 0 0
+$EndNodes
+$Elements
+1 1 1 1
+1 2 1 1
+1 1 2 
+$EndElements
+
+DEAL::Regenerated mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+1
+0 1 "BoundaryID:1"
+$EndPhysicalNames
+$Entities
+1 1 0 0
+2 0 0 0 1 1 
+1 0 0 0 1 0 0 1 2 0 
+$EndEntities
+$Nodes
+2 4 1 2
+0 2 0 2
+1
+2
+0 0 0
+1 0 0
+1 1 0 2
+1
+2
+0 0 0
+1 0 0
+$EndNodes
+$Elements
+1 1 1 1
+1 1 1 1
+1 1 2 
+$EndElements
+
+DEAL::Testing hypercube in dimensions <2,2>
+DEAL::Original mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+4
+1 1 "ManifoldID:1"
+1 2 "BoundaryID:1"
+1 3 "BoundaryID:2"
+1 4 "BoundaryID:3"
+$EndPhysicalNames
+$Entities
+0 4 1 0
+1 0 0 0 0 1 0 1 1 0 
+3 1 0 0 1 1 0 1 2 0 
+4 0 0 0 1 0 0 1 3 0 
+5 0 1 0 1 1 0 1 4 0 
+2 0 0 0 1 1 0 1 5 0 
+$EndEntities
+$Nodes
+5 20 1 4
+1 1 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+1 3 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+1 4 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+1 5 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+2 2 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+$EndNodes
+$Elements
+5 5 1 5
+1 1 1 1
+2 1 3 
+1 3 1 1
+3 2 4 
+1 4 1 1
+4 1 2 
+1 5 1 1
+5 3 4 
+2 2 3 1
+1 1 2 4 3 
+$EndElements
+
+DEAL::Regenerated mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+4
+1 1 "ManifoldID:1"
+1 2 "BoundaryID:1"
+1 3 "BoundaryID:2"
+1 4 "BoundaryID:3"
+$EndPhysicalNames
+$Entities
+0 4 1 0
+1 0 0 0 0 1 0 1 1 0 
+3 1 0 0 1 1 0 1 2 0 
+4 0 0 0 1 0 0 1 3 0 
+5 0 1 0 1 1 0 1 4 0 
+2 0 0 0 1 1 0 1 5 0 
+$EndEntities
+$Nodes
+5 20 1 4
+1 1 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+1 3 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+1 4 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+1 5 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+2 2 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+$EndNodes
+$Elements
+5 5 1 5
+1 1 1 1
+2 1 3 
+1 3 1 1
+3 2 4 
+1 4 1 1
+4 1 2 
+1 5 1 1
+5 3 4 
+2 2 3 1
+1 1 2 4 3 
+$EndElements
+
+DEAL::Testing hypercube in dimensions <2,3>
+DEAL::Original mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+4
+1 1 "ManifoldID:1"
+1 2 "BoundaryID:1"
+1 3 "BoundaryID:2"
+1 4 "BoundaryID:3"
+$EndPhysicalNames
+$Entities
+0 4 1 0
+1 0 0 0 0 1 0 1 1 0 
+3 1 0 0 1 1 0 1 2 0 
+4 0 0 0 1 0 0 1 3 0 
+5 0 1 0 1 1 0 1 4 0 
+2 0 0 0 1 1 0 1 5 0 
+$EndEntities
+$Nodes
+5 20 1 4
+1 1 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+1 3 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+1 4 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+1 5 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+2 2 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+$EndNodes
+$Elements
+5 5 1 5
+1 1 1 1
+2 1 3 
+1 3 1 1
+3 2 4 
+1 4 1 1
+4 1 2 
+1 5 1 1
+5 3 4 
+2 2 3 1
+1 1 2 4 3 
+$EndElements
+
+DEAL::Regenerated mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+4
+1 1 "ManifoldID:1"
+1 2 "BoundaryID:1"
+1 3 "BoundaryID:2"
+1 4 "BoundaryID:3"
+$EndPhysicalNames
+$Entities
+0 4 1 0
+1 0 0 0 0 1 0 1 1 0 
+3 1 0 0 1 1 0 1 2 0 
+4 0 0 0 1 0 0 1 3 0 
+5 0 1 0 1 1 0 1 4 0 
+2 0 0 0 1 1 0 1 5 0 
+$EndEntities
+$Nodes
+5 20 1 4
+1 1 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+1 3 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+1 4 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+1 5 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+2 2 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+$EndNodes
+$Elements
+5 5 1 5
+1 1 1 1
+2 1 3 
+1 3 1 1
+3 2 4 
+1 4 1 1
+4 1 2 
+1 5 1 1
+5 3 4 
+2 2 3 1
+1 1 2 4 3 
+$EndElements
+
+DEAL::Testing hypercube in dimensions <3,3>
+DEAL::Original mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+6
+2 1 "ManifoldID:1"
+2 2 "BoundaryID:1"
+2 3 "BoundaryID:2"
+2 4 "BoundaryID:3"
+2 5 "BoundaryID:4"
+2 6 "BoundaryID:5"
+$EndPhysicalNames
+$Entities
+0 0 6 1
+1 0 0 0 0 1 1 1 1 0 
+3 1 0 0 1 1 1 1 2 0 
+4 0 0 0 1 0 1 1 3 0 
+5 0 1 0 1 1 1 1 4 0 
+6 0 0 0 1 1 0 1 5 0 
+7 0 0 1 1 1 1 1 6 0 
+2 0 0 0 1 1 1 1 7 0 
+$EndEntities
+$Nodes
+7 56 1 8
+2 1 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+2 3 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+2 4 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+2 5 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+2 6 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+2 7 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+3 2 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+$EndNodes
+$Elements
+7 7 1 7
+2 1 3 1
+2 1 3 7 5 
+2 3 3 1
+3 2 4 8 6 
+2 4 3 1
+4 1 5 6 2 
+2 5 3 1
+5 3 7 8 4 
+2 6 3 1
+6 1 2 4 3 
+2 7 3 1
+7 5 6 8 7 
+3 2 5 1
+1 1 2 4 3 5 6 8 7 
+$EndElements
+
+DEAL::Regenerated mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+6
+2 1 "ManifoldID:1"
+2 2 "BoundaryID:1"
+2 3 "BoundaryID:2"
+2 4 "BoundaryID:3"
+2 5 "BoundaryID:4"
+2 6 "BoundaryID:5"
+$EndPhysicalNames
+$Entities
+0 0 6 1
+1 0 0 0 0 1 1 1 1 0 
+3 1 0 0 1 1 1 1 2 0 
+4 0 0 0 1 0 1 1 3 0 
+5 0 1 0 1 1 1 1 4 0 
+6 0 0 0 1 1 0 1 5 0 
+7 0 0 1 1 1 1 1 6 0 
+2 0 0 0 1 1 1 1 7 0 
+$EndEntities
+$Nodes
+7 56 1 8
+2 1 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+2 3 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+2 4 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+2 5 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+2 6 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+2 7 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+3 2 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+$EndNodes
+$Elements
+7 7 1 7
+2 1 3 1
+2 1 3 7 5 
+2 3 3 1
+3 2 4 8 6 
+2 4 3 1
+4 1 5 6 2 
+2 5 3 1
+5 3 7 8 4 
+2 6 3 1
+6 1 2 4 3 
+2 7 3 1
+7 5 6 8 7 
+3 2 5 1
+1 1 2 4 3 5 6 8 7 
+$EndElements
+


### PR DESCRIPTION
Gmesh api was not outputting any vertex when non trivial combinations of physical and elementary entities were used. This seems to be an issue with gmsh api, that does not know how to properly reorder and re-assign nodes to entities when some nodes are shared between too many entities (which is always the case for non-trivial manifold ids/material ids, and so forth).

Since we already know that nodes are not repeated, and we are happy with the grid that we have in deal.II, there is really no need to reorder nodes and eliminate duplicates (as nodes are already sorted in deal.II ordering, and nodes are not repeated in deal.II grids).

Removing that call allows now arbitrary manifold and boundary ids to be specified in gmsh files, and grids to be read and written correctly.

<s>I remember having opened an issue with this, but now I don't find it anywhere... </s> (I had actually opened #13143  with two failing tests. Those tests are a subset of the test I added here.)