### PR TITLE
Do not allow assigning to rvalue references of VectorizedArray.

### DIFF
--- a/doc/news/changes/minor/20230305Bangerth
+++ b/doc/news/changes/minor/20230305Bangerth
@@ -1,0 +1,17 @@
+Fixed: It was previously possible to assign scalar values to
+VectorizedArray objects that were temporaries -- say in expressions
+such as
+```
+  VectorizedArray<...> my_function();
+  ...
+  my_function() = 1.234;
+```
+This does not make any sense: What `my_function()` returns is a
+temporary object, and assigning a value to it has no consequences
+because the temporary object dies at the end of the line. Whatever the
+programmer intended to do here was almost certainly a mistake.
+
+As a consequence, this is now prohibited and the compiler will produce
+an error when trying to do this.
+<br>
+(Wolfgang Bangerth, 2023/03/05)

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -451,15 +451,23 @@ public:
   {}
 
   /**
-   * This function assigns a scalar to this class.
+   * This function assigns a scalar to the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
-  operator=(const Number scalar)
+  operator=(const Number scalar) &
   {
     data = scalar;
     return *this;
   }
+
+  /**
+   * Assign a scalar to the current object. This overload is used for
+   * rvalue references; because it does not make sense to assign
+   * something to a temporary, the function is deleted.
+   */
+  VectorizedArray &
+  operator=(const Number scalar) && = delete;
 
   /**
    * Access operator (only valid with component 0 in the base class without
@@ -992,11 +1000,20 @@ public:
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
-  operator=(const double x)
+  operator=(const double x) &
   {
     data = _mm512_set1_pd(x);
     return *this;
   }
+
+
+  /**
+   * Assign a scalar to the current object. This overload is used for
+   * rvalue references; because it does not make sense to assign
+   * something to a temporary, the function is deleted.
+   */
+  VectorizedArray &
+  operator=(const double scalar) && = delete;
 
   /**
    * Access operator.
@@ -1571,11 +1588,19 @@ public:
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
-  operator=(const float x)
+  operator=(const float x) &
   {
     data = _mm512_set1_ps(x);
     return *this;
   }
+
+  /**
+   * Assign a scalar to the current object. This overload is used for
+   * rvalue references; because it does not make sense to assign
+   * something to a temporary, the function is deleted.
+   */
+  VectorizedArray &
+  operator=(const float scalar) && = delete;
 
   /**
    * Access operator.
@@ -2232,11 +2257,19 @@ public:
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
-  operator=(const double x)
+  operator=(const double x) &
   {
     data = _mm256_set1_pd(x);
     return *this;
   }
+
+  /**
+   * Assign a scalar to the current object. This overload is used for
+   * rvalue references; because it does not make sense to assign
+   * something to a temporary, the function is deleted.
+   */
+  VectorizedArray &
+  operator=(const double scalar) && = delete;
 
   /**
    * Access operator.
@@ -2770,11 +2803,19 @@ public:
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
-  operator=(const float x)
+  operator=(const float x) &
   {
     data = _mm256_set1_ps(x);
     return *this;
   }
+
+  /**
+   * Assign a scalar to the current object. This overload is used for
+   * rvalue references; because it does not make sense to assign
+   * something to a temporary, the function is deleted.
+   */
+  VectorizedArray &
+  operator=(const float scalar) && = delete;
 
   /**
    * Access operator.
@@ -3328,11 +3369,19 @@ public:
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
-  operator=(const double x)
+  operator=(const double x) &
   {
     data = _mm_set1_pd(x);
     return *this;
   }
+
+  /**
+   * Assign a scalar to the current object. This overload is used for
+   * rvalue references; because it does not make sense to assign
+   * something to a temporary, the function is deleted.
+   */
+  VectorizedArray &
+  operator=(const double scalar) && = delete;
 
   /**
    * Access operator.
@@ -3794,11 +3843,19 @@ public:
 
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
-  operator=(const float x)
+  operator=(const float x) &
   {
     data = _mm_set1_ps(x);
     return *this;
   }
+
+  /**
+   * Assign a scalar to the current object. This overload is used for
+   * rvalue references; because it does not make sense to assign
+   * something to a temporary, the function is deleted.
+   */
+  VectorizedArray &
+  operator=(const float scalar) && = delete;
 
   /**
    * Access operator.
@@ -4274,11 +4331,11 @@ public:
   {}
 
   /**
-   * This function assigns a scalar to this class.
+   * This function assigns a scalar to the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
-  operator=(const double x)
+  operator=(const double x) &
   {
     data = vec_splats(x);
 
@@ -4288,6 +4345,14 @@ public:
     (void)x;
     return *this;
   }
+
+  /**
+   * Assign a scalar to the current object. This overload is used for
+   * rvalue references; because it does not make sense to assign
+   * something to a temporary, the function is deleted.
+   */
+  VectorizedArray &
+  operator=(const double scalar) && = delete;
 
   /**
    * Access operator. The component must be either 0 or 1.
@@ -4521,11 +4586,11 @@ public:
   {}
 
   /**
-   * This function assigns a scalar to this class.
+   * This function assigns a scalar to the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
-  operator=(const float x)
+  operator=(const float x) &
   {
     data = vec_splats(x);
 
@@ -4535,6 +4600,14 @@ public:
     (void)x;
     return *this;
   }
+
+  /**
+   * Assign a scalar to the current object. This overload is used for
+   * rvalue references; because it does not make sense to assign
+   * something to a temporary, the function is deleted.
+   */
+  VectorizedArray &
+  operator=(const float scalar) && = delete;
 
   /**
    * Access operator. The component must be between 0 and 3.


### PR DESCRIPTION
This implements the suggestion I made in https://github.com/dealii/dealii/pull/14839#issuecomment-1454734440.