### PR TITLE
Refactor function parser

### DIFF
--- a/include/deal.II/base/function_parser.h
+++ b/include/deal.II/base/function_parser.h
@@ -21,13 +21,11 @@
 
 #include <deal.II/base/auto_derivative_function.h>
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/mu_parser_internal.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/tensor.h>
-#include <deal.II/base/thread_local_storage.h>
-#include <deal.II/base/mu_parser_internal.h>
 
 #include <map>
-#include <memory>
 #include <vector>
 
 DEAL_II_NAMESPACE_OPEN
@@ -216,7 +214,9 @@ class Vector;
  * @ingroup functions
  */
 template <int dim>
-class FunctionParser : public AutoDerivativeFunction<dim>
+class FunctionParser
+  : public AutoDerivativeFunction<dim>,
+    protected internal::FunctionParser::ParserImplementation<dim, double>
 {
 public:
   /**
@@ -381,13 +381,6 @@ public:
   //@}
 
 private:
-  /**
-   * The muParser objects (hidden with the PIMPL idiom) for each thread (and one
-   * for each component).
-   */
-  mutable Threads::ThreadLocalStorage<internal::FunctionParser::ParserData>
-    parser_data;
-
   /**
    * An array to keep track of all the constants, required to initialize fp in
    * each thread.

--- a/include/deal.II/base/function_parser.h
+++ b/include/deal.II/base/function_parser.h
@@ -382,18 +382,6 @@ public:
 
 private:
   /**
-   * An array to keep track of all the constants, required to initialize fp in
-   * each thread.
-   */
-  std::map<std::string, double> constants;
-
-  /**
-   * An array for the variable names, required to initialize fp in each
-   * thread.
-   */
-  std::vector<std::string> var_names;
-
-  /**
    * Initialize fp and vars on the current thread. This function may only be
    * called once per thread. A thread can test whether the function has
    * already been called by testing whether 'fp.get().size()==0' (not
@@ -401,27 +389,6 @@ private:
    */
   void
   init_muparser() const;
-
-  /**
-   * An array of function expressions (one per component), required to
-   * initialize fp in each thread.
-   */
-  std::vector<std::string> expressions;
-
-  /**
-   * State of usability. This variable is checked every time the function is
-   * called for evaluation. It's set to true in the initialize() methods.
-   */
-  bool initialized;
-
-  /**
-   * Number of variables. If this is also a function of time, then the number
-   * of variables is dim+1, otherwise it is dim. In the case that this is a
-   * time dependent function, the time is supposed to be the last variable. If
-   * #n_vars is not identical to the number of the variables parsed by the
-   * initialize() method, then an exception is thrown.
-   */
-  unsigned int n_vars;
 };
 
 

--- a/include/deal.II/base/function_parser.h
+++ b/include/deal.II/base/function_parser.h
@@ -308,11 +308,11 @@ public:
    * this case is dim+1. The value of this parameter defaults to false, i.e.,
    * do not consider time.
    */
-  void
+  virtual void
   initialize(const std::string &             vars,
              const std::vector<std::string> &expressions,
              const ConstMap &                constants,
-             const bool                      time_dependent = false);
+             const bool                      time_dependent = false) override;
 
   /**
    * Initialize the function. Same as above, but accepts a string rather than

--- a/include/deal.II/base/function_parser.h
+++ b/include/deal.II/base/function_parser.h
@@ -345,16 +345,6 @@ public:
   value(const Point<dim> &p, const unsigned int component = 0) const override;
 
   /**
-   * Return all components of a vector-valued function at the given point @p
-   * p.
-   *
-   * <code>values</code> shall have the right size beforehand, i.e.
-   * #n_components.
-   */
-  virtual void
-  vector_value(const Point<dim> &p, Vector<double> &values) const override;
-
-  /**
    * Return an array of function expressions (one per component), used to
    * initialize this function.
    */
@@ -379,16 +369,6 @@ public:
                  << ").");
 
   //@}
-
-private:
-  /**
-   * Initialize fp and vars on the current thread. This function may only be
-   * called once per thread. A thread can test whether the function has
-   * already been called by testing whether 'fp.get().size()==0' (not
-   * initialized) or >0 (already initialized).
-   */
-  void
-  init_muparser() const;
 };
 
 

--- a/include/deal.II/base/function_parser.h
+++ b/include/deal.II/base/function_parser.h
@@ -24,6 +24,7 @@
 #include <deal.II/base/point.h>
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/thread_local_storage.h>
+#include <deal.II/base/mu_parser_internal.h>
 
 #include <map>
 #include <memory>
@@ -36,22 +37,6 @@ DEAL_II_NAMESPACE_OPEN
 template <typename>
 class Vector;
 #endif
-
-namespace internal
-{
-  /**
-   * deal.II uses muParser as a purely internal dependency. To this end, we do
-   * not include any muParser headers in this file (and the bundled version of
-   * the dependency does not install its headers or compile a separate muparser
-   * library). Hence, to interface with muParser, we use the PIMPL idiom here to
-   * wrap a pointer to mu::Parser objects.
-   */
-  class muParserBase
-  {
-  public:
-    virtual ~muParserBase() = default;
-  };
-} // namespace internal
 
 /**
  * This class implements a function object that gets its value by parsing a
@@ -397,47 +382,11 @@ public:
 
 private:
   /**
-   * Class containing the mutable state required by muParser.
-   *
-   * @note For performance reasons it is best to put all mutable state in a
-   * single object so that, for each function call, we only need to get
-   * thread-local data exactly once.
-   */
-  struct ParserData
-  {
-    /**
-     * Default constructor. Threads::ThreadLocalStorage requires that objects be
-     * either default- or copy-constructible: make sure we satisfy the first
-     * case by declaring it here.
-     */
-    ParserData() = default;
-
-    /**
-     * std::is_copy_constructible gives the wrong answer for containers with
-     * non-copy constructible types (e.g., std::vector<std::unique_ptr<int>>) -
-     * for more information, see the documentation of
-     * Threads::ThreadLocalStorage. Hence, to avoid compilation failures, just
-     * delete the copy constructor completely.
-     */
-    ParserData(const ParserData &) = delete;
-
-    /**
-     * Scratch array used to set independent variables (i.e., x, y, and t)
-     * before each muParser call.
-     */
-    std::vector<double> vars;
-
-    /**
-     * The actual muParser parser objects (hidden with PIMPL).
-     */
-    std::vector<std::unique_ptr<internal::muParserBase>> parsers;
-  };
-
-  /**
    * The muParser objects (hidden with the PIMPL idiom) for each thread (and one
    * for each component).
    */
