### PR TITLE
MatrixFree: fix typo assert message

### DIFF
--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -444,7 +444,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::internal_reinit(
         Assert(
           constraint->is_closed(task_info.communicator),
           ExcMessage(
-            "You have proveded a non-empty AffineConstraint object that has not "
+            "You have provided a non-empty AffineConstraints object that has not "
             "been closed. Please call AffineConstraints::close() before "
             "calling MatrixFree::reinit()!"));
 #endif


### PR DESCRIPTION
This PR fixes a typo in the assert message introduced in https://github.com/dealii/dealii/pull/13506.

FYI @peterrum 