### PR TITLE
Add two output variants for tests writing p4est vtk output

### DIFF
--- a/tests/distributed_grids/3d_coarse_grid_03.with_p4est_with_vtk_binary=false.output.2
+++ b/tests/distributed_grids/3d_coarse_grid_03.with_p4est_with_vtk_binary=false.output.2
@@ -1,0 +1,33 @@
+
+DEAL:3d::Checksum: 1585446913
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="12096" NumberOfCells="1512">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            5.85416377e-01   2.52083331e-01   8.35416377e-01
+            5.85416377e-01   2.52083331e-01   9.14583623e-01
+            6.64583623e-01   2.52083331e-01   8.35416377e-01
+            6.64583623e-01   2.52083331e-01   9.14583623e-01
+            5.85416377e-01   3.31249684e-01   8.35416377e-01
+            5.85416377e-01   3.31249684e-01   9.14583623e-01
+            6.64583623e-01   3.31249684e-01   8.35416377e-01
+            6.64583623e-01   3.31249684e-01   9.14583623e-01
+            5.85416377e-01   1.68750331e-01   8.35416377e-01
+            5.85416377e-01   1.68750331e-01   9.14583623e-01
+            6.64583623e-01   1.68750331e-01   8.35416377e-01
+            6.64583623e-01   1.68750331e-01   9.14583623e-01
+            5.85416377e-01   2.47916669e-01   8.35416377e-01

--- a/tests/distributed_grids/3d_coarse_grid_04.with_p4est_with_vtk_binary=false.output.2
+++ b/tests/distributed_grids/3d_coarse_grid_04.with_p4est_with_vtk_binary=false.output.2
@@ -1,0 +1,33 @@
+
+DEAL:3d::Checksum: 2097153
+<?xml version="1.0"?>
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPoints>
+      <PDataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii"/>
+    </PPoints>
+      <PDataArray type="Int32" Name="treeid" format="ascii"/>
+    </PCellData>
+    <Piece Source="1_0000.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <UnstructuredGrid>
+    <Piece NumberOfPoints="16" NumberOfCells="2">
+      <Points>
+        <DataArray type="Float32" Name="Position" NumberOfComponents="3" format="ascii">
+            2.50000004e-02   2.50000004e-02   2.50000004e-02
+            2.50000004e-02   9.75000024e-01   2.50000004e-02
+            2.50000004e-02   2.50000004e-02   9.75000024e-01
+            2.50000004e-02   9.75000024e-01   9.75000024e-01
+            9.75000024e-01   2.50000004e-02   2.50000004e-02
+            9.75000024e-01   9.75000024e-01   2.50000004e-02
+            9.75000024e-01   2.50000004e-02   9.75000024e-01
+            9.75000024e-01   9.75000024e-01   9.75000024e-01
+           -2.50000004e-02   2.50000004e-02   2.50000004e-02
+           -9.75000024e-01   2.50000004e-02   2.50000004e-02
+           -2.50000004e-02   2.50000004e-02   9.75000024e-01
+           -9.75000024e-01   2.50000004e-02   9.75000024e-01
+           -2.50000004e-02   9.75000024e-01   2.50000004e-02


### PR DESCRIPTION
On my installations of p4est (version 2.8 and 2.2, respectively), I get slightly different p4est output in https://github.com/dealii/dealii/blob/4ee9f01fd29c950e957eafb0199485b47bb84b14/tests/distributed_grids/coarse_grid_common.h#L45 than the blessed output files. Add another output variant for now. In the long run, we should do as for other tests and reduce the amount of output, as external libraries are not always stable in how they write the output.