### PR TITLE
disable -Wdeprecated-builtins for boost

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -481,6 +481,7 @@ _Pragma("GCC diagnostic ignored \"-Wunknown-warning\"")           /*!*/ \
 _Pragma("GCC diagnostic ignored \"-Wextra\"")                     /*!*/ \
 _Pragma("GCC diagnostic ignored \"-Waddress-of-packed-member\"")        \
 _Pragma("GCC diagnostic ignored \"-Wcast-function-type\"")              \
+_Pragma("GCC diagnostic ignored \"-Wdeprecated-builtins\"")             \
 _Pragma("GCC diagnostic ignored \"-Wdeprecated-copy\"")                 \
 _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")         \
 _Pragma("GCC diagnostic ignored \"-Wdeprecated-volatile\"")             \

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -25,7 +25,9 @@
 #include <deal.II/base/template_constraints.h>
 #include <deal.II/base/utilities.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/signals2.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <complex>
 #include <limits>

--- a/include/deal.II/base/parameter_acceptor.h
+++ b/include/deal.II/base/parameter_acceptor.h
@@ -23,7 +23,9 @@
 #include <deal.II/base/parameter_handler.h>
 #include <deal.II/base/smartpointer.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/signals2/signal.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <typeinfo>
 

--- a/include/deal.II/base/std_cxx17/optional.h
+++ b/include/deal.II/base/std_cxx17/optional.h
@@ -20,7 +20,9 @@
 #ifdef DEAL_II_HAVE_CXX17
 #  include <optional>
 #else
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <boost/optional.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #endif
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/differentiation/ad/ad_number_traits.h
+++ b/include/deal.II/differentiation/ad/ad_number_traits.h
@@ -23,7 +23,9 @@
 
 #include <deal.II/differentiation/ad/ad_number_types.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/type_traits.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <complex>
 #include <type_traits>

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -25,7 +25,9 @@
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/utilities.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/container/small_vector.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <iosfwd>
 #include <string>

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -31,11 +31,13 @@
 #include <deal.II/grid/tria_iterator_selector.h>
 #include <deal.II/grid/tria_levels.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/serialization/map.hpp>
 #include <boost/serialization/split_member.hpp>
 #include <boost/serialization/unique_ptr.hpp>
 #include <boost/serialization/vector.hpp>
 #include <boost/signals2.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <bitset>
 #include <functional>

--- a/include/deal.II/lac/la_vector.h
+++ b/include/deal.II/lac/la_vector.h
@@ -28,6 +28,7 @@
 #include <deal.II/lac/vector_space_vector.h>
 #include <deal.II/lac/vector_type_traits.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 // boost::serialization::make_array used to be in array.hpp, but was
 // moved to a different file in BOOST 1.64
 #include <boost/version.hpp>
@@ -37,6 +38,7 @@
 #  include <boost/serialization/array.hpp>
 #endif
 #include <boost/serialization/split_member.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <cstdio>
 #include <cstring>

--- a/include/deal.II/lac/sparsity_pattern.h
+++ b/include/deal.II/lac/sparsity_pattern.h
@@ -26,6 +26,7 @@
 
 #include <deal.II/lac/sparsity_pattern_base.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 // boost::serialization::make_array used to be in array.hpp, but was
 // moved to a different file in BOOST 1.64
 #include <boost/version.hpp>
@@ -35,6 +36,7 @@
 #  include <boost/serialization/array.hpp>
 #endif
 #include <boost/serialization/split_member.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <algorithm>
 #include <iostream>

--- a/include/deal.II/particles/particle.h
+++ b/include/deal.II/particles/particle.h
@@ -24,7 +24,9 @@
 
 #include <deal.II/particles/property_pool.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/serialization/array.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <cstdint>
 


### PR DESCRIPTION
clang-15 reports

/home/ubuntu/deal-git/bundled/boost-1.70.0/include/boost/type_traits/has_trivial_destructor.hpp:30:86: warning: buil
tin __has_trivial_destructor is deprecated; use
__is_trivially_destructible instead [-Wdeprecated-builtins] t

We should silence these warnings.