### PR TITLE
Remove now redundant namespace identifier.

### DIFF
--- a/include/deal.II/hp/refinement.h
+++ b/include/deal.II/hp/refinement.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2019 - 2021 by the deal.II authors
+// Copyright (C) 2019 - 2022 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -154,7 +154,7 @@ namespace hp
      */
     template <int dim, int spacedim>
     void
-    full_p_adaptivity(const dealii::DoFHandler<dim, spacedim> &dof_handler);
+    full_p_adaptivity(const DoFHandler<dim, spacedim> &dof_handler);
 
     /**
      * Adapt which finite element to use on cells that have been specifically
@@ -172,9 +172,8 @@ namespace hp
      */
     template <int dim, int spacedim>
     void
-    p_adaptivity_from_flags(
-      const dealii::DoFHandler<dim, spacedim> &dof_handler,
-      const std::vector<bool> &                p_flags);
+    p_adaptivity_from_flags(const DoFHandler<dim, spacedim> &dof_handler,
+                            const std::vector<bool> &        p_flags);
 
     /**
      * Adapt which finite element to use on cells whose criteria meet a certain
@@ -204,10 +203,10 @@ namespace hp
     template <int dim, typename Number, int spacedim>
     void
     p_adaptivity_from_absolute_threshold(
-      const dealii::DoFHandler<dim, spacedim> &dof_handler,
-      const Vector<Number> &                   criteria,
-      const Number                             p_refine_threshold,
-      const Number                             p_coarsen_threshold,
+      const DoFHandler<dim, spacedim> &dof_handler,
+      const Vector<Number> &           criteria,
+      const Number                     p_refine_threshold,
+      const Number                     p_coarsen_threshold,
       const ComparisonFunction<typename identity<Number>::type>
         &compare_refine = std::greater_equal<Number>(),
       const ComparisonFunction<typename identity<Number>::type>
@@ -247,10 +246,10 @@ namespace hp
     template <int dim, typename Number, int spacedim>
     void
     p_adaptivity_from_relative_threshold(
-      const dealii::DoFHandler<dim, spacedim> &dof_handler,
-      const Vector<Number> &                   criteria,
-      const double                             p_refine_fraction  = 0.5,
-      const double                             p_coarsen_fraction = 0.5,
+      const DoFHandler<dim, spacedim> &dof_handler,
+      const Vector<Number> &           criteria,
+      const double                     p_refine_fraction  = 0.5,
+      const double                     p_coarsen_fraction = 0.5,
       const ComparisonFunction<typename identity<Number>::type>
         &compare_refine = std::greater_equal<Number>(),
       const ComparisonFunction<typename identity<Number>::type>
@@ -291,10 +290,10 @@ namespace hp
     template <int dim, typename Number, int spacedim>
     void
     p_adaptivity_fixed_number(
-      const dealii::DoFHandler<dim, spacedim> &dof_handler,
-      const Vector<Number> &                   criteria,
-      const double                             p_refine_fraction  = 0.5,
-      const double                             p_coarsen_fraction = 0.5,
+      const DoFHandler<dim, spacedim> &dof_handler,
+      const Vector<Number> &           criteria,
+      const double                     p_refine_fraction  = 0.5,
+      const double                     p_coarsen_fraction = 0.5,
       const ComparisonFunction<typename identity<Number>::type>
         &compare_refine = std::greater_equal<Number>(),
       const ComparisonFunction<typename identity<Number>::type>
@@ -328,9 +327,8 @@ namespace hp
      */
     template <int dim, typename Number, int spacedim>
     void
