### PR TITLE
Allow template argument deduction in ndarray

### DIFF
--- a/include/deal.II/base/ndarray.h
+++ b/include/deal.II/base/ndarray.h
@@ -105,7 +105,21 @@ namespace internal
  * `std::array` classes.
  */
 template <typename T, std::size_t... Ns>
-using ndarray = typename internal::ndarray::HelperArray<T, Ns...>::type;
+struct ndarray : internal::ndarray::HelperArray<T, Ns...>::type
+{
+  using Base          = typename internal::ndarray::HelperArray<T, Ns...>::type;
+  constexpr ndarray() = default;
+  constexpr ndarray(const Base &rhs)
+    : Base(rhs)
+  {}
+  constexpr ndarray(const std::initializer_list<typename Base::value_type> &l)
+    : Base{}
+  {
+    std::size_t i = 0;
+    for (auto first = l.begin(); first != l.end(); ++first, ++i)
+      (*this)[i] = *first;
+  }
+};
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -1122,7 +1122,7 @@ FEPointEvaluation<n_components, dim, spacedim, Number>::do_reinit()
             make_array_view(shapes.begin() + qb * n_shapes,
                             shapes.begin() + (qb * n_shapes + n_shapes));
 
-          internal::compute_values_of_array(view, poly, vectorized_points);
+          internal::compute_values_of_array<dim>(view, poly, vectorized_points);
         }
     }
 

--- a/include/deal.II/matrix_free/tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/tensor_product_kernels.h
@@ -3257,7 +3257,7 @@ namespace internal
 
         auto view = make_array_view(shapes);
 
-        compute_values_of_array(view, poly, p);
+        compute_values_of_array<dim>(view, poly, p);
 
         return evaluate_tensor_product_value_and_gradient_shapes<dim,
                                                                  Number,


### PR DESCRIPTION
We noticed in https://github.com/dealii/dealii/pull/15063#discussion_r1162499760 that we can't use `ndarray` with template argument deduction (because that only works with CTAD in C++20, see https://en.cppreference.com/w/cpp/language/template_argument_deduction).
This pull request defines a fix for this by inheriting from the implementation type rather than using it as an alias, see https://godbolt.org/z/e8rEfWrd3.

I can clean up the documentation some more of we decide that we would want to move in this direction.