### PR TITLE
Adds create_with_same_size function

### DIFF
--- a/include/deal.II/fe/fe_tools_interpolate.templates.h
+++ b/include/deal.II/fe/fe_tools_interpolate.templates.h
@@ -704,8 +704,9 @@ namespace FETools
       // and we cannot use the sadd function directly, so we have to create
       // a completely distributed vector first and copy the local entries
       // from the vector with ghost entries
-      TrilinosWrappers::MPI::Vector u1_completely_distributed;
-      u1_completely_distributed.reinit(u1_difference, true);
+      auto u1_completely_distributed =
+        TrilinosWrappers::MPI::Vector::create_with_same_size(u1_difference,
+                                                             true);
       u1_completely_distributed = u1;
 
       u1_difference.sadd(-1, u1_completely_distributed);

--- a/include/deal.II/lac/block_vector.h
+++ b/include/deal.II/lac/block_vector.h
@@ -163,6 +163,17 @@ public:
               const InputIterator           first,
               const InputIterator           end);
 
+
+  /**
+   * Creates a new block vector with the same size as the input vector @p V. If
+   * @p omit_zeroing_entries is false, the entries of the new vector will be
+   * initialized with zeros.
+   */
+  template <typename Number2>
+  static BlockVector
+  create_with_same_size(const BlockVector<Number2> &V,
+                        const bool omit_zeroing_entries = false);
+
   /**
    * Destructor. Clears memory
    */
@@ -394,6 +405,19 @@ BlockVector<Number>::BlockVector(const std::vector<size_type> &block_sizes,
       start = end;
     };
   Assert(start == end, ExcIteratorRangeDoesNotMatchVectorSize());
+}
+
+
+
+template <typename Number>
+template <typename Number2>
+BlockVector<Number>
+BlockVector<Number>::create_with_same_size(const BlockVector<Number2> &V,
+                                           const bool omit_zeroing_entries)
+{
+  BlockVector result;
+  result.reinit(V, omit_zeroing_entries);
+  return result;
 }
 
 

--- a/include/deal.II/lac/cuda_vector.h
+++ b/include/deal.II/lac/cuda_vector.h
@@ -87,6 +87,15 @@ namespace LinearAlgebra
       explicit Vector(const size_type n);
 
       /**
+       * Creates a new vector with the same size as the input vector @p V. If
+       * @p omit_zeroing_entries is false, the entries of the new vector will be
+       * initialized with zeros.
+       */
+      static Vector
+      create_with_same_size(const VectorSpaceVector &V,
+                            const bool omit_zeroing_entries = false);
+
+      /**
        * Copy assignment operator.
        */
       Vector &

--- a/include/deal.II/lac/la_parallel_block_vector.h
+++ b/include/deal.II/lac/la_parallel_block_vector.h
@@ -177,6 +177,16 @@ namespace LinearAlgebra
                   const MPI_Comm               communicator);
 
       /**
+       * Creates a new block vector with the same size as the input vector @p V. If
+       * @p omit_zeroing_entries is false, the entries of the new vector will be
+       * initialized with zeros.
+       */
+      template <typename Number2>
+      static BlockVector
+      create_with_same_size(const BlockVector<Number2> &V,
+                            const bool omit_zeroing_entries = false);
+
+      /**
        * Destructor.
        *
        * @note We need to explicitly provide a destructor, otherwise the

--- a/include/deal.II/lac/la_parallel_block_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_block_vector.templates.h
@@ -101,6 +101,19 @@ namespace LinearAlgebra
 
 
     template <typename Number>
+    template <typename Number2>
+    BlockVector<Number>
+    BlockVector<Number>::create_with_same_size(const BlockVector<Number2> &V,
+                                               const bool omit_zeroing_entries)
+    {
+      BlockVector result;
+      result.reinit(V, omit_zeroing_entries);
+      return result;
+    }
+
+
+
+    template <typename Number>
     void
     BlockVector<Number>::reinit(const size_type n_bl,
                                 const size_type bl_sz,

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -333,6 +333,16 @@ namespace LinearAlgebra
         const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner);
 
       /**
+       * Creates a new vector with the same size as the input vector @p V. If
+       * @p omit_zeroing_entries is false, the entries of the new vector will be
+       * initialized with zeros.
+       */
+      template <typename Number2>
+      static Vector
+      create_with_same_size(const Vector<Number2, MemorySpace> &V,
+                            const bool omit_zeroing_entries = false);
+
+      /**
        * Destructor.
        */
       virtual ~Vector() override;

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -783,6 +783,20 @@ namespace LinearAlgebra
 
 
     template <typename Number, typename MemorySpaceType>
