### PR TITLE
cmake fix

### DIFF
--- a/cmake/macros/macro_deal_ii_add_test.cmake
+++ b/cmake/macros/macro_deal_ii_add_test.cmake
@@ -455,7 +455,7 @@ function(deal_ii_add_test _category _test_name _comparison_file)
         set_target_properties(${_target} PROPERTIES OUTPUT_NAME ${_target_short})
 
         deal_ii_setup_target(${_target} ${_build})
-        target_link_libraries(${_target}
+        target_link_libraries(${_target} PUBLIC
           ${TEST_LIBRARIES} ${TEST_LIBRARIES_${_build}}
           )
 


### PR DESCRIPTION
@tamiko Thanks for modernizing CMake. I really appreciate it :) Due to the introduced changes we have problems with the new CMake interface, see https://github.com/exadg/exadg/issues/392.

I think this is related to the fact that CMake can not mix ```target_link_library``` calls with and without the ```PUBLIC|PRIVATE|INTERFACE``` options. In our case we make use of the macro ```deal_II_pickup_tests``` which internally calls ```deal_ii_add_test``` which again calls ```deal_ii_setup_target```. In the last two there is a call of ```target_link_library```. What is the motivation behind https://github.com/dealii/dealii/commit/07113e3ae136f21e85a1a0af697d59df2d9398a9#diff-d965771743485e0e12464f1ff6aa367f3c1a1400f4f9287ef29547bf823c6b71R458? 
To ensure no mixture appears, I added the ```PUBLIC``` keyword in ```deal_ii_add_test```. Is this an option or does it break anything inside deal.II? 

