### PR TITLE
Adjust output of tests using PreconditionChebyshev

### DIFF
--- a/tests/matrix_free/parallel_multigrid.with_p4est=true.with_trilinos=true.with_lapack=true.mpirun=3.output
+++ b/tests/matrix_free/parallel_multigrid.with_p4est=true.with_trilinos=true.with_lapack=true.mpirun=3.output
@@ -5,23 +5,23 @@ DEAL:2d:cg::Starting value 9.000
 DEAL:2d:cg:cg::Starting value 0.02203
 DEAL:2d:cg:cg::Convergence step 1 value 0.000
 DEAL:2d:cg:cg::Starting value 0.0001585
-DEAL:2d:cg:cg::Convergence step 1 value 2.711e-20
-DEAL:2d:cg:cg::Starting value 8.884e-07
 DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Starting value 8.884e-07
+DEAL:2d:cg:cg::Convergence step 1 value 9.863e-23
 DEAL:2d:cg:cg::Starting value 3.123e-09
-DEAL:2d:cg:cg::Convergence step 1 value 8.272e-25
+DEAL:2d:cg:cg::Convergence step 1 value 3.468e-25
 DEAL:2d:cg::Convergence step 4 value 2.071e-08
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 289
 DEAL:2d:cg::Starting value 17.00
 DEAL:2d:cg:cg::Starting value 0.005310
-DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Convergence step 1 value 5.895e-19
 DEAL:2d:cg:cg::Starting value 5.163e-06
 DEAL:2d:cg:cg::Convergence step 1 value 0.000
 DEAL:2d:cg:cg::Starting value 2.182e-08
 DEAL:2d:cg:cg::Convergence step 1 value 0.000
 DEAL:2d:cg:cg::Starting value 9.610e-10
-DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Convergence step 1 value 2.134e-25
 DEAL:2d:cg::Convergence step 4 value 2.778e-08
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 1089
@@ -39,47 +39,47 @@ DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 289
 DEAL:2d:cg::Starting value 17.00
 DEAL:2d:cg:cg::Starting value 3.849
-DEAL:2d:cg:cg::Convergence step 2 value 4.030e-15
+DEAL:2d:cg:cg::Convergence step 2 value 1.388e-15
 DEAL:2d:cg:cg::Starting value 0.0007035
-DEAL:2d:cg:cg::Convergence step 2 value 5.474e-20
+DEAL:2d:cg:cg::Convergence step 2 value 7.914e-19
 DEAL:2d:cg:cg::Starting value 4.286e-06
-DEAL:2d:cg:cg::Convergence step 2 value 4.924e-21
+DEAL:2d:cg:cg::Convergence step 2 value 1.471e-21
 DEAL:2d:cg:cg::Starting value 2.909e-08
-DEAL:2d:cg:cg::Convergence step 2 value 6.440e-24
+DEAL:2d:cg:cg::Convergence step 2 value 1.896e-23
 DEAL:2d:cg::Convergence step 4 value 3.931e-08
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 1089
 DEAL:2d:cg::Starting value 33.00
 DEAL:2d:cg:cg::Starting value 14.69
-DEAL:2d:cg:cg::Convergence step 2 value 1.477e-14
+DEAL:2d:cg:cg::Convergence step 2 value 4.242e-15
 DEAL:2d:cg:cg::Starting value 0.002915
-DEAL:2d:cg:cg::Convergence step 2 value 8.995e-19
+DEAL:2d:cg:cg::Convergence step 2 value 1.213e-18
 DEAL:2d:cg:cg::Starting value 3.439e-06
-DEAL:2d:cg:cg::Convergence step 2 value 3.178e-21
+DEAL:2d:cg:cg::Convergence step 2 value 1.583e-21
 DEAL:2d:cg:cg::Starting value 1.212e-08
-DEAL:2d:cg:cg::Convergence step 2 value 1.500e-23
+DEAL:2d:cg:cg::Convergence step 2 value 1.131e-24
 DEAL:2d:cg::Convergence step 4 value 8.121e-08
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 4225
 DEAL:2d:cg::Starting value 65.00
 DEAL:2d:cg:cg::Starting value 58.09
-DEAL:2d:cg:cg::Convergence step 2 value 5.909e-15
+DEAL:2d:cg:cg::Convergence step 2 value 4.467e-14
 DEAL:2d:cg:cg::Starting value 0.01056
-DEAL:2d:cg:cg::Convergence step 2 value 5.646e-18
+DEAL:2d:cg:cg::Convergence step 2 value 9.358e-19
 DEAL:2d:cg:cg::Starting value 2.588e-05
-DEAL:2d:cg:cg::Convergence step 2 value 8.081e-21
+DEAL:2d:cg:cg::Convergence step 2 value 3.405e-20
 DEAL:2d:cg:cg::Starting value 6.672e-08
