### PR TITLE
Convert PETSc SNES interfaces to use callback error conventions.

### DIFF
--- a/include/deal.II/lac/petsc_snes.h
+++ b/include/deal.II/lac/petsc_snes.h
@@ -29,6 +29,7 @@
 
 #  include <petscsnes.h>
 
+#  include <exception>
 #  if defined(DEAL_II_HAVE_CXX20)
 #    include <concepts>
 #  endif
@@ -350,14 +351,30 @@ namespace PETScWrappers
 
     /**
      * Callback for the computation of the nonlinear residual $F(x)$.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. PETSc's SNES package can not deal
+     * with "recoverable" errors, so if a callback
+     * throws an exception of type RecoverableUserCallbackError, then this
+     * exception is treated like any other exception.
      */
-    std::function<int(const VectorType &x, VectorType &res)> residual;
+    std::function<void(const VectorType &x, VectorType &res)> residual;
 
     /**
      * Callback for the computation of the Jacobian
      * $\dfrac{\partial F}{\partial x}$.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. PETSc's SNES package can not deal
+     * with "recoverable" errors, so if a callback
+     * throws an exception of type RecoverableUserCallbackError, then this
+     * exception is treated like any other exception.
      */
-    std::function<int(const VectorType &x, AMatrixType &A, PMatrixType &P)>
+    std::function<void(const VectorType &x, AMatrixType &A, PMatrixType &P)>
       jacobian;
 
     /**
@@ -366,10 +383,18 @@ namespace PETScWrappers
      * This function is called by NonlinearSolver at the beginning
      * of each time step. Input arguments are the current step number
      * and the current value for ||F(x)||.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. PETSc's SNES package can not deal
+     * with "recoverable" errors, so if a callback
+     * throws an exception of type RecoverableUserCallbackError, then this
+     * exception is treated like any other exception.
      */
-    std::function<int(const VectorType & x,
-                      const unsigned int step_number,
-                      const real_type    f_norm)>
+    std::function<void(const VectorType & x,
+                       const unsigned int step_number,
+                       const real_type    f_norm)>
       monitor;
 
     /**
@@ -379,16 +404,32 @@ namespace PETScWrappers
      * operator $\dfrac{\partial F}{\partial x}$.
      *
      * Solvers must be provided via NonlinearSolver::solve_with_jacobian.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. PETSc's SNES package can not deal
+     * with "recoverable" errors, so if a callback
+     * throws an exception of type RecoverableUserCallbackError, then this
+     * exception is treated like any other exception.
      */
-    std::function<int(const VectorType &x)> setup_jacobian;
+    std::function<void(const VectorType &x)> setup_jacobian;
 
     /**
      * Callback for the solution of the tangent system set up with
      * NonlinearSolver::setup_jacobian.
      *
      * This is used as a preconditioner inside the Krylov process.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. PETSc's SNES package can not deal
+     * with "recoverable" errors, so if a callback
+     * throws an exception of type RecoverableUserCallbackError, then this
+     * exception is treated like any other exception.
      */
-    std::function<int(const VectorType &src, VectorType &dst)>
+    std::function<void(const VectorType &src, VectorType &dst)>
       solve_with_jacobian;
 
     /**
@@ -402,8 +443,16 @@ namespace PETScWrappers
      * the reduction in a trust region step.
      *
      * The value of the energy function must be returned in @p energy_value.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. PETSc's SNES package can not deal
+     * with "recoverable" errors, so if a callback
+     * throws an exception of type RecoverableUserCallbackError, then this
+     * exception is treated like any other exception.
      */
-    std::function<int(const VectorType &x, real_type &energy_value)> energy;
+    std::function<void(const VectorType &x, real_type &energy_value)> energy;
 
   private:
     /**
@@ -418,6 +467,13 @@ namespace PETScWrappers
      * This flag is used to support versions of PETSc older than 3.13.
      */
     bool need_dummy_assemble;
+
+    /**
+     * A pointer to any exception that may have been thrown in user-defined
+     * call-backs and that we have to deal after the KINSOL function we call
+     * has returned.
+     */
+    mutable std::exception_ptr pending_exception;
   };
 
 } // namespace PETScWrappers

