### PR TITLE
cell_weight: remove initial weight from distributed applications.

### DIFF
--- a/doc/news/changes/incompatibilities/20220225Fehling
+++ b/doc/news/changes/incompatibilities/20220225Fehling
@@ -1,0 +1,12 @@
+Changed: For weighted load balancing with parallel::distributed::Triangulation
+objects, an intial weight of `1000` will no longer be assigned to each cell.
+<br>
+You can invoke the old behavior by connecting a function to the signal
+that returns the base weight like this:
+@code{.cc}
+triangulation.signals.cell_weight.connect(
+  [](const typename parallel::distributed::Triangulation<dim>::cell_iterator &,
+     const typename parallel::distributed::Triangulation<dim>::CellStatus)
+    -> unsigned int { return 1000; });
+@endcode
+(Marc Fehling, 2022/02/25)

--- a/doc/news/changes/incompatibilities/20220225Fehling
+++ b/doc/news/changes/incompatibilities/20220225Fehling
@@ -1,10 +1,13 @@
 Changed: For weighted load balancing with parallel::distributed::Triangulation
 objects, an intial weight of `1000` will no longer be assigned to each cell.
 <br>
-You can invoke the old behavior by connecting a function to the signal
-that returns the base weight like this:
+The old signal Triangulation::Signals::cell_weight has been deprecated.
+Please use the new signal Triangulation::Signals::weight instead.
+<br>
+You can invoke the old behavior by connecting a function to the new
+signal that returns the base weight like this:
 @code{.cc}
-triangulation.signals.cell_weight.connect(
+triangulation.signals.weight.connect(
   [](const typename parallel::distributed::Triangulation<dim>::cell_iterator &,
      const typename parallel::distributed::Triangulation<dim>::CellStatus)
     -> unsigned int { return 1000; });

--- a/examples/step-68/step-68.cc
+++ b/examples/step-68/step-68.cc
@@ -350,27 +350,28 @@ namespace Step68
     // should have the status `CELL_PERSIST`. However this function can also
     // be used to distribute load during refinement, therefore we consider
     // refined or coarsened cells as well.
-    if (status == parallel::distributed::Triangulation<dim>::CELL_PERSIST ||
-        status == parallel::distributed::Triangulation<dim>::CELL_REFINE)
+    unsigned int n_particles_in_cell = 0;
+    switch (status)
       {
-        const unsigned int n_particles_in_cell =
-          particle_handler.n_particles_in_cell(cell);
-        return n_particles_in_cell * particle_weight;
+        case parallel::distributed::Triangulation<dim>::CELL_PERSIST:
+        case parallel::distributed::Triangulation<dim>::CELL_REFINE:
+          n_particles_in_cell = particle_handler.n_particles_in_cell(cell);
+          break;
+
+        case parallel::distributed::Triangulation<dim>::CELL_INVALID:
+          break;
+
+        case parallel::distributed::Triangulation<dim>::CELL_COARSEN:
+          for (const auto &child : cell->child_iterators())
+            n_particles_in_cell += particle_handler.n_particles_in_cell(child);
+          break;
+
+        default:
+          Assert(false, ExcInternalError());
+          break;
       }
-    else if (status == parallel::distributed::Triangulation<dim>::CELL_COARSEN)
-      {
-        unsigned int n_particles_in_cell = 0;
 
-        for (unsigned int child_index = 0; child_index < cell->n_children();
-             ++child_index)
-          n_particles_in_cell +=
-            particle_handler.n_particles_in_cell(cell->child(child_index));
-
-        return n_particles_in_cell * particle_weight;
-      }
-
-    Assert(false, ExcInternalError());
-    return 0;
+    return base_weight + particle_weight * n_particles_in_cell;
   }
 
 

--- a/examples/step-68/step-68.cc
+++ b/examples/step-68/step-68.cc
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  *
- * Copyright (C) 2020 - 2021 by the deal.II authors
+ * Copyright (C) 2020 - 2022 by the deal.II authors
  *
  * This file is part of the deal.II library.
  *
@@ -26,7 +26,6 @@
 #include <deal.II/base/parameter_acceptor.h>
 #include <deal.II/base/timer.h>
 
-#include <deal.II/distributed/cell_weights.h>
 #include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
