### PR TITLE
Add output variant.

### DIFF
--- a/tests/distributed_grids/3d_coarsening_04.output.2
+++ b/tests/distributed_grids/3d_coarsening_04.output.2
@@ -1,0 +1,4 @@
+
+DEAL:3d:: Number of cells: 51823 51823
+DEAL:3d::0 Number of cells: 63786 63786
+DEAL:3d::1 Number of cells: 89644 89644


### PR DESCRIPTION
This fixes one of the tests currently failing both on my system and one of the testers. I have not dug into the details, but the point of the test is to verify that a parallel and a non-parallel triangulation refine themselves in the same way, and lead to the same number of cells, when given the same refinement flags. This is the case, we just end up with a different number of cells than the output file we wrote way back.