### PR TITLE
CMake: always export compile_commands.json in deal.II and user projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,8 @@ MESSAGE(STATUS "")
 
 CMAKE_MINIMUM_REQUIRED(VERSION 3.3.0)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
+
 #
 # We support all policy changes up to version 3.3. Thus, explicitly set all
 # policies CMP0001 - CMP0054 to new for version 3.3 (and later) to avoid

--- a/cmake/macros/macro_deal_ii_invoke_autopilot.cmake
+++ b/cmake/macros/macro_deal_ii_invoke_autopilot.cmake
@@ -44,6 +44,8 @@ MACRO(DEAL_II_INVOKE_AUTOPILOT)
     SET(_make_command " $ make")
   ENDIF()
 
+  set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
+
   # Define and setup a compilation target:
   ADD_EXECUTABLE(${TARGET} ${TARGET_SRC})
   DEAL_II_SETUP_TARGET(${TARGET})


### PR DESCRIPTION
Depends on #14463