### PR TITLE
Don't use __has_trivial_copy

### DIFF
--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -247,17 +247,12 @@ namespace internal
       {
         Assert(end >= begin, ExcInternalError());
 
-#if __GNUG__ && __GNUC__ < 5
-        if (__has_trivial_copy(Number) &&
-            std::is_same<Number, OtherNumber>::value)
-#else
-#  ifdef DEAL_II_HAVE_CXX17
+#ifdef DEAL_II_HAVE_CXX17
         if constexpr (std::is_trivially_copyable<Number>() &&
                       std::is_same<Number, OtherNumber>::value)
-#  else
+#else
         if (std::is_trivially_copyable<Number>() &&
             std::is_same<Number, OtherNumber>::value)
-#  endif
 #endif
           std::memcpy(dst + begin, src + begin, (end - begin) * sizeof(Number));
         else


### PR DESCRIPTION
We don't support GCC versions prior to 5 anymore (and the compile path would accidentally also be triggered for recent `clang` versions.