### PR TITLE
Fix a mistaken 'requires' annotation.

### DIFF
--- a/include/deal.II/distributed/p4est_wrappers.h
+++ b/include/deal.II/distributed/p4est_wrappers.h
@@ -47,7 +47,6 @@ namespace parallel
   namespace distributed
   {
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     class Triangulation;
   }
 } // namespace parallel


### PR DESCRIPTION
I made a mistake in #14836 in that I accidentally annotated a forward declaration for `parallel::distributed::Triangulation` even though I only wanted the ones for `::Triangulation`. This fixes the oversight.

Part of #14840.