### PR TITLE
[WIP] Use Trilinos' int_type in wrapper classes.

### DIFF
--- a/include/deal.II/lac/trilinos_precondition.h
+++ b/include/deal.II/lac/trilinos_precondition.h
@@ -79,7 +79,7 @@ namespace TrilinosWrappers
     /**
      * Declare the type for container size.
      */
-    using size_type = dealii::types::global_dof_index;
+    using size_type = TrilinosWrappers::types::int_type;
 
     /**
      * Standardized data struct to pipe additional flags to the

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -111,7 +111,7 @@ namespace TrilinosWrappers
       /**
        * Declare the type for container size.
        */
-      using size_type = dealii::types::global_dof_index;
+      using size_type = TrilinosWrappers::types::int_type;
 
       /**
        * Constructor.
@@ -355,13 +355,13 @@ namespace TrilinosWrappers
       /**
        * Declare type for container size.
        */
-      using size_type = dealii::types::global_dof_index;
+      using size_type = TrilinosWrappers::types::int_type;
 
       /**
        * A type that denotes what data types is used to express the difference
        * between two iterators.
        */
-      using difference_type = dealii::types::global_dof_index;
+      using difference_type = TrilinosWrappers::types::int_type;
 
       /**
        * An alias for the type you get when you dereference an iterator of the
@@ -549,7 +549,7 @@ namespace TrilinosWrappers
     /**
      * Declare the type for container size.
      */
-    using size_type = dealii::types::global_dof_index;
+    using size_type = TrilinosWrappers::types::int_type;
 
     /**
      * Exception

--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -76,7 +76,7 @@ namespace TrilinosWrappers
       /**
        * Declare type for container size.
        */
-      using size_type = dealii::types::global_dof_index;
+      using size_type = TrilinosWrappers::types::int_type;
 
       /**
        * Constructor.
@@ -173,7 +173,7 @@ namespace TrilinosWrappers
       /**
        * Declare type for container size.
        */
-      using size_type = dealii::types::global_dof_index;
+      using size_type = TrilinosWrappers::types::int_type;
 
       /**
        * Constructor. Create an iterator into the matrix @p matrix for the
@@ -277,7 +277,7 @@ namespace TrilinosWrappers
     /**
      * Declare type for container size.
      */
-    using size_type = dealii::types::global_dof_index;
+    using size_type = TrilinosWrappers::types::int_type;
 
     /**
      * Declare an alias for the iterator class.

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -82,7 +82,7 @@ namespace TrilinosWrappers
     /**
      * Declare type for container size.
      */
-    using size_type = dealii::types::global_dof_index;
+    using size_type = TrilinosWrappers::types::int_type;
 
     /**
      * This class implements a wrapper for accessing the Trilinos vector in
@@ -406,7 +406,7 @@ namespace TrilinosWrappers
        */
       using value_type      = TrilinosScalar;
       using real_type       = TrilinosScalar;
-      using size_type       = dealii::types::global_dof_index;
+      using size_type       = TrilinosWrappers::types::int_type;
       using iterator        = value_type *;
       using const_iterator  = const value_type *;
       using reference       = internal::VectorReference;


### PR DESCRIPTION
We decide which datatype we want to use in Trilinos with our cmake configuration.
https://github.com/dealii/dealii/blob/0d07d611007fdbed3ca937c22974b7b1813cfa70/include/deal.II/base/types.h#L166-L182

We also return this type in some wrapper functions, but not everywhere.
https://github.com/dealii/dealii/blob/0d07d611007fdbed3ca937c22974b7b1813cfa70/include/deal.II/lac/trilinos_index_access.h#L34-L47

We use these functions, but convert their return type to the internal `size_type`, which is `global_dof_index` in many classes. I find that incoherent.
https://github.com/dealii/dealii/blob/0d07d611007fdbed3ca937c22974b7b1813cfa70/source/lac/trilinos_sparsity_pattern.cc#L935-L941

---

This PR proposes to use this type in the Trilinos wrapper classes instead of the deal.II `global_dof_index`.

I did not run the testsuite on this patch yet. So I'll keep this as a draft.

Please, correct me if I'm wrong with this suggestion!