### PR TITLE
Fix concepts support for TpetraWrappers::Vector

### DIFF
--- a/include/deal.II/base/template_constraints.h
+++ b/include/deal.II/base/template_constraints.h
@@ -778,28 +778,29 @@ namespace concepts
      * predicate is `true`.
      */
     template <typename T>
-    constexpr bool is_dealii_vector_type = false;
+    inline constexpr bool is_dealii_vector_type = false;
 
     template <typename Number>
-    constexpr bool is_dealii_vector_type<dealii::Vector<Number>> = true;
+    inline constexpr bool is_dealii_vector_type<dealii::Vector<Number>> = true;
 
     template <typename Number>
-    constexpr bool is_dealii_vector_type<dealii::BlockVector<Number>> = true;
+    inline constexpr bool is_dealii_vector_type<dealii::BlockVector<Number>> =
+      true;
 
     template <typename Number>
-    constexpr bool
+    inline constexpr bool
       is_dealii_vector_type<dealii::LinearAlgebra::Vector<Number>> = true;
 
     template <typename Number>
-    constexpr bool
+    inline constexpr bool
       is_dealii_vector_type<dealii::LinearAlgebra::BlockVector<Number>> = true;
 
     template <typename Number, typename MemorySpace>
-    constexpr bool is_dealii_vector_type<
+    inline constexpr bool is_dealii_vector_type<
       dealii::LinearAlgebra::distributed::Vector<Number, MemorySpace>> = true;
 
     template <typename Number>
-    constexpr bool is_dealii_vector_type<
+    inline constexpr bool is_dealii_vector_type<
       dealii::LinearAlgebra::distributed::BlockVector<Number>> = true;
 
 #  ifdef DEAL_II_WITH_PETSC
@@ -836,7 +837,7 @@ namespace concepts
 
 #    ifdef DEAL_II_TRILINOS_WITH_TPETRA
     template <typename Number>
-    constexpr bool is_dealii_vector_type<
+    inline constexpr bool is_dealii_vector_type<
       dealii::LinearAlgebra::TpetraWrappers::Vector<Number>> = true;
 #    endif
 #  endif

--- a/include/deal.II/base/template_constraints.h
+++ b/include/deal.II/base/template_constraints.h
@@ -741,6 +741,7 @@ namespace LinearAlgebra
 #  ifdef DEAL_II_TRILINOS_WITH_TPETRA
   namespace TpetraWrappers
   {
+    template <typename Number>
     class Vector;
   }
 #  endif
@@ -803,40 +804,40 @@ namespace concepts
 
 #  ifdef DEAL_II_WITH_PETSC
     template <>
-    constexpr bool is_dealii_vector_type<dealii::PETScWrappers::Vector> = true;
-
-    template <>
-    constexpr bool is_dealii_vector_type<dealii::PETScWrappers::BlockVector> =
+    inline constexpr bool is_dealii_vector_type<dealii::PETScWrappers::Vector> =
       true;
 
     template <>
-    constexpr bool is_dealii_vector_type<dealii::PETScWrappers::MPI::Vector> =
-      true;
+    inline constexpr bool
+      is_dealii_vector_type<dealii::PETScWrappers::BlockVector> = true;
 
     template <>
-    constexpr bool
+    inline constexpr bool
+      is_dealii_vector_type<dealii::PETScWrappers::MPI::Vector> = true;
+
+    template <>
+    inline constexpr bool
       is_dealii_vector_type<dealii::PETScWrappers::MPI::BlockVector> = true;
 #  endif
 
 #  ifdef DEAL_II_WITH_TRILINOS
     template <>
-    constexpr bool
+    inline constexpr bool
       is_dealii_vector_type<dealii::TrilinosWrappers::MPI::Vector> = true;
 
     template <>
-    constexpr bool
+    inline constexpr bool
       is_dealii_vector_type<dealii::TrilinosWrappers::MPI::BlockVector> = true;
 
     template <>
-    constexpr bool
+    inline constexpr bool
       is_dealii_vector_type<dealii::LinearAlgebra::EpetraWrappers::Vector> =
         true;
 
 #    ifdef DEAL_II_TRILINOS_WITH_TPETRA
-    template <>
-    constexpr bool
-      is_dealii_vector_type<dealii::LinearAlgebra::TpetraWrappers::Vector> =
-        true;
+    template <typename Number>
+    constexpr bool is_dealii_vector_type<
+      dealii::LinearAlgebra::TpetraWrappers::Vector<Number>> = true;
 #    endif
 #  endif
   } // namespace internal


### PR DESCRIPTION
Fixes #14891 by using the correct template for `TpetraWrappers` and using `inline constexpr` variables to avoid duplicated symbols when linking.
Originally part of #14895.