### PR TITLE
Use Kokkos::abort directly

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/kokkos.h>
+#include <Kokkos_Core.hpp>
 
 #include <exception>
 #include <ostream>
@@ -1524,7 +1524,7 @@ namespace deal_II_exceptions
           }))                                                                \
           KOKKOS_IF_ON_DEVICE(({                                             \
             if (!(cond))                                                     \
-              dealii::internal::kokkos_abort(#cond);                         \
+              Kokkos::abort(#cond);                                          \
           }))                                                                \
         }
 #    else /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
@@ -1544,7 +1544,7 @@ namespace deal_II_exceptions
           }))                                                                \
           KOKKOS_IF_ON_DEVICE(({                                             \
             if (!(cond))                                                     \
-              dealii::internal::kokkos_abort(#cond);                         \
+              Kokkos::abort(#cond);                                          \
           }))                                                                \
         }
 #    endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
@@ -1580,10 +1580,10 @@ namespace deal_II_exceptions
           }
 #      endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 #    else    /*#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST*/
-#      define Assert(cond, exc)                    \
-        {                                          \
-          if (!(cond))                             \
-            dealii::internal::kokkos_abort(#cond); \
+#      define Assert(cond, exc)   \
+        {                         \
+          if (!(cond))            \
+            Kokkos::abort(#cond); \
         }
 #    endif /*ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST*/
 #  endif   /*KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST*/

--- a/include/deal.II/base/kokkos.h
+++ b/include/deal.II/base/kokkos.h
@@ -34,13 +34,6 @@ namespace internal
   void
   ensure_kokkos_initialized();
 
-  /**
-   * Calls Kokkos::abort. This wrapper avoids including Kokkos_Core.hpp, which
-   * provides all of Kokkos' functionalities, on the call side.
-   */
-  KOKKOS_FUNCTION void
-  kokkos_abort(const char *error);
-
 } // namespace internal
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1166,7 +1166,7 @@ namespace internal
       KOKKOS_IF_ON_DEVICE(({
         (void)val;
         (void)s;
-        dealii::internal::kokkos_abort(
+        Kokkos::abort(
           "This function is not implemented for std::complex<Number>!\n");
       }))
 #  else
@@ -1175,7 +1175,7 @@ namespace internal
 #    else
       (void)val;
       (void)s;
-      dealii::internal::kokkos_abort(
+      Kokkos::abort(
         "This function is not implemented for std::complex<Number>!\n");
 #    endif
 #  endif

--- a/source/base/kokkos.cc
+++ b/source/base/kokkos.cc
@@ -41,11 +41,5 @@ namespace internal
         (void)dummy;
       }
   }
-
-  KOKKOS_FUNCTION void
-  kokkos_abort(const char *error)
-  {
-    Kokkos::abort(error);
-  }
 } // namespace internal
 DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
Part of #14751. This reverts some changes in https://github.com/dealii/dealii/pull/14753.
`CUDA` and `HIP` device functions can only be used in a different translation unit if special flags are passed that allow this. However, allowing relocatable device code oftentimes prevents optimization. In particular, it doesn't seem worth it if we would only need it for `kokkos_abort`. Thus, this pull request uses `Kokkos::abort` directly at the cost of including `Kokkos_Core.hpp`. An alternative would be to just ignore `Assert` in kernels executed on the device.