### PR TITLE
Reduce cost to set up dictionary for compute_index_owner

### DIFF
--- a/include/deal.II/base/mpi_compute_index_owner_internal.h
+++ b/include/deal.II/base/mpi_compute_index_owner_internal.h
@@ -427,13 +427,13 @@ namespace Utilities
            * out the owner of the index that was requested (using the guess in
            * `owner_index`, as we typically might look up on the same rank
            * several times in a row, which avoids the binary search in
-           * Dictionary::get_owning_rank_index(). Once we know the rank of the
-           * owner, we the vector entry with the rank of the request. Here, we
-           * utilize the fact that requests are processed rank-by-rank, so we
-           * can simply look at the end of the vector if there is already some
-           * data stored or not. Finally, we build ranges, again using that
-           * the index list is sorted and we therefore only need to append at
-           * the end.
+           * Dictionary::get_owning_rank_index()). Once we know the rank of
+           * the owner, we fill the vector entry with the rank of the
+           * request. Here, we utilize the fact that requests are processed
+           * rank-by-rank, so we can simply look at the end of the vector
+           * whether there is already some data stored or not. Finally, we
+           * build ranges, again using that the index list is sorted and we
+           * therefore only need to append at the end.
            */
           void
           append_index_origin(const types::global_dof_index index,


### PR DESCRIPTION
When looking at #13784, I noticed that we make two round-trips to the owner of the locally owned part in `compute_index_owner`, one where we set an invalid entry upon `reinit` and a second one where we set the owner of that part. Since this is typically by far the largest part of the indices and hence dominates the compute time (apart from communication, of course), we should avoid that unnecessary part in release mode. I fixed this by calling `std::vector::resize` only in `fill`, where we know the right rank.