### PR TITLE
Warn users about FE index mismatch instead of silently dropping them.

### DIFF
--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -2140,8 +2140,7 @@ namespace internal
         const DoFCellAccessor<dim, spacedim, level_dof_access> &accessor)
       {
         if (accessor.dof_handler->hp_capability_enabled == false)
-          return 0; // ::DoFHandler only supports a single active FE with index
-                    // zero
+          return DoFHandler<dim, spacedim>::default_fe_index;
 
         Assert(
           accessor.dof_handler != nullptr,
@@ -2168,7 +2167,6 @@ namespace internal
       {
         if (accessor.dof_handler->hp_capability_enabled == false)
           {
-            // ::DoFHandler only supports a single active FE with index zero
             AssertDimension(i, (DoFHandler<dim, spacedim>::default_fe_index));
             return;
           }
@@ -2199,10 +2197,7 @@ namespace internal
         const DoFCellAccessor<dim, spacedim, level_dof_access> &accessor)
       {
         if (accessor.dof_handler->hp_capability_enabled == false)
-          return DoFHandler<dim, spacedim>::
-            default_fe_index; // ::DoFHandler only supports
-                              // a single active FE with
-                              // index zero
+          return DoFHandler<dim, spacedim>::default_fe_index;
 
         Assert(
           accessor.dof_handler != nullptr,
@@ -2234,7 +2229,6 @@ namespace internal
       {
         if (accessor.dof_handler->hp_capability_enabled == false)
           {
-            // ::DoFHandler only supports a single active FE with index zero
             AssertDimension(i, (DoFHandler<dim, spacedim>::default_fe_index));
             return;
           }
@@ -2265,8 +2259,7 @@ namespace internal
         const DoFCellAccessor<dim, spacedim, level_dof_access> &accessor)
       {
         if (accessor.dof_handler->hp_capability_enabled == false)
-          return false; // ::DoFHandler only supports a single active FE with
-                        // index zero
+          return false;
 
         Assert(
           accessor.dof_handler != nullptr,
@@ -2293,8 +2286,7 @@ namespace internal
         const DoFCellAccessor<dim, spacedim, level_dof_access> &accessor)
       {
         if (accessor.dof_handler->hp_capability_enabled == false)
-          return; // ::DoFHandler only supports a single active FE with index
-                  // zero
+          return;
 
         Assert(
           accessor.dof_handler != nullptr,

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -2158,6 +2158,25 @@ void DoFHandler<dim, spacedim>::distribute_dofs(
          ExcMessage("The Triangulation you are using is empty!"));
   Assert(ff.size() > 0, ExcMessage("The given hp::FECollection is empty!"));
 
+#ifdef DEBUG
+  // make sure that the provided FE collection is large enough to
+  // cover all FE indices presently in use on the mesh
+  if ((hp_cell_active_fe_indices.size() > 0) &&
+      (hp_cell_future_fe_indices.size() > 0))
+    {
+      Assert(hp_capability_enabled, ExcInternalError());
+
+      for (const auto &cell :
+           this->active_cell_iterators() | IteratorFilters::LocallyOwnedCell())
+        {
+          Assert(cell->active_fe_index() < ff.size(),
+                 ExcInvalidFEIndex(cell->active_fe_index(), ff.size()));
+          Assert(cell->future_fe_index() < ff.size(),
+                 ExcInvalidFEIndex(cell->future_fe_index(), ff.size()));
+        }
+    }
+#endif
+
   //
   // register the new finite element collection
   //
@@ -2205,22 +2224,6 @@ void DoFHandler<dim, spacedim>::distribute_dofs(
       // on both its own cells and all ghost cells
       internal::hp::DoFHandlerImplementation::Implementation::
         communicate_active_fe_indices(*this);
-
-#ifdef DEBUG
-      // make sure that the FE collection is large enough to
-      // cover all FE indices presently in use on the mesh
-      for (const auto &cell : this->active_cell_iterators())
-        {
-          if (!cell->is_artificial())
-            Assert(cell->active_fe_index() < this->fe_collection.size(),
-                   ExcInvalidFEIndex(cell->active_fe_index(),
-                                     this->fe_collection.size()));
-          if (cell->is_locally_owned())
-            Assert(cell->future_fe_index() < this->fe_collection.size(),
-                   ExcInvalidFEIndex(cell->future_fe_index(),
-                                     this->fe_collection.size()));
-        }
-#endif
     }
 
   {

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -11898,6 +11898,9 @@ void Triangulation<dim, spacedim>::create_triangulation(
               cell->face(pair.first)->set_boundary_id(pair.second);
         }
     }
+
+  // inform all listeners that the triangulation has been created
+  signals.create();
 }
 
 

--- a/tests/hp/non_hp_mode.cc
+++ b/tests/hp/non_hp_mode.cc
@@ -1,0 +1,65 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2023 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// warn users that they should have nonzero active FE indices in non-hp mode
+
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include "../tests.h"
+
+
+template <int dim>
+void
+test()
+{
+  Triangulation<dim> triangulation;
+  GridGenerator::hyper_cube(triangulation);
+
+  FE_Q<dim> fe(1);
+
+  DoFHandler<dim> dof_handler(triangulation);
+
+  // Choose index out of range here.
+  dof_handler.begin_active()->set_active_fe_index(1);
+
+  try
+    {
+      dof_handler.distribute_dofs(fe);
+    }
+  catch (ExceptionBase &e)
+    {
+      deallog << e.what() << std::endl;
+    }
+}
+
+
+int
+main()
+{
+  deal_II_exceptions::disable_abort_on_exception();
+
+  initlog();
+
+  test<2>();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/hp/non_hp_mode.debug.output
+++ b/tests/hp/non_hp_mode.debug.output
@@ -1,0 +1,13 @@
+
+DEAL::
+--------------------------------------------------------
+An error occurred in file <dof_handler.cc> in function
+    void dealii::DoFHandler<dim, spacedim>::distribute_dofs(const dealii::hp::FECollection<dim, spacedim>&) [with int dim = 2; int spacedim = 2]
+The violated condition was:
+    cell->active_fe_index() < ff.size()
+Additional information:
+    The mesh contains a cell with an active FE index of 1, but the finite
+    element collection only has 1 elements
+--------------------------------------------------------
+
+DEAL::OK


### PR DESCRIPTION
Closes #14841.

Moved an assertion to the beginning of a function. It is sufficient to only check locally owned cells, as they will communicated later.

@simonsticko -- I used your example as a test.