### PR TITLE
Provide a second error for Trilinos sparsity pattern problems.

### DIFF
--- a/source/lac/trilinos_sparsity_pattern.cc
+++ b/source/lac/trilinos_sparsity_pattern.cc
@@ -710,7 +710,25 @@ namespace TrilinosWrappers
         AssertThrow(ierr == 0, ExcTrilinosError(ierr));
       }
 
-    ierr = graph->OptimizeStorage();
+    try
+      {
+        ierr = graph->OptimizeStorage();
+      }
+    catch (const int error_code)
+      {
+        AssertThrow(
+          false,
+          ExcMessage(
+            "The Epetra_CrsGraph::OptimizeStorage() function "
+            "has thrown an error with code " +
+            std::to_string(error_code) +
+            ". You will have to look up the exact meaning of this error "
+            "in the Trilinos source code, but oftentimes, this function "
+            "throwing an error indicates that you are trying to allocate "
+            "more than 2,147,483,647 nonzero entries in the sparsity "
+            "pattern on the local process; this will not work because "
+            "Epetra indexes entries with a simple 'signed int'."));
+      }
     AssertThrow(ierr == 0, ExcTrilinosError(ierr));
   }
 


### PR DESCRIPTION
This is another patch to fix #13428, in addition to #13445. I think we want both.

In essence, at some point or other we are going to call `Epetra_CrsGraph::OptimizeStorage()`, which internally looks like this:
```
int Epetra_CrsGraph::OptimizeStorage() {
  [...]

  if(!Contiguous) { // Must pack indices if not already contiguous

    // Allocate one big integer array for all index values
    if (!(StaticProfile())) { // If static profile, All_Indices_ is already allocated, only need to pack data
      int errorcode = Data.All_Indices_.Size(CrsGraphData_->NumMyNonzeros_);
      if(errorcode != 0) throw ReportError("Error with All_Indices_ allocation.", -99);
    }
```
When we allocate too much memory, `CrsGraphData_->NumMyNonzeros_` has overflown and is a negative integer, and then the call to `Data.All_Indices_.Size()` (which is really a *re*size operation) returns an error code. Helpfully (not!), the function we're looking at here decides to not just return this fact as an error code as it's supposed to do, but instead throw an integer exception. That's just poor design :-(

In deal.II, we correctly check the integer error code, but we miss the exception, which then propagates upward to places where we lost track where things happened. This patch avoids that and translates the integer exception into something more readable. I've verified that with the test in #13428 (but without the assertions in #13445), we now catch the exception and provide a better error messages.

I believe that this should also catch the case @marcfehling is considering, and that uses different code paths than #13445. #13445 is able to give error messages earlier, and so I think it is still useful.

/rebuild