### PR TITLE
Skip default values in get_coarse_mesh_description().

### DIFF
--- a/doc/news/changes/incompatibilities/20220509DavidWells
+++ b/doc/news/changes/incompatibilities/20220509DavidWells
@@ -1,0 +1,9 @@
+Improved: GridTools::get_coarse_mesh_description() no longer returns subcell data
+corresponding to default values (i.e., when the manifold_id is
+numbers::flat_manifold_id and when the boundary_id is
+numbers::internal_face_boundary_id). By skipping this data, which is not required by
+Triangulation::create_triangulation(), the total amount of data returned by this
+function is significantly lowered (and, therefore, so is the cost of creating a new
+Triangulation from the output).
+<br>
+(David Wells, 2022/05/09)

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -571,23 +571,33 @@ namespace GridTools
         if (dim > 1)
           {
             for (const unsigned int face_n : cell->face_indices())
-              face_data.insert_face_data(cell->face(face_n));
+              // We don't need to insert anything if we have default values
+              {
+                const auto face = cell->face(face_n);
+                if (face->boundary_id() != numbers::internal_face_boundary_id ||
+                    face->manifold_id() != numbers::flat_manifold_id)
+                  face_data.insert_face_data(face);
+              }
           }
         // Save line data
         if (dim == 3)
           {
             for (unsigned int line_n = 0; line_n < cell->n_lines(); ++line_n)
               {
-                const auto  line = cell->line(line_n);
-                CellData<1> line_cell_data;
-                for (unsigned int vertex_n = 0; vertex_n < line->n_vertices();
-                     ++vertex_n)
-                  line_cell_data.vertices[vertex_n] =
-                    line->vertex_index(vertex_n);
-                line_cell_data.boundary_id = line->boundary_id();
-                line_cell_data.manifold_id = line->manifold_id();
+                const auto line = cell->line(line_n);
+                // We don't need to insert anything if we have default values
+                if (line->boundary_id() != numbers::internal_face_boundary_id ||
+                    line->manifold_id() != numbers::flat_manifold_id)
+                  {
+                    CellData<1> line_cell_data(line->n_vertices());
+                    for (unsigned int vertex_n : line->vertex_indices())
+                      line_cell_data.vertices[vertex_n] =
+                        line->vertex_index(vertex_n);
 
-                line_data.insert(line_cell_data);
+                    line_cell_data.boundary_id = line->boundary_id();
+                    line_cell_data.manifold_id = line->manifold_id();
+                    line_data.insert(line_cell_data);
+                  }
               }
           }
       }

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -485,7 +485,7 @@ namespace GridTools
         face_cell_data.boundary_id = face->boundary_id();
         face_cell_data.manifold_id = face->manifold_id();
 
-        face_data.insert(face_cell_data);
+        face_data.insert(std::move(face_cell_data));
       }
 
       /**
@@ -596,7 +596,7 @@ namespace GridTools
 
                     line_cell_data.boundary_id = line->boundary_id();
                     line_cell_data.manifold_id = line->manifold_id();
-                    line_data.insert(line_cell_data);
+                    line_data.insert(std::move(line_cell_data));
                   }
               }
           }


### PR DESCRIPTION
This is the first of a few patches inspired by a truly terrible grid @labdala and I have been fixing.

A major performance problem with `GridTools::get_coarse_mesh_decription()` is that it presently saves all lines and faces, even when those lines and faces have flat manifold ids and internal boundary ids (i.e., they have the default internal values). This is particularly bad with lines since, in that case, we don't use `std::set` (so the largest consumer of memory is internal lines that don't store any meaningful data). I think its fine to never save this data. The only use case for keeping it is pretty obscure (someone wants to set internal manifold ids on `CellData` objects instead of working with the `Triangulation`).