### PR TITLE
Make DoFRenumbering work when some processors have 0 DoFs.

### DIFF
--- a/doc/news/changes/minor/20220323DavidWells
+++ b/doc/news/changes/minor/20220323DavidWells
@@ -1,0 +1,4 @@
+Fixed: The functions in DoFRenumbering now work correctly (they do not deadlock)
+when a processor has zero locally owned degrees of freedom.
+<br>
+(David Wells, 2022/03/23)

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -689,7 +689,12 @@ namespace DoFRenumbering
                                             dof_handler.end(),
                                             component_order_arg,
                                             false);
-    if (result == 0)
+    (void)result;
+
+    // If we don't have a renumbering (i.e., when there is 1 component) then
+    // return
+    if (Utilities::MPI::max(renumbering.size(),
+                            dof_handler.get_communicator()) == 0)
       return;
 
     // verify that the last numbered
@@ -730,13 +735,13 @@ namespace DoFRenumbering
     const types::global_dof_index result =
       compute_component_wise<dim, spacedim>(
         renumbering, start, end, component_order_arg, true);
+    (void)result;
 
-    if (result == 0)
-      return;
+    Assert(result == 0 || result == dof_handler.n_dofs(level),
+           ExcInternalError());
 
-    Assert(result == dof_handler.n_dofs(level), ExcInternalError());
-
-    if (renumbering.size() != 0)
+    if (Utilities::MPI::max(renumbering.size(),
+                            dof_handler.get_communicator()) > 0)
       dof_handler.renumber_dofs(level, renumbering);
   }
 
@@ -1048,13 +1053,13 @@ namespace DoFRenumbering
                                                                start,
                                                                end,
                                                                true);
+    (void)result;
 
-    if (result == 0)
-      return;
+    Assert(result == 0 || result == dof_handler.n_dofs(level),
+           ExcInternalError());
 
-    Assert(result == dof_handler.n_dofs(level), ExcInternalError());
-
-    if (renumbering.size() != 0)
+    if (Utilities::MPI::max(renumbering.size(),
+                            dof_handler.get_communicator()) > 0)
       dof_handler.renumber_dofs(level, renumbering);
   }
 


### PR DESCRIPTION
First commit off of #13536.