### PR TITLE
Cleanup reinit() of PETSc/Trilinos BlockVector.

### DIFF
--- a/tests/gla/block_vec_04.mpirun=2.debug.output
+++ b/tests/gla/block_vec_04.mpirun=2.debug.output
@@ -1,11 +1,11 @@
 
 DEAL:0:PETSc::numproc=2
-DEAL:0:PETSc::Exception: ExcDimensionMismatch(n_blocks(), v.n_blocks())
+DEAL:0:PETSc::Exception: ExcDimensionMismatch(this->n_blocks(), v.n_blocks())
 DEAL:0:PETSc::OK
 DEAL:0:Trilinos::numproc=2
-DEAL:0:Trilinos::Exception: ExcDimensionMismatch(n_blocks(), v.n_blocks())
+DEAL:0:Trilinos::Exception: ExcDimensionMismatch(this->n_blocks(), v.n_blocks())
 DEAL:0:Trilinos::OK
 
-DEAL:1:PETSc::Exception: ExcDimensionMismatch(n_blocks(), v.n_blocks())
-DEAL:1:Trilinos::Exception: ExcDimensionMismatch(n_blocks(), v.n_blocks())
+DEAL:1:PETSc::Exception: ExcDimensionMismatch(this->n_blocks(), v.n_blocks())
+DEAL:1:Trilinos::Exception: ExcDimensionMismatch(this->n_blocks(), v.n_blocks())
 


### PR DESCRIPTION
- `n_blocks()` returns an `unsigned int`. I matched types in loops.
- `resize()` does nothing when called with same size. We don't need to check for differing sizes beforehand.
- `collect_sizes()` updates the `BlockIndices` object. Although we can omit this part in assignment or copy operations, it's better to keep it up-to-date and rather be safe than sorry.
- `block(i)` returns the i-th component. Depending on the context, I found it easier to read to use either `block(i)` or `component[i]`.