### PR TITLE
Make FE_EVAL_FACTORY_DEGREE_MAX more robust

### DIFF
--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -5856,6 +5856,20 @@ namespace internal
     }
   };
 
+  /**
+   * This struct is used to implement
+   * FEEvaluation::fast_evaluation_supported() and
+   * FEFaceEvaluation::fast_evaluation_supported().
+   */
+  struct FastEvaluationSupported
+  {
+    template <int fe_degree, int n_q_points_1d>
+    static bool
+    run()
+    {
+      return fe_degree != -1;
+    }
+  };
 } // end of namespace internal
 
 

--- a/include/deal.II/matrix_free/evaluation_template_face_factory.templates.h
+++ b/include/deal.II/matrix_free/evaluation_template_face_factory.templates.h
@@ -118,6 +118,21 @@ namespace internal
       fe_eval);
   }
 
+
+
+  // It is important that this file sits in the same compilation unit as the
+  // evaluate() and integrate() calls of this class, to ensure that all
+  // options choose the same code path when compiling FEFaceEvaluationFactory
+  // outside of deal.II.
+  template <int dim, typename Number>
+  bool
+  FEFaceEvaluationFactory<dim, Number>::fast_evaluation_supported(
+    const unsigned int given_degree,
+    const unsigned int n_q_points_1d)
+  {
+    return instantiation_helper_run<1, FastEvaluationSupported>(given_degree,
+                                                                n_q_points_1d);
+  }
 } // end of namespace internal
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/matrix_free/evaluation_template_factory.h
+++ b/include/deal.II/matrix_free/evaluation_template_factory.h
@@ -71,6 +71,10 @@ namespace internal
               const EvaluationFlags::EvaluationFlags integration_flag,
               Number *                               values_dofs,
               FEEvaluationData<dim, Number, true> &  fe_eval);
+
+    static bool
+    fast_evaluation_supported(const unsigned int given_degree,
+                              const unsigned int n_q_points_1d);
   };
 
 

--- a/include/deal.II/matrix_free/evaluation_template_factory.templates.h
+++ b/include/deal.II/matrix_free/evaluation_template_factory.templates.h
@@ -29,18 +29,6 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
-  struct FastEvaluationSupported
-  {
-    template <int fe_degree, int n_q_points_1d>
-    static bool
-    run()
-    {
-      return fe_degree != -1;
-    }
-  };
-
-
-
   template <int dim, typename Number>
   void
   FEEvaluationFactory<dim, Number>::evaluate(
@@ -81,6 +69,10 @@ namespace internal
 
 
 
+  // It is important that this file sits in the same compilation unit as the
+  // evaluate() and integrate() calls of this class, to ensure that all
+  // options choose the same code path when compiling FEFaceEvaluationFactory
+  // outside of deal.II.
   template <int dim, typename Number>
   bool
   FEEvaluationFactory<dim, Number>::fast_evaluation_supported(

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -1709,8 +1709,16 @@ protected:
  * setting the macro `FE_EVAL_FACTORY_DEGREE_MAX` to the desired integer and
  * instantiating the classes FEEvaluationFactory and FEFaceEvaluationFactory
  * (the latter for FEFaceEvaluation) creates paths to templated functions for
- * a possibly larger set of degrees. You can check if fast
- * evaluation/integration for a given degree/n_quadrature_points pair by calling
+ * a possibly larger set of degrees. This can both be set when configuring
+ * deal.II by passing the flag `-D FE_EVAL_FACTORY_DEGREE_MAX=8` (in case you
+ * want to compile all degrees up to eight; recommended setting) or by
+ * compiling `evaluation_template_factory.templates.h` and
+ * `evaluation_template_face_factory.templates.h` with the
+ * `FE_EVAL_FACTORY_DEGREE_MAX` overriden to the desired value. In the second
+ * option, symbols will be available twice, and it depends on your linker and
+ * dynamic library loader whether the user-specified setting takes
+ * precendence. You can check if fast evaluation/integration for a given
+ * degree/n_quadrature_points pair by calling
  * FEEvaluation::fast_evaluation_supported() or
  * FEFaceEvaluation::fast_evaluation_supported().
  *
@@ -9249,7 +9257,7 @@ FEFaceEvaluation<dim,
                             const unsigned int given_n_q_points_1d)
 {
   return fe_degree == -1 ?
-           internal::FEEvaluationFactory<dim, VectorizedArrayType>::
+           internal::FEFaceEvaluationFactory<dim, VectorizedArrayType>::
              fast_evaluation_supported(given_degree, given_n_q_points_1d) :
            true;
 }

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -1716,10 +1716,10 @@ protected:
  * `evaluation_template_face_factory.templates.h` with the
  * `FE_EVAL_FACTORY_DEGREE_MAX` overriden to the desired value. In the second
  * option, symbols will be available twice, and it depends on your linker and
- * dynamic library loader whether the user-specified setting takes
- * precendence. You can check if fast evaluation/integration for a given
- * degree/n_quadrature_points pair by calling
- * FEEvaluation::fast_evaluation_supported() or
+ * dynamic library loader whether the user-specified setting takes precedence;
+ * use `LD_PRELOAD` to select the desired library. You can check if fast
+ * evaluation/integration for a given degree/n_quadrature_points pair by
+ * calling FEEvaluation::fast_evaluation_supported() or
  * FEFaceEvaluation::fast_evaluation_supported().
  *
  * <h3>Handling multi-component systems</h3>


### PR DESCRIPTION
Fixes #14106.

This implements the solution discussed in that PR: On the one hand, we make sure to always use the check `fast_evaluation_support()` compiled in the same compilation unit as the actual code we use from the factory. Furthermore, we recommend setting the define flag in the configuration of deal.II, which is robust because it does not duplicate the symbols.