### PR TITLE
Simplify some MPI code.

### DIFF
--- a/source/multigrid/mg_transfer_internal.cc
+++ b/source/multigrid/mg_transfer_internal.cc
@@ -291,31 +291,16 @@ namespace internal
               {
                 requests.push_back(MPI_Request());
                 std::vector<DoFPair> &data = send_data[dest];
-                // If there is nothing to send, we still need to send a message,
-                // because the receiving end will be waitng. In that case we
-                // just send an empty message.
-                if (data.size())
-                  {
-                    const int ierr = MPI_Isend(data.data(),
-                                               data.size() * sizeof(data[0]),
-                                               MPI_BYTE,
-                                               dest,
-                                               mpi_tag,
-                                               tria->get_communicator(),
-                                               &*requests.rbegin());
-                    AssertThrowMPI(ierr);
-                  }
-                else
-                  {
-                    const int ierr = MPI_Isend(nullptr,
-                                               0,
-                                               MPI_BYTE,
-                                               dest,
-                                               mpi_tag,
-                                               tria->get_communicator(),
-                                               &*requests.rbegin());
-                    AssertThrowMPI(ierr);
-                  }
+
+                const int ierr =
+                  MPI_Isend(data.data(),
+                            data.size() * sizeof(decltype(*data.data())),
+                            MPI_BYTE,
+                            dest,
+                            mpi_tag,
+                            tria->get_communicator(),
+                            &*requests.rbegin());
+                AssertThrowMPI(ierr);
               }
           }
 


### PR DESCRIPTION
I believe the code dates back to a time when we used `&vec[0]` instead of `vec.data()`. The former gave us trouble when the vector was empty, and so we had to write special case code, but we can now safely write `vec.data()` which simply returns `nullptr` when the vector is empty. As a consequence, I believe that the code in the `if` case can now also handle the `else` situation without harm and we can just remove the whole `if-else` thing.

/rebuild