### PR TITLE
ignore external cast-function-type warnings

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -480,6 +480,7 @@ _Pragma("GCC diagnostic ignored \"-Wunknown-warning-option\"")    /*!*/ \
 _Pragma("GCC diagnostic ignored \"-Wunknown-warning\"")           /*!*/ \
 _Pragma("GCC diagnostic ignored \"-Wextra\"")                     /*!*/ \
 _Pragma("GCC diagnostic ignored \"-Waddress-of-packed-member\"")        \
+_Pragma("GCC diagnostic ignored \"-Wcast-function-type\"")              \
 _Pragma("GCC diagnostic ignored \"-Wdeprecated-copy\"")                 \
 _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")         \
 _Pragma("GCC diagnostic ignored \"-Wdeprecated-volatile\"")             \


### PR DESCRIPTION
When building on Ubuntu 22.04 (gcc 11.3) with OpenMPI I am getting the following warnings:
```
[ 58%] Building CXX object
source/base/CMakeFiles/obj_base_release.dir/symbolic_function.cc.o
In file included from
/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi/ompi/mpi/cxx/mpicxx.h:277,
from
/usr/lib/x86_64-linux-gnu/openmpi/include/mpi.h:2887,
from
/home/runner/dealii-candi/tmp/build/deal.II-master/include/deal.II/base/config.h:576,
from
/home/runner/dealii-candi/tmp/unpack/deal.II-master/include/deal.II/base/symbolic_function.templates.h:19,
from
/home/runner/dealii-candi/tmp/unpack/deal.II-master/source/base/symbolic_function.cc:16:
/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi/ompi/mpi/cxx/op_inln.h:
In member function ‘virtual void MPI::Op::Init(void (*)(const void*,
void*, int, const MPI::Datatype&), bool)’:
/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi/ompi/mpi/cxx/op_inln.h:121:25:
warning: cast between incompatible function types from ‘void (*)(void*,
void*, int*, ompi_datatype_t**, void (*)(void*, void*, int*,
ompi_datatype_t**))’ to ‘void (*)(void*, void*, int*,
ompi_datatype_t**)’ [-Wcast-function-type]
  121 |     (void)MPI_Op_create((MPI_User_function*)
```
The code in question doesn't look correct, but we are not using the c++ wrappers anyways.