-  mutable Threads::ThreadLocalStorage<ParserData> parser_data;
+  mutable Threads::ThreadLocalStorage<internal::FunctionParser::ParserData>
+    parser_data;
 
   /**
    * An array to keep track of all the constants, required to initialize fp in

--- a/include/deal.II/base/mu_parser_internal.h
+++ b/include/deal.II/base/mu_parser_internal.h
@@ -21,18 +21,15 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/array_view.h>
+#include <deal.II/base/point.h>
 #include <deal.II/base/thread_local_storage.h>
 
 #include <memory>
 #include <string>
 #include <vector>
 
-
 DEAL_II_NAMESPACE_OPEN
-
-
-
-#ifdef DEAL_II_WITH_MUPARSER
 
 namespace internal
 {
@@ -94,6 +91,19 @@ namespace internal
      */
     std::vector<std::string>
     get_function_names();
+
+    /**
+     * @addtogroup Exceptions
+     * @{
+     */
+    DeclException2(ExcParseError,
+                   int,
+                   std::string,
+                   << "Parsing Error at Column " << arg1
+                   << ". The parser said: " << arg2);
+
+    //@}
+
     /**
      * deal.II uses muParser as a purely internal dependency. To this end, we do
      * not include any muParser headers in our own headers (and the bundled
@@ -160,6 +170,19 @@ namespace internal
       mutable Threads::ThreadLocalStorage<internal::FunctionParser::ParserData>
         parser_data;
 
+      void
+      init_muparser() const;
+
+      Number
+      do_value(const Point<dim> &p,
+               const double      time,
+               unsigned int      component) const;
+
+      void
+      do_all_values(const Point<dim> & p,
+                    const double       time,
+                    ArrayView<Number> &values) const;
+
       /**
        * An array to keep track of all the constants, required to initialize fp
        * in each thread.
@@ -193,14 +216,8 @@ namespace internal
        */
       unsigned int n_vars;
     };
-
-
   } // namespace FunctionParser
-
 } // namespace internal
-#endif
-
-
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/include/deal.II/base/mu_parser_internal.h
+++ b/include/deal.II/base/mu_parser_internal.h
@@ -21,6 +21,9 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/thread_local_storage.h>
+
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -83,6 +86,18 @@ namespace internal
        * The actual muParser parser objects (hidden with PIMPL).
        */
       std::vector<std::unique_ptr<muParserBase>> parsers;
+    };
+
+    template <int dim, typename Number>
+    class ParserImplementation
+    {
+    public:
+      /**
+       * The muParser objects (hidden with the PIMPL idiom) for each thread (and
+       * one for each component).
+       */
+      mutable Threads::ThreadLocalStorage<internal::FunctionParser::ParserData>
+        parser_data;
     };
 
     int

--- a/include/deal.II/base/mu_parser_internal.h
+++ b/include/deal.II/base/mu_parser_internal.h
@@ -136,7 +136,11 @@ namespace internal
     double
     mu_rand();
 
-    extern std::vector<std::string> function_names;
+    /**
+     * Get the array of all function names.
+     */
+    std::vector<std::string>
+    get_function_names();
 
   } // namespace FunctionParser
 

--- a/include/deal.II/base/mu_parser_internal.h
+++ b/include/deal.II/base/mu_parser_internal.h
@@ -38,6 +38,62 @@ namespace internal
 {
   namespace FunctionParser
   {
+    int
+    mu_round(double val);
+
+    double
+    mu_if(double condition, double thenvalue, double elsevalue);
+
+    double
+    mu_or(double left, double right);
+
+    double
+    mu_and(double left, double right);
+
+    double
+    mu_int(double value);
+
+    double
+    mu_ceil(double value);
+
+    double
+    mu_floor(double value);
+
+    double
+    mu_cot(double value);
+
+    double
+    mu_csc(double value);
+
+    double
+    mu_sec(double value);
+
+    double
+    mu_log(double value);
+
+    double
+    mu_pow(double a, double b);
+
+    double
+    mu_erf(double value);
+
+    double
+    mu_erfc(double value);
+
+    // returns a random value in the range [0,1] initializing the generator
+    // with the given seed
+    double
+    mu_rand_seed(double seed);
+
+    // returns a random value in the range [0,1]
+    double
+    mu_rand();
+
+    /**
+     * Get the array of all function names.
+     */
+    std::vector<std::string>
+    get_function_names();
     /**
      * deal.II uses muParser as a purely internal dependency. To this end, we do
      * not include any muParser headers in our own headers (and the bundled
@@ -138,62 +194,6 @@ namespace internal
       unsigned int n_vars;
     };
 
-    int
-    mu_round(double val);
-
-    double
-    mu_if(double condition, double thenvalue, double elsevalue);
-
-    double
-    mu_or(double left, double right);
-
-    double
-    mu_and(double left, double right);
-
-    double
-    mu_int(double value);
-
-    double
-    mu_ceil(double value);
-
-    double
-    mu_floor(double value);
-
-    double
-    mu_cot(double value);
-
-    double
-    mu_csc(double value);
-
-    double
-    mu_sec(double value);
-
-    double
-    mu_log(double value);
-
-    double
-    mu_pow(double a, double b);
-
-    double
-    mu_erf(double value);
-
-    double
-    mu_erfc(double value);
-
-    // returns a random value in the range [0,1] initializing the generator
-    // with the given seed
-    double
-    mu_rand_seed(double seed);
-
-    // returns a random value in the range [0,1]
-    double
-    mu_rand();
-
-    /**
-     * Get the array of all function names.
-     */
-    std::vector<std::string>
-    get_function_names();
 
   } // namespace FunctionParser
 

--- a/include/deal.II/base/mu_parser_internal.h
+++ b/include/deal.II/base/mu_parser_internal.h
@@ -164,11 +164,15 @@ namespace internal
       {}
 
       /**
-       * The muParser objects (hidden with the PIMPL idiom) for each thread (and
-       * one for each component).
+       * Initialize the internal state of the object. This is the same as the
+       * inheriting class method - see FunctionParser::initialize() for more
+       * information.
        */
-      mutable Threads::ThreadLocalStorage<internal::FunctionParser::ParserData>
-        parser_data;
+      virtual void
+      initialize(const std::string &                  vars,
+                 const std::vector<std::string> &     expressions,
+                 const std::map<std::string, double> &constants,
+                 const bool                           time_dependent = false);
 
       void
       init_muparser() const;

--- a/include/deal.II/base/mu_parser_internal.h
+++ b/include/deal.II/base/mu_parser_internal.h
@@ -92,12 +92,50 @@ namespace internal
     class ParserImplementation
     {
     public:
+      ParserImplementation()
+        : initialized(false)
+        , n_vars(0)
+      {}
+
       /**
        * The muParser objects (hidden with the PIMPL idiom) for each thread (and
        * one for each component).
        */
       mutable Threads::ThreadLocalStorage<internal::FunctionParser::ParserData>
         parser_data;
+
+      /**
+       * An array to keep track of all the constants, required to initialize fp
+       * in each thread.
+       */
+      std::map<std::string, double> constants;
+
+      /**
+       * An array for the variable names, required to initialize fp in each
+       * thread.
+       */
+      std::vector<std::string> var_names;
+
+      /**
+       * An array of function expressions (one per component), required to
+       * initialize tfp in each thread.
+       */
+      std::vector<std::string> expressions;
+
+      /**
+       * State of usability. This variable is checked every time the function is
+       * called for evaluation. It's set to true in the initialize() methods.
+       */
+      bool initialized;
+
+      /**
+       * Number of variables. If this is also a function of time, then the
+       * number of variables is dim+1, otherwise it is dim. In the case that
+       * this is a time dependent function, the time is supposed to be the last
+       * variable. If #n_vars is not identical to the number of the variables
+       * parsed by the initialize() method, then an exception is thrown.
+       */
+      unsigned int n_vars;
     };
 
     int

--- a/include/deal.II/base/tensor_function_parser.h
+++ b/include/deal.II/base/tensor_function_parser.h
@@ -196,11 +196,11 @@ public:
    * method in this case is dim+1. The value of this parameter defaults to
    * false, i.e. do not consider time.
    */
-  void
+  virtual void
   initialize(const std::string &             vars,
              const std::vector<std::string> &expressions,
              const ConstMap &                constants,
-             const bool                      time_dependent = false);
+             const bool                      time_dependent = false) override;
 
   /**
    * Initialize the function. Same as above, but accepts a string rather than

--- a/include/deal.II/base/tensor_function_parser.h
+++ b/include/deal.II/base/tensor_function_parser.h
@@ -261,17 +261,7 @@ public:
                  << ").");
 
   //@}
-
 private:
-  /**
-   * Initialize tfp and vars on the current thread. This function may only be
-   * called once per thread. A thread can test whether the function has
-   * already been called by testing whether 'tfp.get().size()==0' (not
-   * initialized) or >0 (already initialized).
-   */
-  void
-  init_muparser() const;
-
   /**
    * Number of components is equal dim<sup>rank</sup>.
    */

