### PR TITLE
Remove unused mpi_communicator pointer members initialized by temporaries

### DIFF
--- a/examples/step-45/step-45.cc
+++ b/examples/step-45/step-45.cc
@@ -202,7 +202,6 @@ namespace Step45
     const SmartPointer<const MatrixType>         matrix;
     const SmartPointer<const PreconditionerType> preconditioner;
 
-    const MPI_Comm *                      mpi_communicator;
     mutable TrilinosWrappers::MPI::Vector tmp;
   };
 
@@ -216,7 +215,6 @@ namespace Step45
     const MPI_Comm            mpi_communicator)
     : matrix(&m)
     , preconditioner(&preconditioner)
-    , mpi_communicator(&mpi_communicator)
     , tmp(locally_owned, mpi_communicator)
   {}
 

--- a/tests/mpi/muelu_periodicity.cc
+++ b/tests/mpi/muelu_periodicity.cc
@@ -197,7 +197,6 @@ namespace Step22
     const SmartPointer<const Matrix>         matrix;
     const SmartPointer<const Preconditioner> preconditioner;
 
-    const MPI_Comm *                      mpi_communicator;
     mutable TrilinosWrappers::MPI::Vector tmp;
   };
 
@@ -210,7 +209,6 @@ namespace Step22
     const MPI_Comm        mpi_communicator)
     : matrix(&m)
     , preconditioner(&preconditioner)
-    , mpi_communicator(&mpi_communicator)
     , tmp(locally_owned, mpi_communicator)
   {}
 

--- a/tests/mpi/periodicity_02.cc
+++ b/tests/mpi/periodicity_02.cc
@@ -199,7 +199,6 @@ namespace Step22
     const SmartPointer<const Matrix>         matrix;
     const SmartPointer<const Preconditioner> preconditioner;
 
-    const MPI_Comm *                      mpi_communicator;
     mutable TrilinosWrappers::MPI::Vector tmp;
   };
 
@@ -212,7 +211,6 @@ namespace Step22
     const MPI_Comm        mpi_communicator)
     : matrix(&m)
     , preconditioner(&preconditioner)
-    , mpi_communicator(&mpi_communicator)
     , tmp(locally_owned, mpi_communicator)
   {}
 

--- a/tests/mpi/periodicity_03.cc
+++ b/tests/mpi/periodicity_03.cc
@@ -122,7 +122,6 @@ namespace Step22
     const SmartPointer<const Matrix>         matrix;
     const SmartPointer<const Preconditioner> preconditioner;
 
-    const MPI_Comm *                      mpi_communicator;
     mutable TrilinosWrappers::MPI::Vector tmp;
   };
 
@@ -135,7 +134,6 @@ namespace Step22
     const MPI_Comm        mpi_communicator)
     : matrix(&m)
     , preconditioner(&preconditioner)
-    , mpi_communicator(&mpi_communicator)
     , tmp(locally_owned, mpi_communicator)
   {}
 


### PR DESCRIPTION
Fixes some warnings in https://cdash.dealii.org/viewBuildError.php?type=1&buildid=1418.