### PR TITLE
Qualify int*_t and uint*_t with std::.

### DIFF
--- a/include/deal.II/base/hdf5.h
+++ b/include/deal.II/base/hdf5.h
@@ -834,7 +834,8 @@ namespace HDF5
      * This function returns the local causes that broke collective I/O on the
      * last parallel I/O call. See <a
      * href="https://support.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#Property-GetMpioNoCollectiveCause">H5Pget_mpio_no_collective_cause</a>.
-     * The return type is `uint32_t` and corresponds to the value returned by
+     * The return type is `std::uint32_t` and corresponds to the value returned
+     * by
      * [H5Pget_mpio_no_collective_cause](https://support.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#Property-GetMpioNoCollectiveCause).
      *
      * The return value can be
@@ -850,7 +851,7 @@ namespace HDF5
      * H5D_MPIO_NOT_CONTIGUOUS_OR_CHUNKED_DATASET | Collective I/O was not performed because the dataset was neither contiguous nor chunked.
      * H5D_MPIO_FILTERS                           | Collective I/O was not performed because filters needed to be applied.
      */
-    uint32_t
+    std::uint32_t
     get_local_no_collective_cause_as_hdf5_type();
 
     /**
@@ -878,8 +879,8 @@ namespace HDF5
      * This function returns the global causes that broke collective I/O on the
      * last parallel I/O call. See <a
      * href="https://support.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#Property-GetMpioNoCollectiveCause">H5Pget_mpio_no_collective_cause</a>.
-     * The return type is `uint32_t` and corresponds to the value returned by
-     * H5Pget_mpio_no_collective_cause.
+     * The return type is `std::uint32_t` and corresponds to the value returned
+     * by H5Pget_mpio_no_collective_cause.
      *
      * The return value can be
      * Value                                      | Meaning
@@ -894,7 +895,7 @@ namespace HDF5
      * H5D_MPIO_NOT_CONTIGUOUS_OR_CHUNKED_DATASET | Collective I/O was not performed because the dataset was neither contiguous nor chunked.
      * H5D_MPIO_FILTERS                           | Collective I/O was not performed because filters needed to be applied.
      */
-    uint32_t
+    std::uint32_t
     get_global_no_collective_cause_as_hdf5_type();
 
     /**
@@ -960,14 +961,14 @@ namespace HDF5
      * last parallel I/O call. See <a
      * href="https://support.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#Property-GetMpioNoCollectiveCause">H5Pget_mpio_no_collective_cause</a>.
      */
-    uint32_t local_no_collective_cause;
+    std::uint32_t local_no_collective_cause;
 
     /**
      * Global causes that broke collective I/O on the
      * last parallel I/O call. See <a
      * href="https://support.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#Property-GetMpioNoCollectiveCause">H5Pget_mpio_no_collective_cause</a>.
      */
-    uint32_t global_no_collective_cause;
+    std::uint32_t global_no_collective_cause;
   };
 
   /**
@@ -1254,8 +1255,8 @@ namespace HDF5
     inline void
     release_plist(hid_t &                    plist,
                   H5D_mpio_actual_io_mode_t &io_mode,
-                  uint32_t &                 local_no_collective_cause,
-                  uint32_t &                 global_no_collective_cause,
+                  std::uint32_t &            local_no_collective_cause,
+                  std::uint32_t &            global_no_collective_cause,
                   const bool                 mpi,
                   const bool                 query_io_mode);
 
@@ -1263,7 +1264,7 @@ namespace HDF5
      * Convert a HDF5 no_collective_cause code to a human readable string.
      */
     inline std::string
-    no_collective_cause_to_string(const uint32_t no_collective_cause);
+    no_collective_cause_to_string(const std::uint32_t no_collective_cause);
   } // namespace internal
 
 
