### PR TITLE
Move implementation of implicit_function() into .cc file

### DIFF
--- a/include/deal.II/cgal/additional_data.h
+++ b/include/deal.II/cgal/additional_data.h
@@ -33,12 +33,14 @@ namespace CGALWrappers
      * corner.
      */
     facet_vertices_on_surface = CGAL::FACET_VERTICES_ON_SURFACE,
+
     /**
      * The three vertices of a facet belonging to a surface patch s have to be
      * on the same surface patch s, on a curve or on a corner.
      */
     facet_vertices_on_same_surface_patch =
       CGAL::FACET_VERTICES_ON_SAME_SURFACE_PATCH,
+
     /**
      * The three vertices of a facet belonging to a surface patch s have to be
      * on the same surface patch s, or on a curve incident to the surface patch
@@ -46,8 +48,6 @@ namespace CGALWrappers
      */
     facet_vertices_on_same_surface_patch_with_adjacency_check =
       CGAL::FACET_VERTICES_ON_SAME_SURFACE_PATCH_WITH_ADJACENCY_CHECK,
-
-
   };
 
   /**
@@ -88,27 +88,46 @@ namespace CGALWrappers
   template <int dim>
   struct AdditionalData
   {
-    // a constant providing a uniform upper bound for the lengths ofcurve edges.
-    // This parameter has to be set to a positive value when1-dimensional
-    // features protection is used.
+    /**
+     * Uniform upper bound for the lengths of curve edges.
+     * This parameter has to be set to a positive value when1-dimensional
+     * features protection is used.
+     */
     double edge_size;
-    //   lower bound for the angles (in degrees) of the surface mesh facets.
+
+    /**
+     * Lower bound for the angles (in degrees) of the surface mesh facets.
+     */
     double facet_angle;
-    // constant describing a uniform upper bound for the radii of the surface
-    // Delaunay balls.
+
+    /**
+     * Uniform upper bound for the radii of the surface Delaunay balls.
+     */
     double facet_size;
-    //  a constant describing a uniform upper bound for the distance between the
-    //  facet circumcenter and the center of its surface Delaunay ball.
+    /**
+     * Uniform upper bound for the distance between the facet circumcenter and
+     * the center of its surface Delaunay ball.
+     */
     double facet_distance;
-    // set of topological constraints which have to be verified by each surface
-    // facet.
+
+    /**
+     * Set of topological constraints which have to be verified by each surface
+     * facet.
+     */
     FacetTopology facet_topology;
-    // upper bound for the radius-edge ratio of the mesh tetrahedra.
+
+    /**
+     * upper bound for the radius-edge ratio of the mesh tetrahedra.
+     */
     double cell_radius_edge_ratio;
-    // a constant describing a uniform upper bound for the circumradii of the
-    // mesh tetrahedra.
+    /**
+     * Uniform upper bound for the circumradii of the mesh tetrahedra.
+     */
     double cell_size;
 
+    /**
+     * Constructor.
+     */
     AdditionalData(
       double        edge_s  = std::numeric_limits<double>::max(),
       double        facet_a = 0.,
@@ -133,8 +152,6 @@ namespace CGALWrappers
     }
   };
 
-
-
   /**
    * Specialization of the above struct when the object to be constructed is a
    * 2D triangulation embedded in the 3D space, i.e. a Triangulation<2,3>.
@@ -151,15 +168,26 @@ namespace CGALWrappers
   template <>
   struct AdditionalData<2>
   {
-    // lower bound in degrees for the angles of mesh facets.
+    /**
+     * Lower bound in degrees for the angles of mesh facets.
+     */
     double angular_bound;
-    // upper bound on the radii of surface Delaunay balls. A surface Delaunay
-    // ball is a ball circumscribing a mesh facet and centered on the surface.
+
+    /**
+     * Upper bound on the radii of surface Delaunay balls. A surface Delaunay
+     * ball is a ball circumscribing a mesh facet and centered on the surface.
+     */
     double radius_bound;
-    // upper bound for the distance between the circumcenter of a mesh facet and
-    // the center of a surface Delaunay ball of this facet.
+
+    /**
+     * Upper bound for the distance between the circumcenter of a mesh facet
+     * and the center of a surface Delaunay ball of this facet.
+     */
     double distance_bound;
 
