### PR TITLE
CMake: add_test(): allow concurrent runs of tests with shared targets

### DIFF
--- a/cmake/macros/macro_deal_ii_add_test.cmake
+++ b/cmake/macros/macro_deal_ii_add_test.cmake
@@ -446,21 +446,10 @@ function(deal_ii_add_test _category _test_name _comparison_file)
       #
 
       if(NOT TARGET ${_target})
-        #
-        # Add a "guard file" rule: The purpose of interrupt_guard.cc is to
-        # force a complete rerun of this test (BUILD, RUN and DIFF stage)
-        # if interrupt_guard.cc is removed by run_test.cmake due to an
-        # interruption.
-        #
-        add_custom_command(
-          OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_target_short}/interrupt_guard.cc
-          COMMAND touch ${CMAKE_CURRENT_BINARY_DIR}/${_target_short}/interrupt_guard.cc
-          )
 
         add_executable(${_target} EXCLUDE_FROM_ALL
           ${_generated_files}
           ${_source_file}
-          ${CMAKE_CURRENT_BINARY_DIR}/${_target_short}/interrupt_guard.cc
           )
 
         set_target_properties(${_target} PROPERTIES OUTPUT_NAME ${_target_short})
@@ -507,7 +496,6 @@ function(deal_ii_add_test _category _test_name _comparison_file)
             -DTEST=${_test_executable_full}
             -DEXPECT=PASSED
             -DBINARY_DIR=${CMAKE_BINARY_DIR}
-            -DGUARD_FILE=${CMAKE_CURRENT_BINARY_DIR}/${_test_name}.${_build_lowercase}/interrupt_guard.cc
             -P ${DEAL_II_PATH}/${DEAL_II_SHARE_RELDIR}/scripts/run_test.cmake
           WORKING_DIRECTORY ${_test_directory}
           )
@@ -593,7 +581,6 @@ function(deal_ii_add_test _category _test_name _comparison_file)
             -DTEST=${_test_full}
             -DEXPECT=${_expect}
             -DBINARY_DIR=${CMAKE_BINARY_DIR}
-            # no guard file
             -P ${DEAL_II_PATH}/${DEAL_II_SHARE_RELDIR}/scripts/run_test.cmake
           WORKING_DIRECTORY ${_test_directory}
           )
@@ -611,7 +598,6 @@ function(deal_ii_add_test _category _test_name _comparison_file)
             -DTEST=${_test_full}
             -DEXPECT=${_expect}
             -DBINARY_DIR=${CMAKE_BINARY_DIR}
-            -DGUARD_FILE=${CMAKE_CURRENT_BINARY_DIR}/${_test_name}.${_build_lowercase}/interrupt_guard.cc
             -P ${DEAL_II_PATH}/${DEAL_II_SHARE_RELDIR}/scripts/run_test.cmake
           WORKING_DIRECTORY ${_test_directory}
           )

--- a/cmake/macros/macro_deal_ii_add_test.cmake
+++ b/cmake/macros/macro_deal_ii_add_test.cmake
@@ -574,36 +574,23 @@ function(deal_ii_add_test _category _test_name _comparison_file)
       # And finally define the test:
       #
 
+      add_test(NAME ${_test_full}
+        COMMAND ${CMAKE_COMMAND}
+          -DTRGT=${_test_target}
+          -DTEST=${_test_full}
+          -DEXPECT=${_expect}
+          -DBINARY_DIR=${CMAKE_BINARY_DIR}
+          -P ${DEAL_II_PATH}/${DEAL_II_SHARE_RELDIR}/scripts/run_test.cmake
+        WORKING_DIRECTORY ${_test_directory}
+        )
+      set_tests_properties(${_test_full} PROPERTIES
+        LABEL "${_category}"
+        TIMEOUT ${TEST_TIME_LIMIT}
+        )
+
       if(_shared_target)
