### PR TITLE
Testsuite: run quick tests during build test

### DIFF
--- a/tests/run_testsuite.cmake
+++ b/tests/run_testsuite.cmake
@@ -266,7 +266,7 @@ if(NOT "${CONFIG_FILE}" STREQUAL "")
 endif()
 
 if("${TRACK}" STREQUAL "Build Tests")
-  set(TEST_PICKUP_REGEX "^do_not_run_any_tests")
+  set(TEST_PICKUP_REGEX "^quick_tests")
 endif()
 
 # Pass all relevant variables down to configure:


### PR DESCRIPTION
Running our quick tests during a build test is incredibly useful to get
some basic idea whether final executable linkage and invocation is actually
working.

I accidentally enabled this during some refactoring and then I accidentaly
disabled this again. So let's make this behavior permanent.