### PR TITLE
Convert ARKode interfaces to conform to our callback policy.

### DIFF
--- a/doc/news/changes/major/20230508Bangerth
+++ b/doc/news/changes/major/20230508Bangerth
@@ -9,7 +9,8 @@ positive value for a recoverable error.
 
 This approach does not scale across the many interfaces we have. As a
 consequence, we standardized how callbacks should behave, as
-documented in @ref GlossUserProvidedCallBack "this glossary entry". 
-The interfaces in SUNDIALS::KINSOL have been changed correspondingly.
+documented in @ref GlossUserProvidedCallBack "this glossary entry".
+The interfaces in SUNDIALS::KINSOL and SUNDIALS::ARKode have been
+changed correspondingly.
 <br>
 (Wolfgang Bangerth, 2023/05/08)

--- a/include/deal.II/sundials/arkode.h
+++ b/include/deal.II/sundials/arkode.h
@@ -51,6 +51,7 @@
 #  include <sundials/sundials_math.h>
 #  include <sundials/sundials_types.h>
 
+#  include <exception>
 #  include <memory>
 
 
@@ -579,15 +580,15 @@ namespace SUNDIALS
      * provided. According to which one is provided, explicit, implicit, or
      * mixed RK methods are used.
      *
-     * This function should return:
-     * - 0: Success
-     * - >0: Recoverable error, ARKode will reattempt the solution and call this
-     *       function again.
-     * - <0: Unrecoverable error, the computation will be aborted and an
-     *       assertion will be thrown.
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, ARKode can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
      */
     std::function<
-      int(const double t, const VectorType &y, VectorType &explicit_f)>
+      void(const double t, const VectorType &y, VectorType &explicit_f)>
       explicit_function;
 
     /**
@@ -599,14 +600,14 @@ namespace SUNDIALS
      * provided. According to which one is provided, explicit, implicit, or
      * mixed RK methods are used.
      *
-     * This function should return:
-     * - 0: Success
-     * - >0: Recoverable error, ARKode will reattempt the solution and call this
-     *       function again.
-     * - <0: Unrecoverable error, the computation will be aborted and an
-     *       assertion will be thrown.
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, ARKode can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
      */
-    std::function<int(const double t, const VectorType &y, VectorType &res)>
+    std::function<void(const double t, const VectorType &y, VectorType &res)>
       implicit_function;
 
     /**
@@ -619,14 +620,14 @@ namespace SUNDIALS
      * A call to this function should store in `Mv` the result of $M$
      * applied to `v`.
      *
-     * This function should return:
-     * - 0: Success
-     * - >0: Recoverable error, ARKode will reattempt the solution and call this
-     *       function again.
-     * - <0: Unrecoverable error, the computation will be aborted and an
-     *       assertion will be thrown.
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, ARKode can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
      */
-    std::function<int(double t, const VectorType &v, VectorType &Mv)>
+    std::function<void(const double t, const VectorType &v, VectorType &Mv)>
       mass_times_vector;
 
     /**
@@ -656,14 +657,14 @@ namespace SUNDIALS
      *
      * @param t The current evaluation time
      *
-     * This function should return:
-     * - 0: Success
-     * - >0: Recoverable error, ARKode will reattempt the solution and call this
-     *       function again.
-     * - <0: Unrecoverable error, the computation will be aborted and an
-     *       assertion will be thrown.
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, ARKode can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
      */
-    std::function<int(const double t)> mass_times_setup;
+    std::function<void(const double t)> mass_times_setup;
 
     /**
      * A function object that users may supply and that is intended to compute
@@ -684,18 +685,18 @@ namespace SUNDIALS
      * @param[in] fy  The current value of the implicit right-hand side at y,
      *   $f_I (t_n, y)$.
      *
-     * This function should return:
-     * - 0: Success
-     * - >0: Recoverable error, ARKode will reattempt the solution and call this
-     *       function again.
-     * - <0: Unrecoverable error, the computation will be aborted and an
-     *       assertion will be thrown.
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, ARKode can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
      */
-    std::function<int(const VectorType &v,
-                      VectorType &      Jv,
-                      double            t,
-                      const VectorType &y,
-                      const VectorType &fy)>
+    std::function<void(const VectorType &v,
+                       VectorType &      Jv,
+                       const double      t,
+                       const VectorType &y,
+                       const VectorType &fy)>
       jacobian_times_vector;
 
     /**
@@ -725,14 +726,15 @@ namespace SUNDIALS
      * @param fy  The implicit right-hand side function evaluated at the
      *   current time $t$ and state $y$, i.e., $f_I(y,t)$
      *
-     * This function should return:
-     * - 0: Success
-     * - >0: Recoverable error, ARKode will reattempt the solution and call this
-     *       function again.
-     * - <0: Unrecoverable error, the computation will be aborted and an
-     *       assertion will be thrown.
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, ARKode can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
      */
-    std::function<int(realtype t, const VectorType &y, const VectorType &fy)>
+    std::function<
+      void(const double t, const VectorType &y, const VectorType &fy)>
       jacobian_times_setup;
 
     /**
@@ -753,6 +755,13 @@ namespace SUNDIALS
      * SUNDIALS packaged SPGMR solver with default settings is used.
      *
      * For more details on the function type refer to LinearSolveFunction.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, ARKode can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
      */
     LinearSolveFunction<VectorType> solve_linearized_system;
 
@@ -770,6 +779,13 @@ namespace SUNDIALS
      * and applied in mass_times_vector().
      *
      * For more details on the function type refer to LinearSolveFunction.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, ARKode can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
      */
     LinearSolveFunction<VectorType> solve_mass;
 
@@ -797,21 +813,21 @@ namespace SUNDIALS
      *   (lr = 2). Only relevant if used with a SUNDIALS packaged solver. If
      *   used with a custom solve_mass() function this will be set to zero.
      *
-     * This function should return:
-     * - 0: Success
-     * - >0: Recoverable error, ARKode will reattempt the solution and call this
-     *       function again.
-     * - <0: Unrecoverable error, the computation will be aborted and an
-     *       assertion will be thrown.
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, ARKode can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
      */
-    std::function<int(double            t,
-                      const VectorType &y,
-                      const VectorType &fy,
-                      const VectorType &r,
-                      VectorType &      z,
-                      double            gamma,
-                      double            tol,
-                      int               lr)>
+    std::function<void(const double      t,
+                       const VectorType &y,
+                       const VectorType &fy,
+                       const VectorType &r,
+                       VectorType &      z,
+                       const double      gamma,
+                       const double      tol,
+                       const int         lr)>
       jacobian_preconditioner_solve;
 
     /**
@@ -849,19 +865,19 @@ namespace SUNDIALS
      * @param[in] gamma The value $\gamma$ in $M-\gamma J$. The preconditioner
      *   should approximate the inverse of this matrix.
      *
-     * This function should return:
-     * - 0: Success
-     * - >0: Recoverable error, ARKode will reattempt the solution and call this
-     *       function again.
-     * - <0: Unrecoverable error, the computation will be aborted and an
-     *       assertion will be thrown.
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, ARKode can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
      */
-    std::function<int(double            t,
-                      const VectorType &y,
-                      const VectorType &fy,
-                      int               jok,
-                      int &             jcur,
-                      double            gamma)>
+    std::function<void(const double      t,
+                       const VectorType &y,
+                       const VectorType &fy,
+                       const int         jok,
+                       int &             jcur,
+                       const double      gamma)>
       jacobian_preconditioner_setup;
 
     /**
@@ -884,15 +900,18 @@ namespace SUNDIALS
      *   (lr = 2). Only relevant if used with a SUNDIALS packaged solver. If
      *   used with a custom solve_mass() function this will be set to zero.
      *
-     * This function should return:
-     * - 0: Success
-     * - >0: Recoverable error, ARKode will reattempt the solution and call this
-     *       function again.
-     * - <0: Unrecoverable error, the computation will be aborted and an
-     *       assertion will be thrown.
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, ARKode can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
      */
