### PR TITLE
Restore compatibility with OpenCASCADE >= 7.6.0

### DIFF
--- a/include/deal.II/opencascade/manifold_lib.h
+++ b/include/deal.II/opencascade/manifold_lib.h
@@ -28,7 +28,9 @@
 // opencascade needs "HAVE_CONFIG_H" to be exported...
 #  define HAVE_CONFIG_H
 #  include <Adaptor3d_Curve.hxx>
-#  include <Adaptor3d_HCurve.hxx>
+#  if !DEAL_II_OPENCASCADE_VERSION_GTE(7, 6, 0)
+#    include <Adaptor3d_HCurve.hxx>
+#  endif
 #  include <BRepAdaptor_Curve.hxx>
 #  undef HAVE_CONFIG_H
 
@@ -325,7 +327,11 @@ namespace OpenCASCADE
      * A Curve adaptor. This is the one which is used in the computations, and
      * it points to the right one above.
      */
+#  if DEAL_II_OPENCASCADE_VERSION_GTE(7, 6, 0)
+    Handle_Adaptor3d_Curve curve;
+#  else
     Handle_Adaptor3d_HCurve curve;
+#  endif
 
     /**
      * Relative tolerance used in all internal computations.

--- a/source/opencascade/manifold_lib.cc
+++ b/source/opencascade/manifold_lib.cc
@@ -23,8 +23,10 @@
 
 #  include <BRepAdaptor_CompCurve.hxx>
 #  include <BRepAdaptor_Curve.hxx>
-#  include <BRepAdaptor_HCompCurve.hxx>
-#  include <BRepAdaptor_HCurve.hxx>
+#  if !DEAL_II_OPENCASCADE_VERSION_GTE(7, 6, 0)
+#    include <BRepAdaptor_HCompCurve.hxx>
+#    include <BRepAdaptor_HCurve.hxx>
+#  endif
 #  include <BRepTools.hxx>
 #  include <BRep_Tool.hxx>
 #  include <GCPnts_AbscissaPoint.hxx>
@@ -48,6 +50,24 @@ namespace OpenCASCADE
      * TopoDS_Shape. This function will fail when the given shape is
      * not of topological dimension one.
      */
+#  if DEAL_II_OPENCASCADE_VERSION_GTE(7, 6, 0)
+    Handle_Adaptor3d_Curve
+    curve_adaptor(const TopoDS_Shape &shape)
+    {
+      Assert((shape.ShapeType() == TopAbs_WIRE) ||
+               (shape.ShapeType() == TopAbs_EDGE),
+             ExcUnsupportedShape());
+      if (shape.ShapeType() == TopAbs_WIRE)
+        return Handle(BRepAdaptor_CompCurve)(
+          new BRepAdaptor_CompCurve(TopoDS::Wire(shape)));
+      else if (shape.ShapeType() == TopAbs_EDGE)
+        return Handle(BRepAdaptor_Curve)(
+          new BRepAdaptor_Curve(TopoDS::Edge(shape)));
+
+      Assert(false, ExcInternalError());
+      return Handle(BRepAdaptor_Curve)(new BRepAdaptor_Curve());
+    }
+#  else
     Handle_Adaptor3d_HCurve
     curve_adaptor(const TopoDS_Shape &shape)
     {
@@ -64,6 +84,7 @@ namespace OpenCASCADE
       Assert(false, ExcInternalError());
       return Handle(BRepAdaptor_HCurve)(new BRepAdaptor_HCurve());
     }
+#  endif
 
 
 
@@ -71,8 +92,13 @@ namespace OpenCASCADE
     double
     shape_length(const TopoDS_Shape &sh)
     {
+#  if DEAL_II_OPENCASCADE_VERSION_GTE(7, 6, 0)
+      Handle_Adaptor3d_Curve adapt = curve_adaptor(sh);
+      return GCPnts_AbscissaPoint::Length(*adapt);
+#  else
       Handle_Adaptor3d_HCurve adapt = curve_adaptor(sh);
       return GCPnts_AbscissaPoint::Length(adapt->GetCurve());
+#  endif
     }
   } // namespace
 
