### PR TITLE
introduce BoundingBox::is_neighbor()

### DIFF
--- a/doc/news/changes/minor/20230118Heinz
+++ b/doc/news/changes/minor/20230118Heinz
@@ -1,0 +1,4 @@
+Improved: Introduce a function that only checks if Bounding Boxes are overlapping.
+Fixed: If a 1D BBox is completely contained in another one, it was not recognized as mergable neighbor.
+<br>
+(Johannes Heinz, 2022/07/07)

--- a/include/deal.II/base/bounding_box.h
+++ b/include/deal.II/base/bounding_box.h
@@ -187,8 +187,14 @@ public:
   /**
    * Check if the current object and @p other_bbox are neighbors, i.e. if the boxes
    * have dimension spacedim, check if their intersection is non empty.
-   *
-   * Return an enumerator of type NeighborType.
+   */
+  bool
+  has_overlap_with(
+    const BoundingBox<spacedim, Number> &other_bbox,
+    const double tolerance = std::numeric_limits<Number>::epsilon()) const;
+
+  /**
+   * Check which NeighborType @p other_bbox is to the current object.
    */
   NeighborType
   get_neighbor_type(

--- a/tests/base/bounding_box_3.output
+++ b/tests/base/bounding_box_3.output
@@ -65,7 +65,7 @@ DEAL::Is neighbor G with A: 3
 DEAL::Vice-versa: 3
 DEAL::Is neighbor G with B: 3
 DEAL::Vice-versa: 3
-DEAL::Is neighbor G with C: 0
+DEAL::Is neighbor G with C: 3
 DEAL::Vice-versa: 3
 DEAL::Is neighbor G with D: 3
 DEAL::Vice-versa: 3

--- a/tests/base/bounding_box_8.cc
+++ b/tests/base/bounding_box_8.cc
@@ -1,0 +1,77 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 - 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// test for BoundingBox<int dim> which tests the function
+// has_overlap_with()
+
+#include <deal.II/base/bounding_box.h>
+#include <deal.II/base/point.h>
+
+#include "../tests.h"
+
+BoundingBox<1>
+generate_bbox(const double left, const double right)
+{
+  Point<1> p1;
+  Point<1> p2;
+
+  p1[0] = left;
+  p2[0] = right;
+
+  BoundingBox<1> bbox(std::make_pair(p1, p2));
+
+  return bbox;
+}
+
+void
+test_bounding_box(const double left_a,
+                  const double right_a,
+                  const double left_b,
+                  const double right_b,
+                  const double tolerance)
+{
+  const auto bbox_a = generate_bbox(left_a, right_a);
+  const auto bbox_b = generate_bbox(left_b, right_b);
+
+  deallog << "Bounding box A: ";
+  deallog << "[" << bbox_a.get_boundary_points().first << ", "
+          << bbox_a.get_boundary_points().second << "]" << std::endl;
+  deallog << "Bounding box B: ";
+  deallog << "[" << bbox_b.get_boundary_points().first << ", "
+          << bbox_b.get_boundary_points().second << "]" << std::endl;
+  deallog << "Has overlap with: " << bbox_a.has_overlap_with(bbox_b, tolerance)
+          << std::endl;
+}
+
+int
+main()
+{
+  initlog();
+
+  test_bounding_box(1.0, 2.0, 2.0, 3.0, 1e-12);
+  test_bounding_box(1.0, 2.0, 2.0 + 1e-11, 3.0, 1e-12);
+  test_bounding_box(1.0, 2.0, 2.0 + 1e-11, 3.0, 1e-10);
+
+  test_bounding_box(-1.0, 0.0, 0.0, 1.0, 1e-12);
+  test_bounding_box(-1.0, 0.0, 0.0 + 1e-11, 1.0, 1e-12);
+  test_bounding_box(-1.0, 0.0, 0.0 + 1e-11, 1.0, 1e-10);
+
+  test_bounding_box(-2.0, -1.0, -1.0, 0.0, 1e-12);
+  test_bounding_box(-2.0, -1.0, -1.0 + 1e-11, 0.0, 1e-12);
+  test_bounding_box(-2.0, -1.0, -1.0 + 1e-11, 0.0, 1e-10);
+
+  return 0;
+}

--- a/tests/base/bounding_box_8.output
+++ b/tests/base/bounding_box_8.output
@@ -1,0 +1,28 @@
+
+DEAL::Bounding box A: [1.00000, 2.00000]
+DEAL::Bounding box B: [2.00000, 3.00000]
+DEAL::Has overlap with: 1
+DEAL::Bounding box A: [1.00000, 2.00000]
+DEAL::Bounding box B: [2.00000, 3.00000]
+DEAL::Has overlap with: 0
+DEAL::Bounding box A: [1.00000, 2.00000]
+DEAL::Bounding box B: [2.00000, 3.00000]
+DEAL::Has overlap with: 1
+DEAL::Bounding box A: [-1.00000, 0.00000]
+DEAL::Bounding box B: [0.00000, 1.00000]
+DEAL::Has overlap with: 1
+DEAL::Bounding box A: [-1.00000, 0.00000]
+DEAL::Bounding box B: [1.00000e-11, 1.00000]
+DEAL::Has overlap with: 0
+DEAL::Bounding box A: [-1.00000, 0.00000]
+DEAL::Bounding box B: [1.00000e-11, 1.00000]
+DEAL::Has overlap with: 1
+DEAL::Bounding box A: [-2.00000, -1.00000]
+DEAL::Bounding box B: [-1.00000, 0.00000]
+DEAL::Has overlap with: 1
+DEAL::Bounding box A: [-2.00000, -1.00000]
+DEAL::Bounding box B: [-1.00000, 0.00000]
+DEAL::Has overlap with: 0
+DEAL::Bounding box A: [-2.00000, -1.00000]
+DEAL::Bounding box B: [-1.00000, 0.00000]
+DEAL::Has overlap with: 1


### PR DESCRIPTION
I only want to know if bounding boxes are neighbors. If they are, get_neighbor_type() does too much work, since it checks which neighbor_type the bounding boxes are. 

During implementation, I found two issues:
* In my opinion ```side_length``` should always return positive values
* In test ```bounding_box_3``` the boxes C [0,2] and G [0.8,1.8] are considered no neighbors while they should be mergable neighbors. 

Given implementation fixes the issues.