-    std::function<
-      int(double t, const VectorType &r, VectorType &z, double tol, int lr)>
+    std::function<void(const double      t,
+                       const VectorType &r,
+                       VectorType &      z,
+                       const double      tol,
+                       const int         lr)>
       mass_preconditioner_solve;
 
     /**
@@ -912,14 +931,14 @@ namespace SUNDIALS
      *
      * @param[in] t  The current time
      *
-     * This function should return:
-     * - 0: Success
-     * - >0: Recoverable error, ARKode will reattempt the solution and call this
-     *       function again.
-     * - <0: Unrecoverable error, the computation will be aborted and an
-     *       assertion will be thrown.
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, ARKode can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
      */
-    std::function<int(double t)> mass_preconditioner_setup;
+    std::function<void(const double t)> mass_preconditioner_setup;
 
     /**
      * A function object that users may supply and that is intended to
@@ -983,7 +1002,7 @@ namespace SUNDIALS
      * @endcode
      *
      * @note This function will be called at the end of all other set up right
-     *   before the actual time evloution is started or continued with
+     *   before the actual time evolution is started or continued with
      *   solve_ode(). This function is also called when the solver is restarted,
      *   see solver_should_restart(). Consult the SUNDIALS manual to see which
      *   options are still available at this point.
@@ -1067,6 +1086,14 @@ namespace SUNDIALS
 
     std::unique_ptr<internal::LinearSolverWrapper<VectorType>> linear_solver;
     std::unique_ptr<internal::LinearSolverWrapper<VectorType>> mass_solver;
+
+  public:
+    /**
+     * A pointer to any exception that may have been thrown in user-defined
+     * call-backs and that we have to deal after the KINSOL function we call
+     * has returned.
+     */
+    mutable std::exception_ptr pending_exception;
 
 #  ifdef DEAL_II_WITH_PETSC
 #    ifdef PETSC_USE_COMPLEX

--- a/include/deal.II/sundials/sunlinsol_wrapper.h
+++ b/include/deal.II/sundials/sunlinsol_wrapper.h
@@ -171,7 +171,7 @@ namespace SUNDIALS
   };
 
   /**
-   * Type of function objects to interface with SUNDIALS linear solvers
+   * Type of function objects to interface with SUNDIALS' linear solvers
    *
    * This function type encapsulates the action of solving $P^{-1}Ax=P^{-1}b$.
    * The LinearOperator @p op encapsulates the matrix vector product $Ax$ and
@@ -188,20 +188,21 @@ namespace SUNDIALS
    * @param[in] b The right-hand side
    * @param[in] tol Tolerance for the iterative solver
    *
-   * This function should return:
-   * - 0: Success
-   * - >0: Recoverable error, ARKode will reattempt the solution and call this
-   *       function again.
-   * - <0: Unrecoverable error, the computation will be aborted and an
-   *       assertion will be thrown.
+   *
+   * @note This variable represents a
+   * @ref GlossUserProvidedCallBack "user provided callback".
+   * See there for a description of how to deal with errors and other
+   * requirements and conventions. In particular, ARKode can deal
+   * with "recoverable" errors in some circumstances, so callbacks
+   * can throw exceptions of type RecoverableUserCallbackError.
    */
   template <typename VectorType>
   using LinearSolveFunction =
-    std::function<int(SundialsOperator<VectorType> &      op,
-                      SundialsPreconditioner<VectorType> &prec,
-                      VectorType &                        x,
-                      const VectorType &                  b,
-                      double                              tol)>;
+    std::function<void(SundialsOperator<VectorType> &      op,
+                       SundialsPreconditioner<VectorType> &prec,
+                       VectorType &                        x,
+                       const VectorType &                  b,
+                       double                              tol)>;
 
   namespace internal
   {

--- a/include/deal.II/sundials/sunlinsol_wrapper.h
+++ b/include/deal.II/sundials/sunlinsol_wrapper.h
@@ -23,6 +23,7 @@
 
 #  include <sundials/sundials_linearsolver.h>
 
+#  include <exception>
 #  include <functional>
 #  include <memory>
 
@@ -216,10 +217,12 @@ namespace SUNDIALS
     class LinearSolverWrapper
     {
     public:
-      explicit LinearSolverWrapper(LinearSolveFunction<VectorType> lsolve
+      explicit LinearSolverWrapper(
+        const LinearSolveFunction<VectorType> &lsolve,
+        std::exception_ptr &                   pending_exception
 #  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
-                                   ,
-                                   SUNContext linsol_ctx
+        ,
+        SUNContext linsol_ctx
 #  endif
       );
 

--- a/source/sundials/arkode.cc
+++ b/source/sundials/arkode.cc
@@ -383,6 +383,7 @@ namespace SUNDIALS
 #  endif
     , mpi_communicator(mpi_comm)
     , last_end_time(data.initial_time)
+    , pending_exception(nullptr)
   {
     set_functions_to_trigger_an_assert();
 
@@ -413,6 +414,8 @@ namespace SUNDIALS
     (void)status;
     AssertARKode(status);
 #  endif
+
+    Assert(pending_exception == nullptr, ExcInternalError());
   }
 
 
@@ -662,7 +665,8 @@ namespace SUNDIALS
                 ,
                 arkode_ctx
 #  endif
-              );
+                ,
+                pending_exception);
             sun_linear_solver = *linear_solver;
           }
         else
@@ -764,7 +768,8 @@ namespace SUNDIALS
                 ,
                 arkode_ctx
 #  endif
-              );
+                ,
+                pending_exception);
             sun_mass_linear_solver = *mass_solver;
           }
         else

--- a/source/sundials/arkode.cc
+++ b/source/sundials/arkode.cc
@@ -51,6 +51,78 @@ namespace SUNDIALS
 {
   namespace
   {
+    /**
+     * A function that calls the function object given by its first argument
+     * with the set of arguments following at the end. If the call returns
+     * regularly, the current function returns zero to indicate success. If the
+     * call fails with an exception of type RecoverableUserCallbackError, then
+     * the current function returns 1 to indicate that the called function
+     * object thought the error it encountered is recoverable. If the call fails
+     * with any other exception, then the current function returns with an error
+     * code of -1. In each of the last two cases, the exception thrown by `f`
+     * is captured and `eptr` is set to the exception. In case of success,
+     * `eptr` is set to `nullptr`.
+     */
+    template <typename F, typename... Args>
+    int
+    call_and_possibly_capture_exception(const F &           f,
+                                        std::exception_ptr &eptr,
+                                        Args &&...args)
+    {
+      // See whether there is already something in the exception pointer
+      // variable. This can only happen if we had previously had
+      // a recoverable exception, and the underlying library actually
+      // did recover successfully. In that case, we can abandon the
+      // exception previously thrown. If eptr contains anything other,
+      // then we really don't know how that could have happened, and
+      // should probably bail out:
+      if (eptr)
+        {
+          try
+            {
+              std::rethrow_exception(eptr);
+            }
+          catch (const RecoverableUserCallbackError &)
+            {
+              // ok, ignore, but reset the pointer
+              eptr = nullptr;
+            }
+          catch (...)
+            {
+              // uh oh:
+              AssertThrow(false, ExcInternalError());
+            }
+        }
+
+      // Call the function and if that succeeds, return zero:
+      try
+        {
+          f(std::forward<Args>(args)...);
+          eptr = nullptr;
+          return 0;
+        }
+      // If the call failed with a recoverable error, then
+      // ignore the exception for now (but store a pointer to it)
+      // and return a positive return value (+1). If the underlying
+      // implementation manages to recover
+      catch (const RecoverableUserCallbackError &)
+        {
+          eptr = std::current_exception();
+          return 1;
+        }
+      // For any other exception, capture the exception and
+      // return -1:
+      catch (const std::exception &)
+        {
+          eptr = std::current_exception();
+          return -1;
+        }
+    }
+  } // namespace
+
+
+  namespace
+  {
     template <typename VectorType>
     int
     explicit_function_callback(realtype tt,
@@ -65,7 +137,11 @@ namespace SUNDIALS
       auto *src_yy = internal::unwrap_nvector_const<VectorType>(yy);
       auto *dst_yp = internal::unwrap_nvector<VectorType>(yp);
 
-      return solver.explicit_function(tt, *src_yy, *dst_yp);
+      return call_and_possibly_capture_exception(solver.explicit_function,
+                                                 solver.pending_exception,
+                                                 tt,
+                                                 *src_yy,
+                                                 *dst_yp);
     }
 
 
@@ -84,7 +160,11 @@ namespace SUNDIALS
       auto *src_yy = internal::unwrap_nvector_const<VectorType>(yy);
       auto *dst_yp = internal::unwrap_nvector<VectorType>(yp);
 
-      return solver.implicit_function(tt, *src_yy, *dst_yp);
+      return call_and_possibly_capture_exception(solver.implicit_function,
+                                                 solver.pending_exception,
+                                                 tt,
+                                                 *src_yy,
+                                                 *dst_yp);
     }
 
 
@@ -109,7 +189,13 @@ namespace SUNDIALS
 
       auto *dst_Jv = internal::unwrap_nvector<VectorType>(Jv);
 
-      return solver.jacobian_times_vector(*src_v, *dst_Jv, t, *src_y, *src_fy);
+      return call_and_possibly_capture_exception(solver.jacobian_times_vector,
+                                                 solver.pending_exception,
+                                                 *src_v,
+                                                 *dst_Jv,
+                                                 t,
+                                                 *src_y,
+                                                 *src_fy);
     }
 
 
