### PR TITLE
Horizontal add function for VectorizedArray

### DIFF
--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -1245,17 +1245,17 @@ private:
    */
   DEAL_II_ALWAYS_INLINE
   __m256d
-  get_low() const
+  get_lower() const
   {
     return _mm512_castpd512_pd256(data);
   }
 
   /**
-   * Extract higher half of data field.
+   * Extract upper half of data field.
    */
   DEAL_II_ALWAYS_INLINE
   __m256d
-  get_high() const
+  get_upper() const
   {
     return _mm512_extractf64x4_pd(data, 1);
   }
@@ -1844,17 +1844,17 @@ private:
    */
   DEAL_II_ALWAYS_INLINE
   __m256
-  get_low() const
+  get_lower() const
   {
     return _mm512_castps512_ps256(data);
   }
 
   /**
-   * Extract higher half of data field.
+   * Extract upper half of data field.
    */
   DEAL_II_ALWAYS_INLINE
   __m256
-  get_high() const
+  get_upper() const
   {
     return _mm256_castpd_ps(_mm512_extractf64x4_pd(_mm512_castps_pd(data), 1));
   }
@@ -2548,17 +2548,17 @@ private:
    */
   DEAL_II_ALWAYS_INLINE
   __m128d
-  get_low() const
+  get_lower() const
   {
     return _mm256_castpd256_pd128(data);
   }
 
   /**
-   * Extract higher half of data field.
+   * Extract upper half of data field.
    */
   DEAL_II_ALWAYS_INLINE
   __m128d
-  get_high() const
+  get_upper() const
   {
     return _mm256_extractf128_pd(data, 1);
   }
@@ -3106,17 +3106,17 @@ private:
    */
   DEAL_II_ALWAYS_INLINE
   __m128
-  get_low() const
+  get_lower() const
   {
     return _mm256_castps256_ps128(data);
   }
 
   /**
-   * Extract higher half of data field.
+   * Extract upper half of data field.
    */
   DEAL_II_ALWAYS_INLINE
   __m128
-  get_high() const
+  get_upper() const
   {
     return _mm256_extractf128_ps(data, 1);
   }
@@ -4971,7 +4971,7 @@ inline double
 VectorizedArray<double, 4>::horizontal_add()
 {
   VectorizedArray<double, 2> t1;
-  t1.data = _mm_add_pd(this->get_low(), this->get_high());
+  t1.data = _mm_add_pd(this->get_lower(), this->get_upper());
   return t1.horizontal_add();
 }
 
@@ -4981,7 +4981,7 @@ inline float
 VectorizedArray<float, 8>::horizontal_add()
 {
   VectorizedArray<float, 4> t1;
-  t1.data = _mm_add_ps(this->get_low(), this->get_high());
+  t1.data = _mm_add_ps(this->get_lower(), this->get_upper());
   return t1.horizontal_add();
 }
 #endif
@@ -4993,7 +4993,7 @@ inline double
 VectorizedArray<double, 8>::horizontal_add()
 {
   VectorizedArray<double, 4> t1;
-  t1.data = _mm256_add_pd(this->get_low(), this->get_high());
+  t1.data = _mm256_add_pd(this->get_lower(), this->get_upper());
   return t1.horizontal_add();
 }
 
@@ -5003,7 +5003,7 @@ inline float
 VectorizedArray<float, 16>::horizontal_add()
 {
   VectorizedArray<float, 8> t1;
-  t1.data = _mm256_add_ps(this->get_low(), this->get_high());
+  t1.data = _mm256_add_ps(this->get_lower(), this->get_upper());
   return t1.horizontal_add();
 }
 #endif

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -657,7 +657,8 @@ public:
   }
 
   /**
-   * Returns sum over entries of data field.
+   * Returns sum over entries of the data field, $\sum_{i=1}^{\text{size}()}
+   * this->data[i]$.
    */
   DEAL_II_ALWAYS_INLINE
   Number
@@ -1227,7 +1228,8 @@ public:
   }
 
   /**
-   * Returns sum over entries of data field.
+   * Returns sum over entries of the data field, $\sum_{i=1}^{\text{size}()}
+   * this->data[i]$.
    */
   double
   sum();
