### PR TITLE
Adjust changelog for 64bit nonzeros.

### DIFF
--- a/doc/news/changes/incompatibilities/20220404Fehling
+++ b/doc/news/changes/incompatibilities/20220404Fehling
@@ -1,5 +1,6 @@
 Changed: All functions `n_nonzero_elements()`, which are members of the
-SparseMatrix and SparsityPattern family of classes, now always return
-`std::uint64_t` instead of types::global_dof_index.
+SparseMatrix and SparsityPattern family of classes from PETSc and
+Trilinos, now always return `std::uint64_t` instead of
+types::global_dof_index.
 <br>
 (Marc Fehling, 2022/04/04)

--- a/source/lac/petsc_matrix_base.cc
+++ b/source/lac/petsc_matrix_base.cc
@@ -294,7 +294,7 @@ namespace PETScWrappers
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
     // MatInfo logs quantities as PetscLogDouble. So we need to cast it to match
-    // out interface.
+    // our interface.
     return static_cast<std::uint64_t>(mat_info.nz_used);
   }
 


### PR DESCRIPTION
#13599 only changed the PETSc and Trilinos classes, but not the deal.II classes. This PR adjusts the changelog to be more specific.