### PR TITLE
Don't include Sacado.hpp in base/numbers.h.

### DIFF
--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -137,15 +137,6 @@ DEAL_II_NAMESPACE_CLOSE
 
 #  include <adolc/adouble.h> // Taped double
 #endif
-// Ideally we'd like to #include <deal.II/differentiation/ad/sacado_math.h>
-// but header indirectly references numbers.h. We therefore simply
-// import the whole Sacado header at this point to get the math
-// functions imported into the standard namespace.
-#ifdef DEAL_II_TRILINOS_WITH_SACADO
-DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
-#  include <Sacado.hpp>
-DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
-#endif
 
 namespace std
 {
@@ -608,7 +599,9 @@ namespace numbers
   typename NumberTraits<number>::real_type
   NumberTraits<number>::abs(const number &x)
   {
-    return std::abs(x);
+    // Make things work with AD types
+    using std::abs;
+    return abs(x);
   }
 
 
@@ -626,7 +619,9 @@ namespace numbers
   typename NumberTraits<std::complex<number>>::real_type
   NumberTraits<std::complex<number>>::abs(const std::complex<number> &x)
   {
-    return std::abs(x);
+    // Make things work with AD types
+    using std::abs;
+    return abs(x);
   }
 
 

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -1563,7 +1563,7 @@ namespace internal
         // whether we have to fear that the matrix is not regular.
         Number diagonal_sum = internal::NumberType<Number>::value(0.0);
         for (unsigned int i = 0; i < N; ++i)
-          diagonal_sum += std::fabs(tmp.data[i][i]);
+          diagonal_sum += numbers::NumberTraits<Number>::abs(tmp.data[i][i]);
         const Number typical_diagonal_element =
           diagonal_sum / static_cast<double>(N);
         (void)typical_diagonal_element;
@@ -1576,12 +1576,12 @@ namespace internal
           {
             // Pivot search: search that part of the line on and right of the
             // diagonal for the largest element.
-            Number       max = std::fabs(tmp.data[j][j]);
-            unsigned int r   = j;
+            Number max     = numbers::NumberTraits<Number>::abs(tmp.data[j][j]);
+            unsigned int r = j;
             for (unsigned int i = j + 1; i < N; ++i)
-              if (std::fabs(tmp.data[i][j]) > max)
+              if (numbers::NumberTraits<Number>::abs(tmp.data[i][j]) > max)
                 {
-                  max = std::fabs(tmp.data[i][j]);
+                  max = numbers::NumberTraits<Number>::abs(tmp.data[i][j]);
                   r   = i;
                 }
 
@@ -2343,25 +2343,25 @@ namespace internal
   compute_norm(const typename SymmetricTensorAccessors::
                  StorageType<2, dim, Number>::base_tensor_type &data)
   {
+    // Make things work with AD types
+    using std::sqrt;
     switch (dim)
       {
         case 1:
           return numbers::NumberTraits<Number>::abs(data[0]);
 
         case 2:
-          return std::sqrt(
-            numbers::NumberTraits<Number>::abs_square(data[0]) +
-            numbers::NumberTraits<Number>::abs_square(data[1]) +
-            2. * numbers::NumberTraits<Number>::abs_square(data[2]));
+          return sqrt(numbers::NumberTraits<Number>::abs_square(data[0]) +
+                      numbers::NumberTraits<Number>::abs_square(data[1]) +
+                      2. * numbers::NumberTraits<Number>::abs_square(data[2]));
 
         case 3:
-          return std::sqrt(
-            numbers::NumberTraits<Number>::abs_square(data[0]) +
-            numbers::NumberTraits<Number>::abs_square(data[1]) +
-            numbers::NumberTraits<Number>::abs_square(data[2]) +
-            2. * numbers::NumberTraits<Number>::abs_square(data[3]) +
-            2. * numbers::NumberTraits<Number>::abs_square(data[4]) +
-            2. * numbers::NumberTraits<Number>::abs_square(data[5]));
+          return sqrt(numbers::NumberTraits<Number>::abs_square(data[0]) +
+                      numbers::NumberTraits<Number>::abs_square(data[1]) +
+                      numbers::NumberTraits<Number>::abs_square(data[2]) +
+                      2. * numbers::NumberTraits<Number>::abs_square(data[3]) +
+                      2. * numbers::NumberTraits<Number>::abs_square(data[4]) +
+                      2. * numbers::NumberTraits<Number>::abs_square(data[5]));
 
         default:
           {
@@ -2375,7 +2375,7 @@ namespace internal
               return_value +=
                 2. * numbers::NumberTraits<Number>::abs_square(data[d]);
 
-            return std::sqrt(return_value);
+            return sqrt(return_value);
           }
       }
   }
@@ -2387,6 +2387,8 @@ namespace internal
   compute_norm(const typename SymmetricTensorAccessors::
                  StorageType<4, dim, Number>::base_tensor_type &data)
   {
+    // Make things work with AD types
+    using std::sqrt;
     switch (dim)
       {
         case 1:
@@ -2416,7 +2418,7 @@ namespace internal
                 return_value +=
                   4. * numbers::NumberTraits<Number>::abs_square(data[i][j]);
 
-            return std::sqrt(return_value);
+            return sqrt(return_value);
           }
       }
   }

--- a/include/deal.II/base/symmetric_tensor.templates.h
+++ b/include/deal.II/base/symmetric_tensor.templates.h
@@ -45,6 +45,9 @@ template <typename Number>
 std::array<Number, 2>
 eigenvalues(const SymmetricTensor<2, 2, Number> &T)
 {
+  // Make things work with AD types
+  using std::sqrt;
+
   const Number upp_tri_sq = T[0][1] * T[0][1];
   if (upp_tri_sq == internal::NumberType<Number>::value(0.0))
     {
@@ -64,7 +67,7 @@ eigenvalues(const SymmetricTensor<2, 2, Number> &T)
         descrim > internal::NumberType<Number>::value(0.0),
         ExcMessage(
           "The roots of the characteristic polynomial are complex valued."));
-      const Number sqrt_desc = std::sqrt(descrim);
+      const Number sqrt_desc = sqrt(descrim);
 
       const std::array<Number, 2> eig_vals = {
         {internal::NumberType<Number>::value(0.5 * (tr_T + sqrt_desc)),
@@ -81,6 +84,11 @@ template <typename Number>
 std::array<Number, 3>
 eigenvalues(const SymmetricTensor<2, 3, Number> &T)
 {
+  // Make things work with AD types
+  using std::acos;
+  using std::cos;
+  using std::sqrt;
+
   const Number upp_tri_sq =
     T[0][1] * T[0][1] + T[0][2] * T[0][2] + T[1][2] * T[1][2];
   if (upp_tri_sq == internal::NumberType<Number>::value(0.0))
@@ -107,7 +115,7 @@ eigenvalues(const SymmetricTensor<2, 3, Number> &T)
       const Number tmp1 = (T[0][0] - q) * (T[0][0] - q) +
                           (T[1][1] - q) * (T[1][1] - q) +
                           (T[2][2] - q) * (T[2][2] - q) + 2.0 * upp_tri_sq;
-      const Number                        p = std::sqrt(tmp1 / 6.0);
+      const Number                        p = sqrt(tmp1 / 6.0);
       const SymmetricTensor<2, 3, Number> B =
         Number(1.0 / p) * (T - q * unit_symmetric_tensor<3, Number>());
       const Number tmp_2 = determinant(B) / 2.0;
@@ -123,15 +131,15 @@ eigenvalues(const SymmetricTensor<2, 3, Number> &T)
            internal::NumberType<Number>::value(numbers::PI / 3.0) :
            (tmp_2 >= 1.0 ?
               internal::NumberType<Number>::value(0.0) :
-              internal::NumberType<Number>::value(std::acos(tmp_2) / 3.0)));
+              internal::NumberType<Number>::value(acos(tmp_2) / 3.0)));
 
       // Due to the trigonometric solution, the computed eigenvalues
       // should be predictably in the order eig1 >= eig2 >= eig3...
       std::array<Number, 3> eig_vals = {
-        {static_cast<Number>(q + 2.0 * p * std::cos(phi)),
+        {static_cast<Number>(q + 2.0 * p * cos(phi)),
          static_cast<Number>(0.0),
-         static_cast<Number>(q + 2.0 * p *
-                                   std::cos(phi + (2.0 / 3.0 * numbers::PI)))}};
+         static_cast<Number>(q +
+                             2.0 * p * cos(phi + (2.0 / 3.0 * numbers::PI)))}};
       // Use the identity tr(T) = eig1 + eig2 + eig3
       eig_vals[1] = tr_T - eig_vals[0] - eig_vals[2];
 
@@ -157,6 +165,9 @@ namespace internal
                    std::array<Number, dim> &                      d,
                    std::array<Number, dim - 1> &                  e)
     {
+      // Make things work with AD types
+      using std::sqrt;
+
       // Create some intermediate storage
       Number h, g, omega_inv, K, f;
 
@@ -173,9 +184,9 @@ namespace internal
 
       g = 0.0;
       if (A[0][1] > 0.0)
-        g = -std::sqrt(h);
+        g = -sqrt(h);
       else
-        g = std::sqrt(h);
+        g = sqrt(h);
       e[0] = g;
 
       std::array<Number, dim> u;
@@ -240,6 +251,10 @@ namespace internal
     std::array<std::pair<Number, Tensor<1, dim, Number>>, dim>
     ql_implicit_shifts(const dealii::SymmetricTensor<2, dim, Number> &A)
     {
+      // Make things work with AD types
+      using std::fabs;
+      using std::sqrt;
+
       static_assert(
         numbers::NumberTraits<Number>::is_complex == false,
         "This implementation of the QL implicit shift algorithm does "
@@ -278,8 +293,8 @@ namespace internal
               int m = l;
               for (; m <= dim - 2; ++m)
                 {
-                  g = std::abs(w[m]) + std::abs(w[m + 1]);
-                  if (std::abs(e[m]) + g == g)
+                  g = fabs(w[m]) + fabs(w[m + 1]);
+                  if (fabs(e[m]) + g == g)
                     break;
                 }
               if (m == l)
@@ -298,7 +313,7 @@ namespace internal
 
               // Calculate the shift..
               g = (w[l + 1] - w[l]) / (e[l] + e[l]);
-              r = std::sqrt(g * g + 1.0);
+              r = sqrt(g * g + 1.0);
               // .. and then compute g = d_m - k_s for the
               // plane rotation (Press2007a eq 11.4.22)
               if (g > 0.0)
@@ -317,17 +332,17 @@ namespace internal
                   b = c * e[i];
 
                   // Branch to recover from underflow
-                  if (std::abs(f) > std::abs(g))
+                  if (fabs(f) > fabs(g))
                     {
                       c        = g / f;
-                      r        = std::sqrt(c * c + 1.0);
+                      r        = sqrt(c * c + 1.0);
                       e[i + 1] = f * r;
                       c *= (s = 1.0 / r);
                     }
                   else
                     {
                       s        = f / g;
-                      r        = std::sqrt(s * s + 1.0);
+                      r        = sqrt(s * s + 1.0);
                       e[i + 1] = g * r;
                       s *= (c = 1.0 / r);
                     }
@@ -382,6 +397,10 @@ namespace internal
                     "This implementation of the Jacobi algorithm does "
                     "not support complex numbers");
 
+      // Make things work with AD types
+      using std::fabs;
+      using std::sqrt;
+
       // Sums of diagonal resp. off-diagonal elements
       Number sd, so;
       // sin(phi), cos(phi), tan(phi) and temporary storage
@@ -414,7 +433,7 @@ namespace internal
           so = 0.0;
           for (unsigned int p = 0; p < dim; ++p)
             for (int q = p + 1; q < dim; ++q)
-              so += std::abs(A[p][q]);
+              so += fabs(A[p][q]);
           if (so == 0.0)
             break;
 
@@ -441,17 +460,17 @@ namespace internal
           for (unsigned int p = 0; p < dim; ++p)
             for (unsigned int q = p + 1; q < dim; ++q)
               {
-                g = 100.0 * std::abs(A[p][q]);
+                g = 100.0 * fabs(A[p][q]);
 
                 // After a given number of iterations the
                 // rotation is skipped if the off-diagonal
                 // element is small
-                if (it > n_it_skip && std::abs(w[p]) + g == std::abs(w[p]) &&
-                    std::abs(w[q]) + g == std::abs(w[q]))
+                if (it > n_it_skip && fabs(w[p]) + g == fabs(w[p]) &&
+                    fabs(w[q]) + g == fabs(w[q]))
                   {
                     A[p][q] = 0.0;
                   }
-                else if (std::abs(A[p][q]) > thresh)
+                else if (fabs(A[p][q]) > thresh)
                   {
                     // Calculate Jacobi transformation
                     h = w[q] - w[p];
@@ -459,7 +478,7 @@ namespace internal
                     // Compute surrogate for angle theta resulting from
                     // angle transformation and subsequent smallest solution
                     // of quadratic equation
-                    if (std::abs(h) + g == std::abs(h))
+                    if (fabs(h) + g == fabs(h))
                       {
                         // Prevent overflow for large theta^2. This computation
                         // is the algebraic equivalent of t = 1/(2*theta).
@@ -469,15 +488,15 @@ namespace internal
                       {
                         theta = 0.5 * h / A[p][q];
                         if (theta < 0.0)
-                          t = -1.0 / (std::sqrt(1.0 + theta * theta) - theta);
+                          t = -1.0 / (sqrt(1.0 + theta * theta) - theta);
                         else
-                          t = 1.0 / (std::sqrt(1.0 + theta * theta) + theta);
+                          t = 1.0 / (sqrt(1.0 + theta * theta) + theta);
                       }
 
                     // Compute trigonometric functions for rotation
                     // in such a way as to prevent overflow for
                     // large theta.
-                    c = 1.0 / std::sqrt(1.0 + t * t);
+                    c = 1.0 / sqrt(1.0 + t * t);
                     s = t * c;
                     z = t * A[p][q];
 
@@ -546,6 +565,9 @@ namespace internal
                     "This implementation of the 2d Hybrid algorithm does "
                     "not support complex numbers");
 
+      // Make things work with AD types
+      using std::fabs;
+
       const unsigned int dim = 2;
 
       // Calculate eigenvalues
@@ -554,10 +576,10 @@ namespace internal
       std::array<std::pair<Number, Tensor<1, dim, Number>>, dim> eig_vals_vecs;
 
       Number t, u; // Intermediate storage
-      t = std::abs(w[0]);
+      t = fabs(w[0]);
       for (unsigned int i = 1; i < dim; ++i)
         {
-          u = std::abs(w[i]);
+          u = fabs(w[i]);
           if (u > t)
             t = u;
         }
@@ -623,6 +645,10 @@ namespace internal
                     "This implementation of the 3d Hybrid algorithm does "
                     "not support complex numbers");
 
+      // Make things work with AD types
+      using std::fabs;
+      using std::sqrt;
+
       const unsigned int dim = 3;
       Number norm; // Squared norm or inverse norm of current eigenvector
       Number t, u; // Intermediate storage
@@ -630,10 +656,10 @@ namespace internal
       // Calculate eigenvalues
       const std::array<Number, dim> w = eigenvalues(A);
 
-      t = std::abs(w[0]);
+      t = fabs(w[0]);
       for (unsigned int i = 1; i < dim; ++i)
         {
-          u = std::abs(w[i]);
+          u = fabs(w[i]);
           if (u > t)
             t = u;
         }
@@ -673,7 +699,7 @@ namespace internal
         }
       else // This is the standard branch
         {
-          norm = std::sqrt(1.0 / norm);
+          norm = sqrt(1.0 / norm);
           for (unsigned j = 0; j < dim; ++j)
             Q[j][0] = Q[j][0] * norm;
         }
@@ -690,7 +716,7 @@ namespace internal
         }
       else
         {
-          norm = std::sqrt(1.0 / norm);
+          norm = sqrt(1.0 / norm);
           for (unsigned int j = 0; j < dim; ++j)
             Q[j][1] = Q[j][1] * norm;
         }

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1727,7 +1727,9 @@ template <int rank_, int dim, typename Number>
 inline typename numbers::NumberTraits<Number>::real_type
 Tensor<rank_, dim, Number>::norm() const
 {
-  return std::sqrt(norm_square());
+  // Make things work with AD types
+  using std::sqrt;
+  return sqrt(norm_square());
 }
 
 
@@ -3009,7 +3011,7 @@ l1_norm(const Tensor<2, dim, Number> &t)
     {
       Number sum = internal::NumberType<Number>::value(0.0);
       for (unsigned int i = 0; i < dim; ++i)
-        sum += std::fabs(t[i][j]);
+        sum += numbers::NumberTraits<Number>::abs(t[i][j]);
 
       if (sum > max)
         max = sum;
@@ -3035,7 +3037,7 @@ linfty_norm(const Tensor<2, dim, Number> &t)
     {
       Number sum = internal::NumberType<Number>::value(0.0);
       for (unsigned int j = 0; j < dim; ++j)
-        sum += std::fabs(t[i][j]);
+        sum += numbers::NumberTraits<Number>::abs(t[i][j]);
 
       if (sum > max)
         max = sum;

--- a/include/deal.II/differentiation/ad/adolc_math.h
+++ b/include/deal.II/differentiation/ad/adolc_math.h
@@ -28,145 +28,53 @@
 
 #  ifndef DOXYGEN
 
+DEAL_II_NAMESPACE_OPEN
 /**
- * Import ADOL-C math operations into standard namespace. This gives us the
- * ability to use them within the Tensor class, and it also allows the user
- * to write generic code and switch between AD number types.
- *
- * The math functions to be exposed come from the ADOL-C's taped
- * (anonymous) and tapeless namespaces.
+ * Implementation of the complementary error function for adol-c adouble
+ * numbers.
  */
-namespace std
+#    ifdef DEAL_II_ADOLC_WITH_ATRIG_ERF
+inline adouble
+erfc(const adouble &x)
 {
-  /**
-   * Make a unary function with one name available under a different name
-   */
-#    define DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION_COPY(func_to, func_from) \
-      inline adouble func_to(const adouble &x)                                \
-      {                                                                       \
-        return func_from(static_cast<const badouble &>(x));                   \
-      }                                                                       \
-      inline adtl::adouble func_to(const adtl::adouble &x)                    \
-      {                                                                       \
-        return adtl::func_from(x);                                            \
-      }
+  // Make things work with AD types
+  using std::erf;
+  return 1.0 - erf(x);
+}
 
-  /**
-   * Expose a unary function
-   */
-#    define DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(func) \
-      DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION_COPY(func, func)
-
-  /**
-   * Make a binary function with one name available under a different name
-   */
-#    define DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION_COPY(func_to, func_from) \
-      inline adouble func_to(const adouble &x, const adouble &y)               \
-      {                                                                        \
-        return func_from(static_cast<const badouble &>(x),                     \
-                         static_cast<const badouble &>(y));                    \
-      }                                                                        \
-      inline adouble func_to(const double x, const adouble &y)                 \
-      {                                                                        \
-        return func_from(x, static_cast<const badouble &>(y));                 \
-      }                                                                        \
-      inline adouble func_to(const adouble &x, const double y)                 \
-      {                                                                        \
-        return func_from(static_cast<const badouble &>(x), y);                 \
-      }                                                                        \
-      inline adtl::adouble func_to(const adtl::adouble &x,                     \
-                                   const adtl::adouble &y)                     \
-      {                                                                        \
-        return adtl::func_from(x, y);                                          \
-      }                                                                        \
-      inline adtl::adouble func_to(const double x, const adtl::adouble &y)     \
-      {                                                                        \
-        return adtl::func_from(x, y);                                          \
-      }                                                                        \
-      inline adtl::adouble func_to(const adtl::adouble &x, const double y)     \
-      {                                                                        \
-        return adtl::func_from(x, y);                                          \
-      }
-
-  /**
-   * Expose a binary function
-   */
-#    define DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION(func) \
-      DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION_COPY(func, func)
-
-  /**
-   * Expose a binary function
-   */
-#    define DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION_2(func) \
-      inline adouble func(const adouble &x, const adouble &y) \
-      {                                                       \
-        return func(static_cast<const badouble &>(x),         \
-                    static_cast<const badouble &>(y));        \
-      }                                                       \
-      inline adtl::adouble func(const adtl::adouble &x,       \
-                                const adtl::adouble &y)       \
-      {                                                       \
-        return adtl::func(x, y);                              \
-      }
-
-  // See
-  // https://gitlab.com/adol-c/adol-c/blob/master/ADOL-C/include/adolc/adouble.h
-  // https://gitlab.com/adol-c/adol-c/blob/master/ADOL-C/include/adolc/internal/paramfunc.h
-
-  DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION(pow)
-  DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION(fmax)
-  DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION_COPY(max, fmax)
-  DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION(fmin)
-  DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION_COPY(min, fmin)
-
-  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(exp)
-  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(log)
-  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(log10)
-  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(sqrt)
-#    ifdef DEAL_II_ADOLC_WITH_ATRIG_ERF
-  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(erf)
-  inline adouble
-  erfc(const adouble &x)
-  {
-    return 1.0 - std::erf(x);
-  }
-  inline adtl::adouble
-  erfc(const adtl::adouble &x)
-  {
-    return 1.0 - std::erf(x);
-  }
+/**
+ * Implementation of the complementary error function for adol-c adtl::adouble
+ * numbers.
+ */
+inline adtl::adouble
+erfc(const adtl::adouble &x)
+{
+  // Make things work with AD types
+  using std::erf;
+  return 1.0 - erf(x);
+}
 #    endif
 
-  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(fabs)
-  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION_COPY(abs, fabs)
-  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(ceil)
-  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(floor)
 
-  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(sin)
-  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(cos)
-  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(tan)
-  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(asin)
-  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(acos)
-  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(atan)
-  DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION_2(atan2)
+/**
+ * For improved genericity, implement abs() in terms of fabs() for adouble.
+ */
+inline adouble
+abs(const adouble &x)
+{
+  return fabs(static_cast<const badouble &>(x));
+}
 
-  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(sinh)
-  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(cosh)
-  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(tanh)
-#    ifdef DEAL_II_ADOLC_WITH_ATRIG_ERF
-  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(asinh)
-  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(acosh)
-  DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION(atanh)
-#    endif
+/**
+ * Same idea: implement abs() in terms of adtl::fabs().
+ */
+inline adtl::adouble
+abs(const adtl::adouble &x)
+{
+  return adtl::fabs(x);
+}
 
-#    undef DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION_2
-#    undef DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION
-#    undef DEAL_II_EXPOSE_ADOLC_BINARY_MATH_FUNCTION_COPY
-#    undef DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION
-#    undef DEAL_II_EXPOSE_ADOLC_UNARY_MATH_FUNCTION_COPY
-
-} // namespace std
-
+DEAL_II_NAMESPACE_CLOSE
 #  endif // DOXYGEN
 
 #endif // DEAL_II_WITH_ADOLC

--- a/include/deal.II/differentiation/ad/sacado_math.h
+++ b/include/deal.II/differentiation/ad/sacado_math.h
@@ -28,76 +28,69 @@
 
 #  ifndef DOXYGEN
 
+DEAL_II_NAMESPACE_OPEN
 /**
- * Define some missing fundamental math functions
+ * Implementation of the error function for real-valued Sacado numbers.
  */
-namespace std
+template <
+  typename ADNumberType,
+  typename = std::enable_if_t<
+    dealii::Differentiation::AD::is_sacado_number<ADNumberType>::value &&
+    dealii::Differentiation::AD::is_real_valued_ad_number<ADNumberType>::value>>
+inline ADNumberType
+erf(ADNumberType x)
 {
-  /**
-   * Implementation of the error function for real-valued Sacado numbers.
-   */
-  template <
-    typename ADNumberType,
-    typename = std::enable_if_t<
-      dealii::Differentiation::AD::is_sacado_number<ADNumberType>::value &&
-      dealii::Differentiation::AD::is_real_valued_ad_number<
-        ADNumberType>::value>>
-  inline ADNumberType
-  erf(ADNumberType x)
-  {
-    // Reference:
-    // Handbook of Mathematical Functions: with Formulas, Graphs, and
-    // Mathematical Tables Abramowitz, M. and Stegun, I. Dover Books on
-    // Mathematics. 1972.
-    //
-    // Current implementation source:
-    // https://www.johndcook.com/blog/cpp_erf/
-    // https://www.johndcook.com/blog/2009/01/19/stand-alone-error-function-erf/
-    //
-    // Note: This implementation has a reported maximum round-off error
-    // of 1.5e-7.
+  // Reference:
+  // Handbook of Mathematical Functions: with Formulas, Graphs, and
+  // Mathematical Tables Abramowitz, M. and Stegun, I. Dover Books on
+  // Mathematics. 1972.
+  //
+  // Current implementation source:
+  // https://www.johndcook.com/blog/cpp_erf/
+  // https://www.johndcook.com/blog/2009/01/19/stand-alone-error-function-erf/
+  //
+  // Note: This implementation has a reported maximum round-off error
+  // of 1.5e-7.
 
-    // Constants
-    const double a1 = 0.254829592;
-    const double a2 = -0.284496736;
-    const double a3 = 1.421413741;
-    const double a4 = -1.453152027;
-    const double a5 = 1.061405429;
-    const double p  = 0.3275911;
+  // Constants
+  const double a1 = 0.254829592;
+  const double a2 = -0.284496736;
+  const double a3 = 1.421413741;
+  const double a4 = -1.453152027;
+  const double a5 = 1.061405429;
+  const double p  = 0.3275911;
 
-    // Save the sign of x
-    const bool neg_val =
-      (x < dealii::internal::NumberType<ADNumberType>::value(0.0) ? true :
-                                                                    false);
-    x = std::fabs(x);
+  // Save the sign of x
+  const bool neg_val =
+    (x < dealii::internal::NumberType<ADNumberType>::value(0.0) ? true : false);
+  x = std::fabs(x);
 
-    // Abramowitz1972a equation 7.1.26
-    const ADNumberType t = 1.0 / (1.0 + p * x);
-    const ADNumberType y =
-      1.0 -
-      (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * std::exp(-x * x);
+  // Abramowitz1972a equation 7.1.26
+  const ADNumberType t = 1.0 / (1.0 + p * x);
+  const ADNumberType y =
+    1.0 -
+    (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * std::exp(-x * x);
 
-    if (!neg_val)
-      return y;
-    else
-      return -y;
-  }
+  if (!neg_val)
+    return y;
+  else
+    return -y;
+}
 
 
-  /**
-   * Implementation of the complementary error function for Sacado numbers.
-   */
-  template <
-    typename ADNumberType,
-    typename = std::enable_if_t<
-      dealii::Differentiation::AD::is_sacado_number<ADNumberType>::value>>
-  inline ADNumberType
-  erfc(const ADNumberType &x)
-  {
-    return 1.0 - std::erf(x);
-  }
+/**
+ * Implementation of the complementary error function for Sacado numbers.
+ */
+template <typename ADNumberType,
+          typename = std::enable_if_t<
+            dealii::Differentiation::AD::is_sacado_number<ADNumberType>::value>>
+inline ADNumberType
+erfc(const ADNumberType &x)
+{
+  return 1.0 - std::erf(x);
+}
 
-} // namespace std
+DEAL_II_NAMESPACE_CLOSE
 
 #  endif // DOXYGEN
 

--- a/include/deal.II/physics/elasticity/kinematics.h
+++ b/include/deal.II/physics/elasticity/kinematics.h
@@ -288,8 +288,9 @@ template <int dim, typename Number>
 inline Tensor<2, dim, Number>
 Physics::Elasticity::Kinematics::F_iso(const Tensor<2, dim, Number> &F)
 {
-  return internal::NumberType<Number>::value(
-           std::pow(determinant(F), -1.0 / dim)) *
+  // Make things work with AD types
+  using std::pow;
+  return internal::NumberType<Number>::value(pow(determinant(F), -1.0 / dim)) *
          F;
 }
 
@@ -299,8 +300,9 @@ template <int dim, typename Number>
 inline SymmetricTensor<2, dim, Number>
 Physics::Elasticity::Kinematics::F_vol(const Tensor<2, dim, Number> &F)
 {
-  return internal::NumberType<Number>::value(
-           std::pow(determinant(F), 1.0 / dim)) *
+  // Make things work with AD types
+  using std::pow;
+  return internal::NumberType<Number>::value(pow(determinant(F), 1.0 / dim)) *
          static_cast<SymmetricTensor<2, dim, Number>>(
            unit_symmetric_tensor<dim>());
 }

--- a/include/deal.II/physics/elasticity/standard_tensors.h
+++ b/include/deal.II/physics/elasticity/standard_tensors.h
@@ -321,6 +321,8 @@ DEAL_II_CONSTEXPR inline SymmetricTensor<4, dim, Number>
 Physics::Elasticity::StandardTensors<dim>::Dev_P(
   const Tensor<2, dim, Number> &F)
 {
+  // Make things work with AD types
+  using std::pow;
   const Number det_F = determinant(F);
   Assert(numbers::value_is_greater_than(det_F, 0.0),
          ExcMessage("Deformation gradient has a negative determinant."));
@@ -333,8 +335,7 @@ Physics::Elasticity::StandardTensors<dim>::Dev_P(
     outer_product(C, C_inv);                   // Dev_P = C_x_C_inv
   Dev_P /= -dim;                               // Dev_P = -[1/dim]C_x_C_inv
   Dev_P += SymmetricTensor<4, dim, Number>(S); // Dev_P = S - [1/dim]C_x_C_inv
-  Dev_P *=
-    std::pow(det_F, -2.0 / dim); // Dev_P = J^{-2/dim} [S - [1/dim]C_x_C_inv]
+  Dev_P *= pow(det_F, -2.0 / dim); // Dev_P = J^{-2/dim} [S - [1/dim]C_x_C_inv]
 
   return Dev_P;
 }
@@ -347,6 +348,8 @@ DEAL_II_CONSTEXPR inline SymmetricTensor<4, dim, Number>
 Physics::Elasticity::StandardTensors<dim>::Dev_P_T(
   const Tensor<2, dim, Number> &F)
 {
+  // Make things work with AD types
+  using std::pow;
   const Number det_F = determinant(F);
   Assert(numbers::value_is_greater_than(det_F, 0.0),
          ExcMessage("Deformation gradient has a negative determinant."));
@@ -360,7 +363,7 @@ Physics::Elasticity::StandardTensors<dim>::Dev_P_T(
   Dev_P_T /= -dim;                               // Dev_P = -[1/dim]C_inv_x_C
   Dev_P_T += SymmetricTensor<4, dim, Number>(S); // Dev_P = S - [1/dim]C_inv_x_C
   Dev_P_T *=
-    std::pow(det_F, -2.0 / dim); // Dev_P = J^{-2/dim} [S - [1/dim]C_inv_x_C]
+    pow(det_F, -2.0 / dim); // Dev_P = J^{-2/dim} [S - [1/dim]C_inv_x_C]
 
   return Dev_P_T;
 }

--- a/include/deal.II/physics/transformations.h
+++ b/include/deal.II/physics/transformations.h
@@ -912,8 +912,12 @@ template <typename Number>
 Tensor<2, 2, Number>
 Physics::Transformations::Rotations::rotation_matrix_2d(const Number &angle)
 {
-  const Number rotation[2][2] = {{std::cos(angle), -std::sin(angle)},
-                                 {std::sin(angle), std::cos(angle)}};
+  // Make things work with AD types
+  using std::cos;
+  using std::sin;
+
+  const Number rotation[2][2] = {{cos(angle), -sin(angle)},
+                                 {sin(angle), cos(angle)}};
   return Tensor<2, 2>(rotation);
 }
 
@@ -925,10 +929,15 @@ Physics::Transformations::Rotations::rotation_matrix_3d(
   const Tensor<1, 3, Number> &axis,
   const Number &              angle)
 {
-  Assert(std::abs(axis.norm() - 1.0) < 1e-9,
+  // Make things work with AD types
+  using std::abs;
+  using std::cos;
+  using std::sin;
+
+  Assert(abs(axis.norm() - 1.0) < 1e-9,
          ExcMessage("The supplied axial vector is not a unit vector."));
-  const Number c              = std::cos(angle);
-  const Number s              = std::sin(angle);
+  const Number c              = cos(angle);
+  const Number s              = sin(angle);
   const Number t              = 1. - c;
   const Number rotation[3][3] = {{t * axis[0] * axis[0] + c,
                                   t * axis[0] * axis[1] - s * axis[2],

--- a/source/base/geometric_utilities.cc
+++ b/source/base/geometric_utilities.cc
@@ -17,6 +17,10 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/geometric_utilities.h>
 
+#include <array>
+#include <cmath>
+#include <limits>
+
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/tests/ad_common_tests/helper_scalar_coupled_2_components_01.h
+++ b/tests/ad_common_tests/helper_scalar_coupled_2_components_01.h
@@ -42,31 +42,31 @@ struct FunctionsTestScalarScalarCoupled
   static NumberType
   psi(const NumberType &s1, const NumberType &s2)
   {
-    return 2.0 * std::pow(s1, 4) * std::pow(s2, 3);
+    return 2.0 * pow(s1, 4) * pow(s2, 3);
   };
 
   static NumberType
   dpsi_ds1(const NumberType &s1, const NumberType &s2)
   {
-    return 8.0 * std::pow(s1, 3) * std::pow(s2, 3);
+    return 8.0 * pow(s1, 3) * pow(s2, 3);
   };
 
   static NumberType
   dpsi_ds2(const NumberType &s1, const NumberType &s2)
   {
-    return 6.0 * std::pow(s1, 4) * std::pow(s2, 2);
+    return 6.0 * pow(s1, 4) * pow(s2, 2);
   };
 
   static NumberType
   d2psi_ds1_ds1(const NumberType &s1, const NumberType &s2)
   {
-    return 24.0 * std::pow(s1, 2) * std::pow(s2, 3);
+    return 24.0 * pow(s1, 2) * pow(s2, 3);
   };
 
   static NumberType
   d2psi_ds2_ds1(const NumberType &s1, const NumberType &s2)
   {
-    return 24.0 * std::pow(s1, 3) * std::pow(s2, 2);
+    return 24.0 * pow(s1, 3) * pow(s2, 2);
   };
 
   static NumberType
@@ -78,7 +78,7 @@ struct FunctionsTestScalarScalarCoupled
   static NumberType
   d2psi_ds2_ds2(const NumberType &s1, const NumberType &s2)
   {
-    return 12.0 * std::pow(s1, 4) * std::pow(s2, 1);
+    return 12.0 * pow(s1, 4) * pow(s2, 1);
   };
 };
 

--- a/tests/ad_common_tests/helper_scalar_coupled_2_components_02.h
+++ b/tests/ad_common_tests/helper_scalar_coupled_2_components_02.h
@@ -42,19 +42,19 @@ struct FunctionsTestVectorScalarCoupled
   static NumberType
   psi(const Tensor<1, dim, NumberType> &v, const NumberType &s)
   {
-    return (v * v) * std::pow(s, 3);
+    return (v * v) * pow(s, 3);
   };
 
   static Tensor<1, dim, NumberType>
   dpsi_dv(const Tensor<1, dim, NumberType> &v, const NumberType &s)
   {
-    return 2.0 * v * std::pow(s, 3);
+    return 2.0 * v * pow(s, 3);
   };
 
   static NumberType
   dpsi_ds(const Tensor<1, dim, NumberType> &v, const NumberType &s)
   {
-    return 3.0 * (v * v) * std::pow(s, 2);
+    return 3.0 * (v * v) * pow(s, 2);
   };
 
   static Tensor<2, dim, NumberType>
@@ -62,13 +62,13 @@ struct FunctionsTestVectorScalarCoupled
   {
     static const Tensor<2, dim, NumberType> I(
       unit_symmetric_tensor<dim, NumberType>());
-    return 2.0 * I * std::pow(s, 3);
+    return 2.0 * I * pow(s, 3);
   };
 
   static Tensor<1, dim, NumberType>
   d2psi_ds_dv(const Tensor<1, dim, NumberType> &v, const NumberType &s)
   {
-    return 6.0 * v * std::pow(s, 2);
+    return 6.0 * v * pow(s, 2);
   };
 
   static Tensor<1, dim, NumberType>
@@ -80,7 +80,7 @@ struct FunctionsTestVectorScalarCoupled
   static NumberType
   d2psi_ds_ds(const Tensor<1, dim, NumberType> &v, const NumberType &s)
   {
-    return 6.0 * (v * v) * std::pow(s, 1);
+    return 6.0 * (v * v) * pow(s, 1);
   };
 };
 

--- a/tests/ad_common_tests/helper_scalar_coupled_2_components_03.h
+++ b/tests/ad_common_tests/helper_scalar_coupled_2_components_03.h
@@ -42,19 +42,19 @@ struct FunctionsTestTensorScalarCoupled
   static NumberType
   psi(const Tensor<2, dim, NumberType> &t, const NumberType &s)
   {
-    return double_contract<0, 0, 1, 1>(t, t) * std::pow(s, 3);
+    return double_contract<0, 0, 1, 1>(t, t) * pow(s, 3);
   };
 
   static Tensor<2, dim, NumberType>
   dpsi_dt(const Tensor<2, dim, NumberType> &t, const NumberType &s)
   {
-    return 2.0 * t * std::pow(s, 3);
+    return 2.0 * t * pow(s, 3);
   };
 
   static NumberType
   dpsi_ds(const Tensor<2, dim, NumberType> &t, const NumberType &s)
   {
-    return 3.0 * double_contract<0, 0, 1, 1>(t, t) * std::pow(s, 2);
+    return 3.0 * double_contract<0, 0, 1, 1>(t, t) * pow(s, 2);
   };
 
   static Tensor<4, dim, NumberType>
@@ -70,13 +70,13 @@ struct FunctionsTestTensorScalarCoupled
           for (unsigned int l = 0; l < dim; ++l)
             II[i][j][k][l] = I[i][k] * I[j][l];
 
-    return 2.0 * II * std::pow(s, 3);
+    return 2.0 * II * pow(s, 3);
   };
 
   static Tensor<2, dim, NumberType>
   d2psi_ds_dt(const Tensor<2, dim, NumberType> &t, const NumberType &s)
   {
-    return 6.0 * t * std::pow(s, 2);
+    return 6.0 * t * pow(s, 2);
   };
 
   static Tensor<2, dim, NumberType>
@@ -88,7 +88,7 @@ struct FunctionsTestTensorScalarCoupled
   static NumberType
   d2psi_ds_ds(const Tensor<2, dim, NumberType> &t, const NumberType &s)
   {
-    return 6.0 * double_contract<0, 0, 1, 1>(t, t) * std::pow(s, 1);
+    return 6.0 * double_contract<0, 0, 1, 1>(t, t) * pow(s, 1);
   };
 };
 

--- a/tests/ad_common_tests/helper_scalar_coupled_2_components_04.h
+++ b/tests/ad_common_tests/helper_scalar_coupled_2_components_04.h
@@ -43,21 +43,21 @@ struct FunctionsTestVectorVectorCoupled
   psi(const Tensor<1, dim, NumberType> &v1,
       const Tensor<1, dim, NumberType> &v2)
   {
-    return std::pow(v1 * v1, 2) * std::pow(v2 * v2, 3);
+    return pow(v1 * v1, 2) * pow(v2 * v2, 3);
   };
 
   static Tensor<1, dim, NumberType>
   dpsi_dv1(const Tensor<1, dim, NumberType> &v1,
            const Tensor<1, dim, NumberType> &v2)
   {
-    return 2.0 * std::pow(v1 * v1, 1) * 2.0 * v1 * std::pow(v2 * v2, 3);
+    return 2.0 * pow(v1 * v1, 1) * 2.0 * v1 * pow(v2 * v2, 3);
   };
 
   static Tensor<1, dim, NumberType>
   dpsi_dv2(const Tensor<1, dim, NumberType> &v1,
            const Tensor<1, dim, NumberType> &v2)
   {
-    return std::pow(v1 * v1, 2) * 3.0 * std::pow(v2 * v2, 2) * 2.0 * v2;
+    return pow(v1 * v1, 2) * 3.0 * pow(v2 * v2, 2) * 2.0 * v2;
   };
 
   static Tensor<2, dim, NumberType>
@@ -66,9 +66,9 @@ struct FunctionsTestVectorVectorCoupled
   {
     const Tensor<2, dim, NumberType> I(
       unit_symmetric_tensor<dim, NumberType>());
-    return 2.0 * 2.0 * std::pow(v2 * v2, 3) *
+    return 2.0 * 2.0 * pow(v2 * v2, 3) *
            (pow(v1 * v1, 0) * 2.0 * outer_product(v1, v1) +
-            std::pow(v1 * v1, 1) * I);
+            pow(v1 * v1, 1) * I);
   };
 
   static Tensor<2, dim, NumberType>
@@ -78,16 +78,16 @@ struct FunctionsTestVectorVectorCoupled
     // Note: This is not symmetric, and this is why we
     // don't set the return type for hessian extractor (vector,vector)
     // operations as SymmetricTensor.
-    return (2.0 * std::pow(v1 * v1, 1) * 2.0) *
-           (3.0 * std::pow(v2 * v2, 2) * 2.0) * outer_product(v1, v2);
+    return (2.0 * pow(v1 * v1, 1) * 2.0) * (3.0 * pow(v2 * v2, 2) * 2.0) *
+           outer_product(v1, v2);
   };
 
   static Tensor<2, dim, NumberType>
   d2psi_dv1_dv2(const Tensor<1, dim, NumberType> &v1,
                 const Tensor<1, dim, NumberType> &v2)
   {
-    return (2.0 * std::pow(v1 * v1, 1) * 2.0) *
-           (3.0 * std::pow(v2 * v2, 2) * 2.0) * outer_product(v2, v1);
+    return (2.0 * pow(v1 * v1, 1) * 2.0) * (3.0 * pow(v2 * v2, 2) * 2.0) *
+           outer_product(v2, v1);
   };
 
   static Tensor<2, dim, NumberType>
@@ -96,12 +96,12 @@ struct FunctionsTestVectorVectorCoupled
   {
     const Tensor<2, dim, NumberType> I(
       unit_symmetric_tensor<dim, NumberType>());
-    // return std::pow(v1*v1,2)*3.0*
-    //        ( 2.0*std::pow(v2*v2,1)*2.0*outer_product(v2,v2) +
-    //        std::pow(v2*v2,2)*2.0*I);
-    return std::pow(v1 * v1, 2) * 3.0 * 2.0 *
-           (2.0 * std::pow(v2 * v2, 1) * 2.0 * outer_product(v2, v2) +
-            std::pow(v2 * v2, 2) * I);
+    // return pow(v1*v1,2)*3.0*
+    //        ( 2.0*pow(v2*v2,1)*2.0*outer_product(v2,v2) +
+    //        pow(v2*v2,2)*2.0*I);
+    return pow(v1 * v1, 2) * 3.0 * 2.0 *
+           (2.0 * pow(v2 * v2, 1) * 2.0 * outer_product(v2, v2) +
+            pow(v2 * v2, 2) * I);
   };
 };
 

--- a/tests/ad_common_tests/helper_scalar_coupled_2_components_05.h
+++ b/tests/ad_common_tests/helper_scalar_coupled_2_components_05.h
@@ -92,37 +92,37 @@ struct FunctionsTestTensorVectorCoupled
   static NumberType
   psi(const Tensor<2, dim, NumberType> &t, const Tensor<1, dim, NumberType> &v)
   {
-    return std::pow(det_t(t), 2) * std::pow(v_squ(v), 3);
+    return pow(det_t(t), 2) * pow(v_squ(v), 3);
   };
 
   static Tensor<2, dim, NumberType>
   dpsi_dt(const Tensor<2, dim, NumberType> &t,
           const Tensor<1, dim, NumberType> &v)
   {
-    return 2.0 * std::pow(det_t(t), 1) * ddet_t_dt(t) * std::pow(v_squ(v), 3);
+    return 2.0 * pow(det_t(t), 1) * ddet_t_dt(t) * pow(v_squ(v), 3);
   };
 
   static Tensor<1, dim, NumberType>
   dpsi_dv(const Tensor<2, dim, NumberType> &t,
           const Tensor<1, dim, NumberType> &v)
   {
-    return std::pow(det_t(t), 2) * 3.0 * std::pow(v_squ(v), 2) * dv_squ_dv(v);
+    return pow(det_t(t), 2) * 3.0 * pow(v_squ(v), 2) * dv_squ_dv(v);
   };
 
   static Tensor<4, dim, NumberType>
   d2psi_dt_dt(const Tensor<2, dim, NumberType> &t,
               const Tensor<1, dim, NumberType> &v)
   {
-    return 2.0 * std::pow(v_squ(v), 3) *
+    return 2.0 * pow(v_squ(v), 3) *
            (pow(det_t(t), 0) * outer_product(ddet_t_dt(t), ddet_t_dt(t)) +
-            std::pow(det_t(t), 1) * d2det_t_dt_dt(t));
+            pow(det_t(t), 1) * d2det_t_dt_dt(t));
   };
 
   static Tensor<3, dim, NumberType>
   d2psi_dv_dt(const Tensor<2, dim, NumberType> &t,
               const Tensor<1, dim, NumberType> &v)
   {
-    return 2.0 * std::pow(det_t(t), 1) * 3.0 * std::pow(v_squ(v), 2) *
+    return 2.0 * pow(det_t(t), 1) * 3.0 * pow(v_squ(v), 2) *
            outer_product(ddet_t_dt(t), dv_squ_dv(v));
   };
 
@@ -130,7 +130,7 @@ struct FunctionsTestTensorVectorCoupled
   d2psi_dt_dv(const Tensor<2, dim, NumberType> &t,
               const Tensor<1, dim, NumberType> &v)
   {
-    return 2.0 * std::pow(det_t(t), 1) * 3.0 * std::pow(v_squ(v), 2) *
+    return 2.0 * pow(det_t(t), 1) * 3.0 * pow(v_squ(v), 2) *
            outer_product(dv_squ_dv(v), ddet_t_dt(t));
   };
 
@@ -138,10 +138,9 @@ struct FunctionsTestTensorVectorCoupled
   d2psi_dv_dv(const Tensor<2, dim, NumberType> &t,
               const Tensor<1, dim, NumberType> &v)
   {
-    return std::pow(det_t(t), 2) * 3.0 *
-           (2.0 * std::pow(v_squ(v), 1) *
-              outer_product(dv_squ_dv(v), dv_squ_dv(v)) +
-            std::pow(v_squ(v), 2) * d2v_squ_dv_dv(v));
+    return pow(det_t(t), 2) * 3.0 *
+           (2.0 * pow(v_squ(v), 1) * outer_product(dv_squ_dv(v), dv_squ_dv(v)) +
+            pow(v_squ(v), 2) * d2v_squ_dv_dv(v));
   };
 };
 

