### PR TITLE
Revert most of "Avoid implicit bool conversions"

### DIFF
--- a/include/deal.II/base/geometry_info.h
+++ b/include/deal.II/base/geometry_info.h
@@ -3827,7 +3827,7 @@ GeometryInfo<3>::line_refinement_case(
   const unsigned int direction[lines_per_cell] = {
     1, 1, 0, 0, 1, 1, 0, 0, 2, 2, 2, 2};
 
-  return ((cell_refinement_case & cut_one[direction[line_no]]) != 0u ?
+  return ((cell_refinement_case & cut_one[direction[line_no]]) ?
             RefinementCase<1>::cut_x :
             RefinementCase<1>::no_refinement);
 }

--- a/include/deal.II/fe/fe_poly.h
+++ b/include/deal.II/fe/fe_poly.h
@@ -281,14 +281,13 @@ protected:
     // polynomial to put the values and derivatives of shape functions
     // to put there, depending on what the user requested
     std::vector<double> values(
-      (update_flags & update_values) != 0u ? this->n_dofs_per_cell() : 0);
+      update_flags & update_values ? this->n_dofs_per_cell() : 0);
     std::vector<Tensor<1, dim>> grads(
-      (update_flags & update_gradients) != 0u ? this->n_dofs_per_cell() : 0);
+      update_flags & update_gradients ? this->n_dofs_per_cell() : 0);
     std::vector<Tensor<2, dim>> grad_grads(
-      (update_flags & update_hessians) != 0u ? this->n_dofs_per_cell() : 0);
+      update_flags & update_hessians ? this->n_dofs_per_cell() : 0);
     std::vector<Tensor<3, dim>> third_derivatives(
-      (update_flags & update_3rd_derivatives) != 0u ? this->n_dofs_per_cell() :
-                                                      0);
+      update_flags & update_3rd_derivatives ? this->n_dofs_per_cell() : 0);
     std::vector<Tensor<4, dim>>
       fourth_derivatives; // won't be needed, so leave empty
 
@@ -313,20 +312,20 @@ protected:
           (output_data.shape_values.n_cols() == n_q_points)))
       data.shape_values.reinit(this->n_dofs_per_cell(), n_q_points);
 
-    if ((update_flags & update_gradients) != 0u)
+    if (update_flags & update_gradients)
       data.shape_gradients.reinit(this->n_dofs_per_cell(), n_q_points);
 
-    if ((update_flags & update_hessians) != 0u)
+    if (update_flags & update_hessians)
       data.shape_hessians.reinit(this->n_dofs_per_cell(), n_q_points);
 
-    if ((update_flags & update_3rd_derivatives) != 0u)
+    if (update_flags & update_3rd_derivatives)
       data.shape_3rd_derivatives.reinit(this->n_dofs_per_cell(), n_q_points);
 
     // next already fill those fields of which we have information by
     // now. note that the shape gradients are only those on the unit
     // cell, and need to be transformed when visiting an actual cell
