### PR TITLE
Simplify Trilinos solver's AdditionalData

### DIFF
--- a/include/deal.II/lac/trilinos_solver.h
+++ b/include/deal.II/lac/trilinos_solver.h
@@ -365,7 +365,6 @@ namespace TrilinosWrappers
                                  const Epetra_Operator &preconditioner);
 
 
-
   /**
    * An implementation of the solver interface using the Trilinos CG solver.
    *
@@ -375,18 +374,6 @@ namespace TrilinosWrappers
   {
   public:
     /**
-     * Standardized data struct to pipe additional data to the solver.
-     */
-
-    struct AdditionalData : public SolverBase::AdditionalData
-    {
-      /**
-       * Set the additional data field to the desired output format.
-       */
-      explicit AdditionalData(const bool output_solver_details = false);
-    };
-
-    /**
      * Constructor. In contrast to deal.II's own solvers, there is no need to
      * give a vector memory object.
      *
@@ -394,12 +381,6 @@ namespace TrilinosWrappers
      * flags for tuning.
      */
     SolverCG(SolverControl &cn, const AdditionalData &data = AdditionalData());
-
-  protected:
-    /**
-     * Store a copy of the flags for this particular solver.
-     */
-    const AdditionalData additional_data;
   };
 
 
@@ -413,17 +394,6 @@ namespace TrilinosWrappers
   {
   public:
     /**
-     * Standardized data struct to pipe additional data to the solver.
-     */
-    struct AdditionalData : public SolverBase::AdditionalData
-    {
-      /**
-       * Set the additional data field to the desired output format.
-       */
-      explicit AdditionalData(const bool output_solver_details = false);
-    };
-
-    /**
      * Constructor. In contrast to deal.II's own solvers, there is no need to
      * give a vector memory object.
      *
@@ -431,12 +401,6 @@ namespace TrilinosWrappers
      * flags for tuning.
      */
     SolverCGS(SolverControl &cn, const AdditionalData &data = AdditionalData());
-
-  protected:
-    /**
-     * Store a copy of the flags for this particular solver.
-     */
-    const AdditionalData additional_data;
   };
 
 
@@ -449,19 +413,6 @@ namespace TrilinosWrappers
   {
   public:
     /**
-     * Standardized data struct to pipe additional data to the solver.
-     */
-    struct AdditionalData : public SolverBase::AdditionalData
-    {
-      /**
-       * Constructor. By default, set the number of temporary vectors to 30,
-       * i.e. do a restart every 30 iterations.
-       */
-      explicit AdditionalData(const bool         output_solver_details = false,
-                              const unsigned int restart_parameter     = 30);
-    };
-
-    /**
      * Constructor. In contrast to deal.II's own solvers, there is no need to
      * give a vector memory object.
      *
@@ -470,12 +421,6 @@ namespace TrilinosWrappers
      */
     SolverGMRES(SolverControl &       cn,
                 const AdditionalData &data = AdditionalData());
-
-  protected:
-    /**
-     * Store a copy of the flags for this particular solver.
-     */
-    const AdditionalData additional_data;
   };
 
 
@@ -490,17 +435,6 @@ namespace TrilinosWrappers
   {
   public:
     /**
-     * Standardized data struct to pipe additional data to the solver.
-     */
-    struct AdditionalData : public SolverBase::AdditionalData
-    {
-      /**
-       * Set the additional data field to the desired output format.
-       */
-      explicit AdditionalData(const bool output_solver_details = false);
-    };
-
-    /**
      * Constructor. In contrast to deal.II's own solvers, there is no need to
      * give a vector memory object.
      *
@@ -509,12 +443,6 @@ namespace TrilinosWrappers
      */
     SolverBicgstab(SolverControl &       cn,
                    const AdditionalData &data = AdditionalData());
-
-  protected:
-    /**
-     * Store a copy of the flags for this particular solver.
-     */
-    const AdditionalData additional_data;
   };
 
 
