### PR TITLE
Make sure to clear a variable that gets set

### DIFF
--- a/source/multigrid/mg_level_global_transfer.cc
+++ b/source/multigrid/mg_level_global_transfer.cc
@@ -387,14 +387,20 @@ MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<Number>>::clear()
 {
   sizes.resize(0);
   copy_indices.clear();
+  solution_copy_indices.clear();
   copy_indices_global_mine.clear();
+  solution_copy_indices_global_mine.clear();
   copy_indices_level_mine.clear();
+  solution_copy_indices_level_mine.clear();
   component_to_block_map.resize(0);
   mg_constrained_dofs = nullptr;
   ghosted_global_vector.reinit(0);
+  solution_ghosted_global_vector.reinit(0);
   ghosted_level_vector.resize(0, 0);
+  solution_ghosted_level_vector.resize(0, 0);
   perform_plain_copy            = false;
   perform_renumbered_plain_copy = false;
+  initialize_dof_vector         = nullptr;
 }
 
 

--- a/source/multigrid/mg_transfer_matrix_free.cc
+++ b/source/multigrid/mg_transfer_matrix_free.cc
@@ -109,10 +109,9 @@ MGTransferMatrixFree<dim, Number>::build(
            "probably close to where you already call distribute_dofs()."));
   if (external_partitioners.size() > 0)
     {
-      Assert(
-        this->initialize_dof_vector == nullptr,
-        ExcMessage(
-          "A initialize_dof_vector function has already been registered in the constructor!"));
+      Assert(this->initialize_dof_vector == nullptr,
+             ExcMessage("An initialize_dof_vector function has already "
+                        "been registered in the constructor!"));
 
       this->initialize_dof_vector =
         [external_partitioners](


### PR DESCRIPTION
I realized in an application code that vectors could be in an invalid state, which I could trace back to `clear()` not cleaning up a member variable.