### PR TITLE
FEEvaluation: Create temporary copy of Jacobian matrix in submit_XXX

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -5647,7 +5647,7 @@ FEEvaluationAccess<dim, 1, Number, is_face, VectorizedArrayType>::
   // general/affine cell type
   else
     {
-      const Tensor<2, dim, VectorizedArrayType> &jac =
+      const Tensor<2, dim, VectorizedArrayType> jac =
         this->cell_type > internal::MatrixFreeFunctions::affine ?
           this->jacobian[q_point] :
           this->jacobian[0];
@@ -6533,7 +6533,7 @@ FEEvaluationAccess<dim, dim, Number, is_face, VectorizedArrayType>::
         }
       else
         {
-          const Tensor<2, dim, VectorizedArrayType> &jac =
+          const Tensor<2, dim, VectorizedArrayType> jac =
             this->cell_type == internal::MatrixFreeFunctions::general ?
               this->jacobian[q_point] :
               this->jacobian[0];
@@ -6609,7 +6609,7 @@ FEEvaluationAccess<dim, dim, Number, is_face, VectorizedArrayType>::
         this->cell_type == internal::MatrixFreeFunctions::general ?
           this->J_value[q_point] :
           this->J_value[0] * this->quadrature_weights[q_point];
-      const Tensor<2, dim, VectorizedArrayType> &jac =
+      const Tensor<2, dim, VectorizedArrayType> jac =
         this->cell_type == internal::MatrixFreeFunctions::general ?
           this->jacobian[q_point] :
           this->jacobian[0];
@@ -6924,7 +6924,7 @@ FEEvaluationAccess<1, 1, Number, is_face, VectorizedArrayType>::submit_gradient(
   this->gradients_quad_submitted = true;
 #  endif
 
-  const Tensor<2, 1, VectorizedArrayType> &jac =
+  const Tensor<2, 1, VectorizedArrayType> jac =
     this->cell_type == internal::MatrixFreeFunctions::general ?
       this->jacobian[q_point] :
       this->jacobian[0];


### PR DESCRIPTION
This patch aims to create a temporary copy of the Jacobian during the `submit_gradient()` functions and friends, similar to what we already do in another place: https://github.com/dealii/dealii/blob/94d28e7df7fbba7201a610db9c2f593a43742318/include/deal.II/matrix_free/fe_evaluation.h#L4997-L5000
The reason is that with the copy, there is no potential aliasing between the value that we write back into `this->gradients_quad` and the Jacobian data, allowing the compiler to hoist the loads. Even better, I could observe that the compiler would reuse the loads during a `get_gradient(q)` -> `submit_gradient(q)` sequence, which reduces pressure on the L1 cache.