### PR TITLE
Fix various typos

### DIFF
--- a/doc/developers/testsuite.html
+++ b/doc/developers/testsuite.html
@@ -640,7 +640,7 @@ category/test.expect=run.output
 </pre>
     </p>
     <p>
-      The testsuite also suppors the special file ending
+      The testsuite also supports the special file ending
       <code>.run_only</code> that indicates that the diff stage should be
       skipped in order to reach the <code>PASSED</code> stage. You can
       specify the keyword by changing the file ending from

--- a/doc/doxygen/headers/automatic_and_symbolic_differentiation.h
+++ b/doc/doxygen/headers/automatic_and_symbolic_differentiation.h
@@ -200,7 +200,7 @@
  *
  * With the aid of the diagram below (it and some of the listed details courtesy of this
  * <a href="https://en.wikipedia.org/wiki/Automatic_differentiation">Wikipedia article</a>),
- * let us think about the represention of the calculation of the function
+ * let us think about the representation of the calculation of the function
  * $f (\mathbf{x}) = \sin (x_{1}) + x_{1} x_{2}$ and its derivatives:
  *
  * <div class="twocolumn" style="width: 80%">

--- a/doc/users/cmake_dealii.html
+++ b/doc/users/cmake_dealii.html
@@ -423,7 +423,7 @@ library        - builds and installs the 'library' component
       you want to override this behavior, please set the C++ standard
       directly for example by configuring with
       <code>-DDEAL_II_CXX_FLAGS="-std=c++17"</code>, or by setting the
-      environement variable <code>CXXFLAGS="-std=c++17"</code>.
+      environment variable <code>CXXFLAGS="-std=c++17"</code>.
 
       Similarly, for enabling SIMD vectorization support, you have to set
       an appropriate target architecture via <code>-march=...</code>, for

