### PR TITLE
Add missing header file

### DIFF
--- a/include/deal.II/base/floating_point_comparator.h
+++ b/include/deal.II/base/floating_point_comparator.h
@@ -21,6 +21,7 @@
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/vectorization.h>
 
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 


### PR DESCRIPTION
On some of our systems, see e.g. https://cdash.dealii.43-1.org/test/1024935 we need to include the `vector` header. Follow-up to #14296.