### PR TITLE
Add an assertion.

### DIFF
--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -3479,6 +3479,7 @@ template <int dim, int spacedim>
 inline TriaIterator<TriaAccessor<dim - 1, dim, spacedim>>
 CellAccessor<dim, spacedim>::face(const unsigned int i) const
 {
+  AssertIndexRange(i, this->n_faces());
   return dealii::internal::CellAccessorImplementation::get_face(*this, i);
 }
 


### PR DESCRIPTION
In thinking about #15440 and https://github.com/dealii/dealii/pull/15441#issuecomment-1603329057, I couldn't quite convince myself that we are only calling `cell->face(i)` for valid face indices. And then I couldn't convince myself that `CellAccessor::face()` actually ever checks that `i` is valid because it quickly descends into a vast network of indirections.

This patch adds an assertion to the first place where we can check these indices, namely the `CellAccessor::face()` function itself.