--- a/include/deal.II/base/tensor_function_parser.h
+++ b/include/deal.II/base/tensor_function_parser.h
@@ -25,6 +25,7 @@
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/tensor_function.h>
 #include <deal.II/base/thread_local_storage.h>
+#include <deal.II/base/mu_parser_internal.h>
 
 #include <map>
 #include <memory>
@@ -263,47 +264,11 @@ public:
 
 private:
   /**
-   * Class containing the mutable state required by muParser.
-   *
-   * @note For performance reasons it is best to put all mutable state in a
-   * single object so that, for each function call, we only need to get
-   * thread-local data exactly once.
-   */
-  struct ParserData
-  {
-    /**
-     * Default constructor. Threads::ThreadLocalStorage requires that objects be
-     * either default- or copy-constructible: make sure we satisfy the first
-     * case by declaring it here.
-     */
-    ParserData() = default;
-
-    /**
-     * std::is_copy_constructible gives the wrong answer for containers with
-     * non-copy constructible types (e.g., std::vector<std::unique_ptr<int>>) -
-     * for more information, see the documentation of
-     * Threads::ThreadLocalStorage. Hence, to avoid compilation failures, just
-     * delete the copy constructor completely.
-     */
-    ParserData(const ParserData &) = delete;
-
-    /**
-     * Scratch array used to set independent variables (i.e., x, y, and t)
-     * before each muParser call.
-     */
-    std::vector<double> vars;
-
-    /**
-     * The actual muParser parser objects (hidden with PIMPL).
-     */
-    std::vector<std::unique_ptr<internal::muParserBase>> parsers;
-  };
-
-  /**
    * The muParser objects (hidden with the PIMPL idiom) for each thread (and one
    * for each component).
    */
-  mutable Threads::ThreadLocalStorage<ParserData> parser_data;
+  mutable Threads::ThreadLocalStorage<internal::FunctionParser::ParserData>
+    parser_data;
 
   /**
    * An array to keep track of all the constants, required to initialize tfp in

--- a/include/deal.II/base/tensor_function_parser.h
+++ b/include/deal.II/base/tensor_function_parser.h
@@ -264,18 +264,6 @@ public:
 
 private:
   /**
-   * An array to keep track of all the constants, required to initialize tfp in
-   * each thread.
-   */
-  std::map<std::string, double> constants;
-
-  /**
-   * An array for the variable names, required to initialize tfp in each
-   * thread.
-   */
-  std::vector<std::string> var_names;
-
-  /**
    * Initialize tfp and vars on the current thread. This function may only be
    * called once per thread. A thread can test whether the function has
    * already been called by testing whether 'tfp.get().size()==0' (not
@@ -283,27 +271,6 @@ private:
    */
   void
   init_muparser() const;
-
-  /**
-   * An array of function expressions (one per component), required to
-   * initialize tfp in each thread.
-   */
-  std::vector<std::string> expressions;
-
-  /**
-   * State of usability. This variable is checked every time the function is
-   * called for evaluation. It's set to true in the initialize() methods.
-   */
-  bool initialized;
-
-  /**
-   * Number of variables. If this is also a function of time, then the number
-   * of variables is dim+1, otherwise it is dim. In the case that this is a
-   * time dependent function, the time is supposed to be the last variable. If
-   * #n_vars is not identical to the number of the variables parsed by the
-   * initialize() method, then an exception is thrown.
-   */
-  unsigned int n_vars;
 
   /**
    * Number of components is equal dim<sup>rank</sup>.

--- a/include/deal.II/base/tensor_function_parser.h
+++ b/include/deal.II/base/tensor_function_parser.h
@@ -21,14 +21,12 @@
 
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/function_parser.h>
+#include <deal.II/base/mu_parser_internal.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/tensor_function.h>
-#include <deal.II/base/thread_local_storage.h>
-#include <deal.II/base/mu_parser_internal.h>
 
 #include <map>
-#include <memory>
 #include <vector>
 
 DEAL_II_NAMESPACE_OPEN
@@ -105,7 +103,9 @@ class Vector;
  * @ingroup functions
  */
 template <int rank, int dim, typename Number = double>
