### PR TITLE
Make sure all Kokkos headers are installed

### DIFF
--- a/bundled/CMakeLists.txt
+++ b/bundled/CMakeLists.txt
@@ -52,7 +52,9 @@ if(DEAL_II_FEATURE_KOKKOS_BUNDLED_CONFIGURED)
     ${KOKKOS_FOLDER}/tpls/desul/include/
     DESTINATION ${DEAL_II_INCLUDE_RELDIR}/deal.II/bundled
     COMPONENT library
-    FILES_MATCHING PATTERN "*.hpp"
+    FILES_MATCHING
+    PATTERN "*.hpp"
+    PATTERN "*.h"
     )
 endif()
 


### PR DESCRIPTION
One of the Kokkos headers has a `.h` extension and not `.hpp` as the others. Add `*.h` to the the pattern of headers we copy over when we install the library.

Fixes #14750