### PR TITLE
Add a check and produce better errors in FEInterfaceValues::reinit().

### DIFF
--- a/doc/news/changes/minor/20230413Bangerth
+++ b/doc/news/changes/minor/20230413Bangerth
@@ -1,0 +1,7 @@
+Fixed: In FEInterfaceValues::reinit(), if `q_index` is not explicitly
+given but none of the two adjacent elements dominates the other, one
+used to get a rather obscure error. The error now produced points at
+the actual problem, and a much expanded discussion of what is going
+wrong is provided in the documentation of the function.
+<br>
+(Simon Sticko, Wolfgang Bangerth, 2023/04/13)

--- a/include/deal.II/fe/fe_interface_values.h
+++ b/include/deal.II/fe/fe_interface_values.h
@@ -2495,6 +2495,24 @@ FEInterfaceValues<dim, spacedim>::reinit(
         internal_hp_fe_face_values->get_fe_collection().find_dominated_fe(
           {cell->active_fe_index(), cell_neighbor->active_fe_index()});
 
+      if (q_index == numbers::invalid_unsigned_int)
+        Assert(dominated_fe_index != numbers::invalid_fe_index,
+               ExcMessage("You called this function with 'q_index' left at its "
+                          "default value, but this can only work if one of "
+                          "the two finite elements adjacent to this face "
+                          "dominates the other. See the documentation "
+                          "of this function for more information of how "
+                          "to deal with this situation."));
+      if (mapping_index == numbers::invalid_unsigned_int)
+        Assert(dominated_fe_index != numbers::invalid_fe_index,
+               ExcMessage("You called this function with 'mapping_index' left "
+                          "at its default value, but this can only work if one "
+                          "of the two finite elements adjacent to this face "
+                          "dominates the other. See the documentation "
+                          "of this function for more information of how "
+                          "to deal with this situation."));
+
+
       const unsigned int used_q_index =
         (q_index == numbers::invalid_unsigned_int ? dominated_fe_index :
                                                     q_index);


### PR DESCRIPTION
This fixes #15095, fixes #15021, and makes part of #15038 unnecessary. It also supersedes #15031. It also makes sure that the error mentioned in #15098 is sensible.

I have verified that the error message one gets with the test case in #15021 is now reasonable.