### PR TITLE
Simplify code using BOOST::variant.

### DIFF
--- a/source/base/table_handler.cc
+++ b/source/base/table_handler.cc
@@ -109,29 +109,15 @@ namespace internal
   }
 
 
-#ifndef DEAL_II_HAVE_CXX17
-  namespace Local
-  {
-    // see which type we can cast to, then use this type to create
-    // a default constructed object
-    struct SetValueToDefault : public boost::static_visitor<>
-    {
-      template <typename T>
-      void
-      operator()(T &operand) const
-      {
-        operand = T();
-      }
-    };
-  } // namespace Local
-#endif
 
   TableEntry
   TableEntry::get_default_constructed_copy() const
   {
     TableEntry new_entry = *this;
 #ifndef DEAL_II_HAVE_CXX17
-    boost::apply_visitor(Local::SetValueToDefault(), new_entry.value);
+    boost::apply_visitor(
+      [](auto &arg) { arg = std::remove_reference_t<decltype(arg)>(); },
+      new_entry.value);
 #else
     // Let std::visit figure out which data type is actually stored,
     // and then set the object so stored to a default-constructed


### PR DESCRIPTION
Following #13556, I looked up the Boost documentation at https://www.boost.org/doc/libs/1_78_0/doc/html/variant/reference.html#variant.concepts.static-visitor and realized that starting with C++14, one can omit writing a class on our own as a visitor, but that a generic lambda works as well. This patch does that, getting rid of a dozen lines or so.

/rebuild