### PR TITLE
Simplify code slightly.

### DIFF
--- a/source/grid/grid_tools_cache.cc
+++ b/source/grid/grid_tools_cache.cc
@@ -130,10 +130,10 @@ namespace GridTools
         std::vector<std::pair<
           BoundingBox<spacedim>,
           typename Triangulation<dim, spacedim>::active_cell_iterator>>
-                     boxes(tria->n_active_cells());
-        unsigned int i = 0;
+          boxes;
+        boxes.reserve(tria->n_active_cells());
         for (const auto &cell : tria->active_cell_iterators())
-          boxes[i++] = std::make_pair(mapping->get_bounding_box(cell), cell);
+          boxes.emplace_back(mapping->get_bounding_box(cell), cell);
 
         cell_bounding_boxes_rtree = pack_rtree(boxes);
         update_flags = update_flags & ~update_cell_bounding_boxes_rtree;


### PR DESCRIPTION
Avoid using a second counter in a range-based for loop, which always looks a bit awkward.