### PR TITLE
Fix the generation of ghost particles when there are periodic boundary conditions in a triangulation

### DIFF
--- a/doc/news/changes/minor/20221118Blais
+++ b/doc/news/changes/minor/20221118Blais
@@ -1,5 +1,5 @@
 Improved: Added capability in the particle handler to generate ghost particles 
-in ghost cells close to perioddic boundary conditions
+in ghost cells close to periodic boundary conditions
 <br>
 (Bruno Blais, Audrey Collard-Daigneault, 2022-11-18)
 

--- a/doc/news/changes/minor/20221118Blais
+++ b/doc/news/changes/minor/20221118Blais
@@ -1,5 +1,5 @@
 Improved: Added capability in the particle handler to generate ghost particles 
-in ghost cells close to periodic boundary conditions
+in ghost cells close to periodic boundary conditions.
 <br>
 (Bruno Blais, Audrey Collard-Daigneault, 2022-11-18)
 

--- a/doc/news/changes/minor/20221118Blais
+++ b/doc/news/changes/minor/20221118Blais
@@ -1,0 +1,7 @@
+Improved: Added capability in the particle handler to generate ghost particles 
+in ghost cells close to perioddic boundary conditions
+<br>
+(Bruno Blais, Audrey Collard-Daigneault, 2022-11-18)
+
+
+

