### PR TITLE
doxygen comments: @ref fixes

### DIFF
--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -500,7 +500,8 @@ namespace internal
        *
        * This class has effect only if artificial cells are allowed. Without
        * artificial cells, the current subdomain IDs already correspond to the
-       * true subdomain IDs. See the @ref GlossArtificialCell "glossary"
+       * true subdomain IDs. See the
+       * @ref GlossArtificialCell "glossary"
        * for more information about artificial cells.
        */
       template <int dim, int spacedim = dim>

--- a/include/deal.II/fe/fe_poly_tensor.h
+++ b/include/deal.II/fe/fe_poly_tensor.h
@@ -252,8 +252,8 @@ protected:
    * The constructor of this class fills this table with 'false' values, i.e.,
    * no sign change at all. Derived finite element classes have to
    * fill this Table with the correct values, see the documentation in
-   * GeometryInfo<dim> and
-   * this @ref GlossFaceOrientation "glossary entry on face orientation".
+   * GeometryInfo<dim> and this
+   * @ref GlossFaceOrientation "glossary entry on face orientation".
    *
    * The table must be filled in finite element classes derived
    * from FE_PolyTensor in a meaningful way since the permutation

--- a/include/deal.II/fe/fe_raviart_thomas.h
+++ b/include/deal.II/fe/fe_raviart_thomas.h
@@ -223,7 +223,8 @@ private:
    * flipped (rotated by +180 degrees) or rotated (rotated by +90 degrees)
    * faces. These are given in the form three flags (face_orientation,
    * face_flip, face_rotation), see the documentation in GeometryInfo<dim> and
-   * this @ref GlossFaceOrientation "glossary entry on face orientation".
+   * this
+   * @ref GlossFaceOrientation "glossary entry on face orientation".
    *
    * <h3>Example: Raviart-Thomas Elements of order 2 (tensor polynomial
    * degree 3)</h3>

