### PR TITLE
Vectorize NonMatching::MappingInfo

### DIFF
--- a/include/deal.II/base/derivative_form.h
+++ b/include/deal.II/base/derivative_form.h
@@ -107,6 +107,13 @@ public:
   operator=(const Tensor<1, dim, Number> &);
 
   /**
+   * Number conversion operator.
+   */
+  template <typename OtherNumber>
+  DerivativeForm &
+  operator=(const DerivativeForm<order, dim, spacedim, OtherNumber> &df);
+
+  /**
    * Converts a DerivativeForm <order, dim, dim, Number> to Tensor<order+1, dim,
    * Number>. In particular, if order == 1 and the derivative is the Jacobian of
    * $\mathbf F(\mathbf x)$, then Tensor[i] = $\nabla F_i(\mathbf x)$.
@@ -247,6 +254,19 @@ DerivativeForm<order, dim, spacedim, Number>::operator=(
 
   (*this)[0] = T;
 
+  return *this;
+}
+
+
+
+template <int order, int dim, int spacedim, typename Number>
+template <typename OtherNumber>
+inline DerivativeForm<order, dim, spacedim, Number> &
+DerivativeForm<order, dim, spacedim, Number>::operator=(
+  const DerivativeForm<order, dim, spacedim, OtherNumber> &df)
+{
+  for (unsigned int j = 0; j < spacedim; ++j)
+    (*this)[j] = df[j];
   return *this;
 }
 

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -5478,48 +5478,149 @@ namespace internal
   template <typename T>
   struct VectorizedArrayTrait
   {
-    using value_type                   = T;
+    /**
+     * Define scalar value type.
+     */
+    using value_type = T;
+
+    /**
+     * Define width of template type.
+     */
     static constexpr std::size_t width = 1;
 
-    static T &
-    get(T &value, unsigned int c)
+    /**
+     * Define vectorized value type for internal vectorization.
+     */
+    using vectorized_value_type = VectorizedArray<T>;
+
+    /**
+     * Define a stride which defines how often the template type T fits into the
+     * vectorized_value_type. This is useful to write vectorized templated code
+     * where the internal computation is vectorized and the user interface is
+     * optionally scalar or also vectorized.
+     */
+    static constexpr std::size_t stride = vectorized_value_type::size();
+
+    /**
+     * Get a reference to scalar value (on lane 0).
+     */
+    static value_type &
+    get(value_type &value, unsigned int c)
     {
-      AssertDimension(c, 0);
+      AssertIndexRange(c, 1);
       (void)c;
 
       return value;
     }
 
-    static const T &
-    get(const T &value, unsigned int c)
+    /**
+     * Get a read-only reference to scalar value (on lane 0).
+     */
+    static const value_type &
+    get(const value_type &value, unsigned int c)
     {
-      AssertDimension(c, 0);
+      AssertIndexRange(c, 1);
       (void)c;
 
       return value;
+    }
+
+    /**
+     * Get a reference to scalar value on lane c from a vectorized values field.
+     */
+    static value_type &
+    get_from_vectorized(vectorized_value_type &values, unsigned int c)
+    {
+      AssertIndexRange(c, stride);
+
+      return values[c];
+    }
+
+    /**
+     * Get a read-only reference to scalar value on lane c from a vectorized
+     * values field.
+     */
+    static const value_type &
+    get_from_vectorized(const vectorized_value_type &values, unsigned int c)
+    {
+      AssertIndexRange(c, stride);
+
+      return values[c];
     }
   };
 
   template <typename T, std::size_t width_>
   struct VectorizedArrayTrait<VectorizedArray<T, width_>>
   {
-    using value_type                   = T;
+    /**
+     * Define scalar value type.
+     */
+    using value_type = T;
+
+    /**
+     * Define width of template type.
+     */
     static constexpr std::size_t width = width_;
 
-    static T &
-    get(VectorizedArray<T, width_> &values, unsigned int c)
+    /**
+     * Define vectorized value type for internal vectorization.
+     */
+    using vectorized_value_type = VectorizedArray<T, width_>;
+
+    /**
+     * Define a stride which defines how often the template type
+     * VectorizedArray<T, width_> fits into the vectorized value type. This is
+     * useful to write vectorized templated code where the internal computation
+     * is vectorized and the user interface is optionally scalar or also
+     * vectorized.
+     */
+    static constexpr std::size_t stride = 1;
+
+    /**
+     * Get a reference to scalar value on lane c.
+     */
+    static value_type &
+    get(vectorized_value_type &values, unsigned int c)
     {
       AssertIndexRange(c, width_);
 
       return values[c];
     }
 
-    static const T &
-    get(const VectorizedArray<T, width_> &values, unsigned int c)
+    /**
+     * Get a read-only reference to scalar value on lane c.
+     */
+    static const value_type &
+    get(const vectorized_value_type &values, unsigned int c)
     {
       AssertIndexRange(c, width_);
 
       return values[c];
+    }
+
+    /**
+     * Get a reference to vectorized values from a vectorized values field.
+     */
+    static vectorized_value_type &
+    get_from_vectorized(vectorized_value_type &values, unsigned int c)
+    {
+      (void)c;
+      AssertIndexRange(c, stride);
+
+      return values;
+    }
+
+    /**
+     * Get a read-only reference to vectorized values from a vectorized values
+     * field.
+     */
+    static const vectorized_value_type &
+    get_from_vectorized(const vectorized_value_type &values, unsigned int c)
+    {
+      (void)c;
+      AssertIndexRange(c, stride);
+
+      return values;
     }
   };
 } // namespace internal

--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -55,8 +55,11 @@ namespace NonMatching
 {
   template <int dim>
   class FEImmersedSurfaceValues;
-  template <int dim, int spacedim>
-  class MappingInfo;
+  namespace internal
+  {
+    template <int dim, int spacedim>
+    class ComputeMappingDataHelper;
+  }
 } // namespace NonMatching
 
 
@@ -1320,7 +1323,7 @@ public:
   friend class FEFaceValues<dim, spacedim>;
   friend class FESubfaceValues<dim, spacedim>;
   friend class NonMatching::FEImmersedSurfaceValues<dim>;
-  friend class NonMatching::MappingInfo<dim, spacedim>;
+  friend class NonMatching::internal::ComputeMappingDataHelper<dim, spacedim>;
 };
 
 

