### PR TITLE
CMake: introduce copy_target_properties() macro

### DIFF
--- a/cmake/macros/macro_copy_target_properties.cmake
+++ b/cmake/macros/macro_copy_target_properties.cmake
@@ -79,11 +79,13 @@ function(copy_target_properties _destination_target)
       if(TARGET ${_lib})
         list(APPEND _source_targets ${_lib})
       else()
-        # Warn loudly if we encounter an undefined target:
+        #
+        # Complain loudly if we encounter an undefined target:
+        #
         if("${_lib}" MATCHES "::")
-          message(WARNING
+          message(FATAL_ERROR
             "Undefined imported target name »${_lib}« present in interface "
-            "of target »${_entry}«"
+            "of target »${_entry}«."
             )
         endif()
         list(APPEND _libraries ${_lib})

--- a/cmake/macros/macro_copy_target_properties.cmake
+++ b/cmake/macros/macro_copy_target_properties.cmake
@@ -75,6 +75,7 @@ function(copy_target_properties _destination_target)
     endif()
 
     foreach(_lib ${_location} ${_values})
+      strip_known_generator_expressions(_lib)
       if(TARGET ${_lib})
         list(APPEND _source_targets ${_lib})
       else()

--- a/cmake/macros/macro_copy_target_properties.cmake
+++ b/cmake/macros/macro_copy_target_properties.cmake
@@ -52,9 +52,21 @@ function(copy_target_properties _destination_target)
     list(APPEND _processed_targets ${_entry})
     message(STATUS "    copying ${_entry} into ${_destination_target} ...")
 
-    get_target_property(_location ${_entry} IMPORTED_LOCATION)
-    if("${_location}" MATCHES "-NOTFOUND")
-      set(_location)
+    #
+    # Only query the LOCATION from non-interface libraries. An interface
+    # library is a CMake target that only consists of "INTERFACE" target
+    # properties and does not by itself refer to an executable or shared
+    # object/static archive. CMake prior to 3.19 will throw an error if we
+    # query for the LOCATION. Newer CMake versions simply return
+    # "-NOTFOUND".
+    #
+    set(_location)
+    get_target_property(_test ${_entry} TYPE)
+    if(NOT "${_test}" STREQUAL "INTERFACE_LIBRARY")
+      get_target_property(_location ${_entry} LOCATION)
+      if("${_location}" MATCHES "-NOTFOUND")
+        set(_location)
+      endif()
     endif()
 
     get_target_property(_values ${_entry} INTERFACE_LINK_LIBRARIES)
@@ -73,7 +85,7 @@ function(copy_target_properties _destination_target)
             "of target »${_entry}«"
             )
         endif()
-        list(APPEND _libraries ${_entry})
+        list(APPEND _libraries ${_lib})
       endif()
     endforeach()
 