@@ -1826,7 +1828,8 @@ public:
   }
 
   /**
-   * Returns sum over entries of data field.
+   * Returns sum over entries of the data field, $\sum_{i=1}^{\text{size}()}
+   * this->data[i]$.
    */
   float
   sum();
@@ -2530,7 +2533,8 @@ public:
   }
 
   /**
-   * Returns sum over entries of data field.
+   * Returns sum over entries of the data field, $\sum_{i=1}^{\text{size}()}
+   * this->data[i]$.
    */
   double
   sum();
@@ -3088,7 +3092,8 @@ public:
   }
 
   /**
-   * Returns sum over entries of data field.
+   * Returns sum over entries of the data field, $\sum_{i=1}^{\text{size}()}
+   * this->data[i]$.
    */
   float
   sum();
@@ -3676,7 +3681,8 @@ public:
   }
 
   /**
-   * Returns sum over entries of data field.
+   * Returns sum over entries of the data field, $\sum_{i=1}^{\text{size}()}
+   * this->data[i]$.
    */
   double
   sum();
@@ -4138,7 +4144,8 @@ public:
   }
 
   /**
-   * Returns sum over entries of data field.
+   * Returns sum over entries of the data field, $\sum_{i=1}^{\text{size}()}
+   * this->data[i]$.
    */
   float
   sum();

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -657,11 +657,11 @@ public:
   }
 
   /**
-   * Returns horizontal sum of data field.
+   * Returns sum over entries of data field.
    */
   DEAL_II_ALWAYS_INLINE
   Number
-  horizontal_add()
+  sum()
   {
     return data;
   }
@@ -1227,10 +1227,10 @@ public:
   }
 
   /**
-   * Returns horizontal sum of data field.
+   * Returns sum over entries of data field.
    */
   double
-  horizontal_add();
+  sum();
 
   /**
    * Actual data field. To be consistent with the standard layout type and to
@@ -1826,10 +1826,10 @@ public:
   }
 
   /**
-   * Returns horizontal sum of data field.
+   * Returns sum over entries of data field.
    */
   float
-  horizontal_add();
+  sum();
 
   /**
    * Actual data field. To be consistent with the standard layout type and to
@@ -2530,10 +2530,10 @@ public:
   }
 
   /**
-   * Returns horizontal sum of data field.
+   * Returns sum over entries of data field.
    */
   double
-  horizontal_add();
+  sum();
 
   /**
    * Actual data field. To be consistent with the standard layout type and to
@@ -3088,10 +3088,10 @@ public:
   }
 
   /**
-   * Returns horizontal sum of data field.
+   * Returns sum over entries of data field.
    */
   float
-  horizontal_add();
+  sum();
 
   /**
    * Actual data field. To be consistent with the standard layout type and to
@@ -3676,10 +3676,10 @@ public:
   }
 
   /**
-   * Returns horizontal sum of data field.
+   * Returns sum over entries of data field.
    */
   double
-  horizontal_add();
+  sum();
 
   /**
    * Actual data field. To be consistent with the standard layout type and to
@@ -4138,10 +4138,10 @@ public:
   }
 
   /**
-   * Returns horizontal sum of data field.
+   * Returns sum over entries of data field.
    */
   float
-  horizontal_add();
+  sum();
 
   /**
    * Actual data field. To be consistent with the standard layout type and to
@@ -4939,12 +4939,12 @@ private:
 #endif // DOXYGEN
 
 /**
- * horizontal_add() functions.
+ * sum() functions.
  */
 
 #if DEAL_II_VECTORIZATION_WIDTH_IN_BITS >= 128 && defined(__SSE2__)
 inline double
