### PR TITLE
Remove a 'using' declaration in step-50 that is in the way.

### DIFF
--- a/examples/step-50/step-50.cc
+++ b/examples/step-50/step-50.cc
@@ -388,10 +388,9 @@ private:
   // We will use the following types throughout the program. First the
   // matrix-based types, after that the matrix-free classes. For the
   // matrix-free implementation, we use @p float for the level operators.
-  using MatrixType         = LA::MPI::SparseMatrix;
-  using VectorType         = LA::MPI::Vector;
-  using PreconditionAMG    = LA::MPI::PreconditionAMG;
-  using PreconditionJacobi = LA::MPI::PreconditionJacobi;
+  using MatrixType      = LA::MPI::SparseMatrix;
+  using VectorType      = LA::MPI::Vector;
+  using PreconditionAMG = LA::MPI::PreconditionAMG;
 
   using MatrixFreeLevelMatrix = MatrixFreeOperators::LaplaceOperator<
     dim,
@@ -1006,7 +1005,7 @@ void LaplaceProblem<dim, degree>::solve()
                                       PreconditionIdentity>
             coarse_grid_solver(coarse_solver, mf_mg_matrix[0], identity);
 
-          using Smoother = dealii::PreconditionJacobi<MatrixFreeLevelMatrix>;
+          using Smoother = PreconditionJacobi<MatrixFreeLevelMatrix>;
           MGSmootherPrecondition<MatrixFreeLevelMatrix,
                                  Smoother,
                                  MatrixFreeLevelVector>


### PR DESCRIPTION
step-50 has a `using` declaration that is never actually used, but whose presence requires that we qualify a use of a deal.II class with `dealii` because of what is now a name conflict. This is easily fixed: If we remove the `using` declaration, we can also remove the `deali::`.

/rebuild