### PR TITLE
Utilities: Fix compile error on certain compilers

### DIFF
--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -1474,7 +1474,7 @@ namespace Utilities
         return object;
       }
 
-    return {};
+    return T();
   }
 
 


### PR DESCRIPTION
For the tests `quadrature_point_data_*`, we need to pack a `FullMatrix` object, but due to the constructor being marked `explicit`, we cannot convert an empty initializer `{}` to it, see the error here: https://cdash.dealii.43-1.org/test/10978430

This PR constructs the relevant type.