### PR TITLE
Fix heading level in step-7 results.dox.

### DIFF
--- a/examples/step-7/doc/results.dox
+++ b/examples/step-7/doc/results.dox
@@ -187,7 +187,7 @@ here) that is written into a file in a way so that it could be
 copy-pasted into a LaTeX document.
 
 
-<h4> When is the error "small"? </h4>
+<h3> When is the error "small"? </h3>
 
 What we showed above is how to determine the size of the error
 $\|u-u_h\|$ in a number of different norms. We did this primarily


### PR DESCRIPTION
We currently have a section at the wrong level, see top right of this picture: 
![image](https://user-images.githubusercontent.com/7504421/232844222-8518316b-266e-428b-bb45-d21b0884c036.png)
