### PR TITLE
Memory optimizations

### DIFF
--- a/include/deal.II/grid/connectivity.h
+++ b/include/deal.II/grid/connectivity.h
@@ -1130,7 +1130,7 @@ namespace internal
 
           std::sort(keys.begin(), keys.end());
 
-          ptr_0.reserve(n_unique_entities);
+          ptr_0.reserve(n_unique_entities + 1);
           col_0.reserve(n_unique_entity_vertices);
         }
 

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -2778,6 +2778,12 @@ namespace GridTools
      * @ref GlossPeriodicConstraints "glossary entry on periodic conditions".
      */
     FullMatrix<double> matrix;
+
+    /**
+     * Return an estimate, in bytes, for the memory consumption of the object.
+     */
+    std::size_t
+    memory_consumption() const;
   };
 
 
@@ -3844,6 +3850,15 @@ namespace GridTools
                 }
             }
         }
+  }
+
+
+
+  template <typename CellIterator>
+  std::size_t
+  PeriodicFacePair<CellIterator>::memory_consumption() const
+  {
+    return sizeof(*this) + matrix.memory_consumption();
   }
 
 

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -681,6 +681,12 @@ public:
   serialize(Archive &archive, const unsigned int /*version*/);
 
   /**
+   * Return the number of bytes used by an instance of this class.
+   */
+  static constexpr std::size_t
+  memory_consumption();
+
+  /**
    * @}
    */
 
@@ -846,6 +852,14 @@ inline void
 ReferenceCell::serialize(Archive &archive, const unsigned int /*version*/)
 {
   archive &kind;
+}
+
+
+
+inline constexpr std::size_t
+ReferenceCell::memory_consumption()
+{
+  return sizeof(ReferenceCells::Invalid);
 }
 
 

--- a/source/base/partitioner.cc
+++ b/source/base/partitioner.cc
@@ -510,19 +510,30 @@ namespace Utilities
     std::size_t
     Partitioner::memory_consumption() const
     {
-      std::size_t memory = (3 * sizeof(types::global_dof_index) +
-                            4 * sizeof(unsigned int) + sizeof(MPI_Comm));
-      memory += MemoryConsumption::memory_consumption(locally_owned_range_data);
+      std::size_t memory = MemoryConsumption::memory_consumption(global_size);
+      memory += locally_owned_range_data.memory_consumption();
+      memory += MemoryConsumption::memory_consumption(local_range_data);
+      memory += ghost_indices_data.memory_consumption();
+      memory += sizeof(n_ghost_indices_data);
       memory += MemoryConsumption::memory_consumption(ghost_targets_data);
-      memory += MemoryConsumption::memory_consumption(import_targets_data);
       memory += MemoryConsumption::memory_consumption(import_indices_data);
+      memory += sizeof(import_indices_plain_dev) +
+                sizeof(*import_indices_plain_dev.begin()) *
+                  import_indices_plain_dev.capacity();
+      memory += MemoryConsumption::memory_consumption(n_import_indices_data);
+      memory += MemoryConsumption::memory_consumption(import_targets_data);
       memory += MemoryConsumption::memory_consumption(
         import_indices_chunks_by_rank_data);
+      memory +=
+        MemoryConsumption::memory_consumption(n_ghost_indices_in_larger_set);
       memory += MemoryConsumption::memory_consumption(
         ghost_indices_subset_chunks_by_rank_data);
       memory +=
         MemoryConsumption::memory_consumption(ghost_indices_subset_data);
-      memory += MemoryConsumption::memory_consumption(ghost_indices_data);
+      memory += MemoryConsumption::memory_consumption(my_pid);
+      memory += MemoryConsumption::memory_consumption(n_procs);
+      memory += MemoryConsumption::memory_consumption(communicator);
+      memory += MemoryConsumption::memory_consumption(have_ghost_indices);
       return memory;
     }
 

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -58,11 +58,21 @@ namespace internal
     std::size_t
     NumberCache<1>::memory_consumption() const
     {
-      return (MemoryConsumption::memory_consumption(n_levels) +
-              MemoryConsumption::memory_consumption(n_lines) +
-              MemoryConsumption::memory_consumption(n_lines_level) +
-              MemoryConsumption::memory_consumption(n_active_lines) +
-              MemoryConsumption::memory_consumption(n_active_lines_level));
+      std::size_t mem =
+        MemoryConsumption::memory_consumption(n_levels) +
+        MemoryConsumption::memory_consumption(n_lines) +
+        MemoryConsumption::memory_consumption(n_lines_level) +
+        MemoryConsumption::memory_consumption(n_active_lines) +
+        MemoryConsumption::memory_consumption(n_active_lines_level);
+
+      if (active_cell_index_partitioner)
+        mem += active_cell_index_partitioner->memory_consumption();
+
+      for (const auto &partitioner : level_cell_index_partitioners)
+        if (partitioner)
+          mem += partitioner->memory_consumption();
+
+      return mem;
     }
 
 
