### PR TITLE
Update bibtex entries of preprints.

### DIFF
--- a/doc/doxygen/references.bib
+++ b/doc/doxygen/references.bib
@@ -1373,13 +1373,18 @@ numpages = {15}
 % Step 76
 % ------------------------------------
 
-@misc{munch2020hyperdeal,
-  author =        {P. Munch and K. Kormann and M. Kronbichler},
-  title =         {hyper.deal: An efficient, matrix-free finite-element library for high-dimensional partial differential equations},
-  year =          {2020},
-  eprint =        {2002.08110},
-  archivePrefix = {arXiv},
-  primaryClass =  {cs.MS}
+@article{munch2020hyperdeal,
+  doi = {10.1145/3469720},
+  url = {https://dl.acm.org/doi/abs/10.1145/3469720},
+  year = 2021,
+  month = sep,
+  publisher = {Association for Computing Machinery ({ACM})},
+  volume = 47,
+  number = 4,
+  pages = {33/1--34},
+  author = {P. Munch and K. Kormann and M. Kronbichler},
+  title = {hyper.deal: An Efficient, Matrix-free Finite-element Library for High-dimensional Partial Differential Equations},
+  journal = {{ACM} Transactions on Mathematical Software}
 }
 
 
@@ -1593,19 +1598,30 @@ numpages = {15}
 }
 
 @article{BGNY2020,
-  title={{LDG} approximation of large deformations of prestrained plates},
-  author={A. Bonito and D. Guignard and R.H. Nochetto and S. Yang},
-  journal={To appear in Journal of Computational Physics},
-  year={2021},
-  url = {https://doi.org/10.1016/j.jcp.2021.110719}
+  doi = {10.1016/j.jcp.2021.110719},
+  url = {https://www.sciencedirect.com/science/article/pii/S0021999121006148},
+  year = 2022,
+  month = jan,
+  publisher = {Elsevier {BV}},
+  volume = 448,
+  pages = {110719/1--27},
+  author = {A. Bonito and D. Guignard and R.H. Nochetto and S. Yang},
+  title = {{LDG} approximation of large deformations of prestrained plates},
+  journal = {Journal of Computational Physics}
 }
 
 @article{BGNY2021,
-  title={Numerical analysis of the {LDG} method for large deformations of prestrained plates},
-  author={A. Bonito and D. Guignard and R.H. Nochetto and S. Yang},
-  journal={Submitted},
-  year={2021},
-  url = {https://arxiv.org/abs/2106.13877}
+  doi = {10.1093/imanum/drab103},
+  url = {https://academic.oup.com/imajna/article/43/2/627/6517084},
+  year = 2022,
+  month = mar,
+  publisher = {Oxford University Press ({OUP})},
+  volume = 43,
+  number = 2,
+  pages = {627--662},
+  author = {A. Bonito and D. Guignard and R.H. Nochetto and S. Yang},
+  title = {Numerical analysis of the {LDG} method for large deformations of prestrained plates},
+  journal = {{IMA} Journal of Numerical Analysis}
 }
 
 % ------------------------------------
@@ -1953,8 +1969,7 @@ numpages = {15}
   author={K. Ljungkvist},
   booktitle={Proceedings of the 25th High Performance Computing Symposium},
   series={HPC '17},
-  articleno={1},
-  numpages={12},
+  pages={1/1--12},
   year={2017},
   url={https://dl.acm.org/doi/10.5555/3108096.3108097}
 }
@@ -2054,14 +2069,17 @@ url = {https://doi.org/10.1016/0045-7930(73)90027-3}
 }
 
 @article{munch2022gc,
-  doi       = {10.48550/ARXIV.2203.12292},  
-  url       = {https://arxiv.org/abs/2203.12292},
-  author    = {Peter Munch and Timo Heister and Laura Prieto Saavedra and Martin Kronbichler},
-  keywords  = {Numerical Analysis (math.NA), Mathematical Software (cs.MS), FOS: Mathematics, FOS: Mathematics, FOS: Computer and information sciences, FOS: Computer and information sciences, G.4},
-  title     = {Efficient distributed matrix-free multigrid methods on locally refined meshes for FEM computations},
-  publisher = {arXiv},
-  year      = {2022},
-  copyright = {arXiv.org perpetual, non-exclusive license}
+  doi = {10.1145/3580314},
+  url = {https://dl.acm.org/doi/full/10.1145/3580314},
+  year = 2023,
+  month = mar,
+  publisher = {Association for Computing Machinery ({ACM})},
+  volume = 10,
+  number = 1,
+  pages = {3/1--38},
+  author = {Peter Munch and Timo Heister and Laura Prieto Saavedra and Martin Kronbichler},
+  title = {Efficient Distributed Matrix-free Multigrid Methods on Locally Refined Meshes for {FEM} Computations},
+  journal = {{ACM} Transactions on Parallel Computing}
 }
 
 @InProceedings{munch2022hn,


### PR DESCRIPTION
One bibtex entry is again displayed odd in the bibliography (see also #13264)
![image](https://user-images.githubusercontent.com/18285973/234464034-cb0095a0-84ac-49ea-b1e1-5dac2a0e4f58.png)

This is a preprint, and the article has been published in the meantime. I replaced the preprint entry with the actual paper. Let's see if that helps.

@peterrum -- FYI