### PR TITLE
Move AdditionalData outside of class definition

### DIFF
--- a/include/deal.II/lac/eigen.h
+++ b/include/deal.II/lac/eigen.h
@@ -33,6 +33,53 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+/**
+ * Standardized data struct to pipe additional data to EigenPower.
+ */
+struct EigenPowerAdditionalData
+{
+  /**
+   * Shift parameter. This parameter allows to shift the spectrum to compute
+   * a different eigenvalue.
+   */
+  double shift;
+  /**
+   * Constructor. Set the shift parameter.
+   */
+  EigenPowerAdditionalData(const double shift = 0.)
+    : shift(shift)
+  {}
+};
+
+/**
+ * Standardized data struct to pipe additional data to EigenInverse.
+ */
+struct EigenInverseAdditionalData
+{
+  /**
+   * Damping of the updated shift value.
+   */
+  double relaxation;
+
+  /**
+   * Start step of adaptive shift parameter.
+   */
+  unsigned int start_adaption;
+  /**
+   * Flag for the stopping criterion.
+   */
+  bool use_residual;
+  /**
+   * Constructor.
+   */
+  EigenInverseAdditionalData(double       relaxation     = 1.,
+                             unsigned int start_adaption = 6,
+                             bool         use_residual   = true)
+    : relaxation(relaxation)
+    , start_adaption(start_adaption)
+    , use_residual(use_residual)
+  {}
+};
 
 /**
  * @addtogroup Solvers
@@ -62,22 +109,9 @@ public:
   using size_type = types::global_dof_index;
 
   /**
-   * Standardized data struct to pipe additional data to the solver.
+   * An alias for the solver-specific additional data.
    */
-  struct AdditionalData
-  {
-    /**
-     * Shift parameter. This parameter allows to shift the spectrum to compute
-     * a different eigenvalue.
-     */
-    double shift;
-    /**
-     * Constructor. Set the shift parameter.
-     */
-    AdditionalData(const double shift = 0.)
-      : shift(shift)
-    {}
-  };
+  using AdditionalData = EigenPowerAdditionalData;
 
   /**
    * Constructor.
@@ -135,34 +169,9 @@ public:
   using size_type = types::global_dof_index;
 
   /**
-   * Standardized data struct to pipe additional data to the solver.
+   * An alias for the solver-specific additional data.
    */
-  struct AdditionalData
-  {
-    /**
-     * Damping of the updated shift value.
-     */
-    double relaxation;
-
-    /**
-     * Start step of adaptive shift parameter.
-     */
-    unsigned int start_adaption;
-    /**
-     * Flag for the stopping criterion.
-     */
-    bool use_residual;
-    /**
-     * Constructor.
-     */
-    AdditionalData(double       relaxation     = 1.,
-                   unsigned int start_adaption = 6,
-                   bool         use_residual   = true)
-      : relaxation(relaxation)
-      , start_adaption(start_adaption)
-      , use_residual(use_residual)
-    {}
-  };
+  using AdditionalData = EigenInverseAdditionalData;
 
   /**
    * Constructor.

--- a/include/deal.II/lac/solver.h
+++ b/include/deal.II/lac/solver.h
@@ -167,7 +167,7 @@ class Vector;
  * Several solvers need additional data, like the damping parameter @p omega
  * of the @p SolverRichardson class or the maximum number of temporary vectors
  * of @p SolverGMRES.  To have a standardized way of constructing solvers,
- * each solver class has a <tt>struct AdditionalData</tt> as a member, and
+ * each solver class has a typedef <tt>AdditionalData</tt> as a member, and
  * constructors of all solver classes take such an argument. Some solvers need
  * no additional data, or may not at the current time. For these solvers the
  * struct @p AdditionalData is empty and calling the constructor may be done

--- a/include/deal.II/lac/solver_bicgstab.h
+++ b/include/deal.II/lac/solver_bicgstab.h
@@ -32,9 +32,49 @@
 DEAL_II_NAMESPACE_OPEN
 
 /**
+ * Standardized data struct to pipe additional data to SolverBicgstab.
+ *
+ * There are two possibilities to compute the residual: one is an estimate
+ * using the computed value @p tau. The other is exact computation using
+ * another matrix vector multiplication. This increases the costs of the
+ * algorithm, so it is should be set to false whenever the problem allows
+ * it.
+ *
+ * Bicgstab is susceptible to breakdowns, so we need a parameter telling us,
+ * which numbers are considered zero.
+ */
+template <typename VectorType>
+struct SolverBicgstabAdditionalData
+{
+  /**
+   * Constructor.
+   *
+   * The default is to perform an exact residual computation and breakdown
+   * parameter is the minimum finite value representable by the value_type of
+   * VectorType.
+   */
+  explicit SolverBicgstabAdditionalData(
+    const bool   exact_residual = true,
+    const double breakdown =
+      std::numeric_limits<typename VectorType::value_type>::min())
+    : exact_residual(exact_residual)
+    , breakdown(breakdown)
+  {}
+  /**
+   * Flag for exact computation of residual.
+   */
+  bool exact_residual;
+  /**
+   * Breakdown threshold.
+   */
+  double breakdown;
+};
+
+/**
  * @addtogroup Solvers
  * @{
  */
