### PR TITLE
MF: fix if all cells of a process are FE_Nothing

### DIFF
--- a/source/matrix_free/dof_info.cc
+++ b/source/matrix_free/dof_info.cc
@@ -621,10 +621,12 @@ namespace internal
                   for (unsigned int j = 0; j < n_comp; ++j)
                     dof_indices_contiguous
                       [dof_access_cell][i * vectorization_length + j] =
-                        this->dof_indices[row_starts[(i * vectorization_length +
-                                                      j) *
-                                                     n_components]
-                                            .first];
+                        this->dof_indices.size() == 0 ?
+                          0 :
+                          this->dof_indices
+                            [row_starts[(i * vectorization_length + j) *
+                                        n_components]
+                               .first];
                 }
 
               if (indices_are_interleaved_and_contiguous)


### PR DESCRIPTION
As reported by @sebproell, the following program run with two processes fails with segfault:

```cpp
#include <deal.II/fe/fe_nothing.h>
#include <deal.II/fe/fe_system.h>

#include <deal.II/grid/grid_generator.h>

#include <deal.II/matrix_free/matrix_free.h>

#include "../tests.h"


template <int dim, int fe_degree>
void
test()
{
  parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD);

  if (true)
    // Fails with segfault
    GridGenerator::subdivided_hyper_cube(tria, 2);
  else
    {
      // works
      GridGenerator::hyper_cube(tria);
      tria.refine_global(1);
    }


  hp::FECollection<dim> fe{FE_Q<dim>(fe_degree), FE_Nothing<dim>(1)};
  DoFHandler<dim>       dof(tria);
  {
    std::vector<unsigned> active_indices(tria.n_active_cells());
    for (unsigned i = 0; i < tria.n_active_cells() / 2; ++i)
      active_indices[i] = 1;
    dof.set_active_fe_indices(active_indices);
  }
  dof.distribute_dofs(fe);

  AffineConstraints<double> constraints;
  constraints.close();

  deallog << "Testing reinit for " << dof.get_fe().get_name() << std::endl;
  deallog << "#dofs: " << dof.n_locally_owned_dofs() << std::endl;

  using number = double;
  MatrixFree<dim, number> mf_data;
  {
    const QGauss<1>                                  quad(fe_degree + 1);
    typename MatrixFree<dim, number>::AdditionalData data;
    data.tasks_parallel_scheme = MatrixFree<dim, number>::AdditionalData::none;
    data.mapping_update_flags =
      (dealii::update_values | dealii::update_gradients |
       dealii::update_JxW_values | dealii::update_quadrature_points);
    mf_data.reinit(MappingQ<dim>(fe_degree),
                   dof,
                   constraints,
                   hp::QCollection<dim>(quad, quad),
                   data);
  }
}

int
main(int argc, char **argv)
{
  Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
  MPILogInitAll                    log;

  deallog << std::setprecision(3);
  {
    deallog.push("2d");
    test<2, 1>();
    test<2, 2>();
    test<2, 3>();
    test<2, 4>();
    deallog.pop();
    deallog.push("3d");
    test<3, 1>();
    test<3, 2>();
    deallog.pop();
  }
}
```

The problem is that all processes have cells but there is a process without DoFs.

@sebproell Maybe you could add your program as test in a follow-up PR.