+    template <typename Number2>
+    inline Vector<Number, MemorySpaceType>
+    Vector<Number, MemorySpaceType>::create_with_same_size(
+      const Vector<Number2, MemorySpaceType> &V,
+      const bool                              omit_zeroing_entries)
+    {
+      Vector result;
+      result.reinit(V, omit_zeroing_entries);
+      return result;
+    }
+
+
+
+    template <typename Number, typename MemorySpaceType>
     inline Vector<Number, MemorySpaceType>::~Vector()
     {
       try

--- a/include/deal.II/lac/la_vector.h
+++ b/include/deal.II/lac/la_vector.h
@@ -113,6 +113,15 @@ namespace LinearAlgebra
     Vector(const InputIterator first, const InputIterator last);
 
     /**
+     * Creates a new vector with the same size as the input vector @p V. If
+     * @p omit_zeroing_entries is false, the entries of the new vector will be
+     * initialized with zeros.
+     */
+    static Vector
+    create_with_same_size(const VectorSpaceVector<Number> &V,
+                          const bool omit_zeroing_entries = false);
+
+    /**
      * Set the global size of the vector to @p size. The stored elements have
      * their index in [0,size).
      *
@@ -446,6 +455,18 @@ namespace LinearAlgebra
   {
     this->reinit(complete_index_set(std::distance(first, last)), true);
     std::copy(first, last, this->begin());
+  }
+
+
+
+  template <typename Number>
+  Vector<Number>
+  Vector<Number>::create_with_same_size(const VectorSpaceVector<Number> &V,
+                                        const bool omit_zeroing_entries)
+  {
+    Vector result;
+    result.reinit(V, omit_zeroing_entries);
+    return result;
   }
 
 

--- a/include/deal.II/lac/petsc_block_vector.h
+++ b/include/deal.II/lac/petsc_block_vector.h
@@ -145,6 +145,15 @@ namespace PETScWrappers
       explicit BlockVector(const std::array<Vec, num_blocks> &);
 
       /**
+       * Creates a new block vector with the same size as the input vector @p V. If
+       * @p omit_zeroing_entries is false, the entries of the new vector will be
+       * initialized with zeros.
+       */
+      static BlockVector
+      create_with_same_size(const BlockVector &V,
+                            const bool         omit_zeroing_entries = false);
+
+      /**
        * Destructor. Clears memory
        */
       ~BlockVector() override;
@@ -444,6 +453,17 @@ namespace PETScWrappers
       for (auto i = 0; i < num_blocks; ++i)
         this->components[i].reinit(arrayV[i]);
       this->collect_sizes();
+    }
+
+
+
+    inline BlockVector
+    BlockVector::create_with_same_size(const BlockVector &v,
+                                       bool               omit_zeroing_entries)
+    {
+      BlockVector result;
+      result.reinit(v, omit_zeroing_entries);
+      return result;
     }
 
 

--- a/include/deal.II/lac/petsc_vector.h
+++ b/include/deal.II/lac/petsc_vector.h
@@ -254,6 +254,15 @@ namespace PETScWrappers
       Vector(const Vector &v);
 
       /**
+       * Creates a new vector with the same size as the input vector @p v. If
+       * @p omit_zeroing_entries is false, the entries of the new vector will be
+       * initialized with zeros.
+       */
+      static Vector
+      create_with_same_size(const Vector &v,
+                            const bool    omit_zeroing_entries = false);
+
+      /**
        * Release all memory and return to a state just like after having
        * called the default constructor.
        */

