### PR TITLE
Make MatrixFree evaluation kernels more flexible w.r.t. number type

### DIFF
--- a/examples/step-76/step-76.cc
+++ b/examples/step-76/step-76.cc
@@ -918,15 +918,13 @@ namespace Euler_DG
               internal::EvaluatorQuantity::hessian,
               dim,
               degree + 1,
-              n_points_1d,
-              VectorizedArrayType,
-              VectorizedArrayType>::do_backward(dim + 2,
-                                                data.get_shape_info()
-                                                  .data[0]
-                                                  .inverse_shape_values_eo,
-                                                false,
-                                                phi.begin_values(),
-                                                phi.begin_dof_values());
+              n_points_1d>::do_backward(dim + 2,
+                                        data.get_shape_info()
+                                          .data[0]
+                                          .inverse_shape_values_eo,
+                                        false,
+                                        phi.begin_values(),
+                                        phi.begin_dof_values());
 
             // Perform Runge-Kutta update and write results back to global
             // vectors:

--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -1048,8 +1048,8 @@ namespace internal
                                         dim,
                                         (fe_degree == -1) ? 1 : fe_degree + 1,
                                         n_q_points_1d,
-                                        Number,
                                         normal_dir,
+                                        Number,
                                         Number2>;
 
     using EvalTangent =
@@ -1057,8 +1057,8 @@ namespace internal
                                         dim,
                                         (fe_degree == -1) ? 1 : fe_degree,
                                         n_q_points_1d,
-                                        Number,
                                         normal_dir,
+                                        Number,
                                         Number2>;
     using Eval0 =
       typename std::conditional<normal_dir == 0, EvalNormal, EvalTangent>::type;
@@ -1244,8 +1244,8 @@ namespace internal
                                         dim,
                                         (fe_degree == -1) ? 1 : fe_degree + 1,
                                         n_q_points_1d,
-                                        Number,
                                         normal_dir,
+                                        Number,
                                         Number2>;
 
     using EvalTangent =
@@ -1253,8 +1253,8 @@ namespace internal
                                         dim,
                                         (fe_degree == -1) ? 1 : fe_degree,
                                         n_q_points_1d,
-                                        Number,
                                         normal_dir,
+                                        Number,
                                         Number2>;
     using Eval0 =
       typename std::conditional<normal_dir == 0, EvalNormal, EvalTangent>::type;
@@ -1437,6 +1437,14 @@ namespace internal
    *
    * This class allows for dimension-independent application of the operation,
    * implemented by template recursion. It has been tested up to 6d.
+   *
+   * The last two template arguments in this class are unused. They have a
+   * default type set to bool, but any type will compile. These arguments are
+   * present for backward compatibility of this (internal) interface with
+   * previous versions of deal.II, where the template arguments were used to
+   * indicate the number types These are now part of the do_forward() and
+   * do_backward() functions, and they will be removed from a future version
+   * of deal.II.
    */
   template <EvaluatorVariant  variant,
             EvaluatorQuantity quantity,
@@ -3053,16 +3061,16 @@ namespace internal
                                           dim - 1,
                                           (fe_degree == -1) ? 1 : fe_degree + 1,
                                           n_q_points_1d,
-                                          Number,
                                           normal_dir,
+                                          Number,
                                           Number2>;
       using EvalTangent =
         EvaluatorTensorProductAnisotropic<evaluate_raviart_thomas,
                                           dim - 1,
                                           (fe_degree == -1) ? 1 : fe_degree,
                                           n_q_points_1d,
-                                          Number,
                                           normal_dir,
+                                          Number,
                                           Number2>;
 
       using TempEval0 = typename std::
@@ -3258,16 +3266,16 @@ namespace internal
                                           dim - 1,
                                           (fe_degree == -1) ? 1 : fe_degree + 1,
                                           n_q_points_1d,
-                                          Number,
                                           normal_dir,
+                                          Number,
                                           Number2>;
       using EvalTangent =
         EvaluatorTensorProductAnisotropic<evaluate_raviart_thomas,
                                           dim - 1,
                                           (fe_degree == -1) ? 1 : fe_degree,
                                           n_q_points_1d,
-                                          Number,
                                           normal_dir,
+                                          Number,
                                           Number2>;
 
       using TempEval0 = typename std::
@@ -3713,15 +3721,15 @@ namespace internal
                                           dim,
                                           (fe_degree == -1) ? 1 : fe_degree + 1,
                                           0,
-                                          Number,
                                           0,
+                                          Number,
                                           Number2>,
         EvaluatorTensorProductAnisotropic<evaluate_raviart_thomas,
                                           dim,
                                           (fe_degree == -1) ? 1 : fe_degree,
                                           0,
-                                          Number,
                                           0,
+                                          Number,
                                           Number2>>::type;
       using Evalf1 = typename std::conditional<
         face_direction == 1,
@@ -3729,15 +3737,15 @@ namespace internal
                                           dim,
                                           (fe_degree == -1) ? 1 : fe_degree + 1,
                                           0,
-                                          Number,
                                           1,
+                                          Number,
                                           Number2>,
         EvaluatorTensorProductAnisotropic<evaluate_raviart_thomas,
                                           dim,
                                           (fe_degree == -1) ? 1 : fe_degree,
                                           0,
-                                          Number,
                                           1,
+                                          Number,
                                           Number2>>::type;
       using Evalf2 = typename std::conditional<
         face_direction == 2,
@@ -3745,15 +3753,15 @@ namespace internal
                                           dim,
                                           (fe_degree == -1) ? 1 : fe_degree + 1,
                                           0,
-                                          Number,
                                           2,
+                                          Number,
                                           Number2>,
         EvaluatorTensorProductAnisotropic<evaluate_raviart_thomas,
                                           dim,
                                           (fe_degree == -1) ? 1 : fe_degree,
                                           0,
-                                          Number,
                                           2,
+                                          Number,
                                           Number2>>::type;
 
       Evalf0 evalf0 =

