### PR TITLE
[9.4] Fix compilation of step-70.

### DIFF
--- a/examples/step-70/step-70.cc
+++ b/examples/step-70/step-70.cc
@@ -143,6 +143,8 @@ namespace LA
 #  include <TopoDS.hxx>
 #endif
 
+#include <boost/algorithm/string/case_conv.hpp>
+
 #include <cmath>
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
Same as the other one - we might as well backport this so that I can get rid of the patch I wrote for Arch.