### PR TITLE
MatrixFree: Do not construct hanging nodes structure for non-adapted meshes

### DIFF
--- a/include/deal.II/matrix_free/hanging_nodes_internal.h
+++ b/include/deal.II/matrix_free/hanging_nodes_internal.h
@@ -376,6 +376,17 @@ namespace internal
     inline void
     HangingNodes<3>::setup_line_to_cell(const Triangulation<3> &triangulation)
     {
+      // Check if we there are no hanging nodes on the current MPI process,
+      // which we do by checking if the second finest level holds no active
+      // non-artificial cell
+      if (triangulation.n_levels() <= 1 ||
+          std::none_of(triangulation.begin_active(triangulation.n_levels() - 2),
+                       triangulation.end_active(triangulation.n_levels() - 2),
+                       [](const CellAccessor<3, 3> &cell) {
+                         return !cell.is_artificial();
+                       }))
+        return;
+
       const unsigned int n_raw_lines = triangulation.n_raw_lines();
       this->line_to_cells.resize(n_raw_lines);
 


### PR DESCRIPTION
This reduces the initialization cost of a data structure that is added with this release, so I would like to tag it with 9.4. Note that this code is well-tested in around a hundred of tests for matrix-free computations.