### PR TITLE
Produce .inst files that are easier to read.

### DIFF
--- a/cmake/scripts/expand_instantiations.cc
+++ b/cmake/scripts/expand_instantiations.cc
@@ -112,6 +112,16 @@ get_substring_with_delim(std::string &in, const std::string &delim_list)
       in.erase(0, 1);
     }
 
+  // We often end up with the '}' delimiter on a separate line, but
+  // not in the first column of the line. Since whitespace isn't
+  // harmful, that isn't a problem in itself, except that it makes
+  // producing nicely formatted output a bit harder than necessary. It
+  // would be nice if we could just end the text we read with the last
+  // newline in such cases. To this end, just trim trailing
+  // whitespace.
+  while ((x.size() > 0) && (x.back() == ' '))
+    x.erase(x.size() - 1, 1);
+
   return x;
 }
 
@@ -416,8 +426,8 @@ substitute(const std::string &                                   text,
           static unsigned int counter = 0;
           std::cout << "#if (SPLIT_INSTANTIATIONS_CHECK(" << counter++ << "))"
                     << std::endl;
-          std::cout << substitute_tokens(text, name, *expansion) << std::endl;
-          std::cout << "#endif" << std::endl;
+          std::cout << substitute_tokens(text, name, *expansion);
+          std::cout << "#endif" << std::endl << std::endl;
         }
     }
   else


### PR DESCRIPTION
I had a need to look at the generated `.inst` files, and they turn out to be quite difficult to read. They look like this:
```
// This file is automatically generated from corresponding .inst.in, do not edit.

#ifdef SPLIT_INSTANTIATIONS_COUNT
  #define SPLIT_INSTANTIATIONS_CHECK(C) (((C) % SPLIT_INSTANTIATIONS_COUNT) == SPLIT_INSTANTIATIONS_INDEX)
#else
  #define SPLIT_INSTANTIATIONS_CHECK(C) (1)
#endif

#if (SPLIT_INSTANTIATIONS_CHECK(0))
template class SymmetricTensor<2,  1 ,  double >;

 template class SymmetricTensor<4,  1 ,  double >;

 template std::array< double ,  1 > eigenvalues(
 const SymmetricTensor<2,  1 ,  double > &);

 template std::array<std::pair< double , Tensor<1,  1 ,  double >>,
 std::integral_constant<int,  1 >::value>
 eigenvectors(const SymmetricTensor<2,  1 ,  double > &,
 const SymmetricTensorEigenvectorMethod);
 
#endif
#if (SPLIT_INSTANTIATIONS_CHECK(1))
template class SymmetricTensor<2,  1 ,  float >;

 template class SymmetricTensor<4,  1 ,  float >;
...
```
The problem is the empty line after the code block, followed by the `#endif`, directly followed by the `#if`. This obscures what should really form one block.

This patch removes the empty line before, and adds an empty line after the `#endif`. To make this work, I had to trim whitespace at the end of input lines in the `.inst.in` files after processing. The end result is that it now looks like this:
```
// This file is automatically generated from corresponding .inst.in, do not edit.

#ifdef SPLIT_INSTANTIATIONS_COUNT
  #define SPLIT_INSTANTIATIONS_CHECK(C) (((C) % SPLIT_INSTANTIATIONS_COUNT) == SPLIT_INSTANTIATIONS_INDEX)
#else
  #define SPLIT_INSTANTIATIONS_CHECK(C) (1)
#endif

#if (SPLIT_INSTANTIATIONS_CHECK(0))
template class SymmetricTensor<2,  1 ,  double >;

 template class SymmetricTensor<4,  1 ,  double >;

 template std::array< double ,  1 > eigenvalues(
 const SymmetricTensor<2,  1 ,  double > &);

 template std::array<std::pair< double , Tensor<1,  1 ,  double >>,
 std::integral_constant<int,  1 >::value>
 eigenvectors(const SymmetricTensor<2,  1 ,  double > &,
 const SymmetricTensorEigenvectorMethod);
#endif

#if (SPLIT_INSTANTIATIONS_CHECK(1))
template class SymmetricTensor<2,  1 ,  float >;

 template class SymmetricTensor<4,  1 ,  float >;
...
```
I think that is at least somewhat easier to visually group.
```