### PR TITLE
Avoid __CUDA_ARCH__ in source code

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -28,7 +28,9 @@
 #  include <cusparse.h>
 #endif
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <Kokkos_Core.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -18,6 +18,8 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/kokkos.h>
+
 #include <exception>
 #include <ostream>
 #include <string>
@@ -27,10 +29,6 @@
 #  include <cusolverSp.h>
 #  include <cusparse.h>
 #endif
-
-DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
-#include <Kokkos_Core.hpp>
-DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -1526,7 +1524,7 @@ namespace deal_II_exceptions
           }))                                                                \
           KOKKOS_IF_ON_DEVICE(({                                             \
             if (!(cond))                                                     \
-              Kokkos::abort(#cond);                                          \
+              dealii::internal::kokkos_abort(#cond);                         \
           }))                                                                \
         }
 #    else /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
@@ -1546,7 +1544,7 @@ namespace deal_II_exceptions
           }))                                                                \
           KOKKOS_IF_ON_DEVICE(({                                             \
             if (!(cond))                                                     \
-              Kokkos::abort(#cond);                                          \
+              dealii::internal::kokkos_abort(#cond);                         \
           }))                                                                \
         }
 #    endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
@@ -1582,10 +1580,10 @@ namespace deal_II_exceptions
           }
 #      endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 #    else    /*#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST*/
-#      define Assert(cond, exc)   \
-        {                         \
-          if (!(cond))            \
-            Kokkos::abort(#cond); \
+#      define Assert(cond, exc)                    \
+        {                                          \
+          if (!(cond))                             \
+            dealii::internal::kokkos_abort(#cond); \
         }
 #    endif /*ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST*/
 #  endif   /*KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST*/

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1508,7 +1508,7 @@ namespace deal_II_exceptions
  * @ingroup Exceptions
  */
 #ifdef DEBUG
-#  ifdef KOKKOS_VERSION >= 30600
+#  if KOKKOS_VERSION >= 30600
 #    ifdef DEAL_II_HAVE_BUILTIN_EXPECT
 #      define Assert(cond, exc)                                              \
         {                                                                    \
@@ -1550,7 +1550,7 @@ namespace deal_II_exceptions
           }))                                                                \
         }
 #    endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
-#  else    /*ifdef KOKKOS_VERSION >= 30600*/
+#  else    /*if KOKKOS_VERSION >= 30600*/
 #    ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
 #      ifdef DEAL_II_HAVE_BUILTIN_EXPECT
 #        define Assert(cond, exc)                                            \

--- a/include/deal.II/base/kokkos.h
+++ b/include/deal.II/base/kokkos.h
@@ -33,6 +33,14 @@ namespace internal
    */
   void
   ensure_kokkos_initialized();
