### PR TITLE
Be more correct in our noexcept usage.

### DIFF
--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -500,8 +500,12 @@ namespace TrilinosWrappers
       /**
        * Move constructor. Creates a new vector by stealing the internal data
        * of the vector @p v.
+       *
+       * @note In order for this constructor to leave the moved-from object in a
+       * valid state it must allocate memory (in this case, an empty
+       * Epetra_FEVector) - hence it cannot be marked as noexcept.
        */
-      Vector(Vector &&v) noexcept;
+      Vector(Vector &&v); // NOLINT
 
       /**
        * Destructor.

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -98,10 +98,11 @@ namespace TrilinosWrappers
 
 
 
-    Vector::Vector(Vector &&v) noexcept
+    Vector::Vector(Vector &&v) // NOLINT
       : Vector()
     {
       // initialize a minimal, valid object and swap
+      static_cast<Subscriptor &>(*this) = static_cast<Subscriptor &&>(v);
       swap(v);
     }
 
@@ -499,6 +500,7 @@ namespace TrilinosWrappers
     Vector &
     Vector::operator=(Vector &&v) noexcept
     {
+      static_cast<Subscriptor &>(*this) = static_cast<Subscriptor &&>(v);
       swap(v);
       return *this;
     }


### PR DESCRIPTION
I noticed this while working on the other one. The default ctor allocates so it's technically not noexcept.

Do we have a policy for this? I don't know if we want to be this pedantic about `std::bad_alloc`.