### PR TITLE
Move a function to ReferenceCell

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -633,6 +633,25 @@ public:
   vtk_lagrange_type() const;
 
   /**
+   * Given a set of node indices of the form $(i)$ or $(i,j)$ or $(i,j,k)$
+   * (depending on whether the reference cell is in 1d, 2d, or 3d), return
+   * the index the VTK format uses for this node for cells that are
+   * subdivided as many times in each of the coordinate directions as
+   * described by the second argument. For a uniformly subdivided cell,
+   * the second argument is an array whose elements will all be equal.
+   *
+   * The last argument, @p legacy_format, indicates whether to use the
+   * old, VTK legacy format (when `true`) or the new, VTU format (when
+   * `false`).
+   */
+  template <int dim>
+  unsigned int
+  vtk_lexicographic_to_node_index(
+    const std::array<unsigned, dim> &node_indices,
+    const std::array<unsigned, dim> &nodes_per_direction,
+    const bool                       legacy_format) const;
+
+  /**
    * Return the GMSH element type code that corresponds to the reference cell.
    */
   unsigned int
@@ -2554,6 +2573,35 @@ ReferenceCell::permute_according_orientation(
   return temp_;
 }
 
+
+
+template <>
+unsigned int
+ReferenceCell::vtk_lexicographic_to_node_index<0>(
+  const std::array<unsigned, 0> &node_indices,
+  const std::array<unsigned, 0> &nodes_per_direction,
+  const bool                     legacy_format) const;
+
+template <>
+unsigned int
+ReferenceCell::vtk_lexicographic_to_node_index<1>(
+  const std::array<unsigned, 1> &node_indices,
+  const std::array<unsigned, 1> &nodes_per_direction,
+  const bool                     legacy_format) const;
+
+template <>
+unsigned int
+ReferenceCell::vtk_lexicographic_to_node_index<2>(
+  const std::array<unsigned, 2> &node_indices,
+  const std::array<unsigned, 2> &nodes_per_direction,
+  const bool                     legacy_format) const;
+
+template <>
+unsigned int
+ReferenceCell::vtk_lexicographic_to_node_index<3>(
+  const std::array<unsigned, 3> &node_indices,
+  const std::array<unsigned, 3> &nodes_per_direction,
+  const bool                     legacy_format) const;
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -995,193 +995,6 @@ namespace
 
 
 
