### PR TITLE
NonMatching: Remove template on sparsity pattern type.

### DIFF
--- a/include/deal.II/non_matching/coupling.h
+++ b/include/deal.II/non_matching/coupling.h
@@ -90,17 +90,13 @@ namespace NonMatching
    * See the tutorial program step-60 for an example on how to use this
    * function.
    */
-  template <int dim0,
-            int dim1,
-            int spacedim,
-            typename Sparsity,
-            typename number = double>
+  template <int dim0, int dim1, int spacedim, typename number = double>
   void
   create_coupling_sparsity_pattern(
     const DoFHandler<dim0, spacedim> &space_dh,
     const DoFHandler<dim1, spacedim> &immersed_dh,
     const Quadrature<dim1> &          quad,
-    Sparsity &                        sparsity,
+    SparsityPatternBase &             sparsity,
     const AffineConstraints<number> & constraints = AffineConstraints<number>(),
     const ComponentMask &             space_comps = ComponentMask(),
     const ComponentMask &             immersed_comps = ComponentMask(),
@@ -117,18 +113,14 @@ namespace NonMatching
    * space_mapping cannot be specified, since it is taken from the @p cache
    * parameter.
    */
-  template <int dim0,
-            int dim1,
-            int spacedim,
-            typename Sparsity,
-            typename number = double>
+  template <int dim0, int dim1, int spacedim, typename number = double>
   void
   create_coupling_sparsity_pattern(
     const GridTools::Cache<dim0, spacedim> &cache,
     const DoFHandler<dim0, spacedim> &      space_dh,
     const DoFHandler<dim1, spacedim> &      immersed_dh,
     const Quadrature<dim1> &                quad,
-    Sparsity &                              sparsity,
+    SparsityPatternBase &                   sparsity,
     const AffineConstraints<number> &constraints = AffineConstraints<number>(),
     const ComponentMask &            space_comps = ComponentMask(),
     const ComponentMask &            immersed_comps = ComponentMask(),
@@ -269,11 +261,7 @@ namespace NonMatching
    * restrictive conditions are required on the two spaces. See the
    * documentation of the other create_coupling_sparsity_pattern() function.
    */
-  template <int dim0,
-            int dim1,
-            int spacedim,
-            typename Sparsity,
-            typename Number = double>
+  template <int dim0, int dim1, int spacedim, typename Number = double>
   void
   create_coupling_sparsity_pattern(
     const double &                          epsilon,
@@ -282,7 +270,7 @@ namespace NonMatching
     const DoFHandler<dim0, spacedim> &      dh0,
     const DoFHandler<dim1, spacedim> &      dh1,
     const Quadrature<dim1> &                quad,
-    Sparsity &                              sparsity,
+    SparsityPatternBase &                   sparsity,
     const AffineConstraints<Number> &constraints0 = AffineConstraints<Number>(),
     const ComponentMask &            comps0       = ComponentMask(),
     const ComponentMask &            comps1       = ComponentMask());

--- a/source/non_matching/coupling.cc
+++ b/source/non_matching/coupling.cc
@@ -169,17 +169,13 @@ namespace NonMatching
     }
   } // namespace internal
 
-  template <int dim0,
-            int dim1,
-            int spacedim,
-            typename Sparsity,
-            typename number>
+  template <int dim0, int dim1, int spacedim, typename number>
   void
   create_coupling_sparsity_pattern(
     const DoFHandler<dim0, spacedim> &space_dh,
     const DoFHandler<dim1, spacedim> &immersed_dh,
     const Quadrature<dim1> &          quad,
-    Sparsity &                        sparsity,
+    SparsityPatternBase &             sparsity,
     const AffineConstraints<number> & constraints,
     const ComponentMask &             space_comps,
     const ComponentMask &             immersed_comps,
@@ -203,18 +199,14 @@ namespace NonMatching
 
 
 
-  template <int dim0,
-            int dim1,
-            int spacedim,
-            typename Sparsity,
-            typename number>
+  template <int dim0, int dim1, int spacedim, typename number>
   void
   create_coupling_sparsity_pattern(
     const GridTools::Cache<dim0, spacedim> &cache,
     const DoFHandler<dim0, spacedim> &      space_dh,
     const DoFHandler<dim1, spacedim> &      immersed_dh,
     const Quadrature<dim1> &                quad,
-    Sparsity &                              sparsity,
+    SparsityPatternBase &                   sparsity,
     const AffineConstraints<number> &       constraints,
     const ComponentMask &                   space_comps,
     const ComponentMask &                   immersed_comps,
@@ -626,11 +618,7 @@ namespace NonMatching
       }
   }
 
