### PR TITLE
Just do 'using namespace dealii' in main().

### DIFF
--- a/examples/step-12b/step-12b.cc
+++ b/examples/step-12b/step-12b.cc
@@ -640,7 +640,8 @@ int main()
 {
   try
     {
-      dealii::deallog.depth_console(5);
+      using namespace dealii;
+      deallog.depth_console(5);
 
       Step12::AdvectionProblem<2> dgmethod;
       dgmethod.run();

--- a/examples/step-81/step-81.cc
+++ b/examples/step-81/step-81.cc
@@ -870,8 +870,10 @@ int main()
 {
   try
     {
+      using namespace dealii;
+
       Step81::Maxwell<2> maxwell_2d;
-      dealii::ParameterAcceptor::initialize("parameters.prm");
+      ParameterAcceptor::initialize("parameters.prm");
       maxwell_2d.run();
     }
   catch (std::exception &exc)


### PR DESCRIPTION
As pointed out to me in an email by Andrew Tadashi Salmon. The issue here is that when we run our tutorial programs through filters and then doxygen, the `dealii::` part is stripped out. As a consequence, while the *code* is correct, if you copy-paste what you see on the website into your own program, it won't compile. Fix this by just doing `using namespace dealii;` in the code and using the unqualified name.

/rebuild