### PR TITLE
Use distinct names for PETSC call_and_possibly_capture_exception functions

### DIFF
--- a/include/deal.II/lac/petsc_snes.templates.h
+++ b/include/deal.II/lac/petsc_snes.templates.h
@@ -53,9 +53,9 @@ namespace PETScWrappers
      */
     template <typename F, typename... Args>
     int
-    call_and_possibly_capture_exception(const F &           f,
-                                        std::exception_ptr &eptr,
-                                        Args &&...args)
+    call_and_possibly_capture_snes_exception(const F &           f,
+                                             std::exception_ptr &eptr,
+                                             Args &&...args)
     {
       // See whether there is already something in the exception pointer
       // variable. There is no reason why this should be so, and
@@ -235,7 +235,7 @@ namespace PETScWrappers
 
       VectorType xdealii(x);
       VectorType fdealii(f);
-      const int  err = call_and_possibly_capture_exception(
+      const int  err = call_and_possibly_capture_snes_exception(
         user->residual, user->pending_exception, xdealii, fdealii);
       petsc_increment_state_counter(f);
       PetscFunctionReturn(err);
@@ -250,7 +250,7 @@ namespace PETScWrappers
       AMatrixType Adealii(A);
       PMatrixType Pdealii(P);
 
-      const int err = call_and_possibly_capture_exception(
+      const int err = call_and_possibly_capture_snes_exception(
         user->jacobian, user->pending_exception, xdealii, Adealii, Pdealii);
       petsc_increment_state_counter(P);
 
@@ -281,9 +281,9 @@ namespace PETScWrappers
       user->A = &Adealii;
       user->P = &Pdealii;
       const int err =
-        call_and_possibly_capture_exception(user->setup_jacobian,
-                                            user->pending_exception,
-                                            xdealii);
+        call_and_possibly_capture_snes_exception(user->setup_jacobian,
+                                                 user->pending_exception,
+                                                 xdealii);
       petsc_increment_state_counter(P);
 
       // Handle older versions of PETSc for which we cannot pass a MATSHELL
@@ -319,7 +319,7 @@ namespace PETScWrappers
       Vec x;
       AssertPETSc(SNESGetSolution(snes, &x));
       VectorType xdealii(x);
-      const int  err = call_and_possibly_capture_exception(
+      const int  err = call_and_possibly_capture_snes_exception(
         user->monitor, user->pending_exception, xdealii, it, f);
       PetscFunctionReturn(err);
     };
@@ -331,7 +331,7 @@ namespace PETScWrappers
 
       real_type  v;
       VectorType xdealii(x);
-      const int  err = call_and_possibly_capture_exception(
+      const int  err = call_and_possibly_capture_snes_exception(
         user->energy, user->pending_exception, xdealii, v);
       *f = v;
       PetscFunctionReturn(err);
@@ -408,10 +408,10 @@ namespace PETScWrappers
         precond.vmult = [&](VectorBase &indst, const VectorBase &insrc) -> int {
           VectorType       dst(static_cast<const Vec &>(indst));
           const VectorType src(static_cast<const Vec &>(insrc));
-          return call_and_possibly_capture_exception(solve_with_jacobian,
-                                                     pending_exception,
-                                                     src,
-                                                     dst);
+          return call_and_possibly_capture_snes_exception(solve_with_jacobian,
+                                                          pending_exception,
+                                                          src,
+                                                          dst);
         };
 
         // Default Krylov solver (preconditioner only)

--- a/include/deal.II/lac/petsc_ts.templates.h
+++ b/include/deal.II/lac/petsc_ts.templates.h
@@ -53,9 +53,9 @@ namespace PETScWrappers
      */
     template <typename F, typename... Args>
     int
-    call_and_possibly_capture_exception(const F &           f,
-                                        std::exception_ptr &eptr,
-                                        Args &&...args)
+    call_and_possibly_capture_ts_exception(const F &           f,
+                                           std::exception_ptr &eptr,
+                                           Args &&...args)
     {
       // See whether there is already something in the exception pointer
       // variable. There is no reason why this should be so, and
@@ -287,12 +287,12 @@ namespace PETScWrappers
       VectorType xdotdealii(xdot);
       VectorType fdealii(f);
       const int  err =
-        call_and_possibly_capture_exception(user->implicit_function,
-                                            user->pending_exception,
-                                            t,
-                                            xdealii,
-                                            xdotdealii,
-                                            fdealii);
+        call_and_possibly_capture_ts_exception(user->implicit_function,
+                                               user->pending_exception,
+                                               t,
+                                               xdealii,
+                                               xdotdealii,
+                                               fdealii);
       petsc_increment_state_counter(f);
       PetscFunctionReturn(err);
     };
@@ -309,14 +309,14 @@ namespace PETScWrappers
       PMatrixType Pdealii(P);
 
       const int err =
-        call_and_possibly_capture_exception(user->implicit_jacobian,
-                                            user->pending_exception,
-                                            t,
-                                            xdealii,
-                                            xdotdealii,
-                                            s,
-                                            Adealii,
-                                            Pdealii);
+        call_and_possibly_capture_ts_exception(user->implicit_jacobian,
+                                               user->pending_exception,
+                                               t,
+                                               xdealii,
+                                               xdotdealii,
+                                               s,
+                                               Adealii,
+                                               Pdealii);
 
       petsc_increment_state_counter(P);
 
@@ -350,12 +350,12 @@ namespace PETScWrappers
       user->A = &Adealii;
       user->P = &Pdealii;
       const int err =
-        call_and_possibly_capture_exception(user->setup_jacobian,
-                                            user->pending_exception,
-                                            t,
-                                            xdealii,
-                                            xdotdealii,
-                                            s);
+        call_and_possibly_capture_ts_exception(user->setup_jacobian,
+                                               user->pending_exception,
+                                               t,
+                                               xdealii,
+                                               xdotdealii,
+                                               s);
 
       petsc_increment_state_counter(P);
 
@@ -395,7 +395,7 @@ namespace PETScWrappers
       VectorType xdealii(x);
       VectorType fdealii(f);
 
-      const int err = call_and_possibly_capture_exception(
+      const int err = call_and_possibly_capture_ts_exception(
         user->explicit_function, user->pending_exception, t, xdealii, fdealii);
       petsc_increment_state_counter(f);
       PetscFunctionReturn(err);
@@ -411,12 +411,12 @@ namespace PETScWrappers
       PMatrixType Pdealii(P);
 
       const int err =
-        call_and_possibly_capture_exception(user->explicit_jacobian,
-                                            user->pending_exception,
-                                            t,
-                                            xdealii,
-                                            Adealii,
-                                            Pdealii);
+        call_and_possibly_capture_ts_exception(user->explicit_jacobian,
+                                               user->pending_exception,
+                                               t,
+                                               xdealii,
+                                               Adealii,
+                                               Pdealii);
 
       petsc_increment_state_counter(P);
 
@@ -452,7 +452,7 @@ namespace PETScWrappers
       auto user = static_cast<TimeStepper *>(ctx);
 
       VectorType xdealii(x);
-      const int  err = call_and_possibly_capture_exception(
+      const int  err = call_and_possibly_capture_ts_exception(
         user->monitor, user->pending_exception, t, xdealii, it);
       PetscFunctionReturn(err);
     };
@@ -544,10 +544,10 @@ namespace PETScWrappers
         precond.vmult = [&](VectorBase &indst, const VectorBase &insrc) -> int {
           VectorType       dst(static_cast<const Vec &>(indst));
           const VectorType src(static_cast<const Vec &>(insrc));
-          return call_and_possibly_capture_exception(solve_with_jacobian,
-                                                     pending_exception,
-                                                     src,
-                                                     dst);
+          return call_and_possibly_capture_ts_exception(solve_with_jacobian,
+                                                        pending_exception,
+                                                        src,
+                                                        dst);
         };
 
         // Default Krylov solver (preconditioner only)


### PR DESCRIPTION
This should fix the `clang-tidy` issues we are currently seeing.