+
 
 /**
  * Bicgstab algorithm by van der Vorst.
@@ -80,40 +120,9 @@ class SolverBicgstab : public SolverBase<VectorType>
 {
 public:
   /**
-   * There are two possibilities to compute the residual: one is an estimate
-   * using the computed value @p tau. The other is exact computation using
-   * another matrix vector multiplication. This increases the costs of the
-   * algorithm, so it is should be set to false whenever the problem allows
-   * it.
-   *
-   * Bicgstab is susceptible to breakdowns, so we need a parameter telling us,
-   * which numbers are considered zero.
+   * An alias for the solver-specific additional data.
    */
-  struct AdditionalData
-  {
-    /**
-     * Constructor.
-     *
-     * The default is to perform an exact residual computation and breakdown
-     * parameter is the minimum finite value representable by the value_type of
-     * VectorType.
-     */
-    explicit AdditionalData(
-      const bool   exact_residual = true,
-      const double breakdown =
-        std::numeric_limits<typename VectorType::value_type>::min())
-      : exact_residual(exact_residual)
-      , breakdown(breakdown)
-    {}
-    /**
-     * Flag for exact computation of residual.
-     */
-    bool exact_residual;
-    /**
-     * Breakdown threshold.
-     */
-    double breakdown;
-  };
+  using AdditionalData = SolverBicgstabAdditionalData<VectorType>;
 
   /**
    * Constructor.

--- a/include/deal.II/lac/solver_cg.h
+++ b/include/deal.II/lac/solver_cg.h
@@ -45,6 +45,23 @@ namespace LinearAlgebra
 } // namespace LinearAlgebra
 #endif
 
+/**
+ * Standardized data struct to pipe additional data to a SolverCG.
+ * Here, it does not store anything but just exists for consistency
+ * with the other solver classes.
+ */
+struct SolverCGAdditionalData
+{};
+
+/**
+ * Standardized data struct to pipe additional data to a SolverFlexibleCG.
+ * Here, it does not store anything but just exists for consistency
+ * with the other solver classes.
+ */
+struct SolverFlexibleCGAdditionalData
+{};
+
+
 
 /** @addtogroup Solvers */
 /** @{ */
@@ -183,12 +200,9 @@ public:
   using size_type = types::global_dof_index;
 
   /**
-   * Standardized data struct to pipe additional data to the solver.
-   * Here, it does not store anything but just exists for consistency
-   * with the other solver classes.
+   * An alias for the solver-specific additional data.
    */
-  struct AdditionalData
-  {};
+  using AdditionalData = SolverCGAdditionalData;
 
   /**
    * Constructor.
@@ -360,12 +374,9 @@ public:
   using size_type = types::global_dof_index;
 
   /**
-   * Standardized data struct to pipe additional data to the solver.
-   * Here, it does not store anything but just exists for consistency
-   * with the other solver classes.
+   * An alias for the solver-specific additional data.
    */
