### PR TITLE
Avoid double packing/unpacking for CA algorithms.

### DIFF
--- a/source/multigrid/mg_tools.cc
+++ b/source/multigrid/mg_tools.cc
@@ -16,6 +16,7 @@
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/mg_level_object.h>
 #include <deal.II/base/mpi_compute_index_owner_internal.h>
+#include <deal.II/base/mpi_consensus_algorithms.templates.h>
 #include <deal.II/base/thread_management.h>
 
 #include <deal.II/dofs/dof_accessor.h>


### PR DESCRIPTION
Following https://github.com/dealii/dealii/pull/13722, we can deal with general data types in the CA algorithms. This fixes those places where we had previously packed data into buffers the existing implementation could handle. Instead, we directly give the unpacked data structure to the CA algorithm and let it do the packing.

Part of https://github.com/dealii/dealii/issues/13208.

/rebuild