### PR TITLE
cgal: disable diagnostics when including CGAL headers

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -487,6 +487,7 @@ _Pragma("GCC diagnostic ignored \"-Wignored-qualifiers\"")              \
 _Pragma("GCC diagnostic ignored \"-Wimplicit-fallthrough\"")            \
 _Pragma("GCC diagnostic ignored \"-Winfinite-recursion\"")              \
 _Pragma("GCC diagnostic ignored \"-Wint-in-bool-context\"")             \
+_Pragma("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")             \
 _Pragma("GCC diagnostic ignored \"-Wmisleading-indentation\"")          \
 _Pragma("GCC diagnostic ignored \"-Wmissing-field-initializers\"")      \
 _Pragma("GCC diagnostic ignored \"-Wnested-anon-types\"")               \

--- a/source/cgal/intersections.cc
+++ b/source/cgal/intersections.cc
@@ -30,6 +30,7 @@
 
 #  include <deal.II/grid/tria.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <CGAL/Boolean_set_operations_2.h>
 #  include <CGAL/Cartesian.h>
 #  include <CGAL/Circular_kernel_intersections.h>
@@ -53,6 +54,7 @@
 #  include <CGAL/Triangulation_3.h>
 #  include <CGAL/Triangulation_face_base_with_id_2.h>
 #  include <CGAL/Triangulation_face_base_with_info_2.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #  include <deal.II/cgal/utilities.h>
 
 #  include <fstream>


### PR DESCRIPTION
This works around a hard to trace compilation warning that can be
triggered in some configurations in CGAL and Boost headers:

```
In file included from /usr/include/CGAL/Static_filtered_predicate.h:15,
                 from /usr/include/CGAL/Lazy_kernel.h:18,
                 from /usr/include/CGAL/Exact_predicates_exact_constructions_kernel.h:27,
                 from /usr/include/CGAL/Arr_segment_traits_2.h:30,
                 from /usr/include/CGAL/Gps_segment_traits_2.h:20,
                 from /usr/include/CGAL/Boolean_set_operations_2/complement.h:27,
                 from /usr/include/CGAL/Boolean_set_operations_2.h:21,
                 from /srv/temp/dealii/source/cgal/intersections.cc:33:
/usr/include/CGAL/Epic_converter.h: In member function ‘std::pair<CGAL::Segment_3<CGAL::Epick>, bool> CGAL::Epic_converter<IK>::operator()(const typename IK::Segment_3&) const [with IK = CGAL::Simple_cartesian<CGAL::Interval_nt<false> >]’:
/usr/include/CGAL/Epic_converter.h:305:29: note: ‘<anonymous>’ declared here
  305 |       return std::make_pair(Segment_3(),false);
      |                             ^~~~~~~~~~~
```

```
In constructor ‘constexpr std::pair<_T1, _T2>::pair(_U1&&, _U2&&) [with _U1 = CGAL::Segment_3<CGAL::Epick>; _U2 = bool; typename std::enable_if<(std::_PCC<true, _T1, _T2>::_MoveConstructiblePair<_U1, _U2>() && std::_PCC<true, _T1, _T2>::_ImplicitlyMoveConvertiblePair<_U1, _U2>()), bool>::type <anonymous> = true; _T1 = CGAL::Segment_3<CGAL::Epick>; _T2 = bool]’,
    inlined from ‘constexpr std::pair<typename std::__strip_reference_wrapper<typename std::decay<_Tp>::type>::__type, typename std::__strip_reference_wrapper<typename std::decay<_Tp2>::type>::__type> std::make_pair(_T1&&, _T2&&) [with _T1 = CGAL::Segment_3<CGAL::Epick>; _T2 = bool]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/12/include/g++-v12/bits/stl_pair.h:746:72,
    inlined from ‘std::pair<CGAL::Segment_3<CGAL::Epick>, bool> CGAL::Epic_converter<IK>::operator()(const typename IK::Segment_3&) const [with IK = CGAL::Simple_cartesian<CGAL::Interval_nt<false> >]’ at /usr/include/CGAL/Epic_converter.h:309:28:
/usr/lib/gcc/x86_64-pc-linux-gnu/12/include/g++-v12/bits/stl_pair.h:535:11: warning: ‘<anonymous>’ may be used uninitialized [-Wmaybe-uninitialized]
  535 |         : first(std::forward<_U1>(__x)), second(std::forward<_U2>(__y)) { }
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/CGAL/Epic_converter.h: In member function ‘std::pair<CGAL::Segment_3<CGAL::Epick>, bool> CGAL::Epic_converter<IK>::operator()(const typename IK::Segment_3&) const [with IK = CGAL::Simple_cartesian<CGAL::Interval_nt<false> >]’:
/usr/include/CGAL/Epic_converter.h:309:29: note: ‘<anonymous>’ declared here
  309 |       return std::make_pair(Segment_3(),false);
      |                             ^~~~~~~~~~~
```

I am not sure what order of includes triggers these warnings, thus my blunt
hammer to simply disable extra diagnostics.