-  template <int dim>
-  unsigned int
-  lexicographic_to_vtk_point_index(const std::array<unsigned, dim> &,
-                                   const std::array<unsigned, dim> &,
-                                   const bool)
-  {
-    Assert(false, ExcNotImplemented());
-    return 0;
-  }
-
-
-
-  /**
-   * Given (i,j,k) coordinates within the Lagrange quadrilateral, return an
-   * offset into the local connectivity array.
-   *
-   * Modified from
-   * https://github.com/Kitware/VTK/blob/265ca48a/Common/DataModel/vtkLagrangeQuadrilateral.cxx#L558
-   */
-  template <>
-  unsigned int
-  lexicographic_to_vtk_point_index<2>(
-    const std::array<unsigned, 2> &node_indices,
-    const std::array<unsigned, 2> &nodes_per_direction,
-    const bool)
-  {
-    const unsigned int i = node_indices[0];
-    const unsigned int j = node_indices[1];
-
-    const bool ibdy = (i == 0 || i == nodes_per_direction[0]);
-    const bool jbdy = (j == 0 || j == nodes_per_direction[1]);
-    // How many boundaries do we lie on at once?
-    const int nbdy = (ibdy ? 1 : 0) + (jbdy ? 1 : 0);
-
-    if (nbdy == 2) // Vertex DOF
-      { // ijk is a corner node. Return the proper index (somewhere in [0,3]):
-        return (i != 0u ? (j != 0u ? 2 : 1) : (j != 0u ? 3 : 0));
-      }
-
-    int offset = 4;
-    if (nbdy == 1) // Edge DOF
-      {
-        if (!ibdy)
-          { // On i axis
-            return (i - 1) +
-                   (j != 0u ?
-                      nodes_per_direction[0] - 1 + nodes_per_direction[1] - 1 :
-                      0) +
-                   offset;
-          }
-
-        if (!jbdy)
-          { // On j axis
-            return (j - 1) +
-                   (i != 0u ? nodes_per_direction[0] - 1 :
-                              2 * (nodes_per_direction[0] - 1) +
-                                nodes_per_direction[1] - 1) +
-                   offset;
-          }
-      }
-
-    offset += 2 * (nodes_per_direction[0] - 1 + nodes_per_direction[1] - 1);
-    // nbdy == 0: Face DOF
-    return offset + (i - 1) + (nodes_per_direction[0] - 1) * ((j - 1));
-  }
-
-
-
-  /**
-   * Given (i,j,k) coordinates within the Lagrange hexahedron, return an
-   * offset into the local connectivity array.
-   *
-   * Modified from
-   * https://github.com/Kitware/VTK/blob/265ca48a/Common/DataModel/vtkLagrangeHexahedron.cxx#L734
-   * (legacy_format=true) and from
-   * https://github.com/Kitware/VTK/blob/256fe70de00e3441f126276ca4a8c5477d0bcb86/Common/DataModel/vtkHigherOrderHexahedron.cxx#L593
-   * (legacy_format=false). The two versions differ regarding the ordering of
-   * lines 10 and 11 (clockwise vs. anti-clockwise). See also:
-   * https://github.com/Kitware/VTK/blob/7a0b92864c96680b1f42ee84920df556fc6ebaa3/Documentation/release/dev/node-numbering-change-for-VTK_LAGRANGE_HEXAHEDRON.md
-   *
-   */
-  template <>
-  unsigned int
-  lexicographic_to_vtk_point_index<3>(
-    const std::array<unsigned, 3> &node_indices,
-    const std::array<unsigned, 3> &nodes_per_direction,
-    const bool                     legacy_format)
-  {
-    const unsigned int i = node_indices[0];
-    const unsigned int j = node_indices[1];
-    const unsigned int k = node_indices[2];
-
-    const bool ibdy = (i == 0 || i == nodes_per_direction[0]);
-    const bool jbdy = (j == 0 || j == nodes_per_direction[1]);
-    const bool kbdy = (k == 0 || k == nodes_per_direction[2]);
-    // How many boundaries do we lie on at once?
-    const int nbdy = (ibdy ? 1 : 0) + (jbdy ? 1 : 0) + (kbdy ? 1 : 0);
-
-    if (nbdy == 3) // Vertex DOF
-      { // ijk is a corner node. Return the proper index (somewhere in [0,7]):
-        return (i != 0u ? (j != 0u ? 2 : 1) : (j != 0u ? 3 : 0)) +
-               (k != 0u ? 4 : 0);
-      }
-
-    int offset = 8;
-    if (nbdy == 2) // Edge DOF
-      {
-        if (!ibdy)
-          { // On i axis
-            return (i - 1) +
-                   (j != 0u ?
-                      nodes_per_direction[0] - 1 + nodes_per_direction[1] - 1 :
-                      0) +
-                   (k != 0u ? 2 * (nodes_per_direction[0] - 1 +
-                                   nodes_per_direction[1] - 1) :
-                              0) +
-                   offset;
-          }
-        if (!jbdy)
-          { // On j axis
-            return (j - 1) +
-                   (i != 0u ? nodes_per_direction[0] - 1 :
-                              2 * (nodes_per_direction[0] - 1) +
-                                nodes_per_direction[1] - 1) +
-                   (k != 0u ? 2 * (nodes_per_direction[0] - 1 +
-                                   nodes_per_direction[1] - 1) :
-                              0) +
-                   offset;
-          }
-        // !kbdy, On k axis
-        offset +=
-          4 * (nodes_per_direction[0] - 1) + 4 * (nodes_per_direction[1] - 1);
-        if (legacy_format)
-          return (k - 1) +
-                 (nodes_per_direction[2] - 1) *
-                   (i != 0u ? (j != 0u ? 3 : 1) : (j != 0u ? 2 : 0)) +
-                 offset;
-        else
-          return (k - 1) +
-                 (nodes_per_direction[2] - 1) *
-                   (i != 0u ? (j != 0u ? 2 : 1) : (j != 0u ? 3 : 0)) +
-                 offset;
-      }
-
-    offset += 4 * (nodes_per_direction[0] - 1 + nodes_per_direction[1] - 1 +
-                   nodes_per_direction[2] - 1);
-    if (nbdy == 1) // Face DOF
-      {
-        if (ibdy) // On i-normal face
-          {
-            return (j - 1) + ((nodes_per_direction[1] - 1) * (k - 1)) +
-                   (i != 0u ? (nodes_per_direction[1] - 1) *
-                                (nodes_per_direction[2] - 1) :
-                              0) +
-                   offset;
-          }
-        offset +=
-          2 * (nodes_per_direction[1] - 1) * (nodes_per_direction[2] - 1);
-        if (jbdy) // On j-normal face
-          {
-            return (i - 1) + ((nodes_per_direction[0] - 1) * (k - 1)) +
-                   (j != 0u ? (nodes_per_direction[2] - 1) *
-                                (nodes_per_direction[0] - 1) :
-                              0) +
-                   offset;
-          }
-        offset +=
-          2 * (nodes_per_direction[2] - 1) * (nodes_per_direction[0] - 1);
-        // kbdy, On k-normal face
-        return (i - 1) + ((nodes_per_direction[0] - 1) * (j - 1)) +
-               (k != 0u ?
-                  (nodes_per_direction[0] - 1) * (nodes_per_direction[1] - 1) :
-                  0) +
-               offset;
-      }
-
-    // nbdy == 0: Body DOF
-    offset += 2 * ((nodes_per_direction[1] - 1) * (nodes_per_direction[2] - 1) +
-                   (nodes_per_direction[2] - 1) * (nodes_per_direction[0] - 1) +
-                   (nodes_per_direction[0] - 1) * (nodes_per_direction[1] - 1));
-    return offset + (i - 1) +
-           (nodes_per_direction[0] - 1) *
-             ((j - 1) + (nodes_per_direction[1] - 1) * ((k - 1)));
-  }
-
-
-
   /**
    * Count the number of nodes and cells referenced by the given
    * argument, and return these numbers (in order nodes, then cells)
@@ -3115,8 +2928,9 @@ namespace DataOutBase
                       {
                         const unsigned int local_index = i1;
                         const unsigned int connectivity_index =
-                          lexicographic_to_vtk_point_index<1>(
-                            {{i1}}, {{n_subdivisions}}, legacy_format);
+                          patch.reference_cell
+                            .template vtk_lexicographic_to_node_index<1>(
+                              {{i1}}, {{n_subdivisions}}, legacy_format);
                         connectivity[connectivity_index] = local_index;
                       }
 
@@ -3129,10 +2943,11 @@ namespace DataOutBase
                         {
                           const unsigned int local_index = i2 * n + i1;
                           const unsigned int connectivity_index =
-                            lexicographic_to_vtk_point_index<2>(
-                              {{i1, i2}},
-                              {{n_subdivisions, n_subdivisions}},
-                              legacy_format);
+                            patch.reference_cell
+                              .template vtk_lexicographic_to_node_index<2>(
+                                {{i1, i2}},
+                                {{n_subdivisions, n_subdivisions}},
+                                legacy_format);
                           connectivity[connectivity_index] = local_index;
                         }
 
@@ -3147,12 +2962,13 @@ namespace DataOutBase
                             const unsigned int local_index =
                               i3 * n * n + i2 * n + i1;
                             const unsigned int connectivity_index =
-                              lexicographic_to_vtk_point_index<3>(
-                                {{i1, i2, i3}},
-                                {{n_subdivisions,
-                                  n_subdivisions,
-                                  n_subdivisions}},
-                                legacy_format);
+                              patch.reference_cell
+                                .template vtk_lexicographic_to_node_index<3>(
+                                  {{i1, i2, i3}},
+                                  {{n_subdivisions,
+                                    n_subdivisions,
+                                    n_subdivisions}},
+                                  legacy_format);
                             connectivity[connectivity_index] = local_index;
                           }
 

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -996,7 +996,7 @@ namespace
 
 
   template <int dim>
-  int
+  unsigned int
   lexicographic_to_vtk_point_index(const std::array<unsigned, dim> &,
                                    const std::array<unsigned, dim> &,
                                    const bool)
@@ -1015,17 +1015,17 @@ namespace
    * https://github.com/Kitware/VTK/blob/265ca48a/Common/DataModel/vtkLagrangeQuadrilateral.cxx#L558
    */
   template <>
