### PR TITLE
Remove checks for CMake versions prior to 3.13.4

### DIFF
--- a/cmake/configure/configure_40_cuda.cmake
+++ b/cmake/configure/configure_40_cuda.cmake
@@ -53,19 +53,6 @@ macro(feature_cuda_find_external var)
       set(${var} TRUE)
 
       #
-      # CUDA support requires CMake version 3.9 or newer
-      #
-      if(CMAKE_VERSION VERSION_LESS 3.9)
-        set(${var} FALSE)
-        message(STATUS "deal.II requires CMake version 3.9, or newer for CUDA support")
-        set(CUDA_ADDITIONAL_ERROR_STRING
-          ${CUDA_ADDITIONAL_ERROR_STRING}
-          "deal.II requires CMake version 3.9, or newer for CUDA support.\n"
-          "Reconfigure with a sufficient cmake version."
-          )
-      endif()
-
-      #
       # disable CUDA support older than 10.2:
       #
       if(CUDA_VERSION VERSION_LESS 10.2)

--- a/cmake/macros/macro_deal_ii_add_library.cmake
+++ b/cmake/macros/macro_deal_ii_add_library.cmake
@@ -40,26 +40,13 @@ macro(deal_ii_add_library _library)
       LINKER_LANGUAGE "CXX"
       )
 
