### PR TITLE
Use one process to build with Intel to decrease memory usage.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -347,7 +347,7 @@ jobs:
       run: |
         source /opt/intel/oneapi/setvars.sh
         cd build
-        make VERBOSE=1 -j2
+        make VERBOSE=1
     - name: quicktest
       run: |
         source /opt/intel/oneapi/setvars.sh


### PR DESCRIPTION
This is an attempt to fix the github-worker running with Intel compilers.
```
icpc: error #10106: Fatal error in /opt/intel/oneapi/compiler/2023.1.0/linux/bin/intel64/../../bin/intel64/mcpcom, terminated by kill signal
compilation aborted for /home/runner/work/dealii/dealii/source/grid/grid_tools.cc (code 1)
```

This issue already occurred in https://github.com/trilinos/Trilinos/issues/3277 and they made the memory consumption responsible for the error.

So let's do the Intel workflow with just one job instead of two. The runner passes on my fork of the library, but of course it takes significantly longer (~3hrs 30mins, see [here](https://github.com/marcfehling/dealii/actions/runs/5172942409/jobs/9317753591)).

We can try to enable two jobs again when moving to the ICX compiler #15301.