### PR TITLE
Use Kokkos for data structures in CUDA matrix-free framework

### DIFF
--- a/doc/news/changes/incompatibilities/20230330Turcksin
+++ b/doc/news/changes/incompatibilities/20230330Turcksin
@@ -1,0 +1,4 @@
+Removed: The CUDAWrappers::MatrixFee::AdditionalData::ParallelizationScheme
+parameter has been removed.
+<br>
+(Bruno Turcksin, 2023/03/30)

--- a/include/deal.II/base/cuda_size.h
+++ b/include/deal.II/base/cuda_size.h
@@ -38,19 +38,6 @@ namespace CUDAWrappers
    * Define the number of threads in a warp.
    */
   constexpr int warp_size = 32;
-
-  /**
-   * Define the largest finite element degree that can be solved using
-   * CUDAWrappers::MatrixFree. Changing this number will affect the amount of
-   * constant memory being used.
-   */
-  constexpr unsigned int mf_max_elem_degree = 10;
-
-  /**
-   * Define the maximum number of valid CUDAWrappers::MatrixFree object.
-   * Changing this number will affect the amount of constant memory being used.
-   */
-  constexpr unsigned int mf_n_concurrent_objects = 5;
 } // namespace CUDAWrappers
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/base/geometry_info.h
+++ b/include/deal.II/base/geometry_info.h
@@ -819,7 +819,7 @@ public:
    * mapping from the symbolic flags defined in the RefinementPossibilities
    * base class to actual numerical values (the array indices).
    */
-  operator std::uint8_t() const;
+  DEAL_II_HOST_DEVICE operator std::uint8_t() const;
 
   /**
    * Return the union of the refinement flags represented by the current
@@ -2814,7 +2814,7 @@ inline RefinementCase<dim>::RefinementCase(const std::uint8_t refinement_case)
 
 
 template <int dim>
-inline RefinementCase<dim>::operator std::uint8_t() const
+inline DEAL_II_HOST_DEVICE RefinementCase<dim>::operator std::uint8_t() const
 {
   return value;
 }

--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -724,7 +724,7 @@ namespace internal
 
     // Type T is explicitly convertible (but not constructible) from F.
     template <typename F>
-    static constexpr DEAL_II_ALWAYS_INLINE T
+    static constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE T
     value(const F &f,
           std::enable_if_t<!std::is_same<typename std::decay<T>::type,
                                          typename std::decay<F>::type>::value &&

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -956,14 +956,15 @@ namespace internal
   template <int rank, int dim, typename T>
   struct NumberType<Tensor<rank, dim, T>>
   {
-    static constexpr DEAL_II_ALWAYS_INLINE const Tensor<rank, dim, T> &
-    value(const Tensor<rank, dim, T> &t)
+    static constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE const
+      Tensor<rank, dim, T> &
+      value(const Tensor<rank, dim, T> &t)
     {
       return t;
     }
 
-    static constexpr DEAL_II_ALWAYS_INLINE Tensor<rank, dim, T>
-                                           value(const T &t)
+    static constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE Tensor<rank, dim, T>
+                                                       value(const T &t)
     {
       Tensor<rank, dim, T> tmp;
       tmp = t;

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -443,22 +443,22 @@ namespace Utilities
    * be an integer type and the exponent @p iexp must not be negative.
    */
   template <typename T>
