### PR TITLE
Can't use ReferenceCells in switch-case.

### DIFF
--- a/tests/simplex/poisson_01.cc
+++ b/tests/simplex/poisson_01.cc
@@ -257,35 +257,38 @@ test(const Triangulation<dim, spacedim> &tria,
   Assert(reference_cells.size() == 1, ExcNotImplemented());
   unsigned int lower = 0;
   unsigned int upper = 0;
-  switch (reference_cells[0])
+  if (reference_cells[0] == ReferenceCells::Triangle)
     {
-      case ReferenceCells::Triangle:
-        lower = 111;
-        upper = 115;
-        break;
-      case ReferenceCells::Quadrilateral:
-        lower = 96;
-        upper = 100;
-        break;
-      case ReferenceCells::Tetrahedron:
-        lower = 154;
-        upper = 158;
-        break;
-      case ReferenceCells::Hexahedron:
-        lower = 132;
-        upper = 136;
-        break;
-      case ReferenceCells::Wedge:
-        lower = 194;
-        upper = 198;
-        break;
-      case ReferenceCells::Pyramid:
-        lower = 81;
-        upper = 85;
-        break;
-      default:
-        Assert(false, ExcInternalError());
+      lower = 111;
+      upper = 115;
     }
+  else if (reference_cells[0] == ReferenceCells::Quadrilateral)
+    {
+      lower = 96;
+      upper = 100;
+    }
+  else if (reference_cells[0] == ReferenceCells::Tetrahedron)
+    {
+      lower = 154;
+      upper = 158;
+    }
+  else if (reference_cells[0] == ReferenceCells::Hexahedron)
+    {
+      lower = 132;
+      upper = 136;
+    }
+  else if (reference_cells[0] == ReferenceCells::Wedge)
+    {
+      lower = 194;
+      upper = 198;
+    }
+  else if (reference_cells[0] == ReferenceCells::Pyramid)
+    {
+      lower = 81;
+      upper = 85;
+    }
+  else
+    Assert(false, ExcInternalError());
 
   check_solver_within_range(
     solver.solve(system_matrix, solution, system_rhs, PreconditionIdentity()),


### PR DESCRIPTION
This addresses the failure mentioned by @tjhei in #13703.

If this works, we'll want that on the 9.4 branch as well.

/rebuild