### PR TITLE
Let KINSOL callbacks conform to our new standard for callback errors.

### DIFF
--- a/doc/doxygen/headers/glossary.h
+++ b/doc/doxygen/headers/glossary.h
@@ -2222,8 +2222,15 @@
  *     [line search algorithms](https://en.wikipedia.org/wiki/Line_search)
  *     where using a shorter step length might actually succeed.) In such
  *     cases, a user-provided callback function should throw an exception
- *     of type RecoverableCallBackError, which will then internally be translated
- *     into an appropriate code understandable by the underlying library.
+ *     of type RecoverableUserCallbackError, which will then internally be
+ *     translated into an appropriate code understandable by the underlying
+ *     library. It is worthwhile pointing out that a user callback throwing
+ *     a "recoverable" exception does not actually guarantee that the
+ *     underlying library can actually recover: For example, KINSOL will
+ *     eventually give up if for several shorter and shorter step lengths
+ *     the residual computation throws a "recoverable" exception, and
+ *     the nonlinear solver will then return to user space with an error
+ *     that the deal.II wrappers translate into an exception.
  *
  *   The purpose of these conventions is to provide a unified approach to user
  *   callbacks that is independent of how the underlying library likes to

--- a/doc/news/changes/major/20230508Bangerth
+++ b/doc/news/changes/major/20230508Bangerth
@@ -1,0 +1,15 @@
+Changed: Several parts of the library involve interfacing with
+external libraries by way of user-defined callback functions. Specific
+examples are the interfaces to the SUNDIALS solvers (e.g., the
+SUNDIALS::KINSOL class). These interfaces typically required using the
+convention for error reporting defined by the underlying library -- in
+the case of SUNDIALS, for example, callbacks needed to return zero in
+case of success, a negative value for an irrecoverable error, and a
+positive value for a recoverable error.
+
+This approach does not scale across the many interfaces we have. As a
+consequence, we standardized how callbacks should behave, as
+documented in @ref GlossUserProvidedCallBack "this glossary entry". 
+The interfaces in SUNDIALS::KINSOL have been changed correspondingly.
+<br>
+(Wolfgang Bangerth, 2023/05/08)

--- a/examples/step-77/step-77.cc
+++ b/examples/step-77/step-77.cc
@@ -572,10 +572,8 @@ namespace Step77
           // the SUNDIALS::KINSOL class that are of type `std::function`, i.e.,
           // they are objects to which we can assign a pointer to a function or,
           // as we do here, a "lambda function" that takes the appropriate
-          // arguments and returns the appropriate information. By convention,
-          // KINSOL wants that functions doing something nontrivial return an
-          // integer where zero indicates success. It turns out that we can do
-          // all of this in just 25 lines of code.
+          // arguments and returns the appropriate information. It turns out
+          // that we can do all of this in just over 20 lines of code.
           //
           // (If you're not familiar what "lambda functions" are, take
           // a look at step-12 or at the
@@ -603,24 +601,18 @@ namespace Step77
             [&](const Vector<double> &evaluation_point,
                 Vector<double> &      residual) {
               compute_residual(evaluation_point, residual);
-
-              return 0;
             };
 
           nonlinear_solver.setup_jacobian =
             [&](const Vector<double> &current_u,
                 const Vector<double> & /*current_f*/) {
               compute_and_factorize_jacobian(current_u);
-
-              return 0;
             };
 
           nonlinear_solver.solve_with_jacobian = [&](const Vector<double> &rhs,
                                                      Vector<double> &      dst,
                                                      const double tolerance) {
             this->solve(rhs, dst, tolerance);
-
-            return 0;
           };
 
           nonlinear_solver.solve(current_solution);

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1272,6 +1272,19 @@ namespace StandardExceptions
     const int error_code;
   };
 #endif // DEAL_II_TRILINOS_WITH_SEACAS
+
+  /**
+   * An exception to be thrown in user call-backs. See the glossary entry
+   * on user call-back functions for more information.
+   */
+  DeclExceptionMsg(
+    RecoverableUserCallbackError,
+    "A user call-back function encountered a recoverable error, "
+    "but the underlying library that called the call-back did not "
+    "manage to recover from the error and aborted its operation."
+    "\n\n"
+    "See the glossary entry on user call-back functions for more "
+    "information.");
 } /*namespace StandardExceptions*/
 
 

