### PR TITLE
Fix some warnings.

### DIFF
--- a/source/cgal/intersections.cc
+++ b/source/cgal/intersections.cc
@@ -384,7 +384,7 @@ namespace CGALWrappers
             internal::mark_domains(cdt);
             std::array<Point<2>, 3> vertices;
 
-            for (const Face_handle &f : cdt.finite_face_handles())
+            for (const Face_handle f : cdt.finite_face_handles())
               {
                 if (f->info().in_domain() &&
                     CGAL::to_double(cdt.triangle(f).area()) > tol)

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -3661,7 +3661,7 @@ namespace internal
         // be assigned.
         types::global_dof_index n_identity_constrained_indices = 0;
         for (const auto &constrained_indices : all_constrained_indices)
-          for (const auto index : constrained_indices)
+          for (const auto &index : constrained_indices)
             if (renumbering[index.first] != numbers::invalid_dof_index)
               ++n_identity_constrained_indices;
 


### PR DESCRIPTION
According to https://cdash.dealii.43-1.org/viewBuildError.php?type=1&buildid=992

```
[source/dofs/dof_handler_policy.cc:3664](https://github.com/dealii/dealii/blob/master/source/dofs/dof_handler_policy.cc#L3664):27: warning: loop variable ‘index’ creates a copy from type ‘const std::pair<const unsigned int, unsigned int>’ [-Wrange-loop-construct]
[source/dofs/dof_handler_policy.cc:3664](https://github.com/dealii/dealii/blob/master/source/dofs/dof_handler_policy.cc#L3664):27: note: use reference type to prevent copying

[source/cgal/intersections.cc:387](https://github.com/dealii/dealii/blob/master/source/cgal/intersections.cc#L387):37: warning: loop variable ‘f’ of type ‘const dealii::CGALWrappers::Face_handle&’ {aka ‘const CGAL::internal::CC_iterator<CGAL::Compact_container<CGAL::Delaunay_mesh_face_base_2<CGAL::Simple_cartesian<CORE::Expr>, CGAL::Constrained_triangulation_face_base_2<CGAL::Simple_cartesian<CORE::Expr>, CGAL::Triangulation_face_base_with_info_2<dealii::CGALWrappers::FaceInfo2, CGAL::Simple_cartesian<CORE::Expr>, CGAL::Triangulation_face_base_2<CGAL::Simple_cartesian<CORE::Expr>, CGAL::Triangulation_ds_face_base_2<CGAL::Triangulation_data_structure_2<CGAL::Triangulation_vertex_base_2<CGAL::Simple_cartesian<CORE::Expr>, CGAL::Triangulation_ds_vertex_base_2<void> >, CGAL::Delaunay_mesh_face_base_2<CGAL::Simple_cartesian<CORE::Expr>, CGAL::Constrained_triangulation_face_base_2<CGAL::Simple_cartesian<CORE::Expr>, CGAL::Triangulation_face_base_with_info_2<dealii::CGALWrappers::FaceInfo2, CGAL::Simple_cartesian<CORE::Expr> > > > > > > > > >, CGAL::Default, CGAL::Default, CGAL::Default>, false>&’} binds to a temporary constructed from type ‘CGAL::Triangulation_2<CGAL::Simple_cartesian<CORE::Expr>, CGAL::Triangulation_data_structure_2<CGAL::Triangulation_vertex_base_2<CGAL::Simple_cartesian<CORE::Expr>, CGAL::Triangulation_ds_vertex_base_2<void> >, CGAL::Delaunay_mesh_face_base_2<CGAL::Simple_cartesian<CORE::Expr>, CGAL::Constrained_triangulation_face_base_2<CGAL::Simple_cartesian<CORE::Expr>, CGAL::Triangulation_face_base_with_info_2<dealii::CGALWrappers::FaceInfo2, CGAL::Simple_cartesian<CORE::Expr> > > > > >::Finite_faces_iterator’ [-Wrange-loop-construct]
[source/cgal/intersections.cc:387](https://github.com/dealii/dealii/blob/master/source/cgal/intersections.cc#L387):37: note: use non-reference type ‘const dealii::CGALWrappers::Face_handle’ {aka ‘const CGAL::internal::CC_iterator<CGAL::Compact_container<CGAL::Delaunay_mesh_face_base_2<CGAL::Simple_cartesian<CORE::Expr>, CGAL::Constrained_triangulation_face_base_2<CGAL::Simple_cartesian<CORE::Expr>, CGAL::Triangulation_face_base_with_info_2<dealii::CGALWrappers::FaceInfo2, CGAL::Simple_cartesian<CORE::Expr>, CGAL::Triangulation_face_base_2<CGAL::Simple_cartesian<CORE::Expr>, CGAL::Triangulation_ds_face_base_2<CGAL::Triangulation_data_structure_2<CGAL::Triangulation_vertex_base_2<CGAL::Simple_cartesian<CORE::Expr>, CGAL::Triangulation_ds_vertex_base_2<void> >, CGAL::Delaunay_mesh_face_base_2<CGAL::Simple_cartesian<CORE::Expr>, CGAL::Constrained_triangulation_face_base_2<CGAL::Simple_cartesian<CORE::Expr>, CGAL::Triangulation_face_base_with_info_2<dealii::CGALWrappers::FaceInfo2, CGAL::Simple_cartesian<CORE::Expr> > > > > > > > > >, CGAL::Default, CGAL::Default, CGAL::Default>, false>’} to make the copy explicit or ‘const CGAL::Triangulation_2<CGAL::Simple_cartesian<CORE::Expr>, CGAL::Triangulation_data_structure_2<CGAL::Triangulation_vertex_base_2<CGAL::Simple_cartesian<CORE::Expr>, CGAL::Triangulation_ds_vertex_base_2<void> >, CGAL::Delaunay_mesh_face_base_2<CGAL::Simple_cartesian<CORE::Expr>, CGAL::Constrained_triangulation_face_base_2<CGAL::Simple_cartesian<CORE::Expr>, CGAL::Triangulation_face_base_with_info_2<dealii::CGALWrappers::FaceInfo2, CGAL::Simple_cartesian<CORE::Expr> > > > > >::Finite_faces_iterator&’ to prevent copying

```