### PR TITLE
Tests: optimization/* add missing includes

### DIFF
--- a/tests/optimization/cubic_fit.cc
+++ b/tests/optimization/cubic_fit.cc
@@ -21,6 +21,7 @@
 #include <deal.II/optimization/line_minimization.h>
 
 #include <fstream>
+#include <functional>
 #include <iostream>
 
 #include "../tests.h"

--- a/tests/optimization/cubic_fit_three_points.cc
+++ b/tests/optimization/cubic_fit_three_points.cc
@@ -21,6 +21,7 @@
 #include <deal.II/optimization/line_minimization.h>
 
 #include <fstream>
+#include <functional>
 #include <iostream>
 
 #include "../tests.h"

--- a/tests/optimization/line_minimization.cc
+++ b/tests/optimization/line_minimization.cc
@@ -20,6 +20,7 @@
 #include <deal.II/optimization/line_minimization.h>
 
 #include <fstream>
+#include <functional>
 #include <iostream>
 
 #include "../tests.h"

--- a/tests/optimization/line_minimization_02.cc
+++ b/tests/optimization/line_minimization_02.cc
@@ -22,6 +22,7 @@
 #include <deal.II/optimization/line_minimization.h>
 
 #include <fstream>
+#include <functional>
 #include <iostream>
 
 #include "../tests.h"

--- a/tests/optimization/line_minimization_03.cc
+++ b/tests/optimization/line_minimization_03.cc
@@ -22,6 +22,7 @@
 #include <deal.II/optimization/line_minimization.h>
 
 #include <fstream>
+#include <functional>
 #include <iostream>
 
 #include "../tests.h"

--- a/tests/optimization/line_minimization_03b.cc
+++ b/tests/optimization/line_minimization_03b.cc
@@ -20,6 +20,7 @@
 #include <deal.II/optimization/line_minimization.h>
 
 #include <fstream>
+#include <functional>
 #include <iostream>
 
 #include "../tests.h"

--- a/tests/optimization/quadratic_fit.cc
+++ b/tests/optimization/quadratic_fit.cc
@@ -20,6 +20,7 @@
 #include <deal.II/optimization/line_minimization.h>
 
 #include <fstream>
+#include <functional>
 #include <iostream>
 
 #include "../tests.h"


### PR DESCRIPTION
Some of the optimization tests use a std::function object but forget to
include the header. These tests work with older versions of libstdc++
due to some transitive include but fail for current versions:

```
/home/testsuite/workspace/regression_tests/dealii/include/deal.II/optimization/line_minimization.h:323:16: error: 'function' in namespace 'std' does not name a template type
  323 |     const std::function<std::pair<NumberType, NumberType>(const NumberType x)>
      |                ^~~~~~~~
/home/testsuite/workspace/regression_tests/dealii/include/deal.II/optimization/line_minimization.h:30:1: note: 'std::function' is defined in header '<functional>'; did you forget to '#include <functional>'?
   29 | #include <fstream>
  +++ |+#include <functional>
   30 | #include <limits>
```