### PR TITLE
p:d:GridRefinement: actually accept other types of triangulations

### DIFF
--- a/include/deal.II/distributed/grid_refinement.h
+++ b/include/deal.II/distributed/grid_refinement.h
@@ -154,11 +154,11 @@ namespace parallel
       template <int dim, typename Number, int spacedim>
       void
       refine_and_coarsen_fixed_number(
-        Triangulation<dim, spacedim> & tria,
-        const dealii::Vector<Number> & criteria,
-        const double                   top_fraction_of_cells,
-        const double                   bottom_fraction_of_cells,
-        const types::global_cell_index max_n_cells =
+        dealii::Triangulation<dim, spacedim> &tria,
+        const dealii::Vector<Number> &        criteria,
+        const double                          top_fraction_of_cells,
+        const double                          bottom_fraction_of_cells,
+        const types::global_cell_index        max_n_cells =
           std::numeric_limits<types::global_cell_index>::max());
 
       /**
@@ -208,10 +208,10 @@ namespace parallel
       template <int dim, typename Number, int spacedim>
       void
       refine_and_coarsen_fixed_fraction(
-        Triangulation<dim, spacedim> &tria,
-        const dealii::Vector<Number> &criteria,
-        const double                  top_fraction_of_error,
-        const double                  bottom_fraction_of_error,
+        dealii::Triangulation<dim, spacedim> &tria,
+        const dealii::Vector<Number> &        criteria,
+        const double                          top_fraction_of_error,
+        const double                          bottom_fraction_of_error,
         const VectorTools::NormType norm_type = VectorTools::NormType::L1_norm);
     } // namespace GridRefinement
   }   // namespace distributed

--- a/source/distributed/grid_refinement.cc
+++ b/source/distributed/grid_refinement.cc
@@ -113,10 +113,9 @@ namespace
    */
   template <int dim, int spacedim, typename Number>
   void
-  get_locally_owned_indicators(
-    const parallel::distributed::Triangulation<dim, spacedim> &tria,
-    const dealii::Vector<Number> &                             criteria,
-    Vector<Number> &locally_owned_indicators)
+  get_locally_owned_indicators(const dealii::Triangulation<dim, spacedim> &tria,
+                               const dealii::Vector<Number> &criteria,
+                               Vector<Number> &locally_owned_indicators)
   {
     Assert(locally_owned_indicators.size() ==
              n_locally_owned_active_cells(tria),
@@ -182,10 +181,10 @@ namespace
    */
   template <int dim, int spacedim, typename Number>
   void
-  mark_cells(parallel::distributed::Triangulation<dim, spacedim> &tria,
-             const dealii::Vector<Number> &                       criteria,
-             const double                                         top_threshold,
-             const double bottom_threshold)
+  mark_cells(dealii::Triangulation<dim, spacedim> &tria,
+             const dealii::Vector<Number> &        criteria,
+             const double                          top_threshold,
+             const double                          bottom_threshold)
   {
     dealii::GridRefinement::refine(tria, criteria, top_threshold);
     dealii::GridRefinement::coarsen(tria, criteria, bottom_threshold);
@@ -212,10 +211,10 @@ namespace
   template <int dim, int spacedim, typename Number>
   void
   refine_and_coarsen_fixed_fraction_via_l1_norm(
-    parallel::distributed::Triangulation<dim, spacedim> &tria,
-    const dealii::Vector<Number> &                       criteria,
-    const double                                         top_fraction_of_error,
-    const double bottom_fraction_of_error)
+    dealii::Triangulation<dim, spacedim> &tria,
+    const dealii::Vector<Number> &        criteria,
+    const double                          top_fraction_of_error,
+    const double                          bottom_fraction_of_error)
   {
     // first extract from the vector of indicators the ones that correspond
     // to cells that we locally own
@@ -503,11 +502,11 @@ namespace parallel
       template <int dim, typename Number, int spacedim>
       void
       refine_and_coarsen_fixed_number(
-        parallel::distributed::Triangulation<dim, spacedim> &tria,
-        const dealii::Vector<Number> &                       criteria,
-        const double                   top_fraction_of_cells,
-        const double                   bottom_fraction_of_cells,
-        const types::global_cell_index max_n_cells)
+        dealii::Triangulation<dim, spacedim> &tria,
+        const dealii::Vector<Number> &        criteria,
+        const double                          top_fraction_of_cells,
+        const double                          bottom_fraction_of_cells,
+        const types::global_cell_index        max_n_cells)
       {
         Assert(criteria.size() == tria.n_active_cells(),
                ExcDimensionMismatch(criteria.size(), tria.n_active_cells()));
@@ -576,11 +575,11 @@ namespace parallel
       template <int dim, typename Number, int spacedim>
       void
       refine_and_coarsen_fixed_fraction(
-        parallel::distributed::Triangulation<dim, spacedim> &tria,
-        const dealii::Vector<Number> &                       criteria,
-        const double                top_fraction_of_error,
-        const double                bottom_fraction_of_error,
-        const VectorTools::NormType norm_type)
+        dealii::Triangulation<dim, spacedim> &tria,
+        const dealii::Vector<Number> &        criteria,
+        const double                          top_fraction_of_error,
+        const double                          bottom_fraction_of_error,
+        const VectorTools::NormType           norm_type)
       {
         Assert(criteria.size() == tria.n_active_cells(),
                ExcDimensionMismatch(criteria.size(), tria.n_active_cells()));

--- a/source/distributed/grid_refinement.inst.in
+++ b/source/distributed/grid_refinement.inst.in
@@ -65,7 +65,7 @@ for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
           refine_and_coarsen_fixed_number<deal_II_dimension,
                                           S,
                                           deal_II_dimension>(
-            Triangulation<deal_II_dimension> &,
+            dealii::Triangulation<deal_II_dimension> &,
             const dealii::Vector<S> &,
             const double,
             const double,
@@ -75,7 +75,7 @@ for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
           refine_and_coarsen_fixed_fraction<deal_II_dimension,
                                             S,
                                             deal_II_dimension>(
-            Triangulation<deal_II_dimension> &,
+            dealii::Triangulation<deal_II_dimension> &,
             const dealii::Vector<S> &,
             const double,
             const double,
@@ -97,7 +97,7 @@ for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
           refine_and_coarsen_fixed_number<deal_II_dimension - 1,
                                           S,
                                           deal_II_dimension>(
-            Triangulation<deal_II_dimension - 1, deal_II_dimension> &,
+            dealii::Triangulation<deal_II_dimension - 1, deal_II_dimension> &,
             const dealii::Vector<S> &,
             const double,
             const double,
@@ -107,7 +107,7 @@ for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
           refine_and_coarsen_fixed_fraction<deal_II_dimension - 1,
                                             S,
                                             deal_II_dimension>(
-            Triangulation<deal_II_dimension - 1, deal_II_dimension> &,
+            dealii::Triangulation<deal_II_dimension - 1, deal_II_dimension> &,
             const dealii::Vector<S> &,
             const double,
             const double,


### PR DESCRIPTION
Follow up to #14072.

I noticed that only changing `p:d:T` to `Trianguation` was not enough, since we are in the `p:d` namespace.