### PR TITLE
MatrixFree: Only set up the inner faces when so requested

### DIFF
--- a/doc/news/changes/incompatibilities/20230619Kronbichler
+++ b/doc/news/changes/incompatibilities/20230619Kronbichler
@@ -1,0 +1,9 @@
+MatrixFree::reinit() would always set up the data structures for inner faces,
+also in case only
+MatrixFree::AdditionalData::mapping_updates_flags_boundary_faces was set. As
+this can lead to considerably higher memory consumption, the inner faces are
+now only set up when requested, increasing efficiency. When inner faces are
+desired, make sure to set
+MatrixFree::AdditionalData::mapping_updates_flags_inner_faces.
+<br>
+(Martin Kronbichler, 2023/06/19)

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -1969,12 +1969,13 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
                     true);
         }
 
-      internal::MatrixFreeFunctions::collect_faces_vectorization(
-        face_setup.inner_faces,
-        hard_vectorization_boundary,
-        task_info.face_partition_data,
-        face_info.faces,
-        dof_info[0].cell_active_fe_index);
+      if (additional_data.mapping_update_flags_inner_faces != update_default)
+        internal::MatrixFreeFunctions::collect_faces_vectorization(
+          face_setup.inner_faces,
+          hard_vectorization_boundary,
+          task_info.face_partition_data,
+          face_info.faces,
+          dof_info[0].cell_active_fe_index);
 
       // on boundary faces, we must also respect the vectorization boundary of
       // the inner faces because we might have dependencies on ghosts of


### PR DESCRIPTION
`MatrixFree::reinit()` would previously aggressively set up both interior faces and boundary faces also when only the boundary faces were requested (e.g., when using continuous elements with some Robin-type boundary conditions, one does not want to set up all interior faces which require more expensive data exchange routines). This is now fixed and the behavior is as documented: https://github.com/dealii/dealii/blob/051637127b117c3c50b215a6ab7a6183951dabfe/include/deal.II/matrix_free/matrix_free.h#L409-L413

This PR creates a backward compatibility problem, in the sense that some codes that relied on this (undocumented) feature will now not perform face integrals. To be done after we branched for the 9.5 release.