### PR TITLE
Test lac/parallel_vector_21: do not use KOKKOS_IMPL_DO_NOT_USE_PRINTF and indeed use printf

### DIFF
--- a/tests/lac/parallel_vector_21.cc
+++ b/tests/lac/parallel_vector_21.cc
@@ -56,7 +56,7 @@ test()
 
   Kokkos::parallel_for(
     v2.local_size(), KOKKOS_LAMBDA(int i) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("%d: %f\n", i, v2_view(i));
+      printf("%d: %f\n", i, v2_view(i));
     });
   // add entries to ghost values
   // Because of limitation in import, the IndexSet of the ReadWriteVector needs


### PR DESCRIPTION
Older versions of Kokkos that come bundled with Trilinos older than 13.2
do not contain the KOKKOS_IMPL_DO_NOT_USE_PRINTF macro. Simply disable
the test in this case.