### PR TITLE
Do not dereference cend

### DIFF
--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -1252,7 +1252,10 @@ namespace Utilities
       const std::vector<char>::const_iterator &cend,
       std::vector<T> &                         object)
     {
-      // First get the size of the vector, and resize the output object
+      // The size of the object vector can be found in cbegin of the buffer.
+      // The data starts at cbegin + sizeof(vector_size).
+
+      // Get the size of the vector
       typename std::vector<T>::size_type vector_size;
       memcpy(&vector_size, &*cbegin, sizeof(vector_size));
 
@@ -1262,13 +1265,15 @@ namespace Utilities
              ExcMessage("The given buffer has the wrong size."));
       (void)cend;
 
-      // Then copy the elements:
+      // Copy the elements:
       object.clear();
       if (vector_size > 0)
-        object.insert(object.end(),
-                      reinterpret_cast<const T *>(&*cbegin +
-                                                  sizeof(vector_size)),
-                      reinterpret_cast<const T *>(&*cend));
+        {
+          const auto buffer_data_begin =
+            reinterpret_cast<const T *>(&*cbegin + sizeof(vector_size));
+          const auto buffer_data_end = buffer_data_begin + vector_size;
+          object.insert(object.end(), buffer_data_begin, buffer_data_end);
+        }
     }
 
 


### PR DESCRIPTION
Avoid deferencing cend because it is undefined behaviour. https://en.cppreference.com/w/cpp/container/vector/end

This is related to #13784 and #13811

I think that the generated assembly is ok, but it would be better not to deference cend.

Since the code is highly optimized, @bangerth and @kronbichler, could you take a look :) ?

When I run deal.II with [libc++ in debug mode](https://libcxx.llvm.org/DesignDocs/DebugMode.html) I obtain the error below. This patch fixes the error.

```
include/c++/v1/__iterator/wrap_iter.h:87: _LIBCPP_ASSERT '__libcpp_is_constant_evaluated() || 
(__get_const_db()->__dereferenceable(this))' failed. Attempted to dereference a non-dereferenceable iterator
```