### PR TITLE
SparseDirectUMFPACK: Use the correct type alias.

### DIFF
--- a/source/lac/sparse_direct.cc
+++ b/source/lac/sparse_direct.cc
@@ -100,12 +100,12 @@ SparseDirectUMFPACK::clear()
     }
 
   {
-    std::vector<long int> tmp;
+    std::vector<types::suitesparse_index> tmp;
     tmp.swap(Ap);
   }
 
   {
-    std::vector<long int> tmp;
+    std::vector<types::suitesparse_index> tmp;
     tmp.swap(Ai);
   }
 


### PR DESCRIPTION
It looks like `SuiteSparse_long` is `long long` on ARM chips, not `long int`. This problem was reported on the mailing list (thanks, Rahul!)