### PR TITLE
Update documentation about CUDA requirements

### DIFF
--- a/doc/external-libs/cuda.html
+++ b/doc/external-libs/cuda.html
@@ -20,10 +20,9 @@
       you need special hardware and compiler to enable CUDA. Because the
       hardware is always evolving, older GPUs do not support all the
       capabilities of newer ones. In order to use CUDA with deal.II, you will
-      need your GPU to have compute capability 3.5 or higher. Independently
+      need your GPU to have compute capability 6.0 or higher. Independently
       from the GPU itself, you also need a version of CUDA recent enough.
-      deal.II supports CUDA 10.2 and higher. Finally to be able to configure
-      deal.II, you will need CMake 3.9 or higher.
+      deal.II supports CUDA 10.2 and higher.
     </p>
 
     <p>


### PR DESCRIPTION
Since https://github.com/dealii/dealii/pull/10298 we are implicitly requiring compute capability 6.0 or higher. `deal.II`'s general `CMake`requirements are now higher than what we needed for CUDA support.