### PR TITLE
Limit friend declarations for DofHandler and Triangulation to the same template arguments

### DIFF
--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -738,9 +738,7 @@ protected:
 private:
   // Make the DoFHandler class a friend so that it can call the set_xxx()
   // functions.
-  template <int, int>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-  friend class DoFHandler;
+  friend class DoFHandler<dim, spacedim>;
 
   friend struct dealii::internal::DoFHandlerImplementation::Policy::
     Implementation;
@@ -1209,9 +1207,7 @@ protected:
 
   // Make the DoFHandler class a friend so that it can call the set_xxx()
   // functions.
-  template <int dim1, int spacedim1>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim1, spacedim1>))
-  friend class DoFHandler;
+  friend class DoFHandler<1, spacedim>;
 
   friend struct dealii::internal::DoFHandlerImplementation::Policy::
     Implementation;

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -1871,9 +1871,7 @@ private:
   clear_children() const;
 
 private:
-  template <int, int>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-  friend class Triangulation;
+  friend class Triangulation<dim, spacedim>;
 
   friend struct dealii::internal::TriangulationImplementation::Implementation;
   friend struct dealii::internal::TriangulationImplementation::
@@ -4172,9 +4170,7 @@ private:
   void
   set_direction_flag(const bool new_direction_flag) const;
 
-  template <int, int>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-  friend class Triangulation;
+  friend class Triangulation<dim, spacedim>;
 
   template <int, int>
   friend class parallel::TriangulationBase;


### PR DESCRIPTION
Originally part of #14895.