### PR TITLE
FEPointEvaluation: skip renumbering when possible

### DIFF
--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -1693,19 +1693,21 @@ FEPointEvaluation<n_components_, dim, spacedim, Number>::prepare_evaluate_fast(
     {
       if (use_face_path)
         {
-          ScalarNumber *input  = scratch_data_scalar.begin();
-          ScalarNumber *output = input + dofs_per_component;
-
+          const ScalarNumber *input;
           if (renumber.empty())
-            input = const_cast<ScalarNumber *>(solution_values.data());
+            input = solution_values.data();
           else
             {
               const unsigned int *renumber_ptr =
                 renumber.data() +
                 (component_in_base_element + comp) * dofs_per_component;
               for (unsigned int i = 0; i < dofs_per_component; ++i)
-                input[i] = solution_values[renumber_ptr[i]];
+                scratch_data_scalar[i] = solution_values[renumber_ptr[i]];
+              input = scratch_data_scalar.data();
             }
+
+          ScalarNumber *output =
+            scratch_data_scalar.begin() + dofs_per_component;
 
           internal::FEFaceNormalEvaluationImpl<dim, -1, ScalarNumber>::
             template interpolate<true, false>(1,

--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -1764,9 +1764,10 @@ FEPointEvaluation<n_components_, dim, spacedim, Number>::compute_evaluate_fast(
             dim - 1,
             scalar_value_type,
             VectorizedArrayType,
-            2>(shapes_faces.data() + qb * n_shapes,
-               n_shapes,
-               solution_renumbered.data());
+            2,
+            true>(shapes_faces.data() + qb * n_shapes,
+                  n_shapes,
+                  solution_renumbered.data());
 
       value = interpolated_value[dim - 1];
       // reorder derivative from tangential/normal derivatives into tensor in
@@ -1816,9 +1817,11 @@ FEPointEvaluation<n_components_, dim, spacedim, Number>::compute_evaluate_fast(
           internal::evaluate_tensor_product_value_and_gradient_shapes<
             dim,
             scalar_value_type,
-            VectorizedArrayType>(shapes.data() + qb * n_shapes,
-                                 n_shapes,
-                                 solution_renumbered.data());
+            VectorizedArrayType,
+            1,
+            true>(shapes.data() + qb * n_shapes,
+                  n_shapes,
+                  solution_renumbered.data());
       gradient[0] = result[0];
       if (dim > 1)
         gradient[1] = result[1];

--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -1767,9 +1767,9 @@ FEPointEvaluation<n_components_, dim, spacedim, Number>::compute_evaluate_fast(
             scalar_value_type,
             VectorizedArrayType,
             2,
-            true>(shapes_faces.data() + qb * n_shapes,
-                  n_shapes,
-                  solution_renumbered.data());
+            false>(shapes_faces.data() + qb * n_shapes,
+                   n_shapes,
+                   solution_renumbered.data());
 
       value = interpolated_value[dim - 1];
       // reorder derivative from tangential/normal derivatives into tensor in
@@ -1821,9 +1821,9 @@ FEPointEvaluation<n_components_, dim, spacedim, Number>::compute_evaluate_fast(
             scalar_value_type,
             VectorizedArrayType,
             1,
-            true>(shapes.data() + qb * n_shapes,
-                  n_shapes,
-                  solution_renumbered.data());
+            false>(shapes.data() + qb * n_shapes,
+                   n_shapes,
+                   solution_renumbered.data());
       gradient[0] = result[0];
       if (dim > 1)
         gradient[1] = result[1];

--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -1610,7 +1610,7 @@ FEPointEvaluation<n_components_, dim, spacedim, Number>::do_reinit()
 
   // use face path if mapping_info in face state and number of quadrature points
   // is large enough
-  use_face_path = mapping_info->is_face_state() && n_q_points_scalar >= 9;
+  use_face_path = mapping_info->is_face_state() && n_q_points_scalar >= 6;
 
   // set unit point pointer
   const unsigned int unit_point_offset =

--- a/include/deal.II/matrix_free/tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/tensor_product_kernels.h
@@ -3042,7 +3042,8 @@ namespace internal
             int length,
             typename Number2,
             typename Number,
-            int n_values = 1>
+            int  n_values    = 1,
+            bool no_renumber = false>
   inline
 #ifndef DEBUG
     DEAL_II_ALWAYS_INLINE
@@ -3078,7 +3079,7 @@ namespace internal
 
         // Distinguish the inner loop based on whether we have a
         // renumbering or not
-        if (renumber.empty())
+        if (no_renumber || renumber.empty())
           for (int i0 = 0; i0 < n_shapes; ++i0, ++i)
             {
               // gradient
@@ -3129,7 +3130,11 @@ namespace internal
    * Interpolates the values and gradients into the points specified in
    * @p compute_values_of_array() with help of the precomputed @p shapes.
    */
-  template <int dim, typename Number, typename Number2, int n_values = 1>
+  template <int dim,
+            typename Number,
+            typename Number2,
+            int  n_values    = 1,
+            bool no_renumber = false>
   inline std::array<typename ProductTypeNoPoint<Number, Number2>::type,
                     dim + n_values>
   evaluate_tensor_product_value_and_gradient_shapes(
@@ -3164,23 +3169,29 @@ namespace internal
         // Generate separate code with known loop bounds for the most common
         // cases
         if (n_shapes == 2)
-          inner_result = do_interpolate_xy<dim, 2, Number2, Number, n_values>(
-            values, renumber, shapes, n_shapes, i);
+          inner_result =
+            do_interpolate_xy<dim, 2, Number2, Number, n_values, no_renumber>(
+              values, renumber, shapes, n_shapes, i);
         else if (n_shapes == 3)
-          inner_result = do_interpolate_xy<dim, 3, Number2, Number, n_values>(
-            values, renumber, shapes, n_shapes, i);
+          inner_result =
+            do_interpolate_xy<dim, 3, Number2, Number, n_values, no_renumber>(
+              values, renumber, shapes, n_shapes, i);
         else if (n_shapes == 4)
-          inner_result = do_interpolate_xy<dim, 4, Number2, Number, n_values>(
-            values, renumber, shapes, n_shapes, i);
+          inner_result =
+            do_interpolate_xy<dim, 4, Number2, Number, n_values, no_renumber>(
+              values, renumber, shapes, n_shapes, i);
         else if (n_shapes == 5)
-          inner_result = do_interpolate_xy<dim, 5, Number2, Number, n_values>(
-            values, renumber, shapes, n_shapes, i);
+          inner_result =
+            do_interpolate_xy<dim, 5, Number2, Number, n_values, no_renumber>(
+              values, renumber, shapes, n_shapes, i);
         else if (n_shapes == 6)
-          inner_result = do_interpolate_xy<dim, 6, Number2, Number, n_values>(
-            values, renumber, shapes, n_shapes, i);
+          inner_result =
+            do_interpolate_xy<dim, 6, Number2, Number, n_values, no_renumber>(
+              values, renumber, shapes, n_shapes, i);
         else
-          inner_result = do_interpolate_xy<dim, -1, Number2, Number, n_values>(
-            values, renumber, shapes, n_shapes, i);
+          inner_result =
+            do_interpolate_xy<dim, -1, Number2, Number, n_values, no_renumber>(
+              values, renumber, shapes, n_shapes, i);
         if (dim == 3)
           {
             // derivative + interpolation in z direction

--- a/include/deal.II/matrix_free/tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/tensor_product_kernels.h
@@ -3043,7 +3043,7 @@ namespace internal
             typename Number2,
             typename Number,
             int  n_values    = 1,
-            bool no_renumber = false>
+            bool do_renumber = true>
   inline
 #ifndef DEBUG
     DEAL_II_ALWAYS_INLINE
@@ -3079,17 +3079,7 @@ namespace internal
 
         // Distinguish the inner loop based on whether we have a
         // renumbering or not
-        if (no_renumber || renumber.empty())
-          for (int i0 = 0; i0 < n_shapes; ++i0, ++i)
-            {
-              // gradient
-              inner_result[0] += shapes[i0][1][0] * values[i];
-              // values
-              inner_result[1] += shapes[i0][0][0] * values[i];
-              if (n_values > 1)
-                inner_result[2] += shapes[i0][0][0] * values_2[i];
-            }
-        else
+        if (do_renumber && !renumber.empty())
           for (int i0 = 0; i0 < n_shapes; ++i0, ++i)
             {
               // gradient
@@ -3098,6 +3088,16 @@ namespace internal
               inner_result[1] += shapes[i0][0][0] * values[renumber[i]];
               if (n_values > 1)
                 inner_result[2] += shapes[i0][0][0] * values_2[renumber[i]];
+            }
+        else
+          for (int i0 = 0; i0 < n_shapes; ++i0, ++i)
+            {
+              // gradient
+              inner_result[0] += shapes[i0][1][0] * values[i];
+              // values
+              inner_result[1] += shapes[i0][0][0] * values[i];
+              if (n_values > 1)
+                inner_result[2] += shapes[i0][0][0] * values_2[i];
             }
 
         if (dim > 1)
@@ -3134,7 +3134,7 @@ namespace internal
             typename Number,
             typename Number2,
             int  n_values    = 1,
-            bool no_renumber = false>
+            bool do_renumber = true>
   inline std::array<typename ProductTypeNoPoint<Number, Number2>::type,
                     dim + n_values>
   evaluate_tensor_product_value_and_gradient_shapes(
@@ -3170,27 +3170,27 @@ namespace internal
         // cases
         if (n_shapes == 2)
           inner_result =
-            do_interpolate_xy<dim, 2, Number2, Number, n_values, no_renumber>(
+            do_interpolate_xy<dim, 2, Number2, Number, n_values, do_renumber>(
               values, renumber, shapes, n_shapes, i);
         else if (n_shapes == 3)
           inner_result =
-            do_interpolate_xy<dim, 3, Number2, Number, n_values, no_renumber>(
+            do_interpolate_xy<dim, 3, Number2, Number, n_values, do_renumber>(
               values, renumber, shapes, n_shapes, i);
         else if (n_shapes == 4)
           inner_result =
-            do_interpolate_xy<dim, 4, Number2, Number, n_values, no_renumber>(
+            do_interpolate_xy<dim, 4, Number2, Number, n_values, do_renumber>(
               values, renumber, shapes, n_shapes, i);
         else if (n_shapes == 5)
           inner_result =
-            do_interpolate_xy<dim, 5, Number2, Number, n_values, no_renumber>(
+            do_interpolate_xy<dim, 5, Number2, Number, n_values, do_renumber>(
               values, renumber, shapes, n_shapes, i);
         else if (n_shapes == 6)
           inner_result =
-            do_interpolate_xy<dim, 6, Number2, Number, n_values, no_renumber>(
+            do_interpolate_xy<dim, 6, Number2, Number, n_values, do_renumber>(
               values, renumber, shapes, n_shapes, i);
         else
           inner_result =
-            do_interpolate_xy<dim, -1, Number2, Number, n_values, no_renumber>(
+            do_interpolate_xy<dim, -1, Number2, Number, n_values, do_renumber>(
               values, renumber, shapes, n_shapes, i);
         if (dim == 3)
           {


### PR DESCRIPTION
Skips the renumbering in `FEPointEvaluation` and removes the check for renumbering in the kernel function via a template argument.

@peterrum @kronbichler 