### PR TITLE
HDF XDMF entry: store reference cell

### DIFF
--- a/doc/news/changes/incompatibilities/20220627Arndt-1
+++ b/doc/news/changes/incompatibilities/20220627Arndt-1
@@ -1,4 +1,0 @@
-Removed: The deprecated overload of XDMFEntry::get_xdmf_content()
-has been removed.
-<br>
-(Daniel Arndt, 2022/06/27)

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -3372,6 +3372,17 @@ public:
   /**
    * Get the XDMF content associated with this entry.
    * If the entry is not valid, this returns an empty string.
+   *
+   * @deprecated Use the overload taking an `unsigned int` and a
+   * `const ReferenceCell &` instead.
+   */
+  DEAL_II_DEPRECATED
+  std::string
+  get_xdmf_content(const unsigned int indent_level) const;
+
+  /**
+   * Get the XDMF content associated with this entry.
+   * If the entry is not valid, this returns an empty string.
    */
   std::string
   get_xdmf_content(const unsigned int   indent_level,

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -3322,7 +3322,31 @@ public:
    * cases where <code>solution_filename == mesh_filename</code>, and
    * <code>dim==spacedim</code>.
    */
+  XDMFEntry(const std::string &  filename,
+            const double         time,
+            const std::uint64_t  nodes,
+            const std::uint64_t  cells,
+            const unsigned int   dim,
+            const ReferenceCell &cell_type);
+
+  /**
+   * Deprecated constructor.
+   *
+   * @deprecated Use the constructor that additionally takes a ReferenceCell.
+   */
   XDMFEntry(const std::string & filename,
+            const double        time,
+            const std::uint64_t nodes,
+            const std::uint64_t cells,
+            const unsigned int  dim);
+
+  /**
+   * Deprecated constructor.
+   *
+   * @deprecated Use the constructor that additionally takes a ReferenceCell.
+   */
+  XDMFEntry(const std::string & mesh_filename,
+            const std::string & solution_filename,
             const double        time,
             const std::uint64_t nodes,
             const std::uint64_t cells,
@@ -3332,16 +3356,20 @@ public:
    * Simplified constructor that calls the complete constructor for
    * cases where <code>dim==spacedim</code>.
    */
-  XDMFEntry(const std::string & mesh_filename,
-            const std::string & solution_filename,
-            const double        time,
-            const std::uint64_t nodes,
-            const std::uint64_t cells,
-            const unsigned int  dim);
+  XDMFEntry(const std::string &  mesh_filename,
+            const std::string &  solution_filename,
+            const double         time,
+            const std::uint64_t  nodes,
+            const std::uint64_t  cells,
+            const unsigned int   dim,
+            const ReferenceCell &cell_type);
 
   /**
-   * Constructor that sets all members to provided parameters.
+   * Deprecated constructor.
+   *
+   * @deprecated Use the constructor that additionally takes a ReferenceCell.
    */
+  DEAL_II_DEPRECATED
   XDMFEntry(const std::string & mesh_filename,
             const std::string & solution_filename,
             const double        time,
@@ -3349,6 +3377,18 @@ public:
             const std::uint64_t cells,
             const unsigned int  dim,
             const unsigned int  spacedim);
+
+  /**
+   * Constructor that sets all members to provided parameters.
+   */
+  XDMFEntry(const std::string &  mesh_filename,
+            const std::string &  solution_filename,
+            const double         time,
+            const std::uint64_t  nodes,
+            const std::uint64_t  cells,
+            const unsigned int   dim,
+            const unsigned int   spacedim,
+            const ReferenceCell &cell_type);
 
   /**
    * Record an attribute and associated dimensionality.
@@ -3366,24 +3406,23 @@ public:
   serialize(Archive &ar, const unsigned int /*version*/)
   {
     ar &valid &h5_sol_filename &h5_mesh_filename &entry_time &num_nodes
-      &num_cells &dimension &space_dimension &attribute_dims;
+      &num_cells &dimension &space_dimension &cell_type &attribute_dims;
   }
 
   /**
    * Get the XDMF content associated with this entry.
    * If the entry is not valid, this returns an empty string.
-   *
-   * @deprecated Use the overload taking an `unsigned int` and a
-   * `const ReferenceCell &` instead.
    */
-  DEAL_II_DEPRECATED
   std::string
   get_xdmf_content(const unsigned int indent_level) const;
 
   /**
    * Get the XDMF content associated with this entry.
    * If the entry is not valid, this returns an empty string.
+   *
+   * @deprecated Use the other function instead.
    */
+  DEAL_II_DEPRECATED
   std::string
   get_xdmf_content(const unsigned int   indent_level,
                    const ReferenceCell &reference_cell) const;
@@ -3429,6 +3468,12 @@ private:
    * Note that dimension <= space_dimension.
    */
   unsigned int space_dimension;
+
+  /**
+   * The type of cell in deal.II language. We currently only support
+   * xdmf entries where all cells have the same type.
+   */
+  ReferenceCell cell_type;
 
   /**
    * The attributes associated with this entry and their dimension.

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -9200,6 +9200,32 @@ namespace
 
 
 std::string
+XDMFEntry::get_xdmf_content(const unsigned int indent_level) const
+{
+  switch (dimension)
+    {
+      case 0:
+        return get_xdmf_content(indent_level,
+                                ReferenceCells::get_hypercube<0>());
+      case 1:
+        return get_xdmf_content(indent_level,
+                                ReferenceCells::get_hypercube<1>());
+      case 2:
+        return get_xdmf_content(indent_level,
+                                ReferenceCells::get_hypercube<2>());
+      case 3:
+        return get_xdmf_content(indent_level,
+                                ReferenceCells::get_hypercube<3>());
+      default:
+        Assert(false, ExcNotImplemented());
+    }
+
+  return "";
+}
+
+
+
+std::string
 XDMFEntry::get_xdmf_content(const unsigned int   indent_level,
                             const ReferenceCell &reference_cell) const
 {

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -7985,13 +7985,24 @@ DataOutInterface<dim, spacedim>::create_xdmf_entry(
   // Output the XDMF file only on the root process
   if (myrank == 0)
     {
+      const auto &patches = get_patches();
+      Assert(patches.size() > 0, DataOutBase::ExcNoPatches());
+      // We currently don't support writing mixed meshes:
+#ifdef DEBUG
+      for (const auto &patch : patches)
+        Assert(patch.reference_cell == patches[0].reference_cell,
+               ExcNotImplemented());
+#endif
+
+
       XDMFEntry    entry(h5_mesh_filename,
                       h5_solution_filename,
                       cur_time,
                       global_node_cell_count[0],
                       global_node_cell_count[1],
                       dim,
-                      spacedim);
+                      spacedim,
+                      patches[0].reference_cell);
       unsigned int n_data_sets = data_filter.n_data_sets();
 
       // The vector names generated here must match those generated in the HDF5

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -8037,20 +8037,9 @@ DataOutInterface<dim, spacedim>::write_xdmf_file(
       xdmf_file
         << "    <Grid Name=\"CellTime\" GridType=\"Collection\" CollectionType=\"Temporal\">\n";
 
-      // Write out all the entries indented
-      const auto &patches = get_patches();
-      Assert(patches.size() > 0, DataOutBase::ExcNoPatches());
-
-      // We currently don't support writing mixed meshes:
-#ifdef DEBUG
-      for (const auto &patch : patches)
-        Assert(patch.reference_cell == patches[0].reference_cell,
-               ExcNotImplemented());
-#endif
-
       for (const auto &entry : entries)
         {
-          xdmf_file << entry.get_xdmf_content(3, patches[0].reference_cell);
+          xdmf_file << entry.get_xdmf_content(3);
         }
 
       xdmf_file << "    </Grid>\n";
@@ -9129,6 +9118,7 @@ XDMFEntry::XDMFEntry()
   , num_cells(numbers::invalid_unsigned_int)
   , dimension(numbers::invalid_unsigned_int)
   , space_dimension(numbers::invalid_unsigned_int)
+  , cell_type()
 {}
 
 
@@ -9138,7 +9128,16 @@ XDMFEntry::XDMFEntry(const std::string & filename,
                      const std::uint64_t nodes,
                      const std::uint64_t cells,
                      const unsigned int  dim)
-  : XDMFEntry(filename, filename, time, nodes, cells, dim, dim)
+  : XDMFEntry(filename, filename, time, nodes, cells, dim, dim, ReferenceCell())
+{}
+
+XDMFEntry::XDMFEntry(const std::string &  filename,
+                     const double         time,
+                     const std::uint64_t  nodes,
+                     const std::uint64_t  cells,
+                     const unsigned int   dim,
+                     const ReferenceCell &cell_type)
+  : XDMFEntry(filename, filename, time, nodes, cells, dim, dim, cell_type)
 {}
 
 
@@ -9149,7 +9148,33 @@ XDMFEntry::XDMFEntry(const std::string & mesh_filename,
                      const std::uint64_t nodes,
                      const std::uint64_t cells,
                      const unsigned int  dim)
-  : XDMFEntry(mesh_filename, solution_filename, time, nodes, cells, dim, dim)
+  : XDMFEntry(mesh_filename,
+              solution_filename,
+              time,
+              nodes,
+              cells,
+              dim,
+              dim,
+              ReferenceCell())
+{}
+
+
+
+XDMFEntry::XDMFEntry(const std::string &  mesh_filename,
+                     const std::string &  solution_filename,
+                     const double         time,
+                     const std::uint64_t  nodes,
+                     const std::uint64_t  cells,
+                     const unsigned int   dim,
+                     const ReferenceCell &cell_type)
+  : XDMFEntry(mesh_filename,
+              solution_filename,
+              time,
+              nodes,
+              cells,
+              dim,
+              dim,
+              cell_type)
 {}
 
 
@@ -9161,6 +9186,26 @@ XDMFEntry::XDMFEntry(const std::string & mesh_filename,
                      const std::uint64_t cells,
                      const unsigned int  dim,
                      const unsigned int  spacedim)
+  : XDMFEntry(mesh_filename,
+              solution_filename,
+              time,
+              nodes,
+              cells,
+              dim,
+              spacedim,
+              ReferenceCell())
+{}
+
+
+
+XDMFEntry::XDMFEntry(const std::string &  mesh_filename,
+                     const std::string &  solution_filename,
+                     const double         time,
+                     const std::uint64_t  nodes,
+                     const std::uint64_t  cells,
+                     const unsigned int   dim,
+                     const unsigned int   spacedim,
+                     const ReferenceCell &cell_type_)
   : valid(true)
   , h5_sol_filename(solution_filename)
   , h5_mesh_filename(mesh_filename)
@@ -9169,7 +9214,29 @@ XDMFEntry::XDMFEntry(const std::string & mesh_filename,
   , num_cells(cells)
   , dimension(dim)
   , space_dimension(spacedim)
-{}
+  , cell_type(cell_type_)
+{
+  if (cell_type == ReferenceCells::Invalid)
+    {
+      switch (dimension)
+        {
+          case 0:
+            cell_type = ReferenceCells::get_hypercube<0>();
+            break;
+          case 1:
+            cell_type = ReferenceCells::get_hypercube<1>();
+            break;
+          case 2:
+            cell_type = ReferenceCells::get_hypercube<2>();
+            break;
+          case 3:
+            cell_type = ReferenceCells::get_hypercube<3>();
+            break;
+          default:
+            AssertThrow(false, ExcMessage("Invalid dimension"));
+        }
+    }
+}
 
 
 
@@ -9200,34 +9267,20 @@ namespace
 
 
 std::string
-XDMFEntry::get_xdmf_content(const unsigned int indent_level) const
+XDMFEntry::get_xdmf_content(const unsigned int   indent_level,
+                            const ReferenceCell &reference_cell) const
 {
-  switch (dimension)
-    {
-      case 0:
-        return get_xdmf_content(indent_level,
-                                ReferenceCells::get_hypercube<0>());
-      case 1:
-        return get_xdmf_content(indent_level,
-                                ReferenceCells::get_hypercube<1>());
-      case 2:
-        return get_xdmf_content(indent_level,
-                                ReferenceCells::get_hypercube<2>());
-      case 3:
-        return get_xdmf_content(indent_level,
-                                ReferenceCells::get_hypercube<3>());
-      default:
-        Assert(false, ExcNotImplemented());
-    }
-
-  return "";
+  // We now store the type of cell in the XDMFEntry:
+  (void)reference_cell;
+  Assert(cell_type == reference_cell,
+         ExcMessage("Incorrect ReferenceCell type passed in."));
+  return get_xdmf_content(indent_level);
 }
 
 
 
 std::string
-XDMFEntry::get_xdmf_content(const unsigned int   indent_level,
-                            const ReferenceCell &reference_cell) const
+XDMFEntry::get_xdmf_content(const unsigned int indent_level) const
 {
   if (!valid)
     return "";
@@ -9260,26 +9313,26 @@ XDMFEntry::get_xdmf_content(const unsigned int   indent_level,
         }
       else if (dimension == 2)
         {
-          Assert(reference_cell == ReferenceCells::Quadrilateral ||
-                   reference_cell == ReferenceCells::Triangle,
+          Assert(cell_type == ReferenceCells::Quadrilateral ||
+                   cell_type == ReferenceCells::Triangle,
                  ExcNotImplemented());
 
-          if (reference_cell == ReferenceCells::Quadrilateral)
+          if (cell_type == ReferenceCells::Quadrilateral)
             {
               ss << "Quadrilateral";
             }
-          else // if (reference_cell == ReferenceCells::Triangle)
+          else // if (cell_type == ReferenceCells::Triangle)
             {
               ss << "Triangle";
             }
         }
       else if (dimension == 3)
         {
-          Assert(reference_cell == ReferenceCells::Hexahedron ||
-                   reference_cell == ReferenceCells::Tetrahedron,
+          Assert(cell_type == ReferenceCells::Hexahedron ||
+                   cell_type == ReferenceCells::Tetrahedron,
                  ExcNotImplemented());
 
-          if (reference_cell == ReferenceCells::Hexahedron)
+          if (cell_type == ReferenceCells::Hexahedron)
             {
               ss << "Hexahedron";
             }
@@ -9299,7 +9352,7 @@ XDMFEntry::get_xdmf_content(const unsigned int   indent_level,
         ss << "\">\n";
 
       ss << indent(indent_level + 2) << "<DataItem Dimensions=\"" << num_cells
-         << " " << reference_cell.n_vertices()
+         << " " << cell_type.n_vertices()
          << "\" NumberType=\"UInt\" Format=\"HDF\">\n";
 
       ss << indent(indent_level + 3) << h5_mesh_filename << ":/cells\n";

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -9209,6 +9209,39 @@ XDMFEntry::XDMFEntry(const std::string & mesh_filename,
 
 
 
+namespace
+{
+  /**
+   * Deprecated XDMFEntry constructors do not fill the cell_type, so we use this
+   * little helper to convert it to the appropriate hex cell.
+   */
+  ReferenceCell
+  cell_type_hex_if_invalid(const ReferenceCell &cell_type,
+                           const unsigned int   dimension)
+  {
+    if (cell_type == ReferenceCells::Invalid)
+      {
+        switch (dimension)
+          {
+            case 0:
+              return ReferenceCells::get_hypercube<0>();
+            case 1:
+              return ReferenceCells::get_hypercube<1>();
+            case 2:
+              return ReferenceCells::get_hypercube<2>();
+            case 3:
+              return ReferenceCells::get_hypercube<3>();
+            default:
+              AssertThrow(false, ExcMessage("Invalid dimension"));
+          }
+      }
+    else
+      return cell_type;
+  }
+} // namespace
+
+
+
 XDMFEntry::XDMFEntry(const std::string &  mesh_filename,
                      const std::string &  solution_filename,
                      const double         time,
@@ -9225,29 +9258,8 @@ XDMFEntry::XDMFEntry(const std::string &  mesh_filename,
   , num_cells(cells)
   , dimension(dim)
   , space_dimension(spacedim)
-  , cell_type(cell_type_)
-{
-  if (cell_type == ReferenceCells::Invalid)
-    {
-      switch (dimension)
-        {
-          case 0:
-            cell_type = ReferenceCells::get_hypercube<0>();
-            break;
-          case 1:
-            cell_type = ReferenceCells::get_hypercube<1>();
-            break;
-          case 2:
-            cell_type = ReferenceCells::get_hypercube<2>();
-            break;
-          case 3:
-            cell_type = ReferenceCells::get_hypercube<3>();
-            break;
-          default:
-            AssertThrow(false, ExcMessage("Invalid dimension"));
-        }
-    }
-}
+  , cell_type(cell_type_hex_if_invalid(cell_type_, dim))
+{}
 
 
 

--- a/tests/data_out/data_out_hdf5_02.cc
+++ b/tests/data_out/data_out_hdf5_02.cc
@@ -134,7 +134,7 @@ check()
     << "    <Grid Name=\"CellTime\" GridType=\"Collection\" CollectionType=\"Temporal\">\n";
 
   // Write out the entry
-  xdmf_file << entry.get_xdmf_content(3, ReferenceCells::get_hypercube<dim>());
+  xdmf_file << entry.get_xdmf_content(3);
 
   xdmf_file << "    </Grid>\n";
   xdmf_file << "  </Domain>\n";

--- a/tests/mpi/data_out_hdf5_02.cc
+++ b/tests/mpi/data_out_hdf5_02.cc
@@ -86,7 +86,7 @@ check()
     << "    <Grid Name=\"CellTime\" GridType=\"Collection\" CollectionType=\"Temporal\">\n";
 
   // Write out the entry
-  xdmf_file << entry.get_xdmf_content(3, ReferenceCells::get_hypercube<dim>());
+  xdmf_file << entry.get_xdmf_content(3);
 
   xdmf_file << "    </Grid>\n";
   xdmf_file << "  </Domain>\n";

--- a/tests/serialization/xdmf_entry.cc
+++ b/tests/serialization/xdmf_entry.cc
@@ -43,7 +43,6 @@ test()
     oa << entry1;
     // archive and stream closed when destructors are called
   }
-  deallog << oss.str() << std::endl;
 
   // verify correctness of the serialization
   {

--- a/tests/serialization/xdmf_entry.cc
+++ b/tests/serialization/xdmf_entry.cc
@@ -54,13 +54,11 @@ test()
 
   deallog << "XDMFEntry before serialization: " << std::endl
           << std::endl
-          << entry1.get_xdmf_content(0, ReferenceCells::get_hypercube<dim>())
-          << std::endl;
+          << entry1.get_xdmf_content(0) << std::endl;
 
   deallog << "XDMFEntry after de-serialization: " << std::endl
           << std::endl
-          << entry2.get_xdmf_content(0, ReferenceCells::get_hypercube<dim>())
-          << std::endl;
+          << entry2.get_xdmf_content(0) << std::endl;
 }
 
 

--- a/tests/serialization/xdmf_entry.output
+++ b/tests/serialization/xdmf_entry.output
@@ -1,6 +1,4 @@
 
-DEAL::0 0 1 11 solution.h5 7 mesh.h5 5.00000000000000000e-01 128 16 2 3 0 0 0 0
-
 DEAL::XDMFEntry before serialization: 
 DEAL::
 DEAL::<Grid Name="mesh" GridType="Uniform">


### PR DESCRIPTION
We added support for XDMF output of simplices in #10852 but ended up not storing the type of cell inside the XDMF entry but rely on passing it in after the fact. I think this is a mistake, so I am adding it here.

This is required for my upcoming fix for #13404