### PR TITLE
Warn about the use of higher order output when using Visit.

### DIFF
--- a/examples/step-11/step-11.cc
+++ b/examples/step-11/step-11.cc
@@ -409,6 +409,13 @@ namespace Step11
   // class only prints curved faces for <i>boundary</i> cells by default, so we
   // need to ensure that also inner cells are printed in a curved representation
   // via the mapping.
+  //
+  // @note As of 2023, Visit 3.3.3 can still not deal with higher-order cells.
+  //   Rather, it simply reports that there is no data to show. To view the
+  //   results of this program with Visit, you will want to comment out the
+  //   line that sets `flags.write_higher_order_cells = true;`. On the other
+  //   hand, Paraview is able to understand VTU files with higher order cells
+  //   just fine.
   template <int dim>
   void LaplaceProblem<dim>::write_high_order_mesh(const unsigned cycle)
   {

--- a/examples/step-44/step-44.cc
+++ b/examples/step-44/step-44.cc
@@ -3179,6 +3179,13 @@ namespace Step44
   // Here we present how the results are written to file to be viewed
   // using ParaView or VisIt. The method is similar to that shown in previous
   // tutorials so will not be discussed in detail.
+  //
+  // @note As of 2023, Visit 3.3.3 can still not deal with higher-order cells.
+  //   Rather, it simply reports that there is no data to show. To view the
+  //   results of this program with Visit, you will want to comment out the
+  //   line that sets `output_flags.write_higher_order_cells = true;`. On the
+  //   other hand, Paraview is able to understand VTU files with higher order
+  //   cells just fine.
   template <int dim>
   void Solid<dim>::output_results() const
   {

--- a/examples/step-65/step-65.cc
+++ b/examples/step-65/step-65.cc
@@ -476,6 +476,13 @@ namespace Step65
   // curved faces for <i>boundary</i> cells by default, so we need to ensure
   // that also inner cells are printed in a curved representation via the
   // mapping.
+  //
+  // @note As of 2023, Visit 3.3.3 can still not deal with higher-order cells.
+  //   Rather, it simply reports that there is no data to show. To view the
+  //   results of this program with Visit, you will want to comment out the
+  //   line that sets `flags.write_higher_order_cells = true;`. On the other
+  //   hand, Paraview is able to understand VTU files with higher order cells
+  //   just fine.
   template <int dim>
   void PoissonProblem<dim>::postprocess(const Mapping<dim> &mapping)
   {

--- a/examples/step-67/step-67.cc
+++ b/examples/step-67/step-67.cc
@@ -2081,6 +2081,13 @@ namespace Euler_DG
   // ignoring the (wrong) values in other entries. The fact that every process
   // submits a vector in which the correct subset of entries is correct is all
   // that is necessary.
+  //
+  // @note As of 2023, Visit 3.3.3 can still not deal with higher-order cells.
+  //   Rather, it simply reports that there is no data to show. To view the
+  //   results of this program with Visit, you will want to comment out the
+  //   line that sets `flags.write_higher_order_cells = true;`. On the other
+  //   hand, Paraview is able to understand VTU files with higher order cells
+  //   just fine.
   template <int dim>
   void EulerProblem<dim>::output_results(const unsigned int result_number)
   {


### PR DESCRIPTION
Fixes #15421.