### PR TITLE
CMake: Silence a warning about HDF5_ROOT containing NOTFOUND

### DIFF
--- a/cmake/modules/FindDEAL_II_HDF5.cmake
+++ b/cmake/modules/FindDEAL_II_HDF5.cmake
@@ -26,7 +26,8 @@
 set(HDF5_DIR "" CACHE PATH "An optional hint to an hdf5 directory")
 set_if_empty(HDF5_DIR "$ENV{HDF5_DIR}")
 
-if(NOT "${HDF5_DIR}" STREQUAL "")
+if( NOT "${HDF5_DIR}" STREQUAL "" AND
+    NOT "${HDF5_DIR}" STREQUAL "HDF5_DIR-NOTFOUND" )
   set(HDF5_ROOT "${HDF5_DIR}")
 endif()
 


### PR DESCRIPTION
The FindHDF5.cmake package might set HDF5_DIR to "HDF5_DIR-NOTFOUND"
(even though it finds and configures an HDF5 installation without a
problem). This isn't terribly elegant, but us setting HDF5_ROOT to that
variable triggers a bogus warning.

Thus filter the invalid name.