### PR TITLE
CMake: Use import targets in FindDEAL_II_BOOST.cmake

### DIFF
--- a/cmake/modules/FindDEAL_II_BOOST.cmake
+++ b/cmake/modules/FindDEAL_II_BOOST.cmake
@@ -45,32 +45,22 @@ endif()
 # compare https://gitlab.kitware.com/cmake/cmake/issues/18865
 # and https://lists.boost.org/Archives/boost/2019/02/245016.php
 set(Boost_NO_BOOST_CMAKE ON)
-
 set(Boost_NO_WARN_NEW_VERSIONS TRUE)
+
 if(DEAL_II_WITH_ZLIB)
   find_package(Boost ${BOOST_VERSION_REQUIRED} COMPONENTS
     iostreams serialization system thread
     )
+  set(_targets Boost::iostreams Boost::serialization Boost::system Boost::thread)
 else()
   find_package(Boost ${BOOST_VERSION_REQUIRED} COMPONENTS
     serialization system thread
     )
-endif()
-
-unset(Boost_NO_BOOST_CMAKE)
-
-if(Boost_FOUND)
-  set(BOOST_VERSION_MAJOR "${Boost_MAJOR_VERSION}")
-  set(BOOST_VERSION_MINOR "${Boost_MINOR_VERSION}")
-  set(BOOST_VERSION_SUBMINOR "${Boost_SUBMINOR_VERSION}")
-  set(BOOST_VERSION
-    "${BOOST_VERSION_MAJOR}.${BOOST_VERSION_MINOR}.${BOOST_VERSION_SUBMINOR}"
-    )
+  set(_targets Boost::serialization Boost::system Boost::thread)
 endif()
 
 process_feature(BOOST
-  LIBRARIES REQUIRED Boost_LIBRARIES
-  INCLUDE_DIRS REQUIRED Boost_INCLUDE_DIRS
+  TARGETS REQUIRED _targets
   CLEAR
     Boost_DIR Boost_INCLUDE_DIRS Boost_IOSTREAMS_LIBRARY_DEBUG
     Boost_IOSTREAMS_LIBRARY_RELEASE Boost_LIBRARY_DIR
@@ -83,3 +73,12 @@ process_feature(BOOST
     BOOST_IOSTREAMS_USABLE # clean up check in configure_boost.cmake
     BOOST_SERIALIZATION_USABLE # clean up check in configure_boost.cmake
   )
+
+if(BOOST_FOUND)
+  set(BOOST_VERSION_MAJOR "${Boost_MAJOR_VERSION}")
+  set(BOOST_VERSION_MINOR "${Boost_MINOR_VERSION}")
+  set(BOOST_VERSION_SUBMINOR "${Boost_SUBMINOR_VERSION}")
+  set(BOOST_VERSION
+    "${BOOST_VERSION_MAJOR}.${BOOST_VERSION_MINOR}.${BOOST_VERSION_SUBMINOR}"
+    )
+endif()

--- a/cmake/modules/FindDEAL_II_BOOST.cmake
+++ b/cmake/modules/FindDEAL_II_BOOST.cmake
@@ -41,13 +41,6 @@ if(NOT "${BOOST_DIR}" STREQUAL "")
   set(BOOST_ROOT "${BOOST_DIR}")
 endif()
 
-#
-# Prefer static libs if BUILD_SHARED_LIBS=OFF:
-#
-if(NOT BUILD_SHARED_LIBS)
-  set(Boost_USE_STATIC_LIBS TRUE)
-endif()
-
 # Work around a CMake compatibility issue with boost-1.70.0
 # compare https://gitlab.kitware.com/cmake/cmake/issues/18865
 # and https://lists.boost.org/Archives/boost/2019/02/245016.php
@@ -62,22 +55,6 @@ else()
   find_package(Boost ${BOOST_VERSION_REQUIRED} COMPONENTS
     serialization system thread
     )
-endif()
-
-#
-# Fall back to dynamic libraries if no static libraries could be found:
-#
-if(NOT Boost_FOUND AND Boost_USE_STATIC_LIBS)
-  set(Boost_USE_STATIC_LIBS FALSE)
-
-  # temporarily disable ${CMAKE_SOURCE_DIR}/cmake/modules for module lookup
-  list(REMOVE_ITEM CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
-  if(DEAL_II_WITH_ZLIB)
-    find_package(Boost ${BOOST_VERSION_REQUIRED} COMPONENTS iostreams serialization system thread)
-  else()
-    find_package(Boost ${BOOST_VERSION_REQUIRED} COMPONENTS serialization system thread)
-  endif()
-  list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
 endif()
 
 unset(Boost_NO_BOOST_CMAKE)


### PR DESCRIPTION
Depends on #15252 #15253 