### PR TITLE
Explicitly template function pointwise_definiteness(..)

### DIFF
--- a/source/non_matching/quadrature_generator.inst.in
+++ b/source/non_matching/quadrature_generator.inst.in
@@ -36,6 +36,12 @@ for (deal_II_dimension : DIMENSIONS)
           find_extreme_values(
             const std::vector<FunctionBounds<deal_II_dimension>> &);
 
+          template Definiteness
+          pointwise_definiteness(
+            const std::vector<
+              std::reference_wrapper<const Function<deal_II_dimension>>> &,
+            const Point<deal_II_dimension> &);
+
           template void
           estimate_function_bounds(
             const std::vector<


### PR DESCRIPTION
I believe this fixes  #13966, but I was not able to test this, because I was not able to reproduce it with my clang version, and I was not able to compile a working version of  Clang-14.0.5