### PR TITLE
Updates Ginkgo solver wrappers

### DIFF
--- a/cmake/modules/FindDEAL_II_GINKGO.cmake
+++ b/cmake/modules/FindDEAL_II_GINKGO.cmake
@@ -56,15 +56,15 @@ foreach(_library ginkgo ${GINKGO_INTERFACE_LINK_LIBRARIES})
   if(_library MATCHES "ginkgo.*")
     list(APPEND _libraries GINKGO_LIBRARY_${_library})
     deal_ii_find_library(GINKGO_LIBRARY_${_library}
-      NAMES ${_library}
-      HINTS ${GINKGO_INSTALL_LIBRARY_DIR}
-      NO_DEFAULT_PATH
-      NO_CMAKE_ENVIRONMENT_PATH
-      NO_CMAKE_PATH
-      NO_SYSTEM_ENVIRONMENT_PATH
-      NO_CMAKE_SYSTEM_PATH
-      NO_CMAKE_FIND_ROOT_PATH
-      )
+        NAMES ${_library} ${_library}d
+        HINTS ${GINKGO_INSTALL_LIBRARY_DIR}
+        NO_DEFAULT_PATH
+        NO_CMAKE_ENVIRONMENT_PATH
+        NO_CMAKE_PATH
+        NO_SYSTEM_ENVIRONMENT_PATH
+        NO_CMAKE_SYSTEM_PATH
+        NO_CMAKE_FIND_ROOT_PATH
+        )
   endif()
 endforeach()
 

--- a/include/deal.II/lac/ginkgo_preconditioner.h
+++ b/include/deal.II/lac/ginkgo_preconditioner.h
@@ -1,0 +1,103 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 - 2023 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_ginkgo_preconditioner_h
+#define dealii_ginkgo_preconditioner_h
+
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_GINKGO
+
+#  include <deal.II/base/subscriptor.h>
+
+#  include <deal.II/lac/ginkgo_sparse_matrix.h>
+#  include <deal.II/lac/ginkgo_vector.h>
+
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace GinkgoWrappers
+{
+  template <typename ValueType, typename IndexType = int32_t>
+  class PreconditionBase : public Subscriptor
+  {
+  public:
+    PreconditionBase(const AbstractMatrix<ValueType, IndexType> &A,
+                     std::shared_ptr<gko::LinOpFactory>          factory);
+
+    std::shared_ptr<const gko::LinOp>
+    get_shared_gko_object() const;
+
+    void
+    vmult(Vector<ValueType> &u, const Vector<ValueType> &v);
+
+  protected:
+    PreconditionBase() = default;
+
+  private:
+    std::shared_ptr<gko::LinOp> preconditioner_;
+  };
+
+
+  namespace detail
+  {
+    struct AdditionalRelaxationData
+    {
+      double       relaxation   = 1.0;
+      unsigned int n_iterations = 1;
+    };
+  } // namespace detail
+
+
+  template <typename ValueType, typename IndexType = int32_t>
+  class PreconditionIdentity : public PreconditionBase<ValueType, IndexType>
+  {
+  public:
+    struct AdditionalData
+    {};
+
+    explicit PreconditionIdentity(const AdditionalData & = {});
+  };
+
+
+  template <typename ValueType, typename IndexType = int32_t>
+  class PreconditionJacobi : public PreconditionBase<ValueType, IndexType>
+  {
+  public:
+    struct AdditionalData : detail::AdditionalRelaxationData
+    {
+      AdditionalData() = default;
+      AdditionalData(double       relaxation,
+                     unsigned int n_iterations,
+                     unsigned int max_block_size)
+        : detail::AdditionalRelaxationData{relaxation, n_iterations}
+        , max_block_size(max_block_size)
+      {}
+
+      unsigned int max_block_size = 32;
+    };
+
+    explicit PreconditionJacobi(const Csr<ValueType, IndexType> &A,
+                                const AdditionalData &           data = {});
+  };
+
+} // namespace GinkgoWrappers
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif
+
+#endif // dealii_ginkgo_preconditioner_h

--- a/include/deal.II/lac/ginkgo_sparse_matrix.h
+++ b/include/deal.II/lac/ginkgo_sparse_matrix.h
@@ -1,0 +1,350 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 - 2023 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_ginkgo_sparse_matrix_h
+#define dealii_ginkgo_sparse_matrix_h
+
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_GINKGO
+
+#  include <deal.II/base/index_set.h>
+#  include <deal.II/base/std_cxx17/variant.h>
+#  include <deal.II/base/subscriptor.h>
+
+#  include <deal.II/lac/ginkgo_vector.h>
+#  include <deal.II/lac/sparse_matrix.h>
+
+#  include <ginkgo/core/matrix/coo.hpp>
+#  include <ginkgo/core/matrix/csr.hpp>
+#  include <ginkgo/core/matrix/ell.hpp>
+#  include <ginkgo/core/matrix/fbcsr.hpp>
+#  include <ginkgo/core/matrix/hybrid.hpp>
+#  include <ginkgo/core/matrix/sellp.hpp>
+
+#  include <iomanip>
+#  include <ios>
+#  include <memory>
+
+#  include "full_matrix.h"
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace GinkgoWrappers
+{
+  template <typename Number, typename IndexType = gko::int32>
+  class AbstractMatrix : public Subscriptor
+  {
+  public:
+    using value_type  = Number;
+    using real_type   = typename numbers::NumberTraits<Number>::real_type;
+    using size_type   = types::global_dof_index;
+    using ginkgo_type = gko::LinOp;
+
+    AbstractMatrix() = delete;
+
+    AbstractMatrix(const AbstractMatrix &) = delete;
+    AbstractMatrix(AbstractMatrix &&m) noexcept;
+
+    AbstractMatrix &
+    operator=(const AbstractMatrix &) = delete;
+    AbstractMatrix &
+    operator=(AbstractMatrix &&m) noexcept(false);
+
+    size_type
+    m() const;
+    size_type
+    n() const;
+
+    template <typename OtherNumber>
+    void
+    vmult(Vector<OtherNumber> &u, const Vector<OtherNumber> &v) const;
+
+    template <typename OtherNumber>
+    void
+    vmult_add(Vector<OtherNumber> &u, const Vector<OtherNumber> &v) const;
+
+    /**
+     * @note Since there is no native Ginkgo support for this, this creates a temporary transpose.
+     */
+    template <typename OtherNumber>
+    void
+    Tvmult(Vector<OtherNumber> &u, const Vector<OtherNumber> &v) const;
+
+    /**
+     * @note Since there is no native Ginkgo support for this, this creates a temporary transpose.
+     */
+    template <typename OtherNumber>
+    void
+    Tvmult_add(Vector<OtherNumber> &u, const Vector<OtherNumber> &v) const;
+
+    void
+    set(const size_type i, const size_type j, const Number value);
+
+    /**
+     * @note Since there is no native Ginkgo support for this, this results in repeated calls to set(const size_type, const_size_type, const Number).
+     */
+    void
+    set(const std::vector<size_type> &indices,
+        const FullMatrix<Number> &    full_matrix,
+        const bool                    elide_zero_values = false);
+
+    /**
+     * @note Since there is no native Ginkgo support for this, this results in repeated calls to set(const size_type, const_size_type, const Number).
+     */
+    void
+    set(const std::vector<size_type> &row_indices,
+        const std::vector<size_type> &col_indices,
+        const FullMatrix<Number> &    full_matrix,
+        const bool                    elide_zero_values = false);
+
+    /**
+     * @note Since there is no native Ginkgo support for this, this results in repeated calls to set(const size_type, const_size_type, const Number).
+     */
+    void
+    set(const size_type               row,
+        const std::vector<size_type> &col_indices,
+        const std::vector<Number> &   values,
+        const bool                    elide_zero_values = false);
+
+    /**
+     * @note Since there is no native Ginkgo support for this, this results in repeated calls to set(const size_type, const_size_type, const Number).
+     */
+    void
+    set(const size_type  row,
+        const size_type  n_cols,
+        const size_type *col_indices,
+        const Number *   values,
+        const bool       elide_zero_values = false);
+
+    void
+    add(const size_type i, const size_type j, const Number value);
+
+    /**
+     * @note Since there is no native Ginkgo support for this, this results in repeated calls to add(const size_type, const_size_type, const Number).
+     */
+    void
+    add(const std::vector<size_type> &indices,
+        const FullMatrix<Number> &    full_matrix,
+        const bool                    elide_zero_values = true);
+
+    /**
+     * @note Since there is no native Ginkgo support for this, this results in repeated calls to add(const size_type, const_size_type, const Number).
+     */
+    void
+    add(const std::vector<size_type> &row_indices,
+        const std::vector<size_type> &col_indices,
+        const FullMatrix<Number> &    full_matrix,
+        const bool                    elide_zero_values = true);
+
+    /**
+     * @note Since there is no native Ginkgo support for this, this results in repeated calls to add(const size_type, const_size_type, const Number).
+     */
+    void
+    add(const size_type               row,
+        const std::vector<size_type> &col_indices,
+        const std::vector<Number> &   values,
+        const bool                    elide_zero_values = true);
+
+    /**
+     * @note Since there is no native Ginkgo support for this, this results in repeated calls to add(const size_type, const_size_type, const Number).
+     */
+    void
+    add(const size_type  row,
+        const size_type  n_cols,
+        const size_type *col_indices,
+        const Number *   values,
+        const bool       elide_zero_values      = true,
+        const bool       col_indices_are_sorted = false);
+
+    virtual void
+    compress(
+      const VectorOperation::values operation = VectorOperation::insert) = 0;
+
+    const ginkgo_type *
+    get_gko_object() const;
+
+    std::shared_ptr<const ginkgo_type>
+    get_shared_gko_object() const;
+
+  protected:
+    AbstractMatrix(std::shared_ptr<const gko::Executor> exec,
+                   const size_type                      m,
+                   const size_type                      n);
+
+    AbstractMatrix(std::unique_ptr<ginkgo_type> M);
+
+    std::shared_ptr<const gko::Executor> exec_;
+
+    using assembly   = gko::matrix_assembly_data<Number, IndexType>;
+    using matrix_ptr = std::shared_ptr<ginkgo_type>;
+    std_cxx17::variant<assembly, matrix_ptr> data_;
+  };
+
+
+  template <typename Number,
+            typename IndexType,
+            template <typename, typename>
+            class GinkgoType>
+  class Matrix : public AbstractMatrix<Number, IndexType>
+  {
+    using Base = AbstractMatrix<Number, IndexType>;
+
+  public:
+    using value_type  = typename Base::value_type;
+    using real_type   = typename Base::real_type;
+    using size_type   = typename Base::size_type;
+    using ginkgo_type = GinkgoType<Number, IndexType>;
+
+    Matrix(std::shared_ptr<const gko::Executor> exec,
+           const size_type                      m,
+           const size_type                      n);
+    Matrix(std::unique_ptr<ginkgo_type> M);
+
+    const ginkgo_type *
+    get_gko_object() const
+    {
+      return static_cast<const ginkgo_type *>(Base::get_gko_object());
+    }
+
+    std::shared_ptr<const ginkgo_type>
+    get_shared_gko_object() const
+    {
+      return std::dynamic_pointer_cast<const ginkgo_type>(
+        Base::get_shared_gko_object());
+    }
+
+    void
+    compress(const VectorOperation::values operation =
+               VectorOperation::insert) override;
+  };
+
+  template <typename Number, typename IndexType = gko::int32>
+  class Csr : public Matrix<Number, IndexType, gko::matrix::Csr>
+  {
+    using Base = Matrix<Number, IndexType, gko::matrix::Csr>;
+
+  public:
+    using value_type  = typename Base::value_type;
+    using real_type   = typename Base::real_type;
+    using size_type   = typename Base::size_type;
+    using ginkgo_type = typename Base::ginkgo_type;
+
+    using Base::Base;
+
+    Csr(std::shared_ptr<const gko::Executor> exec,
+        const SparseMatrix<Number> &         other);
+  };
+
+  template <typename Number, typename IndexType = gko::int32>
+  using Coo = Matrix<Number, IndexType, gko::matrix::Coo>;
+
+  template <typename Number, typename IndexType = gko::int32>
+  using Ell = Matrix<Number, IndexType, gko::matrix::Ell>;
+
+  //  template<typename Number, typename IndexType = gko::int32>
+  //  using Fbcsr = Matrix<Number, IndexType, gko::matrix::Fbcsr>;
+
+  template <typename Number, typename IndexType = gko::int32>
+  using Hybrid = Matrix<Number, IndexType, gko::matrix::Hybrid>;
+
+  template <typename Number, typename IndexType = gko::int32>
+  using Sellp = Matrix<Number, IndexType, gko::matrix::Sellp>;
+
+
+  template <typename Number, typename IndexType>
+  typename AbstractMatrix<Number, IndexType>::size_type
+  AbstractMatrix<Number, IndexType>::m() const
+  {
+    if (std_cxx17::holds_alternative<assembly>(data_))
+      {
+        return std_cxx17::get<assembly>(data_).get_size()[0];
+      }
+    else
+      {
+        return std_cxx17::get<matrix_ptr>(data_)->get_size()[0];
+      }
+  }
+
+  template <typename Number, typename IndexType>
+  typename AbstractMatrix<Number, IndexType>::size_type
+  AbstractMatrix<Number, IndexType>::n() const
+  {
+    if (std_cxx17::holds_alternative<assembly>(data_))
+      {
+        return std_cxx17::get<assembly>(data_).get_size()[1];
+      }
+    else
+      {
+        return std_cxx17::get<matrix_ptr>(data_)->get_size()[1];
+      }
+  }
+
+  template <typename Number, typename IndexType>
+  template <typename OtherNumber>
+  void
+  AbstractMatrix<Number, IndexType>::vmult_add(
+    Vector<OtherNumber> &      u,
+    const Vector<OtherNumber> &v) const
+  {
+    auto one = gko::initialize<gko::matrix::Dense<Number>>({1.0}, exec_);
+    std_cxx17::get<matrix_ptr>(data_)->apply(one.get(),
+                                             v.get_gko_object(),
+                                             one.get(),
+                                             u.get_gko_object());
+  }
+
+  template <typename Number, typename IndexType>
+  template <typename OtherNumber>
+  void
+  AbstractMatrix<Number, IndexType>::vmult(Vector<OtherNumber> &      u,
+                                           const Vector<OtherNumber> &v) const
+  {
+    std_cxx17::get<matrix_ptr>(data_)->apply(v.get_gko_object(),
+                                             u.get_gko_object());
+  }
+
+  template <typename Number, typename IndexType>
+  template <typename OtherNumber>
+  void
+  AbstractMatrix<Number, IndexType>::Tvmult_add(
+    Vector<OtherNumber> &      u,
+    const Vector<OtherNumber> &v) const
+  {
+    auto one = gko::initialize<gko::matrix::Dense<Number>>({1.0}, exec_);
+    gko::as<gko::Transposable>(std_cxx17::get<matrix_ptr>(data_))
+      ->transpose()
+      ->apply(one.get(), v.get_gko_object(), one.get(), u.get_gko_object());
+  }
+
+  template <typename Number, typename IndexType>
+  template <typename OtherNumber>
+  void
+  AbstractMatrix<Number, IndexType>::Tvmult(Vector<OtherNumber> &      u,
+                                            const Vector<OtherNumber> &v) const
+  {
+    gko::as<gko::Transposable>(std_cxx17::get<matrix_ptr>(data_))
+      ->transpose()
+      ->apply(v.get_gko_object(), u.get_gko_object());
+  }
+
+} // namespace GinkgoWrappers
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif
+
+#endif // dealii_ginkgo_sparse_matrix_h

