### PR TITLE
Assert for released handle on parallel::distributed::*Transfer classes.

### DIFF
--- a/include/deal.II/distributed/cell_data_transfer.templates.h
+++ b/include/deal.II/distributed/cell_data_transfer.templates.h
@@ -104,6 +104,10 @@ namespace parallel
           &(*triangulation));
       Assert(tria != nullptr, ExcInternalError());
 
+      Assert(handle == numbers::invalid_unsigned_int,
+             ExcMessage("You can only add one data container per "
+                        "CellDataTransfer object."));
+
       handle = tria->register_data_attach(
         [this](const typename parallel::distributed::
                  Triangulation<dim, spacedim>::cell_iterator &cell,
@@ -193,6 +197,7 @@ namespace parallel
         post_unpack_action(all_out);
 
       input_vectors.clear();
+      handle = numbers::invalid_unsigned_int;
     }
 
 

--- a/source/distributed/solution_transfer.cc
+++ b/source/distributed/solution_transfer.cc
@@ -157,6 +157,10 @@ namespace parallel
             &dof_handler->get_triangulation())));
       Assert(tria != nullptr, ExcInternalError());
 
+      Assert(handle == numbers::invalid_unsigned_int,
+             ExcMessage("You can only add one solution per "
+                        "SolutionTransfer object."));
+
       handle = tria->register_data_attach(
         [this](
           const typename Triangulation<dim, spacedim>::cell_iterator &cell_,
@@ -287,6 +291,7 @@ namespace parallel
         }
 
       input_vectors.clear();
+      handle = numbers::invalid_unsigned_int;
     }
 
 


### PR DESCRIPTION
Fixes #14189.

Check if some container has already been attached on Transfer classes before attaching a new container.

FYI -- @bangerth @tjhei @peterrum 