### PR TITLE
Optimize mapping computation in MappingQ

### DIFF
--- a/include/deal.II/base/qprojector.h
+++ b/include/deal.II/base/qprojector.h
@@ -110,6 +110,20 @@ public:
                   const unsigned int   face_no);
 
   /**
+   * Compute the cell quadrature formula corresponding to using
+   * <tt>quadrature</tt> on face <tt>face_no</tt> taking into account the
+   * orientation of the face. For further details, see the general doc for this
+   * class.
+   */
+  static Quadrature<dim>
+  project_to_oriented_face(const ReferenceCell &reference_cell,
+                           const SubQuadrature &quadrature,
+                           const unsigned int   face_no,
+                           const bool           face_orientation,
+                           const bool           face_flip,
+                           const bool           face_rotation);
+
+  /**
    * Compute the quadrature points on the cell if the given quadrature formula
    * is used on face <tt>face_no</tt>, subface number <tt>subface_no</tt>
    * corresponding to RefineCase::Type <tt>ref_case</tt>. The last argument is
@@ -147,6 +161,25 @@ public:
                      const unsigned int             subface_no,
                      const RefinementCase<dim - 1> &ref_case =
                        RefinementCase<dim - 1>::isotropic_refinement);
+
+  /**
+   * Compute the cell quadrature formula corresponding to using
+   * <tt>quadrature</tt> on subface <tt>subface_no</tt> of face
+   * <tt>face_no</tt> with SubfaceCase<dim> <tt>ref_case</tt>. The last
+   * argument is only used in 3d.
+   *
+   * @note Only the points are transformed. The quadrature weights are the
+   * same as those of the original rule.
+   */
+  static Quadrature<dim>
+  project_to_oriented_subface(const ReferenceCell &            reference_cell,
+                              const SubQuadrature &            quadrature,
+                              const unsigned int               face_no,
+                              const unsigned int               subface_no,
+                              const bool                       face_orientation,
+                              const bool                       face_flip,
+                              const bool                       face_rotation,
+                              const internal::SubfaceCase<dim> ref_case);
 
   /**
    * Take a collection of face quadrature formulas and generate a cell

--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -256,6 +256,37 @@ public:
       &output_data) const;
 
   /**
+   * As opposed to the fill_fe_face_values()
+   * function that relies on pre-computed information of InternalDataBase, this
+   * function chooses the flexible evaluation path on the cell and points
+   * passed in to the current function.
+   *
+   * @param[in] cell The cell where to evaluate the mapping.
+   *
+   * @param[in] face_number The face number where to evaluate the mapping.
+   *
+   * @param[in] face_quadrature The quadrature points where the
+   * transformation (Jacobians, positions) should be computed.
+   *
+   * @param[in] internal_data A reference to an object previously created
+   * that may be used to store information the mapping can compute once on the
+   * reference cell. See the documentation of the Mapping::InternalDataBase
+   * class for an extensive description of the purpose of these objects.
+   *
+   * @param[out] output_data A struct containing the evaluated quantities such
+   * as the Jacobian resulting from application of the mapping on the given
+   * cell with its underlying manifolds.
+   */
+  void
+  fill_mapping_data_for_face_quadrature(
+    const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+    const unsigned int                                          face_number,
+    const Quadrature<dim - 1> &                                 face_quadrature,
+    const typename Mapping<dim, spacedim>::InternalDataBase &   internal_data,
+    internal::FEValuesImplementation::MappingRelatedData<dim, spacedim>
+      &output_data) const;
+
+  /**
    * @name Interface with FEValues and friends
    * @{
    */
@@ -390,6 +421,13 @@ public:
      */
     virtual std::size_t
     memory_consumption() const override;
+
+    /**
+     * Location of quadrature points of faces or subfaces in 3d with all
+     * possible orientations. Can be accessed with the correct offset provided
+     * via QProjector::DataSetDescriptor. Not needed/used for cells.
+     */
+    AlignedVector<Point<dim>> quadrature_points;
 
     /**
      * Values of shape functions. Access by function @p shape.


### PR DESCRIPTION
This PR proposes to use the vectorized and optimized functionality from `tensor_product_kernels.h` via `internal::evaluate_tensor_product_value_and_gradient()` to compute quadrature points and Jacobians for `MappingQ`.

Depends on #15102