### PR TITLE
Don't derive InvalidAccessor from TriaAccessorBase.

### DIFF
--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -567,14 +567,36 @@ private:
  * @ingroup Accessors
  */
 template <int structdim, int dim, int spacedim = dim>
-class InvalidAccessor : public TriaAccessorBase<structdim, dim, spacedim>
+class InvalidAccessor
 {
 public:
   /**
-   * Propagate alias from base class to this class.
+   * Dimension of the space the object represented by this accessor lives in.
+   * For example, if this accessor represents a quad that is part of a two-
+   * dimensional surface in four-dimensional space, then this value is four.
    */
-  using AccessorData =
-    typename TriaAccessorBase<structdim, dim, spacedim>::AccessorData;
+  static constexpr unsigned int space_dimension = spacedim;
+
+  /**
+   * Dimensionality of the object that the thing represented by this accessor
+   * is part of. For example, if this accessor represents a line that is part
+   * of a hexahedron, then this value will be three.
+   */
+  static constexpr unsigned int dimension = dim;
+
+  /**
+   * Dimensionality of the current object represented by this accessor. For
+   * example, if it is line (irrespective of whether it is part of a quad or
+   * hex, and what dimension we are in), then this value equals 1.
+   */
+  static const unsigned int structure_dimension = structdim;
+
+  /**
+   * Declare the data type that this accessor class expects to get passed from
+   * the iterator classes. Since the pure triangulation iterators need no
+   * additional data, this data type is @p void.
+   */
+  using AccessorData = void;
 
   /**
    * Constructor.  This class is used for iterators that do not make
@@ -625,6 +647,28 @@ public:
   operator++() const;
   void
   operator--() const;
+
+  /**
+   * Return the state of the iterator.  For the different states an accessor
+   * can be in, refer to the TriaRawIterator documentation.
+   */
+  static IteratorState::IteratorStates
+  state();
+
+
+  /**
+   * Level of this object. Vertices have no level, so this function always
+   * returns zero.
+   */
+  static int
+  level();
+
+  /**
+   * Index of this object. Returns the global index of the vertex this object
+   * points to.
+   */
+  static int
+  index();
 
   /**
    * Dummy function representing whether the accessor points to a used or an

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -393,9 +393,7 @@ InvalidAccessor<structdim, dim, spacedim>::InvalidAccessor(
 
 template <int structdim, int dim, int spacedim>
 InvalidAccessor<structdim, dim, spacedim>::InvalidAccessor(
-  const InvalidAccessor &i)
-  : TriaAccessorBase<structdim, dim, spacedim>(
-      static_cast<const TriaAccessorBase<structdim, dim, spacedim> &>(i))
+  const InvalidAccessor &)
 {
   Assert(false,
          ExcMessage("You are attempting an invalid conversion between "
@@ -565,7 +563,7 @@ inline typename dealii::internal::TriangulationImplementation::
 {
   // nothing to do here. we could throw an exception but we can't get here
   // without first creating an object which would have already thrown
-  return dealii::internal::TriangulationImplementation::
+  return typename dealii::internal::TriangulationImplementation::
     Iterators<dim, spacedim>::quad_iterator();
 }
 

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -3512,6 +3512,32 @@ CellAccessor<dim, spacedim>::neighbor_child_on_subface(
 
 
 
+template <int structdim, int dim, int spacedim>
+IteratorState::IteratorStates
+InvalidAccessor<structdim, dim, spacedim>::state()
+{
+  return IteratorState::invalid;
+}
+
+
+
+template <int structdim, int dim, int spacedim>
+int
+InvalidAccessor<structdim, dim, spacedim>::level()
+{
+  return -1;
+}
+
+
+
+template <int structdim, int dim, int spacedim>
+int
+InvalidAccessor<structdim, dim, spacedim>::index()
+{
+  return -1;
+}
+
+
 // explicit instantiations
 #include "tria_accessor.inst"
 

--- a/source/grid/tria_accessor.inst.in
+++ b/source/grid/tria_accessor.inst.in
@@ -57,3 +57,11 @@ for (deal_II_space_dimension : DIMENSIONS)
     template class TriaAccessor<0, 1, deal_II_space_dimension>;
     template class TriaIterator<TriaAccessor<0, 1, deal_II_space_dimension>>;
   }
+
+for (deal_II_struct_dimension : DIMENSIONS; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : DIMENSIONS)
+  {
+    template class InvalidAccessor<deal_II_struct_dimension,
+                                   deal_II_dimension,
+                                   deal_II_space_dimension>;
+  }


### PR DESCRIPTION
It is not necessary, and it unnecessarily bloats the library because it instantiates `TriaAccessorBase` with things such as `dim=2, spacedim=1` (which is of course, doh!, invalid!).

This avoids some unnecessary instantiations and reduces the debug library's size by about 100kB -- not much, of course, but a sign that we were doing unnecessary work.