### PR TITLE
Cleanup sundials context

### DIFF
--- a/examples/step-77/step-77.cc
+++ b/examples/step-77/step-77.cc
@@ -29,7 +29,6 @@
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/function.h>
-#include <deal.II/base/mpi.h>
 #include <deal.II/base/timer.h>
 #include <deal.II/base/utilities.h>
 
@@ -641,19 +640,11 @@ namespace Step77
 } // namespace Step77
 
 
-int main(int argc, char **argv)
+int main()
 {
   try
     {
       using namespace Step77;
-#ifdef DEAL_II_WITH_MPI
-      dealii::Utilities::MPI::MPI_InitFinalize mpi_initialization(argc,
-                                                                  argv,
-                                                                  1);
-#else
-      (void)argc;
-      (void)argv;
-#endif
 
       MinimalSurfaceProblem<2> laplace_problem_2d;
       laplace_problem_2d.run();

--- a/include/deal.II/sundials/arkode.h
+++ b/include/deal.II/sundials/arkode.h
@@ -473,18 +473,24 @@ namespace SUNDIALS
     };
 
     /**
-     * Constructor. It is possible to fine tune the SUNDIALS ARKode solver by
-     * passing an AdditionalData() object that sets all of the solver
-     * parameters.
-     *
-     * The MPI communicator is simply ignored in the serial case.
-     *
+     * Constructor, with class parameters set by the AdditionalData object.
      *
      * @param data ARKode configuration data
-     * @param mpi_comm MPI communicator
+     *
+     * @note With SUNDIALS 6 and later this constructor sets up logging
+     * objects to only work on the present processor (i.e., results are only
+     * communicated over MPI_COMM_SELF).
      */
-    ARKode(const AdditionalData &data     = AdditionalData(),
-           const MPI_Comm &      mpi_comm = MPI_COMM_WORLD);
+    ARKode(const AdditionalData &data = AdditionalData());
+
+    /**
+     * Constructor.
+     *
+     * @param data ARKode configuration data
+     * @param mpi_comm MPI Communicator over which logging operations are
+     * computed. Only used in SUNDIALS 6 and newer.
+     */
+    ARKode(const AdditionalData &data, const MPI_Comm &mpi_comm);
 
     /**
      * Destructor.
@@ -1064,9 +1070,8 @@ namespace SUNDIALS
 #  endif
 
     /**
-     * MPI communicator. SUNDIALS solver runs happily in
-     * parallel. Note that if the library is compiled without MPI
-     * support, MPI_Comm is aliased as int.
+     * MPI communicator. Only used for SUNDIALS' logging routines - the actual
+     * solve routines will use the communicator provided by the vector class.
      */
     MPI_Comm mpi_communicator;
 

--- a/include/deal.II/sundials/ida.h
+++ b/include/deal.II/sundials/ida.h
@@ -590,13 +590,22 @@ namespace SUNDIALS
      * choose how these are made consistent, using the same three options that
      * you used for the initial conditions in `reset_type`.
      *
-     * The MPI communicator is simply ignored in the serial case.
-     *
      * @param data IDA configuration data
-     * @param mpi_comm MPI communicator
+     *
+     * @note With SUNDIALS 6 and later this constructor sets up logging
+     * objects to only work on the present processor (i.e., results are only
+     * communicated over MPI_COMM_SELF).
      */
-    IDA(const AdditionalData &data     = AdditionalData(),
-        const MPI_Comm &      mpi_comm = MPI_COMM_WORLD);
+    IDA(const AdditionalData &data = AdditionalData());
+
+    /**
+     * Constructor.
+     *
+     * @param data IDA configuration data. Same as the other constructor.
+     * @param mpi_comm MPI Communicator over which logging operations are
+     * computed. Only used in SUNDIALS 6 and newer.
+     */
+    IDA(const AdditionalData &data, const MPI_Comm &mpi_comm);
 
     /**
      * Destructor.
@@ -885,9 +894,8 @@ namespace SUNDIALS
 #  endif
 
     /**
-     * MPI communicator. SUNDIALS solver runs happily in
-     * parallel. Note that if the library is compiled without MPI
-     * support, MPI_Comm is aliased as int.
+     * MPI communicator. Only used for SUNDIALS' logging routines - the actual
+     * solve routines will use the communicator provided by the vector class.
      */
     MPI_Comm mpi_communicator;
 

--- a/include/deal.II/sundials/kinsol.h
+++ b/include/deal.II/sundials/kinsol.h
@@ -373,15 +373,24 @@ namespace SUNDIALS
     };
 
     /**
-     * Constructor. It is possible to fine tune the SUNDIALS KINSOL solver by
-     * passing an AdditionalData() object that sets all of the solver
-     * parameters.
+     * Constructor, with class parameters set by the AdditionalData object.
      *
      * @param data KINSOL configuration data
-     * @param mpi_comm MPI communicator
+     *
+     * @note With SUNDIALS 6 and later this constructor sets up logging
+     * objects to only work on the present processor (i.e., results are only
+     * communicated over MPI_COMM_SELF).
      */
