### PR TITLE
FEPointEvaluation: Integrate should use JxW

### DIFF
--- a/doc/news/changes/incompatibilities/20230529Bergbauer
+++ b/doc/news/changes/incompatibilities/20230529Bergbauer
@@ -1,0 +1,6 @@
+Changed: The integrate() function of FEPointEvaluation now multiplies the submitted
+entities internally with a JxW value to represent a proper integration like in FEEvaluation.
+The old behavior (where the entities are only multiplied with the test functions and summed up)
+is available through the new function test_and_sum().
+<br>
+(Maximilian Bergbauer, 2023/05/29)

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -4080,7 +4080,7 @@ MGTwoLevelTransferNonNested<dim, LinearAlgebra::distributed::Vector<Number>>::
           evaluator.submit_value(
             values[q + cell_data.reference_point_ptrs[cell]], q);
 
-        evaluator.integrate(solution_values, EvaluationFlags::values);
+        evaluator.test_and_sum(solution_values, EvaluationFlags::values);
 
         // resolve constraints and scatter
         internal::VectorDistributorLocalToGlobal<Number, VectorizedArrayType>

--- a/tests/matrix_free/point_evaluation_01.cc
+++ b/tests/matrix_free/point_evaluation_01.cc
@@ -125,8 +125,9 @@ test(const unsigned int degree)
           evaluator.submit_gradient(evaluator.get_gradient(i), i);
         }
 
-      evaluator.integrate(solution_values,
-                          EvaluationFlags::values | EvaluationFlags::gradients);
+      evaluator.test_and_sum(solution_values,
+                             EvaluationFlags::values |
+                               EvaluationFlags::gradients);
 
       for (const auto i : solution_values)
         deallog << factor_float * i << ' ';

--- a/tests/matrix_free/point_evaluation_02.cc
+++ b/tests/matrix_free/point_evaluation_02.cc
@@ -118,8 +118,9 @@ test(const unsigned int degree)
           evaluator.submit_gradient(evaluator.get_gradient(i), i);
         }
 
-      evaluator.integrate(solution_values,
-                          EvaluationFlags::values | EvaluationFlags::gradients);
+      evaluator.test_and_sum(solution_values,
+                             EvaluationFlags::values |
+                               EvaluationFlags::gradients);
 
       for (const auto i : solution_values)
         deallog << i << ' ';

--- a/tests/matrix_free/point_evaluation_03.cc
+++ b/tests/matrix_free/point_evaluation_03.cc
@@ -134,8 +134,9 @@ test(const unsigned int degree)
           evaluator.submit_gradient(evaluator.get_gradient(i), i);
         }
 
-      evaluator.integrate(solution_values,
-                          EvaluationFlags::values | EvaluationFlags::gradients);
+      evaluator.test_and_sum(solution_values,
+                             EvaluationFlags::values |
+                               EvaluationFlags::gradients);
 
       for (const auto i : solution_values)
         deallog << i << ' ';

--- a/tests/matrix_free/point_evaluation_04.cc
+++ b/tests/matrix_free/point_evaluation_04.cc
@@ -161,16 +161,17 @@ test(const unsigned int degree)
           evaluator_scalar.submit_gradient(evaluator_scalar.get_gradient(i), i);
         }
 
-      evaluator.integrate(solution_values,
-                          EvaluationFlags::values | EvaluationFlags::gradients);
+      evaluator.test_and_sum(solution_values,
+                             EvaluationFlags::values |
+                               EvaluationFlags::gradients);
 
       for (const auto i : solution_values)
         deallog << i << ' ';
       deallog << std::endl;
 
-      evaluator_scalar.integrate(solution_values,
-                                 EvaluationFlags::values |
-                                   EvaluationFlags::gradients);
+      evaluator_scalar.test_and_sum(solution_values,
+                                    EvaluationFlags::values |
+                                      EvaluationFlags::gradients);
 
       for (const auto i : solution_values)
         deallog << i << ' ';

--- a/tests/matrix_free/point_evaluation_05.cc
+++ b/tests/matrix_free/point_evaluation_05.cc
@@ -126,8 +126,9 @@ test(const unsigned int degree)
           evaluator.submit_gradient(evaluator.get_gradient(i), i);
         }
 
-      evaluator.integrate(solution_values,
-                          EvaluationFlags::values | EvaluationFlags::gradients);
+      evaluator.test_and_sum(solution_values,
+                             EvaluationFlags::values |
+                               EvaluationFlags::gradients);
 
       for (const auto i : solution_values)
         deallog << i << ' ';

