### PR TITLE
Fix FEDomination in FEInterfaceValues and ScratchData.

### DIFF
--- a/include/deal.II/fe/fe_interface_values.h
+++ b/include/deal.II/fe/fe_interface_values.h
@@ -2493,7 +2493,8 @@ FEInterfaceValues<dim, spacedim>::reinit(
     {
       const unsigned int dominated_fe_index =
         internal_hp_fe_face_values->get_fe_collection().find_dominated_fe(
-          {cell->active_fe_index(), cell_neighbor->active_fe_index()});
+          {cell->active_fe_index(), cell_neighbor->active_fe_index()},
+          /*codim = */ 1);
 
       const unsigned int used_q_index =
         (q_index == numbers::invalid_unsigned_int ? dominated_fe_index :

--- a/source/meshworker/scratch_data.cc
+++ b/source/meshworker/scratch_data.cc
@@ -317,10 +317,17 @@ namespace MeshWorker
         // then we defer to the dominance of one FE over another. This should
         // ensure that the optimal integration order and mapping order are
         // selected for this situation.
-        const unsigned int dominated_fe_index =
+        unsigned int dominated_fe_index =
           fe_collection->find_dominated_fe({cell->active_fe_index(),
                                             neighbor_cell->active_fe_index()},
                                            /*codim =*/1);
+
+        // TODO: find_dominated_fe returns invalid_fe_index when no dominated FE
+        // has been found. We want to pass this value to FEFaceValues, but it
+        // expects an invalid_unsigned_int in this case. We need to match the
+        // interfaces in the future.
+        if (dominated_fe_index == numbers::invalid_fe_index)
+          dominated_fe_index = numbers::invalid_unsigned_int;
 
         hp_fe_face_values->reinit(cell,
                                   face_no,

--- a/source/meshworker/scratch_data.cc
+++ b/source/meshworker/scratch_data.cc
@@ -318,8 +318,9 @@ namespace MeshWorker
         // ensure that the optimal integration order and mapping order are
         // selected for this situation.
         const unsigned int dominated_fe_index =
-          fe_collection->find_dominated_fe(
-            {cell->active_fe_index(), neighbor_cell->active_fe_index()});
+          fe_collection->find_dominated_fe({cell->active_fe_index(),
+                                            neighbor_cell->active_fe_index()},
+                                           /*codim =*/1);
 
         hp_fe_face_values->reinit(cell,
                                   face_no,

--- a/tests/meshworker/scratch_data_03_hp.with_muparser=on.with_umfpack=on.output
+++ b/tests/meshworker/scratch_data_03_hp.with_muparser=on.with_umfpack=on.output
@@ -1,2 +1,2 @@
 
-DEAL::Linfty norm of solution 0.0737281
+DEAL::Linfty norm of solution 0.100632


### PR DESCRIPTION
In `FEInterfaceValues`, as well as `ScratchData::reinit` that uses `hp::FEFaceValues`, we use the finite element domination logic to find matching quadrature rules and mappings.

Right now, we do this on the cell level (codim = 0), but we should rather do it on a face level (codim = 1) in these two cases.