### PR TITLE
Catch and rethrow *all* exceptions.

### DIFF
--- a/source/sundials/kinsol.cc
+++ b/source/sundials/kinsol.cc
@@ -115,7 +115,7 @@ namespace SUNDIALS
         }
       // For any other exception, capture the exception and
       // return -1:
-      catch (const std::exception &)
+      catch (...)
         {
           eptr = std::current_exception();
           return -1;


### PR DESCRIPTION
I realized that we can deal with *all* exceptions, not just the ones derived from `std::exception`.

Follow-up to #15178. Related to #15112.