### PR TITLE
Make sure not to work with possibly uninitialized variables

### DIFF
--- a/tests/matrix_free/stokes_computation.cc
+++ b/tests/matrix_free/stokes_computation.cc
@@ -256,7 +256,7 @@ namespace StokesClass
       // apply the top right block
       {
         LinearAlgebra::distributed::BlockVector<double> dst_tmp(dst);
-        dst_tmp.block(0) *= 0.0;
+        dst_tmp.block(0) = 0.0;
         stokes_matrix.vmult(utmp, dst_tmp); // B^T
         utmp.block(0) *= -1.0;
         utmp.block(0) += src.block(0);

--- a/tests/numerics/no_flux_18.cc
+++ b/tests/numerics/no_flux_18.cc
@@ -257,7 +257,7 @@ namespace StokesClass
       // apply the top right block
       {
         LinearAlgebra::distributed::BlockVector<double> dst_tmp(dst);
-        dst_tmp.block(0) *= 0.0;
+        dst_tmp.block(0) = 0.0;
         stokes_matrix.vmult(utmp, dst_tmp); // B^T
         utmp.block(0) *= -1.0;
         utmp.block(0) += src.block(0);


### PR DESCRIPTION
Due to a change in #14251, we would now not necessarily initialize a vector in the GMRES solver, see here: https://github.com/dealii/dealii/blob/f28d4d18aeb3028affb6e57d08cfd36f38ba6eff/include/deal.II/lac/solver_gmres.h#L598

In two of our tests, we would use `vector *= 0.0` to set its entries to zero, rather than the (more efficient) `vector = 0.0`. The former accesses whatever content we have in the memory, which could be `NaN`, which can then cause a floating point exception as in this test here: https://cdash.dealii.43-1.org/test/32205805 - while the latter is correct and makes sure we overwrite all content, including `inf` and `nan` data, with the correct value `0.`