### PR TITLE
CMake: Uniformly raise the minimum required version to 3.13.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,11 +33,11 @@
 message(STATUS "This is CMake ${CMAKE_VERSION}")
 message(STATUS "")
 
-cmake_minimum_required(VERSION 3.11.0)
+cmake_minimum_required(VERSION 3.13.4)
 #
 # We support all policy changes up to version 3.11.
 #
-cmake_policy(VERSION 3.11.0)
+cmake_policy(VERSION 3.13.4)
 
 if(POLICY CMP0075)
   # Introduced in CMake 3.12: Use CMAKE_REQUIRED_LIBRARIES also in include

--- a/doc/news/changes/incompatibilities/20221222Maier
+++ b/doc/news/changes/incompatibilities/20221222Maier
@@ -1,3 +1,3 @@
-Updated: deal.II now requires CMake version 3.11 or later.
+Updated: deal.II now requires CMake version 3.13.4 or later.
 <br>
-(Matthias Maier, 2022/12/22)
+(Matthias Maier, 2023/01/26)

--- a/examples/step-1/CMakeLists.txt
+++ b/examples/step-1/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-10/CMakeLists.txt
+++ b/examples/step-10/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-11/CMakeLists.txt
+++ b/examples/step-11/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-12/CMakeLists.txt
+++ b/examples/step-12/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-12b/CMakeLists.txt
+++ b/examples/step-12b/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-13/CMakeLists.txt
+++ b/examples/step-13/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-14/CMakeLists.txt
+++ b/examples/step-14/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-15/CMakeLists.txt
+++ b/examples/step-15/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-16/CMakeLists.txt
+++ b/examples/step-16/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-16b/CMakeLists.txt
+++ b/examples/step-16b/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-17/CMakeLists.txt
+++ b/examples/step-17/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS

--- a/examples/step-18/CMakeLists.txt
+++ b/examples/step-18/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS

--- a/examples/step-19/CMakeLists.txt
+++ b/examples/step-19/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0 QUIET
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-2/CMakeLists.txt
+++ b/examples/step-2/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-20/CMakeLists.txt
+++ b/examples/step-20/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-21/CMakeLists.txt
+++ b/examples/step-21/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-22/CMakeLists.txt
+++ b/examples/step-22/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-23/CMakeLists.txt
+++ b/examples/step-23/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-24/CMakeLists.txt
+++ b/examples/step-24/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-25/CMakeLists.txt
+++ b/examples/step-25/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-26/CMakeLists.txt
+++ b/examples/step-26/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-27/CMakeLists.txt
+++ b/examples/step-27/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-28/CMakeLists.txt
+++ b/examples/step-28/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-29/CMakeLists.txt
+++ b/examples/step-29/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-3/CMakeLists.txt
+++ b/examples/step-3/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-30/CMakeLists.txt
+++ b/examples/step-30/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-31/CMakeLists.txt
+++ b/examples/step-31/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-32/CMakeLists.txt
+++ b/examples/step-32/CMakeLists.txt
@@ -24,7 +24,7 @@ set(CLEAN_UP_FILES *.vtu *.pvtu *.visit)
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-33/CMakeLists.txt
+++ b/examples/step-33/CMakeLists.txt
@@ -24,7 +24,7 @@ set(TARGET_RUN ${TARGET} input.prm)
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-34/CMakeLists.txt
+++ b/examples/step-34/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-35/CMakeLists.txt
+++ b/examples/step-35/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-36/CMakeLists.txt
+++ b/examples/step-36/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-37/CMakeLists.txt
+++ b/examples/step-37/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-38/CMakeLists.txt
+++ b/examples/step-38/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-39/CMakeLists.txt
+++ b/examples/step-39/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-4/CMakeLists.txt
+++ b/examples/step-4/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-40/CMakeLists.txt
+++ b/examples/step-40/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-41/CMakeLists.txt
+++ b/examples/step-41/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-42/CMakeLists.txt
+++ b/examples/step-42/CMakeLists.txt
@@ -24,7 +24,7 @@ set(CLEAN_UP_FILES *.vtu *.pvtu *.visit)
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-43/CMakeLists.txt
+++ b/examples/step-43/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-44/CMakeLists.txt
+++ b/examples/step-44/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-45/CMakeLists.txt
+++ b/examples/step-45/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-46/CMakeLists.txt
+++ b/examples/step-46/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-47/CMakeLists.txt
+++ b/examples/step-47/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-48/CMakeLists.txt
+++ b/examples/step-48/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-49/CMakeLists.txt
+++ b/examples/step-49/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-5/CMakeLists.txt
+++ b/examples/step-5/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-50/CMakeLists.txt
+++ b/examples/step-50/CMakeLists.txt
@@ -24,7 +24,7 @@ set(CLEAN_UP_FILES *.vtu *.pvtu *.visit)
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-51/CMakeLists.txt
+++ b/examples/step-51/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-52/CMakeLists.txt
+++ b/examples/step-52/CMakeLists.txt
@@ -24,7 +24,7 @@ set(CLEAN_UP_FILES *.vtu)
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-53/CMakeLists.txt
+++ b/examples/step-53/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-54/CMakeLists.txt
+++ b/examples/step-54/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-55/CMakeLists.txt
+++ b/examples/step-55/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-56/CMakeLists.txt
+++ b/examples/step-56/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-57/CMakeLists.txt
+++ b/examples/step-57/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-58/CMakeLists.txt
+++ b/examples/step-58/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-59/CMakeLists.txt
+++ b/examples/step-59/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-6/CMakeLists.txt
+++ b/examples/step-6/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-60/CMakeLists.txt
+++ b/examples/step-60/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-61/CMakeLists.txt
+++ b/examples/step-61/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-62/CMakeLists.txt
+++ b/examples/step-62/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-63/CMakeLists.txt
+++ b/examples/step-63/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-64/CMakeLists.txt
+++ b/examples/step-64/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-65/CMakeLists.txt
+++ b/examples/step-65/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-66/CMakeLists.txt
+++ b/examples/step-66/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0 QUIET
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-67/CMakeLists.txt
+++ b/examples/step-67/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-68/CMakeLists.txt
+++ b/examples/step-68/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0 QUIET
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-69/CMakeLists.txt
+++ b/examples/step-69/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-7/CMakeLists.txt
+++ b/examples/step-7/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-70/CMakeLists.txt
+++ b/examples/step-70/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-71/CMakeLists.txt
+++ b/examples/step-71/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0 QUIET
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-72/CMakeLists.txt
+++ b/examples/step-72/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0 QUIET
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-74/CMakeLists.txt
+++ b/examples/step-74/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-75/CMakeLists.txt
+++ b/examples/step-75/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-76/CMakeLists.txt
+++ b/examples/step-76/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-77/CMakeLists.txt
+++ b/examples/step-77/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-78/CMakeLists.txt
+++ b/examples/step-78/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-79/CMakeLists.txt
+++ b/examples/step-79/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-8/CMakeLists.txt
+++ b/examples/step-8/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-81/CMakeLists.txt
+++ b/examples/step-81/CMakeLists.txt
@@ -23,7 +23,7 @@ set(TARGET_SRC
 
 cmake_minimum_required(VERSION 3.13.4)
 
-find_package(deal.II 9.2.0
+find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}
   )
 if(NOT ${deal.II_FOUND})

