### PR TITLE
CGAL: fix some bogus warnings with gcc-13

### DIFF
--- a/include/deal.II/cgal/utilities.h
+++ b/include/deal.II/cgal/utilities.h
@@ -37,7 +37,11 @@
 #  include <CGAL/Mesh_complex_3_in_triangulation_3.h>
 #  include <CGAL/Mesh_criteria_3.h>
 #  include <CGAL/Mesh_triangulation_3.h>
+// Disable a warnung that we get with gcc-13 about a potential unitialized
+// usage of an <anonymous> lambda function in this external CGAL header.
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <CGAL/Polygon_mesh_processing/corefinement.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #  include <CGAL/Polygon_mesh_processing/measure.h>
 #  include <CGAL/Polygon_mesh_processing/remesh.h>
 #  include <CGAL/Polygon_mesh_processing/triangulate_faces.h>

--- a/source/cgal/CMakeLists.txt
+++ b/source/cgal/CMakeLists.txt
@@ -13,6 +13,18 @@
 ##
 ## ---------------------------------------------------------------------
 
+#
+# We have to compile the "intersections.cc" file without the misleading
+# indentation warning enabled. Otherwise, we run into quite a number of
+# warnings with gcc, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89549
+#
+if(DEAL_II_WITH_CGAL)
+  enable_if_supported(_flag "-Wno-misleading-indentation")
+  set_property(SOURCE "intersections.cc"
+    APPEND PROPERTY COMPILE_OPTIONS "${_flag}"
+    )
+endif()
+
 set(_src
   surface_mesh.cc
   intersections.cc

--- a/source/grid/CMakeLists.txt
+++ b/source/grid/CMakeLists.txt
@@ -21,11 +21,12 @@
 # due to a longstanding bug in gcc. Thus, simply set
 # -Wno-misleading-indentation on the command line for the
 # grid_generator_cgal.cc compilation unit.
+# See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89549
 #
 if(DEAL_II_WITH_CGAL)
   enable_if_supported(_flag "-Wno-misleading-indentation")
-  set_property(SOURCE "grid_generator_cgal.cc"
-    APPEND_STRING PROPERTY COMPILE_FLAGS " ${_flag}"
+  set_property(SOURCE "grid_generator_cgal.cc" "grid_tools.cc"
+    APPEND PROPERTY COMPILE_OPTIONS "${_flag}"
     )
 endif()
 


### PR DESCRIPTION
Our old acquaintance, the -Wmisleading-indentation disabled warning [1], made a return and needs some more fixing.

In addition we have to guard on CGAL header inclusion for gcc-13 with our DEAL_II_DISABLE_EXTRA_DIAGNOSTICS macro (the fact that it is an `-isystem` include apparently is not sufficient.)

In reference to #15383