-class TensorFunctionParser : public TensorFunction<rank, dim, Number>
+class TensorFunctionParser
+  : public TensorFunction<rank, dim, Number>,
+    protected internal::FunctionParser::ParserImplementation<dim, Number>
 {
 public:
   /**
@@ -263,13 +263,6 @@ public:
   //@}
 
 private:
-  /**
-   * The muParser objects (hidden with the PIMPL idiom) for each thread (and one
-   * for each component).
-   */
-  mutable Threads::ThreadLocalStorage<internal::FunctionParser::ParserData>
-    parser_data;
-
   /**
    * An array to keep track of all the constants, required to initialize tfp in
    * each thread.

--- a/source/base/CMakeLists.txt
+++ b/source/base/CMakeLists.txt
@@ -148,6 +148,7 @@ SET(_inst
   symbolic_function.inst.in
   tensor_function.inst.in
   tensor_function_parser.inst.in
+  mu_parser_internal.inst.in
   time_stepping.inst.in
   )
 

--- a/source/base/function_parser.cc
+++ b/source/base/function_parser.cc
@@ -209,7 +209,7 @@ FunctionParser<dim>::init_muparser() const
           std::string transformed_expression = expressions[component];
 
           for (const auto &current_function_name :
-               internal::FunctionParser::function_names)
+               internal::FunctionParser::get_function_names())
             {
               const unsigned int function_name_length =
                 current_function_name.size();

--- a/source/base/function_parser.cc
+++ b/source/base/function_parser.cc
@@ -158,7 +158,7 @@ FunctionParser<dim>::init_muparser() const
   // check that we have not already initialized the parser on the
   // current thread, i.e., that the current function is only called
   // once per thread
-  internal::FunctionParser::ParserData &data = parser_data.get();
+  internal::FunctionParser::ParserData &data = this->parser_data.get();
   Assert(data.parsers.size() == 0 && data.vars.size() == 0, ExcInternalError());
 
   // initialize the objects for the current thread
@@ -280,7 +280,7 @@ FunctionParser<dim>::value(const Point<dim> & p,
   AssertIndexRange(component, this->n_components);
 
   // initialize the parser if that hasn't happened yet on the current thread
-  internal::FunctionParser::ParserData &data = parser_data.get();
+  internal::FunctionParser::ParserData &data = this->parser_data.get();
   if (data.vars.size() == 0)
     init_muparser();
 
@@ -327,7 +327,7 @@ FunctionParser<dim>::vector_value(const Point<dim> &p,
 
 
   // initialize the parser if that hasn't happened yet on the current thread
-  internal::FunctionParser::ParserData &data = parser_data.get();
+  internal::FunctionParser::ParserData &data = this->parser_data.get();
   if (data.vars.size() == 0)
     init_muparser();
 

--- a/source/base/function_parser.cc
+++ b/source/base/function_parser.cc
@@ -130,7 +130,7 @@ namespace internal
       /**
        * PIMPL for mu::Parser.
        */
-      class Parser : public internal::muParserBase
+      class Parser : public internal::FunctionParser::muParserBase
       {
       public:
         operator mu::Parser &()
@@ -158,7 +158,7 @@ FunctionParser<dim>::init_muparser() const
   // check that we have not already initialized the parser on the
   // current thread, i.e., that the current function is only called
   // once per thread
-  ParserData &data = parser_data.get();
+  internal::FunctionParser::ParserData &data = parser_data.get();
   Assert(data.parsers.size() == 0 && data.vars.size() == 0, ExcInternalError());
 
   // initialize the objects for the current thread
@@ -280,7 +280,7 @@ FunctionParser<dim>::value(const Point<dim> & p,
   AssertIndexRange(component, this->n_components);
 
   // initialize the parser if that hasn't happened yet on the current thread
-  ParserData &data = parser_data.get();
+  internal::FunctionParser::ParserData &data = parser_data.get();
   if (data.vars.size() == 0)
     init_muparser();
 
@@ -327,7 +327,7 @@ FunctionParser<dim>::vector_value(const Point<dim> &p,
 
 
   // initialize the parser if that hasn't happened yet on the current thread
-  ParserData &data = parser_data.get();
+  internal::FunctionParser::ParserData &data = parser_data.get();
   if (data.vars.size() == 0)
     init_muparser();
 

--- a/source/base/function_parser.cc
+++ b/source/base/function_parser.cc
@@ -70,7 +70,6 @@ FunctionParser<dim>::FunctionParser(const std::string &expression,
 }
 
 
-#ifdef DEAL_II_WITH_MUPARSER
 
 template <int dim>
 void
@@ -137,50 +136,6 @@ FunctionParser<dim>::value(const Point<dim> & p,
 {
   return this->do_value(p, this->get_time(), component);
 }
-
-#else
-
-
-template <int dim>
-void
-FunctionParser<dim>::initialize(const std::string &,
-                                const std::vector<std::string> &,
-                                const std::map<std::string, double> &,
-                                const bool)
-{
-  AssertThrow(false, ExcNeedsFunctionparser());
-}
-
-template <int dim>
-void
-FunctionParser<dim>::initialize(const std::string &,
-                                const std::string &,
-                                const std::map<std::string, double> &,
-                                const bool)
-{
-  AssertThrow(false, ExcNeedsFunctionparser());
-}
-
-
-
-template <int dim>
-double
-FunctionParser<dim>::value(const Point<dim> &, unsigned int) const
-{
-  AssertThrow(false, ExcNeedsFunctionparser());
-  return 0.;
-}
-
-
-template <int dim>
-void
-FunctionParser<dim>::vector_value(const Point<dim> &, Vector<double> &) const
-{
-  AssertThrow(false, ExcNeedsFunctionparser());
-}
-
-
-#endif
 
 // Explicit Instantiations.
 

--- a/source/base/function_parser.cc
+++ b/source/base/function_parser.cc
@@ -25,10 +25,6 @@
 #include <cmath>
 #include <map>
 
-#ifdef DEAL_II_WITH_MUPARSER
-#  include <muParser.h>
-#endif
-
 DEAL_II_NAMESPACE_OPEN
 
 
@@ -111,143 +107,10 @@ FunctionParser<dim>::initialize(const std::string &             variables,
   // value() and vector_value(). this is not strictly necessary because a user
   // may never call these functions on the current thread, but it gets us
   // error messages about wrong formulas right away
-  init_muparser();
+  this->init_muparser();
 
   // finally set the initialization bit
   this->initialized = true;
-}
-
-namespace internal
-{
-  namespace FunctionParserImplementation
-  {
-    namespace
-    {
-      /**
-       * PIMPL for mu::Parser.
-       */
-      class Parser : public internal::FunctionParser::muParserBase
-      {
-      public:
-        operator mu::Parser &()
-        {
-          return parser;
-        }
-
-        operator const mu::Parser &() const
-        {
-          return parser;
-        }
-
-      protected:
-        mu::Parser parser;
-      };
-    } // namespace
-  }   // namespace FunctionParserImplementation
-} // namespace internal
-
-
-template <int dim>
-void
-FunctionParser<dim>::init_muparser() const
-{
-  // check that we have not already initialized the parser on the
-  // current thread, i.e., that the current function is only called
-  // once per thread
-  internal::FunctionParser::ParserData &data = this->parser_data.get();
-  Assert(data.parsers.size() == 0 && data.vars.size() == 0, ExcInternalError());
-
-  // initialize the objects for the current thread
-  data.parsers.reserve(this->n_components);
-  data.vars.resize(this->var_names.size());
-  for (unsigned int component = 0; component < this->n_components; ++component)
-    {
-      data.parsers.emplace_back(
-        new internal::FunctionParserImplementation::Parser());
-      mu::Parser &parser =
-        dynamic_cast<internal::FunctionParserImplementation::Parser &>(
-          *data.parsers.back());
-
-      for (const auto &constant : this->constants)
-        parser.DefineConst(constant.first, constant.second);
-
-      for (unsigned int iv = 0; iv < this->var_names.size(); ++iv)
-        parser.DefineVar(this->var_names[iv], &data.vars[iv]);
-
-      // define some compatibility functions:
-      parser.DefineFun("if", internal::FunctionParser::mu_if, true);
-      parser.DefineOprt("|", internal::FunctionParser::mu_or, 1);
-      parser.DefineOprt("&", internal::FunctionParser::mu_and, 2);
-      parser.DefineFun("int", internal::FunctionParser::mu_int, true);
-      parser.DefineFun("ceil", internal::FunctionParser::mu_ceil, true);
-      parser.DefineFun("cot", internal::FunctionParser::mu_cot, true);
-      parser.DefineFun("csc", internal::FunctionParser::mu_csc, true);
-      parser.DefineFun("floor", internal::FunctionParser::mu_floor, true);
-      parser.DefineFun("sec", internal::FunctionParser::mu_sec, true);
-      parser.DefineFun("log", internal::FunctionParser::mu_log, true);
-      parser.DefineFun("pow", internal::FunctionParser::mu_pow, true);
-      parser.DefineFun("erf", internal::FunctionParser::mu_erf, true);
-      parser.DefineFun("erfc", internal::FunctionParser::mu_erfc, true);
-      parser.DefineFun("rand_seed",
-                       internal::FunctionParser::mu_rand_seed,
-                       true);
-      parser.DefineFun("rand", internal::FunctionParser::mu_rand, true);
-
-      try
-        {
-          // muparser expects that functions have no
-          // space between the name of the function and the opening
-          // parenthesis. this is awkward because it is not backward
-          // compatible to the library we used to use before muparser
-          // (the fparser library) but also makes no real sense.
-          // consequently, in the expressions we set, remove any space
-          // we may find after function names
-          std::string transformed_expression = this->expressions[component];
-
-          for (const auto &current_function_name :
-               internal::FunctionParser::get_function_names())
-            {
-              const unsigned int function_name_length =
-                current_function_name.size();
-
-              std::string::size_type pos = 0;
-              while (true)
-                {
-                  // try to find any occurrences of the function name
-                  pos = transformed_expression.find(current_function_name, pos);
-                  if (pos == std::string::npos)
-                    break;
-
-                  // replace whitespace until there no longer is any
-                  while ((pos + function_name_length <
-                          transformed_expression.size()) &&
-                         ((transformed_expression[pos + function_name_length] ==
-                           ' ') ||
-                          (transformed_expression[pos + function_name_length] ==
-                           '\t')))
-                    transformed_expression.erase(
-                      transformed_expression.begin() + pos +
-                      function_name_length);
-
-                  // move the current search position by the size of the
-                  // actual function name
-                  pos += function_name_length;
-                }
-            }
-
-          // now use the transformed expression
-          parser.SetExpr(transformed_expression);
-        }
-      catch (mu::ParserError &e)
-        {
-          std::cerr << "Message:  <" << e.GetMsg() << ">\n";
-          std::cerr << "Formula:  <" << e.GetExpr() << ">\n";
-          std::cerr << "Token:    <" << e.GetToken() << ">\n";
-          std::cerr << "Position: <" << e.GetPos() << ">\n";
-          std::cerr << "Errc:     <" << e.GetCode() << ">" << std::endl;
-          AssertThrow(false, ExcParseError(e.GetCode(), e.GetMsg()));
-        }
-    }
 }
 
 
@@ -272,78 +135,7 @@ double
 FunctionParser<dim>::value(const Point<dim> & p,
                            const unsigned int component) const
 {
-  Assert(this->initialized == true, ExcNotInitialized());
-  AssertIndexRange(component, this->n_components);
-
-  // initialize the parser if that hasn't happened yet on the current thread
-  internal::FunctionParser::ParserData &data = this->parser_data.get();
-  if (data.vars.size() == 0)
-    init_muparser();
-
-  for (unsigned int i = 0; i < dim; ++i)
-    data.vars[i] = p(i);
-  if (dim != this->n_vars)
-    data.vars[dim] = this->get_time();
-
-  try
-    {
-      Assert(dynamic_cast<internal::FunctionParserImplementation::Parser *>(
-               data.parsers[component].get()),
-             ExcInternalError());
-      // using dynamic_cast in the next line is about 6% slower than
-      // static_cast, so use the assertion above for debugging and disable
-      // clang-tidy:
-      mu::Parser &parser =
-        static_cast<internal::FunctionParserImplementation::Parser &>( // NOLINT
-          *data.parsers[component]);
-      return parser.Eval();
-    }
-  catch (mu::ParserError &e)
-    {
-      std::cerr << "Message:  <" << e.GetMsg() << ">\n";
-      std::cerr << "Formula:  <" << e.GetExpr() << ">\n";
-      std::cerr << "Token:    <" << e.GetToken() << ">\n";
-      std::cerr << "Position: <" << e.GetPos() << ">\n";
-      std::cerr << "Errc:     <" << e.GetCode() << ">" << std::endl;
-      AssertThrow(false, ExcParseError(e.GetCode(), e.GetMsg()));
-      return 0.0;
-    }
-}
-
-
-
-template <int dim>
-void
-FunctionParser<dim>::vector_value(const Point<dim> &p,
-                                  Vector<double> &  values) const
-{
-  Assert(this->initialized == true, ExcNotInitialized());
-  Assert(values.size() == this->n_components,
-         ExcDimensionMismatch(values.size(), this->n_components));
-
-
-  // initialize the parser if that hasn't happened yet on the current thread
-  internal::FunctionParser::ParserData &data = this->parser_data.get();
-  if (data.vars.size() == 0)
-    init_muparser();
-
-  for (unsigned int i = 0; i < dim; ++i)
-    data.vars[i] = p(i);
-  if (dim != this->n_vars)
-    data.vars[dim] = this->get_time();
-
-  for (unsigned int component = 0; component < this->n_components; ++component)
-    {
-      // Same comment in value() applies here too:
-      Assert(dynamic_cast<internal::FunctionParserImplementation::Parser *>(
-               data.parsers[component].get()),
-             ExcInternalError());
-      mu::Parser &parser =
-        static_cast<internal::FunctionParserImplementation::Parser &>( // NOLINT
-          *data.parsers[component]);
-
-      values(component) = parser.Eval();
-    }
+  return this->do_value(p, this->get_time(), component);
 }
 
 #else

--- a/source/base/function_parser.cc
+++ b/source/base/function_parser.cc
@@ -17,12 +17,10 @@
 #include <deal.II/base/function_parser.h>
 #include <deal.II/base/mu_parser_internal.h>
 #include <deal.II/base/patterns.h>
-#include <deal.II/base/thread_management.h>
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/lac/vector.h>
 
-#include <cmath>
 #include <map>
 
 DEAL_II_NAMESPACE_OPEN
@@ -78,38 +76,10 @@ FunctionParser<dim>::initialize(const std::string &             variables,
                                 const std::map<std::string, double> &constants,
                                 const bool time_dependent)
 {
-  this->parser_data.clear(); // this will reset all thread-local objects
-
-  this->constants   = constants;
-  this->var_names   = Utilities::split_string_list(variables, ',');
-  this->expressions = expressions;
-  AssertThrow(((time_dependent) ? dim + 1 : dim) == this->var_names.size(),
-              ExcMessage("Wrong number of variables"));
-
-  // We check that the number of components of this function matches the
-  // number of components passed in as a vector of strings.
   AssertThrow(this->n_components == expressions.size(),
               ExcInvalidExpressionSize(this->n_components, expressions.size()));
-
-  // Now we define how many variables we expect to read in.  We distinguish
-  // between two cases: Time dependent problems, and not time dependent
-  // problems. In the first case the number of variables is given by the
-  // dimension plus one. In the other case, the number of variables is equal
-  // to the dimension. Once we parsed the variables string, if none of this is
-  // the case, then an exception is thrown.
-  if (time_dependent)
-    this->n_vars = dim + 1;
-  else
-    this->n_vars = dim;
-
-  // create a parser object for the current thread we can then query in
-  // value() and vector_value(). this is not strictly necessary because a user
-  // may never call these functions on the current thread, but it gets us
-  // error messages about wrong formulas right away
-  this->init_muparser();
-
-  // finally set the initialization bit
-  this->initialized = true;
+  internal::FunctionParser::ParserImplementation<dim, double>::initialize(
+    variables, expressions, constants, time_dependent);
 }
 
 

--- a/source/base/mu_parser_internal.cc
+++ b/source/base/mu_parser_internal.cc
@@ -155,47 +155,50 @@ namespace internal
       return uniform_distribution(rng);
     }
 
-    std::vector<std::string> function_names = {
-      // functions predefined by muparser
-      "sin",
-      "cos",
-      "tan",
-      "asin",
-      "acos",
-      "atan",
-      "sinh",
-      "cosh",
-      "tanh",
-      "asinh",
-      "acosh",
-      "atanh",
-      "atan2",
-      "log2",
-      "log10",
-      "log",
-      "ln",
-      "exp",
-      "sqrt",
-      "sign",
-      "rint",
-      "abs",
-      "min",
-      "max",
-      "sum",
-      "avg",
-      // functions we define ourselves above
-      "if",
-      "int",
-      "ceil",
-      "cot",
-      "csc",
-      "floor",
-      "sec",
-      "pow",
-      "erf",
-      "erfc",
-      "rand",
-      "rand_seed"};
+    std::vector<std::string>
+    get_function_names()
+    {
+      return {// functions predefined by muparser
+              "sin",
+              "cos",
+              "tan",
+              "asin",
+              "acos",
+              "atan",
+              "sinh",
+              "cosh",
+              "tanh",
+              "asinh",
+              "acosh",
+              "atanh",
+              "atan2",
+              "log2",
+              "log10",
+              "log",
+              "ln",
+              "exp",
+              "sqrt",
+              "sign",
+              "rint",
+              "abs",
+              "min",
+              "max",
+              "sum",
+              "avg",
+              // functions we define ourselves above
+              "if",
+              "int",
+              "ceil",
+              "cot",
+              "csc",
+              "floor",
+              "sec",
+              "pow",
+              "erf",
+              "erfc",
+              "rand",
+              "rand_seed"};
+    }
 
   } // namespace FunctionParser
 

--- a/source/base/mu_parser_internal.cc
+++ b/source/base/mu_parser_internal.cc
@@ -23,12 +23,11 @@
 #include <random>
 #include <vector>
 
+#ifdef DEAL_II_WITH_MUPARSER
+#  include <muParser.h>
+#endif
 
 DEAL_II_NAMESPACE_OPEN
-
-
-
-#ifdef DEAL_II_WITH_MUPARSER
 
 namespace internal
 {
@@ -200,11 +199,232 @@ namespace internal
               "rand_seed"};
     }
 
-  } // namespace FunctionParser
+#ifdef DEAL_II_WITH_MUPARSER
+    /**
+     * PIMPL for mu::Parser.
+     */
+    class Parser : public muParserBase
+    {
+    public:
+      operator mu::Parser &()
+      {
+        return parser;
+      }
 
-} // namespace internal
+      operator const mu::Parser &() const
+      {
+        return parser;
+      }
+
+    protected:
+      mu::Parser parser;
+    };
 #endif
 
 
