### PR TITLE
ParameterHandler::print_parameters(): Fix demangle alias parameter JSON 

### DIFF
--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -335,18 +335,18 @@ namespace
 
   /**
    * Demangle all parameters recursively and attach them to @p tree_out.
-   * @p parameter_node indicates, whether a given node @p tree_in
-   * is a parameter node (as opposed to being a subsection or alias
-   * node).
+   * @p is_parameter_or_alias_node indicates, whether a given node
+   * @p tree_in is a parameter node or an alias node (as opposed to being
+   * a subsection).
    */
   void
   recursively_demangle(const boost::property_tree::ptree &tree_in,
                        boost::property_tree::ptree &      tree_out,
-                       const bool parameter_node = false)
+                       const bool is_parameter_or_alias_node = false)
   {
     for (const auto &p : tree_in)
       {
-        if (parameter_node)
+        if (is_parameter_or_alias_node)
           {
             tree_out.put_child(p.first, p.second);
           }
@@ -357,7 +357,10 @@ namespace
             if (const auto val = p.second.get_value_optional<std::string>())
               temp.put_value<std::string>(*val);
 
-            recursively_demangle(p.second, temp, is_parameter_node(p.second));
+            recursively_demangle(p.second,
+                                 temp,
+                                 is_parameter_node(p.second) ||
+                                   is_alias_node(p.second));
             tree_out.put_child(demangle(p.first), temp);
           }
       }

--- a/tests/parameter_handler/parameter_handler_write_json.cc
+++ b/tests/parameter_handler/parameter_handler_write_json.cc
@@ -16,7 +16,8 @@
 
 
 // check ParameterHandler::print_parameters (..., JSON). have a few
-// names that contain all sorts of weird (for JSON) characters
+// names that contain all sorts of weird (for JSON) characters and
+// aliased parameters.
 
 #include <deal.II/base/parameter_handler.h>
 
@@ -31,6 +32,7 @@ main()
   ParameterHandler prm;
   prm.declare_entry("int1", "1", Patterns::Integer(), "doc 1");
   prm.declare_entry("int2", "2", Patterns::Integer(), "doc 2");
+  prm.declare_alias("int2", "int2_alias");
   prm.enter_subsection("ss1");
   {
     prm.declare_entry("double 1", "1.234", Patterns::Double(), "doc 3");
@@ -38,6 +40,7 @@ main()
     prm.enter_subsection("ss2");
     {
       prm.declare_entry("double 2", "4.321", Patterns::Double(), "doc 4");
+      prm.declare_alias("double 2", "double 2 alias");
     }
     prm.leave_subsection();
   }

--- a/tests/parameter_handler/parameter_handler_write_json.output
+++ b/tests/parameter_handler/parameter_handler_write_json.output
@@ -16,6 +16,11 @@
         "pattern": "1",
         "pattern_description": "[Integer range -2147483648...2147483647 (inclusive)]"
     },
+    "int2_alias":
+    {
+        "alias": "int2",
+        "deprecation_status": "false"
+    },
     "Testing%testing":
     {
         "double+double":
@@ -62,6 +67,11 @@
                 "documentation": "doc 4",
                 "pattern": "3",
                 "pattern_description": "[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]"
+            },
+            "double 2 alias":
+            {
+                "alias": "double 2",
+                "deprecation_status": "false"
             }
         }
     }
@@ -70,6 +80,11 @@
 {
     "int1": "1",
     "int2": "2",
+    "int2_alias":
+    {
+        "alias": "int2",
+        "deprecation_status": "false"
+    },
     "Testing%testing":
     {
         "double+double": "6.1415926",
@@ -81,7 +96,12 @@
         "double 1": "1.234",
         "ss2":
         {
-            "double 2": "4.321"
+            "double 2": "4.321",
+            "double 2 alias":
+            {
+                "alias": "double 2",
+                "deprecation_status": "false"
+            }
         }
     }
 }


### PR DESCRIPTION
This PR solves the issue regarding the demangling of alias parameter in case of `ParameterHandler::OutputStyle::JSON*`, reported in https://github.com/dealii/dealii/pull/13815#issuecomment-1146224331 and as a follow-up to https://github.com/dealii/dealii/pull/13815.

@gassmoeller @tjhei FYI