-DEAL:2d:cg:cg::Convergence step 2 value 4.727e-23
+DEAL:2d:cg:cg::Convergence step 2 value 5.007e-23
 DEAL:2d:cg::Convergence step 4 value 1.695e-07
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 125
 DEAL:3d:cg::Starting value 11.18
 DEAL:3d:cg:cg::Starting value 0.5164
-DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg:cg::Convergence step 1 value 1.147e-16
 DEAL:3d:cg:cg::Starting value 0.02357
-DEAL:3d:cg:cg::Convergence step 1 value 4.907e-18
-DEAL:3d:cg:cg::Starting value 5.322e-05
 DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg:cg::Starting value 5.322e-05
+DEAL:3d:cg:cg::Convergence step 1 value 1.182e-20
 DEAL:3d:cg:cg::Starting value 1.537e-07
 DEAL:3d:cg:cg::Convergence step 1 value 0.000
 DEAL:3d:cg::Convergence step 4 value 3.460e-07
@@ -89,9 +89,9 @@ DEAL:3d:cg::Starting value 27.00
 DEAL:3d:cg:cg::Starting value 0.1824
 DEAL:3d:cg:cg::Convergence step 1 value 0.000
 DEAL:3d:cg:cg::Starting value 0.004902
-DEAL:3d:cg:cg::Convergence step 1 value 6.133e-19
-DEAL:3d:cg:cg::Starting value 5.629e-06
 DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg:cg::Starting value 5.629e-06
+DEAL:3d:cg:cg::Convergence step 1 value 1.250e-21
 DEAL:3d:cg:cg::Starting value 3.386e-10
 DEAL:3d:cg:cg::Convergence step 1 value 0.000
 DEAL:3d:cg::Convergence step 4 value 1.074e-07
@@ -101,45 +101,45 @@ DEAL:3d:cg::Starting value 70.09
 DEAL:3d:cg:cg::Starting value 0.1633
 DEAL:3d:cg:cg::Convergence step 1 value 0.000
 DEAL:3d:cg:cg::Starting value 0.0001064
-DEAL:3d:cg:cg::Convergence step 1 value 1.917e-20
+DEAL:3d:cg:cg::Convergence step 1 value 1.181e-20
 DEAL:3d:cg:cg::Starting value 1.367e-06
-DEAL:3d:cg:cg::Convergence step 1 value 2.995e-22
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
 DEAL:3d:cg:cg::Starting value 1.607e-08
-DEAL:3d:cg:cg::Convergence step 1 value 4.679e-24
+DEAL:3d:cg:cg::Convergence step 1 value 3.568e-24
 DEAL:3d:cg::Convergence step 4 value 5.067e-08
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 729
 DEAL:3d:cg::Starting value 27.00
 DEAL:3d:cg:cg::Starting value 1.696
-DEAL:3d:cg:cg::Convergence step 2 value 3.019e-16
-DEAL:3d:cg:cg::Starting value 0.1038
-DEAL:3d:cg:cg::Convergence step 2 value 1.281e-17
-DEAL:3d:cg:cg::Starting value 0.0001778
-DEAL:3d:cg:cg::Convergence step 2 value 2.774e-20
-DEAL:3d:cg:cg::Starting value 5.289e-06
-DEAL:3d:cg:cg::Convergence step 2 value 5.235e-22
-DEAL:3d:cg::Convergence step 4 value 2.355e-06
+DEAL:3d:cg:cg::Convergence step 2 value 4.279e-16
+DEAL:3d:cg:cg::Starting value 0.1039
+DEAL:3d:cg:cg::Convergence step 2 value 1.250e-17
+DEAL:3d:cg:cg::Starting value 0.0001780
+DEAL:3d:cg:cg::Convergence step 2 value 1.054e-20
+DEAL:3d:cg:cg::Starting value 5.292e-06
+DEAL:3d:cg:cg::Convergence step 2 value 1.622e-22
+DEAL:3d:cg::Convergence step 4 value 2.351e-06
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 4913
 DEAL:3d:cg::Starting value 70.09
-DEAL:3d:cg:cg::Starting value 2.313
-DEAL:3d:cg:cg::Convergence step 2 value 3.056e-16
-DEAL:3d:cg:cg::Starting value 0.04486
-DEAL:3d:cg:cg::Convergence step 2 value 9.479e-18
-DEAL:3d:cg:cg::Starting value 0.0007197
-DEAL:3d:cg:cg::Convergence step 2 value 1.099e-19
-DEAL:3d:cg:cg::Starting value 2.909e-06
-DEAL:3d:cg:cg::Convergence step 2 value 1.507e-22
+DEAL:3d:cg:cg::Starting value 2.288
+DEAL:3d:cg:cg::Convergence step 2 value 1.482e-15
+DEAL:3d:cg:cg::Starting value 0.04493
+DEAL:3d:cg:cg::Convergence step 2 value 2.411e-18
+DEAL:3d:cg:cg::Starting value 0.0007205
+DEAL:3d:cg:cg::Convergence step 2 value 9.281e-20
+DEAL:3d:cg:cg::Starting value 2.913e-06
+DEAL:3d:cg:cg::Convergence step 2 value 5.846e-23
 DEAL:3d:cg::Convergence step 4 value 4.578e-06
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 35937
 DEAL:3d:cg::Starting value 189.6
