### PR TITLE
Small improvement for IndexSet::add_ranges_internal

### DIFF
--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -415,7 +415,17 @@ IndexSet::add_ranges_internal(
       tmp_set.ranges.reserve(tmp_ranges.size());
       for (const auto &i : tmp_ranges)
         tmp_set.add_range(i.first, i.second);
-      this->add_indices(tmp_set);
+
+      // Case if we have zero or just one range: Add into the other set with
+      // its indices, as that is cheaper
+      if (this->ranges.size() <= 1)
+        {
+          if (this->ranges.size() == 1)
+            tmp_set.add_range(ranges[0].begin, ranges[0].end);
+          std::swap(*this, tmp_set);
+        }
+      else
+        this->add_indices(tmp_set);
     }
   else
     for (const auto &i : tmp_ranges)


### PR DESCRIPTION
Follow-up to #14021: If we add indices in ranges to an index set, we would previously check if we only add a few ranges and then insert them directly into a sorted vector, but switch to another algorithm when there are many ranges to be added. This pattern can also go the other way around: If the calling index set only has one range, it is cheap to insert that range into the temporary index set, and then swap them. This is the typical code pattern in `DoFTools::extract_locally_relevant_dofs`.