### PR TITLE
Remove reference cell namespace

### DIFF
--- a/contrib/python-bindings/source/reference_cell_wrapper.cc
+++ b/contrib/python-bindings/source/reference_cell_wrapper.cc
@@ -35,7 +35,7 @@ namespace python
 
   ReferenceCellWrapper::ReferenceCellWrapper(const std::uint8_t &kind)
   {
-    cell_type = internal::ReferenceCell::make_reference_cell_from_int(kind);
+    cell_type = internal::make_reference_cell_from_int(kind);
   }
 
 

--- a/include/deal.II/cgal/utilities.h
+++ b/include/deal.II/cgal/utilities.h
@@ -231,10 +231,10 @@ namespace CGALWrappers
     const unsigned int                                                   degree,
     const BooleanOperation &       bool_op,
     const Mapping<dim0, spacedim> &mapping0 =
-      (dealii::ReferenceCells::get_hypercube<dim0>()
+      (ReferenceCells::get_hypercube<dim0>()
          .template get_default_linear_mapping<dim0, spacedim>()),
     const Mapping<dim1, spacedim> &mapping1 =
-      (dealii::ReferenceCells::get_hypercube<dim1>()
+      (ReferenceCells::get_hypercube<dim1>()
          .template get_default_linear_mapping<dim1, spacedim>()));
 
   /**

--- a/include/deal.II/fe/fe_data.h
+++ b/include/deal.II/fe/fe_data.h
@@ -700,7 +700,7 @@ namespace internal
   internal::GenericDoFsPerObject
   expand(const unsigned int               dim,
          const std::vector<unsigned int> &dofs_per_object,
-         const dealii::ReferenceCell      reference_cell);
+         const ReferenceCell              reference_cell);
 } // namespace internal
 
 

--- a/include/deal.II/grid/connectivity.h
+++ b/include/deal.II/grid/connectivity.h
@@ -72,14 +72,14 @@ namespace internal
       /**
        * Geometric entity type of the @p e-th sub-entity of dimension @p d.
        */
-      virtual dealii::ReferenceCell
+      virtual ReferenceCell
       type_of_entity(const unsigned int d, const unsigned int e) const
       {
         Assert(false, ExcNotImplemented());
         (void)d;
         (void)e;
 
-        return dealii::ReferenceCells::Vertex;
+        return ReferenceCells::Vertex;
       }
 
       /**
@@ -152,17 +152,17 @@ namespace internal
         return {};
       }
 
-      dealii::ReferenceCell
+      ReferenceCell
       type_of_entity(const unsigned int d, const unsigned int e) const override
       {
         (void)e;
 
         if (d == 1)
-          return dealii::ReferenceCells::Line;
+          return ReferenceCells::Line;
 
         Assert(false, ExcNotImplemented());
 
-        return dealii::ReferenceCells::Vertex;
+        return ReferenceCells::Vertex;
       }
 
       unsigned int
@@ -206,20 +206,20 @@ namespace internal
         return {};
       }
 
-      virtual dealii::ReferenceCell
+      virtual ReferenceCell
       type_of_entity(const unsigned int d, const unsigned int e) const override
       {
         (void)e;
 
         if (d == 2)
-          return dealii::ReferenceCells::Triangle;
+          return ReferenceCells::Triangle;
 
         if (d == 1)
-          return dealii::ReferenceCells::Line;
+          return ReferenceCells::Line;
 
         Assert(false, ExcNotImplemented());
 
-        return dealii::ReferenceCells::Vertex;
+        return ReferenceCells::Vertex;
       }
 
       unsigned int
@@ -263,20 +263,20 @@ namespace internal
         return {};
       }
 
-      virtual dealii::ReferenceCell
+      virtual ReferenceCell
       type_of_entity(const unsigned int d, const unsigned int e) const override
       {
         (void)e;
 
         if (d == 2)
-          return dealii::ReferenceCells::Quadrilateral;
+          return ReferenceCells::Quadrilateral;
 
         if (d == 1)
-          return dealii::ReferenceCells::Line;
+          return ReferenceCells::Line;
 
         Assert(false, ExcNotImplemented());
 
-        return dealii::ReferenceCells::Vertex;
+        return ReferenceCells::Vertex;
       }
 
       unsigned int
@@ -328,23 +328,23 @@ namespace internal
         return {};
       }
 
-      virtual dealii::ReferenceCell
+      virtual ReferenceCell
       type_of_entity(const unsigned int d, const unsigned int e) const override
       {
         (void)e;
 
         if (d == 3)
-          return dealii::ReferenceCells::Tetrahedron;
+          return ReferenceCells::Tetrahedron;
 
         if (d == 2)
-          return dealii::ReferenceCells::Triangle;
+          return ReferenceCells::Triangle;
 
         if (d == 1)
-          return dealii::ReferenceCells::Line;
+          return ReferenceCells::Line;
 
         Assert(false, ExcNotImplemented());
 
-        return dealii::ReferenceCells::Vertex;
+        return ReferenceCells::Vertex;
       }
 
       unsigned int
@@ -439,25 +439,25 @@ namespace internal
         return {};
       }
 
-      virtual dealii::ReferenceCell
+      virtual ReferenceCell
       type_of_entity(const unsigned int d, const unsigned int e) const override
       {
         (void)e;
 
         if (d == 3)
-          return dealii::ReferenceCells::Pyramid;
+          return ReferenceCells::Pyramid;
 
         if (d == 2 && e == 0)
-          return dealii::ReferenceCells::Quadrilateral;
+          return ReferenceCells::Quadrilateral;
         else if (d == 2)
-          return dealii::ReferenceCells::Triangle;
+          return ReferenceCells::Triangle;
 
         if (d == 1)
-          return dealii::ReferenceCells::Line;
+          return ReferenceCells::Line;
 
         Assert(false, ExcNotImplemented());
 
-        return dealii::ReferenceCells::Vertex;
+        return ReferenceCells::Vertex;
       }
 
       unsigned int
@@ -565,25 +565,25 @@ namespace internal
         return {};
       }
 
-      virtual dealii::ReferenceCell
+      virtual ReferenceCell
       type_of_entity(const unsigned int d, const unsigned int e) const override
       {
         (void)e;
 
         if (d == 3)
-          return dealii::ReferenceCells::Wedge;
+          return ReferenceCells::Wedge;
 
         if (d == 2 && e > 1)
-          return dealii::ReferenceCells::Quadrilateral;
+          return ReferenceCells::Quadrilateral;
         else if (d == 2)
-          return dealii::ReferenceCells::Triangle;
+          return ReferenceCells::Triangle;
 
         if (d == 1)
-          return dealii::ReferenceCells::Line;
+          return ReferenceCells::Line;
 
         Assert(false, ExcNotImplemented());
 
-        return dealii::ReferenceCells::Vertex;
+        return ReferenceCells::Vertex;
       }
 
       unsigned int
@@ -693,23 +693,23 @@ namespace internal
         return {};
       }
 
-      virtual dealii::ReferenceCell
+      virtual ReferenceCell
       type_of_entity(const unsigned int d, const unsigned int e) const override
       {
         (void)e;
 
         if (d == 3)
-          return dealii::ReferenceCells::Hexahedron;
+          return ReferenceCells::Hexahedron;
 
         if (d == 2)
-          return dealii::ReferenceCells::Quadrilateral;
+          return ReferenceCells::Quadrilateral;
 
         if (d == 1)
-          return dealii::ReferenceCells::Line;
+          return ReferenceCells::Line;
 
         Assert(false, ExcNotImplemented());
 
-        return dealii::ReferenceCells::Vertex;
+        return ReferenceCells::Vertex;
       }
 
       unsigned int
@@ -822,8 +822,8 @@ namespace internal
     template <typename T = unsigned int>
     struct Connectivity
     {
-      Connectivity(const unsigned int                        dim,
-                   const std::vector<dealii::ReferenceCell> &cell_types)
+      Connectivity(const unsigned int                dim,
+                   const std::vector<ReferenceCell> &cell_types)
         : dim(dim)
         , cell_types(cell_types)
       {}
@@ -850,7 +850,7 @@ namespace internal
         return quad_orientation;
       }
 
-      inline std::vector<dealii::ReferenceCell> &
+      inline std::vector<ReferenceCell> &
       entity_types(const unsigned int structdim)
       {
         if (structdim == dim)
@@ -863,7 +863,7 @@ namespace internal
         return quad_types;
       }
 
-      inline const std::vector<dealii::ReferenceCell> &
+      inline const std::vector<ReferenceCell> &
       entity_types(const unsigned int structdim) const
       {
         if (structdim == dim)
@@ -915,8 +915,8 @@ namespace internal
       }
 
     private:
-      const unsigned int                 dim;
-      std::vector<dealii::ReferenceCell> cell_types;
+      const unsigned int         dim;
+      std::vector<ReferenceCell> cell_types;
 
       CRS<T> line_vertices;
 
@@ -930,7 +930,7 @@ namespace internal
       CRS<T> cell_entities;
       CRS<T> neighbors;
 
-      std::vector<dealii::ReferenceCell> quad_types;
+      std::vector<ReferenceCell> quad_types;
     };
 
 
@@ -1000,7 +1000,7 @@ namespace internal
     build_face_entities_templated(
       const unsigned int                                face_dimensionality,
       const std::vector<std::shared_ptr<CellTypeBase>> &cell_types,
-      const std::vector<dealii::ReferenceCell> &        cell_types_index,
+      const std::vector<ReferenceCell> &                cell_types_index,
       const CRS<unsigned int> &                         crs,
       CRS<unsigned int> &                               crs_d,        // result
       CRS<unsigned int> &                               crs_0,        // result
@@ -1040,7 +1040,7 @@ namespace internal
         keys; // key (sorted vertices), cell-entity index
 
       std::vector<std::array<unsigned int, max_n_vertices>> ad_entity_vertices;
-      std::vector<dealii::ReferenceCell>                    ad_entity_types;
+      std::vector<ReferenceCell>                            ad_entity_types;
       std::vector<std::array<unsigned int, max_n_vertices>> ad_compatibility;
 
       keys.reserve(n_entities);
@@ -1191,7 +1191,7 @@ namespace internal
     build_face_entities(
       const unsigned int                                face_dimensionality,
       const std::vector<std::shared_ptr<CellTypeBase>> &cell_types,
-      const std::vector<dealii::ReferenceCell> &        cell_types_index,
+      const std::vector<ReferenceCell> &                cell_types_index,
       const CRS<unsigned int> &                         crs,
       CRS<unsigned int> &                               crs_d,
       CRS<unsigned int> &                               crs_0,
@@ -1255,7 +1255,7 @@ namespace internal
     inline void
     build_intersection(
       const std::vector<std::shared_ptr<CellTypeBase>> &cell_types,
-      const std::vector<dealii::ReferenceCell> &        cell_types_index,
+      const std::vector<ReferenceCell> &                cell_types_index,
       const CRS<unsigned int> &                         con_cv,
       const CRS<unsigned int> &                         con_cl,
       const CRS<unsigned int> &                         con_lv,
@@ -1264,7 +1264,7 @@ namespace internal
       const TriaObjectsOrientations &                   ori_cq,
       CRS<unsigned int> &                               con_ql,   // result
       TriaObjectsOrientations &                         ori_ql,   // result
-      std::vector<dealii::ReferenceCell> &              quad_t_id // result
+      std::vector<ReferenceCell> &                      quad_t_id // result
     )
     {
       // reset output
@@ -1369,8 +1369,8 @@ namespace internal
     Connectivity<T>
     build_connectivity(const unsigned int                                dim,
                        const std::vector<std::shared_ptr<CellTypeBase>> &cell_t,
-                       const std::vector<dealii::ReferenceCell> &cell_t_id,
-                       const CRS<T> &                            con_cv)
+                       const std::vector<ReferenceCell> &cell_t_id,
+                       const CRS<T> &                    con_cv)
     {
       Connectivity<T> connectivity(dim, cell_t_id);
 
@@ -1462,23 +1462,20 @@ namespace internal
       std::vector<std::shared_ptr<CellTypeBase>> cell_types_impl(8);
 
       cell_types_impl[static_cast<types::geometric_entity_type>(
-        dealii::ReferenceCells::Line)] = std::make_shared<CellTypeLine>();
+        ReferenceCells::Line)]     = std::make_shared<CellTypeLine>();
       cell_types_impl[static_cast<types::geometric_entity_type>(
-        dealii::ReferenceCells::Triangle)] =
-        std::make_shared<CellTypeTriangle>();
+        ReferenceCells::Triangle)] = std::make_shared<CellTypeTriangle>();
       cell_types_impl[static_cast<types::geometric_entity_type>(
-        dealii::ReferenceCells::Quadrilateral)] =
+        ReferenceCells::Quadrilateral)] =
         std::make_shared<CellTypeQuadrilateral>();
       cell_types_impl[static_cast<types::geometric_entity_type>(
-        dealii::ReferenceCells::Tetrahedron)] =
-        std::make_shared<CellTypeTetrahedron>();
+        ReferenceCells::Tetrahedron)] = std::make_shared<CellTypeTetrahedron>();
       cell_types_impl[static_cast<types::geometric_entity_type>(
-        dealii::ReferenceCells::Pyramid)] = std::make_shared<CellTypePyramid>();
+        ReferenceCells::Pyramid)]     = std::make_shared<CellTypePyramid>();
       cell_types_impl[static_cast<types::geometric_entity_type>(
-        dealii::ReferenceCells::Wedge)]   = std::make_shared<CellTypeWedge>();
+        ReferenceCells::Wedge)]       = std::make_shared<CellTypeWedge>();
       cell_types_impl[static_cast<types::geometric_entity_type>(
-        dealii::ReferenceCells::Hexahedron)] =
-        std::make_shared<CellTypeHexahedron>();
+        ReferenceCells::Hexahedron)]  = std::make_shared<CellTypeHexahedron>();
 
       // determine cell types and process vertices
       std::vector<T> cell_vertices;
@@ -1494,7 +1491,7 @@ namespace internal
       cell_vertices_ptr.reserve(cells.size() + 1);
       cell_vertices_ptr.push_back(0);
 
-      std::vector<dealii::ReferenceCell> cell_types_indices;
+      std::vector<ReferenceCell> cell_types_indices;
       cell_types_indices.reserve(cells.size());
 
       // loop over cells and create CRS
@@ -1517,11 +1514,10 @@ namespace internal
                    "CellData."));
 #endif
 
-          const dealii::ReferenceCell reference_cell =
-            dealii::ReferenceCell::n_vertices_to_type(dim,
-                                                      cell.vertices.size());
+          const ReferenceCell reference_cell =
+            ReferenceCell::n_vertices_to_type(dim, cell.vertices.size());
 
-          Assert(reference_cell != dealii::ReferenceCells::Invalid,
+          Assert(reference_cell != ReferenceCells::Invalid,
                  ExcNotImplemented());
           AssertIndexRange(static_cast<types::geometric_entity_type>(
                              reference_cell),

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -46,25 +46,20 @@ class ReferenceCell;
 
 namespace internal
 {
-  namespace ReferenceCell
-  {
-    /**
-     * A helper function to create a ReferenceCell object from an
-     * integer. ReferenceCell objects are "singletons" (actually,
-     * "multitons" -- there are multiple, but they are only a handful and
-     * these are all that can be used). What is then necessary is to
-     * have a way to create these with their internal id to distinguish
-     * the few possible ones in existence. We could do this via a public
-     * constructor of ReferenceCell, but that would allow users
-     * to create ones outside the range we envision, and we don't want to do
-     * that. Rather, the constructor that takes an integer is made `private`
-     * but we have this one function in an internal namespace that is a friend
-     * of the class and can be used to create the objects.
-     */
-    constexpr dealii::ReferenceCell
-    make_reference_cell_from_int(const std::uint8_t kind);
-
-  } // namespace ReferenceCell
+  /**
+   * A helper function to create a ReferenceCell object from an integer.
+   * ReferenceCell objects are "singletons" (actually, "multitons" -- there are
+   * multiple, but they are only a handful and these are all that can be used).
+   * What is then necessary is to have a way to create these with their internal
+   * id to distinguish the few possible ones in existence. We could do this via
+   * a public constructor of ReferenceCell, but that would allow users to create
+   * ones outside the range we envision, and we don't want to do that. Rather,
+   * the constructor that takes an integer is made `private` but we have this
+   * one function in an internal namespace that is a friend of the class and can
+   * be used to create the objects.
+   */
+  constexpr ReferenceCell
+  make_reference_cell_from_int(const std::uint8_t kind);
 } // namespace internal
 
 