-    if(CMAKE_VERSION VERSION_LESS 3.9 OR CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    set(_flags "${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_${_build}}")
+    separate_arguments(_flags)
+    target_compile_options(${_library}_${_build_lowercase} PUBLIC ${_flags})
 
-      set_target_properties(${_library}_${_build_lowercase} PROPERTIES
-        COMPILE_FLAGS "${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_${_build}}"
-        COMPILE_DEFINITIONS "${DEAL_II_DEFINITIONS};${DEAL_II_DEFINITIONS_${_build}}"
-        )
-
-    else()
-
-      set(_flags "${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_${_build}}")
-      separate_arguments(_flags)
-      target_compile_options(${_library}_${_build_lowercase} PUBLIC
-        $<$<COMPILE_LANGUAGE:CXX>:${_flags}>
-        )
-
-      target_compile_definitions(${_library}_${_build_lowercase}
-        PUBLIC ${DEAL_II_DEFINITIONS} ${DEAL_II_DEFINITIONS_${_build}}
-        )
-
-    endif()
+    target_compile_definitions(${_library}_${_build_lowercase}
+      PUBLIC ${DEAL_II_DEFINITIONS} ${DEAL_II_DEFINITIONS_${_build}}
+      )
 
     set_property(GLOBAL APPEND PROPERTY DEAL_II_OBJECTS_${_build}
       "$<TARGET_OBJECTS:${_library}_${_build_lowercase}>"

--- a/cmake/macros/macro_deal_ii_setup_target.cmake
+++ b/cmake/macros/macro_deal_ii_setup_target.cmake
@@ -114,27 +114,14 @@ macro(deal_ii_setup_target _target)
     LINK_FLAGS " ${DEAL_II_LINKER_FLAGS} ${DEAL_II_LINKER_FLAGS_${_build}}"
     )
 
-  if(CMAKE_VERSION VERSION_LESS 3.9 OR CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-    set_property(TARGET ${_target} APPEND_STRING PROPERTY
-      COMPILE_FLAGS " ${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_${_build}}"
-      )
-    set_property(TARGET ${_target} APPEND PROPERTY
-      COMPILE_DEFINITIONS "${DEAL_II_DEFINITIONS};${DEAL_II_DEFINITIONS_${_build}}"
-      )
+  set(_flags "${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_${_build}}")
+  separate_arguments(_flags)
 
-  else()
+  target_compile_options(${_target} PUBLIC ${_flags})
 
-    set(_flags "${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_${_build}}")
-    separate_arguments(_flags)
-    target_compile_options(${_target} PUBLIC
-      $<$<COMPILE_LANGUAGE:CXX>:${_flags}>
-      )
-
-    target_compile_definitions(${_target}
-      PUBLIC ${DEAL_II_DEFINITIONS} ${DEAL_II_DEFINITIONS_${_build}}
-      )
-
-  endif()
+  target_compile_definitions(${_target}
+    PUBLIC ${DEAL_II_DEFINITIONS} ${DEAL_II_DEFINITIONS_${_build}}
+    )
 
   #
   # Set up the link interface:

--- a/cmake/macros/macro_insource_setup_target.cmake
+++ b/cmake/macros/macro_insource_setup_target.cmake
@@ -40,26 +40,13 @@ function(insource_setup_target _target _build)
     )
   target_include_directories(${_target} SYSTEM PRIVATE ${DEAL_II_INCLUDE_DIRS})
 
-  if(CMAKE_VERSION VERSION_LESS 3.9 OR CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-    set_property(TARGET ${_target} APPEND_STRING PROPERTY
-      COMPILE_FLAGS " ${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_${_build}}"
-      )
-    set_property(TARGET ${_target} APPEND PROPERTY
-      COMPILE_DEFINITIONS "${DEAL_II_DEFINITIONS};${DEAL_II_DEFINITIONS_${_build}}"
-      )
+  set(_flags "${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_${_build}}")
+  separate_arguments(_flags)
+  target_compile_options(${_target} PUBLIC ${_flags})
 
-  else()
-
-    set(_flags "${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_${_build}}")
-    separate_arguments(_flags)
-    target_compile_options(${_target} PUBLIC
-      $<$<COMPILE_LANGUAGE:CXX>:${_flags}>
-      )
-
-    target_compile_definitions(${_target}
-      PUBLIC ${DEAL_II_DEFINITIONS} ${DEAL_II_DEFINITIONS_${_build}}
-      )
-  endif()
+  target_compile_definitions(${_target}
+    PUBLIC ${DEAL_II_DEFINITIONS} ${DEAL_II_DEFINITIONS_${_build}}
+    )
 
   get_property(_type TARGET ${_target} PROPERTY TYPE)
   if(NOT "${_type}" STREQUAL "OBJECT_LIBRARY")

--- a/contrib/python-bindings/CMakeLists.txt
+++ b/contrib/python-bindings/CMakeLists.txt
@@ -21,15 +21,10 @@ if(DEAL_II_COMPONENT_PYTHON_BINDINGS)
   #
   # Find Python:
   #
-  # Since CMake 3.12, FindPythonInterp is deprecated.
-  if (CMAKE_VERSION VERSION_LESS 3.12)
-    include(FindPythonInterp)
-  else()
-    find_package(Python3)
-    set(PYTHON_VERSION_MAJOR ${Python3_VERSION_MAJOR})
-    set(PYTHON_VERSION_MINOR ${Python3_VERSION_MINOR})
-    set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
-  endif()
+  find_package(Python3)
+  set(PYTHON_VERSION_MAJOR ${Python3_VERSION_MAJOR})
+  set(PYTHON_VERSION_MINOR ${Python3_VERSION_MINOR})
+  set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
   include(FindPythonLibs)
 
   if(DEAL_II_FEATURE_BOOST_BUNDLED_CONFIGURED)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -155,11 +155,6 @@ if(DEFINED DEAL_II_HAVE_TESTS_DIRECTORY)
   # Define a top-level "test" target that runs our quick tests wrapper.
   #
 
-  if("${CMAKE_VERSION}" VERSION_LESS "3.11" AND POLICY CMP0037)
-    # allow to override "test" target for quick tests
-    cmake_policy(SET CMP0037 OLD)
-  endif()
-
   # Use the first available build type (this prefers debug mode if available):
   list(GET DEAL_II_BUILD_TYPES 0 _my_build)
   add_custom_target(test


### PR DESCRIPTION
We don't need to use `set_target_properties` for MSVC if we only care about C++ code. Since the update to using `Kokkos` for `Cuda` support, `C++` is the only relevant language here.