### PR TITLE
fix unused variable warning

### DIFF
--- a/source/opencascade/utilities.cc
+++ b/source/opencascade/utilities.cc
@@ -714,6 +714,7 @@ namespace OpenCASCADE
     [[maybe_unused]] unsigned int counter = 0;
 #  else
     unsigned int     counter = 0;
+    (void)counter;
 #  endif
     unsigned int face_counter = 0;
 


### PR DESCRIPTION
The [[maybe_unused]] doesn't help if compiling in c++14 mode.