--- a/include/deal.II/lac/ginkgo_vector.h
+++ b/include/deal.II/lac/ginkgo_vector.h
@@ -1,0 +1,534 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 - 2023 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_ginkgo_vector_h
+#define dealii_ginkgo_vector_h
+
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_GINKGO
+
+#  include <deal.II/base/index_set.h>
+#  include <deal.II/base/subscriptor.h>
+
+#  include <deal.II/lac/la_vector.h>
+#  include <deal.II/lac/vector.h>
+
+#  include <ginkgo/core/base/version.hpp>
+#  include <ginkgo/core/matrix/dense.hpp>
+
+#  include <iomanip>
+#  include <ios>
+#  include <memory>
+
+
+DEAL_II_NAMESPACE_OPEN
+
+
+/**
+ * A namespace in which wrapper classes for Ginkgo objects reside.
+ *
+ * @ingroup GinkgoWrappers
+ */
+namespace GinkgoWrappers
+{
+  /**
+   * Class wrapping a gko::matrix::Dense (multi) vector. This class implements
+   * most of the methods common to other vector types, so it can be used as a
+   * drop-in replacement.
+   * @tparam Number The numerical data type. Both real and complex types are supported
+   * @ingroup Vectors
+   */
+  template <typename Number>
+  class Vector : public Subscriptor
+  {
+  public:
+    using value_type       = Number;
+    using real_type        = typename numbers::NumberTraits<Number>::real_type;
+    using iterator         = value_type *;
+    using const_iterator   = const value_type *;
+    using size_type        = types::global_dof_index;
+    using ginkgo_type      = gko::matrix::Dense<Number>;
+    using ginkgo_norm_type = typename ginkgo_type::absolute_type;
+
+    // Disable default constructor, because we always need to know the executor.
+    Vector() = delete;
+
+    /**
+     * Creates an empty vector on the given executor @p exec.
+     */
+    Vector(std::shared_ptr<const gko::Executor> exec);
+
+    /**
+     * Directly wraps an Ginkgo vector.
+     */
+    Vector(std::unique_ptr<ginkgo_type> v);
+
+    /**
+     * Creates a vector of size @p size on the executor @p exec.
+     */
+    explicit Vector(std::shared_ptr<const gko::Executor> exec,
+                    const size_type                      size);
+
+
+    /**
+     * Creates a vector on the executor @p exec and initializes
+     * it with the values of @p list
+     */
+    explicit Vector(std::shared_ptr<const gko::Executor> exec,
+                    const std::initializer_list<Number> &list);
+
+    /**
+     * Copy constructor.
+     */
+    Vector(const Vector &other);
+
+    /**
+     * Move constructor.
+     */
+    Vector(Vector &&other) noexcept;
+
+    /**
+     * Creates a vector with the same size and executor as @p V. If
+     * @p omit_zeroing_entries is false, then all elements of the vector
+     * are set to zero.
+     */
+    static Vector
+    create_with_same_size(const Vector &V,
+                          const bool    omit_zeroing_entries = false);
+
+    /**
+     * Copy assignment.
+     * @note The executor of this is not changed. If other has a
+     *       different executor, then the data copied between the
+     *       executors accordingly.
+     */
+    Vector &
+    operator=(const Vector &other);
+
+    /**
+     * Move assignment. Copies in case of different executors.
+     * @note The executor of this is not changed. If other has a
+     *       different executor, then the data copied between the
+     *       executors accordingly.
+     */
+    Vector &
+    operator=(Vector &&other) noexcept(false);
+
+    /**
+     * Creates a vector that is a view on a
+     * dealii::LinearAlgebra::ReadWriteVector.
+     */
+    static std::unique_ptr<Vector>
+    create_view(std::shared_ptr<const gko::Executor>              exec,
+                ::dealii::LinearAlgebra::ReadWriteVector<Number> &other);
+
+
+    /**
+     * Creates a vector that is a view on a
+     * dealii::LinearAlgebra::ReadWriteVector.
+     */
+    static std::unique_ptr<Vector>
+    create_view(std::shared_ptr<const gko::Executor> exec,
+                ::dealii::Vector<Number> &           other);
+
+
+    /**
+     * Creates a constant vector that is a view on a constant
+     * dealii::LinearAlgebra::ReadWriteVector.
+     */
+    static std::unique_ptr<const Vector>
+    create_view(std::shared_ptr<const gko::Executor>                    exec,
+                const ::dealii::LinearAlgebra::ReadWriteVector<Number> &other);
+
+    /**
+     * Creates a constant vector that is a view on a constant
+     * dealii::LinearAlgebra::ReadWriteVector.
+     */
+    static std::unique_ptr<const Vector>
+    create_view(std::shared_ptr<const gko::Executor> exec,
+                const ::dealii::Vector<Number> &     other);
+
+    /**
+     * Returns iterator to the begin of the stored data.
+     * @warning Depending on the executor, this might be a pointer to device memory.
+     */
+    iterator
+    begin() noexcept;
+
+    /**
+     * Returns constant iterator to the begin of the stored data.
+     * @warning Depending on the executor, this might be a pointer to device memory.
+     */
+    const_iterator
+    begin() const noexcept;
+
+    /**
+     * Returns iterator to the end of the stored data.
+     * @warning Depending on the executor, this might be a pointer to device memory.
+     */
+    iterator
+    end() noexcept;
+
+    /**
+     * Returns constant iterator to the end of the stored data.
+     * @warning Depending on the executor, this might be a pointer to device memory.
+     */
+    const_iterator
+    end() const noexcept;
+
+
+    /**
+     * Access the element @p i of the vector.
+     * @warning Depending on the executor, this might access device memory.
+     */
+    Number
+    operator()(const size_type i) const noexcept;
+
+    /**
+     * Mutable access the element @p i of the vector.
+     * @warning Depending on the executor, this might access device memory.
+     */
+    Number &
+    operator()(const size_type i) noexcept;
+
+    // @copydoc operator()(const size_type) const
+    Number
+    operator[](const size_type i) const noexcept;
+
+    // @copydoc operator()(const size_type)
+    Number &
+    operator[](const size_type i) noexcept;
+
+    /**
+     * Returns the size of the vector.
+     */
+    size_type
+    size() const noexcept;
+
+    /**
+     * Returns the index set [0, size()). Necessary for compatability
+     * with other vector types.
+     */
+    IndexSet
+    locally_owned_elements() const;
+
+    std::unique_ptr<const ginkgo_type>
+    get_gko_object() const noexcept;
+
+    std::unique_ptr<ginkgo_type>
+    get_gko_object() noexcept;
+
+    Vector &
+    operator=(const Number s);
+
+    /**
+     * Multiplies all elements with the value @p factor.
+     */
+    Vector &
+    operator*=(const Number factor);
+
+    /**
+     * Divides all elements with the value @p factor.
+     */
+    Vector &
+    operator/=(const Number factor);
+
+    /**
+     * Adds the vector @p V to this.
+     */
+    Vector &
+    operator+=(const Vector &V);
+
+    /**
+     * Subtracts the vector @p V from this.
+     */
+    Vector &
+    operator-=(const Vector &V);
+
+    /**
+     * Returns the scalar product between this and @p V. For complex types, @p V is conjugated.
+     */
+    Number
+    operator*(const Vector &V) const;
+
+    /**
+     * Adds @p a to all elements of this.
+     * @note ince there is no native Ginkgo support for this, this uses a fill and an add operation
+     */
+    void
+    add(const Number a);
+
+    /**
+     * Computes the axpy operation `*this = *this + a * V`.
+     */
+    void
+    add(const Number a, const Vector &V);
+
+    /**
+     * Computes the operation `*this = *this + a * V + b * W`.
+     * @note Since there is no native Ginkgo support for this, this uses a copy and two add operations
+     */
+    void
+    add(const Number a, const Vector &V, const Number b, const Vector &W);
+
+    /**
+     * @copydoc add(coconst size_type , const size_type *, const Number *)
+     */
+    void
+    add(const std::vector<size_type> &indices,
+        const dealii::Vector<Number> &values);
+
+    /**
+     * @copydoc add(coconst size_type , const size_type *, const Number *)
+     */
+    void
+    add(std::vector<unsigned int> &indices, std::vector<Number> &values);
+
+    /**
+     * Adds the values from @p values to the elements at indices @p indices, i. e.
+     * `*this[indices[i]] += values[i]`.
+     * @note Since there is no native Ginkgo support for this, this might involve copies
+     *       between host and device memory.
+     */
+    void
+    add(const size_type  n_elements,
+        const size_type *indices,
+        const Number *   values);
+
+
+    /**
+     * Computes the operation `*this = s * (*this) + a * V`.
+     * @note Since there is no native Ginkgo support for this, this uses a scale and add operation.
+     */
+    void
+    sadd(const Number s, const Number a, const Vector &V);
+
+    /**
+     * Scales the elements componentwise with the values in @p scaling_factors.
+     */
+    void
+    scale(const Vector &scaling_factors);
+
+    /**
+     * Computes the operation `*this = a * V`
+     * @note Since there is no native Ginkgo support for this, this uses a copy and a scale operation.
+     */
+    void
+    equ(const Number a, const Vector &V);
+
+    /**
+     * Checks if all values of the vector are zero.
+     * @note Since there is no native Ginkgo support for this, this computes the L1 norm and compares against 100 * minimal_number
+     */
+    bool
+    all_zero() const;
+
+    /**
+     * @warning Not implemented
+     */
+    Number
+    mean_value() const;
+
+    /**
+     * Returns the l1 norm of this vector.
+     */
+    real_type
+    l1_norm() const;
+
+    /**
+     * Returns the l2 norm of this vector.
+     * @return
+     */
+    real_type
+    l2_norm() const;
+
+    /**
+     * @warning Not implemented
+     */
+    real_type
+    linfty_norm() const;
+
+    /**
+     * Returns the result of scalar product `<*this + a * V, W>`
+     * @note Since there is no native Ginkgo support for this, this uses an add and a scalar product operation
+     */
+    Number
+    add_and_dot(const Number a, const Vector &V, const Vector &W);
+
+    /**
+     * Prints the vector to the stream @p out. The parameter @p accross is ignored, it
+     * will always print the vector using the matrix market format.
+     */
+    void
+    print(std::ostream & out,
+          const unsigned precision  = 3,
+          const bool     scientific = true,
+          const bool     accross    = true);
+
+    /**
+     * The memory consumption in bytes.
+     */
+    std::size_t
+    memory_consumption() const;
+
+    /**
+     * No-op, only necessary for compatibility.
+     */
+    void
+    compress(const VectorOperation::values = VectorOperation::insert) const
+    {}
+
+    /**
+     * No-op, only necessary for compatibility.
+     */
+    bool
+    has_ghost_elements() const
+    {
+      return false;
+    }
+
+    /**
+     * Copies the elements at the indices @p indices to the vector @p values.
+     */
+    template <typename Number2>
+    void
+    extract_subvector_to(const std::vector<size_type> &indices,
+                         std::vector<Number2> &        values) const;
+
+    /**
+     * Copies the element at the indices defined in the range @p indices_begin,
+     * @p indices_end to the output iterator @p values_begin
+     */
+    template <typename ForwardIterator, typename OutputIterator>
+    void
+    extract_subvector_to(ForwardIterator       indices_begin,
+                         const ForwardIterator indices_end,
+                         OutputIterator        values_begin) const;
+
+    /**
+     * Checks if the index @p index is within the local range ([0, size())) of this vector.
+     */
+    bool
+    in_local_range(const size_type index) const;
+
+  private:
+    std::unique_ptr<ginkgo_type> data_;
+  };
+
+  template <typename Number>
+  typename Vector<Number>::iterator
+  Vector<Number>::begin() noexcept
+  {
+    return data_->get_values();
+  }
+
+  template <typename Number>
+  typename Vector<Number>::const_iterator
+  Vector<Number>::begin() const noexcept
+  {
+    return data_->get_const_values();
+  }
+
+
+  template <typename Number>
+  typename Vector<Number>::iterator
+  Vector<Number>::end() noexcept
+  {
+    return data_->get_values() + size();
+  }
+
+  template <typename Number>
+  typename Vector<Number>::const_iterator
+  Vector<Number>::end() const noexcept
+  {
+    return data_->get_const_values() + size();
+  }
+
+  template <typename Number>
+  Number
+  Vector<Number>::operator()(const size_type i) const noexcept
+  {
+    return data_->at(i);
+  }
+
+  template <typename Number>
+  Number &
+  Vector<Number>::operator()(const size_type i) noexcept
+  {
+    return data_->at(i);
+  }
+
+  template <typename Number>
+  Number
+  Vector<Number>::operator[](const size_type i) const noexcept
+  {
+    return data_->at(i);
+  }
+
+  template <typename Number>
+  Number &
+  Vector<Number>::operator[](const size_type i) noexcept
+  {
+    return data_->at(i);
+  }
+
+  template <typename Number>
+  typename Vector<Number>::size_type
+  Vector<Number>::size() const noexcept
+  {
+    return data_->get_size()[0];
+  }
+
+  template <typename Number>
+  template <typename ForwardIterator, typename OutputIterator>
+  void
+  Vector<Number>::extract_subvector_to(ForwardIterator       indices_begin,
+                                       const ForwardIterator indices_end,
+                                       OutputIterator        values_begin) const
+  {
+    auto host_data =
+      gko::make_temporary_clone(data_->get_executor()->get_master(), data_);
+    for (auto it = indices_begin; it != indices_end; ++it, ++values_begin)
+      {
+        *values_begin = host_data->get_const_values()[*it];
+      }
+  }
+
+  template <typename Number>
+  template <typename Number2>
+  void
+  Vector<Number>::extract_subvector_to(const std::vector<size_type> &indices,
+                                       std::vector<Number2> &values) const
+  {
+    extract_subvector_to(indices.begin(), indices.end(), values.begin());
+  }
+} // namespace GinkgoWrappers
+
+/**
+ * Declare dealii::GinkgoWrappers::Vector< Number > as serial vector.
+ *
+ * @relatesalso Vector
+ */
+template <typename Number>
+struct is_serial_vector<GinkgoWrappers::Vector<Number>> : std::true_type
+{};
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif
+
+#endif // dealii_ginkgo_vector_h

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -91,6 +91,14 @@ namespace LinearAlgebra
   }
 } // namespace LinearAlgebra
 #  endif
+
+#  ifdef DEAL_II_WITH_GINKGO
+namespace GinkgoWrappers
+{
+  template <typename Number>
+  class Vector;
+}
+#  endif
 #endif
 
 namespace LinearAlgebra
@@ -498,6 +506,15 @@ namespace LinearAlgebra
     {
       import_elements(V, operation, communication_pattern);
     }