-DEAL:3d:cg:cg::Starting value 17.40
-DEAL:3d:cg:cg::Convergence step 2 value 1.067e-14
-DEAL:3d:cg:cg::Starting value 0.01679
-DEAL:3d:cg:cg::Convergence step 2 value 2.474e-18
-DEAL:3d:cg:cg::Starting value 0.001098
-DEAL:3d:cg:cg::Convergence step 2 value 8.085e-20
-DEAL:3d:cg:cg::Starting value 1.006e-06
-DEAL:3d:cg:cg::Convergence step 2 value 9.940e-23
+DEAL:3d:cg:cg::Starting value 17.19
+DEAL:3d:cg:cg::Convergence step 2 value 1.912e-14
+DEAL:3d:cg:cg::Starting value 0.01678
+DEAL:3d:cg:cg::Convergence step 2 value 4.151e-18
+DEAL:3d:cg:cg::Starting value 0.001099
+DEAL:3d:cg:cg::Convergence step 2 value 2.529e-19
+DEAL:3d:cg:cg::Starting value 9.998e-07
+DEAL:3d:cg:cg::Convergence step 2 value 5.098e-22
 DEAL:3d:cg::Convergence step 4 value 1.784e-05

--- a/tests/matrix_free/parallel_multigrid.with_p4est=true.with_trilinos=true.with_lapack=true.mpirun=7.output
+++ b/tests/matrix_free/parallel_multigrid.with_p4est=true.with_trilinos=true.with_lapack=true.mpirun=7.output
@@ -3,31 +3,31 @@ DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 81
 DEAL:2d:cg::Starting value 9.000
 DEAL:2d:cg:cg::Starting value 0.02203
-DEAL:2d:cg:cg::Convergence step 1 value 3.469e-18
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
 DEAL:2d:cg:cg::Starting value 0.0001585
-DEAL:2d:cg:cg::Convergence step 1 value 2.711e-20
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
 DEAL:2d:cg:cg::Starting value 8.884e-07
 DEAL:2d:cg:cg::Convergence step 1 value 0.000
 DEAL:2d:cg:cg::Starting value 3.123e-09
-DEAL:2d:cg:cg::Convergence step 1 value 4.136e-25
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
 DEAL:2d:cg::Convergence step 4 value 2.071e-08
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 289
 DEAL:2d:cg::Starting value 17.00
 DEAL:2d:cg:cg::Starting value 0.005310
-DEAL:2d:cg:cg::Convergence step 1 value 8.674e-19
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
 DEAL:2d:cg:cg::Starting value 5.163e-06
 DEAL:2d:cg:cg::Convergence step 1 value 0.000
 DEAL:2d:cg:cg::Starting value 2.182e-08
 DEAL:2d:cg:cg::Convergence step 1 value 0.000
 DEAL:2d:cg:cg::Starting value 9.610e-10
-DEAL:2d:cg:cg::Convergence step 1 value 2.068e-25
+DEAL:2d:cg:cg::Convergence step 1 value 0.000
 DEAL:2d:cg::Convergence step 4 value 2.778e-08
 DEAL:2d::Testing FE_Q<2>(1)
 DEAL:2d::Number of degrees of freedom: 1089
 DEAL:2d:cg::Starting value 33.00
 DEAL:2d:cg:cg::Starting value 0.008242
-DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Convergence step 1 value 1.830e-18
 DEAL:2d:cg:cg::Starting value 2.754e-06
 DEAL:2d:cg:cg::Convergence step 1 value 0.000
 DEAL:2d:cg:cg::Starting value 9.820e-09
@@ -39,59 +39,59 @@ DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 289
 DEAL:2d:cg::Starting value 17.00
 DEAL:2d:cg:cg::Starting value 3.849
-DEAL:2d:cg:cg::Convergence step 2 value 2.944e-15
+DEAL:2d:cg:cg::Convergence step 2 value 1.863e-15
 DEAL:2d:cg:cg::Starting value 0.0007035
-DEAL:2d:cg:cg::Convergence step 2 value 9.681e-20
+DEAL:2d:cg:cg::Convergence step 2 value 5.372e-19
 DEAL:2d:cg:cg::Starting value 4.286e-06
-DEAL:2d:cg:cg::Convergence step 2 value 3.549e-21
+DEAL:2d:cg:cg::Convergence step 2 value 4.258e-21
 DEAL:2d:cg:cg::Starting value 2.909e-08
