### PR TITLE
Assert that a method was choosen in the time stepping methods.

### DIFF
--- a/include/deal.II/base/time_stepping.h
+++ b/include/deal.II/base/time_stepping.h
@@ -767,6 +767,10 @@ namespace TimeStepping
      */
     struct Status : public TimeStepping<VectorType>::Status
     {
+      Status()
+        : method(invalid)
+      {}
+
       runge_kutta_method             method;
       embedded_runge_kutta_time_step exit_delta_t;
       unsigned int                   n_iterations;

--- a/include/deal.II/base/time_stepping.templates.h
+++ b/include/deal.II/base/time_stepping.templates.h
@@ -27,6 +27,10 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace TimeStepping
 {
+  DeclExceptionMsg(ExcNoMethodSelected,
+                   "No method selected. You need to call initialize or pass a "
+                   "runge_kutta_method to the constructor.");
+
   // ----------------------------------------------------------------------
   // RungeKutta
   // ----------------------------------------------------------------------
@@ -198,6 +202,8 @@ namespace TimeStepping
     double                                                             delta_t,
     VectorType &                                                       y)
   {
+    Assert(status.method != runge_kutta_method::invalid, ExcNoMethodSelected());
+
     std::vector<VectorType> f_stages(this->n_stages, y);
     // Compute the different stages needed.
     compute_stages(f, t, delta_t, y, f_stages);
@@ -390,6 +396,8 @@ namespace TimeStepping
     VectorType &                                                       vec_ri,
     VectorType &                                                       vec_ki)
   {
+    Assert(status.method != runge_kutta_method::invalid, ExcNoMethodSelected());
+
     compute_one_stage(f,
                       t,
                       this->b[0] * delta_t,
@@ -566,6 +574,8 @@ namespace TimeStepping
     double                                               delta_t,
     VectorType &                                         y)
   {
+    Assert(status.method != runge_kutta_method::invalid, ExcNoMethodSelected());
+
     VectorType              old_y(y);
     std::vector<VectorType> f_stages(this->n_stages, y);
     // Compute the different stages needed.
@@ -996,6 +1006,8 @@ namespace TimeStepping
     double                                                             delta_t,
     VectorType &                                                       y)
   {
+    Assert(status.method != runge_kutta_method::invalid, ExcNoMethodSelected());
+
     bool                    done       = false;
     unsigned int            count      = 0;
     double                  error_norm = 0.;


### PR DESCRIPTION
If one does not pass a `runge_kutta_method` to the constructor of one of the `TimeStepping::*RungeKutta` classes and forgets to call the `initialize(..)`-function, the program crashes with a poor error message. Add asserts to get more descriptive error messages.