### PR TITLE
Change default `compression_level` of vtu output

### DIFF
--- a/doc/news/changes/minor/20230328Schmidt
+++ b/doc/news/changes/minor/20230328Schmidt
@@ -1,0 +1,3 @@
+Changed: The default `compression_level` for vtu output is changed from `best_compression` to `best_speed`.
+<br>
+(Christoph Schmidt, 2023/03/28)

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -1188,7 +1188,7 @@ namespace DataOutBase
 
     /**
      * Flag determining the compression level at which zlib, if available, is
-     * run. The default is <tt>best_compression</tt>.
+     * run. The default is <tt>best_speed</tt>.
      */
     DataOutBase::CompressionLevel compression_level;
 
@@ -1242,9 +1242,8 @@ namespace DataOutBase
       const double           time  = std::numeric_limits<double>::min(),
       const unsigned int     cycle = std::numeric_limits<unsigned int>::min(),
       const bool             print_date_and_time = true,
-      const CompressionLevel compression_level =
-        CompressionLevel::best_compression,
-      const bool write_higher_order_cells                      = false,
+      const CompressionLevel compression_level   = CompressionLevel::best_speed,
+      const bool             write_higher_order_cells          = false,
       const std::map<std::string, std::string> &physical_units = {});
   };
 

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -3718,9 +3718,9 @@ GridOut::write_mesh_per_processor_as_vtu(
                unsigned int,
                std::string,
                DataComponentInterpretation::DataComponentInterpretation>>
-                        vector_data_ranges;
-  DataOutBase::VtkFlags flags;
-  DataOutBase::write_vtu(patches, data_names, vector_data_ranges, flags, out);
+    vector_data_ranges;
+  DataOutBase::write_vtu(
+    patches, data_names, vector_data_ranges, vtu_flags, out);
 }
 
 

--- a/tests/data_out/data_out_12.cc
+++ b/tests/data_out/data_out_12.cc
@@ -166,6 +166,9 @@ check()
   std::vector<std::string> component_name(dim + dim * dim, "tensor");
   std::fill(component_name.begin(), component_name.begin() + dim, "vector");
 
+  DataOutBase::VtkFlags vtk_flags;
+  vtk_flags.compression_level = DataOutBase::CompressionLevel::best_compression;
+
   DataOut<dim> data_out;
   data_out.attach_dof_handler(dof_handler);
   data_out.add_data_vector(v,
@@ -173,6 +176,7 @@ check()
                            DataOut<dim>::type_dof_data,
                            data_component_interpretation);
   data_out.build_patches();
