### PR TITLE
KINSOL: do not copy vectors internally

### DIFF
--- a/include/deal.II/sundials/kinsol.h
+++ b/include/deal.II/sundials/kinsol.h
@@ -739,20 +739,6 @@ namespace SUNDIALS
     SUNContext kinsol_ctx;
 #  endif
 
-    /**
-     * KINSOL solution vector.
-     */
-    N_Vector solution;
-
-    /**
-     * KINSOL solution scale.
-     */
-    N_Vector u_scale;
-
-    /**
-     * KINSOL f scale.
-     */
-    N_Vector f_scale;
 
     /**
      * Memory pool of vectors.


### PR DESCRIPTION
I am not happy that we still set up the (often unneeded) scaling vectors on every call. I might change that in another PR if it is problematic in my application.

 I can remove the now unnecessary `internal::copy` functionality in a follow-up PR.

Closes #12066 