### PR TITLE
Fix issue when adol-c is enabled

### DIFF
--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -2530,7 +2530,7 @@ namespace internal
             exec, 0, size),
           KOKKOS_LAMBDA(size_type i, Number & update) {
 #if KOKKOS_VERSION < 30400
-            update += abs(data.values(i));
+            update += std::abs(data.values(i));
 #elif KOKKOS_VERSION < 30700
             update += Kokkos::Experimental::fabs(data.values(i));
 #else
@@ -2560,7 +2560,7 @@ namespace internal
             exec, 0, size),
           KOKKOS_LAMBDA(size_type i, Number & update) {
 #if KOKKOS_VERSION < 30400
-            update += pow(fabs(data.values(i)), exp);
+            update += std::pow(fabs(data.values(i)), exp);
 #elif KOKKOS_VERSION < 30700
             update += Kokkos::Experimental::pow(
               Kokkos::Experimental::fabs(data.values(i)), exp);

--- a/source/lac/cuda_sparse_matrix.cc
+++ b/source/lac/cuda_sparse_matrix.cc
@@ -255,7 +255,7 @@ namespace CUDAWrappers
       if (row < n_rows)
         {
           for (int j = row_ptr_dev[row]; j < row_ptr_dev[row + 1]; ++j)
-            atomicAdd(&sums[column_index_dev[j]], abs(val_dev[j]));
+            atomicAdd(&sums[column_index_dev[j]], std::abs(val_dev[j]));
         }
     }
 
@@ -276,7 +276,7 @@ namespace CUDAWrappers
         {
           sums[row] = (Number)0.;
           for (int j = row_ptr_dev[row]; j < row_ptr_dev[row + 1]; ++j)
-            sums[row] += abs(val_dev[j]);
+            sums[row] += std::abs(val_dev[j]);
         }
     }
   } // namespace internal


### PR DESCRIPTION
The problem is adol-c defines its own intrinsics in the global namespace. I fixed the problem by adding `std::` when using older versions of Kokkos. The downside is that we lose support for some architectures/compilers but that can be fixed by updating the Kokkos version used.

Fixes #14642