### PR TITLE
Remove CellId::to_cell

### DIFF
--- a/doc/news/changes/incompatibilities/20220628Arndt
+++ b/doc/news/changes/incompatibilities/20220628Arndt
@@ -1,0 +1,3 @@
+Removed: The deprecated member function CellId::to_cell() has been removed.
+<br>
+(Daniel Arndt, 2022/06/28)

--- a/include/deal.II/grid/cell_id.h
+++ b/include/deal.II/grid/cell_id.h
@@ -147,15 +147,6 @@ public:
   to_binary() const;
 
   /**
-   * Return a cell_iterator to the cell represented by this CellId.
-   *
-   * @deprecated Use Triangulation::create_cell_iterator() instead.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED typename Triangulation<dim, spacedim>::cell_iterator
-  to_cell(const Triangulation<dim, spacedim> &tria) const;
-
-  /**
    * Compare two CellId objects for equality.
    */
   bool

--- a/source/grid/cell_id.cc
+++ b/source/grid/cell_id.cc
@@ -161,15 +161,6 @@ CellId::to_string() const
 }
 
 
-
-template <int dim, int spacedim>
-typename Triangulation<dim, spacedim>::cell_iterator
-CellId::to_cell(const Triangulation<dim, spacedim> &tria) const
-{
-  return tria.create_cell_iterator(*this);
-}
-
-
 // explicit instantiations
 #include "cell_id.inst"
 

--- a/source/grid/cell_id.inst.in
+++ b/source/grid/cell_id.inst.in
@@ -15,17 +15,6 @@
 
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
-  {
-#if deal_II_dimension <= deal_II_space_dimension
-    template Triangulation<deal_II_dimension,
-                           deal_II_space_dimension>::cell_iterator
-    CellId::to_cell(
-      const Triangulation<deal_II_dimension, deal_II_space_dimension> &tria)
-      const;
-#endif
-  }
-
 for (deal_II_dimension : DIMENSIONS)
   {
     template CellId::binary_type CellId::to_binary<deal_II_dimension>() const;

--- a/tests/distributed_grids/refine_periodic_02.cc
+++ b/tests/distributed_grids/refine_periodic_02.cc
@@ -195,10 +195,10 @@ test()
           << "n_levels: " << tr.n_levels() << std::endl;
 
   for (const auto &id : marked_coarsen)
-    CellId(id).to_cell(tr)->set_coarsen_flag();
+    tr.create_cell_iterator(CellId(id))->set_coarsen_flag();
 
   for (const auto &id : marked_refine)
-    CellId(id).to_cell(tr)->set_refine_flag();
+    tr.create_cell_iterator(CellId(id))->set_refine_flag();
 
   deallog << "execute_coarsening_and_refinement()..." << std::endl;
 


### PR DESCRIPTION
Deprecated in https://github.com/dealii/dealii/pull/11365.