### PR TITLE
doxygen: fix errors in formulas

### DIFF
--- a/examples/step-75/doc/intro.dox
+++ b/examples/step-75/doc/intro.dox
@@ -133,7 +133,7 @@ be the Mapping from $K$ to its reference cell $\hat{K}$. The entries in
 the right-hand side in the projection system are, therefore,
 @f[
 \int_K u_\text{hp}(x) P_k(x) dx
-= \det(J_K) \int_\hat{K} u_\text{hp}(F_K(\hat{x})) P_k(F_K(\hat{x})) d\hat{x}.
+= \det(J_K) \int_{\hat{K}} u_\text{hp}(F_K(\hat{x})) P_k(F_K(\hat{x})) d\hat{x}.
 @f]
 Recalling the shape function representation of $u_\text{hp}(x)$, we can
 write this as $\det(J_K) \, \mathbf{C} \, \mathbf{c}$, where

--- a/include/deal.II/non_matching/quadrature_generator.h
+++ b/include/deal.II/non_matching/quadrature_generator.h
@@ -906,7 +906,7 @@ namespace NonMatching
          * The roots of the functions in point_restrictions.
          * This will be the values of the height functions, $\{H_i(x_I)\}$ at
          * some lower dimensional quadrature point,
-         * $x_I \in \mathbb{R}^{dim-1}}$.
+         * $x_I \in \mathbb{R}^{dim-1}$.
          */
         std::vector<double> roots;
       };


### PR DESCRIPTION
This fixes 
```
error: Problems running latex. Check your installation or look for typos in _formulas.tex and check _formulas.log!
```
for me.

This would have been great to have in 9.4.