### PR TITLE
changelog news entry

### DIFF
--- a/doc/news/changes/minor/20220510SeanIngimarson
+++ b/doc/news/changes/minor/20220510SeanIngimarson
@@ -1,0 +1,4 @@
+New: The hdf5 DataOut now correctly supports very
+large output files with more than 2 billion nodes/vertices.
+<br>
+(Sean Ingimarson, Timo Heister, Jiaqi Zhang, 2022/05/10)


### PR DESCRIPTION
Tested writing output for large data files using hdf5, which was known to break before a recent update.