### PR TITLE
CMake: fix variable name

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -122,7 +122,7 @@ foreach(build ${DEAL_II_BUILD_TYPES})
   # enabled in client user code irrespective of what compile flags/options
   # they have set.
   #
-  target_compile_features(${DEAL_II_NAMESPACE}_${build_lowercase}
+  target_compile_features(${DEAL_II_TARGET_NAME}_${build_lowercase}
     INTERFACE cxx_std_${CMAKE_CXX_STANDARD}
     )
 


### PR DESCRIPTION
We had an unfortunate "in flight" renaming conflict: One pull request
renamed the variable to DEAL_II_TARGET_NAME (PR #14993) while another
one (PR #14971) created the dealii::dealii target. Both on their own
passed the CI, but once both were merged we have an issue.

In reference to #14971
In reference to #14993