### PR TITLE
FESystem::build_interface_constraints() for wedges/pyramids

### DIFF
--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -840,14 +840,15 @@ bool
 FiniteElement<dim, spacedim>::constraints_are_implemented(
   const internal::SubfaceCase<dim> &subface_case) const
 {
-  // TODO: the implementation makes the assumption that all faces have the
-  // same number of dofs
-  AssertDimension(this->n_unique_faces(), 1);
-  const unsigned int face_no = 0;
-
   if (subface_case == internal::SubfaceCase<dim>::case_isotropic)
-    return (this->n_dofs_per_face(face_no) == 0) ||
-           (interface_constraints.m() != 0);
+    {
+      unsigned int n_dofs_on_faces = 0;
+
+      for (const auto face_no : this->reference_cell().face_indices())
+        n_dofs_on_faces += this->n_dofs_per_face(face_no);
+
+      return (n_dofs_on_faces == 0) || (interface_constraints.m() != 0);
+    }
   else
     return false;
 }

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -1534,13 +1534,6 @@ template <int dim, int spacedim>
 void
 FESystem<dim, spacedim>::build_interface_constraints()
 {
-  // TODO: the implementation makes the assumption that all faces have the
-  // same number of dofs
-  if (this->n_unique_faces() != 1)
-    return;
-
-  const unsigned int face_no = 0;
-
   // check whether all base elements implement their interface constraint
   // matrices. if this is not the case, then leave the interface costraints of
   // this composed element empty as well; however, the rest of the element is
@@ -1548,6 +1541,11 @@ FESystem<dim, spacedim>::build_interface_constraints()
   for (unsigned int base = 0; base < this->n_base_elements(); ++base)
     if (base_element(base).constraints_are_implemented() == false)
       return;
+
+  // TODO: the implementation makes the assumption that all faces have the
+  // same number of dofs
+  AssertDimension(this->n_unique_faces(), 1);
+  const unsigned int face_no = 0;
 
   this->interface_constraints.TableBase<2, double>::reinit(
     this->interface_constraints_size());


### PR DESCRIPTION
Extracted from #12647.

To answer @bangerth's question (https://github.com/dealii/dealii/pull/12647#discussion_r689153455):

> Hm, yes, not ideal. How can we catch this error in a better way? Is there a better place where this assertion could be put?

This would be the alternative.

