### PR TITLE
GC::create_geometric_coarsening_sequence() add assert

### DIFF
--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -2320,6 +2320,8 @@ namespace MGTransferGlobalCoarseningTools
         coarse_grid_triangulations[l - 1] = new_tria;
       }
 
+    AssertDimension(coarse_grid_triangulations[0]->n_global_levels(), 1);
+
     return coarse_grid_triangulations;
   }
 
@@ -2429,6 +2431,8 @@ namespace MGTransferGlobalCoarseningTools
         coarse_grid_triangulations[l - 1] = level_triangulation;
       }
 #endif
+
+    AssertDimension(coarse_grid_triangulations[0]->n_global_levels(), 1);
 
     return coarse_grid_triangulations;
   }


### PR DESCRIPTION
@tjhei In ASPECT, the settings/smoothing of `p:d:T` prevents that the mesh can be coarsened to a single level. I don't know if that is intended. In GC, we strictly do not need coarsen to the coarsest level, i.e, the functions `GC::create_geometric_coarsening_sequence()` could handle that by some additional checks (size of the returned vector would not equal the number of global levels of the input triangulation). For the time being, let's add simple asserts here.