### PR TITLE
MatrixFree: Use separate data arrays for two separate evaluators

### DIFF
--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -2101,11 +2101,10 @@ namespace internal
         FEEvaluationData<dim, VectorizedDouble, true> eval_ext(shape_info,
                                                                false);
 
-        // Let both evaluators use the same array as their use will not
-        // overlap
-        AlignedVector<VectorizedDouble> evaluation_data;
-        eval_int.set_data_pointers(&evaluation_data, dim);
-        eval_ext.set_data_pointers(&evaluation_data, dim);
+        AlignedVector<VectorizedDouble> evaluation_data_int,
+          evaluation_data_ext;
+        eval_int.set_data_pointers(&evaluation_data_int, dim);
+        eval_ext.set_data_pointers(&evaluation_data_ext, dim);
 
         for (unsigned int face = begin_face; face < end_face; ++face)
           for (unsigned vv = 0; vv < n_lanes; vv += n_lanes_d)


### PR DESCRIPTION
As discussed in https://github.com/dealii/dealii/pull/14152#issuecomment-1190477690, we should use two separate arrays for two evaluators. Their use does not overlap, so the old code was not wrong, but if we decide to re-allocate memory on the second evaluator for some reason in the future, the first one will have pointers to free'd memory.