### PR TITLE
Fix Tpetra detection and unit tests

### DIFF
--- a/cmake/configure/configure_20_trilinos.cmake
+++ b/cmake/configure/configure_20_trilinos.cmake
@@ -241,9 +241,9 @@ macro(feature_trilinos_find_external var)
       add_flags(CMAKE_REQUIRED_FLAGS "${DEAL_II_CXX_FLAGS} ${DEAL_II_LINKER_FLAGS}")
 
       if(DEAL_II_WITH_64BIT_INDICES)
-        set(_global_index_type "std::uint64_t")
+        set(_global_index_type "std::int64_t")
       else()
-        set(_global_index_type "unsigned int")
+        set(_global_index_type "int")
       endif()
 
       CHECK_CXX_SOURCE_COMPILES(
@@ -253,7 +253,7 @@ macro(feature_trilinos_find_external var)
         int main()
         {
           using LO       = int;
-          using GO       = std::make_signed_t<${_global_index_type}>;
+          using GO       = ${_global_index_type};
           using map_type = Tpetra::Map<LO, GO>;
           Teuchos::RCP<const map_type>   dummy_map = Teuchos::rcp(new map_type());
           Tpetra::Vector<double, LO, GO> dummy_vector(dummy_map);

--- a/cmake/configure/configure_20_trilinos.cmake
+++ b/cmake/configure/configure_20_trilinos.cmake
@@ -233,6 +233,7 @@ macro(feature_trilinos_find_external var)
       list(APPEND CMAKE_REQUIRED_INCLUDES ${MPI_CXX_INCLUDE_PATH})
 
       list(APPEND CMAKE_REQUIRED_LIBRARIES ${Trilinos_LIBRARIES} ${MPI_LIBRARIES})
+      list(APPEND CMAKE_REQUIRED_FLAGS ${TRILINOS_CXX_FLAGS})
 
       # For the case of Trilinos being compiled with openmp support the
       # following Tpetra test needs -fopenmp to succeed. Make sure that we
@@ -249,11 +250,10 @@ macro(feature_trilinos_find_external var)
         "
         #include <cstdint>
         #include <Tpetra_Vector.hpp>
-        int
-        main()
+        int main()
         {
           using LO       = int;
-          using GO       = ${_global_index_type};
+          using GO       = std::make_signed_t<${_global_index_type}>;
           using map_type = Tpetra::Map<LO, GO>;
           Teuchos::RCP<const map_type>   dummy_map = Teuchos::rcp(new map_type());
           Tpetra::Vector<double, LO, GO> dummy_vector(dummy_map);
@@ -283,6 +283,7 @@ macro(feature_trilinos_find_external var)
       list(APPEND CMAKE_REQUIRED_INCLUDES ${MPI_CXX_INCLUDE_PATH})
 
       list(APPEND CMAKE_REQUIRED_LIBRARIES ${Trilinos_LIBRARIES} ${MPI_LIBRARIES})
+      list(APPEND CMAKE_REQUIRED_FLAGS ${TRILINOS_CXX_FLAGS})
 
       CHECK_CXX_SOURCE_COMPILES(
         "

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -496,7 +496,7 @@ public:
                     const bool      overlapping  = false) const;
 
 #  ifdef DEAL_II_TRILINOS_WITH_TPETRA
-  Tpetra::Map<int, std::make_signed_t<types::global_dof_index>>
+  Tpetra::Map<int, types::signed_global_dof_index>
   make_tpetra_map(const MPI_Comm &communicator = MPI_COMM_WORLD,
                   const bool      overlapping  = false) const;
 #  endif

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -496,7 +496,7 @@ public:
                     const bool      overlapping  = false) const;
 
 #  ifdef DEAL_II_TRILINOS_WITH_TPETRA
-  Tpetra::Map<int, types::global_dof_index>
+  Tpetra::Map<int, std::make_signed_t<types::global_dof_index>>
   make_tpetra_map(const MPI_Comm &communicator = MPI_COMM_WORLD,
                   const bool      overlapping  = false) const;
 #  endif

--- a/include/deal.II/base/types.h
+++ b/include/deal.II/base/types.h
@@ -20,6 +20,7 @@
 #include <deal.II/base/config.h>
 
 #include <cstdint>
+#include <type_traits> // make_signed_t
 
 
 DEAL_II_NAMESPACE_OPEN
@@ -80,6 +81,13 @@ namespace types
 #else
   using global_dof_index  = unsigned int;
 #endif
+
+  /**
+   * Signed version of global_dof_index.
+   * This is useful for interacting with Trilinos' Tpetra that only works well
+   * with a signed global ordinal type.
+   */
+  using signed_global_dof_index = std::make_signed_t<global_dof_index>;
 
   /**
    * An identifier that denotes the MPI type associated with

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -657,9 +657,8 @@ namespace LinearAlgebra
      * used directly.
      */
     void
-    import(const Tpetra::
-             Vector<Number, int, std::make_signed_t<types::global_dof_index>>
-               &                   tpetra_vector,
+    import(const Tpetra::Vector<Number, int, types::signed_global_dof_index>
+             &                     tpetra_vector,
            const IndexSet &        locally_owned_elements,
            VectorOperation::values operation,
            const MPI_Comm &        mpi_comm,

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -657,13 +657,14 @@ namespace LinearAlgebra
      * used directly.
      */
     void
-    import(
-      const Tpetra::Vector<Number, int, types::global_dof_index> &tpetra_vector,
-      const IndexSet &        locally_owned_elements,
-      VectorOperation::values operation,
-      const MPI_Comm &        mpi_comm,
-      const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
-        &communication_pattern);
+    import(const Tpetra::
+             Vector<Number, int, std::make_signed_t<types::global_dof_index>>
+               &                   tpetra_vector,
+           const IndexSet &        locally_owned_elements,
+           VectorOperation::values operation,
+           const MPI_Comm &        mpi_comm,
+           const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
+             &communication_pattern);
 #  endif
 
     /**

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -577,10 +577,11 @@ namespace LinearAlgebra
   template <typename Number>
   void
   ReadWriteVector<Number>::import(
-    const Tpetra::Vector<Number, int, types::global_dof_index> &vector,
-    const IndexSet &                                            source_elements,
-    VectorOperation::values                                     operation,
-    const MPI_Comm &                                            mpi_comm,
+    const Tpetra::
+      Vector<Number, int, std::make_signed_t<types::global_dof_index>> &vector,
+    const IndexSet &        source_elements,
+    VectorOperation::values operation,
+    const MPI_Comm &        mpi_comm,
     const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
       &communication_pattern)
   {
@@ -620,11 +621,11 @@ namespace LinearAlgebra
                       "LinearAlgebra::TpetraWrappers::CommunicationPattern."));
       }
 
-    Tpetra::Export<int, types::global_dof_index> tpetra_export(
-      tpetra_comm_pattern->get_tpetra_export());
+    Tpetra::Export<int, std::make_signed_t<types::global_dof_index>>
+      tpetra_export(tpetra_comm_pattern->get_tpetra_export());
 
-    Tpetra::Vector<Number, int, types::global_dof_index> target_vector(
-      tpetra_export.getSourceMap());
+    Tpetra::Vector<Number, int, std::make_signed_t<types::global_dof_index>>
+      target_vector(tpetra_export.getSourceMap());
     target_vector.doImport(vector, tpetra_export, Tpetra::REPLACE);
 
     const auto *new_values = target_vector.getData().get();

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -577,8 +577,7 @@ namespace LinearAlgebra
   template <typename Number>
   void
   ReadWriteVector<Number>::import(
-    const Tpetra::
-      Vector<Number, int, std::make_signed_t<types::global_dof_index>> &vector,
+    const Tpetra::Vector<Number, int, types::signed_global_dof_index> &vector,
     const IndexSet &        source_elements,
     VectorOperation::values operation,
     const MPI_Comm &        mpi_comm,
@@ -621,11 +620,11 @@ namespace LinearAlgebra
                       "LinearAlgebra::TpetraWrappers::CommunicationPattern."));
       }
 
-    Tpetra::Export<int, std::make_signed_t<types::global_dof_index>>
-      tpetra_export(tpetra_comm_pattern->get_tpetra_export());
+    Tpetra::Export<int, types::signed_global_dof_index> tpetra_export(
+      tpetra_comm_pattern->get_tpetra_export());
 
-    Tpetra::Vector<Number, int, std::make_signed_t<types::global_dof_index>>
-      target_vector(tpetra_export.getSourceMap());
+    Tpetra::Vector<Number, int, types::signed_global_dof_index> target_vector(
+      tpetra_export.getSourceMap());
     target_vector.doImport(vector, tpetra_export, Tpetra::REPLACE);
 
     const auto *new_values = target_vector.getData().get();

--- a/include/deal.II/lac/trilinos_tpetra_communication_pattern.h
+++ b/include/deal.II/lac/trilinos_tpetra_communication_pattern.h
@@ -68,13 +68,13 @@ namespace LinearAlgebra
       /**
        * Return the underlying Tpetra::Import object.
        */
-      const Tpetra::Import<int, types::global_dof_index> &
+      const Tpetra::Import<int, std::make_signed_t<types::global_dof_index>> &
       get_tpetra_import() const;
 
       /**
        * Return the underlying Tpetra::Export object.
        */
-      const Tpetra::Export<int, types::global_dof_index> &
+      const Tpetra::Export<int, std::make_signed_t<types::global_dof_index>> &
       get_tpetra_export() const;
 
     private:
@@ -86,13 +86,15 @@ namespace LinearAlgebra
       /**
        * Shared pointer to the Tpetra::Import object used.
        */
-      std::unique_ptr<Tpetra::Import<int, types::global_dof_index>>
+      std::unique_ptr<
+        Tpetra::Import<int, std::make_signed_t<types::global_dof_index>>>
         tpetra_import;
 
       /**
        * Shared pointer to the Tpetra::Export object used.
        */
-      std::unique_ptr<Tpetra::Export<int, types::global_dof_index>>
+      std::unique_ptr<
+        Tpetra::Export<int, std::make_signed_t<types::global_dof_index>>>
         tpetra_export;
     };
   } // end of namespace TpetraWrappers

--- a/include/deal.II/lac/trilinos_tpetra_communication_pattern.h
+++ b/include/deal.II/lac/trilinos_tpetra_communication_pattern.h
@@ -68,13 +68,13 @@ namespace LinearAlgebra
       /**
        * Return the underlying Tpetra::Import object.
        */
-      const Tpetra::Import<int, std::make_signed_t<types::global_dof_index>> &
+      const Tpetra::Import<int, types::signed_global_dof_index> &
       get_tpetra_import() const;
 
       /**
        * Return the underlying Tpetra::Export object.
        */
-      const Tpetra::Export<int, std::make_signed_t<types::global_dof_index>> &
+      const Tpetra::Export<int, types::signed_global_dof_index> &
       get_tpetra_export() const;
 
     private:
@@ -86,15 +86,13 @@ namespace LinearAlgebra
       /**
        * Shared pointer to the Tpetra::Import object used.
        */
-      std::unique_ptr<
-        Tpetra::Import<int, std::make_signed_t<types::global_dof_index>>>
+      std::unique_ptr<Tpetra::Import<int, types::signed_global_dof_index>>
         tpetra_import;
 
       /**
        * Shared pointer to the Tpetra::Export object used.
        */
-      std::unique_ptr<
-        Tpetra::Export<int, std::make_signed_t<types::global_dof_index>>>
+      std::unique_ptr<Tpetra::Export<int, types::signed_global_dof_index>>
         tpetra_export;
     };
   } // end of namespace TpetraWrappers

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -337,15 +337,14 @@ namespace LinearAlgebra
        * Return a const reference to the underlying Trilinos
        * Tpetra::Vector class.
        */