--- a/cmake/macros/macro_copy_target_properties.cmake
+++ b/cmake/macros/macro_copy_target_properties.cmake
@@ -1,0 +1,140 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2022 - 2022 by the deal.II authors
+##
+## This file is part of the deal.II library.
+##
+## The deal.II library is free software; you can use it, redistribute
+## it, and/or modify it under the terms of the GNU Lesser General
+## Public License as published by the Free Software Foundation; either
+## version 2.1 of the License, or (at your option) any later version.
+## The full text of the license can be found in the file LICENSE.md at
+## the top level directory of deal.II.
+##
+## ---------------------------------------------------------------------
+
+#
+# copy_target_properties(<destination target> [<source targets>])
+#
+# Copies relevant (imported) target properties from the source targets and
+# appends the properties to the destination target.
+#
+
+function(copy_target_properties _destination_target)
+
+  #
+  # Make sure that we expand all targets recursively for the sake of a
+  # cleaner output we check whether we have already included a given target
+  #
+
+  set(_source_targets ${ARGN})
+  set(_processed_targets)
+
+  #
+  # Collect values over all targets found in ${_source_targets}:
+  #
+
+  set(_libraries)
+  set(_include_directories)
+  set(_compile_definitions)
+  set(_compile_options)
+  set(_link_options)
+
+  while(NOT "${_source_targets}" STREQUAL "")
+    # Future FIXME: replace by POP_FRONT (CMake 3.15)
+    list(GET _source_targets 0 _entry)
+    list(REMOVE_AT _source_targets 0)
+
+    if(${_entry} IN_LIST _processed_targets)
+      continue()
+    endif()
+
+    list(APPEND _processed_targets ${_entry})
+    message(STATUS "    copying ${_entry} into ${_destination_target} ...")
+
+    get_target_property(_location ${_entry} IMPORTED_LOCATION)
+    if("${_location}" MATCHES "-NOTFOUND")
+      set(_location)
+    endif()
+
+    get_target_property(_values ${_entry} INTERFACE_LINK_LIBRARIES)
+    if("${_values}" MATCHES "-NOTFOUND")
+      set(_values)
+    endif()
+
+    foreach(_lib ${_location} ${_values})
+      if(TARGET ${_lib})
+        list(APPEND _source_targets ${_lib})
+      else()
+        # Warn loudly if we encounter an undefined target:
+        if("${_lib}" MATCHES "::")
+          message(WARNING
+            "Undefined imported target name »${_lib}« present in interface "
+            "of target »${_entry}«"
+            )
+        endif()
+        list(APPEND _libraries ${_entry})
+      endif()
+    endforeach()
+
+    get_target_property(_values ${_entry} INTERFACE_INCLUDE_DIRECTORIES)
+    if(NOT "${_values}" MATCHES "-NOTFOUND")
+      list(APPEND _include_directories ${_values})
+    endif()
+
+    get_target_property(_values ${_entry} INTERFACE_SYSTEM_INCLUDE_DIRECTORIES)
+    if(NOT "${_values}" MATCHES "-NOTFOUND")
+      list(APPEND _include_directories ${_values})
+    endif()
+
+    get_target_property(_values ${_entry} INTERFACE_COMPILE_DEFINITIONS)
+    if(NOT "${_values}" MATCHES "-NOTFOUND")
+      list(APPEND _compile_definitions ${_values})
+    endif()
+
+    get_target_property(_values ${_entry} INTERFACE_COMPILE_OPTIONS)
+    if(NOT "${_values}" MATCHES "-NOTFOUND")
+      list(APPEND _compile_options ${_values})
+    endif()
+
+    get_target_property(_values ${_entry} INTERFACE_LINK_OPTIONS)
+    if(NOT "${_values}" MATCHES "-NOTFOUND")
+      list(APPEND _link_options ${_values})
+    endif()
+  endwhile()
+
+  #
+  # Populate destination target:
+  #
+
+  if(NOT "${_libraries}" STREQUAL "")
+    remove_duplicates(_libraries REVERSE)
+    message(STATUS "    LINK_LIBRARIES:      ${_libraries}")
+    target_link_libraries(${_destination_target} INTERFACE ${_libraries})
+  endif()
+
+  if(NOT "${_include_directories}" STREQUAL "")
+    remove_duplicates(_include_directories)
+    message(STATUS "    INCLUDE_DIRECTORIES: ${_include_directories}")
+    target_include_directories(${_destination_target} SYSTEM INTERFACE ${_include_directories})
+  endif()
+
+  if(NOT "${_compile_definitions}" STREQUAL "")
+    remove_duplicates(_compile_definitions REVERSE)
+    message(STATUS "    COMPILE_DEFINITIONS: ${_compile_definitions}")
+    target_compile_definitions(${_destination_target} INTERFACE ${_compile_definitions})
+  endif()
+
+  if(NOT "${_compile_options}" STREQUAL "")
+    remove_duplicates(_compile_options REVERSE)
+    message(STATUS "    COMPILE_OPTIONS: ${_compile_options}")
+    target_compile_options(${_destination_target} INTERFACE ${_compile_options})
+  endif()
+
+  if(NOT "${_link_options}" STREQUAL "")
+    remove_duplicates(_link_options REVERSE)
+    message(STATUS "    LINK_OPTIONS: ${_link_options}")
+    target_compile_options(${_destination_target} INTERFACE ${_link_options})
+  endif()
+endfunction()
+

--- a/cmake/macros/macro_define_interface_target.cmake
+++ b/cmake/macros/macro_define_interface_target.cmake
@@ -90,7 +90,6 @@ function(define_interface_target _feature)
     set(_libraries)
     list(APPEND _libraries
       ${${_feature}_LIBRARIES} ${${_feature}_LIBRARIES_${_build}}
-      ${${_feature}_TARGETS} ${${_feature}_TARGETS_${_build}}
       )
     if(NOT "${_libraries}" STREQUAL "")
       message(STATUS "    LINK_LIBRARIES:      ${_libraries}")