--- a/tests/matrix_free/point_evaluation_06.cc
+++ b/tests/matrix_free/point_evaluation_06.cc
@@ -127,8 +127,9 @@ test(const unsigned int degree)
           evaluator.submit_gradient(evaluator.get_gradient(i), i);
         }
 
-      evaluator.integrate(solution_values,
-                          EvaluationFlags::values | EvaluationFlags::gradients);
+      evaluator.test_and_sum(solution_values,
+                             EvaluationFlags::values |
+                               EvaluationFlags::gradients);
 
       for (const auto i : solution_values)
         deallog << i << ' ';

--- a/tests/matrix_free/point_evaluation_07.cc
+++ b/tests/matrix_free/point_evaluation_07.cc
@@ -141,8 +141,9 @@ test(const unsigned int degree)
           evaluator.submit_gradient(evaluator.get_gradient(i), i);
         }
 
-      evaluator.integrate(solution_values,
-                          EvaluationFlags::values | EvaluationFlags::gradients);
+      evaluator.test_and_sum(solution_values,
+                             EvaluationFlags::values |
+                               EvaluationFlags::gradients);
 
       for (const auto i : solution_values)
         deallog << i << ' ';

--- a/tests/matrix_free/point_evaluation_08.cc
+++ b/tests/matrix_free/point_evaluation_08.cc
@@ -168,16 +168,17 @@ test(const unsigned int degree)
           evaluator_scalar.submit_gradient(evaluator_scalar.get_gradient(i), i);
         }
 
-      evaluator.integrate(solution_values,
-                          EvaluationFlags::values | EvaluationFlags::gradients);
+      evaluator.test_and_sum(solution_values,
+                             EvaluationFlags::values |
+                               EvaluationFlags::gradients);
 
       for (const auto i : solution_values)
         deallog << i << ' ';
       deallog << std::endl;
 
-      evaluator_scalar.integrate(solution_values,
-                                 EvaluationFlags::values |
-                                   EvaluationFlags::gradients);
+      evaluator_scalar.test_and_sum(solution_values,
+                                    EvaluationFlags::values |
+                                      EvaluationFlags::gradients);
 
       for (const auto i : solution_values)
         deallog << i << ' ';

--- a/tests/matrix_free/point_evaluation_09.cc
+++ b/tests/matrix_free/point_evaluation_09.cc
@@ -142,8 +142,9 @@ test(const unsigned int degree)
           evaluator.submit_gradient(evaluator.get_gradient(i), i);
         }
 
-      evaluator.integrate(solution_values,
-                          EvaluationFlags::values | EvaluationFlags::gradients);
+      evaluator.test_and_sum(solution_values,
+                             EvaluationFlags::values |
+                               EvaluationFlags::gradients);
 
       for (const auto i : solution_values)
         deallog << i << ' ';

--- a/tests/matrix_free/point_evaluation_10.cc
+++ b/tests/matrix_free/point_evaluation_10.cc
@@ -120,8 +120,9 @@ test(const unsigned int degree)
           evaluator.submit_gradient(evaluator.get_gradient(i), i);
         }
 
-      evaluator.integrate(solution_values,
-                          EvaluationFlags::values | EvaluationFlags::gradients);
+      evaluator.test_and_sum(solution_values,
+                             EvaluationFlags::values |
+                               EvaluationFlags::gradients);
 
       for (const auto i : solution_values)
         deallog << i << ' ';

--- a/tests/matrix_free/point_evaluation_11.cc
+++ b/tests/matrix_free/point_evaluation_11.cc
@@ -118,8 +118,9 @@ test(const unsigned int degree)
           evaluator.submit_gradient(evaluator.get_gradient(i), i);
         }
 
-      evaluator.integrate(solution_values,
-                          EvaluationFlags::values | EvaluationFlags::gradients);
+      evaluator.test_and_sum(solution_values,
+                             EvaluationFlags::values |
+                               EvaluationFlags::gradients);
 
       for (const auto i : solution_values)
         deallog << i << ' ';

--- a/tests/matrix_free/point_evaluation_13.cc
+++ b/tests/matrix_free/point_evaluation_13.cc
@@ -132,8 +132,9 @@ test()
           evaluator.submit_gradient(evaluator.get_gradient(i), i);
         }
 
-      evaluator.integrate(solution_values,
-                          EvaluationFlags::values | EvaluationFlags::gradients);
+      evaluator.test_and_sum(solution_values,
+                             EvaluationFlags::values |
+                               EvaluationFlags::gradients);
 
       for (const auto i : solution_values)
         deallog << i << ' ';