-      const Tpetra::
-        Vector<Number, int, std::make_signed_t<types::global_dof_index>> &
-        trilinos_vector() const;
+      const Tpetra::Vector<Number, int, types::signed_global_dof_index> &
+      trilinos_vector() const;
 
       /**
        * Return a (modifiable) reference to the underlying Trilinos
        * Tpetra::Vector class.
        */
-      Tpetra::Vector<Number, int, std::make_signed_t<types::global_dof_index>> &
+      Tpetra::Vector<Number, int, types::signed_global_dof_index> &
       trilinos_vector();
 
       /**
@@ -400,8 +399,7 @@ namespace LinearAlgebra
        * Pointer to the actual Tpetra vector object.
        */
       std::unique_ptr<
-        Tpetra::
-          Vector<Number, int, std::make_signed_t<types::global_dof_index>>>
+        Tpetra::Vector<Number, int, types::signed_global_dof_index>>
         vector;
 
       /**

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -337,14 +337,15 @@ namespace LinearAlgebra
        * Return a const reference to the underlying Trilinos
        * Tpetra::Vector class.
        */
-      const Tpetra::Vector<Number, int, types::global_dof_index> &
-      trilinos_vector() const;
+      const Tpetra::
+        Vector<Number, int, std::make_signed_t<types::global_dof_index>> &
+        trilinos_vector() const;
 
       /**
        * Return a (modifiable) reference to the underlying Trilinos
        * Tpetra::Vector class.
        */
