### PR TITLE
Fix Kokkos compilation with GCC 13.

### DIFF
--- a/bundled/kokkos-3.7.00/core/src/impl/Kokkos_MemoryPool.cpp
+++ b/bundled/kokkos-3.7.00/core/src/impl/Kokkos_MemoryPool.cpp
@@ -48,6 +48,7 @@
 
 #include <impl/Kokkos_Error.hpp>
 
+#include <cstdint>
 #include <ostream>
 #include <sstream>
 


### PR DESCRIPTION
GCC 13 is picker about where uint32_t et al are defined so we need to explicitly include the correct header here.