### PR TITLE
simplex doxygen: more cleanup

### DIFF
--- a/doc/doxygen/headers/simplex.h
+++ b/doc/doxygen/headers/simplex.h
@@ -17,14 +17,14 @@
 /**
  * @defgroup simplex Simplex support (experimental)
  *
- * @brief This module describes the experimental simplex support in deal.II.
+ * This module describes the experimental simplex support in deal.II.
  *
  * Simplex and mixed meshes in deal.II are still experimental, i.e., work
  * in progress. Large parts of the library have been ported to be able to
  * operate on such kind of meshes. However, there are still many functions
  * that need to be generalized.
  *
- * @section Important Simplex Functionality
+ * @section simplex_functionality_list Important Simplex Functionality
  *
  * Here is an incomplete list of functionality related to simplex
  * computations:

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -1792,7 +1792,8 @@ namespace GridGenerator
    *
    * @image html grid_generator_implicit_function_3d.png
    *
-   * @relates simplex
+   * Also see
+   * @ref simplex "Simplex support".
    *
    * @param[out] tria The output triangulation
    * @param[in] implicit_function The implicit function


### PR DESCRIPTION
- @brief is somehow output twice, so let's get rid of the annotation
- use @section correctly
- fix another @relates