### PR TITLE
Vectorize more work in reductions of vector operations

### DIFF
--- a/tests/lac/bicgstab_large.cc
+++ b/tests/lac/bicgstab_large.cc
@@ -31,6 +31,7 @@ main()
 {
   initlog();
   deallog << std::setprecision(4);
+  deallog.depth_file(1);
 
   SparsityPattern sparsity_pattern(4, 4);
   sparsity_pattern.compress();
@@ -46,17 +47,19 @@ main()
 
   Vector<double> solution(4);
 
+  unsigned int n_iter = 0;
   {
     SolverControl    control(100, 1.e-3);
     SolverBicgstab<> bicgstab(control);
     bicgstab.solve(M, solution, rhs, PreconditionIdentity());
+    n_iter = control.last_step();
   }
 
   solution.print(deallog.get_file_stream());
 
   Vector<double> res(4);
   M.residual(res, solution, rhs);
-  deallog << "residual=" << res.l2_norm() << std::endl;
+  deallog << "residual=" << res.l2_norm() << " niter=" << n_iter << std::endl;
 
   // now set up the same problem but with matrix entries scaled by 1e10 and
   // solver tolerance scaled by 1e10. should get the same solution
@@ -69,8 +72,10 @@ main()
     SolverControl    control(100, 1.e7);
     SolverBicgstab<> bicgstab(control);
     bicgstab.solve(M1, solution, rhs, PreconditionIdentity());
+    n_iter = control.last_step();
   }
   solution.print(deallog.get_file_stream());
   M1.residual(res, solution, rhs);
-  deallog << "residual=" << res.l2_norm() << std::endl;
+  deallog << "scaled residual=" << res.l2_norm() / 1e10 << " niter=" << n_iter
+          << std::endl;
 }

--- a/tests/lac/bicgstab_large.debug.output
+++ b/tests/lac/bicgstab_large.debug.output
@@ -1,9 +1,5 @@
 
-DEAL:Bicgstab::Starting value 2.000
-DEAL:Bicgstab::Convergence step 4 value 0
-1.000  0.1000 0.09091 0.02381 
-DEAL::residual=0
-DEAL:Bicgstab::Starting value 2.000e+10
-DEAL:Bicgstab::Convergence step 4 value 0.001939
-1.000  0.1000 0.09091 0.02381 
-DEAL::residual=0.001937
+1.000e+00 1.000e-01 9.091e-02 2.381e-02 
+DEAL::residual=1.637e-14 niter=4
+1.000e+00 1.000e-01 9.091e-02 2.381e-02 
+DEAL::scaled residual=1.490e-13 niter=4


### PR DESCRIPTION
Addresses one of the issues mentioned in #14251: The reductions for small sizes involve work on up to `n_lanes * 32 - 1` vector items without vectorization. If the vector size is a few hundreds, this scalar work gets clearly visible. We can get this down to less than `n_lanes`. While in this code, I also restructured the reductions on the temporary `outer_results` that contain the result of 32 operations: We can the associated pairwise summation by a single loop (rather than two nested loops) by writing the temporary result to the end of a (now 2x larger) array and sum until we've reached the end.

These two actions result in a considerable improvement. I tested for vector size 400 and found that around 20% fewer instructions get issued with this patch.

Note: This patch changes the order of additions, so I expect that we might need some updates to the result files that are sensitive to roundoff. I think I identified one, but let us wait for the CI machines.