### PR TITLE
ShapeInfo: Implement evaluation of derivatives on faces

### DIFF
--- a/include/deal.II/matrix_free/shape_info.h
+++ b/include/deal.II/matrix_free/shape_info.h
@@ -247,8 +247,8 @@ namespace internal
 
       /**
        * Collects all data of 1D shape values evaluated at the point 0 and 1
-       * (the vertices) in one data structure. Sorting is first the values,
-       * then gradients, then second derivatives.
+       * (the vertices) in one data structure. The sorting of data is to
+       * start with the values, then gradients, then second derivatives.
        */
       std::array<AlignedVector<Number>, 2> shape_data_on_face;
 
@@ -258,9 +258,8 @@ namespace internal
        * point 0 and 1 (the vertices) in one data structure.
        *
        * This data structure can be used to interpolate from the cell to the
-       * face quadrature points.
-       *
-       * @note In contrast to shape_data_on_face, only the vales are evaluated.
+       * face quadrature points. The sorting of data is to start with the
+       * values, then gradients, then second derivatives.
        */
       std::array<AlignedVector<Number>, 2> quadrature_data_on_face;
 

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -748,8 +748,13 @@ namespace internal
 
           for (unsigned int i = 0; i < quad.size(); ++i)
             {
-              quadrature_data_on_face[0][i] = poly_coll[i].value(0.0);
-              quadrature_data_on_face[1][i] = poly_coll[i].value(1.0);
+              std::array<double, 3> values;
+              poly_coll[i].value(0.0, 2, values.data());
+              for (unsigned int d = 0; d < 3; ++d)
+                quadrature_data_on_face[0][i + d * quad.size()] = values[d];
+              poly_coll[i].value(1.0, 2, values.data());
+              for (unsigned int d = 0; d < 3; ++d)
+                quadrature_data_on_face[1][i + d * quad.size()] = values[d];
             }
         }
 


### PR DESCRIPTION
This commit also fills `quadrature_data_on_face` with derivatives and second derivatives, similarly to `shape_data_on_face`. This is necessary to allow evaluation of face-based loop, as I will use it in my upcoming PR.