--- a/include/deal.II/lac/precondition_block.templates.h
+++ b/include/deal.II/lac/precondition_block.templates.h
@@ -980,8 +980,7 @@ PreconditionBlockSSOR<MatrixType, inverse_type>::vmult(
   Vector<number2> &      dst,
   const Vector<number2> &src) const
 {
-  Vector<number2> help;
-  help.reinit(dst);
+  auto help = Vector<number2>::create_with_same_size(dst);
 
   this->forward(help, src, false, false);
 
@@ -1013,8 +1012,7 @@ PreconditionBlockSSOR<MatrixType, inverse_type>::Tvmult(
   Vector<number2> &      dst,
   const Vector<number2> &src) const
 {
-  Vector<number2> help;
-  help.reinit(dst);
+  auto help = Vector<number2>::create_with_same_size(dst);
 
   this->backward(help, src, true, false);
 

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -177,6 +177,17 @@ namespace LinearAlgebra
      */
     explicit ReadWriteVector(const IndexSet &locally_stored_indices);
 
+
+    /**
+     * Creates a new vector with the same size as the input vector @p in_vector.
+     * If @p omit_zeroing_entries is false, the entries of the new vector will be
+     * initialized with zeros.
+     */
+    template <typename Number2>
+    static ReadWriteVector
+    create_with_same_size(const ReadWriteVector<Number2> &in_vector,
+                          bool omit_zeroing_entries = false);
+
     /**
      * Destructor.
      */
@@ -838,6 +849,20 @@ namespace LinearAlgebra
     // override in a derived class
     // for clarity be explicit on which function is called
     ReadWriteVector<Number>::reinit(locally_stored_indices);
+  }
+
+
+
+  template <typename Number>
+  template <typename Number2>
+  inline ReadWriteVector<Number>
+  ReadWriteVector<Number>::create_with_same_size(
+    const ReadWriteVector<Number2> &in_vector,
+    bool                            omit_zeroing_entries)
+  {
+    ReadWriteVector<Number> result;
+    result.reinit(in_vector, omit_zeroing_entries);
+    return result;
   }
 
 

--- a/include/deal.II/lac/trilinos_epetra_vector.h
+++ b/include/deal.II/lac/trilinos_epetra_vector.h
@@ -85,6 +85,15 @@ namespace LinearAlgebra
                       const MPI_Comm  communicator);
 
       /**
+       * Creates a new vector with the same size as the input vector @p V. If
+       * @p omit_zeroing_entries is false, the entries of the new vector will be
+       * initialized with zeros.
+       */
+      static Vector
+      create_with_same_size(const VectorSpaceVector<double> &V,
+                            bool omit_zeroing_entries = false);
+
+      /**
        * Reinit functionality. This function destroys the old vector content
        * and generates a new one based on the input partitioning. The flag
        * <tt>omit_zeroing_entries</tt> determines whether the vector should be

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -141,6 +141,15 @@ namespace LinearAlgebra
                       const MPI_Comm  communicator);
 
       /**
+       * Creates a new vector with the same size as the input vector @p V. If
+       * @p omit_zeroing_entries is false, the entries of the new vector will be
+       * initialized with zeros.
+       */
+      static Vector
+      create_with_same_size(const VectorSpaceVector<Number> &V,
+                            bool omit_zeroing_entries = false);
+
+      /**
        * Reinit functionality. This function destroys the old vector content
        * and generates a new one based on the input partitioning. The flag
        * <tt>omit_zeroing_entries</tt> determines whether the vector should be

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -79,6 +79,18 @@ namespace LinearAlgebra
 
 
     template <typename Number>
+    Vector<Number>
+    Vector<Number>::create_with_same_size(const VectorSpaceVector<Number> &V,
+                                          const bool omit_zeroing_entries)
+    {
+      Vector<Number> result;
+      result.reinit(V, omit_zeroing_entries);
+      return result;
+    }
+
+
+
+    template <typename Number>
     void
     Vector<Number>::reinit(const IndexSet &parallel_partitioner,
                            const MPI_Comm  communicator,

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -508,6 +508,14 @@ namespace TrilinosWrappers
       Vector(Vector &&v); // NOLINT
 
       /**
+       * Creates a new vector with the same size as the input vector @p v. If
+       * @p omit_zeroing_entries is false, the entries of the new vector will be
+       * initialized with zeros.
+       */
+      static Vector create_with_same_size(const Vector &v,
+                             bool    omit_zeroing_entries = false;
+
+      /**
        * Destructor.
        */
       ~Vector() override = default;

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -252,6 +252,16 @@ public:
   Vector(const InputIterator first, const InputIterator last);
 
   /**
+   * Creates a new vector with the same size as the input vector @p V. If
+   * @p omit_zeroing_entries is false, the entries of the new vector will be
+   * initialized with zeros.
+   */
+  template <typename Number2>
+  static Vector
+  create_with_same_size(const Vector<Number2> &V,
+                        const bool             omit_zeroing_entries = false);
+
+  /**
    * Destructor, deallocates memory. Made virtual to allow for derived classes
    * to behave properly.
    */

--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -79,6 +79,19 @@ Vector<Number>::Vector(const Vector<OtherNumber> &v)
 
 
 
+template <typename Number>
+template <typename OtherNumber>
+Vector<Number>
+Vector<Number>::create_with_same_size(const Vector<OtherNumber> &V,
+                                      const bool omit_zeroing_entries)
+{
+  Vector<Number> result;
+  result.reinit(V.size(), omit_zeroing_entries);
+  return result;
+}
+
+
+
 #ifdef DEAL_II_WITH_PETSC
 namespace internal
 {

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -879,12 +879,12 @@ namespace internal
         const VectorType &                          src,
         LinearAlgebra::distributed::Vector<Number> &dst)
       {
-        LinearAlgebra::ReadWriteVector<typename VectorType::value_type> temp;
-        temp.reinit(src.locally_owned_elements());
+        LinearAlgebra::ReadWriteVector<typename VectorType::value_type> temp(
+          src.locally_owned_elements());
         temp.import(src, VectorOperation::insert);
 
-        LinearAlgebra::ReadWriteVector<Number> temp2;
-        temp2.reinit(temp, true);
+        auto temp2 =
+          LinearAlgebra::ReadWriteVector<Number>::create_with_same_size(temp);
         temp2 = temp;
 
         dst.import(temp2, VectorOperation::insert);

--- a/include/deal.II/numerics/vector_tools_interpolate.templates.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.templates.h
@@ -288,10 +288,8 @@ namespace VectorTools
 
       // We will need two temporary global vectors that store the new values
       // and weights.
-      VectorType interpolation;
-      VectorType weights;
-      interpolation.reinit(vec);
-      weights.reinit(vec);
+      auto interpolation = VectorType::create_with_same_size(vec);
+      auto weights       = VectorType::create_with_same_size(vec);
 
       // Store locally owned dofs, so that we can skip all non-local dofs,
       // if they do not need to be interpolated.
@@ -555,8 +553,7 @@ namespace VectorTools
     data_2 = static_cast<number>(0);
 
     // Store how many cells share each dof (unghosted).
-    OutVector touch_count;
-    touch_count.reinit(data_2);
+    OutVector touch_count(data_2);
 
     std::vector<types::global_dof_index> local_dof_indices(
       dof_2.get_fe().n_dofs_per_cell());

--- a/source/lac/block_vector.inst.in
+++ b/source/lac/block_vector.inst.in
@@ -24,12 +24,16 @@ for (S1, S2 : REAL_SCALARS)
   {
     template void BlockVector<S1>::reinit<S2>(const BlockVector<S2> &,
                                               const bool);
+    template BlockVector<S1> BlockVector<S1>::create_with_same_size<S2>(
+      const BlockVector<S2> &, const bool);
   }
 
 for (S1, S2 : COMPLEX_SCALARS)
   {
     template void BlockVector<S1>::reinit<S2>(const BlockVector<S2> &,
                                               const bool);
+    template BlockVector<S1> BlockVector<S1>::create_with_same_size<S2>(
+      const BlockVector<S2> &, const bool);
   }
 
 
@@ -37,4 +41,6 @@ for (S1 : COMPLEX_SCALARS; S2 : REAL_SCALARS)
   {
     template void BlockVector<S1>::reinit<S2>(const BlockVector<S2> &,
                                               const bool);
+    template BlockVector<S1> BlockVector<S1>::create_with_same_size<S2>(
+      const BlockVector<S2> &, const bool);
   }

--- a/source/lac/cuda_vector.cc
+++ b/source/lac/cuda_vector.cc
@@ -62,6 +62,18 @@ namespace LinearAlgebra
 
 
     template <typename Number>
+    Vector<Number>
+    Vector<Number>::create_with_same_size(const VectorSpaceVector<Number> &V,
+                                          const bool omit_zeroing_entries)
+    {
+      Vector result;
+      result.reinit(V, omit_zeroing_entries);
+      return result;
+    }
+
+
+
+    template <typename Number>
     Vector<Number> &
     Vector<Number>::operator=(const Vector<Number> &V)
     {

--- a/source/lac/la_parallel_block_vector.inst.in
+++ b/source/lac/la_parallel_block_vector.inst.in
@@ -70,6 +70,9 @@ for (S1 : REAL_AND_COMPLEX_SCALARS; S2 : REAL_SCALARS)
         template void
         BlockVector<S1>::add<S2>(const std::vector<size_type> &,
                                  const ::dealii::Vector<S2> &);
+        template BlockVector<S1>
+        BlockVector<S1>::create_with_same_size<S2>(const BlockVector<S2> &,
+                                                   const bool);
       \}
     \}
   }