-VectorizedArray<double, 2>::horizontal_add()
+VectorizedArray<double, 2>::sum()
 {
   __m128d t1 = _mm_unpackhi_pd(data, data);
   __m128d t2 = _mm_add_pd(data, t1);
@@ -4954,7 +4954,7 @@ VectorizedArray<double, 2>::horizontal_add()
 
 
 inline float
-VectorizedArray<float, 4>::horizontal_add()
+VectorizedArray<float, 4>::sum()
 {
   __m128 t1 = _mm_movehl_ps(data, data);
   __m128 t2 = _mm_add_ps(data, t1);
@@ -4968,21 +4968,21 @@ VectorizedArray<float, 4>::horizontal_add()
 
 #if DEAL_II_VECTORIZATION_WIDTH_IN_BITS >= 256 && defined(__AVX__)
 inline double
-VectorizedArray<double, 4>::horizontal_add()
+VectorizedArray<double, 4>::sum()
 {
   VectorizedArray<double, 2> t1;
   t1.data = _mm_add_pd(this->get_lower(), this->get_upper());
-  return t1.horizontal_add();
+  return t1.sum();
 }
 
 
 
 inline float
-VectorizedArray<float, 8>::horizontal_add()
+VectorizedArray<float, 8>::sum()
 {
   VectorizedArray<float, 4> t1;
   t1.data = _mm_add_ps(this->get_lower(), this->get_upper());
-  return t1.horizontal_add();
+  return t1.sum();
 }
 #endif
 
@@ -4990,21 +4990,21 @@ VectorizedArray<float, 8>::horizontal_add()
 
 #if DEAL_II_VECTORIZATION_WIDTH_IN_BITS >= 512 && defined(__AVX512F__)
 inline double
-VectorizedArray<double, 8>::horizontal_add()
+VectorizedArray<double, 8>::sum()
 {
   VectorizedArray<double, 4> t1;
   t1.data = _mm256_add_pd(this->get_lower(), this->get_upper());
-  return t1.horizontal_add();
+  return t1.sum();
 }
 
 
 
 inline float
-VectorizedArray<float, 16>::horizontal_add()
+VectorizedArray<float, 16>::sum()
 {
   VectorizedArray<float, 8> t1;
   t1.data = _mm256_add_ps(this->get_lower(), this->get_upper());
-  return t1.horizontal_add();
+  return t1.sum();
 }
 #endif
 

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -657,6 +657,16 @@ public:
   }
 
   /**
+   * Returns horizontal sum of data field.
+   */
+  DEAL_II_ALWAYS_INLINE
+  Number
+  horizontal_add()
+  {
+    return data;
+  }
+
+  /**
    * Actual data field. To be consistent with the standard layout type and to
    * enable interaction with external SIMD functionality, this member is
    * declared public.
@@ -1217,6 +1227,12 @@ public:
   }
 
   /**
+   * Returns horizontal sum of data field.
+   */
+  double
+  horizontal_add();
+
+  /**
    * Actual data field. To be consistent with the standard layout type and to
    * enable interaction with external SIMD functionality, this member is
    * declared public.
@@ -1224,6 +1240,26 @@ public:
   __m512d data;
 
 private:
+  /**
+   * Extract lower half of data field.
+   */
+  DEAL_II_ALWAYS_INLINE
+  __m256d
+  get_low() const
+  {
+    return _mm512_castpd512_pd256(data);
+  }
+
+  /**
+   * Extract higher half of data field.
+   */
+  DEAL_II_ALWAYS_INLINE
+  __m256d
+  get_high() const
+  {
+    return _mm512_extractf64x4_pd(data, 1);
+  }
+
   /**
    * Return the square root of this field. Not for use in user code. Use
    * sqrt(x) instead.
@@ -1790,6 +1826,12 @@ public:
   }
 
   /**
+   * Returns horizontal sum of data field.
+   */
+  float
+  horizontal_add();
+
+  /**
    * Actual data field. To be consistent with the standard layout type and to
    * enable interaction with external SIMD functionality, this member is
    * declared public.
@@ -1797,6 +1839,26 @@ public:
   __m512 data;
 
 private:
+  /**
+   * Extract lower half of data field.
+   */
+  DEAL_II_ALWAYS_INLINE
+  __m256
+  get_low() const
+  {
+    return _mm512_castps512_ps256(data);
+  }
+
+  /**
+   * Extract higher half of data field.
+   */
+  DEAL_II_ALWAYS_INLINE
+  __m256
+  get_high() const
+  {
+    return _mm256_castpd_ps(_mm512_extractf64x4_pd(_mm512_castps_pd(data), 1));
+  }
+
   /**
    * Return the square root of this field. Not for use in user code. Use
    * sqrt(x) instead.
@@ -2253,6 +2315,14 @@ public:
   {}
 
   /**
+   * Construct an array with the data field.
+   */
+  VectorizedArray(__m256d const &x)
+  {
+    data = x;
+  }
+
+  /**
    * This function can be used to set all data fields to a given scalar.
    */
   DEAL_II_ALWAYS_INLINE
@@ -2468,6 +2538,12 @@ public:
   }
 
   /**
+   * Returns horizontal sum of data field.
+   */
+  double
+  horizontal_add();
+
+  /**
    * Actual data field. To be consistent with the standard layout type and to
    * enable interaction with external SIMD functionality, this member is
    * declared public.
@@ -2475,6 +2551,26 @@ public:
   __m256d data;
 
 private:
+  /**
+   * Extract lower half of data field.
+   */
+  DEAL_II_ALWAYS_INLINE
+  __m128d
+  get_low() const
+  {
+    return _mm256_castpd256_pd128(data);
+  }
+
+  /**
+   * Extract higher half of data field.
+   */
+  DEAL_II_ALWAYS_INLINE
+  __m128d
+  get_high() const
+  {
+    return _mm256_extractf128_pd(data, 1);
+  }
+
   /**
    * Return the square root of this field. Not for use in user code. Use
    * sqrt(x) instead.
@@ -2799,6 +2895,14 @@ public:
   {}
 
   /**
+   * Construct an array with the data field.
+   */
+  VectorizedArray(__m256 const &x)
+  {
+    data = x;
+  }
+
+  /**
    * This function can be used to set all data fields to a given scalar.
    */
   DEAL_II_ALWAYS_INLINE