-  template <int dim0,
-            int dim1,
-            int spacedim,
-            typename Sparsity,
-            typename Number>
+  template <int dim0, int dim1, int spacedim, typename Number>
   void
   create_coupling_sparsity_pattern(
     const double &                          epsilon,
@@ -639,7 +627,7 @@ namespace NonMatching
     const DoFHandler<dim0, spacedim> &      dh0,
     const DoFHandler<dim1, spacedim> &      dh1,
     const Quadrature<dim1> &                quad,
-    Sparsity &                              sparsity,
+    SparsityPatternBase &                   sparsity,
     const AffineConstraints<Number> &       constraints0,
     const ComponentMask &                   comps0,
     const ComponentMask &                   comps1)

--- a/source/non_matching/coupling.inst.in
+++ b/source/non_matching/coupling.inst.in
@@ -15,7 +15,6 @@
 
 
 for (dim0 : DIMENSIONS; dim1 : DIMENSIONS; spacedim : SPACE_DIMENSIONS;
-     Sparsity : SPARSITY_PATTERNS;
      S : REAL_AND_COMPLEX_SCALARS)
   {
 #if dim1 <= spacedim && dim0 <= spacedim
@@ -23,7 +22,7 @@ for (dim0 : DIMENSIONS; dim1 : DIMENSIONS; spacedim : SPACE_DIMENSIONS;
       const DoFHandler<dim0, spacedim> &space_dh,
       const DoFHandler<dim1, spacedim> &immersed_dh,
       const Quadrature<dim1> &          quad,
-      Sparsity &                        sparsity,
+      SparsityPatternBase &             sparsity,
       const AffineConstraints<S> &      constraints,
       const ComponentMask &             space_comps,
       const ComponentMask &             immersed_comps,
@@ -36,7 +35,7 @@ for (dim0 : DIMENSIONS; dim1 : DIMENSIONS; spacedim : SPACE_DIMENSIONS;
       const DoFHandler<dim0, spacedim> &      space_dh,
       const DoFHandler<dim1, spacedim> &      immersed_dh,
       const Quadrature<dim1> &                quad,
-      Sparsity &                              sparsity,
+      SparsityPatternBase &                   sparsity,
       const AffineConstraints<S> &            constraints,
       const ComponentMask &                   space_comps,
       const ComponentMask &                   immersed_comps,
@@ -50,7 +49,7 @@ for (dim0 : DIMENSIONS; dim1 : DIMENSIONS; spacedim : SPACE_DIMENSIONS;
       const DoFHandler<dim0, spacedim> &      dh0,
       const DoFHandler<dim1, spacedim> &      dh1,
       const Quadrature<dim1> &                quad,
-      Sparsity &                              sparsity,
+      SparsityPatternBase &                   sparsity,
       const AffineConstraints<S> &            constraints0,
       const ComponentMask &                   comps0,
       const ComponentMask &                   comps1);


### PR DESCRIPTION
Another followup to #14396: part 7/11. This is no longer necessary since all of our SparsityPatterns now inherit from SparsityPatternBase. This file was previously the most expensive to compile in the entire library so cutting down the number of instantiations by a factor of 4 or 6 (with Trilinos) is quite nice.