### PR TITLE
Fix some test typenames for GCC-12.

### DIFF
--- a/tests/algorithms/general_data_storage_01.output.gcc-12
+++ b/tests/algorithms/general_data_storage_01.output.gcc-12
@@ -1,0 +1,75 @@
+
+DEAL::Add by copy
+DEAL::Size: 2
+DEAL::Add by reference
+DEAL::Size: 2
+DEAL::Add or construct
+DEAL::Size: 1
+DEAL::Merge
+DEAL::Data pre-merge:
+DEAL::value		double
+DEAL::Size: 1
+DEAL::Data 2 pre-merge:
+DEAL::value		double
+DEAL::value_2		double
+DEAL::Size: 2
+DEAL::Data post-merge:
+DEAL::value		double
+DEAL::value_2		double
+DEAL::Size: 2
+DEAL::Ambiguous construction
+DEAL::Try to overwrite existing entry: Copy
+DEAL::
+--------------------------------------------------------
+An error occurred in file <general_data_storage.h> in function
+    void dealii::GeneralDataStorage::add_unique_copy(const std::string&, const Type&) [with Type = double; std::string = std::__cxx11::basic_string<char>]
+The violated condition was: 
+    !stores_object_with_name(name)
+Additional information: 
+    An entry with the name value already exists.
+--------------------------------------------------------
+
+DEAL::Try to overwrite existing entry: Reference
+DEAL::
+--------------------------------------------------------
+An error occurred in file <general_data_storage.h> in function
+    void dealii::GeneralDataStorage::add_unique_reference(const std::string&, Type&) [with Type = const double; std::string = std::__cxx11::basic_string<char>]
+The violated condition was: 
+    !stores_object_with_name(name)
+Additional information: 
+    An entry with the name value already exists.
+--------------------------------------------------------
+
+DEAL::Fetch non-existing entry
+DEAL::
+--------------------------------------------------------
+An error occurred in file <general_data_storage.h> in function
+    Type& dealii::GeneralDataStorage::get_object_with_name(const std::string&) [with Type = double; std::string = std::__cxx11::basic_string<char>]
+The violated condition was: 
+    stores_object_with_name(name)
+Additional information: 
+    No entry with the name value exists.
+--------------------------------------------------------
+
+DEAL::Access removed entry (reference)
+DEAL::
+--------------------------------------------------------
+An error occurred in file <general_data_storage.h> in function
+    Type& dealii::GeneralDataStorage::get_object_with_name(const std::string&) [with Type = double; std::string = std::__cxx11::basic_string<char>]
+The violated condition was: 
+    stores_object_with_name(name)
+Additional information: 
+    No entry with the name value exists.
+--------------------------------------------------------
+
+DEAL::Access removed entry (copy)
+DEAL::
+--------------------------------------------------------
+An error occurred in file <general_data_storage.h> in function
+    Type& dealii::GeneralDataStorage::get_object_with_name(const std::string&) [with Type = double; std::string = std::__cxx11::basic_string<char>]
+The violated condition was: 
+    stores_object_with_name(name)
+Additional information: 
+    No entry with the name value exists.
+--------------------------------------------------------
+

--- a/tests/base/unsubscribe_subscriptor.debug.output.gcc-12
+++ b/tests/base/unsubscribe_subscriptor.debug.output.gcc-12
@@ -1,0 +1,25 @@
+
+DEAL::Exception: ExcNoSubscriber(object_info->name(), name)
+DEAL::
+--------------------------------------------------------
+An error occurred in file <subscriptor.cc> in function
+    void dealii::Subscriptor::unsubscribe(std::atomic<bool>*, const std::string&) const
+The violated condition was: 
+    it != counter_map.end()
+Additional information: 
+    No subscriber with identifier <b> subscribes to this object of class
+    N6dealii11SubscriptorE. Consequently, it cannot be unsubscribed.
+--------------------------------------------------------
+
+DEAL::Exception: ExcMessage( "This Subscriptor object does not know anything about the supplied pointer!")
+DEAL::
+--------------------------------------------------------
+An error occurred in file <subscriptor.cc> in function
+    void dealii::Subscriptor::unsubscribe(std::atomic<bool>*, const std::string&) const
+The violated condition was: 
+    validity_ptr_it != validity_pointers.end()
+Additional information: 
+    This Subscriptor object does not know anything about the supplied
+    pointer!
+--------------------------------------------------------
+

--- a/tests/parameter_handler/parameter_handler_25.output.gcc-12
+++ b/tests/parameter_handler/parameter_handler_25.output.gcc-12
@@ -1,0 +1,31 @@
+
+DEAL::
+DEAL::successful
+DEAL::
+--------------------------------------------------------
+An error occurred in file <parameter_handler.cc> in function
+    void dealii::ParameterHandler::set(const std::string&, const std::string&)
+The violated condition was: 
+    false
+Additional information: 
+    You can't ask for entry <Precison> you have not yet declared.
+--------------------------------------------------------
+
+DEAL::
+--------------------------------------------------------
+An error occurred in file <parameter_handler.cc> in function
+    void dealii::ParameterHandler::assert_that_entries_have_been_set() const
+The violated condition was: 
+    entries_wrongly_not_set.size() == 0
+Additional information: 
+    Not all entries of the parameter handler that were declared with
+    `has_to_be_set = true` have been set. The following parameters
+    
+    General.Precision
+    General.dim
+    
+    have not been set. A possible reason might be that you did not add
+    these parameter to the input file or that their spelling is not
+    correct.
+--------------------------------------------------------
+


### PR DESCRIPTION
GCC now identifies the function correctly with arguments of type `std::string` instead of just `string`.

In reference to #13703 