@@ -816,7 +811,7 @@ private:
    * called by anyone, but at least hidden in an internal namespace.
    */
   friend constexpr ReferenceCell
-  internal::ReferenceCell::make_reference_cell_from_int(const std::uint8_t);
+  internal::make_reference_cell_from_int(const std::uint8_t);
 
   friend std::ostream &
   operator<<(std::ostream &out, const ReferenceCell &reference_cell);
@@ -878,23 +873,20 @@ ReferenceCell::operator!=(const ReferenceCell &type) const
 
 namespace internal
 {
-  namespace ReferenceCell
+  inline constexpr ReferenceCell
+  make_reference_cell_from_int(const std::uint8_t kind)
   {
-    inline constexpr dealii::ReferenceCell
-    make_reference_cell_from_int(const std::uint8_t kind)
-    {
 #ifndef DEAL_II_CXX14_CONSTEXPR_BUG
-      // Make sure these are the only indices from which objects can be
-      // created.
-      Assert((kind == static_cast<std::uint8_t>(-1)) || (kind < 8),
-             ExcInternalError());
+    // Make sure these are the only indices from which objects can be
+    // created.
+    Assert((kind == static_cast<std::uint8_t>(-1)) || (kind < 8),
+           ExcInternalError());
 #endif
 
-      // Call the private constructor, which we can from here because this
-      // function is a 'friend'.
-      return {kind};
-    }
-  } // namespace ReferenceCell
+    // Call the private constructor, which we can from here because this
+    // function is a 'friend'.
+    return {kind};
+  }
 } // namespace internal
 
 
