### PR TITLE
Fix bug for global coarsening: Must allow invalid proc id

### DIFF
--- a/include/deal.II/base/mpi_compute_index_owner_internal.h
+++ b/include/deal.II/base/mpi_compute_index_owner_internal.h
@@ -45,7 +45,9 @@ namespace Utilities
           FlexibleIndexStorage(const bool use_vector = true);
 
           void
-          reinit(const bool use_vector, const std::size_t size);
+          reinit(const bool        use_vector,
+                 const bool        index_range_contiguous,
+                 const std::size_t size);
 
           void
           fill(const std::size_t start,

--- a/source/base/mpi_compute_index_owner_internal.cc
+++ b/source/base/mpi_compute_index_owner_internal.cc
@@ -44,6 +44,7 @@ namespace Utilities
 
         void
         FlexibleIndexStorage::reinit(const bool        use_vector,
+                                     const bool        index_range_contiguous,
                                      const std::size_t size)
         {
           this->use_vector = use_vector;
@@ -52,8 +53,10 @@ namespace Utilities
           data = {};
           data_map.clear();
 
-          // do not initialize the vector but only upon first request in
-          // `fill`
+          // in case we have contiguous indices, only fill the vector upon
+          // first request in `fill`
+          if (!index_range_contiguous)
+            data.resize(size, invalid_index_value);
         }
 
 
@@ -263,6 +266,8 @@ namespace Utilities
 
           actually_owning_ranks.reinit((owned_indices_size_actual *
                                         sparsity_factor) > owned_indices.size(),
+                                       owned_indices_size_actual ==
+                                         owned_indices.size(),
                                        locally_owned_size);
 
           // 2) collect relevant processes and process local dict entries


### PR DESCRIPTION
This fixes a bug that appeared due to #13791: We can only fill the full range with the data of the first process adding indices when we know that the full index range will be covered, otherwise we need to still run the old code. This fixes the four tests
```
multigrid-global-coarsening/block_01.mpirun=1.release
multigrid-global-coarsening/interpolate_01.mpirun=1.release
multigrid-global-coarsening/interpolate_01.mpirun=4.release
multigrid-global-coarsening/multigrid_a_01.mpirun=1.release
```
This bug was hard to find because I was looking somewhere else first in terms of the consensus algorithms, missing the actual cause.