-    p_adaptivity_from_regularity(
-      const dealii::DoFHandler<dim, spacedim> &dof_handler,
-      const Vector<Number> &                   sobolev_indices);
+    p_adaptivity_from_regularity(const DoFHandler<dim, spacedim> &dof_handler,
+                                 const Vector<Number> &sobolev_indices);
 
     /**
      * Adapt which finite element to use on each cell based on how its criterion
@@ -355,7 +353,7 @@ namespace hp
     template <int dim, typename Number, int spacedim>
     void
     p_adaptivity_from_reference(
-      const dealii::DoFHandler<dim, spacedim> &                  dof_handler,
+      const DoFHandler<dim, spacedim> &                          dof_handler,
       const Vector<Number> &                                     criteria,
       const Vector<Number> &                                     references,
       const ComparisonFunction<typename identity<Number>::type> &compare_refine,
@@ -592,12 +590,12 @@ namespace hp
      */
     template <int dim, typename Number, int spacedim>
     void
-    predict_error(const dealii::DoFHandler<dim, spacedim> &dof_handler,
-                  const Vector<Number> &                   error_indicators,
-                  Vector<Number> &                         predicted_errors,
-                  const double gamma_p = std::sqrt(0.4),
-                  const double gamma_h = 2.,
-                  const double gamma_n = 1.);
+    predict_error(const DoFHandler<dim, spacedim> &dof_handler,
+                  const Vector<Number> &           error_indicators,
+                  Vector<Number> &                 predicted_errors,
+                  const double                     gamma_p = std::sqrt(0.4),
+                  const double                     gamma_h = 2.,
+                  const double                     gamma_n = 1.);
 
     /**
      * @}
@@ -621,7 +619,7 @@ namespace hp
      */
     template <int dim, int spacedim>
     void
-    force_p_over_h(const dealii::DoFHandler<dim, spacedim> &dof_handler);
+    force_p_over_h(const DoFHandler<dim, spacedim> &dof_handler);
 
     /**
      * Choose p-adaptivity over h-adaptivity whenever it is invoked on all
@@ -669,7 +667,7 @@ namespace hp
      */
     template <int dim, int spacedim>
     void
-    choose_p_over_h(const dealii::DoFHandler<dim, spacedim> &dof_handler);
+    choose_p_over_h(const DoFHandler<dim, spacedim> &dof_handler);
 
     /**
      * @}
@@ -714,10 +712,9 @@ namespace hp
      */
     template <int dim, int spacedim>
     bool
-    limit_p_level_difference(
-      const dealii::DoFHandler<dim, spacedim> &dof_handler,
-      const unsigned int                       max_difference    = 1,
-      const unsigned int                       contains_fe_index = 0);
+    limit_p_level_difference(const DoFHandler<dim, spacedim> &dof_handler,
+                             const unsigned int max_difference    = 1,
+                             const unsigned int contains_fe_index = 0);
 
     /**
      * @}

--- a/source/hp/refinement.cc
+++ b/source/hp/refinement.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2019 - 2021 by the deal.II authors
+// Copyright (C) 2019 - 2022 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -45,15 +45,14 @@ namespace hp
      */
     template <int dim, int spacedim>
     void
