### PR TITLE
Remove template parameter from FPArrayComparator

### DIFF
--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -44,7 +44,7 @@ namespace internal
     template <int dim>
     class HangingNodes;
 
-    template <typename, typename>
+    template <typename>
     struct FPArrayComparator;
 
     struct TaskInfo;
@@ -111,7 +111,7 @@ namespace internal
       std::pair<std::vector<Number>, types::global_dof_index> next_constraint;
       std::map<std::vector<Number>,
                types::global_dof_index,
-               FPArrayComparator<Number, VectorizedArray<Number>>>
+               FPArrayComparator<VectorizedArray<Number>>>
         constraints;
     };
 

--- a/include/deal.II/matrix_free/dof_info.templates.h
+++ b/include/deal.II/matrix_free/dof_info.templates.h
@@ -41,7 +41,7 @@ namespace internal
   {
     template <typename Number>
     ConstraintValues<Number>::ConstraintValues()
-      : constraints(FPArrayComparator<Number>(1.))
+      : constraints(FPArrayComparator<VectorizedArray<Number>>(1.))
     {}
 
 

--- a/include/deal.II/matrix_free/mapping_info.h
+++ b/include/deal.II/matrix_free/mapping_info.h
@@ -310,10 +310,14 @@ namespace internal
      * satisfied). This is not a problem in the use cases for this class, but be
      * careful when using it in other contexts.
      */
