### PR TITLE
Add functions to MGTools

### DIFF
--- a/include/deal.II/multigrid/mg_tools.h
+++ b/include/deal.II/multigrid/mg_tools.h
@@ -284,14 +284,42 @@ namespace MGTools
   max_level_for_coarse_mesh(const Triangulation<dim, spacedim> &tria);
 
   /**
+   * This function returns the local work of each level, i.e., the
+   * number of locally-owned cells on each multigrid level.
+   *
+   * @note This function requires that
+   * parallel::TriangulationBase::is_multilevel_hierarchy_constructed()
+   * is true, which can be controlled by setting the
+   * construct_multigrid_hierarchy flag when constructing the
+   * Triangulation.
+   */
+  template <int dim, int spacedim>
+  std::vector<types::global_dof_index>
+  local_workload(const Triangulation<dim, spacedim> &tria);
+
+  /**
+   * Similar to the above function but for a vector of triangulations as created
+   * e.g. by
+   * MGTransferGlobalCoarseningTools::create_geometric_coarsening_sequence().
+   * This returns the number of locally-owned cells on each of the
+   * triangulations.
+   */
+  template <int dim, int spacedim>
+  std::vector<types::global_dof_index>
+  local_workload(
+    const std::vector<std::shared_ptr<const Triangulation<dim, spacedim>>>
+      &trias);
+
+  /**
    * Return the imbalance of the parallel distribution of the multigrid
-   * mesh hierarchy. Ideally this value is equal to 1 (every processor owns
+   * mesh hierarchy, based on the local workload provided by local_workload().
+   * Ideally this value is equal to 1 (every processor owns
    * the same number of cells on each level, approximately true for most
    * globally refined meshes). Values greater than 1 estimate the slowdown
    * one should see in a geometric multigrid v-cycle as compared with the same
    * computation on a perfectly distributed mesh hierarchy.
    *
-   * This function is a collective MPI call between all ranks of the
+   * @note This function is a collective MPI call between all ranks of the
    * Triangulation and therefore needs to be called from all ranks.
    *
    * @note This function requires that
@@ -303,6 +331,69 @@ namespace MGTools
   template <int dim, int spacedim>
   double
   workload_imbalance(const Triangulation<dim, spacedim> &tria);
+
+  /**
+   * Similar to the above function but for a vector of triangulations as created
+   * e.g. by
+   * MGTransferGlobalCoarseningTools::create_geometric_coarsening_sequence().
+   */
+  template <int dim, int spacedim>
+  double
+  workload_imbalance(
+    const std::vector<std::shared_ptr<const Triangulation<dim, spacedim>>>
+      &trias);
+
+  /**
+   * Return the vertical communication cost between levels.
+   * The returned vector contains for each level the number
+   * of cells that have the same owning process as their
+   * corresponding coarse cell (parent) and the number of cells that have not
+   * the same owning process as their corresponding coarse cell.
+   */
+  template <int dim, int spacedim>
+  std::vector<std::pair<types::global_dof_index, types::global_dof_index>>
+  local_vertical_communication_cost(const Triangulation<dim, spacedim> &tria);
+
+  /**
+   * Similar to the above function but for a vector of triangulations as created
+   * e.g. by
+   * MGTransferGlobalCoarseningTools::create_geometric_coarsening_sequence().
+   *
+   * @note This function is a collective MPI call between all ranks of the
+   * Triangulation and therefore needs to be called from all ranks.
+   */
+  template <int dim, int spacedim>
+  std::vector<std::pair<types::global_dof_index, types::global_dof_index>>
+  local_vertical_communication_cost(
+    const std::vector<std::shared_ptr<const Triangulation<dim, spacedim>>>
+      &trias);
+
+  /**
+   * Share of fine cells that have the same owning process as their
+   * corresponding coarse cell (parent). This quantity gives an
+   * indication on the efficiency of a multigrid transfer operator
+   * and on how much data has to be sent around. A small number indicates
+   * that most of the data has to be completely permuted, involving a large
+   * volume of communication.
+   *
+   * @note This function is a collective MPI call between all ranks of the
+   * Triangulation and therefore needs to be called from all ranks.
+   */
+  template <int dim, int spacedim>
+  double
+  vertical_communication_efficiency(const Triangulation<dim, spacedim> &tria);
+
+  /**
+   * Similar to the above function but for a vector of triangulations as created
+   * e.g. by
+   * MGTransferGlobalCoarseningTools::create_geometric_coarsening_sequence().
+   */
+  template <int dim, int spacedim>
+  double
+  vertical_communication_efficiency(
+    const std::vector<std::shared_ptr<const Triangulation<dim, spacedim>>>
+      &trias);
+
 
 } // namespace MGTools
 

