### PR TITLE
Sparsity pattern base cleanup

### DIFF
--- a/cmake/config/template-arguments.in
+++ b/cmake/config/template-arguments.in
@@ -239,15 +239,6 @@ TRIANGULATIONS := { Triangulation<deal_II_dimension, deal_II_space_dimension>;
                     parallel::shared::Triangulation<deal_II_dimension, deal_II_space_dimension>;
                     parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension>;}
 
-// serial and parallel sparsity pattern types
-SPARSITY_PATTERNS := { SparsityPattern;
-                       DynamicSparsityPattern;
-                       @DEAL_II_EXPAND_TRILINOS_SPARSITY_PATTERN@;
-
-                       BlockSparsityPattern;
-                       BlockDynamicSparsityPattern;
-                       @DEAL_II_EXPAND_TRILINOS_BLOCK_SPARSITY_PATTERN@; }
-
 // all supported logical dimensions
 DIMENSIONS := { 1; 2; 3 }
 

--- a/include/deal.II/matrix_free/dof_info.templates.h
+++ b/include/deal.II/matrix_free/dof_info.templates.h
@@ -24,8 +24,6 @@
 #include <deal.II/base/parallel.h>
 
 #include <deal.II/lac/affine_constraints.h>
-#include <deal.II/lac/dynamic_sparsity_pattern.h>
-#include <deal.II/lac/sparsity_pattern.h>
 
 #include <deal.II/matrix_free/constraint_info.h>
 #include <deal.II/matrix_free/dof_info.h>

--- a/include/deal.II/multigrid/mg_transfer_block.h
+++ b/include/deal.II/multigrid/mg_transfer_block.h
@@ -24,7 +24,6 @@
 
 #include <deal.II/lac/block_sparsity_pattern.h>
 #include <deal.II/lac/block_vector.h>
-#include <deal.II/lac/sparsity_pattern.h>
 #include <deal.II/lac/vector_memory.h>
 
 #include <deal.II/multigrid/mg_base.h>

--- a/include/deal.II/multigrid/mg_transfer_component.h
+++ b/include/deal.II/multigrid/mg_transfer_component.h
@@ -27,7 +27,6 @@
 #include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/block_sparsity_pattern.h>
 #include <deal.II/lac/block_vector.h>
-#include <deal.II/lac/sparsity_pattern.h>
 #include <deal.II/lac/vector_memory.h>
 
 #include <deal.II/multigrid/mg_base.h>

--- a/include/deal.II/multigrid/sparse_matrix_collection.h
+++ b/include/deal.II/multigrid/sparse_matrix_collection.h
@@ -22,6 +22,7 @@
 
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/sparse_matrix.h>
+#include <deal.II/lac/sparsity_pattern.h>
 #include <deal.II/lac/vector.h>
 
 #include <deal.II/multigrid/mg_base.h>

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -27,9 +27,6 @@
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/tria_iterator.h>
 
-#include <deal.II/lac/dynamic_sparsity_pattern.h>
-#include <deal.II/lac/sparsity_tools.h>
-
 #include <algorithm>
 #include <fstream>
 #include <iostream>

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -29,8 +29,6 @@
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/tria_iterator.h>
 
-#include <deal.II/lac/sparsity_pattern.h>
-#include <deal.II/lac/sparsity_tools.h>
 #include <deal.II/lac/vector_memory.h>
 
 #include <algorithm>

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -41,6 +41,7 @@
 
 #include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/sparsity_pattern.h>
+#include <deal.II/lac/sparsity_pattern_base.h>
 #include <deal.II/lac/vector.h>
 
 #include <algorithm>

--- a/source/dofs/dof_tools_sparsity.cc
+++ b/source/dofs/dof_tools_sparsity.cc
@@ -39,10 +39,7 @@
 #include <deal.II/hp/q_collection.h>
 
 #include <deal.II/lac/affine_constraints.h>
-#include <deal.II/lac/block_sparsity_pattern.h>
-#include <deal.II/lac/dynamic_sparsity_pattern.h>
-#include <deal.II/lac/sparsity_pattern.h>
-#include <deal.II/lac/trilinos_sparsity_pattern.h>
+#include <deal.II/lac/sparsity_pattern_base.h>
 #include <deal.II/lac/vector.h>
 
 #include <algorithm>

--- a/source/fe/fe_enriched.cc
+++ b/source/fe/fe_enriched.cc
@@ -17,6 +17,7 @@
 #include <deal.II/fe/fe_enriched.h>
 #include <deal.II/fe/fe_tools.h>
 
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/sparsity_tools.h>
 
 #include <memory>

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -25,7 +25,6 @@
 #  include <deal.II/lac/la_parallel_vector.h>
 #  include <deal.II/lac/sparse_matrix.h>
 #  include <deal.II/lac/sparsity_pattern.h>
-#  include <deal.II/lac/sparsity_tools.h>
 #  include <deal.II/lac/trilinos_precondition.h>
 #  include <deal.II/lac/trilinos_sparsity_pattern.h>
 

--- a/source/matrix_free/dof_info.cc
+++ b/source/matrix_free/dof_info.cc
@@ -18,6 +18,9 @@
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/vectorization.h>
 
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/sparsity_pattern.h>
+
 #include <deal.II/matrix_free/dof_info.templates.h>
 
 #include <iostream>

--- a/source/multigrid/mg_tools.cc
+++ b/source/multigrid/mg_tools.cc
@@ -32,11 +32,9 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include <deal.II/lac/block_sparse_matrix.h>
-#include <deal.II/lac/block_sparsity_pattern.h>
 #include <deal.II/lac/block_vector.h>
-#include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/sparse_matrix.h>
-#include <deal.II/lac/sparsity_pattern.h>
+#include <deal.II/lac/sparsity_pattern_base.h>
 
 #include <deal.II/multigrid/mg_base.h>
 #include <deal.II/multigrid/mg_constrained_dofs.h>

--- a/source/non_matching/coupling.cc
+++ b/source/non_matching/coupling.cc
@@ -31,10 +31,9 @@
 #include <deal.II/lac/petsc_block_sparse_matrix.h>
 #include <deal.II/lac/petsc_sparse_matrix.h>
 #include <deal.II/lac/sparse_matrix.h>
-#include <deal.II/lac/sparsity_pattern.h>
+#include <deal.II/lac/sparsity_pattern_base.h>
 #include <deal.II/lac/trilinos_block_sparse_matrix.h>
 #include <deal.II/lac/trilinos_sparse_matrix.h>
-#include <deal.II/lac/trilinos_sparsity_pattern.h>
 
 #include <deal.II/non_matching/coupling.h>
 


### PR DESCRIPTION
Final followup to #14396 (part 11/11). Part of #13949.

We can now remove `SPARSITY_PATTERNS` from `template-arguments.in` since it is not used anymore. Taken together, removing the templates over the sparsity pattern type lowers the number of symbols in the debug library build from 813005 to 811893.