### PR TITLE
Rename process_dof_gather() to process_dofs()

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -3434,16 +3434,16 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
         for (unsigned int i = 0; i < dofs_per_component;
              ++i, dof_indices += n_lanes)
           for (unsigned int comp = 0; comp < n_components; ++comp)
-            operation.process_dof_gather(dof_indices,
-                                         *src[comp],
-                                         0,
-                                         values_dofs[comp][i],
-                                         vector_selector);
+            operation.process_dofs(dof_indices,
+                                   *src[comp],
+                                   0,
+                                   values_dofs[comp][i],
+                                   vector_selector);
       else
         for (unsigned int comp = 0; comp < n_components; ++comp)
           for (unsigned int i = 0; i < dofs_per_component;
                ++i, dof_indices += n_lanes)
-            operation.process_dof_gather(
+            operation.process_dofs(
               dof_indices, *src[0], 0, values_dofs[comp][i], vector_selector);
       return;
     }
@@ -4000,22 +4000,22 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
             for (unsigned int i = 0; i < dofs_per_component; ++i)
               {
                 for (unsigned int comp = 0; comp < n_components; ++comp)
-                  operation.process_dof_gather(dof_indices,
-                                               *src[comp],
-                                               i * VectorizedArrayType::size(),
-                                               values_dofs[comp][i],
-                                               vector_selector);
+                  operation.process_dofs(dof_indices,
+                                         *src[comp],
+                                         i * VectorizedArrayType::size(),
+                                         values_dofs[comp][i],
+                                         vector_selector);
               }
           else
             for (unsigned int comp = 0; comp < n_components; ++comp)
               for (unsigned int i = 0; i < dofs_per_component; ++i)
                 {
-                  operation.process_dof_gather(dof_indices,
-                                               *src[0],
-                                               (comp * dofs_per_component + i) *
-                                                 VectorizedArrayType::size(),
-                                               values_dofs[comp][i],
-                                               vector_selector);
+                  operation.process_dofs(dof_indices,
+                                         *src[0],
+                                         (comp * dofs_per_component + i) *
+                                           VectorizedArrayType::size(),
+                                         values_dofs[comp][i],
+                                         vector_selector);
                 }
         }
       else