-  constexpr T
+  constexpr DEAL_II_HOST_DEVICE T
   pow(const T base, const int iexp)
   {
 #if defined(DEBUG) && !defined(DEAL_II_CXX14_CONSTEXPR_BUG)
     // Up to __builtin_expect this is the same code as in the 'Assert' macro.
     // The call to __builtin_expect turns out to be problematic.
-    if (!(iexp >= 0))
-      ::dealii::deal_II_exceptions::internals::issue_error_noreturn(
-        ::dealii::deal_II_exceptions::internals::ExceptionHandling::
-          abort_or_throw_on_exception,
-        __FILE__,
-        __LINE__,
-        __PRETTY_FUNCTION__,
-        "iexp>=0",
-        "ExcMessage(\"The exponent must not be negative!\")",
-        ExcMessage("The exponent must not be negative!"));
+    KOKKOS_IF_ON_HOST(if (!(iexp >= 0))::dealii::deal_II_exceptions::internals::
+                        issue_error_noreturn(
+                          ::dealii::deal_II_exceptions::internals::
+                            ExceptionHandling::abort_or_throw_on_exception,
+                          __FILE__,
+                          __LINE__,
+                          __PRETTY_FUNCTION__,
+                          "iexp>=0",
+                          "ExcMessage(\"The exponent must not be negative!\")",
+                          ExcMessage("The exponent must not be negative!"));)
 #endif
     // The "exponentiation by squaring" algorithm used below has to be
     // compressed to one statement due to C++11's restrictions on constexpr

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -449,16 +449,16 @@ namespace Utilities
 #if defined(DEBUG) && !defined(DEAL_II_CXX14_CONSTEXPR_BUG)
     // Up to __builtin_expect this is the same code as in the 'Assert' macro.
     // The call to __builtin_expect turns out to be problematic.
-    KOKKOS_IF_ON_HOST(if (!(iexp >= 0))::dealii::deal_II_exceptions::internals::
-                        issue_error_noreturn(
-                          ::dealii::deal_II_exceptions::internals::
-                            ExceptionHandling::abort_or_throw_on_exception,
-                          __FILE__,
-                          __LINE__,
-                          __PRETTY_FUNCTION__,
-                          "iexp>=0",
-                          "ExcMessage(\"The exponent must not be negative!\")",
-                          ExcMessage("The exponent must not be negative!"));)
+    KOKKOS_IF_ON_HOST((if (!(iexp >= 0))::dealii::deal_II_exceptions::
+                         internals::issue_error_noreturn(
+                           ::dealii::deal_II_exceptions::internals::
+                             ExceptionHandling::abort_or_throw_on_exception,
+                           __FILE__,
+                           __LINE__,
+                           __PRETTY_FUNCTION__,
+                           "iexp>=0",
+                           "ExcMessage(\"The exponent must not be negative!\")",
+                           ExcMessage("The exponent must not be negative!"));))
 #endif
     // The "exponentiation by squaring" algorithm used below has to be
     // compressed to one statement due to C++11's restrictions on constexpr

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -449,16 +449,33 @@ namespace Utilities
 #if defined(DEBUG) && !defined(DEAL_II_CXX14_CONSTEXPR_BUG)
     // Up to __builtin_expect this is the same code as in the 'Assert' macro.
     // The call to __builtin_expect turns out to be problematic.
-    KOKKOS_IF_ON_HOST((if (!(iexp >= 0))::dealii::deal_II_exceptions::
-                         internals::issue_error_noreturn(
-                           ::dealii::deal_II_exceptions::internals::
-                             ExceptionHandling::abort_or_throw_on_exception,
-                           __FILE__,
-                           __LINE__,
-                           __PRETTY_FUNCTION__,
-                           "iexp>=0",
-                           "ExcMessage(\"The exponent must not be negative!\")",
-                           ExcMessage("The exponent must not be negative!"));))
+#  if KOKKOS_VERSION >= 30600
+    KOKKOS_IF_ON_HOST(({
+      if (!(iexp >= 0))
+        ::dealii::deal_II_exceptions::internals::issue_error_noreturn(
+          ::dealii::deal_II_exceptions::internals::ExceptionHandling::
+            abort_or_throw_on_exception,
+          __FILE__,
+          __LINE__,
+          __PRETTY_FUNCTION__,
+          "iexp>=0",
+          "ExcMessage(\"The exponent must not be negative!\")",
+          ExcMessage("The exponent must not be negative!"));
+    }))
+#  else
+#    ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
+    if (!(iexp >= 0))
+      ::dealii::deal_II_exceptions::internals::issue_error_noreturn(
+        ::dealii::deal_II_exceptions::internals::ExceptionHandling::
+          abort_or_throw_on_exception,
+        __FILE__,
+        __LINE__,
+        __PRETTY_FUNCTION__,
+        "iexp>=0",
+        "ExcMessage(\"The exponent must not be negative!\")",
+        ExcMessage("The exponent must not be negative!"));
+#    endif
+#  endif
 #endif
     // The "exponentiation by squaring" algorithm used below has to be
     // compressed to one statement due to C++11's restrictions on constexpr

--- a/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
+++ b/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
@@ -61,8 +61,10 @@ namespace CUDAWrappers
       Kokkos::View<Number *, MemorySpace::Default::kokkos_space>
         constraint_weights,
       const dealii::internal::MatrixFreeFunctions::ConstraintKinds
-              constraint_mask,
-      Number *values)
+        constraint_mask,
+      Kokkos::Subview<
+        Kokkos::View<Number *, MemorySpace::Default::kokkos_space>,
+        Kokkos::pair<int, int>> values)
     {
       const unsigned int x_idx = threadIdx.x % (fe_degree + 1);
       const unsigned int y_idx = threadIdx.y;
@@ -169,8 +171,10 @@ namespace CUDAWrappers
       Kokkos::View<Number *, MemorySpace::Default::kokkos_space>
         constraint_weights,
       const dealii::internal::MatrixFreeFunctions::ConstraintKinds
-              constraint_mask,
-      Number *values)
+        constraint_mask,
+      Kokkos::Subview<
+        Kokkos::View<Number *, MemorySpace::Default::kokkos_space>,
+        Kokkos::pair<int, int>> values)
     {
       const unsigned int x_idx = threadIdx.x % (fe_degree + 1);
       const unsigned int y_idx = threadIdx.y;
@@ -320,8 +324,10 @@ namespace CUDAWrappers
       Kokkos::View<Number *, MemorySpace::Default::kokkos_space>
         constraint_weights,
       const dealii::internal::MatrixFreeFunctions::ConstraintKinds
-              constraint_mask,
-      Number *values)
+        constraint_mask,
+      Kokkos::Subview<
+        Kokkos::View<Number *, MemorySpace::Default::kokkos_space>,
+        Kokkos::pair<int, int>> values)
     {
       if (dim == 2)
         {

--- a/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
+++ b/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
@@ -31,10 +31,6 @@ namespace CUDAWrappers
 {
   namespace internal
   {
-    __constant__ double
-      constraint_weights[(CUDAWrappers::mf_max_elem_degree + 1) *
-                         (CUDAWrappers::mf_max_elem_degree + 1)];
-
     //------------------------------------------------------------------------//
     // Functions for resolving the hanging node constraints on the GPU        //
     //------------------------------------------------------------------------//
@@ -62,6 +58,8 @@ namespace CUDAWrappers
               typename Number>
     DEAL_II_HOST_DEVICE inline void
     interpolate_boundary_2d(
+      Kokkos::View<Number *, MemorySpace::Default::kokkos_space>
+        constraint_weights,
       const dealii::internal::MatrixFreeFunctions::ConstraintKinds
               constraint_mask,
       Number *values)
@@ -168,6 +166,8 @@ namespace CUDAWrappers
               typename Number>
     DEAL_II_HOST_DEVICE inline void
     interpolate_boundary_3d(
+      Kokkos::View<Number *, MemorySpace::Default::kokkos_space>
+        constraint_weights,
       const dealii::internal::MatrixFreeFunctions::ConstraintKinds
               constraint_mask,
       Number *values)
@@ -317,28 +317,35 @@ namespace CUDAWrappers
     template <int dim, int fe_degree, bool transpose, typename Number>
     DEAL_II_HOST_DEVICE void
     resolve_hanging_nodes(
+      Kokkos::View<Number *, MemorySpace::Default::kokkos_space>
+        constraint_weights,
       const dealii::internal::MatrixFreeFunctions::ConstraintKinds
               constraint_mask,
       Number *values)
     {
       if (dim == 2)
         {
-          interpolate_boundary_2d<fe_degree, 0, transpose>(constraint_mask,
+          interpolate_boundary_2d<fe_degree, 0, transpose>(constraint_weights,
+                                                           constraint_mask,
                                                            values);
 
-          interpolate_boundary_2d<fe_degree, 1, transpose>(constraint_mask,
+          interpolate_boundary_2d<fe_degree, 1, transpose>(constraint_weights,
+                                                           constraint_mask,
                                                            values);
         }
       else if (dim == 3)
         {
           // Interpolate y and z faces (x-direction)
-          interpolate_boundary_3d<fe_degree, 0, transpose>(constraint_mask,
+          interpolate_boundary_3d<fe_degree, 0, transpose>(constraint_weights,
+                                                           constraint_mask,
                                                            values);
           // Interpolate x and z faces (y-direction)
-          interpolate_boundary_3d<fe_degree, 1, transpose>(constraint_mask,
+          interpolate_boundary_3d<fe_degree, 1, transpose>(constraint_weights,
+                                                           constraint_mask,
                                                            values);
           // Interpolate x and y faces (z-direction)
-          interpolate_boundary_3d<fe_degree, 2, transpose>(constraint_mask,
+          interpolate_boundary_3d<fe_degree, 2, transpose>(constraint_weights,
+                                                           constraint_mask,
                                                            values);
         }
     }

--- a/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
+++ b/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
@@ -24,6 +24,8 @@
 
 #  include <deal.II/matrix_free/hanging_nodes_internal.h>
 
+#  include <Kokkos_Macros.hpp>
+
 DEAL_II_NAMESPACE_OPEN
 namespace CUDAWrappers
 {
@@ -37,7 +39,7 @@ namespace CUDAWrappers
     // Functions for resolving the hanging node constraints on the GPU        //
     //------------------------------------------------------------------------//
     template <unsigned int size>
-    __device__ inline unsigned int
+    DEAL_II_HOST_DEVICE inline unsigned int
     index2(unsigned int i, unsigned int j)
     {
       return i + size * j;
@@ -46,7 +48,7 @@ namespace CUDAWrappers
 
 
     template <unsigned int size>
-    __device__ inline unsigned int
+    DEAL_II_HOST_DEVICE inline unsigned int
     index3(unsigned int i, unsigned int j, unsigned int k)
     {
       return i + size * j + size * size * k;
@@ -58,7 +60,7 @@ namespace CUDAWrappers
               unsigned int direction,
               bool         transpose,
               typename Number>
-    __device__ inline void
+    DEAL_II_HOST_DEVICE inline void
     interpolate_boundary_2d(
       const dealii::internal::MatrixFreeFunctions::ConstraintKinds
               constraint_mask,
@@ -151,11 +153,11 @@ namespace CUDAWrappers
 
       // The synchronization is done for all the threads in one block with
       // each block being assigned to one element.
-      __syncthreads();
+      KOKKOS_IF_ON_DEVICE(__syncthreads();)
       if (constrained_face && constrained_dof)
         values[index2<fe_degree + 1>(x_idx, y_idx)] = t;
 
-      __syncthreads();
+      KOKKOS_IF_ON_DEVICE(__syncthreads();)
     }
 
 
@@ -164,7 +166,7 @@ namespace CUDAWrappers
               unsigned int direction,
               bool         transpose,
               typename Number>
-    __device__ inline void
+    DEAL_II_HOST_DEVICE inline void
     interpolate_boundary_3d(
       const dealii::internal::MatrixFreeFunctions::ConstraintKinds
               constraint_mask,
@@ -293,14 +295,14 @@ namespace CUDAWrappers
 
       // The synchronization is done for all the threads in one block with
       // each block being assigned to one element.
-      __syncthreads();
+      KOKKOS_IF_ON_DEVICE(__syncthreads();)
 
       if ((constrained_face != dealii::internal::MatrixFreeFunctions::
                                  ConstraintKinds::unconstrained) &&
           constrained_dof)
         values[index3<fe_degree + 1>(x_idx, y_idx, z_idx)] = t;
 
-      __syncthreads();
+      KOKKOS_IF_ON_DEVICE(__syncthreads();)
     }
 
 
@@ -313,7 +315,7 @@ namespace CUDAWrappers
      * @cite kronbichler2019multigrid.
      */
     template <int dim, int fe_degree, bool transpose, typename Number>
-    __device__ void
+    DEAL_II_HOST_DEVICE void
     resolve_hanging_nodes(
       const dealii::internal::MatrixFreeFunctions::ConstraintKinds
               constraint_mask,

--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -104,17 +104,6 @@ namespace CUDAWrappers
       FilteredIterator<typename DoFHandler<dim>::active_cell_iterator>;
 
     /**
-     * Parallelization scheme used: parallel_in_elem (parallelism at the level
-     * of degrees of freedom) or parallel_over_elem (parallelism at the level of
-     * cells)
-     */
-    enum ParallelizationScheme
-    {
-      parallel_in_elem,
-      parallel_over_elem
-    };
-
-    /**
      * Standardized data struct to pipe additional data to MatrixFree.
      */
     struct AdditionalData

--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -221,7 +221,9 @@ namespace CUDAWrappers
       /**
        * Mask deciding where constraints are set on a given cell.
        */
-      dealii::internal::MatrixFreeFunctions::ConstraintKinds *constraint_mask;
+      Kokkos::View<dealii::internal::MatrixFreeFunctions::ConstraintKinds *,
+                   MemorySpace::Default::kokkos_space>
+        constraint_mask;
 
       /**
        * If true, use graph coloring has been used and we can simply add into
@@ -544,7 +546,9 @@ namespace CUDAWrappers
     /**
      * Mask deciding where constraints are set on a given cell.
      */
-    std::vector<dealii::internal::MatrixFreeFunctions::ConstraintKinds *>
+    std::vector<
+      Kokkos::View<dealii::internal::MatrixFreeFunctions::ConstraintKinds *,
+                   MemorySpace::Default::kokkos_space>>
       constraint_mask;
 
     /**
@@ -782,8 +786,9 @@ namespace CUDAWrappers
     /**
      * Mask deciding where constraints are set on a given cell.
      */
-    std::vector<dealii::internal::MatrixFreeFunctions::ConstraintKinds>
-      constraint_mask;
+    typename Kokkos::View<
+      dealii::internal::MatrixFreeFunctions::ConstraintKinds *,
+      MemorySpace::Default::kokkos_space>::HostMirror constraint_mask;
 
     /**
      * If true, use graph coloring has been used and we can simply add into
@@ -837,9 +842,8 @@ namespace CUDAWrappers
         Kokkos::deep_copy(data_host.JxW, data.JxW);
       }
 
-    data_host.constraint_mask.resize(data_host.n_cells);
-    Utilities::CUDA::copy_to_host(data.constraint_mask,
-                                  data_host.constraint_mask);
+    data_host.constraint_mask = Kokkos::create_mirror(data.constraint_mask);
+    Kokkos::deep_copy(data_host.constraint_mask, data.constraint_mask);
 
     return data_host;
   }

--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -454,35 +454,6 @@ namespace CUDAWrappers
       LinearAlgebra::CUDAWrappers::Vector<Number> &      dst) const;
 
     /**
-     * Helper function. Copy the values of the constrained entries of @p src to
-     * @p dst. This function is used when MPI is not used.
-     */
-    template <typename VectorType>
-    void
-    serial_copy_constrained_values(const VectorType &src,
-                                   VectorType &      dst) const;
-
-    /**
-     * Helper function. Copy the values of the constrained entries of @p src to
-     * @p dst. This function is used when MPI is used.
-     */
-    void
-    distributed_copy_constrained_values(
-      const LinearAlgebra::distributed::Vector<Number, MemorySpace::CUDA> &src,
-      LinearAlgebra::distributed::Vector<Number, MemorySpace::CUDA> &dst) const;
-
-    /**
-     * This function should never be called. Calling it results in an internal
-     * error. This function exists only because copy_constrained_values needs
-     * distributed_copy_constrained_values() to exist for
-     * LinearAlgebra::CUDAWrappers::Vector.
-     */
-    void
-    distributed_copy_constrained_values(
-      const LinearAlgebra::CUDAWrappers::Vector<Number> &src,
-      LinearAlgebra::CUDAWrappers::Vector<Number> &      dst) const;
-
-    /**
      * Unique ID associated with the object.
      */
     int my_id;

--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -188,9 +188,34 @@ namespace CUDAWrappers
       Kokkos::View<Number **, MemorySpace::Default::kokkos_space> JxW;
 
       /**
-       * ID of the associated MatrixFree object.
+       * Mask deciding where constraints are set on a given cell.
        */
-      unsigned int id;
+      Kokkos::View<dealii::internal::MatrixFreeFunctions::ConstraintKinds *,
+                   MemorySpace::Default::kokkos_space>
+        constraint_mask;
+
+      /**
+       * Values of the shape functions.
+       */
+      Kokkos::View<Number *, MemorySpace::Default::kokkos_space> shape_values;
+
+      /**
+       * Gradients of the shape functions.
+       */
+      Kokkos::View<Number *, MemorySpace::Default::kokkos_space>
+        shape_gradients;
+
+      /**
+       * Gradients of the shape functions for collocation methods.
+       */
+      Kokkos::View<Number *, MemorySpace::Default::kokkos_space>
+        co_shape_gradients;
+
+      /**
+       * Weights used when resolving hanginf nodes.
+       */
+      Kokkos::View<Number *, MemorySpace::Default::kokkos_space>
+        constraint_weights;
 
       /**
        * Number of cells.
@@ -208,13 +233,6 @@ namespace CUDAWrappers
       unsigned int row_start;
 
       /**
-       * Mask deciding where constraints are set on a given cell.
-       */
-      Kokkos::View<dealii::internal::MatrixFreeFunctions::ConstraintKinds *,
-                   MemorySpace::Default::kokkos_space>
-        constraint_mask;
-
-      /**
        * If true, use graph coloring has been used and we can simply add into
        * the destingation vector. Otherwise, use atomic operations.
        */
@@ -225,11 +243,6 @@ namespace CUDAWrappers
      * Default constructor.
      */
     MatrixFree();
-
-    /**
-     * Destructor.
-     */
-    ~MatrixFree();
 
     /**
      * Return the length of the padding.
@@ -377,12 +390,6 @@ namespace CUDAWrappers
      */
     const std::shared_ptr<const Utilities::MPI::Partitioner> &
     get_vector_partitioner() const;
-
-    /**
-     * Free all the memory allocated.
-     */
-    void
-    free();
 
     /**
      * Return the DoFHandler.
@@ -539,6 +546,28 @@ namespace CUDAWrappers
       Kokkos::View<dealii::internal::MatrixFreeFunctions::ConstraintKinds *,
                    MemorySpace::Default::kokkos_space>>
       constraint_mask;
+
+    /**
+     * Values of the shape functions.
+     */
+    Kokkos::View<Number *, MemorySpace::Default::kokkos_space> shape_values;
+
+    /**
+     * Gradients of the shape functions.
+     */
+    Kokkos::View<Number *, MemorySpace::Default::kokkos_space> shape_gradients;
+
+    /**
+     * Gradients of the shape functions for collocation methods.
+     */
+    Kokkos::View<Number *, MemorySpace::Default::kokkos_space>
+      co_shape_gradients;
+
+    /**
+     * Weights used when resolving hanginf nodes.
+     */
+    Kokkos::View<Number *, MemorySpace::Default::kokkos_space>
+      constraint_weights;
 
     /**
      * Grid dimensions associated to the different colors. The grid dimensions
@@ -753,11 +782,6 @@ namespace CUDAWrappers
                           MemorySpace::Default::kokkos_space>::HostMirror JxW;
 
     /**
-     * ID of the associated MatrixFree object.
-     */
-    unsigned int id;
-
-    /**
      * Number of cells.
      */
     unsigned int n_cells;
@@ -802,7 +826,6 @@ namespace CUDAWrappers
   {
     DataHost<dim, Number> data_host;
 
-    data_host.id             = data.id;
     data_host.n_cells        = data.n_cells;
     data_host.padding_length = data.padding_length;
     data_host.row_start      = data.row_start;

--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -183,7 +183,9 @@ namespace CUDAWrappers
        * Map the position in the local vector to the position in the global
        * vector.
        */
-      types::global_dof_index *local_to_global;
+      Kokkos::View<types::global_dof_index **,
+                   MemorySpace::Default::kokkos_space>
+        local_to_global;
 
       /**
        * Kokkos::View of the inverse Jacobian.
@@ -514,7 +516,9 @@ namespace CUDAWrappers
      * Map the position in the local vector to the position in the global
      * vector.
      */
-    std::vector<types::global_dof_index *> local_to_global;
+    std::vector<Kokkos::View<types::global_dof_index **,
+                             MemorySpace::Default::kokkos_space>>
+      local_to_global;
 
     /**
      * Vector of Kokkos::View of the inverse Jacobian associated to the cells of
@@ -737,7 +741,9 @@ namespace CUDAWrappers
      * Map the position in the local vector to the position in the global
      * vector.
      */
-    std::vector<types::global_dof_index> local_to_global;
+    typename Kokkos::View<types::global_dof_index **,
+                          MemorySpace::Default::kokkos_space>::HostMirror
+      local_to_global;
 
     /**
      * Kokkos::View of inverse Jacobians on the host.
@@ -815,9 +821,8 @@ namespace CUDAWrappers
         Kokkos::deep_copy(data_host.q_points, data.q_points);
       }
 
-    data_host.local_to_global.resize(n_elements);
-    Utilities::CUDA::copy_to_host(data.local_to_global,
-                                  data_host.local_to_global);
+    data_host.local_to_global = Kokkos::create_mirror(data.local_to_global);
+    Kokkos::deep_copy(data_host.local_to_global, data.local_to_global);
 
     if (update_flags & update_gradients)
       {

--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -630,8 +630,7 @@ namespace CUDAWrappers
 
 
 
-  // TODO find a better place to put these things
-
+  // TODO We should rework this to use scratch memory
   /**
    * Structure to pass the shared memory into a general user function.
    */
@@ -639,27 +638,20 @@ namespace CUDAWrappers
   struct SharedData
   {
     /**
-     * Constructor.
+     * Memory for dof and quad values.
      */
-    DEAL_II_HOST_DEVICE
-    SharedData(Number *vd, Number *gq[dim])
-      : values(vd)
-    {
-      for (unsigned int d = 0; d < dim; ++d)
-        gradients[d] = gq[d];
-    }
+    Kokkos::Subview<Kokkos::View<Number *, MemorySpace::Default::kokkos_space>,
+                    Kokkos::pair<int, int>>
+      values;
 
     /**
-     * Shared memory for dof and quad values.
+     * Memory for computed gradients in reference coordinate system.
      */
-    Number *values;
-
-    /**
-     * Shared memory for computed gradients in reference coordinate system.
-     * The gradient in each direction is saved in a struct-of-array
-     * format, i.e. first, all gradients in the x-direction come...
-     */
-    Number *gradients[dim];
+    Kokkos::Subview<
+      Kokkos::View<Number *[dim], MemorySpace::Default::kokkos_space>,
+      Kokkos::pair<int, int>,
+      Kokkos::pair<int, int>>
+      gradients;
   };
 
 

--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -536,9 +536,10 @@ namespace CUDAWrappers
       JxW;
 
     /**
-     * Pointer to the constrained degrees of freedom.
+     * Kokkos::View to the constrained degrees of freedom.
      */
-    types::global_dof_index *constrained_dofs;
+    Kokkos::View<types::global_dof_index *, MemorySpace::Default::kokkos_space>
+      constrained_dofs;
 
     /**
      * Mask deciding where constraints are set on a given cell.

--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -483,34 +483,6 @@ namespace CUDAWrappers
       LinearAlgebra::CUDAWrappers::Vector<Number> &      dst) const;
 
     /**
-     * Helper function. Set the constrained entries of @p dst to @p val. This
-     * function is used when MPI is not used.
-     */
-    template <typename VectorType>
-    void
-    serial_set_constrained_values(const Number val, VectorType &dst) const;
-
-    /**
-     * Helper function. Set the constrained entries of @p dst to @p val. This
-     * function is used when MPI is used.
-     */
-    void
-    distributed_set_constrained_values(
-      const Number                                                   val,
-      LinearAlgebra::distributed::Vector<Number, MemorySpace::CUDA> &dst) const;
-
-    /**
-     * This function should never be called. Calling it results in an internal
-     * error. This function exists only because set_constrained_values needs
-     * distributed_set_constrained_values() to exist for
-     * LinearAlgebra::CUDAWrappers::Vector.
-     */
-    void
-    distributed_set_constrained_values(
-      const Number                                 val,
-      LinearAlgebra::CUDAWrappers::Vector<Number> &dst) const;
-
-    /**
      * Unique ID associated with the object.
      */
     int my_id;

--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -185,9 +185,10 @@ namespace CUDAWrappers
       types::global_dof_index *local_to_global;
 
       /**
-       * Pointer to the inverse Jacobian.
+       * Kokkos::View of the inverse Jacobian.
        */
-      Number *inv_jacobian;
+      Kokkos::View<Number **[dim][dim], MemorySpace::Default::kokkos_space>
+        inv_jacobian;
 
       /**
        * Kokkos::View of the Jacobian times the weights.
@@ -514,10 +515,12 @@ namespace CUDAWrappers
     std::vector<types::global_dof_index *> local_to_global;
 
     /**
-     * Vector of pointer to the inverse Jacobian associated to the cells of each
-     * color.
+     * Vector of Kokkos::View of the inverse Jacobian associated to the cells of
+     * each color.
      */
-    std::vector<Number *> inv_jacobian;
+    std::vector<
+      Kokkos::View<Number **[dim][dim], MemorySpace::Default::kokkos_space>>
+      inv_jacobian;
 
     /**
      * Vector of Kokkos::View to the Jacobian times the weights associated to
@@ -813,7 +816,7 @@ namespace CUDAWrappers
     if (update_flags & update_gradients)
       {
         data_host.inv_jacobian.resize(n_elements * dim * dim);
-        Utilities::CUDA::copy_to_host(data.inv_jacobian,
+        Utilities::CUDA::copy_to_host(data.inv_jacobian.data(),
                                       data_host.inv_jacobian);
       }
 

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -590,8 +590,9 @@ namespace CUDAWrappers
         // When working with distributed vectors, the constrained dofs are
         // computed for ghosted vectors but we want to copy the values of the
         // constrained dofs of non-ghosted vectors.
-        if (constr_dofs[dof] < size)
-          dst_ptr[constr_dofs[dof]] = src_ptr[constr_dofs[dof]];
+        const auto constrained_dof = constr_dofs[dof];
+        if (constrained_dof < size)
+          dst_ptr[constrained_dof] = src_ptr[constrained_dof];
       });
   }
 
@@ -1019,7 +1020,6 @@ namespace CUDAWrappers
           const unsigned int size =
             (grid_dim[i].x * grid_dim[i].y * grid_dim[i].z) * cells_per_block *
             Functor::n_local_dofs;
-          // std::cout << "color " << i << " " << size << std::endl;
           values_colors[i] =
             Kokkos::View<Number *, MemorySpace::Default::kokkos_space>(
               Kokkos::view_alloc("values_" + std::to_string(i),

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -134,67 +134,6 @@ namespace CUDAWrappers
       return global_co_shape_gradients_f[i];
     }
 
-    template <typename Number>
-    using CUDAVector = ::dealii::LinearAlgebra::CUDAWrappers::Vector<Number>;
-
-    /**
-     * Transpose a N x M matrix stored in a one-dimensional array to a M x N
-     * matrix stored in a one-dimensional array.
-     */
-    template <typename Number>
-    void
-    transpose(const unsigned int N,
-              const unsigned     M,
-              const Number *     src,
-              Number *           dst)
-    {
-      // src is N X M
-      // dst is M X N
-      for (unsigned int i = 0; i < N; ++i)
-        for (unsigned int j = 0; j < M; ++j)
-          dst[j * N + i] = src[i * M + j];
-    }
-
-
-
-    /**
-     * Same as above but the source and the destination are the same vector.
-     */
-    template <typename Number>
-    void
-    transpose_in_place(std::vector<Number> &array_host,
-                       const unsigned int   n,
-                       const unsigned int   m)
-    {
-      // convert to structure-of-array
-      std::vector<Number> old(array_host.size());
-      old.swap(array_host);
-
-      transpose(n, m, old.data(), array_host.data());
-    }
-
-
-
-    /**
-     * Allocate an array on the @ref GlossDevice "device" and copy @p array_host to the @ref GlossDevice "device".
-     */
-    template <typename Number1>
-    void
-    alloc_and_copy(Number1 **array_device,
-                   const ArrayView<const Number1, MemorySpace::Host> array_host,
-                   const unsigned int                                n)
-    {
-      cudaError_t error_code = cudaMalloc(array_device, n * sizeof(Number1));
-      AssertCuda(error_code);
-      AssertDimension(array_host.size(), n);
-
-      error_code = cudaMemcpy(*array_device,
-                              array_host.data(),
-                              n * sizeof(Number1),
-                              cudaMemcpyHostToDevice);
-      AssertCuda(error_code);
-    }
-
 
 
     /**

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -75,56 +75,56 @@ namespace CUDAWrappers
                                                   [data_array_size];
 
     template <typename Number>
-    __host__ __device__ inline DataArray<Number> &
-             get_global_shape_values(unsigned int i);
+    DEAL_II_HOST_DEVICE inline DataArray<Number> &
+    get_global_shape_values(unsigned int i);
 
     template <>
-    __host__ __device__ inline DataArray<double> &
-             get_global_shape_values<double>(unsigned int i)
+    DEAL_II_HOST_DEVICE inline DataArray<double> &
+    get_global_shape_values<double>(unsigned int i)
     {
       return global_shape_values_d[i];
     }
 
     template <>
-    __host__ __device__ inline DataArray<float> &
-             get_global_shape_values<float>(unsigned int i)
+    DEAL_II_HOST_DEVICE inline DataArray<float> &
+    get_global_shape_values<float>(unsigned int i)
     {
       return global_shape_values_f[i];
     }
 
     template <typename Number>
-    __host__ __device__ inline DataArray<Number> &
-             get_global_shape_gradients(unsigned int i);
+    DEAL_II_HOST_DEVICE inline DataArray<Number> &
+    get_global_shape_gradients(unsigned int i);
 
     template <>
-    __host__ __device__ inline DataArray<double> &
-             get_global_shape_gradients<double>(unsigned int i)
+    DEAL_II_HOST_DEVICE inline DataArray<double> &
+    get_global_shape_gradients<double>(unsigned int i)
     {
       return global_shape_gradients_d[i];
     }
 
     template <>
-    __host__ __device__ inline DataArray<float> &
-             get_global_shape_gradients<float>(unsigned int i)
+    DEAL_II_HOST_DEVICE inline DataArray<float> &
+    get_global_shape_gradients<float>(unsigned int i)
     {
       return global_shape_gradients_f[i];
     }
 
     // for collocation methods
     template <typename Number>
-    __host__ __device__ inline DataArray<Number> &
-             get_global_co_shape_gradients(unsigned int i);
+    DEAL_II_HOST_DEVICE inline DataArray<Number> &
+    get_global_co_shape_gradients(unsigned int i);
 
     template <>
-    __host__ __device__ inline DataArray<double> &
-             get_global_co_shape_gradients<double>(unsigned int i)
+    DEAL_II_HOST_DEVICE inline DataArray<double> &
+    get_global_co_shape_gradients<double>(unsigned int i)
     {
       return global_co_shape_gradients_d[i];
     }
 
     template <>
-    __host__ __device__ inline DataArray<float> &
-             get_global_co_shape_gradients<float>(unsigned int i)
+    DEAL_II_HOST_DEVICE inline DataArray<float> &
+    get_global_co_shape_gradients<float>(unsigned int i)
     {
       return global_co_shape_gradients_f[i];
     }

--- a/include/deal.II/matrix_free/cuda_tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/cuda_tensor_product_kernels.h
@@ -71,8 +71,8 @@ namespace CUDAWrappers
                                (dim == 2) ? threadIdx.y :
                                             threadIdx.z;
 
-        // This loop simply multiply the shape function at the quadrature point
-        // by the value finite element coefficient.
+        // This loop simply multiplies the shape function at the quadrature
+        // point by the value finite element coefficient.
         Number t = 0;
         for (int k = 0; k < n_q_points_1d; ++k) {
           const unsigned int shape_idx =

--- a/source/matrix_free/cuda_matrix_free.cc
+++ b/source/matrix_free/cuda_matrix_free.cc
@@ -23,11 +23,6 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace CUDAWrappers
 {
-  namespace internal
-  {
-    std::array<std::atomic_bool, mf_n_concurrent_objects> used_objects;
-  }
-
   // Do not instantiate for dim = 1
   template class MatrixFree<2, float>;
   template class MatrixFree<2, double>;

--- a/tests/cuda/coefficient_eval.cc
+++ b/tests/cuda/coefficient_eval.cc
@@ -35,7 +35,7 @@ class DummyOperator
 public:
   DummyOperator() = default;
 
-  __device__ void
+  DEAL_II_HOST_DEVICE void
   operator()(
     const unsigned int                                          cell,
     const typename CUDAWrappers::MatrixFree<dim, double>::Data *gpu_data,
@@ -53,7 +53,7 @@ public:
 
 
 template <int dim, int fe_degree>
-__device__ void
+DEAL_II_HOST_DEVICE void
 DummyOperator<dim, fe_degree>::operator()(
   const unsigned int                                          cell,
   const typename CUDAWrappers::MatrixFree<dim, double>::Data *gpu_data,

--- a/tests/cuda/coefficient_eval.cc
+++ b/tests/cuda/coefficient_eval.cc
@@ -28,6 +28,8 @@
 
 #include "../tests.h"
 
+#include "Kokkos_Core.hpp"
+
 
 template <int dim, int fe_degree>
 class DummyOperator
@@ -172,11 +174,12 @@ int
 main()
 {
   initlog();
-  init_cuda();
+  Kokkos::initialize();
 
   test<2, 3>();
   test<3, 3>();
 
   deallog << "OK" << std::endl;
+  Kokkos::finalize();
   return 0;
 }

--- a/tests/cuda/cuda_evaluate_2d_shape.cc
+++ b/tests/cuda/cuda_evaluate_2d_shape.cc
@@ -34,7 +34,12 @@ namespace CUDA = LinearAlgebra::CUDAWrappers;
 
 template <int M, int N, int type, bool add, bool dof_to_quad>
 __global__ void
-evaluate_tensor_product(double *dst, double *src)
+evaluate_tensor_product(
+  Kokkos::View<double *, MemorySpace::Default::kokkos_space> shape_values,
+  Kokkos::View<double *, MemorySpace::Default::kokkos_space> shape_gradients,
+  Kokkos::View<double *, MemorySpace::Default::kokkos_space> co_shape_gradients,
+  double *                                                   dst,
+  double *                                                   src)
 {
   CUDAWrappers::internal::EvaluatorTensorProduct<
     CUDAWrappers::internal::evaluate_general,
@@ -42,23 +47,19 @@ evaluate_tensor_product(double *dst, double *src)
     M - 1,
     N,
     double>
-    evaluator(0);
+    evaluator(shape_values, shape_gradients, co_shape_gradients);
 
   if (type == 0)
     {
-      evaluator.template values<0, dof_to_quad, false, false>(
-        CUDAWrappers::internal::get_global_shape_values<double>(0), src, src);
+      evaluator.template values<0, dof_to_quad, false, false>(src, src);
       __syncthreads();
-      evaluator.template values<1, dof_to_quad, add, false>(
-        CUDAWrappers::internal::get_global_shape_values<double>(0), src, dst);
+      evaluator.template values<1, dof_to_quad, add, false>(src, dst);
     }
   if (type == 1)
     {
-      evaluator.template gradients<0, dof_to_quad, false, false>(
-        CUDAWrappers::internal::get_global_shape_values<double>(0), src, src);
+      evaluator.template gradients<0, dof_to_quad, false, false>(src, src);
       __syncthreads();
-      evaluator.template gradients<1, dof_to_quad, add, false>(
-        CUDAWrappers::internal::get_global_shape_values<double>(0), src, dst);
+      evaluator.template gradients<1, dof_to_quad, add, false>(src, dst);
     }
 }
 
@@ -67,7 +68,8 @@ void
 test()
 {
   deallog << "Test " << M << " x " << N << std::endl;
-  LinearAlgebra::ReadWriteVector<double> shape_host(M * N);
+  unsigned int                           size_shape_values = M * N;
+  LinearAlgebra::ReadWriteVector<double> shape_host(size_shape_values);
   for (unsigned int i = 0; i < (M + 1) / 2; ++i)
     for (unsigned int j = 0; j < N; ++j)
       {
@@ -121,29 +123,34 @@ test()
   x_dev.import(x_host, VectorOperation::insert);
   y_dev.import(y_host, VectorOperation::insert);
 
-  unsigned int size_shape_values = M * N * sizeof(double);
 
-  cudaError_t cuda_error =
-    cudaMemcpyToSymbol(CUDAWrappers::internal::get_global_shape_values<double>(
-                         0),
-                       shape_host.begin(),
-                       size_shape_values,
-                       0,
-                       cudaMemcpyHostToDevice);
-  AssertCuda(cuda_error);
+  Kokkos::View<double *, MemorySpace::Default::kokkos_space> shape_values(
+    Kokkos::view_alloc("shape_values", Kokkos::WithoutInitializing),
+    size_shape_values);
+  Kokkos::View<double *,
+               MemorySpace::Host::kokkos_space,
+               Kokkos::MemoryTraits<Kokkos::Unmanaged>>
+    shape_host_view(shape_host.begin(), size_shape_values);
+  Kokkos::deep_copy(shape_values, shape_host_view);
 
-  cuda_error = cudaMemcpyToSymbol(
-    CUDAWrappers::internal::get_global_shape_gradients<double>(0),
-    shape_host.begin(),
-    size_shape_values,
-    0,
-    cudaMemcpyHostToDevice);
-  AssertCuda(cuda_error);
+  Kokkos::View<double *, MemorySpace::Default::kokkos_space> shape_gradients(
+    Kokkos::view_alloc("shape_gradients", Kokkos::WithoutInitializing),
+    size_shape_values);
+  Kokkos::deep_copy(shape_gradients, shape_host_view);
+
+  Kokkos::View<double *, MemorySpace::Default::kokkos_space> co_shape_gradients(
+    Kokkos::view_alloc("co_shape_gradients", Kokkos::WithoutInitializing),
+    size_shape_values);
+  Kokkos::deep_copy(co_shape_gradients, shape_host_view);
 
   // Launch the kernel
   dim3 block_dim(M, N);
   evaluate_tensor_product<M, N, type, add, false>
-    <<<1, block_dim>>>(y_dev.get_values(), x_dev.get_values());
+    <<<1, block_dim>>>(shape_values,
+                       shape_gradients,
+                       co_shape_gradients,
+                       y_dev.get_values(),
+                       x_dev.get_values());
 
   // Check the results on the host
   y_host.import(y_dev, VectorOperation::insert);
@@ -173,7 +180,11 @@ test()
 
   // Launch the kernel
   evaluate_tensor_product<M, N, type, add, true>
-    <<<1, block_dim>>>(x_dev.get_values(), y_dev.get_values());
+    <<<1, block_dim>>>(shape_values,
+                       shape_gradients,
+                       co_shape_gradients,
+                       x_dev.get_values(),
+                       y_dev.get_values());
 
   // Check the results on the host
   x_host.import(x_dev, VectorOperation::insert);
@@ -189,6 +200,7 @@ main()
   std::ofstream logfile("output");
   deallog.attach(logfile);
 
+  Kokkos::initialize();
   init_cuda();
 
   deallog.push("values");
@@ -214,6 +226,8 @@ main()
   deallog.pop();
 
   deallog.pop();
+
+  Kokkos::finalize();
 
   return 0;
 }

--- a/tests/cuda/matrix_free_initialize_vector.cc
+++ b/tests/cuda/matrix_free_initialize_vector.cc
@@ -38,9 +38,9 @@
 
 template <typename Number>
 void
-check(
-  const LinearAlgebra::distributed::Vector<Number, MemorySpace::CUDA> &vector,
-  const Utilities::MPI::Partitioner &reference_partitioner)
+check(const LinearAlgebra::distributed::Vector<Number, MemorySpace::Default>
+        &                                vector,
+      const Utilities::MPI::Partitioner &reference_partitioner)
 {
   Assert(vector.get_partitioner()->locally_owned_range() ==
            reference_partitioner.locally_owned_range(),
@@ -116,7 +116,11 @@ main(int argc, char **argv)
   init_cuda(true);
   MPILogInitAll mpi_inilog;
 
-  test<2, 1, LinearAlgebra::distributed::Vector<double, MemorySpace::CUDA>>();
+  test<2,
+       1,
+       LinearAlgebra::distributed::Vector<double, MemorySpace::Default>>();
   if (Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD) == 1)
     test<2, 1, LinearAlgebra::CUDAWrappers::Vector<double>>();
+
+  return 0;
 }

--- a/tests/cuda/matrix_free_multiple_objects.cc
+++ b/tests/cuda/matrix_free_multiple_objects.cc
@@ -43,6 +43,7 @@
 
 #include "../tests.h"
 
+#include "Kokkos_Core.hpp"
 #include "matrix_vector_mf.h"
 
 template <int fe_degree, int n_q_points_1d>
@@ -147,70 +148,74 @@ main()
 
   deallog << std::setprecision(3);
 
+  Kokkos::initialize();
   init_cuda();
 
-  Triangulation<2> tria;
-  GridGenerator::hyper_cube(tria);
-  tria.refine_global(5 - 2);
-  AffineConstraints<double> constraints;
-  constraints.close();
-  bool constant_coefficient = true;
+  {
+    Triangulation<2> tria;
+    GridGenerator::hyper_cube(tria);
+    tria.refine_global(5 - 2);
+    AffineConstraints<double> constraints;
+    constraints.close();
+    bool constant_coefficient = true;
 
-  // Create the first MatrixFree object
-  constexpr unsigned int fe_degree_1     = 1;
-  constexpr unsigned int n_q_points_1d_1 = fe_degree_1 + 1;
-  FE_Q<2>                fe_1(fe_degree_1);
-  DoFHandler<2>          dof_1(tria);
-  dof_1.distribute_dofs(fe_1);
-  MappingQ<2>                                         mapping_1(fe_degree_1);
-  CUDAWrappers::MatrixFree<2, double>                 mf_data_1;
-  CUDAWrappers::MatrixFree<2, double>::AdditionalData additional_data_1;
-  additional_data_1.mapping_update_flags = update_values | update_gradients |
-                                           update_JxW_values |
-                                           update_quadrature_points;
-  const QGauss<1> quad_1(n_q_points_1d_1);
-  mf_data_1.reinit(mapping_1, dof_1, constraints, quad_1, additional_data_1);
-  const unsigned int n_dofs_1 = dof_1.n_dofs();
-  MatrixFreeTest<2,
-                 fe_degree_1,
-                 double,
-                 LinearAlgebra::CUDAWrappers::Vector<double>,
-                 n_q_points_1d_1>
-    mf_1(mf_data_1,
-         n_dofs_1 * std::pow(n_q_points_1d_1, 2),
-         constant_coefficient);
+    // Create the first MatrixFree object
+    constexpr unsigned int fe_degree_1     = 1;
+    constexpr unsigned int n_q_points_1d_1 = fe_degree_1 + 1;
+    FE_Q<2>                fe_1(fe_degree_1);
+    DoFHandler<2>          dof_1(tria);
+    dof_1.distribute_dofs(fe_1);
+    MappingQ<2>                                         mapping_1(fe_degree_1);
+    CUDAWrappers::MatrixFree<2, double>                 mf_data_1;
+    CUDAWrappers::MatrixFree<2, double>::AdditionalData additional_data_1;
+    additional_data_1.mapping_update_flags = update_values | update_gradients |
+                                             update_JxW_values |
+                                             update_quadrature_points;
+    const QGauss<1> quad_1(n_q_points_1d_1);
+    mf_data_1.reinit(mapping_1, dof_1, constraints, quad_1, additional_data_1);
+    const unsigned int n_dofs_1 = dof_1.n_dofs();
+    MatrixFreeTest<2,
+                   fe_degree_1,
+                   double,
+                   LinearAlgebra::CUDAWrappers::Vector<double>,
+                   n_q_points_1d_1>
+      mf_1(mf_data_1,
+           n_dofs_1 * std::pow(n_q_points_1d_1, 2),
+           constant_coefficient);
 
-  // Create the second MatrixFree object
-  constexpr unsigned int fe_degree_2     = 2;
-  constexpr unsigned int n_q_points_1d_2 = fe_degree_2 + 1;
-  FE_Q<2>                fe_2(fe_degree_2);
-  DoFHandler<2>          dof_2(tria);
-  dof_2.distribute_dofs(fe_2);
-  MappingQ<2>                                         mapping_2(fe_degree_2);
-  CUDAWrappers::MatrixFree<2, double>                 mf_data_2;
-  CUDAWrappers::MatrixFree<2, double>::AdditionalData additional_data_2;
-  additional_data_2.mapping_update_flags = update_values | update_gradients |
-                                           update_JxW_values |
-                                           update_quadrature_points;
-  const QGauss<1> quad_2(n_q_points_1d_2);
-  mf_data_2.reinit(mapping_2, dof_2, constraints, quad_2, additional_data_2);
-  const unsigned int n_dofs_2 = dof_2.n_dofs();
-  MatrixFreeTest<2,
-                 fe_degree_2,
-                 double,
-                 LinearAlgebra::CUDAWrappers::Vector<double>,
-                 n_q_points_1d_2>
-    mf_2(mf_data_2,
-         n_dofs_2 * std::pow(n_q_points_1d_2, 2),
-         constant_coefficient);
+    // Create the second MatrixFree object
+    constexpr unsigned int fe_degree_2     = 2;
+    constexpr unsigned int n_q_points_1d_2 = fe_degree_2 + 1;
+    FE_Q<2>                fe_2(fe_degree_2);
+    DoFHandler<2>          dof_2(tria);
+    dof_2.distribute_dofs(fe_2);
+    MappingQ<2>                                         mapping_2(fe_degree_2);
+    CUDAWrappers::MatrixFree<2, double>                 mf_data_2;
+    CUDAWrappers::MatrixFree<2, double>::AdditionalData additional_data_2;
+    additional_data_2.mapping_update_flags = update_values | update_gradients |
+                                             update_JxW_values |
+                                             update_quadrature_points;
+    const QGauss<1> quad_2(n_q_points_1d_2);
+    mf_data_2.reinit(mapping_2, dof_2, constraints, quad_2, additional_data_2);
+    const unsigned int n_dofs_2 = dof_2.n_dofs();
+    MatrixFreeTest<2,
+                   fe_degree_2,
+                   double,
+                   LinearAlgebra::CUDAWrappers::Vector<double>,
+                   n_q_points_1d_2>
+      mf_2(mf_data_2,
+           n_dofs_2 * std::pow(n_q_points_1d_2, 2),
+           constant_coefficient);
 
-  // Perform MV with the first object
-  do_test<fe_degree_1, n_q_points_1d_1>(
-    dof_1, mf_1, n_dofs_1, mapping_1, constraints);
+    // Perform MV with the first object
+    do_test<fe_degree_1, n_q_points_1d_1>(
+      dof_1, mf_1, n_dofs_1, mapping_1, constraints);
 
-  // Perform MV with the second object
-  do_test<fe_degree_2, n_q_points_1d_2>(
-    dof_2, mf_2, n_dofs_2, mapping_2, constraints);
+    // Perform MV with the second object
+    do_test<fe_degree_2, n_q_points_1d_2>(
+      dof_2, mf_2, n_dofs_2, mapping_2, constraints);
+  }
+  Kokkos::finalize();
 
   return 0;
 }

--- a/tests/cuda/matrix_free_no_index_initialize.cc
+++ b/tests/cuda/matrix_free_no_index_initialize.cc
@@ -38,7 +38,7 @@ public:
   MatrixFreeTest(const CUDAWrappers::MatrixFree<dim, Number> &data_in)
     : data(data_in){};
 
-  __device__ void
+  DEAL_II_HOST_DEVICE void
   operator()(
     const unsigned int                                          cell,
     const typename CUDAWrappers::MatrixFree<dim, Number>::Data *gpu_data,
@@ -51,7 +51,7 @@ public:
 
     // set to unit vector
     fe_eval.submit_dof_value(1.);
-    __syncthreads();
+    KOKKOS_IF_ON_DEVICE(__syncthreads();)
     fe_eval.evaluate(/*evaluate_values =*/true, /*evaluate_gradients=*/true);
 
 #ifndef __APPLE__

--- a/tests/cuda/matrix_free_no_index_initialize.cc
+++ b/tests/cuda/matrix_free_no_index_initialize.cc
@@ -24,6 +24,8 @@
 
 #include "../tests.h"
 
+#include "Kokkos_Core.hpp"
+
 template <int dim,
           int fe_degree,
           int n_q_points_1d = fe_degree + 1,
@@ -147,7 +149,12 @@ main()
 {
   initlog();
 
+  Kokkos::initialize();
   init_cuda();
 
   test<2, 1>();
+
+  Kokkos::finalize();
+
+  return 0;
 }

--- a/tests/cuda/matrix_vector_common.h
+++ b/tests/cuda/matrix_vector_common.h
@@ -46,6 +46,7 @@
 
 #include "../tests.h"
 
+#include "Kokkos_Core.hpp"
 #include "matrix_vector_mf.h"
 
 
@@ -194,6 +195,8 @@ main()
 
   deallog << std::setprecision(3);
 
+  Kokkos::initialize();
+
   init_cuda();
 
   {
@@ -222,6 +225,8 @@ main()
     deallog.pop();
     deallog.pop();
   }
+
+  Kokkos::finalize();
 
   return 0;
 }

--- a/tests/cuda/matrix_vector_mf.h
+++ b/tests/cuda/matrix_vector_mf.h
@@ -30,12 +30,12 @@ template <int dim, int fe_degree, typename Number, int n_q_points_1d>
 class HelmholtzOperatorQuad
 {
 public:
-  __device__
+  DEAL_II_HOST_DEVICE
   HelmholtzOperatorQuad(Number coef)
     : coef(coef)
   {}
 
-  __device__ void
+  DEAL_II_HOST_DEVICE void
   operator()(
     CUDAWrappers::FEEvaluation<dim, fe_degree, n_q_points_1d, 1, Number>
       *fe_eval) const;
@@ -47,7 +47,7 @@ private:
 
 
 template <int dim, int fe_degree, typename Number, int n_q_points_1d>
-__device__ void
+DEAL_II_HOST_DEVICE void
 HelmholtzOperatorQuad<dim, fe_degree, Number, n_q_points_1d>::operator()(
   CUDAWrappers::FEEvaluation<dim, fe_degree, n_q_points_1d, 1, Number> *fe_eval)
   const
@@ -66,7 +66,7 @@ public:
     : coef(coefficient)
   {}
 
-  __device__ void
+  DEAL_II_HOST_DEVICE void
   operator()(
     const unsigned int                                          cell,
     const typename CUDAWrappers::MatrixFree<dim, Number>::Data *gpu_data,
@@ -86,7 +86,7 @@ public:
 
 
 template <int dim, int fe_degree, typename Number, int n_q_points_1d>
-__device__ void
+DEAL_II_HOST_DEVICE void
 HelmholtzOperator<dim, fe_degree, Number, n_q_points_1d>::operator()(
   const unsigned int                                          cell,
   const typename CUDAWrappers::MatrixFree<dim, Number>::Data *gpu_data,
@@ -117,7 +117,7 @@ public:
     : coef(coefficient)
   {}
 
-  __device__ void
+  DEAL_II_HOST_DEVICE void
   operator()(
     const unsigned int                                          cell,
     const typename CUDAWrappers::MatrixFree<dim, Number>::Data *gpu_data);
@@ -135,7 +135,7 @@ private:
 
 
 template <int dim, int fe_degree, typename Number, int n_q_points_1d>
-__device__ void
+DEAL_II_HOST_DEVICE void
 VaryingCoefficientFunctor<dim, fe_degree, Number, n_q_points_1d>::operator()(
   const unsigned int                                          cell,
   const typename CUDAWrappers::MatrixFree<dim, Number>::Data *gpu_data)


### PR DESCRIPTION
Moving our CUDA matrix-free framework to Kokkos will be done in 3 steps:
 1. Moving all the data used on the device to Kokkos::View (this is what this PR does)
 2. Move all the kernel launches to Kokkos::parallel_for
 3. Clean-up and optimization
 Until we get to step three, we should expect some loss of performance. 

I will ask for some leniency on this PR. There are several FIXME added in the code and several functions/structures should be renamed or should disappear. I know the code can be simplified but I want to move everything to Kokkos first.

The changes is this PR are backward compatible except that I removed one matrix-free parameter. We only tested the default value and it won't fit well with the use of `Kokkos::parallel_for`.  So I decided to remove the parameter to avoid useless porting.

The PR is pretty large but you can save a couple hundred lines by hiding the white spaces