### PR TITLE
Add a move assignment operator to LA::d::V.

### DIFF
--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -444,6 +444,15 @@ namespace LinearAlgebra
       swap(Vector<Number, MemorySpace> &v);
 
       /**
+       * Move assignment operator.
+       *
+       * @note This method may throw an exception (should an MPI check fail) and
+       * is consequently not `noexcept`.
+       */
+      Vector<Number, MemorySpace> &
+      operator=(Vector<Number, MemorySpace> &&in_vector); // NOLINT
+
+      /**
        * Assigns the vector to the parallel partitioning of the input vector
        * @p in_vector, and copies all the data.
        *

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -1377,6 +1377,18 @@ namespace LinearAlgebra
 
     template <typename Number, typename MemorySpaceType>
     Vector<Number, MemorySpaceType> &
+    Vector<Number, MemorySpaceType>::operator=( // NOLINT
+      Vector<Number, MemorySpaceType> &&v)
+    {
+      static_cast<Subscriptor &>(*this) = static_cast<Subscriptor &&>(v);
+      this->swap(v);
+      return *this;
+    }
+
+
+
+    template <typename Number, typename MemorySpaceType>
+    Vector<Number, MemorySpaceType> &
     Vector<Number, MemorySpaceType>::operator=(const Number s)
     {
       const size_type this_size = locally_owned_size();


### PR DESCRIPTION
I noticed I was doing some extra copies that can be avoided pretty easily.