### PR TITLE
Test robustness2

### DIFF
--- a/tests/matrix_free/parallel_multigrid_interleave.cc
+++ b/tests/matrix_free/parallel_multigrid_interleave.cc
@@ -60,7 +60,8 @@ public:
     : n_calls_vmult(0)
   {}
 
-  ~LaplaceOperator()
+  void
+  print_n_calls_special()
   {
     // round number of calls to make test more robust
     if (n_calls_vmult > 0)
@@ -430,6 +431,14 @@ do_test(const DoFHandler<dim> &dof)
     SolverCG<LinearAlgebra::distributed::Vector<double>> solver(control);
     solver.solve(fine_matrix, sol, in, preconditioner);
   }
+
+  // Print statistics
+  for (unsigned int level = 0;
+       level < dof.get_triangulation().n_global_levels();
+       ++level)
+    mg_matrices[level].print_n_calls_special();
+
+  fine_matrix.print_n_calls_special();
 }
 
 

--- a/tests/matrix_free/parallel_multigrid_interleave_renumber.cc
+++ b/tests/matrix_free/parallel_multigrid_interleave_renumber.cc
@@ -61,7 +61,8 @@ public:
     : n_calls_vmult(0)
   {}
 
-  ~LaplaceOperator()
+  void
+  print_n_calls_special()
   {
     // round number of calls to make test more robust
     if (n_calls_vmult > 0)
@@ -471,6 +472,14 @@ do_test(DoFHandler<dim> &dof)
     SolverCG<LinearAlgebra::distributed::Vector<double>> solver(control);
     solver.solve(fine_matrix, sol, in, preconditioner);
   }
+
+  // Print statistics
+  for (unsigned int level = 0;
+       level < dof.get_triangulation().n_global_levels();
+       ++level)
+    mg_matrices[level].print_n_calls_special();
+
+  fine_matrix.print_n_calls_special();
 }
 
 

--- a/tests/matrix_free/solver_cg_interleave.cc
+++ b/tests/matrix_free/solver_cg_interleave.cc
@@ -61,7 +61,8 @@ public:
     , data(matrix_free)
   {}
 
-  ~HelmholtzOperator()
+  void
+  print_n_calls_special()
   {
     if (n_calls_vmult > 0)
       deallog << "Number of calls to special vmult: " << n_calls_vmult
@@ -217,7 +218,7 @@ test(const unsigned int fe_degree)
   VectorType                                  rhs, sol;
   mf_data.initialize_dof_vector(rhs);
   mf_data.initialize_dof_vector(sol);
-  rhs = 1.;
+  rhs = 1. / std::sqrt(rhs.size());
   DiagonalMatrix<VectorType> preconditioner;
   mf_data.initialize_dof_vector(preconditioner.get_vector());
   mf.vmult(preconditioner.get_vector(), rhs);
@@ -247,6 +248,7 @@ test(const unsigned int fe_degree)
     SolverCG<VectorType>           solver(control);
     solver.solve(matrix, sol, rhs, preconditioner);
     deallog << "Norm of the solution: " << sol.l2_norm() << std::endl;
+    matrix.print_n_calls_special();
   }
 
   // Step 3: solve with CG solver for a matrix that does support but a
@@ -261,6 +263,7 @@ test(const unsigned int fe_degree)
     SolverCG<VectorType>           solver(control);
     solver.solve(matrix, sol, rhs, simple_diagonal);
     deallog << "Norm of the solution: " << sol.l2_norm() << std::endl;
+    matrix.print_n_calls_special();
   }
 
   // Step 4: solve with CG solver for a matrix that does support the
@@ -276,6 +279,7 @@ test(const unsigned int fe_degree)
     SolverCG<VectorType>   solver(control);
     solver.solve(matrix, sol, rhs, diagonal_subrange);
     deallog << "Norm of the solution: " << sol.l2_norm() << std::endl;
+    matrix.print_n_calls_special();
   }
 }
 
@@ -287,6 +291,7 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
   mpi_initlog();
+  deallog << std::setprecision(8);
 
   test<2, double>(3);
   test<3, double>(4);

--- a/tests/matrix_free/solver_cg_interleave.with_p4est=true.mpirun=3.output
+++ b/tests/matrix_free/solver_cg_interleave.with_p4est=true.mpirun=3.output
@@ -1,55 +1,55 @@
 
 DEAL::CG solver without interleaving support
-DEAL:cg::Starting value 49.0000
-DEAL:cg::Convergence step 51 value 0.429721
-DEAL::Norm of the solution: 11776.3
+DEAL:cg::Starting value 1.0000000
+DEAL:cg::Convergence step 51 value 0.0087698196
+DEAL::Norm of the solution: 240.33305
 DEAL::CG solver with interleaving support
