### PR TITLE
ParameterHandler::print_parameters(): Demangle JSON

### DIFF
--- a/doc/news/changes/incompatibilities/20220525SchreterMunch
+++ b/doc/news/changes/incompatibilities/20220525SchreterMunch
@@ -1,0 +1,7 @@
+Changed: For ParameterHandler::OutputStyle::JSON or 
+ParameterHandler::OutputStyle::ShortJSON, the function 
+ParameterHandler::print_parameters() demangles now the 
+parameters before printing the output. Users do not 
+need to demangle the output themselves anymore.
+<br>
+(Magdalena Schreter, Peter Munch, 2022/05/25)

--- a/tests/parameter_handler/parameter_acceptor_09.output
+++ b/tests/parameter_handler/parameter_acceptor_09.output
@@ -15,7 +15,7 @@ DEAL::Generate and read input.json
 {
     "Test":
     {
-        "A_20point":
+        "A point":
         {
             "value": "0, 0, 0",
             "default_value": "0, 0, 0",

--- a/tests/parameter_handler/parameter_handler_27.output
+++ b/tests/parameter_handler/parameter_handler_27.output
@@ -20,7 +20,7 @@ DEAL::========================================
 {
     "Testing":
     {
-        "A_20bool":
+        "A bool":
         {
             "value": "true",
             "default_value": "true",
@@ -29,7 +29,7 @@ DEAL::========================================
             "pattern_description": "[Bool]",
             "actions": "1"
         },
-        "A_20double":
+        "A double":
         {
             "value": "1",
             "default_value": "1",
@@ -38,7 +38,7 @@ DEAL::========================================
             "pattern_description": "[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]",
             "actions": "0"
         },
-        "A_20string":
+        "A string":
         {
             "value": "Ciao",
             "default_value": "Ciao",

--- a/tests/parameter_handler/parameter_handler_28.output
+++ b/tests/parameter_handler/parameter_handler_28.output
@@ -13,10 +13,10 @@ DEAL::========================================
 DEAL::ShortJSON format: 
 DEAL::========================================
 {
-    "A_20double": "1",
-    "Section_20two":
+    "A double": "1",
+    "Section two":
     {
-        "Another_20double": "2"
+        "Another double": "2"
     }
 }
 

--- a/tests/parameter_handler/parameter_handler_read_json.output
+++ b/tests/parameter_handler/parameter_handler_read_json.output
@@ -18,9 +18,9 @@
         "pattern_description": "[Integer range -2147483648...2147483647 (inclusive)]",
         "actions": "1"
     },
-    "Testing_25testing":
+    "Testing%testing":
     {
-        "double_2bdouble":
+        "double+double":
         {
             "value": "7.1415926",
             "default_value": "6.14159",
@@ -29,7 +29,7 @@
             "pattern_description": "[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]",
             "actions": "6"
         },
-        "int_2aint":
+        "int*int":
         {
             "value": "2",
             "default_value": "2",
@@ -38,7 +38,7 @@
             "pattern_description": "[Integer range -2147483648...2147483647 (inclusive)]",
             "actions": "5"
         },
-        "string_26list":
+        "string&list":
         {
             "value": "< & > ; \/",
             "default_value": "< & > ; \/",
@@ -50,7 +50,7 @@
     },
     "ss1":
     {
-        "double_201":
+        "double 1":
         {
             "value": "2.234",
             "default_value": "1.234",
@@ -61,7 +61,7 @@
         },
         "ss2":
         {
-            "double_202":
+            "double 2":
             {
                 "value": "5.321",
                 "default_value": "4.321",

--- a/tests/parameter_handler/parameter_handler_write_json.output
+++ b/tests/parameter_handler/parameter_handler_write_json.output
@@ -16,9 +16,9 @@
         "pattern": "1",
         "pattern_description": "[Integer range -2147483648...2147483647 (inclusive)]"
     },
-    "Testing_25testing":
+    "Testing%testing":
     {
-        "double_2bdouble":
+        "double+double":
         {
             "value": "6.1415926",
             "default_value": "6.1415926",
@@ -26,7 +26,7 @@
             "pattern": "6",
             "pattern_description": "[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]"
         },
-        "int_2aint":
+        "int*int":
         {
             "value": "2",
             "default_value": "2",
@@ -34,7 +34,7 @@
             "pattern": "5",
             "pattern_description": "[Integer range -2147483648...2147483647 (inclusive)]"
         },
-        "string_26list":
+        "string&list":
         {
             "value": "< & > ; \/",
             "default_value": "< & > ; \/",
@@ -45,7 +45,7 @@
     },
     "ss1":
     {
-        "double_201":
+        "double 1":
         {
             "value": "1.234",
             "default_value": "1.234",
@@ -55,7 +55,7 @@
         },
         "ss2":
         {
-            "double_202":
+            "double 2":
             {
                 "value": "4.321",
                 "default_value": "4.321",
@@ -70,18 +70,18 @@
 {
     "int1": "1",
     "int2": "2",
-    "Testing_25testing":
+    "Testing%testing":
     {
-        "double_2bdouble": "6.1415926",
-        "int_2aint": "2",
-        "string_26list": "< & > ; \/"
+        "double+double": "6.1415926",
+        "int*int": "2",
+        "string&list": "< & > ; \/"
     },
     "ss1":
     {
-        "double_201": "1.234",
+        "double 1": "1.234",
         "ss2":
         {
-            "double_202": "4.321"
+            "double 2": "4.321"
         }
     }
 }


### PR DESCRIPTION
In this PR, we propose to demangle the parameters in case of `ParameterHandler::OutputStyle::JSON` or `ParameterHandler::OutputStyle::ShortJSON` prior to printing them within `ParameterHandler::print_parameters()`. Otherwise, the output is not really readable, e.g., for the key-value pair of
```json
"end time": "0.5"
```
printing the output ends up in
```json
"end_20time": "0.05"
```
@peterrum @nmuch 