+#endif
+
+
+#ifdef DEAL_II_WITH_GINKGO
+    void
+    import(const GinkgoWrappers::Vector<Number> &ginkgo_vec,
+           VectorOperation::values               operation,
+           const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
+             & = {});
 #endif
 
     /**

--- a/source/lac/CMakeLists.txt
+++ b/source/lac/CMakeLists.txt
@@ -125,9 +125,10 @@ endif()
 
 if(DEAL_II_WITH_GINKGO)
   set(_unity_include_src
-    ${_unity_include_src}
-    ginkgo_solver.cc
-  )
+      ${_unity_include_src}
+      ginkgo_solver.cc
+      ginkgo_vector.cc
+      )
 endif()
 
 # Also add Trilinos wrapper files

--- a/source/lac/CMakeLists.txt
+++ b/source/lac/CMakeLists.txt
@@ -129,6 +129,7 @@ if(DEAL_II_WITH_GINKGO)
       ginkgo_solver.cc
       ginkgo_vector.cc
       ginkgo_sparse_matrix.cc
+      ginkgo_preconditioner.cc
       )
 endif()
 

--- a/source/lac/CMakeLists.txt
+++ b/source/lac/CMakeLists.txt
@@ -128,6 +128,7 @@ if(DEAL_II_WITH_GINKGO)
       ${_unity_include_src}
       ginkgo_solver.cc
       ginkgo_vector.cc
+      ginkgo_sparse_matrix.cc
       )
 endif()
 

--- a/source/lac/ginkgo_preconditioner.cc
+++ b/source/lac/ginkgo_preconditioner.cc
@@ -1,0 +1,112 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 - 2023 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+#include <deal.II/lac/ginkgo_preconditioner.h>
+
+
+#ifdef DEAL_II_WITH_GINKGO
+
+#  include <ginkgo/core/base/types.hpp>
+#  include <ginkgo/core/preconditioner/jacobi.hpp>
+#  include <ginkgo/core/solver/ir.hpp>
+
+DEAL_II_NAMESPACE_OPEN
+
+
+namespace GinkgoWrappers
+{
+  template <typename ValueType, typename IndexType>
+  PreconditionBase<ValueType, IndexType>::PreconditionBase(
+    const AbstractMatrix<ValueType, IndexType> &A,
+    std::shared_ptr<gko::LinOpFactory>          factory)
+    : preconditioner_(factory->generate(A.get_shared_gko_object()))
+  {}
+
+  template <typename ValueType, typename IndexType>
+  std::shared_ptr<const gko::LinOp>
+  PreconditionBase<ValueType, IndexType>::get_shared_gko_object() const
+  {
+    return preconditioner_;
+  }
+
+  template <typename ValueType, typename IndexType>
+  void
+  PreconditionBase<ValueType, IndexType>::vmult(Vector<ValueType> &      u,
+                                                const Vector<ValueType> &v)
+  {
+    if (preconditioner_)
+      {
+        preconditioner_->apply(v.get_gko_object(), u.get_gko_object());
+      }
+    else
+      {
+        u = v;
+      }
+  }
+
+
+  template <typename ValueType, typename IndexType>
+  PreconditionIdentity<ValueType, IndexType>::PreconditionIdentity(
+    const PreconditionIdentity::AdditionalData &)
+    : PreconditionBase<ValueType, IndexType>()
+  {}
+
+
+  template <typename ValueType, typename IndexType>
+  PreconditionJacobi<ValueType, IndexType>::PreconditionJacobi(
+    const Csr<ValueType, IndexType> &         A,
+    const PreconditionJacobi::AdditionalData &data)
+    : PreconditionBase<ValueType, IndexType>(
+        A,
+        gko::solver::Ir<ValueType>::build()
+          .with_solver(
+            gko::preconditioner::Jacobi<ValueType, IndexType>::build()
+              .with_max_block_size(
+                static_cast<gko::uint32>(data.max_block_size))
+              .on(A.get_gko_object()->get_executor()))
+          .with_relaxation_factor(data.relaxation)
+          .with_criteria(gko::stop::Iteration::build()
+                           .with_max_iters(data.n_iterations)
+                           .on(A.get_gko_object()->get_executor()))
+          .with_default_initial_guess(gko::solver::initial_guess_mode::zero)
+          .on(A.get_gko_object()->get_executor()))
+  {}
+
+  using gko::int32;
+  using gko::int64;
+
+#  define DECLARE_GINKGO_PRECONDITIONER_BASE(_value_type, _index_type) \
+    class PreconditionBase<_value_type, _index_type>
+  GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
+    DECLARE_GINKGO_PRECONDITIONER_BASE);
+
+
+#  define DECLARE_GINKGO_PRECONDITIONER_IDENTITY(_value_type, _index_type) \
+    class PreconditionIdentity<_value_type, _index_type>
+  GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
+    DECLARE_GINKGO_PRECONDITIONER_IDENTITY);
+
+
+#  define DECLARE_GINKGO_PRECONDITIONER_JACOBI(_value_type, _index_type) \
+    class PreconditionJacobi<_value_type, _index_type>
+  GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
+    DECLARE_GINKGO_PRECONDITIONER_JACOBI);
+
+} // namespace GinkgoWrappers
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/source/lac/ginkgo_solver.cc
+++ b/source/lac/ginkgo_solver.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2018 - 2020 by the deal.II authors
+// Copyright (C) 2018 - 2023 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -33,175 +33,30 @@ namespace GinkgoWrappers
   template <typename ValueType, typename IndexType>
   SolverBase<ValueType, IndexType>::SolverBase(SolverControl &solver_control,
                                                const std::string &exec_type)
+    : SolverBase(detail::exec_from_name(exec_type), solver_control)
+  {}
+
+  template <typename ValueType, typename IndexType>
+  SolverBase<ValueType, IndexType>::SolverBase(
+    std::shared_ptr<const gko::Executor> exec,
+    SolverControl &                      solver_control)
     : solver_control(solver_control)
-    , exec_type(exec_type)
-  {
-    if (exec_type == "reference")
-      {
-        executor = gko::ReferenceExecutor::create();
-      }
-    else if (exec_type == "omp")
-      {
-        executor = gko::OmpExecutor::create();
-      }
-    else if (exec_type == "cuda" && gko::CudaExecutor::get_num_devices() > 0)
-      {
-        executor = gko::CudaExecutor::create(0, gko::OmpExecutor::create());
-      }
-    else
-      {
-        Assert(
-          false,
-          ExcMessage(
-            " exec_type needs to be one of the three strings: \"reference\", \"cuda\" or \"omp\" "));
-      }
-    using ResidualCriterionFactory = gko::stop::ResidualNormReduction<>;
-    residual_criterion             = ResidualCriterionFactory::build()
-                           .with_reduction_factor(solver_control.tolerance())
-                           .on(executor);
-
-    combined_factory =
-      gko::stop::Combined::build()
-        .with_criteria(residual_criterion,
-                       gko::stop::Iteration::build()
-                         .with_max_iters(solver_control.max_steps())
-                         .on(executor))
-        .on(executor);
-  }
-
+    , executor(std::move(exec))
+    , system_matrix(executor, 0, 0)
+  {}
 
 
   template <typename ValueType, typename IndexType>
   void
-  SolverBase<ValueType, IndexType>::initialize_ginkgo_log()
+  SolverBase<ValueType, IndexType>::apply(
+    ::dealii::Vector<ValueType> &      solution,
+    const ::dealii::Vector<ValueType> &rhs)
   {
-    // Add the logger object. See the different masks available in Ginkgo's
-    // documentation
-    convergence_logger = gko::log::Convergence<>::create(
-      executor, gko::log::Logger::criterion_check_completed_mask);
+    auto view_solution = Vector<ValueType>::create_view(executor, solution);
+    auto view_rhs      = Vector<ValueType>::create_view(executor, rhs);
+
+    solve(system_matrix, *view_solution, *view_rhs);
   }
-
-
-
-  template <typename ValueType, typename IndexType>
-  void
-  SolverBase<ValueType, IndexType>::apply(Vector<ValueType> &      solution,
-                                          const Vector<ValueType> &rhs)
-  {
-    // some shortcuts.
-    using val_array = gko::Array<ValueType>;
-    using vec       = gko::matrix::Dense<ValueType>;
-
-    Assert(system_matrix, ExcNotInitialized());
-    Assert(executor, ExcNotInitialized());
-    Assert(rhs.size() == solution.size(),
-           ExcDimensionMismatch(rhs.size(), solution.size()));
-
-    // Generate the solver from the solver using the system matrix.
-    auto solver = solver_gen->generate(system_matrix);
-
-    // Create the rhs vector in Ginkgo's format.
-    std::vector<ValueType> f(rhs.size());
-    std::copy(rhs.begin(), rhs.begin() + rhs.size(), f.begin());
-    auto b =
-      vec::create(executor,
-                  gko::dim<2>(rhs.size(), 1),
-                  val_array::view(executor->get_master(), rhs.size(), f.data()),
-                  1);
-
-    // Create the solution vector in Ginkgo's format.
-    std::vector<ValueType> u(solution.size());
-    std::copy(solution.begin(), solution.begin() + solution.size(), u.begin());
-    auto x = vec::create(executor,
-                         gko::dim<2>(solution.size(), 1),
-                         val_array::view(executor->get_master(),
-                                         solution.size(),
-                                         u.data()),
-                         1);
-
-    // Create the logger object to log some data from the solvers to confirm
-    // convergence.
-    initialize_ginkgo_log();
-
-    Assert(convergence_logger, ExcNotInitialized());
-    // Add the convergence logger object to the combined factory to retrieve the
-    // solver and other data
-    combined_factory->add_logger(convergence_logger);
-
-    // Finally, apply the solver to b and get the solution in x.
-    solver->apply(gko::lend(b), gko::lend(x));
-
-    // The convergence_logger object contains the residual vector after the
-    // solver has returned. use this vector to compute the residual norm of the
-    // solution. Get the residual norm from the logger. As the convergence
-    // logger returns a `linop`, it is necessary to convert it to a Dense
-    // matrix. Additionally, if the logger is logging on the gpu, it is
-    // necessary to copy the data to the host and hence the
-    // `residual_norm_d_parent`
-    auto residual_norm = convergence_logger->get_residual_norm();
-    auto residual_norm_d =
-      gko::as<gko::matrix::Dense<ValueType>>(residual_norm);
-    auto residual_norm_d_parent =
-      gko::matrix::Dense<ValueType>::create(executor->get_master(),
-                                            gko::dim<2>{1, 1});
-    residual_norm_d_parent->copy_from(residual_norm_d);
-
-    // Get the number of iterations taken to converge to the solution.
-    auto num_iteration = convergence_logger->get_num_iterations();
-
-    // Ginkgo works with a relative residual norm through its
-    // ResidualNormReduction criterion. Therefore, to get the normalized
-    // residual, we divide by the norm of the rhs.
-    auto b_norm = gko::matrix::Dense<ValueType>::create(executor->get_master(),
-                                                        gko::dim<2>{1, 1});
-    if (executor != executor->get_master())
-      {
-        auto b_master = vec::create(executor->get_master(),
-                                    gko::dim<2>(rhs.size(), 1),
-                                    val_array::view(executor->get_master(),
-                                                    rhs.size(),
-                                                    f.data()),
-                                    1);
-        b_master->compute_norm2(b_norm.get());
-      }
-    else
-      {
-        b->compute_norm2(b_norm.get());
-      }
-
-    Assert(b_norm.get()->at(0, 0) != 0.0, ExcDivideByZero());
-    // Pass the number of iterations and residual norm to the solver_control
-    // object. As both `residual_norm_d_parent` and `b_norm` are seen as Dense
-    // matrices, we use the `at` function to get the first value here. In case
-    // of multiple right hand sides, this will need to be modified.
-    const SolverControl::State state =
-      solver_control.check(num_iteration,
-                           residual_norm_d_parent->at(0, 0) / b_norm->at(0, 0));
-
-    // in case of failure: throw exception
-    if (state != SolverControl::success)
-      AssertThrow(false,
-                  SolverControl::NoConvergence(solver_control.last_step(),
-                                               solver_control.last_value()));
-
-    // Check if the solution is on a CUDA device, if so, copy it over to the
-    // host.
-    if (executor != executor->get_master())
-      {
-        auto x_master = vec::create(executor->get_master(),
-                                    gko::dim<2>(solution.size(), 1),
-                                    val_array::view(executor,
-                                                    solution.size(),
-                                                    x->get_values()),
-                                    1);
-        x.reset(x_master.release());
-      }
-    // Finally copy over the solution vector to deal.II's solution vector.
-    std::copy(x->get_values(),
-              x->get_values() + solution.size(),
-              solution.begin());
-  }
-
 
 
   template <typename ValueType, typename IndexType>
@@ -212,302 +67,193 @@ namespace GinkgoWrappers
   }
 
 
-
   template <typename ValueType, typename IndexType>
   void
   SolverBase<ValueType, IndexType>::initialize(
-    const SparseMatrix<ValueType> &matrix)
+    const ::dealii::SparseMatrix<ValueType> &matrix)
   {
-    // Needs to be a square matrix
-    Assert(matrix.m() == matrix.n(), ExcNotQuadratic());
-
-    using size_type   = dealii::types::global_dof_index;
-    const size_type N = matrix.m();
-
-    using mtx = gko::matrix::Csr<ValueType, IndexType>;
-    std::shared_ptr<mtx> system_matrix_compute;
-    system_matrix_compute   = mtx::create(executor->get_master(),
-                                        gko::dim<2>(N),
-                                        matrix.n_nonzero_elements());
-    ValueType *mat_values   = system_matrix_compute->get_values();
-    IndexType *mat_row_ptrs = system_matrix_compute->get_row_ptrs();
-    IndexType *mat_col_idxs = system_matrix_compute->get_col_idxs();
-
-    // Copy over the data from the matrix to the data structures Ginkgo needs.
-    //
-    // Final note: if the matrix has entries in the sparsity pattern that are
-    // actually occupied by entries that have a zero numerical value, then we
-    // keep them anyway. people are supposed to provide accurate sparsity
-    // patterns.
-
-    // first fill row lengths array
-    mat_row_ptrs[0] = 0;
-    for (size_type row = 1; row <= N; ++row)
-      mat_row_ptrs[row] =
-        mat_row_ptrs[row - 1] + matrix.get_row_length(row - 1);
-
-    // Copy over matrix elements. note that for sparse matrices,
-    // iterators are sorted so that they traverse each row from start to end
-    // before moving on to the next row. however, this isn't true for block
-    // matrices, so we have to do a bit of book keeping
-    {
-      // Have an array that for each row points to the first entry not yet
-      // written to
-      std::vector<IndexType> row_pointers(N + 1);
-      std::copy(system_matrix_compute->get_row_ptrs(),
-                system_matrix_compute->get_row_ptrs() + N + 1,
-                row_pointers.begin());
-
-      // Loop over the elements of the matrix row by row, as suggested in the
-      // documentation of the sparse matrix iterator class
-      for (size_type row = 0; row < N; ++row)
-        {
-          for (typename SparseMatrix<ValueType>::const_iterator p =
-                 matrix.begin(row);
-               p != matrix.end(row);
-               ++p)
-            {
-              // Write entry into the first free one for this row
-              mat_col_idxs[row_pointers[row]] = p->column();
-              mat_values[row_pointers[row]]   = p->value();
-
-              // Then move pointer ahead
-              ++row_pointers[row];
-            }
-        }
-
-      // At the end, we should have written all rows completely
-      for (size_type i = 0; i < N - 1; ++i)
-        Assert(row_pointers[i] == mat_row_ptrs[i + 1], ExcInternalError());
-    }
-    system_matrix =
-      mtx::create(executor, gko::dim<2>(N), matrix.n_nonzero_elements());
-    system_matrix->copy_from(system_matrix_compute.get());
+    system_matrix = Csr<ValueType, IndexType>{executor, matrix};
   }
-
 
 
   template <typename ValueType, typename IndexType>
   void
-  SolverBase<ValueType, IndexType>::solve(const SparseMatrix<ValueType> &matrix,
-                                          Vector<ValueType> &      solution,
-                                          const Vector<ValueType> &rhs)
+  SolverBase<ValueType, IndexType>::solve(
+    const ::dealii::SparseMatrix<ValueType> &matrix,
+    ::dealii::Vector<ValueType> &            solution,
+    const ::dealii::Vector<ValueType> &      rhs)
   {
     initialize(matrix);
     apply(solution, rhs);
   }
 
 
-
-  /* ---------------------- SolverCG ------------------------ */
   template <typename ValueType, typename IndexType>
-  SolverCG<ValueType, IndexType>::SolverCG(SolverControl &       solver_control,
-                                           const std::string &   exec_type,
-                                           const AdditionalData &data)
-    : SolverBase<ValueType, IndexType>(solver_control, exec_type)
-    , additional_data(data)
+  void
+  SolverBase<ValueType, IndexType>::solve(
+    const AbstractMatrix<ValueType, IndexType> &  matrix,
+    Vector<ValueType> &                           solution,
+    const Vector<ValueType> &                     rhs,
+    const PreconditionBase<ValueType, IndexType> &preconditioner)
   {
-    using cg = gko::solver::Cg<ValueType>;
-    this->solver_gen =
-      cg::build().with_criteria(this->combined_factory).on(this->executor);
+    solve_impl(matrix, solution, rhs, preconditioner);
   }
 
 
-
-  template <typename ValueType, typename IndexType>
-  SolverCG<ValueType, IndexType>::SolverCG(
-    SolverControl &                           solver_control,
-    const std::string &                       exec_type,
-    const std::shared_ptr<gko::LinOpFactory> &preconditioner,
-    const AdditionalData &                    data)
-    : SolverBase<ValueType, IndexType>(solver_control, exec_type)
-    , additional_data(data)
+  template <typename ValueType,
+            typename IndexType,
+            template <class>
+            class GinkgoType,
+            typename AdditionalDataType>
+  void
+  EnableSolverBase<ValueType, IndexType, GinkgoType, AdditionalDataType>::
+    initialize_ginkgo_log()
   {
-    using cg         = gko::solver::Cg<ValueType>;
-    this->solver_gen = cg::build()
-                         .with_criteria(this->combined_factory)
-                         .with_preconditioner(preconditioner)
-                         .on(this->executor);
+    // Add the logger object. See the different masks available in Ginkgo's
+    // documentation
+    convergence_logger = gko::log::Convergence<>::create(
+      this->executor, gko::log::Logger::criterion_check_completed_mask);
   }
 
 
+  template <typename T, typename = void>
+  struct has_with_preconditioner : std::false_type
+  {};
 
-  /* ---------------------- SolverBicgstab ------------------------ */
-  template <typename ValueType, typename IndexType>
-  SolverBicgstab<ValueType, IndexType>::SolverBicgstab(
-    SolverControl &       solver_control,
-    const std::string &   exec_type,
-    const AdditionalData &data)
-    : SolverBase<ValueType, IndexType>(solver_control, exec_type)
-    , additional_data(data)
+  template <typename T>
+  struct has_with_preconditioner<
+    T,
+    boost::void_t<decltype(std::declval<T>().with_generated_preconditioner(
+      std::declval<std::shared_ptr<const gko::LinOp>>()))>> : std::true_type
+  {};
+
+
+  template <typename T, typename = void>
+  struct has_with_solver : std::false_type
+  {};
+
+  template <typename T>
+  struct has_with_solver<
+    T,
+    boost::void_t<decltype(std::declval<T>().with_generated_solver(
+      std::declval<std::shared_ptr<const gko::LinOp>>()))>> : std::true_type
+  {};
+
+
+  template <typename ValueType, typename IndexType, typename ParametersType>
+  std::enable_if_t<has_with_preconditioner<ParametersType>::value,
+                   ParametersType &>
+  add_preconditioner(
+    ParametersType &                              parameters,
+    const PreconditionBase<ValueType, IndexType> &preconditioner)
   {
-    using bicgstab   = gko::solver::Bicgstab<ValueType>;
-    this->solver_gen = bicgstab::build()
-                         .with_criteria(this->combined_factory)
-                         .on(this->executor);
+    return parameters.with_generated_preconditioner(
+      preconditioner.get_shared_gko_object());
+  }
+
+  template <typename ValueType, typename IndexType, typename ParametersType>
+  std::enable_if_t<has_with_solver<ParametersType>::value, ParametersType &>
+  add_preconditioner(
+    ParametersType &                              parameters,
+    const PreconditionBase<ValueType, IndexType> &preconditioner)
+  {
+    return parameters.with_generated_solver(
+      preconditioner.get_shared_gko_object());
   }
 
 