--- a/include/deal.II/matrix_free/tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/tensor_product_kernels.h
@@ -2989,7 +2989,7 @@ namespace internal
   template <int dim, typename Number>
   inline void
   compute_values_of_array(
-    ArrayView<dealii::ndarray<Number, 2, dim>> &        shapes,
+    ArrayView<dealii::ndarray<Number, 2, dim>>          shapes,
     const std::vector<Polynomials::Polynomial<double>> &poly,
     const Point<dim, Number> &                          p)
   {

--- a/include/deal.II/non_matching/mapping_info.h
+++ b/include/deal.II/non_matching/mapping_info.h
@@ -38,17 +38,174 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace NonMatching
 {
+  namespace internal
+  {
+    template <int dim, int spacedim = dim>
+    class ComputeMappingDataHelper
+    {
+      using MappingData =
+        dealii::internal::FEValuesImplementation::MappingRelatedData<dim,
+                                                                     spacedim>;
+
+    public:
+      static UpdateFlags
+      required_update_flags(
+        const SmartPointer<const Mapping<dim, spacedim>> mapping,
+        const UpdateFlags &                              update_flags)
+      {
+        return mapping->requires_update_flags(update_flags);
+      }
+
+      static void
+      compute_mapping_data_for_quadrature(
+        const SmartPointer<const Mapping<dim, spacedim>> mapping,
+        const UpdateFlags &                              update_flags_mapping,
+        const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+        CellSimilarity::Similarity &cell_similarity,
+        const Quadrature<dim> &     quadrature,
+        std::shared_ptr<typename Mapping<dim, spacedim>::InternalDataBase>
+                     internal_mapping_data,
+        MappingData &mapping_data)
+      {
+        mapping_data.initialize(quadrature.size(), update_flags_mapping);
+
+        // reuse internal_mapping_data for MappingQ to avoid memory allocations
+        if (const MappingQ<dim, spacedim> *mapping_q =
+              dynamic_cast<const MappingQ<dim, spacedim> *>(&(*mapping)))
+          {
+            (void)mapping_q;
+            auto &data =
+              dynamic_cast<typename MappingQ<dim, spacedim>::InternalData &>(
+                *internal_mapping_data);
+            data.initialize(update_flags_mapping,
+                            quadrature,
+                            quadrature.size());
+          }
+        else
+          {
+            internal_mapping_data =
+              mapping->get_data(update_flags_mapping, quadrature);
+          }
+
+        cell_similarity = mapping->fill_fe_values(cell,
+                                                  cell_similarity,
+                                                  quadrature,
+                                                  *internal_mapping_data,
+                                                  mapping_data);
+      }
+
+
+
+      static void
+      compute_mapping_data_for_immersed_surface_quadrature(
+        const SmartPointer<const Mapping<dim, spacedim>> mapping,
+        const UpdateFlags &                              update_flags_mapping,
+        const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+        const ImmersedSurfaceQuadrature<dim> &                      quadrature,
+        std::shared_ptr<typename Mapping<dim, spacedim>::InternalDataBase>
+                     internal_mapping_data,
+        MappingData &mapping_data)
+      {
+        mapping_data.initialize(quadrature.size(), update_flags_mapping);
+
+        // reuse internal_mapping_data for MappingQ to avoid memory allocations
+        if (dynamic_cast<const MappingQ<dim, spacedim> *>(&(*mapping)))
+          {
+            auto &data =
+              dynamic_cast<typename MappingQ<dim, spacedim>::InternalData &>(
+                *internal_mapping_data);
+            data.initialize(update_flags_mapping,
+                            quadrature,
+                            quadrature.size());
+          }
+        else
+          {
+            internal_mapping_data =
+              mapping->get_data(update_flags_mapping, quadrature);
+          }
+
+        mapping->fill_fe_immersed_surface_values(cell,
+                                                 quadrature,
+                                                 *internal_mapping_data,
+                                                 mapping_data);
+      }
+
+
+
+      static void
+      compute_mapping_data_for_face_quadrature(
+        const SmartPointer<const Mapping<dim, spacedim>> mapping,
+        const UpdateFlags &                              update_flags_mapping,
+        const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+        const unsigned int                                          face_no,
+        const Quadrature<dim - 1> &                                 quadrature,
+        std::shared_ptr<typename Mapping<dim, spacedim>::InternalDataBase>
+                     internal_mapping_data,
+        MappingData &mapping_data)
+      {
+        mapping_data.initialize(quadrature.size(), update_flags_mapping);
+
+        // reuse internal_mapping_data for MappingQ to avoid memory allocations
+        if (const MappingQ<dim, spacedim> *mapping_q =
+              dynamic_cast<const MappingQ<dim, spacedim> *>(&(*mapping)))
+          {
+            auto &data =
+              dynamic_cast<typename MappingQ<dim, spacedim>::InternalData &>(
+                *internal_mapping_data);
+            data.initialize_face(update_flags_mapping,
+                                 QProjector<dim>::project_to_oriented_face(
+                                   ReferenceCells::get_hypercube<dim>(),
+                                   quadrature,
+                                   face_no,
+                                   cell->face_orientation(face_no),
+                                   cell->face_flip(face_no),
+                                   cell->face_rotation(face_no)),
+                                 quadrature.size());
+
+            mapping_q->fill_mapping_data_for_face_quadrature(
+              cell, face_no, quadrature, *internal_mapping_data, mapping_data);
+          }
+        else
+          {
+            auto internal_mapping_data =
+              mapping->get_face_data(update_flags_mapping,
+                                     hp::QCollection<dim - 1>(quadrature));
+
+            mapping->fill_fe_face_values(cell,
+                                         face_no,
+                                         hp::QCollection<dim - 1>(quadrature),
+                                         *internal_mapping_data,
+                                         mapping_data);
+          }
+      }
+    };
+  } // namespace internal
+
   /**
    * This class provides the mapping information computation and mapping data
    * storage to be used together with FEPointEvaluation.
+   *
+   * MappingInfo is vectorized across quadrature points, which means data can be
+   * provided in vectorized format.
+   *
+   * Two different modes are available: partially vectorized and fully
+   * vectorized across quadrature points. Partially vectorized (scalar Number
+   * template argument) means the computed mapping data is provided in scalar
+   * format and only unit points are provided vectorized (for seamless
+   * interaction with FEPointEvaluation). Fully vectorized (vectorized Number
+   * template argument, e.g. VectorizedArray<double>) provides both mapping data
+   * and unit points in vectorized format. The Number template parameter of
+   * MappingInfo and FEPointEvaluation has to be identical.
    */
-  template <int dim, int spacedim = dim>
+  template <int dim, int spacedim = dim, typename Number = double>
   class MappingInfo : public Subscriptor
   {
   public:
-    using MappingData =
-      dealii::internal::FEValuesImplementation::MappingRelatedData<dim,
-                                                                   spacedim>;
+    /**
+     * The VectorizedArray type the unit points are stored in inside this class.
+     */
+    using VectorizedArrayType = typename dealii::internal::VectorizedArrayTrait<
+      Number>::vectorized_value_type;
 
     /**
      * Constructor.
@@ -139,37 +296,46 @@ namespace NonMatching
       const unsigned int n_unfiltered_cells = numbers::invalid_unsigned_int);
 
     /**
-     * Getter function for current unit points.
-     *
-     * @p cell_index and @p face_number are the indices
-     * into the compressed, CRS like data storage of unit points.
-     *
-     * If you have initialized this object with reinit_cells() you can access
-     * the stored unit points of the cell with the respective @p cell_index
-     * (and the default argument for @p face_number).
-     *
-     * If you have initialized this object with reinit_faces() you can access
-     * the stored unit points of the faces on the cell with the respective @p cell_index
-     * and the respective local @p face_number.
-     *
-     * If you have initialized this object with reinit() you can access the
-     * stored unit points of a single cell with the default arguments.
-     *
-     * The correct state of this object is checked in this call (in debug mode).
+     * Getter function for unit points. The offset can be obtained with
+     * compute_unit_point_index_offset().
      */
-    const ArrayView<const Point<dim>>
-    get_unit_points(
-      const unsigned int cell_index  = numbers::invalid_unsigned_int,
-      const unsigned int face_number = numbers::invalid_unsigned_int) const;
+    const Point<dim, VectorizedArrayType> *
+    get_unit_point(const unsigned int offset) const;
 
     /**
-     * Getter function for computed mapping data. This function accesses
-     * internal data and is therefore not a stable interface.
+     * Getter function for Jacobians. The offset can be obtained with
+     * compute_data_index_offset().
      */
-    const MappingData &
-    get_mapping_data(
-      const unsigned int cell_index  = numbers::invalid_unsigned_int,
-      const unsigned int face_number = numbers::invalid_unsigned_int) const;
+    const DerivativeForm<1, dim, spacedim, Number> *
+    get_jacobian(const unsigned int offset) const;
+
+    /**
+     * Getter function for inverse Jacobians. The offset can be obtained with
+     * compute_data_index_offset().
+     */
+    const DerivativeForm<1, spacedim, dim, Number> *
+    get_inverse_jacobian(const unsigned int offset) const;
+
+    /**
+     * Getter function for normal vectors. The offset can be obtained with
+     * compute_data_index_offset().
+     */
+    const Tensor<1, spacedim, Number> *
+    get_normal_vector(const unsigned int offset) const;
+
+    /**
+     * Getter function for Jacobian times quadrature weight (JxW). The offset
+     * can be obtained with compute_data_index_offset().
+     */
+    const Number *
+    get_JxW(const unsigned int offset) const;
+
+    /**
+     * Getter function for real points. The offset can be obtained with
+     * compute_data_index_offset().
+     */
+    const Point<dim, Number> *
+    get_real_point(const unsigned int offset) const;
 
     /**
      * Getter function for underlying mapping.
@@ -184,12 +350,93 @@ namespace NonMatching
     get_update_flags() const;
 
     /**
+     * Getter function for the mapping update flags.
+     */
+    UpdateFlags
+    get_update_flags_mapping() const;
+
+    /**
      * Connects to is_reinitialized().
      */
     boost::signals2::connection
     connect_is_reinitialized(const std::function<void()> &set_is_reinitialized);
 
+    /**
+     * Compute the unit points index offset for the current cell/face.
+     */
+    unsigned int
+    compute_unit_point_index_offset(const unsigned int cell_index,
+                                    const unsigned int face_number) const;
+
+    /**
+     * Compute the data index offset for the current cell/face.
+     */
+    unsigned int
+    compute_data_index_offset(const unsigned int cell_index,
+                              const unsigned int face_number) const;
+
+    /**
+     * Get number of unvectorized quadrature points.
+     */
+    unsigned int
+    get_n_q_points_unvectorized(const unsigned int cell_index,
+                                const unsigned int face_number) const;
+
   private:
+    using MappingData =
+      dealii::internal::FEValuesImplementation::MappingRelatedData<dim,
+                                                                   spacedim>;
+
+    /**
+     * Compute number of quadrature point batches depending on NumberType.
+     */
+    template <typename NumberType>
+    unsigned int
+    compute_n_q_points(const unsigned int n_q_points_unvectorized);
+
+    /**
+     * Resize the unit_point data field.
+     */
+    void
+    resize_unit_points(const unsigned int n_unit_point_batches);
+
+    /**
+     * Resize the mapping data fields.
+     */
+    void
+    resize_data_fields(const unsigned int n_data_point_batches);
+
+    /**
+     * Store the unit points.
+     */
+    void
+    store_unit_points(const unsigned int             unit_points_index_offset,
+                      const unsigned int             n_q_points,
+                      const unsigned int             n_q_points_unvectorized,
+                      const std::vector<Point<dim>> &points);
+
+    /**
+     * Store the requested mapping data.
+     */
+    void
+    store_mapping_data(const unsigned int unit_points_index_offset,
+                       const unsigned int n_q_points,
+                       const unsigned int n_q_points_unvectorized,
+                       const MappingData &mapping_data);
+
+    /**
+     * Compute the compressed cell index.
+     */
+    unsigned int
+    compute_compressed_cell_index(const unsigned int cell_index) const;
+
+    /**
+     * Compute the geometry index offset of the current cell/face.
+     */
+    unsigned int
+    compute_geometry_index_offset(const unsigned int cell_index,
+                                  const unsigned int face_number) const;
+
     /**
      * Enum class for reinitialized states.
      */
@@ -208,54 +455,21 @@ namespace NonMatching
     State state;
 
     /**
-     * Compute the mapping related data for the given @p mapping,
-     * @p cell and @p unit_points that is required by the FEPointEvaluation
-     * class.
-     */
-    void
-    compute_mapping_data_for_quadrature(
-      const typename Triangulation<dim, spacedim>::cell_iterator &cell,
-      CellSimilarity::Similarity &cell_similarity,
-      const Quadrature<dim> &     quadrature,
-      MappingData &               mapping_data);
-
-    /**
-     * Compute the mapping related data for the given @p mapping,
-     * @p cell and @p quadrature that is required by the FEPointEvaluation
-     * class.
-     */
-    void
-    compute_mapping_data_for_immersed_surface_quadrature(
-      const typename Triangulation<dim, spacedim>::cell_iterator &cell,
-      const ImmersedSurfaceQuadrature<dim> &                      quadrature,
-      MappingData &                                               mapping_data);
-
-    /**
-     * Compute the mapping related data for the given @p mapping, @p cell,
-     * @p face_no and @p quadrature that is required by the FEPointEvaluation
-     * class.
-     */
-    void
-    compute_mapping_data_for_face_quadrature(
-      const typename Triangulation<dim, spacedim>::cell_iterator &cell,
-      const unsigned int                                          face_no,
-      const Quadrature<dim - 1> &                                 quadrature,
-      MappingData &                                               mapping_data);
-
-    /**
      * The reference points specified at reinit().
+     *
+     * Indexed by @p unit_points_index.
      */
-    std::vector<Point<dim>> unit_points;
+    AlignedVector<Point<dim, VectorizedArrayType>> unit_points;
 
     /**
-     * Offset to point to the first unit point of a cell/face
+     * Offset to point to the first unit point of a cell/face.
      */
-    std::vector<unsigned int> unit_points_index;
+    AlignedVector<unsigned int> unit_points_index;
 
     /**
      * A pointer to the internal data of the underlying mapping.
      */
-    std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>
+    std::shared_ptr<typename Mapping<dim, spacedim>::InternalDataBase>
       internal_mapping_data;
 
     /**
@@ -274,10 +488,54 @@ namespace NonMatching
     UpdateFlags update_flags_mapping;
 
     /**
-     * The internal data container for mapping information. The implementation
-     * is subject to future changes.
+     * Stores the index offset into the arrays @p JxW_values, @p jacobians,
+     * @p inverse_jacobians and @p normal_vectors.
      */
-    std::vector<MappingData> mapping_data;
+    AlignedVector<unsigned int> data_index_offsets;
+
+    /**
+     * The storage of the Jacobian determinant times the quadrature weight on
+     * quadrature points.
+     *
+     * Indexed by @p data_index_offsets.
+     */
+    AlignedVector<Number> JxW_values;
+
+    /**
+     * Stores the normal vectors.
+     *
+     * Indexed by @p data_index_offsets.
+     */
+    AlignedVector<Tensor<1, spacedim, Number>> normal_vectors;
+
+    /**
+     * The storage of contravariant transformation on quadrature points, i.e.,
+     * the Jacobians of the transformation from the unit to the real cell.
+     *
+     * Indexed by @p data_index_offsets.
+     */
+    AlignedVector<DerivativeForm<1, dim, spacedim, Number>> jacobians;
+
+    /**
+     * The storage of covariant transformation on quadrature points, i.e.,
+     * the inverse Jacobians of the transformation from the
+     * unit to the real cell.
+     *
+     * Indexed by @p data_index_offsets.
+     */
+    AlignedVector<DerivativeForm<1, spacedim, dim, Number>> inverse_jacobians;
+
+    /**
+     * The mapped real points.
+     *
+     * Indexed by @p data_index_offsets.
+     */
+    AlignedVector<Point<spacedim, Number>> real_points;
+
+    /**
+     * Number of unvectorized unit points per geometric entity (cell/face).
+     */
+    std::vector<unsigned int> n_q_points_unvectorized;
 
     /**
      * Offset to point to the first element of a cell in internal data
@@ -306,15 +564,16 @@ namespace NonMatching
   // ----------------------- template functions ----------------------
 
 
-  template <int dim, int spacedim>
-  MappingInfo<dim, spacedim>::MappingInfo(const Mapping<dim> &mapping,
-                                          const UpdateFlags   update_flags)
+  template <int dim, int spacedim, typename Number>
+  MappingInfo<dim, spacedim, Number>::MappingInfo(
+    const Mapping<dim> &mapping,
+    const UpdateFlags   update_flags)
     : mapping(&mapping)
     , update_flags(update_flags)
+    , update_flags_mapping(update_default)
   {
-    update_flags_mapping = update_default;
     // translate update flags
-    if (update_flags & update_jacobians || update_flags & update_JxW_values)
+    if (update_flags & update_jacobians)
       update_flags_mapping |= update_jacobians;
     if (update_flags & update_JxW_values)
       update_flags_mapping |= update_JxW_values;
@@ -326,6 +585,10 @@ namespace NonMatching
 
     // always save quadrature points for now
     update_flags_mapping |= update_quadrature_points;
+
+    update_flags_mapping =
+      internal::ComputeMappingDataHelper<dim, spacedim>::required_update_flags(
+        this->mapping, update_flags_mapping);
 
     // construct internal_mapping_data for MappingQ to be able to reuse it in
     // reinit() calls to avoid memory allocations
@@ -340,9 +603,9 @@ namespace NonMatching
 
 
 
-  template <int dim, int spacedim>
+  template <int dim, int spacedim, typename Number>
   void
-  MappingInfo<dim, spacedim>::reinit(
+  MappingInfo<dim, spacedim, Number>::reinit(
     const typename Triangulation<dim, spacedim>::cell_iterator &cell,
     const std::vector<Point<dim>> &                             unit_points_in)
   {
@@ -351,9 +614,9 @@ namespace NonMatching
 
 
 
-  template <int dim, int spacedim>
+  template <int dim, int spacedim, typename Number>
   void
-  MappingInfo<dim, spacedim>::reinit(
+  MappingInfo<dim, spacedim, Number>::reinit(
     const typename Triangulation<dim, spacedim>::cell_iterator &cell,
     const ArrayView<const Point<dim>> &                         unit_points_in)
   {
@@ -364,21 +627,48 @@ namespace NonMatching
 
 
 
-  template <int dim, int spacedim>
+  template <int dim, int spacedim, typename Number>
   void
-  MappingInfo<dim, spacedim>::reinit(
+  MappingInfo<dim, spacedim, Number>::reinit(
     const typename Triangulation<dim, spacedim>::cell_iterator &cell,
     const Quadrature<dim> &                                     quadrature)
   {
-    unit_points = quadrature.get_points();
+    n_q_points_unvectorized.resize(1);
+    n_q_points_unvectorized[0] = quadrature.size();
 
-    mapping_data.resize(1);
-    CellSimilarity::Similarity cell_similarity =
-      CellSimilarity::Similarity::none;
-    compute_mapping_data_for_quadrature(cell,
-                                        cell_similarity,
-                                        quadrature,
-                                        mapping_data[0]);
+    const unsigned int n_q_points =
+      compute_n_q_points<VectorizedArrayType>(n_q_points_unvectorized[0]);
+
+    const unsigned int n_q_points_data =
+      compute_n_q_points<Number>(n_q_points_unvectorized[0]);
+
+    // resize data vectors
+    resize_unit_points(n_q_points);
+    resize_data_fields(n_q_points_data);
+
+    // store unit points
+    store_unit_points(0,
+                      n_q_points,
+                      n_q_points_unvectorized[0],
+                      quadrature.get_points());
+
+    // compute mapping data
+    MappingData                mapping_data;
+    CellSimilarity::Similarity cell_similarity = CellSimilarity::none;
+    internal::ComputeMappingDataHelper<dim, spacedim>::
+      compute_mapping_data_for_quadrature(mapping,
+                                          update_flags_mapping,
+                                          cell,
+                                          cell_similarity,
+                                          quadrature,
+                                          internal_mapping_data,
+                                          mapping_data);
+
+    // store mapping data
+    store_mapping_data(0,
+                       n_q_points_data,
+                       n_q_points_unvectorized[0],
+                       mapping_data);
 
     state = State::single_cell;
     is_reinitialized();
@@ -386,10 +676,10 @@ namespace NonMatching
 
 
 
-  template <int dim, int spacedim>
+  template <int dim, int spacedim, typename Number>
   template <typename ContainerType>
   void
-  MappingInfo<dim, spacedim>::reinit_cells(
+  MappingInfo<dim, spacedim, Number>::reinit_cells(
     const ContainerType &                       cell_iterator_range,
     const std::vector<std::vector<Point<dim>>> &unit_points_vector,
     const unsigned int                          n_unfiltered_cells)
@@ -409,10 +699,10 @@ namespace NonMatching
 
 
 
-  template <int dim, int spacedim>
+  template <int dim, int spacedim, typename Number>
   template <typename ContainerType>
   void
-  MappingInfo<dim, spacedim>::reinit_cells(
+  MappingInfo<dim, spacedim, Number>::reinit_cells(
     const ContainerType &               cell_iterator_range,
     const std::vector<Quadrature<dim>> &quadrature_vector,
     const unsigned int                  n_unfiltered_cells)
@@ -425,37 +715,70 @@ namespace NonMatching
                     std::distance(cell_iterator_range.begin(),
                                   cell_iterator_range.end()));
 
+    n_q_points_unvectorized.reserve(n_cells);
+
     // fill unit points index offset vector
     unit_points_index.reserve(n_cells + 1);
     unit_points_index.push_back(0);
+    data_index_offsets.reserve(n_cells + 1);
+    data_index_offsets.push_back(0);
     for (const auto &quadrature : quadrature_vector)
-      unit_points_index.push_back(unit_points_index.back() + quadrature.size());
+      {
+        const unsigned int n_points = quadrature.size();
+        n_q_points_unvectorized.push_back(n_points);
+
+        const unsigned int n_q_points =
+          compute_n_q_points<VectorizedArrayType>(n_points);
+        unit_points_index.push_back(unit_points_index.back() + n_q_points);
+
+        const unsigned int n_q_points_data =
+          compute_n_q_points<Number>(n_points);
+        data_index_offsets.push_back(data_index_offsets.back() +
+                                     n_q_points_data);
+      }
 
     const unsigned int n_unit_points = unit_points_index.back();
+    const unsigned int n_data_points = data_index_offsets.back();
 
-    unit_points.resize(n_unit_points);
-    mapping_data.resize(n_cells);
+    // resize data vectors
+    resize_unit_points(n_unit_points);
+    resize_data_fields(n_data_points);
 
     if (do_cell_index_compression)
       cell_index_to_compressed_cell_index.resize(n_unfiltered_cells,
                                                  numbers::invalid_unsigned_int);
+
+    MappingData                mapping_data;
     CellSimilarity::Similarity cell_similarity =
       CellSimilarity::Similarity::none;
     unsigned int cell_index = 0;
     for (const auto &cell : cell_iterator_range)
       {
-        auto it = unit_points.begin() + unit_points_index[cell_index];
-        for (const auto &unit_point :
-             quadrature_vector[cell_index].get_points())
-          {
-            *it = unit_point;
-            ++it;
-          }
+        // store unit points
+        const unsigned int n_q_points = compute_n_q_points<VectorizedArrayType>(
+          n_q_points_unvectorized[cell_index]);
+        store_unit_points(unit_points_index[cell_index],
+                          n_q_points,
+                          n_q_points_unvectorized[cell_index],
+                          quadrature_vector[cell_index].get_points());
 
-        compute_mapping_data_for_quadrature(cell,
-                                            cell_similarity,
-                                            quadrature_vector[cell_index],
-                                            mapping_data[cell_index]);
+        // compute mapping data
+        internal::ComputeMappingDataHelper<dim, spacedim>::
+          compute_mapping_data_for_quadrature(mapping,
+                                              update_flags_mapping,
+                                              cell,
+                                              cell_similarity,
+                                              quadrature_vector[cell_index],
+                                              internal_mapping_data,
+                                              mapping_data);
+
+        // store mapping data
+        const unsigned int n_q_points_data =
+          compute_n_q_points<Number>(n_q_points_unvectorized[cell_index]);
+        store_mapping_data(data_index_offsets[cell_index],
+                           n_q_points_data,
+                           n_q_points_unvectorized[cell_index],
+                           mapping_data);
 
         if (do_cell_index_compression)
           cell_index_to_compressed_cell_index[cell->active_cell_index()] =
@@ -470,10 +793,10 @@ namespace NonMatching
 
 
 
-  template <int dim, int spacedim>
+  template <int dim, int spacedim, typename Number>
   template <typename Iterator>
   void
-  MappingInfo<dim, spacedim>::reinit_surface(
+  MappingInfo<dim, spacedim, Number>::reinit_surface(
     const IteratorRange<Iterator> &                    cell_iterator_range,
     const std::vector<ImmersedSurfaceQuadrature<dim>> &quadrature_vector,
     const unsigned int                                 n_unfiltered_cells)
@@ -489,35 +812,70 @@ namespace NonMatching
                     std::distance(cell_iterator_range.begin(),
                                   cell_iterator_range.end()));
 
+    n_q_points_unvectorized.reserve(n_cells);
+
     // fill unit points index offset vector
     unit_points_index.reserve(n_cells + 1);
     unit_points_index.push_back(0);
+    data_index_offsets.reserve(n_cells + 1);
+    data_index_offsets.push_back(0);
     for (const auto &quadrature : quadrature_vector)
-      unit_points_index.push_back(unit_points_index.back() +
-                                  quadrature.get_points().size());
+      {
+        const unsigned int n_points = quadrature.size();
+        n_q_points_unvectorized.push_back(n_points);
+
+        const unsigned int n_q_points =
+          compute_n_q_points<VectorizedArrayType>(n_points);
+        unit_points_index.push_back(unit_points_index.back() + n_q_points);
+
+        const unsigned int n_q_points_data =
+          compute_n_q_points<Number>(n_points);
+        data_index_offsets.push_back(data_index_offsets.back() +
+                                     n_q_points_data);
+      }
 
     const unsigned int n_unit_points = unit_points_index.back();
+    const unsigned int n_data_points = data_index_offsets.back();
 
-    unit_points.resize(n_unit_points);
-    mapping_data.resize(n_cells);
+    // resize data vectors
+    resize_unit_points(n_unit_points);
+    resize_data_fields(n_data_points);
 
     if (do_cell_index_compression)
       cell_index_to_compressed_cell_index.resize(n_unfiltered_cells,
                                                  numbers::invalid_unsigned_int);
+
+    MappingData  mapping_data;
     unsigned int cell_index = 0;
     for (const auto &cell : cell_iterator_range)
       {
         const auto &quadrature = quadrature_vector[cell_index];
 
-        auto it = unit_points.begin() + unit_points_index[cell_index];
-        for (const auto &unit_point : quadrature.get_points())
-          {
-            *it = unit_point;
-            ++it;
-          }
+        // store unit points
+        const unsigned int n_q_points = compute_n_q_points<VectorizedArrayType>(
+          n_q_points_unvectorized[cell_index]);
+        store_unit_points(unit_points_index[cell_index],
+                          n_q_points,
+                          n_q_points_unvectorized[cell_index],
+                          quadrature_vector[cell_index].get_points());
 
-        compute_mapping_data_for_immersed_surface_quadrature(
-          cell, quadrature, mapping_data[cell_index]);
+        // compute mapping data
+        internal::ComputeMappingDataHelper<dim, spacedim>::
+          compute_mapping_data_for_immersed_surface_quadrature(
+            mapping,
+            update_flags_mapping,
+            cell,
+            quadrature,
+            internal_mapping_data,
+            mapping_data);
+
+        // store mapping data
+        const unsigned int n_q_points_data =
+          compute_n_q_points<Number>(n_q_points_unvectorized[cell_index]);
+        store_mapping_data(data_index_offsets[cell_index],
+                           n_q_points_data,
+                           n_q_points_unvectorized[cell_index],
+                           mapping_data);
 
         if (do_cell_index_compression)
           cell_index_to_compressed_cell_index[cell->active_cell_index()] =
@@ -532,10 +890,10 @@ namespace NonMatching
 
 
 
-  template <int dim, int spacedim>
+  template <int dim, int spacedim, typename Number>
   template <typename Iterator>
   void
-  MappingInfo<dim, spacedim>::reinit_faces(
+  MappingInfo<dim, spacedim, Number>::reinit_faces(
     const IteratorRange<Iterator> &                      cell_iterator_range,
     const std::vector<std::vector<Quadrature<dim - 1>>> &quadrature_vector,
     const unsigned int                                   n_unfiltered_cells)
@@ -559,10 +917,14 @@ namespace NonMatching
         ++cell_index;
       }
 
+    n_q_points_unvectorized.reserve(n_faces);
+
     // fill unit points index offset vector
     unit_points_index.resize(n_faces + 1);
+    data_index_offsets.resize(n_faces + 1);
     cell_index                 = 0;
     unsigned int n_unit_points = 0;
+    unsigned int n_data_points = 0;
     for (const auto &cell : cell_iterator_range)
       {
         for (const auto &f : cell->face_indices())
@@ -570,14 +932,26 @@ namespace NonMatching
             const unsigned int current_face_index =
               cell_index_offset[cell_index] + f;
 
-            unit_points_index[current_face_index] = n_unit_points;
-            n_unit_points +=
-              quadrature_vector[cell_index][f].get_points().size();
+            unit_points_index[current_face_index]  = n_unit_points;
+            data_index_offsets[current_face_index] = n_data_points;
+
+            const unsigned int n_points =
+              quadrature_vector[cell_index][f].size();
+            n_q_points_unvectorized.push_back(n_points);
+
+            const unsigned int n_q_points =
+              compute_n_q_points<VectorizedArrayType>(n_points);
+            n_unit_points += n_q_points;
+
+            const unsigned int n_q_points_data =
+              compute_n_q_points<Number>(n_points);
+            n_data_points += n_q_points_data;
           }
 
         ++cell_index;
       }
-    unit_points_index[n_faces] = n_unit_points;
+    unit_points_index[n_faces]  = n_unit_points;
+    data_index_offsets[n_faces] = n_data_points;
 
     // compress indices
     if (do_cell_index_compression)
@@ -585,8 +959,11 @@ namespace NonMatching
                                                  numbers::invalid_unsigned_int);
 
     // fill unit points and mapping data for every face of all cells
-    unit_points.resize(n_unit_points);
-    mapping_data.resize(n_faces);
+    // resize data vectors
+    resize_unit_points(n_unit_points);
+    resize_data_fields(n_data_points);
+
+    MappingData mapping_data;
     cell_index = 0;
     QProjector<dim> q_projector;
     for (const auto &cell : cell_iterator_range)
@@ -611,16 +988,30 @@ namespace NonMatching
             const unsigned int current_face_index =
               cell_index_offset[cell_index] + f;
 
-            auto it =
-              unit_points.begin() + unit_points_index[current_face_index];
-            for (const auto &unit_point : unit_points_on_cell)
-              {
-                *it = unit_point;
-                ++it;
-              }
+            // store unit points
+            const unsigned int n_q_points =
+              compute_n_q_points<VectorizedArrayType>(
+                n_q_points_unvectorized[current_face_index]);
+            store_unit_points(unit_points_index[current_face_index],
+                              n_q_points,
+                              n_q_points_unvectorized[current_face_index],
+                              quadrature_on_cell.get_points());
 
-            compute_mapping_data_for_face_quadrature(
-              cell, f, quadrature_on_face, mapping_data[current_face_index]);
+            internal::ComputeMappingDataHelper<dim, spacedim>::
+              compute_mapping_data_for_face_quadrature(mapping,
+                                                       update_flags_mapping,
+                                                       cell,
+                                                       f,
+                                                       quadrature_on_face,
+                                                       internal_mapping_data,
+                                                       mapping_data);
+
+            const unsigned int n_q_points_data = compute_n_q_points<Number>(
+              n_q_points_unvectorized[current_face_index]);
+            store_mapping_data(data_index_offsets[current_face_index],
+                               n_q_points_data,
+                               n_q_points_unvectorized[current_face_index],
+                               mapping_data);
           }
         if (do_cell_index_compression)
           cell_index_to_compressed_cell_index[cell->active_cell_index()] =
@@ -635,9 +1026,9 @@ namespace NonMatching
 
 
 
-  template <int dim, int spacedim>
-  inline const ArrayView<const Point<dim>>
-  MappingInfo<dim, spacedim>::get_unit_points(
+  template <int dim, int spacedim, typename Number>
+  unsigned int
+  MappingInfo<dim, spacedim, Number>::get_n_q_points_unvectorized(
     const unsigned int cell_index,
     const unsigned int face_number) const
   {
@@ -647,84 +1038,211 @@ namespace NonMatching
         Assert(state == State::single_cell,
                ExcMessage(
                  "This mapping info is not reinitialized for a single cell!"));
-        return unit_points;
-      }
-    else if (face_number == numbers::invalid_unsigned_int)
-      {
-        Assert(state == State::cell_vector,
-               ExcMessage(
-                 "This mapping info is not reinitialized for a cell vector!"));
-        if (do_cell_index_compression)
-          {
-            Assert(cell_index_to_compressed_cell_index[cell_index] !=
-                     numbers::invalid_unsigned_int,
-                   ExcMessage("Mapping info object was not initialized for this"
-                              " active cell index!"));
-            const auto it_begin =
-              unit_points.begin() +
-              unit_points_index
-                [cell_index_to_compressed_cell_index[cell_index]];
-            const auto it_end =
-              unit_points.begin() +
-              unit_points_index
-                [cell_index_to_compressed_cell_index[cell_index] + 1];
-            return make_array_view(it_begin, it_end);
-          }
-        else
-          {
-            const auto it_begin =
-              unit_points.begin() + unit_points_index[cell_index];
-            const auto it_end =
-              unit_points.begin() + unit_points_index[cell_index + 1];
-            return make_array_view(it_begin, it_end);
-          }
-      }
-    else if (cell_index != numbers::invalid_unsigned_int)
-      {
-        Assert(state == State::faces_on_cells_in_vector,
-               ExcMessage("This mapping info is not reinitialized for faces"
-                          " on cells in a vector!"));
-        if (do_cell_index_compression)
-          {
-            Assert(
-              cell_index_to_compressed_cell_index[cell_index] !=
-                numbers::invalid_unsigned_int,
-              ExcMessage(
-                "Mapping info object was not initialized for this active cell index"
-                " and corresponding face numbers!"));
-            const unsigned int current_face_index =
-              cell_index_offset
-                [cell_index_to_compressed_cell_index[cell_index]] +
-              face_number;
-            const auto it_begin =
-              unit_points.begin() + unit_points_index[current_face_index];
-            const auto it_end =
-              unit_points.begin() + unit_points_index[current_face_index + 1];
-            return make_array_view(it_begin, it_end);
-          }
-        else
-          {
-            const unsigned int current_face_index =
-              cell_index_offset[cell_index] + face_number;
-            const auto it_begin =
-              unit_points.begin() + unit_points_index[current_face_index];
-            const auto it_end =
-              unit_points.begin() + unit_points_index[current_face_index + 1];
-            return make_array_view(it_begin, it_end);
-          }
+        return n_q_points_unvectorized[0];
       }
     else
-      AssertThrow(
-        false,
-        ExcMessage(
-          "cell_index has to be specified if face_number is specified!"));
+      {
+        return n_q_points_unvectorized[compute_geometry_index_offset(
+          cell_index, face_number)];
+      }
   }
 
 
 
-  template <int dim, int spacedim>
-  inline const typename MappingInfo<dim, spacedim>::MappingData &
-  MappingInfo<dim, spacedim>::get_mapping_data(
+  template <int dim, int spacedim, typename Number>
+  template <typename NumberType>
+  unsigned int
+  MappingInfo<dim, spacedim, Number>::compute_n_q_points(
+    const unsigned int n_q_points_unvectorized)
+  {
+    const unsigned int n_lanes =
+      dealii::internal::VectorizedArrayTrait<NumberType>::width;
+    const unsigned int n_filled_lanes_last_batch =
+      n_q_points_unvectorized % n_lanes;
+    unsigned int n_q_points = n_q_points_unvectorized / n_lanes;
+    if (n_filled_lanes_last_batch > 0)
+      ++n_q_points;
+    return n_q_points;
+  }
+
+
+
+  template <int dim, int spacedim, typename Number>
+  unsigned int
+  MappingInfo<dim, spacedim, Number>::compute_geometry_index_offset(
+    const unsigned int cell_index,
+    const unsigned int face_number) const
+  {
+    const unsigned int compressed_cell_index =
+      compute_compressed_cell_index(cell_index);
+    if (face_number == numbers::invalid_unsigned_int)
+      {
+        Assert(state == State::cell_vector,
+               ExcMessage(
+                 "This mapping info is not reinitialized for a cell vector!"));
+        return compressed_cell_index;
+      }
+    else
+      {
+        Assert(cell_index != numbers::invalid_unsigned_int,
+               ExcMessage(
+                 "cell_index has to be set if face_number is specified!"));
+        Assert(state == State::faces_on_cells_in_vector,
+               ExcMessage("This mapping info is not reinitialized for faces"
+                          " on cells in a vector!"));
+        return cell_index_offset[compressed_cell_index] + face_number;
+      }
+  }
+
+
+
+  template <int dim, int spacedim, typename Number>
+  unsigned int
+  MappingInfo<dim, spacedim, Number>::compute_compressed_cell_index(
+    const unsigned int cell_index) const
+  {
+    if (do_cell_index_compression)
+      {
+        Assert(cell_index_to_compressed_cell_index[cell_index] !=
+                 numbers::invalid_unsigned_int,
+               ExcMessage("Mapping info object was not initialized for this"
+                          " active cell index!"));
+        return cell_index_to_compressed_cell_index[cell_index];
+      }
+    else
+      return cell_index;
+  }
+
+
+  template <int dim, int spacedim, typename Number>
+  void
+  MappingInfo<dim, spacedim, Number>::store_unit_points(
+    const unsigned int             unit_points_index_offset,
+    const unsigned int             n_q_points,
+    const unsigned int             n_q_points_unvectorized,
+    const std::vector<Point<dim>> &points)
+  {
+    const unsigned int n_lanes =
+      dealii::internal::VectorizedArrayTrait<VectorizedArrayType>::width;
+
+    for (unsigned int q = 0; q < n_q_points; ++q)
+      {
+        const unsigned int offset = unit_points_index_offset + q;
+        for (unsigned int v = 0;
+             v < n_lanes && q * n_lanes + v < n_q_points_unvectorized;
+             ++v)
+          for (unsigned int d = 0; d < dim; ++d)
+            dealii::internal::VectorizedArrayTrait<VectorizedArrayType>::get(
+              unit_points[offset][d], v) = points[q * n_lanes + v][d];
+      }
+  }
+
+
+
+  template <int dim, int spacedim, typename Number>
+  void
+  MappingInfo<dim, spacedim, Number>::store_mapping_data(
+    const unsigned int              unit_points_index_offset,
+    const unsigned int              n_q_points,
+    const unsigned int              n_q_points_unvectorized,
+    const MappingInfo::MappingData &mapping_data)
+  {
+    const unsigned int n_lanes =
+      dealii::internal::VectorizedArrayTrait<Number>::width;
+
+    for (unsigned int q = 0; q < n_q_points; ++q)
+      {
+        const unsigned int offset = unit_points_index_offset + q;
+        for (unsigned int v = 0;
+             v < n_lanes && q * n_lanes + v < n_q_points_unvectorized;
+             ++v)
+          {
+            if (update_flags_mapping & UpdateFlags::update_jacobians)
+              for (unsigned int d = 0; d < dim; ++d)
+                for (unsigned int s = 0; s < spacedim; ++s)
+                  dealii::internal::VectorizedArrayTrait<Number>::get(
+                    jacobians[offset][d][s], v) =
+                    mapping_data.jacobians[q * n_lanes + v][d][s];
+            if (update_flags_mapping & UpdateFlags::update_inverse_jacobians)
+              for (unsigned int d = 0; d < dim; ++d)
+                for (unsigned int s = 0; s < spacedim; ++s)
+                  dealii::internal::VectorizedArrayTrait<Number>::get(
+                    inverse_jacobians[offset][s][d], v) =
+                    mapping_data.inverse_jacobians[q * n_lanes + v][s][d];
+            if (update_flags_mapping & UpdateFlags::update_JxW_values)
+              dealii::internal::VectorizedArrayTrait<Number>::get(
+                JxW_values[offset], v) =
+                mapping_data.JxW_values[q * n_lanes + v];
+            if (update_flags_mapping & UpdateFlags::update_normal_vectors)
+              for (unsigned int s = 0; s < spacedim; ++s)
+                dealii::internal::VectorizedArrayTrait<Number>::get(
+                  normal_vectors[offset][s], v) =
+                  mapping_data.normal_vectors[q * n_lanes + v][s];
+            if (update_flags_mapping & UpdateFlags::update_quadrature_points)
+              for (unsigned int s = 0; s < spacedim; ++s)
+                dealii::internal::VectorizedArrayTrait<Number>::get(
+                  real_points[offset][s], v) =
+                  mapping_data.quadrature_points[q * n_lanes + v][s];
+          }
+      }
+  }
+
+
+
+  template <int dim, int spacedim, typename Number>
+  void
+  MappingInfo<dim, spacedim, Number>::resize_unit_points(
+    const unsigned int n_unit_point_batches)
+  {
+    unit_points.resize(n_unit_point_batches);
+  }
+
+
+
+  template <int dim, int spacedim, typename Number>
+  void
+  MappingInfo<dim, spacedim, Number>::resize_data_fields(
+    const unsigned int n_data_point_batches)
+  {
+    if (update_flags_mapping & UpdateFlags::update_jacobians)
+      jacobians.resize(n_data_point_batches);
+    if (update_flags_mapping & UpdateFlags::update_inverse_jacobians)
+      inverse_jacobians.resize(n_data_point_batches);
+    if (update_flags_mapping & UpdateFlags::update_JxW_values)
+      JxW_values.resize(n_data_point_batches);
+    if (update_flags_mapping & UpdateFlags::update_normal_vectors)
+      normal_vectors.resize(n_data_point_batches);
+    if (update_flags_mapping & UpdateFlags::update_quadrature_points)
+      real_points.resize(n_data_point_batches);
+  }
+
+
+
+  template <int dim, int spacedim, typename Number>
+  inline const Point<
+    dim,
+    typename MappingInfo<dim, spacedim, Number>::VectorizedArrayType> *
+  MappingInfo<dim, spacedim, Number>::get_unit_point(
+    const unsigned int offset) const
+  {
+    return &unit_points[offset];
+  }
+
+
+
+  template <int dim, int spacedim, typename Number>
+  inline const Point<dim, Number> *
+  MappingInfo<dim, spacedim, Number>::get_real_point(
+    const unsigned int offset) const
+  {
+    return &real_points[offset];
+  }
+
+
+
+  template <int dim, int spacedim, typename Number>
+  unsigned int
+  MappingInfo<dim, spacedim, Number>::compute_unit_point_index_offset(
     const unsigned int cell_index,
     const unsigned int face_number) const
   {
@@ -734,200 +1252,113 @@ namespace NonMatching
         Assert(state == State::single_cell,
                ExcMessage(
                  "This mapping info is not reinitialized for a single cell!"));
-        return mapping_data[0];
-      }
-    else if (face_number == numbers::invalid_unsigned_int)
-      {
-        Assert(state == State::cell_vector,
-               ExcMessage(
-                 "This mapping info is not reinitialized for a cell vector!"));
-        if (do_cell_index_compression)
-          {
-            Assert(cell_index_to_compressed_cell_index[cell_index] !=
-                     numbers::invalid_unsigned_int,
-                   ExcMessage("Mapping info object was not initialized for this"
-                              " active cell index!"));
-            return mapping_data
-              [cell_index_to_compressed_cell_index[cell_index]];
-          }
-        else
-          return mapping_data[cell_index];
-      }
-    else if (cell_index != numbers::invalid_unsigned_int)
-      {
-        Assert(state == State::faces_on_cells_in_vector,
-               ExcMessage("This mapping info is not reinitialized for faces"
-                          " on cells in a vector!"));
-        if (do_cell_index_compression)
-          {
-            Assert(
-              cell_index_to_compressed_cell_index[cell_index] !=
-                numbers::invalid_unsigned_int,
-              ExcMessage(
-                "Mapping info object was not initialized for this active cell index"
-                " and corresponding face numbers!"));
-            return mapping_data
-              [cell_index_offset
-                 [cell_index_to_compressed_cell_index[cell_index]] +
-               face_number];
-          }
-        else
-          return mapping_data[cell_index_offset[cell_index] + face_number];
+        return 0;
       }
     else
-      AssertThrow(
-        false,
-        ExcMessage(
-          "cell_index has to be specified if face_number is specified!"));
+      {
+        const unsigned int offset =
+          compute_geometry_index_offset(cell_index, face_number);
+        return unit_points_index[offset];
+      }
   }
 
 
 
-  template <int dim, int spacedim>
+  template <int dim, int spacedim, typename Number>
+  unsigned int
+  MappingInfo<dim, spacedim, Number>::compute_data_index_offset(
+    const unsigned int cell_index,
+    const unsigned int face_number) const
+  {
+    if (cell_index == numbers::invalid_unsigned_int &&
+        face_number == numbers::invalid_unsigned_int)
+      {
+        Assert(state == State::single_cell,
+               ExcMessage(
+                 "This mapping info is not reinitialized for a single cell!"));
+        return 0;
+      }
+    else
+      {
+        const unsigned int offset =
+          compute_geometry_index_offset(cell_index, face_number);
+        return data_index_offsets[offset];
+      }
+  }
+
+
+
+  template <int dim, int spacedim, typename Number>
+  inline const DerivativeForm<1, dim, spacedim, Number> *
+  MappingInfo<dim, spacedim, Number>::get_jacobian(
+    const unsigned int offset) const
+  {
+    return &jacobians[offset];
+  }
+
+
+
+  template <int dim, int spacedim, typename Number>
+  inline const DerivativeForm<1, spacedim, dim, Number> *
+  MappingInfo<dim, spacedim, Number>::get_inverse_jacobian(
+    const unsigned int offset) const
+  {
+    return &inverse_jacobians[offset];
+  }
+
+
+  template <int dim, int spacedim, typename Number>
+  inline const Tensor<1, spacedim, Number> *
+  MappingInfo<dim, spacedim, Number>::get_normal_vector(
+    const unsigned int offset) const
+  {
+    return &normal_vectors[offset];
+  }
+
+
+
+  template <int dim, int spacedim, typename Number>
+  inline const Number *
+  MappingInfo<dim, spacedim, Number>::get_JxW(const unsigned int offset) const
+  {
+    return &JxW_values[offset];
+  }
+
+
+
+  template <int dim, int spacedim, typename Number>
   const Mapping<dim, spacedim> &
-  MappingInfo<dim, spacedim>::get_mapping() const
+  MappingInfo<dim, spacedim, Number>::get_mapping() const
   {
     return *mapping;
   }
 
 
 
-  template <int dim, int spacedim>
+  template <int dim, int spacedim, typename Number>
   UpdateFlags
-  MappingInfo<dim, spacedim>::get_update_flags() const
+  MappingInfo<dim, spacedim, Number>::get_update_flags() const
   {
     return update_flags;
   }
 
 
 
-  template <int dim, int spacedim>
+  template <int dim, int spacedim, typename Number>
+  UpdateFlags
+  MappingInfo<dim, spacedim, Number>::get_update_flags_mapping() const
+  {
+    return update_flags_mapping;
+  }
+
+
+
+  template <int dim, int spacedim, typename Number>
   boost::signals2::connection
-  MappingInfo<dim, spacedim>::connect_is_reinitialized(
+  MappingInfo<dim, spacedim, Number>::connect_is_reinitialized(
     const std::function<void()> &set_is_reinitialized)
   {
     return is_reinitialized.connect(set_is_reinitialized);
-  }
-
-
-
-  template <int dim, int spacedim>
-  void
-  MappingInfo<dim, spacedim>::compute_mapping_data_for_quadrature(
-    const typename Triangulation<dim, spacedim>::cell_iterator &cell,
-    CellSimilarity::Similarity &                                cell_similarity,
-    const Quadrature<dim> &                                     quadrature,
-    MappingData &                                               mapping_data)
-  {
-    update_flags_mapping |=
-      mapping->requires_update_flags(update_flags_mapping);
-
-    mapping_data.initialize(quadrature.size(), update_flags_mapping);
-
-    // reuse internal_mapping_data for MappingQ to avoid memory allocations
-    if (const MappingQ<dim, spacedim> *mapping_q =
-          dynamic_cast<const MappingQ<dim, spacedim> *>(&(*mapping)))
-      {
-        (void)mapping_q;
-        auto &data =
-          dynamic_cast<typename MappingQ<dim, spacedim>::InternalData &>(
-            *internal_mapping_data);
-        data.initialize(update_flags_mapping, quadrature, quadrature.size());
-      }
-    else
-      {
-        internal_mapping_data =
-          mapping->get_data(update_flags_mapping, quadrature);
-      }
-
-    cell_similarity = mapping->fill_fe_values(
-      cell, cell_similarity, quadrature, *internal_mapping_data, mapping_data);
-  }
-
-
-
-  template <int dim, int spacedim>
-  void
-  MappingInfo<dim, spacedim>::
-    compute_mapping_data_for_immersed_surface_quadrature(
-      const typename Triangulation<dim, spacedim>::cell_iterator &cell,
-      const ImmersedSurfaceQuadrature<dim> &                      quadrature,
-      MappingData &                                               mapping_data)
-  {
-    update_flags_mapping |=
-      mapping->requires_update_flags(update_flags_mapping);
-
-    mapping_data.initialize(quadrature.size(), update_flags_mapping);
-
-    // reuse internal_mapping_data for MappingQ to avoid memory allocations
-    if (const MappingQ<dim, spacedim> *mapping_q =
-          dynamic_cast<const MappingQ<dim, spacedim> *>(&(*mapping)))
-      {
-        (void)mapping_q;
-        auto &data =
-          dynamic_cast<typename MappingQ<dim, spacedim>::InternalData &>(
-            *internal_mapping_data);
-        data.initialize(update_flags_mapping, quadrature, quadrature.size());
-      }
-    else
-      {
-        internal_mapping_data =
-          mapping->get_data(update_flags_mapping, quadrature);
-      }
-
-    mapping->fill_fe_immersed_surface_values(cell,
-                                             quadrature,
-                                             *internal_mapping_data,
-                                             mapping_data);
-  }
-
-
-
-  template <int dim, int spacedim>
-  void
-  MappingInfo<dim, spacedim>::compute_mapping_data_for_face_quadrature(
-    const typename Triangulation<dim, spacedim>::cell_iterator &cell,
-    const unsigned int                                          face_no,
-    const Quadrature<dim - 1> &                                 quadrature,
-    MappingData &                                               mapping_data)
-  {
-    update_flags_mapping |=
-      mapping->requires_update_flags(update_flags_mapping);
-
-    mapping_data.initialize(quadrature.size(), update_flags_mapping);
-
-    // reuse internal_mapping_data for MappingQ to avoid memory allocations
-    if (const MappingQ<dim, spacedim> *mapping_q =
-          dynamic_cast<const MappingQ<dim, spacedim> *>(&(*mapping)))
-      {
-        auto &data =
-          dynamic_cast<typename MappingQ<dim, spacedim>::InternalData &>(
-            *internal_mapping_data);
-        data.initialize_face(update_flags_mapping,
-                             QProjector<dim>::project_to_oriented_face(
-                               ReferenceCells::get_hypercube<dim>(),
-                               quadrature,
-                               face_no,
-                               cell->face_orientation(face_no),
-                               cell->face_flip(face_no),
-                               cell->face_rotation(face_no)),
-                             quadrature.size());
-
-        mapping_q->fill_mapping_data_for_face_quadrature(
-          cell, face_no, quadrature, *internal_mapping_data, mapping_data);
-      }
-    else
-      {
-        auto internal_mapping_data =
-          mapping->get_face_data(update_flags_mapping,
-                                 hp::QCollection<dim - 1>(quadrature));
-
-        mapping->fill_fe_face_values(cell,
-                                     face_no,
-                                     hp::QCollection<dim - 1>(quadrature),
-                                     *internal_mapping_data,
-                                     mapping_data);
-      }
   }
 } // namespace NonMatching
 

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -186,8 +186,10 @@ MappingQ<dim, spacedim>::InternalData::initialize_face(
       if (this->update_each &
           (update_boundary_forms | update_normal_vectors | update_JxW_values))
         {
-          aux.resize(dim - 1,
-                     AlignedVector<Tensor<1, spacedim>>(n_original_q_points));
+          aux.resize(dim - 1);
+          aux[0].resize(n_original_q_points);
+          if (dim > 2)
+            aux[1].resize(n_original_q_points);
 
           // Compute tangentials to the unit cell.
           for (const unsigned int i : GeometryInfo<dim>::face_indices())

--- a/tests/non_matching/mapping_info.cc
+++ b/tests/non_matching/mapping_info.cc
@@ -40,10 +40,10 @@
 
 using namespace dealii;
 
+template <int dim>
 void
 test(const bool filtered_compression)
 {
-  constexpr unsigned int dim    = 2;
   constexpr unsigned int degree = 1;
 
   FE_Q<dim> fe_q(degree);
@@ -471,7 +471,11 @@ main(int argc, char **argv)
 
   initlog();
 
-  test(true);
+  test<2>(true);
   deallog << std::endl;
-  test(false);
+  test<2>(false);
+  deallog << std::endl;
+  test<3>(true);
+  deallog << std::endl;
+  test<3>(false);
 }

--- a/tests/non_matching/mapping_info.output
+++ b/tests/non_matching/mapping_info.output
@@ -6,3 +6,11 @@ DEAL::
 DEAL::check difference l2 norm cell: 0.00000
 DEAL::check difference l2 norm surface: 0.00000
 DEAL::check difference l2 norm faces: 0.00000
+DEAL::
+DEAL::check difference l2 norm cell: 0.00000
+DEAL::check difference l2 norm surface: 0.00000
+DEAL::check difference l2 norm faces: 0.00000
+DEAL::
+DEAL::check difference l2 norm cell: 0.00000
+DEAL::check difference l2 norm surface: 0.00000
+DEAL::check difference l2 norm faces: 0.00000


### PR DESCRIPTION
This PR proposes to vectorize `NonMatching::MappingInfo` depending on the newly introduced template parameter `Number`. As this class interacts with `FEPointEvaluation`, which is vectorized internally also for scalar `Number` template arguments, the unit points are always stored vectorized to make them easily accessible.

To enable vectorized storage, separate `AlignedVector` objects are created for Jacobians, ... and a temporary `internal::FEValuesImplementation::MappingRelatedData` local object is used to use the interfaces which `Mapping` provides to compute mapping data.

The result is a 100% - 10% speedup in throughput of `FEPointEvaluation` depending on the polynomial degree and the dimension of the problem in my Laplace type benchmark.