### PR TITLE
Don't install mold linker in CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -36,10 +36,6 @@ jobs:
         libraries: container iostreams python serialization system thread
         platform: x64
         configuration: Release
-    - name: Install mold linker
-      uses: rui314/setup-mold@v1
-      with:
-        make-default: false
     - name: configure deal.II
       run: |
         mkdir build
@@ -89,10 +85,6 @@ jobs:
             petsc-dev \
             libmetis-dev \
             libhdf5-mpi-dev
-    - name: Install mold linker
-      uses: rui314/setup-mold@v1
-      with:
-        make-default: false
     - name: info
       run: |
         mpicc -v
@@ -168,10 +160,6 @@ jobs:
             numdiff \
             openmpi-bin \
             libboost-all-dev
-    - name: Install mold linker
-      uses: rui314/setup-mold@v1
-      with:
-        make-default: false
     - name: info
       run: |
         mpicc -v
@@ -266,10 +254,6 @@ jobs:
                                 intel-oneapi-mkl-devel \
                                 intel-oneapi-tbb-devel
         sudo apt-get clean
-    - name: Install mold linker
-      uses: rui314/setup-mold@v1
-      with:
-        make-default: false
     - name: info
       run: |
         source /opt/intel/oneapi/setvars.sh

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -22,10 +22,6 @@ jobs:
       run: |
         g++ -v
         cmake --version
-    - name: Install mold linker
-      uses: rui314/setup-mold@v1
-      with:
-        make-default: false
     - name: configure
       run: |
         cmake -D CMAKE_BUILD_TYPE=Debug -D DEAL_II_CXX_FLAGS='-Werror' -D DEAL_II_EARLY_DEPRECATIONS=ON .
@@ -68,10 +64,6 @@ jobs:
         #export OMPI_CXX=g++
         #export OMPI_CC=gcc
         #export OMPI_FC=gfortran
-    - name: Install mold linker
-      uses: rui314/setup-mold@v1
-      with:
-        make-default: false
     - name: info
       run: |
         mpicxx -v


### PR DESCRIPTION
This causes build failures frequently and doesn't work properly in the CI anyway (mold is not detected, but it works locally for me).