### PR TITLE
NonNestedTransfer: allow to pass coarse DH with more dofs than fine DH

### DIFF
--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -3827,9 +3827,6 @@ MGTwoLevelTransferNonNested<dim, LinearAlgebra::distributed::Vector<Number>>::
   Assert(dof_handler_coarse.get_fe().n_components() > 0 &&
            dof_handler_fine.get_fe().n_components() > 0,
          ExcNotImplemented());
-  Assert(dof_handler_fine.n_dofs() > dof_handler_coarse.n_dofs(),
-         ExcMessage(
-           "The coarser DoFHandler has more DoFs than the finer DoFHandler."));
 
   this->fine_element_is_continuous =
     dof_handler_fine.get_fe().n_dofs_per_vertex() > 0;


### PR DESCRIPTION
I am using `MGTwoLevelTransferNonNested` with a coarse mesh which is much larger than the fine mesh. Therefore, the fine mesh has less `DoFs` and an `Assert` triggers. Since the `Assert` is extremely helpful in almost every case, I would like to introduce an option which can be used to switch it off in the corner case I am considering. 

Note, that introduced `AdditionalData` will be also helpful in the future since there are plans to implement an L2 projection with and without `CGAL`. The method can be specified in `AdditionalData` as well.

@fdrmrc @peterrum 

------------------------------
Edit: I simply deleted the Assert as discussed below :)