### PR TITLE
pass MPI_Comm by value

### DIFF
--- a/doc/news/changes/minor/20230508tjhei
+++ b/doc/news/changes/minor/20230508tjhei
@@ -1,0 +1,5 @@
+Changed: MPI communicators (of type `MPI_Comm`) are now treated as
+trivially copyable POD types throughout the library. This means that
+we store and pass them by value instead of by reference.
+<br>
+(Timo Heister, 2023/05/08)

--- a/examples/step-45/step-45.cc
+++ b/examples/step-45/step-45.cc
@@ -193,7 +193,7 @@ namespace Step45
     InverseMatrix(const MatrixType &        m,
                   const PreconditionerType &preconditioner,
                   const IndexSet &          locally_owned,
-                  const MPI_Comm &          mpi_communicator);
+                  const MPI_Comm            mpi_communicator);
 
     void vmult(TrilinosWrappers::MPI::Vector &      dst,
                const TrilinosWrappers::MPI::Vector &src) const;
@@ -213,7 +213,7 @@ namespace Step45
     const MatrixType &        m,
     const PreconditionerType &preconditioner,
     const IndexSet &          locally_owned,
-    const MPI_Comm &          mpi_communicator)
+    const MPI_Comm            mpi_communicator)
     : matrix(&m)
     , preconditioner(&preconditioner)
     , mpi_communicator(&mpi_communicator)
@@ -246,7 +246,7 @@ namespace Step45
                     const InverseMatrix<TrilinosWrappers::SparseMatrix,
                                         PreconditionerType> &  A_inverse,
                     const IndexSet &                           owned_pres,
-                    const MPI_Comm &mpi_communicator);
+                    const MPI_Comm mpi_communicator);
 
     void vmult(TrilinosWrappers::MPI::Vector &      dst,
                const TrilinosWrappers::MPI::Vector &src) const;
@@ -267,7 +267,7 @@ namespace Step45
     const InverseMatrix<TrilinosWrappers::SparseMatrix, PreconditionerType>
       &             A_inverse,
     const IndexSet &owned_vel,
-    const MPI_Comm &mpi_communicator)
+    const MPI_Comm  mpi_communicator)
     : system_matrix(&system_matrix)
     , A_inverse(&A_inverse)
     , tmp1(owned_vel, mpi_communicator)

--- a/include/deal.II/arborx/distributed_tree.h
+++ b/include/deal.II/arborx/distributed_tree.h
@@ -44,7 +44,7 @@ namespace ArborXWrappers
      */
     template <int dim, typename Number>
     DistributedTree(
-      const MPI_Comm &                             comm,
+      const MPI_Comm                               comm,
       const std::vector<BoundingBox<dim, Number>> &bounding_boxes);
 
     /**
@@ -52,7 +52,7 @@ namespace ArborXWrappers
      * in @p points are local to the MPI process.
      */
     template <int dim, typename Number>
