### PR TITLE
MatrixFree: Avoid use of deprecated n_components_filled

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -1606,7 +1606,8 @@ protected:
  * incomplete batch of cells are set to zero, whereas
  * @p distribute_local_to_global or @p set_dof_values simply ignores the
  * content in the empty lanes. The number of actually filled SIMD lanes can by
- * queried by MatrixFree::n_components_filled().
+ * queried by MatrixFree::n_active_entries_per_cell_batch() or
+ * MatrixFree::n_active_entries_per_face_batch().
  *
  * Obviously, the computations performed on the artificial lanes (without real
  * data) should never be mixed with valid results. The contract in using this
@@ -1615,11 +1616,11 @@ protected:
  * put together in vectorization. For example, results on an element should
  * not be added to results on other elements except through the global vector
  * access methods or by access that is masked by
- * MatrixFree::n_components_filled(). No guarantee can be made that results on
- * artificial lanes will always be zero that can safely be added to other
- * results: The data on JxW or Jacobians is copied from the last valid lane in
- * order to avoid division by zero that could trigger floating point
- * exceptions or trouble in other situations.
+ * MatrixFree::n_active_entries_per_cell_batch(). No guarantee can be made
+ * that results on artificial lanes will always be zero that can safely be
+ * added to other results: The data on JxW or Jacobians is copied from the
+ * last valid lane in order to avoid division by zero that could trigger
+ * floating point exceptions or trouble in other situations.
  *
  * <h3>Description of evaluation routines</h3>
  *

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -252,7 +252,8 @@ MatrixFree<dim, Number, VectorizedArrayType>::get_cell_iterator(
 {
   AssertIndexRange(dof_handler_index, dof_handlers.size());
   AssertIndexRange(cell_batch_index, task_info.cell_partition_data.back());
-  AssertIndexRange(lane_index, n_components_filled(cell_batch_index));
+  AssertIndexRange(lane_index,
+                   n_active_entries_per_cell_batch(cell_batch_index));
 
   std::pair<unsigned int, unsigned int> index =
     cell_level_index[cell_batch_index * VectorizedArrayType::size() +
@@ -273,7 +274,8 @@ MatrixFree<dim, Number, VectorizedArrayType>::get_cell_level_and_index(
   const unsigned int lane_index) const
 {
   AssertIndexRange(cell_batch_index, task_info.cell_partition_data.back());
-  AssertIndexRange(lane_index, n_components_filled(cell_batch_index));
+  AssertIndexRange(lane_index,
+                   n_active_entries_per_cell_batch(cell_batch_index));
 
   std::pair<int, int> level_index_pair =
     cell_level_index[cell_batch_index * VectorizedArrayType::size() +
@@ -329,7 +331,8 @@ MatrixFree<dim, Number, VectorizedArrayType>::get_hp_cell_iterator(
 {
   AssertIndexRange(dof_handler_index, dof_handlers.size());
   AssertIndexRange(cell_batch_index, task_info.cell_partition_data.back());
-  AssertIndexRange(lane_index, n_components_filled(cell_batch_index));
+  AssertIndexRange(lane_index,
+                   n_active_entries_per_cell_batch(cell_batch_index));
 
   std::pair<unsigned int, unsigned int> index =
     cell_level_index[cell_batch_index * VectorizedArrayType::size() +
@@ -2056,7 +2059,9 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
           for (unsigned int cell = 0;
                cell < n_cell_batches() + n_ghost_cell_batches();
                ++cell)
-            for (unsigned int v = 0; v < this->n_components_filled(cell); ++v)
+            for (unsigned int v = 0;
+                 v < this->n_active_entries_per_cell_batch(cell);
+                 ++v)
               {
                 const unsigned int index = cell * n_lanes + v;
 

--- a/tests/matrix_free/categorize_by_boundary_ids_01.cc
+++ b/tests/matrix_free/categorize_by_boundary_ids_01.cc
@@ -85,7 +85,8 @@ test(const unsigned int n_refinements)
               {
                 bool temp = true;
 
-                for (unsigned int v = 1; v < data.n_components_filled(cell);
+                for (unsigned int v = 1;
+                     v < data.n_active_entries_per_cell_batch(cell);
                      ++v)
                   temp &= (data.get_faces_by_cells_boundary_id(cell, face)[0] ==
                            data.get_faces_by_cells_boundary_id(cell, face)[v]);

--- a/tests/matrix_free/cell_categorization.cc
+++ b/tests/matrix_free/cell_categorization.cc
@@ -92,7 +92,8 @@ test()
   deallog << "Number of cell batches: " << mf_data.n_cell_batches()
           << std::endl;
   for (unsigned int i = 0; i < mf_data.n_cell_batches(); ++i)
-    for (unsigned int c = 0; c < mf_data.n_components_filled(i); ++c)
+    for (unsigned int c = 0; c < mf_data.n_active_entries_per_cell_batch(i);
+         ++c)
       deallog << mf_data.get_cell_iterator(i, c)->id() << " with "
               << mf_data.get_cell_category(i) << std::endl;
   deallog << std::endl;
@@ -102,7 +103,8 @@ test()
   deallog << "Number of cell batches: " << mf_data.n_cell_batches()
           << std::endl;
   for (unsigned int i = 0; i < mf_data.n_cell_batches(); ++i)
-    for (unsigned int c = 0; c < mf_data.n_components_filled(i); ++c)
+    for (unsigned int c = 0; c < mf_data.n_active_entries_per_cell_batch(i);
+         ++c)
       deallog << mf_data.get_cell_iterator(i, c)->id() << " with "
               << mf_data.get_cell_category(i) << std::endl;
   deallog << std::endl;
@@ -118,7 +120,8 @@ test()
   deallog << "Number of cell batches: " << mf_data.n_cell_batches()
           << std::endl;
   for (unsigned int i = 0; i < mf_data.n_cell_batches(); ++i)
-    for (unsigned int c = 0; c < mf_data.n_components_filled(i); ++c)
+    for (unsigned int c = 0; c < mf_data.n_active_entries_per_cell_batch(i);
+         ++c)
       deallog << mf_data.get_cell_iterator(i, c)->id() << " with "
               << mf_data.get_cell_category(i) << std::endl;
   deallog << std::endl;

--- a/tests/matrix_free/cell_categorization_02.cc
+++ b/tests/matrix_free/cell_categorization_02.cc
@@ -163,7 +163,8 @@ test()
   for (unsigned int i = 0; i < mf_data.n_cell_batches(); ++i)
     {
       const unsigned int m_id = mf_data.get_cell_iterator(i, 0)->material_id();
-      for (unsigned int c = 0; c < mf_data.n_components_filled(i); ++c)
+      for (unsigned int c = 0; c < mf_data.n_active_entries_per_cell_batch(i);
+           ++c)
         {
           const unsigned int c_id =
             mf_data.get_cell_iterator(i, c)->material_id();
@@ -178,7 +179,9 @@ test()
         {
           const unsigned int m_id =
             level_data->get_cell_iterator(i, 0)->material_id();
-          for (unsigned int c = 0; c < level_data->n_components_filled(i); ++c)
+          for (unsigned int c = 0;
+               c < level_data->n_active_entries_per_cell_batch(i);
+               ++c)
             {
               const unsigned int c_id =
                 level_data->get_cell_iterator(i, c)->material_id();

--- a/tests/matrix_free/cell_level_and_index.cc
+++ b/tests/matrix_free/cell_level_and_index.cc
@@ -46,7 +46,7 @@ compare_indices(const MatrixFree<dim, number> *mf_data)
   for (unsigned int batch_no = 0; batch_no < n_batches; ++batch_no)
     {
       const unsigned int n_lanes_filled =
-        mf_data->n_components_filled(batch_no);
+        mf_data->n_active_entries_per_cell_batch(batch_no);
       for (unsigned int lane = 0; lane < n_lanes_filled; ++lane)
         {
           const auto cell = mf_data->get_cell_iterator(batch_no, lane);

--- a/tests/matrix_free/dof_info_01.cc
+++ b/tests/matrix_free/dof_info_01.cc
@@ -170,7 +170,9 @@ test(const bool adaptive_ref = true)
 
       // output cell blocks:
       for (unsigned int cell = 0; cell < n_cells; ++cell)
-        for (unsigned int c = 0; c < mf_data->n_components_filled(cell); ++c)
+        for (unsigned int c = 0;
+             c < mf_data->n_active_entries_per_cell_batch(cell);
+             ++c)
           {
             const auto dof_cell = mf_data->get_cell_iterator(cell, c);
             f << dof_cell->center() << " \"" << cell << "\"\n";

--- a/tests/matrix_free/dof_info_02.cc
+++ b/tests/matrix_free/dof_info_02.cc
@@ -172,7 +172,9 @@ test(const bool adaptive_ref = true)
 
       // output cell blocks:
       for (unsigned int cell = 0; cell < n_cells; ++cell)
-        for (unsigned int c = 0; c < mf_data->n_components_filled(cell); ++c)
+        for (unsigned int c = 0;
+             c < mf_data->n_active_entries_per_cell_batch(cell);
+             ++c)
           {
             const auto dof_cell = mf_data->get_cell_iterator(cell, c);
             f << dof_cell->center() << " \"" << cell << "\"\n";

--- a/tests/matrix_free/get_functions_common.h
+++ b/tests/matrix_free/get_functions_common.h
@@ -101,7 +101,8 @@ public:
 
         // compare values with the ones the FEValues
         // gives us. Those are seen as reference
-        for (unsigned int j = 0; j < data.n_components_filled(cell); ++j)
+        for (unsigned int j = 0; j < data.n_active_entries_per_cell_batch(cell);
+             ++j)
           {
             fe_val.reinit(data.get_cell_iterator(cell, j));
             fe_val.get_function_values(src, reference_values);

--- a/tests/matrix_free/get_functions_multife.cc
+++ b/tests/matrix_free/get_functions_multife.cc
@@ -93,7 +93,8 @@ public:
 
         // compare values with the ones the FEValues
         // gives us. Those are seen as reference
-        for (unsigned int j = 0; j < data.n_components_filled(cell); ++j)
+        for (unsigned int j = 0; j < data.n_active_entries_per_cell_batch(cell);
+             ++j)
           {
             // FE 0
             fe_val0.reinit(data.get_cell_iterator(cell, j, 0));

--- a/tests/matrix_free/get_functions_multife2.cc
+++ b/tests/matrix_free/get_functions_multife2.cc
@@ -107,7 +107,8 @@ public:
 
         // compare values with the ones the FEValues
         // gives us. Those are seen as reference
-        for (unsigned int j = 0; j < data.n_components_filled(cell); ++j)
+        for (unsigned int j = 0; j < data.n_active_entries_per_cell_batch(cell);
+             ++j)
           {
             // FE 0
             fe_val0.reinit(data.get_cell_iterator(cell, j, 0));

--- a/tests/matrix_free/integrate_functions.cc
+++ b/tests/matrix_free/integrate_functions.cc
@@ -104,7 +104,8 @@ MatrixFreeTest<dim, fe_degree, Number>::operator()(
       fe_eval.reinit(cell);
       // compare values with the ones the FEValues
       // gives us. Those are seen as reference
-      for (unsigned int j = 0; j < data.n_components_filled(cell); ++j)
+      for (unsigned int j = 0; j < data.n_active_entries_per_cell_batch(cell);
+           ++j)
         {
           // generate random numbers at quadrature
           // points and test them with basis functions

--- a/tests/matrix_free/integrate_functions_hessians.cc
+++ b/tests/matrix_free/integrate_functions_hessians.cc
@@ -106,7 +106,8 @@ MatrixFreeTest<dim, fe_degree, Number>::operator()(
       fe_eval.reinit(cell);
       // compare values with the ones the FEValues
       // gives us. Those are seen as reference
-      for (unsigned int j = 0; j < data.n_components_filled(cell); ++j)
+      for (unsigned int j = 0; j < data.n_active_entries_per_cell_batch(cell);
+           ++j)
         {
           // generate random numbers at quadrature
           // points and test them with basis functions

--- a/tests/matrix_free/integrate_functions_multife.cc
+++ b/tests/matrix_free/integrate_functions_multife.cc
@@ -122,7 +122,8 @@ MatrixFreeTest<dim, fe_degree, Number>::operator()(
 
       // compare values with the ones the FEValues
       // gives us. Those are seen as reference
-      for (unsigned int j = 0; j < data.n_components_filled(cell); ++j)
+      for (unsigned int j = 0; j < data.n_active_entries_per_cell_batch(cell);
+           ++j)
         {
           // FE 0, Quad 0
           // generate random numbers at quadrature

--- a/tests/matrix_free/integrate_functions_multife2.cc
+++ b/tests/matrix_free/integrate_functions_multife2.cc
@@ -123,7 +123,8 @@ MatrixFreeTest<dim, fe_degree, Number>::operator()(
 
       // compare values with the ones the FEValues
       // gives us. Those are seen as reference
-      for (unsigned int j = 0; j < data.n_components_filled(cell); ++j)
+      for (unsigned int j = 0; j < data.n_active_entries_per_cell_batch(cell);
+           ++j)
         {
           // FE 0, Quad 0
           // generate random numbers at quadrature

--- a/tests/matrix_free/interpolate_functions_common.h
+++ b/tests/matrix_free/interpolate_functions_common.h
@@ -89,7 +89,8 @@ public:
         fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients |
                          EvaluationFlags::hessians);
 
-        for (unsigned int j = 0; j < data.n_components_filled(cell); ++j)
+        for (unsigned int j = 0; j < data.n_active_entries_per_cell_batch(cell);
+             ++j)
           for (unsigned int q = 0; q < fe_eval.n_q_points; ++q)
             {
               ++cell_times;

--- a/tests/matrix_free/jxw_values.cc
+++ b/tests/matrix_free/jxw_values.cc
@@ -82,7 +82,9 @@ test()
   for (unsigned int cell = 0; cell < mf_data.n_cell_batches(); ++cell)
     {
       fe_eval.reinit(cell);
-      for (unsigned int v = 0; v < mf_data.n_components_filled(cell); ++v)
+      for (unsigned int v = 0;
+           v < mf_data.n_active_entries_per_cell_batch(cell);
+           ++v)
         {
           fe_values.reinit(mf_data.get_cell_iterator(cell, v));
           for (unsigned int q = 0; q < quad.size(); ++q)

--- a/tests/matrix_free/quadrature_points.cc
+++ b/tests/matrix_free/quadrature_points.cc
@@ -94,7 +94,9 @@ test()
   for (unsigned int cell = 0; cell < n_cells; ++cell)
     {
       fe_eval.reinit(cell);
-      for (unsigned int j = 0; j < mf_data.n_components_filled(cell); ++j)
+      for (unsigned int j = 0;
+           j < mf_data.n_active_entries_per_cell_batch(cell);
+           ++j)
         {
           fe_values.reinit(mf_data.get_cell_iterator(cell, j));
           for (unsigned int q = 0; q < fe_eval.n_q_points; ++q)


### PR DESCRIPTION
This does not change any functionality and is purely a cleanup of our internal interfaces: The function was deprecated in #11184 but we apparently forgot to remove the use inside the library. This PR does that, and it would be good to have in for a release since this code might get removed soon after the release.