### PR TITLE
Fix check for same face type

### DIFF
--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -4207,14 +4207,10 @@ namespace internal
       if (fe_eval.get_dof_access_index() ==
             MatrixFreeFunctions::DoFInfo::dof_access_cell &&
           fe_eval.is_interior_face() == false) // exterior faces in the ECL loop
-        use_vectorization =
-          fe_eval.get_cell_ids()[0] != numbers::invalid_unsigned_int &&
-          std::all_of(fe_eval.get_cell_ids().begin() + 1,
-                      fe_eval.get_cell_ids().end(),
-                      [&](const auto &v) {
-                        return v == fe_eval.get_cell_ids()[0] ||
-                               v == numbers::invalid_unsigned_int;
-                      });
+        for (unsigned int v = 0; v < Number::size(); ++v)
+          if (fe_eval.get_cell_ids()[v] != numbers::invalid_unsigned_int &&
+              fe_eval.get_face_no(v) != fe_eval.get_face_no(0))
+            use_vectorization = false;
 
       if (use_vectorization == false)
         {


### PR DESCRIPTION
I observed that the ECL loop went way too often into the slow branch, and found that we assess the ability to vectorize on whether the cell ids are the same (see #13063), rather than the local face number that actually decides whether the interpolation directions are different or not. @peterrum I think we are in desperate need for a benchmark for the matrix-free DG infrastructure including the ECL setup. I have a Navier-Stokes one that I plan to post in the next days, I have one that would work well already around.

I ran all tests containing the expression `matrix_free` and they are passing.