### PR TITLE
Avoid a deprecated function in the last context where it is used.

### DIFF
--- a/include/deal.II/grid/connectivity.h
+++ b/include/deal.II/grid/connectivity.h
@@ -1140,9 +1140,8 @@ namespace internal
       std::array<unsigned int, key_length> ref_indices;
       std::fill(ref_key.begin(), ref_key.end(), 0);
 
-      for (unsigned int i = 0, counter = dealii::numbers::invalid_unsigned_int;
-           i < keys.size();
-           i++)
+      unsigned int counter = dealii::numbers::invalid_unsigned_int;
+      for (unsigned int i = 0; i < keys.size(); i++)
         {
           const auto offset_i = std::get<1>(keys[i]);
 
@@ -1164,8 +1163,14 @@ namespace internal
               // occurrence
               orientations.set_raw_orientation(
                 offset_i,
-                ad_entity_types[offset_i].compute_orientation(
-                  ad_entity_vertices[offset_i], ref_indices));
+                ad_entity_types[offset_i]
+                  .template get_orientation_index<unsigned int>(
+                    make_array_view(ad_entity_vertices[offset_i].begin(),
+                                    ad_entity_vertices[offset_i].begin() +
+                                      ad_entity_types[offset_i].n_vertices()),
+                    make_array_view(ref_indices.begin(),
+                                    ref_indices.begin() +
+                                      ad_entity_types[offset_i].n_vertices())));
             }
           col_d[offset_i] = counter;
         }

--- a/include/deal.II/grid/connectivity.h
+++ b/include/deal.II/grid/connectivity.h
@@ -997,7 +997,7 @@ namespace internal
      */
     template <int max_n_vertices, typename FU>
     void
-    build_entity_templated(
+    build_face_entities_templated(
       const unsigned int                                face_dimensionality,
       const std::vector<std::shared_ptr<CellTypeBase>> &cell_types,
       const std::vector<dealii::ReferenceCell> &        cell_types_index,
@@ -1188,14 +1188,15 @@ namespace internal
      */
     template <typename FU>
     void
-    build_entity(const unsigned int face_dimensionality,
-                 const std::vector<std::shared_ptr<CellTypeBase>> &cell_types,
-                 const std::vector<dealii::ReferenceCell> &cell_types_index,
-                 const CRS<unsigned int> &                 crs,
-                 CRS<unsigned int> &                       crs_d,
-                 CRS<unsigned int> &                       crs_0,
-                 TriaObjectsOrientations &                 orientations,
-                 const FU &                                second_key_function)
+    build_face_entities(
+      const unsigned int                                face_dimensionality,
+      const std::vector<std::shared_ptr<CellTypeBase>> &cell_types,
+      const std::vector<dealii::ReferenceCell> &        cell_types_index,
+      const CRS<unsigned int> &                         crs,
+      CRS<unsigned int> &                               crs_d,
+      CRS<unsigned int> &                               crs_0,
+      TriaObjectsOrientations &                         orientations,
+      const FU &                                        second_key_function)
     {
       std::size_t max_n_vertices = 0;
 
@@ -1212,32 +1213,32 @@ namespace internal
         }
 
       if (max_n_vertices == 2)
-        build_entity_templated<2>(face_dimensionality,
-                                  cell_types,
-                                  cell_types_index,
-                                  crs,
-                                  crs_d,
-                                  crs_0,
-                                  orientations,
-                                  second_key_function);
+        build_face_entities_templated<2>(face_dimensionality,
+                                         cell_types,
+                                         cell_types_index,
+                                         crs,
+                                         crs_d,
+                                         crs_0,
+                                         orientations,
+                                         second_key_function);
       else if (max_n_vertices == 3)
-        build_entity_templated<3>(face_dimensionality,
-                                  cell_types,
-                                  cell_types_index,
-                                  crs,
-                                  crs_d,
-                                  crs_0,
-                                  orientations,
-                                  second_key_function);
+        build_face_entities_templated<3>(face_dimensionality,
+                                         cell_types,
+                                         cell_types_index,
+                                         crs,
+                                         crs_d,
+                                         crs_0,
+                                         orientations,
+                                         second_key_function);
       else if (max_n_vertices == 4)
-        build_entity_templated<4>(face_dimensionality,
-                                  cell_types,
-                                  cell_types_index,
-                                  crs,
-                                  crs_d,
-                                  crs_0,
-                                  orientations,
-                                  second_key_function);
+        build_face_entities_templated<4>(face_dimensionality,
+                                         cell_types,
+                                         cell_types_index,
+                                         crs,
+                                         crs_d,
+                                         crs_0,
+                                         orientations,
+                                         second_key_function);
       else
         AssertThrow(false, dealii::StandardExceptions::ExcNotImplemented());
     }
@@ -1382,22 +1383,23 @@ namespace internal
         {
           TriaObjectsOrientations dummy;
 
-          build_entity(1,
-                       cell_t,
-                       connectivity.entity_types(dim),
-                       con_cv,
-                       dim == 2 ? connectivity.entity_to_entities(2, 1) : temp1,
-                       connectivity.entity_to_entities(1, 0),
-                       dim == 2 ? connectivity.entity_orientations(1) : dummy,
-                       [](auto key, const auto &, const auto &, const auto &) {
-                         //  to ensure same enumeration as in deal.II
-                         return key;
-                       });
+          build_face_entities(
+            1,
+            cell_t,
+            connectivity.entity_types(dim),
+            con_cv,
+            dim == 2 ? connectivity.entity_to_entities(2, 1) : temp1,
+            connectivity.entity_to_entities(1, 0),
+            dim == 2 ? connectivity.entity_orientations(1) : dummy,
+            [](auto key, const auto &, const auto &, const auto &) {
+              //  to ensure same enumeration as in deal.II
+              return key;
+            });
         }
 
       if (dim == 3) // build quads
         {
-          build_entity(
+          build_face_entities(
             2,
             cell_t,
             connectivity.entity_types(3),


### PR DESCRIPTION
While there, also clean up a number of things.

This is a follow-up to #14664.

/rebuild