### PR TITLE
Fix compiler warning with clang-16

### DIFF
--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -2885,6 +2885,7 @@ namespace GridTools
                            return cell_marked(cell);
                          });
     };
+    (void)any_cell_marked;
 
     while (found_cell == false)
       {


### PR DESCRIPTION
In clang-16 the lambda function is unused. Avoid the warning.