@@ -3000,6 +3104,12 @@ public:
   }
 
   /**
+   * Returns horizontal sum of data field.
+   */
+  float
+  horizontal_add();
+
+  /**
    * Actual data field. To be consistent with the standard layout type and to
    * enable interaction with external SIMD functionality, this member is
    * declared public.
@@ -3007,6 +3117,26 @@ public:
   __m256 data;
 
 private:
+  /**
+   * Extract lower half of data field.
+   */
+  DEAL_II_ALWAYS_INLINE
+  __m128
+  get_low() const
+  {
+    return _mm256_castps256_ps128(data);
+  }
+
+  /**
+   * Extract higher half of data field.
+   */
+  DEAL_II_ALWAYS_INLINE
+  __m128
+  get_high() const
+  {
+    return _mm256_extractf128_ps(data, 1);
+  }
+
   /**
    * Return the square root of this field. Not for use in user code. Use
    * sqrt(x) instead.
@@ -3365,6 +3495,14 @@ public:
   {}
 
   /**
+   * Construct an array with the data field.
+   */
+  VectorizedArray(__m128d const &x)
+  {
+    data = x;
+  }
+
+  /**
    * This function can be used to set all data fields to a given scalar.
    */
   DEAL_II_ALWAYS_INLINE
@@ -3560,6 +3698,12 @@ public:
     for (unsigned int i = 0; i < 2; ++i)
       base_ptr[offsets[i]] = *(reinterpret_cast<const double *>(&data) + i);
   }
