### PR TITLE
Set is_tensor_product_flag in Quadrature::initialize(..)

### DIFF
--- a/source/base/quadrature.cc
+++ b/source/base/quadrature.cc
@@ -53,8 +53,9 @@ Quadrature<dim>::initialize(const std::vector<Point<dim>> &p,
                             const std::vector<double> &    w)
 {
   AssertDimension(w.size(), p.size());
-  quadrature_points = p;
-  weights           = w;
+  quadrature_points      = p;
+  weights                = w;
+  is_tensor_product_flag = dim == 1;
 }
 
 


### PR DESCRIPTION
If you first create a quadrature which is a tensor product and then call initialize with points and weights which does not correspond to a tensor product, you can make is_tensor_product_flag have wrong value. Set the flag in intialize(..) to avoid this.

```c++
#include <deal.II/base/quadrature_lib.h>

using namespace dealii;

int
main()
{
  const int dim = 2;

  QGauss<dim> quadrature(2);

  std::vector<Point<dim>> arbirary_points(3);
  std::vector<double>     arbirary_weights(3);

  // Puts the tensor product flag in the wrong state.
  quadrature.initialize(arbirary_points, arbirary_weights);
  
  std::cout << quadrature.is_tensor_product() << std::endl;
}
```


Or would it be better to require that the quadrature is empty when initialize is called?