### PR TITLE
Fix header in Zoltan tests.

### DIFF
--- a/tests/zoltan/zoltan_03.cc
+++ b/tests/zoltan/zoltan_03.cc
@@ -19,6 +19,8 @@
 
 #include <deal.II/base/graph_coloring.h>
 
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+
 #include "../tests.h"
 
 

--- a/tests/zoltan/zoltan_04.cc
+++ b/tests/zoltan/zoltan_04.cc
@@ -23,6 +23,8 @@
 
 #include <deal.II/base/graph_coloring.h>
 
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+
 #include "../tests.h"
 
 


### PR DESCRIPTION
Follow-up to #14186.

We now need to include the dynamic_sparsity_pattern header after cleaning out graph_coloring.

```
6574: dealii/tests/zoltan/zoltan_03.cc:26:12: error: variable or field ‘fill_graph’ declared void
6574:  fill_graph(DynamicSparsityPattern &graph)
6574:             ^~~~~~~~~~~~~~~~~~~~~~
6574: dealii/tests/zoltan/zoltan_03.cc:26:12: error: ‘DynamicSparsityPattern’ was not declared in this scope
6574: dealii/tests/zoltan/zoltan_03.cc:26:36: error: ‘graph’ was not declared in this scope
6574:  fill_graph(DynamicSparsityPattern &graph)
6574:                                     ^~~~~
```