### PR TITLE
Symengine: Fix compilation for gcc-12 and older

### DIFF
--- a/source/differentiation/sd/symengine_number_types.cc
+++ b/source/differentiation/sd/symengine_number_types.cc
@@ -104,7 +104,7 @@ namespace Differentiation
         {expression_otherwise.get_RCP(), SE::boolTrue});
 
       // Initialize
-      expression = SE::piecewise(piecewise_function);
+      expression = SE::piecewise(std::move(piecewise_function));
     }
 
 


### PR DESCRIPTION
This partially reverts b2180600184d1d32dc825e5dee66bff296435aaf

Fixes: https://cdash.dealii.org/viewBuildError.php?buildid=44

In reference to #15383 and #15422