### PR TITLE
Fix exponential complexity of FloatingPointComparator with nesting

### DIFF
--- a/include/deal.II/base/floating_point_comparator.h
+++ b/include/deal.II/base/floating_point_comparator.h
@@ -116,7 +116,7 @@ struct FloatingPointComparator
    * Compare two scalar numbers.
    */
   ComparisonResult
-  compare(const ScalarNumber &s1, const ScalarNumber &s2) const;
+  compare(const ScalarNumber s1, const ScalarNumber s2) const;
 
   /**
    * Compare two VectorizedArray instances.
@@ -240,14 +240,15 @@ FloatingPointComparator<Number>::compare(const Table<2, T> &t1,
 
 template <typename Number>
 typename FloatingPointComparator<Number>::ComparisonResult
-FloatingPointComparator<Number>::compare(const ScalarNumber &s1,
-                                         const ScalarNumber &s2) const
+FloatingPointComparator<Number>::compare(const ScalarNumber s1,
+                                         const ScalarNumber s2) const
 {
   if (width == 1 || mask[0])
     {
-      const ScalarNumber tolerance = use_absolute_tolerance ?
-                                       this->tolerance :
-                                       (std::abs(s1 + s2) * this->tolerance);
+      const ScalarNumber tolerance =
+        use_absolute_tolerance ?
+          this->tolerance :
+          ((std::abs(s1) + std::abs(s2)) * this->tolerance);
 
       if (s1 < s2 - tolerance)
         return ComparisonResult::less;


### PR DESCRIPTION
This attempts to fix the exponential complexity observed in https://github.com/dealii/dealii/pull/14298#discussion_r979616489 - rather than spelling out all loops we might possibly have in the code, I opted to track all three ways of a comparison (less, equal, greater), which then avoids calling both `compare(t1, t2)` and `compare(t2, t1)` which eventually lead to the exponential rather than linear complexity. I successfully ran the tests `matrix_free/compress_mapping` and `matrix_free/compress_constraints`, which check the effect of the comparator, but have not run any other test. Hence, let us wait for the CI to see if I really got it right. Note that the instruction count is still higher than before, but I think it's acceptable now.