### PR TITLE
CMake: add DEAL_II_CGAL_HAS_DEPRECATED_BOOST_INCLUDES check

### DIFF
--- a/cmake/configure/configure_50_cgal.cmake
+++ b/cmake/configure/configure_50_cgal.cmake
@@ -54,4 +54,27 @@ MACRO(FEATURE_CGAL_FIND_EXTERNAL var)
   ENDIF()
 ENDMACRO()
 
+
+MACRO(FEATURE_CGAL_CONFIGURE_EXTERNAL)
+  # Similarly to the DEAL_II_BOOST_HAS_BROKEN_HEADER_DEPRECATIONS check run
+  # in configure_20_boost.cmake we have to check whether cgal includes
+  # a deprecated boost header. If yes, disable the boost deprecated header
+  # warning as well.
+
+  LIST(APPEND CMAKE_REQUIRED_INCLUDES
+    ${BOOST_INCLUDE_DIRS} ${BOOST_BUNDLED_INCLUDE_DIRS} ${CGAL_INCLUDE_DIRS}
+    )
+
+  CHECK_CXX_COMPILER_BUG(
+    "
+    #define BOOST_CONFIG_HEADER_DEPRECATED_HPP_INCLUDED
+    #define BOOST_HEADER_DEPRECATED(a) _Pragma(\"GCC error \\\"stop compilation\\\"\");
+    #include <CGAL/make_mesh_3.h>
+    int main() { return 0; }
+    "
+    DEAL_II_CGAL_HAS_DEPRECATED_BOOST_INCLUDES)
+
+  RESET_CMAKE_REQUIRED()
+ENDMACRO()
+
 CONFIGURE_FEATURE(CGAL)

--- a/include/deal.II/base/bounding_box_data_out.h
+++ b/include/deal.II/base/bounding_box_data_out.h
@@ -28,14 +28,8 @@
 #include <deal.II/boost_adaptors/segment.h>
 
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
-#ifdef DEAL_II_BOOST_HAS_BROKEN_HEADER_DEPRECATIONS
-#  define BOOST_ALLOW_DEPRECATED_HEADERS
-#endif
 #include <boost/geometry/index/rtree.hpp>
 #include <boost/geometry/strategies/strategies.hpp>
-#ifdef DEAL_II_BOOST_HAS_BROKEN_HEADER_DEPRECATIONS
-#  undef BOOST_ALLOW_DEPRECATED_HEADERS
-#endif
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -233,6 +233,10 @@
 
 /* cmake/configure/configure_2_boost.cmake */
 #cmakedefine DEAL_II_BOOST_HAS_BROKEN_HEADER_DEPRECATIONS
+#ifdef defined(DEAL_II_BOOST_HAS_BROKEN_HEADER_DEPRECATIONS) && \
+  !defined(BOOST_ALLOW_DEPRECATED_HEADERS)
+#  define BOOST_ALLOW_DEPRECATED_HEADERS
+#endif
 
 /* cmake/configure/configure_2_trilinos.cmake */
 #cmakedefine DEAL_II_TRILINOS_CXX_SUPPORTS_SACADO_COMPLEX_RAD

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -231,12 +231,11 @@
 /* cmake/modules/FindSYMENGINE.cmake */
 #cmakedefine DEAL_II_SYMENGINE_WITH_LLVM
 
-/* cmake/configure/configure_2_boost.cmake */
+/* cmake/configure/configure_20_boost.cmake */
 #cmakedefine DEAL_II_BOOST_HAS_BROKEN_HEADER_DEPRECATIONS
-#ifdef defined(DEAL_II_BOOST_HAS_BROKEN_HEADER_DEPRECATIONS) && \
-  !defined(BOOST_ALLOW_DEPRECATED_HEADERS)
-#  define BOOST_ALLOW_DEPRECATED_HEADERS
-#endif
+
+/* cmake/configure/configure_50_cgal.cmake */
+#cmakedefine DEAL_II_CGAL_HAS_DEPRECATED_BOOST_INCLUDES
 
 /* cmake/configure/configure_2_trilinos.cmake */
 #cmakedefine DEAL_II_TRILINOS_CXX_SUPPORTS_SACADO_COMPLEX_RAD
@@ -248,6 +247,12 @@
 #cmakedefine DEAL_II_TRILINOS_WITH_TPETRA
 #cmakedefine DEAL_II_TRILINOS_WITH_ZOLTAN
 
+#if defined(DEAL_II_BOOST_HAS_BROKEN_HEADER_DEPRECATIONS) || \
+  defined(DEAL_II_CGAL_HAS_DEPRECATED_BOOST_INCLUDES)
+#  ifndef BOOST_ALLOW_DEPRECATED_HEADERS
+#    define BOOST_ALLOW_DEPRECATED_HEADERS
+#  endif
+#endif
 
 /***********************************************************************
  * Various macros for version number query and comparison:

--- a/include/deal.II/numerics/rtree.h
+++ b/include/deal.II/numerics/rtree.h
@@ -27,15 +27,8 @@
 
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/geometry/algorithms/distance.hpp>
-
-#ifdef DEAL_II_BOOST_HAS_BROKEN_HEADER_DEPRECATIONS
-#  define BOOST_ALLOW_DEPRECATED_HEADERS
-#endif
 #include <boost/geometry/index/rtree.hpp>
 #include <boost/geometry/strategies/strategies.hpp>
-#ifdef DEAL_II_BOOST_HAS_BROKEN_HEADER_DEPRECATIONS
-#  undef BOOST_ALLOW_DEPRECATED_HEADERS
-#endif
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <memory>


### PR DESCRIPTION
It is back:
```
In file included from /usr/include/boost/smart_ptr/detail/sp_thread_sleep.hpp:22,
                 from /usr/include/boost/smart_ptr/detail/yield_k.hpp:23,
                 from /usr/include/boost/smart_ptr/detail/spinlock_gcc_atomic.hpp:14,
                 from /usr/include/boost/smart_ptr/detail/spinlock.hpp:42,
                 from /usr/include/boost/smart_ptr/detail/spinlock_pool.hpp:25,
                 from /usr/include/boost/smart_ptr/shared_ptr.hpp:29,
                 from /usr/include/boost/property_map/vector_property_map.hpp:14,
                 from /usr/include/boost/property_map/property_map.hpp:606,
                 from /usr/include/CGAL/property_map.h:19,
                 from /usr/include/CGAL/boost/graph/properties.h:16,
                 from /usr/include/CGAL/boost/graph/helpers.h:16,
                 from /usr/include/CGAL/Polygon_mesh_processing/measure.h:22,
                 from test.cc:10:
/usr/include/boost/iterator.hpp:10:1: note: ‘#pragma message: This header is deprecated. Use <iterator> instead.’
   10 | BOOST_HEADER_DEPRECATED("<iterator>")
```

In order to work around the newest set of deprecated header warnings (this
time triggered by CGAL including a deprecated header :-(() I would
otherwise have to add this "#define dance" at various other places.

Instead, it is cleaner to simply give up and define the macro globally.

The configure checks will ensure that the macro is only ever defined if
needed.

In reference to #13910