### PR TITLE
Suppress some nvcc warnings

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -179,6 +179,7 @@ jobs:
               -D CMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/../kokkos-install \
               -D Kokkos_ENABLE_CUDA=ON \
               -D Kokkos_ENABLE_CUDA_LAMBDA=ON \
+              -D Kokkos_ENABLE_CUDA_CONSTEXPR=ON \
               -D Kokkos_ARCH_VOLTA70=ON \
               ..
         make install

--- a/cmake/macros/macro_deal_ii_add_library.cmake
+++ b/cmake/macros/macro_deal_ii_add_library.cmake
@@ -41,7 +41,12 @@ macro(deal_ii_add_library _library)
       )
 
     set(_flags "${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_${_build}}")
-    separate_arguments(_flags)
+
+    # Make sure some CUDA warning flags don't get deduplicated
+    string(REGEX REPLACE "(-Xcudafe --diag_suppress=[^ ]+)" "\"SHELL:\\1\"" _flags ${_flags})
+
+    separate_arguments(_flags UNIX_COMMAND ${_flags})
+
     target_compile_options(${_library}_${_build_lowercase} PUBLIC ${_flags})
 
     target_compile_definitions(${_library}_${_build_lowercase}

--- a/cmake/macros/macro_deal_ii_setup_target.cmake
+++ b/cmake/macros/macro_deal_ii_setup_target.cmake
@@ -115,7 +115,11 @@ macro(deal_ii_setup_target _target)
     )
 
   set(_flags "${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_${_build}}")
-  separate_arguments(_flags)
+
+  # Make sure some CUDA warning flags don't get deduplicated
+  string(REGEX REPLACE "(-Xcudafe --diag_suppress=[^ ]+)" "\"SHELL:\\1\"" _flags ${_flags})
+
+  separate_arguments(_flags UNIX_COMMAND ${_flags})
 
   target_compile_options(${_target} PUBLIC ${_flags})
 

--- a/cmake/macros/macro_enable_if_supported.cmake
+++ b/cmake/macros/macro_enable_if_supported.cmake
@@ -38,7 +38,7 @@ macro(enable_if_supported _variable _flag)
 
   if(NOT "${_flag_stripped}" STREQUAL "")
     string(REGEX REPLACE "^-" "" _flag_name "${_flag_stripped}")
-    string(REGEX REPLACE "\[-+,\]" "_" _flag_name "${_flag_name}")
+    string(REGEX REPLACE "\[-+,= \]" "_" _flag_name "${_flag_name}")
 
     CHECK_CXX_COMPILER_FLAG("${_flag_sanitized}" DEAL_II_HAVE_FLAG_${_flag_name})
 

--- a/cmake/macros/macro_insource_setup_target.cmake
+++ b/cmake/macros/macro_insource_setup_target.cmake
@@ -41,7 +41,12 @@ function(insource_setup_target _target _build)
   target_include_directories(${_target} SYSTEM PRIVATE ${DEAL_II_INCLUDE_DIRS})
 
   set(_flags "${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_${_build}}")
-  separate_arguments(_flags)
+
+  # Make sure some CUDA warning flags don't get deduplicated
+  string(REGEX REPLACE "(-Xcudafe --diag_suppress=[^ ]+)" "\"SHELL:\\1\"" _flags ${_flags})
+
+  separate_arguments(_flags UNIX_COMMAND ${_flags})
+
   target_compile_options(${_target} PUBLIC ${_flags})
 
   target_compile_definitions(${_target}

--- a/cmake/modules/FindDEAL_II_CUDA.cmake
+++ b/cmake/modules/FindDEAL_II_CUDA.cmake
@@ -40,9 +40,17 @@ if(CUDA_FOUND)
   message(STATUS "Configured to use CUDA installation at ${CUDA_TOOLKIT_ROOT_DIR}")
 endif()
 
+enable_if_supported(_cuda_flags "-Xcudafe --diag_suppress=unsigned_compare_with_zero")
+enable_if_supported(_cuda_flags "-Xcudafe --diag_suppress=integer_sign_change")
+enable_if_supported(_cuda_flags "-Xcudafe --diag_suppress=20208") # long double treated as double
+enable_if_supported(_cuda_flags "-Xcudafe --diag_suppress=1301")  # non-template friend
+enable_if_supported(_cuda_flags "-Wno-non-template-friend")
+enable_if_supported(_cuda_flags "-Xcudafe --diag_suppress=loop_not_reachable")
+
 process_feature(CUDA
   LIBRARIES REQUIRED CUDA_LIBRARIES CUDA_cusparse_LIBRARY CUDA_cusolver_LIBRARY
   INCLUDE_DIRS REQUIRED CUDA_INCLUDE_DIRS
+  CXX_FLAGS OPTIONAL _cuda_flags
   CLEAR
     CUDA_cublas_device_LIBRARY
     CUDA_cublas_LIBRARY

--- a/include/deal.II/base/parsed_convergence_table.h
+++ b/include/deal.II/base/parsed_convergence_table.h
@@ -609,9 +609,9 @@ ParsedConvergenceTable::error_from_exact(const Mapping<dim, spacedim> &mapping,
             continue;
 
           auto components_expr = zero_components;
-          for (unsigned int i = 0; i < n_components; ++i)
-            if (mask[i] == true)
-              components_expr[i] = weight_components[i];
+          for (unsigned int j = 0; j < n_components; ++j)
+            if (mask[j] == true)
+              components_expr[j] = weight_components[j];
 
           FunctionFromFunctionObjects<spacedim> select_component(
             components_expr);

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -9086,8 +9086,6 @@ DataOutBase::write_hdf5_parallel(
       "DataOutBase was asked to write HDF5 output for a space dimension of 1. "
       "HDF5 only supports datasets that live in 2 or 3 dimensions."));
 
-  int ierr = 0;
-  (void)ierr;
 #ifndef DEAL_II_WITH_HDF5
   // throw an exception, but first make sure the compiler does not warn about
   // the now unused function arguments
@@ -9144,7 +9142,7 @@ DataOutBase::write_hdf5_parallel(
                                    split_comm);
     }
 
-  ierr = MPI_Comm_free(&split_comm);
+  const int ierr = MPI_Comm_free(&split_comm);
   AssertThrowMPI(ierr);
 
 #endif


### PR DESCRIPTION
There are a bunch of warnings emitted by `nvcc` we don't really care about. Of particular annoyance are:
-  unsigned_compare_with_zero
- integer_sign_change
- long double treated as double (mostly boost)
- non-template friend (boost)
- loop_not_reachable

Allowing `constexpr` `host` functions to be called in `device` code also limits the number of warnings.