### PR TITLE
Let NOX callbacks conform to our new standard for callback errors.

### DIFF
--- a/include/deal.II/trilinos/nox.h
+++ b/include/deal.II/trilinos/nox.h
@@ -26,6 +26,7 @@
 
 #  include <Teuchos_ParameterList.hpp>
 
+#  include <exception>
 #  include <functional>
 
 DEAL_II_NAMESPACE_OPEN
@@ -180,17 +181,29 @@ namespace TrilinosWrappers
      * A function object that users should supply and that is intended to
      * compute the residual $F(u)$.
      *
-     * @note This function should return 0 in the case of success.
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. NOX can not deal
+     * with "recoverable" errors, so if a callback
+     * throws an exception of type RecoverableUserCallbackError, then this
+     * exception is treated like any other exception.
      */
-    std::function<int(const VectorType &u, VectorType &F)> residual;
+    std::function<void(const VectorType &u, VectorType &F)> residual;
 
     /**
      * A user function that sets up the Jacobian, based on the
      * current solution @p current_u.
      *
-     * @note This function should return 0 in the case of success.
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. NOX can not deal
+     * with "recoverable" errors, so if a callback
+     * throws an exception of type RecoverableUserCallbackError, then this
+     * exception is treated like any other exception.
      */
-    std::function<int(const VectorType &current_u)> setup_jacobian;
+    std::function<void(const VectorType &current_u)> setup_jacobian;
 
     /**
      * A user function that sets up the preconditioner for inverting
@@ -201,9 +214,15 @@ namespace TrilinosWrappers
      * update_preconditioner_predicate and
      * AdditionalData::threshold_nonlinear_iterations).
      *
-     * @note This function should return 0 in the case of success.
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. NOX can not deal
+     * with "recoverable" errors, so if a callback
+     * throws an exception of type RecoverableUserCallbackError, then this
+     * exception is treated like any other exception.
      */
-    std::function<int(const VectorType &current_u)> setup_preconditioner;
+    std::function<void(const VectorType &current_u)> setup_preconditioner;
 
     /**
      * A user function that applies the Jacobian $\nabla_u F(u)$ to
@@ -217,9 +236,15 @@ namespace TrilinosWrappers
      * chosen, whereas for the full step case (`NOX::LineSearch::FullStep`)
      * it won't be called.
      *
-     * @note This function should return 0 in the case of success.
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. NOX can not deal
+     * with "recoverable" errors, so if a callback
+     * throws an exception of type RecoverableUserCallbackError, then this
+     * exception is treated like any other exception.
      */
-    std::function<int(const VectorType &x, VectorType &y)> apply_jacobian;
+    std::function<void(const VectorType &x, VectorType &y)> apply_jacobian;
 
     /**
      * A user function that applies the inverse of the Jacobian
@@ -233,10 +258,16 @@ namespace TrilinosWrappers
      * @note This function is optional and is used in the case of certain
      * configurations.
      *
-     * @note This function should return 0 in the case of success.
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. NOX can not deal
+     * with "recoverable" errors, so if a callback
+     * throws an exception of type RecoverableUserCallbackError, then this
+     * exception is treated like any other exception.
      */
     std::function<
-      int(const VectorType &y, VectorType &x, const double tolerance)>
+      void(const VectorType &y, VectorType &x, const double tolerance)>
       solve_with_jacobian;
 
     /**
@@ -251,6 +282,14 @@ namespace TrilinosWrappers
      *
      * @note This function is optional and is used in the case of certain
      * configurations.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. NOX can not deal
+     * with "recoverable" errors, so if a callback
+     * throws an exception of type RecoverableUserCallbackError, then this
+     * exception is treated like any other exception.
      */
     std::function<
       int(const VectorType &y, VectorType &x, const double tolerance)>
@@ -266,6 +305,14 @@ namespace TrilinosWrappers
      * and the current residual vector @p f.
      *
      * @note This function is optional.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. NOX can not deal
