### PR TITLE
Mark loop indices as 'const' where possible.

### DIFF
--- a/examples/step-11/step-11.cc
+++ b/examples/step-11/step-11.cc
@@ -159,7 +159,7 @@ namespace Step11
     // of what is to come later:
     mean_value_constraints.clear();
     mean_value_constraints.add_line(first_boundary_dof);
-    for (types::global_dof_index i : boundary_dofs)
+    for (const types::global_dof_index i : boundary_dofs)
       if (i != first_boundary_dof)
         mean_value_constraints.add_entry(first_boundary_dof, i, -1);
     mean_value_constraints.close();

--- a/examples/step-15/step-15.cc
+++ b/examples/step-15/step-15.cc
@@ -561,7 +561,7 @@ namespace Step15
     // function from namespace DoFTools:
     hanging_node_constraints.condense(residual);
 
-    for (types::global_dof_index i :
+    for (const types::global_dof_index i :
          DoFTools::extract_boundary_dofs(dof_handler))
       residual(i) = 0;
 

--- a/examples/step-51/step-51.cc
+++ b/examples/step-51/step-51.cc
@@ -544,14 +544,14 @@ namespace Step51
       , fe_support_on_face(GeometryInfo<dim>::faces_per_cell)
       , exact_solution()
     {
-      for (unsigned int face_no : GeometryInfo<dim>::face_indices())
+      for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
         for (unsigned int i = 0; i < fe_local.n_dofs_per_cell(); ++i)
           {
             if (fe_local.has_support_on_face(i, face_no))
               fe_local_support_on_face[face_no].push_back(i);
           }
 
-      for (unsigned int face_no : GeometryInfo<dim>::face_indices())
+      for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
         for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
           {
             if (fe.has_support_on_face(i, face_no))

--- a/examples/step-60/step-60.cc
+++ b/examples/step-60/step-60.cc
@@ -857,7 +857,7 @@ namespace Step60
     space_dh->distribute_dofs(*space_fe);
 
     DoFTools::make_hanging_node_constraints(*space_dh, constraints);
-    for (auto id : parameters.dirichlet_ids)
+    for (const types::boundary_id id : parameters.dirichlet_ids)
       {
         VectorTools::interpolate_boundary_values(
           *space_dh, id, embedding_dirichlet_boundary_function, constraints);

--- a/examples/step-72/step-72.cc
+++ b/examples/step-72/step-72.cc
@@ -959,7 +959,7 @@ namespace Step72
 
     hanging_node_constraints.condense(residual);
 
-    for (types::global_dof_index i :
+    for (const types::global_dof_index i :
          DoFTools::extract_boundary_dofs(dof_handler))
       residual(i) = 0;
 

--- a/examples/step-79/step-79.cc
+++ b/examples/step-79/step-79.cc
@@ -1772,7 +1772,7 @@ namespace SAND
       SolutionBlocks::density_lower_slack_multiplier,
       SolutionBlocks::density_upper_slack_multiplier};
     double constraint_norm = 0;
-    for (unsigned int multiplier_i : equality_constraint_multipliers)
+    for (const unsigned int multiplier_i : equality_constraint_multipliers)
       constraint_norm += system_rhs.block(multiplier_i).linfty_norm();
 
 

--- a/examples/step-85/step-85.cc
+++ b/examples/step-85/step-85.cc
@@ -481,7 +481,7 @@ namespace Step85
         // using FEInterfaceValues. Assembling in this we will traverse each
         // internal face in the mesh twice, so in order to get the penalty
         // constant we expect, we multiply the penalty term with a factor 1/2.
-        for (unsigned int f : cell->face_indices())
+        for (const unsigned int f : cell->face_indices())
           if (face_has_ghost_penalty(cell, f))
             {
               const unsigned int invalid_subface =

--- a/include/deal.II/differentiation/ad/ad_helpers.h
+++ b/include/deal.II/differentiation/ad/ad_helpers.h
@@ -1168,7 +1168,7 @@ namespace Differentiation
      *       // Add contribution from external energy:
      *       // Loop over faces and accumulate external energy into cell
      *       // total energy.
-     *       for (unsigned int face : ...)
+     *       for (const unsigned int face : ...)
      *         if (cell->face(face)->at_boundary())
      *           energy_ad += ...
      *
@@ -1498,7 +1498,7 @@ namespace Differentiation
      *       // linearized.
      *       // Loop over faces and accumulate external contributions into the
      *       // cell total residual.
-     *       for (unsigned int face : ...)
+     *       for (const unsigned int face : ...)
      *         if (cell->face(face)->at_boundary())
      *           residual_ad[I] += ...
      *

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -2481,7 +2481,7 @@ DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::
     GeometryInfo<dimension_>::faces_per_cell>
     face_iterators(this->n_faces());
 
-  for (unsigned int i : this->face_indices())
+  for (const unsigned int i : this->face_indices())
     face_iterators[i] =
       dealii::internal::DoFCellAccessorImplementation::get_face(
         *this, i, std::integral_constant<int, dimension_>());

--- a/include/deal.II/fe/fe_data.h
+++ b/include/deal.II/fe/fe_data.h
@@ -986,7 +986,7 @@ internal::GenericDoFsPerObject::generate(const FiniteElementData<dim> &fe)
 
   unsigned int counter = 0;
 
-  for (unsigned int v : reference_cell.vertex_indices())
+  for (const unsigned int v : reference_cell.vertex_indices())
     {
       const auto c = fe.template n_dofs_per_object<0>(v);
 
@@ -998,7 +998,7 @@ internal::GenericDoFsPerObject::generate(const FiniteElementData<dim> &fe)
     }
 
   if (dim >= 2)
-    for (unsigned int l : reference_cell.line_indices())
+    for (const unsigned int l : reference_cell.line_indices())
       {
         const auto c = fe.template n_dofs_per_object<1>(l);
 
@@ -1011,7 +1011,7 @@ internal::GenericDoFsPerObject::generate(const FiniteElementData<dim> &fe)
       }
 
   if (dim == 3)
-    for (unsigned int f : reference_cell.face_indices())
+    for (const unsigned int f : reference_cell.face_indices())
       {
         const auto c = fe.template n_dofs_per_object<2>(f);
 
@@ -1040,7 +1040,7 @@ internal::GenericDoFsPerObject::generate(const FiniteElementData<dim> &fe)
     }
 
   result.first_object_index_on_face.resize(3);
-  for (unsigned int face_no : reference_cell.face_indices())
+  for (const unsigned int face_no : reference_cell.face_indices())
     {
       result.first_object_index_on_face[0].emplace_back(0);
 

--- a/include/deal.II/fe/fe_interface_values.h
+++ b/include/deal.II/fe/fe_interface_values.h
@@ -3489,7 +3489,7 @@ namespace FEInterfaceViews
 
     AssertDimension(interface_dof_indices.size(), local_dof_values.size());
 
-    for (unsigned int i : this->fe_interface->dof_indices())
+    for (const unsigned int i : this->fe_interface->dof_indices())
       local_dof_values[i] = dof_values(interface_dof_indices[i]);
   }
 
@@ -4044,7 +4044,7 @@ namespace FEInterfaceViews
   {
     AssertDimension(hessians.size(), this->fe_interface->n_quadrature_points);
 
-    for (unsigned int dof_index : this->fe_interface->dof_indices())
+    for (const unsigned int dof_index : this->fe_interface->dof_indices())
       for (const auto q_index : this->fe_interface->quadrature_point_indices())
         {
           if (dof_index == 0)
@@ -4088,7 +4088,7 @@ namespace FEInterfaceViews
     AssertDimension(third_derivatives.size(),
                     this->fe_interface->n_quadrature_points);
 
-    for (unsigned int dof_index : this->fe_interface->dof_indices())
+    for (const unsigned int dof_index : this->fe_interface->dof_indices())
       for (const auto q_index : this->fe_interface->quadrature_point_indices())
         {
           if (dof_index == 0)
@@ -4681,7 +4681,7 @@ namespace FEInterfaceViews
   {
     AssertDimension(hessians.size(), this->fe_interface->n_quadrature_points);
 
-    for (unsigned int dof_index : this->fe_interface->dof_indices())
+    for (const unsigned int dof_index : this->fe_interface->dof_indices())
       for (const auto q_index : this->fe_interface->quadrature_point_indices())
         {
           if (dof_index == 0)
@@ -4725,7 +4725,7 @@ namespace FEInterfaceViews
     AssertDimension(third_derivatives.size(),
                     this->fe_interface->n_quadrature_points);
 
-    for (unsigned int dof_index : this->fe_interface->dof_indices())
+    for (const unsigned int dof_index : this->fe_interface->dof_indices())
       for (const auto q_index : this->fe_interface->quadrature_point_indices())
         {
           if (dof_index == 0)

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -979,7 +979,7 @@ namespace internal
         // For 2d cells the access cell->line_orientation() is already
         // efficient
         std::array<unsigned int, 4> line_indices = {};
-        for (unsigned int line : cell.line_indices())
+        for (const unsigned int line : cell.line_indices())
           line_indices[line] = cell.line_index(line);
         return line_indices;
       }
@@ -1096,7 +1096,7 @@ namespace internal
         // For 2d cells the access cell->line_orientation() is already
         // efficient
         std::array<bool, 4> line_orientations = {};
-        for (unsigned int line : cell.line_indices())
+        for (const unsigned int line : cell.line_indices())
           line_orientations[line] = cell.line_orientation(line);
         return line_orientations;
       }
@@ -3508,7 +3508,7 @@ CellAccessor<dim, spacedim>::face_iterators() const
     GeometryInfo<dim>::faces_per_cell>
     face_iterators(this->n_faces());
 
-  for (unsigned int i : this->face_indices())
+  for (const unsigned int i : this->face_indices())
     face_iterators[i] =
       dealii::internal::CellAccessorImplementation::get_face(*this, i);
 

--- a/include/deal.II/meshworker/dof_info.h
+++ b/include/deal.II/meshworker/dof_info.h
@@ -431,7 +431,7 @@ namespace MeshWorker
     : cell(seed)
     , cell_valid(true)
   {
-    for (unsigned int i : GeometryInfo<dim>::face_indices())
+    for (const unsigned int i : GeometryInfo<dim>::face_indices())
       {
         exterior[i]                = seed;
         interior[i]                = seed;
@@ -447,7 +447,7 @@ namespace MeshWorker
     : cell(other.cell)
     , cell_valid(other.cell_valid)
   {
-    for (unsigned int i : GeometryInfo<dim>::face_indices())
+    for (const unsigned int i : GeometryInfo<dim>::face_indices())
       {
         exterior[i]                = other.exterior[i];
         interior[i]                = other.interior[i];
@@ -463,7 +463,7 @@ namespace MeshWorker
   {
     cell       = other.cell;
     cell_valid = other.cell_valid;
-    for (unsigned int i : GeometryInfo<dim>::face_indices())
+    for (const unsigned int i : GeometryInfo<dim>::face_indices())
       {
         exterior[i]                = other.exterior[i];
         interior[i]                = other.interior[i];
@@ -479,7 +479,7 @@ namespace MeshWorker
   DoFInfoBox<dim, DOFINFO>::reset()
   {
     cell_valid = false;
-    for (unsigned int i : GeometryInfo<dim>::face_indices())
+    for (const unsigned int i : GeometryInfo<dim>::face_indices())
       {
         interior_face_available[i] = false;
         exterior_face_available[i] = false;
@@ -496,7 +496,7 @@ namespace MeshWorker
       return;
 
     assembler.assemble(cell);
-    for (unsigned int i : GeometryInfo<dim>::face_indices())
+    for (const unsigned int i : GeometryInfo<dim>::face_indices())
       {
         // Only do something if data available
         if (interior_face_available[i])

--- a/include/deal.II/meshworker/loop.h
+++ b/include/deal.II/meshworker/loop.h
@@ -454,7 +454,7 @@ namespace MeshWorker
     DoFInfoBox<dim, DOFINFO> dof_info(dinfo);
 
     assembler.initialize_info(dof_info.cell, false);
-    for (unsigned int i : GeometryInfo<dim>::face_indices())
+    for (const unsigned int i : GeometryInfo<dim>::face_indices())
       {
         assembler.initialize_info(dof_info.interior[i], true);
         assembler.initialize_info(dof_info.exterior[i], true);

--- a/include/deal.II/non_matching/fe_values.h
+++ b/include/deal.II/non_matching/fe_values.h
@@ -402,7 +402,7 @@ namespace NonMatching
    *
    *  for (const auto &cell : dof_handler.active_cell_iterators())
    *    {
-   *      for (unsigned int face_index : cell->face_indices())
+   *      for (const unsigned int face_index : cell->face_indices())
    *        {
    *          if (cell->at_boundary(face_index))
    *            fe_interface_values.reinit(cell, face_index);

--- a/include/deal.II/numerics/vector_tools_boundary.templates.h
+++ b/include/deal.II/numerics/vector_tools_boundary.templates.h
@@ -2405,7 +2405,7 @@ namespace VectorTools
     const hp::MappingCollection<dim> mapping_collection(mapping);
     hp::QCollection<dim>             quadrature_collection;
 
-    for (unsigned int face : GeometryInfo<dim>::face_indices())
+    for (const unsigned int face : GeometryInfo<dim>::face_indices())
       quadrature_collection.push_back(QProjector<dim>::project_to_face(
         ReferenceCells::get_hypercube<dim>(), face_quadrature, face));
 
@@ -2567,7 +2567,7 @@ namespace VectorTools
 
         face_quadrature_collection.push_back(quadrature);
 
-        for (unsigned int face : GeometryInfo<dim>::face_indices())
+        for (const unsigned int face : GeometryInfo<dim>::face_indices())
           quadrature_collection.push_back(QProjector<dim>::project_to_face(
             ReferenceCells::get_hypercube<dim>(), quadrature, face));
       }

--- a/include/deal.II/numerics/vector_tools_rhs.templates.h
+++ b/include/deal.II/numerics/vector_tools_rhs.templates.h
@@ -68,7 +68,7 @@ namespace VectorTools
         std::vector<double> rhs_values(n_q_points);
 
         for (const auto &cell : dof_handler.active_cell_iterators())
-          for (unsigned int face : cell->face_indices())
+          for (const unsigned int face : cell->face_indices())
             if (cell->face(face)->at_boundary() &&
                 (boundary_ids.empty() ||
                  (boundary_ids.find(cell->face(face)->boundary_id()) !=
@@ -99,7 +99,7 @@ namespace VectorTools
                                                Vector<double>(n_components));
 
         for (const auto &cell : dof_handler.active_cell_iterators())
-          for (unsigned int face : cell->face_indices())
+          for (const unsigned int face : cell->face_indices())
             if (cell->face(face)->at_boundary() &&
                 (boundary_ids.empty() ||
                  (boundary_ids.find(cell->face(face)->boundary_id()) !=
@@ -207,7 +207,7 @@ namespace VectorTools
         std::vector<double> rhs_values;
 
         for (const auto &cell : dof_handler.active_cell_iterators())
-          for (unsigned int face : cell->face_indices())
+          for (const unsigned int face : cell->face_indices())
             if (cell->face(face)->at_boundary() &&
                 (boundary_ids.empty() ||
                  (boundary_ids.find(cell->face(face)->boundary_id()) !=
@@ -245,7 +245,7 @@ namespace VectorTools
         std::vector<Vector<double>> rhs_values;
 
         for (const auto &cell : dof_handler.active_cell_iterators())
-          for (unsigned int face : cell->face_indices())
+          for (const unsigned int face : cell->face_indices())
             if (cell->face(face)->at_boundary() &&
                 (boundary_ids.empty() ||
                  (boundary_ids.find(cell->face(face)->boundary_id()) !=

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -1775,7 +1775,7 @@ namespace DataOutBase
   // all the other data has a constructor of its own, except for the "neighbors"
   // field, which we set to invalid values.
   {
-    for (unsigned int i : GeometryInfo<dim>::face_indices())
+    for (const unsigned int i : GeometryInfo<dim>::face_indices())
       neighbors[i] = no_neighbor;
 
     AssertIndexRange(dim, spacedim + 1);
@@ -1797,7 +1797,7 @@ namespace DataOutBase
       if (vertices[i].distance(patch.vertices[i]) > epsilon)
         return false;
 
-    for (unsigned int i : GeometryInfo<dim>::face_indices())
+    for (const unsigned int i : GeometryInfo<dim>::face_indices())
       if (neighbors[i] != patch.neighbors[i])
         return false;
 
@@ -9343,7 +9343,7 @@ DataOutReader<dim, spacedim>::merge(const DataOutReader<dim, spacedim> &source)
 
   // adjust patch neighbors
   for (unsigned int i = old_n_patches; i < patches.size(); ++i)
-    for (unsigned int n : GeometryInfo<dim>::face_indices())
+    for (const unsigned int n : GeometryInfo<dim>::face_indices())
       if (patches[i].neighbors[n] !=
           dealii::DataOutBase::Patch<dim, spacedim>::no_neighbor)
         patches[i].neighbors[n] += old_n_patches;
@@ -9698,7 +9698,7 @@ namespace DataOutBase
       out << patch.vertices[i] << ' ';
     out << '\n';
 
-    for (unsigned int i : patch.reference_cell.face_indices())
+    for (const unsigned int i : patch.reference_cell.face_indices())
       out << patch.neighbors[i] << ' ';
     out << '\n';
 
@@ -9758,7 +9758,7 @@ namespace DataOutBase
     for (const unsigned int i : patch.reference_cell.vertex_indices())
       in >> patch.vertices[i];
 
-    for (unsigned int i : patch.reference_cell.face_indices())
+    for (const unsigned int i : patch.reference_cell.face_indices())
       in >> patch.neighbors[i];
 
     in >> patch.patch_index;

--- a/source/base/partitioner.cc
+++ b/source/base/partitioner.cc
@@ -423,7 +423,7 @@ namespace Utilities
           // first translate tight ghost indices into indices within the large
           // set:
           std::vector<unsigned int> expanded_numbering;
-          for (dealii::IndexSet::size_type index : ghost_indices_data)
+          for (const dealii::IndexSet::size_type index : ghost_indices_data)
             {
               Assert(larger_ghost_index_set.is_element(index),
                      ExcMessage("The given larger ghost index set must contain "

--- a/source/base/polynomials_barycentric.cc
+++ b/source/base/polynomials_barycentric.cc
@@ -71,18 +71,18 @@ BarycentricPolynomials<dim>::get_fe_p_basis(const unsigned int degree)
         break;
       case 1:
         {
-          for (unsigned int v : reference_cell.vertex_indices())
+          for (const unsigned int v : reference_cell.vertex_indices())
             polys.push_back(BarycentricPolynomial<dim, double>::monomial(v));
           break;
         }
       case 2:
         {
           // vertices, then lines:
-          for (unsigned int v : reference_cell.vertex_indices())
+          for (const unsigned int v : reference_cell.vertex_indices())
             polys.push_back(
               BarycentricPolynomial<dim, double>::monomial(v) *
               (2 * BarycentricPolynomial<dim, double>::monomial(v) - 1));
-          for (unsigned int l : reference_cell.line_indices())
+          for (const unsigned int l : reference_cell.line_indices())
             {
               const auto v0 = reference_cell.line_to_cell_vertices(l, 0);
               const auto v1 = reference_cell.line_to_cell_vertices(l, 1);

--- a/source/base/polynomials_bernardi_raugel.cc
+++ b/source/base/polynomials_bernardi_raugel.cc
@@ -121,7 +121,7 @@ PolynomialsBernardiRaugel<dim>::evaluate(
   // Normal vectors point in the +x, +y, and +z directions for
   // consistent orientation across edges
   std::vector<Tensor<1, dim>> normals;
-  for (unsigned int i : GeometryInfo<dim>::face_indices())
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     {
       Tensor<1, dim> normal;
       normal[i / 2] = 1;

--- a/source/base/qprojector.cc
+++ b/source/base/qprojector.cc
@@ -985,11 +985,11 @@ QProjector<3>::project_to_all_faces(const ReferenceCell &     reference_cell,
     {
       std::vector<std::vector<Point<3>>> face_vertex_locations(
         reference_cell.n_faces());
-      for (unsigned int f : reference_cell.face_indices())
+      for (const unsigned int f : reference_cell.face_indices())
         {
           face_vertex_locations[f].resize(
             reference_cell.face_reference_cell(f).n_vertices());
-          for (unsigned int v :
+          for (const unsigned int v :
                reference_cell.face_reference_cell(f).vertex_indices())
             face_vertex_locations[f][v] =
               reference_cell.face_vertex_location<3>(f, v);

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -2766,7 +2766,7 @@ namespace DoFRenumbering
               // cell batch range that touched a particular dof)
               data.get_dof_info(component).get_dof_indices_on_cell_batch(
                 dofs_extracted, cell);
-              for (unsigned int dof_index : dofs_extracted)
+              for (const unsigned int dof_index : dofs_extracted)
                 if (dof_index < n_owned_dofs &&
                     last_touch_by_cell_batch_range[dof_index] !=
                       cell_range.first)
@@ -2847,7 +2847,7 @@ namespace DoFRenumbering
     // comparator for std::sort to then order the unknowns by the specified
     // matrix-free loop order
     const std::vector<unsigned int> &purely_local_dofs = dofs_by_rank_access[0];
-    for (unsigned int i : purely_local_dofs)
+    for (const unsigned int i : purely_local_dofs)
       if (local_numbering.second[i] == 1)
         new_numbers.push_back(i);
 

--- a/source/fe/fe_abf.cc
+++ b/source/fe/fe_abf.cc
@@ -354,7 +354,7 @@ FE_ABF<dim>::initialize_restriction()
   const unsigned int n_face_points = q_base.size();
   // First, compute interpolation on
   // subfaces
-  for (unsigned int face : GeometryInfo<dim>::face_indices())
+  for (const unsigned int face : GeometryInfo<dim>::face_indices())
     {
       // The shape functions of the
       // child cell are evaluated
@@ -577,7 +577,7 @@ FE_ABF<dim>::convert_generalized_support_point_values_to_dof_values(
   std::fill(nodal_values.begin(), nodal_values.end(), 0.);
 
   const unsigned int n_face_points = boundary_weights.size(0);
-  for (unsigned int face : GeometryInfo<dim>::face_indices())
+  for (const unsigned int face : GeometryInfo<dim>::face_indices())
     for (unsigned int k = 0; k < n_face_points; ++k)
       for (unsigned int i = 0; i < boundary_weights.size(1); ++i)
         {
@@ -616,7 +616,7 @@ FE_ABF<dim>::convert_generalized_support_point_values_to_dof_values(
           support_point_values[k + start_cell_points][d];
 
   // Face integral of ABF terms
-  for (unsigned int face : GeometryInfo<dim>::face_indices())
+  for (const unsigned int face : GeometryInfo<dim>::face_indices())
     {
       const double n_orient = GeometryInfo<dim>::unit_normal_orientation[face];
       for (unsigned int fp = 0; fp < n_face_points; ++fp)

--- a/source/fe/fe_bernardi_raugel.cc
+++ b/source/fe/fe_bernardi_raugel.cc
@@ -121,7 +121,7 @@ FE_BernardiRaugel<dim>::convert_generalized_support_point_values_to_dof_values(
          ExcDimensionMismatch(nodal_values.size(), this->n_dofs_per_cell()));
 
   std::vector<Tensor<1, dim>> normals;
-  for (unsigned int i : GeometryInfo<dim>::face_indices())
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     {
       Tensor<1, dim> normal;
       normal[i / 2] = 1;

--- a/source/fe/fe_face.cc
+++ b/source/fe/fe_face.cc
@@ -994,7 +994,7 @@ std::pair<Table<2, bool>, std::vector<unsigned int>>
 FE_FaceP<dim, spacedim>::get_constant_modes() const
 {
   Table<2, bool> constant_modes(1, this->n_dofs_per_cell());
-  for (unsigned int face : GeometryInfo<dim>::face_indices())
+  for (const unsigned int face : GeometryInfo<dim>::face_indices())
     constant_modes(0, face * this->n_dofs_per_face(face)) = true;
   return std::pair<Table<2, bool>, std::vector<unsigned int>>(
     constant_modes, std::vector<unsigned int>(1, 0));

--- a/source/fe/fe_raviart_thomas.cc
+++ b/source/fe/fe_raviart_thomas.cc
@@ -446,7 +446,7 @@ FE_RaviartThomas<dim>::initialize_restriction()
   const unsigned int n_face_points = q_base.size();
   // First, compute interpolation on
   // subfaces
-  for (unsigned int face : GeometryInfo<dim>::face_indices())
+  for (const unsigned int face : GeometryInfo<dim>::face_indices())
     {
       // The shape functions of the
       // child cell are evaluated
@@ -681,7 +681,7 @@ FE_RaviartThomas<dim>::convert_generalized_support_point_values_to_dof_values(
   std::fill(nodal_values.begin(), nodal_values.end(), 0.);
 
   const unsigned int n_face_points = boundary_weights.size(0);
-  for (unsigned int face : GeometryInfo<dim>::face_indices())
+  for (const unsigned int face : GeometryInfo<dim>::face_indices())
     for (unsigned int k = 0; k < n_face_points; ++k)
       for (unsigned int i = 0; i < boundary_weights.size(1); ++i)
         {

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -917,7 +917,7 @@ namespace GridGenerator
         set_boundary_ids(Triangulation<2> &tria)
         {
           for (auto cell : tria.active_cell_iterators())
-            for (unsigned int f : GeometryInfo<2>::face_indices())
+            for (const unsigned int f : GeometryInfo<2>::face_indices())
               {
                 if (cell->face(f)->at_boundary() == false)
                   continue;
@@ -1463,7 +1463,7 @@ namespace GridGenerator
       Triangulation<3>::cell_iterator cell = tria.begin();
 
       for (; cell != tria.end(); ++cell)
-        for (unsigned int f : GeometryInfo<3>::face_indices())
+        for (const unsigned int f : GeometryInfo<3>::face_indices())
           {
             if (!cell->face(f)->at_boundary())
               continue;
@@ -2096,7 +2096,7 @@ namespace GridGenerator
     for (auto &cell : tria.cell_iterators())
       {
         // identify faces on torus surface and set manifold to 1
-        for (unsigned int f : GeometryInfo<3>::face_indices())
+        for (const unsigned int f : GeometryInfo<3>::face_indices())
           {
             // faces 4 and 5 are those with normal vector aligned with torus
             // centerline
@@ -3016,7 +3016,7 @@ namespace GridGenerator
         for (; cell != endc; ++cell)
           {
             Point<2> cell_center = cell->center();
-            for (unsigned int f : GeometryInfo<2>::face_indices())
+            for (const unsigned int f : GeometryInfo<2>::face_indices())
               if (cell->face(f)->boundary_id() == 0)
                 {
                   Point<2> face_center = cell->face(f)->center();
@@ -3847,7 +3847,7 @@ namespace GridGenerator
 
     std::vector<Point<spacedim>> points;
     unsigned int                 n_cells = 1;
-    for (unsigned int i : GeometryInfo<dim>::face_indices())
+    for (const unsigned int i : GeometryInfo<dim>::face_indices())
       n_cells += sizes[i];
 
     std::vector<CellData<dim>> cells(n_cells);
@@ -4567,7 +4567,7 @@ namespace GridGenerator
 
     while (cell != end)
       {
-        for (unsigned int i : GeometryInfo<dim>::face_indices())
+        for (const unsigned int i : GeometryInfo<dim>::face_indices())
           {
             if (cell->face(i)->boundary_id() ==
                 numbers::internal_face_boundary_id)
@@ -4634,7 +4634,7 @@ namespace GridGenerator
 
     while (cell != end)
       {
-        for (unsigned int i : GeometryInfo<2>::face_indices())
+        for (const unsigned int i : GeometryInfo<2>::face_indices())
           {
             if (cell->face(i)->boundary_id() ==
                 numbers::internal_face_boundary_id)
@@ -5582,7 +5582,7 @@ namespace GridGenerator
     const double tolerance = 1e-5 * std::min(radius, half_length);
 
     for (const auto &cell : tria.cell_iterators())
-      for (unsigned int i : GeometryInfo<3>::face_indices())
+      for (const unsigned int i : GeometryInfo<3>::face_indices())
         if (cell->at_boundary(i))
           {
             if (cell->face(i)->center()(0) > half_length - tolerance)
@@ -5691,7 +5691,7 @@ namespace GridGenerator
     tria.set_all_manifold_ids_on_boundary(0);
     while (cell != end)
       {
-        for (unsigned int i : GeometryInfo<dim>::face_indices())
+        for (const unsigned int i : GeometryInfo<dim>::face_indices())
           {
             if (cell->face(i)->boundary_id() ==
                 numbers::internal_face_boundary_id)
@@ -5801,7 +5801,7 @@ namespace GridGenerator
     // set to one
     while (cell != end)
       {
-        for (unsigned int i : GeometryInfo<3>::face_indices())
+        for (const unsigned int i : GeometryInfo<3>::face_indices())
           {
             if (!cell->at_boundary(i))
               continue;
@@ -5900,7 +5900,7 @@ namespace GridGenerator
         for (const auto &cell : tria_copy.cell_iterators())
           {
             CellData<dim> data;
-            for (unsigned int v : GeometryInfo<dim>::vertex_indices())
+            for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
               data.vertices[v] = cell->vertex_index(v);
             data.material_id = cell->material_id();
             data.manifold_id = cell->manifold_id();
@@ -6281,7 +6281,7 @@ namespace GridGenerator
         // to all faces in a first step.
         Triangulation<3>::cell_iterator cell = tria.begin();
         for (; cell != tria.end(); ++cell)
-          for (unsigned int i : GeometryInfo<3>::face_indices())
+          for (const unsigned int i : GeometryInfo<3>::face_indices())
             if (cell->at_boundary(i))
               cell->face(i)->set_all_boundary_ids(2);
 
@@ -6290,7 +6290,7 @@ namespace GridGenerator
         // boundary. Then decide whether the center is nearer to the inner
         // or outer boundary to set the correct boundary id.
         for (cell = tria.begin(); cell != tria.end(); ++cell)
-          for (unsigned int i : GeometryInfo<3>::face_indices())
+          for (const unsigned int i : GeometryInfo<3>::face_indices())
             if (cell->at_boundary(i))
               {
                 const Triangulation<3>::face_iterator face = cell->face(i);
@@ -8341,7 +8341,7 @@ namespace GridGenerator
            volume_mesh.begin(0);
          cell != volume_mesh.end(0);
          ++cell)
-      for (unsigned int i : GeometryInfo<dim>::face_indices())
+      for (const unsigned int i : GeometryInfo<dim>::face_indices())
         {
           const typename MeshType<dim, spacedim>::face_iterator face =
             cell->face(i);

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -83,7 +83,7 @@ namespace
     Triangulation<1, spacedim> &triangulation)
   {
     for (auto &cell : triangulation.active_cell_iterators())
-      for (unsigned int face_no : ReferenceCells::Line.face_indices())
+      for (const unsigned int face_no : ReferenceCells::Line.face_indices())
         if (cell->face(face_no)->at_boundary())
           for (const auto &pair : boundary_ids)
             if (cell->face(face_no)->vertex(0) == pair.first)
@@ -3902,7 +3902,7 @@ GridIn<dim, spacedim>::read_exodusii(
            elem_n += n_nodes_per_element)
         {
           CellData<dim> cell(type.n_vertices());
-          for (unsigned int i : type.vertex_indices())
+          for (const unsigned int i : type.vertex_indices())
             {
               cell.vertices[type.exodusii_vertex_to_deal_vertex(i)] =
                 connection[elem_n + i] - 1;

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -924,7 +924,7 @@ GridOut::write_dx(const Triangulation<dim, spacedim> &tria,
       for (const auto &cell : tria.active_cell_iterators())
         {
           // Little trick to get -1 for the interior
-          for (unsigned int f : GeometryInfo<dim>::face_indices())
+          for (const unsigned int f : GeometryInfo<dim>::face_indices())
             {
               out << ' '
                   << static_cast<std::make_signed<types::boundary_id>::type>(
@@ -3913,7 +3913,7 @@ GridOut::write_msh_faces(const Triangulation<dim, spacedim> &tria,
             << static_cast<unsigned int>(face->boundary_id()) << ' '
             << face->n_vertices();
         // note: vertex numbers are 1-base
-        for (unsigned int vertex : face->vertex_indices())
+        for (const unsigned int vertex : face->vertex_indices())
           {
             if (face->reference_cell() == ReferenceCells::Quadrilateral)
               out << ' '

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -611,7 +611,7 @@ namespace GridTools
                     line->manifold_id() != numbers::flat_manifold_id)
                   {
                     CellData<1> line_cell_data(line->n_vertices());
-                    for (unsigned int vertex_n : line->vertex_indices())
+                    for (const unsigned int vertex_n : line->vertex_indices())
                       line_cell_data.vertices[vertex_n] =
                         line->vertex_index(vertex_n);
                     line_cell_data.boundary_id = line->boundary_id();
@@ -2357,7 +2357,7 @@ namespace GridTools
       endc = tria.end();
     for (; cell != endc; ++cell)
       {
-        for (unsigned int i : cell->face_indices())
+        for (const unsigned int i : cell->face_indices())
           {
             const typename Triangulation<dim, spacedim>::face_iterator &face =
               cell->face(i);
@@ -3404,7 +3404,7 @@ namespace GridTools
     cell = triangulation.begin_active();
     for (; cell != endc; ++cell)
       {
-        for (unsigned int i : cell->face_indices())
+        for (const unsigned int i : cell->face_indices())
           {
             if ((cell->at_boundary(i) == false) &&
                 (cell->neighbor(i)->is_active()))
@@ -3542,7 +3542,7 @@ namespace GridTools
         // received.
         if (cell->is_ghost())
           {
-            for (unsigned int i : cell->face_indices())
+            for (const unsigned int i : cell->face_indices())
               {
                 if (cell->at_boundary(i) == false)
                   {

--- a/source/grid/grid_tools_dof_handlers.cc
+++ b/source/grid/grid_tools_dof_handlers.cc
@@ -2265,7 +2265,7 @@ namespace GridTools
          cell != mesh.end(0);
          ++cell)
       {
-        for (unsigned int i : cell->face_indices())
+        for (const unsigned int i : cell->face_indices())
           {
             const typename MeshType::face_iterator face = cell->face(i);
             if (face->at_boundary() && face->boundary_id() == b_id1)

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -10906,7 +10906,7 @@ namespace internal
           return true;
 
         const RefinementCase<dim> ref_case = cell->refinement_case();
-        for (unsigned int n : GeometryInfo<dim>::face_indices())
+        for (const unsigned int n : GeometryInfo<dim>::face_indices())
           {
             // if the cell is not refined along that face, coarsening
             // will not change anything, so do nothing. the same
@@ -14952,7 +14952,7 @@ void Triangulation<dim, spacedim>::execute_coarsening()
             const unsigned int n_lines = std::min(cell->n_lines(), 12u);
             for (unsigned int l = 0; l < n_lines; ++l)
               ++line_cell_count[line_indices[l]];
-            for (unsigned int q : cell->face_indices())
+            for (const unsigned int q : cell->face_indices())
               ++quad_cell_count[cell->face_index(q)];
           }
         else
@@ -15234,7 +15234,7 @@ namespace
     // count all neighbors that will be refined along the face of our
     // cell after the next step
     unsigned int count = 0;
-    for (unsigned int n : GeometryInfo<dim>::face_indices())
+    for (const unsigned int n : GeometryInfo<dim>::face_indices())
       {
         const typename Triangulation<dim, spacedim>::cell_iterator neighbor =
           cell->neighbor(n);

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -1734,9 +1734,9 @@ TriaAccessor<3, 3, 3>::set_all_manifold_ids(
   // for hexes also set manifold_id
   // of bounding quads and lines
 
-  for (unsigned int i : this->face_indices())
+  for (const unsigned int i : this->face_indices())
     this->quad(i)->set_manifold_id(manifold_ind);
-  for (unsigned int i : this->line_indices())
+  for (const unsigned int i : this->line_indices())
     this->line(i)->set_manifold_id(manifold_ind);
 }
 

--- a/source/matrix_free/task_info.cc
+++ b/source/matrix_free/task_info.cc
@@ -923,7 +923,7 @@ namespace internal
           // categories) to the 'other_cells'. The cells with correct group
           // size are immediately appended to the temporary cell numbering
           auto group_it = grouped_cells.begin();
-          for (unsigned int length : n_cells_per_group)
+          for (const unsigned int length : n_cells_per_group)
             if (length < n_cells_per_parent)
               for (unsigned int j = 0; j < length; ++j)
                 other_cells.push_back((group_it++)->second);

--- a/source/opencascade/utilities.cc
+++ b/source/opencascade/utilities.cc
@@ -612,7 +612,7 @@ namespace OpenCASCADE
     unsigned int face_index;
 
     for (const auto &cell : triangulation.active_cell_iterators())
-      for (unsigned int f : GeometryInfo<2>::face_indices())
+      for (const unsigned int f : GeometryInfo<2>::face_indices())
         if (cell->face(f)->at_boundary())
           {
             // get global face and vertex indices

--- a/tests/dofs/n_boundary_dofs_03.cc
+++ b/tests/dofs/n_boundary_dofs_03.cc
@@ -70,7 +70,7 @@ test()
 
   dof_handler.distribute_dofs(fe);
 
-  for (types::boundary_id b : {12, 13, 14, 15})
+  for (const types::boundary_id b : {12, 13, 14, 15})
     {
       const unsigned int N =
         dof_handler.n_boundary_dofs(std::set<types::boundary_id>{b});

--- a/tests/feinterface/fe_interface_values_11.cc
+++ b/tests/feinterface/fe_interface_values_11.cc
@@ -162,8 +162,8 @@ int
 main()
 {
   initlog();
-  for (unsigned int p : {1, 2})
+  for (const unsigned int p : {1, 2})
     test<2>(p);
-  for (unsigned int p : {1})
+  for (const unsigned int p : {1})
     test<3>(p);
 }

--- a/tests/grid/closest_point.cc
+++ b/tests/grid/closest_point.cc
@@ -21,7 +21,7 @@ test(const ReferenceCell &reference_cell,
 
   // The distance we get should be at least as good as the distance to the
   // nearest vertex
-  for (unsigned int vertex_no : reference_cell.vertex_indices())
+  for (const unsigned int vertex_no : reference_cell.vertex_indices())
     AssertThrow(distance_square <=
                   p.distance_square(
                     reference_cell.template vertex<dim>(vertex_no)),

--- a/tests/grid/grid_in_gmsh_04.cc
+++ b/tests/grid/grid_in_gmsh_04.cc
@@ -38,7 +38,7 @@ print_mesh_info(const Triangulation<dim, spacedim> &triangulation,
   {
     std::map<types::boundary_id, unsigned int> boundary_count;
     for (const auto &cell : triangulation.active_cell_iterators())
-      for (unsigned int face_no : cell->face_indices())
+      for (const unsigned int face_no : cell->face_indices())
         if (cell->face(face_no)->at_boundary())
           boundary_count[cell->face(face_no)->boundary_id()]++;
 

--- a/tests/grid/grid_tools_cache_04.cc
+++ b/tests/grid/grid_tools_cache_04.cc
@@ -75,7 +75,7 @@ test(unsigned int n_points)
     {
       // We know the owner as we're working on a shared triangulation
       unsigned int cell_owner = cells[c]->subdomain_id();
-      for (unsigned int idx : maps[c])
+      for (const unsigned int idx : maps[c])
         {
           std::vector<std::pair<BoundingBox<dim>, unsigned int>> test_results;
           global_description.query(bgi::intersects(points[idx]),

--- a/tests/grid/reference_cell_type_04.cc
+++ b/tests/grid/reference_cell_type_04.cc
@@ -36,7 +36,7 @@ test(const ReferenceCell &reference_cell)
   const unsigned int n_samples        = 200000;
 
   // sanity check: does the reference cell contain its own nodes?
-  for (unsigned int vertex_no : reference_cell.vertex_indices())
+  for (const unsigned int vertex_no : reference_cell.vertex_indices())
     AssertThrow(reference_cell.contains_point(
                   reference_cell.template vertex<dim>(vertex_no)),
                 ExcInternalError());

--- a/tests/hp/n_boundary_dofs_03.cc
+++ b/tests/hp/n_boundary_dofs_03.cc
@@ -82,7 +82,7 @@ test()
 
   dof_handler.distribute_dofs(fe);
 
-  for (types::boundary_id b : {12, 13, 14, 15})
+  for (const types::boundary_id b : {12, 13, 14, 15})
     {
       const unsigned int N =
         dof_handler.n_boundary_dofs(std::set<types::boundary_id>{b});

--- a/tests/matrix_free/parallel_multigrid_interleave.cc
+++ b/tests/matrix_free/parallel_multigrid_interleave.cc
@@ -137,7 +137,7 @@ public:
         const LinearAlgebra::distributed::Vector<number> &src) const
   {
     data.cell_loop(&LaplaceOperator::local_apply, this, dst, src, true);
-    for (unsigned int i : data.get_constrained_dofs())
+    for (const unsigned int i : data.get_constrained_dofs())
       dst.local_element(i) = src.local_element(i);
   }
 
@@ -170,7 +170,7 @@ public:
             const LinearAlgebra::distributed::Vector<number> &src) const
   {
     data.cell_loop(&LaplaceOperator::local_apply, this, dst, src);
-    for (unsigned int i : data.get_constrained_dofs())
+    for (const unsigned int i : data.get_constrained_dofs())
       dst.local_element(i) += src.local_element(i);
   }
 

--- a/tests/matrix_free/parallel_multigrid_interleave_renumber.cc
+++ b/tests/matrix_free/parallel_multigrid_interleave_renumber.cc
@@ -178,7 +178,7 @@ public:
         const LinearAlgebra::distributed::Vector<number> &src) const
   {
     data.cell_loop(&LaplaceOperator::local_apply, this, dst, src, true);
-    for (unsigned int i : data.get_constrained_dofs())
+    for (const unsigned int i : data.get_constrained_dofs())
       dst.local_element(i) = src.local_element(i);
   }
 
@@ -211,7 +211,7 @@ public:
             const LinearAlgebra::distributed::Vector<number> &src) const
   {
     data.cell_loop(&LaplaceOperator::local_apply, this, dst, src);
-    for (unsigned int i : data.get_constrained_dofs())
+    for (const unsigned int i : data.get_constrained_dofs())
       dst.local_element(i) += src.local_element(i);
   }
 

--- a/tests/matrix_free/solver_cg_interleave.cc
+++ b/tests/matrix_free/solver_cg_interleave.cc
@@ -85,7 +85,7 @@ public:
            const std::pair<unsigned int, unsigned int> &)>
       function = helmholtz_operator<dim, -1, VectorType, 0>;
     data.cell_loop(function, dst, src, true);
-    for (unsigned int i : data.get_constrained_dofs())
+    for (const unsigned int i : data.get_constrained_dofs())
       dst.local_element(i) = src.local_element(i);
   }
 
@@ -106,7 +106,7 @@ public:
       function = helmholtz_operator<dim, -1, VectorType, 0>;
     data.cell_loop(
       function, dst, src, operation_before_loop, operation_after_loop);
-    for (unsigned int i : data.get_constrained_dofs())
+    for (const unsigned int i : data.get_constrained_dofs())
       dst.local_element(i) = src.local_element(i);
   }
 

--- a/tests/mpi/mg_ghost_layer_periodic.cc
+++ b/tests/mpi/mg_ghost_layer_periodic.cc
@@ -37,7 +37,7 @@ test()
   GridGenerator::subdivided_hyper_cube(tria, 3, 0., 1.);
 
   for (const auto &cell : tria.cell_iterators())
-    for (unsigned int face_index : GeometryInfo<dim>::face_indices())
+    for (const unsigned int face_index : GeometryInfo<dim>::face_indices())
       {
         if (std::abs(cell->face(face_index)->center()(face_index / 2)) < 1e-12)
           cell->face(face_index)->set_all_boundary_ids(face_index);
@@ -65,7 +65,7 @@ test()
           {
             deallog << Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) << ' '
                     << cell->id() << " neighbor subdomain ids: ";
-            for (unsigned int f : GeometryInfo<dim>::face_indices())
+            for (const unsigned int f : GeometryInfo<dim>::face_indices())
               {
                 deallog << cell->neighbor_or_periodic_neighbor(f)->id() << ' ';
                 if (cell->is_active())

--- a/tests/multigrid/renumbering_05.cc
+++ b/tests/multigrid/renumbering_05.cc
@@ -43,7 +43,7 @@ print_dof_numbers(const DoFHandler<dim> &dof)
       {
         cell->get_dof_indices(dof_indices);
         deallog << "cell " << cell->id() << ": ";
-        for (types::global_dof_index i : dof_indices)
+        for (const types::global_dof_index i : dof_indices)
           deallog << i << ' ';
         deallog << std::endl;
       }
@@ -55,7 +55,7 @@ print_dof_numbers(const DoFHandler<dim> &dof)
           {
             cell->get_mg_dof_indices(dof_indices);
             deallog << "cell " << cell->id() << ": ";
-            for (types::global_dof_index i : dof_indices)
+            for (const types::global_dof_index i : dof_indices)
               deallog << i << ' ';
             deallog << std::endl;
           }

--- a/tests/multigrid/renumbering_06.cc
+++ b/tests/multigrid/renumbering_06.cc
@@ -50,7 +50,7 @@ print_dof_numbers(const DoFHandler<dim> &dof)
       {
         cell->get_dof_indices(dof_indices);
         deallog << "cell " << cell->id() << ": ";
-        for (types::global_dof_index i : dof_indices)
+        for (const types::global_dof_index i : dof_indices)
           deallog << i << ' ';
         deallog << std::endl;
       }
@@ -62,7 +62,7 @@ print_dof_numbers(const DoFHandler<dim> &dof)
           {
             cell->get_mg_dof_indices(dof_indices);
             deallog << "cell " << cell->id() << ": ";
-            for (types::global_dof_index i : dof_indices)
+            for (const types::global_dof_index i : dof_indices)
               deallog << i << ' ';
             deallog << std::endl;
           }

--- a/tests/multigrid/renumbering_07.cc
+++ b/tests/multigrid/renumbering_07.cc
@@ -50,7 +50,7 @@ print_dof_numbers(const DoFHandler<dim> &dof)
       {
         cell->get_dof_indices(dof_indices);
         deallog << "cell " << cell->id() << ": ";
-        for (types::global_dof_index i : dof_indices)
+        for (const types::global_dof_index i : dof_indices)
           deallog << i << ' ';
         deallog << std::endl;
       }
@@ -62,7 +62,7 @@ print_dof_numbers(const DoFHandler<dim> &dof)
           {
             cell->get_mg_dof_indices(dof_indices);
             deallog << "cell " << cell->id() << ": ";
-            for (types::global_dof_index i : dof_indices)
+            for (const types::global_dof_index i : dof_indices)
               deallog << i << ' ';
             deallog << std::endl;
           }

--- a/tests/multigrid/renumbering_08.cc
+++ b/tests/multigrid/renumbering_08.cc
@@ -43,7 +43,7 @@ print_dof_numbers(const DoFHandler<dim> &dof)
       {
         cell->get_dof_indices(dof_indices);
         deallog << "cell " << cell->id() << ": ";
-        for (types::global_dof_index i : dof_indices)
+        for (const types::global_dof_index i : dof_indices)
           deallog << i << ' ';
         deallog << std::endl;
       }
@@ -55,7 +55,7 @@ print_dof_numbers(const DoFHandler<dim> &dof)
           {
             cell->get_mg_dof_indices(dof_indices);
             deallog << "cell " << cell->id() << ": ";
-            for (types::global_dof_index i : dof_indices)
+            for (const types::global_dof_index i : dof_indices)
               deallog << i << ' ';
             deallog << std::endl;
           }

--- a/tests/non_matching/fe_interface_values.cc
+++ b/tests/non_matching/fe_interface_values.cc
@@ -173,7 +173,7 @@ Test<dim>::print_which_optionals_have_values_on_cell_0(
 {
   const auto cell = dof_handler.begin_active();
 
-  for (unsigned int face_index : cell->face_indices())
+  for (const unsigned int face_index : cell->face_indices())
     {
       deallog << "face " << face_index << std::endl;
 

--- a/tests/non_matching/fe_interface_values_non_standard_meshes.cc
+++ b/tests/non_matching/fe_interface_values_non_standard_meshes.cc
@@ -115,7 +115,7 @@ void
 Test<dim>::print_quadrature_point_difference_on_both_sides(
   const dealii::FEInterfaceValues<dim> &fe_interface_values)
 {
-  for (unsigned int q : fe_interface_values.quadrature_point_indices())
+  for (const unsigned int q : fe_interface_values.quadrature_point_indices())
     {
       const Point<dim> &point_on_side_0 =
         fe_interface_values.get_fe_face_values(0).quadrature_point(q);
@@ -150,7 +150,7 @@ Test<dim>::run()
 
   // Test that the points agree only on the interface between the two cells,
   // which face this is depends on the incoming triangulation.
-  for (unsigned int face : cell->face_indices())
+  for (const unsigned int face : cell->face_indices())
     if (!cell->face(face)->at_boundary())
       {
         const unsigned int invalid_subface =

--- a/tests/non_matching/mesh_classifier.cc
+++ b/tests/non_matching/mesh_classifier.cc
@@ -77,7 +77,7 @@ print_cell_and_face_locations(
     classifier.location_to_level_set(cell);
   deallog << "cell " << location_to_string(cell_location) << std::endl;
 
-  for (unsigned int f : cell->face_indices())
+  for (const unsigned int f : cell->face_indices())
     {
       const NonMatching::LocationToLevelSet face_location =
         classifier.location_to_level_set(cell, f);

--- a/tests/performance/timing_mg_glob_coarsen.cc
+++ b/tests/performance/timing_mg_glob_coarsen.cc
@@ -739,7 +739,7 @@ LaplaceProblem<dim>::embed_solution_to_dg()
       dg_eval.gather_evaluate(dg_solution, EvaluationFlags::values);
       Solution<dim> solution;
       double        local_error = 0;
-      for (unsigned int q : dg_eval.quadrature_point_indices())
+      for (const unsigned int q : dg_eval.quadrature_point_indices())
         for (unsigned int v = 0;
              v <
              system_matrix.get_matrix_free().n_active_entries_per_cell_batch(

--- a/tests/performance/timing_navier_stokes.cc
+++ b/tests/performance/timing_navier_stokes.cc
@@ -1885,7 +1885,7 @@ namespace NavierStokes_DG
 
     GridGenerator::hyper_rectangle(triangulation, lower_left, upper_right);
     for (const auto &cell : triangulation.cell_iterators())
-      for (unsigned int face : cell->face_indices())
+      for (const unsigned int face : cell->face_indices())
         if (cell->at_boundary(face))
           cell->face(face)->set_boundary_id(face);
     std::vector<

--- a/tests/performance/timing_step_37.cc
+++ b/tests/performance/timing_step_37.cc
@@ -170,7 +170,7 @@ LaplaceOperator<dim, fe_degree, number>::vmult(
   const LinearAlgebra::distributed::Vector<number> &src) const
 {
   this->data->cell_loop(&LaplaceOperator::local_apply, this, dst, src, true);
-  for (unsigned int i : this->data->get_constrained_dofs())
+  for (const unsigned int i : this->data->get_constrained_dofs())
     dst.local_element(i) = src.local_element(i);
 }
 
@@ -192,7 +192,7 @@ LaplaceOperator<dim, fe_degree, number>::vmult(
                         src,
                         operation_before_loop,
                         operation_after_loop);
-  for (unsigned int i : this->data->get_constrained_dofs())
+  for (const unsigned int i : this->data->get_constrained_dofs())
     dst.local_element(i) = src.local_element(i);
 }
 


### PR DESCRIPTION
Noticed while reviewing one of @drwells 's patches yesterday.