### PR TITLE
Minor adjustment to step-77.

### DIFF
--- a/examples/step-77/step-77.cc
+++ b/examples/step-77/step-77.cc
@@ -614,7 +614,7 @@ namespace Step77
           nonlinear_solver.solve_with_jacobian = [&](const Vector<double> &rhs,
                                                      Vector<double> &      dst,
                                                      const double tolerance) {
-            this->solve(rhs, dst, tolerance);
+            solve(rhs, dst, tolerance);
           };
 
           nonlinear_solver.solve(current_solution);


### PR DESCRIPTION
Around the place where I'm making this one-line adjustment, we set up a number of lambda functions as callbacks for the nonlinear solver. In three of these functions, we call members of the current class, but in only one of these places do we prefix the call with `this->`. This patch just makes things uniform by removing the `this->` from the one oddball place. 