-
-  template <typename ValueType, typename IndexType>
-  SolverBicgstab<ValueType, IndexType>::SolverBicgstab(
-    SolverControl &                           solver_control,
-    const std::string &                       exec_type,
-    const std::shared_ptr<gko::LinOpFactory> &preconditioner,
-    const AdditionalData &                    data)
-    : SolverBase<ValueType, IndexType>(solver_control, exec_type)
-    , additional_data(data)
+  template <typename ValueType,
+            typename IndexType,
+            template <class>
+            class GinkgoType,
+            typename AdditionalDataType>
+  EnableSolverBase<ValueType, IndexType, GinkgoType, AdditionalDataType>::
+    EnableSolverBase(std::shared_ptr<const gko::Executor>      exec,
+                     SolverControl &                           solver_control,
+                     const std::shared_ptr<gko::LinOpFactory> &preconditioner,
+                     const AdditionalData &                    data)
+    : EnableSolverBase(exec, solver_control, data)
   {
-    using bicgstab   = gko::solver::Bicgstab<ValueType>;
-    this->solver_gen = bicgstab::build()
-                         .with_criteria(this->combined_factory)
-                         .with_preconditioner(preconditioner)
-                         .on(this->executor);
+    solver_gen = ginkgo_type::build()
+                   .with_criteria(this->combined_factory)
+                   .with_preconditioner(preconditioner)
+                   .on(this->executor);
   }
 
 
-
-  /* ---------------------- SolverCGS ------------------------ */
-  template <typename ValueType, typename IndexType>
-  SolverCGS<ValueType, IndexType>::SolverCGS(SolverControl &    solver_control,
-                                             const std::string &exec_type,
-                                             const AdditionalData &data)
-    : SolverBase<ValueType, IndexType>(solver_control, exec_type)
-    , additional_data(data)
+  template <typename ValueType,
+            typename IndexType,
+            template <class>
+            class GinkgoType,
+            typename AdditionalDataType>
+  void
+  EnableSolverBase<ValueType, IndexType, GinkgoType, AdditionalDataType>::
+    solve_impl(const AbstractMatrix<ValueType, IndexType> &  matrix,
+               Vector<ValueType> &                           solution,
+               const Vector<ValueType> &                     rhs,
+               const PreconditionBase<ValueType, IndexType> &preconditioner)
   {
-    using cgs = gko::solver::Cgs<ValueType>;
-    this->solver_gen =
-      cgs::build().with_criteria(this->combined_factory).on(this->executor);
+    Assert(this->executor, ExcNotInitialized());
+    Assert(rhs.size() == solution.size(),
+           ExcDimensionMismatch(rhs.size(), solution.size()));
+
+    // Generate the solver from the solver using the system matrix.
+    auto solver =
+      solver_gen ?
+        solver_gen->generate(matrix.get_shared_gko_object()) :
+        add_preconditioner(parameters_.with_criteria(combined_factory),
+                           preconditioner)
+          .on(this->executor)
+          ->generate(matrix.get_shared_gko_object());
+
+    // Create the logger object to log some data from the solvers to confirm
+    // convergence.
+    this->initialize_ginkgo_log();
+
+    Assert(this->convergence_logger, ExcNotInitialized());
+    // Add the convergence logger object to the combined factory to retrieve the
+    // solver and other data
+    this->combined_factory->add_logger(convergence_logger);
+
+    // Finally, apply the solver to b and get the solution in x.
+    solver->apply(rhs.get_gko_object(), solution.get_gko_object());
+
+    // The convergence_logger object contains the residual vector after the
+    // solver has returned. use this vector to compute the residual norm of the
+    // solution. Get the residual norm from the logger. As the convergence
+    // logger returns a `linop`, it is necessary to convert it to a Dense
+    // matrix. Additionally, if the logger is logging on the gpu, it is
+    // necessary to copy the data to the host and hence the
+    // `residual_norm_host`
+    auto residual_norm = gko::as<typename Vector<ValueType>::ginkgo_type>(
+      convergence_logger->get_residual_norm());
+    auto residual_norm_host =
+      gko::make_temporary_clone(this->executor->get_master(), residual_norm);
+
+    // Get the number of iterations taken to converge to the solution.
+    auto num_iteration = convergence_logger->get_num_iterations();
+
+    // Ginkgo works with a relative residual norm through its
+    // ResidualNormReduction criterion. Therefore, to get the normalized
+    // residual, we divide by the norm of the rhs.
+    auto rhs_norm = rhs.l2_norm();
+
+    Assert(rhs_norm != 0.0, ExcDivideByZero());
+    // Pass the number of iterations and residual norm to the solver_control
+    // object. As both `residual_norm_host` and `rhs_norm` are seen as Dense
+    // matrices, we use the `at` function to get the first value here. In case
+    // of multiple right hand sides, this will need to be modified.
+    const SolverControl::State state =
+      this->solver_control.check(num_iteration,
+                                 residual_norm_host->at(0, 0) / rhs_norm);
+
+    // in case of failure: throw exception
+    if (state != SolverControl::success)
+      AssertThrow(
+        false,
+        SolverControl::NoConvergence(this->solver_control.last_step(),
+                                     this->solver_control.last_value()));
   }
-
-
-
-  template <typename ValueType, typename IndexType>
-  SolverCGS<ValueType, IndexType>::SolverCGS(
-    SolverControl &                           solver_control,
-    const std::string &                       exec_type,
-    const std::shared_ptr<gko::LinOpFactory> &preconditioner,
-    const AdditionalData &                    data)
-    : SolverBase<ValueType, IndexType>(solver_control, exec_type)
-    , additional_data(data)
-  {
-    using cgs        = gko::solver::Cgs<ValueType>;
-    this->solver_gen = cgs::build()
-                         .with_criteria(this->combined_factory)
-                         .with_preconditioner(preconditioner)
-                         .on(this->executor);
-  }
-
-
-
-  /* ---------------------- SolverFCG ------------------------ */
-  template <typename ValueType, typename IndexType>
-  SolverFCG<ValueType, IndexType>::SolverFCG(SolverControl &    solver_control,
-                                             const std::string &exec_type,
-                                             const AdditionalData &data)
-    : SolverBase<ValueType, IndexType>(solver_control, exec_type)
-    , additional_data(data)
-  {
-    using fcg = gko::solver::Fcg<ValueType>;
-    this->solver_gen =
-      fcg::build().with_criteria(this->combined_factory).on(this->executor);
-  }
-
-
-
-  template <typename ValueType, typename IndexType>
-  SolverFCG<ValueType, IndexType>::SolverFCG(
-    SolverControl &                           solver_control,
-    const std::string &                       exec_type,
-    const std::shared_ptr<gko::LinOpFactory> &preconditioner,
-    const AdditionalData &                    data)
-    : SolverBase<ValueType, IndexType>(solver_control, exec_type)
-    , additional_data(data)
-  {
-    using fcg        = gko::solver::Fcg<ValueType>;
-    this->solver_gen = fcg::build()
-                         .with_criteria(this->combined_factory)
-                         .with_preconditioner(preconditioner)
-                         .on(this->executor);
-  }
-
-
-
-  /* ---------------------- SolverGMRES ------------------------ */
-  template <typename ValueType, typename IndexType>
-  SolverGMRES<ValueType, IndexType>::AdditionalData::AdditionalData(
-    const unsigned int restart_parameter)
-    : restart_parameter(restart_parameter)
-  {}
-
-
-
-  template <typename ValueType, typename IndexType>
-  SolverGMRES<ValueType, IndexType>::SolverGMRES(SolverControl &solver_control,
-                                                 const std::string &exec_type,
-                                                 const AdditionalData &data)
-    : SolverBase<ValueType, IndexType>(solver_control, exec_type)
-    , additional_data(data)
-  {
-    using gmres      = gko::solver::Gmres<ValueType>;
-    this->solver_gen = gmres::build()
-                         .with_krylov_dim(additional_data.restart_parameter)
-                         .with_criteria(this->combined_factory)
-                         .on(this->executor);
-  }
-
-
-
-  template <typename ValueType, typename IndexType>
-  SolverGMRES<ValueType, IndexType>::SolverGMRES(
-    SolverControl &                           solver_control,
-    const std::string &                       exec_type,
-    const std::shared_ptr<gko::LinOpFactory> &preconditioner,
-    const AdditionalData &                    data)
-    : SolverBase<ValueType, IndexType>(solver_control, exec_type)
-    , additional_data(data)
-  {
-    using gmres      = gko::solver::Gmres<ValueType>;
-    this->solver_gen = gmres::build()
-                         .with_krylov_dim(additional_data.restart_parameter)
-                         .with_criteria(this->combined_factory)
-                         .with_preconditioner(preconditioner)
-                         .on(this->executor);
-  }
-
-
-
-  /* ---------------------- SolverIR ------------------------ */
-  template <typename ValueType, typename IndexType>
-  SolverIR<ValueType, IndexType>::SolverIR(SolverControl &       solver_control,
-                                           const std::string &   exec_type,
-                                           const AdditionalData &data)
-    : SolverBase<ValueType, IndexType>(solver_control, exec_type)
-    , additional_data(data)
-  {
-    using ir = gko::solver::Ir<ValueType>;
-    this->solver_gen =
-      ir::build().with_criteria(this->combined_factory).on(this->executor);
-  }
-
-
-
-  template <typename ValueType, typename IndexType>
-  SolverIR<ValueType, IndexType>::SolverIR(
-    SolverControl &                           solver_control,
-    const std::string &                       exec_type,
-    const std::shared_ptr<gko::LinOpFactory> &inner_solver,
-    const AdditionalData &                    data)
-    : SolverBase<ValueType, IndexType>(solver_control, exec_type)
-    , additional_data(data)
-  {
-    using ir         = gko::solver::Ir<ValueType>;
-    this->solver_gen = ir::build()
-                         .with_criteria(this->combined_factory)
-                         .with_solver(inner_solver)
-                         .on(this->executor);
-  }
-
 
 
   // Explicit instantiations in GinkgoWrappers

