### PR TITLE
Test cgal/cgal_remesh_surface: disable floating point exceptions

### DIFF
--- a/tests/cgal/cgal_remesh_surface.cc
+++ b/tests/cgal/cgal_remesh_surface.cc
@@ -40,6 +40,16 @@ template <int dim, int spacedim>
 void
 test()
 {
+  // This test might trigger spurious floating point exception despite
+  // functioning properly. Simply disable floating point exceptions again
+  // (after they had been enabled int tests.h)
+#if defined(DEBUG) && defined(DEAL_II_HAVE_FP_EXCEPTIONS)
+  {
+    const int current_fe_except = fegetexcept();
+    fedisableexcept(current_fe_except);
+  }
+#endif
+
   deallog << "dim= " << dim << ",\t spacedim= " << spacedim << std::endl;
 
   Triangulation<spacedim> tria0, tria1;


### PR DESCRIPTION
Fixes a failing test for the clang-16.01 libc++ testsuite variant.

In reference to #15383