### PR TITLE
CI: Jenkins increase timeout

### DIFF
--- a/contrib/ci/Jenkinsfile.mpi
+++ b/contrib/ci/Jenkinsfile.mpi
@@ -89,7 +89,7 @@ pipeline
         {
           steps
           {
-            timeout(time: 2, unit: 'HOURS')
+            timeout(time: 4, unit: 'HOURS')
             {
               sh "echo \"building on node ${env.NODE_NAME}\""
               sh '''#!/bin/bash


### PR DESCRIPTION
With all MPI tests we are now often close to the 2 hour mark (depends on test ordering). Increase the timeout to avoid problems like in #14803.