### PR TITLE
Ensure to look at square of tolerances

### DIFF
--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -55,8 +55,11 @@ is_cartesian(const CellType &cell)
   if (!cell->reference_cell().is_hyper_cube())
     return false;
 
-  const double abs_tol           = 1e-15;
-  const double rel_tol           = 1e-14;
+  // The tolerances here are somewhat larger than the square of the machine
+  // epsilon, because we are going to compare the square of distances (to
+  // avoid computing square roots).
+  const double abs_tol           = 1e-30;
+  const double rel_tol           = 1e-28;
   const auto   bounding_box      = cell->bounding_box();
   const auto & bounding_vertices = bounding_box.get_boundary_points();
   const auto   bb_diagonal_length_squared =


### PR DESCRIPTION
@bangerth @gassmoeller regarding the tolerance topic I checked the numbers again and believe we should have squares. The reason is that we take the difference between two vertices (each component of which we expect to either satisfy a relative tolerance against the cell diameter or against the absolute tolerance), and then the square in `square()` or `square_distance()`. As a result, the numbers should really be on the order of `machine_epsilon^2`. I looked into prototype numbers of the test that was added in #14092 and can confirm that numbers are really in that order of magnitude: We see squares of around 1e-19, compared to numbers which are 1e13, all of them being squares of either size 1e6 or 1e-9, the roundoff accuracy around 1e6.