### PR TITLE
Support SUNDIALS 6.0 and later.

### DIFF
--- a/include/deal.II/sundials/arkode.h
+++ b/include/deal.II/sundials/arkode.h
@@ -1267,12 +1267,19 @@ namespace SUNDIALS
      */
     void *arkode_mem;
 
+#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+    /**
+     * A context object associated with the ARKode solver.
+     */
+    SUNContext arkode_ctx;
+#  endif
+
     /**
      * MPI communicator. SUNDIALS solver runs happily in
      * parallel. Note that if the library is compiled without MPI
      * support, MPI_Comm is aliased as int.
      */
-    MPI_Comm communicator;
+    MPI_Comm mpi_communicator;
 
     /**
      * The final time in the last call to solve_ode().

--- a/include/deal.II/sundials/ida.h
+++ b/include/deal.II/sundials/ida.h
@@ -882,12 +882,19 @@ namespace SUNDIALS
      */
     void *ida_mem;
 
+#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+    /**
+     * A context object associated with the IDA solver.
+     */
+    SUNContext ida_ctx;
+#  endif
+
     /**
      * MPI communicator. SUNDIALS solver runs happily in
      * parallel. Note that if the library is compiled without MPI
      * support, MPI_Comm is aliased as int.
      */
-    MPI_Comm communicator;
+    MPI_Comm mpi_communicator;
 
     /**
      * Memory pool of vectors.

--- a/include/deal.II/sundials/kinsol.h
+++ b/include/deal.II/sundials/kinsol.h
@@ -685,9 +685,21 @@ namespace SUNDIALS
     AdditionalData data;
 
     /**
+     * The MPI communicator to be used by this solver, if any.
+     */
+    MPI_Comm mpi_communicator;
+
+    /**
      * KINSOL memory object.
      */
     void *kinsol_mem;
+
+#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+    /**
+     * A context object associated with the KINSOL solver.
+     */
+    SUNContext kinsol_ctx;
+#  endif
 
     /**
      * Memory pool of vectors.

--- a/include/deal.II/sundials/n_vector.h
+++ b/include/deal.II/sundials/n_vector.h
@@ -56,13 +56,22 @@ namespace SUNDIALS
      * @tparam VectorType Type of the viewed vector. This parameter can be
      *   deduced automatically and will respect a potential const-qualifier.
      * @param vector The vector to view.
+#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+     * @param nvector_context A SUNDIALS context object to be used for the
+     *   operations we want to do on this vector.
+#  endif
      * @return A NVectorView of the @p vector.
      *
      * @related NVectorView
      */
     template <typename VectorType>
     NVectorView<VectorType>
-    make_nvector_view(VectorType &vector);
+    make_nvector_view(VectorType &vector
+#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+                      ,
+                      SUNContext nvector_context
+#  endif
+    );
 
     /**
      * Retrieve the underlying vector attached to N_Vector @p v. This call will
@@ -129,7 +138,12 @@ namespace SUNDIALS
       /**
        * Constructor. Create view of @p vector.
        */
