### PR TITLE
Update doxygen stylesheet to only use a white table.tutorial in light mode

### DIFF
--- a/doc/doxygen/stylesheet.css
+++ b/doc/doxygen/stylesheet.css
@@ -5,12 +5,14 @@
     color: #80ff00;
 }
 
-table.tutorial {
+@media (prefers-color-scheme: light) {
+  table.tutorial {
     color: black;
     border: 1px solid #aaa;
     background-color: #f9f9f9;
     padding: 5px;
     font-size: 95%;
+  }
 }
 div.tutorial {
     color: black;


### PR DESCRIPTION
This wraps `table.tutorial` in `@media (prefers-color-scheme: light) {` and `}` so the bright white table override shown in #14873 doesn't appear in dark mode, resulting in behavior like this image (shown in Firefox with dark mode enabled).

![img](https://user-images.githubusercontent.com/12531152/224878752-bcc04f7a-401a-4c67-8c8c-9393ddcf3ee7.png)

Closes #14873.