### PR TITLE
Remove obsolete doxygen tags.

### DIFF
--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -271,7 +271,6 @@ EXTERNAL_GROUPS        = YES
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
 
-CLASS_DIAGRAMS         = YES
 HIDE_UNDOC_RELATIONS   = NO
 HAVE_DOT               = YES
 CLASS_GRAPH            = YES
@@ -287,7 +286,6 @@ GRAPHICAL_HIERARCHY    = NO
 DIRECTORY_GRAPH        = YES
 DOT_IMAGE_FORMAT       = svg
 MAX_DOT_GRAPH_DEPTH    = 5
-DOT_TRANSPARENT        = NO
 GENERATE_LEGEND        = YES
 
 DOT_CLEANUP            = YES


### PR DESCRIPTION
Building the documentation locally triggers the following warnings for me.
```
warning: Tag 'CLASS_DIAGRAMS' at line 274 of file 'options.dox' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
warning: Tag 'DOT_TRANSPARENT' at line 290 of file 'options.dox' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
```

I went ahead and updated the options file, and I got the following response.
```
warning: Tag 'CLASS_DIAGRAMS' at line 274 of file 'options.dox' has become obsolete.
         This tag has been removed.
warning: Tag 'DOT_TRANSPARENT' at line 290 of file 'options.dox' has become obsolete.
         This tag has been removed.
```

So I guess it's safe to remove these tags.

I use `doxygen 1.9.5`.