### PR TITLE
Prefer numbers::is_nan over std::isnan

### DIFF
--- a/include/deal.II/lac/full_matrix.templates.h
+++ b/include/deal.II/lac/full_matrix.templates.h
@@ -1726,7 +1726,7 @@ FullMatrix<number>::print_formatted(std::ostream &     out,
       for (size_type j = 0; j < n(); ++j)
         // we might have complex numbers, so use abs also to check for nan
         // since there is no isnan on complex numbers
-        if (std::isnan(std::abs((*this)(i, j))))
+        if (numbers::is_nan(std::abs((*this)(i, j))))
           out << std::setw(width) << (*this)(i, j) << ' ';
         else if (std::abs((*this)(i, j)) > threshold)
           out << std::setw(width) << (*this)(i, j) * number(denominator) << ' ';

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -613,7 +613,7 @@ namespace parallel
 
     const auto unpack = [&](const auto &cell, const auto &vertices) {
       for (const auto v : cell->vertex_indices())
-        if (std::isnan(vertices[v][0]) == false)
+        if (numbers::is_nan(vertices[v][0]) == false)
           cell->vertex(v) = vertices[v];
     };
 

--- a/source/lac/lapack_full_matrix.cc
+++ b/source/lac/lapack_full_matrix.cc
@@ -2461,7 +2461,7 @@ LAPACKFullMatrix<number>::print_formatted(std::ostream &     out,
       for (size_type j = 0; j < nc; ++j)
         // we might have complex numbers, so use abs also to check for nan
         // since there is no isnan on complex numbers
-        if (std::isnan(std::abs((*this)(i, j))))
+        if (numbers::is_nan(std::abs((*this)(i, j))))
           out << std::setw(width) << (*this)(i, j) << ' ';
         else if (std::abs(this->el(i, j)) > threshold)
           out << std::setw(width) << this->el(i, j) * denominator << ' ';

--- a/source/lac/solver_control.cc
+++ b/source/lac/solver_control.cc
@@ -89,7 +89,7 @@ SolverControl::check(const unsigned int step, const double check_value)
       return success;
     }
 
-  if ((step >= maxsteps) || std::isnan(check_value) ||
+  if ((step >= maxsteps) || numbers::is_nan(check_value) ||
       (check_failure && (check_value > failure_residual)))
     {
       if (m_log_result)


### PR DESCRIPTION
Part of #15301.

In preparation to silence all finite math warnings, or at least to collect them all in one spot.