### PR TITLE
PETScWrappers: improve preconditioner class

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -852,6 +852,14 @@ namespace StandardExceptions
     "implement the missing override in your class.");
 
   /**
+   * This exception is used if some user function is not provided.
+   */
+  DeclException1(ExcFunctionNotProvided,
+                 std::string,
+                 << "Please provide an implementation for the function \""
+                 << arg1 << "\"");
+
+  /**
    * This exception is used if some object is found uninitialized.
    */
   DeclException0(ExcNotInitialized);

--- a/include/deal.II/lac/petsc_precondition.h
+++ b/include/deal.II/lac/petsc_precondition.h
@@ -1099,18 +1099,15 @@ namespace PETScWrappers
      */
     PreconditionShell(const MPI_Comm &communicator);
 
-
     /**
-     * The callback for the application of the preconditioner. Defaults to
-     * a copy operation if not provided.
+     * The callback for the application of the preconditioner.
      */
-    std::function<int(VectorBase &dst, const VectorBase &src)> apply;
+    std::function<int(VectorBase &dst, const VectorBase &src)> vmult;
 
     /**
      * The callback for the application of the transposed preconditioner.
-     * Defaults to the non-transpose operation if not provided.
      */
-    std::function<int(VectorBase &dst, const VectorBase &src)> applyT;
+    std::function<int(VectorBase &dst, const VectorBase &src)> vmultT;
 
   protected:
     /**

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -280,13 +280,6 @@ namespace PETScWrappers
     explicit VectorBase(const Vec &v);
 
     /**
-     * The copy assignment operator is deleted to avoid accidental usage with
-     * unexpected behavior.
-     */
-    VectorBase &
-    operator=(const VectorBase &) = delete;
-
-    /**
      * Destructor.
      */
     virtual ~VectorBase() override;
@@ -310,6 +303,12 @@ namespace PETScWrappers
      */
     void
     compress(const VectorOperation::values operation);
