### PR TITLE
Some AffineConstraints instantiations.

### DIFF
--- a/source/lac/affine_constraints.cc
+++ b/source/lac/affine_constraints.cc
@@ -124,6 +124,8 @@ INSTANTIATE_DLTG_VECTOR(TrilinosWrappers::MPI::Vector);
 
 INSTANTIATE_DLTG_VECTORMATRIX(TrilinosWrappers::SparseMatrix, Vector<double>);
 INSTANTIATE_DLTG_VECTORMATRIX(TrilinosWrappers::SparseMatrix,
+                              LinearAlgebra::distributed::Vector<double>);
+INSTANTIATE_DLTG_VECTORMATRIX(TrilinosWrappers::SparseMatrix,
                               TrilinosWrappers::MPI::Vector);
 
 INSTANTIATE_DLTG_BLOCK_VECTORMATRIX(TrilinosWrappers::BlockSparseMatrix,

--- a/source/lac/affine_constraints.cc
+++ b/source/lac/affine_constraints.cc
@@ -130,6 +130,9 @@ INSTANTIATE_DLTG_VECTORMATRIX(TrilinosWrappers::SparseMatrix,
 
 INSTANTIATE_DLTG_BLOCK_VECTORMATRIX(TrilinosWrappers::BlockSparseMatrix,
                                     Vector<double>);
+INSTANTIATE_DLTG_BLOCK_VECTORMATRIX(
+  TrilinosWrappers::BlockSparseMatrix,
+  LinearAlgebra::distributed::BlockVector<double>);
 INSTANTIATE_DLTG_BLOCK_VECTORMATRIX(TrilinosWrappers::BlockSparseMatrix,
                                     TrilinosWrappers::MPI::BlockVector);
 

--- a/source/lac/affine_constraints.inst.in
+++ b/source/lac/affine_constraints.inst.in
@@ -171,24 +171,6 @@ for (S : REAL_AND_COMPLEX_SCALARS; T : DEAL_II_VEC_TEMPLATES)
             std::integral_constant<bool, false>) const;
   }
 
-// TrilinosWrappers::SparseMatrix:
-
-for (T : DEAL_II_VEC_TEMPLATES)
-  {
-#ifdef DEAL_II_WITH_TRILINOS
-    template void AffineConstraints<double>::distribute_local_to_global<
-      TrilinosWrappers::SparseMatrix,
-      LinearAlgebra::distributed::T<double>>(
-      const FullMatrix<double> &,
-      const Vector<double> &,
-      const std::vector<size_type> &,
-      TrilinosWrappers::SparseMatrix &,
-      LinearAlgebra::distributed::T<double> &,
-      bool,
-      std::integral_constant<bool, false>) const;
-#endif
-  }
-
 // BlockSparseMatrix:
 
 for (S : REAL_AND_COMPLEX_SCALARS)


### PR DESCRIPTION
I needed a `distribute_local_to_global` instantiation for `TrilinosWrappers::BlockSparseMatrix` and `LinearAlgebra::distributed::BlockVector<double>`.

I noticed we already had one for the non-block variants in `inst.in`, and found that this one was better suited for the part in the `.cc` file. So I moved it there.

Moves part of #9925.