--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -118,12 +118,15 @@ namespace internal
   {
     static const EvaluatorVariant variant =
       EvaluatorSelector<type, (fe_degree + n_q_points_1d > 4)>::variant;
+    using Number2 =
+      typename FEEvaluationData<dim, Number, false>::shape_info_number_type;
 
     using Eval = EvaluatorTensorProduct<variant,
                                         dim,
                                         fe_degree + 1,
                                         n_q_points_1d,
-                                        Number>;
+                                        Number,
+                                        Number2>;
 
     static void
     evaluate(const unsigned int                     n_components,
@@ -140,7 +143,7 @@ namespace internal
 
     static Eval
     create_evaluator_tensor_product(
-      const MatrixFreeFunctions::UnivariateShapeData<Number>
+      const MatrixFreeFunctions::UnivariateShapeData<Number2>
         *univariate_shape_data)
     {
       if (variant == evaluate_evenodd)
@@ -205,10 +208,10 @@ namespace internal
       const bool                             add_into_values_array = false);
 
   private:
-    template <typename EvalType>
+    template <typename EvalType, typename Number2>
     static EvalType
     create_evaluator_tensor_product(
-      const MatrixFreeFunctions::UnivariateShapeData<Number> &shape_data)
+      const MatrixFreeFunctions::UnivariateShapeData<Number2> &shape_data)
     {
       return EvalType(shape_data.shape_values,
                       shape_data.shape_gradients,
@@ -251,7 +254,7 @@ namespace internal
     if (evaluation_flag == EvaluationFlags::nothing)
       return;
 
-    std::array<const MatrixFreeFunctions::UnivariateShapeData<Number> *, 3>
+    std::array<const MatrixFreeFunctions::UnivariateShapeData<Number2> *, 3>
       univariate_shape_data;
 
     const auto &shape_data = fe_eval.get_shape_info().data;
@@ -522,7 +525,7 @@ namespace internal
     FEEvaluationData<dim, Number, false> & fe_eval,
     const bool                             add_into_values_array)
   {
-    std::array<const MatrixFreeFunctions::UnivariateShapeData<Number> *, 3>
+    std::array<const MatrixFreeFunctions::UnivariateShapeData<Number2> *, 3>
       univariate_shape_data;
 
     const auto &shape_data = fe_eval.get_shape_info().data;
@@ -843,8 +846,10 @@ namespace internal
 
     const auto &shape_data = fe_eval.get_shape_info().data;
 
+    using Number2 =
+      typename FEEvaluationData<dim, Number, false>::shape_info_number_type;
     using Eval =
-      EvaluatorTensorProduct<evaluate_general, 1, 0, 0, Number, Number>;
+      EvaluatorTensorProduct<evaluate_general, 1, 0, 0, Number, Number2>;
 
     if (evaluation_flag & EvaluationFlags::values)
       {
@@ -913,8 +918,10 @@ namespace internal
 
     const auto &shape_data = fe_eval.get_shape_info().data;
 
+    using Number2 =
+      typename FEEvaluationData<dim, Number, false>::shape_info_number_type;
     using Eval =
-      EvaluatorTensorProduct<evaluate_general, 1, 0, 0, Number, Number>;
+      EvaluatorTensorProduct<evaluate_general, 1, 0, 0, Number, Number2>;
 
     if (integration_flag & EvaluationFlags::values)
       {
@@ -1034,13 +1041,16 @@ namespace internal
   {
     (void)add_into_values_array;
 
+    using Number2 =
+      typename FEEvaluationData<dim, Number, false>::shape_info_number_type;
     using EvalNormal =
       EvaluatorTensorProductAnisotropic<evaluate_raviart_thomas,
                                         dim,
                                         (fe_degree == -1) ? 1 : fe_degree + 1,
                                         n_q_points_1d,
                                         Number,
-                                        normal_dir>;
+                                        normal_dir,
+                                        Number2>;
 
     using EvalTangent =
       EvaluatorTensorProductAnisotropic<evaluate_raviart_thomas,
@@ -1048,7 +1058,8 @@ namespace internal
                                         (fe_degree == -1) ? 1 : fe_degree,
                                         n_q_points_1d,
                                         Number,
-                                        normal_dir>;
+                                        normal_dir,
+                                        Number2>;
     using Eval0 =
       typename std::conditional<normal_dir == 0, EvalNormal, EvalTangent>::type;
     using Eval1 =
@@ -1056,9 +1067,8 @@ namespace internal
     using Eval2 =
       typename std::conditional<normal_dir == 2, EvalNormal, EvalTangent>::type;
 
-    const MatrixFreeFunctions::ShapeInfo<Number> &shape_info =
-      fe_eval.get_shape_info();
-    Eval0 eval0 = create_evaluator_tensor_product<Eval0>(
+    const auto &shape_info = fe_eval.get_shape_info();
+    Eval0       eval0      = create_evaluator_tensor_product<Eval0>(
       ((normal_dir == 0) ? shape_info.data[0] : shape_info.data[1]));
     Eval1 eval1 = create_evaluator_tensor_product<Eval1>(
       ((normal_dir == 1) ? shape_info.data[0] : shape_info.data[1]));
@@ -1227,13 +1237,16 @@ namespace internal
       const bool                             add_into_values_array,
       std::integral_constant<bool, true>)
   {
+    using Number2 =
+      typename FEEvaluationData<dim, Number, false>::shape_info_number_type;
     using EvalNormal =
       EvaluatorTensorProductAnisotropic<evaluate_raviart_thomas,
                                         dim,
                                         (fe_degree == -1) ? 1 : fe_degree + 1,
                                         n_q_points_1d,
                                         Number,
-                                        normal_dir>;
+                                        normal_dir,
+                                        Number2>;
 
     using EvalTangent =
       EvaluatorTensorProductAnisotropic<evaluate_raviart_thomas,
@@ -1241,7 +1254,8 @@ namespace internal
                                         (fe_degree == -1) ? 1 : fe_degree,
                                         n_q_points_1d,
                                         Number,
-                                        normal_dir>;
+                                        normal_dir,
+                                        Number2>;
     using Eval0 =
       typename std::conditional<normal_dir == 0, EvalNormal, EvalTangent>::type;
     using Eval1 =
@@ -1249,9 +1263,8 @@ namespace internal
     using Eval2 =
       typename std::conditional<normal_dir == 2, EvalNormal, EvalTangent>::type;
 
-    const MatrixFreeFunctions::ShapeInfo<Number> &shape_info =
-      fe_eval.get_shape_info();
-    Eval0 eval0 = create_evaluator_tensor_product<Eval0>(
+    const auto &shape_info = fe_eval.get_shape_info();
+    Eval0       eval0      = create_evaluator_tensor_product<Eval0>(
       ((normal_dir == 0) ? shape_info.data[0] : shape_info.data[1]));
     Eval1 eval1 = create_evaluator_tensor_product<Eval1>(
       ((normal_dir == 1) ? shape_info.data[0] : shape_info.data[1]));
@@ -1423,15 +1436,15 @@ namespace internal
    * derivative through collocation techniques.
    *
    * This class allows for dimension-independent application of the operation,
-   * implemented by template recursion. It has been tested up to 6D.
+   * implemented by template recursion. It has been tested up to 6d.
    */
   template <EvaluatorVariant  variant,
             EvaluatorQuantity quantity,
             int               dim,
             int               basis_size_1,
             int               basis_size_2,
-            typename Number,
-            typename Number2>
+            typename = bool,
+            typename = bool>
   struct FEEvaluationImplBasisChange
   {
     static_assert(basis_size_1 == 0 || basis_size_1 <= basis_size_2,
@@ -1459,17 +1472,19 @@ namespace internal
      * is zero, the size of the second basis can alternatively be passed in as a
      * run time argument.
      */
+    template <typename Number, typename Number2>
 #ifndef DEBUG
     DEAL_II_ALWAYS_INLINE
 #endif
-    static void
-    do_forward(
-      const unsigned int            n_components,
-      const AlignedVector<Number2> &transformation_matrix,
-      const Number *                values_in,
-      Number *                      values_out,
-      const unsigned int basis_size_1_variable = numbers::invalid_unsigned_int,
-      const unsigned int basis_size_2_variable = numbers::invalid_unsigned_int)
+      static void
+      do_forward(const unsigned int            n_components,
+                 const AlignedVector<Number2> &transformation_matrix,
+                 const Number *                values_in,
+                 Number *                      values_out,
+                 const unsigned int            basis_size_1_variable =
+                   numbers::invalid_unsigned_int,
+                 const unsigned int basis_size_2_variable =
+                   numbers::invalid_unsigned_int)
     {
       Assert(
         basis_size_1 != 0 || basis_size_1_variable <= basis_size_2_variable,
@@ -1494,8 +1509,8 @@ namespace internal
                              Number,
                              Number2>
                          eval_val(transformation_matrix,
-                 AlignedVector<Number2>(),
-                 AlignedVector<Number2>(),
+                 {},
+                 {},
                  basis_size_1_variable,
                  basis_size_2_variable);
       const unsigned int np_1 =
@@ -1518,23 +1533,19 @@ namespace internal
           values_out -= Utilities::fixed_power<dim>(np_2);
           if (next_dim < dim)
             for (unsigned int q = np_1; q != 0; --q)
-              FEEvaluationImplBasisChange<
-                variant,
-                quantity,
-                next_dim,
-                basis_size_1,
-                basis_size_2,
-                Number,
-                Number2>::do_forward(1,
-                                     transformation_matrix,
-                                     values_in +
-                                       (q - 1) *
-                                         Utilities::fixed_power<next_dim>(np_1),
-                                     values_out +
-                                       (q - 1) *
-                                         Utilities::fixed_power<next_dim>(np_2),
-                                     basis_size_1_variable,
-                                     basis_size_2_variable);
+              FEEvaluationImplBasisChange<variant,
+                                          quantity,
+                                          next_dim,
+                                          basis_size_1,
+                                          basis_size_2>::
+                do_forward(1,
+                           transformation_matrix,
+                           values_in +
+                             (q - 1) * Utilities::fixed_power<next_dim>(np_1),
+                           values_out +
+                             (q - 1) * Utilities::fixed_power<next_dim>(np_2),
+                           basis_size_1_variable,
+                           basis_size_2_variable);
 
           // the recursion stops if dim==1 or if dim==2 and
           // basis_size_1==basis_size_2 (the latter is used because the
@@ -1583,18 +1594,20 @@ namespace internal
      * is zero, the size of the second basis can alternatively be passed in as a
      * run time argument.
      */
+    template <typename Number, typename Number2>
 #ifndef DEBUG
     DEAL_II_ALWAYS_INLINE
 #endif
-    static void
-    do_backward(
-      const unsigned int            n_components,
-      const AlignedVector<Number2> &transformation_matrix,
-      const bool                    add_into_result,
-      Number *                      values_in,
-      Number *                      values_out,
-      const unsigned int basis_size_1_variable = numbers::invalid_unsigned_int,
-      const unsigned int basis_size_2_variable = numbers::invalid_unsigned_int)
+      static void
+      do_backward(const unsigned int            n_components,
+                  const AlignedVector<Number2> &transformation_matrix,
+                  const bool                    add_into_result,
+                  Number *                      values_in,
+                  Number *                      values_out,
+                  const unsigned int            basis_size_1_variable =
+                    numbers::invalid_unsigned_int,
+                  const unsigned int basis_size_2_variable =
+                    numbers::invalid_unsigned_int)
     {
       Assert(
         basis_size_1 != 0 || basis_size_1_variable <= basis_size_2_variable,
@@ -1698,9 +1711,7 @@ namespace internal
                                           quantity,
                                           next_dim,
                                           basis_size_1,
-                                          basis_size_2,
-                                          Number,
-                                          Number2>::
+                                          basis_size_2>::
                 do_backward(1,
                             transformation_matrix,
                             add_into_result,
@@ -1736,6 +1747,7 @@ namespace internal
      *                     of the transformation are stored. It may alias with
      *                     the values_in array.
      */
+    template <typename Number, typename Number2>
     static void
     do_mass(const unsigned int            n_components,
             const AlignedVector<Number2> &transformation_matrix,
@@ -1761,16 +1773,14 @@ namespace internal
           EvaluatorQuantity::value,
           next_dim,
           basis_size_1,
-          basis_size_2,
-          Number,
-          Number2>::do_forward(n_components,
-                               transformation_matrix,
-                               values_in +
-                                 (q - 1) *
-                                   Utilities::pow(basis_size_1, dim - 1),
-                               my_scratch +
-                                 (q - 1) *
-                                   Utilities::pow(basis_size_2, dim - 1));
+          basis_size_2>::do_forward(n_components,
+                                    transformation_matrix,
+                                    values_in +
+                                      (q - 1) *
+                                        Utilities::pow(basis_size_1, dim - 1),
+                                    my_scratch +
+                                      (q - 1) *
+                                        Utilities::pow(basis_size_2, dim - 1));
       EvaluatorTensorProduct<variant,
                              dim,
                              basis_size_1,
@@ -1797,20 +1807,16 @@ namespace internal
                 my_scratch + i, my_scratch + i);
           }
       for (unsigned int q = 0; q < basis_size_1; ++q)
-        FEEvaluationImplBasisChange<
-          variant,
-          EvaluatorQuantity::value,
-          next_dim,
-          basis_size_1,
-          basis_size_2,
-          Number,
-          Number2>::do_backward(n_components,
-                                transformation_matrix,
-                                false,
-                                my_scratch +
-                                  q * Utilities::pow(basis_size_2, dim - 1),
-                                values_out +
-                                  q * Utilities::pow(basis_size_1, dim - 1));
+        FEEvaluationImplBasisChange<variant,
+                                    EvaluatorQuantity::value,
+                                    next_dim,
+                                    basis_size_1,
+                                    basis_size_2>::
+          do_backward(n_components,
+                      transformation_matrix,
+                      false,
+                      my_scratch + q * Utilities::pow(basis_size_2, dim - 1),
+                      values_out + q * Utilities::pow(basis_size_1, dim - 1));
     }
   };
 
@@ -1831,6 +1837,15 @@ namespace internal
   template <int dim, int fe_degree, typename Number>
   struct FEEvaluationImplCollocation
   {
+    using Number2 =
+      typename FEEvaluationData<dim, Number, false>::shape_info_number_type;
+    using Eval = EvaluatorTensorProduct<evaluate_evenodd,
+                                        dim,
+                                        fe_degree + 1,
+                                        fe_degree + 1,
+                                        Number,
+                                        Number2>;
+
     static void
     evaluate(const unsigned int                     n_components,
              const EvaluationFlags::EvaluationFlags evaluation_flag,
@@ -1838,7 +1853,7 @@ namespace internal
              FEEvaluationData<dim, Number, false> & fe_eval);
 
     static void
-    do_evaluate(const MatrixFreeFunctions::UnivariateShapeData<Number> &shape,
+    do_evaluate(const MatrixFreeFunctions::UnivariateShapeData<Number2> &shape,
                 const EvaluationFlags::EvaluationFlags evaluation_flag,
                 const Number *                         values_dofs,
                 Number *                               gradients_quad,
@@ -1852,7 +1867,7 @@ namespace internal
               const bool                             add_into_values_array);
 
     static void
-    do_integrate(const MatrixFreeFunctions::UnivariateShapeData<Number> &shape,
+    do_integrate(const MatrixFreeFunctions::UnivariateShapeData<Number2> &shape,
                  const EvaluationFlags::EvaluationFlags integration_flag,
                  Number *                               values_dofs,
                  Number *                               gradients_quad,
@@ -1893,24 +1908,19 @@ namespace internal
   template <int dim, int fe_degree, typename Number>
   inline void
   FEEvaluationImplCollocation<dim, fe_degree, Number>::do_evaluate(
-    const MatrixFreeFunctions::UnivariateShapeData<Number> &shape,
-    const EvaluationFlags::EvaluationFlags                  evaluation_flag,
-    const Number *                                          values_dofs,
-    Number *                                                gradients_quad,
-    Number *                                                hessians_quad)
+    const MatrixFreeFunctions::UnivariateShapeData<Number2> &shape,
+    const EvaluationFlags::EvaluationFlags                   evaluation_flag,
+    const Number *                                           values_dofs,
+    Number *                                                 gradients_quad,
+    Number *                                                 hessians_quad)
   {
     AssertDimension(shape.shape_gradients_collocation_eo.size(),
                     (fe_degree + 2) / 2 * (fe_degree + 1));
     constexpr std::size_t n_points = Utilities::pow(fe_degree + 1, dim);
 
-    EvaluatorTensorProduct<evaluate_evenodd,
-                           dim,
-                           fe_degree + 1,
-                           fe_degree + 1,
-                           Number>
-      eval(AlignedVector<Number>(),
-           shape.shape_gradients_collocation_eo,
-           shape.shape_hessians_collocation_eo);
+    Eval eval({},
+              shape.shape_gradients_collocation_eo,
+              shape.shape_hessians_collocation_eo);
     if ((evaluation_flag &
          (EvaluationFlags::gradients | EvaluationFlags::hessians)) != 0u)
       {
@@ -1992,24 +2002,19 @@ namespace internal
   template <int dim, int fe_degree, typename Number>
   inline void
   FEEvaluationImplCollocation<dim, fe_degree, Number>::do_integrate(
-    const MatrixFreeFunctions::UnivariateShapeData<Number> &shape,
-    const EvaluationFlags::EvaluationFlags                  integration_flag,
-    Number *                                                values_dofs,
-    Number *                                                gradients_quad,
-    const Number *                                          hessians_quad,
+    const MatrixFreeFunctions::UnivariateShapeData<Number2> &shape,
+    const EvaluationFlags::EvaluationFlags                   integration_flag,
+    Number *                                                 values_dofs,
+    Number *                                                 gradients_quad,
+    const Number *                                           hessians_quad,
     const bool add_into_values_array)
   {
     AssertDimension(shape.shape_gradients_collocation_eo.size(),
                     (fe_degree + 2) / 2 * (fe_degree + 1));
 
-    EvaluatorTensorProduct<evaluate_evenodd,
-                           dim,
-                           fe_degree + 1,
-                           fe_degree + 1,
-                           Number>
-                          eval(AlignedVector<Number>(),
-           shape.shape_gradients_collocation_eo,
-           shape.shape_hessians_collocation_eo);
+    Eval                  eval({},
+              shape.shape_gradients_collocation_eo,
+              shape.shape_hessians_collocation_eo);
     constexpr std::size_t n_points = Utilities::pow(fe_degree + 1, dim);
 
     if ((integration_flag & EvaluationFlags::hessians) != 0u)
@@ -2151,12 +2156,10 @@ namespace internal
           EvaluatorQuantity::value,
           dim,
           (fe_degree >= n_q_points_1d ? n_q_points_1d : fe_degree + 1),
-          n_q_points_1d,
-          Number,
-          Number>::do_forward(1,
-                              shape_data.shape_values_eo,
-                              values_dofs + c * n_dofs,
-                              fe_eval.begin_values() + c * n_q_points);
+          n_q_points_1d>::do_forward(1,
+                                     shape_data.shape_values_eo,
+                                     values_dofs + c * n_dofs,
+                                     fe_eval.begin_values() + c * n_q_points);
 
         // apply derivatives in the collocation space
         if (evaluation_flag &
@@ -2217,14 +2220,12 @@ namespace internal
           EvaluatorQuantity::value,
           dim,
           (fe_degree >= n_q_points_1d ? n_q_points_1d : fe_degree + 1),
-          n_q_points_1d,
-          Number,
-          Number>::do_backward(1,
-                               shape_data.shape_values_eo,
-                               add_into_values_array,
-                               fe_eval.begin_values() + c * n_q_points,
-                               values_dofs +
-                                 c * Utilities::pow(fe_degree + 1, dim));
+          n_q_points_1d>::do_backward(1,
+                                      shape_data.shape_values_eo,
+                                      add_into_values_array,
+                                      fe_eval.begin_values() + c * n_q_points,
+                                      values_dofs +
+                                        c * Utilities::pow(fe_degree + 1, dim));
       }
   }
 
@@ -2464,18 +2465,22 @@ namespace internal
     // choice in terms of operation counts (third condition) and if we were
     // able to initialize the fields in shape_info.templates.h from the
     // polynomials (fourth condition).
+    using Number2 =
+      typename FEEvaluationData<dim, Number, true>::shape_info_number_type;
+
     using Eval = EvaluatorTensorProduct<symmetric_evaluate ? evaluate_evenodd :
                                                              evaluate_general,
                                         dim - 1,
                                         fe_degree + 1,
                                         n_q_points_1d,
-                                        Number>;
+                                        Number,
+                                        Number2>;
 
     static Eval
     create_evaluator_tensor_product(
-      const MatrixFreeFunctions::UnivariateShapeData<Number> &data,
-      const unsigned int                                      subface_index,
-      const unsigned int                                      direction)
+      const MatrixFreeFunctions::UnivariateShapeData<Number2> &data,
+      const unsigned int                                       subface_index,
+      const unsigned int                                       direction)
     {
       if (symmetric_evaluate)
         return Eval(data.shape_values_eo,
@@ -2503,15 +2508,15 @@ namespace internal
 
     static void
     evaluate_in_face(
-      const unsigned int                                      n_components,
-      const EvaluationFlags::EvaluationFlags                  evaluation_flag,
-      const MatrixFreeFunctions::UnivariateShapeData<Number> &data,
-      Number *                                                values_dofs,
-      Number *                                                values_quad,
-      Number *                                                gradients_quad,
-      Number *                                                hessians_quad,
-      Number *                                                scratch_data,
-      const unsigned int                                      subface_index)
+      const unsigned int                                       n_components,
+      const EvaluationFlags::EvaluationFlags                   evaluation_flag,
+      const MatrixFreeFunctions::UnivariateShapeData<Number2> &data,
+      Number *                                                 values_dofs,
+      Number *                                                 values_quad,
+      Number *                                                 gradients_quad,
+      Number *                                                 hessians_quad,
+      Number *                                                 scratch_data,
+      const unsigned int                                       subface_index)
     {
       Eval eval0 = create_evaluator_tensor_product(data, subface_index, 0);
       Eval eval1 = create_evaluator_tensor_product(data, subface_index, 1);
@@ -2570,10 +2575,9 @@ namespace internal
                                              dim - 1,
                                              n_q_points_1d,
                                              n_q_points_1d,
-                                             Number>
-                        eval_grad(AlignedVector<Number>(),
-                                  data.shape_gradients_collocation_eo,
-                                  AlignedVector<Number>());
+                                             Number,
+                                             Number2>
+                        eval_grad({}, data.shape_gradients_collocation_eo, {});
                       eval_grad.template gradients<0, true, false>(
                         values_quad, gradients_quad);
                       eval_grad.template gradients<1, true, false>(
@@ -2704,15 +2708,15 @@ namespace internal
 
     static void
     integrate_in_face(
-      const unsigned int                                      n_components,
-      const EvaluationFlags::EvaluationFlags                  integration_flag,
-      const MatrixFreeFunctions::UnivariateShapeData<Number> &data,
-      Number *                                                values_dofs,
-      Number *                                                values_quad,
-      Number *                                                gradients_quad,
-      Number *                                                hessians_quad,
-      Number *                                                scratch_data,
-      const unsigned int                                      subface_index)
+      const unsigned int                                       n_components,
+      const EvaluationFlags::EvaluationFlags                   integration_flag,
+      const MatrixFreeFunctions::UnivariateShapeData<Number2> &data,
+      Number *                                                 values_dofs,
+      Number *                                                 values_quad,
+      Number *                                                 gradients_quad,
+      Number *                                                 hessians_quad,
+      Number *                                                 scratch_data,
+      const unsigned int                                       subface_index)
     {
       Eval eval0 = create_evaluator_tensor_product(data, subface_index, 0);
       Eval eval1 = create_evaluator_tensor_product(data, subface_index, 1);
@@ -2774,10 +2778,9 @@ namespace internal
                                              dim - 1,
                                              n_q_points_1d,
                                              n_q_points_1d,
-                                             Number>
-                        eval_grad(AlignedVector<Number>(),
-                                  data.shape_gradients_collocation_eo,
-                                  AlignedVector<Number>());
+                                             Number,
+                                             Number2>
+                        eval_grad({}, data.shape_gradients_collocation_eo, {});
                       if ((integration_flag & EvaluationFlags::values) != 0u)
                         eval_grad.template gradients<1, false, true>(
                           gradients_quad + n_q_points, values_quad);
@@ -2940,17 +2943,21 @@ namespace internal
   template <int dim, int fe_degree, int n_q_points_1d, typename Number>
   struct FEFaceEvaluationImplRaviartThomas
   {
+    using Number2 =
+      typename FEEvaluationData<dim, Number, true>::shape_info_number_type;
     using EvalGeneral = EvaluatorTensorProduct<evaluate_general,
                                                dim - 1,
                                                fe_degree,
                                                n_q_points_1d,
-                                               Number>;
+                                               Number,
+                                               Number2>;
+
     template <typename EvalType>
     static EvalType
     create_evaluator_tensor_product(
-      const MatrixFreeFunctions::UnivariateShapeData<Number> &data,
-      const unsigned int                                      subface_index,
-      const unsigned int                                      direction)
+      const MatrixFreeFunctions::UnivariateShapeData<Number2> &data,
+      const unsigned int                                       subface_index,
+      const unsigned int                                       direction)
     {
       if (subface_index >= GeometryInfo<dim>::max_children_per_cell)
         return EvalType(data.shape_values,
@@ -3047,14 +3054,16 @@ namespace internal
                                           (fe_degree == -1) ? 1 : fe_degree + 1,
                                           n_q_points_1d,
                                           Number,
-                                          normal_dir>;
+                                          normal_dir,
+                                          Number2>;
       using EvalTangent =
         EvaluatorTensorProductAnisotropic<evaluate_raviart_thomas,
                                           dim - 1,
                                           (fe_degree == -1) ? 1 : fe_degree,
                                           n_q_points_1d,
                                           Number,
-                                          normal_dir>;
+                                          normal_dir,
+                                          Number2>;
 
       using TempEval0 = typename std::
         conditional<normal_dir == 0, EvalNormal, EvalTangent>::type;
@@ -3065,9 +3074,8 @@ namespace internal
       using Eval1 = typename std::
         conditional<normal_dir == 2, EvalGeneral, TempEval1>::type;
 
-      const MatrixFreeFunctions::ShapeInfo<Number> &shape_info =
-        fe_eval.get_shape_info();
-      Eval0 eval0 = create_evaluator_tensor_product<Eval0>(
+      const auto &shape_info = fe_eval.get_shape_info();
+      Eval0       eval0      = create_evaluator_tensor_product<Eval0>(
         ((normal_dir == 0) ? shape_info.data[0] : shape_info.data[1]),
         subface_index,
         0);
@@ -3251,14 +3259,16 @@ namespace internal
                                           (fe_degree == -1) ? 1 : fe_degree + 1,
                                           n_q_points_1d,
                                           Number,
-                                          normal_dir>;
+                                          normal_dir,
+                                          Number2>;
       using EvalTangent =
         EvaluatorTensorProductAnisotropic<evaluate_raviart_thomas,
                                           dim - 1,
                                           (fe_degree == -1) ? 1 : fe_degree,
                                           n_q_points_1d,
                                           Number,
-                                          normal_dir>;
+                                          normal_dir,
+                                          Number2>;
 
       using TempEval0 = typename std::
         conditional<normal_dir == 0, EvalNormal, EvalTangent>::type;
@@ -3269,9 +3279,8 @@ namespace internal
       using Eval1 = typename std::
         conditional<normal_dir == 2, EvalGeneral, TempEval1>::type;
 
-      const MatrixFreeFunctions::ShapeInfo<Number> &shape_info =
-        fe_eval.get_shape_info();
-      Eval0 eval0 = create_evaluator_tensor_product<Eval0>(
+      const auto &shape_info = fe_eval.get_shape_info();
+      Eval0       eval0      = create_evaluator_tensor_product<Eval0>(
         ((normal_dir == 0) ? shape_info.data[0] : shape_info.data[1]),
         subface_index,
         0);
@@ -3473,14 +3482,17 @@ namespace internal
   template <int dim, int fe_degree, typename Number>
   struct FEFaceNormalEvaluationImpl
   {
+    using Number2 =
+      typename FEEvaluationData<dim, Number, true>::shape_info_number_type;
+
     template <bool do_evaluate, bool add_into_output>
     static void
-    interpolate(const unsigned int                            n_components,
-                const EvaluationFlags::EvaluationFlags        flags,
-                const MatrixFreeFunctions::ShapeInfo<Number> &shape_info,
-                const Number *                                input,
-                Number *                                      output,
-                const unsigned int                            face_no)
+    interpolate(const unsigned int                             n_components,
+                const EvaluationFlags::EvaluationFlags         flags,
+                const MatrixFreeFunctions::ShapeInfo<Number2> &shape_info,
+                const Number *                                 input,
+                Number *                                       output,
+                const unsigned int                             face_no)
     {
       Assert(static_cast<unsigned int>(fe_degree) ==
                  shape_info.data.front().fe_degree ||
@@ -3508,12 +3520,12 @@ namespace internal
     template <bool do_evaluate, bool add_into_output>
     static void
     interpolate_quadrature(
-      const unsigned int                            n_components,
-      const EvaluationFlags::EvaluationFlags        flags,
-      const MatrixFreeFunctions::ShapeInfo<Number> &shape_info,
-      const Number *                                input,
-      Number *                                      output,
-      const unsigned int                            face_no)
+      const unsigned int                             n_components,
+      const EvaluationFlags::EvaluationFlags         flags,
+      const MatrixFreeFunctions::ShapeInfo<Number2> &shape_info,
+      const Number *                                 input,
+      Number *                                       output,
+      const unsigned int                             face_no)
     {
       Assert(static_cast<unsigned int>(fe_degree + 1) ==
                  shape_info.data.front().n_q_points_1d ||
@@ -3541,7 +3553,7 @@ namespace internal
                         const EvaluationFlags::EvaluationFlags flag,
                         const unsigned int                     face_no,
                         const unsigned int                     n_points_1d,
-                        const std::array<AlignedVector<Number>, 2> &shape_data,
+                        const std::array<AlignedVector<Number2>, 2> &shape_data,
                         const unsigned int dofs_per_component_on_cell,
                         const unsigned int dofs_per_component_on_face)
     {
@@ -3551,7 +3563,8 @@ namespace internal
                                  dim,
                                  fe_degree + 1,
                                  0,
-                                 Number>
+                                 Number,
+                                 Number2>
             evalf(shape_data[face_no % 2].begin(),
                   nullptr,
                   nullptr,
@@ -3606,12 +3619,10 @@ namespace internal
     template <typename EvalType>
     static EvalType
     create_evaluator_tensor_product(
-      const MatrixFreeFunctions::UnivariateShapeData<Number> &data,
-      const unsigned int                                      face_no)
+      const MatrixFreeFunctions::UnivariateShapeData<Number2> &data,
+      const unsigned int                                       face_no)
     {
-      return EvalType(data.shape_data_on_face[face_no % 2],
-                      AlignedVector<Number>(),
-                      AlignedVector<Number>());
+      return EvalType(data.shape_data_on_face[face_no % 2], {}, {});
     }
 
     template <bool do_evaluate,
@@ -3620,12 +3631,12 @@ namespace internal
               int  max_derivative = 0>
     static void
     interpolate_generic_raviart_thomas(
-      const unsigned int                            n_components,
-      const Number *                                input,
-      Number *                                      output,
-      const EvaluationFlags::EvaluationFlags        flag,
-      const unsigned int                            face_no,
-      const MatrixFreeFunctions::ShapeInfo<Number> &shape_info)
+      const unsigned int                             n_components,
+      const Number *                                 input,
+      Number *                                       output,
+      const EvaluationFlags::EvaluationFlags         flag,
+      const unsigned int                             face_no,
+      const MatrixFreeFunctions::ShapeInfo<Number2> &shape_info)
     {
       if (dim == 1)
         {
@@ -3688,10 +3699,10 @@ namespace internal
               int  max_derivative>
     static inline void
     interpolate_generic_raviart_thomas_apply_face(
-      const MatrixFreeFunctions::ShapeInfo<Number> &shape_info,
-      const unsigned int                            face_no,
-      const Number *                                input,
-      Number *                                      output)
+      const MatrixFreeFunctions::ShapeInfo<Number2> &shape_info,
+      const unsigned int                             face_no,
+      const Number *                                 input,
+      Number *                                       output)
     {
       // These types are evaluators in either normal or tangential direction
       // depending on the face direction, with different normal directions for
@@ -3703,13 +3714,15 @@ namespace internal
                                           (fe_degree == -1) ? 1 : fe_degree + 1,
                                           0,
                                           Number,
-                                          0>,
+                                          0,
+                                          Number2>,
         EvaluatorTensorProductAnisotropic<evaluate_raviart_thomas,
                                           dim,
                                           (fe_degree == -1) ? 1 : fe_degree,
                                           0,
                                           Number,
-                                          0>>::type;
+                                          0,
+                                          Number2>>::type;
       using Evalf1 = typename std::conditional<
         face_direction == 1,
         EvaluatorTensorProductAnisotropic<evaluate_raviart_thomas,
@@ -3717,13 +3730,15 @@ namespace internal
                                           (fe_degree == -1) ? 1 : fe_degree + 1,
                                           0,
                                           Number,
-                                          1>,
+                                          1,
+                                          Number2>,
         EvaluatorTensorProductAnisotropic<evaluate_raviart_thomas,
                                           dim,
                                           (fe_degree == -1) ? 1 : fe_degree,
                                           0,
                                           Number,
-                                          1>>::type;
+                                          1,
+                                          Number2>>::type;
       using Evalf2 = typename std::conditional<
         face_direction == 2,
         EvaluatorTensorProductAnisotropic<evaluate_raviart_thomas,
@@ -3731,13 +3746,15 @@ namespace internal
                                           (fe_degree == -1) ? 1 : fe_degree + 1,
                                           0,
                                           Number,
-                                          2>,
+                                          2,
+                                          Number2>,
         EvaluatorTensorProductAnisotropic<evaluate_raviart_thomas,
                                           dim,
                                           (fe_degree == -1) ? 1 : fe_degree,
                                           0,
                                           Number,
-                                          2>>::type;
+                                          2,
+                                          Number2>>::type;
 
       Evalf0 evalf0 =
         create_evaluator_tensor_product<Evalf0>((face_direction == 0) ?
@@ -4055,6 +4072,8 @@ namespace internal
     {
       const auto &shape_info = fe_eval.get_shape_info();
       const auto &shape_data = shape_info.data.front();
+      using Number2 =
+        typename FEEvaluationData<dim, Number, true>::shape_info_number_type;
 
       if (shape_info.element_type == MatrixFreeFunctions::tensor_none)
         {
@@ -4069,7 +4088,7 @@ namespace internal
           const std::size_t  n_q_points = shape_info.n_q_points_faces[face_no];
 
           using Eval =
-            EvaluatorTensorProduct<evaluate_general, 1, 0, 0, Number, Number>;
+            EvaluatorTensorProduct<evaluate_general, 1, 0, 0, Number, Number2>;
 
           if (evaluation_flag & EvaluationFlags::values)
             {
@@ -4095,7 +4114,7 @@ namespace internal
               auto gradients_quad_ptr     = fe_eval.begin_gradients();
               auto values_dofs_actual_ptr = values_dofs;
 
-              std::array<const Number *, dim> shape_gradients;
+              std::array<const Number2 *, dim> shape_gradients;
               for (unsigned int d = 0; d < dim; ++d)
                 shape_gradients[d] = &shape_data.shape_gradients_face(
                   face_no, face_orientation, d, 0);
@@ -4292,6 +4311,8 @@ namespace internal
     {
       const auto &shape_info = fe_eval.get_shape_info();
       const auto &shape_data = shape_info.data.front();
+      using Number2 =
+        typename FEEvaluationData<dim, Number, true>::shape_info_number_type;
 
       if (shape_info.element_type == MatrixFreeFunctions::tensor_none)
         {
@@ -4306,7 +4327,7 @@ namespace internal
           const std::size_t  n_q_points = shape_info.n_q_points_faces[face_no];
 
           using Eval =
-            EvaluatorTensorProduct<evaluate_general, 1, 0, 0, Number, Number>;
+            EvaluatorTensorProduct<evaluate_general, 1, 0, 0, Number, Number2>;
 
           if (integration_flag & EvaluationFlags::values)
             {
@@ -4332,7 +4353,7 @@ namespace internal
               auto gradients_quad_ptr     = fe_eval.begin_gradients();
               auto values_dofs_actual_ptr = values_dofs;
 
-              std::array<const Number *, dim> shape_gradients;
+              std::array<const Number2 *, dim> shape_gradients;
               for (unsigned int d = 0; d < dim; ++d)
                 shape_gradients[d] = &shape_data.shape_gradients_face(
                   face_no, face_orientation, d, 0);
@@ -5207,12 +5228,12 @@ namespace internal
       return false;
     }
 
+    template <typename Number3>
     static bool
-    supports(
-      const EvaluationFlags::EvaluationFlags evaluation_flag,
-      const MatrixFreeFunctions::ShapeInfo<VectorizedArrayType> &shape_info,
-      const Number2 *                                            vector_ptr,
-      MatrixFreeFunctions::DoFInfo::IndexStorageVariants         storage)
+    supports(const EvaluationFlags::EvaluationFlags             evaluation_flag,
+             const MatrixFreeFunctions::ShapeInfo<Number3> &    shape_info,
+             const Number2 *                                    vector_ptr,
+             MatrixFreeFunctions::DoFInfo::IndexStorageVariants storage)
     {
       const unsigned int fe_degree = shape_info.data.front().fe_degree;
       if (fe_degree < 1 || !shape_info.data.front().nodal_at_cell_boundaries ||
@@ -5518,6 +5539,9 @@ namespace internal
   template <int dim, typename Number>
   struct CellwiseInverseMassMatrixImplBasic
   {
+    using Number2 =
+      typename FEEvaluationData<dim, Number, false>::shape_info_number_type;
+
     template <int fe_degree, int = 0>
     static bool
     run(const unsigned int                          n_components,
@@ -5538,10 +5562,11 @@ namespace internal
                              dim,
                              fe_degree + 1,
                              fe_degree + 1,
-                             Number>
+                             Number,
+                             Number2>
         evaluator(
-          AlignedVector<Number>(),
-          AlignedVector<Number>(),
+          {},
+          {},
           fe_eval.get_shape_info().data.front().inverse_shape_values_eo);
 
       for (unsigned int d = 0; d < n_components; ++d)
@@ -5588,12 +5613,12 @@ namespace internal
 
       Assert(dim >= 1 || dim <= 3, ExcNotImplemented());
 
-      EvaluatorTensorProduct<evaluate_general, dim, 0, 0, Number> evaluator(
-        fe_eval.get_shape_info().data.front().inverse_shape_values,
-        AlignedVector<Number>(),
-        AlignedVector<Number>(),
-        fe_eval.get_shape_info().data.front().fe_degree + 1,
-        fe_eval.get_shape_info().data.front().fe_degree + 1);
+      EvaluatorTensorProduct<evaluate_general, dim, 0, 0, Number, Number2>
+        evaluator(fe_eval.get_shape_info().data.front().inverse_shape_values,
+                  {},
+                  {},
+                  fe_eval.get_shape_info().data.front().fe_degree + 1,
+                  fe_eval.get_shape_info().data.front().fe_degree + 1);
 
       for (unsigned int d = 0; d < n_components; ++d)
         {
@@ -5637,6 +5662,9 @@ namespace internal
   template <int dim, typename Number>
   struct CellwiseInverseMassMatrixImplFlexible
   {
+    using Number2 =
+      typename FEEvaluationData<dim, Number, false>::shape_info_number_type;
+
     template <int fe_degree, int = 0>
     static bool
     run(const unsigned int                          n_desired_components,
@@ -5680,9 +5708,10 @@ namespace internal
                              dim,
                              fe_degree + 1,
                              fe_degree + 1,
-                             Number>
-        evaluator(AlignedVector<Number>(),
-                  AlignedVector<Number>(),
+                             Number,
+                             Number2>
+        evaluator({},
+                  {},
                   fe_eval.get_shape_info().data.front().inverse_shape_values_eo,
                   given_degree + 1,
                   given_degree + 1);
@@ -5824,13 +5853,16 @@ namespace internal
                                        Utilities::pow(fe_degree + 1, dim) :
                                        fe_eval.get_shape_info().n_q_points;
 
+      using Number2 =
+        typename FEEvaluationData<dim, Number, false>::shape_info_number_type;
       EvaluatorTensorProduct<do_inplace ? evaluate_evenodd : evaluate_general,
                              dim,
                              fe_degree + 1,
                              n_q_points_1d,
-                             Number>
-        evaluator(AlignedVector<Number>(),
-                  AlignedVector<Number>(),
+                             Number,
+                             Number2>
+        evaluator({},
+                  {},
                   inverse_shape,
                   fe_eval.get_shape_info().data.front().fe_degree + 1,
                   fe_eval.get_shape_info().data.front().n_q_points_1d);

--- a/include/deal.II/matrix_free/fe_evaluation_data.h
+++ b/include/deal.II/matrix_free/fe_evaluation_data.h
@@ -121,8 +121,8 @@ class FEEvaluationData
 public:
   static constexpr unsigned int dimension = dim;
 
-  using NumberType = Number;
-
+  using NumberType             = Number;
+  using shape_info_number_type = Number;
   using ScalarNumber =
     typename internal::VectorizedArrayTrait<Number>::value_type;
 
@@ -1502,7 +1502,7 @@ FEEvaluationData<dim, Number, is_face>::get_cell_type() const
 
 
 template <int dim, typename Number, bool is_face>
-inline const internal::MatrixFreeFunctions::ShapeInfo<Number> &
+inline const typename FEEvaluationData<dim, Number, is_face>::ShapeInfoType &
 FEEvaluationData<dim, Number, is_face>::get_shape_info() const
 {
   Assert(data != nullptr, ExcInternalError());

--- a/include/deal.II/matrix_free/fe_evaluation_data.h
+++ b/include/deal.II/matrix_free/fe_evaluation_data.h
@@ -1659,6 +1659,8 @@ namespace internal
                              const VectorOfArrayType &         array,
                              ArrayType &                       out)
   {
+    AssertDimension(indices.size(), out.size());
+    AssertDimension(indices.size(), array[0].size());
     // set all entries in array to a valid element
     int index = 0;
     for (; index < N; ++index)

--- a/include/deal.II/matrix_free/tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/tensor_product_kernels.h
@@ -149,8 +149,8 @@ namespace internal
             int              dim,
             int              n_rows,
             int              n_columns,
+            int              normal_dir,
             typename Number,
-            int normal_dir,
             typename Number2 = Number>
   struct EvaluatorTensorProductAnisotropic
   {};
@@ -2534,15 +2534,15 @@ namespace internal
   template <int dim,
             int n_rows,
             int n_columns,
-            typename Number,
             int normal_dir,
+            typename Number,
             typename Number2>
   struct EvaluatorTensorProductAnisotropic<evaluate_raviart_thomas,
                                            dim,
                                            n_rows,
                                            n_columns,
-                                           Number,
                                            normal_dir,
+                                           Number,
                                            Number2>
   {
     static constexpr unsigned int n_rows_of_product =
@@ -2666,8 +2666,8 @@ namespace internal
   template <int dim,
             int n_rows,
             int n_columns,
-            typename Number,
             int normal_dir,
+            typename Number,
             typename Number2>
   template <int direction, bool contract_over_rows, bool add, bool one_line>
   inline void
@@ -2676,8 +2676,8 @@ namespace internal
     dim,
     n_rows,
     n_columns,
-    Number,
     normal_dir,
+    Number,
     Number2>::apply(const Number2 *DEAL_II_RESTRICT shape_data,
                     const Number *                  in,
                     Number *                        out)
@@ -2759,8 +2759,8 @@ namespace internal
   template <int dim,
             int n_rows,
             int n_columns,
-            typename Number,
             int normal_dir,
+            typename Number,
             typename Number2>
   template <int  face_direction,
             bool contract_onto_face,
@@ -2772,8 +2772,8 @@ namespace internal
     dim,
     n_rows,
     n_columns,
-    Number,
     normal_dir,
+    Number,
     Number2>::apply_face(const Number *DEAL_II_RESTRICT in,
                          Number *DEAL_II_RESTRICT       out) const
   {

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -137,14 +137,12 @@ namespace
         internal::EvaluatorQuantity::value,
         dim,
         degree_coarse + 1,
-        degree_fine + 1,
-        Number,
-        Number>::do_forward(1,
-                            prolongation_matrix_1d,
-                            evaluation_data_coarse,
-                            evaluation_data_fine,
-                            degree_coarse_ + 1,
-                            degree_fine_ + 1);
+        degree_fine + 1>::do_forward(1,
+                                     prolongation_matrix_1d,
+                                     evaluation_data_coarse,
+                                     evaluation_data_fine,
+                                     degree_coarse_ + 1,
+                                     degree_fine_ + 1);
     }
 
     void
@@ -157,14 +155,12 @@ namespace
         internal::EvaluatorQuantity::value,
         1,
         0,
-        0,
-        Number,
-        Number>::do_forward(1,
-                            prolongation_matrix,
-                            evaluation_data_coarse,
-                            evaluation_data_fine,
-                            n_dofs_coarse,
-                            n_dofs_fine);
+        0>::do_forward(1,
+                       prolongation_matrix,
+                       evaluation_data_coarse,
+                       evaluation_data_fine,
+                       n_dofs_coarse,
+                       n_dofs_fine);
     }
 
   private:
@@ -203,15 +199,14 @@ namespace
         internal::EvaluatorQuantity::value,
         dim,
         degree_coarse == 0 ? -1 : (degree_coarse + 1),
-        degree_fine == 0 ? -1 : (degree_fine + 1),
-        Number,
-        Number>::do_backward(1,
-                             prolongation_matrix_1d,
-                             false,
-                             evaluation_data_fine,
-                             evaluation_data_coarse,
-                             degree_coarse_ + 1,
-                             degree_fine_ + 1);
+        degree_fine == 0 ? -1 : (degree_fine + 1)>::
+        do_backward(1,
+                    prolongation_matrix_1d,
+                    false,
+                    evaluation_data_fine,
+                    evaluation_data_coarse,
+                    degree_coarse_ + 1,
+                    degree_fine_ + 1);
     }
 
     void
@@ -224,15 +219,13 @@ namespace
         internal::EvaluatorQuantity::value,
         1,
         0,
-        0,
-        Number,
-        Number>::do_backward(1,
-                             prolongation_matrix,
-                             false,
-                             evaluation_data_fine,
-                             evaluation_data_coarse,
-                             n_dofs_coarse,
-                             n_dofs_fine);
+        0>::do_backward(1,
+                        prolongation_matrix,
+                        false,
+                        evaluation_data_fine,
+                        evaluation_data_coarse,
+                        n_dofs_coarse,
+                        n_dofs_fine);
     }
 
   private:

--- a/source/multigrid/mg_transfer_matrix_free.cc
+++ b/source/multigrid/mg_transfer_matrix_free.cc
@@ -496,17 +496,15 @@ MGTransferMatrixFree<dim, Number>::do_prolongate_add(
               internal::EvaluatorQuantity::value,
               dim,
               degree + 1,
-              2 * degree + 1,
-              VectorizedArray<Number>,
-              VectorizedArray<Number>>::do_forward(1,
-                                                   prolongation_matrix_1d,
-                                                   evaluation_data.begin() +
-                                                     c * Utilities::fixed_power<
-                                                           dim>(degree_size),
-                                                   evaluation_data.begin() +
-                                                     c * n_scalar_cell_dofs,
-                                                   fe_degree + 1,
-                                                   2 * fe_degree + 1);
+              2 * degree + 1>::do_forward(1,
+                                          prolongation_matrix_1d,
+                                          evaluation_data.begin() +
+                                            c * Utilities::fixed_power<dim>(
+                                                  degree_size),
+                                          evaluation_data.begin() +
+                                            c * n_scalar_cell_dofs,
+                                          fe_degree + 1,
+                                          2 * fe_degree + 1);
           internal::weight_fe_q_dofs_by_entity<dim,
                                                degree != -1 ? 2 * degree + 1 :
                                                               -1,
@@ -524,17 +522,15 @@ MGTransferMatrixFree<dim, Number>::do_prolongate_add(
               internal::EvaluatorQuantity::value,
               dim,
               degree + 1,
-              2 * degree + 2,
-              VectorizedArray<Number>,
-              VectorizedArray<Number>>::do_forward(1,
-                                                   prolongation_matrix_1d,
-                                                   evaluation_data.begin() +
-                                                     c * Utilities::fixed_power<
-                                                           dim>(degree_size),
-                                                   evaluation_data.begin() +
-                                                     c * n_scalar_cell_dofs,
-                                                   fe_degree + 1,
-                                                   2 * fe_degree + 2);
+              2 * degree + 2>::do_forward(1,
+                                          prolongation_matrix_1d,
+                                          evaluation_data.begin() +
+                                            c * Utilities::fixed_power<dim>(
+                                                  degree_size),
+                                          evaluation_data.begin() +
+                                            c * n_scalar_cell_dofs,
+                                          fe_degree + 1,
+                                          2 * fe_degree + 2);
         }
 
       // write into dst vector
@@ -606,19 +602,16 @@ MGTransferMatrixFree<dim, Number>::do_restrict_add(
               internal::EvaluatorQuantity::value,
               dim,
               degree + 1,
-              2 * degree + 1,
-              VectorizedArray<Number>,
-              VectorizedArray<Number>>::do_backward(1,
-                                                    prolongation_matrix_1d,
-                                                    false,
-                                                    evaluation_data.begin() +
-                                                      c * n_scalar_cell_dofs,
-                                                    evaluation_data.begin() +
-                                                      c *
-                                                        Utilities::fixed_power<
-                                                          dim>(degree_size),
-                                                    fe_degree + 1,
-                                                    2 * fe_degree + 1);
+              2 * degree + 1>::do_backward(1,
+                                           prolongation_matrix_1d,
+                                           false,
+                                           evaluation_data.begin() +
+                                             c * n_scalar_cell_dofs,
+                                           evaluation_data.begin() +
+                                             c * Utilities::fixed_power<dim>(
+                                                   degree_size),
+                                           fe_degree + 1,
+                                           2 * fe_degree + 1);
         }
       else
         {
@@ -628,19 +621,16 @@ MGTransferMatrixFree<dim, Number>::do_restrict_add(
               internal::EvaluatorQuantity::value,
               dim,
               degree + 1,
-              2 * degree + 2,
-              VectorizedArray<Number>,
-              VectorizedArray<Number>>::do_backward(1,
-                                                    prolongation_matrix_1d,
-                                                    false,
-                                                    evaluation_data.begin() +
-                                                      c * n_scalar_cell_dofs,
-                                                    evaluation_data.begin() +
-                                                      c *
-                                                        Utilities::fixed_power<
-                                                          dim>(degree_size),
-                                                    fe_degree + 1,
-                                                    2 * fe_degree + 2);
+              2 * degree + 2>::do_backward(1,
+                                           prolongation_matrix_1d,
+                                           false,
+                                           evaluation_data.begin() +
+                                             c * n_scalar_cell_dofs,
+                                           evaluation_data.begin() +
+                                             c * Utilities::fixed_power<dim>(
+                                                   degree_size),
+                                           fe_degree + 1,
+                                           2 * fe_degree + 2);
         }
 
       // write into dst vector

--- a/tests/performance/timing_navier_stokes.cc
+++ b/tests/performance/timing_navier_stokes.cc
@@ -1014,15 +1014,13 @@ namespace NavierStokes_DG
           internal::EvaluatorQuantity::hessian,
           dim,
           degree + 1,
-          n_points_1d,
-          VectorizedArrayType,
-          VectorizedArrayType>::do_backward(dim + 2,
-                                            data.get_shape_info()
-                                              .data[0]
-                                              .inverse_shape_values_eo,
-                                            false,
-                                            phi.begin_values(),
-                                            phi.begin_dof_values());
+          n_points_1d>::do_backward(dim + 2,
+                                    data.get_shape_info()
+                                      .data[0]
+                                      .inverse_shape_values_eo,
+                                    false,
+                                    phi.begin_values(),
+                                    phi.begin_dof_values());
 
         if (ai == Number())
           {


### PR DESCRIPTION
This is a follow-up to #15207 in that it makes the access to a `ShapeInfo` of a different `Number` type than the actual data arrays possible. Note that this PR does not touch the actually stored data, but merely adjusts template arguments that a change could be made relatively smoothly. There are two short comments that I would like to make:
- The `internal::FEEvaluationImplBasisChange` struct that implements the basis change did have a class template argument for the two types, interpolation matrix and interpolated vectors. This makes adjustments more painful, and I would prefer to make the `Number` and `Number2` types, as we call them, function templates instead, because then the compiler can automatically deduce them. While this would not have been strictly necessary for this PR, I consider this an important step for the future development of the interfaces and thus embedding the change here avoids some unnecessary work. On the downside, we also need to touch some users of this class, and there might even be external users of this class. Instead of making an incompatible change on this (internal) interface, I decided to keep the arguments around as dummies for a while at least.
- The actual decision is now encoded by a new argument `FEEvaluationData::shape_info_number_type`. From here on, it is rather simple to decide on another type in https://github.com/dealii/dealii/blob/e82979bc8e48ec2d78246ec47220d152806d84d0/include/deal.II/matrix_free/matrix_free.h#L2279-L2283 and then adjust this single line in addition - or forward that information to `FEEvaluationData`, depending on what we prefer. I think it does not make sense to make the interfaces fully flexible in terms of independent types, because it would double the instantiations we need to make for `evaluation_template_factory` and friends.