### PR TITLE
Set combined orientation

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -350,6 +350,13 @@ public:
    */
 
   /**
+   * Return the default combined face orientation flag (i.e., the default set of
+   * orientations, defined by orientation, rotate, and flip for a face in 3D).
+   */
+  static constexpr unsigned char
+  default_combined_face_orientation();
+
+  /**
    * Return which child cells are adjacent to a certain face of the
    * mother cell.
    *
@@ -1385,6 +1392,14 @@ ReferenceCell::face_reference_cell(const unsigned int face_no) const
     }
 
   return ReferenceCells::Invalid;
+}
+
+
+
+inline constexpr unsigned char
+ReferenceCell::default_combined_face_orientation()
+{
+  return 1u;
 }
 
 

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -1800,6 +1800,17 @@ private:
   set_face_rotation(const unsigned int face, const bool rotation) const;
 
   /**
+   * Set the combined face orientation (i.e., the integer that uniquely encodes
+   * the orientation, flip, and rotation).
+   *
+   * It is only possible to set the face_orientation of cells in 3d (i.e.
+   * <code>structdim==3 && dim==3</code>).
+   */
+  void
+  set_combined_face_orientation(const unsigned int  face,
+                                const unsigned char combined_orientation) const;
+
+  /**
    * Set the @p used flag. Only for internal use in the library.
    */
   void

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -1769,37 +1769,6 @@ private:
   set_line_orientation(const unsigned int line, const bool orientation) const;
 
   /**
-   * Set whether the quad with index @p face has its normal pointing in the
-   * standard direction (@p true) or whether it is the opposite (@p false).
-   * Which is the standard direction is documented with the GeometryInfo
-   * class.
-   *
-   * This function is only for internal use in the library. Setting this flag
-   * to any other value than the one that the triangulation has already set is
-   * bound to bring you disaster.
-   */
-  void
-  set_face_orientation(const unsigned int face, const bool orientation) const;
-
-  /**
-   * Set the flag indicating, what <code>face_flip()</code> will return.
-   *
-   * It is only possible to set the face_orientation of cells in 3d (i.e.
-   * <code>structdim==3 && dim==3</code>).
-   */
-  void
-  set_face_flip(const unsigned int face, const bool flip) const;
-
-  /**
-   * Set the flag indicating, what <code>face_rotation()</code> will return.
-   *
-   * It is only possible to set the face_orientation of cells in 3d (i.e.
-   * <code>structdim==3 && dim==3</code>).
-   */
-  void
-  set_face_rotation(const unsigned int face, const bool rotation) const;
-
-  /**
    * Set the combined face orientation (i.e., the integer that uniquely encodes
    * the orientation, flip, and rotation).
    *

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -929,6 +929,33 @@ namespace internal
       /**
        * Implementation of the function of some name in the mother class.
        */
+      template <int structdim, int dim, int spacedim>
+      inline static void
+      set_combined_face_orientation(
+        const TriaAccessor<structdim, dim, spacedim> &,
+        const unsigned int,
+        const unsigned char)
+      {
+        Assert(false, ExcInternalError());
+      }
+
+
+
+      inline static void
+      set_combined_face_orientation(const TriaAccessor<3, 3, 3> &accessor,
+                                    const unsigned int           face,
+                                    const unsigned char combined_orientation)
+      {
+        AssertIndexRange(face, accessor.n_faces());
+        accessor.tria->levels[accessor.present_level]
+          ->face_orientations.set_raw_orientation(
+            accessor.present_index * GeometryInfo<3>::faces_per_cell + face,
+            combined_orientation);
+      }
+
+      /**
+       * Implementation of the function of some name in the mother class.
+       */
       template <int dim, int spacedim>
       inline static void
       set_line_orientation(const TriaAccessor<1, dim, spacedim> &,
@@ -1539,6 +1566,21 @@ TriaAccessor<structdim, dim, spacedim>::set_line_orientation(
 
   dealii::internal::TriaAccessorImplementation::Implementation::
     set_line_orientation(*this, line, value);
+}
+
+
+
+template <int structdim, int dim, int spacedim>
+inline void
+TriaAccessor<structdim, dim, spacedim>::set_combined_face_orientation(
+  const unsigned int  face,
+  const unsigned char combined_orientation) const
+{
+  Assert(used(), TriaAccessorExceptions::ExcCellNotUsed());
+  AssertIndexRange(face, this->n_faces());
+
+  dealii::internal::TriaAccessorImplementation::Implementation::
+    set_combined_face_orientation(*this, face, combined_orientation);
 }
 
 

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -840,92 +840,6 @@ namespace internal
           accessor.quad(quad_index)->line_orientation(line_within_face_index));
       }
 