-    template <typename Number,
-              typename VectorizedArrayType = VectorizedArray<Number>>
+    template <typename VectorizedArrayType>
     struct FPArrayComparator
     {
+      using Number = typename dealii::internal::VectorizedArrayTrait<
+        VectorizedArrayType>::value_type;
+      static constexpr std::size_t width =
+        dealii::internal::VectorizedArrayTrait<VectorizedArrayType>::width;
+
       FPArrayComparator(const Number scaling);
 
       /**
@@ -328,9 +332,8 @@ namespace internal
        * issues).
        */
       bool
-      operator()(
-        const Tensor<1, VectorizedArrayType::size(), Number> &t1,
-        const Tensor<1, VectorizedArrayType::size(), Number> &t2) const;
+      operator()(const Tensor<1, width, Number> &t1,
+                 const Tensor<1, width, Number> &t2) const;
 
       /**
        * Compare two rank-1 tensors of vectorized arrays (stored as tensors to
@@ -338,11 +341,8 @@ namespace internal
        */
       template <int dim>
       bool
-      operator()(
-        const Tensor<1, dim, Tensor<1, VectorizedArrayType::size(), Number>>
-          &t1,
-        const Tensor<1, dim, Tensor<1, VectorizedArrayType::size(), Number>>
-          &t2) const;
+      operator()(const Tensor<1, dim, Tensor<1, width, Number>> &t1,
+                 const Tensor<1, dim, Tensor<1, width, Number>> &t2) const;
 
       /**
        * Compare two rank-2 tensors of vectorized arrays (stored as tensors to
@@ -350,11 +350,8 @@ namespace internal
        */
       template <int dim>
       bool
-      operator()(
-        const Tensor<2, dim, Tensor<1, VectorizedArrayType::size(), Number>>
-          &t1,
-        const Tensor<2, dim, Tensor<1, VectorizedArrayType::size(), Number>>
-          &t2) const;
+      operator()(const Tensor<2, dim, Tensor<1, width, Number>> &t1,
+                 const Tensor<2, dim, Tensor<1, width, Number>> &t2) const;
 
       /**
        * Compare two arrays of tensors.

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -347,12 +347,12 @@ namespace internal
       struct CompressedCellData
       {
         CompressedCellData(const double expected_size)
-          : data(FPArrayComparator<Number, VectorizedArrayType>(expected_size))
+          : data(FPArrayComparator<VectorizedArrayType>(expected_size))
         {}
 
         std::map<Tensor<2, dim, Tensor<1, VectorizedArrayType::size(), Number>>,
                  unsigned int,
-                 FPArrayComparator<Number, VectorizedArrayType>>
+                 FPArrayComparator<VectorizedArrayType>>
           data;
       };
 
@@ -1077,10 +1077,11 @@ namespace internal
         // first quadrature point on the cell - we use a relatively coarse
         // tolerance to account for some inaccuracies in the manifold
         // evaluation
-        const FPArrayComparator<double> comparator(1e4 * jacobian_size);
+        const FPArrayComparator<VectorizedArray<double>> comparator(
+          1e4 * jacobian_size);
         std::map<std::array<Tensor<2, dim>, dim + 1>,
                  unsigned int,
-                 FPArrayComparator<double>>
+                 FPArrayComparator<VectorizedArray<double>>>
           compressed_jacobians(comparator);
 
         unsigned int n_data_buckets = 0;
@@ -1503,8 +1504,7 @@ namespace internal
         // CompressedCellData) and add another factor of 512 to account for
         // some roundoff effects.
         CompressedFaceData(const Number jacobian_size)
-          : data(FPArrayComparator<Number, VectorizedArrayType>(512. /
-                                                                jacobian_size))
+          : data(FPArrayComparator<VectorizedArrayType>(512. / jacobian_size))
           , jacobian_size(jacobian_size)
         {}
 
@@ -1518,7 +1518,7 @@ namespace internal
                         2 * dim * dim + dim + 1,
                         Tensor<1, VectorizedArrayType::size(), Number>>,
                  unsigned int,
-                 FPArrayComparator<Number, VectorizedArrayType>>
+                 FPArrayComparator<VectorizedArrayType>>
           data;
 
         // Store the scaling factor
@@ -3351,17 +3351,17 @@ namespace internal
 
     /* ------------------------------------------------------------------ */
 
-    template <typename Number, typename VectorizedArrayType>
-    FPArrayComparator<Number, VectorizedArrayType>::FPArrayComparator(
+    template <typename VectorizedArrayType>
+    FPArrayComparator<VectorizedArrayType>::FPArrayComparator(
       const Number scaling)
       : tolerance(scaling * std::numeric_limits<double>::epsilon() * 1024.)
     {}
 
 
 
-    template <typename Number, typename VectorizedArrayType>
+    template <typename VectorizedArrayType>
     bool
-    FPArrayComparator<Number, VectorizedArrayType>::operator()(
+    FPArrayComparator<VectorizedArrayType>::operator()(
       const std::vector<Number> &v1,
       const std::vector<Number> &v2) const
     {
@@ -3381,13 +3381,13 @@ namespace internal
 
 
 
-    template <typename Number, typename VectorizedArrayType>
+    template <typename VectorizedArrayType>
     bool
-    FPArrayComparator<Number, VectorizedArrayType>::operator()(
-      const Tensor<1, VectorizedArrayType::size(), Number> &t1,
-      const Tensor<1, VectorizedArrayType::size(), Number> &t2) const
+    FPArrayComparator<VectorizedArrayType>::operator()(
+      const Tensor<1, width, Number> &t1,
+      const Tensor<1, width, Number> &t2) const
     {
-      for (unsigned int k = 0; k < VectorizedArrayType::size(); ++k)
+      for (unsigned int k = 0; k < width; ++k)
         if (t1[k] < t2[k] - tolerance)
           return true;
         else if (t1[k] > t2[k] + tolerance)
@@ -3397,16 +3397,15 @@ namespace internal
 
 
 
-    template <typename Number, typename VectorizedArrayType>
+    template <typename VectorizedArrayType>
     template <int dim>
     bool
-    FPArrayComparator<Number, VectorizedArrayType>::operator()(
-      const Tensor<1, dim, Tensor<1, VectorizedArrayType::size(), Number>> &t1,
-      const Tensor<1, dim, Tensor<1, VectorizedArrayType::size(), Number>> &t2)
-      const
+    FPArrayComparator<VectorizedArrayType>::operator()(
+      const Tensor<1, dim, Tensor<1, width, Number>> &t1,
+      const Tensor<1, dim, Tensor<1, width, Number>> &t2) const
     {
       for (unsigned int d = 0; d < dim; ++d)
-        for (unsigned int k = 0; k < VectorizedArrayType::size(); ++k)
+        for (unsigned int k = 0; k < width; ++k)
           if (t1[d][k] < t2[d][k] - tolerance)
             return true;
           else if (t1[d][k] > t2[d][k] + tolerance)
@@ -3416,17 +3415,16 @@ namespace internal
 
 
 
-    template <typename Number, typename VectorizedArrayType>
+    template <typename VectorizedArrayType>
     template <int dim>
     bool
-    FPArrayComparator<Number, VectorizedArrayType>::operator()(
-      const Tensor<2, dim, Tensor<1, VectorizedArrayType::size(), Number>> &t1,
-      const Tensor<2, dim, Tensor<1, VectorizedArrayType::size(), Number>> &t2)
-      const
+    FPArrayComparator<VectorizedArrayType>::operator()(
+      const Tensor<2, dim, Tensor<1, width, Number>> &t1,
+      const Tensor<2, dim, Tensor<1, width, Number>> &t2) const
     {
       for (unsigned int d = 0; d < dim; ++d)
         for (unsigned int e = 0; e < dim; ++e)
-          for (unsigned int k = 0; k < VectorizedArrayType::size(); ++k)
+          for (unsigned int k = 0; k < width; ++k)
             if (t1[d][e][k] < t2[d][e][k] - tolerance)
               return true;
             else if (t1[d][e][k] > t2[d][e][k] + tolerance)
@@ -3436,10 +3434,10 @@ namespace internal
 
 
 
-    template <typename Number, typename VectorizedArrayType>
+    template <typename VectorizedArrayType>
     template <int dim>
     bool
-    FPArrayComparator<Number, VectorizedArrayType>::operator()(
+    FPArrayComparator<VectorizedArrayType>::operator()(
       const std::array<Tensor<2, dim, Number>, dim + 1> &t1,
       const std::array<Tensor<2, dim, Number>, dim + 1> &t2) const
     {

--- a/source/matrix_free/mapping_info.cc
+++ b/source/matrix_free/mapping_info.cc
@@ -31,31 +31,34 @@ DEAL_II_NAMESPACE_OPEN
 
 #if SPLIT_INSTANTIATIONS_INDEX == 0
 
-template struct internal::MatrixFreeFunctions::
-  FPArrayComparator<double, VectorizedArray<double, 1>>;
-template struct internal::MatrixFreeFunctions::
-  FPArrayComparator<float, VectorizedArray<float, 1>>;
+template struct internal::MatrixFreeFunctions::FPArrayComparator<double>;
+template struct internal::MatrixFreeFunctions::FPArrayComparator<float>;
+
+template struct internal::MatrixFreeFunctions::FPArrayComparator<
+  VectorizedArray<double, 1>>;
+template struct internal::MatrixFreeFunctions::FPArrayComparator<
+  VectorizedArray<float, 1>>;
 
 #  if (DEAL_II_VECTORIZATION_WIDTH_IN_BITS >= 128 && defined(__SSE2__)) || \
     (DEAL_II_VECTORIZATION_WIDTH_IN_BITS >= 128 && defined(__ALTIVEC__))
-template struct internal::MatrixFreeFunctions::
-  FPArrayComparator<double, VectorizedArray<double, 2>>;
-template struct internal::MatrixFreeFunctions::
-  FPArrayComparator<float, VectorizedArray<float, 4>>;
+template struct internal::MatrixFreeFunctions::FPArrayComparator<
+  VectorizedArray<double, 2>>;
+template struct internal::MatrixFreeFunctions::FPArrayComparator<
+  VectorizedArray<float, 4>>;
 #  endif
 
 #  if DEAL_II_VECTORIZATION_WIDTH_IN_BITS >= 256 && defined(__AVX__)
-template struct internal::MatrixFreeFunctions::
-  FPArrayComparator<double, VectorizedArray<double, 4>>;
-template struct internal::MatrixFreeFunctions::
-  FPArrayComparator<float, VectorizedArray<float, 8>>;
+template struct internal::MatrixFreeFunctions::FPArrayComparator<
+  VectorizedArray<double, 4>>;
+template struct internal::MatrixFreeFunctions::FPArrayComparator<
+  VectorizedArray<float, 8>>;
 #  endif
 
 #  if DEAL_II_VECTORIZATION_WIDTH_IN_BITS >= 512 && defined(__AVX512F__)
-template struct internal::MatrixFreeFunctions::
-  FPArrayComparator<double, VectorizedArray<double, 8>>;
-template struct internal::MatrixFreeFunctions::
-  FPArrayComparator<float, VectorizedArray<float, 16>>;
+template struct internal::MatrixFreeFunctions::FPArrayComparator<
+  VectorizedArray<double, 8>>;
+template struct internal::MatrixFreeFunctions::FPArrayComparator<
+  VectorizedArray<float, 16>>;
 #  endif
 
 #endif


### PR DESCRIPTION
... with the intention that it not only works for `VectorizedArray<Number>` but also for `Number`.

In forllow up PRs, I plan
- to move the class into a new file
- introduce masks
- add a function for `Table`s
- use it in `TensorProductMatrixSymmetricSumCache`


depends on #14293 