-DEAL:2d:cg:cg::Convergence step 2 value 1.182e-23
+DEAL:2d:cg:cg::Convergence step 2 value 1.177e-24
 DEAL:2d:cg::Convergence step 4 value 3.931e-08
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 1089
 DEAL:2d:cg::Starting value 33.00
 DEAL:2d:cg:cg::Starting value 14.69
-DEAL:2d:cg:cg::Convergence step 2 value 4.231e-15
+DEAL:2d:cg:cg::Convergence step 2 value 1.771e-14
 DEAL:2d:cg:cg::Starting value 0.002915
-DEAL:2d:cg:cg::Convergence step 2 value 5.424e-18
+DEAL:2d:cg:cg::Convergence step 2 value 2.794e-18
 DEAL:2d:cg:cg::Starting value 3.439e-06
-DEAL:2d:cg:cg::Convergence step 2 value 1.113e-21
+DEAL:2d:cg:cg::Convergence step 2 value 1.470e-21
 DEAL:2d:cg:cg::Starting value 1.212e-08
-DEAL:2d:cg:cg::Convergence step 2 value 7.249e-24
+DEAL:2d:cg:cg::Convergence step 2 value 4.310e-24
 DEAL:2d:cg::Convergence step 4 value 8.121e-08
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 4225
 DEAL:2d:cg::Starting value 65.00
 DEAL:2d:cg:cg::Starting value 58.09
-DEAL:2d:cg:cg::Convergence step 2 value 5.109e-14
+DEAL:2d:cg:cg::Convergence step 2 value 7.517e-15
 DEAL:2d:cg:cg::Starting value 0.01056
-DEAL:2d:cg:cg::Convergence step 2 value 7.258e-19
+DEAL:2d:cg:cg::Convergence step 2 value 3.556e-18
 DEAL:2d:cg:cg::Starting value 2.588e-05
-DEAL:2d:cg:cg::Convergence step 2 value 8.491e-21
+DEAL:2d:cg:cg::Convergence step 2 value 1.590e-20
 DEAL:2d:cg:cg::Starting value 6.672e-08
-DEAL:2d:cg:cg::Convergence step 2 value 1.252e-23
+DEAL:2d:cg:cg::Convergence step 2 value 3.475e-23
 DEAL:2d:cg::Convergence step 4 value 1.695e-07
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 125
 DEAL:3d:cg::Starting value 11.18
 DEAL:3d:cg:cg::Starting value 0.5164
-DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg:cg::Convergence step 1 value 1.147e-16
 DEAL:3d:cg:cg::Starting value 0.02357
 DEAL:3d:cg:cg::Convergence step 1 value 0.000
 DEAL:3d:cg:cg::Starting value 5.322e-05
 DEAL:3d:cg:cg::Convergence step 1 value 0.000
 DEAL:3d:cg:cg::Starting value 1.537e-07
-DEAL:3d:cg:cg::Convergence step 1 value 3.743e-23
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
 DEAL:3d:cg::Convergence step 4 value 3.460e-07
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 729
 DEAL:3d:cg::Starting value 27.00
 DEAL:3d:cg:cg::Starting value 0.1824
-DEAL:3d:cg:cg::Convergence step 1 value 3.925e-17
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
 DEAL:3d:cg:cg::Starting value 0.004902
-DEAL:3d:cg:cg::Convergence step 1 value 6.133e-19
+DEAL:3d:cg:cg::Convergence step 1 value 5.443e-19
 DEAL:3d:cg:cg::Starting value 5.629e-06
-DEAL:3d:cg:cg::Convergence step 1 value 1.198e-21
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
 DEAL:3d:cg:cg::Starting value 3.386e-10
 DEAL:3d:cg:cg::Convergence step 1 value 0.000
 DEAL:3d:cg::Convergence step 4 value 1.074e-07
@@ -101,45 +101,45 @@ DEAL:3d:cg::Starting value 70.09
 DEAL:3d:cg:cg::Starting value 0.1633
 DEAL:3d:cg:cg::Convergence step 1 value 0.000
 DEAL:3d:cg:cg::Starting value 0.0001064
-DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg:cg::Convergence step 1 value 2.362e-20
 DEAL:3d:cg:cg::Starting value 1.367e-06
-DEAL:3d:cg:cg::Convergence step 1 value 2.995e-22
+DEAL:3d:cg:cg::Convergence step 1 value 0.000
 DEAL:3d:cg:cg::Starting value 1.607e-08
-DEAL:3d:cg:cg::Convergence step 1 value 4.679e-24
+DEAL:3d:cg:cg::Convergence step 1 value 3.568e-24
 DEAL:3d:cg::Convergence step 4 value 5.067e-08
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 729
 DEAL:3d:cg::Starting value 27.00
 DEAL:3d:cg:cg::Starting value 1.696
