### PR TITLE
Add missing header to `lac/trilinos_tpetra_vector.templates.h`

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -18,6 +18,8 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/mpi.h>
+
 #include <deal.II/lac/trilinos_tpetra_vector.h>
 
 #ifdef DEAL_II_TRILINOS_WITH_TPETRA


### PR DESCRIPTION
In this PR a missing header file is included.

While compiling `deal.II` with `DEAL_II_TRILINOS_WITH_TPETRA` enabled, I ran into an error:

```bash
In file included from /home/dealii/source/lac/trilinos_tpetra_vector.cc:16:
/home/dealii/include/deal.II/lac/trilinos_tpetra_vector.templates.h: In member function ‘virtual bool dealii::LinearAlgebra::TpetraWrappers::Vector<Number>::all_zero() const’:
/home/dealii/include/deal.II/lac/trilinos_tpetra_vector.templates.h:486:25: error: ‘sum’ is not a member of ‘dealii::Utilities::MPI’; did you mean ‘KokkosBlas::sum’?
  486 |         Utilities::MPI::sum(flag, *(mpi_comm->getRawMpiComm())());
      |                         ^~~
```

I traced it back to the header restructuring, performed in https://github.com/dealii/dealii/pull/14185 (FYI @drwells), specifically the change within the following file
https://github.com/dealii/dealii/blob/5ad30e4a74586c6cb320464100521b40b4bf9974/include/deal.II/lac/trilinos_tpetra_vector.h.
