### PR TITLE
Fix test failure: Close the right AffineConstraints object

### DIFF
--- a/tests/mappings/mapping_q_eulerian_14.cc
+++ b/tests/mappings/mapping_q_eulerian_14.cc
@@ -217,7 +217,7 @@ test(const unsigned int n_ref = 0)
   AffineConstraints<double> constraints;
   constraints.reinit(locally_relevant_dofs);
   DoFTools::make_hanging_node_constraints(dof_handler, constraints);
-  constraints_euler.close();
+  constraints.close();
 
   // MG constraints:
   MGConstrainedDoFs mg_constrained_dofs_euler;


### PR DESCRIPTION
Fixes test failure on `mappings/mapping_q_eulerian_14`: https://cdash.43-1.org/test/7765684