### PR TITLE
CMake: Use default Kokkos' DefaultNodeType in Tpetra test

### DIFF
--- a/cmake/configure/configure_20_trilinos.cmake
+++ b/cmake/configure/configure_20_trilinos.cmake
@@ -231,10 +231,9 @@ MACRO(FEATURE_TRILINOS_FIND_EXTERNAL var)
         {
           using LO       = int;
           using GO       = unsigned int;
-          using Node     = Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::Serial>;
-          using map_type = Tpetra::Map<LO, GO, Node>;
-          Teuchos::RCP<const map_type>         dummy_map = Teuchos::rcp(new map_type());
-          Tpetra::Vector<double, LO, GO, Node> dummy_vector(dummy_map);
+          using map_type = Tpetra::Map<LO, GO>;
+          Teuchos::RCP<const map_type>   dummy_map = Teuchos::rcp(new map_type());
+          Tpetra::Vector<double, LO, GO> dummy_vector(dummy_map);
           (void)dummy_vector;
           return 0;
         }


### PR DESCRIPTION
In reference to #13972 

(At least for Trilinos versions 13.2 and 13.4 onwards)

Tpetra is instantiated per default only for the default execution space. Without enabling cuda or openmp this will be `Kokkos::Serial`, but if, for example, openmp is enabled then it will be `Kokkos::OpenMP` and instantiations for `Kokkos::Serial` are omitted. At least so long as the user hasn't set `-DTpetra_INST_SERIAL=ON` while configuring trilinos.

Thus, let us simpy check for a functional Tpetra specifying the `Node` type explicitly.