### PR TITLE
CMake: quick test fixes for CI

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -168,11 +168,14 @@ if(DEFINED DEAL_II_HAVE_TESTS_DIRECTORY)
     COMMENT "Running quicktests..."
     )
 
-  # Depend on the library target to ensure that deal.II is actually
-  # compiled, as well as on the setup_tests_quick_tests target to ensure
+  # Depend on the library targets (to ensure that deal.II is actually
+  # compiled), as well as on the setup_tests_quick_tests target to ensure
   # that quick tests are actually available.
-  add_dependencies(test library)
   add_dependencies(test setup_tests_quick_tests)
+  foreach(_build ${DEAL_II_BUILD_TYPES})
+    string(TOLOWER ${_build} _build_lowercase)
+    add_dependencies(test ${DEAL_II_NAMESPACE}_${_build_lowercase})
+  endforeach()
 
   #
   # Add a dummy target to make files known to IDEs like qtcreator

--- a/tests/run_quick_tests.cmake
+++ b/tests/run_quick_tests.cmake
@@ -95,4 +95,7 @@ recent version or use a different MPI library like MPICH.\n"
         )
     endif()
   endforeach()
+
+  # ensure that this script exits with a non-zero exit code
+  message(FATAL_ERROR "quick tests failed")
 endif()


### PR DESCRIPTION
I accidentally introduced these when refactoring quick tests. This PR
ensures that we

  - do not trigger install during make test
  - return a non-zero exit code when quick tests fail