### PR TITLE
Fix some problems with renumbering with no local DoFs

### DIFF
--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -2931,8 +2931,11 @@ namespace internal
         // independently, and then unifies some located at vertices or faces;
         // this leaves us with fewer DoFs than there were before, so use the
         // largest index as the one to determine the size of the index space
-        return NumberCache(
-          *std::max_element(new_numbers.begin(), new_numbers.end()) + 1);
+        if (new_numbers.size() == 0)
+          return NumberCache();
+        else
+          return NumberCache(
+            *std::max_element(new_numbers.begin(), new_numbers.end()) + 1);
       }
 
 

--- a/source/dofs/number_cache.cc
+++ b/source/dofs/number_cache.cc
@@ -28,8 +28,7 @@ namespace internal
   namespace DoFHandlerImplementation
   {
     NumberCache::NumberCache()
-      : n_global_dofs(0)
-      , n_locally_owned_dofs(0)
+      : NumberCache(0)
     {}
 
 

--- a/tests/fe/fe_nothing_02.cc
+++ b/tests/fe/fe_nothing_02.cc
@@ -1,0 +1,32 @@
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_renumbering.h>
+
+#include <deal.II/fe/fe_nothing.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include "../tests.h"
+
+// Verify that we can set up a mesh consisting entirely of FE_Nothing FEs. While
+// this by itself would be useless, its possible in other contexts to get
+// DoFHandlers with zero DoFs on them with uncommon parallel data distributions.
+// This previously crashed with a segmentation fault inside
+// DoFHandlerImplementation::Policy::Sequential::renumber_dofs().
+
+using namespace dealii;
+int
+main()
+{
+  initlog();
+
+  Triangulation<2> tria;
+  GridGenerator::hyper_cube(tria);
+  FE_Nothing<2> fe;
+  DoFHandler<2> dof_handler(tria);
+  dof_handler.distribute_dofs(fe);
+
+  deallog << "Number of DoFs = " << dof_handler.n_dofs() << std::endl;
+  DoFRenumbering::random(dof_handler);
+  deallog << "Number of DoFs = " << dof_handler.n_dofs() << std::endl;
+}

--- a/tests/fe/fe_nothing_02.output
+++ b/tests/fe/fe_nothing_02.output
@@ -1,0 +1,3 @@
+
+DEAL::Number of DoFs = 0
+DEAL::Number of DoFs = 0

--- a/tests/sharedtria/dof_04.cc
+++ b/tests/sharedtria/dof_04.cc
@@ -41,7 +41,7 @@
 
 template <int dim>
 void
-test()
+test(const unsigned int n_global_refinements)
 {
   parallel::shared::Triangulation<dim> triangulation(
     MPI_COMM_WORLD,
@@ -54,7 +54,7 @@ test()
   DoFHandler<dim> dof_handler(triangulation);
 
   GridGenerator::hyper_cube(triangulation);
-  triangulation.refine_global(2);
+  triangulation.refine_global(n_global_refinements);
 
   const unsigned int n_refinements[] = {0, 4, 3, 2};
   for (unsigned int i = 0; i < n_refinements[dim]; ++i)
@@ -158,11 +158,18 @@ main(int argc, char *argv[])
 
   MPILogInitAll all;
 
-  deallog.push("2d");
-  test<2>();
+  deallog.push("2d, no global refinements");
+  test<2>(0);
+  deallog.pop();
+
+  // To preserve output with an older version of this test reseed here:
+  Testing::srand(1);
+
+  deallog.push("2d, global refinements");
+  test<2>(2);
   deallog.pop();
 
   deallog.push("3d");
-  test<3>();
+  test<3>(2);
   deallog.pop();
 }

--- a/tests/sharedtria/dof_04.with_metis=true.mpirun=3.output
+++ b/tests/sharedtria/dof_04.with_metis=true.mpirun=3.output
@@ -1,20 +1,29 @@
 
-DEAL:0:2d::n_dofs: 818
-DEAL:0:2d::n_dofs: 1754
-DEAL:0:2d::n_dofs: 3056
+DEAL:0:2d, no global refinements::n_dofs: 114
+DEAL:0:2d, no global refinements::n_dofs: 272
+DEAL:0:2d, no global refinements::n_dofs: 652
+DEAL:0:2d, global refinements::n_dofs: 818
+DEAL:0:2d, global refinements::n_dofs: 1754
+DEAL:0:2d, global refinements::n_dofs: 3056
 DEAL:0:3d::n_dofs: 13282
 DEAL:0:3d::n_dofs: 41826
 
-DEAL:1:2d::n_dofs: 818
-DEAL:1:2d::n_dofs: 1754
-DEAL:1:2d::n_dofs: 3056
+DEAL:1:2d, no global refinements::n_dofs: 114
+DEAL:1:2d, no global refinements::n_dofs: 272
+DEAL:1:2d, no global refinements::n_dofs: 652
+DEAL:1:2d, global refinements::n_dofs: 818
+DEAL:1:2d, global refinements::n_dofs: 1754
+DEAL:1:2d, global refinements::n_dofs: 3056
 DEAL:1:3d::n_dofs: 13282
 DEAL:1:3d::n_dofs: 41826
 
 
-DEAL:2:2d::n_dofs: 818
-DEAL:2:2d::n_dofs: 1754
-DEAL:2:2d::n_dofs: 3056
+DEAL:2:2d, no global refinements::n_dofs: 114
+DEAL:2:2d, no global refinements::n_dofs: 272
+DEAL:2:2d, no global refinements::n_dofs: 652
+DEAL:2:2d, global refinements::n_dofs: 818
+DEAL:2:2d, global refinements::n_dofs: 1754
+DEAL:2:2d, global refinements::n_dofs: 3056
 DEAL:2:3d::n_dofs: 13282
 DEAL:2:3d::n_dofs: 41826
 


### PR DESCRIPTION
This PR contains two DoF renumbering bugfixes. In both cases we would crash when some processors had no degrees of freedom on them. I fixed both and added a test (and augmented an existing test for the second bug).