### PR TITLE
Add operator==/!= also for TriaIterator and TriaActiveIterator.

### DIFF
--- a/include/deal.II/grid/tria_iterator.h
+++ b/include/deal.II/grid/tria_iterator.h
@@ -689,6 +689,19 @@ public:
   operator=(const TriaRawIterator<OtherAccessor> &);
 
   /**
+   * Compare for equality.
+   */
+  template <typename OtherAccessor = Accessor>
+  std::enable_if_t<std::is_convertible<OtherAccessor, Accessor>::value, bool>
+  operator==(const TriaRawIterator<OtherAccessor> &) const;
+
+  /**
+   * Compare for inequality.
+   */
+  bool
+  operator!=(const TriaRawIterator<Accessor> &) const;
+
+  /**
    * @name Advancement of iterators
    */
   /** @{ */
@@ -888,6 +901,19 @@ public:
   template <class OtherAccessor>
   TriaActiveIterator<Accessor> &
   operator=(const TriaIterator<OtherAccessor> &);
+
+  /**
+   * Compare for equality.
+   */
+  template <typename OtherAccessor = Accessor>
+  std::enable_if_t<std::is_convertible<OtherAccessor, Accessor>::value, bool>
+  operator==(const TriaRawIterator<OtherAccessor> &) const;
+
+  /**
+   * Compare for inequality.
+   */
+  bool
+  operator!=(const TriaRawIterator<Accessor> &) const;
 
   /**
    * Prefix <tt>++</tt> operator: <tt>++i</tt>. This operator advances the

--- a/include/deal.II/grid/tria_iterator.templates.h
+++ b/include/deal.II/grid/tria_iterator.templates.h
@@ -256,6 +256,26 @@ TriaIterator<Accessor>::operator=(const TriaRawIterator<OtherAccessor> &i)
 
 
 template <typename Accessor>
+template <typename OtherAccessor>
+inline std::enable_if_t<std::is_convertible<OtherAccessor, Accessor>::value,
+                        bool>
+TriaIterator<Accessor>::operator==(
+  const TriaRawIterator<OtherAccessor> &other) const
+{
+  return TriaRawIterator<Accessor>::operator==(other);
+}
+
+
+template <typename Accessor>
+inline bool
+TriaIterator<Accessor>::operator!=(const TriaRawIterator<Accessor> &other) const
+{
+  return TriaRawIterator<Accessor>::operator!=(other);
+}
+
+
+
+template <typename Accessor>
 inline TriaIterator<Accessor> &
 TriaIterator<Accessor>::operator++()
 {
@@ -499,6 +519,27 @@ TriaActiveIterator<Accessor>::operator=(const TriaIterator<Accessor> &i)
 #endif
   return *this;
 }
+
+
+template <typename Accessor>
+template <typename OtherAccessor>
+inline std::enable_if_t<std::is_convertible<OtherAccessor, Accessor>::value,
+                        bool>
+TriaActiveIterator<Accessor>::operator==(
+  const TriaRawIterator<OtherAccessor> &other) const
+{
+  return TriaIterator<Accessor>::operator==(other);
+}
+
+
+template <typename Accessor>
+inline bool
+TriaActiveIterator<Accessor>::operator!=(
+  const TriaRawIterator<Accessor> &other) const
+{
+  return TriaIterator<Accessor>::operator!=(other);
+}
+
 
 
 template <typename Accessor>


### PR DESCRIPTION
I was looking through a recent patch where one of the CI checks uses GCC 9.4 in C++17 mode. We get lots of errors there from strange places, not all of which I'm completely convinced yet are real, but one that I can believe is an issue is that when using `std::pair<iterator,...>::operator==` we fail to find an `operator==` for iterators, possibly because the place where that happens is in a separate namespace `std`, and the compiler is only looking for an `operator==` in the class that is being compared. The underlying reason is that there is an `operator==` in `TriaRawIterator`, but not in the derived classes `TriaIterator` and `TriaActiveIterator`.

There have been changes in recent C++ standards related to lookup of these operators, most recently through the introduction of the spaceship operator in C++20. I don't know whether these lookup changes are responsible for the issue, but it is not hard to work around the issue by simply adding these operators to the derived classes as well, and letting them defer to the base class. This is what this patch does. It should not affect any specific functionality, and simply errs on the side of making sure that it's easy for a compiler to find what it's looking for.

For reference, the failing CI output is here: https://github.com/dealii/dealii/actions/runs/3481702647/jobs/5823128644 which tests https://github.com/dealii/dealii/pull/14435.

/rebuild