+    /**
+     * Constructor.
+     */
     AdditionalData(double angular_b  = 0.,
                    double radius_b   = 0.,
                    double distance_b = 0.)
@@ -178,6 +206,9 @@ DEAL_II_NAMESPACE_CLOSE
 DEAL_II_NAMESPACE_OPEN
 namespace CGALWrappers
 {
+  /**
+   * Empty structure for the case where CGAL is not available.
+   */
   template <int dim>
   struct AdditionalData
   {};

--- a/include/deal.II/cgal/additional_data.h
+++ b/include/deal.II/cgal/additional_data.h
@@ -1,0 +1,136 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_cgal_additional_data_h
+#define dealii_cgal_additional_data_h
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_CGAL
+
+#  include <CGAL/boost/graph/Named_function_parameters.h>
+
+DEAL_II_NAMESPACE_OPEN
+namespace CGALWrappers
+{
+  /**
+   * Struct that must be used to pass additional
+   * arguments to the CGAL::Mesh_criteria_3 class (see
+   * https://doc.cgal.org/latest/Mesh_3/index.html for more information.)
+   *
+   * The arguments allow for fine control on the size, quality, and distribution
+   * of the cells of the final triangulation. CGAL uses Boost named parameters
+   * for these arguments in dimension three, i.e., they must be specified with
+   * the syntax `CGAL::parameters::parameter_name=parameter_value`, irrespective
+   * of their order. Accepted parameters are:
+   *
+   * - `CGAL::parameters::edge_size`: a constant
+   * providing a uniform upper bound for the lengths of
+   * curve edges. This parameter has to be set to a positive value when
+   * 1-dimensional features protection is used.
+   * - `CGAL::parameters::facet_angle`: a lower bound for the angles (in
+   * degrees) of the surface mesh facets.
+   * - `CGAL::parameters::facet_size`: a constant
+   * describing a uniform upper bound for the radii
+   * of the surface Delaunay balls.
+   * - `CGAL::parameters::facet_distance`: a constant
+   * describing a uniform upper bound for the distance
+   * between the facet circumcenter and the center of its surface Delaunay ball.
+   * - `CGAL::parameters::facet_topology`: the set of topological constraints
+   * which have to be verified by each surface facet. The default value is
+   * `CGAL::FACET_VERTICES_ON_SURFACE`. See CGAL::Mesh_facet_topology manual
+   * page to get all possible values.
+   * - `CGAL::parameters::cell_radius_edge_ratio`: an upper bound for the
+   * radius-edge ratio of the mesh tetrahedra.
+   * - `CGAL::parameters::cell_size`: a constant
+   * describing a uniform upper bound for the
+   * circumradii of the mesh tetrahedra.
+   *
+   * @note This struct must be instantiated with `dim=3`.
+   */
+  template <int dim>
+  struct AdditionalData
+  {
+    double facet_angle;
+    double facet_size;
+    double facet_distance;
+    double cell_radius_edge_ratio;
+    double cell_size;
+
+    AdditionalData(
+      double facet_a            = CGAL::parameters::is_default_parameter(true),
+      double facet_s            = CGAL::parameters::is_default_parameter(true),
+      double facet_d            = CGAL::parameters::is_default_parameter(true),
+      double cell_radius_edge_r = CGAL::parameters::is_default_parameter(true),
+      double cell_s             = CGAL::parameters::is_default_parameter(true))
+    {
+      AssertThrow(
+        dim == 3,
+        ExcMessage(
+          "These struct can be instantiated with 3D Triangulations only."));
+      facet_angle            = facet_a;
+      facet_size             = facet_s;
+      facet_distance         = facet_d;
+      cell_radius_edge_ratio = cell_radius_edge_r;
+      cell_size              = cell_s;
+    }
+  };
+
+
+
+  /**
+   * Specialization of the above struct when the object to be constructed is a
+   * 2D triangulation embedded in the 3D space, i.e. a Triangulation<2,3>.
+   * Only three parameters are accepted:
+   * - `angular_bound` is a lower bound in degrees for the angles of mesh
+   * facets.
+   * - `radius_bound` is an upper bound on the radii of surface Delaunay balls.
+   * A surface Delaunay ball is a ball circumscribing a mesh facet and centered
+   * on the surface.
+   * - `distance_bound` is an upper bound for the distance between the
+   * circumcenter of a mesh facet and the center of a surface Delaunay ball of
+   * this facet.
+   */
+  template <>
+  struct AdditionalData<2>
+  {
+    double angular_bound, radius_bound, distance_bound;
+    AdditionalData(double angular_b  = 0.,
+                   double radius_b   = 0.,
+                   double distance_b = 0.)
+    {
+      angular_bound  = angular_b;
+      radius_bound   = radius_b;
+      distance_bound = distance_b;
+    }
+  };
+
+} // namespace CGALWrappers
+DEAL_II_NAMESPACE_CLOSE
+
+#else
+
+DEAL_II_NAMESPACE_OPEN
+namespace CGALWrappers
+{
+  template <int dim>
+  struct AdditionalData
+  {};
+} // namespace CGALWrappers
+
+DEAL_II_NAMESPACE_CLOSE
+#endif
+
+#endif

--- a/include/deal.II/cgal/triangulation.h
+++ b/include/deal.II/cgal/triangulation.h
@@ -18,17 +18,32 @@
 
 #include <deal.II/base/config.h>
 
-#ifdef DEAL_II_WITH_CGAL
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/function.h>
 
-#  include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/cgal/utilities.h>
+
+#ifdef DEAL_II_WITH_CGAL
 
 #  include <boost/hana.hpp>
 
+#  include <CGAL/Complex_2_in_triangulation_3.h>
+#  include <CGAL/IO/facets_in_complex_2_to_triangle_mesh.h>
+#  include <CGAL/Implicit_surface_3.h>
+#  include <CGAL/Labeled_mesh_domain_3.h>
+#  include <CGAL/Mesh_complex_3_in_triangulation_3.h>
+#  include <CGAL/Mesh_criteria_3.h>
+#  include <CGAL/Mesh_triangulation_3.h>
 #  include <CGAL/Polyhedron_3.h>
 #  include <CGAL/Surface_mesh.h>
+#  include <CGAL/Surface_mesh_default_triangulation_3.h>
 #  include <CGAL/Triangulation_2.h>
 #  include <CGAL/Triangulation_3.h>
-#  include <deal.II/cgal/utilities.h>
+#  include <CGAL/make_mesh_3.h>
+#  include <CGAL/make_surface_mesh.h>
+#  include <deal.II/cgal/surface_mesh.h>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -256,8 +271,8 @@ namespace CGALWrappers
             // A face is identified by a cell and by the index within the cell
             // of the opposite vertex. Loop over vertices, and retain only those
             // that belong to this face.
-            unsigned int j = 0;
-            for (unsigned int i = 0; i < 4; ++i)
+            int j = 0;
+            for (int i = 0; i < 4; ++i)
               if (i != cgal_vertex_face_index)
                 dealii_face.vertices[j++] =
                   cgal_to_dealii_vertex_map[cgal_cell->vertex(i)];
@@ -545,8 +560,8 @@ namespace CGALWrappers
       }
     triangulation.create_triangulation(vertices, cells, subcell_data);
   }
