### PR TITLE
PETScWrappers:BlockSparseMatrix: create PETSc MATNEST

### DIFF
--- a/doc/news/changes/minor/20221220StefanoZampini-b
+++ b/doc/news/changes/minor/20221220StefanoZampini-b
@@ -1,0 +1,3 @@
+New: PETScWrappers:BlockSparseMatrix now is also a PETSc MATNEST type.
+<br>
+(StefanZampini, 2022/12/20)

--- a/doc/news/changes/minor/20221220StefanoZampini-b
+++ b/doc/news/changes/minor/20221220StefanoZampini-b
@@ -1,3 +1,3 @@
 New: PETScWrappers:BlockSparseMatrix now is also a PETSc MATNEST type.
 <br>
-(StefanZampini, 2022/12/20)
+(Stefano Zampini, 2022/12/20)

--- a/include/deal.II/lac/petsc_block_sparse_matrix.h
+++ b/include/deal.II/lac/petsc_block_sparse_matrix.h
@@ -279,7 +279,7 @@ namespace PETScWrappers
        * particular, it should only be used for read-only operations into the
        * matrix.
        */
-      operator Mat() const;
+      operator const Mat &() const;
 
       /**
        * Return a reference to the underlying PETSc type. It can be used to

--- a/include/deal.II/lac/petsc_block_sparse_matrix.h
+++ b/include/deal.II/lac/petsc_block_sparse_matrix.h
@@ -105,7 +105,7 @@ namespace PETScWrappers
       /**
        * Destructor.
        */
-      ~BlockSparseMatrix() override = default;
+      ~BlockSparseMatrix() override;
 
       /**
        * Pseudo copy operator only copying empty objects. The sizes of the
@@ -271,6 +271,26 @@ namespace PETScWrappers
        * protected.
        */
       using BlockMatrixBase<SparseMatrix>::clear;
+
+      /**
+       * Conversion operator to gain access to the underlying PETSc type. If you
+       * do this, you cut this class off some information it may need, so this
+       * conversion operator should only be used if you know what you do. In
+       * particular, it should only be used for read-only operations into the
+       * matrix.
+       */
+      operator Mat() const;
+
+      /**
+       * Return a reference to the underlying PETSc type. It can be used to
+       * modify the underlying data, so use it only when you know what you
+       * are doing.
+       */
+      Mat &
+      petsc_matrix();
+
+    private:
+      Mat petsc_nest_matrix = nullptr;
     };
 
 

--- a/source/lac/petsc_parallel_block_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_block_sparse_matrix.cc
@@ -176,7 +176,7 @@ namespace PETScWrappers
       return block(0, 0).get_mpi_communicator();
     }
 
-    BlockSparseMatrix::operator Mat() const
+    BlockSparseMatrix::operator const Mat &() const
     {
       return petsc_nest_matrix;
     }

--- a/source/lac/petsc_parallel_block_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_block_sparse_matrix.cc
@@ -35,7 +35,7 @@ namespace PETScWrappers
     BlockSparseMatrix::~BlockSparseMatrix()
     {
       PetscErrorCode ierr = destroy_matrix(petsc_nest_matrix);
-      AssertThrow(ierr == 0, ExcPETScError(ierr));
+      AssertNothrow(ierr == 0, ExcPETScError(ierr));
     }
 
 #  ifndef DOXYGEN

--- a/tests/petsc/block_matrices_01.cc
+++ b/tests/petsc/block_matrices_01.cc
@@ -67,6 +67,10 @@ test()
   pbsm.reinit(rows, cols, bdsp, MPI_COMM_WORLD);
   deallog << "nonzeros BlockSparseMatrix: " << pbsm.n_nonzero_elements()
           << std::endl;
+
+  // Extract the PETSc MATNEST and use print from PETScWrappers::MatrixBase
+  PETScWrappers::MatrixBase tmp(pbsm.petsc_matrix());
+  tmp.print(deallog.get_file_stream());
 }
 
 

--- a/tests/petsc/block_matrices_01.mpirun=1.output
+++ b/tests/petsc/block_matrices_01.mpirun=1.output
@@ -1,3 +1,12 @@
 
 DEAL::nonzeros BlockSparsityPattern: 9
 DEAL::nonzeros BlockSparseMatrix: 9
+(0,0) 0.00000
+(1,0) 0.00000
+(1,1) 0.00000
+(2,2) 0.00000
+(3,2) 0.00000
+(3,3) 0.00000
+(4,2) 0.00000
+(4,3) 0.00000
+(4,4) 0.00000


### PR DESCRIPTION
This is the first step towards using PETSc solvers with our BlockMatrix wrappers.