### PR TITLE
Cleanup BSP

### DIFF
--- a/include/deal.II/lac/block_sparsity_pattern.h
+++ b/include/deal.II/lac/block_sparsity_pattern.h
@@ -350,12 +350,12 @@ protected:
   /**
    * Number of block rows.
    */
-  size_type rows;
+  size_type block_rows;
 
   /**
    * Number of block columns.
    */
-  size_type columns;
+  size_type block_columns;
 
   /**
    * Array of sparsity patterns.
@@ -770,9 +770,9 @@ inline SparsityPatternType &
 BlockSparsityPatternBase<SparsityPatternType>::block(const size_type row,
                                                      const size_type column)
 {
-  AssertIndexRange(row, rows);
-  AssertIndexRange(column, columns);
-  return *sub_objects[row][column];
+  AssertIndexRange(row, n_block_rows());
+  AssertIndexRange(column, n_block_cols());
+  return *sub_objects(row, column);
 }
 
 
@@ -783,9 +783,9 @@ BlockSparsityPatternBase<SparsityPatternType>::block(
   const size_type row,
   const size_type column) const
 {
-  AssertIndexRange(row, rows);
-  AssertIndexRange(column, columns);
-  return *sub_objects[row][column];
+  AssertIndexRange(row, n_block_rows());
+  AssertIndexRange(column, n_block_cols());
+  return *sub_objects(row, column);
 }
 
 
@@ -841,15 +841,15 @@ BlockSparsityPatternBase<SparsityPatternType>::add_entries(
   Assert(n_cols() == compute_n_cols(), ExcNeedsCollectSizes());
 
   // Resize scratch arrays
-  if (block_column_indices.size() < this->n_block_cols())
+  if (block_column_indices.size() < n_block_cols())
     {
-      block_column_indices.resize(this->n_block_cols());
-      counter_within_block.resize(this->n_block_cols());
+      block_column_indices.resize(n_block_cols());
+      counter_within_block.resize(n_block_cols());
     }
 
-  const size_type n_cols = static_cast<size_type>(end - begin);
+  const size_type n_added_cols = static_cast<size_type>(end - begin);
 
-  // Resize sub-arrays to n_cols. This
+  // Resize sub-arrays to n_added_cols. This
   // is a bit wasteful, but we resize
   // only a few times (then the maximum
   // row length won't increase that
@@ -859,9 +859,9 @@ BlockSparsityPatternBase<SparsityPatternType>::add_entries(
   // whether the size of one is large
   // enough before actually going
   // through all of them.
-  if (block_column_indices[0].size() < n_cols)
+  if (block_column_indices[0].size() < n_added_cols)
     for (size_type i = 0; i < this->n_block_cols(); ++i)
-      block_column_indices[i].resize(n_cols);
+      block_column_indices[i].resize(n_added_cols);
 
   // Reset the number of added elements
   // in each block to zero.
@@ -893,9 +893,9 @@ BlockSparsityPatternBase<SparsityPatternType>::add_entries(
   // If in debug mode, do a check whether
   // the right length has been obtained.
   size_type length = 0;
-  for (size_type i = 0; i < this->n_block_cols(); ++i)
+  for (size_type i = 0; i < n_block_cols(); ++i)
     length += counter_within_block[i];
-  Assert(length == n_cols, ExcInternalError());
+  Assert(length == n_added_cols, ExcInternalError());
 #endif
 
   // Now we found out about where the
@@ -948,7 +948,7 @@ BlockSparsityPatternBase<SparsityPatternType>::row_length(
 
   unsigned int c = 0;
 
-  for (size_type b = 0; b < rows; ++b)
+  for (size_type b = 0; b < n_block_rows(); ++b)
     c += sub_objects[row_index.first][b]->row_length(row_index.second);
 
   return c;
@@ -960,7 +960,7 @@ template <typename SparsityPatternType>
 inline typename BlockSparsityPatternBase<SparsityPatternType>::size_type
 BlockSparsityPatternBase<SparsityPatternType>::n_block_cols() const
 {
-  return columns;
+  return block_columns;
 }
 
 
@@ -969,7 +969,7 @@ template <typename SparsityPatternType>
 inline typename BlockSparsityPatternBase<SparsityPatternType>::size_type
 BlockSparsityPatternBase<SparsityPatternType>::n_block_rows() const
 {
-  return rows;
+  return block_rows;
 }
 
 
@@ -985,7 +985,7 @@ BlockDynamicSparsityPattern::column_number(const size_type    row,
 
   size_type c             = 0;
   size_type block_columns = 0; // sum of n_cols for all blocks to the left
-  for (unsigned int b = 0; b < columns; ++b)
+  for (unsigned int b = 0; b < this->n_block_cols(); ++b)
     {
       unsigned int rowlen =
         sub_objects[row_index.first][b]->row_length(row_index.second);
@@ -1003,11 +1003,11 @@ BlockDynamicSparsityPattern::column_number(const size_type    row,
 
 
 inline void
-BlockSparsityPattern::reinit(const size_type n_block_rows,
-                             const size_type n_block_columns)
+BlockSparsityPattern::reinit(const size_type new_block_rows,
+                             const size_type new_block_columns)
 {
-  BlockSparsityPatternBase<SparsityPattern>::reinit(n_block_rows,
-                                                    n_block_columns);
+  BlockSparsityPatternBase<SparsityPattern>::reinit(new_block_rows,
+                                                    new_block_columns);
 }
 
 

--- a/include/deal.II/lac/block_sparsity_pattern.h
+++ b/include/deal.II/lac/block_sparsity_pattern.h
@@ -118,11 +118,6 @@ public:
   BlockSparsityPatternBase(const BlockSparsityPatternBase &bsp);
 
   /**
-   * Destructor.
-   */
-  ~BlockSparsityPatternBase() override;
-
-  /**
    * Resize the matrix, by setting the number of block rows and columns. This
    * deletes all blocks and replaces them with uninitialized ones, i.e. ones
    * for which also the sizes are not yet set. You have to do that by calling
@@ -160,7 +155,6 @@ public:
    */
   SparsityPatternType &
   block(const size_type row, const size_type column);
