### PR TITLE
Avoid missing symbols and use constexpr functions instead

### DIFF
--- a/include/deal.II/base/floating_point_comparator.h
+++ b/include/deal.II/base/floating_point_comparator.h
@@ -46,7 +46,7 @@ struct FloatingPointComparator
   using ScalarNumber =
     typename dealii::internal::VectorizedArrayTrait<Number>::value_type;
   static constexpr std::size_t width =
-    dealii::internal::VectorizedArrayTrait<Number>::width;
+    dealii::internal::VectorizedArrayTrait<Number>::width();
 
   /**
    * An enum to decode whether a particular comparison returns less, larger,

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -5484,9 +5484,13 @@ namespace internal
     using value_type = T;
 
     /**
-     * Define width of template type.
+     * Return the width of template type.
      */
-    static constexpr std::size_t width = 1;
+    static constexpr std::size_t
+    width()
+    {
+      return 1;
+    }
 
     /**
      * Define vectorized value type for internal vectorization.
@@ -5494,12 +5498,16 @@ namespace internal
     using vectorized_value_type = VectorizedArray<T>;
 
     /**
-     * Define a stride which defines how often the template type T fits into the
-     * vectorized_value_type. This is useful to write vectorized templated code
-     * where the internal computation is vectorized and the user interface is
-     * optionally scalar or also vectorized.
+     * Return a stride which defines how often the template type T fits into
+     * the vectorized_value_type. This is useful to write vectorized templated
+     * code where the internal computation is vectorized and the user
+     * interface is optionally scalar or also vectorized.
      */
-    static constexpr std::size_t stride = vectorized_value_type::size();
+    static constexpr std::size_t
+    stride()
+    {
+      return vectorized_value_type::size();
+    }
 
     /**
      * Get a reference to scalar value (on lane 0).
@@ -5531,7 +5539,7 @@ namespace internal
     static value_type &
     get_from_vectorized(vectorized_value_type &values, unsigned int c)
     {
-      AssertIndexRange(c, stride);
+      AssertIndexRange(c, stride());
 
       return values[c];
     }
@@ -5543,7 +5551,7 @@ namespace internal
     static const value_type &
     get_from_vectorized(const vectorized_value_type &values, unsigned int c)
     {
-      AssertIndexRange(c, stride);
+      AssertIndexRange(c, stride());
 
       return values[c];
     }
@@ -5558,9 +5566,13 @@ namespace internal
     using value_type = T;
 
     /**
-     * Define width of template type.
+     * Return the width of template type.
      */
-    static constexpr std::size_t width = width_;
+    static constexpr std::size_t
+    width()
+    {
+      return width_;
+    }
 
     /**
      * Define vectorized value type for internal vectorization.
@@ -5568,13 +5580,17 @@ namespace internal
     using vectorized_value_type = VectorizedArray<T, width_>;
 
     /**
-     * Define a stride which defines how often the template type
+     * Return a stride which defines how often the template type
      * VectorizedArray<T, width_> fits into the vectorized value type. This is
      * useful to write vectorized templated code where the internal computation
      * is vectorized and the user interface is optionally scalar or also
      * vectorized.
      */
-    static constexpr std::size_t stride = 1;
+    static constexpr std::size_t
+    stride()
+    {
+      return 1;
+    }
 
     /**
      * Get a reference to scalar value on lane c.
@@ -5605,7 +5621,7 @@ namespace internal
     get_from_vectorized(vectorized_value_type &values, unsigned int c)
     {
       (void)c;
-      AssertIndexRange(c, stride);
+      AssertIndexRange(c, stride());
 
       return values;
     }
@@ -5618,7 +5634,7 @@ namespace internal
     get_from_vectorized(const vectorized_value_type &values, unsigned int c)
     {
       (void)c;
-      AssertIndexRange(c, stride);
+      AssertIndexRange(c, stride());
 
       return values;
     }

--- a/include/deal.II/lac/tensor_product_matrix.h
+++ b/include/deal.II/lac/tensor_product_matrix.h
@@ -285,7 +285,7 @@ namespace internal
       using VectorizedArrayTrait =
         dealii::internal::VectorizedArrayTrait<Number>;
       using ScalarNumber = typename VectorizedArrayTrait::value_type;
-      static constexpr std::size_t width = VectorizedArrayTrait::width;
+      static constexpr std::size_t width = VectorizedArrayTrait::width();
 
       MatrixPairComparator()
         : eps(std::sqrt(std::numeric_limits<ScalarNumber>::epsilon()))

--- a/include/deal.II/matrix_free/fe_evaluation_data.h
+++ b/include/deal.II/matrix_free/fe_evaluation_data.h
@@ -127,7 +127,7 @@ public:
     typename internal::VectorizedArrayTrait<Number>::value_type;
 
   static constexpr unsigned int n_lanes =
-    internal::VectorizedArrayTrait<Number>::width;
+    internal::VectorizedArrayTrait<Number>::width();
 
   /**
    * Constructor, taking a single ShapeInfo object to inject the capability

--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -984,11 +984,11 @@ public:
 
 private:
   static constexpr std::size_t n_lanes_user_interface =
-    internal::VectorizedArrayTrait<Number>::width;
+    internal::VectorizedArrayTrait<Number>::width();
   static constexpr std::size_t n_lanes_internal =
-    internal::VectorizedArrayTrait<VectorizedArrayType>::width;
+    internal::VectorizedArrayTrait<VectorizedArrayType>::width();
   static constexpr std::size_t stride =
-    internal::VectorizedArrayTrait<Number>::stride;
+    internal::VectorizedArrayTrait<Number>::stride();
 
   /**
    * Common setup function for both constructors. Does the setup for both fast

--- a/include/deal.II/non_matching/mapping_info.h
+++ b/include/deal.II/non_matching/mapping_info.h
@@ -1056,7 +1056,7 @@ namespace NonMatching
     const unsigned int n_q_points_unvectorized)
   {
     const unsigned int n_lanes =
-      dealii::internal::VectorizedArrayTrait<NumberType>::width;
+      dealii::internal::VectorizedArrayTrait<NumberType>::width();
     const unsigned int n_filled_lanes_last_batch =
       n_q_points_unvectorized % n_lanes;
     unsigned int n_q_points = n_q_points_unvectorized / n_lanes;
@@ -1123,7 +1123,7 @@ namespace NonMatching
     const std::vector<Point<dim>> &points)
   {
     const unsigned int n_lanes =
-      dealii::internal::VectorizedArrayTrait<VectorizedArrayType>::width;
+      dealii::internal::VectorizedArrayTrait<VectorizedArrayType>::width();
 
     for (unsigned int q = 0; q < n_q_points; ++q)
       {
@@ -1148,7 +1148,7 @@ namespace NonMatching
     const MappingInfo::MappingData &mapping_data)
   {
     const unsigned int n_lanes =
-      dealii::internal::VectorizedArrayTrait<Number>::width;
+      dealii::internal::VectorizedArrayTrait<Number>::width();
 
     for (unsigned int q = 0; q < n_q_points; ++q)
       {


### PR DESCRIPTION
Since #15137 has been merged, we have some linker errors, e.g. this one https://cdash.dealii.org/test/50357345 in the build https://cdash.dealii.org/viewTest.php?onlyfailed&buildid=4614 (look at the ones with `point_evaluation`). Technically, we would need to instantiate the `static constexpr` member variables. Since I do not want to do this for all types of `VectorizedArray` and `Number` we might have, my preference is to instead have `constexpr` functions similar to `VectorizedArray::size()`, which should avoid the problem altogether. Opinions?

FYI @bergbauer