### PR TITLE
include/deal.II/optimization/line_minimization.h add missing include

### DIFF
--- a/include/deal.II/optimization/line_minimization.h
+++ b/include/deal.II/optimization/line_minimization.h
@@ -27,6 +27,7 @@
 
 #include <algorithm>
 #include <fstream>
+#include <functional>
 #include <limits>
 #include <string>
 


### PR DESCRIPTION
Round two:

```
/home/testsuite/workspace/regression_tests/dealii/include/deal.II/optimization/line_minimization.h:323:16: error: 'function' in namespace 'std' does not name a template type
  323 |     const std::function<std::pair<NumberType, NumberType>(const NumberType x)>
      |                ^~~~~~~~
/home/testsuite/workspace/regression_tests/dealii/include/deal.II/optimization/line_minimization.h:30:1: note: 'std::function' is defined in header '<functional>'; did you forget to '#include <functional>'?
   29 | #include <fstream>
  +++ |+#include <functional>
   30 | #include <limits>
```