### PR TITLE
Introduce DEAL_II_HOST_DEV_ALWAYS_INLINE

### DIFF
--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -181,7 +181,7 @@ PREDEFINED             = DOXYGEN=1 \
                          DEAL_II_ENABLE_EXTRA_DIAGNOSTICS= \
                          DEAL_II_DISABLE_EXTRA_DIAGNOSTICS= \
                          DEAL_II_DEPRECATED= \
-                         DEAL_II_HOST_DEV= \
+                         DEAL_II_HOST_DEVICE= \
                          DEAL_II_ALWAYS_INLINE= \
                          __device__= \
                          DEAL_II_WITH_ADOLC=1 \

--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -34,6 +34,7 @@
 
 #define DEAL_II_HOST_DEV KOKKOS_FUNCTION
 #define DEAL_II_CUDA_HOST_DEV DEAL_II_HOST_DEV
+#define DEAL_II_HOST_DEV_ALWAYS_INLINE KOKKOS_FORCEINLINE_FUNCTION
 
 // Forward-declare the automatic differentiation types so we can add prototypes
 // for our own wrappers.
@@ -728,8 +729,8 @@ namespace internal
   template <typename T>
   struct NumberType
   {
-    static constexpr DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV const T &
-    value(const T &t)
+    static constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE const T &
+                                                          value(const T &t)
     {
       return t;
     }
@@ -743,7 +744,7 @@ namespace internal
 
     // Type T is constructible from F.
     template <typename F>
-    static constexpr DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV T
+    static constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE T
     value(const F &f,
           std::enable_if_t<!std::is_same<typename std::decay<T>::type,
                                          typename std::decay<F>::type>::value &&

--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -32,9 +32,9 @@
 #include <cstddef>
 #include <type_traits>
 
-#define DEAL_II_HOST_DEV KOKKOS_FUNCTION
-#define DEAL_II_CUDA_HOST_DEV DEAL_II_HOST_DEV
-#define DEAL_II_HOST_DEV_ALWAYS_INLINE KOKKOS_FORCEINLINE_FUNCTION
+#define DEAL_II_HOST_DEVICE KOKKOS_FUNCTION
+#define DEAL_II_CUDA_HOST_DEV DEAL_II_HOST_DEVICE
+#define DEAL_II_HOST_DEVICE_ALWAYS_INLINE KOKKOS_FORCEINLINE_FUNCTION
 
 // Forward-declare the automatic differentiation types so we can add prototypes
 // for our own wrappers.
@@ -269,7 +269,7 @@ namespace numbers
 
   /**
    * Check whether the given type can be used in CUDA device code.
-   * If not, DEAL_II_HOST_DEV needs to be disabled for functions
+   * If not, DEAL_II_HOST_DEVICE needs to be disabled for functions
    * that use this type.
    */
   template <typename Number, typename = void>
@@ -457,8 +457,8 @@ namespace numbers
      *
      * @note This function can also be used in CUDA device code.
      */
-    static constexpr DEAL_II_HOST_DEV const number &
-                                            conjugate(const number &x);
+    static constexpr DEAL_II_HOST_DEVICE const number &
+                                               conjugate(const number &x);
 
     /**
      * Return the square of the absolute value of the given number. Since the
@@ -469,7 +469,7 @@ namespace numbers
      * for this function.
      */
     template <typename Dummy = number>
-    static constexpr DEAL_II_HOST_DEV
+    static constexpr DEAL_II_HOST_DEVICE
       std::enable_if_t<std::is_same<Dummy, number>::value &&
                          is_cuda_compatible<Dummy>::value,
                        real_type>
@@ -586,7 +586,7 @@ namespace numbers
 
 
   template <typename number>
-  constexpr DEAL_II_HOST_DEV const number &
+  constexpr DEAL_II_HOST_DEVICE const number &
   NumberTraits<number>::conjugate(const number &x)
   {
     return x;
@@ -596,7 +596,7 @@ namespace numbers
 
   template <typename number>
   template <typename Dummy>
-  constexpr DEAL_II_HOST_DEV
+  constexpr DEAL_II_HOST_DEVICE
     std::enable_if_t<std::is_same<Dummy, number>::value &&
                        is_cuda_compatible<Dummy>::value,
                      typename NumberTraits<number>::real_type>
@@ -729,8 +729,8 @@ namespace internal
   template <typename T>
   struct NumberType
   {
-    static constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE const T &
-                                                          value(const T &t)
+    static constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE const T &
+                                                             value(const T &t)
     {
       return t;
     }
@@ -744,7 +744,7 @@ namespace internal
 
     // Type T is constructible from F.
     template <typename F>
-    static constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE T
+    static constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE T
     value(const F &f,
           std::enable_if_t<!std::is_same<typename std::decay<T>::type,
                                          typename std::decay<F>::type>::value &&

--- a/include/deal.II/base/point.h
+++ b/include/deal.II/base/point.h
@@ -116,13 +116,13 @@ public:
    *
    * @note This function can also be used in CUDA device code.
    */
-  DEAL_II_HOST_DEV
+  DEAL_II_HOST_DEVICE
   Point();
 
   /**
    * Convert a tensor to a point.
    */
-  explicit DEAL_II_HOST_DEV
+  explicit DEAL_II_HOST_DEVICE
   Point(const Tensor<1, dim, Number> &);
 
   /**
@@ -133,7 +133,7 @@ public:
    *
    * @note This function can also be used in CUDA device code.
    */
-  explicit DEAL_II_HOST_DEV
+  explicit DEAL_II_HOST_DEVICE
   Point(const Number x);
 
   /**
@@ -145,7 +145,7 @@ public:
    *
    * @note This function can also be used in CUDA device code.
    */
-  DEAL_II_HOST_DEV
+  DEAL_II_HOST_DEVICE
   Point(const Number x, const Number y);
 
   /**
@@ -157,7 +157,7 @@ public:
    *
    * @note This function can also be used in CUDA device code.
    */
-  DEAL_II_HOST_DEV
+  DEAL_II_HOST_DEVICE
   Point(const Number x, const Number y, const Number z);
 
   /**
@@ -175,15 +175,15 @@ public:
    *
    * @note This function can also be used in CUDA device code.
    */
-  static DEAL_II_HOST_DEV Point<dim, Number>
-                          unit_vector(const unsigned int i);
+  static DEAL_II_HOST_DEVICE Point<dim, Number>
+                             unit_vector(const unsigned int i);
 
   /**
    * Read access to the <tt>index</tt>th coordinate.
    *
    * @note This function can also be used in CUDA device code.
    */
-  DEAL_II_HOST_DEV Number
+  DEAL_II_HOST_DEVICE Number
   operator()(const unsigned int index) const;
 
   /**
@@ -191,8 +191,8 @@ public:
    *
    * @note This function can also be used in CUDA device code.
    */
-  DEAL_II_HOST_DEV Number &
-                   operator()(const unsigned int index);
+  DEAL_II_HOST_DEVICE Number &
+                      operator()(const unsigned int index);
 
   /**
    * Assignment operator from Tensor<1, dim, Number> with different underlying
@@ -213,8 +213,8 @@ public:
    *
    * @note This function can also be used in CUDA device code.
    */
-  DEAL_II_HOST_DEV Point<dim, Number>
-                   operator+(const Tensor<1, dim, Number> &) const;
+  DEAL_II_HOST_DEVICE Point<dim, Number>
+                      operator+(const Tensor<1, dim, Number> &) const;
 
   /**
    * Subtract two points, i.e., obtain the vector that connects the two. As
@@ -225,8 +225,8 @@ public:
    *
    * @note This function can also be used in CUDA device code.
    */
-  DEAL_II_HOST_DEV Tensor<1, dim, Number>
-                   operator-(const Point<dim, Number> &) const;
+  DEAL_II_HOST_DEVICE Tensor<1, dim, Number>
+                      operator-(const Point<dim, Number> &) const;
 
   /**
    * Subtract a difference vector (represented by a Tensor@<1,dim@>) from the
@@ -236,16 +236,16 @@ public:
    *
    * @note This function can also be used in CUDA device code.
    */
-  DEAL_II_HOST_DEV Point<dim, Number>
-                   operator-(const Tensor<1, dim, Number> &) const;
+  DEAL_II_HOST_DEVICE Point<dim, Number>
+                      operator-(const Tensor<1, dim, Number> &) const;
 
   /**
    * The opposite vector.
    *
    * @note This function can also be used in CUDA device code.
    */
-  DEAL_II_HOST_DEV Point<dim, Number>
-                   operator-() const;
+  DEAL_II_HOST_DEVICE Point<dim, Number>
+                      operator-() const;
 
   /**
    * @}
@@ -264,7 +264,7 @@ public:
    * @relatesalso EnableIfScalar
    */
   template <typename OtherNumber>
-  DEAL_II_HOST_DEV Point<
+  DEAL_II_HOST_DEVICE Point<
     dim,
     typename ProductType<Number,
                          typename EnableIfScalar<OtherNumber>::type>::type>
@@ -276,7 +276,7 @@ public:
    * @note This function can also be used in CUDA device code.
    */
   template <typename OtherNumber>
-  DEAL_II_HOST_DEV Point<
+  DEAL_II_HOST_DEVICE Point<
     dim,
     typename ProductType<Number,
                          typename EnableIfScalar<OtherNumber>::type>::type>
@@ -287,7 +287,7 @@ public:
    *
    * @note This function can also be used in CUDA device code.
    */
-  DEAL_II_HOST_DEV Number
+  DEAL_II_HOST_DEVICE Number
   operator*(const Tensor<1, dim, Number> &p) const;
 
   /**
@@ -302,7 +302,7 @@ public:
    *
    * @note This function can also be used in CUDA device code.
    */
-  DEAL_II_HOST_DEV typename numbers::NumberTraits<Number>::real_type
+  DEAL_II_HOST_DEVICE typename numbers::NumberTraits<Number>::real_type
   square() const;
 
   /**
@@ -312,7 +312,7 @@ public:
    *
    * @note This function can also be used in CUDA device code.
    */
-  DEAL_II_HOST_DEV typename numbers::NumberTraits<Number>::real_type
+  DEAL_II_HOST_DEVICE typename numbers::NumberTraits<Number>::real_type
   distance(const Point<dim, Number> &p) const;
 
   /**
@@ -321,7 +321,7 @@ public:
    *
    * @note This function can also be used in CUDA device code.
    */
-  DEAL_II_HOST_DEV typename numbers::NumberTraits<Number>::real_type
+  DEAL_II_HOST_DEVICE typename numbers::NumberTraits<Number>::real_type
   distance_square(const Point<dim, Number> &p) const;
 
   /**
@@ -345,14 +345,14 @@ public:
 // At least clang-3.7 requires us to have a user-defined constructor
 // and we can't use 'Point<dim,Number>::Point () = default' here.
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEV
+inline DEAL_II_HOST_DEVICE
 Point<dim, Number>::Point() // NOLINT
 {}
 
 
 
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEV
+inline DEAL_II_HOST_DEVICE
 Point<dim, Number>::Point(const Tensor<1, dim, Number> &t)
   : Tensor<1, dim, Number>(t)
 {}
@@ -360,7 +360,7 @@ Point<dim, Number>::Point(const Tensor<1, dim, Number> &t)
 
 
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEV
+inline DEAL_II_HOST_DEVICE
 Point<dim, Number>::Point(const Number x)
 {
 #  ifndef __CUDA_ARCH__
@@ -388,7 +388,7 @@ Point<dim, Number>::Point(const Number x)
 
 
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEV
+inline DEAL_II_HOST_DEVICE
 Point<dim, Number>::Point(const Number x, const Number y)
 {
 #  ifndef __CUDA_ARCH__
@@ -411,7 +411,7 @@ Point<dim, Number>::Point(const Number x, const Number y)
 
 
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEV
+inline DEAL_II_HOST_DEVICE
 Point<dim, Number>::Point(const Number x, const Number y, const Number z)
 {
 #  ifndef __CUDA_ARCH__
@@ -457,8 +457,8 @@ inline Point<dim, Number>::Point(
 
 
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEV Point<dim, Number>
-                        Point<dim, Number>::unit_vector(unsigned int i)
+inline DEAL_II_HOST_DEVICE Point<dim, Number>
+                           Point<dim, Number>::unit_vector(unsigned int i)
 {
   Point<dim, Number> p;
   p[i] = 1.;
@@ -467,7 +467,7 @@ inline DEAL_II_HOST_DEV Point<dim, Number>
 
 
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEV Number
+inline DEAL_II_HOST_DEVICE Number
 Point<dim, Number>::operator()(const unsigned int index) const
 {
 #  ifndef __CUDA_ARCH__
@@ -479,7 +479,7 @@ Point<dim, Number>::operator()(const unsigned int index) const
 
 
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEV Number &
+inline DEAL_II_HOST_DEVICE Number &
 Point<dim, Number>::operator()(const unsigned int index)
 {
 #  ifndef __CUDA_ARCH__
@@ -502,7 +502,7 @@ Point<dim, Number>::operator=(const Tensor<1, dim, OtherNumber> &p)
 
 
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEV Point<dim, Number>
+inline DEAL_II_HOST_DEVICE Point<dim, Number>
 Point<dim, Number>::operator+(const Tensor<1, dim, Number> &p) const
 {
   Point<dim, Number> tmp = *this;
@@ -513,7 +513,7 @@ Point<dim, Number>::operator+(const Tensor<1, dim, Number> &p) const
 
 
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEV Tensor<1, dim, Number>
+inline DEAL_II_HOST_DEVICE Tensor<1, dim, Number>
 Point<dim, Number>::operator-(const Point<dim, Number> &p) const
 {
   return (Tensor<1, dim, Number>(*this) -= p);
@@ -522,7 +522,7 @@ Point<dim, Number>::operator-(const Point<dim, Number> &p) const
 
 
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEV Point<dim, Number>
+inline DEAL_II_HOST_DEVICE Point<dim, Number>
 Point<dim, Number>::operator-(const Tensor<1, dim, Number> &p) const
 {
   Point<dim, Number> tmp = *this;
@@ -533,7 +533,7 @@ Point<dim, Number>::operator-(const Tensor<1, dim, Number> &p) const
 
 
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEV Point<dim, Number>
+inline DEAL_II_HOST_DEVICE Point<dim, Number>
 Point<dim, Number>::operator-() const
 {
   Point<dim, Number> result;
@@ -546,7 +546,7 @@ Point<dim, Number>::operator-() const
 
 template <int dim, typename Number>
 template <typename OtherNumber>
-inline DEAL_II_HOST_DEV
+inline DEAL_II_HOST_DEVICE
   Point<dim,
         typename ProductType<Number,
                              typename EnableIfScalar<OtherNumber>::type>::type>
@@ -562,7 +562,7 @@ inline DEAL_II_HOST_DEV
 
 template <int dim, typename Number>
 template <typename OtherNumber>
-inline DEAL_II_HOST_DEV
+inline DEAL_II_HOST_DEVICE
   Point<dim,
         typename ProductType<Number,
                              typename EnableIfScalar<OtherNumber>::type>::type>
@@ -579,7 +579,7 @@ inline DEAL_II_HOST_DEV
 
 
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEV Number
+inline DEAL_II_HOST_DEVICE Number
 Point<dim, Number>::operator*(const Tensor<1, dim, Number> &p) const
 {
   Number res = Number();
@@ -590,7 +590,7 @@ Point<dim, Number>::operator*(const Tensor<1, dim, Number> &p) const
 
 
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEV typename numbers::NumberTraits<Number>::real_type
+inline DEAL_II_HOST_DEVICE typename numbers::NumberTraits<Number>::real_type
 Point<dim, Number>::square() const
 {
   return this->norm_square();
@@ -599,7 +599,7 @@ Point<dim, Number>::square() const
 
 
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEV typename numbers::NumberTraits<Number>::real_type
+inline DEAL_II_HOST_DEVICE typename numbers::NumberTraits<Number>::real_type
 Point<dim, Number>::distance(const Point<dim, Number> &p) const
 {
   return std::sqrt(distance_square(p));
@@ -608,7 +608,7 @@ Point<dim, Number>::distance(const Point<dim, Number> &p) const
 
 
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEV typename numbers::NumberTraits<Number>::real_type
+inline DEAL_II_HOST_DEVICE typename numbers::NumberTraits<Number>::real_type
 Point<dim, Number>::distance_square(const Point<dim, Number> &p) const
 {
   Number sum = internal::NumberType<Number>::value(0.0);
@@ -647,7 +647,7 @@ Point<dim, Number>::serialize(Archive &ar, const unsigned int)
  * @relates Point
  */
 template <int dim, typename Number, typename OtherNumber>
-inline DEAL_II_HOST_DEV
+inline DEAL_II_HOST_DEVICE
   Point<dim,
         typename ProductType<Number,
                              typename EnableIfScalar<OtherNumber>::type>::type>

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -139,7 +139,7 @@ public:
    *
    * @note This function can also be used in CUDA device code.
    */
-  constexpr DEAL_II_HOST_DEV
+  constexpr DEAL_II_HOST_DEVICE
   Tensor();
 
   /**
@@ -150,7 +150,7 @@ public:
    * @note This function can also be used in CUDA device code.
    */
   template <typename OtherNumber>
-  constexpr DEAL_II_HOST_DEV
+  constexpr DEAL_II_HOST_DEVICE
   Tensor(const Tensor<0, dim, OtherNumber> &initializer);
 
   /**
@@ -159,20 +159,20 @@ public:
    * @note This function can also be used in CUDA device code.
    */
   template <typename OtherNumber>
-  constexpr DEAL_II_HOST_DEV
+  constexpr DEAL_II_HOST_DEVICE
   Tensor(const OtherNumber &initializer);
 
 #ifdef DEAL_II_DELETED_MOVE_CONSTRUCTOR_BUG
   /**
    * Copy constructor
    */
-  constexpr DEAL_II_HOST_DEV
+  constexpr DEAL_II_HOST_DEVICE
   Tensor(const Tensor<0, dim, Number> &other);
 
   /**
    * Move constructor
    */
-  constexpr DEAL_II_HOST_DEV
+  constexpr DEAL_II_HOST_DEVICE
   Tensor(Tensor<0, dim, Number> &&other) noexcept;
 #endif
 
@@ -234,7 +234,7 @@ public:
    *
    * @note This function can also be used in CUDA device code.
    */
-  constexpr DEAL_II_HOST_DEV
+  constexpr DEAL_II_HOST_DEVICE
   operator Number &();
 
   /**
@@ -245,7 +245,7 @@ public:
    *
    * @note This function can also be used in CUDA device code.
    */
-  constexpr DEAL_II_HOST_DEV operator const Number &() const;
+  constexpr DEAL_II_HOST_DEVICE operator const Number &() const;
 
   /**
    * Assignment from tensors with different underlying scalar type. This
@@ -255,8 +255,8 @@ public:
    * @note This function can also be used in CUDA device code.
    */
   template <typename OtherNumber>
-  constexpr DEAL_II_HOST_DEV Tensor &
-                             operator=(const Tensor<0, dim, OtherNumber> &rhs);
+  constexpr DEAL_II_HOST_DEVICE Tensor &
+  operator=(const Tensor<0, dim, OtherNumber> &rhs);
 
 #if defined(__INTEL_COMPILER) || defined(DEAL_II_DELETED_MOVE_CONSTRUCTOR_BUG)
   /**
@@ -267,16 +267,16 @@ public:
    *
    * @note This function can also be used in CUDA device code.
    */
-  constexpr DEAL_II_HOST_DEV Tensor &
-                             operator=(const Tensor<0, dim, Number> &rhs);
+  constexpr DEAL_II_HOST_DEVICE Tensor &
+                                operator=(const Tensor<0, dim, Number> &rhs);
 #endif
 
 #ifdef DEAL_II_DELETED_MOVE_CONSTRUCTOR_BUG
   /**
    * Move assignment operator
    */
-  constexpr DEAL_II_HOST_DEV Tensor<0, dim, Number> &
-                             operator=(Tensor<0, dim, Number> &&other) noexcept;
+  constexpr DEAL_II_HOST_DEVICE Tensor<0, dim, Number> &
+  operator=(Tensor<0, dim, Number> &&other) noexcept;
 #endif
 
   /**
@@ -286,8 +286,8 @@ public:
    * @note This function can also be used in CUDA device code.
    */
   template <typename OtherNumber>
-  constexpr DEAL_II_HOST_DEV Tensor &
-                             operator=(const OtherNumber &d);
+  constexpr DEAL_II_HOST_DEVICE Tensor &
+                                operator=(const OtherNumber &d);
 
   /**
    * Test for equality of two tensors.
@@ -309,8 +309,8 @@ public:
    * @note This function can also be used in CUDA device code.
    */
   template <typename OtherNumber>
-  constexpr DEAL_II_HOST_DEV Tensor &
-                             operator+=(const Tensor<0, dim, OtherNumber> &rhs);
+  constexpr DEAL_II_HOST_DEVICE Tensor &
+  operator+=(const Tensor<0, dim, OtherNumber> &rhs);
 
   /**
    * Subtract another scalar.
@@ -318,8 +318,8 @@ public:
    * @note This function can also be used in CUDA device code.
    */
   template <typename OtherNumber>
-  constexpr DEAL_II_HOST_DEV Tensor &
-                             operator-=(const Tensor<0, dim, OtherNumber> &rhs);
+  constexpr DEAL_II_HOST_DEVICE Tensor &
+  operator-=(const Tensor<0, dim, OtherNumber> &rhs);
 
   /**
    * Multiply the scalar with a <tt>factor</tt>.
@@ -327,8 +327,8 @@ public:
    * @note This function can also be used in CUDA device code.
    */
   template <typename OtherNumber>
-  constexpr DEAL_II_HOST_DEV Tensor &
-                             operator*=(const OtherNumber &factor);
+  constexpr DEAL_II_HOST_DEVICE Tensor &
+                                operator*=(const OtherNumber &factor);
 
   /**
    * Divide the scalar by <tt>factor</tt>.
@@ -336,15 +336,15 @@ public:
    * @note This function can also be used in CUDA device code.
    */
   template <typename OtherNumber>
-  constexpr DEAL_II_HOST_DEV Tensor &
-                             operator/=(const OtherNumber &factor);
+  constexpr DEAL_II_HOST_DEVICE Tensor &
+                                operator/=(const OtherNumber &factor);
 
   /**
    * Tensor with inverted entries.
    *
    * @note This function can also be used in CUDA device code.
    */
-  constexpr DEAL_II_HOST_DEV Tensor
+  constexpr DEAL_II_HOST_DEVICE Tensor
   operator-() const;
 
   /**
@@ -376,7 +376,7 @@ public:
    *
    * @note This function can also be used in CUDA device code.
    */
-  constexpr DEAL_II_HOST_DEV real_type
+  constexpr DEAL_II_HOST_DEVICE real_type
   norm_square() const;
 
   /**
@@ -547,7 +547,7 @@ public:
    *
    * @note This function can also be used in CUDA device code.
    */
-  constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
+  constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE
   Tensor();
 
   /**
@@ -555,7 +555,7 @@ public:
    *
    * @note This function can also be used in CUDA device code.
    */
-  constexpr DEAL_II_HOST_DEV explicit Tensor(const array_type &initializer);
+  constexpr DEAL_II_HOST_DEVICE explicit Tensor(const array_type &initializer);
 
   /**
    * A constructor where the data is copied from an ArrayView object.
@@ -571,7 +571,7 @@ public:
    * @note This function can also be used in CUDA device code.
    */
   template <typename ElementType, typename MemorySpace>
-  constexpr DEAL_II_HOST_DEV explicit Tensor(
+  constexpr DEAL_II_HOST_DEVICE explicit Tensor(
     const ArrayView<ElementType, MemorySpace> &initializer);
 
   /**
@@ -582,7 +582,7 @@ public:
    * @note This function can also be used in CUDA device code.
    */
   template <typename OtherNumber>
-  constexpr DEAL_II_HOST_DEV
+  constexpr DEAL_II_HOST_DEVICE
   Tensor(const Tensor<rank_, dim, OtherNumber> &initializer);
 
   /**
@@ -616,16 +616,16 @@ public:
    *
    * @note This function can also be used in CUDA device code.
    */
-  constexpr DEAL_II_HOST_DEV value_type &
-                             operator[](const unsigned int i);
+  constexpr DEAL_II_HOST_DEVICE value_type &
+                                operator[](const unsigned int i);
 
   /**
    * Read-only access operator.
    *
    * @note This function can also be used in CUDA device code.
    */
-  constexpr DEAL_II_HOST_DEV const value_type &
-                                   operator[](const unsigned int i) const;
+  constexpr DEAL_II_HOST_DEVICE const value_type &
+                                      operator[](const unsigned int i) const;
 
   /**
    * Read access using TableIndices <tt>indices</tt>
@@ -671,7 +671,7 @@ public:
    * @note This function can also be used in CUDA device code.
    */
   template <typename OtherNumber>
-  constexpr DEAL_II_HOST_DEV Tensor &
+  constexpr DEAL_II_HOST_DEVICE Tensor &
   operator=(const Tensor<rank_, dim, OtherNumber> &rhs);
 
   /**
@@ -717,7 +717,7 @@ public:
    * @note This function can also be used in CUDA device code.
    */
   template <typename OtherNumber>
-  constexpr DEAL_II_HOST_DEV Tensor &
+  constexpr DEAL_II_HOST_DEVICE Tensor &
   operator+=(const Tensor<rank_, dim, OtherNumber> &);
 
   /**
@@ -726,7 +726,7 @@ public:
    * @note This function can also be used in CUDA device code.
    */
   template <typename OtherNumber>
-  constexpr DEAL_II_HOST_DEV Tensor &
+  constexpr DEAL_II_HOST_DEVICE Tensor &
   operator-=(const Tensor<rank_, dim, OtherNumber> &);
 
   /**
@@ -736,8 +736,8 @@ public:
    * @note This function can also be used in CUDA device code.
    */
   template <typename OtherNumber>
-  constexpr DEAL_II_HOST_DEV Tensor &
-                             operator*=(const OtherNumber &factor);
+  constexpr DEAL_II_HOST_DEVICE Tensor &
+                                operator*=(const OtherNumber &factor);
 
   /**
    * Scale the vector by <tt>1/factor</tt>.
@@ -745,15 +745,15 @@ public:
    * @note This function can also be used in CUDA device code.
    */
   template <typename OtherNumber>
-  constexpr DEAL_II_HOST_DEV Tensor &
-                             operator/=(const OtherNumber &factor);
+  constexpr DEAL_II_HOST_DEVICE Tensor &
+                                operator/=(const OtherNumber &factor);
 
   /**
    * Unary minus operator. Negate all entries of a tensor.
    *
    * @note This function can also be used in CUDA device code.
    */
-  constexpr DEAL_II_HOST_DEV Tensor
+  constexpr DEAL_II_HOST_DEVICE Tensor
   operator-() const;
 
   /**
@@ -778,7 +778,7 @@ public:
    *
    * @note This function can also be used in CUDA device code.
    */
-  DEAL_II_HOST_DEV
+  DEAL_II_HOST_DEVICE
   typename numbers::NumberTraits<Number>::real_type
   norm() const;
 
@@ -788,8 +788,9 @@ public:
    *
    * @note This function can also be used in CUDA device code.
    */
-  constexpr DEAL_II_HOST_DEV typename numbers::NumberTraits<Number>::real_type
-  norm_square() const;
+  constexpr DEAL_II_HOST_DEVICE
+    typename numbers::NumberTraits<Number>::real_type
+    norm_square() const;
 
   /**
    * Fill a vector with all tensor elements.
@@ -878,7 +879,7 @@ private:
    * @note This function can also be used in CUDA device code.
    */
   template <typename ArrayLike, std::size_t... Indices>
-  constexpr DEAL_II_HOST_DEV
+  constexpr DEAL_II_HOST_DEVICE
   Tensor(const ArrayLike &initializer, std::index_sequence<Indices...>);
 
   // Allow an arbitrary Tensor to access the underlying values.
@@ -955,7 +956,7 @@ namespace internal
 
 
 template <int dim, typename Number>
-constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
+constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE
 Tensor<0, dim, Number>::Tensor()
   // Some auto-differentiable numbers need explicit
   // zero initialization such as adtl::adouble.
@@ -966,7 +967,7 @@ Tensor<0, dim, Number>::Tensor()
 
 template <int dim, typename Number>
 template <typename OtherNumber>
-constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
+constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE
 Tensor<0, dim, Number>::Tensor(const OtherNumber &initializer)
   : value(internal::NumberType<Number>::value(initializer))
 {}
@@ -975,7 +976,7 @@ Tensor<0, dim, Number>::Tensor(const OtherNumber &initializer)
 
 template <int dim, typename Number>
 template <typename OtherNumber>
-constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
+constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE
 Tensor<0, dim, Number>::Tensor(const Tensor<0, dim, OtherNumber> &p)
   : Tensor{p.value}
 {}
@@ -983,7 +984,7 @@ Tensor<0, dim, Number>::Tensor(const Tensor<0, dim, OtherNumber> &p)
 
 #  ifdef DEAL_II_DELETED_MOVE_CONSTRUCTOR_BUG
 template <int dim, typename Number>
-constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
+constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE
 Tensor<0, dim, Number>::Tensor(const Tensor<0, dim, Number> &other)
   : value{other.value}
 {}
@@ -991,7 +992,7 @@ Tensor<0, dim, Number>::Tensor(const Tensor<0, dim, Number> &other)
 
 
 template <int dim, typename Number>
-constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
+constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE
 Tensor<0, dim, Number>::Tensor(Tensor<0, dim, Number> &&other) noexcept
   : value{std::move(other.value)}
 {}
@@ -1035,7 +1036,7 @@ Tensor<0, dim, Number>::end_raw() const
 
 
 template <int dim, typename Number>
-constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
+constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE
 Tensor<0, dim, Number>::operator Number &()
 {
   // We cannot use Assert inside a CUDA kernel
@@ -1049,7 +1050,7 @@ Tensor<0, dim, Number>::operator Number &()
 
 template <int dim, typename Number>
 constexpr inline DEAL_II_ALWAYS_INLINE
-  DEAL_II_HOST_DEV Tensor<0, dim, Number>::operator const Number &() const
+  DEAL_II_HOST_DEVICE Tensor<0, dim, Number>::operator const Number &() const
 {
   // We cannot use Assert inside a CUDA kernel
 #  ifndef __CUDA_ARCH__
@@ -1063,7 +1064,7 @@ constexpr inline DEAL_II_ALWAYS_INLINE
 
 template <int dim, typename Number>
 template <typename OtherNumber>
-constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number> &
+constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE Tensor<0, dim, Number> &
 Tensor<0, dim, Number>::operator=(const Tensor<0, dim, OtherNumber> &p)
 {
   value = internal::NumberType<Number>::value(p.value);
@@ -1073,7 +1074,7 @@ Tensor<0, dim, Number>::operator=(const Tensor<0, dim, OtherNumber> &p)
 
 #  if defined(__INTEL_COMPILER) || defined(DEAL_II_DELETED_MOVE_CONSTRUCTOR_BUG)
 template <int dim, typename Number>
-constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number> &
+constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE Tensor<0, dim, Number> &
 Tensor<0, dim, Number>::operator=(const Tensor<0, dim, Number> &p)
 {
   value = p.value;
@@ -1083,7 +1084,7 @@ Tensor<0, dim, Number>::operator=(const Tensor<0, dim, Number> &p)
 
 #  ifdef DEAL_II_DELETED_MOVE_CONSTRUCTOR_BUG
 template <int dim, typename Number>
-constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number> &
+constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE Tensor<0, dim, Number> &
 Tensor<0, dim, Number>::operator=(Tensor<0, dim, Number> &&other) noexcept
 {
   value = std::move(other.value);
@@ -1095,7 +1096,7 @@ Tensor<0, dim, Number>::operator=(Tensor<0, dim, Number> &&other) noexcept
 
 template <int dim, typename Number>
 template <typename OtherNumber>
-constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number> &
+constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE Tensor<0, dim, Number> &
 Tensor<0, dim, Number>::operator=(const OtherNumber &d)
 {
   value = internal::NumberType<Number>::value(d);
@@ -1131,7 +1132,7 @@ Tensor<0, dim, Number>::operator!=(const Tensor<0, dim, OtherNumber> &p) const
 
 template <int dim, typename Number>
 template <typename OtherNumber>
-constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number> &
+constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE Tensor<0, dim, Number> &
 Tensor<0, dim, Number>::operator+=(const Tensor<0, dim, OtherNumber> &p)
 {
   value += p.value;
@@ -1141,7 +1142,7 @@ Tensor<0, dim, Number>::operator+=(const Tensor<0, dim, OtherNumber> &p)
 
 template <int dim, typename Number>
 template <typename OtherNumber>
-constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number> &
+constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE Tensor<0, dim, Number> &
 Tensor<0, dim, Number>::operator-=(const Tensor<0, dim, OtherNumber> &p)
 {
   value -= p.value;
@@ -1155,7 +1156,7 @@ namespace internal
   namespace ComplexWorkaround
   {
     template <typename Number, typename OtherNumber>
-    constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE void
+    constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE void
     multiply_assign_scalar(Number &val, const OtherNumber &s)
     {
       val *= s;
@@ -1163,7 +1164,7 @@ namespace internal
 
 #  ifdef __CUDA_ARCH__
     template <typename Number, typename OtherNumber>
-    constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE void
+    constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE void
     multiply_assign_scalar(std::complex<Number> &, const OtherNumber &)
     {
       printf("This function is not implemented for std::complex<Number>!\n");
@@ -1176,7 +1177,7 @@ namespace internal
 
 template <int dim, typename Number>
 template <typename OtherNumber>
-constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number> &
+constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE Tensor<0, dim, Number> &
 Tensor<0, dim, Number>::operator*=(const OtherNumber &s)
 {
   internal::ComplexWorkaround::multiply_assign_scalar(value, s);
@@ -1187,7 +1188,7 @@ Tensor<0, dim, Number>::operator*=(const OtherNumber &s)
 
 template <int dim, typename Number>
 template <typename OtherNumber>
-constexpr inline DEAL_II_HOST_DEV Tensor<0, dim, Number> &
+constexpr inline DEAL_II_HOST_DEVICE Tensor<0, dim, Number> &
 Tensor<0, dim, Number>::operator/=(const OtherNumber &s)
 {
   value /= s;
@@ -1196,7 +1197,7 @@ Tensor<0, dim, Number>::operator/=(const OtherNumber &s)
 
 
 template <int dim, typename Number>
-constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number>
+constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE Tensor<0, dim, Number>
 Tensor<0, dim, Number>::operator-() const
 {
   return -value;
@@ -1214,7 +1215,7 @@ Tensor<0, dim, Number>::norm() const
 
 
 template <int dim, typename Number>
-constexpr DEAL_II_HOST_DEV inline DEAL_II_ALWAYS_INLINE
+constexpr DEAL_II_HOST_DEVICE inline DEAL_II_ALWAYS_INLINE
   typename Tensor<0, dim, Number>::real_type
   Tensor<0, dim, Number>::norm_square() const
 {
@@ -1285,7 +1286,7 @@ constexpr unsigned int Tensor<0, dim, Number>::n_independent_components;
 
 template <int rank_, int dim, typename Number>
 template <typename ArrayLike, std::size_t... indices>
-constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
+constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE
 Tensor<rank_, dim, Number>::Tensor(const ArrayLike &initializer,
                                    std::index_sequence<indices...>)
   : values{Tensor<rank_ - 1, dim, Number>(initializer[indices])...}
@@ -1297,7 +1298,7 @@ Tensor<rank_, dim, Number>::Tensor(const ArrayLike &initializer,
 
 
 template <int rank_, int dim, typename Number>
-constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
+constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE
 Tensor<rank_, dim, Number>::Tensor()
   // We would like to use =default, but this causes compile errors with some
   // MSVC versions and internal compiler errors with -O1 in gcc 5.4.
@@ -1307,7 +1308,7 @@ Tensor<rank_, dim, Number>::Tensor()
 
 
 template <int rank_, int dim, typename Number>
-constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
+constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE
 Tensor<rank_, dim, Number>::Tensor(const array_type &initializer)
   : Tensor(initializer, std::make_index_sequence<dim>{})
 {}
@@ -1316,7 +1317,7 @@ Tensor<rank_, dim, Number>::Tensor(const array_type &initializer)
 
 template <int rank_, int dim, typename Number>
 template <typename ElementType, typename MemorySpace>
-constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
+constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE
 Tensor<rank_, dim, Number>::Tensor(
   const ArrayView<ElementType, MemorySpace> &initializer)
 {
@@ -1333,7 +1334,7 @@ Tensor<rank_, dim, Number>::Tensor(
 
 template <int rank_, int dim, typename Number>
 template <typename OtherNumber>
-constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
+constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE
 Tensor<rank_, dim, Number>::Tensor(
   const Tensor<rank_, dim, OtherNumber> &initializer)
   : Tensor(initializer, std::make_index_sequence<dim>{})
@@ -1385,10 +1386,10 @@ namespace internal
   namespace TensorSubscriptor
   {
     template <typename ArrayElementType, int dim>
-    constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE ArrayElementType &
-                                             subscript(ArrayElementType * values,
-                                                       const unsigned int i,
-                                                       std::integral_constant<int, dim>)
+    constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE ArrayElementType &
+    subscript(ArrayElementType * values,
+              const unsigned int i,
+              std::integral_constant<int, dim>)
     {
       // We cannot use Assert in a CUDA kernel
 #  ifndef __CUDA_ARCH__
@@ -1398,10 +1399,10 @@ namespace internal
     }
 
     template <typename ArrayElementType>
-    constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE ArrayElementType &
-                                             subscript(ArrayElementType *dummy,
-                                                       const unsigned int,
-                                                       std::integral_constant<int, 0>)
+    constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE ArrayElementType &
+    subscript(ArrayElementType *dummy,
+              const unsigned int,
+              std::integral_constant<int, 0>)
     {
       // We cannot use Assert in a CUDA kernel
 #  ifndef __CUDA_ARCH__
@@ -1417,7 +1418,7 @@ namespace internal
 
 
 template <int rank_, int dim, typename Number>
-constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
+constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE
   typename Tensor<rank_, dim, Number>::value_type &
   Tensor<rank_, dim, Number>::operator[](const unsigned int i)
 {
@@ -1428,7 +1429,7 @@ constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
 
 template <int rank_, int dim, typename Number>
 constexpr DEAL_II_ALWAYS_INLINE
-  DEAL_II_HOST_DEV const typename Tensor<rank_, dim, Number>::value_type &
+  DEAL_II_HOST_DEVICE const typename Tensor<rank_, dim, Number>::value_type &
   Tensor<rank_, dim, Number>::operator[](const unsigned int i) const
 {
 #  ifndef DEAL_II_COMPILER_CUDA_AWARE
@@ -1596,7 +1597,7 @@ Tensor<rank_, dim, Number>::operator!=(
 template <int rank_, int dim, typename Number>
 template <typename OtherNumber>
 constexpr inline DEAL_II_ALWAYS_INLINE
-  DEAL_II_HOST_DEV Tensor<rank_, dim, Number> &
+  DEAL_II_HOST_DEVICE Tensor<rank_, dim, Number> &
   Tensor<rank_, dim, Number>::operator+=(
     const Tensor<rank_, dim, OtherNumber> &p)
 {
@@ -1609,7 +1610,7 @@ constexpr inline DEAL_II_ALWAYS_INLINE
 template <int rank_, int dim, typename Number>
 template <typename OtherNumber>
 constexpr inline DEAL_II_ALWAYS_INLINE
-  DEAL_II_HOST_DEV Tensor<rank_, dim, Number> &
+  DEAL_II_HOST_DEVICE Tensor<rank_, dim, Number> &
   Tensor<rank_, dim, Number>::operator-=(
     const Tensor<rank_, dim, OtherNumber> &p)
 {
@@ -1622,7 +1623,7 @@ constexpr inline DEAL_II_ALWAYS_INLINE
 template <int rank_, int dim, typename Number>
 template <typename OtherNumber>
 constexpr inline DEAL_II_ALWAYS_INLINE
-  DEAL_II_HOST_DEV Tensor<rank_, dim, Number> &
+  DEAL_II_HOST_DEVICE Tensor<rank_, dim, Number> &
   Tensor<rank_, dim, Number>::operator*=(const OtherNumber &s)
 {
   for (unsigned int i = 0; i < dim; ++i)
@@ -1644,7 +1645,7 @@ namespace internal
                   typename ProductType<Number, OtherNumber>::type>::value &&
                   !std::is_same<Number, Differentiation::SD::Expression>::value,
                 int> = 0>
-    constexpr DEAL_II_HOST_DEV inline DEAL_II_ALWAYS_INLINE void
+    constexpr DEAL_II_HOST_DEVICE inline DEAL_II_ALWAYS_INLINE void
     division_operator(Tensor<rank, dim, Number> (&t)[dim],
                       const OtherNumber &factor)
     {
@@ -1664,7 +1665,7 @@ namespace internal
                   typename ProductType<Number, OtherNumber>::type>::value ||
                   std::is_same<Number, Differentiation::SD::Expression>::value,
                 int> = 0>
-    constexpr DEAL_II_HOST_DEV inline DEAL_II_ALWAYS_INLINE void
+    constexpr DEAL_II_HOST_DEVICE inline DEAL_II_ALWAYS_INLINE void
     division_operator(Tensor<rank, dim, Number> (&t)[dim],
                       const OtherNumber &factor)
     {
@@ -1679,7 +1680,7 @@ namespace internal
 template <int rank_, int dim, typename Number>
 template <typename OtherNumber>
 constexpr inline DEAL_II_ALWAYS_INLINE
-  DEAL_II_HOST_DEV Tensor<rank_, dim, Number> &
+  DEAL_II_HOST_DEVICE Tensor<rank_, dim, Number> &
   Tensor<rank_, dim, Number>::operator/=(const OtherNumber &s)
 {
   internal::TensorImplementation::division_operator(values, s);
@@ -1689,7 +1690,7 @@ constexpr inline DEAL_II_ALWAYS_INLINE
 
 template <int rank_, int dim, typename Number>
 constexpr inline DEAL_II_ALWAYS_INLINE
-  DEAL_II_HOST_DEV Tensor<rank_, dim, Number>
+  DEAL_II_HOST_DEVICE Tensor<rank_, dim, Number>
   Tensor<rank_, dim, Number>::operator-() const
 {
   Tensor<rank_, dim, Number> tmp;
@@ -1712,7 +1713,7 @@ Tensor<rank_, dim, Number>::norm() const
 
 
 template <int rank_, int dim, typename Number>
-constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
+constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE
   typename numbers::NumberTraits<Number>::real_type
   Tensor<rank_, dim, Number>::norm_square() const
 {
@@ -1928,7 +1929,7 @@ operator<<(std::ostream &out, const Tensor<0, dim, Number> &p)
  * @relatesalso Tensor
  */
 template <int dim, typename Number, typename Other>
-constexpr DEAL_II_HOST_DEV inline DEAL_II_ALWAYS_INLINE
+constexpr DEAL_II_HOST_DEVICE inline DEAL_II_ALWAYS_INLINE
   typename ProductType<Other, Number>::type
   operator*(const Other &object, const Tensor<0, dim, Number> &t)
 {
@@ -1948,7 +1949,7 @@ constexpr DEAL_II_HOST_DEV inline DEAL_II_ALWAYS_INLINE
  * @relatesalso Tensor
  */
 template <int dim, typename Number, typename Other>
-constexpr DEAL_II_HOST_DEV inline DEAL_II_ALWAYS_INLINE
+constexpr DEAL_II_HOST_DEVICE inline DEAL_II_ALWAYS_INLINE
   typename ProductType<Number, Other>::type
   operator*(const Tensor<0, dim, Number> &t, const Other &object)
 {
@@ -1968,7 +1969,7 @@ constexpr DEAL_II_HOST_DEV inline DEAL_II_ALWAYS_INLINE
  * @relatesalso Tensor
  */
 template <int dim, typename Number, typename OtherNumber>
-DEAL_II_HOST_DEV constexpr DEAL_II_ALWAYS_INLINE
+DEAL_II_HOST_DEVICE constexpr DEAL_II_ALWAYS_INLINE
   typename ProductType<Number, OtherNumber>::type
   operator*(const Tensor<0, dim, Number> &     src1,
             const Tensor<0, dim, OtherNumber> &src2)
@@ -1986,7 +1987,7 @@ DEAL_II_HOST_DEV constexpr DEAL_II_ALWAYS_INLINE
  * @relatesalso Tensor
  */
 template <int dim, typename Number, typename OtherNumber>
-DEAL_II_HOST_DEV constexpr DEAL_II_ALWAYS_INLINE
+DEAL_II_HOST_DEVICE constexpr DEAL_II_ALWAYS_INLINE
   Tensor<0,
          dim,
          typename ProductType<Number,
@@ -2005,7 +2006,7 @@ DEAL_II_HOST_DEV constexpr DEAL_II_ALWAYS_INLINE
  * @relatesalso Tensor
  */
 template <int dim, typename Number, typename OtherNumber>
-constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
+constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE
   Tensor<0, dim, typename ProductType<Number, OtherNumber>::type>
   operator+(const Tensor<0, dim, Number> &     p,
             const Tensor<0, dim, OtherNumber> &q)
@@ -2022,7 +2023,7 @@ constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
  * @relatesalso Tensor
  */
 template <int dim, typename Number, typename OtherNumber>
-constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
+constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE
   Tensor<0, dim, typename ProductType<Number, OtherNumber>::type>
   operator-(const Tensor<0, dim, Number> &     p,
             const Tensor<0, dim, OtherNumber> &q)
@@ -2044,7 +2045,7 @@ constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
  * @relatesalso Tensor
  */
 template <int rank, int dim, typename Number, typename OtherNumber>
-constexpr DEAL_II_HOST_DEV inline DEAL_II_ALWAYS_INLINE
+constexpr DEAL_II_HOST_DEVICE inline DEAL_II_ALWAYS_INLINE
   Tensor<rank,
          dim,
          typename ProductType<Number,
@@ -2072,7 +2073,7 @@ constexpr DEAL_II_HOST_DEV inline DEAL_II_ALWAYS_INLINE
  * @relatesalso Tensor
  */
 template <int rank, int dim, typename Number, typename OtherNumber>
-DEAL_II_HOST_DEV constexpr inline DEAL_II_ALWAYS_INLINE
+DEAL_II_HOST_DEVICE constexpr inline DEAL_II_ALWAYS_INLINE
   Tensor<rank,
          dim,
          typename ProductType<typename EnableIfScalar<Number>::type,
@@ -2096,7 +2097,7 @@ namespace internal
                 !std::is_integral<
                   typename ProductType<Number, OtherNumber>::type>::value,
                 int> = 0>
-    constexpr DEAL_II_HOST_DEV inline DEAL_II_ALWAYS_INLINE
+    constexpr DEAL_II_HOST_DEVICE inline DEAL_II_ALWAYS_INLINE
       Tensor<rank, dim, typename ProductType<Number, OtherNumber>::type>
       division_operator(const Tensor<rank, dim, Number> &t,
                         const OtherNumber &              factor)
@@ -2118,7 +2119,7 @@ namespace internal
                 std::is_integral<
                   typename ProductType<Number, OtherNumber>::type>::value,
                 int> = 0>
-    constexpr DEAL_II_HOST_DEV inline DEAL_II_ALWAYS_INLINE
+    constexpr DEAL_II_HOST_DEVICE inline DEAL_II_ALWAYS_INLINE
       Tensor<rank, dim, typename ProductType<Number, OtherNumber>::type>
       division_operator(const Tensor<rank, dim, Number> &t,
                         const OtherNumber &              factor)
@@ -2143,7 +2144,7 @@ namespace internal
  * @relatesalso Tensor
  */
 template <int rank, int dim, typename Number, typename OtherNumber>
-constexpr DEAL_II_HOST_DEV inline DEAL_II_ALWAYS_INLINE
+constexpr DEAL_II_HOST_DEVICE inline DEAL_II_ALWAYS_INLINE
   Tensor<rank,
          dim,
          typename ProductType<Number,
@@ -2164,7 +2165,7 @@ constexpr DEAL_II_HOST_DEV inline DEAL_II_ALWAYS_INLINE
  * @relatesalso Tensor
  */
 template <int rank, int dim, typename Number, typename OtherNumber>
-constexpr DEAL_II_HOST_DEV inline DEAL_II_ALWAYS_INLINE
+constexpr DEAL_II_HOST_DEVICE inline DEAL_II_ALWAYS_INLINE
   Tensor<rank, dim, typename ProductType<Number, OtherNumber>::type>
   operator+(const Tensor<rank, dim, Number> &     p,
             const Tensor<rank, dim, OtherNumber> &q)
@@ -2188,7 +2189,7 @@ constexpr DEAL_II_HOST_DEV inline DEAL_II_ALWAYS_INLINE
  * @relatesalso Tensor
  */
 template <int rank, int dim, typename Number, typename OtherNumber>
-constexpr DEAL_II_HOST_DEV inline DEAL_II_ALWAYS_INLINE
+constexpr DEAL_II_HOST_DEVICE inline DEAL_II_ALWAYS_INLINE
   Tensor<rank, dim, typename ProductType<Number, OtherNumber>::type>
   operator-(const Tensor<rank, dim, Number> &     p,
             const Tensor<rank, dim, OtherNumber> &q)

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -547,7 +547,7 @@ public:
    *
    * @note This function can also be used in CUDA device code.
    */
-  constexpr DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV
+  constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
   Tensor();
 
   /**
@@ -955,7 +955,7 @@ namespace internal
 
 
 template <int dim, typename Number>
-constexpr DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV
+constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
 Tensor<0, dim, Number>::Tensor()
   // Some auto-differentiable numbers need explicit
   // zero initialization such as adtl::adouble.
@@ -966,7 +966,7 @@ Tensor<0, dim, Number>::Tensor()
 
 template <int dim, typename Number>
 template <typename OtherNumber>
-constexpr DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV
+constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
 Tensor<0, dim, Number>::Tensor(const OtherNumber &initializer)
   : value(internal::NumberType<Number>::value(initializer))
 {}
@@ -975,7 +975,7 @@ Tensor<0, dim, Number>::Tensor(const OtherNumber &initializer)
 
 template <int dim, typename Number>
 template <typename OtherNumber>
-constexpr DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV
+constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
 Tensor<0, dim, Number>::Tensor(const Tensor<0, dim, OtherNumber> &p)
   : Tensor{p.value}
 {}
@@ -983,7 +983,7 @@ Tensor<0, dim, Number>::Tensor(const Tensor<0, dim, OtherNumber> &p)
 
 #  ifdef DEAL_II_DELETED_MOVE_CONSTRUCTOR_BUG
 template <int dim, typename Number>
-constexpr DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV
+constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
 Tensor<0, dim, Number>::Tensor(const Tensor<0, dim, Number> &other)
   : value{other.value}
 {}
@@ -991,7 +991,7 @@ Tensor<0, dim, Number>::Tensor(const Tensor<0, dim, Number> &other)
 
 
 template <int dim, typename Number>
-constexpr DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV
+constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
 Tensor<0, dim, Number>::Tensor(Tensor<0, dim, Number> &&other) noexcept
   : value{std::move(other.value)}
 {}
@@ -1035,7 +1035,7 @@ Tensor<0, dim, Number>::end_raw() const
 
 
 template <int dim, typename Number>
-constexpr inline DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV
+constexpr inline DEAL_II_HOST_DEV_ALWAYS_INLINE
 Tensor<0, dim, Number>::operator Number &()
 {
   // We cannot use Assert inside a CUDA kernel
@@ -1063,7 +1063,7 @@ constexpr inline DEAL_II_ALWAYS_INLINE
 
 template <int dim, typename Number>
 template <typename OtherNumber>
-constexpr inline DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV Tensor<0, dim, Number> &
+constexpr inline DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number> &
 Tensor<0, dim, Number>::operator=(const Tensor<0, dim, OtherNumber> &p)
 {
   value = internal::NumberType<Number>::value(p.value);
@@ -1073,7 +1073,7 @@ Tensor<0, dim, Number>::operator=(const Tensor<0, dim, OtherNumber> &p)
 
 #  if defined(__INTEL_COMPILER) || defined(DEAL_II_DELETED_MOVE_CONSTRUCTOR_BUG)
 template <int dim, typename Number>
-constexpr inline DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV Tensor<0, dim, Number> &
+constexpr inline DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number> &
 Tensor<0, dim, Number>::operator=(const Tensor<0, dim, Number> &p)
 {
   value = p.value;
@@ -1083,7 +1083,7 @@ Tensor<0, dim, Number>::operator=(const Tensor<0, dim, Number> &p)
 
 #  ifdef DEAL_II_DELETED_MOVE_CONSTRUCTOR_BUG
 template <int dim, typename Number>
-constexpr DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV Tensor<0, dim, Number> &
+constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number> &
 Tensor<0, dim, Number>::operator=(Tensor<0, dim, Number> &&other) noexcept
 {
   value = std::move(other.value);
@@ -1095,7 +1095,7 @@ Tensor<0, dim, Number>::operator=(Tensor<0, dim, Number> &&other) noexcept
 
 template <int dim, typename Number>
 template <typename OtherNumber>
-constexpr inline DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV Tensor<0, dim, Number> &
+constexpr inline DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number> &
 Tensor<0, dim, Number>::operator=(const OtherNumber &d)
 {
   value = internal::NumberType<Number>::value(d);
@@ -1131,7 +1131,7 @@ Tensor<0, dim, Number>::operator!=(const Tensor<0, dim, OtherNumber> &p) const
 
 template <int dim, typename Number>
 template <typename OtherNumber>
-constexpr inline DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV Tensor<0, dim, Number> &
+constexpr inline DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number> &
 Tensor<0, dim, Number>::operator+=(const Tensor<0, dim, OtherNumber> &p)
 {
   value += p.value;
@@ -1141,7 +1141,7 @@ Tensor<0, dim, Number>::operator+=(const Tensor<0, dim, OtherNumber> &p)
 
 template <int dim, typename Number>
 template <typename OtherNumber>
-constexpr inline DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV Tensor<0, dim, Number> &
+constexpr inline DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number> &
 Tensor<0, dim, Number>::operator-=(const Tensor<0, dim, OtherNumber> &p)
 {
   value -= p.value;
@@ -1155,7 +1155,7 @@ namespace internal
   namespace ComplexWorkaround
   {
     template <typename Number, typename OtherNumber>
-    constexpr inline DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV void
+    constexpr inline DEAL_II_HOST_DEV_ALWAYS_INLINE void
     multiply_assign_scalar(Number &val, const OtherNumber &s)
     {
       val *= s;
@@ -1163,7 +1163,7 @@ namespace internal
 
 #  ifdef __CUDA_ARCH__
     template <typename Number, typename OtherNumber>
-    constexpr inline DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV void
+    constexpr inline DEAL_II_HOST_DEV_ALWAYS_INLINE void
     multiply_assign_scalar(std::complex<Number> &, const OtherNumber &)
     {
       printf("This function is not implemented for std::complex<Number>!\n");
@@ -1176,7 +1176,7 @@ namespace internal
 
 template <int dim, typename Number>
 template <typename OtherNumber>
-constexpr inline DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV Tensor<0, dim, Number> &
+constexpr inline DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number> &
 Tensor<0, dim, Number>::operator*=(const OtherNumber &s)
 {
   internal::ComplexWorkaround::multiply_assign_scalar(value, s);
@@ -1196,7 +1196,7 @@ Tensor<0, dim, Number>::operator/=(const OtherNumber &s)
 
 
 template <int dim, typename Number>
-constexpr DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV Tensor<0, dim, Number>
+constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number>
 Tensor<0, dim, Number>::operator-() const
 {
   return -value;
@@ -1285,7 +1285,7 @@ constexpr unsigned int Tensor<0, dim, Number>::n_independent_components;
 
 template <int rank_, int dim, typename Number>
 template <typename ArrayLike, std::size_t... indices>
-constexpr DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV
+constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
 Tensor<rank_, dim, Number>::Tensor(const ArrayLike &initializer,
                                    std::index_sequence<indices...>)
   : values{Tensor<rank_ - 1, dim, Number>(initializer[indices])...}
@@ -1297,7 +1297,7 @@ Tensor<rank_, dim, Number>::Tensor(const ArrayLike &initializer,
 
 
 template <int rank_, int dim, typename Number>
-constexpr DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV
+constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
 Tensor<rank_, dim, Number>::Tensor()
   // We would like to use =default, but this causes compile errors with some
   // MSVC versions and internal compiler errors with -O1 in gcc 5.4.
@@ -1307,7 +1307,7 @@ Tensor<rank_, dim, Number>::Tensor()
 
 
 template <int rank_, int dim, typename Number>
-constexpr DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV
+constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
 Tensor<rank_, dim, Number>::Tensor(const array_type &initializer)
   : Tensor(initializer, std::make_index_sequence<dim>{})
 {}
@@ -1316,7 +1316,7 @@ Tensor<rank_, dim, Number>::Tensor(const array_type &initializer)
 
 template <int rank_, int dim, typename Number>
 template <typename ElementType, typename MemorySpace>
-constexpr DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV
+constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
 Tensor<rank_, dim, Number>::Tensor(
   const ArrayView<ElementType, MemorySpace> &initializer)
 {
@@ -1333,7 +1333,7 @@ Tensor<rank_, dim, Number>::Tensor(
 
 template <int rank_, int dim, typename Number>
 template <typename OtherNumber>
-constexpr DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV
+constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
 Tensor<rank_, dim, Number>::Tensor(
   const Tensor<rank_, dim, OtherNumber> &initializer)
   : Tensor(initializer, std::make_index_sequence<dim>{})
@@ -1385,7 +1385,7 @@ namespace internal
   namespace TensorSubscriptor
   {
     template <typename ArrayElementType, int dim>
-    constexpr inline DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV ArrayElementType &
+    constexpr inline DEAL_II_HOST_DEV_ALWAYS_INLINE ArrayElementType &
     subscript(ArrayElementType * values,
               const unsigned int i,
               std::integral_constant<int, dim>)
@@ -1398,7 +1398,7 @@ namespace internal
     }
 
     template <typename ArrayElementType>
-    constexpr inline DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV ArrayElementType &
+    constexpr inline DEAL_II_HOST_DEV_ALWAYS_INLINE ArrayElementType &
     subscript(ArrayElementType *dummy,
               const unsigned int,
               std::integral_constant<int, 0>)
@@ -1417,7 +1417,7 @@ namespace internal
 
 
 template <int rank_, int dim, typename Number>
-constexpr inline DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV
+constexpr inline DEAL_II_HOST_DEV_ALWAYS_INLINE
   typename Tensor<rank_, dim, Number>::value_type &
   Tensor<rank_, dim, Number>::operator[](const unsigned int i)
 {
@@ -1712,7 +1712,7 @@ Tensor<rank_, dim, Number>::norm() const
 
 
 template <int rank_, int dim, typename Number>
-constexpr inline DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV
+constexpr inline DEAL_II_HOST_DEV_ALWAYS_INLINE
   typename numbers::NumberTraits<Number>::real_type
   Tensor<rank_, dim, Number>::norm_square() const
 {
@@ -2005,7 +2005,7 @@ DEAL_II_HOST_DEV constexpr DEAL_II_ALWAYS_INLINE
  * @relatesalso Tensor
  */
 template <int dim, typename Number, typename OtherNumber>
-constexpr DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV
+constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
   Tensor<0, dim, typename ProductType<Number, OtherNumber>::type>
   operator+(const Tensor<0, dim, Number> &     p,
             const Tensor<0, dim, OtherNumber> &q)
@@ -2022,7 +2022,7 @@ constexpr DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV
  * @relatesalso Tensor
  */
 template <int dim, typename Number, typename OtherNumber>
-constexpr DEAL_II_ALWAYS_INLINE DEAL_II_HOST_DEV
+constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
   Tensor<0, dim, typename ProductType<Number, OtherNumber>::type>
   operator-(const Tensor<0, dim, Number> &     p,
             const Tensor<0, dim, OtherNumber> &q)

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1035,7 +1035,7 @@ Tensor<0, dim, Number>::end_raw() const
 
 
 template <int dim, typename Number>
-constexpr inline DEAL_II_HOST_DEV_ALWAYS_INLINE
+constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
 Tensor<0, dim, Number>::operator Number &()
 {
   // We cannot use Assert inside a CUDA kernel
@@ -1063,7 +1063,7 @@ constexpr inline DEAL_II_ALWAYS_INLINE
 
 template <int dim, typename Number>
 template <typename OtherNumber>
-constexpr inline DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number> &
+constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number> &
 Tensor<0, dim, Number>::operator=(const Tensor<0, dim, OtherNumber> &p)
 {
   value = internal::NumberType<Number>::value(p.value);
@@ -1073,7 +1073,7 @@ Tensor<0, dim, Number>::operator=(const Tensor<0, dim, OtherNumber> &p)
 
 #  if defined(__INTEL_COMPILER) || defined(DEAL_II_DELETED_MOVE_CONSTRUCTOR_BUG)
 template <int dim, typename Number>
-constexpr inline DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number> &
+constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number> &
 Tensor<0, dim, Number>::operator=(const Tensor<0, dim, Number> &p)
 {
   value = p.value;
@@ -1095,7 +1095,7 @@ Tensor<0, dim, Number>::operator=(Tensor<0, dim, Number> &&other) noexcept
 
 template <int dim, typename Number>
 template <typename OtherNumber>
-constexpr inline DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number> &
+constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number> &
 Tensor<0, dim, Number>::operator=(const OtherNumber &d)
 {
   value = internal::NumberType<Number>::value(d);
@@ -1131,7 +1131,7 @@ Tensor<0, dim, Number>::operator!=(const Tensor<0, dim, OtherNumber> &p) const
 
 template <int dim, typename Number>
 template <typename OtherNumber>
-constexpr inline DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number> &
+constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number> &
 Tensor<0, dim, Number>::operator+=(const Tensor<0, dim, OtherNumber> &p)
 {
   value += p.value;
@@ -1141,7 +1141,7 @@ Tensor<0, dim, Number>::operator+=(const Tensor<0, dim, OtherNumber> &p)
 
 template <int dim, typename Number>
 template <typename OtherNumber>
-constexpr inline DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number> &
+constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number> &
 Tensor<0, dim, Number>::operator-=(const Tensor<0, dim, OtherNumber> &p)
 {
   value -= p.value;
@@ -1155,7 +1155,7 @@ namespace internal
   namespace ComplexWorkaround
   {
     template <typename Number, typename OtherNumber>
-    constexpr inline DEAL_II_HOST_DEV_ALWAYS_INLINE void
+    constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE void
     multiply_assign_scalar(Number &val, const OtherNumber &s)
     {
       val *= s;
@@ -1163,7 +1163,7 @@ namespace internal
 
 #  ifdef __CUDA_ARCH__
     template <typename Number, typename OtherNumber>
-    constexpr inline DEAL_II_HOST_DEV_ALWAYS_INLINE void
+    constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE void
     multiply_assign_scalar(std::complex<Number> &, const OtherNumber &)
     {
       printf("This function is not implemented for std::complex<Number>!\n");
@@ -1176,7 +1176,7 @@ namespace internal
 
 template <int dim, typename Number>
 template <typename OtherNumber>
-constexpr inline DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number> &
+constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE Tensor<0, dim, Number> &
 Tensor<0, dim, Number>::operator*=(const OtherNumber &s)
 {
   internal::ComplexWorkaround::multiply_assign_scalar(value, s);
@@ -1385,10 +1385,10 @@ namespace internal
   namespace TensorSubscriptor
   {
     template <typename ArrayElementType, int dim>
-    constexpr inline DEAL_II_HOST_DEV_ALWAYS_INLINE ArrayElementType &
-    subscript(ArrayElementType * values,
-              const unsigned int i,
-              std::integral_constant<int, dim>)
+    constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE ArrayElementType &
+                                             subscript(ArrayElementType * values,
+                                                       const unsigned int i,
+                                                       std::integral_constant<int, dim>)
     {
       // We cannot use Assert in a CUDA kernel
 #  ifndef __CUDA_ARCH__
@@ -1398,10 +1398,10 @@ namespace internal
     }
 
     template <typename ArrayElementType>
-    constexpr inline DEAL_II_HOST_DEV_ALWAYS_INLINE ArrayElementType &
-    subscript(ArrayElementType *dummy,
-              const unsigned int,
-              std::integral_constant<int, 0>)
+    constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE ArrayElementType &
+                                             subscript(ArrayElementType *dummy,
+                                                       const unsigned int,
+                                                       std::integral_constant<int, 0>)
     {
       // We cannot use Assert in a CUDA kernel
 #  ifndef __CUDA_ARCH__
@@ -1417,7 +1417,7 @@ namespace internal
 
 
 template <int rank_, int dim, typename Number>
-constexpr inline DEAL_II_HOST_DEV_ALWAYS_INLINE
+constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
   typename Tensor<rank_, dim, Number>::value_type &
   Tensor<rank_, dim, Number>::operator[](const unsigned int i)
 {
@@ -1712,7 +1712,7 @@ Tensor<rank_, dim, Number>::norm() const
 
 
 template <int rank_, int dim, typename Number>
-constexpr inline DEAL_II_HOST_DEV_ALWAYS_INLINE
+constexpr DEAL_II_HOST_DEV_ALWAYS_INLINE
   typename numbers::NumberTraits<Number>::real_type
   Tensor<rank_, dim, Number>::norm_square() const
 {

--- a/include/deal.II/matrix_free/hanging_nodes_internal.h
+++ b/include/deal.II/matrix_free/hanging_nodes_internal.h
@@ -199,7 +199,7 @@ namespace internal
      * would be an integer which would in turn trigger a compiler warning when
      * we tried to assign it to an object of type UpdateFlags.
      */
-    DEAL_II_HOST_DEV inline ConstraintKinds
+    DEAL_II_HOST_DEVICE inline ConstraintKinds
     operator|(const ConstraintKinds f1, const ConstraintKinds f2)
     {
       return static_cast<ConstraintKinds>(static_cast<std::uint16_t>(f1) |
@@ -212,7 +212,7 @@ namespace internal
      * Global operator which sets the bits from the second argument also in the
      * first one.
      */
-    DEAL_II_HOST_DEV inline ConstraintKinds &
+    DEAL_II_HOST_DEVICE inline ConstraintKinds &
     operator|=(ConstraintKinds &f1, const ConstraintKinds f2)
     {
       f1 = f1 | f2;
@@ -224,7 +224,7 @@ namespace internal
     /**
      * Global operator which checks inequality.
      */
-    DEAL_II_HOST_DEV inline bool
+    DEAL_II_HOST_DEVICE inline bool
     operator!=(const ConstraintKinds f1, const ConstraintKinds f2)
     {
       return static_cast<std::uint16_t>(f1) != static_cast<std::uint16_t>(f2);
@@ -236,7 +236,7 @@ namespace internal
      * Global operator which checks if the first argument is less than the
      * second.
      */
-    DEAL_II_HOST_DEV inline bool
+    DEAL_II_HOST_DEVICE inline bool
     operator<(const ConstraintKinds f1, const ConstraintKinds f2)
     {
       return static_cast<std::uint16_t>(f1) < static_cast<std::uint16_t>(f2);
@@ -247,7 +247,7 @@ namespace internal
     /**
      * Global operator which performs a binary and for the provided arguments.
      */
-    DEAL_II_HOST_DEV inline ConstraintKinds
+    DEAL_II_HOST_DEVICE inline ConstraintKinds
     operator&(const ConstraintKinds f1, const ConstraintKinds f2)
     {
       return static_cast<ConstraintKinds>(static_cast<std::uint16_t>(f1) &


### PR DESCRIPTION
Follow-up to #14453. As mentioned there, it's not quite clear if `DEAL_II_ALWAYS_INLINE` did the correct thing for `__host__ __device__` functions. We should really let `Kokkos` handle the correct flags (but we don't want to use `KOKKOS_FORCEINLINE_FUNCTION` directly).