### PR TITLE
Avoid a quadratic bottleneck in AffineConstraints::distribute().

### DIFF
--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -2610,11 +2610,19 @@ AffineConstraints<number>::distribute(VectorType &vec) const
       // following.
       IndexSet needed_elements = vec_owned_elements;
 
+      std::vector<types::global_dof_index> additional_elements;
       for (const ConstraintLine &line : lines)
         if (vec_owned_elements.is_element(line.index))
           for (const std::pair<size_type, number> &entry : line.entries)
             if (!vec_owned_elements.is_element(entry.first))
-              needed_elements.add_index(entry.first);
+              additional_elements.emplace_back(entry.first);
+      std::sort(additional_elements.begin(), additional_elements.end());
+      additional_elements.erase(std::unique(additional_elements.begin(),
+                                            additional_elements.end()),
+                                additional_elements.end());
+
+      needed_elements.add_indices(additional_elements.begin(),
+                                  additional_elements.end());
 
       VectorType ghosted_vector;
       internal::import_vector_with_ghost_elements(


### PR DESCRIPTION
@marcfehling found that in one of his programs, `AffineConstraints::distribute()` takes a rather long time when working on an h-refined mesh with high polynomial degree. @peterrum pointed out that that may (or may not, not sure yet) be a result of a quadratic algorithm in that function. This turns out to be easily avoided: We shouldn't insert elements into an `IndexSet` one-by-one, but give `AffineConstraints` an already sorted list instead. This patch does this.

I consider this a bug in the current implementation, and a relatively safe patch given that `AffineConstraint` is used in 887 tests. Not all of those run through this path (which only affects the parallel case), but a substantial number of MPI tests will use this (for example, 76 in `tests/mpi/`). As a consequence, could I propose that we still merge this before the release?