@@ -334,21 +333,18 @@ namespace Step68
     const typename parallel::distributed::Triangulation<dim>::CellStatus status)
     const
   {
-    // We do not assign any weight to cells we do not own (i.e., artificial
-    // or ghost cells)
-    if (!cell->is_locally_owned())
-      return 0;
+    // First, we introduce a base weight that will be assigned to every cell.
+    const unsigned int base_weight = 1;
 
-    // This determines how important particle work is compared to cell
-    // work (by default every cell has a weight of 1000).
-    // We set the weight per particle much higher to indicate that
-    // the particle load is the only one that is important to distribute the
-    // cells in this example. The optimal value of this number depends on the
-    // application and can range from 0 (cheap particle operations,
-    // expensive cell operations) to much larger than 1000 (expensive
-    // particle operations, cheap cell operations, like presumed in this
-    // example).
-    const unsigned int particle_weight = 10000;
+    // The following variable then determines how important particle work is
+    // compared to cell work. We set the weight per particle much higher to
+    // indicate that the particle load is the only one that is important to
+    // distribute the cells in this example. The optimal value of this number
+    // depends on the application and can range from 0 (cheap particle
+    // operations, expensive cell operations) to much larger than the base
+    // weight of 1 (expensive particle operations, cheap cell operations, like
+    // presumed in this example).
+    const unsigned int particle_weight = 10;
 
     // This example does not use adaptive refinement, therefore every cell
     // should have the status `CELL_PERSIST`. However this function can also

--- a/examples/step-68/step-68.cc
+++ b/examples/step-68/step-68.cc
@@ -322,7 +322,7 @@ namespace Step68
   // return value of this function (representing "work for this cell") is
   // calculated based on the number of particles in the current cell.
   // The function is
-  // connected to the cell_weight() signal inside the triangulation, and will be
+  // connected to the `weight` signal inside the triangulation, and will be
   // called once per cell, whenever the triangulation repartitions the domain
   // between ranks (the connection is created inside the
   // generate_particles() function of this class).
@@ -398,7 +398,7 @@ namespace Step68
     // be created once, so we might as well have set it up in the constructor
     // of this class, but for the purpose of this example we want to group the
     // particle related instructions.
-    background_triangulation.signals.cell_weight.connect(
+    background_triangulation.signals.weight.connect(
       [&](
         const typename parallel::distributed::Triangulation<dim>::cell_iterator
           &cell,

--- a/examples/step-75/step-75.cc
+++ b/examples/step-75/step-75.cc
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  *
- * Copyright (C) 2021 by the deal.II authors
+ * Copyright (C) 2021 - 2022 by the deal.II authors
  *
  * This file is part of the deal.II library.
  *
@@ -191,7 +191,7 @@ namespace Step75
     double p_refine_fraction  = 0.9;
     double p_coarsen_fraction = 0.9;
 
-    double weighting_factor   = 1e6;
+    double weighting_factor   = 1.;
     double weighting_exponent = 1.;
   };
 
@@ -980,16 +980,13 @@ namespace Step75
     // for hp-adaptation and right before repartitioning for load balancing is
     // about to happen. Functions can be registered that will attach weights in
     // the form that $a (n_\text{dofs})^b$ with a provided pair of parameters
-    // $(a,b)$. We register such a function in the following. Every cell will be
-    // charged with a constant weight at creation, which is a value of 1000 (see
-    // Triangulation::Signals::cell_weight).
+    // $(a,b)$. We register such a function in the following.
     //
     // For load balancing, efficient solvers like the one we use should scale
-    // linearly with the number of degrees of freedom owned. Further, to
-    // increase the impact of the weights we would like to attach, make sure
-    // that the individual weight will exceed this base weight by orders of
-    // magnitude. We set the parameters for cell weighting correspondingly: A
-    // large weighting factor of $10^6$ and an exponent of $1$.
+    // linearly with the number of degrees of freedom owned. We set the
+    // parameters for cell weighting correspondingly: A weighting factor of $1$
+    // and an exponent of $1$ (see the definitions of the `weighting_factor` and
+    // `weighting_exponent` above).
     cell_weights = std::make_unique<parallel::CellWeights<dim>>(
       dof_handler,
       parallel::CellWeights<dim>::ndofs_weighting(

--- a/include/deal.II/distributed/cell_weights.h
+++ b/include/deal.II/distributed/cell_weights.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2018 - 2021 by the deal.II authors
+// Copyright (C) 2018 - 2022 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -53,12 +53,11 @@ namespace parallel
    * The connected weighting function may be changed anytime using the
    * CellWeights::reinit() function. The following code snippet demonstrates how
    * to achieve each cell being weighted by its current number of degrees of
-   * freedom. We chose a factor of `1000` that corresponds to the initial weight
-   * each cell is assigned to upon creation.
+   * freedom.
    * @code
    * parallel::CellWeights<dim, spacedim> cell_weights(
    *   hp_dof_handler,
-   *   parallel::CellWeights<dim, spacedim>::ndofs_weighting({1000, 1}));
+   *   parallel::CellWeights<dim, spacedim>::ndofs_weighting({1, 1}));
    * @endcode
    *
    * On the other hand, you are also able to take care of handling the signal
@@ -69,8 +68,7 @@ namespace parallel
    *   hp_dof_handler.get_triangulation().signals.cell_weight.connect(
    *     parallel::CellWeights<dim, spacedim>::make_weighting_callback(
    *       hp_dof_handler,
-   *       parallel::CellWeights<dim, spacedim>::ndofs_weighting(
-   *         {1000, 1}));
+   *       parallel::CellWeights<dim, spacedim>::ndofs_weighting({1, 1}));
    * @endcode
    *
    * The use of this class is demonstrated in step-75.
@@ -84,6 +82,17 @@ namespace parallel
    * latter via DoFHandler::reinit(), an assertion will be triggered in
    * the weight_callback() function. Use CellWeights::reinit() to deregister the
    * weighting function on the old Triangulation and connect it to the new one.
+   *
+   * @note A hp::FECollection needs to be attached to your DoFHandler object via
+   * DoFHandler::distribute_dofs() <em>once before</em> the
+   * Triangulation::Signals::cell_weight signal will be triggered. Otherwise,
+   * your DoFHandler does not know many degrees of freedom your cells have. In
+   * other words, you need to call DoFHandler::distribute_dofs() once before you
+   * call
+   * parallel::distributed::Triangulation::execute_coarsening_and_refinement(),
+   * parallel::distributed::Triangulation::refine_global(),
+   * parallel::distributed::Triangulation::repartition(), or
+   * GridTools::partition_triangulation() for the very first time.
    *
    * @ingroup distributed
    */
@@ -156,7 +165,7 @@ namespace parallel
      * Choose a constant weight @p factor on each cell.
      */
     static WeightingFunction
-    constant_weighting(const unsigned int factor = 1000);
+    constant_weighting(const unsigned int factor = 1);
 
     /**
      * The pair of floating point numbers $(a,b)$ provided via

--- a/include/deal.II/distributed/cell_weights.h
+++ b/include/deal.II/distributed/cell_weights.h
@@ -65,7 +65,7 @@ namespace parallel
    * this case, an analogous code example looks as follows.
    * @code
    * boost::signals2::connection connection =
-   *   hp_dof_handler.get_triangulation().signals.cell_weight.connect(
+   *   hp_dof_handler.get_triangulation().signals.weight.connect(
    *     parallel::CellWeights<dim, spacedim>::make_weighting_callback(
    *       hp_dof_handler,
    *       parallel::CellWeights<dim, spacedim>::ndofs_weighting({1, 1}));
@@ -73,7 +73,7 @@ namespace parallel
    *
    * The use of this class is demonstrated in step-75.
    *
-   * @note See Triangulation::Signals::cell_weight for more information on
+   * @note See Triangulation::Signals::weight for more information on
    * weighting and load balancing.
    *
    * @note Be aware that this class connects the weight function to the
@@ -85,7 +85,7 @@ namespace parallel
    *
    * @note A hp::FECollection needs to be attached to your DoFHandler object via
    * DoFHandler::distribute_dofs() <em>once before</em> the
-   * Triangulation::Signals::cell_weight signal will be triggered. Otherwise,
+   * Triangulation::Signals::weight signal will be triggered. Otherwise,
    * your DoFHandler does not know many degrees of freedom your cells have. In
    * other words, you need to call DoFHandler::distribute_dofs() once before you
    * call
@@ -197,13 +197,13 @@ namespace parallel
 
   private:
     /**
-     * A connection to the corresponding cell_weight signal of the Triangulation
+     * A connection to the corresponding weight signal of the Triangulation
      * which is attached to the DoFHandler.
      */
     boost::signals2::connection connection;
 
     /**
-     * A callback function that will be connected to the cell_weight signal of
+     * A callback function that will be connected to the weight signal of
      * the @p triangulation, to which the @p dof_handler is attached. Ultimately
      * returns the weight for each cell, determined by the @p weighting_function
      * provided as a parameter. Returns zero if @p dof_handler has not been

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -499,7 +499,7 @@ namespace parallel
        * @note This function by default partitions the mesh in such a way that
        * the number of cells on all processors is roughly equal. If you want
        * to set weights for partitioning, e.g. because some cells are more
-       * expensive to compute than others, you can use the signal cell_weight
+       * expensive to compute than others, you can use the signal weight
        * as documented in the dealii::Triangulation class. This function will
        * check whether a function is connected to the signal and if so use it.
        * If you prefer to repartition the mesh yourself at user-defined
@@ -508,7 +508,7 @@ namespace parallel
        * flag to the constructor, which ensures that calling the current
        * function only refines and coarsens the triangulation, but doesn't
        * partition it. You can then call the repartition() function manually.
-       * The usage of the cell_weights signal is identical in both cases, if a
+       * The usage of the weight signal is identical in both cases, if a
        * function is connected to the signal it will be used to balance the
        * calculated weights, otherwise the number of cells is balanced.
        */
@@ -542,7 +542,7 @@ namespace parallel
        * the same way as execute_coarsening_and_refinement() with respect to
        * dealing with data movement (SolutionTransfer, etc.).
        *
-       * @note If no function is connected to the cell_weight signal described
+       * @note If no function is connected to the weight signal described
        * in the dealii::Triangulation class, this function will balance the
        * number of cells on each processor. If one or more functions are
        * connected, it will calculate the sum of the weights and balance the

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -2163,7 +2163,7 @@ namespace GridTools
    * single-partition case without packages installed, and only requires them
    * installed when multiple partitions are required.
    *
-   * @note If the @p cell_weight signal has been attached to the @p triangulation,
+   * @note If the @p weight signal has been attached to the @p triangulation,
    * then this will be used and passed to the partitioner.
    */
   template <int dim, int spacedim>
@@ -2233,7 +2233,7 @@ namespace GridTools
    * case like this, partitioning algorithm may sometimes make bad decisions and
    * you may want to build your own connectivity graph.
    *
-   * @note If the @p cell_weight signal has been attached to the @p triangulation,
+   * @note If the @p weight signal has been attached to the @p triangulation,
    * then this will be used and passed to the partitioner.
    */
   template <int dim, int spacedim>

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2021 by the deal.II authors
+// Copyright (C) 1998 - 2022 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -2173,8 +2173,7 @@ public:
 
     /**
      * This signal is triggered for each cell during every automatic or manual
-     * repartitioning. This signal is somewhat special in that it is only
-     * triggered for distributed parallel calculations and only if functions
+     * repartitioning. This signal will only be triggered if functions
      * are connected to it. It is intended to allow a weighted repartitioning
      * of the domain to balance the computational load across processes in a
      * different way than balancing the number of cells. Any connected
@@ -2183,18 +2182,23 @@ public:
      * coarsened or left untouched (see the documentation of the CellStatus
      * enum for more information). The function is expected to return an
      * unsigned integer, which is interpreted as the additional computational
-     * load of this cell. If this cell is going to be coarsened, the signal is
-     * called for the parent cell and you need to provide the weight of the
-     * future parent cell. If this cell is going to be refined the function
-     * should return a weight, which will be equally assigned to every future
-     * child cell of the current cell. As a reference a value of 1000 is added
-     * for every cell to the total weight. This means a signal return value of
-     * 1000 (resulting in a weight of 2000) means that it is twice as
-     * expensive for a process to handle this particular cell. If several
-     * functions are connected to this signal, their return values will be
-     * summed to calculate the final weight.
+     * load of this cell.
      *
-     * This function is used in step-68.
+     * In serial and parallel shared applications, partitioning happens after
+     * refinement. So all cells will have the `CELL_PERSIST` status.
+     *
+     * In parallel distributed applications, partitioning happens during
+     * refinement. If this cell is going to be coarsened, the signal is called
+     * for the parent cell and you need to provide the weight of the future
+     * parent cell. If this cell is going to be refined, the function is called
+     * on all children and you should ideally return the same weight for all
+     * children.
+     *
+     * If several functions are connected to this signal, their return values
+     * will be summed to calculate the final weight via `CellWeightSum`.
+     *
+     * This function is used in step-68 and implicitely in step-75 using the
+     * parallel::CellWeights class.
      */
     boost::signals2::signal<unsigned int(const cell_iterator &,
                                          const CellStatus),

--- a/source/distributed/cell_weights.cc
+++ b/source/distributed/cell_weights.cc
@@ -50,7 +50,7 @@ namespace parallel
       &weighting_function)
   {
     connection.disconnect();
-    connection = dof_handler.get_triangulation().signals.cell_weight.connect(
+    connection = dof_handler.get_triangulation().signals.weight.connect(
       make_weighting_callback(dof_handler, weighting_function));
   }
 

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -1453,7 +1453,7 @@ namespace
   {
   public:
     /**
-     * This constructor assumes the cell_weights are already sorted in the
+     * This constructor assumes the @p cell_weights are already sorted in the
      * order that p4est will encounter the cells, and they do not contain
      * ghost cells or artificial cells.
      */
@@ -3351,7 +3351,7 @@ namespace parallel
         {
           // partition the new mesh between all processors. If cell weights
           // have not been given balance the number of cells.
-          if (this->signals.cell_weight.num_slots() == 0)
+          if (this->signals.weight.empty())
             dealii::internal::p4est::functions<dim>::partition(
               parallel_forest,
               /* prepare coarsening */ 1,
@@ -3529,7 +3529,7 @@ namespace parallel
                         (parallel_forest->mpisize + 1));
         }
 
-      if (this->signals.cell_weight.num_slots() == 0)
+      if (this->signals.weight.empty())
         {
           // no cell weights given -- call p4est's 'partition' without a
           // callback for cell weights
@@ -4056,16 +4056,16 @@ namespace parallel
 
       // Iterate over p4est and Triangulation relations
       // to find refined/coarsened/kept
-      // cells. Then append cell_weight.
+      // cells. Then append weight.
       // Note that we need to follow the p4est ordering
-      // instead of the deal.II ordering to get the cell_weights
+      // instead of the deal.II ordering to get the weights
       // in the same order p4est will encounter them during repartitioning.
       for (const auto &cell_rel : this->local_cell_relations)
         {
           const auto &cell_it     = cell_rel.first;
           const auto &cell_status = cell_rel.second;
 
-          weights.push_back(this->signals.cell_weight(cell_it, cell_status));
+          weights.push_back(this->signals.weight(cell_it, cell_status));
         }
 
       return weights;

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2008 - 2021 by the deal.II authors
+// Copyright (C) 2008 - 2022 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -4038,47 +4038,7 @@ namespace parallel
           const auto &cell_it     = cell_rel.first;
           const auto &cell_status = cell_rel.second;
 
-          switch (cell_status)
-            {
-              case parallel::distributed::Triangulation<dim,
-                                                        spacedim>::CELL_PERSIST:
-                weights.push_back(1000);
-                weights.back() += this->signals.cell_weight(
-                  cell_it,
-                  parallel::distributed::Triangulation<dim,
-                                                       spacedim>::CELL_PERSIST);
-                break;
-
-              case parallel::distributed::Triangulation<dim,
-                                                        spacedim>::CELL_REFINE:
-              case parallel::distributed::Triangulation<dim,
-                                                        spacedim>::CELL_INVALID:
-                {
-                  // calculate weight of parent cell
-                  unsigned int parent_weight = 1000;
-                  parent_weight += this->signals.cell_weight(
-                    cell_it,
-                    parallel::distributed::Triangulation<dim, spacedim>::
-                      CELL_REFINE);
-                  // assign the weight of the parent cell equally to all
-                  // children
-                  weights.push_back(parent_weight);
-                  break;
-                }
-
-              case parallel::distributed::Triangulation<dim,
-                                                        spacedim>::CELL_COARSEN:
-                weights.push_back(1000);
-                weights.back() += this->signals.cell_weight(
-                  cell_it,
-                  parallel::distributed::Triangulation<dim,
-                                                       spacedim>::CELL_COARSEN);
-                break;
-
-              default:
-                Assert(false, ExcInternalError());
-                break;
-            }
+          weights.push_back(this->signals.cell_weight(cell_it, cell_status));
         }
 
       return weights;

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -3361,6 +3361,20 @@ namespace parallel
               // get cell weights for a weighted repartitioning.
               const std::vector<unsigned int> cell_weights = get_cell_weights();
 
+#  ifdef DEBUG
+              // verify that the global sum of weights is larger than 0
+              const auto local_weights_sum =
+                std::accumulate(cell_weights.begin(),
+                                cell_weights.end(),
+                                std::uint64_t(0));
+              const auto global_weights_sum =
+                Utilities::MPI::sum(local_weights_sum, this->mpi_communicator);
+              Assert(global_weights_sum > 0,
+                     ExcMessage(
+                       "The global sum of weights over all active cells "
+                       "is zero. Please verify how you generate weights."));
+#  endif
+
               PartitionWeights<dim, spacedim> partition_weights(cell_weights);
 
               // attach (temporarily) a pointer to the cell weights through
@@ -3528,6 +3542,19 @@ namespace parallel
         {
           // get cell weights for a weighted repartitioning.
           const std::vector<unsigned int> cell_weights = get_cell_weights();
+
+#  ifdef DEBUG
+          // verify that the global sum of weights is larger than 0
+          const auto local_weights_sum = std::accumulate(cell_weights.begin(),
+                                                         cell_weights.end(),
+                                                         std::uint64_t(0));
+          const auto global_weights_sum =
+            Utilities::MPI::sum(local_weights_sum, this->mpi_communicator);
+          Assert(global_weights_sum > 0,
+                 ExcMessage(
+                   "The global sum of weights over all active cells "
+                   "is zero. Please verify how you generate weights."));
+#  endif
 
           PartitionWeights<dim, spacedim> partition_weights(cell_weights);
 

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2001 - 2021 by the deal.II authors
+// Copyright (C) 2001 - 2022 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -3832,7 +3832,7 @@ namespace GridTools
         // If this is a parallel triangulation, we then need to also
         // get the weights for all other cells. We have asserted above
         // that this function can't be used for
-        // parallel::distribute::Triangulation objects, so the only
+        // parallel::distributed::Triangulation objects, so the only
         // ones we have to worry about here are
         // parallel::shared::Triangulation
         if (const auto shared_tria =
@@ -3841,6 +3841,16 @@ namespace GridTools
           Utilities::MPI::sum(cell_weights,
                               shared_tria->get_communicator(),
                               cell_weights);
+
+#ifdef DEBUG
+        // verify that the global sum of weights is larger than 0
+        const auto global_cell_sum = std::accumulate(cell_weights.begin(),
+                                                     cell_weights.end(),
+                                                     std::uint64_t(0));
+        Assert(global_cell_sum > 0,
+               ExcMessage("The global sum of weights over all active cells "
+                          "is zero. Please verify how you generate weights."));
+#endif
       }
 
     // Call the other more general function
@@ -3935,6 +3945,16 @@ namespace GridTools
           Utilities::MPI::sum(cell_weights,
                               shared_tria->get_communicator(),
                               cell_weights);
+
+#ifdef DEBUG
+        // verify that the global sum of weights is larger than 0
+        const auto global_cell_sum = std::accumulate(cell_weights.begin(),
+                                                     cell_weights.end(),
+                                                     std::uint64_t(0));
+        Assert(global_cell_sum > 0,
+               ExcMessage("The global sum of weights over all active cells "
+                          "is zero. Please verify how you generate weights."));
+#endif
       }
 
     // Call the other more general function

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -3816,7 +3816,7 @@ namespace GridTools
     std::vector<unsigned int> cell_weights;
 
     // Get cell weighting if a signal has been attached to the triangulation
-    if (!triangulation.signals.cell_weight.empty())
+    if (!triangulation.signals.weight.empty())
       {
         cell_weights.resize(triangulation.n_active_cells(), 0U);
 
@@ -3826,7 +3826,7 @@ namespace GridTools
         for (const auto &cell : triangulation.active_cell_iterators())
           if (cell->is_locally_owned())
             cell_weights[cell->active_cell_index()] =
-              triangulation.signals.cell_weight(
+              triangulation.signals.weight(
                 cell, Triangulation<dim, spacedim>::CellStatus::CELL_PERSIST);
 
         // If this is a parallel triangulation, we then need to also
@@ -3920,7 +3920,7 @@ namespace GridTools
     std::vector<unsigned int> cell_weights;
 
     // Get cell weighting if a signal has been attached to the triangulation
-    if (!triangulation.signals.cell_weight.empty())
+    if (!triangulation.signals.weight.empty())
       {
         cell_weights.resize(triangulation.n_active_cells(), 0U);
 
@@ -3930,7 +3930,7 @@ namespace GridTools
         for (const auto &cell : triangulation.active_cell_iterators() |
                                   IteratorFilters::LocallyOwnedCell())
           cell_weights[cell->active_cell_index()] =
-            triangulation.signals.cell_weight(
+            triangulation.signals.weight(
               cell, Triangulation<dim, spacedim>::CellStatus::CELL_PERSIST);
 
         // If this is a parallel triangulation, we then need to also
@@ -4060,7 +4060,7 @@ namespace GridTools
                       "are already partitioned implicitly and can not be "
                       "partitioned again explicitly."));
     Assert(n_partitions > 0, ExcInvalidNumberOfPartitions(n_partitions));
-    Assert(triangulation.signals.cell_weight.empty(), ExcNotImplemented());
+    Assert(triangulation.signals.weight.empty(), ExcNotImplemented());
 
     // signal that partitioning is going to happen
     triangulation.signals.pre_partition();

--- a/tests/mpi/cell_weights_01.cc
+++ b/tests/mpi/cell_weights_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2020 by the deal.II authors
+// Copyright (C) 2009 - 2022 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -56,7 +56,7 @@ test()
   const auto n_locally_owned_active_cells_per_processor =
     Utilities::MPI::all_gather(tr.get_communicator(),
                                tr.n_locally_owned_active_cells());
-  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+  if (myid == 0)
     for (unsigned int p = 0; p < numproc; ++p)
       deallog << "processor " << p << ": "
               << n_locally_owned_active_cells_per_processor[p]

--- a/tests/mpi/cell_weights_01_back_and_forth_01.cc
+++ b/tests/mpi/cell_weights_01_back_and_forth_01.cc
@@ -75,16 +75,12 @@ test()
 
   // repartition the mesh as described above, first in some arbitrary
   // way, and then with all equal weights
-  tr.signals.cell_weight.connect(std::bind(&cell_weight_1<dim>,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2));
+  tr.signals.weight.connect(&cell_weight_1<dim>);
   tr.repartition();
 
-  tr.signals.cell_weight.disconnect_all_slots();
+  tr.signals.weight.disconnect_all_slots();
 
-  tr.signals.cell_weight.connect(std::bind(&cell_weight_2<dim>,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2));
+  tr.signals.weight.connect(&cell_weight_2<dim>);
   tr.repartition();
 
   const auto n_locally_owned_active_cells_per_processor =

--- a/tests/mpi/cell_weights_01_back_and_forth_02.cc
+++ b/tests/mpi/cell_weights_01_back_and_forth_02.cc
@@ -64,12 +64,10 @@ test()
 
   // repartition the mesh as described above, first in some arbitrary
   // way, and then with no weights
-  tr.signals.cell_weight.connect(std::bind(&cell_weight_1<dim>,
-                                           std::placeholders::_1,
-                                           std::placeholders::_2));
+  tr.signals.weight.connect(&cell_weight_1<dim>);
   tr.repartition();
 
-  tr.signals.cell_weight.disconnect_all_slots();
+  tr.signals.weight.disconnect_all_slots();
   tr.repartition();
 
   const auto n_locally_owned_active_cells_per_processor =

--- a/tests/mpi/cell_weights_02.cc
+++ b/tests/mpi/cell_weights_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2020 by the deal.II authors
+// Copyright (C) 2009 - 2022 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -40,7 +40,7 @@ cell_weight(
   const typename parallel::distributed::Triangulation<dim>::cell_iterator &cell,
   const typename parallel::distributed::Triangulation<dim>::CellStatus status)
 {
-  return 100;
+  return 1;
 }
 
 template <int dim>
@@ -55,14 +55,13 @@ test()
 
   GridGenerator::subdivided_hyper_cube(tr, 16);
 
-  tr.signals.cell_weight.connect(
-    std::bind(&cell_weight<dim>, std::placeholders::_1, std::placeholders::_2));
+  tr.signals.cell_weight.connect(&cell_weight<dim>);
   tr.refine_global(1);
 
   const auto n_locally_owned_active_cells_per_processor =
     Utilities::MPI::all_gather(tr.get_communicator(),
                                tr.n_locally_owned_active_cells());
-  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+  if (myid == 0)
     for (unsigned int p = 0; p < numproc; ++p)
       deallog << "processor " << p << ": "
               << n_locally_owned_active_cells_per_processor[p]

--- a/tests/mpi/cell_weights_02.cc
+++ b/tests/mpi/cell_weights_02.cc
@@ -55,7 +55,7 @@ test()
 
   GridGenerator::subdivided_hyper_cube(tr, 16);
 
-  tr.signals.cell_weight.connect(&cell_weight<dim>);
+  tr.signals.weight.connect(&cell_weight<dim>);
   tr.refine_global(1);
 
   const auto n_locally_owned_active_cells_per_processor =

--- a/tests/mpi/cell_weights_03.cc
+++ b/tests/mpi/cell_weights_03.cc
@@ -63,7 +63,7 @@ test()
 
   tr.refine_global(1);
 
-  tr.signals.cell_weight.connect(&cell_weight<dim>);
+  tr.signals.weight.connect(&cell_weight<dim>);
 
   tr.repartition();
 

--- a/tests/mpi/cell_weights_03.cc
+++ b/tests/mpi/cell_weights_03.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2020 by the deal.II authors
+// Copyright (C) 2009 - 2022 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -25,6 +25,7 @@
 
 #include <deal.II/distributed/tria.h>
 
+#include <deal.II/grid/filtered_iterator.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>
 #include <deal.II/grid/tria.h>
@@ -41,7 +42,7 @@ cell_weight(
   const typename parallel::distributed::Triangulation<dim>::CellStatus status)
 {
   const unsigned int cell_weight =
-    (cell->center()[0] < 0.5 || cell->center()[1] < 0.5 ? 0 : 3 * 1000);
+    (cell->center()[0] < 0.5 || cell->center()[1] < 0.5 ? 1 : 4);
 
   return cell_weight;
 }
@@ -62,33 +63,29 @@ test()
 
   tr.refine_global(1);
 
-  tr.signals.cell_weight.connect(
-    std::bind(&cell_weight<dim>, std::placeholders::_1, std::placeholders::_2));
+  tr.signals.cell_weight.connect(&cell_weight<dim>);
 
   tr.repartition();
 
   const auto n_locally_owned_active_cells_per_processor =
     Utilities::MPI::all_gather(tr.get_communicator(),
                                tr.n_locally_owned_active_cells());
-  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+  if (myid == 0)
     for (unsigned int p = 0; p < numproc; ++p)
       deallog << "processor " << p << ": "
               << n_locally_owned_active_cells_per_processor[p]
               << " locally owned active cells" << std::endl;
 
   // let each processor sum up its weights
-  std::vector<double> integrated_weights(numproc, 0.0);
-  for (typename Triangulation<dim>::active_cell_iterator cell =
-         tr.begin_active();
-       cell != tr.end();
-       ++cell)
-    if (cell->is_locally_owned())
-      integrated_weights[myid] +=
-        1000 + cell_weight<dim>(
-                 cell, parallel::distributed::Triangulation<dim>::CELL_PERSIST);
+  std::vector<unsigned int> integrated_weights(numproc, 0);
+  for (const auto &cell :
+       tr.active_cell_iterators() | IteratorFilters::LocallyOwnedCell())
+    integrated_weights[myid] +=
+      cell_weight<dim>(cell,
+                       parallel::distributed::Triangulation<dim>::CELL_PERSIST);
 
   Utilities::MPI::sum(integrated_weights, MPI_COMM_WORLD, integrated_weights);
-  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+  if (myid == 0)
     for (unsigned int p = 0; p < numproc; ++p)
       deallog << "processor " << p << ": " << integrated_weights[p] << " weight"
               << std::endl;

--- a/tests/mpi/cell_weights_03.mpirun=5.with_p4est=true.output
+++ b/tests/mpi/cell_weights_03.mpirun=5.with_p4est=true.output
@@ -4,18 +4,18 @@ DEAL:2d::processor 1: 356 locally owned active cells
 DEAL:2d::processor 2: 128 locally owned active cells
 DEAL:2d::processor 3: 92 locally owned active cells
 DEAL:2d::processor 4: 88 locally owned active cells
-DEAL:2d::processor 0: 360000. weight
-DEAL:2d::processor 1: 356000. weight
-DEAL:2d::processor 2: 356000. weight
-DEAL:2d::processor 3: 368000. weight
-DEAL:2d::processor 4: 352000. weight
+DEAL:2d::processor 0: 360 weight
+DEAL:2d::processor 1: 356 weight
+DEAL:2d::processor 2: 356 weight
+DEAL:2d::processor 3: 368 weight
+DEAL:2d::processor 4: 352 weight
 DEAL:3d::processor 0: 11472 locally owned active cells
 DEAL:3d::processor 1: 3480 locally owned active cells
 DEAL:3d::processor 2: 7168 locally owned active cells
 DEAL:3d::processor 3: 7784 locally owned active cells
 DEAL:3d::processor 4: 2864 locally owned active cells
-DEAL:3d::processor 0: 1.14720e+07 weight
-DEAL:3d::processor 1: 1.14720e+07 weight
-DEAL:3d::processor 2: 1.14640e+07 weight
-DEAL:3d::processor 3: 1.14800e+07 weight
-DEAL:3d::processor 4: 1.14560e+07 weight
+DEAL:3d::processor 0: 11472 weight
+DEAL:3d::processor 1: 11472 weight
+DEAL:3d::processor 2: 11464 weight
+DEAL:3d::processor 3: 11480 weight
+DEAL:3d::processor 4: 11456 weight

--- a/tests/mpi/cell_weights_04.cc
+++ b/tests/mpi/cell_weights_04.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2020 by the deal.II authors
+// Copyright (C) 2009 - 2022 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -23,6 +23,7 @@
 
 #include <deal.II/distributed/tria.h>
 
+#include <deal.II/grid/filtered_iterator.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>
 #include <deal.II/grid/tria.h>
@@ -39,7 +40,7 @@ cell_weight(
   const typename parallel::distributed::Triangulation<dim>::CellStatus status)
 {
   const unsigned int cell_weight =
-    (cell->center()[0] < 0.5 || cell->center()[1] < 0.5 ? 0 : 999 * 1000);
+    (cell->center()[0] < 0.5 || cell->center()[1] < 0.5 ? 1 : 1000);
 
   return cell_weight;
 }
@@ -56,33 +57,29 @@ test()
 
   GridGenerator::subdivided_hyper_cube(tr, 16);
 
-  tr.signals.cell_weight.connect(
-    std::bind(&cell_weight<dim>, std::placeholders::_1, std::placeholders::_2));
+  tr.signals.cell_weight.connect(&cell_weight<dim>);
 
   tr.refine_global(1);
 
   const auto n_locally_owned_active_cells_per_processor =
     Utilities::MPI::all_gather(tr.get_communicator(),
                                tr.n_locally_owned_active_cells());
-  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+  if (myid == 0)
     for (unsigned int p = 0; p < numproc; ++p)
       deallog << "processor " << p << ": "
               << n_locally_owned_active_cells_per_processor[p]
               << " locally owned active cells" << std::endl;
 
   // let each processor sum up its weights
-  std::vector<double> integrated_weights(numproc, 0.0);
-  for (typename Triangulation<dim>::active_cell_iterator cell =
-         tr.begin_active();
-       cell != tr.end();
-       ++cell)
-    if (cell->is_locally_owned())
-      integrated_weights[myid] +=
-        1000 + cell_weight<dim>(
-                 cell, parallel::distributed::Triangulation<dim>::CELL_PERSIST);
+  std::vector<unsigned int> integrated_weights(numproc, 0);
+  for (const auto &cell :
+       tr.active_cell_iterators() | IteratorFilters::LocallyOwnedCell())
+    integrated_weights[myid] +=
+      cell_weight<dim>(cell,
+                       parallel::distributed::Triangulation<dim>::CELL_PERSIST);
 
   Utilities::MPI::sum(integrated_weights, MPI_COMM_WORLD, integrated_weights);
-  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+  if (myid == 0)
     for (unsigned int p = 0; p < numproc; ++p)
       deallog << "processor " << p << ": " << integrated_weights[p] << " weight"
               << std::endl;

--- a/tests/mpi/cell_weights_04.cc
+++ b/tests/mpi/cell_weights_04.cc
@@ -57,7 +57,7 @@ test()
 
   GridGenerator::subdivided_hyper_cube(tr, 16);
 
-  tr.signals.cell_weight.connect(&cell_weight<dim>);
+  tr.signals.weight.connect(&cell_weight<dim>);
 
   tr.refine_global(1);
 

--- a/tests/mpi/cell_weights_04.mpirun=5.with_p4est=true.output
+++ b/tests/mpi/cell_weights_04.mpirun=5.with_p4est=true.output
@@ -4,18 +4,18 @@ DEAL:2d::processor 1: 52 locally owned active cells
 DEAL:2d::processor 2: 52 locally owned active cells
 DEAL:2d::processor 3: 48 locally owned active cells
 DEAL:2d::processor 4: 52 locally owned active cells
-DEAL:2d::processor 0: 5.27680e+07 weight
-DEAL:2d::processor 1: 5.20000e+07 weight
-DEAL:2d::processor 2: 5.20000e+07 weight
-DEAL:2d::processor 3: 4.80000e+07 weight
-DEAL:2d::processor 4: 5.20000e+07 weight
+DEAL:2d::processor 0: 52768 weight
+DEAL:2d::processor 1: 52000 weight
+DEAL:2d::processor 2: 52000 weight
+DEAL:2d::processor 3: 48000 weight
+DEAL:2d::processor 4: 52000 weight
 DEAL:3d::processor 0: 13920 locally owned active cells
 DEAL:3d::processor 1: 1640 locally owned active cells
 DEAL:3d::processor 2: 13920 locally owned active cells
 DEAL:3d::processor 3: 1648 locally owned active cells
 DEAL:3d::processor 4: 1640 locally owned active cells
-DEAL:3d::processor 0: 1.64429e+09 weight
-DEAL:3d::processor 1: 1.64000e+09 weight
-DEAL:3d::processor 2: 1.64429e+09 weight
-DEAL:3d::processor 3: 1.64800e+09 weight
-DEAL:3d::processor 4: 1.64000e+09 weight
+DEAL:3d::processor 0: 1644288 weight
+DEAL:3d::processor 1: 1640000 weight
+DEAL:3d::processor 2: 1644288 weight
+DEAL:3d::processor 3: 1648000 weight
+DEAL:3d::processor 4: 1640000 weight

--- a/tests/mpi/cell_weights_05.cc
+++ b/tests/mpi/cell_weights_05.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2020 by the deal.II authors
+// Copyright (C) 2009 - 2022 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -34,6 +34,7 @@
 
 #include <deal.II/distributed/tria.h>
 
+#include <deal.II/grid/filtered_iterator.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>
 #include <deal.II/grid/tria.h>
@@ -49,13 +50,14 @@ cell_weight(
   const typename parallel::distributed::Triangulation<dim>::cell_iterator &cell,
   const typename parallel::distributed::Triangulation<dim>::CellStatus status)
 {
-  return (
-    // bottom left corner
-    (cell->center()[0] < 1) && (cell->center()[1] < 1) &&
-        (dim == 3 ? (cell->center()[2] < 1) : true) ?
-      // one cell has more weight than all others together
-      Utilities::pow(16, dim) * 1000 :
-      0);
+  unsigned int weight = 1;
+
+  // one cell in bottom left corner has more weight than all others together
+  if ((cell->center()[0] < 1) && (cell->center()[1] < 1) &&
+      (dim == 3 ? (cell->center()[2] < 1) : true))
+    weight += Utilities::pow(16, dim);
+
+  return weight;
 }
 
 template <int dim>
@@ -75,32 +77,29 @@ test()
 
 
   // repartition the mesh; attach different weights to all cells
-  tr.signals.cell_weight.connect(
-    std::bind(&cell_weight<dim>, std::placeholders::_1, std::placeholders::_2));
+  tr.signals.cell_weight.connect(&cell_weight<dim>);
 
   tr.repartition();
 
   const auto n_locally_owned_active_cells_per_processor =
     Utilities::MPI::all_gather(tr.get_communicator(),
                                tr.n_locally_owned_active_cells());
-  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+  if (myid == 0)
     for (unsigned int p = 0; p < numproc; ++p)
       deallog << "processor " << p << ": "
               << n_locally_owned_active_cells_per_processor[p]
               << " locally owned active cells" << std::endl;
 
   // let each processor sum up its weights
-  std::vector<double> integrated_weights(numproc, 0.0);
-  for (typename Triangulation<dim>::active_cell_iterator cell =
-         tr.begin_active();
-       cell != tr.end();
-       ++cell)
-    if (cell->is_locally_owned())
-      integrated_weights[myid] +=
-        1000 + cell_weight<dim>(
-                 cell, parallel::distributed::Triangulation<dim>::CELL_PERSIST);
+  std::vector<unsigned int> integrated_weights(numproc, 0);
+  for (const auto &cell :
+       tr.active_cell_iterators() | IteratorFilters::LocallyOwnedCell())
+    integrated_weights[myid] +=
+      cell_weight<dim>(cell,
+                       parallel::distributed::Triangulation<dim>::CELL_PERSIST);
+
   Utilities::MPI::sum(integrated_weights, MPI_COMM_WORLD, integrated_weights);
-  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+  if (myid == 0)
     for (unsigned int p = 0; p < numproc; ++p)
       deallog << "processor " << p << ": " << integrated_weights[p] << " weight"
               << std::endl;

--- a/tests/mpi/cell_weights_05.cc
+++ b/tests/mpi/cell_weights_05.cc
@@ -77,7 +77,7 @@ test()
 
 
   // repartition the mesh; attach different weights to all cells
-  tr.signals.cell_weight.connect(&cell_weight<dim>);
+  tr.signals.weight.connect(&cell_weight<dim>);
 
   tr.repartition();
 

--- a/tests/mpi/cell_weights_05.mpirun=3.with_p4est=true.output
+++ b/tests/mpi/cell_weights_05.mpirun=3.with_p4est=true.output
@@ -1,13 +1,13 @@
 
 DEAL:2d::processor 0: 1 locally owned active cells
-DEAL:2d::processor 1: 85 locally owned active cells
-DEAL:2d::processor 2: 170 locally owned active cells
-DEAL:2d::processor 0: 257000. weight
-DEAL:2d::processor 1: 85000.0 weight
-DEAL:2d::processor 2: 170000. weight
+DEAL:2d::processor 1: 84 locally owned active cells
+DEAL:2d::processor 2: 171 locally owned active cells
+DEAL:2d::processor 0: 257 weight
+DEAL:2d::processor 1: 84 weight
+DEAL:2d::processor 2: 171 weight
 DEAL:3d::processor 0: 1 locally owned active cells
-DEAL:3d::processor 1: 1365 locally owned active cells
-DEAL:3d::processor 2: 2730 locally owned active cells
-DEAL:3d::processor 0: 4.09700e+06 weight
-DEAL:3d::processor 1: 1.36500e+06 weight
-DEAL:3d::processor 2: 2.73000e+06 weight
+DEAL:3d::processor 1: 1364 locally owned active cells
+DEAL:3d::processor 2: 2731 locally owned active cells
+DEAL:3d::processor 0: 4097 weight
+DEAL:3d::processor 1: 1364 weight
+DEAL:3d::processor 2: 2731 weight

--- a/tests/mpi/cell_weights_05.mpirun=5.with_p4est=true.output
+++ b/tests/mpi/cell_weights_05.mpirun=5.with_p4est=true.output
@@ -1,21 +1,21 @@
 
 DEAL:2d::processor 0: 1 locally owned active cells
 DEAL:2d::processor 1: 0 locally owned active cells
-DEAL:2d::processor 2: 51 locally owned active cells
+DEAL:2d::processor 2: 50 locally owned active cells
 DEAL:2d::processor 3: 102 locally owned active cells
-DEAL:2d::processor 4: 102 locally owned active cells
-DEAL:2d::processor 0: 257000. weight
+DEAL:2d::processor 4: 103 locally owned active cells
+DEAL:2d::processor 0: 257 weight
 DEAL:2d::processor 1: 0 weight
-DEAL:2d::processor 2: 51000.0 weight
-DEAL:2d::processor 3: 102000. weight
-DEAL:2d::processor 4: 102000. weight
+DEAL:2d::processor 2: 50 weight
+DEAL:2d::processor 3: 102 weight
+DEAL:2d::processor 4: 103 weight
 DEAL:3d::processor 0: 1 locally owned active cells
 DEAL:3d::processor 1: 0 locally owned active cells
-DEAL:3d::processor 2: 819 locally owned active cells
+DEAL:3d::processor 2: 818 locally owned active cells
 DEAL:3d::processor 3: 1638 locally owned active cells
-DEAL:3d::processor 4: 1638 locally owned active cells
-DEAL:3d::processor 0: 4.09700e+06 weight
+DEAL:3d::processor 4: 1639 locally owned active cells
+DEAL:3d::processor 0: 4097 weight
 DEAL:3d::processor 1: 0 weight
-DEAL:3d::processor 2: 819000. weight
-DEAL:3d::processor 3: 1.63800e+06 weight
-DEAL:3d::processor 4: 1.63800e+06 weight
+DEAL:3d::processor 2: 818 weight
+DEAL:3d::processor 3: 1638 weight
+DEAL:3d::processor 4: 1639 weight

--- a/tests/mpi/cell_weights_06.cc
+++ b/tests/mpi/cell_weights_06.cc
@@ -77,7 +77,7 @@ test()
 
   // repartition the mesh; attach different weights to all cells
   n_global_active_cells = tr.n_global_active_cells();
-  tr.signals.cell_weight.connect(&cell_weight<dim>);
+  tr.signals.weight.connect(&cell_weight<dim>);
   tr.repartition();
 
   const auto n_locally_owned_active_cells_per_processor =

--- a/tests/mpi/cell_weights_06.cc
+++ b/tests/mpi/cell_weights_06.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2020 by the deal.II authors
+// Copyright (C) 2009 - 2022 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -31,6 +31,7 @@
 
 #include <deal.II/distributed/tria.h>
 
+#include <deal.II/grid/filtered_iterator.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>
 #include <deal.II/grid/tria.h>
@@ -48,13 +49,14 @@ cell_weight(
   const typename parallel::distributed::Triangulation<dim>::cell_iterator &cell,
   const typename parallel::distributed::Triangulation<dim>::CellStatus status)
 {
-  return (
-    // bottom left corner
-    (cell->center()[0] < 1) && (cell->center()[1] < 1) &&
-        (dim == 3 ? (cell->center()[2] < 1) : true) ?
-      // one cell has more weight than all others together
-      n_global_active_cells * 1000 :
-      0);
+  unsigned int weight = 1;
+
+  // one cell in bottom left corner has more weight than all others together
+  if ((cell->center()[0] < 1) && (cell->center()[1] < 1) &&
+      (dim == 3 ? (cell->center()[2] < 1) : true))
+    weight += n_global_active_cells;
+
+  return weight;
 }
 
 template <int dim>
@@ -75,31 +77,28 @@ test()
 
   // repartition the mesh; attach different weights to all cells
   n_global_active_cells = tr.n_global_active_cells();
-  tr.signals.cell_weight.connect(
-    std::bind(&cell_weight<dim>, std::placeholders::_1, std::placeholders::_2));
+  tr.signals.cell_weight.connect(&cell_weight<dim>);
   tr.repartition();
 
   const auto n_locally_owned_active_cells_per_processor =
     Utilities::MPI::all_gather(tr.get_communicator(),
                                tr.n_locally_owned_active_cells());
-  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+  if (myid == 0)
     for (unsigned int p = 0; p < numproc; ++p)
       deallog << "processor " << p << ": "
               << n_locally_owned_active_cells_per_processor[p]
               << " locally owned active cells" << std::endl;
 
   // let each processor sum up its weights
-  std::vector<double> integrated_weights(numproc, 0.0);
-  for (typename Triangulation<dim>::active_cell_iterator cell =
-         tr.begin_active();
-       cell != tr.end();
-       ++cell)
-    if (cell->is_locally_owned())
-      integrated_weights[myid] +=
-        1000 + cell_weight<dim>(
-                 cell, parallel::distributed::Triangulation<dim>::CELL_PERSIST);
+  std::vector<unsigned int> integrated_weights(numproc, 0);
+  for (const auto &cell :
+       tr.active_cell_iterators() | IteratorFilters::LocallyOwnedCell())
+    integrated_weights[myid] +=
+      cell_weight<dim>(cell,
+                       parallel::distributed::Triangulation<dim>::CELL_PERSIST);
+
   Utilities::MPI::sum(integrated_weights, MPI_COMM_WORLD, integrated_weights);
-  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+  if (myid == 0)
     for (unsigned int p = 0; p < numproc; ++p)
       deallog << "processor " << p << ": " << integrated_weights[p] << " weight"
               << std::endl;

--- a/tests/mpi/cell_weights_06.mpirun=3.with_p4est=true.output
+++ b/tests/mpi/cell_weights_06.mpirun=3.with_p4est=true.output
@@ -1,13 +1,13 @@
 
 DEAL:2d::processor 0: 0 locally owned active cells
-DEAL:2d::processor 1: 88 locally owned active cells
-DEAL:2d::processor 2: 168 locally owned active cells
+DEAL:2d::processor 1: 84 locally owned active cells
+DEAL:2d::processor 2: 172 locally owned active cells
 DEAL:2d::processor 0: 0 weight
-DEAL:2d::processor 1: 344000. weight
-DEAL:2d::processor 2: 168000. weight
+DEAL:2d::processor 1: 340 weight
+DEAL:2d::processor 2: 172 weight
 DEAL:3d::processor 0: 0 locally owned active cells
 DEAL:3d::processor 1: 1368 locally owned active cells
 DEAL:3d::processor 2: 2728 locally owned active cells
 DEAL:3d::processor 0: 0 weight
-DEAL:3d::processor 1: 5.46400e+06 weight
-DEAL:3d::processor 2: 2.72800e+06 weight
+DEAL:3d::processor 1: 5464 weight
+DEAL:3d::processor 2: 2728 weight

--- a/tests/mpi/hp_cell_weights_01.cc
+++ b/tests/mpi/hp_cell_weights_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2018 - 2021 by the deal.II authors
+// Copyright (C) 2018 - 2022 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -24,8 +24,6 @@
 // repartitioning the triangulation. The expected accumulated weight on
 // each processor should correlate to the sum of all degrees of
 // freedom on all cells of the corresponding subdomain.
-// We employ a large proportionality factor on our weighting function
-// to neglect the standard weight of '1000' per cell.
 //
 // This test works on a parallel::distributed::Triangulation.
 
@@ -78,7 +76,7 @@ test()
 
 
   const parallel::CellWeights<dim> cell_weights(
-    dh, parallel::CellWeights<dim>::ndofs_weighting({100000, 1}));
+    dh, parallel::CellWeights<dim>::ndofs_weighting({1, 1}));
 
   tria.repartition();
 

--- a/tests/mpi/hp_cell_weights_01.with_p4est=true.mpirun=2.output
+++ b/tests/mpi/hp_cell_weights_01.with_p4est=true.mpirun=2.output
@@ -7,8 +7,8 @@ DEAL:0:2d::ExcMessage("Triangulation associated with the DoFHandler has changed!
 DEAL:0:2d::OK
 DEAL:0:3d::Number of cells before repartitioning: 32
 DEAL:0:3d::  Cumulative dofs per cell: 464
-DEAL:0:3d::Number of cells after repartitioning: 24
-DEAL:0:3d::  Cumulative dofs per cell: 400
+DEAL:0:3d::Number of cells after repartitioning: 16
+DEAL:0:3d::  Cumulative dofs per cell: 336
 DEAL:0:3d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:0:3d::OK
 
@@ -20,8 +20,8 @@ DEAL:1:2d::ExcMessage("Triangulation associated with the DoFHandler has changed!
 DEAL:1:2d::OK
 DEAL:1:3d::Number of cells before repartitioning: 32
 DEAL:1:3d::  Cumulative dofs per cell: 256
-DEAL:1:3d::Number of cells after repartitioning: 40
-DEAL:1:3d::  Cumulative dofs per cell: 320
+DEAL:1:3d::Number of cells after repartitioning: 48
+DEAL:1:3d::  Cumulative dofs per cell: 384
 DEAL:1:3d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:1:3d::OK
 

--- a/tests/mpi/hp_cell_weights_02.cc
+++ b/tests/mpi/hp_cell_weights_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2018 - 2021 by the deal.II authors
+// Copyright (C) 2018 - 2022 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -24,8 +24,6 @@
 // repartitioning the triangulation. The expected accumulated weight on
 // each processor should correlate to the sum of all degrees of
 // freedom on all cells of the corresponding subdomain.
-// We employ a large proportionality factor on our weighting function
-// to neglect the standard weight of '1000' per cell.
 //
 // This test works on a parallel::distributed::Triangulation.
 //
@@ -84,7 +82,7 @@ test()
 
 
   const parallel::CellWeights<dim> cell_weights(
-    dh, parallel::CellWeights<dim>::ndofs_weighting({100000, 1}));
+    dh, parallel::CellWeights<dim>::ndofs_weighting({1, 1}));
 
   tria.repartition();
 

--- a/tests/mpi/hp_cell_weights_03.cc
+++ b/tests/mpi/hp_cell_weights_03.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2018 - 2021 by the deal.II authors
+// Copyright (C) 2018 - 2022 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -24,8 +24,6 @@
 // repartitioning the triangulation. The expected accumulated weight on
 // each processor should correlate to the sum of all degrees of
 // freedom on all cells of the corresponding subdomain.
-// We employ a large proportionality factor on our weighting function
-// to neglect the standard weight of '1000' per cell.
 //
 // This test works on a parallel::shared::Triangulation with METIS
 // as a partitioner. Cell weighting with ZOLTAN was not available
@@ -84,7 +82,7 @@ test()
 
 
   const parallel::CellWeights<dim> cell_weights(
-    dh, parallel::CellWeights<dim>::ndofs_weighting({100000, 1}));
+    dh, parallel::CellWeights<dim>::ndofs_weighting({1, 1}));
 
   // we didn't mark any cells, but we want to repartition our domain
   tria.execute_coarsening_and_refinement();

--- a/tests/mpi/hp_cell_weights_04.cc
+++ b/tests/mpi/hp_cell_weights_04.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2019 - 2021 by the deal.II authors
+// Copyright (C) 2019 - 2022 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -24,8 +24,6 @@
 // repartitioning the triangulation. The expected accumulated weight on
 // each processor should correlate to the sum of all degrees of
 // freedom on all cells of the corresponding subdomain.
-// We employ a large proportionality factor on our weighting function
-// to neglect the standard weight of '1000' per cell.
 //
 // This test works on a parallel::shared::Triangulation with METIS
 // as a partitioner. Cell weighting with ZOLTAN was not available
@@ -86,7 +84,7 @@ test()
 
 
   const parallel::CellWeights<dim> cell_weights(
-    dh, parallel::CellWeights<dim>::ndofs_weighting({100000, 1}));
+    dh, parallel::CellWeights<dim>::ndofs_weighting({1, 1}));
 
   // we didn't mark any cells, but we want to repartition our domain
   tria.execute_coarsening_and_refinement();

--- a/tests/particles/particle_weights_01.cc
+++ b/tests/particles/particle_weights_01.cc
@@ -1,0 +1,128 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// verify particle weighting mechanism
+
+
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/fe/mapping_q1.h>
+
+#include <deal.II/grid/filtered_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include <deal.II/particles/generators.h>
+#include <deal.II/particles/particle_handler.h>
+
+#include "../tests.h"
+
+
+template <int dim>
+void
+test()
+{
+  // initialize grid
+  parallel::distributed::Triangulation<dim> triangulation(MPI_COMM_WORLD);
+  {
+    GridGenerator::hyper_cube(triangulation);
+    triangulation.refine_global(2);
+  }
+
+  // initialize particle handler
+  const MappingQ1<dim>            mapping;
+  Particles::ParticleHandler<dim> particle_handler(triangulation, mapping);
+  {
+    const auto local_bounding_box =
+      GridTools::compute_mesh_predicate_bounding_box(
+        triangulation, IteratorFilters::LocallyOwnedCell());
+    const auto global_bounding_boxes =
+      Utilities::MPI::all_gather(triangulation.get_communicator(),
+                                 local_bounding_box);
+
+    Particles::Generators::quadrature_points(triangulation,
+                                             QMidpoint<dim>(),
+                                             global_bounding_boxes,
+                                             particle_handler);
+
+    Assert(particle_handler.n_locally_owned_particles() ==
+             triangulation.n_locally_owned_active_cells(),
+           ExcInternalError());
+    Assert(particle_handler.n_global_particles() ==
+             triangulation.n_global_active_cells(),
+           ExcInternalError());
+  }
+
+  // register weighting function that returns the number of particles per cell
+  triangulation.signals.weight.connect(
+    [&particle_handler](
+      const typename parallel::distributed::Triangulation<dim>::cell_iterator
+        &cell,
+      const typename parallel::distributed::Triangulation<dim>::CellStatus
+        status) -> unsigned int {
+      unsigned int n_particles_in_cell = 0;
+      switch (status)
+        {
+          case parallel::distributed::Triangulation<dim>::CELL_PERSIST:
+          case parallel::distributed::Triangulation<dim>::CELL_REFINE:
+            n_particles_in_cell = particle_handler.n_particles_in_cell(cell);
+            break;
+
+          case parallel::distributed::Triangulation<dim>::CELL_INVALID:
+            break;
+
+          case parallel::distributed::Triangulation<dim>::CELL_COARSEN:
+            for (const auto &child : cell->child_iterators())
+              n_particles_in_cell +=
+                particle_handler.n_particles_in_cell(child);
+            break;
+
+          default:
+            Assert(false, ExcInternalError());
+            break;
+        }
+      deallog << ' ' << n_particles_in_cell << std::endl;
+      return n_particles_in_cell;
+    });
+
+  // refine one cell, and coarsen one group of siblings
+  for (const auto &cell : triangulation.active_cell_iterators() |
+                            IteratorFilters::LocallyOwnedCell())
+    {
+      if (cell->id().to_string() == "0_2:00")
+        cell->set_refine_flag();
+      else if (cell->parent()->id().to_string() == "0_1:3")
+        cell->set_coarsen_flag();
+    }
+
+  deallog << "weights before repartitioning:" << std::endl;
+  triangulation.execute_coarsening_and_refinement();
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  MPILogInitAll all;
+
+  test<2>();
+}

--- a/tests/particles/particle_weights_01.with_p4est=true.mpirun=1.output
+++ b/tests/particles/particle_weights_01.with_p4est=true.mpirun=1.output
@@ -1,0 +1,18 @@
+
+DEAL:0::weights before repartitioning:
+DEAL:0:: 1
+DEAL:0:: 0
+DEAL:0:: 0
+DEAL:0:: 0
+DEAL:0:: 1
+DEAL:0:: 1
+DEAL:0:: 1
+DEAL:0:: 1
+DEAL:0:: 1
+DEAL:0:: 1
+DEAL:0:: 1
+DEAL:0:: 1
+DEAL:0:: 1
+DEAL:0:: 1
+DEAL:0:: 1
+DEAL:0:: 4

--- a/tests/particles/particle_weights_01.with_p4est=true.mpirun=4.output
+++ b/tests/particles/particle_weights_01.with_p4est=true.mpirun=4.output
@@ -1,0 +1,27 @@
+
+DEAL:0::weights before repartitioning:
+DEAL:0:: 1
+DEAL:0:: 0
+DEAL:0:: 0
+DEAL:0:: 0
+DEAL:0:: 1
+DEAL:0:: 1
+DEAL:0:: 1
+
+DEAL:1::weights before repartitioning:
+DEAL:1:: 1
+DEAL:1:: 1
+DEAL:1:: 1
+DEAL:1:: 1
+
+
+DEAL:2::weights before repartitioning:
+DEAL:2:: 1
+DEAL:2:: 1
+DEAL:2:: 1
+DEAL:2:: 1
+
+
+DEAL:3::weights before repartitioning:
+DEAL:3:: 4
+

--- a/tests/particles/step-68.cc
+++ b/tests/particles/step-68.cc
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  *
- * Copyright (C) 2020 - 2021 by the deal.II authors
+ * Copyright (C) 2020 - 2022 by the deal.II authors
  *
  * This file is part of the deal.II library.
  *
@@ -26,7 +26,6 @@
 #include <deal.II/base/parameter_acceptor.h>
 #include <deal.II/base/timer.h>
 
-#include <deal.II/distributed/cell_weights.h>
 #include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
@@ -262,21 +261,18 @@ namespace Step68
     const typename parallel::distributed::Triangulation<dim>::CellStatus status)
     const
   {
-    // We do not assign any weight to cells we do not own (i.e., artificial
-    // or ghost cells)
-    if (!cell->is_locally_owned())
-      return 0;
+    // First, we introduce a base weight that will be assigned to every cell.
+    const unsigned int base_weight = 1;
 
-    // This determines how important particle work is compared to cell
-    // work (by default every cell has a weight of 1000).
-    // We set the weight per particle much higher to indicate that
-    // the particle load is the only one that is important to distribute the
-    // cells in this example. The optimal value of this number depends on the
-    // application and can range from 0 (cheap particle operations,
-    // expensive cell operations) to much larger than 1000 (expensive
-    // particle operations, cheap cell operations, like presumed in this
-    // example).
-    const unsigned int particle_weight = 10000;
+    // The following variable then determines how important particle work is
+    // compared to cell work. We set the weight per particle much higher to
+    // indicate that the particle load is the only one that is important to
+    // distribute the cells in this example. The optimal value of this number
+    // depends on the application and can range from 0 (cheap particle
+    // operations, expensive cell operations) to much larger than the base
+    // weight of 1 (expensive particle operations, cheap cell operations, like
+    // presumed in this example).
+    const unsigned int particle_weight = 10;
 
     // This example does not use adaptive refinement, therefore every cell
     // should have the status `CELL_PERSIST`. However this function can also

--- a/tests/particles/step-68.cc
+++ b/tests/particles/step-68.cc
@@ -249,7 +249,7 @@ namespace Step68
   // return value of this function (representing "work for this cell") is
   // calculated based on the number of particles in the current cell.
   // The function is
-  // connected to the cell_weight() signal inside the triangulation, and will be
+  // connected to the `weight` signal inside the triangulation, and will be
   // called once per cell, whenever the triangulation repartitions the domain
   // between ranks (the connection is created inside the
   // generate_particles() function of this class).
@@ -327,7 +327,7 @@ namespace Step68
     // be created once, so we might as well have set it up in the constructor
     // of this class, but for the purpose of this example we want to group the
     // particle related instructions.
-    background_triangulation.signals.cell_weight.connect(
+    background_triangulation.signals.weight.connect(
       [&](
         const typename parallel::distributed::Triangulation<dim>::cell_iterator
           &cell,


### PR DESCRIPTION
Closes #13510.

I've made some changes to the weighting mechanism for parallel distributed Triangulations.

I noticed that we assigned a base weight for every cell in parallel distributed Triangulations. However, I see two problems with this approach:
- There is no base weight in parallel shared Triangulations (see [grid_tools](https://github.com/dealii/dealii/blob/dc79bc018f6ac5ad37f27c9b90a02d42ff559077/source/grid/grid_tools.cc#L3811-L3818)). So currently there is different behavior between both classes.
- In [step-68](https://github.com/dealii/dealii/blob/dc79bc018f6ac5ad37f27c9b90a02d42ff559077/examples/step-68/step-68.cc#L342-L351) and [step-75](https://github.com/dealii/dealii/blob/dc79bc018f6ac5ad37f27c9b90a02d42ff559077/examples/step-75/step-75.cc#L987-L996), we mitigate the impact of the base weight by choosing additional weights that are much larger than the base weight. I'm sure other users do the same thing, also because we present it like this in our tutorials.

I propose to remove that base weight, and that each user should provide a base weight on their own if they want it.

Right now I'll run the testsuite to see how many test results need to be changed. I'm sure there will be a few.

@gassmoeller -- You implemented that feature back then in #1707. Are you okay with the proposed changes? Do you see any trouble that could arise in user code?

EDIT: @jppelteret -- I just saw that you were the author behind the parallel shared implementation in #6253. I also want to make sure that you agree to this approach :-)