### PR TITLE
Fix source typos in tests/

### DIFF
--- a/tests/parameter_handler/parameter_handler_25.cc
+++ b/tests/parameter_handler/parameter_handler_25.cc
@@ -87,7 +87,7 @@ fail()
   try
     {
       prm.enter_subsection("General");
-      prm.set("Precison", "float"); // here is a typo!
+      prm.set("Precision", "float"); // here is a typo!
       // dim is not set!
       prm.leave_subsection();
     }

--- a/tests/parameter_handler/parameter_handler_25.output
+++ b/tests/parameter_handler/parameter_handler_25.output
@@ -8,7 +8,7 @@ An error occurred in file <parameter_handler.cc> in function
 The violated condition was: 
     false
 Additional information: 
-    You can't ask for entry <Precison> you have not yet declared.
+    You can't ask for entry <Precision> you have not yet declared.
 --------------------------------------------------------
 
 DEAL::

--- a/tests/parameter_handler/parameter_handler_25.output.gcc-12
+++ b/tests/parameter_handler/parameter_handler_25.output.gcc-12
@@ -8,7 +8,7 @@ An error occurred in file <parameter_handler.cc> in function
 The violated condition was: 
     false
 Additional information: 
-    You can't ask for entry <Precison> you have not yet declared.
+    You can't ask for entry <Precision> you have not yet declared.
 --------------------------------------------------------
 
 DEAL::

--- a/tests/parameter_handler/parameter_handler_25.output.std
+++ b/tests/parameter_handler/parameter_handler_25.output.std
@@ -8,7 +8,7 @@ An error occurred in file <parameter_handler.cc> in function
 The violated condition was: 
     false
 Additional information: 
-    You can't ask for entry <Precison> you have not yet declared.
+    You can't ask for entry <Precision> you have not yet declared.
 --------------------------------------------------------
 
 DEAL::

--- a/tests/parameter_handler/parameter_handler_25.output2
+++ b/tests/parameter_handler/parameter_handler_25.output2
@@ -8,7 +8,7 @@ An error occurred in file <parameter_handler.cc> in function
 The violated condition was: 
     false
 Additional information: 
-    You can't ask for entry <Precison> you have not yet declared.
+    You can't ask for entry <Precision> you have not yet declared.
 --------------------------------------------------------
 
 DEAL::

--- a/tests/parameter_handler/prm/parameter_handler_26_fail.json
+++ b/tests/parameter_handler/prm/parameter_handler_26_fail.json
@@ -1,5 +1,5 @@
 {
   "General": {
-  "Precison": "float"
+  "Precision": "float"
   }
 }

--- a/tests/parameter_handler/prm/parameter_handler_26_fail.prm
+++ b/tests/parameter_handler/prm/parameter_handler_26_fail.prm
@@ -1,3 +1,3 @@
 subsection General
-  set Precison = float
+  set Precision = float
 end


### PR DESCRIPTION
Substitute `precison` for `precision`