### PR TITLE
Test output of a simplex cell with n_subdivisions=2.

### DIFF
--- a/tests/data_out/write_subdivided_simplex_vtu.cc
+++ b/tests/data_out/write_subdivided_simplex_vtu.cc
@@ -1,0 +1,91 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 - 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Test DataOut::write_vtu() for a single simplex subdivided more than once.
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_simplex_p.h>
+#include <deal.II/fe/mapping_fe.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/numerics/data_out.h>
+#include <deal.II/numerics/vector_tools.h>
+
+#include "../tests.h"
+
+using namespace dealii;
+
+template <int dim>
+class RightHandSideFunction : public Function<dim>
+{
+public:
+  virtual double
+  value(const Point<dim> &p, const unsigned int component = 0) const
+  {
+    return p * p;
+  }
+};
+
+
+template <int dim, int spacedim = dim>
+void
+test()
+{
+  Triangulation<dim, spacedim> tria;
+  GridGenerator::reference_cell(tria, ReferenceCells::get_simplex<dim>());
+
+  // Use a quadratic element; this can correctly represent the
+  // quadratic function we are interpolating
+  FE_SimplexP<dim> fe(2);
+  DoFHandler<dim>  dof_handler(tria);
+
+  dof_handler.distribute_dofs(fe);
+
+  Vector<double> solution(dof_handler.n_dofs());
+
+  MappingFE<dim> mapping(FE_SimplexP<dim>(1));
+
+  VectorTools::interpolate(mapping,
+                           dof_handler,
+                           RightHandSideFunction<dim>(),
+                           solution);
+
+  // Switch off compression to make the resulting file easier to read
+  // as a human
+  DataOutBase::VtkFlags flags;
+  flags.compression_level = DataOutBase::CompressionLevel::plain_text;
+
+  DataOut<dim> data_out;
+  data_out.attach_dof_handler(dof_handler);
+  data_out.add_data_vector(solution, "solution");
+  data_out.build_patches(mapping, 2);
+
+  data_out.set_flags(flags);
+  data_out.write_vtu(deallog.get_file_stream());
+}
+
+int
+main()
+{
+  initlog();
+
+  test<2>();
+  test<3>();
+}

--- a/tests/data_out/write_subdivided_simplex_vtu.output
+++ b/tests/data_out/write_subdivided_simplex_vtu.output
@@ -1,0 +1,67 @@
+
+<?xml version="1.0" ?> 
+<!-- 
+# vtk DataFile Version 3.0
+#This file was generated 
+-->
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+<UnstructuredGrid>
+<Piece NumberOfPoints="6" NumberOfCells="1" >
+  <Points>
+    <DataArray type="Float32" NumberOfComponents="3" format="ascii">
+0 0 0 1 0 0 0 1 0 0.5 0 0 0.5 0.5 0 0 0.5 0 
+    </DataArray>
+  </Points>
+
+  <Cells>
+    <DataArray type="Int32" Name="connectivity" format="ascii">
+	0	1	2	3	4	5
+    </DataArray>
+    <DataArray type="Int32" Name="offsets" format="ascii">
+6 
+    </DataArray>
+    <DataArray type="UInt8" Name="types" format="ascii">
+22 
+    </DataArray>
+  </Cells>
+  <PointData Scalars="scalars">
+    <DataArray type="Float32" Name="solution" format="ascii">
+0 1 1 0.25 0.5 0.25 
+    </DataArray>
+  </PointData>
+ </Piece>
+ </UnstructuredGrid>
+</VTKFile>
+<?xml version="1.0" ?> 
+<!-- 
+# vtk DataFile Version 3.0
+#This file was generated 
+-->
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+<UnstructuredGrid>
+<Piece NumberOfPoints="10" NumberOfCells="1" >
+  <Points>
+    <DataArray type="Float32" NumberOfComponents="3" format="ascii">
+0 0 0 1 0 0 0 1 0 0 0 1 0.5 0 0 0.5 0.5 0 0 0.5 0 0 0 0.5 0.5 0 0.5 0 0.5 0.5 
+    </DataArray>
+  </Points>
+
+  <Cells>
+    <DataArray type="Int32" Name="connectivity" format="ascii">
+	0	1	2	3	4	5	6	7	8	9
+    </DataArray>
+    <DataArray type="Int32" Name="offsets" format="ascii">
+10 
+    </DataArray>
+    <DataArray type="UInt8" Name="types" format="ascii">
+24 
+    </DataArray>
+  </Cells>
+  <PointData Scalars="scalars">
+    <DataArray type="Float32" Name="solution" format="ascii">
+0 1 1 1 0.25 0.5 0.25 0.25 0.5 0.5 
+    </DataArray>
+  </PointData>
+ </Piece>
+ </UnstructuredGrid>
+</VTKFile>


### PR DESCRIPTION
This is a simplified version of the test `simplex/data_out_write_vtu_01` and checks what happens if one calls `data_out.build_patches(2)` on a simplex cell and then outputs with VTU format. This happens to work right now, but strictly speaking the output is not actually what we want. That's because for hypercubes, if `n_subdivisions>1`, we actually subdivide the cell into smaller ones and so the number of cells output that will actually be visualized is a multiple of the number of cells in the mesh on which we did computations. In contrast, for simplices, if `n_subdivisions==2`, we output things as if it was a single higher-order (here, quadratic) cell courtesy of the following piece of code:
```
  template <int dim, int spacedim>
  std::array<unsigned int, 3>
  extract_vtk_patch_info(const DataOutBase::Patch<dim, spacedim> &patch,
                         const bool write_higher_order_cells)
  {
    std::array<unsigned int, 3> vtk_cell_id = {
      {/* cell type, tbd: */ numbers::invalid_unsigned_int,
       /* # of cells, default: just one cell */ 1,
       /* # of nodes, default: as many nodes as vertices */
       patch.reference_cell.n_vertices()}};

    if (write_higher_order_cells)
      {
        vtk_cell_id[0] = patch.reference_cell.vtk_lagrange_type();
        vtk_cell_id[2] = patch.data.n_cols();
      }
    else if (patch.data.n_cols() == patch.reference_cell.n_vertices())
      // One data set per vertex -> a linear cell
      vtk_cell_id[0] = patch.reference_cell.vtk_linear_type();
    else if (patch.reference_cell == ReferenceCells::Triangle &&           // <----- from here
             patch.data.n_cols() == 6)
      {
        vtk_cell_id[0] = patch.reference_cell.vtk_quadratic_type();
        vtk_cell_id[2] = patch.data.n_cols();
      }
    else if (patch.reference_cell == ReferenceCells::Tetrahedron &&
             patch.data.n_cols() == 10)
      {
        vtk_cell_id[0] = patch.reference_cell.vtk_quadratic_type();
        vtk_cell_id[2] = patch.data.n_cols();                                              // <------ to here
      }
    else if (patch.reference_cell.is_hyper_cube())
      {
        // For hypercubes, we support sub-divided linear cells
        vtk_cell_id[0] = patch.reference_cell.vtk_linear_type();
        vtk_cell_id[1] = Utilities::pow(patch.n_subdivisions, dim);
      }
    else
      {
        Assert(false, ExcNotImplemented());
      }

    return vtk_cell_id;
  }
```
The case `n_subdivisions>2` is not supported for simplices right now.

So while I think that the result isn't quite what one would expect, it's also not entirely wrong and it makes sense to add a test specifically for this case.

(Compared to the test where it is simplified from, this test does not use system elements and, most importantly, outputs things in clear text rather than compressed VTU form -- the latter is just not readable when debugging.)

/rebuild