### PR TITLE
MatrixFree: Fix bug in setup of new cell_index for MG

### DIFF
--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -869,7 +869,9 @@ MatrixFree<dim, Number, VectorizedArrayType>::internal_reinit(
 
     mf_cell_indices.resize((mg_level == numbers::invalid_unsigned_int) ?
                              tria.n_active_cells() :
-                             tria.n_cells(mg_level),
+                             (mg_level < tria.n_levels() ?
+                                tria.n_raw_cells(mg_level) :
+                                0),
                            numbers::invalid_unsigned_int);
 
     for (unsigned int cell = 0;


### PR DESCRIPTION
Fix a bug introduced by #14130: When we access a cell by `cell->index()`, we need to allocate space for `n_raw_cells()`, not just `n_cells`, as we might not use all available indices in the mesh. See e.g. https://github.com/dealii/dealii/blob/e829caf24518ec02f1382288b1ff38aa50b33e99/include/deal.II/matrix_free/matrix_free.templates.h#L1545-L1546 for a similar use case.