-DEAL:cg::Starting value 49.0000
-DEAL:cg::Convergence step 51 value 0.429721
-DEAL::Norm of the solution: 11776.3
+DEAL:cg::Starting value 1.0000000
+DEAL:cg::Convergence step 51 value 0.0087698196
+DEAL::Norm of the solution: 240.33305
 DEAL::Number of calls to special vmult: 51
 DEAL::CG solver with matrix with interleaving support but no preconditioner
-DEAL:cg::Starting value 49.0000
-DEAL:cg::Convergence step 51 value 0.429721
-DEAL::Norm of the solution: 11776.3
+DEAL:cg::Starting value 1.0000000
+DEAL:cg::Convergence step 51 value 0.0087698196
+DEAL::Norm of the solution: 240.33305
 DEAL::CG solver with interleaving support and preconditioner working on subrange
-DEAL:cg::Starting value 49.0000
-DEAL:cg::Convergence step 51 value 0.429721
-DEAL::Norm of the solution: 11776.3
+DEAL:cg::Starting value 1.0000000
+DEAL:cg::Convergence step 51 value 0.0087698196
+DEAL::Norm of the solution: 240.33305
 DEAL::Number of calls to special vmult: 51
 DEAL::CG solver without interleaving support
-DEAL:cg::Starting value 189.571
-DEAL:cg::Convergence step 61 value 1.71195
-DEAL::Norm of the solution: 684335.
+DEAL:cg::Starting value 1.0000000
+DEAL:cg::Convergence step 61 value 0.0090310678
+DEAL::Norm of the solution: 3609.9220
 DEAL::CG solver with interleaving support
-DEAL:cg::Starting value 189.571
-DEAL:cg::Convergence step 61 value 1.71195
-DEAL::Norm of the solution: 684335.
+DEAL:cg::Starting value 1.0000000
+DEAL:cg::Convergence step 61 value 0.0090310675
+DEAL::Norm of the solution: 3609.9220
 DEAL::Number of calls to special vmult: 61
 DEAL::CG solver with matrix with interleaving support but no preconditioner
-DEAL:cg::Starting value 189.571
-DEAL:cg::Convergence step 61 value 1.71195
-DEAL::Norm of the solution: 684335.
+DEAL:cg::Starting value 1.0000000
+DEAL:cg::Convergence step 61 value 0.0090310678
+DEAL::Norm of the solution: 3609.9220
 DEAL::CG solver with interleaving support and preconditioner working on subrange
-DEAL:cg::Starting value 189.571
-DEAL:cg::Convergence step 61 value 1.71195
-DEAL::Norm of the solution: 684335.
+DEAL:cg::Starting value 1.0000000
+DEAL:cg::Convergence step 61 value 0.0090310574
+DEAL::Norm of the solution: 3609.9220
 DEAL::Number of calls to special vmult: 61
 DEAL::CG solver without interleaving support
-DEAL:cg::Starting value 125.000
-DEAL:cg::Convergence step 39 value 1.10898
-DEAL::Norm of the solution: 196549.
+DEAL:cg::Starting value 1.0000000
+DEAL:cg::Convergence step 39 value 0.0088718752
+DEAL::Norm of the solution: 1572.3941
 DEAL::CG solver with interleaving support
-DEAL:cg::Starting value 125.000
-DEAL:cg::Convergence step 39 value 1.10898
-DEAL::Norm of the solution: 196549.
+DEAL:cg::Starting value 1.0000000
+DEAL:cg::Convergence step 39 value 0.0088718752
+DEAL::Norm of the solution: 1572.3941
 DEAL::Number of calls to special vmult: 39
 DEAL::CG solver with matrix with interleaving support but no preconditioner
-DEAL:cg::Starting value 125.000
-DEAL:cg::Convergence step 39 value 1.10898
-DEAL::Norm of the solution: 196549.
+DEAL:cg::Starting value 1.0000000
+DEAL:cg::Convergence step 39 value 0.0088718752
+DEAL::Norm of the solution: 1572.3941
 DEAL::CG solver with interleaving support and preconditioner working on subrange
-DEAL:cg::Starting value 125.000
-DEAL:cg::Convergence step 39 value 1.10898
-DEAL::Norm of the solution: 196549.
+DEAL:cg::Starting value 1.0000000
+DEAL:cg::Convergence step 39 value 0.0088718752
+DEAL::Norm of the solution: 1572.3941
 DEAL::Number of calls to special vmult: 39


### PR DESCRIPTION
The two commits of this PR fix two problems:
- By looking at https://cdash.dealii.43-1.org/test/9949796 I realized that my tests with the interleaved option depend on the order the destructor is called on a vector of object, which is not robust. Instead of printing the info in the destructor, I now use dedicated print functions
- The CG solver is sensitive on roundoff in the 9th digit or so, seen in relative terms against the initial residual. However, the residual change due to roundoff might be above the 1e-6 relative tolerance of numdiff. To ensure that we remain below the absolute tolerance of 1e-8 of numdiff, scale the initial solution such that its norm is 1 and hence we end up with errors below the absolute tolerance for sure.