### PR TITLE
Simplify a ?: expression in step-22.

### DIFF
--- a/examples/step-22/step-22.cc
+++ b/examples/step-22/step-22.cc
@@ -202,7 +202,15 @@ namespace Step22
            ExcIndexRange(component, 0, this->n_components));
 
     if (component == 0)
-      return (p[0] < 0 ? -1 : (p[0] > 0 ? 1 : 0));
+      {
+        if (p[0] < 0)
+          return -1;
+        else if (p[0] > 0)
+          return 1;
+        else
+          return 0;
+      }
+
     return 0;
   }
 


### PR DESCRIPTION
There is no real advantage here to using terse syntax. It's just harder to read and since it's a frequently used tutorial program, it's worth keeping it simple.