### PR TITLE
Remove dealii:: prefix from VectorOperation.

### DIFF
--- a/include/deal.II/base/partitioner.templates.h
+++ b/include/deal.II/base/partitioner.templates.h
@@ -587,7 +587,7 @@ namespace Utilities
         initialize_import_indices_plain_dev();
 #    endif
 
-      if (vector_operation != dealii::VectorOperation::insert)
+      if (vector_operation != VectorOperation::insert)
         AssertDimension(n_ghost_targets + n_import_targets, requests.size());
       // first wait for the receive to complete
       if (requests.size() > 0 && n_import_targets > 0)
@@ -603,7 +603,7 @@ namespace Utilities
                                                  MemorySpaceType,
                                                  MemorySpace::Default>::value)
             {
-              if (vector_operation == dealii::VectorOperation::add)
+              if (vector_operation == VectorOperation::add)
                 {
                   for (auto const &import_indices_plain :
                        import_indices_plain_dev)
@@ -627,7 +627,7 @@ namespace Utilities
                       read_position += chunk_size;
                     }
                 }
-              else if (vector_operation == dealii::VectorOperation::min)
+              else if (vector_operation == VectorOperation::min)
                 {
                   for (auto const &import_indices_plain :
                        import_indices_plain_dev)
@@ -654,7 +654,7 @@ namespace Utilities
                       read_position += chunk_size;
                     }
                 }
-              else if (vector_operation == dealii::VectorOperation::max)
+              else if (vector_operation == VectorOperation::max)
                 {
                   for (auto const &import_indices_plain :
                        import_indices_plain_dev)
@@ -700,13 +700,13 @@ namespace Utilities
               // local values. For insert, nothing is done here (but in debug
               // mode we assert that the specified value is either zero or
               // matches with the ones already present
-              if (vector_operation == dealii::VectorOperation::add)
+              if (vector_operation == VectorOperation::add)
                 for (const auto &import_range : import_indices_data)
                   for (unsigned int j = import_range.first;
                        j < import_range.second;
                        j++)
                     locally_owned_array[j] += *read_position++;
-              else if (vector_operation == dealii::VectorOperation::min)
+              else if (vector_operation == VectorOperation::min)
                 for (const auto &import_range : import_indices_data)
                   for (unsigned int j = import_range.first;
                        j < import_range.second;
@@ -717,7 +717,7 @@ namespace Utilities
                                           locally_owned_array[j]);
                       read_position++;
                     }
