### PR TITLE
Simplify access to number of raw objects

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -4669,9 +4669,7 @@ namespace GridTools
       cell_filter,
       [&](const auto &process) {
         for (const auto &cell : mesh.cell_iterators())
-          if (cell->level_subdomain_id() !=
-                dealii::numbers::artificial_subdomain_id &&
-              !cell->is_locally_owned_on_level())
+          if (cell->is_ghost_on_level())
             process(cell, cell->level_subdomain_id());
       },
       [](const auto &tria) { return tria.level_ghost_owners(); });

--- a/include/deal.II/grid/tria_objects.h
+++ b/include/deal.II/grid/tria_objects.h
@@ -373,9 +373,10 @@ namespace internal
     inline unsigned int
     TriaObjects::n_objects() const
     {
-      // assume that each cell has the same number of faces
-      const unsigned int faces_per_cell = 2 * this->structdim;
-      return cells.size() / faces_per_cell;
+      // ensure that sizes are consistent, and then return one that
+      // corresponds to the number of objects
+      AssertDimension(cells.size(), manifold_id.size() * 2 * this->structdim);
+      return manifold_id.size();
     }
 
 


### PR DESCRIPTION
I observed that our `TriaAccessor::operator++` is doing a division. Looking for the cause, I found https://github.com/dealii/dealii/blob/99afe8a202cb9d536d3952d3d3901adf1dc18da2/include/deal.II/grid/tria_objects.h#L374-L378 which was introduced when extending functionality for simplices in #10329. Similar improvement as #13931, but here we can simply use one of the other arrays that should have the same length.