### PR TITLE
Add an assertion.

### DIFF
--- a/source/particles/generators.cc
+++ b/source/particles/generators.cc
@@ -121,6 +121,9 @@ namespace Particles
         const Mapping<dim, spacedim> &mapping,
         std::mt19937 &                random_number_generator)
       {
+        Assert(cell->reference_cell().is_hyper_cube() == true,
+               ExcNotImplemented());
+
         // Uniform distribution on the interval [0,1]. This
         // will be used to generate random particle locations.
         std::uniform_real_distribution<double> uniform_distribution_01(0, 1);


### PR DESCRIPTION
While looking at #12931, I realized that the function will only work if one works on hypercube cells. More work is necessary to make this work for non-hypercube cells.

/rebuild