--- a/include/deal.II/lac/petsc_snes.templates.h
+++ b/include/deal.II/lac/petsc_snes.templates.h
@@ -38,16 +38,6 @@ DEAL_II_NAMESPACE_OPEN
       }                                              \
     while (0)
 
-// Shorthand notation for User error codes.
-#  define AssertUser(code, name)                                               \
-    do                                                                         \
-      {                                                                        \
-        int ierr = (code);                                                     \
-        AssertThrow(ierr == 0,                                                 \
-                    StandardExceptions::ExcFunctionNonzeroReturn(name, ierr)); \
-      }                                                                        \
-    while (0)
-
 namespace PETScWrappers
 {
   namespace
@@ -514,7 +504,6 @@ namespace PETScWrappers
 } // namespace PETScWrappers
 
 #  undef AssertPETSc
-#  undef AssertUser
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/include/deal.II/lac/petsc_snes.templates.h
+++ b/include/deal.II/lac/petsc_snes.templates.h
@@ -50,12 +50,54 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace PETScWrappers
 {
+  namespace
+  {
+    /**
+     * A function that calls the function object given by its first argument
+     * with the set of arguments following at the end. If the call returns
+     * regularly, the current function returns zero to indicate success. If
+     * the call fails with an exception, then the current function returns with
+     * an error code of -1. In that case, the exception thrown by `f` is
+     * captured and `eptr` is set to the exception. In case of success,
+     * `eptr` is set to `nullptr`.
+     */
+    template <typename F, typename... Args>
+    int
+    call_and_possibly_capture_exception(const F &           f,
+                                        std::exception_ptr &eptr,
+                                        Args &&...args)
+    {
+      // See whether there is already something in the exception pointer
+      // variable. There is no reason why this should be so, and
+      // we should probably bail out:
+      AssertThrow(eptr == nullptr, ExcInternalError());
+
+      // Call the function and if that succeeds, return zero:
+      try
+        {
+          f(std::forward<Args>(args)...);
+          eptr = nullptr;
+          return 0;
+        }
+      // In case of an exception, capture the exception and
+      // return -1:
+      catch (...)
+        {
+          eptr = std::current_exception();
+          return -1;
+        }
+    }
+  } // namespace
+
+
+
   template <typename VectorType, typename PMatrixType, typename AMatrixType>
   DEAL_II_CXX20_REQUIRES((concepts::is_dealii_petsc_vector_type<VectorType> ||
                           std::constructible_from<VectorType, Vec>))
   NonlinearSolver<VectorType, PMatrixType, AMatrixType>::NonlinearSolver(
     const NonlinearSolverData &data,
     const MPI_Comm             mpi_comm)
+    : pending_exception(nullptr)
   {
     AssertPETSc(SNESCreate(mpi_comm, &snes));
     AssertPETSc(SNESSetApplicationContext(snes, this));
@@ -101,6 +143,8 @@ namespace PETScWrappers
   NonlinearSolver<VectorType, PMatrixType, AMatrixType>::~NonlinearSolver()
   {
     AssertPETSc(SNESDestroy(&snes));
+
+    Assert(pending_exception == nullptr, ExcInternalError());
   }
 
 
@@ -201,9 +245,10 @@ namespace PETScWrappers
 
       VectorType xdealii(x);
       VectorType fdealii(f);
-      AssertUser(user->residual(xdealii, fdealii), "residual");
+      const int  err = call_and_possibly_capture_exception(
+        user->residual, user->pending_exception, xdealii, fdealii);
       petsc_increment_state_counter(f);
-      PetscFunctionReturn(0);
+      PetscFunctionReturn(err);
     };
 
     const auto snes_jacobian =
@@ -214,7 +259,9 @@ namespace PETScWrappers
       VectorType  xdealii(x);
       AMatrixType Adealii(A);
       PMatrixType Pdealii(P);
-      AssertUser(user->jacobian(xdealii, Adealii, Pdealii), "jacobian");
+
+      const int err = call_and_possibly_capture_exception(
+        user->jacobian, user->pending_exception, xdealii, Adealii, Pdealii);
       petsc_increment_state_counter(P);
 
       // Handle the Jacobian-free case
@@ -229,7 +276,7 @@ namespace PETScWrappers
         }
       else
         petsc_increment_state_counter(A);
