### PR TITLE
Play with C++20 concepts

### DIFF
--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -66,6 +66,8 @@ macro(_test_cxx20_support)
   # of the C++20 standard (which will have "202002L" when finalized). gcc-10
   # exports this version number when configured with C++20 support.
   # clang-10 exports the final "202002L" version instead, as does gcc-11.
+  #
+  # Beyond this, check for some features we actually need.
   CHECK_CXX_SOURCE_COMPILES(
     "
     #include <cmath>
@@ -78,6 +80,20 @@ macro(_test_cxx20_support)
     #if !(defined __cpp_lib_ranges) || (__cpp_lib_ranges < 201911)
     #  error \"insufficient support for C++20\"
     #endif
+
+
+    // Test concepts and requires clauses
+    template <int dim, int spacedim>
+    concept is_valid_dim_spacedim = (dim >= 1 && spacedim <= 3 &&
+                                     dim <= spacedim);
+
+    template <int dim, int spacedim>
+    requires is_valid_dim_spacedim<dim,spacedim>
+    class Triangulation 
+    {};
+
+    Triangulation<1,3> t;
+
 
     int main()
     {

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -150,6 +150,18 @@
 #cmakedefine DEAL_II_HAVE_CXX17
 #cmakedefine DEAL_II_HAVE_CXX20
 
+/**
+ * If we have C++20 available, we can have concepts and requires
+ * clauses. We want to avoid using too many `#ifdef` statements, so
+ * define a convenience macro that allows us to write a 'requires'
+ * clause that is simply removed when not using C++20.
+ */
+#ifdef DEAL_II_HAVE_CXX20
+#  define DEAL_II_CXX20_REQUIRES(condition) requires(condition)
+#else
+#  define DEAL_II_CXX20_REQUIRES(condition)
+#endif
+
 #cmakedefine DEAL_II_HAVE_FP_EXCEPTIONS
 #cmakedefine DEAL_II_HAVE_COMPLEX_OPERATOR_OVERLOADS
 #cmakedefine DEAL_II_HAVE_CXX17_BESSEL_FUNCTIONS
@@ -174,9 +186,10 @@
 #cmakedefine DEAL_II_FALLTHROUGH @DEAL_II_FALLTHROUGH@
 #cmakedefine DEAL_II_CONSTEXPR @DEAL_II_CONSTEXPR@
 
-// defined for backwards compatibility with older deal.II versions
+// The following two are defined for backwards compatibility with older deal.II versions:
 #define DEAL_II_WITH_CXX11
 #define DEAL_II_WITH_CXX14
+
 #ifdef DEAL_II_HAVE_CXX17
 #  define DEAL_II_WITH_CXX17
 #endif

--- a/include/deal.II/base/point.h
+++ b/include/deal.II/base/point.h
@@ -105,6 +105,7 @@ DEAL_II_NAMESPACE_OPEN
  * @ingroup geomprimitives
  */
 template <int dim, typename Number = double>
+DEAL_II_CXX20_REQUIRES(dim >= 0)
 class Point : public Tensor<1, dim, Number>
 {
 public:

--- a/include/deal.II/base/template_constraints.h
+++ b/include/deal.II/base/template_constraints.h
@@ -680,6 +680,29 @@ struct EnableIfScalar<std::complex<T>>
 };
 
 
+/**
+ * A namespace that is used to declare concepts used in C++20-style
+ * `requires` clauses.
+ */
+namespace concepts
+{
+#ifdef DEAL_II_HAVE_CXX20
+  /**
+   * A concept that tests that a combination of `dim` and `spacedim`
+   * template arguments is valid. Specifically, we must have that
+   * - `dim>=1`
+   * - `spacedim<=3`
+   * - `dim<=spacedim`.
+   * These are the kinds of requirements that are imposed, for
+   * example, on class Triangulation.
+   */
+  template <int dim, int spacedim>
+  concept is_valid_dim_spacedim = (dim >= 1 && spacedim <= 3 &&
+                                   dim <= spacedim);
+#endif
+} // namespace concepts
+
+
 DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -38,8 +38,11 @@ DEAL_II_NAMESPACE_OPEN
 #ifndef DOXYGEN
 template <typename ElementType, typename MemorySpace>
 class ArrayView;
+
 template <int dim, typename Number>
+DEAL_II_CXX20_REQUIRES(dim >= 0)
 class Point;
+
 template <int rank_, int dim, typename Number = double>
 class Tensor;
 template <typename Number>

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -48,6 +48,7 @@ DEAL_II_NAMESPACE_OPEN
 // forward declare Point
 #ifndef DOXYGEN
 template <int dim, typename Number>
+DEAL_II_CXX20_REQUIRES(dim >= 0)
 class Point;
 #endif
 

--- a/include/deal.II/distributed/p4est_wrappers.h
+++ b/include/deal.II/distributed/p4est_wrappers.h
@@ -47,6 +47,7 @@ namespace parallel
   namespace distributed
   {
     template <int dim, int spacedim>
+    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     class Triangulation;
   }
 } // namespace parallel

--- a/include/deal.II/dofs/block_info.h
+++ b/include/deal.II/dofs/block_info.h
@@ -20,6 +20,7 @@
 
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/subscriptor.h>
+#include <deal.II/base/template_constraints.h>
 
 #include <deal.II/lac/block_indices.h>
 
@@ -30,6 +31,7 @@ DEAL_II_NAMESPACE_OPEN
 // Forward declarations
 #ifndef DOXYGEN
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 #endif
 

--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -739,6 +739,7 @@ private:
   // Make the DoFHandler class a friend so that it can call the set_xxx()
   // functions.
   template <int, int>
+  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
   friend class DoFHandler;
 
   friend struct dealii::internal::DoFHandlerImplementation::Policy::
@@ -1208,7 +1209,8 @@ protected:
 
   // Make the DoFHandler class a friend so that it can call the set_xxx()
   // functions.
-  template <int, int>
+  template <int dim1, int spacedim1>
+  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim1, spacedim1>))
   friend class DoFHandler;
 
   friend struct dealii::internal::DoFHandlerImplementation::Policy::

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -311,6 +311,7 @@ namespace parallel
  * @ingroup dofs
  */
 template <int dim, int spacedim = dim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler : public Subscriptor
 {
   using ActiveSelector =

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -50,6 +50,7 @@ DEAL_II_NAMESPACE_OPEN
 template <int dim, int spacedim>
 class FiniteElement;
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class Triangulation;
 
 namespace internal

--- a/include/deal.II/dofs/dof_handler_policy.h
+++ b/include/deal.II/dofs/dof_handler_policy.h
@@ -32,7 +32,8 @@ DEAL_II_NAMESPACE_OPEN
 
 // Forward declaration
 #ifndef DOXYGEN
-template <int, int>
+template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 #endif
 

--- a/include/deal.II/dofs/dof_iterator_selector.h
+++ b/include/deal.II/dofs/dof_iterator_selector.h
@@ -32,6 +32,7 @@ template <int dim, int spacedim, bool lda>
 class DoFCellAccessor;
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 
 template <typename Accessor>

--- a/include/deal.II/dofs/dof_objects.h
+++ b/include/deal.II/dofs/dof_objects.h
@@ -20,6 +20,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/template_constraints.h>
 
 #include <vector>
 
@@ -27,7 +28,8 @@ DEAL_II_NAMESPACE_OPEN
 
 // Forward declarations
 #ifndef DOXYGEN
-template <int, int>
+template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 #endif
 

--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -48,6 +48,7 @@ class Quadrature;
 template <int dim, int spacedim>
 class FiniteElement;
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 template <int dim>
 class FiniteElementData;

--- a/include/deal.II/fe/mapping_q_cache.h
+++ b/include/deal.II/fe/mapping_q_cache.h
@@ -31,7 +31,8 @@ DEAL_II_NAMESPACE_OPEN
 
 // Forward declarations
 #ifndef DOXYGEN
-template <int, int>
+template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 #endif
 

--- a/include/deal.II/grid/cell_id.h
+++ b/include/deal.II/grid/cell_id.h
@@ -34,7 +34,8 @@ DEAL_II_NAMESPACE_OPEN
 
 // Forward declarations
 #ifndef DOXYGEN
-template <int, int>
+template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class Triangulation;
 #endif
 

--- a/include/deal.II/grid/grid_in.h
+++ b/include/deal.II/grid/grid_in.h
@@ -31,7 +31,8 @@ DEAL_II_NAMESPACE_OPEN
 
 // Forward declarations
 #ifndef DOXYGEN
-template <int dim, int space_dim>
+template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class Triangulation;
 template <int dim>
 struct CellData;

--- a/include/deal.II/grid/grid_out.h
+++ b/include/deal.II/grid/grid_out.h
@@ -32,6 +32,7 @@ DEAL_II_NAMESPACE_OPEN
 #ifndef DOXYGEN
 class ParameterHandler;
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class Triangulation;
 template <int dim, int spacedim>
 class Mapping;

--- a/include/deal.II/grid/grid_refinement.h
+++ b/include/deal.II/grid/grid_refinement.h
@@ -30,6 +30,7 @@ DEAL_II_NAMESPACE_OPEN
 // forward declarations
 #ifndef DOXYGEN
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class Triangulation;
 template <typename Number>
 class Vector;

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -71,7 +71,7 @@ namespace parallel
 {
   namespace distributed
   {
-    template <int, int>
+    template <int dim, int spacedim>
     class Triangulation;
   }
 } // namespace parallel

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1131,6 +1131,7 @@ namespace internal
  * @ingroup grid aniso
  */
 template <int dim, int spacedim = dim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class Triangulation : public Subscriptor
 {
 private:

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -55,6 +55,7 @@ namespace parallel
 }
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 template <int dim, int spacedim, bool lda>
 class DoFCellAccessor;

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -39,6 +39,7 @@ DEAL_II_NAMESPACE_OPEN
 // Forward declarations
 #ifndef DOXYGEN
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class Triangulation;
 template <typename Accessor>
 class TriaRawIterator;
@@ -1870,6 +1871,7 @@ private:
 
 private:
   template <int, int>
+  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
   friend class Triangulation;
 
   friend struct dealii::internal::TriangulationImplementation::Implementation;
@@ -4170,6 +4172,7 @@ private:
   set_direction_flag(const bool new_direction_flag) const;
 
   template <int, int>
+  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
   friend class Triangulation;
 
   template <int, int>

--- a/include/deal.II/grid/tria_iterator.h
+++ b/include/deal.II/grid/tria_iterator.h
@@ -32,6 +32,7 @@ DEAL_II_NAMESPACE_OPEN
 // Forward declarations
 #ifndef DOXYGEN
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class Triangulation;
 template <int, int, int>
 class TriaAccessorBase;

--- a/include/deal.II/grid/tria_objects.h
+++ b/include/deal.II/grid/tria_objects.h
@@ -29,6 +29,7 @@ DEAL_II_NAMESPACE_OPEN
 // Forward declarations
 #ifndef DOXYGEN
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class Triangulation;
 template <class Accessor>
 class TriaRawIterator;

--- a/include/deal.II/hp/refinement.h
+++ b/include/deal.II/hp/refinement.h
@@ -34,6 +34,7 @@ template <typename Number>
 class Vector;
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 #endif
 

--- a/include/deal.II/multigrid/mg_constrained_dofs.h
+++ b/include/deal.II/multigrid/mg_constrained_dofs.h
@@ -33,6 +33,7 @@ DEAL_II_NAMESPACE_OPEN
 // Forward declaration
 #ifndef DOXYGEN
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 #endif
 

--- a/include/deal.II/multigrid/mg_tools.h
+++ b/include/deal.II/multigrid/mg_tools.h
@@ -32,6 +32,7 @@ DEAL_II_NAMESPACE_OPEN
 // Forward declarations
 #ifndef DOXYGEN
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 class MGConstrainedDoFs;
 #endif

--- a/include/deal.II/multigrid/mg_transfer_block.h
+++ b/include/deal.II/multigrid/mg_transfer_block.h
@@ -38,6 +38,7 @@ DEAL_II_NAMESPACE_OPEN
 // Forward declaration
 #ifndef DOXYGEN
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 #endif
 

--- a/include/deal.II/multigrid/mg_transfer_component.h
+++ b/include/deal.II/multigrid/mg_transfer_component.h
@@ -40,6 +40,7 @@ DEAL_II_NAMESPACE_OPEN
 // Forward declaration
 #ifndef DOXYGEN
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 #endif
 

--- a/include/deal.II/numerics/data_out_stack.h
+++ b/include/deal.II/numerics/data_out_stack.h
@@ -34,6 +34,7 @@ DEAL_II_NAMESPACE_OPEN
 // Forward declaration
 #ifndef DOXYGEN
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 #endif
 

--- a/include/deal.II/numerics/error_estimator.h
+++ b/include/deal.II/numerics/error_estimator.h
@@ -30,7 +30,8 @@ DEAL_II_NAMESPACE_OPEN
 
 // Forward declarations
 #ifndef DOXYGEN
-template <int, int>
+template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 template <int, int>
 class Mapping;

--- a/include/deal.II/numerics/matrix_creator.h
+++ b/include/deal.II/numerics/matrix_creator.h
@@ -47,6 +47,7 @@ class SparseMatrix;
 template <int dim, int spacedim>
 class Mapping;
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 
 namespace hp

--- a/include/deal.II/numerics/matrix_tools.h
+++ b/include/deal.II/numerics/matrix_tools.h
@@ -56,6 +56,7 @@ class BlockVector;
 template <int dim, int spacedim>
 class Mapping;
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 
 namespace hp

--- a/include/deal.II/numerics/smoothness_estimator.h
+++ b/include/deal.II/numerics/smoothness_estimator.h
@@ -36,6 +36,7 @@ template <typename Number>
 class Vector;
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 
 namespace FESeries

--- a/include/deal.II/numerics/time_dependent.h
+++ b/include/deal.II/numerics/time_dependent.h
@@ -34,6 +34,7 @@ class TimeStepBase;
 template <typename number>
 class Vector;
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class Triangulation;
 #endif
 

--- a/include/deal.II/numerics/vector_tools_boundary.h
+++ b/include/deal.II/numerics/vector_tools_boundary.h
@@ -30,6 +30,7 @@ DEAL_II_NAMESPACE_OPEN
 template <typename number>
 class AffineConstraints;
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 template <int dim, typename Number>
 class Function;

--- a/include/deal.II/numerics/vector_tools_integrate_difference.h
+++ b/include/deal.II/numerics/vector_tools_integrate_difference.h
@@ -32,6 +32,7 @@ class Mapping;
 template <int dim>
 class Quadrature;
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class Triangulation;
 namespace hp
 {

--- a/include/deal.II/numerics/vector_tools_integrate_difference.h
+++ b/include/deal.II/numerics/vector_tools_integrate_difference.h
@@ -24,6 +24,7 @@
 DEAL_II_NAMESPACE_OPEN
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 template <int dim, typename Number>
 class Function;

--- a/include/deal.II/numerics/vector_tools_interpolate.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.h
@@ -27,6 +27,7 @@ DEAL_II_NAMESPACE_OPEN
 template <typename number>
 class AffineConstraints;
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 template <typename number>
 class FullMatrix;

--- a/include/deal.II/numerics/vector_tools_mean_value.h
+++ b/include/deal.II/numerics/vector_tools_mean_value.h
@@ -26,6 +26,7 @@ DEAL_II_NAMESPACE_OPEN
 #ifndef DOXYGEN
 // forward declarations
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 template <int dim, int spacedim>
 class Mapping;

--- a/include/deal.II/numerics/vector_tools_point_gradient.h
+++ b/include/deal.II/numerics/vector_tools_point_gradient.h
@@ -25,6 +25,7 @@
 DEAL_II_NAMESPACE_OPEN
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 template <int dim, typename Number>
 class Function;

--- a/include/deal.II/numerics/vector_tools_point_gradient.h
+++ b/include/deal.II/numerics/vector_tools_point_gradient.h
@@ -30,8 +30,11 @@ template <int dim, typename Number>
 class Function;
 template <int dim, int spacedim>
 class Mapping;
+
 template <int dim, typename Number>
+DEAL_II_CXX20_REQUIRES(dim >= 0)
 class Point;
+
 template <int rank_, int dim, typename Number>
 class Tensor;
 template <typename Number>

--- a/include/deal.II/numerics/vector_tools_point_value.h
+++ b/include/deal.II/numerics/vector_tools_point_value.h
@@ -22,6 +22,7 @@
 DEAL_II_NAMESPACE_OPEN
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 template <int dim, typename Number>
 class Function;

--- a/include/deal.II/numerics/vector_tools_point_value.h
+++ b/include/deal.II/numerics/vector_tools_point_value.h
@@ -27,8 +27,11 @@ template <int dim, typename Number>
 class Function;
 template <int dim, int spacedim>
 class Mapping;
+
 template <int dim, typename Number>
+DEAL_II_CXX20_REQUIRES(dim >= 0)
 class Point;
+
 template <typename Number>
 class Vector;
 namespace hp

--- a/include/deal.II/numerics/vector_tools_project.h
+++ b/include/deal.II/numerics/vector_tools_project.h
@@ -27,6 +27,7 @@ DEAL_II_NAMESPACE_OPEN
 template <typename number>
 class AffineConstraints;
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 template <int dim, typename Number>
 class Function;

--- a/include/deal.II/numerics/vector_tools_rhs.h
+++ b/include/deal.II/numerics/vector_tools_rhs.h
@@ -25,6 +25,7 @@ DEAL_II_NAMESPACE_OPEN
 template <typename number>
 class AffineConstraints;
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 template <int dim, typename Number>
 class Function;


### PR DESCRIPTION
A while ago, we had a mail on the forum where someone got a linker error that turned out to be rather difficult to figure out. Ultimately, what happened is that they called a `VectorTools` function with many arguments from a `const` member function, which made the type of the solution vector a `const Vector`, which the compiler gladly accepted as a valid template argument -- alas, we did of course not instantiate the function with a `const` type because the argument was supposed to be writable.

That made me think about how we could avoid this kind of thing. The long-term solution is to use C++20 concepts that would annotate this function with a
```
  requires (std::is_const_v<VectorType> == false)
```
clause. If that clause had been there, the compiler would have provided an error message of the sort
```
  No such function.
  Candidate is: ...
  Candidate is not viable because requires clause is not satisfied:
            std::is_const_v<VectorType> == false
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
That would have at least produced a compiler (rather than linker) error that is modestly helpful in finding the issue.

This patch is an attempt at playing with C++20 concepts a bit. Everything is guarded by `#ifdef DEAL_II_HAVE_CXX20`, so nothing should be visible to compilers that don't enable this. For the moment, I haven't gone all in at annotating things, but only trialled the following classes:
* Triangulation: Can only be instantiated for `dim>=1, spacedim<=3, dim<=spacedim`
* DoFHandler: The same
* Point: Can only be instantiated for `dim>=0`.

In reality, I don't think that all that many classes need to be annotated with `requires` clauses because in many cases we keep passing objects around. If `SolutionTransfer` takes a `DoFHandler` as template argument, then the constraints on `DoFHandler` automatically carry over to `SolutionTransfer`: You can't instantiate `SolutionTransfer<DoFHandler<3,2>>` because you can't instantiate `DoFHandler`. Whether we do or do not annotate `SolutionTransfer` is then more a matter of taste or documentation. 

In any case, I'm not trying to be comprehensive here, but am looking for feedback on whether that's a direction worth going. My personal opinion is that it is, in parts because we know that we want to use C++20 anyway in a few years. As an illustration of the usefulness of the general idea, I present #14828 and #14832, which are cases where we violated the constraints I had attached to `Triangulation` in specific instantiations.