### PR TITLE
Work around nvcc compiler bug in mg_transfer_global_coarsening.templates.h

### DIFF
--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -76,11 +76,17 @@ namespace
       else if ((degree_fine == (2 * deg + 1)) && (degree_coarse == deg))
         fu.template run<2 * deg + 1, deg>(); // h-MG
       else if ((degree_fine == deg) && (degree_coarse == std::max(deg / 2, 1u)))
-        fu.template run<deg, std::max(deg / 2u, 1u)>(); // p-MG: bisection
+        {
+          constexpr unsigned int degree_coarse_used = std::max(deg / 2u, 1u);
+          fu.template run<deg, degree_coarse_used>(); // p-MG: bisection
+        }
       else if ((degree_fine == deg) && (degree_coarse == deg))
         fu.template run<deg, deg>(); // identity (nothing to do)
       else if ((degree_fine == deg) && (degree_coarse == std::max(deg - 1, 1u)))
-        fu.template run<deg, std::max(deg - 1u, 1u)>(); // p-MG: --
+        {
+          constexpr unsigned int degree_coarse_used = std::max(deg - 1u, 1u);
+          fu.template run<deg, degree_coarse_used>(); // p-MG: --
+        }
       else if ((degree_fine == deg) && (degree_coarse == 1))
         fu.template run<deg, 1>(); // p-MG: jump to 1
       else if (deg < max_degree)


### PR DESCRIPTION
`nvcc` says it doesn't know about any matching overloads for the present code. It seems to work though if the result of the `max` call is stored in a separate variable instead of computing it inline.  