### PR TITLE
Release preparation: update gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,7 @@ Jenkinsfile export-ignore
 /tests/CMakeLists.txt -export-ignore
 /tests/quick_tests -export-ignore
 /tests/run_*.cmake -export-ignore
+/tests/setup_testsubproject.cmake -export-ignore
 /tests/tests.h -export-ignore
 
 #


### PR DESCRIPTION
Export a missing cmake configuration file that is needed in order to run our quick tests.

In reference to #15383