--- a/source/lac/ginkgo_sparse_matrix.cc
+++ b/source/lac/ginkgo_sparse_matrix.cc
@@ -1,0 +1,394 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 - 2023 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+#include <deal.II/base/logstream.h>
+
+#include <deal.II/lac/ginkgo_sparse_matrix.h>
+
+#ifdef DEAL_II_WITH_GINKGO
+
+#  include <deal.II/lac/exceptions.h>
+
+#  include <ginkgo/core/base/mtx_io.hpp>
+#  include <ginkgo/core/base/types.hpp>
+
+#  include <cmath>
+#  include <memory>
+
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace GinkgoWrappers
+{
+  namespace detail
+  {
+    // helper type for the visitor #4
+    template <class... Ts>
+    struct overloaded : Ts...
+    {
+      using Ts::operator()...;
+    };
+    // explicit deduction guide (not needed as of C++20)
+    template <class... Ts>
+    overloaded(Ts...) -> overloaded<Ts...>;
+
+  } // namespace detail
+
+  template <typename Number, typename IndexType>
+  AbstractMatrix<Number, IndexType>::AbstractMatrix(
+    std::shared_ptr<const gko::Executor> exec,
+    const AbstractMatrix::size_type      m,
+    const AbstractMatrix::size_type      n)
+    : exec_(std::move(exec))
+    , data_{AbstractMatrix::assembly{gko::dim<2>{m, n}}}
+  {}
+
+  template <typename Number, typename IndexType>
+  AbstractMatrix<Number, IndexType>::AbstractMatrix(
+    std::unique_ptr<ginkgo_type> M)
+    : exec_(M->get_executor())
+    , data_(std::move(M))
+  {}
+
+  template <typename Number, typename IndexType>
+  AbstractMatrix<Number, IndexType> &
+  AbstractMatrix<Number, IndexType>::operator=(AbstractMatrix &&m) noexcept(
+    false)
+  {
+    if (this != &m)
+      {
+        std::visit(detail::overloaded{
+                     [this](assembly &data) {
+                       this->data_ =
+                         std::exchange(data, assembly{data.get_size()});
+                     },
+                     [this](matrix_ptr data) {
+                       this->data_ = data->create_default();
+                       std_cxx17::get<matrix_ptr>(this->data_)->move_from(data);
+                     }},
+                   m.data_);
+      }
+    return *this;
+  }
+
+  template <typename Number, typename IndexType>
+  AbstractMatrix<Number, IndexType>::AbstractMatrix(AbstractMatrix &&m) noexcept
+    : exec_(m.exec_)
+    , data_(matrix_ptr{})
+  {
+    *this = std::move(m);
+  }
+
+  template <typename Number, typename IndexType>
+  const typename AbstractMatrix<Number, IndexType>::ginkgo_type *
+  AbstractMatrix<Number, IndexType>::get_gko_object() const
+  {
+    return std_cxx17::get<matrix_ptr>(this->data_).get();
+  }
+
+  template <typename Number, typename IndexType>
+  std::shared_ptr<const typename AbstractMatrix<Number, IndexType>::ginkgo_type>
+  AbstractMatrix<Number, IndexType>::get_shared_gko_object() const
+  {
+    return std_cxx17::get<matrix_ptr>(this->data_);
+  }
+
+  template <typename Number, typename IndexType>
+  void
+  AbstractMatrix<Number, IndexType>::set(const AbstractMatrix::size_type i,
+                                         const AbstractMatrix::size_type j,
+                                         const Number                    value)
+  {
+    std_cxx17::get<assembly>(data_).set_value(static_cast<IndexType>(i),
+                                              static_cast<IndexType>(j),
+                                              value);
+  }
+
+  template <typename Number, typename IndexType>
+  void
+  AbstractMatrix<Number, IndexType>::set(
+    const AbstractMatrix::size_type  row,
+    const AbstractMatrix::size_type  n_cols,
+    const AbstractMatrix::size_type *col_indices,
+    const Number *                   values,
+    const bool                       elide_zero_values)
+  {
+    for (size_type k = 0; k < n_cols; ++k)
+      {
+        if (values[k] != Number{0} || !elide_zero_values)
+          {
+            set(row, col_indices[k], values[k]);
+          }
+      }
+  }
+
+  template <typename Number, typename IndexType>
+  void
+  AbstractMatrix<Number, IndexType>::set(const std::vector<size_type> &indices,
+                                         const FullMatrix<Number> &full_matrix,
+                                         const bool elide_zero_values)
+  {
+    set(indices, indices, full_matrix, elide_zero_values);
+  }
+
+  template <typename Number, typename IndexType>
+  void
+  AbstractMatrix<Number, IndexType>::set(
+    const std::vector<size_type> &row_indices,
+    const std::vector<size_type> &col_indices,
+    const FullMatrix<Number> &    full_matrix,
+    const bool                    elide_zero_values)
+  {
+    for (size_type row = 0; row < row_indices.size(); ++row)
+      {
+        set(row_indices[row],
+            col_indices.size(),
+            col_indices.data(),
+            full_matrix[row].begin(),
+            elide_zero_values);
+      }
+  }
+
+  template <typename Number, typename IndexType>
+  void
+  AbstractMatrix<Number, IndexType>::set(
+    const AbstractMatrix::size_type row,
+    const std::vector<size_type> &  col_indices,
+    const std::vector<Number> &     values,
+    const bool                      elide_zero_values)
+  {
+    set(row,
+        col_indices.size(),
+        col_indices.data(),
+        values.data(),
+        elide_zero_values);
+  }
+
+
+  template <typename Number, typename IndexType>
+  void
+  AbstractMatrix<Number, IndexType>::add(const AbstractMatrix::size_type i,
+                                         const AbstractMatrix::size_type j,
+                                         const Number                    value)
+  {
+    std_cxx17::get<assembly>(data_).add_value(static_cast<IndexType>(i),
+                                              static_cast<IndexType>(j),
+                                              value);
+  }
+
+  template <typename Number, typename IndexType>
+  void
+  AbstractMatrix<Number, IndexType>::add(
+    const AbstractMatrix::size_type  row,
+    const AbstractMatrix::size_type  n_cols,
+    const AbstractMatrix::size_type *col_indices,
+    const Number *                   values,
+    const bool                       elide_zero_values,
+    const bool                       col_indices_are_sorted [[maybe_unused]])
+  {
+    for (size_type k = 0; k < n_cols; ++k)
+      {
+        if (values[k] != Number{0} || !elide_zero_values)
+          {
+            add(row, col_indices[k], values[k]);
+          }
+      }
+  }
+
+  template <typename Number, typename IndexType>
+  void
+  AbstractMatrix<Number, IndexType>::add(const std::vector<size_type> &indices,
+                                         const FullMatrix<Number> &full_matrix,
+                                         const bool elide_zero_values)
+  {
+    add(indices, indices, full_matrix, elide_zero_values);
+  }
+
+  template <typename Number, typename IndexType>
+  void
+  AbstractMatrix<Number, IndexType>::add(
+    const std::vector<size_type> &row_indices,
+    const std::vector<size_type> &col_indices,
+    const FullMatrix<Number> &    full_matrix,
+    const bool                    elide_zero_values)
+  {
+    for (size_type i = 0; i < row_indices.size(); ++i)
+      {
+        add(row_indices[i],
+            col_indices.size(),
+            col_indices.data(),
+            full_matrix[i].begin(),
+            elide_zero_values);
+      }
+  }
+
+  template <typename Number, typename IndexType>
+  void
+  AbstractMatrix<Number, IndexType>::add(
+    const AbstractMatrix::size_type row,
+    const std::vector<size_type> &  col_indices,
+    const std::vector<Number> &     values,
+    const bool                      elide_zero_values)
+  {
+    add(row,
+        col_indices.size(),
+        col_indices.data(),
+        values.data(),
+        elide_zero_values);
+  }
+
+
+  template <typename Number,
+            typename IndexType,
+            template <class, class>
+            class GinkgoType>
+  Matrix<Number, IndexType, GinkgoType>::Matrix(
+    std::shared_ptr<const gko::Executor> exec,
+    const Matrix::size_type              m,
+    const Matrix::size_type              n)
+    : AbstractMatrix<Number, IndexType>(exec, m, n)
+  {}
+
+  template <typename Number,
+            typename IndexType,
+            template <class, class>
+            class GinkgoType>
+  Matrix<Number, IndexType, GinkgoType>::Matrix(std::unique_ptr<ginkgo_type> M)
+    : AbstractMatrix<Number, IndexType>(std::move(M))
+  {}
+
+  template <typename Number,
+            typename IndexType,
+            template <class, class>
+            class GinkgoType>
+  void
+  Matrix<Number, IndexType, GinkgoType>::compress(
+    const VectorOperation::values /* unused */)
+  {
+    auto assembly_data =
+      std::move(std_cxx17::get<typename Base::assembly>(this->data_));
+    auto assembled_matrix = ginkgo_type::create(this->exec_);
+    assembled_matrix->read(assembly_data.get_ordered_data());
+    this->data_ = std::move(assembled_matrix);
+  }
+
+
+  template <typename Number, typename IndexType>
+  Csr<Number, IndexType>::Csr(std::shared_ptr<const gko::Executor> exec,
+                              const SparseMatrix<Number> &         other)
+    : Csr::Base{std::move(exec), 0, 0}
+  {
+    const size_type M = other.m();
+    const size_type N = other.n();
+
+    auto       data_host    = ginkgo_type::create(this->exec_->get_master(),
+                                         gko::dim<2>(M, N),
+                                         other.n_nonzero_elements());
+    Number *   mat_values   = data_host->get_values();
+    IndexType *mat_row_ptrs = data_host->get_row_ptrs();
+    IndexType *mat_col_idxs = data_host->get_col_idxs();
+
+    // Copy over the data from the matrix to the data structures Ginkgo needs.
+    //
+    // Final note: if the matrix has entries in the sparsity pattern that are
+    // actually occupied by entries that have a zero numerical value, then we
+    // keep them anyway. people are supposed to provide accurate sparsity
+    // patterns.
+
+    // first fill row lengths array
+    mat_row_ptrs[0] = 0;
+    for (size_type row = 1; row <= M; ++row)
+      mat_row_ptrs[row] = mat_row_ptrs[row - 1] + other.get_row_length(row - 1);
+
+    // Copy over matrix elements. note that for sparse matrices,
+    // iterators are sorted so that they traverse each row from start to end
+    // before moving on to the next row. however, this isn't true for block
+    // matrices, so we have to do a bit of bookkeeping
+    {
+      // Have an array that for each row points to the first entry not yet
+      // written to
+      std::vector<IndexType> row_pointers(M + 1);
+      std::copy(data_host->get_row_ptrs(),
+                data_host->get_row_ptrs() + M + 1,
+                row_pointers.begin());
+
+      // Loop over the elements of the matrix row by row, as suggested in the
+      // documentation of the sparse matrix iterator class
+      for (size_type row = 0; row < M; ++row)
+        {
+          for (typename ::dealii::SparseMatrix<Number>::const_iterator p =
+                 other.begin(row);
+               p != other.end(row);
+               ++p)
+            {
+              // Write entry into the first free one for this row
+              mat_col_idxs[row_pointers[row]] = p->column();
+              mat_values[row_pointers[row]]   = p->value();
+
+              // Then move pointer ahead
+              ++row_pointers[row];
+            }
+        }
+
+      // At the end, we should have written all rows completely
+      for (size_type i = 0; i < M - 1; ++i)
+        Assert(row_pointers[i] == mat_row_ptrs[i + 1], ExcInternalError());
+    }
+
+    auto data = ginkgo_type::create(this->exec_);
+    data->move_from(data_host.get());
+    data->sort_by_column_index();
+
+    *this = Csr{std::move(data)};
+  }
+
+  using gko::int32;
+  using gko::int64;
+
+#  define DECLARE_ABSTRACT_MATRIX(_value_type, _index_type) \
+    class AbstractMatrix<_value_type, _index_type>
+
+  GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(DECLARE_ABSTRACT_MATRIX);
+
+
+#  define DECLARE_CSR(_value_type, _index_type) \
+    class Csr<_value_type, _index_type>
+
+  GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(DECLARE_CSR);
+
+
+#  define INSTANTIATE_CONCRETE_MATRIX(_type)                   \
+    template class Matrix<double, int32, _type>;               \
+    template class Matrix<double, int64, _type>;               \
+    template class Matrix<float, int32, _type>;                \
+    template class Matrix<float, int64, _type>;                \
+    template class Matrix<std::complex<double>, int32, _type>; \
+    template class Matrix<std::complex<double>, int64, _type>; \
+    template class Matrix<std::complex<float>, int32, _type>;  \
+    template class Matrix<std::complex<float>, int64, _type>
+
+  INSTANTIATE_CONCRETE_MATRIX(gko::matrix::Csr);
+  INSTANTIATE_CONCRETE_MATRIX(gko::matrix::Coo);
+  INSTANTIATE_CONCRETE_MATRIX(gko::matrix::Ell);
+  //    INSTANTIATE_CONCRETE_MATRIX(gko::matrix::Fbcsr); // need to fix ginkgo
+  //    constructor
+  INSTANTIATE_CONCRETE_MATRIX(gko::matrix::Hybrid);
+  INSTANTIATE_CONCRETE_MATRIX(gko::matrix::Sellp);
+} // namespace GinkgoWrappers
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/source/lac/ginkgo_vector.cc
+++ b/source/lac/ginkgo_vector.cc
@@ -437,6 +437,21 @@ namespace GinkgoWrappers
     add(indices.size(), indices.data(), values.begin());
   }
 
+  template <typename Number>
+  void
+  Vector<Number>::extract_subvector_to(
+    const ArrayView<const size_type> &indices,
+    ArrayView<Number> &               values) const
+  {
+    Assert(indices.size() == values.size(),
+           ExcDimensionMismatch(indices.size(), values.size()));
+    auto host_data =
+      gko::make_temporary_clone(data_->get_executor()->get_master(), data_);
+    for (size_type i = 0; i < indices.size(); ++i)
+      {
+        values[i] = host_data->get_const_values()[indices[i]];
+      }
+  }
 
 #  define DECLARE_GINKGO_VECTOR(_type) class Vector<_type>
 

