### PR TITLE
Return objects by value, rather than via a reference.

### DIFF
--- a/doc/news/changes/minor/20230407Bangerth
+++ b/doc/news/changes/minor/20230407Bangerth
@@ -1,0 +1,7 @@
+Deprecated: The DoFTools::map_dofs_to_support_points() function family
+had functions that returned what they computed via a non-const
+reference argument `support_points` of type `std::map`. These
+overloads are now deprecated and replaced by functions that return the
+map via a regular `return` value.
+<br>
+(Wolfgang Bangerth, 2023/04/07)

--- a/examples/step-2/step-2.cc
+++ b/examples/step-2/step-2.cc
@@ -120,8 +120,7 @@ void make_grid(Triangulation<2> &triangulation)
 // understand exactly what this function does, and you can skip over
 // it. But if you would like to know anyway: We want to call the
 // function DoFTools::map_dofs_to_support_points() that returns a list
-// of locations (in the form of Point objects that store
-// coordinates). It does so in the form of a map through which we can
+// of locations. It does so in the form of a map through which we can
 // query (in a statement such as `dof_location_map[42]`) where the DoF
 // is located (in the example, where the 42nd DoF is). It puts this
 // information into the `dof_location_map` object.
@@ -134,10 +133,8 @@ void make_grid(Triangulation<2> &triangulation)
 void write_dof_locations(const DoFHandler<2> &dof_handler,
                          const std::string &  filename)
 {
-  std::map<types::global_dof_index, Point<2>> dof_location_map;
-  DoFTools::map_dofs_to_support_points(MappingQ1<2>(),
-                                       dof_handler,
-                                       dof_location_map);
+  std::map<types::global_dof_index, Point<2>> dof_location_map =
+    DoFTools::map_dofs_to_support_points(MappingQ1<2>(), dof_handler);
 
   std::ofstream dof_location_file(filename);
   DoFTools::write_gnuplot_dof_support_point_info(dof_location_file,

--- a/examples/step-60/step-60.cc
+++ b/examples/step-60/step-60.cc
@@ -709,7 +709,7 @@ namespace Step60
     //
     // With the mapping in place, it is now possible to query what is the
     // location of all support points associated with the `embedded_dh`, by
-    // calling the method DoFTools::map_dofs_to_support_points.
+    // calling the method DoFTools::map_dofs_to_support_points().
     //
     // This method has two variants. One that does *not* take a Mapping, and
     // one that takes a Mapping. If you use the second type, like we are doing

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -2274,17 +2274,37 @@ namespace DoFTools
    * is of course dense, i.e., every DoF is to be found in it.
    *
    * @param[in] mapping The mapping from the reference cell to the real cell on
-   * which DoFs are defined.
+   *   which DoFs are defined.
    * @param[in] dof_handler The object that describes which DoF indices live on
-   * which cell of the triangulation.
-   * @param[in,out] support_points A map that for every locally relevant DoF
-   * index contains the corresponding location in real space coordinates.
-   * Previous content of this object is deleted in this function.
+   *   which cell of the triangulation.
    * @param[in] mask An optional component mask that restricts the
-   * components from which the support points are extracted.
+   *   components from which the support points are extracted.
+   * @return A map that for every locally relevant DoF
+   *   index contains the corresponding location in real space coordinates.
    */
   template <int dim, int spacedim>
-  void
+  std::map<types::global_dof_index, Point<spacedim>>
+  map_dofs_to_support_points(const Mapping<dim, spacedim> &   mapping,
+                             const DoFHandler<dim, spacedim> &dof_handler,
+                             const ComponentMask &mask = ComponentMask());
+
+  /**
+   * Same as the previous function but for the hp-case.
+   */
+  template <int dim, int spacedim>
+  std::map<types::global_dof_index, Point<spacedim>>
+  map_dofs_to_support_points(
+    const dealii::hp::MappingCollection<dim, spacedim> &mapping,
+    const DoFHandler<dim, spacedim> &                   dof_handler,
+    const ComponentMask &                               mask = ComponentMask());
+
+  /**
+   * A version of the function of same name that returns the map via its third
+   * argument. This function is deprecated.
+   * @deprecated Use the function that returns the `std::map` instead.
+   */
+  template <int dim, int spacedim>
+  DEAL_II_DEPRECATED_EARLY void
   map_dofs_to_support_points(
     const Mapping<dim, spacedim> &                      mapping,
     const DoFHandler<dim, spacedim> &                   dof_handler,
@@ -2292,10 +2312,12 @@ namespace DoFTools
     const ComponentMask &                               mask = ComponentMask());
 
   /**
-   * Same as the previous function but for the hp-case.
+   * A version of the function of same name that returns the map via its third
+   * argument. This function is deprecated.
+   * @deprecated Use the function that returns the `std::map` instead.
    */
   template <int dim, int spacedim>
-  void
+  DEAL_II_DEPRECATED_EARLY void
   map_dofs_to_support_points(
     const dealii::hp::MappingCollection<dim, spacedim> &mapping,
     const DoFHandler<dim, spacedim> &                   dof_handler,

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -2248,10 +2248,10 @@ namespace DoFTools
   template <int dim, int spacedim>
   void
   map_dofs_to_support_points(
-    const dealii::hp::MappingCollection<dim, spacedim> &mapping,
-    const DoFHandler<dim, spacedim> &                   dof_handler,
-    std::vector<Point<spacedim>> &                      support_points,
-    const ComponentMask &                               mask = ComponentMask());
+    const hp::MappingCollection<dim, spacedim> &mapping,
+    const DoFHandler<dim, spacedim> &           dof_handler,
+    std::vector<Point<spacedim>> &              support_points,
+    const ComponentMask &                       mask = ComponentMask());
 
   /**
    * This function is a version of the above map_dofs_to_support_points
@@ -2294,9 +2294,9 @@ namespace DoFTools
   template <int dim, int spacedim>
   std::map<types::global_dof_index, Point<spacedim>>
   map_dofs_to_support_points(
-    const dealii::hp::MappingCollection<dim, spacedim> &mapping,
-    const DoFHandler<dim, spacedim> &                   dof_handler,
-    const ComponentMask &                               mask = ComponentMask());
+    const hp::MappingCollection<dim, spacedim> &mapping,
+    const DoFHandler<dim, spacedim> &           dof_handler,
+    const ComponentMask &                       mask = ComponentMask());
 
   /**
    * A version of the function of same name that returns the map via its third
@@ -2319,7 +2319,7 @@ namespace DoFTools
   template <int dim, int spacedim>
   DEAL_II_DEPRECATED_EARLY void
   map_dofs_to_support_points(
-    const dealii::hp::MappingCollection<dim, spacedim> &mapping,
+    const hp::MappingCollection<dim, spacedim> &        mapping,
     const DoFHandler<dim, spacedim> &                   dof_handler,
     std::map<types::global_dof_index, Point<spacedim>> &support_points,
     const ComponentMask &                               mask = ComponentMask());

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -2143,13 +2143,14 @@ namespace DoFTools
     namespace
     {
       template <int dim, int spacedim>
-      void
+      std::map<types::global_dof_index, Point<spacedim>>
       map_dofs_to_support_points(
-        const hp::MappingCollection<dim, spacedim> &        mapping,
-        const DoFHandler<dim, spacedim> &                   dof_handler,
-        std::map<types::global_dof_index, Point<spacedim>> &support_points,
-        const ComponentMask &                               in_mask)
+        const hp::MappingCollection<dim, spacedim> &mapping,
+        const DoFHandler<dim, spacedim> &           dof_handler,
+        const ComponentMask &                       in_mask)
       {
+        std::map<types::global_dof_index, Point<spacedim>> support_points;
+
         const hp::FECollection<dim, spacedim> &fe_collection =
           dof_handler.get_fe_collection();
         hp::QCollection<dim> q_coll_dummy;
@@ -2208,23 +2209,24 @@ namespace DoFTools
                     support_points[local_dof_indices[i]] = points[i];
                 }
             }
+
+        return support_points;
       }
 
 
       template <int dim, int spacedim>
-      void
-      map_dofs_to_support_points(
+      std::vector<Point<spacedim>>
+      map_dofs_to_support_points_vector(
         const hp::MappingCollection<dim, spacedim> &mapping,
         const DoFHandler<dim, spacedim> &           dof_handler,
-        std::vector<Point<spacedim>> &              support_points,
         const ComponentMask &                       mask)
       {
+        std::vector<Point<spacedim>> support_points(dof_handler.n_dofs());
+
         // get the data in the form of the map as above
-        std::map<types::global_dof_index, Point<spacedim>> x_support_points;
-        map_dofs_to_support_points(mapping,
-                                   dof_handler,
-                                   x_support_points,
-                                   mask);
+        const std::map<types::global_dof_index, Point<spacedim>>
+          x_support_points =
+            map_dofs_to_support_points(mapping, dof_handler, mask);
 
         // now convert from the map to the linear vector. make sure every
         // entry really appeared in the map
@@ -2233,11 +2235,14 @@ namespace DoFTools
             Assert(x_support_points.find(i) != x_support_points.end(),
                    ExcInternalError());
 
-            support_points[i] = x_support_points[i];
+            support_points[i] = x_support_points.find(i)->second;
           }
+
+        return support_points;
       }
     } // namespace
   }   // namespace internal
+
 
   template <int dim, int spacedim>
   void
@@ -2258,10 +2263,10 @@ namespace DoFTools
     // gets a MappingCollection
     const hp::MappingCollection<dim, spacedim> mapping_collection(mapping);
 
-    internal::map_dofs_to_support_points(mapping_collection,
-                                         dof_handler,
-                                         support_points,
-                                         mask);
+    support_points =
+      internal::map_dofs_to_support_points_vector(mapping_collection,
+                                                  dof_handler,
+                                                  mask);
   }
 
 
@@ -2283,10 +2288,8 @@ namespace DoFTools
 
     // Let the internal function do all the work, just make sure that it
     // gets a MappingCollection
-    internal::map_dofs_to_support_points(mapping,
-                                         dof_handler,
-                                         support_points,
-                                         mask);
+    support_points =
+      internal::map_dofs_to_support_points_vector(mapping, dof_handler, mask);
   }
 
 
@@ -2304,10 +2307,9 @@ namespace DoFTools
     // gets a MappingCollection
     const hp::MappingCollection<dim, spacedim> mapping_collection(mapping);
 
-    internal::map_dofs_to_support_points(mapping_collection,
-                                         dof_handler,
-                                         support_points,
-                                         mask);
+    support_points = internal::map_dofs_to_support_points(mapping_collection,
+                                                          dof_handler,
+                                                          mask);
   }
 
 
@@ -2323,10 +2325,8 @@ namespace DoFTools
 
     // Let the internal function do all the work, just make sure that it
     // gets a MappingCollection
-    internal::map_dofs_to_support_points(mapping,
-                                         dof_handler,
-                                         support_points,
-                                         mask);
+    support_points =
+      internal::map_dofs_to_support_points(mapping, dof_handler, mask);
   }
 
   template <int spacedim>

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -2293,8 +2293,9 @@ namespace DoFTools
   }
 
 
+  // This functino is deprecated:
   template <int dim, int spacedim>
-  void
+  DEAL_II_DEPRECATED_EARLY void
   map_dofs_to_support_points(
     const Mapping<dim, spacedim> &                      mapping,
     const DoFHandler<dim, spacedim> &                   dof_handler,
@@ -2313,8 +2314,9 @@ namespace DoFTools
   }
 
 
+  // This functino is deprecated:
   template <int dim, int spacedim>
-  void
+  DEAL_II_DEPRECATED_EARLY void
   map_dofs_to_support_points(
     const hp::MappingCollection<dim, spacedim> &        mapping,
     const DoFHandler<dim, spacedim> &                   dof_handler,
@@ -2328,6 +2330,34 @@ namespace DoFTools
     support_points =
       internal::map_dofs_to_support_points(mapping, dof_handler, mask);
   }
+
+
+  template <int dim, int spacedim>
+  std::map<types::global_dof_index, Point<spacedim>>
+  map_dofs_to_support_points(const Mapping<dim, spacedim> &   mapping,
+                             const DoFHandler<dim, spacedim> &dof_handler,
+                             const ComponentMask &            mask)
+  {
+    // Let the internal function do all the work, just make sure that it
+    // gets a MappingCollection
+    const hp::MappingCollection<dim, spacedim> mapping_collection(mapping);
+
+    return internal::map_dofs_to_support_points(mapping_collection,
+                                                dof_handler,
+                                                mask);
+  }
+
+
+  template <int dim, int spacedim>
+  std::map<types::global_dof_index, Point<spacedim>>
+  map_dofs_to_support_points(
+    const hp::MappingCollection<dim, spacedim> &mapping,
+    const DoFHandler<dim, spacedim> &           dof_handler,
+    const ComponentMask &                       mask)
+  {
+    return internal::map_dofs_to_support_points(mapping, dof_handler, mask);
+  }
+
 
   template <int spacedim>
   void

--- a/source/dofs/dof_tools.inst.in
+++ b/source/dofs/dof_tools.inst.in
@@ -404,6 +404,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
         std::vector<Point<deal_II_space_dimension>> &,
         const ComponentMask &);
 
+      // This function is deprecated:
       template void
       map_dofs_to_support_points<deal_II_dimension, deal_II_space_dimension>(
         const Mapping<deal_II_dimension, deal_II_space_dimension> &,
@@ -411,12 +412,26 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
         std::map<types::global_dof_index, Point<deal_II_space_dimension>> &,
         const ComponentMask &);
 
+      // This function is deprecated:
       template void
       map_dofs_to_support_points<deal_II_dimension, deal_II_space_dimension>(
         const hp::MappingCollection<deal_II_dimension, deal_II_space_dimension>
           &,
         const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
         std::map<types::global_dof_index, Point<deal_II_space_dimension>> &,
+        const ComponentMask &);
+
+      template std::map<types::global_dof_index, Point<deal_II_space_dimension>>
+      map_dofs_to_support_points<deal_II_dimension, deal_II_space_dimension>(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const ComponentMask &);
+
+      template std::map<types::global_dof_index, Point<deal_II_space_dimension>>
+      map_dofs_to_support_points<deal_II_dimension, deal_II_space_dimension>(
+        const hp::MappingCollection<deal_II_dimension, deal_II_space_dimension>
+          &,
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
         const ComponentMask &);
     \}
 #endif

--- a/source/particles/generators.cc
+++ b/source/particles/generators.cc
@@ -468,12 +468,9 @@ namespace Particles
         (components.size() == 0 ? ComponentMask(fe.n_components(), true) :
                                   components);
 
-      std::map<types::global_dof_index, Point<spacedim>> support_points_map;
-
-      DoFTools::map_dofs_to_support_points(mapping,
-                                           dof_handler,
-                                           support_points_map,
-                                           mask);
+      const std::map<types::global_dof_index, Point<spacedim>>
+        support_points_map =
+          DoFTools::map_dofs_to_support_points(mapping, dof_handler, mask);
 
       // Generate the vector of points from the map
       // Memory is reserved for efficiency reasons


### PR DESCRIPTION
We now have move operators that apply to return objects, along with mandatory return value optimization. There is no readon not to use this.

This patch applies this to some internal functions. I will write a separate patch to make this the case for the public interfaces that call these functions.