--- a/tests/ad_common_tests/helper_scalar_coupled_2_components_06.h
+++ b/tests/ad_common_tests/helper_scalar_coupled_2_components_06.h
@@ -96,22 +96,22 @@ struct FunctionsTestSymmetricTensorVectorCoupled
   psi(const SymmetricTensor<2, dim, NumberType> &t,
       const Tensor<1, dim, NumberType> &         v)
   {
-    return std::pow(det_t(t), 2) * std::pow(v_squ(v), 3);
+    return pow(det_t(t), 2) * pow(v_squ(v), 3);
   };
 
   static SymmetricTensor<2, dim, NumberType>
   dpsi_dt(const SymmetricTensor<2, dim, NumberType> &t,
           const Tensor<1, dim, NumberType> &         v)
   {
-    return SymmetricTensor<2, dim, NumberType>(
-      2.0 * std::pow(det_t(t), 1) * ddet_t_dt(t) * std::pow(v_squ(v), 3));
+    return SymmetricTensor<2, dim, NumberType>(2.0 * pow(det_t(t), 1) *
+                                               ddet_t_dt(t) * pow(v_squ(v), 3));
   };
 
   static Tensor<1, dim, NumberType>
   dpsi_dv(const SymmetricTensor<2, dim, NumberType> &t,
           const Tensor<1, dim, NumberType> &         v)
   {
-    return std::pow(det_t(t), 2) * 3.0 * std::pow(v_squ(v), 2) * dv_squ_dv(v);
+    return pow(det_t(t), 2) * 3.0 * pow(v_squ(v), 2) * dv_squ_dv(v);
   };
 
   static SymmetricTensor<4, dim, NumberType>
