### PR TITLE
Use Kokkos to launch kernels in CUDAWrappers::MatrixFree 

### DIFF
--- a/doc/news/changes/incompatibilities/20230511Turcksin
+++ b/doc/news/changes/incompatibilities/20230511Turcksin
@@ -1,0 +1,3 @@
+Extensive rework of CUDAWrappers::MatrixFree and CUDAWrappers::FEEvalution.
+<br>
+(Bruno Turcksin, 2023/05/11)

--- a/examples/step-64/step-64.cc
+++ b/examples/step-64/step-64.cc
@@ -61,8 +61,8 @@ namespace Step64
   // an object of this type to a CUDAWrappers::MatrixFree
   // object that expects the class to have an `operator()` that fills the
   // values provided in the constructor for a given cell. This operator
-  // needs to run on the device, so it needs to be marked as `__device__`
-  // for the compiler.
+  // needs to run on the device, so it needs to be marked as
+  // `DEAL_II_HOST_DEVICE` for the compiler.
   template <int dim, int fe_degree>
   class VaryingCoefficientFunctor
   {
@@ -71,13 +71,15 @@ namespace Step64
       : coef(coefficient)
     {}
 
-    __device__ void operator()(
+    DEAL_II_HOST_DEVICE void operator()(
+      const typename CUDAWrappers::MatrixFree<dim, double>::Data *gpu_data,
       const unsigned int                                          cell,
-      const typename CUDAWrappers::MatrixFree<dim, double>::Data *gpu_data);
+      const unsigned int                                          q) const;
 
     // Since CUDAWrappers::MatrixFree::Data doesn't know about the size of its
-    // arrays, we need to store the number of quadrature points and the numbers
-    // of degrees of freedom in this class to do necessary index conversions.
+    // arrays, we need to store the number of quadrature points and the
+    // numbers of degrees of freedom in this class to do necessary index
+    // conversions.
     static const unsigned int n_dofs_1d    = fe_degree + 1;
     static const unsigned int n_local_dofs = Utilities::pow(n_dofs_1d, dim);
     static const unsigned int n_q_points   = Utilities::pow(n_dofs_1d, dim);
@@ -92,16 +94,14 @@ namespace Step64
   // the introduction that we have defined it as $a(\mathbf
   // x)=\frac{10}{0.05 + 2\|\mathbf x\|^2}$
   template <int dim, int fe_degree>
-  __device__ void VaryingCoefficientFunctor<dim, fe_degree>::operator()(
+  DEAL_II_HOST_DEVICE void
+  VaryingCoefficientFunctor<dim, fe_degree>::operator()(
+    const typename CUDAWrappers::MatrixFree<dim, double>::Data *gpu_data,
     const unsigned int                                          cell,
-    const typename CUDAWrappers::MatrixFree<dim, double>::Data *gpu_data)
+    const unsigned int                                          q) const
   {
-    const unsigned int pos = CUDAWrappers::local_q_point_id<dim, double>(
-      cell, gpu_data, n_dofs_1d, n_q_points);
-    const Point<dim> q_point =
-      CUDAWrappers::get_quadrature_point<dim, double>(cell,
-                                                      gpu_data,
-                                                      n_dofs_1d);
+    const unsigned int pos = gpu_data->local_q_point_id(cell, n_q_points, q);
+    const Point<dim>   q_point = gpu_data->get_quadrature_point(cell, q);
 
     double p_square = 0.;
     for (unsigned int i = 0; i < dim; ++i)
@@ -121,22 +121,31 @@ namespace Step64
   // step-37. In contrast to there, the actual quadrature point
   // index is treated implicitly by converting the current thread
   // index. As before, the functions of this class need to run on
-  // the device, so need to be marked as `__device__` for the
+  // the device, so need to be marked as `DEAL_II_HOST_DEVICE` for the
   // compiler.
   template <int dim, int fe_degree>
   class HelmholtzOperatorQuad
   {
   public:
-    __device__ HelmholtzOperatorQuad(double coef)
+    DEAL_II_HOST_DEVICE HelmholtzOperatorQuad(
+      const typename CUDAWrappers::MatrixFree<dim, double>::Data *gpu_data,
+      double *                                                    coef,
+      int                                                         cell)
       : coef(coef)
     {}
 
-    __device__ void operator()(
+    DEAL_II_HOST_DEVICE void operator()(
       CUDAWrappers::FEEvaluation<dim, fe_degree, fe_degree + 1, 1, double>
-        *fe_eval) const;
+        *       fe_eval,
+      const int q_point) const;
+
+    static const unsigned int n_q_points =
+      dealii::Utilities::pow(fe_degree + 1, dim);
 
   private:
-    double coef;
+    const typename CUDAWrappers::MatrixFree<dim, double>::Data *gpu_data;
+    double *                                                    coef;
+    int                                                         cell;
   };
 
 
@@ -148,12 +157,16 @@ namespace Step64
   // the two terms on the left-hand side correspond to the two function calls
   // here:
   template <int dim, int fe_degree>
-  __device__ void HelmholtzOperatorQuad<dim, fe_degree>::operator()(
+  DEAL_II_HOST_DEVICE void HelmholtzOperatorQuad<dim, fe_degree>::operator()(
     CUDAWrappers::FEEvaluation<dim, fe_degree, fe_degree + 1, 1, double>
-      *fe_eval) const
+      *       fe_eval,
+    const int q_point) const
   {
-    fe_eval->submit_value(coef * fe_eval->get_value());
-    fe_eval->submit_gradient(fe_eval->get_gradient());
+    const unsigned int pos =
+      gpu_data->local_q_point_id(cell, n_q_points, q_point);
+
+    fe_eval->submit_value(coef[pos] * fe_eval->get_value(q_point), q_point);
+    fe_eval->submit_gradient(fe_eval->get_gradient(q_point), q_point);
   }
 
 
@@ -166,23 +179,25 @@ namespace Step64
   class LocalHelmholtzOperator
   {
   public:
+    // Again, the CUDAWrappers::MatrixFree object doesn't know about the number
+    // of degrees of freedom and the number of quadrature points so we need
+    // to store these for index calculations in the call operator.
+    static constexpr unsigned int n_dofs_1d = fe_degree + 1;
+    static constexpr unsigned int n_local_dofs =
+      Utilities::pow(fe_degree + 1, dim);
+    static constexpr unsigned int n_q_points =
+      Utilities::pow(fe_degree + 1, dim);
+
     LocalHelmholtzOperator(double *coefficient)
       : coef(coefficient)
     {}
 
-    __device__ void operator()(
+    DEAL_II_HOST_DEVICE void operator()(
       const unsigned int                                          cell,
       const typename CUDAWrappers::MatrixFree<dim, double>::Data *gpu_data,
       CUDAWrappers::SharedData<dim, double> *                     shared_data,
       const double *                                              src,
       double *                                                    dst) const;
-
-    // Again, the CUDAWrappers::MatrixFree object doesn't know about the number
-    // of degrees of freedom and the number of quadrature points so we need
-    // to store these for index calculations in the call operator.
-    static const unsigned int n_dofs_1d    = fe_degree + 1;
-    static const unsigned int n_local_dofs = Utilities::pow(fe_degree + 1, dim);
-    static const unsigned int n_q_points   = Utilities::pow(fe_degree + 1, dim);
 
   private:
     double *coef;
@@ -195,22 +210,19 @@ namespace Step64
   // vector and we write value and gradient information to the destination
   // vector.
   template <int dim, int fe_degree>
-  __device__ void LocalHelmholtzOperator<dim, fe_degree>::operator()(
+  DEAL_II_HOST_DEVICE void LocalHelmholtzOperator<dim, fe_degree>::operator()(
     const unsigned int                                          cell,
     const typename CUDAWrappers::MatrixFree<dim, double>::Data *gpu_data,
     CUDAWrappers::SharedData<dim, double> *                     shared_data,
     const double *                                              src,
     double *                                                    dst) const
   {
-    const unsigned int pos = CUDAWrappers::local_q_point_id<dim, double>(
-      cell, gpu_data, n_dofs_1d, n_q_points);
-
     CUDAWrappers::FEEvaluation<dim, fe_degree, fe_degree + 1, 1, double>
-      fe_eval(cell, gpu_data, shared_data);
+      fe_eval(gpu_data, shared_data);
     fe_eval.read_dof_values(src);
     fe_eval.evaluate(true, true);
     fe_eval.apply_for_each_quad_point(
-      HelmholtzOperatorQuad<dim, fe_degree>(coef[pos]));
+      HelmholtzOperatorQuad<dim, fe_degree>(gpu_data, coef, cell));
     fe_eval.integrate(true, true);
     fe_eval.distribute_local_to_global(dst);
   }

--- a/examples/step-64/step-64.cc
+++ b/examples/step-64/step-64.cc
@@ -78,7 +78,7 @@ namespace Step64
 
     // Since CUDAWrappers::MatrixFree::Data doesn't know about the size of its
     // arrays, we need to store the number of quadrature points and the
-    // numbers of degrees of freedom in this class to do necessary index
+    // number of degrees of freedom in this class to do necessary index
     // conversions.
     static const unsigned int n_dofs_1d    = fe_degree + 1;
     static const unsigned int n_local_dofs = Utilities::pow(n_dofs_1d, dim);

--- a/include/deal.II/base/partitioner.templates.h
+++ b/include/deal.II/base/partitioner.templates.h
@@ -130,7 +130,7 @@ namespace Utilities
               auto locally_owned_array_data = locally_owned_array.data();
               MemorySpace::Default::kokkos_space::execution_space exec;
               Kokkos::parallel_for(
-                "fill temp_array_ptr",
+                "dealii::fill temp_array_ptr",
                 Kokkos::RangePolicy<
                   MemorySpace::Default::kokkos_space::execution_space>(
                   exec, 0, chunk_size),
@@ -611,7 +611,7 @@ namespace Utilities
                       using IndexType = decltype(chunk_size);
                       MemorySpace::Default::kokkos_space::execution_space exec;
                       Kokkos::parallel_for(
-                        "fill locally_owned_array, add",
+                        "dealii::fill locally_owned_array, add",
                         Kokkos::RangePolicy<
                           MemorySpace::Default::kokkos_space::execution_space>(
                           exec, 0, chunk_size),
@@ -635,7 +635,7 @@ namespace Utilities
                       using IndexType = decltype(chunk_size);
                       MemorySpace::Default::kokkos_space::execution_space exec;
                       Kokkos::parallel_for(
-                        "fill locally_owned_array, min",
+                        "dealii::fill locally_owned_array, min",
                         Kokkos::RangePolicy<
                           MemorySpace::Default::kokkos_space::execution_space>(
                           exec, 0, chunk_size),
@@ -662,7 +662,7 @@ namespace Utilities
                       using IndexType = decltype(chunk_size);
                       MemorySpace::Default::kokkos_space::execution_space exec;
                       Kokkos::parallel_for(
-                        "fill locally_owned_array, max",
+                        "dealii::fill locally_owned_array, max",
                         Kokkos::RangePolicy<
                           MemorySpace::Default::kokkos_space::execution_space>(
                           exec, 0, chunk_size),

--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -2272,7 +2272,7 @@ namespace internal
       ExecutionSpace exec;
       auto           local_values = vec.get_values();
       Kokkos::parallel_for(
-        "set_zero_parallel",
+        "dealii::set_zero_parallel",
         Kokkos::RangePolicy<ExecutionSpace>(exec, 0, n_constraints),
         KOKKOS_LAMBDA(int i) {
           local_values[constrained_local_dofs_device[i]] = 0;

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -387,7 +387,7 @@ namespace LinearAlgebra
             Kokkos::view_alloc(Kokkos::WithoutInitializing, "indices"),
             n_elements);
           Kokkos::parallel_for(
-            "import_elements: fill indices",
+            "dealii::import_elements: fill indices",
             Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(host_exec,
                                                                    0,
                                                                    n_elements),
@@ -410,7 +410,7 @@ namespace LinearAlgebra
 
           // Set the values in tmp_vector
           Kokkos::parallel_for(
-            "import_elements: set values tmp_vector",
+            "dealii::import_elements: set values tmp_vector",
             Kokkos::RangePolicy<
               ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
               exec, 0, n_elements),
@@ -426,7 +426,7 @@ namespace LinearAlgebra
           const size_type tmp_n_elements = tmp_index_set.n_elements();
           Kokkos::realloc(indices, tmp_n_elements);
           Kokkos::parallel_for(
-            "import_elements: copy local elements to val",
+            "dealii::import_elements: copy local elements to val",
             Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(host_exec,
                                                                    0,
                                                                    n_elements),
@@ -443,7 +443,7 @@ namespace LinearAlgebra
 
           if (operation == VectorOperation::add)
             Kokkos::parallel_for(
-              "import_elements: add values",
+              "dealii::import_elements: add values",
               Kokkos::RangePolicy<
                 ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
                 exec, 0, n_elements),
@@ -452,7 +452,7 @@ namespace LinearAlgebra
               });
           else
             Kokkos::parallel_for(
-              "import_elements: set values",
+              "dealii::import_elements: set values",
               Kokkos::RangePolicy<
                 ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
                 exec, 0, n_elements),
@@ -476,7 +476,7 @@ namespace LinearAlgebra
           typename ::dealii::MemorySpace::Default::kokkos_space::execution_space
             exec;
           Kokkos::parallel_reduce(
-            "linfty_norm_local",
+            "dealii::linfty_norm_local",
             Kokkos::RangePolicy<
               ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
               exec, 0, size),

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -3384,7 +3384,7 @@ namespace internal
                           Kokkos::IndexType<types::global_dof_index>>
         policy(0, n_local_elements);
       Kokkos::parallel_for(
-        "PreconditionChebyshev::set_initial_guess",
+        "dealii::PreconditionChebyshev::set_initial_guess",
         policy,
         KOKKOS_LAMBDA(types::global_dof_index i) {
           values_ptr[i] = (i + first_local_range) % 11;

--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -2168,7 +2168,7 @@ namespace internal
         auto exec = typename ::dealii::MemorySpace::Default::kokkos_space::
           execution_space{};
         Kokkos::parallel_for(
-          "add_vector",
+          "dealii::add_vector",
           Kokkos::RangePolicy<
             ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
             exec, 0, size),
@@ -2189,7 +2189,7 @@ namespace internal
         auto exec = typename ::dealii::MemorySpace::Default::kokkos_space::
           execution_space{};
         Kokkos::parallel_for(
-          "subtract_vector",
+          "dealii::subtract_vector",
           Kokkos::RangePolicy<
             ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
             exec, 0, size),
@@ -2209,7 +2209,7 @@ namespace internal
         auto exec = typename ::dealii::MemorySpace::Default::kokkos_space::
           execution_space{};
         Kokkos::parallel_for(
-          "add_factor",
+          "dealii::add_factor",
           Kokkos::RangePolicy<
             ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
             exec, 0, size),
@@ -2231,7 +2231,7 @@ namespace internal
         auto exec = typename ::dealii::MemorySpace::Default::kokkos_space::
           execution_space{};
         Kokkos::parallel_for(
-          "add_av",
+          "dealii::add_av",
           Kokkos::RangePolicy<
             ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
             exec, 0, size),
@@ -2258,7 +2258,7 @@ namespace internal
         auto exec = typename ::dealii::MemorySpace::Default::kokkos_space::
           execution_space{};
         Kokkos::parallel_for(
-          "add_avpbw",
+          "dealii::add_avpbw",
           Kokkos::RangePolicy<
             ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
             exec, 0, size),
@@ -2282,7 +2282,7 @@ namespace internal
         auto exec = typename ::dealii::MemorySpace::Default::kokkos_space::
           execution_space{};
         Kokkos::parallel_for(
-          "sadd_xv",
+          "dealii::sadd_xv",
           Kokkos::RangePolicy<
             ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
             exec, 0, size),
@@ -2307,7 +2307,7 @@ namespace internal
         auto exec = typename ::dealii::MemorySpace::Default::kokkos_space::
           execution_space{};
         Kokkos::parallel_for(
-          "sadd_xav",
+          "dealii::sadd_xav",
           Kokkos::RangePolicy<
             ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
             exec, 0, size),
@@ -2335,7 +2335,7 @@ namespace internal
         auto exec = typename ::dealii::MemorySpace::Default::kokkos_space::
           execution_space{};
         Kokkos::parallel_for(
-          "sadd_xavbw",
+          "dealii::sadd_xavbw",
           Kokkos::RangePolicy<
             ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
             exec, 0, size),
@@ -2358,7 +2358,7 @@ namespace internal
         auto exec = typename ::dealii::MemorySpace::Default::kokkos_space::
           execution_space{};
         Kokkos::parallel_for(
-          "multiply_factor",
+          "dealii::multiply_factor",
           Kokkos::RangePolicy<
             ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
             exec, 0, size),
@@ -2379,7 +2379,7 @@ namespace internal
         auto exec = typename ::dealii::MemorySpace::Default::kokkos_space::
           execution_space{};
         Kokkos::parallel_for(
-          "scale",
+          "dealii::scale",
           Kokkos::RangePolicy<
             ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
             exec, 0, size),
@@ -2401,7 +2401,7 @@ namespace internal
         auto exec = typename ::dealii::MemorySpace::Default::kokkos_space::
           execution_space{};
         Kokkos::parallel_for(
-          "equ_au",
+          "dealii::equ_au",
           Kokkos::RangePolicy<
             ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
             exec, 0, size),
@@ -2428,7 +2428,7 @@ namespace internal
         auto exec = typename ::dealii::MemorySpace::Default::kokkos_space::
           execution_space{};
         Kokkos::parallel_for(
-          "equ_aubv",
+          "dealii::equ_aubv",
           Kokkos::RangePolicy<
             ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
             exec, 0, size),
@@ -2452,7 +2452,7 @@ namespace internal
         auto exec = typename ::dealii::MemorySpace::Default::kokkos_space::
           execution_space{};
         Kokkos::parallel_reduce(
-          "dot",
+          "dealii::dot",
           Kokkos::RangePolicy<
             ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
             exec, 0, size),
@@ -2489,7 +2489,7 @@ namespace internal
         auto exec = typename ::dealii::MemorySpace::Default::kokkos_space::
           execution_space{};
         Kokkos::parallel_reduce(
-          "mean_value",
+          "dealii::mean_value",
           Kokkos::RangePolicy<
             ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
             exec, 0, size),
@@ -2515,7 +2515,7 @@ namespace internal
         auto exec = typename ::dealii::MemorySpace::Default::kokkos_space::
           execution_space{};
         Kokkos::parallel_reduce(
-          "norm_1",
+          "dealii::norm_1",
           Kokkos::RangePolicy<
             ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
             exec, 0, size),
@@ -2545,7 +2545,7 @@ namespace internal
         auto exec = typename ::dealii::MemorySpace::Default::kokkos_space::
           execution_space{};
         Kokkos::parallel_reduce(
-          "norm_p",
+          "dealii::norm_p",
           Kokkos::RangePolicy<
             ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
             exec, 0, size),
@@ -2580,7 +2580,7 @@ namespace internal
         auto exec = typename ::dealii::MemorySpace::Default::kokkos_space::
           execution_space{};
         Kokkos::parallel_reduce(
-          "add_and_dot",
+          "dealii::add_and_dot",
           Kokkos::RangePolicy<
             ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
             exec, 0, size),

--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -652,9 +652,9 @@ namespace CUDAWrappers
       Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 
     DEAL_II_HOST_DEVICE
-    SharedData(const TeamHandle &team_member,
-               SharedView1D      values,
-               SharedView2D      gradients)
+    SharedData(const TeamHandle &  team_member,
+               const SharedView1D &values,
+               const SharedView2D &gradients)
       : team_member(team_member)
       , values(values)
       , gradients(gradients)

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -580,7 +580,7 @@ namespace CUDAWrappers
     const Number *     src_ptr = src.get_values();
     Number *           dst_ptr = dst.get_values();
     Kokkos::parallel_for(
-      "copy_constrained_values",
+      "dealii::copy_constrained_values",
       Kokkos::RangePolicy<MemorySpace::Default::kokkos_space::execution_space>(
         0, n_constrained_dofs),
       KOKKOS_LAMBDA(int dof) {
@@ -614,7 +614,7 @@ namespace CUDAWrappers
     const unsigned int size =
       partitioner ? dst.locally_owned_size() : dst.size();
     Kokkos::parallel_for(
-      "set_constrained_values",
+      "dealii::set_constrained_values",
       Kokkos::RangePolicy<MemorySpace::Default::kokkos_space::execution_space>(
         0, n_constrained_dofs),
       KOKKOS_LAMBDA(int dof) {

--- a/include/deal.II/matrix_free/cuda_tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/cuda_tensor_product_kernels.h
@@ -59,41 +59,70 @@ namespace CUDAWrappers
               typename ViewTypeIn,
               typename ViewTypeOut>
     DEAL_II_HOST_DEVICE void
-    apply(const Kokkos::View<Number *, MemorySpace::Default::kokkos_space>
+    apply(const Kokkos::TeamPolicy<
+            MemorySpace::Default::kokkos_space::execution_space>::member_type
+            &team_member,
+          const Kokkos::View<Number *, MemorySpace::Default::kokkos_space>
                            shape_data,
           const ViewTypeIn in,
           ViewTypeOut      out)
     {
-      KOKKOS_IF_ON_DEVICE(
-        const unsigned int i = (dim == 1) ? 0 : threadIdx.x % n_q_points_1d;
-        const unsigned int j = (dim == 3) ? threadIdx.y : 0;
-        const unsigned int q = (dim == 1) ? (threadIdx.x % n_q_points_1d) :
-                               (dim == 2) ? threadIdx.y :
-                                            threadIdx.z;
+      constexpr unsigned int n_q_points = Utilities::pow(n_q_points_1d, dim);
 
-        // This loop simply multiplies the shape function at the quadrature
-        // point by the value finite element coefficient.
-        Number t = 0;
-        for (int k = 0; k < n_q_points_1d; ++k) {
-          const unsigned int shape_idx =
-            dof_to_quad ? (q + k * n_q_points_1d) : (k + q * n_q_points_1d);
-          const unsigned int source_idx =
-            (direction == 0) ? (k + n_q_points_1d * (i + n_q_points_1d * j)) :
-            (direction == 1) ? (i + n_q_points_1d * (k + n_q_points_1d * j)) :
-                               (i + n_q_points_1d * (j + n_q_points_1d * k));
-          t += shape_data[shape_idx] *
-               (in_place ? out[source_idx] : in[source_idx]);
-        }
+      Number t[n_q_points];
+      Kokkos::parallel_for(
+        Kokkos::TeamThreadRange(team_member, n_q_points),
+        [&](const int &q_point) {
+          const unsigned int i = (dim == 1) ? 0 : q_point % n_q_points_1d;
+          const unsigned int j =
+            (dim == 3) ? (q_point / n_q_points_1d) % n_q_points_1d : 0;
+          const unsigned int q =
+            (dim == 1) ? q_point :
+            (dim == 2) ? (q_point / n_q_points_1d) % n_q_points_1d :
+                         q_point / (n_q_points_1d * n_q_points_1d);
 
-        if (in_place) __syncthreads();
+          // This loop simply multiplies the shape function at the quadrature
+          // point by the value finite element coefficient.
+          t[q_point] = 0;
+          for (int k = 0; k < n_q_points_1d; ++k)
+            {
+              const unsigned int shape_idx =
+                dof_to_quad ? (q + k * n_q_points_1d) : (k + q * n_q_points_1d);
+              const unsigned int source_idx =
+                (direction == 0) ?
+                  (k + n_q_points_1d * (i + n_q_points_1d * j)) :
+                (direction == 1) ?
+                  (i + n_q_points_1d * (k + n_q_points_1d * j)) :
+                  (i + n_q_points_1d * (j + n_q_points_1d * k));
+              t[q_point] += shape_data[shape_idx] *
+                            (in_place ? out(source_idx) : in(source_idx));
+            }
+        });
 
-        const unsigned int destination_idx =
-          (direction == 0) ? (q + n_q_points_1d * (i + n_q_points_1d * j)) :
-          (direction == 1) ? (i + n_q_points_1d * (q + n_q_points_1d * j)) :
-                             (i + n_q_points_1d * (j + n_q_points_1d * q));
+      if (in_place)
+        team_member.team_barrier();
 
-        if (add) Kokkos::atomic_add(&out[destination_idx], t);
-        else out[destination_idx] = t;)
+      Kokkos::parallel_for(
+        Kokkos::TeamThreadRange(team_member, n_q_points),
+        [&](const int &q_point) {
+          const unsigned int i = (dim == 1) ? 0 : q_point % n_q_points_1d;
+          const unsigned int j =
+            (dim == 3) ? (q_point / n_q_points_1d) % n_q_points_1d : 0;
+          const unsigned int q =
+            (dim == 1) ? q_point :
+            (dim == 2) ? (q_point / n_q_points_1d) % n_q_points_1d :
+                         q_point / (n_q_points_1d * n_q_points_1d);
+
+          const unsigned int destination_idx =
+            (direction == 0) ? (q + n_q_points_1d * (i + n_q_points_1d * j)) :
+            (direction == 1) ? (i + n_q_points_1d * (q + n_q_points_1d * j)) :
+                               (i + n_q_points_1d * (j + n_q_points_1d * q));
+
+          if (add)
+            Kokkos::atomic_add(&out(destination_idx), t[q_point]);
+          else
+            out(destination_idx) = t[q_point];
+        });
     }
 
 
@@ -125,8 +154,12 @@ namespace CUDAWrappers
                                   n_q_points_1d,
                                   Number>
     {
+      using TeamHandle = Kokkos::TeamPolicy<
+        MemorySpace::Default::kokkos_space::execution_space>::member_type;
+
       DEAL_II_HOST_DEVICE
       EvaluatorTensorProduct(
+        const TeamHandle &                                         team_member,
         Kokkos::View<Number *, MemorySpace::Default::kokkos_space> shape_values,
         Kokkos::View<Number *, MemorySpace::Default::kokkos_space>
           shape_gradients,
@@ -219,6 +252,11 @@ namespace CUDAWrappers
       integrate_value_and_gradient(ViewType1 u, ViewType2 grad_u);
 
       /**
+       * TeamPolicy handle.
+       */
+      const TeamHandle &team_member;
+
+      /**
        * Values of the shape functions.
        */
       Kokkos::View<Number *, MemorySpace::Default::kokkos_space> shape_values;
@@ -246,12 +284,14 @@ namespace CUDAWrappers
                            n_q_points_1d,
                            Number>::
       EvaluatorTensorProduct(
+        const TeamHandle &                                         team_member,
         Kokkos::View<Number *, MemorySpace::Default::kokkos_space> shape_values,
         Kokkos::View<Number *, MemorySpace::Default::kokkos_space>
           shape_gradients,
         Kokkos::View<Number *, MemorySpace::Default::kokkos_space>
           co_shape_gradients)
-      : shape_values(shape_values)
+      : team_member(team_member)
+      , shape_values(shape_values)
       , shape_gradients(shape_gradients)
       , co_shape_gradients(co_shape_gradients)
     {}
@@ -274,7 +314,7 @@ namespace CUDAWrappers
                                            ViewTypeOut      out) const
     {
       apply<dim, n_q_points_1d, Number, direction, dof_to_quad, add, in_place>(
-        shape_values, in, out);
+        team_member, shape_values, in, out);
     }
 
 
@@ -295,7 +335,7 @@ namespace CUDAWrappers
                                               ViewTypeOut      out) const
     {
       apply<dim, n_q_points_1d, Number, direction, dof_to_quad, add, in_place>(
-        shape_gradients, in, out);
+        team_member, shape_gradients, in, out);
     }
 
 
@@ -316,7 +356,7 @@ namespace CUDAWrappers
                                                  ViewTypeOut      out) const
     {
       apply<dim, n_q_points_1d, Number, direction, dof_to_quad, add, in_place>(
-        co_shape_gradients, in, out);
+        team_member, co_shape_gradients, in, out);
     }
 
 
@@ -341,7 +381,7 @@ namespace CUDAWrappers
           case 2:
             {
               values<0, true, false, true>(u, u);
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
               values<1, true, false, true>(u, u);
 
               break;
@@ -349,9 +389,9 @@ namespace CUDAWrappers
           case 3:
             {
               values<0, true, false, true>(u, u);
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
               values<1, true, false, true>(u, u);
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
               values<2, true, false, true>(u, u);
 
               break;
@@ -386,7 +426,7 @@ namespace CUDAWrappers
           case 2:
             {
               values<0, false, false, true>(u, u);
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
               values<1, false, false, true>(u, u);
 
               break;
@@ -394,9 +434,9 @@ namespace CUDAWrappers
           case 3:
             {
               values<0, false, false, true>(u, u);
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
               values<1, false, false, true>(u, u);
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
               values<2, false, false, true>(u, u);
 
               break;
@@ -437,7 +477,7 @@ namespace CUDAWrappers
               values<0, true, false, false>(
                 u, Kokkos::subview(grad_u, Kokkos::ALL, 1));
 
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
 
               values<1, true, false, true>(
                 Kokkos::subview(grad_u, Kokkos::ALL, 0),
@@ -457,7 +497,7 @@ namespace CUDAWrappers
               values<0, true, false, false>(
                 u, Kokkos::subview(grad_u, Kokkos::ALL, 2));
 
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
 
               values<1, true, false, true>(
                 Kokkos::subview(grad_u, Kokkos::ALL, 0),
@@ -469,7 +509,7 @@ namespace CUDAWrappers
                 Kokkos::subview(grad_u, Kokkos::ALL, 2),
                 Kokkos::subview(grad_u, Kokkos::ALL, 2));
 
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
 
               values<2, true, false, true>(
                 Kokkos::subview(grad_u, Kokkos::ALL, 0),
@@ -509,7 +549,7 @@ namespace CUDAWrappers
           case 1:
             {
               values<0, true, false, true>(u, u);
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
 
               co_gradients<0, true, false, false>(
                 u, Kokkos::subview(grad_u, Kokkos::ALL, 0));
@@ -519,9 +559,9 @@ namespace CUDAWrappers
           case 2:
             {
               values<0, true, false, true>(u, u);
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
               values<1, true, false, true>(u, u);
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
 
               co_gradients<0, true, false, false>(
                 u, Kokkos::subview(grad_u, Kokkos::ALL, 0));
@@ -533,11 +573,11 @@ namespace CUDAWrappers
           case 3:
             {
               values<0, true, false, true>(u, u);
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
               values<1, true, false, true>(u, u);
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
               values<2, true, false, true>(u, u);
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
 
               co_gradients<0, true, false, false>(
                 u, Kokkos::subview(grad_u, Kokkos::ALL, 0));
@@ -586,11 +626,11 @@ namespace CUDAWrappers
                 Kokkos::subview(grad_u, Kokkos::ALL, 1),
                 Kokkos::subview(grad_u, Kokkos::ALL, 1));
 
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
 
               values<1, false, add, false>(
                 Kokkos::subview(grad_u, Kokkos::ALL, 0), u);
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
               gradients<1, false, true, false>(
                 Kokkos::subview(grad_u, Kokkos::ALL, 1), u);
 
@@ -608,7 +648,7 @@ namespace CUDAWrappers
                 Kokkos::subview(grad_u, Kokkos::ALL, 2),
                 Kokkos::subview(grad_u, Kokkos::ALL, 2));
 
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
 
               values<1, false, false, true>(
                 Kokkos::subview(grad_u, Kokkos::ALL, 0),
@@ -620,14 +660,14 @@ namespace CUDAWrappers
                 Kokkos::subview(grad_u, Kokkos::ALL, 2),
                 Kokkos::subview(grad_u, Kokkos::ALL, 2));
 
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
 
               values<2, false, add, false>(
                 Kokkos::subview(grad_u, Kokkos::ALL, 0), u);
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
               values<2, false, true, false>(
                 Kokkos::subview(grad_u, Kokkos::ALL, 1), u);
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
               gradients<2, false, true, false>(
                 Kokkos::subview(grad_u, Kokkos::ALL, 2), u);
 
@@ -660,7 +700,7 @@ namespace CUDAWrappers
             {
               co_gradients<0, false, true, false>(
                 Kokkos::subview(grad_u, Kokkos::ALL, 0), u);
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
 
               values<0, false, false, true>(u, u);
 
@@ -670,15 +710,15 @@ namespace CUDAWrappers
             {
               co_gradients<1, false, true, false>(
                 Kokkos::subview(grad_u, Kokkos::ALL, 1), u);
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
               co_gradients<0, false, true, false>(
                 Kokkos::subview(grad_u, Kokkos::ALL, 0), u);
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
 
               values<1, false, false, true>(u, u);
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
               values<0, false, false, true>(u, u);
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
 
               break;
             }
@@ -686,20 +726,20 @@ namespace CUDAWrappers
             {
               co_gradients<2, false, true, false>(
                 Kokkos::subview(grad_u, Kokkos::ALL, 2), u);
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
               co_gradients<1, false, true, false>(
                 Kokkos::subview(grad_u, Kokkos::ALL, 1), u);
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
               co_gradients<0, false, true, false>(
                 Kokkos::subview(grad_u, Kokkos::ALL, 0), u);
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
 
               values<2, false, false, true>(u, u);
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
               values<1, false, false, true>(u, u);
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
               values<0, false, false, true>(u, u);
-              KOKKOS_IF_ON_DEVICE(__syncthreads();)
+              team_member.team_barrier();
 
               break;
             }

--- a/tests/cuda/cuda_evaluate_1d_shape.cc
+++ b/tests/cuda/cuda_evaluate_1d_shape.cc
@@ -20,7 +20,7 @@
 // much easier to check their correctness directly rather than from the results
 // in dependent functions
 
-#include "deal.II/base/memory_space.h"
+#include <deal.II/base/memory_space.h>
 
 #include <deal.II/lac/cuda_vector.h>
 #include <deal.II/lac/read_write_vector.h>

--- a/tests/cuda/cuda_evaluate_1d_shape.cc
+++ b/tests/cuda/cuda_evaluate_1d_shape.cc
@@ -20,6 +20,8 @@
 // much easier to check their correctness directly rather than from the results
 // in dependent functions
 
+#include "deal.II/base/memory_space.h"
+
 #include <deal.II/lac/cuda_vector.h>
 #include <deal.II/lac/read_write_vector.h>
 
@@ -32,14 +34,18 @@
 
 namespace CUDA = LinearAlgebra::CUDAWrappers;
 
+using TeamHandle = Kokkos::TeamPolicy<
+  MemorySpace::Default::kokkos_space::execution_space>::member_type;
+
 template <int M, int N, int type, bool add, bool dof_to_quad>
-__global__ void
+DEAL_II_HOST_DEVICE void
 evaluate_tensor_product(
+  const TeamHandle &                                         team_member,
   Kokkos::View<double *, MemorySpace::Default::kokkos_space> shape_values,
   Kokkos::View<double *, MemorySpace::Default::kokkos_space> shape_gradients,
   Kokkos::View<double *, MemorySpace::Default::kokkos_space> co_shape_gradients,
-  double *                                                   dst,
-  double *                                                   src)
+  Kokkos::View<double *, MemorySpace::Default::kokkos_space> dst,
+  Kokkos::View<double *, MemorySpace::Default::kokkos_space> src)
 {
   CUDAWrappers::internal::EvaluatorTensorProduct<
     CUDAWrappers::internal::evaluate_general,
@@ -47,7 +53,7 @@ evaluate_tensor_product(
     M - 1,
     N,
     double>
-    evaluator(shape_values, shape_gradients, co_shape_gradients);
+    evaluator(team_member, shape_values, shape_gradients, co_shape_gradients);
 
   if (type == 0)
     evaluator.template values<0, dof_to_quad, add, false>(src, dst);
@@ -81,25 +87,29 @@ test()
   if (type == 1 && M % 2 == 1 && N % 2 == 1)
     shape_host[M / 2 * N + N / 2] = 0.;
 
-  LinearAlgebra::ReadWriteVector<double> x_host(N), x_ref(N), y_host(M),
-    y_ref(M);
+  LinearAlgebra::ReadWriteVector<double> x_ref(N), y_ref(M);
+  Kokkos::View<double[N], MemorySpace::Default::kokkos_space> x_dev(
+    Kokkos::view_alloc("x_dev", Kokkos::WithoutInitializing));
+  Kokkos::View<double[M], MemorySpace::Default::kokkos_space> y_dev(
+    Kokkos::view_alloc("y_dev", Kokkos::WithoutInitializing));
+  auto x_host = Kokkos::create_mirror_view(x_dev);
+  auto y_host = Kokkos::create_mirror_view(y_dev);
+
   for (unsigned int i = 0; i < N; ++i)
-    x_host[i] = static_cast<double>(Testing::rand()) / RAND_MAX;
+    x_host(i) = static_cast<double>(Testing::rand()) / RAND_MAX;
 
   // Compute reference
   for (unsigned int i = 0; i < M; ++i)
     {
-      y_host[i] = 1.;
-      y_ref[i]  = add ? y_host[i] : 0.;
+      y_host(i) = 1.;
+      y_ref[i]  = add ? y_host(i) : 0.;
       for (unsigned int j = 0; j < N; ++j)
-        y_ref[i] += shape_host[i * N + j] * x_host[j];
+        y_ref[i] += shape_host[i * N + j] * x_host(j);
     }
 
   // Copy data to the GPU.
-  CUDA::Vector<double> x_dev(N), y_dev(M);
-  x_dev.import(x_host, VectorOperation::insert);
-  y_dev.import(y_host, VectorOperation::insert);
-
+  Kokkos::deep_copy(x_dev, x_host);
+  Kokkos::deep_copy(y_dev, y_host);
 
   Kokkos::View<double *, MemorySpace::Default::kokkos_space> shape_values(
     Kokkos::view_alloc("shape_values", Kokkos::WithoutInitializing),
@@ -122,49 +132,60 @@ test()
 
 
   // Launch the kernel
-  evaluate_tensor_product<M, N, type, add, false><<<1, M>>>(shape_values,
-                                                            shape_gradients,
-                                                            co_shape_gradients,
-                                                            y_dev.get_values(),
-                                                            x_dev.get_values());
+  MemorySpace::Default::kokkos_space::execution_space exec;
+  Kokkos::TeamPolicy<MemorySpace::Default::kokkos_space::execution_space>
+    team_policy(exec, 1, Kokkos::AUTO);
+  Kokkos::parallel_for(
+    team_policy, KOKKOS_LAMBDA(const TeamHandle &team_member) {
+      evaluate_tensor_product<M, N, type, add, false>(team_member,
+                                                      shape_values,
+                                                      shape_gradients,
+                                                      co_shape_gradients,
+                                                      y_dev,
+                                                      x_dev);
+    });
 
   // Check the results on the host
-  y_host.import(y_dev, VectorOperation::insert);
+  Kokkos::deep_copy(y_host, y_dev);
   deallog << "Errors no transpose: ";
   for (unsigned int i = 0; i < M; ++i)
-    deallog << y_host[i] - y_ref[i] << " ";
+    deallog << y_host(i) - y_ref[i] << " ";
   deallog << std::endl;
 
   for (unsigned int i = 0; i < M; ++i)
-    y_host[i] = static_cast<double>(Testing::rand()) / RAND_MAX;
+    y_host(i) = static_cast<double>(Testing::rand()) / RAND_MAX;
 
   // Copy y_host to the device
-  y_dev.import(y_host, VectorOperation::insert);
+  Kokkos::deep_copy(y_dev, y_host);
 
   // Compute reference
   for (unsigned int i = 0; i < N; ++i)
     {
-      x_host[i] = 2.;
-      x_ref[i]  = add ? x_host[i] : 0.;
+      x_host(i) = 2.;
+      x_ref[i]  = add ? x_host(i) : 0.;
       for (unsigned int j = 0; j < M; ++j)
-        x_ref[i] += shape_host[j * N + i] * y_host[j];
+        x_ref[i] += shape_host[j * N + i] * y_host(j);
     }
 
   // Copy x_host to the device
-  x_dev.import(x_host, VectorOperation::insert);
+  Kokkos::deep_copy(x_dev, x_host);
 
   // Launch the kernel
-  evaluate_tensor_product<M, N, type, add, true><<<1, M>>>(shape_values,
-                                                           shape_gradients,
-                                                           co_shape_gradients,
-                                                           x_dev.get_values(),
-                                                           y_dev.get_values());
+  Kokkos::parallel_for(
+    team_policy, KOKKOS_LAMBDA(const TeamHandle &team_member) {
+      evaluate_tensor_product<M, N, type, add, true>(team_member,
+                                                     shape_values,
+                                                     shape_gradients,
+                                                     co_shape_gradients,
+                                                     x_dev,
+                                                     y_dev);
+    });
 
   // Check the results on the host
-  x_host.import(x_dev, VectorOperation::insert);
+  Kokkos::deep_copy(x_host, x_dev);
   deallog << "Errors transpose:    ";
   for (unsigned int i = 0; i < N; ++i)
-    deallog << x_host[i] - x_ref[i] << " ";
+    deallog << x_host(i) - x_ref[i] << " ";
   deallog << std::endl;
 }
 

--- a/tests/cuda/cuda_evaluate_2d_shape.cc
+++ b/tests/cuda/cuda_evaluate_2d_shape.cc
@@ -32,14 +32,18 @@
 
 namespace CUDA = LinearAlgebra::CUDAWrappers;
 
+using TeamHandle = Kokkos::TeamPolicy<
+  MemorySpace::Default::kokkos_space::execution_space>::member_type;
+
 template <int M, int N, int type, bool add, bool dof_to_quad>
-__global__ void
+DEAL_II_HOST_DEVICE void
 evaluate_tensor_product(
+  const TeamHandle &                                         team_member,
   Kokkos::View<double *, MemorySpace::Default::kokkos_space> shape_values,
   Kokkos::View<double *, MemorySpace::Default::kokkos_space> shape_gradients,
   Kokkos::View<double *, MemorySpace::Default::kokkos_space> co_shape_gradients,
-  double *                                                   dst,
-  double *                                                   src)
+  Kokkos::View<double *, MemorySpace::Default::kokkos_space> dst,
+  Kokkos::View<double *, MemorySpace::Default::kokkos_space> src)
 {
   CUDAWrappers::internal::EvaluatorTensorProduct<
     CUDAWrappers::internal::evaluate_general,
@@ -47,18 +51,18 @@ evaluate_tensor_product(
     M - 1,
     N,
     double>
-    evaluator(shape_values, shape_gradients, co_shape_gradients);
+    evaluator(team_member, shape_values, shape_gradients, co_shape_gradients);
 
   if (type == 0)
     {
       evaluator.template values<0, dof_to_quad, false, false>(src, src);
-      __syncthreads();
+      team_member.team_barrier();
       evaluator.template values<1, dof_to_quad, add, false>(src, dst);
     }
   if (type == 1)
     {
       evaluator.template gradients<0, dof_to_quad, false, false>(src, src);
-      __syncthreads();
+      team_member.team_barrier();
       evaluator.template gradients<1, dof_to_quad, add, false>(src, dst);
     }
 }
@@ -91,10 +95,16 @@ test()
 
   constexpr int                          M_2d = M * M;
   constexpr int                          N_2d = N * N;
-  LinearAlgebra::ReadWriteVector<double> x_host(N_2d), x_ref(N_2d),
-    y_host(M_2d), y_ref(M_2d);
+  LinearAlgebra::ReadWriteVector<double> x_ref(N_2d), y_ref(M_2d);
+  Kokkos::View<double[N_2d], MemorySpace::Default::kokkos_space> x_dev(
+    Kokkos::view_alloc("x_dev", Kokkos::WithoutInitializing));
+  Kokkos::View<double[M_2d], MemorySpace::Default::kokkos_space> y_dev(
+    Kokkos::view_alloc("y_dev", Kokkos::WithoutInitializing));
+  auto x_host = Kokkos::create_mirror_view(x_dev);
+  auto y_host = Kokkos::create_mirror_view(y_dev);
+
   for (unsigned int i = 0; i < N_2d; ++i)
-    x_host[i] = static_cast<double>(Testing::rand()) / RAND_MAX;
+    x_host(i) = static_cast<double>(Testing::rand()) / RAND_MAX;
 
   FullMatrix<double> shape_2d(M_2d, N_2d);
   for (unsigned int i = 0; i < M; ++i)
@@ -112,16 +122,15 @@ test()
   // Compute reference
   for (unsigned int i = 0; i < M_2d; ++i)
     {
-      y_host[i] = 1.;
-      y_ref[i]  = add ? y_host[i] : 0.;
+      y_host(i) = 1.;
+      y_ref[i]  = add ? y_host(i) : 0.;
       for (unsigned int j = 0; j < N_2d; ++j)
-        y_ref[i] += shape_2d(i, j) * x_host[j];
+        y_ref[i] += shape_2d(i, j) * x_host(j);
     }
 
   // Copy data to the GPU.
-  CUDA::Vector<double> x_dev(N_2d), y_dev(M_2d);
-  x_dev.import(x_host, VectorOperation::insert);
-  y_dev.import(y_host, VectorOperation::insert);
+  Kokkos::deep_copy(x_dev, x_host);
+  Kokkos::deep_copy(y_dev, y_host);
 
 
   Kokkos::View<double *, MemorySpace::Default::kokkos_space> shape_values(
@@ -144,53 +153,61 @@ test()
   Kokkos::deep_copy(co_shape_gradients, shape_host_view);
 
   // Launch the kernel
-  dim3 block_dim(M, N);
-  evaluate_tensor_product<M, N, type, add, false>
-    <<<1, block_dim>>>(shape_values,
-                       shape_gradients,
-                       co_shape_gradients,
-                       y_dev.get_values(),
-                       x_dev.get_values());
+  MemorySpace::Default::kokkos_space::execution_space exec;
+  Kokkos::TeamPolicy<MemorySpace::Default::kokkos_space::execution_space>
+    team_policy(exec, 1, Kokkos::AUTO);
+  Kokkos::parallel_for(
+    team_policy, KOKKOS_LAMBDA(const TeamHandle &team_member) {
+      evaluate_tensor_product<M, N, type, add, false>(team_member,
+                                                      shape_values,
+                                                      shape_gradients,
+                                                      co_shape_gradients,
+                                                      y_dev,
+                                                      x_dev);
+    });
 
   // Check the results on the host
-  y_host.import(y_dev, VectorOperation::insert);
+  Kokkos::deep_copy(y_host, y_dev);
   deallog << "Errors no transpose: ";
 
   for (unsigned int i = 0; i < M_2d; ++i)
-    deallog << y_host[i] - y_ref[i] << " ";
+    deallog << y_host(i) - y_ref[i] << " ";
   deallog << std::endl;
 
   for (unsigned int i = 0; i < M_2d; ++i)
-    y_host[i] = static_cast<double>(Testing::rand()) / RAND_MAX;
+    y_host(i) = static_cast<double>(Testing::rand()) / RAND_MAX;
 
   // Copy y_host to the device
-  y_dev.import(y_host, VectorOperation::insert);
+  Kokkos::deep_copy(y_dev, y_host);
 
   // Compute reference
   for (unsigned int i = 0; i < N_2d; ++i)
     {
-      x_host[i] = 2.;
-      x_ref[i]  = add ? x_host[i] : 0.;
+      x_host(i) = 2.;
+      x_ref[i]  = add ? x_host(i) : 0.;
       for (unsigned int j = 0; j < M_2d; ++j)
-        x_ref[i] += shape_2d(j, i) * y_host[j];
+        x_ref[i] += shape_2d(j, i) * y_host(j);
     }
 
   // Copy x_host to the device
-  x_dev.import(x_host, VectorOperation::insert);
+  Kokkos::deep_copy(x_dev, x_host);
 
   // Launch the kernel
-  evaluate_tensor_product<M, N, type, add, true>
-    <<<1, block_dim>>>(shape_values,
-                       shape_gradients,
-                       co_shape_gradients,
-                       x_dev.get_values(),
-                       y_dev.get_values());
+  Kokkos::parallel_for(
+    team_policy, KOKKOS_LAMBDA(const TeamHandle &team_member) {
+      evaluate_tensor_product<M, N, type, add, true>(team_member,
+                                                     shape_values,
+                                                     shape_gradients,
+                                                     co_shape_gradients,
+                                                     x_dev,
+                                                     y_dev);
+    });
 
   // Check the results on the host
-  x_host.import(x_dev, VectorOperation::insert);
+  Kokkos::deep_copy(x_host, x_dev);
   deallog << "Errors transpose:    ";
   for (unsigned int i = 0; i < N_2d; ++i)
-    deallog << x_host[i] - x_ref[i] << " ";
+    deallog << x_host(i) - x_ref[i] << " ";
   deallog << std::endl;
 }
 

--- a/tests/cuda/matrix_free_matrix_vector_03.cc
+++ b/tests/cuda/matrix_free_matrix_vector_03.cc
@@ -41,7 +41,6 @@ test()
   tria.begin(tria.n_levels() - 1)->set_refine_flag();
   tria.last()->set_refine_flag();
   tria.execute_coarsening_and_refinement();
-  cell = tria.begin_active();
   for (unsigned int i = 0; i < 10 - 3 * dim; ++i)
     {
       cell                 = tria.begin_active();


### PR DESCRIPTION
This PR uses Kokkos to launch the kernels in CUDAWrappers::MatrixFree. Since we need the threads in a warp to work together, we need to use `Kokkos::TeamPolicy` and `Kokkos::TeamThreadRange`. This also allows us to use scratch memory. The biggest issue with this PR is that the new code is not backward compatible. The main reason is that we took advantage of `threadIdx.*` and `blockIdx.*` to compute indices. This is not allowed anymore and we now need to pass the indices to the functions. So we have an extra argument to several functions. 