### PR TITLE
Intel 18: more constexpr problems

### DIFF
--- a/source/grid/grid_generator_pipe_junction.cc
+++ b/source/grid/grid_generator_pipe_junction.cc
@@ -314,7 +314,7 @@ namespace GridGenerator
     };
 
     // Cartesian base represented by unit vectors.
-    constexpr std::array<vector3d, spacedim> directions = {
+    const std::array<vector3d, spacedim> directions = {
       {vector3d({1., 0., 0.}), vector3d({0., 1., 0.}), vector3d({0., 0., 1.})}};
 
     // The skeleton corresponds to the axis of symmetry in the center of each


### PR DESCRIPTION
Part of #13821.

Error message:
```
/dealii/source/grid/grid_generator_pipe_junction.cc(318): error: expression must have a constant value
        {vector3d({1., 0., 0.}), vector3d({0., 1., 0.}), vector3d({0., 0., 1.})}};
                  ^
/dealii/source/grid/grid_generator_pipe_junction.cc(318): note: reference or pointer to temporary with limited lifetime
        {vector3d({1., 0., 0.}), vector3d({0., 1., 0.}), vector3d({0., 0., 1.})}};
                  ^
```
Affected code: https://github.com/dealii/dealii/blob/9d6abca75f91a50a9c52623cbef21292b0592351/source/grid/grid_generator_pipe_junction.cc#L317-L318

It's easiest to simply turn this into `const`.