### PR TITLE
Fix compute_index_owner_01.

### DIFF
--- a/tests/mpi/compute_index_owner_01.cc
+++ b/tests/mpi/compute_index_owner_01.cc
@@ -61,8 +61,8 @@ test()
       process(local_owned, local_relevant, comm, owning_ranks_of_ghosts, true);
 
     Utilities::MPI::ConsensusAlgorithms::Selector<
-      std::pair<types::global_dof_index, types::global_dof_index>,
-      unsigned int>
+      std::vector<std::pair<types::global_dof_index, types::global_dof_index>>,
+      std::vector<unsigned int>>
       consensus_algorithm(process, comm);
     consensus_algorithm.run();
 


### PR DESCRIPTION
https://cdash.dealii.43-1.org/test/9313140 reports a missing header for the `dealii::Utilities::MPI::ConsensusAlgorithms::Selector` class.

I used the template variant as `Selector<std::pair<types::global_dof_index, types::global_dof_index>, unsigned int>` does not show up in the explicit instantiations in https://github.com/dealii/dealii/blob/master/source/base/mpi_consensus_algorithms.cc.

Part of #13703.