### PR TITLE
CMake: Silence bogus Boost warning

### DIFF
--- a/cmake/modules/FindDEAL_II_BOOST.cmake
+++ b/cmake/modules/FindDEAL_II_BOOST.cmake
@@ -53,6 +53,7 @@ endif()
 # and https://lists.boost.org/Archives/boost/2019/02/245016.php
 set(Boost_NO_BOOST_CMAKE ON)
 
+set(Boost_NO_WARN_NEW_VERSIONS TRUE)
 if(DEAL_II_WITH_ZLIB)
   find_package(Boost ${BOOST_VERSION_REQUIRED} COMPONENTS
     iostreams serialization system thread


### PR DESCRIPTION
Silence the following noisy warning:
```
CMake Warning at /usr/share/cmake/Modules/FindBoost.cmake:1384 (message):
  New Boost version may have incorrect or missing dependencies and imported
  targets
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindBoost.cmake:1507 (_Boost_COMPONENT_DEPENDENCIES)
  /usr/share/cmake/Modules/FindBoost.cmake:2118 (_Boost_MISSING_DEPENDENCIES)
  cmake/modules/FindDEAL_II_BOOST.cmake:57 (find_package)
  cmake/configure/configure_20_boost.cmake:36 (find_package)
  /scratch/users/testsuite/build-3O4p1Svw/CMakeFiles/CMakeTmp/evaluate_expression.tmp:1 (feature_BOOST_find_external)
  cmake/macros/macro_evaluate_expression.cmake:30 (include)
  cmake/macros/macro_configure_feature.cmake:239 (evaluate_expression)
  cmake/configure/configure_20_boost.cmake:170 (configure_feature)
  cmake/macros/macro_verbose_include.cmake:19 (include)
  CMakeLists.txt:130 (verbose_include)
```