### PR TITLE
Fix more headers in Zoltan tests.

### DIFF
--- a/tests/zoltan/zoltan_03.cc
+++ b/tests/zoltan/zoltan_03.cc
@@ -20,6 +20,7 @@
 #include <deal.II/base/graph_coloring.h>
 
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
 

--- a/tests/zoltan/zoltan_04.cc
+++ b/tests/zoltan/zoltan_04.cc
@@ -24,6 +24,7 @@
 #include <deal.II/base/graph_coloring.h>
 
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
 


### PR DESCRIPTION
I ran the Zoltan tests again and found another header missing.

They passed when I opened #14196. Might have been a consequence of merging #14191? I don't know.

```
6574: dealii/tests/zoltan/zoltan_03.cc: In function ‘int main(int, char**)’:
6574: dealii/tests/zoltan/zoltan_03.cc:68:19: error: aggregate ‘dealii::SparsityPattern sp_graph’ has incomplete type and cannot be defined
6574:    SparsityPattern sp_graph;
6574:                    ^~~~~~~~
```