-    KINSOL(const AdditionalData &data     = AdditionalData(),
-           const MPI_Comm &      mpi_comm = MPI_COMM_WORLD);
+    KINSOL(const AdditionalData &data = AdditionalData());
+
+    /**
+     * Constructor.
+     *
+     * @param data KINSOL configuration data
+     * @param mpi_comm MPI Communicator over which logging operations are
+     * computed. Only used in SUNDIALS 6 and newer.
+     */
+    KINSOL(const AdditionalData &data, const MPI_Comm &mpi_comm);
 
     /**
      * Destructor.
@@ -691,6 +700,13 @@ namespace SUNDIALS
      */
     void *kinsol_mem;
 
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+    /**
+     * A context object associated with the KINSOL solver.
+     */
+    SUNContext kinsol_ctx;
+#  endif
+
     /**
      * KINSOL solution vector.
      */
@@ -705,13 +721,6 @@ namespace SUNDIALS
      * KINSOL f scale.
      */
     N_Vector f_scale;
-
-#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
-    /**
-     * A context object associated with the KINSOL solver.
-     */
-    SUNContext kinsol_ctx;
-#  endif
 
     /**
      * Memory pool of vectors.

--- a/source/sundials/arkode.cc
+++ b/source/sundials/arkode.cc
@@ -250,16 +250,37 @@ namespace SUNDIALS
 
 
   template <typename VectorType>
+  ARKode<VectorType>::ARKode(const AdditionalData &data)
+    : ARKode(data, MPI_COMM_SELF)
+  {}
+
+
+  template <typename VectorType>
   ARKode<VectorType>::ARKode(const AdditionalData &data,
                              const MPI_Comm &      mpi_comm)
     : data(data)
     , arkode_mem(nullptr)
-    , mpi_communicator(is_serial_vector<VectorType>::value ?
-                         MPI_COMM_SELF :
-                         Utilities::MPI::duplicate_communicator(mpi_comm))
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+    , arkode_ctx(nullptr)
+#  endif
+    , mpi_communicator(mpi_comm)
     , last_end_time(data.initial_time)
   {
     set_functions_to_trigger_an_assert();
+
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+    // SUNDIALS will always duplicate communicators if we provide them. This
+    // can cause problems if SUNDIALS is configured with MPI and we pass along
+    // MPI_COMM_SELF in a serial application as MPI won't be
+    // initialized. Hence, work around that by just not providing a
+    // communicator in that case.
+    const int status =
+      SUNContext_Create(mpi_communicator == MPI_COMM_SELF ? nullptr :
+                                                            &mpi_communicator,
+                        &arkode_ctx);
+    (void)status;
+    AssertARKode(status);
+#  endif
   }
 
 
@@ -267,20 +288,12 @@ namespace SUNDIALS
   template <typename VectorType>
   ARKode<VectorType>::~ARKode()
   {
-    if (arkode_mem)
-      {
-        ARKStepFree(&arkode_mem);
+    ARKStepFree(&arkode_mem);
 
 #  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
-        const int status = SUNContext_Free(&arkode_ctx);
-        (void)status;
-        AssertARKode(status);
-#  endif
-      }
-
-#  ifdef DEAL_II_WITH_MPI
-    if (is_serial_vector<VectorType>::value == false)
-      Utilities::MPI::free_communicator(mpi_communicator);
+    const int status = SUNContext_Free(&arkode_ctx);
+    (void)status;
+    AssertARKode(status);
 #  endif
   }
 
@@ -387,12 +400,13 @@ namespace SUNDIALS
     (void)status;
 
 #  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
-    if (arkode_ctx)
-      {
-        status = SUNContext_Free(&arkode_ctx);
-        AssertARKode(status);
-      }
-    status = SUNContext_Create(&mpi_communicator, &arkode_ctx);
+    status = SUNContext_Free(&arkode_ctx);
+    AssertARKode(status);
+    // Same comment applies as in class constructor:
+    status =
+      SUNContext_Create(mpi_communicator == MPI_COMM_SELF ? nullptr :
+                                                            &mpi_communicator,
+                        &arkode_ctx);
     AssertARKode(status);
 #  endif
 

--- a/source/sundials/ida.cc
+++ b/source/sundials/ida.cc
@@ -120,13 +120,34 @@ namespace SUNDIALS
 
 
   template <typename VectorType>
+  IDA<VectorType>::IDA(const AdditionalData &data)
+    : IDA(data, MPI_COMM_SELF)
+  {}
+
+
+
+  template <typename VectorType>
   IDA<VectorType>::IDA(const AdditionalData &data, const MPI_Comm &mpi_comm)
     : data(data)
     , ida_mem(nullptr)
-    , mpi_communicator(is_serial_vector<VectorType>::value ?
-                         MPI_COMM_SELF :
-                         Utilities::MPI::duplicate_communicator(mpi_comm))
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+    , ida_ctx(nullptr)
+#  endif
+    , mpi_communicator(mpi_comm)
   {
+    // SUNDIALS will always duplicate communicators if we provide them. This
+    // can cause problems if SUNDIALS is configured with MPI and we pass along
+    // MPI_COMM_SELF in a serial application as MPI won't be
+    // initialized. Hence, work around that by just not providing a
+    // communicator in that case.
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+    const int status =
+      SUNContext_Create(mpi_communicator == MPI_COMM_SELF ? nullptr :
+                                                            &mpi_communicator,
+                        &ida_ctx);
+    (void)status;
+    AssertIDA(status);
+#  endif
     set_functions_to_trigger_an_assert();
   }
 
@@ -135,20 +156,11 @@ namespace SUNDIALS
   template <typename VectorType>
   IDA<VectorType>::~IDA()
   {
-    if (ida_mem)
-      {
-        IDAFree(&ida_mem);
-
-#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
-        const int status = SUNContext_Free(&ida_ctx);
-        (void)status;
-        AssertIDA(status);
-#  endif
-      }
-
-#  ifdef DEAL_II_WITH_MPI
-    if (is_serial_vector<VectorType>::value == false)
-      Utilities::MPI::free_communicator(mpi_communicator);
+    IDAFree(&ida_mem);
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+    const int status = SUNContext_Free(&ida_ctx);
+    (void)status;
+    AssertIDA(status);
 #  endif
   }
 
@@ -220,27 +232,30 @@ namespace SUNDIALS
   {
     bool first_step = (current_time == data.initial_time);
 
-    if (ida_mem)
-      {
-        IDAFree(&ida_mem);
-
-#  if !DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
-        const int status = SUNContext_Free(&ida_ctx);
-        (void)status;
-        AssertIDA(status);
-#  endif
-      }
-
     int status;
     (void)status;
 
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+    status = SUNContext_Free(&ida_ctx);
+    AssertIDA(status);
+
+    // Same comment applies as in class constructor:
+    status =
+      SUNContext_Create(mpi_communicator == MPI_COMM_SELF ? nullptr :
+                                                            &mpi_communicator,
+                        &ida_ctx);
+    AssertIDA(status);
+#  endif
+
+    if (ida_mem)
+      {
+        IDAFree(&ida_mem);
+        // Initialization is version-dependent: do that in a moment
+      }
 
 #  if DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
     ida_mem = IDACreate();
 #  else
-    status = SUNContext_Create(&mpi_communicator, &ida_ctx);
-    AssertIDA(status);
-
     ida_mem = IDACreate(ida_ctx);
 #  endif
 

--- a/tests/sundials/arkode_01.cc
+++ b/tests/sundials/arkode_01.cc
@@ -50,12 +50,9 @@
  * y[1](t) = k cos(k t)
  */
 int
