### PR TITLE
Fix bug in matrix-free operators regarding diagonal

### DIFF
--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -2382,7 +2382,8 @@ namespace MatrixFreeOperators
         VectorizedArrayType local_diagonal_vector[phi.static_dofs_per_cell];
         for (unsigned int i = 0; i < phi.dofs_per_component; ++i)
           {
-            for (unsigned int j = 0; j < phi.dofs_per_component; ++j)
+            for (unsigned int j = 0; j < phi.dofs_per_component * n_components;
+                 ++j)
               phi.begin_dof_values()[j] = VectorizedArrayType();
             phi.begin_dof_values()[i] = 1.;
             do_operation_on_cell(phi, cell);


### PR DESCRIPTION
I believe this should help with https://github.com/geodynamics/aspect/issues/4905 - this is a problem I found. @tjhei can you try this with your copy of ASPECT, I seem to have problems with some other aspects of the relevant tests. If yes, we can add a new test case here in deal.II for a vector-valued Laplace problem, to ensure that all components get properly handled.