### PR TITLE
Fix 'testing equality to None' python issue

### DIFF
--- a/contrib/utilities/parse_ctest_output.py
+++ b/contrib/utilities/parse_ctest_output.py
@@ -77,7 +77,7 @@ def parse_revision(dirname):
         status = 4
         if fail:
             text = test.find('Results').find('Measurement').find('Value').text
-            if text == None:
+            if text is None:
                 text=""
             failtext = text.encode('utf-8')
             failtextlines = failtext.replace('"','').split('\n')


### PR DESCRIPTION
"Testing whether an object is '`None`' using the `==` operator is inefficient and potentially incorrect."  