### PR TITLE
De template AffineConstraints::add_entries_local_to_global()

### DIFF
--- a/cmake/config/template-arguments.in
+++ b/cmake/config/template-arguments.in
@@ -248,16 +248,6 @@ SPARSITY_PATTERNS := { SparsityPattern;
                        BlockDynamicSparsityPattern;
                        @DEAL_II_EXPAND_TRILINOS_BLOCK_SPARSITY_PATTERN@; }
 
-// Special lists for AffineConstraints:
-AFFINE_CONSTRAINTS_SP := { SparsityPattern;
-                           DynamicSparsityPattern;
-                           @DEAL_II_EXPAND_TRILINOS_SPARSITY_PATTERN@;
-                         }
-AFFINE_CONSTRAINTS_SP_BLOCK := { BlockSparsityPattern;
-                                 BlockDynamicSparsityPattern;
-                                 @DEAL_II_EXPAND_TRILINOS_BLOCK_SPARSITY_PATTERN@;
-                               }
-
 // all supported logical dimensions
 DIMENSIONS := { 1; 2; 3 }
 

--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -1533,12 +1533,11 @@ public:
   /**
    * Similar to the other function, but for non-quadratic sparsity patterns.
    */
-  template <typename SparsityPatternType>
   void
   add_entries_local_to_global(
     const std::vector<size_type> &row_indices,
     const std::vector<size_type> &col_indices,
-    SparsityPatternType &         sparsity_pattern,
+    SparsityPatternBase &         sparsity_pattern,
     const bool                    keep_constrained_entries = true,
     const Table<2, bool> &        dof_mask = Table<2, bool>()) const;
 
@@ -1546,13 +1545,12 @@ public:
    * Similar to the other function, but for non-quadratic sparsity patterns, and
    * for different constraints in the column space.
    */
-  template <typename SparsityPatternType>
   void
   add_entries_local_to_global(
     const std::vector<size_type> &   row_indices,
     const AffineConstraints<number> &col_constraints,
     const std::vector<size_type> &   col_indices,
-    SparsityPatternType &            sparsity_pattern,
+    SparsityPatternBase &            sparsity_pattern,
     const bool                       keep_constrained_entries = true,
     const Table<2, bool> &           dof_mask = Table<2, bool>()) const;
 

--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -358,6 +358,11 @@ namespace internal
       bool in_use;
 
       /**
+       * Temporary array for row indices
+       */
+      std::vector<size_type> rows;
+
+      /**
        * Temporary array for column indices
        */
       std::vector<size_type> columns;

--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -25,6 +25,7 @@
 #include <deal.II/base/template_constraints.h>
 #include <deal.II/base/thread_local_storage.h>
 
+#include <deal.II/lac/sparsity_pattern_base.h>
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/vector_element_access.h>
 
@@ -1522,11 +1523,10 @@ public:
    * caller's site. There is no locking mechanism inside this method to
    * prevent data races.
    */
-  template <typename SparsityPatternType>
   void
   add_entries_local_to_global(
     const std::vector<size_type> &local_dof_indices,
-    SparsityPatternType &         sparsity_pattern,
+    SparsityPatternBase &         sparsity_pattern,
     const bool                    keep_constrained_entries = true,
     const Table<2, bool> &        dof_mask = Table<2, bool>()) const;
 

--- a/source/lac/affine_constraints.inst.in
+++ b/source/lac/affine_constraints.inst.in
@@ -261,12 +261,6 @@ for (S : REAL_AND_COMPLEX_SCALARS; SP : AFFINE_CONSTRAINTS_SP)
   {
     template void AffineConstraints<S>::add_entries_local_to_global<SP>(
       const std::vector<AffineConstraints<S>::size_type> &,
-      SP &,
-      const bool,
-      const Table<2, bool> &) const;
-
-    template void AffineConstraints<S>::add_entries_local_to_global<SP>(
-      const std::vector<AffineConstraints<S>::size_type> &,
       const std::vector<AffineConstraints<S>::size_type> &,
       SP &,
       const bool,
@@ -283,12 +277,6 @@ for (S : REAL_AND_COMPLEX_SCALARS; SP : AFFINE_CONSTRAINTS_SP)
 
 for (S : REAL_AND_COMPLEX_SCALARS; SP : AFFINE_CONSTRAINTS_SP_BLOCK)
   {
-    template void AffineConstraints<S>::add_entries_local_to_global<SP>(
-      const std::vector<AffineConstraints<S>::size_type> &,
-      SP &,
-      const bool,
-      const Table<2, bool> &) const;
-
     template void AffineConstraints<S>::add_entries_local_to_global<SP>(
       const std::vector<AffineConstraints<S>::size_type> &,
       const std::vector<AffineConstraints<S>::size_type> &,

--- a/source/lac/affine_constraints.inst.in
+++ b/source/lac/affine_constraints.inst.in
@@ -252,50 +252,6 @@ for (S : REAL_AND_COMPLEX_SCALARS)
 
 // ---------------------------------------------------------------------
 //
-// Instantiate AffineConstraints<S>::add_entries_local_to_global variants
-//
-// ---------------------------------------------------------------------
-
-
-for (S : REAL_AND_COMPLEX_SCALARS; SP : AFFINE_CONSTRAINTS_SP)
-  {
-    template void AffineConstraints<S>::add_entries_local_to_global<SP>(
-      const std::vector<AffineConstraints<S>::size_type> &,
-      const std::vector<AffineConstraints<S>::size_type> &,
-      SP &,
-      const bool,
-      const Table<2, bool> &) const;
-
-    template void AffineConstraints<S>::add_entries_local_to_global<SP>(
-      const std::vector<AffineConstraints<S>::size_type> &,
-      const AffineConstraints<S> &,
-      const std::vector<AffineConstraints<S>::size_type> &,
-      SP &,
-      const bool,
-      const Table<2, bool> &) const;
-  }
-
-for (S : REAL_AND_COMPLEX_SCALARS; SP : AFFINE_CONSTRAINTS_SP_BLOCK)
-  {
-    template void AffineConstraints<S>::add_entries_local_to_global<SP>(
-      const std::vector<AffineConstraints<S>::size_type> &,
-      const std::vector<AffineConstraints<S>::size_type> &,
-      SP &,
-      const bool,
-      const Table<2, bool> &) const;
-
-    template void AffineConstraints<S>::add_entries_local_to_global<SP>(
-      const std::vector<AffineConstraints<S>::size_type> &,
-      const AffineConstraints<S> &,
-      const std::vector<AffineConstraints<S>::size_type> &,
-      SP &,
-      const bool,
-      const Table<2, bool> &) const;
-  }
-
-
-// ---------------------------------------------------------------------
-//
 // Rest:
 //
 // ---------------------------------------------------------------------


### PR DESCRIPTION
Another followup to #14396: part 6/11. I introduced the base class so that we could make this change - the next step is to get rid of the templates over the sparsity pattern type in the calling functions.

I reran the same benchmark for block sparsity patterns and I now see
```
merge + affineconstraints:
2D: 2429, 2439, 2386
3D: 6002, 6009, 5995
```

which is actually faster than the previous patches, perhaps because `add()` gets inlined into `add_entries()` - I didn't check closely. 
There is definitely some room for further optimization in these functions if we want to do it - I more-or-less just replaced calls to `add()` with the new `add_entries()` function.