-DEAL:3d:cg:cg::Convergence step 2 value 2.866e-16
-DEAL:3d:cg:cg::Starting value 0.1038
-DEAL:3d:cg:cg::Convergence step 2 value 2.373e-17
-DEAL:3d:cg:cg::Starting value 0.0001778
-DEAL:3d:cg:cg::Convergence step 2 value 2.322e-20
-DEAL:3d:cg:cg::Starting value 5.289e-06
-DEAL:3d:cg:cg::Convergence step 2 value 3.474e-22
-DEAL:3d:cg::Convergence step 4 value 2.355e-06
+DEAL:3d:cg:cg::Convergence step 2 value 1.987e-16
+DEAL:3d:cg:cg::Starting value 0.1039
+DEAL:3d:cg:cg::Convergence step 2 value 3.578e-18
+DEAL:3d:cg:cg::Starting value 0.0001780
+DEAL:3d:cg:cg::Convergence step 2 value 1.311e-20
+DEAL:3d:cg:cg::Starting value 5.292e-06
+DEAL:3d:cg:cg::Convergence step 2 value 5.646e-22
+DEAL:3d:cg::Convergence step 4 value 2.351e-06
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 4913
 DEAL:3d:cg::Starting value 70.09
-DEAL:3d:cg:cg::Starting value 2.313
-DEAL:3d:cg:cg::Convergence step 2 value 2.276e-15
-DEAL:3d:cg:cg::Starting value 0.04486
-DEAL:3d:cg:cg::Convergence step 2 value 8.352e-19
-DEAL:3d:cg:cg::Starting value 0.0007197
-DEAL:3d:cg:cg::Convergence step 2 value 7.308e-20
-DEAL:3d:cg:cg::Starting value 2.909e-06
-DEAL:3d:cg:cg::Convergence step 2 value 1.373e-22
+DEAL:3d:cg:cg::Starting value 2.288
+DEAL:3d:cg:cg::Convergence step 2 value 6.751e-17
+DEAL:3d:cg:cg::Starting value 0.04493
+DEAL:3d:cg:cg::Convergence step 2 value 1.105e-17
+DEAL:3d:cg:cg::Starting value 0.0007205
+DEAL:3d:cg:cg::Convergence step 2 value 1.525e-20
+DEAL:3d:cg:cg::Starting value 2.913e-06
+DEAL:3d:cg:cg::Convergence step 2 value 7.041e-22
 DEAL:3d:cg::Convergence step 4 value 4.578e-06
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 35937
 DEAL:3d:cg::Starting value 189.6
-DEAL:3d:cg:cg::Starting value 17.40
-DEAL:3d:cg:cg::Convergence step 2 value 1.045e-14
-DEAL:3d:cg:cg::Starting value 0.01679
-DEAL:3d:cg:cg::Convergence step 2 value 2.190e-18
-DEAL:3d:cg:cg::Starting value 0.001098
-DEAL:3d:cg:cg::Convergence step 2 value 1.752e-19
-DEAL:3d:cg:cg::Starting value 1.006e-06
-DEAL:3d:cg:cg::Convergence step 2 value 7.732e-22
+DEAL:3d:cg:cg::Starting value 17.19
+DEAL:3d:cg:cg::Convergence step 2 value 5.350e-15
+DEAL:3d:cg:cg::Starting value 0.01678
+DEAL:3d:cg:cg::Convergence step 2 value 3.272e-18
+DEAL:3d:cg:cg::Starting value 0.001099
+DEAL:3d:cg:cg::Convergence step 2 value 2.132e-20
+DEAL:3d:cg:cg::Starting value 9.998e-07
+DEAL:3d:cg:cg::Convergence step 2 value 3.927e-22
 DEAL:3d:cg::Convergence step 4 value 1.784e-05

--- a/tests/matrix_free/parallel_multigrid_02.with_p4est=true.with_trilinos=true.with_lapack=true.mpirun=3.output
+++ b/tests/matrix_free/parallel_multigrid_02.with_p4est=true.with_trilinos=true.with_lapack=true.mpirun=3.output
@@ -18,25 +18,25 @@ DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 289
 DEAL:2d:cg::Starting value 17.00
 DEAL:2d:cg:cg::Starting value 3.765
-DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Convergence step 1 value 2.359e-16
 DEAL:2d:cg:cg::Starting value 0.0005314
-DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Convergence step 1 value 6.437e-20
 DEAL:2d:cg:cg::Starting value 3.806e-06
-DEAL:2d:cg:cg::Convergence step 1 value 4.235e-22
+DEAL:2d:cg:cg::Convergence step 1 value 9.264e-23
 DEAL:2d:cg:cg::Starting value 1.628e-08
-DEAL:2d:cg:cg::Convergence step 1 value 3.309e-24
+DEAL:2d:cg:cg::Convergence step 1 value 1.034e-24
 DEAL:2d:cg::Convergence step 4 value 1.712e-08
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 1089
 DEAL:2d:cg::Starting value 33.00
 DEAL:2d:cg:cg::Starting value 14.37
-DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Convergence step 1 value 8.327e-16
 DEAL:2d:cg:cg::Starting value 0.002280
-DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Convergence step 1 value 2.711e-20
 DEAL:2d:cg:cg::Starting value 6.550e-06
-DEAL:2d:cg:cg::Convergence step 1 value 8.470e-22
+DEAL:2d:cg:cg::Convergence step 1 value 1.570e-22
 DEAL:2d:cg:cg::Starting value 5.084e-08
-DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Convergence step 1 value 6.035e-24
 DEAL:2d:cg::Convergence step 4 value 4.315e-08
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 125
@@ -55,24 +55,24 @@ DEAL:3d:cg::Convergence step 3 value 1.025e-06
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 729
 DEAL:3d:cg::Starting value 27.00
-DEAL:3d:cg:cg::Starting value 0.3913
-DEAL:3d:cg:cg::Convergence step 1 value 0.000
-DEAL:3d:cg:cg::Starting value 0.0006066
-DEAL:3d:cg:cg::Convergence step 1 value 0.000
-DEAL:3d:cg:cg::Starting value 3.469e-07
-DEAL:3d:cg:cg::Convergence step 1 value 0.000
-DEAL:3d:cg:cg::Starting value 5.798e-10
-DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg:cg::Starting value 0.3870
+DEAL:3d:cg:cg::Convergence step 1 value 4.005e-17
+DEAL:3d:cg:cg::Starting value 0.0005996
+DEAL:3d:cg:cg::Convergence step 1 value 2.717e-20
+DEAL:3d:cg:cg::Starting value 3.381e-07
+DEAL:3d:cg:cg::Convergence step 1 value 1.182e-23
+DEAL:3d:cg:cg::Starting value 5.601e-10
+DEAL:3d:cg:cg::Convergence step 1 value 5.638e-26
 DEAL:3d:cg::Convergence step 4 value 5.998e-09
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 4913
 DEAL:3d:cg::Starting value 70.09
-DEAL:3d:cg:cg::Starting value 2.274
-DEAL:3d:cg:cg::Convergence step 1 value 0.000
-DEAL:3d:cg:cg::Starting value 0.0007566
-DEAL:3d:cg:cg::Convergence step 1 value 0.000
-DEAL:3d:cg:cg::Starting value 3.302e-06
-DEAL:3d:cg:cg::Convergence step 1 value 4.235e-22
-DEAL:3d:cg:cg::Starting value 1.183e-08
-DEAL:3d:cg:cg::Convergence step 1 value 1.654e-24
+DEAL:3d:cg:cg::Starting value 2.248
+DEAL:3d:cg:cg::Convergence step 1 value 8.552e-17
+DEAL:3d:cg:cg::Starting value 0.0007474
+DEAL:3d:cg:cg::Convergence step 1 value 1.057e-19
+DEAL:3d:cg:cg::Starting value 3.260e-06
+DEAL:3d:cg:cg::Convergence step 1 value 4.268e-23
+DEAL:3d:cg:cg::Starting value 1.168e-08
+DEAL:3d:cg:cg::Convergence step 1 value 4.233e-25
 DEAL:3d:cg::Convergence step 4 value 5.811e-08

--- a/tests/matrix_free/parallel_multigrid_02.with_p4est=true.with_trilinos=true.with_lapack=true.mpirun=7.output
+++ b/tests/matrix_free/parallel_multigrid_02.with_p4est=true.with_trilinos=true.with_lapack=true.mpirun=7.output
@@ -18,25 +18,25 @@ DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 289
 DEAL:2d:cg::Starting value 17.00
 DEAL:2d:cg:cg::Starting value 3.765
-DEAL:2d:cg:cg::Convergence step 1 value 4.441e-16
+DEAL:2d:cg:cg::Convergence step 1 value 2.220e-16
 DEAL:2d:cg:cg::Starting value 0.0005314
-DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Convergence step 1 value 2.282e-20
 DEAL:2d:cg:cg::Starting value 3.806e-06
-DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Convergence step 1 value 2.569e-22
 DEAL:2d:cg:cg::Starting value 1.628e-08
-DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Convergence step 1 value 9.306e-25
 DEAL:2d:cg::Convergence step 4 value 1.712e-08
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Number of degrees of freedom: 1089
 DEAL:2d:cg::Starting value 33.00
 DEAL:2d:cg:cg::Starting value 14.37
-DEAL:2d:cg:cg::Convergence step 1 value 1.776e-15
+DEAL:2d:cg:cg::Convergence step 1 value 9.437e-16
 DEAL:2d:cg:cg::Starting value 0.002280
-DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Convergence step 1 value 2.168e-19
 DEAL:2d:cg:cg::Starting value 6.550e-06
