### PR TITLE
Testsuite: numerics/nonlinear_solver_selector_03_petsc: add output variant

### DIFF
--- a/tests/numerics/nonlinear_solver_selector_03_petsc.with_petsc_with_hypre=true.mpirun=4.output.2
+++ b/tests/numerics/nonlinear_solver_selector_03_petsc.with_petsc_with_hypre=true.mpirun=4.output.2
@@ -1,0 +1,254 @@
+
+DEAL::Running with PETSc on 4 MPI rank(s)...
+DEAL::  Target_tolerance: 0.00100000
+DEAL::
+DEAL::  Computing residual vector... norm=0.170956
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 2.33051
+DEAL::Convergence step 9 value 3.48236e-13
+DEAL::   Solved in 9 iterations.
+DEAL::  Computing residual vector... norm=0.170956
+DEAL::  Computing residual vector... norm=0.129347
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 1.66678
+DEAL::Convergence step 9 value 2.53743e-13
+DEAL::   Solved in 9 iterations.
+DEAL::  Computing residual vector... norm=0.129347
+DEAL::  Computing residual vector... norm=0.100710
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 1.37207
+DEAL::Convergence step 9 value 1.25880e-13
+DEAL::   Solved in 9 iterations.
+DEAL::  Computing residual vector... norm=0.100710
+DEAL::  Computing residual vector... norm=0.0776513
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.798421
+DEAL::Convergence step 9 value 2.26161e-13
+DEAL::   Solved in 9 iterations.
+DEAL::  Computing residual vector... norm=0.0776513
+DEAL::  Computing residual vector... norm=0.0593571
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.407505
+DEAL::Convergence step 9 value 8.68573e-14
+DEAL::   Solved in 9 iterations.
+DEAL::  Computing residual vector... norm=0.0593571
+DEAL::  Computing residual vector... norm=0.0459878
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.289329
+DEAL::Convergence step 9 value 1.45258e-13
+DEAL::   Solved in 9 iterations.
+DEAL::  Computing residual vector... norm=0.0459878
+DEAL::  Computing residual vector... norm=0.0355434
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.222775
+DEAL::Convergence step 9 value 8.91405e-14
+DEAL::   Solved in 9 iterations.
+DEAL::  Computing residual vector... norm=0.0355434
+DEAL::  Computing residual vector... norm=0.0274503
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.171125
+DEAL::Convergence step 9 value 6.58309e-14
+DEAL::   Solved in 9 iterations.
+DEAL::  Computing residual vector... norm=0.0274503
+DEAL::  Computing residual vector... norm=0.0212126
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.134637
+DEAL::Convergence step 9 value 5.16078e-14
+DEAL::   Solved in 9 iterations.
+DEAL::  Computing residual vector... norm=0.0212126
+DEAL::  Computing residual vector... norm=0.0164293
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.106529
+DEAL::Convergence step 8 value 7.02723e-13
+DEAL::   Solved in 8 iterations.
+DEAL::  Computing residual vector... norm=0.0164293
+DEAL::  Computing residual vector... norm=0.0127897
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.0845243
+DEAL::Convergence step 9 value 2.33609e-14
+DEAL::   Solved in 9 iterations.
+DEAL::  Computing residual vector... norm=0.0127897
+DEAL::  Computing residual vector... norm=0.0100451
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.0671268
+DEAL::Convergence step 8 value 7.25230e-13
+DEAL::   Solved in 8 iterations.
+DEAL::  Computing residual vector... norm=0.0100451
+DEAL::  Computing residual vector... norm=0.00798892
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.0530793
+DEAL::Convergence step 8 value 7.87468e-13
+DEAL::   Solved in 8 iterations.
+DEAL::  Computing residual vector... norm=0.00798892
+DEAL::  Computing residual vector... norm=0.00645103
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.0417948
+DEAL::Convergence step 8 value 2.50171e-13
+DEAL::   Solved in 8 iterations.
+DEAL::  Computing residual vector... norm=0.00645103
+DEAL::  Computing residual vector... norm=0.00529638
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.0326875
+DEAL::Convergence step 8 value 1.68196e-13
+DEAL::   Solved in 8 iterations.
+DEAL::  Computing residual vector... norm=0.00529638
+DEAL::  Computing residual vector... norm=0.00442194
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.0254398
+DEAL::Convergence step 8 value 3.43461e-13
+DEAL::   Solved in 8 iterations.
+DEAL::  Computing residual vector... norm=0.00442194
+DEAL::  Computing residual vector... norm=0.00375154
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.0197539
+DEAL::Convergence step 8 value 1.48344e-13
+DEAL::   Solved in 8 iterations.
+DEAL::  Computing residual vector... norm=0.00375154
+DEAL::  Computing residual vector... norm=0.00323013
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.0154032
+DEAL::Convergence step 8 value 6.64478e-14
+DEAL::   Solved in 8 iterations.
+DEAL::  Computing residual vector... norm=0.00323013
+DEAL::  Computing residual vector... norm=0.00281833
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.0119981
+DEAL::Convergence step 8 value 3.68260e-14
+DEAL::   Solved in 8 iterations.
+DEAL::  Computing residual vector... norm=0.00281834
+DEAL::  Computing residual vector... norm=0.00248811
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.00940082
+DEAL::Convergence step 7 value 8.24025e-13
+DEAL::   Solved in 7 iterations.
+DEAL::  Computing residual vector... norm=0.00248811
+DEAL::  Computing residual vector... norm=0.00221939
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.00741120
+DEAL::Convergence step 7 value 5.90592e-13
+DEAL::   Solved in 7 iterations.
+DEAL::  Computing residual vector... norm=0.00221939
+DEAL::  Computing residual vector... norm=0.00199769
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.00589627
+DEAL::Convergence step 8 value 3.44070e-14
+DEAL::   Solved in 8 iterations.
+DEAL::  Computing residual vector... norm=0.00199769
+DEAL::  Computing residual vector... norm=0.00181244
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.00472736
+DEAL::Convergence step 7 value 8.54830e-13
+DEAL::   Solved in 7 iterations.
+DEAL::  Computing residual vector... norm=0.00181244
+DEAL::  Computing residual vector... norm=0.00165582
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.00382847
+DEAL::Convergence step 7 value 5.57802e-13
+DEAL::   Solved in 7 iterations.
+DEAL::  Computing residual vector... norm=0.00165583
+DEAL::  Computing residual vector... norm=0.00152199
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.00313128
+DEAL::Convergence step 7 value 3.37352e-13
+DEAL::   Solved in 7 iterations.
+DEAL::  Computing residual vector... norm=0.00152199
+DEAL::  Computing residual vector... norm=0.00140649
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.00258601
+DEAL::Convergence step 7 value 2.12098e-13
+DEAL::   Solved in 7 iterations.
+DEAL::  Computing residual vector... norm=0.00140649
+DEAL::  Computing residual vector... norm=0.00130588
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.00215550
+DEAL::Convergence step 7 value 1.91339e-13
+DEAL::   Solved in 7 iterations.
+DEAL::  Computing residual vector... norm=0.00130589
+DEAL::  Computing residual vector... norm=0.00121752
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.00180719
+DEAL::Convergence step 7 value 2.22479e-13
+DEAL::   Solved in 7 iterations.
+DEAL::  Computing residual vector... norm=0.00121752
+DEAL::  Computing residual vector... norm=0.00113928
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.00153777
+DEAL::Convergence step 7 value 2.37318e-13
+DEAL::   Solved in 7 iterations.
+DEAL::  Computing residual vector... norm=0.00113929
+DEAL::  Computing residual vector... norm=0.00106952
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.00131231
+DEAL::Convergence step 7 value 2.07345e-13
+DEAL::   Solved in 7 iterations.
+DEAL::  Computing residual vector... norm=0.00106952
+DEAL::  Computing residual vector... norm=0.00100687
+DEAL::  Computing Jacobian matrix
+DEAL::  Factorizing Jacobian matrix
+DEAL::  Solving linear system
+DEAL::Starting value 0.00112683
+DEAL::Convergence step 7 value 1.83758e-13
+DEAL::   Solved in 7 iterations.
+DEAL::  Computing residual vector... norm=0.00100688
+DEAL::  Computing residual vector... norm=0.000950282
+DEAL::


### PR DESCRIPTION
I see a stable, but different, output for this test on three different machines. Let us thus add an output variant for now.

Note that a proper fix would be to not print initial and final residuals in these tests. Even though the numbers seem to be pretty stable.

I have opened an issue for a proper fix, #15395

In reference to #15383