### PR TITLE
DoFAccessor: Run process_dof_indices only on FE entities with DoFs

### DIFF
--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -1033,9 +1033,10 @@ namespace internal
         unsigned int index = 0;
 
         // 1) VERTEX dofs
-        for (const auto vertex : accessor.vertex_indices())
-          dof_operation.process_vertex_dofs(
-            accessor, vertex, index, dof_indices, fe_index, dof_processor);
+        if (fe.n_dofs_per_vertex() > 0)
+          for (const auto vertex : accessor.vertex_indices())
+            dof_operation.process_vertex_dofs(
+              accessor, vertex, index, dof_indices, fe_index, dof_processor);
 
         // 2) copy dof numbers from the LINE. for lines with the wrong
         // orientation (which might occur in 3d), we have already made sure that
@@ -1044,7 +1045,7 @@ namespace internal
         // orientation, we look at it in flipped orientation and we will have to
         // adjust the shape function indices that we see to correspond to the
         // correct (face/cell-local) ordering.
-        if (structdim == 2 || structdim == 3)
+        if ((structdim == 2 || structdim == 3) && fe.n_dofs_per_line() > 0)
           for (const auto line : accessor.line_indices())
             dof_operation.process_dofs(
               *accessor.line(line),
@@ -1065,7 +1066,7 @@ namespace internal
         // adjust the shape function indices that we see to correspond to the
         // correct (cell-local) ordering. The same applies, if the face_rotation
         // or face_orientation is non-standard
-        if (structdim == 3)
+        if (structdim == 3 && fe.max_dofs_per_quad() > 0)
           for (const auto quad : accessor.face_indices())
             dof_operation.process_dofs(
               *accessor.quad(quad),
@@ -1083,13 +1084,14 @@ namespace internal
               dof_processor);
 
         // 4) INNER dofs
-        dof_operation.process_dofs(
-          accessor,
-          [&](const auto d) { return d; },
-          index,
-          dof_indices,
-          fe_index,
-          dof_processor);
+        if (fe.template n_dofs_per_object<structdim>() > 0)
+          dof_operation.process_dofs(
+            accessor,
+            [&](const auto d) { return d; },
+            index,
+            dof_indices,
+            fe_index,
+            dof_processor);
 
         AssertDimension(n_dof_indices(accessor, fe_index, count_level_dofs),
                         index);

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -1032,7 +1032,8 @@ namespace internal
 
         unsigned int index = 0;
 
-        // 1) VERTEX dofs
+        // 1) VERTEX dofs, only step into the functions if we actually have
+        // DoFs on them
         if (fe.n_dofs_per_vertex() > 0)
           for (const auto vertex : accessor.vertex_indices())
             dof_operation.process_vertex_dofs(
@@ -1108,8 +1109,13 @@ namespace internal
                   dof_processor);
             }
 
-        // 4) INNER dofs
-        if (fe.template n_dofs_per_object<structdim>() > 0)
+        // 4) INNER dofs - here we need to make sure that the shortcut to not
+        // run the function does not miss the faces of wedge and pyramid
+        // elements where n_dofs_per_object might not return the largest
+        // possible value
+        if (((dim == 3 && structdim == 2) ?
+               fe.max_dofs_per_quad() :
+               fe.template n_dofs_per_object<structdim>()) > 0)
           dof_operation.process_dofs(
             accessor,
             [&](const auto d) { return d; },


### PR DESCRIPTION
This PR is based on the observation that iterating through lines of a cell in 3D is quite expensive. If there are no DoFs on certain entities (e.g., because all DoFs sit on vertices for bi-/tri-linear elements), we do not need to step into the other parts. Note that once #13924 is reviewed and merged, I will use the ability to extract those line indices in the `DoFAccessor` as well.