+
+  /**
+   * Returns horizontal sum of data field.
+   */
+  double
+  horizontal_add();
 
   /**
    * Actual data field. To be consistent with the standard layout type and to
@@ -3850,6 +3994,14 @@ public:
   }
 
   /**
+   * Construct an array with the data field.
+   */
+  VectorizedArray(__m128 const &x)
+  {
+    data = x;
+  }
+
+  /**
    * Assign a scalar to the current object. This overload is used for
    * rvalue references; because it does not make sense to assign
    * something to a temporary, the function is deleted.
@@ -4016,6 +4168,12 @@ public:
     for (unsigned int i = 0; i < 4; ++i)
       base_ptr[offsets[i]] = *(reinterpret_cast<const float *>(&data) + i);
   }
+
+  /**
+   * Returns horizontal sum of data field.
+   */
+  float
+  horizontal_add();
 
   /**
    * Actual data field. To be consistent with the standard layout type and to
@@ -4811,6 +4969,74 @@ private:
 
 
 #endif // DOXYGEN
+
+/**
+ * horizontal_add() functions.
+ */
+
+#if DEAL_II_VECTORIZATION_WIDTH_IN_BITS >= 128 && defined(__SSE2__)
+inline double
+VectorizedArray<double, 2>::horizontal_add()
+{
+  __m128d t1 = _mm_unpackhi_pd(data, data);
+  __m128d t2 = _mm_add_pd(data, t1);
+  return _mm_cvtsd_f64(t2);
+}
+
+
+
+inline float
+VectorizedArray<float, 4>::horizontal_add()
+{
+  __m128 t1 = _mm_movehl_ps(data, data);
+  __m128 t2 = _mm_add_ps(data, t1);
+  __m128 t3 = _mm_shuffle_ps(t2, t2, 1);
+  __m128 t4 = _mm_add_ss(t2, t3);
+  return _mm_cvtss_f32(t4);
+}
+#endif
+
+
+
+#if DEAL_II_VECTORIZATION_WIDTH_IN_BITS >= 256 && defined(__AVX__)
+inline double
+VectorizedArray<double, 4>::horizontal_add()
+{
+  VectorizedArray<double, 2> t1(this->get_low() + this->get_high());
+  return t1.horizontal_add();
+}
+
+
+
+inline float
+VectorizedArray<float, 8>::horizontal_add()
+{
+  VectorizedArray<float, 4> t1(this->get_low() + this->get_high());
+  return t1.horizontal_add();
+}
+#endif
+
+
+
+#if DEAL_II_VECTORIZATION_WIDTH_IN_BITS >= 512 && defined(__AVX512F__)
+inline double
+VectorizedArray<double, 8>::horizontal_add()
+{
+  VectorizedArray<double, 4> t1(this->get_low() + this->get_high());
+  return t1.horizontal_add();
+}
+
+
+
+inline float
+VectorizedArray<float, 16>::horizontal_add()
+{
+  VectorizedArray<float, 8> t1(this->get_low() + this->get_high());
+  return t1.horizontal_add();
+}
+#endif
+
+
 
 /**
  * @name Arithmetic operations with VectorizedArray

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -2315,14 +2315,6 @@ public:
   {}
 
   /**
-   * Construct an array with the data field.
-   */
-  VectorizedArray(__m256d const &x)
-  {
-    data = x;
-  }
-
-  /**
    * This function can be used to set all data fields to a given scalar.
    */
   DEAL_II_ALWAYS_INLINE
@@ -2893,14 +2885,6 @@ public:
   VectorizedArray(const std::initializer_list<U> &list)
     : VectorizedArrayBase<VectorizedArray<float, 8>, 8>(list)
   {}
-
-  /**
-   * Construct an array with the data field.
-   */
-  VectorizedArray(__m256 const &x)
-  {
-    data = x;
-  }
 
   /**
    * This function can be used to set all data fields to a given scalar.
@@ -3495,14 +3479,6 @@ public:
   {}
 
   /**
-   * Construct an array with the data field.
-   */
-  VectorizedArray(__m128d const &x)
-  {
-    data = x;
-  }
-
-  /**
    * This function can be used to set all data fields to a given scalar.
    */
   DEAL_II_ALWAYS_INLINE
