### PR TITLE
Fix test output for trilinos 13.2.0

### DIFF
--- a/tests/rol/vector_adaptor_no_ghost_01.mpirun=1.output.1
+++ b/tests/rol/vector_adaptor_no_ghost_01.mpirun=1.output.1
@@ -1,0 +1,38 @@
+
+********** Begin verification of linear algebra. *********************************************
+
+Commutativity of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Associativity of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Identity element of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Inverse elements of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Identity element of scalar multiplication. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Consistency of scalar multiplication with field multiplication. Consistency error: >>>>>>>>>>> 0
+Distributivity of scalar multiplication with respect to field addition. Consistency error: >>> 0
+Distributivity of scalar multiplication with respect to vector addition. Consistency error: >> 0
+Commutativity of dot (inner) product over the field of reals. Consistency error: >>>>>>>>>>>>> 0
+Additivity of dot (inner) product. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Consistency of scalar multiplication and norm. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Reflexivity. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Consistency of apply and dual:>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+
+********** End verification of linear algebra. ***********************************************
+
+
+********** Begin verification of linear algebra. *********************************************
+
+Commutativity of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Associativity of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Identity element of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Inverse elements of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Identity element of scalar multiplication. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Consistency of scalar multiplication with field multiplication. Consistency error: >>>>>>>>>>> 0
+Distributivity of scalar multiplication with respect to field addition. Consistency error: >>> 0
+Distributivity of scalar multiplication with respect to vector addition. Consistency error: >> 0
+Commutativity of dot (inner) product over the field of reals. Consistency error: >>>>>>>>>>>>> 0
+Additivity of dot (inner) product. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Consistency of scalar multiplication and norm. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Reflexivity. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Consistency of apply and dual:>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+
+********** End verification of linear algebra. ***********************************************
+

--- a/tests/rol/vector_adaptor_no_ghost_01.mpirun=5.output.1
+++ b/tests/rol/vector_adaptor_no_ghost_01.mpirun=5.output.1
@@ -1,0 +1,38 @@
+
+********** Begin verification of linear algebra. *********************************************
+
+Commutativity of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Associativity of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Identity element of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Inverse elements of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Identity element of scalar multiplication. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Consistency of scalar multiplication with field multiplication. Consistency error: >>>>>>>>>>> 0
+Distributivity of scalar multiplication with respect to field addition. Consistency error: >>> 0
+Distributivity of scalar multiplication with respect to vector addition. Consistency error: >> 0
+Commutativity of dot (inner) product over the field of reals. Consistency error: >>>>>>>>>>>>> 0
+Additivity of dot (inner) product. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Consistency of scalar multiplication and norm. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Reflexivity. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Consistency of apply and dual:>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+
+********** End verification of linear algebra. ***********************************************
+
+
+********** Begin verification of linear algebra. *********************************************
+
+Commutativity of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Associativity of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Identity element of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Inverse elements of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Identity element of scalar multiplication. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Consistency of scalar multiplication with field multiplication. Consistency error: >>>>>>>>>>> 0
+Distributivity of scalar multiplication with respect to field addition. Consistency error: >>> 0
+Distributivity of scalar multiplication with respect to vector addition. Consistency error: >> 0
+Commutativity of dot (inner) product over the field of reals. Consistency error: >>>>>>>>>>>>> 0
+Additivity of dot (inner) product. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Consistency of scalar multiplication and norm. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Reflexivity. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Consistency of apply and dual:>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+
+********** End verification of linear algebra. ***********************************************
+

--- a/tests/rol/vector_adaptor_with_ghost_01.mpirun=10.output.1
+++ b/tests/rol/vector_adaptor_with_ghost_01.mpirun=10.output.1
@@ -1,0 +1,19 @@
+
+********** Begin verification of linear algebra. *********************************************
+
+Commutativity of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Associativity of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Identity element of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Inverse elements of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Identity element of scalar multiplication. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Consistency of scalar multiplication with field multiplication. Consistency error: >>>>>>>>>>> 0
+Distributivity of scalar multiplication with respect to field addition. Consistency error: >>> 0
+Distributivity of scalar multiplication with respect to vector addition. Consistency error: >> 0
+Commutativity of dot (inner) product over the field of reals. Consistency error: >>>>>>>>>>>>> 0
+Additivity of dot (inner) product. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Consistency of scalar multiplication and norm. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Reflexivity. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Consistency of apply and dual:>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+
+********** End verification of linear algebra. ***********************************************
+

--- a/tests/rol/vector_adaptor_with_ghost_01.mpirun=7.output.1
+++ b/tests/rol/vector_adaptor_with_ghost_01.mpirun=7.output.1
@@ -1,0 +1,19 @@
+
+********** Begin verification of linear algebra. *********************************************
+
+Commutativity of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Associativity of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Identity element of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Inverse elements of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Identity element of scalar multiplication. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Consistency of scalar multiplication with field multiplication. Consistency error: >>>>>>>>>>> 0
+Distributivity of scalar multiplication with respect to field addition. Consistency error: >>> 0
+Distributivity of scalar multiplication with respect to vector addition. Consistency error: >> 0
+Commutativity of dot (inner) product over the field of reals. Consistency error: >>>>>>>>>>>>> 0
+Additivity of dot (inner) product. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Consistency of scalar multiplication and norm. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Reflexivity. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Consistency of apply and dual:>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+
+********** End verification of linear algebra. ***********************************************
+


### PR DESCRIPTION
Part of #13703.

It turns out that in newer releases of Trilinos, Teuchos prints out an additional line 
```
Consistency of apply and dual:>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
```

To be backwards compatible, I introduced alternative output files with the additional line.