### PR TITLE
Move check about FECollection size to DoFHandler.

### DIFF
--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -2149,14 +2149,19 @@ DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 void DoFHandler<dim, spacedim>::distribute_dofs(
   const hp::FECollection<dim, spacedim> &ff)
 {
-  Assert(
-    this->tria != nullptr,
-    ExcMessage(
-      "You need to set the Triangulation in the DoFHandler using reinit() or "
-      "in the constructor before you can distribute DoFs."));
+  Assert(this->tria != nullptr,
+         ExcMessage(
+           "You need to set the Triangulation in the DoFHandler using reinit() "
+           "or in the constructor before you can distribute DoFs."));
   Assert(this->tria->n_levels() > 0,
          ExcMessage("The Triangulation you are using is empty!"));
+
+  // verify size of provided FE collection
   Assert(ff.size() > 0, ExcMessage("The given hp::FECollection is empty!"));
+  Assert((ff.size() <= std::numeric_limits<types::fe_index>::max()) &&
+           (ff.size() != numbers::invalid_fe_index),
+         ExcMessage("The given hp::FECollection contains more finite elements "
+                    "than the DoFHandler can cover with active FE indices."));
 
   //
   // register the new finite element collection

--- a/source/hp/fe_collection.cc
+++ b/source/hp/fe_collection.cc
@@ -73,11 +73,6 @@ namespace hp
            ExcMessage("All elements inside a collection need to have the "
                       "same number of vector components!"));
 
-    Assert(this->size() <= std::numeric_limits<types::fe_index>::max() &&
-             this->size() != numbers::invalid_fe_index,
-           ExcMessage(
-             "You reached the maximum possible number of finite elements."));
-
     Collection<FiniteElement<dim, spacedim>>::push_back(new_fe.clone());
   }
 


### PR DESCRIPTION
Part of #13595. Follow-up to #14866.

A `hp::FECollection` should be able to store as many elements as it likes. The size limitation on active FE indices really comes from the `DoFHandler` implementation, so I vote for moving the size check into the `distribute_dofs` function.

This PR just moves an assert to a different place.

---

Further, we have the `hp::Collection` base class since #11934. The main job of derived classes is to store their elements and provide diagnostics for the collection.

The functions in the `Functions to support hp-adaptivity` section, like `hp_vertex_dof_identities()`, should not be part of the `hp::FECollection` in my opinion. I would suggest to introduce them as free functions in a separate namespace instead. I will prepare a follow-up PR.