### PR TITLE
CMake: add a compile_test_executables target

### DIFF
--- a/cmake/macros/macro_deal_ii_add_test.cmake
+++ b/cmake/macros/macro_deal_ii_add_test.cmake
@@ -105,6 +105,10 @@
 
 FUNCTION(DEAL_II_ADD_TEST _category _test_name _comparison_file)
 
+  IF(NOT TARGET compile_test_executables)
+    ADD_CUSTOM_TARGET(compile_test_executables)
+  ENDIF()
+
   IF(NOT DEAL_II_PROJECT_CONFIG_INCLUDED)
     MESSAGE(FATAL_ERROR
       "\nDEAL_II_ADD_TEST can only be called in external (test sub-) projects after "
@@ -413,6 +417,8 @@ FUNCTION(DEAL_II_ADD_TEST _category _test_name _comparison_file)
           ${_source_file}
           ${CMAKE_CURRENT_BINARY_DIR}/${_target_short}/interrupt_guard.cc
           )
+
+        ADD_DEPENDENCIES(compile_test_executables ${_target})
 
         SET_TARGET_PROPERTIES(${_target} PROPERTIES OUTPUT_NAME ${_target_short})
 

--- a/doc/news/changes/minor/20221111Maier
+++ b/doc/news/changes/minor/20221111Maier
@@ -1,0 +1,11 @@
+Workaround: The testsuite CMake macros now generate a top-level target
+compile_test_executables in user projects that can be used to force the
+compilation of all test executables. This works around an issue with the
+ninja build system that concurrent invocation of tests
+(via <code>ctest -jN</code>) that build executables will fail when calling
+back into cmake. As a workaround it is now possible to first build all
+executables first via <code>ninja compile_test_executables</code> and then
+run tests in parallel with <code>ctest -jN</code>.
+<br>
+(Matthias Maier, 2022/11/11)
+


### PR DESCRIPTION
This pull-request adds a top-level compile_test_executables and modifies
the ADD_TEST() macro to let it depend on all executables generated by our
DEAL_II_PICKUP_TESTS() mechanism.

This is mainly intended for user projects and works around the issue that
simultaneous calls to ninja are not reentrant, meaning when configuring a
user project with ninja one is otherwise limited to run tests in serial.

As a workaround it is now possible to first build all executables first via
`ninja compile_test_executables` and then run tests in parallel with `ctest
-jN`.