### PR TITLE
Restrict permissions for GITHUB_TOKEN.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,10 @@ on:
   push: 
     branches: [master]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build-master-docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/indent.yml
+++ b/.github/workflows/indent.yml
@@ -6,6 +6,9 @@ concurrency:
   group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
+permissions:
+  contents: read
+
 jobs:
   indent:
     # run the indent checks

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,6 +6,9 @@ concurrency:
   group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
+permissions:
+  contents: read
+
 jobs:
   linux-release-serial:
     # simple serial release build using g++

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -6,6 +6,9 @@ concurrency:
   group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
+permissions:
+  contents: read
+
 jobs:
   osx-serial:
     # simple serial build using apple clang

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,6 +6,9 @@ concurrency:
   group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
+permissions:
+  contents: read
+
 jobs:
   windows-serial:
     # Serial build on Windows


### PR DESCRIPTION
We can restrict access to our repository in case some attacker somehow manages to insert malicious code and executes it.

I've added these restrictions for our workers. I'm not 100% sure if permissions for the docker script are correct, but we can always revert it in a follow-up.

See: https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions