### PR TITLE
Remove need to store MPI communicator in PETScWrappers::SolverBase

### DIFF
--- a/doc/news/changes/minor/20221116Bangerth
+++ b/doc/news/changes/minor/20221116Bangerth
@@ -1,0 +1,8 @@
+Changed: The constructors of the various solver classes in the PETScWrappers namespace
+used to take an `MPI_Comm` argument. This has now been changed: There
+is a new set of constructors that no longer take this argument, and
+the old constructors have been deprecated. In practice, the solvers
+now use the same MPI communicator as the matrix give to the `solve()`
+function.
+<br>
+(Wolfgang Bangerth, 2022/11/16)

--- a/examples/step-17/step-17.cc
+++ b/examples/step-17/step-17.cc
@@ -616,7 +616,7 @@ namespace Step17
   unsigned int ElasticProblem<dim>::solve()
   {
     SolverControl solver_control(solution.size(), 1e-8 * system_rhs.l2_norm());
-    PETScWrappers::SolverCG cg(solver_control, mpi_communicator);
+    PETScWrappers::SolverCG cg(solver_control);
 
     PETScWrappers::PreconditionBlockJacobi preconditioner(system_matrix);
 

--- a/examples/step-18/step-18.cc
+++ b/examples/step-18/step-18.cc
@@ -1122,7 +1122,7 @@ namespace Step18
     SolverControl solver_control(dof_handler.n_dofs(),
                                  1e-16 * system_rhs.l2_norm());
 
-    PETScWrappers::SolverCG cg(solver_control, mpi_communicator);
+    PETScWrappers::SolverCG cg(solver_control);
 
     PETScWrappers::PreconditionBlockJacobi preconditioner(system_matrix);
 

--- a/examples/step-40/step-40.cc
+++ b/examples/step-40/step-40.cc
@@ -469,22 +469,16 @@ namespace Step40
                                                     mpi_communicator);
 
     SolverControl solver_control(dof_handler.n_dofs(), 1e-12);
+    LA::SolverCG  solver(solver_control);
 
-#ifdef USE_PETSC_LA
-    LA::SolverCG solver(solver_control, mpi_communicator);
-#else
-    LA::SolverCG solver(solver_control);
-#endif
-
-    LA::MPI::PreconditionAMG preconditioner;
 
     LA::MPI::PreconditionAMG::AdditionalData data;
-
 #ifdef USE_PETSC_LA
     data.symmetric_operator = true;
 #else
     /* Trilinos defaults are good */
 #endif
+    LA::MPI::PreconditionAMG preconditioner;
     preconditioner.initialize(system_matrix, data);
 
     solver.solve(system_matrix,

--- a/include/deal.II/lac/petsc_precondition.h
+++ b/include/deal.II/lac/petsc_precondition.h
@@ -164,7 +164,6 @@ namespace PETScWrappers
      */
     PreconditionJacobi() = default;
 
-
     /**
      * Constructor. Take the matrix which is used to form the preconditioner,
      * and additional flags if there are any.

--- a/include/deal.II/lac/petsc_precondition.h
+++ b/include/deal.II/lac/petsc_precondition.h
@@ -62,7 +62,15 @@ namespace PETScWrappers
     /**
      * Constructor.
      */
-    PreconditionBase(const MPI_Comm &mpi_communicator = MPI_COMM_NULL);
+    explicit PreconditionBase(const MPI_Comm &mpi_communicator);
+
+    /**
+     * Constructor. This constructor is deprecated.
+     *
+     * @deprecated
+     */
+    DEAL_II_DEPRECATED
+    PreconditionBase();
 
     /**
      * Destructor.

--- a/include/deal.II/lac/petsc_precondition.h
+++ b/include/deal.II/lac/petsc_precondition.h
@@ -62,7 +62,7 @@ namespace PETScWrappers
     /**
      * Constructor.
      */
-    PreconditionBase();
+    PreconditionBase(const MPI_Comm &mpi_communicator = MPI_COMM_NULL);
 
     /**
      * Destructor.
@@ -95,9 +95,20 @@ namespace PETScWrappers
     const PC &
     get_pc() const;
 
+    /**
+     * Return the MPI communicator object used by this preconditioner.
+     */
+    MPI_Comm
+    get_mpi_communicator() const;
+
   protected:
     /**
-     * the PETSc preconditioner object
+     * The communicator to be used for this preconditioner.
+     */
+    MPI_Comm mpi_communicator;
+
+    /**
+     * The PETSc preconditioner object
      */
     PC pc;
 

--- a/include/deal.II/lac/petsc_solver.h
+++ b/include/deal.II/lac/petsc_solver.h
@@ -251,23 +251,24 @@ namespace PETScWrappers
 
     /**
      * Constructor. In contrast to deal.II's own solvers, there is no need to
-     * give a vector memory object. However, PETSc solvers want to have an MPI
-     * communicator context over which computations are parallelized. By
-     * default, @p PETSC_COMM_SELF is used here, but you can change this. Note
-     * that for single processor (non-MPI) versions, this parameter does not
-     * have any effect.
+     * give a vector memory object.
      *
      * The last argument takes a structure with additional, solver dependent
      * flags for tuning.
-     *
-     * Note that the communicator used here must match the communicator used
-     * in the system matrix, solution, and right hand side object of the solve
-     * to be done with this solver. Otherwise, PETSc will generate hard to
-     * track down errors, see the documentation of the SolverBase class.
      */
     SolverRichardson(SolverControl &       cn,
-                     const MPI_Comm &      mpi_communicator = PETSC_COMM_SELF,
-                     const AdditionalData &data             = AdditionalData());
+                     const AdditionalData &data = AdditionalData());
+
+    /**
+     * Constructor. This constructor is deprecated and ignores the MPI
+     * communicator argument. Use the other constructor instead.
+     *
+     * @deprecated
+     */
+    DEAL_II_DEPRECATED_EARLY
+    SolverRichardson(SolverControl &       cn,
+                     const MPI_Comm &      mpi_communicator,
+                     const AdditionalData &data = AdditionalData());
 
   protected:
     /**
@@ -302,23 +303,24 @@ namespace PETScWrappers
 
     /**
      * Constructor. In contrast to deal.II's own solvers, there is no need to
-     * give a vector memory object. However, PETSc solvers want to have an MPI
-     * communicator context over which computations are parallelized. By
-     * default, @p PETSC_COMM_SELF is used here, but you can change this. Note
-     * that for single processor (non-MPI) versions, this parameter does not
-     * have any effect.
+     * give a vector memory object.
      *
      * The last argument takes a structure with additional, solver dependent
      * flags for tuning.
-     *
-     * Note that the communicator used here must match the communicator used
-     * in the system matrix, solution, and right hand side object of the solve
-     * to be done with this solver. Otherwise, PETSc will generate hard to
-     * track down errors, see the documentation of the SolverBase class.
      */
     SolverChebychev(SolverControl &       cn,
-                    const MPI_Comm &      mpi_communicator = PETSC_COMM_SELF,
-                    const AdditionalData &data             = AdditionalData());
+                    const AdditionalData &data = AdditionalData());
+
+    /**
+     * Constructor. This constructor is deprecated and ignores the MPI
+     * communicator argument. Use the other constructor instead.
+     *
+     * @deprecated
+     */
+    DEAL_II_DEPRECATED_EARLY
+    SolverChebychev(SolverControl &       cn,
+                    const MPI_Comm &      mpi_communicator,
+                    const AdditionalData &data = AdditionalData());
 
   protected:
     /**
@@ -352,23 +354,23 @@ namespace PETScWrappers
 
     /**
      * Constructor. In contrast to deal.II's own solvers, there is no need to
-     * give a vector memory object. However, PETSc solvers want to have an MPI
-     * communicator context over which computations are parallelized. By
-     * default, @p PETSC_COMM_SELF is used here, but you can change this. Note
-     * that for single processor (non-MPI) versions, this parameter does not
-     * have any effect.
+     * give a vector memory object.
      *
      * The last argument takes a structure with additional, solver dependent
      * flags for tuning.
-     *
-     * Note that the communicator used here must match the communicator used
-     * in the system matrix, solution, and right hand side object of the solve
-     * to be done with this solver. Otherwise, PETSc will generate hard to
-     * track down errors, see the documentation of the SolverBase class.
      */
+    SolverCG(SolverControl &cn, const AdditionalData &data = AdditionalData());
+
+    /**
+     * Constructor. This constructor is deprecated and ignores the MPI
+     * communicator argument. Use the other constructor instead.
+     *
+     * @deprecated
+     */
+    DEAL_II_DEPRECATED_EARLY
     SolverCG(SolverControl &       cn,
-             const MPI_Comm &      mpi_communicator = PETSC_COMM_SELF,
-             const AdditionalData &data             = AdditionalData());
+             const MPI_Comm &      mpi_communicator,
+             const AdditionalData &data = AdditionalData());
 
   protected:
     /**
@@ -402,23 +404,24 @@ namespace PETScWrappers
 
     /**
      * Constructor. In contrast to deal.II's own solvers, there is no need to
-     * give a vector memory object. However, PETSc solvers want to have an MPI
-     * communicator context over which computations are parallelized. By
-     * default, @p PETSC_COMM_SELF is used here, but you can change this. Note
-     * that for single processor (non-MPI) versions, this parameter does not
-     * have any effect.
+     * give a vector memory object.
      *
      * The last argument takes a structure with additional, solver dependent
      * flags for tuning.
-     *
-     * Note that the communicator used here must match the communicator used
-     * in the system matrix, solution, and right hand side object of the solve
-     * to be done with this solver. Otherwise, PETSc will generate hard to
-     * track down errors, see the documentation of the SolverBase class.
      */
     SolverBiCG(SolverControl &       cn,
-               const MPI_Comm &      mpi_communicator = PETSC_COMM_SELF,
-               const AdditionalData &data             = AdditionalData());
+               const AdditionalData &data = AdditionalData());
+
+    /**
+     * Constructor. This constructor is deprecated and ignores the MPI
+     * communicator argument. Use the other constructor instead.
+     *
+     * @deprecated
+     */
+    DEAL_II_DEPRECATED_EARLY
+    SolverBiCG(SolverControl &       cn,
+               const MPI_Comm &      mpi_communicator,
+               const AdditionalData &data = AdditionalData());
 
   protected:
     /**
@@ -469,23 +472,24 @@ namespace PETScWrappers
 
     /**
      * Constructor. In contrast to deal.II's own solvers, there is no need to
-     * give a vector memory object. However, PETSc solvers want to have an MPI
-     * communicator context over which computations are parallelized. By
-     * default, @p PETSC_COMM_SELF is used here, but you can change this. Note
-     * that for single processor (non-MPI) versions, this parameter does not
-     * have any effect.
+     * give a vector memory object.
      *
      * The last argument takes a structure with additional, solver dependent
      * flags for tuning.
-     *
-     * Note that the communicator used here must match the communicator used
-     * in the system matrix, solution, and right hand side object of the solve
-     * to be done with this solver. Otherwise, PETSc will generate hard to
-     * track down errors, see the documentation of the SolverBase class.
      */
     SolverGMRES(SolverControl &       cn,
-                const MPI_Comm &      mpi_communicator = PETSC_COMM_SELF,
-                const AdditionalData &data             = AdditionalData());
+                const AdditionalData &data = AdditionalData());
+
+    /**
+     * Constructor. This constructor is deprecated and ignores the MPI
+     * communicator argument. Use the other constructor instead.
+     *
+     * @deprecated
+     */
+    DEAL_II_DEPRECATED_EARLY
+    SolverGMRES(SolverControl &       cn,
+                const MPI_Comm &      mpi_communicator,
+                const AdditionalData &data = AdditionalData());
 
   protected:
     /**
@@ -520,23 +524,24 @@ namespace PETScWrappers
 
     /**
      * Constructor. In contrast to deal.II's own solvers, there is no need to
-     * give a vector memory object. However, PETSc solvers want to have an MPI
-     * communicator context over which computations are parallelized. By
-     * default, @p PETSC_COMM_SELF is used here, but you can change this. Note
-     * that for single processor (non-MPI) versions, this parameter does not
-     * have any effect.
+     * give a vector memory object.
      *
      * The last argument takes a structure with additional, solver dependent
      * flags for tuning.
-     *
-     * Note that the communicator used here must match the communicator used
-     * in the system matrix, solution, and right hand side object of the solve
-     * to be done with this solver. Otherwise, PETSc will generate hard to
-     * track down errors, see the documentation of the SolverBase class.
      */
     SolverBicgstab(SolverControl &       cn,
-                   const MPI_Comm &      mpi_communicator = PETSC_COMM_SELF,
-                   const AdditionalData &data             = AdditionalData());
+                   const AdditionalData &data = AdditionalData());
+
+    /**
+     * Constructor. This constructor is deprecated and ignores the MPI
+     * communicator argument. Use the other constructor instead.
+     *
+     * @deprecated
+     */
+    DEAL_II_DEPRECATED_EARLY
+    SolverBicgstab(SolverControl &       cn,
+                   const MPI_Comm &      mpi_communicator,
+                   const AdditionalData &data = AdditionalData());
 
   protected:
     /**
@@ -551,6 +556,8 @@ namespace PETScWrappers
     virtual void
     set_solver_type(KSP &ksp) const override;
   };
+
+
 
   /**
    * An implementation of the solver interface using the PETSc CG Squared
@@ -569,23 +576,23 @@ namespace PETScWrappers
 
     /**
      * Constructor. In contrast to deal.II's own solvers, there is no need to
-     * give a vector memory object. However, PETSc solvers want to have an MPI
-     * communicator context over which computations are parallelized. By
-     * default, @p PETSC_COMM_SELF is used here, but you can change this. Note
-     * that for single processor (non-MPI) versions, this parameter does not
-     * have any effect.
+     * give a vector memory object.
      *
      * The last argument takes a structure with additional, solver dependent
      * flags for tuning.
-     *
-     * Note that the communicator used here must match the communicator used
-     * in the system matrix, solution, and right hand side object of the solve
-     * to be done with this solver. Otherwise, PETSc will generate hard to
-     * track down errors, see the documentation of the SolverBase class.
      */
+    SolverCGS(SolverControl &cn, const AdditionalData &data = AdditionalData());
+
+    /**
+     * Constructor. This constructor is deprecated and ignores the MPI
+     * communicator argument. Use the other constructor instead.
+     *
+     * @deprecated
+     */
+    DEAL_II_DEPRECATED_EARLY
     SolverCGS(SolverControl &       cn,
-              const MPI_Comm &      mpi_communicator = PETSC_COMM_SELF,
-              const AdditionalData &data             = AdditionalData());
+              const MPI_Comm &      mpi_communicator,
+              const AdditionalData &data = AdditionalData());
 
   protected:
     /**
@@ -619,23 +626,24 @@ namespace PETScWrappers
 
     /**
      * Constructor. In contrast to deal.II's own solvers, there is no need to
-     * give a vector memory object. However, PETSc solvers want to have an MPI
-     * communicator context over which computations are parallelized. By
-     * default, @p PETSC_COMM_SELF is used here, but you can change this. Note
-     * that for single processor (non-MPI) versions, this parameter does not
-     * have any effect.
+     * give a vector memory object.
      *
      * The last argument takes a structure with additional, solver dependent
      * flags for tuning.
-     *
-     * Note that the communicator used here must match the communicator used
-     * in the system matrix, solution, and right hand side object of the solve
-     * to be done with this solver. Otherwise, PETSc will generate hard to
-     * track down errors, see the documentation of the SolverBase class.
      */
     SolverTFQMR(SolverControl &       cn,
-                const MPI_Comm &      mpi_communicator = PETSC_COMM_SELF,
-                const AdditionalData &data             = AdditionalData());
+                const AdditionalData &data = AdditionalData());
+
+    /**
+     * Constructor. This constructor is deprecated and ignores the MPI
+     * communicator argument. Use the other constructor instead.
+     *
+     * @deprecated
+     */
+    DEAL_II_DEPRECATED_EARLY
+    SolverTFQMR(SolverControl &       cn,
+                const MPI_Comm &      mpi_communicator,
+                const AdditionalData &data = AdditionalData());
 
   protected:
     /**
@@ -674,23 +682,24 @@ namespace PETScWrappers
 
     /**
      * Constructor. In contrast to deal.II's own solvers, there is no need to
-     * give a vector memory object. However, PETSc solvers want to have an MPI
-     * communicator context over which computations are parallelized. By
-     * default, @p PETSC_COMM_SELF is used here, but you can change this. Note
-     * that for single processor (non-MPI) versions, this parameter does not
-     * have any effect.
+     * give a vector memory object.
      *
      * The last argument takes a structure with additional, solver dependent
      * flags for tuning.
-     *
-     * Note that the communicator used here must match the communicator used
-     * in the system matrix, solution, and right hand side object of the solve
-     * to be done with this solver. Otherwise, PETSc will generate hard to
-     * track down errors, see the documentation of the SolverBase class.
      */
     SolverTCQMR(SolverControl &       cn,
-                const MPI_Comm &      mpi_communicator = PETSC_COMM_SELF,
-                const AdditionalData &data             = AdditionalData());
+                const AdditionalData &data = AdditionalData());
+
+    /**
+     * Constructor. This constructor is deprecated and ignores the MPI
+     * communicator argument. Use the other constructor instead.
+     *
+     * @deprecated
+     */
+    DEAL_II_DEPRECATED_EARLY
+    SolverTCQMR(SolverControl &       cn,
+                const MPI_Comm &      mpi_communicator,
+                const AdditionalData &data = AdditionalData());
 
   protected:
     /**
@@ -724,23 +733,23 @@ namespace PETScWrappers
 
     /**
      * Constructor. In contrast to deal.II's own solvers, there is no need to
-     * give a vector memory object. However, PETSc solvers want to have an MPI
-     * communicator context over which computations are parallelized. By
-     * default, @p PETSC_COMM_SELF is used here, but you can change this. Note
-     * that for single processor (non-MPI) versions, this parameter does not
-     * have any effect.
+     * give a vector memory object.
      *
      * The last argument takes a structure with additional, solver dependent
      * flags for tuning.
-     *
-     * Note that the communicator used here must match the communicator used
-     * in the system matrix, solution, and right hand side object of the solve
-     * to be done with this solver. Otherwise, PETSc will generate hard to
-     * track down errors, see the documentation of the SolverBase class.
      */
