### PR TITLE
Simplify assertion by AssertIndexRange

### DIFF
--- a/include/deal.II/dofs/dof_objects.h
+++ b/include/deal.II/dofs/dof_objects.h
@@ -182,20 +182,16 @@ namespace internal
       const unsigned int                          local_index)
     {
       (void)fe_index;
-      Assert(
-        (fe_index == dealii::DoFHandler<dh_dim, spacedim>::default_fe_index),
-        ExcMessage(
-          "Only the default FE index is allowed for non-hp-DoFHandler objects"));
-      Assert(
-        local_index < dof_handler.get_fe().template n_dofs_per_object<dim>(),
-        ExcIndexRange(local_index,
-                      0,
-                      dof_handler.get_fe().template n_dofs_per_object<dim>()));
-      Assert(obj_index *
-                   dof_handler.get_fe().template n_dofs_per_object<dim>() +
-                 local_index <
-               dofs.size(),
-             ExcInternalError());
+      Assert((fe_index ==
+              dealii::DoFHandler<dh_dim, spacedim>::default_fe_index),
+             ExcMessage("Only the default FE index is allowed for DoFHandler "
+                        "objects without hp capability"));
+      AssertIndexRange(local_index,
+                       dof_handler.get_fe().template n_dofs_per_object<dim>());
+      AssertIndexRange(
+        obj_index * dof_handler.get_fe().template n_dofs_per_object<dim>() +
+          local_index,
+        dofs.size());
 
       return dofs[obj_index *
                     dof_handler.get_fe().template n_dofs_per_object<dim>() +


### PR DESCRIPTION
Update some text now that `hp::DoFHandler` is gone. Also use the `AssertIndexRange` macro for nicer messages.