### PR TITLE
Make the PETSc TS interfaces conform to callback conventions.

### DIFF
--- a/include/deal.II/lac/petsc_ts.h
+++ b/include/deal.II/lac/petsc_ts.h
@@ -29,6 +29,8 @@
 
 #  include <petscts.h>
 
+#  include <exception>
+
 #  if defined(DEAL_II_HAVE_CXX20)
 #    include <concepts>
 #  endif
@@ -421,11 +423,19 @@ namespace PETScWrappers
 
     /**
      * Callback for the computation of the implicit residual $F(t, y, \dot y)$.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. PETSc's TS package can not deal
+     * with "recoverable" errors, so if a callback
+     * throws an exception of type RecoverableUserCallbackError, then this
+     * exception is treated like any other exception.
      */
-    std::function<int(const real_type   t,
-                      const VectorType &y,
-                      const VectorType &y_dot,
-                      VectorType &      res)>
+    std::function<void(const real_type   t,
+                       const VectorType &y,
+                       const VectorType &y_dot,
+                       VectorType &      res)>
       implicit_function;
 
     /**
@@ -436,29 +446,53 @@ namespace PETScWrappers
      * All implicit solvers implementations are recast to use the above
      * linearization. The $\alpha$ parameter is time-step and solver-type
      * specific.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. PETSc's TS package can not deal
+     * with "recoverable" errors, so if a callback
+     * throws an exception of type RecoverableUserCallbackError, then this
+     * exception is treated like any other exception.
      */
-    std::function<int(const real_type   t,
-                      const VectorType &y,
-                      const VectorType &y_dot,
-                      const real_type   alpha,
-                      AMatrixType &     A,
-                      PMatrixType &     P)>
+    std::function<void(const real_type   t,
+                       const VectorType &y,
+                       const VectorType &y_dot,
+                       const real_type   alpha,
+                       AMatrixType &     A,
+                       PMatrixType &     P)>
       implicit_jacobian;
 
     /**
      * Callback for the computation of the explicit residual $G(t, y)$.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. PETSc's TS package can not deal
+     * with "recoverable" errors, so if a callback
+     * throws an exception of type RecoverableUserCallbackError, then this
+     * exception is treated like any other exception.
      */
-    std::function<int(const real_type t, const VectorType &y, VectorType &res)>
+    std::function<void(const real_type t, const VectorType &y, VectorType &res)>
       explicit_function;
 
     /**
      * Callback for the computation of the explicit Jacobian $\dfrac{\partial
      * G}{\partial y}$.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. PETSc's TS package can not deal
+     * with "recoverable" errors, so if a callback
+     * throws an exception of type RecoverableUserCallbackError, then this
+     * exception is treated like any other exception.
      */
-    std::function<int(const real_type   t,
-                      const VectorType &y,
-                      AMatrixType &     A,
-                      PMatrixType &     P)>
+    std::function<void(const real_type   t,
+                       const VectorType &y,
+                       AMatrixType &     A,
+                       PMatrixType &     P)>
       explicit_jacobian;
 
     /**
@@ -466,10 +500,18 @@ namespace PETScWrappers
      *
      * This function is called by TimeStepper at the beginning
      * of each time step.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. PETSc's TS package can not deal
+     * with "recoverable" errors, so if a callback
+     * throws an exception of type RecoverableUserCallbackError, then this
+     * exception is treated like any other exception.
      */
-    std::function<int(const real_type    t,
-                      const VectorType & y,
-                      const unsigned int step_number)>
+    std::function<void(const real_type    t,
+                       const VectorType & y,
+                       const unsigned int step_number)>
       monitor;
 
     /**
@@ -485,11 +527,19 @@ namespace PETScWrappers
      * specific.
      *
      * Solvers must be provided via TimeStepper::solve_with_jacobian.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. PETSc's TS package can not deal
+     * with "recoverable" errors, so if a callback
+     * throws an exception of type RecoverableUserCallbackError, then this
+     * exception is treated like any other exception.
      */
-    std::function<int(const real_type   t,
-                      const VectorType &y,
-                      const VectorType &ydot,
-                      const real_type   alpha)>
+    std::function<void(const real_type   t,
+                       const VectorType &y,
+                       const VectorType &ydot,
+                       const real_type   alpha)>
       setup_jacobian;
 
     /**
@@ -497,8 +547,16 @@ namespace PETScWrappers
      * TimeStepper::setup_jacobian.
      *
      * This is used as a preconditioner inside the Krylov process.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. PETSc's TS package can not deal
+     * with "recoverable" errors, so if a callback
+     * throws an exception of type RecoverableUserCallbackError, then this
+     * exception is treated like any other exception.
      */
-    std::function<int(const VectorType &src, VectorType &dst)>
+    std::function<void(const VectorType &src, VectorType &dst)>
       solve_with_jacobian;
 
     /**
@@ -529,6 +587,13 @@ namespace PETScWrappers
      * This flag is used to support versions of PETSc older than 3.13.
      */
     bool need_dummy_assemble;
+
+    /**
+     * A pointer to any exception that may have been thrown in user-defined
+     * call-backs and that we have to deal after the KINSOL function we call
+     * has returned.
+     */
+    mutable std::exception_ptr pending_exception;
   };
 
 } // namespace PETScWrappers

--- a/include/deal.II/lac/petsc_ts.templates.h
+++ b/include/deal.II/lac/petsc_ts.templates.h
@@ -664,7 +664,6 @@ namespace PETScWrappers
 } // namespace PETScWrappers
 
 #  undef AssertPETSc
-#  undef AssertUser
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/include/deal.II/lac/petsc_ts.templates.h
+++ b/include/deal.II/lac/petsc_ts.templates.h
@@ -38,24 +38,56 @@ DEAL_II_NAMESPACE_OPEN
       }                                              \
     while (0)
 
-// Shorthand notation for User error codes.
-#  define AssertUser(code, name)                                               \
-    do                                                                         \
-      {                                                                        \
-        int ierr = (code);                                                     \
-        AssertThrow(ierr == 0,                                                 \
-                    StandardExceptions::ExcFunctionNonzeroReturn(name, ierr)); \
-      }                                                                        \
-    while (0)
-
 namespace PETScWrappers
 {
+  namespace
+  {
+    /**
+     * A function that calls the function object given by its first argument
+     * with the set of arguments following at the end. If the call returns
+     * regularly, the current function returns zero to indicate success. If
+     * the call fails with an exception, then the current function returns with
+     * an error code of -1. In that case, the exception thrown by `f` is
+     * captured and `eptr` is set to the exception. In case of success,
+     * `eptr` is set to `nullptr`.
+     */
+    template <typename F, typename... Args>
+    int
+    call_and_possibly_capture_exception(const F &           f,
+                                        std::exception_ptr &eptr,
+                                        Args &&...args)
+    {
+      // See whether there is already something in the exception pointer
+      // variable. There is no reason why this should be so, and
+      // we should probably bail out:
+      AssertThrow(eptr == nullptr, ExcInternalError());
+
+      // Call the function and if that succeeds, return zero:
+      try
+        {
+          f(std::forward<Args>(args)...);
+          eptr = nullptr;
+          return 0;
+        }
+      // In case of an exception, capture the exception and
+      // return -1:
+      catch (...)
+        {
+          eptr = std::current_exception();
+          return -1;
+        }
+    }
+  } // namespace
+
+
+
   template <typename VectorType, typename PMatrixType, typename AMatrixType>
   DEAL_II_CXX20_REQUIRES((concepts::is_dealii_petsc_vector_type<VectorType> ||
                           std::constructible_from<VectorType, Vec>))
   TimeStepper<VectorType, PMatrixType, AMatrixType>::TimeStepper(
     const TimeStepperData &data,
     const MPI_Comm         mpi_comm)
+    : pending_exception(nullptr)
   {
     AssertPETSc(TSCreate(mpi_comm, &ts));
     AssertPETSc(TSSetApplicationContext(ts, this));
@@ -70,6 +102,8 @@ namespace PETScWrappers
   TimeStepper<VectorType, PMatrixType, AMatrixType>::~TimeStepper()
   {
     AssertPETSc(TSDestroy(&ts));
+
+    Assert(pending_exception == nullptr, ExcInternalError());
   }
 
 
@@ -252,10 +286,15 @@ namespace PETScWrappers
       VectorType xdealii(x);
       VectorType xdotdealii(xdot);
       VectorType fdealii(f);
-      AssertUser(user->implicit_function(t, xdealii, xdotdealii, fdealii),
-                 "implicit_function");
+      const int  err =
+        call_and_possibly_capture_exception(user->implicit_function,
+                                            user->pending_exception,
+                                            t,
+                                            xdealii,
+                                            xdotdealii,
+                                            fdealii);
       petsc_increment_state_counter(f);
-      PetscFunctionReturn(0);
+      PetscFunctionReturn(err);
     };
 
     const auto ts_ijacobian =
@@ -269,9 +308,16 @@ namespace PETScWrappers
       AMatrixType Adealii(A);
       PMatrixType Pdealii(P);
 
-      AssertUser(
-        user->implicit_jacobian(t, xdealii, xdotdealii, s, Adealii, Pdealii),
-        "implicit_jacobian");
+      const int err =
+        call_and_possibly_capture_exception(user->implicit_jacobian,
+                                            user->pending_exception,
+                                            t,
+                                            xdealii,
+                                            xdotdealii,
+                                            s,
+                                            Adealii,
+                                            Pdealii);
+
       petsc_increment_state_counter(P);
 
       // Handle the Jacobian-free case
@@ -286,7 +332,8 @@ namespace PETScWrappers
         }
       else
         petsc_increment_state_counter(A);
