### PR TITLE
CMake: Use deal.II's global index type in Tpetra compatibility test

### DIFF
--- a/cmake/configure/configure_20_trilinos.cmake
+++ b/cmake/configure/configure_20_trilinos.cmake
@@ -227,14 +227,22 @@ MACRO(FEATURE_TRILINOS_FIND_EXTERNAL var)
       # supply the correct compiler and linker flags:
       ADD_FLAGS(CMAKE_REQUIRED_FLAGS "${DEAL_II_CXX_FLAGS} ${DEAL_II_LINKER_FLAGS}")
 
+      IF(DEAL_II_WITH_64BIT_INDICES)
+        SET(_global_index_type "std::uint64_t")
+      ELSE()
+        SET(_global_index_type "unsigned int")
+      ENDIF()
+
       CHECK_CXX_SOURCE_COMPILES(
         "
+        #include <cstdint>
         #include <Tpetra_Vector.hpp>
         int
         main()
         {
           using LO       = int;
           using GO       = unsigned int;
+          using GO       = ${_global_index_type};
           using map_type = Tpetra::Map<LO, GO>;
           Teuchos::RCP<const map_type>   dummy_map = Teuchos::rcp(new map_type());
           Tpetra::Vector<double, LO, GO> dummy_vector(dummy_map);


### PR DESCRIPTION
We use Tpetra templates with types::global_dof_index throughout our
codebase - so we should also check for compatibility with said index
type.

Alternatively, this information is also available in
TpetraCore_config.h:
```
  /* #undef HAVE_TPETRA_INST_INT_INT */
  /* #undef HAVE_TPETRA_INST_INT_LONG */
  #define HAVE_TPETRA_INST_INT_LONG_LONG
  /* #undef HAVE_TPETRA_INST_INT_UNSIGNED */
  /* #undef HAVE_TPETRA_INST_INT_UNSIGNED_LONG */
```

In reference to #13972 