### PR TITLE
Get rid of VtuStream class

### DIFF
--- a/doc/news/changes/minor/20221230Bangerth
+++ b/doc/news/changes/minor/20221230Bangerth
@@ -1,0 +1,5 @@
+New: Writing graphical output in VTU format now uses a workflow that
+uses multiple threads where possible, substantially increasing the
+speed with which functions such as DataOut::write_vtu() work.
+<br>
+(Wolfgang Bangerth, 2022/12/30)

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -564,7 +564,7 @@ public:
 
   /**
    * Determine the orientation of the current entity described by its
-   * vertices @p vertices_1 relative to an entity described by @p var_0.
+   * vertices @p vertices_1 relative to an entity described by @p vertices_0.
    * The two arrays given as arguments can be arrays of global vertex
    * indices or local vertex indices, arrays of vertex locations, or
    * arrays of any other objects identifying the vertices.

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -6070,11 +6070,6 @@ namespace DataOutBase
                       default:
                         Assert(false, ExcNotImplemented());
                     }
-
-                  // Finally update the number of the first vertex of this
-                  // patch
-                  first_vertex_of_patch +=
-                    Utilities::fixed_power<dim>(n_subdivisions + 1);
                 }
               else // use higher-order output
                 {
@@ -6174,11 +6169,12 @@ namespace DataOutBase
                         o << '\t' << first_vertex_of_patch + c;
                       o << '\n';
                     }
-
-                  // Finally update the number of the first vertex of this
-                  // patch
-                  first_vertex_of_patch += Utilities::fixed_power<dim>(n);
                 }
+
+              // Finally update the number of the first vertex of this
+              // patch
+              first_vertex_of_patch +=
+                Utilities::fixed_power<dim>(patch.n_subdivisions + 1);
             }
         }
 

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -5867,7 +5867,8 @@ namespace DataOutBase
 
       for (const auto &patch : patches)
         {
-          // special treatment of simplices since they are not subdivided
+          // First treat non-hypercubes since they can currently
+          // not be subdivided (into sub-cells, or into higher-order cells):
           if (patch.reference_cell != ReferenceCells::get_hypercube<dim>())
             {
               const unsigned int n_points = patch.data.n_cols();

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -5935,137 +5935,149 @@ namespace DataOutBase
       o << "  <Cells>\n";
       o << "    <DataArray type=\"Int32\" Name=\"connectivity\" format=\""
         << ascii_or_binary << "\">\n";
+
+      std::vector<int32_t> cells;
       if (flags.write_higher_order_cells)
         {
-          std::ostringstream oo;
-          {
-            VtuStream vtu_out(oo, flags);
+          Assert(dim <= 3 && dim > 1, ExcNotImplemented());
+          unsigned int first_vertex_of_patch = 0;
+          // Array to hold all the node numbers of a cell
+          std::vector<unsigned> connectivity;
 
-            Assert(dim <= 3 && dim > 1, ExcNotImplemented());
-            unsigned int first_vertex_of_patch = 0;
-            // Array to hold all the node numbers of a cell
-            std::vector<unsigned> connectivity;
+          for (const auto &patch : patches)
+            {
+              if (patch.reference_cell != ReferenceCells::get_hypercube<dim>())
+                {
+                  connectivity.resize(patch.data.n_cols());
 
-            for (const auto &patch : patches)
-              {
-                if (patch.reference_cell !=
-                    ReferenceCells::get_hypercube<dim>())
-                  {
-                    connectivity.resize(patch.data.n_cols());
+                  for (unsigned int i = 0; i < patch.data.n_cols(); ++i)
+                    connectivity[i] = i;
 
-                    for (unsigned int i = 0; i < patch.data.n_cols(); ++i)
-                      connectivity[i] = i;
+                  if (deal_ii_with_zlib &&
+                      (flags.compression_level !=
+                       DataOutBase::CompressionLevel::plain_text))
+                    {
+                      for (const auto &c : connectivity)
+                        cells.push_back(first_vertex_of_patch + c);
+                    }
+                  else
+                    {
+                      for (const auto &c : connectivity)
+                        o << '\t' << first_vertex_of_patch + c;
+                      o << '\n';
+                    }
 
-                    vtu_out.template write_high_order_cell<dim>(
-                      first_vertex_of_patch, connectivity);
+                  first_vertex_of_patch += patch.data.n_cols();
+                }
+              else
+                {
+                  const unsigned int n_subdivisions = patch.n_subdivisions;
+                  const unsigned int n              = n_subdivisions + 1;
 
-                    first_vertex_of_patch += patch.data.n_cols();
-                  }
-                else
-                  {
-                    const unsigned int n_subdivisions = patch.n_subdivisions;
-                    const unsigned int n              = n_subdivisions + 1;
+                  connectivity.resize(Utilities::fixed_power<dim>(n));
 
-                    connectivity.resize(Utilities::fixed_power<dim>(n));
+                  switch (dim)
+                    {
+                      case 0:
+                        {
+                          Assert(false,
+                                 ExcMessage(
+                                   "Point-like cells should not be possible "
+                                   "when writing higher-order cells."));
+                          break;
+                        }
+                      case 1:
+                        {
+                          for (unsigned int i1 = 0; i1 < n_subdivisions + 1;
+                               ++i1)
+                            {
+                              const unsigned int local_index = i1;
+                              const unsigned int connectivity_index =
+                                patch.reference_cell
+                                  .template vtk_lexicographic_to_node_index<1>(
+                                    {{i1}},
+                                    {{n_subdivisions}},
+                                    /* use VTU, not VTK: */ false);
+                              connectivity[connectivity_index] = local_index;
+                            }
 
