### PR TITLE
SparsityPatternBase: redo add_entries() to take pairs.

### DIFF
--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -359,6 +359,11 @@ namespace internal
       bool in_use;
 
       /**
+       * Temporary array for pairs of indices
+       */
+      std::vector<std::pair<size_type, size_type>> new_entries;
+
+      /**
        * Temporary array for row indices
        */
       std::vector<size_type> rows;

--- a/include/deal.II/lac/block_sparsity_pattern.h
+++ b/include/deal.II/lac/block_sparsity_pattern.h
@@ -253,9 +253,7 @@ public:
                   const ArrayView<const size_type> &columns,
                   const bool indices_are_sorted = false) override;
 
-  virtual void
-  add_entries(const ArrayView<const size_type> &rows,
-              const ArrayView<const size_type> &columns) override;
+  using SparsityPatternBase::add_entries;
 
   /**
    * Return number of rows of this matrix, which equals the dimension of the
@@ -992,19 +990,6 @@ BlockSparsityPatternBase<SparsityPatternType>::add_row_entries(
   const bool                        indices_are_sorted)
 {
   add_entries(row, columns.begin(), columns.end(), indices_are_sorted);
-}
-
-
-
-template <typename SparsityPatternType>
-inline void
-BlockSparsityPatternBase<SparsityPatternType>::add_entries(
-  const ArrayView<const size_type> &rows,
-  const ArrayView<const size_type> &columns)
-{
-  AssertDimension(rows.size(), columns.size());
-  for (std::size_t i = 0; i < rows.size(); ++i)
-    add(rows[i], columns[i]);
 }
 
 

--- a/include/deal.II/lac/dynamic_sparsity_pattern.h
+++ b/include/deal.II/lac/dynamic_sparsity_pattern.h
@@ -445,9 +445,7 @@ public:
                   const ArrayView<const size_type> &columns,
                   const bool indices_are_sorted = false) override;
 
-  virtual void
-  add_entries(const ArrayView<const size_type> &rows,
-              const ArrayView<const size_type> &columns) override;
+  using SparsityPatternBase::add_entries;
 
   /**
    * Check if a value at a certain position may be non-zero.

--- a/include/deal.II/lac/sparsity_pattern.h
+++ b/include/deal.II/lac/sparsity_pattern.h
@@ -735,10 +735,7 @@ public:
                   const ArrayView<const size_type> &columns,
                   const bool indices_are_sorted = false) override;
 
-  virtual void
-  add_entries(const ArrayView<const size_type> &rows,
-              const ArrayView<const size_type> &columns) override;
-
+  using SparsityPatternBase::add_entries;
 
   /**
    * Make the sparsity pattern symmetric by adding the sparsity pattern of the

--- a/include/deal.II/lac/sparsity_pattern_base.h
+++ b/include/deal.II/lac/sparsity_pattern_base.h
@@ -23,6 +23,8 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/subscriptor.h>
 
+#include <utility>
+
 DEAL_II_NAMESPACE_OPEN
 
 /**
@@ -98,13 +100,14 @@ public:
                   const bool indices_are_sorted = false) = 0;
 
   /**
-   * General function for adding new entries. By default this function calls
-   * add_row_entries() for each new entry: inheriting classes may want to add a
-   * more optimized implementation.
+   * General function for adding new entries from an unsorted list of pairs.
+   *
+   * This function is useful when multiple entries need to be added which do
+   * not correspond to a particular row, e.g., when assembling a flux sparsity
+   * pattern.
    */
   virtual void
