### PR TITLE
matrix-free FEEvaluation: initialize with nan

### DIFF
--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -836,8 +836,8 @@ namespace numbers
   values_are_equal(const adouble &value_1, const Number &value_2)
   {
     // Use the specialized definition for two ADOL-C taped types
-    return values_are_equal(value_1,
-                            internal::NumberType<adouble>::value(value_2));
+    return values_are_equal(
+      value_1, dealii::internal::NumberType<adouble>::value(value_2));
   }
 
 
@@ -892,7 +892,7 @@ namespace numbers
   {
     // Use the specialized definition for two ADOL-C taped types
     return value_is_less_than(value_1,
-                              internal::NumberType<adouble>::value(value_2));
+                              ::internal::NumberType<adouble>::value(value_2));
   }
 
 
@@ -912,8 +912,8 @@ namespace numbers
   value_is_less_than(const Number &value_1, const adouble &value_2)
   {
     // Use the specialized definition for two ADOL-C taped types
-    return value_is_less_than(internal::NumberType<adouble>::value(value_1),
-                              value_2);
+    return value_is_less_than(
+      dealii::internal::NumberType<adouble>::value(value_1), value_2);
   }
 
 #endif
@@ -923,7 +923,7 @@ namespace numbers
   constexpr bool
   values_are_equal(const Number1 &value_1, const Number2 &value_2)
   {
-    return (value_1 == internal::NumberType<Number1>::value(value_2));
+    return (value_1 == dealii::internal::NumberType<Number1>::value(value_2));
   }
 
 
@@ -947,7 +947,7 @@ namespace numbers
   inline bool
   value_is_less_than(const Number1 &value_1, const Number2 &value_2)
   {
-    return (value_1 < internal::NumberType<Number1>::value(value_2));
+    return (value_1 < dealii::internal::NumberType<Number1>::value(value_2));
   }
 
 

--- a/include/deal.II/matrix_free/fe_evaluation_data.h
+++ b/include/deal.II/matrix_free/fe_evaluation_data.h
@@ -23,6 +23,7 @@
 #include <deal.II/base/array_view.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/geometry_info.h>
+#include <deal.II/base/signaling_nan.h>
 #include <deal.II/base/smartpointer.h>
 #include <deal.II/base/std_cxx20/iota_view.h>
 #include <deal.II/base/symmetric_tensor.h>
@@ -1219,7 +1220,13 @@ FEEvaluationData<dim, Number, is_face>::set_data_pointers(
      n_quadrature_points);
 
   const unsigned int allocated_size = size_scratch_data + size_data_arrays;
+#  ifdef DEBUG
+  scratch_data_array->clear();
+  scratch_data_array->resize(allocated_size,
+                             Number(numbers::signaling_nan<ScalarNumber>()));
+#  else
   scratch_data_array->resize_fast(allocated_size);
+#  endif
   scratch_data.reinit(scratch_data_array->begin() + size_data_arrays,
                       size_scratch_data);
 


### PR DESCRIPTION
Initialize the internal scratch_data of FEEvaluation with signaling_nans
in debug mode.