### PR TITLE
Fix a few more 'set up'

### DIFF
--- a/examples/step-15/step-15.cc
+++ b/examples/step-15/step-15.cc
@@ -164,7 +164,7 @@ namespace Step15
 
   // @sect4{MinimalSurfaceProblem::setup_system}
 
-  // As always in the setup-system function, we setup the variables of the
+  // As always in the setup-system function, we set up the variables of the
   // finite element method. There are same differences to step-6, because
   // there we start solving the PDE from scratch in every refinement cycle
   // whereas here we need to take the solution from the previous mesh onto the

--- a/examples/step-29/step-29.cc
+++ b/examples/step-29/step-29.cc
@@ -398,7 +398,7 @@ namespace Step29
 
   // @sect4{<code>UltrasoundProblem::make_grid</code>}
 
-  // Here we setup the grid for our domain.  As mentioned in the exposition,
+  // Here we set up the grid for our domain.  As mentioned in the exposition,
   // the geometry is just a unit square (in 2d) with the part of the boundary
   // that represents the transducer lens replaced by a sector of a circle.
   template <int dim>

--- a/examples/step-44/step-44.cc
+++ b/examples/step-44/step-44.cc
@@ -1037,7 +1037,7 @@ namespace Step44
     // The Finite Element System is composed of dim continuous displacement
     // DOFs, and discontinuous pressure and dilatation DOFs. In an attempt to
     // satisfy the Babuska-Brezzi or LBB stability conditions (see Hughes
-    // (2000)), we setup a $Q_n \times DGP_{n-1} \times DGP_{n-1}$
+    // (2000)), we set up a $Q_n \times DGP_{n-1} \times DGP_{n-1}$
     // system. $Q_2 \times DGP_1 \times DGP_1$ elements satisfy this
     // condition, while $Q_1 \times DGP_0 \times DGP_0$ elements do
     // not. However, it has been shown that the latter demonstrate good
@@ -1237,7 +1237,7 @@ namespace Step44
   // matrix. Recall that we wish to solve for a displacement-based formulation.
   // We do the condensation at the element level as the $\widetilde{p}$ and
   // $\widetilde{J}$ fields are element-wise discontinuous.  As these operations
-  // are matrix-based, we need to setup a number of matrices to store the local
+  // are matrix-based, we need to set up a number of matrices to store the local
   // contributions from a number of the tangent matrix sub-blocks.  We place
   // these in the PerTaskData struct.
   //
@@ -1551,7 +1551,7 @@ namespace Step44
                                         triangulation.end(),
                                         n_q_points);
 
-    // Next we setup the initial quadrature point data.
+    // Next we set up the initial quadrature point data.
     // Note that when the quadrature point data is retrieved,
     // it is returned as a vector of smart pointers.
     for (const auto &cell : triangulation.active_cell_iterators())

--- a/examples/step-46/step-46.cc
+++ b/examples/step-46/step-46.cc
@@ -320,7 +320,7 @@ namespace Step46
 
   // @sect4{<code>FluidStructureProblem::setup_dofs</code>}
 
-  // The next step is to setup the data structures for the linear system. To
+  // The next step is to set up the data structures for the linear system. To
   // this end, we first have to set the active FE indices with the function
   // immediately above, then distribute degrees of freedom, and then determine
   // constraints on the linear system. The latter includes hanging node

--- a/examples/step-50/step-50.cc
+++ b/examples/step-50/step-50.cc
@@ -1461,7 +1461,7 @@ void LaplaceProblem<dim, degree>::output_results(const unsigned int cycle)
 // @sect4{LaplaceProblem::run()}
 
 // As in most tutorials, this function calls the various functions defined
-// above to setup, assemble, solve, and output the results.
+// above to set up, assemble, solve, and output the results.
 template <int dim, int degree>
 void LaplaceProblem<dim, degree>::run()
 {

--- a/examples/step-60/step-60.cc
+++ b/examples/step-60/step-60.cc
@@ -639,8 +639,8 @@ namespace Step60
       std::make_unique<GridTools::Cache<spacedim, spacedim>>(*space_grid);
 
     // The same is done with the embedded grid. Since the embedded grid is
-    // deformed, we first need to setup the deformation mapping. We do so in the
-    // following few lines:
+    // deformed, we first need to set up the deformation mapping. We do so in
+    // the following few lines:
     embedded_grid = std::make_unique<Triangulation<dim, spacedim>>();
     GridGenerator::hyper_cube(*embedded_grid);
     embedded_grid->refine_global(parameters.initial_embedded_refinement);

--- a/examples/step-76/step-76.cc
+++ b/examples/step-76/step-76.cc
@@ -548,7 +548,7 @@ namespace Euler_DG
   }
 
 
