### PR TITLE
Fix two small things in FiniteElement.

### DIFF
--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -679,18 +679,16 @@ FiniteElement<dim, spacedim>::adjust_quad_dof_index_for_face_orientation(
   AssertIndexRange(index, this->n_dofs_per_quad(face));
   Assert(adjust_quad_dof_index_for_face_orientation_table
              [this->n_unique_quads() == 1 ? 0 : face]
-               .n_elements() == (this->reference_cell().face_reference_cell(
-                                   face) == ReferenceCells::Quadrilateral ?
-                                   8 :
-                                   6) *
-                                  this->n_dofs_per_quad(face),
+               .n_elements() ==
+           (this->reference_cell().n_face_orientations(face)) *
+             this->n_dofs_per_quad(face),
          ExcInternalError());
   return index +
          adjust_quad_dof_index_for_face_orientation_table
            [this->n_unique_quads() == 1 ? 0 : face](index,
-                                                    (face_orientation ? 4 : 0) +
-                                                      (face_flip ? 2 : 0) +
-                                                      (face_rotation ? 1 : 0));
+                                                    (face_orientation ? 1 : 0) +
+                                                      (face_rotation ? 2 : 0) +
+                                                      (face_flip ? 4 : 0));
 }
 
 


### PR DESCRIPTION
Taken from #14583.

1. Avoid hard-coding in the number of permutations
2. Correctly calculate the combined/raw orientation

Here and elsewhere, we store the orientation information in a single `unsigned char` which we unpack to call this function and then pack again to access the array. Is there any reason to not just pass the combined orientation as an argument? I'd like to deprecate this function and eliminate that middle step to avoid packing/unpacking bugs like this one.