### PR TITLE
Fix docker build

### DIFF
--- a/contrib/python-bindings/CMakeLists.txt
+++ b/contrib/python-bindings/CMakeLists.txt
@@ -48,6 +48,7 @@ IF(DEAL_II_COMPONENT_PYTHON_BINDINGS)
   # On case-insensitive file systems, FindBOOST.cmake and FindBoost.cmake are indistinguishable.
   # Make sure FindBoost.cmake from CMake installation is found.
   LIST(REMOVE_ITEM CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
+  SET(Boost_USE_DEBUG_RUNTIME FALSE)
   IF(${BOOST_VERSION} VERSION_LESS 1.67)
     FIND_PACKAGE(Boost 1.59 COMPONENTS python REQUIRED)
   ELSE()


### PR DESCRIPTION
The docker build currently fails because during cmake configure `FIND_PACKAGE` does not find the python boost package component which we require with `-DDEAL_II_COMPONENT_PYTHON_BINDINGS=ON`.

```
-- Setting up python bindings
CMake Error at /usr/lib/x86_64-linux-gnu/cmake/Boost-1.71.0/BoostConfig.cmake:117 (find_package):
  Found package configuration file:

    /usr/lib/x86_64-linux-gnu/cmake/boost_python-1.71.0/boost_python-config.cmake

  but it set boost_python_FOUND to FALSE so package "boost_python" is
  considered to be NOT FOUND.  Reason given by package:

  No suitable build variant has been found.

  The following variants have been tried and rejected:

  * libboost_python38.so.1.71.0 (release runtime,
  Boost_USE_DEBUG_RUNTIME=TRUE)

  * libboost_python38.a (static, Boost_USE_STATIC_LIBS=OFF)

Call Stack (most recent call first):
  /usr/lib/x86_64-linux-gnu/cmake/Boost-1.71.0/BoostConfig.cmake:182 (boost_find_component)
  /usr/share/cmake-3.16/Modules/FindBoost.cmake:443 (find_package)
  contrib/python-bindings/CMakeLists.txt:54 (FIND_PACKAGE)


-- Configuring incomplete, errors occurred!
```
Setting `Boost_USE_DEBUG_RUNTIME` to `FALSE` fixes the issue for me in the docker container.

Does anybody have a better idea what is happening?

Related to #14158