+
+    template <int dim, typename Number>
+    void
+    ParserImplementation<dim, Number>::init_muparser() const
+    {
+#ifdef DEAL_II_WITH_MUPARSER
+      // check that we have not already initialized the parser on the
+      // current thread, i.e., that the current function is only called
+      // once per thread
+      ParserData &data = this->parser_data.get();
+      Assert(data.parsers.size() == 0 && data.vars.size() == 0,
+             ExcInternalError());
+      const unsigned int n_components = expressions.size();
+
+      // initialize the objects for the current thread
+      data.parsers.reserve(n_components);
+      data.vars.resize(this->var_names.size());
+      for (unsigned int component = 0; component < n_components; ++component)
+        {
+          data.parsers.emplace_back(std::make_unique<Parser>());
+          mu::Parser &parser = dynamic_cast<Parser &>(*data.parsers.back());
+
+          for (const auto &constant : this->constants)
+            parser.DefineConst(constant.first, constant.second);
+
+          for (unsigned int iv = 0; iv < this->var_names.size(); ++iv)
+            parser.DefineVar(this->var_names[iv], &data.vars[iv]);
+
+          // define some compatibility functions:
+          parser.DefineFun("if", mu_if, true);
+          parser.DefineOprt("|", mu_or, 1);
+          parser.DefineOprt("&", mu_and, 2);
+          parser.DefineFun("int", mu_int, true);
+          parser.DefineFun("ceil", mu_ceil, true);
+          parser.DefineFun("cot", mu_cot, true);
+          parser.DefineFun("csc", mu_csc, true);
+          parser.DefineFun("floor", mu_floor, true);
+          parser.DefineFun("sec", mu_sec, true);
+          parser.DefineFun("log", mu_log, true);
+          parser.DefineFun("pow", mu_pow, true);
+          parser.DefineFun("erfc", mu_erfc, true);
+          parser.DefineFun("rand_seed", mu_rand_seed, true);
+          parser.DefineFun("rand", mu_rand, true);
+
+          try
+            {
+              // muparser expects that functions have no
+              // space between the name of the function and the opening
+              // parenthesis. this is awkward because it is not backward
+              // compatible to the library we used to use before muparser
+              // (the fparser library) but also makes no real sense.
+              // consequently, in the expressions we set, remove any space
+              // we may find after function names
+              std::string transformed_expression = this->expressions[component];
+
+              for (const auto &current_function_name : get_function_names())
+                {
+                  const unsigned int function_name_length =
+                    current_function_name.size();
+
+                  std::string::size_type pos = 0;
+                  while (true)
+                    {
+                      // try to find any occurrences of the function name
+                      pos =
+                        transformed_expression.find(current_function_name, pos);
+                      if (pos == std::string::npos)
+                        break;
+
+                      // replace whitespace until there no longer is any
+                      while (
+                        (pos + function_name_length <
+                         transformed_expression.size()) &&
+                        ((transformed_expression[pos + function_name_length] ==
+                          ' ') ||
+                         (transformed_expression[pos + function_name_length] ==
+                          '\t')))
+                        transformed_expression.erase(
+                          transformed_expression.begin() + pos +
+                          function_name_length);
+
+                      // move the current search position by the size of the
+                      // actual function name
+                      pos += function_name_length;
+                    }
+                }
+
+              // now use the transformed expression
+              parser.SetExpr(transformed_expression);
+            }
+          catch (mu::ParserError &e)
+            {
+              std::cerr << "Message:  <" << e.GetMsg() << ">\n";
+              std::cerr << "Formula:  <" << e.GetExpr() << ">\n";
+              std::cerr << "Token:    <" << e.GetToken() << ">\n";
+              std::cerr << "Position: <" << e.GetPos() << ">\n";
+              std::cerr << "Errc:     <" << e.GetCode() << ">" << std::endl;
+              AssertThrow(false, ExcParseError(e.GetCode(), e.GetMsg()));
+            }
+        }
+#else
+      AssertThrow(false, ExcNeedsFunctionparser());
+#endif
+    }
+
+    template <int dim, typename Number>
+    Number
+    ParserImplementation<dim, Number>::do_value(const Point<dim> &p,
+                                                const double      time,
+                                                unsigned int component) const
+    {
+#ifdef DEAL_II_WITH_MUPARSER
+      Assert(this->initialized == true, ExcNotInitialized());
+
+      // initialize the parser if that hasn't happened yet on the current
+      // thread
+      internal::FunctionParser::ParserData &data = this->parser_data.get();
+      if (data.vars.size() == 0)
+        init_muparser();
+
+      for (unsigned int i = 0; i < dim; ++i)
+        data.vars[i] = p(i);
+      if (dim != this->n_vars)
+        data.vars[dim] = time;
+
+      try
+        {
+          Assert(dynamic_cast<Parser *>(data.parsers[component].get()),
+                 ExcInternalError());
+          // NOLINTNEXTLINE don't warn about using static_cast once we check
+          mu::Parser &parser = static_cast<Parser &>(*data.parsers[component]);
+          return parser.Eval();
+        } // try
+      catch (mu::ParserError &e)
+        {
+          std::cerr << "Message:  <" << e.GetMsg() << ">\n";
+          std::cerr << "Formula:  <" << e.GetExpr() << ">\n";
+          std::cerr << "Token:    <" << e.GetToken() << ">\n";
+          std::cerr << "Position: <" << e.GetPos() << ">\n";
+          std::cerr << "Errc:     <" << e.GetCode() << ">" << std::endl;
+          AssertThrow(false, ExcParseError(e.GetCode(), e.GetMsg()));
+        } // catch
+
+#else
+      AssertThrow(false, ExcNeedsFunctionparser());
+#endif
+      return std::numeric_limits<double>::signaling_NaN();
+    }
+
+    template <int dim, typename Number>
+    void
+    ParserImplementation<dim, Number>::do_all_values(
+      const Point<dim> & p,
+      const double       time,
+      ArrayView<Number> &values) const
+    {
+#ifdef DEAL_II_WITH_MUPARSER
+      Assert(this->initialized == true, ExcNotInitialized());
+
+      // initialize the parser if that hasn't happened yet on the current
+      // thread
+      internal::FunctionParser::ParserData &data = this->parser_data.get();
+      if (data.vars.size() == 0)
+        init_muparser();
+
+      for (unsigned int i = 0; i < dim; ++i)
+        data.vars[i] = p(i);
+      if (dim != this->n_vars)
+        data.vars[dim] = time;
+
+      AssertDimension(values.size(), data.parsers.size());
+      try
+        {
+          for (unsigned int component = 0; component < data.parsers.size();
+               ++component)
+            {
+              Assert(dynamic_cast<Parser *>(data.parsers[component].get()),
+                     ExcInternalError());
+              mu::Parser &parser =
+                // We just checked that the pointer is valid so suppress the
+                // clang-tidy check
+                static_cast<Parser &>(*data.parsers[component]); // NOLINT
+              values[component] = parser.Eval();
+            }
+        } // try
+      catch (mu::ParserError &e)
+        {
+          std::cerr << "Message:  <" << e.GetMsg() << ">\n";
+          std::cerr << "Formula:  <" << e.GetExpr() << ">\n";
+          std::cerr << "Token:    <" << e.GetToken() << ">\n";
+          std::cerr << "Position: <" << e.GetPos() << ">\n";
+          std::cerr << "Errc:     <" << e.GetCode() << ">" << std::endl;
+          AssertThrow(false, ExcParseError(e.GetCode(), e.GetMsg()));
+        } // catch
+#else
+      AssertThrow(false, ExcNeedsFunctionparser());
+#endif
+    }
+
+// explicit instantiations
+#include "mu_parser_internal.inst"
+
+  } // namespace FunctionParser
+} // namespace internal
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/base/mu_parser_internal.cc
+++ b/source/base/mu_parser_internal.cc
@@ -222,6 +222,11 @@ namespace internal
     };
 #endif
 
