### PR TITLE
More interface mismatch in ScratchData in hp mode.

### DIFF
--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -422,7 +422,7 @@ namespace hp
      * If this set consists of exactly one element, we consider it to be
      * the dominating one and return its corresponding index. Further, if the
      * function is not able to find a finite element at all, it returns
-     * numbers::invalid_unsigned_int.
+     * numbers::invalid_fe_index.
      *
      * For example, if a FECollection consists of
      * `{FE_Q(1),FE_Q(2),FE_Q(3),FE_Q(4)}` elements and we are looking for the
@@ -458,7 +458,7 @@ namespace hp
      * If this set consists of exactly one element, we consider it to be
      * the dominated one and return its corresponding index. Further, if the
      * function is not able to find a finite element at all, it returns
-     * numbers::invalid_unsigned_int.
+     * numbers::invalid_fe_index.
      *
      * For example, if a FECollection consists of
      * `{FE_Q(1),FE_Q(2),FE_Q(3),FE_Q(4)}` elements and we are looking for the
@@ -498,7 +498,7 @@ namespace hp
      * If this set consists of exactly one element, we consider it to be
      * the dominated one and return its corresponding index. Further, if the
      * function is not able to find a finite element at all, it returns
-     * numbers::invalid_unsigned_int.
+     * numbers::invalid_fe_index.
      *
      * The @p codim parameter describes the codimension of the investigated
      * subspace and specifies that it is subject to this comparison. See
@@ -524,7 +524,7 @@ namespace hp
      * If this set consists of exactly one element, we consider it to be
      * the dominating one and return its corresponding index. Further, if the
      * function is not able to find a finite element at all, it returns
-     * numbers::invalid_unsigned_int.
+     * numbers::invalid_fe_index.
      *
      * The @p codim parameter describes the codimension of the investigated
      * subspace and specifies that it is subject to this comparison. See

--- a/source/meshworker/scratch_data.cc
+++ b/source/meshworker/scratch_data.cc
@@ -410,9 +410,15 @@ namespace MeshWorker
             // face, then we defer to the dominance of one FE over another. This
             // should ensure that the optimal integration order and mapping
             // order are selected for this situation.
-            const unsigned int dominated_fe_index =
-              fe_collection->find_dominated_fe(
-                {cell->active_fe_index(), neighbor_cell->active_fe_index()});
+            unsigned int dominated_fe_index = fe_collection->find_dominated_fe(
+              {cell->active_fe_index(), neighbor_cell->active_fe_index()});
+
+            // TODO: find_dominated_fe returns invalid_fe_index when no
+            // dominated FE has been found. We want to pass this value to
+            // FEFaceValues, but it expects an invalid_unsigned_int in this
+            // case. We need to match the interfaces in the future.
+            if (dominated_fe_index == numbers::invalid_fe_index)
+              dominated_fe_index = numbers::invalid_unsigned_int;
 
             hp_fe_subface_values->reinit(cell,
                                          face_no,
@@ -498,9 +504,15 @@ namespace MeshWorker
         // face, then we defer to the dominance of one FE over another. This
         // should ensure that the optimal integration order and mapping
         // order are selected for this situation.
-        const unsigned int dominated_fe_index =
-          fe_collection->find_dominated_fe(
-            {cell->active_fe_index(), cell_neighbor->active_fe_index()});
+        unsigned int dominated_fe_index = fe_collection->find_dominated_fe(
+          {cell->active_fe_index(), cell_neighbor->active_fe_index()});
+
+        // TODO: find_dominated_fe returns invalid_fe_index when no dominated FE
+        // has been found. We want to pass this value to FEFaceValues, but it
+        // expects an invalid_unsigned_int in this case. We need to match the
+        // interfaces in the future.
+        if (dominated_fe_index == numbers::invalid_fe_index)
+          dominated_fe_index = numbers::invalid_unsigned_int;
 
         interface_fe_values->reinit(cell,
                                     face_no,
@@ -617,9 +629,15 @@ namespace MeshWorker
         // then we defer to the dominance of one FE over another. This should
         // ensure that the optimal integration order and mapping order are
         // selected for this situation.
-        const unsigned int dominated_fe_index =
-          fe_collection->find_dominated_fe(
-            {cell->active_fe_index(), neighbor_cell->active_fe_index()});
+        unsigned int dominated_fe_index = fe_collection->find_dominated_fe(
+          {cell->active_fe_index(), neighbor_cell->active_fe_index()});
+
+        // TODO: find_dominated_fe returns invalid_fe_index when no dominated FE
+        // has been found. We want to pass this value to FEFaceValues, but it
+        // expects an invalid_unsigned_int in this case. We need to match the
+        // interfaces in the future.
+        if (dominated_fe_index == numbers::invalid_fe_index)
+          dominated_fe_index = numbers::invalid_unsigned_int;
 
         neighbor_hp_fe_face_values->reinit(neighbor_cell,
                                            face_no,
@@ -706,9 +724,15 @@ namespace MeshWorker
             // face, then we defer to the dominance of one FE over another. This
             // should ensure that the optimal integration order and mapping
             // order are selected for this situation.
-            const unsigned int dominated_fe_index =
-              fe_collection->find_dominated_fe(
-                {cell->active_fe_index(), neighbor_cell->active_fe_index()});
+            unsigned int dominated_fe_index = fe_collection->find_dominated_fe(
+              {cell->active_fe_index(), neighbor_cell->active_fe_index()});
+
+            // TODO: find_dominated_fe returns invalid_fe_index when no
+            // dominated FE has been found. We want to pass this value to
+            // FEFaceValues, but it expects an invalid_unsigned_int in this
+            // case. We need to match the interfaces in the future.
+            if (dominated_fe_index == numbers::invalid_fe_index)
+              dominated_fe_index = numbers::invalid_unsigned_int;
 
             neighbor_hp_fe_subface_values->reinit(neighbor_cell,
                                                   face_no,


### PR DESCRIPTION
Follow-up to #15105. There are other occurrences in which we need to convert the return type.

I noticed that we didn't update the documentation for these functions in #14225. This PR also closes this gap.

