### PR TITLE
Allow external initialization of MPI and p4est

### DIFF
--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -1131,7 +1131,8 @@ namespace Utilities
       MPI_InitFinalize(
         int &              argc,
         char **&           argv,
-        const unsigned int max_num_threads = numbers::invalid_unsigned_int);
+        const unsigned int max_num_threads = numbers::invalid_unsigned_int,
+        const bool         allow_external_initialization_ = false);
 
       /**
        * Destructor. Calls <tt>MPI_Finalize()</tt> in case this class owns the
@@ -1206,8 +1207,18 @@ namespace Utilities
        */
       static std::set<MPI_Request *> requests;
 
+      bool allow_external_initialization = false;
+
 #ifdef DEAL_II_WITH_PETSC
       bool finalize_petscslepc;
+#endif
+
+#ifdef DEAL_II_WITH_MPI
+      bool finalize_mpi = true;
+#endif
+
+#ifdef DEAL_II_WITH_P4EST
+      bool finalize_sc = true;
 #endif
     };
 

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -737,7 +737,9 @@ namespace Utilities
 
     MPI_InitFinalize::MPI_InitFinalize(int &              argc,
                                        char **&           argv,
-                                       const unsigned int max_num_threads)
+                                       const unsigned int max_num_threads,
+                                       const bool         allow_external_initialization_)
+      : allow_external_initialization(allow_external_initialization_)
     {
       static bool constructor_has_already_run = false;
       (void)constructor_has_already_run;
@@ -753,17 +755,25 @@ namespace Utilities
       int MPI_has_been_started = 0;
       ierr                     = MPI_Initialized(&MPI_has_been_started);
       AssertThrowMPI(ierr);
-      AssertThrow(MPI_has_been_started == 0,
-                  ExcMessage("MPI error. You can only start MPI once!"));
 
-      int provided;
-      // this works like ierr = MPI_Init (&argc, &argv); but tells MPI that
-      // we might use several threads but never call two MPI functions at the
-      // same time. For an explanation see on why we do this see
-      // http://www.open-mpi.org/community/lists/users/2010/03/12244.php
-      int wanted = MPI_THREAD_SERIALIZED;
-      ierr       = MPI_Init_thread(&argc, &argv, wanted, &provided);
-      AssertThrowMPI(ierr);
+      if (MPI_has_been_started == 1 && allow_external_initialization)
+        {
+          finalize_mpi = false;
+        }
+      else
+        {
+          AssertThrow(MPI_has_been_started == 0,
+                      ExcMessage("MPI error. You can only start MPI once!"));
+
+          int provided;
+          // this works like ierr = MPI_Init (&argc, &argv); but tells MPI that
+          // we might use several threads but never call two MPI functions at the
+          // same time. For an explanation see on why we do this see
+          // http://www.open-mpi.org/community/lists/users/2010/03/12244.php
+          int wanted = MPI_THREAD_SERIALIZED;
+          ierr       = MPI_Init_thread(&argc, &argv, wanted, &provided);
+          AssertThrowMPI(ierr);
+        }
 
       // disable for now because at least some implementations always return
       // MPI_THREAD_SINGLE.
@@ -834,9 +844,19 @@ namespace Utilities
       // MPI_Comm_create_group (see cburstedde/p4est#30).
       // Disabling it leads to more verbose p4est error messages
       // which should be fine.
-      sc_init(MPI_COMM_WORLD, 0, 0, nullptr, SC_LP_SILENT);
+      if (sc_package_id >= 0 && allow_external_initialization)
+        {
+          finalize_sc = false;
+        }
+      else
+        {
+          sc_init(MPI_COMM_WORLD, 0, 0, nullptr, SC_LP_SILENT);
+        }
 #  endif
-      p4est_init(nullptr, SC_LP_SILENT);
+      if (p4est_package_id < 0 || !allow_external_initialization)
+        {
+          p4est_init(nullptr, SC_LP_SILENT);
+        }
 #endif
 
       constructor_has_already_run = true;
@@ -1011,7 +1031,10 @@ namespace Utilities
 #ifdef DEAL_II_WITH_P4EST
       // now end p4est and libsc
       // Note: p4est has no finalize function
-      sc_finalize();
+      if (finalize_sc)
+        {
+          sc_finalize();
+        }
 #endif
 
 
@@ -1035,9 +1058,12 @@ namespace Utilities
             }
           else
             {
-              const int ierr = MPI_Finalize();
-              (void)ierr;
-              AssertNothrow(ierr == MPI_SUCCESS, dealii::ExcMPI(ierr));
+              if (finalize_mpi)
+                {
+                  const int ierr = MPI_Finalize();
+                  (void)ierr;
+                  AssertNothrow(ierr == MPI_SUCCESS, dealii::ExcMPI(ierr));
+                }
             }
         }
 #endif


### PR DESCRIPTION
This PR allows some packages, namely MPI and p4est, to be initialized (and finalized) externally. That is, in the constructor for `Utilities::MPI_InitFinalize`, either library is only initialized if it has not already been initialized before. For consistency, if external initialization was detected, finalization in the destructor is also omitted.

The motivation for this proposed change is a joint project with @kronbichler and @ranocha, where we use deal.II as a *library* and not as the main driver of a simulation. Since MPI and p4est are already initialized when deal.II is loaded, we need to be able to switch off the automatic initialization of third-party libraries.

An optional function parameter is added to the constructor of `Utilities::MPI_InitFinalize` that enables the new behavior. By default, everything remains as is, i.e., for existing codes nothing should change and, e.g., an already initialized MPI library will cause an error to be thrown as before.

Please note that I am not an expert on the inner workings of deal.II, and that thus there might be smarter ways to achieve the same effect. Therefore, please view this PR not necessarily as the best possible implementation but rather as a means to get the discussion started.