### PR TITLE
Silence warnings from Sacado in user projects.

### DIFF
--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -142,7 +142,9 @@ DEAL_II_NAMESPACE_CLOSE
 // import the whole Sacado header at this point to get the math
 // functions imported into the standard namespace.
 #ifdef DEAL_II_TRILINOS_WITH_SACADO
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Sacado.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #endif
 
 namespace std

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -28,6 +28,8 @@
 #include <utility>
 #include <vector>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+
 #ifdef DEAL_II_WITH_TRILINOS
 #  include <Epetra_Comm.h>
 #  include <Epetra_Map.h>
@@ -39,8 +41,6 @@
 #    include <Epetra_SerialComm.h>
 #  endif
 #endif
-
-DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/archive/binary_oarchive.hpp>


### PR DESCRIPTION
Without this I get a bunch of unused function argument warnings from Teuchos in a downstream project.