### PR TITLE
MGConstrainedDoFs::add_boundary_indices()

### DIFF
--- a/doc/news/changes/minor/20220502JiaqiZhang
+++ b/doc/news/changes/minor/20220502JiaqiZhang
@@ -1,0 +1,4 @@
+New: MGConstrainedDoFs now has a function add_boundary_indices()
+to add boundary indices on levels.
+<br>
+(Jiaqi Zhang, 2021/05/02)

--- a/include/deal.II/multigrid/mg_constrained_dofs.h
+++ b/include/deal.II/multigrid/mg_constrained_dofs.h
@@ -96,6 +96,18 @@ public:
     const ComponentMask &               component_mask = ComponentMask());
 
   /**
+   * Fill the internal data structures with information
+   * about Dirichlet boundary dofs on level @p level.
+   * The indices are restricted to the set of locally relevant
+   * level dofs.
+   */
+  template <int dim, int spacedim>
+  void
+  add_boundary_indices(const DoFHandler<dim, spacedim> &dof,
+                       const unsigned int               level,
+                       const IndexSet &                 boundary_indices);
+
+  /**
    * Add user defined constraints to be used on level @p level.
    *
    * The user can call this function multiple times and any new,
@@ -351,6 +363,25 @@ MGConstrainedDoFs::make_zero_boundary_constraints(
                               boundary_ids,
                               boundary_indices,
                               component_mask);
+}
+
+
+
+template <int dim, int spacedim>
+inline void
+MGConstrainedDoFs::add_boundary_indices(const DoFHandler<dim, spacedim> &dof,
+                                        const unsigned int               level,
+                                        const IndexSet &level_boundary_indices)
+{
+  const unsigned int n_levels = dof.get_triangulation().n_global_levels();
+  if (boundary_indices.size() == 0)
+    {
+      boundary_indices.resize(n_levels);
+      for (unsigned int i = 0; i < n_levels; ++i)
+        boundary_indices[i] = IndexSet(dof.n_dofs(i));
+    }
+  AssertDimension(boundary_indices.size(), n_levels);
+  boundary_indices[level].add_indices(level_boundary_indices);
 }
 
 

--- a/include/deal.II/multigrid/mg_constrained_dofs.h
+++ b/include/deal.II/multigrid/mg_constrained_dofs.h
@@ -96,8 +96,8 @@ public:
     const ComponentMask &               component_mask = ComponentMask());
 
   /**
-   * Fill the internal data structures with information
-   * about Dirichlet boundary dofs on level @p level.
+   * Add Dirichlet boundary dofs to the internal data structures
+   * on level @p level.
    * The indices are restricted to the set of locally relevant
    * level dofs.
    */

--- a/tests/multigrid/constrained_dofs_01.with_p4est=true.mpirun=1.output
+++ b/tests/multigrid/constrained_dofs_01.with_p4est=true.mpirun=1.output
@@ -32,3 +32,36 @@ DEAL:0::{[0,1], [4,5], 8}
 DEAL:0::relevant:
 DEAL:0::{[0,8]}
 DEAL:0::ok ok 
+DEAL:0::Test add_boundary_indices: 
+DEAL:0::Level 0:
+DEAL:0::get_boundary_indices test:
+DEAL:0::{[0,3]}
+DEAL:0::relevant:
+DEAL:0::{[0,3]}
+DEAL:0::ok 
+DEAL:0::Level 1:
+DEAL:0::get_boundary_indices test:
+DEAL:0::{[0,2], [4,8]}
+DEAL:0::relevant:
+DEAL:0::{[0,8]}
+DEAL:0::ok 
+DEAL:0::Level 2:
+DEAL:0::get_boundary_indices test:
+DEAL:0::{[0,2], 4, 6, 9, [11,12], [14,15], [18,20], [22,24]}
+DEAL:0::relevant:
+DEAL:0::{[0,24]}
+DEAL:0::ok 
+DEAL:0::Level 3:
+DEAL:0::get_boundary_indices test:
+DEAL:0::{[0,1], [4,5], 8}
+DEAL:0::relevant:
+DEAL:0::{[0,8]}
+DEAL:0::ok 
+DEAL:0::Level 0:
+DEAL:0::ok 
+DEAL:0::Level 1:
+DEAL:0::ok 
+DEAL:0::Level 2:
+DEAL:0::ok 
+DEAL:0::Level 3:
+DEAL:0::ok 

--- a/tests/multigrid/constrained_dofs_01.with_p4est=true.mpirun=3.output
+++ b/tests/multigrid/constrained_dofs_01.with_p4est=true.mpirun=3.output
@@ -32,6 +32,39 @@ DEAL:0::{[0,1]}
 DEAL:0::relevant:
 DEAL:0::{[0,3], [6,7]}
 DEAL:0::ok ok 
