### PR TITLE
Add test to ensure consistent constraints in parallel

### DIFF
--- a/tests/mpi/constraints_consistent_02.cc
+++ b/tests/mpi/constraints_consistent_02.cc
@@ -1,0 +1,78 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2023 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// test AffineConstraints<double>::make_consistent_in_parallel for case
+// where constraints need to be combined between different ranks
+
+#include <deal.II/base/mpi.h>
+
+#include <deal.II/lac/affine_constraints.h>
+
+#include "../tests.h"
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv);
+  MPILogInitAll                    all;
+
+  const unsigned int my_proc = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+  const unsigned int n_procs = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+
+  AssertThrow(n_procs == 3, ExcMessage("Only working on 3 ranks"));
+
+  const unsigned int        n_indices = 5;
+  IndexSet                  owned_elements(n_indices);
+  IndexSet                  relevant_elements(n_indices);
+  AffineConstraints<double> constraints;
+  if (my_proc == 0)
+    {
+      owned_elements.add_index(0);
+      relevant_elements.add_range(0, 3);
+    }
+  else if (my_proc == 1)
+    {
+      owned_elements.add_range(1, 3);
+      relevant_elements.add_range(0, n_indices);
+      constraints.add_line(0);
+      constraints.add_entry(0, 1, 0.5);
+      constraints.add_entry(0, 2, 0.5);
+      constraints.add_line(2);
+      constraints.add_entry(2, 3, 1.5);
+    }
+  else if (my_proc == 2)
+    {
+      owned_elements.add_range(3, n_indices);
+      relevant_elements.add_range(0, n_indices);
+      constraints.add_line(0);
+      constraints.add_entry(0, 1, 0.5);
+      constraints.add_entry(0, 3, 0.5);
+    }
+
+  deallog << "Output 0" << std::endl;
+  constraints.print(deallog.get_file_stream());
+  constraints.make_consistent_in_parallel(owned_elements,
+                                          relevant_elements,
+                                          MPI_COMM_WORLD);
+  deallog << "Output 1" << std::endl;
+  constraints.print(deallog.get_file_stream());
+  constraints.close();
+  deallog << "Output 2" << std::endl;
+  constraints.print(deallog.get_file_stream());
+
+  return 0;
+}

--- a/tests/mpi/constraints_consistent_02.mpirun=3.output
+++ b/tests/mpi/constraints_consistent_02.mpirun=3.output
@@ -1,0 +1,17 @@
+Working on rank 0 of 3
+Output 0
+Working on rank 1 of 3
+Working on rank 2 of 3
+Output 1
+    0 1:  0.5
+    0 3:  0.5
+    0 2:  0.5
+    2 3:  1.5
+Output 2
+    0 1:  0.5
+    0 3:  1.25
+    2 3:  1.5
+Output proc2
+    0 1:  0.5
+    0 3:  1.25
+    2 3:  1.5


### PR DESCRIPTION
This is the test needed for #14905. I added it as a separate PR as it can currently run (but would fail to produce a reasonable output). The idea of the test is to set up constraints for a DoF owned at process with index 0, but defined only from information on processes with rank 1 and 2. The problem to be represented is that neither of process 1 and 2 have the full information on the constraints, and only their combined form represents the valid state.