### PR TITLE
Fix a warning regarding unused variable

### DIFF
--- a/include/deal.II/lac/trilinos_solver.h
+++ b/include/deal.II/lac/trilinos_solver.h
@@ -766,9 +766,10 @@ namespace TrilinosWrappers
       /**
        * Constructor.
        */
-      AdditionalData(const SolverName &solver_name           = SolverName::cg,
-                     const bool        right_preconditioning = false)
-        : right_preconditioning(right_preconditioning)
+      AdditionalData(const SolverName solver_name           = SolverName::cg,
+                     const bool       right_preconditioning = false)
+        : solver_name(solver_name)
+        , right_preconditioning(right_preconditioning)
       {}
 
       /**


### PR DESCRIPTION
Follow-up to #14352 - we forgot to pass in the chosen option to the struct. Fixes warnings of the kind https://cdash.dealii.43-1.org/viewBuildError.php?type=1&buildid=1346