@@ -119,16 +119,16 @@ struct FunctionsTestSymmetricTensorVectorCoupled
               const Tensor<1, dim, NumberType> &         v)
   {
     return SymmetricTensor<4, dim, NumberType>(
-      2.0 * std::pow(v_squ(v), 3) *
+      2.0 * pow(v_squ(v), 3) *
       (pow(det_t(t), 0) * outer_product(ddet_t_dt(t), ddet_t_dt(t)) +
-       std::pow(det_t(t), 1) * d2det_t_dt_dt(t)));
+       pow(det_t(t), 1) * d2det_t_dt_dt(t)));
   };
 
   static Tensor<3, dim, NumberType>
   d2psi_dv_dt(const SymmetricTensor<2, dim, NumberType> &t,
               const Tensor<1, dim, NumberType> &         v)
   {
-    return 2.0 * std::pow(det_t(t), 1) * 3.0 * std::pow(v_squ(v), 2) *
+    return 2.0 * pow(det_t(t), 1) * 3.0 * pow(v_squ(v), 2) *
            outer_product(static_cast<Tensor<2, dim, NumberType>>(ddet_t_dt(t)),
                          dv_squ_dv(v));
   };
@@ -137,7 +137,7 @@ struct FunctionsTestSymmetricTensorVectorCoupled
   d2psi_dt_dv(const SymmetricTensor<2, dim, NumberType> &t,
               const Tensor<1, dim, NumberType> &         v)
   {
-    return 2.0 * std::pow(det_t(t), 1) * 3.0 * std::pow(v_squ(v), 2) *
+    return 2.0 * pow(det_t(t), 1) * 3.0 * pow(v_squ(v), 2) *
            outer_product(dv_squ_dv(v),
                          static_cast<Tensor<2, dim, NumberType>>(ddet_t_dt(t)));
   };
