### PR TITLE
Refactor `internal::guess_point_owner`

### DIFF
--- a/source/base/mpi_remote_point_evaluation.cc
+++ b/source/base/mpi_remote_point_evaluation.cc
@@ -90,12 +90,8 @@ namespace Utilities
       const auto local_tree = pack_rtree(local_boxes);
 
       // compress r-tree to a minimal set of bounding boxes
-      const auto local_reduced_box =
-        extract_rtree_level(local_tree, rtree_level);
-
-      // gather bounding boxes of other processes
-      const auto global_bboxes =
-        Utilities::MPI::all_gather(tria.get_communicator(), local_reduced_box);
+      std::vector<std::vector<BoundingBox<spacedim>>> global_bboxes(1);
+      global_bboxes[0] = extract_rtree_level(local_tree, rtree_level);
 
       const GridTools::Cache<dim, spacedim> cache(tria, mapping);
 


### PR DESCRIPTION
This PR refactors `internal::guess_point_owner()`:
- so that it works for `Point` and `BoundingBox`
- R-tree is used
- if global information has not been collected, it is gathered here

As a follow-up, we can use now `ArborX` (as suggested in https://github.com/dealii/dealii/pull/14931#pullrequestreview-1351947707) that would allow to skip the last step.

replacement of #14931

FYI @jh66637 