### PR TITLE
Replace #if DEBUG with #ifdef DEBUG

### DIFF
--- a/include/deal.II/matrix_free/vector_access_internal.h
+++ b/include/deal.II/matrix_free/vector_access_internal.h
@@ -25,7 +25,7 @@
 #include <deal.II/matrix_free/matrix_free.h>
 #include <deal.II/matrix_free/type_traits.h>
 
-#if DEBUG
+#ifdef DEBUG
 #  include <boost/algorithm/string/join.hpp>
 #endif
 
@@ -210,7 +210,7 @@ namespace internal
     (void)matrix_free;
     (void)dof_info;
 
-#if DEBUG
+#ifdef DEBUG
     if (vec.partitioners_are_compatible(*dof_info.vector_partitioner) == false)
       {
         unsigned int dof_index = numbers::invalid_unsigned_int;

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -1791,7 +1791,7 @@ namespace internal
                              fe.n_dofs_per_vertex() > 0;
                     });
 
-#if DEBUG
+#ifdef DEBUG
       const bool fine_element_is_discontinuous =
         std::all_of(dof_handler_fine.get_fe_collection().begin(),
                     dof_handler_fine.get_fe_collection().end(),

--- a/source/base/quadrature.cc
+++ b/source/base/quadrature.cc
@@ -587,7 +587,7 @@ QIterated<1>::QIterated(const Quadrature<1> &        base_quadrature,
     else if (std::abs(i[0] - 1.0) < 1e-12)
       i[0] = 1.0;
 
-#if DEBUG
+#ifdef DEBUG
   double sum_of_weights = 0;
   for (unsigned int i = 0; i < this->size(); ++i)
     sum_of_weights += this->weight(i);

--- a/source/hp/fe_collection.cc
+++ b/source/hp/fe_collection.cc
@@ -480,7 +480,7 @@ namespace hp
           for (const Edge &e : sub_graph)
             identities_graph.erase(e);
 
-#if DEBUG
+#ifdef DEBUG
           // There are three checks we ought to perform:
           // - That the sub-graph is undirected, i.e. that every edge appears
           //   in both directions

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -293,7 +293,7 @@ namespace PETScWrappers
 
       Assert(size() == n, ExcDimensionMismatch(size(), n));
 
-#  if DEBUG
+#  ifdef DEBUG
       {
         // test ghost allocation in debug mode
         PetscInt begin, end;

--- a/tests/adolc/helper_scalar_failure_01.cc
+++ b/tests/adolc/helper_scalar_failure_01.cc
@@ -94,7 +94,7 @@ main()
   initlog();
 
   deal_II_exceptions::disable_abort_on_exception();
-#if DEBUG
+#ifdef DEBUG
   // Asserts should be triggered
   const bool expected_result = false;
 #else

--- a/tests/adolc/helper_scalar_failure_02.cc
+++ b/tests/adolc/helper_scalar_failure_02.cc
@@ -96,7 +96,7 @@ main()
   initlog();
 
   deal_II_exceptions::disable_abort_on_exception();
-#if DEBUG
+#ifdef DEBUG
   // Asserts should be triggered
   const bool expected_result = false;
 #else

--- a/tests/adolc/helper_scalar_failure_03.cc
+++ b/tests/adolc/helper_scalar_failure_03.cc
@@ -97,7 +97,7 @@ main()
   initlog();
 
   deal_II_exceptions::disable_abort_on_exception();
-#if DEBUG
+#ifdef DEBUG
   // Asserts should be triggered
   const bool expected_result = false;
 #else

--- a/tests/adolc/helper_scalar_failure_04.cc
+++ b/tests/adolc/helper_scalar_failure_04.cc
@@ -95,7 +95,7 @@ main()
   initlog();
 
   deal_II_exceptions::disable_abort_on_exception();
-#if DEBUG
+#ifdef DEBUG
   // Asserts should be triggered
   const bool expected_result_taped    = false;
   const bool expected_result_tapeless = false;

--- a/tests/adolc/helper_scalar_failure_05.cc
+++ b/tests/adolc/helper_scalar_failure_05.cc
@@ -97,7 +97,7 @@ main()
   initlog();
 
   deal_II_exceptions::disable_abort_on_exception();
-#if DEBUG
+#ifdef DEBUG
   // Asserts should be triggered
   const bool expected_result = false;
 #else

--- a/tests/symengine/sd_common_tests/batch_optimizer_07.h
+++ b/tests/symengine/sd_common_tests/batch_optimizer_07.h
@@ -376,7 +376,7 @@ evaluate_SD_SD_stored_symbols_optimisation(const Tensor<2, dim> &t,
       using func_sd = CoupledFunction<dim, SDNumberType>;
 
       symb_psi = func_sd::psi(symb_t, symb_v, symb_s);
-#if DEBUG_EXTRA
+#ifdef DEBUG_EXTRA
       deallog << "symb_t: " << symb_t << std::endl;
       deallog << "symb_v: " << symb_v << std::endl;
       deallog << "symb_s: " << symb_s << std::endl;
@@ -397,7 +397,7 @@ evaluate_SD_SD_stored_symbols_optimisation(const Tensor<2, dim> &t,
       symb_d2psi_dt_ds = SD::differentiate(symb_dpsi_ds, symb_t);
       symb_d2psi_dv_ds = SD::differentiate(symb_dpsi_ds, symb_v);
       symb_d2psi_ds_ds = SD::differentiate(symb_dpsi_ds, symb_s);
-#if DEBUG_EXTRA
+#ifdef DEBUG_EXTRA
       print(deallog, "symb_psi", symb_psi);
       print(deallog, "symb_dpsi_dt", symb_dpsi_dt);
       print(deallog, "symb_dpsi_dv", symb_dpsi_dv);

--- a/tests/symengine/symengine_tensor_operations_03.cc
+++ b/tests/symengine/symengine_tensor_operations_03.cc
@@ -507,7 +507,7 @@ test_symmetric_tensor_tensor_vector_scalar_coupled(
   symb_d2psi_ds_x_dv  = SD::differentiate(symb_dpsi_ds, symb_v);
   symb_d2psi_ds_x_ds  = SD::differentiate(symb_dpsi_ds, symb_s);
 
-#if DEBUG
+#ifdef DEBUG
   print(std::cout, "symb_st", symb_st);
   print(std::cout, "symb_t", symb_t);
   print(std::cout, "symb_v", symb_v);


### PR DESCRIPTION
This is mostly for consistency. `#if DEBUG` only works because we are passing it as compile definition and don't set it as preprocessor variable.