### PR TITLE
Fix compiler error for older version of GCC

### DIFF
--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -1953,8 +1953,6 @@ namespace internal
                           typename SymmetricTensorAccessors::
                             StorageType<2, dim, Number>::base_tensor_type &data)
   {
-    static_assert(dim <= 3, "The selected dimension is not yet supported.");
-
     // 1d is very simple and done first
     if (dim == 1)
       return data[0];
@@ -2002,8 +2000,6 @@ namespace internal
                           const typename SymmetricTensorAccessors::
                             StorageType<2, dim, Number>::base_tensor_type &data)
   {
-    static_assert(dim <= 3, "The selected dimension is not yet supported.");
-
     // 1d is very simple and done first
     if (dim == 1)
       return data[0];
@@ -2051,8 +2047,6 @@ namespace internal
                           typename SymmetricTensorAccessors::
                             StorageType<4, dim, Number>::base_tensor_type &data)
   {
-    static_assert(dim <= 3, "The selected dimension is not yet supported.");
-
     switch (dim)
       {
         case 1:
@@ -2101,8 +2095,6 @@ namespace internal
                           const typename SymmetricTensorAccessors::
                             StorageType<4, dim, Number>::base_tensor_type &data)
   {
-    static_assert(dim <= 3, "The selected dimension is not yet supported.");
-
     switch (dim)
       {
         case 1:

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -1953,6 +1953,8 @@ namespace internal
                           typename SymmetricTensorAccessors::
                             StorageType<2, dim, Number>::base_tensor_type &data)
   {
+    static_assert(dim <= 3, "The selected dimension is not yet supported.");
+
     // 1d is very simple and done first
     if (dim == 1)
       return data[0];
@@ -1989,7 +1991,6 @@ namespace internal
     // We cannot return a static variable, as this class must support number
     // types that require no instances of the number type to be in scope during
     // a reinitialization procedure (e.g. ADOL-C adtl::adouble).
-    Assert(false, ExcInternalError());
     return data[0];
   }
 
@@ -2001,6 +2002,8 @@ namespace internal
                           const typename SymmetricTensorAccessors::
                             StorageType<2, dim, Number>::base_tensor_type &data)
   {
+    static_assert(dim <= 3, "The selected dimension is not yet supported.");
+
     // 1d is very simple and done first
     if (dim == 1)
       return data[0];
@@ -2037,7 +2040,6 @@ namespace internal
     // We cannot return a static variable, as this class must support number
     // types that require no instances of the number type to be in scope during
     // a reinitialization procedure (e.g. ADOL-C adtl::adouble).
-    Assert(false, ExcInternalError());
     return data[0];
   }
 
@@ -2049,6 +2051,8 @@ namespace internal
                           typename SymmetricTensorAccessors::
                             StorageType<4, dim, Number>::base_tensor_type &data)
   {
+    static_assert(dim <= 3, "The selected dimension is not yet supported.");
+
     switch (dim)
       {
         case 1:
@@ -2087,7 +2091,6 @@ namespace internal
     // We cannot return a static variable, as this class must support number
     // types that require no instances of the number type to be in scope during
     // a reinitialization procedure (e.g. ADOL-C adtl::adouble).
-    Assert(false, ExcInternalError());
     return data[0][0];
   }
 
@@ -2098,6 +2101,8 @@ namespace internal
                           const typename SymmetricTensorAccessors::
                             StorageType<4, dim, Number>::base_tensor_type &data)
   {
+    static_assert(dim <= 3, "The selected dimension is not yet supported.");
+
     switch (dim)
       {
         case 1:
@@ -2136,7 +2141,6 @@ namespace internal
     // We cannot return a static variable, as this class must support number
     // types that require no instances of the number type to be in scope during
     // a reinitialization procedure (e.g. ADOL-C adtl::adouble).
-    Assert(false, ExcInternalError());
     return data[0][0];
   }
 


### PR DESCRIPTION
Address a rather cryptic error reported by GCC 8.4.0 that was introduced by 87c1195877301881931c2104a50ae0c0a0f1c494 :
```
symmetric_tensor.h:2048</a>:3: sorry, unimplemented: unexpected AST of kind switch_expr
```
See https://cdash.dealii.org/viewBuildError.php?type=0&buildid=954.

I didn't find too much information about this problem, but a hint given by one thread that I found suggested that throwing in a `constexpr` function might render these kinds of errors.

@tamiko, would you mind please running this branch on the tester to see if it works?