+    SolverCR(SolverControl &cn, const AdditionalData &data = AdditionalData());
+
+    /**
+     * Constructor. This constructor is deprecated and ignores the MPI
+     * communicator argument. Use the other constructor instead.
+     *
+     * @deprecated
+     */
+    DEAL_II_DEPRECATED_EARLY
     SolverCR(SolverControl &       cn,
-             const MPI_Comm &      mpi_communicator = PETSC_COMM_SELF,
-             const AdditionalData &data             = AdditionalData());
+             const MPI_Comm &      mpi_communicator,
+             const AdditionalData &data = AdditionalData());
 
   protected:
     /**
@@ -775,23 +784,24 @@ namespace PETScWrappers
 
     /**
      * Constructor. In contrast to deal.II's own solvers, there is no need to
-     * give a vector memory object. However, PETSc solvers want to have an MPI
-     * communicator context over which computations are parallelized. By
-     * default, @p PETSC_COMM_SELF is used here, but you can change this. Note
-     * that for single processor (non-MPI) versions, this parameter does not
-     * have any effect.
+     * give a vector memory object.
      *
      * The last argument takes a structure with additional, solver dependent
      * flags for tuning.
-     *
-     * Note that the communicator used here must match the communicator used
-     * in the system matrix, solution, and right hand side object of the solve
-     * to be done with this solver. Otherwise, PETSc will generate hard to
-     * track down errors, see the documentation of the SolverBase class.
      */
     SolverLSQR(SolverControl &       cn,
-               const MPI_Comm &      mpi_communicator = PETSC_COMM_SELF,
-               const AdditionalData &data             = AdditionalData());
+               const AdditionalData &data = AdditionalData());
+
+    /**
+     * Constructor. This constructor is deprecated and ignores the MPI
+     * communicator argument. Use the other constructor instead.
+     *
+     * @deprecated
+     */
+    DEAL_II_DEPRECATED_EARLY
+    SolverLSQR(SolverControl &       cn,
+               const MPI_Comm &      mpi_communicator,
+               const AdditionalData &data = AdditionalData());
 
   protected:
     /**
@@ -830,23 +840,24 @@ namespace PETScWrappers
 
     /**
      * Constructor. In contrast to deal.II's own solvers, there is no need to
-     * give a vector memory object. However, PETSc solvers want to have an MPI
-     * communicator context over which computations are parallelized. By
-     * default, @p PETSC_COMM_SELF is used here, but you can change this. Note
-     * that for single processor (non-MPI) versions, this parameter does not
-     * have any effect.
+     * give a vector memory object.
      *
      * The last argument takes a structure with additional, solver dependent
      * flags for tuning.
-     *
-     * Note that the communicator used here must match the communicator used
-     * in the system matrix, solution, and right hand side object of the solve
-     * to be done with this solver. Otherwise, PETSc will generate hard to
-     * track down errors, see the documentation of the SolverBase class.
      */
     SolverPreOnly(SolverControl &       cn,
-                  const MPI_Comm &      mpi_communicator = PETSC_COMM_SELF,
-                  const AdditionalData &data             = AdditionalData());
+                  const AdditionalData &data = AdditionalData());
+
+    /**
+     * Constructor. This constructor is deprecated and ignores the MPI
+     * communicator argument. Use the other constructor instead.
+     *
+     * @deprecated
+     */
+    DEAL_II_DEPRECATED_EARLY
+    SolverPreOnly(SolverControl &       cn,
+                  const MPI_Comm &      mpi_communicator,
+                  const AdditionalData &data = AdditionalData());
 
   protected:
     /**
@@ -893,11 +904,22 @@ namespace PETScWrappers
      */
     struct AdditionalData
     {};
