### PR TITLE
CMake: silence the CMAKE_CXX_EXTENSIONS warning when including Kokkos

### DIFF
--- a/cmake/modules/FindDEAL_II_ARBORX.cmake
+++ b/cmake/modules/FindDEAL_II_ARBORX.cmake
@@ -26,7 +26,8 @@
 set(ARBORX_DIR "" CACHE PATH "An optional hint to an ArborX installation")
 set_if_empty(ARBORX_DIR "$ENV{ARBORX_DIR}")
 
-
+# silence a warning when including FindKOKKOS.cmake
+set(CMAKE_CXX_EXTENSIONS OFF)
 find_package(ArborX QUIET
   HINTS ${ARBORX_DIR} ${ArborX_DIR} $ENV{ArborX_DIR}
   )

--- a/cmake/modules/FindDEAL_II_KOKKOS.cmake
+++ b/cmake/modules/FindDEAL_II_KOKKOS.cmake
@@ -32,6 +32,9 @@ if(DEAL_II_TRILINOS_WITH_KOKKOS OR DEAL_II_PETSC_WITH_KOKKOS)
   # Let deal.II know that we have found Kokkos
   set(KOKKOS_FOUND ON)
 else()
+
+  # silence a warning when including FindKOKKOS.cmake
+  set(CMAKE_CXX_EXTENSIONS OFF)
   find_package(Kokkos 3.7.0 QUIET
     HINTS ${KOKKOS_DIR} ${Kokkos_DIR} $ENV{Kokkos_DIR}
     )

--- a/cmake/modules/FindDEAL_II_TRILINOS.cmake
+++ b/cmake/modules/FindDEAL_II_TRILINOS.cmake
@@ -32,6 +32,9 @@
 set(TRILINOS_DIR "" CACHE PATH "An optional hint to a Trilinos installation")
 set_if_empty(TRILINOS_DIR "$ENV{TRILINOS_DIR}")
 
+# silence a warning when including FindKOKKOS.cmake
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 #
 # Include the trilinos package configuration:
 #


### PR DESCRIPTION
The CMAKE_CXX_EXTENSIONS variable controls whether CMake sets the
"CXX_EXTENSIONS" property for a target. If this property is set then
CMake ensures that gnu extensions are enabled by default by using
corresponding -std=gnu1X flags instead of -std=cxx1X flags.

Kokkos forcefully disables this variable as soon as FindKOKKOS.cmake is
included with a prominent warning. Thus simply set the variable prior to
including FindKOKKOS.cmake.

On a sidenote - Kokkos' workaround here is not really effective: We
currently do not use the CXX_STANDARD target property but set the
language standard by hand. Thus, the variable is simply ignored.

Also, even if a project happens to use the CMAKE_CXX_STANDARD variable,
this generally doesn't work as the project that includes
FindKOKKOS.cmake can simply override the variable later.