### PR TITLE
Add reference to dissertation in hp::Refinement namespace.

### DIFF
--- a/include/deal.II/hp/refinement.h
+++ b/include/deal.II/hp/refinement.h
@@ -52,6 +52,9 @@ namespace hp
    * selected dynamically. This namespace collects tools to decide which type
    * of adaptive methods to apply.
    *
+   * @note A formal description of the algorithms provided in this namespace
+   * can be found in @cite fehling2020 . See in particular Section 3.2.
+   *
    * <h3>Usage</h3>
    *
    * To successfully apply hp-adaptive methods, we recommend the following


### PR DESCRIPTION
A description of the algorithms is also part of my dissertation. So I think it is a good idea to also reference it.