### PR TITLE
[9.4] Make ConsensusAlgorithm deprecations early-deprecated instead.

### DIFF
--- a/include/deal.II/base/mpi_consensus_algorithms.h
+++ b/include/deal.II/base/mpi_consensus_algorithms.h
@@ -250,7 +250,7 @@ namespace Utilities
          *   the default constructor of this class along with the run()
          *   function that takes an argument.
          */
-        DEAL_II_DEPRECATED
+        DEAL_II_DEPRECATED_EARLY
         Interface(Process<RequestType, AnswerType> &process,
                   const MPI_Comm &                  comm);
 
@@ -269,7 +269,7 @@ namespace Utilities
          *   been provided to the non-default constructor. Use the run()
          *   functions taking arguments instead.
          */
-        DEAL_II_DEPRECATED
+        DEAL_II_DEPRECATED_EARLY
         std::vector<unsigned int>
         run();
 
@@ -325,7 +325,7 @@ namespace Utilities
          * and the run() function without argument. It is a `nullptr`
          * otherwise
          */
-        DEAL_II_DEPRECATED
+        DEAL_II_DEPRECATED_EARLY
         Process<RequestType, AnswerType> *process;
 
         /**
@@ -334,7 +334,7 @@ namespace Utilities
          * This member variable is only used in the deprecated constructor
          * and the run() function without argument.
          */
-        DEAL_II_DEPRECATED
+        DEAL_II_DEPRECATED_EARLY
         MPI_Comm comm;
       };
 
@@ -373,7 +373,7 @@ namespace Utilities
          *   the default constructor of this class along with the run()
          *   function that takes an argument.
          */
-        DEAL_II_DEPRECATED
+        DEAL_II_DEPRECATED_EARLY
         NBX(Process<RequestType, AnswerType> &process, const MPI_Comm &comm);
 
         /**
@@ -617,7 +617,7 @@ namespace Utilities
          *   the default constructor of this class along with the run()
          *   function that takes an argument.
          */
-        DEAL_II_DEPRECATED
+        DEAL_II_DEPRECATED_EARLY
         PEX(Process<RequestType, AnswerType> &process, const MPI_Comm &comm);
 
         /**
@@ -830,7 +830,7 @@ namespace Utilities
          *   the default constructor of this class along with the run()
          *   function that takes an argument.
          */
-        DEAL_II_DEPRECATED
+        DEAL_II_DEPRECATED_EARLY
         Serial(Process<RequestType, AnswerType> &process, const MPI_Comm &comm);
 
         // Import the declarations from the base class.
@@ -962,7 +962,7 @@ namespace Utilities
          *   the default constructor of this class along with the run()
          *   function that takes an argument.
          */
-        DEAL_II_DEPRECATED
+        DEAL_II_DEPRECATED_EARLY
         Selector(Process<RequestType, AnswerType> &process,
                  const MPI_Comm &                  comm);
 
@@ -1083,7 +1083,7 @@ namespace Utilities
        * own implementation but can register lambda functions directly.
        */
       template <typename RequestType, typename AnswerType>
-      class DEAL_II_DEPRECATED AnonymousProcess
+      class DEAL_II_DEPRECATED_EARLY AnonymousProcess
         : public Process<RequestType, AnswerType>
       {
       public:


### PR DESCRIPTION
They should have always been early-deprecated. This is worth doing now (for 9.4.1) because these deprecation warnings show up when we include some headers (like mpi_noncontiguous_partitioner.h).

We only need to make this change on the release branch since everything (which would have included this) marked early-deprecated already got promoted to deprecated after we branched.