### PR TITLE
Map boundary to bulk dof iterators.

### DIFF
--- a/doc/news/changes/minor/20230412LucaHeltai
+++ b/doc/news/changes/minor/20230412LucaHeltai
@@ -1,0 +1,7 @@
+New: Added a function DoFTools::map_boundary_to_bulk_dof_iterators() that 
+generates a mapping of codimension-1 active DoFHandler cell iterators to
+codimension-0 cells and face indices, to couple DoFHandler objects of different
+co-dimensions, initialized on grids generated with
+GridTools::extract_boundary_mesh()
+<br>
+(Luca Heltai, 2023/04/12)

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -1381,13 +1381,13 @@ namespace DoFTools
       c0_to_c1;
 
     // map volume mesh face -> codimension 1 dof cell
-    for (auto c1_cell : c1_dh.active_cell_iterators())
+    for (const auto &c1_cell : c1_dh.active_cell_iterators())
       if (c1_to_c0.find(c1_cell) != c1_to_c0.end())
         c0_to_c1[c1_to_c0.at(c1_cell)] = c1_cell;
 
     // generate a mapping that maps codimension-1 cells
     // to codimension-0 cells and faces
-    for (auto cell :
+    for (const auto &cell :
          c0_dh.active_cell_iterators()) // disp_dof.active_cell_iterators())
       for (const auto f : cell->face_indices())
         if (cell->face(f)->at_boundary() &&

--- a/source/dofs/dof_tools.inst.in
+++ b/source/dofs/dof_tools.inst.in
@@ -484,3 +484,28 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
     \}
 #endif
   }
+
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
+  {
+#if deal_II_dimension >= 2 && (deal_II_dimension <= deal_II_space_dimension)
+    namespace DoFTools
+    \{
+      template std::map<
+        typename DoFHandler<deal_II_dimension - 1,
+                            deal_II_space_dimension>::active_cell_iterator,
+        std::pair<
+          typename DoFHandler<deal_II_dimension,
+                              deal_II_space_dimension>::active_cell_iterator,
+          unsigned int>>
+      map_boundary_to_bulk_dof_iterators<deal_II_dimension,
+                                         deal_II_space_dimension>(
+        const std::map<
+          typename Triangulation<deal_II_dimension - 1,
+                                 deal_II_space_dimension>::cell_iterator,
+          typename Triangulation<deal_II_dimension,
+                                 deal_II_space_dimension>::face_iterator> &,
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const DoFHandler<deal_II_dimension - 1, deal_II_space_dimension> &);
+    \}
+#endif
+  }

--- a/tests/dofs/map_boundary_to_bulk_dof_iterators_01.cc
+++ b/tests/dofs/map_boundary_to_bulk_dof_iterators_01.cc
@@ -1,0 +1,90 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2023 by the deal.II authors
+//
+//    This file is subject to LGPL and may not be distributed
+//    without copyright and license information. Please refer
+//    to the file deal.II/doc/license.html for the  text  and
+//    further information on this license.
+//
+//-----------------------------------------------------------
+
+// Test map_boundary_to_bulk_dof_iterators
+
+#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/manifold_lib.h>
+#include <deal.II/grid/tria.h>
+
+#include "../tests.h"
+
+
+
+template <int dim>
+void
+test()
+{
+  Triangulation<dim>          triangulation;
+  Triangulation<dim - 1, dim> surface_triangulation;
+
+  FE_Q<dim>       fe(1);
+  DoFHandler<dim> dof_handler(triangulation);
+
+  FE_Q<dim - 1, dim>       surface_fe(1);
+  DoFHandler<dim - 1, dim> surface_dof_handler(surface_triangulation);
+
+  GridGenerator::half_hyper_ball(triangulation);
+  triangulation.refine_global(4 - dim);
+
+  surface_triangulation.set_manifold(0, SphericalManifold<dim - 1, dim>());
+  const auto surface_to_bulk_map =
+    GridGenerator::extract_boundary_mesh(triangulation,
+                                         surface_triangulation,
+                                         {0});
+
+  deallog << "Bulk mesh active cells:" << triangulation.n_active_cells()
+          << std::endl
+          << "Surface mesh active cells:"
+          << surface_triangulation.n_active_cells() << std::endl;
+
+  dof_handler.distribute_dofs(fe);
+  surface_dof_handler.distribute_dofs(surface_fe);
+
+  // Log degrees of freedom:
+  deallog << "Bulk mesh degrees of freedom:" << dof_handler.n_dofs()
+          << std::endl
+          << "Surface mesh degrees of freedom:" << surface_dof_handler.n_dofs()
+          << std::endl;
+
+  // Extract the mapping between surface and bulk degrees of freedom:
+  const auto surface_to_bulk_dof_iterator_map =
+    DoFTools::map_boundary_to_bulk_dof_iterators(surface_to_bulk_map,
+                                                 dof_handler,
+                                                 surface_dof_handler);
+
+  // Loop over the map, and print some information:
+  for (const auto &p : surface_to_bulk_dof_iterator_map)
+    {
+      const auto &surface_cell = p.first;
+      const auto &bulk_cell    = p.second.first;
+      const auto &bulk_face    = p.second.second;
+      deallog << "Surface cell " << surface_cell << " coincides with face "
+              << bulk_face << " of bulk cell " << bulk_cell << std::endl;
+    }
+}
+
+
+
+int
+main()
+{
+  initlog();
+
+  test<2>();
+  test<3>();
+}

