### PR TITLE
Optimize Utilities::pack/unpack for empty objects.

### DIFF
--- a/include/deal.II/base/mpi_consensus_algorithms.h
+++ b/include/deal.II/base/mpi_consensus_algorithms.h
@@ -1177,29 +1177,27 @@ namespace Utilities
       {
         // TODO: For the moment, simply implement this special case by
         // forwarding to the other function with rewritten function
-        // objects and using a plain 'char' as answer type. This way,
+        // objects and using an empty type as answer type. This way,
         // we have the interface in place and can provide a more
         // efficient implementation later on.
-        return nbx<RequestType, char>(
+        using EmptyType = std::tuple<>;
+
+        return nbx<RequestType, EmptyType>(
           targets,
           create_request,
           // answer_request:
           [&process_request](const unsigned int source_rank,
-                             const RequestType &request) -> char {
+                             const RequestType &request) -> EmptyType {
             process_request(source_rank, request);
             // Return something. What it is is arbitrary here, except that
-            // we will want to check what it is below in the process_answer().
-            // We choose the smallest possible data type for the replies (a
-            // 'char'), but we can make ourselves feel more important by
-            // putting a whole "        " into one char (sensible editor
-            // settings assumed).
-            return '\t';
+            // we want it to be as small an object as possible. Using
+            // std::tuple<> is interpreted as an empty object that is packed
+            // down to a zero-length char array.
+            return {};
           },
           // process_answer:
-          [](const unsigned int /*target_rank */, const char &answer) {
-            (void)answer;
-            Assert(answer == '\t', ExcInternalError());
-          },
+          [](const unsigned int /*target_rank */,
+             const EmptyType & /*answer*/) {},
           comm);
       }
 
@@ -1231,29 +1229,27 @@ namespace Utilities
       {
         // TODO: For the moment, simply implement this special case by
         // forwarding to the other function with rewritten function
-        // objects and using a plain 'char' as answer type. This way,
+        // objects and using an empty type as answer type. This way,
         // we have the interface in place and can provide a more
         // efficient implementation later on.
-        return pex<RequestType, char>(
+        using EmptyType = std::tuple<>;
+
+        return pex<RequestType, EmptyType>(
           targets,
           create_request,
           // answer_request:
           [&process_request](const unsigned int source_rank,
-                             const RequestType &request) -> char {
+                             const RequestType &request) -> EmptyType {
             process_request(source_rank, request);
             // Return something. What it is is arbitrary here, except that
-            // we will want to check what it is below in the process_answer().
-            // We choose the smallest possible data type for the replies (a
-            // 'char'), but we can make ourselves feel more important by
-            // putting a whole "        " into one char (sensible editor
-            // settings assumed).
-            return '\t';
+            // we want it to be as small an object as possible. Using
+            // std::tuple<> is interpreted as an empty object that is packed
+            // down to a zero-length char array.
+            return {};
           },
           // process_answer:
-          [](const unsigned int /*target_rank */, const char &answer) {
-            (void)answer;
-            Assert(answer == '\t', ExcInternalError());
-          },
+          [](const unsigned int /*target_rank */,
+             const EmptyType & /*answer*/) {},
           comm);
       }
 
@@ -1287,29 +1283,27 @@ namespace Utilities
       {
         // TODO: For the moment, simply implement this special case by
         // forwarding to the other function with rewritten function
-        // objects and using a plain 'char' as answer type. This way,
+        // objects and using an empty type as answer type. This way,
         // we have the interface in place and can provide a more
         // efficient implementation later on.
-        return serial<RequestType, char>(
+        using EmptyType = std::tuple<>;
+
+        return serial<RequestType, EmptyType>(
           targets,
           create_request,
           // answer_request:
           [&process_request](const unsigned int source_rank,
-                             const RequestType &request) -> char {
+                             const RequestType &request) -> EmptyType {
             process_request(source_rank, request);
             // Return something. What it is is arbitrary here, except that
-            // we will want to check what it is below in the process_answer().
-            // We choose the smallest possible data type for the replies (a
-            // 'char'), but we can make ourselves feel more important by
-            // putting a whole "        " into one char (sensible editor
-            // settings assumed).
-            return '\t';
+            // we want it to be as small an object as possible. Using
+            // std::tuple<> is interpreted as an empty object that is packed
+            // down to a zero-length char array.
+            return {};
           },
           // process_answer:
-          [](const unsigned int /*target_rank */, const char &answer) {
-            (void)answer;
-            Assert(answer == '\t', ExcInternalError());
-          },
+          [](const unsigned int /*target_rank */,
+             const EmptyType & /*answer*/) {},
           comm);
       }
 
@@ -1343,29 +1337,27 @@ namespace Utilities
       {
         // TODO: For the moment, simply implement this special case by
         // forwarding to the other function with rewritten function
-        // objects and using a plain 'char' as answer type. This way,
+        // objects and using an empty type as answer type. This way,
         // we have the interface in place and can provide a more
         // efficient implementation later on.
-        return selector<RequestType, char>(
+        using EmptyType = std::tuple<>;
+
+        return selector<RequestType, EmptyType>(
           targets,
           create_request,
           // answer_request:
           [&process_request](const unsigned int source_rank,
-                             const RequestType &request) -> char {
+                             const RequestType &request) -> EmptyType {
             process_request(source_rank, request);
             // Return something. What it is is arbitrary here, except that
-            // we will want to check what it is below in the process_answer().
-            // We choose the smallest possible data type for the replies (a
-            // 'char'), but we can make ourselves feel more important by
-            // putting a whole "        " into one char (sensible editor
-            // settings assumed).
-            return '\t';
+            // we want it to be as small an object as possible. Using
+            // std::tuple<> is interpreted as an empty object that is packed
+            // down to a zero-length char array.
+            return {};
           },
           // process_answer:
-          [](const unsigned int /*target_rank */, const char &answer) {
-            (void)answer;
-            Assert(answer == '\t', ExcInternalError());
-          },
+          [](const unsigned int /*target_rank */,
+             const EmptyType & /*answer*/) {},
           comm);
       }
 

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -597,6 +597,20 @@ namespace Utilities
    *   this by providing a type which the present function packs into an
    *   empty output buffer, given that many deal.II functions send objects
    *   only after calling pack() to serialize them.
+   *
+   * In several of the special cases above, the `std::is_trivially_copyable`
+   * property is important, see
+   * https://en.cppreference.com/w/cpp/types/is_trivially_copyable .
+   * For a type `T` to satisfy this property essentially means that an object
+   * `t2` of this type can be initialized by copying another object `t1`
+   * bit-by-bit into the memory space of `t2`. In particular, this is the case
+   * for built-in types such as `int`, `double`, or `char`, as well as
+   * structures and classes that only consist of such types and that have
+   * neither user-defined constructors nor `virtual` functions. In practice,
+   * and together with the fact that vectors and vector-of-vectors of these
+   * types are also special-cased, this covers many of the most common kinds of
+   * messages one sends around with MPI or one wants to serialize (the two
+   * most common use cases for this function).
    */
   template <typename T>
   size_t

--- a/tests/base/utilities_pack_unpack_08.cc
+++ b/tests/base/utilities_pack_unpack_08.cc
@@ -1,0 +1,60 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 - 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// Make sure that Utilities::pack/unpack can be used on objects that
+// are empty, and that the resulting packed string has length zero.
+
+
+#include <deal.II/base/point.h>
+#include <deal.II/base/timer.h>
+#include <deal.II/base/utilities.h>
+
+#include <tuple>
+
+#include "../tests.h"
+
+
+
+void
+test()
+{
+  using Empty = std::tuple<>;
+
+  Empty e;
+  deallog << "Size = " << sizeof(e) << std::endl;
+
+  // Pack the object and make sure the packed length is zero
+  const std::vector<char> packed = Utilities::pack(e, false);
+  deallog << "Packed size = " << packed.size() << std::endl;
+
+  // Then unpack again. The two should be the same -- though one may
+  // question what equality of objects of size zero might mean -- and
+  // we should check so:
+  Empty e2 = Utilities::unpack<Empty>(packed, false);
+  Assert(e2 == e, ExcInternalError());
+
+  deallog << "OK" << std::endl;
+}
+
+
+
+int
+main()
+{
+  initlog();
+
+  test();
+}

--- a/tests/base/utilities_pack_unpack_08.output
+++ b/tests/base/utilities_pack_unpack_08.output
@@ -1,0 +1,4 @@
+
+DEAL::Size = 1
+DEAL::Packed size = 0
+DEAL::OK


### PR DESCRIPTION
[Not necessary for the release unless others feel like it would be particularly useful.]

This is another optimization to the pack()/unpack() functions: We can special case a truly empty object that will be packed down to zero bytes. The corresponding MPI sends/receives are then empty.

There is no C++ facility to determine whether a type is empty. `sizeof(T)` always returns at least one, so one has to choose something for which we know that it really doesn't store anything even if its size is >0, and for that reason that type cannot be a user-defined type. I'm simply using `std::tuple<>` (i.e., a tuple with no elements) to designate that type. This patch does that and documents it.

Why do I want to do that: In #13826 -- where I consider the consensus algorithms that typically have a send-request/reply-with-an-answer phases, but for the special case where no answer is required -- I need send a dummy object that is empty. In the patch, I just use a single-character `char` object, the smallest possible object in C++. After packing, that results in a one-byte message whose content we don't actually care about. It would be nice if we could shrink this to a zero-length message, but that requires that we have something that `pack()` can shrink down to a zero-size buffer. This patch does that.

/rebuild