--- a/include/deal.II/sundials/kinsol.h
+++ b/include/deal.II/sundials/kinsol.h
@@ -699,14 +699,6 @@ namespace SUNDIALS
                    << "returned a negative error code: " << arg1
                    << ". Please consult SUNDIALS manual.");
 
-
-    /**
-     * A pointer to any exception that may have been thrown in user-defined
-     * call-backs and that we have to deal after the KINSOL function we call
-     * has returned.
-     */
-    mutable std::exception_ptr pending_exception;
-
   private:
     /**
      * Throw an exception when a function with the given name is not
@@ -766,6 +758,13 @@ namespace SUNDIALS
      * Memory pool of vectors.
      */
     GrowingVectorMemory<VectorType> mem;
+
+    /**
+     * A pointer to any exception that may have been thrown in user-defined
+     * call-backs and that we have to deal after the KINSOL function we call
+     * has returned.
+     */
+    mutable std::exception_ptr pending_exception;
   };
 
 } // namespace SUNDIALS

--- a/include/deal.II/sundials/kinsol.h
+++ b/include/deal.II/sundials/kinsol.h
@@ -38,6 +38,7 @@
 #  include <sundials/sundials_math.h>
 #  include <sundials/sundials_types.h>
 
+#  include <exception>
 #  include <memory>
 
 
@@ -430,7 +431,7 @@ namespace SUNDIALS
      * - <0: Unrecoverable error the computation will be aborted and an
      * assertion will be thrown.
      */
-    std::function<int(const VectorType &src, VectorType &dst)> residual;
+    std::function<void(const VectorType &src, VectorType &dst)> residual;
 
     /**
      * A function object that users should supply and that is intended to
@@ -445,7 +446,7 @@ namespace SUNDIALS
      * - <0: Unrecoverable error; the computation will be aborted and an
      * assertion will be thrown.
      */
-    std::function<int(const VectorType &src, VectorType &dst)>
+    std::function<void(const VectorType &src, VectorType &dst)>
       iteration_function;
 
     /**
@@ -493,7 +494,8 @@ namespace SUNDIALS
      * - <0: Unrecoverable error the computation will be aborted and an
      * assertion will be thrown.
      */
-    std::function<int(const VectorType &current_u, const VectorType &current_f)>
+    std::function<void(const VectorType &current_u,
+                       const VectorType &current_f)>
       setup_jacobian;
 
     /**
@@ -555,10 +557,10 @@ namespace SUNDIALS
      *   that the Jacobian should be re-computed in every iteration.
      */
     DEAL_II_DEPRECATED
-    std::function<int(const VectorType &ycur,
-                      const VectorType &fcur,
-                      const VectorType &rhs,
-                      VectorType &      dst)>
+    std::function<void(const VectorType &ycur,
+                       const VectorType &fcur,
+                       const VectorType &rhs,
+                       VectorType &      dst)>
       solve_jacobian_system;
 
     /**
@@ -601,7 +603,7 @@ namespace SUNDIALS
      * assertion will be thrown.
      */
     std::function<
-      int(const VectorType &rhs, VectorType &dst, const double tolerance)>
+      void(const VectorType &rhs, VectorType &dst, const double tolerance)>
       solve_with_jacobian;
 
     /**
@@ -669,6 +671,13 @@ namespace SUNDIALS
                    << "returned a negative error code: " << arg1
                    << ". Please consult SUNDIALS manual.");
 
+
+    /**
+     * A pointer to any exception that may have been thrown in user-defined
+     * call-backs and that we have to deal after the KINSOL function we call
+     * has returned.
+     */
+    mutable std::exception_ptr pending_exception;
 
   private:
     /**

--- a/include/deal.II/sundials/kinsol.h
+++ b/include/deal.II/sundials/kinsol.h
@@ -415,6 +415,13 @@ namespace SUNDIALS
      * block vectors are used), and MPI communicator (if the vector is
      * distributed across multiple processors using MPI), along with any
      * other properties necessary.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, KINSOL can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
      */
     std::function<void(VectorType &)> reinit_vector;
 
@@ -424,12 +431,12 @@ namespace SUNDIALS
      * SolutionStrategy::newton, SolutionStrategy::linesearch, or
      * SolutionStrategy::picard strategies were selected.
      *
-     * This function should return:
-     * - 0: Success
-     * - >0: Recoverable error (KINSOL will try to change its internal
-     * parameters and attempt a new solution step)
-     * - <0: Unrecoverable error the computation will be aborted and an
-     * assertion will be thrown.
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, KINSOL can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
      */
     std::function<void(const VectorType &src, VectorType &dst)> residual;
 
