### PR TITLE
Partial revert of #14753

### DIFF
--- a/include/deal.II/base/point.h
+++ b/include/deal.II/base/point.h
@@ -362,12 +362,14 @@ template <int dim, typename Number>
 inline DEAL_II_HOST_DEVICE
 Point<dim, Number>::Point(const Number x)
 {
+#  ifndef __CUDA_ARCH__
   Assert(dim == 1,
          ExcMessage(
            "You can only initialize Point<1> objects using the constructor "
            "that takes only one argument. Point<dim> objects with dim!=1 "
            "require initialization with the constructor that takes 'dim' "
            "arguments."));
+#  endif
 
   // we can only get here if we pass the assertion. use the switch anyway so
   // as to avoid compiler warnings about uninitialized elements or writing
@@ -388,12 +390,14 @@ template <int dim, typename Number>
 inline DEAL_II_HOST_DEVICE
 Point<dim, Number>::Point(const Number x, const Number y)
 {
+#  ifndef __CUDA_ARCH__
   Assert(dim == 2,
          ExcMessage(
            "You can only initialize Point<2> objects using the constructor "
            "that takes two arguments. Point<dim> objects with dim!=2 "
            "require initialization with the constructor that takes 'dim' "
            "arguments."));
+#  endif
 
   // we can only get here if we pass the assertion. use the indirection anyway
   // so as to avoid compiler warnings about uninitialized elements or writing
@@ -409,12 +413,14 @@ template <int dim, typename Number>
 inline DEAL_II_HOST_DEVICE
 Point<dim, Number>::Point(const Number x, const Number y, const Number z)
 {
+#  ifndef __CUDA_ARCH__
   Assert(dim == 3,
          ExcMessage(
            "You can only initialize Point<3> objects using the constructor "
            "that takes three arguments. Point<dim> objects with dim!=3 "
            "require initialization with the constructor that takes 'dim' "
            "arguments."));
+#  endif
 
   // we can only get here if we pass the assertion. use the indirection anyway
   // so as to avoid compiler warnings about uninitialized elements or writing
@@ -463,7 +469,9 @@ template <int dim, typename Number>
 inline DEAL_II_HOST_DEVICE Number
 Point<dim, Number>::operator()(const unsigned int index) const
 {
+#  ifndef __CUDA_ARCH__
   AssertIndexRange(static_cast<int>(index), dim);
+#  endif
   return this->values[index];
 }
 
@@ -473,7 +481,9 @@ template <int dim, typename Number>
 inline DEAL_II_HOST_DEVICE Number &
 Point<dim, Number>::operator()(const unsigned int index)
 {
+#  ifndef __CUDA_ARCH__
   AssertIndexRange(static_cast<int>(index), dim);
+#  endif
   return this->values[index];
 }
 

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1043,8 +1043,10 @@ template <int dim, typename Number>
 constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE
 Tensor<0, dim, Number>::operator Number &()
 {
+#  ifndef __CUDA_ARCH__
   Assert(dim != 0,
          ExcMessage("Cannot access an object of type Tensor<0,0,Number>"));
+#  endif
   return value;
 }
 
@@ -1053,8 +1055,10 @@ template <int dim, typename Number>
 constexpr inline DEAL_II_ALWAYS_INLINE
   DEAL_II_HOST_DEVICE Tensor<0, dim, Number>::operator const Number &() const
 {
+#  ifndef __CUDA_ARCH__
   Assert(dim != 0,
          ExcMessage("Cannot access an object of type Tensor<0,0,Number>"));
+#  endif
   return value;
 }
 
@@ -1231,8 +1235,10 @@ constexpr DEAL_II_HOST_DEVICE inline DEAL_II_ALWAYS_INLINE
   typename Tensor<0, dim, Number>::real_type
   Tensor<0, dim, Number>::norm_square() const
 {
+#  ifndef __CUDA_ARCH__
   Assert(dim != 0,
          ExcMessage("Cannot access an object of type Tensor<0,0,Number>"));
+#  endif
   return numbers::NumberTraits<Number>::abs_square(value);
 }
 
@@ -1332,7 +1338,9 @@ Tensor<rank_, dim, Number>::Tensor(
 {
   // make nvcc happy
   const int my_n_independent_components = n_independent_components;
+#  ifndef __CUDA_ARCH__
   AssertDimension(initializer.size(), my_n_independent_components);
+#  endif
 
   for (unsigned int i = 0; i < my_n_independent_components; ++i)
     (*this)[unrolled_to_component_indices(i)] = initializer[i];
@@ -1399,7 +1407,9 @@ namespace internal
               const unsigned int i,
               std::integral_constant<int, dim>)
     {
+#  ifndef __CUDA_ARCH__
       AssertIndexRange(i, dim);
+#  endif
       return values[i];
     }
 
@@ -1409,10 +1419,12 @@ namespace internal
               const unsigned int,
               std::integral_constant<int, 0>)
     {
+#  ifndef __CUDA_ARCH__
       Assert(
         false,
         ExcMessage(
           "Cannot access elements of an object of type Tensor<rank,0,Number>."));
+#  endif
       return *dummy;
     }
   } // namespace TensorSubscriptor


### PR DESCRIPTION
This PR partially reverts #14753. Right now we have a lot of failing [tests](https://cdash.dealii.org/viewTest.php?onlyfailed&buildid=2076) with a strange error message:
```
An error occurred in line <1187> of file </home/bt2/dealii-ci/dealii/include/deal.II/matrix_free/cuda_matrix_free.templates.h> in function
    void dealii::CUDAWrappers::MatrixFree<dim, Number>::serial_cell_loop(const Functor&, const VectorType&, VectorType&) const [with Functor = HelmholtzOperator<2, 1, double, 2>; VectorType = dealii::LinearAlgebra::CUDAWrappers::Vector<double>; int dim = 2; Number = double]
The violated condition was: 
    local_error_code == cudaSuccess
Additional information: 
    unspecified launch failure
```
This is not a full revert of #14753 because I hope that once I am done porting the MatrixFree code to Kokkos, we will be able to remove `__CUDA_ARCH__` once again.