### PR TITLE
gitignore: ignore clangd files and directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ qtcreator/
 # qt creator
 CMakeLists.txt.user
 
+# clangd
+/.cache
+/.clangd
+
 # misc
 /compile_commands.json
 /.clang_complete


### PR DESCRIPTION
In order to use clangd it is currently necessary to add some
configuration into a .clangd file. Unfortunately, this is very situation
specific and cannot meaningfully be upstreamed. (For example, I need to
manually specify "-std=c++17" to work around the issue that gcc defaults
to c++17 and clang defaults to c++14.)

While at it also ignore the .cache directory where clangd stores its
index.