### PR TITLE
find_neighbor_type with customizable tolerance

### DIFF
--- a/include/deal.II/base/bounding_box.h
+++ b/include/deal.II/base/bounding_box.h
@@ -187,7 +187,9 @@ public:
    * Return an enumerator of type NeighborType.
    */
   NeighborType
-  get_neighbor_type(const BoundingBox<spacedim, Number> &other_bbox) const;
+  get_neighbor_type(
+    const BoundingBox<spacedim, Number> &other_bbox,
+    const double tolerance = std::numeric_limits<Number>::epsilon()) const;
 
   /**
    * Enlarge the current object so that it contains @p other_bbox .


### PR DESCRIPTION
Currently, the function uses ```std::numeric_limits<Number>::epsilon()``` as hard coded tolerance. However, it would be nice to be able to specify the tolerance as the user.