### PR TITLE
Fix MatrixIterator comparison operator for C++20

### DIFF
--- a/include/deal.II/lac/matrix_iterator.h
+++ b/include/deal.II/lac/matrix_iterator.h
@@ -87,14 +87,16 @@ public:
   /**
    * Comparison. True, if both accessors are equal.
    */
+  template <class OtherAccessor>
   bool
-  operator==(const MatrixIterator &) const;
+  operator==(const MatrixIterator<OtherAccessor> &) const;
 
   /**
    * Inverse of <tt>==</tt>.
    */
+  template <class OtherAccessor>
   bool
-  operator!=(const MatrixIterator &) const;
+  operator!=(const MatrixIterator<OtherAccessor> &) const;
 
   /**
    * Comparison operator. Result is true if either the first row number is
@@ -178,16 +180,20 @@ MatrixIterator<ACCESSOR>::operator->() const
 
 
 template <class ACCESSOR>
+template <class OtherAccessor>
 inline bool
-MatrixIterator<ACCESSOR>::operator==(const MatrixIterator &other) const
+MatrixIterator<ACCESSOR>::operator==(
+  const MatrixIterator<OtherAccessor> &other) const
 {
   return (accessor == other.accessor);
 }
 
 
 template <class ACCESSOR>
+template <class OtherAccessor>
 inline bool
-MatrixIterator<ACCESSOR>::operator!=(const MatrixIterator &other) const
+MatrixIterator<ACCESSOR>::operator!=(
+  const MatrixIterator<OtherAccessor> &other) const
 {
   return !(*this == other);
 }


### PR DESCRIPTION
While looking at #14936 some tests were failing because of an ambiguous comparison operator for `MatrixIterator`.
Since C++20, also comparisons with swapped arguments are considered and in this case, one of the arguments had a different template argument. Templating the comparison resolves this ambiguity.