### PR TITLE
Move job_supports_mpi() to a more central place

### DIFF
--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -1348,9 +1348,9 @@ namespace LinearAlgebra
 
       // make sure that there are not outstanding requests from updating
       // ghost values or compress
-      int flag = 1;
       if (update_ghost_values_requests.size() > 0)
         {
+          int       flag = 1;
           const int ierr = MPI_Testall(update_ghost_values_requests.size(),
                                        update_ghost_values_requests.data(),
                                        &flag,
@@ -1363,6 +1363,7 @@ namespace LinearAlgebra
         }
       if (compress_requests.size() > 0)
         {
+          int       flag = 1;
           const int ierr = MPI_Testall(compress_requests.size(),
                                        compress_requests.data(),
                                        &flag,

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -149,28 +149,30 @@ namespace Utilities
     unsigned int
     n_mpi_processes(const MPI_Comm mpi_communicator)
     {
-      int n_jobs = 1;
       if (job_supports_mpi())
         {
-          const int ierr = MPI_Comm_size(mpi_communicator, &n_jobs);
+          int       n_jobs = 1;
+          const int ierr   = MPI_Comm_size(mpi_communicator, &n_jobs);
           AssertThrowMPI(ierr);
+          return n_jobs;
         }
-
-      return n_jobs;
+      else
+        return 1;
     }
 
 
     unsigned int
     this_mpi_process(const MPI_Comm mpi_communicator)
     {
-      int rank = 0;
       if (job_supports_mpi())
         {
+          int       rank = 0;
           const int ierr = MPI_Comm_rank(mpi_communicator, &rank);
           AssertThrowMPI(ierr);
+          return rank;
         }
-
-      return rank;
+      else
+        return 0;
     }
 
 


### PR DESCRIPTION
Part of #15512.

In many places of the library, we used to have a check `Utilities::MPI::job_supports_mpi()` in order to shield code from the case where `MPI_Init` was not called (because deal.II was compiled with MPI, but the code should run in serial). As discussed in the linked issue, the `MGTwoLevelTransfer` failed in this scenario and in the related case of deal.II compiled without MPI altogether. Most often, we simply call `MPI_Comm_rank` or `MPI_Comm_size` via `Utilities::MPI::this_mpi_process()` or `Utilities::MPI::n_mpi_processes`. This PR suggests to move the check `job_supports_mpi()` into these two functions, to create symmetry with the non-MPI case that always return 0 or 1 in that case (with underlying communicator `MPI_COMM_SELF`). This simplifies around 20 places in the library.

This PR also includes fixes I had to do to make the global coarsening MG transfer working without `MPI_Init`. In a follow-up PR, I will fix the `mg_transfer_global_coarsening.templates.h` file and provide test cases that ensure the functionality.