@@ -909,24 +901,23 @@ namespace internal
 namespace ReferenceCells
 {
   constexpr const ReferenceCell Vertex =
-    internal::ReferenceCell::make_reference_cell_from_int(0);
+    internal::make_reference_cell_from_int(0);
   constexpr const ReferenceCell Line =
-    internal::ReferenceCell::make_reference_cell_from_int(1);
+    internal::make_reference_cell_from_int(1);
   constexpr const ReferenceCell Triangle =
-    internal::ReferenceCell::make_reference_cell_from_int(2);
+    internal::make_reference_cell_from_int(2);
   constexpr const ReferenceCell Quadrilateral =
-    internal::ReferenceCell::make_reference_cell_from_int(3);
+    internal::make_reference_cell_from_int(3);
   constexpr const ReferenceCell Tetrahedron =
-    internal::ReferenceCell::make_reference_cell_from_int(4);
+    internal::make_reference_cell_from_int(4);
   constexpr const ReferenceCell Pyramid =
-    internal::ReferenceCell::make_reference_cell_from_int(5);
+    internal::make_reference_cell_from_int(5);
   constexpr const ReferenceCell Wedge =
-    internal::ReferenceCell::make_reference_cell_from_int(6);
+    internal::make_reference_cell_from_int(6);
   constexpr const ReferenceCell Hexahedron =
-    internal::ReferenceCell::make_reference_cell_from_int(7);
+    internal::make_reference_cell_from_int(7);
   constexpr const ReferenceCell Invalid =
-    internal::ReferenceCell::make_reference_cell_from_int(
-      static_cast<std::uint8_t>(-1));
+    internal::make_reference_cell_from_int(static_cast<std::uint8_t>(-1));
 
   /**
    * Return the correct simplex reference cell type for the given dimension
@@ -2599,9 +2590,9 @@ namespace internal
     /**
      * Constructor.
      */
-    NoPermutation(const dealii::ReferenceCell &entity_type,
-                  const ArrayView<const T> &   vertices_0,
-                  const ArrayView<const T> &   vertices_1)
+    NoPermutation(const ReferenceCell &     entity_type,
+                  const ArrayView<const T> &vertices_0,
+                  const ArrayView<const T> &vertices_1)
       : entity_type(entity_type)
       , vertices_0(vertices_0)
       , vertices_1(vertices_1)
@@ -2647,7 +2638,7 @@ namespace internal
     /**
      * Entity type.
      */
-    const dealii::ReferenceCell entity_type;
+    const ReferenceCell entity_type;
 
     /**
      * First set of values.

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -58,19 +58,19 @@ namespace internal
       const ReferenceCell reference_cell =
         ReferenceCell::n_vertices_to_type(dim, vertices.size());
 
-      if (reference_cell == dealii::ReferenceCells::Line)
+      if (reference_cell == ReferenceCells::Line)
         // Return the distance between the two vertices
         return (vertices[1] - vertices[0]).norm();
-      else if (reference_cell == dealii::ReferenceCells::Triangle)
+      else if (reference_cell == ReferenceCells::Triangle)
         // Return the longest of the three edges
         return std::max({(vertices[1] - vertices[0]).norm(),
                          (vertices[2] - vertices[1]).norm(),
                          (vertices[2] - vertices[0]).norm()});
-      else if (reference_cell == dealii::ReferenceCells::Quadrilateral)
+      else if (reference_cell == ReferenceCells::Quadrilateral)
         // Return the longer one of the two diagonals of the quadrilateral
         return std::max({(vertices[3] - vertices[0]).norm(),
                          (vertices[2] - vertices[1]).norm()});
-      else if (reference_cell == dealii::ReferenceCells::Tetrahedron)
+      else if (reference_cell == ReferenceCells::Tetrahedron)
         // Return the longest of the six edges of the tetrahedron
         return std::max({(vertices[1] - vertices[0]).norm(),
                          (vertices[2] - vertices[0]).norm(),
@@ -78,7 +78,7 @@ namespace internal
                          (vertices[3] - vertices[0]).norm(),
                          (vertices[3] - vertices[1]).norm(),
                          (vertices[3] - vertices[2]).norm()});
-      else if (reference_cell == dealii::ReferenceCells::Pyramid)
+      else if (reference_cell == ReferenceCells::Pyramid)
         // Return ...
         return std::max({// the longest diagonal of the quadrilateral base
                          // of the pyramid or ...
@@ -90,7 +90,7 @@ namespace internal
                          (vertices[4] - vertices[1]).norm(),
                          (vertices[4] - vertices[2]).norm(),
                          (vertices[4] - vertices[3]).norm()});
-      else if (reference_cell == dealii::ReferenceCells::Wedge)
+      else if (reference_cell == ReferenceCells::Wedge)
         // Return ...
         return std::max({// the longest of the 2*3=6 diagonals of the three
                          // quadrilateral sides of the wedge or ...
@@ -108,7 +108,7 @@ namespace internal
                          (vertices[4] - vertices[3]).norm(),
                          (vertices[5] - vertices[4]).norm(),
                          (vertices[5] - vertices[3]).norm()});
-      else if (reference_cell == dealii::ReferenceCells::Hexahedron)
+      else if (reference_cell == ReferenceCells::Hexahedron)
         // Return the longest of the four diagonals of the hexahedron
         return std::max({(vertices[7] - vertices[0]).norm(),
                          (vertices[6] - vertices[1]).norm(),

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -55,8 +55,8 @@ namespace internal
                                            GeometryInfo<dim>::vertices_per_cell>
         vertices)
     {
-      const dealii::ReferenceCell reference_cell =
-        dealii::ReferenceCell::n_vertices_to_type(dim, vertices.size());
+      const ReferenceCell reference_cell =
+        ReferenceCell::n_vertices_to_type(dim, vertices.size());
 
       if (reference_cell == dealii::ReferenceCells::Line)
         // Return the distance between the two vertices

--- a/include/deal.II/grid/tria_faces.h
+++ b/include/deal.II/grid/tria_faces.h
@@ -85,15 +85,14 @@ namespace internal
       /**
        * Helper accessor function for quad_is_quadrilateral
        */
-      dealii::ReferenceCell
+      ReferenceCell
       get_quad_type(const std::size_t index) const;
 
       /**
        * Helper accessor function for quad_is_quadrilateral
        */
       void
-      set_quad_type(const std::size_t           index,
-                    const dealii::ReferenceCell face_type);
+      set_quad_type(const std::size_t index, const ReferenceCell face_type);
 
       /**
        * The TriaObject containing the data of lines.
@@ -121,7 +120,7 @@ namespace internal
 
 
 
-    inline dealii::ReferenceCell
+    inline ReferenceCell
     TriaFaces::get_quad_type(const std::size_t index) const
     {
       AssertIndexRange(index, quad_is_quadrilateral.size());
@@ -132,8 +131,8 @@ namespace internal
 
 
     inline void
-    TriaFaces::set_quad_type(const std::size_t           index,
-                             const dealii::ReferenceCell face_type)
+    TriaFaces::set_quad_type(const std::size_t   index,
+                             const ReferenceCell face_type)
     {
       AssertIndexRange(index, quad_is_quadrilateral.size());
       Assert(face_type == ReferenceCells::Quadrilateral ||

--- a/include/deal.II/grid/tria_levels.h
+++ b/include/deal.II/grid/tria_levels.h
@@ -223,7 +223,7 @@ namespace internal
        *
        * @note Used only for dim=2 and dim=3.
        */
-      std::vector<dealii::ReferenceCell> reference_cell;
+      std::vector<ReferenceCell> reference_cell;
 
       /**
        * A cache for the vertex indices of the cells (`structdim == dim`), in

--- a/include/deal.II/matrix_free/face_setup_internal.h
+++ b/include/deal.II/matrix_free/face_setup_internal.h
@@ -797,7 +797,7 @@ namespace internal
                         info.face_type =
                           is_mixed_mesh ?
                             (dcell->face(f)->reference_cell() !=
-                             dealii::ReferenceCells::get_hypercube<dim - 1>()) :
+                             ReferenceCells::get_hypercube<dim - 1>()) :
                             0;
                         info.subface_index =
                           GeometryInfo<dim>::max_children_per_cell;
@@ -986,7 +986,7 @@ namespace internal
 
       info.face_type = is_mixed_mesh ?
                          (cell->face(face_no)->reference_cell() !=
-                          dealii::ReferenceCells::get_hypercube<dim - 1>()) :
+                          ReferenceCells::get_hypercube<dim - 1>()) :
                          0;
 
       info.subface_index = GeometryInfo<dim>::max_children_per_cell;

--- a/include/deal.II/matrix_free/mapping_info.h
+++ b/include/deal.II/matrix_free/mapping_info.h
@@ -199,7 +199,7 @@ namespace internal
        * Reference-cell type related to each quadrature and active quadrature
        * index.
        */
-      std::vector<std::vector<dealii::ReferenceCell>> reference_cell_types;
+      std::vector<std::vector<ReferenceCell>> reference_cell_types;
 
       /**
        * Internal function to compute the geometry for the case the mapping is

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -178,7 +178,7 @@ namespace internal
                   face_data_by_cells[my_q].descriptor[hpq * scale].initialize(
                     quad_face);
                   reference_cell_types[my_q][hpq] =
-                    dealii::ReferenceCells::get_hypercube<dim>();
+                    ReferenceCells::get_hypercube<dim>();
                 }
             }
         }
@@ -1539,13 +1539,12 @@ namespace internal
       reorder_face_derivative_indices(
         const unsigned int  face_no,
         const unsigned int  index,
-        const ReferenceCell reference_cell = dealii::ReferenceCells::Invalid)
+        const ReferenceCell reference_cell = ReferenceCells::Invalid)
       {
         Assert(index < dim, ExcInternalError());
 
-        if ((reference_cell == dealii::ReferenceCells::Invalid ||
-             reference_cell == dealii::ReferenceCells::get_hypercube<dim>()) ==
-            false)
+        if ((reference_cell == ReferenceCells::Invalid ||
+             reference_cell == ReferenceCells::get_hypercube<dim>()) == false)
           {
             return index;
           }

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -1537,10 +1537,9 @@ namespace internal
       template <int dim>
       unsigned int
       reorder_face_derivative_indices(
-        const unsigned int          face_no,
-        const unsigned int          index,
-        const dealii::ReferenceCell reference_cell =
-          dealii::ReferenceCells::Invalid)
+        const unsigned int  face_no,
+        const unsigned int  index,
+        const ReferenceCell reference_cell = dealii::ReferenceCells::Invalid)
       {
         Assert(index < dim, ExcInternalError());
 

--- a/include/deal.II/matrix_free/util.h
+++ b/include/deal.II/matrix_free/util.h
@@ -40,7 +40,7 @@ namespace internal
      * are defined on each face.
      */
     template <int dim>
-    inline std::pair<dealii::ReferenceCell, dealii::hp::QCollection<dim - 1>>
+    inline std::pair<ReferenceCell, dealii::hp::QCollection<dim - 1>>
     get_face_quadrature_collection(const Quadrature<dim> &quad,
                                    const bool             do_assert = true)
     {

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -348,10 +348,9 @@ namespace internal
                         quadrature.push_back(*quadrature_hypercube);
                       else if (reference_cell.is_simplex())
                         quadrature.push_back(*quadrature_simplex);
-                      else if (reference_cell == dealii::ReferenceCells::Wedge)
+                      else if (reference_cell == ReferenceCells::Wedge)
                         quadrature.push_back(*quadrature_wedge);
-                      else if (reference_cell ==
-                               dealii::ReferenceCells::Pyramid)
+                      else if (reference_cell == ReferenceCells::Pyramid)
                         quadrature.push_back(*quadrature_pyramid);
                       else
                         Assert(false, ExcNotImplemented());
@@ -434,16 +433,16 @@ namespace internal
                       // need hypercube quadratures.
                       if ((dim < 3) ||
                           (reference_cell.is_hyper_cube() ||
-                           (reference_cell == dealii::ReferenceCells::Wedge) ||
-                           (reference_cell == dealii::ReferenceCells::Pyramid)))
+                           (reference_cell == ReferenceCells::Wedge) ||
+                           (reference_cell == ReferenceCells::Pyramid)))
                         quadrature.push_back(*quadrature_hypercube);
 
                       // In 3d, if the element is for simplex/wedge/pyramid
                       // cells, then we also need simplex quadratures
                       if ((dim == 3) &&
                           (reference_cell.is_simplex() ||
-                           (reference_cell == dealii::ReferenceCells::Wedge) ||
-                           (reference_cell == dealii::ReferenceCells::Pyramid)))
+                           (reference_cell == ReferenceCells::Wedge) ||
+                           (reference_cell == ReferenceCells::Pyramid)))
                         quadrature.push_back(*quadrature_simplex);
                     }
 
