### PR TITLE
Allow to call communicate_mg_ghost_cells in 1D

### DIFF
--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -3675,15 +3675,6 @@ namespace internal
 
 
 
-        template <int spacedim>
-        void
-        communicate_mg_ghost_cells(DoFHandler<1, spacedim> &)
-        {
-          Assert(false, ExcNotImplemented());
-        }
-
-
-
         /**
          * A function that communicates the DoF indices from that subset of
          * locally owned cells that have their user indices set to the


### PR DESCRIPTION
In #13816, I removed the triangulation argument to a function specialization in 1D that would otherwise never get called but now did. This is because we expected a `parallel::distributed::Triangulation<1, spacedim>` argument, but the triangulation at the calling site was never downcast to a `p:d:Tria`, so we would never call the specialization. Hence, we should remove this code, to fix the tests fullydistributed_grids.copy_serial_tria_??`, see e.g. one of them: https://cdash.dealii.43-1.org/test/12321626

This is extracted from #13853, which we decided to hold off till after the release.