+     * with "recoverable" errors, so if a callback
+     * throws an exception of type RecoverableUserCallbackError, then this
+     * exception is treated like any other exception.
      */
     std::function<SolverControl::State(const unsigned int i,
                                        const double       norm_f,
@@ -282,6 +329,14 @@ namespace TrilinosWrappers
      *
      * @note This function is optional. If no function is attached, this
      * means implicitly a return value of `false`.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. NOX can not deal
+     * with "recoverable" errors, so if a callback
+     * throws an exception of type RecoverableUserCallbackError, then this
+     * exception is treated like any other exception.
      */
     std::function<bool()> update_preconditioner_predicate;
 
@@ -317,6 +372,13 @@ namespace TrilinosWrappers
      * The number of linear iterations of the last Jacobian solve.
      */
     unsigned int n_last_linear_iterations;
+
+    /**
+     * A pointer to any exception that may have been thrown in user-defined
+     * call-backs and that we have to deal after the KINSOL function we call
+     * has returned.
+     */
+    mutable std::exception_ptr pending_exception;
   };
 } // namespace TrilinosWrappers
 

--- a/include/deal.II/trilinos/nox.templates.h
+++ b/include/deal.II/trilinos/nox.templates.h
@@ -967,7 +967,10 @@ namespace TrilinosWrappers
     // create group
     const auto group = Teuchos::rcp(new internal::NOXWrappers::Group<
                                     VectorType>(
+      /* Starting vector */
       solution,
+
+      /* Residual function */
       [&](const VectorType &x, VectorType &f) -> int {
         Assert(
           residual,
@@ -980,6 +983,8 @@ namespace TrilinosWrappers
         return internal::NOXWrappers::call_and_possibly_capture_exception(
           residual, pending_exception, x, f);
       },
+
+      /* setup_jacobian function */
       [&](const VectorType &x) -> int {
         Assert(
           setup_jacobian,
@@ -1015,6 +1020,8 @@ namespace TrilinosWrappers
 
         return flag;
       },
+
+      /* apply_jacobian function */
       [&](const VectorType &x, VectorType &v) -> int {
         Assert(
           apply_jacobian,
@@ -1027,6 +1034,8 @@ namespace TrilinosWrappers
         return internal::NOXWrappers::call_and_possibly_capture_exception(
           apply_jacobian, pending_exception, x, v);
       },
+
+      /* solve_with_jacobian function */
       [&](const VectorType &f, VectorType &x, const double tolerance) -> int {
         n_nonlinear_iterations++;
 

--- a/include/deal.II/trilinos/nox.templates.h
+++ b/include/deal.II/trilinos/nox.templates.h
@@ -43,6 +43,46 @@ namespace TrilinosWrappers
   {
     namespace NOXWrappers
     {
+      namespace
+      {
+        /**
+         * A function that calls the function object given by its first argument
+         * with the set of arguments following at the end. If the call returns
+         * regularly, the current function returns zero to indicate success. If
+         * the call fails with an, then the current function returns with an
+         * error code of -1. In that case, the exception thrown by `f` is
+         * captured and `eptr` is set to the exception. In case of success,
+         * `eptr` is set to `nullptr`.
+         */
+        template <typename F, typename... Args>
+        int
+        call_and_possibly_capture_exception(const F &           f,
+                                            std::exception_ptr &eptr,
+                                            Args &&...args)
+        {
+          // See whether there is already something in the exception pointer
+          // variable. There is no reason why this should be so, and
+          // we should probably bail out:
+          AssertThrow(eptr == nullptr, ExcInternalError());
+
+          // Call the function and if that succeeds, return zero:
+          try
+            {
+              f(std::forward<Args>(args)...);
+              eptr = nullptr;
+              return 0;
+            }
+          // In case of an exception, capture the exception and
+          // return -1:
+          catch (...)
+            {
+              eptr = std::current_exception();
+              return -1;
+            }
+        }
+      } // namespace
+
+
       template <typename VectorType>
       class Group;
 
@@ -937,7 +977,8 @@ namespace TrilinosWrappers
         n_residual_evaluations++;
 
         // evalute residual
-        return residual(x, f);
+        return internal::NOXWrappers::call_and_possibly_capture_exception(
+          residual, pending_exception, x, f);
       },
       [&](const VectorType &x) -> int {
         Assert(
@@ -946,7 +987,8 @@ namespace TrilinosWrappers
             "No setup_jacobian function has been attached to the NOXSolver object."));
 
         // setup Jacobian
-        int flag = setup_jacobian(x);
+        int flag = internal::NOXWrappers::call_and_possibly_capture_exception(
+          setup_jacobian, pending_exception, x);
 
         if (flag != 0)
           return flag;
@@ -967,7 +1009,8 @@ namespace TrilinosWrappers
               update_preconditioner = update_preconditioner_predicate();
 
             if (update_preconditioner)
-              flag = setup_preconditioner(x);
+              flag = internal::NOXWrappers::call_and_possibly_capture_exception(
+                setup_preconditioner, pending_exception, x);
           }
 
         return flag;
@@ -981,7 +1024,8 @@ namespace TrilinosWrappers
         n_jacobian_applications++;
 
         // apply Jacobian
-        return apply_jacobian(x, v);
+        return internal::NOXWrappers::call_and_possibly_capture_exception(
+          apply_jacobian, pending_exception, x, v);
       },
       [&](const VectorType &f, VectorType &x, const double tolerance) -> int {
         n_nonlinear_iterations++;
@@ -996,7 +1040,8 @@ namespace TrilinosWrappers
                 "solve_with_jacobian_and_track_n_linear_iterations!"));
 
             // without tracking of linear iterations
-            return solve_with_jacobian(f, x, tolerance);
+            return internal::NOXWrappers::call_and_possibly_capture_exception(
+              solve_with_jacobian, pending_exception, f, x, tolerance);
           }
         else if (solve_with_jacobian_and_track_n_linear_iterations)
           {
@@ -1063,8 +1108,18 @@ namespace TrilinosWrappers
     // create non-linear solver
     const auto solver = NOX::Solver::buildSolver(group, check, parameters);
 
-    // solve
+    // Solve, then check whether an exception was thrown by one of the user
+    // callback functions. If so, exit by rethrowing the exception that
+    // we had previously saved. This also calls the destructors of all of
+    // the member variables above, so we do not have to clean things up by hand.
     const auto status = solver->solve();
+    if (pending_exception)
+      {
+        std::exception_ptr this_exception = pending_exception;
+        pending_exception                 = nullptr;
+
+        std::rethrow_exception(this_exception);
+      }
 
     AssertThrow(status == NOX::StatusTest::Converged, ExcNOXNoConvergence());
 

--- a/tests/trilinos/nox_solver_01.cc
+++ b/tests/trilinos/nox_solver_01.cc
@@ -94,25 +94,21 @@ main(int argc, char **argv)
     solver.residual = [](const auto &src, auto &dst) {
       // compute residual
       dst[0] = src[0] * src[0];
-      return 0;
     };
 
     solver.setup_jacobian = [&](const auto &src) {
       // compute Jacobian
       J = 2.0 * src[0];
-      return 0;
     };
 
     solver.apply_jacobian = [&](const auto &src, auto &dst) {
       // solve with Jacobian
       dst[0] = src[0] * J;
-      return 0;
     };
 
     solver.solve_with_jacobian = [&](const auto &src, auto &dst, const auto) {
       // solve with Jacobian
       dst[0] = src[0] / J;
-      return 0;
     };
 
     // initial guess

--- a/tests/trilinos/nox_solver_02.cc
+++ b/tests/trilinos/nox_solver_02.cc
@@ -77,26 +77,22 @@ main(int argc, char **argv)
     // compute residual
     deallog << "Evaluating residual at u=" << src[0] << std::endl;
     dst[0] = std::atan(src[0]) - 0.5;
-    return 0;
   };
 
   solver.setup_jacobian = [&](const auto &src) {
     // compute Jacobian
     deallog << "Setting up Jacobian at u=" << src[0] << std::endl;
     J = 1. / (1 + src[0] * src[0]);
-    return 0;
   };
 
   solver.apply_jacobian = [&](const auto &src, auto &dst) {
     // solve with Jacobian
     dst[0] = src[0] * J;
-    return 0;
   };
 
   solver.solve_with_jacobian = [&](const auto &src, auto &dst, const auto) {
     // solve with Jacobian
     dst[0] = src[0] / J;
-    return 0;
   };
 
   // initial guess

--- a/tests/trilinos/nox_solver_03.cc
+++ b/tests/trilinos/nox_solver_03.cc
@@ -87,19 +87,18 @@ main(int argc, char **argv)
                                                  non_linear_parameters);
 
   // ... helper functions
-  solver.residual = [](const VectorType &u, VectorType &F) -> int {
+  solver.residual = [](const VectorType &u, VectorType &F) {
     deallog << "Evaluating the solution at u=(" << u[0] << ',' << u[1] << ')'
             << std::endl;
 
     F(0) = std::cos(u[0] + u[1]) - 1 + 2 * u[0];
     F(1) = std::sin(u[0] - u[1]) + 2 * u[1];
-    return 0;
   };
 
   FullMatrix<double> J(2, 2);
   FullMatrix<double> J_inverse(2, 2);
 
-  solver.setup_jacobian = [&J, &J_inverse](const VectorType &u) -> int {
+  solver.setup_jacobian = [&J, &J_inverse](const VectorType &u) {
     // We don't do any kind of set-up in this program, but we can at least
     // say that we're here
     deallog << "Setting up Jacobian system at u=(" << u[0] << ',' << u[1] << ')'
@@ -111,24 +110,19 @@ main(int argc, char **argv)
     J(1, 1) = -std::cos(u[0] - u[1]) + 2;
 
     J_inverse.invert(J);
-
-    return 0;
   };
 
   solver.apply_jacobian = [&](const VectorType &src, VectorType &dst) {
     J.vmult(dst, src);
-    return -0;
   };
 
   solver.solve_with_jacobian = [&J_inverse](const VectorType &rhs,
                                             VectorType &      dst,
-                                            const double /*tolerance*/) -> int {
+                                            const double /*tolerance*/) {
     deallog << "Solving Jacobian system with rhs=(" << rhs[0] << ',' << rhs[1]
             << ')' << std::endl;
 
     J_inverse.vmult(dst, rhs);
-
-    return 0;
   };
 
   // initial guess

--- a/tests/trilinos/nox_solver_04.cc
+++ b/tests/trilinos/nox_solver_04.cc
@@ -1,0 +1,140 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Check TrilinosWrappers::NOXSolver. This test solves the same
+// problem as nox_solver_03, but it throws an exception in one of the
+// user functions. The test checks that we capture and rethrow the
+// exception, and that we can ultimately catch it.
+
+
+#include <deal.II/base/mpi.h>
+
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include <deal.II/trilinos/nox.h>
+
+// as reference solution
+#include <deal.II/lac/trilinos_precondition.h>
+#include <deal.II/lac/trilinos_solver.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_sparsity_pattern.h>
+
+#include "../tests.h"
+
+
+int
+main(int argc, char **argv)
+{
+  initlog();
+
+  Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv, 1);
+
+  using Number     = double;
+  using VectorType = Vector<Number>;
+
+  // set up solver control
+  const unsigned int n_max_iterations  = 100;
+  const double       abs_tolerance     = 1e-9;
+  const double       rel_tolerance     = 1e-5;
+  const double       lin_rel_tolerance = 1e-3;
+
+  TrilinosWrappers::NOXSolver<VectorType>::AdditionalData additional_data(
+    n_max_iterations, abs_tolerance, rel_tolerance);
+
+  // set up parameters
+  Teuchos::RCP<Teuchos::ParameterList> non_linear_parameters =
+    Teuchos::rcp(new Teuchos::ParameterList);
+
+  non_linear_parameters->set("Nonlinear Solver", "Line Search Based");
+  non_linear_parameters->sublist("Printing").set("Output Information", 15);
+  non_linear_parameters->sublist("Direction").set("Method", "Newton");
+  non_linear_parameters->sublist("Direction")
+    .sublist("Newton")
+    .sublist("Linear Solver")
+    .set("Tolerance", lin_rel_tolerance);
+  non_linear_parameters->sublist("Line Search").set("Method", "Polynomial");
+
+
+  // set up solver
+  TrilinosWrappers::NOXSolver<VectorType> solver(additional_data,
+                                                 non_linear_parameters);
+
+  // ... helper functions
+  solver.residual = [](const VectorType &u, VectorType &F) {
+    deallog << "Evaluating the solution at u=(" << u[0] << ',' << u[1] << ')'
+            << std::endl;
+
+    F(0) = std::cos(u[0] + u[1]) - 1 + 2 * u[0];
+    F(1) = std::sin(u[0] - u[1]) + 2 * u[1];
+
+    throw ExcMessage("Irrecoverable failure.");
+  };
+
+  FullMatrix<double> J(2, 2);
+  FullMatrix<double> J_inverse(2, 2);
+
+  solver.setup_jacobian = [&J, &J_inverse](const VectorType &u) {
+    // We don't do any kind of set-up in this program, but we can at least
+    // say that we're here
+    deallog << "Setting up Jacobian system at u=(" << u[0] << ',' << u[1] << ')'
+            << std::endl;
+
+    J(0, 0) = -std::sin(u[0] + u[1]) + 2;
+    J(0, 1) = -std::sin(u[0] + u[1]);
+    J(1, 0) = std::cos(u[0] - u[1]);
+    J(1, 1) = -std::cos(u[0] - u[1]) + 2;
+
+    J_inverse.invert(J);
+  };
+
+  solver.apply_jacobian = [&](const VectorType &src, VectorType &dst) {
+    J.vmult(dst, src);
+  };
+
+  solver.solve_with_jacobian = [&J_inverse](const VectorType &rhs,
+                                            VectorType &      dst,
+                                            const double /*tolerance*/) {
+    deallog << "Solving Jacobian system with rhs=(" << rhs[0] << ',' << rhs[1]
+            << ')' << std::endl;
+
+    J_inverse.vmult(dst, rhs);
+  };
+
+  // initial guess
+  const unsigned int N = 2;
+  VectorType         solution(N);
+  solution[0] = 0.5;
+  solution[1] = 1.234;
+
+  // solve with the given initial guess
+  try
+    {
+      auto niter = solver.solve(solution);
+      solution.print(deallog.get_file_stream());
+      deallog << "Converged in " << niter << " iterations." << std::endl;
+    }
+  catch (const std::exception &exc)
+    {
+      deallog << "Caught an irrecoverable exception in a callback:" << std::endl
+              << exc.what() << std::endl;
+    }
+  catch (const char *s)
+    {
+      deallog << "Trilinos threw its own exception of type char*:" << std::endl
+              << s << std::endl;
+    }
+}

--- a/tests/trilinos/nox_solver_04.with_trilinos_with_nox=true.output
+++ b/tests/trilinos/nox_solver_04.with_trilinos_with_nox=true.output
@@ -1,0 +1,24 @@
+
+DEAL::Evaluating the solution at u=(0.500000,1.23400)
+DEAL::Caught an irrecoverable exception in a callback:
+DEAL::
+--------------------------------------------------------
+An error occurred in line <0> of file <> in function
+    
+The violated condition was: 
+    
+Additional information: 
+    NOX aborted with an error text of <NOX Error> after a user callback
+    function had thrown an exception with the following message:
+    
+    --------------------------------------------------------
+    An error occurred in line <0> of file <> in function
+    
+    The violated condition was:
+    
+    Additional information:
+    Irrecoverable failure.
+    --------------------------------------------------------
+    
+--------------------------------------------------------
+

--- a/tests/trilinos/step-77-with-nox.cc
+++ b/tests/trilinos/step-77-with-nox.cc
@@ -430,23 +430,17 @@ namespace Step77
             [&](const Vector<double> &evaluation_point,
                 Vector<double> &      residual) {
               compute_residual(evaluation_point, residual);
-
-              return 0;
             };
 
           nonlinear_solver.setup_jacobian =
             [&](const Vector<double> &current_u) {
               compute_and_factorize_jacobian(current_u);
-
-              return 0;
             };
 
           nonlinear_solver.solve_with_jacobian = [&](const Vector<double> &rhs,
                                                      Vector<double> &      dst,
                                                      const double tolerance) {
             this->solve(rhs, dst, tolerance);
-
-            return 0;
           };
 
           nonlinear_solver.solve(current_solution);


### PR DESCRIPTION
Like in #15178. Implements the resolution in #15112, #15146. NOX has complicated ways to report errors, if I may say so (see https://github.com/trilinos/Trilinos/issues/11868), and this introduces some complexity in error handling. I've added a test that checks that we correctly handle exceptions thrown in callbacks.