### PR TITLE
Further refactoring in data_out_base.cc

### DIFF
--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -3441,7 +3441,7 @@ namespace DataOutBase
     // first count the number of cells and cells for later use
     unsigned int n_nodes;
     unsigned int n_cells;
-    std::tie(n_nodes, n_cells) = count_nodes_and_cells<dim, spacedim>(patches);
+    std::tie(n_nodes, n_cells) = count_nodes_and_cells(patches);
     //---------------------
     // preamble
     if (flags.write_preamble)
@@ -3534,7 +3534,7 @@ namespace DataOutBase
     // first count the number of cells and cells for later use
     unsigned int n_nodes;
     unsigned int n_cells;
-    std::tie(n_nodes, n_cells) = count_nodes_and_cells<dim, spacedim>(patches);
+    std::tie(n_nodes, n_cells) = count_nodes_and_cells(patches);
 
     // start with vertices order is lexicographical, x varying fastest
     out << "object \"vertices\" class array type float rank 1 shape "
@@ -4923,7 +4923,7 @@ namespace DataOutBase
     // first count the number of cells and cells for later use
     unsigned int n_nodes;
     unsigned int n_cells;
-    std::tie(n_nodes, n_cells) = count_nodes_and_cells<dim, spacedim>(patches);
+    std::tie(n_nodes, n_cells) = count_nodes_and_cells(patches);
 
     // in gmv format the vertex coordinates and the data have an order that is a
     // bit unpleasant (first all x coordinates, then all y coordinate, ...;
@@ -5055,7 +5055,7 @@ namespace DataOutBase
     // first count the number of cells and cells for later use
     unsigned int n_nodes;
     unsigned int n_cells;
-    std::tie(n_nodes, n_cells) = count_nodes_and_cells<dim, spacedim>(patches);
+    std::tie(n_nodes, n_cells) = count_nodes_and_cells(patches);
 
     //---------
     // preamble
@@ -5317,7 +5317,7 @@ namespace DataOutBase
     // first count the number of cells and cells for later use
     unsigned int n_nodes;
     unsigned int n_cells;
-    std::tie(n_nodes, n_cells) = count_nodes_and_cells<dim, spacedim>(patches);
+    std::tie(n_nodes, n_cells) = count_nodes_and_cells(patches);
     // local variables only needed to write Tecplot binary output files
     const unsigned int vars_per_node  = (spacedim + n_data_sets),
                        nodes_per_cell = GeometryInfo<dim>::vertices_per_cell;
@@ -8786,7 +8786,6 @@ DataOutBase::write_filtered_data(
   DataOutBase::DataOutFilter &filtered_data)
 {
   const unsigned int n_data_sets = data_names.size();
-  unsigned int       n_node, n_cell;
   Table<2, double>   data_vectors;
   Threads::Task<>    reorder_task;
 
@@ -8804,8 +8803,7 @@ DataOutBase::write_filtered_data(
 #endif
 
   unsigned int n_nodes;
-  std::tie(n_nodes, std::ignore) =
-    count_nodes_and_cells<dim, spacedim>(patches);
+  std::tie(n_nodes, std::ignore) = count_nodes_and_cells(patches);
 
   data_vectors = Table<2, double>(n_data_sets, n_nodes);
   void (*fun_ptr)(const std::vector<Patch<dim, spacedim>> &,

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -1153,7 +1153,7 @@ namespace
           }
       }
 
-    return std::tuple<unsigned int, unsigned int>(n_nodes, n_cells);
+    return std::make_tuple(n_nodes, n_cells);
   }
 
 
@@ -1209,8 +1209,7 @@ namespace
           }
       }
 
