### PR TITLE
Add more reinit() to LA::distributed::BlockVector.

### DIFF
--- a/include/deal.II/lac/la_parallel_block_vector.h
+++ b/include/deal.II/lac/la_parallel_block_vector.h
@@ -300,6 +300,35 @@ namespace LinearAlgebra
              const bool                  omit_zeroing_entries = false);
 
       /**
+       * Initialize the block vector. For each block, the local range is
+       * specified by the corresponding entry in @p local_ranges (note that this
+       * must be a contiguous interval, multiple intervals are not possible).
+       * The parameter @p ghost_indices specifies ghost indices for each block,
+       * i.e., indices which one might need to read data from or accumulate data
+       * from. It is allowed that the set of ghost indices also contains the
+       * local range, but it does not need to.
+       *
+       * This function involves global communication, so it should only be
+       * called once for a given layout. Use the @p reinit function with
+       * BlockVector<Number> argument to create additional vectors with the same
+       * parallel layout.
+       *
+       * @see
+       * @ref GlossGhostedVector "vectors with ghost elements"
+       */
+      void
+      reinit(const std::vector<IndexSet> &local_ranges,
+             const std::vector<IndexSet> &ghost_indices,
+             const MPI_Comm &             communicator);
+
+      /**
+       * Same as above, but without ghost entries.
+       */
+      void
+      reinit(const std::vector<IndexSet> &local_ranges,
+             const MPI_Comm &             communicator);
+
+      /**
        * This function copies the data that has accumulated in the data buffer
        * for ghost indices to the owning processor. For the meaning of the
        * argument @p operation, see the entry on

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -362,12 +362,12 @@ namespace LinearAlgebra
              const bool                          omit_zeroing_entries = false);
 
       /**
-       * Initialize the vector. The local range is specified by @p
-       * locally_owned_set (note that this must be a contiguous interval,
-       * multiple intervals are not possible). The IndexSet @p ghost_indices
-       * specifies ghost indices, i.e., indices which one might need to read
-       * data from or accumulate data from. It is allowed that the set of
-       * ghost indices also contains the local range, but it does not need to.
+       * Initialize the vector. The local range is specified by @p local_range
+       * (note that this must be a contiguous interval, multiple intervals are
+       * not possible). The IndexSet @p ghost_indices specifies ghost indices,
+       * i.e., indices which one might need to read data from or accumulate data
+       * from. It is allowed that the set of ghost indices also contains the
+       * local range, but it does not need to.
        *
        * This function involves global communication, so it should only be
        * called once for a given layout. Use the @p reinit function with


### PR DESCRIPTION
Part of #14426.

`LA::distributed::BlockVector` does not have those `reinit` functions that we use for the `Trilinos` and `PETSc` variants.

I cleaned up a few things along the way similar to #14476.