### PR TITLE
Fix concepts support for clang++

### DIFF
--- a/include/deal.II/base/point.h
+++ b/include/deal.II/base/point.h
@@ -344,23 +344,24 @@ public:
 // At least clang-3.7 requires us to have a user-defined constructor
 // and we can't use 'Point<dim,Number>::Point () = default' here.
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEVICE
-Point<dim, Number>::Point() // NOLINT
+DEAL_II_CXX20_REQUIRES(dim >= 0)
+inline DEAL_II_HOST_DEVICE Point<dim, Number>::Point() // NOLINT
 {}
 
 
 
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEVICE
-Point<dim, Number>::Point(const Tensor<1, dim, Number> &t)
+DEAL_II_CXX20_REQUIRES(dim >= 0)
+inline DEAL_II_HOST_DEVICE Point<dim, Number>::Point(
+  const Tensor<1, dim, Number> &t)
   : Tensor<1, dim, Number>(t)
 {}
 
 
 
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEVICE
-Point<dim, Number>::Point(const Number x)
+DEAL_II_CXX20_REQUIRES(dim >= 0)
+inline DEAL_II_HOST_DEVICE Point<dim, Number>::Point(const Number x)
 {
   Assert(dim == 1,
          ExcMessage(
@@ -385,8 +386,9 @@ Point<dim, Number>::Point(const Number x)
 
 
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEVICE
-Point<dim, Number>::Point(const Number x, const Number y)
+DEAL_II_CXX20_REQUIRES(dim >= 0)
+inline DEAL_II_HOST_DEVICE Point<dim, Number>::Point(const Number x,
+                                                     const Number y)
 {
   Assert(dim == 2,
          ExcMessage(
@@ -406,8 +408,10 @@ Point<dim, Number>::Point(const Number x, const Number y)
 
 
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEVICE
-Point<dim, Number>::Point(const Number x, const Number y, const Number z)
+DEAL_II_CXX20_REQUIRES(dim >= 0)
+inline DEAL_II_HOST_DEVICE Point<dim, Number>::Point(const Number x,
+                                                     const Number y,
+                                                     const Number z)
 {
   Assert(dim == 3,
          ExcMessage(
@@ -429,6 +433,7 @@ Point<dim, Number>::Point(const Number x, const Number y, const Number z)
 
 
 template <int dim, typename Number>
+DEAL_II_CXX20_REQUIRES(dim >= 0)
 template <std::size_t dummy_dim,
           std::enable_if_t<(dim == dummy_dim) && (dummy_dim != 0), int>>
 inline Point<dim, Number>::Point(
@@ -450,8 +455,9 @@ inline Point<dim, Number>::Point(
 
 
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEVICE Point<dim, Number>
-                           Point<dim, Number>::unit_vector(unsigned int i)
+DEAL_II_CXX20_REQUIRES(dim >= 0)
+inline DEAL_II_HOST_DEVICE Point<dim, Number> Point<dim, Number>::unit_vector(
+  unsigned int i)
 {
   Point<dim, Number> p;
   p[i] = 1.;
@@ -460,8 +466,9 @@ inline DEAL_II_HOST_DEVICE Point<dim, Number>
 
 
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEVICE Number
-Point<dim, Number>::operator()(const unsigned int index) const
+DEAL_II_CXX20_REQUIRES(dim >= 0)
+inline DEAL_II_HOST_DEVICE Number Point<dim, Number>::operator()(
+  const unsigned int index) const
 {
   AssertIndexRange(static_cast<int>(index), dim);
   return this->values[index];
@@ -470,8 +477,9 @@ Point<dim, Number>::operator()(const unsigned int index) const
 
 
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEVICE Number &
-Point<dim, Number>::operator()(const unsigned int index)
+DEAL_II_CXX20_REQUIRES(dim >= 0)
+inline DEAL_II_HOST_DEVICE Number &Point<dim, Number>::operator()(
+  const unsigned int index)
 {
   AssertIndexRange(static_cast<int>(index), dim);
   return this->values[index];
@@ -480,9 +488,10 @@ Point<dim, Number>::operator()(const unsigned int index)
 
 
 template <int dim, typename Number>
+DEAL_II_CXX20_REQUIRES(dim >= 0)
 template <typename OtherNumber>
-inline DEAL_II_ALWAYS_INLINE Point<dim, Number> &
-Point<dim, Number>::operator=(const Tensor<1, dim, OtherNumber> &p)
+inline DEAL_II_ALWAYS_INLINE Point<dim, Number> &Point<dim, Number>::operator=(
+  const Tensor<1, dim, OtherNumber> &p)
 {
   Tensor<1, dim, Number>::operator=(p);
   return *this;
@@ -491,8 +500,9 @@ Point<dim, Number>::operator=(const Tensor<1, dim, OtherNumber> &p)
 
 
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEVICE Point<dim, Number>
-Point<dim, Number>::operator+(const Tensor<1, dim, Number> &p) const
+DEAL_II_CXX20_REQUIRES(dim >= 0)
+inline DEAL_II_HOST_DEVICE Point<dim, Number> Point<dim, Number>::operator+(
+  const Tensor<1, dim, Number> &p) const
 {
   Point<dim, Number> tmp = *this;
   tmp += p;
@@ -502,8 +512,9 @@ Point<dim, Number>::operator+(const Tensor<1, dim, Number> &p) const
 
 
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEVICE Tensor<1, dim, Number>
-Point<dim, Number>::operator-(const Point<dim, Number> &p) const
+DEAL_II_CXX20_REQUIRES(dim >= 0)
+inline DEAL_II_HOST_DEVICE Tensor<1, dim, Number> Point<dim, Number>::operator-(
+  const Point<dim, Number> &p) const
 {
   return (Tensor<1, dim, Number>(*this) -= p);
 }
@@ -511,8 +522,9 @@ Point<dim, Number>::operator-(const Point<dim, Number> &p) const
 
 
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEVICE Point<dim, Number>
-Point<dim, Number>::operator-(const Tensor<1, dim, Number> &p) const
+DEAL_II_CXX20_REQUIRES(dim >= 0)
+inline DEAL_II_HOST_DEVICE Point<dim, Number> Point<dim, Number>::operator-(
+  const Tensor<1, dim, Number> &p) const
 {
   Point<dim, Number> tmp = *this;
   tmp -= p;
@@ -522,8 +534,9 @@ Point<dim, Number>::operator-(const Tensor<1, dim, Number> &p) const
 
 
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEVICE Point<dim, Number>
-Point<dim, Number>::operator-() const
+DEAL_II_CXX20_REQUIRES(dim >= 0)
+inline DEAL_II_HOST_DEVICE Point<dim, Number> Point<dim, Number>::operator-()
+  const
 {
   Point<dim, Number> result;
   for (unsigned int i = 0; i < dim; ++i)
@@ -534,12 +547,12 @@ Point<dim, Number>::operator-() const
 
 
 template <int dim, typename Number>
+DEAL_II_CXX20_REQUIRES(dim >= 0)
 template <typename OtherNumber>
-inline DEAL_II_HOST_DEVICE
-  Point<dim,
-        typename ProductType<Number,
-                             typename EnableIfScalar<OtherNumber>::type>::type>
-  Point<dim, Number>::operator*(const OtherNumber factor) const
+inline DEAL_II_HOST_DEVICE Point<
+  dim,
+  typename ProductType<Number, typename EnableIfScalar<OtherNumber>::type>::
+    type> Point<dim, Number>::operator*(const OtherNumber factor) const
 {
   Point<dim, typename ProductType<Number, OtherNumber>::type> tmp;
   for (unsigned int i = 0; i < dim; ++i)
@@ -550,12 +563,12 @@ inline DEAL_II_HOST_DEVICE
 
 
 template <int dim, typename Number>
+DEAL_II_CXX20_REQUIRES(dim >= 0)
 template <typename OtherNumber>
-inline DEAL_II_HOST_DEVICE
-  Point<dim,
-        typename ProductType<Number,
-                             typename EnableIfScalar<OtherNumber>::type>::type>
-  Point<dim, Number>::operator/(const OtherNumber factor) const
+inline DEAL_II_HOST_DEVICE Point<
+  dim,
+  typename ProductType<Number, typename EnableIfScalar<OtherNumber>::type>::
+    type> Point<dim, Number>::operator/(const OtherNumber factor) const
 {
   const Tensor<1, dim, Number> &base_object = *this;
   return Point<
@@ -568,8 +581,9 @@ inline DEAL_II_HOST_DEVICE
 
 
 template <int dim, typename Number>
-inline DEAL_II_HOST_DEVICE Number
-Point<dim, Number>::operator*(const Tensor<1, dim, Number> &p) const
+DEAL_II_CXX20_REQUIRES(dim >= 0)
+inline DEAL_II_HOST_DEVICE Number Point<dim, Number>::operator*(
+  const Tensor<1, dim, Number> &p) const
 {
   Number res = Number();
   for (unsigned int i = 0; i < dim; ++i)
@@ -579,8 +593,9 @@ Point<dim, Number>::operator*(const Tensor<1, dim, Number> &p) const
 
 
 template <int dim, typename Number>
+DEAL_II_CXX20_REQUIRES(dim >= 0)
 inline DEAL_II_HOST_DEVICE typename numbers::NumberTraits<Number>::real_type
-Point<dim, Number>::square() const
+  Point<dim, Number>::square() const
 {
   return this->norm_square();
 }
@@ -588,8 +603,9 @@ Point<dim, Number>::square() const
 
 
 template <int dim, typename Number>
+DEAL_II_CXX20_REQUIRES(dim >= 0)
 inline DEAL_II_HOST_DEVICE typename numbers::NumberTraits<Number>::real_type
-Point<dim, Number>::distance(const Point<dim, Number> &p) const
+  Point<dim, Number>::distance(const Point<dim, Number> &p) const
 {
   return std::sqrt(distance_square(p));
 }
@@ -597,8 +613,9 @@ Point<dim, Number>::distance(const Point<dim, Number> &p) const
 
 
 template <int dim, typename Number>
+DEAL_II_CXX20_REQUIRES(dim >= 0)
 inline DEAL_II_HOST_DEVICE typename numbers::NumberTraits<Number>::real_type
-Point<dim, Number>::distance_square(const Point<dim, Number> &p) const
+  Point<dim, Number>::distance_square(const Point<dim, Number> &p) const
 {
   Number sum = internal::NumberType<Number>::value(0.0);
   for (unsigned int i = 0; i < dim; ++i)
@@ -613,9 +630,9 @@ Point<dim, Number>::distance_square(const Point<dim, Number> &p) const
 
 
 template <int dim, typename Number>
+DEAL_II_CXX20_REQUIRES(dim >= 0)
 template <class Archive>
-inline void
-Point<dim, Number>::serialize(Archive &ar, const unsigned int)
+inline void Point<dim, Number>::serialize(Archive &ar, const unsigned int)
 {
   // forward to serialization
   // function in the base class
@@ -653,6 +670,7 @@ inline DEAL_II_HOST_DEVICE
  * @relatesalso Point
  */
 template <int dim, typename Number>
+DEAL_II_CXX20_REQUIRES(dim >= 0)
 inline std::ostream &
 operator<<(std::ostream &out, const Point<dim, Number> &p)
 {
@@ -670,6 +688,7 @@ operator<<(std::ostream &out, const Point<dim, Number> &p)
  * @relatesalso Point
  */
 template <int dim, typename Number>
+DEAL_II_CXX20_REQUIRES(dim >= 0)
 inline std::istream &
 operator>>(std::istream &in, Point<dim, Number> &p)
 {

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -1812,8 +1812,8 @@ namespace internal
 
 
 template <int dim, int spacedim>
-inline bool
-DoFHandler<dim, spacedim>::has_hp_capabilities() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+inline bool DoFHandler<dim, spacedim>::has_hp_capabilities() const
 {
   return hp_capability_enabled;
 }
@@ -1821,8 +1821,8 @@ DoFHandler<dim, spacedim>::has_hp_capabilities() const
 
 
 template <int dim, int spacedim>
-inline bool
-DoFHandler<dim, spacedim>::has_level_dofs() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+inline bool DoFHandler<dim, spacedim>::has_level_dofs() const
 {
   return mg_number_cache.size() > 0;
 }
@@ -1830,8 +1830,8 @@ DoFHandler<dim, spacedim>::has_level_dofs() const
 
 
 template <int dim, int spacedim>
-inline bool
-DoFHandler<dim, spacedim>::has_active_dofs() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+inline bool DoFHandler<dim, spacedim>::has_active_dofs() const
 {
   return number_cache.n_global_dofs > 0;
 }
@@ -1839,8 +1839,8 @@ DoFHandler<dim, spacedim>::has_active_dofs() const
 
 
 template <int dim, int spacedim>
-inline types::global_dof_index
-DoFHandler<dim, spacedim>::n_dofs() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+inline types::global_dof_index DoFHandler<dim, spacedim>::n_dofs() const
 {
   return number_cache.n_global_dofs;
 }
@@ -1848,8 +1848,9 @@ DoFHandler<dim, spacedim>::n_dofs() const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 inline types::global_dof_index
-DoFHandler<dim, spacedim>::n_dofs(const unsigned int level) const
+  DoFHandler<dim, spacedim>::n_dofs(const unsigned int level) const
 {
   Assert(has_level_dofs(),
          ExcMessage(
@@ -1861,8 +1862,8 @@ DoFHandler<dim, spacedim>::n_dofs(const unsigned int level) const
 
 
 template <int dim, int spacedim>
-types::global_dof_index
-DoFHandler<dim, spacedim>::n_locally_owned_dofs() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+types::global_dof_index DoFHandler<dim, spacedim>::n_locally_owned_dofs() const
 {
   return number_cache.n_locally_owned_dofs;
 }
@@ -1870,8 +1871,8 @@ DoFHandler<dim, spacedim>::n_locally_owned_dofs() const
 
 
 template <int dim, int spacedim>
-const IndexSet &
-DoFHandler<dim, spacedim>::locally_owned_dofs() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+const IndexSet &DoFHandler<dim, spacedim>::locally_owned_dofs() const
 {
   return number_cache.locally_owned_dofs;
 }
@@ -1879,8 +1880,9 @@ DoFHandler<dim, spacedim>::locally_owned_dofs() const
 
 
 template <int dim, int spacedim>
-const IndexSet &
-DoFHandler<dim, spacedim>::locally_owned_mg_dofs(const unsigned int level) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+const IndexSet &DoFHandler<dim, spacedim>::locally_owned_mg_dofs(
+  const unsigned int level) const
 {
   Assert(level < this->get_triangulation().n_global_levels(),
          ExcMessage("The given level index exceeds the number of levels "
@@ -1895,8 +1897,9 @@ DoFHandler<dim, spacedim>::locally_owned_mg_dofs(const unsigned int level) const
 
 
 template <int dim, int spacedim>
-inline const FiniteElement<dim, spacedim> &
-DoFHandler<dim, spacedim>::get_fe(const types::fe_index number) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+inline const FiniteElement<dim, spacedim> &DoFHandler<dim, spacedim>::get_fe(
+  const types::fe_index number) const
 {
   Assert(fe_collection.size() > 0,
          ExcMessage("No finite element collection is associated with "
@@ -1907,8 +1910,9 @@ DoFHandler<dim, spacedim>::get_fe(const types::fe_index number) const
 
 
 template <int dim, int spacedim>
-inline const hp::FECollection<dim, spacedim> &
-DoFHandler<dim, spacedim>::get_fe_collection() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+inline const hp::FECollection<dim, spacedim>
+  &DoFHandler<dim, spacedim>::get_fe_collection() const
 {
   return fe_collection;
 }
@@ -1916,8 +1920,9 @@ DoFHandler<dim, spacedim>::get_fe_collection() const
 
 
 template <int dim, int spacedim>
-inline const Triangulation<dim, spacedim> &
-DoFHandler<dim, spacedim>::get_triangulation() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+inline const Triangulation<dim, spacedim>
+  &DoFHandler<dim, spacedim>::get_triangulation() const
 {
   Assert(tria != nullptr,
          ExcMessage("This DoFHandler object has not been associated "
@@ -1928,8 +1933,8 @@ DoFHandler<dim, spacedim>::get_triangulation() const
 
 
 template <int dim, int spacedim>
-inline MPI_Comm
-DoFHandler<dim, spacedim>::get_communicator() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+inline MPI_Comm DoFHandler<dim, spacedim>::get_communicator() const
 {
   Assert(tria != nullptr,
          ExcMessage("This DoFHandler object has not been associated "
@@ -1940,8 +1945,8 @@ DoFHandler<dim, spacedim>::get_communicator() const
 
 
 template <int dim, int spacedim>
-inline const BlockInfo &
-DoFHandler<dim, spacedim>::block_info() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+inline const BlockInfo &DoFHandler<dim, spacedim>::block_info() const
 {
   Assert(this->hp_capability_enabled == false, ExcNotImplementedWithHP());
 
@@ -1951,9 +1956,9 @@ DoFHandler<dim, spacedim>::block_info() const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 template <typename number>
-types::global_dof_index
-DoFHandler<dim, spacedim>::n_boundary_dofs(
+types::global_dof_index DoFHandler<dim, spacedim>::n_boundary_dofs(
   const std::map<types::boundary_id, const Function<spacedim, number> *>
     &boundary_ids) const
 {
@@ -1994,9 +1999,9 @@ namespace internal
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 template <class Archive>
-void
-DoFHandler<dim, spacedim>::save(Archive &ar, const unsigned int) const
+void DoFHandler<dim, spacedim>::save(Archive &ar, const unsigned int) const
 {
   if (this->hp_capability_enabled)
     {
@@ -2044,9 +2049,9 @@ DoFHandler<dim, spacedim>::save(Archive &ar, const unsigned int) const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 template <class Archive>
-void
-DoFHandler<dim, spacedim>::load(Archive &ar, const unsigned int)
+void DoFHandler<dim, spacedim>::load(Archive &ar, const unsigned int)
 {
   if (this->hp_capability_enabled)
     {
@@ -2126,11 +2131,12 @@ DoFHandler<dim, spacedim>::load(Archive &ar, const unsigned int)
 
 
 template <int dim, int spacedim>
-inline types::global_dof_index &
-DoFHandler<dim, spacedim>::MGVertexDoFs::access_index(
-  const unsigned int level,
-  const unsigned int dof_number,
-  const unsigned int dofs_per_vertex)
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+inline types::global_dof_index
+  &DoFHandler<dim, spacedim>::MGVertexDoFs::access_index(
+    const unsigned int level,
+    const unsigned int dof_number,
+    const unsigned int dofs_per_vertex)
 {
   Assert((level >= coarsest_level) && (level <= finest_level),
          ExcInvalidLevel(level));

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -4342,8 +4342,9 @@ namespace internal
 
 
 template <int dim, int spacedim>
-inline bool
-Triangulation<dim, spacedim>::vertex_used(const unsigned int index) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+inline bool Triangulation<dim, spacedim>::vertex_used(
+  const unsigned int index) const
 {
   AssertIndexRange(index, vertices_used.size());
   return vertices_used[index];
@@ -4352,23 +4353,23 @@ Triangulation<dim, spacedim>::vertex_used(const unsigned int index) const
 
 
 template <int dim, int spacedim>
-inline unsigned int
-Triangulation<dim, spacedim>::n_levels() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+inline unsigned int Triangulation<dim, spacedim>::n_levels() const
 {
   return number_cache.n_levels;
 }
 
 template <int dim, int spacedim>
-inline unsigned int
-Triangulation<dim, spacedim>::n_global_levels() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+inline unsigned int Triangulation<dim, spacedim>::n_global_levels() const
 {
   return number_cache.n_levels;
 }
 
 
 template <int dim, int spacedim>
-inline unsigned int
-Triangulation<dim, spacedim>::n_vertices() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+inline unsigned int Triangulation<dim, spacedim>::n_vertices() const
 {
   return vertices.size();
 }
@@ -4376,17 +4377,18 @@ Triangulation<dim, spacedim>::n_vertices() const
 
 
 template <int dim, int spacedim>
-inline const std::vector<Point<spacedim>> &
-Triangulation<dim, spacedim>::get_vertices() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+inline const std::vector<Point<spacedim>>
+  &Triangulation<dim, spacedim>::get_vertices() const
 {
   return vertices;
 }
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 template <class Archive>
-void
-Triangulation<dim, spacedim>::save(Archive &ar, const unsigned int) const
+void Triangulation<dim, spacedim>::save(Archive &ar, const unsigned int) const
 {
   // as discussed in the documentation, do not store the signals as
   // well as boundary and manifold description but everything else
@@ -4423,9 +4425,9 @@ Triangulation<dim, spacedim>::save(Archive &ar, const unsigned int) const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 template <class Archive>
-void
-Triangulation<dim, spacedim>::load(Archive &ar, const unsigned int)
+void Triangulation<dim, spacedim>::load(Archive &ar, const unsigned int)
 {
   // clear previous content. this also calls the respective signal
   clear();
@@ -4496,9 +4498,10 @@ Triangulation<dim, spacedim>::load(Archive &ar, const unsigned int)
 
 
 template <int dim, int spacedim>
-inline unsigned int
-Triangulation<dim, spacedim>::coarse_cell_id_to_coarse_cell_index(
-  const types::coarse_cell_id coarse_cell_id) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+inline unsigned int Triangulation<dim, spacedim>::
+  coarse_cell_id_to_coarse_cell_index(
+    const types::coarse_cell_id coarse_cell_id) const
 {
   return coarse_cell_id;
 }
@@ -4506,9 +4509,10 @@ Triangulation<dim, spacedim>::coarse_cell_id_to_coarse_cell_index(
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 inline types::coarse_cell_id
-Triangulation<dim, spacedim>::coarse_cell_index_to_coarse_cell_id(
-  const unsigned int coarse_cell_index) const
+  Triangulation<dim, spacedim>::coarse_cell_index_to_coarse_cell_id(
+    const unsigned int coarse_cell_index) const
 {
   return coarse_cell_index;
 }

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -4172,8 +4172,7 @@ private:
 
   friend class Triangulation<dim, spacedim>;
 
-  template <int, int>
-  friend class parallel::TriangulationBase;
+  friend class parallel::TriangulationBase<dim, spacedim>;
 
   friend struct dealii::internal::TriangulationImplementation::Implementation;
   friend struct dealii::internal::TriangulationImplementation::

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -43,6 +43,7 @@
 DEAL_II_NAMESPACE_OPEN
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 const types::fe_index DoFHandler<dim, spacedim>::default_fe_index;
 
 
@@ -1711,6 +1712,7 @@ namespace internal
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 DoFHandler<dim, spacedim>::DoFHandler()
   : hp_capability_enabled(true)
   , tria(nullptr, typeid(*this).name())
@@ -1720,6 +1722,7 @@ DoFHandler<dim, spacedim>::DoFHandler()
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 DoFHandler<dim, spacedim>::DoFHandler(const Triangulation<dim, spacedim> &tria)
   : DoFHandler()
 {
@@ -1729,6 +1732,7 @@ DoFHandler<dim, spacedim>::DoFHandler(const Triangulation<dim, spacedim> &tria)
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 DoFHandler<dim, spacedim>::~DoFHandler()
 {
   // unsubscribe all attachments to signals of the underlying triangulation
@@ -1755,8 +1759,8 @@ DoFHandler<dim, spacedim>::~DoFHandler()
 
 
 template <int dim, int spacedim>
-void
-DoFHandler<dim, spacedim>::reinit(const Triangulation<dim, spacedim> &tria)
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void DoFHandler<dim, spacedim>::reinit(const Triangulation<dim, spacedim> &tria)
 {
   //
   // call destructor
@@ -1795,8 +1799,9 @@ DoFHandler<dim, spacedim>::reinit(const Triangulation<dim, spacedim> &tria)
 /*------------------------ Cell iterator functions ------------------------*/
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename DoFHandler<dim, spacedim>::cell_iterator
-DoFHandler<dim, spacedim>::begin(const unsigned int level) const
+  DoFHandler<dim, spacedim>::begin(const unsigned int level) const
 {
   typename Triangulation<dim, spacedim>::cell_iterator cell =
     this->get_triangulation().begin(level);
@@ -1808,8 +1813,9 @@ DoFHandler<dim, spacedim>::begin(const unsigned int level) const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename DoFHandler<dim, spacedim>::active_cell_iterator
-DoFHandler<dim, spacedim>::begin_active(const unsigned int level) const
+  DoFHandler<dim, spacedim>::begin_active(const unsigned int level) const
 {
   // level is checked in begin
   cell_iterator i = begin(level);
@@ -1824,8 +1830,9 @@ DoFHandler<dim, spacedim>::begin_active(const unsigned int level) const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename DoFHandler<dim, spacedim>::cell_iterator
-DoFHandler<dim, spacedim>::end() const
+  DoFHandler<dim, spacedim>::end() const
 {
   return cell_iterator(&this->get_triangulation(), -1, -1, this);
 }
@@ -1833,8 +1840,9 @@ DoFHandler<dim, spacedim>::end() const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename DoFHandler<dim, spacedim>::cell_iterator
-DoFHandler<dim, spacedim>::end(const unsigned int level) const
+  DoFHandler<dim, spacedim>::end(const unsigned int level) const
 {
   typename Triangulation<dim, spacedim>::cell_iterator cell =
     this->get_triangulation().end(level);
@@ -1846,8 +1854,9 @@ DoFHandler<dim, spacedim>::end(const unsigned int level) const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename DoFHandler<dim, spacedim>::active_cell_iterator
-DoFHandler<dim, spacedim>::end_active(const unsigned int level) const
+  DoFHandler<dim, spacedim>::end_active(const unsigned int level) const
 {
   typename Triangulation<dim, spacedim>::cell_iterator cell =
     this->get_triangulation().end_active(level);
@@ -1859,8 +1868,9 @@ DoFHandler<dim, spacedim>::end_active(const unsigned int level) const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename DoFHandler<dim, spacedim>::level_cell_iterator
-DoFHandler<dim, spacedim>::begin_mg(const unsigned int level) const
+  DoFHandler<dim, spacedim>::begin_mg(const unsigned int level) const
 {
   Assert(this->has_level_dofs(),
          ExcMessage("You can only iterate over mg "
@@ -1875,8 +1885,9 @@ DoFHandler<dim, spacedim>::begin_mg(const unsigned int level) const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename DoFHandler<dim, spacedim>::level_cell_iterator
-DoFHandler<dim, spacedim>::end_mg(const unsigned int level) const
+  DoFHandler<dim, spacedim>::end_mg(const unsigned int level) const
 {
   Assert(this->has_level_dofs(),
          ExcMessage("You can only iterate over mg "
@@ -1891,8 +1902,9 @@ DoFHandler<dim, spacedim>::end_mg(const unsigned int level) const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename DoFHandler<dim, spacedim>::level_cell_iterator
-DoFHandler<dim, spacedim>::end_mg() const
+  DoFHandler<dim, spacedim>::end_mg() const
 {
   return level_cell_iterator(&this->get_triangulation(), -1, -1, this);
 }
@@ -1900,8 +1912,10 @@ DoFHandler<dim, spacedim>::end_mg() const
 
 
 template <int dim, int spacedim>
-IteratorRange<typename DoFHandler<dim, spacedim>::cell_iterator>
-DoFHandler<dim, spacedim>::cell_iterators() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+IteratorRange<typename DoFHandler<dim, spacedim>::cell_iterator> DoFHandler<
+  dim,
+  spacedim>::cell_iterators() const
 {
   return IteratorRange<typename DoFHandler<dim, spacedim>::cell_iterator>(
     begin(), end());
@@ -1910,8 +1924,10 @@ DoFHandler<dim, spacedim>::cell_iterators() const
 
 
 template <int dim, int spacedim>
-IteratorRange<typename DoFHandler<dim, spacedim>::active_cell_iterator>
-DoFHandler<dim, spacedim>::active_cell_iterators() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+IteratorRange<typename DoFHandler<dim, spacedim>::
+                active_cell_iterator> DoFHandler<dim, spacedim>::
+  active_cell_iterators() const
 {
   return IteratorRange<
     typename DoFHandler<dim, spacedim>::active_cell_iterator>(begin_active(),
@@ -1921,8 +1937,10 @@ DoFHandler<dim, spacedim>::active_cell_iterators() const
 
 
 template <int dim, int spacedim>
-IteratorRange<typename DoFHandler<dim, spacedim>::level_cell_iterator>
-DoFHandler<dim, spacedim>::mg_cell_iterators() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+IteratorRange<
+  typename DoFHandler<dim, spacedim>::
+    level_cell_iterator> DoFHandler<dim, spacedim>::mg_cell_iterators() const
 {
   return IteratorRange<typename DoFHandler<dim, spacedim>::level_cell_iterator>(
     begin_mg(), end_mg());
@@ -1931,9 +1949,10 @@ DoFHandler<dim, spacedim>::mg_cell_iterators() const
 
 
 template <int dim, int spacedim>
-IteratorRange<typename DoFHandler<dim, spacedim>::cell_iterator>
-DoFHandler<dim, spacedim>::cell_iterators_on_level(
-  const unsigned int level) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+IteratorRange<typename DoFHandler<dim, spacedim>::cell_iterator> DoFHandler<
+  dim,
+  spacedim>::cell_iterators_on_level(const unsigned int level) const
 {
   return IteratorRange<typename DoFHandler<dim, spacedim>::cell_iterator>(
     begin(level), end(level));
@@ -1942,9 +1961,10 @@ DoFHandler<dim, spacedim>::cell_iterators_on_level(
 
 
 template <int dim, int spacedim>
-IteratorRange<typename DoFHandler<dim, spacedim>::active_cell_iterator>
-DoFHandler<dim, spacedim>::active_cell_iterators_on_level(
-  const unsigned int level) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+IteratorRange<typename DoFHandler<dim, spacedim>::
+                active_cell_iterator> DoFHandler<dim, spacedim>::
+  active_cell_iterators_on_level(const unsigned int level) const
 {
   return IteratorRange<
     typename DoFHandler<dim, spacedim>::active_cell_iterator>(
@@ -1954,9 +1974,10 @@ DoFHandler<dim, spacedim>::active_cell_iterators_on_level(
 
 
 template <int dim, int spacedim>
-IteratorRange<typename DoFHandler<dim, spacedim>::level_cell_iterator>
-DoFHandler<dim, spacedim>::mg_cell_iterators_on_level(
-  const unsigned int level) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+IteratorRange<typename DoFHandler<dim, spacedim>::
+                level_cell_iterator> DoFHandler<dim, spacedim>::
+  mg_cell_iterators_on_level(const unsigned int level) const
 {
   return IteratorRange<typename DoFHandler<dim, spacedim>::level_cell_iterator>(
     begin_mg(level), end_mg(level));
@@ -1969,8 +1990,8 @@ DoFHandler<dim, spacedim>::mg_cell_iterators_on_level(
 
 
 template <int dim, int spacedim>
-types::global_dof_index
-DoFHandler<dim, spacedim>::n_boundary_dofs() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+types::global_dof_index DoFHandler<dim, spacedim>::n_boundary_dofs() const
 {
   Assert(!(dim == 2 && spacedim == 3) || hp_capability_enabled == false,
          ExcNotImplementedWithHP());
@@ -2018,8 +2039,8 @@ DoFHandler<dim, spacedim>::n_boundary_dofs() const
 
 
 template <int dim, int spacedim>
-types::global_dof_index
-DoFHandler<dim, spacedim>::n_boundary_dofs(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+types::global_dof_index DoFHandler<dim, spacedim>::n_boundary_dofs(
   const std::set<types::boundary_id> &boundary_ids) const
 {
   Assert(!(dim == 2 && spacedim == 3) || hp_capability_enabled == false,
@@ -2070,8 +2091,8 @@ DoFHandler<dim, spacedim>::n_boundary_dofs(
 
 
 template <int dim, int spacedim>
-std::size_t
-DoFHandler<dim, spacedim>::memory_consumption() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+std::size_t DoFHandler<dim, spacedim>::memory_consumption() const
 {
   std::size_t mem = MemoryConsumption::memory_consumption(this->tria) +
                     MemoryConsumption::memory_consumption(this->fe_collection) +
@@ -2114,8 +2135,8 @@ DoFHandler<dim, spacedim>::memory_consumption() const
 
 
 template <int dim, int spacedim>
-void
-DoFHandler<dim, spacedim>::distribute_dofs(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void DoFHandler<dim, spacedim>::distribute_dofs(
   const FiniteElement<dim, spacedim> &fe)
 {
   this->distribute_dofs(hp::FECollection<dim, spacedim>(fe));
@@ -2124,8 +2145,8 @@ DoFHandler<dim, spacedim>::distribute_dofs(
 
 
 template <int dim, int spacedim>
-void
-DoFHandler<dim, spacedim>::distribute_dofs(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void DoFHandler<dim, spacedim>::distribute_dofs(
   const hp::FECollection<dim, spacedim> &ff)
 {
   Assert(
@@ -2255,8 +2276,8 @@ DoFHandler<dim, spacedim>::distribute_dofs(
 
 
 template <int dim, int spacedim>
-void
-DoFHandler<dim, spacedim>::distribute_mg_dofs()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void DoFHandler<dim, spacedim>::distribute_mg_dofs()
 {
   AssertThrow(hp_capability_enabled == false, ExcNotImplementedWithHP());
 
@@ -2287,8 +2308,8 @@ DoFHandler<dim, spacedim>::distribute_mg_dofs()
 
 
 template <int dim, int spacedim>
-void
-DoFHandler<dim, spacedim>::initialize_local_block_info()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void DoFHandler<dim, spacedim>::initialize_local_block_info()
 {
   AssertThrow(hp_capability_enabled == false, ExcNotImplementedWithHP());
 
@@ -2298,8 +2319,8 @@ DoFHandler<dim, spacedim>::initialize_local_block_info()
 
 
 template <int dim, int spacedim>
-void
-DoFHandler<dim, spacedim>::setup_policy()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void DoFHandler<dim, spacedim>::setup_policy()
 {
   // decide whether we need a sequential or a parallel distributed policy
   if (dynamic_cast<const dealii::parallel::shared::Triangulation<dim, spacedim>
@@ -2321,8 +2342,8 @@ DoFHandler<dim, spacedim>::setup_policy()
 
 
 template <int dim, int spacedim>
-void
-DoFHandler<dim, spacedim>::clear()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void DoFHandler<dim, spacedim>::clear()
 {
   // release memory
   this->clear_space();
@@ -2332,8 +2353,8 @@ DoFHandler<dim, spacedim>::clear()
 
 
 template <int dim, int spacedim>
-void
-DoFHandler<dim, spacedim>::clear_space()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void DoFHandler<dim, spacedim>::clear_space()
 {
   object_dof_indices.clear();
 
@@ -2348,8 +2369,8 @@ DoFHandler<dim, spacedim>::clear_space()
 
 
 template <int dim, int spacedim>
-void
-DoFHandler<dim, spacedim>::clear_mg_space()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void DoFHandler<dim, spacedim>::clear_mg_space()
 {
   this->mg_levels.clear();
   this->mg_faces.reset();
@@ -2364,8 +2385,8 @@ DoFHandler<dim, spacedim>::clear_mg_space()
 
 
 template <int dim, int spacedim>
-void
-DoFHandler<dim, spacedim>::renumber_dofs(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void DoFHandler<dim, spacedim>::renumber_dofs(
   const std::vector<types::global_dof_index> &new_numbers)
 {
   if (hp_capability_enabled)
@@ -2476,8 +2497,8 @@ DoFHandler<dim, spacedim>::renumber_dofs(
 
 
 template <int dim, int spacedim>
-void
-DoFHandler<dim, spacedim>::renumber_dofs(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void DoFHandler<dim, spacedim>::renumber_dofs(
   const unsigned int                          level,
   const std::vector<types::global_dof_index> &new_numbers)
 {
@@ -2519,8 +2540,9 @@ DoFHandler<dim, spacedim>::renumber_dofs(
 
 
 template <int dim, int spacedim>
-unsigned int
-DoFHandler<dim, spacedim>::max_couplings_between_boundary_dofs() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int DoFHandler<dim, spacedim>::max_couplings_between_boundary_dofs()
+  const
 {
   Assert(this->fe_collection.size() > 0, ExcNoFESelected());
 
@@ -2553,8 +2575,8 @@ DoFHandler<dim, spacedim>::max_couplings_between_boundary_dofs() const
 
 
 template <int dim, int spacedim>
-unsigned int
-DoFHandler<dim, spacedim>::max_couplings_between_dofs() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int DoFHandler<dim, spacedim>::max_couplings_between_dofs() const
 {
   Assert(this->fe_collection.size() > 0, ExcNoFESelected());
   return internal::DoFHandlerImplementation::Implementation::
@@ -2564,8 +2586,8 @@ DoFHandler<dim, spacedim>::max_couplings_between_dofs() const
 
 
 template <int dim, int spacedim>
-void
-DoFHandler<dim, spacedim>::set_active_fe_indices(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void DoFHandler<dim, spacedim>::set_active_fe_indices(
   const std::vector<types::fe_index> &active_fe_indices)
 {
   Assert(active_fe_indices.size() == this->get_triangulation().n_active_cells(),
@@ -2585,8 +2607,8 @@ DoFHandler<dim, spacedim>::set_active_fe_indices(
 
 
 template <int dim, int spacedim>
-void
-DoFHandler<dim, spacedim>::set_active_fe_indices(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void DoFHandler<dim, spacedim>::set_active_fe_indices(
   const std::vector<unsigned int> &active_fe_indices)
 {
   set_active_fe_indices(std::vector<types::fe_index>(active_fe_indices.begin(),
@@ -2596,8 +2618,9 @@ DoFHandler<dim, spacedim>::set_active_fe_indices(
 
 
 template <int dim, int spacedim>
-std::vector<types::fe_index>
-DoFHandler<dim, spacedim>::get_active_fe_indices() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+std::vector<types::fe_index> DoFHandler<dim, spacedim>::get_active_fe_indices()
+  const
 {
   std::vector<types::fe_index> active_fe_indices(
     this->get_triangulation().n_active_cells(), numbers::invalid_fe_index);
@@ -2615,8 +2638,8 @@ DoFHandler<dim, spacedim>::get_active_fe_indices() const
 
 
 template <int dim, int spacedim>
-void
-DoFHandler<dim, spacedim>::get_active_fe_indices(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void DoFHandler<dim, spacedim>::get_active_fe_indices(
   std::vector<unsigned int> &active_fe_indices) const
 {
   const std::vector<types::fe_index> indices = get_active_fe_indices();
@@ -2627,8 +2650,8 @@ DoFHandler<dim, spacedim>::get_active_fe_indices(
 
 
 template <int dim, int spacedim>
-void
-DoFHandler<dim, spacedim>::set_future_fe_indices(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void DoFHandler<dim, spacedim>::set_future_fe_indices(
   const std::vector<types::fe_index> &future_fe_indices)
 {
   Assert(future_fe_indices.size() == this->get_triangulation().n_active_cells(),
@@ -2650,8 +2673,9 @@ DoFHandler<dim, spacedim>::set_future_fe_indices(
 
 
 template <int dim, int spacedim>
-std::vector<types::fe_index>
-DoFHandler<dim, spacedim>::get_future_fe_indices() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+std::vector<types::fe_index> DoFHandler<dim, spacedim>::get_future_fe_indices()
+  const
 {
   std::vector<types::fe_index> future_fe_indices(
     this->get_triangulation().n_active_cells(), numbers::invalid_fe_index);
@@ -2669,8 +2693,8 @@ DoFHandler<dim, spacedim>::get_future_fe_indices() const
 
 
 template <int dim, int spacedim>
-void
-DoFHandler<dim, spacedim>::connect_to_triangulation_signals()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void DoFHandler<dim, spacedim>::connect_to_triangulation_signals()
 {
   // make sure this is called during initialization in hp-mode
   Assert(hp_capability_enabled, ExcOnlyAvailableWithHP());
@@ -2761,8 +2785,8 @@ DoFHandler<dim, spacedim>::connect_to_triangulation_signals()
 
 
 template <int dim, int spacedim>
-void
-DoFHandler<dim, spacedim>::create_active_fe_table()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void DoFHandler<dim, spacedim>::create_active_fe_table()
 {
   AssertThrow(hp_capability_enabled == true, ExcOnlyAvailableWithHP());
 
@@ -2812,8 +2836,8 @@ DoFHandler<dim, spacedim>::create_active_fe_table()
 
 
 template <int dim, int spacedim>
-void
-DoFHandler<dim, spacedim>::update_active_fe_table()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void DoFHandler<dim, spacedim>::update_active_fe_table()
 {
   //  // Normally only one level is added, but if this Triangulation
   //  // is created by copy_triangulation, it can be more than one level.
@@ -2850,8 +2874,8 @@ DoFHandler<dim, spacedim>::update_active_fe_table()
 
 
 template <int dim, int spacedim>
-void
-DoFHandler<dim, spacedim>::pre_transfer_action()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void DoFHandler<dim, spacedim>::pre_transfer_action()
 {
   Assert(this->active_fe_index_transfer == nullptr, ExcInternalError());
 
@@ -2864,8 +2888,8 @@ DoFHandler<dim, spacedim>::pre_transfer_action()
 
 
 template <int dim, int spacedim>
-void
-DoFHandler<dim, spacedim>::pre_distributed_transfer_action()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void DoFHandler<dim, spacedim>::pre_distributed_transfer_action()
 {
 #ifndef DEAL_II_WITH_P4EST
   Assert(false,
@@ -2931,8 +2955,8 @@ DoFHandler<dim, spacedim>::pre_distributed_transfer_action()
 
 
 template <int dim, int spacedim>
-void
-DoFHandler<dim, spacedim>::post_transfer_action()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void DoFHandler<dim, spacedim>::post_transfer_action()
 {
   update_active_fe_table();
 
@@ -2954,8 +2978,8 @@ DoFHandler<dim, spacedim>::post_transfer_action()
 
 
 template <int dim, int spacedim>
-void
-DoFHandler<dim, spacedim>::post_distributed_transfer_action()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void DoFHandler<dim, spacedim>::post_distributed_transfer_action()
 {
 #ifndef DEAL_II_WITH_P4EST
   Assert(false, ExcInternalError());
@@ -2986,8 +3010,8 @@ DoFHandler<dim, spacedim>::post_distributed_transfer_action()
 
 
 template <int dim, int spacedim>
-void
-DoFHandler<dim, spacedim>::prepare_for_serialization_of_active_fe_indices()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void DoFHandler<dim, spacedim>::prepare_for_serialization_of_active_fe_indices()
 {
 #ifndef DEAL_II_WITH_P4EST
   Assert(false,
@@ -3044,8 +3068,8 @@ DoFHandler<dim, spacedim>::prepare_for_serialization_of_active_fe_indices()
 
 
 template <int dim, int spacedim>
-void
-DoFHandler<dim, spacedim>::deserialize_active_fe_indices()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void DoFHandler<dim, spacedim>::deserialize_active_fe_indices()
 {
 #ifndef DEAL_II_WITH_P4EST
   Assert(false,
@@ -3108,6 +3132,7 @@ DoFHandler<dim, spacedim>::deserialize_active_fe_indices()
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 DoFHandler<dim, spacedim>::MGVertexDoFs::MGVertexDoFs()
   : coarsest_level(numbers::invalid_unsigned_int)
   , finest_level(0)
@@ -3116,8 +3141,8 @@ DoFHandler<dim, spacedim>::MGVertexDoFs::MGVertexDoFs()
 
 
 template <int dim, int spacedim>
-void
-DoFHandler<dim, spacedim>::MGVertexDoFs::init(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void DoFHandler<dim, spacedim>::MGVertexDoFs::init(
   const unsigned int cl,
   const unsigned int fl,
   const unsigned int dofs_per_vertex)
@@ -3142,8 +3167,8 @@ DoFHandler<dim, spacedim>::MGVertexDoFs::init(
 
 
 template <int dim, int spacedim>
-unsigned int
-DoFHandler<dim, spacedim>::MGVertexDoFs::get_coarsest_level() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int DoFHandler<dim, spacedim>::MGVertexDoFs::get_coarsest_level() const
 {
   return coarsest_level;
 }
@@ -3151,8 +3176,8 @@ DoFHandler<dim, spacedim>::MGVertexDoFs::get_coarsest_level() const
 
 
 template <int dim, int spacedim>
-unsigned int
-DoFHandler<dim, spacedim>::MGVertexDoFs::get_finest_level() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int DoFHandler<dim, spacedim>::MGVertexDoFs::get_finest_level() const
 {
   return finest_level;
 }

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -11099,11 +11099,13 @@ namespace internal
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 const unsigned int Triangulation<dim, spacedim>::dimension;
 
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 Triangulation<dim, spacedim>::Triangulation(
   const MeshSmoothing smooth_grid,
   const bool          check_for_distorted_cells)
@@ -11129,6 +11131,7 @@ Triangulation<dim, spacedim>::Triangulation(
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 Triangulation<dim, spacedim>::Triangulation(
   Triangulation<dim, spacedim> &&tria) noexcept
   : Subscriptor(std::move(tria))
@@ -11155,8 +11158,8 @@ Triangulation<dim, spacedim>::Triangulation(
 
 
 template <int dim, int spacedim>
-Triangulation<dim, spacedim> &
-Triangulation<dim, spacedim>::operator=(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+Triangulation<dim, spacedim> &Triangulation<dim, spacedim>::operator=(
   Triangulation<dim, spacedim> &&tria) noexcept
 {
   Subscriptor::operator=(std::move(tria));
@@ -11186,6 +11189,7 @@ Triangulation<dim, spacedim>::operator=(
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 Triangulation<dim, spacedim>::~Triangulation()
 {
   // notify listeners that the triangulation is going down...
@@ -11214,8 +11218,8 @@ Triangulation<dim, spacedim>::~Triangulation()
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::clear()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::clear()
 {
   // notify listeners that the triangulation is going down...
   signals.clear();
@@ -11229,8 +11233,8 @@ Triangulation<dim, spacedim>::clear()
 
 
 template <int dim, int spacedim>
-MPI_Comm
-Triangulation<dim, spacedim>::get_communicator() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+MPI_Comm Triangulation<dim, spacedim>::get_communicator() const
 {
   return MPI_COMM_SELF;
 }
@@ -11238,8 +11242,10 @@ Triangulation<dim, spacedim>::get_communicator() const
 
 
 template <int dim, int spacedim>
-const std::weak_ptr<const Utilities::MPI::Partitioner>
-Triangulation<dim, spacedim>::global_active_cell_index_partitioner() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+const std::weak_ptr<const Utilities::MPI::Partitioner> Triangulation<
+  dim,
+  spacedim>::global_active_cell_index_partitioner() const
 {
   return number_cache.active_cell_index_partitioner;
 }
@@ -11247,9 +11253,10 @@ Triangulation<dim, spacedim>::global_active_cell_index_partitioner() const
 
 
 template <int dim, int spacedim>
-const std::weak_ptr<const Utilities::MPI::Partitioner>
-Triangulation<dim, spacedim>::global_level_cell_index_partitioner(
-  const unsigned int level) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+const std::weak_ptr<const Utilities::MPI::Partitioner> Triangulation<
+  dim,
+  spacedim>::global_level_cell_index_partitioner(const unsigned int level) const
 {
   AssertIndexRange(level, this->n_levels());
 
@@ -11259,8 +11266,8 @@ Triangulation<dim, spacedim>::global_level_cell_index_partitioner(
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::set_mesh_smoothing(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::set_mesh_smoothing(
   const MeshSmoothing mesh_smoothing)
 {
   Assert(n_levels() == 0,
@@ -11271,8 +11278,9 @@ Triangulation<dim, spacedim>::set_mesh_smoothing(
 
 
 template <int dim, int spacedim>
-const typename Triangulation<dim, spacedim>::MeshSmoothing &
-Triangulation<dim, spacedim>::get_mesh_smoothing() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+const typename Triangulation<dim, spacedim>::MeshSmoothing
+  &Triangulation<dim, spacedim>::get_mesh_smoothing() const
 {
   return smooth_grid;
 }
@@ -11280,8 +11288,8 @@ Triangulation<dim, spacedim>::get_mesh_smoothing() const
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::set_manifold(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::set_manifold(
   const types::manifold_id       m_number,
   const Manifold<dim, spacedim> &manifold_object)
 {
@@ -11293,8 +11301,9 @@ Triangulation<dim, spacedim>::set_manifold(
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::reset_manifold(const types::manifold_id m_number)
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::reset_manifold(
+  const types::manifold_id m_number)
 {
   AssertIndexRange(m_number, numbers::flat_manifold_id);
 
@@ -11304,16 +11313,16 @@ Triangulation<dim, spacedim>::reset_manifold(const types::manifold_id m_number)
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::reset_all_manifolds()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::reset_all_manifolds()
 {
   manifolds.clear();
 }
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::set_all_manifold_ids(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::set_all_manifold_ids(
   const types::manifold_id m_number)
 {
   Assert(
@@ -11327,8 +11336,8 @@ Triangulation<dim, spacedim>::set_all_manifold_ids(
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::set_all_manifold_ids_on_boundary(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::set_all_manifold_ids_on_boundary(
   const types::manifold_id m_number)
 {
   Assert(
@@ -11344,8 +11353,8 @@ Triangulation<dim, spacedim>::set_all_manifold_ids_on_boundary(
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::set_all_manifold_ids_on_boundary(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::set_all_manifold_ids_on_boundary(
   const types::boundary_id b_id,
   const types::manifold_id m_number)
 {
@@ -11385,8 +11394,8 @@ Triangulation<dim, spacedim>::set_all_manifold_ids_on_boundary(
 
 
 template <int dim, int spacedim>
-const Manifold<dim, spacedim> &
-Triangulation<dim, spacedim>::get_manifold(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+const Manifold<dim, spacedim> &Triangulation<dim, spacedim>::get_manifold(
   const types::manifold_id m_number) const
 {
   // look, if there is a manifold stored at
@@ -11408,8 +11417,9 @@ Triangulation<dim, spacedim>::get_manifold(
 
 
 template <int dim, int spacedim>
-std::vector<types::boundary_id>
-Triangulation<dim, spacedim>::get_boundary_ids() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+std::vector<types::boundary_id> Triangulation<dim, spacedim>::get_boundary_ids()
+  const
 {
   // in 1d, we store a map of all used boundary indicators. use it for
   // our purposes
@@ -11440,8 +11450,9 @@ Triangulation<dim, spacedim>::get_boundary_ids() const
 
 
 template <int dim, int spacedim>
-std::vector<types::manifold_id>
-Triangulation<dim, spacedim>::get_manifold_ids() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+std::vector<types::manifold_id> Triangulation<dim, spacedim>::get_manifold_ids()
+  const
 {
   std::set<types::manifold_id> m_ids;
   for (const auto &cell : active_cell_iterators())
@@ -11468,8 +11479,8 @@ Triangulation<dim, spacedim>::get_manifold_ids() const
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::copy_triangulation(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::copy_triangulation(
   const Triangulation<dim, spacedim> &other_tria)
 {
   Assert((vertices.size() == 0) && (levels.size() == 0) && (faces == nullptr),
@@ -11534,8 +11545,8 @@ Triangulation<dim, spacedim>::copy_triangulation(
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::create_triangulation_compatibility(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::create_triangulation_compatibility(
   const std::vector<Point<spacedim>> &v,
   const std::vector<CellData<dim>> &  cells,
   const SubCellData &                 subcelldata)
@@ -11553,8 +11564,8 @@ Triangulation<dim, spacedim>::create_triangulation_compatibility(
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::reset_policy()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::reset_policy()
 {
   this->update_reference_cells();
 
@@ -11579,8 +11590,8 @@ Triangulation<dim, spacedim>::reset_policy()
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::create_triangulation(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::create_triangulation(
   const std::vector<Point<spacedim>> &v,
   const std::vector<CellData<dim>> &  cells,
   const SubCellData &                 subcelldata)
@@ -11764,8 +11775,8 @@ Triangulation<dim, spacedim>::create_triangulation(
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::create_triangulation(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::create_triangulation(
   const TriangulationDescription::Description<dim, spacedim> &construction_data)
 {
   // 1) create coarse grid
@@ -11891,8 +11902,8 @@ Triangulation<dim, spacedim>::create_triangulation(
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::flip_all_direction_flags()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::flip_all_direction_flags()
 {
   AssertThrow(dim + 1 == spacedim,
               ExcMessage("Only works for dim == spacedim-1"));
@@ -11903,8 +11914,8 @@ Triangulation<dim, spacedim>::flip_all_direction_flags()
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::set_all_refine_flags()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::set_all_refine_flags()
 {
   Assert(n_cells() > 0,
          ExcMessage("Error: An empty Triangulation can not be refined."));
@@ -11919,8 +11930,8 @@ Triangulation<dim, spacedim>::set_all_refine_flags()
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::refine_global(const unsigned int times)
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::refine_global(const unsigned int times)
 {
   for (unsigned int i = 0; i < times; ++i)
     {
@@ -11932,8 +11943,8 @@ Triangulation<dim, spacedim>::refine_global(const unsigned int times)
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::coarsen_global(const unsigned int times)
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::coarsen_global(const unsigned int times)
 {
   for (unsigned int i = 0; i < times; ++i)
     {
@@ -11952,8 +11963,8 @@ Triangulation<dim, spacedim>::coarsen_global(const unsigned int times)
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::save_refine_flags(std::vector<bool> &v) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::save_refine_flags(std::vector<bool> &v) const
 {
   v.resize(dim * n_active_cells(), false);
   std::vector<bool>::iterator i = v.begin();
@@ -11969,8 +11980,8 @@ Triangulation<dim, spacedim>::save_refine_flags(std::vector<bool> &v) const
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::save_refine_flags(std::ostream &out) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::save_refine_flags(std::ostream &out) const
 {
   std::vector<bool> v;
   save_refine_flags(v);
@@ -11983,8 +11994,8 @@ Triangulation<dim, spacedim>::save_refine_flags(std::ostream &out) const
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::load_refine_flags(std::istream &in)
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::load_refine_flags(std::istream &in)
 {
   std::vector<bool> v;
   read_bool_vector(mn_tria_refine_flags_begin, v, mn_tria_refine_flags_end, in);
@@ -11994,8 +12005,8 @@ Triangulation<dim, spacedim>::load_refine_flags(std::istream &in)
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::load_refine_flags(const std::vector<bool> &v)
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::load_refine_flags(const std::vector<bool> &v)
 {
   AssertThrow(v.size() == dim * n_active_cells(), ExcGridReadError());
 
@@ -12021,8 +12032,9 @@ Triangulation<dim, spacedim>::load_refine_flags(const std::vector<bool> &v)
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::save_coarsen_flags(std::vector<bool> &v) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::save_coarsen_flags(
+  std::vector<bool> &v) const
 {
   v.resize(n_active_cells(), false);
   std::vector<bool>::iterator i = v.begin();
@@ -12038,8 +12050,8 @@ Triangulation<dim, spacedim>::save_coarsen_flags(std::vector<bool> &v) const
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::save_coarsen_flags(std::ostream &out) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::save_coarsen_flags(std::ostream &out) const
 {
   std::vector<bool> v;
   save_coarsen_flags(v);
@@ -12052,8 +12064,8 @@ Triangulation<dim, spacedim>::save_coarsen_flags(std::ostream &out) const
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::load_coarsen_flags(std::istream &in)
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::load_coarsen_flags(std::istream &in)
 {
   std::vector<bool> v;
   read_bool_vector(mn_tria_coarsen_flags_begin,
@@ -12066,8 +12078,9 @@ Triangulation<dim, spacedim>::load_coarsen_flags(std::istream &in)
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::load_coarsen_flags(const std::vector<bool> &v)
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::load_coarsen_flags(
+  const std::vector<bool> &v)
 {
   Assert(v.size() == n_active_cells(), ExcGridReadError());
 
@@ -12086,8 +12099,8 @@ Triangulation<dim, spacedim>::load_coarsen_flags(const std::vector<bool> &v)
 
 
 template <int dim, int spacedim>
-bool
-Triangulation<dim, spacedim>::get_anisotropic_refinement_flag() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+bool Triangulation<dim, spacedim>::get_anisotropic_refinement_flag() const
 {
   return anisotropic_refinement;
 }
@@ -12158,8 +12171,8 @@ namespace
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::clear_user_data()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::clear_user_data()
 {
   // let functions in anonymous namespace do their work
   dealii::clear_user_data(levels);
@@ -12197,8 +12210,8 @@ namespace
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::clear_user_flags_line()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::clear_user_flags_line()
 {
   dealii::clear_user_flags_line(dim, levels, faces.get());
 }
@@ -12237,8 +12250,8 @@ namespace
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::clear_user_flags_quad()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::clear_user_flags_quad()
 {
   dealii::clear_user_flags_quad(dim, levels, faces.get());
 }
@@ -12277,8 +12290,8 @@ namespace
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::clear_user_flags_hex()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::clear_user_flags_hex()
 {
   dealii::clear_user_flags_hex(dim, levels, faces.get());
 }
@@ -12286,8 +12299,8 @@ Triangulation<dim, spacedim>::clear_user_flags_hex()
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::clear_user_flags()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::clear_user_flags()
 {
   clear_user_flags_line();
   clear_user_flags_quad();
@@ -12297,8 +12310,8 @@ Triangulation<dim, spacedim>::clear_user_flags()
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::save_user_flags(std::ostream &out) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::save_user_flags(std::ostream &out) const
 {
   save_user_flags_line(out);
 
@@ -12315,8 +12328,8 @@ Triangulation<dim, spacedim>::save_user_flags(std::ostream &out) const
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::save_user_flags(std::vector<bool> &v) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::save_user_flags(std::vector<bool> &v) const
 {
   // clear vector and append
   // all the stuff later on
@@ -12346,8 +12359,8 @@ Triangulation<dim, spacedim>::save_user_flags(std::vector<bool> &v) const
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::load_user_flags(std::istream &in)
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::load_user_flags(std::istream &in)
 {
   load_user_flags_line(in);
 
@@ -12364,8 +12377,8 @@ Triangulation<dim, spacedim>::load_user_flags(std::istream &in)
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::load_user_flags(const std::vector<bool> &v)
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::load_user_flags(const std::vector<bool> &v)
 {
   Assert(v.size() == n_lines() + n_quads() + n_hexs(), ExcInternalError());
   std::vector<bool> tmp;
@@ -12401,8 +12414,9 @@ Triangulation<dim, spacedim>::load_user_flags(const std::vector<bool> &v)
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::save_user_flags_line(std::vector<bool> &v) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::save_user_flags_line(
+  std::vector<bool> &v) const
 {
   v.resize(n_lines(), false);
   std::vector<bool>::iterator i    = v.begin();
@@ -12416,8 +12430,8 @@ Triangulation<dim, spacedim>::save_user_flags_line(std::vector<bool> &v) const
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::save_user_flags_line(std::ostream &out) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::save_user_flags_line(std::ostream &out) const
 {
   std::vector<bool> v;
   save_user_flags_line(v);
@@ -12430,8 +12444,8 @@ Triangulation<dim, spacedim>::save_user_flags_line(std::ostream &out) const
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::load_user_flags_line(std::istream &in)
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::load_user_flags_line(std::istream &in)
 {
   std::vector<bool> v;
   read_bool_vector(mn_tria_line_user_flags_begin,
@@ -12444,8 +12458,9 @@ Triangulation<dim, spacedim>::load_user_flags_line(std::istream &in)
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::load_user_flags_line(const std::vector<bool> &v)
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::load_user_flags_line(
+  const std::vector<bool> &v)
 {
   Assert(v.size() == n_lines(), ExcGridReadError());
 
@@ -12520,8 +12535,9 @@ namespace
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::save_user_flags_quad(std::vector<bool> &v) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::save_user_flags_quad(
+  std::vector<bool> &v) const
 {
   v.resize(n_quads(), false);
 
@@ -12539,8 +12555,8 @@ Triangulation<dim, spacedim>::save_user_flags_quad(std::vector<bool> &v) const
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::save_user_flags_quad(std::ostream &out) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::save_user_flags_quad(std::ostream &out) const
 {
   std::vector<bool> v;
   save_user_flags_quad(v);
@@ -12553,8 +12569,8 @@ Triangulation<dim, spacedim>::save_user_flags_quad(std::ostream &out) const
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::load_user_flags_quad(std::istream &in)
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::load_user_flags_quad(std::istream &in)
 {
   std::vector<bool> v;
   read_bool_vector(mn_tria_quad_user_flags_begin,
@@ -12567,8 +12583,9 @@ Triangulation<dim, spacedim>::load_user_flags_quad(std::istream &in)
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::load_user_flags_quad(const std::vector<bool> &v)
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::load_user_flags_quad(
+  const std::vector<bool> &v)
 {
   Assert(v.size() == n_quads(), ExcGridReadError());
 
@@ -12589,8 +12606,9 @@ Triangulation<dim, spacedim>::load_user_flags_quad(const std::vector<bool> &v)
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::save_user_flags_hex(std::vector<bool> &v) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::save_user_flags_hex(
+  std::vector<bool> &v) const
 {
   v.resize(n_hexs(), false);
 
@@ -12608,8 +12626,8 @@ Triangulation<dim, spacedim>::save_user_flags_hex(std::vector<bool> &v) const
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::save_user_flags_hex(std::ostream &out) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::save_user_flags_hex(std::ostream &out) const
 {
   std::vector<bool> v;
   save_user_flags_hex(v);
@@ -12622,8 +12640,8 @@ Triangulation<dim, spacedim>::save_user_flags_hex(std::ostream &out) const
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::load_user_flags_hex(std::istream &in)
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::load_user_flags_hex(std::istream &in)
 {
   std::vector<bool> v;
   read_bool_vector(mn_tria_hex_user_flags_begin,
@@ -12636,8 +12654,9 @@ Triangulation<dim, spacedim>::load_user_flags_hex(std::istream &in)
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::load_user_flags_hex(const std::vector<bool> &v)
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::load_user_flags_hex(
+  const std::vector<bool> &v)
 {
   Assert(v.size() == n_hexs(), ExcGridReadError());
 
@@ -12658,8 +12677,8 @@ Triangulation<dim, spacedim>::load_user_flags_hex(const std::vector<bool> &v)
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::save_user_indices(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::save_user_indices(
   std::vector<unsigned int> &v) const
 {
   // clear vector and append all the
@@ -12690,8 +12709,8 @@ Triangulation<dim, spacedim>::save_user_indices(
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::load_user_indices(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::load_user_indices(
   const std::vector<unsigned int> &v)
 {
   Assert(v.size() == n_lines() + n_quads() + n_hexs(), ExcInternalError());
@@ -12770,8 +12789,8 @@ namespace
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::save_user_indices_line(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::save_user_indices_line(
   std::vector<unsigned int> &v) const
 {
   v.resize(n_lines(), 0);
@@ -12784,8 +12803,8 @@ Triangulation<dim, spacedim>::save_user_indices_line(
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::load_user_indices_line(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::load_user_indices_line(
   const std::vector<unsigned int> &v)
 {
   Assert(v.size() == n_lines(), ExcGridReadError());
@@ -12798,8 +12817,8 @@ Triangulation<dim, spacedim>::load_user_indices_line(
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::save_user_indices_quad(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::save_user_indices_quad(
   std::vector<unsigned int> &v) const
 {
   v.resize(n_quads(), 0);
@@ -12816,8 +12835,8 @@ Triangulation<dim, spacedim>::save_user_indices_quad(
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::load_user_indices_quad(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::load_user_indices_quad(
   const std::vector<unsigned int> &v)
 {
   Assert(v.size() == n_quads(), ExcGridReadError());
@@ -12833,8 +12852,8 @@ Triangulation<dim, spacedim>::load_user_indices_quad(
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::save_user_indices_hex(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::save_user_indices_hex(
   std::vector<unsigned int> &v) const
 {
   v.resize(n_hexs(), 0);
@@ -12851,8 +12870,8 @@ Triangulation<dim, spacedim>::save_user_indices_hex(
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::load_user_indices_hex(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::load_user_indices_hex(
   const std::vector<unsigned int> &v)
 {
   Assert(v.size() == n_hexs(), ExcGridReadError());
@@ -12914,8 +12933,9 @@ namespace
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::save_user_pointers(std::vector<void *> &v) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::save_user_pointers(
+  std::vector<void *> &v) const
 {
   // clear vector and append all the
   // stuff later on
@@ -12945,8 +12965,9 @@ Triangulation<dim, spacedim>::save_user_pointers(std::vector<void *> &v) const
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::load_user_pointers(const std::vector<void *> &v)
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::load_user_pointers(
+  const std::vector<void *> &v)
 {
   Assert(v.size() == n_lines() + n_quads() + n_hexs(), ExcInternalError());
   std::vector<void *> tmp;
@@ -12982,8 +13003,8 @@ Triangulation<dim, spacedim>::load_user_pointers(const std::vector<void *> &v)
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::save_user_pointers_line(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::save_user_pointers_line(
   std::vector<void *> &v) const
 {
   v.resize(n_lines(), nullptr);
@@ -12996,8 +13017,8 @@ Triangulation<dim, spacedim>::save_user_pointers_line(
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::load_user_pointers_line(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::load_user_pointers_line(
   const std::vector<void *> &v)
 {
   Assert(v.size() == n_lines(), ExcGridReadError());
@@ -13011,8 +13032,8 @@ Triangulation<dim, spacedim>::load_user_pointers_line(
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::save_user_pointers_quad(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::save_user_pointers_quad(
   std::vector<void *> &v) const
 {
   v.resize(n_quads(), nullptr);
@@ -13029,8 +13050,8 @@ Triangulation<dim, spacedim>::save_user_pointers_quad(
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::load_user_pointers_quad(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::load_user_pointers_quad(
   const std::vector<void *> &v)
 {
   Assert(v.size() == n_quads(), ExcGridReadError());
@@ -13046,8 +13067,8 @@ Triangulation<dim, spacedim>::load_user_pointers_quad(
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::save_user_pointers_hex(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::save_user_pointers_hex(
   std::vector<void *> &v) const
 {
   v.resize(n_hexs(), nullptr);
@@ -13064,8 +13085,8 @@ Triangulation<dim, spacedim>::save_user_pointers_hex(
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::load_user_pointers_hex(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::load_user_pointers_hex(
   const std::vector<void *> &v)
 {
   Assert(v.size() == n_hexs(), ExcGridReadError());
@@ -13085,8 +13106,9 @@ Triangulation<dim, spacedim>::load_user_pointers_hex(
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::raw_cell_iterator
-Triangulation<dim, spacedim>::begin_raw(const unsigned int level) const
+  Triangulation<dim, spacedim>::begin_raw(const unsigned int level) const
 {
   switch (dim)
     {
@@ -13105,8 +13127,9 @@ Triangulation<dim, spacedim>::begin_raw(const unsigned int level) const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::cell_iterator
-Triangulation<dim, spacedim>::begin(const unsigned int level) const
+  Triangulation<dim, spacedim>::begin(const unsigned int level) const
 {
   switch (dim)
     {
@@ -13125,8 +13148,9 @@ Triangulation<dim, spacedim>::begin(const unsigned int level) const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::active_cell_iterator
-Triangulation<dim, spacedim>::begin_active(const unsigned int level) const
+  Triangulation<dim, spacedim>::begin_active(const unsigned int level) const
 {
   switch (dim)
     {
@@ -13145,8 +13169,9 @@ Triangulation<dim, spacedim>::begin_active(const unsigned int level) const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::cell_iterator
-Triangulation<dim, spacedim>::last() const
+  Triangulation<dim, spacedim>::last() const
 {
   const unsigned int level = levels.size() - 1;
   if (levels[level]->cells.n_objects() == 0)
@@ -13170,8 +13195,9 @@ Triangulation<dim, spacedim>::last() const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::active_cell_iterator
-Triangulation<dim, spacedim>::last_active() const
+  Triangulation<dim, spacedim>::last_active() const
 {
   // get the last used cell
   cell_iterator cell = last();
@@ -13191,8 +13217,10 @@ Triangulation<dim, spacedim>::last_active() const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::cell_iterator
-Triangulation<dim, spacedim>::create_cell_iterator(const CellId &cell_id) const
+  Triangulation<dim, spacedim>::create_cell_iterator(
+    const CellId &cell_id) const
 {
   cell_iterator cell(
     this, 0, coarse_cell_id_to_coarse_cell_index(cell_id.get_coarse_cell_id()));
@@ -13216,8 +13244,9 @@ Triangulation<dim, spacedim>::create_cell_iterator(const CellId &cell_id) const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::cell_iterator
-Triangulation<dim, spacedim>::end() const
+  Triangulation<dim, spacedim>::end() const
 {
   return cell_iterator(const_cast<Triangulation<dim, spacedim> *>(this),
                        -1,
@@ -13227,8 +13256,9 @@ Triangulation<dim, spacedim>::end() const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::raw_cell_iterator
-Triangulation<dim, spacedim>::end_raw(const unsigned int level) const
+  Triangulation<dim, spacedim>::end_raw(const unsigned int level) const
 {
   // This function may be called on parallel triangulations on levels
   // that exist globally, but not on the local portion of the
@@ -13256,8 +13286,9 @@ Triangulation<dim, spacedim>::end_raw(const unsigned int level) const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::cell_iterator
-Triangulation<dim, spacedim>::end(const unsigned int level) const
+  Triangulation<dim, spacedim>::end(const unsigned int level) const
 {
   // This function may be called on parallel triangulations on levels
   // that exist globally, but not on the local portion of the
@@ -13285,8 +13316,9 @@ Triangulation<dim, spacedim>::end(const unsigned int level) const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::active_cell_iterator
-Triangulation<dim, spacedim>::end_active(const unsigned int level) const
+  Triangulation<dim, spacedim>::end_active(const unsigned int level) const
 {
   // This function may be called on parallel triangulations on levels
   // that exist globally, but not on the local portion of the
@@ -13313,8 +13345,10 @@ Triangulation<dim, spacedim>::end_active(const unsigned int level) const
 
 
 template <int dim, int spacedim>
-IteratorRange<typename Triangulation<dim, spacedim>::cell_iterator>
-Triangulation<dim, spacedim>::cell_iterators() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+IteratorRange<typename Triangulation<dim, spacedim>::
+                cell_iterator> Triangulation<dim, spacedim>::cell_iterators()
+  const
 {
   return IteratorRange<typename Triangulation<dim, spacedim>::cell_iterator>(
     begin(), end());
@@ -13322,8 +13356,10 @@ Triangulation<dim, spacedim>::cell_iterators() const
 
 
 template <int dim, int spacedim>
-IteratorRange<typename Triangulation<dim, spacedim>::active_cell_iterator>
-Triangulation<dim, spacedim>::active_cell_iterators() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+IteratorRange<typename Triangulation<dim, spacedim>::
+                active_cell_iterator> Triangulation<dim, spacedim>::
+  active_cell_iterators() const
 {
   return IteratorRange<
     typename Triangulation<dim, spacedim>::active_cell_iterator>(begin_active(),
@@ -13333,9 +13369,10 @@ Triangulation<dim, spacedim>::active_cell_iterators() const
 
 
 template <int dim, int spacedim>
-IteratorRange<typename Triangulation<dim, spacedim>::cell_iterator>
-Triangulation<dim, spacedim>::cell_iterators_on_level(
-  const unsigned int level) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+IteratorRange<typename Triangulation<dim, spacedim>::
+                cell_iterator> Triangulation<dim, spacedim>::
+  cell_iterators_on_level(const unsigned int level) const
 {
   return IteratorRange<typename Triangulation<dim, spacedim>::cell_iterator>(
     begin(level), end(level));
@@ -13344,9 +13381,10 @@ Triangulation<dim, spacedim>::cell_iterators_on_level(
 
 
 template <int dim, int spacedim>
-IteratorRange<typename Triangulation<dim, spacedim>::active_cell_iterator>
-Triangulation<dim, spacedim>::active_cell_iterators_on_level(
-  const unsigned int level) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+IteratorRange<typename Triangulation<dim, spacedim>::
+                active_cell_iterator> Triangulation<dim, spacedim>::
+  active_cell_iterators_on_level(const unsigned int level) const
 {
   return IteratorRange<
     typename Triangulation<dim, spacedim>::active_cell_iterator>(
@@ -13358,8 +13396,9 @@ Triangulation<dim, spacedim>::active_cell_iterators_on_level(
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::face_iterator
-Triangulation<dim, spacedim>::begin_face() const
+  Triangulation<dim, spacedim>::begin_face() const
 {
   switch (dim)
     {
@@ -13379,8 +13418,9 @@ Triangulation<dim, spacedim>::begin_face() const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::active_face_iterator
-Triangulation<dim, spacedim>::begin_active_face() const
+  Triangulation<dim, spacedim>::begin_active_face() const
 {
   switch (dim)
     {
@@ -13400,8 +13440,9 @@ Triangulation<dim, spacedim>::begin_active_face() const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::face_iterator
-Triangulation<dim, spacedim>::end_face() const
+  Triangulation<dim, spacedim>::end_face() const
 {
   switch (dim)
     {
@@ -13421,8 +13462,10 @@ Triangulation<dim, spacedim>::end_face() const
 
 
 template <int dim, int spacedim>
-IteratorRange<typename Triangulation<dim, spacedim>::active_face_iterator>
-Triangulation<dim, spacedim>::active_face_iterators() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+IteratorRange<typename Triangulation<dim, spacedim>::
+                active_face_iterator> Triangulation<dim, spacedim>::
+  active_face_iterators() const
 {
   return IteratorRange<
     typename Triangulation<dim, spacedim>::active_face_iterator>(
@@ -13433,8 +13476,9 @@ Triangulation<dim, spacedim>::active_face_iterators() const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::vertex_iterator
-Triangulation<dim, spacedim>::begin_vertex() const
+  Triangulation<dim, spacedim>::begin_vertex() const
 {
   vertex_iterator i =
     raw_vertex_iterator(const_cast<Triangulation<dim, spacedim> *>(this), 0, 0);
@@ -13450,8 +13494,9 @@ Triangulation<dim, spacedim>::begin_vertex() const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::active_vertex_iterator
-Triangulation<dim, spacedim>::begin_active_vertex() const
+  Triangulation<dim, spacedim>::begin_active_vertex() const
 {
   // every vertex is active
   return begin_vertex();
@@ -13460,8 +13505,9 @@ Triangulation<dim, spacedim>::begin_active_vertex() const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::vertex_iterator
-Triangulation<dim, spacedim>::end_vertex() const
+  Triangulation<dim, spacedim>::end_vertex() const
 {
   return raw_vertex_iterator(const_cast<Triangulation<dim, spacedim> *>(this),
                              -1,
@@ -13475,8 +13521,9 @@ Triangulation<dim, spacedim>::end_vertex() const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::raw_line_iterator
-Triangulation<dim, spacedim>::begin_raw_line(const unsigned int level) const
+  Triangulation<dim, spacedim>::begin_raw_line(const unsigned int level) const
 {
   // This function may be called on parallel triangulations on levels
   // that exist globally, but not on the local portion of the
@@ -13515,8 +13562,9 @@ Triangulation<dim, spacedim>::begin_raw_line(const unsigned int level) const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::line_iterator
-Triangulation<dim, spacedim>::begin_line(const unsigned int level) const
+  Triangulation<dim, spacedim>::begin_line(const unsigned int level) const
 {
   // level is checked in begin_raw
   raw_line_iterator ri = begin_raw_line(level);
@@ -13531,8 +13579,10 @@ Triangulation<dim, spacedim>::begin_line(const unsigned int level) const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::active_line_iterator
-Triangulation<dim, spacedim>::begin_active_line(const unsigned int level) const
+  Triangulation<dim, spacedim>::begin_active_line(
+    const unsigned int level) const
 {
   // level is checked in begin_raw
   line_iterator i = begin_line(level);
@@ -13547,8 +13597,9 @@ Triangulation<dim, spacedim>::begin_active_line(const unsigned int level) const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::line_iterator
-Triangulation<dim, spacedim>::end_line() const
+  Triangulation<dim, spacedim>::end_line() const
 {
   return raw_line_iterator(const_cast<Triangulation<dim, spacedim> *>(this),
                            -1,
@@ -13561,8 +13612,9 @@ Triangulation<dim, spacedim>::end_line() const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::raw_quad_iterator
-Triangulation<dim, spacedim>::begin_raw_quad(const unsigned int level) const
+  Triangulation<dim, spacedim>::begin_raw_quad(const unsigned int level) const
 {
   // This function may be called on parallel triangulations on levels
   // that exist globally, but not on the local portion of the
@@ -13615,8 +13667,9 @@ Triangulation<dim, spacedim>::begin_raw_quad(const unsigned int level) const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::quad_iterator
-Triangulation<dim, spacedim>::begin_quad(const unsigned int level) const
+  Triangulation<dim, spacedim>::begin_quad(const unsigned int level) const
 {
   // level is checked in begin_raw
   raw_quad_iterator ri = begin_raw_quad(level);
@@ -13631,8 +13684,10 @@ Triangulation<dim, spacedim>::begin_quad(const unsigned int level) const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::active_quad_iterator
-Triangulation<dim, spacedim>::begin_active_quad(const unsigned int level) const
+  Triangulation<dim, spacedim>::begin_active_quad(
+    const unsigned int level) const
 {
   // level is checked in begin_raw
   quad_iterator i = begin_quad(level);
@@ -13647,8 +13702,9 @@ Triangulation<dim, spacedim>::begin_active_quad(const unsigned int level) const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::quad_iterator
-Triangulation<dim, spacedim>::end_quad() const
+  Triangulation<dim, spacedim>::end_quad() const
 {
   return raw_quad_iterator(const_cast<Triangulation<dim, spacedim> *>(this),
                            -1,
@@ -13660,8 +13716,9 @@ Triangulation<dim, spacedim>::end_quad() const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::raw_hex_iterator
-Triangulation<dim, spacedim>::begin_raw_hex(const unsigned int level) const
+  Triangulation<dim, spacedim>::begin_raw_hex(const unsigned int level) const
 {
   // This function may be called on parallel triangulations on levels
   // that exist globally, but not on the local portion of the
@@ -13706,8 +13763,9 @@ Triangulation<dim, spacedim>::begin_raw_hex(const unsigned int level) const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::hex_iterator
-Triangulation<dim, spacedim>::begin_hex(const unsigned int level) const
+  Triangulation<dim, spacedim>::begin_hex(const unsigned int level) const
 {
   // level is checked in begin_raw
   raw_hex_iterator ri = begin_raw_hex(level);
@@ -13722,8 +13780,9 @@ Triangulation<dim, spacedim>::begin_hex(const unsigned int level) const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::active_hex_iterator
-Triangulation<dim, spacedim>::begin_active_hex(const unsigned int level) const
+  Triangulation<dim, spacedim>::begin_active_hex(const unsigned int level) const
 {
   // level is checked in begin_raw
   hex_iterator i = begin_hex(level);
@@ -13738,8 +13797,9 @@ Triangulation<dim, spacedim>::begin_active_hex(const unsigned int level) const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::hex_iterator
-Triangulation<dim, spacedim>::end_hex() const
+  Triangulation<dim, spacedim>::end_hex() const
 {
   return raw_hex_iterator(const_cast<Triangulation<dim, spacedim> *>(this),
                           -1,
@@ -13804,37 +13864,39 @@ namespace internal
 
 
 template <int dim, int spacedim>
-unsigned int
-Triangulation<dim, spacedim>::n_cells() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int Triangulation<dim, spacedim>::n_cells() const
 {
   return internal::TriangulationImplementation::n_cells(number_cache);
 }
 
 
 template <int dim, int spacedim>
-unsigned int
-Triangulation<dim, spacedim>::n_active_cells() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int Triangulation<dim, spacedim>::n_active_cells() const
 {
   return internal::TriangulationImplementation::n_active_cells(number_cache);
 }
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 types::global_cell_index
-Triangulation<dim, spacedim>::n_global_active_cells() const
+  Triangulation<dim, spacedim>::n_global_active_cells() const
 {
   return n_active_cells();
 }
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 types::coarse_cell_id
-Triangulation<dim, spacedim>::n_global_coarse_cells() const
+  Triangulation<dim, spacedim>::n_global_coarse_cells() const
 {
   return n_cells(0);
 }
 
 template <int dim, int spacedim>
-unsigned int
-Triangulation<dim, spacedim>::n_faces() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int Triangulation<dim, spacedim>::n_faces() const
 {
   switch (dim)
     {
@@ -13852,8 +13914,8 @@ Triangulation<dim, spacedim>::n_faces() const
 
 
 template <int dim, int spacedim>
-unsigned int
-Triangulation<dim, spacedim>::n_raw_faces() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int Triangulation<dim, spacedim>::n_raw_faces() const
 {
   switch (dim)
     {
@@ -13871,8 +13933,8 @@ Triangulation<dim, spacedim>::n_raw_faces() const
 
 
 template <int dim, int spacedim>
-unsigned int
-Triangulation<dim, spacedim>::n_active_faces() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int Triangulation<dim, spacedim>::n_active_faces() const
 {
   switch (dim)
     {
@@ -13890,8 +13952,9 @@ Triangulation<dim, spacedim>::n_active_faces() const
 
 
 template <int dim, int spacedim>
-unsigned int
-Triangulation<dim, spacedim>::n_raw_cells(const unsigned int level) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int Triangulation<dim, spacedim>::n_raw_cells(
+  const unsigned int level) const
 {
   switch (dim)
     {
@@ -13910,8 +13973,9 @@ Triangulation<dim, spacedim>::n_raw_cells(const unsigned int level) const
 
 
 template <int dim, int spacedim>
-unsigned int
-Triangulation<dim, spacedim>::n_cells(const unsigned int level) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int Triangulation<dim, spacedim>::n_cells(
+  const unsigned int level) const
 {
   switch (dim)
     {
@@ -13930,8 +13994,9 @@ Triangulation<dim, spacedim>::n_cells(const unsigned int level) const
 
 
 template <int dim, int spacedim>
-unsigned int
-Triangulation<dim, spacedim>::n_active_cells(const unsigned int level) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int Triangulation<dim, spacedim>::n_active_cells(
+  const unsigned int level) const
 {
   switch (dim)
     {
@@ -13949,8 +14014,8 @@ Triangulation<dim, spacedim>::n_active_cells(const unsigned int level) const
 
 
 template <int dim, int spacedim>
-bool
-Triangulation<dim, spacedim>::has_hanging_nodes() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+bool Triangulation<dim, spacedim>::has_hanging_nodes() const
 {
   if (anisotropic_refinement == false)
     {
@@ -13970,8 +14035,8 @@ Triangulation<dim, spacedim>::has_hanging_nodes() const
 
 
 template <int dim, int spacedim>
-unsigned int
-Triangulation<dim, spacedim>::n_lines() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int Triangulation<dim, spacedim>::n_lines() const
 {
   return number_cache.n_lines;
 }
@@ -13979,8 +14044,9 @@ Triangulation<dim, spacedim>::n_lines() const
 
 
 template <int dim, int spacedim>
-unsigned int
-Triangulation<dim, spacedim>::n_raw_lines(const unsigned int level) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int Triangulation<dim, spacedim>::n_raw_lines(
+  const unsigned int level) const
 {
   if (dim == 1)
     {
@@ -13994,8 +14060,8 @@ Triangulation<dim, spacedim>::n_raw_lines(const unsigned int level) const
 
 
 template <int dim, int spacedim>
-unsigned int
-Triangulation<dim, spacedim>::n_raw_lines() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int Triangulation<dim, spacedim>::n_raw_lines() const
 {
   if (dim == 1)
     {
@@ -14008,8 +14074,9 @@ Triangulation<dim, spacedim>::n_raw_lines() const
 
 
 template <int dim, int spacedim>
-unsigned int
-Triangulation<dim, spacedim>::n_lines(const unsigned int level) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int Triangulation<dim, spacedim>::n_lines(
+  const unsigned int level) const
 {
   AssertIndexRange(level, number_cache.n_lines_level.size());
   Assert(dim == 1, ExcFacesHaveNoLevel());
@@ -14018,16 +14085,17 @@ Triangulation<dim, spacedim>::n_lines(const unsigned int level) const
 
 
 template <int dim, int spacedim>
-unsigned int
-Triangulation<dim, spacedim>::n_active_lines() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int Triangulation<dim, spacedim>::n_active_lines() const
 {
   return number_cache.n_active_lines;
 }
 
 
 template <int dim, int spacedim>
-unsigned int
-Triangulation<dim, spacedim>::n_active_lines(const unsigned int level) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int Triangulation<dim, spacedim>::n_active_lines(
+  const unsigned int level) const
 {
   AssertIndexRange(level, number_cache.n_lines_level.size());
   Assert(dim == 1, ExcFacesHaveNoLevel());
@@ -14183,16 +14251,17 @@ Triangulation<1, 3>::n_active_quads() const
 
 
 template <int dim, int spacedim>
-unsigned int
-Triangulation<dim, spacedim>::n_quads() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int Triangulation<dim, spacedim>::n_quads() const
 {
   return number_cache.n_quads;
 }
 
 
 template <int dim, int spacedim>
-unsigned int
-Triangulation<dim, spacedim>::n_quads(const unsigned int level) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int Triangulation<dim, spacedim>::n_quads(
+  const unsigned int level) const
 {
   Assert(dim == 2, ExcFacesHaveNoLevel());
   AssertIndexRange(level, number_cache.n_quads_level.size());
@@ -14231,8 +14300,8 @@ Triangulation<3, 3>::n_raw_quads(const unsigned int) const
 
 
 template <int dim, int spacedim>
-unsigned int
-Triangulation<dim, spacedim>::n_raw_quads() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int Triangulation<dim, spacedim>::n_raw_quads() const
 {
   Assert(false, ExcNotImplemented());
   return 0;
@@ -14250,16 +14319,17 @@ Triangulation<3, 3>::n_raw_quads() const
 
 
 template <int dim, int spacedim>
-unsigned int
-Triangulation<dim, spacedim>::n_active_quads() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int Triangulation<dim, spacedim>::n_active_quads() const
 {
   return number_cache.n_active_quads;
 }
 
 
 template <int dim, int spacedim>
-unsigned int
-Triangulation<dim, spacedim>::n_active_quads(const unsigned int level) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int Triangulation<dim, spacedim>::n_active_quads(
+  const unsigned int level) const
 {
   AssertIndexRange(level, number_cache.n_quads_level.size());
   Assert(dim == 2, ExcFacesHaveNoLevel());
@@ -14269,8 +14339,8 @@ Triangulation<dim, spacedim>::n_active_quads(const unsigned int level) const
 
 
 template <int dim, int spacedim>
-unsigned int
-Triangulation<dim, spacedim>::n_hexs() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int Triangulation<dim, spacedim>::n_hexs() const
 {
   return 0;
 }
@@ -14278,8 +14348,8 @@ Triangulation<dim, spacedim>::n_hexs() const
 
 
 template <int dim, int spacedim>
-unsigned int
-Triangulation<dim, spacedim>::n_hexs(const unsigned int) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int Triangulation<dim, spacedim>::n_hexs(const unsigned int) const
 {
   return 0;
 }
@@ -14287,16 +14357,16 @@ Triangulation<dim, spacedim>::n_hexs(const unsigned int) const
 
 
 template <int dim, int spacedim>
-unsigned int
-Triangulation<dim, spacedim>::n_raw_hexs(const unsigned int) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int Triangulation<dim, spacedim>::n_raw_hexs(const unsigned int) const
 {
   return 0;
 }
 
 
 template <int dim, int spacedim>
-unsigned int
-Triangulation<dim, spacedim>::n_active_hexs() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int Triangulation<dim, spacedim>::n_active_hexs() const
 {
   return 0;
 }
@@ -14304,8 +14374,9 @@ Triangulation<dim, spacedim>::n_active_hexs() const
 
 
 template <int dim, int spacedim>
-unsigned int
-Triangulation<dim, spacedim>::n_active_hexs(const unsigned int) const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int Triangulation<dim, spacedim>::n_active_hexs(
+  const unsigned int) const
 {
   return 0;
 }
@@ -14361,8 +14432,8 @@ Triangulation<3, 3>::n_active_hexs(const unsigned int level) const
 
 
 template <int dim, int spacedim>
-unsigned int
-Triangulation<dim, spacedim>::n_used_vertices() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int Triangulation<dim, spacedim>::n_used_vertices() const
 {
   return std::count(vertices_used.begin(), vertices_used.end(), true);
 }
@@ -14370,8 +14441,8 @@ Triangulation<dim, spacedim>::n_used_vertices() const
 
 
 template <int dim, int spacedim>
-const std::vector<bool> &
-Triangulation<dim, spacedim>::get_used_vertices() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+const std::vector<bool> &Triangulation<dim, spacedim>::get_used_vertices() const
 {
   return vertices_used;
 }
@@ -14404,8 +14475,8 @@ Triangulation<1, 3>::max_adjacent_cells() const
 
 
 template <int dim, int spacedim>
-unsigned int
-Triangulation<dim, spacedim>::max_adjacent_cells() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+unsigned int Triangulation<dim, spacedim>::max_adjacent_cells() const
 {
   cell_iterator cell = begin(0),
                 endc = (n_levels() > 1 ? begin(1) : cell_iterator(end()));
@@ -14437,8 +14508,9 @@ Triangulation<dim, spacedim>::max_adjacent_cells() const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 types::subdomain_id
-Triangulation<dim, spacedim>::locally_owned_subdomain() const
+  Triangulation<dim, spacedim>::locally_owned_subdomain() const
 {
   return numbers::invalid_subdomain_id;
 }
@@ -14446,8 +14518,8 @@ Triangulation<dim, spacedim>::locally_owned_subdomain() const
 
 
 template <int dim, int spacedim>
-Triangulation<dim, spacedim> &
-Triangulation<dim, spacedim>::get_triangulation()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+Triangulation<dim, spacedim> &Triangulation<dim, spacedim>::get_triangulation()
 {
   return *this;
 }
@@ -14455,8 +14527,9 @@ Triangulation<dim, spacedim>::get_triangulation()
 
 
 template <int dim, int spacedim>
-const Triangulation<dim, spacedim> &
-Triangulation<dim, spacedim>::get_triangulation() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+const Triangulation<dim, spacedim>
+  &Triangulation<dim, spacedim>::get_triangulation() const
 {
   return *this;
 }
@@ -14464,8 +14537,8 @@ Triangulation<dim, spacedim>::get_triangulation() const
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::add_periodicity(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::add_periodicity(
   const std::vector<GridTools::PeriodicFacePair<cell_iterator>>
     &periodicity_vector)
 {
@@ -14480,12 +14553,13 @@ Triangulation<dim, spacedim>::add_periodicity(
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 const typename std::map<
   std::pair<typename Triangulation<dim, spacedim>::cell_iterator, unsigned int>,
   std::pair<std::pair<typename Triangulation<dim, spacedim>::cell_iterator,
                       unsigned int>,
-            std::bitset<3>>> &
-Triangulation<dim, spacedim>::get_periodic_face_map() const
+            std::bitset<3>>>
+  &Triangulation<dim, spacedim>::get_periodic_face_map() const
 {
   return periodic_face_map;
 }
@@ -14493,8 +14567,8 @@ Triangulation<dim, spacedim>::get_periodic_face_map() const
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::execute_coarsening_and_refinement()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::execute_coarsening_and_refinement()
 {
   // Call our version of prepare_coarsening_and_refinement() even if a derived
   // class like parallel::distributed::Triangulation overrides it. Their
@@ -14543,8 +14617,8 @@ Triangulation<dim, spacedim>::execute_coarsening_and_refinement()
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::reset_active_cell_indices()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::reset_active_cell_indices()
 {
   unsigned int active_cell_index = 0;
   for (raw_cell_iterator cell = begin_raw(); cell != end(); ++cell)
@@ -14562,8 +14636,8 @@ Triangulation<dim, spacedim>::reset_active_cell_indices()
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::reset_global_cell_indices()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::reset_global_cell_indices()
 {
   {
     types::global_cell_index cell_index = 0;
@@ -14582,8 +14656,8 @@ Triangulation<dim, spacedim>::reset_global_cell_indices()
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::reset_cell_vertex_indices_cache()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::reset_cell_vertex_indices_cache()
 {
   for (unsigned int l = 0; l < levels.size(); ++l)
     {
@@ -14656,8 +14730,8 @@ Triangulation<dim, spacedim>::reset_cell_vertex_indices_cache()
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::update_periodic_face_map()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::update_periodic_face_map()
 {
   // first empty the currently stored objects
   periodic_face_map.clear();
@@ -14719,8 +14793,8 @@ Triangulation<dim, spacedim>::update_periodic_face_map()
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::update_reference_cells()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::update_reference_cells()
 {
   std::set<ReferenceCell> reference_cells_set;
   for (auto cell : active_cell_iterators())
@@ -14735,8 +14809,9 @@ Triangulation<dim, spacedim>::update_reference_cells()
 
 
 template <int dim, int spacedim>
-const std::vector<ReferenceCell> &
-Triangulation<dim, spacedim>::get_reference_cells() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+const std::vector<ReferenceCell>
+  &Triangulation<dim, spacedim>::get_reference_cells() const
 {
   return this->reference_cells;
 }
@@ -14744,8 +14819,8 @@ Triangulation<dim, spacedim>::get_reference_cells() const
 
 
 template <int dim, int spacedim>
-bool
-Triangulation<dim, spacedim>::all_reference_cells_are_hyper_cube() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+bool Triangulation<dim, spacedim>::all_reference_cells_are_hyper_cube() const
 {
   Assert(this->reference_cells.size() > 0,
          ExcMessage("You can't ask about the kinds of reference "
@@ -14758,8 +14833,8 @@ Triangulation<dim, spacedim>::all_reference_cells_are_hyper_cube() const
 
 
 template <int dim, int spacedim>
-bool
-Triangulation<dim, spacedim>::all_reference_cells_are_simplex() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+bool Triangulation<dim, spacedim>::all_reference_cells_are_simplex() const
 {
   Assert(this->reference_cells.size() > 0,
          ExcMessage("You can't ask about the kinds of reference "
@@ -14772,8 +14847,8 @@ Triangulation<dim, spacedim>::all_reference_cells_are_simplex() const
 
 
 template <int dim, int spacedim>
-bool
-Triangulation<dim, spacedim>::is_mixed_mesh() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+bool Triangulation<dim, spacedim>::is_mixed_mesh() const
 {
   Assert(this->reference_cells.size() > 0,
          ExcMessage("You can't ask about the kinds of reference "
@@ -14787,8 +14862,8 @@ Triangulation<dim, spacedim>::is_mixed_mesh() const
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::clear_despite_subscriptions()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::clear_despite_subscriptions()
 {
   levels.clear();
   faces.reset();
@@ -14804,8 +14879,9 @@ Triangulation<dim, spacedim>::clear_despite_subscriptions()
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::DistortedCellList
-Triangulation<dim, spacedim>::execute_refinement()
+  Triangulation<dim, spacedim>::execute_refinement()
 {
   const DistortedCellList cells_with_distorted_children =
     this->policy->execute_refinement(*this, check_for_distorted_cells);
@@ -14834,8 +14910,8 @@ Triangulation<dim, spacedim>::execute_refinement()
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::execute_coarsening()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::execute_coarsening()
 {
   // first find out if there are any cells at all to be coarsened in the
   // loop below
@@ -14915,8 +14991,8 @@ Triangulation<dim, spacedim>::execute_coarsening()
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::fix_coarsen_flags()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::fix_coarsen_flags()
 {
   // copy a piece of code from prepare_coarsening_and_refinement that
   // ensures that the level difference at vertices is limited if so
@@ -15317,8 +15393,8 @@ namespace
 
 
 template <int dim, int spacedim>
-bool
-Triangulation<dim, spacedim>::prepare_coarsening_and_refinement()
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+bool Triangulation<dim, spacedim>::prepare_coarsening_and_refinement()
 {
   // save the flags to determine whether something was changed in the
   // course of this function
@@ -16326,8 +16402,8 @@ Triangulation<dim, spacedim>::prepare_coarsening_and_refinement()
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::write_bool_vector(
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::write_bool_vector(
   const unsigned int       magic_number1,
   const std::vector<bool> &v,
   const unsigned int       magic_number2,
@@ -16361,11 +16437,12 @@ Triangulation<dim, spacedim>::write_bool_vector(
 
 
 template <int dim, int spacedim>
-void
-Triangulation<dim, spacedim>::read_bool_vector(const unsigned int magic_number1,
-                                               std::vector<bool> &v,
-                                               const unsigned int magic_number2,
-                                               std::istream &     in)
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::read_bool_vector(
+  const unsigned int magic_number1,
+  std::vector<bool> &v,
+  const unsigned int magic_number2,
+  std::istream &     in)
 {
   AssertThrow(in.fail() == false, ExcIO());
 
@@ -16399,8 +16476,8 @@ Triangulation<dim, spacedim>::read_bool_vector(const unsigned int magic_number1,
 
 
 template <int dim, int spacedim>
-std::size_t
-Triangulation<dim, spacedim>::memory_consumption() const
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+std::size_t Triangulation<dim, spacedim>::memory_consumption() const
 {
   std::size_t mem = 0;
   mem += sizeof(MeshSmoothing);
@@ -16424,6 +16501,7 @@ Triangulation<dim, spacedim>::memory_consumption() const
 
 
 template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 Triangulation<dim, spacedim>::DistortedCellList::~DistortedCellList() noexcept =
   default;
 


### PR DESCRIPTION
Fixes #14891. It turns out that `clang++` also requires `requires`-clauses for the out-of-line member function definitions.
Also, we use the correct template for `TpetraWrappers::Vector`.