### PR TITLE
Add an abstract base class ReadVector purely for vector access.

### DIFF
--- a/doc/news/changes/incompatibilities/20230701DavidWells
+++ b/doc/news/changes/incompatibilities/20230701DavidWells
@@ -1,0 +1,5 @@
+Changed: Most of the member functions of FEValues now have different template
+parameters. As a result, some function calls which relied on implicit
+conversions to ArrayView now require explicit conversions instead.
+<br>
+(David Wells, 2023/07/01)

--- a/doc/news/changes/major/20230701DavidWells
+++ b/doc/news/changes/major/20230701DavidWells
@@ -1,0 +1,4 @@
+New: All vector classes in deal.II now inherit from ReadVector, which provides
+some common read operations.
+<br>
+(David Wells, 2023/07/01)

--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -24,6 +24,8 @@
 
 #include <deal.II/grid/tria_accessor.h>
 
+#include <deal.II/lac/read_vector.h>
+
 #include <boost/container/small_vector.hpp>
 
 #include <set>
@@ -1589,11 +1591,11 @@ public:
    * caller to assure that the types of the numbers stored in input and output
    * vectors are compatible and with similar accuracy.
    */
-  template <class InputVector, typename ForwardIterator>
+  template <typename Number, typename ForwardIterator>
   void
-  get_dof_values(const InputVector &values,
-                 ForwardIterator    local_values_begin,
-                 ForwardIterator    local_values_end) const;
+  get_dof_values(const ReadVector<Number> &values,
+                 ForwardIterator           local_values_begin,
+                 ForwardIterator           local_values_end) const;
 
   /**
    * Collect the values of the given vector restricted to the dofs of this cell
@@ -1683,12 +1685,12 @@ public:
    * interpolation is presently only provided for cells by the finite element
    * classes.
    */
-  template <class InputVector, typename number>
+  template <typename Number>
   void
   get_interpolated_dof_values(
-    const InputVector &   values,
-    Vector<number> &      interpolated_values,
-    const types::fe_index fe_index = numbers::invalid_fe_index) const;
+    const ReadVector<Number> &values,
+    Vector<Number> &          interpolated_values,
+    const types::fe_index     fe_index = numbers::invalid_fe_index) const;
 
   /**
    * This function is the counterpart to get_interpolated_dof_values(): you

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -484,12 +484,11 @@ namespace FEValuesViews
      *
      * @dealiiRequiresUpdateFlags{update_gradients}
      */
-    template <class InputVector>
+    template <typename Number>
     void
     get_function_gradients(
-      const InputVector &fe_function,
-      std::vector<solution_gradient_type<typename InputVector::value_type>>
-        &gradients) const;
+      const ReadVector<Number> &                   fe_function,
+      std::vector<solution_gradient_type<Number>> &gradients) const;
 
     /**
      * This function relates to get_function_gradients() in the same way
@@ -1171,12 +1170,11 @@ namespace FEValuesViews
      *
      * @dealiiRequiresUpdateFlags{update_gradients}
      */
-    template <class InputVector>
+    template <typename Number>
     void
     get_function_gradients(
-      const InputVector &fe_function,
-      std::vector<solution_gradient_type<typename InputVector::value_type>>
-        &gradients) const;
+      const ReadVector<Number> &                   fe_function,
+      std::vector<solution_gradient_type<Number>> &gradients) const;
 
     /**
      * This function relates to get_function_gradients() in the same way
@@ -2157,12 +2155,11 @@ namespace FEValuesViews
      *
      * @dealiiRequiresUpdateFlags{update_gradients}
      */
-    template <class InputVector>
+    template <typename Number>
     void
     get_function_gradients(
-      const InputVector &fe_function,
-      std::vector<solution_gradient_type<typename InputVector::value_type>>
-        &gradients) const;
+      const ReadVector<Number> &                   fe_function,
+      std::vector<solution_gradient_type<Number>> &gradients) const;
 
     /**
      * This function relates to get_function_gradients() in the same way
@@ -2887,12 +2884,11 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_gradients}
    */
-  template <class InputVector>
+  template <typename Number>
   void
   get_function_gradients(
-    const InputVector &fe_function,
-    std::vector<Tensor<1, spacedim, typename InputVector::value_type>>
-      &gradients) const;
+    const ReadVector<Number> &                fe_function,
+    std::vector<Tensor<1, spacedim, Number>> &gradients) const;
 
   /**
    * This function does the same as the other get_function_gradients(), but
@@ -2910,13 +2906,11 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_gradients}
    */
-  template <class InputVector>
+  template <typename Number>
   void
   get_function_gradients(
-    const InputVector &fe_function,
-    std::vector<
-      std::vector<Tensor<1, spacedim, typename InputVector::value_type>>>
-      &gradients) const;
+    const ReadVector<Number> &                             fe_function,
+    std::vector<std::vector<Tensor<1, spacedim, Number>>> &gradients) const;
 
   /**
    * This function relates to the first of the get_function_gradients() function
@@ -2926,13 +2920,12 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_gradients}
    */
-  template <class InputVector>
+  template <typename Number>
   void
   get_function_gradients(
-    const InputVector &                             fe_function,
+    const ReadVector<Number> &                      fe_function,
     const ArrayView<const types::global_dof_index> &indices,
-    std::vector<Tensor<1, spacedim, typename InputVector::value_type>>
-      &gradients) const;
+    std::vector<Tensor<1, spacedim, Number>> &      gradients) const;
 
   /**
    * This function relates to the first of the get_function_gradients() function
@@ -2942,14 +2935,12 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_gradients}
    */
-  template <class InputVector>
+  template <typename Number>
   void
   get_function_gradients(
-    const InputVector &                             fe_function,
-    const ArrayView<const types::global_dof_index> &indices,
-    ArrayView<
-      std::vector<Tensor<1, spacedim, typename InputVector::value_type>>>
-               gradients,
+    const ReadVector<Number> &                          fe_function,
+    const ArrayView<const types::global_dof_index> &    indices,
+    ArrayView<std::vector<Tensor<1, spacedim, Number>>> gradients,
     const bool quadrature_points_fastest = false) const;
 
   /** @} */

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -41,6 +41,8 @@
 
 #include <deal.II/hp/q_collection.h>
 
+#include <deal.II/lac/read_vector.h>
+
 #include <algorithm>
 #include <memory>
 #include <type_traits>
@@ -419,12 +421,10 @@ namespace FEValuesViews
      *
      * @dealiiRequiresUpdateFlags{update_values}
      */
-    template <class InputVector>
+    template <typename Number>
     void
-    get_function_values(
-      const InputVector &fe_function,
-      std::vector<solution_value_type<typename InputVector::value_type>>
-        &values) const;
+    get_function_values(const ReadVector<Number> &                fe_function,
+                        std::vector<solution_value_type<Number>> &values) const;
 
     /**
      * Same as above, but using a vector of local degree-of-freedom values. In
@@ -1108,12 +1108,10 @@ namespace FEValuesViews
      *
      * @dealiiRequiresUpdateFlags{update_values}
      */
-    template <class InputVector>
+    template <typename Number>
     void
-    get_function_values(
-      const InputVector &fe_function,
-      std::vector<solution_value_type<typename InputVector::value_type>>
-        &values) const;
+    get_function_values(const ReadVector<Number> &                fe_function,
+                        std::vector<solution_value_type<Number>> &values) const;
 
     /**
      * Same as above, but using a vector of local degree-of-freedom values. In
@@ -1682,12 +1680,10 @@ namespace FEValuesViews
      *
      * @dealiiRequiresUpdateFlags{update_values}
      */
-    template <class InputVector>
+    template <typename Number>
     void
-    get_function_values(
-      const InputVector &fe_function,
-      std::vector<solution_value_type<typename InputVector::value_type>>
-        &values) const;
+    get_function_values(const ReadVector<Number> &                fe_function,
+                        std::vector<solution_value_type<Number>> &values) const;
 
     /**
      * Same as above, but using a vector of local degree-of-freedom values. In
@@ -2058,12 +2054,10 @@ namespace FEValuesViews
      *
      * @dealiiRequiresUpdateFlags{update_values}
      */
-    template <class InputVector>
+    template <typename Number>
     void
-    get_function_values(
-      const InputVector &fe_function,
-      std::vector<solution_value_type<typename InputVector::value_type>>
-        &values) const;
+    get_function_values(const ReadVector<Number> &                fe_function,
+                        std::vector<solution_value_type<Number>> &values) const;
 
     /**
      * Same as above, but using a vector of local degree-of-freedom values. In
@@ -2717,19 +2711,12 @@ public:
    * @post <code>values[q]</code> will contain the value of the field
    * described by fe_function at the $q$th quadrature point.
    *
-   * @note The actual data type of the input vector may be either a
-   * Vector&lt;T&gt;, BlockVector&lt;T&gt;, or one of the PETSc or Trilinos
-   * vector wrapper classes. It represents a global vector of DoF values
-   * associated with the DoFHandler object with which this FEValues object was
-   * last initialized.
-   *
    * @dealiiRequiresUpdateFlags{update_values}
    */
-  template <class InputVector>
+  template <typename Number>
   void
-  get_function_values(
-    const InputVector &                            fe_function,
-    std::vector<typename InputVector::value_type> &values) const;
+  get_function_values(const ReadVector<Number> &fe_function,
+                      std::vector<Number> &     values) const;
 
   /**
    * This function does the same as the other get_function_values(), but
@@ -2744,11 +2731,10 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_values}
    */
-  template <class InputVector>
+  template <typename Number>
   void
-  get_function_values(
-    const InputVector &                                    fe_function,
-    std::vector<Vector<typename InputVector::value_type>> &values) const;
+  get_function_values(const ReadVector<Number> &   fe_function,
+                      std::vector<Vector<Number>> &values) const;
 
   /**
    * Generate function values from an arbitrary vector. This function
@@ -2806,12 +2792,11 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_values}
    */
-  template <class InputVector>
+  template <typename Number>
   void
-  get_function_values(
-    const InputVector &                             fe_function,
-    const ArrayView<const types::global_dof_index> &indices,
-    std::vector<typename InputVector::value_type> & values) const;
+  get_function_values(const ReadVector<Number> &fe_function,
+                      const ArrayView<const types::global_dof_index> &indices,
+                      std::vector<Number> &values) const;
 
   /**
    * Generate vector function values from an arbitrary vector.
@@ -2821,12 +2806,11 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_values}
    */
-  template <class InputVector>
+  template <typename Number>
   void
-  get_function_values(
-    const InputVector &                                    fe_function,
-    const ArrayView<const types::global_dof_index> &       indices,
-    std::vector<Vector<typename InputVector::value_type>> &values) const;
+  get_function_values(const ReadVector<Number> &fe_function,
+                      const ArrayView<const types::global_dof_index> &indices,
+                      std::vector<Vector<Number>> &values) const;
 
 
   /**
@@ -2850,13 +2834,12 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_values}
    */
-  template <class InputVector>
+  template <typename Number>
   void
-  get_function_values(
-    const InputVector &                                      fe_function,
-    const ArrayView<const types::global_dof_index> &         indices,
-    ArrayView<std::vector<typename InputVector::value_type>> values,
-    const bool quadrature_points_fastest) const;
+  get_function_values(const ReadVector<Number> &fe_function,
+                      const ArrayView<const types::global_dof_index> &indices,
+                      ArrayView<std::vector<Number>>                  values,
+                      const bool quadrature_points_fastest) const;
 
   /** @} */
   /// @name Access to derivatives of global finite element fields
@@ -3882,11 +3865,10 @@ protected:
      * Call @p get_interpolated_dof_values of the iterator with the
      * given arguments.
      */
-    template <typename VectorType>
+    template <typename Number>
     void
-    get_interpolated_dof_values(
-      const VectorType &                       in,
-      Vector<typename VectorType::value_type> &out) const;
+    get_interpolated_dof_values(const ReadVector<Number> &in,
+                                Vector<Number> &          out) const;
 
     /**
      * Call @p get_interpolated_dof_values of the iterator with the

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -520,12 +520,11 @@ namespace FEValuesViews
      *
      * @dealiiRequiresUpdateFlags{update_hessians}
      */
-    template <class InputVector>
+    template <typename Number>
     void
     get_function_hessians(
-      const InputVector &fe_function,
-      std::vector<solution_hessian_type<typename InputVector::value_type>>
-        &hessians) const;
+      const ReadVector<Number> &                  fe_function,
+      std::vector<solution_hessian_type<Number>> &hessians) const;
 
     /**
      * This function relates to get_function_hessians() in the same way
@@ -559,12 +558,11 @@ namespace FEValuesViews
      *
      * @dealiiRequiresUpdateFlags{update_hessians}
      */
-    template <class InputVector>
+    template <typename Number>
     void
     get_function_laplacians(
-      const InputVector &fe_function,
-      std::vector<solution_laplacian_type<typename InputVector::value_type>>
-        &laplacians) const;
+      const ReadVector<Number> &                    fe_function,
+      std::vector<solution_laplacian_type<Number>> &laplacians) const;
 
     /**
      * This function relates to get_function_laplacians() in the same way
@@ -598,13 +596,12 @@ namespace FEValuesViews
      *
      * @dealiiRequiresUpdateFlags{update_third_derivatives}
      */
-    template <class InputVector>
+    template <typename Number>
     void
     get_function_third_derivatives(
-      const InputVector &fe_function,
-      std::vector<
-        solution_third_derivative_type<typename InputVector::value_type>>
-        &third_derivatives) const;
+      const ReadVector<Number> &                           fe_function,
+      std::vector<solution_third_derivative_type<Number>> &third_derivatives)
+      const;
 
     /**
      * This function relates to get_function_third_derivatives() in the same way
@@ -1212,12 +1209,11 @@ namespace FEValuesViews
      *
      * @dealiiRequiresUpdateFlags{update_gradients}
      */
-    template <class InputVector>
+    template <typename Number>
     void
     get_function_symmetric_gradients(
-      const InputVector &fe_function,
-      std::vector<
-        solution_symmetric_gradient_type<typename InputVector::value_type>>
+      const ReadVector<Number> &fe_function,
+      std::vector<solution_symmetric_gradient_type<Number>>
         &symmetric_gradients) const;
 
     /**
@@ -1252,12 +1248,11 @@ namespace FEValuesViews
      *
      * @dealiiRequiresUpdateFlags{update_gradients}
      */
-    template <class InputVector>
+    template <typename Number>
     void
     get_function_divergences(
-      const InputVector &fe_function,
-      std::vector<solution_divergence_type<typename InputVector::value_type>>
-        &divergences) const;
+      const ReadVector<Number> &                     fe_function,
+      std::vector<solution_divergence_type<Number>> &divergences) const;
 
     /**
      * This function relates to get_function_divergences() in the same way
@@ -1290,12 +1285,10 @@ namespace FEValuesViews
      *
      * @dealiiRequiresUpdateFlags{update_gradients}
      */
-    template <class InputVector>
+    template <typename Number>
     void
-    get_function_curls(
-      const InputVector &fe_function,
-      std::vector<solution_curl_type<typename InputVector::value_type>> &curls)
-      const;
+    get_function_curls(const ReadVector<Number> &               fe_function,
+                       std::vector<solution_curl_type<Number>> &curls) const;
 
     /**
      * This function relates to get_function_curls() in the same way
@@ -1327,12 +1320,11 @@ namespace FEValuesViews
      *
      * @dealiiRequiresUpdateFlags{update_hessians}
      */
-    template <class InputVector>
+    template <typename Number>
     void
     get_function_hessians(
-      const InputVector &fe_function,
-      std::vector<solution_hessian_type<typename InputVector::value_type>>
-        &hessians) const;
+      const ReadVector<Number> &                  fe_function,
+      std::vector<solution_hessian_type<Number>> &hessians) const;
 
     /**
      * This function relates to get_function_hessians() in the same way
@@ -1365,12 +1357,11 @@ namespace FEValuesViews
      *
      * @dealiiRequiresUpdateFlags{update_hessians}
      */
-    template <class InputVector>
+    template <typename Number>
     void
     get_function_laplacians(
-      const InputVector &fe_function,
-      std::vector<solution_laplacian_type<typename InputVector::value_type>>
-        &laplacians) const;
+      const ReadVector<Number> &                    fe_function,
+      std::vector<solution_laplacian_type<Number>> &laplacians) const;
 
     /**
      * This function relates to get_function_laplacians() in the same way
@@ -1403,13 +1394,12 @@ namespace FEValuesViews
      *
      * @dealiiRequiresUpdateFlags{update_third_derivatives}
      */
-    template <class InputVector>
+    template <typename Number>
     void
     get_function_third_derivatives(
-      const InputVector &fe_function,
-      std::vector<
-        solution_third_derivative_type<typename InputVector::value_type>>
-        &third_derivatives) const;
+      const ReadVector<Number> &                           fe_function,
+      std::vector<solution_third_derivative_type<Number>> &third_derivatives)
+      const;
 
     /**
      * This function relates to get_function_third_derivatives() in the same way
@@ -1745,12 +1735,11 @@ namespace FEValuesViews
      *
      * @dealiiRequiresUpdateFlags{update_gradients}
      */
-    template <class InputVector>
+    template <typename Number>
     void
     get_function_divergences(
-      const InputVector &fe_function,
-      std::vector<solution_divergence_type<typename InputVector::value_type>>
-        &divergences) const;
+      const ReadVector<Number> &                     fe_function,
+      std::vector<solution_divergence_type<Number>> &divergences) const;
 
     /**
      * This function relates to get_function_divergences() in the same way
@@ -2119,12 +2108,11 @@ namespace FEValuesViews
      *
      * @dealiiRequiresUpdateFlags{update_gradients}
      */
-    template <class InputVector>
+    template <typename Number>
     void
     get_function_divergences(
-      const InputVector &fe_function,
-      std::vector<solution_divergence_type<typename InputVector::value_type>>
-        &divergences) const;
+      const ReadVector<Number> &                     fe_function,
+      std::vector<solution_divergence_type<Number>> &divergences) const;
 
     /**
      * This function relates to get_function_divergences() in the same way
@@ -2986,12 +2974,11 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_hessians}
    */
-  template <class InputVector>
+  template <typename Number>
   void
   get_function_hessians(
-    const InputVector &fe_function,
-    std::vector<Tensor<2, spacedim, typename InputVector::value_type>>
-      &hessians) const;
+    const ReadVector<Number> &                fe_function,
+    std::vector<Tensor<2, spacedim, Number>> &hessians) const;
 
   /**
    * This function does the same as the other get_function_hessians(), but
@@ -3010,13 +2997,11 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_hessians}
    */
-  template <class InputVector>
+  template <typename Number>
   void
   get_function_hessians(
-    const InputVector &fe_function,
-    std::vector<
-      std::vector<Tensor<2, spacedim, typename InputVector::value_type>>>
-      &        hessians,
+    const ReadVector<Number> &                             fe_function,
+    std::vector<std::vector<Tensor<2, spacedim, Number>>> &hessians,
     const bool quadrature_points_fastest = false) const;
 
   /**
@@ -3027,13 +3012,12 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_hessians}
    */
-  template <class InputVector>
+  template <typename Number>
   void
   get_function_hessians(
-    const InputVector &                             fe_function,
+    const ReadVector<Number> &                      fe_function,
     const ArrayView<const types::global_dof_index> &indices,
-    std::vector<Tensor<2, spacedim, typename InputVector::value_type>>
-      &hessians) const;
+    std::vector<Tensor<2, spacedim, Number>> &      hessians) const;
 
   /**
    * This function relates to the first of the get_function_hessians() function
@@ -3043,14 +3027,12 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_hessians}
    */
-  template <class InputVector>
+  template <typename Number>
   void
   get_function_hessians(
-    const InputVector &                             fe_function,
-    const ArrayView<const types::global_dof_index> &indices,
-    ArrayView<
-      std::vector<Tensor<2, spacedim, typename InputVector::value_type>>>
-               hessians,
+    const ReadVector<Number> &                          fe_function,
+    const ArrayView<const types::global_dof_index> &    indices,
+    ArrayView<std::vector<Tensor<2, spacedim, Number>>> hessians,
     const bool quadrature_points_fastest = false) const;
 
   /**
@@ -3093,11 +3075,10 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_hessians}
    */
-  template <class InputVector>
+  template <typename Number>
   void
-  get_function_laplacians(
-    const InputVector &                            fe_function,
-    std::vector<typename InputVector::value_type> &laplacians) const;
+  get_function_laplacians(const ReadVector<Number> &fe_function,
+                          std::vector<Number> &     laplacians) const;
 
   /**
    * This function does the same as the other get_function_laplacians(), but
@@ -3118,11 +3099,10 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_hessians}
    */
-  template <class InputVector>
+  template <typename Number>
   void
-  get_function_laplacians(
-    const InputVector &                                    fe_function,
-    std::vector<Vector<typename InputVector::value_type>> &laplacians) const;
+  get_function_laplacians(const ReadVector<Number> &   fe_function,
+                          std::vector<Vector<Number>> &laplacians) const;
 
   /**
    * This function relates to the first of the get_function_laplacians()
@@ -3132,12 +3112,12 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_hessians}
    */
-  template <class InputVector>
+  template <typename Number>
   void
   get_function_laplacians(
-    const InputVector &                             fe_function,
+    const ReadVector<Number> &                      fe_function,
     const ArrayView<const types::global_dof_index> &indices,
-    std::vector<typename InputVector::value_type> & laplacians) const;
+    std::vector<Number> &                           laplacians) const;
 
   /**
    * This function relates to the first of the get_function_laplacians()
@@ -3147,12 +3127,12 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_hessians}
    */
-  template <class InputVector>
+  template <typename Number>
   void
   get_function_laplacians(
-    const InputVector &                                    fe_function,
-    const ArrayView<const types::global_dof_index> &       indices,
-    std::vector<Vector<typename InputVector::value_type>> &laplacians) const;
+    const ReadVector<Number> &                      fe_function,
+    const ArrayView<const types::global_dof_index> &indices,
+    std::vector<Vector<Number>> &                   laplacians) const;
 
   /**
    * This function relates to the first of the get_function_laplacians()
@@ -3162,12 +3142,12 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_hessians}
    */
-  template <class InputVector>
+  template <typename Number>
   void
   get_function_laplacians(
-    const InputVector &                                         fe_function,
-    const ArrayView<const types::global_dof_index> &            indices,
-    std::vector<std::vector<typename InputVector::value_type>> &laplacians,
+    const ReadVector<Number> &                      fe_function,
+    const ArrayView<const types::global_dof_index> &indices,
+    std::vector<std::vector<Number>> &              laplacians,
     const bool quadrature_points_fastest = false) const;
 
   /** @} */
@@ -3212,12 +3192,11 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_3rd_derivatives}
    */
-  template <class InputVector>
+  template <typename Number>
   void
   get_function_third_derivatives(
-    const InputVector &fe_function,
-    std::vector<Tensor<3, spacedim, typename InputVector::value_type>>
-      &third_derivatives) const;
+    const ReadVector<Number> &                fe_function,
+    std::vector<Tensor<3, spacedim, Number>> &third_derivatives) const;
 
   /**
    * This function does the same as the other
@@ -3237,13 +3216,11 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_3rd_derivatives}
    */
-  template <class InputVector>
+  template <typename Number>
   void
   get_function_third_derivatives(
-    const InputVector &fe_function,
-    std::vector<
-      std::vector<Tensor<3, spacedim, typename InputVector::value_type>>>
-      &        third_derivatives,
+    const ReadVector<Number> &                             fe_function,
+    std::vector<std::vector<Tensor<3, spacedim, Number>>> &third_derivatives,
     const bool quadrature_points_fastest = false) const;
 
   /**
@@ -3254,13 +3231,12 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_3rd_derivatives}
    */
-  template <class InputVector>
+  template <typename Number>
   void
   get_function_third_derivatives(
-    const InputVector &                             fe_function,
+    const ReadVector<Number> &                      fe_function,
     const ArrayView<const types::global_dof_index> &indices,
-    std::vector<Tensor<3, spacedim, typename InputVector::value_type>>
-      &third_derivatives) const;
+    std::vector<Tensor<3, spacedim, Number>> &      third_derivatives) const;
 
   /**
    * This function relates to the first of the get_function_third_derivatives()
@@ -3270,14 +3246,12 @@ public:
    *
    * @dealiiRequiresUpdateFlags{update_3rd_derivatives}
    */
-  template <class InputVector>
+  template <typename Number>
   void
   get_function_third_derivatives(
-    const InputVector &                             fe_function,
-    const ArrayView<const types::global_dof_index> &indices,
-    ArrayView<
-      std::vector<Tensor<3, spacedim, typename InputVector::value_type>>>
-               third_derivatives,
+    const ReadVector<Number> &                          fe_function,
+    const ArrayView<const types::global_dof_index> &    indices,
+    ArrayView<std::vector<Tensor<3, spacedim, Number>>> third_derivatives,
     const bool quadrature_points_fastest = false) const;
   /** @} */
 

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -27,6 +27,7 @@
 #include <deal.II/base/partitioner.h>
 #include <deal.II/base/subscriptor.h>
 
