### PR TITLE
PreconditionChebyshev: Implement power iteration for eigenvalue estimate

### DIFF
--- a/doc/news/changes/minor/20220523Kronbichler
+++ b/doc/news/changes/minor/20220523Kronbichler
@@ -1,0 +1,7 @@
+New: PreconditionChebyshev can now also estimate eigenvalues with the power
+method, rather than the Lanczos algorithm underlying the SolverCG
+estimation. This is useful for matrices that are slightly non-symmetric such
+that the eigenvalue estimate of SolverCG breaks down, but not too much so that
+the Chebyshev iteration is still a useful iteration.
+<br>
+(Martin Kronbichler, 2022/05/23)

--- a/tests/lac/precondition_chebyshev_03.with_lapack=true.output
+++ b/tests/lac/precondition_chebyshev_03.with_lapack=true.output
@@ -1,8 +1,8 @@
 
 DEAL::Size 4 Unknowns 9
-DEAL::Residual step i=0:   ilu=0.3321, cheby=0.0789
-DEAL::Residual step i=1:   ilu=0.3592, cheby=0.0789
-DEAL::Residual step i=2:   ilu=0.1717, cheby=0.0507
+DEAL::Residual step i=0:   ilu=0.3321, cheby=0.0794
+DEAL::Residual step i=1:   ilu=0.3592, cheby=0.0794
+DEAL::Residual step i=2:   ilu=0.1717, cheby=0.0509
 DEAL::Size 8 Unknowns 49
 DEAL::Residual step i=0:   ilu=1.9436, cheby=0.1549
 DEAL::Residual step i=1:   ilu=2.1487, cheby=0.1583

--- a/tests/lac/precondition_chebyshev_06.cc
+++ b/tests/lac/precondition_chebyshev_06.cc
@@ -1,0 +1,89 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// Test PreconditionChebyshev with power iteration rather than SolverCG to
+// estimate the eigenvalues (less accurate)
+
+
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/sparse_ilu.h>
+#include <deal.II/lac/sparse_matrix.h>
+#include <deal.II/lac/vector.h>
+
+#include "../tests.h"
+
+#include "../testmatrix.h"
+
+
+
+int
+main()
+{
+  initlog();
+  deallog << std::setprecision(10);
+
+  for (unsigned int size = 4; size <= 16; size *= 2)
+    {
+      unsigned int dim = (size - 1) * (size - 1);
+
+      deallog << "Size " << size << " Unknowns " << dim << std::endl;
+
+      // Make matrix
+      FDMatrix        testproblem(size, size);
+      SparsityPattern structure(dim, dim, 5);
+      testproblem.five_point_structure(structure);
+      structure.compress();
+      SparseMatrix<double> A(structure);
+      testproblem.five_point(A);
+
+      using Chebyshev = PreconditionChebyshev<SparseMatrix<double>,
+                                              Vector<double>,
+                                              SparseILU<double>>;
+      Chebyshev                 cheby;
+      Chebyshev::AdditionalData cheby_data;
+      cheby_data.preconditioner.reset(new SparseILU<double>());
+      cheby_data.preconditioner->initialize(A);
+      cheby_data.degree          = 11;
+      cheby_data.smoothing_range = 40;
+      cheby_data.eigenvalue_algorithm =
+        Chebyshev::AdditionalData::EigenvalueAlgorithm::power_iteration;
+      cheby.initialize(A, cheby_data);
+
+      Vector<double> v(dim);
+      Vector<double> tmp1(dim), tmp2(dim);
+      for (unsigned int i = 0; i < 3; ++i)
+        {
+          for (unsigned int j = 0; j < dim; ++j)
+            v(j) = random_value<double>();
+
+          A.vmult(tmp1, v);
+          cheby_data.preconditioner->vmult(tmp2, tmp1);
+          tmp2 -= v;
+          const double ilu_residual = tmp2.l2_norm();
+
+          A.vmult(tmp1, v);
+          cheby.vmult(tmp2, tmp1);
+          tmp2 -= v;
+          const double cheby_residual = tmp2.l2_norm();
+
+          deallog << "Residual step i=" << i << ":  "
+                  << " ilu=" << ilu_residual << ", cheby=" << cheby_residual
+                  << std::endl;
+        }
+    }
+
+  return 0;
+}

--- a/tests/lac/precondition_chebyshev_06.output
+++ b/tests/lac/precondition_chebyshev_06.output
@@ -1,0 +1,13 @@
+
+DEAL::Size 4 Unknowns 9
+DEAL::Residual step i=0:   ilu=0.3321067622, cheby=0.05099432420
+DEAL::Residual step i=1:   ilu=0.3592209788, cheby=0.04600439733
+DEAL::Residual step i=2:   ilu=0.1716913688, cheby=0.02710123523
+DEAL::Size 8 Unknowns 49
+DEAL::Residual step i=0:   ilu=1.943632434, cheby=0.1724610774
+DEAL::Residual step i=1:   ilu=2.148727169, cheby=0.1731956717
+DEAL::Residual step i=2:   ilu=1.756318039, cheby=0.1687993258
+DEAL::Size 16 Unknowns 225
+DEAL::Residual step i=0:   ilu=6.146258348, cheby=0.4251547823
+DEAL::Residual step i=1:   ilu=6.252364591, cheby=0.4316860132
+DEAL::Residual step i=2:   ilu=5.653977586, cheby=0.4063348761


### PR DESCRIPTION
This implements a different option for the eigenvalue estimation in PreconditionChebyshev. In general, the Lanczos algorithm that we use as a default results in much more accurate predictions for the same number of iterations, but the new option might be useful for some non-symmetric matrices.