### PR TITLE
Require Trilinos 13.2 if it includes Kokkos

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -67,7 +67,7 @@ jobs:
     # simple parallel debug build using g++ with simplex configuration enabled
 
     name: linux debug parallel simplex
-    runs-on: [ubuntu-20.04]
+    runs-on: [ubuntu-22.04]
 
     steps:
     - uses: actions/checkout@v3

--- a/cmake/configure/configure_20_trilinos.cmake
+++ b/cmake/configure/configure_20_trilinos.cmake
@@ -185,6 +185,24 @@ macro(feature_trilinos_find_external var)
         set(${var} FALSE)
       endif()
 
+      #
+      # We require at least Trilinos 13.2
+      #
+      if(TRILINOS_VERSION VERSION_LESS 13.2)
+        message(STATUS "Could not find a sufficient Trilinos installation: "
+          "deal.II requires at least version 13.2 if the Trilinos installation includes Kokkos, "
+          "but version ${TRILINOS_VERSION} was found."
+          )
+        set(TRILINOS_ADDITIONAL_ERROR_STRING
+          ${TRILINOS_ADDITIONAL_ERROR_STRING}
+          "The Trilinos installation (found at \"${TRILINOS_DIR}\")\n"
+          "with version ${TRILINOS_VERSION} is too old.\n"
+          "deal.II requires at least version 13.2 if the Trilinos installation includes Kokkos.\n\n"
+          )
+        set(${var} FALSE)
+      endif()
+
+
       if(Kokkos_ENABLE_CUDA)
         # We need to disable SIMD vectorization for CUDA device code.
         # Otherwise, nvcc compilers from version 9 on will emit an error message like:
@@ -267,7 +285,7 @@ macro(feature_trilinos_find_external var)
         main()
         {
           Epetra_CrsMatrix *matrix;
-          const auto teuchos_wrapped_matrix = Teuchos::rcp(matrix, false);	
+          const auto teuchos_wrapped_matrix = Teuchos::rcp(matrix, false);
           Teuchos::ParameterList parameters;
           MueLu::CreateEpetraPreconditioner(teuchos_wrapped_matrix, parameters);
           return 0;

--- a/doc/external-libs/trilinos.html
+++ b/doc/external-libs/trilinos.html
@@ -49,7 +49,8 @@
     <h5>Installing Trilinos</h5>
 
     <p style="color: red">
-      Note: The current version of deal.II requires at least Trilinos 12.4.
+      Note: The current version of deal.II requires at least Trilinos 12.4
+      (13.2 if Trilinos includes Kokkos).
       Deal.II is known to work with Trilinos up to 13.4. Other versions of
       Trilinos should work too but have not been tested prior to the
       release.

--- a/doc/news/changes/20221230DanielArndt
+++ b/doc/news/changes/20221230DanielArndt
@@ -1,0 +1,4 @@
+Updated: The minimum version for Trilinos has been bumped to 13.2 if Trilinos
+bundles Kokkkos.
+<br>
+(Daniel Arndt, 2022/12/30)

--- a/tests/simplex/cell_bounding_boxes_2d.cc
+++ b/tests/simplex/cell_bounding_boxes_2d.cc
@@ -40,7 +40,7 @@ template <int dim>
 void
 compute_bounding_boxes(Triangulation<dim> &tria)
 {
-  for (const auto cell : tria.active_cell_iterators())
+  for (const auto &cell : tria.active_cell_iterators())
     {
       const auto cell_bb = cell->bounding_box();
       deallog << "Center : " << cell_bb.center()

--- a/tests/simplex/cell_bounding_boxes_3d.cc
+++ b/tests/simplex/cell_bounding_boxes_3d.cc
@@ -40,7 +40,7 @@ template <int dim>
 void
 compute_bounding_boxes(Triangulation<dim> &tria)
 {
-  for (const auto cell : tria.active_cell_iterators())
+  for (const auto &cell : tria.active_cell_iterators())
     {
       const auto cell_bb = cell->bounding_box();
       deallog << "Center : " << cell_bb.center()

--- a/tests/simplex/step-68.cc
+++ b/tests/simplex/step-68.cc
@@ -253,7 +253,7 @@ namespace Step68
 
     std::vector<BoundingBox<dim>> all_boxes;
     all_boxes.reserve(background_triangulation.n_locally_owned_active_cells());
-    for (const auto cell : background_triangulation.active_cell_iterators())
+    for (const auto &cell : background_triangulation.active_cell_iterators())
       if (cell->is_locally_owned())
         all_boxes.emplace_back(cell->bounding_box());
     const auto tree        = pack_rtree(all_boxes);


### PR DESCRIPTION
I remember that we settled on requiring Trilinos 13.2 for Kokkos features we can use. At the moment,we technically need at least Kokkos 2.6.0 (Trilinos 12.14.1), though. @tamiko suggested to only require a newer version if `Trilinos` bundles `Kokkos`.