### PR TITLE
Add an assertion.

### DIFF
--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -1143,6 +1143,7 @@ namespace
           }
         else
           {
+            Assert(patch.n_subdivisions == 1, ExcNotImplemented());
             n_nodes += patch.data.n_cols();
             n_cells += 1;
             n_points_and_n_cells += patch.data.n_cols() + 1;


### PR DESCRIPTION
The lines following where I add the assertion are only valid for the case where a cell is not further subdivided (i.e., `build_patches()` has not been instructed to subdivide the cell). 

Part of #14403.

/rebuild