+DEAL:0::Test add_boundary_indices: 
+DEAL:0::Level 0:
+DEAL:0::get_boundary_indices test:
+DEAL:0::{[0,3]}
+DEAL:0::relevant:
+DEAL:0::{[0,3]}
+DEAL:0::ok 
+DEAL:0::Level 1:
+DEAL:0::get_boundary_indices test:
+DEAL:0::{[0,2], [4,8]}
+DEAL:0::relevant:
+DEAL:0::{[0,8]}
+DEAL:0::ok 
+DEAL:0::Level 2:
+DEAL:0::get_boundary_indices test:
+DEAL:0::{[0,2], 4, 6, 9, [11,12], [14,15]}
+DEAL:0::relevant:
+DEAL:0::{[0,17], 21}
+DEAL:0::ok 
+DEAL:0::Level 3:
+DEAL:0::get_boundary_indices test:
+DEAL:0::{[0,1]}
+DEAL:0::relevant:
+DEAL:0::{[0,3], [6,7]}
+DEAL:0::ok 
+DEAL:0::Level 0:
+DEAL:0::ok 
+DEAL:0::Level 1:
+DEAL:0::ok 
+DEAL:0::Level 2:
+DEAL:0::ok 
+DEAL:0::Level 3:
+DEAL:0::ok 
 
 DEAL:1::FE_Q<2>(1)
 DEAL:1::Level 0:
@@ -66,6 +99,39 @@ DEAL:1::{[0,1], [4,5], 8}
 DEAL:1::relevant:
 DEAL:1::{[0,8]}
 DEAL:1::ok ok 
+DEAL:1::Test add_boundary_indices: 
+DEAL:1::Level 0:
+DEAL:1::get_boundary_indices test:
+DEAL:1::{}
+DEAL:1::relevant:
+DEAL:1::{}
+DEAL:1::ok 
+DEAL:1::Level 1:
+DEAL:1::get_boundary_indices test:
+DEAL:1::{1, [4,5]}
+DEAL:1::relevant:
+DEAL:1::{1, [3,5]}
+DEAL:1::ok 
+DEAL:1::Level 2:
+DEAL:1::get_boundary_indices test:
+DEAL:1::{1, 4, 9, [11,12], 14, 22}
+DEAL:1::relevant:
+DEAL:1::{1, [3,5], [7,14], [16,17], [21,22]}
+DEAL:1::ok 
+DEAL:1::Level 3:
+DEAL:1::get_boundary_indices test:
+DEAL:1::{[0,1], [4,5], 8}
+DEAL:1::relevant:
+DEAL:1::{[0,8]}
+DEAL:1::ok 
+DEAL:1::Level 0:
+DEAL:1::ok 
+DEAL:1::Level 1:
+DEAL:1::ok 
+DEAL:1::Level 2:
+DEAL:1::ok 
+DEAL:1::Level 3:
+DEAL:1::ok 
 
 
 DEAL:2::FE_Q<2>(1)
@@ -101,4 +167,37 @@ DEAL:2::{}
 DEAL:2::relevant:
 DEAL:2::{}
 DEAL:2::ok ok 
+DEAL:2::Test add_boundary_indices: 
+DEAL:2::Level 0:
+DEAL:2::get_boundary_indices test:
+DEAL:2::{[0,3]}
+DEAL:2::relevant:
+DEAL:2::{[0,3]}
+DEAL:2::ok 
+DEAL:2::Level 1:
+DEAL:2::get_boundary_indices test:
+DEAL:2::{[0,2], [4,8]}
+DEAL:2::relevant:
+DEAL:2::{[0,8]}
+DEAL:2::ok 
+DEAL:2::Level 2:
+DEAL:2::get_boundary_indices test:
+DEAL:2::{2, 6, 12, [14,15], [18,20], [22,24]}
+DEAL:2::relevant:
+DEAL:2::{[2,3], [5,8], 10, [12,24]}
+DEAL:2::ok 
+DEAL:2::Level 3:
+DEAL:2::get_boundary_indices test:
+DEAL:2::{}
+DEAL:2::relevant:
+DEAL:2::{}
+DEAL:2::ok 
+DEAL:2::Level 0:
+DEAL:2::ok 
+DEAL:2::Level 1:
+DEAL:2::ok 
+DEAL:2::Level 2:
+DEAL:2::ok 
+DEAL:2::Level 3:
+DEAL:2::ok 
 


### PR DESCRIPTION
Add a function `MGConstrainedDoFs::add_boundary_indices() `to add Dirichlet boundary indices manually.
Ultimately we want to set all the constraints including level constraints in the `AffineConstraints` objects and then import them to `MGConstrainedDoFs`. @tjhei 