### PR TITLE
Windows action: archive library only if merged into master

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -49,6 +49,8 @@ jobs:
       run: |
         cmake --build build  --target test -- -m
     - name: archive library
+      # run only if a PR is merged into master
+      if: github.ref == 'refs/heads/master'
       uses: actions/upload-artifact@v3
       with:
         name: dealii-windows.zip


### PR DESCRIPTION
... it gets a bit annoying that hardly any PR passes the full tests on GitHub.