### PR TITLE
CMake: prefer CMAKE_CXX_STANDARD and export cxx_std_?? COMPILE_FEATURES target property

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -99,6 +99,16 @@ foreach(build ${DEAL_II_BUILD_TYPES})
   #
   populate_target_properties(${DEAL_II_NAMESPACE}_${build_lowercase} ${build})
 
+  #
+  # Record the expected C++ standard as a compile feature. This target
+  # property ensures that support for our expected C++ standard is always
+  # enabled in client user code irrespective of what compile flags/options
+  # they have set.
+  #
+  target_compile_features(${DEAL_II_NAMESPACE}_${build_lowercase}
+    INTERFACE cxx_std_${CMAKE_CXX_STANDARD}
+    )
+
   if(BUILD_SHARED_LIBS)
     #
     # Add all object targets as private link targets
@@ -107,7 +117,7 @@ foreach(build ${DEAL_II_BUILD_TYPES})
     target_link_libraries(${DEAL_II_NAMESPACE}_${build_lowercase}
       PRIVATE ${_object_targets}
       )
-    endif()
+  endif()
 
   set_target_properties(${DEAL_II_NAMESPACE}_${build_lowercase}
     PROPERTIES


### PR DESCRIPTION
In reference to https://github.com/dealii/dealii/pull/14491, https://github.com/dealii/dealii/issues/12374

Alright, I think I figured this one out: With this change in place we support setting the language standard with the `CMAKE_CXX_STANDARD` CMake variable. Besides being the recommended this has a couple of advantages...

... most importantly we now export the required C++ standard as a `COMPILE_FEATURES` target property! This ensures that user code that links against our library will automatically have at least our required level of C++ standard enabled - irrespective of what compile options/flags the user project configures.