### PR TITLE
Remove remaining deprecations

### DIFF
--- a/doc/news/changes/incompatibilities/20220629Arndt
+++ b/doc/news/changes/incompatibilities/20220629Arndt
@@ -1,0 +1,4 @@
+Removed: The deprecated QTrapezoid, ParticleHandler::locally_relevant_ids(),
+and Arkode::reinit_vector have been removed.
+<br>
+(Daniel Arndt, 2022/06/29)

--- a/doc/news/changes/incompatibilities/20220629Arndt
+++ b/doc/news/changes/incompatibilities/20220629Arndt
@@ -1,4 +1,4 @@
-Removed: The deprecated QTrapezoid, ParticleHandler::locally_relevant_ids(),
+Removed: The deprecated QTrapez, ParticleHandler::locally_relevant_ids(),
 and Arkode::reinit_vector have been removed.
 <br>
 (Daniel Arndt, 2022/06/29)

--- a/include/deal.II/base/quadrature_lib.h
+++ b/include/deal.II/base/quadrature_lib.h
@@ -128,22 +128,6 @@ public:
 
 
 /**
- * An alias for QTrapezoid available for historic reasons. This name is
- * deprecated.
- *
- * The class was originally named QTrapez, a poorly named choice since the
- * proper name of the quadrature formula
- * is "trapezoidal rule", or sometimes also called the "trapezoid rule". The
- * misnomer resulted from the fact that its original authors' poor English
- * language skills led them to translate the name incorrectly from the German
- * "Trapezregel".
- */
-template <int dim>
-using QTrapez DEAL_II_DEPRECATED = QTrapezoid<dim>;
-
-
-
-/**
  * The Milne rule for numerical quadrature formula. The Milne rule is a closed
  * Newton-Cotes formula and is exact for polynomials of degree 5.
  *

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -2489,8 +2489,7 @@ namespace FETools
                     // find sub-quadrature
                     position = name.find('(');
                     const std::string subquadrature_name(name, 0, position);
-                    AssertThrow(subquadrature_name == "QTrapez" ||
-                                  subquadrature_name == "QTrapezoid",
+                    AssertThrow(subquadrature_name == "QTrapezoid",
                                 ExcNotImplemented(
                                   "Could not detect quadrature of name " +
                                   subquadrature_name));

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -236,7 +236,7 @@ public:
    *
    * @note The weights of the quadrature object are left unfilled and
    *   consequently the object cannot usefully be used for actually
-   *   computing integrals. This is in contrast to, for example, the QTrapez
+   *   computing integrals. This is in contrast to, for example, the QTrapezoid
    *   class that correctly sets quadrature weights.
    */
   template <int dim>

--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -669,27 +669,6 @@ namespace Particles
      *
      * @return An IndexSet of size get_next_free_particle_index(), containing
      * n_locally_owned_particle() indices.
-     *
-     * @deprecated Use locally_owned_particle_ids() instead.
-     */
-    DEAL_II_DEPRECATED IndexSet
-    locally_relevant_ids() const;
-
-    /**
-     * Extract an IndexSet with global dimensions equal to
-     * get_next_free_particle_index(), containing the locally owned
-     * particle indices.
-     *
-     * This function can be used to construct distributed vectors and matrices
-     * to manipulate particles using linear algebra operations.
-     *
-     * Notice that it is the user's responsibility to guarantee that particle
-     * indices are unique, and no check is performed to verify that this is the
-     * case, nor that the union of all IndexSet objects on each mpi process is
-     * complete.
-     *
-     * @return An IndexSet of size get_next_free_particle_index(), containing
-     * n_locally_owned_particle() indices.
      */
     IndexSet
     locally_owned_particle_ids() const;
@@ -1401,15 +1380,6 @@ namespace Particles
       output_vector.compress(VectorOperation::add);
     else
       output_vector.compress(VectorOperation::insert);
-  }
-
-
-
-  template <int dim, int spacedim>
-  inline IndexSet
-  ParticleHandler<dim, spacedim>::locally_relevant_ids() const
-  {
-    return this->locally_owned_particle_ids();
   }
 
 } // namespace Particles

