### PR TITLE
Reduce run time of matrix-free RT tests

### DIFF
--- a/tests/matrix_free/matrix_vector_rt_face_common.h
+++ b/tests/matrix_free/matrix_vector_rt_face_common.h
@@ -252,7 +252,7 @@ do_test(const DoFHandler<dim> &          dof,
       initial_condition[i] = random_value<Number>();
     }
 
-  MatrixFreeTest<dim, fe_degree, fe_degree + 2, Number> mf(mf_data, test_type);
+  MatrixFreeTest<dim, -1, 0, Number> mf(mf_data, test_type);
   mf.test_functions(solution, initial_condition);
 
 
@@ -273,6 +273,9 @@ do_test(const DoFHandler<dim> &          dof,
   std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
   FullMatrix<double> local_matrix(dofs_per_cell, dofs_per_cell);
 
+  std::vector<Tensor<1, dim>> phi_val(dofs_per_cell);
+  std::vector<Tensor<2, dim>> phi_grad(dofs_per_cell);
+  std::vector<double>         phi_div(dofs_per_cell);
 
   const FEValuesExtractors::Vector velocities(0);
   // Assemble matrix
@@ -283,30 +286,27 @@ do_test(const DoFHandler<dim> &          dof,
         local_matrix = 0;
 
         for (const auto q : fe_val.quadrature_point_indices())
-          for (unsigned int i = 0; i < dofs_per_cell; ++i)
-            {
-              const Tensor<1, dim> phi_i = fe_val[velocities].value(i, q) * 10.;
-              const Tensor<2, dim> grad_phi_i =
-                fe_val[velocities].gradient(i, q);
-              const Number div_phi_i = fe_val[velocities].divergence(i, q);
-
+          {
+            const double JxW = fe_val.JxW(q);
+            for (unsigned int i = 0; i < dofs_per_cell; ++i)
+              {
+                phi_val[i]  = fe_val[velocities].value(i, q);
+                phi_grad[i] = fe_val[velocities].gradient(i, q);
+                phi_div[i]  = fe_val[velocities].divergence(i, q);
+              }
+            for (unsigned int i = 0; i < dofs_per_cell; ++i)
               for (unsigned int j = 0; j < dofs_per_cell; ++j)
                 {
-                  const Tensor<1, dim> phi_j = fe_val[velocities].value(j, q);
-                  const Tensor<2, dim> grad_phi_j =
-                    fe_val[velocities].gradient(j, q);
-                  const Number div_phi_j = fe_val[velocities].divergence(j, q);
-
                   if (test_type < TestType::gradients)
-                    local_matrix(i, j) += phi_j * phi_i * fe_val.JxW(q);
+                    local_matrix(i, j) += 10. * (phi_val[j] * phi_val[i]) * JxW;
                   if (test_type == TestType::gradients ||
                       test_type == TestType::values_gradients)
                     local_matrix(i, j) +=
-                      scalar_product(grad_phi_i, grad_phi_j) * fe_val.JxW(q);
+                      scalar_product(phi_grad[i], phi_grad[j]) * JxW;
                   else if (test_type == TestType::divergence)
-                    local_matrix(i, j) += div_phi_i * div_phi_j * fe_val.JxW(q);
+                    local_matrix(i, j) += phi_div[i] * phi_div[j] * JxW;
                 }
-            }
+          }
         cell->get_dof_indices(local_dof_indices);
         for (unsigned int i = 0; i < dofs_per_cell; ++i)
           for (unsigned int j = 0; j < dofs_per_cell; ++j)


### PR DESCRIPTION
On several machines, the new matrix-free tests with Raviart-Thomas evaluation run very slowly, which is mostly due to the expensive reference solution with `FEValues`/`FEFaceValues`. Use a common trick to circumvent the performance of the extractors by putting all fields into a separate variable. This should reduce operation count by a factor of 5 at least and thus make run times more tolerable. Also use the parameter `-1` for the degree to run the pre-compiled part for the cell integrals, which reduces the compile times.