### PR TITLE
SparseDirectUMFPACK: Use the correct type alias.

### DIFF
--- a/source/lac/sparse_direct.cc
+++ b/source/lac/sparse_direct.cc
@@ -100,12 +100,12 @@ SparseDirectUMFPACK::clear()
     }
 
   {
-    std::vector<long int> tmp;
+    std::vector<types::suitesparse_index> tmp;
     tmp.swap(Ap);
   }
 
   {
-    std::vector<long int> tmp;
+    std::vector<types::suitesparse_index> tmp;
     tmp.swap(Ai);
   }
 


### PR DESCRIPTION
Same as #14720 but for 9.4.