### PR TITLE
quick_tests/affinity: fix warning

### DIFF
--- a/tests/quick_tests/affinity.cc
+++ b/tests/quick_tests/affinity.cc
@@ -50,7 +50,7 @@ getaffinity(unsigned int &bits_set, unsigned int &mask)
   for (int i = 0; i < CPU_SETSIZE; ++i)
     bits_set += CPU_ISSET(i, &my_set);
 
-  mask = *reinterpret_cast<int *>(&my_set);
+  mask = *reinterpret_cast<unsigned int *>(&my_set);
 #else
   // sadly we don't have an implementation
   // for mac/windows


### PR DESCRIPTION
```
1/7 Test #2: affinity.release .................***Failed    6.17 sec
/home/runner/work/dealii/dealii/tests/quick_tests/affinity.cc: In function ‘bool getaffinity(unsigned int&, unsigned int&)’:
/home/runner/work/dealii/dealii/tests/quick_tests/affinity.cc:53:42: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
   mask = *reinterpret_cast<int *>(&my_set);
                                          ^
cc1plus: all warnings being treated as errors
```
As `mask` is of type `unsigned int`, this should fix the problem.

Part of https://github.com/dealii/dealii/pull/13467#issuecomment-1054859645.