### PR TITLE
Use pre-compiled structdim for access to TriaObjects in Accessor

### DIFF
--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -612,8 +612,9 @@ namespace internal
       line_index(const TriaAccessor<2, dim, spacedim> &accessor,
                  const unsigned int                    i)
       {
-        return accessor.objects().get_bounding_object_indices(
-          accessor.present_index)[i];
+        constexpr unsigned int max_faces_per_cell = 4;
+        return accessor.objects()
+          .cells[accessor.present_index * max_faces_per_cell + i];
       }
 
 
@@ -651,8 +652,9 @@ namespace internal
       inline static unsigned int
       quad_index(const TriaAccessor<3, 3, 3> &accessor, const unsigned int i)
       {
+        constexpr unsigned int max_faces_per_cell = 6;
         return accessor.tria->levels[accessor.present_level]
-          ->cells.get_bounding_object_indices(accessor.present_index)[i];
+          ->cells.cells[accessor.present_index * max_faces_per_cell + i];
       }
 
 
@@ -1010,8 +1012,9 @@ namespace internal
       vertex_index(const TriaAccessor<1, dim, spacedim> &accessor,
                    const unsigned int                    corner)
       {
-        return accessor.objects().get_bounding_object_indices(
-          accessor.present_index)[corner];
+        constexpr unsigned int max_faces_per_cell = 2;
+        return accessor.objects()
+          .cells[accessor.present_index * max_faces_per_cell + corner];
       }
 
 


### PR DESCRIPTION
A small optimization: For the access to the vertex/line/quad index via the triangulation objects (lines, quads, hexes), we can get the compiler to generate better code if we pull the content of https://github.com/dealii/dealii/blob/38cf3f584366bb27d2d94dd994675011842e8fac/include/deal.II/grid/tria_objects.h#L387-L389 into the place of use - on the one hand, it is not much more code, we rely on the precise storage inside the tria accessors already anyway. The advantage is that `structdim` is `constexpr` there, whereas it is a class variable that needs to be loaded from memory in the previous case.