### PR TITLE
CMake: Do not warn about not finding CGAL

### DIFF
--- a/cmake/modules/FindCGAL.cmake
+++ b/cmake/modules/FindCGAL.cmake
@@ -32,7 +32,7 @@ IF(DEAL_II_HAVE_CXX17)
   # temporarily disable ${CMAKE_SOURCE_DIR}/cmake/modules for module lookup
   LIST(REMOVE_ITEM CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
   SET(CGAL_DO_NOT_WARN_ABOUT_CMAKE_BUILD_TYPE ON)
-  FIND_PACKAGE(CGAL)
+  FIND_PACKAGE(CGAL QUIET)
   # Check version manually. Older binary distros don't do this properly.
   IF(CGAL_MAJOR_VERSION LESS 5)
     SET(CGAL_FOUND FALSE)


### PR DESCRIPTION
Newer CMake versions (encountered with CMake 3.20) seem to warn very
verbosely about not finding a package. Let's add the "QUIET" keyword to
the find_package() call to silence the warning.