### PR TITLE
[9.4] Take over #14002, Fix failing symengine tests

### DIFF
--- a/tests/symengine/batch_optimizer_09_1.output.symengine-0.9.0
+++ b/tests/symengine/batch_optimizer_09_1.output.symengine-0.9.0
@@ -1,0 +1,26 @@
+
+DEAL:Double:Evaluation::f: x*y
+DEAL:Double:Evaluation::G: (x + y)*T_00 (x + y)*T_01 (x + y)*T_10 (x + y)*T_11
+DEAL:Double:Evaluation::H: S_00/(x - y) S_01/(x - y) S_01/(x - y) S_11/(x - y)
+DEAL:Double:Evaluation::f(x,y): 20.00000000
+DEAL:Double:Evaluation::G(x,y,T): 48.00000000 48.00000000 60.00000000 84.00000000
+DEAL:Double:Evaluation::H(x,y,S): 0.6250000000 0.7500000000 0.7500000000 0.7500000000
+DEAL:Double:Evaluation::
+DEAL:Double:Extraction::f(x,y): 20.00000000
+DEAL:Double:Extraction::G(x,y,T): 48.00000000 48.00000000 60.00000000 84.00000000
+DEAL:Double:Extraction::H(x,y,S): 0.6250000000 0.7500000000 0.7500000000 0.7500000000
+DEAL:Double:Extraction::
+DEAL:Double:Invalid evaluation::Going to try evaluation without substitution...
+DEAL:Double:Invalid evaluation::f(x,y): 0.000000000
+DEAL:Double:Invalid evaluation::
+DEAL:Double:Invalid evaluation::Caught invalid evaluation before substitution: Tensor
+DEAL:Double:Invalid evaluation::Caught invalid evaluation before substitution: SymmetricTensor
+DEAL:Double:Invalid evaluation::Going to try substitution without optimization...
+DEAL:Double:Invalid evaluation::Caught invalid substitution before optimization.
+DEAL:Double:Invalid evaluation::Going to try evaluation without optimization...
+DEAL:Double:Invalid evaluation::f(x,y): 0.000000000
+DEAL:Double:Invalid evaluation::
+DEAL:Double:Invalid evaluation::Caught invalid evaluation before optimization: Tensor
+DEAL:Double:Invalid evaluation::Caught invalid evaluation before optimization: SymmetricTensor
+DEAL:Double::OK
+DEAL::OK

--- a/tests/symengine/sd_common_tests/step-44-sd-quadrature_level.h
+++ b/tests/symengine/sd_common_tests/step-44-sd-quadrature_level.h
@@ -1056,7 +1056,7 @@ namespace Step44
     DoFRenumbering::Cuthill_McKee(dof_handler_ref);
     DoFRenumbering::component_wise(dof_handler_ref, block_component);
     dofs_per_block =
-      DoFTools::count_dofs_per_block(dof_handler_ref, block_component);
+      DoFTools::count_dofs_per_fe_block(dof_handler_ref, block_component);
     std::cout << "Triangulation:"
               << "\n\t Number of active cells: "
               << triangulation.n_active_cells()


### PR DESCRIPTION
55b26b217c (Matthias Maier, 37 minutes ago)
   symengine/batch_optimizer_09_1: add test variant

   symengine-0.9.0 actually produces some output for the scalar case where the
   old test variant recorded an exception. As this is a strictly improved
   behavior let's simply add a test variant.

dee89b56ce (Matthias Maier, 41 minutes ago)
   symengine/sd_common_tests: update tests