### PR TITLE
Declare a number of static consts as constexpr

### DIFF
--- a/include/deal.II/base/function.h
+++ b/include/deal.II/base/function.h
@@ -156,7 +156,7 @@ public:
    * Export the value of the template parameter as a static member constant.
    * Sometimes useful for some expression template programming.
    */
-  static const unsigned int dimension = dim;
+  static constexpr unsigned int dimension = dim;
 
   /**
    * Number of vector components.

--- a/include/deal.II/base/incremental_function.h
+++ b/include/deal.II/base/incremental_function.h
@@ -56,7 +56,7 @@ namespace Functions
      * Export the value of the template parameter as a static member constant.
      * This is sometimes useful in the context of template programming.
      */
-    static const unsigned int dimension = dim;
+    static constexpr unsigned int dimension = dim;
 
     /**
      * The scalar-valued real type used for representing time.

--- a/include/deal.II/base/polynomial_space.h
+++ b/include/deal.II/base/polynomial_space.h
@@ -102,7 +102,7 @@ public:
    * Access to the dimension of this object, for checking and automatic
    * setting of dimension in other classes.
    */
-  static const unsigned int dimension = dim;
+  static constexpr unsigned int dimension = dim;
 
   /**
    * Constructor. <tt>pols</tt> is a vector of pointers to one-dimensional

--- a/include/deal.II/base/polynomials_barycentric.h
+++ b/include/deal.II/base/polynomials_barycentric.h
@@ -243,7 +243,7 @@ public:
   /**
    * Make the dimension available to the outside.
    */
-  static const unsigned int dimension = dim;
+  static constexpr unsigned int dimension = dim;
 
   /**
    * Get the standard Lagrange basis for a specified degree.

--- a/include/deal.II/base/polynomials_p.h
+++ b/include/deal.II/base/polynomials_p.h
@@ -51,7 +51,7 @@ public:
    * Access to the dimension of this object, for checking and automatic
    * setting of dimension in other classes.
    */
-  static const unsigned int dimension = dim;
+  static constexpr unsigned int dimension = dim;
 
   /**
    * Constructor. Creates all basis functions of $P_p$. @arg p: the degree of

--- a/include/deal.II/base/polynomials_pyramid.h
+++ b/include/deal.II/base/polynomials_pyramid.h
@@ -34,7 +34,7 @@ public:
   /**
    * Make the dimension available to the outside.
    */
-  static const unsigned int dimension = dim;
+  static constexpr unsigned int dimension = dim;
 
   /*
    * Constructor taking the polynomial @p degree as input.

--- a/include/deal.II/base/polynomials_rannacher_turek.h
+++ b/include/deal.II/base/polynomials_rannacher_turek.h
@@ -45,7 +45,7 @@ public:
   /**
    * Dimension we are working in.
    */
-  static const unsigned int dimension = dim;
+  static constexpr unsigned int dimension = dim;
 
   /**
    * Constructor, checking that the basis is implemented in this dimension.

--- a/include/deal.II/base/polynomials_wedge.h
+++ b/include/deal.II/base/polynomials_wedge.h
@@ -40,7 +40,7 @@ public:
   /**
    * Make the dimension available to the outside.
    */
-  static const unsigned int dimension = dim;
+  static constexpr unsigned int dimension = dim;
 
   /*
    * Constructor taking the polynomial @p degree as input.

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -680,7 +680,7 @@ public:
    * of an inlined function; the compiler may therefore produce more efficient
    * code and you may use this value to declare other data types.
    */
-  static const unsigned int dimension = dim;
+  static constexpr unsigned int dimension = dim;
 
   /**
    * Publish the rank of this tensor to the outside world.

--- a/include/deal.II/base/tensor_product_polynomials.h
+++ b/include/deal.II/base/tensor_product_polynomials.h
@@ -80,7 +80,7 @@ public:
    * Access to the dimension of this object, for checking and automatic
    * setting of dimension in other classes.
    */
-  static const unsigned int dimension = dim;
+  static constexpr unsigned int dimension = dim;
 
   /**
    * Constructor. <tt>pols</tt> is a vector of objects that should be derived

--- a/include/deal.II/base/tensor_product_polynomials_bubbles.h
+++ b/include/deal.II/base/tensor_product_polynomials_bubbles.h
@@ -57,7 +57,7 @@ public:
    * Access to the dimension of this object, for checking and automatic
    * setting of dimension in other classes.
    */
-  static const unsigned int dimension = dim;
+  static constexpr unsigned int dimension = dim;
 
   /**
    * Constructor. <tt>pols</tt> is a vector of objects that should be derived

--- a/include/deal.II/base/tensor_product_polynomials_const.h
+++ b/include/deal.II/base/tensor_product_polynomials_const.h
@@ -50,7 +50,7 @@ public:
    * Access to the dimension of this object, for checking and automatic
    * setting of dimension in other classes.
    */