+    template <int dim, typename Number>
+    ParserImplementation<dim, Number>::ParserImplementation()
+      : initialized(false)
+      , n_vars(0)
+    {}
 
 
 

--- a/source/base/mu_parser_internal.inst.in
+++ b/source/base/mu_parser_internal.inst.in
@@ -1,0 +1,25 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2022 - 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+for (S : REAL_SCALARS; dim : SPACE_DIMENSIONS)
+  {
+    template class ParserImplementation<dim, S>;
+  }
+
+for (S : COMPLEX_SCALARS; dim : SPACE_DIMENSIONS)
+  {
+    template class ParserImplementation<dim, S>;
+  }

--- a/source/base/tensor_function_parser.cc
+++ b/source/base/tensor_function_parser.cc
@@ -173,7 +173,7 @@ TensorFunctionParser<rank, dim, Number>::init_muparser() const
   // check that we have not already initialized the parser on the
   // current thread, i.e., that the current function is only called
   // once per thread
-  internal::FunctionParser::ParserData &data = parser_data.get();
+  internal::FunctionParser::ParserData &data = this->parser_data.get();
   Assert(data.parsers.size() == 0 && data.vars.size() == 0, ExcInternalError());
 
   // initialize the objects for the current thread
@@ -294,7 +294,7 @@ TensorFunctionParser<rank, dim, Number>::value(const Point<dim> &p) const
   Assert(initialized == true, ExcNotInitialized());
 
   // initialize the parser if that hasn't happened yet on the current thread
