### PR TITLE
Fix copy constructor of MappingQ

### DIFF
--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -259,6 +259,7 @@ MappingQ<dim, spacedim>::MappingQ(const MappingQ<dim, spacedim> &mapping)
   , polynomials_1d(mapping.polynomials_1d)
   , renumber_lexicographic_to_hierarchic(
       mapping.renumber_lexicographic_to_hierarchic)
+  , unit_cell_support_points(mapping.unit_cell_support_points)
   , support_point_weights_perimeter_to_interior(
       mapping.support_point_weights_perimeter_to_interior)
   , support_point_weights_cell(mapping.support_point_weights_cell)


### PR DESCRIPTION
step-70 crashed with the following assert:
```
--------------------------------------------------------
An error occurred in line <902> of file </home/munch/sw-adaflo-simplex2/dealii/include/deal.II/fe/mapping_q_internal.h> in function
    dealii::internal::MappingQImplementation::InverseQuadraticApproximation<dim, spacedim>::InverseQuadraticApproximation(const std::vector<dealii::Point<spacedim> >&, const std::vector<dealii::Point<dim> >&) [with int dim = 2; int spacedim = 2]
The violated condition was: 
    ::dealii::deal_II_exceptions::internals::compare_for_equality(real_support_points.size(), unit_support_points.size())
Additional information: 
    Two sizes or dimensions were supposed to be equal, but aren't. They
    are 4 and 0.

Stacktrace:
-----------
#0  /home/munch/sw-adaflo-simplex2/dealii-build/lib/libdeal_II.g.so.9.5.0-pre: dealii::internal::MappingQImplementation::InverseQuadraticApproximation<2, 2>::InverseQuadraticApproximation(std::vector<dealii::Point<2, double>, std::allocator<dealii::Point<2, double> > > const&, std::vector<dealii::Point<2, double>, std::allocator<dealii::Point<2, double> > > const&)
#1  /home/munch/sw-adaflo-simplex2/dealii-build/lib/libdeal_II.g.so.9.5.0-pre: dealii::MappingQ<2, 2>::transform_points_real_to_unit_cell(dealii::TriaIterator<dealii::CellAccessor<2, 2> > const&, dealii::ArrayView<dealii::Point<2, double> const, dealii::MemorySpace::Host> const&, dealii::ArrayView<dealii::Point<2, double>, dealii::MemorySpace::Host> const&) const
#2  /home/munch/sw-adaflo-simplex2/dealii-build/lib/libdeal_II.g.so.9.5.0-pre: dealii::Particles::ParticleHandler<2, 2>::sort_particles_into_subdomains_and_cells()
#3  ./bin/step-70.debug: std::enable_if<std::is_convertible<dealii::TrilinosWrappers::MPI::Vector*, dealii::Function<2, double>*>::value==(false), void>::type dealii::Particles::ParticleHandler<2, 2>::set_particle_positions<dealii::TrilinosWrappers::MPI::Vector>(dealii::TrilinosWrappers::MPI::Vector const&, bool)
#4  ./bin/step-70.debug: Step70::StokesImmersedProblem<2, 2>::run()
#5  ./bin/step-70.debug: main
```


FYI @mschreter 

closes #14844