### PR TITLE
Make doxygen show correct header file for GridTools::Cache

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -88,6 +88,12 @@ namespace hp
 }
 
 class SparsityPattern;
+
+namespace GridTools
+{
+  template <int dim, int spacedim>
+  class Cache;
+}
 #endif
 
 namespace internal
@@ -124,9 +130,6 @@ namespace internal
  */
 namespace GridTools
 {
-  template <int dim, int spacedim>
-  class Cache;
-
   /**
    * @name Information about meshes and cells
    */


### PR DESCRIPTION
Fixes #13544.