### PR TITLE
Consensus algorithm specialization for the case where no answer is requested.

### DIFF
--- a/include/deal.II/fe/fe_tools_extrapolate.templates.h
+++ b/include/deal.II/fe/fe_tools_extrapolate.templates.h
@@ -1150,40 +1150,23 @@ namespace FETools
         return cells_for_this_destination;
       };
 
-      const auto answer_request =
+      const auto process_request =
         [&received_cells](const unsigned int           other_rank,
-                          const std::vector<CellData> &request) -> int {
-        // We got a message from 'other_rank', so let us decode the
-        // message in the same way as we have assembled it above.
-        // Note that the cells just received do not contain
-        // information where they came from, and we have to add that
-        // ourselves for later use.
-        for (CellData cell_data : request)
-          {
-            cell_data.receiver = other_rank;
-            received_cells.emplace_back(std::move(cell_data));
-          }
+                          const std::vector<CellData> &request) {
+          // We got a message from 'other_rank', so let us decode the
+          // message in the same way as we have assembled it above.
+          // Note that the cells just received do not contain
+          // information where they came from, and we have to add that
+          // ourselves for later use.
+          for (CellData cell_data : request)
+            {
+              cell_data.receiver = other_rank;
+              received_cells.emplace_back(std::move(cell_data));
+            }
+        };
 
-        // Nothing left to do here, we don't actually need to provide an
-        // answer:
-        return 0;
-      };
-
-      const auto read_answer = [](const unsigned int /*other_rank*/,
-                                  const int &answer) {
-        // We don't put anything into the answers, so nothing should
-        // have been coming out at this end either that differs from
-        // the default-sent zero integer:
-        (void)answer;
-        Assert(answer == 0, ExcInternalError());
-      };
-
-      Utilities::MPI::ConsensusAlgorithms::selector<std::vector<CellData>, int>(
-        destinations,
-        create_request,
-        answer_request,
-        read_answer,
-        communicator);
+      Utilities::MPI::ConsensusAlgorithms::selector<std::vector<CellData>>(
+        destinations, create_request, process_request, communicator);
     }
 
 

--- a/source/grid/tria_description.cc
+++ b/source/grid/tria_description.cc
@@ -126,16 +126,17 @@ namespace TriangulationDescription
             return description_temp[other_rank_index];
           };
 
-          const auto answer_request =
+          const auto process_request =
             [&](const unsigned int,
                 const DescriptionTemp<dim, spacedim> &request) {
               this->merge(request, vertices_have_unique_ids);
-              return char{};
             };
 
           dealii::Utilities::MPI::ConsensusAlgorithms::selector<
-            DescriptionTemp<dim, spacedim>,
-            char>(relevant_processes, create_request, answer_request, {}, comm);
+            DescriptionTemp<dim, spacedim>>(relevant_processes,
+                                            create_request,
+                                            process_request,
+                                            comm);
         }
 
         /**


### PR DESCRIPTION
This is the last part that I'd like to do for #13208 before the release. It introduces function signatures for consensus algorithm implementations where processes want to send other processes a message, but don't expect an answer. This turns out to be a common operation (often called "some-to-some" and also implemented with a different signature in `Utilities::MPI::some_to_some()`), and the last commit converts two places where we do this. The `DictionaryPayLoad` class in `mpi_compute_index_owner_internal.h` also falls in this category, but it still uses the old CA interface and so requires a bit more work.

I'm not actually implementing any specialized algorithms for these new functions -- I simply forward to the existing functionality but make the simpler interface available. The implementation of more efficient algorithms will have to wait until after the release.

The current PR sits atop #13824 and #13825, and so only the last two commits are relevant. I will rebase once the other two PRs are merged.

/rebuild