### PR TITLE
Simplify code

### DIFF
--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -1786,19 +1786,41 @@ namespace
     const unsigned int start = s + 1;
     stream << gmv_cell_type[dim] << '\n';
 
-    stream << start;
-    if (dim >= 1)
+    switch (dim)
       {
-        stream << '\t' << start + d1;
-        if (dim >= 2)
+        case 0:
           {
-            stream << '\t' << start + d2 + d1 << '\t' << start + d2;
-            if (dim >= 3)
-              {
-                stream << '\t' << start + d3 << '\t' << start + d3 + d1 << '\t'
-                       << start + d3 + d2 + d1 << '\t' << start + d3 + d2;
-              }
+            stream << start;
+            break;
           }
+
+        case 1:
+          {
+            stream << start;
+            stream << '\t' << start + d1;
+            break;
+          }
+
+        case 2:
+          {
+            stream << start;
+            stream << '\t' << start + d1;
+            stream << '\t' << start + d2 + d1 << '\t' << start + d2;
+            break;
+          }
+
+        case 3:
+          {
+            stream << start;
+            stream << '\t' << start + d1;
+            stream << '\t' << start + d2 + d1 << '\t' << start + d2;
+            stream << '\t' << start + d3 << '\t' << start + d3 + d1 << '\t'
+                   << start + d3 + d2 + d1 << '\t' << start + d3 + d2;
+            break;
+          }
+
+        default:
+          Assert(false, ExcNotImplemented());
       }
     stream << '\n';
   }
@@ -1832,19 +1854,41 @@ namespace
   {
     const unsigned int start = s + 1;
 
-    stream << start;
-    if (dim >= 1)
+    switch (dim)
       {
-        stream << '\t' << start + d1;
-        if (dim >= 2)
+        case 0:
           {
-            stream << '\t' << start + d2 + d1 << '\t' << start + d2;
-            if (dim >= 3)
-              {
-                stream << '\t' << start + d3 << '\t' << start + d3 + d1 << '\t'
-                       << start + d3 + d2 + d1 << '\t' << start + d3 + d2;
-              }
+            stream << start;
+            break;
           }
+
+        case 1:
+          {
+            stream << start;
+            stream << '\t' << start + d1;
+            break;
+          }
+
+        case 2:
+          {
+            stream << start;
+            stream << '\t' << start + d1;
+            stream << '\t' << start + d2 + d1 << '\t' << start + d2;
+            break;
+          }
+
+        case 3:
+          {
+            stream << start;
+            stream << '\t' << start + d1;
+            stream << '\t' << start + d2 + d1 << '\t' << start + d2;
+            stream << '\t' << start + d3 << '\t' << start + d3 + d1 << '\t'
+                   << start + d3 + d2 + d1 << '\t' << start + d3 + d2;
+            break;
+          }
+
+        default:
+          Assert(false, ExcNotImplemented());
       }
     stream << '\n';
   }
@@ -1934,23 +1978,48 @@ namespace
                         unsigned int d2,
                         unsigned int d3)
   {
-    stream << GeometryInfo<dim>::vertices_per_cell << '\t' << start;
+    stream << GeometryInfo<dim>::vertices_per_cell << '\t';
 
-    if (dim >= 1)
-      stream << '\t' << start + d1;
-    {
-      if (dim >= 2)
-        {
-          stream << '\t' << start + d2 + d1 << '\t' << start + d2;
-          if (dim >= 3)
-            {
-              stream << '\t' << start + d3 << '\t' << start + d3 + d1 << '\t'
-                     << start + d3 + d2 + d1 << '\t' << start + d3 + d2;
-            }
-        }
-    }
+    switch (dim)
+      {
+        case 0:
+          {
+            stream << start;
+            break;
+          }
+
+        case 1:
+          {
+            stream << start;
+            stream << '\t' << start + d1;
+            break;
+          }
+
+        case 2:
+          {
+            stream << start;
+            stream << '\t' << start + d1;
+            stream << '\t' << start + d2 + d1 << '\t' << start + d2;
+            break;
+          }
+
+        case 3:
+          {
+            stream << start;
+            stream << '\t' << start + d1;
+            stream << '\t' << start + d2 + d1 << '\t' << start + d2;
+            stream << '\t' << start + d3 << '\t' << start + d3 + d1 << '\t'
+                   << start + d3 + d2 + d1 << '\t' << start + d3 + d2;
+            break;
+          }
+
+        default:
+          Assert(false, ExcNotImplemented());
+      }
     stream << '\n';
   }
