### PR TITLE
affine_constraints: hide another block of forward declarations

### DIFF
--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -415,10 +415,6 @@ namespace internal
                  dealii::BlockVector<T> &                    vec);
   } // namespace AffineConstraintsImplementation
 } // namespace internal
-
-
-template <typename number>
-class AffineConstraints;
 #endif
 
 // TODO[WB]: We should have a function of the kind
@@ -2348,6 +2344,8 @@ AffineConstraints<number>::get_dof_values(
     }
 }
 
+// Forward declarations
+#ifndef DOXYGEN
 template <typename MatrixType>
 class BlockMatrixBase;
 template <typename SparsityPatternType>
@@ -2465,6 +2463,7 @@ namespace internal
 
   } // namespace AffineConstraints
 } // namespace internal
+#endif
 
 
 


### PR DESCRIPTION
The doc for `BlockMatrixBase` points to the wrong include file. Should be fixed with this patch.

See https://www.dealii.org/developer/doxygen/deal.II/classBlockMatrixBase.html