-
-
-      /**
-       * Implementation of the function of some name in the mother class.
-       */
-      template <int structdim, int dim, int spacedim>
-      inline static void
-      set_face_orientation(const TriaAccessor<structdim, dim, spacedim> &,
-                           const unsigned int,
-                           const bool)
-      {
-        Assert(false, ExcInternalError());
-      }
-
-
-      inline static void
-      set_face_orientation(const TriaAccessor<3, 3, 3> &accessor,
-                           const unsigned int           face,
-                           const bool                   value)
-      {
-        Assert(accessor.used(), TriaAccessorExceptions::ExcCellNotUsed());
-        AssertIndexRange(face, accessor.n_faces());
-
-        accessor.tria->levels[accessor.present_level]
-          ->face_orientations.set_orientation(
-            accessor.present_index * GeometryInfo<3>::faces_per_cell + face,
-            value);
-      }
-
-
-
-      /**
-       * Implementation of the function of some name in the mother class.
-       */
-      template <int structdim, int dim, int spacedim>
-      inline static void
-      set_face_flip(const TriaAccessor<structdim, dim, spacedim> &,
-                    const unsigned int,
-                    const bool)
-      {
-        Assert(false, ExcInternalError());
-      }
-
-
-      inline static void
-      set_face_flip(const TriaAccessor<3, 3, 3> &accessor,
-                    const unsigned int           face,
-                    const bool                   value)
-      {
-        AssertIndexRange(face, accessor.n_faces());
-
-        accessor.tria->levels[accessor.present_level]
-          ->face_orientations.set_flip(accessor.present_index *
-                                           GeometryInfo<3>::faces_per_cell +
-                                         face,
-                                       value);
-      }
-
-
-
-      /**
-       * Implementation of the function of some name in the mother class.
-       */
-      template <int structdim, int dim, int spacedim>
-      inline static void
-      set_face_rotation(const TriaAccessor<structdim, dim, spacedim> &,
-                        const unsigned int,
-                        const bool)
-      {
-        Assert(false, ExcInternalError());
-      }
-
-
-      inline static void
-      set_face_rotation(const TriaAccessor<3, 3, 3> &accessor,
-                        const unsigned int           face,
-                        const bool                   value)
-      {
-        AssertIndexRange(face, accessor.n_faces());
-        accessor.tria->levels[accessor.present_level]
-          ->face_orientations.set_rotation(accessor.present_index *
-                                               GeometryInfo<3>::faces_per_cell +
-                                             face,
-                                           value);
-      }
-
       /**
        * Implementation of the function of some name in the mother class.
        */
@@ -1511,46 +1425,6 @@ TriaAccessor<structdim, dim, spacedim>::line_orientation(
 
   return dealii::internal::TriaAccessorImplementation::Implementation::
     line_orientation(*this, line);
-}
-
-
-
-template <int structdim, int dim, int spacedim>
-inline void
-TriaAccessor<structdim, dim, spacedim>::set_face_orientation(
-  const unsigned int face,
-  const bool         value) const
-{
-  Assert(used(), TriaAccessorExceptions::ExcCellNotUsed());
-
-  dealii::internal::TriaAccessorImplementation::Implementation::
-    set_face_orientation(*this, face, value);
-}
-
-
-
-template <int structdim, int dim, int spacedim>
-inline void
-TriaAccessor<structdim, dim, spacedim>::set_face_flip(const unsigned int face,
-                                                      const bool value) const
-{
-  Assert(used(), TriaAccessorExceptions::ExcCellNotUsed());
-
-  dealii::internal::TriaAccessorImplementation::Implementation::set_face_flip(
-    *this, face, value);
-}
-
-
-template <int structdim, int dim, int spacedim>
-inline void
-TriaAccessor<structdim, dim, spacedim>::set_face_rotation(
-  const unsigned int face,
-  const bool         value) const
-{
-  Assert(used(), TriaAccessorExceptions::ExcCellNotUsed());
-
-  dealii::internal::TriaAccessorImplementation::Implementation::
-    set_face_rotation(*this, face, value);
 }
 
 


### PR DESCRIPTION
Related to #14667 - where possible lets set the default orientation (now stored in `ReferenceCell`) and otherwise use the full flag instead of setting individual booleans.