-#  endif
 } // namespace CGALWrappers
+#  endif // doxygen
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/include/deal.II/cgal/utilities.h
+++ b/include/deal.II/cgal/utilities.h
@@ -18,6 +18,8 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/cgal/additional_data.h>
+
 #ifdef DEAL_II_WITH_CGAL
 #  include <deal.II/base/quadrature_lib.h>
 
@@ -111,100 +113,6 @@ namespace CGALWrappers
      * @image html boolean_union.png
      */
     compute_union = 1 << 3,
-  };
-
-
-
-  /**
-   * Struct that must be used to pass additional
-   * arguments to the CGAL::Mesh_criteria_3 class (see
-   * https://doc.cgal.org/latest/Mesh_3/index.html for more information.)
-   *
-   * The arguments allow for fine control on the size, quality, and distribution
-   * of the cells of the final triangulation. CGAL uses Boost named parameters
-   * for these arguments in dimension three, i.e., they must be specified with
-   * the syntax `CGAL::parameters::parameter_name=parameter_value`, irrespective
-   * of their order. Accepted parameters are:
-   *
-   * - `CGAL::parameters::edge_size`: a constant
-   * providing a uniform upper bound for the lengths of
-   * curve edges. This parameter has to be set to a positive value when
-   * 1-dimensional features protection is used.
-   * - `CGAL::parameters::facet_angle`: a lower bound for the angles (in
-   * degrees) of the surface mesh facets.
-   * - `CGAL::parameters::facet_size`: a constant
-   * describing a uniform upper bound for the radii
-   * of the surface Delaunay balls.
-   * - `CGAL::parameters::facet_distance`: a constant
-   * describing a uniform upper bound for the distance
-   * between the facet circumcenter and the center of its surface Delaunay ball.
-   * - `CGAL::parameters::facet_topology`: the set of topological constraints
-   * which have to be verified by each surface facet. The default value is
-   * `CGAL::FACET_VERTICES_ON_SURFACE`. See CGAL::Mesh_facet_topology manual
-   * page to get all possible values.
-   * - `CGAL::parameters::cell_radius_edge_ratio`: an upper bound for the
-   * radius-edge ratio of the mesh tetrahedra.
-   * - `CGAL::parameters::cell_size`: a constant
-   * describing a uniform upper bound for the
-   * circumradii of the mesh tetrahedra.
-   *
-   * @note This struct must be instantiated with `dim=3`.
-   */
-  template <int dim>
-  struct AdditionalData
-  {
-    double facet_angle;
-    double facet_size;
-    double facet_distance;
-    double cell_radius_edge_ratio;
-    double cell_size;
-
-    AdditionalData(
-      double facet_a            = CGAL::parameters::is_default_parameter(true),
-      double facet_s            = CGAL::parameters::is_default_parameter(true),
-      double facet_d            = CGAL::parameters::is_default_parameter(true),
-      double cell_radius_edge_r = CGAL::parameters::is_default_parameter(true),
-      double cell_s             = CGAL::parameters::is_default_parameter(true))
-    {
-      AssertThrow(
-        dim == 3,
-        ExcMessage(
-          "These struct can be instantiated with 3D Triangulations only."));
-      facet_angle            = facet_a;
-      facet_size             = facet_s;
-      facet_distance         = facet_d;
-      cell_radius_edge_ratio = cell_radius_edge_r;
-      cell_size              = cell_s;
-    }
-  };
-
-
-
-  /**
-   * Specialization of the above struct when the object to be constructed is a
-   * 2D triangulation embedded in the 3D space, i.e. a Triangulation<2,3>.
-   * Only three parameters are accepted:
-   * - `angular_bound` is a lower bound in degrees for the angles of mesh
-   * facets.
-   * - `radius_bound` is an upper bound on the radii of surface Delaunay balls.
-   * A surface Delaunay ball is a ball circumscribing a mesh facet and centered
-   * on the surface.
-   * - `distance_bound` is an upper bound for the distance between the
-   * circumcenter of a mesh facet and the center of a surface Delaunay ball of
-   * this facet.
-   */
-  template <>
-  struct AdditionalData<2>
-  {
-    double angular_bound, radius_bound, distance_bound;
-    AdditionalData(double angular_b  = 0.,
-                   double radius_b   = 0.,
-                   double distance_b = 0.)
-    {
-      angular_bound  = angular_b;
-      radius_bound   = radius_b;
-      distance_bound = distance_b;
-    }
   };
 
 

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -28,22 +28,7 @@
 #include <deal.II/grid/reference_cell.h>
 #include <deal.II/grid/tria.h>
 
