### PR TITLE
cell_weight: add changelog for bugfix.

### DIFF
--- a/doc/news/changes/incompatibilities/20220225Fehling2
+++ b/doc/news/changes/incompatibilities/20220225Fehling2
@@ -1,0 +1,8 @@
+Fixed: Callback functions attached to any weighted load balancing signal
+of parallel::distributed::Triangulation objects now need to handle cells
+with CELL_INVALID status explicitely.
+<br>
+If a cell gets refined, only the first child has the CELL_REFINE status,
+while all other children are CELL_INVALID.
+<br>
+(Marc Fehling, 2022/02/25)


### PR DESCRIPTION
After a discussion with @blaisb, we should also add to the changelog that callback functions now need to handle the CELL_INVALID status.

Users might encounter problems when they do not handle CELL_INVALID cells in their AMR code. I don't know how to make this backwards compatible, as this really was a bug in our library. What do you think?