### PR TITLE
fix: update ninja build resource

### DIFF
--- a/doc/users/cmake_dealii.html
+++ b/doc/users/cmake_dealii.html
@@ -350,7 +350,7 @@ $ cmake -G"Eclipse CDT4 - Unix Makefiles" [...]
 
     <p>
       An interesting alternative to (GNU) Make might also be <a
-      href="http://martine.github.io/ninja/">Ninja</a>. Configure via
+      href="https://ninja-build.org/">Ninja</a>. Configure via
 <pre class="cmake">
 $ cmake -GNinja [...]
 </pre>


### PR DESCRIPTION
**PR Summary**:
The PR contains a fix to the broken hyperlink leading to ninja build resource.