### PR TITLE
CMake: silence configure warnings for ArborX and Ginkgo

### DIFF
--- a/cmake/modules/FindDEAL_II_ARBORX.cmake
+++ b/cmake/modules/FindDEAL_II_ARBORX.cmake
@@ -27,7 +27,7 @@ set(ARBORX_DIR "" CACHE PATH "An optional hint to an ArborX installation")
 set_if_empty(ARBORX_DIR "$ENV{ARBORX_DIR}")
 
 
-find_package(ArborX
+find_package(ArborX QUIET
   HINTS ${ARBORX_DIR} ${ArborX_DIR} $ENV{ArborX_DIR}
   )
 

--- a/cmake/modules/FindDEAL_II_GINKGO.cmake
+++ b/cmake/modules/FindDEAL_II_GINKGO.cmake
@@ -32,7 +32,7 @@ set_if_empty(GINKGO_DIR "$ENV{GINKGO_DIR}")
 # subsequent configuration to fail.
 #
 set(_cmake_module_path ${CMAKE_MODULE_PATH})
-find_package(Ginkgo
+find_package(Ginkgo QUIET
   HINTS ${GINKGO_DIR} ${Ginkgo_DIR} $ENV{Ginkgo_DIR}
   )
 set(CMAKE_MODULE_PATH ${_cmake_module_path})


### PR DESCRIPTION
Both packages install their own package config files. Thus, if they are
not installed `find_package()` throws a warning.