### PR TITLE
Let all SolverCG constructors take MPI_Comm.

### DIFF
--- a/examples/step-40/step-40.cc
+++ b/examples/step-40/step-40.cc
@@ -470,11 +470,7 @@ namespace Step40
 
     SolverControl solver_control(dof_handler.n_dofs(), 1e-12);
 
-#ifdef USE_PETSC_LA
     LA::SolverCG solver(solver_control, mpi_communicator);
-#else
-    LA::SolverCG solver(solver_control);
-#endif
 
     LA::MPI::PreconditionAMG preconditioner;
 

--- a/include/deal.II/lac/solver_cg.h
+++ b/include/deal.II/lac/solver_cg.h
@@ -204,6 +204,13 @@ public:
   SolverCG(SolverControl &cn, const AdditionalData &data = AdditionalData());
 
   /**
+   * Constructor for compatibility to PETSc interface.
+   */
+  SolverCG(SolverControl &       cn,
+           const MPI_Comm &      mpi_communicator,
+           const AdditionalData &data = AdditionalData());
+
+  /**
    * Virtual destructor.
    */
   virtual ~SolverCG() override = default;
@@ -408,6 +415,17 @@ SolverCG<VectorType>::SolverCG(SolverControl &cn, const AdditionalData &data)
   , additional_data(data)
   , determine_beta_by_flexible_formula(false)
 {}
+
+
+
+template <typename VectorType>
+SolverCG<VectorType>::SolverCG(SolverControl &       cn,
+                               const MPI_Comm &      mpi_communicator,
+                               const AdditionalData &data)
+  : SolverCG<VectorType>(cn, data)
+{
+  (void)mpi_communicator; // unused, for compatibility with PETSc
+}
 
 
 

--- a/include/deal.II/lac/trilinos_solver.h
+++ b/include/deal.II/lac/trilinos_solver.h
@@ -393,6 +393,13 @@ namespace TrilinosWrappers
      */
     SolverCG(SolverControl &cn, const AdditionalData &data = AdditionalData());
 
+    /**
+     * Constructor for compatibility to PETSc interface.
+     */
+    SolverCG(SolverControl &       cn,
+             const MPI_Comm &      mpi_communicator,
+             const AdditionalData &data = AdditionalData());
+
   protected:
     /**
      * Store a copy of the flags for this particular solver.

--- a/source/lac/trilinos_solver.cc
+++ b/source/lac/trilinos_solver.cc
@@ -605,6 +605,16 @@ namespace TrilinosWrappers
   }
 
 
+
+  SolverCG::SolverCG(SolverControl &       cn,
+                     const MPI_Comm &      mpi_communicator,
+                     const AdditionalData &data)
+    : SolverCG(cn, data)
+  {
+    (void)mpi_communicator; // unused, for compatibility with PETSc
+  }
+
+
   /* ---------------------- SolverGMRES ------------------------ */
 
   SolverGMRES::AdditionalData::AdditionalData(


### PR DESCRIPTION
Part of #14426.

We can use the same parameters to construct any kind of `SolverCG` object.

PETScWrappers::SolverCG
https://github.com/dealii/dealii/blob/7e6198a4cd5e2cb9435fd7cadb2eb68bcfdf7874/include/deal.II/lac/petsc_solver.h#L404-L406

**NEW** TrilinosWrappers::SolverCG
```
    SolverCG(SolverControl &       cn,
             const MPI_Comm &      mpi_communicator,
             const AdditionalData &data = AdditionalData());
```

**NEW** SolverCG
```
  SolverCG(SolverControl &       cn,
           const MPI_Comm &      mpi_communicator,
           const AdditionalData &data = AdditionalData());
```

