### PR TITLE
MatrixFree: Fix element-centric loops with different cell geometry compression

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -8189,8 +8189,9 @@ FEFaceEvaluation<dim,
     return;
   Assert(this->matrix_free != nullptr, ExcNotInitialized());
 
-  this->cell_type = this->matrix_free->get_mapping_info().cell_type[cell_index];
-  this->cell      = cell_index;
+  this->cell_type = this->matrix_free->get_mapping_info()
+                      .faces_by_cells_type[cell_index][face_number];
+  this->cell          = cell_index;
   this->subface_index = GeometryInfo<dim>::max_children_per_cell;
   this->dof_access_index =
     internal::MatrixFreeFunctions::DoFInfo::dof_access_cell;

--- a/include/deal.II/matrix_free/mapping_info.h
+++ b/include/deal.II/matrix_free/mapping_info.h
@@ -67,7 +67,7 @@ namespace internal
       initialize(
         const dealii::Triangulation<dim> &                        tria,
         const std::vector<std::pair<unsigned int, unsigned int>> &cells,
-        const FaceInfo<VectorizedArrayType::size()> &             faces,
+        const FaceInfo<VectorizedArrayType::size()> &             face_info,
         const std::vector<unsigned int> &active_fe_index,
         const std::shared_ptr<dealii::hp::MappingCollection<dim>> &mapping,
         const std::vector<dealii::hp::QCollection<dim>> &          quad,
@@ -86,7 +86,7 @@ namespace internal
       update_mapping(
         const dealii::Triangulation<dim> &                        tria,
         const std::vector<std::pair<unsigned int, unsigned int>> &cells,
-        const FaceInfo<VectorizedArrayType::size()> &             faces,
+        const FaceInfo<VectorizedArrayType::size()> &             face_info,
         const std::vector<unsigned int> &active_fe_index,
         const std::shared_ptr<dealii::hp::MappingCollection<dim>> &mapping);
 
@@ -158,6 +158,15 @@ namespace internal
       std::vector<GeometryType> face_type;
 
       /**
+       * Store whether the face geometry for the face_data_by_cells data
+       * structure is represented as Cartesian (cell type 0), with constant
+       * transform data (Jacobians) (cell type 1), or a general type (cell
+       * type 3). Note that both the interior and exterior agree on the type
+       * of the data structure, using the more general of the two.
+       */
+      std::vector<std::array<GeometryType, 2 * dim>> faces_by_cells_type;
+
+      /**
        * The data cache for the cells.
        */
       std::vector<MappingInfoStorage<dim, dim, VectorizedArrayType>> cell_data;
@@ -209,15 +218,14 @@ namespace internal
        * given as a tuple of the level and index within the level as used in
        * the main initialization of the class
        *
-       * @param faces The description of the connectivity from faces to cells
-       * as filled in the MatrixFree class
+       * @param face_info The description of the connectivity from faces to
+       * cells as filled in the MatrixFree class
        */
       void
       compute_mapping_q(
         const dealii::Triangulation<dim> &                        tria,
         const std::vector<std::pair<unsigned int, unsigned int>> &cells,
-        const std::vector<FaceToCellTopology<VectorizedArrayType::size()>>
-          &faces);
+        const FaceInfo<VectorizedArrayType::size()> &             face_info);
 
       /**
        * Computes the information in the given cells, called within
@@ -251,6 +259,7 @@ namespace internal
       initialize_faces_by_cells(
         const dealii::Triangulation<dim> &                        tria,
         const std::vector<std::pair<unsigned int, unsigned int>> &cells,
+        const FaceInfo<VectorizedArrayType::size()> &             face_info,
         const dealii::hp::MappingCollection<dim> &                mapping);
     };
 

--- a/tests/matrix_free/compare_faces_by_cells.cc
+++ b/tests/matrix_free/compare_faces_by_cells.cc
@@ -15,7 +15,7 @@
 
 
 
-// compares the computation of the diagonal using a face integration
+// compares the computation of the diagonal using the face integration
 // facilities with the alternative reinit(cell_index, face_number) approach
 
 #include <deal.II/base/function.h>
@@ -82,8 +82,8 @@ public:
   compute_diagonal_by_face(
     LinearAlgebra::distributed::Vector<number> &result) const
   {
-    int dummy;
-    result = 0;
+    int dummy = 0;
+    result    = 0;
     data.loop(&LaplaceOperator::local_diagonal_dummy,
               &LaplaceOperator::local_diagonal_face,
               &LaplaceOperator::local_diagonal_boundary,
@@ -96,7 +96,7 @@ public:
   compute_diagonal_by_cell(
     LinearAlgebra::distributed::Vector<number> &result) const
   {
-    int dummy;
+    int dummy = 0;
     result.zero_out_ghost_values();
     data.cell_loop(&LaplaceOperator::local_diagonal_by_cell,
                    this,


### PR DESCRIPTION
Fixes #13942.

As supposed by @peterrum in https://github.com/dealii/dealii/issues/13703#issuecomment-1133978999, we need to make sure that the geometry detection considers both the cells and the neighbors (by a `max` operation on the types of the adjacent entities). The maximum is necessary because we use the same `JxW` data field from both sides, and we have the plain determinant in one case, but also multiplied by the quadrature weight in the other. One could in principle relax this with some changes, but those are "only" performance optimizations for the future and hence left out from the present PR.