### PR TITLE
Tests: performance: add missing valgrind wrapper

### DIFF
--- a/tests/performance/CMakeLists.txt
+++ b/tests/performance/CMakeLists.txt
@@ -32,6 +32,7 @@ else()
 endif()
 
 set(performance_instrumentation_step_3_RUNARGS_PREFIX "${_command_line}")
+set(performance_instrumentation_step_3_count_cycles_RUNARGS_PREFIX "${_command_line}")
 set(performance_instrumentation_step_22_RUNARGS_PREFIX "${_command_line}")
 
 deal_ii_pickup_tests()


### PR DESCRIPTION
@bangerth I need our help here. Currently, `performance/instrumentation_step_3_count_cycles` is failing because it is never executed through the valgrind wrapper. Looking at the test itself I am confused: It seems to test the `count_cycles` wrapper you introduced in the internal header `valgrind_instrumentation.h` - otherwise it is identical to the `instrumentation_step-3` test.

Wouldn't it make more sense to simply refactor the `instrumentation_step_3` test instead?