### PR TITLE
Fix sundials 6 tests, part 1

### DIFF
--- a/include/deal.II/sundials/arkode.h
+++ b/include/deal.II/sundials/arkode.h
@@ -1267,7 +1267,7 @@ namespace SUNDIALS
      */
     void *arkode_mem;
 
-#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
     /**
      * A context object associated with the ARKode solver.
      */

--- a/include/deal.II/sundials/ida.h
+++ b/include/deal.II/sundials/ida.h
@@ -882,7 +882,7 @@ namespace SUNDIALS
      */
     void *ida_mem;
 
-#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
     /**
      * A context object associated with the IDA solver.
      */

--- a/include/deal.II/sundials/kinsol.h
+++ b/include/deal.II/sundials/kinsol.h
@@ -694,7 +694,7 @@ namespace SUNDIALS
      */
     void *kinsol_mem;
 
-#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
     /**
      * A context object associated with the KINSOL solver.
      */

--- a/include/deal.II/sundials/n_vector.h
+++ b/include/deal.II/sundials/n_vector.h
@@ -41,6 +41,7 @@ namespace SUNDIALS
 {
   namespace internal
   {
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
     /**
      * Create a NVectorView of the given @p vector.
      *
@@ -56,22 +57,48 @@ namespace SUNDIALS
      * @tparam VectorType Type of the viewed vector. This parameter can be
      *   deduced automatically and will respect a potential const-qualifier.
      * @param vector The vector to view.
-#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
      * @param nvector_context A SUNDIALS context object to be used for the
      *   operations we want to do on this vector.
-#  endif
      * @return A NVectorView of the @p vector.
      *
      * @related NVectorView
+     *
+     * @note Versions of this function prior to SUNDIALS 6.0 did not take a
+     * SUNContext argument.
      */
     template <typename VectorType>
     NVectorView<VectorType>
-    make_nvector_view(VectorType &vector
-#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
-                      ,
-                      SUNContext nvector_context
+    make_nvector_view(VectorType &vector, SUNContext nvector_context);
+#  else
+    /**
+     * Create a NVectorView of the given @p vector.
+     *
+     * This call is intended to be used as
+     *
+     * @code
+     *   auto view = make_nvector_view(vector);
+     * @endcode
+     *
+     * The resulting object `view` must be kept around as long as any other
+     * object will use the internally viewed N_Vector.
+     *
+     * @tparam VectorType Type of the viewed vector. This parameter can be
+     *   deduced automatically and will respect a potential const-qualifier.
+     * @param vector The vector to view.
+     * @param nvector_context A SUNDIALS context object to be used for the
+     *   operations we want to do on this vector.
+     * @return A NVectorView of the @p vector.
+     *
+     * @related NVectorView
+     *
+     * @note This version of make_nvector_view() is only for versions of
+     * SUNDIALS prior to 6.0 which did not need a SUNContext object to set up a
+     * vector.
+     */
+    template <typename VectorType>
+    NVectorView<VectorType>
+    make_nvector_view(VectorType &vector);
 #  endif
-    );
 
     /**
      * Retrieve the underlying vector attached to N_Vector @p v. This call will
@@ -135,15 +162,23 @@ namespace SUNDIALS
        */
       NVectorView() = default;
 
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
       /**
        * Constructor. Create view of @p vector.
+       *
+       * @note Versions of this function prior to SUNDIALS 6.0 did not take a
+       * SUNContext argument.
        */
-      NVectorView(VectorType &vector
-#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
-                  ,
-                  SUNContext nvector_context
+      NVectorView(VectorType &vector, SUNContext nvector_context);
+#  else
+      /**
+       * Constructor. Create view of @p vector.
+       *
+       * @note This constructor is only for versions of SUNDIALS prior to 6.0
+       * which do not need a SUNContext object to set up a vector.
+       */
+      NVectorView(VectorType &vector);
 #  endif
-      );
 
       /**
        * Move assignment.

--- a/include/deal.II/sundials/n_vector.h
+++ b/include/deal.II/sundials/n_vector.h
@@ -56,7 +56,7 @@ namespace SUNDIALS
      * @tparam VectorType Type of the viewed vector. This parameter can be
      *   deduced automatically and will respect a potential const-qualifier.
      * @param vector The vector to view.
-#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
      * @param nvector_context A SUNDIALS context object to be used for the
      *   operations we want to do on this vector.
 #  endif
@@ -67,7 +67,7 @@ namespace SUNDIALS
     template <typename VectorType>
     NVectorView<VectorType>
     make_nvector_view(VectorType &vector
-#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
                       ,
                       SUNContext nvector_context
 #  endif
@@ -139,7 +139,7 @@ namespace SUNDIALS
        * Constructor. Create view of @p vector.
        */
       NVectorView(VectorType &vector
-#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
                   ,
                   SUNContext nvector_context
 #  endif

--- a/include/deal.II/sundials/n_vector.templates.h
+++ b/include/deal.II/sundials/n_vector.templates.h
@@ -363,22 +363,21 @@ namespace SUNDIALS
 
 
 
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
     template <typename VectorType>
     NVectorView<VectorType>
-    make_nvector_view(VectorType &vector
-#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
-                      ,
-                      SUNContext nvector_context
-#  endif
-    )
+    make_nvector_view(VectorType &vector, SUNContext nvector_context)
     {
-      return NVectorView<VectorType>(vector
-#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
-                                     ,
-                                     nvector_context
-#  endif
-      );
+      return NVectorView<VectorType>(vector, nvector_context);
     }
+#  else
+    template <typename VectorType>
+    NVectorView<VectorType>
+    make_nvector_view(VectorType &vector)
+    {
+      return NVectorView<VectorType>(vector);
+    }
+#  endif
 
 
 

--- a/include/deal.II/sundials/n_vector.templates.h
+++ b/include/deal.II/sundials/n_vector.templates.h
@@ -126,7 +126,7 @@ namespace SUNDIALS
     template <typename VectorType>
     N_Vector
     create_nvector(NVectorContent<VectorType> *content
-#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
                    ,
                    SUNContext nvector_context
 #  endif
@@ -139,7 +139,7 @@ namespace SUNDIALS
     template <typename VectorType>
     N_Vector
     create_empty_nvector(
-#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
       SUNContext nvector_context
 #  endif
     );
@@ -366,14 +366,14 @@ namespace SUNDIALS
     template <typename VectorType>
     NVectorView<VectorType>
     make_nvector_view(VectorType &vector
-#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
                       ,
                       SUNContext nvector_context
 #  endif
     )
     {
       return NVectorView<VectorType>(vector
-#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
                                      ,
                                      nvector_context
 #  endif
@@ -410,7 +410,7 @@ namespace SUNDIALS
 
     template <typename VectorType>
     NVectorView<VectorType>::NVectorView(VectorType &vector
-#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
                                          ,
                                          SUNContext nvector_context
 #  endif
@@ -419,7 +419,7 @@ namespace SUNDIALS
           create_nvector(
             new NVectorContent<typename std::remove_const<VectorType>::type>(
               &vector)
-#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
               ,
             nvector_context
 #  endif
@@ -451,7 +451,7 @@ namespace SUNDIALS
     template <typename VectorType>
     N_Vector
     create_nvector(NVectorContent<VectorType> *content
-#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
                    ,
                    SUNContext nvector_context
 #  endif
@@ -983,7 +983,7 @@ namespace SUNDIALS
     template <typename VectorType>
     N_Vector
     create_empty_nvector(
-#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
       SUNContext nvector_context
 #  endif
     )

--- a/include/deal.II/sundials/sunlinsol_wrapper.h
+++ b/include/deal.II/sundials/sunlinsol_wrapper.h
@@ -167,7 +167,7 @@ namespace SUNDIALS
     {
     public:
       explicit LinearSolverWrapper(LinearSolveFunction<VectorType> lsolve
-#    if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+#    if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
                                    ,
                                    SUNContext &linsol_ctx
 #    endif

--- a/source/sundials/arkode.cc
+++ b/source/sundials/arkode.cc
@@ -389,7 +389,7 @@ namespace SUNDIALS
         ARKStepFree(&arkode_mem);
 #  endif
 
-#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
         const int status = SUNContext_Free(&arkode_ctx);
         (void)status;
         AssertARKode(status);
@@ -452,7 +452,7 @@ namespace SUNDIALS
       }
 
     auto solution_nvector = internal::make_nvector_view(solution
-#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
                                                         ,
                                                         arkode_ctx
 #  endif
@@ -524,7 +524,7 @@ namespace SUNDIALS
     // just a view on the memory in solution, all write operations on yy by
     // ARKODE will automatically be mirrored to solution
     auto initial_condition_nvector = internal::make_nvector_view(solution
-#    if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+#    if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
                                                                  ,
                                                                  arkode_ctx
 #    endif
@@ -541,7 +541,7 @@ namespace SUNDIALS
     if (get_local_tolerances)
       {
         const auto abs_tols = internal::make_nvector_view(get_local_tolerances()
-#    if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+#    if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
                                                             ,
                                                           arkode_ctx
 #    endif
@@ -630,7 +630,7 @@ namespace SUNDIALS
       {
         ARKStepFree(&arkode_mem);
 
-#    if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+#    if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
         const int status = SUNContext_Free(&arkode_ctx);
         (void)status;
         AssertARKode(status);
@@ -643,7 +643,7 @@ namespace SUNDIALS
     // just a view on the memory in solution, all write operations on yy by
     // ARKODE will automatically be mirrored to solution
     auto initial_condition_nvector = internal::make_nvector_view(solution
-#    if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+#    if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
                                                                  ,
                                                                  arkode_ctx
 #    endif
@@ -674,7 +674,7 @@ namespace SUNDIALS
     if (get_local_tolerances)
       {
         const auto abs_tols = internal::make_nvector_view(get_local_tolerances()
-#    if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+#    if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
                                                             ,
                                                           arkode_ctx
 #    endif
@@ -734,7 +734,7 @@ namespace SUNDIALS
             linear_solver =
               std::make_unique<internal::LinearSolverWrapper<VectorType>>(
                 solve_linearized_system
-#    if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+#    if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
                 ,
                 arkode_ctx
 #    endif
@@ -746,7 +746,7 @@ namespace SUNDIALS
             // use default solver from SUNDIALS
             // TODO give user options
             auto y_template = internal::make_nvector_view(solution
-#    if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+#    if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
                                                           ,
                                                           arkode_ctx
 #    endif
@@ -793,7 +793,7 @@ namespace SUNDIALS
     else
       {
         auto y_template = internal::make_nvector_view(solution
-#    if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+#    if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
                                                       ,
                                                       arkode_ctx
 #    endif
@@ -836,7 +836,7 @@ namespace SUNDIALS
             mass_solver =
               std::make_unique<internal::LinearSolverWrapper<VectorType>>(
                 solve_mass
-#    if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+#    if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
                 ,
                 arkode_ctx
 #    endif
@@ -846,7 +846,7 @@ namespace SUNDIALS
         else
           {
             auto y_template = internal::make_nvector_view(solution
-#    if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+#    if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
                                                           ,
                                                           arkode_ctx
 #    endif


### PR DESCRIPTION
I presently get a bunch of test failures (listed in #13703) with SUNDIALS 6. A lot of our code looks like

https://github.com/dealii/dealii/blob/8d72163873b452da62abdf59699cd1a775e0e8ba/source/sundials/sunlinsol_wrapper.cc#L243-L257

i.e., we unconditionally abort in SUNDIALS 6. This PR cleans up some SUNDIALS 6 preprocessor checks and fixes the nvector tests.