+
+
 
   void
   VtkStream::write_cell_single(const unsigned int   index,

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -3007,24 +3007,68 @@ namespace DataOutBase
           {
             const unsigned int n_subdivisions = patch.n_subdivisions;
             const unsigned int n              = n_subdivisions + 1;
-            // Length of loops in all dimensions
-            const unsigned int n1 = (dim > 0) ? n_subdivisions : 1;
-            const unsigned int n2 = (dim > 1) ? n_subdivisions : 1;
-            const unsigned int n3 = (dim > 2) ? n_subdivisions : 1;
-            // Offsets of outer loops
-            const unsigned int d1 = 1;
-            const unsigned int d2 = n;
-            const unsigned int d3 = n * n;
-            for (unsigned int i3 = 0; i3 < n3; ++i3)
-              for (unsigned int i2 = 0; i2 < n2; ++i2)
-                for (unsigned int i1 = 0; i1 < n1; ++i1)
+
+            switch (dim)
+              {
+                case 0:
                   {
-                    const unsigned int offset =
-                      first_vertex_of_patch + i3 * d3 + i2 * d2 + i1 * d1;
-                    // First write line in x direction
-                    out.template write_cell<dim>(count++, offset, d1, d2, d3);
+                    const unsigned int offset = first_vertex_of_patch;
+                    out.template write_cell<dim>(count++, offset, 0, 0, 0);
+                    break;
                   }
-            // finally update the number of the first vertex of this patch
+                case 1:
+                  {
+                    const unsigned int d1 = 1;
+
+                    for (unsigned int i1 = 0; i1 < n_subdivisions; ++i1)
+                      {
+                        const unsigned int offset =
+                          first_vertex_of_patch + i1 * d1;
+                        out.template write_cell<dim>(count++, offset, d1, 0, 0);
+                      }
+
+                    break;
+                  }
+                case 2:
+                  {
+                    const unsigned int d1 = 1;
+                    const unsigned int d2 = n;
+
+                    for (unsigned int i2 = 0; i2 < n_subdivisions; ++i2)
+                      for (unsigned int i1 = 0; i1 < n_subdivisions; ++i1)
+                        {
+                          const unsigned int offset =
+                            first_vertex_of_patch + i2 * d2 + i1 * d1;
+                          out.template write_cell<dim>(
+                            count++, offset, d1, d2, 0);
+                        }
+
+                    break;
+                  }
+                case 3:
+                  {
+                    const unsigned int d1 = 1;
+                    const unsigned int d2 = n;
+                    const unsigned int d3 = n * n;
+
+                    for (unsigned int i3 = 0; i3 < n_subdivisions; ++i3)
+                      for (unsigned int i2 = 0; i2 < n_subdivisions; ++i2)
+                        for (unsigned int i1 = 0; i1 < n_subdivisions; ++i1)
+                          {
+                            const unsigned int offset = first_vertex_of_patch +
+                                                        i3 * d3 + i2 * d2 +
+                                                        i1 * d1;
+                            out.template write_cell<dim>(
+                              count++, offset, d1, d2, d3);
+                          }
+
+                    break;
+                  }
+                default:
+                  Assert(false, ExcNotImplemented());
+              }
+
+            // Update the number of the first vertex of this patch
             first_vertex_of_patch +=
               Utilities::fixed_power<dim>(n_subdivisions + 1);
           }

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -589,22 +589,37 @@ namespace DataOutBase
     const unsigned int base_entry =
       index * GeometryInfo<dim>::vertices_per_cell;
 
-    internal_add_cell(base_entry + 0, start);
-    if (dim >= 1)
+    switch (dim)
       {
-        internal_add_cell(base_entry + 1, start + d1);
-        if (dim >= 2)
-          {
-            internal_add_cell(base_entry + 2, start + d2 + d1);
-            internal_add_cell(base_entry + 3, start + d2);
-            if (dim >= 3)
-              {
-                internal_add_cell(base_entry + 4, start + d3);
-                internal_add_cell(base_entry + 5, start + d3 + d1);
-                internal_add_cell(base_entry + 6, start + d3 + d2 + d1);
-                internal_add_cell(base_entry + 7, start + d3 + d2);
-              }
-          }
+        case 0:
+          internal_add_cell(base_entry + 0, start);
+          break;
+
+        case 1:
+          internal_add_cell(base_entry + 0, start);
+          internal_add_cell(base_entry + 1, start + d1);
+          break;
+
+        case 2:
+          internal_add_cell(base_entry + 0, start);
+          internal_add_cell(base_entry + 1, start + d1);
+          internal_add_cell(base_entry + 2, start + d2 + d1);
+          internal_add_cell(base_entry + 3, start + d2);
+          break;
+
+        case 3:
+          internal_add_cell(base_entry + 0, start);
+          internal_add_cell(base_entry + 1, start + d1);
+          internal_add_cell(base_entry + 2, start + d2 + d1);
+          internal_add_cell(base_entry + 3, start + d2);
+          internal_add_cell(base_entry + 4, start + d3);
+          internal_add_cell(base_entry + 5, start + d3 + d1);
+          internal_add_cell(base_entry + 6, start + d3 + d2 + d1);
+          internal_add_cell(base_entry + 7, start + d3 + d2);
+          break;
+
+        default:
+          Assert(false, ExcNotImplemented());
       }
   }
 
@@ -3076,6 +3091,8 @@ namespace DataOutBase
 
     out.flush_cells();
   }
+
+
 
   template <int dim, int spacedim, typename StreamType>
   void


### PR DESCRIPTION
For some reason, I find it extremely difficult to read code of the form
```
  f();
  if (dim>=1)
  {
    f();
    if (dim>=2)
    {
       f();
       if (dim>=3)
         f();
    }
  }
```
I find this even worse:
```
  for (unsigned int i3=0; i3<(dim>=3?n:0); ++i3)
    for (unsigned int i2=0; i2<(dim>=2?n:0); ++i2)
      for (unsigned int i1=0; i1<(dim>=1?n:0); ++i1)
        f(i3*n*n+i2*n+i1);
```
This patch avoids some of these constructs in favor of explicit `switch-case` statements that make it easier to understand when and how often each statement is executed. I think it also makes it easier to read the code in general, even though it requires a few lines of code duplication.

Part of #14403.

/rebuild