### PR TITLE
make it possible to fill RPE with GT::DistributedComputePointLocation…

### DIFF
--- a/include/deal.II/base/mpi_remote_point_evaluation.h
+++ b/include/deal.II/base/mpi_remote_point_evaluation.h
@@ -25,6 +25,15 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations
+namespace GridTools
+{
+  namespace internal
+  {
+    template <int dim, int spacedim>
+    struct DistributedComputePointLocationsInternal;
+  }
+} // namespace GridTools
 
 namespace Utilities
 {
@@ -85,6 +94,21 @@ namespace Utilities
       reinit(const std::vector<Point<spacedim>> &points,
              const Triangulation<dim, spacedim> &tria,
              const Mapping<dim, spacedim> &      mapping);
+
+      /**
+       * Set up internal data structures and communication pattern based on
+       * GridTools::internal::DistributedComputePointLocationsInternal.
+       *
+       * This function is called internally by the reinit() function above.
+       * Having it as a seperate function makes it possible to setup the class
+       * if it is known in which cells corresponding reference points are
+       * located (e.g. if intersections of cells are known).
+       */
+      void
+      reinit(const GridTools::internal::
+               DistributedComputePointLocationsInternal<dim, spacedim> &data,
+             const Triangulation<dim, spacedim> &                       tria,
+             const Mapping<dim, spacedim> &mapping);
 
       /**
        * Data of points positioned in a cell.

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -1213,6 +1213,22 @@ namespace GridTools
     template <int dim, int spacedim>
     struct DistributedComputePointLocationsInternal
     {
+      DistributedComputePointLocationsInternal();
+
+      /**
+       * Function which sets up @p send_ranks, @p send_ptrs, @p recv_ranks,
+       * and @p recv_ptrs from @p send_components, @p recv_components,
+       * and @p n_searched_points. Internally @p send_components and @p recv_components
+       * are sorted and enumerated.
+       */
+      void
+      finalize_setup();
+
+      /**
+       * Number of searched point locations.
+       */
+      unsigned int n_searched_points;
+
       /**
        * Information of each point on sending/evaluation side. The elements of
        * the tuple are as follows: 0) cell level and index, 1) rank of the

--- a/source/base/mpi_remote_point_evaluation.cc
+++ b/source/base/mpi_remote_point_evaluation.cc
@@ -78,9 +78,6 @@ namespace Utilities
       tria_signal =
         tria.signals.any_change.connect([&]() { this->ready_flag = false; });
 
-      this->tria    = &tria;
-      this->mapping = &mapping;
-
       std::vector<BoundingBox<spacedim>> local_boxes;
       for (const auto &cell :
            tria.active_cell_iterators() | IteratorFilters::LocallyOwnedCell())
@@ -105,6 +102,23 @@ namespace Utilities
           true,
           enforce_unique_mapping);
 
+      this->reinit(data, tria, mapping);
+#endif
+    }
+
+
+
+    template <int dim, int spacedim>
+    void
+    RemotePointEvaluation<dim, spacedim>::reinit(
+      const GridTools::internal::
+        DistributedComputePointLocationsInternal<dim, spacedim> &data,
+      const Triangulation<dim, spacedim> &                       tria,
+      const Mapping<dim, spacedim> &                             mapping)
+    {
+      this->tria    = &tria;
+      this->mapping = &mapping;
+
       this->recv_ranks = data.recv_ranks;
       this->recv_ptrs  = data.recv_ptrs;
 
@@ -113,7 +127,7 @@ namespace Utilities
 
       this->recv_permutation = {};
       this->recv_permutation.resize(data.recv_components.size());
-      this->point_ptrs.assign(points.size() + 1, 0);
+      this->point_ptrs.assign(data.n_searched_points + 1, 0);
       for (unsigned int i = 0; i < data.recv_components.size(); ++i)
         {
           AssertIndexRange(std::get<2>(data.recv_components[i]),
@@ -130,7 +144,7 @@ namespace Utilities
       std::tuple<unsigned int, unsigned int> n_owning_processes_local =
         n_owning_processes_default;
 
-      for (unsigned int i = 0; i < points.size(); ++i)
+      for (unsigned int i = 0; i < data.n_searched_points; ++i)
         {
           std::get<0>(n_owning_processes_local) =
             std::min(std::get<0>(n_owning_processes_local),
@@ -196,7 +210,6 @@ namespace Utilities
         cell_data.reference_point_values.size());
 
       this->ready_flag = true;
-#endif
     }
 
 

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -141,6 +141,10 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
         const std::vector<bool> &marked_vertices,
         const bool               enforce_unique_mapping);
 
+      template struct internal::DistributedComputePointLocationsInternal<
+        deal_II_dimension,
+        deal_II_space_dimension>;
+
       template internal::DistributedComputePointLocationsInternal<
         deal_II_dimension,
         deal_II_space_dimension>


### PR DESCRIPTION
Belongs to https://github.com/dealii/dealii/issues/14338. 

If we have all information to compute ```GT::DistributedComputePointLocationsInternal``` we can initialize ```RPE```, skipping the search of point locations. I will keep this PR as a draft until I placed the remaining PRs of https://github.com/dealii/dealii/issues/14338.

@fdrmrc @peterrum 