### PR TITLE
Reduce header inclusions

### DIFF
--- a/include/deal.II/base/mpi.templates.h
+++ b/include/deal.II/base/mpi.templates.h
@@ -23,8 +23,6 @@
 #include <deal.II/base/symmetric_tensor.h>
 #include <deal.II/base/tensor.h>
 
-#include <deal.II/lac/full_matrix.h>
-#include <deal.II/lac/lapack_full_matrix.h>
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/vector.h>
 

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -24,8 +24,10 @@
 #include <deal.II/base/multithread_info.h>
 #include <deal.II/base/utilities.h>
 
+#include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/la_parallel_block_vector.h>
 #include <deal.II/lac/la_parallel_vector.h>
+#include <deal.II/lac/lapack_full_matrix.h>
 #include <deal.II/lac/vector_memory.h>
 
 #include <boost/serialization/utility.hpp>

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -46,6 +46,7 @@
 
 #include <deal.II/lac/constrained_linear_operator.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/lapack_full_matrix.h>
 #include <deal.II/lac/precondition.h>
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/sparse_matrix.h>


### PR DESCRIPTION
Working on #14865, I observed that we do some unnecessary inclusions of `lapack_full_matrix.h` in the library.