### PR TITLE
Make it possible to document C++20 requirements (and do so).

### DIFF
--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -93,6 +93,8 @@ ALIASES += dealiiWriggersA{2}="@note For a discussion of the background of this 
 
 ALIASES += dealiiHolzapfelA{2}="@note For a discussion of the background of this function, see G. A. Holzapfel: \"Nonlinear solid mechanics. A Continuum Approach for Engineering\" (2007), and in particular formula (\2) on p. \1 (or thereabouts). "
 
+ALIASES += dealiiConceptRequires{1}="@note This class, function, or variable is a template, and it can only be instantiated if the following condition is true: @code \1 @endcode If your compiler supports the C++20 standard, then this constraint will be enforced by a [C++20 requires clause](https://en.cppreference.com/w/cpp/language/constraints)."
+
 #---------------------------------------------------------------------------
 # configuration options related to source browsing
 #---------------------------------------------------------------------------

--- a/include/deal.II/base/parallel.h
+++ b/include/deal.II/base/parallel.h
@@ -131,6 +131,12 @@ namespace parallel
    * applicable, see the
    * @ref threads "Parallel computing with multiple processors"
    * module.
+   *
+   * @dealiiConceptRequires{(std::invocable<Function,
+   *    decltype(*std::declval<InputIterator>())> &&
+   *    std::assignable_from<decltype(*std::declval<OutputIterator>()),
+   *    std::invoke_result_t<Function,
+   * decltype(*std::declval<InputIterator>())>>)}
    */
   template <typename InputIterator, typename OutputIterator, typename Function>
   DEAL_II_CXX20_REQUIRES(
@@ -192,6 +198,14 @@ namespace parallel
    * applicable, see the
    * @ref threads "Parallel computing with multiple processors"
    * module.
+   *
+   * @dealiiConceptRequires{(std::invocable<Function,
+   *    decltype(*std::declval<InputIterator1>()),
+   *    decltype(*std::declval<InputIterator2>())> &&
+   *    std::assignable_from<decltype(*std::declval<OutputIterator>()),
+   *    std::invoke_result_t<Function,
+   * decltype(*std::declval<InputIterator1>()),
+   *    decltype(*std::declval<InputIterator2>())>>)}
    */
   template <typename InputIterator1,
             typename InputIterator2,
@@ -261,6 +275,16 @@ namespace parallel
    * applicable, see the
    * @ref threads "Parallel computing with multiple processors"
    * module.
+   *
+   * @dealiiConceptRequires{(std::invocable<Function,
+   *    decltype(*std::declval<InputIterator1>()),
+   *    decltype(*std::declval<InputIterator2>()),
+   *    decltype(*std::declval<InputIterator3>())> &&
+   *    std::assignable_from<decltype(*std::declval<OutputIterator>()),
+   *    std::invoke_result_t<Function,
+   * decltype(*std::declval<InputIterator1>()),
+   *    decltype(*std::declval<InputIterator2>()),
+   *    decltype(*std::declval<InputIterator3>())>>)}
    */
   template <typename InputIterator1,
             typename InputIterator2,
@@ -321,6 +345,8 @@ namespace parallel
     /**
      * Take a range argument and call the given function with its begin and
      * end.
+     *
+     * @dealiiConceptRequires{(std::invocable<Function, Iterator, Iterator>)}
      */
     template <typename Iterator, typename Function>
     DEAL_II_CXX20_REQUIRES((std::invocable<Function, Iterator, Iterator>))
@@ -401,6 +427,8 @@ namespace parallel
    * applicable, see also the
    * @ref threads "Parallel computing with multiple processors"
    * module.
+   *
+   * @dealiiConceptRequires{(std::invocable<Function, Iterator, Iterator>)}
    */
   template <typename Iterator, typename Function>
   DEAL_II_CXX20_REQUIRES((std::invocable<Function, Iterator, Iterator>))
@@ -547,6 +575,10 @@ namespace parallel
    * applicable, see also the
    * @ref threads "Parallel computing with multiple processors"
    * module.
+   *
+   * @dealiiConceptRequires{(std::invocable<Function, Iterator, Iterator> &&
+   *    std::convertible_to<std::invoke_result_t<Function, Iterator, Iterator>,
+   *    ResultType>)}
    */
   template <typename ResultType, typename Iterator, typename Function>
   DEAL_II_CXX20_REQUIRES(

--- a/include/deal.II/base/point.h
+++ b/include/deal.II/base/point.h
@@ -103,6 +103,8 @@ DEAL_II_NAMESPACE_OPEN
  *
  *
  * @ingroup geomprimitives
+ *
+ * @dealiiConceptRequires{dim >= 0}
  */
 template <int dim, typename Number = double>
 DEAL_II_CXX20_REQUIRES(dim >= 0)
@@ -668,6 +670,8 @@ inline DEAL_II_HOST_DEVICE
  * Output operator for points. Print the elements consecutively, with a space
  * in between.
  * @relatesalso Point
+ *
+ * @dealiiConceptRequires{dim >= 0}
  */
 template <int dim, typename Number>
 DEAL_II_CXX20_REQUIRES(dim >= 0)
@@ -686,6 +690,8 @@ operator<<(std::ostream &out, const Point<dim, Number> &p)
 /**
  * Input operator for points. Inputs the elements consecutively.
  * @relatesalso Point
+ *
+ * @dealiiConceptRequires{dim >= 0}
  */
 template <int dim, typename Number>
 DEAL_II_CXX20_REQUIRES(dim >= 0)

--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -790,6 +790,8 @@ namespace Threads
    * @deprecated Use std::thread or std::jthread instead.
    *
    * @ingroup CPP11
+   *
+   * @dealiiConceptRequires{(std::invocable<FunctionObjectType>)}
    */
   template <typename FunctionObjectType>
   DEAL_II_CXX20_REQUIRES((std::invocable<FunctionObjectType>))
@@ -916,6 +918,9 @@ namespace Threads
   {
     /**
      * Set the value of a std::promise object by evaluating the action.
+     *
+     * @dealiiConceptRequires{(std::invocable<Function> &&
+     *    std::convertible_to<std::invoke_result_t<Function>, RT>)}
      */
     template <typename RT, typename Function>
     DEAL_II_CXX20_REQUIRES(
@@ -933,6 +938,8 @@ namespace Threads
      * for the case where the return type is `void`. Consequently, we
      * can't set a value. But we do evaluate the function object and
      * call `std::promise::set_value()` without argument.
+     *
+     * @dealiiConceptRequires{(std::invocable<Function>)}
      */
     template <typename Function>
     DEAL_II_CXX20_REQUIRES((std::invocable<Function>))
@@ -1566,6 +1573,8 @@ namespace Threads
    *   for more information.
    *
    * @ingroup CPP11
+   *
+   * @dealiiConceptRequires{(std::invocable<FunctionObjectType>)}
    */
   template <typename FunctionObjectType>
   DEAL_II_CXX20_REQUIRES((std::invocable<FunctionObjectType>))

--- a/include/deal.II/distributed/fully_distributed_tria.h
+++ b/include/deal.II/distributed/fully_distributed_tria.h
@@ -105,6 +105,8 @@ namespace parallel
      * @note Currently only simple periodicity conditions (i.e. without offsets
      *       and rotation matrices - see also the documentation of
      *       GridTools::collect_periodic_faces()) are supported.
+     *
+     * @dealiiConceptRequires{(concepts::is_valid_dim_spacedim<dim, spacedim>)}
      */
     template <int dim, int spacedim = dim>
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))

--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -101,6 +101,8 @@ namespace parallel
      * mesh.
      *
      * @ingroup distributed
+     *
+     * @dealiiConceptRequires{(concepts::is_valid_dim_spacedim<dim, spacedim>)}
      */
     template <int dim, int spacedim = dim>
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
@@ -430,6 +432,8 @@ namespace parallel
      * Since the constructor of this class is deleted, no such objects
      * can actually be created as this would be pointless given that
      * MPI is not available.
+     *
+     * @dealiiConceptRequires{(concepts::is_valid_dim_spacedim<dim, spacedim>)}
      */
     template <int dim, int spacedim = dim>
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -240,6 +240,8 @@ namespace parallel
      *
      *
      * @ingroup distributed
+     *
+     * @dealiiConceptRequires{(concepts::is_valid_dim_spacedim<dim, spacedim>)}
      */
     template <int dim, int spacedim = dim>
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
@@ -851,6 +853,8 @@ namespace parallel
      * Specialization of the general template for the 1d case. There is
      * currently no support for distributing 1d triangulations. Consequently,
      * all this class does is throw an exception.
+     *
+     * @dealiiConceptRequires{(concepts::is_valid_dim_spacedim<1, spacedim>)}
      */
     template <int spacedim>
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<1, spacedim>))
@@ -992,6 +996,8 @@ namespace parallel
      * Since the constructor of this class is deleted, no such objects
      * can actually be created as this would be pointless given that
      * p4est is not available.
