### PR TITLE
Change cell type passed to DiscreteQuadratureGenerator::generate()

### DIFF
--- a/include/deal.II/non_matching/quadrature_generator.h
+++ b/include/deal.II/non_matching/quadrature_generator.h
@@ -510,6 +510,9 @@ namespace NonMatching
     /**
      * Construct immersed quadratures rules based on the discrete level
      * set vector over the incoming cell.
+     *
+     * @note The cell needs to belong to the same triangulation as the one
+     * associated with the DoFHandler passed to the constructor.
      */
     void
     generate(const typename Triangulation<dim>::active_cell_iterator &cell);
@@ -563,6 +566,9 @@ namespace NonMatching
     /**
      * Construct immersed quadratures rules based on the discrete level
      * set vector over the incoming face described by cell and face index.
+     *
+     * @note The cell needs to belong to the same triangulation as the one
+     * associated with the DoFHandler passed to the constructor.
      */
     void
     generate(const typename Triangulation<dim>::active_cell_iterator &cell,

--- a/include/deal.II/non_matching/quadrature_generator.h
+++ b/include/deal.II/non_matching/quadrature_generator.h
@@ -511,10 +511,8 @@ namespace NonMatching
      * Construct immersed quadratures rules based on the discrete level
      * set vector over the incoming cell.
      */
-    template <bool level_dof_access>
     void
-    generate(
-      const TriaIterator<DoFCellAccessor<dim, dim, level_dof_access>> &cell);
+    generate(const typename Triangulation<dim>::active_cell_iterator &cell);
 
   private:
     /**
@@ -566,11 +564,9 @@ namespace NonMatching
      * Construct immersed quadratures rules based on the discrete level
      * set vector over the incoming face described by cell and face index.
      */
-    template <bool level_dof_access>
     void
-    generate(
-      const TriaIterator<DoFCellAccessor<dim, dim, level_dof_access>> &cell,
-      const unsigned int face_index);
+    generate(const typename Triangulation<dim>::active_cell_iterator &cell,
+             const unsigned int face_index);
 
   private:
     /**

--- a/source/non_matching/quadrature_generator.cc
+++ b/source/non_matching/quadrature_generator.cc
@@ -1887,10 +1887,9 @@ namespace NonMatching
 
 
   template <int dim>
-  template <bool level_dof_access>
   void
   DiscreteQuadratureGenerator<dim>::generate(
-    const TriaIterator<DoFCellAccessor<dim, dim, level_dof_access>> &cell)
+    const typename Triangulation<dim>::active_cell_iterator &cell)
   {
     reference_space_level_set->set_active_cell(cell);
     const BoundingBox<dim> unit_box = create_unit_bounding_box<dim>();
@@ -1917,11 +1916,10 @@ namespace NonMatching
 
 
   template <int dim>
-  template <bool level_dof_access>
   void
   DiscreteFaceQuadratureGenerator<dim>::generate(
-    const TriaIterator<DoFCellAccessor<dim, dim, level_dof_access>> &cell,
-    const unsigned int                                               face_index)
+    const typename Triangulation<dim>::active_cell_iterator &cell,
+    const unsigned int                                       face_index)
   {
     reference_space_level_set->set_active_cell(cell);
     const BoundingBox<dim> unit_box = create_unit_bounding_box<dim>();

--- a/source/non_matching/quadrature_generator.inst.in
+++ b/source/non_matching/quadrature_generator.inst.in
@@ -93,18 +93,3 @@ for (VEC : REAL_VECTOR_TYPES; deal_II_dimension : DIMENSIONS)
                                       const VEC &,
                                       const AdditionalData &);
   }
-
-// Template generate function
-for (deal_II_dimension : DIMENSIONS; lda : BOOL)
-  {
-    template void
-    NonMatching::DiscreteQuadratureGenerator<deal_II_dimension>::generate(
-      const TriaIterator<
-        DoFCellAccessor<deal_II_dimension, deal_II_dimension, lda>> &);
-
-    template void
-    NonMatching::DiscreteFaceQuadratureGenerator<deal_II_dimension>::generate(
-      const TriaIterator<
-        DoFCellAccessor<deal_II_dimension, deal_II_dimension, lda>> &,
-      const unsigned int);
-  }

--- a/tests/non_matching/discrete_quadrature_generator.cc
+++ b/tests/non_matching/discrete_quadrature_generator.cc
@@ -138,7 +138,7 @@ Test<dim>::test_discrete_quadrature_generator()
 {
   NonMatching::DiscreteQuadratureGenerator<dim> quadrature_generator(
     q_collection1D, dof_handler, level_set);
-  quadrature_generator.generate(dof_handler.begin_active());
+  quadrature_generator.generate(triangulation.begin_active());
 
   print_quadrature(quadrature_generator.get_inside_quadrature());
   print_quadrature(quadrature_generator.get_outside_quadrature());
@@ -154,7 +154,7 @@ Test<dim>::test_discrete_face_quadrature_generator()
   NonMatching::DiscreteFaceQuadratureGenerator<dim> face_quadrature_generator(
     q_collection1D, dof_handler, level_set);
 
-  const auto &cell = dof_handler.begin_active();
+  const auto &cell = triangulation.begin_active();
   for (const auto f : cell->face_indices())
     {
       face_quadrature_generator.generate(cell, f);

--- a/tests/non_matching/discrete_quadrature_generator.cc
+++ b/tests/non_matching/discrete_quadrature_generator.cc
@@ -18,11 +18,9 @@
 #include <deal.II/base/quadrature_lib.h>
 
 #include <deal.II/fe/fe_q.h>
-#include <deal.II/fe/mapping_cartesian.h>
 
 #include <deal.II/grid/grid_generator.h>
 
-#include <deal.II/non_matching/mesh_classifier.h>
 #include <deal.II/non_matching/quadrature_generator.h>
 
 #include <deal.II/numerics/vector_tools.h>
@@ -61,12 +59,9 @@ private:
   hp::FECollection<dim> fe_collection;
   DoFHandler<dim>       dof_handler;
 
-  hp::MappingCollection<dim> mapping_collection;
-  hp::QCollection<dim>       q_collection;
-  hp::QCollection<1>         q_collection1D;
+  hp::QCollection<1> q_collection1D;
 
-  Vector<double>                   level_set;
-  NonMatching::MeshClassifier<dim> mesh_classifier;
+  Vector<double> level_set;
 };
 
 
@@ -74,12 +69,9 @@ private:
 template <int dim>
 Test<dim>::Test()
   : dof_handler(triangulation)
-  , mesh_classifier(dof_handler, level_set)
 {
   fe_collection.push_back(FE_Q<dim>(1));
-  mapping_collection.push_back(MappingCartesian<dim>());
   const unsigned int n_quadrature_points = 1;
-  q_collection.push_back(QGauss<dim>(n_quadrature_points));
   q_collection1D.push_back(QGauss<1>(n_quadrature_points));
 }
 
@@ -92,7 +84,6 @@ Test<dim>::run()
   setup_mesh();
   dof_handler.distribute_dofs(fe_collection);
   setup_discrete_level_set();
-  mesh_classifier.reclassify();
   test_discrete_quadrature_generator();
   test_discrete_face_quadrature_generator();
 }


### PR DESCRIPTION
The cell passed to the generate()-functions does not need to have dofs associated with it. The cell will be cast to an iterator of the correct type internally. Change the parameter type of the generate function to Triangulation::active_cell_iterator.

Noticed this when I used these new classes today. I didn't think of it before. @bergbauer 