-    full_p_adaptivity(const dealii::DoFHandler<dim, spacedim> &dof_handler)
+    full_p_adaptivity(const DoFHandler<dim, spacedim> &dof_handler)
     {
       if (dof_handler.get_fe_collection().size() == 0)
         // nothing to do
         return;
 
-      Assert(
-        dof_handler.has_hp_capabilities(),
-        (typename dealii::DoFHandler<dim, spacedim>::ExcOnlyAvailableWithHP()));
+      Assert(dof_handler.has_hp_capabilities(),
+             (typename DoFHandler<dim, spacedim>::ExcOnlyAvailableWithHP()));
 
       std::vector<bool> p_flags(
         dof_handler.get_triangulation().n_active_cells(), true);
@@ -65,17 +64,15 @@ namespace hp
 
     template <int dim, int spacedim>
     void
-    p_adaptivity_from_flags(
-      const dealii::DoFHandler<dim, spacedim> &dof_handler,
-      const std::vector<bool> &                p_flags)
+    p_adaptivity_from_flags(const DoFHandler<dim, spacedim> &dof_handler,
+                            const std::vector<bool> &        p_flags)
     {
       if (dof_handler.get_fe_collection().size() == 0)
         // nothing to do
         return;
 
-      Assert(
-        dof_handler.has_hp_capabilities(),
-        (typename dealii::DoFHandler<dim, spacedim>::ExcOnlyAvailableWithHP()));
+      Assert(dof_handler.has_hp_capabilities(),
+             (typename DoFHandler<dim, spacedim>::ExcOnlyAvailableWithHP()));
       AssertDimension(dof_handler.get_triangulation().n_active_cells(),
                       p_flags.size());
 
@@ -110,10 +107,10 @@ namespace hp
     template <int dim, typename Number, int spacedim>
     void
     p_adaptivity_from_absolute_threshold(
-      const dealii::DoFHandler<dim, spacedim> &dof_handler,
-      const Vector<Number> &                   criteria,
-      const Number                             p_refine_threshold,
-      const Number                             p_coarsen_threshold,
+      const DoFHandler<dim, spacedim> &dof_handler,
+      const Vector<Number> &           criteria,
+      const Number                     p_refine_threshold,
+      const Number                     p_coarsen_threshold,
       const ComparisonFunction<typename identity<Number>::type> &compare_refine,
       const ComparisonFunction<typename identity<Number>::type>
         &compare_coarsen)
@@ -122,9 +119,8 @@ namespace hp
         // nothing to do
         return;
 
-      Assert(
-        dof_handler.has_hp_capabilities(),
-        (typename dealii::DoFHandler<dim, spacedim>::ExcOnlyAvailableWithHP()));
+      Assert(dof_handler.has_hp_capabilities(),
+             (typename DoFHandler<dim, spacedim>::ExcOnlyAvailableWithHP()));
       AssertDimension(dof_handler.get_triangulation().n_active_cells(),
                       criteria.size());
 
@@ -149,10 +145,10 @@ namespace hp
     template <int dim, typename Number, int spacedim>
     void
     p_adaptivity_from_relative_threshold(
-      const dealii::DoFHandler<dim, spacedim> &dof_handler,
-      const Vector<Number> &                   criteria,
-      const double                             p_refine_fraction,
-      const double                             p_coarsen_fraction,
+      const DoFHandler<dim, spacedim> &dof_handler,
+      const Vector<Number> &           criteria,
+      const double                     p_refine_fraction,
+      const double                     p_coarsen_fraction,
       const ComparisonFunction<typename identity<Number>::type> &compare_refine,
       const ComparisonFunction<typename identity<Number>::type>
         &compare_coarsen)
@@ -161,15 +157,14 @@ namespace hp
         // nothing to do
         return;
 
-      Assert(
-        dof_handler.has_hp_capabilities(),
-        (typename dealii::DoFHandler<dim, spacedim>::ExcOnlyAvailableWithHP()));
+      Assert(dof_handler.has_hp_capabilities(),
+             (typename DoFHandler<dim, spacedim>::ExcOnlyAvailableWithHP()));
       AssertDimension(dof_handler.get_triangulation().n_active_cells(),
                       criteria.size());
       Assert((p_refine_fraction >= 0) && (p_refine_fraction <= 1),
-             dealii::GridRefinement::ExcInvalidParameterValue());
+             GridRefinement::ExcInvalidParameterValue());
       Assert((p_coarsen_fraction >= 0) && (p_coarsen_fraction <= 1),
-             dealii::GridRefinement::ExcInvalidParameterValue());
+             GridRefinement::ExcInvalidParameterValue());
 
       // We first have to determine the maximal and minimal values of the
       // criteria of all flagged cells.
@@ -246,10 +241,10 @@ namespace hp
     template <int dim, typename Number, int spacedim>
     void
     p_adaptivity_fixed_number(
-      const dealii::DoFHandler<dim, spacedim> &dof_handler,
-      const Vector<Number> &                   criteria,
-      const double                             p_refine_fraction,
-      const double                             p_coarsen_fraction,
+      const DoFHandler<dim, spacedim> &dof_handler,
+      const Vector<Number> &           criteria,
+      const double                     p_refine_fraction,
+      const double                     p_coarsen_fraction,
       const ComparisonFunction<typename identity<Number>::type> &compare_refine,
       const ComparisonFunction<typename identity<Number>::type>
         &compare_coarsen)
