### PR TITLE
Fix warnings with gcc-13.1

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -3871,7 +3871,9 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
                    VectorizedArrayType::size()>
           vector_ptrs = {};
 
-        for (unsigned int v = 0; v < n_filled_lanes; ++v)
+        const auto upper_bound =
+          std::min<unsigned int>(n_filled_lanes, VectorizedArrayType::size());
+        for (unsigned int v = 0; v < upper_bound; ++v)
           {
             if (mask[v] == false)
               {

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -6644,7 +6644,7 @@ namespace GridGenerator
           else if (structdim == 2)
             {
               // rotate the vertex numbers so that the lowest one is first
-              std::array<unsigned int, 4> renumbering;
+              std::array<unsigned int, 4> renumbering{};
               std::copy(std::begin(cell_data.vertices),
                         std::end(cell_data.vertices),
                         renumbering.begin());


### PR DESCRIPTION
gcc-13.1 was warning about 
- an out-of-bounds access in `fe_evaluation.h` since it couldn't figure out that `n_filled_lanes` is always bounded by `VectorizedArrayType::size()`.
- using uninitialized values in `grid_generator.cc` since it couldn't see that `cell_data.vertices` also contains all 4 elements.