### PR TITLE
Do not infringe on the compiler's use of names.

### DIFF
--- a/source/lac/petsc_communication_pattern.cc
+++ b/source/lac/petsc_communication_pattern.cc
@@ -23,12 +23,12 @@
 
 DEAL_II_NAMESPACE_OPEN
 // Shorthand notation for PETSc error codes.
-#  define AssertPETSc(code)                              \
-    do                                                   \
-      {                                                  \
-        PetscErrorCode __ierr = (code);                  \
-        AssertThrow(__ierr == 0, ExcPETScError(__ierr)); \
-      }                                                  \
+#  define AssertPETSc(code)                          \
+    do                                               \
+      {                                              \
+        PetscErrorCode ierr = (code);                \
+        AssertThrow(ierr == 0, ExcPETScError(ierr)); \
+      }                                              \
     while (0)
 
 namespace PETScWrappers


### PR DESCRIPTION
The C++ standard reserves all variables starting with either underscore+Capital letter, or starting with two underscores for compiler and standard library use. Stay away from such symbols.

@stefanozampini FYI.