### PR TITLE
Compute DoFInfo::hanging_node_constraint_masks_comp once

### DIFF
--- a/include/deal.II/matrix_free/dof_info.templates.h
+++ b/include/deal.II/matrix_free/dof_info.templates.h
@@ -283,18 +283,7 @@ namespace internal
       const TriaIterator<DoFCellAccessor<dim, dim, false>> &cell,
       std::vector<types::global_dof_index> &                dof_indices)
     {
-      // 1) check if finite elements support fast hanging-node algorithm
-      this->hanging_node_constraint_masks_comp =
-        hanging_nodes.compute_supported_components(
-          cell->get_dof_handler().get_fe_collection());
-
-      if ([](const auto &supported_components) {
-            return std::none_of(supported_components.begin(),
-                                supported_components.end(),
-                                [](const auto &a) {
-                                  return *std::max_element(a.begin(), a.end());
-                                });
-          }(hanging_node_constraint_masks_comp))
+      if (this->hanging_node_constraint_masks_comp.size() == 0)
         return false;
 
       // 2) determine the refinement configuration of the cell

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -3325,6 +3325,7 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
       for (unsigned int v = 0; v < n_lanes; ++v)
         if (cells[v] != numbers::invalid_unsigned_int &&
             this->dof_info->hanging_node_constraint_masks.size() > 0 &&
+            this->dof_info->hanging_node_constraint_masks_comp.size() > 0 &&
             this->dof_info->hanging_node_constraint_masks[cells[v]] !=
               internal::MatrixFreeFunctions::ConstraintKinds::unconstrained &&
             this->dof_info->hanging_node_constraint_masks_comp
@@ -3427,6 +3428,7 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
             has_constraints = true;
 
           if (this->dof_info->hanging_node_constraint_masks.size() > 0 &&
+              this->dof_info->hanging_node_constraint_masks_comp.size() > 0 &&
               this->dof_info->hanging_node_constraint_masks[cells[v]] !=
                 internal::MatrixFreeFunctions::ConstraintKinds::unconstrained &&
               this->dof_info->hanging_node_constraint_masks_comp
@@ -3515,6 +3517,7 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
              this->dof_info->row_starts[cell_dof_index + n_components_read]
                .second ||
            ((this->dof_info->hanging_node_constraint_masks.size() > 0 &&
+             this->dof_info->hanging_node_constraint_masks_comp.size() > 0 &&
              this->dof_info->hanging_node_constraint_masks[cell_index] !=
                internal::MatrixFreeFunctions::ConstraintKinds::unconstrained) &&
             this->dof_info->hanging_node_constraint_masks_comp
@@ -4155,6 +4158,7 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
 {
   if (this->dof_info == nullptr ||
       this->dof_info->hanging_node_constraint_masks.size() == 0 ||
+      this->dof_info->hanging_node_constraint_masks_comp.size() == 0 ||
       this->dof_info->hanging_node_constraint_masks_comp
           [this->active_fe_index][this->first_selected_component] == false)
     return; // nothing to do with faces

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -1241,7 +1241,23 @@ namespace internal
         hanging_nodes = std::make_unique<
           dealii::internal::MatrixFreeFunctions::HangingNodes<dim>>(tria);
         for (unsigned int no = 0; no < n_dof_handlers; ++no)
-          dof_info[no].hanging_node_constraint_masks.resize(n_active_cells);
+          {
+            dof_info[no].hanging_node_constraint_masks.resize(n_active_cells);
+
+            dof_info[no].hanging_node_constraint_masks_comp =
+              hanging_nodes->compute_supported_components(
+                dof_handler[no]->get_fe_collection());
+
+            if ([](const auto &supported_components) {
+                  return std::none_of(supported_components.begin(),
+                                      supported_components.end(),
+                                      [](const auto &a) {
+                                        return *std::max_element(a.begin(),
+                                                                 a.end());
+                                      });
+                }(dof_info[no].hanging_node_constraint_masks_comp))
+              dof_info[no].hanging_node_constraint_masks_comp = {};
+          }
       }
 
     for (unsigned int counter = 0; counter < n_active_cells; ++counter)

--- a/include/deal.II/matrix_free/tools.h
+++ b/include/deal.II/matrix_free/tools.h
@@ -448,6 +448,7 @@ namespace MatrixFreeTools
 
             // STEP 2c: apply hanging-node constraints
             if (dof_info.hanging_node_constraint_masks.size() > 0 &&
+                dof_info.hanging_node_constraint_masks_comp.size() > 0 &&
                 dof_info
                   .hanging_node_constraint_masks_comp[phi.get_active_fe_index()]
                                                      [first_selected_component])

--- a/source/matrix_free/dof_info.cc
+++ b/source/matrix_free/dof_info.cc
@@ -104,6 +104,7 @@ namespace internal
           // one
           const bool has_constraints =
             (hanging_node_constraint_masks.size() != 0 &&
+             hanging_node_constraint_masks_comp.size() != 0 &&
              hanging_node_constraint_masks[cell * n_vectorization + v] !=
                ConstraintKinds::unconstrained &&
              hanging_node_constraint_masks_comp[fe_index][0 /*TODO*/]) ||
@@ -235,6 +236,7 @@ namespace internal
                   AssertIndexRange(fe_index, dofs_per_cell.size());
 
                   if (hanging_node_constraint_masks.size() > 0 &&
+                      hanging_node_constraint_masks_comp.size() > 0 &&
                       hanging_node_constraint_masks[boundary_cells[i]] !=
                         ConstraintKinds::unconstrained)
                     for (unsigned int comp = 0; comp < n_components; ++comp)
@@ -374,7 +376,8 @@ namespace internal
 
               bool has_hanging_nodes = false;
 
-              if (hanging_node_constraint_masks.size() > 0)
+              if (hanging_node_constraint_masks.size() > 0 &&
+                  hanging_node_constraint_masks_comp.size() > 0)
                 {
                   const auto mask =
                     hanging_node_constraint_masks[renumbering[position_cell +


### PR DESCRIPTION
references #13411

`DoFInfo::hanging_node_constraint_masks` still needs to be moved to `MatrixFree`, but that is more involved, since it is used at two places in `DoFInfo`, e.g.: 

https://github.com/dealii/dealii/blob/a1e0f76d2082c3a06723cac0eebd83bff6771a59/source/matrix_free/dof_info.cc#L105-L110