### PR TITLE
Adding wrappers for Ginkgo vectors

### DIFF
--- a/cmake/modules/FindDEAL_II_GINKGO.cmake
+++ b/cmake/modules/FindDEAL_II_GINKGO.cmake
@@ -56,15 +56,15 @@ foreach(_library ginkgo ${GINKGO_INTERFACE_LINK_LIBRARIES})
   if(_library MATCHES "ginkgo.*")
     list(APPEND _libraries GINKGO_LIBRARY_${_library})
     deal_ii_find_library(GINKGO_LIBRARY_${_library}
-      NAMES ${_library}
-      HINTS ${GINKGO_INSTALL_LIBRARY_DIR}
-      NO_DEFAULT_PATH
-      NO_CMAKE_ENVIRONMENT_PATH
-      NO_CMAKE_PATH
-      NO_SYSTEM_ENVIRONMENT_PATH
-      NO_CMAKE_SYSTEM_PATH
-      NO_CMAKE_FIND_ROOT_PATH
-      )
+        NAMES ${_library} ${_library}d
+        HINTS ${GINKGO_INSTALL_LIBRARY_DIR}
+        NO_DEFAULT_PATH
+        NO_CMAKE_ENVIRONMENT_PATH
+        NO_CMAKE_PATH
+        NO_SYSTEM_ENVIRONMENT_PATH
+        NO_CMAKE_SYSTEM_PATH
+        NO_CMAKE_FIND_ROOT_PATH
+        )
   endif()
 endforeach()
 

