### PR TITLE
Update documentation for deal.II+Cuda

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -173,7 +173,6 @@ jobs:
       run: |
         cmake -D CMAKE_BUILD_TYPE=Debug \
               -D CMAKE_CXX_COMPILER=${GITHUB_WORKSPACE}/kokkos/bin/nvcc_wrapper \
-              -D DEAL_II_CUDA_FLAGS='-arch=sm_70' \
               -D DEAL_II_CXX_FLAGS='-Werror -Wno-non-template-friend' \
               -D DEAL_II_EARLY_DEPRECATIONS=ON \
               -D DEAL_II_WITH_CUDA="ON" \

--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -181,7 +181,7 @@ PREDEFINED             = DOXYGEN=1 \
                          DEAL_II_ENABLE_EXTRA_DIAGNOSTICS= \
                          DEAL_II_DISABLE_EXTRA_DIAGNOSTICS= \
                          DEAL_II_DEPRECATED= \
-                         DEAL_II_CUDA_HOST_DEV= \
+                         DEAL_II_HOST_DEV= \
                          DEAL_II_ALWAYS_INLINE= \
                          __device__= \
                          DEAL_II_WITH_ADOLC=1 \

--- a/doc/external-libs/cuda.html
+++ b/doc/external-libs/cuda.html
@@ -13,7 +13,9 @@
     <h1>Installing deal.II with CUDA</h1>
 
     <p>
-      To compile and run CUDA code, you need a CUDA-enabled GPU, appropriate
+      To compile and run CUDA code, you need to use an external Kokkos
+      installation that has been configured with CUDA support.
+      This, in turn, requires a CUDA-enabled GPU, appropriate
       drivers, the CUDA toolkit, and the nvcc compiler. Unlike other libraries,
       you need special hardware and compiler to enable CUDA. Because the
       hardware is always evolving, older GPUs do not support all the
@@ -30,23 +32,7 @@
 
         -DDEAL_II_WITH_CUDA=ON
       </pre>
-      Depending on you system, this may be enough to get CUDA to work. If
-      you are using CUDA 10.2, you will have to make sure that
-      C++17 is disabled.
-      By default, we try to detect the compute capability of your device
-      but you can easily set your own CUDA flags:
-      <pre>
-
-        -DDEAL_II_CUDA_FLAGS="-arch=sm_60"
-      </pre>
-      <code>-DDEAL_II_CUDA_FLAGS_DEBUG</code> and
-      <code>-DDEAL_II_CUDA_FLAGS_RELEASE</code> are also available if you want
-      a finer control on the CUDA flags. The CUDA compiler and the
-      CUDA toolkit root directory can be set using
-      <code>-DDEAL_II_CUDA_COMPILER</code> and
-      <code>-DDEAL_II_CUDA_TOOLKIT_ROOT_DIR</code>.
-      Finally, the CUDA host compiler is the same as the C++ compiler
-      by default, but can be changed using CUDA flags as well.
+      CUDA versions prior to 11.0 don't support C++17 or higher.
     </p>
 
     <p>

--- a/doc/external-libs/cuda.html
+++ b/doc/external-libs/cuda.html
@@ -32,7 +32,8 @@
 
         -DDEAL_II_WITH_CUDA=ON
       </pre>
-      CUDA versions prior to 11.0 don't support C++17 or higher.
+      CUDA versions prior to 11.0 don't support C++17 or higher. You will have
+      to make sure that C++17 is disabled when using earlier versions.
     </p>
 
     <p>

--- a/doc/users/cmake_user.html
+++ b/doc/users/cmake_user.html
@@ -480,9 +480,6 @@ source file you have to touch a <code>CMakeLists.txt</code> file or to run
     href="#dealiiconfig"><code>deal.IIConfig.cmake</code></a> for
   details):
 <pre class="cmake">
-DEAL_II_CUDA_FLAGS
-DEAL_II_CUDA_FLAGS_DEBUG
-DEAL_II_CUDA_FLAGS_RELEASE
 DEAL_II_CXX_FLAGS
 DEAL_II_CXX_FLAGS_DEBUG
 DEAL_II_CXX_FLAGS_RELEASE
@@ -827,17 +824,6 @@ DEAL_II_INCLUDE_DIRS
 DEAL_II_LIBRARIES_DEBUG   - a list of the full link interface for the debug configuration
 DEAL_II_LIBRARIES_RELEASE - a list of the full link interface for the release configuration
 DEAL_II_LIBRARIES         - full list of libraries with "debug" and "optimized" keywords
-
-#
-# Information about CUDA configuration
-#
-
-DEAL_II_CUDA_TOOLKIT_ROOT_DIR   - CUDA toolkit directory
-DEAL_II_CUDA_COMPILER           - the CUDA compiler used to compiler deal.II
-
-DEAL_II_CUDA_FLAGS              - compile flags for all CUDA configuration
-DEAL_II_CUDA_FLAGS_DEBUG        - _additional_ compile flags for the CUDA debug configuration
-DEAL_II_CUDA_FLAGS_RELEASE      - _additional_ compile flags for the CUDA release configuration
 
 #
 # Information about library targets


### PR DESCRIPTION
This removes all remaining mentions of `DEAL_II_CUDA*` variables (apart from `DEAL_II_CUDA_HOST_DEV`) and updates the documentation for using `Cuda` as an external library.