### PR TITLE
Move 'using MPI_Comm = int' et al to a separate header.

### DIFF
--- a/include/deal.II/base/communication_pattern_base.h
+++ b/include/deal.II/base/communication_pattern_base.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/mpi.h>
+#include <deal.II/base/mpi_stub.h>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -20,7 +20,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/geometry_info.h>
-#include <deal.II/base/mpi.h>
+#include <deal.II/base/mpi_stub.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/table.h>
 

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -19,6 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/mpi_stub.h>
 #include <deal.II/base/mutex.h>
 #include <deal.II/base/utilities.h>
 
@@ -34,15 +35,6 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #  include <Epetra_Map.h>
 #  ifdef DEAL_II_TRILINOS_WITH_TPETRA
 #    include <Tpetra_Map.hpp>
-#  endif
-#endif
-
-#if defined(DEAL_II_WITH_MPI) || defined(DEAL_II_WITH_PETSC)
-#  include <mpi.h>
-#else
-using MPI_Comm = int;
-#  ifndef MPI_COMM_WORLD
-#    define MPI_COMM_WORLD 0
 #  endif
 #endif
 

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -19,6 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/array_view.h>
+#include <deal.II/base/mpi_stub.h>
 #include <deal.II/base/mpi_tags.h>
 #include <deal.II/base/numbers.h>
 #include <deal.II/base/template_constraints.h>
@@ -31,40 +32,6 @@
 #include <numeric>
 #include <set>
 #include <vector>
-
-#if !defined(DEAL_II_WITH_MPI) && !defined(DEAL_II_WITH_PETSC)
-// without MPI, we would still like to use
-// some constructs with MPI data
-// types. Therefore, create some dummies
-using MPI_Comm     = int;
-using MPI_Request  = int;
-using MPI_Datatype = int;
-using MPI_Op       = int;
-#  ifndef MPI_COMM_WORLD
-#    define MPI_COMM_WORLD 0
-#  endif
-#  ifndef MPI_COMM_SELF
-#    define MPI_COMM_SELF 0
-#  endif
-#  ifndef MPI_COMM_NULL
-#    define MPI_COMM_NULL 0
-#  endif
-#  ifndef MPI_REQUEST_NULL
-#    define MPI_REQUEST_NULL 0
-#  endif
-#  ifndef MPI_MIN
-#    define MPI_MIN 0
-#  endif
-#  ifndef MPI_MAX
-#    define MPI_MAX 0
-#  endif
-#  ifndef MPI_SUM
-#    define MPI_SUM 0
-#  endif
-#  ifndef MPI_LOR
-#    define MPI_LOR 0
-#  endif
-#endif
 
 
 

--- a/include/deal.II/base/mpi_compute_index_owner_internal.h
+++ b/include/deal.II/base/mpi_compute_index_owner_internal.h
@@ -18,8 +18,8 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/mpi.h>
 #include <deal.II/base/mpi_consensus_algorithms.h>
+#include <deal.II/base/mpi_stub.h>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/base/mpi_consensus_algorithms.h
+++ b/include/deal.II/base/mpi_consensus_algorithms.h
@@ -20,6 +20,7 @@
 
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/mpi.templates.h>
+#include <deal.II/base/mpi_tags.h>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/base/mpi_noncontiguous_partitioner.h
+++ b/include/deal.II/base/mpi_noncontiguous_partitioner.h
@@ -19,9 +19,8 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/communication_pattern_base.h>
-#include <deal.II/base/mpi.h>
 #include <deal.II/base/mpi_compute_index_owner_internal.h>
-#include <deal.II/base/mpi_tags.h>
+#include <deal.II/base/mpi_stub.h>
 
 #include <deal.II/lac/vector_space_vector.h>
 

--- a/include/deal.II/base/mpi_noncontiguous_partitioner.templates.h
+++ b/include/deal.II/base/mpi_noncontiguous_partitioner.templates.h
@@ -22,6 +22,7 @@
 #include <deal.II/base/mpi.templates.h>
 #include <deal.II/base/mpi_compute_index_owner_internal.h>
 #include <deal.II/base/mpi_noncontiguous_partitioner.h>
