### PR TITLE
Testsuite: fix gmsh tests

### DIFF
--- a/tests/gmsh/gmsh_api_01.cc
+++ b/tests/gmsh/gmsh_api_01.cc
@@ -22,8 +22,10 @@
 #include "../tests.h"
 
 int
-main()
+main(int argc, char **argv)
 {
+  // gmsh might be build with mpi support enabled.
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv);
   initlog();
 
   const unsigned int dim      = 2;

--- a/tests/gmsh/gmsh_api_02.cc
+++ b/tests/gmsh/gmsh_api_02.cc
@@ -41,8 +41,10 @@ test(const std::uint8_t kind, const std::string out = "")
 }
 
 int
-main()
+main(int argc, char **argv)
 {
+  // gmsh might be build with mpi support enabled.
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv);
   initlog();
 
   // Generate and print all reference cells

--- a/tests/gmsh/gmsh_api_03.cc
+++ b/tests/gmsh/gmsh_api_03.cc
@@ -44,8 +44,10 @@ test(const Triangulation<dim, spacedim> &tria)
 
 
 int
-main()
+main(int argc, char **argv)
 {
+  // gmsh might be build with mpi support enabled.
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv);
   initlog();
   {
     Triangulation<2> tria;

--- a/tests/gmsh/gmsh_api_04.cc
+++ b/tests/gmsh/gmsh_api_04.cc
@@ -55,8 +55,10 @@ test(const std::uint8_t kind, const std::string out = "")
 }
 
 int
-main()
+main(int argc, char **argv)
 {
+  // gmsh might be build with mpi support enabled.
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv);
   initlog();
 
   // Generate and print all reference cells

