### PR TITLE
Hotfix muparser: Fix problem with IntelLLVM finite math

### DIFF
--- a/bundled/muparser_v2_3_3/src/muParserTest.cpp
+++ b/bundled/muparser_v2_3_3/src/muParserTest.cpp
@@ -1546,17 +1546,7 @@ namespace mu
 					// The tests equations never result in infinity, if they do thats a bug.
 					// reference:
 					// http://sourceforge.net/projects/muparser/forums/forum/462843/topic/5037825
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4127)
-#endif
-					if (std::numeric_limits<value_type>::has_infinity)
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
-					{
-						bCloseEnough &= (fabs(fVal[i]) != numeric_limits<value_type>::infinity());
-					}
+					bCloseEnough &= std::isfinite(fVal[i]);
 				}
 
 				iRet = ((bCloseEnough && a_fPass) || (!bCloseEnough && !a_fPass)) ? 0 : 1;


### PR DESCRIPTION
Part of #15301.

Applies https://github.com/beltoforion/muparser/pull/121 until we decide to update the bundled package with a new release (that incorporates this change).