### PR TITLE
Fix DEAL_II_COMPILER_HAS_ATTRIBUTE_ALWAYS_INLINE with -Werror

### DIFF
--- a/cmake/checks/check_02_compiler_features.cmake
+++ b/cmake/checks/check_02_compiler_features.cmake
@@ -276,7 +276,7 @@ endif()
 #
 CHECK_CXX_SOURCE_COMPILES(
   "
-          __attribute__((always_inline)) int fn () { return 0; }
+          __attribute__((always_inline)) inline int fn () { return 0; }
           int main () { return fn(); }
   "
   DEAL_II_COMPILER_HAS_ATTRIBUTE_ALWAYS_INLINE

--- a/cmake/setup_compiler_flags_intel.cmake
+++ b/cmake/setup_compiler_flags_intel.cmake
@@ -48,6 +48,7 @@ enable_if_supported(DEAL_II_CXX_FLAGS "-w2")
 # Disable remarks like "Inlining inhibited by limit max-size"
 #
 enable_if_supported(DEAL_II_CXX_FLAGS "-diag-disable=remark")
+enable_if_supported(DEAL_II_CXX_FLAGS "-diag-disable=16219")
 
 #
 # Disable some warnings that lead to a lot of false positives:


### PR DESCRIPTION
`always_inline` requires `inline`