### PR TITLE
Added hp::Refinement::copy_future_fe_indices().

### DIFF
--- a/doc/news/changes/minor/20220802Fehling
+++ b/doc/news/changes/minor/20220802Fehling
@@ -1,0 +1,4 @@
+New: Function hp::Refinement::copy_future_fe_indices() that copies
+future FE indices from one DoFHandler to another.
+<br>
+(Marc Fehling, 2022/08/02)

--- a/include/deal.II/hp/refinement.h
+++ b/include/deal.II/hp/refinement.h
@@ -720,6 +720,23 @@ namespace hp
       const unsigned int                       contains_fe_index = 0);
 
     /**
+     * Transfer all future FE indices from the DoFHandler object
+     * @p dof_handler_source to the object @p dof_handler_destination.
+     *
+     * Both @p dof_handler_source and @p dof_handler_destination must have been
+     * assigned to the same Triangulation object.
+     *
+     * Returns the number of future FE indices that have been copied on the
+     * locally owned subdomain. In a MPI universe, use Utilities::MPI::sum() if
+     * you want to compute the number of indices that changed on the global
+     * mesh.
+     */
+    template <int dim, int spacedim>
+    unsigned int
+    copy_future_fe_indices(const DoFHandler<dim, spacedim> &dof_handler_source,
+                           DoFHandler<dim, spacedim> &dof_handler_destination);
+
+    /**
      * @}
      */
   } // namespace Refinement

--- a/source/hp/refinement.cc
+++ b/source/hp/refinement.cc
@@ -1059,6 +1059,38 @@ namespace hp
 
       return levels_changed;
     }
+
+
+
+    template <int dim, int spacedim>
+    unsigned int
+    copy_future_fe_indices(const DoFHandler<dim, spacedim> &dof_handler_source,
+                           DoFHandler<dim, spacedim> &dof_handler_destination)
+    {
+      Assert(dof_handler_source.get_triangulation().n_active_cells() ==
+               dof_handler_destination.get_triangulation().n_active_cells(),
+             ExcMessage(
+               "Both DoFHandler objects must work on the same Triangulation!"));
+
+      typename DoFHandler<dim, spacedim>::active_cell_iterator cell_destination;
+
+      unsigned int count_changed_indices = 0;
+      for (const auto &cell_source : dof_handler_source.active_cell_iterators())
+        if (cell_source->is_locally_owned() &&
+            cell_source->future_fe_index_set())
+          {
+            cell_destination =
+              cell_source->as_dof_handler_iterator(dof_handler_destination);
+
+            Assert(cell_destination->is_locally_owned(), ExcInternalError());
+
+            cell_destination->set_future_fe_index(
+              cell_source->future_fe_index());
+            ++count_changed_indices;
+          }
+
+      return count_changed_indices;
+    }
   } // namespace Refinement
 } // namespace hp
 

--- a/source/hp/refinement.inst.in
+++ b/source/hp/refinement.inst.in
@@ -49,6 +49,11 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
             &,
           const unsigned int,
           const unsigned int);
+
+        template unsigned int
+        copy_future_fe_indices<deal_II_dimension, deal_II_space_dimension>(
+          const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+          DoFHandler<deal_II_dimension, deal_II_space_dimension> &);
       \}
     \}
 #endif

--- a/tests/mpi/hp_copy_future_fe_indices_01.cc
+++ b/tests/mpi/hp_copy_future_fe_indices_01.cc
@@ -1,0 +1,87 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Check functionality of hp::Refinement::copy_future_fe_indices.
+
+
+#include <deal.II/base/mpi.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/hp/refinement.h>
+
+#include "../tests.h"
+
+#include "../test_grids.h"
+
+
+template <int dim, int spacedim>
+void
+test()
+{
+  MPI_Comm mpi_comm = MPI_COMM_WORLD;
+
+  const unsigned int n_procs = Utilities::MPI::n_mpi_processes(mpi_comm);
+
+  parallel::distributed::Triangulation<dim, spacedim> tria(mpi_comm);
+  TestGrids::hyper_line(tria, n_procs);
+  tria.refine_global(1);
+
+  DoFHandler<dim, spacedim> dofh_src(tria);
+  DoFHandler<dim, spacedim> dofh_dst(tria);
+
+  // set future fe index on first cell of every process
+  for (const auto &cell : dofh_src.active_cell_iterators())
+    if (cell->is_locally_owned())
+      {
+        cell->set_future_fe_index(1);
+        break;
+      }
+
+
+  deallog << "indices copied: "
+          << hp::Refinement::copy_future_fe_indices(dofh_src, dofh_dst)
+          << std::endl;
+
+
+  for (const auto &cell : tria.active_cell_iterators())
+    if (cell->is_locally_owned())
+      {
+        const auto cell_src = cell->as_dof_handler_iterator(dofh_src);
+        const auto cell_dst = cell->as_dof_handler_iterator(dofh_dst);
+
+        AssertThrow(cell_src->future_fe_index_set() ==
+                      cell_dst->future_fe_index_set(),
+                    ExcInternalError());
+        AssertThrow(cell_src->future_fe_index() == cell_dst->future_fe_index(),
+                    ExcInternalError());
+      }
+
+  deallog << "OK" << std::endl;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPILogInitAll                    log;
+
+  test<2, 2>();
+}

--- a/tests/mpi/hp_copy_future_fe_indices_01.with_p4est=true.mpirun=2.output
+++ b/tests/mpi/hp_copy_future_fe_indices_01.with_p4est=true.mpirun=2.output
@@ -1,0 +1,7 @@
+
+DEAL:0::indices copied: 1
+DEAL:0::OK
+
+DEAL:1::indices copied: 1
+DEAL:1::OK
+


### PR DESCRIPTION
Functions that copies future FE indices from one DoFHandler to another. Useful when dealing with multiple DoFHandler objects for the same problem, for example, if you have one for Stokes and one for the temperature as in step-32.