+
+  /**
+   * Calls Kokkos::abort. This wrapper avoids including Kokkos_Core.hpp, which
+   * provides all of Kokkos' functionalities, on the call side.
+   */
+  KOKKOS_FUNCTION void
+  kokkos_abort(const char *error);
+
 } // namespace internal
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/base/point.h
+++ b/include/deal.II/base/point.h
@@ -363,14 +363,12 @@ template <int dim, typename Number>
 inline DEAL_II_HOST_DEVICE
 Point<dim, Number>::Point(const Number x)
 {
-#  ifndef __CUDA_ARCH__
   Assert(dim == 1,
          ExcMessage(
            "You can only initialize Point<1> objects using the constructor "
            "that takes only one argument. Point<dim> objects with dim!=1 "
            "require initialization with the constructor that takes 'dim' "
            "arguments."));
-#  endif
 
   // we can only get here if we pass the assertion. use the switch anyway so
   // as to avoid compiler warnings about uninitialized elements or writing
@@ -391,14 +389,12 @@ template <int dim, typename Number>
 inline DEAL_II_HOST_DEVICE
 Point<dim, Number>::Point(const Number x, const Number y)
 {
-#  ifndef __CUDA_ARCH__
   Assert(dim == 2,
          ExcMessage(
            "You can only initialize Point<2> objects using the constructor "
            "that takes two arguments. Point<dim> objects with dim!=2 "
            "require initialization with the constructor that takes 'dim' "
            "arguments."));
-#  endif
 
   // we can only get here if we pass the assertion. use the indirection anyway
   // so as to avoid compiler warnings about uninitialized elements or writing
@@ -414,14 +410,12 @@ template <int dim, typename Number>
 inline DEAL_II_HOST_DEVICE
 Point<dim, Number>::Point(const Number x, const Number y, const Number z)
 {
-#  ifndef __CUDA_ARCH__
   Assert(dim == 3,
          ExcMessage(
            "You can only initialize Point<3> objects using the constructor "
            "that takes three arguments. Point<dim> objects with dim!=3 "
            "require initialization with the constructor that takes 'dim' "
            "arguments."));
-#  endif
 
   // we can only get here if we pass the assertion. use the indirection anyway
   // so as to avoid compiler warnings about uninitialized elements or writing
@@ -470,9 +464,7 @@ template <int dim, typename Number>
 inline DEAL_II_HOST_DEVICE Number
 Point<dim, Number>::operator()(const unsigned int index) const
 {
-#  ifndef __CUDA_ARCH__
   AssertIndexRange(static_cast<int>(index), dim);
-#  endif
   return this->values[index];
 }
 
@@ -482,9 +474,7 @@ template <int dim, typename Number>
 inline DEAL_II_HOST_DEVICE Number &
 Point<dim, Number>::operator()(const unsigned int index)
 {
-#  ifndef __CUDA_ARCH__
   AssertIndexRange(static_cast<int>(index), dim);
-#  endif
   return this->values[index];
 }
 

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -19,6 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/kokkos.h>
 #include <deal.II/base/numbers.h>
 #include <deal.II/base/table_indices.h>
 #include <deal.II/base/template_constraints.h>
@@ -1165,7 +1166,7 @@ namespace internal
       KOKKOS_IF_ON_DEVICE(({
         (void)val;
         (void)s;
-        Kokkos::abort(
+        dealii::internal::kokkos_abort(
           "This function is not implemented for std::complex<Number>!\n");
       }))
 #  else
@@ -1174,7 +1175,7 @@ namespace internal
 #    else
       (void)val;
       (void)s;
-      Kokkos::abort(
+      dealii::internal::kokkos_abort(
         "This function is not implemented for std::complex<Number>!\n");
 #    endif
 #  endif

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1326,9 +1326,11 @@ constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE
 Tensor<rank_, dim, Number>::Tensor(
   const ArrayView<ElementType, MemorySpace> &initializer)
 {
-  AssertDimension(initializer.size(), n_independent_components);
+  // make nvcc happy
+  const int my_n_independent_components = n_independent_components;
+  AssertDimension(initializer.size(), my_n_independent_components);
 
-  for (unsigned int i = 0; i < n_independent_components; ++i)
+  for (unsigned int i = 0; i < my_n_independent_components; ++i)
     (*this)[unrolled_to_component_indices(i)] = initializer[i];
 }
 

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1160,7 +1160,7 @@ namespace internal
     constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE void
     multiply_assign_scalar(std::complex<Number> &val, const OtherNumber &s)
     {
-#  ifdef KOKKOS_VERSION >= 30600
+#  if KOKKOS_VERSION >= 30600
       KOKKOS_IF_ON_HOST((val *= s;))
       KOKKOS_IF_ON_DEVICE(({
         (void)val;

--- a/source/base/kokkos.cc
+++ b/source/base/kokkos.cc
@@ -41,5 +41,11 @@ namespace internal
         (void)dummy;
       }
   }
+
+  KOKKOS_FUNCTION void
+  kokkos_abort(const char *error)
+  {
+    Kokkos::abort(error);
+  }
 } // namespace internal
 DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
I really don't like also the duplication for `Kokkos` versions earlier than 3.6.00.