### PR TITLE
Provide a defaulted copy operator.

### DIFF
--- a/include/deal.II/meshworker/copy_data.h
+++ b/include/deal.II/meshworker/copy_data.h
@@ -75,10 +75,15 @@ namespace MeshWorker
       const std::array<unsigned int, n_dof_indices> &dof_indices_sizes);
 
     /**
-     * Deep copy constructor.
+     * Copy constructor.
      */
-    CopyData(const CopyData<n_matrices, n_vectors, n_dof_indices, ScalarType>
-               &other) = default;
+    CopyData(const CopyData &other) = default;
+
+    /**
+     * Copy operator.
+     */
+    CopyData &
+    operator=(const CopyData &other) = default;
 
     /**
      * Reinitialize everything the same @p size. This is usually the number of


### PR DESCRIPTION
Fixes https://cdash.dealii.org/viewBuildError.php?type=1&buildid=1654. This is really a bug in clang 14 to warn about this, but it also doesn't hurt to add the operator.

/rebuild