### PR TITLE
Doc: Inform user how to exchange active FE indices on ghost cells.

### DIFF
--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -590,7 +590,8 @@ public:
    *
    * Active FE indices will only be set for locally owned cells. Ghost and
    * artificial cells will be ignored; no active FE index will be assigned to
-   * them.
+   * them. To exchange active FE indices on ghost cells, call distribute_dofs()
+   * afterwards.
    */
   void
   set_active_fe_indices(const std::vector<types::fe_index> &active_fe_indices);


### PR DESCRIPTION
Just a small addition to tell users how to perform the ghost exchange.