-      PetscFunctionReturn(0);
+
+      PetscFunctionReturn(err);
     };
 
     const auto ts_ijacobian_with_setup =
@@ -302,8 +349,14 @@ namespace PETScWrappers
 
       user->A = &Adealii;
       user->P = &Pdealii;
-      AssertUser(user->setup_jacobian(t, xdealii, xdotdealii, s),
-                 "setup_jacobian");
+      const int err =
+        call_and_possibly_capture_exception(user->setup_jacobian,
+                                            user->pending_exception,
+                                            t,
+                                            xdealii,
+                                            xdotdealii,
+                                            s);
+
       petsc_increment_state_counter(P);
 
       // Handle older versions of PETSc for which we cannot pass a MATSHELL
@@ -330,7 +383,8 @@ namespace PETScWrappers
         }
       else
         petsc_increment_state_counter(A);
-      PetscFunctionReturn(0);
+
+      PetscFunctionReturn(err);
     };
 
     const auto ts_rhsfunction =
@@ -341,10 +395,10 @@ namespace PETScWrappers
       VectorType xdealii(x);
       VectorType fdealii(f);
 
-      AssertUser(user->explicit_function(t, xdealii, fdealii),
-                 "explicit_function");
+      const int err = call_and_possibly_capture_exception(
+        user->explicit_function, user->pending_exception, t, xdealii, fdealii);
       petsc_increment_state_counter(f);
-      PetscFunctionReturn(0);
+      PetscFunctionReturn(err);
     };
 
     const auto ts_rhsjacobian =
@@ -356,8 +410,14 @@ namespace PETScWrappers
       AMatrixType Adealii(A);
       PMatrixType Pdealii(P);
 
-      AssertUser(user->explicit_jacobian(t, xdealii, Adealii, Pdealii),
-                 "explicit_jacobian");
+      const int err =
+        call_and_possibly_capture_exception(user->explicit_jacobian,
+                                            user->pending_exception,
+                                            t,
+                                            xdealii,
+                                            Adealii,
+                                            Pdealii);
+
       petsc_increment_state_counter(P);
 
       // Handle older versions of PETSc for which we cannot pass a MATSHELL
@@ -382,7 +442,8 @@ namespace PETScWrappers
         }
       else
         petsc_increment_state_counter(A);
-      PetscFunctionReturn(0);
+
+      PetscFunctionReturn(err);
     };
 
     const auto ts_monitor =
@@ -391,8 +452,9 @@ namespace PETScWrappers
       auto user = static_cast<TimeStepper *>(ctx);
 
       VectorType xdealii(x);
-      AssertUser(user->monitor(t, xdealii, it), "monitor");
-      PetscFunctionReturn(0);
+      const int  err = call_and_possibly_capture_exception(
+        user->monitor, user->pending_exception, t, xdealii, it);
+      PetscFunctionReturn(err);
     };
 
     AssertThrow(explicit_function || implicit_function,
@@ -482,7 +544,10 @@ namespace PETScWrappers
         precond.vmult = [&](VectorBase &indst, const VectorBase &insrc) -> int {
           VectorType       dst(static_cast<const Vec &>(indst));
           const VectorType src(static_cast<const Vec &>(insrc));
-          return solve_with_jacobian(src, dst);
+          return call_and_possibly_capture_exception(solve_with_jacobian,
+                                                     pending_exception,
+                                                     src,
+                                                     dst);
         };
 
         // Default Krylov solver (preconditioner only)
@@ -528,8 +593,31 @@ namespace PETScWrappers
       }
 
     // Having set everything up, now do the actual work
-    // and let PETSc do the time stepping.
-    AssertPETSc(TSSolve(ts, nullptr));
+    // and let PETSc do the time stepping. If there is
+    // a pending exception, then one of the user callbacks
+    // threw an exception we didn't know how to deal with
+    // at the time. It is possible that PETSc managed to
+    // recover anyway and in that case would have returned
+    // a zero error code -- if so, just eat the exception and
+    // continue on; otherwise, just rethrow the exception
+    // and get outta here.
+    const int status = TSSolve(ts, nullptr);
+    if (pending_exception)
+      {
+        try
+          {
+            std::rethrow_exception(pending_exception);
+          }
+        catch (...)
+          {
+            pending_exception = nullptr;
+            if (status == 0)
+              /* just eat the exception */;
+            else
+              throw;
+          }
+      }
+    AssertPETSc(status);
 
     // Get the number of steps taken.
     auto nt = ts_get_step_number(ts);

--- a/include/deal.II/trilinos/nox.templates.h
+++ b/include/deal.II/trilinos/nox.templates.h
@@ -49,9 +49,9 @@ namespace TrilinosWrappers
          * A function that calls the function object given by its first argument
          * with the set of arguments following at the end. If the call returns
          * regularly, the current function returns zero to indicate success. If
-         * the call fails with an, then the current function returns with an
-         * error code of -1. In that case, the exception thrown by `f` is
-         * captured and `eptr` is set to the exception. In case of success,
+         * the call fails with an exception, then the current function returns
+         * with an error code of -1. In that case, the exception thrown by `f`
+         * is captured and `eptr` is set to the exception. In case of success,
          * `eptr` is set to `nullptr`.
          */
         template <typename F, typename... Args>

--- a/tests/petsc/petsc_ts_01.cc
+++ b/tests/petsc/petsc_ts_01.cc
@@ -83,5 +83,4 @@ main(int argc, char **argv)
     {
       deallog << exc.what() << std::endl;
     }
-  return 0;
 }

--- a/tests/petsc/petsc_ts_02.cc
+++ b/tests/petsc/petsc_ts_02.cc
@@ -47,11 +47,10 @@ public:
     implicit_function = [&](const real_type   t,
                             const VectorType &y,
                             const VectorType &y_dot,
-                            VectorType &      res) -> int {
+                            VectorType &      res) -> void {
       res(0) = y_dot(0) - y(0);
       res(1) = y(1) - y(0);
       res.compress(VectorOperation::insert);
-      return 0;
     };
 
     // Return the index set representing the
@@ -86,5 +85,4 @@ main(int argc, char **argv)
 
   Dummy dae;
   dae.solve();
-  return 0;
 }