+#include <deal.II/base/mpi_tags.h>
 
 #include <deal.II/lac/vector_space_vector.h>
 

--- a/include/deal.II/base/mpi_remote_point_evaluation.h
+++ b/include/deal.II/base/mpi_remote_point_evaluation.h
@@ -18,6 +18,9 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/mpi_tags.h>
+
 #include <deal.II/dofs/dof_handler.h>
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/base/mpi_stub.h
+++ b/include/deal.II/base/mpi_stub.h
@@ -1,0 +1,63 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2011 - 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_mpi_stub_h
+#define dealii_mpi_stub_h
+
+#include <deal.II/base/config.h>
+
+// If we have mpi.h then include it. Otherwise, define some common MPI data
+// types and global constants for the no-MPI case. This way we can still use,
+// e.g., MPI_Comm in the API.
+
+#if defined(DEAL_II_WITH_MPI) || defined(DEAL_II_WITH_PETSC)
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+#  include <mpi.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
+#else
+// without MPI, we would still like to use
+// some constructs with MPI data
+// types. Therefore, create some dummies
+using MPI_Comm     = int;
+using MPI_Request  = int;
+using MPI_Datatype = int;
+using MPI_Op       = int;
+#  ifndef MPI_COMM_WORLD
+#    define MPI_COMM_WORLD 0
+#  endif
+#  ifndef MPI_COMM_SELF
+#    define MPI_COMM_SELF 0
+#  endif
+#  ifndef MPI_COMM_NULL
+#    define MPI_COMM_NULL 0
+#  endif
+#  ifndef MPI_REQUEST_NULL
+#    define MPI_REQUEST_NULL 0
+#  endif
+#  ifndef MPI_MIN
+#    define MPI_MIN 0
+#  endif
+#  ifndef MPI_MAX
+#    define MPI_MAX 0
+#  endif
+#  ifndef MPI_SUM
+#    define MPI_SUM 0
+#  endif
+#  ifndef MPI_LOR
+#    define MPI_LOR 0
+#  endif
+#endif
+
+#endif

--- a/include/deal.II/base/partitioner.h
+++ b/include/deal.II/base/partitioner.h
@@ -22,13 +22,13 @@
 #include <deal.II/base/communication_pattern_base.h>
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/memory_space.h>
-#include <deal.II/base/mpi.h>
+#include <deal.II/base/mpi_stub.h>
 #include <deal.II/base/types.h>
 
 #include <deal.II/lac/vector_operation.h>
 
 #include <limits>
-
+#include <memory>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/base/partitioner.templates.h
+++ b/include/deal.II/base/partitioner.templates.h
@@ -19,6 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/cuda_size.h>
+#include <deal.II/base/mpi_tags.h>
 #include <deal.II/base/partitioner.h>
 
 #include <deal.II/lac/cuda_kernels.templates.h>

--- a/include/deal.II/distributed/fully_distributed_tria.h
+++ b/include/deal.II/distributed/fully_distributed_tria.h
@@ -19,14 +19,12 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/mpi_stub.h>
+
 #include <deal.II/distributed/repartitioning_policy_tools.h>
 #include <deal.II/distributed/tria_base.h>
 
 #include <vector>
-
-#ifdef DEAL_II_WITH_MPI
-#  include <mpi.h>
-#endif
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -19,6 +19,7 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/mpi_stub.h>
 #include <deal.II/base/smartpointer.h>
 #include <deal.II/base/subscriptor.h>
 #include <deal.II/base/template_constraints.h>
@@ -32,11 +33,6 @@
 #include <set>
 #include <utility>
 #include <vector>
-
-#ifdef DEAL_II_WITH_MPI
-#  include <mpi.h>
-#endif
-
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -19,6 +19,7 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/mpi_stub.h>
 #include <deal.II/base/smartpointer.h>
 #include <deal.II/base/subscriptor.h>
 #include <deal.II/base/template_constraints.h>
