### PR TITLE
Bundled: avoid a warning in boost::serialization

### DIFF
--- a/bundled/boost-1.70.0/libs/serialization/src/CMakeLists.txt
+++ b/bundled/boost-1.70.0/libs/serialization/src/CMakeLists.txt
@@ -59,7 +59,8 @@ set(src_boost_serialization
   xml_wiarchive.cpp
   xml_woarchive.cpp
   )
-enable_if_supported(DEAL_II_CXX_FLAGS -Wno-deprecated-copy)
 enable_if_supported(DEAL_II_CXX_FLAGS -Wno-c11-extensions)
+enable_if_supported(DEAL_II_CXX_FLAGS -Wno-deprecated-copy)
+enable_if_supported(DEAL_II_CXX_FLAGS -Wno-uninitialized)
 
 deal_ii_add_library(obj_boost_serialization OBJECT ${src_boost_serialization})


### PR DESCRIPTION
This avoids some annoying warnings when compilng with gcc-12