@@ -16386,6 +16396,9 @@ std::size_t
 Triangulation<dim, spacedim>::memory_consumption() const
 {
   std::size_t mem = 0;
+  mem += sizeof(MeshSmoothing);
+  mem += MemoryConsumption::memory_consumption(reference_cells);
+  mem += MemoryConsumption::memory_consumption(periodic_face_pairs_level_0);
   mem += MemoryConsumption::memory_consumption(levels);
   for (const auto &level : levels)
     mem += MemoryConsumption::memory_consumption(*level);

--- a/source/grid/tria_faces.cc
+++ b/source/grid/tria_faces.cc
@@ -38,6 +38,8 @@ namespace internal
         return MemoryConsumption::memory_consumption(lines);
       if (dim == 3)
         return (MemoryConsumption::memory_consumption(quads) +
+                MemoryConsumption::memory_consumption(quads_line_orientations) +
+                MemoryConsumption::memory_consumption(quad_reference_cell) +
                 MemoryConsumption::memory_consumption(lines));
 
       return 0;

--- a/source/grid/tria_levels.cc
+++ b/source/grid/tria_levels.cc
@@ -27,15 +27,21 @@ namespace internal
     std::size_t
     TriaLevel::memory_consumption() const
     {
-      return (MemoryConsumption::memory_consumption(refine_flags) +
-              MemoryConsumption::memory_consumption(coarsen_flags) +
-              MemoryConsumption::memory_consumption(active_cell_indices) +
-              MemoryConsumption::memory_consumption(neighbors) +
-              MemoryConsumption::memory_consumption(subdomain_ids) +
-              MemoryConsumption::memory_consumption(level_subdomain_ids) +
-              MemoryConsumption::memory_consumption(parents) +
-              MemoryConsumption::memory_consumption(direction_flags) +
-              MemoryConsumption::memory_consumption(cells));
+      return (
+        MemoryConsumption::memory_consumption(refine_flags) +
+        MemoryConsumption::memory_consumption(coarsen_flags) +
+        MemoryConsumption::memory_consumption(active_cell_indices) +
+        MemoryConsumption::memory_consumption(global_active_cell_indices) +
+        MemoryConsumption::memory_consumption(global_level_cell_indices) +
+        MemoryConsumption::memory_consumption(neighbors) +
+        MemoryConsumption::memory_consumption(subdomain_ids) +
+        MemoryConsumption::memory_consumption(level_subdomain_ids) +
+        MemoryConsumption::memory_consumption(parents) +
+        MemoryConsumption::memory_consumption(direction_flags) +
+        MemoryConsumption::memory_consumption(cells) +
+        MemoryConsumption::memory_consumption(face_orientations) +
+        MemoryConsumption::memory_consumption(reference_cell) +
+        MemoryConsumption::memory_consumption(cell_vertex_indices_cache));
     }
   } // namespace TriangulationImplementation
 } // namespace internal


### PR DESCRIPTION
I did some profiling of loading in my favorite mesh (2.4 million tets) and I noticed that the memory consumption estimate (580 MB) was pretty far off from the peak measured by massif (1.3 GB). Part of the difference is from temporary construction data, but a larger part is that we missed a few things in `Triangulation::memory_consumption()`.

I added some missing memory consumption functions (our computed memory consumption is now 712 MB) and optimized some of our allocations (which lowered the peak to 1.2 GB).