### PR TITLE
Remove inclusion of additional headers

### DIFF
--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -24,11 +24,6 @@
 #include <deal.II/base/partitioner.h>
 #include <deal.II/base/vectorization.h>
 
-#include <deal.II/dofs/dof_handler.h>
-
-#include <deal.II/lac/affine_constraints.h>
-#include <deal.II/lac/dynamic_sparsity_pattern.h>
-
 #include <deal.II/matrix_free/face_info.h>
 #include <deal.II/matrix_free/shape_info.h>
 #include <deal.II/matrix_free/task_info.h>
@@ -41,6 +36,9 @@
 DEAL_II_NAMESPACE_OPEN
 
 #ifndef DOXYGEN
+
+// forward declarations
+
 namespace internal
 {
   namespace MatrixFreeFunctions
@@ -52,6 +50,18 @@ namespace internal
     struct FPArrayComparator;
   } // namespace MatrixFreeFunctions
 } // namespace internal
+
+template <typename>
+class AffineConstraints;
+
+class DynamicSparsityPattern;
+
+template <typename>
+class TriaIterator;
+
+template <int, int, bool>
+class DoFCellAccessor;
+
 #endif
 
 namespace internal

--- a/include/deal.II/matrix_free/dof_info.templates.h
+++ b/include/deal.II/matrix_free/dof_info.templates.h
@@ -24,6 +24,7 @@
 #include <deal.II/base/parallel.h>
 #include <deal.II/base/thread_management.h>
 
+#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/sparsity_pattern.h>
 

--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -19,11 +19,10 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/geometry_info.h>
 #include <deal.II/base/ndarray.h>
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/vectorization.h>
-
-#include <deal.II/fe/fe_q.h>
 
 #include <deal.II/matrix_free/dof_info.h>
 #include <deal.II/matrix_free/evaluation_flags.h>

--- a/include/deal.II/matrix_free/fe_evaluation_data.h
+++ b/include/deal.II/matrix_free/fe_evaluation_data.h
@@ -22,7 +22,9 @@
 
 #include <deal.II/base/array_view.h>
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/geometry_info.h>
 #include <deal.II/base/smartpointer.h>
+#include <deal.II/base/std_cxx20/iota_view.h>
 #include <deal.II/base/symmetric_tensor.h>
 #include <deal.II/base/template_constraints.h>
 #include <deal.II/base/tensor.h>

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -38,6 +38,8 @@
 
 #include <deal.II/hp/q_collection.h>
 
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+
 #include <deal.II/matrix_free/face_info.h>
 #include <deal.II/matrix_free/face_setup_internal.h>
 #include <deal.II/matrix_free/hanging_nodes_internal.h>

--- a/include/deal.II/matrix_free/task_info.h
+++ b/include/deal.II/matrix_free/task_info.h
@@ -28,11 +28,14 @@
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/vectorization.h>
 
-#include <deal.II/lac/dynamic_sparsity_pattern.h>
-
 
 DEAL_II_NAMESPACE_OPEN
 
+
+// forward declaration
+#ifndef DOXYGEN
+class DynamicSparsityPattern;
+#endif
 
 
 namespace internal

--- a/include/deal.II/numerics/vector_tools_project.templates.h
+++ b/include/deal.II/numerics/vector_tools_project.templates.h
@@ -21,6 +21,7 @@
 #include <deal.II/fe/fe_simplex_p_bubbles.h>
 
 #include <deal.II/lac/block_vector.h>
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/la_parallel_block_vector.h>
 #include <deal.II/lac/la_parallel_vector.h>
 #include <deal.II/lac/la_vector.h>

--- a/source/matrix_free/task_info.cc
+++ b/source/matrix_free/task_info.cc
@@ -21,6 +21,8 @@
 #include <deal.II/base/parallel.h>
 #include <deal.II/base/utilities.h>
 
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+
 #include <deal.II/matrix_free/task_info.h>
 
 

--- a/tests/matrix_free/matrix_vector_large_degree_02.cc
+++ b/tests/matrix_free/matrix_vector_large_degree_02.cc
@@ -33,6 +33,7 @@
 #include <deal.II/grid/manifold_lib.h>
 
 #include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/sparsity_pattern.h>
 

--- a/tests/matrix_free/matrix_vector_stokes_onedof.cc
+++ b/tests/matrix_free/matrix_vector_stokes_onedof.cc
@@ -38,6 +38,7 @@
 #include <deal.II/grid/tria.h>
 
 #include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/sparsity_pattern.h>
 #include <deal.II/lac/vector.h>

--- a/tests/simplex/matrix_free_01.cc
+++ b/tests/simplex/matrix_free_01.cc
@@ -33,6 +33,7 @@
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria.h>
 
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/la_parallel_vector.h>
 #include <deal.II/lac/precondition.h>
 #include <deal.II/lac/solver_cg.h>

--- a/tests/simplex/matrix_free_02.cc
+++ b/tests/simplex/matrix_free_02.cc
@@ -35,6 +35,7 @@
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria.h>
 
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/la_parallel_vector.h>
 #include <deal.II/lac/precondition.h>
 #include <deal.II/lac/solver_cg.h>


### PR DESCRIPTION
Follow-up to #13871 to further reduce the chances to recompile `evaluation_template_factory`.