@@ -439,12 +446,12 @@ namespace SUNDIALS
      * iteration. This function is only used if the
      * SolutionStrategy::fixed_point strategy is selected.
      *
-     * This function should return:
-     * - 0: Success
-     * - >0: Recoverable error (KINSOL will try to change its internal
-     * parameters and attempt a new solution step)
-     * - <0: Unrecoverable error; the computation will be aborted and an
-     * assertion will be thrown.
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, KINSOL can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
      */
     std::function<void(const VectorType &src, VectorType &dst)>
       iteration_function;
@@ -487,12 +494,12 @@ namespace SUNDIALS
      * @param current_u Current value of $u$
      * @param current_f Current value of $F(u)$ or $G(u)$
      *
-     * This function should return:
-     * - 0: Success
-     * - >0: Recoverable error (KINSOL will try to change its internal
-     * parameters and attempt a new solution step)
-     * - <0: Unrecoverable error the computation will be aborted and an
-     * assertion will be thrown.
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, KINSOL can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
      */
     std::function<void(const VectorType &current_u,
                        const VectorType &current_f)>
@@ -555,6 +562,13 @@ namespace SUNDIALS
      *   to a *previous* iterate), then you will also have to set the
      *   AdditionalData::maximum_newton_step variable to one, indicating
      *   that the Jacobian should be re-computed in every iteration.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, KINSOL can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
      */
     DEAL_II_DEPRECATED
     std::function<void(const VectorType &ycur,
@@ -595,12 +609,12 @@ namespace SUNDIALS
      * @param[in] tolerance The tolerance with which to solve the linear system
      *   of equations.
      *
-     * This function should return:
-     * - 0: Success
-     * - >0: Recoverable error (KINSOL will try to change its internal
-     * parameters and attempt a new solution step)
-     * - <0: Unrecoverable error the computation will be aborted and an
-     * assertion will be thrown.
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, KINSOL can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
      */
     std::function<
       void(const VectorType &rhs, VectorType &dst, const double tolerance)>
@@ -643,6 +657,13 @@ namespace SUNDIALS
      * If no function is provided to a KINSOL object, then this is interpreted
      * as implicitly saying that all of these scaling factors should be
      * considered as one.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, KINSOL can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
      */
     std::function<VectorType &()> get_solution_scaling;
 
@@ -659,6 +680,13 @@ namespace SUNDIALS
      * than the components of $U$, when computing norms. As above, if no
      * function is provided, then this is equivalent to using a scaling vector
      * whose components are all equal to one.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, KINSOL can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
      */
     std::function<VectorType &()> get_function_scaling;
 

--- a/source/sundials/kinsol.cc
+++ b/source/sundials/kinsol.cc
@@ -217,14 +217,10 @@ namespace SUNDIALS
 
       internal::copy(*src_yy, yy);
 
-      int err = 0;
-      if (solver.residual)
-        err = call_and_possibly_capture_exception(solver.residual,
-                                                  solver.pending_exception,
-                                                  *src_yy,
-                                                  *dst_FF);
-      else
-        Assert(false, ExcInternalError());
+      Assert(solver.residual, ExcInternalError());
+
+      const int err = call_and_possibly_capture_exception(
+        solver.residual, solver.pending_exception, *src_yy, *dst_FF);
 
       internal::copy(FF, *dst_FF);
 
@@ -249,14 +245,10 @@ namespace SUNDIALS
 
       internal::copy(*src_yy, yy);
 
-      int err = 0;
-      if (solver.iteration_function)
-        err = call_and_possibly_capture_exception(solver.iteration_function,
-                                                  solver.pending_exception,
-                                                  *src_yy,
-                                                  *dst_FF);
-      else
-        Assert(false, ExcInternalError());
+      Assert(solver.iteration_function, ExcInternalError());
+
+      const int err = call_and_possibly_capture_exception(
+        solver.iteration_function, solver.pending_exception, *src_yy, *dst_FF);
 
       internal::copy(FF, *dst_FF);
 

--- a/tests/sundials/kinsol_01.cc
+++ b/tests/sundials/kinsol_01.cc
@@ -61,7 +61,7 @@ main()
   kinsol.reinit_vector = [N](VectorType &v) { v.reinit(N); };
 
   // Robert example
-  kinsol.iteration_function = [](const VectorType &u, VectorType &F) -> int {
+  kinsol.iteration_function = [](const VectorType &u, VectorType &F) {
     const double dstep = 0.1;
     const double y10   = 1.0;
     const double y20   = 0.0;
@@ -73,8 +73,6 @@ main()
     F[0] = yd1 + y10;
     F[1] = -yd1 - yd3 + y20;
     F[2] = yd3 + y30;
-
-    return 0;
   };
 
   VectorType v(N);

--- a/tests/sundials/kinsol_02.cc
+++ b/tests/sundials/kinsol_02.cc
@@ -63,27 +63,20 @@ main()
 
   kinsol.reinit_vector = [N](VectorType &v) { v.reinit(N); };
 
-  kinsol.residual = [&](const VectorType &u, VectorType &F) -> int {
+  kinsol.residual = [&](const VectorType &u, VectorType &F) {
     F = u;
 
     F[0] += .1 * u[0] * u[0] - 1;
     F[1] += .1 * u[1] * u[1] - 2;
-    return 0;
   };
 
   kinsol.solve_with_jacobian =
-    [&](const VectorType &rhs, VectorType &dst, double) -> int {
-    dst = rhs;
-    return 0;
-  };
+    [&](const VectorType &rhs, VectorType &dst, double) { dst = rhs; };
 
   kinsol.solve_jacobian_system = [&](const VectorType &,
                                      const VectorType &,
                                      const VectorType &rhs,
-                                     VectorType &      dst) -> int {
-    dst = rhs;
-    return 0;
-  };
+                                     VectorType &      dst) { dst = rhs; };
 
   VectorType v(N);
 

--- a/tests/sundials/kinsol_03.cc
+++ b/tests/sundials/kinsol_03.cc
@@ -65,17 +65,16 @@ main()
 
   kinsol.reinit_vector = [N](VectorType &v) { v.reinit(N); };
 
-  kinsol.residual = [](const VectorType &u, VectorType &F) -> int {
+  kinsol.residual = [](const VectorType &u, VectorType &F) {
     deallog << "Evaluating the solution at u=(" << u[0] << ',' << u[1] << ')'
             << std::endl;
 
     F(0) = std::cos(u[0] + u[1]) - 1 + 2 * u[0];
     F(1) = std::sin(u[0] - u[1]) + 2 * u[1];
-    return 0;
   };
 
 
-  kinsol.iteration_function = [](const VectorType &u, VectorType &F) -> int {
+  kinsol.iteration_function = [](const VectorType &u, VectorType &F) {
     // We want a Newton-type scheme, not a fixed point iteration. So we
     // shouldn't get into this function.
     std::abort();
@@ -83,23 +82,21 @@ main()
     // But if anyone wanted to see how it would look like:
     F(0) = std::cos(u[0] + u[1]) - 1 + 2 * u[0] - u[0];
     F(1) = std::sin(u[0] - u[1]) + 2 * u[1] - u[1];
-    return 0;
   };
 
 
-  kinsol.setup_jacobian = [](const VectorType &u, const VectorType &F) -> int {
+  kinsol.setup_jacobian = [](const VectorType &u, const VectorType &F) {
     // We don't do any kind of set-up in this program, but we can at least
     // say that we're here
     deallog << "Setting up Jacobian system at u=(" << u[0] << ',' << u[1] << ')'
             << std::endl;
-    return 0;
   };
 
 
   kinsol.solve_jacobian_system = [](const VectorType &,
                                     const VectorType &,
                                     const VectorType &rhs,
-                                    VectorType &      dst) -> int {
+                                    VectorType &      dst) {
     deallog << "Solving Jacobian system with rhs=(" << rhs[0] << ',' << rhs[1]
             << ')' << std::endl;
 
@@ -120,8 +117,6 @@ main()
     J_inverse.invert(J);
 
     J_inverse.vmult(dst, rhs);
-
-    return 0;
   };
 
   VectorType v(N);

--- a/tests/sundials/kinsol_03_new_interface.cc
+++ b/tests/sundials/kinsol_03_new_interface.cc
@@ -65,17 +65,16 @@ main()
 
   kinsol.reinit_vector = [N](VectorType &v) { v.reinit(N); };
 
-  kinsol.residual = [](const VectorType &u, VectorType &F) -> int {
+  kinsol.residual = [](const VectorType &u, VectorType &F) {
     deallog << "Evaluating the solution at u=(" << u[0] << ',' << u[1] << ')'
             << std::endl;
 
     F(0) = std::cos(u[0] + u[1]) - 1 + 2 * u[0];
     F(1) = std::sin(u[0] - u[1]) + 2 * u[1];
-    return 0;
   };
 
 
-  kinsol.iteration_function = [](const VectorType &u, VectorType &F) -> int {
+  kinsol.iteration_function = [](const VectorType &u, VectorType &F) {
     // We want a Newton-type scheme, not a fixed point iteration. So we
     // shouldn't get into this function.
     std::abort();
@@ -83,45 +82,40 @@ main()
     // But if anyone wanted to see how it would look like:
     F(0) = std::cos(u[0] + u[1]) - 1 + 2 * u[0] - u[0];
     F(1) = std::sin(u[0] - u[1]) + 2 * u[1] - u[1];
-    return 0;
   };
 
 
-  kinsol.setup_jacobian = [](const VectorType &u, const VectorType &F) -> int {
+  kinsol.setup_jacobian = [](const VectorType &u, const VectorType &F) {
     // We don't do any kind of set-up in this program, but we can at least
     // say that we're here
     deallog << "Setting up Jacobian system at u=(" << u[0] << ',' << u[1] << ')'
             << std::endl;
-    return 0;
   };
 
 
-  kinsol.solve_with_jacobian = [](const VectorType &rhs,
-                                  VectorType &      dst,
-                                  const double /*tolerance*/) -> int {
-    deallog << "Solving Jacobian system with rhs=(" << rhs[0] << ',' << rhs[1]
-            << ')' << std::endl;
+  kinsol.solve_with_jacobian =
+    [](const VectorType &rhs, VectorType &dst, const double /*tolerance*/) {
+      deallog << "Solving Jacobian system with rhs=(" << rhs[0] << ',' << rhs[1]
+              << ')' << std::endl;
 
-    // This isn't right for SUNDIALS >4.0: We don't actually get a valid
-    // 'u' vector, and so do the linearization of the problem around
-    // the zero vector. This *happens* to converge, but it isn't the
-    // right approach. Check the _04 test for a better approach.
-    VectorType u(2);
-    u[0] = u[1] = 0;
+      // This isn't right for SUNDIALS >4.0: We don't actually get a valid
+      // 'u' vector, and so do the linearization of the problem around
+      // the zero vector. This *happens* to converge, but it isn't the
+      // right approach. Check the _04 test for a better approach.
+      VectorType u(2);
+      u[0] = u[1] = 0;
 
-    FullMatrix<double> J(2, 2);
-    J(0, 0) = -std::sin(u[0] + u[1]) + 2;
-    J(0, 1) = -std::sin(u[0] + u[1]);
-    J(1, 0) = std::cos(u[0] - u[1]);
-    J(1, 1) = -std::cos(u[0] - u[1]) + 2;
+      FullMatrix<double> J(2, 2);
+      J(0, 0) = -std::sin(u[0] + u[1]) + 2;
+      J(0, 1) = -std::sin(u[0] + u[1]);
+      J(1, 0) = std::cos(u[0] - u[1]);
+      J(1, 1) = -std::cos(u[0] - u[1]) + 2;
 
-    FullMatrix<double> J_inverse(2, 2);
-    J_inverse.invert(J);
+      FullMatrix<double> J_inverse(2, 2);
+      J_inverse.invert(J);
 
-    J_inverse.vmult(dst, rhs);
-
-    return 0;
-  };
+      J_inverse.vmult(dst, rhs);
+    };
 
   VectorType v(N);
   v(0) = 0.5;

--- a/tests/sundials/kinsol_04.cc
+++ b/tests/sundials/kinsol_04.cc
@@ -77,17 +77,16 @@ main()
 
   kinsol.reinit_vector = [N](VectorType &v) { v.reinit(N); };
 
-  kinsol.residual = [](const VectorType &u, VectorType &F) -> int {
+  kinsol.residual = [](const VectorType &u, VectorType &F) {
     deallog << "Evaluating the solution at u=(" << u[0] << ',' << u[1] << ')'
             << std::endl;
 
     F(0) = std::cos(u[0] + u[1]) - 1 + 2 * u[0];
     F(1) = std::sin(u[0] - u[1]) + 2 * u[1];
-    return 0;
   };
 
 
-  kinsol.iteration_function = [](const VectorType &u, VectorType &F) -> int {
+  kinsol.iteration_function = [](const VectorType &u, VectorType &F) {
     // We want a Newton-type scheme, not a fixed point iteration. So we
     // shouldn't get into this function.
     std::abort();
@@ -95,13 +94,12 @@ main()
     // But if anyone wanted to see how it would look like:
     F(0) = std::cos(u[0] + u[1]) - 1 + 2 * u[0] - u[0];
     F(1) = std::sin(u[0] - u[1]) + 2 * u[1] - u[1];
-    return 0;
   };
 
   FullMatrix<double> J_inverse(2, 2);
 
   kinsol.setup_jacobian = [&J_inverse](const VectorType &u,
-                                       const VectorType &F) -> int {
+                                       const VectorType &F) {
     deallog << "Setting up Jacobian system at u=(" << u[0] << ',' << u[1] << ')'
             << std::endl;
 
@@ -112,21 +110,17 @@ main()
     J(1, 1) = -std::cos(u[0] - u[1]) + 2;
 
     J_inverse.invert(J);
-
-    return 0;
   };
 
 
   kinsol.solve_jacobian_system = [&J_inverse](const VectorType &u,
                                               const VectorType &,
                                               const VectorType &rhs,
-                                              VectorType &      dst) -> int {
+                                              VectorType &      dst) {
     deallog << "Solving Jacobian system with rhs=(" << rhs[0] << ',' << rhs[1]
             << ')' << std::endl;
 
     J_inverse.vmult(dst, rhs);
-
-    return 0;
   };
 
   VectorType v(N);

--- a/tests/sundials/kinsol_04_new_interface.cc
+++ b/tests/sundials/kinsol_04_new_interface.cc
@@ -77,17 +77,16 @@ main()
 
   kinsol.reinit_vector = [N](VectorType &v) { v.reinit(N); };
 
-  kinsol.residual = [](const VectorType &u, VectorType &F) -> int {
+  kinsol.residual = [](const VectorType &u, VectorType &F) {
     deallog << "Evaluating the solution at u=(" << u[0] << ',' << u[1] << ')'
             << std::endl;
 
     F(0) = std::cos(u[0] + u[1]) - 1 + 2 * u[0];
     F(1) = std::sin(u[0] - u[1]) + 2 * u[1];
-    return 0;
   };
 
 
-  kinsol.iteration_function = [](const VectorType &u, VectorType &F) -> int {
+  kinsol.iteration_function = [](const VectorType &u, VectorType &F) {
     // We want a Newton-type scheme, not a fixed point iteration. So we
     // shouldn't get into this function.
     std::abort();
@@ -95,13 +94,12 @@ main()
     // But if anyone wanted to see how it would look like:
     F(0) = std::cos(u[0] + u[1]) - 1 + 2 * u[0] - u[0];
     F(1) = std::sin(u[0] - u[1]) + 2 * u[1] - u[1];
-    return 0;
   };
 
   FullMatrix<double> J_inverse(2, 2);
 
   kinsol.setup_jacobian = [&J_inverse](const VectorType &u,
-                                       const VectorType &F) -> int {
+                                       const VectorType &F) {
     deallog << "Setting up Jacobian system at u=(" << u[0] << ',' << u[1] << ')'
             << std::endl;
 
@@ -112,20 +110,16 @@ main()
     J(1, 1) = -std::cos(u[0] - u[1]) + 2;
 
     J_inverse.invert(J);
-
-    return 0;
   };
 
 
   kinsol.solve_with_jacobian = [&J_inverse](const VectorType &rhs,
                                             VectorType &      dst,
-                                            const double /*tolerance*/) -> int {
+                                            const double /*tolerance*/) {
     deallog << "Solving Jacobian system with rhs=(" << rhs[0] << ',' << rhs[1]
             << ')' << std::endl;
 
     J_inverse.vmult(dst, rhs);
-
-    return 0;
   };
 
   VectorType v(N);

--- a/tests/sundials/kinsol_05.cc
+++ b/tests/sundials/kinsol_05.cc
@@ -75,17 +75,16 @@ main()
 
   kinsol.reinit_vector = [N](VectorType &v) { v.reinit(N); };
 
-  kinsol.residual = [](const VectorType &u, VectorType &F) -> int {
+  kinsol.residual = [](const VectorType &u, VectorType &F) {
     deallog << "Evaluating the solution at u=(" << u[0] << ',' << u[1] << ')'
             << std::endl;
 
     F(0) = std::cos(u[0] + u[1]) - 1 + 2 * u[0];
     F(1) = std::sin(u[0] - u[1]) + 2 * u[1];
-    return 0;
   };
 
 
-  kinsol.iteration_function = [](const VectorType &u, VectorType &F) -> int {
+  kinsol.iteration_function = [](const VectorType &u, VectorType &F) {
     // We want a Newton-type scheme, not a fixed point iteration. So we
     // shouldn't get into this function.
     std::abort();
@@ -93,13 +92,12 @@ main()
     // But if anyone wanted to see how it would look like:
     F(0) = std::cos(u[0] + u[1]) - 1 + 2 * u[0] - u[0];
     F(1) = std::sin(u[0] - u[1]) + 2 * u[1] - u[1];
-    return 0;
   };
 
   FullMatrix<double> J_inverse(2, 2);
 
   kinsol.setup_jacobian = [&J_inverse](const VectorType &u,
-                                       const VectorType &F) -> int {
+                                       const VectorType &F) {
     // We don't do any kind of set-up in this program, but we can at least
     // say that we're here
     deallog << "Setting up Jacobian system at u=(" << u[0] << ',' << u[1] << ')'
@@ -112,21 +110,17 @@ main()
     J(1, 1) = -std::cos(u[0] - u[1]) + 2;
 
     J_inverse.invert(J);
-
-    return 0;
   };
 
 
   kinsol.solve_jacobian_system = [&J_inverse](const VectorType &u,
                                               const VectorType &,
                                               const VectorType &rhs,
-                                              VectorType &      dst) -> int {
+                                              VectorType &      dst) {
     deallog << "Solving Jacobian system with rhs=(" << rhs[0] << ',' << rhs[1]
             << ')' << std::endl;
 
     J_inverse.vmult(dst, rhs);
-
-    return 0;
   };
 
   VectorType v(N);

--- a/tests/sundials/kinsol_05_new_interface.cc
+++ b/tests/sundials/kinsol_05_new_interface.cc
@@ -75,17 +75,16 @@ main()
 
   kinsol.reinit_vector = [N](VectorType &v) { v.reinit(N); };
 
-  kinsol.residual = [](const VectorType &u, VectorType &F) -> int {
+  kinsol.residual = [](const VectorType &u, VectorType &F) {
     deallog << "Evaluating the solution at u=(" << u[0] << ',' << u[1] << ')'
             << std::endl;
 
     F(0) = std::cos(u[0] + u[1]) - 1 + 2 * u[0];
     F(1) = std::sin(u[0] - u[1]) + 2 * u[1];
-    return 0;
   };
 
 
-  kinsol.iteration_function = [](const VectorType &u, VectorType &F) -> int {
+  kinsol.iteration_function = [](const VectorType &u, VectorType &F) {
     // We want a Newton-type scheme, not a fixed point iteration. So we
     // shouldn't get into this function.
     std::abort();
@@ -93,13 +92,12 @@ main()
     // But if anyone wanted to see how it would look like:
     F(0) = std::cos(u[0] + u[1]) - 1 + 2 * u[0] - u[0];
     F(1) = std::sin(u[0] - u[1]) + 2 * u[1] - u[1];
-    return 0;
   };
 
   FullMatrix<double> J_inverse(2, 2);
 
   kinsol.setup_jacobian = [&J_inverse](const VectorType &u,
-                                       const VectorType &F) -> int {
+                                       const VectorType &F) {
     // We don't do any kind of set-up in this program, but we can at least
     // say that we're here
     deallog << "Setting up Jacobian system at u=(" << u[0] << ',' << u[1] << ')'
@@ -112,20 +110,16 @@ main()
     J(1, 1) = -std::cos(u[0] - u[1]) + 2;
 
     J_inverse.invert(J);
-
-    return 0;
   };
 
 
   kinsol.solve_with_jacobian = [&J_inverse](const VectorType &rhs,
                                             VectorType &      dst,
-                                            const double /*tolerance*/) -> int {
+                                            const double /*tolerance*/) {
     deallog << "Solving Jacobian system with rhs=(" << rhs[0] << ',' << rhs[1]
             << ')' << std::endl;
 
     J_inverse.vmult(dst, rhs);
-
-    return 0;
   };
 
   VectorType v(N);

--- a/tests/sundials/kinsol_06.cc
+++ b/tests/sundials/kinsol_06.cc
@@ -60,40 +60,34 @@ main()
 
   kinsol.reinit_vector = [N](VectorType &v) { v.reinit(N); };
 
-  kinsol.residual = [&](const VectorType &u, VectorType &F) -> int {
+  kinsol.residual = [&](const VectorType &u, VectorType &F) {
     deallog << "Computing residual at " << u[0] << std::endl;
 
     if ((u[0] < -10) || (u[0] > 20))
       {
         deallog << "Reporting recoverable failure." << std::endl;
-        return 1;
+        throw RecoverableUserCallbackError();
       }
 
 
     F.reinit(u);
     F[0] = std::atan(u[0]) - 0.5;
-
-    return 0;
   };
 
   double J_inverse;
 
   kinsol.setup_jacobian = [&J_inverse](const VectorType &u,
-                                       const VectorType &F) -> int {
+                                       const VectorType &F) {
     deallog << "Setting up Jacobian system at u=" << u[0] << std::endl;
 
     const double J = 1. / (1 + u[0] * u[0]);
     J_inverse      = 1. / J;
-
-    return 0;
   };
 
 
-  kinsol.solve_with_jacobian =
-    [&](const VectorType &rhs, VectorType &dst, double) -> int {
-    dst[0] = J_inverse * rhs[0];
-    return 0;
-  };
+  kinsol.solve_with_jacobian = [&](const VectorType &rhs,
+                                   VectorType &      dst,
+                                   double) { dst[0] = J_inverse * rhs[0]; };
 
   VectorType v(N);
   v[0] = 10;

--- a/tests/sundials/step-77.cc
+++ b/tests/sundials/step-77.cc
@@ -424,24 +424,18 @@ namespace Step77
             [&](const Vector<double> &evaluation_point,
                 Vector<double> &      residual) {
               compute_residual(evaluation_point, residual);
-
-              return 0;
             };
 
           nonlinear_solver.setup_jacobian =
             [&](const Vector<double> &current_u,
                 const Vector<double> & /*current_f*/) {
               compute_and_factorize_jacobian(current_u);
-
-              return 0;
             };
 
           nonlinear_solver.solve_with_jacobian = [&](const Vector<double> &rhs,
                                                      Vector<double> &      dst,
                                                      const double tolerance) {
             this->solve(rhs, dst, tolerance);
-
-            return 0;
           };
 
           nonlinear_solver.solve(current_solution);
@@ -461,5 +455,4 @@ main()
 
   MinimalSurfaceProblem<2> laplace_problem_2d;
   laplace_problem_2d.run();
-  return 0;
 }


### PR DESCRIPTION
As laid out in #15112 and documented in #15146.

I broke this into a number of individual commit that might be easier to understand in separation:
* fcb062c is the one that actually converts user callback exceptions into the return codes KINSOL wants to see (in the `call_and_possibly_capture_exception()` function), and consequently changes the interface of the `std::function` callbacks.
* 91fbf68 converts the tests. Take a particular look at `kinsol_06.cc`, the test introduced in #15172 that illustrates how KINSOL deals with recoverable errors.
* 6dba3d3 converts step-77, shrinking the size of the callbacks by about 1/3 :-)
* cfc5539 cleans up a wart in the first of the commits mentioned above: I introduce a variable `std::exception_ptr pending_exception;` that I needed to make `public` because it is referenced in several free functions. Each of these free functions is used in only one place, so I'm turning these free functions into lambdas -- and that allows me to make the member variable `private`. This is because the following is apparently ok:
```
  class X {
    private:
      int i;
      void f();
  };

  void X::f() {
    auto callback = []() {
     X x;   // create an object in the 'callback' lambda
     return x.i; // access its private member function -- can do because we are *in* X right now
    };
  }
```

I should note that this is backward compatible at least for the case where user callbacks return zero (=no error). That's because you can assign a function that returns something to a `std::function<void(...)>`. The returned value will then simply be ignored. Once I'm done with #15112, I will write a changelog entry that documents all of this. In the meantime, my suspicion is that 100% of user callbacks actually return zero, and so there is no actual change; the only change is if callbacks return nonzero codes, which will now be ignored.

All of this passes all 27 SUNDIALS tests for me.

@sebproell Since you know SUNDIALS, I thought you might be interested in looking at this. I will do something similar for the NOX as well as for the other SUNDIALS interfaces.
@stefanozampini I would do something similar for the PETSc callbacks.
