### PR TITLE
Jenkins: run tests in random order

### DIFF
--- a/contrib/ci/Jenkinsfile.mpi
+++ b/contrib/ci/Jenkinsfile.mpi
@@ -110,7 +110,7 @@ pipeline
                   time ninja test # quicktests
                   time ctest --rerun-failed --output-on-failure -R quick_tests/
                   time ninja setup_tests
-                  time ctest -R "all-headers|multigrid/transfer|matrix_free/matrix_" --output-on-failure -j $NP --no-compress-output -T test
+                  time ctest -R "all-headers|multigrid/transfer|matrix_free/matrix_" --output-on-failure --schedule-random -j $NP --no-compress-output -T test
                  '''
               githubNotify context: 'Jenkins: MPI', description: 'OK',  status: 'SUCCESS'
             }


### PR DESCRIPTION
Schedule tests in random order to improve load balance over time and therefor improve speed.

In reference to #14615