### PR TITLE
GT::distributed_compute_point_locations(): project reference points onto cell

### DIFF
--- a/doc/news/changes/minor/20220912Munch_2
+++ b/doc/news/changes/minor/20220912Munch_2
@@ -1,0 +1,6 @@
+Fixed: The function GridTools::internal::distributed_compute_point_locations()
+now projects reference points outside of a cell (but within a tolerance) onto
+the unit cell. This enables the use of FE_Q_iso_Q1 in 
+Utilities::MPI::RemotePointEvaluation.
+<br>
+(Peter Munch, Magdalena Schreter, 2022/09/12)

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -6089,13 +6089,22 @@ namespace GridTools
                 for (const auto &cell_and_reference_position :
                      cells_and_reference_positions)
                   {
+                    const auto cell = cell_and_reference_position.first;
+                    auto       reference_position =
+                      cell_and_reference_position.second;
+
+                    // TODO: we need to implement
+                    // ReferenceCell::project_to_unit_cell()
+                    if (cell->reference_cell().is_hyper_cube())
+                      reference_position =
+                        GeometryInfo<dim>::project_to_unit_cell(
+                          reference_position);
+
                     send_components.emplace_back(
-                      std::pair<int, int>(
-                        cell_and_reference_position.first->level(),
-                        cell_and_reference_position.first->index()),
+                      std::pair<int, int>(cell->level(), cell->index()),
                       other_rank,
                       index_and_point.first,
-                      cell_and_reference_position.second,
+                      reference_position,
                       index_and_point.second,
                       numbers::invalid_unsigned_int);
                   }


### PR DESCRIPTION
This was necessary to enable `FE_Q_iso_Q1` in `Utilities::MPI::RemotePointEvaluation`. `FE_Q_iso_Q1` seems to be undefined outside of the domain.

FYI @mschreter 