### PR TITLE
CMake: do not use VERSION for interface targets for older CMake versions

### DIFF
--- a/cmake/macros/macro_define_interface_target.cmake
+++ b/cmake/macros/macro_define_interface_target.cmake
@@ -78,9 +78,13 @@ function(define_interface_target _feature)
 
     if(DEFINED ${_feature}_VERSION)
       message(STATUS "    VERSION:             ${${_feature}_VERSION}")
-      set_target_properties(${_interface_target}
-        PROPERTIES VERSION "${${_feature_}_VERSION}"
-        )
+      # CMake versions prior to 3.19 have a significantly more restrictive
+      # set of allowed interface target properties.
+      if(NOT CMAKE_VERSION VERSION_LESS 3.19)
+        set_target_properties(${_interface_target}
+          PROPERTIES VERSION "${${_feature_}_VERSION}"
+          )
+      endif()
     endif()
 
     set(_libraries)


### PR DESCRIPTION
This fixes:

  https://cdash.dealii.org/build/588/configure