@@ -258,15 +253,14 @@ namespace hp
         // nothing to do
         return;
 
-      Assert(
-        dof_handler.has_hp_capabilities(),
-        (typename dealii::DoFHandler<dim, spacedim>::ExcOnlyAvailableWithHP()));
+      Assert(dof_handler.has_hp_capabilities(),
+             (typename DoFHandler<dim, spacedim>::ExcOnlyAvailableWithHP()));
       AssertDimension(dof_handler.get_triangulation().n_active_cells(),
                       criteria.size());
       Assert((p_refine_fraction >= 0) && (p_refine_fraction <= 1),
-             dealii::GridRefinement::ExcInvalidParameterValue());
+             GridRefinement::ExcInvalidParameterValue());
       Assert((p_coarsen_fraction >= 0) && (p_coarsen_fraction <= 1),
-             dealii::GridRefinement::ExcInvalidParameterValue());
+             GridRefinement::ExcInvalidParameterValue());
 
       // ComparisonFunction returning 'true' or 'false' for any set of
       // parameters. These will be used to overwrite user-provided comparison
@@ -353,12 +347,12 @@ namespace hp
           // 3.) Figure out the global max and min of the criteria. We don't
           //     need it here, but it's a collective communication call.
           const std::pair<Number, Number> global_min_max_refinement =
-            dealii::internal::parallel::distributed::GridRefinement::
+            internal::parallel::distributed::GridRefinement::
               compute_global_min_and_max_at_root(indicators_refinement,
                                                  mpi_communicator);
 
           const std::pair<Number, Number> global_min_max_coarsening =
-            dealii::internal::parallel::distributed::GridRefinement::
+            internal::parallel::distributed::GridRefinement::
               compute_global_min_and_max_at_root(indicators_coarsening,
                                                  mpi_communicator);
 
@@ -368,7 +362,7 @@ namespace hp
           else if (target_index_refinement == n_global_flags_refinement)
             reference_compare_refine = std::cref(compare_true);
           else
