### PR TITLE
Fix .prm file in step-60

### DIFF
--- a/examples/step-60/doc/results.dox
+++ b/examples/step-60/doc/results.dox
@@ -387,10 +387,10 @@ subsection Distributed Lagrange<1,2>
   set Embedded configuration finite element degree = 1
   set Embedded space finite element degree         = 1
   set Embedding space finite element degree        = 1
-  set Homogeneous Dirichlet boundary ids           = 0,1,2,3
+  set Dirichlet boundary ids                       = 0,1,2,3
   set Initial embedded space refinement            = 8
   set Initial embedding space refinement           = 4
-  set Local refinements steps near embedded domain = 4
+  set Local refinements steps near embedded domain = 2
   set Use displacement in embedded interface       = false
   set Verbosity level                              = 10
   subsection Embedded configuration


### PR DESCRIPTION
With 4 refinement cycles near the interface the constraint on the ratio between the diameter of the two grids is not fulfilled in the case of a flower-like interface.

@luca-heltai I could push here the routine we are using to adjust that automatically. What do you think?