### PR TITLE
Don't mention wrong defaults in CompressionFlags

### DIFF
--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -215,8 +215,7 @@ namespace DataOutBase
      */
     best_speed,
     /**
-     * Use the algorithm which results in the smallest compressed
-     * files. This is the default flag.
+     * Use the algorithm which results in the smallest compressed files.
      */
     best_compression,
     /**


### PR DESCRIPTION
Whatever is the default is decided in the respective structs for the flags.

fyi @c-p-schmidt 