### PR TITLE
Replace std::vector<RequestType> by RequestType in consensus algorithms. Same for AnswerType.

### DIFF
--- a/include/deal.II/base/mpi_compute_index_owner_internal.h
+++ b/include/deal.II/base/mpi_compute_index_owner_internal.h
@@ -77,8 +77,9 @@ namespace Utilities
          */
         class DictionaryPayLoad
           : public ConsensusAlgorithms::Process<
-              std::pair<types::global_dof_index, types::global_dof_index>,
-              unsigned int>
+              std::vector<
+                std::pair<types::global_dof_index, types::global_dof_index>>,
+              std::vector<unsigned int>>
         {
         public:
           /**
@@ -282,8 +283,9 @@ namespace Utilities
          */
         class ConsensusAlgorithmsPayload
           : public ConsensusAlgorithms::Process<
-              std::pair<types::global_dof_index, types::global_dof_index>,
-              unsigned int>
+              std::vector<
+                std::pair<types::global_dof_index, types::global_dof_index>>,
+              std::vector<unsigned int>>
         {
         public:
           /**

--- a/include/deal.II/base/mpi_consensus_algorithms.h
+++ b/include/deal.II/base/mpi_consensus_algorithms.h
@@ -155,8 +155,7 @@ namespace Utilities
          * @note The buffer is empty. Before using it, you have to set its size.
          */
         virtual void
-        create_request(const unsigned int        other_rank,
-                       std::vector<RequestType> &send_buffer);
+        create_request(const unsigned int other_rank, RequestType &send_buffer);
 
         /**
          * Prepare the buffer where the payload of the answer of the request to
@@ -171,9 +170,9 @@ namespace Utilities
          *       its size.
          */
         virtual void
-        answer_request(const unsigned int              other_rank,
-                       const std::vector<RequestType> &buffer_recv,
-                       std::vector<AnswerType> &       request_buffer);
+        answer_request(const unsigned int other_rank,
+                       const RequestType &buffer_recv,
+                       AnswerType &       request_buffer);
 
         /**
          * Process the payload of the answer of the request to the process with
@@ -183,8 +182,8 @@ namespace Utilities
          * @param[in] recv_buffer data to be sent part of the request (optional)
          */
         virtual void
-        read_answer(const unsigned int             other_rank,
-                    const std::vector<AnswerType> &recv_buffer);
+        read_answer(const unsigned int other_rank,
+                    const AnswerType & recv_buffer);
       };
 
 
@@ -281,16 +280,14 @@ namespace Utilities
          *   is to be performed.
          */
         virtual std::vector<unsigned int>
-        run(const std::vector<unsigned int> &targets,
-            const std::function<std::vector<RequestType>(const unsigned int)>
-              &                                   create_request,
-            const std::function<std::vector<AnswerType>(
-              const unsigned int,
-              const std::vector<RequestType> &)> &answer_request,
-            const std::function<void(const unsigned int,
-                                     const std::vector<AnswerType> &)>
-              &             process_answer,
-            const MPI_Comm &comm) = 0;
+        run(
+          const std::vector<unsigned int> &                     targets,
+          const std::function<RequestType(const unsigned int)> &create_request,
+          const std::function<AnswerType(const unsigned int,
+                                         const RequestType &)> &answer_request,
+          const std::function<void(const unsigned int, const AnswerType &)>
+            &             process_answer,
+          const MPI_Comm &comm) = 0;
 
       private:
         /**
@@ -363,23 +360,21 @@ namespace Utilities
          * @copydoc Interface::run()
          */
         virtual std::vector<unsigned int>
-        run(const std::vector<unsigned int> &targets,
-            const std::function<std::vector<RequestType>(const unsigned int)>
-              &                                   create_request,
-            const std::function<std::vector<AnswerType>(
-              const unsigned int,
-              const std::vector<RequestType> &)> &answer_request,
-            const std::function<void(const unsigned int,
-                                     const std::vector<AnswerType> &)>
-              &             process_answer,
-            const MPI_Comm &comm) override;
+        run(
+          const std::vector<unsigned int> &                     targets,
+          const std::function<RequestType(const unsigned int)> &create_request,
+          const std::function<AnswerType(const unsigned int,
+                                         const RequestType &)> &answer_request,
+          const std::function<void(const unsigned int, const AnswerType &)>
+            &             process_answer,
+          const MPI_Comm &comm) override;
 
       private:
 #ifdef DEAL_II_WITH_MPI
         /**
          * Buffers for sending requests.
          */
-        std::vector<std::vector<RequestType>> send_buffers;
+        std::vector<std::vector<char>> send_buffers;
 
         /**
          * Requests for sending requests.
@@ -393,7 +388,7 @@ namespace Utilities
          * resized and consequently its elements (the pointers) are moved
          * around.
          */
-        std::vector<std::unique_ptr<std::vector<AnswerType>>> request_buffers;
+        std::vector<std::unique_ptr<std::vector<char>>> request_buffers;
 
         /**
          * Requests for sending answers to requests.
@@ -421,8 +416,7 @@ namespace Utilities
          */
         bool
         all_locally_originated_receives_are_completed(
-          const std::function<void(const unsigned int,
-                                   const std::vector<AnswerType> &)>
+          const std::function<void(const unsigned int, const AnswerType &)>
             &             process_answer,
           const MPI_Comm &comm);
 
@@ -448,10 +442,9 @@ namespace Utilities
          */
         void
         maybe_answer_one_request(
-          const std::function<std::vector<AnswerType>(
-            const unsigned int,
-            const std::vector<RequestType> &)> &answer_request,
-          const MPI_Comm &                      comm);
+          const std::function<AnswerType(const unsigned int,
+                                         const RequestType &)> &answer_request,
+          const MPI_Comm &                                      comm);
 
         /**
          * Start to send all requests via ISend and post IRecvs for the incoming
@@ -459,10 +452,9 @@ namespace Utilities
          */
         void
         start_communication(
-          const std::vector<unsigned int> &targets,
-          const std::function<std::vector<RequestType>(const unsigned int)>
-            &             create_request,
-          const MPI_Comm &comm);
+          const std::vector<unsigned int> &                     targets,
+          const std::function<RequestType(const unsigned int)> &create_request,
+          const MPI_Comm &                                      comm);
 
         /**
          * After all rank has received all answers, the MPI data structures can
@@ -489,14 +481,11 @@ namespace Utilities
        */
       template <typename RequestType, typename AnswerType>
       std::vector<unsigned int>
