### PR TITLE
Fix compiling with Trilinos 14 and Cuda

### DIFF
--- a/cmake/modules/FindDEAL_II_TRILINOS.cmake
+++ b/cmake/modules/FindDEAL_II_TRILINOS.cmake
@@ -110,9 +110,13 @@ if(Trilinos_FOUND)
 endif()
 
 if(TRILINOS_VERSION VERSION_GREATER_EQUAL 14)
-  set(_target Trilinos::all_libs)
+  set(_targets Trilinos::all_libs)
+  if(TARGET Kokkos::kokkos)
+    list(APPEND _targets Kokkos::kokkos)
+  endif()
+
   process_feature(TRILINOS
-    TARGETS REQUIRED _target
+    TARGETS REQUIRED _targets
     CLEAR
       EPETRA_CONFIG_H TRILINOS_CXX_SUPPORTS_SACADO_COMPLEX_RAD
     )

--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -1341,9 +1341,9 @@ namespace Particles
                     get_next_free_particle_index() * spacedim);
     for (auto &p : *this)
       {
-        auto       new_point(displace_particles ? p.get_location() :
-                                                  Point<spacedim>());
-        const auto id = p.get_id();
+        Point<spacedim> new_point(displace_particles ? p.get_location() :
+                                                       Point<spacedim>());
+        const auto      id = p.get_id();
         for (unsigned int i = 0; i < spacedim; ++i)
           new_point[i] += input_vector[id * spacedim + i];
         p.set_location(new_point);


### PR DESCRIPTION
Fixes https://github.com/dealii/dealii/pull/15164#issuecomment-1580746831.
It seems that `Trilinos` lists `Kokkos::all_libs` (which depends on `KokkosCore::all_libs` and then `KokkosCore::kokkoscore`) but we don't pull `Kokkos::kokkos` (that specifies compiler flags) in.
Fix this, by listing that target explicitly if it's defined. 