### PR TITLE
Fix a typo in deal.II/base/numbers.h

### DIFF
--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -891,8 +891,8 @@ namespace numbers
   value_is_less_than(const adouble &value_1, const Number &value_2)
   {
     // Use the specialized definition for two ADOL-C taped types
-    return value_is_less_than(value_1,
-                              ::internal::NumberType<adouble>::value(value_2));
+    return value_is_less_than(
+      value_1, dealii::internal::NumberType<adouble>::value(value_2));
   }
 
 


### PR DESCRIPTION
The refactoring done in b1883d9cbf2dfa8452ebb109d580096453f7e10f
introduced a typo that wasn't spotted by our CI. Fix this.