### PR TITLE
step-81: Fix a typo in external links

### DIFF
--- a/examples/step-81/doc/results.dox
+++ b/examples/step-81/doc/results.dox
@@ -45,7 +45,7 @@ Following are the output images:
       </td>
       <td></td>
         <td align="center">
-      <img src="https://www.dealii.org/images/steps/developer/step-81-nointerface_abs_PML0.png" alt="Visualization of the solution of step-81 with no interface, no absorbing boundary conditions and PML strength 0" height="210">
+      <img src="https://www.dealii.org/images/steps/developer/step-81-nointerface_abs_PML0.png" alt="Visualization of the solution of step-81 with no interface, absorbing boundary conditions and PML strength 0" height="210">
         <p> Solution with no interface, absorbing boundary conditions and PML strength 0.</p>
             </td>
         <td></td>

--- a/examples/step-81/doc/results.dox
+++ b/examples/step-81/doc/results.dox
@@ -40,12 +40,12 @@ Following are the output images:
 <table width="80%" align="center">
   <tr>
       <td align="center">
-      <img src="https://www.dealii.org/images/steps/developer/step-81-nointerface_abs_PML0.png" alt="Visualization of the solution of step-81 with no interface, Dirichlet boundary conditions and PML strength 0" height="210"/>
+      <img src="https://www.dealii.org/images/steps/developer/step-81-nointerface_noabs_PML0.png" alt="Visualization of the solution of step-81 with no interface, Dirichlet boundary conditions and PML strength 0" height="210"/>
       <p> Solution with no interface, Dirichlet boundary conditions and PML strength 0.</p>
       </td>
       <td></td>
         <td align="center">
-      <img src="https://www.dealii.org/images/steps/developer/step-81-nointerface_noabs_PML0.png" alt="Visualization of the solution of step-81 with no interface, no absorbing boundary conditions and PML strength 0" height="210">
+      <img src="https://www.dealii.org/images/steps/developer/step-81-nointerface_abs_PML0.png" alt="Visualization of the solution of step-81 with no interface, no absorbing boundary conditions and PML strength 0" height="210">
         <p> Solution with no interface, absorbing boundary conditions and PML strength 0.</p>
             </td>
         <td></td>


### PR DESCRIPTION
It should read "noabs" for the first example with Dirichlet boundary
conditions and "abs" for the examples with absorbing boundary
conditions.