### PR TITLE
Remove PETSc compatibility things.

### DIFF
--- a/include/deal.II/lac/petsc_compatibility.h
+++ b/include/deal.II/lac/petsc_compatibility.h
@@ -39,19 +39,13 @@ namespace PETScWrappers
 {
   /**
    * Set an option in the global PETSc database. This function just wraps
-   * PetscOptionsSetValue with a version check (the signature of this function
-   * changed in PETSc 3.7.0).
+   * PetscOptionsSetValue and checks the error return value.
    */
   inline void
   set_option_value(const std::string &name, const std::string &value)
   {
-#  if DEAL_II_PETSC_VERSION_LT(3, 7, 0)
-    const PetscErrorCode ierr =
-      PetscOptionsSetValue(name.c_str(), value.c_str());
-#  else
     const PetscErrorCode ierr =
       PetscOptionsSetValue(nullptr, name.c_str(), value.c_str());
-#  endif
     AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 

--- a/source/lac/petsc_precondition.cc
+++ b/source/lac/petsc_precondition.cc
@@ -114,11 +114,7 @@ namespace PETScWrappers
 
     create_pc_with_comm(comm);
 
-#  if DEAL_II_PETSC_VERSION_LT(3, 5, 0)
-    ierr = PCSetOperators(pc, matrix, matrix, SAME_PRECONDITIONER);
-#  else
     ierr = PCSetOperators(pc, matrix, matrix);
-#  endif
     AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 
@@ -1098,11 +1094,7 @@ namespace PETScWrappers
   {
     initialize(matrix.get_mpi_communicator());
     PetscErrorCode ierr;
-#  if DEAL_II_PETSC_VERSION_LT(3, 5, 0)
-    ierr = PCSetOperators(pc, matrix, matrix, DIFFERENT_NONZERO_PATTERN);
-#  else
     ierr = PCSetOperators(pc, matrix, matrix);
-#  endif
     AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 


### PR DESCRIPTION
We check in cmake that we have PETSc 3.7 or later, so we no longer need to support older versions.