--- a/include/deal.II/lac/ginkgo_vector.h
+++ b/include/deal.II/lac/ginkgo_vector.h
@@ -1,0 +1,534 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 - 2023 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_ginkgo_vector_h
+#define dealii_ginkgo_vector_h
+
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_GINKGO
+
+#  include <deal.II/base/index_set.h>
+#  include <deal.II/base/subscriptor.h>
+
+#  include <deal.II/lac/la_vector.h>
+#  include <deal.II/lac/vector.h>
+
+#  include <ginkgo/core/base/version.hpp>
+#  include <ginkgo/core/matrix/dense.hpp>
+
+#  include <iomanip>
+#  include <ios>
+#  include <memory>
+
+
+DEAL_II_NAMESPACE_OPEN
+
+
+/**
+ * A namespace in which wrapper classes for Ginkgo objects reside.
+ *
+ * @ingroup GinkgoWrappers
+ */
+namespace GinkgoWrappers
+{
+  /**
+   * Class wrapping a gko::matrix::Dense (multi) vector. This class implements
+   * most of the methods common to other vector types, so it can be used as a
+   * drop-in replacement.
+   * @tparam Number The numerical data type. Both real and complex types are supported
+   * @ingroup Vectors
+   */
+  template <typename Number>
+  class Vector : public Subscriptor
+  {
+  public:
+    using value_type       = Number;
+    using real_type        = typename numbers::NumberTraits<Number>::real_type;
+    using iterator         = value_type *;
+    using const_iterator   = const value_type *;
+    using size_type        = types::global_dof_index;
+    using ginkgo_type      = gko::matrix::Dense<Number>;
+    using ginkgo_norm_type = typename ginkgo_type::absolute_type;
+
+    // Disable default constructor, because we always need to know the executor.
+    Vector() = delete;
+
+    /**
+     * Creates an empty vector on the given executor @p exec.
+     */
+    Vector(std::shared_ptr<const gko::Executor> exec);
+
+    /**
+     * Directly wraps an Ginkgo vector.
+     */
+    Vector(std::unique_ptr<ginkgo_type> v);
+
+    /**
+     * Creates a vector of size @p size on the executor @p exec.
+     */
+    explicit Vector(std::shared_ptr<const gko::Executor> exec,
+                    const size_type                      size);
+
+
+    /**
+     * Creates a vector on the executor @p exec and initializes
+     * it with the values of @p list
+     */
+    explicit Vector(std::shared_ptr<const gko::Executor> exec,
+                    const std::initializer_list<Number> &list);
+
+    /**
+     * Copy constructor.
+     */
+    Vector(const Vector &other);
+
+    /**
+     * Move constructor.
+     */
+    Vector(Vector &&other) noexcept;
+
+    /**
+     * Creates a vector with the same size and executor as @p V. If
+     * @p omit_zeroing_entries is false, then all elements of the vector
+     * are set to zero.
+     */
+    static Vector
+    create_with_same_size(const Vector &V,
+                          const bool    omit_zeroing_entries = false);
+
+    /**
+     * Copy assignment.
+     * @note The executor of this is not changed. If other has a
+     *       different executor, then the data copied between the
+     *       executors accordingly.
+     */
+    Vector &
+    operator=(const Vector &other);
+
+    /**
+     * Move assignment. Copies in case of different executors.
+     * @note The executor of this is not changed. If other has a
+     *       different executor, then the data copied between the
+     *       executors accordingly.
+     */
+    Vector &
+    operator=(Vector &&other) noexcept(false);
+
+    /**
+     * Creates a vector that is a view on a
+     * dealii::LinearAlgebra::ReadWriteVector.
+     */
+    static std::unique_ptr<Vector>
+    create_view(std::shared_ptr<const gko::Executor>              exec,
+                ::dealii::LinearAlgebra::ReadWriteVector<Number> &other);
+
+
+    /**
+     * Creates a vector that is a view on a
+     * dealii::LinearAlgebra::ReadWriteVector.
+     */
+    static std::unique_ptr<Vector>
+    create_view(std::shared_ptr<const gko::Executor> exec,
+                ::dealii::Vector<Number> &           other);
+
+
+    /**
+     * Creates a constant vector that is a view on a constant
+     * dealii::LinearAlgebra::ReadWriteVector.
+     */
+    static std::unique_ptr<const Vector>
+    create_view(std::shared_ptr<const gko::Executor>                    exec,
+                const ::dealii::LinearAlgebra::ReadWriteVector<Number> &other);
+
+    /**
+     * Creates a constant vector that is a view on a constant
+     * dealii::LinearAlgebra::ReadWriteVector.
+     */
+    static std::unique_ptr<const Vector>
+    create_view(std::shared_ptr<const gko::Executor> exec,
+                const ::dealii::Vector<Number> &     other);
+
+    /**
+     * Returns iterator to the begin of the stored data.
+     * @warning Depending on the executor, this might be a pointer to device memory.
+     */
+    iterator
+    begin() noexcept;
+
+    /**
+     * Returns constant iterator to the begin of the stored data.
+     * @warning Depending on the executor, this might be a pointer to device memory.
+     */
+    const_iterator
+    begin() const noexcept;
+
+    /**
+     * Returns iterator to the end of the stored data.
+     * @warning Depending on the executor, this might be a pointer to device memory.
+     */
+    iterator
+    end() noexcept;
+
+    /**
+     * Returns constant iterator to the end of the stored data.
+     * @warning Depending on the executor, this might be a pointer to device memory.
+     */
+    const_iterator
+    end() const noexcept;
+
+
+    /**
+     * Access the element @p i of the vector.
+     * @warning Depending on the executor, this might access device memory.
+     */
+    Number
+    operator()(const size_type i) const noexcept;
+
+    /**
+     * Mutable access the element @p i of the vector.
+     * @warning Depending on the executor, this might access device memory.
+     */
+    Number &
+    operator()(const size_type i) noexcept;
+
+    // @copydoc operator()(const size_type) const
+    Number
+    operator[](const size_type i) const noexcept;
+
+    // @copydoc operator()(const size_type)
+    Number &
+    operator[](const size_type i) noexcept;
+
+    /**
+     * Returns the size of the vector.
+     */
+    size_type
+    size() const noexcept;
+
+    /**
+     * Returns the index set [0, size()). Necessary for compatability
+     * with other vector types.
+     */
+    IndexSet
+    locally_owned_elements() const;
+
+    std::unique_ptr<const ginkgo_type>
+    get_gko_object() const noexcept;
+
+    std::unique_ptr<ginkgo_type>
+    get_gko_object() noexcept;
+
+    Vector &
+    operator=(const Number s);
+
+    /**
+     * Multiplies all elements with the value @p factor.
+     */
+    Vector &
+    operator*=(const Number factor);
+
+    /**
+     * Divides all elements with the value @p factor.
+     */
+    Vector &
+    operator/=(const Number factor);
+
+    /**
+     * Adds the vector @p V to this.
+     */
+    Vector &
+    operator+=(const Vector &V);
+
+    /**
+     * Subtracts the vector @p V from this.
+     */
+    Vector &
+    operator-=(const Vector &V);
+
+    /**
+     * Returns the scalar product between this and @p V. For complex types, @p V is conjugated.
+     */
+    Number
+    operator*(const Vector &V) const;
+
+    /**
+     * Adds @p a to all elements of this.
+     * @note ince there is no native Ginkgo support for this, this uses a fill and an add operation
+     */
+    void
+    add(const Number a);
+
+    /**
+     * Computes the axpy operation `*this = *this + a * V`.
+     */
+    void
+    add(const Number a, const Vector &V);
+
+    /**
+     * Computes the operation `*this = *this + a * V + b * W`.
+     * @note Since there is no native Ginkgo support for this, this uses a copy and two add operations
+     */
+    void
+    add(const Number a, const Vector &V, const Number b, const Vector &W);
+
+    /**
+     * @copydoc add(coconst size_type , const size_type *, const Number *)
+     */
+    void
+    add(const std::vector<size_type> &indices,
+        const dealii::Vector<Number> &values);
+
+    /**
+     * @copydoc add(coconst size_type , const size_type *, const Number *)
+     */
+    void
+    add(std::vector<unsigned int> &indices, std::vector<Number> &values);
+
+    /**
+     * Adds the values from @p values to the elements at indices @p indices, i. e.
+     * `*this[indices[i]] += values[i]`.
+     * @note Since there is no native Ginkgo support for this, this might involve copies
+     *       between host and device memory.
+     */
+    void
+    add(const size_type  n_elements,
+        const size_type *indices,
+        const Number *   values);
+
+
+    /**
+     * Computes the operation `*this = s * (*this) + a * V`.
+     * @note Since there is no native Ginkgo support for this, this uses a scale and add operation.
+     */
+    void
+    sadd(const Number s, const Number a, const Vector &V);
+
+    /**
+     * Scales the elements componentwise with the values in @p scaling_factors.
+     */
+    void
+    scale(const Vector &scaling_factors);
+
+    /**
+     * Computes the operation `*this = a * V`
+     * @note Since there is no native Ginkgo support for this, this uses a copy and a scale operation.
+     */
+    void
+    equ(const Number a, const Vector &V);
+
+    /**
+     * Checks if all values of the vector are zero.
+     * @note Since there is no native Ginkgo support for this, this computes the L1 norm and compares against 100 * minimal_number
+     */
+    bool
+    all_zero() const;
+
+    /**
+     * @warning Not implemented
+     */
+    Number
+    mean_value() const;
+
+    /**
+     * Returns the l1 norm of this vector.
+     */
+    real_type
+    l1_norm() const;
+
+    /**
+     * Returns the l2 norm of this vector.
+     * @return
+     */
+    real_type
+    l2_norm() const;
+
+    /**
+     * @warning Not implemented
+     */
+    real_type
+    linfty_norm() const;
+
+    /**
+     * Returns the result of scalar product `<*this + a * V, W>`
+     * @note Since there is no native Ginkgo support for this, this uses an add and a scalar product operation
+     */
+    Number
+    add_and_dot(const Number a, const Vector &V, const Vector &W);
+
+    /**
+     * Prints the vector to the stream @p out. The parameter @p accross is ignored, it
+     * will always print the vector using the matrix market format.
+     */
+    void
+    print(std::ostream & out,
+          const unsigned precision  = 3,
+          const bool     scientific = true,
+          const bool     accross    = true);
+
+    /**
+     * The memory consumption in bytes.
+     */
+    std::size_t
+    memory_consumption() const;
+
+    /**
+     * No-op, only necessary for compatibility.
+     */
+    void
+    compress(const VectorOperation::values = VectorOperation::insert) const
+    {}
+
+    /**
+     * No-op, only necessary for compatibility.
+     */
+    bool
+    has_ghost_elements() const
+    {
+      return false;
+    }
+
+    /**
+     * Copies the elements at the indices @p indices to the vector @p values.
+     */
+    template <typename Number2>
+    void
+    extract_subvector_to(const std::vector<size_type> &indices,
+                         std::vector<Number2> &        values) const;
+
+    /**
+     * Copies the element at the indices defined in the range @p indices_begin,
+     * @p indices_end to the output iterator @p values_begin
+     */
+    template <typename ForwardIterator, typename OutputIterator>
+    void
+    extract_subvector_to(ForwardIterator       indices_begin,
+                         const ForwardIterator indices_end,
+                         OutputIterator        values_begin) const;
+
+    /**
+     * Checks if the index @p index is within the local range ([0, size())) of this vector.
+     */
+    bool
+    in_local_range(const size_type index) const;
+
+  private:
+    std::unique_ptr<ginkgo_type> data_;
+  };
+
+  template <typename Number>
+  typename Vector<Number>::iterator
+  Vector<Number>::begin() noexcept
+  {
+    return data_->get_values();
+  }
+
+  template <typename Number>
+  typename Vector<Number>::const_iterator
+  Vector<Number>::begin() const noexcept
+  {
+    return data_->get_const_values();
+  }
+
+
+  template <typename Number>
+  typename Vector<Number>::iterator
+  Vector<Number>::end() noexcept
+  {
+    return data_->get_values() + size();
+  }
+
+  template <typename Number>
+  typename Vector<Number>::const_iterator
+  Vector<Number>::end() const noexcept
+  {
+    return data_->get_const_values() + size();
+  }
+
+  template <typename Number>
+  Number
+  Vector<Number>::operator()(const size_type i) const noexcept
+  {
+    return data_->at(i);
+  }
+
+  template <typename Number>
+  Number &
+  Vector<Number>::operator()(const size_type i) noexcept
+  {
+    return data_->at(i);
+  }
+
+  template <typename Number>
+  Number
+  Vector<Number>::operator[](const size_type i) const noexcept
+  {
+    return data_->at(i);
+  }
+
+  template <typename Number>
+  Number &
+  Vector<Number>::operator[](const size_type i) noexcept
+  {
+    return data_->at(i);
+  }
+
+  template <typename Number>
+  typename Vector<Number>::size_type
+  Vector<Number>::size() const noexcept
+  {
+    return data_->get_size()[0];
+  }
+
+  template <typename Number>
+  template <typename ForwardIterator, typename OutputIterator>
+  void
+  Vector<Number>::extract_subvector_to(ForwardIterator       indices_begin,
+                                       const ForwardIterator indices_end,
+                                       OutputIterator        values_begin) const
+  {
+    auto host_data =
+      gko::make_temporary_clone(data_->get_executor()->get_master(), data_);
+    for (auto it = indices_begin; it != indices_end; ++it, ++values_begin)
+      {
+        *values_begin = host_data->get_const_values()[*it];
+      }
+  }
+
+  template <typename Number>
+  template <typename Number2>
+  void
+  Vector<Number>::extract_subvector_to(const std::vector<size_type> &indices,
+                                       std::vector<Number2> &values) const
+  {
+    extract_subvector_to(indices.begin(), indices.end(), values.begin());
+  }
+} // namespace GinkgoWrappers
+
+/**
+ * Declare dealii::GinkgoWrappers::Vector< Number > as serial vector.
+ *
+ * @relatesalso Vector
+ */
+template <typename Number>
+struct is_serial_vector<GinkgoWrappers::Vector<Number>> : std::true_type
+{};
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif
+
+#endif // dealii_ginkgo_vector_h

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -91,6 +91,14 @@ namespace LinearAlgebra
   }
 } // namespace LinearAlgebra
 #  endif