-main(int argc, char **argv)
+main()
 {
   initlog();
-
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(
-    argc, argv, numbers::invalid_unsigned_int);
 
   using VectorType = Vector<double>;
 

--- a/tests/sundials/arkode_02.cc
+++ b/tests/sundials/arkode_02.cc
@@ -50,12 +50,9 @@
  * y[1](t) = k cos(k t)
  */
 int
-main(int argc, char **argv)
+main()
 {
   initlog();
-
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(
-    argc, argv, numbers::invalid_unsigned_int);
 
   using VectorType = Vector<double>;
 

--- a/tests/sundials/arkode_03.cc
+++ b/tests/sundials/arkode_03.cc
@@ -47,12 +47,9 @@
  * eps in right hand side of the third equation).
  */
 int
-main(int argc, char **argv)
+main()
 {
   initlog();
-
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(
-    argc, argv, numbers::invalid_unsigned_int);
 
   using VectorType = LinearAlgebra::distributed::Vector<double>;
 

--- a/tests/sundials/arkode_04.cc
+++ b/tests/sundials/arkode_04.cc
@@ -47,12 +47,9 @@
  * eps in right hand side of the third equation).
  */
 int
-main(int argc, char **argv)
+main()
 {
   initlog();
-
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(
-    argc, argv, numbers::invalid_unsigned_int);
 
   using VectorType = Vector<double>;
 

--- a/tests/sundials/arkode_05.cc
+++ b/tests/sundials/arkode_05.cc
@@ -47,12 +47,9 @@
  * eps in right hand side of the third equation).
  */
 int
-main(int argc, char **argv)
+main()
 {
   initlog();
-
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(
-    argc, argv, numbers::invalid_unsigned_int);
 
   using VectorType = Vector<double>;
 

--- a/tests/sundials/arkode_06.cc
+++ b/tests/sundials/arkode_06.cc
@@ -52,14 +52,11 @@
  * eps in right hand side of the third equation).
  */
 int
-main(int argc, char **argv)
+main()
 {
   initlog();
   // restrict output to highest level
   deallog.depth_file(1);
-
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(
-    argc, argv, numbers::invalid_unsigned_int);
 
   using VectorType = Vector<double>;
 

--- a/tests/sundials/arkode_07.cc
+++ b/tests/sundials/arkode_07.cc
@@ -52,14 +52,11 @@
  * eps in right hand side of the third equation).
  */
 int
-main(int argc, char **argv)
+main()
 {
   initlog();
   // restrict output to highest level
   deallog.depth_file(1);
-
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(
-    argc, argv, numbers::invalid_unsigned_int);
 
   using VectorType = Vector<double>;
 

--- a/tests/sundials/arkode_08.cc
+++ b/tests/sundials/arkode_08.cc
@@ -47,12 +47,9 @@
  * with SUNDIALS nomenclature.
  */
 int
-main(int argc, char **argv)
+main()
 {
   initlog();
-
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(
-    argc, argv, numbers::invalid_unsigned_int);
 
   using VectorType = Vector<double>;
 

--- a/tests/sundials/arkode_repeated_solve.cc
+++ b/tests/sundials/arkode_repeated_solve.cc
@@ -58,12 +58,9 @@ create_solver()
 }
 
 int
-main(int argc, char **argv)
+main()
 {
   initlog();
-
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(
-    argc, argv, numbers::invalid_unsigned_int);
 
   auto ode = create_solver();
   {

--- a/tests/sundials/ida_01.cc
+++ b/tests/sundials/ida_01.cc
@@ -142,10 +142,8 @@ private:
 
 
 int
-main(int argc, char **argv)
+main()
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(
-    argc, argv, numbers::invalid_unsigned_int);
   initlog();
   deallog << std::setprecision(10);
 

--- a/tests/sundials/ida_02.cc
+++ b/tests/sundials/ida_02.cc
@@ -139,10 +139,8 @@ private:
 
 
 int
-main(int argc, char **argv)
+main()
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(
-    argc, argv, numbers::invalid_unsigned_int);
   initlog();
   deallog << std::setprecision(10);
 

--- a/tests/sundials/kinsol_01.cc
+++ b/tests/sundials/kinsol_01.cc
@@ -40,12 +40,9 @@
  * Run statistics (optional outputs) are printed at the end.
  */
 int
-main(int argc, char **argv)
+main()
 {
   initlog();
-
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(
-    argc, argv, numbers::invalid_unsigned_int);
 
   using VectorType = Vector<double>;
 

--- a/tests/sundials/kinsol_02.cc
+++ b/tests/sundials/kinsol_02.cc
@@ -35,12 +35,9 @@
 // N_i(u) = .1*u_i^2 - i - 1
 //
 int
-main(int argc, char **argv)
+main()
 {
   initlog();
-
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(
-    argc, argv, numbers::invalid_unsigned_int);
 
   using VectorType = Vector<double>;
 

--- a/tests/sundials/kinsol_03.cc
+++ b/tests/sundials/kinsol_03.cc
@@ -45,12 +45,9 @@
 // know what to linearize around. The _04 test fixes this by computing
 // the Jacobian in the setup function.
 int
-main(int argc, char **argv)
+main()
 {
   initlog();
-
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(
-    argc, argv, numbers::invalid_unsigned_int);
 
   using VectorType = Vector<double>;
 

--- a/tests/sundials/kinsol_03_new_interface.cc
+++ b/tests/sundials/kinsol_03_new_interface.cc
@@ -45,12 +45,9 @@
 // know what to linearize around. The _04 test fixes this by computing
 // the Jacobian in the setup function.
 int
-main(int argc, char **argv)
+main()
 {
   initlog();
-
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(
-    argc, argv, numbers::invalid_unsigned_int);
 
   using VectorType = Vector<double>;
 

--- a/tests/sundials/kinsol_04.cc
+++ b/tests/sundials/kinsol_04.cc
@@ -57,12 +57,9 @@
 // iteration and, unsurprisingly, converges much quicker.
 
 int
-main(int argc, char **argv)
+main()
 {
   initlog();
-
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(
-    argc, argv, numbers::invalid_unsigned_int);
 
   using VectorType = Vector<double>;
 

--- a/tests/sundials/kinsol_04_new_interface.cc
+++ b/tests/sundials/kinsol_04_new_interface.cc
@@ -57,12 +57,9 @@
 // iteration and, unsurprisingly, converges much quicker.
 
 int
-main(int argc, char **argv)
+main()
 {
   initlog();
-
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(
-    argc, argv, numbers::invalid_unsigned_int);
 
   using VectorType = Vector<double>;
 

--- a/tests/sundials/kinsol_05.cc
+++ b/tests/sundials/kinsol_05.cc
@@ -51,12 +51,9 @@
 // finally updates it in every iteration.
 
 int
-main(int argc, char **argv)
+main()
 {
   initlog();
-
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(
-    argc, argv, numbers::invalid_unsigned_int);
 
   using VectorType = Vector<double>;
 

--- a/tests/sundials/kinsol_05_new_interface.cc
+++ b/tests/sundials/kinsol_05_new_interface.cc
@@ -51,12 +51,9 @@
 // finally updates it in every iteration.
 
 int
-main(int argc, char **argv)
+main()
 {
   initlog();
-
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(
-    argc, argv, numbers::invalid_unsigned_int);
 
   using VectorType = Vector<double>;
 

--- a/tests/sundials/step-77.cc
+++ b/tests/sundials/step-77.cc
@@ -454,17 +454,10 @@ namespace Step77
 
 
 int
-main(int argc, char **argv)
+main()
 {
   initlog();
   using namespace Step77;
-  // SUNDIALS will duplicate communicators even if we are running in serial
-#ifdef DEAL_II_WITH_MPI
-  dealii::Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
-#else
-  (void)argc;
-  (void)argv;
-#endif
 
   MinimalSurfaceProblem<2> laplace_problem_2d;
   laplace_problem_2d.run();


### PR DESCRIPTION
Depends on #13900 - lets merge that first and then I will rebase.

SUNDIALS will duplicate communicators for us, as needed. For example, in `SUNProfiler_Create`, SUNDIALS implements

```cpp
#if SUNDIALS_MPI_ENABLED
profiler->comm = NULL;
if (comm != NULL)
{
    profiler->comm = malloc(sizeof(MPI_Comm));
    MPI_Comm_dup(*((MPI_Comm*) comm), (MPI_Comm*) profiler->comm);
}
#else
profiler->comm = comm;
#endif
```

It is preferable to let SUNDIALS duplicate the communicator so that we don't call MPI functions when we have only serial data structures (and may not have initialized MPI).