--- a/source/multigrid/mg_tools.inst.in
+++ b/source/multigrid/mg_tools.inst.in
@@ -199,9 +199,47 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
       max_level_for_coarse_mesh(
         const Triangulation<deal_II_dimension, deal_II_space_dimension> &tria);
 
+      template std::vector<types::global_dof_index>
+      local_workload(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension> &tria);
+
+      template std::vector<types::global_dof_index>
+      local_workload(
+        const std::vector<std::shared_ptr<
+          const Triangulation<deal_II_dimension, deal_II_space_dimension>>>
+          &tria);
+
       template double
       workload_imbalance(
         const Triangulation<deal_II_dimension, deal_II_space_dimension> &tria);
+
+      template double
+      workload_imbalance(
+        const std::vector<std::shared_ptr<
+          const Triangulation<deal_II_dimension, deal_II_space_dimension>>>
+          &tria);
+
+      template std::vector<
+        std::pair<types::global_dof_index, types::global_dof_index>>
+      local_vertical_communication_cost(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension> &tria);
+
+      template std::vector<
+        std::pair<types::global_dof_index, types::global_dof_index>>
+      local_vertical_communication_cost(
+        const std::vector<std::shared_ptr<
+          const Triangulation<deal_II_dimension, deal_II_space_dimension>>>
+          &tria);
+
+      template double
+      vertical_communication_efficiency(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension> &tria);
+
+      template double
+      vertical_communication_efficiency(
+        const std::vector<std::shared_ptr<
+          const Triangulation<deal_II_dimension, deal_II_space_dimension>>>
+          &tria);
 #endif
     \}
   }

--- a/tests/multigrid/mg_stats_01.cc
+++ b/tests/multigrid/mg_stats_01.cc
@@ -1,0 +1,123 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// Test geometric metrics from MGTools.
+
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/distributed/grid_refinement.h>
+#include <deal.II/distributed/repartitioning_policy_tools.h>
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+
+#include <deal.II/multigrid/mg_constrained_dofs.h>
+#include <deal.II/multigrid/mg_transfer_global_coarsening.h>
+#include <deal.II/multigrid/multigrid.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include "../tests.h"
+
+template <int dim>
+void
+create_quadrant(Triangulation<dim> &tria, const unsigned int n_refinements)
+{
+  GridGenerator::subdivided_hyper_cube(tria, 2, -1.0, +1.0);
+
+  if (n_refinements == 0)
+    return;
+
+  for (unsigned int i = 0; i < n_refinements; i++)
+    {
+      for (auto cell : tria.active_cell_iterators())
+        if (cell->is_locally_owned())
+          {
+            bool flag = true;
+            for (int d = 0; d < dim; d++)
+              if (cell->center()[d] > 0.0)
+                flag = false;
+            if (flag)
+              cell->set_refine_flag();
+          }
+      tria.execute_coarsening_and_refinement();
+    }
+}
+
+
+template <typename T>
+void
+print_stats(const T &tria)
+{
+  deallog << "Workload efficiency:               "
+          << 1.0 / MGTools::workload_imbalance(tria) << std::endl;
+
+  const auto local_workload = MGTools::local_workload(tria);
+  const auto local_vertical_communication_cost =
+    MGTools::local_vertical_communication_cost(tria);
+
+  deallog << "Local workload:                    ";
+  for (unsigned i = 0; i < local_workload.size(); ++i)
+    deallog << local_workload[i] << " ";
+  deallog << std::endl;
+
+  deallog << "Vertical communication efficiency: "
+          << MGTools::vertical_communication_efficiency(tria) << std::endl;
+
+  deallog << "Vertical communication costs:      ";
+  for (unsigned i = 0; i < local_workload.size(); ++i)
+    deallog << "(" << local_vertical_communication_cost[i].first << ", "
+            << local_vertical_communication_cost[i].second << ") ";
+  deallog << std::endl;
+}
+
+
+template <int dim>
+void
+test()
+{
+  parallel::distributed::Triangulation<dim> tria(
+    MPI_COMM_WORLD,
+    Triangulation<dim>::limit_level_difference_at_vertices,
+    parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
+
+  create_quadrant(tria, 2);
+
+  print_stats(tria);
+
+  const RepartitioningPolicyTools::FirstChildPolicy<dim> policy(tria);
+  const auto                                             trias =
+    MGTransferGlobalCoarseningTools::create_geometric_coarsening_sequence(
+      tria, policy);
+
+  print_stats(trias);
+}
+
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPILogInitAll                    all;
+
+  deallog.push("2d");
+  test<2>();
+  deallog.pop();
+}

