### PR TITLE
Increase precision of time written in xdmf output

### DIFF
--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -9783,6 +9783,7 @@ XDMFEntry::get_xdmf_content(const unsigned int indent_level) const
     return "";
 
   std::stringstream ss;
+  ss.precision(12);
   ss << indent(indent_level + 0)
      << "<Grid Name=\"mesh\" GridType=\"Uniform\">\n";
   ss << indent(indent_level + 1) << "<Time Value=\"" << entry_time << "\"/>\n";

--- a/tests/data_out/data_out_hdf5_01.cc
+++ b/tests/data_out/data_out_hdf5_01.cc
@@ -56,8 +56,10 @@ test()
   data_out.write_filtered_data(data_filter);
   data_out.write_hdf5_parallel(data_filter, "out.h5", MPI_COMM_SELF);
   std::vector<XDMFEntry> xdmf_entries;
-  xdmf_entries.push_back(
-    data_out.create_xdmf_entry(data_filter, "out.h5", 0, MPI_COMM_SELF));
+
+  // Use a point in time that requires high precision output
+  xdmf_entries.push_back(data_out.create_xdmf_entry(
+    data_filter, "out.h5", 1 + 1e-10, MPI_COMM_SELF));
 
   data_out.write_xdmf_file(xdmf_entries, "out.xdmf", MPI_COMM_SELF);
 

--- a/tests/data_out/data_out_hdf5_01.with_hdf5=true.with_mpi=false.output
+++ b/tests/data_out/data_out_hdf5_01.with_hdf5=true.with_mpi=false.output
@@ -6,7 +6,7 @@ DEAL::ok
   <Domain>
     <Grid Name="CellTime" GridType="Collection" CollectionType="Temporal">
       <Grid Name="mesh" GridType="Uniform">
-        <Time Value="0"/>
+        <Time Value="1.0000000001"/>
         <Geometry GeometryType="XY">
           <DataItem Dimensions="36 2" NumberType="Float" Precision="8" Format="HDF">
             out.h5:/nodes


### PR DESCRIPTION
I believe the precision should be higher here. Otherwise, the default precision of 6 is too low to distinguish e.g. `1000.0` and `1000.0001`.