### PR TITLE
Reduce header inclusions of index_set.h in evaluation_kernels

### DIFF
--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -19,10 +19,10 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/array_view.h>
-#include <deal.II/base/index_set.h>
 #include <deal.II/base/mpi_tags.h>
 #include <deal.II/base/numbers.h>
 #include <deal.II/base/template_constraints.h>
+#include <deal.II/base/utilities.h>
 
 #include <boost/signals2.hpp>
 
@@ -116,9 +116,10 @@ namespace Utilities
    * return the @p my_partition_id 's IndexSet.
    */
   IndexSet
-  create_evenly_distributed_partitioning(const unsigned int my_partition_id,
-                                         const unsigned int n_partitions,
-                                         const IndexSet::size_type total_size);
+  create_evenly_distributed_partitioning(
+    const unsigned int            my_partition_id,
+    const unsigned int            n_partitions,
+    const types::global_dof_index total_size);
 
   /**
    * A namespace for utility functions that abstract certain operations using
@@ -485,8 +486,9 @@ namespace Utilities
      * starts at the index one larger than the last one stored on process p.
      */
     std::vector<IndexSet>
-    create_ascending_partitioning(const MPI_Comm &          comm,
-                                  const IndexSet::size_type locally_owned_size);
+    create_ascending_partitioning(
+      const MPI_Comm &              comm,
+      const types::global_dof_index locally_owned_size);
 
     /**
      * Given the total number of elements @p total_size, create an evenly
@@ -497,8 +499,8 @@ namespace Utilities
      */
     IndexSet
     create_evenly_distributed_partitioning(
-      const MPI_Comm &          comm,
-      const IndexSet::size_type total_size);
+      const MPI_Comm &              comm,
+      const types::global_dof_index total_size);
 
 #ifdef DEAL_II_WITH_MPI
     /**

--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -21,12 +21,10 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/partitioner.h>
 #include <deal.II/base/vectorization.h>
 
 #include <deal.II/matrix_free/face_info.h>
 #include <deal.II/matrix_free/shape_info.h>
-#include <deal.II/matrix_free/task_info.h>
 #include <deal.II/matrix_free/vector_data_exchange.h>
 
 #include <array>
@@ -48,6 +46,8 @@ namespace internal
 
     template <typename, typename>
     struct FPArrayComparator;
+
+    struct TaskInfo;
   } // namespace MatrixFreeFunctions
 } // namespace internal
 
@@ -61,6 +61,14 @@ class TriaIterator;
 
 template <int, int, bool>
 class DoFCellAccessor;
+
+namespace Utilities
+{
+  namespace MPI
+  {
+    class Partitioner;
+  }
+} // namespace Utilities
 
 #endif
 

--- a/include/deal.II/matrix_free/fe_evaluation_data.h
+++ b/include/deal.II/matrix_free/fe_evaluation_data.h
@@ -33,7 +33,6 @@
 #include <deal.II/matrix_free/dof_info.h>
 #include <deal.II/matrix_free/mapping_info_storage.h>
 #include <deal.II/matrix_free/shape_info.h>
-#include <deal.II/matrix_free/type_traits.h>
 
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/matrix_free/task_info.h
+++ b/include/deal.II/matrix_free/task_info.h
@@ -21,8 +21,8 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/index_set.h>
 #include <deal.II/base/memory_consumption.h>
+#include <deal.II/base/mpi.h>
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/thread_management.h>
 #include <deal.II/base/utilities.h>

--- a/include/deal.II/matrix_free/vector_data_exchange.h
+++ b/include/deal.II/matrix_free/vector_data_exchange.h
@@ -20,10 +20,27 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/partitioner.h>
+#include <deal.II/base/array_view.h>
+#include <deal.II/base/mpi.h>
+
+#include <deal.II/lac/vector_operation.h>
 
 
 DEAL_II_NAMESPACE_OPEN
+
+#ifndef DOXYGEN
+
+// forward declaration
+namespace Utilities
+{
+  namespace MPI
+  {
+    class Partitioner;
+  }
+} // namespace Utilities
+
+#endif
+
 
 namespace internal
 {

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -71,10 +71,15 @@ DEAL_II_NAMESPACE_OPEN
 namespace Utilities
 {
   IndexSet
-  create_evenly_distributed_partitioning(const unsigned int my_partition_id,
-                                         const unsigned int n_partitions,
-                                         const IndexSet::size_type total_size)
+  create_evenly_distributed_partitioning(
+    const unsigned int            my_partition_id,
+    const unsigned int            n_partitions,
+    const types::global_dof_index total_size)
   {
+    static_assert(
+      std::is_same<types::global_dof_index, IndexSet::size_type>::value,
+      "IndexSet::size_type must match types::global_dof_index for "
+      "using this function");
     const unsigned int remain = total_size % n_partitions;
 
     const IndexSet::size_type min_size = total_size / n_partitions;
@@ -214,9 +219,14 @@ namespace Utilities
 
 
     std::vector<IndexSet>
-    create_ascending_partitioning(const MPI_Comm &          comm,
-                                  const IndexSet::size_type locally_owned_size)
+    create_ascending_partitioning(
+      const MPI_Comm &              comm,
+      const types::global_dof_index locally_owned_size)
     {
+      static_assert(
+        std::is_same<types::global_dof_index, IndexSet::size_type>::value,
+        "IndexSet::size_type must match types::global_dof_index for "
+        "using this function");
       const unsigned int                     n_proc = n_mpi_processes(comm);
       const std::vector<IndexSet::size_type> sizes =
         all_gather(comm, locally_owned_size);
@@ -238,8 +248,9 @@ namespace Utilities
 
 
     IndexSet
-    create_evenly_distributed_partitioning(const MPI_Comm &          comm,
-                                           const IndexSet::size_type total_size)
+    create_evenly_distributed_partitioning(
+      const MPI_Comm &              comm,
+      const types::global_dof_index total_size)
     {
       const unsigned int this_proc = this_mpi_process(comm);
       const unsigned int n_proc    = n_mpi_processes(comm);
@@ -663,15 +674,17 @@ namespace Utilities
 
 
     std::vector<IndexSet>
-    create_ascending_partitioning(const MPI_Comm & /*comm*/,
-                                  const IndexSet::size_type locally_owned_size)
+    create_ascending_partitioning(
+      const MPI_Comm & /*comm*/,
+      const types::global_dof_index locally_owned_size)
     {
       return std::vector<IndexSet>(1, complete_index_set(locally_owned_size));
     }
 
     IndexSet
