### PR TITLE
Deprecate ConsensusAlgorithms::AnonymousProcess.

### DIFF
--- a/include/deal.II/base/mpi_consensus_algorithms.h
+++ b/include/deal.II/base/mpi_consensus_algorithms.h
@@ -842,7 +842,8 @@ namespace Utilities
        * own implementation but can register lambda functions directly.
        */
       template <typename RequestType, typename AnswerType>
-      class AnonymousProcess : public Process<RequestType, AnswerType>
+      class DEAL_II_DEPRECATED AnonymousProcess
+        : public Process<RequestType, AnswerType>
       {
       public:
         /**


### PR DESCRIPTION
This class is no longer used, and no longer necessary: It provides an interface whereby one can pass in four lambda function objects that are then given to the CA algorithms. But since #13414, we already have free functions that take such lambda functions as arguments, there is simply no need for an enclosing class any more.

In reference to #13208.

/rebuild