### PR TITLE
Drop the requirement for Trilinos+Kokkos from 13.2 to 12.14.1

### DIFF
--- a/cmake/configure/configure_20_trilinos.cmake
+++ b/cmake/configure/configure_20_trilinos.cmake
@@ -198,18 +198,18 @@ macro(feature_trilinos_find_external var)
       endif()
 
       #
-      # We require at least Trilinos 13.2
+      # We require at least Trilinos 12.14.1
       #
-      if(TRILINOS_VERSION VERSION_LESS 13.2)
+      if(TRILINOS_VERSION VERSION_LESS 12.14.1)
         message(STATUS "Could not find a sufficient Trilinos installation: "
-          "deal.II requires at least version 13.2 if the Trilinos installation includes Kokkos, "
+          "deal.II requires at least version 12.14.1 if the Trilinos installation includes Kokkos, "
           "but version ${TRILINOS_VERSION} was found."
           )
         set(TRILINOS_ADDITIONAL_ERROR_STRING
           ${TRILINOS_ADDITIONAL_ERROR_STRING}
           "The Trilinos installation (found at \"${TRILINOS_DIR}\")\n"
           "with version ${TRILINOS_VERSION} is too old.\n"
-          "deal.II requires at least version 13.2 if the Trilinos installation includes Kokkos.\n\n"
+          "deal.II requires at least version 12.14.1 if the Trilinos installation includes Kokkos.\n\n"
           )
         set(${var} FALSE)
       endif()

--- a/doc/external-libs/trilinos.html
+++ b/doc/external-libs/trilinos.html
@@ -50,7 +50,7 @@
 
     <p style="color: red">
       Note: The current version of deal.II requires at least Trilinos 12.4
-      (13.2 if Trilinos includes Kokkos).
+      (12.14.1 if Trilinos includes Kokkos).
       Deal.II is known to work with Trilinos up to 13.4. Other versions of
       Trilinos should work too but have not been tested prior to the
       release.

--- a/doc/news/changes/20221230DanielArndt
+++ b/doc/news/changes/20221230DanielArndt
@@ -1,4 +1,4 @@
-Updated: The minimum version for Trilinos has been bumped to 13.2 if Trilinos
+Updated: The minimum version for Trilinos has been bumped to 12.14.1 if Trilinos
 bundles Kokkkos.
 <br>
 (Daniel Arndt, 2022/12/30)


### PR DESCRIPTION
Fixes #14637. There seem to be too many issues requiring something newer for now but we might revisit shortly before the release.