### PR TITLE
Inline most of the remaining functions in VtuStream into write_vtu_main().

### DIFF
--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -2986,7 +2986,7 @@ namespace DataOutBase
 
                 case 1:
                   {
-                    const unsigned int d1 = 1;
+                    constexpr unsigned int d1 = 1;
 
                     for (unsigned int i1 = 0; i1 < n_subdivisions; ++i1)
                       {
@@ -3000,8 +3000,8 @@ namespace DataOutBase
 
                 case 2:
                   {
-                    const unsigned int d1 = 1;
-                    const unsigned int d2 = n;
+                    constexpr unsigned int d1 = 1;
+                    const unsigned int     d2 = n;
 
                     for (unsigned int i2 = 0; i2 < n_subdivisions; ++i2)
                       for (unsigned int i1 = 0; i1 < n_subdivisions; ++i1)
@@ -3018,9 +3018,9 @@ namespace DataOutBase
 
                 case 3:
                   {
-                    const unsigned int d1 = 1;
-                    const unsigned int d2 = n;
-                    const unsigned int d3 = n * n;
+                    constexpr unsigned int d1 = 1;
+                    const unsigned int     d2 = n;
+                    const unsigned int     d3 = n * n;
 
                     for (unsigned int i3 = 0; i3 < n_subdivisions; ++i3)
                       for (unsigned int i2 = 0; i2 < n_subdivisions; ++i2)
@@ -3093,9 +3093,9 @@ namespace DataOutBase
             const unsigned int n2 = (dim > 1) ? n_subdivisions : 0;
             const unsigned int n3 = (dim > 2) ? n_subdivisions : 0;
             // Offsets of outer loops
-            const unsigned int d1 = 1;
-            const unsigned int d2 = n;
-            const unsigned int d3 = n * n;
+            constexpr unsigned int d1 = 1;
+            const unsigned int     d2 = n;
+            const unsigned int     d3 = n * n;
             for (unsigned int i3 = 0; i3 <= n3; ++i3)
               for (unsigned int i2 = 0; i2 <= n2; ++i2)
                 for (unsigned int i1 = 0; i1 <= n1; ++i1)
@@ -6219,10 +6219,10 @@ namespace DataOutBase
 
                     case 1:
                       {
-                        const unsigned int d1 = 1;
+                        constexpr unsigned int d1 = 1;
 
                         auto write_cell =
-                          [&flags, &out, &cells, d1](const unsigned int start) {
+                          [&flags, &out, &cells](const unsigned int start) {
                             if (deal_ii_with_zlib &&
                                 (flags.compression_level !=
                                  DataOutBase::CompressionLevel::plain_text))
@@ -6248,27 +6248,27 @@ namespace DataOutBase
 
                     case 2:
                       {
-                        const unsigned int d1 = 1;
-                        const unsigned int d2 = n;
+                        constexpr unsigned int d1 = 1;
+                        const unsigned int     d2 = n;
 
-                        auto write_cell = [&flags, &out, &cells, d1, d2](
-                                            const unsigned int start) {
-                          if (deal_ii_with_zlib &&
-                              (flags.compression_level !=
-                               DataOutBase::CompressionLevel::plain_text))
-                            {
-                              cells.push_back(start);
-                              cells.push_back(start + d1);
-                              cells.push_back(start + d2 + d1);
-                              cells.push_back(start + d2);
-                            }
-                          else
-                            {
-                              out << start << '\t' << start + d1 << '\t'
-                                  << start + d2 + d1 << '\t' << start + d2;
-                              out << '\n';
-                            }
-                        };
+                        auto write_cell =
+                          [&flags, &out, &cells, d2](const unsigned int start) {
+                            if (deal_ii_with_zlib &&
+                                (flags.compression_level !=
+                                 DataOutBase::CompressionLevel::plain_text))
+                              {
+                                cells.push_back(start);
+                                cells.push_back(start + d1);
+                                cells.push_back(start + d2 + d1);
+                                cells.push_back(start + d2);
+                              }
+                            else
+                              {
+                                out << start << '\t' << start + d1 << '\t'
+                                    << start + d2 + d1 << '\t' << start + d2;
+                                out << '\n';
+                              }
+                          };
 
                         for (unsigned int i2 = 0; i2 < n_subdivisions; ++i2)
                           for (unsigned int i1 = 0; i1 < n_subdivisions; ++i1)
@@ -6282,11 +6282,11 @@ namespace DataOutBase
 
                     case 3:
                       {
-                        const unsigned int d1 = 1;
-                        const unsigned int d2 = n;
-                        const unsigned int d3 = n * n;
+                        constexpr unsigned int d1 = 1;
+                        const unsigned int     d2 = n;
+                        const unsigned int     d3 = n * n;
 
-                        auto write_cell = [&flags, &out, &cells, d1, d2, d3](
+                        auto write_cell = [&flags, &out, &cells, d2, d3](
                                             const unsigned int start) {
                           if (deal_ii_with_zlib &&
                               (flags.compression_level !=

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -6311,9 +6311,12 @@ namespace DataOutBase
                   {
                     case 0:
                       {
-                        const unsigned int offset = first_vertex_of_patch;
+                        const unsigned int starting_offset =
+                          first_vertex_of_patch;
                         // First write line in x direction
-                        vtu_out.template write_cell<0>(count++, offset, {});
+                        vtu_out.template write_cell<0>(count++,
+                                                       starting_offset,
+                                                       {});
                         break;
                       }
 
@@ -6322,11 +6325,11 @@ namespace DataOutBase
                         const unsigned int d1 = 1;
                         for (unsigned int i1 = 0; i1 < n_subdivisions; ++i1)
                           {
-                            const unsigned int offset =
+                            const unsigned int starting_offset =
                               first_vertex_of_patch + i1 * d1;
                             // First write line in x direction
                             vtu_out.template write_cell<1>(count++,
-                                                           offset,
+                                                           starting_offset,
                                                            {{d1}});
                           }
                         break;
@@ -6339,11 +6342,11 @@ namespace DataOutBase
                         for (unsigned int i2 = 0; i2 < n_subdivisions; ++i2)
                           for (unsigned int i1 = 0; i1 < n_subdivisions; ++i1)
                             {
-                              const unsigned int offset =
+                              const unsigned int starting_offset =
                                 first_vertex_of_patch + i2 * d2 + i1 * d1;
                               // First write line in x direction
                               vtu_out.template write_cell<2>(count++,
-                                                             offset,
+                                                             starting_offset,
                                                              {{d1, d2}});
                             }
                         break;
@@ -6358,12 +6361,12 @@ namespace DataOutBase
                           for (unsigned int i2 = 0; i2 < n_subdivisions; ++i2)
                             for (unsigned int i1 = 0; i1 < n_subdivisions; ++i1)
                               {
-                                const unsigned int offset =
+                                const unsigned int starting_offset =
                                   first_vertex_of_patch + i3 * d3 + i2 * d2 +
                                   i1 * d1;
                                 // First write line in x direction
                                 vtu_out.template write_cell<3>(count++,
-                                                               offset,
+                                                               starting_offset,
                                                                {{d1, d2, d3}});
                               }
                         break;

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -6190,7 +6190,7 @@ namespace DataOutBase
             else
               {
                 const unsigned int n_subdivisions = patch.n_subdivisions;
-                const unsigned int n              = n_subdivisions + 1;
+                const unsigned int n_points_per_direction = n_subdivisions + 1;
 
                 switch (dim)
                   {
@@ -6219,8 +6219,6 @@ namespace DataOutBase
 
                     case 1:
                       {
-                        constexpr unsigned int d1 = 1;
-
                         auto write_cell =
                           [&flags, &out, &cells](const unsigned int start) {
                             if (deal_ii_with_zlib &&
@@ -6228,11 +6226,11 @@ namespace DataOutBase
                                  DataOutBase::CompressionLevel::plain_text))
                               {
                                 cells.push_back(start);
-                                cells.push_back(start + d1);
+                                cells.push_back(start + 1);
                               }
                             else
                               {
-                                out << start << '\t' << start + d1;
+                                out << start << '\t' << start + 1;
                                 out << '\n';
                               }
                           };
@@ -6240,7 +6238,7 @@ namespace DataOutBase
                         for (unsigned int i1 = 0; i1 < n_subdivisions; ++i1)
                           {
                             const unsigned int starting_offset =
-                              first_vertex_of_patch + i1 * d1;
+                              first_vertex_of_patch + i1;
                             write_cell(starting_offset);
                           }
                         break;
@@ -6248,24 +6246,24 @@ namespace DataOutBase
 
                     case 2:
                       {
-                        constexpr unsigned int d1 = 1;
-                        const unsigned int     d2 = n;
-
                         auto write_cell =
-                          [&flags, &out, &cells, d2](const unsigned int start) {
+                          [&flags, &out, &cells, n_points_per_direction](
+                            const unsigned int start) {
                             if (deal_ii_with_zlib &&
                                 (flags.compression_level !=
                                  DataOutBase::CompressionLevel::plain_text))
                               {
                                 cells.push_back(start);
-                                cells.push_back(start + d1);
-                                cells.push_back(start + d2 + d1);
-                                cells.push_back(start + d2);
+                                cells.push_back(start + 1);
+                                cells.push_back(start + n_points_per_direction +
+                                                1);
+                                cells.push_back(start + n_points_per_direction);
                               }
                             else
                               {
-                                out << start << '\t' << start + d1 << '\t'
-                                    << start + d2 + d1 << '\t' << start + d2;
+                                out << start << '\t' << start + 1 << '\t'
+                                    << start + n_points_per_direction + 1
+                                    << '\t' << start + n_points_per_direction;
                                 out << '\n';
                               }
                           };
@@ -6274,7 +6272,8 @@ namespace DataOutBase
                           for (unsigned int i1 = 0; i1 < n_subdivisions; ++i1)
                             {
                               const unsigned int starting_offset =
-                                first_vertex_of_patch + i2 * d2 + i1 * d1;
+                                first_vertex_of_patch +
+                                i2 * n_points_per_direction + i1;
                               write_cell(starting_offset);
                             }
                         break;
@@ -6282,33 +6281,57 @@ namespace DataOutBase
 
                     case 3:
                       {
-                        constexpr unsigned int d1 = 1;
-                        const unsigned int     d2 = n;
-                        const unsigned int     d3 = n * n;
-
-                        auto write_cell = [&flags, &out, &cells, d2, d3](
+                        auto write_cell = [&flags,
+                                           &out,
+                                           &cells,
+                                           n_points_per_direction](
                                             const unsigned int start) {
                           if (deal_ii_with_zlib &&
                               (flags.compression_level !=
                                DataOutBase::CompressionLevel::plain_text))
                             {
                               cells.push_back(start);
-                              cells.push_back(start + d1);
-                              cells.push_back(start + d2 + d1);
-                              cells.push_back(start + d2);
-                              cells.push_back(start + d3);
-                              cells.push_back(start + d3 + d1);
-                              cells.push_back(start + d3 + d2 + d1);
-                              cells.push_back(start + d3 + d2);
+                              cells.push_back(start + 1);
+                              cells.push_back(start + n_points_per_direction +
+                                              1);
+                              cells.push_back(start + n_points_per_direction);
+                              cells.push_back(start + n_points_per_direction *
+                                                        n_points_per_direction);
+                              cells.push_back(start +
+                                              n_points_per_direction *
+                                                n_points_per_direction +
+                                              1);
+                              cells.push_back(start +
+                                              n_points_per_direction *
+                                                n_points_per_direction +
+                                              n_points_per_direction + 1);
+                              cells.push_back(start +
+                                              n_points_per_direction *
+                                                n_points_per_direction +
+                                              n_points_per_direction);
                             }
                           else
                             {
-                              out << start << '\t' << start + d1 << '\t'
-                                  << start + d2 + d1 << '\t' << start + d2
-                                  << '\t' << start + d3 << '\t'
-                                  << start + d3 + d1 << '\t'
-                                  << start + d3 + d2 + d1 << '\t'
-                                  << start + d3 + d2;
+                              out << start << '\t' << start + 1 << '\t'
+                                  << start + n_points_per_direction + 1 << '\t'
+                                  << start + n_points_per_direction << '\t'
+                                  << start + n_points_per_direction *
+                                               n_points_per_direction
+                                  << '\t'
+                                  << start +
+                                       n_points_per_direction *
+                                         n_points_per_direction +
+                                       1
+                                  << '\t'
+                                  << start +
+                                       n_points_per_direction *
+                                         n_points_per_direction +
+                                       n_points_per_direction + 1
+                                  << '\t'
+                                  << start +
+                                       n_points_per_direction *
+                                         n_points_per_direction +
+                                       n_points_per_direction;
                               out << '\n';
                             }
                         };
@@ -6318,8 +6341,10 @@ namespace DataOutBase
                             for (unsigned int i1 = 0; i1 < n_subdivisions; ++i1)
                               {
                                 const unsigned int starting_offset =
-                                  first_vertex_of_patch + i3 * d3 + i2 * d2 +
-                                  i1 * d1;
+                                  first_vertex_of_patch +
+                                  i3 * n_points_per_direction *
+                                    n_points_per_direction +
+                                  i2 * n_points_per_direction + i1;
                                 write_cell(starting_offset);
                               }
                         break;


### PR DESCRIPTION
Only the higher-order cell output is left now, and the use of `VtuStream` is confined to only a 4-line block.

Part of #14403.

/rebuild