+
     /**
-     * Constructor
+     * Constructor.
      */
     SparseDirectMUMPS(SolverControl &       cn,
-                      const MPI_Comm &      mpi_communicator = PETSC_COMM_SELF,
+                      const AdditionalData &data = AdditionalData());
+
+    /**
+     * Constructor. This constructor is deprecated and ignores the MPI
+     * communicator argument. Use the other constructor instead.
+     *
+     * @deprecated
+     */
+    DEAL_II_DEPRECATED_EARLY
+    SparseDirectMUMPS(SolverControl &       cn,
+                      const MPI_Comm &      mpi_communicator,
                       const AdditionalData &data = AdditionalData());
 
     /**

--- a/include/deal.II/lac/petsc_solver.h
+++ b/include/deal.II/lac/petsc_solver.h
@@ -83,45 +83,15 @@ namespace PETScWrappers
    * object. This is done for performance reasons. The solver and
    * preconditioner can be reset by calling reset().
    *
-   * One of the gotchas of PETSc is that -- in particular in MPI mode -- it
-   * often does not produce very helpful error messages. In order to save
-   * other users some time in searching a hard to track down error, here is
-   * one situation and the error message one gets there: when you don't
-   * specify an MPI communicator to your solver's constructor. In this case,
-   * you will get an error of the following form from each of your parallel
-   * processes:
-   * @verbatim
-   *   [1]PETSC ERROR: PCSetVector() line 1173 in src/ksp/pc/interface/precon.c
-   *   [1]PETSC ERROR:   Arguments must have same communicators!
-   *   [1]PETSC ERROR:   Different communicators in the two objects: Argument #
-   * 1 and 2! [1]PETSC ERROR: KSPSetUp() line 195 in
-   * src/ksp/ksp/interface/itfunc.c
-   * @endverbatim
-   *
-   * This error, on which one can spend a very long time figuring out what
-   * exactly goes wrong, results from not specifying an MPI communicator. Note
-   * that the communicator @em must match that of the matrix and all vectors
-   * in the linear system which we want to solve. Aggravating the situation is
-   * the fact that the default argument to the solver classes, @p
-   * PETSC_COMM_SELF, is the appropriate argument for the sequential case
-   * (which is why it is the default argument), so this error only shows up in
-   * parallel mode.
-   *
    * @ingroup PETScWrappers
    */
   class SolverBase
   {
   public:
     /**
-     * Constructor. Takes the solver control object and the MPI communicator
-     * over which parallel computations are to happen.
-     *
-     * Note that the communicator used here must match the communicator used
-     * in the system matrix, solution, and right hand side object of the solve
-     * to be done with this solver. Otherwise, PETSc will generate hard to
-     * track down errors, see the documentation of the SolverBase class.
+     * Constructor.
      */
-    SolverBase(SolverControl &cn, const MPI_Comm &mpi_communicator);
+    SolverBase(SolverControl &cn);
 
     /**
      * Destructor.
@@ -179,11 +149,6 @@ namespace PETScWrappers
      * and copy the data back into it afterwards.
      */
     SolverControl &solver_control;
-
-    /**
-     * Copy of the MPI communicator object to be used for the solver.
-     */
-    const MPI_Comm mpi_communicator;
 
     /**
      * %Function that takes a Krylov Subspace Solver context object, and sets

--- a/source/lac/petsc_precondition.cc
+++ b/source/lac/petsc_precondition.cc
@@ -33,10 +33,13 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace PETScWrappers
 {
-  PreconditionBase::PreconditionBase()
-    : pc(nullptr)
+  PreconditionBase::PreconditionBase(const MPI_Comm &comm)
+    : mpi_communicator(comm)
+    , pc(nullptr)
     , matrix(nullptr)
   {}
+
+
 
   PreconditionBase::~PreconditionBase()
   {
@@ -48,9 +51,12 @@ namespace PETScWrappers
       {}
   }
 
+
   void
   PreconditionBase::clear()
   {
+    mpi_communicator = MPI_COMM_NULL;
+
     matrix = nullptr;
 
     if (pc != nullptr)
@@ -72,6 +78,7 @@ namespace PETScWrappers
   }
 
 
+
   void
   PreconditionBase::Tvmult(VectorBase &dst, const VectorBase &src) const
   {
@@ -82,6 +89,15 @@ namespace PETScWrappers
   }
 
 
+
+  MPI_Comm
+  PreconditionBase::get_mpi_communicator() const
+  {
+    return mpi_communicator;
+  }
+
+
+
   void
   PreconditionBase::create_pc()
   {
@@ -89,15 +105,9 @@ namespace PETScWrappers
     // preconditioner once
     AssertThrow(pc == nullptr, StandardExceptions::ExcInvalidState());
 
-    MPI_Comm comm;
-    // this ugly cast is necessary because the
-    // type Mat and PETScObject are
-    // unrelated.
-    PetscErrorCode ierr =
-      PetscObjectGetComm(reinterpret_cast<PetscObject>(matrix), &comm);
-    AssertThrow(ierr == 0, ExcPETScError(ierr));
+    MPI_Comm comm = get_mpi_communicator();
 
-    ierr = PCCreate(comm, &pc);
+    PetscErrorCode ierr = PCCreate(comm, &pc);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
 #  if DEAL_II_PETSC_VERSION_LT(3, 5, 0)
@@ -125,6 +135,7 @@ namespace PETScWrappers
   /* ----------------- PreconditionJacobi -------------------- */
   PreconditionJacobi::PreconditionJacobi(const MPI_Comm &      comm,
                                          const AdditionalData &additional_data_)
+    : PreconditionBase(comm)
   {
     additional_data = additional_data_;
 
@@ -138,9 +149,12 @@ namespace PETScWrappers
 
   PreconditionJacobi::PreconditionJacobi(const MatrixBase &    matrix,
                                          const AdditionalData &additional_data)
+    : PreconditionBase(matrix.get_mpi_communicator())
   {
     initialize(matrix, additional_data);
   }
+
+
 
   void
   PreconditionJacobi::initialize()
@@ -154,11 +168,15 @@ namespace PETScWrappers
     AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 
+
+
   void
   PreconditionJacobi::initialize(const MatrixBase &    matrix_,
                                  const AdditionalData &additional_data_)
   {
     clear();
+
+    mpi_communicator = matrix_.get_mpi_communicator();
 
     matrix          = static_cast<Mat>(matrix_);
     additional_data = additional_data_;
@@ -172,9 +190,12 @@ namespace PETScWrappers
 
 
   /* ----------------- PreconditionBlockJacobi -------------------- */
+
+
   PreconditionBlockJacobi::PreconditionBlockJacobi(
     const MPI_Comm &      comm,
     const AdditionalData &additional_data_)
+    : PreconditionBase(comm)
   {
     additional_data = additional_data_;
 
@@ -189,9 +210,12 @@ namespace PETScWrappers
   PreconditionBlockJacobi::PreconditionBlockJacobi(
     const MatrixBase &    matrix,
     const AdditionalData &additional_data)
+    : PreconditionBase(matrix.get_mpi_communicator())
   {
     initialize(matrix, additional_data);
   }
+
+
 
   void
   PreconditionBlockJacobi::initialize()
@@ -204,11 +228,14 @@ namespace PETScWrappers
   }
 
 
+
   void
   PreconditionBlockJacobi::initialize(const MatrixBase &    matrix_,
                                       const AdditionalData &additional_data_)
   {
     clear();
+
+    mpi_communicator = matrix_.get_mpi_communicator();
 
     matrix          = static_cast<Mat>(matrix_);
     additional_data = additional_data_;
@@ -231,6 +258,7 @@ namespace PETScWrappers
 
   PreconditionSOR::PreconditionSOR(const MatrixBase &    matrix,
                                    const AdditionalData &additional_data)
+    : PreconditionBase(matrix.get_mpi_communicator())
   {
     initialize(matrix, additional_data);
   }
@@ -241,6 +269,8 @@ namespace PETScWrappers
                               const AdditionalData &additional_data_)
   {
     clear();
+
+    mpi_communicator = matrix_.get_mpi_communicator();
 
     matrix          = static_cast<Mat>(matrix_);
     additional_data = additional_data_;
@@ -272,6 +302,7 @@ namespace PETScWrappers
 
   PreconditionSSOR::PreconditionSSOR(const MatrixBase &    matrix,
                                      const AdditionalData &additional_data)
+    : PreconditionBase(matrix.get_mpi_communicator())
   {
     initialize(matrix, additional_data);
   }
@@ -282,6 +313,8 @@ namespace PETScWrappers
                                const AdditionalData &additional_data_)
   {
     clear();
+
+    mpi_communicator = matrix_.get_mpi_communicator();
 
     matrix          = static_cast<Mat>(matrix_);
     additional_data = additional_data_;
@@ -318,6 +351,7 @@ namespace PETScWrappers
 
   PreconditionICC::PreconditionICC(const MatrixBase &    matrix,
                                    const AdditionalData &additional_data)
+    : PreconditionBase(matrix.get_mpi_communicator())
   {
     initialize(matrix, additional_data);
   }
@@ -328,6 +362,8 @@ namespace PETScWrappers
                               const AdditionalData &additional_data_)
   {
     clear();
+
+    mpi_communicator = matrix_.get_mpi_communicator();
 
     matrix          = static_cast<Mat>(matrix_);
     additional_data = additional_data_;
@@ -359,6 +395,7 @@ namespace PETScWrappers
 
   PreconditionILU::PreconditionILU(const MatrixBase &    matrix,
                                    const AdditionalData &additional_data)
+    : PreconditionBase(matrix.get_mpi_communicator())
   {
     initialize(matrix, additional_data);
   }
@@ -369,6 +406,8 @@ namespace PETScWrappers
                               const AdditionalData &additional_data_)
   {
     clear();
+
+    mpi_communicator = matrix_.get_mpi_communicator();
 
     matrix          = static_cast<Mat>(matrix_);
     additional_data = additional_data_;
@@ -501,6 +540,7 @@ namespace PETScWrappers
   PreconditionBoomerAMG::PreconditionBoomerAMG(
     const MPI_Comm &      comm,
     const AdditionalData &additional_data_)
+    : PreconditionBase(comm)
   {
     additional_data = additional_data_;
 
@@ -518,12 +558,16 @@ namespace PETScWrappers
   }
 
 
+
   PreconditionBoomerAMG::PreconditionBoomerAMG(
     const MatrixBase &    matrix,
     const AdditionalData &additional_data)
+    : PreconditionBase(matrix.get_mpi_communicator())
   {
     initialize(matrix, additional_data);
   }
+
+
 
   void
   PreconditionBoomerAMG::initialize()
@@ -633,12 +677,16 @@ namespace PETScWrappers
 #  endif
   }
 
+
+
   void
   PreconditionBoomerAMG::initialize(const MatrixBase &    matrix_,
                                     const AdditionalData &additional_data_)
   {
 #  ifdef DEAL_II_PETSC_WITH_HYPRE
     clear();
+
+    mpi_communicator = matrix_.get_mpi_communicator();
 
     matrix          = static_cast<Mat>(matrix_);
     additional_data = additional_data_;
@@ -679,6 +727,7 @@ namespace PETScWrappers
   PreconditionParaSails::PreconditionParaSails(
     const MatrixBase &    matrix,
     const AdditionalData &additional_data)
+    : PreconditionBase(matrix.get_mpi_communicator())
   {
     initialize(matrix, additional_data);
   }
@@ -689,6 +738,8 @@ namespace PETScWrappers
                                     const AdditionalData &additional_data_)
   {
     clear();
+
+    mpi_communicator = matrix_.get_mpi_communicator();
 
     matrix          = static_cast<Mat>(matrix_);
     additional_data = additional_data_;
@@ -773,6 +824,7 @@ namespace PETScWrappers
 
   PreconditionNone::PreconditionNone(const MatrixBase &    matrix,
                                      const AdditionalData &additional_data)
+    : PreconditionBase(matrix.get_mpi_communicator())
   {
     initialize(matrix, additional_data);
   }
@@ -783,6 +835,8 @@ namespace PETScWrappers
                                const AdditionalData &additional_data_)
   {
     clear();
+
+    mpi_communicator = matrix_.get_mpi_communicator();
 
     matrix          = static_cast<Mat>(matrix_);
     additional_data = additional_data_;
@@ -814,6 +868,7 @@ namespace PETScWrappers
 
   PreconditionLU::PreconditionLU(const MatrixBase &    matrix,
                                  const AdditionalData &additional_data)
+    : PreconditionBase(matrix.get_mpi_communicator())
   {
     initialize(matrix, additional_data);
   }
@@ -824,6 +879,8 @@ namespace PETScWrappers
                              const AdditionalData &additional_data_)
   {
     clear();
+
+    mpi_communicator = matrix_.get_mpi_communicator();
 
     matrix          = static_cast<Mat>(matrix_);
     additional_data = additional_data_;
@@ -866,10 +923,13 @@ namespace PETScWrappers
     , coords(coords)
   {}
 
+
+
   template <int dim>
   PreconditionBDDC<dim>::PreconditionBDDC(
     const MPI_Comm        comm,
     const AdditionalData &additional_data_)
+    : PreconditionBase(comm)
   {
     additional_data = additional_data_;
 
@@ -879,12 +939,16 @@ namespace PETScWrappers
     initialize();
   }
 
+
+
   template <int dim>
   PreconditionBDDC<dim>::PreconditionBDDC(const MatrixBase &    matrix,
                                           const AdditionalData &additional_data)
+    : PreconditionBase(matrix.get_mpi_communicator())
   {
     initialize(matrix, additional_data);
   }
+
 
 
   template <int dim>
@@ -960,12 +1024,16 @@ namespace PETScWrappers
 #  endif
   }
 
+
+
   template <int dim>
   void
   PreconditionBDDC<dim>::initialize(const MatrixBase &    matrix_,
                                     const AdditionalData &additional_data_)
   {
     clear();
+
+    mpi_communicator = matrix_.get_mpi_communicator();
 
     matrix          = static_cast<Mat>(matrix_);
     additional_data = additional_data_;

--- a/source/lac/petsc_precondition.cc
+++ b/source/lac/petsc_precondition.cc
@@ -41,6 +41,12 @@ namespace PETScWrappers
 
 
 
+  PreconditionBase::PreconditionBase()
+    : PreconditionBase(MPI_COMM_NULL)
+  {}
+
+
+
   PreconditionBase::~PreconditionBase()
   {
     try

--- a/source/lac/petsc_solver.cc
+++ b/source/lac/petsc_solver.cc
@@ -42,9 +42,8 @@ namespace PETScWrappers
 
 
 
-  SolverBase::SolverBase(SolverControl &cn, const MPI_Comm &mpi_communicator)
+  SolverBase::SolverBase(SolverControl &cn)
     : solver_control(cn)
-    , mpi_communicator(mpi_communicator)
   {}
 
 
@@ -74,7 +73,8 @@ namespace PETScWrappers
       {
         solver_data = std::make_unique<SolverData>();
 
-        PetscErrorCode ierr = KSPCreate(mpi_communicator, &solver_data->ksp);
+        PetscErrorCode ierr =
+          KSPCreate(A.get_mpi_communicator(), &solver_data->ksp);
         AssertThrow(ierr == 0, ExcPETScError(ierr));
 
         // let derived classes set the solver
@@ -207,7 +207,7 @@ namespace PETScWrappers
 
     solver_data = std::make_unique<SolverData>();
 
-    ierr = KSPCreate(mpi_communicator, &solver_data->ksp);
+    ierr = KSPCreate(preconditioner.get_mpi_communicator(), &solver_data->ksp);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
     // let derived classes set the solver
@@ -246,10 +246,10 @@ namespace PETScWrappers
 
 
 
-  SolverRichardson::SolverRichardson(SolverControl &       cn,
-                                     const MPI_Comm &      mpi_communicator,
+  SolverRichardson::SolverRichardson(SolverControl &cn,
+                                     const MPI_Comm &,
                                      const AdditionalData &data)
-    : SolverBase(cn, mpi_communicator)
+    : SolverBase(cn)
     , additional_data(data)
   {}
 
@@ -294,10 +294,10 @@ namespace PETScWrappers
 
   /* ---------------------- SolverChebychev ------------------------ */
 
-  SolverChebychev::SolverChebychev(SolverControl &       cn,
-                                   const MPI_Comm &      mpi_communicator,
+  SolverChebychev::SolverChebychev(SolverControl &cn,
+                                   const MPI_Comm &,
                                    const AdditionalData &data)
-    : SolverBase(cn, mpi_communicator)
+    : SolverBase(cn)
     , additional_data(data)
   {}
 
@@ -318,10 +318,10 @@ namespace PETScWrappers
 
   /* ---------------------- SolverCG ------------------------ */
 
-  SolverCG::SolverCG(SolverControl &       cn,
-                     const MPI_Comm &      mpi_communicator,
+  SolverCG::SolverCG(SolverControl &cn,
+                     const MPI_Comm &,
                      const AdditionalData &data)
-    : SolverBase(cn, mpi_communicator)
+    : SolverBase(cn)
     , additional_data(data)
   {}
 
@@ -342,10 +342,10 @@ namespace PETScWrappers
 
   /* ---------------------- SolverBiCG ------------------------ */
 
-  SolverBiCG::SolverBiCG(SolverControl &       cn,
-                         const MPI_Comm &      mpi_communicator,
+  SolverBiCG::SolverBiCG(SolverControl &cn,
+                         const MPI_Comm &,
                          const AdditionalData &data)
-    : SolverBase(cn, mpi_communicator)
+    : SolverBase(cn)
     , additional_data(data)
   {}
 
@@ -375,10 +375,10 @@ namespace PETScWrappers
 
 
 
-  SolverGMRES::SolverGMRES(SolverControl &       cn,
-                           const MPI_Comm &      mpi_communicator,
+  SolverGMRES::SolverGMRES(SolverControl &cn,
+                           const MPI_Comm &,
                            const AdditionalData &data)
-    : SolverBase(cn, mpi_communicator)
+    : SolverBase(cn)
     , additional_data(data)
   {}
 
@@ -409,10 +409,10 @@ namespace PETScWrappers
 
   /* ---------------------- SolverBicgstab ------------------------ */
 
-  SolverBicgstab::SolverBicgstab(SolverControl &       cn,
-                                 const MPI_Comm &      mpi_communicator,
+  SolverBicgstab::SolverBicgstab(SolverControl &cn,
+                                 const MPI_Comm &,
                                  const AdditionalData &data)
-    : SolverBase(cn, mpi_communicator)
+    : SolverBase(cn)
     , additional_data(data)
   {}
 
@@ -433,10 +433,10 @@ namespace PETScWrappers
 
   /* ---------------------- SolverCGS ------------------------ */
 
-  SolverCGS::SolverCGS(SolverControl &       cn,
-                       const MPI_Comm &      mpi_communicator,
+  SolverCGS::SolverCGS(SolverControl &cn,
+                       const MPI_Comm &,
                        const AdditionalData &data)
-    : SolverBase(cn, mpi_communicator)
+    : SolverBase(cn)
     , additional_data(data)
   {}
 
@@ -457,10 +457,10 @@ namespace PETScWrappers
 
   /* ---------------------- SolverTFQMR ------------------------ */
 
-  SolverTFQMR::SolverTFQMR(SolverControl &       cn,
-                           const MPI_Comm &      mpi_communicator,
+  SolverTFQMR::SolverTFQMR(SolverControl &cn,
+                           const MPI_Comm &,
                            const AdditionalData &data)
-    : SolverBase(cn, mpi_communicator)
+    : SolverBase(cn)
     , additional_data(data)
   {}
 
@@ -481,10 +481,10 @@ namespace PETScWrappers
 
   /* ---------------------- SolverTCQMR ------------------------ */
 
-  SolverTCQMR::SolverTCQMR(SolverControl &       cn,
-                           const MPI_Comm &      mpi_communicator,
+  SolverTCQMR::SolverTCQMR(SolverControl &cn,
+                           const MPI_Comm &,
                            const AdditionalData &data)
-    : SolverBase(cn, mpi_communicator)
+    : SolverBase(cn)
     , additional_data(data)
   {}
 
@@ -505,10 +505,10 @@ namespace PETScWrappers
 
   /* ---------------------- SolverCR ------------------------ */
 
-  SolverCR::SolverCR(SolverControl &       cn,
-                     const MPI_Comm &      mpi_communicator,
+  SolverCR::SolverCR(SolverControl &cn,
+                     const MPI_Comm &,
                      const AdditionalData &data)
-    : SolverBase(cn, mpi_communicator)
+    : SolverBase(cn)
     , additional_data(data)
   {}
 
@@ -529,10 +529,10 @@ namespace PETScWrappers
 
   /* ---------------------- SolverLSQR ------------------------ */
 
-  SolverLSQR::SolverLSQR(SolverControl &       cn,
-                         const MPI_Comm &      mpi_communicator,
+  SolverLSQR::SolverLSQR(SolverControl &cn,
+                         const MPI_Comm &,
                          const AdditionalData &data)
-    : SolverBase(cn, mpi_communicator)
+    : SolverBase(cn)
     , additional_data(data)
   {}
 
@@ -553,10 +553,10 @@ namespace PETScWrappers
 
   /* ---------------------- SolverPreOnly ------------------------ */
 
-  SolverPreOnly::SolverPreOnly(SolverControl &       cn,
-                               const MPI_Comm &      mpi_communicator,
+  SolverPreOnly::SolverPreOnly(SolverControl &cn,
+                               const MPI_Comm &,
                                const AdditionalData &data)
-    : SolverBase(cn, mpi_communicator)
+    : SolverBase(cn)
     , additional_data(data)
   {}
 
@@ -595,10 +595,10 @@ namespace PETScWrappers
   }
 
 
-  SparseDirectMUMPS::SparseDirectMUMPS(SolverControl &       cn,
-                                       const MPI_Comm &      mpi_communicator,
+  SparseDirectMUMPS::SparseDirectMUMPS(SolverControl &cn,
+                                       const MPI_Comm &,
                                        const AdditionalData &data)
-    : SolverBase(cn, mpi_communicator)
+    : SolverBase(cn)
     , additional_data(data)
     , symmetric_mode(false)
   {}
@@ -668,7 +668,8 @@ namespace PETScWrappers
          * creates the default KSP context and puts it in the location
          * solver_data->ksp
          */
-        PetscErrorCode ierr = KSPCreate(mpi_communicator, &solver_data->ksp);
+        PetscErrorCode ierr =
+          KSPCreate(A.get_mpi_communicator(), &solver_data->ksp);
         AssertThrow(ierr == 0, ExcPETScError(ierr));
 
         /*

--- a/source/lac/petsc_solver.cc
+++ b/source/lac/petsc_solver.cc
@@ -200,6 +200,8 @@ namespace PETScWrappers
     return 0;
   }
 
+
+
   void
   SolverBase::initialize(const PreconditionBase &preconditioner)
   {
@@ -246,11 +248,18 @@ namespace PETScWrappers
 
 
 
-  SolverRichardson::SolverRichardson(SolverControl &cn,
-                                     const MPI_Comm &,
+  SolverRichardson::SolverRichardson(SolverControl &       cn,
                                      const AdditionalData &data)
     : SolverBase(cn)
     , additional_data(data)
+  {}
+
+
+
+  SolverRichardson::SolverRichardson(SolverControl &cn,
+                                     const MPI_Comm &,
+                                     const AdditionalData &data)
+    : SolverRichardson(cn, data)
   {}
 
 
@@ -294,11 +303,17 @@ namespace PETScWrappers
 
   /* ---------------------- SolverChebychev ------------------------ */
 
-  SolverChebychev::SolverChebychev(SolverControl &cn,
-                                   const MPI_Comm &,
+  SolverChebychev::SolverChebychev(SolverControl &       cn,
                                    const AdditionalData &data)
     : SolverBase(cn)
     , additional_data(data)
+  {}
+
+
+  SolverChebychev::SolverChebychev(SolverControl &cn,
+                                   const MPI_Comm &,
+                                   const AdditionalData &data)
+    : SolverChebychev(cn, data)
   {}
 
 
@@ -318,11 +333,16 @@ namespace PETScWrappers
 
   /* ---------------------- SolverCG ------------------------ */
 
+  SolverCG::SolverCG(SolverControl &cn, const AdditionalData &data)
+    : SolverBase(cn)
+    , additional_data(data)
+  {}
+
+
   SolverCG::SolverCG(SolverControl &cn,
                      const MPI_Comm &,
                      const AdditionalData &data)
-    : SolverBase(cn)
-    , additional_data(data)
+    : SolverCG(cn, data)
   {}
 
 
@@ -342,11 +362,16 @@ namespace PETScWrappers
 
   /* ---------------------- SolverBiCG ------------------------ */
 
+  SolverBiCG::SolverBiCG(SolverControl &cn, const AdditionalData &data)
+    : SolverBase(cn)
+    , additional_data(data)
+  {}
+
+
   SolverBiCG::SolverBiCG(SolverControl &cn,
                          const MPI_Comm &,
                          const AdditionalData &data)
-    : SolverBase(cn)
-    , additional_data(data)
+    : SolverBiCG(cn, data)
   {}
 
 
@@ -375,11 +400,16 @@ namespace PETScWrappers
 
 
 
+  SolverGMRES::SolverGMRES(SolverControl &cn, const AdditionalData &data)
+    : SolverBase(cn)
+    , additional_data(data)
+  {}
+
+
   SolverGMRES::SolverGMRES(SolverControl &cn,
                            const MPI_Comm &,
                            const AdditionalData &data)
-    : SolverBase(cn)
-    , additional_data(data)
+    : SolverGMRES(cn, data)
   {}
 
 
@@ -409,11 +439,16 @@ namespace PETScWrappers
 
   /* ---------------------- SolverBicgstab ------------------------ */
 
+  SolverBicgstab::SolverBicgstab(SolverControl &cn, const AdditionalData &data)
+    : SolverBase(cn)
+    , additional_data(data)
+  {}
+
+
   SolverBicgstab::SolverBicgstab(SolverControl &cn,
                                  const MPI_Comm &,
                                  const AdditionalData &data)
-    : SolverBase(cn)
-    , additional_data(data)
+    : SolverBicgstab(cn, data)
   {}
 
 
@@ -433,11 +468,16 @@ namespace PETScWrappers
 
   /* ---------------------- SolverCGS ------------------------ */
 
+  SolverCGS::SolverCGS(SolverControl &cn, const AdditionalData &data)
+    : SolverBase(cn)
+    , additional_data(data)
+  {}
+
+
   SolverCGS::SolverCGS(SolverControl &cn,
                        const MPI_Comm &,
                        const AdditionalData &data)
-    : SolverBase(cn)
-    , additional_data(data)
+    : SolverCGS(cn, data)
   {}
 
 
@@ -457,11 +497,16 @@ namespace PETScWrappers
 
   /* ---------------------- SolverTFQMR ------------------------ */
 
+  SolverTFQMR::SolverTFQMR(SolverControl &cn, const AdditionalData &data)
+    : SolverBase(cn)
+    , additional_data(data)
+  {}
+
+
   SolverTFQMR::SolverTFQMR(SolverControl &cn,
                            const MPI_Comm &,
                            const AdditionalData &data)
-    : SolverBase(cn)
-    , additional_data(data)
+    : SolverTFQMR(cn, data)
   {}
 
 
@@ -481,11 +526,16 @@ namespace PETScWrappers
 
   /* ---------------------- SolverTCQMR ------------------------ */
 
+  SolverTCQMR::SolverTCQMR(SolverControl &cn, const AdditionalData &data)
+    : SolverBase(cn)
+    , additional_data(data)
+  {}
+
+
   SolverTCQMR::SolverTCQMR(SolverControl &cn,
                            const MPI_Comm &,
                            const AdditionalData &data)
-    : SolverBase(cn)
-    , additional_data(data)
+    : SolverTCQMR(cn, data)
   {}
 
 
@@ -505,11 +555,16 @@ namespace PETScWrappers
 
   /* ---------------------- SolverCR ------------------------ */
 
+  SolverCR::SolverCR(SolverControl &cn, const AdditionalData &data)
+    : SolverBase(cn)
+    , additional_data(data)
+  {}
+
+
   SolverCR::SolverCR(SolverControl &cn,
                      const MPI_Comm &,
                      const AdditionalData &data)
-    : SolverBase(cn)
-    , additional_data(data)
+    : SolverCR(cn, data)
   {}
 
 
@@ -529,12 +584,19 @@ namespace PETScWrappers
 
   /* ---------------------- SolverLSQR ------------------------ */
 
-  SolverLSQR::SolverLSQR(SolverControl &cn,
-                         const MPI_Comm &,
-                         const AdditionalData &data)
+  SolverLSQR::SolverLSQR(SolverControl &cn, const AdditionalData &data)
     : SolverBase(cn)
     , additional_data(data)
   {}
+
+
+
+  SolverLSQR::SolverLSQR(SolverControl &cn,
+                         const MPI_Comm &,
+                         const AdditionalData &data)
+    : SolverLSQR(cn, data)
+  {}
+
 
 
   void
@@ -553,11 +615,16 @@ namespace PETScWrappers
 
   /* ---------------------- SolverPreOnly ------------------------ */
 
+  SolverPreOnly::SolverPreOnly(SolverControl &cn, const AdditionalData &data)
+    : SolverBase(cn)
+    , additional_data(data)
+  {}
+
+
   SolverPreOnly::SolverPreOnly(SolverControl &cn,
                                const MPI_Comm &,
                                const AdditionalData &data)
-    : SolverBase(cn)
-    , additional_data(data)
+    : SolverPreOnly(cn, data)
   {}
 
 
@@ -587,21 +654,29 @@ namespace PETScWrappers
 
   /* ---------------------- SparseDirectMUMPS------------------------ */
 
+  SparseDirectMUMPS::SparseDirectMUMPS(SolverControl &       cn,
+                                       const AdditionalData &data)
+    : SolverBase(cn)
+    , additional_data(data)
+    , symmetric_mode(false)
+  {}
+
+
+
+  SparseDirectMUMPS::SparseDirectMUMPS(SolverControl &cn,
+                                       const MPI_Comm &,
+                                       const AdditionalData &data)
+    : SparseDirectMUMPS(cn, data)
+  {}
+
+
+
   SparseDirectMUMPS::SolverDataMUMPS::~SolverDataMUMPS()
   {
     destroy_krylov_solver(ksp);
     // the 'pc' object is owned by the 'ksp' object, and consequently
     // does not have to be destroyed explicitly here
   }
-
-
-  SparseDirectMUMPS::SparseDirectMUMPS(SolverControl &cn,
-                                       const MPI_Comm &,
-                                       const AdditionalData &data)
-    : SolverBase(cn)
-    , additional_data(data)
-    , symmetric_mode(false)
-  {}
 
 
   void
@@ -803,6 +878,8 @@ namespace PETScWrappers
 #  endif
   }
 
+
+
   PetscErrorCode
   SparseDirectMUMPS::convergence_test(KSP /*ksp*/,
                                       const PetscInt      iteration,
@@ -839,6 +916,8 @@ namespace PETScWrappers
 
     return 0;
   }
+
+
 
   void
   SparseDirectMUMPS::set_symmetric_mode(const bool flag)

--- a/tests/arpack/parpack_advection_diffusion_petsc.cc
+++ b/tests/arpack/parpack_advection_diffusion_petsc.cc
@@ -114,7 +114,7 @@ public:
   PETScInverse(const dealii::PETScWrappers::MatrixBase &A,
                dealii::SolverControl &                  cn,
                const MPI_Comm &mpi_communicator = PETSC_COMM_SELF)
-    : solver(cn, mpi_communicator)
+    : solver(cn)
     , matrix(A)
     , preconditioner(matrix)
   {}

--- a/tests/arpack/step-36_parpack.cc
+++ b/tests/arpack/step-36_parpack.cc
@@ -117,7 +117,7 @@ public:
   PETScInverse(const dealii::PETScWrappers::MatrixBase &A,
                dealii::SolverControl &                  cn,
                const MPI_Comm &mpi_communicator = PETSC_COMM_SELF)
-    : solver(cn, mpi_communicator)
+    : solver(cn)
     , matrix(A)
     , preconditioner(matrix)
   {}

--- a/tests/fe/fe_enriched_color_07.cc
+++ b/tests/fe/fe_enriched_color_07.cc
@@ -1576,7 +1576,7 @@ LaplaceProblem<dim>::solve()
 {
   pcout << "...solving" << std::endl;
   SolverControl solver_control(prm.max_iterations, prm.tolerance, false, false);
-  PETScWrappers::SolverCG cg(solver_control, mpi_communicator);
+  PETScWrappers::SolverCG cg(solver_control);
 
   PETScWrappers::PreconditionSOR preconditioner(system_matrix);
 

--- a/tests/mpi/hp_step-40.cc
+++ b/tests/mpi/hp_step-40.cc
@@ -261,7 +261,7 @@ namespace Step40
 
     SolverControl solver_control(dof_handler.n_dofs(), 1e-12);
 
-    PETScWrappers::SolverCG solver(solver_control, mpi_communicator);
+    PETScWrappers::SolverCG solver(solver_control);
 
 #ifndef PETSC_USE_COMPLEX
     PETScWrappers::PreconditionBoomerAMG preconditioner(

--- a/tests/mpi/hp_step-40_variable_01.cc
+++ b/tests/mpi/hp_step-40_variable_01.cc
@@ -267,7 +267,7 @@ namespace Step40
 
     SolverControl solver_control(dof_handler.n_dofs(), 1e-12);
 
-    PETScWrappers::SolverCG solver(solver_control, mpi_communicator);
+    PETScWrappers::SolverCG solver(solver_control);
 
 #ifndef PETSC_USE_COMPLEX
     PETScWrappers::PreconditionBoomerAMG preconditioner(

--- a/tests/mpi/periodicity_01.cc
+++ b/tests/mpi/periodicity_01.cc
@@ -277,7 +277,7 @@ namespace Step40
 
     SolverControl solver_control(dof_handler.n_dofs(), 1e-12, false, false);
 
-    PETScWrappers::SolverCG solver(solver_control, mpi_communicator);
+    PETScWrappers::SolverCG solver(solver_control);
 
 #ifndef PETSC_USE_COMPLEX
     // Ask for a symmetric preconditioner by setting the first parameter in

--- a/tests/mpi/step-40.cc
+++ b/tests/mpi/step-40.cc
@@ -246,7 +246,7 @@ namespace Step40
 
     SolverControl solver_control(dof_handler.n_dofs(), 1e-12);
 
-    PETScWrappers::SolverCG solver(solver_control, mpi_communicator);
+    PETScWrappers::SolverCG solver(solver_control);
 
 #ifndef PETSC_USE_COMPLEX
     PETScWrappers::PreconditionBoomerAMG preconditioner(

--- a/tests/mpi/step-40_cuthill_mckee.cc
+++ b/tests/mpi/step-40_cuthill_mckee.cc
@@ -308,7 +308,7 @@ namespace Step40
 
     SolverControl solver_control(dof_handler.n_dofs(), 1e-12);
 
-    PETScWrappers::SolverCG solver(solver_control, mpi_communicator);
+    PETScWrappers::SolverCG solver(solver_control);
 
 #ifndef PETSC_USE_COMPLEX
     PETScWrappers::PreconditionBoomerAMG preconditioner(

--- a/tests/mpi/step-40_cuthill_mckee_MPI-subset.cc
+++ b/tests/mpi/step-40_cuthill_mckee_MPI-subset.cc
@@ -309,7 +309,7 @@ namespace Step40
 
     SolverControl solver_control(dof_handler.n_dofs(), 1e-12);
 
-    PETScWrappers::SolverCG solver(solver_control, mpi_communicator);
+    PETScWrappers::SolverCG solver(solver_control);
 
 #ifndef PETSC_USE_COMPLEX
     PETScWrappers::PreconditionBoomerAMG preconditioner(

--- a/tests/petsc/bddc.cc
+++ b/tests/petsc/bddc.cc
@@ -156,8 +156,8 @@ main(int argc, char *argv[])
 
   SolverControl solver_control(dof_handler.n_dofs(), 1e-12);
 
-  PETScWrappers::SolverCG            solver(solver_control, MPI_COMM_WORLD);
-  PETScWrappers::PreconditionBDDC<2> preconditioner;
+  PETScWrappers::SolverCG                            solver(solver_control);
+  PETScWrappers::PreconditionBDDC<2>                 preconditioner;
   PETScWrappers::PreconditionBDDC<2>::AdditionalData data;
 
   // Now we setup the dof coordinates if a sufficiently new PETSc is used

--- a/tests/physics/step-18-rotation_matrix.cc
+++ b/tests/physics/step-18-rotation_matrix.cc
@@ -482,7 +482,7 @@ namespace Step18
                                  1e-16 * system_rhs.l2_norm(),
                                  false,
                                  false);
-    PETScWrappers::SolverCG                cg(solver_control, mpi_communicator);
+    PETScWrappers::SolverCG                cg(solver_control);
     PETScWrappers::PreconditionBlockJacobi preconditioner(system_matrix);
     cg.solve(system_matrix,
              distributed_incremental_displacement,

--- a/tests/physics/step-18.cc
+++ b/tests/physics/step-18.cc
@@ -498,7 +498,7 @@ namespace Step18
                                  1e-16 * system_rhs.l2_norm(),
                                  false,
                                  false);
-    PETScWrappers::SolverCG                cg(solver_control, mpi_communicator);
+    PETScWrappers::SolverCG                cg(solver_control);
     PETScWrappers::PreconditionBlockJacobi preconditioner(system_matrix);
     cg.solve(system_matrix,
              distributed_incremental_displacement,

--- a/tests/simplex/step-17.cc
+++ b/tests/simplex/step-17.cc
@@ -327,7 +327,7 @@ namespace Step17
   ElasticProblem<dim>::solve()
   {
     SolverControl solver_control(solution.size(), 1e-8 * system_rhs.l2_norm());
-    PETScWrappers::SolverCG cg(solver_control, mpi_communicator);
+    PETScWrappers::SolverCG cg(solver_control);
 
     // PreconditionBlockJacobi depends on the processor count
     PETScWrappers::PreconditionBlockJacobi preconditioner(system_matrix);

--- a/tests/simplex/step-18.cc
+++ b/tests/simplex/step-18.cc
@@ -701,7 +701,7 @@ namespace Step18
                                  1e-16 * system_rhs.l2_norm());
 
 #ifdef DEAL_II_WITH_PETSC
-    PETScWrappers::SolverCG cg(solver_control, mpi_communicator);
+    PETScWrappers::SolverCG cg(solver_control);
 
     PETScWrappers::PreconditionBlockJacobi preconditioner(system_matrix);
 

--- a/tests/slepc/step-36_parallel.cc
+++ b/tests/slepc/step-36_parallel.cc
@@ -247,8 +247,7 @@ test(std::string solver_name, std::string preconditioner_name)
                                                 1e-15,
                                                 /*log_history*/ false,
                                                 /*log_results*/ false);
-    PETScWrappers::SolverCG linear_solver(linear_solver_control,
-                                          mpi_communicator);
+    PETScWrappers::SolverCG linear_solver(linear_solver_control);
     linear_solver.initialize(*preconditioner);
 
     dealii::SolverControl solver_control(100,

--- a/tests/slepc/step-36_parallel.cc
+++ b/tests/slepc/step-36_parallel.cc
@@ -217,7 +217,7 @@ test(std::string solver_name, std::string preconditioner_name)
 
   // test SLEPc by
   {
-    PETScWrappers::PreconditionBase *preconditioner;
+    PETScWrappers::PreconditionBase *preconditioner = nullptr;
 
     dealii::deallog << preconditioner_name << std::endl;
     if (preconditioner_name == "Jacobi")
@@ -240,11 +240,7 @@ test(std::string solver_name, std::string preconditioner_name)
       }
     else
       {
-        AssertThrow(false, ExcMessage("not supported preconditioner"));
-
-        // make compiler happy
-        preconditioner =
-          new PETScWrappers::PreconditionJacobi(mpi_communicator);
+        AssertThrow(false, ExcMessage("Unsupported preconditioner"));
       }
 
     dealii::SolverControl   linear_solver_control(dof_handler.n_dofs(),

--- a/tests/slepc/step-36_parallel_02.cc
+++ b/tests/slepc/step-36_parallel_02.cc
@@ -247,8 +247,7 @@ test(std::string solver_name, std::string preconditioner_name)
                                                 1e-15,
                                                 /*log_history*/ false,
                                                 /*log_results*/ false);
-    PETScWrappers::SolverCG linear_solver(linear_solver_control,
-                                          mpi_communicator);
+    PETScWrappers::SolverCG linear_solver(linear_solver_control);
     linear_solver.initialize(*preconditioner);
 
     dealii::SolverControl solver_control(100,

--- a/tests/slepc/step-36_parallel_02.cc
+++ b/tests/slepc/step-36_parallel_02.cc
@@ -217,7 +217,7 @@ test(std::string solver_name, std::string preconditioner_name)
 
   // test SLEPc by
   {
-    PETScWrappers::PreconditionBase *preconditioner;
+    PETScWrappers::PreconditionBase *preconditioner = nullptr;
 
     dealii::deallog << preconditioner_name << std::endl;
     if (preconditioner_name == "Jacobi")
@@ -240,11 +240,7 @@ test(std::string solver_name, std::string preconditioner_name)
       }
     else
       {
-        AssertThrow(false, ExcMessage("not supported preconditioner"));
-
-        // make compiler happy
-        preconditioner =
-          new PETScWrappers::PreconditionJacobi(mpi_communicator);
+        AssertThrow(false, ExcMessage("Unsupported preconditioner"));
       }
 
     dealii::SolverControl   linear_solver_control(dof_handler.n_dofs(),

--- a/tests/slepc/step-36_parallel_03.cc
+++ b/tests/slepc/step-36_parallel_03.cc
@@ -247,8 +247,7 @@ test(std::string solver_name, std::string preconditioner_name)
                                                 1e-15,
                                                 /*log_history*/ false,
                                                 /*log_results*/ false);
-    PETScWrappers::SolverCG linear_solver(linear_solver_control,
-                                          mpi_communicator);
+    PETScWrappers::SolverCG linear_solver(linear_solver_control);
     linear_solver.initialize(*preconditioner);
 
     dealii::SolverControl solver_control(100,

--- a/tests/slepc/step-36_parallel_03.cc
+++ b/tests/slepc/step-36_parallel_03.cc
@@ -217,7 +217,7 @@ test(std::string solver_name, std::string preconditioner_name)
 
   // test SLEPc by
   {
-    PETScWrappers::PreconditionBase *preconditioner;
+    PETScWrappers::PreconditionBase *preconditioner = nullptr;
 
     dealii::deallog << preconditioner_name << std::endl;
     if (preconditioner_name == "Jacobi")
@@ -240,11 +240,7 @@ test(std::string solver_name, std::string preconditioner_name)
       }
     else
       {
-        AssertThrow(false, ExcMessage("not supported preconditioner"));
-
-        // make compiler happy
-        preconditioner =
-          new PETScWrappers::PreconditionJacobi(mpi_communicator);
+        AssertThrow(false, ExcMessage("Unsupported preconditioner"));
       }
 
     dealii::SolverControl   linear_solver_control(dof_handler.n_dofs(),


### PR DESCRIPTION
This addresses the first part of the concerns raised in #14428 (@marcfehling @kronbichler FYI). The patch removes the need to store the MPI communicator in the PETSc `SolverBase` class and instead gets the information from other places. 

There is a small hiccup in the scheme in that, for some use cases with SLEPc, we need to be able to query the MPI communicator from the PETSc `PreconditionBase` class. That class does not currently store this information, but fortunately, all derived classes have this information and can provide it. So this does not present a problem from an interface perspective.

This patch only addresses the issue of whether PETSc solvers store a the communicator. They now no longer do, and consequently, the separate communicators given to their constructors are ignored. I will change the constructor calls in a second step to remove the communicator object, but thought I'd post this patch here already.

The patch passes all PETSc and SLEPc tests on my system.

/rebuild