### PR TITLE
MappingFEField: Remove update_JxW_values for Piola transform

### DIFF
--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -496,15 +496,6 @@ MappingFEField<dim, spacedim, VectorType>::requires_update_flags(
            update_jacobian_pushed_forward_3rd_derivatives))
         out |= update_covariant_transformation;
 
-      // The contravariant transformation
-      // is a Piola transformation, which
-      // requires the determinant of the
-      // Jacobi matrix of the transformation.
-      // Therefore these values have to be
-      // updated for each cell.
-      if (out & update_contravariant_transformation)
-        out |= update_JxW_values;
-
       if (out & update_normal_vectors)
         out |= update_JxW_values;
     }


### PR DESCRIPTION
The comment seems outdated, see https://github.com/dealii/dealii/blob/b065060f03394ccfd68e30b48bca1986da95bd33/source/fe/mapping_fe_field.cc#L1979-L1997 where `update_volume_elements` is used and the contravariant transformation https://github.com/dealii/dealii/blob/2896a7e6381a97c79d9cad55ba4c2f1fbac4b05a/source/fe/mapping_fe_field.cc#L736-L764

We should not set `update_JxW_values` when not necessary. Preparation for https://github.com/dealii/dealii/pull/15281