### PR TITLE
CMake: enable dynamic linking for Windows

### DIFF
--- a/cmake/checks/check_02_system_features.cmake
+++ b/cmake/checks/check_02_system_features.cmake
@@ -91,7 +91,6 @@ if( CMAKE_SYSTEM_NAME MATCHES "CYGWIN" OR
 endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-
   #
   # Export DEAL_II_MSVC if we are on a Windows platform:
   #
@@ -100,21 +99,10 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows")
   #
   # Shared library handling:
   #
-
-  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-    # With MinGW we're lucky:
-    enable_if_links(DEAL_II_LINKER_FLAGS "-Wl,--export-all-symbols")
-    enable_if_links(DEAL_II_LINKER_FLAGS "-Wl,--enable-auto-import")
-    enable_if_links(DEAL_II_LINKER_FLAGS "-Wl,--allow-multiple-definition")
-  else()
-    # Otherwise disable shared libraries:
-    message(WARNING "\n"
-      "BUILD_SHARED_LIBS forced to OFF\n\n"
-      )
-    set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
-
-    # And disable compilation of examples:
-    set(DEAL_II_COMPILE_EXAMPLES OFF CACHE BOOL "" FORCE)
+  # Let's use the CMake infrastructure to automatically export symbols on
+  # Windows targets:
+  #
+  if(BUILD_SHARED_LIBS)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
   endif()
-
 endif()

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -79,7 +79,7 @@ foreach(build ${DEAL_II_BUILD_TYPES})
   string(TOLOWER ${build} build_lowercase)
 
   #
-  # Combine all ${build} OBJECT targets to a ${build} library:
+  # Combine all ${build} SHARED targets to a ${build} library:
   #
 
   get_property(_objects GLOBAL PROPERTY DEAL_II_OBJECTS_${build})

--- a/source/algorithms/CMakeLists.txt
+++ b/source/algorithms/CMakeLists.txt
@@ -29,5 +29,5 @@ file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/algorithms/*.h
   )
 
-deal_ii_add_library(obj_algorithms OBJECT ${_src} ${_header} ${_inst})
+deal_ii_add_library(obj_algorithms SHARED ${_src} ${_header} ${_inst})
 expand_instantiations(obj_algorithms "${_inst}")

--- a/source/arborx/CMakeLists.txt
+++ b/source/arborx/CMakeLists.txt
@@ -27,5 +27,5 @@ file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/arborx/*.h
   )
 
-deal_ii_add_library(obj_arborx OBJECT ${_src} ${_header} ${_inst})
+deal_ii_add_library(obj_arborx SHARED ${_src} ${_header} ${_inst})
 expand_instantiations(obj_arborx "${_inst}")

--- a/source/base/CMakeLists.txt
+++ b/source/base/CMakeLists.txt
@@ -156,7 +156,7 @@ file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/base/*.h
   )
 
-deal_ii_add_library(obj_base OBJECT ${_src} ${_header} ${_inst}
+deal_ii_add_library(obj_base SHARED ${_src} ${_header} ${_inst}
   ${CMAKE_BINARY_DIR}/include/deal.II/base/config.h
   )
 expand_instantiations(obj_base "${_inst}")

--- a/source/cgal/CMakeLists.txt
+++ b/source/cgal/CMakeLists.txt
@@ -33,5 +33,5 @@ file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/cgal/*.h
   )
 
-deal_ii_add_library(obj_cgal OBJECT ${_src} ${_header} ${_inst})
+deal_ii_add_library(obj_cgal SHARED ${_src} ${_header} ${_inst})
 expand_instantiations(obj_cgal "${_inst}")

--- a/source/differentiation/ad/CMakeLists.txt
+++ b/source/differentiation/ad/CMakeLists.txt
@@ -38,5 +38,5 @@ file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/differentiation/ad/*.h
   )
 
-deal_ii_add_library(obj_differentiation_ad OBJECT ${_src} ${_header} ${_inst})
+deal_ii_add_library(obj_differentiation_ad SHARED ${_src} ${_header} ${_inst})
 expand_instantiations(obj_differentiation_ad "${_inst}")

--- a/source/differentiation/sd/CMakeLists.txt
+++ b/source/differentiation/sd/CMakeLists.txt
@@ -36,5 +36,5 @@ file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/differentiation/sd/*.h
   )
 
-deal_ii_add_library(obj_differentiation_sd OBJECT ${_src} ${_header} ${_inst})
+deal_ii_add_library(obj_differentiation_sd SHARED ${_src} ${_header} ${_inst})
 expand_instantiations(obj_differentiation_sd "${_inst}")

--- a/source/distributed/CMakeLists.txt
+++ b/source/distributed/CMakeLists.txt
@@ -59,5 +59,5 @@ file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/distributed/*.h
   )
 
-deal_ii_add_library(obj_distributed OBJECT ${_src} ${_header} ${_inst})
+deal_ii_add_library(obj_distributed SHARED ${_src} ${_header} ${_inst})
 expand_instantiations(obj_distributed "${_inst}")

--- a/source/dofs/CMakeLists.txt
+++ b/source/dofs/CMakeLists.txt
@@ -61,5 +61,5 @@ file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/dofs/*.h
   )
 
-deal_ii_add_library(obj_dofs OBJECT ${_src} ${_header} ${_inst})
+deal_ii_add_library(obj_dofs SHARED ${_src} ${_header} ${_inst})
 expand_instantiations(obj_dofs "${_inst}")

--- a/source/fe/CMakeLists.txt
+++ b/source/fe/CMakeLists.txt
@@ -148,5 +148,5 @@ file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/fe/*.h
   )
 
-deal_ii_add_library(obj_fe OBJECT ${_src} ${_header} ${_inst})
+deal_ii_add_library(obj_fe SHARED ${_src} ${_header} ${_inst})
 expand_instantiations(obj_fe "${_inst}")

--- a/source/gmsh/CMakeLists.txt
+++ b/source/gmsh/CMakeLists.txt
@@ -27,5 +27,5 @@ file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/gmsh/*.h
   )
 
-deal_ii_add_library(obj_gmsh OBJECT ${_src} ${_header} ${_inst})
+deal_ii_add_library(obj_gmsh SHARED ${_src} ${_header} ${_inst})
 expand_instantiations(obj_gmsh "${_inst}")

--- a/source/grid/CMakeLists.txt
+++ b/source/grid/CMakeLists.txt
@@ -97,5 +97,5 @@ file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/grid/*.h
   )
 
-deal_ii_add_library(obj_grid OBJECT ${_src} ${_header} ${_inst})
+deal_ii_add_library(obj_grid SHARED ${_src} ${_header} ${_inst})
 expand_instantiations(obj_grid "${_inst}")

--- a/source/hp/CMakeLists.txt
+++ b/source/hp/CMakeLists.txt
@@ -45,5 +45,5 @@ file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/hp/*.h
   )
 
-deal_ii_add_library(obj_hp OBJECT ${_src} ${_header} ${_inst})
+deal_ii_add_library(obj_hp SHARED ${_src} ${_header} ${_inst})
 expand_instantiations(obj_hp "${_inst}")

--- a/source/integrators/CMakeLists.txt
+++ b/source/integrators/CMakeLists.txt
@@ -22,4 +22,4 @@ file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/integrators/*.h
   )
 
-deal_ii_add_library(obj_integrators OBJECT ${_src} ${_header})
+deal_ii_add_library(obj_integrators SHARED ${_src} ${_header})

--- a/source/lac/CMakeLists.txt
+++ b/source/lac/CMakeLists.txt
@@ -192,5 +192,5 @@ file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/lac/*.h
   )
 
-deal_ii_add_library(obj_lac OBJECT ${_src} ${_header} ${_inst})
+deal_ii_add_library(obj_lac SHARED ${_src} ${_header} ${_inst})
 expand_instantiations(obj_lac "${_inst}")

--- a/source/matrix_free/CMakeLists.txt
+++ b/source/matrix_free/CMakeLists.txt
@@ -64,5 +64,5 @@ if(DEAL_II_WITH_CUDA)
     )
 endif()
 
-deal_ii_add_library(obj_matrix_free OBJECT ${_src} ${_header} ${_inst})
+deal_ii_add_library(obj_matrix_free SHARED ${_src} ${_header} ${_inst})
 expand_instantiations(obj_matrix_free "${_inst}")

--- a/source/meshworker/CMakeLists.txt
+++ b/source/meshworker/CMakeLists.txt
@@ -32,5 +32,5 @@ file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/meshworker/*.h
   )
 
-deal_ii_add_library(obj_meshworker OBJECT ${_src} ${_header} ${_inst})
+deal_ii_add_library(obj_meshworker SHARED ${_src} ${_header} ${_inst})
 expand_instantiations(obj_meshworker "${_inst}")

--- a/source/multigrid/CMakeLists.txt
+++ b/source/multigrid/CMakeLists.txt
@@ -57,5 +57,5 @@ file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/multigrid/*.h
   )
 
-deal_ii_add_library(obj_multigrid OBJECT ${_src} ${_header} ${_inst})
+deal_ii_add_library(obj_multigrid SHARED ${_src} ${_header} ${_inst})
 expand_instantiations(obj_multigrid "${_inst}")

--- a/source/non_matching/CMakeLists.txt
+++ b/source/non_matching/CMakeLists.txt
@@ -36,5 +36,5 @@ file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/non_matching/*.h
   )
 
-deal_ii_add_library(obj_non_matching OBJECT ${_src} ${_header} ${_inst})
+deal_ii_add_library(obj_non_matching SHARED ${_src} ${_header} ${_inst})
 expand_instantiations(obj_non_matching "${_inst}")

--- a/source/numerics/CMakeLists.txt
+++ b/source/numerics/CMakeLists.txt
@@ -112,5 +112,5 @@ file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/numerics/*.h
   )
 
-deal_ii_add_library(obj_numerics OBJECT ${_src} ${_header} ${_inst})
+deal_ii_add_library(obj_numerics SHARED ${_src} ${_header} ${_inst})
 expand_instantiations(obj_numerics "${_inst}")

--- a/source/opencascade/CMakeLists.txt
+++ b/source/opencascade/CMakeLists.txt
@@ -29,5 +29,5 @@ file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/opencascade/*.h
   )
 
-deal_ii_add_library(obj_opencascade OBJECT ${_src} ${_header} ${_inst})
+deal_ii_add_library(obj_opencascade SHARED ${_src} ${_header} ${_inst})
 expand_instantiations(obj_opencascade "${_inst}")

--- a/source/optimization/rol/CMakeLists.txt
+++ b/source/optimization/rol/CMakeLists.txt
@@ -25,5 +25,5 @@ file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/optimization/rol/*.h
   )
 
-deal_ii_add_library(obj_rol OBJECT ${_src} ${_header} ${_inst})
+deal_ii_add_library(obj_rol SHARED ${_src} ${_header} ${_inst})
 expand_instantiations(obj_rol "${_inst}")

--- a/source/particles/CMakeLists.txt
+++ b/source/particles/CMakeLists.txt
@@ -37,5 +37,5 @@ file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/particles/*.h
   )
 
-deal_ii_add_library(obj_particle OBJECT ${_src} ${_header} ${_inst})
+deal_ii_add_library(obj_particle SHARED ${_src} ${_header} ${_inst})
 expand_instantiations(obj_particle "${_inst}")

--- a/source/physics/CMakeLists.txt
+++ b/source/physics/CMakeLists.txt
@@ -30,5 +30,5 @@ file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/physics/*.h
   )
 
-deal_ii_add_library(obj_physics OBJECT ${_src} ${_header} ${_inst})
+deal_ii_add_library(obj_physics SHARED ${_src} ${_header} ${_inst})
 expand_instantiations(obj_physics "${_inst}")

--- a/source/physics/elasticity/CMakeLists.txt
+++ b/source/physics/elasticity/CMakeLists.txt
@@ -30,5 +30,5 @@ file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/physics/elasticity/*.h
   )
 
-deal_ii_add_library(obj_physics_elasticity OBJECT ${_src} ${_header} ${_inst})
+deal_ii_add_library(obj_physics_elasticity SHARED ${_src} ${_header} ${_inst})
 expand_instantiations(obj_physics_elasticity "${_inst}")

--- a/source/sundials/CMakeLists.txt
+++ b/source/sundials/CMakeLists.txt
@@ -32,5 +32,5 @@ file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/sundials/*.h
   )
 
-deal_ii_add_library(obj_sundials OBJECT ${_src} ${_header} ${_inst})
+deal_ii_add_library(obj_sundials SHARED ${_src} ${_header} ${_inst})
 expand_instantiations(obj_sundials "${_inst}")


### PR DESCRIPTION
Let's see what happens.
Reference: https://www.kitware.com//create-dlls-on-windows-without-declspec-using-new-cmake-export-all-feature/

Closes #2460