### PR TITLE
Remove the LINK_LANGUAGE:CXX generator.

### DIFF
--- a/cmake/macros/macro_deal_ii_setup_target.cmake
+++ b/cmake/macros/macro_deal_ii_setup_target.cmake
@@ -104,9 +104,7 @@ macro(deal_ii_setup_target _target)
       "${DEAL_II_LINKER_FLAGS} ${DEAL_II_LINKER_FLAGS_${_build}}"
       )
     shell_escape_option_groups(_link_options)
-    target_link_options(${_target} PRIVATE
-      $<$<LINK_LANGUAGE:CXX>:${_link_options}>
-      )
+    target_link_options(${_target} PRIVATE ${_link_options})
   endif()
 
   target_link_libraries(${_target} ${DEAL_II_TARGET_${_build}})


### PR DESCRIPTION
Fixes #14949. This was pretty easy.

1. Presently, all of our tests are written in C++, so this is just for extra safety.
2. Link language generators were added in CMake 3.18, which we do not yet require.