### PR TITLE
[9.4 branch] Mark a variable as extern

### DIFF
--- a/include/deal.II/hp/mapping_collection.h
+++ b/include/deal.II/hp/mapping_collection.h
@@ -191,6 +191,19 @@ namespace hp
   extern template struct StaticMappingQ1<2, 2>;
   extern template struct StaticMappingQ1<2, 3>;
   extern template struct StaticMappingQ1<3, 3>;
+
+  extern template MappingCollection<1, 1>
+    StaticMappingQ1<1, 1>::mapping_collection;
+  extern template MappingCollection<1, 2>
+    StaticMappingQ1<1, 2>::mapping_collection;
+  extern template MappingCollection<1, 3>
+    StaticMappingQ1<1, 3>::mapping_collection;
+  extern template MappingCollection<2, 2>
+    StaticMappingQ1<2, 2>::mapping_collection;
+  extern template MappingCollection<2, 3>
+    StaticMappingQ1<2, 3>::mapping_collection;
+  extern template MappingCollection<3, 3>
+    StaticMappingQ1<3, 3>::mapping_collection;
 #endif
 
 } // namespace hp

--- a/include/deal.II/hp/mapping_collection.h
+++ b/include/deal.II/hp/mapping_collection.h
@@ -151,6 +151,7 @@ namespace hp
   };
 
 
+
   /* --------------- inline functions ------------------- */
 
   template <int dim, int spacedim>
@@ -171,6 +172,26 @@ namespace hp
     for (const auto p : mapping_pointers)
       push_back(*p);
   }
+
+
+
+  template <int dim, int spacedim>
+  MappingCollection<dim, spacedim>
+    StaticMappingQ1<dim, spacedim>::mapping_collection =
+      MappingCollection<dim, spacedim>(MappingQ1<dim, spacedim>{});
+
+
+#ifndef DOXYGEN
+  // Declare the existence of explicit instantiations of the class
+  // above to avoid certain warnings issues by clang and
+  // newer (LLVM-based) Intel compilers:
+  extern template struct StaticMappingQ1<1, 1>;
+  extern template struct StaticMappingQ1<1, 2>;
+  extern template struct StaticMappingQ1<1, 3>;
+  extern template struct StaticMappingQ1<2, 2>;
+  extern template struct StaticMappingQ1<2, 3>;
+  extern template struct StaticMappingQ1<3, 3>;
+#endif
 
 } // namespace hp
 

--- a/include/deal.II/hp/mapping_collection.h
+++ b/include/deal.II/hp/mapping_collection.h
@@ -192,6 +192,7 @@ namespace hp
   extern template struct StaticMappingQ1<2, 3>;
   extern template struct StaticMappingQ1<3, 3>;
 
+#  ifndef _MSC_VER
   extern template MappingCollection<1, 1>
     StaticMappingQ1<1, 1>::mapping_collection;
   extern template MappingCollection<1, 2>
@@ -204,6 +205,7 @@ namespace hp
     StaticMappingQ1<2, 3>::mapping_collection;
   extern template MappingCollection<3, 3>
     StaticMappingQ1<3, 3>::mapping_collection;
+#  endif
 #endif
 
 } // namespace hp

--- a/source/hp/mapping_collection.cc
+++ b/source/hp/mapping_collection.cc
@@ -73,12 +73,6 @@ namespace hp
       return mapping;
     }
   } // namespace
-
-  template <int dim, int spacedim>
-  MappingCollection<dim, spacedim>
-    StaticMappingQ1<dim, spacedim>::mapping_collection =
-      MappingCollection<dim, spacedim>(get_static_mapping_q1<dim, spacedim>());
-
 } // namespace hp
 
 


### PR DESCRIPTION
This takes over #14698 and #14701 onto the release branch given that the lack of these `extern` declarations led to errors and warnings (as reported by @victoreijkhout in #14695).