### PR TITLE
FEInterfaceValues::get_jump/average_*_function_values

### DIFF
--- a/doc/news/changes/minor/20220411JiaqiZhang
+++ b/doc/news/changes/minor/20220411JiaqiZhang
@@ -1,0 +1,5 @@
+New: FEInterfaceValues now has functions get_*_function_values() to evaluate solution 
+values across cell faces, such as the jump in (or average of) values, 
+gradients, and Hessians.
+<br>
+(Jiaqi Zhang, 2022/04/11)

--- a/examples/step-74/step-74.cc
+++ b/examples/step-74/step-74.cc
@@ -175,47 +175,6 @@ namespace Step74
 
 
   // @sect3{Auxiliary functions}
-  // The following two auxiliary functions are used to compute
-  // jump terms for $u_h$ and $\nabla u_h$ on a face,
-  // respectively.
-  template <int dim>
-  void get_function_jump(const FEInterfaceValues<dim> &fe_iv,
-                         const Vector<double> &        solution,
-                         std::vector<double> &         jump)
-  {
-    const unsigned int                 n_q = fe_iv.n_quadrature_points;
-    std::array<std::vector<double>, 2> face_values;
-    jump.resize(n_q);
-    for (unsigned int i = 0; i < 2; ++i)
-      {
-        face_values[i].resize(n_q);
-        fe_iv.get_fe_face_values(i).get_function_values(solution,
-                                                        face_values[i]);
-      }
-    for (unsigned int q = 0; q < n_q; ++q)
-      jump[q] = face_values[0][q] - face_values[1][q];
-  }
-
-
-
-  template <int dim>
-  void get_function_gradient_jump(const FEInterfaceValues<dim> &fe_iv,
-                                  const Vector<double> &        solution,
-                                  std::vector<Tensor<1, dim>> & gradient_jump)
-  {
-    const unsigned int          n_q = fe_iv.n_quadrature_points;
-    std::vector<Tensor<1, dim>> face_gradients[2];
-    gradient_jump.resize(n_q);
-    for (unsigned int i = 0; i < 2; ++i)
-      {
-        face_gradients[i].resize(n_q);
-        fe_iv.get_fe_face_values(i).get_function_gradients(solution,
-                                                           face_gradients[i]);
-      }
-    for (unsigned int q = 0; q < n_q; ++q)
-      gradient_jump[q] = face_gradients[0][q] - face_gradients[1][q];
-  }
-
   // This function computes the penalty $\sigma$.
   double get_penalty_factor(const unsigned int fe_degree,
                             const double       cell_extent_left,
@@ -705,10 +664,10 @@ namespace Step74
       const unsigned int n_q_points = q_points.size();
 
       std::vector<double> jump(n_q_points);
-      get_function_jump(fe_iv, solution, jump);
+      fe_iv.get_jump_in_function_values(solution, jump);
 
       std::vector<Tensor<1, dim>> grad_jump(n_q_points);
-      get_function_gradient_jump(fe_iv, solution, grad_jump);
+      fe_iv.get_jump_in_function_gradients(solution, grad_jump);
 
       const double h = cell->face(f)->diameter();
 
@@ -871,7 +830,7 @@ namespace Step74
       const unsigned int n_q_points = q_points.size();
 
       std::vector<double> jump(n_q_points);
-      get_function_jump(fe_iv, solution, jump);
+      fe_iv.get_jump_in_function_values(solution, jump);
 
       const double extent1 = cell->measure() / cell->face(f)->measure();
       const double extent2 = ncell->measure() / ncell->face(nf)->measure();

--- a/include/deal.II/fe/fe_interface_values.h
+++ b/include/deal.II/fe/fe_interface_values.h
@@ -2844,16 +2844,8 @@ FEInterfaceValues<dim, spacedim>::get_jump_in_function_values(
 {
   AssertDimension(values.size(), n_quadrature_points);
 
-  std::vector<typename InputVector::value_type> values_0(n_quadrature_points);
-  std::vector<typename InputVector::value_type> values_1(n_quadrature_points);
-
-  get_fe_face_values(0).get_function_values(fe_function, values_0);
-  get_fe_face_values(1).get_function_values(fe_function, values_1);
-
-  for (unsigned int q = 0; q < n_quadrature_points; ++q)
-    {
-      values[q] = values_0[q] - values_1[q];
-    }
+  const FEValuesExtractors::Scalar scalar(0);
+  this->operator[](scalar).get_jump_in_function_values(fe_function, values);
 }
 
 
@@ -2868,18 +2860,9 @@ FEInterfaceValues<dim, spacedim>::get_jump_in_function_gradients(
 {
   AssertDimension(gradients.size(), n_quadrature_points);
 
-  std::vector<Tensor<1, spacedim, typename InputVector::value_type>>
-    gradients_0(n_quadrature_points);
-  std::vector<Tensor<1, spacedim, typename InputVector::value_type>>
-    gradients_1(n_quadrature_points);
-
-  get_fe_face_values(0).get_function_gradients(fe_function, gradients_0);
-  get_fe_face_values(1).get_function_gradients(fe_function, gradients_1);
-
-  for (unsigned int q = 0; q < n_quadrature_points; ++q)
-    {
-      gradients[q] = gradients_0[q] - gradients_1[q];
-    }
+  const FEValuesExtractors::Scalar scalar(0);
+  this->operator[](scalar).get_jump_in_function_gradients(fe_function,
+                                                          gradients);
 }
 
 
@@ -2894,18 +2877,8 @@ FEInterfaceValues<dim, spacedim>::get_jump_in_function_hessians(
 {
   AssertDimension(hessians.size(), n_quadrature_points);
 
-  std::vector<Tensor<2, spacedim, typename InputVector::value_type>> hessians_0(
-    n_quadrature_points);
-  std::vector<Tensor<2, spacedim, typename InputVector::value_type>> hessians_1(
-    n_quadrature_points);
-
-  get_fe_face_values(0).get_function_hessians(fe_function, hessians_0);
-  get_fe_face_values(1).get_function_hessians(fe_function, hessians_1);
-
-  for (unsigned int q = 0; q < n_quadrature_points; ++q)
-    {
-      hessians[q] = (hessians_0[q] - hessians_1[q]);
-    }
+  const FEValuesExtractors::Scalar scalar(0);
+  this->operator[](scalar).get_jump_in_function_hessians(fe_function, hessians);
 }
 
 
@@ -2920,20 +2893,9 @@ FEInterfaceValues<dim, spacedim>::get_jump_in_function_third_derivatives(
 {
   AssertDimension(third_derivatives.size(), n_quadrature_points);
 
-  std::vector<Tensor<3, spacedim, typename InputVector::value_type>>
-    third_derivatives_0(n_quadrature_points);
-  std::vector<Tensor<3, spacedim, typename InputVector::value_type>>
-    third_derivatives_1(n_quadrature_points);
-
-  get_fe_face_values(0).get_function_third_derivatives(fe_function,
-                                                       third_derivatives_0);
-  get_fe_face_values(1).get_function_third_derivatives(fe_function,
-                                                       third_derivatives_1);
-
-  for (unsigned int q = 0; q < n_quadrature_points; ++q)
-    {
-      third_derivatives[q] = (third_derivatives_0[q] - third_derivatives_1[q]);
-    }
+  const FEValuesExtractors::Scalar scalar(0);
+  this->operator[](scalar).get_jump_in_function_third_derivatives(
+    fe_function, third_derivatives);
 }
 
 
@@ -2947,16 +2909,8 @@ FEInterfaceValues<dim, spacedim>::get_average_of_function_values(
 {
   AssertDimension(values.size(), n_quadrature_points);
 
-  std::vector<typename InputVector::value_type> values_0(n_quadrature_points);
-  std::vector<typename InputVector::value_type> values_1(n_quadrature_points);
-
-  get_fe_face_values(0).get_function_values(fe_function, values_0);
-  get_fe_face_values(1).get_function_values(fe_function, values_1);
-
-  for (unsigned int q = 0; q < n_quadrature_points; ++q)
-    {
-      values[q] = (values_0[q] + values_1[q]) * 0.5;
-    }
+  const FEValuesExtractors::Scalar scalar(0);
+  this->operator[](scalar).get_average_of_function_values(fe_function, values);
 }
 
 
@@ -2971,18 +2925,9 @@ FEInterfaceValues<dim, spacedim>::get_average_of_function_gradients(
 {
   AssertDimension(gradients.size(), n_quadrature_points);
 
-  std::vector<Tensor<1, spacedim, typename InputVector::value_type>>
-    gradients_0(n_quadrature_points);
-  std::vector<Tensor<1, spacedim, typename InputVector::value_type>>
-    gradients_1(n_quadrature_points);
-
-  get_fe_face_values(0).get_function_gradients(fe_function, gradients_0);
-  get_fe_face_values(1).get_function_gradients(fe_function, gradients_1);
-
-  for (unsigned int q = 0; q < n_quadrature_points; ++q)
-    {
-      gradients[q] = (gradients_0[q] + gradients_1[q]) * 0.5;
-    }
+  const FEValuesExtractors::Scalar scalar(0);
+  this->operator[](scalar).get_average_of_function_gradients(fe_function,
+                                                             gradients);
 }
 
 
@@ -2997,18 +2942,9 @@ FEInterfaceValues<dim, spacedim>::get_average_of_function_hessians(
 {
   AssertDimension(hessians.size(), n_quadrature_points);
 
-  std::vector<Tensor<2, spacedim, typename InputVector::value_type>> hessians_0(
-    n_quadrature_points);
-  std::vector<Tensor<2, spacedim, typename InputVector::value_type>> hessians_1(
-    n_quadrature_points);
-
-  get_fe_face_values(0).get_function_hessians(fe_function, hessians_0);
-  get_fe_face_values(1).get_function_hessians(fe_function, hessians_1);
-
-  for (unsigned int q = 0; q < n_quadrature_points; ++q)
-    {
-      hessians[q] = (hessians_0[q] + hessians_1[q]) * 0.5;
-    }
+  const FEValuesExtractors::Scalar scalar(0);
+  this->operator[](scalar).get_average_of_function_hessians(fe_function,
+                                                            hessians);
 }
 
 

--- a/include/deal.II/fe/fe_interface_values.h
+++ b/include/deal.II/fe/fe_interface_values.h
@@ -1954,6 +1954,126 @@ public:
    * @}
    */
 
+
+
+  /**
+   * @name Access to jumps in the function values and derivatives
+   * @{
+   */
+
+  /**
+   * Return the jump in the values of the
+   * finite element function characterized by <tt>fe_function</tt> at the
+   * quadrature points of the cell interface selected the last time
+   * the <tt>reinit</tt> function of the FEInterfaceValues object was called.
+   *
+   * @dealiiRequiresUpdateFlags{update_values}
+   */
+  template <class InputVector>
+  void
+  get_jump_in_function_values(
+    const InputVector &                            fe_function,
+    std::vector<typename InputVector::value_type> &values) const;
+
+  /**
+   * Return the jump in the gradients of the
+   * finite element function characterized by <tt>fe_function</tt> at the
+   * quadrature points of the cell interface selected the last time
+   * the <tt>reinit</tt> function of the FEInterfaceValues object was called.
+   *
+   * @dealiiRequiresUpdateFlags{update_gradients}
+   */
+  template <class InputVector>
+  void
+  get_jump_in_function_gradients(
+    const InputVector &fe_function,
+    std::vector<Tensor<1, spacedim, typename InputVector::value_type>>
+      &gradients) const;
+
+  /**
+   * Return the jump in the Hessians of the
+   * finite element function characterized by <tt>fe_function</tt> at the
+   * quadrature points of the cell interface selected the last time
+   * the <tt>reinit</tt> function of the FEInterfaceValues object was called.
+   * @dealiiRequiresUpdateFlags{update_hessians}
+   */
+  template <class InputVector>
+  void
+  get_jump_in_function_hessians(
+    const InputVector &fe_function,
+    std::vector<Tensor<2, spacedim, typename InputVector::value_type>>
+      &hessians) const;
+
+  /**
+   * Return the jump in the third derivatives of the
+   * the finite element function characterized by <tt>fe_function</tt> at
+   * the quadrature points of the cell interface selected the last time
+   * the <tt>reinit</tt> function of the FEInterfaceValues object was called.
+   *
+   * @dealiiRequiresUpdateFlags{update_third_derivatives}
+   */
+  template <class InputVector>
+  void
+  get_jump_in_function_third_derivatives(
+    const InputVector &fe_function,
+    std::vector<Tensor<3, spacedim, typename InputVector::value_type>>
+      &third_derivatives) const;
+
+  //@}
+
+  /**
+   * @name Access to the average of the function values and derivatives
+   */
+  //@{
+
+  /**
+   * Return the average of the values of the
+   * finite element function characterized by <tt>fe_function</tt> at the
+   * quadrature points of the cell interface selected the last time
+   * the <tt>reinit</tt> function of the FEInterfaceValues object was called.
+   *
+   * @dealiiRequiresUpdateFlags{update_values}
+   */
+  template <class InputVector>
+  void
+  get_average_of_function_values(
+    const InputVector &                            fe_function,
+    std::vector<typename InputVector::value_type> &values) const;
+
+  /**
+   * Return the average of the gradients of the
+   * the finite element function characterized by <tt>fe_function</tt> at the
+   * quadrature points of the cell interface selected the last time
+   * the <tt>reinit</tt> function of the FEInterfaceValues object was called.
+   * @dealiiRequiresUpdateFlags{update_gradients}
+   */
+  template <class InputVector>
+  void
+  get_average_of_function_gradients(
+    const InputVector &fe_function,
+    std::vector<Tensor<1, spacedim, typename InputVector::value_type>>
+      &gradients) const;
+
+  /**
+   * Return the average of the Hessians of the
+   * the finite element function characterized by <tt>fe_function</tt> at the
+   * quadrature points of the cell interface selected the last time
+   * the <tt>reinit</tt> function of the FEInterfaceValues object was called.
+   * @dealiiRequiresUpdateFlags{update_hessians}
+   */
+  template <class InputVector>
+  void
+  get_average_of_function_hessians(
+    const InputVector &fe_function,
+    std::vector<Tensor<2, spacedim, typename InputVector::value_type>>
+      &hessians) const;
+
+  /**
+   * @}
+   */
+
+
+
   /**
    * @name Extractors Methods to extract individual components
    * @{
@@ -2711,6 +2831,184 @@ FEInterfaceValues<dim, spacedim>::jump_3rd_derivative(
   const unsigned int component) const
 {
   return jump_in_shape_3rd_derivatives(interface_dof_index, q_point, component);
+}
+
+
+
+template <int dim, int spacedim>
+template <class InputVector>
+void
+FEInterfaceValues<dim, spacedim>::get_jump_in_function_values(
+  const InputVector &                            fe_function,
+  std::vector<typename InputVector::value_type> &values) const
+{
+  AssertDimension(values.size(), n_quadrature_points);
+
+  std::vector<typename InputVector::value_type> values_0(n_quadrature_points);
+  std::vector<typename InputVector::value_type> values_1(n_quadrature_points);
+
+  get_fe_face_values(0).get_function_values(fe_function, values_0);
+  get_fe_face_values(1).get_function_values(fe_function, values_1);
+
+  for (unsigned int q = 0; q < n_quadrature_points; ++q)
+    {
+      values[q] = values_0[q] - values_1[q];
+    }
+}
+
+
+
+template <int dim, int spacedim>
+template <class InputVector>
+void
+FEInterfaceValues<dim, spacedim>::get_jump_in_function_gradients(
+  const InputVector &fe_function,
+  std::vector<Tensor<1, spacedim, typename InputVector::value_type>> &gradients)
+  const
+{
+  AssertDimension(gradients.size(), n_quadrature_points);
+
+  std::vector<Tensor<1, spacedim, typename InputVector::value_type>>
+    gradients_0(n_quadrature_points);
+  std::vector<Tensor<1, spacedim, typename InputVector::value_type>>
+    gradients_1(n_quadrature_points);
+
+  get_fe_face_values(0).get_function_gradients(fe_function, gradients_0);
+  get_fe_face_values(1).get_function_gradients(fe_function, gradients_1);
+
+  for (unsigned int q = 0; q < n_quadrature_points; ++q)
+    {
+      gradients[q] = gradients_0[q] - gradients_1[q];
+    }
+}
+
+
+
+template <int dim, int spacedim>
+template <class InputVector>
+void
+FEInterfaceValues<dim, spacedim>::get_jump_in_function_hessians(
+  const InputVector &fe_function,
+  std::vector<Tensor<2, spacedim, typename InputVector::value_type>> &hessians)
+  const
+{
+  AssertDimension(hessians.size(), n_quadrature_points);
+
+  std::vector<Tensor<2, spacedim, typename InputVector::value_type>> hessians_0(
+    n_quadrature_points);
+  std::vector<Tensor<2, spacedim, typename InputVector::value_type>> hessians_1(
+    n_quadrature_points);
+
+  get_fe_face_values(0).get_function_hessians(fe_function, hessians_0);
+  get_fe_face_values(1).get_function_hessians(fe_function, hessians_1);
+
+  for (unsigned int q = 0; q < n_quadrature_points; ++q)
+    {
+      hessians[q] = (hessians_0[q] - hessians_1[q]);
+    }
+}
+
+
+
+template <int dim, int spacedim>
+template <class InputVector>
+void
+FEInterfaceValues<dim, spacedim>::get_jump_in_function_third_derivatives(
+  const InputVector &fe_function,
+  std::vector<Tensor<3, spacedim, typename InputVector::value_type>>
+    &third_derivatives) const
+{
+  AssertDimension(third_derivatives.size(), n_quadrature_points);
+
+  std::vector<Tensor<3, spacedim, typename InputVector::value_type>>
+    third_derivatives_0(n_quadrature_points);
+  std::vector<Tensor<3, spacedim, typename InputVector::value_type>>
+    third_derivatives_1(n_quadrature_points);
+
+  get_fe_face_values(0).get_function_third_derivatives(fe_function,
+                                                       third_derivatives_0);
+  get_fe_face_values(1).get_function_third_derivatives(fe_function,
+                                                       third_derivatives_1);
+
+  for (unsigned int q = 0; q < n_quadrature_points; ++q)
+    {
+      third_derivatives[q] = (third_derivatives_0[q] - third_derivatives_1[q]);
+    }
+}
+
+
+
+template <int dim, int spacedim>
+template <class InputVector>
+void
+FEInterfaceValues<dim, spacedim>::get_average_of_function_values(
+  const InputVector &                            fe_function,
+  std::vector<typename InputVector::value_type> &values) const
+{
+  AssertDimension(values.size(), n_quadrature_points);
+
+  std::vector<typename InputVector::value_type> values_0(n_quadrature_points);
+  std::vector<typename InputVector::value_type> values_1(n_quadrature_points);
+
+  get_fe_face_values(0).get_function_values(fe_function, values_0);
+  get_fe_face_values(1).get_function_values(fe_function, values_1);
+
+  for (unsigned int q = 0; q < n_quadrature_points; ++q)
+    {
+      values[q] = (values_0[q] + values_1[q]) * 0.5;
+    }
+}
+
+
+
+template <int dim, int spacedim>
+template <class InputVector>
+void
+FEInterfaceValues<dim, spacedim>::get_average_of_function_gradients(
+  const InputVector &fe_function,
+  std::vector<Tensor<1, spacedim, typename InputVector::value_type>> &gradients)
+  const
+{
+  AssertDimension(gradients.size(), n_quadrature_points);
+
+  std::vector<Tensor<1, spacedim, typename InputVector::value_type>>
+    gradients_0(n_quadrature_points);
+  std::vector<Tensor<1, spacedim, typename InputVector::value_type>>
+    gradients_1(n_quadrature_points);
+
+  get_fe_face_values(0).get_function_gradients(fe_function, gradients_0);
+  get_fe_face_values(1).get_function_gradients(fe_function, gradients_1);
+
+  for (unsigned int q = 0; q < n_quadrature_points; ++q)
+    {
+      gradients[q] = (gradients_0[q] + gradients_1[q]) * 0.5;
+    }
+}
+
+
+
+template <int dim, int spacedim>
+template <class InputVector>
+void
+FEInterfaceValues<dim, spacedim>::get_average_of_function_hessians(
+  const InputVector &fe_function,
+  std::vector<Tensor<2, spacedim, typename InputVector::value_type>> &hessians)
+  const
+{
+  AssertDimension(hessians.size(), n_quadrature_points);
+
+  std::vector<Tensor<2, spacedim, typename InputVector::value_type>> hessians_0(
+    n_quadrature_points);
+  std::vector<Tensor<2, spacedim, typename InputVector::value_type>> hessians_1(
+    n_quadrature_points);
+
+  get_fe_face_values(0).get_function_hessians(fe_function, hessians_0);
+  get_fe_face_values(1).get_function_hessians(fe_function, hessians_1);
+
+  for (unsigned int q = 0; q < n_quadrature_points; ++q)
+    {
+      hessians[q] = (hessians_0[q] + hessians_1[q]) * 0.5;
+    }
 }
 
 

--- a/include/deal.II/fe/fe_interface_values.h
+++ b/include/deal.II/fe/fe_interface_values.h
@@ -3011,7 +3011,7 @@ namespace FEInterfaceViews
 
     AssertDimension(interface_dof_indices.size(), local_dof_values.size());
 
-    for (unsigned int i = 0; i < interface_dof_indices.size(); ++i)
+    for (unsigned int i : this->fe_interface->dof_indices())
       local_dof_values[i] = dof_values(interface_dof_indices[i]);
   }
 
@@ -3318,9 +3318,6 @@ namespace FEInterfaceViews
   {
     AssertDimension(values.size(), this->fe_interface->n_quadrature_points);
 
-    const auto &interface_dof_indices =
-      this->fe_interface->get_interface_dof_indices();
-
     for (const auto dof_index : this->fe_interface->dof_indices())
       for (const auto q_index : this->fe_interface->quadrature_point_indices())
         {
@@ -3364,9 +3361,6 @@ namespace FEInterfaceViews
   {
     AssertDimension(values.size(), this->fe_interface->n_quadrature_points);
 
-    const auto &interface_dof_indices =
-      this->fe_interface->get_interface_dof_indices();
-
     for (const auto dof_index : this->fe_interface->dof_indices())
       for (const auto q_index : this->fe_interface->quadrature_point_indices())
         {
@@ -3406,9 +3400,6 @@ namespace FEInterfaceViews
       &gradients) const
   {
     AssertDimension(gradients.size(), this->fe_interface->n_quadrature_points);
-
-    const auto &interface_dof_indices =
-      this->fe_interface->get_interface_dof_indices();
 
     for (const auto dof_index : this->fe_interface->dof_indices())
       for (const auto q_index : this->fe_interface->quadrature_point_indices())
@@ -3450,9 +3441,6 @@ namespace FEInterfaceViews
     const
   {
     AssertDimension(values.size(), this->fe_interface->n_quadrature_points);
-
-    const auto &interface_dof_indices =
-      this->fe_interface->get_interface_dof_indices();
 
     for (const auto dof_index : this->fe_interface->dof_indices())
       for (const auto q_index : this->fe_interface->quadrature_point_indices())
@@ -3496,9 +3484,6 @@ namespace FEInterfaceViews
   {
     AssertDimension(gradients.size(), this->fe_interface->n_quadrature_points);
 
-    const auto &interface_dof_indices =
-      this->fe_interface->get_interface_dof_indices();
-
     for (const auto dof_index : this->fe_interface->dof_indices())
       for (const auto q_index : this->fe_interface->quadrature_point_indices())
         {
@@ -3539,9 +3524,6 @@ namespace FEInterfaceViews
       &hessians) const
   {
     AssertDimension(hessians.size(), this->fe_interface->n_quadrature_points);
-
-    const auto &interface_dof_indices =
-      this->fe_interface->get_interface_dof_indices();
 
     for (const auto dof_index : this->fe_interface->dof_indices())
       for (const auto q_index : this->fe_interface->quadrature_point_indices())
@@ -3584,11 +3566,7 @@ namespace FEInterfaceViews
   {
     AssertDimension(hessians.size(), this->fe_interface->n_quadrature_points);
 
-    const auto &interface_dof_indices =
-      this->fe_interface->get_interface_dof_indices();
-
-    for (unsigned int dof_index = 0; dof_index < interface_dof_indices.size();
-         ++dof_index)
+    for (unsigned int dof_index : this->fe_interface->dof_indices())
       for (const auto q_index : this->fe_interface->quadrature_point_indices())
         {
           if (dof_index == 0)
@@ -3632,11 +3610,7 @@ namespace FEInterfaceViews
     AssertDimension(third_derivatives.size(),
                     this->fe_interface->n_quadrature_points);
 
-    const auto &interface_dof_indices =
-      this->fe_interface->get_interface_dof_indices();
-
-    for (unsigned int dof_index = 0; dof_index < interface_dof_indices.size();
-         ++dof_index)
+    for (unsigned int dof_index : this->fe_interface->dof_indices())
       for (const auto q_index : this->fe_interface->quadrature_point_indices())
         {
           if (dof_index == 0)
@@ -3981,9 +3955,6 @@ namespace FEInterfaceViews
   {
     AssertDimension(values.size(), this->fe_interface->n_quadrature_points);
 
-    const auto &interface_dof_indices =
-      this->fe_interface->get_interface_dof_indices();
-
     for (const auto dof_index : this->fe_interface->dof_indices())
       for (const auto q_index : this->fe_interface->quadrature_point_indices())
         {
@@ -4027,9 +3998,6 @@ namespace FEInterfaceViews
   {
     AssertDimension(values.size(), this->fe_interface->n_quadrature_points);
 
-    const auto &interface_dof_indices =
-      this->fe_interface->get_interface_dof_indices();
-
     for (const auto dof_index : this->fe_interface->dof_indices())
       for (const auto q_index : this->fe_interface->quadrature_point_indices())
         {
@@ -4069,9 +4037,6 @@ namespace FEInterfaceViews
       &gradients) const
   {
     AssertDimension(gradients.size(), this->fe_interface->n_quadrature_points);
-
-    const auto &interface_dof_indices =
-      this->fe_interface->get_interface_dof_indices();
 
     for (const auto dof_index : this->fe_interface->dof_indices())
       for (const auto q_index : this->fe_interface->quadrature_point_indices())
@@ -4113,9 +4078,6 @@ namespace FEInterfaceViews
     const
   {
     AssertDimension(values.size(), this->fe_interface->n_quadrature_points);
-
-    const auto &interface_dof_indices =
-      this->fe_interface->get_interface_dof_indices();
 
     for (const auto dof_index : this->fe_interface->dof_indices())
       for (const auto q_index : this->fe_interface->quadrature_point_indices())
@@ -4159,9 +4121,6 @@ namespace FEInterfaceViews
   {
     AssertDimension(gradients.size(), this->fe_interface->n_quadrature_points);
 
-    const auto &interface_dof_indices =
-      this->fe_interface->get_interface_dof_indices();
-
     for (const auto dof_index : this->fe_interface->dof_indices())
       for (const auto q_index : this->fe_interface->quadrature_point_indices())
         {
@@ -4202,9 +4161,6 @@ namespace FEInterfaceViews
       &hessians) const
   {
     AssertDimension(hessians.size(), this->fe_interface->n_quadrature_points);
-
-    const auto &interface_dof_indices =
-      this->fe_interface->get_interface_dof_indices();
 
     for (const auto dof_index : this->fe_interface->dof_indices())
       for (const auto q_index : this->fe_interface->quadrature_point_indices())
@@ -4247,11 +4203,7 @@ namespace FEInterfaceViews
   {
     AssertDimension(hessians.size(), this->fe_interface->n_quadrature_points);
 
-    const auto &interface_dof_indices =
-      this->fe_interface->get_interface_dof_indices();
-
-    for (unsigned int dof_index = 0; dof_index < interface_dof_indices.size();
-         ++dof_index)
+    for (unsigned int dof_index : this->fe_interface->dof_indices())
       for (const auto q_index : this->fe_interface->quadrature_point_indices())
         {
           if (dof_index == 0)
@@ -4295,11 +4247,7 @@ namespace FEInterfaceViews
     AssertDimension(third_derivatives.size(),
                     this->fe_interface->n_quadrature_points);
 
-    const auto &interface_dof_indices =
-      this->fe_interface->get_interface_dof_indices();
-
-    for (unsigned int dof_index = 0; dof_index < interface_dof_indices.size();
-         ++dof_index)
+    for (unsigned int dof_index : this->fe_interface->dof_indices())
       for (const auto q_index : this->fe_interface->quadrature_point_indices())
         {
           if (dof_index == 0)

--- a/tests/feinterface/fe_interface_values_10.cc
+++ b/tests/feinterface/fe_interface_values_10.cc
@@ -161,7 +161,7 @@ test()
   std::vector<Tensor<3, dim>> average_of_3rd_derivatives(n_face_q_points);
   std::vector<Tensor<3, dim>> exact_average_of_3rd_derivatives(n_face_q_points);
 
-  const double tol = 1e-11;
+  const double tol = 1e-15;
 
   typename DoFHandler<dim>::active_cell_iterator cell =
     dof_handler.begin_active();
@@ -244,15 +244,13 @@ main(int argc, char **argv)
 {
   initlog();
 
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(
-    argc, argv, testing_max_num_threads());
-
   deallog.push("Test jump in function values");
   {
     test_jump_function();
   }
   deallog.pop();
   deallog << "OK" << std::endl;
+
   deallog.push("Test all functions");
   {
     test();

--- a/tests/feinterface/fe_interface_values_10.cc
+++ b/tests/feinterface/fe_interface_values_10.cc
@@ -1,0 +1,263 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 - 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// Check FEInterfaceViews::get_*_function_values/gradients...
+
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_renumbering.h>
+
+#include <deal.II/fe/fe_dgp.h>
+#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/fe/fe_interface_values.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/fe_values.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/lac/vector.h>
+
+#include <fstream>
+#include <type_traits>
+
+#include "../tests.h"
+
+template <int dim = 2>
+void
+test_jump_function()
+{
+  FE_DGP<dim> fe(0);
+
+  Triangulation<dim> tria;
+  DoFHandler<dim>    dof_handler(tria);
+  Vector<double>     solution;
+
+  GridGenerator::hyper_cube(tria, -1, 1);
+  tria.refine_global(1);
+  dof_handler.distribute_dofs(fe);
+
+  solution.reinit(dof_handler.n_dofs());
+
+  std::vector<types::global_dof_index> local_dof_indices(1);
+  // Populate with non-trivial values
+  for (const auto &cell : dof_handler.active_cell_iterators())
+    {
+      cell->get_dof_indices(local_dof_indices);
+      solution(local_dof_indices[0]) =
+        static_cast<double>(cell->active_cell_index());
+    }
+
+  const QGauss<dim - 1>  face_quadrature(2);
+  FEInterfaceValues<dim> fe_iv(fe,
+                               face_quadrature,
+                               update_values | update_gradients |
+                                 update_quadrature_points |
+                                 update_3rd_derivatives);
+
+  std::vector<double> qp_jumps_global(face_quadrature.size());
+
+  typename DoFHandler<dim>::active_cell_iterator cell =
+    dof_handler.begin_active();
+  for (; cell != dof_handler.end(); ++cell)
+    for (const auto f : cell->face_indices())
+      if (!cell->face(f)->at_boundary())
+        {
+          {
+            fe_iv.reinit(cell,
+                         f,
+                         numbers::invalid_unsigned_int,
+                         cell->neighbor(f),
+                         cell->neighbor_of_neighbor(f),
+                         numbers::invalid_unsigned_int);
+
+            fe_iv.get_jump_in_function_values(solution, qp_jumps_global);
+
+            double exact = cell->active_cell_index() * 1.0 -
+                           cell->neighbor(f)->active_cell_index() * 1.0;
+
+            for (unsigned int q = 0; q < face_quadrature.size(); ++q)
+              Assert(std::fabs(qp_jumps_global[q] - exact) < 1e-15,
+                     ExcNotImplemented());
+          }
+        }
+
+  deallog << "OK" << std::endl;
+}
+
+template <int dim = 2>
+void
+test()
+{
+  FESystem<dim>              fe(FE_DGP<dim>(4), 1);
+  FEValuesExtractors::Scalar extractor(0);
+
+  Triangulation<dim> tria;
+  DoFHandler<dim>    dof_handler(tria);
+  Vector<double>     solution;
+
+  GridGenerator::hyper_cube(tria, -1, 1);
+  tria.refine_global(1);
+  dof_handler.distribute_dofs(fe);
+
+  solution.reinit(dof_handler.n_dofs());
+
+  const unsigned int dofs_per_cell = dof_handler.get_fe().dofs_per_cell;
+
+  std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+  // Populate with non-trivial values
+  for (const auto &cell : dof_handler.active_cell_iterators())
+    {
+      cell->get_dof_indices(local_dof_indices);
+      for (unsigned int i = 0; i < dofs_per_cell; ++i)
+        solution(local_dof_indices[i]) =
+          static_cast<double>(cell->active_cell_index() + 1);
+    }
+
+  const QGauss<dim - 1>  face_quadrature(2);
+  FEInterfaceValues<dim> fe_iv(fe,
+                               face_quadrature,
+                               update_values | update_gradients |
+                                 update_quadrature_points |
+                                 update_3rd_derivatives);
+  const unsigned int     n_face_q_points = face_quadrature.size();
+
+  std::vector<double> jump_in_values(n_face_q_points);
+  std::vector<double> exact_jump_in_values(n_face_q_points);
+
+  std::vector<Tensor<1, dim>> jump_in_grads(n_face_q_points);
+  std::vector<Tensor<1, dim>> exact_jump_in_grads(n_face_q_points);
+
+  std::vector<Tensor<2, dim>> jump_in_hessians(n_face_q_points);
+  std::vector<Tensor<2, dim>> exact_jump_in_hessians(n_face_q_points);
+
+  std::vector<Tensor<3, dim>> jump_in_3rd_derivatives(n_face_q_points);
+  std::vector<Tensor<3, dim>> exact_jump_in_3rd_derivatives(n_face_q_points);
+
+  std::vector<double> average_of_values(n_face_q_points);
+  std::vector<double> exact_average_of_values(n_face_q_points);
+
+  std::vector<Tensor<1, dim>> average_of_grads(n_face_q_points);
+  std::vector<Tensor<1, dim>> exact_average_of_grads(n_face_q_points);
+
+  std::vector<Tensor<2, dim>> average_of_hessians(n_face_q_points);
+  std::vector<Tensor<2, dim>> exact_average_of_hessians(n_face_q_points);
+
+  std::vector<Tensor<3, dim>> average_of_3rd_derivatives(n_face_q_points);
+  std::vector<Tensor<3, dim>> exact_average_of_3rd_derivatives(n_face_q_points);
+
+  const double tol = 1e-11;
+
+  typename DoFHandler<dim>::active_cell_iterator cell =
+    dof_handler.begin_active();
+  for (; cell != dof_handler.end(); ++cell)
+    for (const auto f : cell->face_indices())
+      if (!cell->face(f)->at_boundary())
+        {
+          {
+            fe_iv.reinit(cell,
+                         f,
+                         numbers::invalid_unsigned_int,
+                         cell->neighbor(f),
+                         cell->neighbor_of_neighbor(f),
+                         numbers::invalid_unsigned_int);
+
+            fe_iv.get_jump_in_function_values(solution, jump_in_values);
+            fe_iv[extractor].get_jump_in_function_values(solution,
+                                                         exact_jump_in_values);
+
+            fe_iv.get_jump_in_function_gradients(solution, jump_in_grads);
+            fe_iv[extractor].get_jump_in_function_gradients(
+              solution, exact_jump_in_grads);
+
+            fe_iv.get_jump_in_function_hessians(solution, jump_in_hessians);
+            fe_iv[extractor].get_jump_in_function_hessians(
+              solution, exact_jump_in_hessians);
+
+            fe_iv.get_jump_in_function_third_derivatives(
+              solution, jump_in_3rd_derivatives);
+            fe_iv[extractor].get_jump_in_function_third_derivatives(
+              solution, exact_jump_in_3rd_derivatives);
+
+            fe_iv.get_average_of_function_values(solution, average_of_values);
+            fe_iv[extractor].get_average_of_function_values(
+              solution, exact_average_of_values);
+
+            fe_iv.get_average_of_function_gradients(solution, average_of_grads);
+            fe_iv[extractor].get_average_of_function_gradients(
+              solution, exact_average_of_grads);
+
+            fe_iv.get_average_of_function_hessians(solution,
+                                                   average_of_hessians);
+            fe_iv[extractor].get_average_of_function_hessians(
+              solution, exact_average_of_hessians);
+
+            for (unsigned int q = 0; q < face_quadrature.size(); ++q)
+              {
+                Assert(std::fabs(jump_in_values[q] - exact_jump_in_values[q]) <
+                         tol,
+                       ExcNotImplemented());
+                Assert((jump_in_grads[q] - exact_jump_in_grads[q]).norm() < tol,
+                       ExcNotImplemented());
+                Assert((jump_in_hessians[q] - exact_jump_in_hessians[q])
+                           .norm() < tol,
+                       ExcNotImplemented());
+                Assert((jump_in_3rd_derivatives[q] -
+                        exact_jump_in_3rd_derivatives[q])
+                           .norm() < tol,
+                       ExcNotImplemented());
+
+                Assert(std::fabs(average_of_values[q] -
+                                 exact_average_of_values[q]) < tol,
+                       ExcNotImplemented());
+                Assert((average_of_grads[q] - exact_average_of_grads[q])
+                           .norm() < tol,
+                       ExcNotImplemented());
+                Assert((average_of_hessians[q] - exact_average_of_hessians[q])
+                           .norm() < tol,
+                       ExcNotImplemented());
+              }
+          }
+        }
+
+  deallog << "OK" << std::endl;
+}
+
+
+int
+main(int argc, char **argv)
+{
+  initlog();
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(
+    argc, argv, testing_max_num_threads());
+
+  deallog.push("Test jump in function values");
+  {
+    test_jump_function();
+  }
+  deallog.pop();
+  deallog << "OK" << std::endl;
+  deallog.push("Test all functions");
+  {
+    test();
+  }
+  deallog.pop();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/feinterface/fe_interface_values_10.output
+++ b/tests/feinterface/fe_interface_values_10.output
@@ -1,0 +1,5 @@
+
+DEAL:Test jump in function values::OK
+DEAL::OK
+DEAL:Test all functions::OK
+DEAL::OK

--- a/tests/simplex/step-74.cc
+++ b/tests/simplex/step-74.cc
@@ -167,44 +167,6 @@ namespace Step74
       values[i] = -ref.laplacian(points[i]);
   }
 
-  template <int dim>
-  void
-  get_function_jump(const FEInterfaceValues<dim> &fe_iv,
-                    const Vector<double> &        solution,
-                    std::vector<double> &         jump)
-  {
-    const unsigned                     n_q = fe_iv.n_quadrature_points;
-    std::array<std::vector<double>, 2> face_values;
-    jump.resize(n_q);
-    for (unsigned i = 0; i < 2; ++i)
-      {
-        face_values[i].resize(n_q);
-        fe_iv.get_fe_face_values(i).get_function_values(solution,
-                                                        face_values[i]);
-      }
-    for (unsigned int q = 0; q < n_q; ++q)
-      jump[q] = face_values[0][q] - face_values[1][q];
-  }
-
-  template <int dim>
-  void
-  get_function_gradient_jump(const FEInterfaceValues<dim> &fe_iv,
-                             const Vector<double> &        solution,
-                             std::vector<Tensor<1, dim>> & gradient_jump)
-  {
-    const unsigned              n_q = fe_iv.n_quadrature_points;
-    std::vector<Tensor<1, dim>> face_gradients[2];
-    gradient_jump.resize(n_q);
-    for (unsigned i = 0; i < 2; ++i)
-      {
-        face_gradients[i].resize(n_q);
-        fe_iv.get_fe_face_values(i).get_function_gradients(solution,
-                                                           face_gradients[i]);
-      }
-    for (unsigned int q = 0; q < n_q; ++q)
-      gradient_jump[q] = face_gradients[0][q] - face_gradients[1][q];
-  }
-
   double
   compute_penalty(const unsigned int fe_degree,
                   const double       cell_extend_left,
@@ -655,10 +617,10 @@ namespace Step74
       const unsigned int n_q_points = q_points.size();
 
       std::vector<double> jump(n_q_points);
-      get_function_jump(fe_iv, solution, jump);
+      fe_iv.get_jump_in_function_values(solution, jump);
 
       std::vector<Tensor<1, dim>> grad_jump(n_q_points);
-      get_function_gradient_jump(fe_iv, solution, grad_jump);
+      fe_iv.get_jump_in_function_gradients(solution, grad_jump);
 
       const double h = cell->face(f)->diameter();
 
@@ -795,7 +757,7 @@ namespace Step74
       const unsigned int n_q_points = q_points.size();
 
       std::vector<double> jump(n_q_points);
-      get_function_jump(fe_iv, solution, jump);
+      fe_iv.get_jump_in_function_values(solution, jump);
 
       const double extent1 = cell->measure() / cell->face(f)->measure();
       const double extent2 = ncell->measure() / ncell->face(nf)->measure();


### PR DESCRIPTION
Address https://github.com/dealii/dealii/issues/11464

Add FEInterfaceValues::functions get_*_function_values() to evaluate solution 
values across cell faces, such as the jump in (or average of) values, gradients, and Hessians.
@tjhei 