### PR TITLE
Fix hp decision on coarse level cells.

### DIFF
--- a/examples/step-75/doc/results.dox
+++ b/examples/step-75/doc/results.dox
@@ -17,40 +17,40 @@ Cycle 0:
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |     0.598s |            |
+| Total wallclock time elapsed since start    |     0.172s |            |
 |                                             |            |            |
 | Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| calculate transformation        |         1 |    0.0533s |       8.9% |
-| compute indicators              |         1 |    0.0177s |         3% |
-| initialize grid                 |         1 |    0.0397s |       6.6% |
-| output results                  |         1 |    0.0844s |        14% |
-| setup system                    |         1 |    0.0351s |       5.9% |
-| solve system                    |         1 |     0.362s |        61% |
+| calculate transformation        |         1 |    0.0194s |        11% |
+| compute indicators              |         1 |   0.00676s |       3.9% |
+| initialize grid                 |         1 |     0.011s |       6.4% |
+| output results                  |         1 |    0.0343s |        20% |
+| setup system                    |         1 |   0.00839s |       4.9% |
+| solve system                    |         1 |    0.0896s |        52% |
 +---------------------------------+-----------+------------+------------+
 
 
 Cycle 1:
    Number of active cells:       3351
      by partition:               875 761 843 872
-   Number of degrees of freedom: 18223
-     by partition:               4535 4735 4543 4410
+   Number of degrees of freedom: 18228
+     by partition:               4535 4735 4543 4415
    Number of constraints:        1202
      by partition:               303 290 326 283
-   Frequencies of poly. degrees: 2:2523 3:828
+   Frequencies of poly. degrees: 2:2522 3:829
    Solved in 7 iterations.
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |     0.442s |            |
+| Total wallclock time elapsed since start    |     0.165s |            |
 |                                             |            |            |
 | Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| adapt resolution                |         1 |    0.0189s |       4.3% |
-| compute indicators              |         1 |    0.0135s |         3% |
-| output results                  |         1 |     0.064s |        14% |
-| setup system                    |         1 |    0.0232s |       5.2% |
-| solve system                    |         1 |     0.322s |        73% |
+| adapt resolution                |         1 |   0.00473s |       2.9% |
+| compute indicators              |         1 |   0.00764s |       4.6% |
+| output results                  |         1 |    0.0243s |        15% |
+| setup system                    |         1 |   0.00662s |         4% |
+| solve system                    |         1 |     0.121s |        74% |
 +---------------------------------+-----------+------------+------------+
 
 
@@ -60,24 +60,24 @@ Cycle 1:
 Cycle 7:
    Number of active cells:       5610
      by partition:               1324 1483 1482 1321
-   Number of degrees of freedom: 82062
-     by partition:               21116 19951 20113 20882
-   Number of constraints:        14383
-     by partition:               3825 3225 3557 3776
-   Frequencies of poly. degrees: 2:1130 3:1283 4:2727 5:465 6:5
+   Number of degrees of freedom: 82047
+     by partition:               21098 19960 20111 20878
+   Number of constraints:        14357
+     by partition:               3807 3229 3554 3767
+   Frequencies of poly. degrees: 2:1126 3:1289 4:2725 5:465 6:5
    Solved in 7 iterations.
 
 
 +---------------------------------------------+------------+------------+
-| Total wallclock time elapsed since start    |     0.932s |            |
+| Total wallclock time elapsed since start    |      1.83s |            |
 |                                             |            |            |
 | Section                         | no. calls |  wall time | % of total |
 +---------------------------------+-----------+------------+------------+
-| adapt resolution                |         1 |    0.0182s |       1.9% |
-| compute indicators              |         1 |    0.0173s |       1.9% |
-| output results                  |         1 |    0.0572s |       6.1% |
-| setup system                    |         1 |    0.0252s |       2.7% |
-| solve system                    |         1 |     0.813s |        87% |
+| adapt resolution                |         1 |   0.00834s |      0.46% |
+| compute indicators              |         1 |    0.0178s |      0.97% |
+| output results                  |         1 |    0.0434s |       2.4% |
+| setup system                    |         1 |    0.0165s |       0.9% |
+| solve system                    |         1 |      1.74s |        95% |
 +---------------------------------+-----------+------------+------------+
 @endcode
 

--- a/examples/step-75/step-75.cc
+++ b/examples/step-75/step-75.cc
@@ -1351,15 +1351,6 @@ namespace Step75
                                               prm.p_refine_fraction,
                                               prm.p_coarsen_fraction);
 
-    // At this stage, we have both the future FE indices and the classic refine
-    // and coarsen flags set, from which the latter will be interpreted by
-    // Triangulation::execute_coarsening_and_refinement() for h-adaptation.
-    // We would like to only impose one type of adaptation on cells, which is
-    // what the next function will sort out for us. In short, on cells which
-    // have both types of indicators assigned, we will favor the p-adaptation
-    // one and remove the h-adaptation one.
-    hp::Refinement::choose_p_over_h(dof_handler);
-
     // After setting all indicators, we will remove those that exceed the
     // specified limits of the provided level ranges in the Parameters struct.
     // This limitation naturally arises for p-adaptation as the number of
@@ -1383,6 +1374,18 @@ namespace Step75
     for (const auto &cell :
          triangulation.active_cell_iterators_on_level(prm.min_h_level))
       cell->clear_coarsen_flag();
+
+    // At this stage, we have both the future FE indices and the classic refine
+    // and coarsen flags set. The latter will be interpreted by
+    // Triangulation::execute_coarsening_and_refinement() for h-adaptation, and
+    // our previous modification ensures that the resulting Triangulation stays
+    // within the specified level range.
+    //
+    // Now, we would like to only impose one type of adaptation on cells, which
+    // is what the next function will sort out for us. In short, on cells which
+    // have both types of indicators assigned, we will favor the p-adaptation
+    // one and remove the h-adaptation one.
+    hp::Refinement::choose_p_over_h(dof_handler);
 
     // In the end, we are left to execute coarsening and refinement. Here, not
     // only the grid will be updated, but also all previous future FE indices

--- a/source/hp/refinement.cc
+++ b/source/hp/refinement.cc
@@ -585,6 +585,11 @@ namespace hp
           // determine degree of its future finite element
           if (cell->coarsen_flag_set())
             {
+              Assert(cell->level() > 0,
+                     ExcMessage("A coarse cell is flagged for coarsening. "
+                                "Please read the note in the documentation "
+                                "of predict_error()."));
+
               // cell will be coarsened, thus determine future finite element
               // on parent cell
               const auto &parent = cell->parent();
@@ -705,6 +710,15 @@ namespace hp
             // or p-adaptivity.
             if (cell->coarsen_flag_set())
               {
+                if (cell->level() == 0)
+                  {
+                    // This cell is a coarse cell and has neither parent nor
+                    // siblings, thus it cannot be h-coarsened.
+                    // Clear the flag and move on to the next cell.
+                    cell->clear_coarsen_flag();
+                    continue;
+                  }
+
                 const auto &       parent     = cell->parent();
                 const unsigned int n_children = parent->n_children();
 


### PR DESCRIPTION
Some functions in `hp::Refinement` ask for parents of coarse cells (level = 0), which does not work.

Further, in `step-75`, we should decide whether to perform h- or p-adaptation *after* limiting the h-levels. Otherwise, we might favor h-coarsening over p-coarsening on cells that cannot be h-coarsened -- which does not make sense and we would unintentionally drop the p-coarsening flags.