-  internal::FunctionParser::ParserData &data = parser_data.get();
+  internal::FunctionParser::ParserData &data = this->parser_data.get();
   if (data.vars.size() == 0)
     init_muparser();
 

--- a/source/base/tensor_function_parser.cc
+++ b/source/base/tensor_function_parser.cc
@@ -70,7 +70,6 @@ TensorFunctionParser<rank, dim, Number>::TensorFunctionParser(
 }
 
 
-#ifdef DEAL_II_WITH_MUPARSER
 
 template <int rank, int dim, typename Number>
 void
@@ -172,55 +171,6 @@ TensorFunctionParser<rank, dim, Number>::value_list(
       values[i] = value(p[i]);
     }
 }
-
-#else
-
-
-template <int rank, int dim, typename Number>
-void
-TensorFunctionParser<rank, dim, Number>::initialize(
-  const std::string &,
-  const std::vector<std::string> &,
-  const std::map<std::string, double> &,
-  const bool)
-{
-  AssertThrow(false, ExcNeedsFunctionparser());
-}
-
-template <int rank, int dim, typename Number>
-void
-TensorFunctionParser<rank, dim, Number>::initialize(
-  const std::string &,
-  const std::string &,
-  const std::map<std::string, double> &,
-  const bool)
-{
-  AssertThrow(false, ExcNeedsFunctionparser());
-}
-
-
-
-template <int rank, int dim, typename Number>
-Tensor<rank, dim, Number>
-TensorFunctionParser<rank, dim, Number>::value(const Point<dim> &) const
-{
-  AssertThrow(false, ExcNeedsFunctionparser());
-  return Tensor<rank, dim, Number>();
-}
-
-
-
-template <int rank, int dim, typename Number>
-void
-TensorFunctionParser<rank, dim, Number>::value_list(
-  const std::vector<Point<dim>> &,
-  std::vector<Tensor<rank, dim, Number>> &) const
-{
-  AssertThrow(false, ExcNeedsFunctionparser());
-}
-
-
-#endif
 
 // explicit instantiations
 #include "tensor_function_parser.inst"

