### PR TITLE
MatrixFree: Fix assertion in presence of FE_Nothing

### DIFF
--- a/source/matrix_free/dof_info.cc
+++ b/source/matrix_free/dof_info.cc
@@ -863,7 +863,7 @@ namespace internal
                             vectorization_length);
             AssertIndexRange(
               row_starts[i * vectorization_length * n_components].first,
-              this->dof_indices_interleaved.size());
+              this->dof_indices_interleaved.size() + 1);
             AssertIndexRange(
               row_starts[i * vectorization_length * n_components].first +
                 ndofs * vectorization_length,


### PR DESCRIPTION
The change in #14121 triggered an exception in https://cdash.dealii.43-1.org/test/29769847: The problem is that we can have cells without unknowns for `FE_Nothing`, which means that we can have an index pointer pointing to the end of the value array in case the last cell does not have DoFs.