### PR TITLE
instantiate mapped quadrature for dim=1 and spacedim=2

### DIFF
--- a/source/base/quadrature_lib.cc
+++ b/source/base/quadrature_lib.cc
@@ -2266,6 +2266,10 @@ template Quadrature<3>
 QSimplex<3>::compute_affine_transformation(
   const std::array<Point<3>, 3 + 1> &vertices) const;
 
+template Quadrature<2>
+QSimplex<1>::mapped_quadrature(
+  const std::vector<std::array<Point<2>, 1 + 1>> &simplices) const;
+
 template Quadrature<3>
 QSimplex<1>::mapped_quadrature(
   const std::vector<std::array<Point<3>, 1 + 1>> &simplices) const;


### PR DESCRIPTION
I regularly need mapped quadratures on element faces in 2d. This worked flawlessly in the past. With the current master build the linker fails. I don't know when exactly this stopped working, but adding the corresponding instantiation fixes the problem for me.

@peterrum 