### PR TITLE
Do not add locally owned dofs to ghost set during construction

### DIFF
--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -652,6 +652,11 @@ namespace internal
           }
       }
 
+      this->is_extended_locally_owned =
+        mg_level_fine == numbers::invalid_unsigned_int ?
+          dof_handler_fine.locally_owned_dofs() :
+          dof_handler_fine.locally_owned_mg_dofs(mg_level_fine);
+
       std::vector<types::global_dof_index> ghost_indices;
 
       // process local cells
@@ -674,9 +679,9 @@ namespace internal
             else
               cell_->get_mg_dof_indices(indices);
 
-            ghost_indices.insert(ghost_indices.end(),
-                                 indices.begin(),
-                                 indices.end());
+            for (const auto i : indices)
+              if (!is_extended_locally_owned.is_element(i))
+                ghost_indices.push_back(i);
           }
       }
 
@@ -728,13 +733,15 @@ namespace internal
               MPI_STATUS_IGNORE);
             AssertThrowMPI(ierr_3);
 
-            for (unsigned int i = 0; i < buffer.size();
-                 i += dof_handler_fine.get_fe(buffer[i]).n_dofs_per_cell() + 1)
-              ghost_indices.insert(
-                ghost_indices.end(),
-                buffer.begin() + i + 1,
-                buffer.begin() + i + 1 +
-                  dof_handler_fine.get_fe(buffer[i]).n_dofs_per_cell());
+            for (unsigned int i = 0; i < buffer.size();)
+              {
+                const unsigned int dofs_per_cell =
+                  dof_handler_fine.get_fe(buffer[i]).n_dofs_per_cell();
+                ++i;
+                for (unsigned int j = 0; j < dofs_per_cell; ++j, ++i)
+                  if (!is_extended_locally_owned.is_element(buffer[i]))
+                    ghost_indices.push_back(buffer[i]);
+              }
 
             const unsigned int rank = status.MPI_SOURCE;
 
@@ -764,11 +771,6 @@ namespace internal
       ghost_indices.erase(std::unique(ghost_indices.begin(),
                                       ghost_indices.end()),
                           ghost_indices.end());
-
-      this->is_extended_locally_owned =
-        mg_level_fine == numbers::invalid_unsigned_int ?
-          dof_handler_fine.locally_owned_dofs() :
-          dof_handler_fine.locally_owned_mg_dofs(mg_level_fine);
 
       this->is_extended_ghosts =
         IndexSet(mg_level_fine == numbers::invalid_unsigned_int ?

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -739,8 +739,11 @@ namespace internal
                   dof_handler_fine.get_fe(buffer[i]).n_dofs_per_cell();
                 ++i;
                 for (unsigned int j = 0; j < dofs_per_cell; ++j, ++i)
-                  if (!is_extended_locally_owned.is_element(buffer[i]))
-                    ghost_indices.push_back(buffer[i]);
+                  {
+                    AssertIndexRange(i, buffer.size());
+                    if (!is_extended_locally_owned.is_element(buffer[i]))
+                      ghost_indices.push_back(buffer[i]);
+                  }
               }
 
             const unsigned int rank = status.MPI_SOURCE;


### PR DESCRIPTION
Similarly to what is done in https://github.com/dealii/dealii/blob/c6cbcf1cea8e88a9b98462141f31f6171c8135c4/source/multigrid/mg_transfer_internal.cc#L785-L787 we should only add the dofs that end up being ghosts, to reduce the impact of the `n log(n)` sort costs and addition to the index set.