### PR TITLE
Also mark some variable instantiations as 'extern'.

### DIFF
--- a/include/deal.II/hp/mapping_collection.h
+++ b/include/deal.II/hp/mapping_collection.h
@@ -193,6 +193,7 @@ namespace hp
   extern template struct StaticMappingQ1<2, 3>;
   extern template struct StaticMappingQ1<3, 3>;
 
+#  ifndef _MSC_VER
   extern template MappingCollection<1, 1>
     StaticMappingQ1<1, 1>::mapping_collection;
   extern template MappingCollection<1, 2>
@@ -205,6 +206,7 @@ namespace hp
     StaticMappingQ1<2, 3>::mapping_collection;
   extern template MappingCollection<3, 3>
     StaticMappingQ1<3, 3>::mapping_collection;
+#  endif
 #endif
 
 } // namespace hp

--- a/include/deal.II/hp/mapping_collection.h
+++ b/include/deal.II/hp/mapping_collection.h
@@ -192,6 +192,19 @@ namespace hp
   extern template struct StaticMappingQ1<2, 2>;
   extern template struct StaticMappingQ1<2, 3>;
   extern template struct StaticMappingQ1<3, 3>;
+
+  extern template MappingCollection<1, 1>
+    StaticMappingQ1<1, 1>::mapping_collection;
+  extern template MappingCollection<1, 2>
+    StaticMappingQ1<1, 2>::mapping_collection;
+  extern template MappingCollection<1, 3>
+    StaticMappingQ1<1, 3>::mapping_collection;
+  extern template MappingCollection<2, 2>
+    StaticMappingQ1<2, 2>::mapping_collection;
+  extern template MappingCollection<2, 3>
+    StaticMappingQ1<2, 3>::mapping_collection;
+  extern template MappingCollection<3, 3>
+    StaticMappingQ1<3, 3>::mapping_collection;
 #endif
 
 } // namespace hp


### PR DESCRIPTION
#14698 turned an error into a warning, so there was something left to do still. I believe that the `extern` markings here should do the trick to finally fix #14695.