@@ -90,6 +93,9 @@ for (S1, S2 : COMPLEX_SCALARS)
         template void
         BlockVector<S1>::add<S2>(const std::vector<size_type> &,
                                  const ::dealii::Vector<S2> &);
+        template BlockVector<S1>
+        BlockVector<S1>::create_with_same_size<S2>(const BlockVector<S2> &,
+                                                   const bool);
       \}
     \}
   }

--- a/source/lac/la_parallel_vector.inst.in
+++ b/source/lac/la_parallel_vector.inst.in
@@ -47,6 +47,8 @@ for (S1 : REAL_AND_COMPLEX_SCALARS; S2 : REAL_SCALARS)
         template void
         Vector<S1, ::dealii::MemorySpace::Host>::copy_locally_owned_data_from<
           S2>(const Vector<S2, ::dealii::MemorySpace::Host> &);
+        template Vector<S1>
+        Vector<S1>::create_with_same_size<S2>(const Vector<S2> &, const bool);
       \}
     \}
   }
@@ -68,6 +70,8 @@ for (S1, S2 : COMPLEX_SCALARS)
         template void
         Vector<S1, ::dealii::MemorySpace::Host>::copy_locally_owned_data_from<
           S2>(const Vector<S2, ::dealii::MemorySpace::Host> &);
