### PR TITLE
Use std_cxx20::type_identity_t instead of identity<...>::type.

### DIFF
--- a/include/deal.II/base/graph_coloring.h
+++ b/include/deal.II/base/graph_coloring.h
@@ -108,10 +108,10 @@ namespace GraphColoring
     template <typename Iterator>
     std::vector<std::vector<Iterator>>
     create_partitioning(
-      const Iterator &                         begin,
-      const typename identity<Iterator>::type &end,
+      const Iterator &                            begin,
+      const std_cxx20::type_identity_t<Iterator> &end,
       const std::function<std::vector<types::global_dof_index>(
-        const Iterator &)> &                   get_conflict_indices)
+        const Iterator &)> &                      get_conflict_indices)
     {
       // Number of iterators.
       unsigned int n_iterators = 0;
@@ -539,10 +539,10 @@ namespace GraphColoring
   template <typename Iterator>
   std::vector<std::vector<Iterator>>
   make_graph_coloring(
-    const Iterator &                               begin,
-    const typename identity<Iterator>::type &      end,
+    const Iterator &                                  begin,
+    const std_cxx20::type_identity_t<Iterator> &      end,
     const std::function<std::vector<types::global_dof_index>(
-      const typename identity<Iterator>::type &)> &get_conflict_indices)
+      const std_cxx20::type_identity_t<Iterator> &)> &get_conflict_indices)
   {
     Assert(begin != end,
            ExcMessage(

--- a/include/deal.II/base/iterator_range.h
+++ b/include/deal.II/base/iterator_range.h
@@ -290,8 +290,8 @@ private:
  */
 template <typename BaseIterator>
 IteratorRange<BaseIterator>
-make_iterator_range(const BaseIterator &                         begin,
-                    const typename identity<BaseIterator>::type &end)
+make_iterator_range(const BaseIterator &                            begin,
+                    const std_cxx20::type_identity_t<BaseIterator> &end)
 {
   IteratorRange<BaseIterator> ir(begin, end);
   return ir;

--- a/include/deal.II/base/mutable_bind.h
+++ b/include/deal.II/base/mutable_bind.h
@@ -186,7 +186,7 @@ namespace Utilities
   template <typename ReturnType, class... FunctionArgs>
   MutableBind<ReturnType, FunctionArgs...>
   mutable_bind(ReturnType (*function)(FunctionArgs...),
-               typename identity<FunctionArgs>::type &&...arguments);
+               std_cxx20::type_identity_t<FunctionArgs> &&...arguments);
 
   /**
    * Same as above, using a std::function object.
@@ -194,7 +194,7 @@ namespace Utilities
   template <typename ReturnType, class... FunctionArgs>
   MutableBind<ReturnType, FunctionArgs...>
   mutable_bind(std::function<ReturnType(FunctionArgs...)>,
-               typename identity<FunctionArgs>::type &&...arguments);
+               std_cxx20::type_identity_t<FunctionArgs> &&...arguments);
 
   /**
    * Create a MutableBind object from a function pointer, with uninitialized
@@ -292,7 +292,7 @@ namespace Utilities
   template <typename ReturnType, class... FunctionArgs>
   MutableBind<ReturnType, FunctionArgs...>
   mutable_bind(ReturnType (*function)(FunctionArgs...),
-               typename identity<FunctionArgs>::type &&...arguments)
+               std_cxx20::type_identity_t<FunctionArgs> &&...arguments)
   {
     return MutableBind<ReturnType, FunctionArgs...>(function,
                                                     std::move(arguments)...);
@@ -312,7 +312,7 @@ namespace Utilities
   template <typename ReturnType, class... FunctionArgs>
   MutableBind<ReturnType, FunctionArgs...>
   mutable_bind(std::function<ReturnType(FunctionArgs...)> function,
-               typename identity<FunctionArgs>::type &&...arguments)
+               std_cxx20::type_identity_t<FunctionArgs> &&...arguments)
   {
     return MutableBind<ReturnType, FunctionArgs...>(function,
                                                     std::move(arguments)...);

--- a/include/deal.II/base/parallel.h
+++ b/include/deal.II/base/parallel.h
@@ -394,10 +394,10 @@ namespace parallel
    */
   template <typename Iterator, typename Function>
   DEAL_II_CXX20_REQUIRES((std::invocable<Function, Iterator, Iterator>))
-  void apply_to_subranges(const Iterator &                         begin,
-                          const typename identity<Iterator>::type &end,
-                          const Function &                         f,
-                          const unsigned int                       grainsize)
+  void apply_to_subranges(const Iterator &                            begin,
+                          const std_cxx20::type_identity_t<Iterator> &end,
+                          const Function &                            f,
+                          const unsigned int                          grainsize)
   {
 #ifndef DEAL_II_WITH_TBB
     // make sure we don't get compiler
@@ -544,9 +544,9 @@ namespace parallel
      std::convertible_to<std::invoke_result_t<Function, Iterator, Iterator>,
                          ResultType>))
   ResultType
-    accumulate_from_subranges(const Function &                         f,
-                              const Iterator &                         begin,
-                              const typename identity<Iterator>::type &end,
+    accumulate_from_subranges(const Function &                            f,
+                              const Iterator &                            begin,
+                              const std_cxx20::type_identity_t<Iterator> &end,
                               const unsigned int grainsize)
   {
 #ifndef DEAL_II_WITH_TBB

--- a/include/deal.II/base/std_cxx20/type_traits.h
+++ b/include/deal.II/base/std_cxx20/type_traits.h
@@ -43,7 +43,7 @@ namespace std_cxx20
    * written as
    * @code
    * template <typename T>
-   * void f(T, typename identity<T>::type);
+   * void f(T, std_cxx20::type_identity_t<T>);
    * @endcode
    * then the call becomes valid: the type <code>T</code> is not deducible
    * from the second argument to the function, so only the first argument
@@ -73,7 +73,7 @@ namespace std_cxx20
    * achieve this by writing the code as follows:
    * @code
    * template <typename RT, typename A>
-   * void forward_call(RT (*p) (A), typename identity<A>::type a)
+   * void forward_call(RT (*p) (A), std_cxx20::type_identity_t<A> a)
    * {
    *   p(a);
    * }

--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -815,7 +815,7 @@ namespace Threads
    */
   template <typename RT, typename... Args>
   DEAL_II_DEPRECATED inline Thread<RT>
-  new_thread(RT (*fun_ptr)(Args...), typename identity<Args>::type... args)
+  new_thread(RT (*fun_ptr)(Args...), std_cxx20::type_identity_t<Args>... args)
   {
     // See the comment in the first new_thread() implementation
     DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
@@ -837,8 +837,8 @@ namespace Threads
   template <typename RT, typename C, typename... Args>
   DEAL_II_DEPRECATED inline Thread<RT>
   new_thread(RT (C::*fun_ptr)(Args...),
-             typename identity<C>::type &c,
-             typename identity<Args>::type... args)
+             std_cxx20::type_identity_t<C> &c,
+             std_cxx20::type_identity_t<Args>... args)
   {
     // NOLINTNEXTLINE(modernize-avoid-bind) silence clang-tidy
     return new_thread(std::function<RT()>(std::bind(
@@ -855,8 +855,8 @@ namespace Threads
   template <typename RT, typename C, typename... Args>
   DEAL_II_DEPRECATED inline Thread<RT>
   new_thread(RT (C::*fun_ptr)(Args...) const,
-             typename identity<const C>::type &c,
-             typename identity<Args>::type... args)
+             std_cxx20::type_identity_t<const C> &c,
+             std_cxx20::type_identity_t<Args>... args)
   {
     // See the comment in the first new_thread() implementation
     DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
@@ -1587,7 +1587,7 @@ namespace Threads
    */
   template <typename RT, typename... Args>
   inline Task<RT>
-  new_task(RT (*fun_ptr)(Args...), typename identity<Args>::type... args)
+  new_task(RT (*fun_ptr)(Args...), std_cxx20::type_identity_t<Args>... args)
   {
     auto dummy = std::make_tuple(internal::maybe_make_ref<Args>::act(args)...);
     return new_task(
@@ -1605,8 +1605,8 @@ namespace Threads
   template <typename RT, typename C, typename... Args>
   inline Task<RT>
   new_task(RT (C::*fun_ptr)(Args...),
-           typename identity<C>::type &c,
-           typename identity<Args>::type... args)
+           std_cxx20::type_identity_t<C> &c,
+           std_cxx20::type_identity_t<Args>... args)
   {
     // NOLINTNEXTLINE(modernize-avoid-bind) silence clang-tidy
     return new_task(std::function<RT()>(std::bind(
@@ -1622,8 +1622,8 @@ namespace Threads
   template <typename RT, typename C, typename... Args>
   inline Task<RT>
   new_task(RT (C::*fun_ptr)(Args...) const,
-           typename identity<const C>::type &c,
-           typename identity<Args>::type... args)
+           std_cxx20::type_identity_t<const C> &c,
+           std_cxx20::type_identity_t<Args>... args)
   {
     // NOLINTNEXTLINE(modernize-avoid-bind) silence clang-tidy
     return new_task(std::function<RT()>(std::bind(

--- a/include/deal.II/base/work_stream.h
+++ b/include/deal.II/base/work_stream.h
@@ -469,14 +469,14 @@ namespace WorkStream
                 typename ScratchData,
                 typename CopyData>
       void
-      run(const Iterator &                         begin,
-          const typename identity<Iterator>::type &end,
-          Worker                                   worker,
-          Copier                                   copier,
-          const ScratchData &                      sample_scratch_data,
-          const CopyData &                         sample_copy_data,
-          const unsigned int                       queue_length,
-          const unsigned int                       chunk_size)
+      run(const Iterator &                            begin,
+          const std_cxx20::type_identity_t<Iterator> &end,
+          Worker                                      worker,
+          Copier                                      copier,
+          const ScratchData &                         sample_scratch_data,
+          const CopyData &                            sample_copy_data,
+          const unsigned int                          queue_length,
+          const unsigned int                          chunk_size)
       {
         using ItemType = typename IteratorRangeToItemStream<Iterator,
                                                             ScratchData,
@@ -678,12 +678,12 @@ namespace WorkStream
                 typename ScratchData,
                 typename CopyData>
       void
-      run(const Iterator &                         begin,
-          const typename identity<Iterator>::type &end,
-          Worker                                   worker,
-          Copier                                   copier,
-          const ScratchData &                      sample_scratch_data,
-          const CopyData &                         sample_copy_data)
+      run(const Iterator &                            begin,
+          const std_cxx20::type_identity_t<Iterator> &end,
+          Worker                                      worker,
+          Copier                                      copier,
+          const ScratchData &                         sample_scratch_data,
+          const CopyData &                            sample_copy_data)
       {
         // need to copy the sample since it is marked const
         ScratchData scratch_data = sample_scratch_data;
@@ -1119,12 +1119,12 @@ namespace WorkStream
             typename ScratchData,
             typename CopyData>
   void
-  run(const Iterator &                         begin,
-      const typename identity<Iterator>::type &end,
-      Worker                                   worker,
-      Copier                                   copier,
-      const ScratchData &                      sample_scratch_data,
-      const CopyData &                         sample_copy_data,
+  run(const Iterator &                            begin,
+      const std_cxx20::type_identity_t<Iterator> &end,
+      Worker                                      worker,
+      Copier                                      copier,
+      const ScratchData &                         sample_scratch_data,
+      const CopyData &                            sample_copy_data,
       const unsigned int queue_length = 2 * MultithreadInfo::n_threads(),
       const unsigned int chunk_size   = 8)
   {
@@ -1356,9 +1356,9 @@ namespace WorkStream
             typename ScratchData,
             typename CopyData>
   void
-  run(const Iterator &                         begin,
-      const typename identity<Iterator>::type &end,
-      MainClass &                              main_object,
+  run(const Iterator &                            begin,
+      const std_cxx20::type_identity_t<Iterator> &end,
+      MainClass &                                 main_object,
       void (MainClass::*worker)(const Iterator &, ScratchData &, CopyData &),
       void (MainClass::*copier)(const CopyData &),
       const ScratchData &sample_scratch_data,
@@ -1390,8 +1390,8 @@ namespace WorkStream
             typename ScratchData,
             typename CopyData>
   void
-  run(const IteratorOverIterators<Iterator> &                         begin,
-      const IteratorOverIterators<typename identity<Iterator>::type> &end,
+  run(const IteratorOverIterators<Iterator> &                            begin,
+      const IteratorOverIterators<std_cxx20::type_identity_t<Iterator>> &end,
       MainClass &main_object,
       void (MainClass::*worker)(const Iterator &, ScratchData &, CopyData &),
       void (MainClass::*copier)(const CopyData &),
@@ -1433,17 +1433,18 @@ namespace WorkStream
             typename CopyData,
             typename = std::enable_if_t<has_begin_and_end<IteratorRangeType>>>
   void
-  run(IteratorRangeType iterator_range,
-      MainClass &       main_object,
-      void (MainClass::*worker)(
-        const typename identity<IteratorRangeType>::type::iterator &,
-        ScratchData &,
-        CopyData &),
-      void (MainClass::*copier)(const CopyData &),
-      const ScratchData &sample_scratch_data,
-      const CopyData &   sample_copy_data,
-      const unsigned int queue_length = 2 * MultithreadInfo::n_threads(),
-      const unsigned int chunk_size   = 8)
+  run(
+    IteratorRangeType iterator_range,
+    MainClass &       main_object,
+    void (MainClass::*worker)(
+      const typename std_cxx20::type_identity_t<IteratorRangeType>::iterator &,
+      ScratchData &,
+      CopyData &),
+    void (MainClass::*copier)(const CopyData &),
+    const ScratchData &sample_scratch_data,
+    const CopyData &   sample_copy_data,
+    const unsigned int queue_length = 2 * MultithreadInfo::n_threads(),
+    const unsigned int chunk_size   = 8)
   {
     // Call the function above
     run(std::begin(iterator_range),

--- a/include/deal.II/dofs/dof_renumbering.h
+++ b/include/deal.II/dofs/dof_renumbering.h
@@ -698,7 +698,7 @@ namespace DoFRenumbering
   types::global_dof_index
   compute_component_wise(std::vector<types::global_dof_index> &new_dof_indices,
                          const CellIterator &                  start,
-                         const typename identity<CellIterator>::type &end,
+                         const std_cxx20::type_identity_t<CellIterator> &end,
                          const std::vector<unsigned int> &target_component,
                          const bool                       is_level_operation);
 

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -1029,9 +1029,9 @@ namespace DoFTools
   template <typename FaceIterator, typename number>
   void
   make_periodicity_constraints(
-    const FaceIterator &                         face_1,
-    const typename identity<FaceIterator>::type &face_2,
-    AffineConstraints<number> &                  constraints,
+    const FaceIterator &                            face_1,
+    const std_cxx20::type_identity_t<FaceIterator> &face_2,
+    AffineConstraints<number> &                     constraints,
     const ComponentMask &            component_mask   = ComponentMask(),
     const bool                       face_orientation = true,
     const bool                       face_flip        = false,

--- a/include/deal.II/hp/refinement.h
+++ b/include/deal.II/hp/refinement.h
@@ -211,9 +211,9 @@ namespace hp
       const Vector<Number> &           criteria,
       const Number                     p_refine_threshold,
       const Number                     p_coarsen_threshold,
-      const ComparisonFunction<typename identity<Number>::type>
+      const ComparisonFunction<std_cxx20::type_identity_t<Number>>
         &compare_refine = std::greater_equal<Number>(),
-      const ComparisonFunction<typename identity<Number>::type>
+      const ComparisonFunction<std_cxx20::type_identity_t<Number>>
         &compare_coarsen = std::less_equal<Number>());
 
     /**
@@ -254,9 +254,9 @@ namespace hp
       const Vector<Number> &           criteria,
       const double                     p_refine_fraction  = 0.5,
       const double                     p_coarsen_fraction = 0.5,
-      const ComparisonFunction<typename identity<Number>::type>
+      const ComparisonFunction<std_cxx20::type_identity_t<Number>>
         &compare_refine = std::greater_equal<Number>(),
-      const ComparisonFunction<typename identity<Number>::type>
+      const ComparisonFunction<std_cxx20::type_identity_t<Number>>
         &compare_coarsen = std::less_equal<Number>());
 
     /**
@@ -298,9 +298,9 @@ namespace hp
       const Vector<Number> &           criteria,
       const double                     p_refine_fraction  = 0.5,
       const double                     p_coarsen_fraction = 0.5,
-      const ComparisonFunction<typename identity<Number>::type>
+      const ComparisonFunction<std_cxx20::type_identity_t<Number>>
         &compare_refine = std::greater_equal<Number>(),
-      const ComparisonFunction<typename identity<Number>::type>
+      const ComparisonFunction<std_cxx20::type_identity_t<Number>>
         &compare_coarsen = std::less_equal<Number>());
 
     /**
@@ -357,11 +357,12 @@ namespace hp
     template <int dim, typename Number, int spacedim>
     void
     p_adaptivity_from_reference(
-      const DoFHandler<dim, spacedim> &                          dof_handler,
-      const Vector<Number> &                                     criteria,
-      const Vector<Number> &                                     references,
-      const ComparisonFunction<typename identity<Number>::type> &compare_refine,
-      const ComparisonFunction<typename identity<Number>::type>
+      const DoFHandler<dim, spacedim> &dof_handler,
+      const Vector<Number> &           criteria,
+      const Vector<Number> &           references,
+      const ComparisonFunction<std_cxx20::type_identity_t<Number>>
+        &compare_refine,
+      const ComparisonFunction<std_cxx20::type_identity_t<Number>>
         &compare_coarsen);
 
     /**

--- a/include/deal.II/meshworker/loop.h
+++ b/include/deal.II/meshworker/loop.h
@@ -436,10 +436,10 @@ namespace MeshWorker
             class ASSEMBLER,
             class ITERATOR>
   void
-  loop(ITERATOR                          begin,
-       typename identity<ITERATOR>::type end,
-       DOFINFO &                         dinfo,
-       INFOBOX &                         info,
+  loop(ITERATOR                             begin,
+       std_cxx20::type_identity_t<ITERATOR> end,
+       DOFINFO &                            dinfo,
+       INFOBOX &                            info,
        const std::function<void(DOFINFO &, typename INFOBOX::CellInfo &)>
          &cell_worker,
        const std::function<void(DOFINFO &, typename INFOBOX::CellInfo &)>
@@ -491,7 +491,7 @@ namespace MeshWorker
   template <int dim, int spacedim, class ITERATOR, class ASSEMBLER>
   void
   integration_loop(ITERATOR                              begin,
-                   typename identity<ITERATOR>::type     end,
+                   std_cxx20::type_identity_t<ITERATOR>  end,
                    DoFInfo<dim, spacedim> &              dof_info,
                    IntegrationInfoBox<dim, spacedim> &   box,
                    const LocalIntegrator<dim, spacedim> &integrator,

--- a/include/deal.II/meshworker/mesh_loop.h
+++ b/include/deal.II/meshworker/mesh_loop.h
@@ -299,13 +299,13 @@ namespace MeshWorker
     const unsigned int queue_length = 2 * MultithreadInfo::n_threads(),
     const unsigned int chunk_size   = 8
 #else
-    const CellIteratorType &                         begin,
-    const typename identity<CellIteratorType>::type &end,
+    const CellIteratorType &                            begin,
+    const std_cxx20::type_identity_t<CellIteratorType> &end,
 
-    const typename identity<std::function<
-      void(const CellIteratorBaseType &, ScratchData &, CopyData &)>>::type
+    const std_cxx20::type_identity_t<std::function<
+      void(const CellIteratorBaseType &, ScratchData &, CopyData &)>>
       &cell_worker,
-    const typename identity<std::function<void(const CopyData &)>>::type
+    const std_cxx20::type_identity_t<std::function<void(const CopyData &)>>
       &copier,
 
     const ScratchData &sample_scratch_data,
@@ -313,31 +313,33 @@ namespace MeshWorker
 
     const AssembleFlags flags = assemble_own_cells,
 
-    const typename identity<std::function<void(const CellIteratorBaseType &,
-                                               const unsigned int,
-                                               ScratchData &,
-                                               CopyData &)>>::type
-      &boundary_worker = std::function<void(const CellIteratorBaseType &,
-                                            const unsigned int,
-                                            ScratchData &,
-                                            CopyData &)>(),
+    const std_cxx20::type_identity_t<
+      std::function<void(const CellIteratorBaseType &,
+                         const unsigned int,
+                         ScratchData &,
+                         CopyData &)>> &boundary_worker =
+      std::function<void(const CellIteratorBaseType &,
+                         const unsigned int,
+                         ScratchData &,
+                         CopyData &)>(),
 
-    const typename identity<std::function<void(const CellIteratorBaseType &,
-                                               const unsigned int,
-                                               const unsigned int,
-                                               const CellIteratorBaseType &,
-                                               const unsigned int,
-                                               const unsigned int,
-                                               ScratchData &,
-                                               CopyData &)>>::type
-      &face_worker = std::function<void(const CellIteratorBaseType &,
-                                        const unsigned int,
-                                        const unsigned int,
-                                        const CellIteratorBaseType &,
-                                        const unsigned int,
-                                        const unsigned int,
-                                        ScratchData &,
-                                        CopyData &)>(),
+    const std_cxx20::type_identity_t<
+      std::function<void(const CellIteratorBaseType &,
+                         const unsigned int,
+                         const unsigned int,
+                         const CellIteratorBaseType &,
+                         const unsigned int,
+                         const unsigned int,
+                         ScratchData &,
+                         CopyData &)>> &face_worker =
+      std::function<void(const CellIteratorBaseType &,
+                         const unsigned int,
+                         const unsigned int,
+                         const CellIteratorBaseType &,
+                         const unsigned int,
+                         const unsigned int,
+                         ScratchData &,
+                         CopyData &)>(),
 
     const unsigned int queue_length = 2 * MultithreadInfo::n_threads(),
     const unsigned int chunk_size   = 8
@@ -713,10 +715,10 @@ namespace MeshWorker
   void
   mesh_loop(
     IteratorRange<CellIteratorType> iterator_range,
-    const typename identity<std::function<
-      void(const CellIteratorBaseType &, ScratchData &, CopyData &)>>::type
+    const std_cxx20::type_identity_t<std::function<
+      void(const CellIteratorBaseType &, ScratchData &, CopyData &)>>
       &cell_worker,
-    const typename identity<std::function<void(const CopyData &)>>::type
+    const std_cxx20::type_identity_t<std::function<void(const CopyData &)>>
       &copier,
 
     const ScratchData &sample_scratch_data,
@@ -724,31 +726,33 @@ namespace MeshWorker
 
     const AssembleFlags flags = assemble_own_cells,
 
-    const typename identity<std::function<void(const CellIteratorBaseType &,
-                                               const unsigned int,
-                                               ScratchData &,
-                                               CopyData &)>>::type
-      &boundary_worker = std::function<void(const CellIteratorBaseType &,
-                                            const unsigned int,
-                                            ScratchData &,
-                                            CopyData &)>(),
+    const std_cxx20::type_identity_t<
+      std::function<void(const CellIteratorBaseType &,
+                         const unsigned int,
+                         ScratchData &,
+                         CopyData &)>> &boundary_worker =
+      std::function<void(const CellIteratorBaseType &,
+                         const unsigned int,
+                         ScratchData &,
+                         CopyData &)>(),
 
-    const typename identity<std::function<void(const CellIteratorBaseType &,
-                                               const unsigned int,
-                                               const unsigned int,
-                                               const CellIteratorBaseType &,
-                                               const unsigned int,
-                                               const unsigned int,
-                                               ScratchData &,
-                                               CopyData &)>>::type
-      &face_worker = std::function<void(const CellIteratorBaseType &,
-                                        const unsigned int,
-                                        const unsigned int,
-                                        const CellIteratorBaseType &,
-                                        const unsigned int,
-                                        const unsigned int,
-                                        ScratchData &,
-                                        CopyData &)>(),
+    const std_cxx20::type_identity_t<
+      std::function<void(const CellIteratorBaseType &,
+                         const unsigned int,
+                         const unsigned int,
+                         const CellIteratorBaseType &,
+                         const unsigned int,
+                         const unsigned int,
+                         ScratchData &,
+                         CopyData &)>> &face_worker =
+      std::function<void(const CellIteratorBaseType &,
+                         const unsigned int,
+                         const unsigned int,
+                         const CellIteratorBaseType &,
+                         const unsigned int,
+                         const unsigned int,
+                         ScratchData &,
+                         CopyData &)>(),
 
     const unsigned int queue_length = 2 * MultithreadInfo::n_threads(),
     const unsigned int chunk_size   = 8)
@@ -834,9 +838,9 @@ namespace MeshWorker
             class CopyData,
             class MainClass>
   void
-  mesh_loop(const CellIteratorType &                         begin,
-            const typename identity<CellIteratorType>::type &end,
-            MainClass &                                      main_class,
+  mesh_loop(const CellIteratorType &                            begin,
+            const std_cxx20::type_identity_t<CellIteratorType> &end,
+            MainClass &                                         main_class,
             void (MainClass::*cell_worker)(const CellIteratorType &,
                                            ScratchData &,
                                            CopyData &),

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -753,7 +753,7 @@ namespace DoFRenumbering
   types::global_dof_index
   compute_component_wise(std::vector<types::global_dof_index> &new_indices,
                          const CellIterator &                  start,
-                         const typename identity<CellIterator>::type &end,
+                         const std_cxx20::type_identity_t<CellIterator> &end,
                          const std::vector<unsigned int> &component_order_arg,
                          const bool                       is_level_operation)
   {

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -1839,15 +1839,15 @@ namespace DoFTools
     template <typename FaceIterator, typename number>
     void
     set_periodicity_constraints(
-      const FaceIterator &                         face_1,
-      const typename identity<FaceIterator>::type &face_2,
-      const FullMatrix<double> &                   transformation,
-      AffineConstraints<number> &                  affine_constraints,
-      const ComponentMask &                        component_mask,
-      const bool                                   face_orientation,
-      const bool                                   face_flip,
-      const bool                                   face_rotation,
-      const number                                 periodicity_factor)
+      const FaceIterator &                            face_1,
+      const std_cxx20::type_identity_t<FaceIterator> &face_2,
+      const FullMatrix<double> &                      transformation,
+      AffineConstraints<number> &                     affine_constraints,
+      const ComponentMask &                           component_mask,
+      const bool                                      face_orientation,
+      const bool                                      face_flip,
+      const bool                                      face_rotation,
+      const number                                    periodicity_factor)
     {
       static const int dim      = FaceIterator::AccessorType::dimension;
       static const int spacedim = FaceIterator::AccessorType::space_dimension;
@@ -2290,16 +2290,16 @@ namespace DoFTools
   template <typename FaceIterator, typename number>
   void
   make_periodicity_constraints(
-    const FaceIterator &                         face_1,
-    const typename identity<FaceIterator>::type &face_2,
-    AffineConstraints<number> &                  affine_constraints,
-    const ComponentMask &                        component_mask,
-    const bool                                   face_orientation,
-    const bool                                   face_flip,
-    const bool                                   face_rotation,
-    const FullMatrix<double> &                   matrix,
-    const std::vector<unsigned int> &            first_vector_components,
-    const number                                 periodicity_factor)
+    const FaceIterator &                            face_1,
+    const std_cxx20::type_identity_t<FaceIterator> &face_2,
+    AffineConstraints<number> &                     affine_constraints,
+    const ComponentMask &                           component_mask,
+    const bool                                      face_orientation,
+    const bool                                      face_flip,
+    const bool                                      face_rotation,
+    const FullMatrix<double> &                      matrix,
+    const std::vector<unsigned int> &               first_vector_components,
+    const number                                    periodicity_factor)
   {
     static const int dim      = FaceIterator::AccessorType::dimension;
     static const int spacedim = FaceIterator::AccessorType::space_dimension;

--- a/source/grid/grid_tools_dof_handlers.cc
+++ b/source/grid/grid_tools_dof_handlers.cc
@@ -2024,7 +2024,7 @@ namespace GridTools
   void
   match_periodic_face_pairs(
     std::set<std::pair<CellIterator, unsigned int>> &pairs1,
-    std::set<std::pair<typename identity<CellIterator>::type, unsigned int>>
+    std::set<std::pair<std_cxx20::type_identity_t<CellIterator>, unsigned int>>
       &                                          pairs2,
     const unsigned int                           direction,
     std::vector<PeriodicFacePair<CellIterator>> &matched_pairs,

--- a/source/hp/refinement.cc
+++ b/source/hp/refinement.cc
@@ -112,8 +112,9 @@ namespace hp
       const Vector<Number> &           criteria,
       const Number                     p_refine_threshold,
       const Number                     p_coarsen_threshold,
-      const ComparisonFunction<typename identity<Number>::type> &compare_refine,
-      const ComparisonFunction<typename identity<Number>::type>
+      const ComparisonFunction<std_cxx20::type_identity_t<Number>>
+        &compare_refine,
+      const ComparisonFunction<std_cxx20::type_identity_t<Number>>
         &compare_coarsen)
     {
       if (dof_handler.get_fe_collection().size() == 0)
@@ -150,8 +151,9 @@ namespace hp
       const Vector<Number> &           criteria,
       const double                     p_refine_fraction,
       const double                     p_coarsen_fraction,
-      const ComparisonFunction<typename identity<Number>::type> &compare_refine,
-      const ComparisonFunction<typename identity<Number>::type>
+      const ComparisonFunction<std_cxx20::type_identity_t<Number>>
+        &compare_refine,
+      const ComparisonFunction<std_cxx20::type_identity_t<Number>>
         &compare_coarsen)
     {
       if (dof_handler.get_fe_collection().size() == 0)
@@ -246,8 +248,9 @@ namespace hp
       const Vector<Number> &           criteria,
       const double                     p_refine_fraction,
       const double                     p_coarsen_fraction,
-      const ComparisonFunction<typename identity<Number>::type> &compare_refine,
-      const ComparisonFunction<typename identity<Number>::type>
+      const ComparisonFunction<std_cxx20::type_identity_t<Number>>
+        &compare_refine,
+      const ComparisonFunction<std_cxx20::type_identity_t<Number>>
         &compare_coarsen)
     {
       if (dof_handler.get_fe_collection().size() == 0)
@@ -498,11 +501,12 @@ namespace hp
     template <int dim, typename Number, int spacedim>
     void
     p_adaptivity_from_reference(
-      const DoFHandler<dim, spacedim> &                          dof_handler,
-      const Vector<Number> &                                     criteria,
-      const Vector<Number> &                                     references,
-      const ComparisonFunction<typename identity<Number>::type> &compare_refine,
-      const ComparisonFunction<typename identity<Number>::type>
+      const DoFHandler<dim, spacedim> &dof_handler,
+      const Vector<Number> &           criteria,
+      const Vector<Number> &           references,
+      const ComparisonFunction<std_cxx20::type_identity_t<Number>>
+        &compare_refine,
+      const ComparisonFunction<std_cxx20::type_identity_t<Number>>
         &compare_coarsen)
     {
       if (dof_handler.get_fe_collection().size() == 0)

--- a/source/hp/refinement.inst.in
+++ b/source/hp/refinement.inst.in
@@ -65,8 +65,8 @@ for (deal_II_dimension : DIMENSIONS; S : REAL_SCALARS;
           const Vector<S> &,
           const S,
           const S,
-          const ComparisonFunction<typename identity<S>::type> &,
-          const ComparisonFunction<typename identity<S>::type> &);
+          const ComparisonFunction<std_cxx20::type_identity_t<S>> &,
+          const ComparisonFunction<std_cxx20::type_identity_t<S>> &);
 
         template void
         p_adaptivity_from_relative_threshold<deal_II_dimension,
@@ -76,8 +76,8 @@ for (deal_II_dimension : DIMENSIONS; S : REAL_SCALARS;
           const Vector<S> &,
           const double,
           const double,
-          const ComparisonFunction<typename identity<S>::type> &,
-          const ComparisonFunction<typename identity<S>::type> &);
+          const ComparisonFunction<std_cxx20::type_identity_t<S>> &,
+          const ComparisonFunction<std_cxx20::type_identity_t<S>> &);
 
         template void
         p_adaptivity_fixed_number<deal_II_dimension,
@@ -87,8 +87,8 @@ for (deal_II_dimension : DIMENSIONS; S : REAL_SCALARS;
           const Vector<S> &,
           const double,
           const double,
-          const ComparisonFunction<typename identity<S>::type> &,
-          const ComparisonFunction<typename identity<S>::type> &);
+          const ComparisonFunction<std_cxx20::type_identity_t<S>> &,
+          const ComparisonFunction<std_cxx20::type_identity_t<S>> &);
 
         template void
         p_adaptivity_from_regularity<deal_II_dimension,
@@ -104,8 +104,8 @@ for (deal_II_dimension : DIMENSIONS; S : REAL_SCALARS;
           const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
           const Vector<S> &,
           const Vector<S> &,
-          const ComparisonFunction<typename identity<S>::type> &,
-          const ComparisonFunction<typename identity<S>::type> &);
+          const ComparisonFunction<std_cxx20::type_identity_t<S>> &,
+          const ComparisonFunction<std_cxx20::type_identity_t<S>> &);
 
         template void
         predict_error<deal_II_dimension, S, deal_II_space_dimension>(

--- a/tests/mpi/mesh_worker_01.cc
+++ b/tests/mpi/mesh_worker_01.cc
@@ -105,7 +105,7 @@ test_simple(DoFHandler<dim> &dofs, MeshWorker::LoopControl &lctrl)
   MeshWorker::DoFInfo<dim> dof_info(dofs.block_info());
 
   //  integration_loop(ITERATOR begin,
-  //                typename identity<ITERATOR>::type end,
+  //                std_cxx20::type_identity_t<ITERATOR> end,
   //                DOFINFO &dinfo,
   //                INFOBOX &info,
   //                const std::function<void (DOFINFO &, typename

--- a/tests/mpi/mesh_worker_02.cc
+++ b/tests/mpi/mesh_worker_02.cc
@@ -105,7 +105,7 @@ test_simple(DoFHandler<dim> &dofs, MeshWorker::LoopControl &lctrl)
   MeshWorker::DoFInfo<dim> dof_info(dofs.block_info());
 
   //  integration_loop(ITERATOR begin,
-  //                typename identity<ITERATOR>::type end,
+  //                std_cxx20::type_identity_t<ITERATOR> end,
   //                DOFINFO &dinfo,
   //                INFOBOX &info,
   //                const std::function<void (DOFINFO &, typename

--- a/tests/mpi/mesh_worker_03.cc
+++ b/tests/mpi/mesh_worker_03.cc
@@ -105,7 +105,7 @@ test_simple(DoFHandler<dim> &dofs, MeshWorker::LoopControl &lctrl)
   MeshWorker::DoFInfo<dim> dof_info(dofs.block_info());
 
   //  integration_loop(ITERATOR begin,
-  //                typename identity<ITERATOR>::type end,
+  //                std_cxx20::type_identity_t<ITERATOR> end,
   //                DOFINFO &dinfo,
   //                INFOBOX &info,
   //                const std::function<void (DOFINFO &, typename

--- a/tests/mpi/mesh_worker_04.cc
+++ b/tests/mpi/mesh_worker_04.cc
@@ -106,7 +106,7 @@ test_simple(DoFHandler<dim> &dofs, MeshWorker::LoopControl &lctrl)
   MeshWorker::DoFInfo<dim> dof_info(dofs.block_info());
 
   //  integration_loop(ITERATOR begin,
-  //                typename identity<ITERATOR>::type end,
+  //                std_cxx20::type_identity_t<ITERATOR> end,
   //                DOFINFO &dinfo,
   //                INFOBOX &info,
   //                const std::function<void (DOFINFO &, typename

--- a/tests/mpi/mesh_worker_05.cc
+++ b/tests/mpi/mesh_worker_05.cc
@@ -106,7 +106,7 @@ test_simple(DoFHandler<dim> &dofs, MeshWorker::LoopControl &lctrl)
   MeshWorker::DoFInfo<dim> dof_info(dofs.block_info());
 
   //  integration_loop(ITERATOR begin,
-  //                typename identity<ITERATOR>::type end,
+  //                std_cxx20::type_identity_t<ITERATOR> end,
   //                DOFINFO &dinfo,
   //                INFOBOX &info,
   //                const std::function<void (DOFINFO &, typename

--- a/tests/multithreading/taskflow.h
+++ b/tests/multithreading/taskflow.h
@@ -24,12 +24,12 @@ namespace taskflow_v1
             typename ScratchData,
             typename CopyData>
   void
-  run(const Iterator &                         begin,
-      const typename identity<Iterator>::type &end,
-      Worker                                   worker,
-      Copier                                   copier,
-      const ScratchData &                      sample_scratch_data,
-      const CopyData &                         sample_copy_data,
+  run(const Iterator &                            begin,
+      const std_cxx20::type_identity_t<Iterator> &end,
+      Worker                                      worker,
+      Copier                                      copier,
+      const ScratchData &                         sample_scratch_data,
+      const CopyData &                            sample_copy_data,
       const unsigned int queue_length = 2 * MultithreadInfo::n_threads(),
       const unsigned int chunk_size   = 8)
   {
@@ -115,9 +115,9 @@ namespace taskflow_v1
             typename ScratchData,
             typename CopyData>
   void
-  run(const Iterator &                         begin,
-      const typename identity<Iterator>::type &end,
-      MainClass &                              main_object,
+  run(const Iterator &                            begin,
+      const std_cxx20::type_identity_t<Iterator> &end,
+      MainClass &                                 main_object,
       void (MainClass::*worker)(const Iterator &, ScratchData &, CopyData &),
       void (MainClass::*copier)(const CopyData &),
       const ScratchData &sample_scratch_data,


### PR DESCRIPTION
This uses the infrastructure in #14915.