### PR TITLE
use FEPE::get_normal_vector() to be consistent with FEE

### DIFF
--- a/doc/doxygen/headers/matrixfree.h
+++ b/doc/doxygen/headers/matrixfree.h
@@ -211,7 +211,7 @@ digraph G
  * information, respectively. Besides access to the function values with
  * FEEvaluationAccess::get_value() or gradients with
  * FEEvaluationAccess::get_gradient(), the face evaluator also enables the
- * access to the normal vector by FEEvaluationAccess::get_normal_vector() and
+ * access to the normal vector by FEEvaluationAccess::normal_vector() and
  * a specialized field FEEvaluationAccess::get_normal_derivative(), which
  * returns the derivative of the solution field normal to the face. This
  * quantity is computed as the gradient (in real space) multiplied by the

--- a/examples/step-59/step-59.cc
+++ b/examples/step-59/step-59.cc
@@ -579,9 +579,9 @@ namespace Step59
         // take the absolute value of these factors as the normal could point
         // into either positive or negative direction.
         const VectorizedArray<number> inverse_length_normal_to_face =
-          0.5 * (std::abs((phi_inner.get_normal_vector(0) *
+          0.5 * (std::abs((phi_inner.normal_vector(0) *
                            phi_inner.inverse_jacobian(0))[dim - 1]) +
-                 std::abs((phi_outer.get_normal_vector(0) *
+                 std::abs((phi_outer.normal_vector(0) *
                            phi_outer.inverse_jacobian(0))[dim - 1]));
         const VectorizedArray<number> sigma =
           inverse_length_normal_to_face * get_penalty_factor();
@@ -680,9 +680,8 @@ namespace Step59
                                   EvaluationFlags::values |
                                     EvaluationFlags::gradients);
 
-        const VectorizedArray<number> inverse_length_normal_to_face =
-          std::abs((phi_inner.get_normal_vector(0) *
-                    phi_inner.inverse_jacobian(0))[dim - 1]);
+        const VectorizedArray<number> inverse_length_normal_to_face = std::abs((
+          phi_inner.normal_vector(0) * phi_inner.inverse_jacobian(0))[dim - 1]);
         const VectorizedArray<number> sigma =
           inverse_length_normal_to_face * get_penalty_factor();
 
@@ -1134,9 +1133,8 @@ namespace Step59
       {
         phi_face.reinit(face);
 
-        const VectorizedArray<double> inverse_length_normal_to_face =
-          std::abs((phi_face.get_normal_vector(0) *
-                    phi_face.inverse_jacobian(0))[dim - 1]);
+        const VectorizedArray<double> inverse_length_normal_to_face = std::abs(
+          (phi_face.normal_vector(0) * phi_face.inverse_jacobian(0))[dim - 1]);
         const VectorizedArray<double> sigma =
           inverse_length_normal_to_face * system_matrix.get_penalty_factor();
 
@@ -1169,7 +1167,7 @@ namespace Step59
                   {
                     Tensor<1, dim> normal;
                     for (unsigned int d = 0; d < dim; ++d)
-                      normal[d] = phi_face.get_normal_vector(q)[d][v];
+                      normal[d] = phi_face.normal_vector(q)[d][v];
                     test_normal_derivative[v] =
                       -normal * exact_solution.gradient(single_point);
                   }

--- a/examples/step-67/step-67.cc
+++ b/examples/step-67/step-67.cc
@@ -1125,7 +1125,7 @@ namespace Euler_DG
             const auto numerical_flux =
               euler_numerical_flux<dim>(phi_m.get_value(q),
                                         phi_p.get_value(q),
-                                        phi_m.get_normal_vector(q));
+                                        phi_m.normal_vector(q));
             phi_m.submit_value(-numerical_flux, q);
             phi_p.submit_value(numerical_flux, q);
           }
@@ -1205,7 +1205,7 @@ namespace Euler_DG
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           {
             const auto w_m    = phi.get_value(q);
-            const auto normal = phi.get_normal_vector(q);
+            const auto normal = phi.normal_vector(q);
 
             auto rho_u_dot_n = w_m[1] * normal[0];
             for (unsigned int d = 1; d < dim; ++d)

--- a/examples/step-76/step-76.cc
+++ b/examples/step-76/step-76.cc
@@ -812,7 +812,7 @@ namespace Euler_DG
                         const auto numerical_flux =
                           euler_numerical_flux<dim>(phi_m.get_value(q),
                                                     phi_p.get_value(q),
-                                                    phi_m.get_normal_vector(q));
+                                                    phi_m.normal_vector(q));
                         phi_m.submit_value(-numerical_flux, q);
                       }
                   }
@@ -825,7 +825,7 @@ namespace Euler_DG
                     for (unsigned int q = 0; q < phi_m.n_q_points; ++q)
                       {
                         const auto w_m    = phi_m.get_value(q);
-                        const auto normal = phi_m.get_normal_vector(q);
+                        const auto normal = phi_m.normal_vector(q);
 
                         auto rho_u_dot_n = w_m[1] * normal[0];
                         for (unsigned int d = 1; d < dim; ++d)

--- a/include/deal.II/matrix_free/face_info.h
+++ b/include/deal.II/matrix_free/face_info.h
@@ -56,7 +56,7 @@ namespace internal
       /**
        * Indices of the faces in the current face batch as compared to the
        * numbers of the cells on the logical "interior" side of the face which
-       * is aligned to the direction of FEEvaluation::get_normal_vector().
+       * is aligned to the direction of FEEvaluation::normal_vector().
        */
       std::array<unsigned int, vectorization_width> cells_interior;
 
@@ -64,7 +64,7 @@ namespace internal
        * Indices of the faces in the current face batch as compared to the
        * numbers of the cells on the logical "exterior" side of the face which
        * is aligned to the opposite direction of
-       * FEEvaluation::get_normal_vector(). Note that the distinction into
+       * FEEvaluation::normal_vector(). Note that the distinction into
        * interior and exterior faces is purely logical and refers to the
        * direction of the normal only. In the actual discretization of a
        * problem, the discretization typically needs to make sure that interior

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -365,7 +365,7 @@ public:
    * to the face: $\boldsymbol \nabla u(\mathbf x_q) \cdot \mathbf n(\mathbf
    * x_q)$
    *
-   * This call is equivalent to calling get_gradient() * get_normal_vector()
+   * This call is equivalent to calling get_gradient() * normal_vector()
    * but will use a more efficient internal representation of data.
    *
    * @note The derived class FEEvaluationAccess overloads this operation

--- a/include/deal.II/matrix_free/fe_evaluation_data.h
+++ b/include/deal.II/matrix_free/fe_evaluation_data.h
@@ -227,6 +227,14 @@ public:
    * @note Only implemented in case `is_face == true`.
    */
   Tensor<1, dim, Number>
+  normal_vector(const unsigned int q_point) const;
+
+  /**
+   * Same as `normal_vector(const unsigned int q_point)`.
+   *
+   * @warning  This function will be deprecated!
+   */
+  Tensor<1, dim, Number>
   get_normal_vector(const unsigned int q_point) const;
 
   /** @} */
@@ -1260,7 +1268,7 @@ FEEvaluationData<dim, Number, is_face>::reinit_face(
 
 template <int dim, typename Number, bool is_face>
 inline DEAL_II_ALWAYS_INLINE Tensor<1, dim, Number>
-FEEvaluationData<dim, Number, is_face>::get_normal_vector(
+FEEvaluationData<dim, Number, is_face>::normal_vector(
   const unsigned int q_point) const
 {
   AssertIndexRange(q_point, n_quadrature_points);
@@ -1271,6 +1279,17 @@ FEEvaluationData<dim, Number, is_face>::get_normal_vector(
     return normal_vectors[0];
   else
     return normal_vectors[q_point];
+}
+
+
+
+// This function is deprecated.
+template <int dim, typename Number, bool is_face>
+inline DEAL_II_ALWAYS_INLINE Tensor<1, dim, Number>
+FEEvaluationData<dim, Number, is_face>::get_normal_vector(
+  const unsigned int q_point) const
+{
+  return normal_vector(q_point);
 }
 
 

--- a/tests/matrix_free/advect_1d.cc
+++ b/tests/matrix_free/advect_1d.cc
@@ -151,7 +151,7 @@ private:
             value_type u_minus = phi_m.get_value(q),
                        u_plus  = phi_p.get_value(q);
             const VectorizedArray<number> normal_times_advection =
-              advection * phi_m.get_normal_vector(q);
+              advection * phi_m.normal_vector(q);
             const value_type flux_times_normal =
               make_vectorized_array<number>(0.5) *
               ((u_minus + u_plus) * normal_times_advection +
@@ -193,7 +193,7 @@ private:
             value_type                    u_minus = fe_eval.get_value(q);
             value_type                    u_plus  = -u_minus;
             const VectorizedArray<number> normal_times_advection =
-              advection * fe_eval.get_normal_vector(q);
+              advection * fe_eval.normal_vector(q);
             const value_type flux_times_normal =
               make_vectorized_array<number>(0.5) *
               ((u_minus + u_plus) * normal_times_advection +

--- a/tests/matrix_free/advect_1d_deprecated.output
+++ b/tests/matrix_free/advect_1d_deprecated.output
@@ -1,0 +1,22 @@
+
+DEAL::Testing FE_DGQ<1>(2)
+DEAL::Norm of difference:          0.531539 
+DEAL::Norm of difference:          0.135407 
+DEAL::Norm of difference:          0.0340112 
+DEAL::Norm of difference:          0.00851279 
+DEAL::Norm of difference:          0.00212882 
+DEAL::Norm of difference:          0.000532245 
+DEAL::Testing FE_DGQ<1>(4)
+DEAL::Norm of difference:          0.00529591 
+DEAL::Norm of difference:          0.000336014 
+DEAL::Norm of difference:          2.10801e-05 
+DEAL::Norm of difference:          1.31874e-06 
+DEAL::Norm of difference:          8.24413e-08 
+DEAL::Norm of difference:          5.15331e-09 
+DEAL::Testing FE_DGQ<1>(5)
+DEAL::Norm of difference:          0.000346887 
+DEAL::Norm of difference:          1.09982e-05 
+DEAL::Norm of difference:          3.44938e-07 
+DEAL::Norm of difference:          1.07881e-08 
+DEAL::Norm of difference:          3.35085e-10 
+DEAL::Norm of difference:          9.72689e-12 

--- a/tests/matrix_free/advect_1d_vectorization_mask.cc
+++ b/tests/matrix_free/advect_1d_vectorization_mask.cc
@@ -159,7 +159,7 @@ private:
             value_type u_minus = phi_m.get_value(q),
                        u_plus  = phi_p.get_value(q);
             const VectorizedArray<number> normal_times_advection =
-              advection * phi_m.get_normal_vector(q);
+              advection * phi_m.normal_vector(q);
             const value_type flux_times_normal =
               make_vectorized_array<number>(0.5) *
               ((u_minus + u_plus) * normal_times_advection +
@@ -213,7 +213,7 @@ private:
             value_type                    u_minus = fe_eval.get_value(q);
             value_type                    u_plus  = -u_minus;
             const VectorizedArray<number> normal_times_advection =
-              advection * fe_eval.get_normal_vector(q);
+              advection * fe_eval.normal_vector(q);
             const value_type flux_times_normal =
               make_vectorized_array<number>(0.5) *
               ((u_minus + u_plus) * normal_times_advection +

--- a/tests/matrix_free/compare_faces_by_cells.cc
+++ b/tests/matrix_free/compare_faces_by_cells.cc
@@ -142,8 +142,7 @@ private:
         // penalty parameter because the cell-based method cannot read the
         // sigma parameter on the neighbor
         VectorizedArray<number> sigmaF =
-          std::abs(
-            (phi.get_normal_vector(0) * phi.inverse_jacobian(0))[dim - 1]) *
+          std::abs((phi.normal_vector(0) * phi.inverse_jacobian(0))[dim - 1]) *
           (number)(std::max(fe_degree, 1) * (fe_degree + 1.0)) * 2.0;
 
         // Compute phi part
@@ -178,7 +177,7 @@ private:
         phi.distribute_local_to_global(dst);
 
         // Compute phi_outer part
-        sigmaF = std::abs((phi.get_normal_vector(0) *
+        sigmaF = std::abs((phi.normal_vector(0) *
                            phi_outer.inverse_jacobian(0))[dim - 1]) *
                  (number)(std::max(fe_degree, 1) * (fe_degree + 1.0)) * 2.0;
         for (unsigned int j = 0; j < phi.dofs_per_cell; ++j)
@@ -229,8 +228,7 @@ private:
 
         VectorizedArray<number> local_diagonal_vector[phi.static_dofs_per_cell];
         VectorizedArray<number> sigmaF =
-          std::abs(
-            (phi.get_normal_vector(0) * phi.inverse_jacobian(0))[dim - 1]) *
+          std::abs((phi.normal_vector(0) * phi.inverse_jacobian(0))[dim - 1]) *
           (number)(std::max(1, fe_degree) * (fe_degree + 1.0)) * 2.;
 
         for (unsigned int i = 0; i < phi.dofs_per_cell; ++i)
@@ -277,8 +275,8 @@ private:
           {
             phif.reinit(cell, face);
             VectorizedArray<number> sigmaF =
-              std::abs((phif.get_normal_vector(0) *
-                        phif.inverse_jacobian(0))[dim - 1]) *
+              std::abs(
+                (phif.normal_vector(0) * phif.inverse_jacobian(0))[dim - 1]) *
               (number)(std::max(1, fe_degree) * (fe_degree + 1.0)) * 2.;
 
             std::array<types::boundary_id, VectorizedArray<number>::size()>

--- a/tests/matrix_free/ecl.h
+++ b/tests/matrix_free/ecl.h
@@ -167,10 +167,10 @@ test(const unsigned int geometry      = 0,
           phi_p.read_dof_values(src);
           phi_p.evaluate(true, true);
           VectorizedArrayType sigmaF =
-            (std::abs((phi_m.get_normal_vector(0) *
-                       phi_m.inverse_jacobian(0))[dim - 1]) +
-             std::abs((phi_m.get_normal_vector(0) *
-                       phi_p.inverse_jacobian(0))[dim - 1])) *
+            (std::abs(
+               (phi_m.normal_vector(0) * phi_m.inverse_jacobian(0))[dim - 1]) +
+             std::abs(
+               (phi_m.normal_vector(0) * phi_p.inverse_jacobian(0))[dim - 1])) *
             (Number)(std::max(fe_degree, 1) * (fe_degree + 1.0));
 
           for (unsigned int q = 0; q < phi_m.n_q_points; ++q)
@@ -200,8 +200,8 @@ test(const unsigned int geometry      = 0,
           phi_m.read_dof_values(src);
           phi_m.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
           VectorizedArrayType sigmaF =
-            std::abs((phi_m.get_normal_vector(0) *
-                      phi_m.inverse_jacobian(0))[dim - 1]) *
+            std::abs(
+              (phi_m.normal_vector(0) * phi_m.inverse_jacobian(0))[dim - 1]) *
             Number(std::max(fe_degree, 1) * (fe_degree + 1.0)) * 2.0;
 
           for (unsigned int q = 0; q < phi_m.n_q_points; ++q)
@@ -258,7 +258,7 @@ test(const unsigned int geometry      = 0,
                   phi_m.evaluate(EvaluationFlags::values |
                                  EvaluationFlags::gradients);
                   VectorizedArrayType sigmaF =
-                    std::abs((phi_m.get_normal_vector(0) *
+                    std::abs((phi_m.normal_vector(0) *
                               phi_m.inverse_jacobian(0))[dim - 1]) *
                     Number(std::max(fe_degree, 1) * (fe_degree + 1.0)) * 2.0;
 
@@ -291,9 +291,9 @@ test(const unsigned int geometry      = 0,
                                  EvaluationFlags::gradients);
 
                   VectorizedArrayType sigmaF =
-                    (std::abs((phi_m.get_normal_vector(0) *
+                    (std::abs((phi_m.normal_vector(0) *
                                phi_m.inverse_jacobian(0))[dim - 1]) +
-                     std::abs((phi_m.get_normal_vector(0) *
+                     std::abs((phi_m.normal_vector(0) *
                                phi_p.inverse_jacobian(0))[dim - 1])) *
                     (Number)(std::max(fe_degree, 1) * (fe_degree + 1.0));
 

--- a/tests/matrix_free/element_birth_and_death_01.cc
+++ b/tests/matrix_free/element_birth_and_death_01.cc
@@ -150,7 +150,7 @@ test(const unsigned int n_refinements)
             for (const auto q : phi.quadrature_point_indices())
               {
                 auto gradient = phi.get_gradient(q);
-                auto normal   = phi.get_normal_vector(q);
+                auto normal   = phi.normal_vector(q);
 
                 if (is_interior_face == false) // fix sign!
                   normal *= -1.0;

--- a/tests/matrix_free/interpolate_functions_common.h
+++ b/tests/matrix_free/interpolate_functions_common.h
@@ -162,7 +162,7 @@ public:
                 double normal_derivative = 0;
                 for (unsigned int d = 0; d < dim; ++d)
                   normal_derivative += function.gradient(p, 0)[d] *
-                                       fe_evalm.get_normal_vector(q)[d][j];
+                                       fe_evalm.normal_vector(q)[d][j];
                 facem_errors[3] += std::abs(
                   fe_evalm.get_normal_derivative(q)[j] - normal_derivative);
 
@@ -228,7 +228,7 @@ public:
                 double normal_derivative = 0;
                 for (unsigned int d = 0; d < dim; ++d)
                   normal_derivative += function.gradient(p, 0)[d] *
-                                       fe_evalm.get_normal_vector(q)[d][j];
+                                       fe_evalm.normal_vector(q)[d][j];
                 boundary_errors[3] += std::abs(
                   fe_evalm.get_normal_derivative(q)[j] - normal_derivative);
               }

--- a/tests/matrix_free/matrix_vector_faces_35.cc
+++ b/tests/matrix_free/matrix_vector_faces_35.cc
@@ -196,7 +196,7 @@ private:
             value_type u_minus = phi_m.get_value(q),
                        u_plus  = phi_p.get_value(q);
             const VectorizedArrayType normal_times_advection =
-              advection * phi_m.get_normal_vector(q);
+              advection * phi_m.normal_vector(q);
             const value_type flux_times_normal =
               make_vectorized_array<number, VectorizedArrayType::size()>(0.5) *
               ((u_minus + u_plus) * normal_times_advection +
@@ -247,7 +247,7 @@ private:
           {
             value_type                u_minus = fe_eval.get_value(q);
             const VectorizedArrayType normal_times_advection =
-              advection * fe_eval.get_normal_vector(q);
+              advection * fe_eval.normal_vector(q);
             const value_type flux_times_normal =
               make_vectorized_array<number, VectorizedArrayType::size()>(0.5) *
               ((u_minus + u_plus) * normal_times_advection +

--- a/tests/matrix_free/matrix_vector_faces_common.h
+++ b/tests/matrix_free/matrix_vector_faces_common.h
@@ -156,9 +156,9 @@ private:
         fe_eval_neighbor.evaluate(EvaluationFlags::values |
                                   EvaluationFlags::gradients);
         VectorizedArrayType sigmaF =
-          (std::abs((fe_eval.get_normal_vector(0) *
+          (std::abs((fe_eval.normal_vector(0) *
                      fe_eval.inverse_jacobian(0))[dim - 1]) +
-           std::abs((fe_eval.get_normal_vector(0) *
+           std::abs((fe_eval.normal_vector(0) *
                      fe_eval_neighbor.inverse_jacobian(0))[dim - 1])) *
           (number)(std::max(actual_degree, 1) * (actual_degree + 1.0));
 
@@ -217,8 +217,8 @@ private:
         fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
         VectorizedArrayType sigmaF =
           2.0 *
-          std::abs((fe_eval.get_normal_vector(0) *
-                    fe_eval.inverse_jacobian(0))[dim - 1]) *
+          std::abs(
+            (fe_eval.normal_vector(0) * fe_eval.inverse_jacobian(0))[dim - 1]) *
           number(std::max(actual_degree, 1) * (actual_degree + 1.0));
 
         for (unsigned int q = 0; q < fe_eval.n_q_points; ++q)
@@ -362,9 +362,9 @@ private:
                                            EvaluationFlags::gradients);
 
         VectorizedArrayType sigmaF =
-          (std::abs((fe_eval.get_normal_vector(0) *
+          (std::abs((fe_eval.normal_vector(0) *
                      fe_eval.inverse_jacobian(0))[dim - 1]) +
-           std::abs((fe_eval.get_normal_vector(0) *
+           std::abs((fe_eval.normal_vector(0) *
                      fe_eval_neighbor.inverse_jacobian(0))[dim - 1])) *
           (number)(std::max(actual_degree, 1) * (actual_degree + 1.0));
 
@@ -423,8 +423,8 @@ private:
                                 EvaluationFlags::values |
                                   EvaluationFlags::gradients);
         VectorizedArrayType sigmaF =
-          std::abs((fe_eval.get_normal_vector(0) *
-                    fe_eval.inverse_jacobian(0))[dim - 1]) *
+          std::abs(
+            (fe_eval.normal_vector(0) * fe_eval.inverse_jacobian(0))[dim - 1]) *
           number(std::max(actual_degree, 1) * (actual_degree + 1.0)) * 2.0;
 
         for (unsigned int q = 0; q < fe_eval.n_q_points; ++q)
@@ -598,7 +598,7 @@ private:
             value_type u_minus = phi_m.get_value(q),
                        u_plus  = phi_p.get_value(q);
             const VectorizedArrayType normal_times_advection =
-              advection * phi_m.get_normal_vector(q);
+              advection * phi_m.normal_vector(q);
             const value_type flux_times_normal =
               make_vectorized_array<number, VectorizedArrayType::size()>(0.5) *
               ((u_minus + u_plus) * normal_times_advection +
@@ -646,7 +646,7 @@ private:
           {
             value_type                u_minus = fe_eval.get_value(q);
             const VectorizedArrayType normal_times_advection =
-              advection * fe_eval.get_normal_vector(q);
+              advection * fe_eval.normal_vector(q);
             const value_type flux_times_normal =
               make_vectorized_array<number, VectorizedArrayType::size()>(0.5) *
               ((u_minus + u_plus) * normal_times_advection +

--- a/tests/matrix_free/multigrid_dg_periodic.cc
+++ b/tests/matrix_free/multigrid_dg_periodic.cc
@@ -208,9 +208,9 @@ private:
         fe_eval_neighbor.evaluate(EvaluationFlags::values |
                                   EvaluationFlags::gradients);
         VectorizedArray<number> sigmaF =
-          (std::abs((fe_eval.get_normal_vector(0) *
+          (std::abs((fe_eval.normal_vector(0) *
                      fe_eval.inverse_jacobian(0))[dim - 1]) +
-           std::abs((fe_eval.get_normal_vector(0) *
+           std::abs((fe_eval.normal_vector(0) *
                      fe_eval_neighbor.inverse_jacobian(0))[dim - 1])) *
           (number)(std::max(fe_degree, 1) * (fe_degree + 1.0));
 
@@ -250,8 +250,8 @@ private:
         fe_eval.read_dof_values(src);
         fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
         VectorizedArray<number> sigmaF =
-          std::abs((fe_eval.get_normal_vector(0) *
-                    fe_eval.inverse_jacobian(0))[dim - 1]) *
+          std::abs(
+            (fe_eval.normal_vector(0) * fe_eval.inverse_jacobian(0))[dim - 1]) *
           (number)(std::max(1, fe_degree) * (fe_degree + 1.0)) * 2.;
 
         for (unsigned int q = 0; q < fe_eval.n_q_points; ++q)
@@ -339,10 +339,9 @@ private:
         phi_outer.reinit(face);
 
         VectorizedArray<number> sigmaF =
-          (std::abs(
-             (phi.get_normal_vector(0) * phi.inverse_jacobian(0))[dim - 1]) +
-           std::abs((phi.get_normal_vector(0) *
-                     phi_outer.inverse_jacobian(0))[dim - 1])) *
+          (std::abs((phi.normal_vector(0) * phi.inverse_jacobian(0))[dim - 1]) +
+           std::abs(
+             (phi.normal_vector(0) * phi_outer.inverse_jacobian(0))[dim - 1])) *
           (number)(std::max(fe_degree, 1) * (fe_degree + 1.0));
 
         // Compute phi part
@@ -426,8 +425,7 @@ private:
         phi.reinit(face);
 
         VectorizedArray<number> sigmaF =
-          std::abs(
-            (phi.get_normal_vector(0) * phi.inverse_jacobian(0))[dim - 1]) *
+          std::abs((phi.normal_vector(0) * phi.inverse_jacobian(0))[dim - 1]) *
           (number)(std::max(1, fe_degree) * (fe_degree + 1.0)) * 2.;
 
         for (unsigned int i = 0; i < phi.dofs_per_cell; ++i)

--- a/tests/matrix_free/multigrid_dg_sip_01.cc
+++ b/tests/matrix_free/multigrid_dg_sip_01.cc
@@ -217,9 +217,9 @@ private:
         fe_eval_neighbor.evaluate(EvaluationFlags::values |
                                   EvaluationFlags::gradients);
         VectorizedArray<number> sigmaF =
-          (std::abs((fe_eval.get_normal_vector(0) *
+          (std::abs((fe_eval.normal_vector(0) *
                      fe_eval.inverse_jacobian(0))[dim - 1]) +
-           std::abs((fe_eval.get_normal_vector(0) *
+           std::abs((fe_eval.normal_vector(0) *
                      fe_eval_neighbor.inverse_jacobian(0))[dim - 1])) *
           (number)(std::max(fe_degree, 1) * (fe_degree + 1.0));
 
@@ -259,8 +259,8 @@ private:
         fe_eval.read_dof_values(src);
         fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
         VectorizedArray<number> sigmaF =
-          std::abs((fe_eval.get_normal_vector(0) *
-                    fe_eval.inverse_jacobian(0))[dim - 1]) *
+          std::abs(
+            (fe_eval.normal_vector(0) * fe_eval.inverse_jacobian(0))[dim - 1]) *
           number(std::max(fe_degree, 1) * (fe_degree + 1.0)) * 2.0;
 
         for (unsigned int q = 0; q < fe_eval.n_q_points; ++q)
@@ -346,10 +346,9 @@ private:
         phi_outer.reinit(face);
 
         VectorizedArray<number> sigmaF =
-          (std::abs(
-             (phi.get_normal_vector(0) * phi.inverse_jacobian(0))[dim - 1]) +
-           std::abs((phi.get_normal_vector(0) *
-                     phi_outer.inverse_jacobian(0))[dim - 1])) *
+          (std::abs((phi.normal_vector(0) * phi.inverse_jacobian(0))[dim - 1]) +
+           std::abs(
+             (phi.normal_vector(0) * phi_outer.inverse_jacobian(0))[dim - 1])) *
           (number)(std::max(fe_degree, 1) * (fe_degree + 1.0));
 
         // Compute phi part
@@ -433,8 +432,7 @@ private:
         phi.reinit(face);
 
         VectorizedArray<number> sigmaF =
-          std::abs(
-            (phi.get_normal_vector(0) * phi.inverse_jacobian(0))[dim - 1]) *
+          std::abs((phi.normal_vector(0) * phi.inverse_jacobian(0))[dim - 1]) *
           number(std::max(fe_degree, 1) * (fe_degree + 1.0)) * 2.0;
 
         for (unsigned int i = 0; i < phi.dofs_per_cell; ++i)

--- a/tests/matrix_free/multigrid_dg_sip_02.cc
+++ b/tests/matrix_free/multigrid_dg_sip_02.cc
@@ -220,9 +220,9 @@ private:
         fe_eval_neighbor.evaluate(EvaluationFlags::values |
                                   EvaluationFlags::gradients);
         VectorizedArray<number> sigmaF =
-          (std::abs((fe_eval.get_normal_vector(0) *
+          (std::abs((fe_eval.normal_vector(0) *
                      fe_eval.inverse_jacobian(0))[dim - 1]) +
-           std::abs((fe_eval.get_normal_vector(0) *
+           std::abs((fe_eval.normal_vector(0) *
                      fe_eval_neighbor.inverse_jacobian(0))[dim - 1])) *
           (number)(std::max(fe_degree, 1) * (fe_degree + 1.0));
 
@@ -262,8 +262,8 @@ private:
         fe_eval.read_dof_values(src);
         fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
         VectorizedArray<number> sigmaF =
-          std::abs((fe_eval.get_normal_vector(0) *
-                    fe_eval.inverse_jacobian(0))[dim - 1]) *
+          std::abs(
+            (fe_eval.normal_vector(0) * fe_eval.inverse_jacobian(0))[dim - 1]) *
           (number)(std::max(1, fe_degree) * (fe_degree + 1.0)) * 2.;
 
         for (unsigned int q = 0; q < fe_eval.n_q_points; ++q)
@@ -328,8 +328,8 @@ private:
           {
             phif.reinit(cell, face);
             VectorizedArray<number> sigmaF =
-              std::abs((phif.get_normal_vector(0) *
-                        phif.inverse_jacobian(0))[dim - 1]) *
+              std::abs(
+                (phif.normal_vector(0) * phif.inverse_jacobian(0))[dim - 1]) *
               (number)(std::max(1, fe_degree) * (fe_degree + 1.0)) * 2.;
             std::array<types::boundary_id, VectorizedArray<number>::size()>
               boundary_ids = data.get_faces_by_cells_boundary_id(cell, face);

--- a/tests/performance/timing_navier_stokes.cc
+++ b/tests/performance/timing_navier_stokes.cc
@@ -845,9 +845,9 @@ namespace NavierStokes_DG
                                         EvaluationFlags::gradients);
 
                 const auto tau_ip =
-                  (std::abs((phi_m.get_normal_vector(0) *
+                  (std::abs((phi_m.normal_vector(0) *
                              phi_m.inverse_jacobian(0))[dim - 1]) +
-                   std::abs((phi_p.get_normal_vector(0) *
+                   std::abs((phi_p.normal_vector(0) *
                              phi_p.inverse_jacobian(0))[dim - 1])) *
                   Number(viscosity * (degree + 1) * (degree + 1));
 
@@ -855,7 +855,7 @@ namespace NavierStokes_DG
                   {
                     const auto w_m    = phi_m.get_value(q);
                     const auto w_p    = phi_p.get_value(q);
-                    const auto normal = phi_m.get_normal_vector(q);
+                    const auto normal = phi_m.normal_vector(q);
                     auto       numerical_flux =
                       -euler_numerical_flux<dim>(w_m, w_p, normal);
                     const auto grad_w_m = phi_m.get_gradient(q);
@@ -882,14 +882,14 @@ namespace NavierStokes_DG
             else
               {
                 const auto tau_ip =
-                  std::abs((phi_m.get_normal_vector(0) *
+                  std::abs((phi_m.normal_vector(0) *
                             phi_m.inverse_jacobian(0))[dim - 1]) *
                   Number(2. * viscosity * (degree + 1) * (degree + 1));
 
                 for (unsigned int q = 0; q < phi_m.n_q_points; ++q)
                   {
                     const auto w_m      = phi_m.get_value(q);
-                    const auto normal   = phi_m.get_normal_vector(q);
+                    const auto normal   = phi_m.normal_vector(q);
                     const auto grad_w_m = phi_m.get_gradient(q);
                     const auto grad_w_p = grad_w_m;
 
@@ -1225,9 +1225,9 @@ namespace NavierStokes_DG
                               EvaluationFlags::values |
                                 EvaluationFlags::gradients);
 
-        const auto tau_ip = (std::abs((phi_m.get_normal_vector(0) *
+        const auto tau_ip = (std::abs((phi_m.normal_vector(0) *
                                        phi_m.inverse_jacobian(0))[dim - 1]) +
-                             std::abs((phi_p.get_normal_vector(0) *
+                             std::abs((phi_p.normal_vector(0) *
                                        phi_p.inverse_jacobian(0))[dim - 1])) *
                             Number(viscosity * (degree + 1) * (degree + 1));
 
@@ -1235,7 +1235,7 @@ namespace NavierStokes_DG
           {
             const auto w_m      = phi_m.get_value(q);
             const auto w_p      = phi_p.get_value(q);
-            const auto normal   = phi_m.get_normal_vector(q);
+            const auto normal   = phi_m.normal_vector(q);
             auto numerical_flux = -euler_numerical_flux<dim>(w_m, w_p, normal);
             const auto grad_w_m = phi_m.get_gradient(q);
             const auto grad_w_p = phi_p.get_gradient(q);
@@ -1294,7 +1294,7 @@ namespace NavierStokes_DG
 
         const auto tau_ip =
           std::abs(
-            (phi_m.get_normal_vector(0) * phi_m.inverse_jacobian(0))[dim - 1]) *
+            (phi_m.normal_vector(0) * phi_m.inverse_jacobian(0))[dim - 1]) *
           Number(2. * viscosity * (degree + 1) * (degree + 1));
 
         const auto boundary_id = data.get_boundary_id(face);
@@ -1302,7 +1302,7 @@ namespace NavierStokes_DG
         for (unsigned int q = 0; q < phi_m.n_q_points; ++q)
           {
             const auto w_m      = phi_m.get_value(q);
-            const auto normal   = phi_m.get_normal_vector(q);
+            const auto normal   = phi_m.normal_vector(q);
             const auto grad_w_m = phi_m.get_gradient(q);
             const auto grad_w_p = grad_w_m;
 

--- a/tests/simplex/matrix_free_03.cc
+++ b/tests/simplex/matrix_free_03.cc
@@ -187,9 +187,9 @@ public:
                                              EvaluationFlags::values |
                                                EvaluationFlags::gradients);
             VectorizedArray<number> sigmaF = PENALTY;
-            //  (std::abs((fe_eval.get_normal_vector(0) *
+            //  (std::abs((fe_eval.normal_vector(0) *
             //             fe_eval.inverse_jacobian(0))[dim - 1]) +
-            //   std::abs((fe_eval.get_normal_vector(0) *
+            //   std::abs((fe_eval.normal_vector(0) *
             //             fe_eval_neighbor.inverse_jacobian(0))[dim - 1])) *
             //  (number)(std::max(fe_degree, 1) * (fe_degree + 1.0));
 
@@ -225,7 +225,7 @@ public:
             fe_eval.evaluate(EvaluationFlags::values |
                              EvaluationFlags::gradients);
             VectorizedArray<number> sigmaF = PENALTY;
-            //  std::abs((fe_eval.get_normal_vector(0) *
+            //  std::abs((fe_eval.normal_vector(0) *
             //            fe_eval.inverse_jacobian(0))[dim - 1]) *
             //  number(std::max(fe_degree, 1) * (fe_degree + 1.0)) * 2.0;
 

--- a/tests/simplex/step-12c.cc
+++ b/tests/simplex/step-12c.cc
@@ -763,8 +763,8 @@ public:
             phi.reinit(face);
             for (unsigned int q = 0; q < phi.n_q_points; ++q)
               {
-                const auto beta_n = this->beta(phi.quadrature_point(q)) *
-                                    phi.get_normal_vector(q);
+                const auto beta_n =
+                  this->beta(phi.quadrature_point(q)) * phi.normal_vector(q);
                 const auto beta_n_m = (-std::abs(beta_n) + beta_n) * 0.5;
                 phi.submit_value(-beta_n_m * this->boundary_values(
                                                phi.quadrature_point(q)),
@@ -810,7 +810,7 @@ public:
             for (unsigned int q = 0; q < phi_m.n_q_points; ++q)
               {
                 const auto beta_n = this->beta(phi_m.quadrature_point(q)) *
-                                    phi_m.get_normal_vector(q);
+                                    phi_m.normal_vector(q);
 
                 const auto u_m = phi_m.get_value(q);
                 const auto u_p = phi_p.get_value(q);
@@ -834,8 +834,8 @@ public:
             phi.gather_evaluate(src, true, false);
             for (unsigned int q = 0; q < phi.n_q_points; ++q)
               {
-                const auto beta_n = this->beta(phi.quadrature_point(q)) *
-                                    phi.get_normal_vector(q);
+                const auto beta_n =
+                  this->beta(phi.quadrature_point(q)) * phi.normal_vector(q);
                 const auto beta_n_p = (std::abs(beta_n) + beta_n) * 0.5;
                 phi.submit_value(beta_n_p * phi.get_value(q), q);
               }

--- a/tests/simplex/step-67.cc
+++ b/tests/simplex/step-67.cc
@@ -1199,7 +1199,7 @@ namespace Euler_DG
             const auto numerical_flux =
               euler_numerical_flux<dim>(phi_m.get_value(q),
                                         phi_p.get_value(q),
-                                        phi_m.get_normal_vector(q));
+                                        phi_m.normal_vector(q));
             //	    std::cout<<" phim: "<<phi_m.get_value(q)
             //	     <<" phip: "<<phi_p.get_value(q)<<std::endl;
             phi_m.submit_value(-numerical_flux, q);
@@ -1286,7 +1286,7 @@ namespace Euler_DG
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           {
             const auto w_m    = phi.get_value(q);
-            const auto normal = phi.get_normal_vector(q);
+            const auto normal = phi.normal_vector(q);
 
             auto rho_u_dot_n = w_m[1] * normal[0];
             for (unsigned int d = 1; d < dim; ++d)


### PR DESCRIPTION
As discussed in https://github.com/dealii/dealii/issues/15302 I am renaming `FEPE::get_normal_vector()` to be consistent with `FEE`

@bergbauer @kronbichler 