--- a/tests/petsc/petsc_ts_03.cc
+++ b/tests/petsc/petsc_ts_03.cc
@@ -1,0 +1,241 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2023 by the deal.II authors
+//
+//    This file is part of the deal.II library.
+//
+//    The deal.II library is free software; you can use it, redistribute
+//    it, and/or modify it under the terms of the GNU Lesser General
+//    Public License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//    The full text of the license can be found in the file LICENSE.md at
+//    the top level directory of deal.II.
+//
+//-----------------------------------------------------------
+
+#include <deal.II/base/parameter_handler.h>
+
+#include <deal.II/lac/petsc_matrix_base.h>
+#include <deal.II/lac/petsc_ts.h>
+#include <deal.II/lac/petsc_vector.h>
+
+#include <cmath>
+
+#include "../tests.h"
+
+/**
+ * Solves the equations of exponential decay:
+ *
+ * u' = -k u
+ * u (t0) = 1
+ *
+ * using the PETScWrappers::TimeStepper class
+ * that interfaces PETSc TS ODE solver object.
+ * The ODE can be an EXPLICIT first order ode:
+ *
+ * y[0]' = - k   y[0]     -> y' = G(y,t)
+ *
+ * or specified in IMPLICIT form:
+ *
+ * y[0]' +  k  y[1]  = 0  -> F(y',y,t) = 0
+ *
+ * The exact solution is, in either case,
+ *
+ * y[0](t) = exp(-kt)
+ *
+ * We use the same class to test both formulations.
+ * The class also supports a third approach where
+ * control for linear systems generation and
+ * solution is completely on users. In this case
+ * users are in charge of solving for the
+ * implicit Jacobian.
+ * The model used to wrap PETSc's TS is the same
+ * used for the nonlinear solver SNES. Check
+ * petsc_snes_00.cc for additional information.
+ *
+ */
+using VectorType  = PETScWrappers::MPI::Vector;
+using MatrixType  = PETScWrappers::MatrixBase;
+using TimeStepper = PETScWrappers::TimeStepper<VectorType, MatrixType>;
+using real_type   = TimeStepper::real_type;
+
+class HarmonicOscillator
+{
+public:
+  HarmonicOscillator(real_type                                      _kappa,
+                     const typename PETScWrappers::TimeStepperData &data,
+                     bool                                           setjac,
+                     bool                                           implicit,
+                     bool                                           user)
+    : time_stepper(data)
+    , kappa(_kappa)
+  {
+    // In this case we use the implicit form
+    if (implicit)
+      {
+        time_stepper.implicit_function = [&](const real_type   t,
+                                             const VectorType &y,
+                                             const VectorType &y_dot,
+                                             VectorType &      res) -> void {
+          deallog << "Evaluating implicit function at t=" << t << std::endl;
+          res(0) = y_dot(0) + kappa * y(0);
+          res.compress(VectorOperation::insert);
+        };
+
+        // We either have the possibility of using PETSc standard
+        // functionalities for Jacobian setup and solve, or take full control of
+        // the Jacobian solutions. The latter aligns more with deal.II tutorials
+        // For our testing class, 'user' discriminate between those two
+        // approaches.
+        if (!user && setjac)
+          {
+            // Callback for Jacobian evaluation
+            // This callback populates the P matrix with
+            //     shift * dF/dydot + dF/dy
+            // A and P are the same matrix if not otherwise specified
+            // PETSc can compute a Jacobian by finite-differencing the residual
+            // evaluation, and it can be selected at command line.
+            time_stepper.implicit_jacobian = [&](const real_type   t,
+                                                 const VectorType &y,
+                                                 const VectorType &y_dot,
+                                                 const real_type   shift,
+                                                 MatrixType &      A,
+                                                 MatrixType &      P) -> void {
+              deallog << "Evaluating implicit Jacobian at t=" << t << std::endl;
+              P.set(0, 0, shift + kappa);
+              P.compress(VectorOperation::insert);
+            };
+          }
+        else if (user)
+          {
+            // In this code block, users are completely in charge of
+            // setting up the Jacobian system and solve for it.
+            // In this example we only store the solver shift
+            // during setup.
+            time_stepper.setup_jacobian = [&](const real_type   t,
+                                              const VectorType &y,
+                                              const VectorType &y_dot,
+                                              const real_type   shift) -> void {
+              deallog << "Setting up Jacobian at t=" << t << std::endl;
+              myshift = shift;
+            };
+
+            // In the solve phase we se the stored shift to solve
+            // for the implicit Jacobian system
+            time_stepper.solve_with_jacobian = [&](const VectorType &src,
+                                                   VectorType &dst) -> void {
+              deallog << "Solving with Jacobian" << std::endl;
+              dst(0) = src(0) / (myshift + kappa);
+              dst.compress(VectorOperation::insert);
+            };
+          }
+      }
+    else
+      { // Here we instead use the explicit form
+        // This is the only function one would populate in case an explicit
+        // solver is used.
+        time_stepper.explicit_function =
+          [&](const real_type t, const VectorType &y, VectorType &res) -> void {
+          deallog << "Evaluating explicit function at t=" << t << std::endl;
+          res(0) = -kappa * y(0);
+          res.compress(VectorOperation::insert);
+        };
+
+        // The explicit Jacobian callback is not needed in case
+        // an explicit solver is used. We need it when moving to
+        // an implicit solver like in the parameter file used for
+        // this test
+        if (setjac)
+          {
+            time_stepper.explicit_jacobian = [&](const real_type   t,
+                                                 const VectorType &y,
+                                                 MatrixType &      A,
+                                                 MatrixType &      P) -> void {
+              deallog << "Evaluating explicit Jacobian at t=" << t << std::endl;
+              P.set(0, 0, -kappa);
+              P.compress(VectorOperation::insert);
+            };
+          }
+      }
+
+    // Monitoring routine. Here we print diagnostic for the exact
+    // solution to the log file.
+    time_stepper.monitor = [&](const real_type   t,
+                               const VectorType &sol,
+                               const unsigned int /*step_number*/) -> void {
+      deallog << "Intermediate output:" << std::endl;
+      deallog << "  t =" << t << std::endl;
+      deallog << "  y =" << sol[0] << "  (exact: " << std::exp(-kappa * t)
+              << ')' << std::endl;
+    };
+  }
+
+  void
+  run()
+  {
+    // Set initial conditions
+    // This test uses a nonzero initial time
+    // We can access the time value with the
+    // get_time method
+    auto t = time_stepper.get_time();
+
+    VectorType y(MPI_COMM_SELF, 1, 1);
+    y[0] = 1;
+    y.compress(VectorOperation::insert);
+
+    // Integrate the ODE.
+    auto nt = time_stepper.solve(y);
+    deallog << "# Number of steps taken: " << nt << std::endl;
+  }
+
+private:
+  TimeStepper time_stepper;
+  real_type   kappa;   // Defines the oscillator
+  real_type   myshift; // Used by the user solve
+};
+
+
+int
+main(int argc, char **argv)
+{
+  initlog();
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  PETScWrappers::TimeStepperData data;
+  ParameterHandler               prm;
+
+  data.add_parameters(prm);
+  deallog << "# Default Parameters" << std::endl;
+  prm.print_parameters(deallog.get_file_stream(), ParameterHandler::ShortText);
+
+  std::ifstream ifile(SOURCE_DIR "/petsc_ts_03_in.prm");
+  prm.parse_input(ifile);
+
+  deallog << "# Testing Parameters" << std::endl;
+  prm.print_parameters(deallog.get_file_stream(), ParameterHandler::ShortText);
+
+  for (int setjaci = 0; setjaci < 2; setjaci++)
+    {
+      bool setjac = setjaci ? true : false;
+
+      {
+        deallog << "# Test explicit interface (J " << setjac << ")"
+                << std::endl;
+        HarmonicOscillator ode_expl(1.0, data, setjac, false, false);
+        ode_expl.run();
+      }
+
+      {
+        deallog << "# Test implicit interface (J " << setjac << ")"
+                << std::endl;
+        HarmonicOscillator ode_impl(1.0, data, setjac, true, false);
+        ode_impl.run();
+      }
+    }
+
+  {
+    deallog << "# Test user interface" << std::endl;
+    HarmonicOscillator ode_user(1.0, data, true, true, true);
+    ode_user.run();
+  }
+}

