### PR TITLE
Fix step-77: zero out residual before assembly

### DIFF
--- a/examples/step-77/step-77.cc
+++ b/examples/step-77/step-77.cc
@@ -334,6 +334,8 @@ namespace Step77
 
     std::cout << "  Computing residual vector..." << std::flush;
 
+    residual = 0.0;
+
     const QGauss<dim> quadrature_formula(fe.degree + 1);
     FEValues<dim>     fe_values(fe,
                             quadrature_formula,

--- a/tests/sundials/step-77.cc
+++ b/tests/sundials/step-77.cc
@@ -243,6 +243,8 @@ namespace Step77
     const Vector<double> &evaluation_point,
     Vector<double> &      residual)
   {
+    residual = 0.0;
+
     const QGauss<dim> quadrature_formula(fe.degree + 1);
     FEValues<dim>     fe_values(fe,
                             quadrature_formula,


### PR DESCRIPTION
This patch resolves the problem in #15194.

@bangerth @luca-heltai  N_Vector interfaces are correct after all :) 