@@ -146,10 +146,9 @@ struct FunctionsTestSymmetricTensorVectorCoupled
   d2psi_dv_dv(const SymmetricTensor<2, dim, NumberType> &t,
               const Tensor<1, dim, NumberType> &         v)
   {
-    return std::pow(det_t(t), 2) * 3.0 *
-           (2.0 * std::pow(v_squ(v), 1) *
-              outer_product(dv_squ_dv(v), dv_squ_dv(v)) +
-            std::pow(v_squ(v), 2) * d2v_squ_dv_dv(v));
+    return pow(det_t(t), 2) * 3.0 *
+           (2.0 * pow(v_squ(v), 1) * outer_product(dv_squ_dv(v), dv_squ_dv(v)) +
+            pow(v_squ(v), 2) * d2v_squ_dv_dv(v));
   };
 };
 

--- a/tests/ad_common_tests/helper_scalar_coupled_2_components_06a.h
+++ b/tests/ad_common_tests/helper_scalar_coupled_2_components_06a.h
@@ -103,22 +103,22 @@ struct FunctionsTestSymmetricTensorVectorCoupled
   psi(const SymmetricTensor<2, dim, NumberType> &t,
       const Tensor<1, dim, NumberType> &         v)
   {
-    return std::pow(det_t(t), 2) * std::pow(v_squ(v), 3);
+    return pow(det_t(t), 2) * pow(v_squ(v), 3);
   };
 
   static SymmetricTensor<2, dim, NumberType>
   dpsi_dt(const SymmetricTensor<2, dim, NumberType> &t,
           const Tensor<1, dim, NumberType> &         v)
   {
-    return SymmetricTensor<2, dim, NumberType>(
-      2.0 * std::pow(det_t(t), 1) * ddet_t_dt(t) * std::pow(v_squ(v), 3));
+    return SymmetricTensor<2, dim, NumberType>(2.0 * pow(det_t(t), 1) *
+                                               ddet_t_dt(t) * pow(v_squ(v), 3));
   };
 
   static Tensor<1, dim, NumberType>
   dpsi_dv(const SymmetricTensor<2, dim, NumberType> &t,
           const Tensor<1, dim, NumberType> &         v)
   {
-    return std::pow(det_t(t), 2) * 3.0 * std::pow(v_squ(v), 2) * dv_squ_dv(v);
+    return pow(det_t(t), 2) * 3.0 * pow(v_squ(v), 2) * dv_squ_dv(v);
   };
 
   static SymmetricTensor<4, dim, NumberType>
@@ -126,16 +126,16 @@ struct FunctionsTestSymmetricTensorVectorCoupled
               const Tensor<1, dim, NumberType> &         v)
   {
     return SymmetricTensor<4, dim, NumberType>(
-      2.0 * std::pow(v_squ(v), 3) *
+      2.0 * pow(v_squ(v), 3) *
       (pow(det_t(t), 0) * outer_product(ddet_t_dt(t), ddet_t_dt(t)) +
-       std::pow(det_t(t), 1) * d2det_t_dt_dt(t)));
+       pow(det_t(t), 1) * d2det_t_dt_dt(t)));
   };
 
   static Tensor<3, dim, NumberType>
   d2psi_dv_dt(const SymmetricTensor<2, dim, NumberType> &t,
               const Tensor<1, dim, NumberType> &         v)
   {
-    return 2.0 * std::pow(det_t(t), 1) * 3.0 * std::pow(v_squ(v), 2) *
+    return 2.0 * pow(det_t(t), 1) * 3.0 * pow(v_squ(v), 2) *
            outer_product(static_cast<Tensor<2, dim, NumberType>>(ddet_t_dt(t)),
                          dv_squ_dv(v));
   };
@@ -144,7 +144,7 @@ struct FunctionsTestSymmetricTensorVectorCoupled
   d2psi_dt_dv(const SymmetricTensor<2, dim, NumberType> &t,
               const Tensor<1, dim, NumberType> &         v)
   {
-    return 2.0 * std::pow(det_t(t), 1) * 3.0 * std::pow(v_squ(v), 2) *
+    return 2.0 * pow(det_t(t), 1) * 3.0 * pow(v_squ(v), 2) *
            outer_product(dv_squ_dv(v),
                          static_cast<Tensor<2, dim, NumberType>>(ddet_t_dt(t)));
   };
@@ -153,10 +153,9 @@ struct FunctionsTestSymmetricTensorVectorCoupled
   d2psi_dv_dv(const SymmetricTensor<2, dim, NumberType> &t,
               const Tensor<1, dim, NumberType> &         v)
   {
-    return std::pow(det_t(t), 2) * 3.0 *
-           (2.0 * std::pow(v_squ(v), 1) *
-              outer_product(dv_squ_dv(v), dv_squ_dv(v)) +
-            std::pow(v_squ(v), 2) * d2v_squ_dv_dv(v));
+    return pow(det_t(t), 2) * 3.0 *
+           (2.0 * pow(v_squ(v), 1) * outer_product(dv_squ_dv(v), dv_squ_dv(v)) +
+            pow(v_squ(v), 2) * d2v_squ_dv_dv(v));
   };
 };
 

--- a/tests/ad_common_tests/helper_scalar_coupled_2_components_07.h
+++ b/tests/ad_common_tests/helper_scalar_coupled_2_components_07.h
@@ -106,7 +106,7 @@ struct FunctionsTestSymmetricTensorTensorCoupled
   psi(const SymmetricTensor<2, dim, NumberType> &t1,
       const Tensor<2, dim, NumberType> &         t2)
   {
-    return std::pow(det_t(t1), 2) * std::pow(det_t(t2), 3);
+    return pow(det_t(t1), 2) * pow(det_t(t2), 3);
   };
 
   static SymmetricTensor<2, dim, NumberType>
@@ -114,15 +114,14 @@ struct FunctionsTestSymmetricTensorTensorCoupled
            const Tensor<2, dim, NumberType> &         t2)
   {
     return SymmetricTensor<2, dim, NumberType>(
-      2.0 * std::pow(det_t(t1), 1) * ddet_t_dt(t1) * std::pow(det_t(t2), 3));
+      2.0 * pow(det_t(t1), 1) * ddet_t_dt(t1) * pow(det_t(t2), 3));
   };
 
   static Tensor<2, dim, NumberType>
   dpsi_dt2(const SymmetricTensor<2, dim, NumberType> &t1,
            const Tensor<2, dim, NumberType> &         t2)
   {
-    return std::pow(det_t(t1), 2) * 3.0 * std::pow(det_t(t2), 2) *
-           ddet_t_dt(t2);
+    return pow(det_t(t1), 2) * 3.0 * pow(det_t(t2), 2) * ddet_t_dt(t2);
   };
 
   static SymmetricTensor<4, dim, NumberType>
@@ -130,16 +129,16 @@ struct FunctionsTestSymmetricTensorTensorCoupled
                 const Tensor<2, dim, NumberType> &         t2)
   {
     return SymmetricTensor<4, dim, NumberType>(
-      2.0 * std::pow(det_t(t2), 3) *
+      2.0 * pow(det_t(t2), 3) *
       (pow(det_t(t1), 0) * outer_product(ddet_t_dt(t1), ddet_t_dt(t1)) +
-       std::pow(det_t(t1), 1) * d2det_t_dt_dt(t1)));
+       pow(det_t(t1), 1) * d2det_t_dt_dt(t1)));
   };
 
   static Tensor<4, dim, NumberType>
   d2psi_dt2_dt1(const SymmetricTensor<2, dim, NumberType> &t1,
                 const Tensor<2, dim, NumberType> &         t2)
   {
-    return 2.0 * std::pow(det_t(t1), 1) * 3.0 * std::pow(det_t(t2), 2) *
+    return 2.0 * pow(det_t(t1), 1) * 3.0 * pow(det_t(t2), 2) *
            outer_product(static_cast<Tensor<2, dim, NumberType>>(ddet_t_dt(t1)),
                          ddet_t_dt(t2));
   };
