### PR TITLE
Update checks for AD-types.

### DIFF
--- a/include/deal.II/lac/full_matrix.h
+++ b/include/deal.II/lac/full_matrix.h
@@ -23,8 +23,6 @@
 #include <deal.II/base/table.h>
 #include <deal.II/base/tensor.h>
 
-#include <deal.II/differentiation/ad/ad_number_traits.h>
-
 #include <deal.II/lac/exceptions.h>
 #include <deal.II/lac/identity_matrix.h>
 
@@ -80,11 +78,19 @@ template <typename number>
 class FullMatrix : public Table<2, number>
 {
 public:
-  // The assertion in full_matrix.templates.h for whether or not a number is
-  // finite is not compatible for AD number types.
+  /**
+   * This class only supports basic numeric types (i.e., we support double and
+   * float but not automatically differentiated numbers).
+   *
+   * @note we test real_type here to get the underlying scalar type when using
+   * std::complex.
+   */
   static_assert(
-    !Differentiation::AD::is_ad_number<number>::value,
-    "The FullMatrix class does not support auto-differentiable numbers.");
+    std::is_arithmetic<
+      typename numbers::NumberTraits<number>::real_type>::value,
+    "The FullMatrix class only supports basic numeric types. In particular, it "
+    "does not support automatically differentiated numbers.");
+
 
   /**
    * A type of used to index into this container.

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -22,9 +22,8 @@
 #include <deal.II/base/aligned_vector.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/index_set.h>
+#include <deal.II/base/numbers.h>
 #include <deal.II/base/subscriptor.h>
-
-#include <deal.II/differentiation/ad/ad_number_traits.h>
 
 #include <deal.II/lac/vector_operation.h>
 #include <deal.II/lac/vector_type_traits.h>
@@ -109,11 +108,18 @@ template <typename Number>
 class Vector : public Subscriptor
 {
 public:
-  // The assertion in vector.templates.h for whether or not a number is
-  // finite is not compatible for AD number types.
+  /**
+   * This class only supports basic numeric types (i.e., we support double and
+   * float but not automatically differentiated numbers).
+   *
+   * @note we test real_type here to get the underlying scalar type when using
+   * std::complex.
+   */
   static_assert(
-    !Differentiation::AD::is_ad_number<Number>::value,
-    "The Vector class does not support auto-differentiable numbers.");
+    std::is_arithmetic<
+      typename numbers::NumberTraits<Number>::real_type>::value,
+    "The Vector class only supports basic numeric types. In particular, it "
+    "does not support automatically differentiated numbers.");
 
   /**
    * Declare standard types used in all containers. These types parallel those

--- a/tests/physics/notation-kelvin_01.cc
+++ b/tests/physics/notation-kelvin_01.cc
@@ -147,9 +147,12 @@ test_rank_0_tensors()
   const Vector<double>     vA = Notation::Kelvin::to_vector(A);
   const FullMatrix<double> mA = Notation::Kelvin::to_matrix(A);
 
-  using InpType      = typename std::decay<decltype(A)>::type;
-  const auto vA_conv = Notation::Kelvin::to_tensor<InpType>(vA);
-  const auto mA_conv = Notation::Kelvin::to_tensor<InpType>(mA);
+  using InpType = typename std::decay<decltype(A)>::type;
+  // Here and below we need both types to work around a problem present in GCC
+  // 5.4.0 in which the compiler does not correctly handle SFINAE with
+  // static_assert(). This was fixed by GCC 9.
+  const auto vA_conv = Notation::Kelvin::to_tensor<InpType, double>(vA);
+  const auto mA_conv = Notation::Kelvin::to_tensor<InpType, double>(mA);
 
   Assert(std::abs(vA_conv - A) < 1e-12,
          ExcMessage("Different result for vector conversion"));
@@ -167,7 +170,7 @@ test_rank_1_tensors()
   const Vector<double> vA = Notation::Kelvin::to_vector(A);
 
   using InpType      = typename std::decay<decltype(A)>::type;
-  const auto vA_conv = Notation::Kelvin::to_tensor<InpType>(vA);
+  const auto vA_conv = Notation::Kelvin::to_tensor<InpType, double>(vA);
 
   Assert((vA_conv - A).norm() < 1e-12,
          ExcMessage("Different result for vector conversion"));
@@ -186,8 +189,8 @@ test_rank_2_tensors()
     const FullMatrix<double> mA = Notation::Kelvin::to_matrix(A);
 
     using InpType      = typename std::decay<decltype(A)>::type;
-    const auto vA_conv = Notation::Kelvin::to_tensor<InpType>(vA);
-    const auto mA_conv = Notation::Kelvin::to_tensor<InpType>(mA);
+    const auto vA_conv = Notation::Kelvin::to_tensor<InpType, double>(vA);
+    const auto mA_conv = Notation::Kelvin::to_tensor<InpType, double>(mA);
 
     Assert((vA_conv - A).norm() < 1e-12,
            ExcMessage("Different result for vector conversion"));
@@ -204,8 +207,8 @@ test_rank_2_tensors()
     const FullMatrix<double> mA = Notation::Kelvin::to_matrix(A);
 
     using InpType      = typename std::decay<decltype(A)>::type;
-    const auto vA_conv = Notation::Kelvin::to_tensor<InpType>(vA);
-    const auto mA_conv = Notation::Kelvin::to_tensor<InpType>(mA);
+    const auto vA_conv = Notation::Kelvin::to_tensor<InpType, double>(vA);
+    const auto mA_conv = Notation::Kelvin::to_tensor<InpType, double>(mA);
 
     Assert((vA_conv - A).norm() < 1e-12,
            ExcMessage("Different result for vector conversion"));
@@ -227,7 +230,7 @@ test_rank_3_tensors()
       Notation::Kelvin::to_matrix<dim, Tensor<1, dim>, Tensor<2, dim>>(A);
 
     using InpType      = typename std::decay<decltype(A)>::type;
-    const auto mA_conv = Notation::Kelvin::to_tensor<InpType>(mA);
+    const auto mA_conv = Notation::Kelvin::to_tensor<InpType, double>(mA);
 
     Assert((mA_conv - A).norm() < 1e-12,
            ExcMessage("Different result for matrix conversion"));
@@ -242,7 +245,7 @@ test_rank_3_tensors()
       Notation::Kelvin::to_matrix<dim, Tensor<2, dim>, Tensor<1, dim>>(A);
 
     using InpType      = typename std::decay<decltype(A)>::type;
-    const auto mA_conv = Notation::Kelvin::to_tensor<InpType>(mA);
+    const auto mA_conv = Notation::Kelvin::to_tensor<InpType, double>(mA);
 
     Assert((mA_conv - A).norm() < 1e-12,
            ExcMessage("Different result for matrix conversion"));
@@ -258,7 +261,7 @@ test_rank_3_tensors()
         A);
 
     using InpType      = typename std::decay<decltype(A)>::type;
-    const auto mA_conv = Notation::Kelvin::to_tensor<InpType>(mA);
+    const auto mA_conv = Notation::Kelvin::to_tensor<InpType, double>(mA);
 
     Assert((mA_conv - A).norm() < 1e-12,
            ExcMessage("Different result for matrix conversion"));
@@ -274,7 +277,7 @@ test_rank_3_tensors()
         A);
 
     using InpType      = typename std::decay<decltype(A)>::type;
-    const auto mA_conv = Notation::Kelvin::to_tensor<InpType>(mA);
+    const auto mA_conv = Notation::Kelvin::to_tensor<InpType, double>(mA);
 
     Assert((mA_conv - A).norm() < 1e-12,
            ExcMessage("Different result for matrix conversion"));
@@ -293,7 +296,7 @@ test_rank_4_tensors()
     const FullMatrix<double> mA = Notation::Kelvin::to_matrix(A);
 
     using InpType      = typename std::decay<decltype(A)>::type;
-    const auto mA_conv = Notation::Kelvin::to_tensor<InpType>(mA);
+    const auto mA_conv = Notation::Kelvin::to_tensor<InpType, double>(mA);
 
     Assert((mA_conv - A).norm() < 1e-12,
            ExcMessage("Different result for matrix conversion"));
@@ -307,7 +310,7 @@ test_rank_4_tensors()
     const FullMatrix<double> mA = Notation::Kelvin::to_matrix(A);
 
     using InpType      = typename std::decay<decltype(A)>::type;
-    const auto mA_conv = Notation::Kelvin::to_tensor<InpType>(mA);
+    const auto mA_conv = Notation::Kelvin::to_tensor<InpType, double>(mA);
 
     Assert((mA_conv - A).norm() < 1e-12,
            ExcMessage("Different result for matrix conversion"));

--- a/tests/physics/notation-kelvin_02.cc
+++ b/tests/physics/notation-kelvin_02.cc
@@ -135,12 +135,15 @@ test_scalars()
   Vector<double>           vB(mC.m());
   mC.vmult(vB, vA);
 
-  using InpVecType  = typename std::decay<decltype(A)>::type;
-  using ResVecType  = typename std::decay<decltype(B)>::type;
-  using InpMatType  = typename std::decay<decltype(C)>::type;
-  const auto A_conv = Notation::Kelvin::to_tensor<InpVecType>(vA);
-  const auto B_conv = Notation::Kelvin::to_tensor<ResVecType>(vB);
-  const auto C_conv = Notation::Kelvin::to_tensor<InpMatType>(mC);
+  using InpVecType = typename std::decay<decltype(A)>::type;
+  using ResVecType = typename std::decay<decltype(B)>::type;
+  using InpMatType = typename std::decay<decltype(C)>::type;
+  // Here and below we need both types to work around a problem present in GCC
+  // 5.4.0 in which the compiler does not correctly handle SFINAE with
+  // static_assert(). This was fixed by GCC 9.
+  const auto A_conv = Notation::Kelvin::to_tensor<InpVecType, double>(vA);
+  const auto B_conv = Notation::Kelvin::to_tensor<ResVecType, double>(vB);
+  const auto C_conv = Notation::Kelvin::to_tensor<InpMatType, double>(mC);
 
   std::cout << "Scalar" << std::endl;
   std::cout << "A: " << A << "  A_conv: " << A_conv << std::endl;
@@ -178,9 +181,9 @@ test_rank_0_tensors()
   using InpVecType  = typename std::decay<decltype(A)>::type;
   using ResVecType  = typename std::decay<decltype(B)>::type;
   using InpMatType  = typename std::decay<decltype(C)>::type;
-  const auto A_conv = Notation::Kelvin::to_tensor<InpVecType>(vA);
-  const auto B_conv = Notation::Kelvin::to_tensor<ResVecType>(vB);
-  const auto C_conv = Notation::Kelvin::to_tensor<InpMatType>(mC);
+  const auto A_conv = Notation::Kelvin::to_tensor<InpVecType, double>(vA);
+  const auto B_conv = Notation::Kelvin::to_tensor<ResVecType, double>(vB);
+  const auto C_conv = Notation::Kelvin::to_tensor<InpMatType, double>(mC);
 
   std::cout << "Rank 0" << std::endl;
   std::cout << "A: " << A << "  A_conv: " << A_conv << std::endl;
@@ -222,9 +225,9 @@ test_rank_1_2_tensors()
     using InpVecType  = typename std::decay<decltype(A)>::type;
     using ResVecType  = typename std::decay<decltype(B)>::type;
     using InpMatType  = typename std::decay<decltype(C)>::type;
-    const auto A_conv = Notation::Kelvin::to_tensor<InpVecType>(vA);
-    const auto B_conv = Notation::Kelvin::to_tensor<ResVecType>(vB);
-    const auto C_conv = Notation::Kelvin::to_tensor<InpMatType>(mC);
+    const auto A_conv = Notation::Kelvin::to_tensor<InpVecType, double>(vA);
+    const auto B_conv = Notation::Kelvin::to_tensor<ResVecType, double>(vB);
+    const auto C_conv = Notation::Kelvin::to_tensor<InpMatType, double>(mC);
 
     std::cout << "Rank 1 (non-symm)" << std::endl;
     std::cout << "A: " << A << "  A_conv: " << A_conv << std::endl;
@@ -262,9 +265,9 @@ test_rank_1_2_tensors()
     using InpVecType  = typename std::decay<decltype(A)>::type;
     using ResVecType  = typename std::decay<decltype(B)>::type;
     using InpMatType  = typename std::decay<decltype(C)>::type;
-    const auto A_conv = Notation::Kelvin::to_tensor<InpVecType>(vA);
-    const auto B_conv = Notation::Kelvin::to_tensor<ResVecType>(vB);
-    const auto C_conv = Notation::Kelvin::to_tensor<InpMatType>(mC);
+    const auto A_conv = Notation::Kelvin::to_tensor<InpVecType, double>(vA);
+    const auto B_conv = Notation::Kelvin::to_tensor<ResVecType, double>(vB);
+    const auto C_conv = Notation::Kelvin::to_tensor<InpMatType, double>(mC);
 
     std::cout << "Rank 1 (symm)" << std::endl;
     std::cout << "A: " << A << "  A_conv: " << A_conv << std::endl;
@@ -307,9 +310,9 @@ test_rank_2_4_tensors()
     using InpVecType  = typename std::decay<decltype(A)>::type;
     using ResVecType  = typename std::decay<decltype(B)>::type;
     using InpMatType  = typename std::decay<decltype(C)>::type;
-    const auto A_conv = Notation::Kelvin::to_tensor<InpVecType>(vA);
-    const auto B_conv = Notation::Kelvin::to_tensor<ResVecType>(vB);
-    const auto C_conv = Notation::Kelvin::to_tensor<InpMatType>(mC);
+    const auto A_conv = Notation::Kelvin::to_tensor<InpVecType, double>(vA);
+    const auto B_conv = Notation::Kelvin::to_tensor<ResVecType, double>(vB);
+    const auto C_conv = Notation::Kelvin::to_tensor<InpMatType, double>(mC);
 
     std::cout << "Rank 2 (non-symm)" << std::endl;
     std::cout << "A: " << A << "  A_conv: " << A_conv << std::endl;
@@ -347,9 +350,9 @@ test_rank_2_4_tensors()
     using InpVecType  = typename std::decay<decltype(A)>::type;
     using ResVecType  = typename std::decay<decltype(B)>::type;
     using InpMatType  = typename std::decay<decltype(C)>::type;
-    const auto A_conv = Notation::Kelvin::to_tensor<InpVecType>(vA);
-    const auto B_conv = Notation::Kelvin::to_tensor<ResVecType>(vB);
-    const auto C_conv = Notation::Kelvin::to_tensor<InpMatType>(mC);
+    const auto A_conv = Notation::Kelvin::to_tensor<InpVecType, double>(vA);
+    const auto B_conv = Notation::Kelvin::to_tensor<ResVecType, double>(vB);
+    const auto C_conv = Notation::Kelvin::to_tensor<InpMatType, double>(mC);
 
     std::cout << "Rank 2 (symm)" << std::endl;
     std::cout << "A: " << A << "  A_conv: " << A_conv << std::endl;
@@ -390,9 +393,9 @@ test_rank_2_4_tensors()
     using InpVecType  = typename std::decay<decltype(A)>::type;
     using ResVecType  = typename std::decay<decltype(B)>::type;
     using InpMatType  = typename std::decay<decltype(C)>::type;
-    const auto A_conv = Notation::Kelvin::to_tensor<InpVecType>(vA);
-    const auto B_conv = Notation::Kelvin::to_tensor<ResVecType>(vB);
-    const auto C_conv = Notation::Kelvin::to_tensor<InpMatType>(mC);
+    const auto A_conv = Notation::Kelvin::to_tensor<InpVecType, double>(vA);
+    const auto B_conv = Notation::Kelvin::to_tensor<ResVecType, double>(vB);
+    const auto C_conv = Notation::Kelvin::to_tensor<InpMatType, double>(mC);
 
     std::cout << "Rank 2 (non-symm from symm)" << std::endl;
     std::cout << "A: " << A << "  A_conv: " << A_conv << std::endl;
@@ -437,9 +440,9 @@ test_rank_3_tensors()
     using InpVecType  = typename std::decay<decltype(A)>::type;
     using ResVecType  = typename std::decay<decltype(B)>::type;
     using InpMatType  = typename std::decay<decltype(C)>::type;
-    const auto A_conv = Notation::Kelvin::to_tensor<InpVecType>(vA);
-    const auto B_conv = Notation::Kelvin::to_tensor<ResVecType>(vB);
-    const auto C_conv = Notation::Kelvin::to_tensor<InpMatType>(mC);
+    const auto A_conv = Notation::Kelvin::to_tensor<InpVecType, double>(vA);
+    const auto B_conv = Notation::Kelvin::to_tensor<ResVecType, double>(vB);
+    const auto C_conv = Notation::Kelvin::to_tensor<InpMatType, double>(mC);
 
     std::cout << "Rank 3 (non-symm 1)" << std::endl;
     std::cout << "A: " << A << "  A_conv: " << A_conv << std::endl;
@@ -481,9 +484,9 @@ test_rank_3_tensors()
     using InpVecType  = typename std::decay<decltype(A)>::type;
     using ResVecType  = typename std::decay<decltype(B)>::type;
     using InpMatType  = typename std::decay<decltype(C)>::type;
-    const auto A_conv = Notation::Kelvin::to_tensor<InpVecType>(vA);
-    const auto B_conv = Notation::Kelvin::to_tensor<ResVecType>(vB);
-    const auto C_conv = Notation::Kelvin::to_tensor<InpMatType>(mC);
+    const auto A_conv = Notation::Kelvin::to_tensor<InpVecType, double>(vA);
+    const auto B_conv = Notation::Kelvin::to_tensor<ResVecType, double>(vB);
+    const auto C_conv = Notation::Kelvin::to_tensor<InpMatType, double>(mC);
 
     std::cout << "Rank 3 (non-symm 2)" << std::endl;
     std::cout << "A: " << A << "  A_conv: " << A_conv << std::endl;
@@ -526,9 +529,9 @@ test_rank_3_tensors()
     using InpVecType  = typename std::decay<decltype(A)>::type;
     using ResVecType  = typename std::decay<decltype(B)>::type;
     using InpMatType  = typename std::decay<decltype(C)>::type;
-    const auto A_conv = Notation::Kelvin::to_tensor<InpVecType>(vA);
-    const auto B_conv = Notation::Kelvin::to_tensor<ResVecType>(vB);
-    const auto C_conv = Notation::Kelvin::to_tensor<InpMatType>(mC);
+    const auto A_conv = Notation::Kelvin::to_tensor<InpVecType, double>(vA);
+    const auto B_conv = Notation::Kelvin::to_tensor<ResVecType, double>(vB);
+    const auto C_conv = Notation::Kelvin::to_tensor<InpMatType, double>(mC);
 
     std::cout << "Rank 3 (symm 1)" << std::endl;
     std::cout << "A: " << A << "  A_conv: " << A_conv << std::endl;
@@ -571,9 +574,9 @@ test_rank_3_tensors()
     using InpVecType  = typename std::decay<decltype(A)>::type;
     using ResVecType  = typename std::decay<decltype(B)>::type;
     using InpMatType  = typename std::decay<decltype(C)>::type;
-    const auto A_conv = Notation::Kelvin::to_tensor<InpVecType>(vA);
-    const auto B_conv = Notation::Kelvin::to_tensor<ResVecType>(vB);
-    const auto C_conv = Notation::Kelvin::to_tensor<InpMatType>(mC);
+    const auto A_conv = Notation::Kelvin::to_tensor<InpVecType, double>(vA);
+    const auto B_conv = Notation::Kelvin::to_tensor<ResVecType, double>(vB);
+    const auto C_conv = Notation::Kelvin::to_tensor<InpMatType, double>(mC);
 
     std::cout << "Rank 3 (symm 2)" << std::endl;
     std::cout << "A: " << A << "  A_conv: " << A_conv << std::endl;


### PR DESCRIPTION
At some point these stopped working and something like

```cpp
#include <deal.II/lac/vector.h>
#include <deal.II/lac/vector.templates.h>

#include <adolc/adouble.h>

int
main()
{
  using namespace dealii;

  Vector<adouble> vec;
}
```
compiles (but compiling Vector<adouble>::l2_norm() fails).

[This comment](https://github.com/dealii/dealii/pull/6943#issuecomment-407073898) implies the previous fix is better than this one, but I don't really see any downsides to the present version - `real_type` is going to work for all complex and real types which make sense to put in a `Vector` or `FullMatrix`.

Part of #13949 (no links to differentiation in lac)