### PR TITLE
Fix the type used to initialize a DerivativeForm from a tensor.

### DIFF
--- a/doc/news/changes/minor/20230201Bangerth
+++ b/doc/news/changes/minor/20230201Bangerth
@@ -1,0 +1,7 @@
+Fixed: The DerivativeForm class had a constructor that took an array
+of elements via the type
+`Tensor<order, spacedim, Tensor<1, dim,Number>>`.
+This should have been
+`Tensor<1, spacedim, Tensor<order, dim, Number>>`, and it is now fixed.
+<br>
+(Robin Goermer, Wolfgang Bangerth, 2023/02/01)

--- a/include/deal.II/base/derivative_form.h
+++ b/include/deal.II/base/derivative_form.h
@@ -69,9 +69,12 @@ public:
   DerivativeForm(const Tensor<order + 1, dim, Number> &);
 
   /**
-   * Constructor from a tensor.
+   * Constructor. This constructor initializes the data stored by this
+   * object from a `spacedim x dim^order` array that is represented
+   * by a Tensor with `spacedim` components each of which is a
+   * Tensor of rank `order` and size `dim`.
    */
-  DerivativeForm(const Tensor<order, spacedim, Tensor<1, dim, Number>> &);
+  DerivativeForm(const Tensor<1, spacedim, Tensor<order, dim, Number>> &);
 
   /**
    * Read-Write access operator.
@@ -199,7 +202,7 @@ inline DerivativeForm<order, dim, spacedim, Number>::DerivativeForm(
 
 template <int order, int dim, int spacedim, typename Number>
 inline DerivativeForm<order, dim, spacedim, Number>::DerivativeForm(
-  const Tensor<order, spacedim, Tensor<1, dim, Number>> &T)
+  const Tensor<1, spacedim, Tensor<order, dim, Number>> &T)
 {
   for (unsigned int j = 0; j < spacedim; ++j)
     (*this)[j] = T[j];

--- a/tests/base/derivative_form_initialization.cc
+++ b/tests/base/derivative_form_initialization.cc
@@ -1,0 +1,60 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// Verify that DerivativeForm can be initialized from a
+// Tensor<1,dim,Tensor<order,spacedim>. We used to have a bug where the
+// copy constructor offered Tensor<order,dim,Tensor<1,spacedim> instead,
+// but that was just wrong.
+
+#include <deal.II/base/derivative_form.h>
+
+#include <boost/type_traits.hpp>
+
+#include <complex>
+
+#include "../tests.h"
+
+template <typename Number>
+void
+test()
+{
+  // Choose orders and dimensions so that they are all not equal:
+  constexpr int order    = 2;
+  constexpr int dim      = 1;
+  constexpr int spacedim = 3;
+
+
+  Tensor<order, dim, Number> inner;
+  inner[0][0] = 1;
+  Tensor<1, spacedim, Tensor<order, dim, Number>> t;
+  t[0] = t[1] = t[2] = inner;
+
+  const DerivativeForm<order, dim, spacedim, Number> d(t);
+
+  deallog << "norm: " << d.norm() << std::endl;
+}
+
+int
+main()
+{
+  initlog();
+
+  deallog << "testing float" << std::endl;
+  test<float>();
+
+  deallog << "testing double" << std::endl;
+  test<double>();
+}

--- a/tests/base/derivative_form_initialization.output
+++ b/tests/base/derivative_form_initialization.output
@@ -1,0 +1,5 @@
+
+DEAL::testing float
+DEAL::norm: 1.73205
+DEAL::testing double
+DEAL::norm: 1.73205


### PR DESCRIPTION
Fixes #14748.