### PR TITLE
test cgal/cgal_surface_mesh_01: add output variant

### DIFF
--- a/tests/cgal/cgal_surface_mesh_01.output.cgal-5.4.1
+++ b/tests/cgal/cgal_surface_mesh_01.output.cgal-5.4.1
@@ -5,21 +5,25 @@ DEAL::deal faces: 3, cgal faces 1
 DEAL::Valid mesh: true
 DEAL::OFF
 3 1 0
+
 0.00000 0.00000 0.00000
 1.00000 0.00000 0.00000
 0.00000 1.00000 0.00000
-3 2 1 0
+3  2 1 0
+
 
 DEAL::deal vertices: 4, cgal vertices 4
 DEAL::deal faces: 4, cgal faces 1
 DEAL::Valid mesh: true
 DEAL::OFF
 4 1 0
+
 0.00000 0.00000 0.00000
 1.00000 0.00000 0.00000
 0.00000 1.00000 0.00000
 1.00000 1.00000 0.00000
-4 2 3 1 0
+4  2 3 1 0
+
 
 DEAL::dim= 2,	 spacedim= 3
 DEAL::deal vertices: 3, cgal vertices 3
@@ -27,21 +31,25 @@ DEAL::deal faces: 3, cgal faces 1
 DEAL::Valid mesh: true
 DEAL::OFF
 3 1 0
+
 0.00000 0.00000 0.00000
 1.00000 0.00000 0.00000
 0.00000 1.00000 0.00000
-3 2 1 0
+3  2 1 0
+
 
 DEAL::deal vertices: 4, cgal vertices 4
 DEAL::deal faces: 4, cgal faces 1
 DEAL::Valid mesh: true
 DEAL::OFF
 4 1 0
+
 0.00000 0.00000 0.00000
 1.00000 0.00000 0.00000
 0.00000 1.00000 0.00000
 1.00000 1.00000 0.00000
-4 2 3 1 0
+4  2 3 1 0
+
 
 DEAL::dim= 3,	 spacedim= 3
 DEAL::deal vertices: 4, cgal vertices 4
@@ -49,53 +57,60 @@ DEAL::deal faces: 4, cgal faces 4
 DEAL::Valid mesh: true
 DEAL::OFF
 4 4 0
+
 0.00000 0.00000 0.00000
 1.00000 0.00000 0.00000
 0.00000 1.00000 0.00000
 0.00000 0.00000 1.00000
-3 2 1 0
-3 3 0 1
-3 3 2 0
-3 3 1 2
+3  2 1 0
+3  3 0 1
+3  3 2 0
+3  3 1 2
+
 
 DEAL::deal vertices: 5, cgal vertices 5
 DEAL::deal faces: 5, cgal faces 5
 DEAL::Valid mesh: true
 DEAL::OFF
 5 5 0
+
 -1.00000 -1.00000 0.00000
 1.00000 -1.00000 0.00000
 -1.00000 1.00000 0.00000
 1.00000 1.00000 0.00000
 0.00000 0.00000 1.00000
-4 2 3 1 0
-3 4 2 0
-3 4 1 3
-3 4 0 1
-3 4 3 2
+4  2 3 1 0
+3  4 2 0
+3  4 1 3
+3  4 0 1
+3  4 3 2
+
 
 DEAL::deal vertices: 6, cgal vertices 6
 DEAL::deal faces: 5, cgal faces 5
 DEAL::Valid mesh: true
 DEAL::OFF
 6 5 0
+
 0.00000 0.00000 0.00000
 1.00000 0.00000 0.00000
 0.00000 1.00000 0.00000
 0.00000 0.00000 1.00000
 1.00000 0.00000 1.00000
 0.00000 1.00000 1.00000
-3 2 0 1
-3 5 4 3
-4 3 4 1 0
-4 4 5 2 1
-4 5 3 0 2
+3  2 0 1
+3  5 4 3
+4  3 4 1 0
+4  4 5 2 1
+4  5 3 0 2
+
 
 DEAL::deal vertices: 8, cgal vertices 8
 DEAL::deal faces: 6, cgal faces 6
 DEAL::Valid mesh: true
 DEAL::OFF
 8 6 0
+
 0.00000 0.00000 0.00000
 1.00000 0.00000 0.00000
 0.00000 1.00000 0.00000
@@ -104,10 +119,11 @@ DEAL::OFF
 1.00000 0.00000 1.00000
 0.00000 1.00000 1.00000
 1.00000 1.00000 1.00000
-4 4 6 2 0
-4 1 3 7 5
-4 1 5 4 0
-4 2 6 7 3
-4 2 3 1 0
-4 4 5 7 6
+4  4 6 2 0
+4  1 3 7 5
+4  1 5 4 0
+4  2 6 7 3
+4  2 3 1 0
+4  4 5 7 6
+
 


### PR DESCRIPTION
It turns out that an output variant is needed: We end up printing some
additional empty lines with CGal 5.4.1.