-      nbx(const std::vector<unsigned int> &targets,
-          const std::function<std::vector<RequestType>(const unsigned int)>
-            &                                   create_request,
-          const std::function<std::vector<AnswerType>(
-            const unsigned int,
-            const std::vector<RequestType> &)> &answer_request,
-          const std::function<void(const unsigned int,
-                                   const std::vector<AnswerType> &)>
+      nbx(const std::vector<unsigned int> &                     targets,
+          const std::function<RequestType(const unsigned int)> &create_request,
+          const std::function<AnswerType(const unsigned int,
+                                         const RequestType &)> &answer_request,
+          const std::function<void(const unsigned int, const AnswerType &)>
             &             process_answer,
           const MPI_Comm &comm);
 
@@ -563,28 +552,26 @@ namespace Utilities
          * @copydoc Interface::run()
          */
         virtual std::vector<unsigned int>
-        run(const std::vector<unsigned int> &targets,
-            const std::function<std::vector<RequestType>(const unsigned int)>
-              &                                   create_request,
-            const std::function<std::vector<AnswerType>(
-              const unsigned int,
-              const std::vector<RequestType> &)> &answer_request,
-            const std::function<void(const unsigned int,
-                                     const std::vector<AnswerType> &)>
-              &             process_answer,
-            const MPI_Comm &comm) override;
+        run(
+          const std::vector<unsigned int> &                     targets,
+          const std::function<RequestType(const unsigned int)> &create_request,
+          const std::function<AnswerType(const unsigned int,
+                                         const RequestType &)> &answer_request,
+          const std::function<void(const unsigned int, const AnswerType &)>
+            &             process_answer,
+          const MPI_Comm &comm) override;
 
       private:
 #ifdef DEAL_II_WITH_MPI
         /**
          * Buffers for sending requests.
          */
-        std::vector<std::vector<RequestType>> send_buffers;
+        std::vector<std::vector<char>> send_buffers;
 
         /**
          * Buffers for receiving answers to requests.
          */
-        std::vector<std::vector<AnswerType>> recv_buffers;
+        std::vector<std::vector<char>> recv_buffers;
 
         /**
          * MPI request objects for sending request messages.
@@ -594,7 +581,7 @@ namespace Utilities
         /**
          * Buffers for sending answers to requests.
          */
-        std::vector<std::vector<AnswerType>> requests_buffers;
+        std::vector<std::vector<char>> requests_buffers;
 
         /**
          * Requests for sending answers to requests.
@@ -612,21 +599,20 @@ namespace Utilities
          */
         unsigned int
         start_communication(
-          const std::vector<unsigned int> &targets,
-          const std::function<std::vector<RequestType>(const unsigned int)>
-            &             create_request,
-          const MPI_Comm &comm);
+          const std::vector<unsigned int> &                     targets,
+          const std::function<RequestType(const unsigned int)> &create_request,
+          const MPI_Comm &                                      comm);
 
         /**
          * The `index`th request message from another rank has been received:
          * process the request and send an answer.
          */
         void
-        answer_one_request(const unsigned int                    index,
-                           const std::function<std::vector<AnswerType>(
-                             const unsigned int,
-                             const std::vector<RequestType> &)> &answer_request,
-                           const MPI_Comm &                      comm);
+        answer_one_request(
+          const unsigned int                                    index,
+          const std::function<AnswerType(const unsigned int,
+                                         const RequestType &)> &answer_request,
+          const MPI_Comm &                                      comm);
 
         /**
          * Receive and process all of the incoming responses to the
@@ -635,8 +621,7 @@ namespace Utilities
         void
         process_incoming_answers(
           const unsigned int n_targets,
-          const std::function<void(const unsigned int,
-                                   const std::vector<AnswerType> &)>
+          const std::function<void(const unsigned int, const AnswerType &)>
             &             process_answer,
           const MPI_Comm &comm);
 
@@ -678,14 +663,11 @@ namespace Utilities
        */
       template <typename RequestType, typename AnswerType>
       std::vector<unsigned int>
-      pex(const std::vector<unsigned int> &targets,
-          const std::function<std::vector<RequestType>(const unsigned int)>
-            &                                   create_request,
-          const std::function<std::vector<AnswerType>(
-            const unsigned int,
-            const std::vector<RequestType> &)> &answer_request,
-          const std::function<void(const unsigned int,
-                                   const std::vector<AnswerType> &)>
+      pex(const std::vector<unsigned int> &                     targets,
+          const std::function<RequestType(const unsigned int)> &create_request,
+          const std::function<AnswerType(const unsigned int,
+                                         const RequestType &)> &answer_request,
+          const std::function<void(const unsigned int, const AnswerType &)>
             &             process_answer,
           const MPI_Comm &comm);
 
@@ -725,16 +707,14 @@ namespace Utilities
          * @copydoc Interface::run()
          */
         virtual std::vector<unsigned int>
-        run(const std::vector<unsigned int> &targets,
-            const std::function<std::vector<RequestType>(const unsigned int)>
-              &                                   create_request,
-            const std::function<std::vector<AnswerType>(
-              const unsigned int,
-              const std::vector<RequestType> &)> &answer_request,
-            const std::function<void(const unsigned int,
-                                     const std::vector<AnswerType> &)>
-              &             process_answer,
-            const MPI_Comm &comm) override;
+        run(
+          const std::vector<unsigned int> &                     targets,
+          const std::function<RequestType(const unsigned int)> &create_request,
+          const std::function<AnswerType(const unsigned int,
+                                         const RequestType &)> &answer_request,
+          const std::function<void(const unsigned int, const AnswerType &)>
+            &             process_answer,
+          const MPI_Comm &comm) override;
       };
 
 
@@ -751,14 +731,11 @@ namespace Utilities
        */
       template <typename RequestType, typename AnswerType>
       std::vector<unsigned int>
-      pex(const std::vector<unsigned int> &targets,
-          const std::function<std::vector<RequestType>(const unsigned int)>
-            &                                   create_request,
-          const std::function<std::vector<AnswerType>(
-            const unsigned int,
-            const std::vector<RequestType> &)> &answer_request,
-          const std::function<void(const unsigned int,
-                                   const std::vector<AnswerType> &)>
+      pex(const std::vector<unsigned int> &                     targets,
+          const std::function<RequestType(const unsigned int)> &create_request,
+          const std::function<AnswerType(const unsigned int,
+                                         const RequestType &)> &answer_request,
+          const std::function<void(const unsigned int, const AnswerType &)>
             &             process_answer,
           const MPI_Comm &comm);
 
@@ -815,16 +792,14 @@ namespace Utilities
          * @note The function call is delegated to another ConsensusAlgorithms::Interface implementation.
          */
         virtual std::vector<unsigned int>
-        run(const std::vector<unsigned int> &targets,
-            const std::function<std::vector<RequestType>(const unsigned int)>
-              &                                   create_request,
-            const std::function<std::vector<AnswerType>(
-              const unsigned int,
-              const std::vector<RequestType> &)> &answer_request,
-            const std::function<void(const unsigned int,
-                                     const std::vector<AnswerType> &)>
-              &             process_answer,
-            const MPI_Comm &comm) override;
+        run(
+          const std::vector<unsigned int> &                     targets,
+          const std::function<RequestType(const unsigned int)> &create_request,
+          const std::function<AnswerType(const unsigned int,
+                                         const RequestType &)> &answer_request,
+          const std::function<void(const unsigned int, const AnswerType &)>
+            &             process_answer,
+          const MPI_Comm &comm) override;
 
       private:
         // Pointer to the actual ConsensusAlgorithms::Interface implementation.
@@ -849,16 +824,14 @@ namespace Utilities
        */
       template <typename RequestType, typename AnswerType>
       std::vector<unsigned int>
-      selector(const std::vector<unsigned int> &targets,
-               const std::function<std::vector<RequestType>(const unsigned int)>
-                 &                                   create_request,
-               const std::function<std::vector<AnswerType>(
-                 const unsigned int,
-                 const std::vector<RequestType> &)> &answer_request,
-               const std::function<void(const unsigned int,
-                                        const std::vector<AnswerType> &)>
-                 &             process_answer,
-               const MPI_Comm &comm);
+      selector(
+        const std::vector<unsigned int> &                     targets,
+        const std::function<RequestType(const unsigned int)> &create_request,
+        const std::function<AnswerType(const unsigned int, const RequestType &)>
+          &answer_request,
+        const std::function<void(const unsigned int, const AnswerType &)>
+          &             process_answer,
+        const MPI_Comm &comm);
 
 
 
@@ -884,15 +857,12 @@ namespace Utilities
         AnonymousProcess(
           const std::function<std::vector<unsigned int>()>
             &function_compute_targets,
+          const std::function<void(const unsigned int, RequestType &)>
+            &                                      function_create_request = {},
           const std::function<void(const unsigned int,
-                                   std::vector<RequestType> &)>
-            &function_create_request = {},
-          const std::function<void(const unsigned int,
-                                   const std::vector<RequestType> &,
-                                   std::vector<AnswerType> &)>
-            &function_answer_request = {},
-          const std::function<void(const unsigned int,
-                                   const std::vector<AnswerType> &)>
+                                   const RequestType &,
+                                   AnswerType &)> &function_answer_request = {},
+          const std::function<void(const unsigned int, const AnswerType &)>
             &function_read_answer = {});
 
         /**
@@ -905,34 +875,33 @@ namespace Utilities
          * @copydoc Process::create_request()
          */
         void
