### PR TITLE
CMake: avoid race conditions between concurrent prm tests

### DIFF
--- a/cmake/macros/macro_deal_ii_add_test.cmake
+++ b/cmake/macros/macro_deal_ii_add_test.cmake
@@ -571,11 +571,19 @@ function(deal_ii_add_test _category _test_name _comparison_file)
         set_tests_properties(${_test_full} PROPERTIES PROCESSORS ${_slots})
       endif()
 
-      if(NOT "${_n_cpu}${_n_threads}" STREQUAL "00")
+      #
+      # Serialize all tests that share a common executable target. This
+      # involves tests with .threads=N. and .mpirun=N. annotation, as well
+      # as tests with parameter files (that might share a common executable
+      # target).
+      #
+      if( NOT "${_n_cpu}${_n_threads}" STREQUAL "00" OR
+          "${_source_file}" MATCHES "(prm|json)$" )
         #
-        # Running multiple variants in parallel triggers a race condition
-        # where the same (not yet existent) executable is built
-        # concurrently leading to undefined outcomes.
+        # Running multiple variants of tests with the same target
+        # executable in parallel triggers a race condition where the same
+        # (not yet existent) target is built concurrently leading to
+        # undefined outcomes.
         #
         # Luckily CMake has a mechanism to force a test to be run after
         # another has finished (and both are scheduled):

--- a/tests/a-framework/CMakeLists.txt
+++ b/tests/a-framework/CMakeLists.txt
@@ -2,25 +2,10 @@ cmake_minimum_required(VERSION 3.3.0)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 
-add_executable(dummy.release dummy.cc)
-add_executable(dummy.debug dummy.cc)
-set(TEST_TARGET_RELEASE dummy.release)
-set(TEST_TARGET_DEBUG dummy.debug)
+add_executable(dummy dummy.cc)
+set(TEST_TARGET dummy)
 
 deal_ii_pickup_tests()
-
-#
-# Limit concurrency between the two parameter file tests.
-#
-foreach(_build ${DEAL_II_BUILD_TYPES})
-  string(TOLOWER ${_build} _build)
-  if(TARGET parameter_file_2.${_build}.diff AND
-     TARGET parameter_file_1.${_build}.diff )
-    set_tests_properties(a-framework/parameter_file_2.${_build} PROPERTIES
-      DEPENDS a-framework/parameter_file_1.${_build}
-      )
-  endif()
-endforeach()
 
 
 #


### PR DESCRIPTION
We need to serialize all tests that share a common executable target. This
involves tests with `.threads=N.` and `.mpirun=N.` annotation, as well as
tests with parameter files (that might share a common executable target).

Running multiple variants in parallel triggers a race condition where the
same (not yet existent) executable is built concurrently leading to
undefined outcomes.

@tjhei This race condition was present for a long time. I think I we simply
never saw it on the regression tester due to `ctest --schedule-random` ...

In reference to #14576