### PR TITLE
Fix the TBB quick test.

### DIFF
--- a/tests/quick_tests/tbb.cc
+++ b/tests/quick_tests/tbb.cc
@@ -18,8 +18,6 @@
 #include <deal.II/base/thread_management.h>
 #include <deal.II/base/work_stream.h>
 
-#include <tbb/task_scheduler_init.h>
-
 #include <iostream>
 
 using namespace dealii;
@@ -87,8 +85,7 @@ test2()
 int
 main()
 {
-  std::cout << "TBB will use "
-            << tbb::task_scheduler_init::default_num_threads() << " threads."
+  std::cout << "TBB will use " << MultithreadInfo::n_threads() << " threads."
             << std::endl;
 
   test1();


### PR DESCRIPTION
I fixed the test to avoid things not in the oneAPI version of TBB. Unfortunately this means the most recent release's quick tests don't work with oneAPI.

I'm worried that we somehow managed to put out a patch release (9.3.3) without ever running this quick test. In fact, I don't know where the CI actually runs the quick tests: we should make sure that happens at some point to avoid problems like this in the future.