### PR TITLE
Correctly handle unpacking empty objects

### DIFF
--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -1289,7 +1289,10 @@ namespace Utilities
       // dereferencing iterators if the std::vector<char> is empty,
       // which would not be allowed.
       if (cbegin == cend)
-        return;
+        {
+          object.clear();
+          return;
+        }
 
       // The size of the object vector can be found in cbegin of the buffer.
       // The data starts at cbegin + sizeof(vector_size).
@@ -1344,7 +1347,10 @@ namespace Utilities
       // dereferencing iterators if the std::vector<char> is empty,
       // which would not be allowed.
       if (cbegin == cend)
-        return;
+        {
+          object.clear();
+          return;
+        }
 
       // First get the size of the vector, and resize the output object
       using size_type = typename std::vector<T>::size_type;
@@ -1490,7 +1496,6 @@ namespace Utilities
     // see if the object is small and copyable via memcpy. if so, use
     // this fast path. otherwise, we have to go through the BOOST
     // serialization machinery
-#ifdef DEAL_II_HAVE_CXX17
     if constexpr (std::is_trivially_copyable<T>() && sizeof(T) < 256)
       {
         // Determine the size. There are places where we would like to use a

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -1285,6 +1285,12 @@ namespace Utilities
       const std::vector<char>::const_iterator &cend,
       std::vector<T>                          &object)
     {
+      // return early if nothing to copy. this avoids
+      // dereferencing iterators if the std::vector<char> is empty,
+      // which would not be allowed.
+      if (cbegin == cend)
+        return;
+
       // The size of the object vector can be found in cbegin of the buffer.
       // The data starts at cbegin + sizeof(vector_size).
 
@@ -1334,6 +1340,12 @@ namespace Utilities
       const std::vector<char>::const_iterator &cend,
       std::vector<std::vector<T>>             &object)
     {
+      // return early if nothing to copy. this avoids
+      // dereferencing iterators if the std::vector<char> is empty,
+      // which would not be allowed.
+      if (cbegin == cend)
+        return;
+
       // First get the size of the vector, and resize the output object
       using size_type = typename std::vector<T>::size_type;
       std::vector<char>::const_iterator iterator = cbegin;
@@ -1468,9 +1480,17 @@ namespace Utilities
          const std::vector<char>::const_iterator &cend,
          const bool                               allow_compression)
   {
+    // See if the object is empty. If so, shortcut the whole
+    // operation and return an empty object. This avoids
+    // dereferencing iterators if the std::vector<char> is empty,
+    // which would not be allowed.
+    if (cbegin == cend)
+      return {};
+
     // see if the object is small and copyable via memcpy. if so, use
     // this fast path. otherwise, we have to go through the BOOST
     // serialization machinery
+#ifdef DEAL_II_HAVE_CXX17
     if constexpr (std::is_trivially_copyable<T>() && sizeof(T) < 256)
       {
         // Determine the size. There are places where we would like to use a
@@ -1537,6 +1557,11 @@ namespace Utilities
   T
   unpack(const std::vector<char> &buffer, const bool allow_compression)
   {
+    // see if the object is empty. if so, shortcut the whole
+    // operation and return an empty object.
+    if (buffer.size() == 0)
+      return {};
+
     return unpack<T>(buffer.cbegin(), buffer.cend(), allow_compression);
   }
 
@@ -1548,6 +1573,15 @@ namespace Utilities
          T (&unpacked_object)[N],
          const bool allow_compression)
   {
+    // empty arrays are not allowed and so unpacking requires to
+    // have a non-zero amount of input data
+    Assert(
+      cbegin != cend,
+      ExcMessage(
+        "Utilities::unpack was asked to unpack "
+        "an array, but no input data to unpack was provided. Empty arrays are "
+        "not allowed."));
+
     // see if the object is small and copyable via memcpy. if so, use
     // this fast path. otherwise, we have to go through the BOOST
     // serialization machinery
@@ -1581,6 +1615,15 @@ namespace Utilities
          T (&unpacked_object)[N],
          const bool allow_compression)
   {
+    // empty arrays are not allowed and so unpacking requires to
+    // have a non-zero amount of input data
+    Assert(
+      buffer.size() != 0,
+      ExcMessage(
+        "Utilities::unpack was asked to unpack "
+        "an array, but no input data to unpack was provided. Empty arrays are "
+        "not allowed."));
+
     unpack<T, N>(buffer.cbegin(),
                  buffer.cend(),
                  unpacked_object,


### PR DESCRIPTION
Still hunting for the solution to geodynamics/aspect#4984, but at least I think this PR should fix a real issue when we try to unpack an empty object. If the packed buffer `std::vector<char>` is empty, we are not allowed to do anything with its iterators, except for checking for equality between `cbegin` and `cend`. So no matter if the object is trivially copyable or not, we should just return an default constructed object of type T (or crash for the version of the unpack function that unpacks an array, because empty arrays are not allowed).
