### PR TITLE
AssertThrow for BlockVector usage in MassOperator

### DIFF
--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -730,7 +730,7 @@ namespace MatrixFreeOperators
   /**
    * This class implements the operation of the action of a mass matrix.
    *
-   * Note that this class only supports the non-blocked vector variant of the
+   * @note This class only supports the non-blocked vector variant of the
    * Base operator because only a single FEEvaluation object is used in the
    * apply function.
    */

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -1831,7 +1831,12 @@ namespace MatrixFreeOperators
                VectorType,
                VectorizedArrayType>::MassOperator()
     : Base<dim, VectorType, VectorizedArrayType>()
-  {}
+  {
+    AssertThrow(
+      IsBlockVector<VectorType>::value == false,
+      ExcNotImplemented(
+        "This class only supports the non-blocked vector variant of the Base operator because only a single FEEvaluation object is used in the apply function."));
+  }
 
 
 

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -1835,7 +1835,9 @@ namespace MatrixFreeOperators
     AssertThrow(
       IsBlockVector<VectorType>::value == false,
       ExcNotImplemented(
-        "This class only supports the non-blocked vector variant of the Base operator because only a single FEEvaluation object is used in the apply function."));
+        "This class only supports the non-blocked vector variant of the Base "
+        "operator because only a single FEEvaluation object is used in the "
+        "apply function."));
   }
 
 


### PR DESCRIPTION
1. Maybe highlight this note in the documentation of the MassOperator a bit more. I just run intho this trap.
2. Add an AssertThrow in the constructor of this class to catch the not implemented case.