### PR TITLE
Remove unnecessary include.

### DIFF
--- a/tests/dofs/nodal_renumbering_01.cc
+++ b/tests/dofs/nodal_renumbering_01.cc
@@ -35,8 +35,6 @@
 #include <deal.II/numerics/data_out.h>
 #include <deal.II/numerics/vector_tools_interpolate.h>
 
-#include <boost/algorithm/apply_permutation.hpp>
-
 #include <iostream>
 #include <map>
 


### PR DESCRIPTION
Fixing #13649 turned out to be easier than I had thought -- just remove the offending `#include` altogether, and things will work :-)

Fixes #13649.

/rebuild