### PR TITLE
Fix matrix_free_device tests for Trilinos 12.14.1

### DIFF
--- a/include/deal.II/matrix_free/cuda_fe_evaluation.h
+++ b/include/deal.II/matrix_free/cuda_fe_evaluation.h
@@ -519,6 +519,19 @@ namespace CUDAWrappers
                          [&](const int &i) { func(this, i); });
     shared_data->team_member.team_barrier();
   }
+
+
+
+#ifndef DOXYGEN
+  template <int dim,
+            int fe_degree,
+            int n_q_points_1d,
+            int n_components_,
+            typename Number>
+  constexpr unsigned int
+    FEEvaluation<dim, fe_degree, n_q_points_1d, n_components_, Number>::
+      n_q_points;
+#endif
 } // namespace CUDAWrappers
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -624,7 +624,12 @@ namespace CUDAWrappers
             "dealii::MatrixFree::evaluate_coeff",
             Kokkos::MDRangePolicy<
               MemorySpace::Default::kokkos_space::execution_space,
-              Kokkos::Rank<2>>(exec, {0, 0}, {n_cells[i], Functor::n_q_points}),
+              Kokkos::Rank<2>>(
+#if KOKKOS_VERSION >= 20900
+              exec,
+#endif
+              {0, 0},
+              {n_cells[i], Functor::n_q_points}),
             KOKKOS_LAMBDA(const int cell, const int q) {
               func(&color_data, cell, q);
             });
@@ -920,7 +925,12 @@ namespace CUDAWrappers
           MemorySpace::Default::kokkos_space::execution_space exec;
           Kokkos::TeamPolicy<
             MemorySpace::Default::kokkos_space::execution_space>
-            team_policy(exec, n_cells[color], Kokkos::AUTO);
+            team_policy(
+#if KOKKOS_VERSION >= 20900
+              exec,
+#endif
+              n_cells[color],
+              Kokkos::AUTO);
 
           internal::ApplyKernel<dim, Number, Functor> apply_kernel(
             func, get_data(color), src.get_values(), dst.get_values());
@@ -960,7 +970,12 @@ namespace CUDAWrappers
               {
                 Kokkos::TeamPolicy<
                   MemorySpace::Default::kokkos_space::execution_space>
-                  team_policy(exec, n_cells[0], Kokkos::AUTO);
+                  team_policy(
+#if KOKKOS_VERSION >= 20900
+                    exec,
+#endif
+                    n_cells[0],
+                    Kokkos::AUTO);
 
                 internal::ApplyKernel<dim, Number, Functor> apply_kernel(
                   func, get_data(0), src.get_values(), dst.get_values());
@@ -978,7 +993,12 @@ namespace CUDAWrappers
               {
                 Kokkos::TeamPolicy<
                   MemorySpace::Default::kokkos_space::execution_space>
-                  team_policy(exec, n_cells[1], Kokkos::AUTO);
+                  team_policy(
+#if KOKKOS_VERSION >= 20900
+                    exec,
+#endif
+                    n_cells[1],
+                    Kokkos::AUTO);
 
                 internal::ApplyKernel<dim, Number, Functor> apply_kernel(
                   func, get_data(1), src.get_values(), dst.get_values());
@@ -1001,7 +1021,12 @@ namespace CUDAWrappers
               {
                 Kokkos::TeamPolicy<
                   MemorySpace::Default::kokkos_space::execution_space>
-                  team_policy(exec, n_cells[2], Kokkos::AUTO);
+                  team_policy(
+#if KOKKOS_VERSION >= 20900
+                    exec,
+#endif
+                    n_cells[2],
+                    Kokkos::AUTO);
 
                 internal::ApplyKernel<dim, Number, Functor> apply_kernel(
                   func, get_data(2), src.get_values(), dst.get_values());
@@ -1029,7 +1054,12 @@ namespace CUDAWrappers
                 {
                   Kokkos::TeamPolicy<
                     MemorySpace::Default::kokkos_space::execution_space>
-                    team_policy(exec, n_cells[i], Kokkos::AUTO);
+                    team_policy(
+#if KOKKOS_VERSION >= 20900
+                      exec,
+#endif
+                      n_cells[i],
+                      Kokkos::AUTO);
 
                   internal::ApplyKernel<dim, Number, Functor> apply_kernel(
                     func, get_data(i), src.get_values(), dst.get_values());
@@ -1061,7 +1091,12 @@ namespace CUDAWrappers
             {
               Kokkos::TeamPolicy<
                 MemorySpace::Default::kokkos_space::execution_space>
-                team_policy(exec, n_cells[i], Kokkos::AUTO);
+                team_policy(
+#if KOKKOS_VERSION >= 20900
+                  exec,
+#endif
+                  n_cells[i],
+                  Kokkos::AUTO);
 
               internal::ApplyKernel<dim, Number, Functor> apply_kernel(
                 func,

--- a/tests/matrix_free/matrix_free_device_no_index_initialize.cc
+++ b/tests/matrix_free/matrix_free_device_no_index_initialize.cc
@@ -97,6 +97,18 @@ protected:
   const CUDAWrappers::MatrixFree<dim, Number> &data;
 };
 
+template <int dim, int fe_degree, int n_q_points_1d, typename Number>
+const unsigned int
+  MatrixFreeTest<dim, fe_degree, n_q_points_1d, Number>::n_dofs_1d;
+
+template <int dim, int fe_degree, int n_q_points_1d, typename Number>
+const unsigned int
+  MatrixFreeTest<dim, fe_degree, n_q_points_1d, Number>::n_local_dofs;
+
+template <int dim, int fe_degree, int n_q_points_1d, typename Number>
+const unsigned int
+  MatrixFreeTest<dim, fe_degree, n_q_points_1d, Number>::n_q_points;
+
 
 
 template <int dim, int fe_degree, typename number>


### PR DESCRIPTION
Fixes the `matrix_free_device_*` tests in https://cdash.dealii.org/viewTest.php?onlyfailed&buildid=1688. 
I really hope we can drop support for these old `Trilinos` versions soon.