### PR TITLE
Fix TriaAccessor::is_ghost_on_level for case without MPI

### DIFF
--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -2228,17 +2228,6 @@ CellAccessor<dim, spacedim>::set_subdomain_id(
 
 
 template <int dim, int spacedim>
-types::subdomain_id
-CellAccessor<dim, spacedim>::level_subdomain_id() const
-{
-  Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
-  return this->tria->levels[this->present_level]
-    ->level_subdomain_ids[this->present_index];
-}
-
-
-
-template <int dim, int spacedim>
 void
 CellAccessor<dim, spacedim>::set_level_subdomain_id(
   const types::subdomain_id new_level_subdomain_id) const

--- a/tests/multigrid/is_locally_owned_on_level.cc
+++ b/tests/multigrid/is_locally_owned_on_level.cc
@@ -1,0 +1,74 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check CellAccessor::is_locally_owned_on_level and is_ghost_on_level for a
+// serial triangulation (where trivially all cells are locally owned and none
+// is ghosted/artificial), going through a code path that is not tested
+// otherwise
+
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+
+#include "../tests.h"
+
+
+
+template <int dim>
+void
+test()
+{
+  Triangulation<dim> tr;
+
+  GridGenerator::subdivided_hyper_cube(tr, 2);
+
+  for (const auto &cell : tr.cell_iterators())
+    {
+      if (cell->is_locally_owned_on_level())
+        {
+          deallog << cell << ": locally owned" << std::endl;
+          Assert(!cell->is_ghost_on_level() && !cell->is_artificial_on_level(),
+                 ExcInternalError());
+        }
+      if (cell->is_ghost_on_level())
+        {
+          deallog << cell << ": ghost" << std::endl;
+          Assert(!cell->is_locally_owned_on_level() &&
+                   !cell->is_artificial_on_level(),
+                 ExcInternalError());
+        }
+      if (cell->is_artificial_on_level())
+        {
+          deallog << cell << ": artificial" << std::endl;
+          Assert(!cell->is_locally_owned_on_level() &&
+                   !cell->is_ghost_on_level(),
+                 ExcInternalError());
+        }
+    }
+}
+
+
+int
+main()
+{
+  initlog();
+  test<2>();
+}

--- a/tests/multigrid/is_locally_owned_on_level.output
+++ b/tests/multigrid/is_locally_owned_on_level.output
@@ -1,0 +1,5 @@
+
+DEAL::0.0: locally owned
+DEAL::0.1: locally owned
+DEAL::0.2: locally owned
+DEAL::0.3: locally owned


### PR DESCRIPTION
While looking at some functions, I realized that `TriaAccessor::is_ghost_on_level()` would return true in case MPI is disabled. This is inconsistent with https://github.com/dealii/dealii/blob/99afe8a202cb9d536d3952d3d3901adf1dc18da2/include/deal.II/grid/tria_accessor.templates.h#L3768-L3770 and https://github.com/dealii/dealii/blob/99afe8a202cb9d536d3952d3d3901adf1dc18da2/include/deal.II/grid/tria_accessor.templates.h#L3741-L3745 so fix it. I guess we never really look into that function without MPI.

While there, I also clean up some access functions
- the compiler cannot see whether the virtual function `locally_owned_subdomain` has side effects, so we should only call it once when querying ghost state
- we should inline a frequently used function regarding the level cell subdomain, in analogy to the active cell subdomain.

I am tagging for the 9.4 release because this fixes a bug. The subdomain ids could be put aside if so desired, but I feel they are so well-tested and hence a modification is safe, given that I should not change any functionality.