+        template Vector<S1>
+        Vector<S1>::create_with_same_size<S2>(const Vector<S2> &, const bool);
       \}
     \}
   }

--- a/source/lac/trilinos_epetra_vector.cc
+++ b/source/lac/trilinos_epetra_vector.cc
@@ -62,6 +62,17 @@ namespace LinearAlgebra
 
 
 
+    Vector
+    Vector::create_with_same_size(const VectorSpaceVector<double> &V,
+                                  const bool omit_zeroing_entries)
+    {
+      Vector result;
+      result.reinit(V, omit_zeroing_entries);
+      return result;
+    }
+
+
+
     void
     Vector::reinit(const IndexSet &parallel_partitioner,
                    const MPI_Comm  communicator,

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -2063,8 +2063,7 @@ namespace TrilinosWrappers
 
     // Reinit a temporary vector with fast argument set, which does not
     // overwrite the content (to save time).
-    VectorType tmp_vector;
-    tmp_vector.reinit(dst, true);
+    auto tmp_vector = VectorType::create_with_same_size(dst, true);
     vmult(tmp_vector, src);
     dst += tmp_vector;
   }
@@ -2079,8 +2078,7 @@ namespace TrilinosWrappers
 
     // Reinit a temporary vector with fast argument set, which does not
     // overwrite the content (to save time).
-    VectorType tmp_vector;
-    tmp_vector.reinit(dst, true);
+    auto tmp_vector = VectorType::create_with_same_size(dst, true);
     Tvmult(tmp_vector, src);
     dst += tmp_vector;
   }