@@ -148,7 +147,7 @@ struct FunctionsTestSymmetricTensorTensorCoupled
   d2psi_dt1_dt2(const SymmetricTensor<2, dim, NumberType> &t1,
                 const Tensor<2, dim, NumberType> &         t2)
   {
-    return 2.0 * std::pow(det_t(t1), 1) * 3.0 * std::pow(det_t(t2), 2) *
+    return 2.0 * pow(det_t(t1), 1) * 3.0 * pow(det_t(t2), 2) *
            outer_product(ddet_t_dt(t2),
                          static_cast<Tensor<2, dim, NumberType>>(
                            ddet_t_dt(t1)));
@@ -158,10 +157,10 @@ struct FunctionsTestSymmetricTensorTensorCoupled
   d2psi_dt2_dt2(const SymmetricTensor<2, dim, NumberType> &t1,
                 const Tensor<2, dim, NumberType> &         t2)
   {
-    return std::pow(det_t(t1), 2) * 3.0 *
-           (2.0 * std::pow(det_t(t2), 1) *
+    return pow(det_t(t1), 2) * 3.0 *
+           (2.0 * pow(det_t(t2), 1) *
               outer_product(ddet_t_dt(t2), ddet_t_dt(t2)) +
-            std::pow(det_t(t2), 2) * d2det_t_dt_dt(t2));
+            pow(det_t(t2), 2) * d2det_t_dt_dt(t2));
   };
 };
 

--- a/tests/ad_common_tests/helper_scalar_coupled_2_components_08.h
+++ b/tests/ad_common_tests/helper_scalar_coupled_2_components_08.h
@@ -76,7 +76,7 @@ struct FunctionsTestSymmetricTensorSymmetricTensorCoupled
   psi(const SymmetricTensor<2, dim, NumberType> &t1,
       const SymmetricTensor<2, dim, NumberType> &t2)
   {
-    return std::pow(det_t(t1), 2) * std::pow(det_t(t2), 3);
+    return pow(det_t(t1), 2) * pow(det_t(t2), 3);
   };
 
   static SymmetricTensor<2, dim, NumberType>
@@ -84,7 +84,7 @@ struct FunctionsTestSymmetricTensorSymmetricTensorCoupled
            const SymmetricTensor<2, dim, NumberType> &t2)
   {
     return SymmetricTensor<2, dim, NumberType>(
-      2.0 * std::pow(det_t(t1), 1) * ddet_t_dt(t1) * std::pow(det_t(t2), 3));
+      2.0 * pow(det_t(t1), 1) * ddet_t_dt(t1) * pow(det_t(t2), 3));
   };
 
   static SymmetricTensor<2, dim, NumberType>
@@ -92,7 +92,7 @@ struct FunctionsTestSymmetricTensorSymmetricTensorCoupled
            const SymmetricTensor<2, dim, NumberType> &t2)
   {
     return SymmetricTensor<2, dim, NumberType>(
-      pow(det_t(t1), 2) * 3.0 * std::pow(det_t(t2), 2) * ddet_t_dt(t2));
+      pow(det_t(t1), 2) * 3.0 * pow(det_t(t2), 2) * ddet_t_dt(t2));
   };
 
   static SymmetricTensor<4, dim, NumberType>
@@ -100,9 +100,9 @@ struct FunctionsTestSymmetricTensorSymmetricTensorCoupled
                 const SymmetricTensor<2, dim, NumberType> &t2)
   {
     return SymmetricTensor<4, dim, NumberType>(
-      2.0 * std::pow(det_t(t2), 3) *
+      2.0 * pow(det_t(t2), 3) *
       (pow(det_t(t1), 0) * outer_product(ddet_t_dt(t1), ddet_t_dt(t1)) +
-       std::pow(det_t(t1), 1) * d2det_t_dt_dt(t1)));
+       pow(det_t(t1), 1) * d2det_t_dt_dt(t1)));
   };
 
   static SymmetricTensor<4, dim, NumberType>
@@ -110,7 +110,7 @@ struct FunctionsTestSymmetricTensorSymmetricTensorCoupled
                 const SymmetricTensor<2, dim, NumberType> &t2)
   {
     return SymmetricTensor<4, dim, NumberType>(
-      2.0 * std::pow(det_t(t1), 1) * 3.0 * std::pow(det_t(t2), 2) *
+      2.0 * pow(det_t(t1), 1) * 3.0 * pow(det_t(t2), 2) *
       outer_product(ddet_t_dt(t1), ddet_t_dt(t2)));
   };
 
@@ -119,7 +119,7 @@ struct FunctionsTestSymmetricTensorSymmetricTensorCoupled
                 const SymmetricTensor<2, dim, NumberType> &t2)
   {
     return SymmetricTensor<4, dim, NumberType>(
-      2.0 * std::pow(det_t(t1), 1) * 3.0 * std::pow(det_t(t2), 2) *
+      2.0 * pow(det_t(t1), 1) * 3.0 * pow(det_t(t2), 2) *
       outer_product(ddet_t_dt(t2), ddet_t_dt(t1)));
   };
 
@@ -129,9 +129,8 @@ struct FunctionsTestSymmetricTensorSymmetricTensorCoupled
   {
     return SymmetricTensor<4, dim, NumberType>(
       pow(det_t(t1), 2) * 3.0 *
-      (2.0 * std::pow(det_t(t2), 1) *
-         outer_product(ddet_t_dt(t2), ddet_t_dt(t2)) +
-       std::pow(det_t(t2), 2) * d2det_t_dt_dt(t2)));
+      (2.0 * pow(det_t(t2), 1) * outer_product(ddet_t_dt(t2), ddet_t_dt(t2)) +
+       pow(det_t(t2), 2) * d2det_t_dt_dt(t2)));
   };
 };
 

--- a/tests/ad_common_tests/helper_scalar_coupled_3_components_01.h
+++ b/tests/ad_common_tests/helper_scalar_coupled_3_components_01.h
@@ -97,7 +97,7 @@ struct FunctionsTestTensorVectorScalarCoupled
       const Tensor<1, dim, NumberType> &v,
       const NumberType &                s)
   {
-    return std::pow(det_t(t), 2) * std::pow(v_squ(v), 3) * std::pow(s, sf);
+    return pow(det_t(t), 2) * pow(v_squ(v), 3) * pow(s, sf);
   };
 
   static Tensor<2, dim, NumberType>
@@ -105,8 +105,8 @@ struct FunctionsTestTensorVectorScalarCoupled
           const Tensor<1, dim, NumberType> &v,
           const NumberType &                s)
   {
-    return 2.0 * std::pow(det_t(t), 1) * ddet_t_dt(t) * std::pow(v_squ(v), 3) *
-           std::pow(s, sf);
+    return 2.0 * pow(det_t(t), 1) * ddet_t_dt(t) * pow(v_squ(v), 3) *
+           pow(s, sf);
   };
 
   static Tensor<1, dim, NumberType>
@@ -114,8 +114,8 @@ struct FunctionsTestTensorVectorScalarCoupled
           const Tensor<1, dim, NumberType> &v,
           const NumberType &                s)
   {
-    return std::pow(det_t(t), 2) * 3.0 * std::pow(v_squ(v), 2) * dv_squ_dv(v) *
-           std::pow(s, sf);
+    return pow(det_t(t), 2) * 3.0 * pow(v_squ(v), 2) * dv_squ_dv(v) *
+           pow(s, sf);
   };
 
   static NumberType
@@ -123,8 +123,7 @@ struct FunctionsTestTensorVectorScalarCoupled
           const Tensor<1, dim, NumberType> &v,
           const NumberType &                s)
   {
-    return std::pow(det_t(t), 2) * std::pow(v_squ(v), 3) * sf *
-           std::pow(s, sf - 1.0);
+    return pow(det_t(t), 2) * pow(v_squ(v), 3) * sf * pow(s, sf - 1.0);
   };
 
   static Tensor<4, dim, NumberType>
@@ -132,10 +131,10 @@ struct FunctionsTestTensorVectorScalarCoupled
               const Tensor<1, dim, NumberType> &v,
               const NumberType &                s)
   {
-    return 2.0 * std::pow(v_squ(v), 3) *
+    return 2.0 * pow(v_squ(v), 3) *
            (pow(det_t(t), 0) * outer_product(ddet_t_dt(t), ddet_t_dt(t)) +
-            std::pow(det_t(t), 1) * d2det_t_dt_dt(t)) *
-           std::pow(s, sf);
+            pow(det_t(t), 1) * d2det_t_dt_dt(t)) *
+           pow(s, sf);
   };
 
   static Tensor<3, dim, NumberType>
@@ -143,8 +142,8 @@ struct FunctionsTestTensorVectorScalarCoupled
               const Tensor<1, dim, NumberType> &v,
               const NumberType &                s)
   {
-    return 2.0 * std::pow(det_t(t), 1) * 3.0 * std::pow(v_squ(v), 2) *
-           outer_product(ddet_t_dt(t), dv_squ_dv(v)) * std::pow(s, sf);
+    return 2.0 * pow(det_t(t), 1) * 3.0 * pow(v_squ(v), 2) *
+           outer_product(ddet_t_dt(t), dv_squ_dv(v)) * pow(s, sf);
   };
 
   static Tensor<2, dim, NumberType>
@@ -152,8 +151,8 @@ struct FunctionsTestTensorVectorScalarCoupled
               const Tensor<1, dim, NumberType> &v,
               const NumberType &                s)
   {
-    return 2.0 * std::pow(det_t(t), 1) * ddet_t_dt(t) * std::pow(v_squ(v), 3) *
-           sf * std::pow(s, sf - 1.0);
+    return 2.0 * pow(det_t(t), 1) * ddet_t_dt(t) * pow(v_squ(v), 3) * sf *
+           pow(s, sf - 1.0);
   };
 
   static Tensor<3, dim, NumberType>
@@ -161,8 +160,8 @@ struct FunctionsTestTensorVectorScalarCoupled
               const Tensor<1, dim, NumberType> &v,
               const NumberType &                s)
   {
-    return 2.0 * std::pow(det_t(t), 1) * 3.0 * std::pow(v_squ(v), 2) *
-           outer_product(dv_squ_dv(v), ddet_t_dt(t)) * std::pow(s, sf);
+    return 2.0 * pow(det_t(t), 1) * 3.0 * pow(v_squ(v), 2) *
+           outer_product(dv_squ_dv(v), ddet_t_dt(t)) * pow(s, sf);
   };
 
   static Tensor<2, dim, NumberType>
@@ -170,11 +169,10 @@ struct FunctionsTestTensorVectorScalarCoupled
               const Tensor<1, dim, NumberType> &v,
               const NumberType &                s)
   {
-    return std::pow(det_t(t), 2) * 3.0 *
-           (2.0 * std::pow(v_squ(v), 1) *
-              outer_product(dv_squ_dv(v), dv_squ_dv(v)) +
-            std::pow(v_squ(v), 2) * d2v_squ_dv_dv(v)) *
-           std::pow(s, sf);
+    return pow(det_t(t), 2) * 3.0 *
+           (2.0 * pow(v_squ(v), 1) * outer_product(dv_squ_dv(v), dv_squ_dv(v)) +
+            pow(v_squ(v), 2) * d2v_squ_dv_dv(v)) *
+           pow(s, sf);
   };
 
   static Tensor<1, dim, NumberType>
@@ -182,8 +180,8 @@ struct FunctionsTestTensorVectorScalarCoupled
               const Tensor<1, dim, NumberType> &v,
               const NumberType &                s)
   {
-    return std::pow(det_t(t), 2) * 3.0 * std::pow(v_squ(v), 2) * dv_squ_dv(v) *
-           sf * std::pow(s, sf - 1.0);
+    return pow(det_t(t), 2) * 3.0 * pow(v_squ(v), 2) * dv_squ_dv(v) * sf *
+           pow(s, sf - 1.0);
   };
 
   static Tensor<2, dim, NumberType>
@@ -191,8 +189,8 @@ struct FunctionsTestTensorVectorScalarCoupled
               const Tensor<1, dim, NumberType> &v,
               const NumberType &                s)
   {
-    return 2.0 * std::pow(det_t(t), 1) * ddet_t_dt(t) * std::pow(v_squ(v), 3) *
-           sf * std::pow(s, sf - 1.0);
+    return 2.0 * pow(det_t(t), 1) * ddet_t_dt(t) * pow(v_squ(v), 3) * sf *
+           pow(s, sf - 1.0);
   };
 
   static Tensor<1, dim, NumberType>
@@ -200,8 +198,8 @@ struct FunctionsTestTensorVectorScalarCoupled
               const Tensor<1, dim, NumberType> &v,
               const NumberType &                s)
   {
-    return std::pow(det_t(t), 2) * 3.0 * std::pow(v_squ(v), 2) * dv_squ_dv(v) *
-           sf * std::pow(s, sf - 1.0);
+    return pow(det_t(t), 2) * 3.0 * pow(v_squ(v), 2) * dv_squ_dv(v) * sf *
+           pow(s, sf - 1.0);
   };
 
   static NumberType
@@ -209,8 +207,8 @@ struct FunctionsTestTensorVectorScalarCoupled
               const Tensor<1, dim, NumberType> &v,
               const NumberType &                s)
   {
-    return std::pow(det_t(t), 2) * std::pow(v_squ(v), 3) * sf * (sf - 1.0) *
-           std::pow(s, sf - 2.0);
+    return pow(det_t(t), 2) * pow(v_squ(v), 3) * sf * (sf - 1.0) *
+           pow(s, sf - 2.0);
   };
 };
 

--- a/tests/ad_common_tests/helper_scalar_coupled_3_components_01_tapeless_only.h
+++ b/tests/ad_common_tests/helper_scalar_coupled_3_components_01_tapeless_only.h
@@ -101,7 +101,7 @@ struct FunctionsTestTensorVectorScalarCoupled
       const Tensor<1, dim, NumberType> &v,
       const NumberType &                s)
   {
-    return std::pow(det_t(t), 2) * std::pow(v_squ(v), 3) * std::pow(s, sf);
+    return pow(det_t(t), 2) * pow(v_squ(v), 3) * pow(s, sf);
   };
 
   static Tensor<2, dim, NumberType>