-      PetscFunctionReturn(0);
+      PetscFunctionReturn(err);
     };
 
     const auto snes_jacobian_with_setup =
@@ -243,7 +290,10 @@ namespace PETScWrappers
 
       user->A = &Adealii;
       user->P = &Pdealii;
-      AssertUser(user->setup_jacobian(xdealii), "setup_jacobian");
+      const int err =
+        call_and_possibly_capture_exception(user->setup_jacobian,
+                                            user->pending_exception,
+                                            xdealii);
       petsc_increment_state_counter(P);
 
       // Handle older versions of PETSc for which we cannot pass a MATSHELL
@@ -267,7 +317,8 @@ namespace PETScWrappers
         }
       else
         petsc_increment_state_counter(A);
-      PetscFunctionReturn(0);
+
+      PetscFunctionReturn(err);
     };
 
     const auto snes_monitor =
@@ -278,8 +329,9 @@ namespace PETScWrappers
       Vec x;
       AssertPETSc(SNESGetSolution(snes, &x));
       VectorType xdealii(x);
-      AssertUser(user->monitor(xdealii, it, f), "monitor");
-      PetscFunctionReturn(0);
+      const int  err = call_and_possibly_capture_exception(
+        user->monitor, user->pending_exception, xdealii, it, f);
+      PetscFunctionReturn(err);
     };
 
     const auto snes_objective =
@@ -289,9 +341,10 @@ namespace PETScWrappers
 
       real_type  v;
       VectorType xdealii(x);
-      AssertUser(user->energy(xdealii, v), "energy");
+      const int  err = call_and_possibly_capture_exception(
+        user->energy, user->pending_exception, xdealii, v);
       *f = v;
