### PR TITLE
Add explicit instantiations for VectorTools::get_position_vector overload

### DIFF
--- a/source/numerics/vector_tools_interpolate.inst.in
+++ b/source/numerics/vector_tools_interpolate.inst.in
@@ -56,6 +56,13 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
 
       template void
       get_position_vector(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        VEC &,
+        const ComponentMask &);
+
+      template void
+      get_position_vector(
         const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
         VEC &,
         const ComponentMask &);


### PR DESCRIPTION
I need this for `vector_tools/get_position_vector_01.debug` to pass locally.