### PR TITLE
Check for range of function calls in bfgs tests.

### DIFF
--- a/tests/optimization/bfgs_05.cc
+++ b/tests/optimization/bfgs_05.cc
@@ -210,7 +210,13 @@ test()
   SolverBFGS<VectorType>                          solver(solver_control, data);
   solver.connect_line_search_slot(line_min);
   solver.connect_preconditioner_slot(preconditioner);
-  solver.solve(func, x);
+
+  // We will check whether the number of function calls is within a specified
+  // range.
+  check_solver_within_range(solver.solve(func, x),
+                            (tot_fun_calls - 1) /*one evaluation above*/,
+                            130,
+                            140);
 
   Assert(tot_fun_calls == line_search_iterations + 1, ExcInternalError());
 
@@ -221,9 +227,6 @@ test()
 
   x.add(-1, location);
   deallog << "Linf error in solution: " << x.linfty_norm() << std::endl;
-
-  // deallog << "function calls: "
-  //         << (tot_fun_calls - 1) /*one evaluation above*/ << std::endl;
 }
 
 int

--- a/tests/optimization/bfgs_05.cc
+++ b/tests/optimization/bfgs_05.cc
@@ -222,8 +222,8 @@ test()
   x.add(-1, location);
   deallog << "Linf error in solution: " << x.linfty_norm() << std::endl;
 
-  deallog << "function calls: "
-          << (tot_fun_calls - 1) /*one evaluation above*/ << std::endl;
+  // deallog << "function calls: "
+  //         << (tot_fun_calls - 1) /*one evaluation above*/ << std::endl;
 }
 
 int

--- a/tests/optimization/bfgs_05.output
+++ b/tests/optimization/bfgs_05.output
@@ -161,4 +161,3 @@ DEAL::Limited memory BFGS solution:
 -4.483e-09 5.000e-02 1.000e-01 1.500e-01 2.000e-01 2.500e-01 3.000e-01 3.500e-01 4.000e-01 4.500e-01 5.000e-01 5.500e-01 6.000e-01 6.500e-01 7.000e-01 7.500e-01 8.000e-01 8.500e-01 9.000e-01 9.500e-01 1.000e+00 
 DEAL::Function value: 1.3096e-13
 DEAL::Linf error in solution: 1.6564e-07
-DEAL::function calls: 133

--- a/tests/optimization/bfgs_05.output
+++ b/tests/optimization/bfgs_05.output
@@ -1,5 +1,4 @@
 
-DEAL:BFGS::Starting value 63.201
 ------------------------------------------------
 Line search 0
 
@@ -156,7 +155,7 @@ function value: 9.39817  stepsize: 1.00000
          -0.10382         -2.78767          0.00745
          -0.04649         -1.29372          0.00407
           0.00033          0.06337         -0.00053
-DEAL:BFGS::Convergence step 127 value 8.1397e-06
+DEAL::Solver stopped within 130 - 140 iterations
 DEAL::Limited memory BFGS solution:
 -4.483e-09 5.000e-02 1.000e-01 1.500e-01 2.000e-01 2.500e-01 3.000e-01 3.500e-01 4.000e-01 4.500e-01 5.000e-01 5.500e-01 6.000e-01 6.500e-01 7.000e-01 7.500e-01 8.000e-01 8.500e-01 9.000e-01 9.500e-01 1.000e+00 
 DEAL::Function value: 1.3096e-13

--- a/tests/optimization/bfgs_05b.cc
+++ b/tests/optimization/bfgs_05b.cc
@@ -113,7 +113,13 @@ test()
   typename SolverBFGS<VectorType>::AdditionalData data(m_max, false);
   SolverBFGS<VectorType>                          solver(solver_control, data);
   solver.connect_preconditioner_slot(preconditioner);
-  solver.solve(func, x);
+
+  // We will check whether the number of function calls is within a specified
+  // range.
+  check_solver_within_range(solver.solve(func, x),
+                            (tot_fun_calls - 1) /*one evaluation above*/,
+                            130,
+                            140);
 
   deallog << "Limited memory BFGS solution:" << std::endl;
   x.print(deallog.get_file_stream());
@@ -122,9 +128,6 @@ test()
 
   x.add(-1, location);
   deallog << "Linf error in solution: " << x.linfty_norm() << std::endl;
-
-  // deallog << "function calls: "
-  //         << (tot_fun_calls - 1) /*one evaluation above*/ << std::endl;
 }
 
 int

--- a/tests/optimization/bfgs_05b.cc
+++ b/tests/optimization/bfgs_05b.cc
@@ -123,8 +123,8 @@ test()
   x.add(-1, location);
   deallog << "Linf error in solution: " << x.linfty_norm() << std::endl;
 
-  deallog << "function calls: "
-          << (tot_fun_calls - 1) /*one evaluation above*/ << std::endl;
+  // deallog << "function calls: "
+  //         << (tot_fun_calls - 1) /*one evaluation above*/ << std::endl;
 }
 
 int

--- a/tests/optimization/bfgs_05b.output
+++ b/tests/optimization/bfgs_05b.output
@@ -5,4 +5,3 @@ DEAL::Limited memory BFGS solution:
 -4.483e-09 5.000e-02 1.000e-01 1.500e-01 2.000e-01 2.500e-01 3.000e-01 3.500e-01 4.000e-01 4.500e-01 5.000e-01 5.500e-01 6.000e-01 6.500e-01 7.000e-01 7.500e-01 8.000e-01 8.500e-01 9.000e-01 9.500e-01 1.000e+00 
 DEAL::Function value: 1.3096e-13
 DEAL::Linf error in solution: 1.6564e-07
-DEAL::function calls: 133

--- a/tests/optimization/bfgs_05b.output
+++ b/tests/optimization/bfgs_05b.output
@@ -1,6 +1,5 @@
 
-DEAL:BFGS::Starting value 63.201
-DEAL:BFGS::Convergence step 127 value 8.1397e-06
+DEAL::Solver stopped within 130 - 140 iterations
 DEAL::Limited memory BFGS solution:
 -4.483e-09 5.000e-02 1.000e-01 1.500e-01 2.000e-01 2.500e-01 3.000e-01 3.500e-01 4.000e-01 4.500e-01 5.000e-01 5.500e-01 6.000e-01 6.500e-01 7.000e-01 7.500e-01 8.000e-01 8.500e-01 9.000e-01 9.500e-01 1.000e+00 
 DEAL::Function value: 1.3096e-13


### PR DESCRIPTION
The `bfgs_05` tests report 134 function calls on our machine instead of 133 in the output file. Other machines on `cdash` report that they need 135 function calls, see https://cdash.dealii.43-1.org/test/9355358.

To me this appears to be a very strict condition for a test. I disable writing the number of function calls into `deallog`.

I'm open for different suggestions. For example, we could still accept a range of function calls (+/- 2 or so, like #13755).

Part of #13703.