@@ -1500,8 +1501,8 @@ namespace HDF5
     inline void
     release_plist(hid_t &                    plist,
                   H5D_mpio_actual_io_mode_t &io_mode,
-                  uint32_t &                 local_no_collective_cause,
-                  uint32_t &                 global_no_collective_cause,
+                  std::uint32_t &            local_no_collective_cause,
+                  std::uint32_t &            global_no_collective_cause,
                   const bool                 mpi,
                   const bool                 query_io_mode)
     {
@@ -1537,7 +1538,7 @@ namespace HDF5
 
 
     inline std::string
-    no_collective_cause_to_string(const uint32_t no_collective_cause)
+    no_collective_cause_to_string(const std::uint32_t no_collective_cause)
     {
       std::string message;
 

--- a/include/deal.II/base/mpi_noncontiguous_partitioner.h
+++ b/include/deal.II/base/mpi_noncontiguous_partitioner.h
@@ -257,7 +257,7 @@ namespace Utilities
        *   we use an arbitrary type of size 1 byte. The type is cast to the
        *   requested type in the relevant functions.
        */
-      mutable std::vector<uint8_t> buffers;
+      mutable std::vector<std::uint8_t> buffers;
 
       /**
        * MPI requests for sending and receiving.

--- a/include/deal.II/base/types.h
+++ b/include/deal.II/base/types.h
@@ -45,7 +45,7 @@ namespace types
   /**
    * The type used for global indices of vertices.
    */
-  using global_vertex_index = uint64_t;
+  using global_vertex_index = std::uint64_t;
 
   /**
    * An identifier that denotes the MPI type associated with
@@ -71,7 +71,7 @@ namespace types
    * page for guidance on when this type should or should not be used.
    */
 #ifdef DEAL_II_WITH_64BIT_INDICES
-  using global_dof_index = uint64_t;
+  using global_dof_index = std::uint64_t;
 #else
   using global_dof_index  = unsigned int;
 #endif
@@ -100,7 +100,7 @@ namespace types
    * The data type always corresponds to an unsigned integer type.
    */
 #ifdef DEAL_II_WITH_64BIT_INDICES
-  using global_cell_index = uint64_t;
+  using global_cell_index = std::uint64_t;
 #else
   using global_cell_index = unsigned int;
 #endif

--- a/include/deal.II/distributed/p4est_wrappers.h
+++ b/include/deal.II/distributed/p4est_wrappers.h
@@ -145,7 +145,7 @@ namespace internal
 
       static void (&quadrant_set_morton)(types<2>::quadrant *quadrant,
                                          int                 level,
-                                         uint64_t            id);
+                                         std::uint64_t       id);
 
       static int (&quadrant_is_equal)(const types<2>::quadrant *q1,
                                       const types<2>::quadrant *q2);
@@ -348,7 +348,7 @@ namespace internal
 
       static void (&quadrant_set_morton)(types<3>::quadrant *quadrant,
                                          int                 level,
-                                         uint64_t            id);
+                                         std::uint64_t       id);
 
       static int (&quadrant_is_equal)(const types<3>::quadrant *q1,
                                       const types<3>::quadrant *q2);

--- a/include/deal.II/particles/property_pool.h
+++ b/include/deal.II/particles/property_pool.h
@@ -40,7 +40,7 @@ namespace types
    *
    * The data type always indicates an unsigned integer type.
    */