-DEAL:2d:cg:cg::Convergence step 1 value 8.470e-22
+DEAL:2d:cg:cg::Convergence step 1 value 5.823e-22
 DEAL:2d:cg:cg::Starting value 5.084e-08
-DEAL:2d:cg:cg::Convergence step 1 value 0.000
+DEAL:2d:cg:cg::Convergence step 1 value 4.136e-25
 DEAL:2d:cg::Convergence step 4 value 4.315e-08
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Number of degrees of freedom: 125
@@ -55,24 +55,24 @@ DEAL:3d:cg::Convergence step 3 value 1.025e-06
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 729
 DEAL:3d:cg::Starting value 27.00
-DEAL:3d:cg:cg::Starting value 0.3913
-DEAL:3d:cg:cg::Convergence step 1 value 5.551e-17
-DEAL:3d:cg:cg::Starting value 0.0006066
-DEAL:3d:cg:cg::Convergence step 1 value 0.000
-DEAL:3d:cg:cg::Starting value 3.469e-07
-DEAL:3d:cg:cg::Convergence step 1 value 0.000
-DEAL:3d:cg:cg::Starting value 5.798e-10
-DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg:cg::Starting value 0.3870
+DEAL:3d:cg:cg::Convergence step 1 value 3.850e-18
+DEAL:3d:cg:cg::Starting value 0.0005996
+DEAL:3d:cg:cg::Convergence step 1 value 1.355e-20
+DEAL:3d:cg:cg::Starting value 3.381e-07
+DEAL:3d:cg:cg::Convergence step 1 value 8.779e-24
+DEAL:3d:cg:cg::Starting value 5.601e-10
+DEAL:3d:cg:cg::Convergence step 1 value 4.426e-26
 DEAL:3d:cg::Convergence step 4 value 5.998e-09
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Number of degrees of freedom: 4913
 DEAL:3d:cg::Starting value 70.09
-DEAL:3d:cg:cg::Starting value 2.274
-DEAL:3d:cg:cg::Convergence step 1 value 0.000
-DEAL:3d:cg:cg::Starting value 0.0007566
-DEAL:3d:cg:cg::Convergence step 1 value 1.084e-19
-DEAL:3d:cg:cg::Starting value 3.302e-06
-DEAL:3d:cg:cg::Convergence step 1 value 0.000
-DEAL:3d:cg:cg::Starting value 1.183e-08
-DEAL:3d:cg:cg::Convergence step 1 value 0.000
+DEAL:3d:cg:cg::Starting value 2.248
+DEAL:3d:cg:cg::Convergence step 1 value 2.463e-16
+DEAL:3d:cg:cg::Starting value 0.0007474
+DEAL:3d:cg:cg::Convergence step 1 value 1.924e-20
+DEAL:3d:cg:cg::Starting value 3.260e-06
+DEAL:3d:cg:cg::Convergence step 1 value 2.263e-22
+DEAL:3d:cg:cg::Starting value 1.168e-08
+DEAL:3d:cg:cg::Convergence step 1 value 1.617e-26
 DEAL:3d:cg::Convergence step 4 value 5.811e-08

--- a/tests/matrix_free/parallel_multigrid_interleave.with_p4est=true.with_lapack=true.mpirun=2.output
+++ b/tests/matrix_free/parallel_multigrid_interleave.with_p4est=true.with_lapack=true.mpirun=2.output
@@ -21,8 +21,8 @@ DEAL::Approx. number of calls to special vmult for Operator of size 1089: 50
 DEAL::Testing FE_Q<2>(3)
 DEAL::Number of degrees of freedom: 2401
 DEAL:cg::Starting value 47.0000
-DEAL:cg::Convergence step 6 value 3.65064e-09
-DEAL::Approx. number of calls to special vmult for Operator of size 16: 20
+DEAL:cg::Convergence step 6 value 5.14228e-09
+DEAL::Approx. number of calls to special vmult for Operator of size 16: 30
 DEAL::Approx. number of calls to special vmult for Operator of size 49: 50
 DEAL::Approx. number of calls to special vmult for Operator of size 169: 50
 DEAL::Approx. number of calls to special vmult for Operator of size 625: 50
@@ -30,8 +30,8 @@ DEAL::Approx. number of calls to special vmult for Operator of size 2401: 50
 DEAL::Testing FE_Q<2>(3)
 DEAL::Number of degrees of freedom: 9409
 DEAL:cg::Starting value 95.0000
-DEAL:cg::Convergence step 6 value 8.12469e-09
-DEAL::Approx. number of calls to special vmult for Operator of size 16: 20
+DEAL:cg::Convergence step 6 value 1.44454e-08
+DEAL::Approx. number of calls to special vmult for Operator of size 16: 30
 DEAL::Approx. number of calls to special vmult for Operator of size 49: 50
 DEAL::Approx. number of calls to special vmult for Operator of size 169: 50
 DEAL::Approx. number of calls to special vmult for Operator of size 625: 50