-        add_test(NAME ${_test_full}
-          COMMAND ${CMAKE_COMMAND}
-            -DTRGT=${_test_target}
-            -DTEST=${_test_full}
-            -DEXPECT=${_expect}
-            -DBINARY_DIR=${CMAKE_BINARY_DIR}
-            -P ${DEAL_II_PATH}/${DEAL_II_SHARE_RELDIR}/scripts/run_test.cmake
-          WORKING_DIRECTORY ${_test_directory}
-          )
         set_tests_properties(${_test_full} PROPERTIES
-          LABEL "${_category}"
-          TIMEOUT ${TEST_TIME_LIMIT}
           FIXTURES_REQUIRED ${_test_executable_full}
-          )
-
-      else()
-
-        add_test(NAME ${_test_full}
-          COMMAND ${CMAKE_COMMAND}
-            -DTRGT=${_test_target}
-            -DTEST=${_test_full}
-            -DEXPECT=${_expect}
-            -DBINARY_DIR=${CMAKE_BINARY_DIR}
-            -P ${DEAL_II_PATH}/${DEAL_II_SHARE_RELDIR}/scripts/run_test.cmake
-          WORKING_DIRECTORY ${_test_directory}
-          )
-        set_tests_properties(${_test_full} PROPERTIES
-          LABEL "${_category}"
-          TIMEOUT ${TEST_TIME_LIMIT}
           )
       endif()
 

--- a/cmake/macros/macro_deal_ii_add_test.cmake
+++ b/cmake/macros/macro_deal_ii_add_test.cmake
@@ -601,25 +601,10 @@ function(deal_ii_add_test _category _test_name _comparison_file)
         #
         set_tests_properties(${_test_full} PROPERTIES RUN_SERIAL TRUE)
 
-      elseif(NOT ENABLE_PERFORMANCE_TESTS)
-        #
-        # Limit concurrency of mpi tests. We can only set concurrency for
-        # the entire test, which includes the compiling and linking stages
-        # that are purely sequential. There is no good way to model this
-        # without unnecessarily restricting concurrency. Consequently, we
-        # just choose to model an "average" concurrency as one half of the
-        # number of MPI jobs.
-        #
-        if(_n_cpu GREATER 2)
-          math(EXPR _slots "${_n_cpu} / 2")
-          set_tests_properties(${_test_full} PROPERTIES PROCESSORS ${_slots})
-        endif()
-
       else()
         #
-        # In case ENABLE_PERFORMANCE_TESTS is set we limit the concurrency
-        # of performance tests to the number of specified mpi ranks times
-        # the number of specified threads.
+        # Limit concurrency of tests that run on multiple mpi ranks, or
+        # that explicitly spawn multiple worker threads.
         #
         set(_slots 1)
         if(_n_cpu GREATER 0)

--- a/cmake/scripts/run_test.cmake
+++ b/cmake/scripts/run_test.cmake
@@ -27,26 +27,6 @@
 #            (return value 0)
 #            Possible values are CONFIGURE, BUILD, RUN, DIFF, PASSED
 #
-#   GUARD_FILE - used to detect a forced interruption of this script: On
-#                startup the backed up file ${GUARD_FILE}_bck is put back
-#                in place as ${GUARD_FILE} and on exit ${GUARD_FILE} is
-#                backed up as ${GUARD_FILE}_bck. If on startup a stale
-#                ${GUARD_FILE} is found, it is deleted.
-#
-
-if(NOT "${GUARD_FILE}" STREQUAL "" AND EXISTS ${GUARD_FILE})
-  #
-  # Guard file still exists, so this script must have been interrupted.
-  # Remove guard file to force a complete rerun:
-  #
-  execute_process(COMMAND rm -f ${GUARD_FILE})
-elseif(NOT "${GUARD_FILE}" STREQUAL "" AND EXISTS ${GUARD_FILE}_bck)
-  #
-  # A backed up guard file exists. Put it back in place:
-  #
-  execute_process(COMMAND mv ${GUARD_FILE}_bck ${GUARD_FILE})
-endif()
-
 
 if("${EXPECT}" STREQUAL "")
   set(EXPECT "PASSED")
@@ -126,14 +106,6 @@ else()
 endif()
 
 message("===============================    OUTPUT END   ===============================")
-
-#
-# Back up guard file:
-#
-
-if(NOT "${GUARD_FILE}" STREQUAL "" AND EXISTS ${GUARD_FILE})
-  execute_process(COMMAND mv ${GUARD_FILE} ${GUARD_FILE}_bck)
-endif()
 
 #
 # Bail out:


### PR DESCRIPTION
In order to make this possible we define an *additional* test (and test target) that depends on the executable target and ensures that the target is in place before it is called concurrently.

I have also remove the `interrupt_guard.cc` logic. I think this worked around a bug with CMake targets that an interrupt would nevertheless create a partial `output` file and then a subsequent diff failed. In any case, I was not able to trigger this issue any more so I have removed the logic.

Fixes #14648