### PR TITLE
Fix ArborX tests for Trilinos 14/Kokkos 4

### DIFF
--- a/source/base/kokkos.cc
+++ b/source/base/kokkos.cc
@@ -30,7 +30,11 @@ namespace internal
   void
   ensure_kokkos_initialized()
   {
-    if (!Kokkos::is_initialized())
+    if (!Kokkos::is_initialized()
+#if KOKKOS_VERSION >= 30700
+        && !Kokkos::is_finalized()
+#endif
+    )
       {
         // only execute once
         static bool dummy = [] {

--- a/tests/arborx/distributed_tree_intersect.cc
+++ b/tests/arborx/distributed_tree_intersect.cc
@@ -187,8 +187,6 @@ test_3d()
 int
 main(int argc, char **argv)
 {
-  // Initialize Kokkos
-  Kokkos::initialize(argc, argv);
   Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv);
 
   initlog();
@@ -196,6 +194,4 @@ main(int argc, char **argv)
   // tests
   test_2d();
   test_3d();
-
-  Kokkos::finalize();
 }

--- a/tests/arborx/distributed_tree_nearest.cc
+++ b/tests/arborx/distributed_tree_nearest.cc
@@ -323,8 +323,6 @@ test_point_3d()
 int
 main(int argc, char **argv)
 {
-  // Initialize Kokkos
-  Kokkos::initialize(argc, argv);
   Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv);
 
   initlog();
@@ -334,6 +332,4 @@ main(int argc, char **argv)
   test_bounding_box_3d();
   test_point_2d();
   test_point_3d();
-
-  Kokkos::finalize();
 }

--- a/tests/arborx/point_intersect.cc
+++ b/tests/arborx/point_intersect.cc
@@ -170,9 +170,6 @@ test_3d()
 int
 main(int argc, char **argv)
 {
-  // Initialize Kokkos
-  Kokkos::initialize(argc, argv);
-
   initlog();
 
   // Initialize ArborX
@@ -181,6 +178,4 @@ main(int argc, char **argv)
   // tests
   test_2d();
   test_3d();
-
-  Kokkos::finalize();
 }

--- a/tests/arborx/point_nearest.cc
+++ b/tests/arborx/point_nearest.cc
@@ -283,9 +283,6 @@ test_points_3d()
 int
 main(int argc, char **argv)
 {
-  // Initialize Kokkos
-  Kokkos::initialize(argc, argv);
-
   initlog();
 
   // Initialize ArborX
@@ -296,6 +293,4 @@ main(int argc, char **argv)
   test_bounding_box_3d();
   test_points_2d();
   test_points_3d();
-
-  Kokkos::finalize();
 }

--- a/tests/arborx/sphere_intersect.cc
+++ b/tests/arborx/sphere_intersect.cc
@@ -144,9 +144,6 @@ test_3d()
 int
 main(int argc, char **argv)
 {
-  // Initialize Kokkos
-  Kokkos::initialize(argc, argv);
-
   initlog();
 
   // Initialize ArborX
@@ -155,6 +152,4 @@ main(int argc, char **argv)
   // tests
   test_2d();
   test_3d();
-
-  Kokkos::finalize();
 }

--- a/tests/arborx/sphere_nearest.cc
+++ b/tests/arborx/sphere_nearest.cc
@@ -143,9 +143,6 @@ test_3d()
 int
 main(int argc, char **argv)
 {
-  // Initialize Kokkos
-  Kokkos::initialize(argc, argv);
-
   initlog();
 
   // Initialize ArborX
@@ -154,6 +151,4 @@ main(int argc, char **argv)
   // tests
   test_2d();
   test_3d();
-
-  Kokkos::finalize();
 }


### PR DESCRIPTION
`Kokkos 4` enforces that `Kokkos::initialize/finalize` is called only once. The tests here are calling `MPI_InitFinalize` which initializes `Kokkos` and they also initialize `Kokkos` explicitly. Furthermore, we shouldn't try to initialize `Kokkos` if it has already been finalized.

In reference to #15383 