### PR TITLE
(Dynamic)SparsityPattern: inherit from SparsityPatternBase.

### DIFF
--- a/include/deal.II/lac/dynamic_sparsity_pattern.h
+++ b/include/deal.II/lac/dynamic_sparsity_pattern.h
@@ -24,6 +24,7 @@
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/lac/exceptions.h>
+#include <deal.II/lac/sparsity_pattern_base.h>
 
 #include <algorithm>
 #include <iostream>
@@ -318,7 +319,7 @@ namespace DynamicSparsityPatternIterators
  * sp.copy_from (dynamic_pattern);
  * @endcode
  */
-class DynamicSparsityPattern : public Subscriptor
+class DynamicSparsityPattern : public SparsityPatternBase
 {
 public:
   /**
@@ -439,6 +440,15 @@ public:
               ForwardIterator end,
               const bool      indices_are_unique_and_sorted = false);
 
+  virtual void
+  add_row_entries(const size_type &                 row,
+                  const ArrayView<const size_type> &columns,
+                  const bool indices_are_sorted = false) override;
+
+  virtual void
+  add_entries(const ArrayView<const size_type> &rows,
+              const ArrayView<const size_type> &columns) override;
+
   /**
    * Check if a value at a certain position may be non-zero.
    */
@@ -505,19 +515,6 @@ public:
    */
   void
   print_gnuplot(std::ostream &out) const;
-
-  /**
-   * Return the number of rows, which equals the dimension of the image space.
-   */
-  size_type
-  n_rows() const;
-
-  /**
-   * Return the number of columns, which equals the dimension of the range
-   * space.
-   */
-  size_type
-  n_cols() const;
 
   /**
    * Number of entries in a specific row. This function can only be called if
@@ -674,16 +671,6 @@ private:
    * A flag that stores whether any entries have been added so far.
    */
   bool have_entries;
-
-  /**
-   * Number of rows that this sparsity structure shall represent.
-   */
-  size_type rows;
-
-  /**
-   * Number of columns that this sparsity structure shall represent.
-   */
-  size_type cols;
 
   /**
    * A set that contains the valid rows.
@@ -1014,27 +1001,11 @@ DynamicSparsityPattern::Line::add(const size_type j)
 
 
 
-inline DynamicSparsityPattern::size_type
-DynamicSparsityPattern::n_rows() const
-{
-  return rows;
-}
-
-
-
-inline types::global_dof_index
-DynamicSparsityPattern::n_cols() const
-{
-  return cols;
-}
-
-
-
 inline void
 DynamicSparsityPattern::add(const size_type i, const size_type j)
 {
-  AssertIndexRange(i, rows);
-  AssertIndexRange(j, cols);
+  AssertIndexRange(i, n_rows());
+  AssertIndexRange(j, n_cols());
 
   if (rowset.size() > 0 && !rowset.is_element(i))
     return;

--- a/include/deal.II/lac/sparsity_pattern.h
+++ b/include/deal.II/lac/sparsity_pattern.h
@@ -24,6 +24,8 @@
 #include <deal.II/base/linear_index_iterator.h>
 #include <deal.II/base/subscriptor.h>
 
+#include <deal.II/lac/sparsity_pattern_base.h>
+
 // boost::serialization::make_array used to be in array.hpp, but was
 // moved to a different file in BOOST 1.64
 #include <boost/version.hpp>
@@ -338,7 +340,7 @@ namespace SparsityPatternIterators
  * SparsityPatternIterators::Accessor, like <tt>it->column()</tt> and
  * <tt>it->row()</tt>.
  */
-class SparsityPattern : public Subscriptor
+class SparsityPattern : public SparsityPatternBase
 {
 public:
   /**
@@ -728,6 +730,16 @@ public:
               ForwardIterator end,
               const bool      indices_are_sorted = false);
 
+  virtual void
+  add_row_entries(const size_type &                 row,
+                  const ArrayView<const size_type> &columns,
+                  const bool indices_are_sorted = false) override;
+
+  virtual void
+  add_entries(const ArrayView<const size_type> &rows,
+              const ArrayView<const size_type> &columns) override;
+
+
   /**
    * Make the sparsity pattern symmetric by adding the sparsity pattern of the
    * transpose object.
@@ -760,20 +772,6 @@ public:
    */
   std::size_t
   n_nonzero_elements() const;
-
-  /**
-   * Return number of rows of this matrix, which equals the dimension of the
-   * image space.
-   */
-  size_type
-  n_rows() const;
-
-  /**
-   * Return number of columns of this matrix, which equals the dimension of
-   * the range space.
-   */
-  size_type
-  n_cols() const;
 
   /**
    * Return whether the object is empty. It is empty if no memory is
@@ -1097,16 +1095,6 @@ private:
   size_type max_dim;
 
   /**
-   * Number of rows that this sparsity structure shall represent.
-   */
-  size_type rows;
-
-  /**
-   * Number of columns that this sparsity structure shall represent.
-   */
-  size_type cols;
-
-  /**
    * Size of the actually allocated array #colnums. Here, the same applies as
    * for the #rowstart array, i.e. it may be larger than the actually used
    * part of the array.
@@ -1327,22 +1315,6 @@ SparsityPattern::n_nonzero_elements() const
   else
     // the object is empty or has zero size
     return 0;
-}
-
-
-
-inline SparsityPattern::size_type
-SparsityPattern::n_rows() const
-{
-  return rows;
-}
-
-
-
-inline SparsityPattern::size_type
-SparsityPattern::n_cols() const
-{
-  return cols;
 }
 
 

--- a/include/deal.II/lac/sparsity_pattern_base.h
+++ b/include/deal.II/lac/sparsity_pattern_base.h
@@ -1,0 +1,190 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2022 - 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_sparsity_pattern_base_h
+#define dealii_sparsity_pattern_base_h
+
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/array_view.h>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/subscriptor.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+/**
+ * @addtogroup Sparsity
+ * @{
+ */
+
+/**
+ * Base class for all sparsity patterns, defining a common interface by which
+ * new values can be added.
+ */
+class SparsityPatternBase : public Subscriptor
+{
+public:
+  /**
+   * Declare type for container size.
+   */
+  using size_type = types::global_dof_index;
+
+  /**
+   * Constructor. Sets up an empty (zero-by-zero) sparsity pattern.
+   */
+  SparsityPatternBase();
+
+  /**
+   * Constructor. Sets up a @p rows by @p cols sparsity pattern.
+   */
+  SparsityPatternBase(const size_type rows, const size_type cols);
+
+  /**
+   * Copy constructor.
+   */
+  SparsityPatternBase(const SparsityPatternBase &sparsity_pattern) = default;
+
+  /**
+   * Move constructor.
+   */
+  SparsityPatternBase(SparsityPatternBase &&sparsity_pattern) noexcept =
+    default;
+
+  /**
+   * Assignment operator.
+   */
+  SparsityPatternBase &
+  operator=(const SparsityPatternBase &sparsity_pattern) = default;
+
+  /**
+   * Move assignment operator.
+   */
+  SparsityPatternBase &
+  operator=(SparsityPatternBase &&sparsity_pattern) noexcept = default;
+
+  /**
+   * Return number of rows of this matrix, which equals the dimension of the
+   * image space.
+   */
+  size_type
+  n_rows() const;
+
+  /**
+   * Return number of columns of this matrix, which equals the dimension of
+   * the range space.
+   */
+  size_type
+  n_cols() const;
+
+  /**
+   * Optimized function for adding new entries to a given row.
+   */
+  virtual void
+  add_row_entries(const size_type &                 row,
+                  const ArrayView<const size_type> &columns,
+                  const bool indices_are_sorted = false) = 0;
+
+  /**
+   * General function for adding new entries. By default this function calls
+   * add_row_entries() for each new entry: inheriting classes may want to add a
+   * more optimized implementation.
+   */
+  virtual void
+  add_entries(const ArrayView<const size_type> &rows,
+              const ArrayView<const size_type> &columns);
+
+protected:
+  /**
+   * Internal function for updating the stored size of the sparsity pattern.
+   */
+  virtual void
+  resize(const size_type rows, const size_type cols);
+
+  /**
+   * Number of rows that this sparsity pattern shall represent.
+   */
+  size_type rows;
+
+  /**
+   * Number of columns that this sparsity pattern shall represent.
+   */
+  size_type cols;
+};
+
+/**
+ * @}
+ */
+
+
+/* ---------------------------- Inline functions ---------------------------- */
+
+#ifndef DOXYGEN
+
+inline SparsityPatternBase::SparsityPatternBase()
+  : rows(0)
+  , cols(0)
+{}
+
+
+
+inline SparsityPatternBase::SparsityPatternBase(const size_type rows,
+                                                const size_type cols)
+  : rows(rows)
+  , cols(cols)
+{}
+
+
+
+inline SparsityPatternBase::size_type
+SparsityPatternBase::n_rows() const
+{
+  return rows;
+}
+
+
+
+inline SparsityPatternBase::size_type
+SparsityPatternBase::n_cols() const
+{
+  return cols;
+}
+
+
+
+inline void
+SparsityPatternBase::add_entries(const ArrayView<const size_type> &rows,
+                                 const ArrayView<const size_type> &columns)
+{
+  AssertDimension(rows.size(), columns.size());
+  for (std::size_t i = 0; i < rows.size(); ++i)
+    add_row_entries(rows[i],
+                    make_array_view(columns.begin() + i,
+                                    columns.begin() + i + 1));
+}
+
+
+
+inline void
+SparsityPatternBase::resize(const size_type rows, const size_type cols)
+{
+  this->rows = rows;
+  this->cols = cols;
+}
+#endif
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif


### PR DESCRIPTION
Followup to #14304: we can remove all the instantiations over sparsity pattern types by adding a sufficiently general base class. This PR (1/11) adds that base class and converts SP and DSP to use it.