### PR TITLE
Fix namespacing in the ExodusII error macro.

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -2082,7 +2082,8 @@ namespace internal
  * @ingroup Exceptions
  */
 #  define AssertThrowExodusII(error_code) \
-    AssertThrow(error_code == 0, ExcExodusII(error_code));
+    AssertThrow(error_code == 0,          \
+                dealii::StandardExceptions::ExcExodusII(error_code));
 #endif // DEAL_II_TRILINOS_WITH_SEACAS
 
 using namespace StandardExceptions;


### PR DESCRIPTION
Found by @labdala in my office hours.

I checked and all the other macros in this file are OK.