### PR TITLE
[CI] limit parallelism in docker master build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,9 @@ name: github-docker
 
 on: 
   push: 
-    branches: [master]
+    branches:
+      - 'docker*'
+      - 'master'
 
 permissions:
   contents: read
@@ -30,7 +32,7 @@ jobs:
           context: ./contrib/docker/
           cache-from: type=registry,ref=dealii/dependencies:focal
           cache-to: type=inline
-          push: true
+          push: false
           tags: dealii/dealii:master-focal
 
       - name: Build and push Docker image of master with root user
@@ -40,6 +42,6 @@ jobs:
           file: ./contrib/docker/Dockerfile.root
           cache-from: type=registry,ref=dealii/dealii:master-focal
           cache-to: type=inline
-          push: true
+          push: false
           tags: dealii/dealii:master-focal-root
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,7 @@ jobs:
           context: ./contrib/docker/
           cache-from: type=registry,ref=dealii/dependencies:focal
           cache-to: type=inline
-          push: false
+          push: ${{github.ref_name == 'master'}}
           tags: dealii/dealii:master-focal
 
       - name: Build and push Docker image of master with root user
@@ -42,6 +42,6 @@ jobs:
           file: ./contrib/docker/Dockerfile.root
           cache-from: type=registry,ref=dealii/dealii:master-focal
           cache-to: type=inline
-          push: false
+          push: ${{github.ref_name == 'master'}}
           tags: dealii/dealii:master-focal-root
 

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN cd /usr/src \
     -DDEAL_II_WITH_MPI=ON \
     -DCMAKE_CXX_FLAGS="-std=c++17" \
     .. \  
-    && ninja install \
+    && ninja -j 2 install \
     && cd ../ && rm -rf .git build
 
 USER $USER


### PR DESCRIPTION
The docker build of the master image seems to fail the last couple of days due to lack of memory:
   ```
7 5395.8 c++: fatal error: Killed signal terminated program cc1plus
```
see https://github.com/dealii/dealii/runs/7171343247?check_suite_focus=true#step:5:1813

Fix this by specifying ``-j 2`` as the github runners have two cores and ninja will oversubscribe to 4, I think. We don't care about the speed of this CI step, so this should be okay.

Also allow testing the changes of this CI step by also testing all branches in dealii/dealii that start with "docker-". It is a bit annoying having to create the PRs from branches pushed directly to this repo, but this is better than the situation before (no way to test without merging). I can untangle the PRs if you guys want me to.