### PR TITLE
CMake: Rename DEAL_II_NAMESPACE to DEAL_II_TARGET_NAME

### DIFF
--- a/cmake/config/CMakeLists.txt
+++ b/cmake/config/CMakeLists.txt
@@ -81,7 +81,7 @@ foreach(_build ${DEAL_II_BUILD_TYPES})
     endif()
   endif()
 
-  set(CONFIG_TARGET_${_build} ${DEAL_II_NAMESPACE}::${DEAL_II_NAMESPACE}_${_build_lowercase})
+  set(CONFIG_TARGET_${_build} ${DEAL_II_TARGET_NAME}::${DEAL_II_TARGET_NAME}_${_build_lowercase})
   list(APPEND CONFIG_TARGET ${_keyword} \${DEAL_II_TARGET_${_build}})
 endforeach()
 

--- a/cmake/macros/macro_define_interface_target.cmake
+++ b/cmake/macros/macro_define_interface_target.cmake
@@ -130,7 +130,7 @@ function(define_interface_target _feature)
     endif()
 
     export(TARGETS ${_interface_target}
-      NAMESPACE "${DEAL_II_NAMESPACE}::"
+      NAMESPACE "${DEAL_II_TARGET_NAME}::"
       FILE ${CMAKE_BINARY_DIR}/${DEAL_II_PROJECT_CONFIG_RELDIR}/${DEAL_II_PROJECT_CONFIG_NAME}Targets.cmake
       APPEND
       )

--- a/cmake/macros/macro_insource_setup_target.cmake
+++ b/cmake/macros/macro_insource_setup_target.cmake
@@ -55,5 +55,5 @@ function(insource_setup_target _target _build)
       ${DEAL_II_INCLUDE_DIRS}
     )
 
-  target_link_libraries(${_target} ${DEAL_II_NAMESPACE}_${_build_lowercase})
+  target_link_libraries(${_target} ${DEAL_II_TARGET_NAME}_${_build_lowercase})
 endfunction()

--- a/cmake/macros/macro_populate_target_properties.cmake
+++ b/cmake/macros/macro_populate_target_properties.cmake
@@ -37,15 +37,15 @@
 
 function(populate_target_properties _target _build)
 
-  if(NOT "${_target}" MATCHES "^(object|bundled|${DEAL_II_NAMESPACE})_")
+  if(NOT "${_target}" MATCHES "^(object|bundled|${DEAL_II_TARGET_NAME})_")
     message(FATAL_ERROR
       "Internal error: The specified target name must begin with object_, "
-      "bundled_, or ${DEAL_II_NAMESPACE}_. Encountered: ${_target}"
+      "bundled_, or ${DEAL_II_TARGET_NAME}_. Encountered: ${_target}"
       )
   endif()
 
   set(_visibility PRIVATE)
-  if("${_target}" MATCHES "^${DEAL_II_NAMESPACE}")
+  if("${_target}" MATCHES "^${DEAL_II_TARGET_NAME}")
     set(_visibility PUBLIC)
   endif()
 

--- a/cmake/setup_deal_ii.cmake
+++ b/cmake/setup_deal_ii.cmake
@@ -37,7 +37,7 @@
 #
 # Information about paths, install locations and names:
 
-#     DEAL_II_NAMESPACE               *)
+#     DEAL_II_TARGET_NAME             *)
 #
 #     DEAL_II_PROJECT_CONFIG_NAME     *)
 #     DEAL_II_BASE_NAME               *)
