### PR TITLE
Fix race condition in implicit Kokkos initialization

### DIFF
--- a/include/deal.II/lac/vector_memory.templates.h
+++ b/include/deal.II/lac/vector_memory.templates.h
@@ -41,8 +41,8 @@ GrowingVectorMemory<VectorType>::get_pool()
   // finalized past program end together with static variables and we need to
   // make sure to empty the Pool when finalizing Kokkos so that the destruction
   // of the Pool doesn't call Kokkos functions.
-  internal::ensure_kokkos_initialized();
   static auto pool = []() {
+    internal::ensure_kokkos_initialized();
     if (!internal::dealii_initialized_kokkos)
       Kokkos::push_finalize_hook(
         GrowingVectorMemory<VectorType>::release_unused_memory);


### PR DESCRIPTION
@tamiko had noticed some test failures that reported that `Kokkos` wasn't initialized. The problem with the current implementation is that multiple threads could try to call `ensure_kokkos_initialized` (when `Kokkos` wasn't initialized by the user already) and some of them might continue before the initialization is complete. Since `Kokkos` must be initialized exactly once, it is sufficient to move the call to the static variable that is very conveniently located in the next line. The initialization of `static` variables is thread-safe in the sense that only one thread calls the constructor (which uses an immediately invoked lambda here) while all other threads are waiting. Hence, that should fix the problem.

Another option would be to use a similar trick directly in `ensure_kokkos_initialized`.