@@ -2497,11 +2496,11 @@ DataOut_DoFData<dim, patch_dim, spacedim, patch_spacedim>::get_fes() const
             finite_elements.emplace_back(
               std::make_shared<dealii::hp::FECollection<dim, spacedim>>(
                 FE_SimplexDGP<dim, spacedim>(1)));
-          else if (reference_cell == dealii::ReferenceCells::Wedge)
+          else if (reference_cell == ReferenceCells::Wedge)
             finite_elements.emplace_back(
               std::make_shared<dealii::hp::FECollection<dim, spacedim>>(
                 FE_WedgeDGP<dim, spacedim>(1)));
-          else if (reference_cell == dealii::ReferenceCells::Pyramid)
+          else if (reference_cell == ReferenceCells::Pyramid)
             finite_elements.emplace_back(
               std::make_shared<dealii::hp::FECollection<dim, spacedim>>(
                 FE_PyramidDGP<dim, spacedim>(1)));

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -235,7 +235,7 @@ namespace internal
       // to test there if dim<3.
       static const auto has_fe_with_reference_cell =
         [](const dealii::hp::FECollection<dim, spacedim> &fe_collection,
-           const dealii::ReferenceCell &                  reference_cell) {
+           const ReferenceCell &                          reference_cell) {
           for (unsigned int i = 0; i < fe_collection.size(); ++i)
             if (fe_collection[i].reference_cell() == reference_cell)
               return true;
@@ -341,7 +341,7 @@ namespace internal
 
                   for (unsigned int j = 0; j < finite_elements[i]->size(); ++j)
                     {
-                      const dealii::ReferenceCell reference_cell =
+                      const ReferenceCell reference_cell =
                         (*finite_elements[i])[j].reference_cell();
 
                       if (reference_cell.is_hyper_cube())
@@ -427,7 +427,7 @@ namespace internal
 
                   for (unsigned int j = 0; j < finite_elements[i]->size(); ++j)
                     {
-                      const dealii::ReferenceCell reference_cell =
+                      const ReferenceCell reference_cell =
                         (*finite_elements[i])[j].reference_cell();
 
                       // In 1d/2d and for hypercube/wedge/pyramid elements, we

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -315,7 +315,7 @@ namespace parallel
     this->reference_cells.clear();
     for (const auto &i : reference_cells_ui)
       this->reference_cells.emplace_back(
-        dealii::internal::ReferenceCell::make_reference_cell_from_int(i));
+        dealii::internal::make_reference_cell_from_int(i));
   }
 
 

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -820,7 +820,7 @@ namespace internal
                                 quad_dof_identities
                                   [most_dominating_fe_index][other_fe_index]
                                   [cell->quad(q)->reference_cell() ==
-                                   dealii::ReferenceCells::Quadrilateral],
+                                   ReferenceCells::Quadrilateral],
                                 most_dominating_fe_index_face_no);
 
                             for (const auto &identity : identities)
