### PR TITLE
CMake: Bugfix: only export DEAL_II_GMSH_WITH_API if gmsh is configured

### DIFF
--- a/cmake/configure/configure_50_gmsh.cmake
+++ b/cmake/configure/configure_50_gmsh.cmake
@@ -17,5 +17,8 @@
 # Configuration for the gmsh executable:
 #
 
+macro(feature_gmsh_configure_external)
+  set(DEAL_II_GMSH_WITH_API ${GMSH_WITH_API})
+endmacro()
+
 configure_feature(GMSH)
-set(DEAL_II_GMSH_WITH_API ${GMSH_WITH_API})

--- a/include/deal.II/grid/grid_in.h
+++ b/include/deal.II/grid/grid_in.h
@@ -521,7 +521,7 @@ public:
   void
   read_msh(std::istream &in);
 
-#ifdef DEAL_II_GMSH_WITH_API
+#if defined(DEAL_II_WITH_GMSH) && defined(DEAL_II_GMSH_WITH_API)
   /**
    * Read grid data using Gmsh API. Any file supported by Gmsh can be passed as
    * argument. The format is deduced from the filename extension.

--- a/include/deal.II/grid/grid_out.h
+++ b/include/deal.II/grid/grid_out.h
@@ -1098,7 +1098,7 @@ public:
   void
   write_msh(const Triangulation<dim, spacedim> &tria, std::ostream &out) const;
 
-#ifdef DEAL_II_GMSH_WITH_API
+#if defined(DEAL_II_WITH_GMSH) && defined(DEAL_II_GMSH_WITH_API)
   /**
    * Write the triangulation in any format supported by gmsh API.
    *

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -31,7 +31,7 @@
 #include <boost/property_tree/xml_parser.hpp>
 #include <boost/serialization/serialization.hpp>
 
-#ifdef DEAL_II_GMSH_WITH_API
+#if defined(DEAL_II_WITH_GMSH) && defined(DEAL_II_GMSH_WITH_API)
 #  include <gmsh.h>
 #endif
 
@@ -2655,7 +2655,7 @@ GridIn<dim, spacedim>::read_msh(std::istream &in)
 
 
 
-#ifdef DEAL_II_GMSH_WITH_API
+#if defined(DEAL_II_WITH_GMSH) && defined(DEAL_II_GMSH_WITH_API)
 template <int dim, int spacedim>
 void
 GridIn<dim, spacedim>::read_msh(const std::string &fname)

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -33,7 +33,7 @@
 
 #include <boost/archive/binary_oarchive.hpp>
 
-#ifdef DEAL_II_GMSH_WITH_API
+#if defined(DEAL_II_WITH_GMSH) && defined(DEAL_II_GMSH_WITH_API)
 #  include <gmsh.h>
 #endif
 
@@ -1435,7 +1435,7 @@ GridOut::write_xfig(const Triangulation<2> &tria,
 
 
 
-#ifdef DEAL_II_GMSH_WITH_API
+#if defined(DEAL_II_WITH_GMSH) && defined(DEAL_II_GMSH_WITH_API)
 template <int dim, int spacedim>
 void
 GridOut::write_msh(const Triangulation<dim, spacedim> &tria,

--- a/source/grid/grid_out.inst.in
+++ b/source/grid/grid_out.inst.in
@@ -26,7 +26,7 @@ for (deal_II_dimension : DIMENSIONS)
 
     template void GridOut::write_msh(const Triangulation<deal_II_dimension> &,
                                      std::ostream &) const;
-#ifdef DEAL_II_GMSH_WITH_API
+#if defined(DEAL_II_WITH_GMSH) && defined(DEAL_II_GMSH_WITH_API)
     template void GridOut::write_msh(const Triangulation<deal_II_dimension> &,
                                      const std::string &) const;
 #endif


### PR DESCRIPTION
If the gmsh library is installed but the gmsh executable is missing we 
currently disable gmsh support. This implies that we will not link against
the gmsh library.

Unfortunately, on first configure pass the variable `GMSH_WITH_API` is 
still populated with a `TRUE` value and the `DEAL_II_GMSH_WITH_API` 
variable gets set by accident and final linkage fails.

This issue is hard to spot because a second invocation of cmake will cure
the configure mistake (and the debian/ubuntu packages do not run any
autodetection).