### PR TITLE
Remove some unnecessary includes of grid_tools.h

### DIFF
--- a/doc/news/changes/incompatibilities/20220222MartinKronbichler
+++ b/doc/news/changes/incompatibilities/20220222MartinKronbichler
@@ -1,0 +1,6 @@
+Updated: Spurious inclusions of the header files `deal.II/grid/grid_tools.h`
+and `deal.II/grid/grid_tools_cache.h` from other headers of deal.II have been
+removed. User codes relying on this implicit inclusion will need to add the
+respective include files.
+<br>
+(Martin Kronbichler, 2022/02/22)

--- a/examples/step-75/step-75.cc
+++ b/examples/step-75/step-75.cc
@@ -51,6 +51,7 @@
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/trilinos_precondition.h>
 #include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_sparsity_pattern.h>
 #include <deal.II/lac/vector.h>
 
 #include <deal.II/numerics/data_out.h>

--- a/examples/step-85/step-85.cc
+++ b/examples/step-85/step-85.cc
@@ -42,6 +42,7 @@
 #include <deal.II/hp/q_collection.h>
 
 #include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/precondition.h>
 #include <deal.II/lac/solver_cg.h>

--- a/include/deal.II/base/mpi_remote_point_evaluation.h
+++ b/include/deal.II/base/mpi_remote_point_evaluation.h
@@ -20,9 +20,6 @@
 
 #include <deal.II/dofs/dof_handler.h>
 
-#include <deal.II/grid/grid_tools.h>
-#include <deal.II/grid/grid_tools_cache.h>
-
 DEAL_II_NAMESPACE_OPEN
 
 

--- a/include/deal.II/distributed/fully_distributed_tria.h
+++ b/include/deal.II/distributed/fully_distributed_tria.h
@@ -22,8 +22,6 @@
 #include <deal.II/distributed/repartitioning_policy_tools.h>
 #include <deal.II/distributed/tria_base.h>
 
-#include <deal.II/grid/grid_tools.h>
-
 #include <vector>
 
 #ifdef DEAL_II_WITH_MPI

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -32,8 +32,6 @@
 #include <deal.II/fe/mapping.h>
 #include <deal.II/fe/mapping_q1.h>
 
-#include <deal.II/grid/grid_tools.h>
-
 #include <deal.II/hp/dof_handler.h>
 #include <deal.II/hp/mapping_collection.h>
 #include <deal.II/hp/q_collection.h>

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -34,7 +34,6 @@
 
 #include <deal.II/grid/cell_id_translator.h>
 #include <deal.II/grid/filtered_iterator.h>
-#include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/tria_description.h>
 
 #include <deal.II/hp/dof_handler.h>

--- a/include/deal.II/numerics/point_value_history.h
+++ b/include/deal.II/numerics/point_value_history.h
@@ -34,8 +34,6 @@
 #include <deal.II/fe/mapping.h>
 #include <deal.II/fe/mapping_q1.h>
 
-#include <deal.II/grid/grid_tools.h>
-
 #include <deal.II/lac/vector.h>
 
 #include <deal.II/numerics/data_postprocessor.h>

--- a/source/numerics/point_value_history.cc
+++ b/source/numerics/point_value_history.cc
@@ -14,6 +14,8 @@
 // ---------------------------------------------------------------------
 
 
+#include <deal.II/grid/grid_tools.h>
+
 #include <deal.II/lac/block_vector.h>
 #include <deal.II/lac/la_parallel_block_vector.h>
 #include <deal.II/lac/la_parallel_vector.h>

--- a/tests/distributed_grids/checkpointing_02.cc
+++ b/tests/distributed_grids/checkpointing_02.cc
@@ -47,6 +47,7 @@ const bool big = false;
 
 #include <deal.II/lac/la_parallel_vector.h>
 #include <deal.II/lac/sparsity_tools.h>
+#include <deal.II/lac/trilinos_vector.h>
 #include <deal.II/lac/vector.h>
 
 #include <deal.II/numerics/data_out.h>

--- a/tests/distributed_grids/checkpointing_03.cc
+++ b/tests/distributed_grids/checkpointing_03.cc
@@ -44,6 +44,7 @@ const bool big = false;
 
 #include <deal.II/lac/la_parallel_vector.h>
 #include <deal.II/lac/sparsity_tools.h>
