### PR TITLE
Make TrilinosWrappers::MPI::Vector::reinit accept Utilities::MPI::Partitioner.

### DIFF
--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -22,6 +22,7 @@
 #ifdef DEAL_II_WITH_TRILINOS
 #  include <deal.II/base/index_set.h>
 #  include <deal.II/base/mpi_stub.h>
+#  include <deal.II/base/partitioner.h>
 #  include <deal.II/base/subscriptor.h>
 
 #  include <deal.II/lac/exceptions.h>
@@ -599,6 +600,15 @@ namespace TrilinosWrappers
              const IndexSet &ghost_entries,
              const MPI_Comm &communicator    = MPI_COMM_WORLD,
              const bool      vector_writable = false);
+
+      /**
+       * Initialize the vector given to the parallel partitioning described in
+       * @p partitioner using the function above.
+       */
+      void
+      reinit(
+        const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner,
+        const bool vector_writable = false);
 
       /**
        * Create vector by merging components from a block vector.

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -407,6 +407,19 @@ namespace TrilinosWrappers
 
 
 
+    void
+    Vector::reinit(
+      const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner,
+      const bool                                                vector_writable)
+    {
+      this->reinit(partitioner->locally_owned_range(),
+                   partitioner->ghost_indices(),
+                   partitioner->get_mpi_communicator(),
+                   vector_writable);
+    }
+
+
+
     Vector &
     Vector::operator=(const Vector &v)
     {


### PR DESCRIPTION
Part of #14426.

We can use the same `reinit(partitioner)` call for the three classes with this patch.

LA::distributed::Vector
https://github.com/dealii/dealii/blob/81a05a0e56e879337f189a9a8902f5033922eeb7/include/deal.II/lac/la_parallel_vector.h#L403-L406

PETScWrappers::MPI::Vector
https://github.com/dealii/dealii/blob/81a05a0e56e879337f189a9a8902f5033922eeb7/include/deal.II/lac/petsc_vector.h#L347-L349

**NEW** TrilinosWrappers::MPI::Vector
```
      void
      reinit(
        const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner,
        const bool vector_writable = false);
```