### PR TITLE
Add support for the mold linker

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -36,6 +36,10 @@ jobs:
         libraries: container iostreams python serialization system thread
         platform: x64
         configuration: Release
+    - name: Install mold linker
+      uses: rui314/setup-mold@v1
+      with:
+        make-default: false
     - name: configure deal.II
       run: |
         mkdir build
@@ -85,6 +89,10 @@ jobs:
             petsc-dev \
             libmetis-dev \
             libhdf5-mpi-dev
+    - name: Install mold linker
+      uses: rui314/setup-mold@v1
+      with:
+        make-default: false
     - name: info
       run: |
         mpicc -v
@@ -160,6 +168,10 @@ jobs:
             numdiff \
             openmpi-bin \
             libboost-all-dev
+    - name: Install mold linker
+      uses: rui314/setup-mold@v1
+      with:
+        make-default: false
     - name: info
       run: |
         mpicc -v
@@ -254,6 +266,10 @@ jobs:
                                 intel-oneapi-mkl-devel \
                                 intel-oneapi-tbb-devel
         sudo apt-get clean
+    - name: Install mold linker
+      uses: rui314/setup-mold@v1
+      with:
+        make-default: false
     - name: info
       run: |
         source /opt/intel/oneapi/setvars.sh

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -22,6 +22,10 @@ jobs:
       run: |
         g++ -v
         cmake --version
+    - name: Install mold linker
+      uses: rui314/setup-mold@v1
+      with:
+        make-default: false
     - name: configure
       run: |
         cmake -D CMAKE_BUILD_TYPE=Debug -D DEAL_II_CXX_FLAGS='-Werror' -D DEAL_II_EARLY_DEPRECATIONS=ON .
@@ -64,6 +68,10 @@ jobs:
         #export OMPI_CXX=g++
         #export OMPI_CC=gcc
         #export OMPI_FC=gfortran
+    - name: Install mold linker
+      uses: rui314/setup-mold@v1
+      with:
+        make-default: false
     - name: info
       run: |
         mpicxx -v

--- a/cmake/checks/check_02_compiler_features.cmake
+++ b/cmake/checks/check_02_compiler_features.cmake
@@ -330,11 +330,12 @@ reset_cmake_required()
 
 
 #
-# Use 'lld' or the 'gold' linker if possible, given that either of them is
-# substantially faster.
+# Use 'mold', 'lld' or the 'gold' linker if possible, given that either of them
+# is substantially faster.
 #
-# We have to try to link a full executable with -fuse-ld=lld or -fuse-ld=gold
-# to check whether "ld.lld" or "ld.gold" is actually available.
+# We have to try to link a full executable with -fuse-ld=mold, -fuse-ld=lld or
+# -fuse-ld=gold to check whether "ld.mold", "ld.lld" or "ld.gold" is actually
+# available.
 #
 # Clang always reports "argument unused during compilation", but fails at link
 # time for an unsupported linker.
@@ -368,8 +369,17 @@ if(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   add_flags(CMAKE_REQUIRED_FLAGS "-fPIC")
 
   #
-  # Check for ld.lld and ld.gold support:
+  # Check for ld.mold, ld.lld and ld.gold support:
   #
+  add_flags(CMAKE_REQUIRED_FLAGS "-fuse-ld=mold")
+  CHECK_CXX_SOURCE_COMPILES(
+    "
+    #include <iostream>
+    void foo() { std::cout << \"Hello, world!\" << std::endl; }
+    "
+    DEAL_II_COMPILER_HAS_FUSE_LD_MOLD)
+
+  strip_flag(CMAKE_REQUIRED_FLAGS "-fuse-ld=mold")
   add_flags(CMAKE_REQUIRED_FLAGS "-fuse-ld=lld")
   CHECK_CXX_SOURCE_COMPILES(
     "
@@ -387,7 +397,9 @@ if(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     "
     DEAL_II_COMPILER_HAS_FUSE_LD_GOLD)
 
-  if(DEAL_II_COMPILER_HAS_FUSE_LD_LLD)
+  if(DEAL_II_COMPILER_HAS_FUSE_LD_MOLD)
+    add_flags(DEAL_II_LINKER_FLAGS "-fuse-ld=mold")
+  elseif(DEAL_II_COMPILER_HAS_FUSE_LD_LLD)
     add_flags(DEAL_II_LINKER_FLAGS "-fuse-ld=lld")
   elseif(DEAL_II_COMPILER_HAS_FUSE_LD_GOLD)
     add_flags(DEAL_II_LINKER_FLAGS "-fuse-ld=gold")


### PR DESCRIPTION
https://github.com/rui314/mold is a newer linker that is supposed to be faster than `lld` or `gold`. Out of the three, for me, this one was the easiest to get on Mac OS via
```
brew install mold
```
to make linking less painful.