### PR TITLE
Enable output of compressed hdf5 files

### DIFF
--- a/cmake/config/template-arguments.in
+++ b/cmake/config/template-arguments.in
@@ -266,7 +266,7 @@ SYM_RANKS := { 2; 4 }
 
 // Flags that are allowed in DataOutInterface::set_flags
 OUTPUT_FLAG_TYPES := { DXFlags; UcdFlags; GnuplotFlags; PovrayFlags; EpsFlags;
-                       GmvFlags; TecplotFlags; VtkFlags; SvgFlags;
+                       GmvFlags; Hdf5Flags; TecplotFlags; VtkFlags; SvgFlags;
                        Deal_II_IntermediateFlags }
 
 // CGAL Kernels

--- a/doc/news/changes/incompatibilities/20230324Schmidt
+++ b/doc/news/changes/incompatibilities/20230324Schmidt
@@ -1,0 +1,3 @@
+Changed: The default behavior of the hdf5 output is changed from "not compressed" to "compressed" (default compression_level: best_speed).
+<br>
+(Christoph Schmidt, 2023/03/24)

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -1079,6 +1079,23 @@ namespace DataOutBase
   {};
 
   /**
+   * Flags controlling the details of output in HDF5 format.
+   *
+   * @ingroup output
+   */
+  struct Hdf5Flags : public OutputFlagsBase<Hdf5Flags>
+  {
+    /**
+     * Flag determining the compression level at which zlib, if available, is
+     * run. The default is <tt>best_speed</tt>.
+     */
+    DataOutBase::CompressionLevel compression_level;
+
+    explicit Hdf5Flags(
+      const CompressionLevel compression_level = CompressionLevel::best_speed);
+  };
+
+  /**
    * Flags controlling the details of output in Tecplot format.
    *
    * @ingroup output
@@ -2396,6 +2413,7 @@ namespace DataOutBase
   void
   write_hdf5_parallel(const std::vector<Patch<dim, spacedim>> &patches,
                       const DataOutFilter &                    data_filter,
+                      const DataOutBase::Hdf5Flags &           flags,
                       const std::string &                      filename,
                       const MPI_Comm &                         comm);
 
@@ -2410,6 +2428,7 @@ namespace DataOutBase
   void
   write_hdf5_parallel(const std::vector<Patch<dim, spacedim>> &patches,
                       const DataOutFilter &                    data_filter,
+                      const DataOutBase::Hdf5Flags &           flags,
                       const bool                               write_mesh_file,
                       const std::string &                      mesh_filename,
                       const std::string &solution_filename,
@@ -3157,6 +3176,12 @@ private:
    * changed by using the <tt>set_flags</tt> function.
    */
   DataOutBase::GmvFlags gmv_flags;
+
+  /**
+   * Flags to be used upon output of hdf5 data in one space dimension. Can be
+   * changed by using the <tt>set_flags</tt> function.
+   */
+  DataOutBase::Hdf5Flags hdf5_flags;
 
   /**
    * Flags to be used upon output of Tecplot data in one space dimension. Can

--- a/source/base/data_out_base.inst.in
+++ b/source/base/data_out_base.inst.in
@@ -222,10 +222,11 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS;
       template void
       write_hdf5_parallel(
         const std::vector<Patch<deal_II_dimension, deal_II_space_dimension>>
-          &                  patches,
-        const DataOutFilter &data_filter,
-        const std::string &  filename,
-        const MPI_Comm &     comm);
+          &                           patches,
+        const DataOutFilter &         data_filter,
+        const DataOutBase::Hdf5Flags &flags,
+        const std::string &           filename,
+        const MPI_Comm &              comm);
 
       template void
       write_filtered_data(

--- a/tests/mpi/data_out_hdf5_02.cc
+++ b/tests/mpi/data_out_hdf5_02.cc
@@ -54,10 +54,11 @@ check()
 
   std::string output_basename = std::to_string(dim) + std::to_string(spacedim);
 
-  DataOutBase::write_hdf5_parallel(patches,
-                                   data_filter,
-                                   output_basename + ".h5",
-                                   MPI_COMM_WORLD);
+  DataOutBase::Hdf5Flags hdf5Flags;
+  hdf5Flags.compression_level = DataOutBase::CompressionLevel::no_compression;
+
+  DataOutBase::write_hdf5_parallel(
+    patches, data_filter, hdf5Flags, output_basename + ".h5", MPI_COMM_WORLD);
 
   const double current_time = 0.0;
   XDMFEntry    entry(output_basename + ".h5",


### PR DESCRIPTION
So far output of compressed hdf5 files was not possible. This is introduced by the following changes:

- `Hdf5Flags` are introduced to enable setting the desired `DataOutBase::CompressionLevel`
- default compression level for the `Hdf5Flags` is `best_compression`
- `HDF5Flags` are added to the corresponding `write_hdf5_parallel` and `do_write_hdf5` methods
- if deal.II is build `with zlib` support, all necessary calls to perform compression using zlib (i.e. setting the compression level, setting the chunk size) are shielded behind `ifdef DEAL_II_WITH_ZLIB`
- if deal.II is build `without zlib` support, but compression_level is not set to no_compression an exception is raised.

Some more information on the chunking:
- According to  https://portal.hdfgroup.org/display/HDF5/H5P_SET_CHUNK the maximum allowed chunk size is 4GB, or 2^{32}-1 elements
--> Since I think this is a rather large amount of data per processor, I decided to not restrict the chunk size at the moment

I compared the compressed hdf5 output with the already available vtu output by the following toy-problem:
- dealii::parallel::distributed::Triangulation, setup as subdivided_hyper_cube with 2 cells per direction and a global refinement level of 6
- with an FE_Q(1) formulation this results in 2 146 689 dofs
- fill one vector with random numbers by using std::library tools
- output of the solution vector and the mesh using the available vtu and the updated hdf5 output routines at compression level 9 (best_compression) results in the following output data:
  - vtu:
    - dealii-vector_size_2146689_num_proc_5_compression_level_9_random_numbers.vtu: 85 M
  - hdf5 (all files to have the same output information compared to the vtu output)
    - dealii-mesh-vector_size_2146689_num_proc_5_compression_level_9_random_numbers.h5: 22 M
    - dealii-vector_size_2146689_num_proc_5_compression_level_9_random_numbers.h5: 8.9 M
    - dealii-vector_size_2146689_num_proc_5_compression_level_9_random_numbers.xdmf: 4 k
    - sum over all hdf5 files: 30.9 M

--> Compression seems to perform way better in the hdf5 case