### PR TITLE
Take over #14540 and #14544

### DIFF
--- a/cmake/configure/configure_50_gmsh.cmake
+++ b/cmake/configure/configure_50_gmsh.cmake
@@ -17,5 +17,8 @@
 # Configuration for the gmsh executable:
 #
 
+MACRO(feature_gmsh_configure_external)
+  SET(DEAL_II_GMSH_WITH_API ${GMSH_WITH_API})
+ENDMACRO()
+
 CONFIGURE_FEATURE(GMSH)
-SET(DEAL_II_GMSH_WITH_API ${GMSH_WITH_API})


### PR DESCRIPTION
df39deedac (Matthias Maier, 16 hours ago)
   CMake: Bugfix: only export DEAL_II_GMSH_WITH_API if gmsh is configured

e58c2eb630 (Matthias Maier, 2 days ago)
   CMake: Ensure we use "-pthread" instead of "-lpthread" for thread support