### PR TITLE
Avoid some more instantiations of class Triangulation for invalid arguments.

### DIFF
--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -1260,10 +1260,10 @@ public:
    * semantic sense, and we generate an exception when such an object is
    * actually generated.
    */
-  DoFInvalidAccessor(const Triangulation<dim, spacedim> *parent     = 0,
-                     const int                           level      = -1,
-                     const int                           index      = -1,
-                     const AccessorData *                local_data = 0);
+  DoFInvalidAccessor(const void *        parent     = 0,
+                     const int           level      = -1,
+                     const int           index      = -1,
+                     const AccessorData *local_data = 0);
 
   /**
    * Copy constructor.  This class is used for iterators that do not make

--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -1260,10 +1260,10 @@ public:
    * semantic sense, and we generate an exception when such an object is
    * actually generated.
    */
-  DoFInvalidAccessor(const void *        parent     = 0,
+  DoFInvalidAccessor(const void *        parent     = nullptr,
                      const int           level      = -1,
                      const int           index      = -1,
-                     const AccessorData *local_data = 0);
+                     const AccessorData *local_data = nullptr);
 
   /**
    * Copy constructor.  This class is used for iterators that do not make

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -605,10 +605,10 @@ public:
    * semantic sense, and we generate an exception when such an object is
    * actually generated.
    */
-  InvalidAccessor(const Triangulation<dim, spacedim> *parent     = nullptr,
-                  const int                           level      = -1,
-                  const int                           index      = -1,
-                  const AccessorData *                local_data = nullptr);
+  InvalidAccessor(const void *        parent     = nullptr,
+                  const int           level      = -1,
+                  const int           index      = -1,
+                  const AccessorData *local_data = nullptr);
 
   /**
    * Copy constructor.  This class is used for iterators that do not make
@@ -718,17 +718,15 @@ public:
    * Dummy function to extract lines. Returns a default-constructed line
    * iterator.
    */
-  typename dealii::internal::TriangulationImplementation::
-    Iterators<dim, spacedim>::line_iterator
-    line(const unsigned int i) const;
+  void *
+  line(const unsigned int i) const;
 
   /**
    * Dummy function to extract quads. Returns a default-constructed quad
    * iterator.
    */
-  typename dealii::internal::TriangulationImplementation::
-    Iterators<dim, spacedim>::quad_iterator
-    quad(const unsigned int i) const;
+  void *
+  quad(const unsigned int i) const;
 };
 
 

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -375,11 +375,10 @@ TriaAccessorBase<structdim, dim, spacedim>::objects() const
 /*---------------------- Functions: InvalidAccessor -------------------------*/
 
 template <int structdim, int dim, int spacedim>
-InvalidAccessor<structdim, dim, spacedim>::InvalidAccessor(
-  const Triangulation<dim, spacedim> *,
-  const int,
-  const int,
-  const AccessorData *)
+InvalidAccessor<structdim, dim, spacedim>::InvalidAccessor(const void *,
+                                                           const int,
+                                                           const int,
+                                                           const AccessorData *)
 {
   Assert(false,
          ExcMessage("You are attempting an invalid conversion between "
@@ -544,27 +543,23 @@ InvalidAccessor<structdim, dim, spacedim>::vertex(const unsigned int) const
 
 
 template <int structdim, int dim, int spacedim>
-inline typename dealii::internal::TriangulationImplementation::
-  Iterators<dim, spacedim>::line_iterator
-  InvalidAccessor<structdim, dim, spacedim>::line(const unsigned int) const
+inline void *
+InvalidAccessor<structdim, dim, spacedim>::line(const unsigned int) const
 {
   // nothing to do here. we could throw an exception but we can't get here
   // without first creating an object which would have already thrown
-  return typename dealii::internal::TriangulationImplementation::
-    Iterators<dim, spacedim>::line_iterator();
+  return nullptr;
 }
 
 
 
 template <int structdim, int dim, int spacedim>
-inline typename dealii::internal::TriangulationImplementation::
-  Iterators<dim, spacedim>::quad_iterator
-  InvalidAccessor<structdim, dim, spacedim>::quad(const unsigned int) const
+inline void *
+InvalidAccessor<structdim, dim, spacedim>::quad(const unsigned int) const
 {
   // nothing to do here. we could throw an exception but we can't get here
   // without first creating an object which would have already thrown
-  return typename dealii::internal::TriangulationImplementation::
-    Iterators<dim, spacedim>::quad_iterator();
+  return nullptr;
 }
 
 

--- a/source/dofs/dof_accessor.cc
+++ b/source/dofs/dof_accessor.cc
@@ -42,7 +42,7 @@ const unsigned int
 
 template <int structdim, int dim, int spacedim>
 DoFInvalidAccessor<structdim, dim, spacedim>::DoFInvalidAccessor(
-  const Triangulation<dim, spacedim> *,
+  const void *,
   const int,
   const int,
   const AccessorData *)


### PR DESCRIPTION
I need one follow-up patch to #14828. 