### PR TITLE
Check during MF::reinit() if AffineConstraints are closed

### DIFF
--- a/doc/news/changes/incompatibilities/20220308Munch
+++ b/doc/news/changes/incompatibilities/20220308Munch
@@ -1,0 +1,9 @@
+Changed: To be able to guarantee correctness of
+the application of constraints in MatrixFree, we
+require that users call AffineConstraints::close()
+before calling MatrixFree::reinit() if AffineConstraints
+objects are passed that are not empty. One can check
+if an AffineConstraints object is closed with the
+new function AffineConstraints::is_closed(). 
+<br>
+(Peter Munch, 2022/03/08)

--- a/tests/matrix_free/mixed_mesh_hn_algorithm_01.cc
+++ b/tests/matrix_free/mixed_mesh_hn_algorithm_01.cc
@@ -106,6 +106,7 @@ main()
 
   AffineConstraints<double> constraints;
   DoFTools::make_hanging_node_constraints(dof_handler, constraints);
+  constraints.close();
 
   const auto print = [](const auto &label, const auto &matrix_free) {
     deallog << label << std::endl;

--- a/tests/matrix_free/mixed_mesh_hn_algorithm_01.output
+++ b/tests/matrix_free/mixed_mesh_hn_algorithm_01.output
@@ -1,9 +1,9 @@
 
 DEAL::use_fast_hanging_node_algorithm = true
 DEAL::0   : 12  13  14  
-DEAL::0   : 13  2   2   1   
-DEAL::0   : 14  2   1   1   
-DEAL::0   : 13  2   1   14  
+DEAL::0   : 13  2   1   2   
+DEAL::0   : 14  1   2   1   
+DEAL::0   : 13  1   2   14  
 DEAL::0   : 0   1   2   
 DEAL::0   : 3   1   4   
 DEAL::0   : 5   4   1   
@@ -17,9 +17,9 @@ DEAL::
 DEAL::
 DEAL::use_fast_hanging_node_algorithm = false
 DEAL::0   : 12  13  14  
-DEAL::0   : 13  2   2   1   
-DEAL::0   : 14  2   1   1   
-DEAL::0   : 13  2   1   14  
+DEAL::0   : 13  2   1   2   
+DEAL::0   : 14  1   2   1   
+DEAL::0   : 13  1   2   14  
 DEAL::0   : 0   1   2   
 DEAL::0   : 3   1   4   
 DEAL::0   : 5   4   1   
@@ -27,6 +27,6 @@ DEAL::0   : 1   0   5
 DEAL::0   : 6   5   0   
 DEAL::0   : 7   8   9   10  
 DEAL::0   : 8   12  10  14  
-DEAL::0   : 9   10  3   3   1   
-DEAL::0   : 10  14  3   1   1   
+DEAL::0   : 9   10  3   1   3   
+DEAL::0   : 10  14  1   3   1   
 DEAL::


### PR DESCRIPTION
If one does not close, the following `MatrixFree` object gives different results, depending on fast HN algorithm is enabled or not:

```cpp
  Triangulation<dim> tria;
  GridGenerator::subdivided_hyper_cube(tria, 2);
  tria.begin()->set_refine_flag();
  tria.execute_coarsening_and_refinement();

  QGauss<dim>    quad(degree + 1);
  FE_Q<dim>      fe(degree);
  MappingQ1<dim> mapping;

  DoFHandler<dim> dof_handler;
  dof_handler.reinit(tria);
  dof_handler.distribute_dofs(fe);

  AffineConstraints<Number> constraints;
  DoFTools::make_zero_boundary_constraints(dof_handler, constraints);
  DoFTools::make_hanging_node_constraints(dof_handler, constraints);
  constraints.close(); // needed!!!

  typename MatrixFree<dim, Number, VectorizedArrayType>::AdditionalData
    additional_data;
  additional_data.mapping_update_flags = update_values | update_gradients |
                                         update_JxW_values |
                                         dealii::update_quadrature_points;

  MatrixFree<dim, Number, VectorizedArrayType> matrix_free;
  matrix_free.reinit(mapping, dof_handler, constraints, quad, additional_data);
```

~depends on #13505~