-  static const unsigned int dimension = dim;
+  static constexpr unsigned int dimension = dim;
 
   /**
    * Constructor. <tt>pols</tt> is a vector of objects that should be derived

--- a/include/deal.II/differentiation/ad/ad_helpers.h
+++ b/include/deal.II/differentiation/ad/ad_helpers.h
@@ -2646,7 +2646,7 @@ namespace Differentiation
        * Type definition for the dimension of the associated input and output
        * tensor types.
        */
-      static const unsigned int dimension = dim;
+      static constexpr unsigned int dimension = dim;
 
       /**
        * Type definition for the floating point number type that is used in,

--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -216,13 +216,13 @@ public:
    * A static variable that allows users of this class to discover the value
    * of the second template argument.
    */
-  static const unsigned int dimension = dim;
+  static constexpr unsigned int dimension = dim;
 
   /**
    * A static variable that allows users of this class to discover the value
    * of the third template argument.
    */
-  static const unsigned int space_dimension = spacedim;
+  static constexpr unsigned int space_dimension = spacedim;
 
   /**
    * Declare an alias to the base class to make accessing some of the
@@ -770,13 +770,13 @@ public:
    * A static variable that allows users of this class to discover the value
    * of the second template argument.
    */
-  static const unsigned int dimension = 1;
+  static constexpr unsigned int dimension = 1;
 
   /**
    * A static variable that allows users of this class to discover the value
    * of the third template argument.
    */
-  static const unsigned int space_dimension = spacedim;
+  static constexpr unsigned int space_dimension = spacedim;
 
   /**
    * Declare an alias to the base class to make accessing some of the

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -506,12 +506,12 @@ public:
   /**
    * Make the dimension available in function templates.
    */
-  static const unsigned int dimension = dim;
+  static constexpr unsigned int dimension = dim;
 
   /**
    * Make the space dimension available in function templates.
    */
-  static const unsigned int space_dimension = spacedim;
+  static constexpr unsigned int space_dimension = spacedim;
 
   /**
    * The default index of the finite element to be used on a given cell.

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -656,7 +656,7 @@ public:
   /**
    * The dimension of the image space, corresponding to Triangulation.
    */
-  static const unsigned int space_dimension = spacedim;
+  static constexpr unsigned int space_dimension = spacedim;
 
   /**
    * A base class for internal data that derived finite element classes may

--- a/include/deal.II/fe/fe_base.h
+++ b/include/deal.II/fe/fe_base.h
@@ -283,7 +283,7 @@ public:
    * The dimension of the finite element, which is the template parameter
    * <tt>dim</tt>
    */
-  static const unsigned int dimension = dim;
+  static constexpr unsigned int dimension = dim;
 
 private:
   /**

--- a/include/deal.II/fe/fe_poly.h
+++ b/include/deal.II/fe/fe_poly.h
@@ -42,7 +42,7 @@ DEAL_II_NAMESPACE_OPEN
  * functions can be used as template parameter @p PolynomialType.
  *
  * @code
- *  static const unsigned int dimension;
+ *  static constexpr unsigned int dimension;
  *
  *  void evaluate (const Point<dim>            &unit_point,
  *                 std::vector<double>         &values,

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -2415,12 +2415,12 @@ public:
   /**
    * Dimension in which this object operates.
    */
-  static const unsigned int dimension = dim;
+  static constexpr unsigned int dimension = dim;
 
   /**
    * Dimension of the space in which this object operates.
    */
-  static const unsigned int space_dimension = spacedim;
+  static constexpr unsigned int space_dimension = spacedim;
 
   /**
    * Number of quadrature points of the current object. Its value is
@@ -4048,7 +4048,7 @@ public:
    * Dimension of the object over which we integrate. For the present class,
    * this is equal to <code>dim</code>.
    */
-  static const unsigned int integral_dimension = dim;
+  static constexpr unsigned int integral_dimension = dim;
 
   /**
    * Constructor. Gets cell independent data from mapping and finite element
@@ -4187,7 +4187,7 @@ public:
    * Dimension of the object over which we integrate. For the present class,
    * this is equal to <code>dim-1</code>.
    */
-  static const unsigned int integral_dimension = dim - 1;
+  static constexpr unsigned int integral_dimension = dim - 1;
 
   /**
    * Constructor. Call the constructor of the base class and set up the arrays
@@ -4307,15 +4307,15 @@ public:
    * Dimension in which this object operates.
    */
 
-  static const unsigned int dimension = dim;
+  static constexpr unsigned int dimension = dim;
 
-  static const unsigned int space_dimension = spacedim;
+  static constexpr unsigned int space_dimension = spacedim;
 
   /**
    * Dimension of the object over which we integrate. For the present class,
    * this is equal to <code>dim-1</code>.
    */
-  static const unsigned int integral_dimension = dim - 1;
+  static constexpr unsigned int integral_dimension = dim - 1;
 
   /**
    * Constructor. Gets cell independent data from mapping and finite element
@@ -4472,18 +4472,18 @@ public:
   /**
    * Dimension in which this object operates.
    */
