### PR TITLE
Optimize IndexSet::add_indices() for the case of duplicate indices.

### DIFF
--- a/doc/news/changes/minor/20230620Bangerth
+++ b/doc/news/changes/minor/20230620Bangerth
@@ -1,0 +1,5 @@
+Fixed: The function IndexSet::add_indices() was not efficient when
+adding sets of indices that are sorted but contain duplicates. This is
+now fixed.
+<br>
+(Wolfgang Bangerth, 2023/06/20)

--- a/tests/base/index_set_32.cc
+++ b/tests/base/index_set_32.cc
@@ -1,0 +1,50 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2009 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// Test how IndexSet::add_indices deals with duplicate indices to be added
+
+#include <deal.II/base/index_set.h>
+
+#include "../tests.h"
+
+
+void
+test()
+{
+  IndexSet index_set(10);
+
+  {
+    const unsigned int array[] = {2, 2, 2, 3, 4, 6, 8, 8};
+    index_set.add_indices((const unsigned int *)array,
+                          array + sizeof(array) / sizeof(array[0]));
+  }
+
+  Assert(index_set.is_contiguous() == false, ExcInternalError());
+
+  for (unsigned int i = 0; i < index_set.size(); ++i)
+    deallog << i << ' ' << (index_set.is_element(i) ? "true" : "false")
+            << std::endl;
+}
+
+
+
+int
+main()
+{
+  initlog();
+
+  test();
+}

--- a/tests/base/index_set_32.output
+++ b/tests/base/index_set_32.output
@@ -1,0 +1,11 @@
+
+DEAL::0 false
+DEAL::1 false
+DEAL::2 true
+DEAL::3 true
+DEAL::4 true
+DEAL::5 false
+DEAL::6 true
+DEAL::7 false
+DEAL::8 true
+DEAL::9 false


### PR DESCRIPTION
I decided to fix at least part of #15400 right away. The function `IndexSet::add_indices()` deals poorly if the list of indices has duplicates, such as in `{2, 2, 2, 3, 4, 6, 8, 8}`. The resulting index set is correct, but the function adds the following ranges:
```
DEAL::Adding the following ranges:
DEAL::   2...3
DEAL::   2...3
DEAL::   2...5
DEAL::   6...7
DEAL::   8...9
DEAL::   8...9
```
This is certainly not efficient. This patch fixes this. With it, the ranges added are as follows:
```
DEAL::Adding the following ranges:
DEAL::   2...5
DEAL::   6...7
DEAL::   8...9
```
That's much better.