### PR TITLE
[9.4] Take over #14540 and #14544

### DIFF
--- a/cmake/configure/configure_50_gmsh.cmake
+++ b/cmake/configure/configure_50_gmsh.cmake
@@ -17,5 +17,8 @@
 # Configuration for the gmsh executable:
 #
 
+MACRO(feature_gmsh_configure_external)
+  SET(DEAL_II_GMSH_WITH_API ${GMSH_WITH_API})
+ENDMACRO()
+
 CONFIGURE_FEATURE(GMSH)
-SET(DEAL_II_GMSH_WITH_API ${GMSH_WITH_API})

--- a/include/deal.II/grid/grid_in.h
+++ b/include/deal.II/grid/grid_in.h
@@ -521,7 +521,7 @@ public:
   void
   read_msh(std::istream &in);
 
-#ifdef DEAL_II_GMSH_WITH_API
+#if defined(DEAL_II_WITH_GMSH) && defined(DEAL_II_GMSH_WITH_API)
   /**
    * Read grid data using Gmsh API. Any file supported by Gmsh can be passed as
    * argument. The format is deduced from the filename extension.

--- a/include/deal.II/grid/grid_out.h
+++ b/include/deal.II/grid/grid_out.h
@@ -1098,7 +1098,7 @@ public:
   void
   write_msh(const Triangulation<dim, spacedim> &tria, std::ostream &out) const;
 
-#ifdef DEAL_II_GMSH_WITH_API
+#if defined(DEAL_II_WITH_GMSH) && defined(DEAL_II_GMSH_WITH_API)
   /**
    * Write the triangulation in any format supported by gmsh API.
    *

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -31,7 +31,7 @@
 #include <boost/property_tree/xml_parser.hpp>
 #include <boost/serialization/serialization.hpp>
 
-#ifdef DEAL_II_GMSH_WITH_API
+#if defined(DEAL_II_WITH_GMSH) && defined(DEAL_II_GMSH_WITH_API)
 #  include <gmsh.h>
 #endif
 
@@ -2706,7 +2706,7 @@ GridIn<dim, spacedim>::read_msh(std::istream &in)
 
 
 
-#ifdef DEAL_II_GMSH_WITH_API
+#if defined(DEAL_II_WITH_GMSH) && defined(DEAL_II_GMSH_WITH_API)
 template <int dim, int spacedim>
 void
 GridIn<dim, spacedim>::read_msh(const std::string &fname)

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -32,7 +32,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/archive/binary_oarchive.hpp>
 
-#ifdef DEAL_II_GMSH_WITH_API
+#if defined(DEAL_II_WITH_GMSH) && defined(DEAL_II_GMSH_WITH_API)
 #  include <gmsh.h>
 #endif
 
@@ -1434,7 +1434,7 @@ GridOut::write_xfig(const Triangulation<2> &tria,
 
 
 
-#ifdef DEAL_II_GMSH_WITH_API
+#if defined(DEAL_II_WITH_GMSH) && defined(DEAL_II_GMSH_WITH_API)
 template <int dim, int spacedim>
 void
 GridOut::write_msh(const Triangulation<dim, spacedim> &tria,

--- a/source/grid/grid_out.inst.in
+++ b/source/grid/grid_out.inst.in
@@ -26,7 +26,7 @@ for (deal_II_dimension : DIMENSIONS)
 
     template void GridOut::write_msh(const Triangulation<deal_II_dimension> &,
                                      std::ostream &) const;
-#ifdef DEAL_II_GMSH_WITH_API
+#if defined(DEAL_II_WITH_GMSH) && defined(DEAL_II_GMSH_WITH_API)
     template void GridOut::write_msh(const Triangulation<deal_II_dimension> &,
                                      const std::string &) const;
 #endif


### PR DESCRIPTION
32c0237b58 (Matthias Maier, 14 minutes ago)
   harden DEAL_II_GMSH_WITH_API ifdef

df39deedac (Matthias Maier, 25 minutes ago)
   CMake: Bugfix: only export DEAL_II_GMSH_WITH_API if gmsh is configured

e58c2eb630 (Matthias Maier, 25 hours ago)
   CMake: Ensure we use "-pthread" instead of "-lpthread" for thread support