--- a/source/lac/ginkgo_vector.cc
+++ b/source/lac/ginkgo_vector.cc
@@ -1,0 +1,453 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 - 2023 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+#include <deal.II/base/logstream.h>
+
+#include <deal.II/lac/ginkgo_vector.h>
+
+#ifdef DEAL_II_WITH_GINKGO
+
+#  include <deal.II/lac/exceptions.h>
+#  include <deal.II/lac/vector.h>
+
+#  include <ginkgo/core/base/mtx_io.hpp>
+#  include <ginkgo/core/base/types.hpp>
+
+#  include <cmath>
+#  include <memory>
+
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace GinkgoWrappers
+{
+  template <typename Number>
+  Vector<Number>::Vector(std::shared_ptr<const gko::Executor> exec)
+    : data_(ginkgo_type::create(std::move(exec)))
+  {}
+
+  template <typename Number>
+  Vector<Number>::Vector(std::unique_ptr<ginkgo_type> v)
+    : data_(std::move(v))
+  {}
+
+  template <typename Number>
+  Vector<Number>::Vector(std::shared_ptr<const gko::Executor> exec,
+                         const size_type                      size)
+    : data_(ginkgo_type::create(std::move(exec), gko::dim<2>{size, 1}))
+  {}
+
+  template <typename Number>
+  Vector<Number>::Vector(std::shared_ptr<const gko::Executor> exec,
+                         const std::initializer_list<Number> &list)
+    : data_(gko::initialize<ginkgo_type>(list, std::move(exec)))
+  {}
+
+  template <typename Number>
+  Vector<Number>::Vector(const Vector<Number> &other)
+    : Subscriptor()
+    , data_(gko::clone(other.data_))
+  {}
+
+  template <typename Number>
+  Vector<Number>::Vector(Vector<Number> &&other) noexcept
+    : Vector(other.data_->get_executor())
+  {
+    data_->move_from(other.data_.get());
+  }
+
+  template <typename Number>
+  Vector<Number>
+  Vector<Number>::create_with_same_size(const Vector<Number> &V,
+                                        const bool omit_zeroing_entries)
+  {
+    Vector result{V.get_gko_object()->get_executor(), V.size()};
+    if (!omit_zeroing_entries)
+      {
+        result = Number(0.0);
+      }
+    return result;
+  }
+
+  template <typename Number>
+  Vector<Number> &
+  Vector<Number>::operator=(const Vector<Number> &other)
+  {
+    if (this != &other)
+      {
+        data_->copy_from(other.data_.get());
+      }
+    return *this;
+  }
+
+  template <typename Number>
+  Vector<Number> &
+  Vector<Number>::operator=(Vector<Number> &&other) noexcept(false)
+  {
+    if (this != &other)
+      {
+        data_->move_from(other.data_.get());
+      }
+    return *this;
+  }
+
+  template <typename Number>
+  std::unique_ptr<const typename Vector<Number>::ginkgo_type>
+  Vector<Number>::get_gko_object() const noexcept
+  {
+    return gko::make_const_dense_view(data_);
+  }
+
+  template <typename Number>
+  std::unique_ptr<typename Vector<Number>::ginkgo_type>
+  Vector<Number>::get_gko_object() noexcept
+  {
+    return gko::make_dense_view(data_);
+  }
+
+  template <typename Number>
+  std::size_t
+  Vector<Number>::memory_consumption() const
+  {
+    return sizeof(Vector<Number>) + sizeof(ginkgo_type) +
+           sizeof(Number) * size();
+  }
+
+  template <typename Number>
+  void
+  Vector<Number>::print(std::ostream &     out,
+                        const unsigned int precision,
+                        const bool         scientific,
+                        const bool         accross [[maybe_unused]])
+  {
+    // TODO: figure out the meaning of accross
+    const auto default_precision = out.precision();
+
+    out << std::setprecision(precision);
+    if (scientific)
+      out << std::scientific;
+
+    gko::write(out, data_.get());
+
+    out << std::setprecision(default_precision);
+    if (scientific)
+      out << std::defaultfloat;
+  }
+
+  template <typename Number>
+  IndexSet
+  Vector<Number>::locally_owned_elements() const
+  {
+    return IndexSet(size());
+  }
+
+  template <typename Number>
+  Number
+  Vector<Number>::add_and_dot(const Number a, const Vector &V, const Vector &W)
+  {
+    this->add(a, V);
+    return *this * W;
+  }
+
+  template <typename Number>
+  typename Vector<Number>::real_type
+  Vector<Number>::linfty_norm() const
+  {
+    throw ExcNotImplemented();
+  }
+
+  template <typename Number>
+  typename Vector<Number>::real_type
+  Vector<Number>::l2_norm() const
+  {
+    auto result = ginkgo_norm_type::create(data_->get_executor()->get_master(),
+                                           gko::dim<2>{1, 1});
+    data_->compute_norm2(result.get());
+    return result->at(0);
+  }
+
+  template <typename Number>
+  typename Vector<Number>::real_type
+  Vector<Number>::l1_norm() const
+  {
+    auto result = ginkgo_norm_type ::create(data_->get_executor()->get_master(),
+                                            gko::dim<2>{1, 1});
+    data_->compute_norm1(result.get());
+    return result->at(0);
+  }
+
+  template <typename Number>
+  Number
+  Vector<Number>::mean_value() const
+  {
+    throw ExcNotImplemented();
+  }
+
+  template <typename Number>
+  bool
+  Vector<Number>::all_zero() const
+  {
+    auto norm = l1_norm();
+    return norm <=
+           1e2 * std::numeric_limits<gko::remove_complex<Number>>::min();
+  }
+
+  template <typename Number>
+  Vector<Number> &
+  Vector<Number>::operator=(const Number s)
+  {
+    data_->fill(s);
+    return *this;
+  }
+
+  template <typename Number>
+  void
+  Vector<Number>::equ(const Number a, const Vector &V)
+  {
+    AssertDimension(V.size(), size());
+    *this = V;
+    *this *= a;
+  }
+
+  template <typename Number>
+  void
+  Vector<Number>::scale(const Vector &scaling_factors)
+  {
+    AssertDimension(scaling_factors.size(), size());
+    auto exec = data_->get_executor();
+    auto col_view =
+      ginkgo_type::create(exec,
+                          gko::dim<2>{1, size()},
+                          gko::make_array_view(exec, size(), begin()),
+                          size());
+    col_view->scale(scaling_factors.data_.get());
+  }
+
+  template <typename Number>
+  void
+  Vector<Number>::sadd(const Number s, const Number a, const Vector &V)
+  {
+    AssertDimension(V.size(), size());
+    *this *= s;
+    this->add(a, V);
+  }
+
+  template <typename Number>
+  void
+  Vector<Number>::add(const Number  a,
+                      const Vector &V,
+                      const Number  b,
+                      const Vector &W)
+  {
+    AssertDimension(V.size(), size());
+    AssertDimension(W.size(), size());
+    Vector tmp(V);
+    tmp.add(b / a, W);
+    this->add(a, tmp);
+  }
+
+  template <typename Number>
+  void
+  Vector<Number>::add(const Number a, const Vector &V)
+  {
+    Assert(V.size() == size(), ExcDimensionMismatch(V.size(), size()));
+    auto a_dense = gko::initialize<ginkgo_type>({a}, data_->get_executor());
+    data_->add_scaled(a_dense.get(), V.data_.get());
+  }
+
+  template <typename Number>
+  void
+  Vector<Number>::add(const Number a)
+  {
+    auto a_vec = Vector(data_->get_executor(), size());
+    a_vec.data_->fill(a);
+    *this += a_vec;
+  }
+
+  template <typename Number>
+  Vector<Number> &
+  Vector<Number>::operator*=(const Number factor)
+  {
+    auto factor_dense =
+      gko::initialize<ginkgo_type>({factor}, data_->get_executor());
+    data_->scale(factor_dense.get());
+    return *this;
+  }
+
+  template <typename Number>
+  Vector<Number> &
+  Vector<Number>::operator/=(const Number factor)
+  {
+    auto factor_dense =
+      gko::initialize<ginkgo_type>({factor}, data_->get_executor());
+    data_->inv_scale(factor_dense.get());
+    return *this;
+  }
+
+  template <typename Number>
+  Vector<Number> &
+  Vector<Number>::operator+=(const Vector &V)
+  {
+    AssertDimension(V.size(), size());
+    auto one = gko::initialize<ginkgo_type>({1.0}, data_->get_executor());
+    data_->add_scaled(one.get(), V.data_.get());
+    return *this;
+  }
+
+  template <typename Number>
+  Vector<Number> &
+  Vector<Number>::operator-=(const Vector &V)
+  {
+    AssertDimension(V.size(), size());
+    auto neg_one = gko::initialize<ginkgo_type>({-1.0}, data_->get_executor());
+    data_->add_scaled(neg_one.get(), V.data_.get());
+    return *this;
+  }
+
+  template <typename Number>
+  Number
+  Vector<Number>::operator*(const Vector &V) const
+  {
+    AssertDimension(V.size(), size());
+    auto result = ginkgo_type ::create(data_->get_executor()->get_master(),
+                                       gko::dim<2>{1, 1});
+    data_->compute_conj_dot(V.data_.get(), result.get());
+    return result->at(0);
+  }
+
+  template <typename GinkgoType, typename ValueType>
+  std::unique_ptr<GinkgoType>
+  create_view_impl(std::shared_ptr<const gko::Executor> exec,
+                   types::global_dof_index              size,
+                   ValueType *                          data)
+  {
+    auto host_exec = exec->get_master();
+    return GinkgoType::create(host_exec,
+                              gko::dim<2>{size, 1},
+                              gko::make_array_view(host_exec, size, data),
+                              1);
+  }
+
+  template <typename Number>
+  std::unique_ptr<Vector<Number>>
+  Vector<Number>::create_view(
+    std::shared_ptr<const gko::Executor>              exec,
+    ::dealii::LinearAlgebra::ReadWriteVector<Number> &other)
+  {
+    return std::make_unique<Vector<Number>>(create_view_impl<ginkgo_type>(
+      std::move(exec), other.size(), other.begin()));
+  }
+
+  template <typename Number>
+  std::unique_ptr<Vector<Number>>
+  Vector<Number>::create_view(std::shared_ptr<const gko::Executor> exec,
+                              ::dealii::Vector<Number> &           other)
+  {
+    if (!exec->memory_accessible(exec->get_master()))
+      {
+        throw ExcInternalError(
+          "Can't create a view on CPU data, since the CPU memory is not accessible from the passed in executor.");
+      }
+    return std::make_unique<Vector<Number>>(create_view_impl<ginkgo_type>(
+      std::move(exec), other.size(), other.begin()));
+  }
+
+  template <typename Number>
+  std::unique_ptr<const Vector<Number>>
+  Vector<Number>::create_view(
+    std::shared_ptr<const gko::Executor>                    exec,
+    const ::dealii::LinearAlgebra::ReadWriteVector<Number> &other)
+  {
+    if (!exec->memory_accessible(exec->get_master()))
+      {
+        throw ExcInternalError(
+          "Can't create a view on CPU data, since the CPU memory is not accessible from the passed in executor.");
+      }
+    return std::make_unique<Vector<Number>>(create_view_impl<ginkgo_type>(
+      std::move(exec),
+      other.size(),
+      const_cast<
+        typename ::dealii::LinearAlgebra::ReadWriteVector<Number>::iterator>(
+        other.begin())));
+  }
+
+  template <typename Number>
+  std::unique_ptr<const Vector<Number>>
+  Vector<Number>::create_view(std::shared_ptr<const gko::Executor> exec,
+                              const ::dealii::Vector<Number> &     other)
+  {
+    return std::make_unique<Vector<Number>>(create_view_impl<ginkgo_type>(
+      std::move(exec),
+      other.size(),
+      const_cast<
+        typename ::dealii::LinearAlgebra::ReadWriteVector<Number>::iterator>(
+        other.begin())));
+  }
+
+  template <typename Number>
+  void
+  Vector<Number>::add(std::vector<unsigned int> &indices,
+                      std::vector<Number> &      values)
+  {
+    Assert(indices.size() == values.size(),
+           ExcDimensionMismatch(indices.size(), values.size()));
+    add(indices.size(), indices.data(), values.data());
+  }
+
+  template <typename Number>
+  void
+  Vector<Number>::add(const Vector::size_type  n_elements,
+                      const Vector::size_type *indices,
+                      const Number *           values)
+  {
+    auto host_data =
+      gko::make_temporary_clone(data_->get_executor()->get_master(), data_);
+    for (size_type i = 0; i < n_elements; ++i)
+      {
+        host_data->get_values()[indices[i]] = values[i];
+      }
+  }
+
+  template <typename Number>
+  bool
+  Vector<Number>::in_local_range(const Vector::size_type index) const
+  {
+    return index < size();
+  }
+  template <typename Number>
+  void
+  Vector<Number>::add(const std::vector<size_type> &indices,
+                      const dealii::Vector<Number> &values)
+  {
+    Assert(indices.size() == values.size(),
+           ExcDimensionMismatch(indices.size(), values.size()));
+    add(indices.size(), indices.data(), values.begin());
+  }
+
+
+#  define DECLARE_GINKGO_VECTOR(_type) class Vector<_type>
+
+  GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(DECLARE_GINKGO_VECTOR);
+
+#  undef DECLARE_GINKGO_VECTOR
+
+
+} // namespace GinkgoWrappers
+
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/tests/ginkgo/csr.cc
+++ b/tests/ginkgo/csr.cc
@@ -1,0 +1,181 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 - 2023 by the deal.II Authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Tests the GinkgoWrappers::Csr interface
+
+#include "deal.II/lac/dynamic_sparsity_pattern.h"
+
+#include "../tests.h"
+
+#include "test_macros.h"
+
+// all include files you need here
+#include <deal.II/lac/ginkgo_sparse_matrix.h>
+#include <deal.II/lac/sparse_matrix.h>
+
+
+auto exec = gko::ReferenceExecutor::create();
+
+
+TEST(can_create_with_size)
+{
+  GinkgoWrappers::Csr<double> m(exec, 3, 5);
+
+  TEST_ASSERT(m.m() == 3);
+  TEST_ASSERT(m.n() == 5);
+}
+
+TEST(can_create_from_ginkgo_object)
+{
+  auto csr =
+    gko::initialize<gko::matrix::Csr<double>>({{1, 2, 3}, {4, 5, 6}, {6, 7, 8}},
+                                              exec);
+  auto orig_csr = gko::clone(csr);
+
+  GinkgoWrappers::Csr<double> m(std::move(csr));
+
+  TEST_ASSERT(m.get_gko_object()->get_size() == orig_csr->get_size());
+  TEST_ASSERT(m.get_gko_object()->get_num_stored_elements() ==
+              orig_csr->get_num_stored_elements());
+  for (size_t i = 0; i < orig_csr->get_size()[0]; ++i)
+    {
+      TEST_ASSERT(orig_csr->get_row_ptrs()[i] ==
+                  m.get_gko_object()->get_const_row_ptrs()[i]);
+    }
+  for (size_t k = 0; k < orig_csr->get_num_stored_elements(); ++k)
+    {
+      TEST_ASSERT(orig_csr->get_col_idxs()[k] ==
+                  m.get_gko_object()->get_const_col_idxs()[k]);
+      TEST_ASSERT(orig_csr->get_values()[k] ==
+                  m.get_gko_object()->get_const_values()[k]);
+    }
+}
+
+
+TEST(can_create_from_dealii_object)
+{
+  std::vector<std::vector<unsigned int>> col_idxs{{0, 3}, {1}, {0, 2}};
+  dealii::SparsityPattern                pattern;
+  pattern.copy_from(3, 4, col_idxs.begin(), col_idxs.end());
+
+  dealii::SparseMatrix<double> dealii_obj(pattern);
+  dealii_obj.set(0, 0, 1);
+  dealii_obj.set(0, 3, 2);
+  dealii_obj.set(1, 1, 3);
+  dealii_obj.set(2, 0, 4);
+  dealii_obj.set(2, 2, 5);
+
+  GinkgoWrappers::Csr<double> csr(exec, dealii_obj);
+
+  auto obj = csr.get_gko_object();
+  TEST_ASSERT(obj->get_num_stored_elements() == 5);
+  TEST_ASSERT(obj->get_const_col_idxs()[0] == 0);
+  TEST_ASSERT(obj->get_const_col_idxs()[1] == 3);
+  TEST_ASSERT(obj->get_const_col_idxs()[2] == 1);
+  TEST_ASSERT(obj->get_const_col_idxs()[3] == 0);
+  TEST_ASSERT(obj->get_const_col_idxs()[4] == 2);
+  TEST_ASSERT(obj->get_const_values()[0] == 1);
+  TEST_ASSERT(obj->get_const_values()[1] == 2);
+  TEST_ASSERT(obj->get_const_values()[2] == 3);
+  TEST_ASSERT(obj->get_const_values()[3] == 4);
+  TEST_ASSERT(obj->get_const_values()[4] == 5);
+  TEST_ASSERT(obj->get_const_row_ptrs()[0] == 0);
+  TEST_ASSERT(obj->get_const_row_ptrs()[1] == 2);
+  TEST_ASSERT(obj->get_const_row_ptrs()[2] == 3);
+  TEST_ASSERT(obj->get_const_row_ptrs()[3] == 5);
+}
+
+
+TEST(can_vmult)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 1, 1});
+  GinkgoWrappers::Vector<double> u(exec, {1, 1, 1});
+  GinkgoWrappers::Csr<double>    m(
+    gko::initialize<gko::matrix::Csr<double>>({{1, 2, 3}, {4, 5, 6}, {6, 7, 8}},
+                                              exec));
+
+  m.vmult(u, v);
+
+  TEST_ASSERT(u[0] == 6);
+  TEST_ASSERT(u[1] == 15);
+  TEST_ASSERT(u[2] == 21);
+}
+
+
+TEST(can_vmult_add)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 1, 1});
+  GinkgoWrappers::Vector<double> u(exec, {1, 1, 1});
+  GinkgoWrappers::Csr<double>    m(
+    gko::initialize<gko::matrix::Csr<double>>({{1, 2, 3}, {4, 5, 6}, {6, 7, 8}},
+                                              exec));
+
+  m.vmult_add(u, v);
+
+  TEST_ASSERT(u[0] == 7);
+  TEST_ASSERT(u[1] == 16);
+  TEST_ASSERT(u[2] == 22);
+}
+
+
+TEST(can_tvmult)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 1, 1});
+  GinkgoWrappers::Vector<double> u(exec, {1, 1, 1});
+  GinkgoWrappers::Csr<double>    m(
+    gko::initialize<gko::matrix::Csr<double>>({{1, 2, 3}, {4, 5, 6}, {6, 7, 8}},
+                                              exec));
+
+  m.Tvmult(u, v);
+
+  TEST_ASSERT(u[0] == 11);
+  TEST_ASSERT(u[1] == 14);
+  TEST_ASSERT(u[2] == 17);
+}
+
+
+TEST(can_tvmult_add)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 1, 1});
+  GinkgoWrappers::Vector<double> u(exec, {1, 1, 1});
+  GinkgoWrappers::Csr<double>    m(
+    gko::initialize<gko::matrix::Csr<double>>({{1, 2, 3}, {4, 5, 6}, {6, 7, 8}},
+                                              exec));
+
+  m.Tvmult_add(u, v);
+
+  TEST_ASSERT(u[0] == 12);
+  TEST_ASSERT(u[1] == 15);
+  TEST_ASSERT(u[2] == 18);
+}
+
+
+int
+main()
+{
+  // Initialize deallog for test output.
+  // This also reroutes deallog output to a file "output".
+  initlog();
+
+  can_create_with_size();
+  can_create_from_ginkgo_object();
+  can_create_from_dealii_object();
+  can_vmult();
+  can_vmult_add();
+  can_tvmult();
+  can_tvmult_add();
+
+  return 0;
+}

--- a/tests/ginkgo/csr.output
+++ b/tests/ginkgo/csr.output
@@ -1,0 +1,8 @@
+
+DEAL:can_create_with_size:OK
+DEAL:can_create_from_ginkgo_object:OK
+DEAL:can_create_from_dealii_object:OK
+DEAL:can_vmult:OK
+DEAL:can_vmult_add:OK
+DEAL:can_tvmult:OK
+DEAL:can_tvmult_add:OK

--- a/tests/ginkgo/csr_formats.cc
+++ b/tests/ginkgo/csr_formats.cc
@@ -1,0 +1,90 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 - 2023 by the deal.II Authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Tests the GinkgoWrappers::Csr interface
+
+#include "deal.II/lac/dynamic_sparsity_pattern.h"
+
+#include "../tests.h"
+
+#include "test_macros.h"
+
+// all include files you need here
+#include <deal.II/lac/ginkgo_sparse_matrix.h>
+#include <deal.II/lac/sparse_matrix.h>
+
+
+auto exec = gko::ReferenceExecutor::create();
+
+
+TEST(can_create_coo)
+{
+  GinkgoWrappers::Coo<double> m(exec, 3, 5);
+
+  m.compress();
+
+  TEST_ASSERT(m.m() == 3);
+  TEST_ASSERT(m.n() == 5);
+}
+
+
+TEST(can_create_ell)
+{
+  GinkgoWrappers::Ell<double> m(exec, 3, 5);
+
+  m.compress();
+
+  TEST_ASSERT(m.m() == 3);
+  TEST_ASSERT(m.n() == 5);
+}
+
+
+TEST(can_create_hybrid)
+{
+  GinkgoWrappers::Hybrid<double> m(exec, 3, 5);
+
+  m.compress();
+
+  TEST_ASSERT(m.m() == 3);
+  TEST_ASSERT(m.n() == 5);
+}
+
+
+TEST(can_create_sellp)
+{
+  GinkgoWrappers::Sellp<double> m(exec, 3, 5);
+
+  m.compress();
+
+  TEST_ASSERT(m.m() == 3);
+  TEST_ASSERT(m.n() == 5);
+}
+
+
+
+int
+main()
+{
+  // Initialize deallog for test output.
+  // This also reroutes deallog output to a file "output".
+  initlog();
+
+  can_create_coo();
+  can_create_ell();
+  can_create_hybrid();
+  can_create_sellp();
+
+  return 0;
+}

--- a/tests/ginkgo/csr_formats.output
+++ b/tests/ginkgo/csr_formats.output
@@ -1,0 +1,5 @@
+
+DEAL:can_create_coo:OK
+DEAL:can_create_ell:OK
+DEAL:can_create_hybrid:OK
+DEAL:can_create_sellp:OK

