### PR TITLE
Remove deprecated XDMFEntry::get_xdmf_content

### DIFF
--- a/doc/news/changes/incompatibilities/20220627Arndt-1
+++ b/doc/news/changes/incompatibilities/20220627Arndt-1
@@ -1,0 +1,4 @@
+Removed: The deprecated overload of XDMFEntry::get_xdmf_content()
+has been removed.
+<br>
+(Daniel Arndt, 2022/06/27)

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -3372,17 +3372,6 @@ public:
   /**
    * Get the XDMF content associated with this entry.
    * If the entry is not valid, this returns an empty string.
-   *
-   * @deprecated Use the overload taking an `unsigned int` and a
-   * `const ReferenceCell &` instead.
-   */
-  DEAL_II_DEPRECATED
-  std::string
-  get_xdmf_content(const unsigned int indent_level) const;
-
-  /**
-   * Get the XDMF content associated with this entry.
-   * If the entry is not valid, this returns an empty string.
    */
   std::string
   get_xdmf_content(const unsigned int   indent_level,

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -9200,32 +9200,6 @@ namespace
 
 
 std::string
-XDMFEntry::get_xdmf_content(const unsigned int indent_level) const
-{
-  switch (dimension)
-    {
-      case 0:
-        return get_xdmf_content(indent_level,
-                                ReferenceCells::get_hypercube<0>());
-      case 1:
-        return get_xdmf_content(indent_level,
-                                ReferenceCells::get_hypercube<1>());
-      case 2:
-        return get_xdmf_content(indent_level,
-                                ReferenceCells::get_hypercube<2>());
-      case 3:
-        return get_xdmf_content(indent_level,
-                                ReferenceCells::get_hypercube<3>());
-      default:
-        Assert(false, ExcNotImplemented());
-    }
-
-  return "";
-}
-
-
-
-std::string
 XDMFEntry::get_xdmf_content(const unsigned int   indent_level,
                             const ReferenceCell &reference_cell) const
 {

--- a/tests/data_out/data_out_hdf5_02.cc
+++ b/tests/data_out/data_out_hdf5_02.cc
@@ -134,7 +134,7 @@ check()
     << "    <Grid Name=\"CellTime\" GridType=\"Collection\" CollectionType=\"Temporal\">\n";
 
   // Write out the entry
-  xdmf_file << entry.get_xdmf_content(3);
+  xdmf_file << entry.get_xdmf_content(3, ReferenceCells::get_hypercube<dim>());
 
   xdmf_file << "    </Grid>\n";
   xdmf_file << "  </Domain>\n";

--- a/tests/mpi/data_out_hdf5_02.cc
+++ b/tests/mpi/data_out_hdf5_02.cc
@@ -86,7 +86,7 @@ check()
     << "    <Grid Name=\"CellTime\" GridType=\"Collection\" CollectionType=\"Temporal\">\n";
 
   // Write out the entry
-  xdmf_file << entry.get_xdmf_content(3);
+  xdmf_file << entry.get_xdmf_content(3, ReferenceCells::get_hypercube<dim>());
 
   xdmf_file << "    </Grid>\n";
   xdmf_file << "  </Domain>\n";

--- a/tests/serialization/xdmf_entry.cc
+++ b/tests/serialization/xdmf_entry.cc
@@ -54,11 +54,13 @@ test()
 
   deallog << "XDMFEntry before serialization: " << std::endl
           << std::endl
-          << entry1.get_xdmf_content(0) << std::endl;
+          << entry1.get_xdmf_content(0, ReferenceCells::get_hypercube<dim>())
+          << std::endl;
 
   deallog << "XDMFEntry after de-serialization: " << std::endl
           << std::endl
-          << entry2.get_xdmf_content(0) << std::endl;
+          << entry2.get_xdmf_content(0, ReferenceCells::get_hypercube<dim>())
+          << std::endl;
 }
 
 


### PR DESCRIPTION
Deprecated in https://github.com/dealii/dealii/pull/10852.