### PR TITLE
Fix a missing transpose.

### DIFF
--- a/examples/step-69/doc/intro.dox
+++ b/examples/step-69/doc/intro.dox
@@ -65,7 +65,7 @@ where $\mathbf{u}(\textbf{x},t):\mathbb{R}^{d} \times \mathbb{R}
 dimension. We say that $\mathbf{u} \in \mathbb{R}^{d+2}$ is the state and
 $\mathbb{f}(\mathbf{u}) \in  \mathbb{R}^{(d+2) \times d}$ is the flux of
 the system. In the case of Euler's equations the state is given by
-$\textbf{u} = [\rho, \textbf{m},E]^{\top}$: where $\rho \in \mathbb{R}^+$
+$\textbf{u} = [\rho, \textbf{m}^\top,E]^{\top}$: where $\rho \in \mathbb{R}^+$
 denotes the density, $\textbf{m} \in \mathbb{R}^d$ is the momentum, and $E
 \in \mathbb{R}^+$ is the total energy of the system. The flux of the system
 $\mathbb{f}(\mathbf{u})$ is defined as
@@ -129,7 +129,7 @@ to satisfy the constraint $\textbf{u}(\mathbf{x},t) \in \mathcal{B}$ for
 all $\mathbf{x} \in \Omega$ and $t \geq 0$ where
 @f{align}
   \mathcal{B} = \big\{ \textbf{u} =
-  [\rho, \textbf{m},E]^{\top} \in \mathbb{R}^{d+2} \, \big |
+  [\rho, \textbf{m}^\top,E]^{\top} \in \mathbb{R}^{d+2} \, \big |
   \
   \rho > 0 \, ,
   \


### PR DESCRIPTION
In this place, we create a column vector by transposing a vector written as a row vector -- except that one component of the row vector is a column vector.

@jerett-cc FYI