@@ -36,10 +37,6 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
-
-#ifdef DEAL_II_WITH_MPI
-#  include <mpi.h>
-#endif
 
 #ifdef DEAL_II_WITH_P4EST
 #  include <p4est.h>

--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -19,7 +19,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/mpi.h>
+#include <deal.II/base/mpi_stub.h>
 #include <deal.II/base/partitioner.h>
 #include <deal.II/base/smartpointer.h>
 #include <deal.II/base/subscriptor.h>

--- a/include/deal.II/dofs/number_cache.h
+++ b/include/deal.II/dofs/number_cache.h
@@ -19,7 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/index_set.h>
-#include <deal.II/base/mpi.h>
+#include <deal.II/base/mpi_stub.h>
 
 #include <vector>
 

--- a/include/deal.II/grid/tria_description.h
+++ b/include/deal.II/grid/tria_description.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/mpi.h>
+#include <deal.II/base/mpi_stub.h>
 
 #include <deal.II/grid/cell_id.h>
 #include <deal.II/grid/reference_cell.h>

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -21,7 +21,7 @@
 #include <deal.II/base/communication_pattern_base.h>
 #include <deal.II/base/memory_space.h>
 #include <deal.II/base/memory_space_data.h>
-#include <deal.II/base/mpi.h>
+#include <deal.II/base/mpi_stub.h>
 #include <deal.II/base/numbers.h>
 #include <deal.II/base/parallel.h>
 #include <deal.II/base/partitioner.h>

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -21,6 +21,7 @@
 
 #include <deal.II/base/cuda.h>
 #include <deal.II/base/cuda_size.h>
+#include <deal.II/base/mpi.h>
 
 #include <deal.II/lac/exceptions.h>
 #include <deal.II/lac/la_parallel_vector.h>

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -21,7 +21,7 @@
 #include <deal.II/base/communication_pattern_base.h>
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/memory_consumption.h>
-#include <deal.II/base/mpi.h>
+#include <deal.II/base/mpi_stub.h>
 #include <deal.II/base/parallel.h>
 #include <deal.II/base/subscriptor.h>
 #include <deal.II/base/template_constraints.h>
@@ -47,6 +47,9 @@ DEAL_II_NAMESPACE_OPEN
 
 // Forward declarations
 #ifndef DOXYGEN
