### PR TITLE
MatrixFree inverse mass matrix: Make tests more robust

### DIFF
--- a/tests/matrix_free/inverse_mass_10.cc
+++ b/tests/matrix_free/inverse_mass_10.cc
@@ -150,7 +150,7 @@ private:
                   make_vectorized_array(random_value<Number>(1.0e-2, 1.0e-1));
                 // make diagonal dominant because inverse is needed
                 if (d1 == d2)
-                  dyadic_coefficients[q][d1][d2] *= 1.0e2;
+                  dyadic_coefficients[q][d1][d2] += 5.0;
               }
           }
         inverse_dyadic_coefficients[q] = invert(dyadic_coefficients[q]);
@@ -219,12 +219,6 @@ test()
     tria.refine_global(1);
   tria.begin(tria.n_levels() - 1)->set_refine_flag();
   tria.last()->set_refine_flag();
-  tria.execute_coarsening_and_refinement();
-  typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
-                                                    endc = tria.end();
-  for (; cell != endc; ++cell)
-    if (cell->center().norm() < 1e-8)
-      cell->set_refine_flag();
   tria.execute_coarsening_and_refinement();
 
   const unsigned int degree = fe_degree;

--- a/tests/matrix_free/inverse_mass_11.cc
+++ b/tests/matrix_free/inverse_mass_11.cc
@@ -151,7 +151,7 @@ private:
                   make_vectorized_array(random_value<Number>(1.0e-2, 1.0e-1));
                 // make diagonal dominant because inverse is needed
                 if (d1 == d2)
-                  dyadic_coefficients[q][d1][d2] *= 1.0e2;
+                  dyadic_coefficients[q][d1][d2] += 5.0;
               }
           }
         inverse_dyadic_coefficients[q] = invert(dyadic_coefficients[q]);
@@ -220,12 +220,6 @@ test()
     tria.refine_global(1);
   tria.begin(tria.n_levels() - 1)->set_refine_flag();
   tria.last()->set_refine_flag();
-  tria.execute_coarsening_and_refinement();
-  typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
-                                                    endc = tria.end();
-  for (; cell != endc; ++cell)
-    if (cell->center().norm() < 1e-8)
-      cell->set_refine_flag();
   tria.execute_coarsening_and_refinement();
 
   const unsigned int degree = fe_degree;


### PR DESCRIPTION
This makes two tests recently introduced by @bugrahantemur more robust by making the dyadic tensor more diagonally dominant with similar size of the entries (make entries spread around 5, rather than multiplying random numbers between 0.01 and 0.1 by 100). This should address failures like https://cdash.dealii.org/test/1003848 that fail because GMRES without precondition does not converge in 1000 iterations (roundoff errors are significant).

While there, also remove a refinement step that does not execute, `if (cell->center().norm() < 1e-8)` will evaluate to false as soon as the grid for `(-1, 1)` is refined at least once.