-    return std::tuple<unsigned int, unsigned int, unsigned int>(
-      n_nodes, n_cells, n_points_and_n_cells);
+    return std::make_tuple(n_nodes, n_cells, n_points_and_n_cells);
   }
 
   /**

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -4950,11 +4950,10 @@ namespace DataOutBase
     // vertices, so do this on a separate task and when wanting to write out the
     // data, we wait for that task to finish
     Table<2, double> data_vectors(n_data_sets, n_nodes);
-    void (*fun_ptr)(const std::vector<Patch<dim, spacedim>> &,
-                    Table<2, double> &) =
-      &write_gmv_reorder_data_vectors<dim, spacedim>;
-    Threads::Task<> reorder_task =
-      Threads::new_task(fun_ptr, patches, data_vectors);
+    Threads::Task<>  reorder_task =
+      Threads::new_task([&patches, &data_vectors]() mutable {
+        write_gmv_reorder_data_vectors(patches, data_vectors);
+      });
 
     //-----------------------------
     // first make up a list of used vertices along with their coordinates
@@ -5130,12 +5129,10 @@ namespace DataOutBase
     // data, we wait for that task to finish
 
     Table<2, double> data_vectors(n_data_sets, n_nodes);
-
-    void (*fun_ptr)(const std::vector<Patch<dim, spacedim>> &,
-                    Table<2, double> &) =
-      &write_gmv_reorder_data_vectors<dim, spacedim>;
-    Threads::Task<> reorder_task =
-      Threads::new_task(fun_ptr, patches, data_vectors);
+    Threads::Task<>  reorder_task =
+      Threads::new_task([&patches, &data_vectors]() mutable {
+        write_gmv_reorder_data_vectors(patches, data_vectors);
+      });
 
     //-----------------------------
     // first make up a list of used vertices along with their coordinates
@@ -5369,12 +5366,10 @@ namespace DataOutBase
     // vertices, so do this on a separate task and when wanting to write out the
     // data, we wait for that task to finish
     Table<2, double> data_vectors(n_data_sets, n_nodes);
-
-    void (*fun_ptr)(const std::vector<Patch<dim, spacedim>> &,
-                    Table<2, double> &) =
-      &write_gmv_reorder_data_vectors<dim, spacedim>;
-    Threads::Task<> reorder_task =
-      Threads::new_task(fun_ptr, patches, data_vectors);
+    Threads::Task<>  reorder_task =
+      Threads::new_task([&patches, &data_vectors]() mutable {
+        write_gmv_reorder_data_vectors(patches, data_vectors);
+      });
 
     //-----------------------------
     // first make up a list of used vertices along with their coordinates
@@ -5674,12 +5669,10 @@ namespace DataOutBase
     // vertices, so do this on a separate task and when wanting to write out the
     // data, we wait for that task to finish
     Table<2, double> data_vectors(n_data_sets, n_nodes);
-
-    void (*fun_ptr)(const std::vector<Patch<dim, spacedim>> &,
-                    Table<2, double> &) =
-      &write_gmv_reorder_data_vectors<dim, spacedim>;
-    Threads::Task<> reorder_task =
-      Threads::new_task(fun_ptr, patches, data_vectors);
+    Threads::Task<>  reorder_task =
+      Threads::new_task([&patches, &data_vectors]() mutable {
+        write_gmv_reorder_data_vectors(patches, data_vectors);
+      });
 
     //-----------------------------
     // first make up a list of used vertices along with their coordinates
@@ -6059,11 +6052,10 @@ namespace DataOutBase
     // data, we wait for that task to finish
     Table<2, float> data_vectors(n_data_sets, n_nodes);
 
-    void (*fun_ptr)(const std::vector<Patch<dim, spacedim>> &,
-                    Table<2, float> &) =
-      &write_gmv_reorder_data_vectors<dim, spacedim, float>;
     Threads::Task<> reorder_task =
-      Threads::new_task(fun_ptr, patches, data_vectors);
+      Threads::new_task([&patches, &data_vectors]() mutable {
+        write_gmv_reorder_data_vectors(patches, data_vectors);
+      });
 
     //-----------------------------
     // first make up a list of used vertices along with their coordinates
@@ -8781,6 +8773,8 @@ namespace
 #endif
 } // namespace
 
+
+
 template <int dim, int spacedim>
 void
 DataOutBase::write_filtered_data(
@@ -8796,7 +8790,6 @@ DataOutBase::write_filtered_data(
 {
   const unsigned int n_data_sets = data_names.size();
   Table<2, double>   data_vectors;
-  Threads::Task<>    reorder_task;
 
 #ifndef DEAL_II_WITH_MPI
   // verify that there are indeed patches to be written out. most of the times,
@@ -8815,10 +8808,10 @@ DataOutBase::write_filtered_data(
   std::tie(n_nodes, std::ignore) = count_nodes_and_cells(patches);
 
   data_vectors = Table<2, double>(n_data_sets, n_nodes);
-  void (*fun_ptr)(const std::vector<Patch<dim, spacedim>> &,
-                  Table<2, double> &) =
-    &DataOutBase::template write_gmv_reorder_data_vectors<dim, spacedim>;
-  reorder_task = Threads::new_task(fun_ptr, patches, data_vectors);
+  Threads::Task<> reorder_task =
+    Threads::new_task([&patches, &data_vectors]() mutable {
+      write_gmv_reorder_data_vectors(patches, data_vectors);
+    });
 
   // Write the nodes/cells to the DataOutFilter object.
   write_nodes(patches, filtered_data);

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -725,7 +725,7 @@ namespace
 
     if (write_higher_order_cells)
       {
-        if (patch.reference_cell == ReferenceCells::get_hypercube<dim>())
+        if (patch.reference_cell.is_hyper_cube())
           {
             const std::array<unsigned int, 4> cell_type_by_dim{
               {VTK_VERTEX,
@@ -781,7 +781,7 @@ namespace
         vtk_cell_id[0] = VTK_PYRAMID;
         vtk_cell_id[1] = 1;
       }
-    else if (patch.reference_cell == ReferenceCells::get_hypercube<dim>())
+    else if (patch.reference_cell.is_hyper_cube())
       {
         const std::array<unsigned int, 4> cell_type_by_dim{
           {VTK_VERTEX, VTK_LINE, VTK_QUAD, VTK_HEXAHEDRON}};
@@ -819,8 +819,7 @@ namespace
     const unsigned int                         n_subdivisions)
   {
     // This function only makes sense when called on hypercube cells
-    Assert(patch.reference_cell == ReferenceCells::get_hypercube<dim>(),
-           ExcInternalError());
+    Assert(patch.reference_cell.is_hyper_cube(), ExcInternalError());
 
     Assert(lattice_location.size() == dim, ExcInternalError());
 
@@ -1132,7 +1131,7 @@ namespace
                  "but that is clearly not a valid choice. Did you forget "
                  "to set the reference cell for the patch?"));
 
-        if (patch.reference_cell == ReferenceCells::get_hypercube<dim>())
+        if (patch.reference_cell.is_hyper_cube())
           {
             n_nodes += Utilities::fixed_power<dim>(patch.n_subdivisions + 1);
             n_cells += Utilities::fixed_power<dim>(patch.n_subdivisions);
@@ -1164,7 +1163,7 @@ namespace
 
     for (const auto &patch : patches)
       {
-        if (patch.reference_cell == ReferenceCells::get_hypercube<dim>())
+        if (patch.reference_cell.is_hyper_cube())
           {
             n_nodes += Utilities::fixed_power<dim>(patch.n_subdivisions + 1);
 

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -8803,9 +8803,11 @@ DataOutBase::write_filtered_data(
     return;
 #endif
 
-  std::tie(n_node, n_cell) = count_nodes_and_cells<dim, spacedim>(patches);
+  unsigned int n_nodes;
+  std::tie(n_nodes, std::ignore) =
+    count_nodes_and_cells<dim, spacedim>(patches);
 
-  data_vectors = Table<2, double>(n_data_sets, n_node);
+  data_vectors = Table<2, double>(n_data_sets, n_nodes);
   void (*fun_ptr)(const std::vector<Patch<dim, spacedim>> &,
                   Table<2, double> &) =
     &DataOutBase::template write_gmv_reorder_data_vectors<dim, spacedim>;

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -1153,7 +1153,7 @@ namespace
           }
       }
 
-    return {n_nodes, n_cells};
+    return std::tuple<unsigned int, unsigned int>(n_nodes, n_cells);
   }
 
 
@@ -1209,7 +1209,8 @@ namespace
           }
       }
 
-    return {n_nodes, n_cells, n_points_and_n_cells};
+    return std::tuple<unsigned int, unsigned int, unsigned int>(
+      n_nodes, n_cells, n_points_and_n_cells);
   }
 
   /**


### PR DESCRIPTION
The next step towards #14403. This is still just refactoring, and the individual commits might be easiest to review by looking at them one at a time.

The one I'd like specifically to point at, because it illustrates a design (anti-)pattern is c38e3216cf4bf93d9ba3350eb2d8eaff9401d76d. We used to write things such as
```
  void f (const int input, BigObject &output) {...}

  void g () {
    BigObject o;
    Threads::Task<> t([&o](){ f(42, o); }    // build o in the background
    ...
    t.join();
    ...                // do something with o.
```
This of course works, but it is error prone because the object `o` is around all along and if one moves code around, it is easy to accidentally access `o` before it is actually guaranteed to be built by the background call to `f` above.

This patch changes this pattern to the following:
```
  std::unique_ptr<BigObject> f (const int input) {...}

  void g () {
    Threads::Task<std::unique_ptr<BigObject>> t([](){ f(42); }    // build o in the background
    ...
    const BigObject o = std::move(*t.return_value());
    ...                // do something with o.
```
The advantage of this approach is that the object `o` is created only at the point where it is guaranteed to actually exist. I believe that this is a refactoring step worth doing in other places as well.

/rebuild