### PR TITLE
Tpetra is not functional without sync() function

### DIFF
--- a/cmake/configure/configure_20_trilinos.cmake
+++ b/cmake/configure/configure_20_trilinos.cmake
@@ -257,7 +257,10 @@ macro(feature_trilinos_find_external var)
           using map_type = Tpetra::Map<LO, GO>;
           Teuchos::RCP<const map_type>   dummy_map = Teuchos::rcp(new map_type());
           Tpetra::Vector<double, LO, GO> dummy_vector(dummy_map);
-          (void)dummy_vector;
+
+          // Newer versions of Trilinos deprecate/remove this call
+          dummy_vector.template sync<Kokkos::HostSpace>();
+
           return 0;
         }
         "


### PR DESCRIPTION
When testing a version of Trilinos 13.1 together with @c-p-schmidt, we found that deal.II requires a deprecated call of Tpetra::Vector, namely `sync()`. In 13.2 (which seems to be supported by deal.II) this deprecation has been commented out; however, in newer versions `sync()` is completely removed. As far as I can tell, the current implementation in deal.II always requires this function, thus I added it to the configure-time check. This patch allows us to cleanly build deal.II with Trilinos 13.1 (ofc, with Tpetra support in deal.II disabled by the check).

@tamiko Let me know if this is the correct way to add this check.

Related to #13972 