--- a/examples/step-81/CMakeLists.txt
+++ b/examples/step-81/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.2.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-82/CMakeLists.txt
+++ b/examples/step-82/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-85/CMakeLists.txt
+++ b/examples/step-85/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/examples/step-9/CMakeLists.txt
+++ b/examples/step-9/CMakeLists.txt
@@ -21,7 +21,7 @@ set(TARGET_SRC
 
 # Usually, you will not need to modify anything beyond this point...
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 find_package(deal.II 9.5.0
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,7 +22,7 @@
 #    test           - run all quick_tests
 #
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 
 macro(set_if_empty _variable)
   if("${${_variable}}" STREQUAL "")

--- a/tests/a-framework/CMakeLists.txt
+++ b/tests/a-framework/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 

--- a/tests/adolc/CMakeLists.txt
+++ b/tests/adolc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 if(DEAL_II_WITH_ADOLC)

--- a/tests/algorithms/CMakeLists.txt
+++ b/tests/algorithms/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/all-headers/CMakeLists.txt
+++ b/tests/all-headers/CMakeLists.txt
@@ -13,7 +13,7 @@
 ##
 ## ---------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 

--- a/tests/aniso/CMakeLists.txt
+++ b/tests/aniso/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/arborx/CMakeLists.txt
+++ b/tests/arborx/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 if(DEAL_II_WITH_ARBORX)

--- a/tests/arpack/CMakeLists.txt
+++ b/tests/arpack/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 if(DEAL_II_WITH_ARPACK)

--- a/tests/base/CMakeLists.txt
+++ b/tests/base/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/belos/CMakeLists.txt
+++ b/tests/belos/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 

--- a/tests/bits/CMakeLists.txt
+++ b/tests/bits/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/boost/CMakeLists.txt
+++ b/tests/boost/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/cgal/CMakeLists.txt
+++ b/tests/cgal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 if(DEAL_II_WITH_CGAL)

--- a/tests/codim_one/CMakeLists.txt
+++ b/tests/codim_one/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 if(DEAL_II_WITH_CUDA)

--- a/tests/data_out/CMakeLists.txt
+++ b/tests/data_out/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/distributed_grids/CMakeLists.txt
+++ b/tests/distributed_grids/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 if(DEAL_II_WITH_P4EST)

--- a/tests/dofs/CMakeLists.txt
+++ b/tests/dofs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/epetraext/CMakeLists.txt
+++ b/tests/epetraext/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 if(DEAL_II_WITH_TRILINOS AND DEAL_II_TRILINOS_WITH_EPETRAEXT)

--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/fe/CMakeLists.txt
+++ b/tests/fe/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/feinterface/CMakeLists.txt
+++ b/tests/feinterface/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/full_matrix/CMakeLists.txt
+++ b/tests/full_matrix/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/fullydistributed_grids/CMakeLists.txt
+++ b/tests/fullydistributed_grids/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/ginkgo/CMakeLists.txt
+++ b/tests/ginkgo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 if(DEAL_II_WITH_GINKGO)

--- a/tests/gla/CMakeLists.txt
+++ b/tests/gla/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 if(DEAL_II_WITH_MPI AND DEAL_II_WITH_P4EST AND DEAL_II_WITH_PETSC AND DEAL_II_WITH_TRILINOS)

--- a/tests/gmsh/CMakeLists.txt
+++ b/tests/gmsh/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 if(DEAL_II_WITH_GMSH)

--- a/tests/grid/CMakeLists.txt
+++ b/tests/grid/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/hp/CMakeLists.txt
+++ b/tests/hp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/integrators/CMakeLists.txt
+++ b/tests/integrators/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/lac/CMakeLists.txt
+++ b/tests/lac/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/lapack/CMakeLists.txt
+++ b/tests/lapack/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 if(DEAL_II_WITH_LAPACK)

--- a/tests/manifold/CMakeLists.txt
+++ b/tests/manifold/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/mappings/CMakeLists.txt
+++ b/tests/mappings/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/matrix_free/CMakeLists.txt
+++ b/tests/matrix_free/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/meshworker/CMakeLists.txt
+++ b/tests/meshworker/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/metis/CMakeLists.txt
+++ b/tests/metis/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 if(DEAL_II_WITH_METIS)

--- a/tests/mpi/CMakeLists.txt
+++ b/tests/mpi/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 if(DEAL_II_WITH_MPI)

--- a/tests/multigrid-global-coarsening/CMakeLists.txt
+++ b/tests/multigrid-global-coarsening/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/multigrid/CMakeLists.txt
+++ b/tests/multigrid/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/multithreading/CMakeLists.txt
+++ b/tests/multithreading/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/non_matching/CMakeLists.txt
+++ b/tests/non_matching/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/numerics/CMakeLists.txt
+++ b/tests/numerics/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/opencascade/CMakeLists.txt
+++ b/tests/opencascade/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 if(DEAL_II_WITH_OPENCASCADE)

--- a/tests/optimization/CMakeLists.txt
+++ b/tests/optimization/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/parameter_handler/CMakeLists.txt
+++ b/tests/parameter_handler/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/particles/CMakeLists.txt
+++ b/tests/particles/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/performance/CMakeLists.txt
+++ b/tests/performance/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 

--- a/tests/petsc/CMakeLists.txt
+++ b/tests/petsc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 if(DEAL_II_WITH_PETSC AND NOT DEAL_II_PETSC_WITH_COMPLEX)

--- a/tests/petsc_complex/CMakeLists.txt
+++ b/tests/petsc_complex/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 if(DEAL_II_WITH_PETSC AND DEAL_II_PETSC_WITH_COMPLEX)

--- a/tests/physics/CMakeLists.txt
+++ b/tests/physics/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/quick_tests/CMakeLists.txt
+++ b/tests/quick_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/remote_point_evaluation/CMakeLists.txt
+++ b/tests/remote_point_evaluation/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/rol/CMakeLists.txt
+++ b/tests/rol/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 if(DEAL_II_WITH_TRILINOS AND DEAL_II_TRILINOS_WITH_ROL)

--- a/tests/sacado/CMakeLists.txt
+++ b/tests/sacado/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 if(DEAL_II_WITH_TRILINOS AND DEAL_II_TRILINOS_WITH_SACADO)

--- a/tests/scalapack/CMakeLists.txt
+++ b/tests/scalapack/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 if(DEAL_II_WITH_SCALAPACK)

--- a/tests/serialization/CMakeLists.txt
+++ b/tests/serialization/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/sharedtria/CMakeLists.txt
+++ b/tests/sharedtria/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 include(${DEAL_II_TARGET_CONFIG})

--- a/tests/simplex/CMakeLists.txt
+++ b/tests/simplex/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/slepc/CMakeLists.txt
+++ b/tests/slepc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 if(DEAL_II_WITH_PETSC AND DEAL_II_WITH_SLEPC AND NOT DEAL_II_PETSC_WITH_COMPLEX)

--- a/tests/slepc_complex/CMakeLists.txt
+++ b/tests/slepc_complex/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 if(DEAL_II_WITH_PETSC AND DEAL_II_WITH_SLEPC AND PETSC_WITH_COMPLEX)

--- a/tests/sparsity/CMakeLists.txt
+++ b/tests/sparsity/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/sundials/CMakeLists.txt
+++ b/tests/sundials/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 if(DEAL_II_WITH_SUNDIALS)

--- a/tests/symengine/CMakeLists.txt
+++ b/tests/symengine/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 if(DEAL_II_WITH_SYMENGINE)

--- a/tests/tensors/CMakeLists.txt
+++ b/tests/tensors/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/trilinos/CMakeLists.txt
+++ b/tests/trilinos/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 if(DEAL_II_WITH_TRILINOS)

--- a/tests/umfpack/CMakeLists.txt
+++ b/tests/umfpack/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 if(DEAL_II_WITH_UMFPACK)

--- a/tests/vector/CMakeLists.txt
+++ b/tests/vector/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/vector_tools/CMakeLists.txt
+++ b/tests/vector_tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 deal_ii_pickup_tests()

--- a/tests/zoltan/CMakeLists.txt
+++ b/tests/zoltan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.13.4)
 include(../setup_testsubproject.cmake)
 project(testsuite CXX)
 


### PR DESCRIPTION
I made a mistake - I thought I would need CMake Version 3.11 for the
modernization, but I indeed need version 3.13.4 (for features like
`target_link_options()`, which I really, really want to use :-). Thus,
let's raise the minimum version uniformly to 3.13.4.

The impact for requiring 3.13.4 should be rather minimal:
 - our entire testing infrastructure has at least 3.14.4 installed.
 - Debian 10 (oldstable) ships with 3.13.4
 - Ubuntu LTS 20.04 (focal) ships with 3.16.3

We have already lost support for Ubuntu LTS 18.04 which ships with 3.10.x.