-              else if (vector_operation == dealii::VectorOperation::max)
+              else if (vector_operation == VectorOperation::max)
                 for (const auto &import_range : import_indices_data)
                   for (unsigned int j = import_range.first;
                        j < import_range.second;

--- a/include/deal.II/distributed/cell_data_transfer.templates.h
+++ b/include/deal.II/distributed/cell_data_transfer.templates.h
@@ -50,7 +50,7 @@ namespace internal
         post_unpack_action(std::vector<VectorType *> &all_out)
         {
           for (auto &out : all_out)
-            out->compress(::dealii::VectorOperation::insert);
+            out->compress(VectorOperation::insert);
         }
 
         template <typename value_type>

--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -653,7 +653,7 @@ public:
    * for more information.
    */
   void
-  compress(::dealii::VectorOperation::values operation);
+  compress(VectorOperation::values operation);
 
   /**
    * Multiply the entire matrix by a fixed factor.
@@ -2144,8 +2144,7 @@ BlockMatrixBase<MatrixType>::diag_element(const size_type i) const
 
 template <class MatrixType>
 inline void
-BlockMatrixBase<MatrixType>::compress(
-  ::dealii::VectorOperation::values operation)
+BlockMatrixBase<MatrixType>::compress(VectorOperation::values operation)
 {
   for (unsigned int r = 0; r < n_block_rows(); ++r)
     for (unsigned int c = 0; c < n_block_cols(); ++c)

--- a/include/deal.II/lac/block_vector.h
+++ b/include/deal.II/lac/block_vector.h
@@ -179,8 +179,7 @@ public:
    * for more information.
    */
   void
-  compress(::dealii::VectorOperation::values operation =
-             ::dealii::VectorOperation::unknown);
+  compress(VectorOperation::values operation = VectorOperation::unknown);
 
   /**
    * Returns `false` as this is a serial block vector.
@@ -444,7 +443,7 @@ BlockVector<Number>::operator=(const BlockVector<Number2> &v)
 
 template <typename Number>
 inline void
-BlockVector<Number>::compress(::dealii::VectorOperation::values operation)
+BlockVector<Number>::compress(VectorOperation::values operation)
 {
   for (size_type i = 0; i < this->n_blocks(); ++i)
     this->components[i].compress(operation);

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -508,7 +508,7 @@ public:
    * for more information.
    */
   void
-  compress(::dealii::VectorOperation::values operation);
+  compress(VectorOperation::values operation);
 
   /**
    * Access to a single block.
@@ -1527,8 +1527,7 @@ BlockVectorBase<VectorType>::collect_sizes()
 
 template <class VectorType>
 inline void
-BlockVectorBase<VectorType>::compress(
-  ::dealii::VectorOperation::values operation)
+BlockVectorBase<VectorType>::compress(VectorOperation::values operation)
 {
   for (unsigned int i = 0; i < n_blocks(); ++i)
     block(i).compress(operation);

--- a/include/deal.II/lac/la_parallel_block_vector.h
+++ b/include/deal.II/lac/la_parallel_block_vector.h
@@ -352,7 +352,7 @@ namespace LinearAlgebra
        * elements do not agree.
        */
       virtual void
-      compress(::dealii::VectorOperation::values operation) override;
+      compress(VectorOperation::values operation) override;
 
       /**
        * Fills the data field for ghost indices with the values stored in the

--- a/include/deal.II/lac/la_parallel_block_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_block_vector.templates.h
@@ -372,7 +372,7 @@ namespace LinearAlgebra
 
     template <typename Number>
     void
-    BlockVector<Number>::compress(::dealii::VectorOperation::values operation)
+    BlockVector<Number>::compress(VectorOperation::values operation)
     {
       const unsigned int n_chunks =
         (this->n_blocks() + communication_block_size - 1) /

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -516,7 +516,7 @@ namespace LinearAlgebra
        * after the second calculation will be zero.
        */
       virtual void
-      compress(::dealii::VectorOperation::values operation) override;
+      compress(VectorOperation::values operation) override;
 
       /**
        * Fills the data field for ghost indices with the values stored in the
@@ -560,9 +560,8 @@ namespace LinearAlgebra
        * LinearAlgebra::distributed::BlockVector).
        */
       void
-      compress_start(
-        const unsigned int                communication_channel = 0,
-        ::dealii::VectorOperation::values operation = VectorOperation::add);
+      compress_start(const unsigned int      communication_channel = 0,
+                     VectorOperation::values operation = VectorOperation::add);
 
       /**
        * For all requests that have been initiated in compress_start, wait for
@@ -583,7 +582,7 @@ namespace LinearAlgebra
        * the device after the call to compress_start will be lost.
        */
       void
-      compress_finish(::dealii::VectorOperation::values operation);
+      compress_finish(VectorOperation::values operation);
 
       /**
        * Initiates communication for the @p update_ghost_values() function

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -103,7 +103,7 @@ namespace LinearAlgebra
         static void
         import_elements(
           const ::dealii::LinearAlgebra::ReadWriteVector<Number> & /*V*/,
-          ::dealii::VectorOperation::values /*operation*/,
+          VectorOperation::values /*operation*/,
           const std::shared_ptr<const ::dealii::Utilities::MPI::Partitioner> &
           /*communication_pattern*/,
           const IndexSet & /*locally_owned_elem*/,
@@ -253,7 +253,7 @@ namespace LinearAlgebra
         static void
         import_elements(
           const ::dealii::LinearAlgebra::ReadWriteVector<Number> &V,
-          ::dealii::VectorOperation::values                       operation,
+          VectorOperation::values                                 operation,
           const std::shared_ptr<const ::dealii::Utilities::MPI::Partitioner>
             &             communication_pattern,
           const IndexSet &locally_owned_elem,
@@ -262,8 +262,8 @@ namespace LinearAlgebra
             &data)
         {
           Assert(
-            (operation == ::dealii::VectorOperation::add) ||
-              (operation == ::dealii::VectorOperation::insert),
+            (operation == VectorOperation::add) ||
+              (operation == VectorOperation::insert),
             ExcMessage(
               "Only VectorOperation::add and VectorOperation::insert are allowed"));
 
@@ -369,8 +369,8 @@ namespace LinearAlgebra
             &data)
         {
           Assert(
-            (operation == ::dealii::VectorOperation::add) ||
-              (operation == ::dealii::VectorOperation::insert),
+            (operation == VectorOperation::add) ||
+              (operation == VectorOperation::insert),
             ExcMessage(
               "Only VectorOperation::add and VectorOperation::insert are allowed"));
 
@@ -919,8 +919,7 @@ namespace LinearAlgebra
 
     template <typename Number, typename MemorySpaceType>
     void
-    Vector<Number, MemorySpaceType>::compress(
-      ::dealii::VectorOperation::values operation)
+    Vector<Number, MemorySpaceType>::compress(VectorOperation::values operation)
     {
       compress_start(0, operation);
       compress_finish(operation);
@@ -967,8 +966,8 @@ namespace LinearAlgebra
     template <typename Number, typename MemorySpaceType>
     void
     Vector<Number, MemorySpaceType>::compress_start(
-      const unsigned int                communication_channel,
-      ::dealii::VectorOperation::values operation)
+      const unsigned int      communication_channel,
+      VectorOperation::values operation)
     {
       AssertIndexRange(communication_channel, 200);
       Assert(vector_is_ghosted == false,
@@ -1044,7 +1043,7 @@ namespace LinearAlgebra
     template <typename Number, typename MemorySpaceType>
     void
     Vector<Number, MemorySpaceType>::compress_finish(
-      ::dealii::VectorOperation::values operation)
+      VectorOperation::values operation)
     {
 #ifdef DEAL_II_WITH_MPI
       vector_is_ghosted = false;

--- a/include/deal.II/lac/petsc_vector.h
+++ b/include/deal.II/lac/petsc_vector.h
@@ -484,7 +484,7 @@ namespace PETScWrappers
       for (size_type i = 0; i < v.size(); ++i)
         (*this)(i) = v(i);
 
-      compress(::dealii::VectorOperation::insert);
+      compress(VectorOperation::insert);
 
       return *this;
     }

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -97,9 +97,9 @@ namespace LinearAlgebra
     {
       static void
       import(const std::shared_ptr<const ::dealii::Utilities::MPI::Partitioner>
-               &                                     communication_pattern,
-             const Number *                          values,
-             const ::dealii::VectorOperation::values operation,
+               &                           communication_pattern,
+             const Number *                values,
+             const VectorOperation::values operation,
              ::dealii::LinearAlgebra::ReadWriteVector<Number> &rw_vector)
       {
         (void)communication_pattern;
@@ -124,9 +124,9 @@ namespace LinearAlgebra
 
       static void
       import(const std::shared_ptr<const ::dealii::Utilities::MPI::Partitioner>
-               &                                     communication_pattern,
-             const Number *                          values,
-             const ::dealii::VectorOperation::values operation,
+               &                           communication_pattern,
+             const Number *                values,
+             const VectorOperation::values operation,
              ::dealii::LinearAlgebra::ReadWriteVector<Number> &rw_vector)
       {
         distributed::Vector<Number, ::dealii::MemorySpace::Host> tmp_vector(
@@ -167,9 +167,9 @@ namespace LinearAlgebra
 
       static void
       import(const std::shared_ptr<const ::dealii::Utilities::MPI::Partitioner>
-               &                                     communication_pattern,
-             const Number *                          values,
-             const ::dealii::VectorOperation::values operation,
+               &                           communication_pattern,
+             const Number *                values,
+             const VectorOperation::values operation,
              ::dealii::LinearAlgebra::ReadWriteVector<Number> &rw_vector)
       {
         distributed::Vector<Number, ::dealii::MemorySpace::Host> tmp_vector(

--- a/include/deal.II/lac/relaxation_block.templates.h
+++ b/include/deal.II/lac/relaxation_block.templates.h
@@ -283,7 +283,7 @@ RelaxationBlock<MatrixType, InverseNumberType, VectorType>::do_step(
               additional_data->relaxation * x_cell(row_cell);
         }
     }
-  dst.compress(dealii::VectorOperation::add);
+  dst.compress(VectorOperation::add);
 }
 
 

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -783,7 +783,7 @@ public:
   /**
    * Dummy function for compatibility with distributed, parallel matrices.
    */
-  void compress(::dealii::VectorOperation::values);
+  void compress(VectorOperation::values);
 
   /** @} */
   /**

--- a/include/deal.II/lac/sparse_matrix.templates.h
+++ b/include/deal.II/lac/sparse_matrix.templates.h
@@ -2069,7 +2069,7 @@ SparseMatrix<number>::block_read(std::istream &in)
 
 
 template <typename number>
-void SparseMatrix<number>::compress(::dealii::VectorOperation::values)
+void SparseMatrix<number>::compress(VectorOperation::values)
 {}
 
 

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -1034,7 +1034,7 @@ namespace TrilinosWrappers
      * for more information.
      */
     void
-    compress(::dealii::VectorOperation::values operation);
+    compress(VectorOperation::values operation);
 
     /**
      * Set the element (<i>i,j</i>) to @p value.

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -633,7 +633,7 @@ namespace TrilinosWrappers
        * for more information.
        */
       void
-      compress(::dealii::VectorOperation::values operation);
+      compress(VectorOperation::values operation);
 
       /**
        * Set all components of the vector to the given number @p s. Simply

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -271,8 +271,7 @@ public:
    * an empty function.
    */
   void
-  compress(::dealii::VectorOperation::values operation =
-             ::dealii::VectorOperation::unknown) const;
+  compress(VectorOperation::values operation = VectorOperation::unknown) const;
 
   /**
    * Change the dimension of the vector to @p N. The reserved memory for this
@@ -1326,7 +1325,7 @@ Vector<Number>::operator!=(const Vector<Number2> &v) const
 
 
 template <typename Number>
-inline void Vector<Number>::compress(::dealii::VectorOperation::values) const
+inline void Vector<Number>::compress(VectorOperation::values) const
 {}
 
 

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -3618,7 +3618,7 @@ namespace internal
     {
       (void)component_in_block_vector;
       Assert(vec.has_ghost_elements() == false, ExcNotImplemented());
-      vec.compress(dealii::VectorOperation::add);
+      vec.compress(VectorOperation::add);
     }
 
 
@@ -3681,7 +3681,7 @@ namespace internal
           AssertDimension(requests.size(), tmp_data.size());
 
           part.import_from_ghosted_array_start(
-            dealii::VectorOperation::add,
+            VectorOperation::add,
             component_in_block_vector * 2 + channel_shift,
             ArrayView<Number>(vec.begin(), part.locally_owned_size()),
             vec.shared_vector_data(),
@@ -3725,7 +3725,7 @@ namespace internal
                     VectorType &       vec)
     {
       (void)component_in_block_vector;
-      vec.compress_finish(dealii::VectorOperation::add);
+      vec.compress_finish(VectorOperation::add);
     }
 
 
@@ -4255,7 +4255,7 @@ namespace internal
     const unsigned int                                    channel = 0)
   {
     if (get_communication_block_size(vec) < vec.n_blocks())
-      vec.compress(dealii::VectorOperation::add);
+      vec.compress(VectorOperation::add);
     else
       for (unsigned int i = 0; i < vec.n_blocks(); ++i)
         compress_start(vec.block(i), exchanger, channel + i);

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -2315,7 +2315,7 @@ namespace internal
 
       embedded_partitioner
         ->template import_from_ghosted_array_start<Number, MemorySpace::Host>(
-          dealii::VectorOperation::add,
+          VectorOperation::add,
           0,
           dealii::ArrayView<Number>(
             const_cast<Number *>(vec.begin()) +
@@ -2338,7 +2338,7 @@ namespace internal
 
       embedded_partitioner
         ->template import_from_ghosted_array_finish<Number, MemorySpace::Host>(
-          dealii::VectorOperation::add,
+          VectorOperation::add,
           dealii::ArrayView<const Number>(buffer.begin(), buffer.size()),
           dealii::ArrayView<Number>(vec.begin(),
                                     embedded_partitioner->locally_owned_size()),

--- a/include/deal.II/numerics/cell_data_transfer.templates.h
+++ b/include/deal.II/numerics/cell_data_transfer.templates.h
@@ -35,7 +35,7 @@ namespace internal
     void
     post_unpack_action(VectorType &out)
     {
-      out.compress(::dealii::VectorOperation::insert);
+      out.compress(VectorOperation::insert);
     }
 
     template <typename value_type>

--- a/source/distributed/field_transfer.cc
+++ b/source/distributed/field_transfer.cc
@@ -204,7 +204,7 @@ namespace parallel
 
 
         // Communicate the results.
-        out.compress(dealii::VectorOperation::insert);
+        out.compress(VectorOperation::insert);
 
         // Treat hanging nodes
         std::vector<types::global_dof_index> dof_indices;

--- a/source/distributed/solution_transfer.cc
+++ b/source/distributed/solution_transfer.cc
@@ -270,24 +270,24 @@ namespace parallel
         {
           // finalize valence: compress and invert
           using Number = typename VectorType::value_type;
-          valence.compress(::dealii::VectorOperation::add);
+          valence.compress(VectorOperation::add);
           for (const auto i : valence.locally_owned_elements())
             valence[i] = (static_cast<Number>(valence[i]) == Number() ?
                             Number() :
                             (Number(1.0) / static_cast<Number>(valence[i])));
-          valence.compress(::dealii::VectorOperation::insert);
+          valence.compress(VectorOperation::insert);
 
           for (const auto vec : all_out)
             {
               // compress and weight with valence
-              vec->compress(::dealii::VectorOperation::add);
+              vec->compress(VectorOperation::add);
               vec->scale(valence);
             }
         }
       else
         {
           for (const auto vec : all_out)
-            vec->compress(::dealii::VectorOperation::insert);
+            vec->compress(VectorOperation::insert);
         }
 
       input_vectors.clear();

--- a/source/lac/petsc_matrix_base.cc
+++ b/source/lac/petsc_matrix_base.cc
@@ -92,7 +92,7 @@ namespace PETScWrappers
   void
   MatrixBase::reinit(Mat A)
   {
-    AssertThrow(last_action == ::dealii::VectorOperation::unknown,
+    AssertThrow(last_action == VectorOperation::unknown,
                 ExcMessage("Cannot assign a new Mat."));
     PetscErrorCode ierr =
       PetscObjectReference(reinterpret_cast<PetscObject>(A));

--- a/source/lac/petsc_parallel_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_sparse_matrix.cc
@@ -326,7 +326,7 @@ namespace PETScWrappers
           ierr = MatMPIAIJSetPreallocationCSR(matrix, &i, &i, nullptr);
           AssertThrow(ierr == 0, ExcPETScError(ierr));
         }
-      compress(dealii::VectorOperation::insert);
+      compress(VectorOperation::insert);
 
       {
         close_matrix(matrix);
@@ -664,7 +664,7 @@ namespace PETScWrappers
           ierr = MatSeqAIJSetPreallocationCSR(local_matrix, &i, &i, nullptr);
           AssertThrow(ierr == 0, ExcPETScError(ierr));
         }
-      compress(dealii::VectorOperation::insert);
+      compress(VectorOperation::insert);
 
       {
         close_matrix(local_matrix);

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -123,7 +123,7 @@ namespace PETScWrappers
   VectorBase::VectorBase()
     : vector(nullptr)
     , ghosted(false)
-    , last_action(::dealii::VectorOperation::unknown)
+    , last_action(VectorOperation::unknown)
   {}
 
 
@@ -132,7 +132,7 @@ namespace PETScWrappers
     : Subscriptor()
     , ghosted(v.ghosted)
     , ghost_indices(v.ghost_indices)
-    , last_action(::dealii::VectorOperation::unknown)
+    , last_action(VectorOperation::unknown)
   {
     PetscErrorCode ierr = VecDuplicate(v.vector, &vector);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
@@ -147,7 +147,7 @@ namespace PETScWrappers
     : Subscriptor()
     , vector(v)
     , ghosted(false)
-    , last_action(::dealii::VectorOperation::unknown)
+    , last_action(VectorOperation::unknown)
   {
     /* TODO GHOSTED */
     const PetscErrorCode ierr =
@@ -171,7 +171,7 @@ namespace PETScWrappers
   VectorBase::reinit(Vec v)
   {
     /* TODO GHOSTED */
-    AssertThrow(last_action == ::dealii::VectorOperation::unknown,
+    AssertThrow(last_action == VectorOperation::unknown,
                 ExcMessage("Cannot assign a new Vec"));
     PetscErrorCode ierr =
       PetscObjectReference(reinterpret_cast<PetscObject>(v));
@@ -189,7 +189,7 @@ namespace PETScWrappers
 
     ghosted = false;
     ghost_indices.clear();
-    last_action = ::dealii::VectorOperation::unknown;
+    last_action = VectorOperation::unknown;
   }
 
 
@@ -407,8 +407,8 @@ namespace PETScWrappers
                                      get_mpi_communicator());
       AssertThrowMPI(ierr);
 
-      AssertThrow(all_int_last_action != (::dealii::VectorOperation::add |
-                                          ::dealii::VectorOperation::insert),
+      AssertThrow(all_int_last_action !=
+                    (VectorOperation::add | VectorOperation::insert),
                   ExcMessage("Error: not all processors agree on the last "
                              "VectorOperation before this compress() call."));
 #    endif
@@ -416,8 +416,7 @@ namespace PETScWrappers
     }
 
     AssertThrow(
-      last_action == ::dealii::VectorOperation::unknown ||
-        last_action == operation,
+      last_action == VectorOperation::unknown || last_action == operation,
       ExcMessage(
         "Missing compress() or calling with wrong VectorOperation argument."));
 
@@ -443,7 +442,7 @@ namespace PETScWrappers
     // reset the last action field to
     // indicate that we're back to a
     // pristine state
-    last_action = ::dealii::VectorOperation::unknown;
+    last_action = VectorOperation::unknown;
   }
 
 
@@ -973,11 +972,9 @@ namespace PETScWrappers
                                    const PetscScalar *values,
                                    const bool         add_values)
   {
-    ::dealii::VectorOperation::values action =
-      (add_values ? ::dealii::VectorOperation::add :
-                    ::dealii::VectorOperation::insert);
-    Assert((last_action == action) ||
-             (last_action == ::dealii::VectorOperation::unknown),
+    VectorOperation::values action =
+      (add_values ? VectorOperation::add : VectorOperation::insert);
+    Assert((last_action == action) || (last_action == VectorOperation::unknown),
            internal::VectorReference::ExcWrongMode(action, last_action));
     Assert(!has_ghost_elements(), ExcGhostsPresent());
     // VecSetValues complains if we

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -1037,15 +1037,15 @@ namespace TrilinosWrappers
 
 
   void
-  SparseMatrix::compress(::dealii::VectorOperation::values operation)
+  SparseMatrix::compress(VectorOperation::values operation)
   {
     Epetra_CombineMode mode = last_action;
     if (last_action == Zero)
       {
-        if ((operation == ::dealii::VectorOperation::add) ||
-            (operation == ::dealii::VectorOperation::unknown))
+        if ((operation == VectorOperation::add) ||
+            (operation == VectorOperation::unknown))
           mode = Add;
-        else if (operation == ::dealii::VectorOperation::insert)
+        else if (operation == VectorOperation::insert)
           mode = Insert;
         else
           Assert(
@@ -1055,11 +1055,10 @@ namespace TrilinosWrappers
       }
     else
       {
-        Assert(((last_action == Add) &&
-                (operation != ::dealii::VectorOperation::insert)) ||
-                 ((last_action == Insert) &&
-                  (operation != ::dealii::VectorOperation::add)),
-               ExcMessage("Operation and argument to compress() do not match"));
+        Assert(
+          ((last_action == Add) && (operation != VectorOperation::insert)) ||
+            ((last_action == Insert) && (operation != VectorOperation::add)),
+          ExcMessage("Operation and argument to compress() do not match"));
       }
 
     // flush buffers
@@ -1762,9 +1761,8 @@ namespace TrilinosWrappers
   SparseMatrix::operator=(const double d)
   {
     Assert(d == 0, ExcScalarAssignmentOnlyForZeroValue());
-    compress(
-      ::dealii::VectorOperation::unknown); // TODO: why do we do this? Should we
-                                           // not check for is_compressed?
+    compress(VectorOperation::unknown); // TODO: why do we do this? Should we
+                                        // not check for is_compressed?
 
     const int ierr = matrix->PutScalar(d);
     AssertThrow(ierr == 0, ExcTrilinosError(ierr));

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -581,7 +581,7 @@ namespace TrilinosWrappers
 
 
     void
-    Vector::compress(::dealii::VectorOperation::values given_last_action)
+    Vector::compress(VectorOperation::values given_last_action)
     {
       // Select which mode to send to Trilinos. Note that we use last_action if
       // available and ignore what the user tells us to detect wrongly mixed
@@ -591,9 +591,9 @@ namespace TrilinosWrappers
       Epetra_CombineMode mode = last_action;
       if (last_action == Zero)
         {
-          if (given_last_action == ::dealii::VectorOperation::add)
+          if (given_last_action == VectorOperation::add)
             mode = Add;
-          else if (given_last_action == ::dealii::VectorOperation::insert)
+          else if (given_last_action == VectorOperation::insert)
             mode = Insert;
           else
             Assert(
@@ -605,9 +605,9 @@ namespace TrilinosWrappers
         {
           Assert(
             ((last_action == Add) &&
-             (given_last_action == ::dealii::VectorOperation::add)) ||
+             (given_last_action == VectorOperation::add)) ||
               ((last_action == Insert) &&
-               (given_last_action == ::dealii::VectorOperation::insert)),
+               (given_last_action == VectorOperation::insert)),
             ExcMessage(
               "The last operation on the Vector and the given last action in the compress() call do not agree!"));
         }

--- a/source/matrix_free/vector_data_exchange.cc
+++ b/source/matrix_free/vector_data_exchange.cc
@@ -1100,7 +1100,7 @@ namespace internal
         (void)data_others;
         (void)operation;
 
-        Assert(operation == dealii::VectorOperation::add, ExcNotImplemented());
+        Assert(operation == VectorOperation::add, ExcNotImplemented());
 
         requests.resize(sm_ghost_ranks.size() + sm_import_ranks.size() +
                         ghost_targets_data.size() + import_targets_data.size());
@@ -1224,7 +1224,7 @@ namespace internal
 
         (void)operation;
 
-        Assert(operation == dealii::VectorOperation::add, ExcNotImplemented());
+        Assert(operation == VectorOperation::add, ExcNotImplemented());
 
         AssertDimension(requests.size(),
                         sm_ghost_ranks.size() + sm_import_ranks.size() +


### PR DESCRIPTION
AFAICT this is never needed - we don't have any conflicting names and none of our dependencies define a class with the same name.