--- a/tests/gmsh/gmsh_api_04.with_gmsh_with_api=on.output.3
+++ b/tests/gmsh/gmsh_api_04.with_gmsh_with_api=on.output.3
@@ -1,0 +1,610 @@
+
+DEAL::Testing kind(1) in dimensions <1,1>
+DEAL::Original mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+1
+0 1 "BoundaryID:1"
+$EndPhysicalNames
+$Entities
+1 1 0 0
+2 0 0 0 1 1 
+1 0 0 0 1 0 0 1 2 0 
+$EndEntities
+$Nodes
+2 4 1 2
+0 2 0 2
+1
+2
+0 0 0
+1 0 0
+1 1 0 2
+1
+2
+0 0 0
+1 0 0
+$EndNodes
+$Elements
+1 1 1 1
+1 1 1 1
+1 1 2 
+$EndElements
+
+DEAL::Regenerated mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$Entities
+0 1 0 0
+1 0 0 0 1 0 0 1 1 0 
+$EndEntities
+$Nodes
+1 2 1 2
+1 1 0 2
+1
+2
+0 0 0
+1 0 0
+$EndNodes
+$Elements
+1 1 1 1
+1 1 1 1
+1 1 2 
+$EndElements
+
+DEAL::Testing kind(1) in dimensions <1,2>
+DEAL::Original mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+1
+0 1 "BoundaryID:1"
+$EndPhysicalNames
+$Entities
+1 1 0 0
+2 0 0 0 1 1 
+1 0 0 0 1 0 0 1 2 0 
+$EndEntities
+$Nodes
+2 4 1 2
+0 2 0 2
+1
+2
+0 0 0
+1 0 0
+1 1 0 2
+1
+2
+0 0 0
+1 0 0
+$EndNodes
+$Elements
+1 1 1 1
+1 1 1 1
+1 1 2 
+$EndElements
+
+DEAL::Regenerated mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$Entities
+0 1 0 0
+1 0 0 0 1 0 0 1 1 0 
+$EndEntities
+$Nodes
+1 2 1 2
+1 1 0 2
+1
+2
+0 0 0
+1 0 0
+$EndNodes
+$Elements
+1 1 1 1
+1 1 1 1
+1 1 2 
+$EndElements
+
+DEAL::Testing kind(1) in dimensions <1,3>
+DEAL::Original mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+1
+0 1 "BoundaryID:1"
+$EndPhysicalNames
+$Entities
+1 1 0 0
+2 0 0 0 1 1 
+1 0 0 0 1 0 0 1 2 0 
+$EndEntities
+$Nodes
+2 4 1 2
+0 2 0 2
+1
+2
+0 0 0
+1 0 0
+1 1 0 2
+1
+2
+0 0 0
+1 0 0
+$EndNodes
+$Elements
+1 1 1 1
+1 1 1 1
+1 1 2 
+$EndElements
+
+DEAL::Regenerated mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$Entities
+0 1 0 0
+1 0 0 0 1 0 0 1 1 0 
+$EndEntities
+$Nodes
+1 2 1 2
+1 1 0 2
+1
+2
+0 0 0
+1 0 0
+$EndNodes
+$Elements
+1 1 1 1
+1 1 1 1
+1 1 2 
+$EndElements
+
+DEAL::Testing kind(2) in dimensions <2,2>
+DEAL::Original mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$Entities
+0 0 1 0
+1 0 0 0 1 1 0 1 1 0 
+$EndEntities
+$Nodes
+1 3 1 3
+2 1 0 3
+1
+2
+3
+0 0 0
+1 0 0
+0 1 0
+$EndNodes
+$Elements
+1 1 1 1
+2 1 2 1
+1 1 2 3 
+$EndElements
+
+DEAL::Regenerated mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$Entities
+0 0 1 0
+1 0 0 0 1 1 0 1 1 0 
+$EndEntities
+$Nodes
+1 3 1 3
+2 1 0 3
+1
+2
+3
+0 0 0
+1 0 0
+0 1 0
+$EndNodes
+$Elements
+1 1 1 1
+2 1 2 1
+1 1 2 3 
+$EndElements
+
+DEAL::Testing kind(2) in dimensions <2,3>
+DEAL::Original mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$Entities
+0 0 1 0
+1 0 0 0 1 1 0 1 1 0 
+$EndEntities
+$Nodes
+1 3 1 3
+2 1 0 3
+1
+2
+3
+0 0 0
+1 0 0
+0 1 0
+$EndNodes
+$Elements
+1 1 1 1
+2 1 2 1
+1 1 2 3 
+$EndElements
+
+DEAL::Regenerated mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$Entities
+0 0 1 0
+1 0 0 0 1 1 0 1 1 0 
+$EndEntities
+$Nodes
+1 3 1 3
+2 1 0 3
+1
+2
+3
+0 0 0
+1 0 0
+0 1 0
+$EndNodes
+$Elements
+1 1 1 1
+2 1 2 1
+1 1 2 3 
+$EndElements
+
+DEAL::Testing kind(3) in dimensions <2,2>
+DEAL::Original mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$Entities
+0 0 1 0
+1 0 0 0 1 1 0 1 1 0 
+$EndEntities
+$Nodes
+1 4 1 4
+2 1 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+$EndNodes
+$Elements
+1 1 1 1
+2 1 3 1
+1 1 2 4 3 
+$EndElements
+
+DEAL::Regenerated mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$Entities
+0 0 1 0
+1 0 0 0 1 1 0 1 1 0 
+$EndEntities
+$Nodes
+1 4 1 4
+2 1 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+$EndNodes
+$Elements
+1 1 1 1
+2 1 3 1
+1 1 2 4 3 
+$EndElements
+
+DEAL::Testing kind(3) in dimensions <2,3>
+DEAL::Original mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$Entities
+0 0 1 0
+1 0 0 0 1 1 0 1 1 0 
+$EndEntities
+$Nodes
+1 4 1 4
+2 1 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+$EndNodes
+$Elements
+1 1 1 1
+2 1 3 1
+1 1 2 4 3 
+$EndElements
+
+DEAL::Regenerated mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$Entities
+0 0 1 0
+1 0 0 0 1 1 0 1 1 0 
+$EndEntities
+$Nodes
+1 4 1 4
+2 1 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+$EndNodes
+$Elements
+1 1 1 1
+2 1 3 1
+1 1 2 4 3 
+$EndElements
+
+DEAL::Testing kind(4) in dimensions <3,3>
+DEAL::Original mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$Entities
+0 0 0 1
+1 0 0 0 1 1 1 1 1 0 
+$EndEntities
+$Nodes
+1 4 1 4
+3 1 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+0 0 1
+$EndNodes
+$Elements
+1 1 1 1
+3 1 4 1
+1 1 2 3 4 
+$EndElements
+
+DEAL::Regenerated mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$Entities
+0 0 0 1
+1 0 0 0 1 1 1 1 1 0 
+$EndEntities
+$Nodes
+1 4 1 4
+3 1 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+0 0 1
+$EndNodes
+$Elements
+1 1 1 1
+3 1 4 1
+1 1 2 3 4 
+$EndElements
+
+DEAL::Testing kind(5) in dimensions <3,3>
+DEAL::Original mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$Entities
+0 0 0 1
+1 -1 -1 0 1 1 1 1 1 0 
+$EndEntities
+$Nodes
+1 5 1 5
+3 1 0 5
+1
+2
+3
+4
+5
+-1 -1 0
+1 -1 0
+-1 1 0
+1 1 0
+0 0 1
+$EndNodes
+$Elements
+1 1 1 1
+3 1 7 1
+1 1 2 4 3 5 
+$EndElements
+
+DEAL::Regenerated mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$Entities
+0 0 0 1
+1 -1 -1 0 1 1 1 1 1 0 
+$EndEntities
+$Nodes
+1 5 1 5
+3 1 0 5
+1
+2
+3
+4
+5
+-1 -1 0
+1 -1 0
+-1 1 0
+1 1 0
+0 0 1
+$EndNodes
+$Elements
+1 1 1 1
+3 1 7 1
+1 1 2 4 3 5 
+$EndElements
+
+DEAL::Testing kind(6) in dimensions <3,3>
+DEAL::Original mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$Entities
+0 0 0 1
+1 0 0 0 1 1 1 1 1 0 
+$EndEntities
+$Nodes
+1 6 1 6
+3 1 0 6
+1
+2
+3
+4
+5
+6
+0 0 0
+1 0 0
+0 1 0
+0 0 1
+1 0 1
+0 1 1
+$EndNodes
+$Elements
+1 1 1 1
+3 1 6 1
+1 1 2 3 4 5 6 
+$EndElements
+
+DEAL::Regenerated mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$Entities
+0 0 0 1
+1 0 0 0 1 1 1 1 1 0 
+$EndEntities
+$Nodes
+1 6 1 6
+3 1 0 6
+1
+2
+3
+4
+5
+6
+0 0 0
+1 0 0
+0 1 0
+0 0 1
+1 0 1
+0 1 1
+$EndNodes
+$Elements
+1 1 1 1
+3 1 6 1
+1 1 2 3 4 5 6 
+$EndElements
+
+DEAL::Testing kind(7) in dimensions <3,3>
+DEAL::Original mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$Entities
+0 0 0 1
+1 0 0 0 1 1 1 1 1 0 
+$EndEntities
+$Nodes
+1 8 1 8
+3 1 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+$EndNodes
+$Elements
+1 1 1 1
+3 1 5 1
+1 1 2 4 3 5 6 8 7 
+$EndElements
+
+DEAL::Regenerated mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$Entities
+0 0 0 1
+1 0 0 0 1 1 1 1 1 0 
+$EndEntities
+$Nodes
+1 8 1 8
+3 1 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+$EndNodes
+$Elements
+1 1 1 1
+3 1 5 1
+1 1 2 4 3 5 6 8 7 
+$EndElements
+