+  data_out.set_flags(vtk_flags);
 
   /*
   std::ofstream out("output_" + Utilities::int_to_string(dim) + "d.vtu");

--- a/tests/data_out/data_out_13.cc
+++ b/tests/data_out/data_out_13.cc
@@ -166,6 +166,9 @@ check()
   std::vector<std::string> component_name(dim + dim * dim, "tensor");
   std::fill(component_name.begin(), component_name.begin() + dim, "vector");
 
+  DataOutBase::VtkFlags vtk_flags;
+  vtk_flags.compression_level = DataOutBase::CompressionLevel::best_compression;
+
   DataOut<dim> data_out;
   data_out.attach_dof_handler(dof_handler);
   data_out.add_data_vector(v,
@@ -173,6 +176,7 @@ check()
                            DataOut<dim>::type_dof_data,
                            data_component_interpretation);
   data_out.build_patches();
+  data_out.set_flags(vtk_flags);
 
   std::vector<std::string> filenames;
   filenames.push_back("output_" + Utilities::int_to_string(dim) + "d.vtu");

--- a/tests/data_out/data_out_base_vtu_02.cc
+++ b/tests/data_out/data_out_base_vtu_02.cc
@@ -67,6 +67,7 @@ check_all(std::ostream &log)
 
   char                  name[100];
   DataOutBase::VtkFlags flags;
+  flags.compression_level = DataOutBase::CompressionLevel::best_compression;
   if (true)
     {
       sprintf(name, "%d%d.vtu", dim, spacedim);

--- a/tests/data_out/data_out_base_vtu_04.cc
+++ b/tests/data_out/data_out_base_vtu_04.cc
@@ -61,6 +61,7 @@ check(std::ostream &log, unsigned cell_order)
 
   DataOutBase::VtkFlags flags;
   flags.write_higher_order_cells = true;
+  flags.compression_level = DataOutBase::CompressionLevel::best_compression;
 
   DataOut<dim> data_out;
   data_out.set_flags(flags);

--- a/tests/data_out/data_out_base_vtu_05.cc
+++ b/tests/data_out/data_out_base_vtu_05.cc
@@ -53,6 +53,7 @@ check(std::ostream &log, unsigned cell_order)
 
   DataOutBase::VtkFlags flags;
   flags.write_higher_order_cells = true;
+  flags.compression_level = DataOutBase::CompressionLevel::best_compression;
 
   DataOut<dim> data_out;
   data_out.set_flags(flags);

--- a/tests/data_out/data_out_postprocessor_tensor_02.cc
+++ b/tests/data_out/data_out_postprocessor_tensor_02.cc
@@ -362,6 +362,10 @@ namespace Step8
 
     StrainPostprocessor<dim> grad_u;
 
+    DataOutBase::VtkFlags vtk_flags;
+    vtk_flags.compression_level =
+      DataOutBase::CompressionLevel::best_compression;
+
     DataOut<dim> data_out;
     data_out.attach_dof_handler(dof_handler);
 
@@ -376,6 +380,7 @@ namespace Step8
                              data_component_interpretation);
     data_out.add_data_vector(solution, grad_u);
     data_out.build_patches();
+    data_out.set_flags(vtk_flags);
     data_out.write_vtu(deallog.get_file_stream());
   }
 

--- a/tests/grid/grid_out_07.cc
+++ b/tests/grid/grid_out_07.cc
@@ -44,7 +44,10 @@ test(std::ostream &logfile)
   tria.begin_active()->set_refine_flag();
   tria.execute_coarsening_and_refinement();
 
-  GridOut grid_out;
+  GridOut           grid_out;
+  GridOutFlags::Vtu vtu_flags;
+  vtu_flags.compression_level = DataOutBase::CompressionLevel::best_compression;
+  grid_out.set_flags(vtu_flags);
   grid_out.write_vtu(tria, logfile);
 }
 

--- a/tests/grid/grid_out_08.cc
+++ b/tests/grid/grid_out_08.cc
@@ -71,7 +71,10 @@ test()
 
   tria.refine_global(1);
 
-  GridOut grid_out;
+  GridOut           grid_out;
+  GridOutFlags::Vtu vtu_flags;
+  vtu_flags.compression_level = DataOutBase::CompressionLevel::best_compression;
+  grid_out.set_flags(vtu_flags);
   grid_out.write_vtu(tria, deallog.get_file_stream());
 }
 

--- a/tests/grid/grid_out_per_processor_vtu_01.cc
+++ b/tests/grid/grid_out_per_processor_vtu_01.cc
@@ -46,7 +46,10 @@ output(const parallel::distributed::Triangulation<dim> &tr,
        const bool                                       view_levels,
        const bool                                       include_artificial)
 {
-  GridOut out;
+  GridOut           out;
+  GridOutFlags::Vtu vtu_flags;
+  vtu_flags.compression_level = DataOutBase::CompressionLevel::best_compression;
+  out.set_flags(vtu_flags);
   out.write_mesh_per_processor_as_vtu(tr,
                                       filename,
                                       view_levels,

--- a/tests/grid/grid_out_per_processor_vtu_02.cc
+++ b/tests/grid/grid_out_per_processor_vtu_02.cc
@@ -47,7 +47,10 @@ output(const parallel::shared::Triangulation<dim> &tr,
        const bool                                  view_levels,
        const bool                                  include_artificial)
 {
-  GridOut out;
+  GridOut           out;
+  GridOutFlags::Vtu vtu_flags;
+  vtu_flags.compression_level = DataOutBase::CompressionLevel::best_compression;
+  out.set_flags(vtu_flags);
   out.write_mesh_per_processor_as_vtu(tr,
                                       filename,
                                       view_levels,

--- a/tests/grid/grid_out_per_processor_vtu_03.cc
+++ b/tests/grid/grid_out_per_processor_vtu_03.cc
@@ -49,8 +49,11 @@ test()
   GridGenerator::hyper_cube(tr);
   tr.refine_global(3);
 
-  std::string filename = "file" + Utilities::int_to_string(dim);
-  GridOut     grid_out;
+  std::string       filename = "file" + Utilities::int_to_string(dim);
+  GridOut           grid_out;
+  GridOutFlags::Vtu vtu_flags;
+  vtu_flags.compression_level = DataOutBase::CompressionLevel::best_compression;
+  grid_out.set_flags(vtu_flags);
   grid_out.write_mesh_per_processor_as_vtu(tr, filename, true);
 
   cat_file((std::string(filename) + ".vtu").c_str());

--- a/tests/hp/solution_transfer_03.cc
+++ b/tests/hp/solution_transfer_03.cc
@@ -78,12 +78,16 @@ main()
   Vector<double> solution(dof_handler.n_dofs());
   solution = 1.0;
 
+  // Define compression level for output data
+  DataOutBase::VtkFlags vtk_flags;
+  vtk_flags.compression_level = DataOutBase::CompressionLevel::best_compression;
 
   // Save output
   DataOut<2> data_out;
   data_out.attach_dof_handler(dof_handler);
   data_out.add_data_vector(solution, "Solution");
   data_out.build_patches();
+  data_out.set_flags(vtk_flags);
   data_out.write_vtu(deallog.get_file_stream());
 
 
@@ -109,5 +113,6 @@ main()
   data_out2.attach_dof_handler(dof_handler);
   data_out2.add_data_vector(new_solution, "Solution");
   data_out2.build_patches();
+  data_out2.set_flags(vtk_flags);
   data_out2.write_vtu(deallog.get_file_stream());
 }

--- a/tests/hp/solution_transfer_05.cc
+++ b/tests/hp/solution_transfer_05.cc
@@ -88,12 +88,17 @@ main()
   Vector<double> new_solution(dof_handler.n_dofs());
   solultion_trans.interpolate(solution, new_solution);
 
+  // Define compression level for output data
+  DataOutBase::VtkFlags vtk_flags;
+  vtk_flags.compression_level = DataOutBase::CompressionLevel::best_compression;
+
   // a follow-up error to the one fixed with _04 was that DataOut also got
   // itself confused
   DataOut<2> data_out2;
   data_out2.attach_dof_handler(dof_handler);
   data_out2.add_data_vector(new_solution, "Solution");
   data_out2.build_patches();
+  data_out2.set_flags(vtk_flags);
   data_out2.write_vtu(deallog.get_file_stream());
 
   // we are good if we made it to here

--- a/tests/mpi/codim_01.cc
+++ b/tests/mpi/codim_01.cc
@@ -89,12 +89,16 @@ test(std::ostream & /*out*/)
   dh.distribute_dofs(fe);
   deallog << "dofs " << dh.n_dofs() << std::endl;
 