-      NVectorView(VectorType &vector);
+      NVectorView(VectorType &vector
+#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+                  ,
+                  SUNContext nvector_context
+#  endif
+      );
 
       /**
        * Move assignment.

--- a/include/deal.II/sundials/sunlinsol_wrapper.h
+++ b/include/deal.II/sundials/sunlinsol_wrapper.h
@@ -156,7 +156,7 @@ namespace SUNDIALS
 
   namespace internal
   {
-    /*!
+    /**
      * Attach wrapper functions to SUNDIALS' linear solver interface. We pretend
      * that the user-supplied linear solver is matrix-free, even though it can
      * be matrix-based. This way SUNDIALS does not need to understand our matrix
@@ -166,7 +166,12 @@ namespace SUNDIALS
     class LinearSolverWrapper
     {
     public:
-      explicit LinearSolverWrapper(LinearSolveFunction<VectorType> lsolve);
+      explicit LinearSolverWrapper(LinearSolveFunction<VectorType> lsolve
+#    if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+                                   ,
+                                   SUNContext &linsol_ctx
+#    endif
+      );
 
       ~LinearSolverWrapper();
 

--- a/source/sundials/kinsol.cc
+++ b/source/sundials/kinsol.cc
@@ -303,8 +303,12 @@ namespace SUNDIALS
 
 
   template <typename VectorType>
-  KINSOL<VectorType>::KINSOL(const AdditionalData &data, const MPI_Comm &)
+  KINSOL<VectorType>::KINSOL(const AdditionalData &data,
+                             const MPI_Comm &      mpi_comm)
     : data(data)
+    , mpi_communicator(is_serial_vector<VectorType>::value ?
+                         MPI_COMM_SELF :
+                         Utilities::MPI::duplicate_communicator(mpi_comm))
     , kinsol_mem(nullptr)
   {
     set_functions_to_trigger_an_assert();
@@ -315,8 +319,23 @@ namespace SUNDIALS
   template <typename VectorType>
   KINSOL<VectorType>::~KINSOL()
   {
+    int status = 0;
+    (void)status;
+
     if (kinsol_mem)
-      KINFree(&kinsol_mem);
+      {
+        KINFree(&kinsol_mem);
+
+#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+        status = SUNContext_Free(&kinsol_ctx);
+        AssertKINSOL(status);
+#  endif
+      }
+
+#  ifdef DEAL_II_WITH_MPI
+    if (is_serial_vector<VectorType>::value == false)
+      Utilities::MPI::free_communicator(mpi_communicator);
+#  endif
   }
 
 
@@ -330,21 +349,41 @@ namespace SUNDIALS
     VectorType u_scale_temp, f_scale_temp;
 
     if (get_solution_scaling)
-      u_scale = internal::make_nvector_view(get_solution_scaling());
+      u_scale = internal::make_nvector_view(get_solution_scaling()
+#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+                                              ,
+                                            kinsol_ctx
+#  endif
+      );
     else
       {
         reinit_vector(u_scale_temp);
         u_scale_temp = 1.0;
-        u_scale      = internal::make_nvector_view(u_scale_temp);
+        u_scale      = internal::make_nvector_view(u_scale_temp
+#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+                                              ,
+                                              kinsol_ctx
+#  endif
+        );
       }
 
     if (get_function_scaling)
-      f_scale = internal::make_nvector_view(get_function_scaling());
+      f_scale = internal::make_nvector_view(get_function_scaling()
+#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+                                              ,
+                                            kinsol_ctx
+#  endif
+      );
     else
       {
         reinit_vector(f_scale_temp);
         f_scale_temp = 1.0;
-        f_scale      = internal::make_nvector_view(f_scale_temp);
+        f_scale      = internal::make_nvector_view(f_scale_temp
+#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+                                              ,
+                                              kinsol_ctx
+#  endif
+        );
       }
 
     // Make sure we have what we need
@@ -361,15 +400,34 @@ namespace SUNDIALS
                  "solve_jacobian_system || solve_with_jacobian"));
       }
 
-    auto solution = internal::make_nvector_view(initial_guess_and_solution);
-
-    if (kinsol_mem)
-      KINFree(&kinsol_mem);
-
-    kinsol_mem = KINCreate();
+    auto solution = internal::make_nvector_view(initial_guess_and_solution
+#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+                                                ,
+                                                kinsol_ctx
+#  endif
+    );
 
     int status = 0;
     (void)status;
+
+    if (kinsol_mem)
+      {
+        KINFree(&kinsol_mem);
+
+#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+        status = SUNContext_Free(&kinsol_ctx);
+        AssertKINSOL(status);
+#  endif
+      }
+
+#  if DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+    kinsol_mem = KINCreate();
+#  else
+    status = SUNContext_Create(&mpi_communicator, &kinsol_ctx);
+    AssertKINSOL(status);
+
+    kinsol_mem = KINCreate(kinsol_ctx);
+#  endif
 
     status = KINSetUserData(kinsol_mem, static_cast<void *>(this));
     AssertKINSOL(status);
@@ -443,7 +501,11 @@ namespace SUNDIALS
         // called do not actually receive the KINSOL object, just the LS
         // object, so we have to store a pointer to the current
         // object in the LS object
+#    if DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
         LS          = SUNLinSolNewEmpty();
+#    else
+        LS = SUNLinSolNewEmpty(kinsol_ctx);
+#    endif
         LS->content = this;
 
         LS->ops->gettype =
@@ -473,7 +535,11 @@ namespace SUNDIALS
         // if we don't set it, it won't call the functions that set up
         // the matrix object (i.e., the argument to the 'KINSetJacFn'
         // function below).
+#    if DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
         J          = SUNMatNewEmpty();
+#    else
+        J  = SUNMatNewEmpty(kinsol_ctx);
+#    endif
         J->content = this;
 
         J->ops->getid = [](SUNMatrix /*ignored*/) -> SUNMatrix_ID {

--- a/source/sundials/n_vector.inst.in
+++ b/source/sundials/n_vector.inst.in
@@ -17,9 +17,19 @@
 for (S : REAL_SCALARS; V : DEAL_II_VEC_TEMPLATES)
   {
     template SUNDIALS::internal::NVectorView<V<S>>
-    SUNDIALS::internal::make_nvector_view<>(V<S> &);
+    SUNDIALS::internal::make_nvector_view<>(V<S> &
+#if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+                                            ,
+                                            SUNContext
+#endif
+    );
     template SUNDIALS::internal::NVectorView<const V<S>>
-                         SUNDIALS::internal::make_nvector_view<>(const V<S> &);
+    SUNDIALS::internal::make_nvector_view<>(const V<S> &
+#if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+                                            ,
+                                            SUNContext
+#endif
+    );
     template V<S> *      SUNDIALS::internal::unwrap_nvector<V<S>>(N_Vector);
     template const V<S> *SUNDIALS::internal::unwrap_nvector_const<V<S>>(
       N_Vector);
@@ -32,11 +42,21 @@ for (S : REAL_SCALARS; V : DEAL_II_VEC_TEMPLATES)
 for (S : REAL_SCALARS; V : DEAL_II_VEC_TEMPLATES)
   {
     template SUNDIALS::internal::NVectorView<LinearAlgebra::distributed::V<S>>
-    SUNDIALS::internal::make_nvector_view<>(LinearAlgebra::distributed::V<S> &);
+    SUNDIALS::internal::make_nvector_view<>(LinearAlgebra::distributed::V<S> &
+#if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+                                            ,
+                                            SUNContext
+#endif
+    );
     template SUNDIALS::internal::NVectorView<
       const LinearAlgebra::distributed::V<S>>
     SUNDIALS::internal::make_nvector_view<>(
-      const LinearAlgebra::distributed::V<S> &);
+      const LinearAlgebra::distributed::V<S> &
+#if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+      ,
+      SUNContext
+#endif
+    );
     template LinearAlgebra::distributed::V<S>
       *SUNDIALS::internal::unwrap_nvector<LinearAlgebra::distributed::V<S>>(
         N_Vector);
@@ -54,9 +74,19 @@ for (S : REAL_SCALARS; V : DEAL_II_VEC_TEMPLATES)
 for (V : DEAL_II_VEC_TEMPLATES)
   {
     template SUNDIALS::internal::NVectorView<TrilinosWrappers::MPI::V>
-    SUNDIALS::internal::make_nvector_view<>(TrilinosWrappers::MPI::V &);
+    SUNDIALS::internal::make_nvector_view<>(TrilinosWrappers::MPI::V &
+#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+                                            ,
+                                            SUNContext
+#  endif
+    );
     template SUNDIALS::internal::NVectorView<const TrilinosWrappers::MPI::V>
-    SUNDIALS::internal::make_nvector_view<>(const TrilinosWrappers::MPI::V &);
+    SUNDIALS::internal::make_nvector_view<>(const TrilinosWrappers::MPI::V &
+#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+                                            ,
+                                            SUNContext
+#  endif
+    );
     template TrilinosWrappers::MPI::V
       *SUNDIALS::internal::unwrap_nvector<TrilinosWrappers::MPI::V>(N_Vector);
     template const TrilinosWrappers::MPI::V
@@ -74,9 +104,19 @@ for (V : DEAL_II_VEC_TEMPLATES)
 for (V : DEAL_II_VEC_TEMPLATES)
   {
     template SUNDIALS::internal::NVectorView<PETScWrappers::MPI::V>
-    SUNDIALS::internal::make_nvector_view<>(PETScWrappers::MPI::V &);
+    SUNDIALS::internal::make_nvector_view<>(PETScWrappers::MPI::V &
+#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+                                            ,
+                                            SUNContext
+#  endif
+    );
     template SUNDIALS::internal::NVectorView<const PETScWrappers::MPI::V>
-    SUNDIALS::internal::make_nvector_view<>(const PETScWrappers::MPI::V &);
+    SUNDIALS::internal::make_nvector_view<>(const PETScWrappers::MPI::V &
+#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+                                            ,
+                                            SUNContext
+#  endif
+    );
     template PETScWrappers::MPI::V
       *SUNDIALS::internal::unwrap_nvector<PETScWrappers::MPI::V>(N_Vector);
     template const PETScWrappers::MPI::V *


### PR DESCRIPTION
This probably doesn't work yet (I have some open questions in https://github.com/LLNL/sundials/issues/115 and https://github.com/LLNL/sundials/issues/109#issuecomment-1048250591), but I need to move on for the moment. This will ultimately fix #13166 .

There is no denying that this patch is ugly. It introduces a large number of `#if/#else/#endif` statements because a substantial number of SUNDIALS functions now need a context object (see https://github.com/LLNL/sundials/blob/develop/doc/shared/sundials/SUNContext.rst) and we either need to (i) adjust the call sequence of SUNDIALS functions, or (ii) pass these context objects around. It really isn't pretty.

I did think about whether we could do this in a prettier way. One approach would be if we did something along the lines of
```
#if DEAL_II_SUNDIALS_VERSION_LT(6,0,0)
using SUNContext = int;
#endif
```
and then we just always store a context object, and we always pass it around, and we can get rid of the conditional compilation in all places other than those where we actually call SUNDIALS functions.

Anyway, I thought I'd put this out there for discussion already while I turn to other things for the moment.

/rebuild