### PR TITLE
Add typename and instantiation to `project_boundary_values_div_conforming`

### DIFF
--- a/include/deal.II/numerics/vector_tools_boundary.h
+++ b/include/deal.II/numerics/vector_tools_boundary.h
@@ -718,15 +718,15 @@ namespace VectorTools
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
-  template <int dim>
+  template <int dim, typename number, typename number2 = number>
   void
   project_boundary_values_div_conforming(
-    const DoFHandler<dim, dim> & dof_handler,
-    const unsigned int           first_vector_component,
-    const Function<dim, double> &boundary_function,
-    const types::boundary_id     boundary_component,
-    AffineConstraints<double> &  constraints,
-    const Mapping<dim> &         mapping);
+    const DoFHandler<dim, dim> &  dof_handler,
+    const unsigned int            first_vector_component,
+    const Function<dim, number2> &boundary_function,
+    const types::boundary_id      boundary_component,
+    AffineConstraints<number> &   constraints,
+    const Mapping<dim> &          mapping);
 
   /**
    * Same as above for the hp-namespace.
@@ -736,14 +736,14 @@ namespace VectorTools
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
-  template <int dim>
+  template <int dim, typename number, typename number2 = number>
   void
   project_boundary_values_div_conforming(
     const DoFHandler<dim, dim> &           dof_handler,
     const unsigned int                     first_vector_component,
-    const Function<dim, double> &          boundary_function,
+    const Function<dim, number2> &         boundary_function,
     const types::boundary_id               boundary_component,
-    AffineConstraints<double> &            constraints,
+    AffineConstraints<number> &            constraints,
     const hp::MappingCollection<dim, dim> &mapping_collection =
       hp::StaticMappingQ1<dim>::mapping_collection);
 

--- a/source/numerics/vector_tools_boundary.inst.in
+++ b/source/numerics/vector_tools_boundary.inst.in
@@ -268,21 +268,37 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
         AffineConstraints<std::complex<double>> &,
         const hp::MappingCollection<deal_II_dimension> &);
 #    endif
+#  endif
+#endif
+    \}
+  }
+
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
+     number : REAL_SCALARS;
+     number2 : REAL_SCALARS)
+  {
+    namespace VectorTools
+    \{
+#if deal_II_dimension == deal_II_space_dimension
+
+#  if deal_II_dimension != 1
+
       template void
       project_boundary_values_div_conforming<deal_II_dimension>(
         const DoFHandler<deal_II_dimension> &,
         const unsigned int,
-        const Function<deal_II_dimension> &,
+        const Function<deal_II_dimension, number2> &,
         const types::boundary_id,
-        AffineConstraints<double> &,
+        AffineConstraints<number> &,
         const Mapping<deal_II_dimension> &);
+
       template void
       project_boundary_values_div_conforming<deal_II_dimension>(
         const DoFHandler<deal_II_dimension> &,
         const unsigned int,
-        const Function<deal_II_dimension> &,
+        const Function<deal_II_dimension, number2> &,
         const types::boundary_id,
-        AffineConstraints<double> &,
+        AffineConstraints<number> &,
         const hp::MappingCollection<deal_II_dimension> &);
 #  endif
 #endif


### PR DESCRIPTION
I need this function with `Function<dim, double>` and `AffineConstraints<float>` for [ExaDG](https://github.com/exadg/exadg). Much easier to change this than to change so that all functions in ExaDG have templated type. 

This also changes so that `FE_RaviartThomasNodal` can be used as opposed to only `FE_RaviartThomas`. However, I have only tried with a zero function... mentioned in https://github.com/dealii/dealii/issues/13580#issuecomment-1127339837 