-    if ((update_flags & (update_values | update_gradients | update_hessians |
-                         update_3rd_derivatives)) != 0u)
+    if (update_flags & (update_values | update_gradients | update_hessians |
+                        update_3rd_derivatives))
       for (unsigned int i = 0; i < n_q_points; ++i)
         {
           poly_space->evaluate(quadrature.point(i),
@@ -343,7 +342,7 @@ protected:
           // faces and subfaces, but we later on copy only a portion of it
           // into the output object; in that case, copy the data from all
           // faces into the scratch object
-          if ((update_flags & update_values) != 0u)
+          if (update_flags & update_values)
             if (output_data.shape_values.n_rows() > 0)
               {
                 if (output_data.shape_values.n_cols() == n_q_points)
@@ -357,15 +356,15 @@ protected:
           // for everything else, derivatives need to be transformed,
           // so we write them into our scratch space and only later
           // copy stuff into where FEValues wants it
-          if ((update_flags & update_gradients) != 0u)
+          if (update_flags & update_gradients)
             for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
               data.shape_gradients[k][i] = grads[k];
 
-          if ((update_flags & update_hessians) != 0u)
+          if (update_flags & update_hessians)
             for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
               data.shape_hessians[k][i] = grad_grads[k];
 
-          if ((update_flags & update_3rd_derivatives) != 0u)
+          if (update_flags & update_3rd_derivatives)
             for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
               data.shape_3rd_derivatives[k][i] = third_derivatives[k];
         }

--- a/include/deal.II/fe/fe_poly.templates.h
+++ b/include/deal.II/fe/fe_poly.templates.h
@@ -193,19 +193,19 @@ FE_Poly<dim, spacedim>::requires_update_flags(const UpdateFlags flags) const
 {
   UpdateFlags out = update_default;
 
-  if ((flags & update_values) != 0u)
+  if (flags & update_values)
     out |= update_values;
-  if ((flags & update_gradients) != 0u)
+  if (flags & update_gradients)
     out |= update_gradients | update_covariant_transformation;
-  if ((flags & update_hessians) != 0u)
+  if (flags & update_hessians)
     out |= update_hessians | update_covariant_transformation |
            update_gradients | update_jacobian_pushed_forward_grads;
-  if ((flags & update_3rd_derivatives) != 0u)
+  if (flags & update_3rd_derivatives)
     out |= update_3rd_derivatives | update_covariant_transformation |
            update_hessians | update_gradients |
            update_jacobian_pushed_forward_grads |
            update_jacobian_pushed_forward_2nd_derivatives;
-  if ((flags & update_normal_vectors) != 0u)
+  if (flags & update_normal_vectors)
     out |= update_normal_vectors | update_JxW_values;
 
   return out;
@@ -293,7 +293,7 @@ FE_Poly<dim, spacedim>::fill_fe_values(
   // transform gradients and higher derivatives. there is nothing to do
   // for values since we already emplaced them into output_data when
   // we were in get_data()
-  if (((flags & update_gradients) != 0u) &&
+  if ((flags & update_gradients) &&
       (cell_similarity != CellSimilarity::translation))
     for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       mapping.transform(make_array_view(fe_data.shape_gradients, k),
@@ -301,7 +301,7 @@ FE_Poly<dim, spacedim>::fill_fe_values(
                         mapping_internal,
                         make_array_view(output_data.shape_gradients, k));
 
-  if (((flags & update_hessians) != 0u) &&
+  if ((flags & update_hessians) &&
       (cell_similarity != CellSimilarity::translation))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
@@ -314,7 +314,7 @@ FE_Poly<dim, spacedim>::fill_fe_values(
         correct_hessians(output_data, mapping_data, quadrature.size());
     }
 
-  if (((flags & update_3rd_derivatives) != 0u) &&
+  if ((flags & update_3rd_derivatives) &&
       (cell_similarity != CellSimilarity::translation))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
@@ -381,12 +381,12 @@ FE_Poly<dim, spacedim>::fill_fe_face_values(
   // transform gradients and higher derivatives. we also have to copy
   // the values (unlike in the case of fill_fe_values()) since
   // we need to take into account the offsets
-  if ((flags & update_values) != 0u)
+  if (flags & update_values)
     for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       for (unsigned int i = 0; i < n_q_points; ++i)
         output_data.shape_values(k, i) = fe_data.shape_values[k][i + offset];
 
-  if ((flags & update_gradients) != 0u)
+  if (flags & update_gradients)
     for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       mapping.transform(
         make_array_view(fe_data.shape_gradients, k, offset, n_q_points),
@@ -394,7 +394,7 @@ FE_Poly<dim, spacedim>::fill_fe_face_values(
         mapping_internal,
         make_array_view(output_data.shape_gradients, k));
 
-  if ((flags & update_hessians) != 0u)
+  if (flags & update_hessians)
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         mapping.transform(
@@ -407,7 +407,7 @@ FE_Poly<dim, spacedim>::fill_fe_face_values(
         correct_hessians(output_data, mapping_data, n_q_points);
     }
 
-  if ((flags & update_3rd_derivatives) != 0u)
+  if (flags & update_3rd_derivatives)
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         mapping.transform(
@@ -473,12 +473,12 @@ FE_Poly<dim, spacedim>::fill_fe_subface_values(
   // transform gradients and higher derivatives. we also have to copy
   // the values (unlike in the case of fill_fe_values()) since
   // we need to take into account the offsets
-  if ((flags & update_values) != 0u)
+  if (flags & update_values)
     for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       for (unsigned int i = 0; i < quadrature.size(); ++i)
         output_data.shape_values(k, i) = fe_data.shape_values[k][i + offset];
 
-  if ((flags & update_gradients) != 0u)
+  if (flags & update_gradients)
     for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       mapping.transform(
         make_array_view(fe_data.shape_gradients, k, offset, quadrature.size()),
@@ -486,7 +486,7 @@ FE_Poly<dim, spacedim>::fill_fe_subface_values(
         mapping_internal,
         make_array_view(output_data.shape_gradients, k));
 
-  if ((flags & update_hessians) != 0u)
+  if (flags & update_hessians)
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         mapping.transform(
@@ -499,7 +499,7 @@ FE_Poly<dim, spacedim>::fill_fe_subface_values(
         correct_hessians(output_data, mapping_data, quadrature.size());
     }
 
-  if ((flags & update_3rd_derivatives) != 0u)
+  if (flags & update_3rd_derivatives)
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         mapping.transform(make_array_view(fe_data.shape_3rd_derivatives,

--- a/include/deal.II/fe/fe_poly_face.templates.h
+++ b/include/deal.II/fe/fe_poly_face.templates.h
@@ -62,11 +62,11 @@ FE_PolyFace<PolynomialType, dim, spacedim>::requires_update_flags(
   const UpdateFlags flags) const
 {
   UpdateFlags out = flags & update_values;
-  if ((flags & update_gradients) != 0u)
+  if (flags & update_gradients)
     out |= update_gradients | update_covariant_transformation;
-  if ((flags & update_hessians) != 0u)
+  if (flags & update_hessians)
     out |= update_hessians | update_covariant_transformation;
-  if ((flags & update_normal_vectors) != 0u)
+  if (flags & update_normal_vectors)
     out |= update_normal_vectors | update_JxW_values;
 
   return out;

--- a/include/deal.II/fe/fe_poly_tensor.h
+++ b/include/deal.II/fe/fe_poly_tensor.h
@@ -301,8 +301,7 @@ protected:
     std::vector<Tensor<4, dim>> third_derivatives(0);
     std::vector<Tensor<5, dim>> fourth_derivatives(0);
 
-    if ((update_flags & (update_values | update_gradients | update_hessians)) !=
-        0u)
+    if (update_flags & (update_values | update_gradients | update_hessians))
       data.dof_sign_change.resize(this->dofs_per_cell);
 
     // initialize fields only if really
@@ -325,7 +324,7 @@ protected:
     const bool update_transformed_shape_hessian_tensors =
       update_transformed_shape_values;
 
-    if ((update_flags & update_values) != 0u)
+    if (update_flags & update_values)
       {
         values.resize(this->n_dofs_per_cell());
         data.shape_values.reinit(this->n_dofs_per_cell(), n_q_points);
@@ -333,7 +332,7 @@ protected:
           data.transformed_shape_values.resize(n_q_points);
       }
 
-    if ((update_flags & update_gradients) != 0u)
+    if (update_flags & update_gradients)
       {
         grads.resize(this->n_dofs_per_cell());
         data.shape_grads.reinit(this->n_dofs_per_cell(), n_q_points);
@@ -343,7 +342,7 @@ protected:
           data.untransformed_shape_grads.resize(n_q_points);
       }
 
-    if ((update_flags & update_hessians) != 0u)
+    if (update_flags & update_hessians)
       {
         grad_grads.resize(this->n_dofs_per_cell());
         data.shape_grad_grads.reinit(this->n_dofs_per_cell(), n_q_points);
@@ -359,7 +358,7 @@ protected:
     // node values N_i holds
     // N_i(v_j)=\delta_ij for all basis
     // functions v_j
-    if ((update_flags & (update_values | update_gradients)) != 0u)
+    if (update_flags & (update_values | update_gradients))
       for (unsigned int k = 0; k < n_q_points; ++k)
         {
           poly_space->evaluate(quadrature.point(k),
@@ -369,7 +368,7 @@ protected:
                                third_derivatives,
                                fourth_derivatives);
 
-          if ((update_flags & update_values) != 0u)
+          if (update_flags & update_values)
             {
               if (inverse_node_matrix.n_cols() == 0)
                 for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
@@ -384,7 +383,7 @@ protected:
                   }
             }
 
-          if ((update_flags & update_gradients) != 0u)
+          if (update_flags & update_gradients)
             {
               if (inverse_node_matrix.n_cols() == 0)
                 for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
@@ -399,7 +398,7 @@ protected:
                   }
             }
 
-          if ((update_flags & update_hessians) != 0u)
+          if (update_flags & update_hessians)
             {
               if (inverse_node_matrix.n_cols() == 0)
                 for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)

--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -279,12 +279,12 @@ namespace internal
         case 1:
           for (unsigned int c = 0; c < n_components; ++c)
             {
-              if ((evaluation_flag & EvaluationFlags::values) != 0u)
+              if (evaluation_flag & EvaluationFlags::values)
                 eval0.template values<0, true, false>(values_dofs, values_quad);
-              if ((evaluation_flag & EvaluationFlags::gradients) != 0u)
+              if (evaluation_flag & EvaluationFlags::gradients)
                 eval0.template gradients<0, true, false>(values_dofs,
                                                          gradients_quad);
-              if ((evaluation_flag & EvaluationFlags::hessians) != 0u)
+              if (evaluation_flag & EvaluationFlags::hessians)
                 eval0.template hessians<0, true, false>(values_dofs,
                                                         hessians_quad);
 
@@ -300,15 +300,15 @@ namespace internal
           for (unsigned int c = 0; c < n_components; ++c)
             {
               // grad x
-              if ((evaluation_flag & EvaluationFlags::gradients) != 0u)
+              if (evaluation_flag & EvaluationFlags::gradients)
                 {
                   eval0.template gradients<0, true, false>(values_dofs, temp1);
                   eval1.template values<1, true, false>(temp1, gradients_quad);
                 }
-              if ((evaluation_flag & EvaluationFlags::hessians) != 0u)
+              if (evaluation_flag & EvaluationFlags::hessians)
                 {
                   // grad xy
-                  if ((evaluation_flag & EvaluationFlags::gradients) == 0u)
+                  if (!(evaluation_flag & EvaluationFlags::gradients))
                     eval0.template gradients<0, true, false>(values_dofs,
                                                              temp1);
                   eval1.template gradients<1, true, false>(temp1,
@@ -322,19 +322,19 @@ namespace internal
 
               // grad y
               eval0.template values<0, true, false>(values_dofs, temp1);
-              if ((evaluation_flag & EvaluationFlags::gradients) != 0u)
+              if (evaluation_flag & EvaluationFlags::gradients)
                 eval1.template gradients<1, true, false>(temp1,
                                                          gradients_quad +
                                                            n_q_points);
 
               // grad yy
-              if ((evaluation_flag & EvaluationFlags::hessians) != 0u)
+              if (evaluation_flag & EvaluationFlags::hessians)
                 eval1.template hessians<1, true, false>(temp1,
                                                         hessians_quad +
                                                           n_q_points);
 
               // val: can use values applied in x
-              if ((evaluation_flag & EvaluationFlags::values) != 0u)
+              if (evaluation_flag & EvaluationFlags::values)
                 eval1.template values<1, true, false>(temp1, values_quad);
 
               // advance to the next component in 1D array
@@ -348,7 +348,7 @@ namespace internal
         case 3:
           for (unsigned int c = 0; c < n_components; ++c)
             {
-              if ((evaluation_flag & EvaluationFlags::gradients) != 0u)
+              if (evaluation_flag & EvaluationFlags::gradients)
                 {
                   // grad x
                   eval0.template gradients<0, true, false>(values_dofs, temp1);
@@ -356,10 +356,10 @@ namespace internal
                   eval2.template values<2, true, false>(temp2, gradients_quad);
                 }
 
-              if ((evaluation_flag & EvaluationFlags::hessians) != 0u)
+              if (evaluation_flag & EvaluationFlags::hessians)
                 {
                   // grad xz
-                  if ((evaluation_flag & EvaluationFlags::gradients) == 0u)
+                  if (!(evaluation_flag & EvaluationFlags::gradients))
                     {
                       eval0.template gradients<0, true, false>(values_dofs,
                                                                temp1);
@@ -383,7 +383,7 @@ namespace internal
 
               // grad y
               eval0.template values<0, true, false>(values_dofs, temp1);
-              if ((evaluation_flag & EvaluationFlags::gradients) != 0u)
+              if (evaluation_flag & EvaluationFlags::gradients)
                 {
                   eval1.template gradients<1, true, false>(temp1, temp2);
                   eval2.template values<2, true, false>(temp2,
@@ -391,10 +391,10 @@ namespace internal
                                                           n_q_points);
                 }
 
-              if ((evaluation_flag & EvaluationFlags::hessians) != 0u)
+              if (evaluation_flag & EvaluationFlags::hessians)
                 {
                   // grad yz
-                  if ((evaluation_flag & EvaluationFlags::gradients) == 0u)
+                  if (!(evaluation_flag & EvaluationFlags::gradients))
                     eval1.template gradients<1, true, false>(temp1, temp2);
                   eval2.template gradients<2, true, false>(temp2,
                                                            hessians_quad +
@@ -410,21 +410,21 @@ namespace internal
               // grad z: can use the values applied in x direction stored in
               // temp1
               eval1.template values<1, true, false>(temp1, temp2);
-              if ((evaluation_flag & EvaluationFlags::gradients) != 0u)
+              if (evaluation_flag & EvaluationFlags::gradients)
                 eval2.template gradients<2, true, false>(temp2,
                                                          gradients_quad +
                                                            2 * n_q_points);
 
               // grad zz: can use the values applied in x and y direction stored
               // in temp2
-              if ((evaluation_flag & EvaluationFlags::hessians) != 0u)
+              if (evaluation_flag & EvaluationFlags::hessians)
                 eval2.template hessians<2, true, false>(temp2,
                                                         hessians_quad +
                                                           2 * n_q_points);
 
               // val: can use the values applied in x & y direction stored in
               // temp2
-              if ((evaluation_flag & EvaluationFlags::values) != 0u)
+              if (evaluation_flag & EvaluationFlags::values)
                 eval2.template values<2, true, false>(temp2, values_quad);
 
               // advance to the next component in 1D array
@@ -442,7 +442,7 @@ namespace internal
     // case additional dof for FE_Q_DG0: add values; gradients and second
     // derivatives evaluate to zero
     if (type == MatrixFreeFunctions::tensor_symmetric_plus_dg0 &&
-        ((evaluation_flag & EvaluationFlags::values) != 0u))
+        (evaluation_flag & EvaluationFlags::values))
       {
         values_quad -= n_components * n_q_points;
         values_dofs -= n_components * dofs_per_comp;
@@ -526,7 +526,7 @@ namespace internal
         case 1:
           for (unsigned int c = 0; c < n_components; ++c)
             {
-              if ((integration_flag & EvaluationFlags::values) != 0u)
+              if (integration_flag & EvaluationFlags::values)
                 {
                   if (add_into_values_array == false)
                     eval0.template values<0, false, false>(values_quad,
@@ -535,9 +535,9 @@ namespace internal
                     eval0.template values<0, false, true>(values_quad,
                                                           values_dofs);
                 }
-              if ((integration_flag & EvaluationFlags::gradients) != 0u)
+              if (integration_flag & EvaluationFlags::gradients)
                 {
-                  if (((integration_flag & EvaluationFlags::values) != 0u) ||
+                  if (integration_flag & EvaluationFlags::values ||
                       add_into_values_array == true)
                     eval0.template gradients<0, false, true>(gradients_quad,
                                                              values_dofs);
@@ -568,8 +568,8 @@ namespace internal
         case 2:
           for (unsigned int c = 0; c < n_components; ++c)
             {
-              if (((integration_flag & EvaluationFlags::values) != 0u) &&
-                  ((integration_flag & EvaluationFlags::gradients) == 0u))
+              if ((integration_flag & EvaluationFlags::values) &&
+                  !(integration_flag & EvaluationFlags::gradients))
                 {
                   eval1.template values<1, false, false>(values_quad, temp1);
                   if (add_into_values_array == false)
@@ -577,12 +577,12 @@ namespace internal
                   else
                     eval0.template values<0, false, true>(temp1, values_dofs);
                 }
-              if ((integration_flag & EvaluationFlags::gradients) != 0u)
+              if (integration_flag & EvaluationFlags::gradients)
                 {
                   eval1.template gradients<1, false, false>(gradients_quad +
                                                               n_q_points,
                                                             temp1);
-                  if ((integration_flag & EvaluationFlags::values) != 0u)
+                  if (integration_flag & EvaluationFlags::values)
                     eval1.template values<1, false, true>(values_quad, temp1);
                   if (add_into_values_array == false)
                     eval0.template values<0, false, false>(temp1, values_dofs);
@@ -628,8 +628,8 @@ namespace internal
         case 3:
           for (unsigned int c = 0; c < n_components; ++c)
             {
-              if (((integration_flag & EvaluationFlags::values) != 0u) &&
-                  ((integration_flag & EvaluationFlags::gradients) == 0u))
+              if ((integration_flag & EvaluationFlags::values) &&
+                  !(integration_flag & EvaluationFlags::gradients))
                 {
                   eval2.template values<2, false, false>(values_quad, temp1);
                   eval1.template values<1, false, false>(temp1, temp2);
@@ -638,12 +638,12 @@ namespace internal
                   else
                     eval0.template values<0, false, true>(temp2, values_dofs);
                 }
-              if ((integration_flag & EvaluationFlags::gradients) != 0u)
+              if (integration_flag & EvaluationFlags::gradients)
                 {
                   eval2.template gradients<2, false, false>(gradients_quad +
                                                               2 * n_q_points,
                                                             temp1);
-                  if ((integration_flag & EvaluationFlags::values) != 0u)
+                  if (integration_flag & EvaluationFlags::values)
                     eval2.template values<2, false, true>(values_quad, temp1);
                   eval1.template values<1, false, false>(temp1, temp2);
                   eval2.template values<2, false, false>(gradients_quad +
@@ -725,7 +725,7 @@ namespace internal
       {
         values_dofs -= n_components * dofs_per_comp - dofs_per_comp + 1;
         values_quad -= n_components * n_q_points;
-        if ((integration_flag & EvaluationFlags::values) != 0u)
+        if (integration_flag & EvaluationFlags::values)
           for (unsigned int c = 0; c < n_components; ++c)
             {
               values_dofs[0] = values_quad[0];
@@ -790,7 +790,7 @@ namespace internal
     using Eval =
       EvaluatorTensorProduct<evaluate_general, 1, 0, 0, Number, Number>;
 
-    if ((evaluation_flag & EvaluationFlags::values) != 0u)
+    if (evaluation_flag & EvaluationFlags::values)
       {
         const auto shape_values    = shape_data.front().shape_values.data();
         auto       values_quad_ptr = fe_eval.begin_values();
@@ -807,7 +807,7 @@ namespace internal
           }
       }
 
-    if ((evaluation_flag & EvaluationFlags::gradients) != 0u)
+    if (evaluation_flag & EvaluationFlags::gradients)
       {
         const auto shape_gradients = shape_data.front().shape_gradients.data();
         auto       gradients_quad_ptr     = fe_eval.begin_gradients();
@@ -832,7 +832,7 @@ namespace internal
           }
       }
 
-    if ((evaluation_flag & EvaluationFlags::hessians) != 0u)
+    if (evaluation_flag & EvaluationFlags::hessians)
       Assert(false, ExcNotImplemented());
   }
 
@@ -864,7 +864,7 @@ namespace internal
     using Eval =
       EvaluatorTensorProduct<evaluate_general, 1, 0, 0, Number, Number>;
 
-    if ((integration_flag & EvaluationFlags::values) != 0u)
+    if (integration_flag & EvaluationFlags::values)
       {
         const auto shape_values    = shape_data.front().shape_values.data();
         auto       values_quad_ptr = fe_eval.begin_values();
@@ -885,7 +885,7 @@ namespace internal
           }
       }
 
-    if ((integration_flag & EvaluationFlags::gradients) != 0u)
+    if (integration_flag & EvaluationFlags::gradients)
       {
         const auto shape_gradients = shape_data.front().shape_gradients.data();
         auto       gradients_quad_ptr     = fe_eval.begin_gradients();
@@ -902,7 +902,7 @@ namespace internal
                           n_q_points);
 
                 if ((add_into_values_array == false &&
-                     (integration_flag & EvaluationFlags::values) == 0) &&
+                     !(integration_flag & EvaluationFlags::values)) &&
                     d == 0)
                   eval.template gradients<0, false, false>(
                     gradients_quad_ptr, values_dofs_actual_ptr);
@@ -1426,7 +1426,7 @@ namespace internal
                                                   gradients_quad +
                                                     2 * n_points);
       }
-    if ((evaluation_flag & EvaluationFlags::hessians) != 0u)
+    if (evaluation_flag & EvaluationFlags::hessians)
       {
         eval.template hessians<0, true, false>(values_dofs, hessians_quad);
         if (dim > 1)
@@ -1535,7 +1535,7 @@ namespace internal
         if (dim == 2)
           {
             // grad xy, queue into gradient
-            if ((integration_flag & EvaluationFlags::gradients) != 0u)
+            if (integration_flag & EvaluationFlags::gradients)
               eval.template gradients<1, false, true>(hessians_quad +
                                                         2 * n_points,
                                                       gradients_quad);
@@ -1547,7 +1547,7 @@ namespace internal
         if (dim == 3)
           {
             // grad xy, queue into gradient
-            if ((integration_flag & EvaluationFlags::gradients) != 0u)
+            if (integration_flag & EvaluationFlags::gradients)
               eval.template gradients<1, false, true>(hessians_quad +
                                                         3 * n_points,
                                                       gradients_quad);
@@ -1562,7 +1562,7 @@ namespace internal
                                                     gradients_quad);
 
             // grad yz
-            if ((integration_flag & EvaluationFlags::gradients) != 0u)
+            if (integration_flag & EvaluationFlags::gradients)
               eval.template gradients<2, false, true>(
                 hessians_quad + 5 * n_points, gradients_quad + n_points);
             else
@@ -1662,8 +1662,8 @@ namespace internal
                               fe_eval.begin_values() + c * n_q_points);
 
         // apply derivatives in the collocation space
-        if ((evaluation_flag &
-             (EvaluationFlags::gradients | EvaluationFlags::hessians)) != 0u)
+        if (evaluation_flag &
+            (EvaluationFlags::gradients | EvaluationFlags::hessians))
           FEEvaluationImplCollocation<dim, n_q_points_1d - 1, Number>::
             do_evaluate(shape_data,
                         evaluation_flag & (EvaluationFlags::gradients |
@@ -1701,8 +1701,8 @@ namespace internal
     for (unsigned int c = 0; c < n_components; ++c)
       {
         // apply derivatives in collocation space
-        if ((integration_flag &
-             (EvaluationFlags::gradients | EvaluationFlags::hessians)) != 0u)
+        if (integration_flag &
+            (EvaluationFlags::gradients | EvaluationFlags::hessians))
           FEEvaluationImplCollocation<dim, n_q_points_1d - 1, Number>::
             do_integrate(shape_data,
                          integration_flag & (EvaluationFlags::gradients |

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -7189,11 +7189,11 @@ FEEvaluation<dim,
     }
 
 #  ifdef DEBUG
-  if ((evaluation_flag_actual & EvaluationFlags::values) != 0u)
+  if (evaluation_flag_actual & EvaluationFlags::values)
     this->values_quad_initialized = true;
-  if ((evaluation_flag_actual & EvaluationFlags::gradients) != 0u)
+  if (evaluation_flag_actual & EvaluationFlags::gradients)
     this->gradients_quad_initialized = true;
-  if ((evaluation_flag_actual & EvaluationFlags::hessians) != 0u)
+  if (evaluation_flag_actual & EvaluationFlags::hessians)
     this->hessians_quad_initialized = true;
 #  endif
 }
@@ -7425,10 +7425,10 @@ FEEvaluation<dim,
             const bool                             sum_into_values_array)
 {
 #  ifdef DEBUG
-  if ((integration_flag & EvaluationFlags::values) != 0u)
+  if (integration_flag & EvaluationFlags::values)
     Assert(this->values_quad_submitted == true,
            internal::ExcAccessToUninitializedField());
-  if ((integration_flag & EvaluationFlags::gradients) != 0u)
+  if (integration_flag & EvaluationFlags::gradients)
     Assert(this->gradients_quad_submitted == true,
            internal::ExcAccessToUninitializedField());
   if ((integration_flag & EvaluationFlags::hessians) != 0u)
@@ -7982,9 +7982,9 @@ FEFaceEvaluation<dim,
       n_components, evaluation_flag_actual, values_array, *this);
 
 #  ifdef DEBUG
-  if ((evaluation_flag_actual & EvaluationFlags::values) != 0u)
+  if (evaluation_flag_actual & EvaluationFlags::values)
     this->values_quad_initialized = true;
-  if ((evaluation_flag_actual & EvaluationFlags::gradients) != 0u)
+  if (evaluation_flag_actual & EvaluationFlags::gradients)
     this->gradients_quad_initialized = true;
   if ((evaluation_flag_actual & EvaluationFlags::hessians) != 0u)
     this->hessians_quad_initialized = true;
@@ -8091,7 +8091,7 @@ FEFaceEvaluation<dim,
                     "and EvaluationFlags::hessians are supported."));
 
   EvaluationFlags::EvaluationFlags integration_flag_actual = integration_flag;
-  if (((integration_flag & EvaluationFlags::hessians) != 0u) &&
+  if (integration_flag & EvaluationFlags::hessians &&
       (this->cell_type > internal::MatrixFreeFunctions::affine))
     {
       unsigned int size = n_components * dim * n_q_points;

--- a/include/deal.II/matrix_free/mapping_data_on_the_fly.h
+++ b/include/deal.II/matrix_free/mapping_data_on_the_fly.h
@@ -187,7 +187,7 @@ namespace internal
       mapping_info_storage.data_index_offsets.resize(1);
       mapping_info_storage.JxW_values.resize(fe_values->n_quadrature_points);
       mapping_info_storage.jacobians[0].resize(fe_values->n_quadrature_points);
-      if ((update_flags & update_quadrature_points) != 0u)
+      if (update_flags & update_quadrature_points)
         {
           mapping_info_storage.quadrature_point_offsets.resize(1, 0);
           mapping_info_storage.quadrature_points.resize(

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -88,8 +88,8 @@ namespace internal
           update_flags_cells, quad);
 
       this->update_flags_boundary_faces =
-        (((update_flags_inner_faces | update_flags_boundary_faces) &
-          update_quadrature_points) != 0u ?
+        ((update_flags_inner_faces | update_flags_boundary_faces) &
+             update_quadrature_points ?
            update_quadrature_points :
            update_default) |
         (((update_flags_inner_faces | update_flags_boundary_faces) &
@@ -1359,10 +1359,10 @@ namespace internal
             data_cells_local.back().first[my_q].JxW_values.size());
           cell_data[my_q].jacobians[0].resize_fast(
             cell_data[my_q].JxW_values.size());
-          if ((update_flags_cells & update_jacobian_grads) != 0)
+          if (update_flags_cells & update_jacobian_grads)
             cell_data[my_q].jacobian_gradients[0].resize_fast(
               cell_data[my_q].JxW_values.size());
-          if ((update_flags_cells & update_quadrature_points) != 0)
+          if (update_flags_cells & update_quadrature_points)
             {
               cell_data[my_q].quadrature_point_offsets.resize(cell_type.size());
               cell_data[my_q].quadrature_points.resize_fast(
@@ -2402,7 +2402,7 @@ namespace internal
             face_data[my_q].JxW_values.size());
           face_data[my_q].jacobians[1].resize_fast(
             face_data[my_q].JxW_values.size());
-          if ((update_flags_common & update_jacobian_grads) != 0u)
+          if (update_flags_common & update_jacobian_grads)
             {
               face_data[my_q].jacobian_gradients[0].resize_fast(
                 face_data[my_q].JxW_values.size());
@@ -2413,7 +2413,7 @@ namespace internal
             face_data[my_q].JxW_values.size());
           face_data[my_q].normals_times_jacobians[1].resize_fast(
             face_data[my_q].JxW_values.size());
-          if ((update_flags_common & update_quadrature_points) != 0u)
+          if (update_flags_common & update_quadrature_points)
             {
               face_data[my_q].quadrature_point_offsets.resize(face_type.size());
               face_data[my_q].quadrature_points.resize_fast(
@@ -2645,10 +2645,10 @@ namespace internal
 
           my_data.JxW_values.resize_fast(max_size);
           my_data.jacobians[0].resize_fast(max_size);
-          if ((update_flags_cells & update_jacobian_grads) != 0)
+          if (update_flags_cells & update_jacobian_grads)
             my_data.jacobian_gradients[0].resize_fast(max_size);
 
-          if ((update_flags_cells & update_quadrature_points) != 0)
+          if (update_flags_cells & update_quadrature_points)
             {
               my_data.quadrature_point_offsets.resize(cell_type.size());
               for (unsigned int cell = 1; cell < cell_type.size(); ++cell)
@@ -2772,7 +2772,7 @@ namespace internal
           my_data.normal_vectors.resize_fast(max_size);
           my_data.jacobians[0].resize_fast(max_size);
           my_data.jacobians[1].resize_fast(max_size);
-          if ((update_flags_common & update_jacobian_grads) != 0u)
+          if (update_flags_common & update_jacobian_grads)
             {
               my_data.jacobian_gradients[0].resize_fast(max_size);
               my_data.jacobian_gradients[1].resize_fast(max_size);
@@ -2780,7 +2780,7 @@ namespace internal
           my_data.normals_times_jacobians[0].resize_fast(max_size);
           my_data.normals_times_jacobians[1].resize_fast(max_size);
 
-          if ((update_flags_common & update_quadrature_points) != 0u)
+          if (update_flags_common & update_quadrature_points)
             {
               my_data.quadrature_point_offsets.resize(face_type.size());
               my_data.quadrature_point_offsets[0] = 0;
@@ -2876,7 +2876,7 @@ namespace internal
       const unsigned int n_quads = face_data_by_cells.size();
       const unsigned int n_lanes = VectorizedArrayType::size();
       UpdateFlags        update_flags =
-        ((update_flags_faces_by_cells & update_quadrature_points) != 0 ?
+        (update_flags_faces_by_cells & update_quadrature_points ?
            update_quadrature_points :
            update_default) |
         update_normal_vectors | update_JxW_values | update_jacobians;
@@ -2889,7 +2889,7 @@ namespace internal
           AssertDimension(cell_type.size(), cells.size() / n_lanes);
           face_data_by_cells[my_q].data_index_offsets.resize(
             cell_type.size() * GeometryInfo<dim>::faces_per_cell);
-          if ((update_flags & update_quadrature_points) != 0)
+          if (update_flags & update_quadrature_points)
             face_data_by_cells[my_q].quadrature_point_offsets.resize(
               cell_type.size() * GeometryInfo<dim>::faces_per_cell);
           std::size_t storage_length = 0;
@@ -2911,7 +2911,7 @@ namespace internal
                     storage_length +=
                       face_data_by_cells[my_q].descriptor[0].n_q_points;
                   }
-                if ((update_flags & update_quadrature_points) != 0u)
+                if (update_flags & update_quadrature_points)
                   face_data_by_cells[my_q].quadrature_point_offsets
                     [i * GeometryInfo<dim>::faces_per_cell + face] =
                     (i * GeometryInfo<dim>::faces_per_cell + face) *
@@ -2923,22 +2923,22 @@ namespace internal
             storage_length * GeometryInfo<dim>::faces_per_cell);
           face_data_by_cells[my_q].jacobians[1].resize_fast(
             storage_length * GeometryInfo<dim>::faces_per_cell);
-          if ((update_flags & update_normal_vectors) != 0u)
+          if (update_flags & update_normal_vectors)
             face_data_by_cells[my_q].normal_vectors.resize_fast(
               storage_length * GeometryInfo<dim>::faces_per_cell);
-          if (((update_flags & update_normal_vectors) != 0u) &&
-              ((update_flags & update_jacobians) != 0u))
+          if (update_flags & update_normal_vectors &&
+              update_flags & update_jacobians)
             face_data_by_cells[my_q].normals_times_jacobians[0].resize_fast(
               storage_length * GeometryInfo<dim>::faces_per_cell);
-          if (((update_flags & update_normal_vectors) != 0u) &&
-              ((update_flags & update_jacobians) != 0u))
+          if (update_flags & update_normal_vectors &&
+              update_flags & update_jacobians)
             face_data_by_cells[my_q].normals_times_jacobians[1].resize_fast(
               storage_length * GeometryInfo<dim>::faces_per_cell);
-          if ((update_flags & update_jacobian_grads) != 0u)
+          if (update_flags & update_jacobian_grads)
             face_data_by_cells[my_q].jacobian_gradients[0].resize_fast(
               storage_length * GeometryInfo<dim>::faces_per_cell);
 
-          if ((update_flags & update_quadrature_points) != 0u)
+          if (update_flags & update_quadrature_points)
             face_data_by_cells[my_q].quadrature_points.resize_fast(
               cell_type.size() * GeometryInfo<dim>::faces_per_cell *
               face_data_by_cells[my_q].descriptor[0].n_q_points);
@@ -3012,10 +3012,10 @@ namespace internal
                   // copy data for affine data type
                   if (cell_type[cell] <= affine)
                     {
-                      if ((update_flags & update_JxW_values) != 0u)
+                      if (update_flags & update_JxW_values)
                         face_data_by_cells[my_q].JxW_values[offset][v] =
                           fe_val.JxW(0) / fe_val.get_quadrature().weight(0);
-                      if ((update_flags & update_jacobians) != 0u)
+                      if (update_flags & update_jacobians)
                         {
                           DerivativeForm<1, dim, dim> inv_jac =
                             fe_val.jacobian(0).covariant_form();
@@ -3029,7 +3029,7 @@ namespace internal
                                   inv_jac[d][ee];
                               }
                         }
-                      if (is_local && ((update_flags & update_jacobians) != 0u))
+                      if (is_local && (update_flags & update_jacobians))
                         for (unsigned int q = 0; q < fe_val.n_quadrature_points;
                              ++q)
                           {
@@ -3046,11 +3046,11 @@ namespace internal
                                     inv_jac[d][ee];
                                 }
                           }
-                      if ((update_flags & update_jacobian_grads) != 0u)
+                      if (update_flags & update_jacobian_grads)
                         {
                           Assert(false, ExcNotImplemented());
                         }
-                      if ((update_flags & update_normal_vectors) != 0u)
+                      if (update_flags & update_normal_vectors)
                         for (unsigned int d = 0; d < dim; ++d)
                           face_data_by_cells[my_q]
                             .normal_vectors[offset][d][v] =
@@ -3059,12 +3059,12 @@ namespace internal
                   // copy data for general data type
                   else
                     {
-                      if ((update_flags & update_JxW_values) != 0u)
+                      if (update_flags & update_JxW_values)
                         for (unsigned int q = 0; q < fe_val.n_quadrature_points;
                              ++q)
                           face_data_by_cells[my_q].JxW_values[offset + q][v] =
                             fe_val.JxW(q);
-                      if ((update_flags & update_jacobians) != 0u)
+                      if (update_flags & update_jacobians)
                         for (unsigned int q = 0; q < fe_val.n_quadrature_points;
                              ++q)
                           {
@@ -3081,11 +3081,11 @@ namespace internal
                                     inv_jac[d][ee];
                                 }
                           }
-                      if ((update_flags & update_jacobian_grads) != 0u)
+                      if (update_flags & update_jacobian_grads)
                         {
                           Assert(false, ExcNotImplemented());
                         }
-                      if ((update_flags & update_normal_vectors) != 0u)
+                      if (update_flags & update_normal_vectors)
                         for (unsigned int q = 0; q < fe_val.n_quadrature_points;
                              ++q)
                           for (unsigned int d = 0; d < dim; ++d)
@@ -3093,7 +3093,7 @@ namespace internal
                               .normal_vectors[offset + q][d][v] =
                               fe_val.normal_vector(q)[d];
                     }
-                  if ((update_flags & update_quadrature_points) != 0u)
+                  if (update_flags & update_quadrature_points)
                     for (unsigned int q = 0; q < fe_val.n_quadrature_points;
                          ++q)
                       for (unsigned int d = 0; d < dim; ++d)
@@ -3102,8 +3102,8 @@ namespace internal
                              [cell * GeometryInfo<dim>::faces_per_cell + face] +
                            q][d][v] = fe_val.quadrature_point(q)[d];
                 }
-              if (((update_flags & update_normal_vectors) != 0u) &&
-                  ((update_flags & update_jacobians) != 0u))
+              if (update_flags & update_normal_vectors &&
+                  update_flags & update_jacobians)
                 for (unsigned int q = 0; q < (cell_type[cell] <= affine ?
                                                 1 :
                                                 fe_val.n_quadrature_points);
@@ -3112,8 +3112,8 @@ namespace internal
                     .normals_times_jacobians[0][offset + q] =
                     face_data_by_cells[my_q].normal_vectors[offset + q] *
                     face_data_by_cells[my_q].jacobians[0][offset + q];
-              if (((update_flags & update_normal_vectors) != 0u) &&
-                  ((update_flags & update_jacobians) != 0u))
+              if (update_flags & update_normal_vectors &&
+                  update_flags & update_jacobians)
                 for (unsigned int q = 0; q < (cell_type[cell] <= affine ?
                                                 1 :
                                                 fe_val.n_quadrature_points);

--- a/include/deal.II/meshworker/integration_info.h
+++ b/include/deal.II/meshworker/integration_info.h
@@ -786,13 +786,13 @@ namespace MeshWorker
                                             const BlockInfo *block_info)
   {
     initialize_update_flags();
-    initialize_gauss_quadrature(((cell_flags & update_values) != 0) ?
+    initialize_gauss_quadrature((cell_flags & update_values) ?
                                   (el.tensor_degree() + 1) :
                                   el.tensor_degree(),
-                                ((boundary_flags & update_values) != 0) ?
+                                (boundary_flags & update_values) ?
                                   (el.tensor_degree() + 1) :
                                   el.tensor_degree(),
-                                ((face_flags & update_values) != 0) ?
+                                (face_flags & update_values) ?
                                   (el.tensor_degree() + 1) :
                                   el.tensor_degree(),
                                 false);

--- a/source/distributed/fully_distributed_tria.cc
+++ b/source/distributed/fully_distributed_tria.cc
@@ -73,9 +73,8 @@ namespace parallel
       settings = construction_data.settings;
 
       // set the smoothing properties
-      if ((settings &
-           TriangulationDescription::Settings::construct_multigrid_hierarchy) !=
-          0)
+      if (settings &
+          TriangulationDescription::Settings::construct_multigrid_hierarchy)
         this->set_mesh_smoothing(
           static_cast<
             typename dealii::Triangulation<dim, spacedim>::MeshSmoothing>(
@@ -203,8 +202,8 @@ namespace parallel
                     cell->set_subdomain_id(cell_info->subdomain_id);
 
                   // level subdomain id
-                  if ((settings & TriangulationDescription::Settings::
-                                    construct_multigrid_hierarchy) != 0)
+                  if (settings & TriangulationDescription::Settings::
+                                   construct_multigrid_hierarchy)
                     cell->set_level_subdomain_id(cell_info->level_subdomain_id);
                 }
             }
@@ -395,8 +394,9 @@ namespace parallel
     bool
     Triangulation<dim, spacedim>::is_multilevel_hierarchy_constructed() const
     {
-      return (settings & TriangulationDescription::Settings::
-                           construct_multigrid_hierarchy) != 0;
+      return (
+        settings &
+        TriangulationDescription::Settings::construct_multigrid_hierarchy);
     }
 
 

--- a/source/fe/fe_dgp_nonparametric.cc
+++ b/source/fe/fe_dgp_nonparametric.cc
@@ -262,7 +262,7 @@ FE_DGPNonparametric<dim, spacedim>::requires_update_flags(
 {
   UpdateFlags out = flags;
 
-  if ((flags & (update_values | update_gradients | update_hessians)) != 0u)
+  if (flags & (update_values | update_gradients | update_hessians))
     out |= update_quadrature_points;
 
   return out;

--- a/source/fe/fe_enriched.cc
+++ b/source/fe/fe_enriched.cc
@@ -305,11 +305,11 @@ FE_Enriched<dim, spacedim>::requires_update_flags(const UpdateFlags flags) const
   if (is_enriched)
     {
       // if we ask for values or gradients, then we would need quadrature points
-      if ((flags & (update_values | update_gradients)) != 0u)
+      if (flags & (update_values | update_gradients))
         out |= update_quadrature_points;
 
       // if need gradients, add update_values due to product rule
-      if ((out & update_gradients) != 0u)
+      if (out & update_gradients)
         out |= update_values;
     }
 

--- a/source/fe/fe_face.cc
+++ b/source/fe/fe_face.cc
@@ -677,11 +677,11 @@ UpdateFlags
 FE_FaceQ<1, spacedim>::requires_update_flags(const UpdateFlags flags) const
 {
   UpdateFlags out = flags & update_values;
-  if ((flags & update_gradients) != 0u)
+  if (flags & update_gradients)
     out |= update_gradients | update_covariant_transformation;
-  if ((flags & update_hessians) != 0u)
+  if (flags & update_hessians)
     out |= update_hessians | update_covariant_transformation;
-  if ((flags & update_normal_vectors) != 0u)
+  if (flags & update_normal_vectors)
     out |= update_normal_vectors | update_JxW_values;
 
   return out;

--- a/source/fe/fe_nedelec_sz.cc
+++ b/source/fe/fe_nedelec_sz.cc
@@ -165,20 +165,20 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                                 vertices_per_cell, std::vector<double>(dim)));
 
   // Resize shape function arrays according to update flags:
-  if ((flags & update_values) != 0u)
+  if (flags & update_values)
     {
       data.shape_values.resize(this->n_dofs_per_cell(),
                                std::vector<Tensor<1, dim>>(n_q_points));
     }
 
-  if ((flags & update_gradients) != 0u)
+  if (flags & update_gradients)
     {
       data.shape_grads.resize(this->n_dofs_per_cell(),
                               std::vector<DerivativeForm<1, dim, dim>>(
                                 n_q_points));
     }
 
-  if ((flags & update_hessians) != 0u)
+  if (flags & update_hessians)
     {
       data.shape_hessians.resize(this->n_dofs_per_cell(),
                                  std::vector<DerivativeForm<2, dim, dim>>(
@@ -403,8 +403,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
             cell_type2_offset + degree * degree;
           const unsigned int cell_type3_offset2 = cell_type3_offset1 + degree;
 
-          if ((flags & (update_values | update_gradients | update_hessians)) !=
-              0u)
+          if (flags & (update_values | update_gradients | update_hessians))
             {
               // compute all points we must evaluate the 1d polynomials at:
               std::vector<Point<dim>> cell_points(n_q_points);
@@ -429,10 +428,10 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                   // update_values, but need the 2nd derivative too for
                   // update_gradients. For update_hessians we also need the 3rd
                   // derivatives.
-                  const unsigned int poly_length(
-                    (flags & update_hessians) != 0u ?
+                  const unsigned int poly_length =
+                    (flags & update_hessians) ?
                       4 :
-                      ((flags & update_gradients) != 0u ? 3 : 2));
+                      ((flags & update_gradients) ? 3 : 2);
 
                   std::vector<std::vector<double>> polyx(
                     degree, std::vector<double>(poly_length));
@@ -449,7 +448,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                         cell_points[q][1], polyy[i]);
                     }
                   // Now use these to compute the shape functions:
-                  if ((flags & update_values) != 0u)
+                  if (flags & update_values)
                     {
                       for (unsigned int j = 0; j < degree; ++j)
                         {
@@ -486,7 +485,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                           data.shape_values[dof_index3_2][q][1] = polyx[j][0];
                         }
                     }
-                  if ((flags & update_gradients) != 0u)
+                  if (flags & update_gradients)
                     {
                       for (unsigned int j = 0; j < degree; ++j)
                         {
@@ -879,8 +878,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
 
               // for cell-based shape functions:
               // these don't depend on the cell, so can precompute all here:
-              if ((flags &
-                   (update_values | update_gradients | update_hessians)) != 0u)
+              if (flags & (update_values | update_gradients | update_hessians))
                 {
                   // Cell-based shape functions:
                   //
@@ -936,10 +934,10 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                   // update_values, but need the 2nd derivative too for
                   // update_gradients. For update_hessians we also need 3rd
                   // derivative.
-                  const unsigned int poly_length(
-                    (flags & update_hessians) != 0u ?
+                  const unsigned int poly_length =
+                    (flags & update_hessians) ?
                       4 :
-                      ((flags & update_gradients) != 0u ? 3 : 2));
+                      ((flags & update_gradients) ? 3 : 2);
 
                   // Loop through quad points:
                   for (unsigned int q = 0; q < n_q_points; ++q)
@@ -967,7 +965,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                             cell_points[q][2], polyz[i]);
                         }
                       // Now use these to compute the shape functions:
-                      if ((flags & update_values) != 0u)
+                      if (flags & update_values)
                         {
                           for (unsigned int k = 0; k < degree; ++k)
                             {
@@ -1050,7 +1048,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                                 }
                             }
                         }
-                      if ((flags & update_gradients) != 0u)
+                      if (flags & update_gradients)
                         {
                           for (unsigned int k = 0; k < degree; ++k)
                             {
@@ -1518,8 +1516,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
     {
       case 2:
         {
-          if ((flags & (update_values | update_gradients | update_hessians)) !=
-              0u)
+          if (flags & (update_values | update_gradients | update_hessians))
             {
               // Define an edge numbering so that each edge, E_{m} = [e^{m}_{1},
               // e^{m}_{2}] e1 = higher global numbering of the two local
@@ -1612,10 +1609,11 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
               // If we want to generate shape gradients then we need second
               // derivatives of the 1d polynomials, but only first derivatives
               // for the shape values.
-              const unsigned int poly_length(
-                (flags & update_hessians) != 0u ?
+              const unsigned int poly_length =
+                (flags & update_hessians) ?
                   4 :
-                  ((flags & update_gradients) != 0u ? 3 : 2));
+                  ((flags & update_gradients) ? 3 : 2);
+
 
               for (unsigned int m = 0; m < lines_per_cell; ++m)
                 {
@@ -1633,7 +1631,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
                           IntegratedLegendrePolynomials[i + 1].value(
                             edge_sigma_values[m][q], poly[i - 1]);
                         }
-                      if ((flags & update_values) != 0u)
+                      if (flags & update_values)
                         {
                           // Lowest order edge shape functions:
                           for (unsigned int d = 0; d < dim; ++d)
@@ -1658,7 +1656,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
                                 }
                             }
                         }
-                      if ((flags & update_gradients) != 0u)
+                      if (flags & update_gradients)
                         {
                           // Lowest order edge shape functions:
                           for (unsigned int d1 = 0; d1 < dim; ++d1)
@@ -1754,8 +1752,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
         }
       case 3:
         {
-          if ((flags & (update_values | update_gradients | update_hessians)) !=
-              0u)
+          if (flags & (update_values | update_gradients | update_hessians))
             {
               // Define an edge numbering so that each edge, E_{m} = [e^{m}_{1},
               // e^{m}_{2}] e1 = higher global numbering of the two local
@@ -1851,10 +1848,10 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
               // If we want to generate shape gradients then we need second
               // derivatives of the 1d polynomials, but only first derivatives
               // for the shape values.
-              const unsigned int poly_length(
-                (flags & update_hessians) != 0u ?
+              const unsigned int poly_length =
+                (flags & update_hessians) ?
                   4 :
-                  ((flags & update_gradients) != 0u ? 3 : 2));
+                  ((flags & update_gradients) ? 3 : 2);
 
               std::vector<std::vector<double>> poly(
                 degree, std::vector<double>(poly_length));
@@ -1873,7 +1870,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
                                 edge_sigma_values[m][q], poly[i]);
                             }
                         }
-                      if ((flags & update_values) != 0u)
+                      if (flags & update_values)
                         {
                           // Lowest order edge shape functions:
                           for (unsigned int d = 0; d < dim; ++d)
@@ -1898,7 +1895,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
                                 }
                             }
                         }
-                      if ((flags & update_gradients) != 0u)
+                      if (flags & update_gradients)
                         {
                           // Lowest order edge shape functions:
                           for (unsigned int d1 = 0; d1 < dim; ++d1)
@@ -2051,7 +2048,7 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
     {
       const UpdateFlags flags(fe_data.update_each);
 
-      if ((flags & (update_values | update_gradients | update_hessians)) != 0u)
+      if (flags & (update_values | update_gradients | update_hessians))
         {
           const unsigned int n_q_points = quadrature.size();
 
@@ -2177,9 +2174,10 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
                 }
             }
           // Now can generate the basis
-          const unsigned int poly_length((flags & update_hessians) != 0u  ? 4 :
-                                         (flags & update_gradients) != 0u ? 3 :
-                                                                            2);
+          const unsigned int poly_length =
+            (flags & update_hessians) ? 4 :
+                                        ((flags & update_gradients) ? 3 : 2);
+
 
           std::vector<std::vector<double>> polyxi(
             degree, std::vector<double>(poly_length));
@@ -2244,7 +2242,7 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
                         face_eta_values[m][q], polyeta[i]);
                     }
                   // Now use these to compute the shape functions:
-                  if ((flags & update_values) != 0u)
+                  if (flags & update_values)
                     {
                       for (unsigned int j = 0; j < degree; ++j)
                         {
@@ -2296,7 +2294,7 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
                             }
                         }
                     }
-                  if ((flags & update_gradients) != 0u)
+                  if (flags & update_gradients)
                     {
                       for (unsigned int j = 0; j < degree; ++j)
                         {
@@ -2390,7 +2388,7 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
                             }
                         }
                     }
-                  if ((flags & update_hessians) != 0u)
+                  if (flags & update_hessians)
                     {
                       for (unsigned int j = 0; j < degree; ++j)
                         {
@@ -2638,7 +2636,7 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_values(
            fe_data.shape_values[0].size() == n_q_points,
          ExcDimensionMismatch(fe_data.shape_values[0].size(), n_q_points));
 
-  if ((flags & update_values) != 0u)
+  if (flags & update_values)
     {
       // Now have all shape_values stored on the reference cell.
       // Must now transform to the physical cell.
@@ -2665,7 +2663,7 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_values(
         }
     }
 
-  if ((flags & update_gradients) != 0u)
+  if (flags & update_gradients)
     {
       // Now have all shape_grads stored on the reference cell.
       // Must now transform to the physical cell.
@@ -2838,7 +2836,7 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_face_values(
                                              cell->face_rotation(face_no),
                                              n_q_points);
 
-  if ((flags & update_values) != 0u)
+  if (flags & update_values)
     {
       // Now have all shape_values stored on the reference cell.
       // Must now transform to the physical cell.
@@ -2867,7 +2865,7 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_face_values(
             }
         }
     }
-  if ((flags & update_gradients) != 0u)
+  if (flags & update_gradients)
     {
       // Now have all shape_grads stored on the reference cell.
       // Must now transform to the physical cell.
@@ -3007,15 +3005,15 @@ FE_NedelecSZ<dim, spacedim>::requires_update_flags(
 {
   UpdateFlags out = update_default;
 
-  if ((flags & update_values) != 0u)
+  if (flags & update_values)
     out |= update_values | update_covariant_transformation;
 
-  if ((flags & update_gradients) != 0u)
+  if (flags & update_gradients)
     out |= update_gradients | update_values |
            update_jacobian_pushed_forward_grads |
            update_covariant_transformation;
 
-  if ((flags & update_hessians) != 0u)
+  if (flags & update_hessians)
     //     Assert (false, ExcNotImplemented());
     out |= update_hessians | update_values | update_gradients |
            update_jacobian_pushed_forward_grads |

--- a/source/fe/fe_p1nc.cc
+++ b/source/fe/fe_p1nc.cc
@@ -51,13 +51,13 @@ FE_P1NC::requires_update_flags(const UpdateFlags flags) const
 {
   UpdateFlags out = update_default;
 
-  if ((flags & update_values) != 0u)
+  if (flags & update_values)
     out |= update_values | update_quadrature_points;
-  if ((flags & update_gradients) != 0u)
+  if (flags & update_gradients)
     out |= update_gradients;
-  if ((flags & update_normal_vectors) != 0u)
+  if (flags & update_normal_vectors)
     out |= update_normal_vectors | update_JxW_values;
-  if ((flags & update_hessians) != 0u)
+  if (flags & update_hessians)
     out |= update_hessians;
 
   return out;
@@ -148,7 +148,7 @@ FE_P1NC::get_data(
   output_data.initialize(n_q_points, FE_P1NC(), data_ptr->update_each);
 
   // this is a linear element, so its second derivatives are zero
-  if ((data_ptr->update_each & update_hessians) != 0u)
+  if (data_ptr->update_each & update_hessians)
     output_data.shape_hessians.fill(Tensor<2, 2>());
 
   return data_ptr;
@@ -174,7 +174,7 @@ FE_P1NC::get_face_data(
   output_data.initialize(n_q_points, FE_P1NC(), data_ptr->update_each);
 
   // this is a linear element, so its second derivatives are zero
-  if ((data_ptr->update_each & update_hessians) != 0u)
+  if (data_ptr->update_each & update_hessians)
     output_data.shape_hessians.fill(Tensor<2, 2>());
 
   return data_ptr;
@@ -198,7 +198,7 @@ FE_P1NC::get_subface_data(
   output_data.initialize(n_q_points, FE_P1NC(), data_ptr->update_each);
 
   // this is a linear element, so its second derivatives are zero
-  if ((data_ptr->update_each & update_hessians) != 0u)
+  if (data_ptr->update_each & update_hessians)
     output_data.shape_hessians.fill(Tensor<2, 2>());
 
   return data_ptr;
@@ -227,14 +227,14 @@ FE_P1NC::fill_fe_values(
   ndarray<double, 4, 3> coeffs = get_linear_shape_coefficients(cell);
 
   // compute on the cell
-  if ((flags & update_values) != 0u)
+  if (flags & update_values)
     for (unsigned int i = 0; i < n_q_points; ++i)
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_values[k][i] =
           (coeffs[k][0] * mapping_data.quadrature_points[i](0) +
            coeffs[k][1] * mapping_data.quadrature_points[i](1) + coeffs[k][2]);
 
-  if ((flags & update_gradients) != 0u)
+  if (flags & update_gradients)
     for (unsigned int i = 0; i < n_q_points; ++i)
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_gradients[k][i] =
@@ -268,7 +268,7 @@ FE_P1NC::fill_fe_face_values(
                                    quadrature[0],
                                    face_no);
 
-  if ((flags & update_values) != 0u)
+  if (flags & update_values)
     for (unsigned int i = 0; i < quadrature_on_face.size(); ++i)
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         {
@@ -281,7 +281,7 @@ FE_P1NC::fill_fe_face_values(
              coeffs[k][1] * quadrature_point(1) + coeffs[k][2]);
         }
 
-  if ((flags & update_gradients) != 0u)
+  if (flags & update_gradients)
     for (unsigned int i = 0; i < quadrature_on_face.size(); ++i)
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_gradients[k][i] =
@@ -312,7 +312,7 @@ FE_P1NC::fill_fe_subface_values(
   const Quadrature<2> quadrature_on_subface = QProjector<2>::project_to_subface(
     this->reference_cell(), quadrature, face_no, sub_no);
 
-  if ((flags & update_values) != 0u)
+  if (flags & update_values)
     for (unsigned int i = 0; i < quadrature_on_subface.size(); ++i)
       {
         for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
@@ -327,7 +327,7 @@ FE_P1NC::fill_fe_subface_values(
           }
       }
 
-  if ((flags & update_gradients) != 0u)
+  if (flags & update_gradients)
     for (unsigned int i = 0; i < quadrature_on_subface.size(); ++i)
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_gradients[k][i] =

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -2425,14 +2425,14 @@ FE_PolyTensor<dim, spacedim>::requires_update_flags(
         {
           case mapping_none:
             {
-              if ((flags & update_values) != 0u)
+              if (flags & update_values)
                 out |= update_values;
 
-              if ((flags & update_gradients) != 0u)
+              if (flags & update_gradients)
                 out |= update_gradients | update_values |
                        update_jacobian_pushed_forward_grads;
 
-              if ((flags & update_hessians) != 0u)
+              if (flags & update_hessians)
                 out |= update_hessians | update_values | update_gradients |
                        update_jacobian_pushed_forward_grads |
                        update_jacobian_pushed_forward_2nd_derivatives;
@@ -2441,16 +2441,16 @@ FE_PolyTensor<dim, spacedim>::requires_update_flags(
           case mapping_raviart_thomas:
           case mapping_piola:
             {
-              if ((flags & update_values) != 0u)
+              if (flags & update_values)
                 out |= update_values | update_piola;
 
-              if ((flags & update_gradients) != 0u)
+              if (flags & update_gradients)
                 out |= update_gradients | update_values | update_piola |
                        update_jacobian_pushed_forward_grads |
                        update_covariant_transformation |
                        update_contravariant_transformation;
 
-              if ((flags & update_hessians) != 0u)
+              if (flags & update_hessians)
                 out |= update_hessians | update_piola | update_values |
                        update_gradients | update_jacobian_pushed_forward_grads |
                        update_jacobian_pushed_forward_2nd_derivatives |
@@ -2462,16 +2462,16 @@ FE_PolyTensor<dim, spacedim>::requires_update_flags(
 
           case mapping_contravariant:
             {
-              if ((flags & update_values) != 0u)
+              if (flags & update_values)
                 out |= update_values | update_piola;
 
-              if ((flags & update_gradients) != 0u)
+              if (flags & update_gradients)
                 out |= update_gradients | update_values |
                        update_jacobian_pushed_forward_grads |
                        update_covariant_transformation |
                        update_contravariant_transformation;
 
-              if ((flags & update_hessians) != 0u)
+              if (flags & update_hessians)
                 out |= update_hessians | update_piola | update_values |
                        update_gradients | update_jacobian_pushed_forward_grads |
                        update_jacobian_pushed_forward_2nd_derivatives |
@@ -2483,15 +2483,15 @@ FE_PolyTensor<dim, spacedim>::requires_update_flags(
           case mapping_nedelec:
           case mapping_covariant:
             {
-              if ((flags & update_values) != 0u)
+              if (flags & update_values)
                 out |= update_values | update_covariant_transformation;
 
-              if ((flags & update_gradients) != 0u)
+              if (flags & update_gradients)
                 out |= update_gradients | update_values |
                        update_jacobian_pushed_forward_grads |
                        update_covariant_transformation;
 
-              if ((flags & update_hessians) != 0u)
+              if (flags & update_hessians)
                 out |= update_hessians | update_values | update_gradients |
                        update_jacobian_pushed_forward_grads |
                        update_jacobian_pushed_forward_2nd_derivatives |

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -2705,55 +2705,55 @@ namespace internal
       const unsigned int n_quadrature_points,
       const UpdateFlags  flags)
     {
-      if ((flags & update_quadrature_points) != 0u)
+      if (flags & update_quadrature_points)
         this->quadrature_points.resize(
           n_quadrature_points,
           Point<spacedim>(numbers::signaling_nan<Tensor<1, spacedim>>()));
 
-      if ((flags & update_JxW_values) != 0u)
+      if (flags & update_JxW_values)
         this->JxW_values.resize(n_quadrature_points,
                                 numbers::signaling_nan<double>());
 
-      if ((flags & update_jacobians) != 0u)
+      if (flags & update_jacobians)
         this->jacobians.resize(
           n_quadrature_points,
           numbers::signaling_nan<DerivativeForm<1, dim, spacedim>>());
 
-      if ((flags & update_jacobian_grads) != 0u)
+      if (flags & update_jacobian_grads)
         this->jacobian_grads.resize(
           n_quadrature_points,
           numbers::signaling_nan<DerivativeForm<2, dim, spacedim>>());
 
-      if ((flags & update_jacobian_pushed_forward_grads) != 0u)
+      if (flags & update_jacobian_pushed_forward_grads)
         this->jacobian_pushed_forward_grads.resize(
           n_quadrature_points, numbers::signaling_nan<Tensor<3, spacedim>>());
 
-      if ((flags & update_jacobian_2nd_derivatives) != 0u)
+      if (flags & update_jacobian_2nd_derivatives)
         this->jacobian_2nd_derivatives.resize(
           n_quadrature_points,
           numbers::signaling_nan<DerivativeForm<3, dim, spacedim>>());
 
-      if ((flags & update_jacobian_pushed_forward_2nd_derivatives) != 0u)
+      if (flags & update_jacobian_pushed_forward_2nd_derivatives)
         this->jacobian_pushed_forward_2nd_derivatives.resize(
           n_quadrature_points, numbers::signaling_nan<Tensor<4, spacedim>>());
 
-      if ((flags & update_jacobian_3rd_derivatives) != 0u)
+      if (flags & update_jacobian_3rd_derivatives)
         this->jacobian_3rd_derivatives.resize(n_quadrature_points);
 
-      if ((flags & update_jacobian_pushed_forward_3rd_derivatives) != 0u)
+      if (flags & update_jacobian_pushed_forward_3rd_derivatives)
         this->jacobian_pushed_forward_3rd_derivatives.resize(
           n_quadrature_points, numbers::signaling_nan<Tensor<5, spacedim>>());
 
-      if ((flags & update_inverse_jacobians) != 0u)
+      if (flags & update_inverse_jacobians)
         this->inverse_jacobians.resize(
           n_quadrature_points,
           numbers::signaling_nan<DerivativeForm<1, spacedim, dim>>());
 
-      if ((flags & update_boundary_forms) != 0u)
+      if (flags & update_boundary_forms)
         this->boundary_forms.resize(
           n_quadrature_points, numbers::signaling_nan<Tensor<1, spacedim>>());
 
-      if ((flags & update_normal_vectors) != 0u)
+      if (flags & update_normal_vectors)
         this->normal_vectors.resize(
           n_quadrature_points, numbers::signaling_nan<Tensor<1, spacedim>>());
     }
@@ -2806,14 +2806,14 @@ namespace internal
 
       // with the number of rows now known, initialize those fields
       // that we will need to their correct size
-      if ((flags & update_values) != 0u)
+      if (flags & update_values)
         {
           this->shape_values.reinit(n_nonzero_shape_components,
                                     n_quadrature_points);
           this->shape_values.fill(numbers::signaling_nan<double>());
         }
 
-      if ((flags & update_gradients) != 0u)
+      if (flags & update_gradients)
         {
           this->shape_gradients.reinit(n_nonzero_shape_components,
                                        n_quadrature_points);
@@ -2821,7 +2821,7 @@ namespace internal
             numbers::signaling_nan<Tensor<1, spacedim>>());
         }
 
-      if ((flags & update_hessians) != 0u)
+      if (flags & update_hessians)
         {
           this->shape_hessians.reinit(n_nonzero_shape_components,
                                       n_quadrature_points);
@@ -2829,7 +2829,7 @@ namespace internal
             numbers::signaling_nan<Tensor<2, spacedim>>());
         }
 
-      if ((flags & update_3rd_derivatives) != 0u)
+      if (flags & update_3rd_derivatives)
         {
           this->shape_3rd_derivatives.reinit(n_nonzero_shape_components,
                                              n_quadrature_points);
@@ -4235,7 +4235,7 @@ FEValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   const UpdateFlags flags = this->compute_update_flags(update_flags);
 
   // initialize the base classes
-  if ((flags & update_mapping) != 0u)
+  if (flags & update_mapping)
     this->mapping_output.initialize(this->max_n_quadrature_points, flags);
   this->finite_element_output.initialize(this->max_n_quadrature_points,
                                          *this->fe,
@@ -4255,7 +4255,7 @@ FEValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   Threads::Task<
     std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>>
     mapping_get_data;
-  if ((flags & update_mapping) != 0u)
+  if (flags & update_mapping)
     mapping_get_data = Threads::new_task(
       [&]() { return this->mapping->get_data(flags, quadrature); });
 
@@ -4263,7 +4263,7 @@ FEValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
 
   // then collect answers from the two task above
   this->fe_data = std::move(fe_get_data.return_value());
-  if ((flags & update_mapping) != 0u)
+  if (flags & update_mapping)
     this->mapping_data = std::move(mapping_get_data.return_value());
   else
     this->mapping_data =
@@ -4515,7 +4515,7 @@ FEFaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   const UpdateFlags flags = this->compute_update_flags(update_flags);
 
   // initialize the base classes
-  if ((flags & update_mapping) != 0u)
+  if (flags & update_mapping)
     this->mapping_output.initialize(this->max_n_quadrature_points, flags);
   this->finite_element_output.initialize(this->max_n_quadrature_points,
                                          *this->fe,
@@ -4550,7 +4550,7 @@ FEFaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   Threads::Task<
     std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>>
     mapping_get_data;
-  if ((flags & update_mapping) != 0u)
+  if (flags & update_mapping)
     mapping_get_data = Threads::new_task(mapping_get_face_data,
                                          *this->mapping,
                                          flags,
@@ -4560,7 +4560,7 @@ FEFaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
 
   // then collect answers from the two task above
   this->fe_data = std::move(fe_get_data.return_value());
-  if ((flags & update_mapping) != 0u)
+  if (flags & update_mapping)
     this->mapping_data = std::move(mapping_get_data.return_value());
   else
     this->mapping_data =
@@ -4753,7 +4753,7 @@ FESubfaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   const UpdateFlags flags = this->compute_update_flags(update_flags);
 
   // initialize the base classes
-  if ((flags & update_mapping) != 0u)
+  if (flags & update_mapping)
     this->mapping_output.initialize(this->max_n_quadrature_points, flags);
   this->finite_element_output.initialize(this->max_n_quadrature_points,
                                          *this->fe,
@@ -4774,7 +4774,7 @@ FESubfaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   Threads::Task<
     std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>>
     mapping_get_data;
-  if ((flags & update_mapping) != 0u)
+  if (flags & update_mapping)
     mapping_get_data =
       Threads::new_task(&Mapping<dim, spacedim>::get_subface_data,
                         *this->mapping,
@@ -4785,7 +4785,7 @@ FESubfaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
 
   // then collect answers from the two task above
   this->fe_data = std::move(fe_get_data.return_value());
-  if ((flags & update_mapping) != 0u)
+  if (flags & update_mapping)
     this->mapping_data = std::move(mapping_get_data.return_value());
   else
     this->mapping_data =

--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -98,7 +98,7 @@ MappingCartesian<dim, spacedim>::requires_update_flags(
   // since they can be computed from the normal vectors without much
   // further ado
   UpdateFlags out = in;
-  if ((out & update_boundary_forms) != 0u)
+  if (out & update_boundary_forms)
     out |= update_normal_vectors;
 
   return out;

--- a/source/fe/mapping_fe.cc
+++ b/source/fe/mapping_fe.cc
@@ -1022,18 +1022,18 @@ MappingFE<dim, spacedim>::requires_update_flags(const UpdateFlags in) const
       // update_boundary_forms is simply
       // ignored for the interior of a
       // cell.
-      if ((out & (update_JxW_values | update_normal_vectors)) != 0u)
+      if (out & (update_JxW_values | update_normal_vectors))
         out |= update_boundary_forms;
 
-      if ((out & (update_covariant_transformation | update_JxW_values |
-                  update_jacobians | update_jacobian_grads |
-                  update_boundary_forms | update_normal_vectors)) != 0u)
+      if (out & (update_covariant_transformation | update_JxW_values |
+                 update_jacobians | update_jacobian_grads |
+                 update_boundary_forms | update_normal_vectors))
         out |= update_contravariant_transformation;
 
-      if ((out &
-           (update_inverse_jacobians | update_jacobian_pushed_forward_grads |
-            update_jacobian_pushed_forward_2nd_derivatives |
-            update_jacobian_pushed_forward_3rd_derivatives)) != 0u)
+      if (out &
+          (update_inverse_jacobians | update_jacobian_pushed_forward_grads |
+           update_jacobian_pushed_forward_2nd_derivatives |
+           update_jacobian_pushed_forward_3rd_derivatives))
         out |= update_covariant_transformation;
 
       // The contravariant transformation is used in the Piola
@@ -1042,12 +1042,12 @@ MappingFE<dim, spacedim>::requires_update_flags(const UpdateFlags in) const
       // knowing here whether the finite element wants to use the
       // contravariant or the Piola transforms, we add the JxW values
       // to the list of flags to be updated for each cell.
-      if ((out & update_contravariant_transformation) != 0u)
+      if (out & update_contravariant_transformation)
         out |= update_volume_elements;
 
       // the same is true when computing normal vectors: they require
       // the determinant of the Jacobian
-      if ((out & update_normal_vectors) != 0u)
+      if (out & update_normal_vectors)
         out |= update_volume_elements;
     }
 
@@ -1211,7 +1211,7 @@ MappingFE<dim, spacedim>::fill_fe_values(
   // Multiply quadrature weights by absolute value of Jacobian determinants or
   // the area element g=sqrt(DX^t DX) in case of codim > 0
 
-  if ((update_flags & (update_normal_vectors | update_JxW_values)) != 0u)
+  if (update_flags & (update_normal_vectors | update_JxW_values))
     {
       AssertDimension(output_data.JxW_values.size(), n_q_points);
 
@@ -1263,12 +1263,12 @@ MappingFE<dim, spacedim>::fill_fe_values(
                     CellSimilarity::inverted_translation)
                   {
                     // we only need to flip the normal
-                    if ((update_flags & update_normal_vectors) != 0u)
+                    if (update_flags & update_normal_vectors)
                       output_data.normal_vectors[point] *= -1.;
                   }
                 else
                   {
-                    if ((update_flags & update_normal_vectors) != 0u)
+                    if (update_flags & update_normal_vectors)
                       {
                         Assert(spacedim == dim + 1,
                                ExcMessage(
@@ -1301,7 +1301,7 @@ MappingFE<dim, spacedim>::fill_fe_values(
 
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_jacobians) != 0u)
+  if (update_flags & update_jacobians)
     {
       AssertDimension(output_data.jacobians.size(), n_q_points);
       if (computed_cell_similarity != CellSimilarity::translation)
@@ -1310,7 +1310,7 @@ MappingFE<dim, spacedim>::fill_fe_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_inverse_jacobians) != 0u)
+  if (update_flags & update_inverse_jacobians)
     {
       AssertDimension(output_data.inverse_jacobians.size(), n_q_points);
       if (computed_cell_similarity != CellSimilarity::translation)

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -483,18 +483,18 @@ MappingFEField<dim, spacedim, VectorType, void>::requires_update_flags(
       // update_boundary_forms is simply
       // ignored for the interior of a
       // cell.
-      if ((out & (update_JxW_values | update_normal_vectors)) != 0u)
+      if (out & (update_JxW_values | update_normal_vectors))
         out |= update_boundary_forms;
 
-      if ((out & (update_covariant_transformation | update_JxW_values |
-                  update_jacobians | update_jacobian_grads |
-                  update_boundary_forms | update_normal_vectors)) != 0u)
+      if (out & (update_covariant_transformation | update_JxW_values |
+                 update_jacobians | update_jacobian_grads |
+                 update_boundary_forms | update_normal_vectors))
         out |= update_contravariant_transformation;
 
-      if ((out &
-           (update_inverse_jacobians | update_jacobian_pushed_forward_grads |
-            update_jacobian_pushed_forward_2nd_derivatives |
-            update_jacobian_pushed_forward_3rd_derivatives)) != 0u)
+      if (out &
+          (update_inverse_jacobians | update_jacobian_pushed_forward_grads |
+           update_jacobian_pushed_forward_2nd_derivatives |
+           update_jacobian_pushed_forward_3rd_derivatives))
         out |= update_covariant_transformation;
 
       // The contravariant transformation
@@ -503,10 +503,10 @@ MappingFEField<dim, spacedim, VectorType, void>::requires_update_flags(
       // Jacobi matrix of the transformation.
       // Therefore these values have to be
       // updated for each cell.
-      if ((out & update_contravariant_transformation) != 0u)
+      if (out & update_contravariant_transformation)
         out |= update_JxW_values;
 
-      if ((out & update_normal_vectors) != 0u)
+      if (out & update_normal_vectors)
         out |= update_JxW_values;
     }
 
@@ -1529,7 +1529,7 @@ MappingFEField<dim, spacedim, VectorType, void>::fill_fe_values(
   // Multiply quadrature weights by absolute value of Jacobian determinants or
   // the area element g=sqrt(DX^t DX) in case of codim > 0
 
-  if ((update_flags & (update_normal_vectors | update_JxW_values)) != 0u)
+  if (update_flags & (update_normal_vectors | update_JxW_values))
     {
       AssertDimension(output_data.JxW_values.size(), n_q_points);
 
@@ -1574,7 +1574,7 @@ MappingFEField<dim, spacedim, VectorType, void>::fill_fe_values(
               output_data.JxW_values[point] =
                 std::sqrt(determinant(G)) * weights[point];
 
-              if ((update_flags & update_normal_vectors) != 0u)
+              if (update_flags & update_normal_vectors)
                 {
                   Assert(spacedim - dim == 1,
                          ExcMessage("There is no cell normal in codim 2."));
@@ -1603,7 +1603,7 @@ MappingFEField<dim, spacedim, VectorType, void>::fill_fe_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_jacobians) != 0u)
+  if (update_flags & update_jacobians)
     {
       AssertDimension(output_data.jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)
@@ -1611,7 +1611,7 @@ MappingFEField<dim, spacedim, VectorType, void>::fill_fe_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_inverse_jacobians) != 0u)
+  if (update_flags & update_inverse_jacobians)
     {
       AssertDimension(output_data.inverse_jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)

--- a/source/fe/mapping_manifold.cc
+++ b/source/fe/mapping_manifold.cc
@@ -225,18 +225,18 @@ MappingManifold<dim, spacedim>::requires_update_flags(
       // update_boundary_forms is simply
       // ignored for the interior of a
       // cell.
-      if ((out & (update_JxW_values | update_normal_vectors)) != 0u)
+      if (out & (update_JxW_values | update_normal_vectors))
         out |= update_boundary_forms;
 
-      if ((out & (update_covariant_transformation | update_JxW_values |
-                  update_jacobians | update_jacobian_grads |
-                  update_boundary_forms | update_normal_vectors)) != 0u)
+      if (out & (update_covariant_transformation | update_JxW_values |
+                 update_jacobians | update_jacobian_grads |
+                 update_boundary_forms | update_normal_vectors))
         out |= update_contravariant_transformation;
 
-      if ((out &
-           (update_inverse_jacobians | update_jacobian_pushed_forward_grads |
-            update_jacobian_pushed_forward_2nd_derivatives |
-            update_jacobian_pushed_forward_3rd_derivatives)) != 0u)
+      if (out &
+          (update_inverse_jacobians | update_jacobian_pushed_forward_grads |
+           update_jacobian_pushed_forward_2nd_derivatives |
+           update_jacobian_pushed_forward_3rd_derivatives))
         out |= update_covariant_transformation;
 
       // The contravariant transformation used in the Piola
@@ -245,10 +245,10 @@ MappingManifold<dim, spacedim>::requires_update_flags(
       // knowing here whether the finite elements wants to use the
       // contravariant of the Piola transforms, we add the JxW values
       // to the list of flags to be updated for each cell.
-      if ((out & update_contravariant_transformation) != 0u)
+      if (out & update_contravariant_transformation)
         out |= update_JxW_values;
 
-      if ((out & update_normal_vectors) != 0u)
+      if (out & update_normal_vectors)
         out |= update_JxW_values;
     }
 
@@ -497,7 +497,7 @@ MappingManifold<dim, spacedim>::fill_fe_values(
   // Multiply quadrature weights by absolute value of Jacobian determinants or
   // the area element g=sqrt(DX^t DX) in case of codim > 0
 
-  if ((update_flags & (update_normal_vectors | update_JxW_values)) != 0u)
+  if (update_flags & (update_normal_vectors | update_JxW_values))
     {
       AssertDimension(output_data.JxW_values.size(), n_q_points);
 
@@ -543,7 +543,7 @@ MappingManifold<dim, spacedim>::fill_fe_values(
               output_data.JxW_values[point] =
                 std::sqrt(determinant(G)) * weights[point];
 
-              if ((update_flags & update_normal_vectors) != 0u)
+              if (update_flags & update_normal_vectors)
                 {
                   Assert(spacedim == dim + 1,
                          ExcMessage(
@@ -575,7 +575,7 @@ MappingManifold<dim, spacedim>::fill_fe_values(
 
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_jacobians) != 0u)
+  if (update_flags & update_jacobians)
     {
       AssertDimension(output_data.jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)
@@ -583,7 +583,7 @@ MappingManifold<dim, spacedim>::fill_fe_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_inverse_jacobians) != 0u)
+  if (update_flags & update_inverse_jacobians)
     {
       AssertDimension(output_data.inverse_jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -851,18 +851,18 @@ MappingQ<dim, spacedim>::requires_update_flags(const UpdateFlags in) const
       // update_boundary_forms is simply
       // ignored for the interior of a
       // cell.
-      if ((out & (update_JxW_values | update_normal_vectors)) != 0u)
+      if (out & (update_JxW_values | update_normal_vectors))
         out |= update_boundary_forms;
 
-      if ((out & (update_covariant_transformation | update_JxW_values |
-                  update_jacobians | update_jacobian_grads |
-                  update_boundary_forms | update_normal_vectors)) != 0u)
+      if (out & (update_covariant_transformation | update_JxW_values |
+                 update_jacobians | update_jacobian_grads |
+                 update_boundary_forms | update_normal_vectors))
         out |= update_contravariant_transformation;
 
-      if ((out &
-           (update_inverse_jacobians | update_jacobian_pushed_forward_grads |
-            update_jacobian_pushed_forward_2nd_derivatives |
-            update_jacobian_pushed_forward_3rd_derivatives)) != 0u)
+      if (out &
+          (update_inverse_jacobians | update_jacobian_pushed_forward_grads |
+           update_jacobian_pushed_forward_2nd_derivatives |
+           update_jacobian_pushed_forward_3rd_derivatives))
         out |= update_covariant_transformation;
 
       // The contravariant transformation is used in the Piola
@@ -871,12 +871,12 @@ MappingQ<dim, spacedim>::requires_update_flags(const UpdateFlags in) const
       // knowing here whether the finite element wants to use the
       // contravariant or the Piola transforms, we add the JxW values
       // to the list of flags to be updated for each cell.
-      if ((out & update_contravariant_transformation) != 0u)
+      if (out & update_contravariant_transformation)
         out |= update_volume_elements;
 
       // the same is true when computing normal vectors: they require
       // the determinant of the Jacobian
-      if ((out & update_normal_vectors) != 0u)
+      if (out & update_normal_vectors)
         out |= update_volume_elements;
     }
 
@@ -1047,7 +1047,7 @@ MappingQ<dim, spacedim>::fill_fe_values(
   // Multiply quadrature weights by absolute value of Jacobian determinants or
   // the area element g=sqrt(DX^t DX) in case of codim > 0
 
-  if ((update_flags & (update_normal_vectors | update_JxW_values)) != 0u)
+  if (update_flags & (update_normal_vectors | update_JxW_values))
     {
       AssertDimension(output_data.JxW_values.size(), n_q_points);
 
@@ -1099,12 +1099,12 @@ MappingQ<dim, spacedim>::fill_fe_values(
                     CellSimilarity::inverted_translation)
                   {
                     // we only need to flip the normal
-                    if ((update_flags & update_normal_vectors) != 0u)
+                    if (update_flags & update_normal_vectors)
                       output_data.normal_vectors[point] *= -1.;
                   }
                 else
                   {
-                    if ((update_flags & update_normal_vectors) != 0u)
+                    if (update_flags & update_normal_vectors)
                       {
                         Assert(spacedim == dim + 1,
                                ExcMessage(
@@ -1137,7 +1137,7 @@ MappingQ<dim, spacedim>::fill_fe_values(
 
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_jacobians) != 0u)
+  if (update_flags & update_jacobians)
     {
       AssertDimension(output_data.jacobians.size(), n_q_points);
       if (computed_cell_similarity != CellSimilarity::translation)
@@ -1146,7 +1146,7 @@ MappingQ<dim, spacedim>::fill_fe_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_inverse_jacobians) != 0u)
+  if (update_flags & update_inverse_jacobians)
     {
       AssertDimension(output_data.inverse_jacobians.size(), n_q_points);
       if (computed_cell_similarity != CellSimilarity::translation)
@@ -1438,18 +1438,18 @@ MappingQ<dim, spacedim>::fill_mapping_data_for_generic_points(
             polynomial_degree == 1,
             renumber_lexicographic_to_hierarchic);
 
-        if ((update_flags & update_quadrature_points) != 0u)
+        if (update_flags & update_quadrature_points)
           for (unsigned int j = 0; j < n_lanes && i + j < n_points; ++j)
             for (unsigned int d = 0; d < spacedim; ++d)
               output_data.quadrature_points[i + j][d] = result.first[d][j];
 
-        if ((update_flags & update_jacobians) != 0u)
+        if (update_flags & update_jacobians)
           for (unsigned int j = 0; j < n_lanes && i + j < n_points; ++j)
             for (unsigned int d = 0; d < spacedim; ++d)
               for (unsigned int e = 0; e < dim; ++e)
                 output_data.jacobians[i + j][d][e] = result.second[e][d][j];
 
-        if ((update_flags & update_inverse_jacobians) != 0u)
+        if (update_flags & update_inverse_jacobians)
           {
             DerivativeForm<1, spacedim, dim, VectorizedArray<double>> jac(
               result.second);
@@ -1471,16 +1471,16 @@ MappingQ<dim, spacedim>::fill_mapping_data_for_generic_points(
             polynomial_degree == 1,
             renumber_lexicographic_to_hierarchic);
 
-        if ((update_flags & update_quadrature_points) != 0u)
+        if (update_flags & update_quadrature_points)
           output_data.quadrature_points[i] = result.first;
 
-        if ((update_flags & update_jacobians) != 0u)
+        if (update_flags & update_jacobians)
           {
             DerivativeForm<1, spacedim, dim> jac = result.second;
             output_data.jacobians[i]             = jac.transpose();
           }
 
-        if ((update_flags & update_inverse_jacobians) != 0u)
+        if (update_flags & update_inverse_jacobians)
           {
             DerivativeForm<1, spacedim, dim> jac(result.second);
             DerivativeForm<1, spacedim, dim> inv_jac = jac.covariant_form();

--- a/source/grid/grid_tools_cache.cc
+++ b/source/grid/grid_tools_cache.cc
@@ -60,7 +60,7 @@ namespace GridTools
     std::set<typename Triangulation<dim, spacedim>::active_cell_iterator>> &
   Cache<dim, spacedim>::get_vertex_to_cell_map() const
   {
-    if ((update_flags & update_vertex_to_cell_map) != 0)
+    if (update_flags & update_vertex_to_cell_map)
       {
         vertex_to_cells = GridTools::vertex_to_cell_map(*tria);
         update_flags    = update_flags & ~update_vertex_to_cell_map;
@@ -74,7 +74,7 @@ namespace GridTools
   const std::vector<std::vector<Tensor<1, spacedim>>> &
   Cache<dim, spacedim>::get_vertex_to_cell_centers_directions() const
   {
-    if ((update_flags & update_vertex_to_cell_centers_directions) != 0)
+    if (update_flags & update_vertex_to_cell_centers_directions)
       {
         vertex_to_cell_centers = GridTools::vertex_to_cell_centers_directions(
           *tria, get_vertex_to_cell_map());
@@ -89,7 +89,7 @@ namespace GridTools
   const std::map<unsigned int, Point<spacedim>> &
   Cache<dim, spacedim>::get_used_vertices() const
   {
-    if ((update_flags & update_used_vertices) != 0)
+    if (update_flags & update_used_vertices)
       {
         used_vertices = GridTools::extract_used_vertices(*tria, *mapping);
         update_flags  = update_flags & ~update_used_vertices;
@@ -103,7 +103,7 @@ namespace GridTools
   const RTree<std::pair<Point<spacedim>, unsigned int>> &
   Cache<dim, spacedim>::get_used_vertices_rtree() const
   {
-    if ((update_flags & update_used_vertices_rtree) != 0)
+    if (update_flags & update_used_vertices_rtree)
       {
         const auto &used_vertices = get_used_vertices();
         std::vector<std::pair<Point<spacedim>, unsigned int>> vertices(
@@ -125,7 +125,7 @@ namespace GridTools
               typename Triangulation<dim, spacedim>::active_cell_iterator>> &
   Cache<dim, spacedim>::get_cell_bounding_boxes_rtree() const
   {
-    if ((update_flags & update_cell_bounding_boxes_rtree) != 0)
+    if (update_flags & update_cell_bounding_boxes_rtree)
       {
         std::vector<std::pair<
           BoundingBox<spacedim>,
@@ -149,7 +149,7 @@ namespace GridTools
               typename Triangulation<dim, spacedim>::active_cell_iterator>> &
   Cache<dim, spacedim>::get_locally_owned_cell_bounding_boxes_rtree() const
   {
-    if ((update_flags & update_locally_owned_cell_bounding_boxes_rtree) != 0)
+    if (update_flags & update_locally_owned_cell_bounding_boxes_rtree)
       {
         std::vector<std::pair<
           BoundingBox<spacedim>,
@@ -202,7 +202,7 @@ namespace GridTools
   const std::vector<std::set<unsigned int>> &
   Cache<dim, spacedim>::get_vertex_to_neighbor_subdomain() const
   {
-    if ((update_flags & update_vertex_to_neighbor_subdomain) != 0)
+    if (update_flags & update_vertex_to_neighbor_subdomain)
       {
         vertex_to_neighbor_subdomain.clear();
         vertex_to_neighbor_subdomain.resize(tria->n_vertices());

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -204,21 +204,21 @@ DataOut<dim, spacedim>::build_one_patch(
                   // we do not need to worry about getting any imaginary
                   // components to the postprocessor, and we can safely
                   // call the function that evaluates a scalar field
-                  if ((update_flags & update_values) != 0u)
+                  if (update_flags & update_values)
                     dataset->get_function_values(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       scratch_data.patch_values_scalar.solution_values);
 
-                  if ((update_flags & update_gradients) != 0u)
+                  if (update_flags & update_gradients)
                     dataset->get_function_gradients(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       scratch_data.patch_values_scalar.solution_gradients);
 
-                  if ((update_flags & update_hessians) != 0u)
+                  if (update_flags & update_hessians)
                     dataset->get_function_hessians(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
@@ -227,7 +227,7 @@ DataOut<dim, spacedim>::build_one_patch(
 
                   // Also fill some of the other fields postprocessors may
                   // want to access.
-                  if ((update_flags & update_quadrature_points) != 0u)
+                  if (update_flags & update_quadrature_points)
                     scratch_data.patch_values_scalar.evaluation_points =
                       this_fe_patch_values.get_quadrature_points();
 
@@ -260,21 +260,21 @@ DataOut<dim, spacedim>::build_one_patch(
                     {
                       scratch_data.resize_system_vectors(n_components);
 
-                      if ((update_flags & update_values) != 0u)
+                      if (update_flags & update_values)
                         dataset->get_function_values(
                           this_fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           scratch_data.patch_values_system.solution_values);
 
-                      if ((update_flags & update_gradients) != 0u)
+                      if (update_flags & update_gradients)
                         dataset->get_function_gradients(
                           this_fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           scratch_data.patch_values_system.solution_gradients);
 
-                      if ((update_flags & update_hessians) != 0u)
+                      if (update_flags & update_hessians)
                         dataset->get_function_hessians(
                           this_fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
@@ -294,7 +294,7 @@ DataOut<dim, spacedim>::build_one_patch(
                           // First get the real component of the scalar solution
                           // and copy the data into the
                           // scratch_data.patch_values_system output fields
-                          if ((update_flags & update_values) != 0u)
+                          if (update_flags & update_values)
                             {
                               dataset->get_function_values(
                                 this_fe_patch_values,
@@ -320,7 +320,7 @@ DataOut<dim, spacedim>::build_one_patch(
                                 }
                             }
 
-                          if ((update_flags & update_gradients) != 0u)
+                          if (update_flags & update_gradients)
                             {
                               dataset->get_function_gradients(
                                 this_fe_patch_values,
@@ -346,7 +346,7 @@ DataOut<dim, spacedim>::build_one_patch(
                                 }
                             }
 
-                          if ((update_flags & update_hessians) != 0u)
+                          if (update_flags & update_hessians)
                             {
                               dataset->get_function_hessians(
                                 this_fe_patch_values,
@@ -377,7 +377,7 @@ DataOut<dim, spacedim>::build_one_patch(
                           // and copy the data into the
                           // scratch_data.patch_values_system output fields
                           // that follow the real one
-                          if ((update_flags & update_values) != 0u)
+                          if (update_flags & update_values)
                             {
                               dataset->get_function_values(
                                 this_fe_patch_values,
@@ -403,7 +403,7 @@ DataOut<dim, spacedim>::build_one_patch(
                                 }
                             }
 
-                          if ((update_flags & update_gradients) != 0u)
+                          if (update_flags & update_gradients)
                             {
                               dataset->get_function_gradients(
                                 this_fe_patch_values,
@@ -429,7 +429,7 @@ DataOut<dim, spacedim>::build_one_patch(
                                 }
                             }
 
-                          if ((update_flags & update_hessians) != 0u)
+                          if (update_flags & update_hessians)
                             {
                               dataset->get_function_hessians(
                                 this_fe_patch_values,
@@ -484,7 +484,7 @@ DataOut<dim, spacedim>::build_one_patch(
                           // values, then the real and imaginary parts of the
                           // gradients, etc. This allows us to scope the
                           // temporary objects better
-                          if ((update_flags & update_values) != 0u)
+                          if (update_flags & update_values)
                             {
                               std::vector<Vector<double>> tmp(
                                 scratch_data.patch_values_system.solution_values
@@ -539,7 +539,7 @@ DataOut<dim, spacedim>::build_one_patch(
                             }
 
                           // Now do the exact same thing for the gradients
-                          if ((update_flags & update_gradients) != 0u)
+                          if (update_flags & update_gradients)
                             {
                               std::vector<std::vector<Tensor<1, spacedim>>> tmp(
                                 scratch_data.patch_values_system
@@ -590,7 +590,7 @@ DataOut<dim, spacedim>::build_one_patch(
                             }
 
                           // And finally the Hessians. Same scheme as above.
-                          if ((update_flags & update_hessians) != 0u)
+                          if (update_flags & update_hessians)
                             {
                               std::vector<std::vector<Tensor<2, spacedim>>> tmp(
                                 scratch_data.patch_values_system
@@ -643,7 +643,7 @@ DataOut<dim, spacedim>::build_one_patch(
                     }
 
                   // Now set other fields we may need
-                  if ((update_flags & update_quadrature_points) != 0u)
+                  if (update_flags & update_quadrature_points)
                     scratch_data.patch_values_system.evaluation_points =
                       this_fe_patch_values.get_quadrature_points();
 

--- a/source/numerics/data_out_faces.cc
+++ b/source/numerics/data_out_faces.cc
@@ -172,30 +172,30 @@ DataOutFaces<dim, spacedim>::build_one_patch(
                 {
                   // at each point there is only one component of value,
                   // gradient etc.
-                  if ((update_flags & update_values) != 0u)
+                  if (update_flags & update_values)
                     this->dof_data[dataset]->get_function_values(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_scalar.solution_values);
-                  if ((update_flags & update_gradients) != 0u)
+                  if (update_flags & update_gradients)
                     this->dof_data[dataset]->get_function_gradients(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_scalar.solution_gradients);
-                  if ((update_flags & update_hessians) != 0u)
+                  if (update_flags & update_hessians)
                     this->dof_data[dataset]->get_function_hessians(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_scalar.solution_hessians);
 
-                  if ((update_flags & update_quadrature_points) != 0u)
+                  if (update_flags & update_quadrature_points)
                     data.patch_values_scalar.evaluation_points =
                       this_fe_patch_values.get_quadrature_points();
 
-                  if ((update_flags & update_normal_vectors) != 0u)
+                  if (update_flags & update_normal_vectors)
                     data.patch_values_scalar.normals =
                       this_fe_patch_values.get_normal_vectors();
 
@@ -216,30 +216,30 @@ DataOutFaces<dim, spacedim>::build_one_patch(
                   // at each point there is a vector valued function and its
                   // derivative...
                   data.resize_system_vectors(n_components);
-                  if ((update_flags & update_values) != 0u)
+                  if (update_flags & update_values)
                     this->dof_data[dataset]->get_function_values(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_system.solution_values);
-                  if ((update_flags & update_gradients) != 0u)
+                  if (update_flags & update_gradients)
                     this->dof_data[dataset]->get_function_gradients(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_system.solution_gradients);
-                  if ((update_flags & update_hessians) != 0u)
+                  if (update_flags & update_hessians)
                     this->dof_data[dataset]->get_function_hessians(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_system.solution_hessians);
 
-                  if ((update_flags & update_quadrature_points) != 0u)
+                  if (update_flags & update_quadrature_points)
                     data.patch_values_system.evaluation_points =
                       this_fe_patch_values.get_quadrature_points();
 
-                  if ((update_flags & update_normal_vectors) != 0u)
+                  if (update_flags & update_normal_vectors)
                     data.patch_values_system.normals =
                       this_fe_patch_values.get_normal_vectors();
 

--- a/source/numerics/data_out_rotation.cc
+++ b/source/numerics/data_out_rotation.cc
@@ -220,26 +220,26 @@ DataOutRotation<dim, spacedim>::build_one_patch(
                       // at each point there is
                       // only one component of
                       // value, gradient etc.
-                      if ((update_flags & update_values) != 0u)
+                      if (update_flags & update_values)
                         this->dof_data[dataset]->get_function_values(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_scalar.solution_values);
-                      if ((update_flags & update_gradients) != 0u)
+                      if (update_flags & update_gradients)
                         this->dof_data[dataset]->get_function_gradients(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_scalar.solution_gradients);
-                      if ((update_flags & update_hessians) != 0u)
+                      if (update_flags & update_hessians)
                         this->dof_data[dataset]->get_function_hessians(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_scalar.solution_hessians);
 
-                      if ((update_flags & update_quadrature_points) != 0u)
+                      if (update_flags & update_quadrature_points)
                         data.patch_values_scalar.evaluation_points =
                           fe_patch_values.get_quadrature_points();
 
@@ -261,26 +261,26 @@ DataOutRotation<dim, spacedim>::build_one_patch(
 
                       // at each point there is a vector valued function and
                       // its derivative...
-                      if ((update_flags & update_values) != 0u)
+                      if (update_flags & update_values)
                         this->dof_data[dataset]->get_function_values(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_system.solution_values);
-                      if ((update_flags & update_gradients) != 0u)
+                      if (update_flags & update_gradients)
                         this->dof_data[dataset]->get_function_gradients(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_system.solution_gradients);
-                      if ((update_flags & update_hessians) != 0u)
+                      if (update_flags & update_hessians)
                         this->dof_data[dataset]->get_function_hessians(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_system.solution_hessians);
 
-                      if ((update_flags & update_quadrature_points) != 0u)
+                      if (update_flags & update_quadrature_points)
                         data.patch_values_system.evaluation_points =
                           fe_patch_values.get_quadrature_points();
 


### PR DESCRIPTION
This reverts most of commit bb84662fbdd967da82c140e8d13fddf229dd371d. I kept the bug fix with `numbers::invalid_unsigned_int` and a few other things that improved code clarity. I would prefer if we wrote `v.size() == 0` instead of `!v.size()`, etc.: I think those changes improve readability. All changes to enums were reverted.

The clear winner in the poll from

https://github.com/dealii/dealii/pull/13229#issuecomment-1014767396

is 'return to the previous status quo' so this patch is the agreed upon solution.