--- a/tests/ginkgo/csr_manip.cc
+++ b/tests/ginkgo/csr_manip.cc
@@ -1,0 +1,352 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 - 2023 by the deal.II Authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Tests the GinkgoWrappers::Csr manipulation (set/add) interface
+
+#include "../tests.h"
+
+#include "test_macros.h"
+
+// all include files you need here
+#include <deal.II/lac/ginkgo_sparse_matrix.h>
+
+
+auto exec       = gko::ReferenceExecutor::create();
+using size_type = GinkgoWrappers::Csr<double>::size_type;
+
+
+TEST(can_set_single_value)
+{
+  GinkgoWrappers::Csr<double> m(exec, 3, 5);
+
+  m.set(2, 4, 4.4);
+  m.compress();
+
+  auto obj = m.get_gko_object();
+  TEST_ASSERT(obj->get_num_stored_elements() == 1);
+  TEST_ASSERT(obj->get_const_col_idxs()[0] == 4);
+  TEST_ASSERT(obj->get_const_values()[0] == 4.4);
+  TEST_ASSERT(obj->get_const_row_ptrs()[0] == 0);
+  TEST_ASSERT(obj->get_const_row_ptrs()[1] == 0);
+  TEST_ASSERT(obj->get_const_row_ptrs()[2] == 0);
+  TEST_ASSERT(obj->get_const_row_ptrs()[3] == 1);
+}
+
+TEST(can_set_full_matrix)
+{
+  GinkgoWrappers::Csr<double> m(exec, 3, 5);
+  FullMatrix<double>          k(2, 2);
+  k(0, 0) = 1;
+  k(0, 1) = 2;
+  k(1, 0) = 0;
+  k(1, 1) = 4;
+  std::vector<size_type> indices{0, 2};
+
+  m.set(indices, k, false);
+  m.compress();
+
+  auto obj = m.get_gko_object();
+  TEST_ASSERT(obj->get_num_stored_elements() == 4);
+  TEST_ASSERT(obj->get_const_col_idxs()[0] == 0);
+  TEST_ASSERT(obj->get_const_col_idxs()[1] == 2);
+  TEST_ASSERT(obj->get_const_col_idxs()[2] == 0);
+  TEST_ASSERT(obj->get_const_col_idxs()[3] == 2);
+  TEST_ASSERT(obj->get_const_values()[0] == 1);
+  TEST_ASSERT(obj->get_const_values()[1] == 2);
+  TEST_ASSERT(obj->get_const_values()[2] == 0);
+  TEST_ASSERT(obj->get_const_values()[3] == 4);
+  TEST_ASSERT(obj->get_const_row_ptrs()[0] == 0);
+  TEST_ASSERT(obj->get_const_row_ptrs()[1] == 2);
+  TEST_ASSERT(obj->get_const_row_ptrs()[2] == 2);
+  TEST_ASSERT(obj->get_const_row_ptrs()[3] == 4);
+}
+
+TEST(can_set_full_matrix_elide)
+{
+  GinkgoWrappers::Csr<double> m(exec, 3, 5);
+  FullMatrix<double>          k(2, 2);
+  k(0, 0) = 1;
+  k(0, 1) = 2;
+  k(1, 0) = 0;
+  k(1, 1) = 4;
+  std::vector<size_type> indices{0, 2};
+
+  m.set(indices, k, true);
+  m.compress();
+
+  auto obj = m.get_gko_object();
+  TEST_ASSERT(obj->get_num_stored_elements() == 3);
+  TEST_ASSERT(obj->get_const_col_idxs()[0] == 0);
+  TEST_ASSERT(obj->get_const_col_idxs()[1] == 2);
+  TEST_ASSERT(obj->get_const_col_idxs()[2] == 2);
+  TEST_ASSERT(obj->get_const_values()[0] == 1);
+  TEST_ASSERT(obj->get_const_values()[1] == 2);
+  TEST_ASSERT(obj->get_const_values()[2] == 4);
+  TEST_ASSERT(obj->get_const_row_ptrs()[0] == 0);
+  TEST_ASSERT(obj->get_const_row_ptrs()[1] == 2);
+  TEST_ASSERT(obj->get_const_row_ptrs()[2] == 2);
+  TEST_ASSERT(obj->get_const_row_ptrs()[3] == 3);
+}
+
+TEST(can_set_full_matrix_different_row_col_idxs)
+{
+  GinkgoWrappers::Csr<double> m(exec, 3, 5);
+  FullMatrix<double>          k(2, 2);
+  k(0, 0) = 1;
+  k(0, 1) = 2;
+  k(1, 0) = 0;
+  k(1, 1) = 4;
+  std::vector<size_type> row_indices{0, 2};
+  std::vector<size_type> col_indices{3, 4};
+
+  m.set(row_indices, col_indices, k, false);
+  m.compress();
+
+  auto obj = m.get_gko_object();
+  TEST_ASSERT(obj->get_num_stored_elements() == 4);
+  TEST_ASSERT(obj->get_const_col_idxs()[0] == 3);
+  TEST_ASSERT(obj->get_const_col_idxs()[1] == 4);
+  TEST_ASSERT(obj->get_const_col_idxs()[2] == 3);
+  TEST_ASSERT(obj->get_const_col_idxs()[3] == 4);
+  TEST_ASSERT(obj->get_const_values()[0] == 1);
+  TEST_ASSERT(obj->get_const_values()[1] == 2);
+  TEST_ASSERT(obj->get_const_values()[2] == 0);
+  TEST_ASSERT(obj->get_const_values()[3] == 4);
+  TEST_ASSERT(obj->get_const_row_ptrs()[0] == 0);
+  TEST_ASSERT(obj->get_const_row_ptrs()[1] == 2);
+  TEST_ASSERT(obj->get_const_row_ptrs()[2] == 2);
+  TEST_ASSERT(obj->get_const_row_ptrs()[3] == 4);
+}
+
+TEST(can_set_row)
+{
+  GinkgoWrappers::Csr<double> m(exec, 3, 5);
+  std::vector<double>         values{1, 2};
+  std::vector<size_type>      col_indices{3, 4};
+
+  m.set(1, col_indices, values, false);
+  m.compress();
+
+  auto obj = m.get_gko_object();
+  TEST_ASSERT(obj->get_num_stored_elements() == 2);
+  TEST_ASSERT(obj->get_const_col_idxs()[0] == 3);
+  TEST_ASSERT(obj->get_const_col_idxs()[1] == 4);
+  TEST_ASSERT(obj->get_const_values()[0] == 1);
+  TEST_ASSERT(obj->get_const_values()[1] == 2);
+  TEST_ASSERT(obj->get_const_row_ptrs()[0] == 0);
+  TEST_ASSERT(obj->get_const_row_ptrs()[1] == 0);
+  TEST_ASSERT(obj->get_const_row_ptrs()[2] == 2);
+  TEST_ASSERT(obj->get_const_row_ptrs()[3] == 2);
+}
+
+TEST(can_set_row_raw)
+{
+  GinkgoWrappers::Csr<double> m(exec, 3, 5);
+  std::vector<double>         values{1, 2};
+  std::vector<size_type>      col_indices{3, 4};
+
+  m.set(1, col_indices.size(), col_indices.data(), values.data(), false);
+  m.compress();
+
+  auto obj = m.get_gko_object();
+  TEST_ASSERT(obj->get_num_stored_elements() == 2);
+  TEST_ASSERT(obj->get_const_col_idxs()[0] == 3);
+  TEST_ASSERT(obj->get_const_col_idxs()[1] == 4);
+  TEST_ASSERT(obj->get_const_values()[0] == 1);
+  TEST_ASSERT(obj->get_const_values()[1] == 2);
+  TEST_ASSERT(obj->get_const_row_ptrs()[0] == 0);
+  TEST_ASSERT(obj->get_const_row_ptrs()[1] == 0);
+  TEST_ASSERT(obj->get_const_row_ptrs()[2] == 2);
+  TEST_ASSERT(obj->get_const_row_ptrs()[3] == 2);
+}
+
+TEST(can_add_single_value)
+{
+  GinkgoWrappers::Csr<double> m(exec, 3, 5);
+
+  m.add(2, 4, 1.1);
+  m.add(2, 4, 4.4);
+  m.compress();
+
+  auto obj = m.get_gko_object();
+  TEST_ASSERT(obj->get_num_stored_elements() == 1);
+  TEST_ASSERT(obj->get_const_col_idxs()[0] == 4);
+  TEST_ASSERT(obj->get_const_values()[0] == 5.5);
+  TEST_ASSERT(obj->get_const_row_ptrs()[0] == 0);
+  TEST_ASSERT(obj->get_const_row_ptrs()[1] == 0);
+  TEST_ASSERT(obj->get_const_row_ptrs()[2] == 0);
+  TEST_ASSERT(obj->get_const_row_ptrs()[3] == 1);
+}
+
+TEST(can_add_full_matrix)
+{
+  GinkgoWrappers::Csr<double> m(exec, 3, 5);
+  FullMatrix<double>          k(2, 2);
+  k(0, 0) = 1;
+  k(0, 1) = 2;
+  k(1, 0) = 0;
+  k(1, 1) = 4;
+
+  m.add({0, 2}, k, false);
+  m.add({1, 2}, k, false);
+  m.compress();
+
+  auto obj = m.get_gko_object();
+  TEST_ASSERT(obj->get_num_stored_elements() == 7);
+  TEST_ASSERT(obj->get_const_col_idxs()[0] == 0);
+  TEST_ASSERT(obj->get_const_col_idxs()[1] == 2);
+  TEST_ASSERT(obj->get_const_col_idxs()[2] == 1);
+  TEST_ASSERT(obj->get_const_col_idxs()[3] == 2);
+  TEST_ASSERT(obj->get_const_col_idxs()[4] == 0);
+  TEST_ASSERT(obj->get_const_col_idxs()[5] == 1);
+  TEST_ASSERT(obj->get_const_col_idxs()[6] == 2);
+  TEST_ASSERT(obj->get_const_values()[0] == 1);
+  TEST_ASSERT(obj->get_const_values()[1] == 2);
+  TEST_ASSERT(obj->get_const_values()[2] == 1);
+  TEST_ASSERT(obj->get_const_values()[3] == 2);
+  TEST_ASSERT(obj->get_const_values()[4] == 0);
+  TEST_ASSERT(obj->get_const_values()[5] == 0);
+  TEST_ASSERT(obj->get_const_values()[6] == 8);
+  TEST_ASSERT(obj->get_const_row_ptrs()[0] == 0);
+  TEST_ASSERT(obj->get_const_row_ptrs()[1] == 2);
+  TEST_ASSERT(obj->get_const_row_ptrs()[2] == 4);
+  TEST_ASSERT(obj->get_const_row_ptrs()[3] == 7);
+}
+
+TEST(can_add_full_matrix_elide)
+{
+  GinkgoWrappers::Csr<double> m(exec, 3, 5);
+  FullMatrix<double>          k(2, 2);
+  k(0, 0) = 1;
+  k(0, 1) = 2;
+  k(1, 0) = 0;
+  k(1, 1) = 4;
+
+  m.add({0, 2}, k, true);
+  m.add({1, 2}, k, true);
+  m.compress();
+
+  auto obj = m.get_gko_object();
+  TEST_ASSERT(obj->get_num_stored_elements() == 5);
+  TEST_ASSERT(obj->get_const_col_idxs()[0] == 0);
+  TEST_ASSERT(obj->get_const_col_idxs()[1] == 2);
+  TEST_ASSERT(obj->get_const_col_idxs()[2] == 1);
+  TEST_ASSERT(obj->get_const_col_idxs()[3] == 2);
+  TEST_ASSERT(obj->get_const_col_idxs()[4] == 2);
+  TEST_ASSERT(obj->get_const_values()[0] == 1);
+  TEST_ASSERT(obj->get_const_values()[1] == 2);
+  TEST_ASSERT(obj->get_const_values()[2] == 1);
+  TEST_ASSERT(obj->get_const_values()[3] == 2);
+  TEST_ASSERT(obj->get_const_values()[4] == 8);
+  TEST_ASSERT(obj->get_const_row_ptrs()[0] == 0);
+  TEST_ASSERT(obj->get_const_row_ptrs()[1] == 2);
+  TEST_ASSERT(obj->get_const_row_ptrs()[2] == 4);
+  TEST_ASSERT(obj->get_const_row_ptrs()[3] == 5);
+}
+
+TEST(can_add_full_matrix_different_row_col_idxs)
+{
+  GinkgoWrappers::Csr<double> m(exec, 3, 5);
+  FullMatrix<double>          k(2, 2);
+  k(0, 0) = 1;
+  k(0, 1) = 2;
+  k(1, 0) = 0;
+  k(1, 1) = 4;
+  std::vector<size_type> row_indices{0, 2};
+  std::vector<size_type> col_indices{3, 4};
+
+  m.add(row_indices, col_indices, k, false);
+  m.compress();
+
+  auto obj = m.get_gko_object();
+  TEST_ASSERT(obj->get_num_stored_elements() == 4);
+  TEST_ASSERT(obj->get_const_col_idxs()[0] == 3);
+  TEST_ASSERT(obj->get_const_col_idxs()[1] == 4);
+  TEST_ASSERT(obj->get_const_col_idxs()[2] == 3);
+  TEST_ASSERT(obj->get_const_col_idxs()[3] == 4);
+  TEST_ASSERT(obj->get_const_values()[0] == 1);
+  TEST_ASSERT(obj->get_const_values()[1] == 2);
+  TEST_ASSERT(obj->get_const_values()[2] == 0);
+  TEST_ASSERT(obj->get_const_values()[3] == 4);
+  TEST_ASSERT(obj->get_const_row_ptrs()[0] == 0);
+  TEST_ASSERT(obj->get_const_row_ptrs()[1] == 2);
+  TEST_ASSERT(obj->get_const_row_ptrs()[2] == 2);
+  TEST_ASSERT(obj->get_const_row_ptrs()[3] == 4);
+}
+
+TEST(can_add_row)
+{
+  GinkgoWrappers::Csr<double> m(exec, 3, 5);
+  std::vector<double>         values{1, 2};
+  std::vector<size_type>      col_indices{3, 4};
+
+  m.add(1, col_indices, values, false);
+  m.compress();
+
+  auto obj = m.get_gko_object();
+  TEST_ASSERT(obj->get_num_stored_elements() == 2);
+  TEST_ASSERT(obj->get_const_col_idxs()[0] == 3);
+  TEST_ASSERT(obj->get_const_col_idxs()[1] == 4);
+  TEST_ASSERT(obj->get_const_values()[0] == 1);
+  TEST_ASSERT(obj->get_const_values()[1] == 2);
+  TEST_ASSERT(obj->get_const_row_ptrs()[0] == 0);
+  TEST_ASSERT(obj->get_const_row_ptrs()[1] == 0);
+  TEST_ASSERT(obj->get_const_row_ptrs()[2] == 2);
+  TEST_ASSERT(obj->get_const_row_ptrs()[3] == 2);
+}
+
+TEST(can_add_row_raw)
+{
+  GinkgoWrappers::Csr<double> m(exec, 3, 5);
+  std::vector<double>         values{1, 2};
+  std::vector<size_type>      col_indices{3, 4};
+
+  m.add(1, col_indices.size(), col_indices.data(), values.data(), false);
+  m.compress();
+
+  auto obj = m.get_gko_object();
+  TEST_ASSERT(obj->get_num_stored_elements() == 2);
+  TEST_ASSERT(obj->get_const_col_idxs()[0] == 3);
+  TEST_ASSERT(obj->get_const_col_idxs()[1] == 4);
+  TEST_ASSERT(obj->get_const_values()[0] == 1);
+  TEST_ASSERT(obj->get_const_values()[1] == 2);
+  TEST_ASSERT(obj->get_const_row_ptrs()[0] == 0);
+  TEST_ASSERT(obj->get_const_row_ptrs()[1] == 0);
+  TEST_ASSERT(obj->get_const_row_ptrs()[2] == 2);
+  TEST_ASSERT(obj->get_const_row_ptrs()[3] == 2);
+}
+
+int
+main()
+{
+  // Initialize deallog for test output.
+  // This also reroutes deallog output to a file "output".
+  initlog();
+
+  can_set_single_value();
+  can_set_full_matrix();
+  can_set_full_matrix_elide();
+  can_set_full_matrix_different_row_col_idxs();
+  can_set_row();
+  can_set_row_raw();
+  can_add_single_value();
+  can_add_full_matrix();
+  can_add_full_matrix_elide();
+  can_add_full_matrix_different_row_col_idxs();
+  can_add_row();
+  can_add_row_raw();
+
+  return 0;
+}

--- a/tests/ginkgo/csr_manip.output
+++ b/tests/ginkgo/csr_manip.output
@@ -1,0 +1,13 @@
+
+DEAL:can_set_single_value:OK
+DEAL:can_set_full_matrix:OK
+DEAL:can_set_full_matrix_elide:OK
+DEAL:can_set_full_matrix_different_row_col_idxs:OK
+DEAL:can_set_row:OK
+DEAL:can_set_row_raw:OK
+DEAL:can_add_single_value:OK
+DEAL:can_add_full_matrix:OK
+DEAL:can_add_full_matrix_elide:OK
+DEAL:can_add_full_matrix_different_row_col_idxs:OK
+DEAL:can_add_row:OK
+DEAL:can_add_row_raw:OK

--- a/tests/ginkgo/test_macros.h
+++ b/tests/ginkgo/test_macros.h
@@ -1,0 +1,95 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 - 2023 by the deal.II Authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_test_setup_h
+#define dealii_test_setup_h
+
+#include <ginkgo/ginkgo.hpp>
+
+
+template <typename T>
+gko::remove_complex<T>
+get_relative_error(const T a, const T b)
+{
+  return std::abs(a - b) / std::max(std::abs(a), std::abs(b));
+}
+
+template <typename T>
+constexpr gko::remove_complex<T>
+  tol = 10 * std::numeric_limits<gko::remove_complex<T>>::epsilon();
+
+
+#define TEST_ASSERT(_assertion)                                     \
+  if (!(_assertion))                                                \
+    {                                                               \
+      deallog << std::string(TEST_name) + ":FAIL with " #_assertion \
+              << std::endl;                                         \
+      self->test_success = false;                                   \
+      return;                                                       \
+    }                                                               \
+  static_assert(true, "Enforce ; after macro")
+
+
+#define TEST_ASSERT_NEAR(_a, _b, _tol)                                  \
+  {                                                                     \
+    auto rel_err = get_relative_error(_a, _b);                          \
+    if (!(rel_err <= _tol))                                             \
+      {                                                                 \
+        deallog << std::string(TEST_name) + ":FAIL with rel_error(" #_a \
+                                            ", " #_b ")["               \
+                << rel_err << "] <= " << _tol << std::endl;             \
+        self->test_success = false;                                     \
+        return;                                                         \
+      }                                                                 \
+  }                                                                     \
+  static_assert(true, "Enforce ; after macro")
+
+
+#define TEST_ASSERT_THROW(_cmd, _expected_exc) \
+  try                                          \
+    {                                          \
+      _cmd;                                    \
+      self->test_success = false;              \
+      return;                                  \
+    }                                          \
+  catch (const _expected_exc &)                \
+    {}                                         \
+  static_assert(true, "Enforce ; after macro")
+
+
+
+#define TEST(_name)                                             \
+  struct _name                                                  \
+  {                                                             \
+    _name()                                                     \
+      : test_success(true)                                      \
+    {                                                           \
+      _name::run(this);                                         \
+      if (test_success)                                         \
+        deallog << std::string(TEST_name) + ":OK" << std::endl; \
+    }                                                           \
+                                                                \
+    static void                                                 \
+    run(_name *self);                                           \
+                                                                \
+    static constexpr char TEST_name[] = #_name;                 \
+                                                                \
+    bool test_success;                                          \
+  };                                                            \
+  constexpr char _name::TEST_name[];                            \
+  void           _name::run(_name *self)
+
+
+#endif // dealii_test_setup_h

