### PR TITLE
Optimize pack()/unpack() for std::vector<T> with trivially copyable T.

### DIFF
--- a/doc/news/changes/minor/20220522Bangerth
+++ b/doc/news/changes/minor/20220522Bangerth
@@ -1,0 +1,6 @@
+New: The Utilities::pack() and Utilities::unpack() functions are now
+optimized for the rather common case where the argument is of type
+`std::vector<T>` where `T` is a type that can be copied bit by bit
+(using `memcpy()`).
+<br>
+(Wolfgang Bangerth, 2022/05/05)

--- a/examples/step-47/doc/intro.dox
+++ b/examples/step-47/doc/intro.dox
@@ -226,7 +226,7 @@ alternative method.
 We base this program on the $C^0$ IP method presented by Susanne
 Brenner and Li-Yeng Sung in the paper "C$^0$ Interior Penalty Method
 for Linear Fourth Order Boundary Value Problems on polygonal
-domains'' @cite Brenner2005 , where the method is
+domains" @cite Brenner2005 , where the method is
 derived for the biharmonic equation with "clamped" boundary
 conditions.
 

--- a/include/deal.II/lac/utilities.h
+++ b/include/deal.II/lac/utilities.h
@@ -393,14 +393,14 @@ namespace Utilities
       std::vector<double>   work;    // ^^
       types::blas_int       info;
       // call lapack_templates.h wrapper:
-      internal::UtilitiesImplementation::call_stev('N',
-                                                   n,
-                                                   diagonal.data(),
-                                                   subdiagonal.data(),
-                                                   Z.data(),
-                                                   ldz,
-                                                   work.data(),
-                                                   &info);
+      dealii::internal::UtilitiesImplementation::call_stev('N',
+                                                           n,
+                                                           diagonal.data(),
+                                                           subdiagonal.data(),
+                                                           Z.data(),
+                                                           ldz,
+                                                           work.data(),
+                                                           &info);
 
       Assert(info == 0, LAPACKSupport::ExcErrorCode("dstev", info));
 


### PR DESCRIPTION
Since we're doing a lot more packing/unpacking in our MPI communications routines these days, I thought it would be useful to optimize `pack()` and `unpack()` for cases where the argument is a `std::vector<T>` and `T` is a type that allows for `memcpy` initialization -- in particular that means that this patch optimizes for the rather common case where we want to pack `std::vector<char>`, `std::vector<double>`, etc.

If that's what the type is, then this patch simply puts the size and then the actual data into the output buffer by using `memcpy` as appropriate. That should be vastly faster than going through the boost serialization machinery.

/rebuild