### PR TITLE
Fix bug in AffineConstraints::make_sorted_row_list

### DIFF
--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -3844,7 +3844,11 @@ AffineConstraints<number>::make_sorted_row_list(
       for (size_type q = 0; q < position.entries.size(); ++q)
         {
           const size_type new_index = position.entries[q].first;
-          if (active_dofs[active_dofs.size() - i] < new_index)
+          // in case all dofs are constrained, we might insert at
+          // active_dofs.begin(), but we should never insert before that
+          AssertIndexRange(i - 1, active_dofs.size() + 1);
+          if (i > active_dofs.size() ||
+              active_dofs[active_dofs.size() - i] < new_index)
             active_dofs.insert(active_dofs.end() - i + 1, new_index);
 
           // make binary search to find where to put the new index in order to


### PR DESCRIPTION
In `make_sorted_row_list` for the case of `add_entries_local_to_global`, we would read `active_dofs[active_dofs.size() - i]` out-of-range if all dofs on a cell were constrained and some of the dofs was actually resolved into a non-trivial list of other dofs. (We did test all dofs constrained before, but we only had Dirichlet conditions.) Interesting that we never triggered this before - I also added an assertion now.

Fixes #15427.