--- a/tests/petsc/petsc_ts_03.output
+++ b/tests/petsc/petsc_ts_03.output
@@ -1,0 +1,455 @@
+
+DEAL::# Default Parameters
+subsection Error control
+  set absolute error tolerance = -1
+  set adaptor type             = none
+  set ignore algebraic lte     = true
+  set maximum step size        = -1
+  set minimum step size        = -1
+  set relative error tolerance = -1
+end
+subsection Running parameters
+  set final time              = 0
+  set initial step size       = 0
+  set initial time            = 0
+  set match final time        = false
+  set maximum number of steps = -1
+  set options prefix          = 
+  set solver type             = 
+end
+DEAL::# Testing Parameters
+subsection Error control
+  set absolute error tolerance = 0.0001
+  set adaptor type             = none
+  set ignore algebraic lte     = true
+  set maximum step size        = 1e+7
+  set minimum step size        = 1e-7
+  set relative error tolerance = -1
+end
+subsection Running parameters
+  set final time              = 2.0
+  set initial step size       = 0.2
+  set initial time            = 0
+  set match final time        = false
+  set maximum number of steps = -1
+  set options prefix          = 
+  set solver type             = bdf
+end
+DEAL::# Test explicit interface (J 0)
+DEAL::Intermediate output:
+DEAL::  t =0.00000
+DEAL::  y =1.00000  (exact: 1.00000)
+DEAL::Evaluating explicit function at t=0.100000
+DEAL::Evaluating explicit function at t=0.100000
+DEAL::Evaluating explicit function at t=0.100000
+DEAL::Evaluating explicit function at t=0.100000
+DEAL::Evaluating explicit function at t=0.200000
+DEAL::Evaluating explicit function at t=0.200000
+DEAL::Evaluating explicit function at t=0.200000
+DEAL::Evaluating explicit function at t=0.200000
+DEAL::Intermediate output:
+DEAL::  t =0.200000
+DEAL::  y =0.823864  (exact: 0.818731)
+DEAL::Evaluating explicit function at t=0.400000
+DEAL::Evaluating explicit function at t=0.400000
+DEAL::Evaluating explicit function at t=0.400000
+DEAL::Evaluating explicit function at t=0.400000
+DEAL::Intermediate output:
+DEAL::  t =0.400000
+DEAL::  y =0.675134  (exact: 0.670320)
+DEAL::Evaluating explicit function at t=0.600000
+DEAL::Evaluating explicit function at t=0.600000
+DEAL::Evaluating explicit function at t=0.600000
+DEAL::Evaluating explicit function at t=0.600000
+DEAL::Intermediate output:
+DEAL::  t =0.600000
+DEAL::  y =0.551962  (exact: 0.548812)
+DEAL::Evaluating explicit function at t=0.800000
+DEAL::Evaluating explicit function at t=0.800000
+DEAL::Evaluating explicit function at t=0.800000
+DEAL::Evaluating explicit function at t=0.800000
+DEAL::Intermediate output:
+DEAL::  t =0.800000
+DEAL::  y =0.450798  (exact: 0.449329)
+DEAL::Evaluating explicit function at t=1.00000
+DEAL::Evaluating explicit function at t=1.00000
+DEAL::Evaluating explicit function at t=1.00000
+DEAL::Evaluating explicit function at t=1.00000
+DEAL::Intermediate output:
+DEAL::  t =1.00000
+DEAL::  y =0.368009  (exact: 0.367879)
+DEAL::Evaluating explicit function at t=1.20000
+DEAL::Evaluating explicit function at t=1.20000
+DEAL::Evaluating explicit function at t=1.20000
+DEAL::Evaluating explicit function at t=1.20000
+DEAL::Intermediate output:
+DEAL::  t =1.20000
+DEAL::  y =0.300364  (exact: 0.301194)
+DEAL::Evaluating explicit function at t=1.40000
+DEAL::Evaluating explicit function at t=1.40000
+DEAL::Evaluating explicit function at t=1.40000
+DEAL::Evaluating explicit function at t=1.40000
+DEAL::Intermediate output:
+DEAL::  t =1.40000
+DEAL::  y =0.245132  (exact: 0.246597)
+DEAL::Evaluating explicit function at t=1.60000
+DEAL::Evaluating explicit function at t=1.60000
+DEAL::Evaluating explicit function at t=1.60000
+DEAL::Evaluating explicit function at t=1.60000
+DEAL::Intermediate output:
+DEAL::  t =1.60000
+DEAL::  y =0.200048  (exact: 0.201897)
+DEAL::Evaluating explicit function at t=1.80000
+DEAL::Evaluating explicit function at t=1.80000
+DEAL::Evaluating explicit function at t=1.80000
+DEAL::Evaluating explicit function at t=1.80000
+DEAL::Intermediate output:
+DEAL::  t =1.80000
+DEAL::  y =0.163253  (exact: 0.165299)
+DEAL::Evaluating explicit function at t=2.00000
+DEAL::Evaluating explicit function at t=2.00000
+DEAL::Evaluating explicit function at t=2.00000
+DEAL::Evaluating explicit function at t=2.00000
+DEAL::Intermediate output:
+DEAL::  t =2.00000
+DEAL::  y =0.133225  (exact: 0.135335)
+DEAL::Evaluating explicit function at t=2.20000
+DEAL::Evaluating explicit function at t=2.20000
+DEAL::Evaluating explicit function at t=2.20000
+DEAL::Evaluating explicit function at t=2.20000
+DEAL::Intermediate output:
+DEAL::  t =2.20000
+DEAL::  y =0.108719  (exact: 0.110803)
+DEAL::# Number of steps taken: 11
+DEAL::# Test implicit interface (J 0)
+DEAL::Intermediate output:
+DEAL::  t =0.00000
+DEAL::  y =1.00000  (exact: 1.00000)
+DEAL::Evaluating implicit function at t=0.100000
+DEAL::Evaluating implicit function at t=0.100000
+DEAL::Evaluating implicit function at t=0.100000
+DEAL::Evaluating implicit function at t=0.100000
+DEAL::Evaluating implicit function at t=0.200000
+DEAL::Evaluating implicit function at t=0.200000
+DEAL::Evaluating implicit function at t=0.200000
+DEAL::Evaluating implicit function at t=0.200000
+DEAL::Intermediate output:
+DEAL::  t =0.200000
+DEAL::  y =0.823864  (exact: 0.818731)
+DEAL::Evaluating implicit function at t=0.400000
+DEAL::Evaluating implicit function at t=0.400000
+DEAL::Evaluating implicit function at t=0.400000
+DEAL::Evaluating implicit function at t=0.400000
+DEAL::Intermediate output:
+DEAL::  t =0.400000
+DEAL::  y =0.675134  (exact: 0.670320)
+DEAL::Evaluating implicit function at t=0.600000
+DEAL::Evaluating implicit function at t=0.600000
+DEAL::Evaluating implicit function at t=0.600000
+DEAL::Evaluating implicit function at t=0.600000
+DEAL::Intermediate output:
+DEAL::  t =0.600000
+DEAL::  y =0.551962  (exact: 0.548812)
+DEAL::Evaluating implicit function at t=0.800000
+DEAL::Evaluating implicit function at t=0.800000
+DEAL::Evaluating implicit function at t=0.800000
+DEAL::Evaluating implicit function at t=0.800000
+DEAL::Intermediate output:
+DEAL::  t =0.800000
+DEAL::  y =0.450798  (exact: 0.449329)
+DEAL::Evaluating implicit function at t=1.00000
+DEAL::Evaluating implicit function at t=1.00000
+DEAL::Evaluating implicit function at t=1.00000
+DEAL::Evaluating implicit function at t=1.00000
+DEAL::Intermediate output:
+DEAL::  t =1.00000
+DEAL::  y =0.368009  (exact: 0.367879)
+DEAL::Evaluating implicit function at t=1.20000
+DEAL::Evaluating implicit function at t=1.20000
+DEAL::Evaluating implicit function at t=1.20000
+DEAL::Evaluating implicit function at t=1.20000
+DEAL::Intermediate output:
+DEAL::  t =1.20000
+DEAL::  y =0.300364  (exact: 0.301194)
+DEAL::Evaluating implicit function at t=1.40000
+DEAL::Evaluating implicit function at t=1.40000
+DEAL::Evaluating implicit function at t=1.40000
+DEAL::Evaluating implicit function at t=1.40000
+DEAL::Intermediate output:
+DEAL::  t =1.40000
+DEAL::  y =0.245132  (exact: 0.246597)
+DEAL::Evaluating implicit function at t=1.60000
+DEAL::Evaluating implicit function at t=1.60000
+DEAL::Evaluating implicit function at t=1.60000
+DEAL::Evaluating implicit function at t=1.60000
+DEAL::Intermediate output:
+DEAL::  t =1.60000
+DEAL::  y =0.200048  (exact: 0.201897)
+DEAL::Evaluating implicit function at t=1.80000
+DEAL::Evaluating implicit function at t=1.80000
+DEAL::Evaluating implicit function at t=1.80000
+DEAL::Evaluating implicit function at t=1.80000
+DEAL::Intermediate output:
+DEAL::  t =1.80000
+DEAL::  y =0.163253  (exact: 0.165299)
+DEAL::Evaluating implicit function at t=2.00000
+DEAL::Evaluating implicit function at t=2.00000
+DEAL::Evaluating implicit function at t=2.00000
+DEAL::Evaluating implicit function at t=2.00000
+DEAL::Intermediate output:
+DEAL::  t =2.00000
+DEAL::  y =0.133225  (exact: 0.135335)
+DEAL::Evaluating implicit function at t=2.20000
+DEAL::Evaluating implicit function at t=2.20000
+DEAL::Evaluating implicit function at t=2.20000
+DEAL::Evaluating implicit function at t=2.20000
+DEAL::Intermediate output:
+DEAL::  t =2.20000
+DEAL::  y =0.108719  (exact: 0.110803)
+DEAL::# Number of steps taken: 11
+DEAL::# Test explicit interface (J 1)
+DEAL::Intermediate output:
+DEAL::  t =0.00000
+DEAL::  y =1.00000  (exact: 1.00000)
+DEAL::Evaluating explicit function at t=0.100000
+DEAL::Evaluating explicit Jacobian at t=0.100000
+DEAL::Evaluating explicit function at t=0.100000
+DEAL::Evaluating explicit function at t=0.200000
+DEAL::Evaluating explicit Jacobian at t=0.200000
+DEAL::Evaluating explicit function at t=0.200000
+DEAL::Intermediate output:
+DEAL::  t =0.200000
+DEAL::  y =0.823864  (exact: 0.818731)
+DEAL::Evaluating explicit function at t=0.400000
+DEAL::Evaluating explicit Jacobian at t=0.400000
+DEAL::Evaluating explicit function at t=0.400000
+DEAL::Intermediate output:
+DEAL::  t =0.400000
+DEAL::  y =0.675134  (exact: 0.670320)
+DEAL::Evaluating explicit function at t=0.600000
+DEAL::Evaluating explicit Jacobian at t=0.600000
+DEAL::Evaluating explicit function at t=0.600000
+DEAL::Intermediate output:
+DEAL::  t =0.600000
+DEAL::  y =0.551962  (exact: 0.548812)
+DEAL::Evaluating explicit function at t=0.800000
+DEAL::Evaluating explicit Jacobian at t=0.800000
+DEAL::Evaluating explicit function at t=0.800000
+DEAL::Intermediate output:
+DEAL::  t =0.800000
+DEAL::  y =0.450798  (exact: 0.449329)
+DEAL::Evaluating explicit function at t=1.00000
+DEAL::Evaluating explicit Jacobian at t=1.00000
+DEAL::Evaluating explicit function at t=1.00000
+DEAL::Intermediate output:
+DEAL::  t =1.00000
+DEAL::  y =0.368009  (exact: 0.367879)
+DEAL::Evaluating explicit function at t=1.20000
+DEAL::Evaluating explicit Jacobian at t=1.20000
+DEAL::Evaluating explicit function at t=1.20000
+DEAL::Intermediate output:
+DEAL::  t =1.20000
+DEAL::  y =0.300364  (exact: 0.301194)
+DEAL::Evaluating explicit function at t=1.40000
+DEAL::Evaluating explicit Jacobian at t=1.40000
+DEAL::Evaluating explicit function at t=1.40000
+DEAL::Intermediate output:
+DEAL::  t =1.40000
+DEAL::  y =0.245132  (exact: 0.246597)
+DEAL::Evaluating explicit function at t=1.60000
+DEAL::Evaluating explicit Jacobian at t=1.60000
+DEAL::Evaluating explicit function at t=1.60000
+DEAL::Intermediate output:
+DEAL::  t =1.60000
+DEAL::  y =0.200048  (exact: 0.201897)
+DEAL::Evaluating explicit function at t=1.80000
+DEAL::Evaluating explicit Jacobian at t=1.80000
+DEAL::Evaluating explicit function at t=1.80000
+DEAL::Intermediate output:
+DEAL::  t =1.80000
+DEAL::  y =0.163253  (exact: 0.165299)
+DEAL::Evaluating explicit function at t=2.00000
+DEAL::Evaluating explicit Jacobian at t=2.00000
+DEAL::Evaluating explicit function at t=2.00000
+DEAL::Intermediate output:
+DEAL::  t =2.00000
+DEAL::  y =0.133225  (exact: 0.135335)
+DEAL::Evaluating explicit function at t=2.20000
+DEAL::Evaluating explicit Jacobian at t=2.20000
+DEAL::Evaluating explicit function at t=2.20000
+DEAL::Intermediate output:
+DEAL::  t =2.20000
+DEAL::  y =0.108719  (exact: 0.110803)
+DEAL::# Number of steps taken: 11
+DEAL::# Test implicit interface (J 1)
+DEAL::Intermediate output:
+DEAL::  t =0.00000
+DEAL::  y =1.00000  (exact: 1.00000)
+DEAL::Evaluating implicit function at t=0.100000
+DEAL::Evaluating implicit Jacobian at t=0.100000
+DEAL::Evaluating implicit function at t=0.100000
+DEAL::Evaluating implicit function at t=0.200000
+DEAL::Evaluating implicit Jacobian at t=0.200000
+DEAL::Evaluating implicit function at t=0.200000
+DEAL::Intermediate output:
+DEAL::  t =0.200000
+DEAL::  y =0.823864  (exact: 0.818731)
+DEAL::Evaluating implicit function at t=0.400000
+DEAL::Evaluating implicit Jacobian at t=0.400000
+DEAL::Evaluating implicit function at t=0.400000
+DEAL::Intermediate output:
+DEAL::  t =0.400000
+DEAL::  y =0.675134  (exact: 0.670320)
+DEAL::Evaluating implicit function at t=0.600000
+DEAL::Evaluating implicit Jacobian at t=0.600000
+DEAL::Evaluating implicit function at t=0.600000
+DEAL::Intermediate output:
+DEAL::  t =0.600000
+DEAL::  y =0.551962  (exact: 0.548812)
+DEAL::Evaluating implicit function at t=0.800000
+DEAL::Evaluating implicit Jacobian at t=0.800000
+DEAL::Evaluating implicit function at t=0.800000
+DEAL::Intermediate output:
+DEAL::  t =0.800000
+DEAL::  y =0.450798  (exact: 0.449329)
+DEAL::Evaluating implicit function at t=1.00000
+DEAL::Evaluating implicit Jacobian at t=1.00000
+DEAL::Evaluating implicit function at t=1.00000
+DEAL::Intermediate output:
+DEAL::  t =1.00000
+DEAL::  y =0.368009  (exact: 0.367879)
+DEAL::Evaluating implicit function at t=1.20000
+DEAL::Evaluating implicit Jacobian at t=1.20000
+DEAL::Evaluating implicit function at t=1.20000
+DEAL::Intermediate output:
+DEAL::  t =1.20000
+DEAL::  y =0.300364  (exact: 0.301194)
+DEAL::Evaluating implicit function at t=1.40000
+DEAL::Evaluating implicit Jacobian at t=1.40000
+DEAL::Evaluating implicit function at t=1.40000
+DEAL::Intermediate output:
+DEAL::  t =1.40000
+DEAL::  y =0.245132  (exact: 0.246597)
+DEAL::Evaluating implicit function at t=1.60000
+DEAL::Evaluating implicit Jacobian at t=1.60000
+DEAL::Evaluating implicit function at t=1.60000
+DEAL::Intermediate output:
+DEAL::  t =1.60000
+DEAL::  y =0.200048  (exact: 0.201897)
+DEAL::Evaluating implicit function at t=1.80000
+DEAL::Evaluating implicit Jacobian at t=1.80000
+DEAL::Evaluating implicit function at t=1.80000
+DEAL::Intermediate output:
+DEAL::  t =1.80000
+DEAL::  y =0.163253  (exact: 0.165299)
+DEAL::Evaluating implicit function at t=2.00000
+DEAL::Evaluating implicit Jacobian at t=2.00000
+DEAL::Evaluating implicit function at t=2.00000
+DEAL::Intermediate output:
+DEAL::  t =2.00000
+DEAL::  y =0.133225  (exact: 0.135335)
+DEAL::Evaluating implicit function at t=2.20000
+DEAL::Evaluating implicit Jacobian at t=2.20000
+DEAL::Evaluating implicit function at t=2.20000
+DEAL::Intermediate output:
+DEAL::  t =2.20000
+DEAL::  y =0.108719  (exact: 0.110803)
+DEAL::# Number of steps taken: 11
+DEAL::# Test user interface
+DEAL::Intermediate output:
+DEAL::  t =0.00000
+DEAL::  y =1.00000  (exact: 1.00000)
+DEAL::Evaluating implicit function at t=0.100000
+DEAL::Setting up Jacobian at t=0.100000
+DEAL::Solving with Jacobian
+DEAL::Evaluating implicit function at t=0.100000
+DEAL::Evaluating implicit function at t=0.100000
+DEAL::Evaluating implicit function at t=0.200000
+DEAL::Setting up Jacobian at t=0.200000
+DEAL::Solving with Jacobian
+DEAL::Evaluating implicit function at t=0.200000
+DEAL::Evaluating implicit function at t=0.200000
+DEAL::Intermediate output:
+DEAL::  t =0.200000
+DEAL::  y =0.823864  (exact: 0.818731)
+DEAL::Evaluating implicit function at t=0.400000
+DEAL::Setting up Jacobian at t=0.400000
+DEAL::Solving with Jacobian
+DEAL::Evaluating implicit function at t=0.400000
+DEAL::Evaluating implicit function at t=0.400000
+DEAL::Intermediate output:
+DEAL::  t =0.400000
+DEAL::  y =0.675134  (exact: 0.670320)
+DEAL::Evaluating implicit function at t=0.600000
+DEAL::Setting up Jacobian at t=0.600000
+DEAL::Solving with Jacobian
+DEAL::Evaluating implicit function at t=0.600000
+DEAL::Evaluating implicit function at t=0.600000
+DEAL::Intermediate output:
+DEAL::  t =0.600000
+DEAL::  y =0.551962  (exact: 0.548812)
+DEAL::Evaluating implicit function at t=0.800000
+DEAL::Setting up Jacobian at t=0.800000
+DEAL::Solving with Jacobian
+DEAL::Evaluating implicit function at t=0.800000
+DEAL::Evaluating implicit function at t=0.800000
+DEAL::Intermediate output:
+DEAL::  t =0.800000
+DEAL::  y =0.450798  (exact: 0.449329)
+DEAL::Evaluating implicit function at t=1.00000
+DEAL::Setting up Jacobian at t=1.00000
+DEAL::Solving with Jacobian
+DEAL::Evaluating implicit function at t=1.00000
+DEAL::Evaluating implicit function at t=1.00000
+DEAL::Intermediate output:
+DEAL::  t =1.00000
+DEAL::  y =0.368009  (exact: 0.367879)
+DEAL::Evaluating implicit function at t=1.20000
+DEAL::Setting up Jacobian at t=1.20000
+DEAL::Solving with Jacobian
+DEAL::Evaluating implicit function at t=1.20000
+DEAL::Evaluating implicit function at t=1.20000
+DEAL::Intermediate output:
+DEAL::  t =1.20000
+DEAL::  y =0.300364  (exact: 0.301194)
+DEAL::Evaluating implicit function at t=1.40000
+DEAL::Setting up Jacobian at t=1.40000
+DEAL::Solving with Jacobian
+DEAL::Evaluating implicit function at t=1.40000
+DEAL::Evaluating implicit function at t=1.40000
+DEAL::Intermediate output:
+DEAL::  t =1.40000
+DEAL::  y =0.245132  (exact: 0.246597)
+DEAL::Evaluating implicit function at t=1.60000
+DEAL::Setting up Jacobian at t=1.60000
+DEAL::Solving with Jacobian
+DEAL::Evaluating implicit function at t=1.60000
+DEAL::Evaluating implicit function at t=1.60000
+DEAL::Intermediate output:
+DEAL::  t =1.60000
+DEAL::  y =0.200048  (exact: 0.201897)
+DEAL::Evaluating implicit function at t=1.80000
+DEAL::Setting up Jacobian at t=1.80000
+DEAL::Solving with Jacobian
+DEAL::Evaluating implicit function at t=1.80000
+DEAL::Evaluating implicit function at t=1.80000
+DEAL::Intermediate output:
+DEAL::  t =1.80000
+DEAL::  y =0.163253  (exact: 0.165299)
+DEAL::Evaluating implicit function at t=2.00000
+DEAL::Setting up Jacobian at t=2.00000
+DEAL::Solving with Jacobian
+DEAL::Evaluating implicit function at t=2.00000
+DEAL::Evaluating implicit function at t=2.00000
+DEAL::Intermediate output:
+DEAL::  t =2.00000
+DEAL::  y =0.133225  (exact: 0.135335)
+DEAL::Evaluating implicit function at t=2.20000
+DEAL::Setting up Jacobian at t=2.20000
+DEAL::Solving with Jacobian
+DEAL::Evaluating implicit function at t=2.20000
+DEAL::Evaluating implicit function at t=2.20000
+DEAL::Intermediate output:
+DEAL::  t =2.20000
+DEAL::  y =0.108719  (exact: 0.110803)
+DEAL::# Number of steps taken: 11