-#ifdef DEAL_II_WITH_CGAL
-// All functions needed by the CGAL mesh generation utilities
-#  include <CGAL/Complex_2_in_triangulation_3.h>
-#  include <CGAL/IO/facets_in_complex_2_to_triangle_mesh.h>
-#  include <CGAL/Implicit_surface_3.h>
-#  include <CGAL/Labeled_mesh_domain_3.h>
-#  include <CGAL/Mesh_complex_3_in_triangulation_3.h>
-#  include <CGAL/Mesh_criteria_3.h>
-#  include <CGAL/Mesh_triangulation_3.h>
-#  include <CGAL/Surface_mesh.h>
-#  include <CGAL/Surface_mesh_default_triangulation_3.h>
-#  include <CGAL/make_mesh_3.h>
-#  include <CGAL/make_surface_mesh.h>
-#  include <deal.II/cgal/triangulation.h>
-#  include <deal.II/cgal/utilities.h>
-#endif
+#include <deal.II/cgal/additional_data.h>
 
 #include <array>
 #include <map>
@@ -1765,7 +1750,6 @@ namespace GridGenerator
     const std::string &           grid_generator_function_name,
     const std::string &           grid_generator_function_arguments);
 
-#ifdef DEAL_II_WITH_CGAL
   /**
    * Generate a Triangulation from the zero level set of an implicit function,
    * using the CGAL library.
@@ -1823,7 +1807,6 @@ namespace GridGenerator
                       CGALWrappers::AdditionalData<dim>{},
                     const Point<3> &interior_point    = Point<3>(),
                     const double &  outer_ball_radius = 1.0);
-#endif
   ///@}
 
   /**
@@ -2733,110 +2716,7 @@ namespace GridGenerator
                         const double,
                         const bool);
 
-#  ifdef DEAL_II_WITH_CGAL
-  template <int dim>
-  void
-  implicit_function(Triangulation<dim, 3> &tria,
-                    const Function<3> &    dealii_implicit_function,
-                    const CGALWrappers::AdditionalData<dim> &data,
-                    const Point<3> &                         interior_point,
-                    const double &                           outer_ball_radius)
-  {
-    Assert(dealii_implicit_function.n_components == 1,
-           ExcMessage(
-             "The implicit function must have exactly one component."));
-    Assert(dealii_implicit_function.value(interior_point) < 0,
-           ExcMessage(
-             "The implicit function must be negative at the interior point."));
-    Assert(outer_ball_radius > 0,
-           ExcMessage("The outer ball radius must be positive."));
-    Assert(tria.n_active_cells() == 0,
-           ExcMessage("The triangulation must be empty."));
 
-    if constexpr (dim == 3)
-      {
-        using K          = CGAL::Exact_predicates_inexact_constructions_kernel;
-        using NumberType = K::FT;
-        using Point_3    = K::Point_3;
-        using Sphere_3   = K::Sphere_3;
-
-        using Mesh_domain = CGAL::Labeled_mesh_domain_3<K>;
-        using Tr =
-          CGAL::Mesh_triangulation_3<Mesh_domain,
-                                     CGAL::Default,
-                                     CGALWrappers::ConcurrencyTag>::type;
-        using C3t3 = CGAL::Mesh_complex_3_in_triangulation_3<Tr, int, int>;
-        using Mesh_criteria = CGAL::Mesh_criteria_3<Tr>;
-
-
-        auto cgal_implicit_function = [&](const Point_3 &p) {
-          return NumberType(
-            dealii_implicit_function.value(Point<3>(p.x(), p.y(), p.z())));
-        };
-
-        Mesh_domain domain = Mesh_domain::create_implicit_mesh_domain(
-          cgal_implicit_function,
-          K::Sphere_3(
-            Point_3(interior_point[0], interior_point[1], interior_point[2]),
-            outer_ball_radius * outer_ball_radius));
-
-        Mesh_criteria criteria(CGAL::parameters::facet_size  = data.facet_size,
-                               CGAL::parameters::facet_angle = data.facet_angle,
-                               CGAL::parameters::facet_distance =
-                                 data.facet_distance,
-                               CGAL::parameters::cell_radius_edge_ratio =
-                                 data.cell_radius_edge_ratio,
-                               CGAL::parameters::cell_size = data.cell_size);
-
-        auto cgal_triangulation = CGAL::make_mesh_3<C3t3>(domain, criteria);
-        CGALWrappers::cgal_triangulation_to_dealii_triangulation(
-          cgal_triangulation, tria);
-      }
-    else if constexpr (dim == 2)
-      {
-        // default triangulation for Surface_mesher
-        using Tr       = CGAL::Surface_mesh_default_triangulation_3;
-        using C2t3     = CGAL::Complex_2_in_triangulation_3<Tr>;
-        using GT       = Tr::Geom_traits;
-        using Sphere_3 = GT::Sphere_3;
-        using Point_3  = GT::Point_3;
-        using FT       = GT::FT;
-        typedef FT (*Function)(Point_3);
-        using Surface_3    = CGAL::Implicit_surface_3<GT, Function>;
-        using Surface_mesh = CGAL::Surface_mesh<Point_3>;
-
-
-        auto cgal_implicit_function = [&](const Point_3 &p) {
-          return FT(
-            dealii_implicit_function.value(Point<3>(p.x(), p.y(), p.z())));
-        };
-
-        Surface_3 surface(cgal_implicit_function,
-                          Sphere_3(Point_3(interior_point[0],
-                                           interior_point[1],
-                                           interior_point[2]),
-                                   outer_ball_radius * outer_ball_radius));
-
-        Tr           tr;
-        C2t3         c2t3(tr);
-        Surface_mesh mesh;
-
-        CGAL::Surface_mesh_default_criteria_3<Tr> criteria(data.angular_bound,
-                                                           data.radius_bound,
-                                                           data.distance_bound);
-        CGAL::make_surface_mesh(c2t3,
-                                surface,
-                                criteria,
-                                CGAL::Non_manifold_tag());
-        CGAL::facets_in_complex_2_to_triangle_mesh(c2t3, mesh);
-        CGALWrappers::cgal_surface_mesh_to_dealii_triangulation(mesh, tria);
-      }
-    else
-      {
-        Assert(false, ExcImpossibleInDim(dim));
-      }
-  }
-#  endif
 
 #endif
 } // namespace GridGenerator

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -31,6 +31,11 @@
 
 #include <deal.II/physics/transformations.h>
 
+#ifdef DEAL_II_WITH_CGAL
+// Functions needed by the CGAL mesh generation utilities are inside
+#  include <deal.II/cgal/triangulation.h>
+#endif
+
 #include <array>
 #include <cmath>
 #include <limits>
@@ -8639,6 +8644,122 @@ namespace GridGenerator
       }
   }
 
+
+
+  template <int dim>
+  void
+  implicit_function(Triangulation<dim, 3> &tria,
+                    const Function<3> &    dealii_implicit_function,
+                    const CGALWrappers::AdditionalData<dim> &data,
+                    const Point<3> &                         interior_point,
+                    const double &                           outer_ball_radius)
+  {
+#  ifdef DEAL_II_WITH_CGAL
+    Assert(dealii_implicit_function.n_components == 1,
+           ExcMessage(
+             "The implicit function must have exactly one component."));
+    Assert(dealii_implicit_function.value(interior_point) < 0,
+           ExcMessage(
+             "The implicit function must be negative at the interior point."));
+    Assert(outer_ball_radius > 0,
+           ExcMessage("The outer ball radius must be positive."));
+    Assert(tria.n_active_cells() == 0,
+           ExcMessage("The triangulation must be empty."));
+
+    if constexpr (dim == 3)
+      {
+        using K          = CGAL::Exact_predicates_inexact_constructions_kernel;
+        using NumberType = K::FT;
+        using Point_3    = K::Point_3;
+        using Sphere_3   = K::Sphere_3;
+
+        using Mesh_domain = CGAL::Labeled_mesh_domain_3<K>;
+        using Tr =
+          CGAL::Mesh_triangulation_3<Mesh_domain,
+                                     CGAL::Default,
+                                     CGALWrappers::ConcurrencyTag>::type;
+        using C3t3 = CGAL::Mesh_complex_3_in_triangulation_3<Tr, int, int>;
+        using Mesh_criteria = CGAL::Mesh_criteria_3<Tr>;
+
+
+        auto cgal_implicit_function = [&](const Point_3 &p) {
+          return NumberType(
+            dealii_implicit_function.value(Point<3>(p.x(), p.y(), p.z())));
+        };
+
+        Mesh_domain domain = Mesh_domain::create_implicit_mesh_domain(
+          cgal_implicit_function,
+          K::Sphere_3(
+            Point_3(interior_point[0], interior_point[1], interior_point[2]),
+            outer_ball_radius * outer_ball_radius));
+
+        Mesh_criteria criteria(CGAL::parameters::facet_size  = data.facet_size,
+                               CGAL::parameters::facet_angle = data.facet_angle,
+                               CGAL::parameters::facet_distance =
+                                 data.facet_distance,
+                               CGAL::parameters::cell_radius_edge_ratio =
+                                 data.cell_radius_edge_ratio,
+                               CGAL::parameters::cell_size = data.cell_size);
+
+        auto cgal_triangulation = CGAL::make_mesh_3<C3t3>(domain, criteria);
+        CGALWrappers::cgal_triangulation_to_dealii_triangulation(
+          cgal_triangulation, tria);
+      }
+    else if constexpr (dim == 2)
+      {
+        // default triangulation for Surface_mesher
+        using Tr       = CGAL::Surface_mesh_default_triangulation_3;
+        using C2t3     = CGAL::Complex_2_in_triangulation_3<Tr>;
+        using GT       = Tr::Geom_traits;
+        using Sphere_3 = GT::Sphere_3;
+        using Point_3  = GT::Point_3;
+        using FT       = GT::FT;
+        typedef FT (*Function)(Point_3);
+        using Surface_3    = CGAL::Implicit_surface_3<GT, Function>;
+        using Surface_mesh = CGAL::Surface_mesh<Point_3>;
+
+
+        auto cgal_implicit_function = [&](const Point_3 &p) {
+          return FT(
+            dealii_implicit_function.value(Point<3>(p.x(), p.y(), p.z())));
+        };
+
+        Surface_3 surface(cgal_implicit_function,
+                          Sphere_3(Point_3(interior_point[0],
+                                           interior_point[1],
+                                           interior_point[2]),
+                                   outer_ball_radius * outer_ball_radius));
+
+        Tr           tr;
+        C2t3         c2t3(tr);
+        Surface_mesh mesh;
+
+        CGAL::Surface_mesh_default_criteria_3<Tr> criteria(data.angular_bound,
+                                                           data.radius_bound,
+                                                           data.distance_bound);
+        CGAL::make_surface_mesh(c2t3,
+                                surface,
+                                criteria,
+                                CGAL::Non_manifold_tag());
+        CGAL::facets_in_complex_2_to_triangle_mesh(c2t3, mesh);
+        CGALWrappers::cgal_surface_mesh_to_dealii_triangulation(mesh, tria);
+      }
+    else
+      {
+        Assert(false, ExcImpossibleInDim(dim));
+      }
+
+#  else
+
+    (void)tria;
+    (void)dealii_implicit_function;
+    (void)data;
+    (void)interior_point;
+    (void)outer_ball_radius;
+    AssertThrow(false, ExcMessage("This function needs CGAL to be installed."));
+
+#  endif
+  }
 } // namespace GridGenerator
 
 // explicit instantiations

--- a/source/grid/grid_generator.inst.in
+++ b/source/grid/grid_generator.inst.in
@@ -228,6 +228,14 @@ for (deal_II_dimension : DIMENSIONS)
       hyper_ball_balanced<deal_II_dimension>(Triangulation<deal_II_dimension> &,
                                              const Point<deal_II_dimension> &,
                                              const double);
+
+      template void
+      implicit_function<deal_II_dimension>(
+        Triangulation<deal_II_dimension, 3> &,
+        const Function<3> &,
+        const CGALWrappers::AdditionalData<deal_II_dimension> &,
+        const Point<3> &,
+        const double &);
 #endif
     \}
   }

--- a/tests/cgal/implicit_triangulation_01.cc
+++ b/tests/cgal/implicit_triangulation_01.cc
@@ -25,7 +25,6 @@
 
 #include "../tests.h"
 
-using namespace CGAL::parameters;
 
 class ImplicitFunction : public Function<3>
 {
@@ -54,7 +53,7 @@ main()
     std::ofstream of("tria.vtk");
     go.write_vtk(tria, of);
   }
-  // remove(/"tria.vtk");
+  remove("tria.vtk");
   //  If we got here, everything was ok, including writing the grid.
   deallog << "OK" << std::endl;
 }

--- a/tests/cgal/implicit_triangulation_02.cc
+++ b/tests/cgal/implicit_triangulation_02.cc
@@ -25,7 +25,6 @@
 
 #include "../tests.h"
 
-using namespace CGAL::parameters;
 
 class ImplicitFunction : public Function<3>
 {
@@ -53,7 +52,7 @@ main()
     tria, implicit_function, data, Point<3>(1, 0, 0), 10.);
   {
     GridOut       go;
-    std::ofstream of("tria_ancora.vtk");
+    std::ofstream of("tria.vtk");
     go.write_vtk(tria, of);
   }
   remove("tria.vtk");


### PR DESCRIPTION
This moves the implementation of `GridGenerator::implicit_function()` inside grid_generator.cc and adds the corresponding stub. 

To fix some issues with headers, this depends on #13929 , only be572d68043d2c1c78c8d324e55893eb908eb86c should be looked at.