### PR TITLE
Do not use --date=iso-strict in DEAL_II_QUERY_GIT_INFORMATION

### DIFF
--- a/cmake/macros/macro_deal_ii_query_git_information.cmake
+++ b/cmake/macros/macro_deal_ii_query_git_information.cmake
@@ -80,11 +80,11 @@ MACRO(DEAL_II_QUERY_GIT_INFORMATION)
     # Format options for git log:
     #   %H   - the full sha1 hash of the commit, aka "revision"
     #   %h   - the abbreviated sha1 hash of the commit, aka "shortrev"
-    #   %cd  - the commit date (for which we use the strict iso date format)
+    #   %cd  - the commit date (for which we use the default date format)
     #
 
     EXECUTE_PROCESS(
-       COMMAND ${GIT_EXECUTABLE} log -n 1 --pretty=format:"revision=%H, shortrev=%h, date=%cd" --date=iso-strict
+       COMMAND ${GIT_EXECUTABLE} log -n 1 --pretty=format:"revision=%H, shortrev=%h, date=%cd" --date=default
        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
        OUTPUT_VARIABLE _info
        RESULT_VARIABLE _result


### PR DESCRIPTION
@tamiko I have on an old cluster problems with `iso-strict`, since on that system git (`git version 1.8.3.1`) does not know this format. The result that I get know info regarding the git version at all. Could we switch to the default format? What was the reason to selecting that format?