@@ -529,17 +457,6 @@ namespace TrilinosWrappers
   {
   public:
     /**
-     * Standardized data struct to pipe additional data to the solver.
-     */
-    struct AdditionalData : public SolverBase::AdditionalData
-    {
-      /**
-       * Set the additional data field to the desired output format.
-       */
-      explicit AdditionalData(const bool output_solver_details = false);
-    };
-
-    /**
      * Constructor. In contrast to deal.II's own solvers, there is no need to
      * give a vector memory object.
      *
@@ -548,12 +465,6 @@ namespace TrilinosWrappers
      */
     SolverTFQMR(SolverControl &       cn,
                 const AdditionalData &data = AdditionalData());
-
-  protected:
-    /**
-     * Store a copy of the flags for this particular solver.
-     */
-    const AdditionalData additional_data;
   };
 
 

--- a/source/lac/trilinos_solver.cc
+++ b/source/lac/trilinos_solver.cc
@@ -591,85 +591,37 @@ namespace TrilinosWrappers
 
   /* ---------------------- SolverCG ------------------------ */
 
-  SolverCG::AdditionalData::AdditionalData(const bool output_solver_details)
-    : SolverBase::AdditionalData(output_solver_details)
-  {}
-
-
-
   SolverCG::SolverCG(SolverControl &cn, const AdditionalData &data)
-    : SolverBase(cn, data)
-    , additional_data(data)
-  {
-    solver_name = cg;
-  }
+    : SolverBase(cg, cn, data)
+  {}
 
 
   /* ---------------------- SolverGMRES ------------------------ */
 
-  SolverGMRES::AdditionalData::AdditionalData(
-    const bool         output_solver_details,
-    const unsigned int restart_parameter)
-    : SolverBase::AdditionalData(output_solver_details, restart_parameter)
-  {}
-
-
-
   SolverGMRES::SolverGMRES(SolverControl &cn, const AdditionalData &data)
-    : SolverBase(cn, data)
-    , additional_data(data)
-  {
-    solver_name = gmres;
-  }
+    : SolverBase(gmres, cn, data)
+  {}
 
 
   /* ---------------------- SolverBicgstab ------------------------ */
 
-  SolverBicgstab::AdditionalData::AdditionalData(
-    const bool output_solver_details)
-    : SolverBase::AdditionalData(output_solver_details)
-  {}
-
-
-
   SolverBicgstab::SolverBicgstab(SolverControl &cn, const AdditionalData &data)
-    : SolverBase(cn, data)
-    , additional_data(data)
-  {
-    solver_name = bicgstab;
-  }
+    : SolverBase(bicgstab, cn, data)
+  {}
 
 
   /* ---------------------- SolverCGS ------------------------ */
 
-  SolverCGS::AdditionalData::AdditionalData(const bool output_solver_details)
-    : SolverBase::AdditionalData(output_solver_details)
-  {}
-
-
-
   SolverCGS::SolverCGS(SolverControl &cn, const AdditionalData &data)
-    : SolverBase(cn, data)
-    , additional_data(data)
-  {
-    solver_name = cgs;
-  }
+    : SolverBase(cgs, cn, data)
+  {}
 
 
   /* ---------------------- SolverTFQMR ------------------------ */
 
-  SolverTFQMR::AdditionalData::AdditionalData(const bool output_solver_details)
-    : SolverBase::AdditionalData(output_solver_details)
-  {}
-
-
-
   SolverTFQMR::SolverTFQMR(SolverControl &cn, const AdditionalData &data)
-    : SolverBase(cn, data)
-    , additional_data(data)
-  {
-    solver_name = tfqmr;
-  }
+    : SolverBase(tfqmr, cn, data)
+  {}
 
 
 


### PR DESCRIPTION
While working on #14837, I encountered this possible simplification. The comment in `SolverBase::AdditionalData` already mentions that the design isn't very nice. While not improving the design itself, this change at least removes some of the boilerplate so I don't have to apply the changes of #14837 to it. 

note: Technically, this  is not backwards-compatible since I remove an (internally) unused protected member.