### PR TITLE
MatrixFree: Add instantiation for ConstraintValues::insert_entries

### DIFF
--- a/source/matrix_free/dof_info.cc
+++ b/source/matrix_free/dof_info.cc
@@ -1506,13 +1506,20 @@ namespace internal
   namespace MatrixFreeFunctions
   {
     template struct ConstraintValues<double>;
-    template struct ConstraintValues<float>;
+
+    template unsigned short
+    ConstraintValues<double>::insert_entries(
+      const std::vector<std::pair<types::global_dof_index, float>> &);
+    template unsigned short
+    ConstraintValues<double>::insert_entries(
+      const std::vector<std::pair<types::global_dof_index, double>> &);
+
 
     template void
     DoFInfo::read_dof_indices<double>(
       const std::vector<types::global_dof_index> &,
       const std::vector<types::global_dof_index> &,
-      const bool cell_has_hanging_node_constraints,
+      const bool,
       const dealii::AffineConstraints<double> &,
       const unsigned int,
       ConstraintValues<double> &,
@@ -1522,7 +1529,7 @@ namespace internal
     DoFInfo::read_dof_indices<float>(
       const std::vector<types::global_dof_index> &,
       const std::vector<types::global_dof_index> &,
-      const bool cell_has_hanging_node_constraints,
+      const bool,
       const dealii::AffineConstraints<float> &,
       const unsigned int,
       ConstraintValues<double> &,
@@ -1530,25 +1537,25 @@ namespace internal
 
     template bool
     DoFInfo::process_hanging_node_constraints<1>(
-      const HangingNodes<1> &                           hanging_nodes,
-      const std::vector<std::vector<unsigned int>> &    lexicographic_mapping,
-      const unsigned int                                cell_number,
-      const TriaIterator<DoFCellAccessor<1, 1, false>> &cell,
-      std::vector<types::global_dof_index> &            dof_indices);
+      const HangingNodes<1> &,
+      const std::vector<std::vector<unsigned int>> &,
+      const unsigned int,
+      const TriaIterator<DoFCellAccessor<1, 1, false>> &,
+      std::vector<types::global_dof_index> &);
     template bool
     DoFInfo::process_hanging_node_constraints<2>(
-      const HangingNodes<2> &                           hanging_nodes,
-      const std::vector<std::vector<unsigned int>> &    lexicographic_mapping,
-      const unsigned int                                cell_number,
-      const TriaIterator<DoFCellAccessor<2, 2, false>> &cell,
-      std::vector<types::global_dof_index> &            dof_indices);
+      const HangingNodes<2> &,
+      const std::vector<std::vector<unsigned int>> &,
+      const unsigned int,
+      const TriaIterator<DoFCellAccessor<2, 2, false>> &,
+      std::vector<types::global_dof_index> &);
     template bool
     DoFInfo::process_hanging_node_constraints<3>(
-      const HangingNodes<3> &                           hanging_nodes,
-      const std::vector<std::vector<unsigned int>> &    lexicographic_mapping,
-      const unsigned int                                cell_number,
-      const TriaIterator<DoFCellAccessor<3, 3, false>> &cell,
-      std::vector<types::global_dof_index> &            dof_indices);
+      const HangingNodes<3> &,
+      const std::vector<std::vector<unsigned int>> &,
+      const unsigned int,
+      const TriaIterator<DoFCellAccessor<3, 3, false>> &,
+      std::vector<types::global_dof_index> &);
 
     template void
     DoFInfo::compute_face_index_compression<1>(


### PR DESCRIPTION
This should fix the build error observed on gcc-6 here: https://cdash.dealii.43-1.org/viewBuildError.php?buildid=1627

Note that I removed the instantiation `ConstraintValues<float>`, because we never use that one in the code, all uses are here: https://github.com/dealii/dealii/blob/7d391a6239c5a2b6af9c379d9a816e0fb4085112/include/deal.II/matrix_free/matrix_free.templates.h#L1813-L1832 and in the functions consuming this data structure.