@@ -128,7 +214,11 @@ namespace SUNDIALS
       auto *src_y  = internal::unwrap_nvector_const<VectorType>(y);
       auto *src_fy = internal::unwrap_nvector_const<VectorType>(fy);
 
-      return solver.jacobian_times_setup(t, *src_y, *src_fy);
+      return call_and_possibly_capture_exception(solver.jacobian_times_setup,
+                                                 solver.pending_exception,
+                                                 t,
+                                                 *src_y,
+                                                 *src_fy);
     }
 
 
@@ -155,8 +245,17 @@ namespace SUNDIALS
 
       auto *dst_z = internal::unwrap_nvector<VectorType>(z);
 
-      return solver.jacobian_preconditioner_solve(
-        t, *src_y, *src_fy, *src_r, *dst_z, gamma, delta, lr);
+      return call_and_possibly_capture_exception(
+        solver.jacobian_preconditioner_solve,
+        solver.pending_exception,
+        t,
+        *src_y,
+        *src_fy,
+        *src_r,
+        *dst_z,
+        gamma,
+        delta,
+        lr);
     }
 
 
@@ -178,8 +277,15 @@ namespace SUNDIALS
       auto *src_y  = internal::unwrap_nvector_const<VectorType>(y);
       auto *src_fy = internal::unwrap_nvector_const<VectorType>(fy);
 
-      return solver.jacobian_preconditioner_setup(
-        t, *src_y, *src_fy, jok, *jcurPtr, gamma);
+      return call_and_possibly_capture_exception(
+        solver.jacobian_preconditioner_setup,
+        solver.pending_exception,
+        t,
+        *src_y,
+        *src_fy,
+        jok,
+        *jcurPtr,
+        gamma);
     }
 
 
@@ -198,7 +304,8 @@ namespace SUNDIALS
       auto *src_v  = internal::unwrap_nvector_const<VectorType>(v);
       auto *dst_Mv = internal::unwrap_nvector<VectorType>(Mv);
 
-      return solver.mass_times_vector(t, *src_v, *dst_Mv);
+      return call_and_possibly_capture_exception(
+        solver.mass_times_vector, solver.pending_exception, t, *src_v, *dst_Mv);
     }
 
 
@@ -211,7 +318,9 @@ namespace SUNDIALS
       ARKode<VectorType> &solver =
         *static_cast<ARKode<VectorType> *>(mtimes_data);
 
-      return solver.mass_times_setup(t);
+      return call_and_possibly_capture_exception(solver.mass_times_setup,
+                                                 solver.pending_exception,
+                                                 t);
     }
 
 
@@ -232,7 +341,14 @@ namespace SUNDIALS
       auto *src_r = internal::unwrap_nvector_const<VectorType>(r);
       auto *dst_z = internal::unwrap_nvector<VectorType>(z);
 
-      return solver.mass_preconditioner_solve(t, *src_r, *dst_z, delta, lr);
+      return call_and_possibly_capture_exception(
+        solver.mass_preconditioner_solve,
+        solver.pending_exception,
+        t,
+        *src_r,
+        *dst_z,
+        delta,
+        lr);
     }
 
 
@@ -245,7 +361,8 @@ namespace SUNDIALS
       ARKode<VectorType> &solver =
         *static_cast<ARKode<VectorType> *>(user_data);
 
-      return solver.mass_preconditioner_setup(t);
+      return call_and_possibly_capture_exception(
+        solver.mass_preconditioner_setup, solver.pending_exception, t);
     }
   } // namespace
 