--- a/tests/ginkgo/vector.cc
+++ b/tests/ginkgo/vector.cc
@@ -1,0 +1,169 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 - 2023 by the deal.II Authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Tests the GinkgoWrappers::Vector interface
+
+#include "../tests.h"
+
+#include "test_macros.h"
+
+// all include files you need here
+#include <deal.II/lac/ginkgo_vector.h>
+
+
+auto exec = gko::ReferenceExecutor::create();
+
+
+TEST(can_create_from_executor)
+{
+  GinkgoWrappers::Vector<double> v(exec);
+
+  TEST_ASSERT(v.size() == 0);
+}
+
+
+TEST(can_create_from_ginkgo_object)
+{
+  GinkgoWrappers::Vector<double> v(
+    gko::initialize<gko::matrix::Dense<double>>({1, 2, 3}, exec));
+
+  TEST_ASSERT(v[0] == 1);
+  TEST_ASSERT(v[1] == 2);
+  TEST_ASSERT(v[2] == 3);
+}
+
+
+TEST(can_create_from_size)
+{
+  GinkgoWrappers::Vector<double> v(exec, 7);
+
+  TEST_ASSERT(v.size() == 7);
+}
+
+
+TEST(can_create_from_initializer_list)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 5, 3, 9});
+
+  TEST_ASSERT(v[0] == 1);
+  TEST_ASSERT(v[1] == 5);
+  TEST_ASSERT(v[2] == 3);
+  TEST_ASSERT(v[3] == 9);
+}
+
+
+TEST(can_copy_construct)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 5, 3, 9});
+
+  GinkgoWrappers::Vector<double> v2(v);
+
+  TEST_ASSERT(v2.size() == v.size());
+  TEST_ASSERT(v2.get_gko_object() != v.get_gko_object());
+  for (std::size_t i = 0; i < v.size(); ++i)
+    {
+      TEST_ASSERT(v2[i] == v[i]);
+    }
+}
+
+
+TEST(can_move_construct)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 5, 3, 9});
+
+  GinkgoWrappers::Vector<double> v2(std::move(v));
+
+  TEST_ASSERT(v2.size() == 4);
+  TEST_ASSERT(v.size() == 0);
+  TEST_ASSERT(v2.get_gko_object() != v.get_gko_object());
+  TEST_ASSERT(v2[0] == 1);
+  TEST_ASSERT(v2[1] == 5);
+  TEST_ASSERT(v2[2] == 3);
+  TEST_ASSERT(v2[3] == 9);
+}
+
+
+TEST(can_access_ginkgo_object)
+{
+  GinkgoWrappers::Vector<double> v(exec, 10);
+
+  auto obj = v.get_gko_object();
+
+  TEST_ASSERT(obj);
+}
+
+
+TEST(wrapper_same_as_ginkgo_object)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 5, 3, 9});
+
+  auto obj = v.get_gko_object();
+
+  TEST_ASSERT(obj->get_size()[0] == v.size());
+  TEST_ASSERT(obj->get_size()[1] == 1);
+  for (std::size_t i = 0; i < v.size(); ++i)
+    {
+      TEST_ASSERT(obj->at(i) == v[i]);
+    }
+}
+
+TEST(can_create_view_of_dealii_object)
+{
+  std::vector<double>                   values{3, 5, 2};
+  dealii::LinearAlgebra::Vector<double> dealii_obj(values.begin(),
+                                                   values.end());
+
+  auto v = GinkgoWrappers::Vector<double>::create_view(exec, dealii_obj);
+
+  TEST_ASSERT(v->size() == dealii_obj.size());
+  TEST_ASSERT(v->begin() == dealii_obj.begin());
+}
+
+TEST(can_create_view_of_const_dealii_object)
+{
+  std::vector<double>                   values{3, 5, 2};
+  dealii::LinearAlgebra::Vector<double> dealii_obj(values.begin(),
+                                                   values.end());
+
+  auto v = GinkgoWrappers::Vector<double>::create_view(
+    exec,
+    static_cast<const dealii::LinearAlgebra::Vector<double> &>(dealii_obj));
+
+  TEST_ASSERT(v->size() == dealii_obj.size());
+  TEST_ASSERT(v->begin() == dealii_obj.begin());
+  TEST_ASSERT(
+    std::is_const<typename std::decay<decltype(v)>::type::element_type>::value);
+}
+
+int
+main()
+{
+  // Initialize deallog for test output.
+  // This also reroutes deallog output to a file "output".
+  initlog();
+
+  can_create_from_executor();
+  can_create_from_ginkgo_object();
+  can_create_from_size();
+  can_create_from_initializer_list();
+  can_copy_construct();
+  can_move_construct();
+  can_access_ginkgo_object();
+  wrapper_same_as_ginkgo_object();
+  can_create_view_of_dealii_object();
+  can_create_view_of_const_dealii_object();
+
+  return 0;
+}

--- a/tests/ginkgo/vector.output
+++ b/tests/ginkgo/vector.output
@@ -1,0 +1,11 @@
+
+DEAL:can_create_from_executor:OK
+DEAL:can_create_from_ginkgo_object:OK
+DEAL:can_create_from_size:OK
+DEAL:can_create_from_initializer_list:OK
+DEAL:can_copy_construct:OK
+DEAL:can_move_construct:OK
+DEAL:can_access_ginkgo_object:OK
+DEAL:wrapper_same_as_ginkgo_object:OK
+DEAL:can_create_view_of_dealii_object:OK
+DEAL:can_create_view_of_const_dealii_object:OK

--- a/tests/ginkgo/vector_ops.cc
+++ b/tests/ginkgo/vector_ops.cc
@@ -1,0 +1,175 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 - 2023 by the deal.II Authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Tests the GinkgoWrappers::Vector interface for vector space operations
+
+#include "../tests.h"
+
+#include "test_macros.h"
+
+// all include files you need here
+#include <deal.II/lac/ginkgo_vector.h>
+
+auto exec = gko::ReferenceExecutor::create();
+
+
+
+TEST(can_set_to_number)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 2, 3, 4});
+
+  v = 3.3;
+
+  TEST_ASSERT_NEAR(v[0], 3.3, tol<double>);
+  TEST_ASSERT_NEAR(v[1], 3.3, tol<double>);
+  TEST_ASSERT_NEAR(v[2], 3.3, tol<double>);
+  TEST_ASSERT_NEAR(v[3], 3.3, tol<double>);
+}
+
+TEST(can_scale_with_number)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 2, 3, 4});
+
+  v *= 3.3;
+
+  TEST_ASSERT_NEAR(v[0], 3.3, tol<double>);
+  TEST_ASSERT_NEAR(v[1], 6.6, tol<double>);
+  TEST_ASSERT_NEAR(v[2], 9.9, tol<double>);
+  TEST_ASSERT_NEAR(v[3], 13.2, tol<double>);
+}
+
+TEST(can_divide_by_number)
+{
+  GinkgoWrappers::Vector<double> v(exec, {3.3, 6.6, 9.9, 13.2});
+
+  v /= 3.3;
+
+  TEST_ASSERT_NEAR(v[0], 1.0, tol<double>);
+  TEST_ASSERT_NEAR(v[1], 2.0, tol<double>);
+  TEST_ASSERT_NEAR(v[2], 3.0, tol<double>);
+  TEST_ASSERT_NEAR(v[3], 4.0, tol<double>);
+}
+
+TEST(can_add_vector)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 2, 3, 4});
+  GinkgoWrappers::Vector<double> w(exec, {4, 3, 2, 1});
+
+  v += w;
+
+  for (size_t i = 0; i < v.size(); ++i)
+    {
+      TEST_ASSERT_NEAR(v[i], 5.0, tol<double>);
+    }
+}
+
+TEST(can_substract_vector)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 2, 3, 4});
+  GinkgoWrappers::Vector<double> w(exec, {4, 3, 2, 1});
+
+  v -= w;
+
+  TEST_ASSERT_NEAR(v[0], -3.0, tol<double>);
+  TEST_ASSERT_NEAR(v[1], -1.0, tol<double>);
+  TEST_ASSERT_NEAR(v[2], 1.0, tol<double>);
+  TEST_ASSERT_NEAR(v[3], 3.0, tol<double>);
+}
+
+TEST(can_add_number)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 2, 3, 4});
+
+  v.add(3.3);
+
+  TEST_ASSERT_NEAR(v[0], 4.3, tol<double>);
+  TEST_ASSERT_NEAR(v[1], 5.3, tol<double>);
+  TEST_ASSERT_NEAR(v[2], 6.3, tol<double>);
+  TEST_ASSERT_NEAR(v[3], 7.3, tol<double>);
+}
+
+TEST(can_add_number_vector)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 2, 3, 4});
+  GinkgoWrappers::Vector<double> w(exec, {4, 3, 2, 1});
+
+  v.add(3.3, w);
+
+  TEST_ASSERT_NEAR(v[0], 14.2, tol<double>);
+  TEST_ASSERT_NEAR(v[1], 11.9, tol<double>);
+  TEST_ASSERT_NEAR(v[2], 9.6, tol<double>);
+  TEST_ASSERT_NEAR(v[3], 7.3, tol<double>);
+}
+
+TEST(can_add_number_vector_number_vector)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 2, 3, 4});
+  GinkgoWrappers::Vector<double> w(exec, {4, 3, 2, 1});
+  GinkgoWrappers::Vector<double> u(exec, {2, 1, 4, 3});
+
+  v.add(1.1, w, 2.2, u);
+
+  TEST_ASSERT_NEAR(v[0], 9.8, tol<double>);
+  TEST_ASSERT_NEAR(v[1], 7.5, tol<double>);
+  TEST_ASSERT_NEAR(v[2], 14.0, tol<double>);
+  TEST_ASSERT_NEAR(v[3], 11.7, tol<double>);
+}
+
+TEST(can_sadd_number_number_vector)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 2, 3, 4});
+  GinkgoWrappers::Vector<double> w(exec, {4, 3, 2, 1});
+
+  v.sadd(1.1, 2.2, w);
+
+  TEST_ASSERT_NEAR(v[0], 9.9, tol<double>);
+  TEST_ASSERT_NEAR(v[1], 8.8, tol<double>);
+  TEST_ASSERT_NEAR(v[2], 7.7, tol<double>);
+  TEST_ASSERT_NEAR(v[3], 6.6, tol<double>);
+}
+
+TEST(can_equ)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 2, 3, 4});
+  GinkgoWrappers::Vector<double> w(exec, {4, 3, 2, 1});
+
+  v.equ(2.2, w);
+
+  TEST_ASSERT_NEAR(v[0], 8.8, tol<double>);
+  TEST_ASSERT_NEAR(v[1], 6.6, tol<double>);
+  TEST_ASSERT_NEAR(v[2], 4.4, tol<double>);
+  TEST_ASSERT_NEAR(v[3], 2.2, tol<double>);
+}
+
+int
+main()
+{
+  // Initialize deallog for test output.
+  // This also reroutes deallog output to a file "output".
+  initlog();
+
+  can_set_to_number();
+  can_scale_with_number();
+  can_divide_by_number();
+  can_add_vector();
+  can_substract_vector();
+  can_add_number();
+  can_add_number_vector();
+  can_add_number_vector_number_vector();
+  can_sadd_number_number_vector();
+  can_equ();
+
+  return 0;
+}

--- a/tests/ginkgo/vector_ops.output
+++ b/tests/ginkgo/vector_ops.output
@@ -1,0 +1,11 @@
+
+DEAL:can_set_to_number:OK
+DEAL:can_scale_with_number:OK
+DEAL:can_divide_by_number:OK
+DEAL:can_add_vector:OK
+DEAL:can_substract_vector:OK
+DEAL:can_add_number:OK
+DEAL:can_add_number_vector:OK
+DEAL:can_add_number_vector_number_vector:OK
+DEAL:can_sadd_number_number_vector:OK
+DEAL:can_equ:OK

--- a/tests/ginkgo/vector_sp.cc
+++ b/tests/ginkgo/vector_sp.cc
@@ -1,0 +1,112 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 - 2023 by the deal.II Authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Tests the GinkgoWrappers::Vector interface for vector space operations that
+// rely on reductions
+
+#include "../tests.h"
+
+#include "test_macros.h"
+
+// all include files you need here
+#include <deal.II/lac/ginkgo_vector.h>
+
+auto exec = gko::ReferenceExecutor::create();
+
+TEST(can_compute_scalar_product)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 2, 3, 4});
+  GinkgoWrappers::Vector<double> w(exec, {4, 3, 2, 1});
+
+  auto sp = v * w;
+
+  TEST_ASSERT_NEAR(sp, 20.0, tol<double>);
+}
+
+TEST(can_compute_l1_norm)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, -2, 3, -4});
+
+  auto norm = v.l1_norm();
+
+  TEST_ASSERT_NEAR(norm, 10.0, tol<double>);
+}
+
+TEST(can_compute_l2_norm)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, -2, 3, -4});
+
+  auto norm = v.l2_norm();
+
+  TEST_ASSERT_NEAR(norm, std::sqrt(30), tol<double>);
+}
+
+TEST(throws_on_linfty_norm)
+{
+  GinkgoWrappers::Vector<double> v(exec);
+
+  TEST_ASSERT_THROW(v.linfty_norm(), ExcNotImplemented);
+}
+
+TEST(can_compute_add_and_dot)
+{
+  GinkgoWrappers::Vector<double> v(exec, {1, 2, 3, 4});
+  GinkgoWrappers::Vector<double> w(exec, {4, 3, 2, 1});
+  GinkgoWrappers::Vector<double> u(exec, {2, 1, 4, 3});
+
+  auto sp = v.add_and_dot(3.3, w, u);
+
+  TEST_ASSERT_NEAR(sp, 100.6, tol<double>);
+}
+
+TEST(can_compute_all_zero)
+{
+  {
+    GinkgoWrappers::Vector<double> v(exec, {1, 5, 3, 9});
+
+    TEST_ASSERT(v.all_zero() == false);
+  }
+  {
+    GinkgoWrappers::Vector<double> v(exec, {0, 0, 0});
+
+    TEST_ASSERT(v.all_zero() == true);
+  }
+}
+
+TEST(throws_on_mean_value)
+{
+  GinkgoWrappers::Vector<double> v(exec);
+
+  TEST_ASSERT_THROW(v.mean_value(), ExcNotImplemented);
+}
+
+
+int
+main()
+{
+  // Initialize deallog for test output.
+  // This also reroutes deallog output to a file "output".
+  initlog();
+
+  can_compute_scalar_product();
+  can_compute_l1_norm();
+  can_compute_l2_norm();
+  throws_on_linfty_norm();
+  can_compute_add_and_dot();
+  can_compute_all_zero();
+  throws_on_mean_value();
+
+  return 0;
+}

--- a/tests/ginkgo/vector_sp.output
+++ b/tests/ginkgo/vector_sp.output
@@ -1,0 +1,8 @@
+
+DEAL:can_compute_scalar_product:OK
+DEAL:can_compute_l1_norm:OK
+DEAL:can_compute_l2_norm:OK
+DEAL:throws_on_linfty_norm:OK
+DEAL:can_compute_add_and_dot:OK
+DEAL:can_compute_all_zero:OK
+DEAL:throws_on_mean_value:OK


### PR DESCRIPTION
This PR updates the Ginkgo solver wrappers to the new vector and matrix wrappers, introduced in the PRs #15190, #15202. This PR also contains the changes from the other two PRs. Additionally, it introduces wrappers for Ginkgo preconditioners, although only a (block) Jacobi preconditioner is present currently.

Related PRs: 
- #15190 
- #15202

Todo:
- [ ] Add more preconditioner wrappers.