### PR TITLE
Use functionality from ReferenceCell in QProjector.

### DIFF
--- a/source/base/qprojector.cc
+++ b/source/base/qprojector.cc
@@ -698,7 +698,6 @@ QProjector<3>::project_to_all_faces(const ReferenceCell &     reference_cell,
 
                 // scale quadrature weight
                 const double scaling = [&]() {
-                  const auto &       supp_pts = support_points;
                   const unsigned int dim_     = 2;
                   const unsigned int spacedim = 3;
 
@@ -713,12 +712,13 @@ QProjector<3>::project_to_all_faces(const ReferenceCell &     reference_cell,
 
                   for (unsigned int i = 0; i < spacedim; ++i)
                     for (unsigned int j = 0; j < dim_; ++j)
-                      result[i][j] = shape_derivatives[0][j] * supp_pts[0][i];
+                      result[i][j] =
+                        shape_derivatives[0][j] * support_points[0][i];
                   for (unsigned int k = 1; k < n_linear_shape_functions; ++k)
                     for (unsigned int i = 0; i < spacedim; ++i)
                       for (unsigned int j = 0; j < dim_; ++j)
                         result[i][j] +=
-                          shape_derivatives[k][j] * supp_pts[k][i];
+                          shape_derivatives[k][j] * support_points[k][i];
 
                   DerivativeForm<1, dim_, spacedim> contravariant;
 

--- a/source/base/qprojector.cc
+++ b/source/base/qprojector.cc
@@ -643,24 +643,6 @@ Quadrature<3>
 QProjector<3>::project_to_all_faces(const ReferenceCell &     reference_cell,
                                     const hp::QCollection<2> &quadrature)
 {
-  const auto support_points_tri =
-    [](const std::vector<Point<3>> &face,
-       const unsigned char          orientation) -> std::vector<Point<3>> {
-    const boost::container::small_vector<Point<3>, 8> temp =
-      ReferenceCells::Triangle.permute_by_combined_orientation<Point<3>>(
-        face, orientation);
-    return std::vector<Point<3>>(temp.begin(), temp.end());
-  };
-
-  const auto support_points_quad =
-    [](const std::vector<Point<3>> &face,
-       const unsigned char          orientation) -> std::vector<Point<3>> {
-    const boost::container::small_vector<Point<3>, 8> temp =
-      ReferenceCells::Quadrilateral.permute_by_combined_orientation<Point<3>>(
-        face, orientation);
-    return std::vector<Point<3>>(temp.begin(), temp.end());
-  };
-
   const auto process = [&](const std::vector<std::vector<Point<3>>> &faces) {
     // new (projected) quadrature points and weights
     std::vector<Point<3>> points;
@@ -691,10 +673,9 @@ QProjector<3>::project_to_all_faces(const ReferenceCell &     reference_cell,
           {
             const auto &face = faces[face_no];
 
-            const auto support_points =
-              n_linear_shape_functions == 3 ?
-                support_points_tri(face, orientation) :
-                support_points_quad(face, orientation);
+            const boost::container::small_vector<Point<3>, 8> support_points =
+              reference_cell.face_reference_cell(face_no)
+                .permute_by_combined_orientation<Point<3>>(face, orientation);
 
             // the quadrature rule to be projected ...
             const auto &sub_quadrature_points =

--- a/source/base/qprojector.cc
+++ b/source/base/qprojector.cc
@@ -749,67 +749,21 @@ QProjector<3>::project_to_all_faces(const ReferenceCell &     reference_cell,
     return Quadrature<3>(points, weights);
   };
 
-  if (reference_cell == ReferenceCells::Tetrahedron)
+  if ((reference_cell == ReferenceCells::Tetrahedron) ||
+      (reference_cell == ReferenceCells::Wedge) ||
+      (reference_cell == ReferenceCells::Pyramid))
     {
-      const std::vector<std::vector<Point<3>>> face_vertex_locations = {
-        {{Point<3>(0.0, 0.0, 0.0),
-          Point<3>(1.0, 0.0, 0.0),
-          Point<3>(0.0, 1.0, 0.0)}},
-        {{Point<3>(1.0, 0.0, 0.0),
-          Point<3>(0.0, 0.0, 0.0),
-          Point<3>(0.0, 0.0, 1.0)}},
-        {{Point<3>(0.0, 0.0, 0.0),
-          Point<3>(0.0, 1.0, 0.0),
-          Point<3>(0.0, 0.0, 1.0)}},
-        {{Point<3>(0.0, 1.0, 0.0),
-          Point<3>(1.0, 0.0, 0.0),
-          Point<3>(0.0, 0.0, 1.0)}}};
-
-      return process(face_vertex_locations);
-    }
-  else if (reference_cell == ReferenceCells::Wedge)
-    {
-      const std::vector<std::vector<Point<3>>> face_vertex_locations = {
-        {{Point<3>(1.0, 0.0, 0.0),
-          Point<3>(0.0, 0.0, 0.0),
-          Point<3>(0.0, 1.0, 0.0)}},
-        {{Point<3>(0.0, 0.0, 1.0),
-          Point<3>(1.0, 0.0, 1.0),
-          Point<3>(0.0, 1.0, 1.0)}},
-        {{Point<3>(0.0, 0.0, 0.0),
-          Point<3>(1.0, 0.0, 0.0),
-          Point<3>(0.0, 0.0, 1.0),
-          Point<3>(1.0, 0.0, 1.0)}},
-        {{Point<3>(1.0, 0.0, 0.0),
-          Point<3>(0.0, 1.0, 0.0),
-          Point<3>(1.0, 0.0, 1.0),
-          Point<3>(0.0, 1.0, 1.0)}},
-        {{Point<3>(0.0, 1.0, 0.0),
-          Point<3>(0.0, 0.0, 0.0),
-          Point<3>(0.0, 1.0, 1.0),
-          Point<3>(0.0, 0.0, 1.0)}}};
-
-      return process(face_vertex_locations);
-    }
-  else if (reference_cell == ReferenceCells::Pyramid)
-    {
-      const std::vector<std::vector<Point<3>>> face_vertex_locations = {
-        {{Point<3>(-1.0, -1.0, 0.0),
-          Point<3>(+1.0, -1.0, 0.0),
-          Point<3>(-1.0, +1.0, 0.0),
-          Point<3>(+1.0, +1.0, 0.0)}},
-        {{Point<3>(-1.0, -1.0, 0.0),
-          Point<3>(-1.0, +1.0, 0.0),
-          Point<3>(+0.0, +0.0, 1.0)}},
-        {{Point<3>(+1.0, +1.0, 0.0),
-          Point<3>(+1.0, -1.0, 0.0),
-          Point<3>(+0.0, +0.0, 1.0)}},
-        {{Point<3>(+1.0, -1.0, 0.0),
-          Point<3>(-1.0, -1.0, 0.0),
-          Point<3>(+0.0, +0.0, 1.0)}},
-        {{Point<3>(-1.0, +1.0, 0.0),
-          Point<3>(+1.0, +1.0, 0.0),
-          Point<3>(+0.0, +0.0, 1.0)}}};
+      std::vector<std::vector<Point<3>>> face_vertex_locations(
+        reference_cell.n_faces());
+      for (unsigned int f : reference_cell.face_indices())
+        {
+          face_vertex_locations[f].resize(
+            reference_cell.face_reference_cell(f).n_vertices());
+          for (unsigned int v :
+               reference_cell.face_reference_cell(f).vertex_indices())
+            face_vertex_locations[f][v] =
+              reference_cell.face_vertex_location<3>(f, v);
+        }
 
       return process(face_vertex_locations);
     }


### PR DESCRIPTION
This is a follow-up to #14784 -- it just took me a while to find this branch again since I had named it completely unreasonably. In any case, this uses functionality that I had moved from `QProjector` to `ReferenceCell` and that now allows making projecting quadrature formulas to faces of cells much more generic. 

The patch is arguably not easy to read. It might be easiest to read it commit-by-commit.