### PR TITLE
Use std::array instead of a C-style array.

### DIFF
--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -282,7 +282,7 @@ namespace DataOutBase
      * The order of points is the same as for cells in the
      * triangulation.
      */
-    Point<spacedim> vertices[GeometryInfo<dim>::vertices_per_cell];
+    std::array<Point<spacedim>, GeometryInfo<dim>::vertices_per_cell> vertices;
 
     /**
      * Patch indices of neighbors of the current patch. This is made available


### PR DESCRIPTION
This is already done for the following variable.

/rebuild