### PR TITLE
CMake: Promote "tester-ng" to official regression tester

### DIFF
--- a/tests/run_testsuite.cmake
+++ b/tests/run_testsuite.cmake
@@ -245,7 +245,7 @@ endif()
 
 message("-- CTEST_SITE:             ${CTEST_SITE}")
 
-if(TRACK MATCHES "^Regression Tests$" AND NOT CTEST_SITE MATCHES "^tester$")
+if(TRACK MATCHES "^Regression Tests$" AND NOT CTEST_SITE MATCHES "^tester(|-ng)$")
   message(FATAL_ERROR "
 I'm sorry ${CTEST_SITE}, I'm afraid I can't do that.
 The TRACK \"Regression Tests\" is not for you.


### PR DESCRIPTION
"tester-ng" is a new regression test infrastructure located at Texas A&M University that I plan to use for full Regression runs for Debian and Ubuntu.