### PR TITLE
Reduce overhead in calls to tensor product value function

### DIFF
--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -1534,14 +1534,11 @@ FEPointEvaluation<n_components, dim, spacedim, Number>::do_reinit()
   if (fast_path && !polynomials_are_hat_functions)
     {
       const std::size_t n_batches =
-        n_q_points_scalar / n_lanes_internal +
-        (n_q_points_scalar % n_lanes_internal > 0 ? 1 : 0);
+        (n_q_points_scalar + n_lanes_internal - 1) / n_lanes_internal;
       const std::size_t n_shapes = poly.size();
       shapes.resize_fast(n_batches * n_shapes);
       for (unsigned int qb = 0; qb < n_batches; ++qb)
-        internal::compute_values_of_array(make_array_view(shapes,
-                                                          qb * n_shapes,
-                                                          n_shapes),
+        internal::compute_values_of_array(shapes.data() + qb * n_shapes,
                                           poly,
                                           unit_point_ptr[qb]);
     }
@@ -1561,13 +1558,15 @@ FEPointEvaluation<n_components, dim, spacedim, Number>::evaluate_fast(
   if (solution_renumbered.size() != dofs_per_component)
     solution_renumbered.resize(dofs_per_component);
   for (unsigned int comp = 0; comp < n_components; ++comp)
-    for (unsigned int i = 0; i < dofs_per_component; ++i)
-      ETT::read_value(
-        solution_values[renumber[(component_in_base_element + comp) *
-                                   dofs_per_component +
-                                 i]],
-        comp,
-        solution_renumbered[i]);
+    {
+      const unsigned int *renumber_ptr =
+        renumber.data() +
+        (component_in_base_element + comp) * dofs_per_component;
+      for (unsigned int i = 0; i < dofs_per_component; ++i)
+        ETT::read_value(solution_values[renumber_ptr[i]],
+                        comp,
+                        solution_renumbered[i]);
+    }
 
   // unit gradients are currently only implemented with the fast tensor
   // path
@@ -1586,15 +1585,15 @@ FEPointEvaluation<n_components, dim, spacedim, Number>::evaluate_fast(
           internal::evaluate_tensor_product_value_and_gradient_shapes<
             dim,
             scalar_value_type,
-            VectorizedArrayType>(make_array_view(shapes,
-                                                 qb * n_shapes,
-                                                 n_shapes),
+            VectorizedArrayType>(shapes.data() + qb * n_shapes,
                                  n_shapes,
                                  solution_renumbered);
 
       if (evaluation_flags & EvaluationFlags::values)
         {
-          for (unsigned int v = 0; v < stride && q + v < n_q_points_scalar; ++v)
+          for (unsigned int v = 0;
+               v < stride && (stride > 1 ? q + v < n_q_points_scalar : true);
+               ++v)
             ETT::set_value(val_and_grad.first, v, values[qb * stride + v]);
         }
       if (evaluation_flags & EvaluationFlags::gradients)
@@ -1603,7 +1602,9 @@ FEPointEvaluation<n_components, dim, spacedim, Number>::evaluate_fast(
                    update_flags & update_inverse_jacobians,
                  ExcNotInitialized());
 
-          for (unsigned int v = 0; v < stride && q + v < n_q_points_scalar; ++v)
+          for (unsigned int v = 0;
+               v < stride && (stride > 1 ? q + v < n_q_points_scalar : true);
+               ++v)
             {
               const unsigned int offset = qb * stride + v;
               ETT::set_gradient(val_and_grad.second, v, unit_gradients[offset]);
@@ -1762,7 +1763,9 @@ FEPointEvaluation<n_components, dim, spacedim, Number>::integrate_fast(
                 ETT::set_zero_value(values[qb], v);
             }
 
-          for (unsigned int v = 0; v < stride && q + v < n_q_points_scalar; ++v)
+          for (unsigned int v = 0;
+               v < stride && (stride > 1 ? q + v < n_q_points_scalar : true);
+               ++v)
             ETT::get_value(value, v, values[qb * stride + v]);
         }
       if (integration_flags & EvaluationFlags::gradients)
@@ -1778,7 +1781,9 @@ FEPointEvaluation<n_components, dim, spacedim, Number>::integrate_fast(
                 ETT::set_zero_gradient(gradients[qb], v);
             }
 
-          for (unsigned int v = 0; v < stride && q + v < n_q_points_scalar; ++v)
+          for (unsigned int v = 0;
+               v < stride && (stride > 1 ? q + v < n_q_points_scalar : true);
+               ++v)
             {
               const unsigned int offset = qb * stride + v;
               ETT::get_gradient(

--- a/include/deal.II/matrix_free/tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/tensor_product_kernels.h
@@ -3477,12 +3477,11 @@ namespace internal
     DEAL_II_ALWAYS_INLINE
 #endif
     void
-    do_apply_test_functions_xy(
-      AlignedVector<Number2> &                          values,
-      const ArrayView<dealii::ndarray<Number, 2, dim>> &shapes,
-      const std::array<Number2, 3> &                    test_grads_value,
-      const int                                         n_shapes_runtime,
-      int &                                             i)
+    do_apply_test_functions_xy(AlignedVector<Number2> &               values,
+                               const dealii::ndarray<Number, 2, dim> *shapes,
+                               const std::array<Number2, 3> &test_grads_value,
+                               const int                     n_shapes_runtime,
+                               int &                         i)
   {
     if (length > 0)
       {
@@ -3544,11 +3543,11 @@ namespace internal
   template <int dim, typename Number, typename Number2>
   inline void
   integrate_add_tensor_product_value_and_gradient_shapes(
-    const ArrayView<dealii::ndarray<Number, 2, dim>> &shapes,
-    const int                                         n_shapes,
-    const Number2 &                                   value,
-    const Tensor<1, dim, Number2> &                   gradient,
-    AlignedVector<Number2> &                          values)
+    const dealii::ndarray<Number, 2, dim> *shapes,
+    const int                              n_shapes,
+    const Number2 &                        value,
+    const Tensor<1, dim, Number2> &        gradient,
+    AlignedVector<Number2> &               values)
   {
     static_assert(dim >= 1 && dim <= 3, "Only dim=1,2,3 implemented");
 


### PR DESCRIPTION
This is a follow-up to #15137, reducing the integer code overhead a code has to go through. There are three main changes:
- We switch from `ArrayView` to plain pointers in the internal interfaces, which reduces the setup cost by 2 instructions and one register to passed around between function calls.
- The compiler can't see that, for the case `stride==1`, the loop termination criterion `q + v < n_q_points_scalar;` is the same as in the outer loop and thus always true. Avoid one additional branch instruction by spelling out this as `v < stride && (stride > 1 ? q + v < n_q_points_scalar : true);` - I admit this is not super readable and there are maybe better suggestions to make sure the data rearrangement, which is visible in profilers, does not incur a loop if all we add is one element.
- I opted to mark `do_interpolate_xy` with `DEAL_II_ALWAYS_INLINE`. We had a discussion in https://github.com/dealii/dealii/pull/14972#discussion_r1148389694 but it seems that at least my compiler (clang-16) does a bad job in guessing the cost of moving the variables in and out of registers; instead, the outer function `evaluate_tensor_product_value_and_gradient_shapes` should be the function to collect the code. From a code size perspective, I do not see an advantage of not to inline, as the only function calling `do_interpolate_xy` is that other function.