### PR TITLE
Add shortcut to detect whether a DoF is constrained

### DIFF
--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -2196,6 +2196,9 @@ template <typename number>
 inline bool
 AffineConstraints<number>::is_constrained(const size_type index) const
 {
+  if (lines.empty())
+    return false;
+
   const size_type line_index = calculate_line_index(index);
   return ((line_index < lines_cache.size()) &&
           (lines_cache[line_index] != numbers::invalid_size_type));
@@ -2223,6 +2226,9 @@ template <typename number>
 inline const std::vector<std::pair<types::global_dof_index, number>> *
 AffineConstraints<number>::get_constraint_entries(const size_type line_n) const
 {
+  if (lines.empty())
+    return nullptr;
+
   // check whether the entry is constrained. could use is_constrained, but
   // that means computing the line index twice
   const size_type line_index = calculate_line_index(line_n);


### PR DESCRIPTION
If we query whether a certain DoF is constrained, we might have the case that we have no constraints at all on a particular process or even globally, like when setting up `MatrixFree` for `FE_DGQ` that has no constraints, but the interface still requesting such an object. In that case, we do not need to step through the `calculate_line_index`, which might involve a binary search through the available ranges of an `IndexSet`.