--- a/tests/dofs/map_boundary_to_bulk_dof_iterators_01.output
+++ b/tests/dofs/map_boundary_to_bulk_dof_iterators_01.output
@@ -1,0 +1,41 @@
+
+DEAL::Bulk mesh active cells:64
+DEAL::Surface mesh active cells:12
+DEAL::Bulk mesh degrees of freedom:77
+DEAL::Surface mesh degrees of freedom:13
+DEAL::Surface cell 2.0 coincides with face 2 of bulk cell 2.5
+DEAL::Surface cell 2.1 coincides with face 2 of bulk cell 2.4
+DEAL::Surface cell 2.2 coincides with face 2 of bulk cell 2.1
+DEAL::Surface cell 2.3 coincides with face 2 of bulk cell 2.0
+DEAL::Surface cell 2.4 coincides with face 2 of bulk cell 2.37
+DEAL::Surface cell 2.5 coincides with face 2 of bulk cell 2.36
+DEAL::Surface cell 2.6 coincides with face 2 of bulk cell 2.33
+DEAL::Surface cell 2.7 coincides with face 2 of bulk cell 2.32
+DEAL::Surface cell 2.8 coincides with face 0 of bulk cell 2.48
+DEAL::Surface cell 2.9 coincides with face 0 of bulk cell 2.50
+DEAL::Surface cell 2.10 coincides with face 0 of bulk cell 2.56
+DEAL::Surface cell 2.11 coincides with face 0 of bulk cell 2.58
+DEAL::Bulk mesh active cells:48
+DEAL::Surface mesh active cells:20
+DEAL::Bulk mesh degrees of freedom:77
+DEAL::Surface mesh degrees of freedom:25
+DEAL::Surface cell 1.0 coincides with face 4 of bulk cell 1.0
+DEAL::Surface cell 1.1 coincides with face 4 of bulk cell 1.2
+DEAL::Surface cell 1.2 coincides with face 4 of bulk cell 1.1
+DEAL::Surface cell 1.3 coincides with face 4 of bulk cell 1.3
+DEAL::Surface cell 1.4 coincides with face 0 of bulk cell 1.8
+DEAL::Surface cell 1.5 coincides with face 0 of bulk cell 1.12
+DEAL::Surface cell 1.6 coincides with face 0 of bulk cell 1.10
+DEAL::Surface cell 1.7 coincides with face 0 of bulk cell 1.14
+DEAL::Surface cell 1.8 coincides with face 4 of bulk cell 1.24
+DEAL::Surface cell 1.9 coincides with face 4 of bulk cell 1.26
+DEAL::Surface cell 1.10 coincides with face 4 of bulk cell 1.25
+DEAL::Surface cell 1.11 coincides with face 4 of bulk cell 1.27
+DEAL::Surface cell 1.12 coincides with face 0 of bulk cell 1.32
+DEAL::Surface cell 1.13 coincides with face 0 of bulk cell 1.36
+DEAL::Surface cell 1.14 coincides with face 0 of bulk cell 1.34
+DEAL::Surface cell 1.15 coincides with face 0 of bulk cell 1.38
+DEAL::Surface cell 1.16 coincides with face 0 of bulk cell 1.40
+DEAL::Surface cell 1.17 coincides with face 0 of bulk cell 1.44
+DEAL::Surface cell 1.18 coincides with face 0 of bulk cell 1.42
+DEAL::Surface cell 1.19 coincides with face 0 of bulk cell 1.46


### PR DESCRIPTION
This function generates a mapping of codimension-1 active DoFHandler cell
iterators to codimension-0 cells and face indices, for DoFHandler objects
built on top of the boundary of a given `Triangulation<spacedim>`.
If you need to couple a PDE defined on the surface of an existing
Triangulation (as in step-38) with the PDE defined on the bulk (say, for
example, a hyper ball and its boundary), the information that is returned
by the function GridGenerator::extract_boundary_mesh() is not enough, since
you need to build FEValues objects on active cell iterators of the
DoFHandler defined on the surface mesh, and FEFaceValues objects on face
iterators of the DoFHandler defined on the bulk mesh. This second step
requires knowledge of the bulk cell iterator and of the corresponding face
index.
This function examines the map `c1_to_c0` returned by
GridGenerator::extract_boundary_mesh() (when used with two Triangulation
objects as input), and associates to each active cell iterator of the
`c1_dh` DoFHandler that is also contained in the map `c1_to_c0`, a pair of
corresponding active bulk cell iterator of `c0_dh`, and face index
corresponding to the cell iterator on the surface mesh.