-  using particle_index = uint64_t;
+  using particle_index = std::uint64_t;
 
 #  ifdef DEAL_II_WITH_MPI
   /**

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -51,7 +51,7 @@
 #include <set>
 #include <sstream>
 
-// we use uint32_t and uint8_t below, which are declared here:
+// we use std::uint32_t and std::uint8_t below, which are declared here:
 #include <cstdint>
 #include <vector>
 
@@ -121,16 +121,17 @@ namespace
 
         // While zlib's compress2 uses unsigned long (which is 64bits
         // on Linux), the vtu compression header stores the block size
-        // as an uint32_t (see below). While we could implement
+        // as an std::uint32_t (see below). While we could implement
         // writing several smaller blocks, we haven't done that. Let's
         // trigger an error for the user instead:
-        AssertThrow(uncompressed_size <= std::numeric_limits<uint32_t>::max(),
+        AssertThrow(uncompressed_size <=
+                      std::numeric_limits<std::uint32_t>::max(),
                     ExcNotImplemented());
 
         // allocate a buffer for compressing data and do so
         auto compressed_data_length = compressBound(uncompressed_size);
         AssertThrow(compressed_data_length <=
-                      std::numeric_limits<uint32_t>::max(),
+                      std::numeric_limits<std::uint32_t>::max(),
                     ExcNotImplemented());
 
         std::vector<unsigned char> compressed_data(compressed_data_length);
@@ -148,18 +149,20 @@ namespace
         compressed_data.resize(compressed_data_length);
 
         // now encode the compression header
-        const uint32_t compression_header[4] = {
-          1,                                        /* number of blocks */
-          static_cast<uint32_t>(uncompressed_size), /* size of block */
-          static_cast<uint32_t>(uncompressed_size), /* size of last block */
-          static_cast<uint32_t>(
+        const std::uint32_t compression_header[4] = {
+          1,                                             /* number of blocks */
+          static_cast<std::uint32_t>(uncompressed_size), /* size of block */
+          static_cast<std::uint32_t>(
+            uncompressed_size), /* size of last block */
+          static_cast<std::uint32_t>(
             compressed_data_length)}; /* list of compressed sizes of blocks */
 
         const auto header_start =
           reinterpret_cast<const unsigned char *>(&compression_header[0]);
 
         output_stream << Utilities::encode_base64(
-                           {header_start, header_start + 4 * sizeof(uint32_t)})
+                           {header_start,
+                            header_start + 4 * sizeof(std::uint32_t)})
                       << Utilities::encode_base64(compressed_data);
       }
   }
@@ -5999,10 +6002,10 @@ namespace DataOutBase
     std::vector<int32_t> offsets;
     offsets.reserve(n_cells);
 
-    // uint8_t might be an alias to unsigned char which is then not printed
+    // std::uint8_t might be an alias to unsigned char which is then not printed
     // as ascii integers
 #ifdef DEAL_II_WITH_ZLIB
-    std::vector<uint8_t> cell_types;
+    std::vector<std::uint8_t> cell_types;
 #else
     std::vector<unsigned int> cell_types;
 #endif

--- a/source/base/hdf5.cc
+++ b/source/base/hdf5.cc
@@ -267,7 +267,7 @@ namespace HDF5
 
 
 
