### PR TITLE
Format authors in bibliography.

### DIFF
--- a/doc/doxygen/references.bib
+++ b/doc/doxygen/references.bib
@@ -47,7 +47,7 @@
 }
 
 @article{KronbichlerWall2018,
-  author    = {Kronbichler, Martin and Wall, Wolfgang A.},
+  author    = {M. Kronbichler and W.A. Wall},
   title     = {A Performance Comparison of Continuous and Discontinuous Galerkin Methods with Fast Multigrid Solvers},
   journal   = {SIAM Journal on Scientific Computing},
   year      = {2018},
@@ -629,7 +629,7 @@
 %-------------------------------------------------------------------------------
 
 @article{Benzi2006,
-  author = { Benzi, Michele and Olshanskii, Maxim A. },
+  author = { M. Benzi and M.A. Olshanskii },
   title = { An Augmented Lagrangian‐Based Approach to the Oseen Problem },
   journal = { SIAM J. Sci. Comput. },
   year = { 2006 },
@@ -641,7 +641,7 @@
 }
 
 @article{HeisterRapin2013,
-  author = { Heister, Timo and Rapin, Gerd },
+  author = { T. Heister and G. Rapin },
   title = { Efficient augmented Lagrangian-type preconditioning for the Oseen problem using Grad-Div stabilization },
   journal = { Int. J. Numer. Meth. Fluids },
   year = { 2013 },
@@ -653,7 +653,7 @@
 }
 
 @article{Ghia1982,
-  author = { Ghia, U and Ghia, K.N and Shin, C.T },
+  author = { U. Ghia and K.N. Ghia and C.T. Shin },
   title = { High-Re solutions for incompressible flow using the Navier-Stokes equations and a multigrid method },
   journal = { Journal of Computational Physics },
   year = { 1982 },
@@ -665,7 +665,7 @@
 }
 
 @article{Erturk2005,
-  author = { Erturk, E. and Corke, T. C. and G\"ok\c{c}\"ol, C. },
+  author = { E. Erturk and T.C. Corke and C. G\"ok\c{c}\"ol },
   title = { Numerical solutions of 2-D steady incompressible driven cavity flow at high Reynolds numbers },
   journal = { Int. J. Numer. Meth. Fluids },
   year = { 2005 },
@@ -677,7 +677,7 @@
 }
 
 @article{Yang1998,
-  author = { Yang, Jaw-Yen and Yang, Shih-Chang and Chen, Yih-Nan and Hsu, Chiang-An },
+  author = { J.-Y. Yang and S.-C. Yang and Y.-N. Chen and C.-A. Hsu },
   title = { Implicit Weighted ENO Schemes for the Three-Dimensional Incompressible Navier--Stokes Equations },
   journal = { Journal of Computational Physics },
   year = { 1998 },
@@ -689,7 +689,7 @@
 }
 
 @article{Bruneau2006,
-  author = { Bruneau, Charles-Henri and Saad, Mazen },
+  author = { C.-H. Bruneau and M. Saad },
   title = { The 2D lid-driven cavity problem revisited },
   journal = { Computers \& Fluids },
   year = { 2006 },
@@ -706,7 +706,7 @@
 %-------------------------------------------------------------------------------
 
 @article{Fraysse2005,
-  author = { Frayss\'e, Val\'erie and Giraud, Luc and Gratton, Serge and Langou, Julien },
+  author = { V. Frayss\'e and L. Giraud and S. Gratton and J. Langou },
   title = { Algorithm 842: A set of GMRES routines for real and complex arithmetics on high performance computers },
   journal = { ACM Trans. Math. Softw. },
   year = { 2005 },
@@ -718,7 +718,7 @@
 }
 
 @article{Day2001,
-  author = { Day, David and Heroux, Michael A. },
+  author = { D. Day and M.A. Heroux },
   title = { Solving Complex-Valued Linear Systems via Equivalent Real Formulations },
   journal = { SIAM J. Sci. Comput. },
   year = { 2001 },
@@ -730,7 +730,7 @@
 }
 
 @article{Axelsson2014,
-  author = { Axelsson, Owe and Neytcheva, Maya and Ahmad, Bashir },
+  author = { O. Axelsson and M. Neytcheva and B. Ahmad },
   title = { A comparison of iterative methods to solve complex valued linear algebraic systems },
   journal = { Numer Algor },
   year = { 2014 },
@@ -742,7 +742,7 @@
 }
 
 @article{Liao2016,
-  author = { Liao, Li-Dan and Zhang, Guo-Feng },
+  author = { L.-D. Liao and G.-F. Zhang },
   title = { Preconditioning of complex linear systems from the Helmholtz equation },
   journal = { Computers \& Mathematics with Applications },
   year = { 2016 },
@@ -759,7 +759,7 @@
 %-------------------------------------------------------------------------------
 
 @article{Lynch1964,
-  author = {Lynch, Robert E. and Rice, John R. and Thomas, Donald H.},
+  author = {R.E. Lynch and J.R. Rice and D.H. Thomas},
   title = {Direct Solution of Partial Difference Equations by Tensor Product Methods},
   year = {1964},
   issue_date = {December 1964},
@@ -1512,7 +1512,7 @@
 }
 
 @ARTICLE{berenger1994,
-  AUTHOR={Jean-Pierre Bérenger},
+  AUTHOR={J.-P. B\'erenger},
   TITLE={A Perfectly Matched Layer for the Absorption of Electromagnetic Waves},
   JOURNAL={Journal of Computational Physics},
   VOLUME={114},
@@ -1521,7 +1521,7 @@
 }
 
 @ARTICLE{Gopalakrishnan2003,
-  AUTHOR={J. Gopalakrishnan and Pasciak, J. E.},
+  AUTHOR={J. Gopalakrishnan and J.E. Pasciak},
   TITLE={Overlapping Schwarz preconditioners for indefinite time harmonic {M}axwell equations},
   JOURNAL={Math. Comput.},
   VOLUME={72},
@@ -1637,7 +1637,7 @@
   number = {2},
   urldate = {2016-01-27},
   journal = {SIAM Journal on Scientific Computing},
-  author = {Saye, R. I.},
+  author = {R.I. Saye},
   month = jan,
   year = {2015},
   pages = {A993--A1019}
@@ -1653,7 +1653,7 @@
   number = {4},
   urldate = {2015-12-17},
   journal = {Applied Numerical Mathematics},
-  author = {Burman, Erik and Hansbo, Peter},
+  author = {E. Burman and P. Hansbo},
   month = apr,
   year = {2012},
   pages = {328--341}
@@ -1669,7 +1669,7 @@
   number = {7},
   urldate = {2016-01-27},
   journal = {International Journal for Numerical Methods in Engineering},
-  author = {Burman, Erik and Claus, Susanne and Hansbo, Peter and Larson, Mats G. and Massing, André},
+  author = {E. Burman and S. Claus and P. Hansbo and M.G. Larson and A. Massing},
   month = nov,
   year = {2015},
   pages = {472--501}
@@ -1824,7 +1824,7 @@
 }
 
 @book{Refactoring,
-  author = {Martin Fowler},
+  author = {M. Fowler},
   title = {Refactoring: Improving the Design of Existing Code},
   publisher = {Addison-Wesley},
   year = {2018},
@@ -2075,13 +2075,13 @@
   volume = 10,
   number = 1,
   pages = {3/1--38},
-  author = {Peter Munch and Timo Heister and Laura Prieto Saavedra and Martin Kronbichler},
+  author = {P. Munch and T. Heister and L. Prieto Saavedra and M. Kronbichler},
   title = {Efficient Distributed Matrix-free Multigrid Methods on Locally Refined Meshes for {FEM} Computations},
   journal = {{ACM} Transactions on Parallel Computing}
 }
 
 @InProceedings{munch2022hn,
-  author    = {Peter Munch and Karl Ljungkvist and Martin Kronbichler},
+  author    = {P. Munch and K. Ljungkvist and M. Kronbichler},
   title     = {Efficient Application of Hanging-Node Constraints for Matrix-Free High-Order {FEM} Computations on {CPU} and {GPU}},
   booktitle = {Lecture Notes in Computer Science},
   year      = {2022},
@@ -2094,7 +2094,7 @@
 @misc{Barnafi2022,
   doi = {10.48550/ARXIV.2208.06191},
   url = {https://arxiv.org/abs/2208.06191},
-  author = {Barnafi, Nicolás A. and Pavarino, Luca F. and Scacchi, Simone},
+  author = {N.A. Barnafi and L.F. Pavarino and S. Scacchi},
   title = {A comparative study of scalable multilevel preconditioners for cardiac mechanics},
   publisher = {arXiv},
   year = {2022},
@@ -2102,14 +2102,14 @@
 
 @article{lottes2022optimal,
   title={Optimal polynomial smoothers for multigrid V-cycles},
-  author={Lottes, James},
+  author={J. Lottes},
   journal={arXiv preprint arXiv:2202.08830},
   year={2022}
 }
 
 @article{phillips2022optimal,
   title={Optimal Chebyshev Smoothers and One-sided V-cycles},
-  author={Phillips, Malachi and Fischer, Paul},
+  author={M. Phillips and P. Fischer},
   journal={arXiv preprint arXiv:2210.03179},
   year={2022}
 }
@@ -2132,7 +2132,7 @@
 
 @article{zampini2016pcbddc,
   title={PCBDDC: a class of robust dual-primal methods in PETSc},
-  author={Zampini, Stefano},
+  author={S. Zampini},
   journal={SIAM Journal on Scientific Computing},
   volume={38},
   number={5},
@@ -2143,7 +2143,7 @@
 
 @article{zalesak1979fully,
   title={Fully multidimensional flux-corrected transport algorithms for fluids},
-  author={Zalesak, Steven T},
+  author={S.T. Zalesak},
   journal={Journal of Computational Physics},
   volume={31},
   number={3},


### PR DESCRIPTION
In https://github.com/dealii/dealii/pull/12487, we agreed on a naming convention for the `authors` field. This PR maintains it.