-  add_entries(const ArrayView<const size_type> &rows,
-              const ArrayView<const size_type> &columns);
+  add_entries(const ArrayView<const std::pair<size_type, size_type>> &entries);
 
 protected:
   /**
@@ -160,19 +163,6 @@ inline SparsityPatternBase::size_type
 SparsityPatternBase::n_cols() const
 {
   return cols;
-}
-
-
-
-inline void
-SparsityPatternBase::add_entries(const ArrayView<const size_type> &rows,
-                                 const ArrayView<const size_type> &columns)
-{
-  AssertDimension(rows.size(), columns.size());
-  for (std::size_t i = 0; i < rows.size(); ++i)
-    add_row_entries(rows[i],
-                    make_array_view(columns.begin() + i,
-                                    columns.begin() + i + 1));
 }
 
 

--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -778,9 +778,7 @@ namespace TrilinosWrappers
                     const ArrayView<const size_type> &columns,
                     const bool indices_are_sorted = false) override;
 
-    virtual void
-    add_entries(const ArrayView<const size_type> &rows,
-                const ArrayView<const size_type> &columns) override;
+    using SparsityPatternBase::add_entries;
 
     /** @} */
     /**

--- a/source/lac/CMakeLists.txt
+++ b/source/lac/CMakeLists.txt
@@ -42,6 +42,7 @@ SET(_unity_include_src
   sparse_matrix_ez.cc
   sparse_mic.cc
   sparse_vanka.cc
+  sparsity_pattern_base.cc
   sparsity_pattern.cc
   sparsity_tools.cc
   tensor_product_matrix.cc

--- a/source/lac/dynamic_sparsity_pattern.cc
+++ b/source/lac/dynamic_sparsity_pattern.cc
@@ -358,17 +358,6 @@ DynamicSparsityPattern::add_row_entries(
 
 
 
-void
-DynamicSparsityPattern::add_entries(const ArrayView<const size_type> &rows,
-                                    const ArrayView<const size_type> &columns)
-{
-  AssertDimension(rows.size(), columns.size());
-  for (std::size_t i = 0; i < rows.size(); ++i)
-    add(rows[i], columns[i]);
-}
-
-
-
 bool
 DynamicSparsityPattern::exists(const size_type i, const size_type j) const
 {

--- a/source/lac/sparsity_pattern.cc
+++ b/source/lac/sparsity_pattern.cc
@@ -839,17 +839,6 @@ SparsityPattern::add_row_entries(const size_type &                 row,
 
 
 void
-SparsityPattern::add_entries(const ArrayView<const size_type> &rows,
-                             const ArrayView<const size_type> &columns)
-{
-  AssertDimension(rows.size(), columns.size());
-  for (std::size_t i = 0; i < rows.size(); ++i)
-    add(rows[i], columns[i]);
-}
-
-
-
-void
 SparsityPattern::symmetrize()
 {
   Assert((rowstart != nullptr) && (colnums != nullptr), ExcEmptyObject());

--- a/source/lac/sparsity_pattern_base.cc
+++ b/source/lac/sparsity_pattern_base.cc
@@ -1,0 +1,64 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2022 - 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#include <deal.II/lac/sparsity_pattern_base.h>
+
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+#include <boost/container/small_vector.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
+
+#include <algorithm>
+#include <utility>
+
+DEAL_II_NAMESPACE_OPEN
+
+void
+SparsityPatternBase::add_entries(
+  const ArrayView<const std::pair<size_type, size_type>> &inputs)
+{
+  // We always want to sort so that we can use the optimized add_row_entries()
+  // function
+  boost::container::small_vector<std::pair<size_type, size_type>, 128> entries(
+    inputs.begin(), inputs.end());
+  std::sort(entries.begin(), entries.end());
+  boost::container::small_vector<size_type, 128> columns;
+
+  auto entry = entries.begin();
+  while (entry != entries.end())
+    {
+      const auto row     = entry->first;
+      auto       row_end = entry;
+      while (row_end != entries.end() && row_end->first == row)
+        ++row_end;
+
+      columns.resize(0);
+      columns.reserve(row_end - entry);
+      // Simultaneously transform and uniquify
+      columns.push_back(entry->second);
+      ++entry;
+      while (entry != row_end)
+        {
+          if (columns.back() != entry->second)
+            columns.push_back(entry->second);
+          ++entry;
+        }
+
+      add_row_entries(row,
+                      make_array_view(columns.begin(), columns.end()),
+                      true);
+    }
+}
+
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/trilinos_sparsity_pattern.cc
+++ b/source/lac/trilinos_sparsity_pattern.cc
@@ -990,17 +990,6 @@ namespace TrilinosWrappers
 
 
 
-  void
-  SparsityPattern::add_entries(const ArrayView<const size_type> &rows,
-                               const ArrayView<const size_type> &columns)
-  {
-    AssertDimension(rows.size(), columns.size());
-    for (std::size_t i = 0; i < rows.size(); ++i)
-      add(rows[i], columns[i]);
-  }
-
-
-
   const Epetra_Map &
   SparsityPattern::domain_partitioner() const
   {

--- a/tests/sparsity/sparsity_pattern_base_01.cc
+++ b/tests/sparsity/sparsity_pattern_base_01.cc
@@ -1,0 +1,66 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2001 - 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// Test SparsityPatternBase::add_entries()
+
+
+#include <deal.II/lac/sparsity_pattern_base.h>
+
+#include "../tests.h"
+
+class TestPattern : public SparsityPatternBase
+{
+  using SparsityPatternBase::SparsityPatternBase;
+
+  using SparsityPatternBase::size_type;
+
+  virtual void
+  add_row_entries(const size_type &                 row,
+                  const ArrayView<const size_type> &columns,
+                  const bool indices_are_sorted = false) override
+  {
+    deallog << "row = " << row;
+
+    AssertThrow(std::is_sorted(columns.begin(), columns.end()),
+                ExcInternalError());
+
+    for (const auto &col : columns)
+      deallog << "    " << col;
+
+    deallog << std::endl;
+  }
+};
+
+
+
+int
+main()
+{
+  initlog();
+
+  std::vector<
+    std::pair<SparsityPatternBase::size_type, SparsityPatternBase::size_type>>
+    entries;
+
+  for (unsigned int i = 0; i < 100; ++i)
+    entries.emplace_back(rand() % 10, rand() % 100);
+
+  for (auto &entry : entries)
+    deallog << entry.first << ", " << entry.second << std::endl;
+
+  TestPattern test(100, 100);
+  test.add_entries(make_array_view(entries));
+}

--- a/tests/sparsity/sparsity_pattern_base_01.output
+++ b/tests/sparsity/sparsity_pattern_base_01.output
@@ -1,0 +1,111 @@
+
+DEAL::6, 83
+DEAL::5, 77
+DEAL::5, 93
+DEAL::2, 86
+DEAL::1, 49
+DEAL::7, 62
+DEAL::9, 90
+DEAL::6, 63
+DEAL::6, 40
+DEAL::6, 72
+DEAL::8, 11
+DEAL::9, 67
+DEAL::0, 82
+DEAL::3, 62
+DEAL::5, 67
+DEAL::2, 29
+DEAL::8, 22
+DEAL::7, 69
+DEAL::6, 93
+DEAL::2, 11
+DEAL::3, 29
+DEAL::9, 21
+DEAL::7, 84
+DEAL::4, 98
+DEAL::0, 15
+DEAL::6, 13
+DEAL::0, 91
+DEAL::3, 56
+DEAL::0, 62
+DEAL::1, 96
+DEAL::5, 5
+DEAL::7, 84
+DEAL::5, 36
+DEAL::9, 46
+DEAL::7, 13
+DEAL::5, 24
+DEAL::5, 82
+DEAL::7, 14
+DEAL::4, 34
+DEAL::0, 43
+DEAL::8, 87
+DEAL::8, 76
+DEAL::4, 88
+DEAL::1, 3
+DEAL::9, 54
+DEAL::0, 32
+DEAL::8, 76
+DEAL::2, 39
+DEAL::6, 26
+DEAL::9, 94
+DEAL::0, 95
+DEAL::8, 34
+DEAL::1, 67
+DEAL::2, 97
+DEAL::2, 17
+DEAL::6, 52
+DEAL::0, 1
+DEAL::1, 86
+DEAL::9, 65
+DEAL::9, 44
+DEAL::9, 40
+DEAL::7, 31
+DEAL::1, 97
+DEAL::5, 81
+DEAL::7, 9
+DEAL::6, 67
+DEAL::3, 97
+DEAL::5, 86
+DEAL::3, 6
+DEAL::4, 19
+DEAL::1, 28
+DEAL::9, 32
+DEAL::9, 3
+DEAL::8, 70
+DEAL::5, 8
+DEAL::9, 40
+DEAL::3, 96
+DEAL::5, 18
+DEAL::1, 46
+DEAL::5, 21
+DEAL::8, 79
+DEAL::8, 64
+DEAL::0, 41
+DEAL::0, 93
+DEAL::4, 34
+DEAL::4, 24
+DEAL::6, 87
+DEAL::1, 43
+DEAL::5, 27
+DEAL::6, 59
+DEAL::1, 32
+DEAL::8, 37
+DEAL::7, 75
+DEAL::1, 74
+DEAL::5, 58
+DEAL::7, 29
+DEAL::3, 35
+DEAL::8, 18
+DEAL::1, 43
+DEAL::9, 28
+DEAL::row = 0    1    15    32    41    43    62    82    91    93    95
+DEAL::row = 1    3    28    32    43    46    49    67    74    86    96    97
+DEAL::row = 2    11    17    29    39    86    97
+DEAL::row = 3    6    29    35    56    62    96    97
+DEAL::row = 4    19    24    34    88    98
+DEAL::row = 5    5    8    18    21    24    27    36    58    67    77    81    82    86    93
+DEAL::row = 6    13    26    40    52    59    63    67    72    83    87    93
+DEAL::row = 7    9    13    14    29    31    62    69    75    84
+DEAL::row = 8    11    18    22    34    37    64    70    76    79    87
+DEAL::row = 9    3    21    28    32    40    44    46    54    65    67    90    94


### PR DESCRIPTION
Followup to https://github.com/dealii/dealii/pull/14434#discussion_r1023473309 - perhaps there is a better API we can use to build sparsity patterns.

I added a new function to SparsityPatternBase which sorts its input and then calls the optimized `add_row_entries()` functions - this seems like the right choice for building things when we want to add a lot of entries at once that are not given one row at a time (e.g., flux sparsity patterns). If we add something like this then we can just remove `SparsityPatternBase::add_entries()` since we never use it in the library itself.