### PR TITLE
Replace ucd to deal with local vertex numbering

### DIFF
--- a/source/grid/grid_reordering.cc
+++ b/source/grid/grid_reordering.cc
@@ -40,6 +40,9 @@ namespace
    * do the reordering of their
    * arguments in-place.
    */
+  constexpr std::array<unsigned int, 8> local_vertex_numbering{
+    {0, 1, 5, 4, 2, 3, 7, 6}};
+
   void
   reorder_new_to_old_style(std::vector<CellData<1>> &)
   {}
@@ -62,7 +65,7 @@ namespace
         for (const unsigned int i : GeometryInfo<3>::vertex_indices())
           tmp[i] = cell.vertices[i];
         for (const unsigned int i : GeometryInfo<3>::vertex_indices())
-          cell.vertices[i] = tmp[GeometryInfo<3>::ucd_to_deal[i]];
+          cell.vertices[i] = tmp[local_vertex_numbering[i]];
       }
   }
 
@@ -93,7 +96,7 @@ namespace
         for (const unsigned int i : GeometryInfo<3>::vertex_indices())
           tmp[i] = cell.vertices[i];
         for (const unsigned int i : GeometryInfo<3>::vertex_indices())
-          cell.vertices[GeometryInfo<3>::ucd_to_deal[i]] = tmp[i];
+          cell.vertices[local_vertex_numbering[i]] = tmp[i];
       }
   }
 } // namespace

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -447,13 +447,16 @@ namespace
                         SubCellData &             subcelldata)
   {
     unsigned int tmp[GeometryInfo<3>::vertices_per_cell];
+    static constexpr std::array<unsigned int,
+                                GeometryInfo<3>::vertices_per_cell>
+      local_vertex_numbering{{0, 1, 5, 4, 2, 3, 7, 6}};
     for (auto &cell : cells)
       if (cell.vertices.size() == GeometryInfo<3>::vertices_per_cell)
         {
           for (const unsigned int i : GeometryInfo<3>::vertex_indices())
             tmp[i] = cell.vertices[i];
           for (const unsigned int i : GeometryInfo<3>::vertex_indices())
-            cell.vertices[GeometryInfo<3>::ucd_to_deal[i]] = tmp[i];
+            cell.vertices[local_vertex_numbering[i]] = tmp[i];
         }
 
     // now points in boundary quads


### PR DESCRIPTION
In reference to https://github.com/dealii/dealii/issues/14608#issuecomment-1379401141 this replaces the ucd_to_deal array with a local version of it for all occurences in grid_reordering.cc and tria.cc.