### PR TITLE
lac/parpack_solver: add missing compress() operation

### DIFF
--- a/include/deal.II/lac/parpack_solver.h
+++ b/include/deal.II/lac/parpack_solver.h
@@ -1148,6 +1148,7 @@ PArpackSolver<VectorType>::solve(const MatrixType1 &system_matrix,
   {
     tmp = 0.0;
     tmp.add(nloc, local_indices.data(), resid.data());
+    tmp.compress(VectorOperation::add);
     solver_control.check(iparam[2], tmp.l2_norm());
   }
 }


### PR DESCRIPTION
Fixes: https://cdash.dealii.org/test/260915 https://cdash.dealii.org/test/259211

In reference to #15383