### PR TITLE
CMake: do not use PUBLIC keyword for target_link_libraries for tests

### DIFF
--- a/cmake/macros/macro_deal_ii_add_test.cmake
+++ b/cmake/macros/macro_deal_ii_add_test.cmake
@@ -455,7 +455,7 @@ function(deal_ii_add_test _category _test_name _comparison_file)
         set_target_properties(${_target} PROPERTIES OUTPUT_NAME ${_target_short})
 
         deal_ii_setup_target(${_target} ${_build})
-        target_link_libraries(${_target} PUBLIC
+        target_link_libraries(${_target}
           ${TEST_LIBRARIES} ${TEST_LIBRARIES_${_build}}
           )
 


### PR DESCRIPTION
In reference to #14947