### PR TITLE
Standardize on the idiom of calling std::erase after std::unique.

### DIFF
--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -1326,9 +1326,7 @@ AffineConstraints<number>::resolve_indices(
 
   // keep only the unique elements
   std::sort(indices.begin(), indices.end());
-  std::vector<types::global_dof_index>::iterator it;
-  it = std::unique(indices.begin(), indices.end());
-  indices.resize(it - indices.begin());
+  indices.erase(std::unique(indices.begin(), indices.end()), indices.end());
 }
 
 

--- a/source/base/parsed_convergence_table.cc
+++ b/source/base/parsed_convergence_table.cc
@@ -26,8 +26,8 @@ namespace
   get_unique_component_names(const std::vector<std::string> &component_names)
   {
     auto elements = component_names;
-    auto last     = std::unique(elements.begin(), elements.end());
-    elements.resize(last - elements.begin());
+    elements.erase(std::unique(elements.begin(), elements.end()),
+                   elements.end());
     return elements;
   }
 

--- a/source/lac/sparsity_tools.cc
+++ b/source/lac/sparsity_tools.cc
@@ -641,10 +641,9 @@ namespace SparsityTools
         std::sort(next_round_dofs.begin(), next_round_dofs.end());
 
         // delete multiple entries
-        std::vector<DynamicSparsityPattern::size_type>::iterator end_sorted;
-        end_sorted =
-          std::unique(next_round_dofs.begin(), next_round_dofs.end());
-        next_round_dofs.erase(end_sorted, next_round_dofs.end());
+        next_round_dofs.erase(std::unique(next_round_dofs.begin(),
+                                          next_round_dofs.end()),
+                              next_round_dofs.end());
 
         // eliminate dofs which are already numbered
         for (int s = next_round_dofs.size() - 1; s >= 0; --s)


### PR DESCRIPTION
This idiom is used in many other places. This patch changes a number of locations where we do the same thing but instead use a different idiom, using a temporary iterator and/or using resize() instead of erase().