### PR TITLE
Provide inlined fast code path for Vector::reinit(Vector&)

### DIFF
--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -1354,6 +1354,23 @@ Vector<Number>::update_ghost_values() const
 
 
 
+template <typename Number>
+template <typename Number2>
+inline void
+Vector<Number>::reinit(const Vector<Number2> &v,
+                       const bool             omit_zeroing_entries)
+{
+  // go to actual reinit functions in case we need to change something with
+  // the vector, else there is nothing to be done
+  if (!omit_zeroing_entries || size() != v.size())
+    {
+      do_reinit(v.size(), omit_zeroing_entries, false);
+      thread_loop_partitioner = v.thread_loop_partitioner;
+    }
+}
+
+
+
 // Moved from vector.templates.h as an inline function by Luca Heltai
 // on 2009/04/12 to prevent strange compiling errors, after making
 // swap virtual.

--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -243,18 +243,6 @@ Vector<Number>::grow_or_shrink(const size_type n)
 
 
 template <typename Number>
-template <typename Number2>
-void
-Vector<Number>::reinit(const Vector<Number2> &v,
-                       const bool             omit_zeroing_entries)
-{
-  do_reinit(v.size(), omit_zeroing_entries, false);
-  thread_loop_partitioner = v.thread_loop_partitioner;
-}
-
-
-
-template <typename Number>
 bool
 Vector<Number>::all_zero() const
 {

--- a/source/lac/vector.cc
+++ b/source/lac/vector.cc
@@ -33,9 +33,6 @@ Vector<double>::operator=<int>(const dealii::Vector<int> &);
 template bool
 Vector<int>::operator==<int>(dealii::Vector<int> const &) const;
 
-template void
-Vector<int>::reinit<double>(const Vector<double> &, const bool);
-
 // instantiate for long double manually because we use it in a few places:
 template class Vector<long double>;
 template long double

--- a/source/lac/vector.inst.in
+++ b/source/lac/vector.inst.in
@@ -24,18 +24,15 @@ for (S1, S2 : REAL_SCALARS)
   {
     template bool Vector<S1>::operator==<S2>(const Vector<S2> &) const;
     template S1 Vector<S1>::operator*<S2>(const Vector<S2> &) const;
-    template void Vector<S1>::reinit<S2>(const Vector<S2> &, const bool);
   }
 
 for (S1, S2 : COMPLEX_SCALARS)
   {
     template bool Vector<S1>::operator==<S2>(const Vector<S2> &) const;
     template S1 Vector<S1>::operator*<S2>(const Vector<S2> &) const;
-    template void Vector<S1>::reinit<S2>(const Vector<S2> &, const bool);
   }
 
 for (S1 : COMPLEX_SCALARS; S2 : REAL_SCALARS)
   {
     template Vector<S1> &Vector<S1>::operator=<S2>(const Vector<S2> &);
-    template void Vector<S1>::reinit<S2>(const Vector<S2> &, const bool);
   }


### PR DESCRIPTION
As described in #14251, I see a substantial cost of `Vector::reinit(const Vector &, bool)` in case of small vectors, also for the simple case that the vector is already allocated to the right size and we do not request initialization. This PR creates a version that breaks out the function to the header file for the fast path, plus avoiding creating instantiations for this setup.