### PR TITLE
Fix a test regarding concepts.

### DIFF
--- a/tests/grid/grid_tools_transform_01.cc
+++ b/tests/grid/grid_tools_transform_01.cc
@@ -25,18 +25,18 @@
 
 template <int dim>
 Point<dim>
-trans_func(Point<dim> &p);
+trans_func(const Point<dim> &p);
 
 template <>
 Point<2>
-trans_func(Point<2> &p)
+trans_func(const Point<2> &p)
 {
   Point<2> r(p(0) + p(1) * p(1), p(1));
   return r;
 }
 template <>
 Point<3>
-trans_func(Point<3> &p)
+trans_func(const Point<3> &p)
 {
   Point<3> r(p(0) + p(1) * p(1), p(1), p(2));
   return r;


### PR DESCRIPTION
Follow-up to https://github.com/dealii/dealii/pull/14934. That patch introduced the following constraints on a function in `namespace GridTools`:
```
  template <int dim, typename Transformation, int spacedim>
  DEAL_II_CXX20_REQUIRES(
    (std::invocable<Transformation, Point<spacedim>> &&
     std::assignable_from<
       Point<spacedim> &,
       std::invoke_result_t<Transformation, Point<spacedim>>>))
  void transform(const Transformation &        transformation,
                 Triangulation<dim, spacedim> &triangulation);
```
But in the test, we tried to call that function with function that takes a `Point<dim> &`, to which an rvalue `Point` object doesn't bind. Fix this by changing the test: The function should have taken a `const Point &` anyway.

Related to https://github.com/dealii/dealii/issues/14840.