### PR TITLE
Fix bug in FEEvaluation without vectorization

### DIFF
--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -4769,8 +4769,12 @@ namespace internal
                orientation[v][i];
     };
 
+    const unsigned int cell_index =
+      dof_access_index == MatrixFreeFunctions::DoFInfo::dof_access_cell ?
+        fe_eval.get_cell_ids()[0] :
+        cell * n_lanes;
     const unsigned int *dof_indices =
-      &dof_info.dof_indices_contiguous[dof_access_index][cell * n_lanes];
+      &dof_info.dof_indices_contiguous[dof_access_index][cell_index];
 
     for (unsigned int comp = 0; comp < n_components; ++comp)
       {


### PR DESCRIPTION
This fixes the failing test https://cdash.dealii.43-1.org/test/10618821 when vectorization is completely disabled. What happens is that we go into the `gather_evaluate` function with a single orientation, which we take as a signal for the simple case with default DoF indices as `cell_or_face_index * n_lanes`. However, that reasoning fails when we are initializing for an *exterior face* with te cell-centric approach, as we need to check `cell_ids()[0]` in that case. This fixes this case. I think it also fixes the failing tests `ecl_04` that I see on this list: https://cdash.dealii.43-1.org/viewTest.php?onlyfailed&buildid=1843 but the last remaining test `ecl_01` has been discussed elsewhere https://github.com/dealii/dealii/issues/13703#issuecomment-1133978999. Relates to #13703.