+     *
+     * @dealiiConceptRequires{(concepts::is_valid_dim_spacedim<dim, spacedim>)}
      */
     template <int dim, int spacedim = dim>
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))

--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -428,6 +428,8 @@ namespace parallel
    *       return false;
    *   }
    * @endcode
+   *
+   * @dealiiConceptRequires{(concepts::is_valid_dim_spacedim<dim, spacedim>)}
    */
   template <int dim, int spacedim = dim>
   DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -309,6 +309,8 @@ namespace parallel
  * parallel::distributed::SolutionTransfer for more information.
  *
  * @ingroup dofs
+ *
+ * @dealiiConceptRequires{(concepts::is_valid_dim_spacedim<dim, spacedim>)}
  */
 template <int dim, int spacedim = dim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))

--- a/include/deal.II/grid/filtered_iterator.h
+++ b/include/deal.II/grid/filtered_iterator.h
@@ -641,6 +641,8 @@ public:
   /**
    * Constructor. Set the iterator to the default state and use the given
    * predicate for filtering subsequent assignment and iteration.
+   *
+   * @dealiiConceptRequires{(std::predicate<Predicate, BaseIterator>)}
    */
   template <typename Predicate>
   DEAL_II_CXX20_REQUIRES((std::predicate<Predicate, BaseIterator>))
@@ -662,6 +664,8 @@ public:
    * If the cell <code>triangulation.begin_active()</code> does not have a
    * subdomain_id equal to 13, then the iterator will automatically be
    * advanced to the first cell that has.
