### PR TITLE
Remove incorrect static_assert when using CUDA-aware MPI

### DIFF
--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -1143,11 +1143,6 @@ namespace LinearAlgebra
           else
 #  endif
             {
-#  ifdef DEAL_II_MPI_WITH_CUDA_SUPPORT
-              static_assert(
-                std::is_same<MemorySpaceType, dealii::MemorySpace::Host>::value,
-                "This code path should only be compiled for CUDA-aware-MPI for MemorySpace::Host!");
-#  endif
               if (import_data.values.size() == 0)
                 Kokkos::resize(import_data.values,
                                partitioner->n_import_indices());


### PR DESCRIPTION
The `static_assert` should have been removed during the refactor in #14510 The library doesn't compile anymore if you have CUDA-aware MPI