--- a/include/deal.II/grid/grid_reordering.h
+++ b/include/deal.II/grid/grid_reordering.h
@@ -27,7 +27,8 @@ DEAL_II_NAMESPACE_OPEN
 
 /**
  * A class implementing various grid reordering algorithms. For more information
- * see the @ref reordering "reordering module".
+ * see the
+ * @ref reordering "reordering module".
  *
  * @deprecated Use GridTools::invert_all_negative_measure_cells() or
  * GridTools::consistently_order_cells() instead of the functions provided by

--- a/include/deal.II/particles/particle.h
+++ b/include/deal.II/particles/particle.h
@@ -229,8 +229,11 @@ namespace Particles
      *   on both the locally owned cells, as well as on ghost cells. The
      *   particles on the latter are *copies* of particles owned on other
      *   processors, and should therefore be treated in the same way as
-     *   ghost entries in @ref GlossGhostedVector "vectors with ghost elements"
-     *   or @ref GlossGhostCell "ghost cells": In both cases, one should
+     *   ghost entries in
+     *   @ref GlossGhostedVector "vectors with ghost elements"
+     *   or
+     *   @ref GlossGhostCell "ghost cells":
+     *   In both cases, one should
      *   treat the ghost elements or cells as `const` objects that shouldn't
      *   be modified even if the objects allow for calls that modify
      *   properties. Rather, properties should only be modified on processors
@@ -257,8 +260,11 @@ namespace Particles
      *   on both the locally owned cells, as well as on ghost cells. The
      *   particles on the latter are *copies* of particles owned on other
      *   processors, and should therefore be treated in the same way as
-     *   ghost entries in @ref GlossGhostedVector "vectors with ghost elements"
-     *   or @ref GlossGhostCell "ghost cells": In both cases, one should
+     *   ghost entries in
+     *   @ref GlossGhostedVector "vectors with ghost elements"
+     *   or
+     *   @ref GlossGhostCell "ghost cells":
+     *   In both cases, one should
      *   treat the ghost elements or cells as `const` objects that shouldn't
      *   be modified even if the objects allow for calls that modify
      *   properties. Rather, properties should only be modified on processors
@@ -302,8 +308,11 @@ namespace Particles
      *   on both the locally owned cells, as well as on ghost cells. The
      *   particles on the latter are *copies* of particles owned on other
      *   processors, and should therefore be treated in the same way as
-     *   ghost entries in @ref GlossGhostedVector "vectors with ghost elements"
-     *   or @ref GlossGhostCell "ghost cells": In both cases, one should
+     *   ghost entries in
+     *   @ref GlossGhostedVector "vectors with ghost elements"
+     *   or
+     *   @ref GlossGhostCell "ghost cells":
+     *   In both cases, one should
      *   treat the ghost elements or cells as `const` objects that shouldn't
      *   be modified even if the objects allow for calls that modify
      *   properties. Rather, properties should only be modified on processors
@@ -344,8 +353,11 @@ namespace Particles
      *   on both the locally owned cells, as well as on ghost cells. The
      *   particles on the latter are *copies* of particles owned on other
      *   processors, and should therefore be treated in the same way as
-     *   ghost entries in @ref GlossGhostedVector "vectors with ghost elements"
-     *   or @ref GlossGhostCell "ghost cells": In both cases, one should
+     *   ghost entries in
+     *   @ref GlossGhostedVector "vectors with ghost elements"
+     *   or
+     *   @ref GlossGhostCell "ghost cells":
+     *   In both cases, one should
      *   treat the ghost elements or cells as `const` objects that shouldn't
      *   be modified even if the objects allow for calls that modify
      *   properties. Rather, properties should only be modified on processors

--- a/include/deal.II/particles/particle_accessor.h
+++ b/include/deal.II/particles/particle_accessor.h
@@ -135,8 +135,11 @@ namespace Particles
      *   on both the locally owned cells, as well as on ghost cells. The
      *   particles on the latter are *copies* of particles owned on other
      *   processors, and should therefore be treated in the same way as
-     *   ghost entries in @ref GlossGhostedVector "vectors with ghost elements"
-     *   or @ref GlossGhostCell "ghost cells": In both cases, one should
+     *   ghost entries in
+     *   @ref GlossGhostedVector "vectors with ghost elements"
+     *   or
+     *   @ref GlossGhostCell "ghost cells":
+     *   In both cases, one should
      *   treat the ghost elements or cells as `const` objects that shouldn't
      *   be modified even if the objects allow for calls that modify
      *   properties. Rather, properties should only be modified on processors
@@ -163,8 +166,11 @@ namespace Particles
      *   on both the locally owned cells, as well as on ghost cells. The
      *   particles on the latter are *copies* of particles owned on other
      *   processors, and should therefore be treated in the same way as
-     *   ghost entries in @ref GlossGhostedVector "vectors with ghost elements"
-     *   or @ref GlossGhostCell "ghost cells": In both cases, one should
+     *   ghost entries in
+     *   @ref GlossGhostedVector "vectors with ghost elements"
+     *   or
+     *   @ref GlossGhostCell "ghost cells":
+     *   In both cases, one should
      *   treat the ghost elements or cells as `const` objects that shouldn't
      *   be modified even if the objects allow for calls that modify
      *   properties. Rather, properties should only be modified on processors
@@ -229,8 +235,11 @@ namespace Particles
      *   on both the locally owned cells, as well as on ghost cells. The
      *   particles on the latter are *copies* of particles owned on other
      *   processors, and should therefore be treated in the same way as
-     *   ghost entries in @ref GlossGhostedVector "vectors with ghost elements"
-     *   or @ref GlossGhostCell "ghost cells": In both cases, one should
+     *   ghost entries in
+     *   @ref GlossGhostedVector "vectors with ghost elements"
+     *   or
+     *   @ref GlossGhostCell "ghost cells":
+     *    In both cases, one should
      *   treat the ghost elements or cells as `const` objects that shouldn't
      *   be modified even if the objects allow for calls that modify
      *   properties. Rather, properties should only be modified on processors
@@ -249,8 +258,11 @@ namespace Particles
      *   on both the locally owned cells, as well as on ghost cells. The
      *   particles on the latter are *copies* of particles owned on other
      *   processors, and should therefore be treated in the same way as
-     *   ghost entries in @ref GlossGhostedVector "vectors with ghost elements"
-     *   or @ref GlossGhostCell "ghost cells": In both cases, one should
+     *   ghost entries in
+     *   @ref GlossGhostedVector "vectors with ghost elements"
+     *   or
+     *   @ref GlossGhostCell "ghost cells":
+     *   In both cases, one should
      *   treat the ghost elements or cells as `const` objects that shouldn't
      *   be modified even if the objects allow for calls that modify
      *   properties. Rather, properties should only be modified on processors
@@ -272,8 +284,11 @@ namespace Particles
      *   on both the locally owned cells, as well as on ghost cells. The
      *   particles on the latter are *copies* of particles owned on other
      *   processors, and should therefore be treated in the same way as
-     *   ghost entries in @ref GlossGhostedVector "vectors with ghost elements"
-     *   or @ref GlossGhostCell "ghost cells": In both cases, one should
+     *   ghost entries in
+     *   @ref GlossGhostedVector "vectors with ghost elements"
+     *   or
+     *   @ref GlossGhostCell "ghost cells":
+     *   In both cases, one should
      *   treat the ghost elements or cells as `const` objects that shouldn't
      *   be modified even if the objects allow for calls that modify
      *   properties. Rather, properties should only be modified on processors


### PR DESCRIPTION
A few more @ref fixes missed in #13836

(none of them are actually broken, but wrapcomments.py enforces @refs to be on separate lines, which is safer than having text before/after