### PR TITLE
Cleanup CUDAWrappers::MatrixFree

### DIFF
--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -728,7 +728,7 @@ namespace CUDAWrappers
           Kokkos::View<Number *, MemorySpace::Default::kokkos_space>(
             Kokkos::view_alloc("co_shape_gradients",
                                Kokkos::WithoutInitializing),
-            size_shape_values);
+            n_q_points_1d * n_q_points_1d);
         Kokkos::deep_copy(
           co_shape_gradients,
           Kokkos::View<Number *, Kokkos::HostSpace>(


### PR DESCRIPTION
This PR does two things: 
 1. instead of copying the data to the gpu one cell at the time, we copy the data one time for each color. I have also renamed the functions because the name was not appropriate anymore.
 2. as Daniel suggested in #15003, I've removed the temporary Kokkos::Views 