@@ -109,8 +109,8 @@ struct FunctionsTestTensorVectorScalarCoupled
           const Tensor<1, dim, NumberType> &v,
           const NumberType &                s)
   {
-    return 2.0 * std::pow(det_t(t), 1) * ddet_t_dt(t) * std::pow(v_squ(v), 3) *
-           std::pow(s, sf);
+    return 2.0 * pow(det_t(t), 1) * ddet_t_dt(t) * pow(v_squ(v), 3) *
+           pow(s, sf);
   };
 
   static Tensor<1, dim, NumberType>
@@ -118,8 +118,8 @@ struct FunctionsTestTensorVectorScalarCoupled
           const Tensor<1, dim, NumberType> &v,
           const NumberType &                s)
   {
-    return std::pow(det_t(t), 2) * 3.0 * std::pow(v_squ(v), 2) * dv_squ_dv(v) *
-           std::pow(s, sf);
+    return pow(det_t(t), 2) * 3.0 * pow(v_squ(v), 2) * dv_squ_dv(v) *
+           pow(s, sf);
   };
 
   static NumberType
@@ -127,8 +127,7 @@ struct FunctionsTestTensorVectorScalarCoupled
           const Tensor<1, dim, NumberType> &v,
           const NumberType &                s)
   {
-    return std::pow(det_t(t), 2) * std::pow(v_squ(v), 3) * sf *
-           std::pow(s, sf - 1.0);
+    return pow(det_t(t), 2) * pow(v_squ(v), 3) * sf * pow(s, sf - 1.0);
   };
 
   static Tensor<4, dim, NumberType>
@@ -136,10 +135,10 @@ struct FunctionsTestTensorVectorScalarCoupled
               const Tensor<1, dim, NumberType> &v,
               const NumberType &                s)
   {
-    return 2.0 * std::pow(v_squ(v), 3) *
+    return 2.0 * pow(v_squ(v), 3) *
            (pow(det_t(t), 0) * outer_product(ddet_t_dt(t), ddet_t_dt(t)) +
-            std::pow(det_t(t), 1) * d2det_t_dt_dt(t)) *
-           std::pow(s, sf);
+            pow(det_t(t), 1) * d2det_t_dt_dt(t)) *
+           pow(s, sf);
   };
 
   static Tensor<3, dim, NumberType>
@@ -147,8 +146,8 @@ struct FunctionsTestTensorVectorScalarCoupled
               const Tensor<1, dim, NumberType> &v,
               const NumberType &                s)
   {
-    return 2.0 * std::pow(det_t(t), 1) * 3.0 * std::pow(v_squ(v), 2) *
-           outer_product(ddet_t_dt(t), dv_squ_dv(v)) * std::pow(s, sf);
+    return 2.0 * pow(det_t(t), 1) * 3.0 * pow(v_squ(v), 2) *
+           outer_product(ddet_t_dt(t), dv_squ_dv(v)) * pow(s, sf);
   };
 
   static Tensor<2, dim, NumberType>
@@ -156,8 +155,8 @@ struct FunctionsTestTensorVectorScalarCoupled
               const Tensor<1, dim, NumberType> &v,
               const NumberType &                s)
   {
-    return 2.0 * std::pow(det_t(t), 1) * ddet_t_dt(t) * std::pow(v_squ(v), 3) *
-           sf * std::pow(s, sf - 1.0);
+    return 2.0 * pow(det_t(t), 1) * ddet_t_dt(t) * pow(v_squ(v), 3) * sf *
+           pow(s, sf - 1.0);
   };
 
   static Tensor<3, dim, NumberType>
@@ -165,8 +164,8 @@ struct FunctionsTestTensorVectorScalarCoupled
               const Tensor<1, dim, NumberType> &v,
               const NumberType &                s)
   {
-    return 2.0 * std::pow(det_t(t), 1) * 3.0 * std::pow(v_squ(v), 2) *
-           outer_product(dv_squ_dv(v), ddet_t_dt(t)) * std::pow(s, sf);
+    return 2.0 * pow(det_t(t), 1) * 3.0 * pow(v_squ(v), 2) *
+           outer_product(dv_squ_dv(v), ddet_t_dt(t)) * pow(s, sf);
   };
 
   static Tensor<2, dim, NumberType>
@@ -174,11 +173,10 @@ struct FunctionsTestTensorVectorScalarCoupled
               const Tensor<1, dim, NumberType> &v,
               const NumberType &                s)
   {
-    return std::pow(det_t(t), 2) * 3.0 *
-           (2.0 * std::pow(v_squ(v), 1) *
-              outer_product(dv_squ_dv(v), dv_squ_dv(v)) +
-            std::pow(v_squ(v), 2) * d2v_squ_dv_dv(v)) *
-           std::pow(s, sf);
+    return pow(det_t(t), 2) * 3.0 *
+           (2.0 * pow(v_squ(v), 1) * outer_product(dv_squ_dv(v), dv_squ_dv(v)) +
+            pow(v_squ(v), 2) * d2v_squ_dv_dv(v)) *
+           pow(s, sf);
   };
 
   static Tensor<1, dim, NumberType>
@@ -186,8 +184,8 @@ struct FunctionsTestTensorVectorScalarCoupled
               const Tensor<1, dim, NumberType> &v,
               const NumberType &                s)
   {
-    return std::pow(det_t(t), 2) * 3.0 * std::pow(v_squ(v), 2) * dv_squ_dv(v) *
-           sf * std::pow(s, sf - 1.0);
+    return pow(det_t(t), 2) * 3.0 * pow(v_squ(v), 2) * dv_squ_dv(v) * sf *
+           pow(s, sf - 1.0);
   };
 
   static Tensor<2, dim, NumberType>
@@ -195,8 +193,8 @@ struct FunctionsTestTensorVectorScalarCoupled
               const Tensor<1, dim, NumberType> &v,
               const NumberType &                s)
   {
-    return 2.0 * std::pow(det_t(t), 1) * ddet_t_dt(t) * std::pow(v_squ(v), 3) *
-           sf * std::pow(s, sf - 1.0);
+    return 2.0 * pow(det_t(t), 1) * ddet_t_dt(t) * pow(v_squ(v), 3) * sf *
+           pow(s, sf - 1.0);
   };
 
   static Tensor<1, dim, NumberType>
@@ -204,8 +202,8 @@ struct FunctionsTestTensorVectorScalarCoupled
               const Tensor<1, dim, NumberType> &v,
               const NumberType &                s)
   {
-    return std::pow(det_t(t), 2) * 3.0 * std::pow(v_squ(v), 2) * dv_squ_dv(v) *
-           sf * std::pow(s, sf - 1.0);
+    return pow(det_t(t), 2) * 3.0 * pow(v_squ(v), 2) * dv_squ_dv(v) * sf *
+           pow(s, sf - 1.0);
   };
 
   static NumberType
@@ -213,8 +211,8 @@ struct FunctionsTestTensorVectorScalarCoupled
               const Tensor<1, dim, NumberType> &v,
               const NumberType &                s)
   {
-    return std::pow(det_t(t), 2) * std::pow(v_squ(v), 3) * sf * (sf - 1.0) *
-           std::pow(s, sf - 2.0);
+    return pow(det_t(t), 2) * pow(v_squ(v), 3) * sf * (sf - 1.0) *
+           pow(s, sf - 2.0);
   };
 };
 

--- a/tests/ad_common_tests/helper_scalar_coupled_4_components_01.h
+++ b/tests/ad_common_tests/helper_scalar_coupled_4_components_01.h
@@ -131,8 +131,7 @@ struct FunctionsTestSymmetricTensorTensorVectorScalarCoupled
       const Tensor<1, dim, NumberType> &         v,
       const NumberType &                         s)
   {
-    return std::pow(det_t(st), 2) * std::pow(det_t(t), 2) *
-           std::pow(v_squ(v), 3) * std::pow(s, sf);
+    return pow(det_t(st), 2) * pow(det_t(t), 2) * pow(v_squ(v), 3) * pow(s, sf);
   };
 
   // --------------------------------------------------------------------------
@@ -146,8 +145,8 @@ struct FunctionsTestSymmetricTensorTensorVectorScalarCoupled
            const Tensor<1, dim, NumberType> &         v,
            const NumberType &                         s)
   {
-    return 2.0 * std::pow(det_t(st), 1) * ddet_t_dt(st) *
-           std::pow(det_t(t), 2) * std::pow(v_squ(v), 3) * std::pow(s, sf);
+    return 2.0 * pow(det_t(st), 1) * ddet_t_dt(st) * pow(det_t(t), 2) *
+           pow(v_squ(v), 3) * pow(s, sf);
   };
 
   static Tensor<2, dim, NumberType>
@@ -156,8 +155,8 @@ struct FunctionsTestSymmetricTensorTensorVectorScalarCoupled
           const Tensor<1, dim, NumberType> &         v,
           const NumberType &                         s)
   {
-    return 2.0 * std::pow(det_t(st), 2) * std::pow(det_t(t), 1) * ddet_t_dt(t) *
-           std::pow(v_squ(v), 3) * std::pow(s, sf);
+    return 2.0 * pow(det_t(st), 2) * pow(det_t(t), 1) * ddet_t_dt(t) *
+           pow(v_squ(v), 3) * pow(s, sf);
   };
 
   static Tensor<1, dim, NumberType>
@@ -166,8 +165,8 @@ struct FunctionsTestSymmetricTensorTensorVectorScalarCoupled
           const Tensor<1, dim, NumberType> &         v,
           const NumberType &                         s)
   {
-    return std::pow(det_t(st), 2) * std::pow(det_t(t), 2) * 3.0 *
-           std::pow(v_squ(v), 2) * dv_squ_dv(v) * std::pow(s, sf);
+    return pow(det_t(st), 2) * pow(det_t(t), 2) * 3.0 * pow(v_squ(v), 2) *
+           dv_squ_dv(v) * pow(s, sf);
   };
 
   static NumberType
@@ -176,8 +175,8 @@ struct FunctionsTestSymmetricTensorTensorVectorScalarCoupled
           const Tensor<1, dim, NumberType> &         v,
           const NumberType &                         s)
   {
-    return std::pow(det_t(st), 2) * std::pow(det_t(t), 2) *
-           std::pow(v_squ(v), 3) * sf * std::pow(s, sf - 1.0);
+    return pow(det_t(st), 2) * pow(det_t(t), 2) * pow(v_squ(v), 3) * sf *
+           pow(s, sf - 1.0);
   };
 
   static SymmetricTensor<4, dim, NumberType>
@@ -186,11 +185,10 @@ struct FunctionsTestSymmetricTensorTensorVectorScalarCoupled
                   const Tensor<1, dim, NumberType> &         v,
                   const NumberType &                         s)
   {
-    return 2.0 * std::pow(det_t(t), 2) * std::pow(v_squ(v), 3) *
-           (std::pow(det_t(st), 0) *
-              outer_product(ddet_t_dt(st), ddet_t_dt(st)) +
-            std::pow(det_t(st), 1) * d2det_t_dt_dt(st)) *
-           std::pow(s, sf);
+    return 2.0 * pow(det_t(t), 2) * pow(v_squ(v), 3) *
+           (pow(det_t(st), 0) * outer_product(ddet_t_dt(st), ddet_t_dt(st)) +
+            pow(det_t(st), 1) * d2det_t_dt_dt(st)) *
+           pow(s, sf);
   };
 
   static Tensor<4, dim, NumberType>
@@ -199,10 +197,10 @@ struct FunctionsTestSymmetricTensorTensorVectorScalarCoupled
                  const Tensor<1, dim, NumberType> &         v,
                  const NumberType &                         s)
   {
-    return 4.0 * std::pow(det_t(st), 1) * std::pow(det_t(t), 1) *
+    return 4.0 * pow(det_t(st), 1) * pow(det_t(t), 1) *
            outer_product(Tensor<2, dim, NumberType>(ddet_t_dt(st)),
                          ddet_t_dt(t)) *
-           std::pow(v_squ(v), 3) * std::pow(s, sf);
+           pow(v_squ(v), 3) * pow(s, sf);
   };
 
   static Tensor<3, dim, NumberType>
@@ -211,11 +209,10 @@ struct FunctionsTestSymmetricTensorTensorVectorScalarCoupled
                  const Tensor<1, dim, NumberType> &         v,
                  const NumberType &                         s)
   {
-    return 2.0 * std::pow(det_t(t), 2) * std::pow(det_t(st), 1) * 3.0 *
-           std::pow(v_squ(v), 2) *
+    return 2.0 * pow(det_t(t), 2) * pow(det_t(st), 1) * 3.0 * pow(v_squ(v), 2) *
            outer_product(Tensor<2, dim, NumberType>(ddet_t_dt(st)),
                          dv_squ_dv(v)) *
-           std::pow(s, sf);
+           pow(s, sf);
   };
 
   static SymmetricTensor<2, dim, NumberType>
@@ -224,9 +221,8 @@ struct FunctionsTestSymmetricTensorTensorVectorScalarCoupled
                  const Tensor<1, dim, NumberType> &         v,
                  const NumberType &                         s)
   {
-    return 2.0 * std::pow(det_t(st), 1) * ddet_t_dt(st) *
-           std::pow(det_t(t), 2) * std::pow(v_squ(v), 3) * sf *
-           std::pow(s, sf - 1.0);
+    return 2.0 * pow(det_t(st), 1) * ddet_t_dt(st) * pow(det_t(t), 2) *
+           pow(v_squ(v), 3) * sf * pow(s, sf - 1.0);
   };
 
   static Tensor<4, dim, NumberType>
@@ -235,10 +231,10 @@ struct FunctionsTestSymmetricTensorTensorVectorScalarCoupled
                  const Tensor<1, dim, NumberType> &         v,
                  const NumberType &                         s)
   {
-    return 4.0 * std::pow(det_t(st), 1) * std::pow(det_t(t), 1) *
+    return 4.0 * pow(det_t(st), 1) * pow(det_t(t), 1) *
            outer_product(ddet_t_dt(t),
                          Tensor<2, dim, NumberType>(ddet_t_dt(st))) *
-           std::pow(v_squ(v), 3) * std::pow(s, sf);
+           pow(v_squ(v), 3) * pow(s, sf);
   };
 
   static Tensor<4, dim, NumberType>