+#include <deal.II/lac/trilinos_vector.h>
 #include <deal.II/lac/vector.h>
 
 #include <deal.II/numerics/data_out.h>

--- a/tests/matrix_free/compress_mapping.cc
+++ b/tests/matrix_free/compress_mapping.cc
@@ -28,6 +28,7 @@
 #include <deal.II/fe/mapping_q.h>
 
 #include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/manifold_lib.h>
 #include <deal.II/grid/tria.h>
 
 #include <deal.II/lac/affine_constraints.h>

--- a/tests/matrix_free/ecl.h
+++ b/tests/matrix_free/ecl.h
@@ -21,6 +21,7 @@
 #include <deal.II/fe/mapping_q.h>
 
 #include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
 
 #include <deal.II/matrix_free/fe_evaluation.h>
 #include <deal.II/matrix_free/matrix_free.h>

--- a/tests/matrix_free/ecl_02.cc
+++ b/tests/matrix_free/ecl_02.cc
@@ -21,6 +21,7 @@
 #include <deal.II/fe/mapping_q.h>
 
 #include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
 
 #include <deal.II/matrix_free/fe_evaluation.h>
 #include <deal.II/matrix_free/matrix_free.h>

--- a/tests/matrix_free/fe_evaluation_renumbered.cc
+++ b/tests/matrix_free/fe_evaluation_renumbered.cc
@@ -22,6 +22,8 @@
 
 #include <deal.II/grid/grid_generator.h>
 
+#include <deal.II/lac/la_vector.h>
+
 #include <deal.II/matrix_free/fe_evaluation.h>
 #include <deal.II/matrix_free/matrix_free.h>
 

--- a/tests/matrix_free/parallel_multigrid_fullydistributed.cc
+++ b/tests/matrix_free/parallel_multigrid_fullydistributed.cc
@@ -30,6 +30,7 @@
 #include <deal.II/fe/mapping_q.h>
 
 #include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/tria_description.h>
 

--- a/tests/multigrid-global-coarsening/mg_transfer_p_04.cc
+++ b/tests/multigrid-global-coarsening/mg_transfer_p_04.cc
@@ -37,6 +37,7 @@
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/quadrature_lib.h>
 
+#include <deal.II/distributed/shared_tria.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_handler.h>
@@ -48,6 +49,7 @@
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_tools.h>
 
 #include <deal.II/matrix_free/fe_evaluation.h>
 #include <deal.II/matrix_free/matrix_free.h>

--- a/tests/multigrid-global-coarsening/multigrid_util.h
+++ b/tests/multigrid-global-coarsening/multigrid_util.h
@@ -39,6 +39,7 @@
 #include <deal.II/lac/solver_control.h>
 #include <deal.II/lac/trilinos_precondition.h>
 #include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_sparsity_pattern.h>
 
 #include <deal.II/matrix_free/fe_evaluation.h>
 #include <deal.II/matrix_free/matrix_free.h>

--- a/tests/remote_point_evaluation/mapping_02.cc
+++ b/tests/remote_point_evaluation/mapping_02.cc
@@ -25,6 +25,8 @@
 
 #include <deal.II/grid/filtered_iterator.h>
 #include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/grid_tools_cache.h>
 
 #include <deal.II/lac/la_vector.h>
 

--- a/tests/simplex/data_out_write_hdf5_02.cc
+++ b/tests/simplex/data_out_write_hdf5_02.cc
@@ -34,6 +34,7 @@
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_in.h>
 #include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/tria.h>
 
 #include <deal.II/numerics/data_out.h>

--- a/tests/simplex/step-40.cc
+++ b/tests/simplex/step-40.cc
@@ -62,6 +62,7 @@ namespace LA
 #include <deal.II/fe/fe_values.h>
 
 #include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/tria_iterator.h>
 

--- a/tests/simplex/step-67.cc
+++ b/tests/simplex/step-67.cc
@@ -66,6 +66,7 @@
 #include <deal.II/fe/fe_system.h>
 
 #include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/tria_iterator.h>


### PR DESCRIPTION
Inspired by the fact that step-37 includes 626k lines of code once all headers are resolved as noted in #13420, this PR tries to avoid including `grid_tools.h`, which involves a huge amount of boost code. This is possible as there is no reference to those functions in any code, probably a left-over from times where we actually had implementations or data structures using that code. Now we are down to 500k lines of code. More importantly, we more clearly communicate the dependencies, rather than pulling in almost all our code.