### PR TITLE
Use initlog() in more tests.

### DIFF
--- a/tests/bits/step-10-high-order.cc
+++ b/tests/bits/step-10-high-order.cc
@@ -20,10 +20,6 @@
 // that things still work for very high order
 
 
-#include "../tests.h"
-std::ofstream logfile("output");
-
-
 #include <deal.II/base/convergence_table.h>
 #include <deal.II/base/quadrature_lib.h>
 
@@ -41,6 +37,8 @@ std::ofstream logfile("output");
 #include <deal.II/grid/tria_iterator.h>
 
 #include <deal.II/hp/fe_values.h>
+
+#include "../tests.h"
 
 
 const long double pi = 3.141592653589793238462643;
@@ -180,10 +178,10 @@ compute_pi_by_perimeter()
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(16);
-  logfile << std::setprecision(16);
+  deallog.get_file_stream() << std::setprecision(16);
 
-  deallog.attach(logfile);
 
   compute_pi_by_area<2>();
   compute_pi_by_perimeter<2>();

--- a/tests/bits/step-10.cc
+++ b/tests/bits/step-10.cc
@@ -18,10 +18,6 @@
 // a un-hp-ified version of hp/step-10
 
 
-#include "../tests.h"
-std::ofstream logfile("output");
-
-
 #include <deal.II/base/convergence_table.h>
 #include <deal.II/base/quadrature_lib.h>
 
@@ -39,6 +35,8 @@ std::ofstream logfile("output");
 #include <deal.II/grid/tria_iterator.h>
 
 #include <deal.II/hp/fe_values.h>
+
+#include "../tests.h"
 
 
 const long double pi = 3.141592653589793238462643;
@@ -223,10 +221,10 @@ compute_pi_by_perimeter()
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(6);
-  logfile << std::setprecision(6);
+  deallog.get_file_stream() << std::setprecision(6);
 
-  deallog.attach(logfile);
 
   gnuplot_output<2>();
 

--- a/tests/bits/step-12.cc
+++ b/tests/bits/step-12.cc
@@ -18,9 +18,6 @@
 // a un-hp-ified version of hp/step-12
 
 
-#include "../tests.h"
-std::ofstream logfile("output");
-
 #include <deal.II/base/function.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/timer.h>
@@ -47,6 +44,8 @@ std::ofstream logfile("output");
 
 #include <deal.II/numerics/data_out.h>
 #include <deal.II/numerics/derivative_approximation.h>
+
+#include "../tests.h"
 
 
 