--- a/tests/petsc/petsc_ts_03_in.prm
+++ b/tests/petsc/petsc_ts_03_in.prm
@@ -1,0 +1,11 @@
+subsection Running parameters
+  set initial time      = 0
+  set final time        = 2.0
+  set solver type       = bdf 
+  set initial step size = 0.2
+end
+subsection Error control
+  set absolute error tolerance = 0.0001
+  set minimum step size = 1e-7
+  set maximum step size = 1e+7
+end

--- a/tests/petsc/petsc_ts_04.cc
+++ b/tests/petsc/petsc_ts_04.cc
@@ -1,0 +1,275 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2023 by the deal.II authors
+//
+//    This file is part of the deal.II library.
+//
+//    The deal.II library is free software; you can use it, redistribute
+//    it, and/or modify it under the terms of the GNU Lesser General
+//    Public License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//    The full text of the license can be found in the file LICENSE.md at
+//    the top level directory of deal.II.
+//
+//-----------------------------------------------------------
+
+#include <deal.II/base/parameter_handler.h>
+
+#include <deal.II/lac/petsc_matrix_base.h>
+#include <deal.II/lac/petsc_ts.h>
+#include <deal.II/lac/petsc_vector.h>
+
+#include <cmath>
+
+#include "../tests.h"
+
+/**
+ * Like the _03 test, but throw an error whenever we find that the
+ * time step for evaluating the residual is too large.
+ *
+ * Solves the equations of exponential decay:
+ *
+ * u' = -k u
+ * u (t0) = 1
+ *
+ * using the PETScWrappers::TimeStepper class
+ * that interfaces PETSc TS ODE solver object.
+ * The ODE can be an EXPLICIT first order ode:
+ *
+ * y[0]' = - k   y[0]     -> y' = G(y,t)
+ *
+ * or specified in IMPLICIT form:
+ *
+ * y[0]' +  k  y[1]  = 0  -> F(y',y,t) = 0
+ *
+ * The exact solution is, in either case,
+ *
+ * y[0](t) = exp(-kt)
+ *
+ * We use the same class to test both formulations.
+ * The class also supports a third approach where
+ * control for linear systems generation and
+ * solution is completely on users. In this case
+ * users are in charge of solving for the
+ * implicit Jacobian.
+ * The model used to wrap PETSc's TS is the same
+ * used for the nonlinear solver SNES. Check
+ * petsc_snes_00.cc for additional information.
+ *
+ */
+using VectorType  = PETScWrappers::MPI::Vector;
+using MatrixType  = PETScWrappers::MatrixBase;
+using TimeStepper = PETScWrappers::TimeStepper<VectorType, MatrixType>;
+using real_type   = TimeStepper::real_type;
+
+class HarmonicOscillator
+{
+public:
+  HarmonicOscillator(real_type                                      _kappa,
+                     const typename PETScWrappers::TimeStepperData &data,
+                     bool                                           setjac,
+                     bool                                           implicit,
+                     bool                                           user)
+    : time_stepper(data)
+    , kappa(_kappa)
+    , last_eval_time(0)
+  {
+    // In this case we use the implicit form
+    if (implicit)
+      {
+        time_stepper.implicit_function = [&](const real_type   t,
+                                             const VectorType &y,
+                                             const VectorType &y_dot,
+                                             VectorType &      res) -> void {
+          deallog << "Evaluating implicit function at t=" << t << std::endl;
+
+          if (t > last_eval_time + 0.1)
+            {
+              deallog << "Time step too large: last_eval_time="
+                      << last_eval_time << ", t=" << t << std::endl;
+              throw RecoverableUserCallbackError();
+            }
+
+
+          res(0) = y_dot(0) + kappa * y(0);
+          res.compress(VectorOperation::insert);
+
+          last_eval_time = t;
+        };
+
+        // We either have the possibility of using PETSc standard
+        // functionalities for Jacobian setup and solve, or take full control of
+        // the Jacobian solutions. The latter aligns more with deal.II tutorials
+        // For our testing class, 'user' discriminate between those two
+        // approaches.
+        if (!user && setjac)
+          {
+            // Callback for Jacobian evaluation
+            // This callback populates the P matrix with
+            //     shift * dF/dydot + dF/dy
+            // A and P are the same matrix if not otherwise specified
+            // PETSc can compute a Jacobian by finite-differencing the residual
+            // evaluation, and it can be selected at command line.
+            time_stepper.implicit_jacobian = [&](const real_type   t,
+                                                 const VectorType &y,
+                                                 const VectorType &y_dot,
+                                                 const real_type   shift,
+                                                 MatrixType &      A,
+                                                 MatrixType &      P) -> void {
+              deallog << "Evaluating implicit Jacobian at t=" << t << std::endl;
+              P.set(0, 0, shift + kappa);
+              P.compress(VectorOperation::insert);
+            };
+          }
+        else if (user)
+          {
+            // In this code block, users are completely in charge of
+            // setting up the Jacobian system and solve for it.
+            // In this example we only store the solver shift
+            // during setup.
+            time_stepper.setup_jacobian = [&](const real_type   t,
+                                              const VectorType &y,
+                                              const VectorType &y_dot,
+                                              const real_type   shift) -> void {
+              deallog << "Setting up Jacobian at t=" << t << std::endl;
+              myshift = shift;
+            };
+
+            // In the solve phase we se the stored shift to solve
+            // for the implicit Jacobian system
+            time_stepper.solve_with_jacobian = [&](const VectorType &src,
+                                                   VectorType &dst) -> void {
+              deallog << "Solving with Jacobian" << std::endl;
+              dst(0) = src(0) / (myshift + kappa);
+              dst.compress(VectorOperation::insert);
+            };
+          }
+      }
+    else
+      { // Here we instead use the explicit form
+        // This is the only function one would populate in case an explicit
+        // solver is used.
+        time_stepper.explicit_function =
+          [&](const real_type t, const VectorType &y, VectorType &res) -> void {
+          deallog << "Evaluating explicit function at t=" << t << std::endl;
+
+          if (t > last_eval_time + 0.1)
+            {
+              deallog << "Time step too large: last_eval_time="
+                      << last_eval_time << ", t=" << t << std::endl;
+              throw RecoverableUserCallbackError();
+            }
+
+          res(0) = -kappa * y(0);
+          res.compress(VectorOperation::insert);
+
+          last_eval_time = t;
+        };
+
+        // The explicit Jacobian callback is not needed in case
+        // an explicit solver is used. We need it when moving to
+        // an implicit solver like in the parameter file used for
+        // this test
+        if (setjac)
+          {
+            time_stepper.explicit_jacobian = [&](const real_type   t,
+                                                 const VectorType &y,
+                                                 MatrixType &      A,
+                                                 MatrixType &      P) -> void {
+              deallog << "Evaluating explicit Jacobian at t=" << t << std::endl;
+              P.set(0, 0, -kappa);
+              P.compress(VectorOperation::insert);
+            };
+          }
+      }
+
+    // Monitoring routine. Here we print diagnostic for the exact
+    // solution to the log file.
+    time_stepper.monitor = [&](const real_type   t,
+                               const VectorType &sol,
+                               const unsigned int /*step_number*/) -> void {
+      deallog << "Intermediate output:" << std::endl;
+      deallog << "  t =" << t << std::endl;
+      deallog << "  y =" << sol[0] << "  (exact: " << std::exp(-kappa * t)
+              << ')' << std::endl;
+    };
+  }
+
+  void
+  run()
+  {
+    // Set initial conditions
+    // This test uses a nonzero initial time
+    // We can access the time value with the
+    // get_time method
+    auto t = time_stepper.get_time();
+
+    VectorType y(MPI_COMM_SELF, 1, 1);
+    y[0] = 1;
+    y.compress(VectorOperation::insert);
+
+    // Integrate the ODE.
+    try
+      {
+        auto nt = time_stepper.solve(y);
+        deallog << "# Number of steps taken: " << nt << std::endl;
+      }
+    catch (const std::exception &exc)
+      {
+        deallog << "Time stepper aborted with an exception:" << std::endl
+                << exc.what() << std::endl;
+      }
+  }
+
+private:
+  TimeStepper time_stepper;
+  real_type   kappa;   // Defines the oscillator
+  real_type   myshift; // Used by the user solve
+  double      last_eval_time;
+};
+
+
+int
+main(int argc, char **argv)
+{
+  initlog();
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  PETScWrappers::TimeStepperData data;
+  ParameterHandler               prm;
+
+  data.add_parameters(prm);
+  deallog << "# Default Parameters" << std::endl;
+  prm.print_parameters(deallog.get_file_stream(), ParameterHandler::ShortText);
+
+  std::ifstream ifile(SOURCE_DIR "/petsc_ts_03_in.prm");
+  prm.parse_input(ifile);
+
+  deallog << "# Testing Parameters" << std::endl;
+  prm.print_parameters(deallog.get_file_stream(), ParameterHandler::ShortText);
+
+  for (int setjaci = 0; setjaci < 2; setjaci++)
+    {
+      bool setjac = setjaci ? true : false;
+
+      {
+        deallog << "# Test explicit interface (J " << setjac << ")"
+                << std::endl;
+        HarmonicOscillator ode_expl(1.0, data, setjac, false, false);
+        ode_expl.run();
+      }
+
+      {
+        deallog << "# Test implicit interface (J " << setjac << ")"
+                << std::endl;
+        HarmonicOscillator ode_impl(1.0, data, setjac, true, false);
+        ode_impl.run();
+      }
+    }
+
+  {
+    deallog << "# Test user interface" << std::endl;
+    HarmonicOscillator ode_user(1.0, data, true, true, true);
+    ode_user.run();
+  }
+}

