### PR TITLE
bug in RemotePointEvaluation::point_found(i) for i=0

### DIFF
--- a/source/base/mpi_remote_point_evaluation.cc
+++ b/source/base/mpi_remote_point_evaluation.cc
@@ -192,9 +192,10 @@ namespace Utilities
       if (is_map_unique())
         return true;
 
-      for (unsigned int i = 1; i < point_ptrs.size(); ++i)
-        if (point_found(i) == false)
-          return false;
+      if (point_ptrs.size() > 0)
+        for (unsigned int i = 0; i < point_ptrs.size() - 1; ++i)
+          if (point_found(i) == false)
+            return false;
 
       return true;
     }
@@ -206,8 +207,8 @@ namespace Utilities
     RemotePointEvaluation<dim, spacedim>::point_found(
       const unsigned int i) const
     {
-      AssertIndexRange(i, point_ptrs.size());
-      return (point_ptrs[i] - (i > 0) ? point_ptrs[i - 1] : 0) > 0;
+      AssertIndexRange(i, point_ptrs.size() - 1);
+      return (point_ptrs[i + 1] - point_ptrs[i]) > 0;
     }
 
 

--- a/source/base/mpi_remote_point_evaluation.cc
+++ b/source/base/mpi_remote_point_evaluation.cc
@@ -207,7 +207,7 @@ namespace Utilities
       const unsigned int i) const
     {
       AssertIndexRange(i, point_ptrs.size());
-      return (point_ptrs[i] - point_ptrs[i - 1]) > 0;
+      return (point_ptrs[i] - (i > 0) ? point_ptrs[i - 1] : 0) > 0;
     }
 
 


### PR DESCRIPTION
I think there is a bug in the code, because for `i=0`, we access `point_ptrs[0-1]`???

I don't know whether the logic I implemented is correct. I can only state that it avoids the segmentation fault.