### PR TITLE
Run doxygen with threads.

### DIFF
--- a/doc/doxygen/CMakeLists.txt
+++ b/doc/doxygen/CMakeLists.txt
@@ -34,6 +34,7 @@ IF(NOT DOXYGEN_FOUND)
     )
 ENDIF()
 
+
 ########################################################################
 #
 # Process the tutorial and code-gallery files into inputs for doxygen
@@ -271,6 +272,19 @@ FILE(APPEND "${CMAKE_CURRENT_BINARY_DIR}/options.dox"
   IMAGE_PATH=${_doxygen_image_path_string}
   "
   )
+
+# If we use a reasonably modern doxygen version, make sure it is run in parallel
+IF(NOT (${DOXYGEN_VERSION} VERSION_LESS 1.9))
+  FILE(APPEND "${CMAKE_CURRENT_BINARY_DIR}/options.dox"
+    "
+    NUM_PROC_THREADS       = 0
+    DOT_NUM_THREADS        = 0
+    "
+    )
+  MESSAGE(STATUS "Letting doxygen run with multiple threads")
+ENDIF()
+
+
 
 ########################################################################
 #

--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -77,6 +77,7 @@ EXAMPLE_RECURSIVE      = NO
 IMAGE_PATH             =
 INPUT_FILTER           = ${CMAKE_SOURCE_DIR}/doc/doxygen/scripts/filter.pl
 FILTER_SOURCE_FILES    = YES
+NUM_PROC_THREADS       = 0
 
 # Have some user defined commands that we can use in the documentation
 # and that expands to specific text. For some more transformations, see
@@ -290,6 +291,7 @@ DOT_TRANSPARENT        = NO
 GENERATE_LEGEND        = YES
 
 DOT_CLEANUP            = YES
+DOT_NUM_THREADS        = 0
 
 #---------------------------------------------------------------------------
 # Configuration::additions related to the search engine

--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -77,7 +77,6 @@ EXAMPLE_RECURSIVE      = NO
 IMAGE_PATH             =
 INPUT_FILTER           = ${CMAKE_SOURCE_DIR}/doc/doxygen/scripts/filter.pl
 FILTER_SOURCE_FILES    = YES
-NUM_PROC_THREADS       = 0
 
 # Have some user defined commands that we can use in the documentation
 # and that expands to specific text. For some more transformations, see
@@ -291,7 +290,6 @@ DOT_TRANSPARENT        = NO
 GENERATE_LEGEND        = YES
 
 DOT_CLEANUP            = YES
-DOT_NUM_THREADS        = 0
 
 #---------------------------------------------------------------------------
 # Configuration::additions related to the search engine

--- a/doc/news/changes/minor/20221004Bangerth
+++ b/doc/news/changes/minor/20221004Bangerth
@@ -1,0 +1,5 @@
+New: We now instruct doxygen to build the documentation with multiple
+threads, substantially reducing the amount of time it takes to
+complete this step.
+<br>
+(Wolfgang Bangerth, 2022/10/04)


### PR DESCRIPTION
Newer doxygen versions (since late in the 1.8.* series) can use multiple threads to read input files, and to a limited degree generate dot graphs in parallel. Since generating the documentation takes quite a long time, I thought I'd play with this. This is also useful because when generating documentation, everything is funneled into doxygen which then, for several minutes, runs as the only process on systems that today have multiple cores that are then unused.

Setting two of doxygen's parameters to zero then lets doxygen choose the number of threads based on the number of available cores. This substantially reduces the build time, even though it increases the overall CPU time -- but I think the former outweighs the latter given that this is the sequential step:
```
old:
-----
real    4m9.948s
user    4m3.983s
sys     0m6.577s

real    4m11.068s
user    4m4.590s
sys     0m7.003s


new:
------
real    1m27.764s
user    7m1.715s
sys     0m14.377s

real    1m30.634s
user    7m2.998s
sys     0m14.391s
```
(Timings for everything excluding running latex to create formulas. That is apparently broken in the doxygen version I'm testing this with, with or without using multiple threads, for reasons I still have to investigate.)