### PR TITLE
base/polynomials_bdm.cc: avoid a compiler warning with gcc-12

### DIFF
--- a/source/base/polynomials_bdm.cc
+++ b/source/base/polynomials_bdm.cc
@@ -122,7 +122,15 @@ PolynomialsBDM<dim>::evaluate(
   std::vector<std::vector<double>> monovali(dim, std::vector<double>(4));
   std::vector<std::vector<double>> monovalk(dim, std::vector<double>(4));
 
-  if (dim == 2)
+  if (dim == 1)
+    {
+      // Despite the fact that we are instantiating this class for 1, 2 and
+      // 3 space dimensions we only support dimension 2 and 3.
+      Assert(false,
+             dealii::ExcMessage("PolynomialsBDF::evaluate is only "
+                                "available for dim == 2, or dim == 3"));
+    }
+  else if (dim == 2)
     {
       for (unsigned int d = 0; d < dim; ++d)
         monomials[0].value(unit_point(d), monovali[d]);
@@ -164,7 +172,7 @@ PolynomialsBDM<dim>::evaluate(
           grad_grads[start + 1][1][1][1] = -monovali[1][2];
         }
     }
-  else // dim == 3
+  else if (dim == 3)
     {
       // The number of curls in each component. Note that the table in
       // BrezziFortin91 has a typo, but the text has the right basis
@@ -182,6 +190,7 @@ PolynomialsBDM<dim>::evaluate(
               monomials[this->degree() - 1 - i].value(unit_point(d),
                                                       monovalk[d]);
             }
+
           if (values.size() != 0)
             {
               // x p'(y) q(z)
@@ -205,6 +214,7 @@ PolynomialsBDM<dim>::evaluate(
               values[start + 2][0] = -monovali[0][0] * monovalk[1][0];
               values[start + 2][1] = 0.;
             }
+
           if (grads.size() != 0)
             {
               grads[start][0][0] = monovali[1][1] * monovalk[2][0];
@@ -243,6 +253,7 @@ PolynomialsBDM<dim>::evaluate(
               grads[start + 2][1][0] = 0.;
               grads[start + 2][1][1] = 0.;
             }
+
           if (grad_grads.size() != 0)
             {
               grad_grads[start][0][0][0] = 0.;

--- a/source/base/polynomials_bdm.cc
+++ b/source/base/polynomials_bdm.cc
@@ -81,11 +81,8 @@ PolynomialsBDM<dim>::evaluate(
 
   const unsigned int n_sub = polynomial_space.n();
 
-  // guard access to the scratch
-  // arrays in the following block
-  // using a mutex to make sure they
-  // are not used by multiple threads
-  // at once
+  // guard access to the scratch arrays in the following block using a
+  // mutex to make sure they are not used by multiple threads at once
   {
     std::lock_guard<std::mutex> lock(mutex);
 
@@ -93,11 +90,8 @@ PolynomialsBDM<dim>::evaluate(
     p_grads.resize((grads.size() == 0) ? 0 : n_sub);
     p_grad_grads.resize((grad_grads.size() == 0) ? 0 : n_sub);
 
-    // Compute values of complete space
-    // and insert into tensors.  Result
-    // will have first all polynomials
-    // in the x-component, then y and
-    // z.
+    // Compute values of complete space and insert into tensors.  Result
+    // will have first all polynomials in the x-component, then y and z.
     polynomial_space.evaluate(unit_point,
                               p_values,
                               p_grads,
@@ -121,13 +115,10 @@ PolynomialsBDM<dim>::evaluate(
         grad_grads[i + j * n_sub][j] = p_grad_grads[i];
   }
 
-  // This is the first polynomial not
-  // covered by the P_k subspace
+  // This is the first polynomial not covered by the P_k subspace
   unsigned int start = dim * n_sub;
 
-  // Store values of auxiliary
-  // polynomials and their three
-  // derivatives
+  // Store values of auxiliary polynomials and their three derivatives
   std::vector<std::vector<double>> monovali(dim, std::vector<double>(4));
   std::vector<std::vector<double>> monovalk(dim, std::vector<double>(4));
 
@@ -175,16 +166,11 @@ PolynomialsBDM<dim>::evaluate(
     }
   else // dim == 3
     {
-      // The number of curls in each
-      // component. Note that the
-      // table in BrezziFortin91 has
-      // a typo, but the text has the
-      // right basis
+      // The number of curls in each component. Note that the table in
+      // BrezziFortin91 has a typo, but the text has the right basis
 
-      // Note that the next basis
-      // function is always obtained
-      // from the previous by cyclic
-      // rotation of the coordinates
+      // Note that the next basis function is always obtained from the
+      // previous by cyclic rotation of the coordinates
       const unsigned int n_curls = monomials.size() - 1;
       for (unsigned int i = 0; i < n_curls; ++i, start += dim)
         {
@@ -360,73 +346,6 @@ PolynomialsBDM<dim>::evaluate(
     }
 }
 
-
-/*
-template <int dim>
-void
-PolynomialsBDM<dim>::compute_node_matrix (Table<2,double>& A) const
-{
-  std::vector<Polynomial<double> > moment_weight(2);
-  for (unsigned int i=0;i<moment_weight.size();++i)
-    moment_weight[i] = Monomial<double>(i);
-
-  QGauss<dim-1> qface(polynomial_space.degree()+1);
-
-  std::vector<Tensor<1,dim> > values(n());
-  std::vector<Tensor<2,dim> > grads;
-  std::vector<Tensor<3,dim> > grad_grads;
-  values.resize(n());
-
-  for (unsigned int face=0;face<2*dim;++face)
-    {
-      double orientation = 1.;
-      if ((face==0) || (face==3))
-        orientation = -1.;
-
-      for (unsigned int k=0;k<qface.size();++k)
-        {
-          const double w = qface.weight(k) * orientation;
-          const double x = qface.point(k)(0);
-          Point<dim> p;
-          switch (face)
-            {
-              case 2:
-                p(1) = 1.;
-              case 0:
-                p(0) = x;
-                break;
-              case 1:
-                p(0) = 1.;
-              case 3:
-                p(1) = x;
-                break;
-            }
-//      std::cerr << p
-//                << '\t' << moment_weight[0].value(x)
-//                << '\t' << moment_weight[1].value(x);
-
-          compute (p, values, grads, grad_grads);
-
-          for (unsigned int i=0;i<n();++i)
-            {
-//          std::cerr << '\t' << std::setw(6) << values[i][1-face%2];
-                                               // Integrate normal component.
-                                               // This is easy on the unit
-square for (unsigned int j=0;j<moment_weight.size();++j)
-                A(moment_weight.size()*face+j,i)
-                  += w * values[i][1-face%2] * moment_weight[j].value(x);
-            }
-//      std::cerr << std::endl;
-        }
-    }
-
-                                   // Volume integrals are missing
-                                   //
-                                   // This degree is one larger
-  Assert (polynomial_space.degree() <= 2,
-          ExcNotImplemented());
-}
-*/
 
 template <int dim>
 unsigned int


### PR DESCRIPTION
gcc-12 in release mode will inline the evaluate function into some methods
of the FE_BDM class. It then rightfully complains that the (now modified)
else branch will write out of bounds.

Despite the fact that we instantiate this polynomials class and the related
FE class for 1d this code has never worked. Thus, fail prominently with an
error message.

In reference to #13910