+   *
+   * @dealiiConceptRequires{(std::predicate<Predicate, BaseIterator>)}
    */
   template <typename Predicate>
   DEAL_II_CXX20_REQUIRES((std::predicate<Predicate, BaseIterator>))
@@ -893,6 +897,8 @@ private:
  * automatically here.
  *
  * @relatesalso FilteredIterator
+ *
+ * @dealiiConceptRequires{(std::predicate<Predicate, BaseIterator>)}
  */
 template <typename BaseIterator, typename Predicate>
 DEAL_II_CXX20_REQUIRES((std::predicate<Predicate, BaseIterator>))
@@ -984,6 +990,8 @@ namespace internal
  *
  * @relatesalso FilteredIterator
  * @ingroup CPP11
+ *
+ * @dealiiConceptRequires{(std::predicate<Predicate, BaseIterator>)}
  */
 template <typename BaseIterator, typename Predicate>
 DEAL_II_CXX20_REQUIRES((std::predicate<Predicate, BaseIterator>))
@@ -1053,6 +1061,8 @@ inline IteratorRange<FilteredIterator<BaseIterator>> filter_iterators(
  *
  * @relatesalso FilteredIterator
  * @ingroup CPP11
+ *
+ * @dealiiConceptRequires{(std::predicate<Predicate, BaseIterator>)}
  */
 template <typename BaseIterator, typename Predicate, typename... Targs>
 DEAL_II_CXX20_REQUIRES((std::predicate<Predicate, BaseIterator>))
@@ -1127,6 +1137,8 @@ IteratorRange<
  *
  * @relatesalso FilteredIterator
  * @ingroup CPP11
+ *
+ * @dealiiConceptRequires{(std::predicate<Predicate, BaseIterator>)}
  */
 template <typename BaseIterator, typename Predicate>
 DEAL_II_CXX20_REQUIRES((std::predicate<Predicate, BaseIterator>))

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -2657,6 +2657,9 @@ namespace GridGenerator
    * dimensions no manifold objects are copied by this function: you must
    * attach new manifold objects to @p surface_mesh.
    *
+   *
+   * @dealiiConceptRequires{
+   *   concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>}
    */
   template <template <int, int> class MeshType, int dim, int spacedim>
   DEAL_II_CXX20_REQUIRES(

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -622,6 +622,10 @@ namespace GridTools
    *
    * This function is used in the "Possibilities for extensions" section of
    * step-38. It is also used in step-49 and step-53.
+   *
+   * @dealiiConceptRequires{(std::invocable<Transformation, Point<spacedim>> &&
+   *    std::assignable_from<Point<spacedim> &,
+   *    std::invoke_result_t<Transformation, Point<spacedim>>>)}
    */
   template <int dim, typename Transformation, int spacedim>
   DEAL_II_CXX20_REQUIRES(
@@ -1372,6 +1376,9 @@ namespace GridTools
    * Triangulation::n_vertices() for the triangulation underlying the given mesh
    * (as opposed to the value returned by Triangulation::n_used_vertices()).
    * @return The index of the closest vertex found.
+   *
+   * @dealiiConceptRequires{
+   *   concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>}
    */
   template <int dim, template <int, int> class MeshType, int spacedim>
   DEAL_II_CXX20_REQUIRES(
@@ -1403,6 +1410,9 @@ namespace GridTools
    * Triangulation::n_vertices() for the triangulation underlying the given mesh
    * (as opposed to the value returned by Triangulation::n_used_vertices()).
    * @return The index of the closest vertex found.
+   *
+   * @dealiiConceptRequires{
+   *   concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>}
    */
   template <int dim, template <int, int> class MeshType, int spacedim>
   DEAL_II_CXX20_REQUIRES(
@@ -1432,6 +1442,9 @@ namespace GridTools
    * @note It isn't entirely clear at this time whether the function does the
    * right thing with anisotropically refined meshes. It needs to be checked
    * for this case.
+   *
+   * @dealiiConceptRequires{
+   *   concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>}
    */
   template <int dim, template <int, int> class MeshType, int spacedim>
   DEAL_II_CXX20_REQUIRES(
@@ -1507,6 +1520,9 @@ namespace GridTools
    * cell contains a point. For example, if two processors come together
    * at one vertex and the function is called with this vertex, then one
    * processor will return a locally owned cell and the other one a ghost cell.
+   *
+   * @dealiiConceptRequires{
+   *   concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>}
    */
   template <int dim, template <int, int> class MeshType, int spacedim>
   DEAL_II_CXX20_REQUIRES(
@@ -1530,6 +1546,9 @@ namespace GridTools
    * the mapping argument.
    *
    * @return An iterator into the mesh that points to the surrounding cell.
+   *
+   * @dealiiConceptRequires{
+   *   concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>}
    */
   template <int dim, template <int, int> class MeshType, int spacedim>
   DEAL_II_CXX20_REQUIRES(
@@ -1634,6 +1653,9 @@ namespace GridTools
    * GridTools::Cache object. Note, however, that in this case MeshType
    * has to be Triangulation, so that it might be more appropriate to directly
    * call the function above with argument `cache` in this case.
+   *
+   * @dealiiConceptRequires{
+   *   concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>}
    */
   template <int dim, template <int, int> class MeshType, int spacedim>
   DEAL_II_CXX20_REQUIRES(
@@ -1685,6 +1707,9 @@ namespace GridTools
    *   auto all_cells  = GridTools::find_all_active_cells_around_point(
    *   			   mapping, mesh, p, tolerance, first_pair);
    * @endcode
+   *
+   * @dealiiConceptRequires{
+   *   concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>}
    */
   template <int dim, template <int, int> class MeshType, int spacedim>
   DEAL_II_CXX20_REQUIRES(
@@ -1711,6 +1736,9 @@ namespace GridTools
    * functions find_active_cell_around_point() to obtain a first cell, and
    * subsequently adds all other active non-artificial cells by calling the
    * function find_all_active_cells_around_point() above.
+   *
+   * @dealiiConceptRequires{
+   *   concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>}
    */
   template <int dim, template <int, int> class MeshType, int spacedim>
   DEAL_II_CXX20_REQUIRES(
@@ -1751,6 +1779,8 @@ namespace GridTools
    * @code
    *   GridTools::get_active_child_cells<DoFHandler<dim> > (cell)
    * @endcode
+   *
+   * @dealiiConceptRequires{concepts::is_triangulation_or_dof_handler<MeshType>}
    */
   template <class MeshType>
   DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
@@ -1780,6 +1810,8 @@ namespace GridTools
    * @code
    *   GridTools::get_active_neighbors<DoFHandler<dim>>(cell, active_neighbors)
    * @endcode
+   *
+   * @dealiiConceptRequires{concepts::is_triangulation_or_dof_handler<MeshType>}
    */
   template <class MeshType>
   DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
@@ -1835,6 +1867,8 @@ namespace GridTools
    * is a function that takes in an active cell and returns a boolean.
    * @return A list of active cells sharing at least one common vertex with
    * the predicated subdomain.
+   *
+   * @dealiiConceptRequires{concepts::is_triangulation_or_dof_handler<MeshType>}
    */
   template <class MeshType>
   DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
@@ -1851,6 +1885,8 @@ namespace GridTools
    * that level that share a common set of vertices with the subdomain
    * but are not a part of it). Here, the "subdomain" consists of exactly
    * all of those cells for which the @p predicate returns @p true.
+   *
+   * @dealiiConceptRequires{concepts::is_triangulation_or_dof_handler<MeshType>}
    */
   template <class MeshType>
   DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
@@ -1873,6 +1909,8 @@ namespace GridTools
    * @ref ConceptMeshType "MeshType concept".
    * @param[in] mesh A mesh (i.e. objects of type Triangulation or DoFHandler).
    * @return A list of ghost cells
+   *
+   * @dealiiConceptRequires{concepts::is_triangulation_or_dof_handler<MeshType>}
    */
   template <class MeshType>
   DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
@@ -1927,6 +1965,8 @@ namespace GridTools
    * returns @p true.
    *
    * See compute_active_cell_halo_layer().
+   *
+   * @dealiiConceptRequires{concepts::is_triangulation_or_dof_handler<MeshType>}
    */
   template <class MeshType>
   DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
@@ -1958,6 +1998,8 @@ namespace GridTools
    *
    * Also see compute_ghost_cell_halo_layer() and
    * compute_active_cell_layer_within_distance().
+   *
+   * @dealiiConceptRequires{concepts::is_triangulation_or_dof_handler<MeshType>}
    */
   template <class MeshType>
   DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
@@ -1980,6 +2022,8 @@ namespace GridTools
    * object as one may expect. However, BoundingBox has a conversion constructor
    * from pairs of points, so the result of this function can still be assigned
    * to a BoundingBox object.
+   *
+   * @dealiiConceptRequires{concepts::is_triangulation_or_dof_handler<MeshType>}
    */
   template <class MeshType>
   DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
@@ -2061,6 +2105,8 @@ namespace GridTools
    * This function does not take into account the curvature of cells and thus it
    * is not suited for handling curved geometry: the mapping is assumed to be
    * linear.
+   *
+   * @dealiiConceptRequires{concepts::is_triangulation_or_dof_handler<MeshType>}
    */
   template <class MeshType>
   DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
@@ -2566,6 +2612,8 @@ namespace GridTools
    * parallel::distributed::Triangulation when both meshes use the same
    * Triangulation since, with a distributed Triangulation, not all cells are
    * stored locally, so the resulting list may not cover the entire domain.
+   *
+   * @dealiiConceptRequires{concepts::is_triangulation_or_dof_handler<MeshType>}
    */
   template <typename MeshType>
   DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
@@ -2598,6 +2646,8 @@ namespace GridTools
    *
    * @tparam MeshType A type that satisfies the requirements of the
    * @ref ConceptMeshType "MeshType concept".
+   *
+   * @dealiiConceptRequires{concepts::is_triangulation_or_dof_handler<MeshType>}
    */
   template <typename MeshType>
   DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
@@ -2679,6 +2729,8 @@ namespace GridTools
    * ghost cells. For both, we know that these are in fact the real cells of
    * the complete, parallel triangulation. We can also query the degrees of
    * freedom on these.
+   *
+   * @dealiiConceptRequires{concepts::is_triangulation_or_dof_handler<MeshType>}
    */
   template <class MeshType>
   DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
@@ -3026,6 +3078,8 @@ namespace GridTools
    * boundary indicators set. In general, this means that one must first set
    * all boundary indicators on the coarse grid before performing any global
    * or local grid refinement.
+   *
+   * @dealiiConceptRequires{concepts::is_triangulation_or_dof_handler<MeshType>}
    */
   template <typename MeshType>
   DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
@@ -3062,6 +3116,8 @@ namespace GridTools
    * @note This version of collect_periodic_faces() will not work on
    * meshes with cells not in
    * @ref GlossFaceOrientation "standard orientation".
+   *
+   * @dealiiConceptRequires{concepts::is_triangulation_or_dof_handler<MeshType>}
    */
   template <typename MeshType>
   DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
@@ -3291,6 +3347,8 @@ namespace GridTools
    * you get the idea -- the code could, just as well, have exchanged
    * material ids, user indices, boundary indicators, or any kind of other
    * data with similar calls as the ones above.)
+   *
+   * @dealiiConceptRequires{concepts::is_triangulation_or_dof_handler<MeshType>}
    */
   template <typename DataType, typename MeshType>
   DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
@@ -3313,6 +3371,8 @@ namespace GridTools
    * function allows to provide a @p cell_filter function, which can be used to only
    * communicate marked cells. In the default case, all relevant cells are
    * communicated.
+   *
+   * @dealiiConceptRequires{concepts::is_triangulation_or_dof_handler<MeshType>}
    */
   template <typename DataType, typename MeshType>
   DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)

--- a/include/deal.II/grid/intergrid_map.h
+++ b/include/deal.II/grid/intergrid_map.h
@@ -109,6 +109,8 @@ DEAL_II_NAMESPACE_OPEN
  * equally well be Triangulation or PersistentTriangulation).
  *
  * @ingroup grid
+ *
+ * @dealiiConceptRequires{concepts::is_triangulation_or_dof_handler<MeshType>}
  */
 template <class MeshType>
 DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1129,6 +1129,8 @@ namespace internal
  * data stored in the triangulation.
  *
  * @ingroup grid aniso
+ *
+ * @dealiiConceptRequires{(concepts::is_valid_dim_spacedim<dim, spacedim>)}
  */
 template <int dim, int spacedim = dim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))

--- a/include/deal.II/numerics/vector_tools_evaluate.h
+++ b/include/deal.II/numerics/vector_tools_evaluate.h
@@ -130,6 +130,9 @@ namespace VectorTools
    *
    * @warning This is a collective call that needs to be executed by all
    *   processors in the communicator.
+   *
+   * @dealiiConceptRequires{(concepts::is_dealii_vector_type<VectorType> &&
+   *    concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>)}
    */
   template <int n_components,
             template <int, int>
@@ -168,6 +171,9 @@ namespace VectorTools
    *
    * @warning This is a collective call that needs to be executed by all
    *   processors in the communicator.
+   *
+   * @dealiiConceptRequires{(concepts::is_dealii_vector_type<VectorType> &&
+   *    concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>)}
    */
   template <int n_components,
             template <int, int>
@@ -200,6 +206,9 @@ namespace VectorTools
    *
    * @warning This is a collective call that needs to be executed by all
    *   processors in the communicator.
+   *
+   * @dealiiConceptRequires{(concepts::is_dealii_vector_type<VectorType> &&
+   *    concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>)}
    */
   template <int n_components,
             template <int, int>
@@ -238,6 +247,9 @@ namespace VectorTools
    *
    * @warning This is a collective call that needs to be executed by all
    *   processors in the communicator.
+   *
+   * @dealiiConceptRequires{(concepts::is_dealii_vector_type<VectorType> &&
+   *    concepts::is_triangulation_or_dof_handler<MeshType<dim, spacedim>>)}
    */
   template <int n_components,
             template <int, int>

--- a/include/deal.II/numerics/vector_tools_integrate_difference.h
+++ b/include/deal.II/numerics/vector_tools_integrate_difference.h
@@ -140,6 +140,9 @@ namespace VectorTools
    * the general documentation of the namespace), but only for InVectors as in
    * the documentation of the namespace, OutVector only Vector<double> and
    * Vector<float>.
+   *
+   * @dealiiConceptRequires{concepts::is_dealii_vector_type<InVector>
+   *   &&concepts::is_writable_dealii_vector_type<OutVector>}
    */
   template <int dim, class InVector, class OutVector, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<InVector> &&
@@ -158,6 +161,9 @@ namespace VectorTools
   /**
    * Call the integrate_difference() function, see above, with
    * <tt>mapping=MappingQ@<dim@>(1)</tt>.
+   *
+   * @dealiiConceptRequires{concepts::is_dealii_vector_type<InVector>
+   *   &&concepts::is_writable_dealii_vector_type<OutVector>}
    */
   template <int dim, class InVector, class OutVector, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<InVector> &&
@@ -174,6 +180,9 @@ namespace VectorTools
 
   /**
    * Same as above for hp.
+   *
+   * @dealiiConceptRequires{concepts::is_dealii_vector_type<InVector>
+   *   &&concepts::is_writable_dealii_vector_type<OutVector>}
    */
   template <int dim, class InVector, class OutVector, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<InVector> &&
@@ -192,6 +201,9 @@ namespace VectorTools
   /**
    * Call the integrate_difference() function, see above, with
    * <tt>mapping=MappingQ@<dim@>(1)</tt>.
+   *
+   * @dealiiConceptRequires{concepts::is_dealii_vector_type<InVector>
+   *   &&concepts::is_writable_dealii_vector_type<OutVector>}
    */
   template <int dim, class InVector, class OutVector, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<InVector> &&
@@ -230,6 +242,8 @@ namespace VectorTools
    * is chosen.
    *
    * @note Instantiated for type Vector<double> and Vector<float>.
+   *
+   * @dealiiConceptRequires{concepts::is_dealii_vector_type<InVector>}
    */
   template <int dim, int spacedim, class InVector>
   DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<InVector>)

--- a/include/deal.II/numerics/vector_tools_interpolate.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.h
@@ -66,6 +66,8 @@ namespace VectorTools
    * continuous again.
    *
    * See the general documentation of this namespace for further information.
+   *
+   * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
    */
   template <int dim, int spacedim, typename VectorType>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
@@ -78,6 +80,8 @@ namespace VectorTools
 
   /**
    * Same as above but in an hp-context.
+   *
+   * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
    */
   template <int dim, int spacedim, typename VectorType>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
@@ -92,6 +96,8 @@ namespace VectorTools
   /**
    * Call the @p interpolate() function above with
    * <tt>mapping=MappingQ@<dim,spacedim@>(1)</tt>.
+   *
+   * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
    */
   template <int dim, int spacedim, typename VectorType>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
@@ -118,6 +124,9 @@ namespace VectorTools
    * (see the general documentation of the namespace), but only the same
    * vector for InVector and OutVector. Other combinations must be
    * instantiated by hand.
+   *
+   * @dealiiConceptRequires{concepts::is_dealii_vector_type<InVector>
+   *   &&concepts::is_writable_dealii_vector_type<OutVector>}
    */
   template <int dim, class InVector, class OutVector, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<InVector> &&
@@ -173,6 +182,8 @@ namespace VectorTools
    * these objects separately (the order depends on what you want to get
    * between cells), then each subsequent call will rewrite the intercell @p
    * dofs of the previous one.
+   *
+   * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
    */
   template <int dim, int spacedim, typename VectorType>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
@@ -208,6 +219,8 @@ namespace VectorTools
    * only if the parallel partitioning is the same for both meshes (see the
    * parallel::distributed::Triangulation<dim>::no_automatic_repartitioning
    * flag).
+   *
+   * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
    */
   template <int dim, int spacedim, typename VectorType>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
@@ -228,6 +241,8 @@ namespace VectorTools
    * continuous elements on grids with hanging nodes (locally refined grids):
    * Without it - due to cellwise interpolation - the resulting output vector
    * does not necessarily respect continuity requirements at hanging nodes.
+   *
+   * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
    */
   template <int dim, int spacedim, typename VectorType>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
@@ -244,6 +259,8 @@ namespace VectorTools
    *
    * @p intergridmap has to be initialized via InterGridMap::make_mapping
    * pointing from a source DoFHandler to a destination DoFHandler.
+   *
+   * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
    */
   template <int dim, int spacedim, typename VectorType>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
@@ -283,6 +300,8 @@ namespace VectorTools
    *
    * This function is only implemented for FiniteElements where the specified
    * components are primitive.
+   *
+   * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
    */
   template <int dim, int spacedim, typename VectorType>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
@@ -297,6 +316,8 @@ namespace VectorTools
    * degree of the finite element in the DoFHandler @p dh, but more
    * importantly it allows to fill location vectors for mappings that do not
    * preserve vertex locations (like Eulerian mappings).
+   *
+   * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
    */
   template <int dim, int spacedim, typename VectorType>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)

--- a/include/deal.II/numerics/vector_tools_mean_value.h
+++ b/include/deal.II/numerics/vector_tools_mean_value.h
@@ -96,6 +96,8 @@ namespace VectorTools
    *
    * @warning This function can only be used for distributed vector classes
    * provided the boolean mask is empty, i.e. selecting the whole vector.
+   *
+   * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
    */
   template <typename VectorType>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
@@ -127,6 +129,8 @@ namespace VectorTools
    *
    * @note In contrast to subtract_mean_value(), this function can
    * adjust a single component of a distributed vector.
+   *
+   * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
    */
   template <class VectorType, int dim, int spacedim = dim>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
@@ -157,6 +161,8 @@ namespace VectorTools
    * finite element function with mean value zero. In fact, it only works for
    * Lagrangian elements. For all other elements, you will need to compute the
    * mean value and subtract it right inside the evaluation routine.
+   *
+   * @dealiiConceptRequires{concepts::is_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
@@ -171,6 +177,8 @@ namespace VectorTools
    * Calls the other compute_mean_value() function, see above, for the non-hp
    * case. That means, it requires a single FiniteElement, a single Quadrature,
    * and a single Mapping object.
+   *
+   * @dealiiConceptRequires{concepts::is_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
@@ -184,6 +192,8 @@ namespace VectorTools
   /**
    * Call the other compute_mean_value() function, see above, with
    * <tt>mapping=MappingQ@<dim@>(1)</tt>.
+   *
+   * @dealiiConceptRequires{concepts::is_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)

--- a/include/deal.II/numerics/vector_tools_point_gradient.h
+++ b/include/deal.II/numerics/vector_tools_point_gradient.h
@@ -85,6 +85,8 @@ namespace VectorTools
    *   the other, you will get unpredictable values for
    *   points on or close to the boundary of the cell, as one would expect
    *   when trying to evaluate point values of discontinuous functions.
+   *
+   * @dealiiConceptRequires{concepts::is_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
@@ -109,6 +111,8 @@ namespace VectorTools
    *   the other, you will get unpredictable values for
    *   points on or close to the boundary of the cell, as one would expect
    *   when trying to evaluate point values of discontinuous functions.
+   *
+   * @dealiiConceptRequires{concepts::is_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
@@ -149,6 +153,8 @@ namespace VectorTools
    *   the other, you will get unpredictable values for
    *   points on or close to the boundary of the cell, as one would expect
    *   when trying to evaluate point values of discontinuous functions.
+   *
+   * @dealiiConceptRequires{concepts::is_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
@@ -172,6 +178,8 @@ namespace VectorTools
    *   the other, you will get unpredictable values for
    *   points on or close to the boundary of the cell, as one would expect
    *   when trying to evaluate point values of discontinuous functions.
+   *
+   * @dealiiConceptRequires{concepts::is_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
@@ -211,6 +219,8 @@ namespace VectorTools
    *   the other, you will get unpredictable values for
    *   points on or close to the boundary of the cell, as one would expect
    *   when trying to evaluate point values of discontinuous functions.
+   *
+   * @dealiiConceptRequires{concepts::is_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
@@ -236,6 +246,8 @@ namespace VectorTools
    *   the other, you will get unpredictable values for
    *   points on or close to the boundary of the cell, as one would expect
    *   when trying to evaluate point values of discontinuous functions.
+   *
+   * @dealiiConceptRequires{concepts::is_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
@@ -277,6 +289,8 @@ namespace VectorTools
    *   the other, you will get unpredictable values for
    *   points on or close to the boundary of the cell, as one would expect
    *   when trying to evaluate point values of discontinuous functions.
+   *
+   * @dealiiConceptRequires{concepts::is_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
@@ -301,6 +315,8 @@ namespace VectorTools
    *   the other, you will get unpredictable values for
    *   points on or close to the boundary of the cell, as one would expect
    *   when trying to evaluate point values of discontinuous functions.
+   *
+   * @dealiiConceptRequires{concepts::is_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)

--- a/include/deal.II/numerics/vector_tools_point_value.h
+++ b/include/deal.II/numerics/vector_tools_point_value.h
@@ -235,6 +235,8 @@ namespace VectorTools
    *
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
+   *
+   * @dealiiConceptRequires{concepts::is_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
@@ -256,6 +258,8 @@ namespace VectorTools
    *
    * @note If the cell in which the point is found is not locally owned, an
    * exception of type VectorTools::ExcPointNotAvailableHere is thrown.
+   *
+   * @dealiiConceptRequires{concepts::is_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
@@ -302,6 +306,8 @@ namespace VectorTools
    *   is <i>not</i> continuous, then you will get unpredictable values for
    *   points on or close to the boundary of the cell, as one would expect
    *   when trying to evaluate point values of discontinuous functions.
+   *
+   * @dealiiConceptRequires{concepts::is_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
@@ -326,6 +332,8 @@ namespace VectorTools
    *   is <i>not</i> continuous, then you will get unpredictable values for
    *   points on or close to the boundary of the cell, as one would expect
    *   when trying to evaluate point values of discontinuous functions.
+   *
+   * @dealiiConceptRequires{concepts::is_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
@@ -372,6 +380,8 @@ namespace VectorTools
    *   is <i>not</i> continuous, then you will get unpredictable values for
    *   points on or close to the boundary of the cell, as one would expect
    *   when trying to evaluate point values of discontinuous functions.
+   *
+   * @dealiiConceptRequires{concepts::is_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
@@ -396,6 +406,8 @@ namespace VectorTools
    *   is <i>not</i> continuous, then you will get unpredictable values for
    *   points on or close to the boundary of the cell, as one would expect
    *   when trying to evaluate point values of discontinuous functions.
+   *
+   * @dealiiConceptRequires{concepts::is_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
@@ -437,6 +449,8 @@ namespace VectorTools
    *   is <i>not</i> continuous, then you will get unpredictable values for
    *   points on or close to the boundary of the cell, as one would expect
    *   when trying to evaluate point values of discontinuous functions.
+   *
+   * @dealiiConceptRequires{concepts::is_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
@@ -462,6 +476,8 @@ namespace VectorTools
    *   is <i>not</i> continuous, then you will get unpredictable values for
    *   points on or close to the boundary of the cell, as one would expect
    *   when trying to evaluate point values of discontinuous functions.
+   *
+   * @dealiiConceptRequires{concepts::is_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
@@ -503,6 +519,8 @@ namespace VectorTools
    *   is <i>not</i> continuous, then you will get unpredictable values for
    *   points on or close to the boundary of the cell, as one would expect
    *   when trying to evaluate point values of discontinuous functions.
+   *
+   * @dealiiConceptRequires{concepts::is_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
@@ -528,6 +546,8 @@ namespace VectorTools
    *   is <i>not</i> continuous, then you will get unpredictable values for
    *   points on or close to the boundary of the cell, as one would expect
    *   when trying to evaluate point values of discontinuous functions.
+   *
+   * @dealiiConceptRequires{concepts::is_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)

--- a/include/deal.II/numerics/vector_tools_project.h
+++ b/include/deal.II/numerics/vector_tools_project.h
@@ -139,6 +139,8 @@ namespace VectorTools
    * is true.
    * @param[in] project_to_boundary_first If true, perform a projection on the
    * boundary before projecting the interior of the function.
+   *
+   * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
@@ -157,6 +159,8 @@ namespace VectorTools
   /**
    * Call the project() function above, with
    * <tt>mapping=MappingQ@<dim@>(1)</tt>.
+   *
+   * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
@@ -173,6 +177,8 @@ namespace VectorTools
 
   /**
    * Same as above, but with hp-capabilities.
+   *
+   * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
@@ -191,6 +197,8 @@ namespace VectorTools
   /**
    * Call the project() function above, with a collection of $Q_1$ mapping
    * objects, i.e., with hp::StaticMappingQ1::mapping_collection.
+   *
+   * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
@@ -228,6 +236,8 @@ namespace VectorTools
    * @endcode
    * where <code>qp_data</code> is a CellDataStorage object, which stores
    * quadrature point data.
+   *
+   * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
@@ -268,6 +278,8 @@ namespace VectorTools
    * to use in case it was constructed with an <code>std::vector<const
    * DoFHandler<dim>*></code>. It will be used internally in constructor of
    * FEEvaluation object.
+   *
+   * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
@@ -287,6 +299,8 @@ namespace VectorTools
   /**
    * Same as above but for <code>n_q_points_1d =
    * matrix_free.get_dof_handler().get_fe().degree+1</code>.
+   *
+   * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
    */
   template <int dim, typename VectorType>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)

--- a/include/deal.II/numerics/vector_tools_project.templates.h
+++ b/include/deal.II/numerics/vector_tools_project.templates.h
@@ -406,6 +406,8 @@ namespace VectorTools
      * Helper interface for the matrix-free implementation of project(): avoid
      * instantiating the other helper functions for more than one VectorType
      * by copying from a LinearAlgebra::distributed::Vector.
+     *
+     * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
      */
     template <int dim, typename VectorType, int spacedim>
     DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
@@ -470,6 +472,8 @@ namespace VectorTools
 
     /**
      * Generic implementation of the project() function
+     *
+     * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
      */
     template <int dim,
               int spacedim,
@@ -765,6 +769,8 @@ namespace VectorTools
      * number types for MatrixFree support. Check if we actually can use the
      * MatrixFree implementation or need to use the matrix based one nonetheless
      * based on the number of components.
+     *
+     * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
      */
     template <typename VectorType, int dim, int spacedim>
     DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
@@ -829,6 +835,8 @@ namespace VectorTools
     /**
      * Specialization of project() for complex numbers or `dim < spacedim`,
      * for which we are sure that we cannot use the MatrixFree implementation.
+     *
+     * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
      */
     template <typename VectorType, int dim, int spacedim>
     DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)

--- a/include/deal.II/numerics/vector_tools_rhs.h
+++ b/include/deal.II/numerics/vector_tools_rhs.h
@@ -56,6 +56,8 @@ namespace VectorTools
    * vector is deleted.
    *
    * See the general documentation of this namespace for further information.
+   *
+   * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
    */
   template <int dim, int spacedim, typename VectorType>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
@@ -71,6 +73,8 @@ namespace VectorTools
   /**
    * Call the create_right_hand_side() function, see above, with
    * <tt>mapping=MappingQ@<dim@>(1)</tt>.
+   *
+   * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
    */
   template <int dim, int spacedim, typename VectorType>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
@@ -84,6 +88,8 @@ namespace VectorTools
 
   /**
    * Like the previous set of functions, but for hp-objects.
+   *
+   * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
    */
   template <int dim, int spacedim, typename VectorType>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
@@ -98,6 +104,8 @@ namespace VectorTools
 
   /**
    * Like the previous set of functions, but for hp-objects.
+   *
+   * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
    */
   template <int dim, int spacedim, typename VectorType>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
@@ -117,6 +125,8 @@ namespace VectorTools
    *
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
+   *
+   * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
    */
   template <int dim, int spacedim, typename VectorType>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
@@ -135,6 +145,8 @@ namespace VectorTools
    *
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
+   *
+   * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
    */
   template <int dim, int spacedim, typename VectorType>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
@@ -151,6 +163,8 @@ namespace VectorTools
    *
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
+   *
+   * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
    */
   template <int dim, int spacedim, typename VectorType>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
@@ -170,6 +184,8 @@ namespace VectorTools
    *
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
+   *
+   * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
    */
   template <int dim, int spacedim, typename VectorType>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)


### PR DESCRIPTION
This is part of #14840. doxygen is not great in showing `requires` clauses (it does, but it's hardly readable), and I think these requirements should be documented more prominently.

This patch introduces a doxygen macro that expands to a `@note` paragraph. I've then gone (programmatically) through all of the places where we currently already use `requires` clauses and added the corresponding macro to the documentation. Here's an example of how this looks like (see the note at the very bottom):
![image](https://user-images.githubusercontent.com/7504421/233869471-8ebb42ea-2fbf-42bc-b764-8829c70f6d5d.png)