@@ -3991,14 +3967,6 @@ public:
   {
     data = _mm_set1_ps(x);
     return *this;
-  }
-
-  /**
-   * Construct an array with the data field.
-   */
-  VectorizedArray(__m128 const &x)
-  {
-    data = x;
   }
 
   /**
@@ -5002,7 +4970,8 @@ VectorizedArray<float, 4>::horizontal_add()
 inline double
 VectorizedArray<double, 4>::horizontal_add()
 {
-  VectorizedArray<double, 2> t1(this->get_low() + this->get_high());
+  VectorizedArray<double, 2> t1;
+  t1.data = this->get_low() + this->get_high();
   return t1.horizontal_add();
 }
 
@@ -5011,7 +4980,8 @@ VectorizedArray<double, 4>::horizontal_add()
 inline float
 VectorizedArray<float, 8>::horizontal_add()
 {
-  VectorizedArray<float, 4> t1(this->get_low() + this->get_high());
+  VectorizedArray<float, 4> t1;
+  t1.data = this->get_low() + this->get_high();
   return t1.horizontal_add();
 }
 #endif
@@ -5022,7 +4992,8 @@ VectorizedArray<float, 8>::horizontal_add()
 inline double
 VectorizedArray<double, 8>::horizontal_add()
 {
-  VectorizedArray<double, 4> t1(this->get_low() + this->get_high());
+  VectorizedArray<double, 4> t1;
+  t1.data = this->get_low() + this->get_high();
   return t1.horizontal_add();
 }
 
@@ -5031,7 +5002,8 @@ VectorizedArray<double, 8>::horizontal_add()
 inline float
 VectorizedArray<float, 16>::horizontal_add()
 {
-  VectorizedArray<float, 8> t1(this->get_low() + this->get_high());
+  VectorizedArray<float, 8> t1;
+  t1.data = this->get_low() + this->get_high();
   return t1.horizontal_add();
 }
 #endif

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -4971,7 +4971,7 @@ inline double
 VectorizedArray<double, 4>::horizontal_add()
 {
   VectorizedArray<double, 2> t1;
-  t1.data = this->get_low() + this->get_high();
+  t1.data = _mm_add_pd(this->get_low(), this->get_high());
   return t1.horizontal_add();
 }
 
@@ -4981,7 +4981,7 @@ inline float
 VectorizedArray<float, 8>::horizontal_add()
 {
   VectorizedArray<float, 4> t1;
-  t1.data = this->get_low() + this->get_high();
+  t1.data = _mm_add_ps(this->get_low(), this->get_high());
   return t1.horizontal_add();
 }
 #endif
@@ -4993,7 +4993,7 @@ inline double
 VectorizedArray<double, 8>::horizontal_add()
 {
   VectorizedArray<double, 4> t1;
-  t1.data = this->get_low() + this->get_high();
+  t1.data = _mm256_add_pd(this->get_low(), this->get_high());
   return t1.horizontal_add();
 }
 
@@ -5003,7 +5003,7 @@ inline float
 VectorizedArray<float, 16>::horizontal_add()
 {
   VectorizedArray<float, 8> t1;
-  t1.data = this->get_low() + this->get_high();
+  t1.data = _mm256_add_ps(this->get_low(), this->get_high());
   return t1.horizontal_add();
 }
 #endif

--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -2067,7 +2067,7 @@ FEPointEvaluation<n_components_, dim, spacedim, Number>::finish_integrate_fast(
               ETT::write_value(vectorized_input,
                                comp,
                                solution_renumbered_vectorized[i]);
-              input[i] = vectorized_input.horizontal_add();
+              input[i] = vectorized_input.sum();
             }
 
           internal::FEFaceNormalEvaluationImpl<dim, -1, ScalarNumber>::
@@ -2089,7 +2089,7 @@ FEPointEvaluation<n_components_, dim, spacedim, Number>::finish_integrate_fast(
               VectorizedArrayType result;
               ETT::write_value(result, comp, solution_renumbered_vectorized[i]);
               solution_values[renumber[comp * dofs_per_component + i]] =
-                result.horizontal_add();
+                result.sum();
             }
         }
     }

--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -2067,11 +2067,7 @@ FEPointEvaluation<n_components_, dim, spacedim, Number>::finish_integrate_fast(
               ETT::write_value(vectorized_input,
                                comp,
                                solution_renumbered_vectorized[i]);
-              for (unsigned int lane = n_lanes_internal / 2; lane > 0;
-                   lane /= 2)
-                for (unsigned int j = 0; j < lane; ++j)
-                  vectorized_input[j] += vectorized_input[lane + j];
-              input[i] = vectorized_input[0];
+              input[i] = vectorized_input.horizontal_add();
             }
 
           internal::FEFaceNormalEvaluationImpl<dim, -1, ScalarNumber>::
@@ -2092,12 +2088,8 @@ FEPointEvaluation<n_components_, dim, spacedim, Number>::finish_integrate_fast(
             {
               VectorizedArrayType result;
               ETT::write_value(result, comp, solution_renumbered_vectorized[i]);
-              for (unsigned int lane = n_lanes_internal / 2; lane > 0;
-                   lane /= 2)
-                for (unsigned int j = 0; j < lane; ++j)
-                  result[j] += result[lane + j];
               solution_values[renumber[comp * dofs_per_component + i]] =
-                result[0];
+                result.horizontal_add();
             }
         }
     }


### PR DESCRIPTION
Add a new function `horizontal_add()` to `VectorizedArray` which uses vertical adds of the lower and higher part of a VectorizedArray until a 128 bit `VectorizedArray` is reached. Then use SSE2 intrinsics to do the horizontal add and return the horizontal sum.

We can use this function when we do vectorization over quadrature points like in `FEPointEvaluation::finish_integrate_fast()` which is more efficient than the code generated from the for loops on current master.

@peterrum @kronbichler 