### PR TITLE
step-69: Use commonly used name for time step number.

### DIFF
--- a/examples/step-69/step-69.cc
+++ b/examples/step-69/step-69.cc
@@ -2567,15 +2567,17 @@ namespace Step69
 
     print_head(pcout, "enter main loop");
 
-    for (unsigned int cycle = 1; t < t_final; ++cycle)
+    unsigned int timestep_number = 1;
+    while (t < t_final)
       {
         // We first print an informative status message
 
         std::ostringstream head;
         std::ostringstream secondary;
 
-        head << "Cycle  " << Utilities::int_to_string(cycle, 6) << "  (" //
-             << std::fixed << std::setprecision(1) << t / t_final * 100  //
+        head << "Cycle  " << Utilities::int_to_string(timestep_number, 6)
+             << "  ("                                                   //
+             << std::fixed << std::setprecision(1) << t / t_final * 100 //
              << "%)";
         secondary << "at time t = " << std::setprecision(8) << std::fixed << t;
 
@@ -2601,6 +2603,8 @@ namespace Step69
             output(U, base_name, t, output_cycle);
             ++output_cycle;
           }
+
+        ++timestep_number;
       }
 
     // We wait for any remaining background output thread to finish before


### PR DESCRIPTION
step-69 uses the word "cycle" to indicate the number of a time step. That's not a crazy choice, but we use `timestep_number` in pretty much all of the other time stepping programs:
```
> grep -l -r timestep_number examples/ | sort
examples/step-23/step-23.cc
examples/step-24/step-24.cc
examples/step-25/step-25.cc
examples/step-26/step-26.cc
examples/step-31/step-31.cc
examples/step-32/step-32.cc
examples/step-43/step-43.cc
examples/step-48/step-48.cc
examples/step-58/step-58.cc
examples/step-67/step-67.cc
examples/step-76/step-76.cc
examples/step-78/step-78.cc
```
This patch adjusts the name of the variable to what is used elsewhere.

While I was there, I also almost tripped over the statement
```
for (unsigned int cycle = 1; t < t_final; ++cycle)
```
It is confusing because the loop counter does not actually appears in the termination condition. This is really a `while` loop that uses the first and last part of the `for` statement to initialize and increment a variable. I made that into a proper `while` loop.

I recognize that this isn't my tutorial program, but still think that uniformity and simplicity is something we should strive for in all tutorial programs. I will let the authors of the program overrule me if they feel differently about it.

@tamiko @jerett-cc FYI