### PR TITLE
Work on two compile warnings with Clang-14

### DIFF
--- a/examples/step-50/step-50.cc
+++ b/examples/step-50/step-50.cc
@@ -1247,8 +1247,6 @@ struct CopyData
     , value(0.)
   {}
 
-  CopyData(const CopyData &) = default;
-
   struct FaceData
   {
     unsigned int cell_indices[2];

--- a/include/deal.II/cgal/utilities.h
+++ b/include/deal.II/cgal/utilities.h
@@ -437,6 +437,7 @@ namespace CGALWrappers
           output_surface_mesh.clear();
           break;
       }
+    (void)res;
     Assert(res,
            ExcMessage("The boolean operation was not successfully computed."));
   }


### PR DESCRIPTION
This should fix the two compile warnings shown by the Clang-14 build on the tester: https://cdash.dealii.43-1.org/viewBuildError.php?type=1&buildid=2236
```
examples/step-50/step-50.cc:1250: warning:definition of implicit copy assignment operator for 'CopyData' is deprecated because it has a user-declared copy constructor [-Wdeprecated-copy]
```
and
```
include/deal.II/cgal/utilities.h:409: warning: variable 'res' set but not used [-Wunused-but-set-variable]
```