### PR TITLE
CMake: Bugfix: only export DEAL_II_GMSH_WITH_API if gmsh is configured

### DIFF
--- a/cmake/configure/configure_50_gmsh.cmake
+++ b/cmake/configure/configure_50_gmsh.cmake
@@ -17,5 +17,8 @@
 # Configuration for the gmsh executable:
 #
 
+macro(feature_gmsh_configure_external)
+  set(DEAL_II_GMSH_WITH_API ${GMSH_WITH_API})
+endmacro()
+
 configure_feature(GMSH)
-set(DEAL_II_GMSH_WITH_API ${GMSH_WITH_API})


### PR DESCRIPTION
If the gmsh library is installed but the gmsh executable is missing we
currently disable gmsh support. This implies that we will not link
against the gmsh library.

Unfortunately, on first configure pass the variable `GMSH_WITH_API` is
still populated with a `TRUE` value and the `DEAL_II_GMSH_WITH_API`
variable gets set by accident and final linkage fails.

This issue is hard to spot because a second invocation of cmake will
cure the configure mistake (and the debian/ubuntu packages do not run
any autodetection).