-  int
+  unsigned int
   lexicographic_to_vtk_point_index<2>(
-    const std::array<unsigned, 2> &indices,
-    const std::array<unsigned, 2> &points_per_direction,
+    const std::array<unsigned, 2> &node_indices,
+    const std::array<unsigned, 2> &nodes_per_direction,
     const bool)
   {
-    const unsigned int i = indices[0];
-    const unsigned int j = indices[1];
+    const unsigned int i = node_indices[0];
+    const unsigned int j = node_indices[1];
 
-    const bool ibdy = (i == 0 || i == points_per_direction[0]);
-    const bool jbdy = (j == 0 || j == points_per_direction[1]);
+    const bool ibdy = (i == 0 || i == nodes_per_direction[0]);
+    const bool jbdy = (j == 0 || j == nodes_per_direction[1]);
     // How many boundaries do we lie on at once?
     const int nbdy = (ibdy ? 1 : 0) + (jbdy ? 1 : 0);
 
@@ -1040,25 +1040,25 @@ namespace
         if (!ibdy)
           { // On i axis
             return (i - 1) +
-                   (j != 0u ? points_per_direction[0] - 1 +
-                                points_per_direction[1] - 1 :
-                              0) +
+                   (j != 0u ?
+                      nodes_per_direction[0] - 1 + nodes_per_direction[1] - 1 :
+                      0) +
                    offset;
           }
 
         if (!jbdy)
           { // On j axis
             return (j - 1) +
-                   (i != 0u ? points_per_direction[0] - 1 :
-                              2 * (points_per_direction[0] - 1) +
-                                points_per_direction[1] - 1) +
+                   (i != 0u ? nodes_per_direction[0] - 1 :
+                              2 * (nodes_per_direction[0] - 1) +
+                                nodes_per_direction[1] - 1) +
                    offset;
           }
       }
 
