### PR TITLE
Fix compilation of step-70.

### DIFF
--- a/examples/step-70/step-70.cc
+++ b/examples/step-70/step-70.cc
@@ -143,6 +143,8 @@ namespace LA
 #  include <TopoDS.hxx>
 #endif
 
+#include <boost/algorithm/string/case_conv.hpp>
+
 #include <cmath>
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
I'm not sure how this ever worked. Unfortunately I only noticed the problem when updating the deal.II AUR package, so we need to patch this tutorial to get things compiling with all up-to-date dependencies.