@@ -877,12 +876,12 @@ DGMethod<dim>::run()
 int
 main()
 {
+  initlog();
   try
     {
       deallog << std::setprecision(2);
-      logfile << std::setprecision(2);
+      deallog.get_file_stream() << std::setprecision(2);
 
-      deallog.attach(logfile);
 
       DGMethod<2> dgmethod;
       dgmethod.run();

--- a/tests/bits/step-2.cc
+++ b/tests/bits/step-2.cc
@@ -36,9 +36,6 @@
 
 
 
-std::ofstream logfile("output");
-
-
 void
 make_grid(Triangulation<2> &triangulation)
 {
@@ -111,9 +108,9 @@ renumber_dofs(DoFHandler<2> &dof_handler)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(2);
 
-  deallog.attach(logfile);
 
   Triangulation<2> triangulation;
   make_grid(triangulation);

--- a/tests/bits/step-3.cc
+++ b/tests/bits/step-3.cc
@@ -46,10 +46,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
-
-
 class LaplaceProblem
 {
 public:
@@ -217,10 +213,10 @@ LaplaceProblem::run()
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
+  deallog.get_file_stream() << std::setprecision(2);
 
-  deallog.attach(logfile);
 
   LaplaceProblem laplace_problem;
   laplace_problem.run();

--- a/tests/bits/subdomain_ids_01.cc
+++ b/tests/bits/subdomain_ids_01.cc
@@ -34,9 +34,6 @@
 #include "../tests.h"
 
 
-std::ofstream logfile("output");
-
-
 template <int dim>
 void
 test()
@@ -89,8 +86,8 @@ test()
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(4);
-  deallog.attach(logfile);
 
   test<1>();
   test<2>();

--- a/tests/bits/subdomain_ids_02.cc
+++ b/tests/bits/subdomain_ids_02.cc
@@ -34,9 +34,6 @@
 #include "../tests.h"
 
 
-std::ofstream logfile("output");
-
-
 template <int dim>
 void
 test()
@@ -99,8 +96,8 @@ test()
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(4);
-  deallog.attach(logfile);
 
   test<1>();
   test<2>();

--- a/tests/bits/subdomain_ids_03.cc
+++ b/tests/bits/subdomain_ids_03.cc
@@ -35,9 +35,6 @@
 #include "../tests.h"
 
 
-std::ofstream logfile("output");
-
-
 template <int dim>
 void
 test()
@@ -83,8 +80,8 @@ test()
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(4);
-  deallog.attach(logfile);
 
   test<1>();
   test<2>();

--- a/tests/bits/subdomain_ids_04.cc
+++ b/tests/bits/subdomain_ids_04.cc
@@ -35,9 +35,6 @@
 #include "../tests.h"
 
 
-std::ofstream logfile("output");
-
-
 template <int dim>
 void
 test()
@@ -104,8 +101,8 @@ test()
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(4);
-  deallog.attach(logfile);
 
   test<1>();
   test<2>();

--- a/tests/bits/subdomain_ids_05.cc
+++ b/tests/bits/subdomain_ids_05.cc
@@ -34,9 +34,6 @@
 #include "../tests.h"
 
 
-std::ofstream logfile("output");
-
-
 template <int dim>
 void
 test()
@@ -91,8 +88,8 @@ test()
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(4);
-  deallog.attach(logfile);
 
   test<1>();
   test<2>();

--- a/tests/bits/subdomain_ids_06.cc
+++ b/tests/bits/subdomain_ids_06.cc
@@ -35,9 +35,6 @@
 #include "../tests.h"
 
 
-std::ofstream logfile("output");
-
-
 template <int dim>
 void
 test()
@@ -93,8 +90,8 @@ test()
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(4);
-  deallog.attach(logfile);
 
   test<1>();
   test<2>();

--- a/tests/bits/subdomain_ids_07.cc
+++ b/tests/bits/subdomain_ids_07.cc
@@ -34,9 +34,6 @@
 #include "../tests.h"
 
 
-std::ofstream logfile("output");
-
-
 template <int dim>
 void
 test()
@@ -94,8 +91,8 @@ test()
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(4);
-  deallog.attach(logfile);
 
   test<1>();
   test<2>();

--- a/tests/dofs/dof_test.cc
+++ b/tests/dofs/dof_test.cc
@@ -41,9 +41,6 @@
 // 2: refinement of the circle at the boundary
 // 2: refinement of a wiggled area at the boundary
 
-std::ofstream logfile("output");
-
-
 template <int dim>
 class Ball : public FlatManifold<dim>
 {
@@ -325,7 +322,7 @@ TestCases<dim>::run(const unsigned int test_case)
   int unconstrained_bandwidth = sparsity.bandwidth();
 
   deallog << "    Writing sparsity pattern..." << std::endl;
-  sparsity.print_gnuplot(logfile);
+  sparsity.print_gnuplot(deallog.get_file_stream());
 
 
   // computing constraints
@@ -336,7 +333,7 @@ TestCases<dim>::run(const unsigned int test_case)
   constraints.condense(sparsity);
 
   deallog << "    Writing condensed sparsity pattern..." << std::endl;
-  sparsity.print_gnuplot(logfile);
+  sparsity.print_gnuplot(deallog.get_file_stream());
 
 
   deallog << std::endl
@@ -364,7 +361,7 @@ TestCases<dim>::run(const unsigned int test_case)
 int
 main()
 {
-  deallog.attach(logfile);
+  initlog();
 
   for (unsigned int test_case = 1; test_case <= 2; ++test_case)
     {

--- a/tests/dofs/dof_tools_21_b.cc
+++ b/tests/dofs/dof_tools_21_b.cc
@@ -32,9 +32,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
-
 //
 // Test
 //   DoFTools::
@@ -361,9 +358,9 @@ print_matching(DoFHandler<dim, spacedim> &dof_handler,
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(4);
-  logfile << std::setprecision(4);
-  deallog.attach(logfile);
+  deallog.get_file_stream() << std::setprecision(4);
 
   deallog << "Test for 2D, Q1:" << std::endl << std::endl;
 

--- a/tests/dofs/dof_tools_21_b_x.cc
+++ b/tests/dofs/dof_tools_21_b_x.cc
@@ -45,10 +45,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
-
-
 /*
  * Generate a grid consisting of two disjoint cells, colorize the two
  * outermost faces. They will be matched via collect_periodic_faces
@@ -223,9 +219,9 @@ print_matching(DoFHandler<dim, spacedim> &dof_handler)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(4);
-  logfile << std::setprecision(4);
-  deallog.attach(logfile);
+  deallog.get_file_stream() << std::setprecision(4);
 
   {
     // Generate a triangulation and match:

--- a/tests/dofs/dof_tools_21_b_x_q3.cc
+++ b/tests/dofs/dof_tools_21_b_x_q3.cc
@@ -79,10 +79,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
-
-
 /*
  * Generate a grid consisting of two disjoint cells, colorize the two
  * outermost faces. They will be matched via collect_periodic_faces
@@ -257,9 +253,9 @@ print_matching(DoFHandler<dim, spacedim> &dof_handler)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(4);
-  logfile << std::setprecision(4);
-  deallog.attach(logfile);
+  deallog.get_file_stream() << std::setprecision(4);
 
   {
     // Generate a triangulation and match:

--- a/tests/dofs/dof_tools_21_b_y.cc
+++ b/tests/dofs/dof_tools_21_b_y.cc
@@ -43,10 +43,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
-
-
 /*
  * Generate a grid consisting of two disjoint cells, colorize the two
  * outermost faces. They will be matched via collect_periodic_faces
@@ -223,9 +219,9 @@ print_matching(DoFHandler<dim, spacedim> &dof_handler)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(4);
-  logfile << std::setprecision(4);
-  deallog.attach(logfile);
+  deallog.get_file_stream() << std::setprecision(4);
 
   {
     // Generate a triangulation and match:

--- a/tests/dofs/dof_tools_21_c.cc
+++ b/tests/dofs/dof_tools_21_c.cc
@@ -32,9 +32,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
-
 //
 // Test
 //   DoFTools::
@@ -367,9 +364,9 @@ print_matching(DoFHandler<dim, spacedim> &dof_handler,
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(4);
-  logfile << std::setprecision(4);
-  deallog.attach(logfile);
+  deallog.get_file_stream() << std::setprecision(4);
 
   deallog << "Test for 2D, Q1:" << std::endl << std::endl;
 

--- a/tests/fail/abf_approximation_01.cc
+++ b/tests/fail/abf_approximation_01.cc
@@ -29,8 +29,6 @@
 #define PRECISION 2
 
 
-std::ofstream logfile("output");
-
 char buf[1000];
 
 
@@ -428,9 +426,9 @@ TestProjection(Mapping<2> &mapping, DoFHandler<2> *dof_handler)
 int
 main()
 {
-  logfile.precision(PRECISION);
-  logfile.setf(std::ios::fixed);
-  deallog.attach(logfile);
+  initlog();
+  deallog.get_file_stream().precision(PRECISION);
+  deallog.get_file_stream().setf(std::ios::fixed);
 
   Triangulation<2> tria_test;
   DoFHandler<2> *  dof_handler, *dof_handler_def;

--- a/tests/fail/rt_distorted_01.cc
+++ b/tests/fail/rt_distorted_01.cc
@@ -26,9 +26,6 @@
 #define PRECISION 2
 
 
-std::ofstream logfile("output");
-
-
 #include <deal.II/base/function.h>
 #include <deal.II/base/numbers.h>
 #include <deal.II/base/quadrature_lib.h>
@@ -312,9 +309,9 @@ EvaluateArea(Mapping<2> &    mapping,
 int
 main(int /*argc*/, char ** /*argv*/)
 {
-  logfile.precision(PRECISION);
-  logfile.setf(std::ios::fixed);
-  deallog.attach(logfile);
+  initlog();
+  deallog.get_file_stream().precision(PRECISION);
+  deallog.get_file_stream().setf(std::ios::fixed);
 
   Triangulation<2> tria_test;
   DoFHandler<2> *  dof_handler, *dof_handler_def;

--- a/tests/fail/rt_distorted_02.cc
+++ b/tests/fail/rt_distorted_02.cc
@@ -26,8 +26,6 @@
 #define PRECISION 2
 
 
-std::ofstream logfile("output");
-
 char buf[1000];
 
 
@@ -329,9 +327,9 @@ EvaluateDiver(Mapping<2> &    mapping,
 int
 main()
 {
-  logfile.precision(PRECISION);
-  logfile.setf(std::ios::fixed);
-  deallog.attach(logfile);
+  initlog();
+  deallog.get_file_stream().precision(PRECISION);
+  deallog.get_file_stream().setf(std::ios::fixed);
 
   Triangulation<2> tria_test;
   Point<2>         p1(0, 0), p2(1, 1);

--- a/tests/fe/bdm_10.cc
+++ b/tests/fe/bdm_10.cc
@@ -44,8 +44,6 @@
 #define PRECISION 2
 
 
-std::ofstream logfile("output");
-
 template <int dim>
 void
 test(const unsigned int degree)
@@ -87,9 +85,9 @@ test(const unsigned int degree)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(PRECISION);
   deallog << std::fixed;
-  deallog.attach(logfile);
 
   for (unsigned int i = 1; i < 4; ++i)
     test<2>(i);

--- a/tests/fe/bdm_11.cc
+++ b/tests/fe/bdm_11.cc
@@ -50,8 +50,6 @@
 #define PRECISION 2
 
 
-std::ofstream logfile("output");
-
 template <int dim>
 void
 test(const unsigned int degree)
@@ -93,9 +91,9 @@ test(const unsigned int degree)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(PRECISION);
   deallog << std::fixed;
-  deallog.attach(logfile);
 
   for (unsigned int i = 1; i < 4; ++i)
     test<2>(i);

--- a/tests/fe/bdm_12.cc
+++ b/tests/fe/bdm_12.cc
@@ -43,8 +43,6 @@
 #define PRECISION 2
 
 
-std::ofstream logfile("output");
-
 template <int dim>
 void
 test(const unsigned int degree)
@@ -86,9 +84,9 @@ test(const unsigned int degree)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(PRECISION);
   deallog << std::fixed;
-  deallog.attach(logfile);
 
   for (unsigned int i = 1; i < 4; ++i)
     test<2>(i);

--- a/tests/fe/bdm_13.cc
+++ b/tests/fe/bdm_13.cc
@@ -48,8 +48,6 @@
 #define PRECISION 2
 
 
-std::ofstream logfile("output");
-
 template <int dim>
 void
 test(const unsigned int degree)
@@ -91,9 +89,9 @@ test(const unsigned int degree)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(PRECISION);
   deallog << std::fixed;
-  deallog.attach(logfile);
 
   for (unsigned int i = 1; i < 4; ++i)
     test<2>(i);

--- a/tests/fe/bdm_14.cc
+++ b/tests/fe/bdm_14.cc
@@ -48,8 +48,6 @@
 #define PRECISION 2
 
 
-std::ofstream logfile("output");
-
 template <int dim>
 void
 test(const unsigned int degree)
@@ -91,9 +89,9 @@ test(const unsigned int degree)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(PRECISION);
   deallog << std::fixed;
-  deallog.attach(logfile);
 
   for (unsigned int i = 1; i < 4; ++i)
     test<2>(i);

--- a/tests/fe/bdm_15.cc
+++ b/tests/fe/bdm_15.cc
@@ -48,8 +48,6 @@
 #define PRECISION 2
 
 
-std::ofstream logfile("output");
-
 template <int dim>
 void
 test(const unsigned int degree)
@@ -91,9 +89,9 @@ test(const unsigned int degree)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(PRECISION);
   deallog << std::fixed;
-  deallog.attach(logfile);
 
   for (unsigned int i = 1; i < 4; ++i)
     test<2>(i);

--- a/tests/fe/bdm_16.cc
+++ b/tests/fe/bdm_16.cc
@@ -30,8 +30,6 @@
 #include "../tests.h"
 
 
-std::ofstream logfile("output");
-
 template <int dim>
 void
 test(const unsigned int degree)

--- a/tests/fe/bdm_8.cc
+++ b/tests/fe/bdm_8.cc
@@ -42,8 +42,6 @@
 #define PRECISION 5
 
 
-std::ofstream logfile("output");
-
 template <int dim>
 void
 test(const unsigned int degree)
@@ -76,7 +74,7 @@ test(const unsigned int degree)
             (fe.shape_value_component(i, q_point, d) *
              fe.shape_value_component(j, q_point, d) * fe.JxW(q_point));
 
-  mass_matrix.print_formatted(logfile, 3, false, 0, "0", 1);
+  mass_matrix.print_formatted(deallog.get_file_stream(), 3, false, 0, "0", 1);
 
   SolverControl           solver_control(2 * dofs_per_cell, 1e-8);
   PrimitiveVectorMemory<> vector_memory;
@@ -98,9 +96,9 @@ test(const unsigned int degree)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(PRECISION);
   deallog << std::fixed;
-  deallog.attach(logfile);
 
   for (unsigned int i = 1; i < 4; ++i)
     {

--- a/tests/fe/bdm_9.cc
+++ b/tests/fe/bdm_9.cc
@@ -45,8 +45,6 @@
 #define PRECISION 2
 
 
-std::ofstream logfile("output");
-
 template <int dim>
 void
 test(const unsigned int degree)
@@ -72,7 +70,7 @@ test(const unsigned int degree)
 
   MatrixTools::create_mass_matrix(dof, q, mass_matrix);
 
-  mass_matrix.print_formatted(logfile, 3, false, 0, "0", 1);
+  mass_matrix.print_formatted(deallog.get_file_stream(), 3, false, 0, "0", 1);
 
   SolverControl           solver_control(3 * dofs_per_cell, 1e-8);
   PrimitiveVectorMemory<> vector_memory;
@@ -94,9 +92,9 @@ test(const unsigned int degree)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(PRECISION);
   deallog << std::fixed;
-  deallog.attach(logfile);
 
   for (unsigned int i = 1; i < 4; ++i)
     {

--- a/tests/fe/br_approximation_01.cc
+++ b/tests/fe/br_approximation_01.cc
@@ -27,9 +27,6 @@
 #define PRECISION 8
 
 
-std::ofstream logfile("output");
-
-
 #include <deal.II/base/function.h>
 #include <deal.II/base/quadrature_lib.h>
 
@@ -413,11 +410,11 @@ TestProjection(Mapping<2> &mapping, DoFHandler<2> *dof_handler)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(PRECISION);
   deallog << std::fixed;
-  logfile << std::setprecision(PRECISION);
-  logfile << std::fixed;
-  deallog.attach(logfile);
+  deallog.get_file_stream() << std::setprecision(PRECISION);
+  deallog.get_file_stream() << std::fixed;
 
   Triangulation<2> tria_test;
   DoFHandler<2> *  dof_handler, *dof_handler_def;

--- a/tests/fe/numbering.cc
+++ b/tests/fe/numbering.cc
@@ -22,9 +22,6 @@
 #include "../tests.h"
 
 
-std::ofstream logfile("output");
-
-
 template <int dim>
 void
 check(const FE_Q<dim> &fe)
@@ -240,8 +237,9 @@ check(const FE_Q<dim> &fe)
     {
       Assert(l2h[hierarchic_to_lexicographic_numbering[i]] == i,
              ExcInternalError());
-      logfile << dim << "d, degree=" << degree << ": " << l2h[i] << ' '
-              << hierarchic_to_lexicographic_numbering[i] << std::endl;
+      deallog.get_file_stream()
+        << dim << "d, degree=" << degree << ": " << l2h[i] << ' '
+        << hierarchic_to_lexicographic_numbering[i] << std::endl;
     };
 
   // finally, we also have the
@@ -269,9 +267,9 @@ check_dim()
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(2);
   deallog << std::fixed;
-  deallog.attach(logfile);
 
   check_dim<1>();
   check_dim<2>();

--- a/tests/fe/rt_10.cc
+++ b/tests/fe/rt_10.cc
@@ -44,8 +44,6 @@
 #define PRECISION 8
 
 
-std::ofstream logfile("output");
-
 template <int dim>
 void
 test(const unsigned int degree)
@@ -87,9 +85,9 @@ test(const unsigned int degree)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(PRECISION);
   deallog << std::fixed;
-  deallog.attach(logfile);
 
   for (unsigned int i = 0; i < 4; ++i)
     test<2>(i);

--- a/tests/fe/rt_11.cc
+++ b/tests/fe/rt_11.cc
@@ -50,8 +50,6 @@
 #define PRECISION 8
 
 
-std::ofstream logfile("output");
-
 template <int dim>
 void
 test(const unsigned int degree)
@@ -93,9 +91,9 @@ test(const unsigned int degree)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(PRECISION);
   deallog << std::fixed;
-  deallog.attach(logfile);
 
   for (unsigned int i = 0; i < 4; ++i)
     test<2>(i);

--- a/tests/fe/rt_12.cc
+++ b/tests/fe/rt_12.cc
@@ -43,8 +43,6 @@
 #define PRECISION 8
 
 
-std::ofstream logfile("output");
-
 template <int dim>
 void
 test(const unsigned int degree)
@@ -86,9 +84,9 @@ test(const unsigned int degree)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(PRECISION);
   deallog << std::fixed;
-  deallog.attach(logfile);
 
   for (unsigned int i = 0; i < 4; ++i)
     test<2>(i);

--- a/tests/fe/rt_13.cc
+++ b/tests/fe/rt_13.cc
@@ -48,8 +48,6 @@
 #define PRECISION 8
 
 
-std::ofstream logfile("output");
-
 template <int dim>
 void
 test(const unsigned int degree)
@@ -91,9 +89,9 @@ test(const unsigned int degree)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(PRECISION);
   deallog << std::fixed;
-  deallog.attach(logfile);
 
   for (unsigned int i = 0; i < 4; ++i)
     test<2>(i);

--- a/tests/fe/rt_14.cc
+++ b/tests/fe/rt_14.cc
@@ -48,8 +48,6 @@
 #define PRECISION 8
 
 
-std::ofstream logfile("output");
-
 template <int dim>
 void
 test(const unsigned int degree)
@@ -91,9 +89,9 @@ test(const unsigned int degree)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(PRECISION);
   deallog << std::fixed;
-  deallog.attach(logfile);
 
   for (unsigned int i = 0; i < 4; ++i)
     test<2>(i);

--- a/tests/fe/rt_15.cc
+++ b/tests/fe/rt_15.cc
@@ -48,8 +48,6 @@
 #define PRECISION 8
 
 
-std::ofstream logfile("output");
-
 template <int dim>
 void
 test(const unsigned int degree)
@@ -91,9 +89,9 @@ test(const unsigned int degree)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(PRECISION);
   deallog << std::fixed;
-  deallog.attach(logfile);
 
   for (unsigned int i = 0; i < 4; ++i)
     test<2>(i);

--- a/tests/fe/rt_8.cc
+++ b/tests/fe/rt_8.cc
@@ -42,8 +42,6 @@
 #define PRECISION 8
 
 
-std::ofstream logfile("output");
-
 template <int dim>
 void
 test(const unsigned int degree)
@@ -79,7 +77,7 @@ test(const unsigned int degree)
     for (unsigned int j = 0; j < dofs_per_cell; ++j)
       if (std::fabs(mass_matrix(i, j)) < 1e-14)
         mass_matrix(i, j) = 0;
-  mass_matrix.print_formatted(logfile, 3, false, 0, " ", 1);
+  mass_matrix.print_formatted(deallog.get_file_stream(), 3, false, 0, " ", 1);
 
   SolverControl           solver_control(dofs_per_cell, 1e-8);
   PrimitiveVectorMemory<> vector_memory;
@@ -98,9 +96,9 @@ test(const unsigned int degree)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(PRECISION);
   deallog << std::fixed;
-  deallog.attach(logfile);
 
   for (unsigned int i = 0; i < 4; ++i)
     test<2>(i);

--- a/tests/fe/rt_9.cc
+++ b/tests/fe/rt_9.cc
@@ -45,8 +45,6 @@
 #define PRECISION 8
 
 
-std::ofstream logfile("output");
-
 template <int dim>
 void
 test(const unsigned int degree)
@@ -72,7 +70,7 @@ test(const unsigned int degree)
 
   MatrixTools::create_mass_matrix(dof, q, mass_matrix);
 
-  mass_matrix.print_formatted(logfile, 3, false, 0, " ", 1);
+  mass_matrix.print_formatted(deallog.get_file_stream(), 3, false, 0, " ", 1);
 
   SolverControl           solver_control(dofs_per_cell, 1e-8);
   PrimitiveVectorMemory<> vector_memory;
@@ -91,9 +89,9 @@ test(const unsigned int degree)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(PRECISION);
   deallog << std::fixed;
-  deallog.attach(logfile);
 
   for (unsigned int i = 0; i < 4; ++i)
     test<2>(i);

--- a/tests/fe/rt_approximation_01.cc
+++ b/tests/fe/rt_approximation_01.cc
@@ -29,9 +29,6 @@
 #define PRECISION 8
 
 
-std::ofstream logfile("output");
-
-
 #include <deal.II/base/function.h>
 #include <deal.II/base/quadrature_lib.h>
 
@@ -425,11 +422,11 @@ TestProjection(Mapping<2> &mapping, DoFHandler<2> *dof_handler)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(PRECISION);
   deallog << std::fixed;
-  logfile << std::setprecision(PRECISION);
-  logfile << std::fixed;
-  deallog.attach(logfile);
+  deallog.get_file_stream() << std::setprecision(PRECISION);
+  deallog.get_file_stream() << std::fixed;
 
   Triangulation<2> tria_test;
   DoFHandler<2> *  dof_handler, *dof_handler_def;

--- a/tests/fe/rt_bubbles_10.cc
+++ b/tests/fe/rt_bubbles_10.cc
@@ -44,8 +44,6 @@
 #define PRECISION 5
 
 
-std::ofstream logfile("output");
-
 template <int dim>
 void
 test(const unsigned int degree)
@@ -88,9 +86,9 @@ test(const unsigned int degree)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(PRECISION);
   deallog << std::fixed;
-  deallog.attach(logfile);
 
   for (unsigned int i = 1; i < 4; ++i)
     {

--- a/tests/fe/rt_bubbles_11.cc
+++ b/tests/fe/rt_bubbles_11.cc
@@ -45,8 +45,6 @@
 #define PRECISION 5
 
 
-std::ofstream logfile("output");
-
 template <int dim>
 void
 test(const unsigned int degree)
@@ -89,9 +87,9 @@ test(const unsigned int degree)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(PRECISION);
   deallog << std::fixed;
-  deallog.attach(logfile);
 
   for (unsigned int i = 1; i < 4; ++i)
     {

--- a/tests/fe/rt_bubbles_16.cc
+++ b/tests/fe/rt_bubbles_16.cc
@@ -26,8 +26,6 @@
 #include "../tests.h"
 
 
-std::ofstream logfile("output");
-
 template <int dim>
 void
 test(const unsigned int degree)

--- a/tests/fe/rt_bubbles_8.cc
+++ b/tests/fe/rt_bubbles_8.cc
@@ -41,8 +41,6 @@
 #define PRECISION 5
 
 
-std::ofstream logfile("output");
-
 template <int dim>
 void
 test(const unsigned int degree)
@@ -75,7 +73,7 @@ test(const unsigned int degree)
             (fe.shape_value_component(i, q_point, d) *
              fe.shape_value_component(j, q_point, d) * fe.JxW(q_point));
 
-  mass_matrix.print_formatted(logfile, 3, false, 0, "0", 1);
+  mass_matrix.print_formatted(deallog.get_file_stream(), 3, false, 0, "0", 1);
 
   SolverControl           solver_control(2 * dofs_per_cell, 1e-8);
   PrimitiveVectorMemory<> vector_memory;
@@ -98,9 +96,9 @@ test(const unsigned int degree)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(PRECISION);
   deallog << std::fixed;
-  deallog.attach(logfile);
 
   for (unsigned int i = 1; i < 4; ++i)
     {

--- a/tests/fe/rt_bubbles_9.cc
+++ b/tests/fe/rt_bubbles_9.cc
@@ -46,8 +46,6 @@
 #define PRECISION 5
 
 
-std::ofstream logfile("output");
-
 template <int dim>
 void
 test(const unsigned int degree)
@@ -73,7 +71,7 @@ test(const unsigned int degree)
 
   MatrixTools::create_mass_matrix(dof, q, mass_matrix);
 
-  mass_matrix.print_formatted(logfile, 3, false, 0, "0", 1);
+  mass_matrix.print_formatted(deallog.get_file_stream(), 3, false, 0, "0", 1);
 
   SolverControl           solver_control(3 * dofs_per_cell, 1e-8);
   PrimitiveVectorMemory<> vector_memory;
@@ -96,9 +94,9 @@ test(const unsigned int degree)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(PRECISION);
   deallog << std::fixed;
-  deallog.attach(logfile);
 
   for (unsigned int i = 1; i < 4; ++i)
     {

--- a/tests/fe/rt_normal_02.cc
+++ b/tests/fe/rt_normal_02.cc
@@ -53,9 +53,6 @@
 #include <deal.II/numerics/data_out.h>
 #include <deal.II/numerics/vector_tools.h>
 
-std::ofstream logfile("output");
-
-
 /*
  * Check if the normal component is continuous over element edges.
  */
@@ -254,9 +251,9 @@ EvaluateNormal(DoFHandler<2> *dof_handler, Vector<double> &solution)
 int
 main(int /*argc*/, char ** /*argv*/)
 {
+  initlog();
   deallog << std::setprecision(PRECISION);
   deallog << std::fixed;
-  deallog.attach(logfile);
 
   Triangulation<2>          tria_test;
   DoFHandler<2> *           dof_handler;

--- a/tests/grid/grid_generator_non_standard_orientation_mesh_2d.cc
+++ b/tests/grid/grid_generator_non_standard_orientation_mesh_2d.cc
@@ -30,8 +30,6 @@
 // STL
 #include <map>
 
-std::ofstream logfile("output");
-
 using namespace dealii;
 
 template <int dim>
@@ -69,9 +67,9 @@ plot_all_info(const Triangulation<dim> &tria)
 int
 main(int /*argc*/, char ** /*argv*/)
 {
+  initlog();
   deallog << std::setprecision(PRECISION);
   deallog << std::fixed;
-  deallog.attach(logfile);
 
   /*
    * 2D test only

--- a/tests/grid/grid_generator_non_standard_orientation_mesh_3d.cc
+++ b/tests/grid/grid_generator_non_standard_orientation_mesh_3d.cc
@@ -30,9 +30,6 @@
 // STL
 #include <map>
 
-std::ofstream logfile("output");
-
-
 using namespace dealii;
 
 template <int dim>
@@ -71,9 +68,9 @@ plot_all_info(const Triangulation<dim> &tria)
 int
 main(int /*argc*/, char ** /*argv*/)
 {
+  initlog();
   deallog << std::setprecision(PRECISION);
   deallog << std::fixed;
-  deallog.attach(logfile);
 
   /*
    * 3D test only

--- a/tests/lac/constraints.cc
+++ b/tests/lac/constraints.cc
@@ -38,9 +38,6 @@
 
 
 
-std::ofstream logfile("output");
-
-
 void
 make_tria(Triangulation<3> &tria, int step)
 {
@@ -251,9 +248,9 @@ make_tria(Triangulation<3> &tria, int step)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
-  deallog.attach(logfile);
+  deallog.get_file_stream() << std::setprecision(2);
 
   FiniteElement<3> *fe = nullptr;
 
@@ -275,7 +272,7 @@ main()
 
           Triangulation<3> tria;
           make_tria(tria, step);
-          GridOut().write_gnuplot(tria, logfile);
+          GridOut().write_gnuplot(tria, deallog.get_file_stream());
 
           DoFHandler<3> dof(tria);
           dof.distribute_dofs(*fe);
@@ -284,7 +281,7 @@ main()
           DoFTools::make_hanging_node_constraints(dof, constraints);
           constraints.close();
 
-          constraints.print(logfile);
+          constraints.print(deallog.get_file_stream());
 
           // release FE
           dof.clear();

--- a/tests/lac/constraints_block_01.cc
+++ b/tests/lac/constraints_block_01.cc
@@ -61,15 +61,12 @@
 
 
 
-std::ofstream logfile("output");
-
-
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
-  deallog.attach(logfile);
+  deallog.get_file_stream() << std::setprecision(2);
 
   // setting up some constants
   const unsigned int dim       = 2;

--- a/tests/lac/constraints_hanging_nodes_bc.cc
+++ b/tests/lac/constraints_hanging_nodes_bc.cc
@@ -44,9 +44,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
-
 template <int dim>
 void
 test()
@@ -147,7 +144,7 @@ test()
 int
 main()
 {
-  deallog.attach(logfile);
+  initlog();
   deallog << std::setprecision(2);
 
   {

--- a/tests/lac/constraints_local_to_global.cc
+++ b/tests/lac/constraints_local_to_global.cc
@@ -45,8 +45,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 template <int dim>
 void
 test()
@@ -121,9 +119,9 @@ test()
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
-  deallog.attach(logfile);
+  deallog.get_file_stream() << std::setprecision(2);
 
   test<2>();
 }

--- a/tests/lac/constraints_local_to_global_chunk.cc
+++ b/tests/lac/constraints_local_to_global_chunk.cc
@@ -46,8 +46,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 template <int dim>
 void
 test(unsigned int chunk_size)
@@ -124,9 +122,9 @@ test(unsigned int chunk_size)
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
-  deallog.attach(logfile);
+  deallog.get_file_stream() << std::setprecision(2);
 
   test<2>(1);
   test<2>(2);

--- a/tests/lac/constraints_merge.cc
+++ b/tests/lac/constraints_merge.cc
@@ -23,9 +23,6 @@
 
 
 
-std::ofstream logfile("output");
-
-
 void
 merge_check()
 {
@@ -72,7 +69,7 @@ merge_check()
       // now merge the two and print the
       // results
       c1.merge(c2);
-      c1.print(logfile);
+      c1.print(deallog.get_file_stream());
     };
 }
 
@@ -80,9 +77,9 @@ merge_check()
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
-  deallog.attach(logfile);
+  deallog.get_file_stream() << std::setprecision(2);
 
   merge_check();
 }

--- a/tests/lac/constraints_merge_02.cc
+++ b/tests/lac/constraints_merge_02.cc
@@ -24,9 +24,6 @@
 
 
 
-std::ofstream logfile("output");
-
-
 void
 merge_check()
 {
@@ -79,7 +76,7 @@ merge_check()
       // now merge the two and print the
       // results
       c1.merge(c2);
-      c1.print(logfile);
+      c1.print(deallog.get_file_stream());
     };
 }
 
@@ -87,9 +84,9 @@ merge_check()
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
-  deallog.attach(logfile);
+  deallog.get_file_stream() << std::setprecision(2);
 
   merge_check();
 }

--- a/tests/lac/constraints_merge_03.cc
+++ b/tests/lac/constraints_merge_03.cc
@@ -24,9 +24,6 @@
 
 
 
-std::ofstream logfile("output");
-
-
 void
 merge_check()
 {
@@ -72,7 +69,7 @@ merge_check()
           deallog << "OK" << std::endl;
         }
 
-      c1.print(logfile);
+      c1.print(deallog.get_file_stream());
     }
 }
 
@@ -80,9 +77,9 @@ merge_check()
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
-  deallog.attach(logfile);
+  deallog.get_file_stream() << std::setprecision(2);
 
   merge_check();
 }

--- a/tests/lac/constraints_merge_04.cc
+++ b/tests/lac/constraints_merge_04.cc
@@ -24,9 +24,6 @@
 
 
 
-std::ofstream logfile("output");
-
-
 void
 merge_check()
 {
@@ -72,7 +69,7 @@ merge_check()
           Assert(false, ExcInternalError());
         }
 
-      c1.print(logfile);
+      c1.print(deallog.get_file_stream());
     }
 }
 
@@ -80,9 +77,9 @@ merge_check()
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
-  deallog.attach(logfile);
+  deallog.get_file_stream() << std::setprecision(2);
 
   merge_check();
 }

--- a/tests/lac/constraints_merge_05.cc
+++ b/tests/lac/constraints_merge_05.cc
@@ -24,9 +24,6 @@
 
 
 
-std::ofstream logfile("output");
-
-
 void
 merge_check()
 {
@@ -72,7 +69,7 @@ merge_check()
           Assert(false, ExcInternalError());
         }
 
-      c1.print(logfile);
+      c1.print(deallog.get_file_stream());
     }
 }
 
@@ -80,9 +77,9 @@ merge_check()
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
-  deallog.attach(logfile);
+  deallog.get_file_stream() << std::setprecision(2);
 
   merge_check();
 }

--- a/tests/lac/constraints_merge_06.cc
+++ b/tests/lac/constraints_merge_06.cc
@@ -26,9 +26,6 @@
 
 
 
-std::ofstream logfile("output");
-
-
 void
 merge_check()
 {
@@ -78,7 +75,7 @@ merge_check()
           Assert(false, ExcInternalError());
         }
 
-      c1.print(logfile);
+      c1.print(deallog.get_file_stream());
     }
 }
 
@@ -86,9 +83,9 @@ merge_check()
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
-  deallog.attach(logfile);
+  deallog.get_file_stream() << std::setprecision(2);
 
   merge_check();
 }

--- a/tests/lac/constraints_merge_07.cc
+++ b/tests/lac/constraints_merge_07.cc
@@ -27,9 +27,6 @@
 
 
 
-std::ofstream logfile("output");
-
-
 void
 merge_check()
 {
@@ -83,7 +80,7 @@ merge_check()
           Assert(false, ExcInternalError());
         }
 
-      c1.print(logfile);
+      c1.print(deallog.get_file_stream());
     }
 }
 
@@ -91,9 +88,9 @@ merge_check()
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
-  deallog.attach(logfile);
+  deallog.get_file_stream() << std::setprecision(2);
 
   merge_check();
 }

--- a/tests/lac/constraints_merge_08.cc
+++ b/tests/lac/constraints_merge_08.cc
@@ -25,9 +25,6 @@
 
 
 
-std::ofstream logfile("output");
-
-
 void
 merge_check()
 {
@@ -103,7 +100,7 @@ merge_check()
       // now merge the two and print the
       // results
       c1.merge(c2);
-      c1.print(logfile);
+      c1.print(deallog.get_file_stream());
     };
 }
 
@@ -111,9 +108,9 @@ merge_check()
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
-  deallog.attach(logfile);
+  deallog.get_file_stream() << std::setprecision(2);
 
   merge_check();
 }

--- a/tests/lac/constraints_merge_09.cc
+++ b/tests/lac/constraints_merge_09.cc
@@ -27,9 +27,6 @@
 
 
 
-std::ofstream logfile("output");
-
-
 void
 merge_check()
 {
@@ -98,7 +95,7 @@ merge_check()
           Assert(false, ExcInternalError());
         }
 
-      c1.print(logfile);
+      c1.print(deallog.get_file_stream());
     }
 }
 
@@ -106,9 +103,9 @@ merge_check()
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
-  deallog.attach(logfile);
+  deallog.get_file_stream() << std::setprecision(2);
 
   merge_check();
 }

--- a/tests/lac/inhomogeneous_constraints.cc
+++ b/tests/lac/inhomogeneous_constraints.cc
@@ -57,9 +57,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
-
 template <int dim>
 class LaplaceProblem
 {
@@ -785,9 +782,9 @@ LaplaceProblem<dim>::estimate_smoothness(
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
-  deallog.attach(logfile);
+  deallog.get_file_stream() << std::setprecision(2);
 
   {
     deallog.push("2d");

--- a/tests/lac/inhomogeneous_constraints_02.cc
+++ b/tests/lac/inhomogeneous_constraints_02.cc
@@ -54,9 +54,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
-
 void
 test(bool use_inhomogeneity_for_rhs)
 {
@@ -70,7 +67,7 @@ test(bool use_inhomogeneity_for_rhs)
   cm.add_entry(4, 2, 2.0);
 
   cm.close();
-  cm.print(logfile);
+  cm.print(deallog.get_file_stream());
 
 
   DynamicSparsityPattern csp(5, 5);
@@ -96,17 +93,17 @@ test(bool use_inhomogeneity_for_rhs)
   cm.distribute_local_to_global(
     local_mat, local_vec, local_dofs, mat, rhs, use_inhomogeneity_for_rhs);
 
-  mat.print(logfile);
-  rhs.print(logfile);
+  mat.print(deallog.get_file_stream());
+  rhs.print(deallog.get_file_stream());
 }
 
 
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
-  deallog.attach(logfile);
+  deallog.get_file_stream() << std::setprecision(2);
 
   // Use the constraints for the right-hand-side
   {

--- a/tests/lac/inhomogeneous_constraints_03.cc
+++ b/tests/lac/inhomogeneous_constraints_03.cc
@@ -58,9 +58,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
-
 void
 test(bool use_inhomogeneity_for_rhs)
 {
@@ -73,7 +70,7 @@ test(bool use_inhomogeneity_for_rhs)
   cm.set_inhomogeneity(4, 1.0);
 
   cm.close();
-  cm.print(logfile);
+  cm.print(deallog.get_file_stream());
 
 
   DynamicSparsityPattern csp(8, 8);
@@ -109,8 +106,8 @@ test(bool use_inhomogeneity_for_rhs)
     local_mat, local_vec, local_dofs2, mat, rhs, use_inhomogeneity_for_rhs);
 
 
-  mat.print(logfile);
-  rhs.print(logfile);
+  mat.print(deallog.get_file_stream());
+  rhs.print(deallog.get_file_stream());
 
   Vector<double> solution(8);
   for (unsigned int i = 0; i < 8; ++i)
@@ -118,18 +115,18 @@ test(bool use_inhomogeneity_for_rhs)
       solution(i) = rhs(i) / mat(i, i);
     }
 
-  solution.print(logfile);
+  solution.print(deallog.get_file_stream());
   cm.distribute(solution);
-  solution.print(logfile);
+  solution.print(deallog.get_file_stream());
 }
 
 
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
-  deallog.attach(logfile);
+  deallog.get_file_stream() << std::setprecision(2);
 
   // Use the constraints for the right-hand-side
   {

--- a/tests/lac/inhomogeneous_constraints_04.cc
+++ b/tests/lac/inhomogeneous_constraints_04.cc
@@ -55,9 +55,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
-
 void
 test(bool use_constraint_matrix)
 {
@@ -101,7 +98,7 @@ test(bool use_constraint_matrix)
       cm.set_inhomogeneity(4, 0.0);
 
       cm.close();
-      cm.print(logfile);
+      cm.print(deallog.get_file_stream());
 
       cm.distribute_local_to_global(
         local_mat, local_vec, local_dofs1, mat, rhs, true);
@@ -132,24 +129,24 @@ test(bool use_constraint_matrix)
       MatrixTools::apply_boundary_values(boundary_values, mat, solution, rhs);
     }
 
-  mat.print(logfile);
-  rhs.print(logfile);
+  mat.print(deallog.get_file_stream());
+  rhs.print(deallog.get_file_stream());
 
   for (unsigned int i = 0; i < 8; ++i)
     {
       solution(i) = rhs(i) / mat(i, i);
     }
 
-  solution.print(logfile);
+  solution.print(deallog.get_file_stream());
 }
 
 
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
-  deallog.attach(logfile);
+  deallog.get_file_stream() << std::setprecision(2);
 
   // Use the constraints for the right-hand-side
   {

--- a/tests/lac/inhomogeneous_constraints_block.cc
+++ b/tests/lac/inhomogeneous_constraints_block.cc
@@ -50,9 +50,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
-
 template <int dim>
 class AdvectionProblem
 {
@@ -524,9 +521,9 @@ AdvectionProblem<dim>::run()
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
-  deallog.attach(logfile);
+  deallog.get_file_stream() << std::setprecision(2);
 
   {
     AdvectionProblem<2> advection_problem;

--- a/tests/lac/inhomogeneous_constraints_nonsymmetric.cc
+++ b/tests/lac/inhomogeneous_constraints_nonsymmetric.cc
@@ -48,9 +48,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
-
 template <int dim>
 class AdvectionProblem
 {
@@ -476,9 +473,9 @@ AdvectionProblem<dim>::run()
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
-  deallog.attach(logfile);
+  deallog.get_file_stream() << std::setprecision(2);
 
   {
     AdvectionProblem<2> advection_problem;

--- a/tests/lac/inhomogeneous_constraints_vector.cc
+++ b/tests/lac/inhomogeneous_constraints_vector.cc
@@ -53,9 +53,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
-
 template <int dim>
 class LaplaceProblem
 {
@@ -319,9 +316,9 @@ LaplaceProblem<dim>::run()
 int
 main()
 {
+  initlog();
   deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
-  deallog.attach(logfile);
+  deallog.get_file_stream() << std::setprecision(2);
 
   LaplaceProblem<2> laplace_problem_2d;
   laplace_problem_2d.run();

--- a/tests/slepc/00.cc
+++ b/tests/slepc/00.cc
@@ -26,36 +26,35 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 int
 main(int argc, char **argv)
 {
-  deallog.attach(logfile);
+  initlog();
   try
     {
-      logfile << "Initializing SLEPc (PETSc): " << std::flush;
+      deallog.get_file_stream() << "Initializing SLEPc (PETSc): " << std::flush;
 
       SlepcInitialize(&argc, &argv, nullptr, nullptr);
       {
-        logfile << "ok" << std::endl;
+        deallog.get_file_stream() << "ok" << std::endl;
 
         // Do something simple with PETSc
-        logfile << "Using PetscScalar:" << std::endl;
+        deallog.get_file_stream() << "Using PetscScalar:" << std::endl;
 
         const PetscScalar pi  = numbers::PI;
         const PetscScalar two = 2.;
 
-        logfile << "   pi:           " << pi << std::endl
-                << "   two:          " << two << std::endl
-                << "   two times pi: " << two * pi << std::endl;
+        deallog.get_file_stream()
+          << "   pi:           " << pi << std::endl
+          << "   two:          " << two << std::endl
+          << "   two times pi: " << two * pi << std::endl;
 
 
-        logfile << "Finalizing SLEPc (PETSc): " << std::flush;
+        deallog.get_file_stream() << "Finalizing SLEPc (PETSc): " << std::flush;
       }
       SlepcFinalize();
 
-      logfile << "ok" << std::endl << std::endl;
+      deallog.get_file_stream() << "ok" << std::endl << std::endl;
     }
 
   catch (std::exception &exc)

--- a/tests/slepc_complex/00.cc
+++ b/tests/slepc_complex/00.cc
@@ -28,38 +28,37 @@
 #include "../tests.h"
 
 
-std::ofstream logfile("output");
-
 int
 main(int argc, char **argv)
 {
-  deallog.attach(logfile);
+  initlog();
   deallog.depth_console(1);
 
   try
     {
-      logfile << "Initializing SLEPc (PETSc): " << std::flush;
+      deallog.get_file_stream() << "Initializing SLEPc (PETSc): " << std::flush;
 
       SlepcInitialize(&argc, &argv, nullptr, nullptr);
       {
-        logfile << "ok" << std::endl;
+        deallog.get_file_stream() << "ok" << std::endl;
 
         // Do something simple with PETSc
-        logfile << "Using PetscScalar:" << std::endl;
+        deallog.get_file_stream() << "Using PetscScalar:" << std::endl;
 
         const PetscScalar pi_1i = numbers::PI + 1. * PETSC_i;
         const PetscScalar two   = 2.;
 
-        logfile << "   pi+1i:           " << pi_1i << std::endl
-                << "   two:             " << two << std::endl
-                << "   two times pi+1i: " << two * pi_1i << std::endl;
+        deallog.get_file_stream()
+          << "   pi+1i:           " << pi_1i << std::endl
+          << "   two:             " << two << std::endl
+          << "   two times pi+1i: " << two * pi_1i << std::endl;
 
 
-        logfile << "Finalizing SLEPc (PETSc): " << std::flush;
+        deallog.get_file_stream() << "Finalizing SLEPc (PETSc): " << std::flush;
       }
       SlepcFinalize();
 
-      logfile << "ok" << std::endl << std::endl;
+      deallog.get_file_stream() << "ok" << std::endl << std::endl;
     }
 
   catch (std::exception &exc)

--- a/tests/sparsity/dynamic_sparsity_pattern_06.cc
+++ b/tests/sparsity/dynamic_sparsity_pattern_06.cc
@@ -24,8 +24,6 @@
 #include "../tests.h"
 
 
-std::ofstream logfile("output");
-
 void
 test()
 {
@@ -36,7 +34,7 @@ test()
       csp.add(i, (i + (i + 1) * (j * j + i)) % N);
   csp.symmetrize();
 
-  csp.print_gnuplot(logfile);
+  csp.print_gnuplot(deallog.get_file_stream());
   deallog << "OK" << std::endl;
 }
 
@@ -45,7 +43,7 @@ test()
 int
 main()
 {
-  deallog.attach(logfile);
+  initlog();
 
   test();
   return 0;

--- a/tests/trilinos/assemble_matrix_parallel_01.cc
+++ b/tests/trilinos/assemble_matrix_parallel_01.cc
@@ -52,10 +52,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
-
-
 namespace Assembly
 {
   namespace Scratch
@@ -464,12 +460,11 @@ LaplaceProblem<dim>::run()
 int
 main(int argc, char **argv)
 {
-  deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
-  deallog.attach(logfile);
-
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
+
+  mpi_initlog();
+  deallog << std::setprecision(2);
 
   {
     deallog.push("2d");

--- a/tests/trilinos/assemble_matrix_parallel_02.cc
+++ b/tests/trilinos/assemble_matrix_parallel_02.cc
@@ -55,10 +55,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
-
-
 namespace Assembly
 {
   namespace Scratch
@@ -467,12 +463,11 @@ LaplaceProblem<dim>::run()
 int
 main(int argc, char **argv)
 {
-  deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
-  deallog.attach(logfile);
-
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
+  mpi_initlog();
+
+  deallog << std::setprecision(2);
 
   {
     deallog.push("2d");

--- a/tests/trilinos/assemble_matrix_parallel_03.cc
+++ b/tests/trilinos/assemble_matrix_parallel_03.cc
@@ -56,10 +56,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
-
-
 namespace Assembly
 {
   namespace Scratch
@@ -472,12 +468,10 @@ LaplaceProblem<dim>::run()
 int
 main(int argc, char **argv)
 {
-  deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
-  deallog.attach(logfile);
-
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
+  mpi_initlog();
+  deallog << std::setprecision(2);
 
   {
     deallog.push("2d");

--- a/tests/trilinos/assemble_matrix_parallel_04.cc
+++ b/tests/trilinos/assemble_matrix_parallel_04.cc
@@ -57,10 +57,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
-
-
 namespace Assembly
 {
   namespace Scratch
@@ -494,12 +490,10 @@ LaplaceProblem<dim>::run()
 int
 main(int argc, char **argv)
 {
-  deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
-  deallog.attach(logfile);
-
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
+  mpi_initlog();
+  deallog << std::setprecision(2);
 
   {
     deallog.push("2d");

--- a/tests/trilinos/assemble_matrix_parallel_05.cc
+++ b/tests/trilinos/assemble_matrix_parallel_05.cc
@@ -57,10 +57,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
-
-
 namespace Assembly
 {
   namespace Scratch
@@ -469,12 +465,10 @@ LaplaceProblem<dim>::run()
 int
 main(int argc, char **argv)
 {
-  deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
-  deallog.attach(logfile);
-
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
+  mpi_initlog();
+  deallog << std::setprecision(2);
 
   {
     deallog.push("2d");

--- a/tests/trilinos/assemble_matrix_parallel_06.cc
+++ b/tests/trilinos/assemble_matrix_parallel_06.cc
@@ -59,10 +59,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
-
-
 namespace Assembly
 {
   namespace Scratch
@@ -495,12 +491,10 @@ LaplaceProblem<dim>::run()
 int
 main(int argc, char **argv)
 {
-  deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
-  deallog.attach(logfile);
-
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
+  mpi_initlog();
+  deallog << std::setprecision(2);
 
   {
     deallog.push("2d");

--- a/tests/trilinos/assemble_matrix_parallel_07.cc
+++ b/tests/trilinos/assemble_matrix_parallel_07.cc
@@ -56,10 +56,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
-
-
 namespace Assembly
 {
   namespace Scratch
@@ -478,12 +474,10 @@ LaplaceProblem<dim>::run()
 int
 main(int argc, char **argv)
 {
-  deallog << std::setprecision(2);
-  logfile << std::setprecision(2);
-  deallog.attach(logfile);
-
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
+  mpi_initlog();
+  deallog << std::setprecision(2);
 
   {
     deallog.push("2d");


### PR DESCRIPTION
Part of #4250. I was reminded of this when reviewing one of the PETSc patches - its pretty easy to automatically convert many of these with a python script.

