### PR TITLE
Fix petsc/solver_08 for petsc 3.17.1

### DIFF
--- a/tests/petsc/solver_08.cc
+++ b/tests/petsc/solver_08.cc
@@ -64,6 +64,6 @@ main(int argc, char **argv)
     check_solver_within_range(solver.solve(A, u, f, preconditioner),
                               control.last_step(),
                               39,
-                              41);
+                              42);
   }
 }

--- a/tests/petsc/solver_08.output
+++ b/tests/petsc/solver_08.output
@@ -1,4 +1,4 @@
 
 DEAL::Size 32 Unknowns 961
 DEAL::Solver type: N6dealii13PETScWrappers11SolverTFQMRE
-DEAL::Solver stopped within 39 - 41 iterations
+DEAL::Solver stopped within 39 - 42 iterations


### PR DESCRIPTION
Part of #13703.

This tests needs 42 iterations with petsc 3.17.1 which slighlty exceeds the range 39 - 41. I adjusted the upper limit.

The other test that fails is `petsc/preconditioner_tvmult_01.cc` which causes a floating point exception in the `BoomerAMG` stage. This will require some more work to debug.