-  // Modified reinit() function to setup the internal data structures in
+  // Modified reinit() function to set up the internal data structures in
   // MatrixFree in a way that it is usable by the cell-centric loops and
   // the MPI-3.0 shared-memory capabilities are used:
   template <int dim, int degree, int n_points_1d>

--- a/include/deal.II/base/mpi_remote_point_evaluation.h
+++ b/include/deal.II/base/mpi_remote_point_evaluation.h
@@ -100,7 +100,7 @@ namespace Utilities
        * GridTools::internal::DistributedComputePointLocationsInternal.
        *
        * This function is called internally by the reinit() function above.
-       * Having it as a separate function makes it possible to setup the class
+       * Having it as a separate function makes it possible to set up the class
        * if it is known in which cells corresponding reference points are
        * located (e.g. if intersections of cells are known).
        */

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -1299,7 +1299,7 @@ namespace GridTools
      * the fields needed by
      * GridTools::internal::distributed_compute_point_locations() are filled.
      * If the input argument is set to true additional data structures are
-     * set up to be able to setup the communication pattern within
+     * set up to be able to set up the communication pattern within
      * Utilities::MPI::RemotePointEvaluation::reinit().
      */
     template <int dim, int spacedim>
@@ -1370,7 +1370,7 @@ namespace GridTools
        * The parameter @p consistent_numbering_of_sender_and_receiver can be used to ensure
        * points on sender and receiver side are numbered consistently.
        * This parameter is optional if DistributedComputePointLocationsInternal
-       * is used to setup RemotePointEvaluation, but might be helpful for
+       * is used to set up RemotePointEvaluation, but might be helpful for
        * debugging or other usage of DistributedComputePointLocationsInternal.
        * Note that setting this parameter true requires an additional
        * communication step during the setup phase.

--- a/include/deal.II/grid/tria_description.h
+++ b/include/deal.II/grid/tria_description.h
@@ -522,7 +522,7 @@ namespace TriangulationDescription
      * @return Description to be used to set up a Triangulation.
      *
      * @note If construct_multigrid_hierarchy is set in the settings, the source
-     *   triangulation has to be setup with limit_level_difference_at_vertices.
+     *   triangulation has to be set up with limit_level_difference_at_vertices.
      */
     template <int dim, int spacedim = dim>
     Description<dim, spacedim>

--- a/include/deal.II/lac/petsc_block_sparse_matrix.h
+++ b/include/deal.II/lac/petsc_block_sparse_matrix.h
@@ -338,7 +338,7 @@ namespace PETScWrappers
       Mat petsc_nest_matrix;
 
       /**
-       * Utility to setup the MATNEST object
+       * Utility to set up the MATNEST object.
        */
       void
       setup_nest_mat();

--- a/include/deal.II/lac/petsc_ts.templates.h
+++ b/include/deal.II/lac/petsc_ts.templates.h
@@ -751,7 +751,7 @@ namespace PETScWrappers
                                    ts_ijacobian_with_setup,
                                    this));
 
-        // Tell PETSc to setup a MFFD operator for the linear system matrix
+        // Tell PETSc to set up a MFFD operator for the linear system matrix
         if (!A)
           set_use_matrix_free(ts, true, false);
 

--- a/source/distributed/fully_distributed_tria.cc
+++ b/source/distributed/fully_distributed_tria.cc
@@ -229,7 +229,7 @@ namespace parallel
           "You have called the method parallel::fullydistributed::Triangulation::create_triangulation() \n"
           "that takes 3 arguments. If you have not called this function directly, \n"
           "it might have been called via a function from the GridGenerator or GridIn \n"
-          "namespace. To be able to setup a fully-distributed Triangulation with these \n"
+          "namespace. To be able to set up a fully-distributed Triangulation with these \n"
           "utility functions nevertheless, please follow the following three steps:\n"
           "  1) call the utility function for a (serial) Triangulation, \n"
           "     a parallel::shared::Triangulation, or a parallel::distributed::Triangulation object,\n"


### PR DESCRIPTION
It turned out that I missed several "set up" in #15412. It is hard to automatically find the right spots, because we often use it as a noun, which gives many false positive when grepping for it. I now grepped for "to setup" and "we setup" in `include/`, `source/` and `examples/` and switched those places that use it as a verb. Certainly not perfect, but I think we now have a decent state.