### PR TITLE
Suppress 'requires' clauses for doxygen if doxygen is too old.

### DIFF
--- a/doc/doxygen/CMakeLists.txt
+++ b/doc/doxygen/CMakeLists.txt
@@ -32,6 +32,8 @@ if(NOT DOXYGEN_FOUND)
   message(FATAL_ERROR
     "Could not find doxygen which is required for building the documentation"
     )
+else()
+  message(STATUS "Using doxygen version ${DOXYGEN_VERSION}")
 endif()
 
 
@@ -282,6 +284,22 @@ if(NOT (${DOXYGEN_VERSION} VERSION_LESS 1.9))
     "
     )
   message(STATUS "Letting doxygen run with multiple threads")
+endif()
+
+
+# doxygen version 1.9.1 can not correctly parse C++20-style 'requires'
+# clauses and just drops certain classes and shows documentation for
+# DEAL_II_CXX20_REQUIRES instead. 1.9.7 gets this right, but has other
+# bugs. It's unclear for versions inbetween. Err on the safe side, and
+# only make them visible to doxygen if we have at least 1.9.8.
+if(${DOXYGEN_VERSION} VERSION_LESS 1.9.8)
+  message(STATUS "Suppressing 'requires' clause parsing because doxygen is too old")
+  file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/options.dox"
+    "
+    PREDEFINED += DEAL_II_DOXYGEN_DO_NOT_PARSE_REQUIRES_CLAUSES=1
+    PREDEFINED += DEAL_II_CXX20_REQUIRES(x)=
+    "
+    )
 endif()
 
 

--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -186,7 +186,6 @@ PREDEFINED             = DOXYGEN=1 \
                          DEAL_II_HOST_DEVICE= \
                          DEAL_II_ALWAYS_INLINE= \
                          __device__= \
-			 DEAL_II_CXX20_REQUIRES(x)= \
                          DEAL_II_WITH_ADOLC=1 \
                          DEAL_II_ADOLC_WITH_ADVANCED_BRANCHING=1 \
                          DEAL_II_ADOLC_WITH_ATRIG_ERF=1 \

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -156,7 +156,7 @@
  * define a convenience macro that allows us to write a 'requires'
  * clause that is simply removed when not using C++20.
  */
-#ifdef DEAL_II_HAVE_CXX20
+#if defined(DEAL_II_HAVE_CXX20) && !defined(DEAL_II_DOXYGEN_DO_NOT_PARSE_REQUIRES_CLAUSES)
 #  define DEAL_II_CXX20_REQUIRES(condition) requires(condition)
 #else
 #  define DEAL_II_CXX20_REQUIRES(condition)


### PR DESCRIPTION
Should hopefully fix #15234.