@@ -414,13 +440,24 @@ namespace OpenCASCADE
     double              t(0.0);
     ShapeAnalysis_Curve curve_analysis;
     gp_Pnt              proj;
-    const double        dist = curve_analysis.Project(
+
+    const double dist = curve_analysis.Project(
+#  if DEAL_II_OPENCASCADE_VERSION_GTE(7, 6, 0)
+      *curve, point(space_point), tolerance, proj, t, true);
+#  else
       curve->GetCurve(), point(space_point), tolerance, proj, t, true);
+#  endif
+
+    (void)dist;
     Assert(dist < tolerance * length,
            ExcPointNotOnManifold<spacedim>(space_point));
-    (void)dist; // Silence compiler warning in Release mode.
+
     return Point<1>(GCPnts_AbscissaPoint::Length(
+#  if DEAL_II_OPENCASCADE_VERSION_GTE(7, 6, 0)
+      *curve, curve->FirstParameter(), t));
+#  else
       curve->GetCurve(), curve->GetCurve().FirstParameter(), t));
+#  endif
   }
 
 
@@ -430,10 +467,16 @@ namespace OpenCASCADE
   ArclengthProjectionLineManifold<dim, spacedim>::push_forward(
     const Point<1> &chart_point) const
   {
+#  if DEAL_II_OPENCASCADE_VERSION_GTE(7, 6, 0)
+    GCPnts_AbscissaPoint AP(*curve, chart_point[0], curve->FirstParameter());
+    gp_Pnt               P = curve->Value(AP.Parameter());
+#  else
     GCPnts_AbscissaPoint AP(curve->GetCurve(),
                             chart_point[0],
                             curve->GetCurve().FirstParameter());
     gp_Pnt               P = curve->GetCurve().Value(AP.Parameter());
+#  endif
+
     return point<spacedim>(P);
   }
 

--- a/source/opencascade/utilities.cc
+++ b/source/opencascade/utilities.cc
@@ -45,10 +45,14 @@
 #  endif
 
 #  include <BRepAdaptor_Curve.hxx>
-#  include <BRepAdaptor_HCompCurve.hxx>
-#  include <BRepAdaptor_HCurve.hxx>
+#  if DEAL_II_OPENCASCADE_VERSION_GTE(7, 6, 0)
+#    include <BRepAlgoAPI_Section.hxx>
+#  else
+#    include <BRepAdaptor_HCompCurve.hxx>
+#    include <BRepAdaptor_HCurve.hxx>
+#    include <BRepAlgo_Section.hxx>
+#  endif
 #  include <BRepAdaptor_Surface.hxx>
-#  include <BRepAlgo_Section.hxx>
 #  include <BRepBndLib.hxx>
 #  include <BRepBuilderAPI_MakeEdge.hxx>
 #  include <BRepBuilderAPI_Sewing.hxx>
@@ -427,8 +431,12 @@ namespace OpenCASCADE
                   const double /*tolerance*/)
   {
     Handle(Geom_Plane) plane = new Geom_Plane(c_x, c_y, c_z, c);
+#  if DEAL_II_OPENCASCADE_VERSION_GTE(7, 6, 0)
+    BRepAlgoAPI_Section section(in_shape, plane);
+#  else
     BRepAlgo_Section section(in_shape, plane);
-    TopoDS_Shape     edges = section.Shape();
+#  endif
+    TopoDS_Shape edges = section.Shape();
     return edges;
   }
 


### PR DESCRIPTION
Closes #13822. Closes #13318.

Followed the instructions in [this document](https://dev.opencascade.org/doc/overview/html/occt__upgrade.html#upgrade_760_handle_adaptors).

Compilation succeeds  with either opencascade 7.4.0 or 7.6.2, but some tests still fail in `tests/opencascade` ~for 7.6.2~ in release mode. I'll leave this in draft mode for now.