@@ -4031,11 +4031,11 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
             for (unsigned int i = 0; i < dofs_per_component; ++i)
               {
                 for (unsigned int comp = 0; comp < n_components; ++comp)
-                  operation.process_dof_gather(dof_indices,
-                                               *src[comp],
-                                               0,
-                                               values_dofs[comp][i],
-                                               vector_selector);
+                  operation.process_dofs(dof_indices,
+                                         *src[comp],
+                                         0,
+                                         values_dofs[comp][i],
+                                         vector_selector);
                 DEAL_II_OPENMP_SIMD_PRAGMA
                 for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
                   dof_indices[v] += offsets[v];
@@ -4044,11 +4044,11 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
             for (unsigned int comp = 0; comp < n_components; ++comp)
               for (unsigned int i = 0; i < dofs_per_component; ++i)
                 {
-                  operation.process_dof_gather(dof_indices,
-                                               *src[0],
-                                               0,
-                                               values_dofs[comp][i],
-                                               vector_selector);
+                  operation.process_dofs(dof_indices,
+                                         *src[0],
+                                         0,
+                                         values_dofs[comp][i],
+                                         vector_selector);
                   DEAL_II_OPENMP_SIMD_PRAGMA
                   for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
                     dof_indices[v] += offsets[v];

--- a/include/deal.II/matrix_free/vector_access_internal.h
+++ b/include/deal.II/matrix_free/vector_access_internal.h
@@ -406,20 +406,20 @@ namespace internal
     // gather
     template <typename VectorType>
     void
-    process_dof_gather(const unsigned int * indices,
-                       VectorType &         vec,
-                       const unsigned int   constant_offset,
-                       VectorizedArrayType &res,
-                       std::integral_constant<bool, true>) const
+    process_dofs(const unsigned int * indices,
+                 VectorType &         vec,
+                 const unsigned int   constant_offset,
+                 VectorizedArrayType &res,
+                 std::integral_constant<bool, true>) const
     {
 #ifdef DEBUG
       // in debug mode, run non-vectorized version because this path
       // has additional checks (e.g., regarding ghosting)
-      process_dof_gather(indices,
-                         vec,
-                         constant_offset,
-                         res,
-                         std::integral_constant<bool, false>());
+      process_dofs(indices,
+                   vec,
+                   constant_offset,
+                   res,
+                   std::integral_constant<bool, false>());
 #else
       res.gather(vec.begin() + constant_offset, indices);
 #endif
@@ -431,11 +431,11 @@ namespace internal
     // manually load the data
     template <typename VectorType>
     void
-    process_dof_gather(const unsigned int * indices,
-                       const VectorType &   vec,
-                       const unsigned int   constant_offset,
-                       VectorizedArrayType &res,
-                       std::integral_constant<bool, false>) const
+    process_dofs(const unsigned int * indices,
+                 const VectorType &   vec,
+                 const unsigned int   constant_offset,
+                 VectorizedArrayType &res,
+                 std::integral_constant<bool, false>) const
     {
       for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
         res[v] = vector_access(vec, indices[v] + constant_offset);
@@ -613,11 +613,11 @@ namespace internal
     // scatter
     template <typename VectorType>
     void
-    process_dof_gather(const unsigned int * indices,
-                       VectorType &         vec,
-                       const unsigned int   constant_offset,
-                       VectorizedArrayType &res,
-                       std::integral_constant<bool, true>) const
+    process_dofs(const unsigned int * indices,
+                 VectorType &         vec,
+                 const unsigned int   constant_offset,
+                 VectorizedArrayType &res,
+                 std::integral_constant<bool, true>) const
     {
 #if DEAL_II_VECTORIZATION_WIDTH_IN_BITS < 512
       for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
@@ -637,11 +637,11 @@ namespace internal
     // manually append all data
     template <typename VectorType>
     void
-    process_dof_gather(const unsigned int * indices,
-                       VectorType &         vec,
-                       const unsigned int   constant_offset,
-                       VectorizedArrayType &res,
-                       std::integral_constant<bool, false>) const
+    process_dofs(const unsigned int * indices,
+                 VectorType &         vec,
+                 const unsigned int   constant_offset,
+                 VectorizedArrayType &res,
+                 std::integral_constant<bool, false>) const
     {
       for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
         vector_access_add(vec, indices[v] + constant_offset, res[v]);
@@ -807,11 +807,11 @@ namespace internal
 
     template <typename VectorType>
     void
-    process_dof_gather(const unsigned int * indices,
-                       VectorType &         vec,
-                       const unsigned int   constant_offset,
-                       VectorizedArrayType &res,
-                       std::integral_constant<bool, true>) const
+    process_dofs(const unsigned int * indices,
+                 VectorType &         vec,
+                 const unsigned int   constant_offset,
+                 VectorizedArrayType &res,
+                 std::integral_constant<bool, true>) const
     {
       res.scatter(indices, vec.begin() + constant_offset);
     }
@@ -820,11 +820,11 @@ namespace internal
 
     template <typename VectorType>
     void
-    process_dof_gather(const unsigned int * indices,
-                       VectorType &         vec,
-                       const unsigned int   constant_offset,
-                       VectorizedArrayType &res,
-                       std::integral_constant<bool, false>) const
+    process_dofs(const unsigned int * indices,
+                 VectorType &         vec,
+                 const unsigned int   constant_offset,
+                 VectorizedArrayType &res,
+                 std::integral_constant<bool, false>) const
     {
       for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
         vector_access(vec, indices[v] + constant_offset) = res[v];


### PR DESCRIPTION
@kronbichler I would suggest to rename `process_dof_gather()` to make the name independent of the actual operation that is performed (gather/scatter/distribute_local_to_global). I am not sure about the new name and how many of our codes would be affected (and if the pain is worth the change). What do you think?