### PR TITLE
Do not mention update_cell_dof_indices_cache in documentation

### DIFF
--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -2111,10 +2111,6 @@ public:
    */
 
 private:
-  // Make the DoFHandler class a friend so that it can call the
-  // update_cell_dof_indices_cache() function
-  template <int, int>
-  friend class DoFHandler;
   friend struct dealii::internal::DoFCellAccessorImplementation::Implementation;
 };
 

--- a/include/deal.II/dofs/dof_levels.h
+++ b/include/deal.II/dofs/dof_levels.h
@@ -38,16 +38,10 @@ namespace internal
      * Structure for storing degree of freedom information for cells,
      * organized by levels.
      *
-     * We store are cached values for the DoF indices on each cell
-     * in#cell_dof_indices_cache, since this is a frequently requested
-     * operation. The values are set by
-     * DoFCellAccessor::update_cell_dof_indices_cache and are used by
-     * DoFCellAccessor::get_dof_indices.
-     *
-     * Note that vertices are separate from, and in fact have nothing to do
-     * with cells. The indices of degrees of freedom located on vertices
-     * therefore are not stored here, but rather in member variables of the
-     * dealii::DoFHandler class.
+     * Note that vertices use a storage scheme that is entirely separate from
+     * the one used for the cells. The indices of degrees of freedom located
+     * on vertices are therefore not stored here, but rather in member
+     * variables of the dealii::DoFHandler class.
      *
      * The indices of degrees of freedom located on lower dimensional objects,
      * i.e. on lines for 2D and on quads and lines for 3D are treated


### PR DESCRIPTION
Follow-up to #14068 - this should remove all mentioning of the dof indices cache in our files. While there, I also removed a `friend` declaration that is no longer necessary after #14068.