-                    switch (dim)
-                      {
-                        case 0:
-                          {
-                            Assert(false,
-                                   ExcMessage(
-                                     "Point-like cells should not be possible "
-                                     "when writing higher-order cells."));
-                            break;
-                          }
-                        case 1:
-                          {
+                          break;
+                        }
+                      case 2:
+                        {
+                          for (unsigned int i2 = 0; i2 < n_subdivisions + 1;
+                               ++i2)
                             for (unsigned int i1 = 0; i1 < n_subdivisions + 1;
                                  ++i1)
                               {
-                                const unsigned int local_index = i1;
+                                const unsigned int local_index = i2 * n + i1;
                                 const unsigned int connectivity_index =
                                   patch.reference_cell
                                     .template vtk_lexicographic_to_node_index<
-                                      1>({{i1}},
-                                         {{n_subdivisions}},
+                                      2>({{i1, i2}},
+                                         {{n_subdivisions, n_subdivisions}},
                                          /* use VTU, not VTK: */ false);
                                 connectivity[connectivity_index] = local_index;
                               }
 
-                            break;
-                          }
-                        case 2:
-                          {
+                          break;
+                        }
+                      case 3:
+                        {
+                          for (unsigned int i3 = 0; i3 < n_subdivisions + 1;
+                               ++i3)
                             for (unsigned int i2 = 0; i2 < n_subdivisions + 1;
                                  ++i2)
                               for (unsigned int i1 = 0; i1 < n_subdivisions + 1;
                                    ++i1)
                                 {
-                                  const unsigned int local_index = i2 * n + i1;
+                                  const unsigned int local_index =
+                                    i3 * n * n + i2 * n + i1;
                                   const unsigned int connectivity_index =
                                     patch.reference_cell
                                       .template vtk_lexicographic_to_node_index<
-                                        2>({{i1, i2}},
-                                           {{n_subdivisions, n_subdivisions}},
+                                        3>({{i1, i2, i3}},
+                                           {{n_subdivisions,
+                                             n_subdivisions,
+                                             n_subdivisions}},
                                            /* use VTU, not VTK: */ false);
                                   connectivity[connectivity_index] =
                                     local_index;
                                 }
 
-                            break;
-                          }
-                        case 3:
-                          {
-                            for (unsigned int i3 = 0; i3 < n_subdivisions + 1;
-                                 ++i3)
-                              for (unsigned int i2 = 0; i2 < n_subdivisions + 1;
-                                   ++i2)
-                                for (unsigned int i1 = 0;
-                                     i1 < n_subdivisions + 1;
-                                     ++i1)
-                                  {
-                                    const unsigned int local_index =
-                                      i3 * n * n + i2 * n + i1;
-                                    const unsigned int connectivity_index =
-                                      patch.reference_cell
-                                        .template vtk_lexicographic_to_node_index<
-                                          3>({{i1, i2, i3}},
-                                             {{n_subdivisions,
-                                               n_subdivisions,
-                                               n_subdivisions}},
-                                             /* use VTU, not VTK: */ false);
-                                    connectivity[connectivity_index] =
-                                      local_index;
-                                  }
+                          break;
+                        }
+                      default:
+                        Assert(false, ExcNotImplemented());
+                    }
 
-                            break;
-                          }
-                        default:
-                          Assert(false, ExcNotImplemented());
-                      }
+                  // Having so set up the 'connectivity' data structure,
+                  // output it:
+                  if (deal_ii_with_zlib &&
+                      (flags.compression_level !=
+                       DataOutBase::CompressionLevel::plain_text))
+                    {
+                      for (const auto &c : connectivity)
+                        cells.push_back(first_vertex_of_patch + c);
+                    }
+                  else
+                    {
+                      for (const auto &c : connectivity)
+                        o << '\t' << first_vertex_of_patch + c;
+                      o << '\n';
+                    }
 
