### PR TITLE
CGAL: fix header includes

### DIFF
--- a/include/deal.II/cgal/additional_data.h
+++ b/include/deal.II/cgal/additional_data.h
@@ -18,6 +18,8 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/exceptions.h>
+
 #ifdef DEAL_II_WITH_CGAL
 
 #  include <CGAL/Mesh_facet_topology.h>

--- a/include/deal.II/cgal/utilities.h
+++ b/include/deal.II/cgal/utilities.h
@@ -18,6 +18,8 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/exceptions.h>
+
 #include <deal.II/cgal/additional_data.h>
 
 #ifdef DEAL_II_WITH_CGAL


### PR DESCRIPTION
The following includes are needed, otherwise dealii::ExcMessage is not
declared when including the header.