### PR TITLE
Configure: support KOKKOS when found with PETSc

### DIFF
--- a/cmake/configure/configure_20_petsc.cmake
+++ b/cmake/configure/configure_20_petsc.cmake
@@ -112,6 +112,17 @@ macro(feature_petsc_find_external var)
       set(${var} FALSE)
     endif()
 
+    if(DEAL_II_PETSC_WITH_KOKKOS)
+      if(DEAL_II_FORCE_BUNDLED_KOKKOS)
+        set(PETSC_ADDITIONAL_ERROR_STRING
+          ${PETSC_ADDITIONAL_ERROR_STRING}
+          "The PETSc installation (found at \"${PETSC_DIR}\")"
+          "includes Kokkos, but DEAL_II_FORCE_BUNDLED_KOKKOS=ON!\n")
+        set(${var} FALSE)
+      endif()
+    endif()
+
+
     check_mpi_interface(PETSC ${var})
   endif()
 endmacro()
@@ -160,3 +171,4 @@ configure_feature(PETSC)
 set(DEAL_II_PETSC_WITH_COMPLEX ${PETSC_WITH_COMPLEX})
 set(DEAL_II_PETSC_WITH_HYPRE ${PETSC_WITH_HYPRE})
 set(DEAL_II_PETSC_WITH_MUMPS ${PETSC_WITH_MUMPS})
+set(DEAL_II_PETSC_WITH_KOKKOS ${PETSC_WITH_KOKKOS})

--- a/cmake/modules/FindDEAL_II_KOKKOS.cmake
+++ b/cmake/modules/FindDEAL_II_KOKKOS.cmake
@@ -26,7 +26,7 @@ set(KOKKOS_DIR "" CACHE PATH "An optional hint to a Kokkos installation")
 set_if_empty(KOKKOS_DIR "$ENV{KOKKOS_DIR}")
 
 
-if(DEAL_II_TRILINOS_WITH_KOKKOS)
+if(DEAL_II_TRILINOS_WITH_KOKKOS OR DEAL_II_PETSC_WITH_KOKKOS)
   # Let ArborX know that we have found Kokkos
   set(Kokkos_FOUND ON)
   # Let deal.II know that we have found Kokkos

--- a/cmake/modules/FindDEAL_II_PETSC.cmake
+++ b/cmake/modules/FindDEAL_II_PETSC.cmake
@@ -29,6 +29,7 @@
 #     PETSC_WITH_64BIT_INDICES
 #     PETSC_WITH_COMPLEX
 #     PETSC_WITH_HYPRE
+#     PETSC_WITH_KOKKOS
 #     PETSC_WITH_MPIUNI
 #     PETSC_WITH_MUMPS
 #
@@ -69,6 +70,7 @@ if(EXISTS ${PETSC_PETSCCONF_H})
   _petsc_feature_check(64BIT_INDICES "#define.*PETSC_USE_64BIT_INDICES 1")
   _petsc_feature_check(COMPLEX "#define.*PETSC_USE_COMPLEX 1")
   _petsc_feature_check(HYPRE "#define.*PETSC_HAVE_HYPRE 1")
+  _petsc_feature_check(KOKKOS "#define.*PETSC_HAVE_KOKKOS 1")
   _petsc_feature_check(MPIUNI "#define.*PETSC_HAVE_MPIUNI 1")
   _petsc_feature_check(MUMPS "#define.*PETSC_HAVE_MUMPS 1")
 endif()

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -224,6 +224,7 @@
 #cmakedefine DEAL_II_PETSC_WITH_COMPLEX
 #cmakedefine DEAL_II_PETSC_WITH_HYPRE
 #cmakedefine DEAL_II_PETSC_WITH_MUMPS
+#cmakedefine DEAL_II_PETSC_WITH_KOKKOS
 
 /* cmake/modules/FindSUNDIALS.cmake */
 #cmakedefine DEAL_II_SUNDIALS_WITH_IDAS


### PR DESCRIPTION
This still require grabbing the compile flags and some special CUDA handling?

I'm not a CMAKE expert. I profoundly hate it. So if any CMAKE expert wants to pitch in and provide comments/suggestions/improvements, please go ahead @luca-heltai @bangerth 