### PR TITLE
Bugfix: Use correct relative tolerance in MappingCartesian assert.

### DIFF
--- a/doc/news/changes/minor/20220704gassmoeller
+++ b/doc/news/changes/minor/20220704gassmoeller
@@ -1,0 +1,5 @@
+Fixed: MappingCartesian used to throw exceptions in debug mode when checking if
+small cells in a large domain size are actually aligned to coordinate axes.
+This is fixed now.
+<br>
++(Rene Gassmoeller, 2022/07/04)

--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -55,12 +55,21 @@ is_cartesian(const CellType &cell)
   if (!cell->reference_cell().is_hyper_cube())
     return false;
 
-  const double tolerance    = 1e-14 * cell->diameter();
-  const auto   bounding_box = cell->bounding_box();
+  const double tolerance         = 1e-14;
+  const auto   bounding_box      = cell->bounding_box();
+  const auto & bounding_vertices = bounding_box.get_boundary_points();
+  const auto   cell_measure =
+    bounding_vertices.first.distance_square(bounding_vertices.second);
 
   for (const unsigned int v : cell->vertex_indices())
-    if (cell->vertex(v).distance(bounding_box.vertex(v)) > tolerance)
-      return false;
+    {
+      const double vertex_tolerance =
+        tolerance * std::max(cell->vertex(v).norm_square(), cell_measure);
+
+      if (cell->vertex(v).distance_square(bounding_box.vertex(v)) >
+          vertex_tolerance)
+        return false;
+    }
 
   return true;
 }

--- a/tests/mappings/mapping_cartesian_03.cc
+++ b/tests/mappings/mapping_cartesian_03.cc
@@ -1,0 +1,94 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2003 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// there used to be a bug in MappingCartesian, where an assert was triggered
+// for valid cells if the cells where too small compared to the dimension
+// of the triangulation. The bug would not occur for coarse grids,
+// but would reliably be triggered with higher refinement level.
+// In this test we move the origin of the box to trigger the bug
+// easier, but it would also occur with a zero origin (just requiring higher
+// refinement levels).
+
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping_cartesian.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/manifold_lib.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+
+#include "../tests.h"
+
+
+
+template <int dim>
+void
+check(const Triangulation<dim> &tria)
+{
+  MappingCartesian<dim> mapping;
+  FE_Q<dim>             fe(1);
+  DoFHandler<dim>       dof_handler(tria);
+  dof_handler.distribute_dofs(fe);
+
+  QGauss<dim> quadrature(1);
+
+  UpdateFlags update_flags = update_quadrature_points | update_values;
+
+  FEValues<dim> fe_values(mapping, fe, quadrature, update_flags);
+
+  for (auto cell : dof_handler.active_cell_iterators())
+    fe_values.reinit(cell);
+
+  deallog << std::endl;
+
+  deallog << "OK" << std::endl;
+}
+
+
+int
+main()
+{
+  initlog();
+
+  {
+    Triangulation<2>          coarse_grid;
+    std::vector<unsigned int> rep_vec({9, 2});
+    Point<2>                  box_origin(3000000., 660000.);
+    Point<2>                  extents(3000000., 660000.);
+    GridGenerator::subdivided_hyper_rectangle(
+      coarse_grid, rep_vec, box_origin, box_origin + extents, true);
+    coarse_grid.refine_global(2);
+    check(coarse_grid);
+  }
+
+  {
+    Triangulation<3>          coarse_grid;
+    std::vector<unsigned int> rep_vec({9, 9, 2});
+    Point<3>                  box_origin(3000000., 3000000., 660000.);
+    Point<3>                  extents(3000000., 3000000., 660000.);
+    GridGenerator::subdivided_hyper_rectangle(
+      coarse_grid, rep_vec, box_origin, box_origin + extents, true);
+    coarse_grid.refine_global(2);
+    check(coarse_grid);
+  }
+}

--- a/tests/mappings/mapping_cartesian_03.output
+++ b/tests/mappings/mapping_cartesian_03.output
@@ -1,0 +1,5 @@
+
+DEAL::
+DEAL::OK
+DEAL::
+DEAL::OK


### PR DESCRIPTION
This is a fix for a bug in MappingCartesian that breaks some models and tests in geodynamics/aspect. Unfortunately this was not tested for before the release of 9.4 (my fault, I didnt have the time to run our full test suite with the release candidate; I will try to set up a CI to do this in the future). 

The problem: Since #13748 MappingCartesian asserts that the incoming cell in many functions actually is cartesian (i.e. vertices are aligned with coordinates). However, it uses an unsuitable relative tolerance that only depends on the cell diameter and not on the norm of the vertex itself. This means that if the cell is much smaller than the model dimension (e.g. for moderate refinement levels) this assert is triggered purely because of floating point imprecision. I added a test case that triggers the bug at a refinement level of 2 (it is artificially placing the origin far away from 0 to trigger the bug at low refinement levels. in practice I had a model with a zero origin triggering the bug at refinement level 4). The fix is to make the tolerance dependent on the norm of the vertex itself. I added the cell extension as an additional safeguard for vertices close to the center, but maybe it is not even needed. With this fix the test and all the failing tests in ASPECT work correctly.

I am not sure what to do with this PR, I would need someone with more experience to chime in, on if this should somehow make its way into a 9.4.1 eventually. At the moment MappingCartesian will probably throw asserts in debug mode for all models with small cells compared to the extension of the triangulation.

Also let me know where and if to write a changelog entry.