### PR TITLE
Test non_matching/step-70: add an output variant

### DIFF
--- a/tests/non_matching/step-70.with_p4est=true.with_petsc=true.mpirun=2.output.petsc
+++ b/tests/non_matching/step-70.with_p4est=true.with_petsc=true.mpirun=2.output.petsc
@@ -1,0 +1,63 @@
+
+DEAL:0::Running StokesImmersedProblem<2> using PETSc.
+DEAL:0::Cycle 0:
+DEAL:0::Time : 0.00000, time step: 0.00250000
+DEAL:0::   Number of degrees of freedom: 9539 (8450+1089 -- 0+0)
+DEAL:0::Tracer particles: 1504
+DEAL:0::Solid particles: 9216
+DEAL:0:FGMRES::Starting value 30.9301
+DEAL:0:FGMRES::Convergence step 82 value 2.29355e-09
+DEAL:0::   Solved in 82 iterations.
+DEAL:0::   Number of degrees of freedom: 9845 (8722+1123 -- 9216+1504)
+DEAL:0::Cycle 1:
+DEAL:0::Time : 0.00250000, time step: 0.00250000
+DEAL:0:FGMRES::Starting value 2.92442
+DEAL:0:FGMRES::Convergence step 87 value 5.06002e-09
+DEAL:0::   Solved in 87 iterations.
+DEAL:0::Cycle 2:
+DEAL:0::Time : 0.00500000, time step: 0.00250000
+DEAL:0:FGMRES::Starting value 0.637099
+DEAL:0:FGMRES::Convergence step 84 value 5.07250e-09
+DEAL:0::   Solved in 84 iterations.
+DEAL:0::Cycle 3:
+DEAL:0::Time : 0.00750000, time step: 0.00250000
+DEAL:0:FGMRES::Starting value 0.649739
+DEAL:0:FGMRES::Convergence step 84 value 5.34653e-09
+DEAL:0::   Solved in 84 iterations.
+DEAL:0::Cycle 4:
+DEAL:0::Time : 0.0100000, time step: 0.00250000
+DEAL:0:FGMRES::Starting value 0.744112
+DEAL:0:FGMRES::Convergence step 84 value 5.24575e-09
+DEAL:0::   Solved in 84 iterations.
+
+DEAL:1::Running StokesImmersedProblem<2> using PETSc.
+DEAL:1::Cycle 0:
+DEAL:1::Time : 0.00000, time step: 0.00250000
+DEAL:1::   Number of degrees of freedom: 9539 (8450+1089 -- 0+0)
+DEAL:1::Tracer particles: 1504
+DEAL:1::Solid particles: 9216
+DEAL:1:FGMRES::Starting value 30.9301
+DEAL:1:FGMRES::Convergence step 82 value 2.29355e-09
+DEAL:1::   Solved in 82 iterations.
+DEAL:1::   Number of degrees of freedom: 9845 (8722+1123 -- 9216+1504)
+DEAL:1::Cycle 1:
+DEAL:1::Time : 0.00250000, time step: 0.00250000
+DEAL:1:FGMRES::Starting value 2.92442
+DEAL:1:FGMRES::Convergence step 87 value 5.06002e-09
+DEAL:1::   Solved in 87 iterations.
+DEAL:1::Cycle 2:
+DEAL:1::Time : 0.00500000, time step: 0.00250000
+DEAL:1:FGMRES::Starting value 0.637099
+DEAL:1:FGMRES::Convergence step 84 value 5.07250e-09
+DEAL:1::   Solved in 84 iterations.
+DEAL:1::Cycle 3:
+DEAL:1::Time : 0.00750000, time step: 0.00250000
+DEAL:1:FGMRES::Starting value 0.649739
+DEAL:1:FGMRES::Convergence step 84 value 5.34653e-09
+DEAL:1::   Solved in 84 iterations.
+DEAL:1::Cycle 4:
+DEAL:1::Time : 0.0100000, time step: 0.00250000
+DEAL:1:FGMRES::Starting value 0.744112
+DEAL:1:FGMRES::Convergence step 84 value 5.24575e-09
+DEAL:1::   Solved in 84 iterations.
+


### PR DESCRIPTION
Add an output variant for the case when deal.II is configured with PETSc support but without Trilinos support.

In reference to #15383