### PR TITLE
Use try_compile in macro_check_compiler_setup.cmake

### DIFF
--- a/cmake/macros/check_compiler_setup/CMakeLists.txt
+++ b/cmake/macros/check_compiler_setup/CMakeLists.txt
@@ -1,0 +1,8 @@
+project(CheckCompilerSetup)
+cmake_minimum_required(VERSION 3.13.4)
+add_executable(CheckCompilerSetupExec dummy.cpp)
+
+target_compile_options(CheckCompilerSetupExec PRIVATE ${TEST_COMPILE_FLAGS})
+set_property(TARGET CheckCompilerSetupExec PROPERTY LINK_FLAGS "${TEST_LINK_OPTIONS}")
+target_link_libraries(CheckCompilerSetupExec ${TEST_LINK_LIBRARIES})
+

--- a/cmake/macros/check_compiler_setup/dummy.cpp
+++ b/cmake/macros/check_compiler_setup/dummy.cpp
@@ -1,0 +1,1 @@
+int main(){ return 0; }

--- a/cmake/macros/macro_check_compiler_setup.cmake
+++ b/cmake/macros/macro_check_compiler_setup.cmake
@@ -32,6 +32,8 @@ macro(check_compiler_setup _compiler_flags_unstr _linker_flags_unstr _var)
   string(STRIP "${_compiler_flags_unstr}" _compiler_flags)
   string(STRIP "${_linker_flags_unstr}" _linker_flags)
 
+  separate_arguments(_compiler_flags)
+
   #
   # Rerun this test if flags have changed:
   #
@@ -49,13 +51,23 @@ macro(check_compiler_setup _compiler_flags_unstr _linker_flags_unstr _var)
     )
   set(CACHED_${_var}_ARGN "${ARGN}" CACHE INTERNAL "" FORCE)
 
-  set(CMAKE_REQUIRED_FLAGS "${_compiler_flags} ${_linker_flags}")
-  set(CMAKE_REQUIRED_LIBRARIES ${ARGN})
+  message(STATUS "Testing ${_var}")
 
-  CHECK_CXX_SOURCE_COMPILES("int main(){ return 0; }" ${_var})
-  reset_cmake_required()
+  try_compile(
+    ${_var}
+    ${CMAKE_CURRENT_BINARY_DIR}/check_compiler_setup/CheckCompilerSetup${_var}
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/macros/check_compiler_setup
+    CheckCompilerSetup${_var}
+    CMAKE_FLAGS "-DTEST_COMPILE_FLAGS=${_compiler_flags}"
+                "-DTEST_LINK_OPTIONS=${_linker_flags}"
+                "-DTEST_LINK_LIBRARIES=${ARGN}"
+                "-DCMAKE_VERBOSE_MAKEFILE=ON"
+    OUTPUT_VARIABLE _output)
 
   if(${_var})
     set(${_var} TRUE CACHE INTERNAL "")
+    file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/check_compiler_setup/CheckCompilerSetup${var})
+  else()
+    message(STATUS "Compiler setup check for ${_var} failed with:\n${_output}")
   endif()
 endmacro()


### PR DESCRIPTION
Part of #14751. `Kokkos` exports some (necessary) compile options for `Clang+Cuda` that the linker cannot use, see https://github.com/dealii/dealii/issues/14749. However, `CMAKE_REQUIRED_FLAGS` behaves like `CMAKE_CXX_FLAGS` in that the flags are both used for compiling and linking.
This pull request replaces `CHECK_CXX_SOURCE_COMPILES` with `try_run` to build a custom project where we can set `target_compile_options`, `target_link_options` and `target_link_libraries` separately.