### PR TITLE
Step-75: use well-formed deleter

### DIFF
--- a/examples/step-75/step-75.cc
+++ b/examples/step-75/step-75.cc
@@ -669,8 +669,7 @@ namespace Step75
           dof_handler.get_triangulation());
     else
       coarse_grid_triangulations.emplace_back(
-        const_cast<Triangulation<dim> *>(&(dof_handler.get_triangulation())),
-        [](auto &) {});
+        &(dof_handler.get_triangulation()), [](auto *) {});
 
     // Determine the total number of levels for the multigrid operation and
     // allocate sufficient memory for all levels.


### PR DESCRIPTION
LLVM/Clang's libc++ library version 13/14 got stricter by checking
requirements of the deleter, in particular, according to [1] a deleter
must pass the requirement `__shared_ptr_deleter_ctor_reqs` which is
defined as follows:
```
template <class _Dp, class _Pt, class = decltype(declval<_Dp>()(declval<_Pt>()))>
static true_type __well_formed_deleter_test(int);

template <class, class>
static false_type __well_formed_deleter_test(...);

template <class _Dp, class _Pt>
struct __well_formed_deleter : decltype(__well_formed_deleter_test<_Dp, _Pt>(0)) {};

template<class _Dp, class _Tp, class _Yp>
struct __shared_ptr_deleter_ctor_reqs
{
    static const bool value = __compatible_with<_Tp, _Yp>::value &&
                              is_move_constructible<_Dp>::value &&
                              __well_formed_deleter<_Dp, _Tp*>::value;
};
```
Unfortunately, our construct
```
coarse_grid_triangulations.emplace_back(
  const_cast<Triangulation<dim> *>(&(dof_handler.get_triangulation())),
  [](auto &) {});
```
does not pass this test. The issue is that the deleter takes a pointer,
not a reference which, so the lambda `[](auto &){}` does not pass above
`__shared_ptr_deleter_ctor_reqs`.

While at it, remove the const cast: `coarse_grid_triangulations` is
declared as a vector holding a `shared_ptr<const Triangulation<dim>>`,
thus we should simply take the address and not convert to a non-const
object.

Fixes
  https://cdash.dealii.43-1.org/viewBuildError.php?buildid=1614
  https://cdash.dealii.43-1.org/viewBuildError.php?buildid=1613

[1] https://github.com/llvm/llvm-project/blob/main/libcxx/include/__memory/shared_ptr.h

Closes #13613