-
 
   /**
    * Access the block with the given coordinates. Version for constant
@@ -357,10 +351,7 @@ protected:
   /**
    * Array of sparsity patterns.
    */
-  Table<2,
-        SmartPointer<SparsityPatternType,
-                     BlockSparsityPatternBase<SparsityPatternType>>>
-    sub_objects;
+  Table<2, std::unique_ptr<SparsityPatternType>> sub_objects;
 
   /**
    * Object storing and managing the transformation of row indices to indices

--- a/include/deal.II/lac/block_sparsity_pattern.h
+++ b/include/deal.II/lac/block_sparsity_pattern.h
@@ -311,6 +311,13 @@ public:
   print_svg(std::ostream &out) const;
 
   /**
+   * Determine an estimate for the memory consumption (in bytes) of this
+   * object.
+   */
+  std::size_t
+  memory_consumption() const;
+
+  /**
    * @addtogroup Exceptions
    * @{
    */
@@ -463,13 +470,6 @@ public:
    */
   bool
   is_compressed() const;
-
-  /**
-   * Determine an estimate for the memory consumption (in bytes) of this
-   * object.
-   */
-  std::size_t
-  memory_consumption() const;
 
   /**
    * Copy data from an object of type BlockDynamicSparsityPattern, i.e. resize

--- a/include/deal.II/lac/block_sparsity_pattern.h
+++ b/include/deal.II/lac/block_sparsity_pattern.h
@@ -318,6 +318,15 @@ public:
   /**
    * Exception
    */
