### PR TITLE
CMake: Avoid a CMake policy warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,9 +43,16 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.3.0)
 CMAKE_POLICY(VERSION 3.3.0)
 
 IF("${CMAKE_VERSION}" VERSION_LESS "3.11" AND POLICY CMP0037)
-  # allow to override "test" target for quick tests
+  # Allow to override "test" target for quick tests.
   CMAKE_POLICY(SET CMP0037 OLD)
 ENDIF()
+
+IF(POLICY CMP0075)
+  # Use CMAKE_REQUIRED_LIBRARIES also in include file checks. We set the
+  # policy to NEW explicitly in order to avoid spurious configure warnings.
+  CMAKE_POLICY(SET CMP0075 NEW)
+ENDIF()
+
 
 LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
 


### PR DESCRIPTION
This hopefully silences the following warning:
https://cdash.dealii.43-1.org/build/1715/configure
```
-- Looking for C++ include sys/resource.h
CMake Warning (dev) at /usr/share/cmake/Modules/CheckIncludeFileCXX.cmake:79 (message):
  Policy CMP0075 is not set: Include file check macros honor
  CMAKE_REQUIRED_LIBRARIES.  Run "cmake --help-policy CMP0075" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.

  CMAKE_REQUIRED_LIBRARIES is set to:

    -Wl,--as-needed

  For compatibility with CMake 3.11 and below this check is ignoring it.
Call Stack (most recent call first):
  cmake/checks/check_02_system_features.cmake:36 (CHECK_INCLUDE_FILE_CXX)
  cmake/macros/macro_verbose_include.cmake:19 (INCLUDE)
  CMakeLists.txt:112 (VERBOSE_INCLUDE)
This warning is for project developers.  Use -Wno-dev to suppress it.
```