### PR TITLE
Step-69: fix typo in documentation

### DIFF
--- a/examples/step-69/step-69.cc
+++ b/examples/step-69/step-69.cc
@@ -179,8 +179,7 @@ namespace Step69
   // The class <code>OfflineData</code> contains pretty much all components
   // of the discretization that do not evolve in time, in particular, the
   // DoFHandler, SparsityPattern, boundary maps, the
-  // @ref GlossLumpedMassMatrix "lumped" lumped
-  // @ref GlossMassMatrix "mass matrix",
+  // @ref GlossLumpedMassMatrix "lumped mass matrix",
   // $\mathbf{c}_{ij}$ and $\mathbf{n}_{ij}$ matrices. Here, the term
   // <i>offline</i> refers to the fact that all the class
   // members of <code>OfflineData</code> have well-defined values


### PR DESCRIPTION
In the current documentation of step-69 the term "lumped" appears twice (introduced in
https://github.com/dealii/dealii/pull/14830) in a sentence:

![image](https://github.com/dealii/dealii/assets/70260016/032cd602-40e4-4ddf-a0f7-b9044a52ec63)

~~This PR suggests to remove the plain "lumped".~~ 

I am wondering if it would make more sense to only keep the glossary link to the lumped mass matrix instead of having two sequential glossary links:

```diff
- @ref GlossLumpedMassMatrix "lumped" @ref GlossMassMatrix "mass matrix",
+ @ref GlossLumpedMassMatrix "lumped mass matrix",
```

The glossary link to the mass matrix can be found in the lumped mass matrix section anyhow. Thus, this PR suggests to incorporate this modification.
