### PR TITLE
Add std_cxx17::variant.

### DIFF
--- a/include/deal.II/base/std_cxx17/variant.h
+++ b/include/deal.II/base/std_cxx17/variant.h
@@ -1,0 +1,41 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+#ifndef dealii_cxx17_variant_h
+#define dealii_cxx17_variant_h
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_HAVE_CXX17
+#  include <variant>
+#else
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+#  include <boost/variant.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
+#endif
+
+DEAL_II_NAMESPACE_OPEN
+namespace std_cxx17
+{
+#ifndef DEAL_II_HAVE_CXX17
+  using boost::get;
+  using boost::variant;
+#else
+  using std::get;
+  using std::variant;
+#endif
+} // namespace std_cxx17
+DEAL_II_NAMESPACE_CLOSE
+
+#endif // dealii_cxx17_variant_h

--- a/include/deal.II/base/table_handler.h
+++ b/include/deal.II/base/table_handler.h
@@ -20,13 +20,13 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/std_cxx17/variant.h>
 
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/serialization/map.hpp>
 #include <boost/serialization/split_member.hpp>
 #include <boost/serialization/string.hpp>
 #include <boost/serialization/vector.hpp>
-#include <boost/variant.hpp>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <fstream>
@@ -48,10 +48,10 @@ namespace internal
   /**
    * A <tt>TableEntry</tt> stores the value of a table entry. It can either be
    * of type int, unsigned int, std::uint64_t, double or std::string. In
-   * essence, this structure is the same as <code>boost::variant@<int,unsigned
-   * int,std::uint64_t,double,std::string@></code> but we wrap this object in a
+   * essence, this structure is the same as `std::variant<int,unsigned
+   * int,std::uint64_t,double,std::string>` but we wrap this object in a
    * structure for which we can write a function that can serialize it. This is
-   * also why the function is not in fact of type boost::any.
+   * also why the function is not in fact of type std::any.
    */
   struct TableEntry
   {
@@ -151,7 +151,7 @@ namespace internal
      * Abbreviation for the data type stored by this object.
      */
     using value_type =
-      boost::variant<int, unsigned int, std::uint64_t, double, std::string>;
+      std_cxx17::variant<int, unsigned int, std::uint64_t, double, std::string>;
 
     /**
      * Stored value.
@@ -820,13 +820,13 @@ namespace internal
   {
     // we don't quite know the data type in 'value', but
     // it must be one of the ones in the type list of the
-    // boost::variant. so if T is not in the list, or if
+    // std_cxx17::variant. so if T is not in the list, or if
     // the data stored in the TableEntry is not of type
     // T, then we will get an exception that we can
     // catch and produce an error message
     try
       {
-        return boost::get<T>(value);
+        return std_cxx17::get<T>(value);
       }
     catch (...)
       {

--- a/source/base/table_handler.cc
+++ b/source/base/table_handler.cc
@@ -36,13 +36,13 @@ namespace internal
   {
     // we don't quite know the data type in 'value', but
     // it must be one of the ones in the type list of the
-    // boost::variant. Go through this list and return
+    // std_cxx17::variant. Go through this list and return
     // the value if this happens to be a number
     //
     // first try with int
     try
       {
-        return boost::get<int>(value);
+        return std_cxx17::get<int>(value);
       }
     catch (...)
       {}
@@ -51,7 +51,7 @@ namespace internal
     // ... then with unsigned int...
     try
       {
-        return boost::get<unsigned int>(value);
+        return std_cxx17::get<unsigned int>(value);
       }
     catch (...)
       {}
@@ -59,7 +59,7 @@ namespace internal
     // ... then with std::uint64_t...
     try
       {
-        return boost::get<std::uint64_t>(value);
+        return std_cxx17::get<std::uint64_t>(value);
       }
     catch (...)
       {}
@@ -67,7 +67,7 @@ namespace internal
     // ...and finally with double precision:
     try
       {
-        return boost::get<double>(value);
+        return std_cxx17::get<double>(value);
       }
     catch (...)
       {
@@ -105,6 +105,7 @@ namespace internal
   }
 
 
+#ifndef DEAL_II_HAVE_CXX17
   namespace Local
   {
     // see which type we can cast to, then use this type to create
@@ -119,12 +120,20 @@ namespace internal
       }
     };
   } // namespace Local
+#endif
 
   TableEntry
   TableEntry::get_default_constructed_copy() const
   {
     TableEntry new_entry = *this;
+#ifndef DEAL_II_HAVE_CXX17
     boost::apply_visitor(Local::GetDefaultValue(), new_entry.value);
+#else
+    // Let std::visit figure out which data type is actually stored,
+    // and then set the object so stored to a default-constructed
+    // one.
+    std::visit([](auto &arg) { arg = decltype(arg)(); }, new_entry.value);
+#endif
 
     return new_entry;
   }


### PR DESCRIPTION
Like we already do for `std_cxx17::optional`. The second commit also converts uses of `boost::variant` to `std_cxx17::variant`.

/rebuild