### PR TITLE
MatrixFree: Reduce header inclusions in expensive factory files

### DIFF
--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -25,7 +25,6 @@
 
 #include <deal.II/matrix_free/face_info.h>
 #include <deal.II/matrix_free/shape_info.h>
-#include <deal.II/matrix_free/vector_data_exchange.h>
 
 #include <array>
 #include <memory>
@@ -48,6 +47,11 @@ namespace internal
 
     template <typename Number>
     struct ConstraintValues;
+
+    namespace VectorDataExchange
+    {
+      class Base;
+    }
   } // namespace MatrixFreeFunctions
 } // namespace internal
 

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -44,6 +44,7 @@
 #include <deal.II/matrix_free/shape_info.h>
 #include <deal.II/matrix_free/task_info.h>
 #include <deal.II/matrix_free/type_traits.h>
+#include <deal.II/matrix_free/vector_data_exchange.h>
 
 #include <cstdlib>
 #include <limits>

--- a/source/matrix_free/dof_info.cc
+++ b/source/matrix_free/dof_info.cc
@@ -22,6 +22,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 
 #include <deal.II/matrix_free/dof_info.templates.h>
+#include <deal.II/matrix_free/vector_data_exchange.h>
 
 #include <iostream>
 


### PR DESCRIPTION
Avoid to include `vector_data_access.h`, which includes `vector_operation.h`, `index_set.h` and other headers that transitively generate a lot of noise.