### PR TITLE
fix a warning when compiling with cuda support

### DIFF
--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -1024,7 +1024,7 @@ namespace CUDAWrappers
                 std::vector<bool> ghost_vertices(
                   dof_handler->get_triangulation().n_vertices(), false);
 
-                for (const auto cell :
+                for (const auto &cell :
                      dof_handler->get_triangulation().active_cell_iterators())
                   if (cell->is_ghost())
                     for (unsigned int i = 0;


### PR DESCRIPTION
dealii/include/deal.II/matrix_free/cuda_matrix_free.templates.h:1027:17:
    warning: loop variable ‘cell’ creates a copy from type ‘const
    dealii::TriaActiveIterator<dealii::CellAccessor<3, 3> >’
    [-Wrange-loop-construct]
dealii/include/deal.II/matrix_free/cuda_matrix_free.templates.h:1027:17:
    note: use reference type to prevent copying
 1027 |                 for (const auto cell :
      |                 ^~~~
      |                 &