### PR TITLE
Replace std::enable_if by std::enable_if_t throughout.

### DIFF
--- a/include/deal.II/base/complex_overloads.h
+++ b/include/deal.II/base/complex_overloads.h
@@ -37,9 +37,9 @@ struct ProductType;
  * @relatesalso ProductType
  */
 template <typename T, typename U>
-inline typename std::enable_if<
+inline std::enable_if_t<
   std::is_floating_point<T>::value && std::is_floating_point<U>::value,
-  typename ProductType<std::complex<T>, std::complex<U>>::type>::type
+  typename ProductType<std::complex<T>, std::complex<U>>::type>
 operator*(const std::complex<T> &left, const std::complex<U> &right)
 {
   using result_type =
@@ -55,9 +55,9 @@ operator*(const std::complex<T> &left, const std::complex<U> &right)
  * @relatesalso ProductType
  */
 template <typename T, typename U>
-inline typename std::enable_if<
+inline std::enable_if_t<
   std::is_floating_point<T>::value && std::is_floating_point<U>::value,
-  typename ProductType<std::complex<T>, std::complex<U>>::type>::type
+  typename ProductType<std::complex<T>, std::complex<U>>::type>
 operator/(const std::complex<T> &left, const std::complex<U> &right)
 {
   using result_type =
@@ -73,11 +73,10 @@ operator/(const std::complex<T> &left, const std::complex<U> &right)
  * @relatesalso ProductType
  */
 template <typename T, typename U>
-inline
-  typename std::enable_if<std::is_floating_point<T>::value &&
-                            std::is_floating_point<U>::value,
-                          typename ProductType<std::complex<T>, U>::type>::type
-  operator*(const std::complex<T> &left, const U &right)
+inline std::enable_if_t<std::is_floating_point<T>::value &&
+                          std::is_floating_point<U>::value,
+                        typename ProductType<std::complex<T>, U>::type>
+operator*(const std::complex<T> &left, const U &right)
 {
   using result_type = typename ProductType<std::complex<T>, U>::type;
   return static_cast<result_type>(left) * static_cast<result_type>(right);
@@ -91,11 +90,10 @@ inline
  * @relatesalso ProductType
  */
 template <typename T, typename U>
-inline
-  typename std::enable_if<std::is_floating_point<T>::value &&
-                            std::is_floating_point<U>::value,
-                          typename ProductType<std::complex<T>, U>::type>::type
-  operator/(const std::complex<T> &left, const U &right)
+inline std::enable_if_t<std::is_floating_point<T>::value &&
+                          std::is_floating_point<U>::value,
+                        typename ProductType<std::complex<T>, U>::type>
+operator/(const std::complex<T> &left, const U &right)
 {
   using result_type = typename ProductType<std::complex<T>, U>::type;
   return static_cast<result_type>(left) / static_cast<result_type>(right);
@@ -109,12 +107,10 @@ inline
  * @relatesalso ProductType
  */
 template <typename T, typename U>
-inline typename
-
-  std::enable_if<std::is_floating_point<T>::value &&
-                   std::is_floating_point<U>::value,
-                 typename ProductType<T, std::complex<U>>::type>::type
-  operator*(const T &left, const std::complex<U> &right)
+inline std::enable_if_t<std::is_floating_point<T>::value &&
+                          std::is_floating_point<U>::value,
+                        typename ProductType<T, std::complex<U>>::type>
+operator*(const T &left, const std::complex<U> &right)
 {
   using result_type = typename ProductType<T, std::complex<U>>::type;
   return static_cast<result_type>(left) * static_cast<result_type>(right);
@@ -128,11 +124,10 @@ inline typename
  * @relatesalso ProductType
  */
 template <typename T, typename U>
-inline
-  typename std::enable_if<std::is_floating_point<T>::value &&
-                            std::is_floating_point<U>::value,
-                          typename ProductType<T, std::complex<U>>::type>::type
-  operator/(const T &left, const std::complex<U> &right)
+inline std::enable_if_t<std::is_floating_point<T>::value &&
+                          std::is_floating_point<U>::value,
+                        typename ProductType<T, std::complex<U>>::type>
+operator/(const T &left, const std::complex<U> &right)
 {
   using result_type = typename ProductType<T, std::complex<U>>::type;
   return static_cast<result_type>(left) / static_cast<result_type>(right);

--- a/include/deal.II/base/hdf5.h
+++ b/include/deal.II/base/hdf5.h
@@ -1210,29 +1210,29 @@ namespace HDF5
      * of the FullMatrix will be FullMatrix(dim_0,dim_2)
      */
     template <typename Container>
-    typename std::enable_if<
+    std::enable_if_t<
       std::is_same<Container,
                    std::vector<typename Container::value_type>>::value,
-      Container>::type
+      Container>
     initialize_container(const std::vector<hsize_t> &dimensions);
 
     /**
      * Same as above.
      */
     template <typename Container>
-    typename std::enable_if<
+    std::enable_if_t<
       std::is_same<Container, Vector<typename Container::value_type>>::value,
-      Container>::type
+      Container>
     initialize_container(const std::vector<hsize_t> &dimensions);
 
     /**
      * Same as above.
      */
     template <typename Container>
-    typename std::enable_if<
+    std::enable_if_t<
       std::is_same<Container,
                    FullMatrix<typename Container::value_type>>::value,
-      Container>::type
+      Container>
     initialize_container(const std::vector<hsize_t> &dimensions);
 
     /**
@@ -1418,10 +1418,10 @@ namespace HDF5
 
 
     template <typename Container>
-    typename std::enable_if<
+    std::enable_if_t<
       std::is_same<Container,
                    std::vector<typename Container::value_type>>::value,
-      Container>::type
+      Container>
     initialize_container(const std::vector<hsize_t> &dimensions)
     {
       return Container(std::accumulate(
@@ -1431,9 +1431,9 @@ namespace HDF5
 
 
     template <typename Container>
-    typename std::enable_if<
+    std::enable_if_t<
       std::is_same<Container, Vector<typename Container::value_type>>::value,
-      Container>::type
+      Container>
     initialize_container(const std::vector<hsize_t> &dimensions)
     {
       return Container(std::accumulate(
@@ -1443,10 +1443,10 @@ namespace HDF5
 
 
     template <typename Container>
-    typename std::enable_if<
+    std::enable_if_t<
       std::is_same<Container,
                    FullMatrix<typename Container::value_type>>::value,
-      Container>::type
+      Container>
     initialize_container(const std::vector<hsize_t> &dimensions)
     {
       // If the rank is higher than 2, then remove single-dimensional entries

--- a/include/deal.II/base/linear_index_iterator.h
+++ b/include/deal.II/base/linear_index_iterator.h
@@ -250,9 +250,9 @@ public:
    * the same entry in the same container.
    */
   template <typename OtherIterator>
-  friend typename std::enable_if<
+  friend std::enable_if_t<
     std::is_convertible<OtherIterator, DerivedIterator>::value,
-    bool>::type
+    bool>
   operator==(const LinearIndexIterator &left, const OtherIterator &right)
   {
     const auto &right_2 = static_cast<const DerivedIterator &>(right);
@@ -263,9 +263,9 @@ public:
    * Opposite of operator==().
    */
   template <typename OtherIterator>
-  friend typename std::enable_if<
+  friend std::enable_if_t<
     std::is_convertible<OtherIterator, DerivedIterator>::value,
-    bool>::type
+    bool>
   operator!=(const LinearIndexIterator &left, const OtherIterator &right)
   {
     return !(left == right);

--- a/include/deal.II/base/memory_consumption.h
+++ b/include/deal.II/base/memory_consumption.h
@@ -89,9 +89,8 @@ namespace MemoryConsumption
    * implemented.
    */
   template <typename T>
-  inline
-    typename std::enable_if<std::is_fundamental<T>::value, std::size_t>::type
-    memory_consumption(const T &t);
+  inline std::enable_if_t<std::is_fundamental<T>::value, std::size_t>
+  memory_consumption(const T &t);
 
   /**
    * Estimate the memory consumption of an object. If no further template
@@ -100,9 +99,9 @@ namespace MemoryConsumption
    * <tt>t.memory_consumption()</tt>'s value.
    */
   template <typename T>
-  inline typename std::enable_if<!(std::is_fundamental<T>::value ||
-                                   std::is_pointer<T>::value),
-                                 std::size_t>::type
+  inline std::enable_if_t<!(std::is_fundamental<T>::value ||
+                            std::is_pointer<T>::value),
+                          std::size_t>
   memory_consumption(const T &t);
 
   /**
@@ -261,9 +260,8 @@ namespace MemoryConsumption
 namespace MemoryConsumption
 {
   template <typename T>
-  inline
-    typename std::enable_if<std::is_fundamental<T>::value, std::size_t>::type
-    memory_consumption(const T &)
+  inline std::enable_if_t<std::is_fundamental<T>::value, std::size_t>
+  memory_consumption(const T &)
   {
     return sizeof(T);
   }
@@ -411,9 +409,9 @@ namespace MemoryConsumption
 
 
   template <typename T>
-  inline typename std::enable_if<!(std::is_fundamental<T>::value ||
-                                   std::is_pointer<T>::value),
-                                 std::size_t>::type
+  inline std::enable_if_t<!(std::is_fundamental<T>::value ||
+                            std::is_pointer<T>::value),
+                          std::size_t>
   memory_consumption(const T &t)
   {
     return t.memory_consumption();

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -1215,7 +1215,7 @@ namespace Utilities
      *   the @p root_process.
      */
     template <typename T>
-    typename std::enable_if<is_mpi_type<T> == false, T>::type
+    std::enable_if_t<is_mpi_type<T> == false, T>
     broadcast(const MPI_Comm &   comm,
               const T &          object_to_send,
               const unsigned int root_process = 0);
@@ -1243,7 +1243,7 @@ namespace Utilities
      *   the @p root_process.
      */
     template <typename T>
-    typename std::enable_if<is_mpi_type<T> == true, T>::type
+    std::enable_if_t<is_mpi_type<T> == true, T>
     broadcast(const MPI_Comm &   comm,
               const T &          object_to_send,
               const unsigned int root_process = 0);
@@ -1925,7 +1925,7 @@ namespace Utilities
 
 
     template <typename T>
-    typename std::enable_if<is_mpi_type<T> == false, T>::type
+    std::enable_if_t<is_mpi_type<T> == false, T>
     broadcast(const MPI_Comm &   comm,
               const T &          object_to_send,
               const unsigned int root_process)
@@ -1975,7 +1975,7 @@ namespace Utilities
 
 
     template <typename T>
-    typename std::enable_if<is_mpi_type<T> == true, T>::type
+    std::enable_if_t<is_mpi_type<T> == true, T>
     broadcast(const MPI_Comm &   comm,
               const T &          object_to_send,
               const unsigned int root_process)

--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -455,17 +455,16 @@ namespace numbers
      */
     template <typename Dummy = number>
     static constexpr DEAL_II_CUDA_HOST_DEV
-      typename std::enable_if<std::is_same<Dummy, number>::value &&
-                                is_cuda_compatible<Dummy>::value,
-                              real_type>::type
+      std::enable_if_t<std::is_same<Dummy, number>::value &&
+                         is_cuda_compatible<Dummy>::value,
+                       real_type>
       abs_square(const number &x);
 
     template <typename Dummy = number>
-    static constexpr
-      typename std::enable_if<std::is_same<Dummy, number>::value &&
-                                !is_cuda_compatible<Dummy>::value,
-                              real_type>::type
-      abs_square(const number &x);
+    static constexpr std::enable_if_t<std::is_same<Dummy, number>::value &&
+                                        !is_cuda_compatible<Dummy>::value,
+                                      real_type>
+    abs_square(const number &x);
 
     /**
      * Return the absolute value of a number.
@@ -583,9 +582,9 @@ namespace numbers
   template <typename number>
   template <typename Dummy>
   constexpr DEAL_II_CUDA_HOST_DEV
-    typename std::enable_if<std::is_same<Dummy, number>::value &&
-                              is_cuda_compatible<Dummy>::value,
-                            typename NumberTraits<number>::real_type>::type
+    std::enable_if_t<std::is_same<Dummy, number>::value &&
+                       is_cuda_compatible<Dummy>::value,
+                     typename NumberTraits<number>::real_type>
     NumberTraits<number>::abs_square(const number &x)
   {
     return x * x;
@@ -595,11 +594,10 @@ namespace numbers
 
   template <typename number>
   template <typename Dummy>
-  constexpr
-    typename std::enable_if<std::is_same<Dummy, number>::value &&
-                              !is_cuda_compatible<Dummy>::value,
-                            typename NumberTraits<number>::real_type>::type
-    NumberTraits<number>::abs_square(const number &x)
+  constexpr std::enable_if_t<std::is_same<Dummy, number>::value &&
+                               !is_cuda_compatible<Dummy>::value,
+                             typename NumberTraits<number>::real_type>
+  NumberTraits<number>::abs_square(const number &x)
   {
     return x * x;
   }
@@ -718,10 +716,9 @@ namespace internal
     template <typename F>
     static constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV T
     value(const F &f,
-          typename std::enable_if<
-            !std::is_same<typename std::decay<T>::type,
-                          typename std::decay<F>::type>::value &&
-            std::is_constructible<T, F>::value>::type * = nullptr)
+          std::enable_if_t<!std::is_same<typename std::decay<T>::type,
+                                         typename std::decay<F>::type>::value &&
+                           std::is_constructible<T, F>::value> * = nullptr)
     {
       return T(f);
     }
@@ -730,11 +727,11 @@ namespace internal
     template <typename F>
     static constexpr DEAL_II_ALWAYS_INLINE T
     value(const F &f,
-          typename std::enable_if<
-            !std::is_same<typename std::decay<T>::type,
-                          typename std::decay<F>::type>::value &&
-            !std::is_constructible<T, F>::value &&
-            is_explicitly_convertible<const F, T>::value>::type * = nullptr)
+          std::enable_if_t<!std::is_same<typename std::decay<T>::type,
+                                         typename std::decay<F>::type>::value &&
+                           !std::is_constructible<T, F>::value &&
+                           is_explicitly_convertible<const F, T>::value> * =
+            nullptr)
     {
       return static_cast<T>(f);
     }
@@ -745,13 +742,13 @@ namespace internal
     // might fall into the same category.
     template <typename F>
     static T
-    value(const F &f,
-          typename std::enable_if<
-            !std::is_same<typename std::decay<T>::type,
-                          typename std::decay<F>::type>::value &&
-            !std::is_constructible<T, F>::value &&
-            !is_explicitly_convertible<const F, T>::value &&
-            Differentiation::AD::is_ad_number<F>::value>::type * = nullptr)
+    value(
+      const F &f,
+      std::enable_if_t<!std::is_same<typename std::decay<T>::type,
+                                     typename std::decay<F>::type>::value &&
+                       !std::is_constructible<T, F>::value &&
+                       !is_explicitly_convertible<const F, T>::value &&
+                       Differentiation::AD::is_ad_number<F>::value> * = nullptr)
     {
       return Differentiation::AD::internal::NumberType<T>::value(f);
     }

--- a/include/deal.II/base/partitioner.templates.h
+++ b/include/deal.II/base/partitioner.templates.h
@@ -440,16 +440,15 @@ namespace Utilities
       // standards. To avoid this, we use std::abs on default types but
       // simply return the number on unsigned types
       template <typename Number>
-      typename std::enable_if<
-        !std::is_unsigned<Number>::value,
-        typename numbers::NumberTraits<Number>::real_type>::type
+      std::enable_if_t<!std::is_unsigned<Number>::value,
+                       typename numbers::NumberTraits<Number>::real_type>
       get_abs(const Number a)
       {
         return std::abs(a);
       }
 
       template <typename Number>
-      typename std::enable_if<std::is_unsigned<Number>::value, Number>::type
+      std::enable_if_t<std::is_unsigned<Number>::value, Number>
       get_abs(const Number a)
       {
         return a;

--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -1482,38 +1482,34 @@ namespace Patterns
 
     // Arithmetic types
     template <class T>
-    struct Convert<T,
-                   typename std::enable_if<std::is_arithmetic<T>::value>::type>
+    struct Convert<T, std::enable_if_t<std::is_arithmetic<T>::value>>
     {
       template <typename Dummy = T>
-      static
-        typename std::enable_if<std::is_same<Dummy, T>::value &&
-                                  std::is_same<T, bool>::value,
-                                std::unique_ptr<Patterns::PatternBase>>::type
-        to_pattern()
+      static std::enable_if_t<std::is_same<Dummy, T>::value &&
+                                std::is_same<T, bool>::value,
+                              std::unique_ptr<Patterns::PatternBase>>
+      to_pattern()
       {
         return std::make_unique<Patterns::Bool>();
       }
 
       template <typename Dummy = T>
-      static
-        typename std::enable_if<std::is_same<Dummy, T>::value &&
-                                  !std::is_same<T, bool>::value &&
-                                  std::is_integral<T>::value,
-                                std::unique_ptr<Patterns::PatternBase>>::type
-        to_pattern()
+      static std::enable_if_t<std::is_same<Dummy, T>::value &&
+                                !std::is_same<T, bool>::value &&
+                                std::is_integral<T>::value,
+                              std::unique_ptr<Patterns::PatternBase>>
+      to_pattern()
       {
         return std::make_unique<Patterns::Integer>(
           std::numeric_limits<T>::lowest(), std::numeric_limits<T>::max());
       }
 
       template <typename Dummy = T>
-      static
-        typename std::enable_if<std::is_same<Dummy, T>::value &&
-                                  !std::is_same<T, bool>::value &&
-                                  std::is_floating_point<T>::value,
-                                std::unique_ptr<Patterns::PatternBase>>::type
-        to_pattern()
+      static std::enable_if_t<std::is_same<Dummy, T>::value &&
+                                !std::is_same<T, bool>::value &&
+                                std::is_floating_point<T>::value,
+                              std::unique_ptr<Patterns::PatternBase>>
+      to_pattern()
       {
         return std::make_unique<Patterns::Double>(
           std::numeric_limits<T>::lowest(), std::numeric_limits<T>::max());
@@ -1679,9 +1675,7 @@ namespace Patterns
 
       // Rank of vector types
       template <class T>
-      struct RankInfo<
-        T,
-        typename std::enable_if<is_list_compatible<T>::value>::type>
+      struct RankInfo<T, std::enable_if_t<is_list_compatible<T>::value>>
       {
         static constexpr int list_rank =
           RankInfo<typename T::value_type>::list_rank + 1;
@@ -1691,9 +1685,7 @@ namespace Patterns
 
       // Rank of map types
       template <class T>
-      struct RankInfo<
-        T,
-        typename std::enable_if<is_map_compatible<T>::value>::type>
+      struct RankInfo<T, std::enable_if_t<is_map_compatible<T>::value>>
       {
         static constexpr int list_rank =
           max_list_rank<typename T::key_type, typename T::mapped_type>() + 1;
@@ -1766,8 +1758,7 @@ namespace Patterns
 
     // stl containers
     template <class T>
-    struct Convert<T,
-                   typename std::enable_if<is_list_compatible<T>::value>::type>
+    struct Convert<T, std::enable_if_t<is_list_compatible<T>::value>>
     {
       static std::unique_ptr<Patterns::PatternBase>
       to_pattern()
@@ -1834,8 +1825,7 @@ namespace Patterns
 
     // stl maps
     template <class T>
-    struct Convert<T,
-                   typename std::enable_if<is_map_compatible<T>::value>::type>
+    struct Convert<T, std::enable_if_t<is_map_compatible<T>::value>>
     {
       static std::unique_ptr<Patterns::PatternBase>
       to_pattern()

--- a/include/deal.II/base/point.h
+++ b/include/deal.II/base/point.h
@@ -164,8 +164,7 @@ public:
    * Convert a boost::geometry::point to a dealii::Point.
    */
   template <std::size_t dummy_dim,
-            typename std::enable_if<(dim == dummy_dim) && (dummy_dim != 0),
-                                    int>::type = 0>
+            std::enable_if_t<(dim == dummy_dim) && (dummy_dim != 0), int> = 0>
   Point(const boost::geometry::model::
           point<Number, dummy_dim, boost::geometry::cs::cartesian> &boost_pt);
 
@@ -437,9 +436,8 @@ Point<dim, Number>::Point(const Number x, const Number y, const Number z)
 
 
 template <int dim, typename Number>
-template <
-  std::size_t dummy_dim,
-  typename std::enable_if<(dim == dummy_dim) && (dummy_dim != 0), int>::type>
+template <std::size_t dummy_dim,
+          std::enable_if_t<(dim == dummy_dim) && (dummy_dim != 0), int>>
 inline Point<dim, Number>::Point(
   const boost::geometry::model::
     point<Number, dummy_dim, boost::geometry::cs::cartesian> &boost_pt)

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -2598,10 +2598,9 @@ namespace internal
     // this function is for tensors of a rank not already handled
     // above
     template <int dim, int rank_>
-    constexpr inline
-      typename std::enable_if<rank_ != 2, TableIndices<rank_>>::type
-      unrolled_to_component_indices(const unsigned int i,
-                                    const std::integral_constant<int, rank_> &)
+    constexpr inline std::enable_if_t<rank_ != 2, TableIndices<rank_>>
+    unrolled_to_component_indices(const unsigned int i,
+                                  const std::integral_constant<int, rank_> &)
     {
       (void)i;
       Assert(

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1661,11 +1661,11 @@ namespace internal
               int dim,
               typename Number,
               typename OtherNumber,
-              typename std::enable_if<
+              std::enable_if_t<
                 !std::is_integral<
                   typename ProductType<Number, OtherNumber>::type>::value &&
                   !std::is_same<Number, Differentiation::SD::Expression>::value,
-                int>::type = 0>
+                int> = 0>
     constexpr DEAL_II_CUDA_HOST_DEV inline DEAL_II_ALWAYS_INLINE void
     division_operator(Tensor<rank, dim, Number> (&t)[dim],
                       const OtherNumber &factor)
@@ -1681,11 +1681,11 @@ namespace internal
               int dim,
               typename Number,
               typename OtherNumber,
-              typename std::enable_if<
+              std::enable_if_t<
                 std::is_integral<
                   typename ProductType<Number, OtherNumber>::type>::value ||
                   std::is_same<Number, Differentiation::SD::Expression>::value,
-                int>::type = 0>
+                int> = 0>
     constexpr DEAL_II_CUDA_HOST_DEV inline DEAL_II_ALWAYS_INLINE void
     division_operator(Tensor<rank, dim, Number> (&t)[dim],
                       const OtherNumber &factor)
@@ -2111,10 +2111,10 @@ namespace internal
               int dim,
               typename Number,
               typename OtherNumber,
-              typename std::enable_if<
+              std::enable_if_t<
                 !std::is_integral<
                   typename ProductType<Number, OtherNumber>::type>::value,
-                int>::type = 0>
+                int> = 0>
     constexpr DEAL_II_CUDA_HOST_DEV inline DEAL_II_ALWAYS_INLINE
       Tensor<rank, dim, typename ProductType<Number, OtherNumber>::type>
       division_operator(const Tensor<rank, dim, Number> &t,
@@ -2133,10 +2133,10 @@ namespace internal
               int dim,
               typename Number,
               typename OtherNumber,
-              typename std::enable_if<
+              std::enable_if_t<
                 std::is_integral<
                   typename ProductType<Number, OtherNumber>::type>::value,
-                int>::type = 0>
+                int> = 0>
     constexpr DEAL_II_CUDA_HOST_DEV inline DEAL_II_ALWAYS_INLINE
       Tensor<rank, dim, typename ProductType<Number, OtherNumber>::type>
       division_operator(const Tensor<rank, dim, Number> &t,
@@ -2318,7 +2318,7 @@ template <int rank_1,
           int dim,
           typename Number,
           typename OtherNumber,
-          typename = typename std::enable_if<rank_1 >= 1 && rank_2 >= 1>::type>
+          typename = std::enable_if_t<rank_1 >= 1 && rank_2 >= 1>>
 constexpr inline DEAL_II_ALWAYS_INLINE
   typename Tensor<rank_1 + rank_2 - 2,
                   dim,

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -155,8 +155,7 @@ public:
    * current lane.
    */
   template <typename U = T>
-  typename std::enable_if<!std::is_same<U, const U>::value,
-                          typename T::value_type>::type &
+  std::enable_if_t<!std::is_same<U, const U>::value, typename T::value_type> &
   operator*()
   {
     AssertIndexRange(lane, T::size());

--- a/include/deal.II/base/work_stream.h
+++ b/include/deal.II/base/work_stream.h
@@ -1212,8 +1212,7 @@ namespace WorkStream
             typename IteratorRangeType,
             typename ScratchData,
             typename CopyData,
-            typename = typename std::enable_if<
-              has_begin_and_end<IteratorRangeType>>::type>
+            typename = std::enable_if_t<has_begin_and_end<IteratorRangeType>>>
   void
   run(IteratorRangeType  iterator_range,
       Worker             worker,
@@ -1436,8 +1435,7 @@ namespace WorkStream
             typename IteratorRangeType,
             typename ScratchData,
             typename CopyData,
-            typename = typename std::enable_if<
-              has_begin_and_end<IteratorRangeType>>::type>
+            typename = std::enable_if_t<has_begin_and_end<IteratorRangeType>>>
   void
   run(IteratorRangeType iterator_range,
       MainClass &       main_object,

--- a/include/deal.II/differentiation/ad/ad_drivers.h
+++ b/include/deal.II/differentiation/ad/ad_drivers.h
@@ -693,10 +693,9 @@ namespace Differentiation
      * Specialization for taped ADOL-C auto-differentiable numbers.
      */
     template <typename ADNumberType>
-    struct Types<
-      ADNumberType,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>
+    struct Types<ADNumberType,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>
     {
       /**
        * Typedef for tape indices. ADOL-C uses short integers, so
@@ -715,10 +714,9 @@ namespace Differentiation
      * Specialization for taped ADOL-C auto-differentiable numbers.
      */
     template <typename ADNumberType>
-    struct Numbers<
-      ADNumberType,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>
+    struct Numbers<ADNumberType,
+                   std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                    NumberTypes::adolc_taped>>
     {
       /**
        * A tape index that is unusable and can be used to invalidate recording
@@ -765,8 +763,8 @@ namespace Differentiation
     struct TapedDrivers<
       ADNumberType,
       double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>
+      std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                       NumberTypes::adolc_taped>>
     {
       using scalar_type = double;
 
@@ -972,8 +970,8 @@ namespace Differentiation
     struct TapedDrivers<
       ADNumberType,
       double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>
+      std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                       NumberTypes::adolc_taped>>
     {
       using scalar_type = double;
 
@@ -1090,8 +1088,8 @@ namespace Differentiation
     struct TapedDrivers<
       ADNumberType,
       float,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>
+      std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                       NumberTypes::adolc_taped>>
     {
       using scalar_type = float;
 
@@ -1224,10 +1222,10 @@ namespace Differentiation
     struct TapelessDrivers<
       ADNumberType,
       ScalarType,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_rad ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_rad_dfad>::type>
+      std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                         NumberTypes::sacado_rad ||
+                       ADNumberTraits<ADNumberType>::type_code ==
+                         NumberTypes::sacado_rad_dfad>>
     {
       /**
        * Constructor
@@ -1314,12 +1312,12 @@ namespace Differentiation
     struct TapelessDrivers<
       ADNumberType,
       ScalarType,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::adolc_tapeless ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_dfad ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_dfad_dfad>::type>
+      std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                         NumberTypes::adolc_tapeless ||
+                       ADNumberTraits<ADNumberType>::type_code ==
+                         NumberTypes::sacado_dfad ||
+                       ADNumberTraits<ADNumberType>::type_code ==
+                         NumberTypes::sacado_dfad_dfad>>
     {
       /**
        * Constructor

--- a/include/deal.II/differentiation/ad/ad_number_traits.h
+++ b/include/deal.II/differentiation/ad/ad_number_traits.h
@@ -324,8 +324,7 @@ namespace Differentiation
       struct ADNumberInfoFromEnum<
         ScalarType,
         Differentiation::AD::NumberTypes::none,
-        typename std::enable_if<
-          std::is_floating_point<ScalarType>::value>::type>
+        std::enable_if_t<std::is_floating_point<ScalarType>::value>>
       {
         static const bool is_taped                              = false;
         using real_type                                         = ScalarType;
@@ -340,9 +339,9 @@ namespace Differentiation
        * mechanism can be employed (e.g. Sacado types).
        */
       template <typename ScalarType>
-      struct Marking<ScalarType,
-                     typename std::enable_if<
-                       std::is_floating_point<ScalarType>::value>::type>
+      struct Marking<
+        ScalarType,
+        std::enable_if_t<std::is_floating_point<ScalarType>::value>>
       {
         /**
          * Initialize the state of an independent variable.
@@ -380,9 +379,8 @@ namespace Differentiation
        * A specialization of the marking strategy for complex numbers.
        */
       template <typename ADNumberType>
-      struct Marking<
-        ADNumberType,
-        typename std::enable_if<boost::is_complex<ADNumberType>::value>::type>
+      struct Marking<ADNumberType,
+                     std::enable_if_t<boost::is_complex<ADNumberType>::value>>
       {
         /*
          * Initialize the state of an independent variable.
@@ -457,8 +455,8 @@ namespace Differentiation
     template <typename NumberType>
     struct is_taped_ad_number<
       NumberType,
-      typename std::enable_if<
-        ADNumberTraits<typename std::decay<NumberType>::type>::is_taped>::type>
+      std::enable_if_t<
+        ADNumberTraits<typename std::decay<NumberType>::type>::is_taped>>
       : std::true_type
     {};
 
@@ -470,8 +468,8 @@ namespace Differentiation
     template <typename NumberType>
     struct is_tapeless_ad_number<
       NumberType,
-      typename std::enable_if<ADNumberTraits<
-        typename std::decay<NumberType>::type>::is_tapeless>::type>
+      std::enable_if_t<
+        ADNumberTraits<typename std::decay<NumberType>::type>::is_tapeless>>
       : std::true_type
     {};
 
@@ -484,8 +482,8 @@ namespace Differentiation
     template <typename NumberType>
     struct is_real_valued_ad_number<
       NumberType,
-      typename std::enable_if<ADNumberTraits<
-        typename std::decay<NumberType>::type>::is_real_valued>::type>
+      std::enable_if_t<
+        ADNumberTraits<typename std::decay<NumberType>::type>::is_real_valued>>
       : std::true_type
     {};
 
@@ -498,8 +496,8 @@ namespace Differentiation
     template <typename NumberType>
     struct is_complex_valued_ad_number<
       NumberType,
-      typename std::enable_if<ADNumberTraits<
-        typename std::decay<NumberType>::type>::is_complex_valued>::type>
+      std::enable_if_t<ADNumberTraits<
+        typename std::decay<NumberType>::type>::is_complex_valued>>
       : std::true_type
     {};
 
@@ -535,9 +533,9 @@ namespace Differentiation
        * mechanism can be employed (e.g. Sacado types).
        */
       template <typename NumberType>
-      struct ExtractData<NumberType,
-                         typename std::enable_if<
-                           std::is_floating_point<NumberType>::value>::type>
+      struct ExtractData<
+        NumberType,
+        std::enable_if_t<std::is_floating_point<NumberType>::value>>
       {
         /**
          * Extract the floating point value.
@@ -631,9 +629,8 @@ namespace Differentiation
          */
         template <typename F>
         static auto
-        value(const F &f,
-              typename std::enable_if<!is_ad_number<F>::value>::type * =
-                nullptr) -> decltype(dealii::internal::NumberType<T>::value(f))
+        value(const F &f, std::enable_if_t<!is_ad_number<F>::value> * = nullptr)
+          -> decltype(dealii::internal::NumberType<T>::value(f))
         {
           // We call the other function defined in the numbers
           // header to take care of all of the usual cases.
@@ -649,9 +646,8 @@ namespace Differentiation
         template <typename F>
         static T
         value(const F &f,
-              typename std::enable_if<is_ad_number<F>::value &&
-                                      std::is_floating_point<T>::value>::type
-                * = nullptr)
+              std::enable_if_t<is_ad_number<F>::value &&
+                               std::is_floating_point<T>::value> * = nullptr)
         {
           // We recursively call this function in case the AD number is a
           // nested one. The recursion ends when the extracted value is
@@ -668,8 +664,8 @@ namespace Differentiation
         template <typename F>
         static T
         value(const F &f,
-              typename std::enable_if<is_ad_number<F>::value &&
-                                      is_ad_number<T>::value>::type * = nullptr)
+              std::enable_if_t<is_ad_number<F>::value && is_ad_number<T>::value>
+                * = nullptr)
         {
           return T(f);
         }
@@ -683,9 +679,7 @@ namespace Differentiation
          */
         template <typename F>
         static auto
-        value(
-          const F &f,
-          typename std::enable_if<!is_ad_number<F>::value>::type * = nullptr)
+        value(const F &f, std::enable_if_t<!is_ad_number<F>::value> * = nullptr)
           -> decltype(dealii::internal::NumberType<std::complex<T>>::value(f))
         {
           // We call the other function defined in the numbers
@@ -701,9 +695,8 @@ namespace Differentiation
         template <typename F>
         static std::complex<T>
         value(const F &f,
-              typename std::enable_if<is_ad_number<F>::value &&
-                                      std::is_floating_point<T>::value>::type
-                * = nullptr)
+              std::enable_if_t<is_ad_number<F>::value &&
+                               std::is_floating_point<T>::value> * = nullptr)
         {
           // We recursively call this function in case the AD number is a
           // nested one. The recursion ends when the extracted value is
@@ -751,11 +744,11 @@ namespace Differentiation
     struct NumberTraits<
       ScalarType,
       ADNumberTypeCode,
-      typename std::enable_if<
+      std::enable_if_t<
         std::is_floating_point<ScalarType>::value ||
         (boost::is_complex<ScalarType>::value &&
-         std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>::type>
+         std::is_floating_point<
+           typename internal::RemoveComplexWrapper<ScalarType>::type>::value)>>
     {
       /**
        * The type of taping used
@@ -950,11 +943,11 @@ namespace Differentiation
     const bool NumberTraits<
       ScalarType,
       ADNumberTypeCode,
-      typename std::enable_if<
+      std::enable_if_t<
         std::is_floating_point<ScalarType>::value ||
         (boost::is_complex<ScalarType>::value &&
          std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>::type>::is_taped =
+           ScalarType>::type>::value)>>::is_taped =
       internal::ADNumberInfoFromEnum<
         typename internal::RemoveComplexWrapper<ScalarType>::type,
         ADNumberTypeCode>::is_taped;
@@ -964,11 +957,11 @@ namespace Differentiation
     const bool NumberTraits<
       ScalarType,
       ADNumberTypeCode,
-      typename std::enable_if<
+      std::enable_if_t<
         std::is_floating_point<ScalarType>::value ||
         (boost::is_complex<ScalarType>::value &&
          std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>::type>::is_tapeless =
+           ScalarType>::type>::value)>>::is_tapeless =
       !(NumberTraits<ScalarType, ADNumberTypeCode>::is_taped);
 
 
@@ -976,11 +969,11 @@ namespace Differentiation
     const bool NumberTraits<
       ScalarType,
       ADNumberTypeCode,
-      typename std::enable_if<
+      std::enable_if_t<
         std::is_floating_point<ScalarType>::value ||
         (boost::is_complex<ScalarType>::value &&
          std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>::type>::is_real_valued =
+           ScalarType>::type>::value)>>::is_real_valued =
       (!boost::is_complex<ScalarType>::value);
 
 
@@ -988,11 +981,11 @@ namespace Differentiation
     const bool NumberTraits<
       ScalarType,
       ADNumberTypeCode,
-      typename std::enable_if<
+      std::enable_if_t<
         std::is_floating_point<ScalarType>::value ||
         (boost::is_complex<ScalarType>::value &&
          std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>::type>::is_complex_valued =
+           ScalarType>::type>::value)>>::is_complex_valued =
       !(NumberTraits<ScalarType, ADNumberTypeCode>::is_real_valued);
 
 
@@ -1000,11 +993,11 @@ namespace Differentiation
     const unsigned int NumberTraits<
       ScalarType,
       ADNumberTypeCode,
-      typename std::enable_if<
+      std::enable_if_t<
         std::is_floating_point<ScalarType>::value ||
         (boost::is_complex<ScalarType>::value &&
          std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>::type>::n_supported_derivative_levels =
+           ScalarType>::type>::value)>>::n_supported_derivative_levels =
       internal::ADNumberInfoFromEnum<
         typename internal::RemoveComplexWrapper<ScalarType>::type,
         ADNumberTypeCode>::n_supported_derivative_levels;
@@ -1015,55 +1008,55 @@ namespace Differentiation
     constexpr bool NumberTraits<
       ScalarType,
       ADNumberTypeCode,
-      typename std::enable_if<
+      std::enable_if_t<
         std::is_floating_point<ScalarType>::value ||
         (boost::is_complex<ScalarType>::value &&
          std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>::type>::is_taped;
+           ScalarType>::type>::value)>>::is_taped;
 
 
     template <typename ScalarType, enum NumberTypes ADNumberTypeCode>
     constexpr bool NumberTraits<
       ScalarType,
       ADNumberTypeCode,
-      typename std::enable_if<
+      std::enable_if_t<
         std::is_floating_point<ScalarType>::value ||
         (boost::is_complex<ScalarType>::value &&
          std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>::type>::is_tapeless;
+           ScalarType>::type>::value)>>::is_tapeless;
 
 
     template <typename ScalarType, enum NumberTypes ADNumberTypeCode>
     constexpr bool NumberTraits<
       ScalarType,
       ADNumberTypeCode,
-      typename std::enable_if<
+      std::enable_if_t<
         std::is_floating_point<ScalarType>::value ||
         (boost::is_complex<ScalarType>::value &&
          std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>::type>::is_real_valued;
+           ScalarType>::type>::value)>>::is_real_valued;
 
 
     template <typename ScalarType, enum NumberTypes ADNumberTypeCode>
     constexpr bool NumberTraits<
       ScalarType,
       ADNumberTypeCode,
-      typename std::enable_if<
+      std::enable_if_t<
         std::is_floating_point<ScalarType>::value ||
         (boost::is_complex<ScalarType>::value &&
          std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>::type>::is_complex_valued;
+           ScalarType>::type>::value)>>::is_complex_valued;
 
 
     template <typename ScalarType, enum NumberTypes ADNumberTypeCode>
     constexpr unsigned int NumberTraits<
       ScalarType,
       ADNumberTypeCode,
-      typename std::enable_if<
+      std::enable_if_t<
         std::is_floating_point<ScalarType>::value ||
         (boost::is_complex<ScalarType>::value &&
          std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>::type>::n_supported_derivative_levels;
+           ScalarType>::type>::value)>>::n_supported_derivative_levels;
 
 #  endif
 
@@ -1082,11 +1075,11 @@ namespace Differentiation
     struct NumberTraits<
       ScalarType,
       NumberTypes::none,
-      typename std::enable_if<
+      std::enable_if_t<
         std::is_floating_point<ScalarType>::value ||
         (boost::is_complex<ScalarType>::value &&
-         std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>::type>
+         std::is_floating_point<
+           typename internal::RemoveComplexWrapper<ScalarType>::type>::value)>>
     {
       /**
        * The internal number type code.
@@ -1251,33 +1244,33 @@ namespace Differentiation
     const bool NumberTraits<
       ScalarType,
       NumberTypes::none,
-      typename std::enable_if<
+      std::enable_if_t<
         std::is_floating_point<ScalarType>::value ||
         (boost::is_complex<ScalarType>::value &&
          std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>::type>::is_taped = false;
+           ScalarType>::type>::value)>>::is_taped = false;
 
 
     template <typename ScalarType>
     const bool NumberTraits<
       ScalarType,
       NumberTypes::none,
-      typename std::enable_if<
+      std::enable_if_t<
         std::is_floating_point<ScalarType>::value ||
         (boost::is_complex<ScalarType>::value &&
          std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>::type>::is_tapeless = false;
+           ScalarType>::type>::value)>>::is_tapeless = false;
 
 
     template <typename ScalarType>
     const bool NumberTraits<
       ScalarType,
       NumberTypes::none,
-      typename std::enable_if<
+      std::enable_if_t<
         std::is_floating_point<ScalarType>::value ||
         (boost::is_complex<ScalarType>::value &&
          std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>::type>::is_real_valued =
+           ScalarType>::type>::value)>>::is_real_valued =
       (!boost::is_complex<ScalarType>::value);
 
 
@@ -1285,11 +1278,11 @@ namespace Differentiation
     const bool NumberTraits<
       ScalarType,
       NumberTypes::none,
-      typename std::enable_if<
+      std::enable_if_t<
         std::is_floating_point<ScalarType>::value ||
         (boost::is_complex<ScalarType>::value &&
          std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>::type>::is_complex_valued =
+           ScalarType>::type>::value)>>::is_complex_valued =
       !(NumberTraits<ScalarType, NumberTypes::none>::is_real_valued);
 
 
@@ -1297,12 +1290,11 @@ namespace Differentiation
     const unsigned int NumberTraits<
       ScalarType,
       NumberTypes::none,
-      typename std::enable_if<
+      std::enable_if_t<
         std::is_floating_point<ScalarType>::value ||
         (boost::is_complex<ScalarType>::value &&
          std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>::type>::n_supported_derivative_levels =
-      0;
+           ScalarType>::type>::value)>>::n_supported_derivative_levels = 0;
 
 #  else
 
@@ -1310,55 +1302,55 @@ namespace Differentiation
     constexpr bool NumberTraits<
       ScalarType,
       NumberTypes::none,
-      typename std::enable_if<
+      std::enable_if_t<
         std::is_floating_point<ScalarType>::value ||
         (boost::is_complex<ScalarType>::value &&
          std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>::type>::is_taped;
+           ScalarType>::type>::value)>>::is_taped;
 
 
     template <typename ScalarType>
     constexpr bool NumberTraits<
       ScalarType,
       NumberTypes::none,
-      typename std::enable_if<
+      std::enable_if_t<
         std::is_floating_point<ScalarType>::value ||
         (boost::is_complex<ScalarType>::value &&
          std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>::type>::is_tapeless;
+           ScalarType>::type>::value)>>::is_tapeless;
 
 
     template <typename ScalarType>
     constexpr bool NumberTraits<
       ScalarType,
       NumberTypes::none,
-      typename std::enable_if<
+      std::enable_if_t<
         std::is_floating_point<ScalarType>::value ||
         (boost::is_complex<ScalarType>::value &&
          std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>::type>::is_real_valued;
+           ScalarType>::type>::value)>>::is_real_valued;
 
 
     template <typename ScalarType>
     constexpr bool NumberTraits<
       ScalarType,
       NumberTypes::none,
-      typename std::enable_if<
+      std::enable_if_t<
         std::is_floating_point<ScalarType>::value ||
         (boost::is_complex<ScalarType>::value &&
          std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>::type>::is_complex_valued;
+           ScalarType>::type>::value)>>::is_complex_valued;
 
 
     template <typename ScalarType>
     constexpr unsigned int NumberTraits<
       ScalarType,
       NumberTypes::none,
-      typename std::enable_if<
+      std::enable_if_t<
         std::is_floating_point<ScalarType>::value ||
         (boost::is_complex<ScalarType>::value &&
          std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>::type>::n_supported_derivative_levels;
+           ScalarType>::type>::value)>>::n_supported_derivative_levels;
 
 #  endif
 
@@ -1384,7 +1376,7 @@ namespace Differentiation
     template <typename ScalarType>
     struct ADNumberTraits<
       ScalarType,
-      typename std::enable_if<std::is_floating_point<ScalarType>::value>::type>
+      std::enable_if_t<std::is_floating_point<ScalarType>::value>>
       : NumberTraits<ScalarType, NumberTypes::none>
     {};
 
@@ -1394,10 +1386,10 @@ namespace Differentiation
     template <typename ComplexScalarType>
     struct ADNumberTraits<
       ComplexScalarType,
-      typename std::enable_if<
+      std::enable_if_t<
         boost::is_complex<ComplexScalarType>::value &&
-        std::is_floating_point<typename ComplexScalarType::value_type>::value>::
-        type> : NumberTraits<ComplexScalarType, NumberTypes::none>
+        std::is_floating_point<typename ComplexScalarType::value_type>::value>>
+      : NumberTraits<ComplexScalarType, NumberTypes::none>
     {};
 
   } // namespace AD

--- a/include/deal.II/differentiation/ad/adolc_number_types.h
+++ b/include/deal.II/differentiation/ad/adolc_number_types.h
@@ -110,8 +110,7 @@ namespace Differentiation
       struct ADNumberInfoFromEnum<
         ScalarType,
         Differentiation::AD::NumberTypes::adolc_taped,
-        typename std::enable_if<
-          std::is_floating_point<ScalarType>::value>::type>
+        std::enable_if_t<std::is_floating_point<ScalarType>::value>>
       {
         static const bool is_taped = true;
         using real_type            = adouble;
@@ -129,8 +128,7 @@ namespace Differentiation
       struct ADNumberInfoFromEnum<
         ScalarType,
         Differentiation::AD::NumberTypes::adolc_tapeless,
-        typename std::enable_if<
-          std::is_floating_point<ScalarType>::value>::type>
+        std::enable_if_t<std::is_floating_point<ScalarType>::value>>
       {
         static const bool is_taped                              = false;
         using real_type                                         = adtl::adouble;
@@ -142,9 +140,9 @@ namespace Differentiation
       template <typename ADNumberType>
       struct Marking<
         ADNumberType,
-        typename std::enable_if<
-          ADNumberTraits<ADNumberType>::type_code == NumberTypes::adolc_taped &&
-          ADNumberTraits<ADNumberType>::is_real_valued>::type>
+        std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                           NumberTypes::adolc_taped &&
+                         ADNumberTraits<ADNumberType>::is_real_valued>>
       {
         using scalar_type = typename ADNumberTraits<ADNumberType>::scalar_type;
 
@@ -178,11 +176,11 @@ namespace Differentiation
       };
 
       template <typename ADNumberType>
-      struct Marking<ADNumberType,
-                     typename std::enable_if<
-                       ADNumberTraits<ADNumberType>::type_code ==
-                         NumberTypes::adolc_tapeless &&
-                       ADNumberTraits<ADNumberType>::is_real_valued>::type>
+      struct Marking<
+        ADNumberType,
+        std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                           NumberTypes::adolc_tapeless &&
+                         ADNumberTraits<ADNumberType>::is_real_valued>>
       {
         using scalar_type = typename ADNumberTraits<ADNumberType>::scalar_type;
 
@@ -331,7 +329,7 @@ namespace Differentiation
     template <typename ADNumberType>
     struct ADNumberTraits<
       ADNumberType,
-      typename std::enable_if<std::is_same<ADNumberType, adouble>::value>::type>
+      std::enable_if_t<std::is_same<ADNumberType, adouble>::value>>
       : NumberTraits<double, NumberTypes::adolc_taped>
     {
       static_assert(std::is_same<ad_type, adouble>::value,
@@ -353,8 +351,8 @@ namespace Differentiation
     template <typename ADNumberType>
     struct ADNumberTraits<
       ADNumberType,
-      typename std::enable_if<
-        std::is_same<ADNumberType, std::complex<adouble>>::value>::type>
+      std::enable_if_t<
+        std::is_same<ADNumberType, std::complex<adouble>>::value>>
       : NumberTraits<std::complex<double>, NumberTypes::adolc_taped>
     {
       static_assert(std::is_same<ad_type, std::complex<adouble>>::value,
@@ -375,8 +373,7 @@ namespace Differentiation
     template <typename ADNumberType>
     struct ADNumberTraits<
       ADNumberType,
-      typename std::enable_if<
-        std::is_same<ADNumberType, adtl::adouble>::value>::type>
+      std::enable_if_t<std::is_same<ADNumberType, adtl::adouble>::value>>
       : NumberTraits<double, NumberTypes::adolc_tapeless>
     {
       static_assert(std::is_same<ad_type, adtl::adouble>::value,
@@ -398,8 +395,8 @@ namespace Differentiation
     template <typename ADNumberType>
     struct ADNumberTraits<
       ADNumberType,
-      typename std::enable_if<
-        std::is_same<ADNumberType, std::complex<adtl::adouble>>::value>::type>
+      std::enable_if_t<
+        std::is_same<ADNumberType, std::complex<adtl::adouble>>::value>>
       : NumberTraits<std::complex<double>, NumberTypes::adolc_tapeless>
     {
       static_assert(std::is_same<ad_type, std::complex<adtl::adouble>>::value,
@@ -463,9 +460,9 @@ namespace Differentiation
     template <typename NumberType>
     struct is_adolc_taped_number<
       NumberType,
-      typename std::enable_if<
-        ADNumberTraits<typename std::decay<NumberType>::type>::type_code ==
-        NumberTypes::adolc_taped>::type> : std::true_type
+      std::enable_if_t<ADNumberTraits<typename std::decay<NumberType>::type>::
+                         type_code == NumberTypes::adolc_taped>>
+      : std::true_type
     {};
 
 
@@ -476,9 +473,9 @@ namespace Differentiation
     template <typename NumberType>
     struct is_adolc_tapeless_number<
       NumberType,
-      typename std::enable_if<
-        ADNumberTraits<typename std::decay<NumberType>::type>::type_code ==
-        NumberTypes::adolc_tapeless>::type> : std::true_type
+      std::enable_if_t<ADNumberTraits<typename std::decay<NumberType>::type>::
+                         type_code == NumberTypes::adolc_tapeless>>
+      : std::true_type
     {};
 
 
@@ -487,10 +484,10 @@ namespace Differentiation
      * parameter is a (real or complex; taped or tapeless) ADOL-C number.
      */
     template <typename NumberType>
-    struct is_adolc_number<NumberType,
-                           typename std::enable_if<
-                             is_adolc_taped_number<NumberType>::value ||
-                             is_adolc_tapeless_number<NumberType>::value>::type>
+    struct is_adolc_number<
+      NumberType,
+      std::enable_if_t<is_adolc_taped_number<NumberType>::value ||
+                       is_adolc_tapeless_number<NumberType>::value>>
       : std::true_type
     {};
 

--- a/include/deal.II/differentiation/ad/sacado_math.h
+++ b/include/deal.II/differentiation/ad/sacado_math.h
@@ -38,10 +38,10 @@ namespace std
    */
   template <
     typename ADNumberType,
-    typename = typename std::enable_if<
+    typename = std::enable_if_t<
       dealii::Differentiation::AD::is_sacado_number<ADNumberType>::value &&
       dealii::Differentiation::AD::is_real_valued_ad_number<
-        ADNumberType>::value>::type>
+        ADNumberType>::value>>
   inline ADNumberType
   erf(ADNumberType x)
   {
@@ -89,8 +89,8 @@ namespace std
    */
   template <
     typename ADNumberType,
-    typename = typename std::enable_if<
-      dealii::Differentiation::AD::is_sacado_number<ADNumberType>::value>::type>
+    typename = std::enable_if_t<
+      dealii::Differentiation::AD::is_sacado_number<ADNumberType>::value>>
   inline ADNumberType
   erfc(const ADNumberType &x)
   {

--- a/include/deal.II/differentiation/ad/sacado_number_types.h
+++ b/include/deal.II/differentiation/ad/sacado_number_types.h
@@ -147,9 +147,9 @@ namespace Differentiation
       template <typename SacadoNumber>
       struct SacadoNumberInfo<
         SacadoNumber,
-        typename std::enable_if<std::is_same<
+        std::enable_if_t<std::is_same<
           SacadoNumber,
-          Sacado::Fad::DFad<typename SacadoNumber::value_type>>::value>::type>
+          Sacado::Fad::DFad<typename SacadoNumber::value_type>>::value>>
       {
         using ad_type         = SacadoNumber;
         using scalar_type     = typename ad_type::scalar_type;
@@ -167,9 +167,9 @@ namespace Differentiation
       template <typename SacadoNumber>
       struct SacadoNumberInfo<
         SacadoNumber,
-        typename std::enable_if<std::is_same<
+        std::enable_if_t<std::is_same<
           SacadoNumber,
-          Sacado::Rad::ADvar<typename SacadoNumber::value_type>>::value>::type>
+          Sacado::Rad::ADvar<typename SacadoNumber::value_type>>::value>>
       {
         using ad_type         = SacadoNumber;
         using scalar_type     = typename ad_type::ADVari::scalar_type;
@@ -188,10 +188,9 @@ namespace Differentiation
        * templates used in the above specializations.
        */
       template <typename Number>
-      struct SacadoNumberInfo<
-        Number,
-        typename std::enable_if<
-          std::is_arithmetic<typename std::decay<Number>::type>::value>::type>
+      struct SacadoNumberInfo<Number,
+                              std::enable_if_t<std::is_arithmetic<
+                                typename std::decay<Number>::type>::value>>
       {
         static const unsigned int n_supported_derivative_levels = 0;
       };
@@ -205,8 +204,7 @@ namespace Differentiation
       struct ADNumberInfoFromEnum<
         ScalarType,
         Differentiation::AD::NumberTypes::sacado_dfad,
-        typename std::enable_if<
-          std::is_floating_point<ScalarType>::value>::type>
+        std::enable_if_t<std::is_floating_point<ScalarType>::value>>
       {
         static const bool is_taped = false;
         using real_type            = Sacado::Fad::DFad<ScalarType>;
@@ -225,8 +223,7 @@ namespace Differentiation
       struct ADNumberInfoFromEnum<
         ScalarType,
         Differentiation::AD::NumberTypes::sacado_dfad_dfad,
-        typename std::enable_if<
-          std::is_floating_point<ScalarType>::value>::type>
+        std::enable_if_t<std::is_floating_point<ScalarType>::value>>
       {
         static const bool is_taped = false;
         using real_type = Sacado::Fad::DFad<Sacado::Fad::DFad<ScalarType>>;
@@ -245,8 +242,7 @@ namespace Differentiation
       struct ADNumberInfoFromEnum<
         ScalarType,
         Differentiation::AD::NumberTypes::sacado_rad,
-        typename std::enable_if<
-          std::is_floating_point<ScalarType>::value>::type>
+        std::enable_if_t<std::is_floating_point<ScalarType>::value>>
       {
         static const bool is_taped = false;
         using real_type            = Sacado::Rad::ADvar<ScalarType>;
@@ -265,8 +261,7 @@ namespace Differentiation
       struct ADNumberInfoFromEnum<
         ScalarType,
         Differentiation::AD::NumberTypes::sacado_rad_dfad,
-        typename std::enable_if<
-          std::is_floating_point<ScalarType>::value>::type>
+        std::enable_if_t<std::is_floating_point<ScalarType>::value>>
       {
         static const bool is_taped = false;
         using real_type = Sacado::Rad::ADvar<Sacado::Fad::DFad<ScalarType>>;
@@ -486,9 +481,9 @@ namespace Differentiation
     template <typename ADNumberType>
     struct ADNumberTraits<
       ADNumberType,
-      typename std::enable_if<std::is_same<
+      std::enable_if_t<std::is_same<
         ADNumberType,
-        Sacado::Fad::DFad<typename ADNumberType::scalar_type>>::value>::type>
+        Sacado::Fad::DFad<typename ADNumberType::scalar_type>>::value>>
       : NumberTraits<typename ADNumberType::scalar_type,
                      NumberTypes::sacado_dfad>
     {};
@@ -503,10 +498,10 @@ namespace Differentiation
     template <typename ADNumberType>
     struct ADNumberTraits<
       ADNumberType,
-      typename std::enable_if<std::is_same<
+      std::enable_if_t<std::is_same<
         ADNumberType,
         std::complex<Sacado::Fad::DFad<
-          typename ADNumberType::value_type::scalar_type>>>::value>::type>
+          typename ADNumberType::value_type::scalar_type>>>::value>>
       : NumberTraits<
           std::complex<typename ADNumberType::value_type::scalar_type>,
           NumberTypes::sacado_dfad>
@@ -575,10 +570,9 @@ namespace Differentiation
     template <typename ADNumberType>
     struct ADNumberTraits<
       ADNumberType,
-      typename std::enable_if<std::is_same<
+      std::enable_if_t<std::is_same<
         ADNumberType,
-        Sacado::Rad::ADvar<typename ADNumberType::ADVari::scalar_type>>::
-                                value>::type>
+        Sacado::Rad::ADvar<typename ADNumberType::ADVari::scalar_type>>::value>>
       : NumberTraits<typename ADNumberType::ADVari::scalar_type,
                      NumberTypes::sacado_rad>
     {};
@@ -620,10 +614,10 @@ namespace Differentiation
     template <typename ADNumberType>
     struct ADNumberTraits<
       ADNumberType,
-      typename std::enable_if<std::is_same<
+      std::enable_if_t<std::is_same<
         ADNumberType,
-        std::complex<Sacado::Rad::ADvar<typename ADNumberType::value_type::
-                                          ADVari::scalar_type>>>::value>::type>
+        std::complex<Sacado::Rad::ADvar<
+          typename ADNumberType::value_type::ADVari::scalar_type>>>::value>>
       : NumberTraits<
           std::complex<typename ADNumberType::value_type::ADVari::scalar_type>,
           NumberTypes::sacado_rad>
@@ -669,12 +663,11 @@ namespace Differentiation
      * a floating point type.
      */
     template <typename ADNumberType>
-    struct ADNumberTraits<
-      ADNumberType,
-      typename std::enable_if<
-        std::is_same<ADNumberType,
-                     Sacado::Fad::DFad<Sacado::Fad::DFad<
-                       typename ADNumberType::scalar_type>>>::value>::type>
+    struct ADNumberTraits<ADNumberType,
+                          std::enable_if_t<std::is_same<
+                            ADNumberType,
+                            Sacado::Fad::DFad<Sacado::Fad::DFad<
+                              typename ADNumberType::scalar_type>>>::value>>
       : NumberTraits<typename ADNumberType::scalar_type,
                      NumberTypes::sacado_dfad_dfad>
     {};
@@ -690,10 +683,10 @@ namespace Differentiation
     template <typename ADNumberType>
     struct ADNumberTraits<
       ADNumberType,
-      typename std::enable_if<std::is_same<
+      std::enable_if_t<std::is_same<
         ADNumberType,
         std::complex<Sacado::Fad::DFad<Sacado::Fad::DFad<
-          typename ADNumberType::value_type::scalar_type>>>>::value>::type>
+          typename ADNumberType::value_type::scalar_type>>>>::value>>
       : NumberTraits<
           std::complex<typename ADNumberType::value_type::scalar_type>,
           NumberTypes::sacado_dfad_dfad>
@@ -766,10 +759,10 @@ namespace Differentiation
     template <typename ADNumberType>
     struct ADNumberTraits<
       ADNumberType,
-      typename std::enable_if<std::is_same<
-        ADNumberType,
-        Sacado::Rad::ADvar<Sacado::Fad::DFad<
-          typename ADNumberType::ADVari::scalar_type>>>::value>::type>
+      std::enable_if_t<
+        std::is_same<ADNumberType,
+                     Sacado::Rad::ADvar<Sacado::Fad::DFad<
+                       typename ADNumberType::ADVari::scalar_type>>>::value>>
       : NumberTraits<typename ADNumberType::ADVari::scalar_type,
                      NumberTypes::sacado_rad_dfad>
     {};
@@ -814,11 +807,10 @@ namespace Differentiation
     template <typename ADNumberType>
     struct ADNumberTraits<
       ADNumberType,
-      typename std::enable_if<std::is_same<
+      std::enable_if_t<std::is_same<
         ADNumberType,
         std::complex<Sacado::Rad::ADvar<Sacado::Fad::DFad<
-          typename ADNumberType::value_type::ADVari::scalar_type>>>>::value>::
-        type>
+          typename ADNumberType::value_type::ADVari::scalar_type>>>>::value>>
       : NumberTraits<
           std::complex<typename ADNumberType::value_type::ADVari::scalar_type>,
           NumberTypes::sacado_rad_dfad>
@@ -862,20 +854,20 @@ namespace Differentiation
     template <typename NumberType>
     struct is_sacado_dfad_number<
       NumberType,
-      typename std::enable_if<
+      std::enable_if_t<
         ADNumberTraits<typename std::decay<NumberType>::type>::type_code ==
           NumberTypes::sacado_dfad ||
         ADNumberTraits<typename std::decay<NumberType>::type>::type_code ==
-          NumberTypes::sacado_dfad_dfad>::type> : std::true_type
+          NumberTypes::sacado_dfad_dfad>> : std::true_type
     {};
 
 
     template <typename NumberType>
     struct is_sacado_dfad_number<
       NumberType,
-      typename std::enable_if<std::is_same<
+      std::enable_if_t<std::is_same<
         NumberType,
-        Sacado::Fad::Expr<typename NumberType::value_type>>::value>::type>
+        Sacado::Fad::Expr<typename NumberType::value_type>>::value>>
       : std::true_type
     {};
 
@@ -883,21 +875,21 @@ namespace Differentiation
     template <typename NumberType>
     struct is_sacado_rad_number<
       NumberType,
-      typename std::enable_if<
+      std::enable_if_t<
         ADNumberTraits<typename std::decay<NumberType>::type>::type_code ==
           NumberTypes::sacado_rad ||
         ADNumberTraits<typename std::decay<NumberType>::type>::type_code ==
-          NumberTypes::sacado_rad_dfad>::type> : std::true_type
+          NumberTypes::sacado_rad_dfad>> : std::true_type
     {};
 
 
     template <typename NumberType>
     struct is_sacado_rad_number<
       NumberType,
-      typename std::enable_if<std::is_same<
-        NumberType,
-        Sacado::Rad::ADvari<Sacado::Fad::DFad<
-          typename NumberType::ADVari::scalar_type>>>::value>::type>
+      std::enable_if_t<
+        std::is_same<NumberType,
+                     Sacado::Rad::ADvari<Sacado::Fad::DFad<
+                       typename NumberType::ADVari::scalar_type>>>::value>>
       : std::true_type
     {};
 
@@ -905,8 +897,8 @@ namespace Differentiation
     template <typename NumberType>
     struct is_sacado_number<
       NumberType,
-      typename std::enable_if<is_sacado_dfad_number<NumberType>::value ||
-                              is_sacado_rad_number<NumberType>::value>::type>
+      std::enable_if_t<is_sacado_dfad_number<NumberType>::value ||
+                       is_sacado_rad_number<NumberType>::value>>
       : std::true_type
     {};
 
@@ -919,8 +911,9 @@ namespace numbers
   template <typename NumberType>
   struct is_cuda_compatible<
     NumberType,
-    typename std::enable_if<dealii::Differentiation::AD::is_sacado_rad_number<
-      NumberType>::value>::type> : std::false_type
+    std::enable_if_t<
+      dealii::Differentiation::AD::is_sacado_rad_number<NumberType>::value>>
+    : std::false_type
   {};
 } // namespace numbers
 

--- a/include/deal.II/differentiation/sd/symengine_math.h
+++ b/include/deal.II/differentiation/sd/symengine_math.h
@@ -67,9 +67,9 @@ namespace Differentiation
      *
      * This variant is used when the @p exponent is not a Expression.
      */
-    template <typename NumberType,
-              typename = typename std::enable_if<
-                !std::is_same<NumberType, Expression>::value>::type>
+    template <
+      typename NumberType,
+      typename = std::enable_if_t<!std::is_same<NumberType, Expression>::value>>
     Expression
     pow(const Expression &base, const NumberType &exponent)
     {
@@ -86,9 +86,9 @@ namespace Differentiation
      *
      * This variant is used when the @p base is not a Expression.
      */
-    template <typename NumberType,
-              typename = typename std::enable_if<
-                !std::is_same<NumberType, Expression>::value>::type>
+    template <
+      typename NumberType,
+      typename = std::enable_if_t<!std::is_same<NumberType, Expression>::value>>
     Expression
     pow(const NumberType &base, const Expression &exponent)
     {
@@ -152,9 +152,9 @@ namespace Differentiation
      *
      * This variant is used when the @p base is not a Expression.
      */
-    template <typename NumberType,
-              typename = typename std::enable_if<
-                !std::is_same<NumberType, Expression>::value>::type>
+    template <
+      typename NumberType,
+      typename = std::enable_if_t<!std::is_same<NumberType, Expression>::value>>
     Expression
     log(const Expression &x, const NumberType &base)
     {
@@ -171,9 +171,9 @@ namespace Differentiation
      *
      * This variant is used when the @p value is not a Expression.
      */
-    template <typename NumberType,
-              typename = typename std::enable_if<
-                !std::is_same<NumberType, Expression>::value>::type>
+    template <
+      typename NumberType,
+      typename = std::enable_if_t<!std::is_same<NumberType, Expression>::value>>
     Expression
     log(const NumberType &x, const Expression &base)
     {
@@ -311,9 +311,9 @@ namespace Differentiation
      *
      * This variant is used when the numerator @p y is not a Expression.
      */
-    template <typename NumberType,
-              typename = typename std::enable_if<
-                !std::is_same<NumberType, Expression>::value>::type>
+    template <
+      typename NumberType,
+      typename = std::enable_if_t<!std::is_same<NumberType, Expression>::value>>
     Expression
     atan2(const NumberType &y, const Expression &x)
     {
@@ -331,9 +331,9 @@ namespace Differentiation
      *
      * This variant is used when the denominator @p x is not a Expression.
      */
-    template <typename NumberType,
-              typename = typename std::enable_if<
-                !std::is_same<NumberType, Expression>::value>::type>
+    template <
+      typename NumberType,
+      typename = std::enable_if_t<!std::is_same<NumberType, Expression>::value>>
     Expression
     atan2(const Expression &y, const NumberType &x)
     {
@@ -600,9 +600,9 @@ namespace Differentiation
      *
      * This variant is used when @p b is not a Expression.
      */
-    template <typename NumberType,
-              typename = typename std::enable_if<
-                !std::is_same<NumberType, Expression>::value>::type>
+    template <
+      typename NumberType,
+      typename = std::enable_if_t<!std::is_same<NumberType, Expression>::value>>
     Expression
     max(const Expression &a, const NumberType &b)
     {
@@ -619,9 +619,9 @@ namespace Differentiation
      *
      * This variant is used when @p a is not a Expression.
      */
-    template <typename NumberType,
-              typename = typename std::enable_if<
-                !std::is_same<NumberType, Expression>::value>::type>
+    template <
+      typename NumberType,
+      typename = std::enable_if_t<!std::is_same<NumberType, Expression>::value>>
     Expression
     max(const NumberType &a, const Expression &b)
     {
@@ -648,9 +648,9 @@ namespace Differentiation
      *
      * This variant is used when @p b is not a Expression.
      */
-    template <typename NumberType,
-              typename = typename std::enable_if<
-                !std::is_same<NumberType, Expression>::value>::type>
+    template <
+      typename NumberType,
+      typename = std::enable_if_t<!std::is_same<NumberType, Expression>::value>>
     Expression
     min(const Expression &a, const NumberType &b)
     {
@@ -667,9 +667,9 @@ namespace Differentiation
      *
      * This variant is used when @p a is not a Expression.
      */
-    template <typename NumberType,
-              typename = typename std::enable_if<
-                !std::is_same<NumberType, Expression>::value>::type>
+    template <
+      typename NumberType,
+      typename = std::enable_if_t<!std::is_same<NumberType, Expression>::value>>
     Expression
     min(const NumberType &a, const Expression &b)
     {

--- a/include/deal.II/differentiation/sd/symengine_number_types.h
+++ b/include/deal.II/differentiation/sd/symengine_number_types.h
@@ -203,9 +203,9 @@ namespace Differentiation
        * potential ambiguities related to implicit conversions in either user
        * code or math functions that are loaded into the standard namespace.
        */
-      template <typename NumberType,
-                typename = typename std::enable_if<
-                  std::is_arithmetic<NumberType>::value>::type>
+      template <
+        typename NumberType,
+        typename = std::enable_if_t<std::is_arithmetic<NumberType>::value>>
       explicit Expression(const NumberType &value);
 
       /**
@@ -215,9 +215,9 @@ namespace Differentiation
        * potential ambiguities related to implicit conversions in either user
        * code or math functions that are loaded into the standard namespace.
        */
-      template <typename NumberType,
-                typename = typename std::enable_if<
-                  std::is_arithmetic<NumberType>::value>::type>
+      template <
+        typename NumberType,
+        typename = std::enable_if_t<std::is_arithmetic<NumberType>::value>>
       explicit Expression(const std::complex<NumberType> &value);
 
       /**
@@ -231,9 +231,9 @@ namespace Differentiation
        * It is expected that both the @p numerator and @p denominator
        * be integral types.
        */
-      template <typename NumberType,
-                typename = typename std::enable_if<
-                  std::is_integral<NumberType>::value>::type>
+      template <
+        typename NumberType,
+        typename = std::enable_if_t<std::is_integral<NumberType>::value>>
       Expression(const NumberType &numerator, const NumberType &denominator);
 
       /**
@@ -1084,8 +1084,8 @@ namespace Differentiation
      * scalar expressions using Expression more natural.
      */
     template <typename NumberType,
-              typename = typename std::enable_if<
-                std::is_constructible<Expression, NumberType>::value>::type>
+              typename = std::enable_if_t<
+                std::is_constructible<Expression, NumberType>::value>>
     inline Expression
     operator+(const NumberType &lhs, const Expression &rhs)
     {
@@ -1101,8 +1101,8 @@ namespace Differentiation
      * scalar expressions using Expression more natural.
      */
     template <typename NumberType,
-              typename = typename std::enable_if<
-                std::is_constructible<Expression, NumberType>::value>::type>
+              typename = std::enable_if_t<
+                std::is_constructible<Expression, NumberType>::value>>
     inline Expression
     operator+(const Expression &lhs, const NumberType &rhs)
     {
@@ -1118,8 +1118,8 @@ namespace Differentiation
      * scalar expressions using Expression more natural.
      */
     template <typename NumberType,
-              typename = typename std::enable_if<
-                std::is_constructible<Expression, NumberType>::value>::type>
+              typename = std::enable_if_t<
+                std::is_constructible<Expression, NumberType>::value>>
     inline Expression
     operator-(const NumberType &lhs, const Expression &rhs)
     {
@@ -1135,8 +1135,8 @@ namespace Differentiation
      * scalar expressions using Expression more natural.
      */
     template <typename NumberType,
-              typename = typename std::enable_if<
-                std::is_constructible<Expression, NumberType>::value>::type>
+              typename = std::enable_if_t<
+                std::is_constructible<Expression, NumberType>::value>>
     inline Expression
     operator-(const Expression &lhs, const NumberType &rhs)
     {
@@ -1152,8 +1152,8 @@ namespace Differentiation
      * scalar expressions using Expression more natural.
      */
     template <typename NumberType,
-              typename = typename std::enable_if<
-                std::is_constructible<Expression, NumberType>::value>::type>
+              typename = std::enable_if_t<
+                std::is_constructible<Expression, NumberType>::value>>
     inline Expression
     operator*(const NumberType &lhs, const Expression &rhs)
     {
@@ -1169,8 +1169,8 @@ namespace Differentiation
      * scalar expressions using Expression more natural.
      */
     template <typename NumberType,
-              typename = typename std::enable_if<
-                std::is_constructible<Expression, NumberType>::value>::type>
+              typename = std::enable_if_t<
+                std::is_constructible<Expression, NumberType>::value>>
     inline Expression
     operator*(const Expression &lhs, const NumberType &rhs)
     {
@@ -1186,8 +1186,8 @@ namespace Differentiation
      * scalar expressions using Expression more natural.
      */
     template <typename NumberType,
-              typename = typename std::enable_if<
-                std::is_constructible<Expression, NumberType>::value>::type>
+              typename = std::enable_if_t<
+                std::is_constructible<Expression, NumberType>::value>>
     inline Expression
     operator/(const NumberType &lhs, const Expression &rhs)
     {
@@ -1203,8 +1203,8 @@ namespace Differentiation
      * scalar expressions using Expression more natural.
      */
     template <typename NumberType,
-              typename = typename std::enable_if<
-                std::is_constructible<Expression, NumberType>::value>::type>
+              typename = std::enable_if_t<
+                std::is_constructible<Expression, NumberType>::value>>
     inline Expression
     operator/(const Expression &lhs, const NumberType &rhs)
     {
@@ -1376,27 +1376,24 @@ namespace internal
       return t;
     }
 
-    template <
-      typename T,
-      typename = typename std::enable_if<std::is_arithmetic<T>::value>::type>
+    template <typename T,
+              typename = std::enable_if_t<std::is_arithmetic<T>::value>>
     static Differentiation::SD::Expression
     value(const T &t)
     {
       return Differentiation::SD::Expression(t);
     }
 
-    template <
-      typename T,
-      typename = typename std::enable_if<std::is_arithmetic<T>::value>::type>
+    template <typename T,
+              typename = std::enable_if_t<std::is_arithmetic<T>::value>>
     static Differentiation::SD::Expression
     value(T &&t)
     {
       return Differentiation::SD::Expression(t);
     }
 
-    template <
-      typename T,
-      typename = typename std::enable_if<std::is_arithmetic<T>::value>::type>
+    template <typename T,
+              typename = std::enable_if_t<std::is_arithmetic<T>::value>>
     static Differentiation::SD::Expression
     value(const std::complex<T> &t)
     {

--- a/include/deal.II/differentiation/sd/symengine_optimizer.h
+++ b/include/deal.II/differentiation/sd/symengine_optimizer.h
@@ -372,7 +372,7 @@ namespace Differentiation
       template <typename ReturnType_>
       struct SupportedOptimizerTypeTraits<
         ReturnType_,
-        typename std::enable_if<std::is_arithmetic<ReturnType_>::value>::type>
+        std::enable_if_t<std::is_arithmetic<ReturnType_>::value>>
       {
         static const bool is_supported = true;
 
@@ -388,9 +388,9 @@ namespace Differentiation
       template <typename ReturnType_>
       struct SupportedOptimizerTypeTraits<
         ReturnType_,
-        typename std::enable_if<
+        std::enable_if_t<
           boost::is_complex<ReturnType_>::value &&
-          std::is_arithmetic<typename ReturnType_::value_type>::value>::type>
+          std::is_arithmetic<typename ReturnType_::value_type>::value>>
       {
         static const bool is_supported = true;
 
@@ -403,10 +403,9 @@ namespace Differentiation
 
 
       template <typename ReturnType_>
-      struct DictionaryOptimizer<
-        ReturnType_,
-        typename std::enable_if<
-          SupportedOptimizerTypeTraits<ReturnType_>::is_supported>::type>
+      struct DictionaryOptimizer<ReturnType_,
+                                 std::enable_if_t<SupportedOptimizerTypeTraits<
+                                   ReturnType_>::is_supported>>
       {
         using ReturnType =
           typename SupportedOptimizerTypeTraits<ReturnType_>::ReturnType;
@@ -502,10 +501,9 @@ namespace Differentiation
 
 
       template <typename ReturnType_>
-      struct LambdaOptimizer<
-        ReturnType_,
-        typename std::enable_if<
-          SupportedOptimizerTypeTraits<ReturnType_>::is_supported>::type>
+      struct LambdaOptimizer<ReturnType_,
+                             std::enable_if_t<SupportedOptimizerTypeTraits<
+                               ReturnType_>::is_supported>>
       {
         using ReturnType =
           typename std::conditional<!boost::is_complex<ReturnType_>::value,
@@ -605,7 +603,7 @@ namespace Differentiation
       template <typename ReturnType_>
       struct LLVMOptimizer<
         ReturnType_,
-        typename std::enable_if<std::is_arithmetic<ReturnType_>::value>::type>
+        std::enable_if_t<std::is_arithmetic<ReturnType_>::value>>
       {
         using ReturnType =
           typename std::conditional<std::is_same<ReturnType_, float>::value,
@@ -719,9 +717,9 @@ namespace Differentiation
       template <typename ReturnType_>
       struct LLVMOptimizer<
         ReturnType_,
-        typename std::enable_if<
+        std::enable_if_t<
           boost::is_complex<ReturnType_>::value &&
-          std::is_arithmetic<typename ReturnType_::value_type>::value>::type>
+          std::is_arithmetic<typename ReturnType_::value_type>::value>>
       {
         // Since there is no working implementation, these are dummy types
         // that help with templating in the calling function.
@@ -821,11 +819,11 @@ namespace Differentiation
 
 
       template <typename ReturnType, typename Optimizer>
-      struct OptimizerHelper<ReturnType,
-                             Optimizer,
-                             typename std::enable_if<std::is_same<
-                               ReturnType,
-                               typename Optimizer::ReturnType>::value>::type>
+      struct OptimizerHelper<
+        ReturnType,
+        Optimizer,
+        std::enable_if_t<
+          std::is_same<ReturnType, typename Optimizer::ReturnType>::value>>
       {
         /**
          * Initialize an instance of an optimizer.
@@ -963,11 +961,11 @@ namespace Differentiation
       };
 
       template <typename ReturnType, typename Optimizer>
-      struct OptimizerHelper<ReturnType,
-                             Optimizer,
-                             typename std::enable_if<!std::is_same<
-                               ReturnType,
-                               typename Optimizer::ReturnType>::value>::type>
+      struct OptimizerHelper<
+        ReturnType,
+        Optimizer,
+        std::enable_if_t<
+          !std::is_same<ReturnType, typename Optimizer::ReturnType>::value>>
       {
         /**
          * Initialize an instance of an optimizer.

--- a/include/deal.II/differentiation/sd/symengine_product_types.h
+++ b/include/deal.II/differentiation/sd/symengine_product_types.h
@@ -67,7 +67,7 @@ namespace internal
     struct GeneralProductTypeImpl<
       T,
       Differentiation::SD::Expression,
-      typename std::enable_if<std::is_arithmetic<T>::value>::type>
+      std::enable_if_t<std::is_arithmetic<T>::value>>
     {
       using type = Differentiation::SD::Expression;
     };
@@ -76,9 +76,8 @@ namespace internal
     struct GeneralProductTypeImpl<
       T,
       Differentiation::SD::Expression,
-      typename std::enable_if<
-        boost::is_complex<T>::value &&
-        std::is_arithmetic<typename T::value_type>::value>::type>
+      std::enable_if_t<boost::is_complex<T>::value &&
+                       std::is_arithmetic<typename T::value_type>::value>>
     {
       using type = Differentiation::SD::Expression;
     };

--- a/include/deal.II/differentiation/sd/symengine_scalar_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_scalar_operations.h
@@ -303,11 +303,11 @@ namespace Differentiation
     template <bool ignore_invalid_symbols = false,
               typename ValueType          = double,
               typename SymbolicType,
-              typename T = typename std::enable_if<
+              typename T = std::enable_if_t<
                 !std::is_base_of<Expression, SymbolicType>::value &&
                 dealii::internal::is_explicitly_convertible<
                   SymbolicType,
-                  const SymEngine::RCP<const SymEngine::Basic> &>::value>::type>
+                  const SymEngine::RCP<const SymEngine::Basic> &>::value>>
     void
     add_to_symbol_map(types::substitution_map &symbol_map,
                       const SymbolicType &     symbol);
@@ -460,11 +460,11 @@ namespace Differentiation
      */
     template <typename SymbolicType,
               typename ValueType,
-              typename T = typename std::enable_if<
+              typename T = std::enable_if_t<
                 dealii::internal::is_explicitly_convertible<
                   SymbolicType,
                   const SymEngine::RCP<const SymEngine::Basic> &>::value &&
-                std::is_constructible<SymbolicType, ValueType>::value>::type>
+                std::is_constructible<SymbolicType, ValueType>::value>>
     void
     set_value_in_symbol_map(types::substitution_map &substitution_map,
                             const SymbolicType &     symbol,
@@ -649,11 +649,11 @@ namespace Differentiation
      */
     template <typename ExpressionType,
               typename ValueType,
-              typename T = typename std::enable_if<
+              typename T = std::enable_if_t<
                 dealii::internal::is_explicitly_convertible<
                   ExpressionType,
                   const SymEngine::RCP<const SymEngine::Basic> &>::value &&
-                std::is_constructible<ExpressionType, ValueType>::value>::type>
+                std::is_constructible<ExpressionType, ValueType>::value>>
     types::substitution_map
     make_substitution_map(const ExpressionType &symbol, const ValueType &value);
 
@@ -892,11 +892,11 @@ namespace Differentiation
     template <bool ignore_invalid_symbols = false,
               typename ExpressionType,
               typename ValueType,
-              typename = typename std::enable_if<
+              typename = std::enable_if_t<
                 dealii::internal::is_explicitly_convertible<
                   ExpressionType,
                   const SymEngine::RCP<const SymEngine::Basic> &>::value &&
-                std::is_constructible<ExpressionType, ValueType>::value>::type>
+                std::is_constructible<ExpressionType, ValueType>::value>>
     void
     add_to_substitution_map(types::substitution_map &substitution_map,
                             const ExpressionType &   symbol,
@@ -938,11 +938,11 @@ namespace Differentiation
     template <bool ignore_invalid_symbols = false,
               typename ExpressionType,
               typename ValueType,
-              typename = typename std::enable_if<
+              typename = std::enable_if_t<
                 dealii::internal::is_explicitly_convertible<
                   ExpressionType,
                   const SymEngine::RCP<const SymEngine::Basic> &>::value &&
-                std::is_constructible<ExpressionType, ValueType>::value>::type>
+                std::is_constructible<ExpressionType, ValueType>::value>>
     void
     add_to_substitution_map(types::substitution_map &          substitution_map,
                             const std::vector<ExpressionType> &symbols,

--- a/include/deal.II/fe/fe_tools_extrapolate.templates.h
+++ b/include/deal.II/fe/fe_tools_extrapolate.templates.h
@@ -1469,9 +1469,8 @@ namespace FETools
     };
 
     template <class VectorType>
-    struct BlockTypeHelper<
-      VectorType,
-      typename std::enable_if<IsBlockVector<VectorType>::value>::type>
+    struct BlockTypeHelper<VectorType,
+                           std::enable_if_t<IsBlockVector<VectorType>::value>>
     {
       using type = typename VectorType::BlockType;
     };

--- a/include/deal.II/fe/fe_tools_interpolate.templates.h
+++ b/include/deal.II/fe/fe_tools_interpolate.templates.h
@@ -350,7 +350,7 @@ namespace FETools
   namespace internal
   {
     template <int dim, int spacedim, class InVector>
-    typename std::enable_if<is_serial_vector<InVector>::value>::type
+    std::enable_if_t<is_serial_vector<InVector>::value>
     back_interpolate(
       const DoFHandler<dim, spacedim> &                       dof1,
       const AffineConstraints<typename InVector::value_type> &constraints1,

--- a/include/deal.II/grid/tria_iterator.h
+++ b/include/deal.II/grid/tria_iterator.h
@@ -381,8 +381,7 @@ public:
    * Compare for equality.
    */
   template <typename OtherAccessor = Accessor>
-  typename std::enable_if<std::is_convertible<OtherAccessor, Accessor>::value,
-                          bool>::type
+  std::enable_if_t<std::is_convertible<OtherAccessor, Accessor>::value, bool>
   operator==(const TriaRawIterator<OtherAccessor> &) const;
 
   /**

--- a/include/deal.II/grid/tria_iterator.templates.h
+++ b/include/deal.II/grid/tria_iterator.templates.h
@@ -83,11 +83,10 @@ TriaRawIterator<Accessor>::operator=(const TriaRawIterator<Accessor> &i)
 
 template <typename Accessor>
 template <typename OtherAccessor>
-inline
-  typename std::enable_if<std::is_convertible<OtherAccessor, Accessor>::value,
-                          bool>::type
-  TriaRawIterator<Accessor>::operator==(
-    const TriaRawIterator<OtherAccessor> &other) const
+inline std::enable_if_t<std::is_convertible<OtherAccessor, Accessor>::value,
+                        bool>
+TriaRawIterator<Accessor>::operator==(
+  const TriaRawIterator<OtherAccessor> &other) const
 {
   return accessor == other.accessor;
 }

--- a/include/deal.II/lac/full_matrix.templates.h
+++ b/include/deal.II/lac/full_matrix.templates.h
@@ -1216,10 +1216,9 @@ namespace internal
   // LAPACKFullMatrix is only implemented for
   // floats and doubles
   template <typename number>
-  struct Determinant<
-    number,
-    typename std::enable_if<std::is_same<number, float>::value ||
-                            std::is_same<number, double>::value>::type>
+  struct Determinant<number,
+                     std::enable_if_t<std::is_same<number, float>::value ||
+                                      std::is_same<number, double>::value>>
   {
 #ifdef DEAL_II_WITH_LAPACK
     static number

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -1933,18 +1933,18 @@ namespace internal
         is_supported_operation<initialize_dof_vector_t, T>;
 
       // Used for (Trilinos/PETSc)Wrappers::SparseMatrix
-      template <
-        typename MatrixType,
+      template <typename MatrixType,
 #if !defined(__INTEL_COMPILER) || __INTEL_COMPILER >= 1900
-        typename std::enable_if<has_get_mpi_communicator<MatrixType> &&
-                                  has_locally_owned_domain_indices<MatrixType>,
+                std::enable_if_t<has_get_mpi_communicator<MatrixType> &&
+                                   has_locally_owned_domain_indices<MatrixType>,
 #else
-        // workaround for Intel 18
-        typename std::enable_if<
-          is_supported_operation<get_mpi_communicator_t, MatrixType> &&
-            is_supported_operation<locally_owned_domain_indices_t, MatrixType>,
+                // workaround for Intel 18
+                std::enable_if_t<
+                  is_supported_operation<get_mpi_communicator_t, MatrixType> &&
+                    is_supported_operation<locally_owned_domain_indices_t,
+                                           MatrixType>,
 #endif
-                                MatrixType>::type * = nullptr>
+                                 MatrixType> * = nullptr>
       static void
       reinit_domain_vector(MatrixType &                                mat,
                            LinearAlgebra::distributed::Vector<Number> &vec,
@@ -1957,13 +1957,13 @@ namespace internal
       // Used for MatrixFree and DiagonalMatrix
       template <typename MatrixType,
 #if !defined(__INTEL_COMPILER) || __INTEL_COMPILER >= 1900
-                typename std::enable_if<has_initialize_dof_vector<MatrixType>,
+                std::enable_if_t<has_initialize_dof_vector<MatrixType>,
 #else
                 // workaround for Intel 18
-                typename std::enable_if<
+                std::enable_if_t<
                   is_supported_operation<initialize_dof_vector_t, MatrixType>,
 #endif
-                                        MatrixType>::type * = nullptr>
+                                 MatrixType> * = nullptr>
       static void
       reinit_domain_vector(MatrixType &                                mat,
                            LinearAlgebra::distributed::Vector<Number> &vec,
@@ -1975,18 +1975,18 @@ namespace internal
       }
 
       // Used for (Trilinos/PETSc)Wrappers::SparseMatrix
-      template <
-        typename MatrixType,
+      template <typename MatrixType,
 #if !defined(__INTEL_COMPILER) || __INTEL_COMPILER >= 1900
-        typename std::enable_if<has_get_mpi_communicator<MatrixType> &&
-                                  has_locally_owned_range_indices<MatrixType>,
+                std::enable_if_t<has_get_mpi_communicator<MatrixType> &&
+                                   has_locally_owned_range_indices<MatrixType>,
 #else
-        // workaround for Intel 18
-        typename std::enable_if<
-          is_supported_operation<get_mpi_communicator_t, MatrixType> &&
-            is_supported_operation<locally_owned_range_indices_t, MatrixType>,
+                // workaround for Intel 18
+                std::enable_if_t<
+                  is_supported_operation<get_mpi_communicator_t, MatrixType> &&
+                    is_supported_operation<locally_owned_range_indices_t,
+                                           MatrixType>,
 #endif
-                                MatrixType>::type * = nullptr>
+                                 MatrixType> * = nullptr>
       static void
       reinit_range_vector(MatrixType &                                mat,
                           LinearAlgebra::distributed::Vector<Number> &vec,
@@ -1999,13 +1999,13 @@ namespace internal
       // Used for MatrixFree and DiagonalMatrix
       template <typename MatrixType,
 #if !defined(__INTEL_COMPILER) || __INTEL_COMPILER >= 1900
-                typename std::enable_if<has_initialize_dof_vector<MatrixType>,
+                std::enable_if_t<has_initialize_dof_vector<MatrixType>,
 #else
                 // workaround for Intel 18
-                typename std::enable_if<
+                std::enable_if_t<
                   is_supported_operation<initialize_dof_vector_t, MatrixType>,
 #endif
-                                        MatrixType>::type * = nullptr>
+                                 MatrixType> * = nullptr>
       static void
       reinit_range_vector(MatrixType &                                mat,
                           LinearAlgebra::distributed::Vector<Number> &vec,

--- a/include/deal.II/lac/linear_operator.h
+++ b/include/deal.II/lac/linear_operator.h
@@ -238,10 +238,10 @@ public:
    * object @p op for which the conversion function
    * <code>linear_operator</code> is defined.
    */
-  template <typename Op,
-            typename = typename std::enable_if<
-              !std::is_base_of<LinearOperator<Range, Domain, Payload>,
-                               Op>::value>::type>
+  template <
+    typename Op,
+    typename = std::enable_if_t<
+      !std::is_base_of<LinearOperator<Range, Domain, Payload>, Op>::value>>
   LinearOperator(const Op &op)
   {
     *this = linear_operator<Range, Domain, Payload, Op>(op);
@@ -257,10 +257,10 @@ public:
    * Templated copy assignment operator for an object @p op for which the
    * conversion function <code>linear_operator</code> is defined.
    */
-  template <typename Op,
-            typename = typename std::enable_if<
-              !std::is_base_of<LinearOperator<Range, Domain, Payload>,
-                               Op>::value>::type>
+  template <
+    typename Op,
+    typename = std::enable_if_t<
+      !std::is_base_of<LinearOperator<Range, Domain, Payload>, Op>::value>>
   LinearOperator<Range, Domain, Payload> &
   operator=(const Op &op)
   {
@@ -1492,8 +1492,7 @@ template <
   typename Payload = internal::LinearOperatorImplementation::EmptyPayload,
   typename OperatorExemplar,
   typename Matrix,
-  typename =
-    typename std::enable_if<!std::is_lvalue_reference<Matrix>::value>::type>
+  typename = std::enable_if_t<!std::is_lvalue_reference<Matrix>::value>>
 LinearOperator<Range, Domain, Payload>
 linear_operator(const OperatorExemplar &, Matrix &&) = delete;
 
@@ -1503,11 +1502,11 @@ template <
   typename Payload = internal::LinearOperatorImplementation::EmptyPayload,
   typename OperatorExemplar,
   typename Matrix,
-  typename = typename std::enable_if<
-    !std::is_lvalue_reference<OperatorExemplar>::value>::type,
-  typename = typename std::enable_if<
+  typename =
+    std::enable_if_t<!std::is_lvalue_reference<OperatorExemplar>::value>,
+  typename = std::enable_if_t<
     !std::is_same<OperatorExemplar,
-                  LinearOperator<Range, Domain, Payload>>::value>::type>
+                  LinearOperator<Range, Domain, Payload>>::value>>
 LinearOperator<Range, Domain, Payload>
 linear_operator(OperatorExemplar &&, const Matrix &) = delete;
 
@@ -1517,13 +1516,12 @@ template <
   typename Payload = internal::LinearOperatorImplementation::EmptyPayload,
   typename OperatorExemplar,
   typename Matrix,
+  typename = std::enable_if_t<!std::is_lvalue_reference<Matrix>::value>,
   typename =
-    typename std::enable_if<!std::is_lvalue_reference<Matrix>::value>::type,
-  typename = typename std::enable_if<
-    !std::is_lvalue_reference<OperatorExemplar>::value>::type,
-  typename = typename std::enable_if<
+    std::enable_if_t<!std::is_lvalue_reference<OperatorExemplar>::value>,
+  typename = std::enable_if_t<
     !std::is_same<OperatorExemplar,
-                  LinearOperator<Range, Domain, Payload>>::value>::type>
+                  LinearOperator<Range, Domain, Payload>>::value>>
 LinearOperator<Range, Domain, Payload>
 linear_operator(OperatorExemplar &&, Matrix &&) = delete;
 
@@ -1532,8 +1530,7 @@ template <
   typename Domain  = Range,
   typename Payload = internal::LinearOperatorImplementation::EmptyPayload,
   typename Matrix,
-  typename =
-    typename std::enable_if<!std::is_lvalue_reference<Matrix>::value>::type>
+  typename = std::enable_if_t<!std::is_lvalue_reference<Matrix>::value>>
 LinearOperator<Range, Domain, Payload>
 linear_operator(const LinearOperator<Range, Domain, Payload> &,
                 Matrix &&) = delete;
@@ -1543,23 +1540,22 @@ template <
   typename Domain  = Range,
   typename Payload = internal::LinearOperatorImplementation::EmptyPayload,
   typename Matrix,
-  typename =
-    typename std::enable_if<!std::is_lvalue_reference<Matrix>::value>::type>
+  typename = std::enable_if_t<!std::is_lvalue_reference<Matrix>::value>>
 LinearOperator<Range, Domain, Payload>
 linear_operator(Matrix &&) = delete;
 
-template <typename Payload,
-          typename Solver,
-          typename Preconditioner,
-          typename Range  = typename Solver::vector_type,
-          typename Domain = Range,
-          typename        = typename std::enable_if<
-            !std::is_lvalue_reference<Preconditioner>::value>::type,
-          typename = typename std::enable_if<
-            !std::is_same<Preconditioner, PreconditionIdentity>::value>::type,
-          typename = typename std::enable_if<
-            !std::is_same<Preconditioner,
-                          LinearOperator<Range, Domain, Payload>>::value>::type>
+template <
+  typename Payload,
+  typename Solver,
+  typename Preconditioner,
+  typename Range  = typename Solver::vector_type,
+  typename Domain = Range,
+  typename = std::enable_if_t<!std::is_lvalue_reference<Preconditioner>::value>,
+  typename = std::enable_if_t<
+    !std::is_same<Preconditioner, PreconditionIdentity>::value>,
+  typename = std::enable_if_t<
+    !std::is_same<Preconditioner,
+                  LinearOperator<Range, Domain, Payload>>::value>>
 LinearOperator<Domain, Range, Payload>
 inverse_operator(const LinearOperator<Range, Domain, Payload> &,
                  Solver &,

--- a/include/deal.II/lac/packaged_operation.h
+++ b/include/deal.II/lac/packaged_operation.h
@@ -523,10 +523,10 @@ namespace internal
  * @ingroup LAOperators
  */
 
-template <typename Range,
-          typename = typename std::enable_if<
-            internal::PackagedOperationImplementation::has_vector_interface<
-              Range>::type::value>::type>
+template <
+  typename Range,
+  typename = std::enable_if_t<internal::PackagedOperationImplementation::
+                                has_vector_interface<Range>::type::value>>
 PackagedOperation<Range>
 operator+(const Range &u, const Range &v)
 {
@@ -568,10 +568,10 @@ operator+(const Range &u, const Range &v)
  * @ingroup LAOperators
  */
 
-template <typename Range,
-          typename = typename std::enable_if<
-            internal::PackagedOperationImplementation::has_vector_interface<
-              Range>::type::value>::type>
+template <
+  typename Range,
+  typename = std::enable_if_t<internal::PackagedOperationImplementation::
+                                has_vector_interface<Range>::type::value>>
 PackagedOperation<Range>
 operator-(const Range &u, const Range &v)
 {
@@ -612,10 +612,10 @@ operator-(const Range &u, const Range &v)
  *
  * @ingroup LAOperators
  */
-template <typename Range,
-          typename = typename std::enable_if<
-            internal::PackagedOperationImplementation::has_vector_interface<
-              Range>::type::value>::type>
+template <
+  typename Range,
+  typename = std::enable_if_t<internal::PackagedOperationImplementation::
+                                has_vector_interface<Range>::type::value>>
 PackagedOperation<Range>
 operator*(const Range &u, typename Range::value_type number)
 {
@@ -637,10 +637,10 @@ operator*(const Range &u, typename Range::value_type number)
  *
  * @ingroup LAOperators
  */
-template <typename Range,
-          typename = typename std::enable_if<
-            internal::PackagedOperationImplementation::has_vector_interface<
-              Range>::type::value>::type>
+template <
+  typename Range,
+  typename = std::enable_if_t<internal::PackagedOperationImplementation::
+                                has_vector_interface<Range>::type::value>>
 PackagedOperation<Range>
 operator*(typename Range::value_type number, const Range &u)
 {

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -625,18 +625,17 @@ namespace internal
       }
 
       template <typename VectorType,
-                typename std::enable_if<has_jacobi_step<MatrixType, VectorType>,
-                                        MatrixType>::type * = nullptr>
+                std::enable_if_t<has_jacobi_step<MatrixType, VectorType>,
+                                 MatrixType> * = nullptr>
       void
       step(VectorType &dst, const VectorType &src) const
       {
         this->A->Jacobi_step(dst, src, this->relaxation);
       }
 
-      template <
-        typename VectorType,
-        typename std::enable_if<!has_jacobi_step<MatrixType, VectorType>,
-                                MatrixType>::type * = nullptr>
+      template <typename VectorType,
+                std::enable_if_t<!has_jacobi_step<MatrixType, VectorType>,
+                                 MatrixType> * = nullptr>
       void
       step(VectorType &, const VectorType &) const
       {
@@ -682,8 +681,8 @@ namespace internal
       }
 
       template <typename VectorType,
-                typename std::enable_if<has_SOR_step<MatrixType, VectorType>,
-                                        MatrixType>::type * = nullptr>
+                std::enable_if_t<has_SOR_step<MatrixType, VectorType>,
+                                 MatrixType> * = nullptr>
       void
       step(VectorType &dst, const VectorType &src) const
       {
@@ -691,8 +690,8 @@ namespace internal
       }
 
       template <typename VectorType,
-                typename std::enable_if<!has_SOR_step<MatrixType, VectorType>,
-                                        MatrixType>::type * = nullptr>
+                std::enable_if_t<!has_SOR_step<MatrixType, VectorType>,
+                                 MatrixType> * = nullptr>
       void
       step(VectorType &, const VectorType &) const
       {
@@ -702,8 +701,8 @@ namespace internal
       }
 
       template <typename VectorType,
-                typename std::enable_if<has_SOR_step<MatrixType, VectorType>,
-                                        MatrixType>::type * = nullptr>
+                std::enable_if_t<has_SOR_step<MatrixType, VectorType>,
+                                 MatrixType> * = nullptr>
       void
       Tstep(VectorType &dst, const VectorType &src) const
       {
@@ -711,8 +710,8 @@ namespace internal
       }
 
       template <typename VectorType,
-                typename std::enable_if<!has_SOR_step<MatrixType, VectorType>,
-                                        MatrixType>::type * = nullptr>
+                std::enable_if_t<!has_SOR_step<MatrixType, VectorType>,
+                                 MatrixType> * = nullptr>
       void
       Tstep(VectorType &, const VectorType &) const
       {
@@ -785,8 +784,8 @@ namespace internal
       }
 
       template <typename VectorType,
-                typename std::enable_if<has_SSOR_step<MatrixType, VectorType>,
-                                        MatrixType>::type * = nullptr>
+                std::enable_if_t<has_SSOR_step<MatrixType, VectorType>,
+                                 MatrixType> * = nullptr>
       void
       step(VectorType &dst, const VectorType &src) const
       {
@@ -794,8 +793,8 @@ namespace internal
       }
 
       template <typename VectorType,
-                typename std::enable_if<!has_SSOR_step<MatrixType, VectorType>,
-                                        MatrixType>::type * = nullptr>
+                std::enable_if_t<!has_SSOR_step<MatrixType, VectorType>,
+                                 MatrixType> * = nullptr>
       void
       step(VectorType &, const VectorType &) const
       {
@@ -863,12 +862,11 @@ namespace internal
       const std::vector<size_type> &inverse_permutation;
     };
 
-    template <
-      typename MatrixType,
-      typename PreconditionerType,
-      typename VectorType,
-      typename std::enable_if<has_step_omega<PreconditionerType, VectorType>,
-                              PreconditionerType>::type * = nullptr>
+    template <typename MatrixType,
+              typename PreconditionerType,
+              typename VectorType,
+              std::enable_if_t<has_step_omega<PreconditionerType, VectorType>,
+                               PreconditionerType> * = nullptr>
     void
     step(const MatrixType &,
          const PreconditionerType &preconditioner,
@@ -885,9 +883,9 @@ namespace internal
       typename MatrixType,
       typename PreconditionerType,
       typename VectorType,
-      typename std::enable_if<!has_step_omega<PreconditionerType, VectorType> &&
-                                has_step<PreconditionerType, VectorType>,
-                              PreconditionerType>::type * = nullptr>
+      std::enable_if_t<!has_step_omega<PreconditionerType, VectorType> &&
+                         has_step<PreconditionerType, VectorType>,
+                       PreconditionerType> * = nullptr>
     void
     step(const MatrixType &,
          const PreconditionerType &preconditioner,
@@ -908,9 +906,9 @@ namespace internal
       typename MatrixType,
       typename PreconditionerType,
       typename VectorType,
-      typename std::enable_if<!has_step_omega<PreconditionerType, VectorType> &&
-                                !has_step<PreconditionerType, VectorType>,
-                              PreconditionerType>::type * = nullptr>
+      std::enable_if_t<!has_step_omega<PreconditionerType, VectorType> &&
+                         !has_step<PreconditionerType, VectorType>,
+                       PreconditionerType> * = nullptr>
     void
     step(const MatrixType &        A,
          const PreconditionerType &preconditioner,
@@ -930,12 +928,11 @@ namespace internal
       dst.add(relaxation, tmp);
     }
 
-    template <
-      typename MatrixType,
-      typename PreconditionerType,
-      typename VectorType,
-      typename std::enable_if<has_Tstep_omega<PreconditionerType, VectorType>,
-                              PreconditionerType>::type * = nullptr>
+    template <typename MatrixType,
+              typename PreconditionerType,
+              typename VectorType,
+              std::enable_if_t<has_Tstep_omega<PreconditionerType, VectorType>,
+                               PreconditionerType> * = nullptr>
     void
     Tstep(const MatrixType &,
           const PreconditionerType &preconditioner,
@@ -948,13 +945,13 @@ namespace internal
       preconditioner.Tstep(dst, src, relaxation);
     }
 
-    template <typename MatrixType,
-              typename PreconditionerType,
-              typename VectorType,
-              typename std::enable_if<
-                !has_Tstep_omega<PreconditionerType, VectorType> &&
-                  has_Tstep<PreconditionerType, VectorType>,
-                PreconditionerType>::type * = nullptr>
+    template <
+      typename MatrixType,
+      typename PreconditionerType,
+      typename VectorType,
+      std::enable_if_t<!has_Tstep_omega<PreconditionerType, VectorType> &&
+                         has_Tstep<PreconditionerType, VectorType>,
+                       PreconditionerType> * = nullptr>
     void
     Tstep(const MatrixType &,
           const PreconditionerType &preconditioner,
@@ -973,8 +970,8 @@ namespace internal
 
     template <typename MatrixType,
               typename VectorType,
-              typename std::enable_if<has_Tvmult<MatrixType, VectorType>,
-                                      MatrixType>::type * = nullptr>
+              std::enable_if_t<has_Tvmult<MatrixType, VectorType>, MatrixType>
+                * = nullptr>
     void
     Tvmult(const MatrixType &A, VectorType &dst, const VectorType &src)
     {
@@ -983,8 +980,8 @@ namespace internal
 
     template <typename MatrixType,
               typename VectorType,
-              typename std::enable_if<!has_Tvmult<MatrixType, VectorType>,
-                                      MatrixType>::type * = nullptr>
+              std::enable_if_t<!has_Tvmult<MatrixType, VectorType>, MatrixType>
+                * = nullptr>
     void
     Tvmult(const MatrixType &, VectorType &, const VectorType &)
     {
@@ -992,13 +989,13 @@ namespace internal
                   ExcMessage("Matrix A does not provide a Tvmult() function!"));
     }
 
-    template <typename MatrixType,
-              typename PreconditionerType,
-              typename VectorType,
-              typename std::enable_if<
-                !has_Tstep_omega<PreconditionerType, VectorType> &&
-                  !has_Tstep<PreconditionerType, VectorType>,
-                PreconditionerType>::type * = nullptr>
+    template <
+      typename MatrixType,
+      typename PreconditionerType,
+      typename VectorType,
+      std::enable_if_t<!has_Tstep_omega<PreconditionerType, VectorType> &&
+                         !has_Tstep<PreconditionerType, VectorType>,
+                       PreconditionerType> * = nullptr>
     void
     Tstep(const MatrixType &        A,
           const PreconditionerType &preconditioner,
@@ -1053,8 +1050,8 @@ namespace internal
 
     template <typename MatrixType,
               typename VectorType,
-              typename std::enable_if<!IsBlockVector<VectorType>::value,
-                                      VectorType>::type * = nullptr>
+              std::enable_if_t<!IsBlockVector<VectorType>::value, VectorType>
+                * = nullptr>
     void
     step_operations(const MatrixType &                A,
                     const DiagonalMatrix<VectorType> &preconditioner,
@@ -2567,10 +2564,10 @@ namespace internal
       typename MatrixType,
       typename VectorType,
       typename PreconditionerType,
-      typename std::enable_if<!has_vmult_with_std_functions<MatrixType,
-                                                            VectorType,
-                                                            PreconditionerType>,
-                              int>::type * = nullptr>
+      std::enable_if_t<!has_vmult_with_std_functions<MatrixType,
+                                                     VectorType,
+                                                     PreconditionerType>,
+                       int> * = nullptr>
     inline void
     vmult_and_update(const MatrixType &        matrix,
                      const PreconditionerType &preconditioner,
@@ -2596,14 +2593,13 @@ namespace internal
                      solution);
     }
 
-    template <
-      typename MatrixType,
-      typename VectorType,
-      typename PreconditionerType,
-      typename std::enable_if<has_vmult_with_std_functions<MatrixType,
-                                                           VectorType,
-                                                           PreconditionerType>,
-                              int>::type * = nullptr>
+    template <typename MatrixType,
+              typename VectorType,
+              typename PreconditionerType,
+              std::enable_if_t<has_vmult_with_std_functions<MatrixType,
+                                                            VectorType,
+                                                            PreconditionerType>,
+                               int> * = nullptr>
     inline void
     vmult_and_update(const MatrixType &        matrix,
                      const PreconditionerType &preconditioner,

--- a/include/deal.II/lac/solver_cg.h
+++ b/include/deal.II/lac/solver_cg.h
@@ -703,14 +703,14 @@ namespace internal
       VectorType,
       MatrixType,
       PreconditionerType,
-      typename std::enable_if<has_vmult_functions<MatrixType, VectorType> &&
-                                (has_apply_to_subrange<PreconditionerType> ||
-                                 has_apply<PreconditionerType>)&&std::
-                                  is_same<VectorType,
-                                          LinearAlgebra::distributed::Vector<
-                                            typename VectorType::value_type,
-                                            MemorySpace::Host>>::value,
-                              int>::type>
+      std::enable_if_t<has_vmult_functions<MatrixType, VectorType> &&
+                         (has_apply_to_subrange<PreconditionerType> ||
+                          has_apply<PreconditionerType>)&&std::
+                           is_same<VectorType,
+                                   LinearAlgebra::distributed::Vector<
+                                     typename VectorType::value_type,
+                                     MemorySpace::Host>>::value,
+                       int>>
       : public IterationWorkerBase<VectorType, MatrixType, PreconditionerType>
     {
       using Number = typename VectorType::value_type;
@@ -791,7 +791,7 @@ namespace internal
       // Function that we use if the PreconditionerType implements an apply()
       // function
       template <typename U = void>
-      typename std::enable_if<has_apply<PreconditionerType>, U>::type
+      std::enable_if_t<has_apply<PreconditionerType>, U>
       operation_before_loop(const unsigned int iteration_index,
                             const unsigned int start_range,
                             const unsigned int end_range) const
@@ -897,7 +897,7 @@ namespace internal
       // Function that we use if the PreconditionerType implements an apply()
       // function
       template <typename U = void>
-      typename std::enable_if<has_apply<PreconditionerType>, U>::type
+      std::enable_if_t<has_apply<PreconditionerType>, U>
       operation_after_loop(
         const unsigned int                      start_range,
         const unsigned int                      end_range,
@@ -949,7 +949,7 @@ namespace internal
       // Function that we use if the PreconditionerType implements an apply()
       // function
       template <typename U = void>
-      typename std::enable_if<has_apply<PreconditionerType>, U>::type
+      std::enable_if_t<has_apply<PreconditionerType>, U>
       finalize_after_convergence(const unsigned int iteration_index)
       {
         if (iteration_index % 2 == 1 || iteration_index == 2)
@@ -986,7 +986,7 @@ namespace internal
       // apply() function, where we instead need to choose the
       // apply_to_subrange function
       template <typename U = void>
-      typename std::enable_if<!has_apply<PreconditionerType>, U>::type
+      std::enable_if_t<!has_apply<PreconditionerType>, U>
       operation_before_loop(const unsigned int iteration_index,
                             const unsigned int start_range,
                             const unsigned int end_range) const
@@ -1084,7 +1084,7 @@ namespace internal
       // apply() function and where we instead need to use the
       // apply_to_subrange function
       template <typename U = void>
-      typename std::enable_if<!has_apply<PreconditionerType>, U>::type
+      std::enable_if_t<!has_apply<PreconditionerType>, U>
       operation_after_loop(
         const unsigned int                      start_range,
         const unsigned int                      end_range,
@@ -1158,7 +1158,7 @@ namespace internal
       // apply() function, where we instead need to choose the
       // apply_to_subrange function
       template <typename U = void>
-      typename std::enable_if<!has_apply<PreconditionerType>, U>::type
+      std::enable_if_t<!has_apply<PreconditionerType>, U>
       finalize_after_convergence(const unsigned int iteration_index)
       {
         if (iteration_index % 2 == 1 || iteration_index == 2)

--- a/include/deal.II/lac/sparse_matrix.templates.h
+++ b/include/deal.II/lac/sparse_matrix.templates.h
@@ -168,14 +168,14 @@ namespace internal
     using size_type = types::global_dof_index;
 
     template <typename T>
-    typename std::enable_if<std::is_trivial<T>::value>::type
+    std::enable_if_t<std::is_trivial<T>::value>
     zero_subrange(const size_type begin, const size_type end, T *dst)
     {
       std::memset(dst + begin, 0, (end - begin) * sizeof(T));
     }
 
     template <typename T>
-    typename std::enable_if<!std::is_trivial<T>::value>::type
+    std::enable_if_t<!std::is_trivial<T>::value>
     zero_subrange(const size_type begin, const size_type end, T *dst)
     {
       std::fill(dst + begin, dst + end, 0);

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -840,9 +840,8 @@ namespace TrilinosWrappers
      * processors in order to avoid a dead lock.
      */
     template <typename SparsityPatternType>
-    typename std::enable_if<
-      !std::is_same<SparsityPatternType,
-                    dealii::SparseMatrix<double>>::value>::type
+    std::enable_if_t<
+      !std::is_same<SparsityPatternType, dealii::SparseMatrix<double>>::value>
     reinit(const IndexSet &           row_parallel_partitioning,
            const IndexSet &           col_parallel_partitioning,
            const SparsityPatternType &sparsity_pattern,
@@ -1438,8 +1437,8 @@ namespace TrilinosWrappers
      * distributed. Otherwise, an exception will be thrown.
      */
     template <typename VectorType>
-    typename std::enable_if<std::is_same<typename VectorType::value_type,
-                                         TrilinosScalar>::value>::type
+    std::enable_if_t<
+      std::is_same<typename VectorType::value_type, TrilinosScalar>::value>
     vmult(VectorType &dst, const VectorType &src) const;
 
     /**
@@ -1449,8 +1448,8 @@ namespace TrilinosWrappers
      * Despite looking complicated, the return type is just `void`.
      */
     template <typename VectorType>
-    typename std::enable_if<!std::is_same<typename VectorType::value_type,
-                                          TrilinosScalar>::value>::type
+    std::enable_if_t<
+      !std::is_same<typename VectorType::value_type, TrilinosScalar>::value>
     vmult(VectorType &dst, const VectorType &src) const;
 
     /**
@@ -1468,8 +1467,8 @@ namespace TrilinosWrappers
      * Despite looking complicated, the return type is just `void`.
      */
     template <typename VectorType>
-    typename std::enable_if<std::is_same<typename VectorType::value_type,
-                                         TrilinosScalar>::value>::type
+    std::enable_if_t<
+      std::is_same<typename VectorType::value_type, TrilinosScalar>::value>
     Tvmult(VectorType &dst, const VectorType &src) const;
 
     /**
@@ -1479,8 +1478,8 @@ namespace TrilinosWrappers
      * Despite looking complicated, the return type is just `void`.
      */
     template <typename VectorType>
-    typename std::enable_if<!std::is_same<typename VectorType::value_type,
-                                          TrilinosScalar>::value>::type
+    std::enable_if_t<
+      !std::is_same<typename VectorType::value_type, TrilinosScalar>::value>
     Tvmult(VectorType &dst, const VectorType &src) const;
 
     /**
@@ -2182,11 +2181,11 @@ namespace TrilinosWrappers
          * 2. the @p Preconditioner derives from TrilinosWrappers::PreconditionBase.
          */
         template <typename Solver, typename Preconditioner>
-        typename std::enable_if<
+        std::enable_if_t<
           std::is_base_of<TrilinosWrappers::SolverBase, Solver>::value &&
             std::is_base_of<TrilinosWrappers::PreconditionBase,
                             Preconditioner>::value,
-          TrilinosPayload>::type
+          TrilinosPayload>
         inverse_payload(Solver &, const Preconditioner &) const;
 
         /**
@@ -2207,11 +2206,11 @@ namespace TrilinosWrappers
          * TrilinosWrappers::PreconditionBase.
          */
         template <typename Solver, typename Preconditioner>
-        typename std::enable_if<
+        std::enable_if_t<
           !(std::is_base_of<TrilinosWrappers::SolverBase, Solver>::value &&
             std::is_base_of<TrilinosWrappers::PreconditionBase,
                             Preconditioner>::value),
-          TrilinosPayload>::type
+          TrilinosPayload>
         inverse_payload(Solver &, const Preconditioner &) const;
 
         //@}
@@ -3210,11 +3209,11 @@ namespace TrilinosWrappers
 
 
       template <typename Solver, typename Preconditioner>
-      typename std::enable_if<
+      std::enable_if_t<
         std::is_base_of<TrilinosWrappers::SolverBase, Solver>::value &&
           std::is_base_of<TrilinosWrappers::PreconditionBase,
                           Preconditioner>::value,
-        TrilinosPayload>::type
+        TrilinosPayload>
       TrilinosPayload::inverse_payload(
         Solver &              solver,
         const Preconditioner &preconditioner) const
@@ -3265,11 +3264,11 @@ namespace TrilinosWrappers
       }
 
       template <typename Solver, typename Preconditioner>
-      typename std::enable_if<
+      std::enable_if_t<
         !(std::is_base_of<TrilinosWrappers::SolverBase, Solver>::value &&
           std::is_base_of<TrilinosWrappers::PreconditionBase,
                           Preconditioner>::value),
-        TrilinosPayload>::type
+        TrilinosPayload>
       TrilinosPayload::inverse_payload(Solver &, const Preconditioner &) const
       {
         TrilinosPayload return_op(*this);

--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -2006,9 +2006,9 @@ namespace internal
         ::dealii::MemorySpace::MemorySpaceData<Number,
                                                ::dealii::MemorySpace::Host>
           &data,
-        typename std::enable_if<
+        std::enable_if_t<
           std::is_same<MemorySpace2, dealii::MemorySpace::Host>::value,
-          int>::type = 0)
+          int> = 0)
       {
         if (operation == VectorOperation::insert)
           {
@@ -2037,9 +2037,9 @@ namespace internal
         ::dealii::MemorySpace::MemorySpaceData<Number,
                                                ::dealii::MemorySpace::Host>
           &data,
-        typename std::enable_if<
+        std::enable_if_t<
           std::is_same<MemorySpace2, ::dealii::MemorySpace::CUDA>::value,
-          int>::type = 0)
+          int> = 0)
       {
         if (operation == VectorOperation::insert)
           {
@@ -2524,9 +2524,9 @@ namespace internal
         ::dealii::MemorySpace::MemorySpaceData<Number,
                                                ::dealii::MemorySpace::CUDA>
           &data,
-        typename std::enable_if<
+        std::enable_if_t<
           std::is_same<MemorySpace2, ::dealii::MemorySpace::CUDA>::value,
-          int>::type = 0)
+          int> = 0)
       {
         if (operation == VectorOperation::insert)
           {
@@ -2554,9 +2554,9 @@ namespace internal
         ::dealii::MemorySpace::MemorySpaceData<Number,
                                                ::dealii::MemorySpace::CUDA>
           &data,
-        typename std::enable_if<
+        std::enable_if_t<
           std::is_same<MemorySpace2, ::dealii::MemorySpace::Host>::value,
-          int>::type = 0)
+          int> = 0)
       {
         if (operation == VectorOperation::insert)
           {

--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -5594,7 +5594,7 @@ namespace internal
         const FEEvaluationData<dim, Number, false> &fe_eval,
         const Number *                              in_array,
         Number *                                    out_array,
-        typename std::enable_if<fe_degree != -1>::type * = nullptr)
+        std::enable_if_t<fe_degree != -1> * = nullptr)
     {
       constexpr unsigned int dofs_per_component =
         Utilities::pow(fe_degree + 1, dim);
@@ -5650,7 +5650,7 @@ namespace internal
         const FEEvaluationData<dim, Number, false> &fe_eval,
         const Number *                              in_array,
         Number *                                    out_array,
-        typename std::enable_if<fe_degree == -1>::type * = nullptr)
+        std::enable_if_t<fe_degree == -1> * = nullptr)
     {
       static_assert(fe_degree == -1, "Only usable for degree -1");
       const unsigned int dofs_per_component =
@@ -5712,7 +5712,7 @@ namespace internal
         const AlignedVector<Number> &inverse_coefficients,
         const Number *               in_array,
         Number *                     out_array,
-        typename std::enable_if<fe_degree != -1>::type * = nullptr)
+        std::enable_if_t<fe_degree != -1> * = nullptr)
     {
       constexpr unsigned int dofs_per_component =
         Utilities::pow(fe_degree + 1, dim);
@@ -5775,7 +5775,7 @@ namespace internal
         const AlignedVector<Number> &,
         const Number *,
         Number *,
-        typename std::enable_if<fe_degree == -1>::type * = nullptr)
+        std::enable_if_t<fe_degree == -1> * = nullptr)
     {
       static_assert(fe_degree == -1, "Only usable for degree -1");
       Assert(false, ExcNotImplemented());

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -4094,20 +4094,20 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
 
 namespace internal
 {
-  template <typename Number,
-            typename VectorType,
-            typename std::enable_if<!IsBlockVector<VectorType>::value,
-                                    VectorType>::type * = nullptr>
+  template <
+    typename Number,
+    typename VectorType,
+    std::enable_if_t<!IsBlockVector<VectorType>::value, VectorType> * = nullptr>
   decltype(std::declval<VectorType>().begin())
   get_beginning(VectorType &vec)
   {
     return vec.begin();
   }
 
-  template <typename Number,
-            typename VectorType,
-            typename std::enable_if<IsBlockVector<VectorType>::value,
-                                    VectorType>::type * = nullptr>
+  template <
+    typename Number,
+    typename VectorType,
+    std::enable_if_t<IsBlockVector<VectorType>::value, VectorType> * = nullptr>
   typename VectorType::value_type *
   get_beginning(VectorType &)
   {
@@ -4115,8 +4115,8 @@ namespace internal
   }
 
   template <typename VectorType,
-            typename std::enable_if<has_shared_vector_data<VectorType>,
-                                    VectorType>::type * = nullptr>
+            std::enable_if_t<has_shared_vector_data<VectorType>, VectorType> * =
+              nullptr>
   const std::vector<ArrayView<const typename VectorType::value_type>> *
   get_shared_vector_data(VectorType &       vec,
                          const bool         is_valid_mode_for_sm,
@@ -4134,8 +4134,8 @@ namespace internal
   }
 
   template <typename VectorType,
-            typename std::enable_if<!has_shared_vector_data<VectorType>,
-                                    VectorType>::type * = nullptr>
+            std::enable_if_t<!has_shared_vector_data<VectorType>, VectorType>
+              * = nullptr>
   const std::vector<ArrayView<const typename VectorType::value_type>> *
   get_shared_vector_data(VectorType &,
                          const bool,
@@ -7911,9 +7911,9 @@ namespace internal
             typename VectorizedArrayType,
             typename VectorType,
             typename EvaluatorType,
-            typename std::enable_if<internal::has_begin<VectorType> &&
-                                      !IsBlockVector<VectorType>::value,
-                                    VectorType>::type * = nullptr>
+            std::enable_if_t<internal::has_begin<VectorType> &&
+                               !IsBlockVector<VectorType>::value,
+                             VectorType> * = nullptr>
   VectorizedArrayType *
   check_vector_access_inplace(const EvaluatorType &fe_eval, VectorType &vector)
   {
@@ -7963,9 +7963,9 @@ namespace internal
             typename VectorizedArrayType,
             typename VectorType,
             typename EvaluatorType,
-            typename std::enable_if<!internal::has_begin<VectorType> ||
-                                      IsBlockVector<VectorType>::value,
-                                    VectorType>::type * = nullptr>
+            std::enable_if_t<!internal::has_begin<VectorType> ||
+                               IsBlockVector<VectorType>::value,
+                             VectorType> * = nullptr>
   VectorizedArrayType *
   check_vector_access_inplace(const EvaluatorType &, VectorType &)
   {

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -3120,8 +3120,8 @@ namespace internal
      * Start update_ghost_value for serial vectors
      */
     template <typename VectorType,
-              typename std::enable_if<is_not_parallel_vector<VectorType>,
-                                      VectorType>::type * = nullptr>
+              std::enable_if_t<is_not_parallel_vector<VectorType>, VectorType>
+                * = nullptr>
     void
     update_ghost_values_start(const unsigned int /*component_in_block_vector*/,
                               const VectorType & /*vec*/)
@@ -3132,11 +3132,10 @@ namespace internal
      * Start update_ghost_value for vectors that do not support
      * the split into _start() and finish() stages
      */
-    template <
-      typename VectorType,
-      typename std::enable_if<!has_update_ghost_values_start<VectorType> &&
-                                !is_not_parallel_vector<VectorType>,
-                              VectorType>::type * = nullptr>
+    template <typename VectorType,
+              std::enable_if_t<!has_update_ghost_values_start<VectorType> &&
+                                 !is_not_parallel_vector<VectorType>,
+                               VectorType> * = nullptr>
     void
     update_ghost_values_start(const unsigned int component_in_block_vector,
                               const VectorType & vec)
@@ -3161,11 +3160,10 @@ namespace internal
      * the split into _start() and finish() stages, but don't support
      * exchange on a subset of DoFs
      */
-    template <
-      typename VectorType,
-      typename std::enable_if<has_update_ghost_values_start<VectorType> &&
-                                !has_exchange_on_subset<VectorType>,
-                              VectorType>::type * = nullptr>
+    template <typename VectorType,
+              std::enable_if_t<has_update_ghost_values_start<VectorType> &&
+                                 !has_exchange_on_subset<VectorType>,
+                               VectorType> * = nullptr>
     void
     update_ghost_values_start(const unsigned int component_in_block_vector,
                               const VectorType & vec)
@@ -3191,11 +3189,10 @@ namespace internal
      * exchange on a subset of DoFs,
      * i.e. LinearAlgebra::distributed::Vector
      */
-    template <
-      typename VectorType,
-      typename std::enable_if<has_update_ghost_values_start<VectorType> &&
-                                has_exchange_on_subset<VectorType>,
-                              VectorType>::type * = nullptr>
+    template <typename VectorType,
+              std::enable_if_t<has_update_ghost_values_start<VectorType> &&
+                                 has_exchange_on_subset<VectorType>,
+                               VectorType> * = nullptr>
     void
     update_ghost_values_start(const unsigned int component_in_block_vector,
                               const VectorType & vec)
@@ -3251,10 +3248,9 @@ namespace internal
      * Finish update_ghost_value for vectors that do not support
      * the split into _start() and finish() stages and serial vectors
      */
-    template <
-      typename VectorType,
-      typename std::enable_if<!has_update_ghost_values_start<VectorType>,
-                              VectorType>::type * = nullptr>
+    template <typename VectorType,
+              std::enable_if_t<!has_update_ghost_values_start<VectorType>,
+                               VectorType> * = nullptr>
     void
     update_ghost_values_finish(const unsigned int /*component_in_block_vector*/,
                                const VectorType & /*vec*/)
@@ -3267,11 +3263,10 @@ namespace internal
      * the split into _start() and finish() stages, but don't support
      * exchange on a subset of DoFs
      */
-    template <
-      typename VectorType,
-      typename std::enable_if<has_update_ghost_values_start<VectorType> &&
-                                !has_exchange_on_subset<VectorType>,
-                              VectorType>::type * = nullptr>
+    template <typename VectorType,
+              std::enable_if_t<has_update_ghost_values_start<VectorType> &&
+                                 !has_exchange_on_subset<VectorType>,
+                               VectorType> * = nullptr>
     void
     update_ghost_values_finish(const unsigned int component_in_block_vector,
                                const VectorType & vec)
@@ -3288,11 +3283,10 @@ namespace internal
      * exchange on a subset of DoFs,
      * i.e. LinearAlgebra::distributed::Vector
      */
-    template <
-      typename VectorType,
-      typename std::enable_if<has_update_ghost_values_start<VectorType> &&
-                                has_exchange_on_subset<VectorType>,
-                              VectorType>::type * = nullptr>
+    template <typename VectorType,
+              std::enable_if_t<has_update_ghost_values_start<VectorType> &&
+                                 has_exchange_on_subset<VectorType>,
+                               VectorType> * = nullptr>
     void
     update_ghost_values_finish(const unsigned int component_in_block_vector,
                                const VectorType & vec)
@@ -3341,8 +3335,8 @@ namespace internal
      * Start compress for serial vectors
      */
     template <typename VectorType,
-              typename std::enable_if<is_not_parallel_vector<VectorType>,
-                                      VectorType>::type * = nullptr>
+              std::enable_if_t<is_not_parallel_vector<VectorType>, VectorType>
+                * = nullptr>
     void
     compress_start(const unsigned int /*component_in_block_vector*/,
                    VectorType & /*vec*/)
@@ -3355,9 +3349,9 @@ namespace internal
      * the split into _start() and finish() stages
      */
     template <typename VectorType,
-              typename std::enable_if<!has_compress_start<VectorType> &&
-                                        !is_not_parallel_vector<VectorType>,
-                                      VectorType>::type * = nullptr>
+              std::enable_if_t<!has_compress_start<VectorType> &&
+                                 !is_not_parallel_vector<VectorType>,
+                               VectorType> * = nullptr>
     void
     compress_start(const unsigned int component_in_block_vector,
                    VectorType &       vec)
@@ -3375,9 +3369,9 @@ namespace internal
      * exchange on a subset of DoFs
      */
     template <typename VectorType,
-              typename std::enable_if<has_compress_start<VectorType> &&
-                                        !has_exchange_on_subset<VectorType>,
-                                      VectorType>::type * = nullptr>
+              std::enable_if_t<has_compress_start<VectorType> &&
+                                 !has_exchange_on_subset<VectorType>,
+                               VectorType> * = nullptr>
     void
     compress_start(const unsigned int component_in_block_vector,
                    VectorType &       vec)
@@ -3396,9 +3390,9 @@ namespace internal
      * i.e. LinearAlgebra::distributed::Vector
      */
     template <typename VectorType,
-              typename std::enable_if<has_compress_start<VectorType> &&
-                                        has_exchange_on_subset<VectorType>,
-                                      VectorType>::type * = nullptr>
+              std::enable_if_t<has_compress_start<VectorType> &&
+                                 has_exchange_on_subset<VectorType>,
+                               VectorType> * = nullptr>
     void
     compress_start(const unsigned int component_in_block_vector,
                    VectorType &       vec)
@@ -3447,9 +3441,9 @@ namespace internal
      * Finish compress for vectors that do not support
      * the split into _start() and finish() stages and serial vectors
      */
-    template <typename VectorType,
-              typename std::enable_if<!has_compress_start<VectorType>,
-                                      VectorType>::type * = nullptr>
+    template <
+      typename VectorType,
+      std::enable_if_t<!has_compress_start<VectorType>, VectorType> * = nullptr>
     void
     compress_finish(const unsigned int /*component_in_block_vector*/,
                     VectorType & /*vec*/)
@@ -3463,9 +3457,9 @@ namespace internal
      * exchange on a subset of DoFs
      */
     template <typename VectorType,
-              typename std::enable_if<has_compress_start<VectorType> &&
-                                        !has_exchange_on_subset<VectorType>,
-                                      VectorType>::type * = nullptr>
+              std::enable_if_t<has_compress_start<VectorType> &&
+                                 !has_exchange_on_subset<VectorType>,
+                               VectorType> * = nullptr>
     void
     compress_finish(const unsigned int component_in_block_vector,
                     VectorType &       vec)
@@ -3483,9 +3477,9 @@ namespace internal
      * i.e. LinearAlgebra::distributed::Vector
      */
     template <typename VectorType,
-              typename std::enable_if<has_compress_start<VectorType> &&
-                                        has_exchange_on_subset<VectorType>,
-                                      VectorType>::type * = nullptr>
+              std::enable_if_t<has_compress_start<VectorType> &&
+                                 has_exchange_on_subset<VectorType>,
+                               VectorType> * = nullptr>
     void
     compress_finish(const unsigned int component_in_block_vector,
                     VectorType &       vec)
@@ -3540,8 +3534,8 @@ namespace internal
      * Reset all ghost values for serial vectors
      */
     template <typename VectorType,
-              typename std::enable_if<is_not_parallel_vector<VectorType>,
-                                      VectorType>::type * = nullptr>
+              std::enable_if_t<is_not_parallel_vector<VectorType>, VectorType>
+                * = nullptr>
     void
     reset_ghost_values(const VectorType & /*vec*/) const
     {}
@@ -3553,9 +3547,9 @@ namespace internal
      * exchange on a subset of DoFs
      */
     template <typename VectorType,
-              typename std::enable_if<!has_exchange_on_subset<VectorType> &&
-                                        !is_not_parallel_vector<VectorType>,
-                                      VectorType>::type * = nullptr>
+              std::enable_if_t<!has_exchange_on_subset<VectorType> &&
+                                 !is_not_parallel_vector<VectorType>,
+                               VectorType> * = nullptr>
     void
     reset_ghost_values(const VectorType &vec) const
     {
@@ -3573,8 +3567,8 @@ namespace internal
      * LinearAlgebra::distributed::Vector
      */
     template <typename VectorType,
-              typename std::enable_if<has_exchange_on_subset<VectorType>,
-                                      VectorType>::type * = nullptr>
+              std::enable_if_t<has_exchange_on_subset<VectorType>, VectorType>
+                * = nullptr>
     void
     reset_ghost_values(const VectorType &vec) const
     {
@@ -3617,8 +3611,8 @@ namespace internal
      * i.e. LinearAlgebra::distributed::Vector
      */
     template <typename VectorType,
-              typename std::enable_if<has_exchange_on_subset<VectorType>,
-                                      VectorType>::type * = nullptr>
+              std::enable_if_t<has_exchange_on_subset<VectorType>, VectorType>
+                * = nullptr>
     void
     zero_vector_region(const unsigned int range_index, VectorType &vec) const
     {
@@ -3659,9 +3653,9 @@ namespace internal
      * vector type
      */
     template <typename VectorType,
-              typename std::enable_if<!has_exchange_on_subset<VectorType>,
-                                      VectorType>::type * = nullptr,
-              typename VectorType::value_type *           = nullptr>
+              std::enable_if_t<!has_exchange_on_subset<VectorType>, VectorType>
+                *                               = nullptr,
+              typename VectorType::value_type * = nullptr>
     void
     zero_vector_region(const unsigned int range_index, VectorType &vec) const
     {
@@ -3757,8 +3751,8 @@ namespace internal
 
   // default value for vectors that do not have communication_block_size
   template <typename VectorStruct,
-            typename std::enable_if<!has_communication_block_size<VectorStruct>,
-                                    VectorStruct>::type * = nullptr>
+            std::enable_if_t<!has_communication_block_size<VectorStruct>,
+                             VectorStruct> * = nullptr>
   constexpr unsigned int
   get_communication_block_size(const VectorStruct &)
   {
@@ -3768,8 +3762,8 @@ namespace internal
 
 
   template <typename VectorStruct,
-            typename std::enable_if<has_communication_block_size<VectorStruct>,
-                                    VectorStruct>::type * = nullptr>
+            std::enable_if_t<has_communication_block_size<VectorStruct>,
+                             VectorStruct> * = nullptr>
   constexpr unsigned int
   get_communication_block_size(const VectorStruct &)
   {
@@ -3791,8 +3785,8 @@ namespace internal
             typename VectorStruct,
             typename Number,
             typename VectorizedArrayType,
-            typename std::enable_if<IsBlockVector<VectorStruct>::value,
-                                    VectorStruct>::type * = nullptr>
+            std::enable_if_t<IsBlockVector<VectorStruct>::value, VectorStruct>
+              * = nullptr>
   void
   update_ghost_values_start(
     const VectorStruct &                                  vec,
@@ -3820,8 +3814,8 @@ namespace internal
             typename VectorStruct,
             typename Number,
             typename VectorizedArrayType,
-            typename std::enable_if<!IsBlockVector<VectorStruct>::value,
-                                    VectorStruct>::type * = nullptr>
+            std::enable_if_t<!IsBlockVector<VectorStruct>::value, VectorStruct>
+              * = nullptr>
   void
   update_ghost_values_start(
     const VectorStruct &                                  vec,
@@ -3882,8 +3876,8 @@ namespace internal
             typename VectorStruct,
             typename Number,
             typename VectorizedArrayType,
-            typename std::enable_if<IsBlockVector<VectorStruct>::value,
-                                    VectorStruct>::type * = nullptr>
+            std::enable_if_t<IsBlockVector<VectorStruct>::value, VectorStruct>
+              * = nullptr>
   void
   update_ghost_values_finish(
     const VectorStruct &                                  vec,
@@ -3907,8 +3901,8 @@ namespace internal
             typename VectorStruct,
             typename Number,
             typename VectorizedArrayType,
-            typename std::enable_if<!IsBlockVector<VectorStruct>::value,
-                                    VectorStruct>::type * = nullptr>
+            std::enable_if_t<!IsBlockVector<VectorStruct>::value, VectorStruct>
+              * = nullptr>
   void
   update_ghost_values_finish(
     const VectorStruct &                                  vec,
@@ -3969,8 +3963,8 @@ namespace internal
             typename VectorStruct,
             typename Number,
             typename VectorizedArrayType,
-            typename std::enable_if<IsBlockVector<VectorStruct>::value,
-                                    VectorStruct>::type * = nullptr>
+            std::enable_if_t<IsBlockVector<VectorStruct>::value, VectorStruct>
+              * = nullptr>
   inline void
   compress_start(
     VectorStruct &                                        vec,
@@ -3991,8 +3985,8 @@ namespace internal
             typename VectorStruct,
             typename Number,
             typename VectorizedArrayType,
-            typename std::enable_if<!IsBlockVector<VectorStruct>::value,
-                                    VectorStruct>::type * = nullptr>
+            std::enable_if_t<!IsBlockVector<VectorStruct>::value, VectorStruct>
+              * = nullptr>
   inline void
   compress_start(
     VectorStruct &                                        vec,
@@ -4053,8 +4047,8 @@ namespace internal
             typename VectorStruct,
             typename Number,
             typename VectorizedArrayType,
-            typename std::enable_if<IsBlockVector<VectorStruct>::value,
-                                    VectorStruct>::type * = nullptr>
+            std::enable_if_t<IsBlockVector<VectorStruct>::value, VectorStruct>
+              * = nullptr>
   inline void
   compress_finish(
     VectorStruct &                                        vec,
@@ -4078,8 +4072,8 @@ namespace internal
             typename VectorStruct,
             typename Number,
             typename VectorizedArrayType,
-            typename std::enable_if<!IsBlockVector<VectorStruct>::value,
-                                    VectorStruct>::type * = nullptr>
+            std::enable_if_t<!IsBlockVector<VectorStruct>::value, VectorStruct>
+              * = nullptr>
   inline void
   compress_finish(
     VectorStruct &                                        vec,
@@ -4144,8 +4138,8 @@ namespace internal
             typename VectorStruct,
             typename Number,
             typename VectorizedArrayType,
-            typename std::enable_if<IsBlockVector<VectorStruct>::value,
-                                    VectorStruct>::type * = nullptr>
+            std::enable_if_t<IsBlockVector<VectorStruct>::value, VectorStruct>
+              * = nullptr>
   inline void
   reset_ghost_values(
     const VectorStruct &                                  vec,
@@ -4166,8 +4160,8 @@ namespace internal
             typename VectorStruct,
             typename Number,
             typename VectorizedArrayType,
-            typename std::enable_if<!IsBlockVector<VectorStruct>::value,
-                                    VectorStruct>::type * = nullptr>
+            std::enable_if_t<!IsBlockVector<VectorStruct>::value, VectorStruct>
+              * = nullptr>
   inline void
   reset_ghost_values(
     const VectorStruct &                                  vec,
@@ -4227,8 +4221,8 @@ namespace internal
             typename VectorStruct,
             typename Number,
             typename VectorizedArrayType,
-            typename std::enable_if<IsBlockVector<VectorStruct>::value,
-                                    VectorStruct>::type * = nullptr>
+            std::enable_if_t<IsBlockVector<VectorStruct>::value, VectorStruct>
+              * = nullptr>
   inline void
   zero_vector_region(
     const unsigned int                                    range_index,
@@ -4246,8 +4240,8 @@ namespace internal
             typename VectorStruct,
             typename Number,
             typename VectorizedArrayType,
-            typename std::enable_if<!IsBlockVector<VectorStruct>::value,
-                                    VectorStruct>::type * = nullptr>
+            std::enable_if_t<!IsBlockVector<VectorStruct>::value, VectorStruct>
+              * = nullptr>
   inline void
   zero_vector_region(
     const unsigned int                                    range_index,

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -45,24 +45,22 @@ namespace MatrixFreeOperators
     // a non-block vector has one block and the only subblock is the vector
     // itself
     template <typename VectorType>
-    typename std::enable_if<IsBlockVector<VectorType>::value,
-                            unsigned int>::type
+    std::enable_if_t<IsBlockVector<VectorType>::value, unsigned int>
     n_blocks(const VectorType &vector)
     {
       return vector.n_blocks();
     }
 
     template <typename VectorType>
-    typename std::enable_if<!IsBlockVector<VectorType>::value,
-                            unsigned int>::type
+    std::enable_if_t<!IsBlockVector<VectorType>::value, unsigned int>
     n_blocks(const VectorType &)
     {
       return 1;
     }
 
     template <typename VectorType>
-    typename std::enable_if<IsBlockVector<VectorType>::value,
-                            typename VectorType::BlockType &>::type
+    std::enable_if_t<IsBlockVector<VectorType>::value,
+                     typename VectorType::BlockType &>
     subblock(VectorType &vector, unsigned int block_no)
     {
       AssertIndexRange(block_no, vector.n_blocks());
@@ -70,8 +68,8 @@ namespace MatrixFreeOperators
     }
 
     template <typename VectorType>
-    typename std::enable_if<IsBlockVector<VectorType>::value,
-                            const typename VectorType::BlockType &>::type
+    std::enable_if_t<IsBlockVector<VectorType>::value,
+                     const typename VectorType::BlockType &>
     subblock(const VectorType &vector, unsigned int block_no)
     {
       AssertIndexRange(block_no, vector.n_blocks());
@@ -79,30 +77,28 @@ namespace MatrixFreeOperators
     }
 
     template <typename VectorType>
-    typename std::enable_if<!IsBlockVector<VectorType>::value,
-                            VectorType &>::type
+    std::enable_if_t<!IsBlockVector<VectorType>::value, VectorType &>
     subblock(VectorType &vector, unsigned int)
     {
       return vector;
     }
 
     template <typename VectorType>
-    typename std::enable_if<!IsBlockVector<VectorType>::value,
-                            const VectorType &>::type
+    std::enable_if_t<!IsBlockVector<VectorType>::value, const VectorType &>
     subblock(const VectorType &vector, unsigned int)
     {
       return vector;
     }
 
     template <typename VectorType>
-    typename std::enable_if<IsBlockVector<VectorType>::value, void>::type
+    std::enable_if_t<IsBlockVector<VectorType>::value, void>
     collect_sizes(VectorType &vector)
     {
       vector.collect_sizes();
     }
 
     template <typename VectorType>
-    typename std::enable_if<!IsBlockVector<VectorType>::value, void>::type
+    std::enable_if_t<!IsBlockVector<VectorType>::value, void>
     collect_sizes(const VectorType &)
     {}
   } // namespace BlockHelper

--- a/include/deal.II/matrix_free/tools.h
+++ b/include/deal.II/matrix_free/tools.h
@@ -950,11 +950,11 @@ namespace MatrixFreeTools
      */
     template <typename MatrixType,
               typename Number,
-              typename std::enable_if<std::is_same<
+              std::enable_if_t<std::is_same<
                 typename std::remove_const<typename std::remove_reference<
                   typename MatrixType::value_type>::type>::type,
                 typename std::remove_const<typename std::remove_reference<
-                  Number>::type>::type>::value>::type * = nullptr>
+                  Number>::type>::type>::value> * = nullptr>
     const AffineConstraints<typename MatrixType::value_type> &
     create_new_affine_constraints_if_needed(
       const MatrixType &,
@@ -971,11 +971,11 @@ namespace MatrixFreeTools
      */
     template <typename MatrixType,
               typename Number,
-              typename std::enable_if<!std::is_same<
+              std::enable_if_t<!std::is_same<
                 typename std::remove_const<typename std::remove_reference<
                   typename MatrixType::value_type>::type>::type,
                 typename std::remove_const<typename std::remove_reference<
-                  Number>::type>::type>::value>::type * = nullptr>
+                  Number>::type>::type>::value> * = nullptr>
     const AffineConstraints<typename MatrixType::value_type> &
     create_new_affine_constraints_if_needed(
       const MatrixType &,

--- a/include/deal.II/matrix_free/type_traits.h
+++ b/include/deal.II/matrix_free/type_traits.h
@@ -202,8 +202,8 @@ namespace internal
    * indeed a serial vector.
    */
   template <class VectorType>
-  using is_serial_vector_type = decltype(
-    typename std::enable_if<is_serial_vector<VectorType>::value, int>::type());
+  using is_serial_vector_type =
+    decltype(std::enable_if_t<is_serial_vector<VectorType>::value, int>());
 
   /**
    * A variable that indicates that the type `T` is either (i) not

--- a/include/deal.II/matrix_free/vector_access_internal.h
+++ b/include/deal.II/matrix_free/vector_access_internal.h
@@ -39,9 +39,9 @@ namespace internal
   // access to generic const vectors that have operator ().
   // FIXME: this is wrong for Trilinos/Petsc MPI vectors
   // where we should first do Partitioner::local_to_global()
-  template <typename VectorType,
-            typename std::enable_if<!has_local_element<VectorType>,
-                                    VectorType>::type * = nullptr>
+  template <
+    typename VectorType,
+    std::enable_if_t<!has_local_element<VectorType>, VectorType> * = nullptr>
   inline typename VectorType::value_type
   vector_access(const VectorType &vec, const unsigned int entry)
   {
@@ -53,9 +53,9 @@ namespace internal
   // access to generic non-const vectors that have operator ().
   // FIXME: this is wrong for Trilinos/Petsc MPI vectors
   // where we should first do Partitioner::local_to_global()
-  template <typename VectorType,
-            typename std::enable_if<!has_local_element<VectorType>,
-                                    VectorType>::type * = nullptr>
+  template <
+    typename VectorType,
+    std::enable_if_t<!has_local_element<VectorType>, VectorType> * = nullptr>
   inline typename VectorType::value_type &
   vector_access(VectorType &vec, const unsigned int entry)
   {
@@ -67,9 +67,9 @@ namespace internal
   // access to distributed MPI vectors that have a local_element(uint)
   // method to access data in local index space, which is what we use in
   // DoFInfo and hence in read_dof_values etc.
-  template <typename VectorType,
-            typename std::enable_if<has_local_element<VectorType>,
-                                    VectorType>::type * = nullptr>
+  template <
+    typename VectorType,
+    std::enable_if_t<has_local_element<VectorType>, VectorType> * = nullptr>
   inline typename VectorType::value_type &
   vector_access(VectorType &vec, const unsigned int entry)
   {
@@ -79,9 +79,9 @@ namespace internal
 
 
   // same for const access
-  template <typename VectorType,
-            typename std::enable_if<has_local_element<VectorType>,
-                                    VectorType>::type * = nullptr>
+  template <
+    typename VectorType,
+    std::enable_if_t<has_local_element<VectorType>, VectorType> * = nullptr>
   inline typename VectorType::value_type
   vector_access(const VectorType &vec, const unsigned int entry)
   {
@@ -90,9 +90,9 @@ namespace internal
 
 
 
-  template <typename VectorType,
-            typename std::enable_if<has_add_local_element<VectorType>,
-                                    VectorType>::type * = nullptr>
+  template <
+    typename VectorType,
+    std::enable_if_t<has_add_local_element<VectorType>, VectorType> * = nullptr>
   inline void
   vector_access_add(VectorType &                           vec,
                     const unsigned int                     entry,
@@ -104,8 +104,8 @@ namespace internal
 
 
   template <typename VectorType,
-            typename std::enable_if<!has_add_local_element<VectorType>,
-                                    VectorType>::type * = nullptr>
+            std::enable_if_t<!has_add_local_element<VectorType>, VectorType> * =
+              nullptr>
   inline void
   vector_access_add(VectorType &                           vec,
                     const unsigned int                     entry,
@@ -116,9 +116,9 @@ namespace internal
 
 
 
-  template <typename VectorType,
-            typename std::enable_if<has_add_local_element<VectorType>,
-                                    VectorType>::type * = nullptr>
+  template <
+    typename VectorType,
+    std::enable_if_t<has_add_local_element<VectorType>, VectorType> * = nullptr>
   inline void
   vector_access_add_global(VectorType &                           vec,
                            const types::global_dof_index          entry,
@@ -130,8 +130,8 @@ namespace internal
 
 
   template <typename VectorType,
-            typename std::enable_if<!has_add_local_element<VectorType>,
-                                    VectorType>::type * = nullptr>
+            std::enable_if_t<!has_add_local_element<VectorType>, VectorType> * =
+              nullptr>
   inline void
   vector_access_add_global(VectorType &                           vec,
                            const types::global_dof_index          entry,
@@ -142,9 +142,9 @@ namespace internal
 
 
 
-  template <typename VectorType,
-            typename std::enable_if<has_set_local_element<VectorType>,
-                                    VectorType>::type * = nullptr>
+  template <
+    typename VectorType,
+    std::enable_if_t<has_set_local_element<VectorType>, VectorType> * = nullptr>
   inline void
   vector_access_set(VectorType &                           vec,
                     const unsigned int                     entry,
@@ -156,8 +156,8 @@ namespace internal
 
 
   template <typename VectorType,
-            typename std::enable_if<!has_set_local_element<VectorType>,
-                                    VectorType>::type * = nullptr>
+            std::enable_if_t<!has_set_local_element<VectorType>, VectorType> * =
+              nullptr>
   inline void
   vector_access_set(VectorType &                           vec,
                     const unsigned int                     entry,
@@ -172,13 +172,12 @@ namespace internal
   // is really the same as stored in MatrixFree.
   // version below is when has_partitioners_are_compatible == false
   // FIXME: this is incorrect for PETSc/Trilinos MPI vectors
-  template <
-    int dim,
-    typename Number,
-    typename VectorizedArrayType,
-    typename VectorType,
-    typename std::enable_if<!has_partitioners_are_compatible<VectorType>,
-                            VectorType>::type * = nullptr>
+  template <int dim,
+            typename Number,
+            typename VectorizedArrayType,
+            typename VectorType,
+            std::enable_if_t<!has_partitioners_are_compatible<VectorType>,
+                             VectorType> * = nullptr>
   inline void
   check_vector_compatibility(
     const VectorType &                                  vec,
@@ -199,8 +198,8 @@ namespace internal
             typename Number,
             typename VectorizedArrayType,
             typename VectorType,
-            typename std::enable_if<has_partitioners_are_compatible<VectorType>,
-                                    VectorType>::type * = nullptr>
+            std::enable_if_t<has_partitioners_are_compatible<VectorType>,
+                             VectorType> * = nullptr>
   inline void
   check_vector_compatibility(
     const VectorType &                                  vec,

--- a/include/deal.II/multigrid/mg_coarse.h
+++ b/include/deal.II/multigrid/mg_coarse.h
@@ -365,9 +365,9 @@ namespace internal
       class SolverType,
       class MatrixType,
       class PreconditionerType,
-      typename std::enable_if<
+      std::enable_if_t<
         std::is_same<VectorType, typename SolverType::vector_type>::value,
-        VectorType>::type * = nullptr>
+        VectorType> * = nullptr>
     void
     solve(SolverType &              solver,
           const MatrixType &        matrix,
@@ -383,9 +383,9 @@ namespace internal
       class SolverType,
       class MatrixType,
       class PreconditionerType,
-      typename std::enable_if<
+      std::enable_if_t<
         !std::is_same<VectorType, typename SolverType::vector_type>::value,
-        VectorType>::type * = nullptr>
+        VectorType> * = nullptr>
     void
     solve(SolverType &              solver,
           const MatrixType &        matrix,

--- a/include/deal.II/multigrid/multigrid.h
+++ b/include/deal.II/multigrid/multigrid.h
@@ -706,7 +706,7 @@ namespace internal
               typename VectorType,
               class TRANSFER,
               typename OtherVectorType>
-    typename std::enable_if<TRANSFER::supports_dof_handler_vector>::type
+    std::enable_if_t<TRANSFER::supports_dof_handler_vector>
     vmult(
       const std::vector<const dealii::DoFHandler<dim> *> &dof_handler_vector,
       dealii::Multigrid<VectorType> &                     multigrid,
@@ -767,7 +767,7 @@ namespace internal
               typename VectorType,
               class TRANSFER,
               typename OtherVectorType>
-    typename std::enable_if<TRANSFER::supports_dof_handler_vector>::type
+    std::enable_if_t<TRANSFER::supports_dof_handler_vector>
     vmult_add(
       const std::vector<const dealii::DoFHandler<dim> *> &dof_handler_vector,
       dealii::Multigrid<VectorType> &                     multigrid,

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -913,8 +913,8 @@ namespace internal
                 int spacedim,
                 typename VectorType,
                 typename Number,
-                typename std::enable_if<IsBlockVector<VectorType>::value,
-                                        VectorType>::type * = nullptr>
+                std::enable_if_t<IsBlockVector<VectorType>::value, VectorType>
+                  * = nullptr>
       void
       create_dof_vector(const DoFHandler<dim, spacedim> &dof_handler,
                         const VectorType &               src,
@@ -975,8 +975,8 @@ namespace internal
                 int spacedim,
                 typename VectorType,
                 typename Number,
-                typename std::enable_if<!IsBlockVector<VectorType>::value,
-                                        VectorType>::type * = nullptr>
+                std::enable_if_t<!IsBlockVector<VectorType>::value, VectorType>
+                  * = nullptr>
       void
       create_dof_vector(const DoFHandler<dim, spacedim> &dof_handler,
                         const VectorType &               src,
@@ -1009,8 +1009,8 @@ namespace internal
        */
       template <typename VectorType,
                 typename Number,
-                typename std::enable_if<IsBlockVector<VectorType>::value,
-                                        VectorType>::type * = nullptr>
+                std::enable_if_t<IsBlockVector<VectorType>::value, VectorType>
+                  * = nullptr>
       void
       create_cell_vector(const VectorType &                               src,
                          LinearAlgebra::distributed::BlockVector<Number> &dst)
@@ -1032,8 +1032,8 @@ namespace internal
        */
       template <typename VectorType,
                 typename Number,
-                typename std::enable_if<!IsBlockVector<VectorType>::value,
-                                        VectorType>::type * = nullptr>
+                std::enable_if_t<!IsBlockVector<VectorType>::value, VectorType>
+                  * = nullptr>
       void
       create_cell_vector(const VectorType &                               src,
                          LinearAlgebra::distributed::BlockVector<Number> &dst)

--- a/include/deal.II/numerics/vector_tools_boundary.templates.h
+++ b/include/deal.II/numerics/vector_tools_boundary.templates.h
@@ -990,7 +990,7 @@ namespace VectorTools
   namespace internals
   {
     template <int dim, typename cell_iterator, typename number>
-    typename std::enable_if<dim == 3>::type
+    std::enable_if_t<dim == 3>
     compute_edge_projection_l2(const cell_iterator &        cell,
                                const unsigned int           face,
                                const unsigned int           line,
@@ -1280,7 +1280,7 @@ namespace VectorTools
 
 
     template <int dim, typename cell_iterator, typename number>
-    typename std::enable_if<dim != 3>::type
+    std::enable_if_t<dim != 3>
     compute_edge_projection_l2(const cell_iterator &,
                                const unsigned int,
                                const unsigned int,

--- a/include/deal.II/numerics/vector_tools_mean_value.templates.h
+++ b/include/deal.II/numerics/vector_tools_mean_value.templates.h
@@ -44,8 +44,7 @@ namespace VectorTools
   namespace internal
   {
     template <typename VectorType>
-    typename std::enable_if<dealii::is_serial_vector<VectorType>::value ==
-                            true>::type
+    std::enable_if_t<dealii::is_serial_vector<VectorType>::value == true>
     subtract_mean_value(VectorType &v, const std::vector<bool> &p_select)
     {
       if (p_select.size() == 0)
@@ -85,8 +84,7 @@ namespace VectorTools
 
 
     template <typename VectorType>
-    typename std::enable_if<dealii::is_serial_vector<VectorType>::value ==
-                            false>::type
+    std::enable_if_t<dealii::is_serial_vector<VectorType>::value == false>
     subtract_mean_value(VectorType &v, const std::vector<bool> &p_select)
     {
       (void)p_select;

--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -482,9 +482,8 @@ namespace Particles
      * positions.
      */
     template <class VectorType>
-    typename std::enable_if<
-      std::is_convertible<VectorType *, Function<spacedim> *>::value ==
-      false>::type
+    std::enable_if_t<
+      std::is_convertible<VectorType *, Function<spacedim> *>::value == false>
     set_particle_positions(const VectorType &input_vector,
                            const bool        displace_particles = true);
 
@@ -1333,9 +1332,8 @@ namespace Particles
 
   template <int dim, int spacedim>
   template <class VectorType>
-  inline typename std::enable_if<
-    std::is_convertible<VectorType *, Function<spacedim> *>::value ==
-    false>::type
+  inline std::enable_if_t<
+    std::is_convertible<VectorType *, Function<spacedim> *>::value == false>
   ParticleHandler<dim, spacedim>::set_particle_positions(
     const VectorType &input_vector,
     const bool        displace_particles)

--- a/source/differentiation/ad/ad_drivers.cc
+++ b/source/differentiation/ad/ad_drivers.cc
@@ -260,11 +260,10 @@ namespace Differentiation
     // Specialization for taped ADOL-C auto-differentiable numbers.
 
     template <typename ADNumberType>
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::TapedDrivers()
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::TapedDrivers()
       : active_tape(Numbers<ADNumberType>::invalid_tape_index)
       , keep_values(true)
       , is_recording_flag(false)
@@ -279,11 +278,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     bool
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::is_recording()
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::is_recording()
       const
     {
       return is_recording_flag;
@@ -292,11 +290,11 @@ namespace Differentiation
 
     template <typename ADNumberType>
     typename Types<ADNumberType>::tape_index
-    TapedDrivers<ADNumberType,
-                 double,
-                 typename std::enable_if<
-                   ADNumberTraits<ADNumberType>::type_code ==
-                   NumberTypes::adolc_taped>::type>::active_tape_index() const
+    TapedDrivers<
+      ADNumberType,
+      double,
+      std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                       NumberTypes::adolc_taped>>::active_tape_index() const
     {
       return active_tape;
     }
@@ -306,10 +304,9 @@ namespace Differentiation
     bool
     TapedDrivers<ADNumberType,
                  double,
-                 typename std::enable_if<
-                   ADNumberTraits<ADNumberType>::type_code ==
-                   NumberTypes::adolc_taped>::type>::keep_independent_values()
-      const
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
+      keep_independent_values() const
     {
       return keep_values;
     }
@@ -317,11 +314,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     bool
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       is_registered_tape(
         const typename Types<ADNumberType>::tape_index tape_index) const
     {
@@ -391,11 +387,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       set_tape_buffer_sizes(
         const typename Types<ADNumberType>::tape_buffer_sizes in_obufsize,
         const typename Types<ADNumberType>::tape_buffer_sizes in_lbufsize,
@@ -414,11 +409,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       start_taping(const typename Types<ADNumberType>::tape_index tape_index,
                    const bool keep_independent_values)
     {
@@ -440,11 +434,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       stop_taping(
         const typename Types<ADNumberType>::tape_index active_tape_index,
         const bool                                     write_tapes_to_file)
@@ -469,11 +462,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     std::vector<typename Types<ADNumberType>::tape_index>
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       get_registered_tape_indices() const
     {
       // We've chosen to use unsigned shorts for the tape
@@ -490,11 +482,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       activate_tape(const typename Types<ADNumberType>::tape_index tape_index)
     {
       active_tape = tape_index;
@@ -503,11 +494,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     bool
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       requires_retaping(
         const typename Types<ADNumberType>::tape_index tape_index) const
     {
@@ -545,11 +535,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     bool
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       last_action_requires_retaping() const
     {
       return requires_retaping(active_tape);
@@ -558,11 +547,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       remove_tape(const typename Types<ADNumberType>::tape_index tape_index)
     {
       Assert(is_registered_tape(tape_index),
@@ -574,11 +562,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       reset(const bool clear_registered_tapes)
     {
       active_tape       = Numbers<ADNumberType>::invalid_tape_index;
@@ -598,9 +585,9 @@ namespace Differentiation
     void
     TapedDrivers<ADNumberType,
                  double,
-                 typename std::enable_if<
-                   ADNumberTraits<ADNumberType>::type_code ==
-                   NumberTypes::adolc_taped>::type>::print(std::ostream &stream)
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::print(std::ostream
+                                                                      &stream)
       const
     {
       const std::vector<typename Types<ADNumberType>::tape_index>
@@ -630,11 +617,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       print_tape_stats(
         const typename Types<ADNumberType>::tape_index tape_index,
         std::ostream &                                 stream) const
@@ -675,13 +661,12 @@ namespace Differentiation
     typename TapedDrivers<
       ADNumberType,
       double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::scalar_type
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+      std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                       NumberTypes::adolc_taped>>::scalar_type
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       value(const typename Types<ADNumberType>::tape_index active_tape_index,
             const std::vector<scalar_type> &independent_variables) const
     {
@@ -703,11 +688,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       gradient(const typename Types<ADNumberType>::tape_index active_tape_index,
                const std::vector<scalar_type> &independent_variables,
                Vector<scalar_type> &           gradient) const
@@ -736,11 +720,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       hessian(const typename Types<ADNumberType>::tape_index active_tape_index,
               const std::vector<scalar_type> &independent_variables,
               FullMatrix<scalar_type> &       hessian) const
@@ -779,11 +762,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       values(const typename Types<ADNumberType>::tape_index active_tape_index,
              const unsigned int              n_dependent_variables,
              const std::vector<scalar_type> &independent_variables,
@@ -808,11 +790,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       jacobian(const typename Types<ADNumberType>::tape_index active_tape_index,
                const unsigned int              n_dependent_variables,
                const std::vector<scalar_type> &independent_variables,
@@ -847,11 +828,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     bool
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::is_recording()
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::is_recording()
       const
     {
       AssertThrow(false, ExcRequiresADOLC());
@@ -861,11 +841,11 @@ namespace Differentiation
 
     template <typename ADNumberType>
     typename Types<ADNumberType>::tape_index
-    TapedDrivers<ADNumberType,
-                 double,
-                 typename std::enable_if<
-                   ADNumberTraits<ADNumberType>::type_code ==
-                   NumberTypes::adolc_taped>::type>::active_tape_index() const
+    TapedDrivers<
+      ADNumberType,
+      double,
+      std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                       NumberTypes::adolc_taped>>::active_tape_index() const
     {
       AssertThrow(false, ExcRequiresADOLC());
       return Numbers<ADNumberType>::invalid_tape_index;
@@ -876,10 +856,9 @@ namespace Differentiation
     bool
     TapedDrivers<ADNumberType,
                  double,
-                 typename std::enable_if<
-                   ADNumberTraits<ADNumberType>::type_code ==
-                   NumberTypes::adolc_taped>::type>::keep_independent_values()
-      const
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
+      keep_independent_values() const
     {
       AssertThrow(false, ExcRequiresADOLC());
       return false;
@@ -888,11 +867,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     bool
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       is_registered_tape(const typename Types<ADNumberType>::tape_index) const
     {
       AssertThrow(false, ExcRequiresADOLC());
@@ -902,11 +880,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       set_tape_buffer_sizes(
         const typename Types<ADNumberType>::tape_buffer_sizes,
         const typename Types<ADNumberType>::tape_buffer_sizes,
@@ -919,11 +896,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       start_taping(const typename Types<ADNumberType>::tape_index, const bool)
     {
       AssertThrow(false, ExcRequiresADOLC());
@@ -932,11 +908,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       stop_taping(const typename Types<ADNumberType>::tape_index, const bool)
     {
       AssertThrow(false, ExcRequiresADOLC());
@@ -945,11 +920,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     std::vector<typename Types<ADNumberType>::tape_index>
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       get_registered_tape_indices() const
     {
       AssertThrow(false, ExcRequiresADOLC());
@@ -959,11 +933,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       activate_tape(const typename Types<ADNumberType>::tape_index)
     {
       AssertThrow(false, ExcRequiresADOLC());
@@ -972,11 +945,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     bool
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       requires_retaping(const typename Types<ADNumberType>::tape_index) const
     {
       AssertThrow(false, ExcRequiresADOLC());
@@ -986,11 +958,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     bool
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       last_action_requires_retaping() const
     {
       AssertThrow(false, ExcRequiresADOLC());
@@ -1000,11 +971,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       remove_tape(const typename Types<ADNumberType>::tape_index)
     {
       AssertThrow(false, ExcRequiresADOLC());
@@ -1015,9 +985,8 @@ namespace Differentiation
     void
     TapedDrivers<ADNumberType,
                  double,
-                 typename std::enable_if<
-                   ADNumberTraits<ADNumberType>::type_code ==
-                   NumberTypes::adolc_taped>::type>::reset(const bool)
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::reset(const bool)
     {
       AssertThrow(false, ExcRequiresADOLC());
     }
@@ -1027,9 +996,9 @@ namespace Differentiation
     void
     TapedDrivers<ADNumberType,
                  double,
-                 typename std::enable_if<
-                   ADNumberTraits<ADNumberType>::type_code ==
-                   NumberTypes::adolc_taped>::type>::print(std::ostream &) const
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::print(std::ostream
+                                                                      &) const
     {
       AssertThrow(false, ExcRequiresADOLC());
     }
@@ -1037,11 +1006,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       print_tape_stats(const typename Types<ADNumberType>::tape_index,
                        std::ostream &) const
     {
@@ -1053,13 +1021,12 @@ namespace Differentiation
     typename TapedDrivers<
       ADNumberType,
       double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::scalar_type
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+      std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                       NumberTypes::adolc_taped>>::scalar_type
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       value(const typename Types<ADNumberType>::tape_index,
             const std::vector<scalar_type> &) const
     {
@@ -1070,11 +1037,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       gradient(const typename Types<ADNumberType>::tape_index,
                const std::vector<scalar_type> &,
                Vector<scalar_type> &) const
@@ -1085,11 +1051,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       hessian(const typename Types<ADNumberType>::tape_index,
               const std::vector<scalar_type> &,
               FullMatrix<scalar_type> &) const
@@ -1100,11 +1065,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       values(const typename Types<ADNumberType>::tape_index,
              const unsigned int,
              const std::vector<scalar_type> &,
@@ -1116,11 +1080,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      double,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 double,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       jacobian(const typename Types<ADNumberType>::tape_index,
                const unsigned int,
                const std::vector<scalar_type> &,
@@ -1137,11 +1100,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     bool
-    TapedDrivers<
-      ADNumberType,
-      float,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::is_recording()
+    TapedDrivers<ADNumberType,
+                 float,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::is_recording()
       const
     {
       // ADOL-C only supports 'double', not 'float', so we can forward to
@@ -1152,11 +1114,11 @@ namespace Differentiation
 
     template <typename ADNumberType>
     typename Types<ADNumberType>::tape_index
-    TapedDrivers<ADNumberType,
-                 float,
-                 typename std::enable_if<
-                   ADNumberTraits<ADNumberType>::type_code ==
-                   NumberTypes::adolc_taped>::type>::active_tape_index() const
+    TapedDrivers<
+      ADNumberType,
+      float,
+      std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                       NumberTypes::adolc_taped>>::active_tape_index() const
     {
       // ADOL-C only supports 'double', not 'float', so we can forward to
       // the 'double' implementation of this function
@@ -1168,10 +1130,9 @@ namespace Differentiation
     bool
     TapedDrivers<ADNumberType,
                  float,
-                 typename std::enable_if<
-                   ADNumberTraits<ADNumberType>::type_code ==
-                   NumberTypes::adolc_taped>::type>::keep_independent_values()
-      const
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
+      keep_independent_values() const
     {
       return taped_driver.keep_independent_values();
     }
@@ -1179,11 +1140,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     bool
-    TapedDrivers<
-      ADNumberType,
-      float,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 float,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       is_registered_tape(
         const typename Types<ADNumberType>::tape_index tape_index) const
     {
@@ -1195,11 +1155,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      float,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 float,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       set_tape_buffer_sizes(
         const typename Types<ADNumberType>::tape_buffer_sizes obufsize,
         const typename Types<ADNumberType>::tape_buffer_sizes lbufsize,
@@ -1217,11 +1176,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      float,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 float,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       start_taping(const typename Types<ADNumberType>::tape_index tape_index,
                    const bool keep_independent_values)
     {
@@ -1233,11 +1191,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      float,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 float,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       stop_taping(
         const typename Types<ADNumberType>::tape_index active_tape_index,
         const bool                                     write_tapes_to_file)
@@ -1250,11 +1207,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     std::vector<typename Types<ADNumberType>::tape_index>
-    TapedDrivers<
-      ADNumberType,
-      float,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 float,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       get_registered_tape_indices() const
     {
       return taped_driver.get_registered_tape_indices();
@@ -1263,11 +1219,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      float,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 float,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       activate_tape(const typename Types<ADNumberType>::tape_index tape_index)
     {
       taped_driver.activate_tape(tape_index);
@@ -1276,11 +1231,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     bool
-    TapedDrivers<
-      ADNumberType,
-      float,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 float,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       requires_retaping(
         const typename Types<ADNumberType>::tape_index tape_index) const
     {
@@ -1290,11 +1244,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     bool
-    TapedDrivers<
-      ADNumberType,
-      float,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 float,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       last_action_requires_retaping() const
     {
       return taped_driver.last_action_requires_retaping();
@@ -1303,11 +1256,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      float,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 float,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       remove_tape(const typename Types<ADNumberType>::tape_index tape_index)
     {
       taped_driver.remove_tape(tape_index);
@@ -1316,11 +1268,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      float,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 float,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       reset(const bool clear_registered_tapes)
     {
       taped_driver.reset(clear_registered_tapes);
@@ -1331,9 +1282,9 @@ namespace Differentiation
     void
     TapedDrivers<ADNumberType,
                  float,
-                 typename std::enable_if<
-                   ADNumberTraits<ADNumberType>::type_code ==
-                   NumberTypes::adolc_taped>::type>::print(std::ostream &stream)
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::print(std::ostream
+                                                                      &stream)
       const
     {
       taped_driver.print(stream);
@@ -1342,11 +1293,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      float,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 float,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       print_tape_stats(
         const typename Types<ADNumberType>::tape_index tape_index,
         std::ostream &                                 stream) const
@@ -1361,13 +1311,12 @@ namespace Differentiation
     typename TapedDrivers<
       ADNumberType,
       float,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::scalar_type
-    TapedDrivers<
-      ADNumberType,
-      float,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+      std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                       NumberTypes::adolc_taped>>::scalar_type
+    TapedDrivers<ADNumberType,
+                 float,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       value(const typename Types<ADNumberType>::tape_index active_tape_index,
             const std::vector<scalar_type> &independent_variables) const
     {
@@ -1380,11 +1329,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      float,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 float,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       gradient(const typename Types<ADNumberType>::tape_index active_tape_index,
                const std::vector<scalar_type> &independent_variables,
                Vector<scalar_type> &           gradient) const
@@ -1401,11 +1349,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      float,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 float,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       hessian(const typename Types<ADNumberType>::tape_index active_tape_index,
               const std::vector<scalar_type> &independent_variables,
               FullMatrix<scalar_type> &       hessian) const
@@ -1422,11 +1369,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      float,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 float,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       values(const typename Types<ADNumberType>::tape_index active_tape_index,
              const unsigned int              n_dependent_variables,
              const std::vector<scalar_type> &independent_variables,
@@ -1445,11 +1391,10 @@ namespace Differentiation
 
     template <typename ADNumberType>
     void
-    TapedDrivers<
-      ADNumberType,
-      float,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 float,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       jacobian(const typename Types<ADNumberType>::tape_index active_tape_index,
                const unsigned int              n_dependent_variables,
                const std::vector<scalar_type> &independent_variables,
@@ -1469,11 +1414,10 @@ namespace Differentiation
 #  ifndef DOXYGEN
     template <typename ADNumberType>
     std::vector<double>
-    TapedDrivers<
-      ADNumberType,
-      float,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_taped>::type>::
+    TapedDrivers<ADNumberType,
+                 float,
+                 std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                  NumberTypes::adolc_taped>>::
       vector_float_to_double(const std::vector<float> &in) const
     {
       std::vector<double> out(in.size());
@@ -1580,10 +1524,10 @@ namespace Differentiation
        * reverse-mode AD.
        */
       template <typename ADNumberType>
-      typename std::enable_if<!(ADNumberTraits<ADNumberType>::type_code ==
-                                  NumberTypes::sacado_rad ||
-                                ADNumberTraits<ADNumberType>::type_code ==
-                                  NumberTypes::sacado_rad_dfad)>::type
+      std::enable_if_t<!(ADNumberTraits<ADNumberType>::type_code ==
+                           NumberTypes::sacado_rad ||
+                         ADNumberTraits<ADNumberType>::type_code ==
+                           NumberTypes::sacado_rad_dfad)>
       reverse_mode_dependent_variable_activation(ADNumberType &)
       {}
 
@@ -1599,10 +1543,9 @@ namespace Differentiation
        * to. This function broadcasts this information.
        */
       template <typename ADNumberType>
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_rad ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_rad_dfad>::type
+      std::enable_if_t<
+        ADNumberTraits<ADNumberType>::type_code == NumberTypes::sacado_rad ||
+        ADNumberTraits<ADNumberType>::type_code == NumberTypes::sacado_rad_dfad>
       reverse_mode_dependent_variable_activation(
         ADNumberType &dependent_variable)
       {
@@ -1625,8 +1568,8 @@ namespace Differentiation
        * auto-differentiable numbers.
        */
       template <typename ADNumberType>
-      typename std::enable_if<!(ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::adolc_tapeless)>::type
+      std::enable_if_t<!(ADNumberTraits<ADNumberType>::type_code ==
+                         NumberTypes::adolc_tapeless)>
       configure_tapeless_mode(const unsigned int)
       {}
 
@@ -1642,8 +1585,8 @@ namespace Differentiation
        * If not then it throws an error.
        */
       template <typename ADNumberType>
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_tapeless>::type
+      std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                       NumberTypes::adolc_tapeless>
       configure_tapeless_mode(const unsigned int n_directional_derivatives)
       {
 #    ifdef DEAL_II_ADOLC_WITH_TAPELESS_REFCOUNTING
@@ -1702,8 +1645,8 @@ namespace Differentiation
 #  else // DEAL_II_WITH_ADOLC
 
       template <typename ADNumberType>
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                              NumberTypes::adolc_tapeless>::type
+      std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                       NumberTypes::adolc_tapeless>
       configure_tapeless_mode(const unsigned int /*n_directional_derivatives*/)
       {
         AssertThrow(false, ExcRequiresADOLC());
@@ -1724,10 +1667,10 @@ namespace Differentiation
     TapelessDrivers<
       ADNumberType,
       ScalarType,
-      typename std::enable_if<
-        ADNumberTraits<ADNumberType>::type_code == NumberTypes::sacado_rad ||
-        ADNumberTraits<ADNumberType>::type_code ==
-          NumberTypes::sacado_rad_dfad>::type>::TapelessDrivers()
+      std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                         NumberTypes::sacado_rad ||
+                       ADNumberTraits<ADNumberType>::type_code ==
+                         NumberTypes::sacado_rad_dfad>>::TapelessDrivers()
       : dependent_variable_marking_safe(false)
     {}
 #  endif
@@ -1735,13 +1678,12 @@ namespace Differentiation
 
     template <typename ADNumberType, typename ScalarType>
     void
-    TapelessDrivers<
-      ADNumberType,
-      ScalarType,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_rad ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_rad_dfad>::type>::
+    TapelessDrivers<ADNumberType,
+                    ScalarType,
+                    std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_rad ||
+                                     ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_rad_dfad>>::
       initialize_global_environment(const unsigned int n_independent_variables)
     {
       internal::configure_tapeless_mode<ADNumberType>(n_independent_variables);
@@ -1753,11 +1695,10 @@ namespace Differentiation
     TapelessDrivers<
       ADNumberType,
       ScalarType,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_rad ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_rad_dfad>::type>::
-      allow_dependent_variable_marking()
+      std::enable_if_t<
+        ADNumberTraits<ADNumberType>::type_code == NumberTypes::sacado_rad ||
+        ADNumberTraits<ADNumberType>::type_code ==
+          NumberTypes::sacado_rad_dfad>>::allow_dependent_variable_marking()
     {
       dependent_variable_marking_safe = true;
     }
@@ -1768,11 +1709,10 @@ namespace Differentiation
     TapelessDrivers<
       ADNumberType,
       ScalarType,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_rad ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_rad_dfad>::type>::
-      prevent_dependent_variable_marking()
+      std::enable_if_t<
+        ADNumberTraits<ADNumberType>::type_code == NumberTypes::sacado_rad ||
+        ADNumberTraits<ADNumberType>::type_code ==
+          NumberTypes::sacado_rad_dfad>>::prevent_dependent_variable_marking()
     {
       dependent_variable_marking_safe = false;
     }
@@ -1780,13 +1720,12 @@ namespace Differentiation
 
     template <typename ADNumberType, typename ScalarType>
     bool
-    TapelessDrivers<
-      ADNumberType,
-      ScalarType,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_rad ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_rad_dfad>::type>::
+    TapelessDrivers<ADNumberType,
+                    ScalarType,
+                    std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_rad ||
+                                     ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_rad_dfad>>::
       is_dependent_variable_marking_allowed() const
     {
       return dependent_variable_marking_safe;
@@ -1795,13 +1734,12 @@ namespace Differentiation
 
     template <typename ADNumberType, typename ScalarType>
     ScalarType
-    TapelessDrivers<
-      ADNumberType,
-      ScalarType,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_rad ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_rad_dfad>::type>::
+    TapelessDrivers<ADNumberType,
+                    ScalarType,
+                    std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_rad ||
+                                     ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_rad_dfad>>::
       value(const std::vector<ADNumberType> &dependent_variables) const
     {
       Assert(dependent_variables.size() == 1,
@@ -1813,13 +1751,12 @@ namespace Differentiation
 
     template <typename ADNumberType, typename ScalarType>
     void
-    TapelessDrivers<
-      ADNumberType,
-      ScalarType,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_rad ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_rad_dfad>::type>::
+    TapelessDrivers<ADNumberType,
+                    ScalarType,
+                    std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_rad ||
+                                     ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_rad_dfad>>::
       gradient(const std::vector<ADNumberType> &independent_variables,
                const std::vector<ADNumberType> &dependent_variables,
                Vector<ScalarType> &             gradient) const
@@ -1849,13 +1786,12 @@ namespace Differentiation
 
     template <typename ADNumberType, typename ScalarType>
     void
-    TapelessDrivers<
-      ADNumberType,
-      ScalarType,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_rad ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_rad_dfad>::type>::
+    TapelessDrivers<ADNumberType,
+                    ScalarType,
+                    std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_rad ||
+                                     ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_rad_dfad>>::
       hessian(const std::vector<ADNumberType> &independent_variables,
               const std::vector<ADNumberType> &dependent_variables,
               FullMatrix<ScalarType> &         hessian) const
@@ -1904,13 +1840,12 @@ namespace Differentiation
 
     template <typename ADNumberType, typename ScalarType>
     void
-    TapelessDrivers<
-      ADNumberType,
-      ScalarType,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_rad ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_rad_dfad>::type>::
+    TapelessDrivers<ADNumberType,
+                    ScalarType,
+                    std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_rad ||
+                                     ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_rad_dfad>>::
       values(const std::vector<ADNumberType> &dependent_variables,
              Vector<ScalarType> &             values) const
     {
@@ -1926,13 +1861,12 @@ namespace Differentiation
 
     template <typename ADNumberType, typename ScalarType>
     void
-    TapelessDrivers<
-      ADNumberType,
-      ScalarType,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_rad ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_rad_dfad>::type>::
+    TapelessDrivers<ADNumberType,
+                    ScalarType,
+                    std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_rad ||
+                                     ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_rad_dfad>>::
       jacobian(const std::vector<ADNumberType> &independent_variables,
                const std::vector<ADNumberType> &dependent_variables,
                FullMatrix<ScalarType> &         jacobian) const
@@ -1994,12 +1928,12 @@ namespace Differentiation
     TapelessDrivers<
       ADNumberType,
       ScalarType,
-      typename std::enable_if<
-        ADNumberTraits<ADNumberType>::type_code ==
-          NumberTypes::adolc_tapeless ||
-        ADNumberTraits<ADNumberType>::type_code == NumberTypes::sacado_dfad ||
-        ADNumberTraits<ADNumberType>::type_code ==
-          NumberTypes::sacado_dfad_dfad>::type>::TapelessDrivers()
+      std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                         NumberTypes::adolc_tapeless ||
+                       ADNumberTraits<ADNumberType>::type_code ==
+                         NumberTypes::sacado_dfad ||
+                       ADNumberTraits<ADNumberType>::type_code ==
+                         NumberTypes::sacado_dfad_dfad>>::TapelessDrivers()
       : dependent_variable_marking_safe(false)
     {}
 #  endif
@@ -2007,15 +1941,14 @@ namespace Differentiation
 
     template <typename ADNumberType, typename ScalarType>
     void
-    TapelessDrivers<
-      ADNumberType,
-      ScalarType,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::adolc_tapeless ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_dfad ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_dfad_dfad>::type>::
+    TapelessDrivers<ADNumberType,
+                    ScalarType,
+                    std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::adolc_tapeless ||
+                                     ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_dfad ||
+                                     ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_dfad_dfad>>::
       initialize_global_environment(const unsigned int n_independent_variables)
     {
       internal::configure_tapeless_mode<ADNumberType>(n_independent_variables);
@@ -2027,13 +1960,12 @@ namespace Differentiation
     TapelessDrivers<
       ADNumberType,
       ScalarType,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::adolc_tapeless ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_dfad ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_dfad_dfad>::type>::
-      allow_dependent_variable_marking()
+      std::enable_if_t<
+        ADNumberTraits<ADNumberType>::type_code ==
+          NumberTypes::adolc_tapeless ||
+        ADNumberTraits<ADNumberType>::type_code == NumberTypes::sacado_dfad ||
+        ADNumberTraits<ADNumberType>::type_code ==
+          NumberTypes::sacado_dfad_dfad>>::allow_dependent_variable_marking()
     {
       dependent_variable_marking_safe = true;
     }
@@ -2044,13 +1976,12 @@ namespace Differentiation
     TapelessDrivers<
       ADNumberType,
       ScalarType,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::adolc_tapeless ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_dfad ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_dfad_dfad>::type>::
-      prevent_dependent_variable_marking()
+      std::enable_if_t<
+        ADNumberTraits<ADNumberType>::type_code ==
+          NumberTypes::adolc_tapeless ||
+        ADNumberTraits<ADNumberType>::type_code == NumberTypes::sacado_dfad ||
+        ADNumberTraits<ADNumberType>::type_code ==
+          NumberTypes::sacado_dfad_dfad>>::prevent_dependent_variable_marking()
     {
       dependent_variable_marking_safe = false;
     }
@@ -2058,15 +1989,14 @@ namespace Differentiation
 
     template <typename ADNumberType, typename ScalarType>
     bool
-    TapelessDrivers<
-      ADNumberType,
-      ScalarType,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::adolc_tapeless ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_dfad ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_dfad_dfad>::type>::
+    TapelessDrivers<ADNumberType,
+                    ScalarType,
+                    std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::adolc_tapeless ||
+                                     ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_dfad ||
+                                     ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_dfad_dfad>>::
       is_dependent_variable_marking_allowed() const
     {
       return dependent_variable_marking_safe;
@@ -2075,15 +2005,14 @@ namespace Differentiation
 
     template <typename ADNumberType, typename ScalarType>
     ScalarType
-    TapelessDrivers<
-      ADNumberType,
-      ScalarType,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::adolc_tapeless ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_dfad ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_dfad_dfad>::type>::
+    TapelessDrivers<ADNumberType,
+                    ScalarType,
+                    std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::adolc_tapeless ||
+                                     ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_dfad ||
+                                     ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_dfad_dfad>>::
       value(const std::vector<ADNumberType> &dependent_variables) const
     {
       Assert(dependent_variables.size() == 1,
@@ -2095,15 +2024,14 @@ namespace Differentiation
 
     template <typename ADNumberType, typename ScalarType>
     void
-    TapelessDrivers<
-      ADNumberType,
-      ScalarType,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::adolc_tapeless ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_dfad ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_dfad_dfad>::type>::
+    TapelessDrivers<ADNumberType,
+                    ScalarType,
+                    std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::adolc_tapeless ||
+                                     ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_dfad ||
+                                     ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_dfad_dfad>>::
       gradient(const std::vector<ADNumberType> &independent_variables,
                const std::vector<ADNumberType> &dependent_variables,
                Vector<ScalarType> &             gradient) const
@@ -2131,15 +2059,14 @@ namespace Differentiation
 
     template <typename ADNumberType, typename ScalarType>
     void
-    TapelessDrivers<
-      ADNumberType,
-      ScalarType,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::adolc_tapeless ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_dfad ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_dfad_dfad>::type>::
+    TapelessDrivers<ADNumberType,
+                    ScalarType,
+                    std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::adolc_tapeless ||
+                                     ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_dfad ||
+                                     ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_dfad_dfad>>::
       hessian(const std::vector<ADNumberType> &independent_variables,
               const std::vector<ADNumberType> &dependent_variables,
               FullMatrix<ScalarType> &         hessian) const
@@ -2186,15 +2113,14 @@ namespace Differentiation
 
     template <typename ADNumberType, typename ScalarType>
     void
-    TapelessDrivers<
-      ADNumberType,
-      ScalarType,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::adolc_tapeless ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_dfad ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_dfad_dfad>::type>::
+    TapelessDrivers<ADNumberType,
+                    ScalarType,
+                    std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::adolc_tapeless ||
+                                     ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_dfad ||
+                                     ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_dfad_dfad>>::
       values(const std::vector<ADNumberType> &dependent_variables,
              Vector<ScalarType> &             values) const
     {
@@ -2210,15 +2136,14 @@ namespace Differentiation
 
     template <typename ADNumberType, typename ScalarType>
     void
-    TapelessDrivers<
-      ADNumberType,
-      ScalarType,
-      typename std::enable_if<ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::adolc_tapeless ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_dfad ||
-                              ADNumberTraits<ADNumberType>::type_code ==
-                                NumberTypes::sacado_dfad_dfad>::type>::
+    TapelessDrivers<ADNumberType,
+                    ScalarType,
+                    std::enable_if_t<ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::adolc_tapeless ||
+                                     ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_dfad ||
+                                     ADNumberTraits<ADNumberType>::type_code ==
+                                       NumberTypes::sacado_dfad_dfad>>::
       jacobian(const std::vector<ADNumberType> &independent_variables,
                const std::vector<ADNumberType> &dependent_variables,
                FullMatrix<ScalarType> &         jacobian) const

--- a/source/dofs/dof_accessor_set.cc
+++ b/source/dofs/dof_accessor_set.cc
@@ -102,18 +102,18 @@ namespace internal
   constexpr bool has_set_ghost_state =
     is_supported_operation<set_ghost_state_t, T>;
 
-  template <typename VectorType,
-            typename std::enable_if<has_set_ghost_state<VectorType>,
-                                    VectorType>::type * = nullptr>
+  template <
+    typename VectorType,
+    std::enable_if_t<has_set_ghost_state<VectorType>, VectorType> * = nullptr>
   void
   set_ghost_state(VectorType &vector, const bool ghosted)
   {
     vector.set_ghost_state(ghosted);
   }
 
-  template <typename VectorType,
-            typename std::enable_if<!has_set_ghost_state<VectorType>,
-                                    VectorType>::type * = nullptr>
+  template <
+    typename VectorType,
+    std::enable_if_t<!has_set_ghost_state<VectorType>, VectorType> * = nullptr>
   void
   set_ghost_state(VectorType &, const bool)
   {

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -125,8 +125,7 @@ namespace internal
     template <typename Number>
     struct CheckForZero<
       Number,
-      typename std::enable_if<
-        Differentiation::AD::is_ad_number<Number>::value>::type>
+      std::enable_if_t<Differentiation::AD::is_ad_number<Number>::value>>
     {
       static bool
       value(const Number & /*value*/)

--- a/source/grid/grid_generator_from_name.cc
+++ b/source/grid/grid_generator_from_name.cc
@@ -50,7 +50,7 @@ namespace GridGenerator
      * Return true if a grid was actually generated, false otherwise.
      */
     template <int dim, int spacedim>
-    typename std::enable_if<dim != spacedim, bool>::type
+    std::enable_if_t<dim != spacedim, bool>
     generate_codimension_zero_grid(const std::string &,
                                    const std::string &,
                                    Triangulation<dim, spacedim> &)
@@ -243,7 +243,7 @@ namespace GridGenerator
      * Return true if a grid was actually generated, false otherwise.
      */
     template <int dim, int spacedim>
-    typename std::enable_if<dim != spacedim - 1, bool>::type
+    std::enable_if_t<dim != spacedim - 1, bool>
     generate_codimension_one_grid(const std::string &,
                                   const std::string &,
                                   Triangulation<dim, spacedim> &)

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -797,9 +797,8 @@ namespace TrilinosWrappers
 
 
   template <typename SparsityPatternType>
-  inline typename std::enable_if<
-    !std::is_same<SparsityPatternType,
-                  dealii::SparseMatrix<double>>::value>::type
+  inline std::enable_if_t<
+    !std::is_same<SparsityPatternType, dealii::SparseMatrix<double>>::value>
   SparseMatrix::reinit(const IndexSet &           row_parallel_partitioning,
                        const IndexSet &           col_parallel_partitioning,
                        const SparsityPatternType &sparsity_pattern,
@@ -1976,8 +1975,8 @@ namespace TrilinosWrappers
 
 
   template <typename VectorType>
-  typename std::enable_if<
-    std::is_same<typename VectorType::value_type, TrilinosScalar>::value>::type
+  std::enable_if_t<
+    std::is_same<typename VectorType::value_type, TrilinosScalar>::value>
   SparseMatrix::vmult(VectorType &dst, const VectorType &src) const
   {
     Assert(&src != &dst, ExcSourceEqualsDestination());
@@ -2010,8 +2009,8 @@ namespace TrilinosWrappers
 
 
   template <typename VectorType>
-  typename std::enable_if<
-    !std::is_same<typename VectorType::value_type, TrilinosScalar>::value>::type
+  std::enable_if_t<
+    !std::is_same<typename VectorType::value_type, TrilinosScalar>::value>
   SparseMatrix::vmult(VectorType & /*dst*/, const VectorType & /*src*/) const
   {
     AssertThrow(false, ExcNotImplemented());
@@ -2020,8 +2019,8 @@ namespace TrilinosWrappers
 
 
   template <typename VectorType>
-  typename std::enable_if<
-    std::is_same<typename VectorType::value_type, TrilinosScalar>::value>::type
+  std::enable_if_t<
+    std::is_same<typename VectorType::value_type, TrilinosScalar>::value>
   SparseMatrix::Tvmult(VectorType &dst, const VectorType &src) const
   {
     Assert(&src != &dst, ExcSourceEqualsDestination());
@@ -2051,8 +2050,8 @@ namespace TrilinosWrappers
 
 
   template <typename VectorType>
-  typename std::enable_if<
-    !std::is_same<typename VectorType::value_type, TrilinosScalar>::value>::type
+  std::enable_if_t<
+    !std::is_same<typename VectorType::value_type, TrilinosScalar>::value>
   SparseMatrix::Tvmult(VectorType & /*dst*/, const VectorType & /*src*/) const
   {
     AssertThrow(false, ExcNotImplemented());

--- a/tests/base/hdf5_03.cc
+++ b/tests/base/hdf5_03.cc
@@ -29,9 +29,8 @@
 
 // This function initializes a container of Number type
 template <template <class...> class Container, typename Number>
-typename std::enable_if<
-  std::is_same<Container<Number>, std::vector<Number>>::value,
-  Container<Number>>::type
+std::enable_if_t<std::is_same<Container<Number>, std::vector<Number>>::value,
+                 Container<Number>>
 initialize_container(std::vector<hsize_t> dimensions)
 {
   return Container<Number>(std::accumulate(
@@ -39,8 +38,8 @@ initialize_container(std::vector<hsize_t> dimensions)
 }
 
 template <template <class...> class Container, typename Number>
-typename std::enable_if<std::is_same<Container<Number>, Vector<Number>>::value,
-                        Container<Number>>::type
+std::enable_if_t<std::is_same<Container<Number>, Vector<Number>>::value,
+                 Container<Number>>
 initialize_container(std::vector<hsize_t> dimensions)
 {
   return Container<Number>(std::accumulate(
@@ -48,9 +47,8 @@ initialize_container(std::vector<hsize_t> dimensions)
 }
 
 template <template <class...> class Container, typename Number>
-typename std::enable_if<
-  std::is_same<Container<Number>, FullMatrix<Number>>::value,
-  Container<Number>>::type
+std::enable_if_t<std::is_same<Container<Number>, FullMatrix<Number>>::value,
+                 Container<Number>>
 initialize_container(std::vector<hsize_t> dimensions)
 {
   return FullMatrix<Number>(dimensions[0], dimensions[1]);
@@ -58,26 +56,23 @@ initialize_container(std::vector<hsize_t> dimensions)
 
 // This function calculates the sum of the elements in a container
 template <template <class...> class Container, typename Number>
-typename std::enable_if<
-  std::is_same<Container<Number>, std::vector<Number>>::value,
-  Number>::type
+std::enable_if_t<std::is_same<Container<Number>, std::vector<Number>>::value,
+                 Number>
 container_sum(Container<Number> data)
 {
   return std::accumulate(data.begin(), data.end(), static_cast<Number>(0));
 }
 
 template <template <class...> class Container, typename Number>
-typename std::enable_if<std::is_same<Container<Number>, Vector<Number>>::value,
-                        Number>::type
+std::enable_if_t<std::is_same<Container<Number>, Vector<Number>>::value, Number>
 container_sum(Container<Number> data)
 {
   return std::accumulate(data.begin(), data.end(), static_cast<Number>(0));
 }
 
 template <template <class...> class Container, typename Number>
-typename std::enable_if<
-  std::is_same<Container<Number>, FullMatrix<Number>>::value,
-  Number>::type
+std::enable_if_t<std::is_same<Container<Number>, FullMatrix<Number>>::value,
+                 Number>
 container_sum(Container<Number> data)
 {
   Number sum = 0;
@@ -96,14 +91,14 @@ container_sum(Container<Number> data)
 // If Number is scalar the function returns 1
 // If Number is complex the function returns 1 + 1j
 template <typename Number>
-typename std::enable_if<!boost::is_complex<Number>::value, Number>::type
+std::enable_if_t<!boost::is_complex<Number>::value, Number>
 get_factor()
 {
   return 1;
 }
 
 template <typename Number>
-typename std::enable_if<boost::is_complex<Number>::value, Number>::type
+std::enable_if_t<boost::is_complex<Number>::value, Number>
 get_factor()
 {
   return static_cast<Number>(std::complex<float>(1, 1));
@@ -111,9 +106,8 @@ get_factor()
 
 // This function assigns data to the elements of the container
 template <template <class...> class Container, typename Number>
-typename std::enable_if<
-  std::is_same<Container<Number>, std::vector<Number>>::value,
-  void>::type
+std::enable_if_t<std::is_same<Container<Number>, std::vector<Number>>::value,
+                 void>
 assign_data(Container<Number> &data)
 {
   for (unsigned int idx = 0; idx < data.size(); ++idx)
@@ -123,8 +117,7 @@ assign_data(Container<Number> &data)
 }
 
 template <template <class...> class Container, typename Number>
-typename std::enable_if<std::is_same<Container<Number>, Vector<Number>>::value,
-                        void>::type
+std::enable_if_t<std::is_same<Container<Number>, Vector<Number>>::value, void>
 assign_data(Container<Number> &data)
 {
   for (unsigned int idx = 0; idx < data.size(); ++idx)
@@ -134,9 +127,8 @@ assign_data(Container<Number> &data)
 }
 
 template <template <class...> class Container, typename Number>
-typename std::enable_if<
-  std::is_same<Container<Number>, FullMatrix<Number>>::value,
-  void>::type
+std::enable_if_t<std::is_same<Container<Number>, FullMatrix<Number>>::value,
+                 void>
 assign_data(Container<Number> &data)
 {
   for (unsigned int row_idx = 0; row_idx < data.m(); ++row_idx)

--- a/tests/base/hdf5_04.cc
+++ b/tests/base/hdf5_04.cc
@@ -28,9 +28,8 @@
 
 // This function initializes a container of Number type
 template <template <class...> class Container, typename Number>
-typename std::enable_if<
-  std::is_same<Container<Number>, std::vector<Number>>::value,
-  Container<Number>>::type
+std::enable_if_t<std::is_same<Container<Number>, std::vector<Number>>::value,
+                 Container<Number>>
 initialize_container(std::vector<hsize_t> dimensions)
 {
   return Container<Number>(std::accumulate(
@@ -38,8 +37,8 @@ initialize_container(std::vector<hsize_t> dimensions)
 }
 
 template <template <class...> class Container, typename Number>
-typename std::enable_if<std::is_same<Container<Number>, Vector<Number>>::value,
-                        Container<Number>>::type
+std::enable_if_t<std::is_same<Container<Number>, Vector<Number>>::value,
+                 Container<Number>>
 initialize_container(std::vector<hsize_t> dimensions)
 {
   return Container<Number>(std::accumulate(
@@ -47,9 +46,8 @@ initialize_container(std::vector<hsize_t> dimensions)
 }
 
 template <template <class...> class Container, typename Number>
-typename std::enable_if<
-  std::is_same<Container<Number>, FullMatrix<Number>>::value,
-  Container<Number>>::type
+std::enable_if_t<std::is_same<Container<Number>, FullMatrix<Number>>::value,
+                 Container<Number>>
 initialize_container(std::vector<hsize_t> dimensions)
 {
   return FullMatrix<Number>(dimensions[0], dimensions[1]);
@@ -57,26 +55,23 @@ initialize_container(std::vector<hsize_t> dimensions)
 
 // This function calculates the sum of the elements in a container
 template <template <class...> class Container, typename Number>
-typename std::enable_if<
-  std::is_same<Container<Number>, std::vector<Number>>::value,
-  Number>::type
+std::enable_if_t<std::is_same<Container<Number>, std::vector<Number>>::value,
+                 Number>
 container_sum(Container<Number> data)
 {
   return std::accumulate(data.begin(), data.end(), static_cast<Number>(0));
 }
 
 template <template <class...> class Container, typename Number>
-typename std::enable_if<std::is_same<Container<Number>, Vector<Number>>::value,
-                        Number>::type
+std::enable_if_t<std::is_same<Container<Number>, Vector<Number>>::value, Number>
 container_sum(Container<Number> data)
 {
   return std::accumulate(data.begin(), data.end(), static_cast<Number>(0));
 }
 
 template <template <class...> class Container, typename Number>
-typename std::enable_if<
-  std::is_same<Container<Number>, FullMatrix<Number>>::value,
-  Number>::type
+std::enable_if_t<std::is_same<Container<Number>, FullMatrix<Number>>::value,
+                 Number>
 container_sum(Container<Number> data)
 {
   Number sum = 0;
@@ -95,14 +90,14 @@ container_sum(Container<Number> data)
 // If Number is scalar the function returns 1
 // If Number is complex the function returns 1 + 1j
 template <typename Number>
-typename std::enable_if<!boost::is_complex<Number>::value, Number>::type
+std::enable_if_t<!boost::is_complex<Number>::value, Number>
 get_factor()
 {
   return 1;
 }
 
 template <typename Number>
-typename std::enable_if<boost::is_complex<Number>::value, Number>::type
+std::enable_if_t<boost::is_complex<Number>::value, Number>
 get_factor()
 {
   return static_cast<Number>(std::complex<float>(1, 1));
@@ -110,9 +105,8 @@ get_factor()
 
 // This function assigns data to the elements of the container
 template <template <class...> class Container, typename Number>
-typename std::enable_if<
-  std::is_same<Container<Number>, std::vector<Number>>::value,
-  void>::type
+std::enable_if_t<std::is_same<Container<Number>, std::vector<Number>>::value,
+                 void>
 assign_data(Container<Number> &data)
 {
   for (unsigned int idx = 0; idx < data.size(); ++idx)
@@ -122,8 +116,7 @@ assign_data(Container<Number> &data)
 }
 
 template <template <class...> class Container, typename Number>
-typename std::enable_if<std::is_same<Container<Number>, Vector<Number>>::value,
-                        void>::type
+std::enable_if_t<std::is_same<Container<Number>, Vector<Number>>::value, void>
 assign_data(Container<Number> &data)
 {
   for (unsigned int idx = 0; idx < data.size(); ++idx)
@@ -133,9 +126,8 @@ assign_data(Container<Number> &data)
 }
 
 template <template <class...> class Container, typename Number>
-typename std::enable_if<
-  std::is_same<Container<Number>, FullMatrix<Number>>::value,
-  void>::type
+std::enable_if_t<std::is_same<Container<Number>, FullMatrix<Number>>::value,
+                 void>
 assign_data(Container<Number> &data)
 {
   for (unsigned int row_idx = 0; row_idx < data.m(); ++row_idx)

--- a/tests/base/hdf5_05.cc
+++ b/tests/base/hdf5_05.cc
@@ -31,9 +31,8 @@
 
 // This function initializes a container of Number type
 template <template <class...> class Container, typename Number>
-typename std::enable_if<
-  std::is_same<Container<Number>, std::vector<Number>>::value,
-  Container<Number>>::type
+std::enable_if_t<std::is_same<Container<Number>, std::vector<Number>>::value,
+                 Container<Number>>
 initialize_container(std::vector<hsize_t> dimensions)
 {
   return Container<Number>(std::accumulate(
@@ -43,8 +42,8 @@ initialize_container(std::vector<hsize_t> dimensions)
 
 
 template <template <class...> class Container, typename Number>
-typename std::enable_if<std::is_same<Container<Number>, Vector<Number>>::value,
-                        Container<Number>>::type
+std::enable_if_t<std::is_same<Container<Number>, Vector<Number>>::value,
+                 Container<Number>>
 initialize_container(std::vector<hsize_t> dimensions)
 {
   return Container<Number>(std::accumulate(
@@ -54,9 +53,8 @@ initialize_container(std::vector<hsize_t> dimensions)
 
 
 template <template <class...> class Container, typename Number>
-typename std::enable_if<
-  std::is_same<Container<Number>, FullMatrix<Number>>::value,
-  Container<Number>>::type
+std::enable_if_t<std::is_same<Container<Number>, FullMatrix<Number>>::value,
+                 Container<Number>>
 initialize_container(std::vector<hsize_t> dimensions)
 {
   return FullMatrix<Number>(dimensions[0], dimensions[1]);
@@ -66,9 +64,8 @@ initialize_container(std::vector<hsize_t> dimensions)
 
 // This function assigns data to the elements of the container
 template <template <class...> class Container, typename Number>
-typename std::enable_if<
-  std::is_same<Container<Number>, std::vector<Number>>::value,
-  void>::type
+std::enable_if_t<std::is_same<Container<Number>, std::vector<Number>>::value,
+                 void>
 assign_data(Container<Number> &data)
 {
   for (unsigned int idx = 0; idx < data.size(); ++idx)
@@ -80,8 +77,7 @@ assign_data(Container<Number> &data)
 
 
 template <template <class...> class Container, typename Number>
-typename std::enable_if<std::is_same<Container<Number>, Vector<Number>>::value,
-                        void>::type
+std::enable_if_t<std::is_same<Container<Number>, Vector<Number>>::value, void>
 assign_data(Container<Number> &data)
 {
   for (unsigned int idx = 0; idx < data.size(); ++idx)
@@ -93,9 +89,8 @@ assign_data(Container<Number> &data)
 
 
 template <template <class...> class Container, typename Number>
-typename std::enable_if<
-  std::is_same<Container<Number>, FullMatrix<Number>>::value,
-  void>::type
+std::enable_if_t<std::is_same<Container<Number>, FullMatrix<Number>>::value,
+                 void>
 assign_data(Container<Number> &data)
 {
   for (unsigned int row_idx = 0; row_idx < data.m(); ++row_idx)

--- a/tests/base/hdf5_06.cc
+++ b/tests/base/hdf5_06.cc
@@ -31,9 +31,8 @@
 
 // This function initializes a container of Number type
 template <template <class...> class Container, typename Number>
-typename std::enable_if<
-  std::is_same<Container<Number>, std::vector<Number>>::value,
-  Container<Number>>::type
+std::enable_if_t<std::is_same<Container<Number>, std::vector<Number>>::value,
+                 Container<Number>>
 initialize_container(std::vector<hsize_t> dimensions)
 {
   return Container<Number>(std::accumulate(
@@ -43,8 +42,8 @@ initialize_container(std::vector<hsize_t> dimensions)
 
 
 template <template <class...> class Container, typename Number>
-typename std::enable_if<std::is_same<Container<Number>, Vector<Number>>::value,
-                        Container<Number>>::type
+std::enable_if_t<std::is_same<Container<Number>, Vector<Number>>::value,
+                 Container<Number>>
 initialize_container(std::vector<hsize_t> dimensions)
 {
   return Container<Number>(std::accumulate(
@@ -54,9 +53,8 @@ initialize_container(std::vector<hsize_t> dimensions)
 
 
 template <template <class...> class Container, typename Number>
-typename std::enable_if<
-  std::is_same<Container<Number>, FullMatrix<Number>>::value,
-  Container<Number>>::type
+std::enable_if_t<std::is_same<Container<Number>, FullMatrix<Number>>::value,
+                 Container<Number>>
 initialize_container(std::vector<hsize_t> dimensions)
 {
   return FullMatrix<Number>(dimensions[0], dimensions[1]);
@@ -66,9 +64,8 @@ initialize_container(std::vector<hsize_t> dimensions)
 
 // This function assigns data to the elements of the container
 template <template <class...> class Container, typename Number>
-typename std::enable_if<
-  std::is_same<Container<Number>, std::vector<Number>>::value,
-  void>::type
+std::enable_if_t<std::is_same<Container<Number>, std::vector<Number>>::value,
+                 void>
 assign_data(Container<Number> &data)
 {
   for (unsigned int idx = 0; idx < data.size(); ++idx)
@@ -80,8 +77,7 @@ assign_data(Container<Number> &data)
 
 
 template <template <class...> class Container, typename Number>
-typename std::enable_if<std::is_same<Container<Number>, Vector<Number>>::value,
-                        void>::type
+std::enable_if_t<std::is_same<Container<Number>, Vector<Number>>::value, void>
 assign_data(Container<Number> &data)
 {
   for (unsigned int idx = 0; idx < data.size(); ++idx)
@@ -93,9 +89,8 @@ assign_data(Container<Number> &data)
 
 
 template <template <class...> class Container, typename Number>
-typename std::enable_if<
-  std::is_same<Container<Number>, FullMatrix<Number>>::value,
-  void>::type
+std::enable_if_t<std::is_same<Container<Number>, FullMatrix<Number>>::value,
+                 void>
 assign_data(Container<Number> &data)
 {
   for (unsigned int row_idx = 0; row_idx < data.m(); ++row_idx)

--- a/tests/mpi/fe_tools_extrapolate_common.h
+++ b/tests/mpi/fe_tools_extrapolate_common.h
@@ -131,14 +131,14 @@ output_vector(const VectorType &     v,
 
 
 template <typename VectorType>
-typename std::enable_if<!IsBlockVector<VectorType>::value, VectorType>::type
+std::enable_if_t<!IsBlockVector<VectorType>::value, VectorType>
 build_ghosted(const IndexSet &owned_indices, const IndexSet &ghosted_indices)
 {
   return VectorType(owned_indices, ghosted_indices, MPI_COMM_WORLD);
 }
 
 template <typename VectorType>
-typename std::enable_if<IsBlockVector<VectorType>::value, VectorType>::type
+std::enable_if_t<IsBlockVector<VectorType>::value, VectorType>
 build_ghosted(const IndexSet &owned_indices, const IndexSet &ghosted_indices)
 {
   std::vector<IndexSet> owned_indices_vector(1, owned_indices);
@@ -151,14 +151,14 @@ build_ghosted(const IndexSet &owned_indices, const IndexSet &ghosted_indices)
 
 
 template <typename VectorType>
-typename std::enable_if<!IsBlockVector<VectorType>::value, VectorType>::type
+std::enable_if_t<!IsBlockVector<VectorType>::value, VectorType>
 build_distributed(const IndexSet &owned_indices)
 {
   return VectorType(owned_indices, MPI_COMM_WORLD);
 }
 
 template <typename VectorType>
-typename std::enable_if<IsBlockVector<VectorType>::value, VectorType>::type
+std::enable_if_t<IsBlockVector<VectorType>::value, VectorType>
 build_distributed(const IndexSet &owned_indices)
 {
   std::vector<IndexSet> owned_indices_vector(1, owned_indices);

--- a/tests/tensors/symmetric_tensor_36.cc
+++ b/tests/tensors/symmetric_tensor_36.cc
@@ -34,8 +34,7 @@ template <int rank,
           class TensorType,
           typename NumberType1,
           typename NumberType2>
-typename std::enable_if<!std::is_constructible<NumberType1, NumberType2>::value,
-                        void>::type
+std::enable_if_t<!std::is_constructible<NumberType1, NumberType2>::value, void>
 test_tensor_constructor(const std::string &, const std::string &)
 {}
 
@@ -45,8 +44,7 @@ template <int rank,
           class TensorType,
           typename NumberType1,
           typename NumberType2>
-typename std::enable_if<std::is_constructible<NumberType1, NumberType2>::value,
-                        void>::type
+std::enable_if_t<std::is_constructible<NumberType1, NumberType2>::value, void>
 test_tensor_constructor(const std::string &type1, const std::string &type2)
 {
   deallog << "Rank " << rank << ", "

--- a/tests/tensors/symmetric_tensor_44.cc
+++ b/tests/tensors/symmetric_tensor_44.cc
@@ -131,7 +131,7 @@ template <template <int, int, typename> class TensorType1,
           template <int, int, typename>
           class TensorType2,
           typename NumberType2>
-typename std::enable_if<AreSame<TensorType1, TensorType2>::value>::type
+std::enable_if_t<AreSame<TensorType1, TensorType2>::value>
 test_two()
 {
   const unsigned int               dim = 2;
@@ -185,7 +185,7 @@ template <template <int, int, typename> class TensorType1,
           template <int, int, typename>
           class TensorType2,
           typename NumberType2>
-typename std::enable_if<!AreSame<TensorType1, TensorType2>::value>::type
+std::enable_if_t<!AreSame<TensorType1, TensorType2>::value>
 test_two()
 {}
 
@@ -194,8 +194,8 @@ template <template <int, int, typename> class TensorType1,
           template <int, int, typename>
           class TensorType2,
           typename NumberType2>
-typename std::enable_if<(AreSame<TensorType1, SymmetricTensor>::value &&
-                         AreSame<TensorType2, SymmetricTensor>::value)>::type
+std::enable_if_t<(AreSame<TensorType1, SymmetricTensor>::value &&
+                  AreSame<TensorType2, SymmetricTensor>::value)>
 test_three()
 {
   const unsigned int               dim = 2;
@@ -219,8 +219,8 @@ template <template <int, int, typename> class TensorType1,
           template <int, int, typename>
           class TensorType2,
           typename NumberType2>
-typename std::enable_if<!(AreSame<TensorType1, SymmetricTensor>::value &&
-                          AreSame<TensorType2, SymmetricTensor>::value)>::type
+std::enable_if_t<!(AreSame<TensorType1, SymmetricTensor>::value &&
+                   AreSame<TensorType2, SymmetricTensor>::value)>
 test_three()
 {}
 


### PR DESCRIPTION
The latter avoids the `typename ...::type` and just makes the code more concise. `std::enable_if_t` was introduced in C++14.

/rebuild