### PR TITLE
step-75: added link to external repository.

### DIFF
--- a/examples/step-75/doc/results.dox
+++ b/examples/step-75/doc/results.dox
@@ -118,6 +118,14 @@ to degree six:
 <a name="extensions"></a>
 <h3>Possibilities for extensions</h3>
 
+This tutorial shows only one particular way how to use parallel
+hp-adaptive finite element methods. In the following paragraphs, you
+will get to know which alternatives are possible. Most of these
+extensions are already part of https://github.com/marcfehling/hpbox/,
+which provides you with implementation examples that you can play
+around with.
+
+
 <h4>Different hp-decision strategies</h4>
 
 The deal.II library offers multiple strategies to decide which type of


### PR DESCRIPTION
In https://github.com/dealii/dealii/pull/11254#issuecomment-736174426, we agreed on publishing a larger hp-adaptive example in the code gallery in addition to step-75.

I feel like my side project became to big to be part of the code gallery. Instead, I would like to just add a link in step-75 to my repository instead.

step-67 does it in a similar fashion in the end of [this paragraph](https://www.dealii.org/developer/doxygen/deal.II/step_67.html#Moreadvancednumericalfluxfunctionsandskewsymmetricformulations).