--- a/tests/petsc/petsc_ts_04.output
+++ b/tests/petsc/petsc_ts_04.output
@@ -1,0 +1,200 @@
+
+DEAL::# Default Parameters
+subsection Error control
+  set absolute error tolerance = -1
+  set adaptor type             = none
+  set ignore algebraic lte     = true
+  set maximum step size        = -1
+  set minimum step size        = -1
+  set relative error tolerance = -1
+end
+subsection Running parameters
+  set final time              = 0
+  set initial step size       = 0
+  set initial time            = 0
+  set match final time        = false
+  set maximum number of steps = -1
+  set options prefix          = 
+  set solver type             = 
+end
+DEAL::# Testing Parameters
+subsection Error control
+  set absolute error tolerance = 0.0001
+  set adaptor type             = none
+  set ignore algebraic lte     = true
+  set maximum step size        = 1e+7
+  set minimum step size        = 1e-7
+  set relative error tolerance = -1
+end
+subsection Running parameters
+  set final time              = 2.0
+  set initial step size       = 0.2
+  set initial time            = 0
+  set match final time        = false
+  set maximum number of steps = -1
+  set options prefix          = 
+  set solver type             = bdf
+end
+DEAL::# Test explicit interface (J 0)
+DEAL::Intermediate output:
+DEAL::  t =0.00000
+DEAL::  y =1.00000  (exact: 1.00000)
+DEAL::Evaluating explicit function at t=0.100000
+DEAL::Evaluating explicit function at t=0.100000
+DEAL::Evaluating explicit function at t=0.100000
+DEAL::Evaluating explicit function at t=0.100000
+DEAL::Evaluating explicit function at t=0.200000
+DEAL::Evaluating explicit function at t=0.200000
+DEAL::Evaluating explicit function at t=0.200000
+DEAL::Evaluating explicit function at t=0.200000
+DEAL::Intermediate output:
+DEAL::  t =0.200000
+DEAL::  y =0.823864  (exact: 0.818731)
+DEAL::Evaluating explicit function at t=0.400000
+DEAL::Time step too large: last_eval_time=0.200000, t=0.400000
+DEAL::Time stepper aborted with an exception:
+DEAL::
+--------------------------------------------------------
+An error occurred in line <0> of file <> in function
+    
+The violated condition was: 
+    
+Additional information: 
+    A user call-back function encountered a recoverable error, but the
+    underlying library that called the call-back did not manage to recover
+    from the error and aborted its operation.
+    
+    See the glossary entry on user call-back functions for more
+    information.
+--------------------------------------------------------
+
+DEAL::# Test implicit interface (J 0)
+DEAL::Intermediate output:
+DEAL::  t =0.00000
+DEAL::  y =1.00000  (exact: 1.00000)
+DEAL::Evaluating implicit function at t=0.100000
+DEAL::Evaluating implicit function at t=0.100000
+DEAL::Evaluating implicit function at t=0.100000
+DEAL::Evaluating implicit function at t=0.100000
+DEAL::Evaluating implicit function at t=0.200000
+DEAL::Evaluating implicit function at t=0.200000
+DEAL::Evaluating implicit function at t=0.200000
+DEAL::Evaluating implicit function at t=0.200000
+DEAL::Intermediate output:
+DEAL::  t =0.200000
+DEAL::  y =0.823864  (exact: 0.818731)
+DEAL::Evaluating implicit function at t=0.400000
+DEAL::Time step too large: last_eval_time=0.200000, t=0.400000
+DEAL::Time stepper aborted with an exception:
+DEAL::
+--------------------------------------------------------
+An error occurred in line <0> of file <> in function
+    
+The violated condition was: 
+    
+Additional information: 
+    A user call-back function encountered a recoverable error, but the
+    underlying library that called the call-back did not manage to recover
+    from the error and aborted its operation.
+    
+    See the glossary entry on user call-back functions for more
+    information.
+--------------------------------------------------------
+
+DEAL::# Test explicit interface (J 1)
+DEAL::Intermediate output:
+DEAL::  t =0.00000
+DEAL::  y =1.00000  (exact: 1.00000)
+DEAL::Evaluating explicit function at t=0.100000
+DEAL::Evaluating explicit Jacobian at t=0.100000
+DEAL::Evaluating explicit function at t=0.100000
+DEAL::Evaluating explicit function at t=0.200000
+DEAL::Evaluating explicit Jacobian at t=0.200000
+DEAL::Evaluating explicit function at t=0.200000
+DEAL::Intermediate output:
+DEAL::  t =0.200000
+DEAL::  y =0.823864  (exact: 0.818731)
+DEAL::Evaluating explicit function at t=0.400000
+DEAL::Time step too large: last_eval_time=0.200000, t=0.400000
+DEAL::Time stepper aborted with an exception:
+DEAL::
+--------------------------------------------------------
+An error occurred in line <0> of file <> in function
+    
+The violated condition was: 
+    
+Additional information: 
+    A user call-back function encountered a recoverable error, but the
+    underlying library that called the call-back did not manage to recover
+    from the error and aborted its operation.
+    
+    See the glossary entry on user call-back functions for more
+    information.
+--------------------------------------------------------
+
+DEAL::# Test implicit interface (J 1)
+DEAL::Intermediate output:
+DEAL::  t =0.00000
+DEAL::  y =1.00000  (exact: 1.00000)
+DEAL::Evaluating implicit function at t=0.100000
+DEAL::Evaluating implicit Jacobian at t=0.100000
+DEAL::Evaluating implicit function at t=0.100000
+DEAL::Evaluating implicit function at t=0.200000
+DEAL::Evaluating implicit Jacobian at t=0.200000
+DEAL::Evaluating implicit function at t=0.200000
+DEAL::Intermediate output:
+DEAL::  t =0.200000
+DEAL::  y =0.823864  (exact: 0.818731)
+DEAL::Evaluating implicit function at t=0.400000
+DEAL::Time step too large: last_eval_time=0.200000, t=0.400000
+DEAL::Time stepper aborted with an exception:
+DEAL::
+--------------------------------------------------------
+An error occurred in line <0> of file <> in function
+    
+The violated condition was: 
+    
+Additional information: 
+    A user call-back function encountered a recoverable error, but the
+    underlying library that called the call-back did not manage to recover
+    from the error and aborted its operation.
+    
+    See the glossary entry on user call-back functions for more
+    information.
+--------------------------------------------------------
+
+DEAL::# Test user interface
+DEAL::Intermediate output:
+DEAL::  t =0.00000
+DEAL::  y =1.00000  (exact: 1.00000)
+DEAL::Evaluating implicit function at t=0.100000
+DEAL::Setting up Jacobian at t=0.100000
+DEAL::Solving with Jacobian
+DEAL::Evaluating implicit function at t=0.100000
+DEAL::Evaluating implicit function at t=0.100000
+DEAL::Evaluating implicit function at t=0.200000
+DEAL::Setting up Jacobian at t=0.200000
+DEAL::Solving with Jacobian
+DEAL::Evaluating implicit function at t=0.200000
+DEAL::Evaluating implicit function at t=0.200000
+DEAL::Intermediate output:
+DEAL::  t =0.200000
+DEAL::  y =0.823864  (exact: 0.818731)
+DEAL::Evaluating implicit function at t=0.400000
+DEAL::Time step too large: last_eval_time=0.200000, t=0.400000
+DEAL::Time stepper aborted with an exception:
+DEAL::
+--------------------------------------------------------
+An error occurred in line <0> of file <> in function
+    
+The violated condition was: 
+    
+Additional information: 
+    A user call-back function encountered a recoverable error, but the
+    underlying library that called the call-back did not manage to recover
+    from the error and aborted its operation.
+    
+    See the glossary entry on user call-back functions for more
+    information.
+--------------------------------------------------------
+


