### PR TITLE
Move declaration of vtu_stream to where it is used.

### DIFF
--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -6167,8 +6167,6 @@ namespace DataOutBase
     }
 
 
-    VtuStream vtu_out(out, flags);
-
     const unsigned int n_data_sets = data_names.size();
     // check against # of data sets in first patch. checks against all other
     // patches are made in write_gmv_reorder_data_vectors
@@ -6247,6 +6245,8 @@ namespace DataOutBase
     out << "  </Points>\n\n";
     //-------------------------------
     // now for the cells
+    VtuStream vtu_out(out, flags);
+
     out << "  <Cells>\n";
     out << "    <DataArray type=\"Int32\" Name=\"connectivity\" format=\""
         << ascii_or_binary << "\">\n";
@@ -6347,16 +6347,16 @@ namespace DataOutBase
         for (unsigned int i = 0; i < cell_types.size(); ++i)
           cell_types_uint8_t[i] = static_cast<std::uint8_t>(cell_types[i]);
 
-        vtu_out << vtu_stringize_array(cell_types_uint8_t,
-                                       flags.compression_level,
-                                       out.precision());
+        out << vtu_stringize_array(cell_types_uint8_t,
+                                   flags.compression_level,
+                                   out.precision());
       }
     else
 #endif
       {
-        vtu_out << vtu_stringize_array(cell_types,
-                                       flags.compression_level,
-                                       out.precision());
+        out << vtu_stringize_array(cell_types,
+                                   flags.compression_level,
+                                   out.precision());
       }
 
     out << '\n';


### PR DESCRIPTION
This shrinks the scope of the variable and makes it easier to see where it is used.

While there, also use the underlying stream rather than vtu_out where possible: There are two places where we output via `vtu_out`, but because of the data type being output, the output really just routes to the underlying stream. We can avoid the indirection by outputting to the underlying stream right away.

Part of #14403.

/rebuild