-      Tpetra::Vector<Number, int, types::global_dof_index> &
+      Tpetra::Vector<Number, int, std::make_signed_t<types::global_dof_index>> &
       trilinos_vector();
 
       /**
@@ -398,7 +399,9 @@ namespace LinearAlgebra
       /**
        * Pointer to the actual Tpetra vector object.
        */
-      std::unique_ptr<Tpetra::Vector<Number, int, types::global_dof_index>>
+      std::unique_ptr<
+        Tpetra::
+          Vector<Number, int, std::make_signed_t<types::global_dof_index>>>
         vector;
 
       /**

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -47,12 +47,9 @@ namespace LinearAlgebra
     template <typename Number>
     Vector<Number>::Vector()
       : Subscriptor()
-      , vector(new Tpetra::Vector<Number,
-                                  int,
-                                  std::make_signed_t<types::global_dof_index>>(
-          Teuchos::RCP<
-            Tpetra::Map<int, std::make_signed_t<types::global_dof_index>>>(
-            new Tpetra::Map<int, std::make_signed_t<types::global_dof_index>>(
+      , vector(new Tpetra::Vector<Number, int, types::signed_global_dof_index>(
+          Teuchos::RCP<Tpetra::Map<int, types::signed_global_dof_index>>(
+            new Tpetra::Map<int, types::signed_global_dof_index>(
               0,
               0,
               Utilities::Trilinos::tpetra_comm_self()))))
@@ -63,9 +60,7 @@ namespace LinearAlgebra
     template <typename Number>
     Vector<Number>::Vector(const Vector<Number> &V)
       : Subscriptor()
-      , vector(new Tpetra::Vector<Number,
-                                  int,
-                                  std::make_signed_t<types::global_dof_index>>(
+      , vector(new Tpetra::Vector<Number, int, types::signed_global_dof_index>(
           V.trilinos_vector(),
           Teuchos::Copy))
     {}
@@ -76,12 +71,9 @@ namespace LinearAlgebra
     Vector<Number>::Vector(const IndexSet &parallel_partitioner,
                            const MPI_Comm &communicator)
       : Subscriptor()
-      , vector(new Tpetra::Vector<Number,
-                                  int,
-                                  std::make_signed_t<types::global_dof_index>>(
-          Teuchos::rcp(
-            new Tpetra::Map<int, std::make_signed_t<types::global_dof_index>>(
-              parallel_partitioner.make_tpetra_map(communicator, false)))))
+      , vector(new Tpetra::Vector<Number, int, types::signed_global_dof_index>(
+          Teuchos::rcp(new Tpetra::Map<int, types::signed_global_dof_index>(
+            parallel_partitioner.make_tpetra_map(communicator, false)))))
     {}
 
 
@@ -92,15 +84,13 @@ namespace LinearAlgebra
                            const MPI_Comm &communicator,
                            const bool      omit_zeroing_entries)
     {
-      Tpetra::Map<int, std::make_signed_t<types::global_dof_index>> input_map =
+      Tpetra::Map<int, types::signed_global_dof_index> input_map =
         parallel_partitioner.make_tpetra_map(communicator, false);
       if (vector->getMap()->isSameAs(input_map) == false)
         vector = std::make_unique<
-          Tpetra::
-            Vector<Number, int, std::make_signed_t<types::global_dof_index>>>(
+          Tpetra::Vector<Number, int, types::signed_global_dof_index>>(
           Teuchos::rcp(
-            new Tpetra::Map<int, std::make_signed_t<types::global_dof_index>>(
-              input_map)));
+            new Tpetra::Map<int, types::signed_global_dof_index>(input_map)));
       else if (omit_zeroing_entries == false)
         {
           vector->putScalar(0.);
@@ -142,8 +132,8 @@ namespace LinearAlgebra
         {
           if (size() == V.size())
             {
-              Tpetra::Import<int, std::make_signed_t<types::global_dof_index>>
-                data_exchange(vector->getMap(), V.trilinos_vector().getMap());
+              Tpetra::Import<int, types::signed_global_dof_index> data_exchange(
+                vector->getMap(), V.trilinos_vector().getMap());
 
               vector->doImport(V.trilinos_vector(),
                                data_exchange,
@@ -151,9 +141,7 @@ namespace LinearAlgebra
             }
           else
             vector = std::make_unique<
-              Tpetra::Vector<Number,
-                             int,
-                             std::make_signed_t<types::global_dof_index>>>(
+              Tpetra::Vector<Number, int, types::signed_global_dof_index>>(
               V.trilinos_vector());
         }
 
@@ -214,10 +202,10 @@ namespace LinearAlgebra
               "LinearAlgebra::TpetraWrappers::CommunicationPattern."));
         }
 
-      Tpetra::Export<int, std::make_signed_t<types::global_dof_index>>
-        tpetra_export(tpetra_comm_pattern->get_tpetra_export());
-      Tpetra::Vector<Number, int, std::make_signed_t<types::global_dof_index>>
-        source_vector(tpetra_export.getSourceMap());
+      Tpetra::Export<int, types::signed_global_dof_index> tpetra_export(
+        tpetra_comm_pattern->get_tpetra_export());
+      Tpetra::Vector<Number, int, types::signed_global_dof_index> source_vector(
+        tpetra_export.getSourceMap());
 
       {
         source_vector.template sync<Kokkos::HostSpace>();
@@ -229,9 +217,8 @@ namespace LinearAlgebra
         for (size_t k = 0; k < localLength; ++k)
           x_1d(k) = *values_it++;
         source_vector.template sync<
-          typename Tpetra::
-            Vector<Number, int, std::make_signed_t<types::global_dof_index>>::
-              device_type::memory_space>();
+          typename Tpetra::Vector<Number, int, types::signed_global_dof_index>::
+            device_type::memory_space>();
       }
       if (operation == VectorOperation::insert)
         vector->doExport(source_vector, tpetra_export, Tpetra::REPLACE);
@@ -290,11 +277,10 @@ namespace LinearAlgebra
 
           // TODO: Tpetra doesn't have a combine mode that also updates local
           // elements, maybe there is a better workaround.
-          Tpetra::
-            Vector<Number, int, std::make_signed_t<types::global_dof_index>>
-              dummy(vector->getMap(), false);
-          Tpetra::Import<int, std::make_signed_t<types::global_dof_index>>
-            data_exchange(down_V.trilinos_vector().getMap(), dummy.getMap());
+          Tpetra::Vector<Number, int, types::signed_global_dof_index> dummy(
+            vector->getMap(), false);
+          Tpetra::Import<int, types::signed_global_dof_index> data_exchange(
+            down_V.trilinos_vector().getMap(), dummy.getMap());
 
           dummy.doImport(down_V.trilinos_vector(),
                          data_exchange,
@@ -355,9 +341,8 @@ namespace LinearAlgebra
           vector_1d(k) += a;
         }
       vector->template sync<
-        typename Tpetra::
-          Vector<Number, int, std::make_signed_t<types::global_dof_index>>::
-            device_type::memory_space>();
+        typename Tpetra::Vector<Number, int, types::signed_global_dof_index>::
+          device_type::memory_space>();
     }
 
 
@@ -621,9 +606,8 @@ namespace LinearAlgebra
 
 
     template <typename Number>
-    const Tpetra::
-      Vector<Number, int, std::make_signed_t<types::global_dof_index>> &
-      Vector<Number>::trilinos_vector() const
+    const Tpetra::Vector<Number, int, types::signed_global_dof_index> &
+    Vector<Number>::trilinos_vector() const
     {
       return *vector;
     }
@@ -631,7 +615,7 @@ namespace LinearAlgebra
 
 
     template <typename Number>
-    Tpetra::Vector<Number, int, std::make_signed_t<types::global_dof_index>> &
+    Tpetra::Vector<Number, int, types::signed_global_dof_index> &
     Vector<Number>::trilinos_vector()
     {
       return *vector;

--- a/include/deal.II/lac/vector_element_access.h
+++ b/include/deal.II/lac/vector_element_access.h
@@ -157,8 +157,8 @@ namespace internal
     LinearAlgebra::TpetraWrappers::Vector<NumberType> &V)
   {
     // Extract local indices in the vector.
-    Tpetra::Vector<NumberType, int, std::make_signed_t<types::global_dof_index>>
-                                      vector = V.trilinos_vector();
+    Tpetra::Vector<NumberType, int, types::signed_global_dof_index> vector =
+      V.trilinos_vector();
     TrilinosWrappers::types::int_type trilinos_i =
       vector.getMap()->getLocalElement(
         static_cast<TrilinosWrappers::types::int_type>(i));
@@ -170,9 +170,8 @@ namespace internal
     vector.template modify<Kokkos::HostSpace>();
     vector_1d(trilinos_i) += value;
     vector.template sync<
-      typename Tpetra::
-        Vector<NumberType, int, std::make_signed_t<types::global_dof_index>>::
-          device_type::memory_space>();
+      typename Tpetra::Vector<NumberType, int, types::signed_global_dof_index>::
+        device_type::memory_space>();
   }
 
 
@@ -185,8 +184,8 @@ namespace internal
     LinearAlgebra::TpetraWrappers::Vector<NumberType> &V)
   {
     // Extract local indices in the vector.
-    Tpetra::Vector<NumberType, int, std::make_signed_t<types::global_dof_index>>
-                                      vector = V.trilinos_vector();
+    Tpetra::Vector<NumberType, int, types::signed_global_dof_index> vector =
+      V.trilinos_vector();
     TrilinosWrappers::types::int_type trilinos_i =
       vector.getMap()->getLocalElement(
         static_cast<TrilinosWrappers::types::int_type>(i));
@@ -198,9 +197,8 @@ namespace internal
     vector.template modify<Kokkos::HostSpace>();
     vector_1d(trilinos_i) = value;
     vector.template sync<
-      typename Tpetra::
-        Vector<NumberType, int, std::make_signed_t<types::global_dof_index>>::
-          device_type::memory_space>();
+      typename Tpetra::Vector<NumberType, int, types::signed_global_dof_index>::
+        device_type::memory_space>();
   }
 
 
@@ -212,8 +210,8 @@ namespace internal
     const types::global_dof_index                            i)
   {
     // Extract local indices in the vector.
-    Tpetra::Vector<NumberType, int, std::make_signed_t<types::global_dof_index>>
-                                      vector = V.trilinos_vector();
+    Tpetra::Vector<NumberType, int, types::signed_global_dof_index> vector =
+      V.trilinos_vector();
     TrilinosWrappers::types::int_type trilinos_i =
       vector.getMap()->getLocalElement(
         static_cast<TrilinosWrappers::types::int_type>(i));

--- a/include/deal.II/lac/vector_element_access.h
+++ b/include/deal.II/lac/vector_element_access.h
@@ -157,8 +157,8 @@ namespace internal
     LinearAlgebra::TpetraWrappers::Vector<NumberType> &V)
   {
     // Extract local indices in the vector.
-    Tpetra::Vector<NumberType, int, types::global_dof_index> vector =
-      V.trilinos_vector();
+    Tpetra::Vector<NumberType, int, std::make_signed_t<types::global_dof_index>>
+                                      vector = V.trilinos_vector();
     TrilinosWrappers::types::int_type trilinos_i =
       vector.getMap()->getLocalElement(
         static_cast<TrilinosWrappers::types::int_type>(i));
@@ -170,8 +170,9 @@ namespace internal
     vector.template modify<Kokkos::HostSpace>();
     vector_1d(trilinos_i) += value;
     vector.template sync<
-      typename Tpetra::Vector<NumberType, int, types::global_dof_index>::
-        device_type::memory_space>();
+      typename Tpetra::
+        Vector<NumberType, int, std::make_signed_t<types::global_dof_index>>::
+          device_type::memory_space>();
   }
 
 
@@ -184,8 +185,8 @@ namespace internal
     LinearAlgebra::TpetraWrappers::Vector<NumberType> &V)
   {
     // Extract local indices in the vector.
-    Tpetra::Vector<NumberType, int, types::global_dof_index> vector =
-      V.trilinos_vector();
+    Tpetra::Vector<NumberType, int, std::make_signed_t<types::global_dof_index>>
+                                      vector = V.trilinos_vector();
     TrilinosWrappers::types::int_type trilinos_i =
       vector.getMap()->getLocalElement(
         static_cast<TrilinosWrappers::types::int_type>(i));
@@ -197,8 +198,9 @@ namespace internal
     vector.template modify<Kokkos::HostSpace>();
     vector_1d(trilinos_i) = value;
     vector.template sync<
-      typename Tpetra::Vector<NumberType, int, types::global_dof_index>::
-        device_type::memory_space>();
+      typename Tpetra::
+        Vector<NumberType, int, std::make_signed_t<types::global_dof_index>>::
+          device_type::memory_space>();
   }
 
 
@@ -210,8 +212,8 @@ namespace internal
     const types::global_dof_index                            i)
   {
     // Extract local indices in the vector.
-    Tpetra::Vector<NumberType, int, types::global_dof_index> vector =
-      V.trilinos_vector();
+    Tpetra::Vector<NumberType, int, std::make_signed_t<types::global_dof_index>>
+                                      vector = V.trilinos_vector();
     TrilinosWrappers::types::int_type trilinos_i =
       vector.getMap()->getLocalElement(
         static_cast<TrilinosWrappers::types::int_type>(i));

--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -716,7 +716,7 @@ IndexSet::fill_index_vector(std::vector<size_type> &indices) const
 #ifdef DEAL_II_WITH_TRILINOS
 #  ifdef DEAL_II_TRILINOS_WITH_TPETRA
 
-Tpetra::Map<int, types::global_dof_index>
+Tpetra::Map<int, std::make_signed_t<types::global_dof_index>>
 IndexSet::make_tpetra_map(const MPI_Comm &communicator,
                           const bool      overlapping) const
 {
@@ -752,7 +752,7 @@ IndexSet::make_tpetra_map(const MPI_Comm &communicator,
   const bool linear =
     overlapping ? false : is_ascending_and_one_to_one(communicator);
   if (linear)
-    return Tpetra::Map<int, types::global_dof_index>(
+    return Tpetra::Map<int, std::make_signed_t<types::global_dof_index>>(
       size(),
       n_elements(),
       0,
@@ -764,11 +764,13 @@ IndexSet::make_tpetra_map(const MPI_Comm &communicator,
     );
   else
     {
-      const std::vector<size_type>         indices = get_index_vector();
-      std::vector<types::global_dof_index> int_indices(indices.size());
+      const std::vector<size_type> indices = get_index_vector();
+      std::vector<std::make_signed_t<types::global_dof_index>> int_indices(
+        indices.size());
       std::copy(indices.begin(), indices.end(), int_indices.begin());
-      const Teuchos::ArrayView<types::global_dof_index> arr_view(int_indices);
-      return Tpetra::Map<int, types::global_dof_index>(
+      const Teuchos::ArrayView<std::make_signed_t<types::global_dof_index>>
+        arr_view(int_indices);
+      return Tpetra::Map<int, std::make_signed_t<types::global_dof_index>>(
         size(),
         arr_view,
         0,

--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -716,7 +716,7 @@ IndexSet::fill_index_vector(std::vector<size_type> &indices) const
 #ifdef DEAL_II_WITH_TRILINOS
 #  ifdef DEAL_II_TRILINOS_WITH_TPETRA
 
-Tpetra::Map<int, std::make_signed_t<types::global_dof_index>>
+Tpetra::Map<int, types::signed_global_dof_index>
 IndexSet::make_tpetra_map(const MPI_Comm &communicator,
                           const bool      overlapping) const
 {
@@ -752,7 +752,7 @@ IndexSet::make_tpetra_map(const MPI_Comm &communicator,
   const bool linear =
     overlapping ? false : is_ascending_and_one_to_one(communicator);
   if (linear)
-    return Tpetra::Map<int, std::make_signed_t<types::global_dof_index>>(
+    return Tpetra::Map<int, types::signed_global_dof_index>(
       size(),
       n_elements(),
       0,
@@ -764,13 +764,12 @@ IndexSet::make_tpetra_map(const MPI_Comm &communicator,
     );
   else
     {
-      const std::vector<size_type> indices = get_index_vector();
-      std::vector<std::make_signed_t<types::global_dof_index>> int_indices(
-        indices.size());
+      const std::vector<size_type>                indices = get_index_vector();
+      std::vector<types::signed_global_dof_index> int_indices(indices.size());
       std::copy(indices.begin(), indices.end(), int_indices.begin());
-      const Teuchos::ArrayView<std::make_signed_t<types::global_dof_index>>
-        arr_view(int_indices);
-      return Tpetra::Map<int, std::make_signed_t<types::global_dof_index>>(
+      const Teuchos::ArrayView<types::signed_global_dof_index> arr_view(
+        int_indices);
+      return Tpetra::Map<int, types::signed_global_dof_index>(
         size(),
         arr_view,
         0,

--- a/source/lac/trilinos_tpetra_communication_pattern.cc
+++ b/source/lac/trilinos_tpetra_communication_pattern.cc
@@ -51,22 +51,22 @@ namespace LinearAlgebra
     {
       comm = std::make_shared<const MPI_Comm>(communicator);
 
-      auto vector_space_vector_map = Teuchos::rcp(
-        new Tpetra::Map<int, std::make_signed_t<types::global_dof_index>>(
+      auto vector_space_vector_map =
+        Teuchos::rcp(new Tpetra::Map<int, types::signed_global_dof_index>(
           vector_space_vector_index_set.make_tpetra_map(*comm, false)));
-      auto read_write_vector_map = Teuchos::rcp(
-        new Tpetra::Map<int, std::make_signed_t<types::global_dof_index>>(
+      auto read_write_vector_map =
+        Teuchos::rcp(new Tpetra::Map<int, types::signed_global_dof_index>(
           read_write_vector_index_set.make_tpetra_map(*comm, true)));
 
       // Target map is read_write_vector_map
       // Source map is vector_space_vector_map. This map must have uniquely
       // owned GID.
-      tpetra_import = std::make_unique<
-        Tpetra::Import<int, std::make_signed_t<types::global_dof_index>>>(
-        read_write_vector_map, vector_space_vector_map);
-      tpetra_export = std::make_unique<
-        Tpetra::Export<int, std::make_signed_t<types::global_dof_index>>>(
-        read_write_vector_map, vector_space_vector_map);
+      tpetra_import =
+        std::make_unique<Tpetra::Import<int, types::signed_global_dof_index>>(
+          read_write_vector_map, vector_space_vector_map);
+      tpetra_export =
+        std::make_unique<Tpetra::Export<int, types::signed_global_dof_index>>(
+          read_write_vector_map, vector_space_vector_map);
     }
 
 
@@ -79,7 +79,7 @@ namespace LinearAlgebra
 
 
 
-    const Tpetra::Import<int, std::make_signed_t<types::global_dof_index>> &
+    const Tpetra::Import<int, types::signed_global_dof_index> &
     CommunicationPattern::get_tpetra_import() const
     {
       return *tpetra_import;
@@ -87,7 +87,7 @@ namespace LinearAlgebra
 
 
 
-    const Tpetra::Export<int, std::make_signed_t<types::global_dof_index>> &
+    const Tpetra::Export<int, types::signed_global_dof_index> &
     CommunicationPattern::get_tpetra_export() const
     {
       return *tpetra_export;

--- a/source/lac/trilinos_tpetra_communication_pattern.cc
+++ b/source/lac/trilinos_tpetra_communication_pattern.cc
@@ -51,22 +51,22 @@ namespace LinearAlgebra
     {
       comm = std::make_shared<const MPI_Comm>(communicator);
 
-      auto vector_space_vector_map =
-        Teuchos::rcp(new Tpetra::Map<int, types::global_dof_index>(
+      auto vector_space_vector_map = Teuchos::rcp(
+        new Tpetra::Map<int, std::make_signed_t<types::global_dof_index>>(
           vector_space_vector_index_set.make_tpetra_map(*comm, false)));
-      auto read_write_vector_map =
-        Teuchos::rcp(new Tpetra::Map<int, types::global_dof_index>(
+      auto read_write_vector_map = Teuchos::rcp(
+        new Tpetra::Map<int, std::make_signed_t<types::global_dof_index>>(
           read_write_vector_index_set.make_tpetra_map(*comm, true)));
 
       // Target map is read_write_vector_map
       // Source map is vector_space_vector_map. This map must have uniquely
       // owned GID.
-      tpetra_import =
-        std::make_unique<Tpetra::Import<int, types::global_dof_index>>(
-          read_write_vector_map, vector_space_vector_map);
-      tpetra_export =
-        std::make_unique<Tpetra::Export<int, types::global_dof_index>>(
-          read_write_vector_map, vector_space_vector_map);
+      tpetra_import = std::make_unique<
+        Tpetra::Import<int, std::make_signed_t<types::global_dof_index>>>(
+        read_write_vector_map, vector_space_vector_map);
+      tpetra_export = std::make_unique<
+        Tpetra::Export<int, std::make_signed_t<types::global_dof_index>>>(
+        read_write_vector_map, vector_space_vector_map);
     }
 
 
@@ -79,7 +79,7 @@ namespace LinearAlgebra
 
 
 
-    const Tpetra::Import<int, types::global_dof_index> &
+    const Tpetra::Import<int, std::make_signed_t<types::global_dof_index>> &
     CommunicationPattern::get_tpetra_import() const
     {
       return *tpetra_import;
@@ -87,7 +87,7 @@ namespace LinearAlgebra
 
 
 
-    const Tpetra::Export<int, types::global_dof_index> &
+    const Tpetra::Export<int, std::make_signed_t<types::global_dof_index>> &
     CommunicationPattern::get_tpetra_export() const
     {
       return *tpetra_export;


### PR DESCRIPTION
According to https://github.com/trilinos/Trilinos/blob/d7647e9ef3be1752b8de0ce0b714059c7e777312/packages/tpetra/CMakeLists.txt#L678-L712 `Tpetra` strongly discourages using any unsigned type for `global_ordinal` and this results ultimately in `Tpetra` support being disabled for most Trilinos configurations.
Thus, this pull request tries using the signed version of `types::global_index_type` (which is always unsigned) for `Tpetra`.
Of course, this is up for discussion and might cause problems if not using 64-but indices in deal.II.

There is another small change that I need for the `Tpetra` tests to work where `Tpetra` complains if more host mirrors are alive.

With the changes here I can run the `TpetraWrappers::Vector` test successfully also with `Cuda`. In the current implementation, `TpetraWrappers::Vector` always uses the default memory space (which is `Cuda` if `Trilinos` was configured with `Cuda` support) but we could discuss giving it another template parameter to be able to choose the memory space type.  
