### PR TITLE
Filter out --help from argv when initializing Kokkos

### DIFF
--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -788,9 +788,9 @@ namespace Utilities
         // likely did not intend. As a consequence, filter out this specific
         // flag.
         std::vector<char *> argv_new;
-        for (int i = 0; i < argc; ++i)
-          if (strcmp(argv[i], "--help") != 0)
-            argv_new.push_back(argv[i]);
+        for (const auto arg : make_array_view(&argv[0], &argv[0] + argc))
+          if (strcmp(arg, "--help") != 0)
+            argv_new.push_back(arg);
 
         std::stringstream threads_flag;
 #if KOKKOS_VERSION >= 30700

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -781,9 +781,10 @@ namespace Utilities
         // argv has argc+1 elements and the last one is a nullptr. For appending
         // one element we thus create a new argv by copying the first argc
         // elements, append the new option, and then a nullptr.
-        std::vector<char *> argv_new(argc + 2);
+        std::vector<char *> argv_new;
         for (int i = 0; i < argc; ++i)
-          argv_new[i] = argv[i];
+          argv_new.push_back(argv[i]);
+
         std::stringstream threads_flag;
 #if KOKKOS_VERSION >= 30700
         threads_flag << "--kokkos-num-threads=" << MultithreadInfo::n_threads();
@@ -791,12 +792,13 @@ namespace Utilities
         threads_flag << "--kokkos-threads=" << MultithreadInfo::n_threads();
 #endif
         const std::string threads_flag_string = threads_flag.str();
-        argv_new[argc]     = const_cast<char *>(threads_flag_string.c_str());
-        argv_new[argc + 1] = nullptr;
+        argv_new.push_back(const_cast<char *>(threads_flag_string.c_str()));
+        argv_new.push_back(nullptr);
+
         // The first argument in Kokkos::initialize is of type int&. Hence, we
         // need to define a new variable to pass to it (instead of using argc+1
         // inline).
-        int argc_new = argc + 1;
+        int argc_new = argv_new.size() - 1;
         Kokkos::initialize(argc_new, argv_new.data());
       }
 

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -781,9 +781,16 @@ namespace Utilities
         // argv has argc+1 elements and the last one is a nullptr. For appending
         // one element we thus create a new argv by copying the first argc
         // elements, append the new option, and then a nullptr.
+        //
+        // We do get in trouble, though, if a user program is called with
+        // '--help' as a command line argument. This '--help' gets passed on to
+        // Kokkos, which promptly responds with a lengthy message that the user
+        // likely did not intend. As a consequence, filter out this specific
+        // flag.
         std::vector<char *> argv_new;
         for (int i = 0; i < argc; ++i)
-          argv_new.push_back(argv[i]);
+          if (strcmp(argv[i], "--help") != 0)
+            argv_new.push_back(argv[i]);
 
         std::stringstream threads_flag;
 #if KOKKOS_VERSION >= 30700


### PR DESCRIPTION
Fixes #15456. Alternative to #15464.