@@ -368,14 +485,41 @@ namespace SUNDIALS
       {
         time.set_desired_next_step_size(data.output_period);
 
-        // Let ARKode advance time by one period:
+        // Having set up all of the ancillary things, finally call the main
+        // ARKode function. One we return, check that what happened:
+        // - If we have a pending recoverable exception, ignore it if SUNDIAL's
+        //   return code was zero -- in that case, SUNDIALS managed to indeed
+        //   recover and we no longer need the exception
+        // - If we have any other exception, rethrow it
+        // - If no exception, test that SUNDIALS really did successfully return
+        Assert(pending_exception == nullptr, ExcInternalError());
         double     actual_next_time;
         const auto status = ARKStepEvolve(arkode_mem,
                                           time.get_next_time(),
                                           solution_nvector,
                                           &actual_next_time,
                                           ARK_NORMAL);
-        (void)status;
+        if (pending_exception)
+          {
+            try
+              {
+                std::rethrow_exception(pending_exception);
+              }
+            catch (const RecoverableUserCallbackError &exc)
+              {
+                pending_exception = nullptr;
+                if (status == 0)
+                  /* just eat the exception */;
+                else
+                  throw;
+              }
+            catch (...)
+              {
+                pending_exception = nullptr;
+                throw;
+              }
+          }
+
         AssertARKode(status);
 
         // Then reflect this time advancement in our own DiscreteTime object:

--- a/tests/sundials/arkode_01.cc
+++ b/tests/sundials/arkode_01.cc
@@ -75,23 +75,18 @@ main()
 
   double kappa = 1.0;
 
-  ode.explicit_function =
-    [&](double, const VectorType &y, VectorType &ydot) -> int {
+  ode.explicit_function = [&](double, const VectorType &y, VectorType &ydot) {
     ydot[0] = y[1];
     ydot[1] = -kappa * kappa * y[0];
-    return 0;
   };
 
-  ode.output_step = [&](const double       t,
-                        const VectorType & sol,
-                        const unsigned int step_number) -> int {
-    deallog << t << ' ' << sol[0] << ' ' << sol[1] << std::endl;
-    return 0;
-  };
+  ode.output_step =
+    [&](const double t, const VectorType &sol, const unsigned int step_number) {
+      deallog << t << ' ' << sol[0] << ' ' << sol[1] << std::endl;
+    };
 
   Vector<double> y(2);
   y[0] = 0;
   y[1] = kappa;
   ode.solve_ode(y);
-  return 0;
 }

--- a/tests/sundials/arkode_02.cc
+++ b/tests/sundials/arkode_02.cc
@@ -68,27 +68,22 @@ main()
 
   double kappa = 1.0;
 
-  ode.implicit_function =
-    [&](double, const VectorType &y, VectorType &ydot) -> int {
+  ode.implicit_function = [&](double, const VectorType &y, VectorType &ydot) {
     ydot[0] = y[1];
     ydot[1] = -kappa * kappa * y[0];
-    return 0;
   };
 
-  ode.output_step = [&](const double       t,
-                        const VectorType & sol,
-                        const unsigned int step_number) -> int {
-    // limit the output to every 10th step and increase the precision to make
-    // the test more robust
-    if (step_number % 10 == 0)
-      deallog << t << ' ' << std::setprecision(7) << sol[0] << ' ' << sol[1]
-              << std::endl;
-    return 0;
-  };
+  ode.output_step =
+    [&](const double t, const VectorType &sol, const unsigned int step_number) {
+      // limit the output to every 10th step and increase the precision to make
+      // the test more robust
+      if (step_number % 10 == 0)
+        deallog << t << ' ' << std::setprecision(7) << sol[0] << ' ' << sol[1]
+                << std::endl;
+    };
 
   Vector<double> y(2);
   y[0] = 0;
   y[1] = kappa;
   ode.solve_ode(y);
-  return 0;
 }

--- a/tests/sundials/arkode_03.cc
+++ b/tests/sundials/arkode_03.cc
@@ -74,45 +74,38 @@ main()
   // Parameters
   double u0 = 3.9, v0 = 1.1, w0 = 2.8, a = 1.2, b = 2.5, eps = 1e-5;
 
-  ode.implicit_function =
-    [&](double, const VectorType &y, VectorType &ydot) -> int {
+  ode.implicit_function = [&](double, const VectorType &y, VectorType &ydot) {
     ydot[0] = 0;
     ydot[1] = 0;
     ydot[2] = -y[2] / eps;
-    return 0;
   };
 
 
-  ode.explicit_function =
-    [&](double, const VectorType &y, VectorType &ydot) -> int {
+  ode.explicit_function = [&](double, const VectorType &y, VectorType &ydot) {
     ydot[0] = a - (y[2] + 1) * y[0] + y[1] * y[0] * y[0];
     ydot[1] = y[2] * y[0] - y[1] * y[0] * y[0];
     ydot[2] = b / eps - y[2] * y[0];
-    return 0;
   };
 
-  ode.output_step = [&](const double       t,
-                        const VectorType & sol,
-                        const unsigned int step_number) -> int {
-    // limit the output to every 10th step and increase the precision to make
-    // the test more robust
-    if (step_number % 10 == 0)
-      deallog << t << ' ' << std::setprecision(10) << sol[0] << ' ' << sol[1]
-              << ' ' << sol[2] << std::endl;
-    return 0;
-  };
+  ode.output_step =
+    [&](const double t, const VectorType &sol, const unsigned int step_number) {
+      // limit the output to every 10th step and increase the precision to make
+      // the test more robust
+      if (step_number % 10 == 0)
+        deallog << t << ' ' << std::setprecision(10) << sol[0] << ' ' << sol[1]
+                << ' ' << sol[2] << std::endl;
+    };
 
   // This test, for reasons I don't fully understand, generates some output
   // which varies between environments much more than the other ARKODE
   // tests. Work around it by setting a fairly stringent maximum time step.
-  ode.custom_setup = [&](void *arkode_mem) -> int {
+  ode.custom_setup = [&](void *arkode_mem) {
     int ierr = ARKStepSetMinStep(arkode_mem, 1e-8);
     AssertThrow(ierr == 0, ExcInternalError());
     ierr = ARKStepSetMaxStep(arkode_mem, 1e-4);
     AssertThrow(ierr == 0, ExcInternalError());
     ierr = ARKStepSetMaxNumSteps(arkode_mem, 5000);
     AssertThrow(ierr == 0, ExcInternalError());
-    return 0;
   };
 
   VectorType y(3);
@@ -120,5 +113,4 @@ main()
   y[1] = v0;
   y[2] = w0;
   ode.solve_ode(y);
-  return 0;
 }

--- a/tests/sundials/arkode_04.cc
+++ b/tests/sundials/arkode_04.cc
@@ -75,45 +75,36 @@ main()
   FullMatrix<double> J(3, 3);
   J(2, 2) = -1.0 / eps;
 
-  ode.implicit_function =
-    [&](double, const VectorType &y, VectorType &ydot) -> int {
+  ode.implicit_function = [&](double, const VectorType &y, VectorType &ydot) {
     ydot[0] = 0;
     ydot[1] = 0;
     ydot[2] = -y[2] / eps;
-    return 0;
   };
 
 
-  ode.explicit_function =
-    [&](double, const VectorType &y, VectorType &ydot) -> int {
+  ode.explicit_function = [&](double, const VectorType &y, VectorType &ydot) {
     ydot[0] = a - (y[2] + 1) * y[0] + y[1] * y[0] * y[0];
     ydot[1] = y[2] * y[0] - y[1] * y[0] * y[0];
     ydot[2] = b / eps - y[2] * y[0];
-    return 0;
   };
 
   ode.jacobian_times_vector = [&](const VectorType &src,
                                   VectorType &      dst,
                                   double            t,
                                   const VectorType & /*y*/,
-                                  const VectorType & /*fy*/) -> int {
+                                  const VectorType & /*fy*/) {
     J.vmult(dst, src);
-
-    return 0;
   };
 
-  ode.output_step = [&](const double       t,
-                        const VectorType & sol,
-                        const unsigned int step_number) -> int {
-    deallog << std::setprecision(16) << t << ' ' << sol[0] << ' ' << sol[1]
-            << ' ' << sol[2] << std::endl;
-    return 0;
-  };
+  ode.output_step =
+    [&](const double t, const VectorType &sol, const unsigned int step_number) {
+      deallog << std::setprecision(16) << t << ' ' << sol[0] << ' ' << sol[1]
+              << ' ' << sol[2] << std::endl;
+    };
 
   Vector<double> y(3);
   y[0] = u0;
   y[1] = v0;
   y[2] = w0;
   ode.solve_ode(y);
-  return 0;
 }

--- a/tests/sundials/arkode_05.cc
+++ b/tests/sundials/arkode_05.cc
@@ -74,21 +74,17 @@ main()
   // Explicit jacobian.
   FullMatrix<double> J(3, 3);
 
-  ode.implicit_function =
-    [&](double, const VectorType &y, VectorType &ydot) -> int {
+  ode.implicit_function = [&](double, const VectorType &y, VectorType &ydot) {
     ydot[0] = 0;
     ydot[1] = 0;
     ydot[2] = -y[2] / eps;
-    return 0;
   };
 
 
-  ode.explicit_function =
-    [&](double, const VectorType &y, VectorType &ydot) -> int {
+  ode.explicit_function = [&](double, const VectorType &y, VectorType &ydot) {
     ydot[0] = a - (y[2] + 1) * y[0] + y[1] * y[0] * y[0];
     ydot[1] = y[2] * y[0] - y[1] * y[0] * y[0];
     ydot[2] = b / eps - y[2] * y[0];
-    return 0;
   };
 
 
@@ -97,14 +93,13 @@ main()
                            const double gamma,
                            const VectorType &,
                            const VectorType &,
-                           bool &j_is_current) -> int {
+                           bool &j_is_current) {
     J       = 0;
     J(0, 0) = 1;
     J(1, 1) = 1;
     J(2, 2) = 1 + gamma / eps;
     J.gauss_jordan();
     j_is_current = true;
-    return 0;
   };
 
   ode.solve_jacobian_system = [&](const double t,
@@ -112,23 +107,17 @@ main()
                                   const VectorType &,
                                   const VectorType &,
                                   const VectorType &src,
-                                  VectorType &      dst) -> int {
-    J.vmult(dst, src);
-    return 0;
-  };
+                                  VectorType &      dst) { J.vmult(dst, src); };
 
-  ode.output_step = [&](const double       t,
-                        const VectorType & sol,
-                        const unsigned int step_number) -> int {
-    deallog << t << ' ' << sol[0] << ' ' << sol[1] << ' ' << sol[2]
-            << std::endl;
-    return 0;
-  };
+  ode.output_step =
+    [&](const double t, const VectorType &sol, const unsigned int step_number) {
+      deallog << t << ' ' << sol[0] << ' ' << sol[1] << ' ' << sol[2]
+              << std::endl;
+    };
 
   Vector<double> y(3);
   y[0] = u0;
   y[1] = v0;
   y[2] = w0;
   ode.solve_ode(y);
-  return 0;
 }

--- a/tests/sundials/arkode_06.cc
+++ b/tests/sundials/arkode_06.cc
@@ -81,59 +81,48 @@ main()
   // Explicit jacobian.
   FullMatrix<double> J(3, 3);
 
-  ode.implicit_function =
-    [&](double, const VectorType &y, VectorType &ydot) -> int {
+  ode.implicit_function = [&](double, const VectorType &y, VectorType &ydot) {
     ydot[0] = 0;
     ydot[1] = 0;
     ydot[2] = -y[2] / eps;
-    return 0;
   };
 
 
-  ode.explicit_function =
-    [&](double, const VectorType &y, VectorType &ydot) -> int {
+  ode.explicit_function = [&](double, const VectorType &y, VectorType &ydot) {
     ydot[0] = a - (y[2] + 1) * y[0] + y[1] * y[0] * y[0];
     ydot[1] = y[2] * y[0] - y[1] * y[0] * y[0];
     ydot[2] = b / eps - y[2] * y[0];
-    return 0;
   };
 
 
   ode.jacobian_times_setup =
-    [&](realtype t, const VectorType &y, const VectorType &fy) -> int {
-    J       = 0;
-    J(2, 2) = -1.0 / eps;
-    return 0;
-  };
+    [&](realtype t, const VectorType &y, const VectorType &fy) {
+      J       = 0;
+      J(2, 2) = -1.0 / eps;
+    };
 
   ode.jacobian_times_vector = [&](const VectorType &v,
                                   VectorType &      Jv,
                                   double            t,
                                   const VectorType &y,
-                                  const VectorType &fy) -> int {
-    J.vmult(Jv, v);
-    return 0;
-  };
+                                  const VectorType &fy) { J.vmult(Jv, v); };
 
   ode.solve_linearized_system =
     [&](SUNDIALS::SundialsOperator<VectorType> &op,
         SUNDIALS::SundialsPreconditioner<VectorType> &,
         VectorType &      x,
         const VectorType &b,
-        double            tol) -> int {
-    ReductionControl     control;
-    SolverCG<VectorType> solver_cg(control);
-    solver_cg.solve(op, x, b, PreconditionIdentity());
-    return 0;
-  };
+        double            tol) {
+      ReductionControl     control;
+      SolverCG<VectorType> solver_cg(control);
+      solver_cg.solve(op, x, b, PreconditionIdentity());
+    };
 
-  ode.output_step = [&](const double       t,
-                        const VectorType & sol,
-                        const unsigned int step_number) -> int {
-    deallog << t << ' ' << sol[0] << ' ' << sol[1] << ' ' << sol[2]
-            << std::endl;
-    return 0;
-  };
+  ode.output_step =
+    [&](const double t, const VectorType &sol, const unsigned int step_number) {
+      deallog << t << ' ' << sol[0] << ' ' << sol[1] << ' ' << sol[2]
+              << std::endl;
+    };
 
   // after 5.2.0 a special interpolation mode should be used for stiff problems
 #if DEAL_II_SUNDIALS_VERSION_GTE(5, 2, 0)
@@ -147,5 +136,4 @@ main()
   y[1] = v0;
   y[2] = w0;
   ode.solve_ode(y);
-  return 0;
 }

--- a/tests/sundials/arkode_07.cc
+++ b/tests/sundials/arkode_07.cc
@@ -81,60 +81,50 @@ main()
   // Explicit jacobian.
   FullMatrix<double> J(3, 3);
 
-  ode.implicit_function =
-    [&](double, const VectorType &y, VectorType &ydot) -> int {
+  ode.implicit_function = [&](double, const VectorType &y, VectorType &ydot) {
     ydot[0] = 0;
     ydot[1] = 0;
     ydot[2] = -y[2] / eps;
-    return 0;
   };
 
 
-  ode.explicit_function =
-    [&](double, const VectorType &y, VectorType &ydot) -> int {
+  ode.explicit_function = [&](double, const VectorType &y, VectorType &ydot) {
     ydot[0] = a - (y[2] + 1) * y[0] + y[1] * y[0] * y[0];
     ydot[1] = y[2] * y[0] - y[1] * y[0] * y[0];
     ydot[2] = b / eps - y[2] * y[0];
-    return 0;
   };
 
 
   ode.jacobian_times_setup =
-    [&](realtype t, const VectorType &y, const VectorType &fy) -> int {
-    J       = 0;
-    J(2, 2) = -1.0 / eps;
-    return 0;
-  };
+    [&](realtype t, const VectorType &y, const VectorType &fy) {
+      J       = 0;
+      J(2, 2) = -1.0 / eps;
+    };
 
   ode.jacobian_times_vector = [&](const VectorType &v,
                                   VectorType &      Jv,
                                   double            t,
                                   const VectorType &y,
-                                  const VectorType &fy) -> int {
-    J.vmult(Jv, v);
-    return 0;
-  };
+                                  const VectorType &fy) { J.vmult(Jv, v); };
 
   ode.solve_linearized_system =
     [&](SUNDIALS::SundialsOperator<VectorType> &      op,
         SUNDIALS::SundialsPreconditioner<VectorType> &prec,
         VectorType &                                  x,
         const VectorType &                            b,
-        double                                        tol) -> int {
-    ReductionControl     control;
-    SolverCG<VectorType> solver_cg(control);
-    solver_cg.solve(op, x, b, prec);
-    return 0;
-  };
+        double                                        tol) {
+      ReductionControl     control;
+      SolverCG<VectorType> solver_cg(control);
+      solver_cg.solve(op, x, b, prec);
+    };
 
   ode.jacobian_preconditioner_setup = [&](double            t,
                                           const VectorType &y,
                                           const VectorType &fy,
                                           int               jok,
                                           int &             jcur,
-                                          double            gamma) -> int {
+                                          double            gamma) {
     deallog << "jacobian_preconditioner_setup called\n";
-    return 0;
   };
 
   ode.jacobian_preconditioner_solve = [&](double            t,
@@ -144,20 +134,17 @@ main()
                                           VectorType &      z,
                                           double            gamma,
                                           double            delta,
-                                          int               lr) -> int {
+                                          int               lr) {
     deallog << "jacobian_preconditioner_solve called\n";
     z = r;
-    return 0;
   };
 
 
-  ode.output_step = [&](const double       t,
-                        const VectorType & sol,
-                        const unsigned int step_number) -> int {
-    deallog << t << ' ' << sol[0] << ' ' << sol[1] << ' ' << sol[2]
-            << std::endl;
-    return 0;
-  };
+  ode.output_step =
+    [&](const double t, const VectorType &sol, const unsigned int step_number) {
+      deallog << t << ' ' << sol[0] << ' ' << sol[1] << ' ' << sol[2]
+              << std::endl;
+    };
 
   // after 5.2.0 a special interpolation mode should be used for stiff problems
 #if DEAL_II_SUNDIALS_VERSION_GTE(5, 2, 0)
@@ -171,5 +158,4 @@ main()
   y[1] = v0;
   y[2] = w0;
   ode.solve_ode(y);
-  return 0;
 }

--- a/tests/sundials/arkode_08.cc
+++ b/tests/sundials/arkode_08.cc
@@ -79,40 +79,32 @@ main()
   M(0, 0) = M(1, 1) = 2.0 / 3;
   M(1, 0) = M(0, 1) = 1.0 / 3;
 
-  ode.implicit_function =
-    [&](double, const VectorType &y, VectorType &ydot) -> int {
+  ode.implicit_function = [&](double, const VectorType &y, VectorType &ydot) {
     K.vmult(ydot, y);
-    return 0;
   };
 
 
-  ode.explicit_function =
-    [&](double, const VectorType &y, VectorType &ydot) -> int {
+  ode.explicit_function = [&](double, const VectorType &y, VectorType &ydot) {
     ydot[0] = 1;
     ydot[1] = 2;
-    return 0;
   };
 
   ode.jacobian_times_vector = [&](const VectorType &v,
                                   VectorType &      Jv,
                                   double            t,
                                   const VectorType &y,
-                                  const VectorType &fy) -> int {
-    K.vmult(Jv, v);
-    return 0;
-  };
+                                  const VectorType &fy) { K.vmult(Jv, v); };
 
   const auto solve_function =
     [&](SUNDIALS::SundialsOperator<VectorType> &      op,
         SUNDIALS::SundialsPreconditioner<VectorType> &prec,
         VectorType &                                  x,
         const VectorType &                            b,
-        double                                        tol) -> int {
-    ReductionControl     control;
-    SolverCG<VectorType> solver_cg(control);
-    solver_cg.solve(op, x, b, prec);
-    return 0;
-  };
+        double                                        tol) {
+      ReductionControl     control;
+      SolverCG<VectorType> solver_cg(control);
+      solver_cg.solve(op, x, b, prec);
+    };
 
   ode.solve_linearized_system = solve_function;
 
@@ -120,41 +112,31 @@ main()
 
   FullMatrix<double> M_inv(2, 2);
 
-  ode.mass_preconditioner_solve = [&](double            t,
-                                      const VectorType &r,
-                                      VectorType &      z,
-                                      double            gamma,
-                                      int               lr) -> int {
-    LogStream::Prefix prefix("mass_preconditioner_solve");
-    deallog << "applied" << std::endl;
-    M_inv.vmult(z, r);
-    return 0;
-  };
+  ode.mass_preconditioner_solve =
+    [&](double t, const VectorType &r, VectorType &z, double gamma, int lr) {
+      LogStream::Prefix prefix("mass_preconditioner_solve");
+      deallog << "applied" << std::endl;
+      M_inv.vmult(z, r);
+    };
 
-  ode.mass_preconditioner_setup = [&](double t) -> int {
+  ode.mass_preconditioner_setup = [&](double t) {
     LogStream::Prefix prefix("mass_preconditioner_setup");
     deallog << "applied" << std::endl;
     M_inv.invert(M);
-    return 0;
   };
 
-  ode.mass_times_vector =
-    [&](const double t, const VectorType &v, VectorType &Mv) -> int {
-    M.vmult(Mv, v);
-    return 0;
-  };
+  ode.mass_times_vector = [&](const double      t,
+                              const VectorType &v,
+                              VectorType &      Mv) { M.vmult(Mv, v); };
 
 
-  ode.output_step = [&](const double       t,
-                        const VectorType & sol,
-                        const unsigned int step_number) -> int {
-    deallog << t << ' ' << sol[0] << ' ' << sol[1] << std::endl;
-    return 0;
-  };
+  ode.output_step =
+    [&](const double t, const VectorType &sol, const unsigned int step_number) {
+      deallog << t << ' ' << sol[0] << ' ' << sol[1] << std::endl;
+    };
 
   Vector<double> y(2);
   y[0] = 1;
   y[1] = 0;
   ode.solve_ode(y);
-  return 0;
 }

--- a/tests/sundials/arkode_09.cc
+++ b/tests/sundials/arkode_09.cc
@@ -1,0 +1,92 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2017 - 2022 by the deal.II authors
+//
+//    This file is part of the deal.II library.
+//
+//    The deal.II library is free software; you can use it, redistribute
+//    it, and/or modify it under the terms of the GNU Lesser General
+//    Public License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//    The full text of the license can be found in the file LICENSE.md at
+//    the top level directory of deal.II.
+//
+//-----------------------------------------------------------
+
+#include <deal.II/base/parameter_handler.h>
+
+#include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/sundials/arkode.h>
+
+#include "../tests.h"
+
+// Test explicit time stepper where we throw a recoverable error from
+// the function that computes the right hand side. The test case
+// solves the problem y'(t)=-y(t) with exact solution
+// y(t)=exp(-t). The right hand side function throws an exception if
+// evaluated with y<0, and we make sure that that happens by starting
+// with an overly large initial time step.
+int
+main()
+{
+  initlog();
+
+  using VectorType = Vector<double>;
+
+  ParameterHandler                             prm;
+  SUNDIALS::ARKode<VectorType>::AdditionalData data;
+  data.add_parameters(prm);
+
+  // Set to true to reset input file.
+  if (false)
+    {
+      std::ofstream ofile(SOURCE_DIR "/arkode_09_in.prm");
+      prm.print_parameters(ofile, ParameterHandler::ShortText);
+      ofile.close();
+    }
+
+  std::ifstream ifile(SOURCE_DIR "/arkode_09_in.prm");
+  prm.parse_input(ifile);
+
+  SUNDIALS::ARKode<VectorType> ode(data);
+
+  double kappa = 1.0;
+
+  ode.explicit_function =
+    [&](const double t, const VectorType &y, VectorType &ydot) {
+      deallog << "Evaluating right hand side at t=" << t << " with y=" << y[0]
+              << std::endl;
+
+      // Error out in a recoverable way if asked to evaluate at a
+      // point where y<0. This can happen with explicit methods if the
+      // time step is too large.
+      if (y[0] < 0)
+        {
+          deallog << "Reporting a recoverable error." << std::endl;
+          throw RecoverableUserCallbackError();
+        }
+
+      ydot[0] = -y[0];
+    };
+
+  ode.output_step =
+    [&](const double t, const VectorType &sol, const unsigned int step_number) {
+      deallog << "Monitor called at t=" << t << ' ' << sol[0] << std::endl;
+    };
+
+  Vector<double> y(1);
+  y[0] = 1;
+
+  try
+    {
+      ode.solve_ode(y);
+    }
+  catch (const std::exception &exc)
+    {
+      deallog << "ARKODE did not succeed with the following error message:"
+              << std::endl
+              << exc.what() << std::endl;
+    }
+}

--- a/tests/sundials/arkode_09.output
+++ b/tests/sundials/arkode_09.output
@@ -1,0 +1,24 @@
+
+DEAL::Monitor called at t=0.00000 1.00000
+DEAL::Evaluating right hand side at t=0.00000 with y=1.00000
+DEAL::Evaluating right hand side at t=0.00000 with y=1.00000
+DEAL::Evaluating right hand side at t=0.600000 with y=0.400000
+DEAL::Evaluating right hand side at t=0.900000 with y=0.505000
+DEAL::Evaluating right hand side at t=1.80000 with y=-0.638000
+DEAL::Reporting a recoverable error.
+DEAL::ARKODE did not succeed with the following error message:
+DEAL::
+--------------------------------------------------------
+An error occurred in line <0> of file <> in function
+    
+The violated condition was: 
+    
+Additional information: 
+    A user call-back function encountered a recoverable error, but the
+    underlying library that called the call-back did not manage to recover
+    from the error and aborted its operation.
+    
+    See the glossary entry on user call-back functions for more
+    information.
+--------------------------------------------------------
+

--- a/tests/sundials/arkode_09_in.prm
+++ b/tests/sundials/arkode_09_in.prm
@@ -1,0 +1,13 @@
+set Final time                        = 6
+set Initial time                      = 0
+set Time interval between each output = 2
+subsection Error control
+  set Absolute error tolerance = 0.001
+  set Relative error tolerance = 0.010
+end
+subsection Running parameters
+  set Initial step size                      = 3
+  set Maximum number of nonlinear iterations = 10
+  set Maximum order of ARK                   = 5
+  set Minimum step size                      = 0.01
+end

--- a/tests/sundials/arkode_10.cc
+++ b/tests/sundials/arkode_10.cc
@@ -1,0 +1,151 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2020 - 2022 by the deal.II authors
+//
+//    This file is part of the deal.II library.
+//
+//    The deal.II library is free software; you can use it, redistribute
+//    it, and/or modify it under the terms of the GNU Lesser General
+//    Public License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//    The full text of the license can be found in the file LICENSE.md at
+//    the top level directory of deal.II.
+//
+//-----------------------------------------------------------
+
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/parameter_handler.h>
+
+#include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/solver_control.h>
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/sundials/arkode.h>
+
+#include "../tests.h"
+
+
+// Like _08, but throw a recoverable exception when solving with the linearized
+// system.
+
+
+int
+main()
+{
+  initlog();
+
+  using VectorType = Vector<double>;
+
+  ParameterHandler                             prm;
+  SUNDIALS::ARKode<VectorType>::AdditionalData data;
+  data.add_parameters(prm);
+
+  if (false)
+    {
+      std::ofstream ofile(SOURCE_DIR "/arkode_10_in.prm");
+      prm.print_parameters(ofile, ParameterHandler::ShortText);
+      ofile.close();
+    }
+
+  std::ifstream ifile(SOURCE_DIR "/arkode_08_in.prm");
+  prm.parse_input(ifile);
+
+  SUNDIALS::ARKode<VectorType> ode(data);
+
+  // Explicit jacobian = stiffness matrix
+  FullMatrix<double> K(2, 2);
+  K(0, 0) = K(1, 1) = 0.5;
+  K(1, 0) = K(0, 1) = -0.5;
+
+  // mass matrix
+  FullMatrix<double> M(2, 2);
+  M(0, 0) = M(1, 1) = 2.0 / 3;
+  M(1, 0) = M(0, 1) = 1.0 / 3;
+
+  ode.implicit_function = [&](double, const VectorType &y, VectorType &ydot) {
+    K.vmult(ydot, y);
+  };
+
+
+  ode.explicit_function = [&](double, const VectorType &y, VectorType &ydot) {
+    ydot[0] = 1;
+    ydot[1] = 2;
+  };
+
+  ode.jacobian_times_vector = [&](const VectorType &v,
+                                  VectorType &      Jv,
+                                  double            t,
+                                  const VectorType &y,
+                                  const VectorType &fy) { K.vmult(Jv, v); };
+
+  [&](SUNDIALS::SundialsOperator<VectorType> &,
+      SUNDIALS::SundialsPreconditioner<VectorType> &,
+      VectorType &,
+      const VectorType &,
+      double) {
+    deallog << "Reporting recoverable failure." << std::endl;
+    throw RecoverableUserCallbackError();
+  };
+
+  ode.solve_linearized_system =
+    [&](SUNDIALS::SundialsOperator<VectorType> &,
+        SUNDIALS::SundialsPreconditioner<VectorType> &,
+        VectorType &,
+        const VectorType &,
+        double) {
+      deallog << "Reporting recoverable failure when solving linearized system."
+              << std::endl;
+      throw RecoverableUserCallbackError();
+    };
+
+
+  ode.solve_mass = [&](SUNDIALS::SundialsOperator<VectorType> &      op,
+                       SUNDIALS::SundialsPreconditioner<VectorType> &prec,
+                       VectorType &                                  x,
+                       const VectorType &                            b,
+                       double                                        tol) {
+    ReductionControl     control;
+    SolverCG<VectorType> solver_cg(control);
+    solver_cg.solve(op, x, b, prec);
+  };
+
+  FullMatrix<double> M_inv(2, 2);
+
+  ode.mass_preconditioner_solve =
+    [&](double t, const VectorType &r, VectorType &z, double gamma, int lr) {
+      LogStream::Prefix prefix("mass_preconditioner_solve");
+      deallog << "applied" << std::endl;
+      M_inv.vmult(z, r);
+    };
+
+  ode.mass_preconditioner_setup = [&](double t) {
+    LogStream::Prefix prefix("mass_preconditioner_setup");
+    deallog << "applied" << std::endl;
+    M_inv.invert(M);
+  };
+
+  ode.mass_times_vector = [&](const double      t,
+                              const VectorType &v,
+                              VectorType &      Mv) { M.vmult(Mv, v); };
+
+
+  ode.output_step =
+    [&](const double t, const VectorType &sol, const unsigned int step_number) {
+      deallog << t << ' ' << sol[0] << ' ' << sol[1] << std::endl;
+    };
+
+  Vector<double> y(2);
+  y[0] = 1;
+  y[1] = 0;
+
+  try
+    {
+      ode.solve_ode(y);
+    }
+  catch (const std::exception &exc)
+    {
+      deallog << "Caught exception:" << std::endl << exc.what() << std::endl;
+    }
+}

--- a/tests/sundials/arkode_10.output
+++ b/tests/sundials/arkode_10.output
@@ -1,0 +1,258 @@
+
+DEAL::0.00000 1.00000 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 2.12132
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 0.707107
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:cg::Starting value 2.23607
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving linearized system.
+DEAL:cg::Starting value 0.707107
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:cg::Starting value 2.23607
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving linearized system.
+DEAL:cg::Starting value 0.707107
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:cg::Starting value 2.23607
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving linearized system.
+DEAL:cg::Starting value 0.707107
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:cg::Starting value 2.23607
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving linearized system.
+DEAL:cg::Starting value 0.707107
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:cg::Starting value 2.23607
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving linearized system.
+DEAL:cg::Starting value 0.707107
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:cg::Starting value 2.23607
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving linearized system.
+DEAL:cg::Starting value 0.707107
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:cg::Starting value 2.23607
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving linearized system.
+DEAL:cg::Starting value 0.707107
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:cg::Starting value 2.23607
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 2.12132
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 0.707107
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:cg::Starting value 2.23607
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving linearized system.
+DEAL:cg::Starting value 0.707107
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:cg::Starting value 2.23607
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving linearized system.
+DEAL:cg::Starting value 0.707107
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:cg::Starting value 2.23607
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving linearized system.
+DEAL:cg::Starting value 0.707107
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:cg::Starting value 2.23607
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving linearized system.
+DEAL:cg::Starting value 0.707107
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:cg::Starting value 2.23607
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving linearized system.
+DEAL:cg::Starting value 0.707107
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:cg::Starting value 2.23607
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving linearized system.
+DEAL:cg::Starting value 0.707107
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:cg::Starting value 2.23607
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving linearized system.
+DEAL:cg::Starting value 0.707107
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:cg::Starting value 2.23607
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 2.12132
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 2.12132
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL::0.100000 1.15000 0.150000
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 2.12132
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL::0.200000 1.30000 0.300000
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 0.707107
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 7.85046e-17
+DEAL:cg::Starting value 2.23607
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving linearized system.
+DEAL:cg::Starting value 0.707107
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 7.85046e-17
+DEAL:cg::Starting value 2.23607
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving linearized system.
+DEAL:cg::Starting value 0.707107
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 7.85046e-17
+DEAL:cg::Starting value 2.23607
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving linearized system.
+DEAL:cg::Starting value 0.707107
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 7.85046e-17
+DEAL:cg::Starting value 2.23607
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving linearized system.
+DEAL:cg::Starting value 0.707107
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 7.85046e-17
+DEAL:cg::Starting value 2.23607
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving linearized system.
+DEAL:cg::Starting value 0.707107
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 7.85046e-17
+DEAL:cg::Starting value 2.23607
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving linearized system.
+DEAL:cg::Starting value 0.707107
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 7.85046e-17
+DEAL:cg::Starting value 2.23607
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving linearized system.
+DEAL:cg::Starting value 0.707107
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 7.85046e-17
+DEAL:cg::Starting value 2.23607
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 2.12132
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 2.12132
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL::0.300000 1.45000 0.450000
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 2.12132
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL::0.400000 1.60000 0.600000
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 2.12132
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL::0.500000 1.75000 0.750000
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 2.12132
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL::0.600000 1.90000 0.900000
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 2.12132
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL::0.700000 2.05000 1.05000
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 2.12132
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL::0.800000 2.20000 1.20000
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 2.12132
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL::0.900000 2.35000 1.35000
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 2.12132
+DEAL:cg:mass_preconditioner_solve::applied
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL::1.00000 2.50000 1.50000

--- a/tests/sundials/arkode_10_in.prm
+++ b/tests/sundials/arkode_10_in.prm
@@ -1,0 +1,15 @@
+set Final time                        = 1.
+set Initial time                      = 0.
+set Time interval between each output = 0.1
+subsection Error control
+  set Absolute error tolerance = 0.000001
+  set Relative error tolerance = 0.000010
+end
+subsection Running parameters
+  set Implicit function is linear            = true
+  set Implicit function is time independent  = true
+  set Initial step size                      = 0.010000
+  set Maximum number of nonlinear iterations = 10
+  set Maximum order of ARK                   = 5
+  set Minimum step size                      = 0.000001
+end

--- a/tests/sundials/arkode_11.cc
+++ b/tests/sundials/arkode_11.cc
@@ -1,0 +1,152 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2020 - 2022 by the deal.II authors
+//
+//    This file is part of the deal.II library.
+//
+//    The deal.II library is free software; you can use it, redistribute
+//    it, and/or modify it under the terms of the GNU Lesser General
+//    Public License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//    The full text of the license can be found in the file LICENSE.md at
+//    the top level directory of deal.II.
+//
+//-----------------------------------------------------------
+
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/parameter_handler.h>
+
+#include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/solver_control.h>
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/sundials/arkode.h>
+
+#include "../tests.h"
+
+
+// Like _08, but throw a recoverable exception when solving with the mass
+// matrix.
+
+
+int
+main()
+{
+  initlog();
+
+  using VectorType = Vector<double>;
+
+  ParameterHandler                             prm;
+  SUNDIALS::ARKode<VectorType>::AdditionalData data;
+  data.add_parameters(prm);
+
+  if (false)
+    {
+      std::ofstream ofile(SOURCE_DIR "/arkode_11_in.prm");
+      prm.print_parameters(ofile, ParameterHandler::ShortText);
+      ofile.close();
+    }
+
+  std::ifstream ifile(SOURCE_DIR "/arkode_08_in.prm");
+  prm.parse_input(ifile);
+
+  SUNDIALS::ARKode<VectorType> ode(data);
+
+  // Explicit jacobian = stiffness matrix
+  FullMatrix<double> K(2, 2);
+  K(0, 0) = K(1, 1) = 0.5;
+  K(1, 0) = K(0, 1) = -0.5;
+
+  // mass matrix
+  FullMatrix<double> M(2, 2);
+  M(0, 0) = M(1, 1) = 2.0 / 3;
+  M(1, 0) = M(0, 1) = 1.0 / 3;
+
+  ode.implicit_function = [&](double, const VectorType &y, VectorType &ydot) {
+    K.vmult(ydot, y);
+  };
+
+
+  ode.explicit_function = [&](double, const VectorType &y, VectorType &ydot) {
+    ydot[0] = 1;
+    ydot[1] = 2;
+  };
+
+  ode.jacobian_times_vector = [&](const VectorType &v,
+                                  VectorType &      Jv,
+                                  double            t,
+                                  const VectorType &y,
+                                  const VectorType &fy) { K.vmult(Jv, v); };
+
+  [&](SUNDIALS::SundialsOperator<VectorType> &,
+      SUNDIALS::SundialsPreconditioner<VectorType> &,
+      VectorType &,
+      const VectorType &,
+      double) {
+    deallog << "Reporting recoverable failure." << std::endl;
+    throw RecoverableUserCallbackError();
+  };
+
+  ode.solve_mass = [&](SUNDIALS::SundialsOperator<VectorType> &,
+                       SUNDIALS::SundialsPreconditioner<VectorType> &,
+                       VectorType &,
+                       const VectorType &,
+                       double) {
+    deallog
+      << "Reporting recoverable failure when solving with the mass matrix."
+      << std::endl;
+    throw RecoverableUserCallbackError();
+  };
+
+
+  ode.solve_linearized_system =
+    [&](SUNDIALS::SundialsOperator<VectorType> &      op,
+        SUNDIALS::SundialsPreconditioner<VectorType> &prec,
+        VectorType &                                  x,
+        const VectorType &                            b,
+        double                                        tol) {
+      ReductionControl     control;
+      SolverCG<VectorType> solver_cg(control);
+      solver_cg.solve(op, x, b, prec);
+    };
+
+  FullMatrix<double> M_inv(2, 2);
+
+  ode.mass_preconditioner_solve =
+    [&](double t, const VectorType &r, VectorType &z, double gamma, int lr) {
+      LogStream::Prefix prefix("mass_preconditioner_solve");
+      deallog << "applied" << std::endl;
+      M_inv.vmult(z, r);
+    };
+
+  ode.mass_preconditioner_setup = [&](double t) {
+    LogStream::Prefix prefix("mass_preconditioner_setup");
+    deallog << "applied" << std::endl;
+    M_inv.invert(M);
+  };
+
+  ode.mass_times_vector = [&](const double      t,
+                              const VectorType &v,
+                              VectorType &      Mv) { M.vmult(Mv, v); };
+
+
+  ode.output_step =
+    [&](const double t, const VectorType &sol, const unsigned int step_number) {
+      deallog << t << ' ' << sol[0] << ' ' << sol[1] << std::endl;
+    };
+
+  Vector<double> y(2);
+  y[0] = 1;
+  y[1] = 0;
+
+  try
+    {
+      ode.solve_ode(y);
+    }
+  catch (const std::exception &exc)
+    {
+      deallog << "Caught exception:" << std::endl << exc.what() << std::endl;
+    }
+}

--- a/tests/sundials/arkode_11.output
+++ b/tests/sundials/arkode_11.output
@@ -1,0 +1,170 @@
+
+DEAL::0.00000 1.00000 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 0.00144957
+DEAL:cg::Convergence step 1 value 3.06659e-19
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 0.00144957
+DEAL:cg::Convergence step 1 value 3.06659e-19
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 0.00144957
+DEAL:cg::Convergence step 1 value 3.06659e-19
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 0.00144957
+DEAL:cg::Convergence step 1 value 3.06659e-19
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 0.00144957
+DEAL:cg::Convergence step 1 value 3.06659e-19
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 0.00144957
+DEAL:cg::Convergence step 1 value 3.06659e-19
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 0.00144957
+DEAL:cg::Convergence step 1 value 3.06659e-19
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 0.0392202
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 0.0392202
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 0.0392202
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 0.0392202
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 0.0392202
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 0.0392202
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 0.0392202
+DEAL:cg::Convergence step 1 value 0.00000
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::0.100000 1.00000 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::0.200000 1.00000 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 0.104287
+DEAL:cg::Convergence step 1 value 1.96262e-17
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 0.104287
+DEAL:cg::Convergence step 1 value 1.96262e-17
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 0.104287
+DEAL:cg::Convergence step 1 value 1.96262e-17
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 0.104287
+DEAL:cg::Convergence step 1 value 1.96262e-17
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 0.104287
+DEAL:cg::Convergence step 1 value 1.96262e-17
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 0.104287
+DEAL:cg::Convergence step 1 value 1.96262e-17
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL:cg::Starting value 0.104287
+DEAL:cg::Convergence step 1 value 1.96262e-17
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::0.300000 1.00000 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::0.400000 1.00000 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::0.500000 1.00000 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::0.600000 1.00000 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::0.700000 1.00000 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::0.800000 1.00000 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::0.900000 1.00000 0.00000
+DEAL:mass_preconditioner_setup::applied
+DEAL::Reporting recoverable failure when solving with the mass matrix.
+DEAL::Caught exception:
+DEAL::
+--------------------------------------------------------
+An error occurred in line <0> of file <> in function
+    
+The violated condition was: 
+    
+Additional information: 
+    A user call-back function encountered a recoverable error, but the
+    underlying library that called the call-back did not manage to recover
+    from the error and aborted its operation.
+    
+    See the glossary entry on user call-back functions for more
+    information.
+--------------------------------------------------------
+

--- a/tests/sundials/arkode_11_in.prm
+++ b/tests/sundials/arkode_11_in.prm
@@ -1,0 +1,15 @@
+set Final time                        = 1.
+set Initial time                      = 0.
+set Time interval between each output = 0.1
+subsection Error control
+  set Absolute error tolerance = 0.000001
+  set Relative error tolerance = 0.000010
+end
+subsection Running parameters
+  set Implicit function is linear            = true
+  set Implicit function is time independent  = true
+  set Initial step size                      = 0.010000
+  set Maximum number of nonlinear iterations = 10
+  set Maximum order of ARK                   = 5
+  set Minimum step size                      = 0.000001
+end

--- a/tests/sundials/arkode_repeated_solve.cc
+++ b/tests/sundials/arkode_repeated_solve.cc
@@ -41,20 +41,16 @@ create_solver()
   auto ode = std::make_unique<SUNDIALS::ARKode<VectorType>>(data);
 
   // will yield analytic solution y[0] = sin(kappa*t); y[1] = kappa*cos(kappa*t)
-  ode->explicit_function =
-    [&](double, const VectorType &y, VectorType &ydot) -> int {
+  ode->explicit_function = [&](double, const VectorType &y, VectorType &ydot) {
     ydot[0] = y[1];
     ydot[1] = -kappa * kappa * y[0];
-    return 0;
   };
 
-  ode->output_step = [&](const double       t,
-                         const VectorType & sol,
-                         const unsigned int step_number) -> int {
-    deallog << std::setprecision(16) << t << ' ' << sol[0] << ' ' << sol[1]
-            << std::endl;
-    return 0;
-  };
+  ode->output_step =
+    [&](const double t, const VectorType &sol, const unsigned int step_number) {
+      deallog << std::setprecision(16) << t << ' ' << sol[0] << ' ' << sol[1]
+              << std::endl;
+    };
   return ode;
 }
 
@@ -122,6 +118,4 @@ main()
     ode->reset(0.0, 0.01, y0);
     ode->solve_ode_incrementally(y, 2.0);
   }
-
-  return 0;
 }


### PR DESCRIPTION
Like in #15178 and #15186. Implements the resolution in #15112, #15146. 

I have not actually managed to write a test case where ARKode recovers after a recoverable error, but it correctly reports that it has received a recoverable error code. The new test checks this.