@@ -70,7 +70,7 @@
 set_if_empty(DEAL_II_PACKAGE_NAME "deal.II")
 
 set_if_empty(DEAL_II_PACKAGE_VENDOR
-  "The deal.II Authors <http://www.dealii.org/>"
+  "The deal.II Authors <https://www.dealii.org/>"
   )
 set_if_empty(DEAL_II_PACKAGE_DESCRIPTION
   "Library for solving partial differential equations with the finite element method"
@@ -102,9 +102,9 @@ set(DEAL_II_VERSION ${DEAL_II_VERSION_MAJOR}.${DEAL_II_VERSION_MINOR}.${DEAL_II_
 #                                                                      #
 ########################################################################
 
-string(REPLACE "." "" _namespace "${DEAL_II_PACKAGE_NAME}")
-string(TOLOWER "${_namespace}" _namespace)
-set_if_empty(DEAL_II_NAMESPACE "${_namespace}")
+string(REPLACE "." "" _name "${DEAL_II_PACKAGE_NAME}")
+string(TOLOWER "${_name}" _name)
+set_if_empty(DEAL_II_TARGET_NAME "${_name}")
 
 set_if_empty(DEAL_II_PROJECT_CONFIG_NAME "${DEAL_II_PACKAGE_NAME}")
 

--- a/cmake/setup_write_config.cmake
+++ b/cmake/setup_write_config.cmake
@@ -133,7 +133,7 @@ _detailed("#  Library targets:\n")
 foreach(_build ${DEAL_II_BUILD_TYPES})
   string(TOLOWER "${_build}" _build_lowercase)
   _detailed("#\n")
-  _print_target(${DEAL_II_NAMESPACE}_${_build_lowercase})
+  _print_target(${DEAL_II_TARGET_NAME}_${_build_lowercase})
 endforeach()
 _detailed("#\n")
 

--- a/contrib/python-bindings/source/CMakeLists.txt
+++ b/contrib/python-bindings/source/CMakeLists.txt
@@ -71,7 +71,7 @@ foreach(_build ${DEAL_II_BUILD_TYPES})
   endif()
 
   target_link_libraries(PyDealII_${_build_lowercase}
-    ${DEAL_II_NAMESPACE}_${_build_lowercase}
+    ${DEAL_II_TARGET_NAME}_${_build_lowercase}
     ${Boost_LIBRARIES}
     ${PYTHON_LIBRARIES}
     )

--- a/doc/developers/cmake-internals.html
+++ b/doc/developers/cmake-internals.html
@@ -96,7 +96,7 @@ list(APPEND CONFIG_LIBRARIES
   ${CONFIG_LIBRARIES_${_build}}
   )
 
-set_target_properties(${DEAL_II_NAMESPACE}_${build_lowercase}
+set_target_properties(${DEAL_II_TARGET_NAME}_${build_lowercase}
   PROPERTIES
   VERSION ${VERSION}
   SOVERSION ${VERSION}

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -90,26 +90,26 @@ foreach(build ${DEAL_II_BUILD_TYPES})
     endforeach()
   endif()
 
-  add_library(${DEAL_II_NAMESPACE}_${build_lowercase} dummy.cc ${_object_files})
-  add_dependencies(library ${DEAL_II_NAMESPACE}_${build_lowercase})
+  add_library(${DEAL_II_TARGET_NAME}_${build_lowercase} dummy.cc ${_object_files})
+  add_dependencies(library ${DEAL_II_TARGET_NAME}_${build_lowercase})
 
   #
   # Add compile flags, definitions and (public) feature (recorded in
   # DEAL_II_TARGETS(|_DEBUG|_RELEASE)).
   #
-  populate_target_properties(${DEAL_II_NAMESPACE}_${build_lowercase} ${build})
+  populate_target_properties(${DEAL_II_TARGET_NAME}_${build_lowercase} ${build})
 
   if(BUILD_SHARED_LIBS)
     #
     # Add all object targets as private link targets
     #
     get_property(_object_targets GLOBAL PROPERTY DEAL_II_OBJECT_TARGETS_${build})
-    target_link_libraries(${DEAL_II_NAMESPACE}_${build_lowercase}
+    target_link_libraries(${DEAL_II_TARGET_NAME}_${build_lowercase}
       PRIVATE ${_object_targets}
       )
     endif()
 
-  set_target_properties(${DEAL_II_NAMESPACE}_${build_lowercase}
+  set_target_properties(${DEAL_II_TARGET_NAME}_${build_lowercase}
     PROPERTIES
     LINKER_LANGUAGE "CXX"
     VERSION "${DEAL_II_PACKAGE_VERSION}"
@@ -128,7 +128,7 @@ foreach(build ${DEAL_II_BUILD_TYPES})
     )
 
   if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
-    set_target_properties(${DEAL_II_NAMESPACE}_${build_lowercase}
+    set_target_properties(${DEAL_II_TARGET_NAME}_${build_lowercase}
       PROPERTIES
       MACOSX_RPATH OFF
       BUILD_WITH_INSTALL_RPATH OFF
@@ -145,7 +145,7 @@ foreach(build ${DEAL_II_BUILD_TYPES})
   # lib locations for _DEBUG (no support for dynamic linking, _RELEASE will be
   # ignored), but we do it anyhow.
   if (DEAL_II_MSVC)
-    set_target_properties(${DEAL_II_NAMESPACE}_${build_lowercase}
+    set_target_properties(${DEAL_II_TARGET_NAME}_${build_lowercase}
       PROPERTIES
       ARCHIVE_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/${DEAL_II_LIBRARY_RELDIR}"
       LIBRARY_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/${DEAL_II_LIBRARY_RELDIR}"
@@ -157,13 +157,13 @@ foreach(build ${DEAL_II_BUILD_TYPES})
   endif()
 
   file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/${DEAL_II_PROJECT_CONFIG_RELDIR})
-  export(TARGETS ${DEAL_II_NAMESPACE}_${build_lowercase}
-    NAMESPACE "${DEAL_II_NAMESPACE}::"
+  export(TARGETS ${DEAL_II_TARGET_NAME}_${build_lowercase}
+    NAMESPACE "${DEAL_II_TARGET_NAME}::"
     FILE ${CMAKE_BINARY_DIR}/${DEAL_II_PROJECT_CONFIG_RELDIR}/${DEAL_II_PROJECT_CONFIG_NAME}Targets.cmake
     APPEND
     )
 
-  install(TARGETS ${DEAL_II_NAMESPACE}_${build_lowercase}
+  install(TARGETS ${DEAL_II_TARGET_NAME}_${build_lowercase}
     COMPONENT library
     EXPORT ${DEAL_II_PROJECT_CONFIG_NAME}Targets
     RUNTIME DESTINATION ${DEAL_II_EXECUTABLE_RELDIR}
@@ -173,7 +173,7 @@ foreach(build ${DEAL_II_BUILD_TYPES})
 endforeach()
 
 install(EXPORT ${DEAL_II_PROJECT_CONFIG_NAME}Targets
-  NAMESPACE "${DEAL_II_NAMESPACE}::"
+  NAMESPACE "${DEAL_II_TARGET_NAME}::"
   DESTINATION ${DEAL_II_PROJECT_CONFIG_RELDIR}
   COMPONENT library
   )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -169,7 +169,7 @@ if(DEFINED DEAL_II_HAVE_TESTS_DIRECTORY)
   add_dependencies(test setup_tests_quick_tests)
   foreach(_build ${DEAL_II_BUILD_TYPES})
     string(TOLOWER ${_build} _build_lowercase)
-    add_dependencies(test ${DEAL_II_NAMESPACE}_${_build_lowercase})
+    add_dependencies(test ${DEAL_II_TARGET_NAME}_${_build_lowercase})
   endforeach()
 
   #


### PR DESCRIPTION
Rename a poorly worded CMake variable.

In reference to #14491