### PR TITLE
Make ensure_kokkos_initialized thread-safe

### DIFF
--- a/source/base/kokkos.cc
+++ b/source/base/kokkos.cc
@@ -31,9 +31,14 @@ namespace internal
   {
     if (!Kokkos::is_initialized())
       {
-        dealii_initialized_kokkos = true;
-        Kokkos::initialize();
-        std::atexit(Kokkos::finalize);
+        // only execute once
+        static bool dummy = [] {
+          dealii_initialized_kokkos = true;
+          Kokkos::initialize();
+          std::atexit(Kokkos::finalize);
+          return true;
+        }();
+        (void)dummy;
       }
   }
 } // namespace internal


### PR DESCRIPTION
Related to #14641 and #14705. It became clear that `ensure_kokkos_initialized` also needs to be made thread-safe (even if there still seems to be another issue with older `Kokkos` versions for the `OpenMP` backend).