### PR TITLE
improve name and documentation

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -1361,9 +1361,10 @@ namespace GridTools
       std::vector<unsigned int> recv_ptrs;
 
       /**
-       * Distribute quadrature points on found intersections and construct
-       * GridTools::internal::DistributedComputePointLocationsInternal from
-       * class members. This can be done without searching for points again
+       * Distribute quadrature points according to
+       * QGaussSimplex<structdim>(n_points_1D) on found intersections and
+       * construct GridTools::internal::DistributedComputePointLocationsInternal
+       * from class members. This can be done without searching for points again
        * since all information is locally known.
        *
        * The parameter @p consistent_numbering_of_sender_and_receiver can be used to ensure
@@ -1378,7 +1379,7 @@ namespace GridTools
       GridTools::internal::DistributedComputePointLocationsInternal<dim,
                                                                     spacedim>
       convert_to_distributed_compute_point_locations_internal(
-        const unsigned int                  n_quadrature_points,
+        const unsigned int                  n_points_1D,
         const Triangulation<dim, spacedim> &tria,
         const Mapping<dim, spacedim> &      mapping,
         const bool consistent_numbering_of_sender_and_receiver = false) const;

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -6331,7 +6331,7 @@ namespace GridTools
     DistributedComputePointLocationsInternal<dim, spacedim>
     DistributedComputeIntersectionLocationsInternal<structdim, spacedim>::
       convert_to_distributed_compute_point_locations_internal(
-        const unsigned int                  n_quadrature_points,
+        const unsigned int                  n_points_1D,
         const Triangulation<dim, spacedim> &tria,
         const Mapping<dim, spacedim> &      mapping,
         const bool consistent_numbering_of_sender_and_receiver) const
@@ -6346,7 +6346,7 @@ namespace GridTools
       // We need quadrature rules for the intersections. We are using a
       // QGaussSimplex quadrature rule since CGAL always returns simplices
       // as intersections.
-      const QGaussSimplex<structdim> quadrature(n_quadrature_points);
+      const QGaussSimplex<structdim> quadrature(n_points_1D);
 
       // Resulting quadrature points get different indices. In the case the
       // requested intersections are unique also the resulting quadrature


### PR DESCRIPTION
The function 
```
convert_to_distributed_compute_point_locations_internal(n_quadrature_points,...)
```
distributes `structdim*n_quadrature_points` quadrature points, and therefore the name can be easily misunderstood.