-        create_request(const unsigned int        other_rank,
-                       std::vector<RequestType> &send_buffer) override;
+        create_request(const unsigned int other_rank,
+                       RequestType &      send_buffer) override;
 
         /**
          * @copydoc Process::answer_request()
          */
         void
-        answer_request(const unsigned int              other_rank,
-                       const std::vector<RequestType> &buffer_recv,
-                       std::vector<AnswerType> &       request_buffer) override;
+        answer_request(const unsigned int other_rank,
+                       const RequestType &buffer_recv,
+                       AnswerType &       request_buffer) override;
 
         /**
          * @copydoc Process::read_answer()
          */
         void
-        read_answer(const unsigned int             other_rank,
-                    const std::vector<AnswerType> &recv_buffer) override;
+        read_answer(const unsigned int other_rank,
+                    const AnswerType & recv_buffer) override;
 
       private:
         const std::function<std::vector<unsigned int>()>
           function_compute_targets;
-        const std::function<void(const int, std::vector<RequestType> &)>
+        const std::function<void(const int, RequestType &)>
           function_create_request;
-        const std::function<void(const unsigned int,
-                                 const std::vector<RequestType> &,
-                                 std::vector<AnswerType> &)>
+        const std::function<
+          void(const unsigned int, const RequestType &, AnswerType &)>
           function_answer_request;
-        const std::function<void(const int, const std::vector<AnswerType> &)>
+        const std::function<void(const int, const AnswerType &)>
           function_read_answer;
       };
 
@@ -942,14 +911,11 @@ namespace Utilities
 
       template <typename RequestType, typename AnswerType>
       std::vector<unsigned int>
