### PR TITLE
Print detailed.log instead of archiving it

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -49,11 +49,8 @@ jobs:
               -D DEAL_II_EARLY_DEPRECATIONS=ON \
               -DDEAL_II_COMPONENT_PYTHON_BINDINGS=ON \
               ..
-    - name: archive detailed.log
-      uses: actions/upload-artifact@v3
-      with:
-        name: linux-serial-detailed.log
-        path: build/detailed.log
+    - name: print detailed.log
+      run: cat build/detailed.log
     - name: build
       run: |
         cd build
@@ -104,11 +101,8 @@ jobs:
               -D DEAL_II_WITH_HDF5="ON" \
               -D DEAL_II_COMPONENT_EXAMPLES="OFF" \
               ..
-    - name: archive detailed.log
-      uses: actions/upload-artifact@v3
-      with:
-        name: linux-simplex-detailed.log
-        path: build/detailed.log
+    - name: print detailed.log
+      run: cat build/detailed.log
     - name: build
       run: |
         cd build
@@ -199,11 +193,8 @@ jobs:
               -D DEAL_II_WITH_P4EST="ON" \
               -D DEAL_II_COMPONENT_EXAMPLES="ON" \
               ..
-    - name: archive detailed.log
-      uses: actions/upload-artifact@v3
-      with:
-        name: linux-cuda-detailed.log
-        path: build/detailed.log
+    - name: print detailed.log
+      run: cat build/detailed.log
     - name: build deal.II
       run: |
         cd build
@@ -278,11 +269,8 @@ jobs:
               -D LAPACK_DIR=${MKLROOT} \
               -D TBB_DIR=${TBBROOT} \
               ..
-    - name: archive detailed.log
-      uses: actions/upload-artifact@v3
-      with:
-        name: linux-intel-detailed.log
-        path: build/detailed.log
+    - name: print detailed.log
+      run: cat build/detailed.log
     - name: build
       run: |
         source /opt/intel/oneapi/setvars.sh

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -25,11 +25,8 @@ jobs:
     - name: configure
       run: |
         cmake -D CMAKE_BUILD_TYPE=Debug -D DEAL_II_CXX_FLAGS='-Werror' -D DEAL_II_EARLY_DEPRECATIONS=ON .
-    - name: archive
-      uses: actions/upload-artifact@v3
-      with:
-        name: serial-detailed.log
-        path: detailed.log
+    - name: print detailed.log
+      run: cat detailed.log
     - name: build
       run: |
         make -j 2
@@ -71,11 +68,8 @@ jobs:
     - name: configure
       run: |
         CC=mpicc CXX=mpic++ cmake -D CMAKE_BUILD_TYPE=Debug -D DEAL_II_WITH_64BIT_INDICES=ON -D DEAL_II_CXX_FLAGS='-Werror' -D DEAL_II_EARLY_DEPRECATIONS=ON -D DEAL_II_WITH_MPI=on .
-    - name: archive
-      uses: actions/upload-artifact@v3
-      with:
-        name: parallel-detailed.log
-        path: detailed.log
+    - name: print detailed.log
+      run: cat detailed.log
     - name: build
       run: |
         make -j 2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -33,11 +33,8 @@ jobs:
         mkdir c:/project
         cd build
         cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=c:/project -DDEAL_II_WITH_ZLIB=off -DDEAL_II_CXX_FLAGS="-WX /D FE_EVAL_FACTORY_DEGREE_MAX=2" -T host=x64 -A x64 ..
-    - name: archive logs
-      uses: actions/upload-artifact@v3
-      with:
-        name: windows-serial-detailed.log
-        path: build/detailed.log
+    - name: print detailed.log
+      run: type build/detailed.log
     - name: build library
       shell: bash
       run: |


### PR DESCRIPTION
I have trouble finding the artifacts, and it's much easier to print `detailed.log` instead.