@@ -57,7 +57,7 @@ DEAL::Approx. number of calls to special vmult for Operator of size 4913: 50
 DEAL::Testing FE_Q<3>(2)
 DEAL::Number of degrees of freedom: 4913
 DEAL:cg::Starting value 58.0948
-DEAL:cg::Convergence step 6 value 1.18226e-09
+DEAL:cg::Convergence step 6 value 1.17825e-09
 DEAL::Approx. number of calls to special vmult for Operator of size 27: 20
 DEAL::Approx. number of calls to special vmult for Operator of size 125: 50
 DEAL::Approx. number of calls to special vmult for Operator of size 729: 50
@@ -65,7 +65,7 @@ DEAL::Approx. number of calls to special vmult for Operator of size 4913: 50
 DEAL::Testing FE_Q<3>(2)
 DEAL::Number of degrees of freedom: 35937
 DEAL:cg::Starting value 172.601
-DEAL:cg::Convergence step 6 value 4.79606e-09
+DEAL:cg::Convergence step 6 value 4.79055e-09
 DEAL::Approx. number of calls to special vmult for Operator of size 27: 20
 DEAL::Approx. number of calls to special vmult for Operator of size 125: 50
 DEAL::Approx. number of calls to special vmult for Operator of size 729: 50

--- a/tests/matrix_free/parallel_multigrid_interleave_renumber.with_p4est=true.with_lapack=true.mpirun=2.output
+++ b/tests/matrix_free/parallel_multigrid_interleave_renumber.with_p4est=true.with_lapack=true.mpirun=2.output
@@ -21,8 +21,8 @@ DEAL::Approx. number of calls to special vmult for Operator of size 1089: 50
 DEAL::Testing FE_Q<2>(3)
 DEAL::Number of degrees of freedom: 2401
 DEAL:cg::Starting value 47.0000
-DEAL:cg::Convergence step 6 value 1.96747e-09
-DEAL::Approx. number of calls to special vmult for Operator of size 16: 20
+DEAL:cg::Convergence step 6 value 2.11509e-09
+DEAL::Approx. number of calls to special vmult for Operator of size 16: 30
 DEAL::Approx. number of calls to special vmult for Operator of size 49: 50
 DEAL::Approx. number of calls to special vmult for Operator of size 169: 50
 DEAL::Approx. number of calls to special vmult for Operator of size 625: 50
@@ -30,8 +30,8 @@ DEAL::Approx. number of calls to special vmult for Operator of size 2401: 50
 DEAL::Testing FE_Q<2>(3)
 DEAL::Number of degrees of freedom: 9409
 DEAL:cg::Starting value 95.0000
-DEAL:cg::Convergence step 6 value 6.94687e-09
-DEAL::Approx. number of calls to special vmult for Operator of size 16: 20
+DEAL:cg::Convergence step 6 value 8.72760e-09
+DEAL::Approx. number of calls to special vmult for Operator of size 16: 30
 DEAL::Approx. number of calls to special vmult for Operator of size 49: 50
 DEAL::Approx. number of calls to special vmult for Operator of size 169: 50
 DEAL::Approx. number of calls to special vmult for Operator of size 625: 50
@@ -57,7 +57,7 @@ DEAL::Approx. number of calls to special vmult for Operator of size 4913: 50
 DEAL::Testing FE_Q<3>(2)
 DEAL::Number of degrees of freedom: 4913
 DEAL:cg::Starting value 58.0948
-DEAL:cg::Convergence step 6 value 1.26931e-09
+DEAL:cg::Convergence step 6 value 1.26786e-09
 DEAL::Approx. number of calls to special vmult for Operator of size 27: 20
 DEAL::Approx. number of calls to special vmult for Operator of size 125: 50
 DEAL::Approx. number of calls to special vmult for Operator of size 729: 50
@@ -65,7 +65,7 @@ DEAL::Approx. number of calls to special vmult for Operator of size 4913: 50
 DEAL::Testing FE_Q<3>(2)
 DEAL::Number of degrees of freedom: 35937
 DEAL:cg::Starting value 172.601
-DEAL:cg::Convergence step 6 value 4.73674e-09
+DEAL:cg::Convergence step 6 value 4.72892e-09
 DEAL::Approx. number of calls to special vmult for Operator of size 27: 20
 DEAL::Approx. number of calls to special vmult for Operator of size 125: 50
 DEAL::Approx. number of calls to special vmult for Operator of size 729: 50


### PR DESCRIPTION
The PR #13792 changed the tolerance for stopping the Chebyshev iteration to the simpler `IterationNumberControl` in order to avoid the `try`/`catch` block in the code. I also slightly tightened the tolerances, so the number of iterations might slightly differ. This updates the tests I did not detect in the other PR, see e.g. https://cdash.dealii.43-1.org/test/10947264 for a failure. These tests won't run on the CI, so I did not put the flag 'ready to test'