-      PetscFunctionReturn(0);
+      PetscFunctionReturn(err);
     };
 
     AssertThrow(residual,
@@ -365,7 +418,10 @@ namespace PETScWrappers
         precond.vmult = [&](VectorBase &indst, const VectorBase &insrc) -> int {
           VectorType       dst(static_cast<const Vec &>(indst));
           const VectorType src(static_cast<const Vec &>(insrc));
-          return solve_with_jacobian(src, dst);
+          return call_and_possibly_capture_exception(solve_with_jacobian,
+                                                     pending_exception,
+                                                     src,
+                                                     dst);
         };
 
         // Default Krylov solver (preconditioner only)
@@ -385,8 +441,32 @@ namespace PETScWrappers
     // Having set everything up, now do the actual work
     // and let PETSc solve the system.
     // Older versions of PETSc requires the solution vector specified even
-    // if we specified SNESSetSolution upfront
-    AssertPETSc(SNESSolve(snes, nullptr, x.petsc_vector()));
+    // if we specified SNESSetSolution upfront.
+    //
+    // If there is a pending exception, then one of the user callbacks
+    // threw an exception we didn't know how to deal with
+    // at the time. It is possible that PETSc managed to
+    // recover anyway and in that case would have returned
+    // a zero error code -- if so, just eat the exception and
+    // continue on; otherwise, just rethrow the exception
+    // and get outta here.
+    const int status = SNESSolve(snes, nullptr, x.petsc_vector());
+    if (pending_exception)
+      {
+        try
+          {
+            std::rethrow_exception(pending_exception);
+          }
+        catch (...)
+          {
+            pending_exception = nullptr;
+            if (status == 0)
+              /* just eat the exception */;
+            else
+              throw;
+          }
+      }
+    AssertPETSc(status);
 
     // Get the number of steps taken.
     PetscInt nt;

--- a/tests/petsc/petsc_snes_01.cc
+++ b/tests/petsc/petsc_snes_01.cc
@@ -51,14 +51,13 @@ main(int argc, char **argv)
 
     Solver solver;
 
-    solver.residual = [&](const VectorType &X, VectorType &F) -> int {
+    solver.residual = [&](const VectorType &X, VectorType &F) -> void {
       auto x = X.block(0)[0];
       auto y = X.block(1)[0];
 
       F.block(0)[0] = std::pow(x - std::pow(y, 3) + 1, 3) - std::pow(y, 3);
       F.block(1)[0] = x + 2 * y - 3;
       F.compress(VectorOperation::insert);
-      return 0;
     };
 
     VectorType x(2, MPI_COMM_SELF, 1, 1);
@@ -75,18 +74,17 @@ main(int argc, char **argv)
 
     Solver solver;
 
-    solver.residual = [&](const VectorType &X, VectorType &F) -> int {
+    solver.residual = [&](const VectorType &X, VectorType &F) -> void {
       auto x = X.block(0)[0];
       auto y = X.block(1)[0];
 
       F.block(0)[0] = std::pow(x - std::pow(y, 3) + 1, 3) - std::pow(y, 3);
       F.block(1)[0] = x + 2 * y - 3;
       F.compress(VectorOperation::insert);
-      return 0;
     };
 
     solver.jacobian =
-      [&](const VectorType &X, MatrixType &A, MatrixType &P) -> int {
+      [&](const VectorType &X, MatrixType &A, MatrixType &P) -> void {
       auto x    = X.block(0)[0];
       auto y    = X.block(1)[0];
       auto f0_x = 3 * std::pow(x - std::pow(y, 3) + 1, 2);
@@ -97,7 +95,6 @@ main(int argc, char **argv)
       P.block(1, 0).set(0, 0, 1);
       P.block(1, 1).set(0, 0, 2);
       P.compress(VectorOperation::insert);
-      return 0;
     };
 
     VectorType x(2, MPI_COMM_SELF, 1, 1);
@@ -132,19 +129,18 @@ main(int argc, char **argv)
 
     Solver solver;
 
-    solver.residual = [&](const VectorType &X, VectorType &F) -> int {
+    solver.residual = [&](const VectorType &X, VectorType &F) -> void {
       auto x = X.block(0)[0];
       auto y = X.block(1)[0];
 
       F.block(0)[0] = std::pow(x - std::pow(y, 3) + 1, 3) - std::pow(y, 3);
       F.block(1)[0] = x + 2 * y - 3;
       F.compress(VectorOperation::insert);
-      return 0;
     };
 
     FullMatrix<double> Jinv(2, 2);
 
-    solver.setup_jacobian = [&](const VectorType &X) -> int {
+    solver.setup_jacobian = [&](const VectorType &X) -> void {
       auto x    = X.block(0)[0];
       auto y    = X.block(1)[0];
       auto f0_x = 3 * std::pow(x - std::pow(y, 3) + 1, 2);
@@ -156,17 +152,15 @@ main(int argc, char **argv)
       J(1, 0) = 1;
       J(1, 1) = 2;
       Jinv.invert(J);
-      return 0;
     };
 
     solver.solve_with_jacobian = [&](const VectorType &src,
-                                     VectorType &      dst) -> int {
+                                     VectorType &      dst) -> void {
       dst.block(0)[0] =
         Jinv(0, 0) * src.block(0)[0] + Jinv(0, 1) * src.block(1)[0];
       dst.block(1)[0] =
         Jinv(1, 0) * src.block(0)[0] + Jinv(1, 1) * src.block(1)[0];
       dst.compress(VectorOperation::insert);
-      return 0;
     };
 
     VectorType x(2, MPI_COMM_SELF, 1, 1);
@@ -177,6 +171,4 @@ main(int argc, char **argv)
     out << "#   Solution " << x[0] << ", " << x[1] << std::endl;
     out << "#   Iterations " << nit << std::endl;
   }
-
-  return 0;
 }

--- a/tests/petsc/petsc_snes_02.cc
+++ b/tests/petsc/petsc_snes_02.cc
@@ -81,5 +81,4 @@ main(int argc, char **argv)
     {
       deallog << exc.what() << std::endl;
     }
-  return 0;
 }

--- a/tests/petsc/petsc_snes_03.cc
+++ b/tests/petsc/petsc_snes_03.cc
@@ -46,14 +46,12 @@ main(int argc, char **argv)
   {
     Solver solver;
 
-    solver.energy = [&](const VectorType &X, real_type &v) -> int {
+    solver.energy = [&](const VectorType &X, real_type &v) -> void {
       v = X.norm_sqr();
-      return 0;
     };
 
-    solver.residual = [&](const VectorType &X, VectorType &F) -> int {
+    solver.residual = [&](const VectorType &X, VectorType &F) -> void {
       F.equ(2, X);
-      return 0;
     };
 
     auto       commsize = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
@@ -66,5 +64,4 @@ main(int argc, char **argv)
     deallog << "Iterations " << nit << std::endl;
     x.print(deallog.get_file_stream());
   }
-  return 0;
 }

--- a/tests/petsc/petsc_snes_04.cc
+++ b/tests/petsc/petsc_snes_04.cc
@@ -42,9 +42,8 @@ main(int argc, char **argv)
 
     Solver solver(data);
 
-    solver.residual = [&](const VectorType &X, VectorType &F) -> int {
+    solver.residual = [&](const VectorType &X, VectorType &F) -> void {
       F.equ(2, X);
-      return 0;
     };
 
     auto       commsize = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
@@ -61,5 +60,4 @@ main(int argc, char **argv)
         deallog << exc.what() << std::endl;
       }
   }
-  return 0;
 }

--- a/tests/petsc/petsc_snes_05.cc
+++ b/tests/petsc/petsc_snes_05.cc
@@ -1,0 +1,79 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2023 by the deal.II authors
+//
+//    This file is part of the deal.II library.
+//
+//    The deal.II library is free software; you can use it, redistribute
+//    it, and/or modify it under the terms of the GNU Lesser General
+//    Public License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//    The full text of the license can be found in the file LICENSE.md at
+//    the top level directory of deal.II.
+//
+//-----------------------------------------------------------
+
+#include <deal.II/base/parameter_handler.h>
+
+#include <deal.II/lac/petsc_block_sparse_matrix.h>
+#include <deal.II/lac/petsc_block_vector.h>
+#include <deal.II/lac/petsc_snes.h>
+
+#include <cmath>
+
+#include "../tests.h"
+
+/**
+ * Find the solution of f(x)=sin(x)=0, which is rather simple to solve, starting
+ * at x=1.
+ */
+using VectorType = PETScWrappers::MPI::Vector;
+using MatrixType = PETScWrappers::MPI::SparseMatrix;
+using Solver     = PETScWrappers::NonlinearSolver<VectorType, MatrixType>;
+using real_type  = Solver::real_type;
+
+int
+main(int argc, char **argv)
+{
+  initlog();
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  {
+    PETScWrappers::NonlinearSolverData data;
+    Solver                             solver(data);
+
+    solver.residual = [&](const VectorType &X, VectorType &F) -> void {
+      deallog << "Evaluating the residual at x=" << X(0) << std::endl;
+
+      F(0) = std::sin(X(0));
+      F.compress(VectorOperation::insert);
+    };
+
+    solver.jacobian =
+      [&](const VectorType &X, MatrixType &A, MatrixType &P) -> void {
+      deallog << "Evaluating the Jacobian at x=" << X(0) << std::endl;
+
+      P.set(0, 0, std::cos(X(0)));
+      P.compress(VectorOperation::insert);
+      A.set(0, 0, std::cos(X(0)));
+      A.compress(VectorOperation::insert);
+    };
+
+    auto       commsize = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+    auto       commrank = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+    VectorType x(MPI_COMM_WORLD, 1, commrank == commsize - 1 ? 1 : 0);
+    x(0) = 1.0;
+
+    try
+      {
+        const auto nit = solver.solve(x);
+
+        deallog << "Found the solution x=" << x(0) << " after " << nit
+                << " iterations." << std::endl;
+      }
+    catch (std::exception &exc)
+      {
+        deallog << exc.what() << std::endl;
+      }
+  }
+}

--- a/tests/petsc/petsc_snes_05.output
+++ b/tests/petsc/petsc_snes_05.output
@@ -1,0 +1,11 @@
+
+DEAL::Evaluating the residual at x=1.00000
+DEAL::Evaluating the Jacobian at x=1.00000
+DEAL::Evaluating the residual at x=-0.557408
+DEAL::Evaluating the Jacobian at x=-0.557408
+DEAL::Evaluating the residual at x=0.0659365
+DEAL::Evaluating the Jacobian at x=0.0659365
+DEAL::Evaluating the residual at x=-9.57219e-05
+DEAL::Evaluating the Jacobian at x=-9.57219e-05
+DEAL::Evaluating the residual at x=2.92357e-13
+DEAL::Found the solution x=2.92357e-13 after 4 iterations.

--- a/tests/petsc/petsc_snes_06.cc
+++ b/tests/petsc/petsc_snes_06.cc
@@ -1,0 +1,96 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2023 by the deal.II authors
+//
+//    This file is part of the deal.II library.
+//
+//    The deal.II library is free software; you can use it, redistribute
+//    it, and/or modify it under the terms of the GNU Lesser General
+//    Public License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//    The full text of the license can be found in the file LICENSE.md at
+//    the top level directory of deal.II.
+//
+//-----------------------------------------------------------
+
+#include <deal.II/base/parameter_handler.h>
+
+#include <deal.II/lac/petsc_block_sparse_matrix.h>
+#include <deal.II/lac/petsc_block_vector.h>
+#include <deal.II/lac/petsc_snes.h>
+
+#include <cmath>
+
+#include "../tests.h"
+
+/**
+ * Find the solution of f(x)=sin(x)=0, which is rather simple to solve, starting
+ * at x=1.
+ *
+ * This test lets the residual function throw an exception if the step
+ * length was too large from the previous point of evaluation. Let's
+ * see whether PETSc SNES manages to recover by reducing the step
+ * length.
+ */
+using VectorType = PETScWrappers::MPI::Vector;
+using MatrixType = PETScWrappers::MPI::SparseMatrix;
+using Solver     = PETScWrappers::NonlinearSolver<VectorType, MatrixType>;
+using real_type  = Solver::real_type;
+
+int
+main(int argc, char **argv)
+{
+  initlog();
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  {
+    PETScWrappers::NonlinearSolverData data;
+    Solver                             solver(data);
+
+    const double starting_x         = 1;
+    double       last_residual_eval = starting_x;
+
+    solver.residual = [&](const VectorType &X, VectorType &F) -> void {
+      deallog << "Evaluating the residual at x=" << X(0) << std::endl;
+
+      if (std::abs(X(0) - last_residual_eval) > 1)
+        {
+          deallog << "Too large a step. Throwing a recoverable exception."
+                  << std::endl;
+          throw RecoverableUserCallbackError();
+        }
+
+      F(0) = std::sin(X(0));
+      F.compress(VectorOperation::insert);
+
+      last_residual_eval = X(0);
+    };
+
+    solver.jacobian =
+      [&](const VectorType &X, MatrixType &A, MatrixType &P) -> void {
+      deallog << "Evaluating the Jacobian at x=" << X(0) << std::endl;
+
+      P.set(0, 0, std::cos(X(0)));
+      P.compress(VectorOperation::insert);
+      A.set(0, 0, std::cos(X(0)));
+      A.compress(VectorOperation::insert);
+    };
+
+    auto       commsize = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+    auto       commrank = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+    VectorType x(MPI_COMM_WORLD, 1, commrank == commsize - 1 ? 1 : 0);
+    x(0) = starting_x;
+
+    try
+      {
+        const auto nit = solver.solve(x);
+
+        deallog << "Found the solution x=" << x(0) << " after " << nit
+                << " iterations." << std::endl;
+      }
+    catch (std::exception &exc)
+      {
+        deallog << exc.what() << std::endl;
+      }
+  }
+}

--- a/tests/petsc/petsc_snes_06.output
+++ b/tests/petsc/petsc_snes_06.output
@@ -1,0 +1,20 @@
+
+DEAL::Evaluating the residual at x=1.00000
+DEAL::Evaluating the Jacobian at x=1.00000
+DEAL::Evaluating the residual at x=-0.557408
+DEAL::Too large a step. Throwing a recoverable exception.
+DEAL::
+--------------------------------------------------------
+An error occurred in line <0> of file <> in function
+    
+The violated condition was: 
+    
+Additional information: 
+    A user call-back function encountered a recoverable error, but the
+    underlying library that called the call-back did not manage to recover
+    from the error and aborted its operation.
+    
+    See the glossary entry on user call-back functions for more
+    information.
+--------------------------------------------------------
+


### PR DESCRIPTION
The last patch for #15112. Same style as #15269. Including a couple of tests that check that PETSc SNES does not try to backtrack just because a user callback errors out with an exception.