+#include <deal.II/lac/read_vector.h>
 #include <deal.II/lac/vector_operation.h>
 #include <deal.II/lac/vector_space_vector.h>
 #include <deal.II/lac/vector_type_traits.h>
@@ -248,6 +249,7 @@ namespace LinearAlgebra
      */
     template <typename Number, typename MemorySpace = MemorySpace::Host>
     class Vector : public ::dealii::LinearAlgebra::VectorSpaceVector<Number>,
+                   public ::dealii::ReadVector<Number>,
                    public Subscriptor
     {
     public:
@@ -1143,6 +1145,14 @@ namespace LinearAlgebra
       void
       extract_subvector_to(const std::vector<size_type> &indices,
                            std::vector<OtherNumber> &    values) const;
+
+      /**
+       * Extract a range of elements all at once.
+       */
+      virtual void
+      extract_subvector_to(
+        const ArrayView<const types::global_dof_index> &indices,
+        ArrayView<Number> &elements) const override;
 
       /**
        * Instead of getting individual elements of a vector via operator(),

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -1755,6 +1755,22 @@ namespace LinearAlgebra
 
 
     template <typename Number, typename MemorySpaceType>
+    void
+    Vector<Number, MemorySpaceType>::extract_subvector_to(
+      const ArrayView<const types::global_dof_index> &indices,
+      ArrayView<Number> &                             elements) const
+    {
+      AssertDimension(indices.size(), elements.size());
+      for (unsigned int i = 0; i < indices.size(); ++i)
+        {
+          AssertIndexRange(indices[i], size());
+          elements[i] = (*this)[indices[i]];
+        }
+    }
+
+
+
+    template <typename Number, typename MemorySpaceType>
     bool
     Vector<Number, MemorySpaceType>::all_zero() const
     {

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -247,7 +247,7 @@ namespace PETScWrappers
    *
    * @ingroup PETScWrappers
    */
-  class VectorBase : public Subscriptor
+  class VectorBase : public ReadVector<PetscScalar>, public Subscriptor
   {
   public:
     /**
@@ -355,7 +355,7 @@ namespace PETScWrappers
      * Return the global dimension of the vector.
      */
     size_type
-    size() const;
+    size() const override;
 
     /**
      * Return the local dimension of the vector, i.e. the number of elements
@@ -493,6 +493,14 @@ namespace PETScWrappers
     void
     extract_subvector_to(const std::vector<size_type> &indices,
                          std::vector<PetscScalar> &    values) const;
+
+    /**
+     * Extract a range of elements all at once.
+     */
+    virtual void
+    extract_subvector_to(
+      const ArrayView<const types::global_dof_index> &indices,
+      ArrayView<PetscScalar> &                        elements) const override;
 
     /**
      * Instead of getting individual elements of a vector via operator(),
@@ -1191,6 +1199,16 @@ namespace PETScWrappers
            ExcDimensionMismatch(indices.size(), values.size()));
     extract_subvector_to(indices.begin(), indices.end(), values.begin());
   }
+
+  inline void
+  VectorBase::extract_subvector_to(
+    const ArrayView<const types::global_dof_index> &indices,
+    ArrayView<PetscScalar> &                        elements) const
+  {
+    AssertDimension(indices.size(), elements.size());
+    extract_subvector_to(indices.begin(), indices.end(), elements.begin());
+  }
+
 
   template <typename ForwardIterator, typename OutputIterator>
   inline void

--- a/include/deal.II/lac/read_vector.h
+++ b/include/deal.II/lac/read_vector.h
@@ -1,0 +1,64 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2023 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_lac_read_vector_h
+#define dealii_lac_read_vector_h
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/array_view.h>
+#include <deal.II/base/types.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+/**
+ * @addtogroup Vectors
+ * @{
+ */
+
+/**
+ * Base class for providing read-only access to vector elements.
+ *
+ * deal.II supports a large number of vector classes, including both its own
+ * serial and parallel vectors as well as vector classes from external
+ * libraries like PETSc and Trilinos. ReadVector is a common base class for
+ * all vector classes and defines a minimal interface for efficiently
+ * accessing vector elements.
+ */
+template <typename Number>
+class ReadVector
+{
+public:
+  using size_type = types::global_dof_index;
+
+  /**
+   * Return the size of the vector.
+   */
+  virtual size_type
+  size() const = 0;
+
+  /**
+   * Extract a subset of the vector specified by @p indices into the output
+   * array @p elements.
+   */
+  virtual void
+  extract_subvector_to(const ArrayView<const types::global_dof_index> &indices,
+                       ArrayView<Number> &elements) const = 0;
+};
+
+/** @} */
+
+DEAL_II_NAMESPACE_CLOSE
+#endif

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -27,6 +27,7 @@
 #include <deal.II/base/template_constraints.h>
 #include <deal.II/base/types.h>
 
+#include <deal.II/lac/read_vector.h>
 #include <deal.II/lac/vector_operation.h>
 
 #include <cstdlib>
@@ -133,7 +134,7 @@ namespace LinearAlgebra
    * get the first index of the largest range.
    */
   template <typename Number>
-  class ReadWriteVector : public Subscriptor
+  class ReadWriteVector : public Subscriptor, public ReadVector<Number>
   {
   public:
     /**
@@ -537,7 +538,7 @@ namespace LinearAlgebra
      * number returned by the current function.
      */
     size_type
-    size() const;
+    size() const override;
 
     /**
      * This function returns the number of elements stored. It is smaller or
@@ -654,6 +655,14 @@ namespace LinearAlgebra
     void
     extract_subvector_to(const std::vector<size_type> &indices,
                          std::vector<Number2> &        values) const;
+
+    /**
+     * Extract a range of elements all at once.
+     */
+    virtual void
+    extract_subvector_to(
+      const ArrayView<const types::global_dof_index> &indices,
+      ArrayView<Number> &                             entries) const override;
 
     /**
      * Instead of getting individual elements of a vector via operator(),
@@ -1076,6 +1085,19 @@ namespace LinearAlgebra
   {
     for (size_type i = 0; i < indices.size(); ++i)
       extracted_values[i] = operator()(indices[i]);
+  }
+
+
+
+  template <typename Number>
+  void
+  ReadWriteVector<Number>::extract_subvector_to(
+    const ArrayView<const types::global_dof_index> &indices,
+    ArrayView<Number> &                             entries) const
+  {
+    AssertDimension(indices.size(), entries.size());
+    for (unsigned int i = 0; i < indices.size(); ++i)
+      entries[i] = (*this)[indices[i]];
   }
 
 

--- a/include/deal.II/lac/trilinos_epetra_vector.h
+++ b/include/deal.II/lac/trilinos_epetra_vector.h
@@ -25,6 +25,7 @@
 #  include <deal.II/base/mpi_stub.h>
 #  include <deal.II/base/subscriptor.h>
 
+#  include <deal.II/lac/read_vector.h>
 #  include <deal.II/lac/trilinos_epetra_communication_pattern.h>
 #  include <deal.II/lac/vector_operation.h>
 #  include <deal.II/lac/vector_space_vector.h>
@@ -61,9 +62,14 @@ namespace LinearAlgebra
      * @ingroup TrilinosWrappers
      * @ingroup Vectors
      */
-    class Vector : public VectorSpaceVector<double>, public Subscriptor
+    class Vector : public VectorSpaceVector<double>,
+                   public ReadVector<double>,
+                   public Subscriptor
     {
     public:
+      using value_type = double;
+      using size_type  = types::global_dof_index;
+
       /**
        * Constructor. Create a vector of dimension zero.
        */
@@ -102,6 +108,14 @@ namespace LinearAlgebra
       virtual void
       reinit(const VectorSpaceVector<double> &V,
              const bool omit_zeroing_entries = false) override;
+
+      /**
+       * Extract a range of elements all at once.
+       */
+      virtual void
+      extract_subvector_to(
+        const ArrayView<const types::global_dof_index> &indices,
+        ArrayView<double> &elements) const override;
 
       /**
        * Copy function. This function takes a Vector and copies all the

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -25,6 +25,7 @@
 #  include <deal.II/base/mpi_stub.h>
 #  include <deal.II/base/subscriptor.h>
 
+#  include <deal.II/lac/read_vector.h>
 #  include <deal.II/lac/trilinos_tpetra_communication_pattern.h>
 #  include <deal.II/lac/vector_operation.h>
 #  include <deal.II/lac/vector_space_vector.h>
@@ -113,7 +114,9 @@ namespace LinearAlgebra
      * @ingroup Vectors
      */
     template <typename Number>
-    class Vector : public VectorSpaceVector<Number>, public Subscriptor
+    class Vector : public VectorSpaceVector<Number>,
+                   public ReadVector<Number>,
+                   public Subscriptor
     {
     public:
       using value_type = Number;
@@ -158,6 +161,14 @@ namespace LinearAlgebra
       virtual void
       reinit(const VectorSpaceVector<Number> &V,
              const bool omit_zeroing_entries = false) override;
+
+      /**
+       * Extract a range of elements all at once.
+       */
+      virtual void
+      extract_subvector_to(
+        const ArrayView<const types::global_dof_index> &indices,
+        ArrayView<Number> &elements) const override;
 
       /**
        * Copy function. This function takes a Vector and copies all the

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -26,6 +26,7 @@
 #  include <deal.II/base/subscriptor.h>
 
 #  include <deal.II/lac/exceptions.h>
+#  include <deal.II/lac/read_vector.h>
 #  include <deal.II/lac/vector.h>
 #  include <deal.II/lac/vector_operation.h>
 #  include <deal.II/lac/vector_type_traits.h>
@@ -394,7 +395,7 @@ namespace TrilinosWrappers
      * @ingroup TrilinosWrappers
      * @ingroup Vectors
      */
-    class Vector : public Subscriptor
+    class Vector : public Subscriptor, public ReadVector<TrilinosScalar>
     {
     public:
       /**
@@ -760,7 +761,7 @@ namespace TrilinosWrappers
        * Return the global dimension of the vector.
        */
       size_type
-      size() const;
+      size() const override;
 
       /**
        * Return the local dimension of the vector, i.e. the number of elements
@@ -1011,6 +1012,13 @@ namespace TrilinosWrappers
       void
       extract_subvector_to(const std::vector<size_type> &indices,
                            std::vector<TrilinosScalar> & values) const;
+
+      /**
+       * Extract a range of elements all at once.
+       */
+      virtual void
+      extract_subvector_to(const ArrayView<const size_type> &indices,
+                           ArrayView<TrilinosScalar> &elements) const override;
 
       /**
        * Instead of getting individual elements of a vector via operator(),
@@ -1556,6 +1564,20 @@ namespace TrilinosWrappers
     {
       for (size_type i = 0; i < indices.size(); ++i)
         values[i] = operator()(indices[i]);
+    }
+
+
+
+    inline void
+    Vector::extract_subvector_to(const ArrayView<const size_type> &indices,
+                                 ArrayView<TrilinosScalar> &elements) const
+    {
+      AssertDimension(indices.size(), elements.size());
+      for (unsigned int i = 0; i < indices.size(); ++i)
+        {
+          AssertIndexRange(indices[i], size());
+          elements[i] = (*this)[indices[i]];
+        }
     }
 
 

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -25,6 +25,7 @@
 #include <deal.II/base/numbers.h>
 #include <deal.II/base/subscriptor.h>
 
+#include <deal.II/lac/read_vector.h>
 #include <deal.II/lac/vector_operation.h>
 #include <deal.II/lac/vector_type_traits.h>
 
@@ -105,7 +106,7 @@ namespace parallel
  * in the manual).
  */
 template <typename Number>
-class Vector : public Subscriptor
+class Vector : public Subscriptor, public ReadVector<Number>
 {
 public:
   /**
@@ -663,6 +664,13 @@ public:
                        std::vector<OtherNumber> &    values) const;
 
   /**
+   * Extract a range of elements all at once.
+   */
+  virtual void
+  extract_subvector_to(const ArrayView<const types::global_dof_index> &indices,
+                       ArrayView<Number> &elements) const override;
+
+  /**
    * Instead of getting individual elements of a vector via operator(),
    * this function allows getting a whole set of elements at once. In
    * contrast to the previous function, this function obtains the
@@ -958,8 +966,8 @@ public:
   /**
    * Return dimension of the vector.
    */
-  size_type
-  size() const;
+  virtual size_type
+  size() const override;
 
   /**
    * Return local dimension of the vector. Since this vector does not support

--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -558,6 +558,22 @@ Vector<Number>::add_and_dot(const Number          a,
 
 
 template <typename Number>
+void
+Vector<Number>::extract_subvector_to(
+  const ArrayView<const types::global_dof_index> &indices,
+  ArrayView<Number> &                             elements) const
+{
+  AssertDimension(indices.size(), elements.size());
+  for (unsigned int i = 0; i < indices.size(); ++i)
+    {
+      AssertIndexRange(indices[i], size());
+      elements[i] = (*this)[indices[i]];
+    }
+}
+
+
+
+template <typename Number>
 Vector<Number> &
 Vector<Number>::operator+=(const Vector<Number> &v)
 {

--- a/include/deal.II/numerics/error_estimator.h
+++ b/include/deal.II/numerics/error_estimator.h
@@ -336,16 +336,15 @@ public:
    * cell in the mesh as reported by
    * parallel::distributed::Triangulation::n_locally_owned_active_cells().
    */
-  template <typename InputVector>
+  template <typename Number>
   static void
   estimate(
     const Mapping<dim, spacedim> &   mapping,
     const DoFHandler<dim, spacedim> &dof,
     const Quadrature<dim - 1> &      quadrature,
-    const std::map<types::boundary_id,
-                   const Function<spacedim, typename InputVector::value_type> *>
+    const std::map<types::boundary_id, const Function<spacedim, Number> *>
       &                       neumann_bc,
-    const InputVector &       solution,
+    const ReadVector<Number> &solution,
     Vector<float> &           error,
     const ComponentMask &     component_mask = ComponentMask(),
     const Function<spacedim> *coefficients   = nullptr,
@@ -358,15 +357,14 @@ public:
    * Call the @p estimate function, see above, with
    * <tt>mapping=MappingQ@<dim@>(1)</tt>.
    */
-  template <typename InputVector>
+  template <typename Number>
   static void
   estimate(
     const DoFHandler<dim, spacedim> &dof,
     const Quadrature<dim - 1> &      quadrature,
-    const std::map<types::boundary_id,
-                   const Function<spacedim, typename InputVector::value_type> *>
+    const std::map<types::boundary_id, const Function<spacedim, Number> *>
       &                       neumann_bc,
-    const InputVector &       solution,
+    const ReadVector<Number> &solution,
     Vector<float> &           error,
     const ComponentMask &     component_mask = ComponentMask(),
     const Function<spacedim> *coefficients   = nullptr,
@@ -388,60 +386,57 @@ public:
    * construct of vector of references, so we had to use a vector of
    * pointers.)
    */
-  template <typename InputVector>
+  template <typename Number>
   static void
   estimate(
     const Mapping<dim, spacedim> &   mapping,
     const DoFHandler<dim, spacedim> &dof,
     const Quadrature<dim - 1> &      quadrature,
-    const std::map<types::boundary_id,
-                   const Function<spacedim, typename InputVector::value_type> *>
-      &                                     neumann_bc,
-    const std::vector<const InputVector *> &solutions,
-    std::vector<Vector<float> *> &          errors,
-    const ComponentMask &                   component_mask = ComponentMask(),
-    const Function<spacedim> *              coefficients   = nullptr,
-    const unsigned int        n_threads    = numbers::invalid_unsigned_int,
-    const types::subdomain_id subdomain_id = numbers::invalid_subdomain_id,
-    const types::material_id  material_id  = numbers::invalid_material_id,
-    const Strategy            strategy     = cell_diameter_over_24);
+    const std::map<types::boundary_id, const Function<spacedim, Number> *>
+      &                                            neumann_bc,
+    const std::vector<const ReadVector<Number> *> &solutions,
+    std::vector<Vector<float> *> &                 errors,
+    const ComponentMask &     component_mask = ComponentMask(),
+    const Function<spacedim> *coefficients   = nullptr,
+    const unsigned int        n_threads      = numbers::invalid_unsigned_int,
+    const types::subdomain_id subdomain_id   = numbers::invalid_subdomain_id,
+    const types::material_id  material_id    = numbers::invalid_material_id,
+    const Strategy            strategy       = cell_diameter_over_24);
 
   /**
    * Call the @p estimate function, see above, with
    * <tt>mapping=MappingQ@<dim@>(1)</tt>.
    */
-  template <typename InputVector>
+  template <typename Number>
   static void
   estimate(
     const DoFHandler<dim, spacedim> &dof,
     const Quadrature<dim - 1> &      quadrature,
-    const std::map<types::boundary_id,
-                   const Function<spacedim, typename InputVector::value_type> *>
-      &                                     neumann_bc,
-    const std::vector<const InputVector *> &solutions,
-    std::vector<Vector<float> *> &          errors,
-    const ComponentMask &                   component_mask = ComponentMask(),
-    const Function<spacedim> *              coefficients   = nullptr,
-    const unsigned int        n_threads    = numbers::invalid_unsigned_int,
-    const types::subdomain_id subdomain_id = numbers::invalid_subdomain_id,
-    const types::material_id  material_id  = numbers::invalid_material_id,
-    const Strategy            strategy     = cell_diameter_over_24);
+    const std::map<types::boundary_id, const Function<spacedim, Number> *>
+      &                                            neumann_bc,
+    const std::vector<const ReadVector<Number> *> &solutions,
+    std::vector<Vector<float> *> &                 errors,
+    const ComponentMask &     component_mask = ComponentMask(),
+    const Function<spacedim> *coefficients   = nullptr,
+    const unsigned int        n_threads      = numbers::invalid_unsigned_int,
+    const types::subdomain_id subdomain_id   = numbers::invalid_subdomain_id,
+    const types::material_id  material_id    = numbers::invalid_material_id,
+    const Strategy            strategy       = cell_diameter_over_24);
 
 
   /**
    * Equivalent to the set of functions above, except that this one takes a
    * quadrature collection for hp-finite element dof handlers.
    */
-  template <typename InputVector>
+  template <typename Number>
   static void
   estimate(
     const Mapping<dim, spacedim> &   mapping,
     const DoFHandler<dim, spacedim> &dof,
     const hp::QCollection<dim - 1> & quadrature,
-    const std::map<types::boundary_id,
-                   const Function<spacedim, typename InputVector::value_type> *>
+    const std::map<types::boundary_id, const Function<spacedim, Number> *>
       &                       neumann_bc,
-    const InputVector &       solution,
+    const ReadVector<Number> &solution,
     Vector<float> &           error,
     const ComponentMask &     component_mask = ComponentMask(),
     const Function<spacedim> *coefficients   = nullptr,
@@ -455,15 +450,14 @@ public:
    * Equivalent to the set of functions above, except that this one takes a
    * quadrature collection for hp-finite element dof handlers.
    */
-  template <typename InputVector>
+  template <typename Number>
   static void
   estimate(
     const DoFHandler<dim, spacedim> &dof,
     const hp::QCollection<dim - 1> & quadrature,
-    const std::map<types::boundary_id,
-                   const Function<spacedim, typename InputVector::value_type> *>
+    const std::map<types::boundary_id, const Function<spacedim, Number> *>
       &                       neumann_bc,
-    const InputVector &       solution,
+    const ReadVector<Number> &solution,
     Vector<float> &           error,
     const ComponentMask &     component_mask = ComponentMask(),
     const Function<spacedim> *coefficients   = nullptr,
@@ -477,45 +471,43 @@ public:
    * Equivalent to the set of functions above, except that this one takes a
    * quadrature collection for hp-finite element dof handlers.
    */
-  template <typename InputVector>
+  template <typename Number>
   static void
   estimate(
     const Mapping<dim, spacedim> &   mapping,
     const DoFHandler<dim, spacedim> &dof,
     const hp::QCollection<dim - 1> & quadrature,
-    const std::map<types::boundary_id,
-                   const Function<spacedim, typename InputVector::value_type> *>
-      &                                     neumann_bc,
-    const std::vector<const InputVector *> &solutions,
-    std::vector<Vector<float> *> &          errors,
-    const ComponentMask &                   component_mask = ComponentMask(),
-    const Function<spacedim> *              coefficients   = nullptr,
-    const unsigned int        n_threads    = numbers::invalid_unsigned_int,
-    const types::subdomain_id subdomain_id = numbers::invalid_subdomain_id,
-    const types::material_id  material_id  = numbers::invalid_material_id,
-    const Strategy            strategy     = cell_diameter_over_24);
+    const std::map<types::boundary_id, const Function<spacedim, Number> *>
+      &                                            neumann_bc,
+    const std::vector<const ReadVector<Number> *> &solutions,
+    std::vector<Vector<float> *> &                 errors,
+    const ComponentMask &     component_mask = ComponentMask(),
+    const Function<spacedim> *coefficients   = nullptr,
+    const unsigned int        n_threads      = numbers::invalid_unsigned_int,
+    const types::subdomain_id subdomain_id   = numbers::invalid_subdomain_id,
+    const types::material_id  material_id    = numbers::invalid_material_id,
+    const Strategy            strategy       = cell_diameter_over_24);
 
 
   /**
    * Equivalent to the set of functions above, except that this one takes a
    * quadrature collection for hp-finite element dof handlers.
    */
-  template <typename InputVector>
+  template <typename Number>
   static void
   estimate(
     const DoFHandler<dim, spacedim> &dof,
     const hp::QCollection<dim - 1> & quadrature,
-    const std::map<types::boundary_id,
-                   const Function<spacedim, typename InputVector::value_type> *>
-      &                                     neumann_bc,
-    const std::vector<const InputVector *> &solutions,
-    std::vector<Vector<float> *> &          errors,
-    const ComponentMask &                   component_mask = ComponentMask(),
-    const Function<spacedim> *              coefficients   = nullptr,
-    const unsigned int        n_threads    = numbers::invalid_unsigned_int,
-    const types::subdomain_id subdomain_id = numbers::invalid_subdomain_id,
-    const types::material_id  material_id  = numbers::invalid_material_id,
-    const Strategy            strategy     = cell_diameter_over_24);
+    const std::map<types::boundary_id, const Function<spacedim, Number> *>
+      &                                            neumann_bc,
+    const std::vector<const ReadVector<Number> *> &solutions,
+    std::vector<Vector<float> *> &                 errors,
+    const ComponentMask &     component_mask = ComponentMask(),
+    const Function<spacedim> *coefficients   = nullptr,
+    const unsigned int        n_threads      = numbers::invalid_unsigned_int,
+    const types::subdomain_id subdomain_id   = numbers::invalid_subdomain_id,
+    const types::material_id  material_id    = numbers::invalid_material_id,
+    const Strategy            strategy       = cell_diameter_over_24);
 
   /**
    * Exception
@@ -624,16 +616,15 @@ public:
    * respective parameter for compatibility with the function signature in the
    * general case.
    */
-  template <typename InputVector>
+  template <typename Number>
   static void
   estimate(
     const Mapping<1, spacedim> &   mapping,
     const DoFHandler<1, spacedim> &dof,
     const Quadrature<0> &          quadrature,
-    const std::map<types::boundary_id,
-                   const Function<spacedim, typename InputVector::value_type> *>
+    const std::map<types::boundary_id, const Function<spacedim, Number> *>
       &                       neumann_bc,
-    const InputVector &       solution,
+    const ReadVector<Number> &solution,
     Vector<float> &           error,
     const ComponentMask &     component_mask = ComponentMask(),
     const Function<spacedim> *coefficient    = nullptr,
@@ -648,15 +639,14 @@ public:
    * Call the @p estimate function, see above, with
    * <tt>mapping=MappingQ1<1>()</tt>.
    */
-  template <typename InputVector>
+  template <typename Number>
   static void
   estimate(
     const DoFHandler<1, spacedim> &dof,
     const Quadrature<0> &          quadrature,
-    const std::map<types::boundary_id,
-                   const Function<spacedim, typename InputVector::value_type> *>
+    const std::map<types::boundary_id, const Function<spacedim, Number> *>
       &                       neumann_bc,
-    const InputVector &       solution,
+    const ReadVector<Number> &solution,
     Vector<float> &           error,
     const ComponentMask &     component_mask = ComponentMask(),
     const Function<spacedim> *coefficients   = nullptr,
@@ -680,23 +670,22 @@ public:
    * construct of vector of references, so we had to use a vector of
    * pointers.)
    */
-  template <typename InputVector>
+  template <typename Number>
   static void
   estimate(
     const Mapping<1, spacedim> &   mapping,
     const DoFHandler<1, spacedim> &dof,
     const Quadrature<0> &          quadrature,
-    const std::map<types::boundary_id,
-                   const Function<spacedim, typename InputVector::value_type> *>
-      &                                     neumann_bc,
-    const std::vector<const InputVector *> &solutions,
-    std::vector<Vector<float> *> &          errors,
-    const ComponentMask &                   component_mask = ComponentMask(),
-    const Function<spacedim> *              coefficients   = nullptr,
-    const unsigned int        n_threads    = numbers::invalid_unsigned_int,
-    const types::subdomain_id subdomain_id = numbers::invalid_subdomain_id,
-    const types::material_id  material_id  = numbers::invalid_material_id,
-    const Strategy            strategy     = cell_diameter_over_24);
+    const std::map<types::boundary_id, const Function<spacedim, Number> *>
+      &                                            neumann_bc,
+    const std::vector<const ReadVector<Number> *> &solutions,
+    std::vector<Vector<float> *> &                 errors,
+    const ComponentMask &     component_mask = ComponentMask(),
+    const Function<spacedim> *coefficients   = nullptr,
+    const unsigned int        n_threads      = numbers::invalid_unsigned_int,
+    const types::subdomain_id subdomain_id   = numbers::invalid_subdomain_id,
+    const types::material_id  material_id    = numbers::invalid_material_id,
+    const Strategy            strategy       = cell_diameter_over_24);
 
 
 
@@ -704,22 +693,21 @@ public:
    * Call the @p estimate function, see above, with
    * <tt>mapping=MappingQ1<1>()</tt>.
    */
-  template <typename InputVector>
+  template <typename Number>
   static void
   estimate(
     const DoFHandler<1, spacedim> &dof,
     const Quadrature<0> &          quadrature,
-    const std::map<types::boundary_id,
-                   const Function<spacedim, typename InputVector::value_type> *>
-      &                                     neumann_bc,
-    const std::vector<const InputVector *> &solutions,
-    std::vector<Vector<float> *> &          errors,
-    const ComponentMask &                   component_mask = ComponentMask(),
-    const Function<spacedim> *              coefficients   = nullptr,
-    const unsigned int        n_threads    = numbers::invalid_unsigned_int,
-    const types::subdomain_id subdomain_id = numbers::invalid_subdomain_id,
-    const types::material_id  material_id  = numbers::invalid_material_id,
-    const Strategy            strategy     = cell_diameter_over_24);
+    const std::map<types::boundary_id, const Function<spacedim, Number> *>
+      &                                            neumann_bc,
+    const std::vector<const ReadVector<Number> *> &solutions,
+    std::vector<Vector<float> *> &                 errors,
+    const ComponentMask &     component_mask = ComponentMask(),
+    const Function<spacedim> *coefficients   = nullptr,
+    const unsigned int        n_threads      = numbers::invalid_unsigned_int,
+    const types::subdomain_id subdomain_id   = numbers::invalid_subdomain_id,
+    const types::material_id  material_id    = numbers::invalid_material_id,
+    const Strategy            strategy       = cell_diameter_over_24);
 
 
 
@@ -727,16 +715,15 @@ public:
    * Equivalent to the set of functions above, except that this one takes a
    * quadrature collection for hp-finite element dof handlers.
    */
-  template <typename InputVector>
+  template <typename Number>
   static void
   estimate(
     const Mapping<1, spacedim> &   mapping,
     const DoFHandler<1, spacedim> &dof,
     const hp::QCollection<0> &     quadrature,
-    const std::map<types::boundary_id,
-                   const Function<spacedim, typename InputVector::value_type> *>
+    const std::map<types::boundary_id, const Function<spacedim, Number> *>
       &                       neumann_bc,
-    const InputVector &       solution,
+    const ReadVector<Number> &solution,
     Vector<float> &           error,
     const ComponentMask &     component_mask = ComponentMask(),
     const Function<spacedim> *coefficients   = nullptr,
@@ -751,15 +738,14 @@ public:
    * Equivalent to the set of functions above, except that this one takes a
    * quadrature collection for hp-finite element dof handlers.
    */
-  template <typename InputVector>
+  template <typename Number>
   static void
   estimate(
     const DoFHandler<1, spacedim> &dof,
     const hp::QCollection<0> &     quadrature,
-    const std::map<types::boundary_id,
-                   const Function<spacedim, typename InputVector::value_type> *>
+    const std::map<types::boundary_id, const Function<spacedim, Number> *>
       &                       neumann_bc,
-    const InputVector &       solution,
+    const ReadVector<Number> &solution,
     Vector<float> &           error,
     const ComponentMask &     component_mask = ComponentMask(),
     const Function<spacedim> *coefficients   = nullptr,
@@ -774,23 +760,22 @@ public:
    * Equivalent to the set of functions above, except that this one takes a
    * quadrature collection for hp-finite element dof handlers.
    */
-  template <typename InputVector>
+  template <typename Number>
   static void
   estimate(
     const Mapping<1, spacedim> &   mapping,
     const DoFHandler<1, spacedim> &dof,
     const hp::QCollection<0> &     quadrature,
-    const std::map<types::boundary_id,
-                   const Function<spacedim, typename InputVector::value_type> *>
-      &                                     neumann_bc,
-    const std::vector<const InputVector *> &solutions,
-    std::vector<Vector<float> *> &          errors,
-    const ComponentMask &                   component_mask = ComponentMask(),
-    const Function<spacedim> *              coefficients   = nullptr,
-    const unsigned int        n_threads    = numbers::invalid_unsigned_int,
-    const types::subdomain_id subdomain_id = numbers::invalid_subdomain_id,
-    const types::material_id  material_id  = numbers::invalid_material_id,
-    const Strategy            strategy     = cell_diameter_over_24);
+    const std::map<types::boundary_id, const Function<spacedim, Number> *>
+      &                                            neumann_bc,
+    const std::vector<const ReadVector<Number> *> &solutions,
+    std::vector<Vector<float> *> &                 errors,
+    const ComponentMask &     component_mask = ComponentMask(),
+    const Function<spacedim> *coefficients   = nullptr,
+    const unsigned int        n_threads      = numbers::invalid_unsigned_int,
+    const types::subdomain_id subdomain_id   = numbers::invalid_subdomain_id,
+    const types::material_id  material_id    = numbers::invalid_material_id,
+    const Strategy            strategy       = cell_diameter_over_24);
 
 
 
@@ -798,22 +783,21 @@ public:
    * Equivalent to the set of functions above, except that this one takes a
    * quadrature collection for hp-finite element dof handlers.
    */
-  template <typename InputVector>
+  template <typename Number>
   static void
   estimate(
     const DoFHandler<1, spacedim> &dof,
     const hp::QCollection<0> &     quadrature,
-    const std::map<types::boundary_id,
-                   const Function<spacedim, typename InputVector::value_type> *>
-      &                                     neumann_bc,
-    const std::vector<const InputVector *> &solutions,
-    std::vector<Vector<float> *> &          errors,
-    const ComponentMask &                   component_mask = ComponentMask(),
-    const Function<spacedim> *              coefficients   = nullptr,
-    const unsigned int        n_threads    = numbers::invalid_unsigned_int,
-    const types::subdomain_id subdomain_id = numbers::invalid_subdomain_id,
-    const types::material_id  material_id  = numbers::invalid_material_id,
-    const Strategy            strategy     = cell_diameter_over_24);
+    const std::map<types::boundary_id, const Function<spacedim, Number> *>
+      &                                            neumann_bc,
+    const std::vector<const ReadVector<Number> *> &solutions,
+    std::vector<Vector<float> *> &                 errors,
+    const ComponentMask &     component_mask = ComponentMask(),
+    const Function<spacedim> *coefficients   = nullptr,
+    const unsigned int        n_threads      = numbers::invalid_unsigned_int,
+    const types::subdomain_id subdomain_id   = numbers::invalid_subdomain_id,
+    const types::material_id  material_id    = numbers::invalid_material_id,
+    const Strategy            strategy       = cell_diameter_over_24);
 
 
 

--- a/include/deal.II/numerics/error_estimator.templates.h
+++ b/include/deal.II/numerics/error_estimator.templates.h
@@ -652,14 +652,13 @@ namespace internal
    * boundary), or the other side's refinement level is the same as that of
    * this side, then handle the integration of these both cases together.
    */
-  template <typename InputVector, int dim, int spacedim>
+  template <typename Number, int dim, int spacedim>
   void
   integrate_over_regular_face(
-    const std::vector<const InputVector *> &solutions,
-    ParallelData<dim, spacedim, typename InputVector::value_type>
-      &                            parallel_data,
+    const std::vector<const ReadVector<Number> *> &solutions,
+    ParallelData<dim, spacedim, Number> &          parallel_data,
     std::map<typename DoFHandler<dim, spacedim>::face_iterator,
-             std::vector<double>> &local_face_integrals,
+             std::vector<double>> &                local_face_integrals,
     const typename DoFHandler<dim, spacedim>::active_cell_iterator &cell,
     const unsigned int                                              face_no,
     dealii::hp::FEFaceValues<dim, spacedim> &fe_face_values_cell,
@@ -746,14 +745,13 @@ namespace internal
    * over face @p face_no of @p cell, where the respective neighbor is
    * refined, so that the integration is a bit more complex.
    */
-  template <typename InputVector, int dim, int spacedim>
+  template <typename Number, int dim, int spacedim>
   void
   integrate_over_irregular_face(
-    const std::vector<const InputVector *> &solutions,
-    ParallelData<dim, spacedim, typename InputVector::value_type>
-      &                            parallel_data,
+    const std::vector<const ReadVector<Number> *> &solutions,
+    ParallelData<dim, spacedim, Number> &          parallel_data,
     std::map<typename DoFHandler<dim, spacedim>::face_iterator,
-             std::vector<double>> &local_face_integrals,
+             std::vector<double>> &                local_face_integrals,
     const typename DoFHandler<dim, spacedim>::active_cell_iterator &cell,
     const unsigned int                                              face_no,
     dealii::hp::FEFaceValues<dim, spacedim> &   fe_face_values,
@@ -861,15 +859,14 @@ namespace internal
    * This function is only needed in two or three dimensions.  The error
    * estimator in one dimension is implemented separately.
    */
-  template <typename InputVector, int dim, int spacedim>
+  template <typename Number, int dim, int spacedim>
   void
   estimate_one_cell(
     const typename DoFHandler<dim, spacedim>::active_cell_iterator &cell,
-    ParallelData<dim, spacedim, typename InputVector::value_type>
-      &                                     parallel_data,
+    ParallelData<dim, spacedim, Number> &          parallel_data,
     std::map<typename DoFHandler<dim, spacedim>::face_iterator,
-             std::vector<double>> &         local_face_integrals,
-    const std::vector<const InputVector *> &solutions,
+             std::vector<double>> &                local_face_integrals,
+    const std::vector<const ReadVector<Number> *> &solutions,
     const typename KellyErrorEstimator<dim, spacedim>::Strategy strategy)
   {
     const unsigned int n_solution_vectors = solutions.size();
@@ -1001,16 +998,15 @@ namespace internal
 // the following function is still independent of dimension, but it
 // calls dimension dependent functions
 template <int dim, int spacedim>
-template <typename InputVector>
+template <typename Number>
 void
 KellyErrorEstimator<dim, spacedim>::estimate(
   const Mapping<dim, spacedim> &   mapping,
   const DoFHandler<dim, spacedim> &dof_handler,
   const Quadrature<dim - 1> &      quadrature,
-  const std::map<types::boundary_id,
-                 const Function<spacedim, typename InputVector::value_type> *>
+  const std::map<types::boundary_id, const Function<spacedim, Number> *>
     &                       neumann_bc,
-  const InputVector &       solution,
+  const ReadVector<Number> &solution,
   Vector<float> &           error,
   const ComponentMask &     component_mask,
   const Function<spacedim> *coefficients,
@@ -1020,8 +1016,8 @@ KellyErrorEstimator<dim, spacedim>::estimate(
   const Strategy            strategy)
 {
   // just pass on to the other function
-  const std::vector<const InputVector *> solutions(1, &solution);
-  std::vector<Vector<float> *>           errors(1, &error);
+  const std::vector<const ReadVector<Number> *> solutions(1, &solution);
+  std::vector<Vector<float> *>                  errors(1, &error);
   estimate(mapping,
            dof_handler,
            quadrature,
@@ -1038,15 +1034,14 @@ KellyErrorEstimator<dim, spacedim>::estimate(
 
 
 template <int dim, int spacedim>
-template <typename InputVector>
+template <typename Number>
 void
 KellyErrorEstimator<dim, spacedim>::estimate(
   const DoFHandler<dim, spacedim> &dof_handler,
   const Quadrature<dim - 1> &      quadrature,
-  const std::map<types::boundary_id,
-                 const Function<spacedim, typename InputVector::value_type> *>
+  const std::map<types::boundary_id, const Function<spacedim, Number> *>
     &                       neumann_bc,
-  const InputVector &       solution,
+  const ReadVector<Number> &solution,
   Vector<float> &           error,
   const ComponentMask &     component_mask,
   const Function<spacedim> *coefficients,
@@ -1071,16 +1066,15 @@ KellyErrorEstimator<dim, spacedim>::estimate(
 
 
 template <int dim, int spacedim>
-template <typename InputVector>
+template <typename Number>
 void
 KellyErrorEstimator<dim, spacedim>::estimate(
   const Mapping<dim, spacedim> &   mapping,
   const DoFHandler<dim, spacedim> &dof_handler,
   const hp::QCollection<dim - 1> & quadrature,
-  const std::map<types::boundary_id,
-                 const Function<spacedim, typename InputVector::value_type> *>
+  const std::map<types::boundary_id, const Function<spacedim, Number> *>
     &                       neumann_bc,
-  const InputVector &       solution,
+  const ReadVector<Number> &solution,
   Vector<float> &           error,
   const ComponentMask &     component_mask,
   const Function<spacedim> *coefficients,
@@ -1090,8 +1084,8 @@ KellyErrorEstimator<dim, spacedim>::estimate(
   const Strategy            strategy)
 {
   // just pass on to the other function
-  const std::vector<const InputVector *> solutions(1, &solution);
-  std::vector<Vector<float> *>           errors(1, &error);
+  const std::vector<const ReadVector<Number> *> solutions(1, &solution);
+  std::vector<Vector<float> *>                  errors(1, &error);
   estimate(mapping,
            dof_handler,
            quadrature,
@@ -1108,15 +1102,14 @@ KellyErrorEstimator<dim, spacedim>::estimate(
 
 
 template <int dim, int spacedim>
-template <typename InputVector>
+template <typename Number>
 void
 KellyErrorEstimator<dim, spacedim>::estimate(
   const DoFHandler<dim, spacedim> &dof_handler,
   const hp::QCollection<dim - 1> & quadrature,
-  const std::map<types::boundary_id,
-                 const Function<spacedim, typename InputVector::value_type> *>
+  const std::map<types::boundary_id, const Function<spacedim, Number> *>
     &                       neumann_bc,
-  const InputVector &       solution,
+  const ReadVector<Number> &solution,
   Vector<float> &           error,
   const ComponentMask &     component_mask,
   const Function<spacedim> *coefficients,
@@ -1142,19 +1135,18 @@ KellyErrorEstimator<dim, spacedim>::estimate(
 
 
 template <int dim, int spacedim>
-template <typename InputVector>
+template <typename Number>
 void
 KellyErrorEstimator<dim, spacedim>::estimate(
   const Mapping<dim, spacedim> &   mapping,
   const DoFHandler<dim, spacedim> &dof_handler,
   const hp::QCollection<dim - 1> & face_quadratures,
-  const std::map<types::boundary_id,
-                 const Function<spacedim, typename InputVector::value_type> *>
-    &                                     neumann_bc,
-  const std::vector<const InputVector *> &solutions,
-  std::vector<Vector<float> *> &          errors,
-  const ComponentMask &                   component_mask,
-  const Function<spacedim> *              coefficients,
+  const std::map<types::boundary_id, const Function<spacedim, Number> *>
+    &                                            neumann_bc,
+  const std::vector<const ReadVector<Number> *> &solutions,
+  std::vector<Vector<float> *> &                 errors,
+  const ComponentMask &                          component_mask,
+  const Function<spacedim> *                     coefficients,
   const unsigned int,
   const types::subdomain_id subdomain_id_,
   const types::material_id  material_id,
@@ -1222,17 +1214,17 @@ KellyErrorEstimator<dim, spacedim>::estimate(
   // all the data needed in the error estimator by each of the threads is
   // gathered in the following structures
   const hp::MappingCollection<dim, spacedim> mapping_collection(mapping);
-  const internal::ParallelData<dim, spacedim, typename InputVector::value_type>
-    parallel_data(dof_handler.get_fe_collection(),
-                  face_quadratures,
-                  mapping_collection,
-                  (!neumann_bc.empty() || (coefficients != nullptr)),
-                  solutions.size(),
-                  subdomain_id,
-                  material_id,
-                  &neumann_bc,
-                  component_mask,
-                  coefficients);
+  const internal::ParallelData<dim, spacedim, Number> parallel_data(
+    dof_handler.get_fe_collection(),
+    face_quadratures,
+    mapping_collection,
+    (!neumann_bc.empty() || (coefficients != nullptr)),
+    solutions.size(),
+    subdomain_id,
+    material_id,
+    &neumann_bc,
+    component_mask,
+    coefficients);
   std::map<typename DoFHandler<dim, spacedim>::face_iterator,
            std::vector<double>>
     sample_local_face_integrals;
@@ -1244,10 +1236,9 @@ KellyErrorEstimator<dim, spacedim>::estimate(
       dof_handler.end()),
     [&solutions, strategy](
       const typename DoFHandler<dim, spacedim>::active_cell_iterator &cell,
-      internal::ParallelData<dim, spacedim, typename InputVector::value_type>
-        &                            parallel_data,
+      internal::ParallelData<dim, spacedim, Number> &parallel_data,
       std::map<typename DoFHandler<dim, spacedim>::face_iterator,
-               std::vector<double>> &local_face_integrals) {
+               std::vector<double>> &                local_face_integrals) {
       internal::estimate_one_cell(
         cell, parallel_data, local_face_integrals, solutions, strategy);
     },
@@ -1311,23 +1302,22 @@ KellyErrorEstimator<dim, spacedim>::estimate(
 
 
 template <int dim, int spacedim>
-template <typename InputVector>
+template <typename Number>
 void
 KellyErrorEstimator<dim, spacedim>::estimate(
   const Mapping<dim, spacedim> &   mapping,
   const DoFHandler<dim, spacedim> &dof_handler,
   const Quadrature<dim - 1> &      quadrature,
-  const std::map<types::boundary_id,
-                 const Function<spacedim, typename InputVector::value_type> *>
-    &                                     neumann_bc,
-  const std::vector<const InputVector *> &solutions,
-  std::vector<Vector<float> *> &          errors,
-  const ComponentMask &                   component_mask,
-  const Function<spacedim> *              coefficients,
-  const unsigned int                      n_threads,
-  const types::subdomain_id               subdomain_id,
-  const types::material_id                material_id,
-  const Strategy                          strategy)
+  const std::map<types::boundary_id, const Function<spacedim, Number> *>
+    &                                            neumann_bc,
+  const std::vector<const ReadVector<Number> *> &solutions,
+  std::vector<Vector<float> *> &                 errors,
+  const ComponentMask &                          component_mask,
+  const Function<spacedim> *                     coefficients,
+  const unsigned int                             n_threads,
+  const types::subdomain_id                      subdomain_id,
+  const types::material_id                       material_id,
+  const Strategy                                 strategy)
 {
   // forward to the function with the QCollection
   estimate(mapping,
@@ -1346,22 +1336,21 @@ KellyErrorEstimator<dim, spacedim>::estimate(
 
 
 template <int dim, int spacedim>
-template <typename InputVector>
+template <typename Number>
 void
 KellyErrorEstimator<dim, spacedim>::estimate(
   const DoFHandler<dim, spacedim> &dof_handler,
   const Quadrature<dim - 1> &      quadrature,
-  const std::map<types::boundary_id,
-                 const Function<spacedim, typename InputVector::value_type> *>
-    &                                     neumann_bc,
-  const std::vector<const InputVector *> &solutions,
-  std::vector<Vector<float> *> &          errors,
-  const ComponentMask &                   component_mask,
-  const Function<spacedim> *              coefficients,
-  const unsigned int                      n_threads,
-  const types::subdomain_id               subdomain_id,
-  const types::material_id                material_id,
-  const Strategy                          strategy)
+  const std::map<types::boundary_id, const Function<spacedim, Number> *>
+    &                                            neumann_bc,
+  const std::vector<const ReadVector<Number> *> &solutions,
+  std::vector<Vector<float> *> &                 errors,
+  const ComponentMask &                          component_mask,
+  const Function<spacedim> *                     coefficients,
+  const unsigned int                             n_threads,
+  const types::subdomain_id                      subdomain_id,
+  const types::material_id                       material_id,
+  const Strategy                                 strategy)
 {
   estimate(get_default_linear_mapping(dof_handler.get_triangulation()),
            dof_handler,
@@ -1380,22 +1369,21 @@ KellyErrorEstimator<dim, spacedim>::estimate(
 
 
 template <int dim, int spacedim>
-template <typename InputVector>
+template <typename Number>
 void
 KellyErrorEstimator<dim, spacedim>::estimate(
   const DoFHandler<dim, spacedim> &dof_handler,
   const hp::QCollection<dim - 1> & quadrature,
-  const std::map<types::boundary_id,
-                 const Function<spacedim, typename InputVector::value_type> *>
-    &                                     neumann_bc,
-  const std::vector<const InputVector *> &solutions,
-  std::vector<Vector<float> *> &          errors,
-  const ComponentMask &                   component_mask,
-  const Function<spacedim> *              coefficients,
-  const unsigned int                      n_threads,
-  const types::subdomain_id               subdomain_id,
-  const types::material_id                material_id,
-  const Strategy                          strategy)
+  const std::map<types::boundary_id, const Function<spacedim, Number> *>
+    &                                            neumann_bc,
+  const std::vector<const ReadVector<Number> *> &solutions,
+  std::vector<Vector<float> *> &                 errors,
+  const ComponentMask &                          component_mask,
+  const Function<spacedim> *                     coefficients,
+  const unsigned int                             n_threads,
+  const types::subdomain_id                      subdomain_id,
+  const types::material_id                       material_id,
+  const Strategy                                 strategy)
 {
   estimate(get_default_linear_mapping(dof_handler.get_triangulation()),
            dof_handler,

--- a/include/deal.II/numerics/vector_tools_integrate_difference.h
+++ b/include/deal.II/numerics/vector_tools_integrate_difference.h
@@ -144,19 +144,17 @@ namespace VectorTools
    * @dealiiConceptRequires{concepts::is_dealii_vector_type<InVector>
    *   &&concepts::is_writable_dealii_vector_type<OutVector>}
    */
-  template <int dim, class InVector, class OutVector, int spacedim>
-  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<InVector> &&
-                           concepts::is_writable_dealii_vector_type<OutVector>)
-  void integrate_difference(
-    const Mapping<dim, spacedim> &                           mapping,
-    const DoFHandler<dim, spacedim> &                        dof,
-    const InVector &                                         fe_function,
-    const Function<spacedim, typename InVector::value_type> &exact_solution,
-    OutVector &                                              difference,
-    const Quadrature<dim> &                                  q,
-    const NormType &                                         norm,
-    const Function<spacedim, double> *                       weight   = nullptr,
-    const double                                             exponent = 2.);
+  template <int dim, typename Number, class OutVector, int spacedim>
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<OutVector>)
+  void integrate_difference(const Mapping<dim, spacedim> &    mapping,
+                            const DoFHandler<dim, spacedim> & dof,
+                            const ReadVector<Number> &        fe_function,
+                            const Function<spacedim, Number> &exact_solution,
+                            OutVector &                       difference,
+                            const Quadrature<dim> &           q,
+                            const NormType &                  norm,
+                            const Function<spacedim, double> *weight = nullptr,
+                            const double                      exponent = 2.);
 
   /**
    * Call the integrate_difference() function, see above, with
@@ -165,18 +163,16 @@ namespace VectorTools
    * @dealiiConceptRequires{concepts::is_dealii_vector_type<InVector>
    *   &&concepts::is_writable_dealii_vector_type<OutVector>}
    */
-  template <int dim, class InVector, class OutVector, int spacedim>
-  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<InVector> &&
-                           concepts::is_writable_dealii_vector_type<OutVector>)
-  void integrate_difference(
-    const DoFHandler<dim, spacedim> &                        dof,
-    const InVector &                                         fe_function,
-    const Function<spacedim, typename InVector::value_type> &exact_solution,
-    OutVector &                                              difference,
-    const Quadrature<dim> &                                  q,
-    const NormType &                                         norm,
-    const Function<spacedim, double> *                       weight   = nullptr,
-    const double                                             exponent = 2.);
+  template <int dim, typename Number, class OutVector, int spacedim>
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<OutVector>)
+  void integrate_difference(const DoFHandler<dim, spacedim> & dof,
+                            const ReadVector<Number> &        fe_function,
+                            const Function<spacedim, Number> &exact_solution,
+                            OutVector &                       difference,
+                            const Quadrature<dim> &           q,
+                            const NormType &                  norm,
+                            const Function<spacedim, double> *weight = nullptr,
+                            const double                      exponent = 2.);
 
   /**
    * Same as above for hp.
@@ -184,19 +180,17 @@ namespace VectorTools
    * @dealiiConceptRequires{concepts::is_dealii_vector_type<InVector>
    *   &&concepts::is_writable_dealii_vector_type<OutVector>}
    */
-  template <int dim, class InVector, class OutVector, int spacedim>
-  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<InVector> &&
-                           concepts::is_writable_dealii_vector_type<OutVector>)
-  void integrate_difference(
-    const hp::MappingCollection<dim, spacedim> &             mapping,
-    const DoFHandler<dim, spacedim> &                        dof,
-    const InVector &                                         fe_function,
-    const Function<spacedim, typename InVector::value_type> &exact_solution,
-    OutVector &                                              difference,
-    const hp::QCollection<dim> &                             q,
-    const NormType &                                         norm,
-    const Function<spacedim, double> *                       weight   = nullptr,
-    const double                                             exponent = 2.);
+  template <int dim, typename Number, class OutVector, int spacedim>
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<OutVector>)
+  void integrate_difference(const hp::MappingCollection<dim, spacedim> &mapping,
+                            const DoFHandler<dim, spacedim> &           dof,
+                            const ReadVector<Number> &        fe_function,
+                            const Function<spacedim, Number> &exact_solution,
+                            OutVector &                       difference,
+                            const hp::QCollection<dim> &      q,
+                            const NormType &                  norm,
+                            const Function<spacedim, double> *weight = nullptr,
+                            const double                      exponent = 2.);
 
   /**
    * Call the integrate_difference() function, see above, with
@@ -205,18 +199,16 @@ namespace VectorTools
    * @dealiiConceptRequires{concepts::is_dealii_vector_type<InVector>
    *   &&concepts::is_writable_dealii_vector_type<OutVector>}
    */
-  template <int dim, class InVector, class OutVector, int spacedim>
-  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<InVector> &&
-                           concepts::is_writable_dealii_vector_type<OutVector>)
-  void integrate_difference(
-    const DoFHandler<dim, spacedim> &                        dof,
-    const InVector &                                         fe_function,
-    const Function<spacedim, typename InVector::value_type> &exact_solution,
-    OutVector &                                              difference,
-    const hp::QCollection<dim> &                             q,
-    const NormType &                                         norm,
-    const Function<spacedim, double> *                       weight   = nullptr,
-    const double                                             exponent = 2.);
+  template <int dim, typename Number, class OutVector, int spacedim>
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<OutVector>)
+  void integrate_difference(const DoFHandler<dim, spacedim> & dof,
+                            const ReadVector<Number> &        fe_function,
+                            const Function<spacedim, Number> &exact_solution,
+                            OutVector &                       difference,
+                            const hp::QCollection<dim> &      q,
+                            const NormType &                  norm,
+                            const Function<spacedim, double> *weight = nullptr,
+                            const double                      exponent = 2.);
 
   /**
    * Take a Vector @p cellwise_error of errors on each cell with

--- a/include/deal.II/numerics/vector_tools_integrate_difference.templates.h
+++ b/include/deal.II/numerics/vector_tools_integrate_difference.templates.h
@@ -431,22 +431,19 @@ namespace VectorTools
 
 
 
-    template <int dim, int spacedim, class InVector, class OutVector>
-    DEAL_II_CXX20_REQUIRES(
-      concepts::is_dealii_vector_type<InVector>
-        &&concepts::is_writable_dealii_vector_type<OutVector>)
+    template <int dim, int spacedim, typename Number, class OutVector>
+    DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<OutVector>)
     static void do_integrate_difference(
-      const dealii::hp::MappingCollection<dim, spacedim> &     mapping,
-      const DoFHandler<dim, spacedim> &                        dof,
-      const InVector &                                         fe_function,
-      const Function<spacedim, typename InVector::value_type> &exact_solution,
-      OutVector &                                              difference,
-      const dealii::hp::QCollection<dim> &                     q,
-      const NormType &                                         norm,
-      const Function<spacedim> *                               weight,
-      const double                                             exponent_1)
+      const dealii::hp::MappingCollection<dim, spacedim> &mapping,
+      const DoFHandler<dim, spacedim> &                   dof,
+      const ReadVector<Number> &                          fe_function,
+      const Function<spacedim, Number> &                  exact_solution,
+      OutVector &                                         difference,
+      const dealii::hp::QCollection<dim> &                q,
+      const NormType &                                    norm,
+      const Function<spacedim> *                          weight,
+      const double                                        exponent_1)
     {
-      using Number = typename InVector::value_type;
       // we mark the "exponent" parameter to this function "const" since it is
       // strictly incoming, but we need to set it to something different later
       // on, if necessary, so have a read-write version of it:
@@ -553,19 +550,17 @@ namespace VectorTools
 
 
 
-  template <int dim, class InVector, class OutVector, int spacedim>
-  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<InVector> &&
-                           concepts::is_writable_dealii_vector_type<OutVector>)
-  void integrate_difference(
-    const Mapping<dim, spacedim> &                           mapping,
-    const DoFHandler<dim, spacedim> &                        dof,
-    const InVector &                                         fe_function,
-    const Function<spacedim, typename InVector::value_type> &exact_solution,
-    OutVector &                                              difference,
-    const Quadrature<dim> &                                  q,
-    const NormType &                                         norm,
-    const Function<spacedim> *                               weight,
-    const double                                             exponent)
+  template <int dim, typename Number, class OutVector, int spacedim>
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<OutVector>)
+  void integrate_difference(const Mapping<dim, spacedim> &    mapping,
+                            const DoFHandler<dim, spacedim> & dof,
+                            const ReadVector<Number> &        fe_function,
+                            const Function<spacedim, Number> &exact_solution,
+                            OutVector &                       difference,
+                            const Quadrature<dim> &           q,
+                            const NormType &                  norm,
+                            const Function<spacedim> *        weight,
+                            const double                      exponent)
   {
     internal::do_integrate_difference(hp::MappingCollection<dim, spacedim>(
                                         mapping),
@@ -580,18 +575,16 @@ namespace VectorTools
   }
 
 
-  template <int dim, class InVector, class OutVector, int spacedim>
-  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<InVector> &&
-                           concepts::is_writable_dealii_vector_type<OutVector>)
-  void integrate_difference(
-    const DoFHandler<dim, spacedim> &                        dof,
-    const InVector &                                         fe_function,
-    const Function<spacedim, typename InVector::value_type> &exact_solution,
-    OutVector &                                              difference,
-    const Quadrature<dim> &                                  q,
-    const NormType &                                         norm,
-    const Function<spacedim> *                               weight,
-    const double                                             exponent)
+  template <int dim, typename Number, class OutVector, int spacedim>
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<OutVector>)
+  void integrate_difference(const DoFHandler<dim, spacedim> & dof,
+                            const ReadVector<Number> &        fe_function,
+                            const Function<spacedim, Number> &exact_solution,
+                            OutVector &                       difference,
+                            const Quadrature<dim> &           q,
+                            const NormType &                  norm,
+                            const Function<spacedim> *        weight,
+                            const double                      exponent)
   {
     internal::do_integrate_difference(
       hp::StaticMappingQ1<dim, spacedim>::mapping_collection,
@@ -606,19 +599,18 @@ namespace VectorTools
   }
 
 
-  template <int dim, class InVector, class OutVector, int spacedim>
-  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<InVector> &&
-                           concepts::is_writable_dealii_vector_type<OutVector>)
+  template <int dim, typename Number, class OutVector, int spacedim>
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<OutVector>)
   void integrate_difference(
-    const dealii::hp::MappingCollection<dim, spacedim> &     mapping,
-    const DoFHandler<dim, spacedim> &                        dof,
-    const InVector &                                         fe_function,
-    const Function<spacedim, typename InVector::value_type> &exact_solution,
-    OutVector &                                              difference,
-    const dealii::hp::QCollection<dim> &                     q,
-    const NormType &                                         norm,
-    const Function<spacedim> *                               weight,
-    const double                                             exponent)
+    const dealii::hp::MappingCollection<dim, spacedim> &mapping,
+    const DoFHandler<dim, spacedim> &                   dof,
+    const ReadVector<Number> &                          fe_function,
+    const Function<spacedim, Number> &                  exact_solution,
+    OutVector &                                         difference,
+    const dealii::hp::QCollection<dim> &                q,
+    const NormType &                                    norm,
+    const Function<spacedim> *                          weight,
+    const double                                        exponent)
   {
     internal::do_integrate_difference(mapping,
                                       dof,
@@ -631,18 +623,16 @@ namespace VectorTools
                                       exponent);
   }
 
-  template <int dim, class InVector, class OutVector, int spacedim>
-  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<InVector> &&
-                           concepts::is_writable_dealii_vector_type<OutVector>)
-  void integrate_difference(
-    const DoFHandler<dim, spacedim> &                        dof,
-    const InVector &                                         fe_function,
-    const Function<spacedim, typename InVector::value_type> &exact_solution,
-    OutVector &                                              difference,
-    const dealii::hp::QCollection<dim> &                     q,
-    const NormType &                                         norm,
-    const Function<spacedim> *                               weight,
-    const double                                             exponent)
+  template <int dim, typename Number, class OutVector, int spacedim>
+  DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<OutVector>)
+  void integrate_difference(const DoFHandler<dim, spacedim> &   dof,
+                            const ReadVector<Number> &          fe_function,
+                            const Function<spacedim, Number> &  exact_solution,
+                            OutVector &                         difference,
+                            const dealii::hp::QCollection<dim> &q,
+                            const NormType &                    norm,
+                            const Function<spacedim> *          weight,
+                            const double                        exponent)
   {
     internal::do_integrate_difference(
       hp::StaticMappingQ1<dim, spacedim>::mapping_collection,

--- a/include/deal.II/numerics/vector_tools_mean_value.h
+++ b/include/deal.II/numerics/vector_tools_mean_value.h
@@ -19,6 +19,8 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/lac/read_vector.h>
+
 #include <vector>
 
 DEAL_II_NAMESPACE_OPEN
@@ -161,47 +163,39 @@ namespace VectorTools
    * finite element function with mean value zero. In fact, it only works for
    * Lagrangian elements. For all other elements, you will need to compute the
    * mean value and subtract it right inside the evaluation routine.
-   *
-   * @dealiiConceptRequires{concepts::is_dealii_vector_type<VectorType>}
    */
-  template <int dim, typename VectorType, int spacedim>
-  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
-  typename VectorType::value_type compute_mean_value(
+  template <int dim, typename Number, int spacedim>
+  Number
+  compute_mean_value(
     const hp::MappingCollection<dim, spacedim> &mapping_collection,
     const DoFHandler<dim, spacedim> &           dof,
     const hp::QCollection<dim> &                q_collection,
-    const VectorType &                          v,
+    const ReadVector<Number> &                  v,
     const unsigned int                          component);
 
   /**
    * Calls the other compute_mean_value() function, see above, for the non-hp
    * case. That means, it requires a single FiniteElement, a single Quadrature,
    * and a single Mapping object.
-   *
-   * @dealiiConceptRequires{concepts::is_dealii_vector_type<VectorType>}
    */
-  template <int dim, typename VectorType, int spacedim>
-  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
-  typename VectorType::value_type
-    compute_mean_value(const Mapping<dim, spacedim> &   mapping,
-                       const DoFHandler<dim, spacedim> &dof,
-                       const Quadrature<dim> &          quadrature,
-                       const VectorType &               v,
-                       const unsigned int               component);
+  template <int dim, typename Number, int spacedim>
+  Number
+  compute_mean_value(const Mapping<dim, spacedim> &   mapping,
+                     const DoFHandler<dim, spacedim> &dof,
+                     const Quadrature<dim> &          quadrature,
+                     const ReadVector<Number> &       v,
+                     const unsigned int               component);
 
   /**
    * Call the other compute_mean_value() function, see above, with
    * <tt>mapping=MappingQ@<dim@>(1)</tt>.
-   *
-   * @dealiiConceptRequires{concepts::is_dealii_vector_type<VectorType>}
    */
-  template <int dim, typename VectorType, int spacedim>
-  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
-  typename VectorType::value_type
-    compute_mean_value(const DoFHandler<dim, spacedim> &dof,
-                       const Quadrature<dim> &          quadrature,
-                       const VectorType &               v,
-                       const unsigned int               component);
+  template <int dim, typename Number, int spacedim>
+  Number
+  compute_mean_value(const DoFHandler<dim, spacedim> &dof,
+                     const Quadrature<dim> &          quadrature,
+                     const ReadVector<Number> &       v,
+                     const unsigned int               component);
   /** @} */
 } // namespace VectorTools
 

--- a/include/deal.II/numerics/vector_tools_mean_value.templates.h
+++ b/include/deal.II/numerics/vector_tools_mean_value.templates.h
@@ -290,17 +290,15 @@ namespace VectorTools
 
 
 
-  template <int dim, typename VectorType, int spacedim>
-  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
-  typename VectorType::value_type compute_mean_value(
+  template <int dim, typename Number, int spacedim>
+  Number
+  compute_mean_value(
     const hp::MappingCollection<dim, spacedim> &mapping_collection,
     const DoFHandler<dim, spacedim> &           dof,
     const hp::QCollection<dim> &                q_collection,
-    const VectorType &                          v,
+    const ReadVector<Number> &                  v,
     const unsigned int                          component)
   {
-    using Number = typename VectorType::value_type;
-
     const hp::FECollection<dim, spacedim> &fe_collection =
       dof.get_fe_collection();
     const unsigned int n_components = fe_collection.n_components();
@@ -371,14 +369,13 @@ namespace VectorTools
   }
 
 
-  template <int dim, typename VectorType, int spacedim>
-  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
-  typename VectorType::value_type
-    compute_mean_value(const Mapping<dim, spacedim> &   mapping,
-                       const DoFHandler<dim, spacedim> &dof,
-                       const Quadrature<dim> &          quadrature,
-                       const VectorType &               v,
-                       const unsigned int               component)
+  template <int dim, typename Number, int spacedim>
+  Number
+  compute_mean_value(const Mapping<dim, spacedim> &   mapping,
+                     const DoFHandler<dim, spacedim> &dof,
+                     const Quadrature<dim> &          quadrature,
+                     const ReadVector<Number> &       v,
+                     const unsigned int               component)
   {
     return compute_mean_value(hp::MappingCollection<dim, spacedim>(mapping),
                               dof,
@@ -388,13 +385,12 @@ namespace VectorTools
   }
 
 
-  template <int dim, typename VectorType, int spacedim>
-  DEAL_II_CXX20_REQUIRES(concepts::is_dealii_vector_type<VectorType>)
-  typename VectorType::value_type
-    compute_mean_value(const DoFHandler<dim, spacedim> &dof,
-                       const Quadrature<dim> &          quadrature,
-                       const VectorType &               v,
-                       const unsigned int               component)
+  template <int dim, typename Number, int spacedim>
+  Number
+  compute_mean_value(const DoFHandler<dim, spacedim> &dof,
+                     const Quadrature<dim> &          quadrature,
+                     const ReadVector<Number> &       v,
+                     const unsigned int               component)
   {
     return compute_mean_value(get_default_linear_mapping(
                                 dof.get_triangulation()),

--- a/source/dofs/dof_accessor_get.cc
+++ b/source/dofs/dof_accessor_get.cc
@@ -41,12 +41,12 @@ DEAL_II_NAMESPACE_OPEN
 
 
 template <int dim, int spacedim, bool lda>
-template <class InputVector, typename number>
+template <typename Number>
 void
 DoFCellAccessor<dim, spacedim, lda>::get_interpolated_dof_values(
-  const InputVector &   values,
-  Vector<number> &      interpolated_values,
-  const types::fe_index fe_index_) const
+  const ReadVector<Number> &values,
+  Vector<Number> &          interpolated_values,
+  const types::fe_index     fe_index_) const
 {
   const types::fe_index fe_index =
     (this->dof_handler->hp_capability_enabled == false &&
@@ -78,7 +78,7 @@ DoFCellAccessor<dim, spacedim, lda>::get_interpolated_dof_values(
             }
           else
             {
-              Vector<number> tmp(dofs_per_cell);
+              Vector<Number> tmp(dofs_per_cell);
               this->get_dof_values(values, tmp);
 
               FullMatrix<double> interpolation(
@@ -130,8 +130,8 @@ DoFCellAccessor<dim, spacedim, lda>::get_interpolated_dof_values(
       // anyway (and in fact is of size zero, see the assertion above)
       if (fe.n_dofs_per_cell() > 0)
         {
-          Vector<number> tmp1(dofs_per_cell);
-          Vector<number> tmp2(dofs_per_cell);
+          Vector<Number> tmp1(dofs_per_cell);
+          Vector<Number> tmp2(dofs_per_cell);
 
           interpolated_values = 0;
 
@@ -177,7 +177,7 @@ DoFCellAccessor<dim, spacedim, lda>::get_interpolated_dof_values(
               for (unsigned int i = 0; i < dofs_per_cell; ++i)
                 if (fe.restriction_is_additive(i))
                   interpolated_values(i) += tmp2(i);
-                else if (tmp2(i) != number())
+                else if (tmp2(i) != Number())
                   interpolated_values(i) = tmp2(i);
             }
         }

--- a/source/dofs/dof_accessor_get.inst.in
+++ b/source/dofs/dof_accessor_get.inst.in
@@ -15,19 +15,19 @@
 
 
 
-for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS; lda : BOOL)
+for (S : REAL_AND_COMPLEX_SCALARS; deal_II_dimension : DIMENSIONS; lda : BOOL)
   {
     template void DoFCellAccessor<deal_II_dimension, deal_II_dimension, lda>::
-      get_interpolated_dof_values(const VEC &,
-                                  Vector<VEC::value_type> &,
+      get_interpolated_dof_values(const ReadVector<S> &,
+                                  Vector<S> &,
                                   const types::fe_index) const;
 
 #if deal_II_dimension != 3
 
     template void
     DoFCellAccessor<deal_II_dimension, deal_II_dimension + 1, lda>::
-      get_interpolated_dof_values(const VEC &,
-                                  Vector<VEC::value_type> &,
+      get_interpolated_dof_values(const ReadVector<S> &,
+                                  Vector<S> &,
                                   const types::fe_index) const;
 
 #endif
@@ -35,7 +35,7 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS; lda : BOOL)
 #if deal_II_dimension == 3
 
     template void DoFCellAccessor<1, 3, lda>::get_interpolated_dof_values(
-      const VEC &, Vector<VEC::value_type> &, const types::fe_index) const;
+      const ReadVector<S> &, Vector<S> &, const types::fe_index) const;
 
 #endif
   }

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -32,18 +32,7 @@
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/tria_iterator.h>
 
-#include <deal.II/lac/block_vector.h>
-#include <deal.II/lac/la_parallel_block_vector.h>
-#include <deal.II/lac/la_parallel_vector.h>
-#include <deal.II/lac/la_vector.h>
-#include <deal.II/lac/petsc_block_vector.h>
-#include <deal.II/lac/petsc_vector.h>
-#include <deal.II/lac/trilinos_epetra_vector.h>
-#include <deal.II/lac/trilinos_parallel_block_vector.h>
-#include <deal.II/lac/trilinos_tpetra_vector.h>
-#include <deal.II/lac/trilinos_vector.h>
 #include <deal.II/lac/vector.h>
-#include <deal.II/lac/vector_element_access.h>
 
 #include <boost/container/small_vector.hpp>
 
@@ -56,25 +45,6 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  template <class VectorType>
-  typename VectorType::value_type inline get_vector_element(
-    const VectorType &            vector,
-    const types::global_dof_index cell_number)
-  {
-    return internal::ElementAccess<VectorType>::get(vector, cell_number);
-  }
-
-
-
-  IndexSet::value_type inline get_vector_element(
-    const IndexSet &              is,
-    const types::global_dof_index cell_number)
-  {
-    return (is.is_element(cell_number) ? 1 : 0);
-  }
-
-
-
   template <int dim, int spacedim>
   inline std::vector<unsigned int>
   make_shape_function_to_row_table(const FiniteElement<dim, spacedim> &fe)
@@ -1643,12 +1613,11 @@ namespace FEValuesViews
 
 
   template <int dim, int spacedim>
-  template <class InputVector>
+  template <typename Number>
   void
   Scalar<dim, spacedim>::get_function_hessians(
-    const InputVector &fe_function,
-    std::vector<solution_hessian_type<typename InputVector::value_type>>
-      &hessians) const
+    const ReadVector<Number> &                  fe_function,
+    std::vector<solution_hessian_type<Number>> &hessians) const
   {
     Assert(fe_values->update_flags & update_hessians,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
@@ -1659,8 +1628,7 @@ namespace FEValuesViews
                     fe_values->present_cell.n_dofs_for_dof_handler());
 
     // get function values of dofs on this cell
-    dealii::Vector<typename InputVector::value_type> dof_values(
-      fe_values->dofs_per_cell);
+    dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
     fe_values->present_cell.get_interpolated_dof_values(fe_function,
                                                         dof_values);
     internal::do_function_derivatives<2, dim, spacedim>(
@@ -1697,12 +1665,11 @@ namespace FEValuesViews
 
 
   template <int dim, int spacedim>
-  template <class InputVector>
+  template <typename Number>
   void
   Scalar<dim, spacedim>::get_function_laplacians(
-    const InputVector &fe_function,
-    std::vector<solution_laplacian_type<typename InputVector::value_type>>
-      &laplacians) const
+    const ReadVector<Number> &                    fe_function,
+    std::vector<solution_laplacian_type<Number>> &laplacians) const
   {
     Assert(fe_values->update_flags & update_hessians,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
@@ -1713,8 +1680,7 @@ namespace FEValuesViews
                     fe_values->present_cell.n_dofs_for_dof_handler());
 
     // get function values of dofs on this cell
-    dealii::Vector<typename InputVector::value_type> dof_values(
-      fe_values->dofs_per_cell);
+    dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
     fe_values->present_cell.get_interpolated_dof_values(fe_function,
                                                         dof_values);
     internal::do_function_laplacians<dim, spacedim>(
@@ -1751,13 +1717,12 @@ namespace FEValuesViews
 
 
   template <int dim, int spacedim>
-  template <class InputVector>
+  template <typename Number>
   void
   Scalar<dim, spacedim>::get_function_third_derivatives(
-    const InputVector &fe_function,
-    std::vector<
-      solution_third_derivative_type<typename InputVector::value_type>>
-      &third_derivatives) const
+    const ReadVector<Number> &                           fe_function,
+    std::vector<solution_third_derivative_type<Number>> &third_derivatives)
+    const
   {
     Assert(fe_values->update_flags & update_3rd_derivatives,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
@@ -1768,8 +1733,7 @@ namespace FEValuesViews
                     fe_values->present_cell.n_dofs_for_dof_handler());
 
     // get function values of dofs on this cell
-    dealii::Vector<typename InputVector::value_type> dof_values(
-      fe_values->dofs_per_cell);
+    dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
     fe_values->present_cell.get_interpolated_dof_values(fe_function,
                                                         dof_values);
     internal::do_function_derivatives<3, dim, spacedim>(
@@ -1909,13 +1873,12 @@ namespace FEValuesViews
 
 
   template <int dim, int spacedim>
-  template <class InputVector>
+  template <typename Number>
   void
   Vector<dim, spacedim>::get_function_symmetric_gradients(
-    const InputVector &fe_function,
-    std::vector<
-      solution_symmetric_gradient_type<typename InputVector::value_type>>
-      &symmetric_gradients) const
+    const ReadVector<Number> &                             fe_function,
+    std::vector<solution_symmetric_gradient_type<Number>> &symmetric_gradients)
+    const
   {
     Assert(fe_values->update_flags & update_gradients,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
@@ -1926,8 +1889,7 @@ namespace FEValuesViews
                     fe_values->present_cell.n_dofs_for_dof_handler());
 
     // get function values of dofs on this cell
-    dealii::Vector<typename InputVector::value_type> dof_values(
-      fe_values->dofs_per_cell);
+    dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
     fe_values->present_cell.get_interpolated_dof_values(fe_function,
                                                         dof_values);
     internal::do_function_symmetric_gradients<dim, spacedim>(
@@ -1965,12 +1927,11 @@ namespace FEValuesViews
 
 
   template <int dim, int spacedim>
-  template <class InputVector>
+  template <typename Number>
   void
   Vector<dim, spacedim>::get_function_divergences(
-    const InputVector &fe_function,
-    std::vector<solution_divergence_type<typename InputVector::value_type>>
-      &divergences) const
+    const ReadVector<Number> &                     fe_function,
+    std::vector<solution_divergence_type<Number>> &divergences) const
   {
     Assert(fe_values->update_flags & update_gradients,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
@@ -1982,8 +1943,7 @@ namespace FEValuesViews
 
     // get function values of dofs
     // on this cell
-    dealii::Vector<typename InputVector::value_type> dof_values(
-      fe_values->dofs_per_cell);
+    dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
     fe_values->present_cell.get_interpolated_dof_values(fe_function,
                                                         dof_values);
     internal::do_function_divergences<dim, spacedim>(
@@ -2020,12 +1980,11 @@ namespace FEValuesViews
 
 
   template <int dim, int spacedim>
-  template <class InputVector>
+  template <typename Number>
   void
   Vector<dim, spacedim>::get_function_curls(
-    const InputVector &fe_function,
-    std::vector<solution_curl_type<typename InputVector::value_type>> &curls)
-    const
+    const ReadVector<Number> &               fe_function,
+    std::vector<solution_curl_type<Number>> &curls) const
   {
     Assert(fe_values->update_flags & update_gradients,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
@@ -2036,8 +1995,7 @@ namespace FEValuesViews
                     fe_values->present_cell.n_dofs_for_dof_handler());
 
     // get function values of dofs on this cell
-    dealii::Vector<typename InputVector::value_type> dof_values(
-      fe_values->dofs_per_cell);
+    dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
     fe_values->present_cell.get_interpolated_dof_values(fe_function,
                                                         dof_values);
     internal::do_function_curls<dim, spacedim>(
@@ -2074,12 +2032,11 @@ namespace FEValuesViews
 
 
   template <int dim, int spacedim>
-  template <class InputVector>
+  template <typename Number>
   void
   Vector<dim, spacedim>::get_function_hessians(
-    const InputVector &fe_function,
-    std::vector<solution_hessian_type<typename InputVector::value_type>>
-      &hessians) const
+    const ReadVector<Number> &                  fe_function,
+    std::vector<solution_hessian_type<Number>> &hessians) const
   {
     Assert(fe_values->update_flags & update_hessians,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
@@ -2090,8 +2047,7 @@ namespace FEValuesViews
                     fe_values->present_cell.n_dofs_for_dof_handler());
 
     // get function values of dofs on this cell
-    dealii::Vector<typename InputVector::value_type> dof_values(
-      fe_values->dofs_per_cell);
+    dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
     fe_values->present_cell.get_interpolated_dof_values(fe_function,
                                                         dof_values);
     internal::do_function_derivatives<2, dim, spacedim>(
@@ -2128,12 +2084,11 @@ namespace FEValuesViews
 
 
   template <int dim, int spacedim>
-  template <class InputVector>
+  template <typename Number>
   void
   Vector<dim, spacedim>::get_function_laplacians(
-    const InputVector &fe_function,
-    std::vector<solution_value_type<typename InputVector::value_type>>
-      &laplacians) const
+    const ReadVector<Number> &                fe_function,
+    std::vector<solution_value_type<Number>> &laplacians) const
   {
     Assert(fe_values->update_flags & update_hessians,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
@@ -2149,8 +2104,7 @@ namespace FEValuesViews
                            fe_values->present_cell.n_dofs_for_dof_handler()));
 
     // get function values of dofs on this cell
-    dealii::Vector<typename InputVector::value_type> dof_values(
-      fe_values->dofs_per_cell);
+    dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
     fe_values->present_cell.get_interpolated_dof_values(fe_function,
                                                         dof_values);
     internal::do_function_laplacians<dim, spacedim>(
@@ -2190,13 +2144,12 @@ namespace FEValuesViews
 
 
   template <int dim, int spacedim>
-  template <class InputVector>
+  template <typename Number>
   void
   Vector<dim, spacedim>::get_function_third_derivatives(
-    const InputVector &fe_function,
-    std::vector<
-      solution_third_derivative_type<typename InputVector::value_type>>
-      &third_derivatives) const
+    const ReadVector<Number> &                           fe_function,
+    std::vector<solution_third_derivative_type<Number>> &third_derivatives)
+    const
   {
     Assert(fe_values->update_flags & update_3rd_derivatives,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
@@ -2207,8 +2160,7 @@ namespace FEValuesViews
                     fe_values->present_cell.n_dofs_for_dof_handler());
 
     // get function values of dofs on this cell
-    dealii::Vector<typename InputVector::value_type> dof_values(
-      fe_values->dofs_per_cell);
+    dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
     fe_values->present_cell.get_interpolated_dof_values(fe_function,
                                                         dof_values);
     internal::do_function_derivatives<3, dim, spacedim>(
@@ -2296,12 +2248,11 @@ namespace FEValuesViews
 
 
   template <int dim, int spacedim>
-  template <class InputVector>
+  template <typename Number>
   void
   SymmetricTensor<2, dim, spacedim>::get_function_divergences(
-    const InputVector &fe_function,
-    std::vector<solution_divergence_type<typename InputVector::value_type>>
-      &divergences) const
+    const ReadVector<Number> &                     fe_function,
+    std::vector<solution_divergence_type<Number>> &divergences) const
   {
     Assert(fe_values->update_flags & update_gradients,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
@@ -2313,8 +2264,7 @@ namespace FEValuesViews
 
     // get function values of dofs
     // on this cell
-    dealii::Vector<typename InputVector::value_type> dof_values(
-      fe_values->dofs_per_cell);
+    dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
     fe_values->present_cell.get_interpolated_dof_values(fe_function,
                                                         dof_values);
     internal::do_function_divergences<dim, spacedim>(
@@ -2402,12 +2352,11 @@ namespace FEValuesViews
 
 
   template <int dim, int spacedim>
-  template <class InputVector>
+  template <typename Number>
   void
   Tensor<2, dim, spacedim>::get_function_divergences(
-    const InputVector &fe_function,
-    std::vector<solution_divergence_type<typename InputVector::value_type>>
-      &divergences) const
+    const ReadVector<Number> &                     fe_function,
+    std::vector<solution_divergence_type<Number>> &divergences) const
   {
     Assert(fe_values->update_flags & update_gradients,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
@@ -2419,8 +2368,7 @@ namespace FEValuesViews
 
     // get function values of dofs
     // on this cell
-    dealii::Vector<typename InputVector::value_type> dof_values(
-      fe_values->dofs_per_cell);
+    dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
     fe_values->present_cell.get_interpolated_dof_values(fe_function,
                                                         dof_values);
     internal::do_function_divergences<dim, spacedim>(
@@ -3469,7 +3417,7 @@ FEValuesBase<dim, spacedim>::get_function_gradients(
   auto view = make_array_view(dof_values.begin(), dof_values.end());
   fe_function.extract_subvector_to(indices, view);
   internal::do_function_derivatives(
-    make_array_view(dof_values.begin(), dof_values.end()),
+    view,
     this->finite_element_output.shape_gradients,
     *fe,
     this->finite_element_output.shape_function_to_row_table,
@@ -3481,14 +3429,12 @@ FEValuesBase<dim, spacedim>::get_function_gradients(
 
 
 template <int dim, int spacedim>
-template <class InputVector>
+template <typename Number>
 void
 FEValuesBase<dim, spacedim>::get_function_hessians(
-  const InputVector &fe_function,
-  std::vector<Tensor<2, spacedim, typename InputVector::value_type>> &hessians)
-  const
+  const ReadVector<Number> &                fe_function,
+  std::vector<Tensor<2, spacedim, Number>> &hessians) const
 {
-  using Number = typename InputVector::value_type;
   AssertDimension(fe->n_components(), 1);
   Assert(this->update_flags & update_hessians,
          ExcAccessToUninitializedField("update_hessians"));
@@ -3507,25 +3453,22 @@ FEValuesBase<dim, spacedim>::get_function_hessians(
 
 
 template <int dim, int spacedim>
-template <class InputVector>
+template <typename Number>
 void
 FEValuesBase<dim, spacedim>::get_function_hessians(
-  const InputVector &                             fe_function,
+  const ReadVector<Number> &                      fe_function,
   const ArrayView<const types::global_dof_index> &indices,
-  std::vector<Tensor<2, spacedim, typename InputVector::value_type>> &hessians)
-  const
+  std::vector<Tensor<2, spacedim, Number>> &      hessians) const
 {
-  using Number = typename InputVector::value_type;
   Assert(this->update_flags & update_hessians,
          ExcAccessToUninitializedField("update_hessians"));
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
   AssertDimension(indices.size(), dofs_per_cell);
 
   boost::container::small_vector<Number, 200> dof_values(dofs_per_cell);
-  for (unsigned int i = 0; i < dofs_per_cell; ++i)
-    dof_values[i] = internal::get_vector_element(fe_function, indices[i]);
-  internal::do_function_derivatives(make_array_view(dof_values.begin(),
-                                                    dof_values.end()),
+  auto view = make_array_view(dof_values.begin(), dof_values.end());
+  fe_function.extract_subvector_to(indices, view);
+  internal::do_function_derivatives(view,
                                     this->finite_element_output.shape_hessians,
                                     hessians);
 }
@@ -3533,16 +3476,13 @@ FEValuesBase<dim, spacedim>::get_function_hessians(
 
 
 template <int dim, int spacedim>
-template <class InputVector>
+template <typename Number>
 void
 FEValuesBase<dim, spacedim>::get_function_hessians(
-  const InputVector &fe_function,
-  std::vector<
-    std::vector<Tensor<2, spacedim, typename InputVector::value_type>>>
-    &        hessians,
+  const ReadVector<Number> &                             fe_function,
+  std::vector<std::vector<Tensor<2, spacedim, Number>>> &hessians,
   const bool quadrature_points_fastest) const
 {
-  using Number = typename InputVector::value_type;
   Assert(this->update_flags & update_hessians,
          ExcAccessToUninitializedField("update_hessians"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -3563,26 +3503,24 @@ FEValuesBase<dim, spacedim>::get_function_hessians(
 
 
 template <int dim, int spacedim>
-template <class InputVector>
+template <typename Number>
 void
 FEValuesBase<dim, spacedim>::get_function_hessians(
-  const InputVector &                             fe_function,
-  const ArrayView<const types::global_dof_index> &indices,
-  ArrayView<std::vector<Tensor<2, spacedim, typename InputVector::value_type>>>
-             hessians,
+  const ReadVector<Number> &                          fe_function,
+  const ArrayView<const types::global_dof_index> &    indices,
+  ArrayView<std::vector<Tensor<2, spacedim, Number>>> hessians,
   const bool quadrature_points_fastest) const
 {
-  using Number = typename InputVector::value_type;
   Assert(this->update_flags & update_hessians,
          ExcAccessToUninitializedField("update_hessians"));
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
 
   boost::container::small_vector<Number, 200> dof_values(indices.size());
-  for (unsigned int i = 0; i < indices.size(); ++i)
-    dof_values[i] = internal::get_vector_element(fe_function, indices[i]);
+  auto view = make_array_view(dof_values.begin(), dof_values.end());
+  fe_function.extract_subvector_to(indices, view);
   internal::do_function_derivatives(
-    make_array_view(dof_values.begin(), dof_values.end()),
+    view,
     this->finite_element_output.shape_hessians,
     *fe,
     this->finite_element_output.shape_function_to_row_table,
@@ -3594,13 +3532,12 @@ FEValuesBase<dim, spacedim>::get_function_hessians(
 
 
 template <int dim, int spacedim>
-template <class InputVector>
+template <typename Number>
 void
 FEValuesBase<dim, spacedim>::get_function_laplacians(
-  const InputVector &                            fe_function,
-  std::vector<typename InputVector::value_type> &laplacians) const
+  const ReadVector<Number> &fe_function,
+  std::vector<Number> &     laplacians) const
 {
-  using Number = typename InputVector::value_type;
   Assert(this->update_flags & update_hessians,
          ExcAccessToUninitializedField("update_hessians"));
   AssertDimension(fe->n_components(), 1);
@@ -3619,24 +3556,22 @@ FEValuesBase<dim, spacedim>::get_function_laplacians(
 
 
 template <int dim, int spacedim>
-template <class InputVector>
+template <typename Number>
 void
 FEValuesBase<dim, spacedim>::get_function_laplacians(
-  const InputVector &                             fe_function,
+  const ReadVector<Number> &                      fe_function,
   const ArrayView<const types::global_dof_index> &indices,
-  std::vector<typename InputVector::value_type> & laplacians) const
+  std::vector<Number> &                           laplacians) const
 {
-  using Number = typename InputVector::value_type;
   Assert(this->update_flags & update_hessians,
          ExcAccessToUninitializedField("update_hessians"));
   AssertDimension(fe->n_components(), 1);
   AssertDimension(indices.size(), dofs_per_cell);
 
   boost::container::small_vector<Number, 200> dof_values(dofs_per_cell);
-  for (unsigned int i = 0; i < dofs_per_cell; ++i)
-    dof_values[i] = internal::get_vector_element(fe_function, indices[i]);
-  internal::do_function_laplacians(make_array_view(dof_values.begin(),
-                                                   dof_values.end()),
+  auto view = make_array_view(dof_values.begin(), dof_values.end());
+  fe_function.extract_subvector_to(indices, view);
+  internal::do_function_laplacians(view,
                                    this->finite_element_output.shape_hessians,
                                    laplacians);
 }
@@ -3644,13 +3579,12 @@ FEValuesBase<dim, spacedim>::get_function_laplacians(
 
 
 template <int dim, int spacedim>
-template <class InputVector>
+template <typename Number>
 void
 FEValuesBase<dim, spacedim>::get_function_laplacians(
-  const InputVector &                                    fe_function,
-  std::vector<Vector<typename InputVector::value_type>> &laplacians) const
+  const ReadVector<Number> &   fe_function,
+  std::vector<Vector<Number>> &laplacians) const
 {
-  using Number = typename InputVector::value_type;
   Assert(present_cell.is_initialized(), ExcNotReinited());
   Assert(this->update_flags & update_hessians,
          ExcAccessToUninitializedField("update_hessians"));
@@ -3670,14 +3604,13 @@ FEValuesBase<dim, spacedim>::get_function_laplacians(
 
 
 template <int dim, int spacedim>
-template <class InputVector>
+template <typename Number>
 void
 FEValuesBase<dim, spacedim>::get_function_laplacians(
-  const InputVector &                                    fe_function,
-  const ArrayView<const types::global_dof_index> &       indices,
-  std::vector<Vector<typename InputVector::value_type>> &laplacians) const
+  const ReadVector<Number> &                      fe_function,
+  const ArrayView<const types::global_dof_index> &indices,
+  std::vector<Vector<Number>> &                   laplacians) const
 {
-  using Number = typename InputVector::value_type;
   // Size of indices must be a multiple of dofs_per_cell such that an integer
   // number of function values is generated in each point.
   Assert(indices.size() % dofs_per_cell == 0,
@@ -3686,10 +3619,10 @@ FEValuesBase<dim, spacedim>::get_function_laplacians(
          ExcAccessToUninitializedField("update_hessians"));
 
   boost::container::small_vector<Number, 200> dof_values(indices.size());
-  for (unsigned int i = 0; i < indices.size(); ++i)
-    dof_values[i] = internal::get_vector_element(fe_function, indices[i]);
+  auto view = make_array_view(dof_values.begin(), dof_values.end());
+  fe_function.extract_subvector_to(indices, view);
   internal::do_function_laplacians(
-    make_array_view(dof_values.begin(), dof_values.end()),
+    view,
     this->finite_element_output.shape_hessians,
     *fe,
     this->finite_element_output.shape_function_to_row_table,
@@ -3701,25 +3634,24 @@ FEValuesBase<dim, spacedim>::get_function_laplacians(
 
 
 template <int dim, int spacedim>
-template <class InputVector>
+template <typename Number>
 void
 FEValuesBase<dim, spacedim>::get_function_laplacians(
-  const InputVector &                                         fe_function,
-  const ArrayView<const types::global_dof_index> &            indices,
-  std::vector<std::vector<typename InputVector::value_type>> &laplacians,
+  const ReadVector<Number> &                      fe_function,
+  const ArrayView<const types::global_dof_index> &indices,
+  std::vector<std::vector<Number>> &              laplacians,
   const bool quadrature_points_fastest) const
 {
-  using Number = typename InputVector::value_type;
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
   Assert(this->update_flags & update_hessians,
          ExcAccessToUninitializedField("update_hessians"));
 
   boost::container::small_vector<Number, 200> dof_values(indices.size());
-  for (unsigned int i = 0; i < indices.size(); ++i)
-    dof_values[i] = internal::get_vector_element(fe_function, indices[i]);
+  auto view = make_array_view(dof_values.begin(), dof_values.end());
+  fe_function.extract_subvector_to(indices, view);
   internal::do_function_laplacians(
-    make_array_view(dof_values.begin(), dof_values.end()),
+    view,
     this->finite_element_output.shape_hessians,
     *fe,
     this->finite_element_output.shape_function_to_row_table,
@@ -3731,14 +3663,12 @@ FEValuesBase<dim, spacedim>::get_function_laplacians(
 
 
 template <int dim, int spacedim>
-template <class InputVector>
+template <typename Number>
 void
 FEValuesBase<dim, spacedim>::get_function_third_derivatives(
-  const InputVector &fe_function,
-  std::vector<Tensor<3, spacedim, typename InputVector::value_type>>
-    &third_derivatives) const
+  const ReadVector<Number> &                fe_function,
+  std::vector<Tensor<3, spacedim, Number>> &third_derivatives) const
 {
-  using Number = typename InputVector::value_type;
   AssertDimension(fe->n_components(), 1);
   Assert(this->update_flags & update_3rd_derivatives,
          ExcAccessToUninitializedField("update_3rd_derivatives"));
@@ -3757,42 +3687,35 @@ FEValuesBase<dim, spacedim>::get_function_third_derivatives(
 
 
 template <int dim, int spacedim>
-template <class InputVector>
+template <typename Number>
 void
 FEValuesBase<dim, spacedim>::get_function_third_derivatives(
-  const InputVector &                             fe_function,
+  const ReadVector<Number> &                      fe_function,
   const ArrayView<const types::global_dof_index> &indices,
-  std::vector<Tensor<3, spacedim, typename InputVector::value_type>>
-    &third_derivatives) const
+  std::vector<Tensor<3, spacedim, Number>> &      third_derivatives) const
 {
-  using Number = typename InputVector::value_type;
   Assert(this->update_flags & update_3rd_derivatives,
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
   AssertDimension(indices.size(), dofs_per_cell);
 
   boost::container::small_vector<Number, 200> dof_values(dofs_per_cell);
-  for (unsigned int i = 0; i < dofs_per_cell; ++i)
-    dof_values[i] = internal::get_vector_element(fe_function, indices[i]);
+  auto view = make_array_view(dof_values.begin(), dof_values.end());
+  fe_function.extract_subvector_to(indices, view);
   internal::do_function_derivatives(
-    make_array_view(dof_values.begin(), dof_values.end()),
-    this->finite_element_output.shape_3rd_derivatives,
-    third_derivatives);
+    view, this->finite_element_output.shape_3rd_derivatives, third_derivatives);
 }
 
 
 
 template <int dim, int spacedim>
-template <class InputVector>
+template <typename Number>
 void
 FEValuesBase<dim, spacedim>::get_function_third_derivatives(
-  const InputVector &fe_function,
-  std::vector<
-    std::vector<Tensor<3, spacedim, typename InputVector::value_type>>>
-    &        third_derivatives,
+  const ReadVector<Number> &                             fe_function,
+  std::vector<std::vector<Tensor<3, spacedim, Number>>> &third_derivatives,
   const bool quadrature_points_fastest) const
 {
-  using Number = typename InputVector::value_type;
   Assert(this->update_flags & update_3rd_derivatives,
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -3813,26 +3736,24 @@ FEValuesBase<dim, spacedim>::get_function_third_derivatives(
 
 
 template <int dim, int spacedim>
-template <class InputVector>
+template <typename Number>
 void
 FEValuesBase<dim, spacedim>::get_function_third_derivatives(
-  const InputVector &                             fe_function,
-  const ArrayView<const types::global_dof_index> &indices,
-  ArrayView<std::vector<Tensor<3, spacedim, typename InputVector::value_type>>>
-             third_derivatives,
+  const ReadVector<Number> &                          fe_function,
+  const ArrayView<const types::global_dof_index> &    indices,
+  ArrayView<std::vector<Tensor<3, spacedim, Number>>> third_derivatives,
   const bool quadrature_points_fastest) const
 {
-  using Number = typename InputVector::value_type;
   Assert(this->update_flags & update_3rd_derivatives,
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
 
   boost::container::small_vector<Number, 200> dof_values(indices.size());
-  for (unsigned int i = 0; i < indices.size(); ++i)
-    dof_values[i] = internal::get_vector_element(fe_function, indices[i]);
+  auto view = make_array_view(dof_values.begin(), dof_values.end());
+  fe_function.extract_subvector_to(indices, view);
   internal::do_function_derivatives(
-    make_array_view(dof_values.begin(), dof_values.end()),
+    view,
     this->finite_element_output.shape_3rd_derivatives,
     *fe,
     this->finite_element_output.shape_function_to_row_table,

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -1540,25 +1540,21 @@ namespace FEValuesViews
 
 
   template <int dim, int spacedim>
-  template <class InputVector>
+  template <typename Number>
   void
   Scalar<dim, spacedim>::get_function_values(
-    const InputVector &fe_function,
-    std::vector<solution_value_type<typename InputVector::value_type>> &values)
-    const
+    const ReadVector<Number> &                fe_function,
+    std::vector<solution_value_type<Number>> &values) const
   {
     Assert(fe_values->update_flags & update_values,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
-    AssertDimension(fe_function.size(),
-                    fe_values->present_cell.n_dofs_for_dof_handler());
 
     // get function values of dofs on this cell and call internal worker
     // function
-    dealii::Vector<typename InputVector::value_type> dof_values(
-      fe_values->dofs_per_cell);
+    dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
     fe_values->present_cell.get_interpolated_dof_values(fe_function,
                                                         dof_values);
     internal::do_function_values<dim, spacedim>(
@@ -1813,24 +1809,20 @@ namespace FEValuesViews
 
 
   template <int dim, int spacedim>
-  template <class InputVector>
+  template <typename Number>
   void
   Vector<dim, spacedim>::get_function_values(
-    const InputVector &fe_function,
-    std::vector<solution_value_type<typename InputVector::value_type>> &values)
-    const
+    const ReadVector<Number> &                fe_function,
+    std::vector<solution_value_type<Number>> &values) const
   {
     Assert(fe_values->update_flags & update_values,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
-    AssertDimension(fe_function.size(),
-                    fe_values->present_cell.n_dofs_for_dof_handler());
 
     // get function values of dofs on this cell
-    dealii::Vector<typename InputVector::value_type> dof_values(
-      fe_values->dofs_per_cell);
+    dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
     fe_values->present_cell.get_interpolated_dof_values(fe_function,
                                                         dof_values);
     internal::do_function_values<dim, spacedim>(
@@ -2258,24 +2250,20 @@ namespace FEValuesViews
 
 
   template <int dim, int spacedim>
-  template <class InputVector>
+  template <typename Number>
   void
   SymmetricTensor<2, dim, spacedim>::get_function_values(
-    const InputVector &fe_function,
-    std::vector<solution_value_type<typename InputVector::value_type>> &values)
-    const
+    const ReadVector<Number> &                fe_function,
+    std::vector<solution_value_type<Number>> &values) const
   {
     Assert(fe_values->update_flags & update_values,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
-    AssertDimension(fe_function.size(),
-                    fe_values->present_cell.n_dofs_for_dof_handler());
 
     // get function values of dofs on this cell
-    dealii::Vector<typename InputVector::value_type> dof_values(
-      fe_values->dofs_per_cell);
+    dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
     fe_values->present_cell.get_interpolated_dof_values(fe_function,
                                                         dof_values);
     internal::do_function_values<dim, spacedim>(
@@ -2368,24 +2356,20 @@ namespace FEValuesViews
 
 
   template <int dim, int spacedim>
-  template <class InputVector>
+  template <typename Number>
   void
   Tensor<2, dim, spacedim>::get_function_values(
-    const InputVector &fe_function,
-    std::vector<solution_value_type<typename InputVector::value_type>> &values)
-    const
+    const ReadVector<Number> &                fe_function,
+    std::vector<solution_value_type<Number>> &values) const
   {
     Assert(fe_values->update_flags & update_values,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
-    AssertDimension(fe_function.size(),
-                    fe_values->present_cell.n_dofs_for_dof_handler());
 
     // get function values of dofs on this cell
-    dealii::Vector<typename InputVector::value_type> dof_values(
-      fe_values->dofs_per_cell);
+    dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
     fe_values->present_cell.get_interpolated_dof_values(fe_function,
                                                         dof_values);
     internal::do_function_values<dim, spacedim>(
@@ -2645,11 +2629,11 @@ FEValuesBase<dim, spacedim>::CellIteratorContainer::n_dofs_for_dof_handler()
 
 
 template <int dim, int spacedim>
-template <typename VectorType>
+template <typename Number>
 void
 FEValuesBase<dim, spacedim>::CellIteratorContainer::get_interpolated_dof_values(
-  const VectorType &                       in,
-  Vector<typename VectorType::value_type> &out) const
+  const ReadVector<Number> &in,
+  Vector<Number> &          out) const
 {
   Assert(is_initialized(), ExcNotReinited());
   Assert(dof_handler != nullptr, ExcNeedsDoFHandler());
@@ -3265,13 +3249,12 @@ namespace internal
 
 
 template <int dim, int spacedim>
-template <class InputVector>
+template <typename Number>
 void
 FEValuesBase<dim, spacedim>::get_function_values(
-  const InputVector &                            fe_function,
-  std::vector<typename InputVector::value_type> &values) const
+  const ReadVector<Number> &fe_function,
+  std::vector<Number> &     values) const
 {
-  using Number = typename InputVector::value_type;
   Assert(this->update_flags & update_values,
          ExcAccessToUninitializedField("update_values"));
   AssertDimension(fe->n_components(), 1);
@@ -3290,24 +3273,22 @@ FEValuesBase<dim, spacedim>::get_function_values(
 
 
 template <int dim, int spacedim>
-template <class InputVector>
+template <typename Number>
 void
 FEValuesBase<dim, spacedim>::get_function_values(
-  const InputVector &                             fe_function,
+  const ReadVector<Number> &                      fe_function,
   const ArrayView<const types::global_dof_index> &indices,
-  std::vector<typename InputVector::value_type> & values) const
+  std::vector<Number> &                           values) const
 {
-  using Number = typename InputVector::value_type;
   Assert(this->update_flags & update_values,
          ExcAccessToUninitializedField("update_values"));
   AssertDimension(fe->n_components(), 1);
   AssertDimension(indices.size(), dofs_per_cell);
 
   boost::container::small_vector<Number, 200> dof_values(dofs_per_cell);
-  for (unsigned int i = 0; i < dofs_per_cell; ++i)
-    dof_values[i] = internal::get_vector_element(fe_function, indices[i]);
-  internal::do_function_values(make_array_view(dof_values.begin(),
-                                               dof_values.end()),
+  auto view = make_array_view(dof_values.begin(), dof_values.end());
+  fe_function.extract_subvector_to(indices, view);
+  internal::do_function_values(view,
                                this->finite_element_output.shape_values,
                                values);
 }
@@ -3315,13 +3296,12 @@ FEValuesBase<dim, spacedim>::get_function_values(
 
 
 template <int dim, int spacedim>
-template <class InputVector>
+template <typename Number>
 void
 FEValuesBase<dim, spacedim>::get_function_values(
-  const InputVector &                                    fe_function,
-  std::vector<Vector<typename InputVector::value_type>> &values) const
+  const ReadVector<Number> &   fe_function,
+  std::vector<Vector<Number>> &values) const
 {
-  using Number = typename InputVector::value_type;
   Assert(present_cell.is_initialized(), ExcNotReinited());
 
   Assert(this->update_flags & update_values,
@@ -3342,14 +3322,13 @@ FEValuesBase<dim, spacedim>::get_function_values(
 
 
 template <int dim, int spacedim>
-template <class InputVector>
+template <typename Number>
 void
 FEValuesBase<dim, spacedim>::get_function_values(
-  const InputVector &                                    fe_function,
-  const ArrayView<const types::global_dof_index> &       indices,
-  std::vector<Vector<typename InputVector::value_type>> &values) const
+  const ReadVector<Number> &                      fe_function,
+  const ArrayView<const types::global_dof_index> &indices,
+  std::vector<Vector<Number>> &                   values) const
 {
-  using Number = typename InputVector::value_type;
   // Size of indices must be a multiple of dofs_per_cell such that an integer
   // number of function values is generated in each point.
   Assert(indices.size() % dofs_per_cell == 0,
@@ -3358,10 +3337,10 @@ FEValuesBase<dim, spacedim>::get_function_values(
          ExcAccessToUninitializedField("update_values"));
 
   boost::container::small_vector<Number, 200> dof_values(dofs_per_cell);
-  for (unsigned int i = 0; i < dofs_per_cell; ++i)
-    dof_values[i] = internal::get_vector_element(fe_function, indices[i]);
+  auto view = make_array_view(dof_values.begin(), dof_values.end());
+  fe_function.extract_subvector_to(indices, view);
   internal::do_function_values(
-    make_array_view(dof_values.begin(), dof_values.end()),
+    view,
     this->finite_element_output.shape_values,
     *fe,
     this->finite_element_output.shape_function_to_row_table,
@@ -3373,15 +3352,14 @@ FEValuesBase<dim, spacedim>::get_function_values(
 
 
 template <int dim, int spacedim>
-template <class InputVector>
+template <typename Number>
 void
 FEValuesBase<dim, spacedim>::get_function_values(
-  const InputVector &                                      fe_function,
-  const ArrayView<const types::global_dof_index> &         indices,
-  ArrayView<std::vector<typename InputVector::value_type>> values,
+  const ReadVector<Number> &                      fe_function,
+  const ArrayView<const types::global_dof_index> &indices,
+  ArrayView<std::vector<Number>>                  values,
   const bool quadrature_points_fastest) const
 {
-  using Number = typename InputVector::value_type;
   Assert(this->update_flags & update_values,
          ExcAccessToUninitializedField("update_values"));
 
@@ -3390,11 +3368,11 @@ FEValuesBase<dim, spacedim>::get_function_values(
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
 
-  boost::container::small_vector<Number, 200> dof_values(indices.size());
-  for (unsigned int i = 0; i < indices.size(); ++i)
-    dof_values[i] = internal::get_vector_element(fe_function, indices[i]);
+  boost::container::small_vector<Number, 200> dof_values(dofs_per_cell);
+  auto view = make_array_view(dof_values.begin(), dof_values.end());
+  fe_function.extract_subvector_to(indices, view);
   internal::do_function_values(
-    make_array_view(dof_values.begin(), dof_values.end()),
+    view,
     this->finite_element_output.shape_values,
     *fe,
     this->finite_element_output.shape_function_to_row_table,

--- a/source/fe/fe_values.inst.in
+++ b/source/fe/fe_values.inst.in
@@ -145,6 +145,54 @@ for (S : REAL_AND_COMPLEX_SCALARS; deal_II_dimension : DIMENSIONS;
                              const ArrayView<const types::global_dof_index> &,
                              ArrayView<std::vector<S>>,
                              bool) const;
+
+    template void
+    FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
+      get_function_gradients<S>(
+        const ReadVector<S> &,
+        std::vector<
+          ProductType<S, dealii::Tensor<1, deal_II_space_dimension>>::type> &)
+        const;
+
+    template void
+    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
+      get_function_gradients<S>(
+        const ReadVector<S> &,
+        std::vector<
+          ProductType<S, dealii::Tensor<2, deal_II_space_dimension>>::type> &)
+        const;
+
+    template void
+    FEValuesViews::Tensor<2, deal_II_dimension, deal_II_space_dimension>::
+      get_function_gradients<S>(
+        const ReadVector<S> &,
+        std::vector<
+          ProductType<S, dealii::Tensor<3, deal_II_space_dimension>>::type> &)
+        const;
+
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_gradients<S>(
+        const ReadVector<S> &,
+        std::vector<dealii::Tensor<1, deal_II_space_dimension, S>> &) const;
+
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_gradients<S>(
+        const ReadVector<S> &,
+        const ArrayView<const types::global_dof_index> &,
+        std::vector<dealii::Tensor<1, deal_II_space_dimension, S>> &) const;
+
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_gradients<S>(
+        const ReadVector<S> &,
+        std::vector<std::vector<dealii::Tensor<1, deal_II_space_dimension, S>>>
+          &) const;
+
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_gradients<S>(
+        const ReadVector<S> &,
+        const ArrayView<const types::global_dof_index> &,
+        ArrayView<std::vector<dealii::Tensor<1, deal_II_space_dimension, S>>>,
+        bool) const;
 #  endif
   }
 
@@ -154,14 +202,6 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
      deal_II_space_dimension : SPACE_DIMENSIONS)
   {
 #  if deal_II_dimension <= deal_II_space_dimension
-    template void
-    FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
-      get_function_gradients<dealii::VEC>(
-        const dealii::VEC &,
-        std::vector<
-          ProductType<dealii::VEC::value_type,
-                      dealii::Tensor<1, deal_II_space_dimension>>::type> &)
-        const;
     template void
     FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
       get_function_hessians<dealii::VEC>(
@@ -185,14 +225,6 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
                       dealii::Tensor<3, deal_II_space_dimension>>::type> &)
         const;
 
-    template void
-    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
-      get_function_gradients<dealii::VEC>(
-        const dealii::VEC &,
-        std::vector<
-          ProductType<dealii::VEC::value_type,
-                      dealii::Tensor<2, deal_II_space_dimension>>::type> &)
-        const;
     template void
     FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
       get_function_symmetric_gradients<dealii::VEC>(
@@ -253,14 +285,6 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
         std::vector<
           ProductType<dealii::VEC::value_type,
                       dealii::Tensor<1, deal_II_space_dimension>>::type> &)
-        const;
-    template void
-    FEValuesViews::Tensor<2, deal_II_dimension, deal_II_space_dimension>::
-      get_function_gradients<dealii::VEC>(
-        const dealii::VEC &,
-        std::vector<
-          ProductType<dealii::VEC::value_type,
-                      dealii::Tensor<3, deal_II_space_dimension>>::type> &)
         const;
 #  endif
   }
@@ -386,32 +410,6 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
      deal_II_space_dimension : SPACE_DIMENSIONS)
   {
 #  if deal_II_dimension <= deal_II_space_dimension
-
-    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
-      get_function_gradients<VEC>(
-        const VEC &,
-        std::vector<dealii::Tensor<1, deal_II_space_dimension, VEC::value_type>>
-          &) const;
-    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
-      get_function_gradients<VEC>(
-        const VEC &,
-        const ArrayView<const types::global_dof_index> &,
-        std::vector<dealii::Tensor<1, deal_II_space_dimension, VEC::value_type>>
-          &) const;
-
-    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
-      get_function_gradients<VEC>(
-        const VEC &,
-        std::vector<std::vector<
-          dealii::Tensor<1, deal_II_space_dimension, VEC::value_type>>> &)
-        const;
-    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
-      get_function_gradients<VEC>(
-        const VEC &,
-        const ArrayView<const types::global_dof_index> &,
-        ArrayView<std::vector<
-          dealii::Tensor<1, deal_II_space_dimension, VEC::value_type>>>,
-        bool) const;
 
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
       get_function_hessians<VEC>(

--- a/source/fe/fe_values.inst.in
+++ b/source/fe/fe_values.inst.in
@@ -198,93 +198,82 @@ for (S : REAL_AND_COMPLEX_SCALARS; deal_II_dimension : DIMENSIONS;
 
 
 
-for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
+for (S : REAL_AND_COMPLEX_SCALARS; deal_II_dimension : DIMENSIONS;
      deal_II_space_dimension : SPACE_DIMENSIONS)
   {
 #  if deal_II_dimension <= deal_II_space_dimension
     template void
     FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
-      get_function_hessians<dealii::VEC>(
-        const dealii::VEC &,
+      get_function_hessians<S>(
+        const dealii::ReadVector<S> &,
         std::vector<
-          ProductType<dealii::VEC::value_type,
-                      dealii::Tensor<2, deal_II_space_dimension>>::type> &)
+          ProductType<S, dealii::Tensor<2, deal_II_space_dimension>>::type> &)
         const;
     template void
     FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
-      get_function_laplacians<dealii::VEC>(
-        const dealii::VEC &,
-        std::vector<ProductType<dealii::VEC::value_type, double>::type> &)
+      get_function_laplacians<S>(const dealii::ReadVector<S> &,
+                                 std::vector<ProductType<S, double>::type> &)
         const;
     template void
     FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
-      get_function_third_derivatives<dealii::VEC>(
-        const dealii::VEC &,
+      get_function_third_derivatives<S>(
+        const dealii::ReadVector<S> &,
         std::vector<
-          ProductType<dealii::VEC::value_type,
-                      dealii::Tensor<3, deal_II_space_dimension>>::type> &)
+          ProductType<S, dealii::Tensor<3, deal_II_space_dimension>>::type> &)
         const;
 
     template void
     FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
-      get_function_symmetric_gradients<dealii::VEC>(
-        const dealii::VEC &,
+      get_function_symmetric_gradients<S>(
+        const dealii::ReadVector<S> &,
         std::vector<ProductType<
-          dealii::VEC::value_type,
+          S,
           dealii::SymmetricTensor<2, deal_II_space_dimension>>::type> &) const;
+    template void FEValuesViews::
+      Vector<deal_II_dimension, deal_II_space_dimension>::get_function_curls<S>(
+        const dealii::ReadVector<S> &,
+        std::vector<ProductType<S, curl_type>::type> &) const;
     template void
     FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
-      get_function_curls<dealii::VEC>(
-        const dealii::VEC &,
-        std::vector<ProductType<dealii::VEC::value_type, curl_type>::type> &)
+      get_function_divergences<S>(
+        const dealii::ReadVector<S> &,
+        std::vector<ProductType<S, divergence_type>::type> &) const;
+    template void
+    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
+      get_function_hessians<S>(
+        const dealii::ReadVector<S> &,
+        std::vector<
+          ProductType<S, dealii::Tensor<3, deal_II_space_dimension>>::type> &)
         const;
     template void
     FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
-      get_function_divergences<dealii::VEC>(
-        const dealii::VEC &,
-        std::vector<ProductType<dealii::VEC::value_type, divergence_type>::type>
-          &) const;
-    template void
-    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
-      get_function_hessians<dealii::VEC>(
-        const dealii::VEC &,
+      get_function_laplacians<S>(
+        const dealii::ReadVector<S> &,
         std::vector<
-          ProductType<dealii::VEC::value_type,
-                      dealii::Tensor<3, deal_II_space_dimension>>::type> &)
+          ProductType<S, dealii::Tensor<1, deal_II_space_dimension>>::type> &)
         const;
     template void
     FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
-      get_function_laplacians<dealii::VEC>(
-        const dealii::VEC &,
+      get_function_third_derivatives<S>(
+        const dealii::ReadVector<S> &,
         std::vector<
-          ProductType<dealii::VEC::value_type,
-                      dealii::Tensor<1, deal_II_space_dimension>>::type> &)
-        const;
-    template void
-    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
-      get_function_third_derivatives<dealii::VEC>(
-        const dealii::VEC &,
-        std::vector<
-          ProductType<dealii::VEC::value_type,
-                      dealii::Tensor<4, deal_II_space_dimension>>::type> &)
+          ProductType<S, dealii::Tensor<4, deal_II_space_dimension>>::type> &)
         const;
 
     template void FEValuesViews::
       SymmetricTensor<2, deal_II_dimension, deal_II_space_dimension>::
-        get_function_divergences<dealii::VEC>(
-          const dealii::VEC &,
+        get_function_divergences<S>(
+          const dealii::ReadVector<S> &,
           std::vector<
-            ProductType<dealii::VEC::value_type,
-                        dealii::Tensor<1, deal_II_space_dimension>>::type> &)
+            ProductType<S, dealii::Tensor<1, deal_II_space_dimension>>::type> &)
           const;
 
     template void
     FEValuesViews::Tensor<2, deal_II_dimension, deal_II_space_dimension>::
-      get_function_divergences<dealii::VEC>(
-        const dealii::VEC &,
+      get_function_divergences<S>(
+        const dealii::ReadVector<S> &,
         std::vector<
-          ProductType<dealii::VEC::value_type,
-                      dealii::Tensor<1, deal_II_space_dimension>>::type> &)
+          ProductType<S, dealii::Tensor<1, deal_II_space_dimension>>::type> &)
         const;
 #  endif
   }
@@ -406,88 +395,80 @@ for (VEC : GENERAL_CONTAINER_TYPES; Number : ALL_SCALAR_TYPES;
   }
 
 
-for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
+for (S : REAL_AND_COMPLEX_SCALARS; deal_II_dimension : DIMENSIONS;
      deal_II_space_dimension : SPACE_DIMENSIONS)
   {
 #  if deal_II_dimension <= deal_II_space_dimension
 
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
-      get_function_hessians<VEC>(
-        const VEC &,
-        std::vector<dealii::Tensor<2, deal_II_space_dimension, VEC::value_type>>
-          &) const;
+      get_function_hessians<S>(
+        const ReadVector<S> &,
+        std::vector<dealii::Tensor<2, deal_II_space_dimension, S>> &) const;
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
-      get_function_hessians<VEC>(
-        const VEC &,
+      get_function_hessians<S>(
+        const ReadVector<S> &,
         const ArrayView<const types::global_dof_index> &,
-        std::vector<dealii::Tensor<2, deal_II_space_dimension, VEC::value_type>>
-          &) const;
+        std::vector<dealii::Tensor<2, deal_II_space_dimension, S>> &) const;
 
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
-      get_function_hessians<VEC>(
-        const VEC &,
-        std::vector<std::vector<
-          dealii::Tensor<2, deal_II_space_dimension, VEC::value_type>>> &,
+      get_function_hessians<S>(
+        const ReadVector<S> &,
+        std::vector<std::vector<dealii::Tensor<2, deal_II_space_dimension, S>>>
+          &,
         bool) const;
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
-      get_function_hessians<VEC>(
-        const VEC &,
+      get_function_hessians<S>(
+        const ReadVector<S> &,
         const ArrayView<const types::global_dof_index> &,
-        ArrayView<std::vector<
-          dealii::Tensor<2, deal_II_space_dimension, VEC::value_type>>>,
+        ArrayView<std::vector<dealii::Tensor<2, deal_II_space_dimension, S>>>,
         bool) const;
 
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
-      get_function_laplacians<VEC>(const VEC &, std::vector<VEC::value_type> &)
-        const;
+      get_function_laplacians<S>(const ReadVector<S> &, std::vector<S> &) const;
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
-      get_function_laplacians<VEC>(
-        const VEC &,
+      get_function_laplacians<S>(
+        const ReadVector<S> &,
         const ArrayView<const types::global_dof_index> &,
-        std::vector<VEC::value_type> &) const;
+        std::vector<S> &) const;
 
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
-      get_function_laplacians<VEC>(const VEC &,
-                                   std::vector<Vector<VEC::value_type>> &)
-        const;
+      get_function_laplacians<S>(const ReadVector<S> &,
+                                 std::vector<Vector<S>> &) const;
 
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
-      get_function_laplacians<VEC>(
-        const VEC &,
+      get_function_laplacians<S>(
+        const ReadVector<S> &,
         const ArrayView<const types::global_dof_index> &,
-        std::vector<Vector<VEC::value_type>> &) const;
+        std::vector<Vector<S>> &) const;
 
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
-      get_function_laplacians<VEC>(
-        const VEC &,
+      get_function_laplacians<S>(
+        const ReadVector<S> &,
         const ArrayView<const types::global_dof_index> &,
-        std::vector<std::vector<VEC::value_type>> &,
+        std::vector<std::vector<S>> &,
         bool) const;
 
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
-      get_function_third_derivatives<VEC>(
-        const VEC &,
-        std::vector<dealii::Tensor<3, deal_II_space_dimension, VEC::value_type>>
-          &) const;
+      get_function_third_derivatives<S>(
+        const ReadVector<S> &,
+        std::vector<dealii::Tensor<3, deal_II_space_dimension, S>> &) const;
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
-      get_function_third_derivatives<VEC>(
-        const VEC &,
+      get_function_third_derivatives<S>(
+        const ReadVector<S> &,
         const ArrayView<const types::global_dof_index> &,
-        std::vector<dealii::Tensor<3, deal_II_space_dimension, VEC::value_type>>
-          &) const;
+        std::vector<dealii::Tensor<3, deal_II_space_dimension, S>> &) const;
 
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
-      get_function_third_derivatives<VEC>(
-        const VEC &,
-        std::vector<std::vector<
-          dealii::Tensor<3, deal_II_space_dimension, VEC::value_type>>> &,
+      get_function_third_derivatives<S>(
+        const ReadVector<S> &,
+        std::vector<std::vector<dealii::Tensor<3, deal_II_space_dimension, S>>>
+          &,
         bool) const;
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
-      get_function_third_derivatives<VEC>(
-        const VEC &,
+      get_function_third_derivatives<S>(
+        const ReadVector<S> &,
         const ArrayView<const types::global_dof_index> &,
-        ArrayView<std::vector<
-          dealii::Tensor<3, deal_II_space_dimension, VEC::value_type>>>,
+        ArrayView<std::vector<dealii::Tensor<3, deal_II_space_dimension, S>>>,
         bool) const;
 
 #  endif

--- a/source/fe/fe_values.inst.in
+++ b/source/fe/fe_values.inst.in
@@ -88,6 +88,65 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
                                       deal_II_space_dimension>> &);
 #  endif
   }
+for (S : REAL_AND_COMPLEX_SCALARS; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
+#  if deal_II_dimension <= deal_II_space_dimension
+    template void
+    FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
+      get_function_values<S>(const dealii::ReadVector<S> &,
+                             std::vector<ProductType<S, value_type>::type> &)
+        const;
+
+    template void
+    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
+      get_function_values<S>(
+        const dealii::ReadVector<S> &,
+        std::vector<
+          ProductType<S, dealii::Tensor<1, deal_II_space_dimension>>::type> &)
+        const;
+
+    template void FEValuesViews::SymmetricTensor<2,
+                                                 deal_II_dimension,
+                                                 deal_II_space_dimension>::
+      get_function_values<S>(
+        const dealii::ReadVector<S> &,
+        std::vector<ProductType<
+          S,
+          dealii::SymmetricTensor<2, deal_II_space_dimension>>::type> &) const;
+
+    template void
+    FEValuesViews::Tensor<2, deal_II_dimension, deal_II_space_dimension>::
+      get_function_values<S>(
+        const dealii::ReadVector<S> &,
+        std::vector<
+          ProductType<S, dealii::Tensor<2, deal_II_space_dimension>>::type> &)
+        const;
+
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_values<S>(const ReadVector<S> &, std::vector<S> &) const;
+
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_values<S>(const ReadVector<S> &,
+                             const ArrayView<const types::global_dof_index> &,
+                             std::vector<S> &) const;
+
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_values<S>(const ReadVector<S> &, std::vector<Vector<S>> &)
+        const;
+
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_values<S>(const ReadVector<S> &,
+                             const ArrayView<const types::global_dof_index> &,
+                             std::vector<Vector<S>> &) const;
+
+    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
+      get_function_values<S>(const ReadVector<S> &,
+                             const ArrayView<const types::global_dof_index> &,
+                             ArrayView<std::vector<S>>,
+                             bool) const;
+#  endif
+  }
 
 
 
@@ -95,12 +154,6 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
      deal_II_space_dimension : SPACE_DIMENSIONS)
   {
 #  if deal_II_dimension <= deal_II_space_dimension
-    template void
-    FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
-      get_function_values<dealii::VEC>(
-        const dealii::VEC &,
-        std::vector<ProductType<dealii::VEC::value_type, value_type>::type> &)
-        const;
     template void
     FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
       get_function_gradients<dealii::VEC>(
@@ -132,14 +185,6 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
                       dealii::Tensor<3, deal_II_space_dimension>>::type> &)
         const;
 
-    template void
-    FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
-      get_function_values<dealii::VEC>(
-        const dealii::VEC &,
-        std::vector<
-          ProductType<dealii::VEC::value_type,
-                      dealii::Tensor<1, deal_II_space_dimension>>::type> &)
-        const;
     template void
     FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
       get_function_gradients<dealii::VEC>(
@@ -192,14 +237,6 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
                       dealii::Tensor<4, deal_II_space_dimension>>::type> &)
         const;
 
-    template void FEValuesViews::SymmetricTensor<2,
-                                                 deal_II_dimension,
-                                                 deal_II_space_dimension>::
-      get_function_values<dealii::VEC>(
-        const dealii::VEC &,
-        std::vector<ProductType<
-          dealii::VEC::value_type,
-          dealii::SymmetricTensor<2, deal_II_space_dimension>>::type> &) const;
     template void FEValuesViews::
       SymmetricTensor<2, deal_II_dimension, deal_II_space_dimension>::
         get_function_divergences<dealii::VEC>(
@@ -209,14 +246,6 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
                         dealii::Tensor<1, deal_II_space_dimension>>::type> &)
           const;
 
-    template void
-    FEValuesViews::Tensor<2, deal_II_dimension, deal_II_space_dimension>::
-      get_function_values<dealii::VEC>(
-        const dealii::VEC &,
-        std::vector<
-          ProductType<dealii::VEC::value_type,
-                      dealii::Tensor<2, deal_II_space_dimension>>::type> &)
-        const;
     template void
     FEValuesViews::Tensor<2, deal_II_dimension, deal_II_space_dimension>::
       get_function_divergences<dealii::VEC>(
@@ -357,29 +386,6 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
      deal_II_space_dimension : SPACE_DIMENSIONS)
   {
 #  if deal_II_dimension <= deal_II_space_dimension
-
-    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
-      get_function_values<VEC>(const VEC &, std::vector<VEC::value_type> &)
-        const;
-    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
-      get_function_values<VEC>(const VEC &,
-                               const ArrayView<const types::global_dof_index> &,
-                               std::vector<VEC::value_type> &) const;
-
-    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
-      get_function_values<VEC>(const VEC &,
-                               std::vector<Vector<VEC::value_type>> &) const;
-
-    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
-      get_function_values<VEC>(const VEC &,
-                               const ArrayView<const types::global_dof_index> &,
-                               std::vector<Vector<VEC::value_type>> &) const;
-
-    template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
-      get_function_values<VEC>(const VEC &,
-                               const ArrayView<const types::global_dof_index> &,
-                               ArrayView<std::vector<VEC::value_type>>,
-                               bool) const;
 
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
       get_function_gradients<VEC>(

--- a/source/lac/trilinos_epetra_vector.cc
+++ b/source/lac/trilinos_epetra_vector.cc
@@ -99,6 +99,26 @@ namespace LinearAlgebra
 
 
 
+    void
+    Vector::extract_subvector_to(
+      const ArrayView<const types::global_dof_index> &indices,
+      ArrayView<double> &                             elements) const
+    {
+      AssertDimension(indices.size(), elements.size());
+      const auto &vector = trilinos_vector();
+      const auto &map    = vector.Map();
+
+      for (unsigned int i = 0; i < indices.size(); ++i)
+        {
+          AssertIndexRange(indices[i], size());
+          const auto trilinos_i =
+            map.LID(static_cast<TrilinosWrappers::types::int_type>(indices[i]));
+          elements[i] = vector[0][trilinos_i];
+        }
+    }
+
+
+
     Vector &
     Vector::operator=(const Vector &V)
     {

--- a/source/numerics/error_estimator.inst.in
+++ b/source/numerics/error_estimator.inst.in
@@ -22,158 +22,142 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
 #endif
   }
 
-for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
+for (S : REAL_AND_COMPLEX_SCALARS; deal_II_dimension : DIMENSIONS;
      deal_II_space_dimension : SPACE_DIMENSIONS)
   {
 #if deal_II_dimension != 1 && deal_II_dimension <= deal_II_space_dimension
 
     template void
     KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
-      VEC>(
-      const Mapping<deal_II_dimension, deal_II_space_dimension> &,
-      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-      const Quadrature<deal_II_dimension - 1> &,
-      const std::map<types::boundary_id,
-                     const Function<deal_II_space_dimension, VEC::value_type> *>
-        &,
-      const VEC &,
-      Vector<float> &,
-      const ComponentMask &,
-      const Function<deal_II_space_dimension> *,
-      const unsigned int,
-      const types::subdomain_id,
-      const types::material_id,
-      const KellyErrorEstimator<deal_II_dimension,
-                                deal_II_space_dimension>::Strategy);
+      S>(const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+         const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+         const Quadrature<deal_II_dimension - 1> &,
+         const std::map<types::boundary_id,
+                        const Function<deal_II_space_dimension, S> *> &,
+         const ReadVector<S> &,
+         Vector<float> &,
+         const ComponentMask &,
+         const Function<deal_II_space_dimension> *,
+         const unsigned int,
+         const types::subdomain_id,
+         const types::material_id,
+         const KellyErrorEstimator<deal_II_dimension,
+                                   deal_II_space_dimension>::Strategy);
 
     template void
     KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
-      VEC>(
-      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-      const Quadrature<deal_II_dimension - 1> &,
-      const std::map<types::boundary_id,
-                     const Function<deal_II_space_dimension, VEC::value_type> *>
-        &,
-      const VEC &,
-      Vector<float> &,
-      const ComponentMask &,
-      const Function<deal_II_space_dimension> *,
-      const unsigned int,
-      const types::subdomain_id,
-      const types::material_id,
-      const KellyErrorEstimator<deal_II_dimension,
-                                deal_II_space_dimension>::Strategy);
+      S>(const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+         const Quadrature<deal_II_dimension - 1> &,
+         const std::map<types::boundary_id,
+                        const Function<deal_II_space_dimension, S> *> &,
+         const ReadVector<S> &,
+         Vector<float> &,
+         const ComponentMask &,
+         const Function<deal_II_space_dimension> *,
+         const unsigned int,
+         const types::subdomain_id,
+         const types::material_id,
+         const KellyErrorEstimator<deal_II_dimension,
+                                   deal_II_space_dimension>::Strategy);
 
     template void
     KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
-      VEC>(
-      const Mapping<deal_II_dimension, deal_II_space_dimension> &,
-      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-      const Quadrature<deal_II_dimension - 1> &,
-      const std::map<types::boundary_id,
-                     const Function<deal_II_space_dimension, VEC::value_type> *>
-        &,
-      const std::vector<const VEC *> &,
-      std::vector<Vector<float> *> &,
-      const ComponentMask &,
-      const Function<deal_II_space_dimension> *,
-      const unsigned int,
-      const types::subdomain_id,
-      const types::material_id,
-      const KellyErrorEstimator<deal_II_dimension,
-                                deal_II_space_dimension>::Strategy);
+      S>(const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+         const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+         const Quadrature<deal_II_dimension - 1> &,
+         const std::map<types::boundary_id,
+                        const Function<deal_II_space_dimension, S> *> &,
+         const std::vector<const ReadVector<S> *> &,
+         std::vector<Vector<float> *> &,
+         const ComponentMask &,
+         const Function<deal_II_space_dimension> *,
+         const unsigned int,
+         const types::subdomain_id,
+         const types::material_id,
+         const KellyErrorEstimator<deal_II_dimension,
+                                   deal_II_space_dimension>::Strategy);
 
     template void
     KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
-      VEC>(
-      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-      const Quadrature<deal_II_dimension - 1> &,
-      const std::map<types::boundary_id,
-                     const Function<deal_II_space_dimension, VEC::value_type> *>
-        &,
-      const std::vector<const VEC *> &,
-      std::vector<Vector<float> *> &,
-      const ComponentMask &,
-      const Function<deal_II_space_dimension> *,
-      const unsigned int,
-      const types::subdomain_id,
-      const types::material_id,
-      const KellyErrorEstimator<deal_II_dimension,
-                                deal_II_space_dimension>::Strategy);
+      S>(const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+         const Quadrature<deal_II_dimension - 1> &,
+         const std::map<types::boundary_id,
+                        const Function<deal_II_space_dimension, S> *> &,
+         const std::vector<const ReadVector<S> *> &,
+         std::vector<Vector<float> *> &,
+         const ComponentMask &,
+         const Function<deal_II_space_dimension> *,
+         const unsigned int,
+         const types::subdomain_id,
+         const types::material_id,
+         const KellyErrorEstimator<deal_II_dimension,
+                                   deal_II_space_dimension>::Strategy);
 
     template void
     KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
-      VEC>(
-      const Mapping<deal_II_dimension, deal_II_space_dimension> &,
-      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-      const hp::QCollection<deal_II_dimension - 1> &,
-      const std::map<types::boundary_id,
-                     const Function<deal_II_space_dimension, VEC::value_type> *>
-        &,
-      const VEC &,
-      Vector<float> &,
-      const ComponentMask &,
-      const Function<deal_II_space_dimension> *,
-      const unsigned int,
-      const types::subdomain_id,
-      const types::material_id,
-      const KellyErrorEstimator<deal_II_dimension,
-                                deal_II_space_dimension>::Strategy);
+      S>(const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+         const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+         const hp::QCollection<deal_II_dimension - 1> &,
+         const std::map<types::boundary_id,
+                        const Function<deal_II_space_dimension, S> *> &,
+         const ReadVector<S> &,
+         Vector<float> &,
+         const ComponentMask &,
+         const Function<deal_II_space_dimension> *,
+         const unsigned int,
+         const types::subdomain_id,
+         const types::material_id,
+         const KellyErrorEstimator<deal_II_dimension,
+                                   deal_II_space_dimension>::Strategy);
 
     template void
     KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
-      VEC>(
-      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-      const hp::QCollection<deal_II_dimension - 1> &,
-      const std::map<types::boundary_id,
-                     const Function<deal_II_space_dimension, VEC::value_type> *>
-        &,
-      const VEC &,
-      Vector<float> &,
-      const ComponentMask &,
-      const Function<deal_II_space_dimension> *,
-      const unsigned int,
-      const types::subdomain_id,
-      const types::material_id,
-      const KellyErrorEstimator<deal_II_dimension,
-                                deal_II_space_dimension>::Strategy);
+      S>(const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+         const hp::QCollection<deal_II_dimension - 1> &,
+         const std::map<types::boundary_id,
+                        const Function<deal_II_space_dimension, S> *> &,
+         const ReadVector<S> &,
+         Vector<float> &,
+         const ComponentMask &,
+         const Function<deal_II_space_dimension> *,
+         const unsigned int,
+         const types::subdomain_id,
+         const types::material_id,
+         const KellyErrorEstimator<deal_II_dimension,
+                                   deal_II_space_dimension>::Strategy);
 
     template void
     KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
-      VEC>(
-      const Mapping<deal_II_dimension, deal_II_space_dimension> &,
-      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-      const hp::QCollection<deal_II_dimension - 1> &,
-      const std::map<types::boundary_id,
-                     const Function<deal_II_space_dimension, VEC::value_type> *>
-        &,
-      const std::vector<const VEC *> &,
-      std::vector<Vector<float> *> &,
-      const ComponentMask &,
-      const Function<deal_II_space_dimension> *,
-      const unsigned int,
-      const types::subdomain_id,
-      const types::material_id,
-      const KellyErrorEstimator<deal_II_dimension,
-                                deal_II_space_dimension>::Strategy);
+      S>(const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+         const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+         const hp::QCollection<deal_II_dimension - 1> &,
+         const std::map<types::boundary_id,
+                        const Function<deal_II_space_dimension, S> *> &,
+         const std::vector<const ReadVector<S> *> &,
+         std::vector<Vector<float> *> &,
+         const ComponentMask &,
+         const Function<deal_II_space_dimension> *,
+         const unsigned int,
+         const types::subdomain_id,
+         const types::material_id,
+         const KellyErrorEstimator<deal_II_dimension,
+                                   deal_II_space_dimension>::Strategy);
 
     template void
     KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
-      VEC>(
-      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-      const hp::QCollection<deal_II_dimension - 1> &,
-      const std::map<types::boundary_id,
-                     const Function<deal_II_space_dimension, VEC::value_type> *>
-        &,
-      const std::vector<const VEC *> &,
-      std::vector<Vector<float> *> &,
-      const ComponentMask &,
-      const Function<deal_II_space_dimension> *,
-      const unsigned int,
-      const types::subdomain_id,
-      const types::material_id,
-      const KellyErrorEstimator<deal_II_dimension,
-                                deal_II_space_dimension>::Strategy);
+      S>(const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+         const hp::QCollection<deal_II_dimension - 1> &,
+         const std::map<types::boundary_id,
+                        const Function<deal_II_space_dimension, S> *> &,
+         const std::vector<const ReadVector<S> *> &,
+         std::vector<Vector<float> *> &,
+         const ComponentMask &,
+         const Function<deal_II_space_dimension> *,
+         const unsigned int,
+         const types::subdomain_id,
+         const types::material_id,
+         const KellyErrorEstimator<deal_II_dimension,
+                                   deal_II_space_dimension>::Strategy);
 
 #endif
   }

--- a/source/numerics/error_estimator_1d.cc
+++ b/source/numerics/error_estimator_1d.cc
@@ -56,16 +56,15 @@ DEAL_II_NAMESPACE_OPEN
 
 
 template <int spacedim>
-template <typename InputVector>
+template <typename Number>
 void
 KellyErrorEstimator<1, spacedim>::estimate(
   const Mapping<1, spacedim> &   mapping,
   const DoFHandler<1, spacedim> &dof_handler,
   const Quadrature<0> &          quadrature,
-  const std::map<types::boundary_id,
-                 const Function<spacedim, typename InputVector::value_type> *>
+  const std::map<types::boundary_id, const Function<spacedim, Number> *>
     &                       neumann_bc,
-  const InputVector &       solution,
+  const ReadVector<Number> &solution,
   Vector<float> &           error,
   const ComponentMask &     component_mask,
   const Function<spacedim> *coefficients,
@@ -75,8 +74,8 @@ KellyErrorEstimator<1, spacedim>::estimate(
   const Strategy            strategy)
 {
   // just pass on to the other function
-  const std::vector<const InputVector *> solutions(1, &solution);
-  std::vector<Vector<float> *>           errors(1, &error);
+  const std::vector<const ReadVector<Number> *> solutions(1, &solution);
+  std::vector<Vector<float> *>                  errors(1, &error);
   estimate(mapping,
            dof_handler,
            quadrature,
@@ -94,15 +93,14 @@ KellyErrorEstimator<1, spacedim>::estimate(
 
 
 template <int spacedim>
-template <typename InputVector>
+template <typename Number>
 void
 KellyErrorEstimator<1, spacedim>::estimate(
   const DoFHandler<1, spacedim> &dof_handler,
   const Quadrature<0> &          quadrature,
-  const std::map<types::boundary_id,
-                 const Function<spacedim, typename InputVector::value_type> *>
+  const std::map<types::boundary_id, const Function<spacedim, Number> *>
     &                       neumann_bc,
-  const InputVector &       solution,
+  const ReadVector<Number> &solution,
   Vector<float> &           error,
   const ComponentMask &     component_mask,
   const Function<spacedim> *coefficients,
@@ -129,22 +127,21 @@ KellyErrorEstimator<1, spacedim>::estimate(
 
 
 template <int spacedim>
-template <typename InputVector>
+template <typename Number>
 void
 KellyErrorEstimator<1, spacedim>::estimate(
   const DoFHandler<1, spacedim> &dof_handler,
   const Quadrature<0> &          quadrature,
-  const std::map<types::boundary_id,
-                 const Function<spacedim, typename InputVector::value_type> *>
-    &                                     neumann_bc,
-  const std::vector<const InputVector *> &solutions,
-  std::vector<Vector<float> *> &          errors,
-  const ComponentMask &                   component_mask,
-  const Function<spacedim> *              coefficients,
-  const unsigned int                      n_threads,
-  const types::subdomain_id               subdomain_id,
-  const types::material_id                material_id,
-  const Strategy                          strategy)
+  const std::map<types::boundary_id, const Function<spacedim, Number> *>
+    &                                            neumann_bc,
+  const std::vector<const ReadVector<Number> *> &solutions,
+  std::vector<Vector<float> *> &                 errors,
+  const ComponentMask &                          component_mask,
+  const Function<spacedim> *                     coefficients,
+  const unsigned int                             n_threads,
+  const types::subdomain_id                      subdomain_id,
+  const types::material_id                       material_id,
+  const Strategy                                 strategy)
 {
   const auto reference_cell = ReferenceCells::Line;
   estimate(reference_cell.template get_default_linear_mapping<1, spacedim>(),
@@ -164,16 +161,15 @@ KellyErrorEstimator<1, spacedim>::estimate(
 
 
 template <int spacedim>
-template <typename InputVector>
+template <typename Number>
 void
 KellyErrorEstimator<1, spacedim>::estimate(
   const Mapping<1, spacedim> &   mapping,
   const DoFHandler<1, spacedim> &dof_handler,
   const hp::QCollection<0> &     quadrature,
-  const std::map<types::boundary_id,
-                 const Function<spacedim, typename InputVector::value_type> *>
+  const std::map<types::boundary_id, const Function<spacedim, Number> *>
     &                       neumann_bc,
-  const InputVector &       solution,
+  const ReadVector<Number> &solution,
   Vector<float> &           error,
   const ComponentMask &     component_mask,
   const Function<spacedim> *coefficients,
@@ -183,8 +179,8 @@ KellyErrorEstimator<1, spacedim>::estimate(
   const Strategy            strategy)
 {
   // just pass on to the other function
-  const std::vector<const InputVector *> solutions(1, &solution);
-  std::vector<Vector<float> *>           errors(1, &error);
+  const std::vector<const ReadVector<Number> *> solutions(1, &solution);
+  std::vector<Vector<float> *>                  errors(1, &error);
   estimate(mapping,
            dof_handler,
            quadrature,
@@ -202,15 +198,14 @@ KellyErrorEstimator<1, spacedim>::estimate(
 
 
 template <int spacedim>
-template <typename InputVector>
+template <typename Number>
 void
 KellyErrorEstimator<1, spacedim>::estimate(
   const DoFHandler<1, spacedim> &dof_handler,
   const hp::QCollection<0> &     quadrature,
-  const std::map<types::boundary_id,
-                 const Function<spacedim, typename InputVector::value_type> *>
+  const std::map<types::boundary_id, const Function<spacedim, Number> *>
     &                       neumann_bc,
-  const InputVector &       solution,
+  const ReadVector<Number> &solution,
   Vector<float> &           error,
   const ComponentMask &     component_mask,
   const Function<spacedim> *coefficients,
@@ -237,22 +232,21 @@ KellyErrorEstimator<1, spacedim>::estimate(
 
 
 template <int spacedim>
-template <typename InputVector>
+template <typename Number>
 void
 KellyErrorEstimator<1, spacedim>::estimate(
   const DoFHandler<1, spacedim> &dof_handler,
   const hp::QCollection<0> &     quadrature,
-  const std::map<types::boundary_id,
-                 const Function<spacedim, typename InputVector::value_type> *>
-    &                                     neumann_bc,
-  const std::vector<const InputVector *> &solutions,
-  std::vector<Vector<float> *> &          errors,
-  const ComponentMask &                   component_mask,
-  const Function<spacedim> *              coefficients,
-  const unsigned int                      n_threads,
-  const types::subdomain_id               subdomain_id,
-  const types::material_id                material_id,
-  const Strategy                          strategy)
+  const std::map<types::boundary_id, const Function<spacedim, Number> *>
+    &                                            neumann_bc,
+  const std::vector<const ReadVector<Number> *> &solutions,
+  std::vector<Vector<float> *> &                 errors,
+  const ComponentMask &                          component_mask,
+  const Function<spacedim> *                     coefficients,
+  const unsigned int                             n_threads,
+  const types::subdomain_id                      subdomain_id,
+  const types::material_id                       material_id,
+  const Strategy                                 strategy)
 {
   const auto reference_cell = ReferenceCells::Line;
   estimate(reference_cell.template get_default_linear_mapping<1, spacedim>(),
@@ -272,26 +266,25 @@ KellyErrorEstimator<1, spacedim>::estimate(
 
 
 template <int spacedim>
-template <typename InputVector>
+template <typename Number>
 void
 KellyErrorEstimator<1, spacedim>::estimate(
   const Mapping<1, spacedim> &   mapping,
   const DoFHandler<1, spacedim> &dof_handler,
   const hp::QCollection<0> &,
-  const std::map<types::boundary_id,
-                 const Function<spacedim, typename InputVector::value_type> *>
-    &                                     neumann_bc,
-  const std::vector<const InputVector *> &solutions,
-  std::vector<Vector<float> *> &          errors,
-  const ComponentMask &                   component_mask,
-  const Function<spacedim> *              coefficient,
+  const std::map<types::boundary_id, const Function<spacedim, Number> *>
+    &                                            neumann_bc,
+  const std::vector<const ReadVector<Number> *> &solutions,
+  std::vector<Vector<float> *> &                 errors,
+  const ComponentMask &                          component_mask,
+  const Function<spacedim> *                     coefficient,
   const unsigned int,
   const types::subdomain_id subdomain_id_,
   const types::material_id  material_id,
   const Strategy            strategy)
 {
   AssertThrow(strategy == cell_diameter_over_24, ExcNotImplemented());
-  using number                     = typename InputVector::value_type;
+  using number                     = Number;
   types::subdomain_id subdomain_id = numbers::invalid_subdomain_id;
   if (const auto *triangulation = dynamic_cast<
         const parallel::DistributedTriangulationBase<1, spacedim> *>(
@@ -463,7 +456,7 @@ KellyErrorEstimator<1, spacedim>::estimate(
               {
                 if (n_components == 1)
                   {
-                    const typename InputVector::value_type v =
+                    const Number v =
                       neumann_bc.find(n)->second->value(cell->vertex(n));
 
                     for (unsigned int s = 0; s < n_solution_vectors; ++s)
@@ -471,7 +464,7 @@ KellyErrorEstimator<1, spacedim>::estimate(
                   }
                 else
                   {
-                    Vector<typename InputVector::value_type> v(n_components);
+                    Vector<Number> v(n_components);
                     neumann_bc.find(n)->second->vector_value(cell->vertex(n),
                                                              v);
 
@@ -530,23 +523,22 @@ KellyErrorEstimator<1, spacedim>::estimate(
 
 
 template <int spacedim>
-template <typename InputVector>
+template <typename Number>
 void
 KellyErrorEstimator<1, spacedim>::estimate(
   const Mapping<1, spacedim> &   mapping,
   const DoFHandler<1, spacedim> &dof_handler,
   const Quadrature<0> &          quadrature,
-  const std::map<types::boundary_id,
-                 const Function<spacedim, typename InputVector::value_type> *>
-    &                                     neumann_bc,
-  const std::vector<const InputVector *> &solutions,
-  std::vector<Vector<float> *> &          errors,
-  const ComponentMask &                   component_mask,
-  const Function<spacedim> *              coefficients,
-  const unsigned int                      n_threads,
-  const types::subdomain_id               subdomain_id,
-  const types::material_id                material_id,
-  const Strategy                          strategy)
+  const std::map<types::boundary_id, const Function<spacedim, Number> *>
+    &                                            neumann_bc,
+  const std::vector<const ReadVector<Number> *> &solutions,
+  std::vector<Vector<float> *> &                 errors,
+  const ComponentMask &                          component_mask,
+  const Function<spacedim> *                     coefficients,
+  const unsigned int                             n_threads,
+  const types::subdomain_id                      subdomain_id,
+  const types::material_id                       material_id,
+  const Strategy                                 strategy)
 {
   const hp::QCollection<0> quadrature_collection(quadrature);
   estimate(mapping,

--- a/source/numerics/error_estimator_1d.inst.in
+++ b/source/numerics/error_estimator_1d.inst.in
@@ -14,150 +14,134 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
+for (S : REAL_AND_COMPLEX_SCALARS; deal_II_dimension : DIMENSIONS;
      deal_II_space_dimension : SPACE_DIMENSIONS)
   {
 #if deal_II_dimension == 1 && deal_II_dimension <= deal_II_space_dimension
 
     template void
     KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
-      VEC>(
-      const Mapping<deal_II_dimension, deal_II_space_dimension> &,
-      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-      const Quadrature<deal_II_dimension - 1> &,
-      const std::map<types::boundary_id,
-                     const Function<deal_II_space_dimension, VEC::value_type> *>
-        &,
-      const VEC &,
-      Vector<float> &,
-      const ComponentMask &,
-      const Function<deal_II_space_dimension> *,
-      const unsigned int,
-      const types::subdomain_id,
-      const types::material_id,
-      const Strategy);
+      S>(const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+         const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+         const Quadrature<deal_II_dimension - 1> &,
+         const std::map<types::boundary_id,
+                        const Function<deal_II_space_dimension, S> *> &,
+         const ReadVector<S> &,
+         Vector<float> &,
+         const ComponentMask &,
+         const Function<deal_II_space_dimension> *,
+         const unsigned int,
+         const types::subdomain_id,
+         const types::material_id,
+         const Strategy);
 
     template void
     KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
-      VEC>(
-      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-      const Quadrature<deal_II_dimension - 1> &,
-      const std::map<types::boundary_id,
-                     const Function<deal_II_space_dimension, VEC::value_type> *>
-        &,
-      const VEC &,
-      Vector<float> &,
-      const ComponentMask &,
-      const Function<deal_II_space_dimension> *,
-      const unsigned int,
-      const types::subdomain_id,
-      const types::material_id,
-      const Strategy);
+      S>(const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+         const Quadrature<deal_II_dimension - 1> &,
+         const std::map<types::boundary_id,
+                        const Function<deal_II_space_dimension, S> *> &,
+         const ReadVector<S> &,
+         Vector<float> &,
+         const ComponentMask &,
+         const Function<deal_II_space_dimension> *,
+         const unsigned int,
+         const types::subdomain_id,
+         const types::material_id,
+         const Strategy);
 
     template void
     KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
-      VEC>(
-      const Mapping<deal_II_dimension, deal_II_space_dimension> &,
-      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-      const Quadrature<deal_II_dimension - 1> &,
-      const std::map<types::boundary_id,
-                     const Function<deal_II_space_dimension, VEC::value_type> *>
-        &,
-      const std::vector<const VEC *> &,
-      std::vector<Vector<float> *> &,
-      const ComponentMask &,
-      const Function<deal_II_space_dimension> *,
-      const unsigned int,
-      const types::subdomain_id,
-      const types::material_id,
-      const Strategy);
+      S>(const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+         const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+         const Quadrature<deal_II_dimension - 1> &,
+         const std::map<types::boundary_id,
+                        const Function<deal_II_space_dimension, S> *> &,
+         const std::vector<const ReadVector<S> *> &,
+         std::vector<Vector<float> *> &,
+         const ComponentMask &,
+         const Function<deal_II_space_dimension> *,
+         const unsigned int,
+         const types::subdomain_id,
+         const types::material_id,
+         const Strategy);
 
     template void
     KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
-      VEC>(
-      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-      const Quadrature<deal_II_dimension - 1> &,
-      const std::map<types::boundary_id,
-                     const Function<deal_II_space_dimension, VEC::value_type> *>
-        &,
-      const std::vector<const VEC *> &,
-      std::vector<Vector<float> *> &,
-      const ComponentMask &,
-      const Function<deal_II_space_dimension> *,
-      const unsigned int,
-      const types::subdomain_id,
-      const types::material_id,
-      const Strategy);
+      S>(const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+         const Quadrature<deal_II_dimension - 1> &,
+         const std::map<types::boundary_id,
+                        const Function<deal_II_space_dimension, S> *> &,
+         const std::vector<const ReadVector<S> *> &,
+         std::vector<Vector<float> *> &,
+         const ComponentMask &,
+         const Function<deal_II_space_dimension> *,
+         const unsigned int,
+         const types::subdomain_id,
+         const types::material_id,
+         const Strategy);
 
     template void
     KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
-      VEC>(
-      const Mapping<deal_II_dimension, deal_II_space_dimension> &,
-      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-      const hp::QCollection<deal_II_dimension - 1> &,
-      const std::map<types::boundary_id,
-                     const Function<deal_II_space_dimension, VEC::value_type> *>
-        &,
-      const VEC &,
-      Vector<float> &,
-      const ComponentMask &,
-      const Function<deal_II_space_dimension> *,
-      const unsigned int,
-      const types::subdomain_id,
-      const types::material_id,
-      const Strategy);
+      S>(const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+         const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+         const hp::QCollection<deal_II_dimension - 1> &,
+         const std::map<types::boundary_id,
+                        const Function<deal_II_space_dimension, S> *> &,
+         const ReadVector<S> &,
+         Vector<float> &,
+         const ComponentMask &,
+         const Function<deal_II_space_dimension> *,
+         const unsigned int,
+         const types::subdomain_id,
+         const types::material_id,
+         const Strategy);
 
     template void
     KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
-      VEC>(
-      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-      const hp::QCollection<deal_II_dimension - 1> &,
-      const std::map<types::boundary_id,
-                     const Function<deal_II_space_dimension, VEC::value_type> *>
-        &,
-      const VEC &,
-      Vector<float> &,
-      const ComponentMask &,
-      const Function<deal_II_space_dimension> *,
-      const unsigned int,
-      const types::subdomain_id,
-      const types::material_id,
-      const Strategy);
+      S>(const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+         const hp::QCollection<deal_II_dimension - 1> &,
+         const std::map<types::boundary_id,
+                        const Function<deal_II_space_dimension, S> *> &,
+         const ReadVector<S> &,
+         Vector<float> &,
+         const ComponentMask &,
+         const Function<deal_II_space_dimension> *,
+         const unsigned int,
+         const types::subdomain_id,
+         const types::material_id,
+         const Strategy);
 
     template void
     KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
-      VEC>(
-      const Mapping<deal_II_dimension, deal_II_space_dimension> &,
-      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-      const hp::QCollection<deal_II_dimension - 1> &,
-      const std::map<types::boundary_id,
-                     const Function<deal_II_space_dimension, VEC::value_type> *>
-        &,
-      const std::vector<const VEC *> &,
-      std::vector<Vector<float> *> &,
-      const ComponentMask &,
-      const Function<deal_II_space_dimension> *,
-      const unsigned int,
-      const types::subdomain_id,
-      const types::material_id,
-      const Strategy);
+      S>(const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+         const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+         const hp::QCollection<deal_II_dimension - 1> &,
+         const std::map<types::boundary_id,
+                        const Function<deal_II_space_dimension, S> *> &,
+         const std::vector<const ReadVector<S> *> &,
+         std::vector<Vector<float> *> &,
+         const ComponentMask &,
+         const Function<deal_II_space_dimension> *,
+         const unsigned int,
+         const types::subdomain_id,
+         const types::material_id,
+         const Strategy);
 
     template void
     KellyErrorEstimator<deal_II_dimension, deal_II_space_dimension>::estimate<
-      VEC>(
-      const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-      const hp::QCollection<deal_II_dimension - 1> &,
-      const std::map<types::boundary_id,
-                     const Function<deal_II_space_dimension, VEC::value_type> *>
-        &,
-      const std::vector<const VEC *> &,
-      std::vector<Vector<float> *> &,
-      const ComponentMask &,
-      const Function<deal_II_space_dimension> *,
-      const unsigned int,
-      const types::subdomain_id,
-      const types::material_id,
-      const Strategy);
+      S>(const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+         const hp::QCollection<deal_II_dimension - 1> &,
+         const std::map<types::boundary_id,
+                        const Function<deal_II_space_dimension, S> *> &,
+         const std::vector<const ReadVector<S> *> &,
+         std::vector<Vector<float> *> &,
+         const ComponentMask &,
+         const Function<deal_II_space_dimension> *,
+         const unsigned int,
+         const types::subdomain_id,
+         const types::material_id,
+         const Strategy);
 
 #endif
   }

--- a/source/numerics/vector_tools_integrate_difference.inst.in
+++ b/source/numerics/vector_tools_integrate_difference.inst.in
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
+for (S : REAL_AND_COMPLEX_SCALARS; deal_II_dimension : DIMENSIONS;
      deal_II_space_dimension : SPACE_DIMENSIONS)
   {
 #if deal_II_dimension <= deal_II_space_dimension
@@ -23,13 +23,13 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
 
       template void
       integrate_difference<deal_II_dimension,
-                           VEC,
+                           S,
                            Vector<float>,
                            deal_II_space_dimension>(
         const Mapping<deal_II_dimension, deal_II_space_dimension> &,
         const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-        const VEC &,
-        const Function<deal_II_space_dimension, typename VEC::value_type> &,
+        const ReadVector<S> &,
+        const Function<deal_II_space_dimension, S> &,
         Vector<float> &,
         const Quadrature<deal_II_dimension> &,
         const NormType &,
@@ -38,12 +38,12 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
 
       template void
       integrate_difference<deal_II_dimension,
-                           VEC,
+                           S,
                            Vector<float>,
                            deal_II_space_dimension>(
         const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-        const VEC &,
-        const Function<deal_II_space_dimension, typename VEC::value_type> &,
+        const ReadVector<S> &,
+        const Function<deal_II_space_dimension, S> &,
         Vector<float> &,
         const Quadrature<deal_II_dimension> &,
         const NormType &,
@@ -52,13 +52,13 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
 
       template void
       integrate_difference<deal_II_dimension,
-                           VEC,
+                           S,
                            Vector<double>,
                            deal_II_space_dimension>(
         const Mapping<deal_II_dimension, deal_II_space_dimension> &,
         const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-        const VEC &,
-        const Function<deal_II_space_dimension, typename VEC::value_type> &,
+        const ReadVector<S> &,
+        const Function<deal_II_space_dimension, S> &,
         Vector<double> &,
         const Quadrature<deal_II_dimension> &,
         const NormType &,
@@ -67,12 +67,12 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
 
       template void
       integrate_difference<deal_II_dimension,
-                           VEC,
+                           S,
                            Vector<double>,
                            deal_II_space_dimension>(
         const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-        const VEC &,
-        const Function<deal_II_space_dimension, typename VEC::value_type> &,
+        const ReadVector<S> &,
+        const Function<deal_II_space_dimension, S> &,
         Vector<double> &,
         const Quadrature<deal_II_dimension> &,
         const NormType &,
@@ -81,14 +81,14 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
 
       template void
       integrate_difference<deal_II_dimension,
-                           VEC,
+                           S,
                            Vector<double>,
                            deal_II_space_dimension>(
         const hp::MappingCollection<deal_II_dimension, deal_II_space_dimension>
           &,
         const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-        const VEC &,
-        const Function<deal_II_space_dimension, typename VEC::value_type> &,
+        const ReadVector<S> &,
+        const Function<deal_II_space_dimension, S> &,
         Vector<double> &,
         const hp::QCollection<deal_II_dimension> &,
         const NormType &,
@@ -97,12 +97,12 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
 
       template void
       integrate_difference<deal_II_dimension,
-                           VEC,
+                           S,
                            Vector<double>,
                            deal_II_space_dimension>(
         const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-        const VEC &,
-        const Function<deal_II_space_dimension, typename VEC::value_type> &,
+        const ReadVector<S> &,
+        const Function<deal_II_space_dimension, S> &,
         Vector<double> &,
         const hp::QCollection<deal_II_dimension> &,
         const NormType &,
@@ -111,14 +111,14 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
 
       template void
       integrate_difference<deal_II_dimension,
-                           VEC,
+                           S,
                            Vector<float>,
                            deal_II_space_dimension>(
         const hp::MappingCollection<deal_II_dimension, deal_II_space_dimension>
           &,
         const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-        const VEC &,
-        const Function<deal_II_space_dimension, typename VEC::value_type> &,
+        const ReadVector<S> &,
+        const Function<deal_II_space_dimension, S> &,
         Vector<float> &,
         const hp::QCollection<deal_II_dimension> &,
         const NormType &,
@@ -127,12 +127,12 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
 
       template void
       integrate_difference<deal_II_dimension,
-                           VEC,
+                           S,
                            Vector<float>,
                            deal_II_space_dimension>(
         const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-        const VEC &,
-        const Function<deal_II_space_dimension, typename VEC::value_type> &,
+        const ReadVector<S> &,
+        const Function<deal_II_space_dimension, S> &,
         Vector<float> &,
         const hp::QCollection<deal_II_dimension> &,
         const NormType &,

--- a/source/numerics/vector_tools_mean_value.inst.in
+++ b/source/numerics/vector_tools_mean_value.inst.in
@@ -13,6 +13,29 @@
 //
 // ---------------------------------------------------------------------
 
+for (S : REAL_AND_COMPLEX_SCALARS; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
+#if deal_II_dimension <= deal_II_space_dimension
+    namespace VectorTools
+    \{
+      template S
+      compute_mean_value(
+        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const Quadrature<deal_II_dimension> &,
+        const ReadVector<S> &,
+        const unsigned int);
+
+      template S
+      compute_mean_value(
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const Quadrature<deal_II_dimension> &,
+        const ReadVector<S> &,
+        const unsigned int);
+    \}
+#endif
+  }
 
 for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
      deal_II_space_dimension : SPACE_DIMENSIONS)
@@ -20,28 +43,12 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
 #if deal_II_dimension <= deal_II_space_dimension
     namespace VectorTools
     \{
-
-      template VEC::value_type
-      compute_mean_value<deal_II_dimension>(
-        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
-        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-        const Quadrature<deal_II_dimension> &,
-        const VEC &,
-        const unsigned int);
-
-      template VEC::value_type
-      compute_mean_value<deal_II_dimension>(
-        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-        const Quadrature<deal_II_dimension> &,
-        const VEC &,
-        const unsigned int);
-
       template void
-      add_constant<>(VEC &                                      solution,
-                     const DoFHandler<deal_II_dimension,
-                                      deal_II_space_dimension> &dof_handler,
-                     const unsigned int                         component,
-                     const typename VEC::value_type constant_adjustment);
+      add_constant(VEC &solution,
+                   const DoFHandler<deal_II_dimension, deal_II_space_dimension>
+                     &                            dof_handler,
+                   const unsigned int             component,
+                   const typename VEC::value_type constant_adjustment);
     \}
 #endif
   }

--- a/tests/integrators/advection_01.cc
+++ b/tests/integrators/advection_01.cc
@@ -63,7 +63,7 @@ test_cell(const FEValuesBase<dim> &fev)
         u    = 0.;
         u(i) = 1.;
         w    = 0.;
-        fev.get_function_values(u, indices, uval, true);
+        fev.get_function_values(u, indices, make_array_view(uval), true);
         cell_residual(w, fev, uval, vel);
         M.vmult(v, u);
         w.add(-1., v);
@@ -118,7 +118,7 @@ test_boundary(const FEValuesBase<dim> &fev)
         u    = 0.;
         u(i) = 1.;
         w    = 0.;
-        fev.get_function_values(u, indices, uval, true);
+        fev.get_function_values(u, indices, make_array_view(uval), true);
         upwind_value_residual(w, fev, uval, null_val, vel);
         M.vmult(v, u);
         w.add(-1., v);
@@ -191,7 +191,7 @@ test_face(const FEValuesBase<dim> &fev1, const FEValuesBase<dim> &fev2)
         u1(i1) = 1.;
         w1     = 0.;
         w2     = 0.;
-        fev1.get_function_values(u1, indices1, u1val, true);
+        fev1.get_function_values(u1, indices1, make_array_view(u1val), true);
         upwind_face_residual(w1, w2, fev1, fev2, u1val, nullval, vel);
         M11.vmult(v1, u1);
         w1.add(-1., v1);
@@ -213,7 +213,7 @@ test_face(const FEValuesBase<dim> &fev1, const FEValuesBase<dim> &fev2)
           }
         w1 = 0.;
         w2 = 0.;
-        fev2.get_function_values(u1, indices2, u1val, true);
+        fev2.get_function_values(u1, indices2, make_array_view(u1val), true);
         upwind_face_residual(w1, w2, fev1, fev2, nullval, u1val, vel);
         M12.vmult(v1, u1);
         w1.add(-1., v1);

--- a/tests/integrators/divergence_01.cc
+++ b/tests/integrators/divergence_01.cc
@@ -66,7 +66,7 @@ test_cell(const FEValuesBase<dim> &fev, const FEValuesBase<dim> &fes)
       u    = 0.;
       u(i) = 1.;
       w    = 0.;
-      fev.get_function_gradients(u, indices, ugrad, true);
+      fev.get_function_gradients(u, indices, make_array_view(ugrad), true);
       cell_residual<dim>(w, fes, ugrad);
       Md.vmult(v, u);
       w.add(-1., v);
@@ -123,7 +123,7 @@ test_boundary(const FEValuesBase<dim> &fev, const FEValuesBase<dim> &fes)
       u    = 0.;
       u(i) = 1.;
       w    = 0.;
-      fev.get_function_values(u, indices, uval, true);
+      fev.get_function_values(u, indices, make_array_view(uval), true);
       u_dot_n_residual(w, fev, fes, uval);
       M.vmult(v, u);
       w.add(-1., v);

--- a/tests/integrators/elasticity_01.cc
+++ b/tests/integrators/elasticity_01.cc
@@ -58,7 +58,7 @@ test_cell(const FEValuesBase<dim> &fev)
         u    = 0.;
         u(i) = 1.;
         w    = 0.;
-        fev.get_function_gradients(u, indices, ugrad, true);
+        fev.get_function_gradients(u, indices, make_array_view(ugrad), true);
         cell_residual<dim>(w, fev, ugrad);
         M.vmult(v, u);
         w.add(-1., v);
@@ -100,8 +100,8 @@ test_boundary(const FEValuesBase<dim> &fev)
         u    = 0.;
         u(i) = 1.;
         w    = 0.;
-        fev.get_function_values(u, indices, uval, true);
-        fev.get_function_gradients(u, indices, ugrad, true);
+        fev.get_function_values(u, indices, make_array_view(uval), true);
+        fev.get_function_gradients(u, indices, make_array_view(ugrad), true);
         nitsche_residual<dim>(w, fev, uval, ugrad, null_val, 17);
         M.vmult(v, u);
         w.add(-1., v);
@@ -168,8 +168,11 @@ test_face(const FEValuesBase<dim> &fev1, const FEValuesBase<dim> &fev2)
         u1(i1) = 1.;
         w1     = 0.;
         w2     = 0.;
-        fev1.get_function_values(u1, indices1, u1val, true);
-        fev1.get_function_gradients(u1, indices1, u1grad, true);
+        fev1.get_function_values(u1, indices1, make_array_view(u1val), true);
+        fev1.get_function_gradients(u1,
+                                    indices1,
+                                    make_array_view(u1grad),
+                                    true);
         ip_residual<dim>(
           w1, w2, fev1, fev2, u1val, u1grad, nullval, nullgrad, 17);
         M11.vmult(v1, u1);
@@ -180,8 +183,11 @@ test_face(const FEValuesBase<dim> &fev1, const FEValuesBase<dim> &fev2)
 
         w1 = 0.;
         w2 = 0.;
-        fev2.get_function_values(u1, indices2, u1val, true);
-        fev2.get_function_gradients(u1, indices2, u1grad, true);
+        fev2.get_function_values(u1, indices2, make_array_view(u1val), true);
+        fev2.get_function_gradients(u1,
+                                    indices2,
+                                    make_array_view(u1grad),
+                                    true);
         ip_residual<dim>(
           w1, w2, fev1, fev2, nullval, nullgrad, u1val, u1grad, 17);
         M12.vmult(v1, u1);

--- a/tests/integrators/elasticity_02.cc
+++ b/tests/integrators/elasticity_02.cc
@@ -62,8 +62,8 @@ test_boundary(const FEValuesBase<dim> &fev)
         u    = 0.;
         u(i) = 1.;
         w    = 0.;
-        fev.get_function_values(u, indices, uval, true);
-        fev.get_function_gradients(u, indices, ugrad, true);
+        fev.get_function_values(u, indices, make_array_view(uval), true);
+        fev.get_function_gradients(u, indices, make_array_view(ugrad), true);
         nitsche_tangential_residual<dim>(w, fev, uval, ugrad, null_val, 17);
         M.vmult(v, u);
         w.add(-1., v);

--- a/tests/integrators/grad_div_01.cc
+++ b/tests/integrators/grad_div_01.cc
@@ -58,7 +58,7 @@ test_cell(const FEValuesBase<dim> &fev)
         u    = 0.;
         u(i) = 1.;
         w    = 0.;
-        fev.get_function_gradients(u, indices, ugrad, true);
+        fev.get_function_gradients(u, indices, make_array_view(ugrad), true);
         cell_residual<dim>(w, fev, ugrad);
         M.vmult(v, u);
         w.add(-1., v);
@@ -100,8 +100,8 @@ test_boundary(const FEValuesBase<dim> &fev)
         u    = 0.;
         u(i) = 1.;
         w    = 0.;
-        fev.get_function_values(u, indices, uval, true);
-        fev.get_function_gradients(u, indices, ugrad, true);
+        fev.get_function_values(u, indices, make_array_view(uval), true);
+        fev.get_function_gradients(u, indices, make_array_view(ugrad), true);
         nitsche_residual<dim>(w, fev, uval, ugrad, null_val, 17);
         M.vmult(v, u);
         w.add(-1., v);
@@ -168,8 +168,11 @@ test_face(const FEValuesBase<dim> &fev1, const FEValuesBase<dim> &fev2)
         u1(i1) = 1.;
         w1     = 0.;
         w2     = 0.;
-        fev1.get_function_values(u1, indices1, u1val, true);
-        fev1.get_function_gradients(u1, indices1, u1grad, true);
+        fev1.get_function_values(u1, indices1, make_array_view(u1val), true);
+        fev1.get_function_gradients(u1,
+                                    indices1,
+                                    make_array_view(u1grad),
+                                    true);
         ip_residual<dim>(
           w1, w2, fev1, fev2, u1val, u1grad, nullval, nullgrad, 17);
         M11.vmult(v1, u1);
@@ -180,8 +183,11 @@ test_face(const FEValuesBase<dim> &fev1, const FEValuesBase<dim> &fev2)
 
         w1 = 0.;
         w2 = 0.;
-        fev2.get_function_values(u1, indices2, u1val, true);
-        fev2.get_function_gradients(u1, indices2, u1grad, true);
+        fev2.get_function_values(u1, indices2, make_array_view(u1val), true);
+        fev2.get_function_gradients(u1,
+                                    indices2,
+                                    make_array_view(u1grad),
+                                    true);
         ip_residual<dim>(
           w1, w2, fev1, fev2, nullval, nullgrad, u1val, u1grad, 17);
         M12.vmult(v1, u1);

--- a/tests/integrators/laplacian_01.cc
+++ b/tests/integrators/laplacian_01.cc
@@ -57,7 +57,7 @@ test_cell(const FEValuesBase<dim> &fev)
         u    = 0.;
         u(i) = 1.;
         w    = 0.;
-        fev.get_function_gradients(u, indices, ugrad, true);
+        fev.get_function_gradients(u, indices, make_array_view(ugrad), true);
         cell_residual<dim>(w, fev, ugrad);
         M.vmult(v, u);
         w.add(-1., v);
@@ -106,8 +106,8 @@ test_boundary(const FEValuesBase<dim> &fev)
         u    = 0.;
         u(i) = 1.;
         w    = 0.;
-        fev.get_function_values(u, indices, uval, true);
-        fev.get_function_gradients(u, indices, ugrad, true);
+        fev.get_function_values(u, indices, make_array_view(uval), true);
+        fev.get_function_gradients(u, indices, make_array_view(ugrad), true);
         nitsche_residual<dim>(w, fev, uval, ugrad, null_val, 17);
         M.vmult(v, u);
         w.add(-1., v);
@@ -181,8 +181,11 @@ test_face(const FEValuesBase<dim> &fev1, const FEValuesBase<dim> &fev2)
         u1(i1) = 1.;
         w1     = 0.;
         w2     = 0.;
-        fev1.get_function_values(u1, indices1, u1val, true);
-        fev1.get_function_gradients(u1, indices1, u1grad, true);
+        fev1.get_function_values(u1, indices1, make_array_view(u1val), true);
+        fev1.get_function_gradients(u1,
+                                    indices1,
+                                    make_array_view(u1grad),
+                                    true);
         ip_residual<dim>(
           w1, w2, fev1, fev2, u1val, u1grad, nullval, nullgrad, 17);
         M11.vmult(v1, u1);
@@ -213,8 +216,11 @@ test_face(const FEValuesBase<dim> &fev1, const FEValuesBase<dim> &fev2)
 
         w1 = 0.;
         w2 = 0.;
-        fev2.get_function_values(u1, indices2, u1val, true);
-        fev2.get_function_gradients(u1, indices2, u1grad, true);
+        fev2.get_function_values(u1, indices2, make_array_view(u1val), true);
+        fev2.get_function_gradients(u1,
+                                    indices2,
+                                    make_array_view(u1grad),
+                                    true);
         ip_residual<dim>(
           w1, w2, fev1, fev2, nullval, nullgrad, u1val, u1grad, 17);
         M12.vmult(v1, u1);


### PR DESCRIPTION
This is ~at the proof-of-concept stage and~ a viable direction for part of #15168.

In `FEValues` (and places like the Kelly error estimator and `integrate_difference` in which we only access vectors through `FEValues`) the only vector operation we need is "extract values from a global vector on a single cell". We could eliminate the use of `VectorType` completely in that class by making all of our vectors implement a single common interface for that task. I implemented this as new base class `ReadVector<T>` which contains virtual functions `size()` and `extract_entries()`.

`FEValues` is one of the most expensive things to compile so reducing the number of instantiations in it by about an of magnitude (by switching from instantiation over all vector classes to instantiation over all scalars) would help a lot.

One disadvantage to this approach is that we need to ~either delete some checks on vector sizes or~ make `size()` virtual.