### PR TITLE
`TriaAccessor`: remove outdated assert for `n_faces()` for `structdim!=dim`

### DIFF
--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -1741,8 +1741,6 @@ public:
 
   /**
    * Number of faces.
-   *
-   * @note Only implemented for cells (structdim==dim).
    */
   unsigned int
   n_faces() const;
@@ -1764,8 +1762,6 @@ public:
   /**
    * Return an object that can be thought of as an array containing all indices
    * from zero to n_faces().
-   *
-   * @note Only implemented for cells (structdim==dim).
    */
   std_cxx20::ranges::iota_view<unsigned int, unsigned int>
   face_indices() const;

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -2397,8 +2397,6 @@ template <int structdim, int dim, int spacedim>
 unsigned int
 TriaAccessor<structdim, dim, spacedim>::n_faces() const
 {
-  AssertDimension(structdim, dim);
-
   return this->reference_cell().n_faces();
 }
 


### PR DESCRIPTION
This PR removes the assert requiring equal values for `structdim` and `dim` from `TriaAccessor::n_faces()`. This should not be necessary anymore since there is a general implementation for `ReferenceCell`, considering arbitrary combinations of `structdim` and `dim`, see
https://github.com/dealii/dealii/blob/b3d4438c87adb8670b205785dfdd3498d8e0b65b/include/deal.II/grid/tria_accessor.templates.h#L1261-L1274.

@tinhvo-TUM FYI