### PR TITLE
Fix warnings when compiling with nvcc_wrapper

### DIFF
--- a/examples/step-47/step-47.cc
+++ b/examples/step-47/step-47.cc
@@ -87,8 +87,6 @@ namespace Step47
     public:
       static_assert(dim == 2, "Only dim==2 is implemented.");
 
-      Solution() = default;
-
       virtual double value(const Point<dim> &p,
                            const unsigned int /*component*/ = 0) const override
       {
@@ -128,8 +126,6 @@ namespace Step47
     {
     public:
       static_assert(dim == 2, "Only dim==2 is implemented");
-
-      RightHandSide() = default;
 
       virtual double value(const Point<dim> &p,
                            const unsigned int /*component*/ = 0) const override
@@ -411,7 +407,7 @@ namespace Step47
 
       cell->get_dof_indices(copy_data.local_dof_indices);
 
-      const ExactSolution::RightHandSide<dim> right_hand_side;
+      ExactSolution::RightHandSide<dim> right_hand_side;
 
       const unsigned int dofs_per_cell =
         scratch_data.fe_values.get_fe().n_dofs_per_cell();
@@ -614,8 +610,8 @@ namespace Step47
         fe_interface_values.get_normal_vectors();
 
 
-      const ExactSolution::Solution<dim> exact_solution;
-      std::vector<Tensor<1, dim>>        exact_gradients(q_points.size());
+      ExactSolution::Solution<dim> exact_solution;
+      std::vector<Tensor<1, dim>>  exact_gradients(q_points.size());
       exact_solution.gradient_list(q_points, exact_gradients);
 
 

--- a/examples/step-47/step-47.cc
+++ b/examples/step-47/step-47.cc
@@ -87,6 +87,8 @@ namespace Step47
     public:
       static_assert(dim == 2, "Only dim==2 is implemented.");
 
+      Solution() = default;
+
       virtual double value(const Point<dim> &p,
                            const unsigned int /*component*/ = 0) const override
       {
@@ -126,6 +128,8 @@ namespace Step47
     {
     public:
       static_assert(dim == 2, "Only dim==2 is implemented");
+
+      RightHandSide() = default;
 
       virtual double value(const Point<dim> &p,
                            const unsigned int /*component*/ = 0) const override

--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -268,8 +268,6 @@ namespace Step7
   class RightHandSide : public Function<dim>, protected SolutionBase<dim>
   {
   public:
-    RightHandSide() = default;
-
     virtual double value(const Point<dim> & p,
                          const unsigned int component = 0) const override;
   };
@@ -571,8 +569,8 @@ namespace Step7
     // Note that the operations we will do with the right hand side object are
     // only querying data, never changing the object. We can therefore declare
     // it <code>const</code>:
-    const RightHandSide<dim> right_hand_side;
-    std::vector<double>      rhs_values(n_q_points);
+    RightHandSide<dim>  right_hand_side;
+    std::vector<double> rhs_values(n_q_points);
 
     // Finally we define an object denoting the exact solution function. We
     // will use it to compute the Neumann values at the boundary from

--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -268,6 +268,8 @@ namespace Step7
   class RightHandSide : public Function<dim>, protected SolutionBase<dim>
   {
   public:
+    RightHandSide() = default;
+
     virtual double value(const Point<dim> & p,
                          const unsigned int component = 0) const override;
   };

--- a/examples/step-85/step-85.cc
+++ b/examples/step-85/step-85.cc
@@ -582,8 +582,6 @@ namespace Step85
   class AnalyticalSolution : public Function<dim>
   {
   public:
-    AnalyticalSolution() = default;
-
     double value(const Point<dim> & point,
                  const unsigned int component = 0) const override;
   };
@@ -627,8 +625,8 @@ namespace Step85
     // We then iterate iterate over the cells that have LocationToLevelSetValue
     // value inside or intersected again. For each quadrature point, we compute
     // the pointwise error and use this to compute the integral.
-    const AnalyticalSolution<dim> analytical_solution;
-    double                        error_L2_squared = 0;
+    AnalyticalSolution<dim> analytical_solution;
+    double                  error_L2_squared = 0;
 
     for (const auto &cell :
          dof_handler.active_cell_iterators() |

--- a/examples/step-85/step-85.cc
+++ b/examples/step-85/step-85.cc
@@ -582,6 +582,8 @@ namespace Step85
   class AnalyticalSolution : public Function<dim>
   {
   public:
+    AnalyticalSolution() = default;
+
     double value(const Point<dim> & point,
                  const unsigned int component = 0) const override;
   };

--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -326,7 +326,7 @@ namespace numbers
    * of @p value_1.
    */
   template <typename Number1, typename Number2>
-  constexpr bool
+  constexpr DEAL_II_HOST_DEVICE bool
   values_are_equal(const Number1 &value_1, const Number2 &value_2);
 
   /**
@@ -351,7 +351,7 @@ namespace numbers
    * by the input arguments.
    */
   template <typename Number>
-  constexpr bool
+  constexpr DEAL_II_HOST_DEVICE bool
   value_is_zero(const Number &value);
 
   /**
@@ -919,7 +919,7 @@ namespace numbers
 
 
   template <typename Number1, typename Number2>
-  constexpr bool
+  constexpr DEAL_II_HOST_DEVICE bool
   values_are_equal(const Number1 &value_1, const Number2 &value_2)
   {
     return (value_1 == dealii::internal::NumberType<Number1>::value(value_2));
@@ -935,7 +935,7 @@ namespace numbers
 
 
   template <typename Number>
-  constexpr bool
+  constexpr DEAL_II_HOST_DEVICE bool
   value_is_zero(const Number &value)
   {
     return values_are_equal(value, 0.0);

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -845,7 +845,7 @@ public:
    * Return an unrolled index in the range $[0,\text{dim}^{\text{rank}}-1]$
    * for the element of the tensor indexed by the argument to the function.
    */
-  DEAL_II_HOST_DEVICE static constexpr unsigned int
+  static constexpr DEAL_II_HOST_DEVICE unsigned int
   component_to_unrolled_index(const TableIndices<rank_> &indices);
 
   /**
@@ -853,7 +853,7 @@ public:
    * $[0, \text{dim}^{\text{rank}}-1]$, return which set of indices it would
    * correspond to.
    */
-  DEAL_II_HOST_DEVICE static constexpr TableIndices<rank_>
+  static constexpr DEAL_II_HOST_DEVICE TableIndices<rank_>
   unrolled_to_component_indices(const unsigned int i);
 
   /**

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -693,8 +693,8 @@ public:
    * value allowed for <tt>d</tt>, allowing the intuitive notation
    * <tt>t=0</tt> to reset all elements of the tensor to zero.
    */
-  constexpr Tensor &
-  operator=(const Number &d) &;
+  constexpr DEAL_II_HOST_DEVICE Tensor &
+                                operator=(const Number &d) &;
 
   /**
    * Assign a scalar to the current object. This overload is used for
@@ -845,7 +845,7 @@ public:
    * Return an unrolled index in the range $[0,\text{dim}^{\text{rank}}-1]$
    * for the element of the tensor indexed by the argument to the function.
    */
-  static constexpr unsigned int
+  DEAL_II_HOST_DEVICE static constexpr unsigned int
   component_to_unrolled_index(const TableIndices<rank_> &indices);
 
   /**
@@ -853,7 +853,7 @@ public:
    * $[0, \text{dim}^{\text{rank}}-1]$, return which set of indices it would
    * correspond to.
    */
-  static constexpr TableIndices<rank_>
+  DEAL_II_HOST_DEVICE static constexpr TableIndices<rank_>
   unrolled_to_component_indices(const unsigned int i);
 
   /**
@@ -1559,8 +1559,9 @@ Tensor<rank_, dim, Number>::operator=(const Tensor<rank_, dim, OtherNumber> &t)
 
 
 template <int rank_, int dim, typename Number>
-constexpr inline DEAL_II_ALWAYS_INLINE Tensor<rank_, dim, Number> &
-Tensor<rank_, dim, Number>::operator=(const Number &d) &
+constexpr DEAL_II_HOST_DEVICE inline DEAL_II_ALWAYS_INLINE
+  Tensor<rank_, dim, Number> &
+  Tensor<rank_, dim, Number>::operator=(const Number &d) &
 {
   Assert(numbers::value_is_zero(d), ExcScalarAssignmentOnlyForZeroValue());
   (void)d;
@@ -1820,14 +1821,14 @@ namespace internal
   // and rank=2. Make sure we don't have compiler warnings.
 
   template <int dim>
-  inline constexpr unsigned int
+  DEAL_II_HOST_DEVICE inline constexpr unsigned int
   mod(const unsigned int x)
   {
     return x % dim;
   }
 
   template <>
-  inline unsigned int
+  DEAL_II_HOST_DEVICE inline unsigned int
   mod<0>(const unsigned int x)
   {
     Assert(false, ExcInternalError());
@@ -1835,14 +1836,14 @@ namespace internal
   }
 
   template <int dim>
-  inline constexpr unsigned int
+  DEAL_II_HOST_DEVICE inline constexpr unsigned int
   div(const unsigned int x)
   {
     return x / dim;
   }
 
   template <>
-  inline unsigned int
+  DEAL_II_HOST_DEVICE inline unsigned int
   div<0>(const unsigned int x)
   {
     Assert(false, ExcInternalError());
@@ -1857,7 +1858,10 @@ template <int rank_, int dim, typename Number>
 constexpr inline TableIndices<rank_>
 Tensor<rank_, dim, Number>::unrolled_to_component_indices(const unsigned int i)
 {
-  AssertIndexRange(i, n_independent_components);
+  // Work-around nvcc warning
+  unsigned int dummy = n_independent_components;
+  AssertIndexRange(i, dummy);
+  (void)dummy;
 
   TableIndices<rank_> indices;
 


### PR DESCRIPTION
This PR fixes a few warnings when compiling with `nvcc_wrapper`. We still have lots of warnings because we instantiate `std::complex` numbers in `__device__` functions. 