@@ -2092,8 +2090,7 @@ namespace TrilinosWrappers
   {
     Assert(matrix->RowMap().SameAs(matrix->DomainMap()), ExcNotQuadratic());
 
-    MPI::Vector temp_vector;
-    temp_vector.reinit(v, true);
+    auto temp_vector = MPI::Vector::create_with_same_size(v, true);
 
     vmult(temp_vector, v);
     return temp_vector * v;
@@ -2107,8 +2104,7 @@ namespace TrilinosWrappers
   {
     Assert(matrix->RowMap().SameAs(matrix->DomainMap()), ExcNotQuadratic());
 
-    MPI::Vector temp_vector;
-    temp_vector.reinit(v, true);
+    auto temp_vector = MPI::Vector::create_with_same_size(v, true);
 
     vmult(temp_vector, v);
     return u * temp_vector;

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -137,6 +137,17 @@ namespace TrilinosWrappers
 
 
 
+    Vector
+    Vector::create_with_same_size(const Vector &v,
+                                  const bool    omit_zeroing_entries)
+    {
+      Vector result;
+      result.reinit(v, omit_zeroing_entries);
+      return result;
+    }
+
+
+
     void
     Vector::clear()
     {

--- a/source/lac/vector.inst.in
+++ b/source/lac/vector.inst.in
@@ -24,15 +24,24 @@ for (S1, S2 : REAL_SCALARS)
   {
     template bool Vector<S1>::operator==<S2>(const Vector<S2> &) const;
     template S1 Vector<S1>::operator*<S2>(const Vector<S2> &) const;
+    template Vector<S1>     Vector<S1>::create_with_same_size<S2>(
+      const Vector<S2> &, bool);
+    template void Vector<S1>::reinit<S2>(const Vector<S2> &, const bool);
   }
 
 for (S1, S2 : COMPLEX_SCALARS)
   {
     template bool Vector<S1>::operator==<S2>(const Vector<S2> &) const;
     template S1 Vector<S1>::operator*<S2>(const Vector<S2> &) const;
+    template Vector<S1>     Vector<S1>::create_with_same_size<S2>(
+      const Vector<S2> &, bool);
+    template void Vector<S1>::reinit<S2>(const Vector<S2> &, const bool);
   }
 
 for (S1 : COMPLEX_SCALARS; S2 : REAL_SCALARS)
   {
     template Vector<S1> &Vector<S1>::operator=<S2>(const Vector<S2> &);
+    template Vector<S1>              Vector<S1>::create_with_same_size<S2>(
+      const Vector<S2> &, bool);
+    template void Vector<S1>::reinit<S2>(const Vector<S2> &, const bool);
   }

--- a/source/multigrid/mg_base.cc
+++ b/source/multigrid/mg_base.cc
@@ -48,8 +48,7 @@ MGTransferBase<VectorType>::prolongate_and_add(const unsigned int to_level,
                                                VectorType &       dst,
                                                const VectorType & src) const
 {
-  VectorType temp;
-  temp.reinit(dst, true);
+  auto temp = VectorType::create_with_same_size(dst, true);
 
   this->prolongate(to_level, temp, src);
 

--- a/source/numerics/solution_transfer.cc
+++ b/source/numerics/solution_transfer.cc
@@ -596,10 +596,8 @@ SolutionTransfer<dim, VectorType, spacedim>::interpolate(const VectorType &in,
   Assert(out.size() == dof_handler->n_dofs(),
          ExcDimensionMismatch(out.size(), dof_handler->n_dofs()));
 
-  std::vector<VectorType> all_in(1);
-  all_in[0] = in;
-  std::vector<VectorType> all_out(1);
-  all_out[0] = out;
+  std::vector<VectorType> all_in(1, in);
+  std::vector<VectorType> all_out(1, out);
   interpolate(all_in, all_out);
   out = all_out[0];
 }


### PR DESCRIPTION
This PR adds a static function `create_with_same_size` to (hopefully) all vector types. This function can be uses instead of the pattern
```
VectorType v;
v.reinit(u);
```
to create a new vector that has the same size (and possible other properties) as the input vector. In most places `create_with_same_size` is actually implemented using the above pattern. But this function can be used for non-default-constructible vectors (such as the ones introduced in #15190), while the above pattern would not work.

The pattern above is replaced where I could find it. Also, some functions are changed a bit more to be able to use the new interface.