### PR TITLE
Fix a couple tests for older Kokkos versions used by Trilinos

### DIFF
--- a/tests/base/kokkos_tensor_01.cc
+++ b/tests/base/kokkos_tensor_01.cc
@@ -56,8 +56,7 @@ test_gpu()
 
   // Launch the kernels.
   Kokkos::parallel_for(
-    Kokkos::MDRangePolicy<ExecutionSpace, Kokkos::Rank<2>>(exec,
-                                                           {{0, 0}},
+    Kokkos::MDRangePolicy<ExecutionSpace, Kokkos::Rank<2>>({{0, 0}},
                                                            {{dim, dim}}),
     KOKKOS_LAMBDA(int i, int j) { t_dev()[i][j] = j + i * dim + 1.; });
   Kokkos::parallel_for(

--- a/tests/lac/parallel_vector_21.cc
+++ b/tests/lac/parallel_vector_21.cc
@@ -54,10 +54,6 @@ test()
     v2.get_values(), v2.local_size());
   Kokkos::deep_copy(v2_view, 1.);
 
-  Kokkos::parallel_for(
-    v2.local_size(), KOKKOS_LAMBDA(int i) {
-      KOKKOS_IMPL_DO_NOT_USE_PRINTF("%d: %f\n", i, v2_view(i));
-    });
   // add entries to ghost values
   // Because of limitation in import, the IndexSet of the ReadWriteVector needs
   // to have the local elements.


### PR DESCRIPTION
Supersedes #14730. Also, see https://cdash.dealii.org/test/6728969.