### PR TITLE
Adjust iterator traits classes for C++20.

### DIFF
--- a/include/deal.II/base/array_view.h
+++ b/include/deal.II/base/array_view.h
@@ -705,7 +705,13 @@ make_array_view(const Iterator begin, const Iterator end)
 {
   static_assert(
     std::is_same<typename std::iterator_traits<Iterator>::iterator_category,
-                 typename std::random_access_iterator_tag>::value,
+                 typename std::random_access_iterator_tag>::value
+#ifdef DEAL_II_HAVE_CXX20
+      ||
+      std::is_same<typename std::iterator_traits<Iterator>::iterator_category,
+                   typename std::contiguous_iterator_tag>::value
+#endif
+    ,
     "The provided iterator needs to be a random access iterator.");
   Assert(begin <= end,
          ExcMessage(

--- a/include/deal.II/base/linear_index_iterator.h
+++ b/include/deal.II/base/linear_index_iterator.h
@@ -142,7 +142,11 @@ public:
   /**
    * Iterator category.
    */
+#ifdef DEAL_II_HAVE_CXX20
+  using iterator_category = std::contiguous_iterator_tag;
+#else
   using iterator_category = std::random_access_iterator_tag;
+#endif
 
   /**
    * An alias for the type you get when you dereference an iterator of the

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -6052,9 +6052,13 @@ namespace std
   template <class T>
   struct iterator_traits<dealii::VectorizedArrayIterator<T>>
   {
+#ifdef DEAL_II_HAVE_CXX20
+    using iterator_category = contiguous_iterator_tag;
+#else
     using iterator_category = random_access_iterator_tag;
-    using value_type        = typename T::value_type;
-    using difference_type   = std::ptrdiff_t;
+#endif
+    using value_type      = typename T::value_type;
+    using difference_type = std::ptrdiff_t;
   };
 
 } // namespace std

--- a/include/deal.II/hp/collection.h
+++ b/include/deal.II/hp/collection.h
@@ -21,6 +21,7 @@
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/subscriptor.h>
 
+#include <iterator>
 #include <memory>
 #include <vector>
 
@@ -306,11 +307,9 @@ namespace std
    */
   template <class T>
   struct iterator_traits<dealii::hp::CollectionIterator<T>>
-  {
-    using iterator_category = random_access_iterator_tag;
-    using value_type        = T;
-    using difference_type   = std::ptrdiff_t;
-  };
+    : public iterator_traits<
+        typename std::vector<std::shared_ptr<const T>>::iterator>
+  {};
 } // namespace std
 
 #endif

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -141,6 +141,13 @@ namespace internal
        * by algorithms to enquire about the specifics of the iterators they
        * work on. (Example: `std::next()`, which needs to know about a local
        * type named `difference_type`.)
+       *
+       * As for the iterator_category, C++20 has a more specialized
+       * contiguous_iterator_tag, but the elements of block vectors are
+       * not stored in a contiguous manner. They can be accessed in a
+       * random access order, though, with O(1) effort as long as we
+       * assume that the number of blocks of a vector is a constant
+       * (even though the *size* of the vector is not).
        */
       using iterator_category = std::random_access_iterator_tag;
       using difference_type   = std::ptrdiff_t;


### PR DESCRIPTION
C++20 has a new iterator category that is even more specialized than `std::random_access_iterator_tag`: [std::contiguous_iterator_tag](https://en.cppreference.com/w/cpp/iterator/iterator_tags). If we are in C++20 mode, we should use it.

The first two commits make sure other places of our code base can deal with this sort of stuff.