### PR TITLE
[C++20] Annotate the VectorTools functions with vector concepts.

### DIFF
--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -184,6 +184,7 @@ PREDEFINED             = DOXYGEN=1 \
                          DEAL_II_HOST_DEVICE= \
                          DEAL_II_ALWAYS_INLINE= \
                          __device__= \
+			 DEAL_II_CXX20_REQUIRES=requires \
                          DEAL_II_WITH_ADOLC=1 \
                          DEAL_II_ADOLC_WITH_ADVANCED_BRANCHING=1 \
                          DEAL_II_ADOLC_WITH_ATRIG_ERF=1 \

--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -184,7 +184,7 @@ PREDEFINED             = DOXYGEN=1 \
                          DEAL_II_HOST_DEVICE= \
                          DEAL_II_ALWAYS_INLINE= \
                          __device__= \
-			 DEAL_II_CXX20_REQUIRES=requires \
+			 DEAL_II_CXX20_REQUIRES(x)= \
                          DEAL_II_WITH_ADOLC=1 \
                          DEAL_II_ADOLC_WITH_ADVANCED_BRANCHING=1 \
                          DEAL_II_ADOLC_WITH_ATRIG_ERF=1 \

--- a/include/deal.II/base/template_constraints.h
+++ b/include/deal.II/base/template_constraints.h
@@ -754,7 +754,7 @@ namespace LinearAlgebra
  */
 namespace concepts
 {
-#ifdef DEAL_II_HAVE_CXX20
+#if defined(DEAL_II_HAVE_CXX20) || defined(DOXYGEN)
   /**
    * A concept that tests that a combination of `dim` and `spacedim`
    * template arguments is valid. Specifically, we must have that

--- a/include/deal.II/numerics/vector_tools_evaluate.h
+++ b/include/deal.II/numerics/vector_tools_evaluate.h
@@ -137,19 +137,23 @@ namespace VectorTools
             int dim,
             int spacedim,
             typename VectorType>
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
   std::vector<
     typename FEPointEvaluation<n_components,
                                dim,
                                spacedim,
-                               typename VectorType::value_type>::value_type>
-  point_values(
-    const Mapping<dim> &                                  mapping,
-    const MeshType<dim, spacedim> &                       mesh,
-    const VectorType &                                    vector,
-    const std::vector<Point<spacedim>> &                  evaluation_points,
-    Utilities::MPI::RemotePointEvaluation<dim, spacedim> &cache,
-    const EvaluationFlags::EvaluationFlags flags = EvaluationFlags::avg,
-    const unsigned int                     first_selected_component = 0);
+                               typename VectorType::value_type>::
+      value_type> point_values(const Mapping<dim> &           mapping,
+                               const MeshType<dim, spacedim> &mesh,
+                               const VectorType &             vector,
+                               const std::vector<Point<spacedim>>
+                                 &evaluation_points,
+                               Utilities::MPI::RemotePointEvaluation<dim,
+                                                                     spacedim>
+                                 &                                    cache,
+                               const EvaluationFlags::EvaluationFlags flags =
+                                 EvaluationFlags::avg,
+                               const unsigned int first_selected_component = 0);
 
   /**
    * Given a (distributed) solution vector @p vector, evaluate the values at
@@ -169,17 +173,19 @@ namespace VectorTools
             int dim,
             int spacedim,
             typename VectorType>
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
   std::vector<
     typename FEPointEvaluation<n_components,
                                dim,
                                spacedim,
-                               typename VectorType::value_type>::value_type>
-  point_values(
-    const Utilities::MPI::RemotePointEvaluation<dim, spacedim> &cache,
-    const MeshType<dim, spacedim> &                             mesh,
-    const VectorType &                                          vector,
-    const EvaluationFlags::EvaluationFlags flags = EvaluationFlags::avg,
-    const unsigned int                     first_selected_component = 0);
+                               typename VectorType::value_type>::
+      value_type> point_values(const Utilities::MPI::
+                                 RemotePointEvaluation<dim, spacedim> &cache,
+                               const MeshType<dim, spacedim> &         mesh,
+                               const VectorType &                      vector,
+                               const EvaluationFlags::EvaluationFlags  flags =
+                                 EvaluationFlags::avg,
+                               const unsigned int first_selected_component = 0);
 
   /**
    * Given a (distributed) solution vector @p vector, evaluate the gradients at
@@ -197,19 +203,24 @@ namespace VectorTools
             int dim,
             int spacedim,
             typename VectorType>
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
   std::vector<
     typename FEPointEvaluation<n_components,
                                dim,
                                spacedim,
-                               typename VectorType::value_type>::gradient_type>
-  point_gradients(
-    const Mapping<dim> &                                  mapping,
-    const MeshType<dim, spacedim> &                       mesh,
-    const VectorType &                                    vector,
-    const std::vector<Point<spacedim>> &                  evaluation_points,
-    Utilities::MPI::RemotePointEvaluation<dim, spacedim> &cache,
-    const EvaluationFlags::EvaluationFlags flags = EvaluationFlags::avg,
-    const unsigned int                     first_selected_component = 0);
+                               typename VectorType::value_type>::
+      gradient_type> point_gradients(const Mapping<dim> &           mapping,
+                                     const MeshType<dim, spacedim> &mesh,
+                                     const VectorType &             vector,
+                                     const std::vector<Point<spacedim>>
+                                       &evaluation_points,
+                                     Utilities::MPI::RemotePointEvaluation<
+                                       dim,
+                                       spacedim> &cache,
+                                     const EvaluationFlags::EvaluationFlags
+                                       flags = EvaluationFlags::avg,
+                                     const unsigned int
+                                       first_selected_component = 0);
 
   /**
    * Given a (distributed) solution vector @p vector, evaluate the gradients at
@@ -228,17 +239,21 @@ namespace VectorTools
             int dim,
             int spacedim,
             typename VectorType>
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
   std::vector<
     typename FEPointEvaluation<n_components,
                                dim,
                                spacedim,
-                               typename VectorType::value_type>::gradient_type>
-  point_gradients(
-    const Utilities::MPI::RemotePointEvaluation<dim, spacedim> &cache,
-    const MeshType<dim, spacedim> &                             mesh,
-    const VectorType &                                          vector,
-    const EvaluationFlags::EvaluationFlags flags = EvaluationFlags::avg,
-    const unsigned int                     first_selected_component = 0);
+                               typename VectorType::value_type>::
+      gradient_type> point_gradients(const Utilities::MPI::
+                                       RemotePointEvaluation<dim, spacedim>
+                                         &                          cache,
+                                     const MeshType<dim, spacedim> &mesh,
+                                     const VectorType &             vector,
+                                     const EvaluationFlags::EvaluationFlags
+                                       flags = EvaluationFlags::avg,
+                                     const unsigned int
+                                       first_selected_component = 0);
 
 
 
@@ -252,18 +267,22 @@ namespace VectorTools
             int dim,
             int spacedim,
             typename VectorType>
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
   inline std::vector<
     typename FEPointEvaluation<n_components,
                                dim,
                                spacedim,
-                               typename VectorType::value_type>::value_type>
-  point_values(const Mapping<dim> &                mapping,
-               const MeshType<dim, spacedim> &     mesh,
-               const VectorType &                  vector,
-               const std::vector<Point<spacedim>> &evaluation_points,
-               Utilities::MPI::RemotePointEvaluation<dim, spacedim> &cache,
-               const EvaluationFlags::EvaluationFlags                flags,
-               const unsigned int first_selected_component)
+                               typename VectorType::value_type>::
+      value_type> point_values(const Mapping<dim> &           mapping,
+                               const MeshType<dim, spacedim> &mesh,
+                               const VectorType &             vector,
+                               const std::vector<Point<spacedim>>
+                                 &evaluation_points,
+                               Utilities::MPI::RemotePointEvaluation<dim,
+                                                                     spacedim>
+                                 &                                    cache,
+                               const EvaluationFlags::EvaluationFlags flags,
+                               const unsigned int first_selected_component)
   {
     cache.reinit(evaluation_points, mesh.get_triangulation(), mapping);
 
@@ -279,18 +298,24 @@ namespace VectorTools
             int dim,
             int spacedim,
             typename VectorType>
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
   inline std::vector<
     typename FEPointEvaluation<n_components,
                                dim,
                                spacedim,
-                               typename VectorType::value_type>::gradient_type>
-  point_gradients(const Mapping<dim> &                mapping,
-                  const MeshType<dim, spacedim> &     mesh,
-                  const VectorType &                  vector,
-                  const std::vector<Point<spacedim>> &evaluation_points,
-                  Utilities::MPI::RemotePointEvaluation<dim, spacedim> &cache,
-                  const EvaluationFlags::EvaluationFlags                flags,
-                  const unsigned int first_selected_component)
+                               typename VectorType::value_type>::
+      gradient_type> point_gradients(const Mapping<dim> &           mapping,
+                                     const MeshType<dim, spacedim> &mesh,
+                                     const VectorType &             vector,
+                                     const std::vector<Point<spacedim>>
+                                       &evaluation_points,
+                                     Utilities::MPI::RemotePointEvaluation<
+                                       dim,
+                                       spacedim> &cache,
+                                     const EvaluationFlags::EvaluationFlags
+                                       flags,
+                                     const unsigned int
+                                       first_selected_component)
   {
     cache.reinit(evaluation_points, mesh.get_triangulation(), mapping);
 
@@ -595,8 +620,8 @@ namespace VectorTools
               typename MeshType,
               typename VectorType,
               typename value_type>
-    inline std::vector<value_type>
-    evaluate_at_points(
+    DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+    inline std::vector<value_type> evaluate_at_points(
       const Utilities::MPI::RemotePointEvaluation<dim, spacedim> &cache,
       const MeshType &                                            mesh,
       const VectorType &                                          vector,
@@ -701,17 +726,18 @@ namespace VectorTools
             int dim,
             int spacedim,
             typename VectorType>
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
   inline std::vector<
     typename FEPointEvaluation<n_components,
                                dim,
                                spacedim,
-                               typename VectorType::value_type>::value_type>
-  point_values(
-    const Utilities::MPI::RemotePointEvaluation<dim, spacedim> &cache,
-    const MeshType<dim, spacedim> &                             mesh,
-    const VectorType &                                          vector,
-    const EvaluationFlags::EvaluationFlags                      flags,
-    const unsigned int first_selected_component)
+                               typename VectorType::value_type>::
+      value_type> point_values(const Utilities::MPI::
+                                 RemotePointEvaluation<dim, spacedim> &cache,
+                               const MeshType<dim, spacedim> &         mesh,
+                               const VectorType &                      vector,
+                               const EvaluationFlags::EvaluationFlags  flags,
+                               const unsigned int first_selected_component)
   {
     return internal::evaluate_at_points<
       n_components,
@@ -735,23 +761,29 @@ namespace VectorTools
       });
   }
 
+
+
   template <int n_components,
             template <int, int>
             class MeshType,
             int dim,
             int spacedim,
             typename VectorType>
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
   inline std::vector<
     typename FEPointEvaluation<n_components,
                                dim,
                                spacedim,
-                               typename VectorType::value_type>::gradient_type>
-  point_gradients(
-    const Utilities::MPI::RemotePointEvaluation<dim, spacedim> &cache,
-    const MeshType<dim, spacedim> &                             mesh,
-    const VectorType &                                          vector,
-    const EvaluationFlags::EvaluationFlags                      flags,
-    const unsigned int first_selected_component)
+                               typename VectorType::value_type>::
+      gradient_type> point_gradients(const Utilities::MPI::
+                                       RemotePointEvaluation<dim, spacedim>
+                                         &                          cache,
+                                     const MeshType<dim, spacedim> &mesh,
+                                     const VectorType &             vector,
+                                     const EvaluationFlags::EvaluationFlags
+                                       flags,
+                                     const unsigned int
+                                       first_selected_component)
   {
     return internal::evaluate_at_points<
       n_components,

--- a/include/deal.II/numerics/vector_tools_integrate_difference.h
+++ b/include/deal.II/numerics/vector_tools_integrate_difference.h
@@ -26,15 +26,18 @@ DEAL_II_NAMESPACE_OPEN
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
+
 template <int dim, typename Number>
 class Function;
 template <int dim, int spacedim>
 class Mapping;
 template <int dim>
 class Quadrature;
+
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class Triangulation;
+
 namespace hp
 {
   template <int dim, int spacedim>
@@ -139,8 +142,9 @@ namespace VectorTools
    * Vector<float>.
    */
   template <int dim, class InVector, class OutVector, int spacedim>
-  void
-  integrate_difference(
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<InVector> &&
+                           concepts::is_writable_dealii_vector_type<OutVector>)
+  void integrate_difference(
     const Mapping<dim, spacedim> &                           mapping,
     const DoFHandler<dim, spacedim> &                        dof,
     const InVector &                                         fe_function,
@@ -156,8 +160,9 @@ namespace VectorTools
    * <tt>mapping=MappingQ@<dim@>(1)</tt>.
    */
   template <int dim, class InVector, class OutVector, int spacedim>
-  void
-  integrate_difference(
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<InVector> &&
+                           concepts::is_writable_dealii_vector_type<OutVector>)
+  void integrate_difference(
     const DoFHandler<dim, spacedim> &                        dof,
     const InVector &                                         fe_function,
     const Function<spacedim, typename InVector::value_type> &exact_solution,
@@ -171,8 +176,9 @@ namespace VectorTools
    * Same as above for hp.
    */
   template <int dim, class InVector, class OutVector, int spacedim>
-  void
-  integrate_difference(
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<InVector> &&
+                           concepts::is_writable_dealii_vector_type<OutVector>)
+  void integrate_difference(
     const hp::MappingCollection<dim, spacedim> &             mapping,
     const DoFHandler<dim, spacedim> &                        dof,
     const InVector &                                         fe_function,
@@ -188,8 +194,9 @@ namespace VectorTools
    * <tt>mapping=MappingQ@<dim@>(1)</tt>.
    */
   template <int dim, class InVector, class OutVector, int spacedim>
-  void
-  integrate_difference(
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<InVector> &&
+                           concepts::is_writable_dealii_vector_type<OutVector>)
+  void integrate_difference(
     const DoFHandler<dim, spacedim> &                        dof,
     const InVector &                                         fe_function,
     const Function<spacedim, typename InVector::value_type> &exact_solution,
@@ -225,11 +232,11 @@ namespace VectorTools
    * @note Instantiated for type Vector<double> and Vector<float>.
    */
   template <int dim, int spacedim, class InVector>
-  double
-  compute_global_error(const Triangulation<dim, spacedim> &tria,
-                       const InVector &                    cellwise_error,
-                       const NormType &                    norm,
-                       const double                        exponent = 2.);
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<InVector>)
+  double compute_global_error(const Triangulation<dim, spacedim> &tria,
+                              const InVector &cellwise_error,
+                              const NormType &norm,
+                              const double    exponent = 2.);
 
   /** @} */
 } // namespace VectorTools

--- a/include/deal.II/numerics/vector_tools_integrate_difference.templates.h
+++ b/include/deal.II/numerics/vector_tools_integrate_difference.templates.h
@@ -432,8 +432,10 @@ namespace VectorTools
 
 
     template <int dim, int spacedim, class InVector, class OutVector>
-    static void
-    do_integrate_difference(
+    DEAL_II_CXX20_REQUIRES(
+      concepts::is_dealii_vector_type<InVector>
+        &&concepts::is_writable_dealii_vector_type<OutVector>)
+    static void do_integrate_difference(
       const dealii::hp::MappingCollection<dim, spacedim> &     mapping,
       const DoFHandler<dim, spacedim> &                        dof,
       const InVector &                                         fe_function,
@@ -549,9 +551,12 @@ namespace VectorTools
 
   } // namespace internal
 
+
+
   template <int dim, class InVector, class OutVector, int spacedim>
-  void
-  integrate_difference(
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<InVector> &&
+                           concepts::is_writable_dealii_vector_type<OutVector>)
+  void integrate_difference(
     const Mapping<dim, spacedim> &                           mapping,
     const DoFHandler<dim, spacedim> &                        dof,
     const InVector &                                         fe_function,
@@ -576,8 +581,9 @@ namespace VectorTools
 
 
   template <int dim, class InVector, class OutVector, int spacedim>
-  void
-  integrate_difference(
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<InVector> &&
+                           concepts::is_writable_dealii_vector_type<OutVector>)
+  void integrate_difference(
     const DoFHandler<dim, spacedim> &                        dof,
     const InVector &                                         fe_function,
     const Function<spacedim, typename InVector::value_type> &exact_solution,
@@ -601,8 +607,9 @@ namespace VectorTools
 
 
   template <int dim, class InVector, class OutVector, int spacedim>
-  void
-  integrate_difference(
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<InVector> &&
+                           concepts::is_writable_dealii_vector_type<OutVector>)
+  void integrate_difference(
     const dealii::hp::MappingCollection<dim, spacedim> &     mapping,
     const dealii::DoFHandler<dim, spacedim> &                dof,
     const InVector &                                         fe_function,
@@ -625,8 +632,9 @@ namespace VectorTools
   }
 
   template <int dim, class InVector, class OutVector, int spacedim>
-  void
-  integrate_difference(
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<InVector> &&
+                           concepts::is_writable_dealii_vector_type<OutVector>)
+  void integrate_difference(
     const dealii::DoFHandler<dim, spacedim> &                dof,
     const InVector &                                         fe_function,
     const Function<spacedim, typename InVector::value_type> &exact_solution,
@@ -649,11 +657,11 @@ namespace VectorTools
   }
 
   template <int dim, int spacedim, class InVector>
-  double
-  compute_global_error(const Triangulation<dim, spacedim> &tria,
-                       const InVector &                    cellwise_error,
-                       const NormType &                    norm,
-                       const double                        exponent)
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<InVector>)
+  double compute_global_error(const Triangulation<dim, spacedim> &tria,
+                              const InVector &cellwise_error,
+                              const NormType &norm,
+                              const double    exponent)
   {
     Assert(cellwise_error.size() == tria.n_active_cells(),
            ExcMessage("input vector cell_error has invalid size!"));

--- a/include/deal.II/numerics/vector_tools_interpolate.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.h
@@ -26,9 +26,11 @@ DEAL_II_NAMESPACE_OPEN
 
 template <typename number>
 class AffineConstraints;
+
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
+
 template <typename number>
 class FullMatrix;
 template <int dim, typename Number>
@@ -65,8 +67,8 @@ namespace VectorTools
    * See the general documentation of this namespace for further information.
    */
   template <int dim, int spacedim, typename VectorType>
-  void
-  interpolate(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void interpolate(
     const Mapping<dim, spacedim> &                             mapping,
     const DoFHandler<dim, spacedim> &                          dof,
     const Function<spacedim, typename VectorType::value_type> &function,
@@ -77,8 +79,8 @@ namespace VectorTools
    * Same as above but in an hp-context.
    */
   template <int dim, int spacedim, typename VectorType>
-  void
-  interpolate(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void interpolate(
     const hp::MappingCollection<dim, spacedim> &               mapping,
     const DoFHandler<dim, spacedim> &                          dof,
     const Function<spacedim, typename VectorType::value_type> &function,
@@ -91,8 +93,8 @@ namespace VectorTools
    * <tt>mapping=MappingQ@<dim,spacedim@>(1)</tt>.
    */
   template <int dim, int spacedim, typename VectorType>
-  void
-  interpolate(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void interpolate(
     const DoFHandler<dim, spacedim> &                          dof,
     const Function<spacedim, typename VectorType::value_type> &function,
     VectorType &                                               vec,
@@ -117,12 +119,13 @@ namespace VectorTools
    * instantiated by hand.
    */
   template <int dim, class InVector, class OutVector, int spacedim>
-  void
-  interpolate(const DoFHandler<dim, spacedim> &dof_1,
-              const DoFHandler<dim, spacedim> &dof_2,
-              const FullMatrix<double> &       transfer,
-              const InVector &                 data_1,
-              OutVector &                      data_2);
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<InVector> &&
+                           concepts::is_writable_dealii_vector_type<OutVector>)
+  void interpolate(const DoFHandler<dim, spacedim> &dof_1,
+                   const DoFHandler<dim, spacedim> &dof_2,
+                   const FullMatrix<double> &       transfer,
+                   const InVector &                 data_1,
+                   OutVector &                      data_2);
 
   /**
    * This function is a kind of generalization or modification of the very
@@ -171,8 +174,8 @@ namespace VectorTools
    * dofs of the previous one.
    */
   template <int dim, int spacedim, typename VectorType>
-  void
-  interpolate_based_on_material_id(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void interpolate_based_on_material_id(
     const Mapping<dim, spacedim> &   mapping,
     const DoFHandler<dim, spacedim> &dof_handler,
     const std::map<types::material_id,
@@ -206,11 +209,11 @@ namespace VectorTools
    * flag).
    */
   template <int dim, int spacedim, typename VectorType>
-  void
-  interpolate_to_different_mesh(const DoFHandler<dim, spacedim> &dof1,
-                                const VectorType &               u1,
-                                const DoFHandler<dim, spacedim> &dof2,
-                                VectorType &                     u2);
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void interpolate_to_different_mesh(const DoFHandler<dim, spacedim> &dof1,
+                                     const VectorType &               u1,
+                                     const DoFHandler<dim, spacedim> &dof2,
+                                     VectorType &                     u2);
 
   /**
    * Compute the interpolation of a @p dof1-function @p u1 to a @p dof2-function
@@ -226,8 +229,8 @@ namespace VectorTools
    * does not necessarily respect continuity requirements at hanging nodes.
    */
   template <int dim, int spacedim, typename VectorType>
-  void
-  interpolate_to_different_mesh(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void interpolate_to_different_mesh(
     const DoFHandler<dim, spacedim> &                         dof1,
     const VectorType &                                        u1,
     const DoFHandler<dim, spacedim> &                         dof2,
@@ -242,8 +245,8 @@ namespace VectorTools
    * pointing from a source DoFHandler to a destination DoFHandler.
    */
   template <int dim, int spacedim, typename VectorType>
-  void
-  interpolate_to_different_mesh(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void interpolate_to_different_mesh(
     const InterGridMap<DoFHandler<dim, spacedim>> &           intergridmap,
     const VectorType &                                        u1,
     const AffineConstraints<typename VectorType::value_type> &constraints,
@@ -281,10 +284,10 @@ namespace VectorTools
    * components are primitive.
    */
   template <int dim, int spacedim, typename VectorType>
-  void
-  get_position_vector(const DoFHandler<dim, spacedim> &dh,
-                      VectorType &                     vector,
-                      const ComponentMask &            mask = ComponentMask());
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void get_position_vector(const DoFHandler<dim, spacedim> &dh,
+                           VectorType &                     vector,
+                           const ComponentMask &mask = ComponentMask());
 
   /**
    * Like the above function but also taking @p mapping as argument.
@@ -295,11 +298,11 @@ namespace VectorTools
    * preserve vertex locations (like Eulerian mappings).
    */
   template <int dim, int spacedim, typename VectorType>
-  void
-  get_position_vector(const Mapping<dim, spacedim> &   mapping,
-                      const DoFHandler<dim, spacedim> &dh,
-                      VectorType &                     vector,
-                      const ComponentMask &            mask = ComponentMask());
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void get_position_vector(const Mapping<dim, spacedim> &   mapping,
+                           const DoFHandler<dim, spacedim> &dh,
+                           VectorType &                     vector,
+                           const ComponentMask &mask = ComponentMask());
 
   /** @} */
 } // namespace VectorTools

--- a/include/deal.II/numerics/vector_tools_interpolate.templates.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.templates.h
@@ -215,12 +215,13 @@ namespace VectorTools
     //
     // A given cell is skipped if function(cell) == nullptr
     template <int dim, int spacedim, typename VectorType, typename T>
-    void
-    interpolate(const hp::MappingCollection<dim, spacedim> &mapping_collection,
-                const DoFHandler<dim, spacedim> &           dof_handler,
-                T &                                         function,
-                VectorType &                                vec,
-                const ComponentMask &                       component_mask)
+    DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+    void interpolate(
+      const hp::MappingCollection<dim, spacedim> &mapping_collection,
+      const DoFHandler<dim, spacedim> &           dof_handler,
+      T &                                         function,
+      VectorType &                                vec,
+      const ComponentMask &                       component_mask)
     {
       Assert(component_mask.represents_n_components(
                dof_handler.get_fe_collection().n_components()),
@@ -474,8 +475,8 @@ namespace VectorTools
 
 
   template <int dim, int spacedim, typename VectorType>
-  void
-  interpolate(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void interpolate(
     const hp::MappingCollection<dim, spacedim> &               mapping,
     const DoFHandler<dim, spacedim> &                          dof_handler,
     const Function<spacedim, typename VectorType::value_type> &function,
@@ -501,8 +502,8 @@ namespace VectorTools
 
 
   template <int dim, int spacedim, typename VectorType>
-  void
-  interpolate(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void interpolate(
     const Mapping<dim, spacedim> &                             mapping,
     const DoFHandler<dim, spacedim> &                          dof_handler,
     const Function<spacedim, typename VectorType::value_type> &function,
@@ -519,8 +520,8 @@ namespace VectorTools
 
 
   template <int dim, int spacedim, typename VectorType>
-  void
-  interpolate(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void interpolate(
     const DoFHandler<dim, spacedim> &                          dof,
     const Function<spacedim, typename VectorType::value_type> &function,
     VectorType &                                               vec,
@@ -538,12 +539,13 @@ namespace VectorTools
 
 
   template <int dim, class InVector, class OutVector, int spacedim>
-  void
-  interpolate(const DoFHandler<dim, spacedim> &dof_1,
-              const DoFHandler<dim, spacedim> &dof_2,
-              const FullMatrix<double> &       transfer,
-              const InVector &                 data_1,
-              OutVector &                      data_2)
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<InVector> &&
+                           concepts::is_writable_dealii_vector_type<OutVector>)
+  void interpolate(const DoFHandler<dim, spacedim> &dof_1,
+                   const DoFHandler<dim, spacedim> &dof_2,
+                   const FullMatrix<double> &       transfer,
+                   const InVector &                 data_1,
+                   OutVector &                      data_2)
   {
     using number = typename OutVector::value_type;
     Vector<number> cell_data_1(dof_1.get_fe().n_dofs_per_cell());
@@ -617,10 +619,10 @@ namespace VectorTools
 
 
   template <int dim, int spacedim, typename VectorType>
-  void
-  get_position_vector(const DoFHandler<dim, spacedim> &dh,
-                      VectorType &                     vector,
-                      const ComponentMask &            mask)
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void get_position_vector(const DoFHandler<dim, spacedim> &dh,
+                           VectorType &                     vector,
+                           const ComponentMask &            mask)
   {
     const FiniteElement<dim, spacedim> &fe = dh.get_fe();
     get_position_vector(
@@ -634,11 +636,11 @@ namespace VectorTools
 
 
   template <int dim, int spacedim, typename VectorType>
-  void
-  get_position_vector(const Mapping<dim, spacedim> &   map_q,
-                      const DoFHandler<dim, spacedim> &dh,
-                      VectorType &                     vector,
-                      const ComponentMask &            mask)
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void get_position_vector(const Mapping<dim, spacedim> &   map_q,
+                           const DoFHandler<dim, spacedim> &dh,
+                           VectorType &                     vector,
+                           const ComponentMask &            mask)
   {
     AssertDimension(vector.size(), dh.n_dofs());
     const FiniteElement<dim, spacedim> &fe = dh.get_fe();
@@ -808,8 +810,8 @@ namespace VectorTools
   }
 
   template <int dim, int spacedim, typename VectorType>
-  void
-  interpolate_based_on_material_id(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void interpolate_based_on_material_id(
     const Mapping<dim, spacedim> &   mapping,
     const DoFHandler<dim, spacedim> &dof_handler,
     const std::map<types::material_id,
@@ -858,12 +860,14 @@ namespace VectorTools
     }
   } // namespace internal
 
+
+
   template <int dim, int spacedim, typename VectorType>
-  void
-  interpolate_to_different_mesh(const DoFHandler<dim, spacedim> &dof1,
-                                const VectorType &               u1,
-                                const DoFHandler<dim, spacedim> &dof2,
-                                VectorType &                     u2)
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void interpolate_to_different_mesh(const DoFHandler<dim, spacedim> &dof1,
+                                     const VectorType &               u1,
+                                     const DoFHandler<dim, spacedim> &dof2,
+                                     VectorType &                     u2)
   {
     Assert(GridTools::have_same_coarse_mesh(dof1, dof2),
            ExcMessage("The two DoF handlers must represent triangulations that "
@@ -881,8 +885,8 @@ namespace VectorTools
 
 
   template <int dim, int spacedim, typename VectorType>
-  void
-  interpolate_to_different_mesh(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void interpolate_to_different_mesh(
     const DoFHandler<dim, spacedim> &                         dof1,
     const VectorType &                                        u1,
     const DoFHandler<dim, spacedim> &                         dof2,
@@ -899,9 +903,11 @@ namespace VectorTools
     interpolate_to_different_mesh(intergridmap, u1, constraints, u2);
   }
 
+
+
   template <int dim, int spacedim, typename VectorType>
-  void
-  interpolate_to_different_mesh(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void interpolate_to_different_mesh(
     const InterGridMap<DoFHandler<dim, spacedim>> &           intergridmap,
     const VectorType &                                        u1,
     const AffineConstraints<typename VectorType::value_type> &constraints,

--- a/include/deal.II/numerics/vector_tools_mean_value.h
+++ b/include/deal.II/numerics/vector_tools_mean_value.h
@@ -98,8 +98,9 @@ namespace VectorTools
    * provided the boolean mask is empty, i.e. selecting the whole vector.
    */
   template <typename VectorType>
-  void
-  subtract_mean_value(VectorType &v, const std::vector<bool> &p_select = {});
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void subtract_mean_value(VectorType &             v,
+                           const std::vector<bool> &p_select = {});
 
   /**
    * Add the constant @p constant_adjustment to the specified
@@ -128,11 +129,11 @@ namespace VectorTools
    * adjust a single component of a distributed vector.
    */
   template <class VectorType, int dim, int spacedim = dim>
-  void
-  add_constant(VectorType &                          solution,
-               const DoFHandler<dim, spacedim> &     dof_handler,
-               const unsigned int                    component,
-               const typename VectorType::value_type constant_adjustment);
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void add_constant(VectorType &                          solution,
+                    const DoFHandler<dim, spacedim> &     dof_handler,
+                    const unsigned int                    component,
+                    const typename VectorType::value_type constant_adjustment);
 
   /**
    * Compute the mean value of one component of the solution.
@@ -158,8 +159,8 @@ namespace VectorTools
    * mean value and subtract it right inside the evaluation routine.
    */
   template <int dim, typename VectorType, int spacedim>
-  typename VectorType::value_type
-  compute_mean_value(
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  typename VectorType::value_type compute_mean_value(
     const hp::MappingCollection<dim, spacedim> &mapping_collection,
     const DoFHandler<dim, spacedim> &           dof,
     const hp::QCollection<dim> &                q_collection,
@@ -172,23 +173,25 @@ namespace VectorTools
    * and a single Mapping object.
    */
   template <int dim, typename VectorType, int spacedim>
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
   typename VectorType::value_type
-  compute_mean_value(const Mapping<dim, spacedim> &   mapping,
-                     const DoFHandler<dim, spacedim> &dof,
-                     const Quadrature<dim> &          quadrature,
-                     const VectorType &               v,
-                     const unsigned int               component);
+    compute_mean_value(const Mapping<dim, spacedim> &   mapping,
+                       const DoFHandler<dim, spacedim> &dof,
+                       const Quadrature<dim> &          quadrature,
+                       const VectorType &               v,
+                       const unsigned int               component);
 
   /**
    * Call the other compute_mean_value() function, see above, with
    * <tt>mapping=MappingQ@<dim@>(1)</tt>.
    */
   template <int dim, typename VectorType, int spacedim>
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
   typename VectorType::value_type
-  compute_mean_value(const DoFHandler<dim, spacedim> &dof,
-                     const Quadrature<dim> &          quadrature,
-                     const VectorType &               v,
-                     const unsigned int               component);
+    compute_mean_value(const DoFHandler<dim, spacedim> &dof,
+                       const Quadrature<dim> &          quadrature,
+                       const VectorType &               v,
+                       const unsigned int               component);
   /** @} */
 } // namespace VectorTools
 

--- a/include/deal.II/numerics/vector_tools_mean_value.templates.h
+++ b/include/deal.II/numerics/vector_tools_mean_value.templates.h
@@ -101,8 +101,8 @@ namespace VectorTools
 
 
   template <typename VectorType>
-  void
-  subtract_mean_value(VectorType &v, const std::vector<bool> &p_select)
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void subtract_mean_value(VectorType &v, const std::vector<bool> &p_select)
   {
     internal::subtract_mean_value(v, p_select);
   }
@@ -131,11 +131,11 @@ namespace VectorTools
 
 
   template <class VectorType, int dim, int spacedim>
-  void
-  add_constant(VectorType &                          solution,
-               const DoFHandler<dim, spacedim> &     dof_handler,
-               const unsigned int                    component,
-               const typename VectorType::value_type constant_adjustment)
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void add_constant(VectorType &                          solution,
+                    const DoFHandler<dim, spacedim> &     dof_handler,
+                    const unsigned int                    component,
+                    const typename VectorType::value_type constant_adjustment)
   {
     Assert(dof_handler.has_hp_capabilities() == false, ExcNotImplemented());
 
@@ -289,8 +289,8 @@ namespace VectorTools
 
 
   template <int dim, typename VectorType, int spacedim>
-  typename VectorType::value_type
-  compute_mean_value(
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  typename VectorType::value_type compute_mean_value(
     const hp::MappingCollection<dim, spacedim> &mapping_collection,
     const DoFHandler<dim, spacedim> &           dof,
     const hp::QCollection<dim> &                q_collection,
@@ -370,12 +370,13 @@ namespace VectorTools
 
 
   template <int dim, typename VectorType, int spacedim>
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
   typename VectorType::value_type
-  compute_mean_value(const Mapping<dim, spacedim> &   mapping,
-                     const DoFHandler<dim, spacedim> &dof,
-                     const Quadrature<dim> &          quadrature,
-                     const VectorType &               v,
-                     const unsigned int               component)
+    compute_mean_value(const Mapping<dim, spacedim> &   mapping,
+                       const DoFHandler<dim, spacedim> &dof,
+                       const Quadrature<dim> &          quadrature,
+                       const VectorType &               v,
+                       const unsigned int               component)
   {
     return compute_mean_value(hp::MappingCollection<dim, spacedim>(mapping),
                               dof,
@@ -386,11 +387,12 @@ namespace VectorTools
 
 
   template <int dim, typename VectorType, int spacedim>
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
   typename VectorType::value_type
-  compute_mean_value(const DoFHandler<dim, spacedim> &dof,
-                     const Quadrature<dim> &          quadrature,
-                     const VectorType &               v,
-                     const unsigned int               component)
+    compute_mean_value(const DoFHandler<dim, spacedim> &dof,
+                       const Quadrature<dim> &          quadrature,
+                       const VectorType &               v,
+                       const unsigned int               component)
   {
     return compute_mean_value(get_default_linear_mapping(
                                 dof.get_triangulation()),

--- a/include/deal.II/numerics/vector_tools_point_gradient.h
+++ b/include/deal.II/numerics/vector_tools_point_gradient.h
@@ -27,6 +27,7 @@ DEAL_II_NAMESPACE_OPEN
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
+
 template <int dim, typename Number>
 class Function;
 template <int dim, int spacedim>
@@ -86,8 +87,8 @@ namespace VectorTools
    *   when trying to evaluate point values of discontinuous functions.
    */
   template <int dim, typename VectorType, int spacedim>
-  void
-  point_gradient(
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  void point_gradient(
     const DoFHandler<dim, spacedim> &dof,
     const VectorType &               fe_function,
     const Point<spacedim, double> &  point,
@@ -110,8 +111,8 @@ namespace VectorTools
    *   when trying to evaluate point values of discontinuous functions.
    */
   template <int dim, typename VectorType, int spacedim>
-  void
-  point_gradient(
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  void point_gradient(
     const DoFHandler<dim, spacedim> &dof,
     const VectorType &               fe_function,
     const Point<spacedim, double> &  point,
@@ -150,10 +151,11 @@ namespace VectorTools
    *   when trying to evaluate point values of discontinuous functions.
    */
   template <int dim, typename VectorType, int spacedim>
-  Tensor<1, spacedim, typename VectorType::value_type>
-  point_gradient(const DoFHandler<dim, spacedim> &dof,
-                 const VectorType &               fe_function,
-                 const Point<spacedim, double> &  point);
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  Tensor<1, spacedim, typename VectorType::value_type> point_gradient(
+    const DoFHandler<dim, spacedim> &dof,
+    const VectorType &               fe_function,
+    const Point<spacedim, double> &  point);
 
   /**
    * Same as above for hp.
@@ -172,10 +174,11 @@ namespace VectorTools
    *   when trying to evaluate point values of discontinuous functions.
    */
   template <int dim, typename VectorType, int spacedim>
-  Tensor<1, spacedim, typename VectorType::value_type>
-  point_gradient(const DoFHandler<dim, spacedim> &dof,
-                 const VectorType &               fe_function,
-                 const Point<spacedim, double> &  point);
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  Tensor<1, spacedim, typename VectorType::value_type> point_gradient(
+    const DoFHandler<dim, spacedim> &dof,
+    const VectorType &               fe_function,
+    const Point<spacedim, double> &  point);
 
   /**
    * Evaluate a possibly vector-valued finite element function defined by the
@@ -210,8 +213,8 @@ namespace VectorTools
    *   when trying to evaluate point values of discontinuous functions.
    */
   template <int dim, typename VectorType, int spacedim>
-  void
-  point_gradient(
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  void point_gradient(
     const Mapping<dim, spacedim> &   mapping,
     const DoFHandler<dim, spacedim> &dof,
     const VectorType &               fe_function,
@@ -235,8 +238,8 @@ namespace VectorTools
    *   when trying to evaluate point values of discontinuous functions.
    */
   template <int dim, typename VectorType, int spacedim>
-  void
-  point_gradient(
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  void point_gradient(
     const hp::MappingCollection<dim, spacedim> &mapping,
     const DoFHandler<dim, spacedim> &           dof,
     const VectorType &                          fe_function,
@@ -276,11 +279,12 @@ namespace VectorTools
    *   when trying to evaluate point values of discontinuous functions.
    */
   template <int dim, typename VectorType, int spacedim>
-  Tensor<1, spacedim, typename VectorType::value_type>
-  point_gradient(const Mapping<dim, spacedim> &   mapping,
-                 const DoFHandler<dim, spacedim> &dof,
-                 const VectorType &               fe_function,
-                 const Point<spacedim, double> &  point);
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  Tensor<1, spacedim, typename VectorType::value_type> point_gradient(
+    const Mapping<dim, spacedim> &   mapping,
+    const DoFHandler<dim, spacedim> &dof,
+    const VectorType &               fe_function,
+    const Point<spacedim, double> &  point);
 
   /**
    * Same as above for hp.
@@ -299,11 +303,12 @@ namespace VectorTools
    *   when trying to evaluate point values of discontinuous functions.
    */
   template <int dim, typename VectorType, int spacedim>
-  Tensor<1, spacedim, typename VectorType::value_type>
-  point_gradient(const hp::MappingCollection<dim, spacedim> &mapping,
-                 const DoFHandler<dim, spacedim> &           dof,
-                 const VectorType &                          fe_function,
-                 const Point<spacedim, double> &             point);
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  Tensor<1, spacedim, typename VectorType::value_type> point_gradient(
+    const hp::MappingCollection<dim, spacedim> &mapping,
+    const DoFHandler<dim, spacedim> &           dof,
+    const VectorType &                          fe_function,
+    const Point<spacedim, double> &             point);
 
   /** @} */
 } // namespace VectorTools

--- a/include/deal.II/numerics/vector_tools_point_gradient.templates.h
+++ b/include/deal.II/numerics/vector_tools_point_gradient.templates.h
@@ -40,8 +40,8 @@ DEAL_II_NAMESPACE_OPEN
 namespace VectorTools
 {
   template <int dim, typename VectorType, int spacedim>
-  void
-  point_gradient(
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  void point_gradient(
     const DoFHandler<dim, spacedim> &dof,
     const VectorType &               fe_function,
     const Point<spacedim> &          point,
@@ -64,10 +64,11 @@ namespace VectorTools
 
 
   template <int dim, typename VectorType, int spacedim>
-  Tensor<1, spacedim, typename VectorType::value_type>
-  point_gradient(const DoFHandler<dim, spacedim> &dof,
-                 const VectorType &               fe_function,
-                 const Point<spacedim> &          point)
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  Tensor<1, spacedim, typename VectorType::value_type> point_gradient(
+    const DoFHandler<dim, spacedim> &dof,
+    const VectorType &               fe_function,
+    const Point<spacedim> &          point)
   {
     if (dof.has_hp_capabilities() == false)
       return point_gradient(get_default_linear_mapping(dof.get_triangulation()),
@@ -84,8 +85,8 @@ namespace VectorTools
 
 
   template <int dim, typename VectorType, int spacedim>
-  void
-  point_gradient(
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  void point_gradient(
     const Mapping<dim, spacedim> &   mapping,
     const DoFHandler<dim, spacedim> &dof,
     const VectorType &               fe_function,
@@ -129,8 +130,8 @@ namespace VectorTools
 
 
   template <int dim, typename VectorType, int spacedim>
-  void
-  point_gradient(
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  void point_gradient(
     const hp::MappingCollection<dim, spacedim> &mapping,
     const DoFHandler<dim, spacedim> &           dof,
     const VectorType &                          fe_function,
@@ -176,11 +177,12 @@ namespace VectorTools
 
 
   template <int dim, typename VectorType, int spacedim>
-  Tensor<1, spacedim, typename VectorType::value_type>
-  point_gradient(const Mapping<dim, spacedim> &   mapping,
-                 const DoFHandler<dim, spacedim> &dof,
-                 const VectorType &               fe_function,
-                 const Point<spacedim> &          point)
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  Tensor<1, spacedim, typename VectorType::value_type> point_gradient(
+    const Mapping<dim, spacedim> &   mapping,
+    const DoFHandler<dim, spacedim> &dof,
+    const VectorType &               fe_function,
+    const Point<spacedim> &          point)
   {
     Assert(dof.get_fe(0).n_components() == 1,
            ExcMessage(
@@ -195,11 +197,12 @@ namespace VectorTools
 
 
   template <int dim, typename VectorType, int spacedim>
-  Tensor<1, spacedim, typename VectorType::value_type>
-  point_gradient(const hp::MappingCollection<dim, spacedim> &mapping,
-                 const DoFHandler<dim, spacedim> &           dof,
-                 const VectorType &                          fe_function,
-                 const Point<spacedim> &                     point)
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  Tensor<1, spacedim, typename VectorType::value_type> point_gradient(
+    const hp::MappingCollection<dim, spacedim> &mapping,
+    const DoFHandler<dim, spacedim> &           dof,
+    const VectorType &                          fe_function,
+    const Point<spacedim> &                     point)
   {
     Assert(dof.get_fe(0).n_components() == 1,
            ExcMessage(

--- a/include/deal.II/numerics/vector_tools_point_value.h
+++ b/include/deal.II/numerics/vector_tools_point_value.h
@@ -24,6 +24,7 @@ DEAL_II_NAMESPACE_OPEN
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
+
 template <int dim, typename Number>
 class Function;
 template <int dim, int spacedim>
@@ -236,8 +237,8 @@ namespace VectorTools
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
   template <int dim, typename VectorType, int spacedim>
-  void
-  point_difference(
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  void point_difference(
     const DoFHandler<dim, spacedim> &                          dof,
     const VectorType &                                         fe_function,
     const Function<spacedim, typename VectorType::value_type> &exact_solution,
@@ -257,8 +258,8 @@ namespace VectorTools
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
    */
   template <int dim, typename VectorType, int spacedim>
-  void
-  point_difference(
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  void point_difference(
     const Mapping<dim, spacedim> &                             mapping,
     const DoFHandler<dim, spacedim> &                          dof,
     const VectorType &                                         fe_function,
@@ -303,11 +304,11 @@ namespace VectorTools
    *   when trying to evaluate point values of discontinuous functions.
    */
   template <int dim, typename VectorType, int spacedim>
-  void
-  point_value(const DoFHandler<dim, spacedim> &        dof,
-              const VectorType &                       fe_function,
-              const Point<spacedim, double> &          point,
-              Vector<typename VectorType::value_type> &value);
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  void point_value(const DoFHandler<dim, spacedim> &        dof,
+                   const VectorType &                       fe_function,
+                   const Point<spacedim, double> &          point,
+                   Vector<typename VectorType::value_type> &value);
 
   /**
    * Same as above for hp.
@@ -327,11 +328,11 @@ namespace VectorTools
    *   when trying to evaluate point values of discontinuous functions.
    */
   template <int dim, typename VectorType, int spacedim>
-  void
-  point_value(const DoFHandler<dim, spacedim> &        dof,
-              const VectorType &                       fe_function,
-              const Point<spacedim, double> &          point,
-              Vector<typename VectorType::value_type> &value);
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  void point_value(const DoFHandler<dim, spacedim> &        dof,
+                   const VectorType &                       fe_function,
+                   const Point<spacedim, double> &          point,
+                   Vector<typename VectorType::value_type> &value);
 
   /**
    * Evaluate a scalar finite element function defined by the given DoFHandler
@@ -373,10 +374,11 @@ namespace VectorTools
    *   when trying to evaluate point values of discontinuous functions.
    */
   template <int dim, typename VectorType, int spacedim>
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
   typename VectorType::value_type
-  point_value(const DoFHandler<dim, spacedim> &dof,
-              const VectorType &               fe_function,
-              const Point<spacedim, double> &  point);
+    point_value(const DoFHandler<dim, spacedim> &dof,
+                const VectorType &               fe_function,
+                const Point<spacedim, double> &  point);
 
   /**
    * Same as above for hp.
@@ -396,10 +398,11 @@ namespace VectorTools
    *   when trying to evaluate point values of discontinuous functions.
    */
   template <int dim, typename VectorType, int spacedim>
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
   typename VectorType::value_type
-  point_value(const DoFHandler<dim, spacedim> &dof,
-              const VectorType &               fe_function,
-              const Point<spacedim, double> &  point);
+    point_value(const DoFHandler<dim, spacedim> &dof,
+                const VectorType &               fe_function,
+                const Point<spacedim, double> &  point);
 
   /**
    * Evaluate a possibly vector-valued finite element function defined by the
@@ -436,12 +439,12 @@ namespace VectorTools
    *   when trying to evaluate point values of discontinuous functions.
    */
   template <int dim, typename VectorType, int spacedim>
-  void
-  point_value(const Mapping<dim, spacedim> &           mapping,
-              const DoFHandler<dim, spacedim> &        dof,
-              const VectorType &                       fe_function,
-              const Point<spacedim, double> &          point,
-              Vector<typename VectorType::value_type> &value);
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  void point_value(const Mapping<dim, spacedim> &           mapping,
+                   const DoFHandler<dim, spacedim> &        dof,
+                   const VectorType &                       fe_function,
+                   const Point<spacedim, double> &          point,
+                   Vector<typename VectorType::value_type> &value);
 
   /**
    * Same as above for hp.
@@ -461,12 +464,12 @@ namespace VectorTools
    *   when trying to evaluate point values of discontinuous functions.
    */
   template <int dim, typename VectorType, int spacedim>
-  void
-  point_value(const hp::MappingCollection<dim, spacedim> &mapping,
-              const DoFHandler<dim, spacedim> &           dof,
-              const VectorType &                          fe_function,
-              const Point<spacedim, double> &             point,
-              Vector<typename VectorType::value_type> &   value);
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  void point_value(const hp::MappingCollection<dim, spacedim> &mapping,
+                   const DoFHandler<dim, spacedim> &           dof,
+                   const VectorType &                          fe_function,
+                   const Point<spacedim, double> &             point,
+                   Vector<typename VectorType::value_type> &   value);
 
   /**
    * Evaluate a scalar finite element function defined by the given DoFHandler
@@ -502,11 +505,12 @@ namespace VectorTools
    *   when trying to evaluate point values of discontinuous functions.
    */
   template <int dim, typename VectorType, int spacedim>
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
   typename VectorType::value_type
-  point_value(const Mapping<dim, spacedim> &   mapping,
-              const DoFHandler<dim, spacedim> &dof,
-              const VectorType &               fe_function,
-              const Point<spacedim, double> &  point);
+    point_value(const Mapping<dim, spacedim> &   mapping,
+                const DoFHandler<dim, spacedim> &dof,
+                const VectorType &               fe_function,
+                const Point<spacedim, double> &  point);
 
   /**
    * Same as above for hp.
@@ -526,11 +530,12 @@ namespace VectorTools
    *   when trying to evaluate point values of discontinuous functions.
    */
   template <int dim, typename VectorType, int spacedim>
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
   typename VectorType::value_type
-  point_value(const hp::MappingCollection<dim, spacedim> &mapping,
-              const DoFHandler<dim, spacedim> &           dof,
-              const VectorType &                          fe_function,
-              const Point<spacedim, double> &             point);
+    point_value(const hp::MappingCollection<dim, spacedim> &mapping,
+                const DoFHandler<dim, spacedim> &           dof,
+                const VectorType &                          fe_function,
+                const Point<spacedim, double> &             point);
   /** @} */
 } // namespace VectorTools
 

--- a/include/deal.II/numerics/vector_tools_point_value.templates.h
+++ b/include/deal.II/numerics/vector_tools_point_value.templates.h
@@ -42,11 +42,11 @@ DEAL_II_NAMESPACE_OPEN
 namespace VectorTools
 {
   template <int dim, typename VectorType, int spacedim>
-  void
-  point_value(const DoFHandler<dim, spacedim> &        dof,
-              const VectorType &                       fe_function,
-              const Point<spacedim> &                  point,
-              Vector<typename VectorType::value_type> &value)
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  void point_value(const DoFHandler<dim, spacedim> &        dof,
+                   const VectorType &                       fe_function,
+                   const Point<spacedim> &                  point,
+                   Vector<typename VectorType::value_type> &value)
   {
     if (dof.has_hp_capabilities() == false)
       point_value(get_default_linear_mapping(dof.get_triangulation()),
@@ -64,10 +64,11 @@ namespace VectorTools
 
 
   template <int dim, typename VectorType, int spacedim>
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
   typename VectorType::value_type
-  point_value(const DoFHandler<dim, spacedim> &dof,
-              const VectorType &               fe_function,
-              const Point<spacedim> &          point)
+    point_value(const DoFHandler<dim, spacedim> &dof,
+                const VectorType &               fe_function,
+                const Point<spacedim> &          point)
   {
     if (dof.has_hp_capabilities() == false)
       return point_value(get_default_linear_mapping(dof.get_triangulation()),
@@ -83,12 +84,12 @@ namespace VectorTools
 
 
   template <int dim, typename VectorType, int spacedim>
-  void
-  point_value(const Mapping<dim, spacedim> &           mapping,
-              const DoFHandler<dim, spacedim> &        dof,
-              const VectorType &                       fe_function,
-              const Point<spacedim> &                  point,
-              Vector<typename VectorType::value_type> &value)
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  void point_value(const Mapping<dim, spacedim> &           mapping,
+                   const DoFHandler<dim, spacedim> &        dof,
+                   const VectorType &                       fe_function,
+                   const Point<spacedim> &                  point,
+                   Vector<typename VectorType::value_type> &value)
   {
     using Number                 = typename VectorType::value_type;
     const FiniteElement<dim> &fe = dof.get_fe();
@@ -126,12 +127,12 @@ namespace VectorTools
 
 
   template <int dim, typename VectorType, int spacedim>
-  void
-  point_value(const hp::MappingCollection<dim, spacedim> &mapping,
-              const DoFHandler<dim, spacedim> &           dof,
-              const VectorType &                          fe_function,
-              const Point<spacedim> &                     point,
-              Vector<typename VectorType::value_type> &   value)
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  void point_value(const hp::MappingCollection<dim, spacedim> &mapping,
+                   const DoFHandler<dim, spacedim> &           dof,
+                   const VectorType &                          fe_function,
+                   const Point<spacedim> &                     point,
+                   Vector<typename VectorType::value_type> &   value)
   {
     using Number                              = typename VectorType::value_type;
     const hp::FECollection<dim, spacedim> &fe = dof.get_fe_collection();
@@ -173,11 +174,12 @@ namespace VectorTools
 
 
   template <int dim, typename VectorType, int spacedim>
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
   typename VectorType::value_type
-  point_value(const Mapping<dim, spacedim> &   mapping,
-              const DoFHandler<dim, spacedim> &dof,
-              const VectorType &               fe_function,
-              const Point<spacedim> &          point)
+    point_value(const Mapping<dim, spacedim> &   mapping,
+                const DoFHandler<dim, spacedim> &dof,
+                const VectorType &               fe_function,
+                const Point<spacedim> &          point)
   {
     Assert(dof.get_fe(0).n_components() == 1,
            ExcMessage(
@@ -191,11 +193,12 @@ namespace VectorTools
 
 
   template <int dim, typename VectorType, int spacedim>
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
   typename VectorType::value_type
-  point_value(const hp::MappingCollection<dim, spacedim> &mapping,
-              const DoFHandler<dim, spacedim> &           dof,
-              const VectorType &                          fe_function,
-              const Point<spacedim> &                     point)
+    point_value(const hp::MappingCollection<dim, spacedim> &mapping,
+                const DoFHandler<dim, spacedim> &           dof,
+                const VectorType &                          fe_function,
+                const Point<spacedim> &                     point)
   {
     Assert(dof.get_fe(0).n_components() == 1,
            ExcMessage(
@@ -209,8 +212,8 @@ namespace VectorTools
 
 
   template <int dim, typename VectorType, int spacedim>
-  void
-  point_difference(
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  void point_difference(
     const DoFHandler<dim, spacedim> &                          dof,
     const VectorType &                                         fe_function,
     const Function<spacedim, typename VectorType::value_type> &exact_function,
@@ -227,8 +230,8 @@ namespace VectorTools
 
 
   template <int dim, typename VectorType, int spacedim>
-  void
-  point_difference(
+  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  void point_difference(
     const Mapping<dim, spacedim> &                             mapping,
     const DoFHandler<dim, spacedim> &                          dof,
     const VectorType &                                         fe_function,

--- a/include/deal.II/numerics/vector_tools_project.h
+++ b/include/deal.II/numerics/vector_tools_project.h
@@ -26,9 +26,11 @@ DEAL_II_NAMESPACE_OPEN
 
 template <typename number>
 class AffineConstraints;
+
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
+
 template <int dim, typename Number>
 class Function;
 template <int dim, int spacedim>
@@ -139,67 +141,69 @@ namespace VectorTools
    * boundary before projecting the interior of the function.
    */
   template <int dim, typename VectorType, int spacedim>
-  void
-  project(const Mapping<dim, spacedim> &                            mapping,
-          const DoFHandler<dim, spacedim> &                         dof,
-          const AffineConstraints<typename VectorType::value_type> &constraints,
-          const Quadrature<dim> &                                   quadrature,
-          const Function<spacedim, typename VectorType::value_type> &function,
-          VectorType &                                               vec,
-          const bool                 enforce_zero_boundary     = false,
-          const Quadrature<dim - 1> &q_boundary                = (dim > 1 ?
-                                                                    QGauss<dim - 1>(2) :
-                                                                    Quadrature<dim - 1>(0)),
-          const bool                 project_to_boundary_first = false);
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void project(
+    const Mapping<dim, spacedim> &                             mapping,
+    const DoFHandler<dim, spacedim> &                          dof,
+    const AffineConstraints<typename VectorType::value_type> & constraints,
+    const Quadrature<dim> &                                    quadrature,
+    const Function<spacedim, typename VectorType::value_type> &function,
+    VectorType &                                               vec,
+    const bool                 enforce_zero_boundary = false,
+    const Quadrature<dim - 1> &q_boundary = (dim > 1 ? QGauss<dim - 1>(2) :
+                                                       Quadrature<dim - 1>(0)),
+    const bool                 project_to_boundary_first = false);
 
   /**
    * Call the project() function above, with
    * <tt>mapping=MappingQ@<dim@>(1)</tt>.
    */
   template <int dim, typename VectorType, int spacedim>
-  void
-  project(const DoFHandler<dim, spacedim> &                         dof,
-          const AffineConstraints<typename VectorType::value_type> &constraints,
-          const Quadrature<dim> &                                   quadrature,
-          const Function<spacedim, typename VectorType::value_type> &function,
-          VectorType &                                               vec,
-          const bool                 enforce_zero_boundary     = false,
-          const Quadrature<dim - 1> &q_boundary                = (dim > 1 ?
-                                                                    QGauss<dim - 1>(2) :
-                                                                    Quadrature<dim - 1>(0)),
-          const bool                 project_to_boundary_first = false);
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void project(
+    const DoFHandler<dim, spacedim> &                          dof,
+    const AffineConstraints<typename VectorType::value_type> & constraints,
+    const Quadrature<dim> &                                    quadrature,
+    const Function<spacedim, typename VectorType::value_type> &function,
+    VectorType &                                               vec,
+    const bool                 enforce_zero_boundary = false,
+    const Quadrature<dim - 1> &q_boundary = (dim > 1 ? QGauss<dim - 1>(2) :
+                                                       Quadrature<dim - 1>(0)),
+    const bool                 project_to_boundary_first = false);
 
   /**
    * Same as above, but with hp-capabilities.
    */
   template <int dim, typename VectorType, int spacedim>
-  void
-  project(const hp::MappingCollection<dim, spacedim> &              mapping,
-          const DoFHandler<dim, spacedim> &                         dof,
-          const AffineConstraints<typename VectorType::value_type> &constraints,
-          const hp::QCollection<dim> &                              quadrature,
-          const Function<spacedim, typename VectorType::value_type> &function,
-          VectorType &                                               vec,
-          const bool                      enforce_zero_boundary = false,
-          const hp::QCollection<dim - 1> &q_boundary = hp::QCollection<dim - 1>(
-            dim > 1 ? QGauss<dim - 1>(2) : Quadrature<dim - 1>(0)),
-          const bool project_to_boundary_first = false);
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void project(
+    const hp::MappingCollection<dim, spacedim> &               mapping,
+    const DoFHandler<dim, spacedim> &                          dof,
+    const AffineConstraints<typename VectorType::value_type> & constraints,
+    const hp::QCollection<dim> &                               quadrature,
+    const Function<spacedim, typename VectorType::value_type> &function,
+    VectorType &                                               vec,
+    const bool                      enforce_zero_boundary = false,
+    const hp::QCollection<dim - 1> &q_boundary = hp::QCollection<dim - 1>(
+      dim > 1 ? QGauss<dim - 1>(2) : Quadrature<dim - 1>(0)),
+    const bool project_to_boundary_first = false);
 
   /**
    * Call the project() function above, with a collection of $Q_1$ mapping
    * objects, i.e., with hp::StaticMappingQ1::mapping_collection.
    */
   template <int dim, typename VectorType, int spacedim>
-  void
-  project(const DoFHandler<dim, spacedim> &                         dof,
-          const AffineConstraints<typename VectorType::value_type> &constraints,
-          const hp::QCollection<dim> &                              quadrature,
-          const Function<spacedim, typename VectorType::value_type> &function,
-          VectorType &                                               vec,
-          const bool                      enforce_zero_boundary = false,
-          const hp::QCollection<dim - 1> &q_boundary = hp::QCollection<dim - 1>(
-            dim > 1 ? QGauss<dim - 1>(2) : Quadrature<dim - 1>(0)),
-          const bool project_to_boundary_first = false);
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void project(
+    const DoFHandler<dim, spacedim> &                          dof,
+    const AffineConstraints<typename VectorType::value_type> & constraints,
+    const hp::QCollection<dim> &                               quadrature,
+    const Function<spacedim, typename VectorType::value_type> &function,
+    VectorType &                                               vec,
+    const bool                      enforce_zero_boundary = false,
+    const hp::QCollection<dim - 1> &q_boundary = hp::QCollection<dim - 1>(
+      dim > 1 ? QGauss<dim - 1>(2) : Quadrature<dim - 1>(0)),
+    const bool project_to_boundary_first = false);
 
   /**
    * The same as above for projection of scalar-valued quadrature data.
@@ -226,15 +230,16 @@ namespace VectorTools
    * quadrature point data.
    */
   template <int dim, typename VectorType, int spacedim>
-  void
-  project(const Mapping<dim, spacedim> &                            mapping,
-          const DoFHandler<dim, spacedim> &                         dof,
-          const AffineConstraints<typename VectorType::value_type> &constraints,
-          const Quadrature<dim> &                                   quadrature,
-          const std::function<typename VectorType::value_type(
-            const typename DoFHandler<dim, spacedim>::active_cell_iterator &,
-            const unsigned int)> &                                  func,
-          VectorType &                                              vec_result);
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void project(
+    const Mapping<dim, spacedim> &                            mapping,
+    const DoFHandler<dim, spacedim> &                         dof,
+    const AffineConstraints<typename VectorType::value_type> &constraints,
+    const Quadrature<dim> &                                   quadrature,
+    const std::function<typename VectorType::value_type(
+      const typename DoFHandler<dim, spacedim>::active_cell_iterator &,
+      const unsigned int)> &                                  func,
+    VectorType &                                              vec_result);
 
   /**
    * The same as above for projection of scalar-valued MatrixFree quadrature
@@ -265,8 +270,8 @@ namespace VectorTools
    * FEEvaluation object.
    */
   template <int dim, typename VectorType>
-  void
-  project(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void project(
     std::shared_ptr<
       const MatrixFree<dim,
                        typename VectorType::value_type,
@@ -284,8 +289,8 @@ namespace VectorTools
    * matrix_free.get_dof_handler().get_fe().degree+1</code>.
    */
   template <int dim, typename VectorType>
-  void
-  project(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void project(
     std::shared_ptr<
       const MatrixFree<dim,
                        typename VectorType::value_type,

--- a/include/deal.II/numerics/vector_tools_project.templates.h
+++ b/include/deal.II/numerics/vector_tools_project.templates.h
@@ -408,8 +408,8 @@ namespace VectorTools
      * by copying from a LinearAlgebra::distributed::Vector.
      */
     template <int dim, typename VectorType, int spacedim>
-    void
-    project_matrix_free_copy_vector(
+    DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+    void project_matrix_free_copy_vector(
       const Mapping<dim, spacedim> &                             mapping,
       const DoFHandler<dim, spacedim> &                          dof,
       const AffineConstraints<typename VectorType::value_type> & constraints,
@@ -478,8 +478,8 @@ namespace VectorTools
               class M_or_MC,
               template <int>
               class Q_or_QC>
-    void
-    do_project(
+    DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+    void do_project(
       const M_or_MC<dim, spacedim> &                             mapping,
       const DoFHandler<dim, spacedim> &                          dof,
       const AffineConstraints<typename VectorType::value_type> & constraints,
@@ -579,8 +579,8 @@ namespace VectorTools
 
 
     template <int dim, typename VectorType, int spacedim>
-    void
-    project_parallel(
+    DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+    void project_parallel(
       const Mapping<dim, spacedim> &                            mapping,
       const DoFHandler<dim, spacedim> &                         dof,
       const AffineConstraints<typename VectorType::value_type> &constraints,
@@ -682,8 +682,8 @@ namespace VectorTools
 
 
     template <int dim, typename VectorType, int spacedim>
-    void
-    project_parallel(
+    DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+    void project_parallel(
       std::shared_ptr<const MatrixFree<dim, typename VectorType::value_type>>
                                                                 matrix_free,
       const AffineConstraints<typename VectorType::value_type> &constraints,
@@ -767,20 +767,21 @@ namespace VectorTools
      * based on the number of components.
      */
     template <typename VectorType, int dim, int spacedim>
+    DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
     std::enable_if_t<
       !numbers::NumberTraits<typename VectorType::value_type>::is_complex &&
         (dim == spacedim),
-      void>
-    project(
-      const Mapping<dim, spacedim> &                             mapping,
-      const DoFHandler<dim, spacedim> &                          dof,
-      const AffineConstraints<typename VectorType::value_type> & constraints,
-      const Quadrature<dim> &                                    quadrature,
-      const Function<spacedim, typename VectorType::value_type> &function,
-      VectorType &                                               vec_result,
-      const bool                 enforce_zero_boundary,
-      const Quadrature<dim - 1> &q_boundary,
-      const bool                 project_to_boundary_first)
+      void> project(const Mapping<dim, spacedim> &   mapping,
+                    const DoFHandler<dim, spacedim> &dof,
+                    const AffineConstraints<typename VectorType::value_type>
+                      &                    constraints,
+                    const Quadrature<dim> &quadrature,
+                    const Function<spacedim, typename VectorType::value_type>
+                      &                        function,
+                    VectorType &               vec_result,
+                    const bool                 enforce_zero_boundary,
+                    const Quadrature<dim - 1> &q_boundary,
+                    const bool                 project_to_boundary_first)
     {
       // If we can, use the matrix-free implementation
       bool use_matrix_free =
@@ -830,20 +831,21 @@ namespace VectorTools
      * for which we are sure that we cannot use the MatrixFree implementation.
      */
     template <typename VectorType, int dim, int spacedim>
+    DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
     std::enable_if_t<
       numbers::NumberTraits<typename VectorType::value_type>::is_complex ||
         (dim < spacedim),
-      void>
-    project(
-      const Mapping<dim, spacedim> &                             mapping,
-      const DoFHandler<dim, spacedim> &                          dof,
-      const AffineConstraints<typename VectorType::value_type> & constraints,
-      const Quadrature<dim> &                                    quadrature,
-      const Function<spacedim, typename VectorType::value_type> &function,
-      VectorType &                                               vec_result,
-      const bool                 enforce_zero_boundary,
-      const Quadrature<dim - 1> &q_boundary,
-      const bool                 project_to_boundary_first)
+      void> project(const Mapping<dim, spacedim> &   mapping,
+                    const DoFHandler<dim, spacedim> &dof,
+                    const AffineConstraints<typename VectorType::value_type>
+                      &                    constraints,
+                    const Quadrature<dim> &quadrature,
+                    const Function<spacedim, typename VectorType::value_type>
+                      &                        function,
+                    VectorType &               vec_result,
+                    const bool                 enforce_zero_boundary,
+                    const Quadrature<dim - 1> &q_boundary,
+                    const bool                 project_to_boundary_first)
     {
       Assert((dynamic_cast<const parallel::TriangulationBase<dim> *>(
                 &(dof.get_triangulation())) == nullptr),
@@ -864,15 +866,16 @@ namespace VectorTools
 
 
   template <int dim, typename VectorType, int spacedim>
-  void
-  project(const Mapping<dim, spacedim> &                            mapping,
-          const DoFHandler<dim, spacedim> &                         dof,
-          const AffineConstraints<typename VectorType::value_type> &constraints,
-          const Quadrature<dim> &                                   quadrature,
-          const std::function<typename VectorType::value_type(
-            const typename DoFHandler<dim, spacedim>::active_cell_iterator &,
-            const unsigned int)> &                                  func,
-          VectorType &                                              vec_result)
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void project(
+    const Mapping<dim, spacedim> &                            mapping,
+    const DoFHandler<dim, spacedim> &                         dof,
+    const AffineConstraints<typename VectorType::value_type> &constraints,
+    const Quadrature<dim> &                                   quadrature,
+    const std::function<typename VectorType::value_type(
+      const typename DoFHandler<dim, spacedim>::active_cell_iterator &,
+      const unsigned int)> &                                  func,
+    VectorType &                                              vec_result)
   {
     internal::project_parallel<dim, VectorType, spacedim>(
       mapping, dof, constraints, quadrature, func, vec_result);
@@ -881,18 +884,19 @@ namespace VectorTools
 
 
   template <int dim, typename VectorType>
-  void
-  project(std::shared_ptr<const MatrixFree<
-            dim,
-            typename VectorType::value_type,
-            VectorizedArray<typename VectorType::value_type>>>      matrix_free,
-          const AffineConstraints<typename VectorType::value_type> &constraints,
-          const unsigned int,
-          const std::function<VectorizedArray<typename VectorType::value_type>(
-            const unsigned int,
-            const unsigned int)> &func,
-          VectorType &            vec_result,
-          const unsigned int      fe_component)
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void project(
+    std::shared_ptr<const MatrixFree<
+      dim,
+      typename VectorType::value_type,
+      VectorizedArray<typename VectorType::value_type>>>      matrix_free,
+    const AffineConstraints<typename VectorType::value_type> &constraints,
+    const unsigned int,
+    const std::function<VectorizedArray<typename VectorType::value_type>(
+      const unsigned int,
+      const unsigned int)> &func,
+    VectorType &            vec_result,
+    const unsigned int      fe_component)
   {
     internal::project_parallel<dim, VectorType, dim>(
       matrix_free, constraints, func, vec_result, fe_component);
@@ -901,17 +905,18 @@ namespace VectorTools
 
 
   template <int dim, typename VectorType>
-  void
-  project(std::shared_ptr<const MatrixFree<
-            dim,
-            typename VectorType::value_type,
-            VectorizedArray<typename VectorType::value_type>>>      matrix_free,
-          const AffineConstraints<typename VectorType::value_type> &constraints,
-          const std::function<VectorizedArray<typename VectorType::value_type>(
-            const unsigned int,
-            const unsigned int)> &                                  func,
-          VectorType &                                              vec_result,
-          const unsigned int fe_component)
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void project(
+    std::shared_ptr<const MatrixFree<
+      dim,
+      typename VectorType::value_type,
+      VectorizedArray<typename VectorType::value_type>>>      matrix_free,
+    const AffineConstraints<typename VectorType::value_type> &constraints,
+    const std::function<VectorizedArray<typename VectorType::value_type>(
+      const unsigned int,
+      const unsigned int)> &                                  func,
+    VectorType &                                              vec_result,
+    const unsigned int                                        fe_component)
   {
     project(matrix_free,
             constraints,
@@ -924,16 +929,17 @@ namespace VectorTools
 
 
   template <int dim, typename VectorType, int spacedim>
-  void
-  project(const Mapping<dim, spacedim> &                            mapping,
-          const DoFHandler<dim, spacedim> &                         dof,
-          const AffineConstraints<typename VectorType::value_type> &constraints,
-          const Quadrature<dim> &                                   quadrature,
-          const Function<spacedim, typename VectorType::value_type> &function,
-          VectorType &                                               vec_result,
-          const bool                 enforce_zero_boundary,
-          const Quadrature<dim - 1> &q_boundary,
-          const bool                 project_to_boundary_first)
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void project(
+    const Mapping<dim, spacedim> &                             mapping,
+    const DoFHandler<dim, spacedim> &                          dof,
+    const AffineConstraints<typename VectorType::value_type> & constraints,
+    const Quadrature<dim> &                                    quadrature,
+    const Function<spacedim, typename VectorType::value_type> &function,
+    VectorType &                                               vec_result,
+    const bool                 enforce_zero_boundary,
+    const Quadrature<dim - 1> &q_boundary,
+    const bool                 project_to_boundary_first)
   {
     internal::project(mapping,
                       dof,
@@ -949,15 +955,16 @@ namespace VectorTools
 
 
   template <int dim, typename VectorType, int spacedim>
-  void
-  project(const DoFHandler<dim, spacedim> &                         dof,
-          const AffineConstraints<typename VectorType::value_type> &constraints,
-          const Quadrature<dim> &                                   quadrature,
-          const Function<spacedim, typename VectorType::value_type> &function,
-          VectorType &                                               vec,
-          const bool                 enforce_zero_boundary,
-          const Quadrature<dim - 1> &q_boundary,
-          const bool                 project_to_boundary_first)
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void project(
+    const DoFHandler<dim, spacedim> &                          dof,
+    const AffineConstraints<typename VectorType::value_type> & constraints,
+    const Quadrature<dim> &                                    quadrature,
+    const Function<spacedim, typename VectorType::value_type> &function,
+    VectorType &                                               vec,
+    const bool                 enforce_zero_boundary,
+    const Quadrature<dim - 1> &q_boundary,
+    const bool                 project_to_boundary_first)
   {
     project(get_default_linear_mapping(dof.get_triangulation()),
             dof,
@@ -973,16 +980,17 @@ namespace VectorTools
 
 
   template <int dim, typename VectorType, int spacedim>
-  void
-  project(const hp::MappingCollection<dim, spacedim> &              mapping,
-          const DoFHandler<dim, spacedim> &                         dof,
-          const AffineConstraints<typename VectorType::value_type> &constraints,
-          const hp::QCollection<dim> &                              quadrature,
-          const Function<spacedim, typename VectorType::value_type> &function,
-          VectorType &                                               vec_result,
-          const bool                      enforce_zero_boundary,
-          const hp::QCollection<dim - 1> &q_boundary,
-          const bool                      project_to_boundary_first)
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void project(
+    const hp::MappingCollection<dim, spacedim> &               mapping,
+    const DoFHandler<dim, spacedim> &                          dof,
+    const AffineConstraints<typename VectorType::value_type> & constraints,
+    const hp::QCollection<dim> &                               quadrature,
+    const Function<spacedim, typename VectorType::value_type> &function,
+    VectorType &                                               vec_result,
+    const bool                      enforce_zero_boundary,
+    const hp::QCollection<dim - 1> &q_boundary,
+    const bool                      project_to_boundary_first)
   {
     Assert((dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
               &(dof.get_triangulation())) == nullptr),
@@ -1002,15 +1010,16 @@ namespace VectorTools
 
 
   template <int dim, typename VectorType, int spacedim>
-  void
-  project(const DoFHandler<dim, spacedim> &                         dof,
-          const AffineConstraints<typename VectorType::value_type> &constraints,
-          const hp::QCollection<dim> &                              quadrature,
-          const Function<spacedim, typename VectorType::value_type> &function,
-          VectorType &                                               vec,
-          const bool                      enforce_zero_boundary,
-          const hp::QCollection<dim - 1> &q_boundary,
-          const bool                      project_to_boundary_first)
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void project(
+    const DoFHandler<dim, spacedim> &                          dof,
+    const AffineConstraints<typename VectorType::value_type> & constraints,
+    const hp::QCollection<dim> &                               quadrature,
+    const Function<spacedim, typename VectorType::value_type> &function,
+    VectorType &                                               vec,
+    const bool                      enforce_zero_boundary,
+    const hp::QCollection<dim - 1> &q_boundary,
+    const bool                      project_to_boundary_first)
   {
     project(hp::StaticMappingQ1<dim, spacedim>::mapping_collection,
             dof,

--- a/include/deal.II/numerics/vector_tools_rhs.h
+++ b/include/deal.II/numerics/vector_tools_rhs.h
@@ -24,9 +24,11 @@ DEAL_II_NAMESPACE_OPEN
 
 template <typename number>
 class AffineConstraints;
+
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
+
 template <int dim, typename Number>
 class Function;
 template <int dim, int spacedim>
@@ -56,8 +58,8 @@ namespace VectorTools
    * See the general documentation of this namespace for further information.
    */
   template <int dim, int spacedim, typename VectorType>
-  void
-  create_right_hand_side(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void create_right_hand_side(
     const Mapping<dim, spacedim> &                             mapping,
     const DoFHandler<dim, spacedim> &                          dof,
     const Quadrature<dim> &                                    q,
@@ -71,8 +73,8 @@ namespace VectorTools
    * <tt>mapping=MappingQ@<dim@>(1)</tt>.
    */
   template <int dim, int spacedim, typename VectorType>
-  void
-  create_right_hand_side(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void create_right_hand_side(
     const DoFHandler<dim, spacedim> &                          dof,
     const Quadrature<dim> &                                    q,
     const Function<spacedim, typename VectorType::value_type> &rhs,
@@ -84,8 +86,8 @@ namespace VectorTools
    * Like the previous set of functions, but for hp-objects.
    */
   template <int dim, int spacedim, typename VectorType>
-  void
-  create_right_hand_side(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void create_right_hand_side(
     const hp::MappingCollection<dim, spacedim> &               mapping,
     const DoFHandler<dim, spacedim> &                          dof,
     const hp::QCollection<dim> &                               q,
@@ -98,8 +100,8 @@ namespace VectorTools
    * Like the previous set of functions, but for hp-objects.
    */
   template <int dim, int spacedim, typename VectorType>
-  void
-  create_right_hand_side(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void create_right_hand_side(
     const DoFHandler<dim, spacedim> &                          dof,
     const hp::QCollection<dim> &                               q,
     const Function<spacedim, typename VectorType::value_type> &rhs,
@@ -117,8 +119,8 @@ namespace VectorTools
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
   template <int dim, int spacedim, typename VectorType>
-  void
-  create_boundary_right_hand_side(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void create_boundary_right_hand_side(
     const Mapping<dim, spacedim> &                             mapping,
     const DoFHandler<dim, spacedim> &                          dof,
     const Quadrature<dim - 1> &                                q,
@@ -135,8 +137,8 @@ namespace VectorTools
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
   template <int dim, int spacedim, typename VectorType>
-  void
-  create_boundary_right_hand_side(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void create_boundary_right_hand_side(
     const DoFHandler<dim, spacedim> &                          dof,
     const Quadrature<dim - 1> &                                q,
     const Function<spacedim, typename VectorType::value_type> &rhs,
@@ -151,8 +153,8 @@ namespace VectorTools
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
   template <int dim, int spacedim, typename VectorType>
-  void
-  create_boundary_right_hand_side(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void create_boundary_right_hand_side(
     const hp::MappingCollection<dim, spacedim> &               mapping,
     const DoFHandler<dim, spacedim> &                          dof,
     const hp::QCollection<dim - 1> &                           q,
@@ -170,8 +172,8 @@ namespace VectorTools
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
   template <int dim, int spacedim, typename VectorType>
-  void
-  create_boundary_right_hand_side(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void create_boundary_right_hand_side(
     const DoFHandler<dim, spacedim> &                          dof,
     const hp::QCollection<dim - 1> &                           q,
     const Function<spacedim, typename VectorType::value_type> &rhs,

--- a/include/deal.II/numerics/vector_tools_rhs.templates.h
+++ b/include/deal.II/numerics/vector_tools_rhs.templates.h
@@ -37,8 +37,8 @@ DEAL_II_NAMESPACE_OPEN
 namespace VectorTools
 {
   template <int dim, int spacedim, typename VectorType>
-  void
-  create_boundary_right_hand_side(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void create_boundary_right_hand_side(
     const Mapping<dim, spacedim> &                             mapping,
     const DoFHandler<dim, spacedim> &                          dof_handler,
     const Quadrature<dim - 1> &                                quadrature,
@@ -159,8 +159,8 @@ namespace VectorTools
 
 
   template <int dim, int spacedim, typename VectorType>
-  void
-  create_boundary_right_hand_side(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void create_boundary_right_hand_side(
     const DoFHandler<dim, spacedim> &                          dof_handler,
     const Quadrature<dim - 1> &                                quadrature,
     const Function<spacedim, typename VectorType::value_type> &rhs_function,
@@ -178,8 +178,8 @@ namespace VectorTools
 
 
   template <int dim, int spacedim, typename VectorType>
-  void
-  create_boundary_right_hand_side(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void create_boundary_right_hand_side(
     const hp::MappingCollection<dim, spacedim> &               mapping,
     const DoFHandler<dim, spacedim> &                          dof_handler,
     const hp::QCollection<dim - 1> &                           quadrature,
@@ -312,8 +312,8 @@ namespace VectorTools
 
 
   template <int dim, int spacedim, typename VectorType>
-  void
-  create_boundary_right_hand_side(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void create_boundary_right_hand_side(
     const DoFHandler<dim, spacedim> &                          dof_handler,
     const hp::QCollection<dim - 1> &                           quadrature,
     const Function<spacedim, typename VectorType::value_type> &rhs_function,
@@ -329,9 +329,11 @@ namespace VectorTools
       boundary_ids);
   }
 
+
+
   template <int dim, int spacedim, typename VectorType>
-  void
-  create_right_hand_side(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void create_right_hand_side(
     const Mapping<dim, spacedim> &                             mapping,
     const DoFHandler<dim, spacedim> &                          dof_handler,
     const Quadrature<dim> &                                    quadrature,
@@ -447,8 +449,8 @@ namespace VectorTools
 
 
   template <int dim, int spacedim, typename VectorType>
-  void
-  create_right_hand_side(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void create_right_hand_side(
     const DoFHandler<dim, spacedim> &                          dof_handler,
     const Quadrature<dim> &                                    quadrature,
     const Function<spacedim, typename VectorType::value_type> &rhs_function,
@@ -467,8 +469,8 @@ namespace VectorTools
 
 
   template <int dim, int spacedim, typename VectorType>
-  void
-  create_right_hand_side(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void create_right_hand_side(
     const hp::MappingCollection<dim, spacedim> &               mapping,
     const DoFHandler<dim, spacedim> &                          dof_handler,
     const hp::QCollection<dim> &                               quadrature,
@@ -603,8 +605,8 @@ namespace VectorTools
 
 
   template <int dim, int spacedim, typename VectorType>
-  void
-  create_right_hand_side(
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
+  void create_right_hand_side(
     const DoFHandler<dim, spacedim> &                          dof_handler,
     const hp::QCollection<dim> &                               quadrature,
     const Function<spacedim, typename VectorType::value_type> &rhs_function,


### PR DESCRIPTION
This is the next step for #14840 to add `requires` clauses to deal.II classes and functions. This particular change is what would have avoided the error reported on the mailing list that I mentioned in #14836. In essence, for all of the functions in `namespace VectorTools` that take either a `typename VectorType` or a `typename In/OutVector` template argument, I make explicit what these types have to satisfy:

- They have to be deal.II vector types
- In some cases, they have to be writable and so cannot be `const`. (This was the cause of the error.)

This turned out to be a bit tedious, but otherwise straightforward. The biggest hurdle was to enumerate all of the vector classes we have -- as others have observed at times, we have *a lot of vector classes*.

I'll share some experience from writing this patch while I'm at it: I was concerned that I would get unintelligible error messages at link time if I was not consistent between the declaration in the `.h` file and the implementation in the `.templates.h` file, but in the end, this turned out not to be the case once I understood the general principle. Basically, it comes down to this example:
```
// .h file: declaration
template <typename VectorType>
requires (condition on VectorType)
void f(VectorType v);

// .templates.h file: implementation
template <typename VectorType>
void f(VectorType v)                    // oops: forgot the 'requires' clause
{ ...}

// .inst file: explicit instantiation
template
void f(Vector<double> v);
```
The compiler will here say that it doesn't know of an implementation of the function it's trying to instantiate, and after some thought that makes sense. What happens is that in the `.h` file, I declare the existence of a function with constraints on the template type. In the `.templates.h` file, because I forgot the `requires` clause, what this is is the declaration and definition of *another* function of the same name without constraints that the compiler will select for types that do not satisfy the constraints of the first function -- in essence a "less specialized" overload of the name `f`. When the compiler comes to the explicit instantiation, it sees that the template argument `Vector<double>` satisfies the `requires` clause and that consequently an instantiation of the first version is requested -- but the compiler has never been told of an implementation of that function, and thus the error message.

The upshot is that once I understood the origin of the error message, it was not hard to find all of the places where I had gotten something wrong. And I didn't need to wait till link time to learn about it.