-  struct AdditionalData
-  {};
+  using AdditionalData = SolverCGAdditionalData;
 
   /**
    * Constructor.

--- a/include/deal.II/lac/solver_fire.h
+++ b/include/deal.II/lac/solver_fire.h
@@ -29,6 +29,35 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+/**
+ * Standardized data struct to pipe additional data to SolverFIRE.
+ */
+struct SolverFIREAdditionalData
+{
+  /**
+   * Constructor. By default, set the initial time step for the (forward)
+   * Euler integration step to 0.1, the maximum time step to 1 and the
+   * maximum change allowed in any variable (per iteration) to 1.
+   */
+  explicit SolverFIREAdditionalData(const double initial_timestep    = 0.1,
+                                    const double maximum_timestep    = 1,
+                                    const double maximum_linfty_norm = 1);
+
+  /**
+   * Initial time step for the (forward) Euler integration step.
+   */
+  const double initial_timestep;
+
+  /**
+   * Maximum time step for the (forward) Euler integration step.
+   */
+  const double maximum_timestep;
+
+  /**
+   * Maximum change allowed in any variable of the objective function.
+   */
+  const double maximum_linfty_norm;
+};
 
 /**
  * @addtogroup Solvers
@@ -92,34 +121,9 @@ class SolverFIRE : public SolverBase<VectorType>
 {
 public:
   /**
-   * Standardized data struct to pipe additional data to the solver.
+   * An alias for the solver-specific additional data.
    */
-  struct AdditionalData
-  {
-    /**
-     * Constructor. By default, set the initial time step for the (forward)
-     * Euler integration step to 0.1, the maximum time step to 1 and the
-     * maximum change allowed in any variable (per iteration) to 1.
-     */
-    explicit AdditionalData(const double initial_timestep    = 0.1,
-                            const double maximum_timestep    = 1,
-                            const double maximum_linfty_norm = 1);
-
-    /**
-     * Initial time step for the (forward) Euler integration step.
-     */
-    const double initial_timestep;
-
-    /**
-     * Maximum time step for the (forward) Euler integration step.
-     */
-    const double maximum_timestep;
-
-    /**
-     * Maximum change allowed in any variable of the objective function.
-     */
-    const double maximum_linfty_norm;
-  };
+  using AdditionalData = SolverFIREAdditionalData;
 
   /**
    * Constructor.
@@ -187,8 +191,7 @@ protected:
 
 #ifndef DOXYGEN
 
-template <typename VectorType>
-SolverFIRE<VectorType>::AdditionalData::AdditionalData(
+SolverFIREAdditionalData::SolverFIREAdditionalData(
   const double initial_timestep,
   const double maximum_timestep,
   const double maximum_linfty_norm)

--- a/include/deal.II/lac/solver_idr.h
+++ b/include/deal.II/lac/solver_idr.h
@@ -94,6 +94,22 @@ namespace internal
 } // namespace internal
 
 /**
+ * Structure for storing additional data needed by SolverIDR.
+ */
+struct SolverIDRAdditionalData
+{
+  /**
+   * Constructor. By default, an IDR(2) method is used.
+   */
+  explicit SolverIDRAdditionalData(const unsigned int s = 2)
+    : s(s)
+  {}
+
+  const unsigned int s;
+};
+
+
+/**
  * This class implements the IDR(s) method used for solving nonsymmetric,
  * indefinite linear systems, developed in <a
  * href="https://epubs.siam.org/doi/abs/10.1137/070685804">
@@ -120,19 +136,9 @@ class SolverIDR : public SolverBase<VectorType>
 {
 public:
   /**
-   * Structure for storing additional data needed by the solver.
+   * An alias for the solver-specific additional data.
    */
-  struct AdditionalData
-  {
-    /**
-     * Constructor. By default, an IDR(2) method is used.
-     */
-    explicit AdditionalData(const unsigned int s = 2)
-      : s(s)
-    {}
-
-    const unsigned int s;
-  };
+  using AdditionalData = SolverIDRAdditionalData;
 
   /**
    * Constructor.

--- a/include/deal.II/lac/solver_minres.h
+++ b/include/deal.II/lac/solver_minres.h
@@ -31,6 +31,13 @@
 DEAL_II_NAMESPACE_OPEN
 
 /**
+ * Standardized data struct to pipe additional data to SolverMinRes. This
+ * solver does not need additional data yet.
+ */
+struct SolverMinResAdditionalData
+{};
+
+/**
  * @addtogroup Solvers
  * @{
  */
