### PR TITLE
Remove overhead from AlignedVector in FEFaceNormalEvaluationImpl

### DIFF
--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -3552,9 +3552,9 @@ namespace internal
                                  fe_degree + 1,
                                  0,
                                  Number>
-            evalf(shape_data[face_no % 2],
-                  AlignedVector<Number>(),
-                  AlignedVector<Number>(),
+            evalf(shape_data[face_no % 2].begin(),
+                  nullptr,
+                  nullptr,
                   n_points_1d,
                   0);
 

--- a/include/deal.II/matrix_free/tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/tensor_product_kernels.h
@@ -231,6 +231,22 @@ namespace internal
       (void)dummy2;
     }
 
+    /**
+     * Constructor, taking the data from ShapeInfo via raw pointers
+     */
+    EvaluatorTensorProduct(const Number2 *    shape_values,
+                           const Number2 *    shape_gradients,
+                           const Number2 *    shape_hessians,
+                           const unsigned int dummy1 = 0,
+                           const unsigned int dummy2 = 0)
+      : shape_values(shape_values)
+      , shape_gradients(shape_gradients)
+      , shape_hessians(shape_hessians)
+    {
+      (void)dummy1;
+      (void)dummy2;
+    }
+
     template <int direction, bool contract_over_rows, bool add>
     void
     values(const Number in[], Number out[]) const


### PR DESCRIPTION
We observed overhead from the destructor of `AlignedVector` in `FEFaceNormalEvaluationImpl`.

Circumvent this by using raw pointers instead.

@kronbichler 