### PR TITLE
CMake: improve testsuite driver performance

### DIFF
--- a/cmake/macros/macro_deal_ii_add_test.cmake
+++ b/cmake/macros/macro_deal_ii_add_test.cmake
@@ -111,6 +111,7 @@
 #
 
 if(POLICY CMP0112)
+  # Target file component generator expressions do not add target dependencies.
   cmake_policy(SET CMP0112 NEW)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -118,14 +118,11 @@ foreach(_category ${_categories})
 
   file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${_category})
 
+  set(_redirect > /dev/null)
   if(DEAL_II_MSVC)
-    set(_command ${CMAKE_COMMAND} -G${CMAKE_GENERATOR} ${_options} ${_category_dir})
-  else()
-    # Do not pass the generator with -G so that we use make instead of ninja
-    # for the test projects. This is because calling ninja several times in
-    # parallel for the same project will break the configuration.
-    set(_command ${CMAKE_COMMAND} ${_options} ${_category_dir} > /dev/null)
+    set (_redirect)
   endif()
+  set(_command ${CMAKE_COMMAND} -G${CMAKE_GENERATOR} ${_options} ${_category_dir} ${_redirect})
 
   add_custom_target(setup_tests_${_category}
     COMMAND ${_command}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -118,9 +118,9 @@ foreach(_category ${_categories})
 
   file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${_category})
 
-  set(_redirect > /dev/null)
+  set(_redirect ">" "/dev/null")
   if(DEAL_II_MSVC)
-    set (_redirect)
+    set (_redirect "")
   endif()
   set(_command ${CMAKE_COMMAND} -G${CMAKE_GENERATOR} ${_options} ${_category_dir} ${_redirect})
 


### PR DESCRIPTION
Some preliminary results:
```
% ctest -R "petsc_step-27.mpirun=2.debug" # first run:
1/2 Test #9807: test_dependency/mpi.petsc_step-27.debug.executable ...   Passed   14.15 sec
2/2 Test #9811: mpi/petsc_step-27.mpirun=2.debug .....................   Passed    3.08 sec
% ctest -R "petsc_step-27.mpirun=2.debug" # rerun:
1/2 Test #9807: test_dependency/mpi.petsc_step-27.debug.executable ...   Passed    0.15 sec
2/2 Test #9811: mpi/petsc_step-27.mpirun=2.debug .....................   Passed    0.14 sec
```
As compared to a baseline test with make:
```
% ctest -R "petsc_step-27.mpirun=2.debug" # first run
1/2 Test #9807: test_dependency/mpi.petsc_step-27.debug.executable ...   Passed   16.38 sec
2/2 Test #9811: mpi/petsc_step-27.mpirun=2.debug .....................   Passed    5.42 sec
% ctest -R "petsc_step-27.mpirun=2.debug" # rerun
1/2 Test #9807: test_dependency/mpi.petsc_step-27.debug.executable ...   Passed    2.36 sec
2/2 Test #9811: mpi/petsc_step-27.mpirun=2.debug .....................   Passed    2.33 sec
```