--- a/include/deal.II/sundials/arkode.h
+++ b/include/deal.II/sundials/arkode.h
@@ -570,17 +570,6 @@ namespace SUNDIALS
     get_arkode_memory() const;
 
     /**
-     * A function object that was used to `reinit` the given vector. Setting
-     * this field does no longer have any effect and all auxiliary vectors are
-     * reinit-ed automatically based on the user-supplied vector in solve_ode().
-     *
-     * @deprecated This function is no longer used and can be safely removed in
-     *   user code.
-     */
-    DEAL_II_DEPRECATED
-    std::function<void(VectorType &)> reinit_vector;
-
-    /**
      * A function object that users may supply and that is intended to compute
      * the explicit part of the IVP right hand side. Sets $explicit_f = f_E(t,
      * y)$.

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -1689,10 +1689,10 @@ TransfiniteInterpolationManifold<dim, spacedim>::initialize(
   //
   // In the co-dimension one case (meaning  dim < spacedim) we have to fall
   // back to a simple GridTools::affine_cell_approximation<dim>() which
-  // requires 2^dim points, instead. Thus, initialize the QIteraded
+  // requires 2^dim points, instead. Thus, initialize the QIterated
   // quadrature with no subdivisions.
   std::vector<Point<dim>> unit_points =
-    QIterated<dim>(QTrapez<1>(), (dim == spacedim ? 2 : 1)).get_points();
+    QIterated<dim>(QTrapezoid<1>(), (dim == spacedim ? 2 : 1)).get_points();
   std::vector<Point<spacedim>> real_points(unit_points.size());
 
   for (const auto &cell : triangulation.active_cell_iterators())

--- a/source/sundials/arkode.cc
+++ b/source/sundials/arkode.cc
@@ -679,10 +679,6 @@ namespace SUNDIALS
   void
   ARKode<VectorType>::set_functions_to_trigger_an_assert()
   {
-    reinit_vector = [](VectorType &) {
-      AssertThrow(false, ExcFunctionNotProvided("reinit_vector"));
-    };
-
     solver_should_restart = [](const double, VectorType &) -> bool {
       return false;
     };

--- a/tests/bits/point_value_03.cc
+++ b/tests/bits/point_value_03.cc
@@ -124,7 +124,7 @@ check()
   parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD);
   make_mesh(tria);
 
-  FE_Q<dim>       element(QIterated<1>(QTrapez<1>(), 3));
+  FE_Q<dim>       element(QIterated<1>(QTrapezoid<1>(), 3));
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(element);
 

--- a/tests/matrix_free/tensor_product_evaluate_01.cc
+++ b/tests/matrix_free/tensor_product_evaluate_01.cc
@@ -65,7 +65,7 @@ test(const unsigned int degree)
 
   const std::vector<Point<dim>> evaluation_points =
     dim == 3 ? QGauss<dim>(2).get_points() :
-               QIterated<dim>(QTrapez<1>(), 3).get_points();
+               QIterated<dim>(QTrapezoid<1>(), 3).get_points();
 
   deallog << "Evaluate in " << dim << "d with polynomial degree " << degree
           << std::endl;

--- a/tests/matrix_free/tensor_product_evaluate_02.cc
+++ b/tests/matrix_free/tensor_product_evaluate_02.cc
@@ -60,7 +60,7 @@ test(const unsigned int degree)
 
   const std::vector<Point<dim>> evaluation_points =
     dim == 3 ? QGauss<dim>(2).get_points() :
-               QIterated<dim>(QTrapez<1>(), 3).get_points();
+               QIterated<dim>(QTrapezoid<1>(), 3).get_points();
 
   deallog << "Evaluate in " << dim << "d with polynomial degree " << degree
           << std::endl;

--- a/tests/matrix_free/tensor_product_evaluate_03.cc
+++ b/tests/matrix_free/tensor_product_evaluate_03.cc
@@ -61,7 +61,7 @@ test(const unsigned int degree)
 
   const std::vector<Point<dim>> evaluation_points =
     dim == 3 ? QGauss<dim>(2).get_points() :
-               QIterated<dim>(QTrapez<1>(), 3).get_points();
+               QIterated<dim>(QTrapezoid<1>(), 3).get_points();
 
   deallog << "Evaluate in " << dim << "d with polynomial degree " << degree
           << std::endl;

--- a/tests/matrix_free/tensor_product_evaluate_04.cc
+++ b/tests/matrix_free/tensor_product_evaluate_04.cc
@@ -58,7 +58,7 @@ test(const unsigned int degree)
 
   const std::vector<Point<dim>> evaluation_points =
     dim == 3 ? QGauss<dim>(2).get_points() :
-               QIterated<dim>(QTrapez<1>(), 3).get_points();
+               QIterated<dim>(QTrapezoid<1>(), 3).get_points();
 
   deallog << "Evaluate in " << dim << "d with polynomial degree " << degree
           << std::endl;

--- a/tests/matrix_free/tensor_product_evaluate_05.cc
+++ b/tests/matrix_free/tensor_product_evaluate_05.cc
@@ -59,7 +59,7 @@ test(const unsigned int degree)
 
   const std::vector<Point<dim>> evaluation_points =
     dim == 3 ? QGauss<dim>(2).get_points() :
-               QIterated<dim>(QTrapez<1>(), 3).get_points();
+               QIterated<dim>(QTrapezoid<1>(), 3).get_points();
 
   deallog << "Evaluate in " << dim << "d with polynomial degree " << degree
           << std::endl;

--- a/tests/matrix_free/tensor_product_evaluate_06.cc
+++ b/tests/matrix_free/tensor_product_evaluate_06.cc
@@ -55,7 +55,7 @@ test(const unsigned int degree)
 
   const std::vector<Point<dim>> evaluation_points =
     dim == 3 ? QGauss<dim>(2).get_points() :
-               QIterated<dim>(QTrapez<1>(), 3).get_points();
+               QIterated<dim>(QTrapezoid<1>(), 3).get_points();
 
   deallog << "Evaluate in " << dim << "d with polynomial degree " << degree
           << std::endl;


### PR DESCRIPTION
In combination with #9937 and #14070, this should be the last deprecation to be removed for the next release.
Deprecated in https://github.com/dealii/dealii/pull/10981, https://github.com/dealii/dealii/pull/12119, and https://github.com/dealii/dealii/pull/11661.