### PR TITLE
Fix test simplex/step-55.

### DIFF
--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -2943,15 +2943,11 @@ namespace TrilinosWrappers
         // TODO: fix this (do not run compress here, but fail)
         if (last_action == Insert)
           {
-#      ifdef DEBUG
-            int ierr;
-            ierr =
-#      endif
-              matrix->GlobalAssemble(*column_space_map,
-                                     matrix->RowMap(),
-                                     false);
+            const int ierr = matrix->GlobalAssemble(*column_space_map,
+                                                    matrix->RowMap(),
+                                                    false);
 
-            Assert(ierr == 0, ExcTrilinosError(ierr));
+            AssertThrow(ierr == 0, ExcTrilinosError(ierr));
           }
 
         last_action = Add;


### PR DESCRIPTION
Part of #13703.

```
1868: Test timeout computed to be: 600
11868: In file included from dealii/include/deal.II/base/function.h:22,
11868:                  from dealii/tests/simplex/step-55.cc:22:
11868: dealii/include/deal.II/lac/trilinos_sparse_matrix.h: In member function ‘void dealii::TrilinosWrappers::SparseMatrix::add(dealii::TrilinosWrappers::SparseMatrix::size_type, dealii::TrilinosWrappers::SparseMatrix::size_type, dealii::TrilinosScalar)’:
11868: dealii/tests/simplex/../tests.h:73:16: error: ‘ierr’ was not declared in this scope
11868:  #define Assert AssertThrow
11868:                 ^~~~~~~~~~~
11868: dealii/tests/simplex/../tests.h:73:16: note: suggested alternative: ‘Zero’
11868: gmake[3]: *** [CMakeFiles/simplex.step-55.release.dir/step-55.cc.o] Error 1
11868: gmake[2]: *** [CMakeFiles/simplex.step-55.release.dir/all] Error 2
11868: gmake[1]: *** [CMakeFiles/simplex.step-55.mpirun2.release.test.dir/rule] Error 2
11868: gmake: *** [simplex.step-55.mpirun2.release.test] Error 2
```
`tests.h` changes the `Assert` macro to `AssertThrow`. With this substitution, `ierr` can no longer be found.