### PR TITLE
CMake: Ensure we use "-pthread" instead of "-lpthread" for thread support

### DIFF
--- a/cmake/configure/configure_00_threads.cmake
+++ b/cmake/configure/configure_00_threads.cmake
@@ -21,11 +21,28 @@
 # Clear the test flags because FindThreads.cmake will use a C compiler:
 clear_cmake_required()
 
-find_package(Threads)
+#
+# Ensure that we use "-pthread" instead of "-lpthread". We require
+# "-pthread" for certain versions of gcc (and standard library thread
+# support). Otherwise the order of libraries might be wrong on the final
+# link interface and we end up with linker errors such as the following:
+#   /usr/bin/ld: [...]/step-69.cc.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
+#   /usr/bin/ld: /usr/lib/x86_64-linux-gnu/libpthread.so: error adding symbols: DSO missing from command line
+#
+set(THREADS_PREFER_PTHREAD_FLAG true)
 
+find_package(Threads)
 reset_cmake_required()
 
 add_flags(DEAL_II_LINKER_FLAGS "${CMAKE_THREAD_LIBS_INIT}")
+
+#
+# Make sure that we compile with "-pthread" as well. The "-pthread"
+# compiler flag might add certain preprocessor definitions when compiling.
+#
+if("${CMAKE_THREAD_LIBS_INIT}" MATCHES "-pthread")
+  add_flags(DEAL_II_CXX_FLAGS "${CMAKE_THREAD_LIBS_INIT}")
+endif()
 
 if(NOT Threads_FOUND)
   message(FATAL_ERROR


### PR DESCRIPTION
We will need this in 9.4 as well.