--- a/tests/matrix_free/point_evaluation_14.cc
+++ b/tests/matrix_free/point_evaluation_14.cc
@@ -137,8 +137,9 @@ test(const unsigned int degree)
           evaluator.submit_gradient(evaluator.get_gradient(i), i);
         }
 
-      evaluator.integrate(solution_values,
-                          EvaluationFlags::values | EvaluationFlags::gradients);
+      evaluator.test_and_sum(solution_values,
+                             EvaluationFlags::values |
+                               EvaluationFlags::gradients);
 
       for (const auto i : solution_values)
         deallog << i << ' ';

--- a/tests/matrix_free/point_evaluation_15.cc
+++ b/tests/matrix_free/point_evaluation_15.cc
@@ -134,12 +134,12 @@ test()
           evaluator2.submit_gradient(evaluator2.get_gradient(i), i);
         }
 
-      evaluator1.integrate(solution_values,
-                           EvaluationFlags::values |
-                             EvaluationFlags::gradients);
-      evaluator2.integrate(solution_values2,
-                           EvaluationFlags::values |
-                             EvaluationFlags::gradients);
+      evaluator1.test_and_sum(solution_values,
+                              EvaluationFlags::values |
+                                EvaluationFlags::gradients);
+      evaluator2.test_and_sum(solution_values2,
+                              EvaluationFlags::values |
+                                EvaluationFlags::gradients);
 
       for (unsigned int i = 0; i < solution_values.size(); ++i)
         deallog << solution_values[i] - solution_values2[i] << ' ';

--- a/tests/matrix_free/point_evaluation_16.cc
+++ b/tests/matrix_free/point_evaluation_16.cc
@@ -136,11 +136,12 @@ test(const unsigned int degree)
           evaluator2.submit_gradient(evaluator2.get_gradient(i), i);
         }
 
-      evaluator.integrate(solution_values,
-                          EvaluationFlags::values | EvaluationFlags::gradients);
-      evaluator2.integrate(solution_values2,
-                           EvaluationFlags::values |
-                             EvaluationFlags::gradients);
+      evaluator.test_and_sum(solution_values,
+                             EvaluationFlags::values |
+                               EvaluationFlags::gradients);
+      evaluator2.test_and_sum(solution_values2,
+                              EvaluationFlags::values |
+                                EvaluationFlags::gradients);
 
       for (unsigned int i = 0; i < solution_values.size(); ++i)
         deallog << solution_values[i] - solution_values2[i] << ' ';

--- a/tests/matrix_free/point_evaluation_17.cc
+++ b/tests/matrix_free/point_evaluation_17.cc
@@ -137,12 +137,12 @@ test()
           evaluator2.submit_gradient(evaluator2.get_gradient(i), i);
         }
 
-      evaluator1.integrate(solution_values,
-                           EvaluationFlags::values |
-                             EvaluationFlags::gradients);
-      evaluator2.integrate(solution_values2,
-                           EvaluationFlags::values |
-                             EvaluationFlags::gradients);
+      evaluator1.test_and_sum(solution_values,
+                              EvaluationFlags::values |
+                                EvaluationFlags::gradients);
+      evaluator2.test_and_sum(solution_values2,
+                              EvaluationFlags::values |
+                                EvaluationFlags::gradients);
 
       for (unsigned int i = 0; i < solution_values.size(); ++i)
         deallog << solution_values[i] - solution_values2[i] << ' ';

--- a/tests/matrix_free/point_evaluation_21.cc
+++ b/tests/matrix_free/point_evaluation_21.cc
@@ -130,15 +130,16 @@ test(const unsigned int degree)
           evaluator_move.submit_gradient(evaluator_move.get_gradient(i), i);
         }
 
-      evaluator.integrate(solution_values,
-                          EvaluationFlags::values | EvaluationFlags::gradients);
+      evaluator.test_and_sum(solution_values,
+                             EvaluationFlags::values |
+                               EvaluationFlags::gradients);
 
       for (const auto i : solution_values)
         deallog << factor_float * i << ' ';
 
-      evaluator_move.integrate(solution_values,
-                               EvaluationFlags::values |
-                                 EvaluationFlags::gradients);
+      evaluator_move.test_and_sum(solution_values,
+                                  EvaluationFlags::values |
+                                    EvaluationFlags::gradients);
 
       deallog << std::endl;
 

--- a/tests/matrix_free/point_evaluation_22.cc
+++ b/tests/matrix_free/point_evaluation_22.cc
@@ -147,8 +147,9 @@ test(const unsigned int degree, const bool is_mapping_q = true)
           evaluator.submit_gradient(evaluator.get_gradient(i), i);
         }
 
