### PR TITLE
Fix doxygen for PETScWrappers::TimeStepper using DEAL_II_CXX20_REQUIRES

### DIFF
--- a/include/deal.II/lac/petsc_ts.h
+++ b/include/deal.II/lac/petsc_ts.h
@@ -304,7 +304,9 @@ namespace PETScWrappers
   template <typename VectorType  = PETScWrappers::VectorBase,
             typename PMatrixType = PETScWrappers::MatrixBase,
             typename AMatrixType = PMatrixType>
-  DEAL_II_CXX20_REQUIRES(
+#  if defined(DEAL_II_HAVE_CXX20) && \
+    !defined(DEAL_II_DOXYGEN_DO_NOT_PARSE_REQUIRES_CLAUSES)
+  requires(
     (concepts::is_dealii_petsc_vector_type<VectorType> ||
      std::constructible_from<
        VectorType,
@@ -313,7 +315,8 @@ namespace PETScWrappers
                  PMatrixType,
                  Mat>)&&(concepts::is_dealii_petsc_matrix_type<AMatrixType> ||
                          std::constructible_from<AMatrixType, Mat>))
-  class TimeStepper
+#  endif
+    class TimeStepper
   {
   public:
     /**


### PR DESCRIPTION
Fixes https://github.com/dealii/dealii/issues/15234. This seems to be the only location where `DEAL_II_CXX20_REQUIRES` was still making problems. With this patch, I am seeing:
```
$ grep -rIn "DEAL_II_CXX20_REQUIRES" doc/doxygen/ | grep -v "source.html" 
doc/doxygen//options.dox:316:    PREDEFINED += DEAL_II_CXX20_REQUIRES(x)=
doc/doxygen//deal.II/globals_d.html:114:<li>DEAL_II_CXX20_REQUIRES&#160;:&#160;<a class="el" href="config_8h.html#a6b672d00e5fb5035e93a42a956d4e9ce">config.h</a></li>
doc/doxygen//deal.II/config_8h.html:179:<tr class="memitem:a6b672d00e5fb5035e93a42a956d4e9ce"><td class="memItemLeft" align="right" valign="top">#define&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="config_8h.html#a6b672d00e5fb5035e93a42a956d4e9ce">DEAL_II_CXX20_REQUIRES</a>(condition)</td></tr>
doc/doxygen//deal.II/config_8h.html:823:<h2 class="memtitle"><span class="permalink"><a href="#a6b672d00e5fb5035e93a42a956d4e9ce">&#9670;&#160;</a></span>DEAL_II_CXX20_REQUIRES</h2>
doc/doxygen//deal.II/config_8h.html:829:          <td class="memname">#define DEAL_II_CXX20_REQUIRES</td>
doc/doxygen//deal.II/search/all_e.js:123:  ['deal_5fii_5fcxx20_5frequires_120',['DEAL_II_CXX20_REQUIRES',['../config_8h.html#a6b672d00e5fb5035e93a42a956d4e9ce',1,'config.h']]],
doc/doxygen//deal.II/search/defines_2.js:19:  ['deal_5fii_5fcxx20_5frequires_16',['DEAL_II_CXX20_REQUIRES',['../config_8h.html#a6b672d00e5fb5035e93a42a956d4e9ce',1,'config.h']]],
doc/doxygen//deal.II/globals_defs_d.html:114:<li>DEAL_II_CXX20_REQUIRES&#160;:&#160;<a class="el" href="config_8h.html#a6b672d00e5fb5035e93a42a956d4e9ce">config.h</a></li>
doc/doxygen//deal.tag:673:      <name>DEAL_II_CXX20_REQUIRES</name>
```