### PR TITLE
Cleanup artifacts

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,13 @@
+name: 'Artifacts cleanup'
+on:
+  schedule:
+    - cron: '0 1 * * *' # every night at 1 am UTC
+
+jobs:
+  delete-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kolpav/purge-artifacts-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          expire-in: 7days # Set this to 0 to delete all artifacts


### PR DESCRIPTION
We are having some issues with the artifacts not uploading. This checks for all artifacts older than a week (every night) and removes them. It should fix our currently failing PRs.