### PR TITLE
Avoid warning about function that might not be inlinable

### DIFF
--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -1383,7 +1383,7 @@ namespace internal
 #ifndef DEBUG
     DEAL_II_ALWAYS_INLINE
 #endif
-      void
+      inline void
       parallel_reduce(
         const Operation &op,
         const size_type  start,


### PR DESCRIPTION
Fixes a warning introduced by #14253.