### PR TITLE
Require ArborX 1.3 or later

### DIFF
--- a/cmake/modules/FindDEAL_II_ARBORX.cmake
+++ b/cmake/modules/FindDEAL_II_ARBORX.cmake
@@ -28,7 +28,7 @@ set_if_empty(ARBORX_DIR "$ENV{ARBORX_DIR}")
 
 # silence a warning when including FindKOKKOS.cmake
 set(CMAKE_CXX_EXTENSIONS OFF)
-find_package(ArborX QUIET
+find_package(ArborX 1.3 QUIET
   HINTS ${ARBORX_DIR} ${ArborX_DIR} $ENV{ArborX_DIR}
   )
 


### PR DESCRIPTION
Fixes #15490. `ArborX` 1.4 requires `Kokkos` 3.6, see https://github.com/arborx/ArborX/blob/aefe78fd6e8126a17e3b73998377aa8c205a13dd/CMakeLists.txt.

In reference to #15383