### PR TITLE
Fix invalid memory access of DoFAccessorImplementation

### DIFF
--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -516,9 +516,15 @@ namespace internal
         // determine range of dofs in global data structure
         const auto range =
           process_object_range(dof_handler, obj_level, obj_index, fe_index, dd);
+        if (range.second == 0)
+          return;
+
+        std::vector<types::global_dof_index> &object_dof_indices =
+          dof_handler
+            .object_dof_indices[structdim < dim ? 0 : obj_level][structdim];
+        AssertIndexRange(range.first, object_dof_indices.size());
         types::global_dof_index *DEAL_II_RESTRICT stored_indices =
-          &dof_handler.object_dof_indices[structdim < dim ? 0 : obj_level]
-                                         [structdim][range.first];
+          object_dof_indices.data() + range.first;
 
         // process dofs
         for (unsigned int i = 0; i < range.second; ++i, ++dof_indices_ptr)


### PR DESCRIPTION
In case there are no DoFs to be processed, the access `object_dof_indices[...][...][range.first]` to take the address might go past the end of the array. This can be fixed by returning early in that case. Furthermore, we prefer using `.data() + range.first` rather than taking the address nowadays.

With a good optimizing compiler, it should not change the work, because `range.second == 0` is also checked upon entry into the loop https://github.com/dealii/dealii/blob/c6b3d467c3b92c4eaf2fe67aa6c3104569c9024c/include/deal.II/dofs/dof_accessor.templates.h#L523-L524

Fixes #15439. In reference to #15383.