### PR TITLE
Add CITATIONS.bib file to suggest citation in GitHub

### DIFF
--- a/CITATIONS.bib
+++ b/CITATIONS.bib
@@ -1,0 +1,48 @@
+@article{dealII94,
+  title     = {The \texttt{deal.II} Library, Version 9.4},
+  author    = {Daniel Arndt and Wolfgang Bangerth and Marco Feder and
+               Marc Fehling and Rene Gassm{\"o}ller and Timo Heister
+               and Luca Heltai and Martin Kronbichler and
+	       Matthias Maier and Peter Munch and Jean-Paul Pelteret
+	       and Simon Sticko and Bruno Turcksin and David Wells},
+  journal   = {Journal of Numerical Mathematics},
+  doi       = {10.1515/jnma-2022-0054},
+  year      = {2022},
+  volume    = {30},
+  number    = {3},
+  pages     = {231-246},
+  url       = {https://dealii.org/deal94-preprint.pdf}
+}
+
+@article{dealII93,
+  title     = {The \texttt{deal.II} Library, Version 9.3},
+  author    = {Daniel Arndt and Wolfgang Bangerth and Bruno Blais and
+               Marc Fehling and Rene Gassm{\"o}ller and Timo Heister
+               and Luca Heltai and Uwe K{\"o}cher and Martin
+               Kronbichler and Matthias Maier and Peter Munch and
+               Jean-Paul Pelteret and Sebastian Proell and Konrad
+               Simon and Bruno Turcksin and David Wells and Jiaqi
+               Zhang},
+  journal   = {Journal of Numerical Mathematics},
+  year      = {2021},
+  url       = {https://dealii.org/deal93-preprint.pdf},
+  doi       = {10.1515/jnma-2021-0081},
+  volume    = {29},
+  number    = {3},
+  pages     = {171--186}
+}
+
+@Article{dealii2019design,
+  title   = {The {deal.II} finite element library: Design, features, and insights},
+  author  = {Daniel Arndt and Wolfgang Bangerth and Denis Davydov and
+             Timo Heister and Luca Heltai and Martin Kronbichler and
+             Matthias Maier and Jean-Paul Pelteret and Bruno Turcksin and
+             David Wells},
+  journal = {Computers \& Mathematics with Applications},
+  year    = {2021},
+  DOI     = {10.1016/j.camwa.2020.02.022},
+  pages   = {407-422},
+  volume  = {81},
+  issn    = {0898-1221},
+  url     = {https://arxiv.org/abs/1910.13247}
+}

--- a/CITATIONS.bib
+++ b/CITATIONS.bib
@@ -14,24 +14,6 @@
   url       = {https://dealii.org/deal94-preprint.pdf}
 }
 
-@article{dealII93,
-  title     = {The \texttt{deal.II} Library, Version 9.3},
-  author    = {Daniel Arndt and Wolfgang Bangerth and Bruno Blais and
-               Marc Fehling and Rene Gassm{\"o}ller and Timo Heister
-               and Luca Heltai and Uwe K{\"o}cher and Martin
-               Kronbichler and Matthias Maier and Peter Munch and
-               Jean-Paul Pelteret and Sebastian Proell and Konrad
-               Simon and Bruno Turcksin and David Wells and Jiaqi
-               Zhang},
-  journal   = {Journal of Numerical Mathematics},
-  year      = {2021},
-  url       = {https://dealii.org/deal93-preprint.pdf},
-  doi       = {10.1515/jnma-2021-0081},
-  volume    = {29},
-  number    = {3},
-  pages     = {171--186}
-}
-
 @Article{dealii2019design,
   title   = {The {deal.II} finite element library: Design, features, and insights},
   author  = {Daniel Arndt and Wolfgang Bangerth and Denis Davydov and


### PR DESCRIPTION
This adds information in the main Github page (https://github.com/dealii/dealii) for how to cite `deal.II`, see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files.