### PR TITLE
CMake: Update forgotten find_package() call

### DIFF
--- a/cmake/configure/configure_50_arborx.cmake
+++ b/cmake/configure/configure_50_arborx.cmake
@@ -21,7 +21,7 @@ set(FEATURE_ARBORX_AFTER MPI)
 set(FEATURE_ARBORX_DEPENDS KOKKOS)
 
 macro(feature_arborx_find_external var)
-  find_package(ARBORX)
+  find_package(DEAL_II_ARBORX)
 
   if(ARBORX_FOUND)
     #


### PR DESCRIPTION
Updating this find_package() call got lost somewhere while rebasing
during all of the pull request merges.