-  uint32_t
+  std::uint32_t
   DataSet::get_local_no_collective_cause_as_hdf5_type()
   {
     Assert(
@@ -291,7 +291,7 @@ namespace HDF5
 
 
 
-  uint32_t
+  std::uint32_t
   DataSet::get_global_no_collective_cause_as_hdf5_type()
   {
     Assert(

--- a/source/distributed/p4est_wrappers.cc
+++ b/source/distributed/p4est_wrappers.cc
@@ -349,7 +349,7 @@ namespace internal
 
     void (&functions<2>::quadrant_set_morton)(types<2>::quadrant *quadrant,
                                               int                 level,
-                                              uint64_t            id) =
+                                              std::uint64_t       id) =
       p4est_quadrant_set_morton;
 
     int (&functions<2>::quadrant_is_equal)(const types<2>::quadrant *q1,
@@ -564,7 +564,7 @@ namespace internal
 
     void (&functions<3>::quadrant_set_morton)(types<3>::quadrant *quadrant,
                                               int                 level,
-                                              uint64_t            id) =
+                                              std::uint64_t       id) =
       p8est_quadrant_set_morton;
 
     int (&functions<3>::quadrant_is_equal)(const types<3>::quadrant *q1,

--- a/source/distributed/repartitioning_policy_tools.cc
+++ b/source/distributed/repartitioning_policy_tools.cc
@@ -301,12 +301,12 @@ namespace RepartitioningPolicyTools
           cell, Triangulation<dim, spacedim>::CellStatus::CELL_PERSIST);
 
     // determine weight of all the cells locally owned by this process
-    uint64_t process_local_weight = 0;
+    std::uint64_t process_local_weight = 0;
     for (const auto &weight : weights)
       process_local_weight += weight;
 
     // determine partial sum of weights of this process
-    uint64_t process_local_weight_offset = 0;
+    std::uint64_t process_local_weight_offset = 0;
 
     int ierr = MPI_Exscan(
       &process_local_weight,
@@ -318,7 +318,8 @@ namespace RepartitioningPolicyTools
     AssertThrowMPI(ierr);
 
     // total weight of all processes
-    uint64_t total_weight = process_local_weight_offset + process_local_weight;
+    std::uint64_t total_weight =
+      process_local_weight_offset + process_local_weight;
 
     ierr =
       MPI_Bcast(&total_weight,
@@ -331,7 +332,7 @@ namespace RepartitioningPolicyTools
     // setup partition
     LinearAlgebra::distributed::Vector<double> partition(partitioner);
 
-    for (uint64_t i = 0, weight = process_local_weight_offset;
+    for (std::uint64_t i = 0, weight = process_local_weight_offset;
          i < partition.locally_owned_size();
          weight += weights[i], ++i)
       partition.local_element(i) =

--- a/tests/fe/fe_conformity_fill_vector_random.h
+++ b/tests/fe/fe_conformity_fill_vector_random.h
@@ -47,7 +47,7 @@ namespace FEConforimityTest
 
     std::uniform_real_distribution<double> uniform_distribution;
 
-    uint64_t timeSeed;
+    std::uint64_t timeSeed;
 
     std::seed_seq seed_sequence;
 
@@ -61,7 +61,8 @@ namespace FEConforimityTest
     , uniform_distribution(a, b)
     , timeSeed(
         std::chrono::high_resolution_clock::now().time_since_epoch().count())
-    , seed_sequence({uint32_t(timeSeed & 0xffffffff), uint32_t(timeSeed >> 32)})
+    , seed_sequence(
+        {std::uint32_t(timeSeed & 0xffffffff), std::uint32_t(timeSeed >> 32)})
   {
     rng.seed(seed_sequence);
   }

--- a/tests/mpi/mpi_type_id_for_type_01.cc
+++ b/tests/mpi/mpi_type_id_for_type_01.cc
@@ -82,7 +82,7 @@ main(int argc, char *argv[])
   // aliases for some of the types above and consequently are
   // indistinguishable even though the tags are distinguishable. That
   // is: while the type system cannot distinguish between 'unsigned
-  // char' and 'uint8_t', the tags 'MPI_SIGNED_CHAR' and 'MPI_INT8_T'
+  // char' and 'std::uint8_t', the tags 'MPI_SIGNED_CHAR' and 'MPI_INT8_T'
   // are different. We cannot test, then, that the tag we get for
   // these types equals their tags...
 
@@ -90,10 +90,10 @@ main(int argc, char *argv[])
   // TEST(int16_t, MPI_INT16_T);
   // TEST(int32_t, MPI_INT32_T);
   // TEST(int64_t, MPI_INT64_T);
-  // TEST(uint8_t, MPI_UINT8_T);
-  // TEST(uint16_t, MPI_UINT16_T);
-  // TEST(uint32_t, MPI_UINT32_T);
-  // TEST(uint64_t, MPI_UINT64_T);
+  // TEST(std::uint8_t, MPI_UINT8_T);
+  // TEST(std::uint16_t, MPI_UINT16_T);
+  // TEST(std::uint32_t, MPI_UINT32_T);
+  // TEST(std::uint64_t, MPI_UINT64_T);
 
   // Now make sure that the following type is not supported:
   struct X


### PR DESCRIPTION
Not 9.4 material.

In the majority of places we already do this. Let's be consistent.

/rebuild