@@ -247,10 +243,10 @@ struct FunctionsTestSymmetricTensorTensorVectorScalarCoupled
                 const Tensor<1, dim, NumberType> &         v,
                 const NumberType &                         s)
   {
-    return 2.0 * std::pow(det_t(st), 2) * std::pow(v_squ(v), 3) *
+    return 2.0 * pow(det_t(st), 2) * pow(v_squ(v), 3) *
            (pow(det_t(t), 0) * outer_product(ddet_t_dt(t), ddet_t_dt(t)) +
-            std::pow(det_t(t), 1) * d2det_t_dt_dt(t)) *
-           std::pow(s, sf);
+            pow(det_t(t), 1) * d2det_t_dt_dt(t)) *
+           pow(s, sf);
   };
 
   static Tensor<3, dim, NumberType>
@@ -259,9 +255,8 @@ struct FunctionsTestSymmetricTensorTensorVectorScalarCoupled
                 const Tensor<1, dim, NumberType> &         v,
                 const NumberType &                         s)
   {
-    return 2.0 * std::pow(det_t(st), 2) * std::pow(det_t(t), 1) * 3.0 *
-           std::pow(v_squ(v), 2) * outer_product(ddet_t_dt(t), dv_squ_dv(v)) *
-           std::pow(s, sf);
+    return 2.0 * pow(det_t(st), 2) * pow(det_t(t), 1) * 3.0 * pow(v_squ(v), 2) *
+           outer_product(ddet_t_dt(t), dv_squ_dv(v)) * pow(s, sf);
   };
 
   static Tensor<2, dim, NumberType>
@@ -270,8 +265,8 @@ struct FunctionsTestSymmetricTensorTensorVectorScalarCoupled
                 const Tensor<1, dim, NumberType> &         v,
                 const NumberType &                         s)
   {
-    return 2.0 * std::pow(det_t(st), 2) * std::pow(det_t(t), 1) * ddet_t_dt(t) *
-           std::pow(v_squ(v), 3) * sf * std::pow(s, sf - 1.0);
+    return 2.0 * pow(det_t(st), 2) * pow(det_t(t), 1) * ddet_t_dt(t) *
+           pow(v_squ(v), 3) * sf * pow(s, sf - 1.0);
   };
 
   static Tensor<3, dim, NumberType>
@@ -280,11 +275,10 @@ struct FunctionsTestSymmetricTensorTensorVectorScalarCoupled
                  const Tensor<1, dim, NumberType> &         v,
                  const NumberType &                         s)
   {
-    return 2.0 * std::pow(det_t(t), 2) * std::pow(det_t(st), 1) * 3.0 *
-           std::pow(v_squ(v), 2) *
+    return 2.0 * pow(det_t(t), 2) * pow(det_t(st), 1) * 3.0 * pow(v_squ(v), 2) *
            outer_product(dv_squ_dv(v),
                          Tensor<2, dim, NumberType>(ddet_t_dt(st))) *
-           std::pow(s, sf);
+           pow(s, sf);
   };
 
   static Tensor<3, dim, NumberType>
@@ -293,9 +287,8 @@ struct FunctionsTestSymmetricTensorTensorVectorScalarCoupled
                 const Tensor<1, dim, NumberType> &         v,
                 const NumberType &                         s)
   {
-    return 2.0 * std::pow(det_t(st), 2) * std::pow(det_t(t), 1) * 3.0 *
-           std::pow(v_squ(v), 2) * outer_product(dv_squ_dv(v), ddet_t_dt(t)) *
-           std::pow(s, sf);
+    return 2.0 * pow(det_t(st), 2) * pow(det_t(t), 1) * 3.0 * pow(v_squ(v), 2) *
+           outer_product(dv_squ_dv(v), ddet_t_dt(t)) * pow(s, sf);
   };
 
   static Tensor<2, dim, NumberType>
@@ -304,11 +297,10 @@ struct FunctionsTestSymmetricTensorTensorVectorScalarCoupled
                 const Tensor<1, dim, NumberType> &         v,
                 const NumberType &                         s)
   {
-    return std::pow(det_t(st), 2) * std::pow(det_t(t), 2) * 3.0 *
-           (2.0 * std::pow(v_squ(v), 1) *
-              outer_product(dv_squ_dv(v), dv_squ_dv(v)) +
-            std::pow(v_squ(v), 2) * d2v_squ_dv_dv(v)) *
-           std::pow(s, sf);
+    return pow(det_t(st), 2) * pow(det_t(t), 2) * 3.0 *
+           (2.0 * pow(v_squ(v), 1) * outer_product(dv_squ_dv(v), dv_squ_dv(v)) +
+            pow(v_squ(v), 2) * d2v_squ_dv_dv(v)) *
+           pow(s, sf);
   };
 
   static Tensor<1, dim, NumberType>
@@ -317,8 +309,8 @@ struct FunctionsTestSymmetricTensorTensorVectorScalarCoupled
                 const Tensor<1, dim, NumberType> &         v,
                 const NumberType &                         s)
   {
-    return std::pow(det_t(st), 2) * std::pow(det_t(t), 2) * 3.0 *
-           std::pow(v_squ(v), 2) * dv_squ_dv(v) * sf * std::pow(s, sf - 1.0);
+    return pow(det_t(st), 2) * pow(det_t(t), 2) * 3.0 * pow(v_squ(v), 2) *
+           dv_squ_dv(v) * sf * pow(s, sf - 1.0);
   };
 
   static SymmetricTensor<2, dim, NumberType>
@@ -327,9 +319,8 @@ struct FunctionsTestSymmetricTensorTensorVectorScalarCoupled
                  const Tensor<1, dim, NumberType> &         v,
                  const NumberType &                         s)
   {
-    return 2.0 * ddet_t_dt(st) * std::pow(det_t(t), 2) *
-           std::pow(det_t(st), 1) * std::pow(v_squ(v), 3) * sf *
-           std::pow(s, sf - 1.0);
+    return 2.0 * ddet_t_dt(st) * pow(det_t(t), 2) * pow(det_t(st), 1) *
+           pow(v_squ(v), 3) * sf * pow(s, sf - 1.0);
   };
 
   static Tensor<2, dim, NumberType>
@@ -338,8 +329,8 @@ struct FunctionsTestSymmetricTensorTensorVectorScalarCoupled
                 const Tensor<1, dim, NumberType> &         v,
                 const NumberType &                         s)
   {
-    return 2.0 * std::pow(det_t(st), 2) * std::pow(det_t(t), 1) * ddet_t_dt(t) *
-           std::pow(v_squ(v), 3) * sf * std::pow(s, sf - 1.0);
+    return 2.0 * pow(det_t(st), 2) * pow(det_t(t), 1) * ddet_t_dt(t) *
+           pow(v_squ(v), 3) * sf * pow(s, sf - 1.0);
   };
 
   static Tensor<1, dim, NumberType>
@@ -348,8 +339,8 @@ struct FunctionsTestSymmetricTensorTensorVectorScalarCoupled
                 const Tensor<1, dim, NumberType> &         v,
                 const NumberType &                         s)
   {
-    return std::pow(det_t(st), 2) * std::pow(det_t(t), 2) * 3.0 *
-           std::pow(v_squ(v), 2) * dv_squ_dv(v) * sf * std::pow(s, sf - 1.0);
+    return pow(det_t(st), 2) * pow(det_t(t), 2) * 3.0 * pow(v_squ(v), 2) *
+           dv_squ_dv(v) * sf * pow(s, sf - 1.0);
   };
 
   static NumberType
@@ -358,8 +349,8 @@ struct FunctionsTestSymmetricTensorTensorVectorScalarCoupled
                 const Tensor<1, dim, NumberType> &         v,
                 const NumberType &                         s)
   {
-    return std::pow(det_t(st), 2) * std::pow(det_t(t), 2) *
-           std::pow(v_squ(v), 3) * sf * (sf - 1.0) * std::pow(s, sf - 2.0);
+    return pow(det_t(st), 2) * pow(det_t(t), 2) * pow(v_squ(v), 3) * sf *
+           (sf - 1.0) * pow(s, sf - 2.0);
   };
 };
 

--- a/tests/ad_common_tests/helper_scalar_single_component_01.h
+++ b/tests/ad_common_tests/helper_scalar_single_component_01.h
@@ -40,19 +40,19 @@ struct FunctionsTestScalar
   static NumberType
   psi(const NumberType &s)
   {
-    return 4.0 * std::pow(s, 4);
+    return 4.0 * pow(s, 4);
   }
 
   static NumberType
   dpsi_ds(const NumberType &s)
   {
-    return 16.0 * std::pow(s, 3);
+    return 16.0 * pow(s, 3);
   }
 
   static NumberType
   d2psi_ds_ds(const NumberType &s)
   {
-    return 48.0 * std::pow(s, 2);
+    return 48.0 * pow(s, 2);
   }
 };
 

--- a/tests/ad_common_tests/helper_vector_1_indep_1_dep_vars_01.h
+++ b/tests/ad_common_tests/helper_vector_1_indep_1_dep_vars_01.h
@@ -42,13 +42,13 @@ struct FunctionsTestScalar
   static NumberType
   f0(const NumberType &s0)
   {
-    return 4.0 * std::pow(s0, 4);
+    return 4.0 * pow(s0, 4);
   }
 
   static NumberType
   df0_ds0(const NumberType &s0)
   {
-    return 16.0 * std::pow(s0, 3);
+    return 16.0 * pow(s0, 3);
   }
 };
 

--- a/tests/ad_common_tests/helper_vector_1_indep_2_dep_vars_01.h
+++ b/tests/ad_common_tests/helper_vector_1_indep_2_dep_vars_01.h
@@ -42,25 +42,25 @@ struct FunctionsTestSquare
   static NumberType
   f0(const NumberType &s0)
   {
-    return 2.0 * std::pow(s0, 4);
+    return 2.0 * pow(s0, 4);
   };
 
   static NumberType
   df0_ds0(const NumberType &s0)
   {
-    return 8.0 * std::pow(s0, 3);
+    return 8.0 * pow(s0, 3);
   };
 
   static NumberType
   f1(const NumberType &s0)
   {
-    return 3.0 * std::pow(s0, 2);
+    return 3.0 * pow(s0, 2);
   };
 
   static NumberType
   df1_ds0(const NumberType &s0)
   {
-    return 6.0 * std::pow(s0, 1);
+    return 6.0 * pow(s0, 1);
   };
 };
 

--- a/tests/ad_common_tests/helper_vector_2_indep_1_dep_vars_01.h
+++ b/tests/ad_common_tests/helper_vector_2_indep_1_dep_vars_01.h
@@ -42,19 +42,19 @@ struct FunctionsTestSquare
   static NumberType
   f0(const NumberType &s0, const NumberType &s1)
   {
-    return 2.0 * std::pow(s0, 4) * std::pow(s1, 3);
+    return 2.0 * pow(s0, 4) * pow(s1, 3);
   };
 
   static NumberType
   df0_ds0(const NumberType &s0, const NumberType &s1)
   {
-    return 8.0 * std::pow(s0, 3) * std::pow(s1, 3);
+    return 8.0 * pow(s0, 3) * pow(s1, 3);
   };
 
   static NumberType
   df0_ds1(const NumberType &s0, const NumberType &s1)
   {
-    return 6.0 * std::pow(s0, 4) * std::pow(s1, 2);
+    return 6.0 * pow(s0, 4) * pow(s1, 2);
   };
 };
 

--- a/tests/ad_common_tests/helper_vector_2_indep_2_dep_vars_01.h
+++ b/tests/ad_common_tests/helper_vector_2_indep_2_dep_vars_01.h
@@ -42,37 +42,37 @@ struct FunctionsTestSquare
   static NumberType
   f0(const NumberType &s0, const NumberType &s1)
   {
-    return 2.0 * std::pow(s0, 4) * std::pow(s1, 3);
+    return 2.0 * pow(s0, 4) * pow(s1, 3);
   };
 
   static NumberType
   df0_ds0(const NumberType &s0, const NumberType &s1)
   {
-    return 8.0 * std::pow(s0, 3) * std::pow(s1, 3);
+    return 8.0 * pow(s0, 3) * pow(s1, 3);
   };
 
   static NumberType
   df0_ds1(const NumberType &s0, const NumberType &s1)
   {
-    return 6.0 * std::pow(s0, 4) * std::pow(s1, 2);
+    return 6.0 * pow(s0, 4) * pow(s1, 2);
   };
 
   static NumberType
   f1(const NumberType &s0, const NumberType &s1)
   {
-    return 3.0 * std::pow(s0, 2) * std::pow(s1, 4);
+    return 3.0 * pow(s0, 2) * pow(s1, 4);
   };
 
   static NumberType
   df1_ds0(const NumberType &s0, const NumberType &s1)
   {
-    return 6.0 * std::pow(s0, 1) * std::pow(s1, 4);
+    return 6.0 * pow(s0, 1) * pow(s1, 4);
   };
 
   static NumberType
   df1_ds1(const NumberType &s0, const NumberType &s1)
   {
-    return 12.0 * std::pow(s0, 2) * std::pow(s1, 3);
+    return 12.0 * pow(s0, 2) * pow(s1, 3);
   };
 };
 

--- a/tests/ad_common_tests/step-44-helper_res_lin_01.h
+++ b/tests/ad_common_tests/step-44-helper_res_lin_01.h
@@ -475,7 +475,7 @@ namespace Step44
     {
       const NumberType                    det_F = determinant(F);
       SymmetricTensor<2, dim, NumberType> b_bar = symmetrize(F * transpose(F));
-      b_bar *= std::pow(det_F, -2.0 / dim);
+      b_bar *= pow(det_F, -2.0 / dim);
       return 2.0 * c_1 * b_bar;
     }
   };
@@ -1069,9 +1069,8 @@ namespace Step44
             const double det_F_qp = determinant(
               StandardTensors<dim>::I + solution_grads_u_total[q_point]);
             const double J_tilde_qp = solution_values_J_total[q_point];
-            const double the_error_qp_squared =
-              std::pow((det_F_qp - J_tilde_qp), 2);
-            const double JxW = fe_values_ref.JxW(q_point);
+            const double the_error_qp_squared = pow((det_F_qp - J_tilde_qp), 2);
+            const double JxW                  = fe_values_ref.JxW(q_point);
             dil_L2_error += the_error_qp_squared * JxW;
             vol_current += det_F_qp * JxW;
           }

