### PR TITLE
Choose to initialize ghost elements with reinit(partitioner).

### DIFF
--- a/doc/news/changes/minor/20221205Fehling
+++ b/doc/news/changes/minor/20221205Fehling
@@ -1,0 +1,5 @@
+New: TrilinosWrappers::MPI::Vector and PETScWrappers::MPI::Vector now both have
+reinit functions that take a Utilities::MPI::Partitioner as an argument, so
+their interface is compatible to LinearAlgebra::distributed::Vector.
+<br>
+(Marc Fehling, 2022/12/05)

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -406,6 +406,18 @@ namespace LinearAlgebra
         const MPI_Comm &comm_sm = MPI_COMM_SELF);
 
       /**
+       * This function exists purely for reasons of compatibility with the
+       * PETScWrappers::MPI::Vector and TrilinosWrappers::MPI::Vector classes.
+       *
+       * It calls the function above, and ignores the parameter @p make_ghosted.
+       */
+      void
+      reinit(
+        const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner,
+        const bool                                                make_ghosted,
+        const MPI_Comm &comm_sm = MPI_COMM_SELF);
+
+      /**
        * Initialize vector with @p local_size locally-owned and @p ghost_size
        * ghost degrees of freedoms.
        *

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -672,6 +672,18 @@ namespace LinearAlgebra
 
 
     template <typename Number, typename MemorySpaceType>
+    void
+    Vector<Number, MemorySpaceType>::reinit(
+      const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner_in,
+      const bool /*make_ghosted*/,
+      const MPI_Comm &comm_sm)
+    {
+      this->reinit(partitioner_in, comm_sm);
+    }
+
+
+
+    template <typename Number, typename MemorySpaceType>
     Vector<Number, MemorySpaceType>::Vector()
       : partitioner(std::make_shared<Utilities::MPI::Partitioner>())
       , allocated_size(0)

--- a/include/deal.II/lac/petsc_vector.h
+++ b/include/deal.II/lac/petsc_vector.h
@@ -343,10 +343,14 @@ namespace PETScWrappers
       /**
        * Initialize the vector given to the parallel partitioning described in
        * @p partitioner.
+       *
+       * You can decide whether your vector will contain ghost elements with
+       * @p make_ghosted.
        */
       void
       reinit(
-        const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner);
+        const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner,
+        const bool make_ghosted = true);
 
       /**
        * Return a reference to the MPI communicator object in use with this

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -604,10 +604,17 @@ namespace TrilinosWrappers
       /**
        * Initialize the vector given to the parallel partitioning described in
        * @p partitioner using the function above.
+       *
+       * You can decide whether your vector will contain ghost elements with
+       * @p make_ghosted.
+       *
+       * The parameter @p vector_writable only has effect on ghosted vectors
+       * and is ignored for non-ghosted vectors.
        */
       void
       reinit(
         const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner,
+        const bool make_ghosted    = true,
         const bool vector_writable = false);
 
       /**

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -236,11 +236,24 @@ namespace PETScWrappers
 
     void
     Vector::reinit(
-      const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner)
+      const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner,
+      const bool                                                make_ghosted)
     {
-      this->reinit(partitioner->locally_owned_range(),
-                   partitioner->ghost_indices(),
-                   partitioner->get_mpi_communicator());
+      if (make_ghosted)
+        {
+          Assert(partitioner->ghost_indices_initialized(),
+                 ExcMessage("You asked to create a ghosted vector, but the "
+                            "partitioner does not provide ghost indices."));
+
+          this->reinit(partitioner->locally_owned_range(),
+                       partitioner->ghost_indices(),
+                       partitioner->get_mpi_communicator());
+        }
+      else
+        {
+          this->reinit(partitioner->locally_owned_range(),
+                       partitioner->get_mpi_communicator());
+        }
     }
 
 

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -410,12 +410,25 @@ namespace TrilinosWrappers
     void
     Vector::reinit(
       const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner,
+      const bool                                                make_ghosted,
       const bool                                                vector_writable)
     {
-      this->reinit(partitioner->locally_owned_range(),
-                   partitioner->ghost_indices(),
-                   partitioner->get_mpi_communicator(),
-                   vector_writable);
+      if (make_ghosted)
+        {
+          Assert(partitioner->ghost_indices_initialized(),
+                 ExcMessage("You asked to create a ghosted vector, but the "
+                            "partitioner does not provide ghost indices."));
+
+          this->reinit(partitioner->locally_owned_range(),
+                       partitioner->ghost_indices(),
+                       partitioner->get_mpi_communicator(),
+                       vector_writable);
+        }
+      else
+        {
+          this->reinit(partitioner->locally_owned_range(),
+                       partitioner->get_mpi_communicator());
+        }
     }
 
 


### PR DESCRIPTION
`LinearAlgebra::distributed::Vector` has the neat feature to switch between a ghosted and non-ghosted state. However, this feature is not present in the `TrilinosWrappers::MPI::Vector` and `PETScWrappers::MPI::Vector` classes, as they need to be either ghosted or non-ghosted from their construction onwards.

I'm trying to write (matrix-based) code that works with any of these classes, but encountered issues around this discrepancy between the classes. I tried to move to using the `Utilities::MPI::Partitioner` classes for the third party vectors, but those were always initialized in a ghosted state so far with the current compatibility layer (see #12864).

This PR generalizes the reinit interface with a new parameter `make_ghosted` so users can decide to work in a ghosted state or not. A dummy function is also added to the `LA::distributed::Vector` class.

I do not know if this is the right way to go, and I would like to know what you think. I could also drop the `Partitioner` objects for my matrix-based implementations and use the classic `reinit` interfaces with `IndexSets`.