### PR TITLE
Avoid using include with quotation marks

### DIFF
--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -2141,7 +2141,7 @@ DoFInvalidAccessor<structdim, dim, spacedim>::DoFInvalidAccessor(
 DEAL_II_NAMESPACE_CLOSE
 
 // include more templates
-#include "dof_accessor.templates.h"
+#include <deal.II/dofs/dof_accessor.templates.h>
 
 
 #endif

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -4289,6 +4289,6 @@ TriaAccessor<3, 3, 3>::set_all_manifold_ids(const types::manifold_id) const;
 DEAL_II_NAMESPACE_CLOSE
 
 // include more templates in debug and optimized mode
-#include "tria_accessor.templates.h"
+#include <deal.II/grid/tria_accessor.templates.h>
 
 #endif

--- a/include/deal.II/matrix_free/cuda_fe_evaluation.h
+++ b/include/deal.II/matrix_free/cuda_fe_evaluation.h
@@ -18,10 +18,9 @@
 
 #include <deal.II/base/config.h>
 
-#include "deal.II/base/memory_space.h"
-
 #ifdef DEAL_II_WITH_CUDA
 
+#  include <deal.II/base/memory_space.h>
 #  include <deal.II/base/tensor.h>
 #  include <deal.II/base/utilities.h>
 

--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -19,9 +19,6 @@
 
 #include <deal.II/base/config.h>
 
-#include "deal.II/base/memory_space.h"
-#include "deal.II/base/utilities.h"
-
 #ifdef DEAL_II_WITH_CUDA
 
 #  include <deal.II/base/cuda_size.h>
@@ -30,6 +27,7 @@
 #  include <deal.II/base/partitioner.h>
 #  include <deal.II/base/quadrature.h>
 #  include <deal.II/base/tensor.h>
+#  include <deal.II/base/utilities.h>
 
 #  include <deal.II/dofs/dof_handler.h>
 

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -19,17 +19,12 @@
 
 #include <deal.II/base/config.h>
 
-#include "deal.II/base/memory_space.h"
-
-#include <deal.II/matrix_free/cuda_matrix_free.h>
-
-#include <string>
-
 #ifdef DEAL_II_WITH_CUDA
 
 #  include <deal.II/base/cuda.h>
 #  include <deal.II/base/cuda_size.h>
 #  include <deal.II/base/graph_coloring.h>
+#  include <deal.II/base/memory_space.h>
 
 #  include <deal.II/dofs/dof_tools.h>
 
@@ -38,6 +33,7 @@
 #  include <deal.II/fe/mapping_q1.h>
 
 #  include <deal.II/matrix_free/cuda_hanging_nodes_internal.h>
+#  include <deal.II/matrix_free/cuda_matrix_free.h>
 #  include <deal.II/matrix_free/shape_info.h>
 
 #  include <Kokkos_Core.hpp>
@@ -45,6 +41,7 @@
 
 #  include <cmath>
 #  include <functional>
+#  include <string>
 
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/base/polynomials_rt_bubbles.cc
+++ b/source/base/polynomials_rt_bubbles.cc
@@ -14,8 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-#include "deal.II/base/polynomials_rt_bubbles.h"
-
+#include <deal.II/base/polynomials_rt_bubbles.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/thread_management.h>
 


### PR DESCRIPTION
Mostly just for consistency.