### PR TITLE
Shorten compilation time of two MatrixFree tests

### DIFF
--- a/tests/matrix_free/matrix_vector_hp.output
+++ b/tests/matrix_free/matrix_vector_hp.output
@@ -1,5 +1,3 @@
 
-DEAL:2d::Norm of difference: 0
-DEAL:2d::
-DEAL:3d::Norm of difference: 0
-DEAL:3d::
+DEAL::Norm of difference: 1.06581e-14
+DEAL::

--- a/tests/matrix_free/thread_correctness_hp.cc
+++ b/tests/matrix_free/thread_correctness_hp.cc
@@ -46,26 +46,7 @@ public:
               const Vector<Number> &                       src,
               const std::pair<unsigned int, unsigned int> &cell_range) const
   {
-    // Ask MatrixFree for cell_range for different
-    // orders
-    std::pair<unsigned int, unsigned int> subrange_deg;
-#define CALL_METHOD(degree)                                         \
-  subrange_deg = data.create_cell_subrange_hp(cell_range, degree);  \
-  if (subrange_deg.second > subrange_deg.first)                     \
-  helmholtz_operator<dim, degree, Vector<Number>, degree + 1>(data, \
-                                                              dst,  \
-                                                              src,  \
-                                                              subrange_deg)
-
-    CALL_METHOD(1);
-    CALL_METHOD(2);
-    CALL_METHOD(3);
-    CALL_METHOD(4);
-    CALL_METHOD(5);
-    CALL_METHOD(6);
-    CALL_METHOD(7);
-
-#undef CALL_METHOD
+    helmholtz_operator_no_template<dim>(data, dst, src, cell_range);
   }
 
   void


### PR DESCRIPTION
Some hp tests of the matrix-free framework were plagued by long compile times when using templated polynomial degrees to generate all code. It is better to let the code run through the pre-compiled paths, i.e., selecting `-1` as template argument.

Related to #15519.