-      evaluator.integrate(solution_values,
-                          EvaluationFlags::values | EvaluationFlags::gradients);
+      evaluator.test_and_sum(solution_values,
+                             EvaluationFlags::values |
+                               EvaluationFlags::gradients);
 
       for (const auto i : solution_values)
         deallog << factor_float * i << ' ';

--- a/tests/matrix_free/point_evaluation_23.cc
+++ b/tests/matrix_free/point_evaluation_23.cc
@@ -138,9 +138,9 @@ test(const unsigned int degree)
               evaluator.submit_gradient(evaluator.get_gradient(i), i);
             }
 
-          evaluator.integrate(solution_values_out,
-                              EvaluationFlags::values |
-                                EvaluationFlags::gradients);
+          evaluator.test_and_sum(solution_values_out,
+                                 EvaluationFlags::values |
+                                   EvaluationFlags::gradients);
 
           for (double i : solution_values_out)
             deallog << i << ' ';

--- a/tests/matrix_free/point_evaluation_24.cc
+++ b/tests/matrix_free/point_evaluation_24.cc
@@ -138,9 +138,9 @@ test(const unsigned int degree)
               evaluator.submit_gradient(evaluator.get_gradient(i), i);
             }
 
-          evaluator.integrate(solution_values_out,
-                              EvaluationFlags::values |
-                                EvaluationFlags::gradients);
+          evaluator.test_and_sum(solution_values_out,
+                                 EvaluationFlags::values |
+                                   EvaluationFlags::gradients);
 
           for (double i : solution_values_out)
             deallog << i << ' ';

--- a/tests/non_matching/mapping_info.cc
+++ b/tests/non_matching/mapping_info.cc
@@ -211,9 +211,8 @@ test(const bool filtered_compression)
 
         for (const auto q : fe_point.quadrature_point_indices())
           {
-            fe_point.submit_value(fe_point.JxW(q) * fe_point.get_value(q), q);
-            fe_point.submit_gradient(fe_point.JxW(q) * fe_point.get_gradient(q),
-                                     q);
+            fe_point.submit_value(fe_point.get_value(q), q);
+            fe_point.submit_gradient(fe_point.get_gradient(q), q);
           }
 
         fe_point.integrate(solution_values_out,
@@ -247,13 +246,12 @@ test(const bool filtered_compression)
 
           for (const auto q : fe_point_faces_m.quadrature_point_indices())
             {
-              fe_point_faces_m.submit_value(fe_point_faces_m.JxW(q) *
-                                              (fe_point_faces_m.get_value(q) -
-                                               fe_point_faces_p.get_value(q)),
+              fe_point_faces_m.submit_value(fe_point_faces_m.get_value(q) -
+                                              fe_point_faces_p.get_value(q),
                                             q);
               fe_point_faces_m.submit_gradient(
-                fe_point_faces_m.JxW(q) * (fe_point_faces_m.get_gradient(q) -
-                                           fe_point_faces_p.get_gradient(q)),
+                fe_point_faces_m.get_gradient(q) -
+                  fe_point_faces_p.get_gradient(q),
                 q);
             }
 

--- a/tests/remote_point_evaluation/remote_point_evaluation_01.cc
+++ b/tests/remote_point_evaluation/remote_point_evaluation_01.cc
@@ -384,7 +384,7 @@ compute_force_vector_sharp_interface(
         for (unsigned int q = 0; q < unit_points.size(); ++q)
           phi_force.submit_value(force_JxW[q], q);
 
-        phi_force.integrate(buffer, EvaluationFlags::values);
+        phi_force.test_and_sum(buffer, EvaluationFlags::values);
 
         constraints.distribute_local_to_global(buffer,
                                                local_dof_indices,

--- a/tests/remote_point_evaluation/remote_point_evaluation_02.cc
+++ b/tests/remote_point_evaluation/remote_point_evaluation_02.cc
@@ -313,7 +313,7 @@ compute_force_vector_sharp_interface(
 
         // integrate_scatter force
         {
-          phi_force.integrate(buffer_dim, EvaluationFlags::values);
+          phi_force.test_and_sum(buffer_dim, EvaluationFlags::values);
 
           constraints.distribute_local_to_global(buffer_dim,
                                                  local_dof_indices_dim,


### PR DESCRIPTION
This PR makes `FEPointEvaluation::integrate()` multiply with JxW internally. (To really do an integration and make it behave like `FEEvaluation::integrate()` in a sense.)

The old behavior is available via the new function `test_and_sum()`. This is an incompatible change.

@kronbichler @peterrum 