### PR TITLE
Use Ubuntu 20.04 in GitHub actions

### DIFF
--- a/.github/workflows/indent.yml
+++ b/.github/workflows/indent.yml
@@ -35,6 +35,9 @@ jobs:
         cmake -DDEAL_II_COMPONENT_DOCUMENTATION=ON -DDEAL_II_DOXYGEN_USE_MATHJAX=ON ..
         make -j 2 documentation
         cat doxygen.log
+        # Suppress:
+        # warning: Inheritance graph for 'SmartPointer' not generated, too many nodes (138), threshold is 50. Consider increasing DOT_GRAPH_MAX_NODES.
+        # warning: Inheritance graph for 'Subscriptor' not generated, too many nodes (209), threshold is 50. Consider increasing DOT_GRAPH_MAX_NODES.
         sed -i '/Inheritance graph/d' doxygen.log
         ! [ -s doxygen.log ] || exit 1
         tar -czf doxygen_documentation.tar.gz doc/doxygen

--- a/.github/workflows/indent.yml
+++ b/.github/workflows/indent.yml
@@ -14,7 +14,7 @@ jobs:
     # run the indent checks
 
     name: indent
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-20.04]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/indent.yml
+++ b/.github/workflows/indent.yml
@@ -35,6 +35,7 @@ jobs:
         cmake -DDEAL_II_COMPONENT_DOCUMENTATION=ON -DDEAL_II_DOXYGEN_USE_MATHJAX=ON ..
         make -j 2 documentation
         cat doxygen.log
+        sed -i '/Inheritance graph/d' doxygen.log
         ! [ -s doxygen.log ] || exit 1
         tar -czf doxygen_documentation.tar.gz doc/doxygen
     - name: archive documentation

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -120,27 +120,25 @@ jobs:
           build/tests/**/*stdout*
 
 
-  linux-debug-cuda-10:
-    # simple parallel debug build using cuda-10
+  linux-debug-cuda-11:
+    # simple parallel debug build using cuda-11
 
-    name: linux debug cuda-10
+    name: linux debug cuda-11
     runs-on: [ubuntu-20.04]
 
     steps:
     - uses: actions/checkout@v3
     - name: modules
       run: |
-        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin
-        sudo mv cuda-ubuntu1804.pin /etc/apt/preferences.d/cuda-repository-pin-600
-        wget http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda-repo-ubuntu1804-10-2-local-10.2.89-440.33.01_1.0-1_amd64.deb
-        sudo dpkg -i cuda-repo-ubuntu1804-10-2-local-10.2.89-440.33.01_1.0-1_amd64.deb
-        sudo apt-key add /var/cuda-repo-10-2-local-10.2.89-440.33.01/7fa2af80.pub
+        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
+        sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
+        sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
+        sudo add-apt-repository "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /"
         sudo apt-get install -y software-properties-common
         sudo add-apt-repository ppa:ginggs/deal.ii-9.2.0-backports
         sudo apt-get update
-        apt search cuda
         sudo apt-get install -yq --no-install-recommends \
-            cuda-toolkit-10-2 \
+            cuda-toolkit-11-0 \
             libp4est-dev \
             libopenmpi-dev \
             openmpi-bin

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -124,7 +124,7 @@ jobs:
     # simple parallel debug build using cuda-10
 
     name: linux debug cuda-10
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-20.04]
 
     steps:
     - uses: actions/checkout@v3
@@ -176,7 +176,7 @@ jobs:
     # For a list of Intel packages see https://oneapi-src.github.io/oneapi-ci/#linux-apt
 
     name: linux debug intel oneapi
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-20.04]
 
     steps:
     - uses: actions/checkout@v3

--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -70,7 +70,8 @@ WARN_IF_DOC_ERROR      = YES
 
 INPUT                  =
 RECURSIVE              = YES
-EXCLUDE_PATTERNS       = *.templates.h
+EXCLUDE_PATTERNS       = *.templates.h \
+                         *.txt
 EXAMPLE_PATH           = @CMAKE_BINARY_DIR@/doc/doxygen/tutorial \
                          @CMAKE_SOURCE_DIR@/examples/doxygen
 EXAMPLE_RECURSIVE      = NO

--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -71,7 +71,7 @@ WARN_IF_DOC_ERROR      = YES
 INPUT                  =
 RECURSIVE              = YES
 EXCLUDE_PATTERNS       = *.templates.h \
-                         *.txt
+                         CMakeLists.txt
 EXAMPLE_PATH           = @CMAKE_BINARY_DIR@/doc/doxygen/tutorial \
                          @CMAKE_SOURCE_DIR@/examples/doxygen
 EXAMPLE_RECURSIVE      = NO

--- a/doc/news/3.0.0-vs-3.1.0.h
+++ b/doc/news/3.0.0-vs-3.1.0.h
@@ -379,8 +379,8 @@ All entries are signed with the names of the author.
        </p>
 
   <li> <p>