-                    // Having so set up the 'connectivity' data structure,
-                    // output it:
-                    vtu_out.template write_high_order_cell<dim>(
-                      first_vertex_of_patch, connectivity);
-
-                    // Finally update the number of the first vertex of this
-                    // patch
-                    first_vertex_of_patch += Utilities::fixed_power<dim>(n);
-                  }
-              }
-
-            vtu_out.flush_cells();
-          }
-          o << oo.str() << '\n';
+                  // Finally update the number of the first vertex of this
+                  // patch
+                  first_vertex_of_patch += Utilities::fixed_power<dim>(n);
+                }
+            }
         }
       else
         {
           Assert(dim <= 3, ExcNotImplemented());
 
-          std::vector<int32_t> cells;
-          unsigned int         first_vertex_of_patch = 0;
+          unsigned int first_vertex_of_patch = 0;
 
           for (const auto &patch : patches)
             {
@@ -6277,16 +6289,16 @@ namespace DataOutBase
                     Utilities::fixed_power<dim>(n_subdivisions + 1);
                 }
             }
+        }
 
-          // Flush the 'cells' object we created herein.
-          if (deal_ii_with_zlib && (flags.compression_level !=
-                                    DataOutBase::CompressionLevel::plain_text))
-            {
-              o << vtu_stringize_array(cells,
-                                       flags.compression_level,
-                                       output_precision)
-                << '\n';
-            }
+      // Flush the 'cells' object we created herein.
+      if (deal_ii_with_zlib && (flags.compression_level !=
+                                DataOutBase::CompressionLevel::plain_text))
+        {
+          o << vtu_stringize_array(cells,
+                                   flags.compression_level,
+                                   output_precision)
+            << '\n';
         }
       o << "    </DataArray>\n";
 

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -1314,40 +1314,6 @@ namespace
   };
 
 
