### PR TITLE
CMake: remove -Wl,--as-needed flag setup

### DIFF
--- a/cmake/config/CMakeLists.txt
+++ b/cmake/config/CMakeLists.txt
@@ -65,12 +65,6 @@ INSTALL(FILES ${_macros}
 ########################################################################
 
 #
-# Do not force --as-needed for executables on user side:
-#
-
-STRIP_FLAG(DEAL_II_LINKER_FLAGS "-Wl,--as-needed")
-
-#
 # Strip -Wno-deprecated-declarations from DEAL_II_CXX_FLAGS so that
 # deprecation warnings are actually shown for user code:
 #

--- a/cmake/macros/macro_check_compiler_setup.cmake
+++ b/cmake/macros/macro_check_compiler_setup.cmake
@@ -27,28 +27,10 @@
 
 MACRO(CHECK_COMPILER_SETUP _compiler_flags_unstr _linker_flags_unstr _var)
   #
-  # Strip -Wl,--as-needed from the list of linker flags. This works around
-  # a serious regression with ld.bfd in combination with -Wl,--as-needed
-  # when compiling a simple
-  #
-  #    int main () { return 0; }
-  #
-  # and linking against a *huge* list of (entirely unused) libraries.
-  #
-  # Ideally, one should use ld.gold [1] instead of ld.bfd - but because
-  # this is not always possible, simply disable -Wl,--as-needed.
-  #
-  # See https://github.com/dealii/dealii/issues/3686
-  #
-  # [1] https://lwn.net/Articles/274859/
-  #
-  STRING(REPLACE "-Wl,--as-needed" "" _linker_flags "${_linker_flags_unstr}")
-
-  #
   # Strip leading and trailing whitespace to make CMake 2.8.8 happy
   #
   STRING(STRIP "${_compiler_flags_unstr}" _compiler_flags)
-  STRING(STRIP "${_linker_flags}" _linker_flags)
+  STRING(STRIP "${_linker_flags_unstr}" _linker_flags)
 
   #
   # Rerun this test if flags have changed:

--- a/cmake/setup_compiler_flags_gnu.cmake
+++ b/cmake/setup_compiler_flags_gnu.cmake
@@ -66,12 +66,6 @@ ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-pedantic")
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-fPIC")
 
 #
-# Check whether the -as-needed flag is available. If so set it to link
-# the deal.II library with it.
-#
-ENABLE_IF_LINKS(DEAL_II_LINKER_FLAGS "-Wl,--as-needed")
-
-#
 # Setup various warnings:
 #
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-Wall")

--- a/cmake/setup_compiler_flags_intel.cmake
+++ b/cmake/setup_compiler_flags_intel.cmake
@@ -40,12 +40,6 @@ ENDIF()
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-fpic")
 
 #
-# Check whether the -as-needed flag is available. If so set it to link
-# the deal.II library with it.
-#
-ENABLE_IF_LINKS(DEAL_II_LINKER_FLAGS "-Wl,--as-needed")
-
-#
 # Enable verbose warnings:
 #
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-w2")


### PR DESCRIPTION
The issue with the current handling of the --Wl,--as-needed flag is the
fact that we set it internally but later on filter it (unconditionally)
for user projects.

This has the issue that it is currently not possible to set
--Wl,--as-needed by hand when needed.

Thus, let us simply remove the setup and the workarounds.