--- a/source/base/tensor_function_parser.cc
+++ b/source/base/tensor_function_parser.cc
@@ -20,10 +20,8 @@
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/tensor_function.h>
 #include <deal.II/base/tensor_function_parser.h>
-#include <deal.II/base/thread_management.h>
 #include <deal.II/base/utilities.h>
 
-#include <cmath>
 #include <map>
 
 DEAL_II_NAMESPACE_OPEN
@@ -79,49 +77,10 @@ TensorFunctionParser<rank, dim, Number>::initialize(
   const std::map<std::string, double> &constants,
   const bool                           time_dependent)
 {
-  this->parser_data.clear(); // this will reset all thread-local objects
-
-  this->constants   = constants;
-  this->var_names   = Utilities::split_string_list(variables, ',');
-  this->expressions = expressions;
-  AssertThrow(((time_dependent) ? dim + 1 : dim) == this->var_names.size(),
-              ExcMessage("Wrong number of variables"));
-
-  // We check that the number of
-  // components of this function
-  // matches the number of components
-  // passed in as a vector of
-  // strings.
   AssertThrow(this->n_components == expressions.size(),
               ExcInvalidExpressionSize(this->n_components, expressions.size()));
-
-  // Now we define how many variables
-  // we expect to read in.  We
-  // distinguish between two cases:
-  // Time dependent problems, and not
-  // time dependent problems. In the
-  // first case the number of
-  // variables is given by the
-  // dimension plus one. In the other
-  // case, the number of variables is
-  // equal to the dimension. Once we
-  // parsed the variables string, if
-  // none of this is the case, then
-  // an exception is thrown.
-  if (time_dependent)
-    this->n_vars = dim + 1;
-  else
-    this->n_vars = dim;
-
-  // create a parser object for the current thread we can then query
-  // in value() and vector_value(). this is not strictly necessary
-  // because a user may never call these functions on the current
-  // thread, but it gets us error messages about wrong formulas right
-  // away
-  this->init_muparser();
-
-  // finally set the initialization bit
-  this->initialized = true;
+  internal::FunctionParser::ParserImplementation<dim, Number>::initialize(
+    variables, expressions, constants, time_dependent);
 }
 
 

--- a/source/base/tensor_function_parser.cc
+++ b/source/base/tensor_function_parser.cc
@@ -224,7 +224,7 @@ TensorFunctionParser<rank, dim, Number>::init_muparser() const
           std::string transformed_expression = expressions[component];
 
           for (const auto &current_function_name :
-               internal::FunctionParser::function_names)
+               internal::FunctionParser::get_function_names())
             {
               const unsigned int function_name_length =
                 current_function_name.size();

--- a/source/base/tensor_function_parser.cc
+++ b/source/base/tensor_function_parser.cc
@@ -144,7 +144,7 @@ namespace internal
       /**
        * PIMPL for mu::Parser.
        */
-      class Parser : public internal::muParserBase
+      class Parser : public internal::FunctionParser::muParserBase
       {
       public:
         operator mu::Parser &()
@@ -173,7 +173,7 @@ TensorFunctionParser<rank, dim, Number>::init_muparser() const
   // check that we have not already initialized the parser on the
   // current thread, i.e., that the current function is only called
   // once per thread
-  ParserData &data = parser_data.get();
+  internal::FunctionParser::ParserData &data = parser_data.get();
   Assert(data.parsers.size() == 0 && data.vars.size() == 0, ExcInternalError());
 
   // initialize the objects for the current thread
@@ -294,7 +294,7 @@ TensorFunctionParser<rank, dim, Number>::value(const Point<dim> &p) const
   Assert(initialized == true, ExcNotInitialized());
 
   // initialize the parser if that hasn't happened yet on the current thread
-  ParserData &data = parser_data.get();
+  internal::FunctionParser::ParserData &data = parser_data.get();
   if (data.vars.size() == 0)
     init_muparser();
 


### PR DESCRIPTION
Followup to #13745 - we can avoid duplicating a lot of code by adding another base class. We need to use a separate base class (instead of just functions) so that we can use the PIMPL idiom.