### PR TITLE
Enable `sc_init` again.

### DIFF
--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -970,8 +970,7 @@ namespace Utilities
 
 #ifdef DEAL_II_WITH_P4EST
       // Initialize p4est and libsc components
-#  if DEAL_II_P4EST_VERSION_GTE(2, 0, 0, 0)
-#  else
+#  if DEAL_II_P4EST_VERSION_GTE(2, 5, 0, 0)
       // This feature is broken in version 2.0.0 for calls to
       // MPI_Comm_create_group (see cburstedde/p4est#30).
       // Disabling it leads to more verbose p4est error messages


### PR DESCRIPTION
We require p4est 2.0 since #6879.