### PR TITLE
Move Threads::Mutex to a dedicated header.

### DIFF
--- a/examples/step-48/step-48.cc
+++ b/examples/step-48/step-48.cc
@@ -20,6 +20,7 @@
 
 // The necessary files from the deal.II library.
 #include <deal.II/base/logstream.h>
+#include <deal.II/base/multithread_info.h>
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/function.h>
 #include <deal.II/base/conditional_ostream.h>

--- a/include/deal.II/base/flow_function.h
+++ b/include/deal.II/base/flow_function.h
@@ -20,8 +20,8 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/function.h>
+#include <deal.II/base/mutex.h>
 #include <deal.II/base/point.h>
-#include <deal.II/base/thread_management.h>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/base/function_cspline.h
+++ b/include/deal.II/base/function_cspline.h
@@ -20,8 +20,8 @@
 
 #ifdef DEAL_II_WITH_GSL
 #  include <deal.II/base/function.h>
+#  include <deal.II/base/mutex.h>
 #  include <deal.II/base/point.h>
-#  include <deal.II/base/thread_management.h>
 
 #  include <gsl/gsl_spline.h>
 

--- a/include/deal.II/base/incremental_function.h
+++ b/include/deal.II/base/incremental_function.h
@@ -20,7 +20,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/function.h>
-#include <deal.II/base/thread_management.h>
+#include <deal.II/base/mutex.h>
 
 #include <deal.II/lac/vector.h>
 

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -19,7 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/thread_management.h>
+#include <deal.II/base/mutex.h>
 #include <deal.II/base/utilities.h>
 
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS

--- a/include/deal.II/base/mutex.h
+++ b/include/deal.II/base/mutex.h
@@ -1,0 +1,84 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2000 - 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_mutex_h
+#define dealii_mutex_h
+
+
+#include <deal.II/base/config.h>
+
+#include <mutex>
+
+DEAL_II_NAMESPACE_OPEN
+
+/**
+ * @addtogroup threads
+ * @{
+ */
+
+namespace Threads
+{
+  /**
+   * A class implementing a <a
+   * href="https://en.wikipedia.org/wiki/Lock_(computer_science)">mutex</a>.
+   * Mutexes are used to lock data structures to ensure that only a
+   * single thread of execution can access them at the same time.
+   *
+   * This class is a thin wrapper around `std::mutex`. The only difference
+   * is that this class is copyable when `std::mutex` is not.  Indeed, when
+   * copied, the receiving object does not copy any state from the object
+   * being copied, i.e. an entirely new mutex is created. These semantics
+   * are consistent with the common use case if a mutex is used as a member
+   * variable to lock the other member variables of a class: in that case,
+   * the mutex of the copied-to object should only guard the members of the
+   * copied-to object, not the members of both the copied-to and
+   * copied-from object. Since at the time when the class is copied, the
+   * destination's member variable is not used yet, its corresponding mutex
+   * should also remain in its original state.
+   */
+  class Mutex : public std::mutex
+  {
+  public:
+    /**
+     * Default constructor.
+     */
+    Mutex() = default;
+
+    /**
+     * Copy constructor. As discussed in this class's documentation, no state
+     * is copied from the object given as argument.
+     */
+    Mutex(const Mutex &)
+      : std::mutex()
+    {}
+
+    /**
+     * Copy operators. As discussed in this class's documentation, no state
+     * is copied from the object given as argument.
+     */
+    Mutex &
+    operator=(const Mutex &)
+    {
+      return *this;
+    }
+  };
+} // namespace Threads
+
+/**
+ * @}
+ */
+
+DEAL_II_NAMESPACE_CLOSE
+#endif

--- a/include/deal.II/base/parallel.h
+++ b/include/deal.II/base/parallel.h
@@ -20,9 +20,9 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/mutex.h>
 #include <deal.II/base/synchronous_iterator.h>
 #include <deal.II/base/template_constraints.h>
-#include <deal.II/base/thread_management.h>
 
 #include <cstddef>
 #include <functional>
@@ -612,7 +612,7 @@ namespace parallel
       /**
        * A mutex to guard the access to the in_use flag.
        */
