### PR TITLE
Fix compile error of test on certain compilers

### DIFF
--- a/tests/matrix_free/solver_cg_interleave.cc
+++ b/tests/matrix_free/solver_cg_interleave.cc
@@ -258,7 +258,7 @@ test(const unsigned int fe_degree)
             << "no preconditioner" << std::endl;
     sol = 0;
     HelmholtzOperator<dim, number> matrix(mf_data);
-    MyDiagonalMatrix               simple_diagonal(preconditioner.get_vector());
+    MyDiagonalMatrix<number>       simple_diagonal(preconditioner.get_vector());
     SolverControl                  control(200, 1e-2 * rhs.l2_norm());
     SolverCG<VectorType>           solver(control);
     solver.solve(matrix, sol, rhs, simple_diagonal);
@@ -274,9 +274,10 @@ test(const unsigned int fe_degree)
             << "preconditioner working on subrange" << std::endl;
     sol = 0;
     HelmholtzOperator<dim, number> matrix(mf_data);
-    DiagonalMatrixSubrange diagonal_subrange(preconditioner.get_vector());
-    SolverControl          control(200, 1e-2 * rhs.l2_norm());
-    SolverCG<VectorType>   solver(control);
+    DiagonalMatrixSubrange<number> diagonal_subrange(
+      preconditioner.get_vector());
+    SolverControl        control(200, 1e-2 * rhs.l2_norm());
+    SolverCG<VectorType> solver(control);
     solver.solve(matrix, sol, rhs, diagonal_subrange);
     deallog << "Norm of the solution: " << sol.l2_norm() << std::endl;
     matrix.print_n_calls_special();


### PR DESCRIPTION
When I wrote a test in #13698, I had used some newer C++ feature to automatically deduce template arguments of classes from the arguments in the constructor, which my compiler accepted but some others do not, see here: https://cdash.dealii.43-1.org/test/10057764
This fixes these two appearances.