### PR TITLE
CMake: avoid adding ${DEAL_II_BUNDLED_INCLUDE_DIRS} to bundled targets

### DIFF
--- a/bundled/boost-1.70.0/libs/iostreams/src/CMakeLists.txt
+++ b/bundled/boost-1.70.0/libs/iostreams/src/CMakeLists.txt
@@ -23,6 +23,8 @@ set(src_boost_iostreams
 enable_if_supported(DEAL_II_WARNING_FLAGS -Wno-c11-extensions)
 enable_if_supported(DEAL_II_WARNING_FLAGS -Wno-deprecated-copy)
 enable_if_supported(DEAL_II_WARNING_FLAGS -Wno-uninitialized)
+enable_if_supported(DEAL_II_WARNING_FLAGS -Wno-deprecated-builtins)
+enable_if_supported(DEAL_II_WARNING_FLAGS -Wno-deprecated-declarations)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../include)
 define_object_library(bundled_boost_iostreams OBJECT ${src_boost_iostreams})

--- a/bundled/boost-1.70.0/libs/iostreams/src/CMakeLists.txt
+++ b/bundled/boost-1.70.0/libs/iostreams/src/CMakeLists.txt
@@ -24,4 +24,5 @@ enable_if_supported(DEAL_II_WARNING_FLAGS -Wno-c11-extensions)
 enable_if_supported(DEAL_II_WARNING_FLAGS -Wno-deprecated-copy)
 enable_if_supported(DEAL_II_WARNING_FLAGS -Wno-uninitialized)
 
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../include)
 define_object_library(bundled_boost_iostreams OBJECT ${src_boost_iostreams})

--- a/bundled/boost-1.70.0/libs/serialization/src/CMakeLists.txt
+++ b/bundled/boost-1.70.0/libs/serialization/src/CMakeLists.txt
@@ -57,6 +57,8 @@ set(src_boost_serialization
 enable_if_supported(DEAL_II_WARNING_FLAGS -Wno-c11-extensions)
 enable_if_supported(DEAL_II_WARNING_FLAGS -Wno-deprecated-copy)
 enable_if_supported(DEAL_II_WARNING_FLAGS -Wno-uninitialized)
+enable_if_supported(DEAL_II_WARNING_FLAGS -Wno-deprecated-builtins)
+enable_if_supported(DEAL_II_WARNING_FLAGS -Wno-deprecated-declarations)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../include)
 define_object_library(bundled_boost_serialization OBJECT ${src_boost_serialization})

--- a/bundled/boost-1.70.0/libs/serialization/src/CMakeLists.txt
+++ b/bundled/boost-1.70.0/libs/serialization/src/CMakeLists.txt
@@ -58,4 +58,5 @@ enable_if_supported(DEAL_II_WARNING_FLAGS -Wno-c11-extensions)
 enable_if_supported(DEAL_II_WARNING_FLAGS -Wno-deprecated-copy)
 enable_if_supported(DEAL_II_WARNING_FLAGS -Wno-uninitialized)
 
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../include)
 define_object_library(bundled_boost_serialization OBJECT ${src_boost_serialization})

--- a/bundled/boost-1.70.0/libs/system/src/CMakeLists.txt
+++ b/bundled/boost-1.70.0/libs/system/src/CMakeLists.txt
@@ -18,5 +18,6 @@ set(src_boost_system
   error_code.cpp
   )
 
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../include)
 define_object_library(bundled_boost_system OBJECT ${src_boost_system})
 

--- a/bundled/kokkos-3.7.00/CMakeLists.txt
+++ b/bundled/kokkos-3.7.00/CMakeLists.txt
@@ -69,4 +69,12 @@ enable_if_supported(DEAL_II_WARNING_FLAGS -Wno-missing-field-initializers)
 enable_if_supported(DEAL_II_WARNING_FLAGS -Wno-suggest-override)
 enable_if_supported(DEAL_II_WARNING_FLAGS -Wno-unused-but-set-parameter)
 
+include_directories(
+  ${CMAKE_CURRENT_SOURCE_DIR}/algorithms/src
+  ${CMAKE_CURRENT_SOURCE_DIR}/containers/src
+  ${CMAKE_CURRENT_SOURCE_DIR}/core/src
+  ${CMAKE_CURRENT_SOURCE_DIR}/simd/src
+  ${CMAKE_CURRENT_SOURCE_DIR}/tpls/desul/include
+  )
+
 define_object_library(bundled_kokkos OBJECT ${src_kokkos})

--- a/bundled/muparser_v2_3_3/CMakeLists.txt
+++ b/bundled/muparser_v2_3_3/CMakeLists.txt
@@ -24,9 +24,7 @@ enable_if_supported(DEAL_II_WARNING_FLAGS -Wno-implicit-fallthrough)
 enable_if_supported(DEAL_II_WARNING_FLAGS -Wno-cast-function-type)
 enable_if_supported(DEAL_II_WARNING_FLAGS -Wno-float-conversion)
 
-include_directories(
-  include/
-)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include/)
 
 define_object_library(bundled_muparser OBJECT
   src/muParserBase.cpp

--- a/bundled/tbb-2018_U2/src/CMakeLists.txt
+++ b/bundled/tbb-2018_U2/src/CMakeLists.txt
@@ -45,6 +45,7 @@ enable_if_supported(DEAL_II_WARNING_FLAGS "-Wno-tautological-overlap-compare")
 
 set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
 include_directories(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../include/
   ${CMAKE_CURRENT_SOURCE_DIR}/rml/include
   )
 

--- a/bundled/umfpack/AMD/Source/CMakeLists.txt
+++ b/bundled/umfpack/AMD/Source/CMakeLists.txt
@@ -30,6 +30,7 @@ set(src_amd
   amd_valid.cc
   )
 
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../Include)
 define_object_library(bundled_amd_int OBJECT ${src_amd})
 deal_ii_add_definitions(bundled_amd_int "DINT")
 

--- a/bundled/umfpack/UMFPACK/Source/CMakeLists.txt
+++ b/bundled/umfpack/UMFPACK/Source/CMakeLists.txt
@@ -348,6 +348,10 @@ set(src_umfpack_GENERIC
   umfpack_timer.cc
   )
 
+include_directories(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../Include
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../AMD/Include
+  )
 
 #-------------------------------------------------------------------------------
 # Compile each of the following files as long int routines; UMFPACK also allows

--- a/cmake/macros/macro_populate_target_properties.cmake
+++ b/cmake/macros/macro_populate_target_properties.cmake
@@ -62,9 +62,17 @@ function(populate_target_properties _target _build)
     ${CMAKE_BINARY_DIR}/include
     ${CMAKE_SOURCE_DIR}/include
     )
-  target_include_directories(${_target} SYSTEM PRIVATE
-    ${DEAL_II_BUNDLED_INCLUDE_DIRS}
-    )
+
+  #
+  # Do not add bundled include directories to bundled_ targets. First of
+  # all this is unnecessary, secondly, this severly trips up ICC-19 that
+  # cannot handle the additional -isystem include properly...
+  #
+  if(NOT "${_target}" MATCHES "^bundled_")
+    target_include_directories(${_target} SYSTEM PRIVATE
+      ${DEAL_II_BUNDLED_INCLUDE_DIRS}
+      )
+  endif()
 
   # Interface includes:
 


### PR DESCRIPTION
These includes should only be added as system include directories to dependent targets and not to the bundled targets themselves.

While this commit looks purely cosmetic, this commit actually works around an obscure compiler bug with ICC 19 that otherwises errors out when trying to compile our bundled tbb library.

In reference to #15383
Closes #15382