### PR TITLE
Allow using Trilinos 14.0

### DIFF
--- a/cmake/configure/configure_20_trilinos.cmake
+++ b/cmake/configure/configure_20_trilinos.cmake
@@ -355,15 +355,6 @@ macro(feature_trilinos_find_external var)
 
     if(${TRILINOS_WITH_SACADO})
       #
-      # Look for Sacado_config.h - we'll query it to determine C++11 support:
-      #
-      deal_ii_find_file(SACADO_CONFIG_H Sacado_config.h
-        HINTS ${Trilinos_INCLUDE_DIRS}
-        NO_DEFAULT_PATH NO_CMAKE_ENVIRONMENT_PATH NO_CMAKE_PATH
-        NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH NO_CMAKE_FIND_ROOT_PATH
-        )
-
-      #
       # GCC 6.3.0 has a bug that prevents the creation of complex
       # numbers templated on Sacado::Rad::ADvar types:
       #

--- a/cmake/modules/FindDEAL_II_TRILINOS.cmake
+++ b/cmake/modules/FindDEAL_II_TRILINOS.cmake
@@ -32,9 +32,6 @@
 set(TRILINOS_DIR "" CACHE PATH "An optional hint to a Trilinos installation")
 set_if_empty(TRILINOS_DIR "$ENV{TRILINOS_DIR}")
 
-# silence a warning when including FindKOKKOS.cmake
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 #
 # Include the trilinos package configuration:
 #
@@ -51,8 +48,16 @@ find_package(TRILINOS_CONFIG
   NO_SYSTEM_ENVIRONMENT_PATH
   )
 
+set(_target Trilinos::all_libs)
+process_feature(TRILINOS
+  TARGETS REQUIRED _target
+  CLEAR
+    EPETRA_CONFIG_H
+    TRILINOS_CXX_SUPPORTS_SACADO_COMPLEX_RAD
+  )
 
-if(DEFINED Trilinos_VERSION)
+
+if(TRILINOS_FOUND)
   #
   # Extract version numbers:
   #
@@ -66,129 +71,49 @@ if(DEFINED Trilinos_VERSION)
     "^[0-9]+\\.([0-9]+).*$" "\\1"
     TRILINOS_VERSION_MINOR "${Trilinos_VERSION}")
 
-  # If there is no subminor number, 
-  # TRILINOS_VERSION_SUBMINOR is set to an empty string. 
-  # If that is the case, set the subminor number to zero
+  # If there is no subminor number, TRILINOS_VERSION_SUBMINOR is set to an
+  # empty string. If that is the case, set the subminor number to zero
   string(REGEX REPLACE
     "^[0-9]+\\.[0-9]+\\.?(([0-9]+)?).*$" "\\1"
     TRILINOS_VERSION_SUBMINOR "${Trilinos_VERSION}")
   if("${TRILINOS_VERSION_SUBMINOR}" STREQUAL "")
     set(TRILINOS_VERSION_SUBMINOR "0")
   endif()  
-endif()
-
-#
-# Look for Epetra_config.h - we'll query it to determine MPI and 64bit
-# indices support:
-#
-deal_ii_find_file(EPETRA_CONFIG_H Epetra_config.h
-  HINTS ${Trilinos_INCLUDE_DIRS}
-  NO_DEFAULT_PATH NO_CMAKE_ENVIRONMENT_PATH NO_CMAKE_PATH
-  NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH NO_CMAKE_FIND_ROOT_PATH
-  )
-
-if(EXISTS ${EPETRA_CONFIG_H})
-  #
-  # Determine whether Trilinos was configured with MPI and 64bit indices:
-  #
-  file(STRINGS "${EPETRA_CONFIG_H}" EPETRA_MPI_STRING
-    REGEX "^[ \t]*#[ \t]*define[ \t]+HAVE_MPI")
-  if("${EPETRA_MPI_STRING}" STREQUAL "")
-    set(TRILINOS_WITH_MPI FALSE)
-  else()
-    set(TRILINOS_WITH_MPI TRUE)
-  endif()
-  file(STRINGS "${EPETRA_CONFIG_H}" EPETRA_32BIT_STRING
-    REGEX "^[ \t]*#[ \t]*define[ \t]+EPETRA_NO_32BIT_GLOBAL_INDICES")
-  if("${EPETRA_64BIT_STRING}" STREQUAL "")
-    set(TRILINOS_WITH_NO_32BITS_INDICES TRUE)
-  else()
-    set(TRILINOS_WITH_NO_32BITS_INDICES FALSE)
-  endif()
-  file(STRINGS "${EPETRA_CONFIG_H}" EPETRA_64BIT_STRING
-    REGEX "^[ \t]*#[ \t]*define[ \t]+EPETRA_NO_64BIT_GLOBAL_INDICES")
-  if("${EPETRA_64BIT_STRING}" STREQUAL "")
-    set(TRILINOS_WITH_NO_64BITS_INDICES TRUE)
-  else()
-    set(TRILINOS_WITH_NO_64BITS_INDICES FALSE)
-  endif()
-endif()
-
-
-#
-# *Boy* Sanitize variables that are exported by TrilinosConfig.cmake...
-#
-# Especially deduplicate stuff...
-#
-remove_duplicates(Trilinos_LIBRARIES REVERSE)
-remove_duplicates(Trilinos_TPL_LIBRARIES REVERSE)
-
-remove_duplicates(Trilinos_INCLUDE_DIRS)
-string(REGEX REPLACE
-  "(lib64|lib)\\/cmake\\/Trilinos\\/\\.\\.\\/\\.\\.\\/\\.\\.\\/" ""
-  Trilinos_INCLUDE_DIRS "${Trilinos_INCLUDE_DIRS}"
-  )
-
-remove_duplicates(Trilinos_TPL_INCLUDE_DIRS)
-
-if(TARGET Kokkos::kokkos)
-  get_property(KOKKOS_COMPILE_FLAGS_FULL TARGET Kokkos::kokkos PROPERTY INTERFACE_COMPILE_OPTIONS)
-  string(REGEX REPLACE "\\$<\\$<COMPILE_LANGUAGE:CXX>:([^>]*)>" "\\1" KOKKOS_COMPILE_FLAGS "${KOKKOS_COMPILE_FLAGS_FULL}")
-  string(REPLACE ";" " " KOKKOS_COMPILE_FLAGS "${KOKKOS_COMPILE_FLAGS}")
 
   #
