### PR TITLE
MatrixFree: Implement get_affine_constraints()

### DIFF
--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -1631,6 +1631,15 @@ public:
   get_dof_handler(const unsigned int dof_handler_index = 0) const;
 
   /**
+   * Return the AffineConstraints with the index as given to the
+   * respective `std::vector` argument in the reinit() function. Only available
+   * if the AffineConstraints objects have the same template parameter Number as
+   * MatrixFree. Throws an exception otherwise.
+   */
+  const AffineConstraints<Number> &
+  get_affine_constraints(const unsigned int dof_handler_index = 0) const;
+
+  /**
    * Return the cell iterator in deal.II speak to a given cell batch
    * (populating several lanes in a VectorizedArray) and the lane index within
    * the vectorization across cells in the renumbering of this structure.
@@ -2001,6 +2010,14 @@ private:
    * Pointers to the DoFHandlers underlying the current problem.
    */
   std::vector<SmartPointer<const DoFHandler<dim>>> dof_handlers;
+
+  /**
+   * Pointers to the AffineConstraints underlying the current problem. Only
+   * filled with an AffineConstraints object if objects of the same `Number`
+   * template parameter as the `Number` template of MatrixFree is passed to
+   * reinit(). Filled with nullptr otherwise.
+   */
+  std::vector<SmartPointer<const AffineConstraints<Number>>> affine_constraints;
 
   /**
    * Contains the information about degrees of freedom on the individual cells

--- a/tests/matrix_free/affine_constraints_store_and_get.cc
+++ b/tests/matrix_free/affine_constraints_store_and_get.cc
@@ -1,0 +1,84 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 - 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// test internal::store_affine_constraints() and get_affine_constraints()
+
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_dgq.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/matrix_free/matrix_free.h>
+
+#include "../tests.h"
+
+
+int
+main()
+{
+  initlog();
+
+  const unsigned int fe_degree = 1;
+  constexpr int      dim       = 2;
+
+  Triangulation<dim> tria;
+  GridGenerator::hyper_cube(tria, 0, 1, true);
+
+  FE_DGQ<dim>     fe(fe_degree);
+  DoFHandler<dim> dof_handler(tria);
+  dof_handler.distribute_dofs(fe);
+
+  QGauss<1> quadrature(fe_degree + 1);
+
+  AffineConstraints<double> double_ac;
+  double_ac.close();
+
+  {
+    typename MatrixFree<dim, double>::AdditionalData additional_data_double;
+    MatrixFree<dim, double>                          matrix_free_double;
+    matrix_free_double.reinit(MappingQ1<dim>{},
+                              dof_handler,
+                              double_ac,
+                              quadrature,
+                              additional_data_double);
+
+    if (&matrix_free_double.get_affine_constraints() == &double_ac)
+      deallog << "OK" << std::endl;
+  }
+
+  {
+    typename MatrixFree<dim, float>::AdditionalData additional_data_float;
+    MatrixFree<dim, float>                          matrix_free_float;
+    matrix_free_float.reinit(MappingQ1<dim>{},
+                             dof_handler,
+                             double_ac,
+                             quadrature,
+                             additional_data_float);
+
+    try
+      {
+        matrix_free_float.get_affine_constraints();
+      }
+    catch (...)
+      {
+        deallog << "OK" << std::endl;
+      }
+  }
+}

--- a/tests/matrix_free/affine_constraints_store_and_get.output
+++ b/tests/matrix_free/affine_constraints_store_and_get.output
@@ -1,0 +1,3 @@
+
+DEAL::OK
+DEAL::OK


### PR DESCRIPTION
Allows to store the pointers to the `AffineConstraints` pointer vector given to `MatrixFree::reinit()` if they have the same `Number` template argument. The objects can then be queried from the `MatrixFree` object with the new function.

@peterrum @kronbichler 