+  DataOutBase::VtkFlags vtk_flags;
+  vtk_flags.compression_level = DataOutBase::CompressionLevel::best_compression;
+
   DataOut<dim, spacedim> data_out;
   data_out.attach_triangulation(tr);
   Vector<float> subdomain(tr.n_active_cells());
   for (unsigned int i = 0; i < subdomain.size(); ++i)
     subdomain(i) = tr.locally_owned_subdomain();
   data_out.add_data_vector(subdomain, "subdomain");
+  data_out.set_flags(vtk_flags);
 
   std::string name = "f0.vtu";
   name[1] += tr.locally_owned_subdomain();

--- a/tests/mpi/parallel_vtu_01.cc
+++ b/tests/mpi/parallel_vtu_01.cc
@@ -64,10 +64,14 @@ test()
   x.reinit(dofh.locally_owned_dofs(), MPI_COMM_WORLD);
   x = 2.0;
 
+  DataOutBase::VtkFlags vtk_flags;
+  vtk_flags.compression_level = DataOutBase::CompressionLevel::best_compression;
+
   DataOut<dim> data_out;
   data_out.attach_dof_handler(dofh);
   data_out.add_data_vector(x, "x");
   data_out.build_patches();
+  data_out.set_flags(vtk_flags);
 
   data_out.write_vtu_in_parallel("output.vtu", MPI_COMM_WORLD);
   MPI_Barrier(MPI_COMM_WORLD);

--- a/tests/simplex/data_out_write_vtu_01.cc
+++ b/tests/simplex/data_out_write_vtu_01.cc
@@ -73,12 +73,16 @@ test(const FiniteElement<dim, spacedim> &fe, const unsigned int n_components)
                            RightHandSideFunction<dim>(n_components),
                            solution);
 
+  DataOutBase::VtkFlags vtk_flags;
+  vtk_flags.compression_level = DataOutBase::CompressionLevel::best_compression;
+
   for (unsigned int n_subdivisions = 1; n_subdivisions <= 2; ++n_subdivisions)
     {
       DataOut<dim> data_out;
 
       data_out.attach_dof_handler(dof_handler);
       data_out.add_data_vector(solution, "solution");
+      data_out.set_flags(vtk_flags);
 
 
       data_out.build_patches(mapping, n_subdivisions);

--- a/tests/simplex/write_mesh_per_processor_as_vtu_01.cc
+++ b/tests/simplex/write_mesh_per_processor_as_vtu_01.cc
@@ -42,7 +42,10 @@ output(const Triangulation<dim> &tr,
        const bool                view_levels,
        const bool                include_artificial)
 {
-  GridOut out;
+  GridOut           out;
+  GridOutFlags::Vtu vtu_flags;
+  vtu_flags.compression_level = DataOutBase::CompressionLevel::best_compression;
+  out.set_flags(vtu_flags);
   out.write_mesh_per_processor_as_vtu(tr,
                                       filename,
                                       view_levels,


### PR DESCRIPTION
As discussed in #14958 (see e.g. [here for on overview of output performance based on the compression_level](https://github.com/dealii/dealii/pull/14958#issuecomment-1483009631) or [here for the suggestion that probably best_speed should also be set as default for the vtu output](https://github.com/dealii/dealii/pull/14958#pullrequestreview-1359280216)) I'm proposing to change the default compression_level for the vtu output from `best_compression` to `best_speed`.

Tagging @tjhei and @drwells as you might be interested.