-       Improved: <code>FullMatrix</code><code
-       class="member">::invert(...)</code> now inverts matrices of all
+       Improved: <code>FullMatrix::invert</code>
+       now inverts matrices of all
        sizes. If there is no hardcoded inversion, <code
        class="member">gauss_jordan()</code> is used implicitly.
        <br>

--- a/include/deal.II/base/point.h
+++ b/include/deal.II/base/point.h
@@ -645,7 +645,6 @@ Point<dim, Number>::serialize(Archive &ar, const unsigned int)
  * @note This function can also be used in CUDA device code.
  *
  * @relates Point
- * @relatesalso EnableIfScalar
  */
 template <int dim, typename Number, typename OtherNumber>
 inline DEAL_II_CUDA_HOST_DEV

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -3574,7 +3574,6 @@ operator*(const Number &factor, const SymmetricTensor<rank_, dim, Number> &t)
  * input tensor by the scalar factor.
  *
  * @relates SymmetricTensor
- * @relatesalso EnableIfScalar
  */
 template <int rank_, int dim, typename Number, typename OtherNumber>
 constexpr inline DEAL_II_ALWAYS_INLINE SymmetricTensor<
@@ -3604,7 +3603,6 @@ operator*(const SymmetricTensor<rank_, dim, Number> &t,
  * information about template arguments and the return type.
  *
  * @relates SymmetricTensor
- * @relatesalso EnableIfScalar
  */
 template <int rank_, int dim, typename Number, typename OtherNumber>
 constexpr inline DEAL_II_ALWAYS_INLINE SymmetricTensor<
@@ -3719,7 +3717,6 @@ scalar_product(const SymmetricTensor<2, dim, Number> &     t1,
  * <tt>A*B</tt> (instead of <tt>scalar_product(A,B)</tt>) provides
  * $(\mathbf A \cdot\mathbf B)_{ij}=\sum_k A_{ik}B_{kj}$.
  *
- * @relatesalso Tensor
  * @relates SymmetricTensor
  */
 template <int dim, typename Number, typename OtherNumber>
@@ -3747,7 +3744,6 @@ constexpr inline DEAL_II_ALWAYS_INLINE
  * <tt>A*B</tt> (instead of <tt>scalar_product(A,B)</tt>) provides
  * $(\mathbf A \cdot\mathbf B)_{ij}=\sum_k A_{ik}B_{kj}$.
  *
- * @relatesalso Tensor
  * @relates SymmetricTensor
  */
 template <int dim, typename Number, typename OtherNumber>

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1931,7 +1931,9 @@ operator<<(std::ostream &out, const Tensor<0, dim, Number> &p)
 }
 
 
-/** @} */
+/**
+ * @}
+ */
 /**
  * @name Vector space operations on Tensor objects:
  * @{
@@ -2271,7 +2273,9 @@ inline constexpr DEAL_II_ALWAYS_INLINE
   return tmp;
 }
 
-/** @} */
+/**
+ * @}
+ */
 /**
  * @name Contraction operations and the outer product for tensor objects
  * @{
@@ -2613,7 +2617,9 @@ constexpr inline DEAL_II_ALWAYS_INLINE
 }
 
 
-/** @} */
+/**
+ * @}
+ */
 /**
  * @name Special operations on tensors of rank 1
  * @{

--- a/include/deal.II/base/tensor_accessors.h
+++ b/include/deal.II/base/tensor_accessors.h
@@ -43,8 +43,7 @@ DEAL_II_NAMESPACE_OPEN
  * @endcode
  *
  * deal.II has its own implementation for tensorial objects such as
- * dealii::Tensor<rank, dim, Number> and dealii::SymmetricTensor<rank, dim,
- * Number>
+ * dealii::Tensor and dealii::SymmetricTensor
  *
  * The methods and algorithms implemented in this namespace, however, are
  * fully generic. More precisely, it can operate on nested c-style arrays, or

--- a/include/deal.II/differentiation/ad/ad_helpers.h
+++ b/include/deal.II/differentiation/ad/ad_helpers.h
@@ -2696,7 +2696,39 @@ namespace Differentiation
       /** @{ */
 
       /**
-       * @copydoc HelperBase::reset()
+       * Reset the state of the class.
+       *
+       * When an instance of the class is stored as a class member object
+       * with the intention to reuse its instance, it may be necessary to reset
+       * the state of the object before use. This is because, internally, there
+       * is error checking performed to ensure that the correct
+       * auto-differentiable data is being tracked and used only when
+       * appropriate. This function clears all member data and, therefore,
+       * allows the state of all internal flags to be safely reset to their
+       * initial state.
+       *
+       * In the rare case that the number of independent or dependent variables
+       * has changed, this can also be reconfigured by passing in the
+       * appropriate arguments to the function.
+       *
+       * @param[in] n_independent_variables The number of independent variables
+       * that will be used in the definition of the functions that it is
+       * desired to compute the sensitivities of. In the computation of
+       * $\mathbf{f}(\mathbf{X})$, this will be the number of inputs
+       * $\mathbf{X}$, i.e., the dimension of the domain space.
+       * @param[in] n_dependent_variables The number of scalar functions to be
+       * defined that will have a sensitivity to the given independent
+       * variables. In the computation of $\mathbf{f}(\mathbf{X})$, this will
+       * be the number of outputs $\mathbf{f}$, i.e., the dimension of the
+       * image space.
+       * @param[in] clear_registered_tapes A flag that indicates the that
+       * list of @p registered_tapes must be cleared.
+       * If set to <tt>true</tt> then the data structure that tracks which
+       * tapes have been recorded is cleared as well. It is then expected that
+       * any preexisting tapes be re-recorded.
+       *
+       * @note This also resets the active tape number to an invalid number, and
+       * deactivates the recording mode for taped variables.
        */
       virtual void
       reset(const unsigned int n_independent_variables =

--- a/include/deal.II/lac/block_linear_operator.h
+++ b/include/deal.II/lac/block_linear_operator.h
@@ -835,7 +835,6 @@ block_diagonal_operator(
 
 /**
  * @relatesalso LinearOperator
- * @relatesalso BlockLinearOperator
  *
  * This function implements forward substitution to invert a lower block
  * triangular matrix. As arguments, it takes a BlockLinearOperator @p
@@ -952,7 +951,6 @@ block_forward_substitution(
 
 
 /**
- * @relatesalso LinearOperator
  * @relatesalso BlockLinearOperator
  *
  * This function implements back substitution to invert an upper block

--- a/include/deal.II/lac/dynamic_sparsity_pattern.h
+++ b/include/deal.II/lac/dynamic_sparsity_pattern.h
@@ -549,8 +549,8 @@ public:
 
   /**
    * @name Iterators
+   * @{
    */
-  // @{
 
   /**
    * Iterator starting at the first entry of the matrix. The resulting
@@ -604,7 +604,9 @@ public:
   iterator
   end(const size_type r) const;
 
-  /** @} */
+  /**
+   * @}
+   */
 
   /**
    * Compute the bandwidth of the matrix represented by this structure. The

--- a/include/deal.II/meshworker/integration_info.h
+++ b/include/deal.II/meshworker/integration_info.h
@@ -349,8 +349,8 @@ namespace MeshWorker
                const BlockInfo *                   block_info = nullptr);
     /**
      * @name FEValues setup
+     * @{
      */
-    /* @{ */
 
     /**
      * Call this function before initialize() in order to guess the update
@@ -470,8 +470,8 @@ namespace MeshWorker
 
     /**
      * @name Data vectors
+     * @{
      */
-    /* @{ */
 
     /**
      * Initialize the VectorSelector objects #cell_selector,
@@ -507,8 +507,8 @@ namespace MeshWorker
 
     /**
      * @name Interface for MeshWorker::loop()
+     * @{
      */
-    /* @{ */
     /**
      * A callback function which is called in the loop over all cells, after
      * the action on a cell has been performed and before the faces are dealt

--- a/include/deal.II/meshworker/integration_info.h
+++ b/include/deal.II/meshworker/integration_info.h
@@ -586,7 +586,7 @@ namespace MeshWorker
     , n_components(numbers::invalid_unsigned_int)
   {}
 
-
+#ifndef DOXYGEN
   template <int dim, int sdim>
   inline IntegrationInfo<dim, sdim>::IntegrationInfo(
     const IntegrationInfo<dim, sdim> &other)
@@ -631,6 +631,7 @@ namespace MeshWorker
           Assert(false, ExcInternalError());
       }
   }
+#endif
 
 
 
@@ -779,6 +780,7 @@ namespace MeshWorker
   }
 
 
+#ifndef DOXYGEN
   template <int dim, int sdim>
   inline void
   IntegrationInfoBox<dim, sdim>::initialize(const FiniteElement<dim, sdim> &el,
@@ -808,6 +810,7 @@ namespace MeshWorker
     neighbor.template initialize<FEFaceValues<dim, sdim>>(
       el, mapping, face_quadrature, neighbor_flags, block_info);
   }
+#endif
 
 
   template <int dim, int sdim>

--- a/include/deal.II/physics/elasticity/standard_tensors.h
+++ b/include/deal.II/physics/elasticity/standard_tensors.h
@@ -40,7 +40,6 @@ namespace Physics
      * Cartesian basis, where the metric tensor is the identity tensor.
      *
      * @relatesalso Tensor
-     * @relatesalso SymmetricTensor
      */
     template <int dim>
     class StandardTensors

--- a/source/differentiation/sd/symengine_scalar_operations.cc
+++ b/source/differentiation/sd/symengine_scalar_operations.cc
@@ -44,6 +44,7 @@ namespace Differentiation
     }
 
 
+#  ifndef DOXYGEN
     Expression
     make_symbolic_function(const std::string &             symbol,
                            const SD::types::symbol_vector &arguments)
@@ -59,6 +60,7 @@ namespace Differentiation
       return make_symbolic_function(symbol,
                                     SD::Utilities::extract_symbols(arguments));
     }
+#  endif
 
 
     /* --------------------------- Differentiation ------------------------- */


### PR DESCRIPTION
Similar to https://github.com/dealii/dealii/pull/14351.
According to https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/ updating still seems to be necessary.