### PR TITLE
Test mpi/trilinos_step-27: add output variant

### DIFF
--- a/tests/mpi/trilinos_step-27.with_p4est=true.with_trilinos=true.mpirun=1.output.clang-libc++
+++ b/tests/mpi/trilinos_step-27.with_p4est=true.with_trilinos=true.mpirun=1.output.clang-libc++
@@ -1,0 +1,25 @@
+Cycle 0:
+   Number of active cells      : 768
+   Number of degrees of freedom: 3264
+   Number of constraints       : 384
+   Solved in 16 iterations.
+Cycle 1:
+   Number of active cells      : 966
+   Number of degrees of freedom: 5237
+   Number of constraints       : 932
+   Solved in 25 iterations.
+Cycle 2:
+   Number of active cells      : 1149
+   Number of degrees of freedom: 8545
+   Number of constraints       : 1951
+   Solved in 34 iterations.
+Cycle 3:
+   Number of active cells      : 1365
+   Number of degrees of freedom: 12515
+   Number of constraints       : 3096
+   Solved in 45 iterations.
+Cycle 4:
+   Number of active cells      : 1665
+   Number of degrees of freedom: 18523
+   Number of constraints       : 4783
+   Solved in 69 iterations.


### PR DESCRIPTION
With clang and libc++ I get a slightly different adaptive refinement. Thus add an output variant.

Fixes a failing test for the clang-16.01 libc++ testsuite variant.

In reference to #15383