+
+#  ifdef DEAL_II_WITH_GINKGO
+namespace GinkgoWrappers
+{
+  template <typename Number>
+  class Vector;
+}
+#  endif
 #endif
 
 namespace LinearAlgebra
@@ -498,6 +506,15 @@ namespace LinearAlgebra
     {
       import_elements(V, operation, communication_pattern);
     }
+#endif
+
+
+#ifdef DEAL_II_WITH_GINKGO
+    void
+    import(const GinkgoWrappers::Vector<Number> &ginkgo_vec,
+           VectorOperation::values               operation,
+           const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
+             & = {});
 #endif
 
     /**

--- a/source/lac/CMakeLists.txt
+++ b/source/lac/CMakeLists.txt
@@ -125,9 +125,10 @@ endif()
 
 if(DEAL_II_WITH_GINKGO)
   set(_unity_include_src
-    ${_unity_include_src}
-    ginkgo_solver.cc
-  )
+      ${_unity_include_src}
+      ginkgo_solver.cc
+      ginkgo_vector.cc
+      )
 endif()
 
 # Also add Trilinos wrapper files

--- a/source/lac/ginkgo_vector.cc
+++ b/source/lac/ginkgo_vector.cc
@@ -437,6 +437,21 @@ namespace GinkgoWrappers
     add(indices.size(), indices.data(), values.begin());
   }
 
+  template <typename Number>
+  void
+  Vector<Number>::extract_subvector_to(
+    const ArrayView<const size_type> &indices,
+    ArrayView<Number> &               values) const
+  {
+    Assert(indices.size() == values.size(),
+           ExcDimensionMismatch(indices.size(), values.size()));
+    auto host_data =
+      gko::make_temporary_clone(data_->get_executor()->get_master(), data_);
+    for (size_type i = 0; i < indices.size(); ++i)
+      {
+        values[i] = host_data->get_const_values()[indices[i]];
+      }
+  }
 
 #  define DECLARE_GINKGO_VECTOR(_type) class Vector<_type>
 

--- a/source/lac/ginkgo_vector.cc
+++ b/source/lac/ginkgo_vector.cc
@@ -1,0 +1,453 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 - 2023 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+#include <deal.II/base/logstream.h>
+
+#include <deal.II/lac/ginkgo_vector.h>
+
+#ifdef DEAL_II_WITH_GINKGO
+
+#  include <deal.II/lac/exceptions.h>
+#  include <deal.II/lac/vector.h>
+
+#  include <ginkgo/core/base/mtx_io.hpp>
+#  include <ginkgo/core/base/types.hpp>
+
+#  include <cmath>
+#  include <memory>
+
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace GinkgoWrappers
+{
+  template <typename Number>
+  Vector<Number>::Vector(std::shared_ptr<const gko::Executor> exec)
+    : data_(ginkgo_type::create(std::move(exec)))
+  {}
+
+  template <typename Number>
+  Vector<Number>::Vector(std::unique_ptr<ginkgo_type> v)
+    : data_(std::move(v))
+  {}
+
+  template <typename Number>
+  Vector<Number>::Vector(std::shared_ptr<const gko::Executor> exec,
+                         const size_type                      size)
+    : data_(ginkgo_type::create(std::move(exec), gko::dim<2>{size, 1}))
+  {}
+
+  template <typename Number>
+  Vector<Number>::Vector(std::shared_ptr<const gko::Executor> exec,
+                         const std::initializer_list<Number> &list)
+    : data_(gko::initialize<ginkgo_type>(list, std::move(exec)))
+  {}
+
+  template <typename Number>
+  Vector<Number>::Vector(const Vector<Number> &other)
+    : Subscriptor()
+    , data_(gko::clone(other.data_))
+  {}
+
+  template <typename Number>
+  Vector<Number>::Vector(Vector<Number> &&other) noexcept
+    : Vector(other.data_->get_executor())
+  {
+    data_->move_from(other.data_.get());
+  }
+
+  template <typename Number>
+  Vector<Number>
+  Vector<Number>::create_with_same_size(const Vector<Number> &V,
+                                        const bool omit_zeroing_entries)
+  {
+    Vector result{V.get_gko_object()->get_executor(), V.size()};
+    if (!omit_zeroing_entries)
+      {
+        result = Number(0.0);
+      }
+    return result;
+  }
+
+  template <typename Number>
+  Vector<Number> &
+  Vector<Number>::operator=(const Vector<Number> &other)
+  {
+    if (this != &other)
+      {
+        data_->copy_from(other.data_.get());
+      }
+    return *this;
+  }
+
+  template <typename Number>
+  Vector<Number> &
+  Vector<Number>::operator=(Vector<Number> &&other) noexcept(false)
+  {
+    if (this != &other)
+      {
+        data_->move_from(other.data_.get());
+      }
+    return *this;
+  }
+
+  template <typename Number>
+  std::unique_ptr<const typename Vector<Number>::ginkgo_type>
+  Vector<Number>::get_gko_object() const noexcept
+  {
+    return gko::make_const_dense_view(data_);
+  }
+
+  template <typename Number>
+  std::unique_ptr<typename Vector<Number>::ginkgo_type>
+  Vector<Number>::get_gko_object() noexcept
+  {
+    return gko::make_dense_view(data_);
+  }
+
+  template <typename Number>
+  std::size_t
+  Vector<Number>::memory_consumption() const
+  {
+    return sizeof(Vector<Number>) + sizeof(ginkgo_type) +
+           sizeof(Number) * size();
+  }
+
+  template <typename Number>
+  void
+  Vector<Number>::print(std::ostream &     out,
+                        const unsigned int precision,
+                        const bool         scientific,
+                        const bool         accross [[maybe_unused]])
+  {
+    // TODO: figure out the meaning of accross
+    const auto default_precision = out.precision();
+
+    out << std::setprecision(precision);
+    if (scientific)
+      out << std::scientific;
+
+    gko::write(out, data_.get());
+
+    out << std::setprecision(default_precision);
+    if (scientific)
+      out << std::defaultfloat;
+  }
+
+  template <typename Number>
+  IndexSet
+  Vector<Number>::locally_owned_elements() const
+  {
+    return IndexSet(size());
+  }
+
+  template <typename Number>
+  Number
+  Vector<Number>::add_and_dot(const Number a, const Vector &V, const Vector &W)
+  {
+    this->add(a, V);
+    return *this * W;
+  }
+
+  template <typename Number>
+  typename Vector<Number>::real_type
+  Vector<Number>::linfty_norm() const
+  {
+    throw ExcNotImplemented();
+  }
+
+  template <typename Number>
+  typename Vector<Number>::real_type
+  Vector<Number>::l2_norm() const
+  {
+    auto result = ginkgo_norm_type::create(data_->get_executor()->get_master(),
+                                           gko::dim<2>{1, 1});
+    data_->compute_norm2(result.get());
+    return result->at(0);
+  }
+
+  template <typename Number>
+  typename Vector<Number>::real_type
+  Vector<Number>::l1_norm() const
+  {
+    auto result = ginkgo_norm_type ::create(data_->get_executor()->get_master(),
+                                            gko::dim<2>{1, 1});
+    data_->compute_norm1(result.get());
+    return result->at(0);
+  }
+
+  template <typename Number>
+  Number
+  Vector<Number>::mean_value() const
+  {
+    throw ExcNotImplemented();
+  }
+
+  template <typename Number>
+  bool
+  Vector<Number>::all_zero() const
+  {
+    auto norm = l1_norm();
+    return norm <=
+           1e2 * std::numeric_limits<gko::remove_complex<Number>>::min();
+  }
+
+  template <typename Number>
+  Vector<Number> &
+  Vector<Number>::operator=(const Number s)
+  {
+    data_->fill(s);
+    return *this;
+  }
+
+  template <typename Number>
+  void
+  Vector<Number>::equ(const Number a, const Vector &V)
+  {
+    AssertDimension(V.size(), size());
+    *this = V;
+    *this *= a;
+  }
+
+  template <typename Number>
+  void
+  Vector<Number>::scale(const Vector &scaling_factors)
+  {
+    AssertDimension(scaling_factors.size(), size());
+    auto exec = data_->get_executor();
+    auto col_view =
+      ginkgo_type::create(exec,
+                          gko::dim<2>{1, size()},
+                          gko::make_array_view(exec, size(), begin()),
+                          size());
+    col_view->scale(scaling_factors.data_.get());
+  }
+
+  template <typename Number>
+  void
+  Vector<Number>::sadd(const Number s, const Number a, const Vector &V)
+  {
+    AssertDimension(V.size(), size());
+    *this *= s;
+    this->add(a, V);
+  }
+
+  template <typename Number>
+  void
+  Vector<Number>::add(const Number  a,
+                      const Vector &V,
+                      const Number  b,
+                      const Vector &W)
+  {
+    AssertDimension(V.size(), size());
+    AssertDimension(W.size(), size());
+    Vector tmp(V);
+    tmp.add(b / a, W);
+    this->add(a, tmp);
+  }
+
+  template <typename Number>
+  void
+  Vector<Number>::add(const Number a, const Vector &V)
+  {
+    Assert(V.size() == size(), ExcDimensionMismatch(V.size(), size()));
+    auto a_dense = gko::initialize<ginkgo_type>({a}, data_->get_executor());
+    data_->add_scaled(a_dense.get(), V.data_.get());
+  }
+
+  template <typename Number>
+  void
+  Vector<Number>::add(const Number a)
+  {
+    auto a_vec = Vector(data_->get_executor(), size());
+    a_vec.data_->fill(a);
+    *this += a_vec;
+  }
+
+  template <typename Number>
+  Vector<Number> &
+  Vector<Number>::operator*=(const Number factor)
+  {
+    auto factor_dense =
+      gko::initialize<ginkgo_type>({factor}, data_->get_executor());
+    data_->scale(factor_dense.get());
+    return *this;
+  }
+
+  template <typename Number>
+  Vector<Number> &
+  Vector<Number>::operator/=(const Number factor)
+  {
+    auto factor_dense =
+      gko::initialize<ginkgo_type>({factor}, data_->get_executor());
+    data_->inv_scale(factor_dense.get());
+    return *this;
+  }
+
+  template <typename Number>
+  Vector<Number> &
+  Vector<Number>::operator+=(const Vector &V)
+  {
+    AssertDimension(V.size(), size());
+    auto one = gko::initialize<ginkgo_type>({1.0}, data_->get_executor());
+    data_->add_scaled(one.get(), V.data_.get());
+    return *this;
+  }
+
+  template <typename Number>
+  Vector<Number> &
+  Vector<Number>::operator-=(const Vector &V)
+  {
+    AssertDimension(V.size(), size());
+    auto neg_one = gko::initialize<ginkgo_type>({-1.0}, data_->get_executor());
+    data_->add_scaled(neg_one.get(), V.data_.get());
+    return *this;
+  }
+
+  template <typename Number>
+  Number
+  Vector<Number>::operator*(const Vector &V) const
+  {
+    AssertDimension(V.size(), size());
+    auto result = ginkgo_type ::create(data_->get_executor()->get_master(),
+                                       gko::dim<2>{1, 1});
+    data_->compute_conj_dot(V.data_.get(), result.get());
+    return result->at(0);
+  }
+
+  template <typename GinkgoType, typename ValueType>
+  std::unique_ptr<GinkgoType>
+  create_view_impl(std::shared_ptr<const gko::Executor> exec,
+                   types::global_dof_index              size,
+                   ValueType *                          data)
+  {
+    auto host_exec = exec->get_master();
+    return GinkgoType::create(host_exec,
+                              gko::dim<2>{size, 1},
+                              gko::make_array_view(host_exec, size, data),
+                              1);
+  }
+
+  template <typename Number>
+  std::unique_ptr<Vector<Number>>
+  Vector<Number>::create_view(
+    std::shared_ptr<const gko::Executor>              exec,
+    ::dealii::LinearAlgebra::ReadWriteVector<Number> &other)
+  {
+    return std::make_unique<Vector<Number>>(create_view_impl<ginkgo_type>(
+      std::move(exec), other.size(), other.begin()));
+  }
+
+  template <typename Number>
+  std::unique_ptr<Vector<Number>>
+  Vector<Number>::create_view(std::shared_ptr<const gko::Executor> exec,
+                              ::dealii::Vector<Number> &           other)
+  {
+    if (!exec->memory_accessible(exec->get_master()))
+      {
+        throw ExcInternalError(
+          "Can't create a view on CPU data, since the CPU memory is not accessible from the passed in executor.");
+      }
+    return std::make_unique<Vector<Number>>(create_view_impl<ginkgo_type>(
+      std::move(exec), other.size(), other.begin()));
+  }
+
+  template <typename Number>
+  std::unique_ptr<const Vector<Number>>
+  Vector<Number>::create_view(
+    std::shared_ptr<const gko::Executor>                    exec,
+    const ::dealii::LinearAlgebra::ReadWriteVector<Number> &other)
+  {
+    if (!exec->memory_accessible(exec->get_master()))
+      {
+        throw ExcInternalError(
+          "Can't create a view on CPU data, since the CPU memory is not accessible from the passed in executor.");
+      }
+    return std::make_unique<Vector<Number>>(create_view_impl<ginkgo_type>(
+      std::move(exec),
+      other.size(),
+      const_cast<
+        typename ::dealii::LinearAlgebra::ReadWriteVector<Number>::iterator>(
+        other.begin())));
+  }
+
+  template <typename Number>
+  std::unique_ptr<const Vector<Number>>
+  Vector<Number>::create_view(std::shared_ptr<const gko::Executor> exec,
+                              const ::dealii::Vector<Number> &     other)
+  {
+    return std::make_unique<Vector<Number>>(create_view_impl<ginkgo_type>(
+      std::move(exec),
+      other.size(),
+      const_cast<
+        typename ::dealii::LinearAlgebra::ReadWriteVector<Number>::iterator>(
+        other.begin())));
+  }
+
+  template <typename Number>
+  void
+  Vector<Number>::add(std::vector<unsigned int> &indices,
+                      std::vector<Number> &      values)
+  {
+    Assert(indices.size() == values.size(),
+           ExcDimensionMismatch(indices.size(), values.size()));
+    add(indices.size(), indices.data(), values.data());
+  }
+
+  template <typename Number>
+  void
+  Vector<Number>::add(const Vector::size_type  n_elements,
+                      const Vector::size_type *indices,
+                      const Number *           values)
+  {
+    auto host_data =
+      gko::make_temporary_clone(data_->get_executor()->get_master(), data_);
+    for (size_type i = 0; i < n_elements; ++i)
+      {
+        host_data->get_values()[indices[i]] = values[i];
+      }
+  }
+
+  template <typename Number>
+  bool
+  Vector<Number>::in_local_range(const Vector::size_type index) const
+  {
+    return index < size();
+  }
+  template <typename Number>
+  void
+  Vector<Number>::add(const std::vector<size_type> &indices,
+                      const dealii::Vector<Number> &values)
+  {
+    Assert(indices.size() == values.size(),
+           ExcDimensionMismatch(indices.size(), values.size()));
+    add(indices.size(), indices.data(), values.begin());
+  }
+
+
+#  define DECLARE_GINKGO_VECTOR(_type) class Vector<_type>
+
+  GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(DECLARE_GINKGO_VECTOR);
+
+#  undef DECLARE_GINKGO_VECTOR
+
+
+} // namespace GinkgoWrappers
+
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/tests/ginkgo/test_macros.h
+++ b/tests/ginkgo/test_macros.h
@@ -1,0 +1,95 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 - 2023 by the deal.II Authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_test_setup_h
+#define dealii_test_setup_h
+
+#include <ginkgo/ginkgo.hpp>
+
+
+template <typename T>
+gko::remove_complex<T>
+get_relative_error(const T a, const T b)
+{
+  return std::abs(a - b) / std::max(std::abs(a), std::abs(b));
+}
+
+template <typename T>
+constexpr gko::remove_complex<T>
+  tol = 10 * std::numeric_limits<gko::remove_complex<T>>::epsilon();
+
+
+#define TEST_ASSERT(_assertion)                                     \
+  if (!(_assertion))                                                \
+    {                                                               \
+      deallog << std::string(TEST_name) + ":FAIL with " #_assertion \
+              << std::endl;                                         \
+      self->test_success = false;                                   \
+      return;                                                       \
+    }                                                               \
+  static_assert(true, "Enforce ; after macro")
+
+
+#define TEST_ASSERT_NEAR(_a, _b, _tol)                                  \
+  {                                                                     \
+    auto rel_err = get_relative_error(_a, _b);                          \
+    if (!(rel_err <= _tol))                                             \
+      {                                                                 \
+        deallog << std::string(TEST_name) + ":FAIL with rel_error(" #_a \
+                                            ", " #_b ")["               \
+                << rel_err << "] <= " << _tol << std::endl;             \
+        self->test_success = false;                                     \
+        return;                                                         \
+      }                                                                 \
+  }                                                                     \
+  static_assert(true, "Enforce ; after macro")
+
+
+#define TEST_ASSERT_THROW(_cmd, _expected_exc) \
+  try                                          \
+    {                                          \
+      _cmd;                                    \
+      self->test_success = false;              \
+      return;                                  \
+    }                                          \
+  catch (const _expected_exc &)                \
+    {}                                         \
+  static_assert(true, "Enforce ; after macro")
+
+
+
+#define TEST(_name)                                             \
+  struct _name                                                  \
+  {                                                             \
+    _name()                                                     \
+      : test_success(true)                                      \
+    {                                                           \
+      _name::run(this);                                         \
+      if (test_success)                                         \
+        deallog << std::string(TEST_name) + ":OK" << std::endl; \
+    }                                                           \
+                                                                \
+    static void                                                 \
+    run(_name *self);                                           \
+                                                                \
+    static constexpr char TEST_name[] = #_name;                 \
+                                                                \
+    bool test_success;                                          \
+  };                                                            \
+  constexpr char _name::TEST_name[];                            \
+  void           _name::run(_name *self)
+
+
+#endif // dealii_test_setup_h

--- a/tests/ginkgo/vector.cc
+++ b/tests/ginkgo/vector.cc
@@ -1,0 +1,169 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 - 2023 by the deal.II Authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Tests the GinkgoWrappers::Vector interface
+
+#include "../tests.h"
+
+#include "test_macros.h"
+
+// all include files you need here
+#include <deal.II/lac/ginkgo_vector.h>
+
+
+auto exec = gko::ReferenceExecutor::create();
+
+
+TEST(can_create_from_executor)
+{
+  GinkgoWrappers::Vector<double> v(exec);
+
+  TEST_ASSERT(v.size() == 0);
+}
+
+
+TEST(can_create_from_ginkgo_object)
+{
+  GinkgoWrappers::Vector<double> v(
+    gko::initialize<gko::matrix::Dense<double>>({1, 2, 3}, exec));
+
+  TEST_ASSERT(v[0] == 1);
+  TEST_ASSERT(v[1] == 2);
+  TEST_ASSERT(v[2] == 3);
+}
+
+
+TEST(can_create_from_size)
+{
+  GinkgoWrappers::Vector<double> v(exec, 7);
+
+  TEST_ASSERT(v.size() == 7);
+}
+
+
+TEST(can_create_from_initializer_list)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 5, 3, 9});
+
+  TEST_ASSERT(v[0] == 1);
+  TEST_ASSERT(v[1] == 5);
+  TEST_ASSERT(v[2] == 3);
+  TEST_ASSERT(v[3] == 9);
+}
+
+
+TEST(can_copy_construct)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 5, 3, 9});
+
+  GinkgoWrappers::Vector<double> v2(v);
+
+  TEST_ASSERT(v2.size() == v.size());
+  TEST_ASSERT(v2.get_gko_object() != v.get_gko_object());
+  for (std::size_t i = 0; i < v.size(); ++i)
+    {
+      TEST_ASSERT(v2[i] == v[i]);
+    }
+}
+
+
+TEST(can_move_construct)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 5, 3, 9});
+
+  GinkgoWrappers::Vector<double> v2(std::move(v));
+
+  TEST_ASSERT(v2.size() == 4);
+  TEST_ASSERT(v.size() == 0);
+  TEST_ASSERT(v2.get_gko_object() != v.get_gko_object());
+  TEST_ASSERT(v2[0] == 1);
+  TEST_ASSERT(v2[1] == 5);
+  TEST_ASSERT(v2[2] == 3);
+  TEST_ASSERT(v2[3] == 9);
+}
+
+
+TEST(can_access_ginkgo_object)
+{
+  GinkgoWrappers::Vector<double> v(exec, 10);
+
+  auto obj = v.get_gko_object();
+
+  TEST_ASSERT(obj);
+}
+
+
+TEST(wrapper_same_as_ginkgo_object)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 5, 3, 9});
+
+  auto obj = v.get_gko_object();
+
+  TEST_ASSERT(obj->get_size()[0] == v.size());
+  TEST_ASSERT(obj->get_size()[1] == 1);
+  for (std::size_t i = 0; i < v.size(); ++i)
+    {
+      TEST_ASSERT(obj->at(i) == v[i]);
+    }
+}
+
+TEST(can_create_view_of_dealii_object)
+{
+  std::vector<double>                   values{3, 5, 2};
+  dealii::LinearAlgebra::Vector<double> dealii_obj(values.begin(),
+                                                   values.end());
+
+  auto v = GinkgoWrappers::Vector<double>::create_view(exec, dealii_obj);
+
+  TEST_ASSERT(v->size() == dealii_obj.size());
+  TEST_ASSERT(v->begin() == dealii_obj.begin());
+}
+
+TEST(can_create_view_of_const_dealii_object)
+{
+  std::vector<double>                   values{3, 5, 2};
+  dealii::LinearAlgebra::Vector<double> dealii_obj(values.begin(),
+                                                   values.end());
+
+  auto v = GinkgoWrappers::Vector<double>::create_view(
+    exec,
+    static_cast<const dealii::LinearAlgebra::Vector<double> &>(dealii_obj));
+
+  TEST_ASSERT(v->size() == dealii_obj.size());
+  TEST_ASSERT(v->begin() == dealii_obj.begin());
+  TEST_ASSERT(
+    std::is_const<typename std::decay<decltype(v)>::type::element_type>::value);
+}
+
+int
+main()
+{
+  // Initialize deallog for test output.
+  // This also reroutes deallog output to a file "output".
+  initlog();
+
+  can_create_from_executor();
+  can_create_from_ginkgo_object();
+  can_create_from_size();
+  can_create_from_initializer_list();
+  can_copy_construct();
+  can_move_construct();
+  can_access_ginkgo_object();
+  wrapper_same_as_ginkgo_object();
+  can_create_view_of_dealii_object();
+  can_create_view_of_const_dealii_object();
+
+  return 0;
+}

--- a/tests/ginkgo/vector.output
+++ b/tests/ginkgo/vector.output
@@ -1,0 +1,11 @@
+
+DEAL:can_create_from_executor:OK
+DEAL:can_create_from_ginkgo_object:OK
+DEAL:can_create_from_size:OK
+DEAL:can_create_from_initializer_list:OK
+DEAL:can_copy_construct:OK
+DEAL:can_move_construct:OK
+DEAL:can_access_ginkgo_object:OK
+DEAL:wrapper_same_as_ginkgo_object:OK
+DEAL:can_create_view_of_dealii_object:OK
+DEAL:can_create_view_of_const_dealii_object:OK

--- a/tests/ginkgo/vector_ops.cc
+++ b/tests/ginkgo/vector_ops.cc
@@ -1,0 +1,175 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 - 2023 by the deal.II Authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Tests the GinkgoWrappers::Vector interface for vector space operations
+
+#include "../tests.h"
+
+#include "test_macros.h"
+
+// all include files you need here
+#include <deal.II/lac/ginkgo_vector.h>
+
+auto exec = gko::ReferenceExecutor::create();
+
+
+
+TEST(can_set_to_number)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 2, 3, 4});
+
+  v = 3.3;
+
+  TEST_ASSERT_NEAR(v[0], 3.3, tol<double>);
+  TEST_ASSERT_NEAR(v[1], 3.3, tol<double>);
+  TEST_ASSERT_NEAR(v[2], 3.3, tol<double>);
+  TEST_ASSERT_NEAR(v[3], 3.3, tol<double>);
+}
+
+TEST(can_scale_with_number)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 2, 3, 4});
+
+  v *= 3.3;
+
+  TEST_ASSERT_NEAR(v[0], 3.3, tol<double>);
+  TEST_ASSERT_NEAR(v[1], 6.6, tol<double>);
+  TEST_ASSERT_NEAR(v[2], 9.9, tol<double>);
+  TEST_ASSERT_NEAR(v[3], 13.2, tol<double>);
+}
+
+TEST(can_divide_by_number)
+{
+  GinkgoWrappers::Vector<double> v(exec, {3.3, 6.6, 9.9, 13.2});
+
+  v /= 3.3;
+
+  TEST_ASSERT_NEAR(v[0], 1.0, tol<double>);
+  TEST_ASSERT_NEAR(v[1], 2.0, tol<double>);
+  TEST_ASSERT_NEAR(v[2], 3.0, tol<double>);
+  TEST_ASSERT_NEAR(v[3], 4.0, tol<double>);
+}
+
+TEST(can_add_vector)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 2, 3, 4});
+  GinkgoWrappers::Vector<double> w(exec, {4, 3, 2, 1});
+
+  v += w;
+
+  for (size_t i = 0; i < v.size(); ++i)
+    {
+      TEST_ASSERT_NEAR(v[i], 5.0, tol<double>);
+    }
+}
+
+TEST(can_substract_vector)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 2, 3, 4});
+  GinkgoWrappers::Vector<double> w(exec, {4, 3, 2, 1});
+
+  v -= w;
+
+  TEST_ASSERT_NEAR(v[0], -3.0, tol<double>);
+  TEST_ASSERT_NEAR(v[1], -1.0, tol<double>);
+  TEST_ASSERT_NEAR(v[2], 1.0, tol<double>);
+  TEST_ASSERT_NEAR(v[3], 3.0, tol<double>);
+}
+
+TEST(can_add_number)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 2, 3, 4});
+
+  v.add(3.3);
+
+  TEST_ASSERT_NEAR(v[0], 4.3, tol<double>);
+  TEST_ASSERT_NEAR(v[1], 5.3, tol<double>);
+  TEST_ASSERT_NEAR(v[2], 6.3, tol<double>);
+  TEST_ASSERT_NEAR(v[3], 7.3, tol<double>);
+}
+
+TEST(can_add_number_vector)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 2, 3, 4});
+  GinkgoWrappers::Vector<double> w(exec, {4, 3, 2, 1});
+
+  v.add(3.3, w);
+
+  TEST_ASSERT_NEAR(v[0], 14.2, tol<double>);
+  TEST_ASSERT_NEAR(v[1], 11.9, tol<double>);
+  TEST_ASSERT_NEAR(v[2], 9.6, tol<double>);
+  TEST_ASSERT_NEAR(v[3], 7.3, tol<double>);
+}
+
+TEST(can_add_number_vector_number_vector)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 2, 3, 4});
+  GinkgoWrappers::Vector<double> w(exec, {4, 3, 2, 1});
+  GinkgoWrappers::Vector<double> u(exec, {2, 1, 4, 3});
+
+  v.add(1.1, w, 2.2, u);
+
+  TEST_ASSERT_NEAR(v[0], 9.8, tol<double>);
+  TEST_ASSERT_NEAR(v[1], 7.5, tol<double>);
+  TEST_ASSERT_NEAR(v[2], 14.0, tol<double>);
+  TEST_ASSERT_NEAR(v[3], 11.7, tol<double>);
+}
+
+TEST(can_sadd_number_number_vector)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 2, 3, 4});
+  GinkgoWrappers::Vector<double> w(exec, {4, 3, 2, 1});
+
+  v.sadd(1.1, 2.2, w);
+
+  TEST_ASSERT_NEAR(v[0], 9.9, tol<double>);
+  TEST_ASSERT_NEAR(v[1], 8.8, tol<double>);
+  TEST_ASSERT_NEAR(v[2], 7.7, tol<double>);
+  TEST_ASSERT_NEAR(v[3], 6.6, tol<double>);
+}
+
+TEST(can_equ)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 2, 3, 4});
+  GinkgoWrappers::Vector<double> w(exec, {4, 3, 2, 1});
+
+  v.equ(2.2, w);
+
+  TEST_ASSERT_NEAR(v[0], 8.8, tol<double>);
+  TEST_ASSERT_NEAR(v[1], 6.6, tol<double>);
+  TEST_ASSERT_NEAR(v[2], 4.4, tol<double>);
+  TEST_ASSERT_NEAR(v[3], 2.2, tol<double>);
+}
+
+int
+main()
+{
+  // Initialize deallog for test output.
+  // This also reroutes deallog output to a file "output".
+  initlog();
+
+  can_set_to_number();
+  can_scale_with_number();
+  can_divide_by_number();
+  can_add_vector();
+  can_substract_vector();
+  can_add_number();
+  can_add_number_vector();
+  can_add_number_vector_number_vector();
+  can_sadd_number_number_vector();
+  can_equ();
+
+  return 0;
+}

--- a/tests/ginkgo/vector_ops.output
+++ b/tests/ginkgo/vector_ops.output
@@ -1,0 +1,11 @@
+
+DEAL:can_set_to_number:OK
+DEAL:can_scale_with_number:OK
+DEAL:can_divide_by_number:OK
+DEAL:can_add_vector:OK
+DEAL:can_substract_vector:OK
+DEAL:can_add_number:OK
+DEAL:can_add_number_vector:OK
+DEAL:can_add_number_vector_number_vector:OK
+DEAL:can_sadd_number_number_vector:OK
+DEAL:can_equ:OK

--- a/tests/ginkgo/vector_sp.cc
+++ b/tests/ginkgo/vector_sp.cc
@@ -1,0 +1,112 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 - 2023 by the deal.II Authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Tests the GinkgoWrappers::Vector interface for vector space operations that
+// rely on reductions
+
+#include "../tests.h"
+
+#include "test_macros.h"
+
+// all include files you need here
+#include <deal.II/lac/ginkgo_vector.h>
+
+auto exec = gko::ReferenceExecutor::create();
+
+TEST(can_compute_scalar_product)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 2, 3, 4});
+  GinkgoWrappers::Vector<double> w(exec, {4, 3, 2, 1});
+
+  auto sp = v * w;
+
+  TEST_ASSERT_NEAR(sp, 20.0, tol<double>);
+}
+
+TEST(can_compute_l1_norm)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, -2, 3, -4});
+
+  auto norm = v.l1_norm();
+
+  TEST_ASSERT_NEAR(norm, 10.0, tol<double>);
+}
+
+TEST(can_compute_l2_norm)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, -2, 3, -4});
+
+  auto norm = v.l2_norm();
+
+  TEST_ASSERT_NEAR(norm, std::sqrt(30), tol<double>);
+}
+
+TEST(throws_on_linfty_norm)
+{
+  GinkgoWrappers::Vector<double> v(exec);
+
+  TEST_ASSERT_THROW(v.linfty_norm(), ExcNotImplemented);
+}
+
+TEST(can_compute_add_and_dot)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 2, 3, 4});
+  GinkgoWrappers::Vector<double> w(exec, {4, 3, 2, 1});
+  GinkgoWrappers::Vector<double> u(exec, {2, 1, 4, 3});
+
+  auto sp = v.add_and_dot(3.3, w, u);
+
+  TEST_ASSERT_NEAR(sp, 100.6, tol<double>);
+}
+
+TEST(can_compute_all_zero)
+{
+  {
+    GinkgoWrappers::Vector<double> v(exec, {1, 5, 3, 9});
+
+    TEST_ASSERT(v.all_zero() == false);
+  }
+  {
+    GinkgoWrappers::Vector<double> v(exec, {0, 0, 0});
+
+    TEST_ASSERT(v.all_zero() == true);
+  }
+}
+
+TEST(throws_on_mean_value)
+{
+  GinkgoWrappers::Vector<double> v(exec);
+
+  TEST_ASSERT_THROW(v.mean_value(), ExcNotImplemented);
+}
+
+
+int
+main()
+{
+  // Initialize deallog for test output.
+  // This also reroutes deallog output to a file "output".
+  initlog();
+
+  can_compute_scalar_product();
+  can_compute_l1_norm();
+  can_compute_l2_norm();
+  throws_on_linfty_norm();
+  can_compute_add_and_dot();
+  can_compute_all_zero();
+  throws_on_mean_value();
+
+  return 0;
+}

--- a/tests/ginkgo/vector_sp.output
+++ b/tests/ginkgo/vector_sp.output
@@ -1,0 +1,8 @@
+
+DEAL:can_compute_scalar_product:OK
+DEAL:can_compute_l1_norm:OK
+DEAL:can_compute_l2_norm:OK
+DEAL:throws_on_linfty_norm:OK
+DEAL:can_compute_add_and_dot:OK
+DEAL:can_compute_all_zero:OK
+DEAL:throws_on_mean_value:OK


### PR DESCRIPTION
Hello,

this is the first PR extending the current Ginkgo wrappers to enable a more seamless integration with Ginkgo. The aim is to provide wrappers that can be used nearly interchangeable with existing sequential vectors and matrices. This PR adds wrappers for sequential Ginkgo vectors.

Related PRs: 
- #15202 
- #15203 
- #15204 

I will also create a PR with an example, showing how the new wrappers can be used. Since this requires instantiating many deal.ii functions with Ginkgo wapper types, I'm holding off on this until #15204 is merged. Otherwise it becomes difficult to separate the changes cleanly.