-    DistributedTree(const MPI_Comm &                       comm,
+    DistributedTree(const MPI_Comm                         comm,
                     const std::vector<Point<dim, Number>> &points);
 
     /**
@@ -82,7 +82,7 @@ namespace ArborXWrappers
 
   template <int dim, typename Number>
   DistributedTree::DistributedTree(
-    const MPI_Comm &                             comm,
+    const MPI_Comm                               comm,
     const std::vector<BoundingBox<dim, Number>> &bounding_boxes)
     : distributed_tree(comm,
                        Kokkos::DefaultHostExecutionSpace{},
@@ -93,7 +93,7 @@ namespace ArborXWrappers
 
   template <int dim, typename Number>
   DistributedTree::DistributedTree(
-    const MPI_Comm &                       comm,
+    const MPI_Comm                         comm,
     const std::vector<Point<dim, Number>> &points)
     : distributed_tree(comm, Kokkos::DefaultHostExecutionSpace{}, points)
   {}

--- a/include/deal.II/base/aligned_vector.h
+++ b/include/deal.II/base/aligned_vector.h
@@ -346,7 +346,7 @@ public:
    *   the destructor is called.
    */
   void
-  replicate_across_communicator(const MPI_Comm &   communicator,
+  replicate_across_communicator(const MPI_Comm     communicator,
                                 const unsigned int root_process);
 
   /**
@@ -1503,7 +1503,7 @@ AlignedVector<T>::fill(const T &value)
 
 template <class T>
 inline void
-AlignedVector<T>::replicate_across_communicator(const MPI_Comm &   communicator,
+AlignedVector<T>::replicate_across_communicator(const MPI_Comm     communicator,
                                                 const unsigned int root_process)
 {
 #  ifdef DEAL_II_WITH_MPI

--- a/include/deal.II/base/communication_pattern_base.h
+++ b/include/deal.II/base/communication_pattern_base.h
@@ -88,7 +88,7 @@ namespace Utilities
       virtual void
       reinit(const IndexSet &locally_owned_indices,
              const IndexSet &ghost_indices,
-             const MPI_Comm &communicator) = 0;
+             const MPI_Comm  communicator) = 0;
 
       /**
        * Return the underlying MPI communicator.

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -2383,7 +2383,7 @@ namespace DataOutBase
       &                              nonscalar_data_ranges,
     const Deal_II_IntermediateFlags &flags,
     const std::string &              filename,
-    const MPI_Comm &                 comm,
+    const MPI_Comm                   comm,
     const CompressionLevel           compression);
 
   /**
@@ -2396,7 +2396,7 @@ namespace DataOutBase
                       const DataOutFilter &                    data_filter,
                       const DataOutBase::Hdf5Flags &           flags,
                       const std::string &                      filename,
-                      const MPI_Comm &                         comm);
+                      const MPI_Comm                           comm);
 
   /**
    * Write the data in @p data_filter to HDF5 file(s). If @p write_mesh_file is
@@ -2413,7 +2413,7 @@ namespace DataOutBase
                       const bool                               write_mesh_file,
                       const std::string &                      mesh_filename,
                       const std::string &solution_filename,
-                      const MPI_Comm &   comm);
+                      const MPI_Comm     comm);
 
   /**
    * DataOutFilter is an intermediate data format that reduces the amount of
@@ -2743,8 +2743,7 @@ public:
    * DataOutInterface::write_vtu().
    */
   void
-  write_vtu_in_parallel(const std::string &filename,
-                        const MPI_Comm &   comm) const;
+  write_vtu_in_parallel(const std::string &filename, const MPI_Comm comm) const;
 
   /**
    * Some visualization programs, such as ParaView, can read several separate
@@ -2846,7 +2845,7 @@ public:
     const std::string &directory,
     const std::string &filename_without_extension,
     const unsigned int counter,
-    const MPI_Comm &   mpi_communicator,
+    const MPI_Comm     mpi_communicator,
     const unsigned int n_digits_for_counter = numbers::invalid_unsigned_int,
     const unsigned int n_groups             = 0) const;
 
@@ -2879,7 +2878,7 @@ public:
   void
   write_deal_II_intermediate_in_parallel(
     const std::string &                 filename,
-    const MPI_Comm &                    comm,
+    const MPI_Comm                      comm,
     const DataOutBase::CompressionLevel compression) const;
 
   /**
@@ -2891,7 +2890,7 @@ public:
   create_xdmf_entry(const DataOutBase::DataOutFilter &data_filter,
                     const std::string &               h5_filename,
                     const double                      cur_time,
-                    const MPI_Comm &                  comm) const;
+                    const MPI_Comm                    comm) const;
 
   /**
    * Create an XDMFEntry based on the data in the data_filter. This assumes
@@ -2903,7 +2902,7 @@ public:
                     const std::string &               h5_mesh_filename,
                     const std::string &               h5_solution_filename,
                     const double                      cur_time,
-                    const MPI_Comm &                  comm) const;
+                    const MPI_Comm                    comm) const;
 
   /**
    * Write an XDMF file based on the provided vector of XDMFEntry objects.
@@ -2932,7 +2931,7 @@ public:
   void
   write_xdmf_file(const std::vector<XDMFEntry> &entries,
                   const std::string &           filename,
-                  const MPI_Comm &              comm) const;
+                  const MPI_Comm                comm) const;
 
   /**
    * Write the data in @p data_filter to a single HDF5 file containing both the
@@ -2951,7 +2950,7 @@ public:
   void
   write_hdf5_parallel(const DataOutBase::DataOutFilter &data_filter,
                       const std::string &               filename,
-                      const MPI_Comm &                  comm) const;
+                      const MPI_Comm                    comm) const;
 
   /**
    * Write the data in data_filter to HDF5 file(s). If write_mesh_file is
@@ -2965,7 +2964,7 @@ public:
                       const bool                        write_mesh_file,
                       const std::string &               mesh_filename,
                       const std::string &               solution_filename,
-                      const MPI_Comm &                  comm) const;
+                      const MPI_Comm                    comm) const;
 
   /**
    * DataOutFilter is an intermediate data format that reduces the amount of

--- a/include/deal.II/base/hdf5.h
+++ b/include/deal.II/base/hdf5.h
@@ -73,7 +73,7 @@ DEAL_II_NAMESPACE_OPEN
  * MPI support (several processes access the same HDF5 file).
  * File::File(const std::string &, const FileAccessMode)
  * opens/creates an HDF5 file for serial operations.
- * File::File(const std::string &, const FileAccessMode, const MPI_Comm &)
+ * File::File(const std::string &, const FileAccessMode, const MPI_Comm )
  * creates or opens an HDF5 file in parallel using MPI. The HDF5 calls that
  * modify the structure of the file are always collective, whereas writing
  * and reading raw data in a dataset can be done independently or collectively.
@@ -1105,12 +1105,12 @@ namespace HDF5
      */
     File(const std::string &  name,
          const FileAccessMode mode,
-         const MPI_Comm &     mpi_communicator);
+         const MPI_Comm       mpi_communicator);
 
   private:
     /**
      * Delegation internal constructor.
-     * File(const std::string &, const MPI_Comm &, const Mode);
+     * File(const std::string &, const MPI_Comm , const Mode);
      * and
      * File(const std::string &, const Mode)
      * should be used to open or create HDF5 files.
@@ -1118,7 +1118,7 @@ namespace HDF5
     File(const std::string &  name,
          const FileAccessMode mode,
          const bool           mpi,
-         const MPI_Comm &     mpi_communicator);
+         const MPI_Comm       mpi_communicator);
   };
 
   namespace internal

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -252,7 +252,7 @@ public:
    * is complete.
    */
   bool
-  is_ascending_and_one_to_one(const MPI_Comm &communicator) const;
+  is_ascending_and_one_to_one(const MPI_Comm communicator) const;
 
   /**
    * Return the number of elements stored in this index set.
@@ -503,19 +503,19 @@ public:
    * vector, e.g. for extracting only certain solution components.
    */
   Epetra_Map
-  make_trilinos_map(const MPI_Comm &communicator = MPI_COMM_WORLD,
-                    const bool      overlapping  = false) const;
+  make_trilinos_map(const MPI_Comm communicator = MPI_COMM_WORLD,
+                    const bool     overlapping  = false) const;
 
 #  ifdef DEAL_II_TRILINOS_WITH_TPETRA
   Tpetra::Map<int, types::signed_global_dof_index>
-  make_tpetra_map(const MPI_Comm &communicator = MPI_COMM_WORLD,
-                  const bool      overlapping  = false) const;
+  make_tpetra_map(const MPI_Comm communicator = MPI_COMM_WORLD,
+                  const bool     overlapping  = false) const;
 #  endif
 #endif
 
 #ifdef DEAL_II_WITH_PETSC
   IS
-  make_petsc_is(const MPI_Comm &communicator = MPI_COMM_WORLD) const;
+  make_petsc_is(const MPI_Comm communicator = MPI_COMM_WORLD) const;
 #endif
 
 

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -137,7 +137,7 @@ namespace Utilities
      * only one process and the function returns 1.
      */
     unsigned int
-    n_mpi_processes(const MPI_Comm &mpi_communicator);
+    n_mpi_processes(const MPI_Comm mpi_communicator);
 
     /**
      * Return the
@@ -148,15 +148,15 @@ namespace Utilities
      * than) the number of all processes (given by get_n_mpi_processes()).
      */
     unsigned int
-    this_mpi_process(const MPI_Comm &mpi_communicator);
+    this_mpi_process(const MPI_Comm mpi_communicator);
 
     /**
      * Return a vector of the ranks (within @p comm_large) of a subset of
      * processes specified by @p comm_small.
      */
     const std::vector<unsigned int>
-    mpi_processes_within_communicator(const MPI_Comm &comm_large,
-                                      const MPI_Comm &comm_small);
+    mpi_processes_within_communicator(const MPI_Comm comm_large,
+                                      const MPI_Comm comm_small);
 
     /**
      * Consider an unstructured communication pattern where every process in
@@ -181,7 +181,7 @@ namespace Utilities
      */
     std::vector<unsigned int>
     compute_point_to_point_communication_pattern(
-      const MPI_Comm &                 mpi_comm,
+      const MPI_Comm                   mpi_comm,
       const std::vector<unsigned int> &destinations);
 
     /**
@@ -205,7 +205,7 @@ namespace Utilities
      */
     unsigned int
     compute_n_point_to_point_communications(
-      const MPI_Comm &                 mpi_comm,
+      const MPI_Comm                   mpi_comm,
       const std::vector<unsigned int> &destinations);
 
     /**
@@ -225,7 +225,7 @@ namespace Utilities
      * <code>MPI_Comm_dup(mpi_communicator, &return_value);</code>.
      */
     MPI_Comm
-    duplicate_communicator(const MPI_Comm &mpi_communicator);
+    duplicate_communicator(const MPI_Comm mpi_communicator);
 
     /**
      * Free the given
@@ -237,7 +237,7 @@ namespace Utilities
      * <code>MPI_Comm_free(&mpi_communicator);</code>.
      */
     void
-    free_communicator(MPI_Comm &mpi_communicator);
+    free_communicator(MPI_Comm mpi_communicator);
 
     /**
      * Helper class to automatically duplicate and free an MPI
@@ -257,7 +257,7 @@ namespace Utilities
       /**
        * Create a duplicate of the given @p communicator.
        */
-      explicit DuplicatedCommunicator(const MPI_Comm &communicator)
+      explicit DuplicatedCommunicator(const MPI_Comm communicator)
         : comm(duplicate_communicator(communicator))
       {}
 
@@ -342,7 +342,7 @@ namespace Utilities
         /**
          * Constructor. Blocks until it can acquire the lock.
          */
-        explicit ScopedLock(CollectiveMutex &mutex, const MPI_Comm &comm)
+        explicit ScopedLock(CollectiveMutex &mutex, const MPI_Comm comm)
           : mutex(mutex)
           , comm(comm)
         {
@@ -385,7 +385,7 @@ namespace Utilities
        * in the communicator.
        */
       void
-      lock(const MPI_Comm &comm);
+      lock(const MPI_Comm comm);
 
       /**
        * Release the lock.
@@ -394,7 +394,7 @@ namespace Utilities
        * in the communicator.
        */
       void
-      unlock(const MPI_Comm &comm);
+      unlock(const MPI_Comm comm);
 
     private:
       /**
@@ -573,7 +573,7 @@ namespace Utilities
      */
 #ifdef DEAL_II_WITH_MPI
     DEAL_II_DEPRECATED int
-    create_group(const MPI_Comm & comm,
+    create_group(const MPI_Comm   comm,
                  const MPI_Group &group,
                  const int        tag,
                  MPI_Comm *       new_comm);
@@ -589,7 +589,7 @@ namespace Utilities
      */
     std::vector<IndexSet>
     create_ascending_partitioning(
-      const MPI_Comm &              comm,
+      const MPI_Comm                comm,
       const types::global_dof_index locally_owned_size);
 
     /**
@@ -601,7 +601,7 @@ namespace Utilities
      */
     IndexSet
     create_evenly_distributed_partitioning(
-      const MPI_Comm &              comm,
+      const MPI_Comm                comm,
       const types::global_dof_index total_size);
 
 #ifdef DEAL_II_WITH_MPI
@@ -622,9 +622,9 @@ namespace Utilities
      */
     template <class Iterator, typename Number = long double>
     std::pair<Number, typename numbers::NumberTraits<Number>::real_type>
-    mean_and_standard_deviation(const Iterator  begin,
-                                const Iterator  end,
-                                const MPI_Comm &comm);
+    mean_and_standard_deviation(const Iterator begin,
+                                const Iterator end,
+                                const MPI_Comm comm);
 #endif
 
 
@@ -699,7 +699,7 @@ namespace Utilities
      */
     template <typename T>
     T
-    sum(const T &t, const MPI_Comm &mpi_communicator);
+    sum(const T &t, const MPI_Comm mpi_communicator);
 
     /**
      * Like the previous function, but take the sums over the elements of an
@@ -712,7 +712,7 @@ namespace Utilities
      */
     template <typename T, typename U>
     void
-    sum(const T &values, const MPI_Comm &mpi_communicator, U &sums);
+    sum(const T &values, const MPI_Comm mpi_communicator, U &sums);
 
     /**
      * Like the previous function, but take the sums over the elements of an
@@ -726,7 +726,7 @@ namespace Utilities
     template <typename T>
     void
     sum(const ArrayView<const T> &values,
-        const MPI_Comm &          mpi_communicator,
+        const MPI_Comm            mpi_communicator,
         const ArrayView<T> &      sums);
 
     /**
@@ -737,7 +737,7 @@ namespace Utilities
     template <int rank, int dim, typename Number>
     SymmetricTensor<rank, dim, Number>
     sum(const SymmetricTensor<rank, dim, Number> &local,
-        const MPI_Comm &                          mpi_communicator);
+        const MPI_Comm                            mpi_communicator);
 
     /**
      * Perform an MPI sum of the entries of a tensor.
@@ -747,7 +747,7 @@ namespace Utilities
     template <int rank, int dim, typename Number>
     Tensor<rank, dim, Number>
     sum(const Tensor<rank, dim, Number> &local,
-        const MPI_Comm &                 mpi_communicator);
+        const MPI_Comm                   mpi_communicator);
 
     /**
      * Perform an MPI sum of the entries of a SparseMatrix.
@@ -760,7 +760,7 @@ namespace Utilities
     template <typename Number>
     void
     sum(const SparseMatrix<Number> &local,
-        const MPI_Comm &            mpi_communicator,
+        const MPI_Comm              mpi_communicator,
         SparseMatrix<Number> &      global);
 
     /**
@@ -784,7 +784,7 @@ namespace Utilities
      */
     template <typename T>
     T
-    max(const T &t, const MPI_Comm &mpi_communicator);
+    max(const T &t, const MPI_Comm mpi_communicator);
 
     /**
      * Like the previous function, but take the maximum over the elements of an
@@ -797,7 +797,7 @@ namespace Utilities
      */
     template <typename T, typename U>
     void
-    max(const T &values, const MPI_Comm &mpi_communicator, U &maxima);
+    max(const T &values, const MPI_Comm mpi_communicator, U &maxima);
 
     /**
      * Like the previous function, but take the maximum over the elements of an
@@ -811,7 +811,7 @@ namespace Utilities
     template <typename T>
     void
     max(const ArrayView<const T> &values,
-        const MPI_Comm &          mpi_communicator,
+        const MPI_Comm            mpi_communicator,
         const ArrayView<T> &      maxima);
 
     /**
@@ -835,7 +835,7 @@ namespace Utilities
      */
     template <typename T>
     T
-    min(const T &t, const MPI_Comm &mpi_communicator);
+    min(const T &t, const MPI_Comm mpi_communicator);
 
     /**
      * Like the previous function, but take the minima over the elements of an
@@ -848,7 +848,7 @@ namespace Utilities
      */
     template <typename T, typename U>
     void
-    min(const T &values, const MPI_Comm &mpi_communicator, U &minima);
+    min(const T &values, const MPI_Comm mpi_communicator, U &minima);
 
     /**
      * Like the previous function, but take the minimum over the elements of an
@@ -862,7 +862,7 @@ namespace Utilities
     template <typename T>
     void
     min(const ArrayView<const T> &values,
-        const MPI_Comm &          mpi_communicator,
+        const MPI_Comm            mpi_communicator,
         const ArrayView<T> &      minima);
 
     /**
@@ -890,7 +890,7 @@ namespace Utilities
      */
     template <typename T>
     T
-    logical_or(const T &t, const MPI_Comm &mpi_communicator);
+    logical_or(const T &t, const MPI_Comm mpi_communicator);
 
     /**
      * Like the previous function, but performs the <i>logical or</i> operation
@@ -908,7 +908,7 @@ namespace Utilities
      */
     template <typename T, typename U>
     void
-    logical_or(const T &values, const MPI_Comm &mpi_communicator, U &results);
+    logical_or(const T &values, const MPI_Comm mpi_communicator, U &results);
 
     /**
      * Like the previous function, but performs the <i>logical or</i> operation
@@ -922,7 +922,7 @@ namespace Utilities
     template <typename T>
     void
     logical_or(const ArrayView<const T> &values,
-               const MPI_Comm &          mpi_communicator,
+               const MPI_Comm            mpi_communicator,
                const ArrayView<T> &      results);
 
     /**
@@ -1001,7 +1001,7 @@ namespace Utilities
      * everywhere.
      */
     MinMaxAvg
-    min_max_avg(const double my_value, const MPI_Comm &mpi_communicator);
+    min_max_avg(const double my_value, const MPI_Comm mpi_communicator);
 
     /**
      * Same as above but returning the sum, average, minimum, maximum,
@@ -1016,7 +1016,7 @@ namespace Utilities
      */
     std::vector<MinMaxAvg>
     min_max_avg(const std::vector<double> &my_value,
-                const MPI_Comm &           mpi_communicator);
+                const MPI_Comm             mpi_communicator);
 
 
     /**
@@ -1034,7 +1034,7 @@ namespace Utilities
     void
     min_max_avg(const ArrayView<const double> &my_values,
                 const ArrayView<MinMaxAvg> &   result,
-                const MPI_Comm &               mpi_communicator);
+                const MPI_Comm                 mpi_communicator);
 
 
     /**
@@ -1244,7 +1244,7 @@ namespace Utilities
      */
     template <typename T>
     std::map<unsigned int, T>
-    some_to_some(const MPI_Comm &                 comm,
+    some_to_some(const MPI_Comm                   comm,
                  const std::map<unsigned int, T> &objects_to_send);
 
     /**
@@ -1262,7 +1262,7 @@ namespace Utilities
      */
     template <typename T>
     std::vector<T>
-    all_gather(const MPI_Comm &comm, const T &object_to_send);
+    all_gather(const MPI_Comm comm, const T &object_to_send);
 
     /**
      * A generalization of the classic MPI_Gather function, that accepts
@@ -1281,7 +1281,7 @@ namespace Utilities
      */
     template <typename T>
     std::vector<T>
-    gather(const MPI_Comm &   comm,
+    gather(const MPI_Comm     comm,
            const T &          object_to_send,
            const unsigned int root_process = 0);
 
@@ -1301,7 +1301,7 @@ namespace Utilities
      */
     template <typename T>
     T
-    scatter(const MPI_Comm &      comm,
+    scatter(const MPI_Comm        comm,
             const std::vector<T> &objects_to_send,
             const unsigned int    root_process = 0);
 
@@ -1342,7 +1342,7 @@ namespace Utilities
      */
     template <typename T>
     std::enable_if_t<is_mpi_type<T> == false, T>
-    broadcast(const MPI_Comm &   comm,
+    broadcast(const MPI_Comm     comm,
               const T &          object_to_send,
               const unsigned int root_process = 0);
 
@@ -1370,7 +1370,7 @@ namespace Utilities
      */
     template <typename T>
     std::enable_if_t<is_mpi_type<T> == true, T>
-    broadcast(const MPI_Comm &   comm,
+    broadcast(const MPI_Comm     comm,
               const T &          object_to_send,
               const unsigned int root_process = 0);
 
@@ -1395,7 +1395,7 @@ namespace Utilities
     broadcast(T *                buffer,
               const size_t       count,
               const unsigned int root,
-              const MPI_Comm &   comm);
+              const MPI_Comm     comm);
 
     /**
      * A function that combines values @p local_value from all processes
@@ -1412,7 +1412,7 @@ namespace Utilities
     template <typename T>
     T
     reduce(const T &                                     local_value,
-           const MPI_Comm &                              comm,
+           const MPI_Comm                                comm,
            const std::function<T(const T &, const T &)> &combiner,
            const unsigned int                            root_process = 0);
 
@@ -1428,7 +1428,7 @@ namespace Utilities
     template <typename T>
     T
     all_reduce(const T &                                     local_value,
-               const MPI_Comm &                              comm,
+               const MPI_Comm                                comm,
                const std::function<T(const T &, const T &)> &combiner);
 
 
@@ -1528,7 +1528,7 @@ namespace Utilities
     std::vector<unsigned int>
     compute_index_owner(const IndexSet &owned_indices,
                         const IndexSet &indices_to_look_up,
-                        const MPI_Comm &comm);
+                        const MPI_Comm  comm);
 
     /**
      * Compute the union of the input vectors @p vec of all processes in the
@@ -1539,14 +1539,14 @@ namespace Utilities
      */
     template <typename T>
     std::vector<T>
-    compute_set_union(const std::vector<T> &vec, const MPI_Comm &comm);
+    compute_set_union(const std::vector<T> &vec, const MPI_Comm comm);
 
     /**
      * The same as above but for std::set.
      */
     template <typename T>
     std::set<T>
-    compute_set_union(const std::set<T> &set, const MPI_Comm &comm);
+    compute_set_union(const std::set<T> &set, const MPI_Comm comm);
 
 
 
@@ -1741,7 +1741,7 @@ namespace Utilities
       void
       all_reduce(const MPI_Op &            mpi_op,
                  const ArrayView<const T> &values,
-                 const MPI_Comm &          mpi_communicator,
+                 const MPI_Comm            mpi_communicator,
                  const ArrayView<T> &      output);
     } // namespace internal
 
@@ -1804,7 +1804,7 @@ namespace Utilities
 
     template <typename T, unsigned int N>
     void
-    sum(const T (&values)[N], const MPI_Comm &mpi_communicator, T (&sums)[N])
+    sum(const T (&values)[N], const MPI_Comm mpi_communicator, T (&sums)[N])
     {
       internal::all_reduce(MPI_SUM,
                            ArrayView<const T>(values, N),
@@ -1816,7 +1816,7 @@ namespace Utilities
 
     template <typename T, unsigned int N>
     void
-    max(const T (&values)[N], const MPI_Comm &mpi_communicator, T (&maxima)[N])
+    max(const T (&values)[N], const MPI_Comm mpi_communicator, T (&maxima)[N])
     {
       internal::all_reduce(MPI_MAX,
                            ArrayView<const T>(values, N),
@@ -1828,7 +1828,7 @@ namespace Utilities
 
     template <typename T, unsigned int N>
     void
-    min(const T (&values)[N], const MPI_Comm &mpi_communicator, T (&minima)[N])
+    min(const T (&values)[N], const MPI_Comm mpi_communicator, T (&minima)[N])
     {
       internal::all_reduce(MPI_MIN,
                            ArrayView<const T>(values, N),
@@ -1841,7 +1841,7 @@ namespace Utilities
     template <typename T, unsigned int N>
     void
     logical_or(const T (&values)[N],
-               const MPI_Comm &mpi_communicator,
+               const MPI_Comm mpi_communicator,
                T (&results)[N])
     {
       static_assert(std::is_integral<T>::value,
@@ -1857,7 +1857,7 @@ namespace Utilities
 
     template <typename T>
     std::map<unsigned int, T>
-    some_to_some(const MPI_Comm &                 comm,
+    some_to_some(const MPI_Comm                   comm,
                  const std::map<unsigned int, T> &objects_to_send)
     {
 #  ifndef DEAL_II_WITH_MPI
@@ -1973,7 +1973,7 @@ namespace Utilities
 
     template <typename T>
     std::vector<T>
-    all_gather(const MPI_Comm &comm, const T &object)
+    all_gather(const MPI_Comm comm, const T &object)
     {
       if (job_supports_mpi() == false)
         return {object};
@@ -2036,7 +2036,7 @@ namespace Utilities
 
     template <typename T>
     std::vector<T>
-    gather(const MPI_Comm &   comm,
+    gather(const MPI_Comm     comm,
            const T &          object_to_send,
            const unsigned int root_process)
     {
@@ -2119,7 +2119,7 @@ namespace Utilities
 
     template <typename T>
     T
-    scatter(const MPI_Comm &      comm,
+    scatter(const MPI_Comm        comm,
             const std::vector<T> &objects_to_send,
             const unsigned int    root_process)
     {
@@ -2197,7 +2197,7 @@ namespace Utilities
     broadcast(T *                buffer,
               const size_t       count,
               const unsigned int root,
-              const MPI_Comm &   comm)
+              const MPI_Comm     comm)
     {
 #  ifndef DEAL_II_WITH_MPI
       (void)buffer;
@@ -2233,7 +2233,7 @@ namespace Utilities
 
     template <typename T>
     std::enable_if_t<is_mpi_type<T> == false, T>
-    broadcast(const MPI_Comm &   comm,
+    broadcast(const MPI_Comm     comm,
               const T &          object_to_send,
               const unsigned int root_process)
     {
@@ -2283,7 +2283,7 @@ namespace Utilities
 
     template <typename T>
     std::enable_if_t<is_mpi_type<T> == true, T>
-    broadcast(const MPI_Comm &   comm,
+    broadcast(const MPI_Comm     comm,
               const T &          object_to_send,
               const unsigned int root_process)
     {
@@ -2441,9 +2441,9 @@ namespace Utilities
 #  ifdef DEAL_II_WITH_MPI
     template <class Iterator, typename Number>
     std::pair<Number, typename numbers::NumberTraits<Number>::real_type>
-    mean_and_standard_deviation(const Iterator  begin,
-                                const Iterator  end,
-                                const MPI_Comm &comm)
+    mean_and_standard_deviation(const Iterator begin,
+                                const Iterator end,
+                                const MPI_Comm comm)
     {
       // below we do simple and straight-forward implementation. More elaborate
       // options are:

--- a/include/deal.II/base/mpi.templates.h
+++ b/include/deal.II/base/mpi.templates.h
@@ -41,7 +41,7 @@ namespace Utilities
       void
       all_reduce(const MPI_Op &            mpi_op,
                  const ArrayView<const T> &values,
-                 const MPI_Comm &          mpi_communicator,
+                 const MPI_Comm            mpi_communicator,
                  const ArrayView<T> &      output)
       {
         AssertDimension(values.size(), output.size());
@@ -102,7 +102,7 @@ namespace Utilities
       void
       all_reduce(const MPI_Op &                          mpi_op,
                  const ArrayView<const std::complex<T>> &values,
-                 const MPI_Comm &                        mpi_communicator,
+                 const MPI_Comm                          mpi_communicator,
                  const ArrayView<std::complex<T>> &      output)
       {
         AssertDimension(values.size(), output.size());
@@ -141,7 +141,7 @@ namespace Utilities
 
     template <typename T>
     T
-    sum(const T &t, const MPI_Comm &mpi_communicator)
+    sum(const T &t, const MPI_Comm mpi_communicator)
     {
       T return_value{};
       internal::all_reduce(MPI_SUM,
@@ -155,7 +155,7 @@ namespace Utilities
 
     template <typename T, typename U>
     void
-    sum(const T &values, const MPI_Comm &mpi_communicator, U &sums)
+    sum(const T &values, const MPI_Comm mpi_communicator, U &sums)
     {
       static_assert(std::is_same<typename std::decay<T>::type,
                                  typename std::decay<U>::type>::value,
@@ -173,7 +173,7 @@ namespace Utilities
     template <typename T>
     void
     sum(const ArrayView<const T> &values,
-        const MPI_Comm &          mpi_communicator,
+        const MPI_Comm            mpi_communicator,
         const ArrayView<T> &      sums)
     {
       internal::all_reduce(MPI_SUM, values, mpi_communicator, sums);
@@ -183,7 +183,7 @@ namespace Utilities
 
     template <int rank, int dim, typename Number>
     Tensor<rank, dim, Number>
-    sum(const Tensor<rank, dim, Number> &t, const MPI_Comm &mpi_communicator)
+    sum(const Tensor<rank, dim, Number> &t, const MPI_Comm mpi_communicator)
     {
       // Copy the tensor into a C-style array with which we can then
       // call the other sum() function.
@@ -204,7 +204,7 @@ namespace Utilities
     template <int rank, int dim, typename Number>
     SymmetricTensor<rank, dim, Number>
     sum(const SymmetricTensor<rank, dim, Number> &local,
-        const MPI_Comm &                          mpi_communicator)
+        const MPI_Comm                            mpi_communicator)
     {
       // Copy the tensor into a C-style array with which we can then
       // call the other sum() function.
@@ -232,7 +232,7 @@ namespace Utilities
     template <typename Number>
     void
     sum(const SparseMatrix<Number> &local,
-        const MPI_Comm &            mpi_communicator,
+        const MPI_Comm              mpi_communicator,
         SparseMatrix<Number> &      global)
     {
       Assert(
@@ -256,7 +256,7 @@ namespace Utilities
 
     template <typename T>
     T
-    max(const T &t, const MPI_Comm &mpi_communicator)
+    max(const T &t, const MPI_Comm mpi_communicator)
     {
       T return_value{};
       internal::all_reduce(MPI_MAX,
@@ -270,7 +270,7 @@ namespace Utilities
 
     template <typename T, typename U>
     void
-    max(const T &values, const MPI_Comm &mpi_communicator, U &maxima)
+    max(const T &values, const MPI_Comm mpi_communicator, U &maxima)
     {
       static_assert(std::is_same<typename std::decay<T>::type,
                                  typename std::decay<U>::type>::value,
@@ -288,7 +288,7 @@ namespace Utilities
     template <typename T>
     void
     max(const ArrayView<const T> &values,
-        const MPI_Comm &          mpi_communicator,
+        const MPI_Comm            mpi_communicator,
         const ArrayView<T> &      maxima)
     {
       internal::all_reduce(MPI_MAX, values, mpi_communicator, maxima);
@@ -298,7 +298,7 @@ namespace Utilities
 
     template <typename T>
     T
-    min(const T &t, const MPI_Comm &mpi_communicator)
+    min(const T &t, const MPI_Comm mpi_communicator)
     {
       T return_value{};
       internal::all_reduce(MPI_MIN,
@@ -312,7 +312,7 @@ namespace Utilities
 
     template <typename T, typename U>
     void
-    min(const T &values, const MPI_Comm &mpi_communicator, U &minima)
+    min(const T &values, const MPI_Comm mpi_communicator, U &minima)
     {
       static_assert(std::is_same<typename std::decay<T>::type,
                                  typename std::decay<U>::type>::value,
@@ -330,7 +330,7 @@ namespace Utilities
     template <typename T>
     void
     min(const ArrayView<const T> &values,
-        const MPI_Comm &          mpi_communicator,
+        const MPI_Comm            mpi_communicator,
         const ArrayView<T> &      minima)
     {
       internal::all_reduce(MPI_MIN, values, mpi_communicator, minima);
@@ -340,7 +340,7 @@ namespace Utilities
 
     template <typename T>
     T
-    logical_or(const T &t, const MPI_Comm &mpi_communicator)
+    logical_or(const T &t, const MPI_Comm mpi_communicator)
     {
       static_assert(std::is_integral<T>::value,
                     "The MPI_LOR operation only allows integral data types.");
@@ -357,7 +357,7 @@ namespace Utilities
 
     template <typename T, typename U>
     void
-    logical_or(const T &values, const MPI_Comm &mpi_communicator, U &results)
+    logical_or(const T &values, const MPI_Comm mpi_communicator, U &results)
     {
       static_assert(std::is_same<typename std::decay<T>::type,
                                  typename std::decay<U>::type>::value,
@@ -387,7 +387,7 @@ namespace Utilities
     template <typename T>
     void
     logical_or(const ArrayView<const T> &values,
-               const MPI_Comm &          mpi_communicator,
+               const MPI_Comm            mpi_communicator,
                const ArrayView<T> &      results)
     {
       static_assert(std::is_integral<T>::value,
@@ -401,7 +401,7 @@ namespace Utilities
     template <typename T>
     T
     reduce(const T &                                     vec,
-           const MPI_Comm &                              comm,
+           const MPI_Comm                                comm,
            const std::function<T(const T &, const T &)> &combiner,
            const unsigned int                            root_process)
     {
@@ -485,7 +485,7 @@ namespace Utilities
     template <typename T>
     T
     all_reduce(const T &                                     vec,
-               const MPI_Comm &                              comm,
+               const MPI_Comm                                comm,
                const std::function<T(const T &, const T &)> &combiner)
     {
       if (job_supports_mpi() && n_mpi_processes(comm) > 1)
@@ -503,7 +503,7 @@ namespace Utilities
 
     template <typename T>
     std::vector<T>
-    compute_set_union(const std::vector<T> &vec, const MPI_Comm &comm)
+    compute_set_union(const std::vector<T> &vec, const MPI_Comm comm)
     {
       return Utilities::MPI::all_reduce<std::vector<T>>(
         vec, comm, [](const auto &set_1, const auto &set_2) {
@@ -520,7 +520,7 @@ namespace Utilities
 
     template <typename T>
     std::set<T>
-    compute_set_union(const std::set<T> &set_in, const MPI_Comm &comm)
+    compute_set_union(const std::set<T> &set_in, const MPI_Comm comm)
     {
       // convert vector to set
       std::vector<T> vector_in(set_in.begin(), set_in.end());

--- a/include/deal.II/base/mpi_compute_index_owner_internal.h
+++ b/include/deal.II/base/mpi_compute_index_owner_internal.h
@@ -171,7 +171,7 @@ namespace Utilities
            * ranges to the owner of the dictionary part.
            */
           void
-          reinit(const IndexSet &owned_indices, const MPI_Comm &comm);
+          reinit(const IndexSet &owned_indices, const MPI_Comm comm);
 
           /**
            * Translate a global dof index to the MPI rank in the dictionary
@@ -203,7 +203,7 @@ namespace Utilities
            * the number of ranks.
            */
           void
-          partition(const IndexSet &owned_indices, const MPI_Comm &comm);
+          partition(const IndexSet &owned_indices, const MPI_Comm comm);
         };
 
 
@@ -226,7 +226,7 @@ namespace Utilities
            */
           ConsensusAlgorithmsPayload(const IndexSet &owned_indices,
                                      const IndexSet &indices_to_look_up,
-                                     const MPI_Comm &comm,
+                                     const MPI_Comm  comm,
                                      std::vector<unsigned int> &owning_ranks,
                                      const bool track_index_requests = false);
 

--- a/include/deal.II/base/mpi_consensus_algorithms.h
+++ b/include/deal.II/base/mpi_consensus_algorithms.h
@@ -253,7 +253,7 @@ namespace Utilities
          */
         DEAL_II_DEPRECATED
         Interface(Process<RequestType, AnswerType> &process,
-                  const MPI_Comm &                  comm);
+                  const MPI_Comm                    comm);
 
         /**
          * Destructor. Made `virtual` to ensure that one can work with
@@ -283,7 +283,7 @@ namespace Utilities
          * that takes a number of `std::function` arguments.
          */
         std::vector<unsigned int>
-        run(Process<RequestType, AnswerType> &process, const MPI_Comm &comm);
+        run(Process<RequestType, AnswerType> &process, const MPI_Comm comm);
 
         /**
          * Run the consensus algorithm and return a vector of process ranks
@@ -315,8 +315,8 @@ namespace Utilities
           const std::function<AnswerType(const unsigned int,
                                          const RequestType &)> &answer_request,
           const std::function<void(const unsigned int, const AnswerType &)>
-            &             process_answer,
-          const MPI_Comm &comm) = 0;
+            &            process_answer,
+          const MPI_Comm comm) = 0;
 
       private:
         /**
@@ -375,7 +375,7 @@ namespace Utilities
          *   function that takes an argument.
          */
         DEAL_II_DEPRECATED
-        NBX(Process<RequestType, AnswerType> &process, const MPI_Comm &comm);
+        NBX(Process<RequestType, AnswerType> &process, const MPI_Comm comm);
 
         /**
          * Destructor.
@@ -395,8 +395,8 @@ namespace Utilities
           const std::function<AnswerType(const unsigned int,
                                          const RequestType &)> &answer_request,
           const std::function<void(const unsigned int, const AnswerType &)>
-            &             process_answer,
-          const MPI_Comm &comm) override;
+            &            process_answer,
+          const MPI_Comm comm) override;
 
       private:
 #ifdef DEAL_II_WITH_MPI
@@ -446,15 +446,15 @@ namespace Utilities
         bool
         all_locally_originated_receives_are_completed(
           const std::function<void(const unsigned int, const AnswerType &)>
-            &             process_answer,
-          const MPI_Comm &comm);
+            &            process_answer,
+          const MPI_Comm comm);
 
         /**
          * Signal to all other ranks that this rank has received all request
          * answers via entering IBarrier.
          */
         void
-        signal_finish(const MPI_Comm &comm);
+        signal_finish(const MPI_Comm comm);
 
         /**
          * Check whether all of the requests for answers that were created by
@@ -473,7 +473,7 @@ namespace Utilities
         maybe_answer_one_request(
           const std::function<AnswerType(const unsigned int,
                                          const RequestType &)> &answer_request,
-          const MPI_Comm &                                      comm);
+          const MPI_Comm                                        comm);
 
         /**
          * Start to send all requests via ISend and post IRecvs for the incoming
@@ -483,14 +483,14 @@ namespace Utilities
         start_communication(
           const std::vector<unsigned int> &                     targets,
           const std::function<RequestType(const unsigned int)> &create_request,
-          const MPI_Comm &                                      comm);
+          const MPI_Comm                                        comm);
 
         /**
          * After all rank has received all answers, the MPI data structures can
          * be freed and the received answers can be processed.
          */
         void
-        clean_up_and_end_communication(const MPI_Comm &comm);
+        clean_up_and_end_communication(const MPI_Comm comm);
       };
 
 
@@ -545,8 +545,8 @@ namespace Utilities
           const std::function<AnswerType(const unsigned int,
                                          const RequestType &)> &answer_request,
           const std::function<void(const unsigned int, const AnswerType &)>
-            &             process_answer,
-          const MPI_Comm &comm);
+            &            process_answer,
+          const MPI_Comm comm);
 
       /**
        * This function provides a specialization of the one above for
@@ -590,8 +590,8 @@ namespace Utilities
       nbx(const std::vector<unsigned int> &                     targets,
           const std::function<RequestType(const unsigned int)> &create_request,
           const std::function<void(const unsigned int, const RequestType &)>
-            &             process_request,
-          const MPI_Comm &comm);
+            &            process_request,
+          const MPI_Comm comm);
 
       /**
        * This class implements a concrete algorithm for the
@@ -641,7 +641,7 @@ namespace Utilities
          *   function that takes an argument.
          */
         DEAL_II_DEPRECATED
-        PEX(Process<RequestType, AnswerType> &process, const MPI_Comm &comm);
+        PEX(Process<RequestType, AnswerType> &process, const MPI_Comm comm);
 
         /**
          * Destructor.
@@ -661,8 +661,8 @@ namespace Utilities
           const std::function<AnswerType(const unsigned int,
                                          const RequestType &)> &answer_request,
           const std::function<void(const unsigned int, const AnswerType &)>
-            &             process_answer,
-          const MPI_Comm &comm) override;
+            &            process_answer,
+          const MPI_Comm comm) override;
 
       private:
 #ifdef DEAL_II_WITH_MPI
@@ -704,7 +704,7 @@ namespace Utilities
         start_communication(
           const std::vector<unsigned int> &                     targets,
           const std::function<RequestType(const unsigned int)> &create_request,
-          const MPI_Comm &                                      comm);
+          const MPI_Comm                                        comm);
 
         /**
          * The `index`th request message from another rank has been received:
@@ -715,7 +715,7 @@ namespace Utilities
           const unsigned int                                    index,
           const std::function<AnswerType(const unsigned int,
                                          const RequestType &)> &answer_request,
-          const MPI_Comm &                                      comm);
+          const MPI_Comm                                        comm);
 
         /**
          * Receive and process all of the incoming responses to the
@@ -725,8 +725,8 @@ namespace Utilities
         process_incoming_answers(
           const unsigned int n_targets,
           const std::function<void(const unsigned int, const AnswerType &)>
-            &             process_answer,
-          const MPI_Comm &comm);
+            &            process_answer,
+          const MPI_Comm comm);
 
         /**
          * After all answers have been exchanged, the MPI data structures can be
@@ -801,8 +801,8 @@ namespace Utilities
           const std::function<AnswerType(const unsigned int,
                                          const RequestType &)> &answer_request,
           const std::function<void(const unsigned int, const AnswerType &)>
-            &             process_answer,
-          const MPI_Comm &comm);
+            &            process_answer,
+          const MPI_Comm comm);
 
       /**
        * This function provides a specialization of the one above for
@@ -846,8 +846,8 @@ namespace Utilities
       pex(const std::vector<unsigned int> &                     targets,
           const std::function<RequestType(const unsigned int)> &create_request,
           const std::function<void(const unsigned int, const RequestType &)>
-            &             process_request,
-          const MPI_Comm &comm);
+            &            process_request,
+          const MPI_Comm comm);
 
 
       /**
@@ -876,7 +876,7 @@ namespace Utilities
          *   function that takes an argument.
          */
         DEAL_II_DEPRECATED
-        Serial(Process<RequestType, AnswerType> &process, const MPI_Comm &comm);
+        Serial(Process<RequestType, AnswerType> &process, const MPI_Comm comm);
 
         // Import the declarations from the base class.
         using Interface<RequestType, AnswerType>::run;
@@ -891,8 +891,8 @@ namespace Utilities
           const std::function<AnswerType(const unsigned int,
                                          const RequestType &)> &answer_request,
           const std::function<void(const unsigned int, const AnswerType &)>
-            &             process_answer,
-          const MPI_Comm &comm) override;
+            &            process_answer,
+          const MPI_Comm comm) override;
       };
 
 
@@ -937,8 +937,8 @@ namespace Utilities
         const std::function<AnswerType(const unsigned int, const RequestType &)>
           &answer_request,
         const std::function<void(const unsigned int, const AnswerType &)>
-          &             process_answer,
-        const MPI_Comm &comm);
+          &            process_answer,
+        const MPI_Comm comm);
 
       /**
        * This function provides a specialization of the one above for
@@ -975,8 +975,8 @@ namespace Utilities
         const std::vector<unsigned int> &                     targets,
         const std::function<RequestType(const unsigned int)> &create_request,
         const std::function<void(const unsigned int, const RequestType &)>
-          &             process_request,
-        const MPI_Comm &comm);
+          &            process_request,
+        const MPI_Comm comm);
 
 
 
@@ -1015,7 +1015,7 @@ namespace Utilities
          */
         DEAL_II_DEPRECATED
         Selector(Process<RequestType, AnswerType> &process,
-                 const MPI_Comm &                  comm);
+                 const MPI_Comm                    comm);
 
         /**
          * Destructor.
@@ -1037,8 +1037,8 @@ namespace Utilities
           const std::function<AnswerType(const unsigned int,
                                          const RequestType &)> &answer_request,
           const std::function<void(const unsigned int, const AnswerType &)>
-            &             process_answer,
-          const MPI_Comm &comm) override;
+            &            process_answer,
+          const MPI_Comm comm) override;
 
       private:
         // Pointer to the actual ConsensusAlgorithms::Interface implementation.
@@ -1099,8 +1099,8 @@ namespace Utilities
         const std::function<AnswerType(const unsigned int, const RequestType &)>
           &answer_request,
         const std::function<void(const unsigned int, const AnswerType &)>
-          &             process_answer,
-        const MPI_Comm &comm);
+          &            process_answer,
+        const MPI_Comm comm);
 
       /**
        * This function provides a specialization of the one above for
@@ -1145,8 +1145,8 @@ namespace Utilities
         const std::vector<unsigned int> &                     targets,
         const std::function<RequestType(const unsigned int)> &create_request,
         const std::function<void(const unsigned int, const RequestType &)>
-          &             process_request,
-        const MPI_Comm &comm);
+          &            process_request,
+        const MPI_Comm comm);
 
 
       /**
@@ -1231,8 +1231,8 @@ namespace Utilities
           const std::function<AnswerType(const unsigned int,
                                          const RequestType &)> &answer_request,
           const std::function<void(const unsigned int, const AnswerType &)>
-            &             process_answer,
-          const MPI_Comm &comm)
+            &            process_answer,
+          const MPI_Comm comm)
       {
         return NBX<RequestType, AnswerType>().run(
           targets, create_request, answer_request, process_answer, comm);
@@ -1245,8 +1245,8 @@ namespace Utilities
       nbx(const std::vector<unsigned int> &                     targets,
           const std::function<RequestType(const unsigned int)> &create_request,
           const std::function<void(const unsigned int, const RequestType &)>
-            &             process_request,
-          const MPI_Comm &comm)
+            &            process_request,
+          const MPI_Comm comm)
       {
         // TODO: For the moment, simply implement this special case by
         // forwarding to the other function with rewritten function
@@ -1283,8 +1283,8 @@ namespace Utilities
           const std::function<AnswerType(const unsigned int,
                                          const RequestType &)> &answer_request,
           const std::function<void(const unsigned int, const AnswerType &)>
-            &             process_answer,
-          const MPI_Comm &comm)
+            &            process_answer,
+          const MPI_Comm comm)
       {
         return PEX<RequestType, AnswerType>().run(
           targets, create_request, answer_request, process_answer, comm);
@@ -1297,8 +1297,8 @@ namespace Utilities
       pex(const std::vector<unsigned int> &                     targets,
           const std::function<RequestType(const unsigned int)> &create_request,
           const std::function<void(const unsigned int, const RequestType &)>
-            &             process_request,
-          const MPI_Comm &comm)
+            &            process_request,
+          const MPI_Comm comm)
       {
         // TODO: For the moment, simply implement this special case by
         // forwarding to the other function with rewritten function
@@ -1336,8 +1336,8 @@ namespace Utilities
         const std::function<AnswerType(const unsigned int, const RequestType &)>
           &answer_request,
         const std::function<void(const unsigned int, const AnswerType &)>
-          &             process_answer,
-        const MPI_Comm &comm)
+          &            process_answer,
+        const MPI_Comm comm)
       {
         return Serial<RequestType, AnswerType>().run(
           targets, create_request, answer_request, process_answer, comm);
@@ -1351,8 +1351,8 @@ namespace Utilities
         const std::vector<unsigned int> &                     targets,
         const std::function<RequestType(const unsigned int)> &create_request,
         const std::function<void(const unsigned int, const RequestType &)>
-          &             process_request,
-        const MPI_Comm &comm)
+          &            process_request,
+        const MPI_Comm comm)
       {
         // TODO: For the moment, simply implement this special case by
         // forwarding to the other function with rewritten function
@@ -1390,8 +1390,8 @@ namespace Utilities
         const std::function<AnswerType(const unsigned int, const RequestType &)>
           &answer_request,
         const std::function<void(const unsigned int, const AnswerType &)>
-          &             process_answer,
-        const MPI_Comm &comm)
+          &            process_answer,
+        const MPI_Comm comm)
       {
         return Selector<RequestType, AnswerType>().run(
           targets, create_request, answer_request, process_answer, comm);
@@ -1405,8 +1405,8 @@ namespace Utilities
         const std::vector<unsigned int> &                     targets,
         const std::function<RequestType(const unsigned int)> &create_request,
         const std::function<void(const unsigned int, const RequestType &)>
-          &             process_request,
-        const MPI_Comm &comm)
+          &            process_request,
+        const MPI_Comm comm)
       {
         // TODO: For the moment, simply implement this special case by
         // forwarding to the other function with rewritten function
@@ -1554,7 +1554,7 @@ namespace Utilities
          * Handle exceptions inside the ConsensusAlgorithm::run() functions.
          */
         inline void
-        handle_exception(std::exception_ptr &&exception, const MPI_Comm &comm)
+        handle_exception(std::exception_ptr &&exception, const MPI_Comm comm)
         {
 #  ifdef DEAL_II_WITH_MPI
           // an exception within a ConsensusAlgorithm likely causes an
@@ -1664,7 +1664,7 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       Interface<RequestType, AnswerType>::Interface(
         Process<RequestType, AnswerType> &process,
-        const MPI_Comm &                  comm)
+        const MPI_Comm                    comm)
         : process(&process)
         , comm(comm)
       {}
@@ -1697,7 +1697,7 @@ namespace Utilities
       std::vector<unsigned int>
       Interface<RequestType, AnswerType>::run(
         Process<RequestType, AnswerType> &process,
-        const MPI_Comm &                  comm)
+        const MPI_Comm                    comm)
       {
         // Unpack the 'process' object and call the function that takes
         // function objects for all operations.
@@ -1727,7 +1727,7 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       NBX<RequestType, AnswerType>::NBX(
         Process<RequestType, AnswerType> &process,
-        const MPI_Comm &                  comm)
+        const MPI_Comm                    comm)
         : Interface<RequestType, AnswerType>(process, comm)
       {}
 
@@ -1741,8 +1741,8 @@ namespace Utilities
         const std::function<AnswerType(const unsigned int, const RequestType &)>
           &answer_request,
         const std::function<void(const unsigned int, const AnswerType &)>
-          &             process_answer,
-        const MPI_Comm &comm)
+          &            process_answer,
+        const MPI_Comm comm)
       {
         Assert(has_unique_elements(targets),
                ExcMessage("The consensus algorithms expect that each process "
@@ -1805,7 +1805,7 @@ namespace Utilities
       NBX<RequestType, AnswerType>::start_communication(
         const std::vector<unsigned int> &                     targets,
         const std::function<RequestType(const unsigned int)> &create_request,
-        const MPI_Comm &                                      comm)
+        const MPI_Comm                                        comm)
       {
 #  ifdef DEAL_II_WITH_MPI
         // 1)
@@ -1859,8 +1859,8 @@ namespace Utilities
       NBX<RequestType, AnswerType>::
         all_locally_originated_receives_are_completed(
           const std::function<void(const unsigned int, const AnswerType &)>
-            &             process_answer,
-          const MPI_Comm &comm)
+            &            process_answer,
+          const MPI_Comm comm)
       {
 #  ifdef DEAL_II_WITH_MPI
         // We know that all requests have come in when we have pending
@@ -1953,8 +1953,8 @@ namespace Utilities
       void
       NBX<RequestType, AnswerType>::maybe_answer_one_request(
         const std::function<AnswerType(const unsigned int, const RequestType &)>
-          &             answer_request,
-        const MPI_Comm &comm)
+          &            answer_request,
+        const MPI_Comm comm)
       {
 #  ifdef DEAL_II_WITH_MPI
 
@@ -2035,7 +2035,7 @@ namespace Utilities
 
       template <typename RequestType, typename AnswerType>
       void
-      NBX<RequestType, AnswerType>::signal_finish(const MPI_Comm &comm)
+      NBX<RequestType, AnswerType>::signal_finish(const MPI_Comm comm)
       {
 #  ifdef DEAL_II_WITH_MPI
         const auto ierr = MPI_Ibarrier(comm, &barrier_request);
@@ -2069,7 +2069,7 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       void
       NBX<RequestType, AnswerType>::clean_up_and_end_communication(
-        const MPI_Comm &comm)
+        const MPI_Comm comm)
       {
         (void)comm;
 #  ifdef DEAL_II_WITH_MPI
@@ -2107,7 +2107,7 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       PEX<RequestType, AnswerType>::PEX(
         Process<RequestType, AnswerType> &process,
-        const MPI_Comm &                  comm)
+        const MPI_Comm                    comm)
         : Interface<RequestType, AnswerType>(process, comm)
       {}
 
@@ -2121,8 +2121,8 @@ namespace Utilities
         const std::function<AnswerType(const unsigned int, const RequestType &)>
           &answer_request,
         const std::function<void(const unsigned int, const AnswerType &)>
-          &             process_answer,
-        const MPI_Comm &comm)
+          &            process_answer,
+        const MPI_Comm comm)
       {
         Assert(has_unique_elements(targets),
                ExcMessage("The consensus algorithms expect that each process "
@@ -2166,7 +2166,7 @@ namespace Utilities
       PEX<RequestType, AnswerType>::start_communication(
         const std::vector<unsigned int> &                     targets,
         const std::function<RequestType(const unsigned int)> &create_request,
-        const MPI_Comm &                                      comm)
+        const MPI_Comm                                        comm)
       {
 #  ifdef DEAL_II_WITH_MPI
         const int tag_request = Utilities::MPI::internal::Tags::
@@ -2226,8 +2226,8 @@ namespace Utilities
       PEX<RequestType, AnswerType>::answer_one_request(
         const unsigned int index,
         const std::function<AnswerType(const unsigned int, const RequestType &)>
-          &             answer_request,
-        const MPI_Comm &comm)
+          &            answer_request,
+        const MPI_Comm comm)
       {
 #  ifdef DEAL_II_WITH_MPI
         const int tag_request = Utilities::MPI::internal::Tags::
@@ -2300,8 +2300,8 @@ namespace Utilities
       PEX<RequestType, AnswerType>::process_incoming_answers(
         const unsigned int n_targets,
         const std::function<void(const unsigned int, const AnswerType &)>
-          &             process_answer,
-        const MPI_Comm &comm)
+          &            process_answer,
+        const MPI_Comm comm)
       {
 #  ifdef DEAL_II_WITH_MPI
         const int tag_deliver = Utilities::MPI::internal::Tags::
@@ -2387,7 +2387,7 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       Serial<RequestType, AnswerType>::Serial(
         Process<RequestType, AnswerType> &process,
-        const MPI_Comm &                  comm)
+        const MPI_Comm                    comm)
         : Interface<RequestType, AnswerType>(process, comm)
       {}
 
@@ -2401,8 +2401,8 @@ namespace Utilities
         const std::function<AnswerType(const unsigned int, const RequestType &)>
           &answer_request,
         const std::function<void(const unsigned int, const AnswerType &)>
-          &             process_answer,
-        const MPI_Comm &comm)
+          &            process_answer,
+        const MPI_Comm comm)
       {
         (void)comm;
         Assert((Utilities::MPI::job_supports_mpi() == false) ||
@@ -2441,7 +2441,7 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       Selector<RequestType, AnswerType>::Selector(
         Process<RequestType, AnswerType> &process,
-        const MPI_Comm &                  comm)
+        const MPI_Comm                    comm)
         : Interface<RequestType, AnswerType>(process, comm)
       {}
 
@@ -2455,8 +2455,8 @@ namespace Utilities
         const std::function<AnswerType(const unsigned int, const RequestType &)>
           &answer_request,
         const std::function<void(const unsigned int, const AnswerType &)>
-          &             process_answer,
-        const MPI_Comm &comm)
+          &            process_answer,
+        const MPI_Comm comm)
       {
         // Depending on the number of processes we switch between
         // implementations. We reduce the threshold for debug mode to be

--- a/include/deal.II/base/mpi_noncontiguous_partitioner.h
+++ b/include/deal.II/base/mpi_noncontiguous_partitioner.h
@@ -61,7 +61,7 @@ namespace Utilities
        */
       NoncontiguousPartitioner(const IndexSet &indexset_locally_owned,
                                const IndexSet &indexset_ghost,
-                               const MPI_Comm &communicator);
+                               const MPI_Comm  communicator);
 
       /**
        * Constructor. Same as above but for vectors of indices @p indices_locally_owned
@@ -75,7 +75,7 @@ namespace Utilities
       NoncontiguousPartitioner(
         const std::vector<types::global_dof_index> &indices_locally_owned,
         const std::vector<types::global_dof_index> &indices_ghost,
-        const MPI_Comm &                            communicator);
+        const MPI_Comm                              communicator);
 
       /**
        * Fill the vector @p ghost_array according to the precomputed communication
@@ -197,7 +197,7 @@ namespace Utilities
       void
       reinit(const IndexSet &locally_owned_indices,
              const IndexSet &ghost_indices,
-             const MPI_Comm &communicator) override;
+             const MPI_Comm  communicator) override;
 
       /**
        * Initialize the inner data structures using explicit sets of
@@ -207,7 +207,7 @@ namespace Utilities
       void
       reinit(const std::vector<types::global_dof_index> &locally_owned_indices,
              const std::vector<types::global_dof_index> &ghost_indices,
-             const MPI_Comm &                            communicator);
+             const MPI_Comm                              communicator);
 
     private:
       /**

--- a/include/deal.II/base/partitioner.h
+++ b/include/deal.II/base/partitioner.h
@@ -224,7 +224,7 @@ namespace Utilities
        */
       Partitioner(const types::global_dof_index local_size,
                   const types::global_dof_index ghost_size,
-                  const MPI_Comm &              communicator);
+                  const MPI_Comm                communicator);
 
       /**
        * Constructor with index set arguments. This constructor creates a
@@ -235,7 +235,7 @@ namespace Utilities
        */
       Partitioner(const IndexSet &locally_owned_indices,
                   const IndexSet &ghost_indices_in,
-                  const MPI_Comm &communicator_in);
+                  const MPI_Comm  communicator_in);
 
       /**
        * Constructor with one index set argument. This constructor creates a
@@ -245,7 +245,7 @@ namespace Utilities
        * constructor with two index sets.
        */
       Partitioner(const IndexSet &locally_owned_indices,
-                  const MPI_Comm &communicator_in);
+                  const MPI_Comm  communicator_in);
 
       /**
        * Reinitialize the communication pattern. The first argument
@@ -257,7 +257,7 @@ namespace Utilities
       virtual void
       reinit(const IndexSet &vector_space_vector_index_set,
              const IndexSet &read_write_vector_index_set,
-             const MPI_Comm &communicator) override;
+             const MPI_Comm  communicator) override;
 
       /**
        * Set the locally owned indices. Used in the constructor.

--- a/include/deal.II/base/process_grid.h
+++ b/include/deal.II/base/process_grid.h
@@ -71,7 +71,7 @@ namespace Utilities
        * number of cores
        * in the @p mpi_communicator.
        */
-      ProcessGrid(const MPI_Comm &   mpi_communicator,
+      ProcessGrid(const MPI_Comm     mpi_communicator,
                   const unsigned int n_rows,
                   const unsigned int n_columns);
 
@@ -92,7 +92,7 @@ namespace Utilities
        * and the @p mpi_communicator with 11 cores will result in the $3x3$
        * process grid.
        */
-      ProcessGrid(const MPI_Comm &   mpi_communicator,
+      ProcessGrid(const MPI_Comm     mpi_communicator,
                   const unsigned int n_rows_matrix,
                   const unsigned int n_columns_matrix,
                   const unsigned int row_block_size,
@@ -151,7 +151,7 @@ namespace Utilities
        * A private constructor which takes grid dimensions as an
        * <code>std::pair</code>.
        */
-      ProcessGrid(const MPI_Comm &                             mpi_communicator,
+      ProcessGrid(const MPI_Comm                               mpi_communicator,
                   const std::pair<unsigned int, unsigned int> &grid_dimensions);
 
       /**

--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -725,7 +725,7 @@ public:
    *   the destructor is called.
    */
   void
-  replicate_across_communicator(const MPI_Comm &   communicator,
+  replicate_across_communicator(const MPI_Comm     communicator,
                                 const unsigned int root_process);
 
   /**
@@ -2385,7 +2385,7 @@ TableBase<N, T>::fill(const T &value)
 
 template <int N, typename T>
 inline void
-TableBase<N, T>::replicate_across_communicator(const MPI_Comm &   communicator,
+TableBase<N, T>::replicate_across_communicator(const MPI_Comm     communicator,
                                                const unsigned int root_process)
 {
   // Replicate first the actual data, then also exchange the

--- a/include/deal.II/base/timer.h
+++ b/include/deal.II/base/timer.h
@@ -136,7 +136,7 @@ public:
    * communicator occurs; the extra cost of the synchronization is not
    * measured.
    */
-  Timer(const MPI_Comm &mpi_communicator, const bool sync_lap_times = false);
+  Timer(const MPI_Comm mpi_communicator, const bool sync_lap_times = false);
 
   /**
    * Return a reference to the data structure containing basic statistics on
@@ -711,7 +711,7 @@ public:
    * <code>MPI_Barrier</code> call before starting and stopping the timer for
    * each section.
    */
-  TimerOutput(const MPI_Comm &      mpi_comm,
+  TimerOutput(const MPI_Comm        mpi_comm,
               std::ostream &        stream,
               const OutputFrequency output_frequency,
               const OutputType      output_type);
@@ -739,7 +739,7 @@ public:
    * <code>MPI_Barrier</code> call before starting and stopping the timer for
    * each section.)
    */
-  TimerOutput(const MPI_Comm &      mpi_comm,
+  TimerOutput(const MPI_Comm        mpi_comm,
               ConditionalOStream &  stream,
               const OutputFrequency output_frequency,
               const OutputType      output_type);
@@ -795,8 +795,8 @@ public:
    * median is given).
    */
   void
-  print_wall_time_statistics(const MPI_Comm &mpi_comm,
-                             const double    print_quantile = 0.) const;
+  print_wall_time_statistics(const MPI_Comm mpi_comm,
+                             const double   print_quantile = 0.) const;
 
   /**
    * By calling this function, all output can be disabled. This function

--- a/include/deal.II/distributed/fully_distributed_tria.h
+++ b/include/deal.II/distributed/fully_distributed_tria.h
@@ -129,7 +129,7 @@ namespace parallel
        * @param mpi_communicator The MPI communicator to be used for the
        *                         triangulation.
        */
-      explicit Triangulation(const MPI_Comm &mpi_communicator);
+      explicit Triangulation(const MPI_Comm mpi_communicator);
 
       /**
        * Destructor.

--- a/include/deal.II/distributed/grid_refinement.h
+++ b/include/deal.II/distributed/grid_refinement.h
@@ -47,7 +47,7 @@ namespace internal
         std::pair<number, number>
         compute_global_min_and_max_at_root(
           const dealii::Vector<number> &criteria,
-          const MPI_Comm &              mpi_communicator);
+          const MPI_Comm                mpi_communicator);
 
         namespace RefineAndCoarsenFixedNumber
         {
@@ -60,7 +60,7 @@ namespace internal
           compute_threshold(const dealii::Vector<number> &   criteria,
                             const std::pair<double, double> &global_min_and_max,
                             const types::global_cell_index   n_target_cells,
-                            const MPI_Comm &                 mpi_communicator);
+                            const MPI_Comm                   mpi_communicator);
         } // namespace RefineAndCoarsenFixedNumber
 
         namespace RefineAndCoarsenFixedFraction
@@ -78,7 +78,7 @@ namespace internal
           compute_threshold(const dealii::Vector<number> &   criteria,
                             const std::pair<double, double> &global_min_and_max,
                             const double                     target_error,
-                            const MPI_Comm &                 mpi_communicator);
+                            const MPI_Comm                   mpi_communicator);
         } // namespace RefineAndCoarsenFixedFraction
       }   // namespace GridRefinement
     }     // namespace distributed

--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -257,7 +257,7 @@ namespace parallel
        * consider enabling artificial cells.
        */
       Triangulation(
-        const MPI_Comm &mpi_communicator,
+        const MPI_Comm mpi_communicator,
         const typename dealii::Triangulation<dim, spacedim>::MeshSmoothing =
           (dealii::Triangulation<dim, spacedim>::none),
         const bool     allow_artificial_cells = false,

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -367,7 +367,7 @@ namespace parallel
        * triangulation is partitioned.
        */
       explicit Triangulation(
-        const MPI_Comm &mpi_communicator,
+        const MPI_Comm mpi_communicator,
         const typename dealii::Triangulation<dim, spacedim>::MeshSmoothing
           smooth_grid           = (dealii::Triangulation<dim, spacedim>::none),
         const Settings settings = default_setting);
@@ -879,7 +879,7 @@ namespace parallel
        * the triangulation.
        */
       Triangulation(
-        const MPI_Comm &mpi_communicator,
+        const MPI_Comm mpi_communicator,
         const typename dealii::Triangulation<1, spacedim>::MeshSmoothing
                        smooth_grid = (dealii::Triangulation<1, spacedim>::none),
         const Settings settings    = default_setting);
@@ -1022,7 +1022,7 @@ namespace parallel
        * constructed (see also the class documentation).
        */
       explicit Triangulation(
-        const MPI_Comm & /*mpi_communicator*/,
+        const MPI_Comm /*mpi_communicator*/,
         const typename dealii::Triangulation<dim, spacedim>::MeshSmoothing
         /*smooth_grid*/
         = (dealii::Triangulation<dim, spacedim>::none),

--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -83,7 +83,7 @@ namespace parallel
      * Constructor.
      */
     TriangulationBase(
-      const MPI_Comm &mpi_communicator,
+      const MPI_Comm mpi_communicator,
       const typename dealii::Triangulation<dim, spacedim>::MeshSmoothing
                  smooth_grid = (dealii::Triangulation<dim, spacedim>::none),
       const bool check_for_distorted_cells = false);
@@ -441,7 +441,7 @@ namespace parallel
      * Constructor.
      */
     DistributedTriangulationBase(
-      const MPI_Comm &mpi_communicator,
+      const MPI_Comm mpi_communicator,
       const typename dealii::Triangulation<dim, spacedim>::MeshSmoothing
                  smooth_grid = (dealii::Triangulation<dim, spacedim>::none),
       const bool check_for_distorted_cells = false);
@@ -776,7 +776,7 @@ namespace parallel
     class DataTransfer
     {
     public:
-      DataTransfer(const MPI_Comm &mpi_communicator);
+      DataTransfer(const MPI_Comm mpi_communicator);
 
       /**
        * Prepare data transfer by calling the pack callback functions on each

--- a/include/deal.II/dofs/number_cache.h
+++ b/include/deal.II/dofs/number_cache.h
@@ -117,7 +117,7 @@ namespace internal
        */
       std::vector<types::global_dof_index>
       get_n_locally_owned_dofs_per_processor(
-        const MPI_Comm &mpi_communicator) const;
+        const MPI_Comm mpi_communicator) const;
 
       /**
        * Return a representation of @p locally_owned_dofs_per_processor both
@@ -128,7 +128,7 @@ namespace internal
        */
       std::vector<IndexSet>
       get_locally_owned_dofs_per_processor(
-        const MPI_Comm &mpi_communicator) const;
+        const MPI_Comm mpi_communicator) const;
 
       /**
        * Total number of dofs, accumulated over all processors that may

--- a/include/deal.II/fe/fe_tools_interpolate.templates.h
+++ b/include/deal.II/fe/fe_tools_interpolate.templates.h
@@ -461,7 +461,7 @@ namespace FETools
     {
       if (u1.n_blocks() == 0)
         return;
-      const MPI_Comm &mpi_communicator = u1.block(0).get_mpi_communicator();
+      const MPI_Comm  mpi_communicator = u1.block(0).get_mpi_communicator();
       const IndexSet &dof2_locally_owned_dofs = dof2.locally_owned_dofs();
       IndexSet        dof2_locally_relevant_dofs;
       DoFTools::extract_locally_relevant_dofs(dof2, dof2_locally_relevant_dofs);

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -3417,7 +3417,7 @@ namespace GridTools
   std::vector<std::vector<BoundingBox<spacedim>>>
   exchange_local_bounding_boxes(
     const std::vector<BoundingBox<spacedim>> &local_bboxes,
-    const MPI_Comm &                          mpi_communicator);
+    const MPI_Comm                            mpi_communicator);
 
   /**
    * In this collective operation each process provides a vector
@@ -3455,7 +3455,7 @@ namespace GridTools
   RTree<std::pair<BoundingBox<spacedim>, unsigned int>>
   build_global_description_tree(
     const std::vector<BoundingBox<spacedim>> &local_description,
-    const MPI_Comm &                          mpi_communicator);
+    const MPI_Comm                            mpi_communicator);
 
   /**
    * Collect for a given triangulation all locally relevant vertices that

--- a/include/deal.II/grid/tria_description.h
+++ b/include/deal.II/grid/tria_description.h
@@ -528,7 +528,7 @@ namespace TriangulationDescription
     Description<dim, spacedim>
     create_description_from_triangulation(
       const dealii::Triangulation<dim, spacedim> &tria,
-      const MPI_Comm &                            comm,
+      const MPI_Comm                              comm,
       const TriangulationDescription::Settings    settings =
         TriangulationDescription::Settings::default_setting,
       const unsigned int my_rank_in = numbers::invalid_unsigned_int);
@@ -641,9 +641,9 @@ namespace TriangulationDescription
       const std::function<void(dealii::Triangulation<dim, spacedim> &)>
         &                                            serial_grid_generator,
       const std::function<void(dealii::Triangulation<dim, spacedim> &,
-                               const MPI_Comm &,
+                               const MPI_Comm,
                                const unsigned int)> &serial_grid_partitioner,
-      const MPI_Comm &                               comm,
+      const MPI_Comm                                 comm,
       const int                                      group_size = 1,
       const typename Triangulation<dim, spacedim>::MeshSmoothing smoothing =
         dealii::Triangulation<dim, spacedim>::none,

--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -795,7 +795,7 @@ public:
    * AffineConstraints was created for the DG case.
    */
   bool
-  is_closed(const MPI_Comm &comm) const;
+  is_closed(const MPI_Comm comm) const;
 
   /**
    * Merge the constraints represented by the object given as argument into
@@ -1758,7 +1758,7 @@ public:
   bool
   is_consistent_in_parallel(const std::vector<IndexSet> &locally_owned_dofs,
                             const IndexSet &             locally_active_dofs,
-                            const MPI_Comm &             mpi_communicator,
+                            const MPI_Comm               mpi_communicator,
                             const bool                   verbose = false) const;
 
   /**

--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -107,7 +107,7 @@ bool
 AffineConstraints<number>::is_consistent_in_parallel(
   const std::vector<IndexSet> &locally_owned_dofs,
   const IndexSet &             locally_active_dofs,
-  const MPI_Comm &             mpi_communicator,
+  const MPI_Comm               mpi_communicator,
   const bool                   verbose) const
 {
   // Helper to return a ConstraintLine object that belongs to row @p row.
@@ -939,7 +939,7 @@ AffineConstraints<number>::is_closed() const
 
 template <typename number>
 bool
-AffineConstraints<number>::is_closed(const MPI_Comm &comm) const
+AffineConstraints<number>::is_closed(const MPI_Comm comm) const
 {
   return Utilities::MPI::min(static_cast<unsigned int>(is_closed()), comm) == 1;
 }

--- a/include/deal.II/lac/block_sparsity_pattern.h
+++ b/include/deal.II/lac/block_sparsity_pattern.h
@@ -696,7 +696,7 @@ namespace TrilinosWrappers
      * to be saved in each block.
      */
     BlockSparsityPattern(const std::vector<IndexSet> &parallel_partitioning,
-                         const MPI_Comm &communicator = MPI_COMM_WORLD);
+                         const MPI_Comm communicator = MPI_COMM_WORLD);
 
     /**
      * Initialize the pattern with two arrays of index sets that specify rows
@@ -713,7 +713,7 @@ namespace TrilinosWrappers
       const std::vector<IndexSet> &row_parallel_partitioning,
       const std::vector<IndexSet> &column_parallel_partitioning,
       const std::vector<IndexSet> &writeable_rows,
-      const MPI_Comm &             communicator = MPI_COMM_WORLD);
+      const MPI_Comm               communicator = MPI_COMM_WORLD);
 
     /**
      * Resize the matrix to a tensor product of matrices with dimensions
@@ -734,7 +734,7 @@ namespace TrilinosWrappers
      */
     void
     reinit(const std::vector<IndexSet> &parallel_partitioning,
-           const MPI_Comm &             communicator = MPI_COMM_WORLD);
+           const MPI_Comm               communicator = MPI_COMM_WORLD);
 
     /**
      * Resize the matrix to a rectangular block matrices. This method allows
@@ -744,7 +744,7 @@ namespace TrilinosWrappers
     void
     reinit(const std::vector<IndexSet> &row_parallel_partitioning,
            const std::vector<IndexSet> &column_parallel_partitioning,
-           const MPI_Comm &             communicator = MPI_COMM_WORLD);
+           const MPI_Comm               communicator = MPI_COMM_WORLD);
 
     /**
      * Resize the matrix to a rectangular block matrices that furthermore
@@ -758,7 +758,7 @@ namespace TrilinosWrappers
     reinit(const std::vector<IndexSet> &row_parallel_partitioning,
            const std::vector<IndexSet> &column_parallel_partitioning,
            const std::vector<IndexSet> &writeable_rows,
-           const MPI_Comm &             communicator = MPI_COMM_WORLD);
+           const MPI_Comm               communicator = MPI_COMM_WORLD);
 
     /**
      * Allow the use of the reinit functions of the base class as well.

--- a/include/deal.II/lac/la_parallel_block_vector.h
+++ b/include/deal.II/lac/la_parallel_block_vector.h
@@ -168,13 +168,13 @@ namespace LinearAlgebra
        */
       BlockVector(const std::vector<IndexSet> &local_ranges,
                   const std::vector<IndexSet> &ghost_indices,
-                  const MPI_Comm &             communicator);
+                  const MPI_Comm               communicator);
 
       /**
        * Same as above but the ghost indices are assumed to be empty.
        */
       BlockVector(const std::vector<IndexSet> &local_ranges,
-                  const MPI_Comm &             communicator);
+                  const MPI_Comm               communicator);
 
       /**
        * Destructor.
@@ -319,14 +319,14 @@ namespace LinearAlgebra
       void
       reinit(const std::vector<IndexSet> &local_ranges,
              const std::vector<IndexSet> &ghost_indices,
-             const MPI_Comm &             communicator);
+             const MPI_Comm               communicator);
 
       /**
        * Same as above, but without ghost entries.
        */
       void
       reinit(const std::vector<IndexSet> &local_ranges,
-             const MPI_Comm &             communicator);
+             const MPI_Comm               communicator);
 
       /**
        * This function copies the data that has accumulated in the data buffer

--- a/include/deal.II/lac/la_parallel_block_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_block_vector.templates.h
@@ -60,7 +60,7 @@ namespace LinearAlgebra
     template <typename Number>
     BlockVector<Number>::BlockVector(const std::vector<IndexSet> &local_ranges,
                                      const std::vector<IndexSet> &ghost_indices,
-                                     const MPI_Comm &             communicator)
+                                     const MPI_Comm               communicator)
     {
       reinit(local_ranges, ghost_indices, communicator);
     }
@@ -68,7 +68,7 @@ namespace LinearAlgebra
 
     template <typename Number>
     BlockVector<Number>::BlockVector(const std::vector<IndexSet> &local_ranges,
-                                     const MPI_Comm &             communicator)
+                                     const MPI_Comm               communicator)
     {
       reinit(local_ranges, communicator);
     }
@@ -149,7 +149,7 @@ namespace LinearAlgebra
     void
     BlockVector<Number>::reinit(const std::vector<IndexSet> &local_ranges,
                                 const std::vector<IndexSet> &ghost_indices,
-                                const MPI_Comm &             communicator)
+                                const MPI_Comm               communicator)
     {
       AssertDimension(local_ranges.size(), ghost_indices.size());
 
@@ -172,7 +172,7 @@ namespace LinearAlgebra
     template <typename Number>
     void
     BlockVector<Number>::reinit(const std::vector<IndexSet> &local_ranges,
-                                const MPI_Comm &             communicator)
+                                const MPI_Comm               communicator)
     {
       // update the number of blocks
       this->block_indices.reinit(local_ranges.size(), 0);

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -316,12 +316,12 @@ namespace LinearAlgebra
        */
       Vector(const IndexSet &local_range,
              const IndexSet &ghost_indices,
-             const MPI_Comm &communicator);
+             const MPI_Comm  communicator);
 
       /**
        * Same constructor as above but without any ghost indices.
        */
-      Vector(const IndexSet &local_range, const MPI_Comm &communicator);
+      Vector(const IndexSet &local_range, const MPI_Comm communicator);
 
       /**
        * Create the vector based on the parallel partitioning described in @p
@@ -378,13 +378,13 @@ namespace LinearAlgebra
       void
       reinit(const IndexSet &local_range,
              const IndexSet &ghost_indices,
-             const MPI_Comm &communicator);
+             const MPI_Comm  communicator);
 
       /**
        * Same as above, but without ghost entries.
        */
       void
-      reinit(const IndexSet &local_range, const MPI_Comm &communicator);
+      reinit(const IndexSet &local_range, const MPI_Comm communicator);
 
       /**
        * Initialize the vector given to the parallel partitioning described in
@@ -401,7 +401,7 @@ namespace LinearAlgebra
       void
       reinit(
         const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner,
-        const MPI_Comm &comm_sm = MPI_COMM_SELF);
+        const MPI_Comm comm_sm = MPI_COMM_SELF);
 
       /**
        * Initialize vector with @p local_size locally-owned and @p ghost_size
@@ -425,8 +425,8 @@ namespace LinearAlgebra
       void
       reinit(const types::global_dof_index local_size,
              const types::global_dof_index ghost_size,
-             const MPI_Comm &              comm,
-             const MPI_Comm &              comm_sm = MPI_COMM_SELF);
+             const MPI_Comm                comm,
+             const MPI_Comm                comm_sm = MPI_COMM_SELF);
 
       /**
        * Swap the contents of this vector and the other vector @p v. One could
@@ -1419,7 +1419,7 @@ namespace LinearAlgebra
        */
       void
       resize_val(const size_type new_allocated_size,
-                 const MPI_Comm &comm_sm = MPI_COMM_SELF);
+                 const MPI_Comm  comm_sm = MPI_COMM_SELF);
 
       // Make all other vector types friends.
       template <typename Number2, typename MemorySpace2>

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -95,7 +95,7 @@ namespace LinearAlgebra
           types::global_dof_index & /*allocated_size*/,
           ::dealii::MemorySpace::MemorySpaceData<Number, MemorySpaceType>
             & /*data*/,
-          const MPI_Comm & /*comm_sm*/)
+          const MPI_Comm /*comm_sm*/)
         {}
 
         static void
@@ -130,7 +130,7 @@ namespace LinearAlgebra
                    types::global_dof_index &     allocated_size,
                    ::dealii::MemorySpace::
                      MemorySpaceData<Number, ::dealii::MemorySpace::Host> &data,
-                   const MPI_Comm &comm_shared)
+                   const MPI_Comm comm_shared)
         {
           if (comm_shared == MPI_COMM_SELF)
             {
@@ -328,8 +328,8 @@ namespace LinearAlgebra
           types::global_dof_index &     allocated_size,
           ::dealii::MemorySpace::MemorySpaceData<Number,
                                                  ::dealii::MemorySpace::Default>
-            &             data,
-          const MPI_Comm &comm_sm)
+            &            data,
+          const MPI_Comm comm_sm)
         {
           (void)comm_sm;
 
@@ -521,7 +521,7 @@ namespace LinearAlgebra
     template <typename Number, typename MemorySpaceType>
     void
     Vector<Number, MemorySpaceType>::resize_val(const size_type new_alloc_size,
-                                                const MPI_Comm &comm_sm)
+                                                const MPI_Comm  comm_sm)
     {
       internal::la_parallel_vector_templates_functions<
         Number,
@@ -567,8 +567,8 @@ namespace LinearAlgebra
     Vector<Number, MemorySpaceType>::reinit(
       const types::global_dof_index local_size,
       const types::global_dof_index ghost_size,
-      const MPI_Comm &              comm,
-      const MPI_Comm &              comm_sm)
+      const MPI_Comm                comm,
+      const MPI_Comm                comm_sm)
     {
       clear_mpi_requests();
 
@@ -637,7 +637,7 @@ namespace LinearAlgebra
     Vector<Number, MemorySpaceType>::reinit(
       const IndexSet &locally_owned_indices,
       const IndexSet &ghost_indices,
-      const MPI_Comm &communicator)
+      const MPI_Comm  communicator)
     {
       // set up parallel partitioner with index sets and communicator
       reinit(std::make_shared<Utilities::MPI::Partitioner>(
@@ -650,7 +650,7 @@ namespace LinearAlgebra
     void
     Vector<Number, MemorySpaceType>::reinit(
       const IndexSet &locally_owned_indices,
-      const MPI_Comm &communicator)
+      const MPI_Comm  communicator)
     {
       // set up parallel partitioner with index sets and communicator
       reinit(
@@ -664,7 +664,7 @@ namespace LinearAlgebra
     void
     Vector<Number, MemorySpaceType>::reinit(
       const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner_in,
-      const MPI_Comm &                                          comm_sm)
+      const MPI_Comm                                            comm_sm)
     {
       clear_mpi_requests();
 
@@ -737,7 +737,7 @@ namespace LinearAlgebra
     template <typename Number, typename MemorySpaceType>
     Vector<Number, MemorySpaceType>::Vector(const IndexSet &local_range,
                                             const IndexSet &ghost_indices,
-                                            const MPI_Comm &communicator)
+                                            const MPI_Comm  communicator)
       : allocated_size(0)
       , vector_is_ghosted(false)
       , comm_sm(MPI_COMM_SELF)
@@ -749,7 +749,7 @@ namespace LinearAlgebra
 
     template <typename Number, typename MemorySpaceType>
     Vector<Number, MemorySpaceType>::Vector(const IndexSet &local_range,
-                                            const MPI_Comm &communicator)
+                                            const MPI_Comm  communicator)
       : allocated_size(0)
       , vector_is_ghosted(false)
       , comm_sm(MPI_COMM_SELF)

--- a/include/deal.II/lac/parpack_solver.h
+++ b/include/deal.II/lac/parpack_solver.h
@@ -295,7 +295,7 @@ public:
    * Constructor.
    */
   PArpackSolver(SolverControl &       control,
-                const MPI_Comm &      mpi_communicator,
+                const MPI_Comm        mpi_communicator,
                 const AdditionalData &data = AdditionalData());
 
   /**
@@ -638,7 +638,7 @@ PArpackSolver<VectorType>::AdditionalData::AdditionalData(
 
 template <typename VectorType>
 PArpackSolver<VectorType>::PArpackSolver(SolverControl &       control,
-                                         const MPI_Comm &      mpi_communicator,
+                                         const MPI_Comm        mpi_communicator,
                                          const AdditionalData &data)
   : solver_control(control)
   , additional_data(data)

--- a/include/deal.II/lac/petsc_block_sparse_matrix.h
+++ b/include/deal.II/lac/petsc_block_sparse_matrix.h
@@ -172,7 +172,7 @@ namespace PETScWrappers
       reinit(const std::vector<IndexSet> &      rows,
              const std::vector<IndexSet> &      cols,
              const BlockDynamicSparsityPattern &bdsp,
-             const MPI_Comm &                   com);
+             const MPI_Comm                     com);
 
 
       /**
@@ -181,7 +181,7 @@ namespace PETScWrappers
       void
       reinit(const std::vector<IndexSet> &      sizes,
              const BlockDynamicSparsityPattern &bdsp,
-             const MPI_Comm &                   com);
+             const MPI_Comm                     com);
 
 
       /**

--- a/include/deal.II/lac/petsc_block_vector.h
+++ b/include/deal.II/lac/petsc_block_vector.h
@@ -95,7 +95,7 @@ namespace PETScWrappers
        * present process.
        */
       explicit BlockVector(const unsigned int n_blocks,
-                           const MPI_Comm &   communicator,
+                           const MPI_Comm     communicator,
                            const size_type    block_size,
                            const size_type    locally_owned_size);
 
@@ -113,7 +113,7 @@ namespace PETScWrappers
        * process.
        */
       BlockVector(const std::vector<size_type> &block_sizes,
-                  const MPI_Comm &              communicator,
+                  const MPI_Comm                communicator,
                   const std::vector<size_type> &local_elements);
 
       /**
@@ -121,14 +121,14 @@ namespace PETScWrappers
        * initialized with the given IndexSet.
        */
       explicit BlockVector(const std::vector<IndexSet> &parallel_partitioning,
-                           const MPI_Comm &communicator = MPI_COMM_WORLD);
+                           const MPI_Comm communicator = MPI_COMM_WORLD);
 
       /**
        * Same as above, but include ghost elements
        */
       BlockVector(const std::vector<IndexSet> &parallel_partitioning,
                   const std::vector<IndexSet> &ghost_indices,
-                  const MPI_Comm &             communicator);
+                  const MPI_Comm               communicator);
 
       /**
        * Create a BlockVector with a PETSc Vec
@@ -181,7 +181,7 @@ namespace PETScWrappers
        */
       void
       reinit(const unsigned int n_blocks,
-             const MPI_Comm &   communicator,
+             const MPI_Comm     communicator,
              const size_type    block_size,
              const size_type    locally_owned_size,
              const bool         omit_zeroing_entries = false);
@@ -208,7 +208,7 @@ namespace PETScWrappers
        */
       void
       reinit(const std::vector<size_type> &block_sizes,
-             const MPI_Comm &              communicator,
+             const MPI_Comm                communicator,
              const std::vector<size_type> &locally_owned_sizes,
              const bool                    omit_zeroing_entries = false);
 
@@ -235,7 +235,7 @@ namespace PETScWrappers
        */
       void
       reinit(const std::vector<IndexSet> &parallel_partitioning,
-             const MPI_Comm &             communicator);
+             const MPI_Comm               communicator);
 
       /**
        * Same as above but include ghost entries.
@@ -243,7 +243,7 @@ namespace PETScWrappers
       void
       reinit(const std::vector<IndexSet> &parallel_partitioning,
              const std::vector<IndexSet> &ghost_entries,
-             const MPI_Comm &             communicator);
+             const MPI_Comm               communicator);
 
       /**
        * This function collects the sizes of the sub-objects and stores them
@@ -370,7 +370,7 @@ namespace PETScWrappers
 
 
     inline BlockVector::BlockVector(const unsigned int n_blocks,
-                                    const MPI_Comm &   communicator,
+                                    const MPI_Comm     communicator,
                                     const size_type    block_size,
                                     const size_type    locally_owned_size)
       : BlockVector()
@@ -382,7 +382,7 @@ namespace PETScWrappers
 
     inline BlockVector::BlockVector(
       const std::vector<size_type> &block_sizes,
-      const MPI_Comm &              communicator,
+      const MPI_Comm                communicator,
       const std::vector<size_type> &local_elements)
       : BlockVector()
     {
@@ -407,7 +407,7 @@ namespace PETScWrappers
 
     inline BlockVector::BlockVector(
       const std::vector<IndexSet> &parallel_partitioning,
-      const MPI_Comm &             communicator)
+      const MPI_Comm               communicator)
       : BlockVector()
     {
       reinit(parallel_partitioning, communicator);
@@ -418,7 +418,7 @@ namespace PETScWrappers
     inline BlockVector::BlockVector(
       const std::vector<IndexSet> &parallel_partitioning,
       const std::vector<IndexSet> &ghost_indices,
-      const MPI_Comm &             communicator)
+      const MPI_Comm               communicator)
       : BlockVector()
     {
       reinit(parallel_partitioning, ghost_indices, communicator);
@@ -481,7 +481,7 @@ namespace PETScWrappers
 
     inline void
     BlockVector::reinit(const unsigned int n_blocks,
-                        const MPI_Comm &   communicator,
+                        const MPI_Comm     communicator,
                         const size_type    block_size,
                         const size_type    locally_owned_size,
                         const bool         omit_zeroing_entries)
@@ -496,7 +496,7 @@ namespace PETScWrappers
 
     inline void
     BlockVector::reinit(const std::vector<size_type> &block_sizes,
-                        const MPI_Comm &              communicator,
+                        const MPI_Comm                communicator,
                         const std::vector<size_type> &locally_owned_sizes,
                         const bool                    omit_zeroing_entries)
     {
@@ -530,7 +530,7 @@ namespace PETScWrappers
 
     inline void
     BlockVector::reinit(const std::vector<IndexSet> &parallel_partitioning,
-                        const MPI_Comm &             communicator)
+                        const MPI_Comm               communicator)
     {
       // update the number of blocks
       this->block_indices.reinit(parallel_partitioning.size(), 0);
@@ -549,7 +549,7 @@ namespace PETScWrappers
     inline void
     BlockVector::reinit(const std::vector<IndexSet> &parallel_partitioning,
                         const std::vector<IndexSet> &ghost_entries,
-                        const MPI_Comm &             communicator)
+                        const MPI_Comm               communicator)
     {
       AssertDimension(parallel_partitioning.size(), ghost_entries.size());
 

--- a/include/deal.II/lac/petsc_communication_pattern.h
+++ b/include/deal.II/lac/petsc_communication_pattern.h
@@ -62,7 +62,7 @@ namespace PETScWrappers
     virtual void
     reinit(const IndexSet &locally_owned_indices,
            const IndexSet &ghost_indices,
-           const MPI_Comm &communicator) override;
+           const MPI_Comm  communicator) override;
 
     /**
      * Reinitialize the communication pattern. The argument @p indices_locally_owned
@@ -80,7 +80,7 @@ namespace PETScWrappers
     void
     reinit(const std::vector<types::global_dof_index> &indices_locally_owned,
            const std::vector<types::global_dof_index> &indices_want,
-           const MPI_Comm &                            communicator);
+           const MPI_Comm                              communicator);
 
     /**
      * Reinitialization that takes the number of locally-owned degrees of
@@ -98,7 +98,7 @@ namespace PETScWrappers
     void
     reinit(const types::global_dof_index local_size,
            const IndexSet &              ghost_indices,
-           const MPI_Comm &              communicator);
+           const MPI_Comm                communicator);
 
     /**
      * Fill the vector @p ghost_array according to the precomputed communication
@@ -202,7 +202,7 @@ namespace PETScWrappers
               const std::vector<PetscInt> &inloc,
               const std::vector<PetscInt> &outidx,
               const std::vector<PetscInt> &outloc,
-              const MPI_Comm &             communicator);
+              const MPI_Comm               communicator);
   };
 
   /**
@@ -238,7 +238,7 @@ namespace PETScWrappers
     virtual void
     reinit(const IndexSet &locally_owned_indices,
            const IndexSet &ghost_indices,
-           const MPI_Comm &communicator) override;
+           const MPI_Comm  communicator) override;
 
     /**
      * Reinitialize the partitioner. As for the Utilities::MPI::Partitioner,
@@ -251,7 +251,7 @@ namespace PETScWrappers
     reinit(const IndexSet &locally_owned_indices,
            const IndexSet &ghost_indices,
            const IndexSet &larger_ghost_indices,
-           const MPI_Comm &communicator);
+           const MPI_Comm  communicator);
 
     /**
      * Return the actual number of ghost indices.

--- a/include/deal.II/lac/petsc_matrix_free.h
+++ b/include/deal.II/lac/petsc_matrix_free.h
@@ -78,7 +78,7 @@ namespace PETScWrappers
      * any estimation of non_zero entries and has no option
      * <tt>is_symmetric</tt>.
      */
-    MatrixFree(const MPI_Comm &   communicator,
+    MatrixFree(const MPI_Comm     communicator,
                const unsigned int m,
                const unsigned int n,
                const unsigned int local_rows,
@@ -95,7 +95,7 @@ namespace PETScWrappers
      * any estimation of non_zero entries and has no option
      * <tt>is_symmetric</tt>.
      */
-    MatrixFree(const MPI_Comm &                 communicator,
+    MatrixFree(const MPI_Comm                   communicator,
                const unsigned int               m,
                const unsigned int               n,
                const std::vector<unsigned int> &local_rows_per_process,
@@ -129,7 +129,7 @@ namespace PETScWrappers
      * the same argument list as the present function.
      */
     void
-    reinit(const MPI_Comm &   communicator,
+    reinit(const MPI_Comm     communicator,
            const unsigned int m,
            const unsigned int n,
            const unsigned int local_rows,
@@ -141,7 +141,7 @@ namespace PETScWrappers
      * the same argument list as the present function.
      */
     void
-    reinit(const MPI_Comm &                 communicator,
+    reinit(const MPI_Comm                   communicator,
            const unsigned int               m,
            const unsigned int               n,
            const std::vector<unsigned int> &local_rows_per_process,
@@ -266,7 +266,7 @@ namespace PETScWrappers
      * previous matrix is left to the caller.
      */
     void
-    do_reinit(const MPI_Comm &   comm,
+    do_reinit(const MPI_Comm     comm,
               const unsigned int m,
               const unsigned int n,
               const unsigned int local_rows,

--- a/include/deal.II/lac/petsc_precondition.h
+++ b/include/deal.II/lac/petsc_precondition.h
@@ -63,7 +63,7 @@ namespace PETScWrappers
     /**
      * Constructor.
      */
-    explicit PreconditionBase(const MPI_Comm &mpi_communicator);
+    explicit PreconditionBase(const MPI_Comm mpi_communicator);
 
     /**
      * Constructor.
@@ -131,7 +131,7 @@ namespace PETScWrappers
      * Internal function to create the PETSc preconditioner object.
      */
     void
-    create_pc_with_comm(const MPI_Comm &);
+    create_pc_with_comm(const MPI_Comm);
   };
 
 
@@ -175,7 +175,7 @@ namespace PETScWrappers
      * Intended to be used with SLEPc objects.
      */
     PreconditionJacobi(
-      const MPI_Comm &      communicator,
+      const MPI_Comm        communicator,
       const AdditionalData &additional_data = AdditionalData());
 
     /**
@@ -257,7 +257,7 @@ namespace PETScWrappers
      * Intended to be used with SLEPc objects.
      */
     PreconditionBlockJacobi(
-      const MPI_Comm &      communicator,
+      const MPI_Comm        communicator,
       const AdditionalData &additional_data = AdditionalData());
 
 
@@ -764,7 +764,7 @@ namespace PETScWrappers
      * Intended to be used with SLEPc objects.
      */
     PreconditionBoomerAMG(
-      const MPI_Comm &      communicator,
+      const MPI_Comm        communicator,
       const AdditionalData &additional_data = AdditionalData());
 
 
@@ -1097,7 +1097,7 @@ namespace PETScWrappers
     /**
      * Same as above but without setting a matrix to form the preconditioner.
      */
-    PreconditionShell(const MPI_Comm &communicator);
+    PreconditionShell(const MPI_Comm communicator);
 
     /**
      * The callback for the application of the preconditioner.
@@ -1115,7 +1115,7 @@ namespace PETScWrappers
      * matrix. This function sets up the PCSHELL preconditioner
      */
     void
-    initialize(const MPI_Comm &comm);
+    initialize(const MPI_Comm comm);
 
     /**
      * Initialize the preconditioner object with a particular

--- a/include/deal.II/lac/petsc_snes.h
+++ b/include/deal.II/lac/petsc_snes.h
@@ -247,7 +247,7 @@ namespace PETScWrappers
      * Constructor.
      */
     NonlinearSolver(const NonlinearSolverData &data     = NonlinearSolverData(),
-                    const MPI_Comm &           mpi_comm = PETSC_COMM_WORLD);
+                    const MPI_Comm             mpi_comm = PETSC_COMM_WORLD);
 
     /**
      * Destructor.

--- a/include/deal.II/lac/petsc_snes.templates.h
+++ b/include/deal.II/lac/petsc_snes.templates.h
@@ -55,7 +55,7 @@ namespace PETScWrappers
                           std::constructible_from<VectorType, Vec>))
   NonlinearSolver<VectorType, PMatrixType, AMatrixType>::NonlinearSolver(
     const NonlinearSolverData &data,
-    const MPI_Comm &           mpi_comm)
+    const MPI_Comm             mpi_comm)
   {
     AssertPETSc(SNESCreate(mpi_comm, &snes));
     AssertPETSc(SNESSetApplicationContext(snes, this));

--- a/include/deal.II/lac/petsc_solver.h
+++ b/include/deal.II/lac/petsc_solver.h
@@ -179,7 +179,7 @@ namespace PETScWrappers
      * Utility to create the KSP object and attach convergence test.
      */
     void
-    initialize_ksp_with_comm(const MPI_Comm &comm);
+    initialize_ksp_with_comm(const MPI_Comm comm);
 
     /**
      * %Function that takes a Krylov Subspace Solver context object, and sets
@@ -272,7 +272,7 @@ namespace PETScWrappers
      */
     DEAL_II_DEPRECATED_EARLY
     SolverRichardson(SolverControl &       cn,
-                     const MPI_Comm &      mpi_communicator,
+                     const MPI_Comm        mpi_communicator,
                      const AdditionalData &data = AdditionalData());
 
   protected:
@@ -324,7 +324,7 @@ namespace PETScWrappers
      */
     DEAL_II_DEPRECATED_EARLY
     SolverChebychev(SolverControl &       cn,
-                    const MPI_Comm &      mpi_communicator,
+                    const MPI_Comm        mpi_communicator,
                     const AdditionalData &data = AdditionalData());
 
   protected:
@@ -374,7 +374,7 @@ namespace PETScWrappers
      */
     DEAL_II_DEPRECATED_EARLY
     SolverCG(SolverControl &       cn,
-             const MPI_Comm &      mpi_communicator,
+             const MPI_Comm        mpi_communicator,
              const AdditionalData &data = AdditionalData());
 
   protected:
@@ -425,7 +425,7 @@ namespace PETScWrappers
      */
     DEAL_II_DEPRECATED_EARLY
     SolverBiCG(SolverControl &       cn,
-               const MPI_Comm &      mpi_communicator,
+               const MPI_Comm        mpi_communicator,
                const AdditionalData &data = AdditionalData());
 
   protected:
@@ -493,7 +493,7 @@ namespace PETScWrappers
      */
     DEAL_II_DEPRECATED_EARLY
     SolverGMRES(SolverControl &       cn,
-                const MPI_Comm &      mpi_communicator,
+                const MPI_Comm        mpi_communicator,
                 const AdditionalData &data = AdditionalData());
 
   protected:
@@ -545,7 +545,7 @@ namespace PETScWrappers
      */
     DEAL_II_DEPRECATED_EARLY
     SolverBicgstab(SolverControl &       cn,
-                   const MPI_Comm &      mpi_communicator,
+                   const MPI_Comm        mpi_communicator,
                    const AdditionalData &data = AdditionalData());
 
   protected:
@@ -596,7 +596,7 @@ namespace PETScWrappers
      */
     DEAL_II_DEPRECATED_EARLY
     SolverCGS(SolverControl &       cn,
-              const MPI_Comm &      mpi_communicator,
+              const MPI_Comm        mpi_communicator,
               const AdditionalData &data = AdditionalData());
 
   protected:
@@ -647,7 +647,7 @@ namespace PETScWrappers
      */
     DEAL_II_DEPRECATED_EARLY
     SolverTFQMR(SolverControl &       cn,
-                const MPI_Comm &      mpi_communicator,
+                const MPI_Comm        mpi_communicator,
                 const AdditionalData &data = AdditionalData());
 
   protected:
@@ -703,7 +703,7 @@ namespace PETScWrappers
      */
     DEAL_II_DEPRECATED_EARLY
     SolverTCQMR(SolverControl &       cn,
-                const MPI_Comm &      mpi_communicator,
+                const MPI_Comm        mpi_communicator,
                 const AdditionalData &data = AdditionalData());
 
   protected:
@@ -753,7 +753,7 @@ namespace PETScWrappers
      */
     DEAL_II_DEPRECATED_EARLY
     SolverCR(SolverControl &       cn,
-             const MPI_Comm &      mpi_communicator,
+             const MPI_Comm        mpi_communicator,
              const AdditionalData &data = AdditionalData());
 
   protected:
@@ -805,7 +805,7 @@ namespace PETScWrappers
      */
     DEAL_II_DEPRECATED_EARLY
     SolverLSQR(SolverControl &       cn,
-               const MPI_Comm &      mpi_communicator,
+               const MPI_Comm        mpi_communicator,
                const AdditionalData &data = AdditionalData());
 
   protected:
@@ -861,7 +861,7 @@ namespace PETScWrappers
      */
     DEAL_II_DEPRECATED_EARLY
     SolverPreOnly(SolverControl &       cn,
-                  const MPI_Comm &      mpi_communicator,
+                  const MPI_Comm        mpi_communicator,
                   const AdditionalData &data = AdditionalData());
 
   protected:
@@ -924,7 +924,7 @@ namespace PETScWrappers
      */
     DEAL_II_DEPRECATED_EARLY
     SparseDirectMUMPS(SolverControl &       cn,
-                      const MPI_Comm &      mpi_communicator,
+                      const MPI_Comm        mpi_communicator,
                       const AdditionalData &data = AdditionalData());
 
     /**

--- a/include/deal.II/lac/petsc_sparse_matrix.h
+++ b/include/deal.II/lac/petsc_sparse_matrix.h
@@ -432,7 +432,7 @@ namespace PETScWrappers
        * efficient to get memory allocation right from the start.
        */
       template <typename SparsityPatternType>
-      SparseMatrix(const MPI_Comm &              communicator,
+      SparseMatrix(const MPI_Comm                communicator,
                    const SparsityPatternType &   sparsity_pattern,
                    const std::vector<size_type> &local_rows_per_process,
                    const std::vector<size_type> &local_columns_per_process,
@@ -480,7 +480,7 @@ namespace PETScWrappers
        */
       template <typename SparsityPatternType>
       void
-      reinit(const MPI_Comm &              communicator,
+      reinit(const MPI_Comm                communicator,
              const SparsityPatternType &   sparsity_pattern,
              const std::vector<size_type> &local_rows_per_process,
              const std::vector<size_type> &local_columns_per_process,
@@ -497,7 +497,7 @@ namespace PETScWrappers
       void
       reinit(const IndexSet &           local_partitioning,
              const SparsityPatternType &sparsity_pattern,
-             const MPI_Comm &           communicator);
+             const MPI_Comm             communicator);
 
       /**
        * Create a matrix where the size() of the IndexSets determine the
@@ -510,7 +510,7 @@ namespace PETScWrappers
       reinit(const IndexSet &           local_rows,
              const IndexSet &           local_columns,
              const SparsityPatternType &sparsity_pattern,
-             const MPI_Comm &           communicator);
+             const MPI_Comm             communicator);
 
       /**
        * Initialize this matrix to have the same structure as @p other. This
@@ -536,7 +536,7 @@ namespace PETScWrappers
              const IndexSet &           local_columns,
              const IndexSet &           local_active_columns,
              const SparsityPatternType &sparsity_pattern,
-             const MPI_Comm &           communicator);
+             const MPI_Comm             communicator);
 
       /**
        * @addtogroup Exceptions
@@ -626,7 +626,7 @@ namespace PETScWrappers
        */
       template <typename SparsityPatternType>
       void
-      do_reinit(const MPI_Comm &              comm,
+      do_reinit(const MPI_Comm                comm,
                 const SparsityPatternType &   sparsity_pattern,
                 const std::vector<size_type> &local_rows_per_process,
                 const std::vector<size_type> &local_columns_per_process,
@@ -638,7 +638,7 @@ namespace PETScWrappers
        */
       template <typename SparsityPatternType>
       void
-      do_reinit(const MPI_Comm &           comm,
+      do_reinit(const MPI_Comm             comm,
                 const IndexSet &           local_rows,
                 const IndexSet &           local_columns,
                 const SparsityPatternType &sparsity_pattern);
@@ -649,7 +649,7 @@ namespace PETScWrappers
        */
       template <typename SparsityPatternType>
       void
-      do_reinit(const MPI_Comm &           comm,
+      do_reinit(const MPI_Comm             comm,
                 const IndexSet &           local_rows,
                 const IndexSet &           local_active_rows,
                 const IndexSet &           local_columns,

--- a/include/deal.II/lac/petsc_ts.h
+++ b/include/deal.II/lac/petsc_ts.h
@@ -311,7 +311,7 @@ namespace PETScWrappers
      * Constructor.
      */
     TimeStepper(const TimeStepperData &data     = TimeStepperData(),
-                const MPI_Comm &       mpi_comm = PETSC_COMM_WORLD);
+                const MPI_Comm         mpi_comm = PETSC_COMM_WORLD);
 
     /**
      * Destructor.

--- a/include/deal.II/lac/petsc_ts.templates.h
+++ b/include/deal.II/lac/petsc_ts.templates.h
@@ -55,7 +55,7 @@ namespace PETScWrappers
                           std::constructible_from<VectorType, Vec>))
   TimeStepper<VectorType, PMatrixType, AMatrixType>::TimeStepper(
     const TimeStepperData &data,
-    const MPI_Comm &       mpi_comm)
+    const MPI_Comm         mpi_comm)
   {
     AssertPETSc(TSCreate(mpi_comm, &ts));
     AssertPETSc(TSSetApplicationContext(ts, this));

--- a/include/deal.II/lac/petsc_vector.h
+++ b/include/deal.II/lac/petsc_vector.h
@@ -189,7 +189,7 @@ namespace PETScWrappers
        * <tt>v=Vector@<number@>(0);</tt>, i.e. the vector is replaced by one
        * of length zero.
        */
-      explicit Vector(const MPI_Comm &communicator,
+      explicit Vector(const MPI_Comm  communicator,
                       const size_type n,
                       const size_type locally_owned_size);
 
@@ -204,7 +204,7 @@ namespace PETScWrappers
        * different parts of the vector shall communicate
        */
       template <typename Number>
-      explicit Vector(const MPI_Comm &              communicator,
+      explicit Vector(const MPI_Comm                communicator,
                       const dealii::Vector<Number> &v,
                       const size_type               locally_owned_size);
 
@@ -233,7 +233,7 @@ namespace PETScWrappers
        */
       Vector(const IndexSet &local,
              const IndexSet &ghost,
-             const MPI_Comm &communicator);
+             const MPI_Comm  communicator);
 
       /**
        * Construct a new parallel PETSc vector without ghost elements from an
@@ -246,7 +246,7 @@ namespace PETScWrappers
        * not reordered by component (use a PETScWrappers::BlockVector
        * otherwise).
        */
-      explicit Vector(const IndexSet &local, const MPI_Comm &communicator);
+      explicit Vector(const IndexSet &local, const MPI_Comm communicator);
 
       /**
        * Copy constructor.
@@ -308,7 +308,7 @@ namespace PETScWrappers
        * Otherwise, the elements are left an unspecified state.
        */
       void
-      reinit(const MPI_Comm &communicator,
+      reinit(const MPI_Comm  communicator,
              const size_type N,
              const size_type locally_owned_size,
              const bool      omit_zeroing_entries = false);
@@ -335,7 +335,7 @@ namespace PETScWrappers
       void
       reinit(const IndexSet &local,
              const IndexSet &ghost,
-             const MPI_Comm &communicator);
+             const MPI_Comm  communicator);
 
       /**
        * Reinit as a vector without ghost elements. See constructor with same
@@ -345,7 +345,7 @@ namespace PETScWrappers
        * @ref GlossGhostedVector "vectors with ghost elements"
        */
       void
-      reinit(const IndexSet &local, const MPI_Comm &communicator);
+      reinit(const IndexSet &local, const MPI_Comm communicator);
 
       /**
        * Initialize the vector given to the parallel partitioning described in
@@ -389,7 +389,7 @@ namespace PETScWrappers
        * locally.
        */
       virtual void
-      create_vector(const MPI_Comm &comm,
+      create_vector(const MPI_Comm  comm,
                     const size_type n,
                     const size_type locally_owned_size);
 
@@ -401,7 +401,7 @@ namespace PETScWrappers
        * you need to call update_ghost_values() before accessing those.
        */
       virtual void
-      create_vector(const MPI_Comm &comm,
+      create_vector(const MPI_Comm  comm,
                     const size_type n,
                     const size_type locally_owned_size,
                     const IndexSet &ghostnodes);
@@ -428,7 +428,7 @@ namespace PETScWrappers
 #  ifndef DOXYGEN
 
     template <typename number>
-    Vector::Vector(const MPI_Comm &              communicator,
+    Vector::Vector(const MPI_Comm                communicator,
                    const dealii::Vector<number> &v,
                    const size_type               locally_owned_size)
     {

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -665,7 +665,7 @@ namespace LinearAlgebra
              &                     tpetra_vector,
            const IndexSet &        locally_owned_elements,
            VectorOperation::values operation,
-           const MPI_Comm &        mpi_comm,
+           const MPI_Comm          mpi_comm,
            const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
              &communication_pattern);
 #  endif
@@ -679,7 +679,7 @@ namespace LinearAlgebra
     import(const Epetra_MultiVector &multivector,
            const IndexSet &          locally_owned_elements,
            VectorOperation::values   operation,
-           const MPI_Comm &          mpi_comm,
+           const MPI_Comm            mpi_comm,
            const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
              &communication_pattern);
 #endif
@@ -704,7 +704,7 @@ namespace LinearAlgebra
      */
     TpetraWrappers::CommunicationPattern
     create_tpetra_comm_pattern(const IndexSet &source_index_set,
-                               const MPI_Comm &mpi_comm);
+                               const MPI_Comm  mpi_comm);
 #  endif
 
     /**
@@ -713,7 +713,7 @@ namespace LinearAlgebra
      */
     EpetraWrappers::CommunicationPattern
     create_epetra_comm_pattern(const IndexSet &source_index_set,
-                               const MPI_Comm &mpi_comm);
+                               const MPI_Comm  mpi_comm);
 #endif
 
     /**

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -582,7 +582,7 @@ namespace LinearAlgebra
     const Tpetra::Vector<Number, int, types::signed_global_dof_index> &vector,
     const IndexSet &        source_elements,
     VectorOperation::values operation,
-    const MPI_Comm &        mpi_comm,
+    const MPI_Comm          mpi_comm,
     const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
       &communication_pattern)
   {
@@ -699,7 +699,7 @@ namespace LinearAlgebra
     const Epetra_MultiVector &multivector,
     const IndexSet &          source_elements,
     VectorOperation::values   operation,
-    const MPI_Comm &          mpi_comm,
+    const MPI_Comm            mpi_comm,
     const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
       &communication_pattern)
   {
@@ -1046,7 +1046,7 @@ namespace LinearAlgebra
   TpetraWrappers::CommunicationPattern
   ReadWriteVector<Number>::create_tpetra_comm_pattern(
     const IndexSet &source_index_set,
-    const MPI_Comm &mpi_comm)
+    const MPI_Comm  mpi_comm)
   {
     source_stored_elements = source_index_set;
     TpetraWrappers::CommunicationPattern epetra_comm_pattern(
@@ -1064,7 +1064,7 @@ namespace LinearAlgebra
   EpetraWrappers::CommunicationPattern
   ReadWriteVector<Number>::create_epetra_comm_pattern(
     const IndexSet &source_index_set,
-    const MPI_Comm &mpi_comm)
+    const MPI_Comm  mpi_comm)
   {
     source_stored_elements = source_index_set;
     EpetraWrappers::CommunicationPattern epetra_comm_pattern(

--- a/include/deal.II/lac/slepc_solver.h
+++ b/include/deal.II/lac/slepc_solver.h
@@ -150,7 +150,7 @@ namespace SLEPcWrappers
      * Constructor. Takes the MPI communicator over which parallel
      * computations are to happen.
      */
-    SolverBase(SolverControl &cn, const MPI_Comm &mpi_communicator);
+    SolverBase(SolverControl &cn, const MPI_Comm mpi_communicator);
 
     /**
      * Destructor.
@@ -405,7 +405,7 @@ namespace SLEPcWrappers
      * behavior as the PETScWrappers, but you can change that.
      */
     SolverKrylovSchur(SolverControl &       cn,
-                      const MPI_Comm &      mpi_communicator = PETSC_COMM_SELF,
+                      const MPI_Comm        mpi_communicator = PETSC_COMM_SELF,
                       const AdditionalData &data = AdditionalData());
 
   protected:
@@ -456,7 +456,7 @@ namespace SLEPcWrappers
      * behavior as the PETScWrappers, but you can change that.
      */
     SolverArnoldi(SolverControl &       cn,
-                  const MPI_Comm &      mpi_communicator = PETSC_COMM_SELF,
+                  const MPI_Comm        mpi_communicator = PETSC_COMM_SELF,
                   const AdditionalData &data             = AdditionalData());
 
   protected:
@@ -508,7 +508,7 @@ namespace SLEPcWrappers
      * behavior as the PETScWrappers, but you can change that.
      */
     SolverLanczos(SolverControl &       cn,
-                  const MPI_Comm &      mpi_communicator = PETSC_COMM_SELF,
+                  const MPI_Comm        mpi_communicator = PETSC_COMM_SELF,
                   const AdditionalData &data             = AdditionalData());
 
   protected:
@@ -548,7 +548,7 @@ namespace SLEPcWrappers
      * behavior as the PETScWrappers, but you can change that.
      */
     SolverPower(SolverControl &       cn,
-                const MPI_Comm &      mpi_communicator = PETSC_COMM_SELF,
+                const MPI_Comm        mpi_communicator = PETSC_COMM_SELF,
                 const AdditionalData &data             = AdditionalData());
 
   protected:
@@ -597,10 +597,9 @@ namespace SLEPcWrappers
      * computations are parallelized. By default, this carries the same
      * behavior as the PETScWrappers, but you can change that.
      */
-    SolverGeneralizedDavidson(
-      SolverControl &       cn,
-      const MPI_Comm &      mpi_communicator = PETSC_COMM_SELF,
-      const AdditionalData &data             = AdditionalData());
+    SolverGeneralizedDavidson(SolverControl &cn,
+                              const MPI_Comm mpi_communicator = PETSC_COMM_SELF,
+                              const AdditionalData &data = AdditionalData());
 
   protected:
     /**
@@ -638,9 +637,9 @@ namespace SLEPcWrappers
      * computations are parallelized. By default, this carries the same
      * behavior as the PETScWrappers, but you can change that.
      */
-    SolverJacobiDavidson(SolverControl & cn,
-                         const MPI_Comm &mpi_communicator = PETSC_COMM_SELF,
-                         const AdditionalData &data       = AdditionalData());
+    SolverJacobiDavidson(SolverControl &cn,
+                         const MPI_Comm mpi_communicator = PETSC_COMM_SELF,
+                         const AdditionalData &data      = AdditionalData());
 
   protected:
     /**
@@ -679,7 +678,7 @@ namespace SLEPcWrappers
      * behavior as the PETScWrappers, but you can change that.
      */
     SolverLAPACK(SolverControl &       cn,
-                 const MPI_Comm &      mpi_communicator = PETSC_COMM_SELF,
+                 const MPI_Comm        mpi_communicator = PETSC_COMM_SELF,
                  const AdditionalData &data             = AdditionalData());
 
   protected:

--- a/include/deal.II/lac/slepc_spectral_transformation.h
+++ b/include/deal.II/lac/slepc_spectral_transformation.h
@@ -79,7 +79,7 @@ namespace SLEPcWrappers
     /**
      * Constructor.
      */
-    TransformationBase(const MPI_Comm &mpi_communicator);
+    TransformationBase(const MPI_Comm mpi_communicator);
 
   public:
     /**
@@ -144,7 +144,7 @@ namespace SLEPcWrappers
     /**
      * Constructor.
      */
-    TransformationShift(const MPI_Comm &      mpi_communicator,
+    TransformationShift(const MPI_Comm        mpi_communicator,
                         const AdditionalData &data = AdditionalData());
 
 
@@ -184,7 +184,7 @@ namespace SLEPcWrappers
     /**
      * Constructor.
      */
-    TransformationShiftInvert(const MPI_Comm &      mpi_communicator,
+    TransformationShiftInvert(const MPI_Comm        mpi_communicator,
                               const AdditionalData &data = AdditionalData());
 
   protected:
@@ -233,7 +233,7 @@ namespace SLEPcWrappers
      * Constructor.
      */
     TransformationSpectrumFolding(
-      const MPI_Comm &      mpi_communicator,
+      const MPI_Comm        mpi_communicator,
       const AdditionalData &data = AdditionalData());
 
   protected:
@@ -277,7 +277,7 @@ namespace SLEPcWrappers
     /**
      * Constructor.
      */
-    TransformationCayley(const MPI_Comm &      mpi_communicator,
+    TransformationCayley(const MPI_Comm        mpi_communicator,
                          const AdditionalData &data = AdditionalData());
 
   protected:

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -50,7 +50,7 @@ namespace Utilities
   {
     template <typename Number>
     void
-    sum(const SparseMatrix<Number> &, const MPI_Comm &, SparseMatrix<Number> &);
+    sum(const SparseMatrix<Number> &, const MPI_Comm, SparseMatrix<Number> &);
   }
 } // namespace Utilities
 #  endif
@@ -1784,7 +1784,7 @@ private:
   template <typename Number>
   friend void
   Utilities::MPI::sum(const SparseMatrix<Number> &,
-                      const MPI_Comm &,
+                      const MPI_Comm,
                       SparseMatrix<Number> &);
 #endif
 };

--- a/include/deal.II/lac/sparse_matrix_tools.h
+++ b/include/deal.II/lac/sparse_matrix_tools.h
@@ -145,7 +145,7 @@ namespace SparseMatrixTools
   {
     template <typename T>
     std::tuple<T, T>
-    compute_prefix_sum(const T &value, const MPI_Comm &comm)
+    compute_prefix_sum(const T &value, const MPI_Comm comm)
     {
 #  ifndef DEAL_II_WITH_MPI
       (void)comm;
@@ -231,7 +231,7 @@ namespace SparseMatrixTools
     extract_remote_rows(const SparseMatrixType &   system_matrix,
                         const SparsityPatternType &sparsity_pattern,
                         const IndexSet &           locally_active_dofs,
-                        const MPI_Comm &           comm)
+                        const MPI_Comm             comm)
     {
       std::vector<unsigned int> dummy(locally_active_dofs.n_elements());
 

--- a/include/deal.II/lac/sparsity_tools.h
+++ b/include/deal.II/lac/sparsity_tools.h
@@ -267,7 +267,7 @@ namespace SparsityTools
   void
   distribute_sparsity_pattern(DynamicSparsityPattern &dsp,
                               const IndexSet &        locally_owned_rows,
-                              const MPI_Comm &        mpi_comm,
+                              const MPI_Comm          mpi_comm,
                               const IndexSet &        locally_relevant_rows);
 
   /**
@@ -284,7 +284,7 @@ namespace SparsityTools
   distribute_sparsity_pattern(
     DynamicSparsityPattern &                              dsp,
     const std::vector<DynamicSparsityPattern::size_type> &rows_per_cpu,
-    const MPI_Comm &                                      mpi_comm,
+    const MPI_Comm                                        mpi_comm,
     const IndexSet &                                      myrange);
 
   /**
@@ -304,7 +304,7 @@ namespace SparsityTools
   void
   distribute_sparsity_pattern(BlockDynamicSparsityPattern &dsp,
                               const IndexSet &             locally_owned_rows,
-                              const MPI_Comm &             mpi_comm,
+                              const MPI_Comm               mpi_comm,
                               const IndexSet &locally_relevant_rows);
 
   /**
@@ -314,7 +314,7 @@ namespace SparsityTools
   void
   distribute_sparsity_pattern(BlockDynamicSparsityPattern &dsp,
                               const std::vector<IndexSet> &owned_set_per_cpu,
-                              const MPI_Comm &             mpi_comm,
+                              const MPI_Comm               mpi_comm,
                               const IndexSet &             myrange);
 
   /**
@@ -343,7 +343,7 @@ namespace SparsityTools
   void
   gather_sparsity_pattern(DynamicSparsityPattern &dsp,
                           const IndexSet &        locally_owned_rows,
-                          const MPI_Comm &        mpi_comm,
+                          const MPI_Comm          mpi_comm,
                           const IndexSet &        locally_relevant_rows);
 
 #endif

--- a/include/deal.II/lac/trilinos_block_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_block_sparse_matrix.h
@@ -156,7 +156,7 @@ namespace TrilinosWrappers
     void
     reinit(const std::vector<IndexSet> &   input_maps,
            const BlockSparsityPatternType &block_sparsity_pattern,
-           const MPI_Comm &                communicator  = MPI_COMM_WORLD,
+           const MPI_Comm                  communicator  = MPI_COMM_WORLD,
            const bool                      exchange_data = false);
 
     /**
@@ -178,7 +178,7 @@ namespace TrilinosWrappers
     reinit(
       const std::vector<IndexSet> &              parallel_partitioning,
       const ::dealii::BlockSparseMatrix<double> &dealii_block_sparse_matrix,
-      const MPI_Comm &                           communicator = MPI_COMM_WORLD,
+      const MPI_Comm                             communicator = MPI_COMM_WORLD,
       const double                               drop_tolerance = 1e-13);
 
     /**

--- a/include/deal.II/lac/trilinos_epetra_communication_pattern.h
+++ b/include/deal.II/lac/trilinos_epetra_communication_pattern.h
@@ -50,7 +50,7 @@ namespace LinearAlgebra
        */
       CommunicationPattern(const IndexSet &vector_space_vector_index_set,
                            const IndexSet &read_write_vector_index_set,
-                           const MPI_Comm &communicator);
+                           const MPI_Comm  communicator);
 
       /**
        * Reinitialize the object.
@@ -58,7 +58,7 @@ namespace LinearAlgebra
       virtual void
       reinit(const IndexSet &vector_space_vector_index_set,
              const IndexSet &read_write_vector_index_set,
-             const MPI_Comm &communicator) override;
+             const MPI_Comm  communicator) override;
 
       /**
        * Return the underlying MPI communicator.

--- a/include/deal.II/lac/trilinos_epetra_vector.h
+++ b/include/deal.II/lac/trilinos_epetra_vector.h
@@ -82,7 +82,7 @@ namespace LinearAlgebra
        * need to generate a %parallel vector.
        */
       explicit Vector(const IndexSet &parallel_partitioner,
-                      const MPI_Comm &communicator);
+                      const MPI_Comm  communicator);
 
       /**
        * Reinit functionality. This function destroys the old vector content
@@ -92,7 +92,7 @@ namespace LinearAlgebra
        */
       void
       reinit(const IndexSet &parallel_partitioner,
-             const MPI_Comm &communicator,
+             const MPI_Comm  communicator,
              const bool      omit_zeroing_entries = false);
 
       /**
@@ -370,7 +370,7 @@ namespace LinearAlgebra
        */
       void
       create_epetra_comm_pattern(const IndexSet &source_index_set,
-                                 const MPI_Comm &mpi_comm);
+                                 const MPI_Comm  mpi_comm);
 
       /**
        * Pointer to the actual Epetra vector object.

--- a/include/deal.II/lac/trilinos_parallel_block_vector.h
+++ b/include/deal.II/lac/trilinos_parallel_block_vector.h
@@ -109,7 +109,7 @@ namespace TrilinosWrappers
        * the MPI processes.
        */
       explicit BlockVector(const std::vector<IndexSet> &parallel_partitioning,
-                           const MPI_Comm &communicator = MPI_COMM_WORLD);
+                           const MPI_Comm communicator = MPI_COMM_WORLD);
 
       /**
        * Creates a BlockVector with ghost elements. See the respective
@@ -118,7 +118,7 @@ namespace TrilinosWrappers
        */
       BlockVector(const std::vector<IndexSet> &parallel_partitioning,
                   const std::vector<IndexSet> &ghost_values,
-                  const MPI_Comm &             communicator,
+                  const MPI_Comm               communicator,
                   const bool                   vector_writable = false);
 
       /**
@@ -189,7 +189,7 @@ namespace TrilinosWrappers
        */
       void
       reinit(const std::vector<IndexSet> &parallel_partitioning,
-             const MPI_Comm &             communicator         = MPI_COMM_WORLD,
+             const MPI_Comm               communicator         = MPI_COMM_WORLD,
              const bool                   omit_zeroing_entries = false);
 
       /**
@@ -212,7 +212,7 @@ namespace TrilinosWrappers
       void
       reinit(const std::vector<IndexSet> &partitioning,
              const std::vector<IndexSet> &ghost_values,
-             const MPI_Comm &             communicator    = MPI_COMM_WORLD,
+             const MPI_Comm               communicator    = MPI_COMM_WORLD,
              const bool                   vector_writable = false);
 
 
@@ -317,7 +317,7 @@ namespace TrilinosWrappers
     /*-------------------------- Inline functions ---------------------------*/
     inline BlockVector::BlockVector(
       const std::vector<IndexSet> &parallel_partitioning,
-      const MPI_Comm &             communicator)
+      const MPI_Comm               communicator)
     {
       reinit(parallel_partitioning, communicator, false);
     }
@@ -327,7 +327,7 @@ namespace TrilinosWrappers
     inline BlockVector::BlockVector(
       const std::vector<IndexSet> &parallel_partitioning,
       const std::vector<IndexSet> &ghost_values,
-      const MPI_Comm &             communicator,
+      const MPI_Comm               communicator,
       const bool                   vector_writable)
     {
       reinit(parallel_partitioning,

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -748,7 +748,7 @@ namespace TrilinosWrappers
      * use (in the compress() step).
      */
     SparseMatrix(const IndexSet &   parallel_partitioning,
-                 const MPI_Comm &   communicator          = MPI_COMM_WORLD,
+                 const MPI_Comm     communicator          = MPI_COMM_WORLD,
                  const unsigned int n_max_entries_per_row = 0);
 
     /**
@@ -759,7 +759,7 @@ namespace TrilinosWrappers
      * by the respective SparseMatrix::reinit call considerably faster.
      */
     SparseMatrix(const IndexSet &                 parallel_partitioning,
-                 const MPI_Comm &                 communicator,
+                 const MPI_Comm                   communicator,
                  const std::vector<unsigned int> &n_entries_per_row);
 
     /**
@@ -778,7 +778,7 @@ namespace TrilinosWrappers
      */
     SparseMatrix(const IndexSet &row_parallel_partitioning,
                  const IndexSet &col_parallel_partitioning,
-                 const MPI_Comm &communicator          = MPI_COMM_WORLD,
+                 const MPI_Comm  communicator          = MPI_COMM_WORLD,
                  const size_type n_max_entries_per_row = 0);
 
     /**
@@ -797,7 +797,7 @@ namespace TrilinosWrappers
      */
     SparseMatrix(const IndexSet &                 row_parallel_partitioning,
                  const IndexSet &                 col_parallel_partitioning,
-                 const MPI_Comm &                 communicator,
+                 const MPI_Comm                   communicator,
                  const std::vector<unsigned int> &n_entries_per_row);
 
     /**
@@ -824,7 +824,7 @@ namespace TrilinosWrappers
     void
     reinit(const IndexSet &           parallel_partitioning,
            const SparsityPatternType &sparsity_pattern,
-           const MPI_Comm &           communicator  = MPI_COMM_WORLD,
+           const MPI_Comm             communicator  = MPI_COMM_WORLD,
            const bool                 exchange_data = false);
 
     /**
@@ -845,7 +845,7 @@ namespace TrilinosWrappers
     reinit(const IndexSet &           row_parallel_partitioning,
            const IndexSet &           col_parallel_partitioning,
            const SparsityPatternType &sparsity_pattern,
-           const MPI_Comm &           communicator  = MPI_COMM_WORLD,
+           const MPI_Comm             communicator  = MPI_COMM_WORLD,
            const bool                 exchange_data = false);
 
     /**
@@ -868,7 +868,7 @@ namespace TrilinosWrappers
     void
     reinit(const IndexSet &                      parallel_partitioning,
            const ::dealii::SparseMatrix<number> &dealii_sparse_matrix,
-           const MPI_Comm &                      communicator = MPI_COMM_WORLD,
+           const MPI_Comm                        communicator = MPI_COMM_WORLD,
            const double                          drop_tolerance    = 1e-13,
            const bool                            copy_values       = true,
            const ::dealii::SparsityPattern *     use_this_sparsity = nullptr);
@@ -891,7 +891,7 @@ namespace TrilinosWrappers
     reinit(const IndexSet &                      row_parallel_partitioning,
            const IndexSet &                      col_parallel_partitioning,
            const ::dealii::SparseMatrix<number> &dealii_sparse_matrix,
-           const MPI_Comm &                      communicator = MPI_COMM_WORLD,
+           const MPI_Comm                        communicator = MPI_COMM_WORLD,
            const double                          drop_tolerance    = 1e-13,
            const bool                            copy_values       = true,
            const ::dealii::SparsityPattern *     use_this_sparsity = nullptr);
@@ -2419,7 +2419,7 @@ namespace TrilinosWrappers
         TrilinosPayload(EpetraOpType &  op,
                         const bool      supports_inverse_operations,
                         const bool      use_transpose,
-                        const MPI_Comm &mpi_communicator,
+                        const MPI_Comm  mpi_communicator,
                         const IndexSet &locally_owned_domain_indices,
                         const IndexSet &locally_owned_range_indices);
 
@@ -3026,7 +3026,7 @@ namespace TrilinosWrappers
   inline void
   SparseMatrix::reinit(const IndexSet &           parallel_partitioning,
                        const SparsityPatternType &sparsity_pattern,
-                       const MPI_Comm &           communicator,
+                       const MPI_Comm             communicator,
                        const bool                 exchange_data)
   {
     reinit(parallel_partitioning,
@@ -3042,7 +3042,7 @@ namespace TrilinosWrappers
   inline void
   SparseMatrix::reinit(const IndexSet &parallel_partitioning,
                        const ::dealii::SparseMatrix<number> &sparse_matrix,
-                       const MPI_Comm &                      communicator,
+                       const MPI_Comm                        communicator,
                        const double                          drop_tolerance,
                        const bool                            copy_values,
                        const ::dealii::SparsityPattern *     use_this_sparsity)
@@ -3115,7 +3115,7 @@ namespace TrilinosWrappers
         EpetraOpType &  op,
         const bool      supports_inverse_operations,
         const bool      use_transpose,
-        const MPI_Comm &mpi_communicator,
+        const MPI_Comm  mpi_communicator,
         const IndexSet &locally_owned_domain_indices,
         const IndexSet &locally_owned_range_indices)
         : use_transpose(use_transpose)

--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -434,7 +434,7 @@ namespace TrilinosWrappers
      * the performance when creating the sparsity pattern.
      */
     SparsityPattern(const IndexSet &parallel_partitioning,
-                    const MPI_Comm &communicator      = MPI_COMM_WORLD,
+                    const MPI_Comm  communicator      = MPI_COMM_WORLD,
                     const size_type n_entries_per_row = 0);
 
     /**
@@ -448,7 +448,7 @@ namespace TrilinosWrappers
      * designed to describe.
      */
     SparsityPattern(const IndexSet &              parallel_partitioning,
-                    const MPI_Comm &              communicator,
+                    const MPI_Comm                communicator,
                     const std::vector<size_type> &n_entries_per_row);
 
     /**
@@ -467,7 +467,7 @@ namespace TrilinosWrappers
      */
     SparsityPattern(const IndexSet &row_parallel_partitioning,
                     const IndexSet &col_parallel_partitioning,
-                    const MPI_Comm &communicator      = MPI_COMM_WORLD,
+                    const MPI_Comm  communicator      = MPI_COMM_WORLD,
                     const size_type n_entries_per_row = 0);
 
     /**
@@ -483,7 +483,7 @@ namespace TrilinosWrappers
      */
     SparsityPattern(const IndexSet &              row_parallel_partitioning,
                     const IndexSet &              col_parallel_partitioning,
-                    const MPI_Comm &              communicator,
+                    const MPI_Comm                communicator,
                     const std::vector<size_type> &n_entries_per_row);
 
     /**
@@ -515,7 +515,7 @@ namespace TrilinosWrappers
     SparsityPattern(const IndexSet &row_parallel_partitioning,
                     const IndexSet &col_parallel_partitioning,
                     const IndexSet &writable_rows,
-                    const MPI_Comm &communicator      = MPI_COMM_WORLD,
+                    const MPI_Comm  communicator      = MPI_COMM_WORLD,
                     const size_type n_entries_per_row = 0);
 
     /**
@@ -535,7 +535,7 @@ namespace TrilinosWrappers
      */
     void
     reinit(const IndexSet &parallel_partitioning,
-           const MPI_Comm &communicator      = MPI_COMM_WORLD,
+           const MPI_Comm  communicator      = MPI_COMM_WORLD,
            const size_type n_entries_per_row = 0);
 
     /**
@@ -550,7 +550,7 @@ namespace TrilinosWrappers
      */
     void
     reinit(const IndexSet &              parallel_partitioning,
-           const MPI_Comm &              communicator,
+           const MPI_Comm                communicator,
            const std::vector<size_type> &n_entries_per_row);
 
     /**
@@ -572,7 +572,7 @@ namespace TrilinosWrappers
     void
     reinit(const IndexSet &row_parallel_partitioning,
            const IndexSet &col_parallel_partitioning,
-           const MPI_Comm &communicator      = MPI_COMM_WORLD,
+           const MPI_Comm  communicator      = MPI_COMM_WORLD,
            const size_type n_entries_per_row = 0);
 
     /**
@@ -604,7 +604,7 @@ namespace TrilinosWrappers
     reinit(const IndexSet &row_parallel_partitioning,
            const IndexSet &col_parallel_partitioning,
            const IndexSet &writeable_rows,
-           const MPI_Comm &communicator      = MPI_COMM_WORLD,
+           const MPI_Comm  communicator      = MPI_COMM_WORLD,
            const size_type n_entries_per_row = 0);
 
     /**
@@ -614,7 +614,7 @@ namespace TrilinosWrappers
     void
     reinit(const IndexSet &              row_parallel_partitioning,
            const IndexSet &              col_parallel_partitioning,
-           const MPI_Comm &              communicator,
+           const MPI_Comm                communicator,
            const std::vector<size_type> &n_entries_per_row);
 
     /**
@@ -631,7 +631,7 @@ namespace TrilinosWrappers
     reinit(const IndexSet &           row_parallel_partitioning,
            const IndexSet &           col_parallel_partitioning,
            const SparsityPatternType &nontrilinos_sparsity_pattern,
-           const MPI_Comm &           communicator  = MPI_COMM_WORLD,
+           const MPI_Comm             communicator  = MPI_COMM_WORLD,
            const bool                 exchange_data = false);
 
     /**
@@ -646,7 +646,7 @@ namespace TrilinosWrappers
     void
     reinit(const IndexSet &           parallel_partitioning,
            const SparsityPatternType &nontrilinos_sparsity_pattern,
-           const MPI_Comm &           communicator  = MPI_COMM_WORLD,
+           const MPI_Comm             communicator  = MPI_COMM_WORLD,
            const bool                 exchange_data = false);
     /** @} */
     /**

--- a/include/deal.II/lac/trilinos_tpetra_communication_pattern.h
+++ b/include/deal.II/lac/trilinos_tpetra_communication_pattern.h
@@ -49,7 +49,7 @@ namespace LinearAlgebra
        */
       CommunicationPattern(const IndexSet &vector_space_vector_index_set,
                            const IndexSet &read_write_vector_index_set,
-                           const MPI_Comm &communicator);
+                           const MPI_Comm  communicator);
 
       /**
        * Reinitialize the object.
@@ -57,7 +57,7 @@ namespace LinearAlgebra
       virtual void
       reinit(const IndexSet &vector_space_vector_index_set,
              const IndexSet &read_write_vector_index_set,
-             const MPI_Comm &communicator) override;
+             const MPI_Comm  communicator) override;
 
       /**
        * Return the underlying MPI communicator.

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -138,7 +138,7 @@ namespace LinearAlgebra
        * need to generate a %parallel vector.
        */
       explicit Vector(const IndexSet &parallel_partitioner,
-                      const MPI_Comm &communicator);
+                      const MPI_Comm  communicator);
 
       /**
        * Reinit functionality. This function destroys the old vector content
@@ -148,7 +148,7 @@ namespace LinearAlgebra
        */
       void
       reinit(const IndexSet &parallel_partitioner,
-             const MPI_Comm &communicator,
+             const MPI_Comm  communicator,
              const bool      omit_zeroing_entries = false);
 
       /**
@@ -426,7 +426,7 @@ namespace LinearAlgebra
        */
       void
       create_tpetra_comm_pattern(const IndexSet &source_index_set,
-                                 const MPI_Comm &mpi_comm);
+                                 const MPI_Comm  mpi_comm);
 
       /**
        * Pointer to the actual Tpetra vector object.

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -69,7 +69,7 @@ namespace LinearAlgebra
 
     template <typename Number>
     Vector<Number>::Vector(const IndexSet &parallel_partitioner,
-                           const MPI_Comm &communicator)
+                           const MPI_Comm  communicator)
       : Subscriptor()
       , vector(new Tpetra::Vector<Number, int, types::signed_global_dof_index>(
           Teuchos::rcp(new Tpetra::Map<int, types::signed_global_dof_index>(
@@ -81,7 +81,7 @@ namespace LinearAlgebra
     template <typename Number>
     void
     Vector<Number>::reinit(const IndexSet &parallel_partitioner,
-                           const MPI_Comm &communicator,
+                           const MPI_Comm  communicator,
                            const bool      omit_zeroing_entries)
     {
       Tpetra::Map<int, types::signed_global_dof_index> input_map =
@@ -677,7 +677,7 @@ namespace LinearAlgebra
     template <typename Number>
     void
     Vector<Number>::create_tpetra_comm_pattern(const IndexSet &source_index_set,
-                                               const MPI_Comm &mpi_comm)
+                                               const MPI_Comm  mpi_comm)
     {
       source_stored_elements = source_index_set;
       tpetra_comm_pattern =

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -445,7 +445,7 @@ namespace TrilinosWrappers
        * @ref GlossGhostedVector "vectors with ghost elements"
        */
       explicit Vector(const IndexSet &parallel_partitioning,
-                      const MPI_Comm &communicator = MPI_COMM_WORLD);
+                      const MPI_Comm  communicator = MPI_COMM_WORLD);
 
       /**
        * Creates a ghosted parallel vector.
@@ -460,7 +460,7 @@ namespace TrilinosWrappers
        */
       Vector(const IndexSet &local,
              const IndexSet &ghost,
-             const MPI_Comm &communicator = MPI_COMM_WORLD);
+             const MPI_Comm  communicator = MPI_COMM_WORLD);
 
       /**
        * Copy constructor from the TrilinosWrappers vector class. Since a
@@ -478,7 +478,7 @@ namespace TrilinosWrappers
        */
       Vector(const IndexSet &parallel_partitioning,
              const Vector &  v,
-             const MPI_Comm &communicator = MPI_COMM_WORLD);
+             const MPI_Comm  communicator = MPI_COMM_WORLD);
 
       /**
        * Copy-constructor from deal.II vectors. Sets the dimension to that of
@@ -495,7 +495,7 @@ namespace TrilinosWrappers
       template <typename Number>
       Vector(const IndexSet &              parallel_partitioning,
              const dealii::Vector<Number> &v,
-             const MPI_Comm &              communicator = MPI_COMM_WORLD);
+             const MPI_Comm                communicator = MPI_COMM_WORLD);
 
       /**
        * Move constructor. Creates a new vector by stealing the internal data
@@ -571,7 +571,7 @@ namespace TrilinosWrappers
        */
       void
       reinit(const IndexSet &parallel_partitioning,
-             const MPI_Comm &communicator         = MPI_COMM_WORLD,
+             const MPI_Comm  communicator         = MPI_COMM_WORLD,
              const bool      omit_zeroing_entries = false);
 
       /**
@@ -611,7 +611,7 @@ namespace TrilinosWrappers
       void
       reinit(const IndexSet &locally_owned_entries,
              const IndexSet &locally_relevant_or_ghost_entries,
-             const MPI_Comm &communicator    = MPI_COMM_WORLD,
+             const MPI_Comm  communicator    = MPI_COMM_WORLD,
              const bool      vector_writable = false);
 
       /**
@@ -2196,7 +2196,7 @@ namespace TrilinosWrappers
     template <typename number>
     Vector::Vector(const IndexSet &              parallel_partitioner,
                    const dealii::Vector<number> &v,
-                   const MPI_Comm &              communicator)
+                   const MPI_Comm                communicator)
     {
       *this =
         Vector(parallel_partitioner.make_trilinos_map(communicator, true), v);

--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -229,7 +229,7 @@ namespace internal
        */
       void
       assign_ghosts(const std::vector<unsigned int> &boundary_cells,
-                    const MPI_Comm &                 communicator_sm,
+                    const MPI_Comm                   communicator_sm,
                     const bool use_vector_data_exchanger_full);
 
       /**
@@ -284,7 +284,7 @@ namespace internal
         const std::vector<FaceToCellTopology<1>> &inner_faces,
         const std::vector<FaceToCellTopology<1>> &ghosted_faces,
         const bool                                fill_cell_centric,
-        const MPI_Comm &                          communicator_sm,
+        const MPI_Comm                            communicator_sm,
         const bool use_vector_data_exchanger_full);
 
       /**

--- a/include/deal.II/matrix_free/vector_data_exchange.h
+++ b/include/deal.II/matrix_free/vector_data_exchange.h
@@ -264,7 +264,7 @@ namespace internal
       public:
         Full(
           const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner,
-          const MPI_Comm &communicator_sm);
+          const MPI_Comm communicator_sm);
 
         unsigned int
         locally_owned_size() const override;

--- a/include/deal.II/sundials/arkode.h
+++ b/include/deal.II/sundials/arkode.h
@@ -486,7 +486,7 @@ namespace SUNDIALS
      * @param mpi_comm MPI Communicator over which logging operations are
      * computed. Only used in SUNDIALS 6 and newer.
      */
-    ARKode(const AdditionalData &data, const MPI_Comm &mpi_comm);
+    ARKode(const AdditionalData &data, const MPI_Comm mpi_comm);
 
     /**
      * Destructor.

--- a/include/deal.II/sundials/ida.h
+++ b/include/deal.II/sundials/ida.h
@@ -605,7 +605,7 @@ namespace SUNDIALS
      * @param mpi_comm MPI Communicator over which logging operations are
      * computed. Only used in SUNDIALS 6 and newer.
      */
-    IDA(const AdditionalData &data, const MPI_Comm &mpi_comm);
+    IDA(const AdditionalData &data, const MPI_Comm mpi_comm);
 
     /**
      * Destructor.

--- a/include/deal.II/sundials/kinsol.h
+++ b/include/deal.II/sundials/kinsol.h
@@ -393,7 +393,7 @@ namespace SUNDIALS
      * @param mpi_comm MPI Communicator over which logging operations are
      * computed. Only used in SUNDIALS 6 and newer.
      */
-    KINSOL(const AdditionalData &data, const MPI_Comm &mpi_comm);
+    KINSOL(const AdditionalData &data, const MPI_Comm mpi_comm);
 
     /**
      * Destructor.

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -7410,7 +7410,7 @@ namespace DataOutBase
       &                              nonscalar_data_ranges,
     const Deal_II_IntermediateFlags &flags,
     const std::string &              filename,
-    const MPI_Comm &                 comm,
+    const MPI_Comm                   comm,
     const CompressionLevel           compression)
   {
 #ifndef DEAL_II_WITH_MPI
@@ -7716,7 +7716,7 @@ template <int dim, int spacedim>
 void
 DataOutInterface<dim, spacedim>::write_vtu_in_parallel(
   const std::string &filename,
-  const MPI_Comm &   comm) const
+  const MPI_Comm     comm) const
 {
 #ifndef DEAL_II_WITH_MPI
   // without MPI fall back to the normal way to write a vtu file:
@@ -7857,7 +7857,7 @@ DataOutInterface<dim, spacedim>::write_vtu_with_pvtu_record(
   const std::string &directory,
   const std::string &filename_without_extension,
   const unsigned int counter,
-  const MPI_Comm &   mpi_communicator,
+  const MPI_Comm     mpi_communicator,
   const unsigned int n_digits_for_counter,
   const unsigned int n_groups) const
 {
@@ -7950,7 +7950,7 @@ template <int dim, int spacedim>
 void
 DataOutInterface<dim, spacedim>::write_deal_II_intermediate_in_parallel(
   const std::string &                 filename,
-  const MPI_Comm &                    comm,
+  const MPI_Comm                      comm,
   const DataOutBase::CompressionLevel compression) const
 {
   DataOutBase::write_deal_II_intermediate_in_parallel(
@@ -7971,7 +7971,7 @@ DataOutInterface<dim, spacedim>::create_xdmf_entry(
   const DataOutBase::DataOutFilter &data_filter,
   const std::string &               h5_filename,
   const double                      cur_time,
-  const MPI_Comm &                  comm) const
+  const MPI_Comm                    comm) const
 {
   return create_xdmf_entry(
     data_filter, h5_filename, h5_filename, cur_time, comm);
@@ -7986,7 +7986,7 @@ DataOutInterface<dim, spacedim>::create_xdmf_entry(
   const std::string &               h5_mesh_filename,
   const std::string &               h5_solution_filename,
   const double                      cur_time,
-  const MPI_Comm &                  comm) const
+  const MPI_Comm                    comm) const
 {
   AssertThrow(spacedim == 2 || spacedim == 3,
               ExcMessage("XDMF only supports 2 or 3 space dimensions."));
@@ -8123,7 +8123,7 @@ void
 DataOutInterface<dim, spacedim>::write_xdmf_file(
   const std::vector<XDMFEntry> &entries,
   const std::string &           filename,
-  const MPI_Comm &              comm) const
+  const MPI_Comm                comm) const
 {
 #ifdef DEAL_II_WITH_MPI
   const int myrank = Utilities::MPI::this_mpi_process(comm);
@@ -8189,7 +8189,7 @@ namespace
                 const bool                        write_mesh_file,
                 const std::string &               mesh_filename,
                 const std::string &               solution_filename,
-                const MPI_Comm &                  comm)
+                const MPI_Comm                    comm)
   {
     hid_t h5_mesh_file_id = -1, h5_solution_file_id, file_plist_id, plist_id;
     hid_t node_dataspace, node_dataset, node_file_dataspace,
@@ -8658,7 +8658,7 @@ void
 DataOutInterface<dim, spacedim>::write_hdf5_parallel(
   const DataOutBase::DataOutFilter &data_filter,
   const std::string &               filename,
-  const MPI_Comm &                  comm) const
+  const MPI_Comm                    comm) const
 {
   DataOutBase::write_hdf5_parallel(
     get_patches(), data_filter, hdf5_flags, filename, comm);
@@ -8673,7 +8673,7 @@ DataOutInterface<dim, spacedim>::write_hdf5_parallel(
   const bool                        write_mesh_file,
   const std::string &               mesh_filename,
   const std::string &               solution_filename,
-  const MPI_Comm &                  comm) const
+  const MPI_Comm                    comm) const
 {
   DataOutBase::write_hdf5_parallel(get_patches(),
                                    data_filter,
@@ -8693,7 +8693,7 @@ DataOutBase::write_hdf5_parallel(
   const DataOutBase::DataOutFilter &       data_filter,
   const DataOutBase::Hdf5Flags &           flags,
   const std::string &                      filename,
-  const MPI_Comm &                         comm)
+  const MPI_Comm                           comm)
 {
   write_hdf5_parallel(
     patches, data_filter, flags, true, filename, filename, comm);
@@ -8710,7 +8710,7 @@ DataOutBase::write_hdf5_parallel(
   const bool                               write_mesh_file,
   const std::string &                      mesh_filename,
   const std::string &                      solution_filename,
-  const MPI_Comm &                         comm)
+  const MPI_Comm                           comm)
 {
   AssertThrow(
     spacedim >= 2,

--- a/source/base/data_out_base.inst.in
+++ b/source/base/data_out_base.inst.in
@@ -202,7 +202,7 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS;
           &                              nonscalar_data_ranges,
         const Deal_II_IntermediateFlags &flags,
         const std::string &              filename,
-        const MPI_Comm &                 comm,
+        const MPI_Comm                   comm,
         const CompressionLevel           compression);
 
       template void
@@ -212,7 +212,7 @@ for (deal_II_dimension : OUTPUT_DIMENSIONS;
         const DataOutFilter &         data_filter,
         const DataOutBase::Hdf5Flags &flags,
         const std::string &           filename,
-        const MPI_Comm &              comm);
+        const MPI_Comm                comm);
 
       template void
       write_filtered_data(

--- a/source/base/hdf5.cc
+++ b/source/base/hdf5.cc
@@ -409,7 +409,7 @@ namespace HDF5
 
   File::File(const std::string &  name,
              const FileAccessMode mode,
-             const MPI_Comm &     mpi_communicator)
+             const MPI_Comm       mpi_communicator)
     : File(name, mode, true, mpi_communicator)
   {}
 
@@ -418,7 +418,7 @@ namespace HDF5
   File::File(const std::string &  name,
              const FileAccessMode mode,
              const bool           mpi,
-             const MPI_Comm &     mpi_communicator)
+             const MPI_Comm       mpi_communicator)
     : Group(name, mpi)
   {
     hdf5_reference = std::shared_ptr<hid_t>(new hid_t, [](hid_t *pointer) {

--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -717,8 +717,8 @@ IndexSet::fill_index_vector(std::vector<size_type> &indices) const
 #  ifdef DEAL_II_TRILINOS_WITH_TPETRA
 
 Tpetra::Map<int, types::signed_global_dof_index>
-IndexSet::make_tpetra_map(const MPI_Comm &communicator,
-                          const bool      overlapping) const
+IndexSet::make_tpetra_map(const MPI_Comm communicator,
+                          const bool     overlapping) const
 {
   compress();
   (void)communicator;
@@ -786,8 +786,8 @@ IndexSet::make_tpetra_map(const MPI_Comm &communicator,
 
 
 Epetra_Map
-IndexSet::make_trilinos_map(const MPI_Comm &communicator,
-                            const bool      overlapping) const
+IndexSet::make_trilinos_map(const MPI_Comm communicator,
+                            const bool     overlapping) const
 {
   compress();
   (void)communicator;
@@ -855,7 +855,7 @@ IndexSet::make_trilinos_map(const MPI_Comm &communicator,
 
 #ifdef DEAL_II_WITH_PETSC
 IS
-IndexSet::make_petsc_is(const MPI_Comm &communicator) const
+IndexSet::make_petsc_is(const MPI_Comm communicator) const
 {
   std::vector<size_type> indices;
   fill_index_vector(indices);
@@ -875,7 +875,7 @@ IndexSet::make_petsc_is(const MPI_Comm &communicator) const
 
 
 bool
-IndexSet::is_ascending_and_one_to_one(const MPI_Comm &communicator) const
+IndexSet::is_ascending_and_one_to_one(const MPI_Comm communicator) const
 {
   // If the sum of local elements does not add up to the total size,
   // the IndexSet can't be complete.

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -121,7 +121,7 @@ namespace Utilities
 
 
     MinMaxAvg
-    min_max_avg(const double my_value, const MPI_Comm &mpi_communicator)
+    min_max_avg(const double my_value, const MPI_Comm mpi_communicator)
     {
       MinMaxAvg result;
       min_max_avg(ArrayView<const double>(my_value),
@@ -135,7 +135,7 @@ namespace Utilities
 
     std::vector<MinMaxAvg>
     min_max_avg(const std::vector<double> &my_values,
-                const MPI_Comm &           mpi_communicator)
+                const MPI_Comm             mpi_communicator)
     {
       std::vector<MinMaxAvg> results(my_values.size());
       min_max_avg(my_values, results, mpi_communicator);
@@ -147,7 +147,7 @@ namespace Utilities
 
 #ifdef DEAL_II_WITH_MPI
     unsigned int
-    n_mpi_processes(const MPI_Comm &mpi_communicator)
+    n_mpi_processes(const MPI_Comm mpi_communicator)
     {
       int       n_jobs = 1;
       const int ierr   = MPI_Comm_size(mpi_communicator, &n_jobs);
@@ -158,7 +158,7 @@ namespace Utilities
 
 
     unsigned int
-    this_mpi_process(const MPI_Comm &mpi_communicator)
+    this_mpi_process(const MPI_Comm mpi_communicator)
     {
       int       rank = 0;
       const int ierr = MPI_Comm_rank(mpi_communicator, &rank);
@@ -170,8 +170,8 @@ namespace Utilities
 
 
     const std::vector<unsigned int>
-    mpi_processes_within_communicator(const MPI_Comm &comm_large,
-                                      const MPI_Comm &comm_small)
+    mpi_processes_within_communicator(const MPI_Comm comm_large,
+                                      const MPI_Comm comm_small)
     {
       if (Utilities::MPI::job_supports_mpi() == false)
         return std::vector<unsigned int>{0};
@@ -190,7 +190,7 @@ namespace Utilities
 
 
     MPI_Comm
-    duplicate_communicator(const MPI_Comm &mpi_communicator)
+    duplicate_communicator(const MPI_Comm mpi_communicator)
     {
       MPI_Comm  new_communicator;
       const int ierr = MPI_Comm_dup(mpi_communicator, &new_communicator);
@@ -201,7 +201,7 @@ namespace Utilities
 
 
     void
-    free_communicator(MPI_Comm &mpi_communicator)
+    free_communicator(MPI_Comm mpi_communicator)
     {
       // MPI_Comm_free will set the argument to MPI_COMM_NULL automatically.
       const int ierr = MPI_Comm_free(&mpi_communicator);
@@ -211,7 +211,7 @@ namespace Utilities
 
 
     int
-    create_group(const MPI_Comm & comm,
+    create_group(const MPI_Comm   comm,
                  const MPI_Group &group,
                  const int        tag,
                  MPI_Comm *       new_comm)
@@ -225,7 +225,7 @@ namespace Utilities
 
     std::vector<IndexSet>
     create_ascending_partitioning(
-      const MPI_Comm &              comm,
+      const MPI_Comm                comm,
       const types::global_dof_index locally_owned_size)
     {
       static_assert(
@@ -254,7 +254,7 @@ namespace Utilities
 
     IndexSet
     create_evenly_distributed_partitioning(
-      const MPI_Comm &              comm,
+      const MPI_Comm                comm,
       const types::global_dof_index total_size)
     {
       const unsigned int this_proc = this_mpi_process(comm);
@@ -312,7 +312,7 @@ namespace Utilities
 
     std::vector<unsigned int>
     compute_point_to_point_communication_pattern(
-      const MPI_Comm &                 mpi_comm,
+      const MPI_Comm                   mpi_comm,
       const std::vector<unsigned int> &destinations)
     {
       const unsigned int myid    = Utilities::MPI::this_mpi_process(mpi_comm);
@@ -427,7 +427,7 @@ namespace Utilities
 
     unsigned int
     compute_n_point_to_point_communications(
-      const MPI_Comm &                 mpi_comm,
+      const MPI_Comm                   mpi_comm,
       const std::vector<unsigned int> &destinations)
     {
       // Have a little function that checks if destinations provided
@@ -537,7 +537,7 @@ namespace Utilities
     void
     min_max_avg(const ArrayView<const double> &my_values,
                 const ArrayView<MinMaxAvg> &   result,
-                const MPI_Comm &               mpi_communicator)
+                const MPI_Comm                 mpi_communicator)
     {
       // If MPI was not started, we have a serial computation and cannot run
       // the other MPI commands
@@ -655,7 +655,7 @@ namespace Utilities
 #else
 
     unsigned int
-    n_mpi_processes(const MPI_Comm &)
+    n_mpi_processes(const MPI_Comm)
     {
       return 1;
     }
@@ -663,7 +663,7 @@ namespace Utilities
 
 
     unsigned int
-    this_mpi_process(const MPI_Comm &)
+    this_mpi_process(const MPI_Comm)
     {
       return 0;
     }
@@ -671,7 +671,7 @@ namespace Utilities
 
 
     const std::vector<unsigned int>
-    mpi_processes_within_communicator(const MPI_Comm &, const MPI_Comm &)
+    mpi_processes_within_communicator(const MPI_Comm, const MPI_Comm)
     {
       return std::vector<unsigned int>{0};
     }
@@ -680,7 +680,7 @@ namespace Utilities
 
     std::vector<IndexSet>
     create_ascending_partitioning(
-      const MPI_Comm & /*comm*/,
+      const MPI_Comm /*comm*/,
       const types::global_dof_index locally_owned_size)
     {
       return std::vector<IndexSet>(1, complete_index_set(locally_owned_size));
@@ -688,7 +688,7 @@ namespace Utilities
 
     IndexSet
     create_evenly_distributed_partitioning(
-      const MPI_Comm & /*comm*/,
+      const MPI_Comm /*comm*/,
       const types::global_dof_index total_size)
     {
       return complete_index_set(total_size);
@@ -697,15 +697,14 @@ namespace Utilities
 
 
     MPI_Comm
-    duplicate_communicator(const MPI_Comm &mpi_communicator)
+    duplicate_communicator(const MPI_Comm mpi_communicator)
     {
       return mpi_communicator;
     }
 
 
 
-    void
-    free_communicator(MPI_Comm & /*mpi_communicator*/)
+    void free_communicator(MPI_Comm /*mpi_communicator*/)
     {}
 
 
@@ -713,7 +712,7 @@ namespace Utilities
     void
     min_max_avg(const ArrayView<const double> &my_values,
                 const ArrayView<MinMaxAvg> &   result,
-                const MPI_Comm &)
+                const MPI_Comm)
     {
       AssertDimension(my_values.size(), result.size());
 
@@ -1064,7 +1063,7 @@ namespace Utilities
     std::vector<unsigned int>
     compute_index_owner(const IndexSet &owned_indices,
                         const IndexSet &indices_to_look_up,
-                        const MPI_Comm &comm)
+                        const MPI_Comm  comm)
     {
       Assert(owned_indices.size() == indices_to_look_up.size(),
              ExcMessage("IndexSets have to have the same sizes."));
@@ -1165,7 +1164,7 @@ namespace Utilities
 
 
     void
-    CollectiveMutex::lock(const MPI_Comm &comm)
+    CollectiveMutex::lock(const MPI_Comm comm)
     {
       (void)comm;
 
@@ -1199,7 +1198,7 @@ namespace Utilities
 
 
     void
-    CollectiveMutex::unlock(const MPI_Comm &comm)
+    CollectiveMutex::unlock(const MPI_Comm comm)
     {
       (void)comm;
 
@@ -1236,26 +1235,26 @@ namespace Utilities
     // booleans aren't in MPI_SCALARS
     template bool
     reduce(const bool &,
-           const MPI_Comm &,
+           const MPI_Comm,
            const std::function<bool(const bool &, const bool &)> &,
            const unsigned int);
 
     template std::vector<bool>
     reduce(const std::vector<bool> &,
-           const MPI_Comm &,
+           const MPI_Comm,
            const std::function<std::vector<bool>(const std::vector<bool> &,
                                                  const std::vector<bool> &)> &,
            const unsigned int);
 
     template bool
     all_reduce(const bool &,
-               const MPI_Comm &,
+               const MPI_Comm,
                const std::function<bool(const bool &, const bool &)> &);
 
     template std::vector<bool>
     all_reduce(
       const std::vector<bool> &,
-      const MPI_Comm &,
+      const MPI_Comm,
       const std::function<std::vector<bool>(const std::vector<bool> &,
                                             const std::vector<bool> &)> &);
 
@@ -1264,27 +1263,27 @@ namespace Utilities
     template void
     internal::all_reduce<bool>(const MPI_Op &,
                                const ArrayView<const bool> &,
-                               const MPI_Comm &,
+                               const MPI_Comm,
                                const ArrayView<bool> &);
 
 
     template bool
-    logical_or<bool>(const bool &, const MPI_Comm &);
+    logical_or<bool>(const bool &, const MPI_Comm);
 
 
     template void
     logical_or<bool>(const ArrayView<const bool> &,
-                     const MPI_Comm &,
+                     const MPI_Comm,
                      const ArrayView<bool> &);
 
 
     template std::vector<unsigned int>
     compute_set_union(const std::vector<unsigned int> &vec,
-                      const MPI_Comm &                 comm);
+                      const MPI_Comm                   comm);
 
 
     template std::set<unsigned int>
-    compute_set_union(const std::set<unsigned int> &set, const MPI_Comm &comm);
+    compute_set_union(const std::set<unsigned int> &set, const MPI_Comm comm);
 #endif
 
 #include "mpi.inst"

--- a/source/base/mpi.inst.in
+++ b/source/base/mpi.inst.in
@@ -19,74 +19,74 @@
 for (S : REAL_SCALARS)
   {
     template void sum<S>(const SparseMatrix<S> &,
-                         const MPI_Comm &,
+                         const MPI_Comm,
                          SparseMatrix<S> &);
   }
 
 for (S : MPI_SCALARS)
   {
     template void sum<LAPACKFullMatrix<S>>(const LAPACKFullMatrix<S> &,
-                                           const MPI_Comm &,
+                                           const MPI_Comm,
                                            LAPACKFullMatrix<S> &);
 
     template void sum<Vector<S>>(const Vector<S> &,
-                                 const MPI_Comm &,
+                                 const MPI_Comm,
                                  Vector<S> &);
 
     template void sum<FullMatrix<S>>(const FullMatrix<S> &,
-                                     const MPI_Comm &,
+                                     const MPI_Comm,
                                      FullMatrix<S> &);
 
     template void sum<S>(const ArrayView<const S> &,
-                         const MPI_Comm &,
+                         const MPI_Comm,
                          const ArrayView<S> &);
 
-    template S sum<S>(const S &, const MPI_Comm &);
+    template S sum<S>(const S &, const MPI_Comm);
 
     template void sum<std::vector<S>>(const std::vector<S> &,
-                                      const MPI_Comm &,
+                                      const MPI_Comm,
                                       std::vector<S> &);
 
-    template S max<S>(const S &, const MPI_Comm &);
+    template S max<S>(const S &, const MPI_Comm);
 
     template void max<std::vector<S>>(const std::vector<S> &,
-                                      const MPI_Comm &,
+                                      const MPI_Comm,
                                       std::vector<S> &);
 
     template void max<S>(const ArrayView<const S> &,
-                         const MPI_Comm &,
+                         const MPI_Comm,
                          const ArrayView<S> &);
 
-    template S min<S>(const S &, const MPI_Comm &);
+    template S min<S>(const S &, const MPI_Comm);
 
     template void min<std::vector<S>>(const std::vector<S> &,
-                                      const MPI_Comm &,
+                                      const MPI_Comm,
                                       std::vector<S> &);
 
     template void min<S>(const ArrayView<const S> &,
-                         const MPI_Comm &,
+                         const MPI_Comm,
                          const ArrayView<S> &);
 
     template S reduce(const S &                                     vec,
-                      const MPI_Comm &                              comm,
+                      const MPI_Comm                                comm,
                       const std::function<S(const S &, const S &)> &process,
                       const unsigned int root_process);
 
     template std::vector<S> reduce(
       const std::vector<S> &                                       vec,
-      const MPI_Comm &                                             comm,
+      const MPI_Comm                                               comm,
       const std::function<std::vector<S>(const std::vector<S> &,
                                          const std::vector<S> &)> &process,
       const unsigned int root_process);
 
     template S all_reduce(
       const S &                                     vec,
-      const MPI_Comm &                              comm,
+      const MPI_Comm                                comm,
       const std::function<S(const S &, const S &)> &process);
 
     template std::vector<S> all_reduce(
       const std::vector<S> &                                       vec,
-      const MPI_Comm &                                             comm,
+      const MPI_Comm                                               comm,
       const std::function<std::vector<S>(const std::vector<S> &,
                                          const std::vector<S> &)> &process);
 
@@ -107,7 +107,7 @@ for (S : MPI_SCALARS)
     template void Utilities::MPI::internal::all_reduce<S>(
       const MPI_Op &,
       const ArrayView<const S> &,
-      const MPI_Comm &,
+      const MPI_Comm,
       const ArrayView<S> &);
   }
 
@@ -115,7 +115,7 @@ for (S : MPI_SCALARS)
 for (S : REAL_SCALARS; rank : RANKS; dim : SPACE_DIMENSIONS)
   {
     template Tensor<rank, dim, S> sum<rank, dim, S>(
-      const Tensor<rank, dim, S> &, const MPI_Comm &);
+      const Tensor<rank, dim, S> &, const MPI_Comm);
   }
 
 
@@ -123,10 +123,10 @@ for (S : REAL_SCALARS; rank : RANKS; dim : SPACE_DIMENSIONS)
 for (S : REAL_SCALARS; dim : SPACE_DIMENSIONS)
   {
     template SymmetricTensor<2, dim, S> sum<2, dim, S>(
-      const SymmetricTensor<2, dim, S> &, const MPI_Comm &);
+      const SymmetricTensor<2, dim, S> &, const MPI_Comm);
 
     template SymmetricTensor<4, dim, S> sum<4, dim, S>(
-      const SymmetricTensor<4, dim, S> &, const MPI_Comm &);
+      const SymmetricTensor<4, dim, S> &, const MPI_Comm);
   }
 
 

--- a/source/base/mpi_compute_index_owner_internal.cc
+++ b/source/base/mpi_compute_index_owner_internal.cc
@@ -165,7 +165,7 @@ namespace Utilities
 
 
         void
-        Dictionary::reinit(const IndexSet &owned_indices, const MPI_Comm &comm)
+        Dictionary::reinit(const IndexSet &owned_indices, const MPI_Comm comm)
         {
           // 1) set up the partition
           this->partition(owned_indices, comm);
@@ -430,7 +430,7 @@ namespace Utilities
 
         void
         Dictionary::partition(const IndexSet &owned_indices,
-                              const MPI_Comm &comm)
+                              const MPI_Comm  comm)
         {
 #ifdef DEAL_II_WITH_MPI
           const unsigned int n_procs = n_mpi_processes(comm);
@@ -462,7 +462,7 @@ namespace Utilities
         ConsensusAlgorithmsPayload::ConsensusAlgorithmsPayload(
           const IndexSet &           owned_indices,
           const IndexSet &           indices_to_look_up,
-          const MPI_Comm &           comm,
+          const MPI_Comm             comm,
           std::vector<unsigned int> &owning_ranks,
           const bool                 track_index_requests)
           : owned_indices(owned_indices)

--- a/source/base/mpi_noncontiguous_partitioner.cc
+++ b/source/base/mpi_noncontiguous_partitioner.cc
@@ -32,7 +32,7 @@ namespace Utilities
     NoncontiguousPartitioner::NoncontiguousPartitioner(
       const IndexSet &indexset_has,
       const IndexSet &indexset_want,
-      const MPI_Comm &communicator)
+      const MPI_Comm  communicator)
     {
       this->reinit(indexset_has, indexset_want, communicator);
     }
@@ -42,7 +42,7 @@ namespace Utilities
     NoncontiguousPartitioner::NoncontiguousPartitioner(
       const std::vector<types::global_dof_index> &indices_has,
       const std::vector<types::global_dof_index> &indices_want,
-      const MPI_Comm &                            communicator)
+      const MPI_Comm                              communicator)
     {
       this->reinit(indices_has, indices_want, communicator);
     }
@@ -91,7 +91,7 @@ namespace Utilities
     void
     NoncontiguousPartitioner::reinit(const IndexSet &indexset_has,
                                      const IndexSet &indexset_want,
-                                     const MPI_Comm &communicator)
+                                     const MPI_Comm  communicator)
     {
       this->communicator = communicator;
 
@@ -169,7 +169,7 @@ namespace Utilities
     NoncontiguousPartitioner::reinit(
       const std::vector<types::global_dof_index> &indices_has,
       const std::vector<types::global_dof_index> &indices_want,
-      const MPI_Comm &                            communicator)
+      const MPI_Comm                              communicator)
     {
       // step 0) clean vectors from numbers::invalid_dof_index (indicating
       //         padding)

--- a/source/base/partitioner.cc
+++ b/source/base/partitioner.cc
@@ -64,7 +64,7 @@ namespace Utilities
 
     Partitioner::Partitioner(const types::global_dof_index local_size,
                              const types::global_dof_index ghost_size,
-                             const MPI_Comm &              communicator)
+                             const MPI_Comm                communicator)
       : global_size(Utilities::MPI::sum<types::global_dof_index>(local_size,
                                                                  communicator))
       , locally_owned_range_data(global_size)
@@ -100,7 +100,7 @@ namespace Utilities
 
     Partitioner::Partitioner(const IndexSet &locally_owned_indices,
                              const IndexSet &ghost_indices_in,
-                             const MPI_Comm &communicator_in)
+                             const MPI_Comm  communicator_in)
       : global_size(
           static_cast<types::global_dof_index>(locally_owned_indices.size()))
       , n_ghost_indices_data(0)
@@ -118,7 +118,7 @@ namespace Utilities
 
 
     Partitioner::Partitioner(const IndexSet &locally_owned_indices,
-                             const MPI_Comm &communicator_in)
+                             const MPI_Comm  communicator_in)
       : global_size(
           static_cast<types::global_dof_index>(locally_owned_indices.size()))
       , n_ghost_indices_data(0)
@@ -137,7 +137,7 @@ namespace Utilities
     void
     Partitioner::reinit(const IndexSet &vector_space_vector_index_set,
                         const IndexSet &read_write_vector_index_set,
-                        const MPI_Comm &communicator_in)
+                        const MPI_Comm  communicator_in)
     {
       have_ghost_indices = false;
       communicator       = communicator_in;

--- a/source/base/process_grid.cc
+++ b/source/base/process_grid.cc
@@ -34,7 +34,7 @@ namespace
    * https://github.com/elemental/Elemental/blob/master/src/core/Grid.cpp#L67-L91
    */
   inline std::pair<int, int>
-  compute_processor_grid_sizes(const MPI_Comm &   mpi_comm,
+  compute_processor_grid_sizes(const MPI_Comm     mpi_comm,
                                const unsigned int m,
                                const unsigned int n,
                                const unsigned int block_size_m,
@@ -101,7 +101,7 @@ namespace Utilities
   namespace MPI
   {
     ProcessGrid::ProcessGrid(
-      const MPI_Comm &                             mpi_comm,
+      const MPI_Comm                               mpi_comm,
       const std::pair<unsigned int, unsigned int> &grid_dimensions)
       : mpi_communicator(mpi_comm)
       , this_mpi_process(Utilities::MPI::this_mpi_process(mpi_communicator))
@@ -206,7 +206,7 @@ namespace Utilities
 
 
 
-    ProcessGrid::ProcessGrid(const MPI_Comm &   mpi_comm,
+    ProcessGrid::ProcessGrid(const MPI_Comm     mpi_comm,
                              const unsigned int n_rows_matrix,
                              const unsigned int n_columns_matrix,
                              const unsigned int row_block_size,
@@ -221,7 +221,7 @@ namespace Utilities
 
 
 
-    ProcessGrid::ProcessGrid(const MPI_Comm &   mpi_comm,
+    ProcessGrid::ProcessGrid(const MPI_Comm     mpi_comm,
                              const unsigned int n_rows,
                              const unsigned int n_columns)
       : ProcessGrid(mpi_comm, std::make_pair(n_rows, n_columns))

--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -162,7 +162,7 @@ Timer::Timer()
 
 
 
-Timer::Timer(const MPI_Comm &mpi_communicator, const bool sync_lap_times_)
+Timer::Timer(const MPI_Comm mpi_communicator, const bool sync_lap_times_)
   : running(false)
   , mpi_communicator(mpi_communicator)
   , sync_lap_times(sync_lap_times_)
@@ -322,7 +322,7 @@ TimerOutput::TimerOutput(ConditionalOStream &  stream,
 
 
 
-TimerOutput::TimerOutput(const MPI_Comm &      mpi_communicator,
+TimerOutput::TimerOutput(const MPI_Comm        mpi_communicator,
                          std::ostream &        stream,
                          const OutputFrequency output_frequency,
                          const OutputType      output_type)
@@ -335,7 +335,7 @@ TimerOutput::TimerOutput(const MPI_Comm &      mpi_communicator,
 
 
 
-TimerOutput::TimerOutput(const MPI_Comm &      mpi_communicator,
+TimerOutput::TimerOutput(const MPI_Comm        mpi_communicator,
                          ConditionalOStream &  stream,
                          const OutputFrequency output_frequency,
                          const OutputType      output_type)
@@ -839,8 +839,8 @@ TimerOutput::print_summary() const
 
 
 void
-TimerOutput::print_wall_time_statistics(const MPI_Comm &mpi_comm,
-                                        const double    quantile) const
+TimerOutput::print_wall_time_statistics(const MPI_Comm mpi_comm,
+                                        const double   quantile) const
 {
   // we are going to change the precision and width of output below. store the
   // old values so the get restored when exiting this function

--- a/source/distributed/fully_distributed_tria.cc
+++ b/source/distributed/fully_distributed_tria.cc
@@ -45,8 +45,7 @@ namespace parallel
   {
     template <int dim, int spacedim>
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    Triangulation<dim, spacedim>::Triangulation(
-      const MPI_Comm &mpi_communicator)
+    Triangulation<dim, spacedim>::Triangulation(const MPI_Comm mpi_communicator)
       : parallel::DistributedTriangulationBase<dim, spacedim>(mpi_communicator)
       , settings(TriangulationDescription::Settings::default_setting)
       , partitioner([](dealii::Triangulation<dim, spacedim> &tria,

--- a/source/distributed/grid_refinement.cc
+++ b/source/distributed/grid_refinement.cc
@@ -84,7 +84,7 @@ namespace
   template <typename number>
   double
   compute_global_sum(const dealii::Vector<number> &criteria,
-                     const MPI_Comm &              mpi_communicator)
+                     const MPI_Comm                mpi_communicator)
   {
     double my_sum =
       std::accumulate(criteria.begin(),
@@ -274,7 +274,7 @@ namespace internal
         std::pair<number, number>
         compute_global_min_and_max_at_root(
           const dealii::Vector<number> &criteria,
-          const MPI_Comm &              mpi_communicator)
+          const MPI_Comm                mpi_communicator)
         {
           // we'd like to compute the global max and min from the local ones in
           // one MPI communication. we can do that by taking the elementwise
@@ -307,7 +307,7 @@ namespace internal
           compute_threshold(const dealii::Vector<number> &   criteria,
                             const std::pair<double, double> &global_min_and_max,
                             const types::global_cell_index   n_target_cells,
-                            const MPI_Comm &                 mpi_communicator)
+                            const MPI_Comm                   mpi_communicator)
           {
             double interesting_range[2] = {global_min_and_max.first,
                                            global_min_and_max.second};
@@ -390,7 +390,7 @@ namespace internal
           compute_threshold(const dealii::Vector<number> &   criteria,
                             const std::pair<double, double> &global_min_and_max,
                             const double                     target_error,
-                            const MPI_Comm &                 mpi_communicator)
+                            const MPI_Comm                   mpi_communicator)
           {
             double interesting_range[2] = {global_min_and_max.first,
                                            global_min_and_max.second};

--- a/source/distributed/grid_refinement.inst.in
+++ b/source/distributed/grid_refinement.inst.in
@@ -27,7 +27,7 @@ for (S : REAL_SCALARS)
           \{
             template std::pair<S, S>
             compute_global_min_and_max_at_root<S>(const dealii::Vector<S> &,
-                                                  const MPI_Comm &);
+                                                  const MPI_Comm);
 
             namespace RefineAndCoarsenFixedNumber
             \{
@@ -35,7 +35,7 @@ for (S : REAL_SCALARS)
               compute_threshold<S>(const dealii::Vector<S> &,
                                    const std::pair<double, double> &,
                                    const types::global_cell_index,
-                                   const MPI_Comm &);
+                                   const MPI_Comm);
             \}
             namespace RefineAndCoarsenFixedFraction
             \{
@@ -43,7 +43,7 @@ for (S : REAL_SCALARS)
               compute_threshold<S>(const dealii::Vector<S> &,
                                    const std::pair<double, double> &,
                                    const double,
-                                   const MPI_Comm &);
+                                   const MPI_Comm);
             \}
           \}
         \}

--- a/source/distributed/shared_tria.cc
+++ b/source/distributed/shared_tria.cc
@@ -41,7 +41,7 @@ namespace parallel
     template <int dim, int spacedim>
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     Triangulation<dim, spacedim>::Triangulation(
-      const MPI_Comm &mpi_communicator,
+      const MPI_Comm mpi_communicator,
       const typename dealii::Triangulation<dim, spacedim>::MeshSmoothing
                      smooth_grid,
       const bool     allow_artificial_cells,

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -1698,7 +1698,7 @@ namespace parallel
     template <int dim, int spacedim>
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     Triangulation<dim, spacedim>::Triangulation(
-      const MPI_Comm &mpi_communicator,
+      const MPI_Comm mpi_communicator,
       const typename dealii::Triangulation<dim, spacedim>::MeshSmoothing
                      smooth_grid,
       const Settings settings)
@@ -4073,7 +4073,7 @@ namespace parallel
     template <int spacedim>
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<1, spacedim>))
     Triangulation<1, spacedim>::Triangulation(
-      const MPI_Comm &mpi_communicator,
+      const MPI_Comm mpi_communicator,
       const typename dealii::Triangulation<1, spacedim>::MeshSmoothing
         smooth_grid,
       const Settings /*settings*/)

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -46,7 +46,7 @@ namespace parallel
   template <int dim, int spacedim>
   DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
   TriangulationBase<dim, spacedim>::TriangulationBase(
-    const MPI_Comm &mpi_communicator,
+    const MPI_Comm mpi_communicator,
     const typename dealii::Triangulation<dim, spacedim>::MeshSmoothing
                smooth_grid,
     const bool check_for_distorted_cells)
@@ -671,7 +671,7 @@ namespace parallel
   template <int dim, int spacedim>
   DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
   DistributedTriangulationBase<dim, spacedim>::DistributedTriangulationBase(
-    const MPI_Comm &mpi_communicator,
+    const MPI_Comm mpi_communicator,
     const typename dealii::Triangulation<dim, spacedim>::MeshSmoothing
                smooth_grid,
     const bool check_for_distorted_cells)
@@ -877,7 +877,7 @@ namespace parallel
   template <int dim, int spacedim>
   DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
   DistributedTriangulationBase<dim, spacedim>::DataTransfer::DataTransfer(
-    const MPI_Comm &mpi_communicator)
+    const MPI_Comm mpi_communicator)
     : variable_size_data_stored(false)
     , mpi_communicator(mpi_communicator)
   {}

--- a/source/dofs/number_cache.cc
+++ b/source/dofs/number_cache.cc
@@ -84,7 +84,7 @@ namespace internal
 
     std::vector<types::global_dof_index>
     NumberCache::get_n_locally_owned_dofs_per_processor(
-      const MPI_Comm &mpi_communicator) const
+      const MPI_Comm mpi_communicator) const
     {
       if (n_global_dofs == 0)
         return std::vector<types::global_dof_index>();
@@ -107,7 +107,7 @@ namespace internal
 
     std::vector<IndexSet>
     NumberCache::get_locally_owned_dofs_per_processor(
-      const MPI_Comm &mpi_communicator) const
+      const MPI_Comm mpi_communicator) const
     {
       AssertDimension(locally_owned_dofs.size(), n_global_dofs);
       if (n_global_dofs == 0)

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -5997,7 +5997,7 @@ namespace GridTools
                std::vector<unsigned int>,
                std::vector<unsigned int>>
     guess_owners_of_entities(
-      const MPI_Comm &                                       comm,
+      const MPI_Comm                                         comm,
       const std::vector<std::vector<BoundingBox<spacedim>>> &global_bboxes,
       const std::vector<T> &                                 entities,
       const double                                           tolerance)
@@ -6524,7 +6524,7 @@ namespace GridTools
   std::vector<std::vector<BoundingBox<spacedim>>>
   exchange_local_bounding_boxes(
     const std::vector<BoundingBox<spacedim>> &local_bboxes,
-    const MPI_Comm &                          mpi_communicator)
+    const MPI_Comm                            mpi_communicator)
   {
 #ifndef DEAL_II_WITH_MPI
     (void)local_bboxes;
@@ -6620,7 +6620,7 @@ namespace GridTools
   RTree<std::pair<BoundingBox<spacedim>, unsigned int>>
   build_global_description_tree(
     const std::vector<BoundingBox<spacedim>> &local_description,
-    const MPI_Comm &                          mpi_communicator)
+    const MPI_Comm                            mpi_communicator)
   {
 #ifndef DEAL_II_WITH_MPI
     (void)mpi_communicator;

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -181,7 +181,7 @@ for (deal_II_space_dimension : SPACE_DIMENSIONS)
     template std::vector<std::vector<BoundingBox<deal_II_space_dimension>>>
     GridTools::exchange_local_bounding_boxes(
       const std::vector<BoundingBox<deal_II_space_dimension>> &,
-      const MPI_Comm &);
+      const MPI_Comm);
 
     template std::tuple<std::vector<std::vector<unsigned int>>,
                         std::map<unsigned int, unsigned int>,
@@ -202,7 +202,7 @@ for (deal_II_space_dimension : SPACE_DIMENSIONS)
       std::pair<BoundingBox<deal_II_space_dimension>, unsigned int>>
     GridTools::build_global_description_tree(
       const std::vector<BoundingBox<deal_II_space_dimension>> &,
-      const MPI_Comm &);
+      const MPI_Comm);
 
     template Vector<double> GridTools::compute_aspect_ratio_of_cells(
       const Mapping<deal_II_space_dimension> &,

--- a/source/grid/tria_description.cc
+++ b/source/grid/tria_description.cc
@@ -111,7 +111,7 @@ namespace TriangulationDescription
         collect(
           const std::vector<unsigned int> &                  relevant_processes,
           const std::vector<DescriptionTemp<dim, spacedim>> &description_temp,
-          const MPI_Comm &                                   comm,
+          const MPI_Comm                                     comm,
           const bool vertices_have_unique_ids)
         {
           const auto create_request = [&](const unsigned int other_rank) {
@@ -404,7 +404,7 @@ namespace TriangulationDescription
           const std::function<types::subdomain_id(
             const typename dealii::Triangulation<dim, spacedim>::cell_iterator
               &)> &                                level_subdomain_id_function,
-          const MPI_Comm &                         comm,
+          const MPI_Comm                           comm,
           const TriangulationDescription::Settings settings)
           : tria(tria)
           , subdomain_id_function(subdomain_id_function)
@@ -709,7 +709,7 @@ namespace TriangulationDescription
           const typename dealii::Triangulation<dim, spacedim>::cell_iterator &)>
           level_subdomain_id_function;
 
-        const MPI_Comm &                         comm;
+        const MPI_Comm                           comm;
         const TriangulationDescription::Settings settings;
         const bool                               construct_multigrid;
 
@@ -725,7 +725,7 @@ namespace TriangulationDescription
     Description<dim, spacedim>
     create_description_from_triangulation(
       const dealii::Triangulation<dim, spacedim> &tria,
-      const MPI_Comm &                            comm,
+      const MPI_Comm                              comm,
       const TriangulationDescription::Settings    settings,
       const unsigned int                          my_rank_in)
     {
@@ -791,9 +791,9 @@ namespace TriangulationDescription
       const std::function<void(dealii::Triangulation<dim, spacedim> &)>
         &                                            serial_grid_generator,
       const std::function<void(dealii::Triangulation<dim, spacedim> &,
-                               const MPI_Comm &,
+                               const MPI_Comm,
                                const unsigned int)> &serial_grid_partitioner,
-      const MPI_Comm &                               comm,
+      const MPI_Comm                                 comm,
       const int                                      group_size,
       const typename Triangulation<dim, spacedim>::MeshSmoothing smoothing,
       const TriangulationDescription::Settings                   settings)

--- a/source/grid/tria_description.inst.in
+++ b/source/grid/tria_description.inst.in
@@ -26,7 +26,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
         create_description_from_triangulation(
           const dealii::Triangulation<deal_II_dimension,
                                       deal_II_space_dimension> &tria,
-          const MPI_Comm &                                      comm,
+          const MPI_Comm                                        comm,
           const TriangulationDescription::Settings              settings,
           const unsigned int                                    my_rank_in);
 
@@ -37,9 +37,9 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
               &)> &               serial_grid_generator,
           const std::function<void(
             dealii::Triangulation<deal_II_dimension, deal_II_space_dimension> &,
-            const MPI_Comm &,
+            const MPI_Comm,
             const unsigned int)> &serial_grid_partitioner,
-          const MPI_Comm &        comm,
+          const MPI_Comm          comm,
           const int               group_size,
           const typename Triangulation<deal_II_dimension,
                                        deal_II_space_dimension>::MeshSmoothing

--- a/source/lac/block_sparsity_pattern.cc
+++ b/source/lac/block_sparsity_pattern.cc
@@ -556,7 +556,7 @@ namespace TrilinosWrappers
 
   BlockSparsityPattern::BlockSparsityPattern(
     const std::vector<IndexSet> &parallel_partitioning,
-    const MPI_Comm &             communicator)
+    const MPI_Comm               communicator)
     : BlockSparsityPatternBase<SparsityPattern>(parallel_partitioning.size(),
                                                 parallel_partitioning.size())
   {
@@ -574,7 +574,7 @@ namespace TrilinosWrappers
     const std::vector<IndexSet> &row_parallel_partitioning,
     const std::vector<IndexSet> &col_parallel_partitioning,
     const std::vector<IndexSet> &writable_rows,
-    const MPI_Comm &             communicator)
+    const MPI_Comm               communicator)
     : BlockSparsityPatternBase<SparsityPattern>(
         row_parallel_partitioning.size(),
         col_parallel_partitioning.size())
@@ -607,7 +607,7 @@ namespace TrilinosWrappers
   void
   BlockSparsityPattern::reinit(
     const std::vector<IndexSet> &parallel_partitioning,
-    const MPI_Comm &             communicator)
+    const MPI_Comm               communicator)
   {
     dealii::BlockSparsityPatternBase<SparsityPattern>::reinit(
       parallel_partitioning.size(), parallel_partitioning.size());
@@ -625,7 +625,7 @@ namespace TrilinosWrappers
   BlockSparsityPattern::reinit(
     const std::vector<IndexSet> &row_parallel_partitioning,
     const std::vector<IndexSet> &col_parallel_partitioning,
-    const MPI_Comm &             communicator)
+    const MPI_Comm               communicator)
   {
     dealii::BlockSparsityPatternBase<SparsityPattern>::reinit(
       row_parallel_partitioning.size(), col_parallel_partitioning.size());
@@ -644,7 +644,7 @@ namespace TrilinosWrappers
     const std::vector<IndexSet> &row_parallel_partitioning,
     const std::vector<IndexSet> &col_parallel_partitioning,
     const std::vector<IndexSet> &writable_rows,
-    const MPI_Comm &             communicator)
+    const MPI_Comm               communicator)
   {
     AssertDimension(writable_rows.size(), row_parallel_partitioning.size());
     dealii::BlockSparsityPatternBase<SparsityPattern>::reinit(

--- a/source/lac/petsc_communication_pattern.cc
+++ b/source/lac/petsc_communication_pattern.cc
@@ -45,7 +45,7 @@ namespace PETScWrappers
   void
   CommunicationPattern::reinit(const types::global_dof_index local_size,
                                const IndexSet &              ghost_indices,
-                               const MPI_Comm &              communicator)
+                               const MPI_Comm                communicator)
   {
     clear();
 
@@ -81,7 +81,7 @@ namespace PETScWrappers
   void
   CommunicationPattern::reinit(const IndexSet &locally_owned_indices,
                                const IndexSet &ghost_indices,
-                               const MPI_Comm &communicator)
+                               const MPI_Comm  communicator)
   {
     std::vector<types::global_dof_index> in_deal;
     locally_owned_indices.fill_index_vector(in_deal);
@@ -100,7 +100,7 @@ namespace PETScWrappers
   CommunicationPattern::reinit(
     const std::vector<types::global_dof_index> &indices_has,
     const std::vector<types::global_dof_index> &indices_want,
-    const MPI_Comm &                            communicator)
+    const MPI_Comm                              communicator)
   {
     // Clean vectors from numbers::invalid_dof_index (indicating padding)
     std::vector<PetscInt> indices_has_clean, indices_has_loc;
@@ -154,7 +154,7 @@ namespace PETScWrappers
                                   const std::vector<PetscInt> &inloc,
                                   const std::vector<PetscInt> &outidx,
                                   const std::vector<PetscInt> &outloc,
-                                  const MPI_Comm &             communicator)
+                                  const MPI_Comm               communicator)
   {
     clear();
 
@@ -348,7 +348,7 @@ namespace PETScWrappers
   void
   Partitioner::reinit(const IndexSet &locally_owned_indices,
                       const IndexSet &ghost_indices,
-                      const MPI_Comm &communicator)
+                      const MPI_Comm  communicator)
   {
     ghost_indices_data = ghost_indices;
     ghost_indices_data.subtract_set(locally_owned_indices);
@@ -365,7 +365,7 @@ namespace PETScWrappers
   Partitioner::reinit(const IndexSet &locally_owned_indices,
                       const IndexSet &ghost_indices,
                       const IndexSet &larger_ghost_indices,
-                      const MPI_Comm &communicator)
+                      const MPI_Comm  communicator)
   {
     std::vector<types::global_dof_index> local_indices;
     locally_owned_indices.fill_index_vector(local_indices);

--- a/source/lac/petsc_matrix_free.cc
+++ b/source/lac/petsc_matrix_free.cc
@@ -33,7 +33,7 @@ namespace PETScWrappers
 
 
 
-  MatrixFree::MatrixFree(const MPI_Comm &   communicator,
+  MatrixFree::MatrixFree(const MPI_Comm     communicator,
                          const unsigned int m,
                          const unsigned int n,
                          const unsigned int local_rows,
@@ -45,7 +45,7 @@ namespace PETScWrappers
 
 
   MatrixFree::MatrixFree(
-    const MPI_Comm &                 communicator,
+    const MPI_Comm                   communicator,
     const unsigned int               m,
     const unsigned int               n,
     const std::vector<unsigned int> &local_rows_per_process,
@@ -98,7 +98,7 @@ namespace PETScWrappers
 
 
   void
-  MatrixFree::reinit(const MPI_Comm &   communicator,
+  MatrixFree::reinit(const MPI_Comm     communicator,
                      const unsigned int m,
                      const unsigned int n,
                      const unsigned int local_rows,
@@ -114,7 +114,7 @@ namespace PETScWrappers
 
 
   void
-  MatrixFree::reinit(const MPI_Comm &                 communicator,
+  MatrixFree::reinit(const MPI_Comm                   communicator,
                      const unsigned int               m,
                      const unsigned int               n,
                      const std::vector<unsigned int> &local_rows_per_process,
@@ -211,7 +211,7 @@ namespace PETScWrappers
 
 
   void
-  MatrixFree::do_reinit(const MPI_Comm &   communicator,
+  MatrixFree::do_reinit(const MPI_Comm     communicator,
                         const unsigned int m,
                         const unsigned int n,
                         const unsigned int local_rows,

--- a/source/lac/petsc_parallel_block_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_block_sparse_matrix.cc
@@ -111,7 +111,7 @@ namespace PETScWrappers
     BlockSparseMatrix::reinit(const std::vector<IndexSet> &      rows,
                               const std::vector<IndexSet> &      cols,
                               const BlockDynamicSparsityPattern &bdsp,
-                              const MPI_Comm &                   com)
+                              const MPI_Comm                     com)
     {
       Assert(rows.size() == bdsp.n_block_rows(), ExcMessage("invalid size"));
       Assert(cols.size() == bdsp.n_block_cols(), ExcMessage("invalid size"));
@@ -149,7 +149,7 @@ namespace PETScWrappers
     void
     BlockSparseMatrix::reinit(const std::vector<IndexSet> &      sizes,
                               const BlockDynamicSparsityPattern &bdsp,
-                              const MPI_Comm &                   com)
+                              const MPI_Comm                     com)
     {
       reinit(sizes, sizes, bdsp, com);
     }

--- a/source/lac/petsc_parallel_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_sparse_matrix.cc
@@ -57,7 +57,7 @@ namespace PETScWrappers
 
     template <typename SparsityPatternType>
     SparseMatrix::SparseMatrix(
-      const MPI_Comm &              communicator,
+      const MPI_Comm                communicator,
       const SparsityPatternType &   sparsity_pattern,
       const std::vector<size_type> &local_rows_per_process,
       const std::vector<size_type> &local_columns_per_process,
@@ -94,7 +94,7 @@ namespace PETScWrappers
                          const IndexSet &           local_columns,
                          const IndexSet &           local_active_columns,
                          const SparsityPatternType &sparsity_pattern,
-                         const MPI_Comm &           communicator)
+                         const MPI_Comm             communicator)
     {
       // get rid of old matrix and generate a new one
       const PetscErrorCode ierr = MatDestroy(&matrix);
@@ -132,7 +132,7 @@ namespace PETScWrappers
     template <typename SparsityPatternType>
     void
     SparseMatrix::reinit(
-      const MPI_Comm &              communicator,
+      const MPI_Comm                communicator,
       const SparsityPatternType &   sparsity_pattern,
       const std::vector<size_type> &local_rows_per_process,
       const std::vector<size_type> &local_columns_per_process,
@@ -158,7 +158,7 @@ namespace PETScWrappers
     void
     SparseMatrix::reinit(const IndexSet &           local_rows,
                          const SparsityPatternType &sparsity_pattern,
-                         const MPI_Comm &           communicator)
+                         const MPI_Comm             communicator)
     {
       do_reinit(communicator, local_rows, local_rows, sparsity_pattern);
     }
@@ -168,7 +168,7 @@ namespace PETScWrappers
     SparseMatrix::reinit(const IndexSet &           local_rows,
                          const IndexSet &           local_columns,
                          const SparsityPatternType &sparsity_pattern,
-                         const MPI_Comm &           communicator)
+                         const MPI_Comm             communicator)
     {
       // get rid of old matrix and generate a new one
       const PetscErrorCode ierr = MatDestroy(&matrix);
@@ -181,7 +181,7 @@ namespace PETScWrappers
 
     template <typename SparsityPatternType>
     void
-    SparseMatrix::do_reinit(const MPI_Comm &           communicator,
+    SparseMatrix::do_reinit(const MPI_Comm             communicator,
                             const IndexSet &           local_rows,
                             const IndexSet &           local_columns,
                             const SparsityPatternType &sparsity_pattern)
@@ -340,7 +340,7 @@ namespace PETScWrappers
     template <typename SparsityPatternType>
     void
     SparseMatrix::do_reinit(
-      const MPI_Comm &              communicator,
+      const MPI_Comm                communicator,
       const SparsityPatternType &   sparsity_pattern,
       const std::vector<size_type> &local_rows_per_process,
       const std::vector<size_type> &local_columns_per_process,
@@ -465,7 +465,7 @@ namespace PETScWrappers
     // BDDC
     template <typename SparsityPatternType>
     void
-    SparseMatrix::do_reinit(const MPI_Comm &           communicator,
+    SparseMatrix::do_reinit(const MPI_Comm             communicator,
                             const IndexSet &           local_rows,
                             const IndexSet &           local_active_rows,
                             const IndexSet &           local_columns,
@@ -693,13 +693,13 @@ namespace PETScWrappers
 #  ifndef DOXYGEN
     // explicit instantiations
     //
-    template SparseMatrix::SparseMatrix(const MPI_Comm &,
+    template SparseMatrix::SparseMatrix(const MPI_Comm,
                                         const SparsityPattern &,
                                         const std::vector<size_type> &,
                                         const std::vector<size_type> &,
                                         const unsigned int,
                                         const bool);
-    template SparseMatrix::SparseMatrix(const MPI_Comm &,
+    template SparseMatrix::SparseMatrix(const MPI_Comm,
                                         const DynamicSparsityPattern &,
                                         const std::vector<size_type> &,
                                         const std::vector<size_type> &,
@@ -707,14 +707,14 @@ namespace PETScWrappers
                                         const bool);
 
     template void
-    SparseMatrix::reinit(const MPI_Comm &,
+    SparseMatrix::reinit(const MPI_Comm,
                          const SparsityPattern &,
                          const std::vector<size_type> &,
                          const std::vector<size_type> &,
                          const unsigned int,
                          const bool);
     template void
-    SparseMatrix::reinit(const MPI_Comm &,
+    SparseMatrix::reinit(const MPI_Comm,
                          const DynamicSparsityPattern &,
                          const std::vector<size_type> &,
                          const std::vector<size_type> &,
@@ -724,34 +724,34 @@ namespace PETScWrappers
     template void
     SparseMatrix::reinit(const IndexSet &,
                          const SparsityPattern &,
-                         const MPI_Comm &);
+                         const MPI_Comm);
 
     template void
     SparseMatrix::reinit(const IndexSet &,
                          const IndexSet &,
                          const SparsityPattern &,
-                         const MPI_Comm &);
+                         const MPI_Comm);
 
     template void
     SparseMatrix::reinit(const IndexSet &,
                          const DynamicSparsityPattern &,
-                         const MPI_Comm &);
+                         const MPI_Comm);
 
     template void
     SparseMatrix::reinit(const IndexSet &,
                          const IndexSet &,
                          const DynamicSparsityPattern &,
-                         const MPI_Comm &);
+                         const MPI_Comm);
 
     template void
-    SparseMatrix::do_reinit(const MPI_Comm &,
+    SparseMatrix::do_reinit(const MPI_Comm,
                             const SparsityPattern &,
                             const std::vector<size_type> &,
                             const std::vector<size_type> &,
                             const unsigned int,
                             const bool);
     template void
-    SparseMatrix::do_reinit(const MPI_Comm &,
+    SparseMatrix::do_reinit(const MPI_Comm,
                             const DynamicSparsityPattern &,
                             const std::vector<size_type> &,
                             const std::vector<size_type> &,
@@ -759,13 +759,13 @@ namespace PETScWrappers
                             const bool);
 
     template void
-    SparseMatrix::do_reinit(const MPI_Comm &,
+    SparseMatrix::do_reinit(const MPI_Comm,
                             const IndexSet &,
                             const IndexSet &,
                             const SparsityPattern &);
 
     template void
-    SparseMatrix::do_reinit(const MPI_Comm &,
+    SparseMatrix::do_reinit(const MPI_Comm,
                             const IndexSet &,
                             const IndexSet &,
                             const DynamicSparsityPattern &);
@@ -776,24 +776,24 @@ namespace PETScWrappers
                          const IndexSet &,
                          const IndexSet &,
                          const SparsityPattern &,
-                         const MPI_Comm &);
+                         const MPI_Comm);
     template void
     SparseMatrix::reinit(const IndexSet &,
                          const IndexSet &,
                          const IndexSet &,
                          const IndexSet &,
                          const DynamicSparsityPattern &,
-                         const MPI_Comm &);
+                         const MPI_Comm);
 
     template void
-    SparseMatrix::do_reinit(const MPI_Comm &,
+    SparseMatrix::do_reinit(const MPI_Comm,
                             const IndexSet &,
                             const IndexSet &,
                             const IndexSet &,
                             const IndexSet &,
                             const SparsityPattern &);
     template void
-    SparseMatrix::do_reinit(const MPI_Comm &,
+    SparseMatrix::do_reinit(const MPI_Comm,
                             const IndexSet &,
                             const IndexSet &,
                             const IndexSet &,

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -38,7 +38,7 @@ namespace PETScWrappers
 
 
 
-    Vector::Vector(const MPI_Comm &communicator,
+    Vector::Vector(const MPI_Comm  communicator,
                    const size_type n,
                    const size_type locally_owned_size)
     {
@@ -49,7 +49,7 @@ namespace PETScWrappers
 
     Vector::Vector(const IndexSet &local,
                    const IndexSet &ghost,
-                   const MPI_Comm &communicator)
+                   const MPI_Comm  communicator)
     {
       Assert(local.is_ascending_and_one_to_one(communicator),
              ExcNotImplemented());
@@ -83,7 +83,7 @@ namespace PETScWrappers
 
 
 
-    Vector::Vector(const IndexSet &local, const MPI_Comm &communicator)
+    Vector::Vector(const IndexSet &local, const MPI_Comm communicator)
     {
       Assert(local.is_ascending_and_one_to_one(communicator),
              ExcNotImplemented());
@@ -145,7 +145,7 @@ namespace PETScWrappers
 
 
     void
-    Vector::reinit(const MPI_Comm &communicator,
+    Vector::reinit(const MPI_Comm  communicator,
                    const size_type n,
                    const size_type local_sz,
                    const bool      omit_zeroing_entries)
@@ -211,7 +211,7 @@ namespace PETScWrappers
     void
     Vector::reinit(const IndexSet &local,
                    const IndexSet &ghost,
-                   const MPI_Comm &comm)
+                   const MPI_Comm  comm)
     {
       const PetscErrorCode ierr = VecDestroy(&vector);
       AssertThrow(ierr == 0, ExcPETScError(ierr));
@@ -225,7 +225,7 @@ namespace PETScWrappers
     }
 
     void
-    Vector::reinit(const IndexSet &local, const MPI_Comm &comm)
+    Vector::reinit(const IndexSet &local, const MPI_Comm comm)
     {
       const PetscErrorCode ierr = VecDestroy(&vector);
       AssertThrow(ierr == 0, ExcPETScError(ierr));
@@ -246,7 +246,7 @@ namespace PETScWrappers
 
 
     void
-    Vector::create_vector(const MPI_Comm &communicator,
+    Vector::create_vector(const MPI_Comm  communicator,
                           const size_type n,
                           const size_type locally_owned_size)
     {
@@ -266,7 +266,7 @@ namespace PETScWrappers
 
 
     void
-    Vector::create_vector(const MPI_Comm &communicator,
+    Vector::create_vector(const MPI_Comm  communicator,
                           const size_type n,
                           const size_type locally_owned_size,
                           const IndexSet &ghostnodes)

--- a/source/lac/petsc_precondition.cc
+++ b/source/lac/petsc_precondition.cc
@@ -33,7 +33,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace PETScWrappers
 {
-  PreconditionBase::PreconditionBase(const MPI_Comm &comm)
+  PreconditionBase::PreconditionBase(const MPI_Comm comm)
     : pc(nullptr)
   {
     create_pc_with_comm(comm);
@@ -115,7 +115,7 @@ namespace PETScWrappers
   }
 
   void
-  PreconditionBase::create_pc_with_comm(const MPI_Comm &comm)
+  PreconditionBase::create_pc_with_comm(const MPI_Comm comm)
   {
     clear();
     PetscErrorCode ierr = PCCreate(comm, &pc);
@@ -137,7 +137,7 @@ namespace PETScWrappers
 
 
 
-  PreconditionJacobi::PreconditionJacobi(const MPI_Comm &      comm,
+  PreconditionJacobi::PreconditionJacobi(const MPI_Comm        comm,
                                          const AdditionalData &additional_data_)
     : PreconditionBase(comm)
   {
@@ -194,7 +194,7 @@ namespace PETScWrappers
   {}
 
   PreconditionBlockJacobi::PreconditionBlockJacobi(
-    const MPI_Comm &      comm,
+    const MPI_Comm        comm,
     const AdditionalData &additional_data_)
     : PreconditionBase(comm)
   {
@@ -540,7 +540,7 @@ namespace PETScWrappers
 
 
   PreconditionBoomerAMG::PreconditionBoomerAMG(
-    const MPI_Comm &      comm,
+    const MPI_Comm        comm,
     const AdditionalData &additional_data_)
     : PreconditionBase(comm)
   {
@@ -1057,13 +1057,13 @@ namespace PETScWrappers
     initialize(matrix);
   }
 
-  PreconditionShell::PreconditionShell(const MPI_Comm &comm)
+  PreconditionShell::PreconditionShell(const MPI_Comm comm)
   {
     initialize(comm);
   }
 
   void
-  PreconditionShell::initialize(const MPI_Comm &comm)
+  PreconditionShell::initialize(const MPI_Comm comm)
   {
     PetscErrorCode ierr;
     if (pc)

--- a/source/lac/petsc_solver.cc
+++ b/source/lac/petsc_solver.cc
@@ -204,7 +204,7 @@ namespace PETScWrappers
 
 
   void
-  SolverBase::initialize_ksp_with_comm(const MPI_Comm &comm)
+  SolverBase::initialize_ksp_with_comm(const MPI_Comm comm)
   {
     // Create the PETSc KSP object
     AssertPETSc(KSPCreate(comm, &ksp));
@@ -263,7 +263,7 @@ namespace PETScWrappers
 
 
   SolverRichardson::SolverRichardson(SolverControl &cn,
-                                     const MPI_Comm &,
+                                     const MPI_Comm,
                                      const AdditionalData &data)
     : SolverRichardson(cn, data)
   {}
@@ -313,7 +313,7 @@ namespace PETScWrappers
 
 
   SolverChebychev::SolverChebychev(SolverControl &cn,
-                                   const MPI_Comm &,
+                                   const MPI_Comm,
                                    const AdditionalData &data)
     : SolverChebychev(cn, data)
   {}
@@ -340,7 +340,7 @@ namespace PETScWrappers
 
 
   SolverCG::SolverCG(SolverControl &cn,
-                     const MPI_Comm &,
+                     const MPI_Comm,
                      const AdditionalData &data)
     : SolverCG(cn, data)
   {}
@@ -367,7 +367,7 @@ namespace PETScWrappers
 
 
   SolverBiCG::SolverBiCG(SolverControl &cn,
-                         const MPI_Comm &,
+                         const MPI_Comm,
                          const AdditionalData &data)
     : SolverBiCG(cn, data)
   {}
@@ -403,7 +403,7 @@ namespace PETScWrappers
 
 
   SolverGMRES::SolverGMRES(SolverControl &cn,
-                           const MPI_Comm &,
+                           const MPI_Comm,
                            const AdditionalData &data)
     : SolverGMRES(cn, data)
   {}
@@ -438,7 +438,7 @@ namespace PETScWrappers
 
 
   SolverBicgstab::SolverBicgstab(SolverControl &cn,
-                                 const MPI_Comm &,
+                                 const MPI_Comm,
                                  const AdditionalData &data)
     : SolverBicgstab(cn, data)
   {}
@@ -465,7 +465,7 @@ namespace PETScWrappers
 
 
   SolverCGS::SolverCGS(SolverControl &cn,
-                       const MPI_Comm &,
+                       const MPI_Comm,
                        const AdditionalData &data)
     : SolverCGS(cn, data)
   {}
@@ -492,7 +492,7 @@ namespace PETScWrappers
 
 
   SolverTFQMR::SolverTFQMR(SolverControl &cn,
-                           const MPI_Comm &,
+                           const MPI_Comm,
                            const AdditionalData &data)
     : SolverTFQMR(cn, data)
   {}
@@ -519,7 +519,7 @@ namespace PETScWrappers
 
 
   SolverTCQMR::SolverTCQMR(SolverControl &cn,
-                           const MPI_Comm &,
+                           const MPI_Comm,
                            const AdditionalData &data)
     : SolverTCQMR(cn, data)
   {}
@@ -546,7 +546,7 @@ namespace PETScWrappers
 
 
   SolverCR::SolverCR(SolverControl &cn,
-                     const MPI_Comm &,
+                     const MPI_Comm,
                      const AdditionalData &data)
     : SolverCR(cn, data)
   {}
@@ -574,7 +574,7 @@ namespace PETScWrappers
 
 
   SolverLSQR::SolverLSQR(SolverControl &cn,
-                         const MPI_Comm &,
+                         const MPI_Comm,
                          const AdditionalData &data)
     : SolverLSQR(cn, data)
   {}
@@ -609,7 +609,7 @@ namespace PETScWrappers
 
 
   SolverPreOnly::SolverPreOnly(SolverControl &cn,
-                               const MPI_Comm &,
+                               const MPI_Comm,
                                const AdditionalData &data)
     : SolverPreOnly(cn, data)
   {}
@@ -649,7 +649,7 @@ namespace PETScWrappers
 
 
   SparseDirectMUMPS::SparseDirectMUMPS(SolverControl &cn,
-                                       const MPI_Comm &,
+                                       const MPI_Comm,
                                        const AdditionalData &data)
     : SparseDirectMUMPS(cn, data)
   {}

--- a/source/lac/slepc_solver.cc
+++ b/source/lac/slepc_solver.cc
@@ -32,7 +32,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace SLEPcWrappers
 {
-  SolverBase::SolverBase(SolverControl &cn, const MPI_Comm &mpi_communicator)
+  SolverBase::SolverBase(SolverControl &cn, const MPI_Comm mpi_communicator)
     : solver_control(cn)
     , mpi_communicator(mpi_communicator)
     , reason(EPS_CONVERGED_ITERATING)
@@ -360,7 +360,7 @@ namespace SLEPcWrappers
 
   /* ---------------------- SolverKrylovSchur ------------------------ */
   SolverKrylovSchur::SolverKrylovSchur(SolverControl &       cn,
-                                       const MPI_Comm &      mpi_communicator,
+                                       const MPI_Comm        mpi_communicator,
                                        const AdditionalData &data)
     : SolverBase(cn, mpi_communicator)
     , additional_data(data)
@@ -381,7 +381,7 @@ namespace SLEPcWrappers
 
 
   SolverArnoldi::SolverArnoldi(SolverControl &       cn,
-                               const MPI_Comm &      mpi_communicator,
+                               const MPI_Comm        mpi_communicator,
                                const AdditionalData &data)
     : SolverBase(cn, mpi_communicator)
     , additional_data(data)
@@ -408,7 +408,7 @@ namespace SLEPcWrappers
 
 
   SolverLanczos::SolverLanczos(SolverControl &       cn,
-                               const MPI_Comm &      mpi_communicator,
+                               const MPI_Comm        mpi_communicator,
                                const AdditionalData &data)
     : SolverBase(cn, mpi_communicator)
     , additional_data(data)
@@ -424,7 +424,7 @@ namespace SLEPcWrappers
 
   /* ----------------------- Power ------------------------- */
   SolverPower::SolverPower(SolverControl &       cn,
-                           const MPI_Comm &      mpi_communicator,
+                           const MPI_Comm        mpi_communicator,
                            const AdditionalData &data)
     : SolverBase(cn, mpi_communicator)
     , additional_data(data)
@@ -445,7 +445,7 @@ namespace SLEPcWrappers
 
   SolverGeneralizedDavidson::SolverGeneralizedDavidson(
     SolverControl &       cn,
-    const MPI_Comm &      mpi_communicator,
+    const MPI_Comm        mpi_communicator,
     const AdditionalData &data)
     : SolverBase(cn, mpi_communicator)
     , additional_data(data)
@@ -463,8 +463,8 @@ namespace SLEPcWrappers
 
 
   /* ------------------ Jacobi Davidson -------------------- */
-  SolverJacobiDavidson::SolverJacobiDavidson(SolverControl & cn,
-                                             const MPI_Comm &mpi_communicator,
+  SolverJacobiDavidson::SolverJacobiDavidson(SolverControl &cn,
+                                             const MPI_Comm mpi_communicator,
                                              const AdditionalData &data)
     : SolverBase(cn, mpi_communicator)
     , additional_data(data)
@@ -477,7 +477,7 @@ namespace SLEPcWrappers
 
   /* ---------------------- LAPACK ------------------------- */
   SolverLAPACK::SolverLAPACK(SolverControl &       cn,
-                             const MPI_Comm &      mpi_communicator,
+                             const MPI_Comm        mpi_communicator,
                              const AdditionalData &data)
     : SolverBase(cn, mpi_communicator)
     , additional_data(data)

--- a/source/lac/slepc_spectral_transformation.cc
+++ b/source/lac/slepc_spectral_transformation.cc
@@ -29,7 +29,7 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace SLEPcWrappers
 {
-  TransformationBase::TransformationBase(const MPI_Comm &mpi_communicator)
+  TransformationBase::TransformationBase(const MPI_Comm mpi_communicator)
   {
     const PetscErrorCode ierr = STCreate(mpi_communicator, &st);
     AssertThrow(ierr == 0, SolverBase::ExcSLEPcError(ierr));
@@ -66,7 +66,7 @@ namespace SLEPcWrappers
     : shift_parameter(shift_parameter)
   {}
 
-  TransformationShift::TransformationShift(const MPI_Comm &mpi_communicator,
+  TransformationShift::TransformationShift(const MPI_Comm mpi_communicator,
                                            const AdditionalData &data)
     : TransformationBase(mpi_communicator)
     , additional_data(data)
@@ -86,7 +86,7 @@ namespace SLEPcWrappers
   {}
 
   TransformationShiftInvert::TransformationShiftInvert(
-    const MPI_Comm &      mpi_communicator,
+    const MPI_Comm        mpi_communicator,
     const AdditionalData &data)
     : TransformationBase(mpi_communicator)
     , additional_data(data)
@@ -106,7 +106,7 @@ namespace SLEPcWrappers
   {}
 
   TransformationSpectrumFolding::TransformationSpectrumFolding(
-    const MPI_Comm &      mpi_communicator,
+    const MPI_Comm        mpi_communicator,
     const AdditionalData &data)
     : TransformationBase(mpi_communicator)
     , additional_data(data)
@@ -128,7 +128,7 @@ namespace SLEPcWrappers
     , antishift_parameter(antishift_parameter)
   {}
 
-  TransformationCayley::TransformationCayley(const MPI_Comm &mpi_communicator,
+  TransformationCayley::TransformationCayley(const MPI_Comm mpi_communicator,
                                              const AdditionalData &data)
     : TransformationBase(mpi_communicator)
     , additional_data(data)

--- a/source/lac/sparsity_tools.cc
+++ b/source/lac/sparsity_tools.cc
@@ -914,7 +914,7 @@ namespace SparsityTools
   void
   gather_sparsity_pattern(DynamicSparsityPattern &dsp,
                           const IndexSet &        locally_owned_rows,
-                          const MPI_Comm &        mpi_comm,
+                          const MPI_Comm          mpi_comm,
                           const IndexSet &        locally_relevant_rows)
   {
     using map_vec_t =
@@ -1007,7 +1007,7 @@ namespace SparsityTools
   distribute_sparsity_pattern(
     DynamicSparsityPattern &                              dsp,
     const std::vector<DynamicSparsityPattern::size_type> &rows_per_cpu,
-    const MPI_Comm &                                      mpi_comm,
+    const MPI_Comm                                        mpi_comm,
     const IndexSet &                                      myrange)
   {
     const unsigned int myid = Utilities::MPI::this_mpi_process(mpi_comm);
@@ -1028,7 +1028,7 @@ namespace SparsityTools
   void
   distribute_sparsity_pattern(DynamicSparsityPattern &dsp,
                               const IndexSet &        locally_owned_rows,
-                              const MPI_Comm &        mpi_comm,
+                              const MPI_Comm          mpi_comm,
                               const IndexSet &        locally_relevant_rows)
   {
     IndexSet requested_rows(locally_relevant_rows);
@@ -1095,7 +1095,7 @@ namespace SparsityTools
   void
   distribute_sparsity_pattern(BlockDynamicSparsityPattern &dsp,
                               const std::vector<IndexSet> &owned_set_per_cpu,
-                              const MPI_Comm &             mpi_comm,
+                              const MPI_Comm               mpi_comm,
                               const IndexSet &             myrange)
   {
     const unsigned int myid = Utilities::MPI::this_mpi_process(mpi_comm);
@@ -1110,7 +1110,7 @@ namespace SparsityTools
   void
   distribute_sparsity_pattern(BlockDynamicSparsityPattern &dsp,
                               const IndexSet &             locally_owned_rows,
-                              const MPI_Comm &             mpi_comm,
+                              const MPI_Comm               mpi_comm,
                               const IndexSet &locally_relevant_rows)
   {
     using map_vec_t =

--- a/source/lac/trilinos_block_sparse_matrix.cc
+++ b/source/lac/trilinos_block_sparse_matrix.cc
@@ -73,7 +73,7 @@ namespace TrilinosWrappers
   BlockSparseMatrix::reinit(
     const std::vector<IndexSet> &   parallel_partitioning,
     const BlockSparsityPatternType &block_sparsity_pattern,
-    const MPI_Comm &                communicator,
+    const MPI_Comm                  communicator,
     const bool                      exchange_data)
   {
     std::vector<Epetra_Map> epetra_maps;
@@ -164,7 +164,7 @@ namespace TrilinosWrappers
   BlockSparseMatrix::reinit(
     const std::vector<IndexSet> &              parallel_partitioning,
     const ::dealii::BlockSparseMatrix<double> &dealii_block_sparse_matrix,
-    const MPI_Comm &                           communicator,
+    const MPI_Comm                             communicator,
     const double                               drop_tolerance)
   {
     const size_type n_block_rows = parallel_partitioning.size();
@@ -326,7 +326,7 @@ namespace TrilinosWrappers
   template void
   BlockSparseMatrix::reinit(const std::vector<IndexSet> &,
                             const dealii::BlockDynamicSparsityPattern &,
-                            const MPI_Comm &,
+                            const MPI_Comm,
                             const bool);
 #  endif // DOXYGEN
 

--- a/source/lac/trilinos_block_vector.cc
+++ b/source/lac/trilinos_block_vector.cc
@@ -69,7 +69,7 @@ namespace TrilinosWrappers
 
     void
     BlockVector::reinit(const std::vector<IndexSet> &parallel_partitioning,
-                        const MPI_Comm &             communicator,
+                        const MPI_Comm               communicator,
                         const bool                   omit_zeroing_entries)
     {
       // update the number of blocks
@@ -91,7 +91,7 @@ namespace TrilinosWrappers
     void
     BlockVector::reinit(const std::vector<IndexSet> &parallel_partitioning,
                         const std::vector<IndexSet> &ghost_values,
-                        const MPI_Comm &             communicator,
+                        const MPI_Comm               communicator,
                         const bool                   vector_writable)
     {
       AssertDimension(parallel_partitioning.size(), ghost_values.size());

--- a/source/lac/trilinos_epetra_communication_pattern.cc
+++ b/source/lac/trilinos_epetra_communication_pattern.cc
@@ -32,7 +32,7 @@ namespace LinearAlgebra
     CommunicationPattern::CommunicationPattern(
       const IndexSet &vector_space_vector_index_set,
       const IndexSet &read_write_vector_index_set,
-      const MPI_Comm &communicator)
+      const MPI_Comm  communicator)
     {
       // virtual functions called in constructors and destructors never use the
       // override in a derived class
@@ -47,7 +47,7 @@ namespace LinearAlgebra
     void
     CommunicationPattern::reinit(const IndexSet &vector_space_vector_index_set,
                                  const IndexSet &read_write_vector_index_set,
-                                 const MPI_Comm &communicator)
+                                 const MPI_Comm  communicator)
     {
       comm = std::make_shared<const MPI_Comm>(communicator);
 

--- a/source/lac/trilinos_epetra_vector.cc
+++ b/source/lac/trilinos_epetra_vector.cc
@@ -54,7 +54,7 @@ namespace LinearAlgebra
 
 
     Vector::Vector(const IndexSet &parallel_partitioner,
-                   const MPI_Comm &communicator)
+                   const MPI_Comm  communicator)
       : Subscriptor()
       , vector(new Epetra_FEVector(
           parallel_partitioner.make_trilinos_map(communicator, false)))
@@ -64,7 +64,7 @@ namespace LinearAlgebra
 
     void
     Vector::reinit(const IndexSet &parallel_partitioner,
-                   const MPI_Comm &communicator,
+                   const MPI_Comm  communicator,
                    const bool      omit_zeroing_entries)
     {
       Epetra_Map input_map =
@@ -661,7 +661,7 @@ namespace LinearAlgebra
 
     void
     Vector::create_epetra_comm_pattern(const IndexSet &source_index_set,
-                                       const MPI_Comm &mpi_comm)
+                                       const MPI_Comm  mpi_comm)
     {
       source_stored_elements = source_index_set;
       epetra_comm_pattern =

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -269,7 +269,7 @@ namespace TrilinosWrappers
 
 
   SparseMatrix::SparseMatrix(const IndexSet &   parallel_partitioning,
-                             const MPI_Comm &   communicator,
+                             const MPI_Comm     communicator,
                              const unsigned int n_max_entries_per_row)
     : column_space_map(new Epetra_Map(
         parallel_partitioning.make_trilinos_map(communicator, false)))
@@ -284,7 +284,7 @@ namespace TrilinosWrappers
 
 
   SparseMatrix::SparseMatrix(const IndexSet &parallel_partitioning,
-                             const MPI_Comm &communicator,
+                             const MPI_Comm  communicator,
                              const std::vector<unsigned int> &n_entries_per_row)
     : column_space_map(new Epetra_Map(
         parallel_partitioning.make_trilinos_map(communicator, false)))
@@ -302,7 +302,7 @@ namespace TrilinosWrappers
 
   SparseMatrix::SparseMatrix(const IndexSet &row_parallel_partitioning,
                              const IndexSet &col_parallel_partitioning,
-                             const MPI_Comm &communicator,
+                             const MPI_Comm  communicator,
                              const size_type n_max_entries_per_row)
     : column_space_map(new Epetra_Map(
         col_parallel_partitioning.make_trilinos_map(communicator, false)))
@@ -319,7 +319,7 @@ namespace TrilinosWrappers
 
   SparseMatrix::SparseMatrix(const IndexSet &row_parallel_partitioning,
                              const IndexSet &col_parallel_partitioning,
-                             const MPI_Comm &communicator,
+                             const MPI_Comm  communicator,
                              const std::vector<unsigned int> &n_entries_per_row)
     : column_space_map(new Epetra_Map(
         col_parallel_partitioning.make_trilinos_map(communicator, false)))
@@ -452,7 +452,7 @@ namespace TrilinosWrappers
                   const IndexSet &             column_parallel_partitioning,
                   const SparsityPatternType &  sparsity_pattern,
                   const bool                   exchange_data,
-                  const MPI_Comm &             communicator,
+                  const MPI_Comm               communicator,
                   std::unique_ptr<Epetra_Map> &column_space_map,
                   std::unique_ptr<Epetra_FECrsMatrix> &matrix,
                   std::unique_ptr<Epetra_CrsMatrix> &  nonlocal_matrix,
@@ -605,7 +605,7 @@ namespace TrilinosWrappers
                   const IndexSet &              column_parallel_partitioning,
                   const DynamicSparsityPattern &sparsity_pattern,
                   const bool                    exchange_data,
-                  const MPI_Comm &              communicator,
+                  const MPI_Comm                communicator,
                   std::unique_ptr<Epetra_Map> & column_space_map,
                   std::unique_ptr<Epetra_FECrsMatrix> &matrix,
                   std::unique_ptr<Epetra_CrsMatrix> &  nonlocal_matrix,
@@ -800,7 +800,7 @@ namespace TrilinosWrappers
   SparseMatrix::reinit(const IndexSet &           row_parallel_partitioning,
                        const IndexSet &           col_parallel_partitioning,
                        const SparsityPatternType &sparsity_pattern,
-                       const MPI_Comm &           communicator,
+                       const MPI_Comm             communicator,
                        const bool                 exchange_data)
   {
     reinit_matrix(row_parallel_partitioning,
@@ -877,7 +877,7 @@ namespace TrilinosWrappers
     const IndexSet &                      row_parallel_partitioning,
     const IndexSet &                      col_parallel_partitioning,
     const ::dealii::SparseMatrix<number> &dealii_sparse_matrix,
-    const MPI_Comm &                      communicator,
+    const MPI_Comm                        communicator,
     const double                          drop_tolerance,
     const bool                            copy_values,
     const ::dealii::SparsityPattern *     use_this_sparsity)
@@ -3021,14 +3021,14 @@ namespace TrilinosWrappers
   SparseMatrix::reinit(const IndexSet &,
                        const IndexSet &,
                        const dealii::SparsityPattern &,
-                       const MPI_Comm &,
+                       const MPI_Comm,
                        const bool);
 
   template void
   SparseMatrix::reinit(const IndexSet &,
                        const IndexSet &,
                        const DynamicSparsityPattern &,
-                       const MPI_Comm &,
+                       const MPI_Comm,
                        const bool);
 
   template void

--- a/source/lac/trilinos_sparse_matrix.inst.in
+++ b/source/lac/trilinos_sparse_matrix.inst.in
@@ -28,7 +28,7 @@ for (S : REAL_SCALARS)
       SparseMatrix::reinit(const IndexSet &,
                            const IndexSet &,
                            const dealii::SparseMatrix<S> &,
-                           const MPI_Comm &,
+                           const MPI_Comm,
                            const double,
                            const bool,
                            const dealii::SparsityPattern *);

--- a/source/lac/trilinos_sparsity_pattern.cc
+++ b/source/lac/trilinos_sparsity_pattern.cc
@@ -144,7 +144,7 @@ namespace TrilinosWrappers
 
 
   SparsityPattern::SparsityPattern(const IndexSet &parallel_partitioning,
-                                   const MPI_Comm &communicator,
+                                   const MPI_Comm  communicator,
                                    const size_type n_entries_per_row)
   {
     reinit(parallel_partitioning,
@@ -157,7 +157,7 @@ namespace TrilinosWrappers
 
   SparsityPattern::SparsityPattern(
     const IndexSet &              parallel_partitioning,
-    const MPI_Comm &              communicator,
+    const MPI_Comm                communicator,
     const std::vector<size_type> &n_entries_per_row)
   {
     reinit(parallel_partitioning,
@@ -170,7 +170,7 @@ namespace TrilinosWrappers
 
   SparsityPattern::SparsityPattern(const IndexSet &row_parallel_partitioning,
                                    const IndexSet &col_parallel_partitioning,
-                                   const MPI_Comm &communicator,
+                                   const MPI_Comm  communicator,
                                    const size_type n_entries_per_row)
   {
     reinit(row_parallel_partitioning,
@@ -184,7 +184,7 @@ namespace TrilinosWrappers
   SparsityPattern::SparsityPattern(
     const IndexSet &              row_parallel_partitioning,
     const IndexSet &              col_parallel_partitioning,
-    const MPI_Comm &              communicator,
+    const MPI_Comm                communicator,
     const std::vector<size_type> &n_entries_per_row)
   {
     reinit(row_parallel_partitioning,
@@ -198,7 +198,7 @@ namespace TrilinosWrappers
   SparsityPattern::SparsityPattern(const IndexSet &row_parallel_partitioning,
                                    const IndexSet &col_parallel_partitioning,
                                    const IndexSet &writable_rows,
-                                   const MPI_Comm &communicator,
+                                   const MPI_Comm  communicator,
                                    const size_type n_max_entries_per_row)
   {
     reinit(row_parallel_partitioning,
@@ -480,7 +480,7 @@ namespace TrilinosWrappers
 
   void
   SparsityPattern::reinit(const IndexSet &parallel_partitioning,
-                          const MPI_Comm &communicator,
+                          const MPI_Comm  communicator,
                           const size_type n_entries_per_row)
   {
     SparsityPatternBase::resize(parallel_partitioning.size(),
@@ -495,7 +495,7 @@ namespace TrilinosWrappers
 
   void
   SparsityPattern::reinit(const IndexSet &              parallel_partitioning,
-                          const MPI_Comm &              communicator,
+                          const MPI_Comm                communicator,
                           const std::vector<size_type> &n_entries_per_row)
   {
     SparsityPatternBase::resize(parallel_partitioning.size(),
@@ -511,7 +511,7 @@ namespace TrilinosWrappers
   void
   SparsityPattern::reinit(const IndexSet &row_parallel_partitioning,
                           const IndexSet &col_parallel_partitioning,
-                          const MPI_Comm &communicator,
+                          const MPI_Comm  communicator,
                           const size_type n_entries_per_row)
   {
     SparsityPatternBase::resize(row_parallel_partitioning.size(),
@@ -533,7 +533,7 @@ namespace TrilinosWrappers
   void
   SparsityPattern::reinit(const IndexSet &row_parallel_partitioning,
                           const IndexSet &col_parallel_partitioning,
-                          const MPI_Comm &communicator,
+                          const MPI_Comm  communicator,
                           const std::vector<size_type> &n_entries_per_row)
   {
     SparsityPatternBase::resize(row_parallel_partitioning.size(),
@@ -556,7 +556,7 @@ namespace TrilinosWrappers
   SparsityPattern::reinit(const IndexSet &row_parallel_partitioning,
                           const IndexSet &col_parallel_partitioning,
                           const IndexSet &writable_rows,
-                          const MPI_Comm &communicator,
+                          const MPI_Comm  communicator,
                           const size_type n_entries_per_row)
   {
     SparsityPatternBase::resize(row_parallel_partitioning.size(),
@@ -604,7 +604,7 @@ namespace TrilinosWrappers
     const IndexSet &           row_parallel_partitioning,
     const IndexSet &           col_parallel_partitioning,
     const SparsityPatternType &nontrilinos_sparsity_pattern,
-    const MPI_Comm &           communicator,
+    const MPI_Comm             communicator,
     const bool                 exchange_data)
   {
     SparsityPatternBase::resize(row_parallel_partitioning.size(),
@@ -629,7 +629,7 @@ namespace TrilinosWrappers
   SparsityPattern::reinit(
     const IndexSet &           parallel_partitioning,
     const SparsityPatternType &nontrilinos_sparsity_pattern,
-    const MPI_Comm &           communicator,
+    const MPI_Comm             communicator,
     const bool                 exchange_data)
   {
     AssertDimension(nontrilinos_sparsity_pattern.n_rows(),
@@ -1111,12 +1111,12 @@ namespace TrilinosWrappers
   template void
   SparsityPattern::reinit(const IndexSet &,
                           const dealii::SparsityPattern &,
-                          const MPI_Comm &,
+                          const MPI_Comm,
                           bool);
   template void
   SparsityPattern::reinit(const IndexSet &,
                           const dealii::DynamicSparsityPattern &,
-                          const MPI_Comm &,
+                          const MPI_Comm,
                           bool);
 
 
@@ -1124,13 +1124,13 @@ namespace TrilinosWrappers
   SparsityPattern::reinit(const IndexSet &,
                           const IndexSet &,
                           const dealii::SparsityPattern &,
-                          const MPI_Comm &,
+                          const MPI_Comm,
                           bool);
   template void
   SparsityPattern::reinit(const IndexSet &,
                           const IndexSet &,
                           const dealii::DynamicSparsityPattern &,
-                          const MPI_Comm &,
+                          const MPI_Comm,
                           bool);
 #  endif
 

--- a/source/lac/trilinos_tpetra_communication_pattern.cc
+++ b/source/lac/trilinos_tpetra_communication_pattern.cc
@@ -32,7 +32,7 @@ namespace LinearAlgebra
     CommunicationPattern::CommunicationPattern(
       const IndexSet &vector_space_vector_index_set,
       const IndexSet &read_write_vector_index_set,
-      const MPI_Comm &communicator)
+      const MPI_Comm  communicator)
     {
       // virtual functions called in constructors and destructors never use the
       // override in a derived class
@@ -47,7 +47,7 @@ namespace LinearAlgebra
     void
     CommunicationPattern::reinit(const IndexSet &vector_space_vector_index_set,
                                  const IndexSet &read_write_vector_index_set,
-                                 const MPI_Comm &communicator)
+                                 const MPI_Comm  communicator)
     {
       comm = std::make_shared<const MPI_Comm>(communicator);
 

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -80,7 +80,7 @@ namespace TrilinosWrappers
 
 
     Vector::Vector(const IndexSet &parallel_partitioning,
-                   const MPI_Comm &communicator)
+                   const MPI_Comm  communicator)
       : Vector()
     {
       reinit(parallel_partitioning, communicator);
@@ -110,7 +110,7 @@ namespace TrilinosWrappers
 
     Vector::Vector(const IndexSet &parallel_partitioner,
                    const Vector &  v,
-                   const MPI_Comm &communicator)
+                   const MPI_Comm  communicator)
       : Vector()
     {
       AssertThrow(parallel_partitioner.size() ==
@@ -129,7 +129,7 @@ namespace TrilinosWrappers
 
     Vector::Vector(const IndexSet &local,
                    const IndexSet &ghost,
-                   const MPI_Comm &communicator)
+                   const MPI_Comm  communicator)
       : Vector()
     {
       reinit(local, ghost, communicator, false);
@@ -153,7 +153,7 @@ namespace TrilinosWrappers
 
     void
     Vector::reinit(const IndexSet &parallel_partitioner,
-                   const MPI_Comm &communicator,
+                   const MPI_Comm  communicator,
                    const bool /*omit_zeroing_entries*/)
     {
       nonlocal_vector.reset();
@@ -353,7 +353,7 @@ namespace TrilinosWrappers
     void
     Vector::reinit(const IndexSet &locally_owned_entries,
                    const IndexSet &ghost_entries,
-                   const MPI_Comm &communicator,
+                   const MPI_Comm  communicator,
                    const bool      vector_writable)
     {
       nonlocal_vector.reset();

--- a/source/matrix_free/dof_info.cc
+++ b/source/matrix_free/dof_info.cc
@@ -153,7 +153,7 @@ namespace internal
 
     void
     DoFInfo::assign_ghosts(const std::vector<unsigned int> &boundary_cells,
-                           const MPI_Comm &                 communicator_sm,
+                           const MPI_Comm                   communicator_sm,
                            const bool use_vector_data_exchanger_full)
     {
       Assert(boundary_cells.size() < row_starts.size(), ExcInternalError());
@@ -892,7 +892,7 @@ namespace internal
       const std::vector<FaceToCellTopology<1>> &inner_faces,
       const std::vector<FaceToCellTopology<1>> &ghosted_faces,
       const bool                                fill_cell_centric,
-      const MPI_Comm &                          communicator_sm,
+      const MPI_Comm                            communicator_sm,
       const bool                                use_vector_data_exchanger_full)
     {
       const Utilities::MPI::Partitioner &part = *vector_partitioner;

--- a/source/matrix_free/vector_data_exchange.cc
+++ b/source/matrix_free/vector_data_exchange.cc
@@ -371,7 +371,7 @@ namespace internal
 
       Full::Full(
         const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner,
-        const MPI_Comm &communicator_sm)
+        const MPI_Comm communicator_sm)
         : comm(partitioner->get_mpi_communicator())
         , comm_sm(communicator_sm)
         , n_local_elements(partitioner->locally_owned_range().n_elements())

--- a/source/multigrid/mg_level_global_transfer.cc
+++ b/source/multigrid/mg_level_global_transfer.cc
@@ -165,7 +165,7 @@ namespace
       const MGConstrainedDoFs,
       MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<Number>>>
                                                 mg_constrained_dofs,
-    const MPI_Comm &                            mpi_communicator,
+    const MPI_Comm                              mpi_communicator,
     const bool                                  transfer_solution_vectors,
     std::vector<Table<2, unsigned int>> &       copy_indices,
     std::vector<Table<2, unsigned int>> &       copy_indices_global_mine,

--- a/source/multigrid/mg_transfer_internal.cc
+++ b/source/multigrid/mg_transfer_internal.cc
@@ -400,7 +400,7 @@ namespace internal
       std::vector<types::global_dof_index> &ghosted_level_dofs,
       const std::shared_ptr<const Utilities::MPI::Partitioner>
         &                                                 external_partitioner,
-      const MPI_Comm &                                    communicator,
+      const MPI_Comm                                      communicator,
       std::shared_ptr<const Utilities::MPI::Partitioner> &target_partitioner,
       Table<2, unsigned int> &copy_indices_global_mine)
     {

--- a/source/sundials/arkode.cc
+++ b/source/sundials/arkode.cc
@@ -258,7 +258,7 @@ namespace SUNDIALS
 
   template <typename VectorType>
   ARKode<VectorType>::ARKode(const AdditionalData &data,
-                             const MPI_Comm &      mpi_comm)
+                             const MPI_Comm        mpi_comm)
     : data(data)
     , arkode_mem(nullptr)
 #  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)

--- a/source/sundials/ida.cc
+++ b/source/sundials/ida.cc
@@ -128,7 +128,7 @@ namespace SUNDIALS
 
 
   template <typename VectorType>
-  IDA<VectorType>::IDA(const AdditionalData &data, const MPI_Comm &mpi_comm)
+  IDA<VectorType>::IDA(const AdditionalData &data, const MPI_Comm mpi_comm)
     : data(data)
     , ida_mem(nullptr)
 #  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)

--- a/source/sundials/kinsol.cc
+++ b/source/sundials/kinsol.cc
@@ -303,7 +303,7 @@ namespace SUNDIALS
 
   template <typename VectorType>
   KINSOL<VectorType>::KINSOL(const AdditionalData &data,
-                             const MPI_Comm &      mpi_comm)
+                             const MPI_Comm        mpi_comm)
     : data(data)
     , mpi_communicator(mpi_comm)
     , kinsol_mem(nullptr)

--- a/tests/arpack/parpack_advection_diffusion_petsc.cc
+++ b/tests/arpack/parpack_advection_diffusion_petsc.cc
@@ -113,7 +113,7 @@ class PETScInverse
 public:
   PETScInverse(const dealii::PETScWrappers::MatrixBase &A,
                dealii::SolverControl &                  cn,
-               const MPI_Comm &mpi_communicator = PETSC_COMM_SELF)
+               const MPI_Comm mpi_communicator = PETSC_COMM_SELF)
     : solver(cn)
     , matrix(A)
     , preconditioner(matrix)

--- a/tests/arpack/step-36_parpack.cc
+++ b/tests/arpack/step-36_parpack.cc
@@ -116,7 +116,7 @@ class PETScInverse
 public:
   PETScInverse(const dealii::PETScWrappers::MatrixBase &A,
                dealii::SolverControl &                  cn,
-               const MPI_Comm &mpi_communicator = PETSC_COMM_SELF)
+               const MPI_Comm mpi_communicator = PETSC_COMM_SELF)
     : solver(cn)
     , matrix(A)
     , preconditioner(matrix)

--- a/tests/base/consensus_algorithm_01.cc
+++ b/tests/base/consensus_algorithm_01.cc
@@ -22,7 +22,7 @@
 
 
 void
-test(const MPI_Comm &comm)
+test(const MPI_Comm comm)
 {
   const unsigned int my_rank = dealii::Utilities::MPI::this_mpi_process(comm);
   const unsigned int n_rank  = dealii::Utilities::MPI::n_mpi_processes(comm);

--- a/tests/base/mpi_noncontiguous_partitioner_02.cc
+++ b/tests/base/mpi_noncontiguous_partitioner_02.cc
@@ -33,7 +33,7 @@
 
 template <int dim>
 void
-test(const MPI_Comm &comm, const bool do_revert, const unsigned int dir)
+test(const MPI_Comm comm, const bool do_revert, const unsigned int dir)
 {
   const unsigned int degree           = 2;
   const unsigned int n_refinements    = 2;
@@ -143,7 +143,7 @@ test(const MPI_Comm &comm, const bool do_revert, const unsigned int dir)
 
 template <int dim>
 void
-test_dim(const MPI_Comm &comm, const bool do_revert)
+test_dim(const MPI_Comm comm, const bool do_revert)
 {
   for (int dir = 0; dir < dim; ++dir)
     test<dim>(comm, do_revert, dir);

--- a/tests/distributed_grids/grid_tools_exchange_bounding_boxes_1.cc
+++ b/tests/distributed_grids/grid_tools_exchange_bounding_boxes_1.cc
@@ -31,9 +31,9 @@ test_exchange_bbox()
   // For process i the number of boxes n_bboxes[i%7] is created
   std::vector<unsigned int> n_bboxes = {2, 4, 3, 5, 1, 3, 8};
 
-  const MPI_Comm &mpi_communicator = MPI_COMM_WORLD;
-  unsigned int    n_procs = Utilities::MPI::n_mpi_processes(mpi_communicator);
-  unsigned int    proc    = Utilities::MPI::this_mpi_process(mpi_communicator);
+  const MPI_Comm mpi_communicator = MPI_COMM_WORLD;
+  unsigned int   n_procs = Utilities::MPI::n_mpi_processes(mpi_communicator);
+  unsigned int   proc    = Utilities::MPI::this_mpi_process(mpi_communicator);
 
   deallog << "Test for: dimension " << spacedim << std::endl;
   deallog << n_procs << "  mpi processes" << std::endl;

--- a/tests/distributed_grids/grid_tools_exchange_cell_data_01.cc
+++ b/tests/distributed_grids/grid_tools_exchange_cell_data_01.cc
@@ -34,7 +34,7 @@ template <int dim>
 void
 test()
 {
-  const MPI_Comm &mpi_communicator = MPI_COMM_WORLD;
+  const MPI_Comm mpi_communicator = MPI_COMM_WORLD;
   deallog << "dim = " << dim << std::endl;
 
   parallel::distributed::Triangulation<dim> tria(mpi_communicator);

--- a/tests/distributed_grids/grid_tools_exchange_cell_data_02.cc
+++ b/tests/distributed_grids/grid_tools_exchange_cell_data_02.cc
@@ -38,7 +38,7 @@ template <int dim>
 void
 test()
 {
-  const MPI_Comm &mpi_communicator = MPI_COMM_WORLD;
+  const MPI_Comm mpi_communicator = MPI_COMM_WORLD;
   deallog << "dim = " << dim << std::endl;
 
   parallel::distributed::Triangulation<dim> tria(mpi_communicator);

--- a/tests/distributed_grids/grid_tools_exchange_cell_data_03.cc
+++ b/tests/distributed_grids/grid_tools_exchange_cell_data_03.cc
@@ -35,7 +35,7 @@ template <int dim>
 void
 test()
 {
-  const MPI_Comm &mpi_communicator = MPI_COMM_WORLD;
+  const MPI_Comm mpi_communicator = MPI_COMM_WORLD;
   deallog << "dim = " << dim << std::endl;
 
   parallel::shared::Triangulation<dim> tria(

--- a/tests/distributed_grids/grid_tools_exchange_cell_data_04.cc
+++ b/tests/distributed_grids/grid_tools_exchange_cell_data_04.cc
@@ -38,7 +38,7 @@ template <int dim>
 void
 test()
 {
-  const MPI_Comm &mpi_communicator = MPI_COMM_WORLD;
+  const MPI_Comm mpi_communicator = MPI_COMM_WORLD;
   deallog << "dim = " << dim << std::endl;
 
   parallel::distributed::Triangulation<dim> tria(mpi_communicator);

--- a/tests/fullydistributed_grids/repartitioning_05.cc
+++ b/tests/fullydistributed_grids/repartitioning_05.cc
@@ -39,7 +39,7 @@
 using namespace dealii;
 
 MPI_Comm
-create_sub_comm(const MPI_Comm &comm, const unsigned int size)
+create_sub_comm(const MPI_Comm comm, const unsigned int size)
 {
   const auto rank = Utilities::MPI::this_mpi_process(comm);
 
@@ -64,7 +64,7 @@ create_sub_comm(const MPI_Comm &comm, const unsigned int size)
 template <int dim, int spacedim>
 LinearAlgebra::distributed::Vector<double>
 partition_distributed_triangulation(const Triangulation<dim, spacedim> &tria_in,
-                                    const MPI_Comm &                    comm)
+                                    const MPI_Comm                      comm)
 {
   const auto comm_tria = tria_in.get_communicator();
 

--- a/tests/fullydistributed_grids/repartitioning_08.cc
+++ b/tests/fullydistributed_grids/repartitioning_08.cc
@@ -44,7 +44,7 @@ template <int dim, int spacedim = dim>
 class MyPolicy : public RepartitioningPolicyTools::Base<dim, spacedim>
 {
 public:
-  MyPolicy(const MPI_Comm &comm, const unsigned int direction)
+  MyPolicy(const MPI_Comm comm, const unsigned int direction)
     : comm(comm)
     , direction(direction)
   {}
@@ -74,7 +74,7 @@ public:
   }
 
 private:
-  const MPI_Comm &   comm;
+  const MPI_Comm     comm;
   const unsigned int direction;
 };
 

--- a/tests/gla/gla.h
+++ b/tests/gla/gla.h
@@ -53,18 +53,18 @@ public:
       Vector()
       {}
 
-      Vector(const IndexSet local, const MPI_Comm &comm)
+      Vector(const IndexSet local, const MPI_Comm comm)
       {}
 
-      Vector(const IndexSet &local, const IndexSet &ghost, const MPI_Comm &comm)
-      {}
-
-      void
-      reinit(const IndexSet local, const MPI_Comm &comm)
+      Vector(const IndexSet &local, const IndexSet &ghost, const MPI_Comm comm)
       {}
 
       void
-      reinit(const IndexSet local, const IndexSet &ghost, const MPI_Comm &comm)
+      reinit(const IndexSet local, const MPI_Comm comm)
+      {}
+
+      void
+      reinit(const IndexSet local, const IndexSet &ghost, const MPI_Comm comm)
       {}
 
       void
@@ -124,8 +124,8 @@ public:
       template <typename SP>
       SparseMatrix(const IndexSet &local,
                    const IndexSet &,
-                   SP &            sp,
-                   const MPI_Comm &comm = MPI_COMM_WORLD)
+                   SP &           sp,
+                   const MPI_Comm comm = MPI_COMM_WORLD)
       {}
 
       void

--- a/tests/grid/grid_tools_cache_06.cc
+++ b/tests/grid/grid_tools_cache_06.cc
@@ -40,7 +40,7 @@ template <int dim, int spacedim = dim>
 void
 test(unsigned int ref)
 {
-  const MPI_Comm &mpi_communicator = MPI_COMM_WORLD;
+  const MPI_Comm mpi_communicator = MPI_COMM_WORLD;
 
   parallel::distributed::Triangulation<dim, spacedim> tria(mpi_communicator);
   GridGenerator::hyper_ball(tria);

--- a/tests/grid/grid_tools_cache_07.cc
+++ b/tests/grid/grid_tools_cache_07.cc
@@ -40,7 +40,7 @@ template <int dim, int spacedim = dim>
 void
 test(unsigned int ref)
 {
-  const MPI_Comm &mpi_communicator = MPI_COMM_WORLD;
+  const MPI_Comm mpi_communicator = MPI_COMM_WORLD;
 
   parallel::distributed::Triangulation<dim, spacedim> tria(mpi_communicator);
   GridGenerator::hyper_ball(tria);

--- a/tests/grid/grid_tools_compute_mesh_predicate_bounding_box_1.cc
+++ b/tests/grid/grid_tools_compute_mesh_predicate_bounding_box_1.cc
@@ -47,7 +47,7 @@ template <int dim, int spacedim = dim>
 void
 test_hypercube(unsigned int ref, unsigned int max_bbox)
 {
-  const MPI_Comm &mpi_communicator = MPI_COMM_WORLD;
+  const MPI_Comm mpi_communicator = MPI_COMM_WORLD;
   deallog << "Testing hypercube for spacedim = " << spacedim
           << " refinement: " << ref << " max number of boxes: " << max_bbox
           << std::endl;

--- a/tests/grid/grid_tools_halo_layer_ghost_cells.cc
+++ b/tests/grid/grid_tools_halo_layer_ghost_cells.cc
@@ -30,7 +30,7 @@ template <int dim>
 void
 test()
 {
-  const MPI_Comm &mpi_communicator = MPI_COMM_WORLD;
+  const MPI_Comm mpi_communicator = MPI_COMM_WORLD;
   deallog << "dim = " << dim << std::endl;
 
   parallel::distributed::Triangulation<dim> tria(mpi_communicator);

--- a/tests/hp/solution_transfer_14.cc
+++ b/tests/hp/solution_transfer_14.cc
@@ -44,7 +44,7 @@
 
 template <int dim>
 void
-transfer(const MPI_Comm &mpi_communicator)
+transfer(const MPI_Comm mpi_communicator)
 {
   const unsigned int this_mpi_process =
     Utilities::MPI::this_mpi_process(mpi_communicator);
@@ -111,7 +111,7 @@ main(int argc, char *argv[])
 {
   Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
   MPILogInitAll                    log;
-  const MPI_Comm &                 mpi_communicator = MPI_COMM_WORLD;
+  const MPI_Comm                   mpi_communicator = MPI_COMM_WORLD;
 
   deallog << "   1D solution transfer" << std::endl;
   transfer<1>(mpi_communicator);

--- a/tests/hp/solution_transfer_15.cc
+++ b/tests/hp/solution_transfer_15.cc
@@ -89,7 +89,7 @@ initialize_indexsets(IndexSet &             locally_owned_dofs,
 
 template <int dim>
 void
-transfer(const MPI_Comm &mpi_communicator)
+transfer(const MPI_Comm mpi_communicator)
 {
   const unsigned int this_mpi_process =
     Utilities::MPI::this_mpi_process(mpi_communicator);
@@ -175,7 +175,7 @@ main(int argc, char *argv[])
 {
   Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
   MPILogInitAll                    log;
-  const MPI_Comm &                 mpi_communicator = MPI_COMM_WORLD;
+  const MPI_Comm                   mpi_communicator = MPI_COMM_WORLD;
 
   deallog << "   1D solution transfer" << std::endl;
   transfer<1>(mpi_communicator);

--- a/tests/mpi/muelu_periodicity.cc
+++ b/tests/mpi/muelu_periodicity.cc
@@ -187,7 +187,7 @@ namespace Step22
     InverseMatrix(const Matrix &        m,
                   const Preconditioner &preconditioner,
                   const IndexSet &      locally_owned,
-                  const MPI_Comm &      mpi_communicator);
+                  const MPI_Comm        mpi_communicator);
 
     void
     vmult(TrilinosWrappers::MPI::Vector &      dst,
@@ -207,7 +207,7 @@ namespace Step22
     const Matrix &        m,
     const Preconditioner &preconditioner,
     const IndexSet &      locally_owned,
-    const MPI_Comm &      mpi_communicator)
+    const MPI_Comm        mpi_communicator)
     : matrix(&m)
     , preconditioner(&preconditioner)
     , mpi_communicator(&mpi_communicator)
@@ -245,7 +245,7 @@ namespace Step22
                                         Preconditioner> &      A_inverse,
                     const IndexSet &                           owned_pres,
                     const IndexSet &                           relevant_pres,
-                    const MPI_Comm &mpi_communicator);
+                    const MPI_Comm mpi_communicator);
 
     void
     vmult(TrilinosWrappers::MPI::Vector &      dst,
@@ -268,7 +268,7 @@ namespace Step22
       &             A_inverse,
     const IndexSet &owned_vel,
     const IndexSet &relevant_vel,
-    const MPI_Comm &mpi_communicator)
+    const MPI_Comm  mpi_communicator)
     : system_matrix(&system_matrix)
     , A_inverse(&A_inverse)
     , tmp1(owned_vel, mpi_communicator)

--- a/tests/mpi/periodicity_02.cc
+++ b/tests/mpi/periodicity_02.cc
@@ -189,7 +189,7 @@ namespace Step22
     InverseMatrix(const Matrix &        m,
                   const Preconditioner &preconditioner,
                   const IndexSet &      locally_owned,
-                  const MPI_Comm &      mpi_communicator);
+                  const MPI_Comm        mpi_communicator);
 
     void
     vmult(TrilinosWrappers::MPI::Vector &      dst,
@@ -209,7 +209,7 @@ namespace Step22
     const Matrix &        m,
     const Preconditioner &preconditioner,
     const IndexSet &      locally_owned,
-    const MPI_Comm &      mpi_communicator)
+    const MPI_Comm        mpi_communicator)
     : matrix(&m)
     , preconditioner(&preconditioner)
     , mpi_communicator(&mpi_communicator)
@@ -247,7 +247,7 @@ namespace Step22
                                         Preconditioner> &      A_inverse,
                     const IndexSet &                           owned_pres,
                     const IndexSet &                           relevant_pres,
-                    const MPI_Comm &mpi_communicator);
+                    const MPI_Comm mpi_communicator);
 
     void
     vmult(TrilinosWrappers::MPI::Vector &      dst,
@@ -270,7 +270,7 @@ namespace Step22
       &             A_inverse,
     const IndexSet &owned_vel,
     const IndexSet &relevant_vel,
-    const MPI_Comm &mpi_communicator)
+    const MPI_Comm  mpi_communicator)
     : system_matrix(&system_matrix)
     , A_inverse(&A_inverse)
     , tmp1(owned_vel, mpi_communicator)

--- a/tests/mpi/periodicity_03.cc
+++ b/tests/mpi/periodicity_03.cc
@@ -112,7 +112,7 @@ namespace Step22
     InverseMatrix(const Matrix &        m,
                   const Preconditioner &preconditioner,
                   const IndexSet &      locally_owned,
-                  const MPI_Comm &      mpi_communicator);
+                  const MPI_Comm        mpi_communicator);
 
     void
     vmult(TrilinosWrappers::MPI::Vector &      dst,
@@ -132,7 +132,7 @@ namespace Step22
     const Matrix &        m,
     const Preconditioner &preconditioner,
     const IndexSet &      locally_owned,
-    const MPI_Comm &      mpi_communicator)
+    const MPI_Comm        mpi_communicator)
     : matrix(&m)
     , preconditioner(&preconditioner)
     , mpi_communicator(&mpi_communicator)
@@ -168,7 +168,7 @@ namespace Step22
                     const InverseMatrix<TrilinosWrappers::SparseMatrix,
                                         Preconditioner> &      A_inverse,
                     const IndexSet &                           owned_pres,
-                    const MPI_Comm &mpi_communicator);
+                    const MPI_Comm mpi_communicator);
 
     void
     vmult(TrilinosWrappers::MPI::Vector &      dst,
@@ -190,7 +190,7 @@ namespace Step22
     const InverseMatrix<TrilinosWrappers::SparseMatrix, Preconditioner>
       &             A_inverse,
     const IndexSet &owned_vel,
-    const MPI_Comm &mpi_communicator)
+    const MPI_Comm  mpi_communicator)
     : system_matrix(&system_matrix)
     , A_inverse(&A_inverse)
     , tmp1(owned_vel, mpi_communicator)

--- a/tests/mpi/solution_transfer_02.cc
+++ b/tests/mpi/solution_transfer_02.cc
@@ -44,7 +44,7 @@
 
 template <int dim>
 void
-transfer(const MPI_Comm &mpi_communicator)
+transfer(const MPI_Comm mpi_communicator)
 {
   const unsigned int this_mpi_process =
     Utilities::MPI::this_mpi_process(mpi_communicator);
@@ -108,7 +108,7 @@ main(int argc, char *argv[])
 {
   Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
   MPILogInitAll                    log;
-  const MPI_Comm &                 mpi_communicator = MPI_COMM_WORLD;
+  const MPI_Comm                   mpi_communicator = MPI_COMM_WORLD;
 
   deallog << "   1D solution transfer" << std::endl;
   transfer<1>(mpi_communicator);

--- a/tests/mpi/solution_transfer_03.cc
+++ b/tests/mpi/solution_transfer_03.cc
@@ -88,7 +88,7 @@ initialize_indexsets(IndexSet &             locally_owned_dofs,
 
 template <int dim>
 void
-transfer(const MPI_Comm &mpi_communicator)
+transfer(const MPI_Comm mpi_communicator)
 {
   const unsigned int this_mpi_process =
     Utilities::MPI::this_mpi_process(mpi_communicator);
@@ -169,7 +169,7 @@ main(int argc, char *argv[])
 {
   Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
   MPILogInitAll                    log;
-  const MPI_Comm &                 mpi_communicator = MPI_COMM_WORLD;
+  const MPI_Comm                   mpi_communicator = MPI_COMM_WORLD;
 
   deallog << "   1D solution transfer" << std::endl;
   transfer<1>(mpi_communicator);

--- a/tests/mpi/solution_transfer_06.cc
+++ b/tests/mpi/solution_transfer_06.cc
@@ -46,7 +46,7 @@
 
 template <int dim>
 void
-transfer(const MPI_Comm &comm)
+transfer(const MPI_Comm comm)
 {
   AssertDimension(Utilities::MPI::n_mpi_processes(comm), 1);
 

--- a/tests/multigrid-global-coarsening/global_id_01.cc
+++ b/tests/multigrid-global-coarsening/global_id_01.cc
@@ -37,7 +37,7 @@
 
 template <int dim, int spacedim>
 void
-test(const MPI_Comm &comm)
+test(const MPI_Comm comm)
 {
   Triangulation<dim> basetria;
   GridGenerator::subdivided_hyper_cube(basetria, 4);

--- a/tests/numerics/project_parallel_common.h
+++ b/tests/numerics/project_parallel_common.h
@@ -112,9 +112,9 @@ do_project(const parallel::distributed::Triangulation<dim> &triangulation,
 
   deallog << "n_dofs=" << dof_handler.n_dofs() << std::endl;
 
-  const MPI_Comm &mpi_communicator   = triangulation.get_communicator();
-  const IndexSet  locally_owned_dofs = dof_handler.locally_owned_dofs();
-  IndexSet        locally_relevant_dofs;
+  const MPI_Comm mpi_communicator   = triangulation.get_communicator();
+  const IndexSet locally_owned_dofs = dof_handler.locally_owned_dofs();
+  IndexSet       locally_relevant_dofs;
   DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
 
   AffineConstraints<double> constraints;

--- a/tests/petsc/petsc_noncontiguous_partitioner_02.cc
+++ b/tests/petsc/petsc_noncontiguous_partitioner_02.cc
@@ -35,7 +35,7 @@
 
 template <int dim>
 void
-test(const MPI_Comm &comm, const bool do_revert, const unsigned int dir)
+test(const MPI_Comm comm, const bool do_revert, const unsigned int dir)
 {
   const unsigned int degree           = 2;
   const unsigned int n_refinements    = 2;
@@ -144,7 +144,7 @@ test(const MPI_Comm &comm, const bool do_revert, const unsigned int dir)
 
 template <int dim>
 void
-test_dim(const MPI_Comm &comm, const bool do_revert)
+test_dim(const MPI_Comm comm, const bool do_revert)
 {
   for (int dir = 0; dir < dim; ++dir)
     test<dim>(comm, do_revert, dir);

--- a/tests/simplex/poisson_01.cc
+++ b/tests/simplex/poisson_01.cc
@@ -338,7 +338,7 @@ test(const Triangulation<dim, spacedim> &tria,
 
 template <int dim, int spacedim = dim>
 void
-test_tet(const MPI_Comm &comm, const Parameters<dim> &params)
+test_tet(const MPI_Comm comm, const Parameters<dim> &params)
 {
   const unsigned int tria_type = 2;
 
@@ -425,7 +425,7 @@ test_tet(const MPI_Comm &comm, const Parameters<dim> &params)
 
 template <int dim, int spacedim = dim>
 void
-test_hex(const MPI_Comm &comm, const Parameters<dim> &params)
+test_hex(const MPI_Comm comm, const Parameters<dim> &params)
 {
   // 1) Create triangulation...
   parallel::distributed::Triangulation<dim, spacedim> tria(comm);
@@ -467,7 +467,7 @@ test_hex(const MPI_Comm &comm, const Parameters<dim> &params)
 
 template <int dim, int spacedim = dim>
 void
-test_wedge(const MPI_Comm &comm, const Parameters<dim> &params)
+test_wedge(const MPI_Comm comm, const Parameters<dim> &params)
 {
   const unsigned int tria_type = 2;
 
@@ -558,7 +558,7 @@ test_wedge(const MPI_Comm &comm, const Parameters<dim> &params)
 
 template <int dim, int spacedim = dim>
 void
-test_pyramid(const MPI_Comm &comm, const Parameters<dim> &params)
+test_pyramid(const MPI_Comm comm, const Parameters<dim> &params)
 {
   const unsigned int tria_type = 2;
 

--- a/tests/trilinos/parallel_block_vector_copy_01.cc
+++ b/tests/trilinos/parallel_block_vector_copy_01.cc
@@ -36,7 +36,7 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
   MPILogInitAll                    log;
 
-  const MPI_Comm &   mpi_communicator = MPI_COMM_WORLD;
+  const MPI_Comm     mpi_communicator = MPI_COMM_WORLD;
   const unsigned int this_mpi_process =
     Utilities::MPI::this_mpi_process(mpi_communicator);
   const unsigned int n_mpi_processes =

--- a/tests/zoltan/tria_zoltan_01.cc
+++ b/tests/zoltan/tria_zoltan_01.cc
@@ -29,7 +29,7 @@
 
 template <int dim>
 void
-test(const MPI_Comm &mpi_communicator)
+test(const MPI_Comm mpi_communicator)
 {
   parallel::shared::Triangulation<dim> triangulation(
     mpi_communicator, Triangulation<dim>::limit_level_difference_at_vertices);


### PR DESCRIPTION
Based on the recent discussion to return MPI_Comm by value from respective functions (see #14599 #15086 ), I think it makes sense to treat MPI_Comm as in int-like structure (instead of a class). 

This is consistent with how the MPI standard is defined (int the API MPI_Comm is passed by value). 
OpenMPI defines MPI_Comm to be a pointer: https://github.com/open-mpi/ompi/blob/5d9186207e63625091c292fe6425f3178ce4245d/ompi/include/mpi.h.in#L447
MPICH has it defined as an int:
https://github.com/pmodels/mpich/blob/eb36ab149dacf1870834b1c227f4e516eeec248d/src/include/mpi.h.in#L279