### PR TITLE
Reduce the volume of communication somewhat.

### DIFF
--- a/source/distributed/shared_tria.cc
+++ b/source/distributed/shared_tria.cc
@@ -14,6 +14,7 @@
 // ---------------------------------------------------------------------
 
 #include <deal.II/base/mpi.h>
+#include <deal.II/base/mpi.templates.h>
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/distributed/shared_tria.h>
@@ -26,6 +27,8 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include <deal.II/lac/sparsity_tools.h>
+
+#include <type_traits>
 
 
 DEAL_II_NAMESPACE_OPEN
@@ -354,15 +357,30 @@ namespace parallel
       // make sure that all refinement/coarsening flags are the same on all
       // processes
       {
-        std::vector<unsigned int> refinement_configurations(
-          this->n_active_cells() * 2, 0u);
+        // Obtain the type used to store the different possibilities
+        // a cell can be refined. This is a bit awkward because
+        // what `cell->refine_flag_set()` returns is a struct
+        // type, RefinementCase, which internally stores a
+        // std::uint8_t, which actually holds integers of
+        // enum type RefinementPossibilities<dim>::Possibilities.
+        // In the following, use the actual name of the enum, but
+        // make sure that it is in fact a `std::uint8_t` or
+        // equally sized type.
+        using int_type = std::underlying_type_t<
+          typename RefinementPossibilities<dim>::Possibilities>;
+        static_assert(sizeof(int_type) == sizeof(std::uint8_t),
+                      "Internal type mismatch.");
+
+        std::vector<int_type> refinement_configurations(this->n_active_cells() *
+                                                          2,
+                                                        int_type(0));
         for (const auto &cell : this->active_cell_iterators())
           if (cell->is_locally_owned())
             {
               refinement_configurations[cell->active_cell_index() * 2 + 0] =
-                cell->refine_flag_set();
+                static_cast<int_type>(cell->refine_flag_set());
               refinement_configurations[cell->active_cell_index() * 2 + 1] =
-                cell->coarsen_flag_set();
+                static_cast<int_type>(cell->coarsen_flag_set() ? 1 : 0);
             }
 
         Utilities::MPI::max(refinement_configurations,
@@ -385,7 +403,7 @@ namespace parallel
               ExcMessage(
                 "Refinement/coarsening flags of cells are not consistent in parallel!"));
 
-            if (refinement_configurations[cell->active_cell_index() * 2 + 0] >
+            if (refinement_configurations[cell->active_cell_index() * 2 + 0] !=
                 0)
               cell->set_refine_flag(RefinementCase<dim>(
                 refinement_configurations[cell->active_cell_index() * 2 + 0]));


### PR DESCRIPTION
Small improvement to #14073. There is no need to send around 32-bit integer types when we know that 8-bit integers are enough.

/rebuild