### PR TITLE
CMake: avoid a warning in the check_compiler_setup macro

### DIFF
--- a/cmake/macros/check_compiler_setup/CMakeLists.txt
+++ b/cmake/macros/check_compiler_setup/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(CheckCompilerSetup)
 cmake_minimum_required(VERSION 3.13.4)
+project(CheckCompilerSetup)
 add_executable(CheckCompilerSetupExec dummy.cpp)
 
 # Make sure some CUDA warning flags don't get deduplicated


### PR DESCRIPTION
We should call cmake_minimum_required() prior to project().