@@ -1556,7 +1556,7 @@ namespace internal
                                 quad_dof_identities
                                   [most_dominating_fe_index][other_fe_index]
                                   [cell->quad(q)->reference_cell() ==
-                                   dealii::ReferenceCells::Quadrilateral],
+                                   ReferenceCells::Quadrilateral],
                                 most_dominating_fe_index_face_no);
 
                             for (const auto &identity : identities)

--- a/source/fe/fe_data.cc
+++ b/source/fe/fe_data.cc
@@ -24,7 +24,7 @@ namespace internal
   internal::GenericDoFsPerObject
   expand(const unsigned int               dim,
          const std::vector<unsigned int> &dofs_per_object,
-         const dealii::ReferenceCell      cell_type)
+         const ReferenceCell              cell_type)
   {
     internal::GenericDoFsPerObject result;
 

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -4234,7 +4234,7 @@ namespace internal
           Quadrature<dim - 1> quadrature(boundary_points, dummy_weights);
 
           q_projector = QProjector<dim>::project_to_all_faces(
-            dealii::ReferenceCells::get_hypercube<dim>(), quadrature);
+            ReferenceCells::get_hypercube<dim>(), quadrature);
         }
 
       for (const auto &cell : tria.active_cell_iterators())

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -1234,8 +1234,8 @@ namespace internal
               tria_level.reference_cell.insert(
                 tria_level.reference_cell.end(),
                 total_cells - tria_level.reference_cell.size(),
-                tria_level.dim == 2 ? dealii::ReferenceCells::Quadrilateral :
-                                      dealii::ReferenceCells::Hexahedron);
+                tria_level.dim == 2 ? ReferenceCells::Quadrilateral :
+                                      ReferenceCells::Hexahedron);
             }
         }
     }
