### PR TITLE
Fix output for matrix_free/matrix_free_device_initialize_vector with CUDA support

### DIFF
--- a/tests/matrix_free/matrix_free_device_initialize_vector.with_mpi=on.with_p4est=on.with_cuda=on.mpirun=1.output
+++ b/tests/matrix_free/matrix_free_device_initialize_vector.with_mpi=on.with_p4est=on.with_cuda=on.mpirun=1.output
@@ -1,13 +1,11 @@
 
-
--
--DEAL:0:0::locally owned dofs :
--{[0,24]}
--DEAL:0:0::locally relevant dofs :
--{[0,24]}
--DEAL:0:0::OK
--DEAL:0:0::locally owned dofs :
--{[0,24]}
--DEAL:0:0::locally relevant dofs :
--{[0,24]}
--DEAL:0:0::OK
+DEAL:0:0::locally owned dofs :
+{[0,24]}
+DEAL:0:0::locally relevant dofs :
+{[0,24]}
+DEAL:0:0::OK
+DEAL:0:0::locally owned dofs :
+{[0,24]}
+DEAL:0:0::locally relevant dofs :
+{[0,24]}
+DEAL:0:0::OK


### PR DESCRIPTION
Follow-up to 138ae122dba4c5052edb5b2730f954b7b748f54c(#15262).