### PR TITLE
Use 64-bit integer for `n_nonzero_elements`.

### DIFF
--- a/doc/news/changes/incompatibilities/20220404Fehling
+++ b/doc/news/changes/incompatibilities/20220404Fehling
@@ -1,0 +1,5 @@
+Changed: All functions `n_nonzero_elements()`, which are members of the
+SparseMatrix and SparsityPattern family of classes, now always return
+`std::uint64_t` instead of types::global_dof_index.
+<br>
+(Marc Fehling, 2022/04/04)

--- a/include/deal.II/base/types.h
+++ b/include/deal.II/base/types.h
@@ -167,11 +167,16 @@ namespace TrilinosWrappers
 {
   namespace types
   {
+    /**
+     * Declare type of 64 bit integer used in the Epetra package of Trilinos.
+     */
+    using int64_type = long long int;
+
 #ifdef DEAL_II_WITH_64BIT_INDICES
     /**
      * Declare type of integer used in the Epetra package of Trilinos.
      */
-    using int_type = long long int;
+    using int_type = int64_type;
 #else
     /**
      * Declare type of integer used in the Epetra package of Trilinos.

--- a/include/deal.II/lac/petsc_block_sparse_matrix.h
+++ b/include/deal.II/lac/petsc_block_sparse_matrix.h
@@ -255,7 +255,7 @@ namespace PETScWrappers
        * returns the number of entries in the sparsity pattern; if any of the
        * entries should happen to be zero, it is counted anyway.
        */
-      size_type
+      std::uint64_t
       n_nonzero_elements() const;
 
       /**

--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -653,7 +653,7 @@ namespace PETScWrappers
      * returns the number of entries in the sparsity pattern; if any of the
      * entries should happen to be zero, it is counted anyway.
      */
-    size_type
+    std::uint64_t
     n_nonzero_elements() const;
 
     /**

--- a/include/deal.II/lac/trilinos_block_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_block_sparse_matrix.h
@@ -218,7 +218,7 @@ namespace TrilinosWrappers
      * Return the total number of nonzero elements of this matrix (summed
      * over all MPI processes).
      */
-    size_type
+    std::uint64_t
     n_nonzero_elements() const;
 
     /**

--- a/include/deal.II/lac/trilinos_index_access.h
+++ b/include/deal.II/lac/trilinos_index_access.h
@@ -32,18 +32,14 @@ DEAL_II_NAMESPACE_OPEN
 namespace TrilinosWrappers
 {
   /**
-   * A helper function that queries the size of an Epetra_BlockMap object
-   * and calls either the 32 or 64 bit function to get the number of global
-   * elements in the map.
+   * A helper function that queries the size of an Epetra_BlockMap object. We
+   * always call the 64 bit function to get the number of global elements in the
+   * map.
    */
-  inline TrilinosWrappers::types::int_type
+  inline TrilinosWrappers::types::int64_type
   n_global_elements(const Epetra_BlockMap &map)
   {
-#  ifdef DEAL_II_WITH_64BIT_INDICES
     return map.NumGlobalElements64();
-#  else
-    return map.NumGlobalElements();
-#  endif
   }
 
   /**
@@ -133,17 +129,13 @@ namespace TrilinosWrappers
   }
 
   /**
-   * A helper function that finds the number of global entries by calling
-   * either the 32 or 64 bit function.
+   * A helper function that finds the number of global entries. We always call
+   * the 64 bit function.
    */
-  inline TrilinosWrappers::types::int_type
+  inline TrilinosWrappers::types::int64_type
   n_global_entries(const Epetra_CrsGraph &graph)
   {
-#  ifdef DEAL_II_WITH_64BIT_INDICES
     return graph.NumGlobalEntries64();
-#  else
-    return graph.NumGlobalEntries();
-#  endif
   }
 
   /**

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -947,7 +947,7 @@ namespace TrilinosWrappers
      * Return the total number of nonzero elements of this matrix (summed
      * over all MPI processes).
      */
-    size_type
+    std::uint64_t
     n_nonzero_elements() const;
 
     /**
@@ -3015,14 +3015,14 @@ namespace TrilinosWrappers
 
 
 
-  inline SparseMatrix::size_type
+  inline std::uint64_t
   SparseMatrix::n_nonzero_elements() const
   {
-#      ifndef DEAL_II_WITH_64BIT_INDICES
-    return matrix->NumGlobalNonzeros();
-#      else
-    return matrix->NumGlobalNonzeros64();
-#      endif
+    // Trilinos uses 64bit functions internally for attribute access, which
+    // return `long long`. They also offer 32bit variants that return `int`,
+    // however those call the 64bit version and convert the values to 32bit.
+    // There is no necessity in using the 32bit versions at all.
+    return static_cast<std::uint64_t>(matrix->NumGlobalNonzeros64());
   }
 
 

--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -712,7 +712,7 @@ namespace TrilinosWrappers
     /**
      * Return the number of nonzero elements of this sparsity pattern.
      */
-    size_type
+    std::uint64_t
     n_nonzero_elements() const;
 
     /**

--- a/source/lac/petsc_matrix_base.cc
+++ b/source/lac/petsc_matrix_base.cc
@@ -286,14 +286,16 @@ namespace PETScWrappers
 
 
 
-  MatrixBase::size_type
+  std::uint64_t
   MatrixBase::n_nonzero_elements() const
   {
     MatInfo              mat_info;
     const PetscErrorCode ierr = MatGetInfo(matrix, MAT_GLOBAL_SUM, &mat_info);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
-    return static_cast<size_type>(mat_info.nz_used);
+    // MatInfo logs quantities as PetscLogDouble. So we need to cast it to match
+    // out interface.
+    return static_cast<std::uint64_t>(mat_info.nz_used);
   }
 
 

--- a/source/lac/petsc_parallel_block_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_block_sparse_matrix.cc
@@ -135,10 +135,10 @@ namespace PETScWrappers
       return index_sets;
     }
 
-    BlockSparseMatrix::size_type
+    std::uint64_t
     BlockSparseMatrix::n_nonzero_elements() const
     {
-      size_type n_nonzero = 0;
+      std::uint64_t n_nonzero = 0;
       for (size_type rows = 0; rows < this->n_block_rows(); ++rows)
         for (size_type cols = 0; cols < this->n_block_cols(); ++cols)
           n_nonzero += this->block(rows, cols).n_nonzero_elements();

--- a/source/lac/trilinos_block_sparse_matrix.cc
+++ b/source/lac/trilinos_block_sparse_matrix.cc
@@ -232,10 +232,10 @@ namespace TrilinosWrappers
 
 
 
-  BlockSparseMatrix::size_type
+  std::uint64_t
   BlockSparseMatrix::n_nonzero_elements() const
   {
-    size_type n_nonzero = 0;
+    std::uint64_t n_nonzero = 0;
     for (size_type rows = 0; rows < this->n_block_rows(); ++rows)
       for (size_type cols = 0; cols < this->n_block_cols(); ++cols)
         n_nonzero += this->block(rows, cols).n_nonzero_elements();

--- a/source/lac/trilinos_sparsity_pattern.cc
+++ b/source/lac/trilinos_sparsity_pattern.cc
@@ -932,12 +932,12 @@ namespace TrilinosWrappers
 
 
 
-  SparsityPattern::size_type
+  std::uint64_t
   SparsityPattern::n_nonzero_elements() const
   {
-    TrilinosWrappers::types::int_type nnz = n_global_entries(*graph);
+    TrilinosWrappers::types::int64_type nnz = n_global_entries(*graph);
 
-    return static_cast<size_type>(nnz);
+    return static_cast<std::uint64_t>(nnz);
   }
 
 


### PR DESCRIPTION
Sparse matrices, that have a number of columns and rows that can be represented by a 32-bit integer, can potentially have more nonzero entries than a 32-bit integer can represent.

This PR suggests to use 64-bit integers for diagnostic functions regarding the number of nonzero elements. So far, I only covered the wrapper classes for PETSc and Trilinos. ~I plan to extend this idea also on the family of deal.II SparsityPattern and SparseMatrix classes.~ (EDIT: We decided to leave the deal.II classes as they are.)

The changes should be backwards compatible with implicit type conversion. Users should receive warnings about loss of precision in their code.

I used `std::uint64_t` in this patch, but I'm open to switch to `unsigned long long int` instead.

What is your general opinion on this?

---

Some background:

**PETSc:**
- PETSc actually uses `double` to log matrix attributes
  - https://gitlab.com/petsc/petsc/-/blob/main/include/petscmat.h#L622
- We cast these values to 32-bit or 64-bit integers (`size_type` is `global_dof_index`)
  - https://github.com/dealii/dealii/blob/126027dcd31e4de279206d4ffed5a95e7f82824c/source/lac/petsc_matrix_base.cc#L289-L297

---

**Trilinos:**
- Trilinos uses 64bit integers internally, and casts them to 32bit integers just upon request
  - https://github.com/trilinos/Trilinos/blob/7bc4eb697c4ccd9fab1742661da3260a1069d41a/packages/epetra/src/Epetra_CrsMatrix.h#L1058-L1072
  - https://github.com/trilinos/Trilinos/blob/7bc4eb697c4ccd9fab1742661da3260a1069d41a/packages/epetra/src/Epetra_BlockMap.h#L542-L552
  - https://github.com/trilinos/Trilinos/blob/7bc4eb697c4ccd9fab1742661da3260a1069d41a/packages/epetra/src/Epetra_BlockMapData.h#L96
- We cast these values
  - https://github.com/dealii/dealii/blob/126027dcd31e4de279206d4ffed5a95e7f82824c/include/deal.II/lac/trilinos_sparse_matrix.h#L3018-L3026 
  - https://github.com/dealii/dealii/blob/0d07d611007fdbed3ca937c22974b7b1813cfa70/include/deal.II/lac/trilinos_index_access.h#L34-L47