### PR TITLE
[9.4] Take over #14462 and #14465

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ qtcreator/
 # qt creator
 CMakeLists.txt.user
 
+# clangd
+/.cache
+/.clangd
+
 # misc
 /compile_commands.json
 /.clang_complete

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,8 @@ MESSAGE(STATUS "")
 
 CMAKE_MINIMUM_REQUIRED(VERSION 3.3.0)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
+
 #
 # We support all policy changes up to version 3.3. Thus, explicitly set all
 # policies CMP0001 - CMP0054 to new for version 3.3 (and later) to avoid

--- a/cmake/macros/macro_deal_ii_invoke_autopilot.cmake
+++ b/cmake/macros/macro_deal_ii_invoke_autopilot.cmake
@@ -37,6 +37,8 @@
 
 MACRO(DEAL_II_INVOKE_AUTOPILOT)
 
+  SET(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
+
   # Generator specific values:
   IF(CMAKE_GENERATOR MATCHES "Ninja")
     SET(_make_command "$ ninja")


### PR DESCRIPTION
gitignore: ignore clangd files and directories

CMake: always export compile_commands.json in deal.II and user projects

In reference to #14462 and #14465