+template <typename>
+class Vector;
+
 namespace LinearAlgebra
 {
   template <typename>

--- a/include/deal.II/lac/scalapack.h
+++ b/include/deal.II/lac/scalapack.h
@@ -22,14 +22,13 @@
 
 #  include <deal.II/base/exceptions.h>
 #  include <deal.II/base/mpi.h>
+#  include <deal.II/base/mpi_stub.h>
 #  include <deal.II/base/mutex.h>
 #  include <deal.II/base/process_grid.h>
 
 #  include <deal.II/lac/full_matrix.h>
 #  include <deal.II/lac/lapack_full_matrix.h>
 #  include <deal.II/lac/lapack_support.h>
-
-#  include <mpi.h>
 
 #  include <memory>
 

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -18,6 +18,7 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/mpi_stub.h>
 #include <deal.II/base/smartpointer.h>
 #include <deal.II/base/subscriptor.h>
 
@@ -25,9 +26,6 @@
 #include <deal.II/lac/identity_matrix.h>
 #include <deal.II/lac/sparsity_pattern.h>
 #include <deal.II/lac/vector_operation.h>
-#ifdef DEAL_II_WITH_MPI
-#  include <mpi.h>
-#endif
 
 #include <iterator>
 #include <memory>

--- a/include/deal.II/lac/sparsity_tools.h
+++ b/include/deal.II/lac/sparsity_tools.h
@@ -20,6 +20,8 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/index_set.h>
+#include <deal.II/base/mpi_stub.h>
 
 #include <deal.II/lac/block_sparsity_pattern.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
@@ -27,12 +29,6 @@
 
 #include <memory>
 #include <vector>
-
-#ifdef DEAL_II_WITH_MPI
-#  include <deal.II/base/index_set.h>
-
-#  include <mpi.h>
-#endif
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/lac/trilinos_epetra_vector.h
+++ b/include/deal.II/lac/trilinos_epetra_vector.h
@@ -22,6 +22,7 @@
 #ifdef DEAL_II_WITH_TRILINOS
 
 #  include <deal.II/base/index_set.h>
+#  include <deal.II/base/mpi_stub.h>
 #  include <deal.II/base/subscriptor.h>
 
 #  include <deal.II/lac/trilinos_epetra_communication_pattern.h>
@@ -30,7 +31,6 @@
 #  include <deal.II/lac/vector_type_traits.h>
 
 #  include <Epetra_FEVector.h>
-#  include <mpi.h>
 
 #  include <memory>
 

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -22,6 +22,7 @@
 #  ifdef DEAL_II_WITH_TRILINOS
 
 #    include <deal.II/base/index_set.h>
+#    include <deal.II/base/mpi_stub.h>
 #    include <deal.II/base/subscriptor.h>
 
 #    include <deal.II/lac/exceptions.h>
@@ -41,7 +42,6 @@
 #    include <Epetra_MpiComm.h>
 #    include <Epetra_MultiVector.h>
 #    include <Epetra_Operator.h>
-#    include <mpi.h>
 
 #    include <cmath>
 #    include <iterator>

--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -22,6 +22,7 @@
 #  ifdef DEAL_II_WITH_TRILINOS
 
 #    include <deal.II/base/index_set.h>
+#    include <deal.II/base/mpi_stub.h>
 #    include <deal.II/base/subscriptor.h>
 
 #    include <deal.II/lac/exceptions.h>
@@ -29,7 +30,6 @@
 #    include <Epetra_FECrsGraph.h>
 #    include <Epetra_Map.h>
 #    include <Epetra_MpiComm.h>
-#    include <mpi.h>
 
 #    include <cmath>
 #    include <memory>

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -22,6 +22,7 @@
 #ifdef DEAL_II_TRILINOS_WITH_TPETRA
 
 #  include <deal.II/base/index_set.h>
+#  include <deal.II/base/mpi_stub.h>
 #  include <deal.II/base/subscriptor.h>
 
 #  include <deal.II/lac/trilinos_tpetra_communication_pattern.h>
@@ -34,7 +35,6 @@
 #  include <Tpetra_Core.hpp>
 #  include <Tpetra_Vector.hpp>
 #  include <Tpetra_Version.hpp>
-#  include <mpi.h>
 
 #  include <memory>
 

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -21,7 +21,7 @@
 
 #ifdef DEAL_II_WITH_TRILINOS
 #  include <deal.II/base/index_set.h>
-#  include <deal.II/base/mpi.h>
+#  include <deal.II/base/mpi_stub.h>
 #  include <deal.II/base/subscriptor.h>
 #  include <deal.II/base/utilities.h>
 
@@ -35,7 +35,6 @@
 #  include <Epetra_LocalMap.h>
 #  include <Epetra_Map.h>
 #  include <Epetra_MpiComm.h>
-#  include <mpi.h>
 
 #  include <memory>
 #  include <utility>

--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -22,7 +22,8 @@
 #ifdef DEAL_II_COMPILER_CUDA_AWARE
 
 #  include <deal.II/base/cuda_size.h>
-#  include <deal.II/base/mpi.h>
+#  include <deal.II/base/mpi_stub.h>
+#  include <deal.II/base/partitioner.h>
 #  include <deal.II/base/quadrature.h>
 #  include <deal.II/base/tensor.h>
 

--- a/include/deal.II/matrix_free/task_info.h
+++ b/include/deal.II/matrix_free/task_info.h
@@ -22,7 +22,7 @@
 
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/memory_consumption.h>
-#include <deal.II/base/mpi.h>
+#include <deal.II/base/mpi_stub.h>
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/vectorization.h>

--- a/include/deal.II/matrix_free/vector_data_exchange.h
+++ b/include/deal.II/matrix_free/vector_data_exchange.h
@@ -21,10 +21,12 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/array_view.h>
-#include <deal.II/base/mpi.h>
+#include <deal.II/base/mpi_stub.h>
+#include <deal.II/base/partitioner.h>
 
 #include <deal.II/lac/vector_operation.h>
 
+#include <memory>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -21,7 +21,6 @@
 #include <deal.II/base/array_view.h>
 #include <deal.II/base/bounding_box.h>
 #include <deal.II/base/function.h>
-#include <deal.II/base/mpi.h>
 #include <deal.II/base/smartpointer.h>
 #include <deal.II/base/subscriptor.h>
 

--- a/include/deal.II/sundials/arkode.h
+++ b/include/deal.II/sundials/arkode.h
@@ -19,14 +19,15 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/mpi.h>
 
 #ifdef DEAL_II_WITH_SUNDIALS
 
 #  include <deal.II/base/conditional_ostream.h>
 #  include <deal.II/base/exceptions.h>
 #  include <deal.II/base/logstream.h>
+#  include <deal.II/base/mpi_stub.h>
 #  include <deal.II/base/parameter_handler.h>
+
 #  ifdef DEAL_II_WITH_PETSC
 #    include <deal.II/lac/petsc_block_vector.h>
 #    include <deal.II/lac/petsc_vector.h>

--- a/include/deal.II/sundials/ida.h
+++ b/include/deal.II/sundials/ida.h
@@ -19,12 +19,13 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/mpi.h>
 #ifdef DEAL_II_WITH_SUNDIALS
 #  include <deal.II/base/conditional_ostream.h>
 #  include <deal.II/base/exceptions.h>
 #  include <deal.II/base/logstream.h>
+#  include <deal.II/base/mpi_stub.h>
 #  include <deal.II/base/parameter_handler.h>
+
 #  ifdef DEAL_II_WITH_PETSC
 #    include <deal.II/lac/petsc_block_vector.h>
 #    include <deal.II/lac/petsc_vector.h>

--- a/include/deal.II/sundials/kinsol.h
+++ b/include/deal.II/sundials/kinsol.h
@@ -25,7 +25,7 @@
 #  include <deal.II/base/conditional_ostream.h>
 #  include <deal.II/base/exceptions.h>
 #  include <deal.II/base/logstream.h>
-#  include <deal.II/base/mpi.h>
+#  include <deal.II/base/mpi_stub.h>
 #  include <deal.II/base/parameter_handler.h>
 
 #  include <deal.II/lac/vector.h>

--- a/source/grid/grid_tools_cache.cc
+++ b/source/grid/grid_tools_cache.cc
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 #include <deal.II/base/bounding_box.h>
-#include <deal.II/base/mpi.h>
+#include <deal.II/base/mpi_stub.h>
 
 #include <deal.II/grid/filtered_iterator.h>
 #include <deal.II/grid/grid_tools.h>

--- a/source/lac/trilinos_epetra_vector.cc
+++ b/source/lac/trilinos_epetra_vector.cc
@@ -18,6 +18,7 @@
 #ifdef DEAL_II_WITH_TRILINOS
 
 #  include <deal.II/base/index_set.h>
+#  include <deal.II/base/mpi.h>
 
 #  include <deal.II/lac/read_write_vector.h>
 


### PR DESCRIPTION
Part of #13949.

Most of the time we only need declarations of MPI classes (like MPI_Comm) and not our own utility functions in headers. To this end, we can just put mpi.h (or our equivalent stub declarations) in a separate header and use that. 

This and some other minor patches provide a modest speedup essentially due to avoiding the boost headers we have in `mpi.h`:
make -j4 obj_fe_debug on master: user time: 1170, wall time 5:35
make -j4 obj_fe_debug on feature: user time 1104.7, wall time 5:16
