### PR TITLE
Fix NVCC CI

### DIFF
--- a/cmake/macros/check_compiler_setup/CMakeLists.txt
+++ b/cmake/macros/check_compiler_setup/CMakeLists.txt
@@ -2,6 +2,11 @@ project(CheckCompilerSetup)
 cmake_minimum_required(VERSION 3.13.4)
 add_executable(CheckCompilerSetupExec dummy.cpp)
 
+# Make sure some CUDA warning flags don't get deduplicated
+string (REPLACE ";" " " TEST_COMPILE_FLAGS "${TEST_COMPILE_FLAGS}")
+string(REGEX REPLACE "(-Xcudafe --diag_suppress=[^ ]+)" "\"SHELL:\\1\"" TEST_COMPILE_FLAGS "${TEST_COMPILE_FLAGS}")
+separate_arguments(TEST_COMPILE_FLAGS UNIX_COMMAND "${TEST_COMPILE_FLAGS}")
+
 target_compile_options(CheckCompilerSetupExec PRIVATE ${TEST_COMPILE_FLAGS})
 set_property(TARGET CheckCompilerSetupExec PROPERTY LINK_FLAGS "${TEST_LINK_OPTIONS}")
 target_link_libraries(CheckCompilerSetupExec ${TEST_LINK_LIBRARIES})


### PR DESCRIPTION
Apparently, #14783 and #14771 were conflicting and we also need to avoid deduplication of the flags in `check_compiler_setup`.