-  class VtuStream : public StreamBase<DataOutBase::VtkFlags>
-  {
-  public:
-    VtuStream(std::ostream &stream, const DataOutBase::VtkFlags &flags);
-
-    /**
-     * Write a high-order cell type, i.e., a Lagrange cell
-     * in the VTK terminology.
-     * The connectivity order of the points is given in the
-     * @p connectivity array, which are offset
-     * by the global index @p start.
-     */
-    template <int dim>
-    void
-    write_high_order_cell(const unsigned int           start,
-                          const std::vector<unsigned> &connectivity);
-
-    void
-    flush_cells();
-
-  private:
-    /**
-     * A list of vertices and cells, to be used in case we want to compress the
-     * data.
-     *
-     * The data types of these arrays needs to match what we print in the
-     * XML-preamble to the respective parts of VTU files (e.g. Float32 and
-     * Int32)
-     */
-    std::vector<float>   vertices;
-    std::vector<int32_t> cells;
-  };
-
-
   //----------------------------------------------------------------------//
 
   DXStream::DXStream(std::ostream &out, const DataOutBase::DXFlags &f)
@@ -1795,48 +1761,6 @@ namespace
     for (const auto &c : connectivity)
       stream << '\t' << start + c;
     stream << '\n';
-  }
-
-
-
-  VtuStream::VtuStream(std::ostream &out, const DataOutBase::VtkFlags &f)
-    : StreamBase<DataOutBase::VtkFlags>(out, f)
-  {}
-
-
-
-  template <int dim>
-  void
-  VtuStream::write_high_order_cell(const unsigned int           start,
-                                   const std::vector<unsigned> &connectivity)
-  {
-    if (deal_ii_with_zlib &&
-        (flags.compression_level != DataOutBase::CompressionLevel::plain_text))
-      {
-        for (const auto &c : connectivity)
-          cells.push_back(start + c);
-      }
-    else
-      {
-        for (const auto &c : connectivity)
-          stream << '\t' << start + c;
-        stream << '\n';
-      }
-  }
-
-  void
-  VtuStream::flush_cells()
-  {
-    if (deal_ii_with_zlib &&
-        (flags.compression_level != DataOutBase::CompressionLevel::plain_text))
-      {
-        // compress the data we have in memory and write them to the stream.
-        // then release the data
-        *this << vtu_stringize_array(cells,
-                                     flags.compression_level,
-                                     stream.precision());
-        cells.clear();
-      }
   }
 } // namespace
 

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -5865,14 +5865,13 @@ namespace DataOutBase
         {
           Assert(dim <= 3 && dim > 1, ExcNotImplemented());
           unsigned int first_vertex_of_patch = 0;
-          // Array to hold all the node numbers of a cell
-          std::vector<unsigned> connectivity;
 
           for (const auto &patch : patches)
             {
               if (patch.reference_cell != ReferenceCells::get_hypercube<dim>())
                 {
-                  connectivity.resize(patch.data.n_cols());
+                  // Array to hold all the node numbers of a cell
+                  std::vector<unsigned> connectivity(patch.data.n_cols());
 
                   for (unsigned int i = 0; i < patch.data.n_cols(); ++i)
                     connectivity[i] = i;
@@ -5898,7 +5897,9 @@ namespace DataOutBase
                   const unsigned int n_subdivisions = patch.n_subdivisions;
                   const unsigned int n              = n_subdivisions + 1;
 
-                  connectivity.resize(Utilities::fixed_power<dim>(n));
+                  // Array to hold all the node numbers of a cell
+                  std::vector<unsigned> connectivity(
+                    Utilities::fixed_power<dim>(n));
 
                   switch (dim)
                     {
@@ -5997,7 +5998,7 @@ namespace DataOutBase
                 }
             }
         }
-      else
+      else // do not as higher-order cells
         {
           Assert(dim <= 3, ExcNotImplemented());
 


### PR DESCRIPTION
This closes #14403 and finishes the whole process. It moves a lot of code around, so I broke it into commits that may individually be easier to review, oftentimes with whitespace changes hidden if code is moved one scope up or down. There are a lot of clean-ups as well and in a number of cases, I've tried to merge code that was previously in separate functions: For example, outputting cells involved loops that were duplicated across the "normal cell" and "higher order cell" cases, and the controlling `if` is now moved into the body of the loop, avoiding the loop duplication.

This patch also includes a changelog entry for the entire series of patches, as well as the comment issue mentioned by @tjhei in a commit from a couple of days ago.

/rebuild