### PR TITLE
extend distributed_compute_point_locations

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -1108,6 +1108,16 @@ namespace GridTools
    *   of the cells adjacent to a vertex or an edge/face this function returns.
    *   Consequently, algorithms that call this function need to take into
    *   account that the returned cell will only contain the point approximately.
+   * @param[in] enforce_unique_mapping Enforce a one to one mapping between
+   points
+   *   in real and reference space.
+   * @param[in] marked_vertices An array of bools indicating which
+   * vertices of @p mesh will be considered within the search
+   * as the potentially closest vertex. On receiving a non-empty
+   * @p marked_vertices, the function will
+   * only search among @p marked_vertices for the closest vertex,
+   * otherwise on all vertices in the mesh.
+
    * @return A tuple containing the quadrature information
    *
    * The elements of the output tuple are:
@@ -1164,7 +1174,9 @@ namespace GridTools
     const GridTools::Cache<dim, spacedim> &                cache,
     const std::vector<Point<spacedim>> &                   local_points,
     const std::vector<std::vector<BoundingBox<spacedim>>> &global_bboxes,
-    const double                                           tolerance = 1e-10);
+    const double                                           tolerance = 1e-10,
+    const std::vector<bool> &                              marked_vertices = {},
+    const bool enforce_unique_mapping = true);
 
   namespace internal
   {

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -5924,12 +5924,20 @@ namespace GridTools
     const GridTools::Cache<dim, spacedim> &                cache,
     const std::vector<Point<spacedim>> &                   points,
     const std::vector<std::vector<BoundingBox<spacedim>>> &global_bboxes,
-    const double                                           tolerance)
+    const double                                           tolerance,
+    const std::vector<bool> &                              marked_vertices,
+    const bool enforce_unique_mapping)
   {
     // run internal function ...
-    const auto all = internal::distributed_compute_point_locations(
-                       cache, points, global_bboxes, {}, tolerance, false, true)
-                       .send_components;
+    const auto all =
+      internal::distributed_compute_point_locations(cache,
+                                                    points,
+                                                    global_bboxes,
+                                                    marked_vertices,
+                                                    tolerance,
+                                                    false,
+                                                    enforce_unique_mapping)
+        .send_components;
 
     // ... and reshuffle the data
     std::tuple<

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -137,7 +137,9 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
         const Cache<deal_II_dimension, deal_II_space_dimension> &,
         const std::vector<Point<deal_II_space_dimension>> &,
         const std::vector<std::vector<BoundingBox<deal_II_space_dimension>>> &,
-        const double tolerance);
+        const double             tolerance,
+        const std::vector<bool> &marked_vertices,
+        const bool               enforce_unique_mapping);
 
       template internal::DistributedComputePointLocationsInternal<
         deal_II_dimension,


### PR DESCRIPTION
I want to use ```distributed_compute_point_locations``` in combination with ```enforce_unique_mapping=false```. Since this function just calls the internal one, the needed changes are just to forward the arguments. I also added ```marked_vfertices``` to the function signature to be able to specify it as well.

@peterrum 