@@ -2662,7 +2662,7 @@ namespace internal
 
         level.neighbors.assign(size * max_faces_per_cell, {-1, -1});
 
-        level.reference_cell.assign(size, dealii::ReferenceCells::Invalid);
+        level.reference_cell.assign(size, ReferenceCells::Invalid);
 
         if (orientation_needed)
           level.face_orientations.reinit(size * max_faces_per_cell);

--- a/tests/gmsh/gmsh_api_02.cc
+++ b/tests/gmsh/gmsh_api_02.cc
@@ -29,8 +29,8 @@ test(const std::uint8_t kind, const std::string out = "")
           << ',' << spacedim << '>' << std::endl;
 
   Triangulation<dim, spacedim> tria;
-  GridGenerator::reference_cell(
-    tria, internal::ReferenceCell::make_reference_cell_from_int(kind));
+  GridGenerator::reference_cell(tria,
+                                internal::make_reference_cell_from_int(kind));
   GridOut go;
   go.write_msh(tria, "output.msh");
   cat_file("output.msh");

--- a/tests/gmsh/gmsh_api_04.cc
+++ b/tests/gmsh/gmsh_api_04.cc
@@ -31,8 +31,8 @@ test(const std::uint8_t kind, const std::string out = "")
           << ',' << spacedim << '>' << std::endl;
 
   Triangulation<dim, spacedim> tria;
-  GridGenerator::reference_cell(
-    tria, internal::ReferenceCell::make_reference_cell_from_int(kind));
+  GridGenerator::reference_cell(tria,
+                                internal::make_reference_cell_from_int(kind));
 
   GridOut go;
   go.write_msh(tria, "output.msh");


### PR DESCRIPTION
Having a class with the same name as a namespace is annoying because, when we are in `dealii::internal`, the `internal::ReferenceCell` name takes precedence over the class.