-      std::mutex mutex;
+      Threads::Mutex mutex;
 #endif
     };
   } // namespace internal

--- a/include/deal.II/base/polynomials_abf.h
+++ b/include/deal.II/base/polynomials_abf.h
@@ -20,13 +20,13 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/mutex.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomial_space.h>
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/tensor_polynomials_base.h>
 #include <deal.II/base/tensor_product_polynomials.h>
-#include <deal.II/base/thread_management.h>
 
 #include <memory>
 #include <vector>

--- a/include/deal.II/base/polynomials_bdm.h
+++ b/include/deal.II/base/polynomials_bdm.h
@@ -20,12 +20,12 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/mutex.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomial_space.h>
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/tensor_polynomials_base.h>
-#include <deal.II/base/thread_management.h>
 
 #include <vector>
 

--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -14,31 +14,31 @@
 // ---------------------------------------------------------------------
 
 #ifndef dealii_thread_management_h
-#  define dealii_thread_management_h
+#define dealii_thread_management_h
 
 
-#  include <deal.II/base/config.h>
+#include <deal.II/base/config.h>
 
-#  include <deal.II/base/exceptions.h>
-#  include <deal.II/base/multithread_info.h>
-#  include <deal.II/base/std_cxx17/tuple.h>
-#  include <deal.II/base/template_constraints.h>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/multithread_info.h>
+#include <deal.II/base/mutex.h>
+#include <deal.II/base/std_cxx17/tuple.h>
+#include <deal.II/base/template_constraints.h>
 
-#  include <atomic>
-#  include <functional>
-#  include <future>
-#  include <list>
-#  include <memory>
-#  include <mutex>
-#  include <thread>
-#  include <utility>
-#  include <vector>
+#include <atomic>
+#include <functional>
+#include <future>
+#include <list>
+#include <memory>
+#include <thread>
+#include <utility>
+#include <vector>
 
-#  ifdef DEAL_II_WITH_TBB
+#ifdef DEAL_II_WITH_TBB
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
-#    include <tbb/task_group.h>
+#  include <tbb/task_group.h>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
-#  endif
+#endif
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -54,55 +54,6 @@ DEAL_II_NAMESPACE_OPEN
  *
  * @ingroup threads
  */
-namespace Threads
-{
-  /**
-   * A class implementing a <a
-   * href="https://en.wikipedia.org/wiki/Lock_(computer_science)">mutex</a>.
-   * Mutexes are used to lock data structures to ensure that only a
-   * single thread of execution can access them at the same time.
-   *
-   * This class is a thin wrapper around `std::mutex`. The only difference
-   * is that this class is copyable when `std::mutex` is not.  Indeed, when
-   * copied, the receiving object does not copy any state from the object
-   * being copied, i.e. an entirely new mutex is created. These semantics
-   * are consistent with the common use case if a mutex is used as a member
-   * variable to lock the other member variables of a class: in that case,
-   * the mutex of the copied-to object should only guard the members of the
-   * copied-to object, not the members of both the copied-to and
-   * copied-from object. Since at the time when the class is copied, the
-   * destination's member variable is not used yet, its corresponding mutex
-   * should also remain in its original state.
-   */
-  class Mutex : public std::mutex
-  {
-  public:
-    /**
-     * Default constructor.
-     */
-    Mutex() = default;
-
-    /**
-     * Copy constructor. As discussed in this class's documentation, no state
-     * is copied from the object given as argument.
-     */
-    Mutex(const Mutex &)
-      : std::mutex()
-    {}
-
-    /**
-     * Copy operators. As discussed in this class's documentation, no state
-     * is copied from the object given as argument.
-     */
-    Mutex &
-    operator=(const Mutex &)
-    {
-      return *this;
-    }
-  };
-} // namespace Threads
-
-
 namespace Threads
 {
   /**
@@ -185,7 +136,7 @@ namespace Threads
 } // namespace Threads
 
 /* ----------- implementation of functions in namespace Threads ---------- */
-#  ifndef DOXYGEN
+#ifndef DOXYGEN
 namespace Threads
 {
   template <typename ForwardIterator>
@@ -236,7 +187,7 @@ namespace Threads
   }
 } // namespace Threads
 
