### PR TITLE
Use <version> header for C++20 feature checks

### DIFF
--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -70,8 +70,7 @@ macro(_test_cxx20_support)
   # Beyond this, check for some features we actually need.
   CHECK_CXX_SOURCE_COMPILES(
     "
-    #include <cmath>
-    #include <ranges>
+    #include <version>
 
     #if __cplusplus < 201709L && !defined(_MSC_VER) && !defined(__INTEL_COMPILER)
     #  error \"insufficient support for C++20\"


### PR DESCRIPTION
All feature-test macros (`__cpp_*`) are supposed to be provided in that file for C++20.