-  static const unsigned int dimension = dim;
+  static constexpr unsigned int dimension = dim;
 
   /**
    * Dimension of the space in which this object operates.
    */
-  static const unsigned int space_dimension = spacedim;
+  static constexpr unsigned int space_dimension = spacedim;
 
   /**
    * Dimension of the object over which we integrate. For the present class,
    * this is equal to <code>dim-1</code>.
    */
-  static const unsigned int integral_dimension = dim - 1;
+  static constexpr unsigned int integral_dimension = dim - 1;
 
   /**
    * Constructor. Gets cell independent data from mapping and finite element

--- a/include/deal.II/grid/persistent_tria.h
+++ b/include/deal.II/grid/persistent_tria.h
@@ -111,8 +111,8 @@ public:
   /**
    * Make the dimension available in function templates.
    */
-  static const unsigned int dimension      = dim;
-  static const unsigned int spacedimension = spacedim;
+  static constexpr unsigned int dimension      = dim;
+  static const unsigned int     spacedimension = spacedim;
 
   /**
    * Build up the triangulation from the coarse grid in future. Copy smoothing

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1539,12 +1539,12 @@ public:
   /**
    * Make the dimension available in function templates.
    */
-  static const unsigned int dimension = dim;
+  static constexpr unsigned int dimension = dim;
 
   /**
    * Make the space-dimension available in function templates.
    */
-  static const unsigned int space_dimension = spacedim;
+  static constexpr unsigned int space_dimension = spacedim;
 
   /**
    * Create an empty triangulation. Do not create any cells.

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -306,14 +306,14 @@ public:
    * For example, if this accessor represents a quad that is part of a two-
    * dimensional surface in four-dimensional space, then this value is four.
    */
-  static const unsigned int space_dimension = spacedim;
+  static constexpr unsigned int space_dimension = spacedim;
 
   /**
    * Dimensionality of the object that the thing represented by this accessor
    * is part of. For example, if this accessor represents a line that is part
    * of a hexahedron, then this value will be three.
    */
-  static const unsigned int dimension = dim;
+  static constexpr unsigned int dimension = dim;
 
   /**
    * Dimensionality of the current object represented by this accessor. For
@@ -1881,14 +1881,14 @@ public:
    * For example, if this accessor represents a quad that is part of a two-
    * dimensional surface in four-dimensional space, then this value is four.
    */
-  static const unsigned int space_dimension = spacedim;
+  static constexpr unsigned int space_dimension = spacedim;
 
   /**
    * Dimensionality of the object that the thing represented by this accessor
    * is part of. For example, if this accessor represents a line that is part
    * of a hexahedron, then this value will be three.
    */
-  static const unsigned int dimension = dim;
+  static constexpr unsigned int dimension = dim;
 
   /**
    * Dimensionality of the current object represented by this accessor. For
@@ -2299,14 +2299,14 @@ public:
    * For example, if this accessor represents a quad that is part of a two-
    * dimensional surface in four-dimensional space, then this value is four.
    */
-  static const unsigned int space_dimension = spacedim;
+  static constexpr unsigned int space_dimension = spacedim;
 
   /**
    * Dimensionality of the object that the thing represented by this accessor
    * is part of. For example, if this accessor represents a line that is part
    * of a hexahedron, then this value will be three.
    */
-  static const unsigned int dimension = 1;
+  static constexpr unsigned int dimension = 1;
 
   /**
    * Dimensionality of the current object represented by this accessor. For

--- a/include/deal.II/hp/fe_values.h
+++ b/include/deal.II/hp/fe_values.h
@@ -316,9 +316,9 @@ namespace hp
     : public hp::FEValuesBase<dim, dim, dealii::FEValues<dim, spacedim>>
   {
   public:
-    static const unsigned int dimension = dim;
+    static constexpr unsigned int dimension = dim;
 
-    static const unsigned int space_dimension = spacedim;
+    static constexpr unsigned int space_dimension = spacedim;
 
     /**
      * Constructor. Initialize this object with the given parameters.

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -128,7 +128,7 @@ public:
   /**
    * The dimension set by the template argument `dim`.
    */
-  static const unsigned int dimension = dim;
+  static constexpr unsigned int dimension = dim;
 
   /**
    * Collects the options for initialization of the MatrixFree class. The

--- a/include/deal.II/meshworker/integration_info.h
+++ b/include/deal.II/meshworker/integration_info.h
@@ -81,8 +81,8 @@ namespace MeshWorker
     std::vector<std::shared_ptr<FEValuesBase<dim, spacedim>>> fevalv;
 
   public:
-    static const unsigned int dimension       = dim;
-    static const unsigned int space_dimension = spacedim;
+    static constexpr unsigned int dimension       = dim;
+    static constexpr unsigned int space_dimension = spacedim;
 
     /**
      * Constructor.


### PR DESCRIPTION
By changing the underlying type from `static const` to
`static constexpr` it is possible to use these dimension constants also
in template expressions.