-#  endif // DOXYGEN
+#endif // DOXYGEN
 
 namespace Threads
 {
@@ -1034,7 +985,7 @@ namespace Threads
     {
       if (MultithreadInfo::n_threads() > 1)
         {
-#  ifdef DEAL_II_WITH_TBB
+#ifdef DEAL_II_WITH_TBB
           // Create a promise object and from it extract a future that
           // we can use to refer to the outcome of the task. For reasons
           // explained below, we can't just create a std::promise object,
@@ -1102,7 +1053,7 @@ namespace Threads
                 }
             });
 
-#  else
+#else
           // If no threading library is supported, just fall back onto C++11
           // facilities. The problem with this is that the standard does
           // not actually say what std::async should do. The first
@@ -1123,7 +1074,7 @@ namespace Threads
           task_data = std::make_shared<TaskData>(
             std::async(std::launch::async | std::launch::deferred,
                        function_object));
-#  endif
+#endif
         }
       else
         {
@@ -1410,7 +1361,7 @@ namespace Threads
           return;
         else
           {
-#  ifdef DEAL_II_WITH_TBB
+#ifdef DEAL_II_WITH_TBB
             // If we build on the TBB, then we can't just wait for the
             // std::future object to get ready. Apparently the TBB happily
             // enqueues a task into an arena and then just sits on it without
@@ -1419,7 +1370,7 @@ namespace Threads
             // tbb::task_group, and then here wait for the single task
             // associated with that task group.
             task_group.wait();
-#  endif
+#endif
 
             // Wait for the task to finish and then move its
             // result. (We could have made the set_from() function
@@ -1488,14 +1439,14 @@ namespace Threads
        */
       internal::return_value<RT> returned_object;
 
-#  ifdef DEAL_II_WITH_TBB
+#ifdef DEAL_II_WITH_TBB
       /**
        * A task group object we can wait for.
        */
       tbb::task_group task_group;
 
       friend class Task<RT>;
-#  endif
+#endif
     };
 
     /**
@@ -1744,8 +1695,5 @@ namespace Threads
  */
 
 
-//---------------------------------------------------------------------------
 DEAL_II_NAMESPACE_CLOSE
-// end of #ifndef dealii_thread_management_h
 #endif
-//---------------------------------------------------------------------------

--- a/include/deal.II/base/timer.h
+++ b/include/deal.II/base/timer.h
@@ -20,7 +20,7 @@
 
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/mpi.h>
-#include <deal.II/base/thread_management.h>
+#include <deal.II/base/mutex.h>
 #include <deal.II/base/utilities.h>
 
 #include <chrono>

--- a/include/deal.II/fe/fe_dgq.h
+++ b/include/deal.II/fe/fe_dgq.h
@@ -18,8 +18,8 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/mutex.h>
 #include <deal.II/base/tensor_product_polynomials.h>
-#include <deal.II/base/thread_management.h>
 
 #include <deal.II/fe/fe_poly.h>
 

--- a/include/deal.II/fe/fe_nedelec.h
+++ b/include/deal.II/fe/fe_nedelec.h
@@ -19,12 +19,12 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/geometry_info.h>
+#include <deal.II/base/mutex.h>
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomials_nedelec.h>
 #include <deal.II/base/table.h>
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/tensor_product_polynomials.h>
-#include <deal.II/base/thread_management.h>
 
 #include <deal.II/fe/fe.h>
 #include <deal.II/fe/fe_poly_tensor.h>

--- a/include/deal.II/fe/fe_poly_tensor.h
+++ b/include/deal.II/fe/fe_poly_tensor.h
@@ -20,9 +20,9 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/derivative_form.h>
+#include <deal.II/base/mutex.h>
 #include <deal.II/base/quadrature.h>
 #include <deal.II/base/tensor_polynomials_base.h>
-#include <deal.II/base/thread_management.h>
 
 #include <deal.II/fe/fe.h>
 
@@ -536,7 +536,7 @@ protected:
   /**
    * A mutex to be used to guard access to the variables below.
    */
-  mutable std::mutex cache_mutex;
+  mutable Threads::Mutex cache_mutex;
 
   /**
    * If a shape function is computed at a single point, we must compute all of

--- a/include/deal.II/fe/fe_q_base.h
+++ b/include/deal.II/fe/fe_q_base.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/thread_management.h>
+#include <deal.II/base/mutex.h>
 
 #include <deal.II/fe/fe_poly.h>
 

--- a/include/deal.II/fe/fe_raviart_thomas.h
+++ b/include/deal.II/fe/fe_raviart_thomas.h
@@ -18,6 +18,7 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/mutex.h>
 #include <deal.II/base/table.h>
 
 #include <deal.II/fe/fe.h>

--- a/include/deal.II/fe/fe_simplex_p.h
+++ b/include/deal.II/fe/fe_simplex_p.h
@@ -18,6 +18,7 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/mutex.h>
 #include <deal.II/base/polynomials_barycentric.h>
 
 #include <deal.II/fe/fe_poly.h>

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -20,7 +20,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/mg_level_object.h>
-#include <deal.II/base/thread_management.h>
+#include <deal.II/base/mutex.h>
 
 #include <deal.II/dofs/dof_handler.h>
 
@@ -648,7 +648,7 @@ private:
   /**
    * A variable to guard access to the fe_values variable.
    */
-  mutable std::mutex fe_values_mutex;
+  mutable Threads::Mutex fe_values_mutex;
 
   void
   compute_data(const UpdateFlags      update_flags,

--- a/include/deal.II/fe/mapping_q_eulerian.h
+++ b/include/deal.II/fe/mapping_q_eulerian.h
@@ -19,8 +19,8 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/mutex.h>
 #include <deal.II/base/smartpointer.h>
-#include <deal.II/base/thread_management.h>
 
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_handler.h>

--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -20,9 +20,9 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/memory_consumption.h>
+#include <deal.II/base/mutex.h>
 #include <deal.II/base/smartpointer.h>
 #include <deal.II/base/table.h>
-#include <deal.II/base/thread_management.h>
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/lac/block_indices.h>
@@ -33,6 +33,7 @@
 #include <deal.II/lac/vector_operation.h>
 
 #include <cmath>
+#include <mutex>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -1038,7 +1039,7 @@ private:
      * A mutex variable used to guard access to the member variables of this
      * structure;
      */
-    std::mutex mutex;
+    Threads::Mutex mutex;
 
     /**
      * Copy operator. This is needed because the default copy operator of this

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -26,7 +26,6 @@
 #include <deal.II/base/parallel.h>
 #include <deal.II/base/partitioner.h>
 #include <deal.II/base/subscriptor.h>
-#include <deal.II/base/thread_management.h>
 
 #include <deal.II/lac/vector_operation.h>
 #include <deal.II/lac/vector_space_vector.h>

--- a/include/deal.II/lac/lapack_full_matrix.h
+++ b/include/deal.II/lac/lapack_full_matrix.h
@@ -19,9 +19,9 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/mutex.h>
 #include <deal.II/base/smartpointer.h>
 #include <deal.II/base/table.h>
-#include <deal.II/base/thread_management.h>
 
 #include <deal.II/lac/lapack_support.h>
 #include <deal.II/lac/vector_memory.h>
@@ -972,7 +972,7 @@ private:
   /**
    * Thread mutex.
    */
-  mutable std::mutex mutex;
+  mutable Threads::Mutex mutex;
 };
 
 

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -20,10 +20,10 @@
 
 #include <deal.II/base/cuda_size.h>
 #include <deal.II/base/memory_space.h>
+#include <deal.II/base/mutex.h>
 #include <deal.II/base/parallel.h>
 #include <deal.II/base/smartpointer.h>
 #include <deal.II/base/template_constraints.h>
-#include <deal.II/base/thread_management.h>
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/lac/affine_constraints.h>

--- a/include/deal.II/lac/scalapack.h
+++ b/include/deal.II/lac/scalapack.h
@@ -22,8 +22,8 @@
 
 #  include <deal.II/base/exceptions.h>
 #  include <deal.II/base/mpi.h>
+#  include <deal.II/base/mutex.h>
 #  include <deal.II/base/process_grid.h>
-#  include <deal.II/base/thread_management.h>
 
 #  include <deal.II/lac/full_matrix.h>
 #  include <deal.II/lac/lapack_full_matrix.h>

--- a/include/deal.II/lac/tensor_product_matrix.h
+++ b/include/deal.II/lac/tensor_product_matrix.h
@@ -20,7 +20,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/array_view.h>
-#include <deal.II/base/thread_management.h>
+#include <deal.II/base/mutex.h>
 
 #include <deal.II/lac/lapack_full_matrix.h>
 

--- a/include/deal.II/lac/vector_memory.h
+++ b/include/deal.II/lac/vector_memory.h
@@ -20,8 +20,8 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/logstream.h>
+#include <deal.II/base/mutex.h>
 #include <deal.II/base/smartpointer.h>
-#include <deal.II/base/thread_management.h>
 
 #include <deal.II/lac/vector.h>
 

--- a/include/deal.II/matrix_free/dof_info.templates.h
+++ b/include/deal.II/matrix_free/dof_info.templates.h
@@ -20,9 +20,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/memory_consumption.h>
-#include <deal.II/base/multithread_info.h>
 #include <deal.II/base/parallel.h>
-#include <deal.II/base/thread_management.h>
 
 #include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>

--- a/include/deal.II/matrix_free/mapping_info_storage.templates.h
+++ b/include/deal.II/matrix_free/mapping_info_storage.templates.h
@@ -19,8 +19,6 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/memory_consumption.h>
-#include <deal.II/base/multithread_info.h>
-#include <deal.II/base/thread_management.h>
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/fe/fe_dgq.h>

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -22,6 +22,7 @@
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/mpi_consensus_algorithms.h>
+#include <deal.II/base/multithread_info.h>
 #include <deal.II/base/polynomials_piecewise.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/tensor_product_polynomials.h>

--- a/include/deal.II/matrix_free/task_info.h
+++ b/include/deal.II/matrix_free/task_info.h
@@ -24,7 +24,6 @@
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/tensor.h>
-#include <deal.II/base/thread_management.h>
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/vectorization.h>
 

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -18,6 +18,7 @@
 #include <deal.II/base/geometry_info.h>
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/mpi.templates.h>
+#include <deal.II/base/thread_management.h>
 
 #include <deal.II/distributed/cell_data_transfer.templates.h>
 #include <deal.II/distributed/fully_distributed_tria.h>

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -22,6 +22,7 @@
 #include <deal.II/base/tensor_product_polynomials.h>
 #include <deal.II/base/tensor_product_polynomials_bubbles.h>
 #include <deal.II/base/tensor_product_polynomials_const.h>
+#include <deal.II/base/thread_management.h>
 
 #include <deal.II/fe/fe_dgp.h>
 #include <deal.II/fe/fe_dgq.h>

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -15,6 +15,7 @@
 
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/quadrature.h>
+#include <deal.II/base/thread_management.h>
 
 #include <deal.II/dofs/dof_accessor.h>
 

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -19,6 +19,7 @@
 #include <deal.II/base/numbers.h>
 #include <deal.II/base/quadrature.h>
 #include <deal.II/base/signaling_nan.h>
+#include <deal.II/base/thread_management.h>
 
 #include <deal.II/differentiation/ad.h>
 

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -16,6 +16,7 @@
 
 #include <deal.II/base/geometry_info.h>
 #include <deal.II/base/memory_consumption.h>
+#include <deal.II/base/thread_management.h>
 
 #include <deal.II/fe/mapping_q1.h>
 

--- a/source/non_matching/fe_immersed_values.cc
+++ b/source/non_matching/fe_immersed_values.cc
@@ -13,6 +13,8 @@
 //
 // ---------------------------------------------------------------------
 
+#include <deal.II/base/thread_management.h>
+
 #include <deal.II/grid/tria_iterator.h>
 
 #include <deal.II/non_matching/fe_immersed_values.h>


### PR DESCRIPTION
Part of #13949.

Most files don't need anything in `Threads` other than `Threads::Mutex` so we can decouple them from TBB et. al. by moving this class to its own header.

This is only a slight improvement in compile time - 628s user time for compiling base vs. 640s on master.