-      nbx(const std::vector<unsigned int> &targets,
-          const std::function<std::vector<RequestType>(const unsigned int)>
-            &                                   create_request,
-          const std::function<std::vector<AnswerType>(
-            const unsigned int,
-            const std::vector<RequestType> &)> &answer_request,
-          const std::function<void(const unsigned int,
-                                   const std::vector<AnswerType> &)>
+      nbx(const std::vector<unsigned int> &                     targets,
+          const std::function<RequestType(const unsigned int)> &create_request,
+          const std::function<AnswerType(const unsigned int,
+                                         const RequestType &)> &answer_request,
+          const std::function<void(const unsigned int, const AnswerType &)>
             &             process_answer,
           const MPI_Comm &comm)
       {
@@ -961,14 +927,11 @@ namespace Utilities
 
       template <typename RequestType, typename AnswerType>
       std::vector<unsigned int>
-      pex(const std::vector<unsigned int> &targets,
-          const std::function<std::vector<RequestType>(const unsigned int)>
-            &                                   create_request,
-          const std::function<std::vector<AnswerType>(
-            const unsigned int,
-            const std::vector<RequestType> &)> &answer_request,
-          const std::function<void(const unsigned int,
-                                   const std::vector<AnswerType> &)>
+      pex(const std::vector<unsigned int> &                     targets,
+          const std::function<RequestType(const unsigned int)> &create_request,
+          const std::function<AnswerType(const unsigned int,
+                                         const RequestType &)> &answer_request,
+          const std::function<void(const unsigned int, const AnswerType &)>
             &             process_answer,
           const MPI_Comm &comm)
       {
@@ -980,16 +943,14 @@ namespace Utilities
 
       template <typename RequestType, typename AnswerType>
       std::vector<unsigned int>
-      serial(const std::vector<unsigned int> &targets,
-             const std::function<std::vector<RequestType>(const unsigned int)>
-               &                                   create_request,
-             const std::function<std::vector<AnswerType>(
-               const unsigned int,
-               const std::vector<RequestType> &)> &answer_request,
-             const std::function<void(const unsigned int,
-                                      const std::vector<AnswerType> &)>
-               &             process_answer,
-             const MPI_Comm &comm)
+      serial(
+        const std::vector<unsigned int> &                     targets,
+        const std::function<RequestType(const unsigned int)> &create_request,
+        const std::function<AnswerType(const unsigned int, const RequestType &)>
+          &answer_request,
+        const std::function<void(const unsigned int, const AnswerType &)>
+          &             process_answer,
+        const MPI_Comm &comm)
       {
         return Serial<RequestType, AnswerType>().run(
           targets, create_request, answer_request, process_answer, comm);
@@ -999,16 +960,14 @@ namespace Utilities
 
       template <typename RequestType, typename AnswerType>
       std::vector<unsigned int>
-      selector(const std::vector<unsigned int> &targets,
-               const std::function<std::vector<RequestType>(const unsigned int)>
-                 &                                   create_request,
-               const std::function<std::vector<AnswerType>(
-                 const unsigned int,
-                 const std::vector<RequestType> &)> &answer_request,
-               const std::function<void(const unsigned int,
-                                        const std::vector<AnswerType> &)>
-                 &             process_answer,
-               const MPI_Comm &comm)
+      selector(
+        const std::vector<unsigned int> &                     targets,
+        const std::function<RequestType(const unsigned int)> &create_request,
+        const std::function<AnswerType(const unsigned int, const RequestType &)>
+          &answer_request,
+        const std::function<void(const unsigned int, const AnswerType &)>
+          &             process_answer,
+        const MPI_Comm &comm)
       {
         return Selector<RequestType, AnswerType>().run(
           targets, create_request, answer_request, process_answer, comm);
@@ -1020,15 +979,12 @@ namespace Utilities
       AnonymousProcess<RequestType, AnswerType>::AnonymousProcess(
         const std::function<std::vector<unsigned int>()>
           &function_compute_targets,
+        const std::function<void(const unsigned int, RequestType &)>
+          &                                      function_create_request,
         const std::function<void(const unsigned int,
-                                 std::vector<RequestType> &)>
-          &function_create_request,
-        const std::function<void(const unsigned int,
-                                 const std::vector<RequestType> &,
-                                 std::vector<AnswerType> &)>
-          &function_answer_request,
-        const std::function<void(const unsigned int,
-                                 const std::vector<AnswerType> &)>
+                                 const RequestType &,
+                                 AnswerType &)> &function_answer_request,
+        const std::function<void(const unsigned int, const AnswerType &)>
           &function_read_answer)
         : function_compute_targets(function_compute_targets)
         , function_create_request(function_create_request)
@@ -1050,8 +1006,8 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       void
       AnonymousProcess<RequestType, AnswerType>::create_request(
-        const unsigned int        other_rank,
-        std::vector<RequestType> &send_buffer)
+        const unsigned int other_rank,
+        RequestType &      send_buffer)
       {
         if (function_create_request)
           function_create_request(other_rank, send_buffer);
@@ -1062,9 +1018,9 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       void
       AnonymousProcess<RequestType, AnswerType>::answer_request(
-        const unsigned int              other_rank,
-        const std::vector<RequestType> &buffer_recv,
-        std::vector<AnswerType> &       request_buffer)
+        const unsigned int other_rank,
+        const RequestType &buffer_recv,
+        AnswerType &       request_buffer)
       {
         if (function_answer_request)
           function_answer_request(other_rank, buffer_recv, request_buffer);
@@ -1075,8 +1031,8 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       void
       AnonymousProcess<RequestType, AnswerType>::read_answer(
-        const unsigned int             other_rank,
-        const std::vector<AnswerType> &recv_buffer)
+        const unsigned int other_rank,
+        const AnswerType & recv_buffer)
       {
         if (function_read_answer)
           function_read_answer(other_rank, recv_buffer);

--- a/include/deal.II/base/mpi_consensus_algorithms.templates.h
+++ b/include/deal.II/base/mpi_consensus_algorithms.templates.h
@@ -74,10 +74,9 @@ namespace Utilities
 
       template <typename RequestType, typename AnswerType>
       void
-      Process<RequestType, AnswerType>::answer_request(
-        const unsigned int,
-        const std::vector<RequestType> &,
-        std::vector<AnswerType> &)
+      Process<RequestType, AnswerType>::answer_request(const unsigned int,
+                                                       const RequestType &,
+                                                       AnswerType &)
       {
         // nothing to do
       }
@@ -86,9 +85,8 @@ namespace Utilities
 
       template <typename RequestType, typename AnswerType>
       void
-      Process<RequestType, AnswerType>::create_request(
-        const unsigned int,
-        std::vector<RequestType> &)
+      Process<RequestType, AnswerType>::create_request(const unsigned int,
+                                                       RequestType &)
       {
         // nothing to do
       }
@@ -97,9 +95,8 @@ namespace Utilities
 
       template <typename RequestType, typename AnswerType>
       void
-      Process<RequestType, AnswerType>::read_answer(
-        const unsigned int,
-        const std::vector<AnswerType> &)
+      Process<RequestType, AnswerType>::read_answer(const unsigned int,
+                                                    const AnswerType &)
       {
         // nothing to do
       }
@@ -150,20 +147,18 @@ namespace Utilities
           process.compute_targets(),
           /* create_request: */
           [&process](const unsigned int target) {
-            std::vector<RequestType> request;
+            RequestType request;
             process.create_request(target, request);
             return request;
           },
           /* answer_request: */
-          [&process](const unsigned int              source,
-                     const std::vector<RequestType> &request) {
-            std::vector<AnswerType> answer;
+          [&process](const unsigned int source, const RequestType &request) {
+            AnswerType answer;
             process.answer_request(source, request, answer);
             return answer;
           },
           /* process_answer: */
-          [&process](const unsigned int             target,
-                     const std::vector<AnswerType> &answer) {
+          [&process](const unsigned int target, const AnswerType &answer) {
             process.read_answer(target, answer);
           },
           comm);
@@ -183,14 +178,11 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       std::vector<unsigned int>
       NBX<RequestType, AnswerType>::run(
-        const std::vector<unsigned int> &targets,
-        const std::function<std::vector<RequestType>(const unsigned int)>
-          &                                   create_request,
-        const std::function<std::vector<AnswerType>(
-          const unsigned int,
-          const std::vector<RequestType> &)> &answer_request,
-        const std::function<void(const unsigned int,
-                                 const std::vector<AnswerType> &)>
+        const std::vector<unsigned int> &                     targets,
+        const std::function<RequestType(const unsigned int)> &create_request,
+        const std::function<AnswerType(const unsigned int, const RequestType &)>
+          &answer_request,
+        const std::function<void(const unsigned int, const AnswerType &)>
           &             process_answer,
         const MPI_Comm &comm)
       {
@@ -246,10 +238,9 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       void
       NBX<RequestType, AnswerType>::start_communication(
-        const std::vector<unsigned int> &targets,
-        const std::function<std::vector<RequestType>(const unsigned int)>
-          &             create_request,
-        const MPI_Comm &comm)
+        const std::vector<unsigned int> &                     targets,
+        const std::function<RequestType(const unsigned int)> &create_request,
+        const MPI_Comm &                                      comm)
       {
 #ifdef DEAL_II_WITH_MPI
         // 1)
@@ -270,13 +261,14 @@ namespace Utilities
               AssertIndexRange(rank, Utilities::MPI::n_mpi_processes(comm));
 
               auto &send_buffer = send_buffers[index];
-              send_buffer       = (create_request ? create_request(rank) :
-                                                    std::vector<RequestType>());
+              send_buffer =
+                (create_request ? Utilities::pack(create_request(rank)) :
+                                  std::vector<char>());
 
               // Post a request to send data
               auto ierr = MPI_Isend(send_buffer.data(),
-                                    send_buffer.size() * sizeof(RequestType),
-                                    MPI_BYTE,
+                                    send_buffer.size(),
+                                    MPI_CHAR,
                                     rank,
                                     tag_request,
                                     comm,
@@ -301,8 +293,7 @@ namespace Utilities
       bool
       NBX<RequestType, AnswerType>::
         all_locally_originated_receives_are_completed(
-          const std::function<void(const unsigned int,
-                                   const std::vector<AnswerType> &)>
+          const std::function<void(const unsigned int, const AnswerType &)>
             &             process_answer,
           const MPI_Comm &comm)
       {
@@ -344,31 +335,28 @@ namespace Utilities
                 int message_size;
                 {
                   const int ierr =
-                    MPI_Get_count(&status, MPI_BYTE, &message_size);
+                    MPI_Get_count(&status, MPI_CHAR, &message_size);
                   AssertThrowMPI(ierr);
                 }
-                Assert(message_size % sizeof(AnswerType) == 0,
-                       ExcInternalError());
-                std::vector<AnswerType> recv_buffer(message_size /
-                                                    sizeof(AnswerType));
+                std::vector<char> recv_buffer(message_size);
 
                 {
                   const int tag_deliver = Utilities::MPI::internal::Tags::
                     consensus_algorithm_nbx_process_deliver;
 
-                  const int ierr =
-                    MPI_Recv(recv_buffer.data(),
-                             recv_buffer.size() * sizeof(AnswerType),
-                             MPI_BYTE,
-                             target,
-                             tag_deliver,
-                             comm,
-                             MPI_STATUS_IGNORE);
+                  const int ierr = MPI_Recv(recv_buffer.data(),
+                                            recv_buffer.size(),
+                                            MPI_CHAR,
+                                            target,
+                                            tag_deliver,
+                                            comm,
+                                            MPI_STATUS_IGNORE);
                   AssertThrowMPI(ierr);
                 }
 
                 if (process_answer)
-                  process_answer(target, recv_buffer);
+                  process_answer(target,
+                                 Utilities::unpack<AnswerType>(recv_buffer));
 
                 // Finally, remove this rank from the list of outstanding
                 // targets:
@@ -399,10 +387,9 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       void
       NBX<RequestType, AnswerType>::maybe_answer_one_request(
-        const std::function<std::vector<AnswerType>(
-          const unsigned int,
-          const std::vector<RequestType> &)> &answer_request,
-        const MPI_Comm &                      comm)
+        const std::function<AnswerType(const unsigned int, const RequestType &)>
+          &             answer_request,
+        const MPI_Comm &comm)
       {
 #ifdef DEAL_II_WITH_MPI
 
@@ -437,17 +424,14 @@ namespace Utilities
 
             // get size of incoming message
             int  number_amount;
-            auto ierr = MPI_Get_count(&status, MPI_BYTE, &number_amount);
+            auto ierr = MPI_Get_count(&status, MPI_CHAR, &number_amount);
             AssertThrowMPI(ierr);
 
             // allocate memory for incoming message
-            Assert(number_amount % sizeof(RequestType) == 0,
-                   ExcInternalError());
-            std::vector<RequestType> buffer_recv(number_amount /
-                                                 sizeof(RequestType));
+            std::vector<char> buffer_recv(number_amount);
             ierr = MPI_Recv(buffer_recv.data(),
                             number_amount,
-                            MPI_BYTE,
+                            MPI_CHAR,
                             other_rank,
                             tag_request,
                             comm,
@@ -456,17 +440,18 @@ namespace Utilities
 
             // Allocate memory for an answer message to the current request,
             // and ask the 'process' object to produce an answer:
-            request_buffers.emplace_back(
-              std::make_unique<std::vector<AnswerType>>());
+            request_buffers.emplace_back(std::make_unique<std::vector<char>>());
             auto &request_buffer = *request_buffers.back();
             if (answer_request)
-              request_buffer = answer_request(other_rank, buffer_recv);
+              request_buffer = Utilities::pack(
+                answer_request(other_rank,
+                               Utilities::unpack<RequestType>(buffer_recv)));
 
             // Then initiate sending the answer back to the requester.
             request_requests.emplace_back(std::make_unique<MPI_Request>());
             ierr = MPI_Isend(request_buffer.data(),
-                             request_buffer.size() * sizeof(AnswerType),
-                             MPI_BYTE,
+                             request_buffer.size(),
+                             MPI_CHAR,
                              other_rank,
                              tag_deliver,
                              comm,
@@ -564,14 +549,11 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       std::vector<unsigned int>
       PEX<RequestType, AnswerType>::run(
-        const std::vector<unsigned int> &targets,
-        const std::function<std::vector<RequestType>(const unsigned int)>
-          &                                   create_request,
-        const std::function<std::vector<AnswerType>(
-          const unsigned int,
-          const std::vector<RequestType> &)> &answer_request,
-        const std::function<void(const unsigned int,
-                                 const std::vector<AnswerType> &)>
+        const std::vector<unsigned int> &                     targets,
+        const std::function<RequestType(const unsigned int)> &create_request,
+        const std::function<AnswerType(const unsigned int, const RequestType &)>
+          &answer_request,
+        const std::function<void(const unsigned int, const AnswerType &)>
           &             process_answer,
         const MPI_Comm &comm)
       {
@@ -608,10 +590,9 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       unsigned int
       PEX<RequestType, AnswerType>::start_communication(
-        const std::vector<unsigned int> &targets,
-        const std::function<std::vector<RequestType>(const unsigned int)>
-          &             create_request,
-        const MPI_Comm &comm)
+        const std::vector<unsigned int> &                     targets,
+        const std::function<RequestType(const unsigned int)> &create_request,
+        const MPI_Comm &                                      comm)
       {
 #ifdef DEAL_II_WITH_MPI
         const int tag_request = Utilities::MPI::internal::Tags::
@@ -641,13 +622,13 @@ namespace Utilities
 
             // pack data which should be sent
             auto &send_buffer = send_buffers[i];
-            send_buffer       = (create_request ? create_request(rank) :
-                                                  std::vector<RequestType>());
+            if (create_request)
+              send_buffer = Utilities::pack(create_request(rank));
 
             // start to send data
             auto ierr = MPI_Isend(send_buffer.data(),
-                                  send_buffer.size() * sizeof(RequestType),
-                                  MPI_BYTE,
+                                  send_buffer.size(),
+                                  MPI_CHAR,
                                   rank,
                                   tag_request,
                                   comm,
@@ -669,11 +650,10 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       void
       PEX<RequestType, AnswerType>::answer_one_request(
-        const unsigned int                    index,
-        const std::function<std::vector<AnswerType>(
-          const unsigned int,
-          const std::vector<RequestType> &)> &answer_request,
-        const MPI_Comm &                      comm)
+        const unsigned int index,
+        const std::function<AnswerType(const unsigned int, const RequestType &)>
+          &             answer_request,
+        const MPI_Comm &comm)
       {
 #ifdef DEAL_II_WITH_MPI
         const int tag_request = Utilities::MPI::internal::Tags::
@@ -698,18 +678,15 @@ namespace Utilities
                  "received. This algorithm does not expect this to happen."));
         requesting_processes.insert(other_rank);
 
-        std::vector<RequestType> buffer_recv;
-
         // Actually get the incoming message:
         int number_amount;
-        ierr = MPI_Get_count(&status, MPI_BYTE, &number_amount);
+        ierr = MPI_Get_count(&status, MPI_CHAR, &number_amount);
         AssertThrowMPI(ierr);
-        Assert(number_amount % sizeof(RequestType) == 0, ExcInternalError());
 
-        buffer_recv.resize(number_amount / sizeof(RequestType));
+        std::vector<char> buffer_recv(number_amount);
         ierr = MPI_Recv(buffer_recv.data(),
                         number_amount,
-                        MPI_BYTE,
+                        MPI_CHAR,
                         other_rank,
                         tag_request,
                         comm,
@@ -720,12 +697,14 @@ namespace Utilities
         // the answer and post a send for it.
         auto &request_buffer = requests_buffers[index];
         request_buffer =
-          (answer_request ? answer_request(other_rank, buffer_recv) :
-                            std::vector<AnswerType>());
+          (answer_request ?
+             Utilities::pack(answer_request(
+               other_rank, Utilities::unpack<RequestType>(buffer_recv))) :
+             std::vector<char>());
 
         ierr = MPI_Isend(request_buffer.data(),
-                         request_buffer.size() * sizeof(AnswerType),
-                         MPI_BYTE,
+                         request_buffer.size(),
+                         MPI_CHAR,
                          other_rank,
                          tag_deliver,
                          comm,
@@ -744,8 +723,7 @@ namespace Utilities
       void
       PEX<RequestType, AnswerType>::process_incoming_answers(
         const unsigned int n_targets,
-        const std::function<void(const unsigned int,
-                                 const std::vector<AnswerType> &)>
+        const std::function<void(const unsigned int, const AnswerType &)>
           &             process_answer,
         const MPI_Comm &comm)
       {
@@ -770,20 +748,18 @@ namespace Utilities
             const auto other_rank = status.MPI_SOURCE;
             int        message_size;
             {
-              const int ierr = MPI_Get_count(&status, MPI_BYTE, &message_size);
+              const int ierr = MPI_Get_count(&status, MPI_CHAR, &message_size);
               AssertThrowMPI(ierr);
             }
-            Assert(message_size % sizeof(AnswerType) == 0, ExcInternalError());
-            std::vector<AnswerType> recv_buffer(message_size /
-                                                sizeof(AnswerType));
+            std::vector<char> recv_buffer(message_size);
 
             // Now actually receive the answer. Because the MPI_Probe
             // above blocks until we have a message, we know that the
             // following MPI_Recv call will immediately succeed.
             {
               const int ierr = MPI_Recv(recv_buffer.data(),
-                                        recv_buffer.size() * sizeof(AnswerType),
-                                        MPI_BYTE,
+                                        recv_buffer.size(),
+                                        MPI_CHAR,
                                         other_rank,
                                         tag_deliver,
                                         comm,
@@ -792,7 +768,8 @@ namespace Utilities
             }
 
             if (process_answer)
-              process_answer(other_rank, recv_buffer);
+              process_answer(other_rank,
+                             Utilities::unpack<AnswerType>(recv_buffer));
           }
 #else
         (void)n_targets;
@@ -843,14 +820,11 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       std::vector<unsigned int>
       Serial<RequestType, AnswerType>::run(
-        const std::vector<unsigned int> &targets,
-        const std::function<std::vector<RequestType>(const unsigned int)>
-          &                                   create_request,
-        const std::function<std::vector<AnswerType>(
-          const unsigned int,
-          const std::vector<RequestType> &)> &answer_request,
-        const std::function<void(const unsigned int,
-                                 const std::vector<AnswerType> &)>
+        const std::vector<unsigned int> &                     targets,
+        const std::function<RequestType(const unsigned int)> &create_request,
+        const std::function<AnswerType(const unsigned int, const RequestType &)>
+          &answer_request,
+        const std::function<void(const unsigned int, const AnswerType &)>
           &             process_answer,
         const MPI_Comm &comm)
       {
@@ -874,11 +848,10 @@ namespace Utilities
             // Since the caller indicates that there is a target, and since we
             // know that it is the current process, let the process send
             // something to itself.
-            const std::vector<RequestType> request =
-              (create_request ? create_request(0) : std::vector<RequestType>());
-            const std::vector<AnswerType> answer =
-              (answer_request ? answer_request(0, request) :
-                                std::vector<AnswerType>());
+            const RequestType request =
+              (create_request ? create_request(0) : RequestType());
+            const AnswerType answer =
+              (answer_request ? answer_request(0, request) : AnswerType());
 
             if (process_answer)
               process_answer(0, answer);
@@ -901,14 +874,11 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       std::vector<unsigned int>
       Selector<RequestType, AnswerType>::run(
-        const std::vector<unsigned int> &targets,
-        const std::function<std::vector<RequestType>(const unsigned int)>
-          &                                   create_request,
-        const std::function<std::vector<AnswerType>(
-          const unsigned int,
-          const std::vector<RequestType> &)> &answer_request,
-        const std::function<void(const unsigned int,
-                                 const std::vector<AnswerType> &)>
+        const std::vector<unsigned int> &                     targets,
+        const std::function<RequestType(const unsigned int)> &create_request,
+        const std::function<AnswerType(const unsigned int, const RequestType &)>
+          &answer_request,
+        const std::function<void(const unsigned int, const AnswerType &)>
           &             process_answer,
         const MPI_Comm &comm)
       {

--- a/include/deal.II/base/mpi_consensus_algorithms.templates.h
+++ b/include/deal.II/base/mpi_consensus_algorithms.templates.h
@@ -262,7 +262,7 @@ namespace Utilities
 
               auto &send_buffer = send_buffers[index];
               send_buffer =
-                (create_request ? Utilities::pack(create_request(rank)) :
+                (create_request ? Utilities::pack(create_request(rank), false) :
                                   std::vector<char>());
 
               // Post a request to send data
@@ -356,7 +356,8 @@ namespace Utilities
 
                 if (process_answer)
                   process_answer(target,
-                                 Utilities::unpack<AnswerType>(recv_buffer));
+                                 Utilities::unpack<AnswerType>(recv_buffer,
+                                                               false));
 
                 // Finally, remove this rank from the list of outstanding
                 // targets:
@@ -443,9 +444,11 @@ namespace Utilities
             request_buffers.emplace_back(std::make_unique<std::vector<char>>());
             auto &request_buffer = *request_buffers.back();
             if (answer_request)
-              request_buffer = Utilities::pack(
-                answer_request(other_rank,
-                               Utilities::unpack<RequestType>(buffer_recv)));
+              request_buffer =
+                Utilities::pack(answer_request(other_rank,
+                                               Utilities::unpack<RequestType>(
+                                                 buffer_recv, false)),
+                                false);
 
             // Then initiate sending the answer back to the requester.
             request_requests.emplace_back(std::make_unique<MPI_Request>());
@@ -623,7 +626,7 @@ namespace Utilities
             // pack data which should be sent
             auto &send_buffer = send_buffers[i];
             if (create_request)
-              send_buffer = Utilities::pack(create_request(rank));
+              send_buffer = Utilities::pack(create_request(rank), false);
 
             // start to send data
             auto ierr = MPI_Isend(send_buffer.data(),
@@ -698,8 +701,10 @@ namespace Utilities
         auto &request_buffer = requests_buffers[index];
         request_buffer =
           (answer_request ?
-             Utilities::pack(answer_request(
-               other_rank, Utilities::unpack<RequestType>(buffer_recv))) :
+             Utilities::pack(answer_request(other_rank,
+                                            Utilities::unpack<RequestType>(
+                                              buffer_recv, false)),
+                             false) :
              std::vector<char>());
 
         ierr = MPI_Isend(request_buffer.data(),
@@ -769,7 +774,7 @@ namespace Utilities
 
             if (process_answer)
               process_answer(other_rank,
-                             Utilities::unpack<AnswerType>(recv_buffer));
+                             Utilities::unpack<AnswerType>(recv_buffer, false));
           }
 #else
         (void)n_targets;

--- a/include/deal.II/fe/fe_tools_extrapolate.templates.h
+++ b/include/deal.II/fe/fe_tools_extrapolate.templates.h
@@ -1177,11 +1177,13 @@ namespace FETools
         Assert(answer.size() == 0, ExcInternalError());
       };
 
-      Utilities::MPI::ConsensusAlgorithms::selector<char, char>(destinations,
-                                                                create_request,
-                                                                answer_request,
-                                                                read_answer,
-                                                                communicator);
+      Utilities::MPI::ConsensusAlgorithms::selector<std::vector<char>,
+                                                    std::vector<char>>(
+        destinations,
+        create_request,
+        answer_request,
+        read_answer,
+        communicator);
     }
 
 

--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -261,8 +261,8 @@ namespace internal
                                   true);
 
     Utilities::MPI::ConsensusAlgorithms::Selector<
-      std::pair<types::global_dof_index, types::global_dof_index>,
-      unsigned int>(constrained_indices_process, mpi_communicator)
+      std::vector<std::pair<types::global_dof_index, types::global_dof_index>>,
+      std::vector<unsigned int>>(constrained_indices_process, mpi_communicator)
       .run();
 
     // step 2: collect all locally owned constraints
@@ -388,8 +388,10 @@ namespace internal
                                       true);
 
       Utilities::MPI::ConsensusAlgorithms::Selector<
-        std::pair<types::global_dof_index, types::global_dof_index>,
-        unsigned int>(locally_relevant_dofs_process, mpi_communicator)
+        std::vector<
+          std::pair<types::global_dof_index, types::global_dof_index>>,
+        std::vector<unsigned int>>(locally_relevant_dofs_process,
+                                   mpi_communicator)
         .run();
 
       const auto locally_relevant_dofs_by_ranks =

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -2170,13 +2170,14 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
               }
           };
 
-          Utilities::MPI::ConsensusAlgorithms::
-            Selector<dealii::types::global_dof_index, unsigned int>()
-              .run(targets,
-                   create_request,
-                   answer_request,
-                   process_answer,
-                   communicator_sm);
+          Utilities::MPI::ConsensusAlgorithms::Selector<
+            std::vector<dealii::types::global_dof_index>,
+            std::vector<unsigned int>>()
+            .run(targets,
+                 create_request,
+                 answer_request,
+                 process_answer,
+                 communicator_sm);
 
           return cells;
         }();

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -567,8 +567,9 @@ namespace internal
                 false);
 
             Utilities::MPI::ConsensusAlgorithms::Selector<
-              std::pair<types::global_cell_index, types::global_cell_index>,
-              unsigned int>
+              std::vector<
+                std::pair<types::global_cell_index, types::global_cell_index>>,
+              std::vector<unsigned int>>
               consensus_algorithm(process, communicator);
             consensus_algorithm.run();
           }
@@ -593,8 +594,9 @@ namespace internal
                 true);
 
       Utilities::MPI::ConsensusAlgorithms::Selector<
-        std::pair<types::global_cell_index, types::global_cell_index>,
-        unsigned int>
+        std::vector<
+          std::pair<types::global_cell_index, types::global_cell_index>>,
+        std::vector<unsigned int>>
         consensus_algorithm(process, communicator);
       consensus_algorithm.run();
 
@@ -3086,8 +3088,9 @@ MGTwoLevelTransfer<dim, LinearAlgebra::distributed::Vector<Number>>::reinit(
                 false);
 
       Utilities::MPI::ConsensusAlgorithms::Selector<
-        std::pair<types::global_cell_index, types::global_cell_index>,
-        unsigned int>
+        std::vector<
+          std::pair<types::global_cell_index, types::global_cell_index>>,
+        std::vector<unsigned int>>
         consensus_algorithm(process, communicator);
       consensus_algorithm.run();
 

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -381,7 +381,7 @@ namespace Utilities
       if (Utilities::MPI::min((my_destinations_are_unique ? 1 : 0), mpi_comm) ==
           1)
         {
-          return ConsensusAlgorithms::nbx<char, char>(
+          return ConsensusAlgorithms::nbx<std::vector<char>, std::vector<char>>(
             destinations, {}, {}, {}, mpi_comm);
         }
 
@@ -477,7 +477,7 @@ namespace Utilities
       if (Utilities::MPI::min((my_destinations_are_unique ? 1 : 0), mpi_comm) ==
           1)
         {
-          return ConsensusAlgorithms::nbx<char, char>(
+          return ConsensusAlgorithms::nbx<std::vector<char>, std::vector<char>>(
                    destinations, {}, {}, {}, mpi_comm)
             .size();
         }
@@ -1098,8 +1098,9 @@ namespace Utilities
       // partition (i.e. in the dictionary). This process returns the actual
       // owner of the index.
       ConsensusAlgorithms::Selector<
-        std::pair<types::global_dof_index, types::global_dof_index>,
-        unsigned int>
+        std::vector<
+          std::pair<types::global_dof_index, types::global_dof_index>>,
+        std::vector<unsigned int>>
         consensus_algorithm(process, comm);
       consensus_algorithm.run();
 

--- a/source/base/mpi_compute_index_owner_internal.cc
+++ b/source/base/mpi_compute_index_owner_internal.cc
@@ -408,8 +408,9 @@ namespace Utilities
                                      actually_owning_rank_list);
 
               ConsensusAlgorithms::Selector<
-                std::pair<types::global_dof_index, types::global_dof_index>,
-                unsigned int>
+                std::vector<
+                  std::pair<types::global_dof_index, types::global_dof_index>>,
+                std::vector<unsigned int>>
                 consensus_algo(temp, comm);
               consensus_algo.run();
             }

--- a/source/base/mpi_consensus_algorithms.cc
+++ b/source/base/mpi_consensus_algorithms.cc
@@ -15,6 +15,9 @@
 
 #include <deal.II/base/mpi_consensus_algorithms.templates.h>
 
+#include <boost/serialization/utility.hpp>
+
+
 DEAL_II_NAMESPACE_OPEN
 
 namespace Utilities
@@ -23,68 +26,78 @@ namespace Utilities
   {
     namespace ConsensusAlgorithms
     {
-      template class Process<unsigned int, unsigned int>;
+      template class Process<std::vector<unsigned int>,
+                             std::vector<unsigned int>>;
 
-      template class Interface<unsigned int, unsigned int>;
+      template class Interface<std::vector<unsigned int>,
+                               std::vector<unsigned int>>;
 
-      template class NBX<unsigned int, unsigned int>;
+      template class NBX<std::vector<unsigned int>, std::vector<unsigned int>>;
 
-      template class PEX<unsigned int, unsigned int>;
+      template class PEX<std::vector<unsigned int>, std::vector<unsigned int>>;
 
-      template class Serial<unsigned int, unsigned int>;
+      template class Serial<std::vector<unsigned int>,
+                            std::vector<unsigned int>>;
 
-      template class Selector<unsigned int, unsigned int>;
+      template class Selector<std::vector<unsigned int>,
+                              std::vector<unsigned int>>;
 
 
-      template class Process<
-        std::pair<types::global_dof_index, types::global_dof_index>,
-        unsigned int>;
+      template class Process<std::vector<std::pair<types::global_dof_index,
+                                                   types::global_dof_index>>,
+                             std::vector<unsigned int>>;
 
-      template class Interface<
-        std::pair<types::global_dof_index, types::global_dof_index>,
-        unsigned int>;
+      template class Interface<std::vector<std::pair<types::global_dof_index,
+                                                     types::global_dof_index>>,
+                               std::vector<unsigned int>>;
 
-      template class Selector<
-        std::pair<types::global_dof_index, types::global_dof_index>,
-        unsigned int>;
+      template class Selector<std::vector<std::pair<types::global_dof_index,
+                                                    types::global_dof_index>>,
+                              std::vector<unsigned int>>;
 
-      template class NBX<
-        std::pair<types::global_dof_index, types::global_dof_index>,
-        unsigned int>;
+      template class NBX<std::vector<std::pair<types::global_dof_index,
+                                               types::global_dof_index>>,
+                         std::vector<unsigned int>>;
 
-      template class Serial<
-        std::pair<types::global_dof_index, types::global_dof_index>,
-        unsigned int>;
+      template class Serial<std::vector<std::pair<types::global_dof_index,
+                                                  types::global_dof_index>>,
+                            std::vector<unsigned int>>;
 
-      template class PEX<
-        std::pair<types::global_dof_index, types::global_dof_index>,
-        unsigned int>;
+      template class PEX<std::vector<std::pair<types::global_dof_index,
+                                               types::global_dof_index>>,
+                         std::vector<unsigned int>>;
 
 #ifdef DEAL_II_WITH_64BIT_INDICES
-      template class Process<types::global_dof_index, unsigned int>;
+      template class Process<std::vector<types::global_dof_index>,
+                             std::vector<unsigned int>>;
 
-      template class Interface<types::global_dof_index, unsigned int>;
+      template class Interface<std::vector<types::global_dof_index>,
+                               std::vector<unsigned int>>;
 
-      template class NBX<types::global_dof_index, unsigned int>;
+      template class NBX<std::vector<types::global_dof_index>,
+                         std::vector<unsigned int>>;
 
-      template class Serial<types::global_dof_index, unsigned int>;
+      template class Serial<std::vector<types::global_dof_index>,
+                            std::vector<unsigned int>>;
 
-      template class PEX<types::global_dof_index, unsigned int>;
+      template class PEX<std::vector<types::global_dof_index>,
+                         std::vector<unsigned int>>;
 
-      template class Selector<types::global_dof_index, unsigned int>;
+      template class Selector<std::vector<types::global_dof_index>,
+                              std::vector<unsigned int>>;
 #endif
 
-      template class Process<char, char>;
+      template class Process<std::vector<char>, std::vector<char>>;
 
-      template class Interface<char, char>;
+      template class Interface<std::vector<char>, std::vector<char>>;
 
-      template class NBX<char, char>;
+      template class NBX<std::vector<char>, std::vector<char>>;
 
-      template class PEX<char, char>;
+      template class PEX<std::vector<char>, std::vector<char>>;
 
-      template class Serial<char, char>;
+      template class Serial<std::vector<char>, std::vector<char>>;
 
-      template class Selector<char, char>;
+      template class Selector<std::vector<char>, std::vector<char>>;
 
     } // namespace ConsensusAlgorithms
   }   // end of namespace MPI

--- a/source/base/mpi_noncontiguous_partitioner.cc
+++ b/source/base/mpi_noncontiguous_partitioner.cc
@@ -115,8 +115,9 @@ namespace Utilities
                 true);
 
       Utilities::MPI::ConsensusAlgorithms::Selector<
-        std::pair<types::global_dof_index, types::global_dof_index>,
-        unsigned int>
+        std::vector<
+          std::pair<types::global_dof_index, types::global_dof_index>>,
+        std::vector<unsigned int>>
         consensus_algorithm(process, communicator);
       consensus_algorithm.run();
 

--- a/source/base/partitioner.cc
+++ b/source/base/partitioner.cc
@@ -281,8 +281,9 @@ namespace Utilities
       // in the static partition (i.e. in the dictionary). This process
       // returns the actual owner of the index.
       ConsensusAlgorithms::Selector<
-        std::pair<types::global_dof_index, types::global_dof_index>,
-        unsigned int>
+        std::vector<
+          std::pair<types::global_dof_index, types::global_dof_index>>,
+        std::vector<unsigned int>>
         consensus_algorithm(process, communicator);
       consensus_algorithm.run();
 

--- a/source/distributed/repartitioning_policy_tools.cc
+++ b/source/distributed/repartitioning_policy_tools.cc
@@ -156,8 +156,9 @@ namespace RepartitioningPolicyTools
                 false);
 
       Utilities::MPI::ConsensusAlgorithms::Selector<
-        std::pair<types::global_cell_index, types::global_cell_index>,
-        unsigned int>
+        std::vector<
+          std::pair<types::global_cell_index, types::global_cell_index>>,
+        std::vector<unsigned int>>
         consensus_algorithm(process, communicator);
       consensus_algorithm.run();
     }

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -6080,7 +6080,8 @@ namespace GridTools
           }
       };
 
-      Utilities::MPI::ConsensusAlgorithms::selector<char, char>(
+      Utilities::MPI::ConsensusAlgorithms::selector<std::vector<char>,
+                                                    std::vector<char>>(
         potential_owners_ranks,
         create_request,
         answer_request,

--- a/source/grid/tria_description.cc
+++ b/source/grid/tria_description.cc
@@ -143,12 +143,12 @@ namespace TriangulationDescription
           };
 
 
-          dealii::Utilities::MPI::ConsensusAlgorithms::selector<char, char>(
-            relevant_processes,
-            create_request,
-            answer_request,
-            process_answer,
-            comm);
+          dealii::Utilities::MPI::ConsensusAlgorithms::
+            selector<std::vector<char>, std::vector<char>>(relevant_processes,
+                                                           create_request,
+                                                           answer_request,
+                                                           process_answer,
+                                                           comm);
         }
 
         /**

--- a/source/matrix_free/vector_data_exchange.cc
+++ b/source/matrix_free/vector_data_exchange.cc
@@ -24,6 +24,8 @@
 
 #ifdef DEAL_II_WITH_64BIT_INDICES
 #  include <deal.II/base/mpi_consensus_algorithms.templates.h>
+
+#  include <boost/serialization/utility.hpp>
 #endif
 
 #include <map>

--- a/source/matrix_free/vector_data_exchange.cc
+++ b/source/matrix_free/vector_data_exchange.cc
@@ -441,8 +441,9 @@ namespace internal
                   /*track_index_requests = */ true);
 
         Utilities::MPI::ConsensusAlgorithms::Selector<
