### PR TITLE
Add LinearAlgebra::distributed::BlockVector::set_ghost_state()

### DIFF
--- a/include/deal.II/lac/la_parallel_block_vector.h
+++ b/include/deal.II/lac/la_parallel_block_vector.h
@@ -361,10 +361,16 @@ namespace LinearAlgebra
       zero_out_ghost_values() const;
 
       /**
-       * Return if this Vector contains ghost elements.
+       * Return if any of the blocks in this vector contains ghost elements.
        */
       bool
       has_ghost_elements() const;
+
+      /**
+       * Change the ghost state of all blocks in this vector to @p ghosted.
+       */
+      void
+      set_ghost_state(const bool ghosted) const;
 
       /**
        * This method copies the data in the locally owned range from another

--- a/include/deal.II/lac/la_parallel_block_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_block_vector.templates.h
@@ -423,6 +423,16 @@ namespace LinearAlgebra
 
     template <typename Number>
     void
+    BlockVector<Number>::set_ghost_state(const bool ghosted) const
+    {
+      for (unsigned int block = 0; block < this->n_blocks(); ++block)
+        this->block(block).set_ghost_state(ghosted);
+    }
+
+
+
+    template <typename Number>
+    void
     BlockVector<Number>::reinit(const VectorSpaceVector<Number> &V,
                                 const bool omit_zeroing_entries)
     {


### PR DESCRIPTION
Extracted from #12463. This addition seems to cause there the largest confusion although this function only calls the function of the non-blocked vectors.