### PR TITLE
Ensure we set a flag correctly even if a task ends in an exception.

### DIFF
--- a/doc/news/changes/minor/20230626Bangerth
+++ b/doc/news/changes/minor/20230626Bangerth
@@ -1,0 +1,5 @@
+Fixed: With some compilers, calling Threads::Task::Task() with a
+function object that ends with an exception lead to a segmentation
+fault. This is now fixed.
+<br>
+(Wolfgang Bangerth, 2023/06/26)


### PR DESCRIPTION
This should fix #15478, or at least I hope so. I believe that we just bypassed setting a flag when a task ends in an exception, and then end up calling a function on `std::future` twice that can only be called once.

@tamiko Would you mind trying this out on the test?