### PR TITLE
Add another variant for multigrid test

### DIFF
--- a/tests/matrix_free/parallel_multigrid_interleave_renumber.with_p4est=true.with_lapack=true.mpirun=2.output.2
+++ b/tests/matrix_free/parallel_multigrid_interleave_renumber.with_p4est=true.with_lapack=true.mpirun=2.output.2
@@ -1,0 +1,65 @@
+
+DEAL::Testing FE_Q<2>(1)
+DEAL::Number of degrees of freedom: 81
+DEAL:cg::Starting value 7.00000
+DEAL:cg::Convergence step 3 value 1.45467e-07
+DEAL::Number of calls to special vmult for Operator of size 4: 13
+DEAL::Number of calls to special vmult for Operator of size 9: 29
+DEAL::Number of calls to special vmult for Operator of size 25: 33
+DEAL::Number of calls to special vmult for Operator of size 81: 42
+DEAL::Testing FE_Q<2>(1)
+DEAL::Number of degrees of freedom: 289
+DEAL:cg::Starting value 15.0000
+DEAL:cg::Convergence step 4 value 1.05853e-08
+DEAL::Number of calls to special vmult for Operator of size 4: 17
+DEAL::Number of calls to special vmult for Operator of size 9: 38
+DEAL::Number of calls to special vmult for Operator of size 25: 42
+DEAL::Number of calls to special vmult for Operator of size 81: 51
+DEAL::Number of calls to special vmult for Operator of size 289: 51
+DEAL::Testing FE_Q<2>(3)
+DEAL::Number of degrees of freedom: 625
+DEAL:cg::Starting value 23.0000
+DEAL:cg::Convergence step 4 value 6.97010e-08
+DEAL::Number of calls to special vmult for Operator of size 16: 19
+DEAL::Number of calls to special vmult for Operator of size 49: 48
+DEAL::Number of calls to special vmult for Operator of size 169: 51
+DEAL::Number of calls to special vmult for Operator of size 625: 51
+DEAL::Testing FE_Q<2>(3)
+DEAL::Number of degrees of freedom: 2401
+DEAL:cg::Starting value 47.0000
+DEAL:cg::Convergence step 4 value 2.52497e-07
+DEAL::Number of calls to special vmult for Operator of size 16: 19
+DEAL::Number of calls to special vmult for Operator of size 49: 48
+DEAL::Number of calls to special vmult for Operator of size 169: 51
+DEAL::Number of calls to special vmult for Operator of size 625: 51
+DEAL::Number of calls to special vmult for Operator of size 2401: 51
+DEAL::Testing FE_Q<3>(1)
+DEAL::Number of degrees of freedom: 125
+DEAL:cg::Starting value 5.19615
+DEAL:cg::Convergence step 3 value 5.18177e-09
+DEAL::Number of calls to special vmult for Operator of size 8: 13
+DEAL::Number of calls to special vmult for Operator of size 27: 28
+DEAL::Number of calls to special vmult for Operator of size 125: 34
+DEAL::Testing FE_Q<3>(1)
+DEAL::Number of degrees of freedom: 729
+DEAL:cg::Starting value 18.5203
+DEAL:cg::Convergence step 3 value 9.84548e-07
+DEAL::Number of calls to special vmult for Operator of size 8: 13
+DEAL::Number of calls to special vmult for Operator of size 27: 28
+DEAL::Number of calls to special vmult for Operator of size 125: 34
+DEAL::Number of calls to special vmult for Operator of size 729: 42
+DEAL::Testing FE_Q<3>(2)
+DEAL::Number of degrees of freedom: 729
+DEAL:cg::Starting value 18.5203
+DEAL:cg::Convergence step 4 value 5.63253e-09
+DEAL::Number of calls to special vmult for Operator of size 27: 18
+DEAL::Number of calls to special vmult for Operator of size 125: 43
+DEAL::Number of calls to special vmult for Operator of size 729: 51
+DEAL::Testing FE_Q<3>(2)
+DEAL::Number of degrees of freedom: 4913
+DEAL:cg::Starting value 58.0948
+DEAL:cg::Convergence step 4 value 3.48121e-08
+DEAL::Number of calls to special vmult for Operator of size 27: 18
+DEAL::Number of calls to special vmult for Operator of size 125: 43
+DEAL::Number of calls to special vmult for Operator of size 729: 51
+DEAL::Number of calls to special vmult for Operator of size 4913: 51


### PR DESCRIPTION
The test to check the behavior of multigrid with the interleaved CG solver turns out to be somewhat sensitive to roundoff errors. Since counting the number of times we call the matrix-vector product is the core purpose of this test, we need to add a second verified test output. (I hope that this one is accepted by https://cdash.43-1.org/viewTest.php?onlyfailed&buildid=1508 - unfortunately I can't see the failure on that hardware.)