--- a/tests/multigrid/mg_stats_01.with_p4est=true.mpirun=3.output
+++ b/tests/multigrid/mg_stats_01.with_p4est=true.mpirun=3.output
@@ -1,0 +1,29 @@
+
+DEAL:0:2d::Workload efficiency:               0.666667
+DEAL:0:2d::Local workload:                    1 2 8 
+DEAL:0:2d::Vertical communication efficiency: 0.937500
+DEAL:0:2d::Vertical communication costs:      (0, 0) (2, 2) (8, 0) 
+DEAL:0:2d::Workload efficiency:               0.764706
+DEAL:0:2d::Local workload:                    1 2 8 
+DEAL:0:2d::Vertical communication efficiency: 0.937500
+DEAL:0:2d::Vertical communication costs:      (0, 0) (2, 2) (8, 0) 
+
+DEAL:1:2d::Workload efficiency:               0.666667
+DEAL:1:2d::Local workload:                    1 6 8 
+DEAL:1:2d::Vertical communication efficiency: 0.937500
+DEAL:1:2d::Vertical communication costs:      (0, 0) (4, 0) (8, 0) 
+DEAL:1:2d::Workload efficiency:               0.764706
+DEAL:1:2d::Local workload:                    1 3 12 
+DEAL:1:2d::Vertical communication efficiency: 0.937500
+DEAL:1:2d::Vertical communication costs:      (0, 0) (0, 0) (12, 0) 
+
+
+DEAL:2:2d::Workload efficiency:               0.666667
+DEAL:2:2d::Local workload:                    2 8 0 
+DEAL:2:2d::Vertical communication efficiency: 0.937500
+DEAL:2:2d::Vertical communication costs:      (0, 0) (8, 0) (0, 0) 
+DEAL:2:2d::Workload efficiency:               0.764706
+DEAL:2:2d::Local workload:                    2 2 8 
+DEAL:2:2d::Vertical communication efficiency: 0.937500
+DEAL:2:2d::Vertical communication costs:      (0, 0) (0, 0) (8, 0) 
+


### PR DESCRIPTION
This PR adds diagnostic functions that work both for local-smoothing and global-coarsening multigrid:
- `local_workload()`
- `workload_imbalance()` - new version for GC; old one rewritten so that it uses `local_workload()`
- `local_vertical_communication_cost()`
- `vertical_communication_efficiency()`

Move functions from https://github.com/peterrum/dealii-multigrid/blob/master/include/mg_tools.h.

FYI @tjhei 