### PR TITLE
Added missing headers to failing test.

### DIFF
--- a/tests/sharedtria/refine_and_coarsen_01.cc
+++ b/tests/sharedtria/refine_and_coarsen_01.cc
@@ -22,6 +22,10 @@
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_refinement.h>
 
+#include <deal.II/lac/vector.h>
+
+#include <vector>
+
 #include "../tests.h"
 
 


### PR DESCRIPTION
According to https://cdash.dealii.43-1.org/test/8539907, this test has missing headers.

Part of https://github.com/dealii/dealii/issues/13703.