### PR TITLE
Fix an array index warning.

### DIFF
--- a/source/base/geometric_utilities.cc
+++ b/source/base/geometric_utilities.cc
@@ -46,18 +46,22 @@ namespace GeometricUtilities
     std::array<double, dim>
     to_spherical(const Point<dim> &position)
     {
-      std::array<double, dim> scoord;
+      std::array<double, dim> scoord{};
+      Assert(dim > 1, ExcNotImplemented());
 
       // radius
-      scoord[0] = position.norm();
-      // azimuth angle \theta:
-      scoord[1] = std::atan2(position(1), position(0));
-      // correct to [0,2*pi)
-      if (scoord[1] < 0.0)
-        scoord[1] += 2.0 * numbers::PI;
+      if DEAL_II_CONSTEXPR_IN_CONDITIONAL (dim > 1)
+        {
+          scoord[0] = position.norm();
+          // azimuth angle \theta:
+          scoord[1] = std::atan2(position(1), position(0));
+          // correct to [0,2*pi)
+          if (scoord[1] < 0.0)
+            scoord[1] += 2.0 * numbers::PI;
+        }
 
       // polar angle \phi:
-      if (dim == 3)
+      if DEAL_II_CONSTEXPR_IN_CONDITIONAL (dim == 3)
         {
           // acos returns the angle in the range [0,\pi]
           if (scoord[0] > std::numeric_limits<double>::min())


### PR DESCRIPTION
This warning only occurs at high optimization levels with newer versions of GCC - hence lets just fix it with a C++17 feature.