-    create_evenly_distributed_partitioning(const MPI_Comm & /*comm*/,
-                                           const IndexSet::size_type total_size)
+    create_evenly_distributed_partitioning(
+      const MPI_Comm & /*comm*/,
+      const types::global_dof_index total_size)
     {
       return complete_index_set(total_size);
     }

--- a/source/matrix_free/vector_data_exchange.cc
+++ b/source/matrix_free/vector_data_exchange.cc
@@ -18,6 +18,7 @@
 #include <deal.II/base/mpi.templates.h>
 #include <deal.II/base/mpi_compute_index_owner_internal.h>
 #include <deal.II/base/mpi_consensus_algorithms.h>
+#include <deal.II/base/partitioner.h>
 #include <deal.II/base/timer.h>
 
 #include <deal.II/matrix_free/vector_data_exchange.h>


### PR DESCRIPTION
This PR removes the need to include `index_set.h` and `partitioner.h` from the expensive compute files `matrix_free/evaluation_kernels.h`. The untangle this dependency, I had to avoid including `index_set.h` from `mpi.h` (because `aligned_vector.h` necessarily includes `mpi.h`, and we need `AlignedVector`), for which I added a forward declaration and a few similar types `IndexSet::size_type` -> `types::global_dof_index`. The former is defined as the latter, https://github.com/dealii/dealii/blob/706a51c7554fe9acf3775e71eca112d7a424b264/include/deal.II/base/index_set.h#L76-L80 so the change is equivalent. To further strengthen the link and avoid divergence in the two code paths, I added some static asserts.