### PR TITLE
Query ghost index set only once in Partitioner::global_to_local

### DIFF
--- a/include/deal.II/base/partitioner.h
+++ b/include/deal.II/base/partitioner.h
@@ -873,15 +873,19 @@ namespace Utilities
              ExcIndexNotPresent(global_index, my_pid));
       if (in_local_range(global_index))
         return static_cast<unsigned int>(global_index - local_range_data.first);
-      else if (is_ghost_entry(global_index))
-        return (locally_owned_size() +
-                static_cast<unsigned int>(
-                  ghost_indices_data.index_within_set(global_index)));
       else
-        // should only end up here in optimized mode, when we use this large
-        // number to trigger a segfault when using this method for array
-        // access
-        return numbers::invalid_unsigned_int;
+        {
+          // avoid checking the ghost index set via a binary search twice by
+          // querying the index within set, which returns invalid_dof_index
+          // for non-existent entries
+          const types::global_dof_index index_within_ghosts =
+            ghost_indices_data.index_within_set(global_index);
+          if (index_within_ghosts == numbers::invalid_dof_index)
+            return numbers::invalid_unsigned_int;
+          else
+            return locally_owned_size() +
+                   static_cast<unsigned int>(index_within_ghosts);
+        }
     }
 
 


### PR DESCRIPTION
In terms of inlining opportunities as exposed in #14021, I noticed that the partitioner does an index translation twice, once for checking whether an index is actually present, and then for the actual translation. As `IndexSet::index_within_set` is written in a way that it allows for precisely the case of non-present indices, we can skip that initial check.