### PR DESCRIPTION
@stefanozampini I would love it if you could take a look over this.

On my workstation, this currently fails with an exception of this form:
```
11719: 5.9375 -0.344285 (-0.338842) 0.937523 (0.940843)
11719: 6 -0.285132 (-0.279415) 0.957169 (0.96017)
11719: # Number of steps taken: 80
11719: # Test explicit interface (J 1)
11719: 1 0.841471 (0.841471) 0.540302 (0.540302)
11719: 
11719: petsc/petsc_ts_00.debug: RUN failed. ------ Additional output on stdout/stderr:
11719: 
11719: [0]PETSC ERROR: --------------------- Error Message --------------------------------------------------------------
11719: [0]PETSC ERROR: Object is in wrong state
11719: [0]PETSC ERROR: Not for unassembled matrix
11719: [0]PETSC ERROR: See http://www.mcs.anl.gov/petsc/documentation/faq.html for trouble shooting.
11719: [0]PETSC ERROR: Petsc Release Version 3.7.4, Oct, 02, 2016 
11719: [0]PETSC ERROR: /home/fac/g/bangerth/p/deal.II/1/build/tests/petsc/petsc_ts_00.debug/petsc_ts_00.debug on a x86_64 named strange.math.colostate.edu by bangerth Wed May 24 17:34:28 2023
11719: [0]PETSC ERROR: Configure options --with-shared-libraries=1 --with-x=0 --with-mpi=1 --download-hypre=1 --download-superlu_dist=yes --download-mumps=yes --download-parmetis=yes --download-scalapack=yes --download-metis=yes --download-blacs=yes
11719: [0]PETSC ERROR: #1 MatDuplicate() line 4335 in /raid/bangerth/bin/petsc-3.7.4/src/mat/interface/matrix.c
11719: [0]PETSC ERROR: #2 TSGetRHSMats_Private() line 751 in /raid/bangerth/bin/petsc-3.7.4/src/ts/interface/ts.c
11719: [0]PETSC ERROR: #3 TSComputeIJacobian() line 929 in /raid/bangerth/bin/petsc-3.7.4/src/ts/interface/ts.c
11719: [0]PETSC ERROR: #4 SNESTSFormJacobian_BDF() line 324 in /raid/bangerth/bin/petsc-3.7.4/src/ts/impls/bdf/bdf.c
11719: [0]PETSC ERROR: #5 SNESTSFormJacobian() line 5015 in /raid/bangerth/bin/petsc-3.7.4/src/ts/interface/ts.c
11719: [0]PETSC ERROR: #6 SNESComputeJacobian() line 2312 in /raid/bangerth/bin/petsc-3.7.4/src/snes/interface/snes.c
11719: [0]PETSC ERROR: #7 SNESSolve_NEWTONLS() line 228 in /raid/bangerth/bin/petsc-3.7.4/src/snes/impls/ls/ls.c
11719: [0]PETSC ERROR: #8 SNESSolve() line 4005 in /raid/bangerth/bin/petsc-3.7.4/src/snes/interface/snes.c
11719: [0]PETSC ERROR: #9 TS_SNESSolve() line 160 in /raid/bangerth/bin/petsc-3.7.4/src/ts/impls/bdf/bdf.c
11719: [0]PETSC ERROR: #10 TSBDF_Restart() line 181 in /raid/bangerth/bin/petsc-3.7.4/src/ts/impls/bdf/bdf.c
11719: [0]PETSC ERROR: #11 TSStep_BDF() line 216 in /raid/bangerth/bin/petsc-3.7.4/src/ts/impls/bdf/bdf.c
11719: [0]PETSC ERROR: #12 TSStep() line 3733 in /raid/bangerth/bin/petsc-3.7.4/src/ts/interface/ts.c
11719: [0]PETSC ERROR: #13 TSSolve() line 3982 in /raid/bangerth/bin/petsc-3.7.4/src/ts/interface/ts.c
11719: terminate called after throwing an instance of 'dealii::LACExceptions::ExcPETScError'
11719:   what():  
11719: --------------------------------------------------------
11719: An error occurred in line <587> of file </home/fac/g/bangerth/p/deal.II/1/dealii/include/deal.II/lac/petsc_ts.templates.h> in function
11719:     unsigned int dealii::PETScWrappers::TimeStepper<VectorType, PMatrixType, AMatrixType>::solve(VectorType&) [with VectorType = dealii::PETScWrappers::MPI::Vector; PMatrixType = dealii::PETScWrappers::MatrixBase; AMatrixType = dealii::PETScWrappers::MatrixBase]
11719: The violated condition was: 
11719:     ierr == 0
11719: Additional information: 
11719:     deal.II encountered an error while calling a PETSc function.
11719:     The description of the error provided by PETSc is "Object is in wrong
11719:     state".
11719:     The numerical value of the original error code is 73.
11719: --------------------------------------------------------
```
I have to run, and so have not investigated what may be going wrong. I also don't know whether I have run these tests on this machine before, so am only half-certain that this is caused by the current patch.

In reference to #15112. 
