### PR TITLE
Linking error: make `dealii::internal::SolverGMRESImplementation::solve_triangular()` inline

### DIFF
--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -621,7 +621,7 @@ namespace internal
 
     // A function to solve the (upper) triangular system after Givens
     // rotations on a matrix that has possibly unused rows and columns
-    void
+    inline void
     solve_triangular(const unsigned int        dim,
                      const FullMatrix<double> &H,
                      const Vector<double> &    rhs,


### PR DESCRIPTION
This PR suggests to make the function `dealii::internal::SolverGMRESImplementation::solve_triangular()` inline, since it is currently defined in the header file. Otherwise a linking error occurs with a multiple definitions warning. The function was introduced in https://github.com/dealii/dealii/pull/14251.

@kronbichler FYI