### PR TITLE
Instantiate MGTwoLevelTransferBase explicitly

### DIFF
--- a/source/multigrid/mg_transfer_global_coarsening.inst.in
+++ b/source/multigrid/mg_transfer_global_coarsening.inst.in
@@ -14,6 +14,11 @@
 // ---------------------------------------------------------------------
 
 
+for (S1 : REAL_SCALARS)
+  {
+    template class MGTwoLevelTransferBase<
+      LinearAlgebra::distributed::Vector<S1>>;
+  }
 
 for (deal_II_dimension : DIMENSIONS; S1 : REAL_SCALARS)
   {


### PR DESCRIPTION
Without this, all `multigrid-global-coarsening` are failing to build on my Mac.