### PR TITLE
CMake: create a compile_commands.json symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /*build*
+/examples/step*/*build*
 /code-gallery
 
 # eclipse


### PR DESCRIPTION
Modern IDEs such as VSCode use a separate build directory for configuring and compiling a project (such as our example steps).

Unfortunately, this sometimes confuses language servers such as clangd that might fail to find the correct `compile_commands.json` in that build directory. Let's work around this issue by simply creating a symlink from the source directory pointing to the `compile_commands.json` file.

As a sanity check, if there is already a `compile_commands.json` file  present, or if the source and build directory are the same we simply do nothing.