### PR TITLE
Testsuite: symengine/symengine_tensor_operations_04: fix test compilation

### DIFF
--- a/tests/symengine/symengine_tensor_operations_04.cc
+++ b/tests/symengine/symengine_tensor_operations_04.cc
@@ -104,12 +104,10 @@ test_tensor()
   using Tensor_t           = Tensor<rank, dim, double>;
 
   Tensor_t t_a, t_b;
-  for (unsigned int i = 0; i < Tensor_t::n_independent_components; ++i)
-    {
-      const auto index = t_a.unrolled_to_component_index(i);
-      t_a[index]       = 1.0;
-      t_b[index]       = 2.0;
-    }
+  for (auto it = t_a.begin_raw(); it != t_a.end_raw(); ++it)
+    *it = 1.0;
+  for (auto it = t_b.begin_raw(); it != t_b.end_raw(); ++it)
+    *it = 2.0;
 
   const Tensor_SD_number_t symb_t_a =
     SD::make_tensor_of_symbols<rank, dim>("a");
@@ -130,13 +128,10 @@ test_symmetric_tensor()
   using Tensor_t           = SymmetricTensor<rank, dim, double>;
 
   Tensor_t t_a, t_b;
-  for (unsigned int i = 0; i < Tensor_t::n_independent_components; ++i)
-    {
-      const auto index = t_a.unrolled_to_component_index(i);
-      t_a[index]       = 1.0;
-      t_b[index]       = 2.0;
-    }
-
+  for (auto it = t_a.begin_raw(); it != t_a.end_raw(); ++it)
+    *it = 1.0;
+  for (auto it = t_b.begin_raw(); it != t_b.end_raw(); ++it)
+    *it = 2.0;
 
   const Tensor_SD_number_t symb_t_a =
     SD::make_symmetric_tensor_of_symbols<rank, dim>("a");


### PR DESCRIPTION
This partially reverts 7ad068984b29f5712dd2bed5742459a9e2030ac3

This part has been commited and merged accidentally (partly due to our CI not testing any symengine artifacts). Unfortunately, the anticipated replacement of `begin_raw()` by `unrolled_to_component_indices(i)` does not work as intended. It is neither implemented for Tensor of rank 0, nor for SymmetricTensor of rank 4.

In reference to #15383 and #15406