### PR TITLE
Don't make copies of expensive objects.

### DIFF
--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -759,8 +759,8 @@ namespace DoFRenumbering
                          const std::vector<unsigned int> &component_order_arg,
                          const bool                       is_level_operation)
   {
-    const hp::FECollection<dim, spacedim> fe_collection(
-      start->get_dof_handler().get_fe_collection());
+    const hp::FECollection<dim, spacedim> &fe_collection =
+      start->get_dof_handler().get_fe_collection();
 
     // do nothing if the FE has only
     // one component
@@ -1072,8 +1072,8 @@ namespace DoFRenumbering
                      const ENDITERATOR &                   end,
                      const bool                            is_level_operation)
   {
-    const hp::FECollection<dim, spacedim> fe_collection(
-      start->get_dof_handler().get_fe_collection());
+    const hp::FECollection<dim, spacedim> &fe_collection =
+      start->get_dof_handler().get_fe_collection();
 
     // do nothing if the FE has only
     // one component


### PR DESCRIPTION
`DoFHandler::get_fe_collection()` returns a reference. Store that reference, rather than making a copy of an expensive object.

/rebuild