### PR TITLE
Fix instantiation for add_entries_local_to_global

### DIFF
--- a/source/lac/affine_constraints.inst.in
+++ b/source/lac/affine_constraints.inst.in
@@ -297,6 +297,14 @@ for (S : REAL_AND_COMPLEX_SCALARS; SP : AFFINE_CONSTRAINTS_SP_BLOCK)
       SP &,
       const bool,
       const Table<2, bool> &) const;
+
+    template void AffineConstraints<S>::add_entries_local_to_global<SP>(
+      const std::vector<AffineConstraints<S>::size_type> &,
+      const AffineConstraints<S> &,
+      const std::vector<AffineConstraints<S>::size_type> &,
+      SP &,
+      const bool,
+      const Table<2, bool> &) const;
   }
 
 


### PR DESCRIPTION
`add_entries_local_to_global` currently is not instantiated for block systems, this should fix it. @tjhei 

intel compiler complains with
```
ld.bfd: /work2/08254/jiaqi2/frontera/dealii/installed_intel_test_branch/lib/libdeal_II.so.10.0.0-pre: undefined reference to `void dealii::AffineConstraints<double>::add_entries_local_to_global<dealii::BlockDynamicSparsityPattern>(std::vector<unsigned long, std::allocator<unsigned long> > const&, dealii::AffineConstraints<double> const&, std::vector<unsigned long, std::allocator<unsigned long> > const&, dealii::BlockDynamicSparsityPattern&, bool, dealii::Table<2, bool> const&) const'
ld.bfd: /work2/08254/jiaqi2/frontera/dealii/installed_intel_test_branch/lib/libdeal_II.so.10.0.0-pre: undefined reference to `void dealii::AffineConstraints<float>::add_entries_local_to_global<dealii::BlockDynamicSparsityPattern>(std::vector<unsigned long, std::allocator<unsigned long> > const&, dealii::AffineConstraints<float> const&, std::vector<unsigned long, std::allocator<unsigned long> > const&, dealii::BlockDynamicSparsityPattern&, bool, dealii::Table<2, bool> const&) const'
```