### PR TITLE
Clearify LA::d::BlockVector::reinit input argument

### DIFF
--- a/include/deal.II/lac/la_parallel_block_vector.h
+++ b/include/deal.II/lac/la_parallel_block_vector.h
@@ -276,7 +276,7 @@ namespace LinearAlgebra
        * be routed to the wrong block.
        */
       void
-      reinit(const std::vector<size_type> &N,
+      reinit(const std::vector<size_type> &block_sizes,
              const bool                    omit_zeroing_entries = false);
 
       /**

--- a/include/deal.II/lac/la_parallel_block_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_block_vector.templates.h
@@ -127,15 +127,15 @@ namespace LinearAlgebra
 
     template <typename Number>
     void
-    BlockVector<Number>::reinit(const std::vector<size_type> &n,
+    BlockVector<Number>::reinit(const std::vector<size_type> &block_sizes,
                                 const bool omit_zeroing_entries)
     {
-      this->block_indices.reinit(n);
+      this->block_indices.reinit(block_sizes);
       if (this->components.size() != this->n_blocks())
         this->components.resize(this->n_blocks());
 
       for (size_type i = 0; i < this->n_blocks(); ++i)
-        this->components[i].reinit(n[i], omit_zeroing_entries);
+        this->components[i].reinit(block_sizes[i], omit_zeroing_entries);
     }
 
 


### PR DESCRIPTION
In the documentation of the refered version of LA::d::BlockVector::reinit() it is said about ``block_sizes`` but the argument of the function is called ``n``. This PR fixes this naming.