-          std::pair<types::global_dof_index, types::global_dof_index>,
-          unsigned int>
+          std::vector<
+            std::pair<types::global_dof_index, types::global_dof_index>>,
+          std::vector<unsigned int>>
           consensus_algorithm(process, comm);
         consensus_algorithm.run();
 

--- a/source/multigrid/mg_tools.cc
+++ b/source/multigrid/mg_tools.cc
@@ -1823,8 +1823,9 @@ namespace MGTools
                   false);
 
         Utilities::MPI::ConsensusAlgorithms::Selector<
-          std::pair<types::global_cell_index, types::global_cell_index>,
-          unsigned int>
+          std::vector<
+            std::pair<types::global_cell_index, types::global_cell_index>>,
+          std::vector<unsigned int>>
           consensus_algorithm;
         consensus_algorithm.run(process, communicator);
 

--- a/tests/base/consensus_algorithm_01.cc
+++ b/tests/base/consensus_algorithm_01.cc
@@ -27,24 +27,24 @@ test(const MPI_Comm &comm)
   const unsigned int my_rank = dealii::Utilities::MPI::this_mpi_process(comm);
   const unsigned int n_rank  = dealii::Utilities::MPI::n_mpi_processes(comm);
 
-  using T1 = unsigned int;
-  using T2 = unsigned int;
+  using T1 = std::vector<unsigned int>;
+  using T2 = std::vector<unsigned int>;
 
   const auto sources =
     dealii::Utilities::MPI::ConsensusAlgorithms::selector<T1, T2>(
       /* target_processes: */
       std::vector<unsigned int>{(my_rank + 1) % n_rank},
       /* create_request: */
-      [my_rank](const unsigned int) { return std::vector<T1>({my_rank}); },
+      [my_rank](const unsigned int) { return T1({my_rank}); },
       /* answer_request: */
-      [my_rank](const unsigned int other_rank, const std::vector<T1> &request) {
+      [my_rank](const unsigned int other_rank, const T1 &request) {
         AssertDimension(other_rank, request.front());
         deallog << "ConsensusAlgorithmProcess::answer_request() passed!"
                 << std::endl;
-        return std::vector<T2>({my_rank});
+        return T2({my_rank});
       },
       /* process_answer: */
-      [](const unsigned int other_rank, const std::vector<T2> &answer) {
+      [](const unsigned int other_rank, const T2 &answer) {
         AssertDimension(other_rank, answer.front());
         deallog << "ConsensusAlgorithmProcess::function_read_answer() passed!"
                 << std::endl;


### PR DESCRIPTION
As written right now, the consensus algorithms take a `std::vector<RequestType>`/`std::vector<AnswerType>` and transmit this data to other processes. However, they do this on a byte-by-byte basis, not using the MPI type mechanism. This is conceptually not great since (i) it doesn't ensure that MPI converts data types when transmitting from systems with different endianness (not generally a problem, nobody does work on systems that are heterogeneous in this way), but more importantly (ii) it essentially assumes that the bit representation of a type is all that matters. The implementation does not currently have a way to ensure that that is true, and as a consequence you can currently send things such as `std::vector<std::string>` or some such without an error -- but all you get at the other end is the same bit representation of the `std::string` object, which is not generally what you want and will contain pointers that point to random places in memory.

This patch does two things:
* It calls `Utilities::pack/unpack()` on the data so sent.
* While there, it replaces `std::vector<RequestType>`/`std::vector<AnswerType>` by `RequestType`/`AnswerType`, that is, one can now exchange *all* data types via the consensus algorithms interface, not just `std::vector` objects of scalar objects. 

There are a couple of places in the library where the send/receive functions currently already pack non-vector objects into `std::vector<char>` arrays. This means that in those places, we currently pack/unpack twice. I will fix this in a follow-up patch, but wanted to get the basic functionality out as a stand-alone patch.

I will add that there is a cost associated with packing/unpacking. I believe that that cost is acceptable given the more flexible interface.

Part of #13208.

/rebuild