--- a/include/deal.II/cgal/triangulation.h
+++ b/include/deal.II/cgal/triangulation.h
@@ -368,7 +368,7 @@ namespace CGALWrappers
           // This is a degenerate Triangulation_2, made of edges
           for (const auto &e : cgal_triangulation.finite_edges())
             {
-              // An edge is idendified by a face and a vertex index in the
+              // An edge is identified by a face and a vertex index in the
               // face
               const auto &  f = e.first;
               const auto &  i = e.second;
@@ -408,7 +408,7 @@ namespace CGALWrappers
           // This is a degenerate Triangulation_3, made of triangles
           for (const auto &facet : cgal_triangulation.finite_facets())
             {
-              // A facet is idenfied by a cell and the opposite vertex index
+              // A facet is identified by a cell and the opposite vertex index
               // in the face
               const auto &  c = facet.first;
               const auto &  i = facet.second;
@@ -430,7 +430,7 @@ namespace CGALWrappers
           // This is a degenerate Triangulation_3, made of edges
           for (const auto &edge : cgal_triangulation.finite_edges())
             {
-              // An edge is idenfied by a cell and its two vertices
+              // An edge is identified by a cell and its two vertices
               const auto &[c, i, j] = edge;
               CellData<dim> cell(ReferenceCells::Line.n_vertices());
               cell.vertices[0] = vertex_map[c->vertex(i)];

--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -134,7 +134,7 @@ enum MappingKind
   /**
    * The mappings for 2-forms and third order tensors.
    *
-   * These are mappings typpically applied to hessians transformed to the
+   * These are mappings typically applied to hessians transformed to the
    * reference cell.
    *
    * Mapping of the hessian of a covariant vector field (see

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -4067,7 +4067,7 @@ private:
   reset_active_cell_indices();
 
   /**
-   * Reset global cell ids and globale level cell ids.
+   * Reset global cell ids and global level cell ids.
    */
   void
   reset_global_cell_indices();

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -252,7 +252,7 @@ namespace LinearAlgebra
     if (omit_zeroing_entries == false)
       this->operator=(Number());
 
-    // reset the communication patter
+    // reset the communication pattern
     source_stored_elements.clear();
     comm_pattern.reset();
   }
@@ -272,7 +272,7 @@ namespace LinearAlgebra
     if (omit_zeroing_entries == false)
       this->operator=(Number());
 
-    // reset the communication patter
+    // reset the communication pattern
     source_stored_elements.clear();
     comm_pattern.reset();
   }

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -503,7 +503,7 @@ public:
      * Such an example is "local time stepping", where cells of different
      * caterogries progress with different time-step sizes and, as a
      * consequence, can only processed together with cells with the same
-     * cateogry.
+     * category.
      *
      * This array is accessed by the number given by cell->active_cell_index()
      * when working on the active cells (with

--- a/include/deal.II/non_matching/fe_immersed_values.h
+++ b/include/deal.II/non_matching/fe_immersed_values.h
@@ -76,7 +76,7 @@ namespace NonMatching
     reinit(const typename Triangulation<dim>::cell_iterator &cell);
 
     /**
-     * Reinitialize quantitites (shape function values, gradients, etc) for the
+     * Reinitialize quantities (shape function values, gradients, etc) for the
      * given cell of type "iterator into a DoFHandler object", and the finite
      * element associated with this object.
      */

--- a/include/deal.II/opencascade/utilities.h
+++ b/include/deal.II/opencascade/utilities.h
@@ -142,7 +142,7 @@ namespace OpenCASCADE
    * mesh it automatically. We remark that the automatic mesh generation in
    * OpenCASCADE takes care only of the geometrical resemblance between the
    * shape and the mesh, to control the shape and regularity of the triangles
-   * you should use other meshing softwares. The two arguments `deflection` and
+   * you should use other meshing software. The two arguments `deflection` and
    * `angular_deflection` select the accuracy of the created triangulation with
    * respect to the original topological shape. The argument
    * `sew_different_faces` gives the possibility to use a Sewer from OpenCASCADE

--- a/include/deal.II/opencascade/utilities.h
+++ b/include/deal.II/opencascade/utilities.h
@@ -142,7 +142,7 @@ namespace OpenCASCADE
    * mesh it automatically. We remark that the automatic mesh generation in
    * OpenCASCADE takes care only of the geometrical resemblance between the
    * shape and the mesh, to control the shape and regularity of the triangles
-   * you should use other meshing software. The two arguments `deflection` and
+   * you should use other meshing softwares. The two arguments `deflection` and
    * `angular_deflection` select the accuracy of the created triangulation with
    * respect to the original topological shape. The argument
    * `sew_different_faces` gives the possibility to use a Sewer from OpenCASCADE

--- a/include/deal.II/optimization/line_minimization.h
+++ b/include/deal.II/optimization/line_minimization.h
@@ -251,7 +251,7 @@ namespace LineMinimization
    *
    *   // Next we can write a function to determine if taking the full Newton
    *   // step is a good idea or not (i.e. if it offers good convergence
-   *   // characterisics). This function calls the one we defined above,
+   *   // characteristics). This function calls the one we defined above,
    *   // and actually only performs the line search if an early exit
    *   // criterion is not met.
    *   auto perform_linesearch = [&]()

--- a/include/deal.II/particles/data_out.h
+++ b/include/deal.II/particles/data_out.h
@@ -35,7 +35,7 @@ namespace Particles
    * This class generates graphical output for the particles stored by a
    * ParticleHandler object. From a particle handler, it generates patches which
    * can then be used to write traditional output files. This class currently
-   * only supports witing the particle position and their ID and does not allow
+   * only supports writing the particle position and their ID and does not allow
    * to write the properties attached to the particles
    *
    * @ingroup Particle

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -304,7 +304,7 @@ namespace
           (is_parameter_node(b.second) || is_alias_node(b.second));
 
         // If a is a parameter/alias and b is a subsection,
-        // a should go first, and viceversa.
+        // a should go first, and vice-versa.
         if (a_is_param && !b_is_param)
           return true;
 

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -585,7 +585,7 @@ namespace
 
   public:
     /**
-     * Callback exectuted before point function. Last argument is always
+     * Callback executed before point function. Last argument is always
      * nullptr.
      *
      * @return `int` interpreted as a C "bool". Zero means "stop the recursion".

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -788,7 +788,7 @@ namespace internal
             (typename DoFHandler<dim, spacedim>::ExcOnlyAvailableWithHP()));
 
           // this function should only be called for dim<3 where there are
-          // no quad dof identies. for dim==3, the specialization below should
+          // no quad dof identities. for dim==3, the specialization below should
           // take care of it
           Assert(dim < 3, ExcInternalError());
 
@@ -1518,7 +1518,7 @@ namespace internal
             (typename DoFHandler<dim, spacedim>::ExcOnlyAvailableWithHP()));
 
           // this function should only be called for dim<3 where there are
-          // no quad dof identies. for dim>=3, the specialization below should
+          // no quad dof identities. for dim>=3, the specialization below should
           // take care of it
           Assert(dim < 3, ExcInternalError());
         }

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -1535,7 +1535,7 @@ void
 FESystem<dim, spacedim>::build_interface_constraints()
 {
   // check whether all base elements implement their interface constraint
-  // matrices. if this is not the case, then leave the interface costraints of
+  // matrices. if this is not the case, then leave the interface constraints of
   // this composed element empty as well; however, the rest of the element is
   // usable
   for (unsigned int base = 0; base < this->n_base_elements(); ++base)

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -6443,7 +6443,7 @@ namespace GridTools
     std::map<unsigned int, std::vector<unsigned int>> &coinciding_vertex_groups,
     std::map<unsigned int, unsigned int> &vertex_to_coinciding_vertex_group)
   {
-    // 1) determine for each vertex a vertex it concides with and
+    // 1) determine for each vertex a vertex it coincides with and
     //    put it into a map
     {
       static const int lookup_table_2d[2][2] =

--- a/source/grid/grid_tools_nontemplates.cc
+++ b/source/grid/grid_tools_nontemplates.cc
@@ -96,7 +96,7 @@ namespace GridTools
 
       # C(measure, optimized);
 
-      additional optimizaton: divide by 2 only one time
+      additional optimization: divide by 2 only one time
     */
 
     const double x[4] = {all_vertices[vertex_indices[0]](0),

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -13288,7 +13288,7 @@ Triangulation<dim, spacedim>::end(const unsigned int level) const
 {
   // This function may be called on parallel triangulations on levels
   // that exist globally, but not on the local portion of the
-  // triangulation. In that case, just retrn the end iterator.
+  // triangulation. In that case, just return the end iterator.
   //
   // We need to use levels.size() instead of n_levels() because the
   // latter function uses the cache, but we need to be able to call

--- a/source/lac/cuda_vector.cu
+++ b/source/lac/cuda_vector.cu
@@ -592,7 +592,7 @@ namespace LinearAlgebra
       Assert(dynamic_cast<const Vector<Number> *>(&W) != nullptr,
              ExcVectorTypeNotCompatible());
 
-      // Downcast V and W. If it fails, throw an exceptiion.
+      // Downcast V and W. If it fails, throw an exception.
       const Vector<Number> &down_V = dynamic_cast<const Vector<Number> &>(V);
       Assert(down_V.size() == this->size(),
              ExcMessage("Vector V has the wrong size."));

--- a/source/opencascade/utilities.cc
+++ b/source/opencascade/utilities.cc
@@ -867,7 +867,7 @@ namespace OpenCASCADE
     Standard_Real Max_Curvature = props.MaxCurvature();
     Tensor<1, 3>  normal        = Point<3>(Normal.X(), Normal.Y(), Normal.Z());
 
-    // In the case your manifold changes from convex to concave or viceversa
+    // In the case your manifold changes from convex to concave or vice-versa
     // the normal could jump from "inner" to "outer" normal.
     // However, you should be able to change the normal sense preserving
     // the manifold orientation:

--- a/source/particles/generators.cc
+++ b/source/particles/generators.cc
@@ -361,7 +361,7 @@ namespace Particles
           std::llround(static_cast<double>(n_particles_to_create) *
                        local_start_weight / global_weight_integral);
 
-        // Calcualate number of local particles
+        // Calculate number of local particles
         const types::particle_index end_particle_id =
           std::llround(static_cast<double>(n_particles_to_create) *
                        ((local_start_weight + local_weight_integral) /


### PR DESCRIPTION
Fix typos found in source/, include/, and doc/  
Found via `codespell -q 3 -S ./bundled,./doc/news -L ba,commend,nd,pres,ro,rotat,stoer,workd`