### PR TITLE
Do not default initialize projection matrix in GMRES

### DIFF
--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -879,7 +879,7 @@ SolverGMRES<VectorType>::solve(const MatrixType &        A,
     H_orig.reinit(n_tmp_vectors, n_tmp_vectors - 1);
 
   // matrix used for the orthogonalization process later
-  H.reinit(n_tmp_vectors, n_tmp_vectors - 1);
+  H.reinit(n_tmp_vectors, n_tmp_vectors - 1, /* omit_initialization */ true);
 
   // some additional vectors, also used in the orthogonalization
   gamma.reinit(n_tmp_vectors);


### PR DESCRIPTION
Follow-up to #14251: We do not need to zero-initialize the small projection matrix because we overwrite all entries and all operations are restricted to entries that we wrote into before.