+
+    /**
+     * The copy assignment operator.
+     */
+    VectorBase &
+    operator=(const VectorBase &);
 
     /**
      * Set all components of the vector to the given number @p s. Simply pass

--- a/source/lac/petsc_precondition.cc
+++ b/source/lac/petsc_precondition.cc
@@ -816,7 +816,7 @@ namespace PETScWrappers
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
 #  else // DEAL_II_PETSC_WITH_HYPRE
-    (void)pc;
+    (void)matrix_;
     Assert(false,
            ExcMessage("Your PETSc installation does not include a copy of "
                       "the hypre package necessary for this preconditioner."));

--- a/source/lac/petsc_precondition.cc
+++ b/source/lac/petsc_precondition.cc
@@ -68,7 +68,7 @@ namespace PETScWrappers
   {
     AssertThrow(pc != nullptr, StandardExceptions::ExcInvalidState());
 
-    const PetscErrorCode ierr = PCApply(pc, src, dst);
+    PetscErrorCode ierr = PCApply(pc, src, dst);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 
@@ -77,7 +77,7 @@ namespace PETScWrappers
   {
     AssertThrow(pc != nullptr, StandardExceptions::ExcInvalidState());
 
-    const PetscErrorCode ierr = PCApplyTranspose(pc, src, dst);
+    PetscErrorCode ierr = PCApplyTranspose(pc, src, dst);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 
@@ -1115,13 +1115,14 @@ namespace PETScWrappers
     PetscErrorCode ierr = PCShellGetContext(ppc, &ctx);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
+    auto user = static_cast<PreconditionShell *>(ctx);
+    AssertThrow(user->vmult,
+                StandardExceptions::ExcFunctionNotProvided(
+                  "std::function vmult"));
+
     VectorBase src(x);
     VectorBase dst(y);
-    auto       user = static_cast<PreconditionShell *>(ctx);
-    if (user->apply)
-      user->apply(dst, src);
-    else
-      dst.sadd(0, src);
+    user->vmult(dst, src);
     PetscFunctionReturn(0);
   }
 
@@ -1134,15 +1135,14 @@ namespace PETScWrappers
     PetscErrorCode ierr = PCShellGetContext(ppc, &ctx);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
-    auto       user = static_cast<PreconditionShell *>(ctx);
+    auto user = static_cast<PreconditionShell *>(ctx);
+    AssertThrow(user->vmultT,
+                StandardExceptions::ExcFunctionNotProvided(
+                  "std::function vmultT"));
+
     VectorBase src(x);
     VectorBase dst(y);
-    if (user->applyT)
-      user->applyT(dst, src);
-    else if (user->apply)
-      user->apply(dst, src);
-    else
-      dst.sadd(0, src);
+    user->vmult(dst, src);
     PetscFunctionReturn(0);
   }
 

--- a/source/lac/petsc_solver.cc
+++ b/source/lac/petsc_solver.cc
@@ -779,7 +779,7 @@ namespace PETScWrappers
         ierr = KSPSetConvergenceTest(solver_data->ksp,
                                      &convergence_test,
                                      reinterpret_cast<void *>(&solver_control),
-                                     PETSC_NULL);
+                                     nullptr);
         AssertThrow(ierr == 0, ExcPETScError(ierr));
 
         /*

--- a/source/lac/petsc_solver.cc
+++ b/source/lac/petsc_solver.cc
@@ -86,15 +86,12 @@ namespace PETScWrappers
         ierr = KSPSetPC(solver_data->ksp, preconditioner.get_pc());
         AssertThrow(ierr == 0, ExcPETScError(ierr));
 
-        // make sure the preconditioner has an associated matrix set
-        const Mat B = preconditioner;
-        AssertThrow(B != nullptr,
-                    ExcMessage("PETSc preconditioner should have an "
-                               "associated matrix set to be used in solver."));
-
         // setting the preconditioner overwrites the used matrices.
         // hence, we need to set the matrices after the preconditioner.
-        ierr = KSPSetOperators(solver_data->ksp, A, preconditioner);
+        Mat B;
+        ierr = PCGetOperators(preconditioner.get_pc(), nullptr, &B);
+        AssertThrow(ierr == 0, ExcPETScError(ierr));
+        ierr = KSPSetOperators(solver_data->ksp, A, B);
         AssertThrow(ierr == 0, ExcPETScError(ierr));
 
         // then a convergence monitor

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -50,7 +50,7 @@ namespace PETScWrappers
             VecGetOwnershipRange(vector.vector, &begin, &end);
           AssertThrow(ierr == 0, ExcPETScError(ierr));
 
-          Vec locally_stored_elements = PETSC_NULL;
+          Vec locally_stored_elements = nullptr;
           ierr = VecGhostGetLocalForm(vector.vector, &locally_stored_elements);
           AssertThrow(ierr == 0, ExcPETScError(ierr));
 
@@ -201,7 +201,7 @@ namespace PETScWrappers
 
     if (has_ghost_elements())
       {
-        Vec ghost = PETSC_NULL;
+        Vec ghost = nullptr;
         ierr      = VecGhostGetLocalForm(vector, &ghost);
         AssertThrow(ierr == 0, ExcPETScError(ierr));
 

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -190,6 +190,19 @@ namespace PETScWrappers
 
 
   VectorBase &
+  VectorBase::operator=(const VectorBase &v)
+  {
+    Assert(size() == v.size(), ExcDimensionMismatch(size(), v.size()));
+
+    PetscErrorCode ierr = VecCopy(v, vector);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
+
+    return *this;
+  }
+
+
+
+  VectorBase &
   VectorBase::operator=(const PetscScalar s)
   {
     AssertIsFinite(s);

--- a/tests/petsc/solver_03_mf.cc
+++ b/tests/petsc/solver_03_mf.cc
@@ -62,5 +62,12 @@ main(int argc, char **argv)
                               control.last_step(),
                               42,
                               44);
+
+    u = 0.;
+    PETScWrappers::PreconditionShell preconditioner_user(A);
+    check_solver_within_range(solver.solve(A, u, f, preconditioner_user),
+                              control.last_step(),
+                              42,
+                              44);
   }
 }

--- a/tests/petsc/solver_03_mf.cc
+++ b/tests/petsc/solver_03_mf.cc
@@ -65,6 +65,15 @@ main(int argc, char **argv)
 
     u = 0.;
     PETScWrappers::PreconditionShell preconditioner_user(A);
+
+    // Identity preconditioner
+    preconditioner_user.vmult =
+      [](PETScWrappers::VectorBase &      dst,
+         const PETScWrappers::VectorBase &src) -> int {
+      dst = src;
+      return 0;
+    };
+
     check_solver_within_range(solver.solve(A, u, f, preconditioner_user),
                               control.last_step(),
                               42,

--- a/tests/petsc/solver_03_mf.output
+++ b/tests/petsc/solver_03_mf.output
@@ -2,3 +2,4 @@
 DEAL::Size 32 Unknowns 961
 DEAL::Solver type: N6dealii13PETScWrappers8SolverCGE
 DEAL::Solver stopped within 42 - 44 iterations
+DEAL::Solver stopped within 42 - 44 iterations


### PR DESCRIPTION
- Add support for SHELL preconditioning: this allows users to provide their own matrix-free approximate solver
- Remove usage of MPI_COMM_NULL since it is not in line with the rest of the deal.II wrappers for PETSc
- Align get_mpi_communicator with other methods of the PETSc classes for the moment