--- a/tests/gmsh/gmsh_api_05.cc
+++ b/tests/gmsh/gmsh_api_05.cc
@@ -50,8 +50,10 @@ test()
 }
 
 int
-main()
+main(int argc, char **argv)
 {
+  // gmsh might be build with mpi support enabled.
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv);
   initlog();
 
   // Generate and print all hypercubes in all dimension combinations

--- a/tests/gmsh/gmsh_api_05.with_gmsh_with_api=on.output.2
+++ b/tests/gmsh/gmsh_api_05.with_gmsh_with_api=on.output.2
@@ -1,0 +1,840 @@
+
+DEAL::Testing hypercube in dimensions <1,1>
+DEAL::Original mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+2
+0 1 "ManifoldID:1"
+0 2 "BoundaryID:1"
+$EndPhysicalNames
+$Entities
+2 1 0 0
+1 0 0 0 1 1 
+3 0 0 0 1 2 
+2 0 0 0 1 0 0 1 3 0 
+$EndEntities
+$Nodes
+3 6 1 2
+0 1 0 2
+1
+2
+0 0 0
+1 0 0
+0 3 0 2
+1
+2
+0 0 0
+1 0 0
+1 2 0 2
+1
+2
+0 0 0
+1 0 0
+$EndNodes
+$Elements
+1 1 1 1
+1 2 1 1
+1 1 2 
+$EndElements
+
+DEAL::Regenerated mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$Entities
+0 1 0 0
+1 0 0 0 1 0 0 1 1 0 
+$EndEntities
+$Nodes
+1 2 1 2
+1 1 0 2
+1
+2
+0 0 0
+1 0 0
+$EndNodes
+$Elements
+1 1 1 1
+1 1 1 1
+1 1 2 
+$EndElements
+
+DEAL::Testing hypercube in dimensions <1,2>
+DEAL::Original mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+2
+0 1 "ManifoldID:1"
+0 2 "BoundaryID:1"
+$EndPhysicalNames
+$Entities
+2 1 0 0
+1 0 0 0 1 1 
+3 0 0 0 1 2 
+2 0 0 0 1 0 0 1 3 0 
+$EndEntities
+$Nodes
+3 6 1 2
+0 1 0 2
+1
+2
+0 0 0
+1 0 0
+0 3 0 2
+1
+2
+0 0 0
+1 0 0
+1 2 0 2
+1
+2
+0 0 0
+1 0 0
+$EndNodes
+$Elements
+1 1 1 1
+1 2 1 1
+1 1 2 
+$EndElements
+
+DEAL::Regenerated mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$Entities
+0 1 0 0
+1 0 0 0 1 0 0 1 1 0 
+$EndEntities
+$Nodes
+1 2 1 2
+1 1 0 2
+1
+2
+0 0 0
+1 0 0
+$EndNodes
+$Elements
+1 1 1 1
+1 1 1 1
+1 1 2 
+$EndElements
+
+DEAL::Testing hypercube in dimensions <1,3>
+DEAL::Original mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+2
+0 1 "ManifoldID:1"
+0 2 "BoundaryID:1"
+$EndPhysicalNames
+$Entities
+2 1 0 0
+1 0 0 0 1 1 
+3 0 0 0 1 2 
+2 0 0 0 1 0 0 1 3 0 
+$EndEntities
+$Nodes
+3 6 1 2
+0 1 0 2
+1
+2
+0 0 0
+1 0 0
+0 3 0 2
+1
+2
+0 0 0
+1 0 0
+1 2 0 2
+1
+2
+0 0 0
+1 0 0
+$EndNodes
+$Elements
+1 1 1 1
+1 2 1 1
+1 1 2 
+$EndElements
+
+DEAL::Regenerated mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$Entities
+0 1 0 0
+1 0 0 0 1 0 0 1 1 0 
+$EndEntities
+$Nodes
+1 2 1 2
+1 1 0 2
+1
+2
+0 0 0
+1 0 0
+$EndNodes
+$Elements
+1 1 1 1
+1 1 1 1
+1 1 2 
+$EndElements
+
+DEAL::Testing hypercube in dimensions <2,2>
+DEAL::Original mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+4
+1 1 "ManifoldID:1"
+1 2 "BoundaryID:1"
+1 3 "BoundaryID:2"
+1 4 "BoundaryID:3"
+$EndPhysicalNames
+$Entities
+0 4 1 0
+1 0 0 0 0 1 0 1 1 0 
+3 1 0 0 1 1 0 1 2 0 
+4 0 0 0 1 0 0 1 3 0 
+5 0 1 0 1 1 0 1 4 0 
+2 0 0 0 1 1 0 1 5 0 
+$EndEntities
+$Nodes
+5 20 1 4
+1 1 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+1 3 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+1 4 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+1 5 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+2 2 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+$EndNodes
+$Elements
+5 5 1 5
+1 1 1 1
+2 1 3 
+1 3 1 1
+3 2 4 
+1 4 1 1
+4 1 2 
+1 5 1 1
+5 3 4 
+2 2 3 1
+1 1 2 4 3 
+$EndElements
+
+DEAL::Regenerated mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+4
+1 1 "ManifoldID:1"
+1 2 "BoundaryID:1"
+1 3 "BoundaryID:2"
+1 4 "BoundaryID:3"
+$EndPhysicalNames
+$Entities
+0 4 1 0
+1 0 0 0 0 1 0 1 1 0 
+3 1 0 0 1 1 0 1 2 0 
+4 0 0 0 1 0 0 1 3 0 
+5 0 1 0 1 1 0 1 4 0 
+2 0 0 0 1 1 0 1 5 0 
+$EndEntities
+$Nodes
+5 20 1 4
+1 1 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+1 3 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+1 4 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+1 5 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+2 2 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+$EndNodes
+$Elements
+5 5 1 5
+1 1 1 1
+2 1 3 
+1 3 1 1
+3 2 4 
+1 4 1 1
+4 1 2 
+1 5 1 1
+5 3 4 
+2 2 3 1
+1 1 2 4 3 
+$EndElements
+
+DEAL::Testing hypercube in dimensions <2,3>
+DEAL::Original mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+4
+1 1 "ManifoldID:1"
+1 2 "BoundaryID:1"
+1 3 "BoundaryID:2"
+1 4 "BoundaryID:3"
+$EndPhysicalNames
+$Entities
+0 4 1 0
+1 0 0 0 0 1 0 1 1 0 
+3 1 0 0 1 1 0 1 2 0 
+4 0 0 0 1 0 0 1 3 0 
+5 0 1 0 1 1 0 1 4 0 
+2 0 0 0 1 1 0 1 5 0 
+$EndEntities
+$Nodes
+5 20 1 4
+1 1 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+1 3 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+1 4 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+1 5 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+2 2 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+$EndNodes
+$Elements
+5 5 1 5
+1 1 1 1
+2 1 3 
+1 3 1 1
+3 2 4 
+1 4 1 1
+4 1 2 
+1 5 1 1
+5 3 4 
+2 2 3 1
+1 1 2 4 3 
+$EndElements
+
+DEAL::Regenerated mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+4
+1 1 "ManifoldID:1"
+1 2 "BoundaryID:1"
+1 3 "BoundaryID:2"
+1 4 "BoundaryID:3"
+$EndPhysicalNames
+$Entities
+0 4 1 0
+1 0 0 0 0 1 0 1 1 0 
+3 1 0 0 1 1 0 1 2 0 
+4 0 0 0 1 0 0 1 3 0 
+5 0 1 0 1 1 0 1 4 0 
+2 0 0 0 1 1 0 1 5 0 
+$EndEntities
+$Nodes
+5 20 1 4
+1 1 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+1 3 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+1 4 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+1 5 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+2 2 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+$EndNodes
+$Elements
+5 5 1 5
+1 1 1 1
+2 1 3 
+1 3 1 1
+3 2 4 
+1 4 1 1
+4 1 2 
+1 5 1 1
+5 3 4 
+2 2 3 1
+1 1 2 4 3 
+$EndElements
+
+DEAL::Testing hypercube in dimensions <3,3>
+DEAL::Original mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+6
+2 1 "ManifoldID:1"
+2 2 "BoundaryID:1"
+2 3 "BoundaryID:2"
+2 4 "BoundaryID:3"
+2 5 "BoundaryID:4"
+2 6 "BoundaryID:5"
+$EndPhysicalNames
+$Entities
+0 0 6 1
+1 0 0 0 0 1 1 1 1 0 
+3 1 0 0 1 1 1 1 2 0 
+4 0 0 0 1 0 1 1 3 0 
+5 0 1 0 1 1 1 1 4 0 
+6 0 0 0 1 1 0 1 5 0 
+7 0 0 1 1 1 1 1 6 0 
+2 0 0 0 1 1 1 1 7 0 
+$EndEntities
+$Nodes
+7 56 1 8
+2 1 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+2 3 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+2 4 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+2 5 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+2 6 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+2 7 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+3 2 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+$EndNodes
+$Elements
+7 7 1 7
+2 1 3 1
+2 1 3 7 5 
+2 3 3 1
+3 2 4 8 6 
+2 4 3 1
+4 1 5 6 2 
+2 5 3 1
+5 3 7 8 4 
+2 6 3 1
+6 1 2 4 3 
+2 7 3 1
+7 5 6 8 7 
+3 2 5 1
+1 1 2 4 3 5 6 8 7 
+$EndElements
+
+DEAL::Regenerated mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+6
+2 1 "ManifoldID:1"
+2 2 "BoundaryID:1"
+2 3 "BoundaryID:2"
+2 4 "BoundaryID:3"
+2 5 "BoundaryID:4"
+2 6 "BoundaryID:5"
+$EndPhysicalNames
+$Entities
+0 0 6 1
+1 0 0 0 0 1 1 1 1 0 
+3 1 0 0 1 1 1 1 2 0 
+4 0 0 0 1 0 1 1 3 0 
+5 0 1 0 1 1 1 1 4 0 
+6 0 0 0 1 1 0 1 5 0 
+7 0 0 1 1 1 1 1 6 0 
+2 0 0 0 1 1 1 1 7 0 
+$EndEntities
+$Nodes
+7 56 1 8
+2 1 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+2 3 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+2 4 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+2 5 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+2 6 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+2 7 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+3 2 0 8
+1
+2
+3
+4
+5
+6
+7
+8
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+0 0 1
+1 0 1
+0 1 1
+1 1 1
+$EndNodes
+$Elements
+7 7 1 7
+2 1 3 1
+2 1 3 7 5 
+2 3 3 1
+3 2 4 8 6 
+2 4 3 1
+4 1 5 6 2 
+2 5 3 1
+5 3 7 8 4 
+2 6 3 1
+6 1 2 4 3 
+2 7 3 1
+7 5 6 8 7 
+3 2 5 1
+1 1 2 4 3 5 6 8 7 
+$EndElements
+


### PR DESCRIPTION
 - add MPI_InitFinialize to the api tests so that the MPI context is properly initalized and finalized. Otherwise our tests fail when gmsh is compiled with MPI support.
 - add output variants for the two unstable tests.

In reference to #15383