@@ -71,11 +78,9 @@ class SolverMinRes : public SolverBase<VectorType>
 {
 public:
   /**
-   * Standardized data struct to pipe additional data to the solver. This
-   * solver does not need additional data yet.
+   * An alias for the solver-specific additional data.
    */
-  struct AdditionalData
-  {};
+  using AdditionalData = SolverMinResAdditionalData;
 
   /**
    * Constructor.

--- a/include/deal.II/lac/solver_qmrs.h
+++ b/include/deal.II/lac/solver_qmrs.h
@@ -28,6 +28,72 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+
+/**
+ * Standardized data struct to pipe additional data to SolverQMRS.
+ *
+ * The user is able to switch between right and left preconditioning, that
+ * means solving the systems <i>P<sup>-1</sup>A</i> and <i>AP<sup>-1</sup></i>
+ * respectively, using the corresponding parameter. Note that left
+ * preconditioning means to employ the preconditioned (BiCG-)residual and
+ * otherwise the unpreconditioned one. The default is the application from the
+ * right side.
+ *
+ * The @p solver_tolerance threshold is used to define the said bound below which the residual
+ * is computed exactly. See the class documentation for more information. The
+ * default value is 1e-9, that is the default solving precision multiplied by
+ * ten.
+ *
+ * SQMR is susceptible to breakdowns (divisions by zero), so we need a
+ * parameter telling us which numbers are considered zero. The proper
+ * breakdown criterion is very unclear, so experiments may be necessary here.
+ * It is even possible to achieve convergence despite of dividing through by
+ * small numbers. There are even cases in which it is advantageous to accept
+ * such divisions because the cheap iteration cost makes the algorithm the
+ * fastest of all available indefinite iterative solvers. Nonetheless, the
+ * default breakdown threshold value is 1e-16.
+ */
+struct SolverQMRSAdditionalData
+{
+  /**
+   * Constructor.
+   *
+   * The default is right preconditioning, with the @p solver_tolerance chosen to be 1e-9 and
+   * the @p breakdown_threshold set at 1e-16.
+   */
+  explicit SolverQMRSAdditionalData(const bool   left_preconditioning = false,
+                                    const double solver_tolerance     = 1.e-9,
+                                    const bool   breakdown_testing    = true,
+                                    const double breakdown_threshold  = 1.e-16)
+    : left_preconditioning(left_preconditioning)
+    , solver_tolerance(solver_tolerance)
+    , breakdown_testing(breakdown_testing)
+    , breakdown_threshold(breakdown_threshold)
+  {}
+
+  /**
+   * Flag for using a left-preconditioned version.
+   */
+  bool left_preconditioning;
+
+  /**
+   * The threshold below which the current residual is computed exactly.
+   */
+  double solver_tolerance;
+
+  /**
+   * Flag for breakdown testing.
+   */
+  bool breakdown_testing;
+
+  /**
+   * Breakdown threshold. Scalars measured to this bound are used for
+   * divisions.
+   */
+  double breakdown_threshold;
+};
+
+
 /**
  * @addtogroup Solvers
  * @{
@@ -95,68 +161,9 @@ class SolverQMRS : public SolverBase<VectorType>
 {
 public:
   /**
-   * Standardized data struct to pipe additional data to the solver.
-   *
-   * The user is able to switch between right and left preconditioning, that
-   * means solving the systems <i>P<sup>-1</sup>A</i> and <i>AP<sup>-1</sup></i>
-   * respectively, using the corresponding parameter. Note that left
-   * preconditioning means to employ the preconditioned (BiCG-)residual and
-   * otherwise the unpreconditioned one. The default is the application from the
-   * right side.
-   *
-   * The @p solver_tolerance threshold is used to define the said bound below which the residual
-   * is computed exactly. See the class documentation for more information. The
-   * default value is 1e-9, that is the default solving precision multiplied by
-   * ten.
-   *
-   * SQMR is susceptible to breakdowns (divisions by zero), so we need a
-   * parameter telling us which numbers are considered zero. The proper
-   * breakdown criterion is very unclear, so experiments may be necessary here.
-   * It is even possible to achieve convergence despite of dividing through by
-   * small numbers. There are even cases in which it is advantageous to accept
-   * such divisions because the cheap iteration cost makes the algorithm the
-   * fastest of all available indefinite iterative solvers. Nonetheless, the
-   * default breakdown threshold value is 1e-16.
+   * An alias for the solver-specific additional data.
    */
-  struct AdditionalData
-  {
-    /**
-     * Constructor.
-     *
-     * The default is right preconditioning, with the @p solver_tolerance chosen to be 1e-9 and
-     * the @p breakdown_threshold set at 1e-16.
-     */
-    explicit AdditionalData(const bool   left_preconditioning = false,
-                            const double solver_tolerance     = 1.e-9,
-                            const bool   breakdown_testing    = true,
-                            const double breakdown_threshold  = 1.e-16)
-      : left_preconditioning(left_preconditioning)
-      , solver_tolerance(solver_tolerance)
-      , breakdown_testing(breakdown_testing)
-      , breakdown_threshold(breakdown_threshold)
-    {}
-
-    /**
-     * Flag for using a left-preconditioned version.
-     */
-    bool left_preconditioning;
-
-    /**
-     * The threshold below which the current residual is computed exactly.
-     */
-    double solver_tolerance;
-
-    /**
-     * Flag for breakdown testing.
-     */
-    bool breakdown_testing;
-
-    /**
-     * Breakdown threshold. Scalars measured to this bound are used for
-     * divisions.
-     */
-    double breakdown_threshold;
-  };
+  using AdditionalData = SolverQMRSAdditionalData;
 
   /**
    * Constructor.

--- a/include/deal.II/lac/solver_relaxation.h
+++ b/include/deal.II/lac/solver_relaxation.h
@@ -28,6 +28,13 @@
 DEAL_II_NAMESPACE_OPEN
 
 /**
+ * Standardized data struct to pipe additional data to SolverRelaxation. There
+ * is no data in here for relaxation methods.
+ */
+struct SolverRelaxationAdditionalData
+{};
+
+/**
  * Implementation of an iterative solver based on relaxation methods. The
  * stopping criterion is the norm of the residual.
  *
@@ -58,11 +65,9 @@ class SolverRelaxation : public SolverBase<VectorType>
 {
 public:
   /**
-   * Standardized data struct to pipe additional data to the solver. There is
-   * no data in here for relaxation methods.
+   * An alias for the solver-specific additional data.
    */
-  struct AdditionalData
-  {};
+  using AdditionalData = SolverRelaxationAdditionalData;
 
   /**
    * Constructor.

--- a/include/deal.II/lac/solver_richardson.h
+++ b/include/deal.II/lac/solver_richardson.h
@@ -30,6 +30,30 @@
 DEAL_II_NAMESPACE_OPEN
 
 /**
+ * Standardized data struct to pipe additional data to SolverRichardson.
+ */
+struct SolverRichardsonAdditionalData
+{
+  /**
+   * Constructor. By default, set the damping parameter to one.
+   */
+  explicit SolverRichardsonAdditionalData(
+    const double omega                       = 1,
+    const bool   use_preconditioned_residual = false);
+
+  /**
+   * Relaxation parameter.
+   */
+  double omega;
+
+  /**
+   * Parameter for stopping criterion.
+   */
+  bool use_preconditioned_residual;
+};
+
+
+/**
  * @addtogroup Solvers
  * @{
  */
@@ -65,26 +89,9 @@ class SolverRichardson : public SolverBase<VectorType>
 {
 public:
   /**
-   * Standardized data struct to pipe additional data to the solver.
+   * An alias for the solver-specific additional data.
    */
-  struct AdditionalData
-  {
-    /**
-     * Constructor. By default, set the damping parameter to one.
-     */
-    explicit AdditionalData(const double omega                       = 1,
-                            const bool   use_preconditioned_residual = false);
-
-    /**
-     * Relaxation parameter.
-     */
-    double omega;
-
-    /**
-     * Parameter for stopping criterion.
-     */
-    bool use_preconditioned_residual;
-  };
+  using AdditionalData = SolverRichardsonAdditionalData;
 
   /**
    * Constructor.
@@ -163,8 +170,8 @@ protected:
 
 #ifndef DOXYGEN
 
-template <class VectorType>
-inline SolverRichardson<VectorType>::AdditionalData::AdditionalData(
+
+inline SolverRichardsonAdditionalData::SolverRichardsonAdditionalData(
   const double omega,
   const bool   use_preconditioned_residual)
   : omega(omega)

--- a/include/deal.II/non_matching/quadrature_generator.h
+++ b/include/deal.II/non_matching/quadrature_generator.h
@@ -57,18 +57,19 @@ namespace NonMatching
   /**
    * Struct storing settings for the QuadratureGenerator class.
    */
-  struct AdditionalQGeneratorData
+  struct QuadratureGeneratorAdditionalData
   {
     /**
      * Constructor.
      */
-    AdditionalQGeneratorData(const unsigned int max_box_splits          = 4,
-                             const double lower_bound_implicit_function = 1e-11,
-                             const double min_distance_between_roots    = 1e-12,
-                             const double limit_to_be_definite          = 1e-11,
-                             const double root_finder_tolerance         = 1e-12,
-                             const unsigned int max_root_finder_splits  = 2,
-                             bool               split_in_half           = true);
+    QuadratureGeneratorAdditionalData(
+      const unsigned int max_box_splits                = 4,
+      const double       lower_bound_implicit_function = 1e-11,
+      const double       min_distance_between_roots    = 1e-12,
+      const double       limit_to_be_definite          = 1e-11,
+      const double       root_finder_tolerance         = 1e-12,
+      const unsigned int max_root_finder_splits        = 2,
+      bool               split_in_half                 = true);
 
     /**
      * The number of times we are allowed to split the incoming box
@@ -129,6 +130,11 @@ namespace NonMatching
     bool split_in_half;
   };
 
+  /**
+   * Deprecated alias. Use QuadratureGeneratorAdditionalData.
+   */
+  using AdditionalQGeneratorData DEAL_II_DEPRECATED =
+    QuadratureGeneratorAdditionalData;
 
 
   /**
@@ -188,7 +194,7 @@ namespace NonMatching
   class QuadratureGenerator
   {
   public:
-    using AdditionalData = AdditionalQGeneratorData;
+    using AdditionalData = QuadratureGeneratorAdditionalData;
 
     /**
      * Constructor. Each Quadrature<1> in @p quadratures1d can be chosen as base
@@ -292,7 +298,7 @@ namespace NonMatching
   class FaceQuadratureGenerator
   {
   public:
-    using AdditionalData = AdditionalQGeneratorData;
+    using AdditionalData = QuadratureGeneratorAdditionalData;
 
     /**
      * Constructor. Each Quadrature<1> in @p quadratures1d can be chosen as base
@@ -393,7 +399,7 @@ namespace NonMatching
   class FaceQuadratureGenerator<1>
   {
   public:
-    using AdditionalData = AdditionalQGeneratorData;
+    using AdditionalData = QuadratureGeneratorAdditionalData;
 
     /**
      * Constructor. The incoming hp::QCollection is not used. But this class
@@ -491,7 +497,7 @@ namespace NonMatching
   class DiscreteQuadratureGenerator : public QuadratureGenerator<dim>
   {
   public:
-    using AdditionalData = AdditionalQGeneratorData;
+    using AdditionalData = QuadratureGeneratorAdditionalData;
 
     /**
      * Constructor, the discrete level set function is described by the
@@ -547,7 +553,7 @@ namespace NonMatching
   class DiscreteFaceQuadratureGenerator : public FaceQuadratureGenerator<dim>
   {
   public:
-    using AdditionalData = AdditionalQGeneratorData;
+    using AdditionalData = QuadratureGeneratorAdditionalData;
 
     /**
      * Constructor, the discrete level set function is described by the
@@ -589,6 +595,38 @@ namespace NonMatching
     namespace QuadratureGeneratorImplementation
     {
       /**
+       * Struct storing settings for the RootFinder class.
+       */
+      struct RootFinderAdditionalData
+      {
+        /**
+         * Constructor.
+         */
+        RootFinderAdditionalData(const double       tolerance           = 1e-12,
+                                 const unsigned int max_recursion_depth = 2,
+                                 const unsigned int max_iterations      = 500);
+
+        /**
+         * The tolerance in the stopping criteria for the underlying root
+         * finding algorithm boost::math::tools::toms748_solve.
+         */
+        double tolerance;
+
+        /**
+         * The number of times we are allowed to split the interval where we
+         * seek roots.
+         */
+        unsigned int max_recursion_depth;
+
+        /**
+         * The maximum number of iterations in
+         * boost::math::tools::toms748_solve.
+         */
+        unsigned int max_iterations;
+      };
+
+
+      /**
        * A class that attempts to find multiple distinct roots of a function,
        * $f(x)$, over an interval, $[l, r]$. This is done as follows. If there
        * is a sign change in function value between the interval end points,
@@ -609,36 +647,9 @@ namespace NonMatching
       {
       public:
         /**
-         * Struct storing settings for the RootFinder class.
+         * Alias for the additional data.
          */
-        struct AdditionalData
-        {
-          /**
-           * Constructor.
-           */
-          AdditionalData(const double       tolerance           = 1e-12,
-                         const unsigned int max_recursion_depth = 2,
-                         const unsigned int max_iterations      = 500);
-
-          /**
-           * The tolerance in the stopping criteria for the underlying root
-           * finding algorithm boost::math::tools::toms748_solve.
-           */
-          double tolerance;
-
-          /**
-           * The number of times we are allowed to split the interval where we
-           * seek roots.
-           */
-          unsigned int max_recursion_depth;
-
-          /**
-           * The maximum number of iterations in
-           * boost::math::tools::toms748_solve.
-           */
-          unsigned int max_iterations;
-        };
-
+        using AdditionalData = RootFinderAdditionalData;
 
         /**
          * Constructor.
@@ -832,8 +843,8 @@ namespace NonMatching
          * Constructor. Takes the same parameters as QuadratureGenerator.
          */
         UpThroughDimensionCreator(
-          const hp::QCollection<1> &      q_collection1D,
-          const AdditionalQGeneratorData &additional_data);
+          const hp::QCollection<1> &               q_collection1D,
+          const QuadratureGeneratorAdditionalData &additional_data);
 
         /**
          * Create $dim$-dimensional immersed quadratures from the incoming
@@ -883,7 +894,7 @@ namespace NonMatching
         /**
          * Stores options/settings for the algorithm.
          */
-        const AdditionalQGeneratorData additional_data;
+        const QuadratureGeneratorAdditionalData additional_data;
 
         /**
          * Which quadrature rule in the above collection that is used to
@@ -958,8 +969,9 @@ namespace NonMatching
       class QGeneratorBase
       {
       public:
-        QGeneratorBase(const hp::QCollection<1> &      q_collection1D,
-                       const AdditionalQGeneratorData &additional_data);
+        QGeneratorBase(
+          const hp::QCollection<1> &               q_collection1D,
+          const QuadratureGeneratorAdditionalData &additional_data);
 
         /**
          * Clear the quadratures created by the previous call to generate().
@@ -977,7 +989,7 @@ namespace NonMatching
         /**
          * Stores options/settings for the algorithm.
          */
-        const AdditionalQGeneratorData additional_data;
+        const QuadratureGeneratorAdditionalData additional_data;
 
         /**
          * Which 1d-quadrature in the collection we should use to generate
@@ -1088,8 +1100,8 @@ namespace NonMatching
         /**
          * Constructor. Takes the same parameters QuadratureGenerator.
          */
-        QGenerator(const hp::QCollection<1> &      q_collection1D,
-                   const AdditionalQGeneratorData &additional_data);
+        QGenerator(const hp::QCollection<1> &               q_collection1D,
+                   const QuadratureGeneratorAdditionalData &additional_data);
 
         /**
          * Create immersed quadrature rules over the incoming @p box and add
@@ -1144,7 +1156,7 @@ namespace NonMatching
         /**
          * Split the incoming box and call generate() recursively with each box.
          * The box is split in 2 or 4 parts depending on the value of
-         * AdditionalQGeneratorData::split_in_half.
+         * QuadratureGeneratorAdditionalData::split_in_half.
          */
         void
         split_box_and_recurse(
@@ -1211,8 +1223,8 @@ namespace NonMatching
         /**
          * Constructor. Takes the same parameters QuadratureGenerator.
          */
-        QGenerator(const hp::QCollection<1> &      quadratures1D,
-                   const AdditionalQGeneratorData &additional_data);
+        QGenerator(const hp::QCollection<1> &               quadratures1D,
+                   const QuadratureGeneratorAdditionalData &additional_data);
 
         /**
          * Creates quadrature points over the interval defined by the incoming

--- a/source/non_matching/quadrature_generator.cc
+++ b/source/non_matching/quadrature_generator.cc
@@ -467,9 +467,9 @@ namespace NonMatching
         const double               weight,
         const unsigned int         height_function_direction,
         const std::vector<std::reference_wrapper<const Function<1>>>
-          &                             level_sets,
-        const AdditionalQGeneratorData &additional_data,
-        QPartitioning<dim> &            q_partitioning)
+          &                                      level_sets,
+        const QuadratureGeneratorAdditionalData &additional_data,
+        QPartitioning<dim> &                     q_partitioning)
       {
         // Make this int to avoid a warning signed/unsigned comparison.
         const int n_roots = roots.size();
@@ -511,7 +511,7 @@ namespace NonMatching
 
 
 
-      RootFinder::AdditionalData::AdditionalData(
+      RootFinderAdditionalData::RootFinderAdditionalData(
         const double       tolerance,
         const unsigned int max_recursion_depth,
         const unsigned int max_iterations)
@@ -707,8 +707,8 @@ namespace NonMatching
 
       template <int dim, int spacedim>
       UpThroughDimensionCreator<dim, spacedim>::UpThroughDimensionCreator(
-        const hp::QCollection<1> &      q_collection1D,
-        const AdditionalQGeneratorData &additional_data)
+        const hp::QCollection<1> &               q_collection1D,
+        const QuadratureGeneratorAdditionalData &additional_data)
         : q_collection1D(&q_collection1D)
         , additional_data(additional_data)
         , root_finder(
@@ -843,8 +843,8 @@ namespace NonMatching
 
       template <int dim, int spacedim>
       QGeneratorBase<dim, spacedim>::QGeneratorBase(
-        const hp::QCollection<1> &      q_collection1D,
-        const AdditionalQGeneratorData &additional_data)
+        const hp::QCollection<1> &               q_collection1D,
+        const QuadratureGeneratorAdditionalData &additional_data)
         : additional_data(additional_data)
         , q_collection1D(&q_collection1D)
       {
@@ -855,8 +855,8 @@ namespace NonMatching
 
       template <int dim, int spacedim>
       QGenerator<dim, spacedim>::QGenerator(
-        const hp::QCollection<1> &      q_collection1D,
-        const AdditionalQGeneratorData &additional_data)
+        const hp::QCollection<1> &               q_collection1D,
+        const QuadratureGeneratorAdditionalData &additional_data)
         : QGeneratorBase<dim, spacedim>(q_collection1D, additional_data)
         , low_dim_algorithm(q_collection1D, additional_data)
         , up_through_dimension_creator(q_collection1D, additional_data)
@@ -1184,8 +1184,8 @@ namespace NonMatching
 
       template <int spacedim>
       QGenerator<1, spacedim>::QGenerator(
-        const hp::QCollection<1> &      q_collection1D,
-        const AdditionalQGeneratorData &additional_data)
+        const hp::QCollection<1> &               q_collection1D,
+        const QuadratureGeneratorAdditionalData &additional_data)
         : QGeneratorBase<1, spacedim>(q_collection1D, additional_data)
         , root_finder(
             RootFinder::AdditionalData(additional_data.root_finder_tolerance,
@@ -1601,7 +1601,7 @@ namespace NonMatching
 
 
 
-  AdditionalQGeneratorData::AdditionalQGeneratorData(
+  QuadratureGeneratorAdditionalData::QuadratureGeneratorAdditionalData(
     const unsigned int max_box_splits,
     const double       lower_bound_implicit_function,
     const double       min_distance_between_roots,

--- a/tests/non_matching/up_through_dimension_creator.cc
+++ b/tests/non_matching/up_through_dimension_creator.cc
@@ -58,8 +58,8 @@ template <int dim>
 void
 create_and_print_partitioning(const Function<dim> &level_set)
 {
-  const hp::QCollection<1>                    q_collection1D(QGauss<1>(2));
-  const NonMatching::AdditionalQGeneratorData additional_data;
+  const hp::QCollection<1> q_collection1D(QGauss<1>(2));
+  const NonMatching::QuadratureGeneratorAdditionalData additional_data;
 
   UpThroughDimensionCreator<dim, dim> up_through_dimension_creator(
     q_collection1D, additional_data);


### PR DESCRIPTION
When one wants to fill the `AdditionalData` struct of a class (especially solvers), currently one needs to know the `VectorType` template parameter although it is not necessary for the struct and only for the surrounding solver. This patch suggests a way to move these structure outside and still retain the convenient access for generic code. Instead of `ExampleClass::AdditionalData` the struct is now called `ExampleClassAdditionalData`. Due to the using statement, I think this should be backward-compatible (not sure about the binary representation of the struct though)?

I only changed it for GMRES. If we decide to go for such a change I am happy to change it everywhere.

fyi @mschreter 