-    offset += 2 * (points_per_direction[0] - 1 + points_per_direction[1] - 1);
+    offset += 2 * (nodes_per_direction[0] - 1 + nodes_per_direction[1] - 1);
     // nbdy == 0: Face DOF
-    return offset + (i - 1) + (points_per_direction[0] - 1) * ((j - 1));
+    return offset + (i - 1) + (nodes_per_direction[0] - 1) * ((j - 1));
   }
 
 
@@ -1077,19 +1077,19 @@ namespace
    *
    */
   template <>
-  int
+  unsigned int
   lexicographic_to_vtk_point_index<3>(
-    const std::array<unsigned, 3> &indices,
-    const std::array<unsigned, 3> &points_per_direction,
+    const std::array<unsigned, 3> &node_indices,
+    const std::array<unsigned, 3> &nodes_per_direction,
     const bool                     legacy_format)
   {
-    const unsigned int i = indices[0];
-    const unsigned int j = indices[1];
-    const unsigned int k = indices[2];
+    const unsigned int i = node_indices[0];
+    const unsigned int j = node_indices[1];
+    const unsigned int k = node_indices[2];
 
-    const bool ibdy = (i == 0 || i == points_per_direction[0]);
-    const bool jbdy = (j == 0 || j == points_per_direction[1]);
-    const bool kbdy = (k == 0 || k == points_per_direction[2]);
+    const bool ibdy = (i == 0 || i == nodes_per_direction[0]);
+    const bool jbdy = (j == 0 || j == nodes_per_direction[1]);
+    const bool kbdy = (k == 0 || k == nodes_per_direction[2]);
     // How many boundaries do we lie on at once?
     const int nbdy = (ibdy ? 1 : 0) + (jbdy ? 1 : 0) + (kbdy ? 1 : 0);
 
@@ -1105,80 +1105,79 @@ namespace
         if (!ibdy)
           { // On i axis
             return (i - 1) +
-                   (j != 0u ? points_per_direction[0] - 1 +
-                                points_per_direction[1] - 1 :
-                              0) +
-                   (k != 0u ? 2 * (points_per_direction[0] - 1 +
-                                   points_per_direction[1] - 1) :
+                   (j != 0u ?
+                      nodes_per_direction[0] - 1 + nodes_per_direction[1] - 1 :
+                      0) +
+                   (k != 0u ? 2 * (nodes_per_direction[0] - 1 +
+                                   nodes_per_direction[1] - 1) :
                               0) +
                    offset;
           }
         if (!jbdy)
           { // On j axis
             return (j - 1) +
-                   (i != 0u ? points_per_direction[0] - 1 :
-                              2 * (points_per_direction[0] - 1) +
-                                points_per_direction[1] - 1) +
-                   (k != 0u ? 2 * (points_per_direction[0] - 1 +
-                                   points_per_direction[1] - 1) :
+                   (i != 0u ? nodes_per_direction[0] - 1 :
+                              2 * (nodes_per_direction[0] - 1) +
+                                nodes_per_direction[1] - 1) +
+                   (k != 0u ? 2 * (nodes_per_direction[0] - 1 +
+                                   nodes_per_direction[1] - 1) :
                               0) +
                    offset;
           }
         // !kbdy, On k axis
         offset +=
-          4 * (points_per_direction[0] - 1) + 4 * (points_per_direction[1] - 1);
+          4 * (nodes_per_direction[0] - 1) + 4 * (nodes_per_direction[1] - 1);
         if (legacy_format)
           return (k - 1) +
-                 (points_per_direction[2] - 1) *
+                 (nodes_per_direction[2] - 1) *
                    (i != 0u ? (j != 0u ? 3 : 1) : (j != 0u ? 2 : 0)) +
                  offset;
         else
           return (k - 1) +
-                 (points_per_direction[2] - 1) *
+                 (nodes_per_direction[2] - 1) *
                    (i != 0u ? (j != 0u ? 2 : 1) : (j != 0u ? 3 : 0)) +
                  offset;
       }
 
-    offset += 4 * (points_per_direction[0] - 1 + points_per_direction[1] - 1 +
-                   points_per_direction[2] - 1);
+    offset += 4 * (nodes_per_direction[0] - 1 + nodes_per_direction[1] - 1 +
+                   nodes_per_direction[2] - 1);
     if (nbdy == 1) // Face DOF
       {
         if (ibdy) // On i-normal face
           {
-            return (j - 1) + ((points_per_direction[1] - 1) * (k - 1)) +
-                   (i != 0u ? (points_per_direction[1] - 1) *
-                                (points_per_direction[2] - 1) :
+            return (j - 1) + ((nodes_per_direction[1] - 1) * (k - 1)) +
+                   (i != 0u ? (nodes_per_direction[1] - 1) *
+                                (nodes_per_direction[2] - 1) :
                               0) +
                    offset;
           }
         offset +=
-          2 * (points_per_direction[1] - 1) * (points_per_direction[2] - 1);
+          2 * (nodes_per_direction[1] - 1) * (nodes_per_direction[2] - 1);
         if (jbdy) // On j-normal face
           {
-            return (i - 1) + ((points_per_direction[0] - 1) * (k - 1)) +
-                   (j != 0u ? (points_per_direction[2] - 1) *
-                                (points_per_direction[0] - 1) :
+            return (i - 1) + ((nodes_per_direction[0] - 1) * (k - 1)) +
+                   (j != 0u ? (nodes_per_direction[2] - 1) *
+                                (nodes_per_direction[0] - 1) :
                               0) +
                    offset;
           }
         offset +=
-          2 * (points_per_direction[2] - 1) * (points_per_direction[0] - 1);
+          2 * (nodes_per_direction[2] - 1) * (nodes_per_direction[0] - 1);
         // kbdy, On k-normal face
-        return (i - 1) + ((points_per_direction[0] - 1) * (j - 1)) +
-               (k != 0u ? (points_per_direction[0] - 1) *
-                            (points_per_direction[1] - 1) :
-                          0) +
+        return (i - 1) + ((nodes_per_direction[0] - 1) * (j - 1)) +
+               (k != 0u ?
+                  (nodes_per_direction[0] - 1) * (nodes_per_direction[1] - 1) :
+                  0) +
                offset;
       }
 
     // nbdy == 0: Body DOF
-    offset +=
-      2 * ((points_per_direction[1] - 1) * (points_per_direction[2] - 1) +
-           (points_per_direction[2] - 1) * (points_per_direction[0] - 1) +
-           (points_per_direction[0] - 1) * (points_per_direction[1] - 1));
+    offset += 2 * ((nodes_per_direction[1] - 1) * (nodes_per_direction[2] - 1) +
+                   (nodes_per_direction[2] - 1) * (nodes_per_direction[0] - 1) +
+                   (nodes_per_direction[0] - 1) * (nodes_per_direction[1] - 1));
     return offset + (i - 1) +
-           (points_per_direction[0] - 1) *
-             ((j - 1) + (points_per_direction[1] - 1) * ((k - 1)));
+           (nodes_per_direction[0] - 1) *
+             ((j - 1) + (nodes_per_direction[1] - 1) * ((k - 1)));
   }
 
 


### PR DESCRIPTION
We already deal with translating our own counting into that of various different output formats in class `ReferenceCell`, so it seems natural to move a set of functions used in writing VTK/VTU format there as well. The first commit does a few adjustments to return type and argument names of these functions, whereas the second one is a straight copy from the old place to the new place -- 1:1 code, without any changes.

/rebuild