-            threshold_refinement = dealii::internal::parallel::distributed::
+            threshold_refinement = internal::parallel::distributed::
               GridRefinement::RefineAndCoarsenFixedNumber::compute_threshold(
                 indicators_refinement,
                 global_min_max_refinement,
@@ -380,7 +374,7 @@ namespace hp
           else if (target_index_coarsening == 0)
             reference_compare_coarsen = std::cref(compare_true);
           else
-            threshold_coarsening = dealii::internal::parallel::distributed::
+            threshold_coarsening = internal::parallel::distributed::
               GridRefinement::RefineAndCoarsenFixedNumber::compute_threshold(
                 indicators_coarsening,
                 global_min_max_coarsening,
@@ -446,17 +440,15 @@ namespace hp
 
     template <int dim, typename Number, int spacedim>
     void
-    p_adaptivity_from_regularity(
-      const dealii::DoFHandler<dim, spacedim> &dof_handler,
-      const Vector<Number> &                   sobolev_indices)
+    p_adaptivity_from_regularity(const DoFHandler<dim, spacedim> &dof_handler,
+                                 const Vector<Number> &sobolev_indices)
     {
       if (dof_handler.get_fe_collection().size() == 0)
         // nothing to do
         return;
 
-      Assert(
-        dof_handler.has_hp_capabilities(),
-        (typename dealii::DoFHandler<dim, spacedim>::ExcOnlyAvailableWithHP()));
+      Assert(dof_handler.has_hp_capabilities(),
+             (typename DoFHandler<dim, spacedim>::ExcOnlyAvailableWithHP()));
       AssertDimension(dof_handler.get_triangulation().n_active_cells(),
                       sobolev_indices.size());
 
@@ -505,7 +497,7 @@ namespace hp
     template <int dim, typename Number, int spacedim>
     void
     p_adaptivity_from_reference(
-      const dealii::DoFHandler<dim, spacedim> &                  dof_handler,
+      const DoFHandler<dim, spacedim> &                          dof_handler,
       const Vector<Number> &                                     criteria,
       const Vector<Number> &                                     references,
       const ComparisonFunction<typename identity<Number>::type> &compare_refine,
@@ -516,9 +508,8 @@ namespace hp
         // nothing to do
         return;
 
-      Assert(
-        dof_handler.has_hp_capabilities(),
-        (typename dealii::DoFHandler<dim, spacedim>::ExcOnlyAvailableWithHP()));
+      Assert(dof_handler.has_hp_capabilities(),
+             (typename DoFHandler<dim, spacedim>::ExcOnlyAvailableWithHP()));
       AssertDimension(dof_handler.get_triangulation().n_active_cells(),
                       criteria.size());
       AssertDimension(dof_handler.get_triangulation().n_active_cells(),
@@ -547,12 +538,12 @@ namespace hp
      */
     template <int dim, typename Number, int spacedim>
     void
-    predict_error(const dealii::DoFHandler<dim, spacedim> &dof_handler,
-                  const Vector<Number> &                   error_indicators,
-                  Vector<Number> &                         predicted_errors,
-                  const double                             gamma_p,
-                  const double                             gamma_h,
-                  const double                             gamma_n)
+    predict_error(const DoFHandler<dim, spacedim> &dof_handler,
+                  const Vector<Number> &           error_indicators,
+                  Vector<Number> &                 predicted_errors,
+                  const double                     gamma_p,
+                  const double                     gamma_h,
+                  const double                     gamma_n)
     {
       if (dof_handler.get_fe_collection().size() == 0)
         // nothing to do
@@ -563,9 +554,9 @@ namespace hp
       AssertDimension(dof_handler.get_triangulation().n_active_cells(),
                       predicted_errors.size());
       Assert(0 < gamma_p && gamma_p < 1,
-             dealii::GridRefinement::ExcInvalidParameterValue());
-      Assert(0 < gamma_h, dealii::GridRefinement::ExcInvalidParameterValue());
-      Assert(0 < gamma_n, dealii::GridRefinement::ExcInvalidParameterValue());
+             GridRefinement::ExcInvalidParameterValue());
+      Assert(0 < gamma_h, GridRefinement::ExcInvalidParameterValue());
+      Assert(0 < gamma_n, GridRefinement::ExcInvalidParameterValue());
 
       // auxiliary variables
       unsigned int future_fe_degree       = numbers::invalid_unsigned_int;
@@ -602,12 +593,12 @@ namespace hp
 #ifdef DEBUG
                   for (const auto &child : parent->child_iterators())
                     Assert(child->is_active() && child->coarsen_flag_set(),
-                           typename dealii::Triangulation<
+                           typename Triangulation<
                              dim>::ExcInconsistentCoarseningFlags());
 #endif
 
                   parent_future_fe_index =
-                    dealii::internal::hp::DoFHandlerImplementation::
+                    internal::hp::DoFHandlerImplementation::
                       dominated_future_fe_on_children<dim, spacedim>(parent);
 
                   future_fe_indices_on_coarsened_cells.insert(
@@ -664,15 +655,14 @@ namespace hp
      */
     template <int dim, int spacedim>
     void
-    force_p_over_h(const dealii::DoFHandler<dim, spacedim> &dof_handler)
+    force_p_over_h(const DoFHandler<dim, spacedim> &dof_handler)
     {
       if (dof_handler.get_fe_collection().size() == 0)
         // nothing to do
         return;
 
-      Assert(
-        dof_handler.has_hp_capabilities(),
-        (typename dealii::DoFHandler<dim, spacedim>::ExcOnlyAvailableWithHP()));
+      Assert(dof_handler.has_hp_capabilities(),
+             (typename DoFHandler<dim, spacedim>::ExcOnlyAvailableWithHP()));
 
       for (const auto &cell : dof_handler.active_cell_iterators())
         if (cell->is_locally_owned() && cell->future_fe_index_set())
@@ -686,24 +676,22 @@ namespace hp
 
     template <int dim, int spacedim>
     void
-    choose_p_over_h(const dealii::DoFHandler<dim, spacedim> &dof_handler)
+    choose_p_over_h(const DoFHandler<dim, spacedim> &dof_handler)
     {
       if (dof_handler.get_fe_collection().size() == 0)
         // nothing to do
         return;
 
-      Assert(
-        dof_handler.has_hp_capabilities(),
-        (typename dealii::DoFHandler<dim, spacedim>::ExcOnlyAvailableWithHP()));
+      Assert(dof_handler.has_hp_capabilities(),
+             (typename DoFHandler<dim, spacedim>::ExcOnlyAvailableWithHP()));
 
       // Ghost siblings might occur on parallel::shared::Triangulation objects.
       // We need information about future FE indices on all locally relevant
       // cells here, and thus communicate them.
       if (dynamic_cast<const parallel::shared::Triangulation<dim, spacedim> *>(
             &dof_handler.get_triangulation()) != nullptr)
-        dealii::internal::hp::DoFHandlerImplementation::
-          communicate_future_fe_indices(
-            const_cast<dealii::DoFHandler<dim, spacedim> &>(dof_handler));
+        internal::hp::DoFHandlerImplementation::communicate_future_fe_indices(
+          const_cast<DoFHandler<dim, spacedim> &>(dof_handler));
 
       for (const auto &cell : dof_handler.active_cell_iterators())
         if (cell->is_locally_owned() && cell->future_fe_index_set())
@@ -749,11 +737,10 @@ namespace hp
                             // need this information here and thus call the
                             // internal function that does not check for cell
                             // ownership.
-                            if (dealii::internal::
-                                  DoFCellAccessorImplementation::
-                                    Implementation::
-                                      future_fe_index_set<dim, spacedim, false>(
-                                        *child))
+                            if (internal::DoFCellAccessorImplementation::
+                                  Implementation::
+                                    future_fe_index_set<dim, spacedim, false>(
+                                      *child))
                               ++p_flagged_children;
                           }
                         else
@@ -800,18 +787,16 @@ namespace hp
      */
     template <int dim, int spacedim>
     bool
-    limit_p_level_difference(
-      const dealii::DoFHandler<dim, spacedim> &dof_handler,
-      const unsigned int                       max_difference,
-      const unsigned int                       contains_fe_index)
+    limit_p_level_difference(const DoFHandler<dim, spacedim> &dof_handler,
+                             const unsigned int               max_difference,
+                             const unsigned int               contains_fe_index)
     {
       if (dof_handler.get_fe_collection().size() == 0)
         // nothing to do
         return false;
 
-      Assert(
-        dof_handler.has_hp_capabilities(),
-        (typename dealii::DoFHandler<dim, spacedim>::ExcOnlyAvailableWithHP()));
+      Assert(dof_handler.has_hp_capabilities(),
+             (typename DoFHandler<dim, spacedim>::ExcOnlyAvailableWithHP()));
       Assert(
         max_difference > 0,
         ExcMessage(
@@ -827,7 +812,7 @@ namespace hp
       // there can be as many levels in the hierarchy as active FE indices are
       // possible
       using level_type =
-        typename dealii::DoFHandler<dim, spacedim>::active_fe_index_type;
+        typename DoFHandler<dim, spacedim>::active_fe_index_type;
       const auto invalid_level = static_cast<level_type>(-1);
 
       // map from FE index to level in hierarchy
@@ -940,7 +925,7 @@ namespace hp
             for (const auto &child : parent->child_iterators())
               {
                 Assert(child->is_active() && child->coarsen_flag_set(),
-                       (typename dealii::Triangulation<dim, spacedim>::
+                       (typename Triangulation<dim, spacedim>::
                           ExcInconsistentCoarseningFlags()));
 
                 const level_type child_level = static_cast<level_type>(

--- a/source/hp/refinement.inst.in
+++ b/source/hp/refinement.inst.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2019 - 2021 by the deal.II authors
+// Copyright (C) 2019 - 2022 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -24,29 +24,24 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
       \{
         template void
         full_p_adaptivity<deal_II_dimension, deal_II_space_dimension>(
-          const dealii::DoFHandler<deal_II_dimension, deal_II_space_dimension>
-            &);
+          const DoFHandler<deal_II_dimension, deal_II_space_dimension> &);
 
         template void
         p_adaptivity_from_flags<deal_II_dimension, deal_II_space_dimension>(
-          const dealii::DoFHandler<deal_II_dimension, deal_II_space_dimension>
-            &,
+          const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
           const std::vector<bool> &);
 
         template void
         force_p_over_h<deal_II_dimension, deal_II_space_dimension>(
-          const dealii::DoFHandler<deal_II_dimension, deal_II_space_dimension>
-            &);
+          const DoFHandler<deal_II_dimension, deal_II_space_dimension> &);
 
         template void
         choose_p_over_h<deal_II_dimension, deal_II_space_dimension>(
-          const dealii::DoFHandler<deal_II_dimension, deal_II_space_dimension>
-            &);
+          const DoFHandler<deal_II_dimension, deal_II_space_dimension> &);
 
         template bool
         limit_p_level_difference<deal_II_dimension, deal_II_space_dimension>(
-          const dealii::DoFHandler<deal_II_dimension, deal_II_space_dimension>
-            &,
+          const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
           const unsigned int,
           const unsigned int);
       \}
@@ -66,8 +61,7 @@ for (deal_II_dimension : DIMENSIONS; S : REAL_SCALARS;
         p_adaptivity_from_absolute_threshold<deal_II_dimension,
                                              S,
                                              deal_II_space_dimension>(
-          const dealii::DoFHandler<deal_II_dimension, deal_II_space_dimension>
-            &,
+          const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
           const Vector<S> &,
           const S,
           const S,
@@ -78,8 +72,7 @@ for (deal_II_dimension : DIMENSIONS; S : REAL_SCALARS;
         p_adaptivity_from_relative_threshold<deal_II_dimension,
                                              S,
                                              deal_II_space_dimension>(
-          const dealii::DoFHandler<deal_II_dimension, deal_II_space_dimension>
-            &,
+          const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
           const Vector<S> &,
           const double,
           const double,
@@ -90,8 +83,7 @@ for (deal_II_dimension : DIMENSIONS; S : REAL_SCALARS;
         p_adaptivity_fixed_number<deal_II_dimension,
                                   S,
                                   deal_II_space_dimension>(
-          const dealii::DoFHandler<deal_II_dimension, deal_II_space_dimension>
-            &,
+          const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
           const Vector<S> &,
           const double,
           const double,
@@ -102,16 +94,14 @@ for (deal_II_dimension : DIMENSIONS; S : REAL_SCALARS;
         p_adaptivity_from_regularity<deal_II_dimension,
                                      S,
                                      deal_II_space_dimension>(
-          const dealii::DoFHandler<deal_II_dimension, deal_II_space_dimension>
-            &,
+          const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
           const Vector<S> &);
 
         template void
         p_adaptivity_from_reference<deal_II_dimension,
                                     S,
                                     deal_II_space_dimension>(
-          const dealii::DoFHandler<deal_II_dimension, deal_II_space_dimension>
-            &,
+          const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
           const Vector<S> &,
           const Vector<S> &,
           const ComparisonFunction<typename identity<S>::type> &,
@@ -119,8 +109,7 @@ for (deal_II_dimension : DIMENSIONS; S : REAL_SCALARS;
 
         template void
         predict_error<deal_II_dimension, S, deal_II_space_dimension>(
-          const dealii::DoFHandler<deal_II_dimension, deal_II_space_dimension>
-            &,
+          const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
           const Vector<S> &,
           Vector<S> &,
           const double,


### PR DESCRIPTION
Initially part of #14173 as requested in https://github.com/dealii/dealii/pull/14173#discussion_r940344377.

It's easier to handle this cleanup step in a separate PR as discussion in #14173 continues.

@drwells -- FYI