### PR TITLE
github-actions: Do not treat `tautological-constant-compare` as error.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -332,7 +332,7 @@ jobs:
         cd build
         cmake -D CMAKE_BUILD_TYPE=Debug \
               -D CMAKE_CXX_COMPILER=icpx \
-              -D DEAL_II_CXX_FLAGS='-Werror -fno-finite-math-only' \
+              -D DEAL_II_CXX_FLAGS='-Werror -Wno-error=tautological-constant-compare' \
               -D DEAL_II_EARLY_DEPRECATIONS=ON \
               -D DEAL_II_WITH_MPI=ON \
               -D DEAL_II_WITH_LAPACK=ON \


### PR DESCRIPTION
Part of #15301.

Instead of disabling finite math for the IntelLLVM build, I propose to no longer treat the warning associated with the `isnan` comparison as an error. They will still be displayed as warnings, but the build completes. This only affects the CI check, not the general way we build the library with IntelLLVM.

This way we can catch other issues related to finite math mode, which is the default for the IntelLLVM compiler.

@masterleinad -- What do you think?