### PR TITLE
Use shortcut when determining isotropic refinement cases

### DIFF
--- a/include/deal.II/base/geometry_info.h
+++ b/include/deal.II/base/geometry_info.h
@@ -3675,6 +3675,10 @@ GeometryInfo<2>::face_refinement_case(
                    RefinementCase<dim>::isotropic_refinement + 1);
   AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
 
+  // simple special case
+  if (cell_refinement_case == RefinementCase<dim>::cut_xy)
+    return RefinementCase<1>::cut_x;
+
   const RefinementCase<dim - 1>
     ref_cases[RefinementCase<dim>::isotropic_refinement +
               1][GeometryInfo<dim>::faces_per_cell / 2] = {
@@ -3705,6 +3709,10 @@ GeometryInfo<3>::face_refinement_case(
   AssertIndexRange(cell_refinement_case,
                    RefinementCase<dim>::isotropic_refinement + 1);
   AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
+
+  // simple special case
+  if (cell_refinement_case == RefinementCase<dim>::cut_xyz)
+    return RefinementCase<dim - 1>::cut_xy;
 
   const RefinementCase<dim - 1>
     ref_cases[RefinementCase<dim>::isotropic_refinement + 1]
@@ -3815,6 +3823,10 @@ GeometryInfo<3>::line_refinement_case(
   AssertIndexRange(cell_refinement_case,
                    RefinementCase<dim>::isotropic_refinement + 1);
   AssertIndexRange(line_no, GeometryInfo<dim>::lines_per_cell);
+
+  // simple special case
+  if (cell_refinement_case == RefinementCase<dim>::cut_xyz)
+    return RefinementCase<1>::cut_x;
 
   // array indicating, which simple refine
   // case cuts a line in direction x, y or


### PR DESCRIPTION
When looking at the generated code for refinement options, I noticed some weird code. Apparently the compiler can't see through all switches for the isotropic refinement, and includes some logical `and` in the process. Help it along by providing a shortcut for our most common case.