### PR TITLE
Tensor product kernels: Use the right type in some templated functions

### DIFF
--- a/include/deal.II/matrix_free/tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/tensor_product_kernels.h
@@ -466,7 +466,7 @@ namespace internal
     AssertIndexRange(face_direction, dim);
     constexpr int in_stride  = Utilities::pow(n_rows, face_direction);
     constexpr int out_stride = Utilities::pow(n_rows, dim - 1);
-    const Number *DEAL_II_RESTRICT shape_values = this->shape_values;
+    const Number2 *DEAL_II_RESTRICT shape_values = this->shape_values;
 
     for (int i2 = 0; i2 < n_blocks2; ++i2)
       {
@@ -2799,7 +2799,7 @@ namespace internal
                                                           n_rows)));
     constexpr int out_stride = n_blocks1 * n_blocks2;
 
-    const Number *DEAL_II_RESTRICT shape_values = this->shape_values;
+    const Number2 *DEAL_II_RESTRICT shape_values = this->shape_values;
 
     for (int i2 = 0; i2 < n_blocks2; ++i2)
       {


### PR DESCRIPTION
When using the tensor product kernels of the matrix-free framework with `Number = VectorizedArray<double>` and `Number2 = double`, I observed that some functions would not compile. This is now fixed. The longer-term plan is to convert https://github.com/dealii/dealii/blob/89a79f24d29d64ae5d93cd77734fe4a837ef369b/include/deal.II/matrix_free/fe_evaluation_data.h#L114-L116C17 from `ShapeInfo<VectorizedArray<double>>` to `ShapeInfo<double>` for our regular integrators. (If the benchmarks we have suggest that there is no performance loss, which is not clear at this point.)