### PR TITLE
Non-affine Piola and hanging nodes support for matrix-free RT

### DIFF
--- a/include/deal.II/matrix_free/mapping_info.h
+++ b/include/deal.II/matrix_free/mapping_info.h
@@ -74,7 +74,8 @@ namespace internal
         const UpdateFlags update_flags_cells,
         const UpdateFlags update_flags_boundary_faces,
         const UpdateFlags update_flags_inner_faces,
-        const UpdateFlags update_flags_faces_by_cells);
+        const UpdateFlags update_flags_faces_by_cells,
+        const bool        piola_transform = false);
 
       /**
        * Update the information in the given cells and faces that is the

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -68,7 +68,8 @@ namespace internal
       const UpdateFlags update_flags_cells,
       const UpdateFlags update_flags_boundary_faces,
       const UpdateFlags update_flags_inner_faces,
-      const UpdateFlags update_flags_faces_by_cells)
+      const UpdateFlags update_flags_faces_by_cells,
+      const bool        piola_transform)
     {
       clear();
       this->mapping_collection = mapping;
@@ -85,15 +86,18 @@ namespace internal
       // the mapping that are independent of the FE
       this->update_flags_cells =
         MappingInfoStorage<dim, dim, VectorizedArrayType>::compute_update_flags(
-          update_flags_cells, quad);
+          update_flags_cells, quad, piola_transform);
 
       this->update_flags_boundary_faces =
         ((update_flags_inner_faces | update_flags_boundary_faces) &
              update_quadrature_points ?
            update_quadrature_points :
            update_default) |
-        (((update_flags_inner_faces | update_flags_boundary_faces) &
-          (update_jacobian_grads | update_hessians)) != 0u ?
+        ((((update_flags_inner_faces | update_flags_boundary_faces) &
+           (update_jacobian_grads | update_hessians)) != 0u ||
+          (piola_transform &&
+           ((update_flags_inner_faces | update_flags_boundary_faces) &
+            update_gradients) != 0u)) ?
            update_jacobian_grads :
            update_default) |
         update_normal_vectors | update_JxW_values | update_jacobians;

--- a/include/deal.II/matrix_free/mapping_info_storage.h
+++ b/include/deal.II/matrix_free/mapping_info_storage.h
@@ -330,7 +330,8 @@ namespace internal
       compute_update_flags(
         const UpdateFlags                                     update_flags,
         const std::vector<dealii::hp::QCollection<spacedim>> &quads =
-          std::vector<dealii::hp::QCollection<spacedim>>());
+          std::vector<dealii::hp::QCollection<spacedim>>(),
+        const bool piola_transform = false);
 
       /**
        * Prints a detailed summary of memory consumption in the different

--- a/include/deal.II/matrix_free/mapping_info_storage.h
+++ b/include/deal.II/matrix_free/mapping_info_storage.h
@@ -260,6 +260,27 @@ namespace internal
         jacobian_gradients;
 
       /**
+       * The storage of the gradients of the Jacobian transformation. Because of
+       * symmetry, only the upper diagonal and diagonal part are needed. The
+       * first index runs through the derivatives, starting with the diagonal
+       * and then continuing row-wise, i.e., $\partial^2/\partial x_1 \partial
+       * x_2$ first, then
+       * $\partial^2/\partial x_1 \partial x_3$, and so on. The second index
+       * is the spatial coordinate.
+       *
+       * Indexed by @p data_index_offsets.
+       *
+       * Contains two fields for access from both sides for interior faces,
+       * but the default case (cell integrals or boundary integrals) only
+       * fills the zeroth component and ignores the first one.
+       */
+      std::array<
+        AlignedVector<
+          Tensor<1, spacedim *(spacedim + 1) / 2, Tensor<1, spacedim, Number>>>,
+        2>
+        jacobian_gradients_non_inverse;
+
+      /**
        * Stores the Jacobian transformations times the normal vector (this
        * represents a shortcut that is accessed often and can thus get higher
        * performance).

--- a/include/deal.II/matrix_free/mapping_info_storage.templates.h
+++ b/include/deal.II/matrix_free/mapping_info_storage.templates.h
@@ -125,7 +125,8 @@ namespace internal
     UpdateFlags
     MappingInfoStorage<structdim, spacedim, Number>::compute_update_flags(
       const UpdateFlags                                     update_flags,
-      const std::vector<dealii::hp::QCollection<spacedim>> &quads)
+      const std::vector<dealii::hp::QCollection<spacedim>> &quads,
+      const bool                                            piola_transform)
     {
       // this class is build around the evaluation of jacobians, so compute
       // them in any case. The Jacobians will be inverted manually. Since we
@@ -136,7 +137,8 @@ namespace internal
       // Jacobians (these two together will give use the gradients of the
       // inverse Jacobians, which is what we need)
       if ((update_flags & update_hessians) != 0u ||
-          (update_flags & update_jacobian_grads) != 0u)
+          (update_flags & update_jacobian_grads) != 0u ||
+          (piola_transform && (update_flags & update_gradients) != 0u))
         new_flags |= update_jacobian_grads;
 
       if ((update_flags & update_quadrature_points) != 0u)

--- a/include/deal.II/matrix_free/mapping_info_storage.templates.h
+++ b/include/deal.II/matrix_free/mapping_info_storage.templates.h
@@ -112,6 +112,7 @@ namespace internal
         {
           jacobians[i].clear();
           jacobian_gradients[i].clear();
+          jacobian_gradients_non_inverse[i].clear();
           normals_times_jacobians[i].clear();
         }
       quadrature_point_offsets.clear();
@@ -179,6 +180,10 @@ namespace internal
              MemoryConsumption::memory_consumption(jacobians[1]) +
              MemoryConsumption::memory_consumption(jacobian_gradients[0]) +
              MemoryConsumption::memory_consumption(jacobian_gradients[1]) +
+             MemoryConsumption::memory_consumption(
+               jacobian_gradients_non_inverse[0]) +
+             MemoryConsumption::memory_consumption(
+               jacobian_gradients_non_inverse[1]) +
              MemoryConsumption::memory_consumption(normals_times_jacobians[0]) +
              MemoryConsumption::memory_consumption(normals_times_jacobians[1]) +
              MemoryConsumption::memory_consumption(quadrature_point_offsets) +
@@ -214,7 +219,11 @@ namespace internal
           task_info.print_memory_statistics(
             out,
             MemoryConsumption::memory_consumption(jacobian_gradients[0]) +
-              MemoryConsumption::memory_consumption(jacobian_gradients[1]));
+              MemoryConsumption::memory_consumption(jacobian_gradients[1]) +
+              MemoryConsumption::memory_consumption(
+                jacobian_gradients_non_inverse[0]) +
+              MemoryConsumption::memory_consumption(
+                jacobian_gradients_non_inverse[1]));
         }
       const std::size_t normal_size =
         Utilities::MPI::sum(normal_vectors.size(), task_info.communicator);

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -35,6 +35,7 @@
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_poly.h>
 #include <deal.II/fe/fe_q_dg0.h>
+#include <deal.II/fe/fe_raviart_thomas.h>
 
 #include <deal.II/hp/q_collection.h>
 
@@ -809,6 +810,23 @@ MatrixFree<dim, Number, VectorizedArrayType>::internal_reinit(
             }
         }
 
+      // Will the piola transform be used? If so we need to update
+      // the jacobian gradients in case of update_gradients on general cells.
+      bool piola_transform = false;
+      for (unsigned int no = 0, c = 0; no < dof_handler.size(); ++no)
+        for (unsigned int b = 0;
+             b < dof_handler[no]->get_fe(0).n_base_elements();
+             ++b, ++c)
+          for (unsigned int fe_no = 0;
+               fe_no < dof_handler[no]->get_fe_collection().size();
+               ++fe_no)
+            for (unsigned int nq = 0; nq < quad.size(); ++nq)
+              for (unsigned int q_no = 0; q_no < quad[nq].size(); ++q_no)
+                if (shape_info(c, nq, fe_no, q_no).element_type ==
+                    internal::MatrixFreeFunctions::ElementType::
+                      tensor_raviart_thomas)
+                  piola_transform = true;
+
       mapping_info.initialize(
         dof_handler[0]->get_triangulation(),
         cell_level_index,
@@ -821,7 +839,8 @@ MatrixFree<dim, Number, VectorizedArrayType>::internal_reinit(
         additional_data.mapping_update_flags,
         additional_data.mapping_update_flags_boundary_faces,
         additional_data.mapping_update_flags_inner_faces,
-        additional_data.mapping_update_flags_faces_by_cells);
+        additional_data.mapping_update_flags_faces_by_cells,
+        piola_transform);
 
       mapping_is_initialized = true;
     }

--- a/tests/matrix_free/matrix_vector_rt_01.output
+++ b/tests/matrix_free/matrix_vector_rt_01.output
@@ -4,62 +4,50 @@ DEAL:2d::Number of cells: 16
 DEAL:2d::Number of degrees of freedom: 144
 DEAL:2d::
 DEAL:2d::Testing Values 
-DEAL:2d::Norm of solution: 16.5132
-DEAL:2d::Norm of difference: 3.63536e-15
+DEAL:2d::Norm of difference: 2.61453e-15
 DEAL:2d::
 DEAL:2d::Testing Gradients 
-DEAL:2d::Norm of solution: 132.862
-DEAL:2d::Norm of difference: 1.55640e-14
+DEAL:2d::Norm of difference: 6.23772e-15
 DEAL:2d::
 DEAL:2d::Testing Divergence 
-DEAL:2d::Norm of solution: 119.010
-DEAL:2d::Norm of difference: 5.11308e-15
+DEAL:2d::Norm of difference: 3.80204e-15
 DEAL:2d::
 DEAL:2d::Using FE_RaviartThomasNodal<2>(2)
 DEAL:2d::Number of cells: 16
 DEAL:2d::Number of degrees of freedom: 312
 DEAL:2d::
 DEAL:2d::Testing Values 
-DEAL:2d::Norm of solution: 14.0918
-DEAL:2d::Norm of difference: 1.43100e-14
+DEAL:2d::Norm of difference: 7.43226e-15
 DEAL:2d::
 DEAL:2d::Testing Gradients 
-DEAL:2d::Norm of solution: 325.637
-DEAL:2d::Norm of difference: 1.18579e-14
+DEAL:2d::Norm of difference: 1.08102e-14
 DEAL:2d::
 DEAL:2d::Testing Divergence 
-DEAL:2d::Norm of solution: 265.508
-DEAL:2d::Norm of difference: 7.83102e-15
+DEAL:2d::Norm of difference: 2.64297e-15
 DEAL:2d::
 DEAL:3d::Using FE_RaviartThomasNodal<3>(1)
 DEAL:3d::Number of cells: 64
 DEAL:3d::Number of degrees of freedom: 1728
 DEAL:3d::
 DEAL:3d::Testing Values 
-DEAL:3d::Norm of solution: 104.458
-DEAL:3d::Norm of difference: 4.66178e-15
+DEAL:3d::Norm of difference: 4.39080e-15
 DEAL:3d::
 DEAL:3d::Testing Gradients 
-DEAL:3d::Norm of solution: 739.015
-DEAL:3d::Norm of difference: 3.41121e-14
+DEAL:3d::Norm of difference: 1.34515e-14
 DEAL:3d::
 DEAL:3d::Testing Divergence 
-DEAL:3d::Norm of solution: 715.240
-DEAL:3d::Norm of difference: 5.75164e-15
+DEAL:3d::Norm of difference: 5.97286e-15
 DEAL:3d::
 DEAL:3d::Using FE_RaviartThomasNodal<3>(2)
 DEAL:3d::Number of cells: 64
 DEAL:3d::Number of degrees of freedom: 5616
 DEAL:3d::
 DEAL:3d::Testing Values 
-DEAL:3d::Norm of solution: 90.0432
-DEAL:3d::Norm of difference: 8.73551e-15
+DEAL:3d::Norm of difference: 6.20876e-15
 DEAL:3d::
 DEAL:3d::Testing Gradients 
-DEAL:3d::Norm of solution: 2248.46
-DEAL:3d::Norm of difference: 1.49298e-14
+DEAL:3d::Norm of difference: 1.81453e-14
 DEAL:3d::
 DEAL:3d::Testing Divergence 
-DEAL:3d::Norm of solution: 1814.05
-DEAL:3d::Norm of difference: 7.35099e-15
+DEAL:3d::Norm of difference: 6.56897e-15
 DEAL:3d::

--- a/tests/matrix_free/matrix_vector_rt_02.output
+++ b/tests/matrix_free/matrix_vector_rt_02.output
@@ -4,38 +4,46 @@ DEAL:2d::Number of cells: 4
 DEAL:2d::Number of degrees of freedom: 40
 DEAL:2d::
 DEAL:2d::Testing Values and Gradients 
-DEAL:2d::Norm of difference: 3.77395e-16
+DEAL:2d::Norm of solution: 85.6311
+DEAL:2d::Norm of difference: 7.45355e-15
 DEAL:2d::
 DEAL:2d::Testing Divergence 
-DEAL:2d::Norm of difference: 7.00345e-16
+DEAL:2d::Norm of solution: 40.3104
+DEAL:2d::Norm of difference: 3.85190e-15
 DEAL:2d::
 DEAL:2d::Using FE_RaviartThomasNodal<2>(2)
 DEAL:2d::Number of cells: 4
 DEAL:2d::Number of degrees of freedom: 84
 DEAL:2d::
 DEAL:2d::Testing Values and Gradients 
-DEAL:2d::Norm of difference: 7.63491e-16
+DEAL:2d::Norm of solution: 201.410
+DEAL:2d::Norm of difference: 9.95265e-15
 DEAL:2d::
 DEAL:2d::Testing Divergence 
-DEAL:2d::Norm of difference: 7.46533e-16
+DEAL:2d::Norm of solution: 59.9827
+DEAL:2d::Norm of difference: 4.62851e-15
 DEAL:2d::
 DEAL:3d::Using FE_RaviartThomasNodal<3>(1)
 DEAL:3d::Number of cells: 8
 DEAL:3d::Number of degrees of freedom: 240
 DEAL:3d::
 DEAL:3d::Testing Values and Gradients 
-DEAL:3d::Norm of difference: 1.22886e-15
+DEAL:3d::Norm of solution: 55.5428
+DEAL:3d::Norm of difference: 1.93546e-14
 DEAL:3d::
 DEAL:3d::Testing Divergence 
-DEAL:3d::Norm of difference: 1.16405e-15
+DEAL:3d::Norm of solution: 26.6731
+DEAL:3d::Norm of difference: 9.31239e-15
 DEAL:3d::
 DEAL:3d::Using FE_RaviartThomasNodal<3>(2)
 DEAL:3d::Number of cells: 8
 DEAL:3d::Number of degrees of freedom: 756
 DEAL:3d::
 DEAL:3d::Testing Values and Gradients 
-DEAL:3d::Norm of difference: 2.06049e-15
+DEAL:3d::Norm of solution: 148.661
+DEAL:3d::Norm of difference: 1.58875e-14
 DEAL:3d::
 DEAL:3d::Testing Divergence 
-DEAL:3d::Norm of difference: 1.23490e-15
+DEAL:3d::Norm of solution: 84.7257
+DEAL:3d::Norm of difference: 8.95306e-15
 DEAL:3d::

--- a/tests/matrix_free/matrix_vector_rt_02.output
+++ b/tests/matrix_free/matrix_vector_rt_02.output
@@ -4,46 +4,38 @@ DEAL:2d::Number of cells: 4
 DEAL:2d::Number of degrees of freedom: 40
 DEAL:2d::
 DEAL:2d::Testing Values and Gradients 
-DEAL:2d::Norm of solution: 85.6311
-DEAL:2d::Norm of difference: 7.45355e-15
+DEAL:2d::Norm of difference: 4.65353e-15
 DEAL:2d::
 DEAL:2d::Testing Divergence 
-DEAL:2d::Norm of solution: 40.3104
-DEAL:2d::Norm of difference: 3.85190e-15
+DEAL:2d::Norm of difference: 1.63414e-15
 DEAL:2d::
 DEAL:2d::Using FE_RaviartThomasNodal<2>(2)
 DEAL:2d::Number of cells: 4
 DEAL:2d::Number of degrees of freedom: 84
 DEAL:2d::
 DEAL:2d::Testing Values and Gradients 
-DEAL:2d::Norm of solution: 201.410
-DEAL:2d::Norm of difference: 9.95265e-15
+DEAL:2d::Norm of difference: 1.31449e-14
 DEAL:2d::
 DEAL:2d::Testing Divergence 
-DEAL:2d::Norm of solution: 59.9827
-DEAL:2d::Norm of difference: 4.62851e-15
+DEAL:2d::Norm of difference: 2.68752e-15
 DEAL:2d::
 DEAL:3d::Using FE_RaviartThomasNodal<3>(1)
 DEAL:3d::Number of cells: 8
 DEAL:3d::Number of degrees of freedom: 240
 DEAL:3d::
 DEAL:3d::Testing Values and Gradients 
-DEAL:3d::Norm of solution: 55.5428
-DEAL:3d::Norm of difference: 1.93546e-14
+DEAL:3d::Norm of difference: 1.07664e-14
 DEAL:3d::
 DEAL:3d::Testing Divergence 
-DEAL:3d::Norm of solution: 26.6731
-DEAL:3d::Norm of difference: 9.31239e-15
+DEAL:3d::Norm of difference: 6.56100e-15
 DEAL:3d::
 DEAL:3d::Using FE_RaviartThomasNodal<3>(2)
 DEAL:3d::Number of cells: 8
 DEAL:3d::Number of degrees of freedom: 756
 DEAL:3d::
 DEAL:3d::Testing Values and Gradients 
-DEAL:3d::Norm of solution: 148.661
-DEAL:3d::Norm of difference: 1.58875e-14
+DEAL:3d::Norm of difference: 1.12673e-14
 DEAL:3d::
 DEAL:3d::Testing Divergence 
-DEAL:3d::Norm of solution: 84.7257
-DEAL:3d::Norm of difference: 8.95306e-15
+DEAL:3d::Norm of difference: 7.10070e-15
 DEAL:3d::

--- a/tests/matrix_free/matrix_vector_rt_03.cc
+++ b/tests/matrix_free/matrix_vector_rt_03.cc
@@ -1,0 +1,74 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// This test is the same as matrix_vector_rt_01.cc but with hanging nodes.
+
+#include <deal.II/dofs/dof_tools.h>
+
+#include "../tests.h"
+
+#include "matrix_vector_rt_common.h"
+
+
+template <int dim, int fe_degree>
+void
+test()
+{
+  Triangulation<dim> tria;
+  GridGenerator::hyper_cube(tria);
+  if (dim < 3 || fe_degree < 2)
+    tria.refine_global(2);
+  else
+    tria.refine_global(1);
+  typename Triangulation<dim>::active_cell_iterator cell, endc;
+  cell = tria.begin_active(), endc = tria.end();
+  for (; cell != endc; ++cell)
+    if (cell->center().norm() < 1e-8)
+      cell->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  cell = tria.begin_active();
+  for (; cell != endc; ++cell)
+    if (cell->center().norm() < 0.2)
+      cell->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  tria.begin(tria.n_levels() - 1)->set_refine_flag();
+  tria.last()->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  cell = tria.begin_active();
+  for (unsigned int i = 0; i < 10 - 3 * dim; ++i)
+    {
+      cell                 = tria.begin_active();
+      unsigned int counter = 0;
+      for (; cell != endc; ++cell, ++counter)
+        if (counter % (7 - i) == 0)
+          cell->set_refine_flag();
+      tria.execute_coarsening_and_refinement();
+    }
+
+  FE_RaviartThomasNodal<dim> fe(fe_degree - 1);
+  DoFHandler<dim>            dof(tria);
+  dof.distribute_dofs(fe);
+
+  AffineConstraints<double> constraints;
+  DoFTools::make_hanging_node_constraints(dof, constraints);
+  constraints.close();
+
+  deallog << "Using " << dof.get_fe().get_name() << std::endl;
+  deallog << "Number of cells: " << dof.get_triangulation().n_active_cells()
+          << std::endl;
+  deallog << "Number of degrees of freedom: " << dof.n_dofs() << std::endl
+          << std::endl;
+  do_test<dim, fe_degree, double>(dof, constraints, TestType::values_gradients);
+}

--- a/tests/matrix_free/matrix_vector_rt_03.output
+++ b/tests/matrix_free/matrix_vector_rt_03.output
@@ -1,0 +1,33 @@
+
+DEAL:2d::Using FE_RaviartThomasNodal<2>(1)
+DEAL:2d::Number of cells: 481
+DEAL:2d::Number of degrees of freedom: 4548
+DEAL:2d::
+DEAL:2d::Testing Values and Gradients 
+DEAL:2d::Norm of solution: 427113.
+DEAL:2d::Norm of difference: 2.41516e-13
+DEAL:2d::
+DEAL:2d::Using FE_RaviartThomasNodal<2>(2)
+DEAL:2d::Number of cells: 481
+DEAL:2d::Number of degrees of freedom: 9708
+DEAL:2d::
+DEAL:2d::Testing Values and Gradients 
+DEAL:2d::Norm of solution: 889452.
+DEAL:2d::Norm of difference: 4.92892e-13
+DEAL:2d::
+DEAL:3d::Using FE_RaviartThomasNodal<3>(1)
+DEAL:3d::Number of cells: 85
+DEAL:3d::Number of degrees of freedom: 2392
+DEAL:3d::
+DEAL:3d::Testing Values and Gradients 
+DEAL:3d::Norm of solution: 3720.90
+DEAL:3d::Norm of difference: 3.54795e-14
+DEAL:3d::
+DEAL:3d::Using FE_RaviartThomasNodal<3>(2)
+DEAL:3d::Number of cells: 85
+DEAL:3d::Number of degrees of freedom: 7677
+DEAL:3d::
+DEAL:3d::Testing Values and Gradients 
+DEAL:3d::Norm of solution: 12162.3
+DEAL:3d::Norm of difference: 3.09696e-14
+DEAL:3d::

--- a/tests/matrix_free/matrix_vector_rt_03.output
+++ b/tests/matrix_free/matrix_vector_rt_03.output
@@ -4,30 +4,26 @@ DEAL:2d::Number of cells: 481
 DEAL:2d::Number of degrees of freedom: 4548
 DEAL:2d::
 DEAL:2d::Testing Values and Gradients 
-DEAL:2d::Norm of solution: 427113.
-DEAL:2d::Norm of difference: 2.41516e-13
+DEAL:2d::Norm of difference: 1.13503e-13
 DEAL:2d::
 DEAL:2d::Using FE_RaviartThomasNodal<2>(2)
 DEAL:2d::Number of cells: 481
 DEAL:2d::Number of degrees of freedom: 9708
 DEAL:2d::
 DEAL:2d::Testing Values and Gradients 
-DEAL:2d::Norm of solution: 889452.
-DEAL:2d::Norm of difference: 4.92892e-13
+DEAL:2d::Norm of difference: 2.05175e-13
 DEAL:2d::
 DEAL:3d::Using FE_RaviartThomasNodal<3>(1)
 DEAL:3d::Number of cells: 85
 DEAL:3d::Number of degrees of freedom: 2392
 DEAL:3d::
 DEAL:3d::Testing Values and Gradients 
-DEAL:3d::Norm of solution: 3720.90
-DEAL:3d::Norm of difference: 3.54795e-14
+DEAL:3d::Norm of difference: 1.98105e-14
 DEAL:3d::
 DEAL:3d::Using FE_RaviartThomasNodal<3>(2)
 DEAL:3d::Number of cells: 85
 DEAL:3d::Number of degrees of freedom: 7677
 DEAL:3d::
 DEAL:3d::Testing Values and Gradients 
-DEAL:3d::Norm of solution: 12162.3
-DEAL:3d::Norm of difference: 3.09696e-14
+DEAL:3d::Norm of difference: 3.46605e-14
 DEAL:3d::

--- a/tests/matrix_free/matrix_vector_rt_04.cc
+++ b/tests/matrix_free/matrix_vector_rt_04.cc
@@ -1,0 +1,172 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// This test is the same as matrix_vector_rt_01.cc but with non-affine cells in
+// standard orientation.
+
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/grid/manifold_lib.h>
+
+#include "../tests.h"
+
+#include "matrix_vector_rt_common.h"
+
+// This class is taken from
+// https://github.com/exadg/exadg/blob/master/include/exadg/grid/deformed_cube_manifold.h
+template <int dim>
+class DeformedCubeManifold : public dealii::ChartManifold<dim, dim, dim>
+{
+public:
+  DeformedCubeManifold(double const       left,
+                       double const       right,
+                       double const       deformation,
+                       unsigned int const frequency = 1)
+    : left(left)
+    , right(right)
+    , deformation(deformation)
+    , frequency(frequency)
+  {}
+
+  dealii::Point<dim>
+  push_forward(dealii::Point<dim> const &chart_point) const override
+  {
+    double sinval = deformation;
+    for (unsigned int d = 0; d < dim; ++d)
+      sinval *= std::sin(frequency * dealii::numbers::PI *
+                         (chart_point(d) - left) / (right - left));
+    dealii::Point<dim> space_point;
+    for (unsigned int d = 0; d < dim; ++d)
+      space_point(d) = chart_point(d) + sinval;
+    return space_point;
+  }
+
+  dealii::Point<dim>
+  pull_back(dealii::Point<dim> const &space_point) const override
+  {
+    dealii::Point<dim> x = space_point;
+    dealii::Point<dim> one;
+    for (unsigned int d = 0; d < dim; ++d)
+      one(d) = 1.;
+
+    // Newton iteration to solve the nonlinear equation given by the point
+    dealii::Tensor<1, dim> sinvals;
+    for (unsigned int d = 0; d < dim; ++d)
+      sinvals[d] = std::sin(frequency * dealii::numbers::PI * (x(d) - left) /
+                            (right - left));
+
+    double sinval = deformation;
+    for (unsigned int d = 0; d < dim; ++d)
+      sinval *= sinvals[d];
+    dealii::Tensor<1, dim> residual = space_point - x - sinval * one;
+    unsigned int           its      = 0;
+    while (residual.norm() > 1e-12 && its < 100)
+      {
+        dealii::Tensor<2, dim> jacobian;
+        for (unsigned int d = 0; d < dim; ++d)
+          jacobian[d][d] = 1.;
+        for (unsigned int d = 0; d < dim; ++d)
+          {
+            double sinval_der = deformation * frequency / (right - left) *
+                                dealii::numbers::PI *
+                                std::cos(frequency * dealii::numbers::PI *
+                                         (x(d) - left) / (right - left));
+            for (unsigned int e = 0; e < dim; ++e)
+              if (e != d)
+                sinval_der *= sinvals[e];
+            for (unsigned int e = 0; e < dim; ++e)
+              jacobian[e][d] += sinval_der;
+          }
+
+        x += invert(jacobian) * residual;
+
+        for (unsigned int d = 0; d < dim; ++d)
+          sinvals[d] = std::sin(frequency * dealii::numbers::PI *
+                                (x(d) - left) / (right - left));
+
+        sinval = deformation;
+        for (unsigned int d = 0; d < dim; ++d)
+          sinval *= sinvals[d];
+        residual = space_point - x - sinval * one;
+        ++its;
+      }
+    AssertThrow(residual.norm() < 1e-12,
+                dealii::ExcMessage("Newton for point did not converge."));
+    return x;
+  }
+
+  std::unique_ptr<dealii::Manifold<dim>>
+  clone() const override
+  {
+    return std::make_unique<DeformedCubeManifold<dim>>(left,
+                                                       right,
+                                                       deformation,
+                                                       frequency);
+  }
+
+private:
+  double const       left;
+  double const       right;
+  double const       deformation;
+  unsigned int const frequency;
+};
+
+template <int dim, int fe_degree>
+void
+test()
+{
+  Triangulation<dim> tria;
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(2);
+  unsigned int const               frequency   = 2;
+  double const                     deformation = 0.05;
+  static DeformedCubeManifold<dim> manifold(0.0, 1.0, deformation, frequency);
+  tria.set_all_manifold_ids(1);
+  tria.set_manifold(1, manifold);
+
+  std::vector<bool> vertex_touched(tria.n_vertices(), false);
+
+  for (auto cell : tria.cell_iterators())
+    {
+      for (auto const &v : cell->vertex_indices())
+        {
+          if (vertex_touched[cell->vertex_index(v)] == false)
+            {
+              Point<dim> &vertex    = cell->vertex(v);
+              Point<dim>  new_point = manifold.push_forward(vertex);
+              vertex                = new_point;
+              vertex_touched[cell->vertex_index(v)] = true;
+            }
+        }
+    }
+
+
+  FE_RaviartThomasNodal<dim> fe(fe_degree - 1);
+  DoFHandler<dim>            dof(tria);
+  dof.distribute_dofs(fe);
+
+  AffineConstraints<double> constraints;
+  DoFTools::make_hanging_node_constraints(dof, constraints);
+  constraints.close();
+
+  deallog << "Using " << dof.get_fe().get_name() << std::endl;
+  deallog << "Number of cells: " << dof.get_triangulation().n_active_cells()
+          << std::endl;
+  deallog << "Number of degrees of freedom: " << dof.n_dofs() << std::endl
+          << std::endl;
+  do_test<dim, fe_degree, double>(dof, constraints, TestType::values);
+  do_test<dim, fe_degree, double>(dof, constraints, TestType::gradients);
+  do_test<dim, fe_degree, double>(dof, constraints, TestType::divergence);
+}

--- a/tests/matrix_free/matrix_vector_rt_04.output
+++ b/tests/matrix_free/matrix_vector_rt_04.output
@@ -4,62 +4,62 @@ DEAL:2d::Number of cells: 16
 DEAL:2d::Number of degrees of freedom: 144
 DEAL:2d::
 DEAL:2d::Testing Values 
-DEAL:2d::Norm of solution: 16.5132
-DEAL:2d::Norm of difference: 3.63536e-15
+DEAL:2d::Norm of solution: 17.4924
+DEAL:2d::Norm of difference: 1.15823e-15
 DEAL:2d::
 DEAL:2d::Testing Gradients 
-DEAL:2d::Norm of solution: 132.862
-DEAL:2d::Norm of difference: 1.55640e-14
+DEAL:2d::Norm of solution: 153.376
+DEAL:2d::Norm of difference: 1.16732e-14
 DEAL:2d::
 DEAL:2d::Testing Divergence 
-DEAL:2d::Norm of solution: 119.010
-DEAL:2d::Norm of difference: 5.11308e-15
+DEAL:2d::Norm of solution: 131.432
+DEAL:2d::Norm of difference: 2.12696e-15
 DEAL:2d::
 DEAL:2d::Using FE_RaviartThomasNodal<2>(2)
 DEAL:2d::Number of cells: 16
 DEAL:2d::Number of degrees of freedom: 312
 DEAL:2d::
 DEAL:2d::Testing Values 
-DEAL:2d::Norm of solution: 14.0918
-DEAL:2d::Norm of difference: 1.43100e-14
+DEAL:2d::Norm of solution: 14.1243
+DEAL:2d::Norm of difference: 1.57831e-15
 DEAL:2d::
 DEAL:2d::Testing Gradients 
-DEAL:2d::Norm of solution: 325.637
-DEAL:2d::Norm of difference: 1.18579e-14
+DEAL:2d::Norm of solution: 412.757
+DEAL:2d::Norm of difference: 7.38344e-15
 DEAL:2d::
 DEAL:2d::Testing Divergence 
-DEAL:2d::Norm of solution: 265.508
-DEAL:2d::Norm of difference: 7.83102e-15
+DEAL:2d::Norm of solution: 301.315
+DEAL:2d::Norm of difference: 1.72185e-15
 DEAL:2d::
 DEAL:3d::Using FE_RaviartThomasNodal<3>(1)
 DEAL:3d::Number of cells: 64
 DEAL:3d::Number of degrees of freedom: 1728
 DEAL:3d::
 DEAL:3d::Testing Values 
-DEAL:3d::Norm of solution: 104.458
-DEAL:3d::Norm of difference: 4.66178e-15
+DEAL:3d::Norm of solution: 108.138
+DEAL:3d::Norm of difference: 2.41040e-15
 DEAL:3d::
 DEAL:3d::Testing Gradients 
-DEAL:3d::Norm of solution: 739.015
-DEAL:3d::Norm of difference: 3.41121e-14
+DEAL:3d::Norm of solution: 860.089
+DEAL:3d::Norm of difference: 2.34828e-14
 DEAL:3d::
 DEAL:3d::Testing Divergence 
-DEAL:3d::Norm of solution: 715.240
-DEAL:3d::Norm of difference: 5.75164e-15
+DEAL:3d::Norm of solution: 744.376
+DEAL:3d::Norm of difference: 1.84582e-15
 DEAL:3d::
 DEAL:3d::Using FE_RaviartThomasNodal<3>(2)
 DEAL:3d::Number of cells: 64
 DEAL:3d::Number of degrees of freedom: 5616
 DEAL:3d::
 DEAL:3d::Testing Values 
-DEAL:3d::Norm of solution: 90.0432
-DEAL:3d::Norm of difference: 8.73551e-15
+DEAL:3d::Norm of solution: 92.6632
+DEAL:3d::Norm of difference: 4.09020e-15
 DEAL:3d::
 DEAL:3d::Testing Gradients 
-DEAL:3d::Norm of solution: 2248.46
-DEAL:3d::Norm of difference: 1.49298e-14
+DEAL:3d::Norm of solution: 2642.78
+DEAL:3d::Norm of difference: 1.87917e-14
 DEAL:3d::
 DEAL:3d::Testing Divergence 
-DEAL:3d::Norm of solution: 1814.05
-DEAL:3d::Norm of difference: 7.35099e-15
+DEAL:3d::Norm of solution: 1915.34
+DEAL:3d::Norm of difference: 8.84232e-15
 DEAL:3d::

--- a/tests/matrix_free/matrix_vector_rt_04.output
+++ b/tests/matrix_free/matrix_vector_rt_04.output
@@ -4,62 +4,50 @@ DEAL:2d::Number of cells: 16
 DEAL:2d::Number of degrees of freedom: 144
 DEAL:2d::
 DEAL:2d::Testing Values 
-DEAL:2d::Norm of solution: 17.4924
-DEAL:2d::Norm of difference: 1.15823e-15
+DEAL:2d::Norm of difference: 2.32427e-15
 DEAL:2d::
 DEAL:2d::Testing Gradients 
-DEAL:2d::Norm of solution: 153.376
-DEAL:2d::Norm of difference: 1.16732e-14
+DEAL:2d::Norm of difference: 1.00134e-14
 DEAL:2d::
 DEAL:2d::Testing Divergence 
-DEAL:2d::Norm of solution: 131.432
-DEAL:2d::Norm of difference: 2.12696e-15
+DEAL:2d::Norm of difference: 1.67249e-15
 DEAL:2d::
 DEAL:2d::Using FE_RaviartThomasNodal<2>(2)
 DEAL:2d::Number of cells: 16
 DEAL:2d::Number of degrees of freedom: 312
 DEAL:2d::
 DEAL:2d::Testing Values 
-DEAL:2d::Norm of solution: 14.1243
-DEAL:2d::Norm of difference: 1.57831e-15
+DEAL:2d::Norm of difference: 5.70018e-16
 DEAL:2d::
 DEAL:2d::Testing Gradients 
-DEAL:2d::Norm of solution: 412.757
-DEAL:2d::Norm of difference: 7.38344e-15
+DEAL:2d::Norm of difference: 1.04689e-14
 DEAL:2d::
 DEAL:2d::Testing Divergence 
-DEAL:2d::Norm of solution: 301.315
-DEAL:2d::Norm of difference: 1.72185e-15
+DEAL:2d::Norm of difference: 4.48610e-16
 DEAL:2d::
 DEAL:3d::Using FE_RaviartThomasNodal<3>(1)
 DEAL:3d::Number of cells: 64
 DEAL:3d::Number of degrees of freedom: 1728
 DEAL:3d::
 DEAL:3d::Testing Values 
-DEAL:3d::Norm of solution: 108.138
-DEAL:3d::Norm of difference: 2.41040e-15
+DEAL:3d::Norm of difference: 3.30534e-15
 DEAL:3d::
 DEAL:3d::Testing Gradients 
-DEAL:3d::Norm of solution: 860.089
-DEAL:3d::Norm of difference: 2.34828e-14
+DEAL:3d::Norm of difference: 1.56133e-14
 DEAL:3d::
 DEAL:3d::Testing Divergence 
-DEAL:3d::Norm of solution: 744.376
-DEAL:3d::Norm of difference: 1.84582e-15
+DEAL:3d::Norm of difference: 4.45455e-15
 DEAL:3d::
 DEAL:3d::Using FE_RaviartThomasNodal<3>(2)
 DEAL:3d::Number of cells: 64
 DEAL:3d::Number of degrees of freedom: 5616
 DEAL:3d::
 DEAL:3d::Testing Values 
-DEAL:3d::Norm of solution: 92.6632
-DEAL:3d::Norm of difference: 4.09020e-15
+DEAL:3d::Norm of difference: 3.08613e-15
 DEAL:3d::
 DEAL:3d::Testing Gradients 
-DEAL:3d::Norm of solution: 2642.78
-DEAL:3d::Norm of difference: 1.87917e-14
+DEAL:3d::Norm of difference: 1.38898e-14
 DEAL:3d::
 DEAL:3d::Testing Divergence 
-DEAL:3d::Norm of solution: 1915.34
-DEAL:3d::Norm of difference: 8.84232e-15
+DEAL:3d::Norm of difference: 4.73268e-15
 DEAL:3d::

--- a/tests/matrix_free/matrix_vector_rt_common.h
+++ b/tests/matrix_free/matrix_vector_rt_common.h
@@ -267,7 +267,6 @@ do_test(const DoFHandler<dim> &          dof,
   ref -= solution;
 
   const double diff_norm = ref.linfty_norm() / solution.linfty_norm();
-  deallog << "Norm of solution: " << solution.l2_norm() << std::endl;
   deallog << "Norm of difference: " << diff_norm << std::endl << std::endl;
 }
 

--- a/tests/matrix_free/matrix_vector_rt_face_01.output
+++ b/tests/matrix_free/matrix_vector_rt_face_01.output
@@ -4,34 +4,28 @@ DEAL:2d::Number of cells: 4
 DEAL:2d::Number of degrees of freedom: 40
 DEAL:2d::
 DEAL:2d::Testing Values and Gradients 
-DEAL:2d::Norm of solution: 349.420
-DEAL:2d::Norm of difference: 5.51354e-15
+DEAL:2d::Norm of difference: 7.46625e-15
 DEAL:2d::
 DEAL:2d::Testing Divergence 
-DEAL:2d::Norm of solution: 278.856
-DEAL:2d::Norm of difference: 3.16427e-15
+DEAL:2d::Norm of difference: 2.58308e-15
 DEAL:2d::
 DEAL:2d::Using FE_RaviartThomasNodal<2>(2)
 DEAL:2d::Number of cells: 4
 DEAL:2d::Number of degrees of freedom: 84
 DEAL:2d::
 DEAL:2d::Testing Values and Gradients 
-DEAL:2d::Norm of solution: 1079.93
-DEAL:2d::Norm of difference: 7.57657e-15
+DEAL:2d::Norm of difference: 7.18468e-15
 DEAL:2d::
 DEAL:2d::Testing Divergence 
-DEAL:2d::Norm of solution: 742.108
-DEAL:2d::Norm of difference: 5.41246e-15
+DEAL:2d::Norm of difference: 8.17176e-15
 DEAL:2d::
 DEAL:3d::Using FE_RaviartThomasNodal<3>(1)
 DEAL:3d::Number of cells: 8
 DEAL:3d::Number of degrees of freedom: 240
 DEAL:3d::
 DEAL:3d::Testing Values and Gradients 
-DEAL:3d::Norm of solution: 713.187
-DEAL:3d::Norm of difference: 1.34671e-14
+DEAL:3d::Norm of difference: 1.38066e-14
 DEAL:3d::
 DEAL:3d::Testing Divergence 
-DEAL:3d::Norm of solution: 606.610
-DEAL:3d::Norm of difference: 4.86336e-15
+DEAL:3d::Norm of difference: 4.05280e-15
 DEAL:3d::

--- a/tests/matrix_free/matrix_vector_rt_face_01.output
+++ b/tests/matrix_free/matrix_vector_rt_face_01.output
@@ -4,28 +4,34 @@ DEAL:2d::Number of cells: 4
 DEAL:2d::Number of degrees of freedom: 40
 DEAL:2d::
 DEAL:2d::Testing Values and Gradients 
-DEAL:2d::Norm of difference: 2.36910e-16
+DEAL:2d::Norm of solution: 349.420
+DEAL:2d::Norm of difference: 5.51354e-15
 DEAL:2d::
 DEAL:2d::Testing Divergence 
-DEAL:2d::Norm of difference: 4.52039e-16
+DEAL:2d::Norm of solution: 278.856
+DEAL:2d::Norm of difference: 3.16427e-15
 DEAL:2d::
 DEAL:2d::Using FE_RaviartThomasNodal<2>(2)
 DEAL:2d::Number of cells: 4
 DEAL:2d::Number of degrees of freedom: 84
 DEAL:2d::
 DEAL:2d::Testing Values and Gradients 
-DEAL:2d::Norm of difference: 7.31531e-15
+DEAL:2d::Norm of solution: 1079.93
+DEAL:2d::Norm of difference: 7.57657e-15
 DEAL:2d::
 DEAL:2d::Testing Divergence 
-DEAL:2d::Norm of difference: 2.97155e-15
+DEAL:2d::Norm of solution: 742.108
+DEAL:2d::Norm of difference: 5.41246e-15
 DEAL:2d::
 DEAL:3d::Using FE_RaviartThomasNodal<3>(1)
 DEAL:3d::Number of cells: 8
 DEAL:3d::Number of degrees of freedom: 240
 DEAL:3d::
 DEAL:3d::Testing Values and Gradients 
-DEAL:3d::Norm of difference: 3.73456e-15
+DEAL:3d::Norm of solution: 713.187
+DEAL:3d::Norm of difference: 1.34671e-14
 DEAL:3d::
 DEAL:3d::Testing Divergence 
-DEAL:3d::Norm of difference: 4.51598e-15
+DEAL:3d::Norm of solution: 606.610
+DEAL:3d::Norm of difference: 4.86336e-15
 DEAL:3d::

--- a/tests/matrix_free/matrix_vector_rt_face_02.output
+++ b/tests/matrix_free/matrix_vector_rt_face_02.output
@@ -4,34 +4,28 @@ DEAL:2d::Number of cells: 4
 DEAL:2d::Number of degrees of freedom: 40
 DEAL:2d::
 DEAL:2d::Testing Values and Gradients 
-DEAL:2d::Norm of solution: 2207.20
-DEAL:2d::Norm of difference: 1.28793e-14
+DEAL:2d::Norm of difference: 1.45411e-14
 DEAL:2d::
 DEAL:2d::Testing Divergence 
-DEAL:2d::Norm of solution: 985.425
-DEAL:2d::Norm of difference: 2.36732e-15
+DEAL:2d::Norm of difference: 2.63432e-15
 DEAL:2d::
 DEAL:2d::Using FE_RaviartThomasNodal<2>(2)
 DEAL:2d::Number of cells: 4
 DEAL:2d::Number of degrees of freedom: 84
 DEAL:2d::
 DEAL:2d::Testing Values and Gradients 
-DEAL:2d::Norm of solution: 7691.65
-DEAL:2d::Norm of difference: 1.76389e-14
+DEAL:2d::Norm of difference: 1.52206e-14
 DEAL:2d::
 DEAL:2d::Testing Divergence 
-DEAL:2d::Norm of solution: 2373.85
-DEAL:2d::Norm of difference: 1.17067e-14
+DEAL:2d::Norm of difference: 6.67882e-15
 DEAL:2d::
 DEAL:3d::Using FE_RaviartThomasNodal<3>(1)
 DEAL:3d::Number of cells: 8
 DEAL:3d::Number of degrees of freedom: 240
 DEAL:3d::
 DEAL:3d::Testing Values and Gradients 
-DEAL:3d::Norm of solution: 1074.84
-DEAL:3d::Norm of difference: 2.53479e-14
+DEAL:3d::Norm of difference: 2.58421e-14
 DEAL:3d::
 DEAL:3d::Testing Divergence 
-DEAL:3d::Norm of solution: 649.261
-DEAL:3d::Norm of difference: 8.33840e-15
+DEAL:3d::Norm of difference: 7.91079e-15
 DEAL:3d::

--- a/tests/matrix_free/matrix_vector_rt_face_02.output
+++ b/tests/matrix_free/matrix_vector_rt_face_02.output
@@ -4,28 +4,34 @@ DEAL:2d::Number of cells: 4
 DEAL:2d::Number of degrees of freedom: 40
 DEAL:2d::
 DEAL:2d::Testing Values and Gradients 
-DEAL:2d::Norm of difference: 6.92435e-16
+DEAL:2d::Norm of solution: 2207.20
+DEAL:2d::Norm of difference: 1.28793e-14
 DEAL:2d::
 DEAL:2d::Testing Divergence 
-DEAL:2d::Norm of difference: 2.84791e-16
+DEAL:2d::Norm of solution: 985.425
+DEAL:2d::Norm of difference: 2.36732e-15
 DEAL:2d::
 DEAL:2d::Using FE_RaviartThomasNodal<2>(2)
 DEAL:2d::Number of cells: 4
 DEAL:2d::Number of degrees of freedom: 84
 DEAL:2d::
 DEAL:2d::Testing Values and Gradients 
-DEAL:2d::Norm of difference: 4.97871e-15
+DEAL:2d::Norm of solution: 7691.65
+DEAL:2d::Norm of difference: 1.76389e-14
 DEAL:2d::
 DEAL:2d::Testing Divergence 
-DEAL:2d::Norm of difference: 4.05232e-15
+DEAL:2d::Norm of solution: 2373.85
+DEAL:2d::Norm of difference: 1.17067e-14
 DEAL:2d::
 DEAL:3d::Using FE_RaviartThomasNodal<3>(1)
 DEAL:3d::Number of cells: 8
 DEAL:3d::Number of degrees of freedom: 240
 DEAL:3d::
 DEAL:3d::Testing Values and Gradients 
-DEAL:3d::Norm of difference: 2.96549e-15
+DEAL:3d::Norm of solution: 1074.84
+DEAL:3d::Norm of difference: 2.53479e-14
 DEAL:3d::
 DEAL:3d::Testing Divergence 
-DEAL:3d::Norm of difference: 4.91752e-15
+DEAL:3d::Norm of solution: 649.261
+DEAL:3d::Norm of difference: 8.33840e-15
 DEAL:3d::

--- a/tests/matrix_free/matrix_vector_rt_face_03.cc
+++ b/tests/matrix_free/matrix_vector_rt_face_03.cc
@@ -1,0 +1,70 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// This test does the same as matrix_vector_rt_face_01.cc but also uses hanging
+// nodes.
+
+#include <deal.II/dofs/dof_tools.h>
+
+#include "../tests.h"
+
+#include "matrix_vector_rt_face_common.h"
+
+
+template <int dim, int fe_degree>
+void
+test()
+{
+  Triangulation<dim> tria;
+  GridGenerator::hyper_cube(tria);
+  typename Triangulation<dim>::active_cell_iterator cell, endc;
+  cell = tria.begin_active(), endc = tria.end();
+  for (; cell != endc; ++cell)
+    if (cell->center().norm() < 1e-8)
+      cell->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  cell = tria.begin_active();
+  for (; cell != endc; ++cell)
+    if (cell->center().norm() < 0.2)
+      cell->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  tria.begin(tria.n_levels() - 1)->set_refine_flag();
+  tria.last()->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  cell = tria.begin_active();
+  for (unsigned int i = 0; i < 10 - 3 * dim; ++i)
+    {
+      cell                 = tria.begin_active();
+      unsigned int counter = 0;
+      for (; cell != endc; ++cell, ++counter)
+        if (counter % (7 - i) == 0)
+          cell->set_refine_flag();
+      tria.execute_coarsening_and_refinement();
+    }
+
+  FE_RaviartThomasNodal<dim> fe(fe_degree - 1);
+  DoFHandler<dim>            dof(tria);
+  dof.distribute_dofs(fe);
+  AffineConstraints<double> constraints;
+  DoFTools::make_hanging_node_constraints(dof, constraints);
+  constraints.close();
+
+  deallog << "Using " << dof.get_fe().get_name() << std::endl;
+  deallog << "Number of cells: " << tria.n_active_cells() << std::endl;
+  deallog << "Number of degrees of freedom: " << dof.n_dofs() << std::endl
+          << std::endl;
+  do_test<dim, fe_degree, double>(dof, constraints, TestType::values_gradients);
+  //   do_test<dim, fe_degree, double>(dof, constraints, TestType::divergence);
+}

--- a/tests/matrix_free/matrix_vector_rt_face_03.output
+++ b/tests/matrix_free/matrix_vector_rt_face_03.output
@@ -1,0 +1,25 @@
+
+DEAL:2d::Using FE_RaviartThomasNodal<2>(1)
+DEAL:2d::Number of cells: 85
+DEAL:2d::Number of degrees of freedom: 798
+DEAL:2d::
+DEAL:2d::Testing Values and Gradients 
+DEAL:2d::Norm of solution: 832655.
+DEAL:2d::Norm of difference: 1.35208e-13
+DEAL:2d::
+DEAL:2d::Using FE_RaviartThomasNodal<2>(2)
+DEAL:2d::Number of cells: 85
+DEAL:2d::Number of degrees of freedom: 1707
+DEAL:2d::
+DEAL:2d::Testing Values and Gradients 
+DEAL:2d::Norm of solution: 3.45006e+06
+DEAL:2d::Norm of difference: 1.21762e-13
+DEAL:2d::
+DEAL:3d::Using FE_RaviartThomasNodal<3>(1)
+DEAL:3d::Number of cells: 22
+DEAL:3d::Number of degrees of freedom: 672
+DEAL:3d::
+DEAL:3d::Testing Values and Gradients 
+DEAL:3d::Norm of solution: 14812.3
+DEAL:3d::Norm of difference: 3.65060e-14
+DEAL:3d::

--- a/tests/matrix_free/matrix_vector_rt_face_03.output
+++ b/tests/matrix_free/matrix_vector_rt_face_03.output
@@ -4,22 +4,19 @@ DEAL:2d::Number of cells: 85
 DEAL:2d::Number of degrees of freedom: 798
 DEAL:2d::
 DEAL:2d::Testing Values and Gradients 
-DEAL:2d::Norm of solution: 832655.
-DEAL:2d::Norm of difference: 1.35208e-13
+DEAL:2d::Norm of difference: 1.46726e-13
 DEAL:2d::
 DEAL:2d::Using FE_RaviartThomasNodal<2>(2)
 DEAL:2d::Number of cells: 85
 DEAL:2d::Number of degrees of freedom: 1707
 DEAL:2d::
 DEAL:2d::Testing Values and Gradients 
-DEAL:2d::Norm of solution: 3.45006e+06
-DEAL:2d::Norm of difference: 1.21762e-13
+DEAL:2d::Norm of difference: 1.47883e-13
 DEAL:2d::
 DEAL:3d::Using FE_RaviartThomasNodal<3>(1)
 DEAL:3d::Number of cells: 22
 DEAL:3d::Number of degrees of freedom: 672
 DEAL:3d::
 DEAL:3d::Testing Values and Gradients 
-DEAL:3d::Norm of solution: 14812.3
-DEAL:3d::Norm of difference: 3.65060e-14
+DEAL:3d::Norm of difference: 3.31436e-14
 DEAL:3d::

--- a/tests/matrix_free/matrix_vector_rt_face_04.cc
+++ b/tests/matrix_free/matrix_vector_rt_face_04.cc
@@ -1,0 +1,173 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// This test it the same as matrix_vector_rt_face_01.cc but with non-affine
+// cells in standard orientation.
+
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/grid/manifold_lib.h>
+
+#include "../tests.h"
+
+#include "matrix_vector_rt_face_common.h"
+
+
+// This class is taken from
+// https://github.com/exadg/exadg/blob/master/include/exadg/grid/deformed_cube_manifold.h
+template <int dim>
+class DeformedCubeManifold : public dealii::ChartManifold<dim, dim, dim>
+{
+public:
+  DeformedCubeManifold(double const       left,
+                       double const       right,
+                       double const       deformation,
+                       unsigned int const frequency = 1)
+    : left(left)
+    , right(right)
+    , deformation(deformation)
+    , frequency(frequency)
+  {}
+
+  dealii::Point<dim>
+  push_forward(dealii::Point<dim> const &chart_point) const override
+  {
+    double sinval = deformation;
+    for (unsigned int d = 0; d < dim; ++d)
+      sinval *= std::sin(frequency * dealii::numbers::PI *
+                         (chart_point(d) - left) / (right - left));
+    dealii::Point<dim> space_point;
+    for (unsigned int d = 0; d < dim; ++d)
+      space_point(d) = chart_point(d) + sinval;
+    return space_point;
+  }
+
+  dealii::Point<dim>
+  pull_back(dealii::Point<dim> const &space_point) const override
+  {
+    dealii::Point<dim> x = space_point;
+    dealii::Point<dim> one;
+    for (unsigned int d = 0; d < dim; ++d)
+      one(d) = 1.;
+
+    // Newton iteration to solve the nonlinear equation given by the point
+    dealii::Tensor<1, dim> sinvals;
+    for (unsigned int d = 0; d < dim; ++d)
+      sinvals[d] = std::sin(frequency * dealii::numbers::PI * (x(d) - left) /
+                            (right - left));
+
+    double sinval = deformation;
+    for (unsigned int d = 0; d < dim; ++d)
+      sinval *= sinvals[d];
+    dealii::Tensor<1, dim> residual = space_point - x - sinval * one;
+    unsigned int           its      = 0;
+    while (residual.norm() > 1e-12 && its < 100)
+      {
+        dealii::Tensor<2, dim> jacobian;
+        for (unsigned int d = 0; d < dim; ++d)
+          jacobian[d][d] = 1.;
+        for (unsigned int d = 0; d < dim; ++d)
+          {
+            double sinval_der = deformation * frequency / (right - left) *
+                                dealii::numbers::PI *
+                                std::cos(frequency * dealii::numbers::PI *
+                                         (x(d) - left) / (right - left));
+            for (unsigned int e = 0; e < dim; ++e)
+              if (e != d)
+                sinval_der *= sinvals[e];
+            for (unsigned int e = 0; e < dim; ++e)
+              jacobian[e][d] += sinval_der;
+          }
+
+        x += invert(jacobian) * residual;
+
+        for (unsigned int d = 0; d < dim; ++d)
+          sinvals[d] = std::sin(frequency * dealii::numbers::PI *
+                                (x(d) - left) / (right - left));
+
+        sinval = deformation;
+        for (unsigned int d = 0; d < dim; ++d)
+          sinval *= sinvals[d];
+        residual = space_point - x - sinval * one;
+        ++its;
+      }
+    AssertThrow(residual.norm() < 1e-12,
+                dealii::ExcMessage("Newton for point did not converge."));
+    return x;
+  }
+
+  std::unique_ptr<dealii::Manifold<dim>>
+  clone() const override
+  {
+    return std::make_unique<DeformedCubeManifold<dim>>(left,
+                                                       right,
+                                                       deformation,
+                                                       frequency);
+  }
+
+private:
+  double const       left;
+  double const       right;
+  double const       deformation;
+  unsigned int const frequency;
+};
+
+template <int dim, int fe_degree>
+void
+test()
+{
+  Triangulation<dim> tria;
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(2);
+  unsigned int const               frequency   = 2;
+  double const                     deformation = 0.05;
+  static DeformedCubeManifold<dim> manifold(0.0, 1.0, deformation, frequency);
+  tria.set_all_manifold_ids(1);
+  tria.set_manifold(1, manifold);
+
+  std::vector<bool> vertex_touched(tria.n_vertices(), false);
+
+  for (auto cell : tria.cell_iterators())
+    {
+      for (auto const &v : cell->vertex_indices())
+        {
+          if (vertex_touched[cell->vertex_index(v)] == false)
+            {
+              Point<dim> &vertex    = cell->vertex(v);
+              Point<dim>  new_point = manifold.push_forward(vertex);
+              vertex                = new_point;
+              vertex_touched[cell->vertex_index(v)] = true;
+            }
+        }
+    }
+
+
+  FE_RaviartThomasNodal<dim> fe(fe_degree - 1);
+  DoFHandler<dim>            dof(tria);
+  dof.distribute_dofs(fe);
+
+  AffineConstraints<double> constraints;
+  DoFTools::make_hanging_node_constraints(dof, constraints);
+  constraints.close();
+
+  deallog << "Using " << dof.get_fe().get_name() << std::endl;
+  deallog << "Number of cells: " << dof.get_triangulation().n_active_cells()
+          << std::endl;
+  deallog << "Number of degrees of freedom: " << dof.n_dofs() << std::endl
+          << std::endl;
+  do_test<dim, fe_degree, double>(dof, constraints, TestType::values);
+  do_test<dim, fe_degree, double>(dof, constraints, TestType::gradients);
+  do_test<dim, fe_degree, double>(dof, constraints, TestType::divergence);
+}

--- a/tests/matrix_free/matrix_vector_rt_face_04.output
+++ b/tests/matrix_free/matrix_vector_rt_face_04.output
@@ -1,0 +1,49 @@
+
+DEAL:2d::Using FE_RaviartThomasNodal<2>(1)
+DEAL:2d::Number of cells: 16
+DEAL:2d::Number of degrees of freedom: 144
+DEAL:2d::
+DEAL:2d::Testing Values 
+DEAL:2d::Norm of solution: 272.771
+DEAL:2d::Norm of difference: 7.93613e-15
+DEAL:2d::
+DEAL:2d::Testing Gradients 
+DEAL:2d::Norm of solution: 5392.41
+DEAL:2d::Norm of difference: 3.37303e-14
+DEAL:2d::
+DEAL:2d::Testing Divergence 
+DEAL:2d::Norm of solution: 5021.93
+DEAL:2d::Norm of difference: 6.95683e-15
+DEAL:2d::
+DEAL:2d::Using FE_RaviartThomasNodal<2>(2)
+DEAL:2d::Number of cells: 16
+DEAL:2d::Number of degrees of freedom: 312
+DEAL:2d::
+DEAL:2d::Testing Values 
+DEAL:2d::Norm of solution: 210.761
+DEAL:2d::Norm of difference: 8.57270e-15
+DEAL:2d::
+DEAL:2d::Testing Gradients 
+DEAL:2d::Norm of solution: 18412.1
+DEAL:2d::Norm of difference: 2.05123e-14
+DEAL:2d::
+DEAL:2d::Testing Divergence 
+DEAL:2d::Norm of solution: 15842.0
+DEAL:2d::Norm of difference: 2.30101e-14
+DEAL:2d::
+DEAL:3d::Using FE_RaviartThomasNodal<3>(1)
+DEAL:3d::Number of cells: 64
+DEAL:3d::Number of degrees of freedom: 1728
+DEAL:3d::
+DEAL:3d::Testing Values 
+DEAL:3d::Norm of solution: 2482.78
+DEAL:3d::Norm of difference: 2.47208e-14
+DEAL:3d::
+DEAL:3d::Testing Gradients 
+DEAL:3d::Norm of solution: 36293.9
+DEAL:3d::Norm of difference: 3.82120e-14
+DEAL:3d::
+DEAL:3d::Testing Divergence 
+DEAL:3d::Norm of solution: 34869.7
+DEAL:3d::Norm of difference: 1.19666e-14
+DEAL:3d::

--- a/tests/matrix_free/matrix_vector_rt_face_04.output
+++ b/tests/matrix_free/matrix_vector_rt_face_04.output
@@ -4,46 +4,37 @@ DEAL:2d::Number of cells: 16
 DEAL:2d::Number of degrees of freedom: 144
 DEAL:2d::
 DEAL:2d::Testing Values 
-DEAL:2d::Norm of solution: 272.771
-DEAL:2d::Norm of difference: 7.93613e-15
+DEAL:2d::Norm of difference: 7.70271e-15
 DEAL:2d::
 DEAL:2d::Testing Gradients 
-DEAL:2d::Norm of solution: 5392.41
-DEAL:2d::Norm of difference: 3.37303e-14
+DEAL:2d::Norm of difference: 2.06943e-14
 DEAL:2d::
 DEAL:2d::Testing Divergence 
-DEAL:2d::Norm of solution: 5021.93
-DEAL:2d::Norm of difference: 6.95683e-15
+DEAL:2d::Norm of difference: 5.70616e-15
 DEAL:2d::
 DEAL:2d::Using FE_RaviartThomasNodal<2>(2)
 DEAL:2d::Number of cells: 16
 DEAL:2d::Number of degrees of freedom: 312
 DEAL:2d::
 DEAL:2d::Testing Values 
-DEAL:2d::Norm of solution: 210.761
-DEAL:2d::Norm of difference: 8.57270e-15
+DEAL:2d::Norm of difference: 6.01369e-15
 DEAL:2d::
 DEAL:2d::Testing Gradients 
-DEAL:2d::Norm of solution: 18412.1
-DEAL:2d::Norm of difference: 2.05123e-14
+DEAL:2d::Norm of difference: 3.30476e-14
 DEAL:2d::
 DEAL:2d::Testing Divergence 
-DEAL:2d::Norm of solution: 15842.0
-DEAL:2d::Norm of difference: 2.30101e-14
+DEAL:2d::Norm of difference: 3.09657e-14
 DEAL:2d::
 DEAL:3d::Using FE_RaviartThomasNodal<3>(1)
 DEAL:3d::Number of cells: 64
 DEAL:3d::Number of degrees of freedom: 1728
 DEAL:3d::
 DEAL:3d::Testing Values 
-DEAL:3d::Norm of solution: 2482.78
-DEAL:3d::Norm of difference: 2.47208e-14
+DEAL:3d::Norm of difference: 1.68332e-14
 DEAL:3d::
 DEAL:3d::Testing Gradients 
-DEAL:3d::Norm of solution: 36293.9
-DEAL:3d::Norm of difference: 3.82120e-14
+DEAL:3d::Norm of difference: 3.15188e-14
 DEAL:3d::
 DEAL:3d::Testing Divergence 
-DEAL:3d::Norm of solution: 34869.7
-DEAL:3d::Norm of difference: 1.19666e-14
+DEAL:3d::Norm of difference: 1.04375e-14
 DEAL:3d::

--- a/tests/matrix_free/matrix_vector_rt_face_common.h
+++ b/tests/matrix_free/matrix_vector_rt_face_common.h
@@ -328,7 +328,6 @@ do_test(const DoFHandler<dim> &          dof,
   ref -= solution;
 
   const double diff_norm = ref.linfty_norm() / solution.linfty_norm();
-  deallog << "Norm of solution: " << solution.l2_norm() << std::endl;
   deallog << "Norm of difference: " << diff_norm << std::endl << std::endl;
 }
 

--- a/tests/matrix_free/matrix_vector_rt_face_common.h
+++ b/tests/matrix_free/matrix_vector_rt_face_common.h
@@ -225,17 +225,21 @@ do_test(const DoFHandler<dim> &          dof,
 {
   deallog << "Testing " << enum_to_string(test_type) << std::endl;
 
+  constexpr unsigned int n_q_points = fe_degree + 2;
+  constexpr unsigned int m_degree   = fe_degree + 2;
+
+  const MappingQ<dim>     mapping(m_degree);
   MatrixFree<dim, Number> mf_data;
   {
-    const QGaussLobatto<1>                           quad(fe_degree + 2);
-    const MappingQ<dim>                              mapping(fe_degree);
+    const QGaussLobatto<1>                           quad(n_q_points);
     typename MatrixFree<dim, Number>::AdditionalData data;
     data.tasks_parallel_scheme = MatrixFree<dim, Number>::AdditionalData::none;
-    data.mapping_update_flags  = update_gradients | update_JxW_values;
+    data.mapping_update_flags =
+      (update_gradients | update_JxW_values | update_hessians);
     data.mapping_update_flags_inner_faces =
-      (update_gradients | update_JxW_values);
+      (update_gradients | update_JxW_values | update_hessians);
     data.mapping_update_flags_boundary_faces =
-      (update_gradients | update_JxW_values);
+      (update_gradients | update_JxW_values | update_hessians);
     mf_data.reinit(mapping, dof, constraints, quad, data);
   }
 
@@ -251,23 +255,25 @@ do_test(const DoFHandler<dim> &          dof,
         continue;
       initial_condition[i] = random_value<Number>();
     }
+  constraints.distribute(initial_condition);
 
   MatrixFreeTest<dim, -1, 0, Number> mf(mf_data, test_type);
   mf.test_functions(solution, initial_condition);
 
 
+  // Evaluation with FEFaceValues
   SparsityPattern        sp;
   SparseMatrix<double>   system_matrix;
   DynamicSparsityPattern dsp(dof.n_dofs(), dof.n_dofs());
-  DoFTools::make_sparsity_pattern(dof, dsp);
+  DoFTools::make_sparsity_pattern(dof, dsp, constraints, false);
   sp.copy_from(dsp);
   system_matrix.reinit(sp);
 
-  FEFaceValues<dim> fe_val(
-    dof.get_fe(),
-    QGaussLobatto<dim - 1>(mf_data.get_quadrature(0).size()),
-    update_values | update_gradients | update_JxW_values);
-
+  FEFaceValues<dim> fe_val(mapping,
+                           dof.get_fe(),
+                           QGaussLobatto<dim - 1>(n_q_points),
+                           update_values | update_gradients |
+                             update_JxW_values | update_piola);
 
   const unsigned int dofs_per_cell = fe_val.get_fe().dofs_per_cell;
   std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
@@ -308,21 +314,21 @@ do_test(const DoFHandler<dim> &          dof,
                 }
           }
         cell->get_dof_indices(local_dof_indices);
-        for (unsigned int i = 0; i < dofs_per_cell; ++i)
-          for (unsigned int j = 0; j < dofs_per_cell; ++j)
-            system_matrix.add(local_dof_indices[i],
-                              local_dof_indices[j],
-                              local_matrix(i, j));
+        constraints.distribute_local_to_global(local_matrix,
+                                               local_dof_indices,
+                                               system_matrix);
       }
 
   Vector<Number> ref(solution.size());
 
   // Compute reference
   system_matrix.vmult(ref, initial_condition);
+  constraints.set_zero(ref);
 
   ref -= solution;
 
   const double diff_norm = ref.linfty_norm() / solution.linfty_norm();
+  deallog << "Norm of solution: " << solution.l2_norm() << std::endl;
   deallog << "Norm of difference: " << diff_norm << std::endl << std::endl;
 }
 


### PR DESCRIPTION
Adds support for non-affine meshes and adds test for hanging nodes for the matrix-free implementation of `FE_RaviartThomasNodal`. 

This adds a more data to `mapping_info_storage` which is not ideal. To avoid this one would have to change how the Hessians are computed, i.e to compute the inverse jacobian gradient on the fly. 

Still missing for the matrix-free evaluation of RT is support for cells in non-standard orientation. 