### PR TITLE
Fixes CMake version > 3.12 python-binding build failure

### DIFF
--- a/contrib/python-bindings/CMakeLists.txt
+++ b/contrib/python-bindings/CMakeLists.txt
@@ -21,7 +21,14 @@ IF(DEAL_II_COMPONENT_PYTHON_BINDINGS)
   #
   # Find Python:
   #
-  INCLUDE(FindPythonInterp)
+  # Since CMake 3.12, FindPythonInterp is deprecated.
+  if (CMAKE_VERSION VERSION_LESS 3.12)
+    INCLUDE(FindPythonInterp)
+  else()
+    FIND_PACKAGE(Python3)
+    set(PYTHON_VERSION_MAJOR ${Python3_VERSION_MAJOR})
+    set(PYTHON_VERSION_MINOR ${Python3_VERSION_MINOR})
+  endif()
   INCLUDE(FindPythonLibs)
 
   IF(FEATURE_BOOST_BUNDLED_CONFIGURED)


### PR DESCRIPTION
My build (deal.II 9.3.3, Ubuntu 18.04) with python-bindings was failing at the `cmake .` stage. Looking at the `CMakeLists.txt` file and comparing against the CMake documentation, it seems that this is due to a deprecation of `FindPythonInterp` for newer versions of CMake.

In order to fix the issue, I added a check based on the User's CMake version, since deal.II supports older versions. Using the new CMake functionality sets different CMake variables for Python version, so I set the existing variables based on the new variables as well. They're needed later in the file.

After making these changes, I'm able to build the library, the quicktests pass, and I'm able to import the PyDealII python library from an interpreter.