### PR TITLE
[C++20] Annotate 'MeshType' template parameters with concepts

### DIFF
--- a/include/deal.II/base/template_constraints.h
+++ b/include/deal.II/base/template_constraints.h
@@ -907,34 +907,34 @@ namespace parallel
 
 namespace concepts
 {
+#if defined(DEAL_II_HAVE_CXX20) || defined(DOXYGEN)
   namespace internal
   {
     template <typename T>
-    constexpr bool is_triangulation_or_dof_handler = false;
+    inline constexpr bool is_triangulation_or_dof_handler = false;
 
     template <int dim, int spacedim>
-    constexpr bool
+    inline constexpr bool
       is_triangulation_or_dof_handler<Triangulation<dim, spacedim>> = true;
 
     template <int dim, int spacedim>
-    constexpr bool is_triangulation_or_dof_handler<
+    inline constexpr bool is_triangulation_or_dof_handler<
       parallel::distributed::Triangulation<dim, spacedim>> = true;
 
     template <int dim, int spacedim>
-    constexpr bool is_triangulation_or_dof_handler<
+    inline constexpr bool is_triangulation_or_dof_handler<
       parallel::shared::Triangulation<dim, spacedim>> = true;
 
     template <int dim, int spacedim>
-    constexpr bool is_triangulation_or_dof_handler<
+    inline constexpr bool is_triangulation_or_dof_handler<
       parallel::fullydistributed::Triangulation<dim, spacedim>> = true;
 
     template <int dim, int spacedim>
-    constexpr bool is_triangulation_or_dof_handler<DoFHandler<dim, spacedim>> =
-      true;
+    inline constexpr bool
+      is_triangulation_or_dof_handler<DoFHandler<dim, spacedim>> = true;
   } // namespace internal
 
 
-#if defined(DEAL_II_HAVE_CXX20) || defined(DOXYGEN)
   /**
    * A concept that is used to check whether the `MeshType` template
    * type used in many functions in namespace GridTools and

--- a/include/deal.II/base/template_constraints.h
+++ b/include/deal.II/base/template_constraints.h
@@ -749,6 +749,7 @@ namespace LinearAlgebra
 #endif
 
 
+
 /**
  * A namespace that is used to declare concepts used in C++20-style
  * `requires` clauses.
@@ -875,6 +876,78 @@ namespace concepts
 
 #endif
 } // namespace concepts
+
+
+template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+class Triangulation;
+
+template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+class DoFHandler;
+
+namespace parallel
+{
+  namespace distributed
+  {
+    template <int dim, int spacedim>
+    class Triangulation;
+  }
+  namespace shared
+  {
+    template <int dim, int spacedim>
+    class Triangulation;
+  }
+  namespace fullydistributed
+  {
+    template <int dim, int spacedim>
+    class Triangulation;
+  }
+} // namespace parallel
+
+namespace concepts
+{
+  namespace internal
+  {
+    template <typename T>
+    constexpr bool is_triangulation_or_dof_handler = false;
+
+    template <int dim, int spacedim>
+    constexpr bool
+      is_triangulation_or_dof_handler<Triangulation<dim, spacedim>> = true;
+
+    template <int dim, int spacedim>
+    constexpr bool is_triangulation_or_dof_handler<
+      parallel::distributed::Triangulation<dim, spacedim>> = true;
+
+    template <int dim, int spacedim>
+    constexpr bool is_triangulation_or_dof_handler<
+      parallel::shared::Triangulation<dim, spacedim>> = true;
+
+    template <int dim, int spacedim>
+    constexpr bool is_triangulation_or_dof_handler<
+      parallel::fullydistributed::Triangulation<dim, spacedim>> = true;
+
+    template <int dim, int spacedim>
+    constexpr bool is_triangulation_or_dof_handler<DoFHandler<dim, spacedim>> =
+      true;
+  } // namespace internal
+
+
+#if defined(DEAL_II_HAVE_CXX20) || defined(DOXYGEN)
+  /**
+   * A concept that is used to check whether the `MeshType` template
+   * type used in many functions in namespace GridTools and
+   * VectorTools is in fact a "mesh" in the sense expected by these
+   * functions. Specifically, this means that the type is either a
+   * Triangulation or a DoFHandler type.
+   */
+  template <typename MeshType>
+  concept is_triangulation_or_dof_handler =
+    internal::is_triangulation_or_dof_handler<MeshType>;
+#endif
+} // namespace concepts
+
 
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -53,6 +53,7 @@ namespace hp
   class FECollection;
 } // namespace hp
 template <class MeshType>
+DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
 class InterGridMap;
 template <int dim, int spacedim>
 class Mapping;

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -2543,6 +2543,8 @@ namespace GridGenerator
   // intermediate type. This is only used when using MS VC++ and uses
   // the direct way of doing it otherwise
   template <template <int, int> class MeshType, int dim, int spacedim>
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
   struct ExtractBoundaryMesh
   {
     using return_type =
@@ -2646,6 +2648,8 @@ namespace GridGenerator
    *
    */
   template <template <int, int> class MeshType, int dim, int spacedim>
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
 #ifdef DOXYGEN
   return_type
 #else
@@ -2656,10 +2660,10 @@ namespace GridGenerator
   typename ExtractBoundaryMesh<MeshType, dim, spacedim>::return_type
 #  endif
 #endif
-  extract_boundary_mesh(const MeshType<dim, spacedim> &     volume_mesh,
-                        MeshType<dim - 1, spacedim> &       surface_mesh,
-                        const std::set<types::boundary_id> &boundary_ids =
-                          std::set<types::boundary_id>());
+    extract_boundary_mesh(const MeshType<dim, spacedim> &     volume_mesh,
+                          MeshType<dim - 1, spacedim> &       surface_mesh,
+                          const std::set<types::boundary_id> &boundary_ids =
+                            std::set<types::boundary_id>());
 
   //** @} */
 

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -94,6 +94,7 @@ namespace GridTools
 namespace internal
 {
   template <int dim, int spacedim, class MeshType>
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
   class ActiveCellIterator
   {
   public:
@@ -1333,10 +1334,12 @@ namespace GridTools
    * @return The index of the closest vertex found.
    */
   template <int dim, template <int, int> class MeshType, int spacedim>
-  unsigned int
-  find_closest_vertex(const MeshType<dim, spacedim> &mesh,
-                      const Point<spacedim> &        p,
-                      const std::vector<bool> &      marked_vertices = {});
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
+  unsigned int find_closest_vertex(
+    const MeshType<dim, spacedim> &mesh,
+    const Point<spacedim> &        p,
+    const std::vector<bool> &      marked_vertices = {});
 
   /**
    * Find and return the index of the used vertex (or marked vertex) in a
@@ -1362,11 +1365,13 @@ namespace GridTools
    * @return The index of the closest vertex found.
    */
   template <int dim, template <int, int> class MeshType, int spacedim>
-  unsigned int
-  find_closest_vertex(const Mapping<dim, spacedim> & mapping,
-                      const MeshType<dim, spacedim> &mesh,
-                      const Point<spacedim> &        p,
-                      const std::vector<bool> &      marked_vertices = {});
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
+  unsigned int find_closest_vertex(
+    const Mapping<dim, spacedim> & mapping,
+    const MeshType<dim, spacedim> &mesh,
+    const Point<spacedim> &        p,
+    const std::vector<bool> &      marked_vertices = {});
 
 
   /**
@@ -1389,6 +1394,8 @@ namespace GridTools
    * for this case.
    */
   template <int dim, template <int, int> class MeshType, int spacedim>
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
 #ifndef _MSC_VER
   std::vector<typename MeshType<dim, spacedim>::active_cell_iterator>
 #else
@@ -1396,8 +1403,8 @@ namespace GridTools
     typename dealii::internal::
       ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim>>::type>
 #endif
-  find_cells_adjacent_to_vertex(const MeshType<dim, spacedim> &container,
-                                const unsigned int             vertex_index);
+    find_cells_adjacent_to_vertex(const MeshType<dim, spacedim> &container,
+                                  const unsigned int             vertex_index);
 
   /**
    * Find an active non-artificial cell that surrounds a given point @p p. The return type
@@ -1462,6 +1469,8 @@ namespace GridTools
    * processor will return a locally owned cell and the other one a ghost cell.
    */
   template <int dim, template <int, int> class MeshType, int spacedim>
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
 #ifndef _MSC_VER
   std::pair<typename MeshType<dim, spacedim>::active_cell_iterator, Point<dim>>
 #else
@@ -1469,11 +1478,11 @@ namespace GridTools
               ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim>>::type,
             Point<dim>>
 #endif
-  find_active_cell_around_point(const Mapping<dim, spacedim> & mapping,
-                                const MeshType<dim, spacedim> &mesh,
-                                const Point<spacedim> &        p,
-                                const std::vector<bool> &marked_vertices = {},
-                                const double             tolerance = 1.e-10);
+    find_active_cell_around_point(const Mapping<dim, spacedim> & mapping,
+                                  const MeshType<dim, spacedim> &mesh,
+                                  const Point<spacedim> &        p,
+                                  const std::vector<bool> &marked_vertices = {},
+                                  const double             tolerance = 1.e-10);
 
   /**
    * A version of the above function that assumes straight boundaries and
@@ -1483,16 +1492,18 @@ namespace GridTools
    * @return An iterator into the mesh that points to the surrounding cell.
    */
   template <int dim, template <int, int> class MeshType, int spacedim>
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
 #ifndef _MSC_VER
   typename MeshType<dim, spacedim>::active_cell_iterator
 #else
   typename dealii::internal::
     ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim>>::type
 #endif
-  find_active_cell_around_point(const MeshType<dim, spacedim> &mesh,
-                                const Point<spacedim> &        p,
-                                const std::vector<bool> &marked_vertices = {},
-                                const double             tolerance = 1.e-10);
+    find_active_cell_around_point(const MeshType<dim, spacedim> &mesh,
+                                  const Point<spacedim> &        p,
+                                  const std::vector<bool> &marked_vertices = {},
+                                  const double             tolerance = 1.e-10);
 
   /**
    * Another version where we use that mapping on a given
@@ -1585,6 +1596,8 @@ namespace GridTools
    * call the function above with argument `cache` in this case.
    */
   template <int dim, template <int, int> class MeshType, int spacedim>
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
 #ifndef _MSC_VER
   std::pair<typename MeshType<dim, spacedim>::active_cell_iterator, Point<dim>>
 #else
@@ -1592,24 +1605,25 @@ namespace GridTools
               ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim>>::type,
             Point<dim>>
 #endif
-  find_active_cell_around_point(
-    const Mapping<dim, spacedim> & mapping,
-    const MeshType<dim, spacedim> &mesh,
-    const Point<spacedim> &        p,
-    const std::vector<
-      std::set<typename MeshType<dim, spacedim>::active_cell_iterator>>
-      &                                                  vertex_to_cell_map,
-    const std::vector<std::vector<Tensor<1, spacedim>>> &vertex_to_cell_centers,
-    const typename MeshType<dim, spacedim>::active_cell_iterator &cell_hint =
-      typename MeshType<dim, spacedim>::active_cell_iterator(),
-    const std::vector<bool> &                              marked_vertices = {},
-    const RTree<std::pair<Point<spacedim>, unsigned int>> &used_vertices_rtree =
-      RTree<std::pair<Point<spacedim>, unsigned int>>{},
-    const double tolerance = 1.e-10,
-    const RTree<
-      std::pair<BoundingBox<spacedim>,
-                typename Triangulation<dim, spacedim>::active_cell_iterator>>
-      *relevant_cell_bounding_boxes_rtree = nullptr);
+    find_active_cell_around_point(
+      const Mapping<dim, spacedim> & mapping,
+      const MeshType<dim, spacedim> &mesh,
+      const Point<spacedim> &        p,
+      const std::vector<
+        std::set<typename MeshType<dim, spacedim>::active_cell_iterator>>
+        &vertex_to_cell_map,
+      const std::vector<std::vector<Tensor<1, spacedim>>>
+        &vertex_to_cell_centers,
+      const typename MeshType<dim, spacedim>::active_cell_iterator &cell_hint =
+        typename MeshType<dim, spacedim>::active_cell_iterator(),
+      const std::vector<bool> &marked_vertices = {},
+      const RTree<std::pair<Point<spacedim>, unsigned int>> &
+        used_vertices_rtree = RTree<std::pair<Point<spacedim>, unsigned int>>{},
+      const double tolerance = 1.e-10,
+      const RTree<
+        std::pair<BoundingBox<spacedim>,
+                  typename Triangulation<dim, spacedim>::active_cell_iterator>>
+        *relevant_cell_bounding_boxes_rtree = nullptr);
 
   /**
    * As compared to the functions above, this function identifies all active
@@ -1633,6 +1647,8 @@ namespace GridTools
    * @endcode
    */
   template <int dim, template <int, int> class MeshType, int spacedim>
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
 #ifndef _MSC_VER
   std::vector<std::pair<typename MeshType<dim, spacedim>::active_cell_iterator,
                         Point<dim>>>
@@ -1642,13 +1658,13 @@ namespace GridTools
       ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim>>::type,
     Point<dim>>>
 #endif
-  find_all_active_cells_around_point(
-    const Mapping<dim, spacedim> & mapping,
-    const MeshType<dim, spacedim> &mesh,
-    const Point<spacedim> &        p,
-    const double                   tolerance,
-    const std::pair<typename MeshType<dim, spacedim>::active_cell_iterator,
-                    Point<dim>> &  first_cell);
+    find_all_active_cells_around_point(
+      const Mapping<dim, spacedim> & mapping,
+      const MeshType<dim, spacedim> &mesh,
+      const Point<spacedim> &        p,
+      const double                   tolerance,
+      const std::pair<typename MeshType<dim, spacedim>::active_cell_iterator,
+                      Point<dim>> &  first_cell);
 
   /**
    * A variant of the previous function that internally calls one of the
@@ -1657,6 +1673,8 @@ namespace GridTools
    * function find_all_active_cells_around_point() above.
    */
   template <int dim, template <int, int> class MeshType, int spacedim>
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
 #ifndef _MSC_VER
   std::vector<std::pair<typename MeshType<dim, spacedim>::active_cell_iterator,
                         Point<dim>>>
@@ -1666,12 +1684,12 @@ namespace GridTools
       ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim>>::type,
     Point<dim>>>
 #endif
-  find_all_active_cells_around_point(
-    const Mapping<dim, spacedim> & mapping,
-    const MeshType<dim, spacedim> &mesh,
-    const Point<spacedim> &        p,
-    const double                   tolerance       = 1e-10,
-    const std::vector<bool> &      marked_vertices = {});
+    find_all_active_cells_around_point(
+      const Mapping<dim, spacedim> & mapping,
+      const MeshType<dim, spacedim> &mesh,
+      const Point<spacedim> &        p,
+      const double                   tolerance       = 1e-10,
+      const std::vector<bool> &      marked_vertices = {});
 
   /**
    * Return a list of all descendants of the given cell that are active. For
@@ -1695,8 +1713,9 @@ namespace GridTools
    * @endcode
    */
   template <class MeshType>
-  std::vector<typename MeshType::active_cell_iterator>
-  get_active_child_cells(const typename MeshType::cell_iterator &cell);
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  std::vector<typename MeshType::active_cell_iterator> get_active_child_cells(
+    const typename MeshType::cell_iterator &cell);
 
   /**
    * Extract the active cells around a given cell @p cell and return them in
@@ -1723,8 +1742,8 @@ namespace GridTools
    * @endcode
    */
   template <class MeshType>
-  void
-  get_active_neighbors(
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  void get_active_neighbors(
     const typename MeshType::active_cell_iterator &       cell,
     std::vector<typename MeshType::active_cell_iterator> &active_neighbors);
 
@@ -1778,11 +1797,12 @@ namespace GridTools
    * the predicated subdomain.
    */
   template <class MeshType>
-  std::vector<typename MeshType::active_cell_iterator>
-  compute_active_cell_halo_layer(
-    const MeshType &mesh,
-    const std::function<bool(const typename MeshType::active_cell_iterator &)>
-      &predicate);
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  std::
+    vector<typename MeshType::active_cell_iterator> compute_active_cell_halo_layer(
+      const MeshType &mesh,
+      const std::function<bool(const typename MeshType::active_cell_iterator &)>
+        &predicate);
 
 
   /**
@@ -1793,12 +1813,13 @@ namespace GridTools
    * all of those cells for which the @p predicate returns @p true.
    */
   template <class MeshType>
-  std::vector<typename MeshType::cell_iterator>
-  compute_cell_halo_layer_on_level(
-    const MeshType &mesh,
-    const std::function<bool(const typename MeshType::cell_iterator &)>
-      &                predicate,
-    const unsigned int level);
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  std::
+    vector<typename MeshType::cell_iterator> compute_cell_halo_layer_on_level(
+      const MeshType &mesh,
+      const std::function<bool(const typename MeshType::cell_iterator &)>
+        &                predicate,
+      const unsigned int level);
 
 
   /**
@@ -1814,8 +1835,10 @@ namespace GridTools
    * @return A list of ghost cells
    */
   template <class MeshType>
-  std::vector<typename MeshType::active_cell_iterator>
-  compute_ghost_cell_halo_layer(const MeshType &mesh);
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  std::vector<
+    typename MeshType::
+      active_cell_iterator> compute_ghost_cell_halo_layer(const MeshType &mesh);
 
   /**
    * Extract and return the set of active cells within a geometric distance of
@@ -1866,12 +1889,13 @@ namespace GridTools
    * See compute_active_cell_halo_layer().
    */
   template <class MeshType>
-  std::vector<typename MeshType::active_cell_iterator>
-  compute_active_cell_layer_within_distance(
-    const MeshType &mesh,
-    const std::function<bool(const typename MeshType::active_cell_iterator &)>
-      &          predicate,
-    const double layer_thickness);
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  std::
+    vector<typename MeshType::active_cell_iterator> compute_active_cell_layer_within_distance(
+      const MeshType &mesh,
+      const std::function<bool(const typename MeshType::active_cell_iterator &)>
+        &          predicate,
+      const double layer_thickness);
 
   /**
    * Extract and return a set of ghost cells which are within a
@@ -1896,9 +1920,11 @@ namespace GridTools
    * compute_active_cell_layer_within_distance().
    */
   template <class MeshType>
-  std::vector<typename MeshType::active_cell_iterator>
-  compute_ghost_cell_layer_within_distance(const MeshType &mesh,
-                                           const double    layer_thickness);
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  std::
+    vector<typename MeshType::active_cell_iterator> compute_ghost_cell_layer_within_distance(
+      const MeshType &mesh,
+      const double    layer_thickness);
 
   /**
    * Compute and return a bounding box, defined through a pair of points
@@ -1916,11 +1942,15 @@ namespace GridTools
    * to a BoundingBox object.
    */
   template <class MeshType>
-  std::pair<Point<MeshType::space_dimension>, Point<MeshType::space_dimension>>
-  compute_bounding_box(
-    const MeshType &mesh,
-    const std::function<bool(const typename MeshType::active_cell_iterator &)>
-      &predicate);
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  std::pair<
+    Point<MeshType::space_dimension>,
+    Point<MeshType::
+            space_dimension>> compute_bounding_box(const MeshType &mesh,
+                                                   const std::function<bool(
+                                                     const typename MeshType::
+                                                       active_cell_iterator &)>
+                                                     &predicate);
 
   /**
    * Compute a collection of bounding boxes so that all active cells for which
@@ -1993,14 +2023,15 @@ namespace GridTools
    * linear.
    */
   template <class MeshType>
-  std::vector<BoundingBox<MeshType::space_dimension>>
-  compute_mesh_predicate_bounding_box(
-    const MeshType &mesh,
-    const std::function<bool(const typename MeshType::active_cell_iterator &)>
-      &                predicate,
-    const unsigned int refinement_level = 0,
-    const bool         allow_merge      = false,
-    const unsigned int max_boxes        = numbers::invalid_unsigned_int);
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  std::
+    vector<BoundingBox<MeshType::space_dimension>> compute_mesh_predicate_bounding_box(
+      const MeshType &mesh,
+      const std::function<bool(const typename MeshType::active_cell_iterator &)>
+        &                predicate,
+      const unsigned int refinement_level = 0,
+      const bool         allow_merge      = false,
+      const unsigned int max_boxes        = numbers::invalid_unsigned_int);
 
   /**
    * Given an array of points, use the global bounding box description obtained
@@ -2497,9 +2528,13 @@ namespace GridTools
    * stored locally, so the resulting list may not cover the entire domain.
    */
   template <typename MeshType>
-  std::list<std::pair<typename MeshType::cell_iterator,
-                      typename MeshType::cell_iterator>>
-  get_finest_common_cells(const MeshType &mesh_1, const MeshType &mesh_2);
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  std::list<std::pair<
+    typename MeshType::cell_iterator,
+    typename MeshType::cell_iterator>> get_finest_common_cells(const MeshType
+                                                                 &mesh_1,
+                                                               const MeshType
+                                                                 &mesh_2);
 
   /**
    * Return true if the two triangulations are based on the same coarse mesh.
@@ -2525,8 +2560,8 @@ namespace GridTools
    * @ref ConceptMeshType "MeshType concept".
    */
   template <typename MeshType>
-  bool
-  have_same_coarse_mesh(const MeshType &mesh_1, const MeshType &mesh_2);
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  bool have_same_coarse_mesh(const MeshType &mesh_1, const MeshType &mesh_2);
 
   /** @} */
   /**
@@ -2606,8 +2641,9 @@ namespace GridTools
    * freedom on these.
    */
   template <class MeshType>
-  std::vector<typename MeshType::active_cell_iterator>
-  get_patch_around_cell(const typename MeshType::active_cell_iterator &cell);
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  std::vector<typename MeshType::active_cell_iterator> get_patch_around_cell(
+    const typename MeshType::active_cell_iterator &cell);
 
 
   /**
@@ -2952,8 +2988,8 @@ namespace GridTools
    * or local grid refinement.
    */
   template <typename MeshType>
-  void
-  collect_periodic_faces(
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  void collect_periodic_faces(
     const MeshType &         mesh,
     const types::boundary_id b_id1,
     const types::boundary_id b_id2,
@@ -2988,8 +3024,8 @@ namespace GridTools
    * @ref GlossFaceOrientation "standard orientation".
    */
   template <typename MeshType>
-  void
-  collect_periodic_faces(
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  void collect_periodic_faces(
     const MeshType &         mesh,
     const types::boundary_id b_id,
     const unsigned int       direction,
@@ -3217,8 +3253,8 @@ namespace GridTools
    * data with similar calls as the ones above.)
    */
   template <typename DataType, typename MeshType>
-  void
-  exchange_cell_data_to_ghosts(
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  void exchange_cell_data_to_ghosts(
     const MeshType &                                     mesh,
     const std::function<std_cxx17::optional<DataType>(
       const typename MeshType::active_cell_iterator &)> &pack,
@@ -3239,8 +3275,8 @@ namespace GridTools
    * communicated.
    */
   template <typename DataType, typename MeshType>
-  void
-  exchange_cell_data_to_level_ghosts(
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  void exchange_cell_data_to_level_ghosts(
     const MeshType &                                    mesh,
     const std::function<std_cxx17::optional<DataType>(
       const typename MeshType::level_cell_iterator &)> &pack,
@@ -3795,8 +3831,9 @@ namespace GridTools
 
 
   template <class MeshType>
-  std::vector<typename MeshType::active_cell_iterator>
-  get_active_child_cells(const typename MeshType::cell_iterator &cell)
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  std::vector<typename MeshType::active_cell_iterator> get_active_child_cells(
+    const typename MeshType::cell_iterator &cell)
   {
     std::vector<typename MeshType::active_cell_iterator> child_cells;
 
@@ -3821,8 +3858,8 @@ namespace GridTools
 
 
   template <class MeshType>
-  void
-  get_active_neighbors(
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  void get_active_neighbors(
     const typename MeshType::active_cell_iterator &       cell,
     std::vector<typename MeshType::active_cell_iterator> &active_neighbors)
   {
@@ -4429,8 +4466,8 @@ namespace GridTools
     template <typename DataType,
               typename MeshType,
               typename MeshCellIteratorType>
-    inline void
-    exchange_cell_data(
+    DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+    inline void exchange_cell_data(
       const MeshType &mesh,
       const std::function<
         std_cxx17::optional<DataType>(const MeshCellIteratorType &)> &pack,
@@ -4719,8 +4756,8 @@ namespace GridTools
   } // namespace internal
 
   template <typename DataType, typename MeshType>
-  inline void
-  exchange_cell_data_to_ghosts(
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  inline void exchange_cell_data_to_ghosts(
     const MeshType &                                     mesh,
     const std::function<std_cxx17::optional<DataType>(
       const typename MeshType::active_cell_iterator &)> &pack,
@@ -4755,8 +4792,8 @@ namespace GridTools
 
 
   template <typename DataType, typename MeshType>
-  inline void
-  exchange_cell_data_to_level_ghosts(
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  inline void exchange_cell_data_to_level_ghosts(
     const MeshType &                                    mesh,
     const std::function<std_cxx17::optional<DataType>(
       const typename MeshType::level_cell_iterator &)> &pack,

--- a/include/deal.II/grid/intergrid_map.h
+++ b/include/deal.II/grid/intergrid_map.h
@@ -111,6 +111,7 @@ DEAL_II_NAMESPACE_OPEN
  * @ingroup grid
  */
 template <class MeshType>
+DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
 class InterGridMap : public Subscriptor
 {
 public:

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -253,10 +253,10 @@ namespace internal
   namespace
   {
     template <typename MeshType, typename OPType>
-    void
-    loop_over_active_or_level_cells(const MeshType &   tria,
-                                    const unsigned int level,
-                                    const OPType &     op)
+    DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+    void loop_over_active_or_level_cells(const MeshType &   tria,
+                                         const unsigned int level,
+                                         const OPType &     op)
     {
       if (level == numbers::invalid_unsigned_int)
         {

--- a/include/deal.II/numerics/vector_tools_evaluate.h
+++ b/include/deal.II/numerics/vector_tools_evaluate.h
@@ -137,7 +137,9 @@ namespace VectorTools
             int dim,
             int spacedim,
             typename VectorType>
-  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_dealii_vector_type<VectorType> &&
+     concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
   std::vector<
     typename FEPointEvaluation<n_components,
                                dim,
@@ -173,7 +175,9 @@ namespace VectorTools
             int dim,
             int spacedim,
             typename VectorType>
-  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_dealii_vector_type<VectorType> &&
+     concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
   std::vector<
     typename FEPointEvaluation<n_components,
                                dim,
@@ -203,7 +207,9 @@ namespace VectorTools
             int dim,
             int spacedim,
             typename VectorType>
-  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_dealii_vector_type<VectorType> &&
+     concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
   std::vector<
     typename FEPointEvaluation<n_components,
                                dim,
@@ -239,7 +245,9 @@ namespace VectorTools
             int dim,
             int spacedim,
             typename VectorType>
-  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_dealii_vector_type<VectorType> &&
+     concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
   std::vector<
     typename FEPointEvaluation<n_components,
                                dim,
@@ -267,7 +275,9 @@ namespace VectorTools
             int dim,
             int spacedim,
             typename VectorType>
-  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_dealii_vector_type<VectorType> &&
+     concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
   inline std::vector<
     typename FEPointEvaluation<n_components,
                                dim,
@@ -298,7 +308,9 @@ namespace VectorTools
             int dim,
             int spacedim,
             typename VectorType>
-  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_dealii_vector_type<VectorType> &&
+     concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
   inline std::vector<
     typename FEPointEvaluation<n_components,
                                dim,
@@ -620,7 +632,9 @@ namespace VectorTools
               typename MeshType,
               typename VectorType,
               typename value_type>
-    DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+    DEAL_II_CXX20_REQUIRES(
+      concepts::is_dealii_vector_type<VectorType>
+        &&concepts::is_triangulation_or_dof_handler<MeshType>)
     inline std::vector<value_type> evaluate_at_points(
       const Utilities::MPI::RemotePointEvaluation<dim, spacedim> &cache,
       const MeshType &                                            mesh,
@@ -726,7 +740,9 @@ namespace VectorTools
             int dim,
             int spacedim,
             typename VectorType>
-  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_dealii_vector_type<VectorType> &&
+     concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
   inline std::vector<
     typename FEPointEvaluation<n_components,
                                dim,
@@ -769,7 +785,9 @@ namespace VectorTools
             int dim,
             int spacedim,
             typename VectorType>
-  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_dealii_vector_type<VectorType> &&
+     concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
   inline std::vector<
     typename FEPointEvaluation<n_components,
                                dim,

--- a/include/deal.II/numerics/vector_tools_interpolate.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.h
@@ -36,6 +36,7 @@ class FullMatrix;
 template <int dim, typename Number>
 class Function;
 template <class MeshType>
+DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
 class InterGridMap;
 template <int dim, int spacedim>
 class Mapping;

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -450,7 +450,7 @@ namespace parallel
     // 4) determine the global indices of ghost cells
     std::vector<types::global_dof_index> is_ghost_vector;
     GridTools::exchange_cell_data_to_ghosts<types::global_cell_index>(
-      *this,
+      static_cast<dealii::Triangulation<dim, spacedim> &>(*this),
       [](const auto &cell) { return cell->global_active_cell_index(); },
       [&is_ghost_vector](const auto &cell, const auto &id) {
         cell->set_global_active_cell_index(id);
@@ -595,10 +595,15 @@ namespace parallel
 
     if (this->is_multilevel_hierarchy_constructed())
       GridTools::exchange_cell_data_to_level_ghosts<
-        std::vector<Point<spacedim>>>(*this, pack, unpack);
+        std::vector<Point<spacedim>>>(
+        static_cast<dealii::Triangulation<dim, spacedim> &>(*this),
+        pack,
+        unpack);
     else
       GridTools::exchange_cell_data_to_ghosts<std::vector<Point<spacedim>>>(
-        *this, pack, unpack);
+        static_cast<dealii::Triangulation<dim, spacedim> &>(*this),
+        pack,
+        unpack);
   }
 
 

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -8257,15 +8257,17 @@ namespace GridGenerator
 
 
   template <template <int, int> class MeshType, int dim, int spacedim>
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
 #  ifndef _MSC_VER
   std::map<typename MeshType<dim - 1, spacedim>::cell_iterator,
            typename MeshType<dim, spacedim>::face_iterator>
 #  else
   typename ExtractBoundaryMesh<MeshType, dim, spacedim>::return_type
 #  endif
-  extract_boundary_mesh(const MeshType<dim, spacedim> &     volume_mesh,
-                        MeshType<dim - 1, spacedim> &       surface_mesh,
-                        const std::set<types::boundary_id> &boundary_ids)
+    extract_boundary_mesh(const MeshType<dim, spacedim> &     volume_mesh,
+                          MeshType<dim - 1, spacedim> &       surface_mesh,
+                          const std::set<types::boundary_id> &boundary_ids)
   {
     Assert((dynamic_cast<
               const parallel::distributed::Triangulation<dim, spacedim> *>(

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -2598,10 +2598,11 @@ namespace GridTools
 
 
   template <int dim, template <int, int> class MeshType, int spacedim>
-  unsigned int
-  find_closest_vertex(const MeshType<dim, spacedim> &mesh,
-                      const Point<spacedim> &        p,
-                      const std::vector<bool> &      marked_vertices)
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
+  unsigned int find_closest_vertex(const MeshType<dim, spacedim> &mesh,
+                                   const Point<spacedim> &        p,
+                                   const std::vector<bool> &marked_vertices)
   {
     // first get the underlying triangulation from the mesh and determine
     // vertices and used vertices
@@ -2664,11 +2665,12 @@ namespace GridTools
 
 
   template <int dim, template <int, int> class MeshType, int spacedim>
-  unsigned int
-  find_closest_vertex(const Mapping<dim, spacedim> & mapping,
-                      const MeshType<dim, spacedim> &mesh,
-                      const Point<spacedim> &        p,
-                      const std::vector<bool> &      marked_vertices)
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
+  unsigned int find_closest_vertex(const Mapping<dim, spacedim> & mapping,
+                                   const MeshType<dim, spacedim> &mesh,
+                                   const Point<spacedim> &        p,
+                                   const std::vector<bool> &marked_vertices)
   {
     // Take a shortcut in the simple case.
     if (mapping.preserves_vertex_locations() == true)
@@ -2720,6 +2722,8 @@ namespace GridTools
 
 
   template <int dim, template <int, int> class MeshType, int spacedim>
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
 #ifndef _MSC_VER
   std::vector<typename MeshType<dim, spacedim>::active_cell_iterator>
 #else
@@ -2727,8 +2731,8 @@ namespace GridTools
     typename dealii::internal::
       ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim>>::type>
 #endif
-  find_cells_adjacent_to_vertex(const MeshType<dim, spacedim> &mesh,
-                                const unsigned int             vertex)
+    find_cells_adjacent_to_vertex(const MeshType<dim, spacedim> &mesh,
+                                  const unsigned int             vertex)
   {
     // make sure that the given vertex is
     // an active vertex of the underlying
@@ -2911,6 +2915,8 @@ namespace GridTools
   } // namespace internal
 
   template <int dim, template <int, int> class MeshType, int spacedim>
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
 #ifndef _MSC_VER
   std::pair<typename MeshType<dim, spacedim>::active_cell_iterator, Point<dim>>
 #else
@@ -2918,22 +2924,24 @@ namespace GridTools
               ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim>>::type,
             Point<dim>>
 #endif
-  find_active_cell_around_point(
-    const Mapping<dim, spacedim> & mapping,
-    const MeshType<dim, spacedim> &mesh,
-    const Point<spacedim> &        p,
-    const std::vector<
-      std::set<typename MeshType<dim, spacedim>::active_cell_iterator>>
-      &                                                  vertex_to_cells,
-    const std::vector<std::vector<Tensor<1, spacedim>>> &vertex_to_cell_centers,
-    const typename MeshType<dim, spacedim>::active_cell_iterator &cell_hint,
-    const std::vector<bool> &                              marked_vertices,
-    const RTree<std::pair<Point<spacedim>, unsigned int>> &used_vertices_rtree,
-    const double                                           tolerance,
-    const RTree<
-      std::pair<BoundingBox<spacedim>,
-                typename Triangulation<dim, spacedim>::active_cell_iterator>>
-      *relevant_cell_bounding_boxes_rtree)
+    find_active_cell_around_point(
+      const Mapping<dim, spacedim> & mapping,
+      const MeshType<dim, spacedim> &mesh,
+      const Point<spacedim> &        p,
+      const std::vector<
+        std::set<typename MeshType<dim, spacedim>::active_cell_iterator>>
+        &vertex_to_cells,
+      const std::vector<std::vector<Tensor<1, spacedim>>>
+        &vertex_to_cell_centers,
+      const typename MeshType<dim, spacedim>::active_cell_iterator &cell_hint,
+      const std::vector<bool> &marked_vertices,
+      const RTree<std::pair<Point<spacedim>, unsigned int>>
+        &          used_vertices_rtree,
+      const double tolerance,
+      const RTree<
+        std::pair<BoundingBox<spacedim>,
+                  typename Triangulation<dim, spacedim>::active_cell_iterator>>
+        *relevant_cell_bounding_boxes_rtree)
   {
     std::pair<typename MeshType<dim, spacedim>::active_cell_iterator,
               Point<dim>>
@@ -3206,11 +3214,16 @@ namespace GridTools
     namespace BoundingBoxPredicate
     {
       template <class MeshType>
-      std::tuple<BoundingBox<MeshType::space_dimension>, bool>
-      compute_cell_predicate_bounding_box(
-        const typename MeshType::cell_iterator &parent_cell,
-        const std::function<
-          bool(const typename MeshType::active_cell_iterator &)> &predicate)
+      DEAL_II_CXX20_REQUIRES(
+        concepts::is_triangulation_or_dof_handler<MeshType>)
+      std::tuple<
+        BoundingBox<MeshType::space_dimension>,
+        bool> compute_cell_predicate_bounding_box(const typename MeshType::
+                                                    cell_iterator &parent_cell,
+                                                  const std::function<bool(
+                                                    const typename MeshType::
+                                                      active_cell_iterator &)>
+                                                    &predicate)
       {
         bool has_predicate =
           false; // Start assuming there's no cells with predicate inside
@@ -3259,14 +3272,15 @@ namespace GridTools
 
 
   template <class MeshType>
-  std::vector<BoundingBox<MeshType::space_dimension>>
-  compute_mesh_predicate_bounding_box(
-    const MeshType &mesh,
-    const std::function<bool(const typename MeshType::active_cell_iterator &)>
-      &                predicate,
-    const unsigned int refinement_level,
-    const bool         allow_merge,
-    const unsigned int max_boxes)
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  std::
+    vector<BoundingBox<MeshType::space_dimension>> compute_mesh_predicate_bounding_box(
+      const MeshType &mesh,
+      const std::function<bool(const typename MeshType::active_cell_iterator &)>
+        &                predicate,
+      const unsigned int refinement_level,
+      const bool         allow_merge,
+      const unsigned int max_boxes)
   {
     // Algorithm brief description: begin with creating bounding boxes of all
     // cells at refinement_level (and coarser levels if there are active cells)

--- a/source/grid/grid_tools_dof_handlers.cc
+++ b/source/grid/grid_tools_dof_handlers.cc
@@ -52,10 +52,11 @@ DEAL_II_NAMESPACE_OPEN
 namespace GridTools
 {
   template <int dim, template <int, int> class MeshType, int spacedim>
-  unsigned int
-  find_closest_vertex(const MeshType<dim, spacedim> &mesh,
-                      const Point<spacedim> &        p,
-                      const std::vector<bool> &      marked_vertices)
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
+  unsigned int find_closest_vertex(const MeshType<dim, spacedim> &mesh,
+                                   const Point<spacedim> &        p,
+                                   const std::vector<bool> &marked_vertices)
   {
     // first get the underlying
     // triangulation from the
@@ -128,11 +129,12 @@ namespace GridTools
 
 
   template <int dim, template <int, int> class MeshType, int spacedim>
-  unsigned int
-  find_closest_vertex(const Mapping<dim, spacedim> & mapping,
-                      const MeshType<dim, spacedim> &mesh,
-                      const Point<spacedim> &        p,
-                      const std::vector<bool> &      marked_vertices)
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
+  unsigned int find_closest_vertex(const Mapping<dim, spacedim> & mapping,
+                                   const MeshType<dim, spacedim> &mesh,
+                                   const Point<spacedim> &        p,
+                                   const std::vector<bool> &marked_vertices)
   {
     // Take a shortcut in the simple case.
     if (mapping.preserves_vertex_locations() == true)
@@ -188,6 +190,8 @@ namespace GridTools
 
 
   template <int dim, template <int, int> class MeshType, int spacedim>
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
 #ifndef _MSC_VER
   std::vector<typename MeshType<dim, spacedim>::active_cell_iterator>
 #else
@@ -195,8 +199,8 @@ namespace GridTools
     typename dealii::internal::
       ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim>>::type>
 #endif
-  find_cells_adjacent_to_vertex(const MeshType<dim, spacedim> &mesh,
-                                const unsigned int             vertex)
+    find_cells_adjacent_to_vertex(const MeshType<dim, spacedim> &mesh,
+                                  const unsigned int             vertex)
   {
     // make sure that the given vertex is
     // an active vertex of the underlying
@@ -329,8 +333,9 @@ namespace GridTools
   namespace
   {
     template <int dim, template <int, int> class MeshType, int spacedim>
-    void
-    find_active_cell_around_point_internal(
+    DEAL_II_CXX20_REQUIRES(
+      (concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
+    void find_active_cell_around_point_internal(
       const MeshType<dim, spacedim> &mesh,
 #ifndef _MSC_VER
       std::set<typename MeshType<dim, spacedim>::active_cell_iterator>
@@ -402,16 +407,18 @@ namespace GridTools
 
 
   template <int dim, template <int, int> class MeshType, int spacedim>
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
 #ifndef _MSC_VER
   typename MeshType<dim, spacedim>::active_cell_iterator
 #else
   typename dealii::internal::
     ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim>>::type
 #endif
-  find_active_cell_around_point(const MeshType<dim, spacedim> &mesh,
-                                const Point<spacedim> &        p,
-                                const std::vector<bool> &      marked_vertices,
-                                const double                   tolerance)
+    find_active_cell_around_point(const MeshType<dim, spacedim> &mesh,
+                                  const Point<spacedim> &        p,
+                                  const std::vector<bool> &marked_vertices,
+                                  const double             tolerance)
   {
     return find_active_cell_around_point<dim, MeshType, spacedim>(
              get_default_linear_mapping(mesh.get_triangulation()),
@@ -425,6 +432,8 @@ namespace GridTools
 
 
   template <int dim, template <int, int> class MeshType, int spacedim>
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
 #ifndef _MSC_VER
   std::pair<typename MeshType<dim, spacedim>::active_cell_iterator, Point<dim>>
 #else
@@ -432,11 +441,11 @@ namespace GridTools
               ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim>>::type,
             Point<dim>>
 #endif
-  find_active_cell_around_point(const Mapping<dim, spacedim> & mapping,
-                                const MeshType<dim, spacedim> &mesh,
-                                const Point<spacedim> &        p,
-                                const std::vector<bool> &      marked_vertices,
-                                const double                   tolerance)
+    find_active_cell_around_point(const Mapping<dim, spacedim> & mapping,
+                                  const MeshType<dim, spacedim> &mesh,
+                                  const Point<spacedim> &        p,
+                                  const std::vector<bool> &marked_vertices,
+                                  const double             tolerance)
   {
     using active_cell_iterator = typename dealii::internal::
       ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim>>::type;
@@ -557,6 +566,8 @@ namespace GridTools
 
 
   template <int dim, template <int, int> class MeshType, int spacedim>
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
 #ifndef _MSC_VER
   std::vector<std::pair<typename MeshType<dim, spacedim>::active_cell_iterator,
                         Point<dim>>>
@@ -566,11 +577,11 @@ namespace GridTools
       ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim>>::type,
     Point<dim>>>
 #endif
-  find_all_active_cells_around_point(const Mapping<dim, spacedim> & mapping,
-                                     const MeshType<dim, spacedim> &mesh,
-                                     const Point<spacedim> &        p,
-                                     const double                   tolerance,
-                                     const std::vector<bool> &marked_vertices)
+    find_all_active_cells_around_point(const Mapping<dim, spacedim> & mapping,
+                                       const MeshType<dim, spacedim> &mesh,
+                                       const Point<spacedim> &        p,
+                                       const double                   tolerance,
+                                       const std::vector<bool> &marked_vertices)
   {
     const auto cell_and_point = find_active_cell_around_point(
       mapping, mesh, p, marked_vertices, tolerance);
@@ -585,6 +596,8 @@ namespace GridTools
 
 
   template <int dim, template <int, int> class MeshType, int spacedim>
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>))
 #ifndef _MSC_VER
   std::vector<std::pair<typename MeshType<dim, spacedim>::active_cell_iterator,
                         Point<dim>>>
@@ -594,13 +607,13 @@ namespace GridTools
       ActiveCellIterator<dim, spacedim, MeshType<dim, spacedim>>::type,
     Point<dim>>>
 #endif
-  find_all_active_cells_around_point(
-    const Mapping<dim, spacedim> & mapping,
-    const MeshType<dim, spacedim> &mesh,
-    const Point<spacedim> &        p,
-    const double                   tolerance,
-    const std::pair<typename MeshType<dim, spacedim>::active_cell_iterator,
-                    Point<dim>> &  first_cell)
+    find_all_active_cells_around_point(
+      const Mapping<dim, spacedim> & mapping,
+      const MeshType<dim, spacedim> &mesh,
+      const Point<spacedim> &        p,
+      const double                   tolerance,
+      const std::pair<typename MeshType<dim, spacedim>::active_cell_iterator,
+                      Point<dim>> &  first_cell)
   {
     std::vector<
       std::pair<typename MeshType<dim, spacedim>::active_cell_iterator,
@@ -746,11 +759,12 @@ namespace GridTools
 
 
   template <class MeshType>
-  std::vector<typename MeshType::active_cell_iterator>
-  compute_active_cell_halo_layer(
-    const MeshType &mesh,
-    const std::function<bool(const typename MeshType::active_cell_iterator &)>
-      &predicate)
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  std::
+    vector<typename MeshType::active_cell_iterator> compute_active_cell_halo_layer(
+      const MeshType &mesh,
+      const std::function<bool(const typename MeshType::active_cell_iterator &)>
+        &predicate)
   {
     std::vector<typename MeshType::active_cell_iterator> active_halo_layer;
     std::vector<bool> locally_active_vertices_on_subdomain(
@@ -783,12 +797,13 @@ namespace GridTools
 
 
   template <class MeshType>
-  std::vector<typename MeshType::cell_iterator>
-  compute_cell_halo_layer_on_level(
-    const MeshType &mesh,
-    const std::function<bool(const typename MeshType::cell_iterator &)>
-      &                predicate,
-    const unsigned int level)
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  std::
+    vector<typename MeshType::cell_iterator> compute_cell_halo_layer_on_level(
+      const MeshType &mesh,
+      const std::function<bool(const typename MeshType::cell_iterator &)>
+        &                predicate,
+      const unsigned int level)
   {
     std::vector<typename MeshType::cell_iterator> level_halo_layer;
     std::vector<bool> locally_active_vertices_on_level_subdomain(
@@ -827,8 +842,8 @@ namespace GridTools
   namespace
   {
     template <class MeshType>
-    bool
-    contains_locally_owned_cells(
+    DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+    bool contains_locally_owned_cells(
       const std::vector<typename MeshType::active_cell_iterator> &cells)
     {
       for (typename std::vector<
@@ -844,8 +859,8 @@ namespace GridTools
     }
 
     template <class MeshType>
-    bool
-    contains_artificial_cells(
+    DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+    bool contains_artificial_cells(
       const std::vector<typename MeshType::active_cell_iterator> &cells)
     {
       for (typename std::vector<
@@ -864,8 +879,10 @@ namespace GridTools
 
 
   template <class MeshType>
-  std::vector<typename MeshType::active_cell_iterator>
-  compute_ghost_cell_halo_layer(const MeshType &mesh)
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  std::vector<
+    typename MeshType::
+      active_cell_iterator> compute_ghost_cell_halo_layer(const MeshType &mesh)
   {
     std::function<bool(const typename MeshType::active_cell_iterator &)>
       predicate = IteratorFilters::LocallyOwnedCell();
@@ -886,12 +903,13 @@ namespace GridTools
 
 
   template <class MeshType>
-  std::vector<typename MeshType::active_cell_iterator>
-  compute_active_cell_layer_within_distance(
-    const MeshType &mesh,
-    const std::function<bool(const typename MeshType::active_cell_iterator &)>
-      &          predicate,
-    const double layer_thickness)
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  std::
+    vector<typename MeshType::active_cell_iterator> compute_active_cell_layer_within_distance(
+      const MeshType &mesh,
+      const std::function<bool(const typename MeshType::active_cell_iterator &)>
+        &          predicate,
+      const double layer_thickness)
   {
     std::vector<typename MeshType::active_cell_iterator>
       subdomain_boundary_cells, active_cell_layer_within_distance;
@@ -1030,9 +1048,13 @@ namespace GridTools
 
 
   template <class MeshType>
-  std::vector<typename MeshType::active_cell_iterator>
-  compute_ghost_cell_layer_within_distance(const MeshType &mesh,
-                                           const double    layer_thickness)
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  std::vector<
+    typename MeshType::
+      active_cell_iterator> compute_ghost_cell_layer_within_distance(const MeshType
+                                                                       &mesh,
+                                                                     const double
+                                                                       layer_thickness)
   {
     IteratorFilters::LocallyOwnedCell locally_owned_cell_predicate;
     std::function<bool(const typename MeshType::active_cell_iterator &)>
@@ -1066,11 +1088,15 @@ namespace GridTools
 
 
   template <class MeshType>
-  std::pair<Point<MeshType::space_dimension>, Point<MeshType::space_dimension>>
-  compute_bounding_box(
-    const MeshType &mesh,
-    const std::function<bool(const typename MeshType::active_cell_iterator &)>
-      &predicate)
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  std::pair<
+    Point<MeshType::space_dimension>,
+    Point<MeshType::
+            space_dimension>> compute_bounding_box(const MeshType &mesh,
+                                                   const std::function<bool(
+                                                     const typename MeshType::
+                                                       active_cell_iterator &)>
+                                                     &predicate)
   {
     std::vector<bool> locally_active_vertices_on_subdomain(
       mesh.get_triangulation().n_vertices(), false);
@@ -1113,9 +1139,13 @@ namespace GridTools
 
 
   template <typename MeshType>
-  std::list<std::pair<typename MeshType::cell_iterator,
-                      typename MeshType::cell_iterator>>
-  get_finest_common_cells(const MeshType &mesh_1, const MeshType &mesh_2)
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  std::list<std::pair<
+    typename MeshType::cell_iterator,
+    typename MeshType::cell_iterator>> get_finest_common_cells(const MeshType
+                                                                 &mesh_1,
+                                                               const MeshType
+                                                                 &mesh_2)
   {
     Assert(have_same_coarse_mesh(mesh_1, mesh_2),
            ExcMessage("The two meshes must be represent triangulations that "
@@ -1255,8 +1285,8 @@ namespace GridTools
 
 
   template <typename MeshType>
-  bool
-  have_same_coarse_mesh(const MeshType &mesh_1, const MeshType &mesh_2)
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  bool have_same_coarse_mesh(const MeshType &mesh_1, const MeshType &mesh_2)
   {
     return have_same_coarse_mesh(mesh_1.get_triangulation(),
                                  mesh_2.get_triangulation());
@@ -1396,8 +1426,9 @@ namespace GridTools
 
 
   template <class MeshType>
-  std::vector<typename MeshType::active_cell_iterator>
-  get_patch_around_cell(const typename MeshType::active_cell_iterator &cell)
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  std::vector<typename MeshType::active_cell_iterator> get_patch_around_cell(
+    const typename MeshType::active_cell_iterator &cell)
   {
     Assert(cell->is_locally_owned(),
            ExcMessage("This function only makes sense if the cell for "
@@ -2115,8 +2146,8 @@ namespace GridTools
 
 
   template <typename MeshType>
-  void
-  collect_periodic_faces(
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  void collect_periodic_faces(
     const MeshType &         mesh,
     const types::boundary_id b_id,
     const unsigned int       direction,
@@ -2196,8 +2227,8 @@ namespace GridTools
 
 
   template <typename MeshType>
-  void
-  collect_periodic_faces(
+  DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+  void collect_periodic_faces(
     const MeshType &         mesh,
     const types::boundary_id b_id1,
     const types::boundary_id b_id2,

--- a/source/grid/intergrid_map.cc
+++ b/source/grid/intergrid_map.cc
@@ -34,6 +34,7 @@ DEAL_II_NAMESPACE_OPEN
 
 
 template <class MeshType>
+DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
 InterGridMap<MeshType>::InterGridMap()
   : source_grid(nullptr, typeid(*this).name())
   , destination_grid(nullptr, typeid(*this).name())
@@ -42,9 +43,9 @@ InterGridMap<MeshType>::InterGridMap()
 
 
 template <class MeshType>
-void
-InterGridMap<MeshType>::make_mapping(const MeshType &source_grid,
-                                     const MeshType &destination_grid)
+DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+void InterGridMap<MeshType>::make_mapping(const MeshType &source_grid,
+                                          const MeshType &destination_grid)
 {
   // first delete all contents
   clear();
@@ -98,9 +99,9 @@ InterGridMap<MeshType>::make_mapping(const MeshType &source_grid,
 
 
 template <class MeshType>
-void
-InterGridMap<MeshType>::set_mapping(const cell_iterator &src_cell,
-                                    const cell_iterator &dst_cell)
+DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+void InterGridMap<MeshType>::set_mapping(const cell_iterator &src_cell,
+                                         const cell_iterator &dst_cell)
 {
   // first set the map for this cell
   mapping[src_cell->level()][src_cell->index()] = dst_cell;
@@ -137,9 +138,9 @@ InterGridMap<MeshType>::set_mapping(const cell_iterator &src_cell,
 
 
 template <class MeshType>
-void
-InterGridMap<MeshType>::set_entries_to_cell(const cell_iterator &src_cell,
-                                            const cell_iterator &dst_cell)
+DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+void InterGridMap<MeshType>::set_entries_to_cell(const cell_iterator &src_cell,
+                                                 const cell_iterator &dst_cell)
 {
   // first set the map for this cell
   mapping[src_cell->level()][src_cell->index()] = dst_cell;
@@ -153,8 +154,9 @@ InterGridMap<MeshType>::set_entries_to_cell(const cell_iterator &src_cell,
 
 
 template <class MeshType>
+DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
 typename InterGridMap<MeshType>::cell_iterator
-InterGridMap<MeshType>::operator[](const cell_iterator &source_cell) const
+  InterGridMap<MeshType>::operator[](const cell_iterator &source_cell) const
 {
   Assert(source_cell.state() == IteratorState::valid,
          ExcInvalidKey(source_cell));
@@ -170,8 +172,8 @@ InterGridMap<MeshType>::operator[](const cell_iterator &source_cell) const
 
 
 template <class MeshType>
-void
-InterGridMap<MeshType>::clear()
+DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+void InterGridMap<MeshType>::clear()
 {
   mapping.clear();
   source_grid      = nullptr;
@@ -181,8 +183,8 @@ InterGridMap<MeshType>::clear()
 
 
 template <class MeshType>
-const MeshType &
-InterGridMap<MeshType>::get_source_grid() const
+DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+const MeshType &InterGridMap<MeshType>::get_source_grid() const
 {
   return *source_grid;
 }
@@ -190,8 +192,8 @@ InterGridMap<MeshType>::get_source_grid() const
 
 
 template <class MeshType>
-const MeshType &
-InterGridMap<MeshType>::get_destination_grid() const
+DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+const MeshType &InterGridMap<MeshType>::get_destination_grid() const
 {
   return *destination_grid;
 }
@@ -199,8 +201,8 @@ InterGridMap<MeshType>::get_destination_grid() const
 
 
 template <class MeshType>
-std::size_t
-InterGridMap<MeshType>::memory_consumption() const
+DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
+std::size_t InterGridMap<MeshType>::memory_consumption() const
 {
   return (MemoryConsumption::memory_consumption(mapping) +
           MemoryConsumption::memory_consumption(source_grid) +


### PR DESCRIPTION
Next step for #14840. We have plenty of places with `template <class MeshType>` where `MeshType` is a triangulation or DoFHandler. This patch ensures that the function cannot be called with anything else.

/rebuild