-  # Extract missing openmp linker options from the
-  # "INTERFACE_LINK_LIBRARIES" property of the Kokkos::kokkos target:
+  # Look for Epetra_config.h - we'll query it to determine MPI and 64bit
+  # indices support:
   #
-  set(_kokkos_openmp_flags)
-  get_property(_libraries TARGET Kokkos::kokkos PROPERTY INTERFACE_LINK_LIBRARIES)
-  foreach(_entry ${_libraries})
-    if(${_entry} MATCHES "^-f?openmp")
-      add_flags(_kokkos_openmp_flags "${_entry}")
-    endif()
-  endforeach()
-
-  # Some Kokkos versions included in Trilinos before 13.2.0 add "-x cuda" when 
-  # using clang++ as compiler even if Kokkos has not been configured with Cuda
-  # support. Simply strip that flag from what we are using in that case.
-  if(NOT Kokkos_ENABLE_CUDA)
-    string(REPLACE "-x cuda" "" KOKKOS_COMPILE_FLAGS "${KOKKOS_COMPILE_FLAGS}")
-  endif()
-endif()
-
-#
-# We'd like to have the full library names but the Trilinos package only
-# exports a list with short names...
-# So we check again for every lib and store the full path:
-#
-set(_libraries "")
-foreach(_library ${Trilinos_LIBRARIES})
-  list(APPEND _libraries TRILINOS_LIBRARY_${_library})
-  deal_ii_find_library(TRILINOS_LIBRARY_${_library}
-    NAMES ${_library}
-    HINTS ${Trilinos_LIBRARY_DIRS}
-    NO_DEFAULT_PATH
-    NO_CMAKE_ENVIRONMENT_PATH
-    NO_CMAKE_PATH
-    NO_SYSTEM_ENVIRONMENT_PATH
-    NO_CMAKE_SYSTEM_PATH
-    NO_CMAKE_FIND_ROOT_PATH
+  deal_ii_find_file(EPETRA_CONFIG_H Epetra_config.h
+    HINTS ${Trilinos_INCLUDE_DIRS}
+    NO_DEFAULT_PATH NO_CMAKE_ENVIRONMENT_PATH NO_CMAKE_PATH
+    NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH NO_CMAKE_FIND_ROOT_PATH
     )
-endforeach()
 
-process_feature(TRILINOS
-  LIBRARIES
-    REQUIRED ${_libraries}
-    OPTIONAL Trilinos_TPL_LIBRARIES MPI_CXX_LIBRARIES
-  INCLUDE_DIRS
-    REQUIRED Trilinos_INCLUDE_DIRS
-    OPTIONAL Trilinos_TPL_INCLUDE_DIRS
-  CXX_FLAGS
-    OPTIONAL KOKKOS_COMPILE_FLAGS
-  LINKER_FLAGS
-  OPTIONAL Trilinos_EXTRA_LD_FLAGS _kokkos_openmp_flags
-  CLEAR
-    TRILINOS_CONFIG_DIR EPETRA_CONFIG_H SACADO_CMATH_HPP ${_libraries}
-    SACADO_CONFIG_H
-    TRILINOS_CXX_SUPPORTS_SACADO_COMPLEX_RAD
-  )
+  if(EXISTS ${EPETRA_CONFIG_H})
+    #
+    # Determine whether Trilinos was configured with MPI and 64bit indices:
+    #
+    file(STRINGS "${EPETRA_CONFIG_H}" EPETRA_MPI_STRING
+      REGEX "^[ \t]*#[ \t]*define[ \t]+HAVE_MPI")
+    if("${EPETRA_MPI_STRING}" STREQUAL "")
+      set(TRILINOS_WITH_MPI FALSE)
+    else()
+      set(TRILINOS_WITH_MPI TRUE)
+    endif()
+    file(STRINGS "${EPETRA_CONFIG_H}" EPETRA_32BIT_STRING
+      REGEX "^[ \t]*#[ \t]*define[ \t]+EPETRA_NO_32BIT_GLOBAL_INDICES")
+    if("${EPETRA_64BIT_STRING}" STREQUAL "")
+      set(TRILINOS_WITH_NO_32BITS_INDICES TRUE)
+    else()
+      set(TRILINOS_WITH_NO_32BITS_INDICES FALSE)
+    endif()
+    file(STRINGS "${EPETRA_CONFIG_H}" EPETRA_64BIT_STRING
+      REGEX "^[ \t]*#[ \t]*define[ \t]+EPETRA_NO_64BIT_GLOBAL_INDICES")
+    if("${EPETRA_64BIT_STRING}" STREQUAL "")
+      set(TRILINOS_WITH_NO_64BITS_INDICES TRUE)
+    else()
+      set(TRILINOS_WITH_NO_64BITS_INDICES FALSE)
+    endif()
+  endif()
+endif()


### PR DESCRIPTION
`Trilinos 14` uses proper targets also for its libraries (not just library names) so it seems to be necessary to also provide these targets when linking against `deal.II` by refinding `Trilinos` with hardcoded paths.