### PR TITLE
Add Kokkos::initialize and finalize to MPI_InitFinalize

### DIFF
--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -30,6 +30,8 @@
 
 #include <boost/serialization/utility.hpp>
 
+#include <Kokkos_Core.hpp>
+
 #include <iostream>
 #include <limits>
 #include <numeric>
@@ -773,6 +775,9 @@ namespace Utilities
       (void)ierr;
 #endif
 
+      // Initialize Kokkos
+      Kokkos::initialize(argc, argv);
+
       // we are allowed to call MPI_Init ourselves and PETScInitialize will
       // detect this. This allows us to use MPI_Init_thread instead.
 #ifdef DEAL_II_WITH_PETSC
@@ -986,6 +991,9 @@ namespace Utilities
       sc_finalize();
 #endif
 
+
+      // Finalize Kokkos
+      Kokkos::finalize();
 
       // only MPI_Finalize if we are running with MPI. We also need to do this
       // when running PETSc, because we initialize MPI ourselves before

--- a/tests/mpi/parallel_partitioner_device_06.cc
+++ b/tests/mpi/parallel_partitioner_device_06.cc
@@ -199,8 +199,6 @@ int
 main(int argc, char **argv)
 {
   Utilities::MPI::MPI_InitFinalize mpi(argc, argv);
-  Kokkos::initialize();
-  MPILogInitAll log;
+  MPILogInitAll                    log;
   test();
-  Kokkos::finalize();
 }

--- a/tests/mpi/parallel_partitioner_device_07.cc
+++ b/tests/mpi/parallel_partitioner_device_07.cc
@@ -229,8 +229,6 @@ int
 main(int argc, char **argv)
 {
   Utilities::MPI::MPI_InitFinalize mpi(argc, argv);
-  Kokkos::initialize();
-  MPILogInitAll log;
+  MPILogInitAll                    log;
   test();
-  Kokkos::finalize();
 }

--- a/tests/mpi/parallel_partitioner_device_08.cc
+++ b/tests/mpi/parallel_partitioner_device_08.cc
@@ -177,11 +177,9 @@ main(int argc, char **argv)
   using namespace dealii;
 
   Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
-  Kokkos::initialize();
-  MPILogInitAll log;
+  MPILogInitAll                    log;
 
   test();
 
-  Kokkos::finalize();
   return 0;
 }


### PR DESCRIPTION
We have a couple of tests that are using `MPI_InitFinalize` and `Kokkos::initialize/finalize`. This doesn't work because the destructor of `MPI_InitFinalize` needs Kokkos to be initialized. I've removed `Kokkos::initialize/finalize` from the tests.  I've also added `Kokkos::initialize/finalize` to `MPI_InitFinalize`. So there is a way for users to pass command line arguments to Kokkos.