--- a/tests/ad_common_tests/step-44-helper_scalar_01.h
+++ b/tests/ad_common_tests/step-44-helper_scalar_01.h
@@ -433,7 +433,7 @@ namespace Step44
                          const double          J_tilde_in)
     {
       det_F   = determinant(F);
-      b_bar   = std::pow(det_F, -2.0 / dim) * symmetrize(F * transpose(F));
+      b_bar   = pow(det_F, -2.0 / dim) * symmetrize(F * transpose(F));
       p_tilde = p_tilde_in;
       J_tilde = J_tilde_in;
       Assert(det_F > 0, ExcInternalError());
@@ -607,7 +607,7 @@ namespace Step44
 
             const ADNumberType det_F_AD = sqrt(determinant(C_AD));
             SymmetricTensor<2, dim, ADNumberType> C_bar_AD(C_AD);
-            C_bar_AD *= std::pow(det_F_AD, -2.0 / dim);
+            C_bar_AD *= pow(det_F_AD, -2.0 / dim);
 
             ADNumberType psi_CpJ = material->get_Psi_iso(C_bar_AD);
             psi_CpJ += p_tilde_AD * (det_F_AD - J_tilde_AD);
@@ -1553,11 +1553,10 @@ namespace Step44
         Assert(lqph.size() == n_q_points, ExcInternalError());
         for (unsigned int q_point = 0; q_point < n_q_points; ++q_point)
           {
-            const double det_F_qp   = lqph[q_point]->get_det_F();
-            const double J_tilde_qp = lqph[q_point]->get_J_tilde();
-            const double the_error_qp_squared =
-              std::pow((det_F_qp - J_tilde_qp), 2);
-            const double JxW = fe_values_ref.JxW(q_point);
+            const double det_F_qp             = lqph[q_point]->get_det_F();
+            const double J_tilde_qp           = lqph[q_point]->get_J_tilde();
+            const double the_error_qp_squared = pow((det_F_qp - J_tilde_qp), 2);
+            const double JxW                  = fe_values_ref.JxW(q_point);
             dil_L2_error += the_error_qp_squared * JxW;
           }
       }

--- a/tests/ad_common_tests/step-44-helper_var_form_01.h
+++ b/tests/ad_common_tests/step-44-helper_var_form_01.h
@@ -466,7 +466,7 @@ namespace Step44
         symmetrize(transpose(F) * F);
       const NumberType                    det_F = determinant(F);
       SymmetricTensor<2, dim, NumberType> C_bar(C);
-      C_bar *= std::pow(det_F, -2.0 / dim);
+      C_bar *= pow(det_F, -2.0 / dim);
 
       NumberType psi_CpJ = material->get_Psi_iso(C_bar);
       psi_CpJ += material->get_Psi_vol(J_tilde);
@@ -1035,9 +1035,8 @@ namespace Step44
             const double det_F_qp = determinant(
               StandardTensors<dim>::I + solution_grads_u_total[q_point]);
             const double J_tilde_qp = solution_values_J_total[q_point];
-            const double the_error_qp_squared =
-              std::pow((det_F_qp - J_tilde_qp), 2);
-            const double JxW = fe_values_ref.JxW(q_point);
+            const double the_error_qp_squared = pow((det_F_qp - J_tilde_qp), 2);
+            const double JxW                  = fe_values_ref.JxW(q_point);
             dil_L2_error += the_error_qp_squared * JxW;
             vol_current += det_F_qp * JxW;
           }

--- a/tests/ad_common_tests/step-44-helper_vector_01.h
+++ b/tests/ad_common_tests/step-44-helper_vector_01.h
@@ -476,7 +476,7 @@ namespace Step44
     {
       const NumberType                    det_F = determinant(F);
       SymmetricTensor<2, dim, NumberType> b_bar = symmetrize(F * transpose(F));
-      b_bar *= std::pow(det_F, -2.0 / dim);
+      b_bar *= pow(det_F, -2.0 / dim);
       return 2.0 * c_1 * b_bar;
     }
   };
@@ -1072,9 +1072,8 @@ namespace Step44
             const double det_F_qp = determinant(
               StandardTensors<dim>::I + solution_grads_u_total[q_point]);
             const double J_tilde_qp = solution_values_J_total[q_point];
-            const double the_error_qp_squared =
-              std::pow((det_F_qp - J_tilde_qp), 2);
-            const double JxW = fe_values_ref.JxW(q_point);
+            const double the_error_qp_squared = pow((det_F_qp - J_tilde_qp), 2);
+            const double JxW                  = fe_values_ref.JxW(q_point);
             dil_L2_error += the_error_qp_squared * JxW;
             vol_current += det_F_qp * JxW;
           }

--- a/tests/ad_common_tests/symmetric_tensor_functions_03.h
+++ b/tests/ad_common_tests/symmetric_tensor_functions_03.h
@@ -43,7 +43,9 @@ template <int dim, typename NumberType>
 NumberType
 J(const SymmetricTensor<2, dim, NumberType> &C)
 {
-  return std::sqrt(determinant(C));
+  // Make things work with AD types
+  using std::sqrt;
+  return sqrt(determinant(C));
 }
 
 template <int dim, typename NumberType>
@@ -53,7 +55,9 @@ struct IncompressibleNeoHookean
   static NumberType
   psi(const SymmetricTensor<2, dim, NumberType> &C)
   {
-    return 0.5 * mu() * (trace(C) - dim) - mu() * std::log(J(C));
+    // Make things work with AD types
+    using std::log;
+    return 0.5 * mu() * (trace(C) - dim) - mu() * log(J(C));
   }
 
   static SymmetricTensor<2, dim, NumberType>
@@ -89,15 +93,18 @@ struct IncompressibleNeoHookeanPrincipalStretches
   psi(const std::array<std::pair<NumberType, Tensor<1, dim, NumberType>>, dim>
         eig_C)
   {
+    // Make things work with AD types
+    using std::log;
+    using std::sqrt;
     NumberType psi = 0.0;
     NumberType J   = 1.0;
     for (unsigned int d = 0; d < dim; ++d)
       {
         const NumberType &lambda_squared = eig_C[d].first;
         psi += 0.5 * mu() * (lambda_squared - 1.0);
-        J *= std::sqrt(lambda_squared);
+        J *= sqrt(lambda_squared);
       }
-    psi -= mu() * std::log(J);
+    psi -= mu() * log(J);
     return psi;
   }
 

--- a/tests/ad_common_tests/symmetric_tensor_functions_04.h
+++ b/tests/ad_common_tests/symmetric_tensor_functions_04.h
@@ -43,7 +43,9 @@ template <int dim, typename NumberType>
 NumberType
 J(const SymmetricTensor<2, dim, NumberType> &C)
 {
-  return std::sqrt(determinant(C));
+  // Make things work with AD types
+  using std::sqrt;
+  return sqrt(determinant(C));
 }
 
 template <int dim, typename NumberType>
@@ -53,7 +55,9 @@ struct IncompressibleNeoHookean
   static NumberType
   psi(const SymmetricTensor<2, dim, NumberType> &C)
   {
-    return 0.5 * mu() * (trace(C) - dim) - mu() * std::log(J(C));
+    // Make things work with AD types
+    using std::log;
+    return 0.5 * mu() * (trace(C) - dim) - mu() * log(J(C));
   }
 
   static SymmetricTensor<2, dim, NumberType>

--- a/tests/adolc/helper_retaping_01.cc
+++ b/tests/adolc/helper_retaping_01.cc
@@ -51,31 +51,31 @@ struct FunctionsTestScalarScalarCoupled
   static NumberType
   psi(const NumberType &s1, const NumberType &s2)
   {
-    return 2.0 * std::pow(s1, 4) * std::pow(s2, 3);
+    return 2.0 * pow(s1, 4) * pow(s2, 3);
   };
 
   static NumberType
   dpsi_ds1(const NumberType &s1, const NumberType &s2)
   {
-    return 8.0 * std::pow(s1, 3) * std::pow(s2, 3);
+    return 8.0 * pow(s1, 3) * pow(s2, 3);
   };
 
   static NumberType
   dpsi_ds2(const NumberType &s1, const NumberType &s2)
   {
-    return 6.0 * std::pow(s1, 4) * std::pow(s2, 2);
+    return 6.0 * pow(s1, 4) * pow(s2, 2);
   };
 
   static NumberType
   d2psi_ds1_ds1(const NumberType &s1, const NumberType &s2)
   {
-    return 24.0 * std::pow(s1, 2) * std::pow(s2, 3);
+    return 24.0 * pow(s1, 2) * pow(s2, 3);
   };
 
   static NumberType
   d2psi_ds2_ds1(const NumberType &s1, const NumberType &s2)
   {
-    return 24.0 * std::pow(s1, 3) * std::pow(s2, 2);
+    return 24.0 * pow(s1, 3) * pow(s2, 2);
   };
 
   static NumberType
@@ -87,7 +87,7 @@ struct FunctionsTestScalarScalarCoupled
   static NumberType
   d2psi_ds2_ds2(const NumberType &s1, const NumberType &s2)
   {
-    return 12.0 * std::pow(s1, 4) * std::pow(s2, 1);
+    return 12.0 * pow(s1, 4) * pow(s2, 1);
   };
 };
 

--- a/tests/adolc/helper_retaping_02.cc
+++ b/tests/adolc/helper_retaping_02.cc
@@ -51,31 +51,31 @@ struct FunctionsTestScalarScalarCoupled
   static NumberType
   psi(const NumberType &s1, const NumberType &s2)
   {
-    return 2.0 * std::pow(s1, 4) * std::pow(s2, 3);
+    return 2.0 * pow(s1, 4) * pow(s2, 3);
   };
 
   static NumberType
   dpsi_ds1(const NumberType &s1, const NumberType &s2)
   {
-    return 8.0 * std::pow(s1, 3) * std::pow(s2, 3);
+    return 8.0 * pow(s1, 3) * pow(s2, 3);
   };
 
   static NumberType
   dpsi_ds2(const NumberType &s1, const NumberType &s2)
   {
-    return 6.0 * std::pow(s1, 4) * std::pow(s2, 2);
+    return 6.0 * pow(s1, 4) * pow(s2, 2);
   };
 
   static NumberType
   d2psi_ds1_ds1(const NumberType &s1, const NumberType &s2)
   {
-    return 24.0 * std::pow(s1, 2) * std::pow(s2, 3);
+    return 24.0 * pow(s1, 2) * pow(s2, 3);
   };
 
   static NumberType
   d2psi_ds2_ds1(const NumberType &s1, const NumberType &s2)
   {
-    return 24.0 * std::pow(s1, 3) * std::pow(s2, 2);
+    return 24.0 * pow(s1, 3) * pow(s2, 2);
   };
 
   static NumberType
@@ -87,7 +87,7 @@ struct FunctionsTestScalarScalarCoupled
   static NumberType
   d2psi_ds2_ds2(const NumberType &s1, const NumberType &s2)
   {
-    return 12.0 * std::pow(s1, 4) * std::pow(s2, 1);
+    return 12.0 * pow(s1, 4) * pow(s2, 1);
   };
 };
 

--- a/tests/adolc/helper_retaping_03.cc
+++ b/tests/adolc/helper_retaping_03.cc
@@ -50,31 +50,31 @@ struct FunctionsTestScalarScalarCoupled
   static NumberType
   psi(const NumberType &s1, const NumberType &s2)
   {
-    return 2.0 * std::pow(s1, 4) * std::pow(s2, 3);
+    return 2.0 * pow(s1, 4) * pow(s2, 3);
   };
 
   static NumberType
   dpsi_ds1(const NumberType &s1, const NumberType &s2)
   {
-    return 8.0 * std::pow(s1, 3) * std::pow(s2, 3);
+    return 8.0 * pow(s1, 3) * pow(s2, 3);
   };
 
   static NumberType
   dpsi_ds2(const NumberType &s1, const NumberType &s2)
   {
-    return 6.0 * std::pow(s1, 4) * std::pow(s2, 2);
+    return 6.0 * pow(s1, 4) * pow(s2, 2);
   };
 
   static NumberType
   d2psi_ds1_ds1(const NumberType &s1, const NumberType &s2)
   {
-    return 24.0 * std::pow(s1, 2) * std::pow(s2, 3);
+    return 24.0 * pow(s1, 2) * pow(s2, 3);
   };
 
   static NumberType
   d2psi_ds2_ds1(const NumberType &s1, const NumberType &s2)
   {
-    return 24.0 * std::pow(s1, 3) * std::pow(s2, 2);
+    return 24.0 * pow(s1, 3) * pow(s2, 2);
   };
 
   static NumberType
@@ -86,7 +86,7 @@ struct FunctionsTestScalarScalarCoupled
   static NumberType
   d2psi_ds2_ds2(const NumberType &s1, const NumberType &s2)
   {
-    return 12.0 * std::pow(s1, 4) * std::pow(s2, 1);
+    return 12.0 * pow(s1, 4) * pow(s2, 1);
   };
 };
 

--- a/tests/adolc/helper_tape_index_01.cc
+++ b/tests/adolc/helper_tape_index_01.cc
@@ -43,31 +43,31 @@ struct FunctionsTestScalarScalarCoupled
   static NumberType
   psi(const NumberType &s1, const NumberType &s2)
   {
-    return 2.0 * std::pow(s1, 4) * std::pow(s2, 3);
+    return 2.0 * pow(s1, 4) * pow(s2, 3);
   };
 
   static NumberType
   dpsi_ds1(const NumberType &s1, const NumberType &s2)
   {
-    return 8.0 * std::pow(s1, 3) * std::pow(s2, 3);
+    return 8.0 * pow(s1, 3) * pow(s2, 3);
   };
 
   static NumberType
   dpsi_ds2(const NumberType &s1, const NumberType &s2)
   {
-    return 6.0 * std::pow(s1, 4) * std::pow(s2, 2);
+    return 6.0 * pow(s1, 4) * pow(s2, 2);
   };
 
   static NumberType
   d2psi_ds1_ds1(const NumberType &s1, const NumberType &s2)
   {
-    return 24.0 * std::pow(s1, 2) * std::pow(s2, 3);
+    return 24.0 * pow(s1, 2) * pow(s2, 3);
   };
 
   static NumberType
   d2psi_ds2_ds1(const NumberType &s1, const NumberType &s2)
   {
-    return 24.0 * std::pow(s1, 3) * std::pow(s2, 2);
+    return 24.0 * pow(s1, 3) * pow(s2, 2);
   };
 
   static NumberType
@@ -79,7 +79,7 @@ struct FunctionsTestScalarScalarCoupled
   static NumberType
   d2psi_ds2_ds2(const NumberType &s1, const NumberType &s2)
   {
-    return 12.0 * std::pow(s1, 4) * std::pow(s2, 1);
+    return 12.0 * pow(s1, 4) * pow(s2, 1);
   };
 };
 


### PR DESCRIPTION
Part of #13949.

Sacado.hpp, when preprocessed, is over 200,000 lines. We can get things working in an equivalent way by using argument dependent lookup instead. All of the `sacado/` tests pass on my machine.

With this patch I can compile `obj_fe_debug` in 5:37, while on master it is 6:00.