### PR TITLE
Fix matrix_free test.

### DIFF
--- a/tests/matrix_free/point_evaluation_25.cc
+++ b/tests/matrix_free/point_evaluation_25.cc
@@ -115,7 +115,7 @@ test(const unsigned int degree)
       for (const auto q : evaluator.quadrature_point_indices())
         evaluator.submit_value(evaluator.get_value(q), q);
 
-      evaluator.integrate(solution_values, EvaluationFlags::values);
+      evaluator.test_and_sum(solution_values, EvaluationFlags::values);
 
       for (const auto i : solution_values)
         deallog << factor_float * i << ' ';


### PR DESCRIPTION
#15281 missed test `point_evaluation_25.cc` which was introduced in #15273.

@bergbauer -- FYI

---

Error message:
```
matrix_free/point_evaluation_25.debug: RUN failed. ------ Return code 134
matrix_free/point_evaluation_25.debug: RUN failed. ------ Result: /home/dealii/build/tests/matrix_free/point_evaluation_25.debug/failing_output
matrix_free/point_evaluation_25.debug: RUN failed. ------ Partial output:
JobId aaefd3897163 Sat Jun  3 19:54:09 2023
DEAL::Mapping of degree 3
DEAL::Cell with center 0.2500000000
DEAL::0.000000000: 0.000000000 error value 0.000000000
DEAL::0.02941176471: 0.02941176471 error value 0.000000000
DEAL::0.05882352941: 0.05882352941 error value -2.775557562e-17
DEAL::0.08823529412: 0.08823529412 error value 1.387778781e-17
DEAL::0.1176470588: 0.1176470588 error value 1.387778781e-17
DEAL::0.1470588235: 0.1470588235 error value -2.775557562e-17
DEAL::0.1764705882: 0.1764705882 error value 0.000000000
DEAL::0.2058823529: 0.2058823529 error value 5.551115123e-17
DEAL::0.2352941176: 0.2352941176 error value -2.775557562e-17
DEAL::0.2647058824: 0.2647058824 error value 0.000000000
DEAL::0.2941176471: 0.2941176471 error value 5.551115123e-17
DEAL::0.3235294118: 0.3235294118 error value 0.000000000
DEAL::0.3529411765: 0.3529411765 error value -5.551115123e-17
DEAL::

matrix_free/point_evaluation_25.debug: RUN failed. ------ Additional output on stdout/stderr:


--------------------------------------------------------
An error occurred in line <2441> of file </jenkins/workspace/dealii-serial_PR-15297/include/deal.II/matrix_free/fe_point_evaluation.h> in function
    void dealii::FEPointEvaluation<n_components_, dim, spacedim, Number>::do_integrate(const dealii::ArrayView<typename dealii::internal::VectorizedArrayTrait<Number>::value_type>&, const dealii::EvaluationFlags::EvaluationFlags&) [with bool do_JxW = true; int n_components_ = 1; int dim = 1; int spacedim = 1; Number = double; typename dealii::internal::VectorizedArrayTrait<Number>::value_type = double]
The violated condition was: 
    !do_JxW || JxW_ptr != nullptr
Additional information: 
    JxW pointer is not set! If you do not want to integrate() use
    test_and_sum()
--------------------------------------------------------

```