### PR TITLE
CMake: rename quick tests to "quick_tests/<test>" and hook up to ctest

### DIFF
--- a/cmake/macros/macro_insource_setup_target.cmake
+++ b/cmake/macros/macro_insource_setup_target.cmake
@@ -14,17 +14,16 @@
 ## ---------------------------------------------------------------------
 
 #
-# This file provides an insource version of the DEAL_II_SETUP_TARGET macro.
+# This file provides an "insource" version of the DEAL_II_SETUP_TARGET macro.
 #
 # Usage:
-#       deal_ii_insource_setup_target(target build)
+#       insource_setup_target(target build)
 #
 # This appends necessary include directories, linker flags, compile
 # definitions and the deal.II library link interface to the given target.
 #
-#
 
-macro(deal_ii_insource_setup_target _target _build)
+function(insource_setup_target _target _build)
   string(TOLOWER ${_build} _build_lowercase)
 
   set_target_properties(${_target} PROPERTIES
@@ -60,12 +59,11 @@ macro(deal_ii_insource_setup_target _target _build)
     target_compile_definitions(${_target}
       PUBLIC ${DEAL_II_DEFINITIONS} ${DEAL_II_DEFINITIONS_${_build}}
       )
-
   endif()
 
-get_property(_type TARGET ${_target} PROPERTY TYPE)
-if(NOT "${_type}" STREQUAL "OBJECT_LIBRARY")
-  target_link_libraries(${_target} ${DEAL_II_NAMESPACE}_${_build_lowercase})
-endif()
+  get_property(_type TARGET ${_target} PROPERTY TYPE)
+  if(NOT "${_type}" STREQUAL "OBJECT_LIBRARY")
+    target_link_libraries(${_target} ${DEAL_II_NAMESPACE}_${_build_lowercase})
+  endif()
 
-endmacro()
+endfunction()

--- a/doc/news/changes/minor/20221129Maier
+++ b/doc/news/changes/minor/20221129Maier
@@ -1,0 +1,6 @@
+Improved: The quick_tests mechanism has been redesigned. The tests are now
+called <code>quick_tests/[tests].[build]</code> and can be invoked via
+ctest as well.
+<br>
+(Matthias Maier, 2022/11/29)
+

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -90,7 +90,7 @@ if(DEAL_II_COMPONENT_EXAMPLES)
         foreach(_build ${DEAL_II_BUILD_TYPES})
           string(TOLOWER ${_build} _build_lowercase)
           add_executable(${_name}.${_build_lowercase} ${_step})
-          deal_ii_insource_setup_target(${_name}.${_build_lowercase} ${_build})
+          insource_setup_target(${_name}.${_build_lowercase} ${_build})
           set_target_properties(${_name}.${_build_lowercase}
             PROPERTIES
             RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${DEAL_II_EXECUTABLE_RELDIR}"
@@ -129,7 +129,7 @@ if(DEAL_II_COMPONENT_EXAMPLES)
         foreach(_build ${DEAL_II_BUILD_TYPES})
           string(TOLOWER ${_build} _build_lowercase)
           add_executable(${_name}.${_build_lowercase} ${_step})
-          deal_ii_insource_setup_target(${_name}.${_build_lowercase} ${_build})
+          insource_setup_target(${_name}.${_build_lowercase} ${_build})
 
           set_target_properties(${_name}.${_build_lowercase}
             PROPERTIES

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -95,7 +95,9 @@ else()
   set(_options "-DDEAL_II_DIR=${DEAL_II_PATH}")
 endif()
 
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/CTestTestfile.cmake "")
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/CTestTestfile.cmake
+    "subdirs(quick_tests)\n"
+    )
 
 #
 # Always undefine the following variables in the setup_tests target:

--- a/tests/quick_tests/CMakeLists.txt
+++ b/tests/quick_tests/CMakeLists.txt
@@ -34,8 +34,10 @@ set(ALL_TESTS) # clean variable
 # define a macro to set up a quick test:
 macro(make_quicktest test_basename build_name mpi_run)
   string(TOLOWER ${build_name} _build_lowercase)
-  set(_target ${test_basename}.${_build_lowercase})
-  list(APPEND ALL_TESTS "${_target}")
+  set(_test "quick_tests/${test_basename}.${_build_lowercase}")
+  set(_target "quick_tests_${test_basename}_${_build_lowercase}")
+
+  list(APPEND ALL_TESTS "${_test}")
   add_executable(${_target} EXCLUDE_FROM_ALL ${test_basename}.cc)
   insource_setup_target(${_target} ${build_name})
 
@@ -48,7 +50,7 @@ macro(make_quicktest test_basename build_name mpi_run)
       set(_command ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${mpi_run} ${MPIEXEC_PREFLAGS} ./${_target})
     endif()
   endif()
-  add_custom_target(${_target}.run
+  add_custom_target(${_target}_run
     DEPENDS ${_target}
     COMMAND
       ${_command} > ${_target}-OK 2>&1
@@ -56,25 +58,25 @@ macro(make_quicktest test_basename build_name mpi_run)
          && cat ${_target}-OK
          && rm ${_target}-OK
          && exit 1)
-    COMMAND echo "${_target}: PASSED."
+    COMMAND echo "${_test}: PASSED."
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
 
-  # this is a hack to make sure the -OK file is deleted
-  # even if compilation fails.
-  add_custom_target(reset-${_target}-OK
+  # this is a hack to make sure the -OK file is deleted even if compilation
+  # fails.
+  add_custom_target(reset_${_target}
     COMMAND ${CMAKE_COMMAND} -E remove -f ${_target}-OK
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
-  add_dependencies(${_target} reset-${_target}-OK)
+  add_dependencies(${_target} reset_${_target})
 
-  add_test(NAME ${_target}
-    COMMAND ${CMAKE_COMMAND} -DTRGT=${_target}.run -DTEST=${_target}
+  add_test(NAME ${_test}
+    COMMAND ${CMAKE_COMMAND} -DTRGT=${_target}_run -DTEST=${_test}
       -DBINARY_DIR=${CMAKE_BINARY_DIR}
       -P ${CMAKE_SOURCE_DIR}/cmake/scripts/run_test.cmake
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
-  set_tests_properties(${_target} PROPERTIES
+  set_tests_properties(${_test} PROPERTIES
     LABEL "sanity checks"
     ENVIRONMENT "OMPI_MCA_rmaps_base_oversubscribe=1")
   # ^^^ Allow oversubscription for MPI (needed for Openmpi@3.0)

--- a/tests/quick_tests/CMakeLists.txt
+++ b/tests/quick_tests/CMakeLists.txt
@@ -37,7 +37,7 @@ macro(make_quicktest test_basename build_name mpi_run)
   set(_target ${test_basename}.${_build_lowercase})
   list(APPEND ALL_TESTS "${_target}")
   add_executable(${_target} EXCLUDE_FROM_ALL ${test_basename}.cc)
-  deal_ii_insource_setup_target(${_target} ${build_name})
+  insource_setup_target(${_target} ${build_name})
 
   if("${mpi_run}" STREQUAL "")
     set(_command ${_target})


### PR DESCRIPTION
This pull request fixes a number of long standing issues:

 - the test "quick_tests" test targets that are defined during configure are
   now named consistently `quick_tests_<test name>_...`. This makes it
   obvious what the target is actually doing.

 - The tests are also renamed to "quick_tests/<test>.<build>" to follow the
   same naming convention as every other test.

 - The "quick_test" subdirectory is chained into the regular testsuite as
   well. This allows to simply call them via `ctest`