### PR TITLE
Use numbers::is_finite whenever we compare with infinity.

### DIFF
--- a/include/deal.II/lac/utilities.h
+++ b/include/deal.II/lac/utilities.h
@@ -432,7 +432,7 @@ namespace Utilities
       const double b = unwanted_spectrum.second;
       Assert(degree > 0, ExcMessage("Only positive degrees make sense."));
 
-      const bool scale = (a_L < std::numeric_limits<double>::infinity());
+      const bool scale = numbers::is_finite(a_L);
       Assert(
         a < b,
         ExcMessage(

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -1261,11 +1261,11 @@ namespace Particles
         auto particle = pic.begin();
         for (const auto &p_unit : reference_locations)
           {
-            if (p_unit[0] == std::numeric_limits<double>::infinity() ||
-                !GeometryInfo<dim>::is_inside_unit_cell(p_unit))
-              particles_out_of_cell.push_back(particle);
-            else
+            if (numbers::is_finite(p_unit[0]) &&
+                GeometryInfo<dim>::is_inside_unit_cell(p_unit))
               particle->set_reference_location(p_unit);
+            else
+              particles_out_of_cell.push_back(particle);
 
             ++particle;
           }


### PR DESCRIPTION
Part of #15301.

The patch replaces comparisons with infinity by using `numbers::is_finite`. This gets rid of the warnings of the `icpx` compiler, and I think the patch also makes the code more easily readable.