### PR TITLE
Bump the minimum PETSc version number.

### DIFF
--- a/cmake/configure/configure_30_petsc.cmake
+++ b/cmake/configure/configure_30_petsc.cmake
@@ -30,16 +30,15 @@ MACRO(FEATURE_PETSC_FIND_EXTERNAL var)
     SET(${var} TRUE)
 
     #
-    # We support petsc from version 3.3.x onwards
+    # We support petsc from version 3.7.x onwards
     #
-    IF(PETSC_VERSION_MAJOR LESS 3 OR
-        ((PETSC_VERSION_MAJOR EQUAL 3) AND (PETSC_VERSION_MINOR LESS 3)))
+    IF(${PETSC_VERSION} VERSION_LESS 3.7.0)
       MESSAGE(STATUS "Could not find a sufficiently modern PETSc installation: "
-        "Version >=3.3.0 required!"
+        "Version >=3.7.0 required!"
         )
       SET(PETSC_ADDITIONAL_ERROR_STRING
         "Could not find a sufficiently modern PETSc installation: "
-        "Version >=3.3.0 required!\n"
+        "Version >=3.7.0 required!\n"
         )
       SET(${var} FALSE)
     ENDIF()
@@ -121,7 +120,7 @@ ENDMACRO()
 MACRO(FEATURE_PETSC_CONFIGURE_EXTERNAL)
   SET(DEAL_II_EXPAND_PETSC_MPI_VECTOR "PETScWrappers::MPI::Vector")
   SET(DEAL_II_EXPAND_PETSC_MPI_BLOCKVECTOR "PETScWrappers::MPI::BlockVector")
-  SET(DEAL_II_EXPAND_PETSC_SPARSE_MATRICES 
+  SET(DEAL_II_EXPAND_PETSC_SPARSE_MATRICES
       "PETScWrappers::SparseMatrix"
       "PETScWrappers::MPI::SparseMatrix"
       "PETScWrappers::MPI::BlockSparseMatrix")
@@ -141,7 +140,7 @@ MACRO(FEATURE_PETSC_ERROR_MESSAGE)
   MESSAGE(FATAL_ERROR "\n"
     "Could not find the petsc library!\n"
     ${PETSC_ADDITIONAL_ERROR_STRING}
-    "\nPlease ensure that the petsc library version 3.3.0 or newer is "
+    "\nPlease ensure that the petsc library version 3.7.0 or newer is "
     "installed on your computer and is configured with the same mpi options "
     "as deal.II\n"
     "If the library is not at a default location, either provide some hints\n"

--- a/doc/external-libs/petsc.html
+++ b/doc/external-libs/petsc.html
@@ -40,7 +40,7 @@
       <acronym>deal.II</acronym> is version 3.17.1. If you use a later
       version than this and encounter problems, let us
       know. <acronym>deal.II</acronym> does not support versions of PETSc prior
-      to 3.3.0.
+      to 3.7.0.
     </p>
 
     <p>

--- a/doc/news/changes/incompatibilities/20220727Wells
+++ b/doc/news/changes/incompatibilities/20220727Wells
@@ -1,0 +1,4 @@
+Changed: The oldest supported version of PETSc has been increased from 3.3.0
+to 3.7.0.
+<br>
+(David Wells, 2022/07/27)

--- a/include/deal.II/lac/slepc_spectral_transformation.h
+++ b/include/deal.II/lac/slepc_spectral_transformation.h
@@ -203,9 +203,13 @@ namespace SLEPcWrappers
    * Spectrum Folding. This transformation type has been removed in SLEPc
    * 3.5.0 and thus cannot be used in the newer versions.
    *
+   * @deprecated Since deal.II requires PETSc 3.7 or newer this class no longer
+   * does anything.
+   *
    * @ingroup SLEPcWrappers
    */
-  class TransformationSpectrumFolding : public TransformationBase
+  class DEAL_II_DEPRECATED TransformationSpectrumFolding
+    : public TransformationBase
   {
   public:
     /**

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -337,18 +337,6 @@ namespace PETScWrappers
                           static_cast<PetscInt>(ghost_indices.n_elements()));
       }
 #  endif
-
-
-      // in PETSc versions up to 3.5, VecCreateGhost zeroed out the locally
-      // owned vector elements but forgot about the ghost elements. we need to
-      // do this ourselves
-      //
-      // see https://code.google.com/p/dealii/issues/detail?id=233
-#  if DEAL_II_PETSC_VERSION_LT(3, 6, 0)
-      PETScWrappers::MPI::Vector zero;
-      zero.reinit(communicator, this->size(), locally_owned_size);
-      *this = zero;
-#  endif
     }
 
 

--- a/source/lac/slepc_spectral_transformation.cc
+++ b/source/lac/slepc_spectral_transformation.cc
@@ -111,20 +111,12 @@ namespace SLEPcWrappers
     : TransformationBase(mpi_communicator)
     , additional_data(data)
   {
-#  if DEAL_II_PETSC_VERSION_LT(3, 5, 0)
-    PetscErrorCode ierr = STSetType(st, const_cast<char *>(STFOLD));
-    AssertThrow(ierr == 0, SolverBase::ExcSLEPcError(ierr));
-
-    ierr = STSetShift(st, additional_data.shift_parameter);
-    AssertThrow(ierr == 0, SolverBase::ExcSLEPcError(ierr));
-#  else
-    // PETSc/SLEPc version must be < 3.5.0.
-    (void)st;
-    Assert((false),
+    // This feature is only in PETSc/SLEPc versions 3.4 or older, which we no
+    // longer support.
+    Assert(false,
            ExcMessage(
              "Folding transformation has been removed in SLEPc 3.5.0 and newer."
              " You cannot use this transformation anymore."));
-#  endif
   }
 
   /* ------------------- TransformationCayley --------------------- */


### PR DESCRIPTION
Increasing the minimum version number lets us clean up a bunch of old workarounds.