--- a/include/deal.II/grid/grid_tools_cache.h
+++ b/include/deal.II/grid/grid_tools_cache.h
@@ -75,7 +75,7 @@ namespace GridTools
      * @param mapping The mapping to use when computing cached objects
      */
     Cache(const Triangulation<dim, spacedim> &tria,
-          const Mapping<dim, spacedim> &      mapping =
+          const Mapping<dim, spacedim>       &mapping =
             (ReferenceCells::get_hypercube<dim>()
 #ifndef _MSC_VER
                .template get_default_linear_mapping<dim, spacedim>()
@@ -169,22 +169,11 @@ namespace GridTools
     get_vertex_to_neighbor_subdomain() const;
 
     /**
-     * Returns the std::map of std::vector of unsigned integer containing
-     * coinciding vertices labeled by an arbitrary element from them. This
-     * feature is used to identify cells which are connected by periodic
-     * boundaries.
+     * Return a map that, for each vertex, lists all the processes whose
+     * subdomains are adjacent to that vertex.
      */
-    const std::map<unsigned int, std::vector<unsigned int>> &
-    get_coinciding_vertex_groups() const;
-
-    /**
-     * Returns the std::map of unsigned integer containing
-     * the label of a group of coinciding vertices. This
-     * feature is used to identify cells which are connected by periodic
-     * boundaries.
-     */
-    const std::map<unsigned int, unsigned int> &
-    get_vertex_to_coinciding_vertex_group() const;
+    const std::map<unsigned int, std::set<types::subdomain_id>> &
+    get_vertices_with_ghost_neighbors() const;
 
     /**
      * Return a reference to the stored triangulation.
@@ -311,20 +300,11 @@ namespace GridTools
     mutable std::vector<std::set<unsigned int>> vertex_to_neighbor_subdomain;
 
     /**
-     * Store an std::map of std::vector of unsigned integer containing
-     * coinciding vertices labeled by an arbitrary element from them.
-     */
-    mutable std::map<unsigned int, std::vector<unsigned int>>
-      coinciding_vertex_groups;
-
-    /**
      * Store an std::map of unsigned integer containing
-     * the label of a group of coinciding vertices.
-     * This std::map is generally used in combination
-     * with the above std::map coinciding_vertex_groups.
+     * the set of subdomains connected to each vertices
      */
-    mutable std::map<unsigned int, unsigned int>
-      vertex_to_coinciding_vertex_group;
+    mutable std::map<unsigned int, std::set<dealii::types::subdomain_id>>
+      vertices_with_ghost_neighbors;
 
     /**
      * Storage for the status of the triangulation signal.

--- a/include/deal.II/grid/grid_tools_cache.h
+++ b/include/deal.II/grid/grid_tools_cache.h
@@ -75,7 +75,7 @@ namespace GridTools
      * @param mapping The mapping to use when computing cached objects
      */
     Cache(const Triangulation<dim, spacedim> &tria,
-          const Mapping<dim, spacedim>       &mapping =
+          const Mapping<dim, spacedim> &      mapping =
             (ReferenceCells::get_hypercube<dim>()
 #ifndef _MSC_VER
                .template get_default_linear_mapping<dim, spacedim>()

--- a/include/deal.II/grid/grid_tools_cache.h
+++ b/include/deal.II/grid/grid_tools_cache.h
@@ -75,7 +75,7 @@ namespace GridTools
      * @param mapping The mapping to use when computing cached objects
      */
     Cache(const Triangulation<dim, spacedim> &tria,
-          const Mapping<dim, spacedim> &      mapping =
+          const Mapping<dim, spacedim>       &mapping =
             (ReferenceCells::get_hypercube<dim>()
 #ifndef _MSC_VER
                .template get_default_linear_mapping<dim, spacedim>()
@@ -167,6 +167,15 @@ namespace GridTools
      */
     const std::vector<std::set<unsigned int>> &
     get_vertex_to_neighbor_subdomain() const;
+
+    /**
+     * TODO
+     */
+    const std::map<unsigned int, std::vector<unsigned int>> &
+    get_coinciding_vertex_groups() const;
+
+    const std::map<unsigned int, unsigned int> &
+    get_vertex_to_coinciding_vertex_group() const;
 
     /**
      * Return a reference to the stored triangulation.
@@ -291,6 +300,20 @@ namespace GridTools
      * subdomain to which a vertex is connected to.
      */
     mutable std::vector<std::set<unsigned int>> vertex_to_neighbor_subdomain;
+
+    /**
+     * Store an std::map of std::vector of unsigned integer containing
+     * coinciding vertices labeled by an arbitrary element from them
+     */
+    mutable std::map<unsigned int, std::vector<unsigned int>>
+      coinciding_vertex_groups;
+
+    /**
+     * Store an std::map of unsigned integer containing
+     * the label of a group of coinciding vertices
+     */
+    mutable std::map<unsigned int, unsigned int>
+      vertex_to_coinciding_vertex_group;
 
     /**
      * Storage for the status of the triangulation signal.

--- a/include/deal.II/grid/grid_tools_cache.h
+++ b/include/deal.II/grid/grid_tools_cache.h
@@ -169,11 +169,20 @@ namespace GridTools
     get_vertex_to_neighbor_subdomain() const;
 
     /**
-     * TODO
+     * Returns the std::map of std::vector of unsigned integer containing
+     * coinciding vertices labeled by an arbitrary element from them. This
+     * feature is used to identify cells which are connected by periodic
+     * boundaries.
      */
     const std::map<unsigned int, std::vector<unsigned int>> &
     get_coinciding_vertex_groups() const;
 
+    /**
+     * Returns the std::map of unsigned integer containing
+     * the label of a group of coinciding vertices. This
+     * feature is used to identify cells which are connected by periodic
+     * boundaries.
+     */
     const std::map<unsigned int, unsigned int> &
     get_vertex_to_coinciding_vertex_group() const;
 
@@ -303,14 +312,16 @@ namespace GridTools
 
     /**
      * Store an std::map of std::vector of unsigned integer containing
-     * coinciding vertices labeled by an arbitrary element from them
+     * coinciding vertices labeled by an arbitrary element from them.
      */
     mutable std::map<unsigned int, std::vector<unsigned int>>
       coinciding_vertex_groups;
 
     /**
      * Store an std::map of unsigned integer containing
-     * the label of a group of coinciding vertices
+     * the label of a group of coinciding vertices.
+     * This std::map is generally used in combination
+     * with the above std::map coinciding_vertex_groups.
      */
     mutable std::map<unsigned int, unsigned int>
       vertex_to_coinciding_vertex_group;

--- a/include/deal.II/grid/grid_tools_cache.h
+++ b/include/deal.II/grid/grid_tools_cache.h
@@ -301,7 +301,7 @@ namespace GridTools
 
     /**
      * Store an std::map of unsigned integer containing
-     * the set of subdomains connected to each vertices
+     * the set of subdomains connected to each vertex.
      */
     mutable std::map<unsigned int, std::set<dealii::types::subdomain_id>>
       vertices_with_ghost_neighbors;

--- a/include/deal.II/grid/grid_tools_cache_update_flags.h
+++ b/include/deal.II/grid/grid_tools_cache_update_flags.h
@@ -88,7 +88,7 @@ namespace GridTools
      * Update the coinciding vertex groups as well as the
      * vertex_to_coinciding_vertex_group
      */
-    update_collection_of_coinciding_vertices = 0x200,
+    update_vertex_with_ghost_neighbors = 0x200,
 
     /**
      * Update all objects.

--- a/include/deal.II/grid/grid_tools_cache_update_flags.h
+++ b/include/deal.II/grid/grid_tools_cache_update_flags.h
@@ -85,7 +85,8 @@ namespace GridTools
     update_vertex_to_neighbor_subdomain = 0x100,
 
     /**
-     * Update the information about which subdomains are connected to each vertex.
+     * Update the information about which subdomains are connected to each
+     * vertex.
      */
     update_vertex_with_ghost_neighbors = 0x200,
 

--- a/include/deal.II/grid/grid_tools_cache_update_flags.h
+++ b/include/deal.II/grid/grid_tools_cache_update_flags.h
@@ -85,6 +85,12 @@ namespace GridTools
     update_vertex_to_neighbor_subdomain = 0x100,
 
     /**
+     * Update the coinciding vertex groups as well as the
+     * vertex_to_coinciding_vertex_group
+     */
+    update_collection_of_coinciding_vertices = 0x200,
+
+    /**
      * Update all objects.
      */
     update_all = 0xFFF,

--- a/include/deal.II/grid/grid_tools_cache_update_flags.h
+++ b/include/deal.II/grid/grid_tools_cache_update_flags.h
@@ -85,8 +85,7 @@ namespace GridTools
     update_vertex_to_neighbor_subdomain = 0x100,
 
     /**
-     * Update the coinciding vertex groups as well as the
-     * vertex_to_coinciding_vertex_group
+     * Update the information about which subdomains are connected to each vertex.
      */
     update_vertex_with_ghost_neighbors = 0x200,
 

--- a/source/grid/grid_tools_cache.cc
+++ b/source/grid/grid_tools_cache.cc
@@ -26,7 +26,7 @@ namespace GridTools
 {
   template <int dim, int spacedim>
   Cache<dim, spacedim>::Cache(const Triangulation<dim, spacedim> &tria,
-                              const Mapping<dim, spacedim>       &mapping)
+                              const Mapping<dim, spacedim> &      mapping)
     : update_flags(update_all)
     , tria(&tria)
     , mapping(&mapping)

--- a/source/grid/grid_tools_cache.cc
+++ b/source/grid/grid_tools_cache.cc
@@ -26,7 +26,7 @@ namespace GridTools
 {
   template <int dim, int spacedim>
   Cache<dim, spacedim>::Cache(const Triangulation<dim, spacedim> &tria,
-                              const Mapping<dim, spacedim> &      mapping)
+                              const Mapping<dim, spacedim>       &mapping)
     : update_flags(update_all)
     , tria(&tria)
     , mapping(&mapping)
@@ -216,6 +216,36 @@ namespace GridTools
         update_flags = update_flags & ~update_vertex_to_neighbor_subdomain;
       }
     return vertex_to_neighbor_subdomain;
+  }
+
+  template <int dim, int spacedim>
+  const std::map<unsigned int, std::vector<unsigned int>> &
+  Cache<dim, spacedim>::get_coinciding_vertex_groups() const
+  {
+    if (update_flags & update_collection_of_coinciding_vertices)
+      {
+        GridTools::collect_coinciding_vertices(
+          *tria, coinciding_vertex_groups, vertex_to_coinciding_vertex_group);
+
+        update_flags = update_flags & ~update_collection_of_coinciding_vertices;
+      }
+
+    return coinciding_vertex_groups;
+  }
+
+  template <int dim, int spacedim>
+  const std::map<unsigned int, unsigned int> &
+  Cache<dim, spacedim>::get_vertex_to_coinciding_vertex_group() const
+  {
+    if (update_flags & update_collection_of_coinciding_vertices)
+      {
+        GridTools::collect_coinciding_vertices(
+          *tria, coinciding_vertex_groups, vertex_to_coinciding_vertex_group);
+
+        update_flags = update_flags & ~update_collection_of_coinciding_vertices;
+      }
+
+    return vertex_to_coinciding_vertex_group;
   }
 
 #include "grid_tools_cache.inst"

--- a/source/grid/grid_tools_cache.cc
+++ b/source/grid/grid_tools_cache.cc
@@ -26,7 +26,7 @@ namespace GridTools
 {
   template <int dim, int spacedim>
   Cache<dim, spacedim>::Cache(const Triangulation<dim, spacedim> &tria,
-                              const Mapping<dim, spacedim> &      mapping)
+                              const Mapping<dim, spacedim>       &mapping)
     : update_flags(update_all)
     , tria(&tria)
     , mapping(&mapping)
@@ -219,33 +219,18 @@ namespace GridTools
   }
 
   template <int dim, int spacedim>
-  const std::map<unsigned int, std::vector<unsigned int>> &
-  Cache<dim, spacedim>::get_coinciding_vertex_groups() const
+  const std::map<unsigned int, std::set<types::subdomain_id>> &
+  Cache<dim, spacedim>::get_vertices_with_ghost_neighbors() const
   {
-    if (update_flags & update_collection_of_coinciding_vertices)
+    if (update_flags & update_vertex_with_ghost_neighbors)
       {
-        GridTools::collect_coinciding_vertices(
-          *tria, coinciding_vertex_groups, vertex_to_coinciding_vertex_group);
+        vertices_with_ghost_neighbors =
+          GridTools::compute_vertices_with_ghost_neighbors(*tria);
 
-        update_flags = update_flags & ~update_collection_of_coinciding_vertices;
+        update_flags = update_flags & ~update_vertex_with_ghost_neighbors;
       }
 
-    return coinciding_vertex_groups;
-  }
-
-  template <int dim, int spacedim>
-  const std::map<unsigned int, unsigned int> &
-  Cache<dim, spacedim>::get_vertex_to_coinciding_vertex_group() const
-  {
-    if (update_flags & update_collection_of_coinciding_vertices)
-      {
-        GridTools::collect_coinciding_vertices(
-          *tria, coinciding_vertex_groups, vertex_to_coinciding_vertex_group);
-
-        update_flags = update_flags & ~update_collection_of_coinciding_vertices;
-      }
-
-    return vertex_to_coinciding_vertex_group;
+    return vertices_with_ghost_neighbors;
   }
 
 #include "grid_tools_cache.inst"

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -77,7 +77,7 @@ namespace Particles
   template <int dim, int spacedim>
   ParticleHandler<dim, spacedim>::ParticleHandler(
     const Triangulation<dim, spacedim> &triangulation,
-    const Mapping<dim, spacedim> &      mapping,
+    const Mapping<dim, spacedim>       &mapping,
     const unsigned int                  n_properties)
     : triangulation(&triangulation, typeid(*this).name())
     , mapping(&mapping, typeid(*this).name())
@@ -117,7 +117,7 @@ namespace Particles
   void
   ParticleHandler<dim, spacedim>::initialize(
     const Triangulation<dim, spacedim> &new_triangulation,
-    const Mapping<dim, spacedim> &      new_mapping,
+    const Mapping<dim, spacedim>       &new_mapping,
     const unsigned int                  n_properties)
   {
     clear();
@@ -577,7 +577,7 @@ namespace Particles
   template <int dim, int spacedim>
   typename ParticleHandler<dim, spacedim>::particle_iterator
   ParticleHandler<dim, spacedim>::insert_particle(
-    const Particle<dim, spacedim> &                                    particle,
+    const Particle<dim, spacedim>                                     &particle,
     const typename Triangulation<dim, spacedim>::active_cell_iterator &cell)
   {
     return insert_particle(particle.get_location(),
@@ -623,7 +623,7 @@ namespace Particles
   template <int dim, int spacedim>
   typename ParticleHandler<dim, spacedim>::particle_iterator
   ParticleHandler<dim, spacedim>::insert_particle(
-    const void *&                                                      data,
+    const void                                                       *&data,
     const typename Triangulation<dim, spacedim>::active_cell_iterator &cell)
   {
     Assert(triangulation != nullptr, ExcInternalError());
@@ -648,8 +648,8 @@ namespace Particles
   template <int dim, int spacedim>
   typename ParticleHandler<dim, spacedim>::particle_iterator
   ParticleHandler<dim, spacedim>::insert_particle(
-    const Point<spacedim> &     position,
-    const Point<dim> &          reference_position,
+    const Point<spacedim>      &position,
+    const Point<dim>           &reference_position,
     const types::particle_index particle_index,
     const typename Triangulation<dim, spacedim>::active_cell_iterator &cell,
     const ArrayView<const double> &properties)
@@ -764,8 +764,8 @@ namespace Particles
   ParticleHandler<dim, spacedim>::insert_global_particles(
     const std::vector<Point<spacedim>> &positions,
     const std::vector<std::vector<BoundingBox<spacedim>>>
-      &                                       global_bounding_boxes,
-    const std::vector<std::vector<double>> &  properties,
+                                             &global_bounding_boxes,
+    const std::vector<std::vector<double>>   &properties,
     const std::vector<types::particle_index> &ids)
   {
     if (!properties.empty())
@@ -1190,7 +1190,7 @@ namespace Particles
     compare_particle_association(
       const unsigned int                 a,
       const unsigned int                 b,
-      const Tensor<1, dim> &             particle_direction,
+      const Tensor<1, dim>              &particle_direction,
       const std::vector<Tensor<1, dim>> &center_directions)
     {
       const double scalar_product_a = center_directions[a] * particle_direction;
@@ -1545,14 +1545,11 @@ namespace Particles
     // In the case of a parallel simulation with periodic boundary conditions
     // the vertices associated with periodic boundaries are not directly
     // connected to the ghost cells but they are connected to the ghost cells
-    // through their coinciding vertices. We gather the information about
-    // the coinciding vertices through the grid cache.
-    const std::map<unsigned int, std::vector<unsigned int>>
-      &coinciding_vertex_groups =
-        triangulation_cache->get_coinciding_vertex_groups();
-    const std::map<unsigned int, unsigned int>
-      &vertex_to_coinciding_vertex_group =
-        triangulation_cache->get_vertex_to_coinciding_vertex_group();
+    // through their coinciding vertices. We gather this information using the
+    // vertices_with_ghost_neighbors map
+    const std::map<unsigned int, std::set<types::subdomain_id>>
+      &vertices_with_ghost_neighbors =
+        triangulation_cache->get_vertices_with_ghost_neighbors();
 
     const std::set<types::subdomain_id> ghost_owners =
       parallel_triangulation->ghost_owners();
@@ -1570,29 +1567,14 @@ namespace Particles
             std::set<unsigned int> cell_to_neighbor_subdomain;
             for (const unsigned int v : cell->vertex_indices())
               {
-                cell_to_neighbor_subdomain.insert(
-                  vertex_to_neighbor_subdomain[cell->vertex_index(v)].begin(),
-                  vertex_to_neighbor_subdomain[cell->vertex_index(v)].end());
-
-                // If the vertex has one or more coinciding vertices, then
-                // all of these vertices, including the current vertex being
-                // looped over are contained inside the
-                // vertex_to_coinciding_vertex_group. Consequently, we loop over
-                // the full content of the coinciding vertex group which will
-                // include the current vertex. When we reach the current vertex,
-                // we skip it to avoid repetition.
-                if (vertex_to_coinciding_vertex_group.find(cell->vertex_index(
-                      v)) != vertex_to_coinciding_vertex_group.end())
+                if (vertices_with_ghost_neighbors.find(cell->vertex_index(v)) !=
+                    vertices_with_ghost_neighbors.end())
                   {
-                    for (const unsigned int cv : coinciding_vertex_groups.at(
-                           vertex_to_coinciding_vertex_group.at(
-                             cell->vertex_index(v))))
-                      {
-                        if (cv != cell->vertex_index(v))
-                          cell_to_neighbor_subdomain.insert(
-                            vertex_to_neighbor_subdomain[cv].begin(),
-                            vertex_to_neighbor_subdomain[cv].end());
-                      }
+                    cell_to_neighbor_subdomain.insert(
+                      vertices_with_ghost_neighbors.at(cell->vertex_index(v))
+                        .begin(),
+                      vertices_with_ghost_neighbors.at(cell->vertex_index(v))
+                        .end());
                   }
               }
 
@@ -1669,7 +1651,7 @@ namespace Particles
     const std::map<
       types::subdomain_id,
       std::vector<typename Triangulation<dim, spacedim>::active_cell_iterator>>
-      &        send_cells,
+              &send_cells,
     const bool build_cache)
   {
     Assert(triangulation != nullptr, ExcInternalError());
@@ -2073,7 +2055,7 @@ namespace Particles
   template <int dim, int spacedim>
   void
   ParticleHandler<dim, spacedim>::register_additional_store_load_functions(
-    const std::function<std::size_t()> &                            size_callb,
+    const std::function<std::size_t()>                             &size_callb,
     const std::function<void *(const particle_iterator &, void *)> &store_callb,
     const std::function<const void *(const particle_iterator &, const void *)>
       &load_callb)
@@ -2203,7 +2185,7 @@ namespace Particles
     const auto callback_function =
       [this](
         const typename Triangulation<dim, spacedim>::cell_iterator
-          &                                                     cell_iterator,
+                                                               &cell_iterator,
         const typename Triangulation<dim, spacedim>::CellStatus cell_status) {
         return this->pack_callback(cell_iterator, cell_status);
       };
@@ -2360,7 +2342,7 @@ namespace Particles
   template <int dim, int spacedim>
   void
   ParticleHandler<dim, spacedim>::unpack_callback(
-    const typename Triangulation<dim, spacedim>::cell_iterator &    cell,
+    const typename Triangulation<dim, spacedim>::cell_iterator     &cell,
     const typename Triangulation<dim, spacedim>::CellStatus         status,
     const boost::iterator_range<std::vector<char>::const_iterator> &data_range)
   {
@@ -2394,14 +2376,12 @@ namespace Particles
     // now update particle storage location and properties if necessary
     switch (status)
       {
-        case parallel::TriangulationBase<dim, spacedim>::CELL_PERSIST:
-          {
+          case parallel::TriangulationBase<dim, spacedim>::CELL_PERSIST: {
             // all particles are correctly inserted
           }
           break;
 
-        case parallel::TriangulationBase<dim, spacedim>::CELL_COARSEN:
-          {
+          case parallel::TriangulationBase<dim, spacedim>::CELL_COARSEN: {
             // all particles are in correct cell, but their reference location
             // has changed
             for (auto &particle : loaded_particles_on_cell)
@@ -2414,8 +2394,7 @@ namespace Particles
           }
           break;
 
-        case parallel::TriangulationBase<dim, spacedim>::CELL_REFINE:
-          {
+          case parallel::TriangulationBase<dim, spacedim>::CELL_REFINE: {
             // we need to find the correct child to store the particles and
             // their reference location has changed
             typename particle_container::iterator &cache =

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -1577,7 +1577,7 @@ namespace Particles
                 // If the vertex has one or more coinciding vertices, then
                 // all of these vertices, including the current vertex being
                 // looped over are contained inside the
-                // vertex_to_coinciding_vertex_group Consequently, we loop over
+                // vertex_to_coinciding_vertex_group. Consequently, we loop over
                 // the full content of the coinciding vertex group which will
                 // include the current vertex. When we reach the current vertex,
                 // we skip it to avoid repetition.

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -77,7 +77,7 @@ namespace Particles
   template <int dim, int spacedim>
   ParticleHandler<dim, spacedim>::ParticleHandler(
     const Triangulation<dim, spacedim> &triangulation,
-    const Mapping<dim, spacedim> &      mapping,
+    const Mapping<dim, spacedim>       &mapping,
     const unsigned int                  n_properties)
     : triangulation(&triangulation, typeid(*this).name())
     , mapping(&mapping, typeid(*this).name())
@@ -117,7 +117,7 @@ namespace Particles
   void
   ParticleHandler<dim, spacedim>::initialize(
     const Triangulation<dim, spacedim> &new_triangulation,
-    const Mapping<dim, spacedim> &      new_mapping,
+    const Mapping<dim, spacedim>       &new_mapping,
     const unsigned int                  n_properties)
   {
     clear();
@@ -577,7 +577,7 @@ namespace Particles
   template <int dim, int spacedim>
   typename ParticleHandler<dim, spacedim>::particle_iterator
   ParticleHandler<dim, spacedim>::insert_particle(
-    const Particle<dim, spacedim> &                                    particle,
+    const Particle<dim, spacedim>                                     &particle,
     const typename Triangulation<dim, spacedim>::active_cell_iterator &cell)
   {
     return insert_particle(particle.get_location(),
@@ -623,7 +623,7 @@ namespace Particles
   template <int dim, int spacedim>
   typename ParticleHandler<dim, spacedim>::particle_iterator
   ParticleHandler<dim, spacedim>::insert_particle(
-    const void *&                                                      data,
+    const void                                                       *&data,
     const typename Triangulation<dim, spacedim>::active_cell_iterator &cell)
   {
     Assert(triangulation != nullptr, ExcInternalError());
@@ -648,8 +648,8 @@ namespace Particles
   template <int dim, int spacedim>
   typename ParticleHandler<dim, spacedim>::particle_iterator
   ParticleHandler<dim, spacedim>::insert_particle(
-    const Point<spacedim> &     position,
-    const Point<dim> &          reference_position,
+    const Point<spacedim>      &position,
+    const Point<dim>           &reference_position,
     const types::particle_index particle_index,
     const typename Triangulation<dim, spacedim>::active_cell_iterator &cell,
     const ArrayView<const double> &properties)
@@ -764,8 +764,8 @@ namespace Particles
   ParticleHandler<dim, spacedim>::insert_global_particles(
     const std::vector<Point<spacedim>> &positions,
     const std::vector<std::vector<BoundingBox<spacedim>>>
-      &                                       global_bounding_boxes,
-    const std::vector<std::vector<double>> &  properties,
+                                             &global_bounding_boxes,
+    const std::vector<std::vector<double>>   &properties,
     const std::vector<types::particle_index> &ids)
   {
     if (!properties.empty())
@@ -1190,7 +1190,7 @@ namespace Particles
     compare_particle_association(
       const unsigned int                 a,
       const unsigned int                 b,
-      const Tensor<1, dim> &             particle_direction,
+      const Tensor<1, dim>              &particle_direction,
       const std::vector<Tensor<1, dim>> &center_directions)
     {
       const double scalar_product_a = center_directions[a] * particle_direction;
@@ -1542,6 +1542,18 @@ namespace Particles
     ghost_particles_cache.ghost_particles_by_domain.clear();
     ghost_particles_cache.valid = false;
 
+    // In the case of a parallel simulation with periodic boundary conditions
+    // the vertices associated with periodic boundaries are not directly
+    // connected to the ghost cells but they are connected to the ghost cells
+    // through their coinciding vertices. We loop over the coinciding vertices
+    // to identify cells in which ghost particles must be generated
+    const std::map<unsigned int, std::vector<unsigned int>>
+      coinciding_vertex_groups =
+        triangulation_cache->get_coinciding_vertex_groups();
+    const std::map<unsigned int, unsigned int>
+      vertex_to_coinciding_vertex_group =
+        triangulation_cache->get_vertex_to_coinciding_vertex_group();
+
     const std::set<types::subdomain_id> ghost_owners =
       parallel_triangulation->ghost_owners();
     for (const auto ghost_owner : ghost_owners)
@@ -1561,6 +1573,26 @@ namespace Particles
                 cell_to_neighbor_subdomain.insert(
                   vertex_to_neighbor_subdomain[cell->vertex_index(v)].begin(),
                   vertex_to_neighbor_subdomain[cell->vertex_index(v)].end());
+
+                // If the vertex has one or more coinciding vertices, then
+                // all of these vertices, including the current vertex being
+                // looped over are contained inside the
+                // vertex_to_coinciding_vertex_group Consequently, we loop over
+                // the full content of the coinciding vertex group which will
+                // include the current vertex and we skip the current vertex.
+                if (vertex_to_coinciding_vertex_group.find(cell->vertex_index(
+                      v)) != vertex_to_coinciding_vertex_group.end())
+                  {
+                    for (const unsigned int cv : coinciding_vertex_groups.at(
+                           vertex_to_coinciding_vertex_group.at(
+                             cell->vertex_index(v))))
+                      {
+                        if (cv != cell->vertex_index(v))
+                          cell_to_neighbor_subdomain.insert(
+                            vertex_to_neighbor_subdomain[cv].begin(),
+                            vertex_to_neighbor_subdomain[cv].end());
+                      }
+                  }
               }
 
             if (cell_to_neighbor_subdomain.size() > 0)
@@ -1580,6 +1612,8 @@ namespace Particles
               }
           }
       }
+
+
 
     send_recv_particles(
       ghost_particles_cache.ghost_particles_by_domain,
@@ -1634,7 +1668,7 @@ namespace Particles
     const std::map<
       types::subdomain_id,
       std::vector<typename Triangulation<dim, spacedim>::active_cell_iterator>>
-      &        send_cells,
+              &send_cells,
     const bool build_cache)
   {
     Assert(triangulation != nullptr, ExcInternalError());
@@ -2038,7 +2072,7 @@ namespace Particles
   template <int dim, int spacedim>
   void
   ParticleHandler<dim, spacedim>::register_additional_store_load_functions(
-    const std::function<std::size_t()> &                            size_callb,
+    const std::function<std::size_t()>                             &size_callb,
     const std::function<void *(const particle_iterator &, void *)> &store_callb,
     const std::function<const void *(const particle_iterator &, const void *)>
       &load_callb)
@@ -2168,7 +2202,7 @@ namespace Particles
     const auto callback_function =
       [this](
         const typename Triangulation<dim, spacedim>::cell_iterator
-          &                                                     cell_iterator,
+                                                               &cell_iterator,
         const typename Triangulation<dim, spacedim>::CellStatus cell_status) {
         return this->pack_callback(cell_iterator, cell_status);
       };
@@ -2325,7 +2359,7 @@ namespace Particles
   template <int dim, int spacedim>
   void
   ParticleHandler<dim, spacedim>::unpack_callback(
-    const typename Triangulation<dim, spacedim>::cell_iterator &    cell,
+    const typename Triangulation<dim, spacedim>::cell_iterator     &cell,
     const typename Triangulation<dim, spacedim>::CellStatus         status,
     const boost::iterator_range<std::vector<char>::const_iterator> &data_range)
   {
@@ -2359,14 +2393,12 @@ namespace Particles
     // now update particle storage location and properties if necessary
     switch (status)
       {
-        case parallel::TriangulationBase<dim, spacedim>::CELL_PERSIST:
-          {
+          case parallel::TriangulationBase<dim, spacedim>::CELL_PERSIST: {
             // all particles are correctly inserted
           }
           break;
 
-        case parallel::TriangulationBase<dim, spacedim>::CELL_COARSEN:
-          {
+          case parallel::TriangulationBase<dim, spacedim>::CELL_COARSEN: {
             // all particles are in correct cell, but their reference location
             // has changed
             for (auto &particle : loaded_particles_on_cell)
@@ -2379,8 +2411,7 @@ namespace Particles
           }
           break;
 
-        case parallel::TriangulationBase<dim, spacedim>::CELL_REFINE:
-          {
+          case parallel::TriangulationBase<dim, spacedim>::CELL_REFINE: {
             // we need to find the correct child to store the particles and
             // their reference location has changed
             typename particle_container::iterator &cache =

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -1596,8 +1596,6 @@ namespace Particles
           }
       }
 
-
-
     send_recv_particles(
       ghost_particles_cache.ghost_particles_by_domain,
       std::map<

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -1548,10 +1548,10 @@ namespace Particles
     // through their coinciding vertices. We gather the information about
     // the coinciding vertices through the grid cache.
     const std::map<unsigned int, std::vector<unsigned int>>
-      coinciding_vertex_groups =
+      &coinciding_vertex_groups =
         triangulation_cache->get_coinciding_vertex_groups();
     const std::map<unsigned int, unsigned int>
-      vertex_to_coinciding_vertex_group =
+      &vertex_to_coinciding_vertex_group =
         triangulation_cache->get_vertex_to_coinciding_vertex_group();
 
     const std::set<types::subdomain_id> ghost_owners =

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -77,7 +77,7 @@ namespace Particles
   template <int dim, int spacedim>
   ParticleHandler<dim, spacedim>::ParticleHandler(
     const Triangulation<dim, spacedim> &triangulation,
-    const Mapping<dim, spacedim>       &mapping,
+    const Mapping<dim, spacedim> &      mapping,
     const unsigned int                  n_properties)
     : triangulation(&triangulation, typeid(*this).name())
     , mapping(&mapping, typeid(*this).name())
@@ -117,7 +117,7 @@ namespace Particles
   void
   ParticleHandler<dim, spacedim>::initialize(
     const Triangulation<dim, spacedim> &new_triangulation,
-    const Mapping<dim, spacedim>       &new_mapping,
+    const Mapping<dim, spacedim> &      new_mapping,
     const unsigned int                  n_properties)
   {
     clear();
@@ -577,7 +577,7 @@ namespace Particles
   template <int dim, int spacedim>
   typename ParticleHandler<dim, spacedim>::particle_iterator
   ParticleHandler<dim, spacedim>::insert_particle(
-    const Particle<dim, spacedim>                                     &particle,
+    const Particle<dim, spacedim> &                                    particle,
     const typename Triangulation<dim, spacedim>::active_cell_iterator &cell)
   {
     return insert_particle(particle.get_location(),
@@ -623,7 +623,7 @@ namespace Particles
   template <int dim, int spacedim>
   typename ParticleHandler<dim, spacedim>::particle_iterator
   ParticleHandler<dim, spacedim>::insert_particle(
-    const void                                                       *&data,
+    const void *&                                                      data,
     const typename Triangulation<dim, spacedim>::active_cell_iterator &cell)
   {
     Assert(triangulation != nullptr, ExcInternalError());
@@ -648,8 +648,8 @@ namespace Particles
   template <int dim, int spacedim>
   typename ParticleHandler<dim, spacedim>::particle_iterator
   ParticleHandler<dim, spacedim>::insert_particle(
-    const Point<spacedim>      &position,
-    const Point<dim>           &reference_position,
+    const Point<spacedim> &     position,
+    const Point<dim> &          reference_position,
     const types::particle_index particle_index,
     const typename Triangulation<dim, spacedim>::active_cell_iterator &cell,
     const ArrayView<const double> &properties)
@@ -764,8 +764,8 @@ namespace Particles
   ParticleHandler<dim, spacedim>::insert_global_particles(
     const std::vector<Point<spacedim>> &positions,
     const std::vector<std::vector<BoundingBox<spacedim>>>
-                                             &global_bounding_boxes,
-    const std::vector<std::vector<double>>   &properties,
+      &                                       global_bounding_boxes,
+    const std::vector<std::vector<double>> &  properties,
     const std::vector<types::particle_index> &ids)
   {
     if (!properties.empty())
@@ -1190,7 +1190,7 @@ namespace Particles
     compare_particle_association(
       const unsigned int                 a,
       const unsigned int                 b,
-      const Tensor<1, dim>              &particle_direction,
+      const Tensor<1, dim> &             particle_direction,
       const std::vector<Tensor<1, dim>> &center_directions)
     {
       const double scalar_product_a = center_directions[a] * particle_direction;
@@ -1567,7 +1567,8 @@ namespace Particles
             std::set<unsigned int> cell_to_neighbor_subdomain;
             for (const unsigned int v : cell->vertex_indices())
               {
-                const auto vertex_ghost_neighbors = vertices_with_ghost_neighbors.find(cell->vertex_index(v));
+                const auto vertex_ghost_neighbors =
+                  vertices_with_ghost_neighbors.find(cell->vertex_index(v));
                 if (vertex_ghost_neighbors !=
                     vertices_with_ghost_neighbors.end())
                   {
@@ -1650,7 +1651,7 @@ namespace Particles
     const std::map<
       types::subdomain_id,
       std::vector<typename Triangulation<dim, spacedim>::active_cell_iterator>>
-              &send_cells,
+      &        send_cells,
     const bool build_cache)
   {
     Assert(triangulation != nullptr, ExcInternalError());
@@ -2054,7 +2055,7 @@ namespace Particles
   template <int dim, int spacedim>
   void
   ParticleHandler<dim, spacedim>::register_additional_store_load_functions(
-    const std::function<std::size_t()>                             &size_callb,
+    const std::function<std::size_t()> &                            size_callb,
     const std::function<void *(const particle_iterator &, void *)> &store_callb,
     const std::function<const void *(const particle_iterator &, const void *)>
       &load_callb)
@@ -2184,7 +2185,7 @@ namespace Particles
     const auto callback_function =
       [this](
         const typename Triangulation<dim, spacedim>::cell_iterator
-                                                               &cell_iterator,
+          &                                                     cell_iterator,
         const typename Triangulation<dim, spacedim>::CellStatus cell_status) {
         return this->pack_callback(cell_iterator, cell_status);
       };
@@ -2341,7 +2342,7 @@ namespace Particles
   template <int dim, int spacedim>
   void
   ParticleHandler<dim, spacedim>::unpack_callback(
-    const typename Triangulation<dim, spacedim>::cell_iterator     &cell,
+    const typename Triangulation<dim, spacedim>::cell_iterator &    cell,
     const typename Triangulation<dim, spacedim>::CellStatus         status,
     const boost::iterator_range<std::vector<char>::const_iterator> &data_range)
   {
@@ -2375,12 +2376,14 @@ namespace Particles
     // now update particle storage location and properties if necessary
     switch (status)
       {
-          case parallel::TriangulationBase<dim, spacedim>::CELL_PERSIST: {
+        case parallel::TriangulationBase<dim, spacedim>::CELL_PERSIST:
+          {
             // all particles are correctly inserted
           }
           break;
 
-          case parallel::TriangulationBase<dim, spacedim>::CELL_COARSEN: {
+        case parallel::TriangulationBase<dim, spacedim>::CELL_COARSEN:
+          {
             // all particles are in correct cell, but their reference location
             // has changed
             for (auto &particle : loaded_particles_on_cell)
@@ -2393,7 +2396,8 @@ namespace Particles
           }
           break;
 
-          case parallel::TriangulationBase<dim, spacedim>::CELL_REFINE: {
+        case parallel::TriangulationBase<dim, spacedim>::CELL_REFINE:
+          {
             // we need to find the correct child to store the particles and
             // their reference location has changed
             typename particle_container::iterator &cache =

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -77,7 +77,7 @@ namespace Particles
   template <int dim, int spacedim>
   ParticleHandler<dim, spacedim>::ParticleHandler(
     const Triangulation<dim, spacedim> &triangulation,
-    const Mapping<dim, spacedim>       &mapping,
+    const Mapping<dim, spacedim> &      mapping,
     const unsigned int                  n_properties)
     : triangulation(&triangulation, typeid(*this).name())
     , mapping(&mapping, typeid(*this).name())
@@ -117,7 +117,7 @@ namespace Particles
   void
   ParticleHandler<dim, spacedim>::initialize(
     const Triangulation<dim, spacedim> &new_triangulation,
-    const Mapping<dim, spacedim>       &new_mapping,
+    const Mapping<dim, spacedim> &      new_mapping,
     const unsigned int                  n_properties)
   {
     clear();
@@ -577,7 +577,7 @@ namespace Particles
   template <int dim, int spacedim>
   typename ParticleHandler<dim, spacedim>::particle_iterator
   ParticleHandler<dim, spacedim>::insert_particle(
-    const Particle<dim, spacedim>                                     &particle,
+    const Particle<dim, spacedim> &                                    particle,
     const typename Triangulation<dim, spacedim>::active_cell_iterator &cell)
   {
     return insert_particle(particle.get_location(),
@@ -623,7 +623,7 @@ namespace Particles
   template <int dim, int spacedim>
   typename ParticleHandler<dim, spacedim>::particle_iterator
   ParticleHandler<dim, spacedim>::insert_particle(
-    const void                                                       *&data,
+    const void *&                                                      data,
     const typename Triangulation<dim, spacedim>::active_cell_iterator &cell)
   {
     Assert(triangulation != nullptr, ExcInternalError());
@@ -648,8 +648,8 @@ namespace Particles
   template <int dim, int spacedim>
   typename ParticleHandler<dim, spacedim>::particle_iterator
   ParticleHandler<dim, spacedim>::insert_particle(
-    const Point<spacedim>      &position,
-    const Point<dim>           &reference_position,
+    const Point<spacedim> &     position,
+    const Point<dim> &          reference_position,
     const types::particle_index particle_index,
     const typename Triangulation<dim, spacedim>::active_cell_iterator &cell,
     const ArrayView<const double> &properties)
@@ -764,8 +764,8 @@ namespace Particles
   ParticleHandler<dim, spacedim>::insert_global_particles(
     const std::vector<Point<spacedim>> &positions,
     const std::vector<std::vector<BoundingBox<spacedim>>>
-                                             &global_bounding_boxes,
-    const std::vector<std::vector<double>>   &properties,
+      &                                       global_bounding_boxes,
+    const std::vector<std::vector<double>> &  properties,
     const std::vector<types::particle_index> &ids)
   {
     if (!properties.empty())
@@ -1190,7 +1190,7 @@ namespace Particles
     compare_particle_association(
       const unsigned int                 a,
       const unsigned int                 b,
-      const Tensor<1, dim>              &particle_direction,
+      const Tensor<1, dim> &             particle_direction,
       const std::vector<Tensor<1, dim>> &center_directions)
     {
       const double scalar_product_a = center_directions[a] * particle_direction;
@@ -1669,7 +1669,7 @@ namespace Particles
     const std::map<
       types::subdomain_id,
       std::vector<typename Triangulation<dim, spacedim>::active_cell_iterator>>
-              &send_cells,
+      &        send_cells,
     const bool build_cache)
   {
     Assert(triangulation != nullptr, ExcInternalError());
@@ -2073,7 +2073,7 @@ namespace Particles
   template <int dim, int spacedim>
   void
   ParticleHandler<dim, spacedim>::register_additional_store_load_functions(
-    const std::function<std::size_t()>                             &size_callb,
+    const std::function<std::size_t()> &                            size_callb,
     const std::function<void *(const particle_iterator &, void *)> &store_callb,
     const std::function<const void *(const particle_iterator &, const void *)>
       &load_callb)
@@ -2203,7 +2203,7 @@ namespace Particles
     const auto callback_function =
       [this](
         const typename Triangulation<dim, spacedim>::cell_iterator
-                                                               &cell_iterator,
+          &                                                     cell_iterator,
         const typename Triangulation<dim, spacedim>::CellStatus cell_status) {
         return this->pack_callback(cell_iterator, cell_status);
       };
@@ -2360,7 +2360,7 @@ namespace Particles
   template <int dim, int spacedim>
   void
   ParticleHandler<dim, spacedim>::unpack_callback(
-    const typename Triangulation<dim, spacedim>::cell_iterator     &cell,
+    const typename Triangulation<dim, spacedim>::cell_iterator &    cell,
     const typename Triangulation<dim, spacedim>::CellStatus         status,
     const boost::iterator_range<std::vector<char>::const_iterator> &data_range)
   {
@@ -2394,12 +2394,14 @@ namespace Particles
     // now update particle storage location and properties if necessary
     switch (status)
       {
-          case parallel::TriangulationBase<dim, spacedim>::CELL_PERSIST: {
+        case parallel::TriangulationBase<dim, spacedim>::CELL_PERSIST:
+          {
             // all particles are correctly inserted
           }
           break;
 
-          case parallel::TriangulationBase<dim, spacedim>::CELL_COARSEN: {
+        case parallel::TriangulationBase<dim, spacedim>::CELL_COARSEN:
+          {
             // all particles are in correct cell, but their reference location
             // has changed
             for (auto &particle : loaded_particles_on_cell)
@@ -2412,7 +2414,8 @@ namespace Particles
           }
           break;
 
-          case parallel::TriangulationBase<dim, spacedim>::CELL_REFINE: {
+        case parallel::TriangulationBase<dim, spacedim>::CELL_REFINE:
+          {
             // we need to find the correct child to store the particles and
             // their reference location has changed
             typename particle_container::iterator &cache =

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -1567,14 +1567,13 @@ namespace Particles
             std::set<unsigned int> cell_to_neighbor_subdomain;
             for (const unsigned int v : cell->vertex_indices())
               {
-                if (vertices_with_ghost_neighbors.find(cell->vertex_index(v)) !=
+                const auto vertex_ghost_neighbors = vertices_with_ghost_neighbors.find(cell->vertex_index(v));
+                if (vertex_ghost_neighbors !=
                     vertices_with_ghost_neighbors.end())
                   {
                     cell_to_neighbor_subdomain.insert(
-                      vertices_with_ghost_neighbors.at(cell->vertex_index(v))
-                        .begin(),
-                      vertices_with_ghost_neighbors.at(cell->vertex_index(v))
-                        .end());
+                      vertex_ghost_neighbors->second.begin(),
+                      vertex_ghost_neighbors->second.end());
                   }
               }
 

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -1545,8 +1545,8 @@ namespace Particles
     // In the case of a parallel simulation with periodic boundary conditions
     // the vertices associated with periodic boundaries are not directly
     // connected to the ghost cells but they are connected to the ghost cells
-    // through their coinciding vertices. We loop over the coinciding vertices
-    // to identify cells in which ghost particles must be generated
+    // through their coinciding vertices. We gather the information about
+    // the coinciding vertices through the grid cache.
     const std::map<unsigned int, std::vector<unsigned int>>
       coinciding_vertex_groups =
         triangulation_cache->get_coinciding_vertex_groups();
@@ -1579,7 +1579,8 @@ namespace Particles
                 // looped over are contained inside the
                 // vertex_to_coinciding_vertex_group Consequently, we loop over
                 // the full content of the coinciding vertex group which will
-                // include the current vertex and we skip the current vertex.
+                // include the current vertex. When we reach the current vertex,
+                // we skip it to avoid repetition.
                 if (vertex_to_coinciding_vertex_group.find(cell->vertex_index(
                       v)) != vertex_to_coinciding_vertex_group.end())
                   {

--- a/tests/particles/exchange_ghosts_periodic_01.cc
+++ b/tests/particles/exchange_ghosts_periodic_01.cc
@@ -13,10 +13,12 @@
 //
 // ---------------------------------------------------------------------
 
-
-
-// like particle_handler_06, but tests that the particle handlers function
-// n_locally_owned_particles only counts locally owned particles.
+// This test a triangulation which has a periodic boundary along the x axis.
+// Particles are generated close to the x- and x+ limit of the domain
+// and ghost particles are exchanged. Because the domain is periodic,
+// ghost particles should be generated on both processors even if the cells
+// do not share vertices because they are connected by the periodicity.
+// This test verifies that ghost particles are indeed generated on both cores.
 
 #include <deal.II/distributed/tria.h>
 
@@ -59,7 +61,7 @@ test()
     GridTools::collect_periodic_faces(tr, 0, 1, 0, periodicity_vector);
     tr.add_periodicity(periodicity_vector);
 
-    // both processes create a particle handler with a particle in a
+    // Both processes create a particle handler with a particle in a
     // position that is in a ghost cell to the other process connected by a
     // periodic boundary
     Particles::ParticleHandler<dim, spacedim> particle_handler(tr, mapping);
@@ -88,6 +90,8 @@ test()
 
     particle_handler.sort_particles_into_subdomains_and_cells();
 
+    // We count the number of ghost particles before they are exchanged
+    // The expected result is zero
 
     unsigned int n_ghost_particles = 0;
     for (auto ghost_particle = particle_handler.begin_ghost();
@@ -109,6 +113,9 @@ test()
       {
         ++n_ghost_particles;
       }
+
+    // We count the number of ghost particles after they are exchanged
+    // The expected result is one
 
     deallog << "Number of ghost particles after exchange ghost: "
             << std::to_string(n_ghost_particles) << std::endl;

--- a/tests/particles/exchange_ghosts_periodic_01.cc
+++ b/tests/particles/exchange_ghosts_periodic_01.cc
@@ -68,7 +68,7 @@ test()
     Point<dim>      reference_position;
 
     if (Utilities::MPI::this_mpi_process(tr.get_communicator()) == 0)
-      position(0) = 0.001;
+      position[0] = 0.001;
     else
       position[0] = 0.999;
 

--- a/tests/particles/exchange_ghosts_periodic_01.cc
+++ b/tests/particles/exchange_ghosts_periodic_01.cc
@@ -1,0 +1,135 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// like particle_handler_06, but tests that the particle handlers function
+// n_locally_owned_particles only counts locally owned particles.
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/fe/mapping_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include <deal.II/particles/particle_handler.h>
+
+#include "../tests.h"
+
+template <int dim, int spacedim>
+void
+test()
+{
+  {
+    parallel::distributed::Triangulation<dim, spacedim> tr(MPI_COMM_WORLD);
+
+    // Create a subdivided hyper rectangle with divisions along the x axis
+    // Colorize is set to true to enable setting one set of periodic boundary
+    // conditions along id 0 and 1
+    std::vector<unsigned int> repetitions({6, 1});
+    if (dim == 3)
+      repetitions.push_back(1);
+    Point<spacedim> left;
+    Point<spacedim> right;
+    for (int i = 0; i < spacedim; ++i)
+      right[i] = 1;
+
+    GridGenerator::subdivided_hyper_rectangle(
+      tr, repetitions, left, right, true);
+    MappingQ<dim, spacedim> mapping(1);
+
+
+    // Generate periodic boundary conditions
+    std::vector<GridTools::PeriodicFacePair<
+      typename Triangulation<dim, spacedim>::cell_iterator>>
+      periodicity_vector;
+    GridTools::collect_periodic_faces(tr, 0, 1, 0, periodicity_vector);
+    tr.add_periodicity(periodicity_vector);
+
+    // both processes create a particle handler with a particle in a
+    // position that is in a ghost cell to the other process connected by a
+    // periodic boundary
+    Particles::ParticleHandler<dim, spacedim> particle_handler(tr, mapping);
+
+    Point<spacedim> position;
+    Point<dim>      reference_position;
+
+    if (Utilities::MPI::this_mpi_process(tr.get_communicator()) == 0)
+      position(0) = 0.001;
+    else
+      position[0] = 0.999;
+
+    Particles::Particle<dim, spacedim> particle(
+      position,
+      reference_position,
+      Utilities::MPI::this_mpi_process(tr.get_communicator()));
+
+    // We give a local random cell hint to check that sorting and
+    // transferring ghost particles works.
+    typename Triangulation<dim, spacedim>::active_cell_iterator cell =
+      tr.begin_active();
+    while (!cell->is_locally_owned())
+      ++cell;
+
+    particle_handler.insert_particle(particle, cell);
+
+    particle_handler.sort_particles_into_subdomains_and_cells();
+
+
+    unsigned int n_ghost_particles = 0;
+    for (auto ghost_particle = particle_handler.begin_ghost();
+         ghost_particle != particle_handler.end_ghost();
+         ++ghost_particle)
+      {
+        ++n_ghost_particles;
+      }
+
+    deallog << "Number of ghost particles before exchange ghost: "
+            << std::to_string(n_ghost_particles) << std::endl;
+
+    particle_handler.exchange_ghost_particles();
+
+    n_ghost_particles = 0;
+    for (auto ghost_particle = particle_handler.begin_ghost();
+         ghost_particle != particle_handler.end_ghost();
+         ++ghost_particle)
+      {
+        ++n_ghost_particles;
+      }
+
+    deallog << "Number of ghost particles after exchange ghost: "
+            << std::to_string(n_ghost_particles) << std::endl;
+  }
+
+  deallog << "OK" << std::endl;
+}
+
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  MPILogInitAll all;
+
+  deallog.push("2d/2d");
+  test<2, 2>();
+  deallog.pop();
+  deallog.push("3d/3d");
+  test<3, 3>();
+  deallog.pop();
+}

--- a/tests/particles/exchange_ghosts_periodic_01.mpirun=2.output
+++ b/tests/particles/exchange_ghosts_periodic_01.mpirun=2.output
@@ -1,0 +1,15 @@
+
+DEAL:0:2d/2d::Number of ghost particles before exchange ghost: 0
+DEAL:0:2d/2d::Number of ghost particles after exchange ghost: 1
+DEAL:0:2d/2d::OK
+DEAL:0:3d/3d::Number of ghost particles before exchange ghost: 0
+DEAL:0:3d/3d::Number of ghost particles after exchange ghost: 1
+DEAL:0:3d/3d::OK
+
+DEAL:1:2d/2d::Number of ghost particles before exchange ghost: 0
+DEAL:1:2d/2d::Number of ghost particles after exchange ghost: 1
+DEAL:1:2d/2d::OK
+DEAL:1:3d/3d::Number of ghost particles before exchange ghost: 0
+DEAL:1:3d/3d::Number of ghost particles after exchange ghost: 1
+DEAL:1:3d/3d::OK
+


### PR DESCRIPTION
This PR aims at addressing #14430.

Our solution is to add the matching vertices information to the Grid Tools triangulation cache.
When exchange_ghost_particles is called within the particle handler, we now loop over vertices AND coinciding vertices to identify the subdomains in the vicinity of the cell. This has to be done in the loops over all cells that is initially done. However, some benchmark on our side showed that this had negligible impact(could not measure any on my machines). In most cases, the map is empty and thus the call to find is a trivial return to end. In addition, we avoided the use of if/else statement so as to prevent any type of branch prediction.

This work was done in collaboration my student @acdaigneault 

@gassmoeller I think you volunteered yourself to review.
@kronbichler I second your comment that maps are really not ideal for this scenario. If you want, I would gladly take your suggestions to make a second PR where this information is stored in a more efficient fashion :).