+  DeclExceptionMsg(
+    ExcNeedsCollectSizes,
+    "The number of rows and columns (returned by n_rows() and n_cols()) does "
+    "not match their directly computed values. This typically means that a "
+    "call to collect_sizes() is missing.");
+
+  /**
+   * Exception
+   */
   DeclException4(ExcIncompatibleRowNumbers,
                  int,
                  int,
@@ -366,6 +375,18 @@ protected:
   BlockIndices column_indices;
 
 private:
+  /**
+   * Internal utility function for computing the number of rows.
+   */
+  size_type
+  compute_n_rows() const;
+
+  /**
+   * Internal utility function for computing the number of columns.
+   */
+  size_type
+  compute_n_cols() const;
+
   /**
    * Temporary vector for counting the elements written into the individual
    * blocks when doing a collective add or set.
@@ -814,6 +835,11 @@ BlockSparsityPatternBase<SparsityPatternType>::add_entries(
   ForwardIterator end,
   const bool      indices_are_sorted)
 {
+  // In debug mode, verify that collect_sizes() was called by redoing the
+  // calculation
+  Assert(n_rows() == compute_n_rows(), ExcNeedsCollectSizes());
+  Assert(n_cols() == compute_n_cols(), ExcNeedsCollectSizes());
+
   // Resize scratch arrays
   if (block_column_indices.size() < this->n_block_cols())
     {

--- a/source/lac/block_sparsity_pattern.cc
+++ b/source/lac/block_sparsity_pattern.cc
@@ -93,6 +93,34 @@ BlockSparsityPatternBase<SparsityPatternType>::operator=(
 
 
 template <class SparsityPatternType>
+typename BlockSparsityPatternBase<SparsityPatternType>::size_type
+BlockSparsityPatternBase<SparsityPatternType>::compute_n_rows() const
+{
+  // only count in first column, since
+  // all rows should be equivalent
+  size_type count = 0;
+  for (size_type r = 0; r < rows; ++r)
+    count += sub_objects[r][0]->n_rows();
+  return count;
+}
+
+
+
+template <class SparsityPatternType>
+typename BlockSparsityPatternBase<SparsityPatternType>::size_type
+BlockSparsityPatternBase<SparsityPatternType>::compute_n_cols() const
+{
+  // only count in first row, since
+  // all rows should be equivalent
+  size_type count = 0;
+  for (size_type c = 0; c < columns; ++c)
+    count += sub_objects[0][c]->n_cols();
+  return count;
+}
+
+
+
+template <class SparsityPatternType>
 void
 BlockSparsityPatternBase<SparsityPatternType>::collect_sizes()
 {
@@ -178,12 +206,9 @@ template <class SparsityPatternType>
 typename BlockSparsityPatternBase<SparsityPatternType>::size_type
 BlockSparsityPatternBase<SparsityPatternType>::n_rows() const
 {
-  // only count in first column, since
-  // all rows should be equivalent
-  size_type count = 0;
-  for (size_type r = 0; r < rows; ++r)
-    count += sub_objects[r][0]->n_rows();
-  return count;
+  // While trivial for the moment, this will be replaced by a base class
+  // function in a future patch
+  return compute_n_rows();
 }
 
 
@@ -192,12 +217,9 @@ template <class SparsityPatternType>
 typename BlockSparsityPatternBase<SparsityPatternType>::size_type
 BlockSparsityPatternBase<SparsityPatternType>::n_cols() const
 {
-  // only count in first row, since
-  // all rows should be equivalent
-  size_type count = 0;
-  for (size_type c = 0; c < columns; ++c)
-    count += sub_objects[0][c]->n_cols();
-  return count;
+  // While trivial for the moment, this will be replaced by a base class
+  // function in a future patch
+  return compute_n_cols();
 }
 
 

--- a/source/lac/block_sparsity_pattern.cc
+++ b/source/lac/block_sparsity_pattern.cc
@@ -33,8 +33,7 @@ template <class SparsityPatternType>
 BlockSparsityPatternBase<SparsityPatternType>::BlockSparsityPatternBase(
   const size_type n_block_rows,
   const size_type n_block_columns)
-  : rows(0)
-  , columns(0)
+  : BlockSparsityPatternBase()
 {
   reinit(n_block_rows, n_block_columns);
 }
@@ -44,9 +43,7 @@ BlockSparsityPatternBase<SparsityPatternType>::BlockSparsityPatternBase(
 template <class SparsityPatternType>
 BlockSparsityPatternBase<SparsityPatternType>::BlockSparsityPatternBase(
   const BlockSparsityPatternBase &s)
-  : Subscriptor()
-  , rows(0)
-  , columns(0)
+  : BlockSparsityPatternBase()
 {
   (void)s;
   Assert(s.rows == 0 && s.columns == 0,
@@ -59,49 +56,20 @@ BlockSparsityPatternBase<SparsityPatternType>::BlockSparsityPatternBase(
 
 
 template <class SparsityPatternType>
-BlockSparsityPatternBase<SparsityPatternType>::~BlockSparsityPatternBase()
-{
-  // clear all memory
-  try
-    {
-      reinit(0, 0);
-    }
-  catch (...)
-    {}
-}
-
-
-
-template <class SparsityPatternType>
 void
 BlockSparsityPatternBase<SparsityPatternType>::reinit(
   const size_type n_block_rows,
   const size_type n_block_columns)
 {
-  // delete previous content and
-  // clean the sub_objects array
-  // completely
-  for (size_type i = 0; i < rows; ++i)
-    for (size_type j = 0; j < columns; ++j)
-      {
-        SparsityPatternType *sp = sub_objects[i][j];
-        sub_objects[i][j]       = nullptr;
-        delete sp;
-      }
   sub_objects.reinit(0, 0);
 
-  // then set new sizes
   rows    = n_block_rows;
   columns = n_block_columns;
-  sub_objects.reinit(rows, columns);
 
-  // allocate new objects
+  sub_objects.reinit(rows, columns);
   for (size_type i = 0; i < rows; ++i)
     for (size_type j = 0; j < columns; ++j)
-      {
-        SparsityPatternType *p = new SparsityPatternType;
-        sub_objects[i][j]      = p;
-      }
+      sub_objects[i][j] = std::make_unique<SparsityPatternType>();
 }
 
 

--- a/source/lac/block_sparsity_pattern.cc
+++ b/source/lac/block_sparsity_pattern.cc
@@ -362,6 +362,25 @@ BlockSparsityPatternBase<SparsityPatternType>::print_svg(
 
 
 
+template <class SparsityPatternType>
+std::size_t
+BlockSparsityPatternBase<SparsityPatternType>::memory_consumption() const
+{
+  std::size_t mem = 0;
+  mem += (MemoryConsumption::memory_consumption(n_block_rows()) +
+          MemoryConsumption::memory_consumption(n_block_cols()) +
+          MemoryConsumption::memory_consumption(sub_objects) +
+          MemoryConsumption::memory_consumption(row_indices) +
+          MemoryConsumption::memory_consumption(column_indices));
+  for (size_type r = 0; r < n_block_rows(); ++r)
+    for (size_type c = 0; c < n_block_cols(); ++c)
+      mem += MemoryConsumption::memory_consumption(*sub_objects[r][c]);
+
+  return mem;
+}
+
+
+
 BlockSparsityPattern::BlockSparsityPattern(const size_type n_rows,
                                            const size_type n_columns)
   : BlockSparsityPatternBase<SparsityPattern>(n_rows, n_columns)
@@ -414,23 +433,6 @@ BlockSparsityPattern::is_compressed() const
       if (sub_objects[i][j]->is_compressed() == false)
         return false;
   return true;
-}
-
-
-std::size_t
-BlockSparsityPattern::memory_consumption() const
-{
-  std::size_t mem = 0;
-  mem += (MemoryConsumption::memory_consumption(n_block_rows()) +
-          MemoryConsumption::memory_consumption(n_block_cols()) +
-          MemoryConsumption::memory_consumption(sub_objects) +
-          MemoryConsumption::memory_consumption(row_indices) +
-          MemoryConsumption::memory_consumption(column_indices));
-  for (size_type r = 0; r < n_block_rows(); ++r)
-    for (size_type c = 0; c < n_block_cols(); ++c)
-      mem += MemoryConsumption::memory_consumption(*sub_objects[r][c]);
-
-  return mem;
 }
 
 

--- a/source/lac/block_sparsity_pattern.cc
+++ b/source/lac/block_sparsity_pattern.cc
@@ -23,19 +23,19 @@ DEAL_II_NAMESPACE_OPEN
 
 template <class SparsityPatternType>
 BlockSparsityPatternBase<SparsityPatternType>::BlockSparsityPatternBase()
-  : rows(0)
-  , columns(0)
+  : block_rows(0)
+  , block_columns(0)
 {}
 
 
 
 template <class SparsityPatternType>
 BlockSparsityPatternBase<SparsityPatternType>::BlockSparsityPatternBase(
-  const size_type n_block_rows,
-  const size_type n_block_columns)
+  const size_type block_rows,
+  const size_type block_columns)
   : BlockSparsityPatternBase()
 {
-  reinit(n_block_rows, n_block_columns);
+  reinit(block_rows, block_columns);
 }
 
 
@@ -46,7 +46,7 @@ BlockSparsityPatternBase<SparsityPatternType>::BlockSparsityPatternBase(
   : BlockSparsityPatternBase()
 {
   (void)s;
-  Assert(s.rows == 0 && s.columns == 0,
+  Assert(s.n_block_rows() == 0 && s.n_block_cols() == 0,
          ExcMessage(
            "This constructor can only be called if the provided argument "
            "is the sparsity pattern for an empty matrix. This constructor can "
@@ -58,17 +58,17 @@ BlockSparsityPatternBase<SparsityPatternType>::BlockSparsityPatternBase(
 template <class SparsityPatternType>
 void
 BlockSparsityPatternBase<SparsityPatternType>::reinit(
-  const size_type n_block_rows,
-  const size_type n_block_columns)
+  const size_type new_block_rows,
+  const size_type new_block_columns)
 {
   sub_objects.reinit(0, 0);
 
-  rows    = n_block_rows;
-  columns = n_block_columns;
+  block_rows    = new_block_rows;
+  block_columns = new_block_columns;
 
-  sub_objects.reinit(rows, columns);
-  for (size_type i = 0; i < rows; ++i)
-    for (size_type j = 0; j < columns; ++j)
+  sub_objects.reinit(block_rows, block_columns);
+  for (size_type i = 0; i < n_block_rows(); ++i)
+    for (size_type j = 0; j < n_block_cols(); ++j)
       sub_objects[i][j] = std::make_unique<SparsityPatternType>();
 }
 
@@ -78,11 +78,11 @@ BlockSparsityPatternBase<SparsityPatternType> &
 BlockSparsityPatternBase<SparsityPatternType>::operator=(
   const BlockSparsityPatternBase<SparsityPatternType> &bsp)
 {
-  Assert(rows == bsp.rows, ExcDimensionMismatch(rows, bsp.rows));
-  Assert(columns == bsp.columns, ExcDimensionMismatch(columns, bsp.columns));
+  AssertDimension(n_block_rows(), bsp.n_block_rows());
+  AssertDimension(n_block_cols(), bsp.n_block_cols());
   // copy objects
-  for (size_type i = 0; i < rows; ++i)
-    for (size_type j = 0; j < columns; ++j)
+  for (size_type i = 0; i < n_block_rows(); ++i)
+    for (size_type j = 0; j < n_block_cols(); ++j)
       *sub_objects[i][j] = *bsp.sub_objects[i][j];
   // update index objects
   collect_sizes();
@@ -99,7 +99,7 @@ BlockSparsityPatternBase<SparsityPatternType>::compute_n_rows() const
   // only count in first column, since
   // all rows should be equivalent
   size_type count = 0;
-  for (size_type r = 0; r < rows; ++r)
+  for (size_type r = 0; r < n_block_rows(); ++r)
     count += sub_objects[r][0]->n_rows();
   return count;
 }
@@ -113,7 +113,7 @@ BlockSparsityPatternBase<SparsityPatternType>::compute_n_cols() const
   // only count in first row, since
   // all rows should be equivalent
   size_type count = 0;
-  for (size_type c = 0; c < columns; ++c)
+  for (size_type c = 0; c < n_block_cols(); ++c)
     count += sub_objects[0][c]->n_cols();
   return count;
 }
@@ -124,18 +124,18 @@ template <class SparsityPatternType>
 void
 BlockSparsityPatternBase<SparsityPatternType>::collect_sizes()
 {
-  std::vector<size_type> row_sizes(rows);
-  std::vector<size_type> col_sizes(columns);
+  std::vector<size_type> row_sizes(n_block_rows());
+  std::vector<size_type> col_sizes(n_block_cols());
 
   // first find out the row sizes
   // from the first block column
-  for (size_type r = 0; r < rows; ++r)
+  for (size_type r = 0; r < n_block_rows(); ++r)
     row_sizes[r] = sub_objects[r][0]->n_rows();
   // then check that the following
   // block columns have the same
   // sizes
-  for (size_type c = 1; c < columns; ++c)
-    for (size_type r = 0; r < rows; ++r)
+  for (size_type c = 1; c < n_block_cols(); ++c)
+    for (size_type r = 0; r < n_block_rows(); ++r)
       Assert(row_sizes[r] == sub_objects[r][c]->n_rows(),
              ExcIncompatibleRowNumbers(r, 0, r, c));
 
@@ -145,10 +145,10 @@ BlockSparsityPatternBase<SparsityPatternType>::collect_sizes()
 
 
   // then do the same with the columns
-  for (size_type c = 0; c < columns; ++c)
+  for (size_type c = 0; c < n_block_cols(); ++c)
     col_sizes[c] = sub_objects[0][c]->n_cols();
-  for (size_type r = 1; r < rows; ++r)
-    for (size_type c = 0; c < columns; ++c)
+  for (size_type r = 1; r < n_block_rows(); ++r)
+    for (size_type c = 0; c < n_block_cols(); ++c)
       Assert(col_sizes[c] == sub_objects[r][c]->n_cols(),
              ExcIncompatibleRowNumbers(0, c, r, c));
 
@@ -163,8 +163,8 @@ template <class SparsityPatternType>
 void
 BlockSparsityPatternBase<SparsityPatternType>::compress()
 {
-  for (size_type i = 0; i < rows; ++i)
-    for (size_type j = 0; j < columns; ++j)
+  for (size_type i = 0; i < n_block_rows(); ++i)
+    for (size_type j = 0; j < n_block_cols(); ++j)
       sub_objects[i][j]->compress();
 }
 
@@ -174,8 +174,8 @@ template <class SparsityPatternType>
 bool
 BlockSparsityPatternBase<SparsityPatternType>::empty() const
 {
-  for (size_type i = 0; i < rows; ++i)
-    for (size_type j = 0; j < columns; ++j)
+  for (size_type i = 0; i < n_block_rows(); ++i)
+    for (size_type j = 0; j < n_block_cols(); ++j)
       if (sub_objects[i][j]->empty() == false)
         return false;
   return true;
@@ -188,10 +188,10 @@ typename BlockSparsityPatternBase<SparsityPatternType>::size_type
 BlockSparsityPatternBase<SparsityPatternType>::max_entries_per_row() const
 {
   size_type max_entries = 0;
-  for (size_type block_row = 0; block_row < rows; ++block_row)
+  for (size_type block_row = 0; block_row < n_block_rows(); ++block_row)
     {
       size_type this_row = 0;
-      for (size_type c = 0; c < columns; ++c)
+      for (size_type c = 0; c < n_block_cols(); ++c)
         this_row += sub_objects[block_row][c]->max_entries_per_row();
 
       if (this_row > max_entries)
@@ -229,8 +229,8 @@ typename BlockSparsityPatternBase<SparsityPatternType>::size_type
 BlockSparsityPatternBase<SparsityPatternType>::n_nonzero_elements() const
 {
   size_type count = 0;
-  for (size_type i = 0; i < rows; ++i)
-    for (size_type j = 0; j < columns; ++j)
+  for (size_type i = 0; i < n_block_rows(); ++i)
+    for (size_type j = 0; j < n_block_cols(); ++j)
       count += sub_objects[i][j]->n_nonzero_elements();
   return count;
 }
@@ -347,7 +347,7 @@ BlockSparsityPatternBase<SparsityPatternType>::print_svg(
     << "\" fill=\"rgb(255, 255, 255)\"/>\n\n";
 
   for (unsigned int block_i = 0; block_i < n_block_rows(); ++block_i)
-    for (unsigned int block_j = 0; block_j < n_block_rows(); ++block_j)
+    for (unsigned int block_j = 0; block_j < n_block_cols(); ++block_j)
       for (const auto &entry : block(block_i, block_j))
         {
           out << "  <rect class=\"pixel\" x=\""
@@ -409,8 +409,8 @@ BlockSparsityPattern::reinit(
 bool
 BlockSparsityPattern::is_compressed() const
 {
-  for (size_type i = 0; i < rows; ++i)
-    for (size_type j = 0; j < columns; ++j)
+  for (size_type i = 0; i < n_block_rows(); ++i)
+    for (size_type j = 0; j < n_block_cols(); ++j)
       if (sub_objects[i][j]->is_compressed() == false)
         return false;
   return true;
@@ -421,13 +421,13 @@ std::size_t
 BlockSparsityPattern::memory_consumption() const
 {
   std::size_t mem = 0;
-  mem += (MemoryConsumption::memory_consumption(rows) +
-          MemoryConsumption::memory_consumption(columns) +
+  mem += (MemoryConsumption::memory_consumption(n_block_rows()) +
+          MemoryConsumption::memory_consumption(n_block_cols()) +
           MemoryConsumption::memory_consumption(sub_objects) +
           MemoryConsumption::memory_consumption(row_indices) +
           MemoryConsumption::memory_consumption(column_indices));
-  for (size_type r = 0; r < rows; ++r)
-    for (size_type c = 0; c < columns; ++c)
+  for (size_type r = 0; r < n_block_rows(); ++r)
+    for (size_type c = 0; c < n_block_cols(); ++c)
       mem += MemoryConsumption::memory_consumption(*sub_objects[r][c]);
 
   return mem;


### PR DESCRIPTION
Second (2/11) followup to #14304. This PR cleans up BSP so that it can be set up to inherit from `SparsityPatternBase` in a followup PR (see also #14396).