### PR TITLE
Initialize Quadrature with move argument

### DIFF
--- a/include/deal.II/base/quadrature.h
+++ b/include/deal.II/base/quadrature.h
@@ -190,6 +190,13 @@ public:
              const std::vector<double> &    weights);
 
   /**
+   * Construct a quadrature formula from given vectors of quadrature points
+   * (which should really be in the unit cell) and the corresponding weights,
+   * moving the points and weights into the present object.
+   */
+  Quadrature(std::vector<Point<dim>> &&points, std::vector<double> &&weights);
+
+  /**
    * Construct a dummy quadrature formula from a list of points, with weights
    * set to infinity. The resulting object is therefore not meant to actually
    * perform integrations, but rather to be used with FEValues objects in

--- a/source/base/quadrature.cc
+++ b/source/base/quadrature.cc
@@ -74,6 +74,19 @@ Quadrature<dim>::Quadrature(const std::vector<Point<dim>> &points,
 
 
 template <int dim>
+Quadrature<dim>::Quadrature(std::vector<Point<dim>> &&points,
+                            std::vector<double> &&    weights)
+  : quadrature_points(std::move(points))
+  , weights(std::move(weights))
+  , is_tensor_product_flag(dim == 1)
+{
+  Assert(weights.size() == points.size(),
+         ExcDimensionMismatch(weights.size(), points.size()));
+}
+
+
+
+template <int dim>
 Quadrature<dim>::Quadrature(const std::vector<Point<dim>> &points)
   : quadrature_points(points)
   , weights(points.size(), std::numeric_limits<double>::infinity())


### PR DESCRIPTION
While looking at #15035, I realized that our `QProjector` class uses many instances of the type https://github.com/dealii/dealii/blob/24f24820f69495746618e6599870b9b5877f09e7/source/base/qprojector.cc#L861

As we construct both these arrays in place, I wonder whether we should provide a constructor of `Quadrature` with move arguments, in order to avoid allocating memory for a second time. In my local experiments, this does exactly what I hoped for. I will soon push another PR with some clean-ups on `QProjector` where this can be seen.