### PR TITLE
Increment the majorest version number.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-What is deal.II?
+What is deal.III?
 ================
 
-deal.II is a C++ program library targeted at the computational solution
+deal.III is a C++ program library targeted at the computational solution
 of partial differential equations using adaptive finite elements. It uses
 state-of-the-art programming techniques to offer you a modern interface
 to the complex data structures and algorithms required.
@@ -9,8 +9,8 @@ to the complex data structures and algorithms required.
 For the impatient:
 ------------------
 
-Let's say you've unpacked the .tar.gz file into a directory /path/to/dealii/sources. 
-Then configure, compile, and install the deal.II library with:
+Let's say you've unpacked the .tar.gz file into a directory /path/to/dealii/sources.
+Then configure, compile, and install the deal.III library with:
 
     $ mkdir build
     $ cd build
@@ -34,10 +34,10 @@ Getting started:
 
 The tutorial steps are located under examples/ of the installation.
 Information about the tutorial steps can be found at
-[./doc/doxygen/tutorial/index.html](https://dealii.org/developer/doxygen/deal.II/Tutorial.html)
+[./doc/doxygen/tutorial/index.html](https://dealii.org/developer/doxygen/deal.III/Tutorial.html)
 or at https://www.dealii.org/.
 
-deal.II includes support for pretty-printing deal.II objects inside GDB.
+deal.III includes support for pretty-printing deal.III objects inside GDB.
 See [`contrib/utilities/dotgdbinit.py`](contrib/utilities/dotgdbinit.py) or
 the new documentation page (under 'information for users') for instructions
 on how to set this up.
@@ -67,7 +67,7 @@ Continuous Integration Status:
 | MacOS  | [![Build Status](https://github.com/dealii/dealii/workflows/github-OSX/badge.svg)](https://github.com/dealii/dealii/actions?query=workflow%3Agithub-OSX)                                                                                         | See https://github.com/dealii/dealii/actions                                          |
 | MSVC   | [![Build status](https://github.com/dealii/dealii/workflows/github-windows/badge.svg)](https://github.com/dealii/dealii/actions?query=workflow%3Agithub-windows)                                                                                 | See https://github.com/dealii/dealii/actions                                          |
 | Docker | [![Build status](https://github.com/dealii/dealii/workflows/github-docker/badge.svg)](https://github.com/dealii/dealii/actions?query=workflow%3Agithub-docker)                                                                                   | See https://github.com/dealii/dealii/actions                                          |
-| CDash  | [![cdash](https://img.shields.io/website?down_color=lightgrey&down_message=offline&label=CDash&up_color=green&up_message=up&url=https%3A%2F%2Fcdash.dealii.org%2Findex.php%3Fproject%3Ddeal.II)](https://cdash.dealii.org/index.php?project=deal.II) | Various builds and configurations on https://cdash.dealii.org/index.php?project=deal.II |
+| CDash  | [![cdash](https://img.shields.io/website?down_color=lightgrey&down_message=offline&label=CDash&up_color=green&up_message=up&url=https%3A%2F%2Fcdash.dealii.org%2Findex.php%3Fproject%3Ddeal.III)](https://cdash.dealii.org/index.php?project=deal.III) | Various builds and configurations on https://cdash.dealii.org/index.php?project=deal.III |
 
 Docker Images:
 -------------
@@ -81,6 +81,6 @@ by running, for example:
     $ docker run --rm -t -i dealii/dealii:master-focal
 
 The above command would drop you into an isolated environment, in which you 
-will find the latest version of deal.II (master development branch) installed
+will find the latest version of deal.III (master development branch) installed
 under `/usr/local`.
 

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -467,12 +467,24 @@
 #endif
 
 /***********************************************************************
- * Two macro names that we put at the top and bottom of all deal.II files
- * and that will be expanded to "namespace dealii {" and "}".
+ * Two macro names that we put at the top and bottom of all deal.III files
+ * and that will be expanded to "namespace dealiii {" and "}".
  */
 
-#define DEAL_II_NAMESPACE_OPEN namespace dealii {
+#define DEAL_II_NAMESPACE_OPEN namespace dealiii {
 #define DEAL_II_NAMESPACE_CLOSE }
+
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
+/***********************************************************************
+ * Support the old namespace for backwards compatibility.
+ */
+namespace DEAL_II_DEPRECATED dealii
+{
+  using namespace dealiii;
+}
+
 
 /***********************************************************************
  * Two macros to guard external header includes.

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -1694,7 +1694,6 @@ namespace parallel
 {
   namespace distributed
   {
-    /*----------------- class Triangulation<dim,spacedim> ---------------\*/
     template <int dim, int spacedim>
     Triangulation<dim, spacedim>::Triangulation(
       const MPI_Comm &mpi_communicator,
@@ -4189,7 +4188,6 @@ namespace parallel
     {
       Assert(false, ExcNotImplemented());
     }
-
   } // namespace distributed
 } // namespace parallel
 


### PR DESCRIPTION
Followup to #14942 and #14963 - I needed those changes to make this PR possible.

I recently chatted with some of the libMesh developers who were not aware that we now support simplices. In fact, due to everyone's travel being limited over the last three years, I don't think the larger community is aware that we now support three-sided reference elements. We definitely need to get the word out!

With all that in mind, I propose that we go three-for-three and increment the majorest version number. Three years, three sides to a triangle, `deal.III`. Fortunately, with our deprecation mechanism, we can still support the old namespace for the next release and then fully switch to `dealiii` everywhere for version 10.0.