### PR TITLE
Test lac/vector_memory_02: add output variant

### DIFF
--- a/tests/lac/vector_memory_02.debug.output.clang-libc++
+++ b/tests/lac/vector_memory_02.debug.output.clang-libc++
@@ -1,0 +1,23 @@
+
+DEAL::Exception: StandardExceptions::ExcMemoryLeak(current_alloc)
+DEAL::
+--------------------------------------------------------
+An error occurred in file <vector_memory.templates.h> in function
+    virtual dealii::GrowingVectorMemory<dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Default>>::~GrowingVectorMemory() [VectorType = dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Default>]
+The violated condition was: 
+    current_alloc == 0
+Additional information: 
+    Destroying memory handler while 1 objects are still allocated.
+--------------------------------------------------------
+
+DEAL::Exception: StandardExceptions::ExcMemoryLeak(current_alloc)
+DEAL::
+--------------------------------------------------------
+An error occurred in file <vector_memory.templates.h> in function
+    virtual dealii::GrowingVectorMemory<dealii::LinearAlgebra::distributed::Vector<float, dealii::MemorySpace::Default>>::~GrowingVectorMemory() [VectorType = dealii::LinearAlgebra::distributed::Vector<float, dealii::MemorySpace::Default>]
+The violated condition was: 
+    current_alloc == 0
+Additional information: 
+    Destroying memory handler while 1 objects are still allocated.
+--------------------------------------------------------
+


### PR DESCRIPTION
libc++ does have a different pretty printing than libstc++. Thus add an output variant.

Fixes a failing test for the clang-16.01 libc++ testsuite variant.

In reference to #15383