### PR TITLE
Fix the function declaration a doc string is attached to.

### DIFF
--- a/include/deal.II/base/mpi_consensus_algorithms.h
+++ b/include/deal.II/base/mpi_consensus_algorithms.h
@@ -731,13 +731,14 @@ namespace Utilities
        */
       template <typename RequestType, typename AnswerType>
       std::vector<unsigned int>
-      pex(const std::vector<unsigned int> &                     targets,
-          const std::function<RequestType(const unsigned int)> &create_request,
-          const std::function<AnswerType(const unsigned int,
-                                         const RequestType &)> &answer_request,
-          const std::function<void(const unsigned int, const AnswerType &)>
-            &             process_answer,
-          const MPI_Comm &comm);
+      serial(
+        const std::vector<unsigned int> &                     targets,
+        const std::function<RequestType(const unsigned int)> &create_request,
+        const std::function<AnswerType(const unsigned int, const RequestType &)>
+          &answer_request,
+        const std::function<void(const unsigned int, const AnswerType &)>
+          &             process_answer,
+        const MPI_Comm &comm);
 
 
 


### PR DESCRIPTION
We declared the `pex()` function twice, when it should have really been `pex()` once and `serial()` the other time. This didn't matter to the compiler because both functions are implemented further down below in the file, and so the compiler saw declarations for both. It's just that doxygen would not have seen the `serial()` function documented at all.

In reference to https://github.com/dealii/dealii/issues/13208.

/rebuild