@@ -127,6 +126,12 @@ function(define_interface_target _feature)
     if(NOT "${_link_options}" STREQUAL "")
       message(STATUS "    LINK_OPTIONS:        ${_link_options}")
       target_link_options(${_interface_target} INTERFACE ${_link_options})
+    endif()
+
+    if(NOT "${${_feature}_TARGETS}${${_feature}_TARGETS_${_build}}" STREQUAL "")
+      set(_targets ${${_feature}_TARGETS}${${_feature}_TARGETS_${_build}})
+      message(STATUS "    IMPORTED TARGETS:    ${_targets}")
+      copy_target_properties(${_interface_target} ${${_feature}_TARGETS} ${${_feature}_TARGETS_${_build}})
     endif()
 
     export(TARGETS ${_interface_target}

--- a/cmake/macros/macro_define_interface_target.cmake
+++ b/cmake/macros/macro_define_interface_target.cmake
@@ -92,6 +92,16 @@ function(define_interface_target _feature)
       ${${_feature}_LIBRARIES} ${${_feature}_LIBRARIES_${_build}}
       )
     if(NOT "${_libraries}" STREQUAL "")
+      foreach(_lib ${_libraries})
+        # Warn loudly if we encounter an undefined target:
+        if("${_lib}" MATCHES "::")
+          message(WARNING
+            "Undefined imported target name »${_lib}« present when defining "
+            "interface target »${_interface_target}«"
+            )
+        endif()
+      endforeach()
+
       message(STATUS "    LINK_LIBRARIES:      ${_libraries}")
       target_link_libraries(${_interface_target} INTERFACE ${_libraries})
     endif()

--- a/cmake/macros/macro_define_interface_target.cmake
+++ b/cmake/macros/macro_define_interface_target.cmake
@@ -93,9 +93,11 @@ function(define_interface_target _feature)
       )
     if(NOT "${_libraries}" STREQUAL "")
       foreach(_lib ${_libraries})
-        # Warn loudly if we encounter an undefined target:
+        #
+        # Complain loudly if we encounter an undefined target:
+        #
         if("${_lib}" MATCHES "::")
-          message(WARNING
+          message(FATAL_ERROR
             "Undefined imported target name »${_lib}« present when defining "
             "interface target »${_interface_target}«"
             )

--- a/cmake/macros/macro_strip_known_generator_expressions.cmake
+++ b/cmake/macros/macro_strip_known_generator_expressions.cmake
@@ -1,0 +1,26 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2023 - 2023 by the deal.II authors
+##
+## This file is part of the deal.II library.
+##
+## The deal.II library is free software; you can use it, redistribute
+## it, and/or modify it under the terms of the GNU Lesser General
+## Public License as published by the Free Software Foundation; either
+## version 2.1 of the License, or (at your option) any later version.
+## The full text of the license can be found in the file LICENSE.md at
+## the top level directory of deal.II.
+##
+## ---------------------------------------------------------------------
+
+#
+# strip_known_generator_expressions(<variable>)
+#
+# Strip an enclosing generator expression from the variable. This macro is
+# primarily used in copy_target_properties
+#
+
+macro(strip_known_generator_expressions _variable)
+  string(REGEX REPLACE "^\\$<LINK_ONLY:(.*)>$" "\\1" ${_variable} "${${_variable}}")
+endmacro()
+


### PR DESCRIPTION
This macro is used to copy target properties from imported targets recursively into our interface targets. This will allow us to modernize our configure_<feature> macros to use imported targets directly instead of extracting all of this information for each external feature.

I will switch boost and kokkos over to using this interface in a follow-up pull request.

Remark: I think that simply copying this information is the best move forward for the time being - it is more robust for users and I do not need to come up with a robust way of reimporting all the external projects in the deal.II cmake config file again (+ some issues with our build system where we are not prepared for imported targets within our build system yet). However, I plan to make it possible to simply export the imported target signatures (without copying target properties) in the build system. This will probably require CMake 3.25 to function properly...

In reference to https://github.com/dealii/dealii/pull/14491