### PR TITLE
Use ArborX for spatial search in `guess_owners_of_entities()`

### DIFF
--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -5888,90 +5888,136 @@ namespace GridTools
       std::vector<std::pair<unsigned int, unsigned int>> ranks_and_indices;
       ranks_and_indices.reserve(entities.size());
 
-#if !defined(DEAL_II_WITH_ARBORX)
-
-      std::vector<std::vector<BoundingBox<spacedim>>> global_bboxes_temp;
-      auto *global_bboxes_to_be_used = &global_bboxes;
-      if (global_bboxes.size() == 1)
-        {
-          global_bboxes_temp =
-            Utilities::MPI::all_gather(comm, global_bboxes[0]);
-          global_bboxes_to_be_used = &global_bboxes_temp;
-        }
-
-
-      // helper function to determine if a bounding box is valid
-      const auto is_valid = [](const auto &bb) {
-        for (unsigned int i = 0; i < spacedim; ++i)
-          if (bb.get_boundary_points().first[i] >
-              bb.get_boundary_points().second[i])
-            return false;
-
-        return true;
-      };
-
-      // linearize vector of vectors
-      std::vector<std::pair<BoundingBox<spacedim>, unsigned int>>
-        boxes_and_ranks;
-
-      for (unsigned rank = 0; rank < global_bboxes_to_be_used->size(); ++rank)
-        for (const auto &box : (*global_bboxes_to_be_used)[rank])
-          if (is_valid(box))
-            boxes_and_ranks.emplace_back(box, rank);
-
-      // pack boxes into r-tree
-      const auto tree = pack_rtree(boxes_and_ranks);
-
-      // loop over all entities
-      for (unsigned int i = 0; i < entities.size(); ++i)
-        {
-          // create a bounding box with tolerance
-          const auto bb =
-            BoundingBox<spacedim>(entities[i]).create_extended(tolerance);
-
-          // determine ranks potentially owning point/bounding box
-          std::set<unsigned int> my_ranks;
-
-          for (const auto &box_and_rank :
-               tree | boost::geometry::index::adaptors::queried(
-                        boost::geometry::index::intersects(bb)))
-            my_ranks.insert(box_and_rank.second);
-
-          for (const auto rank : my_ranks)
-            ranks_and_indices.emplace_back(rank, i);
-        }
-
+#if defined(DEAL_II_WITH_ARBORX)
+#  define USE_ARBORX true
 #else
-      if (global_bboxes.size() == 1)
+#  define USE_ARBORX false
+#endif
+
+      if constexpr (USE_ARBORX == false)
         {
-          // Create query bounding boxes out of entities
-          std::vector<BoundingBox<spacedim>> query_bounding_boxes;
-          for (const auto &entity : entities)
-            query_bounding_boxes.push_back(
-              BoundingBox<spacedim>(entity).create_extended(tolerance));
-          ArborXWrappers::BoundingBoxIntersectPredicate bb_intersect(
-            query_bounding_boxes);
-
-          // Create bounding volume hierarchy out of input vector of bounding
-          ArborXWrappers::DistributedTree distributed_tree(comm,
-                                                           global_bboxes[0]);
-
-          auto indices_ranks_offset = distributed_tree.query(bb_intersect);
-
-          auto indices_ranks = indices_ranks_offset.first;
-          auto offsets       = indices_ranks_offset.second;
-
-          std::set<unsigned int> my_ranks;
-          for (unsigned int i = 0; i < offsets.size() - 1; ++i)
+          std::vector<std::vector<BoundingBox<spacedim>>> global_bboxes_temp;
+          auto *global_bboxes_to_be_used = &global_bboxes;
+          if (global_bboxes.size() == 1)
             {
-              for (int j = offsets[i]; j < offsets[i + 1]; ++j)
-                my_ranks.insert(indices_ranks[j].second);
+              global_bboxes_temp =
+                Utilities::MPI::all_gather(comm, global_bboxes[0]);
+              global_bboxes_to_be_used = &global_bboxes_temp;
+            }
+
+
+          // helper function to determine if a bounding box is valid
+          const auto is_valid = [](const auto &bb) {
+            for (unsigned int i = 0; i < spacedim; ++i)
+              if (bb.get_boundary_points().first[i] >
+                  bb.get_boundary_points().second[i])
+                return false;
+
+            return true;
+          };
+
+          // linearize vector of vectors
+          std::vector<std::pair<BoundingBox<spacedim>, unsigned int>>
+            boxes_and_ranks;
+
+          for (unsigned rank = 0; rank < global_bboxes_to_be_used->size();
+               ++rank)
+            for (const auto &box : (*global_bboxes_to_be_used)[rank])
+              if (is_valid(box))
+                boxes_and_ranks.emplace_back(box, rank);
+
+          // pack boxes into r-tree
+          const auto tree = pack_rtree(boxes_and_ranks);
+
+          // loop over all entities
+          for (unsigned int i = 0; i < entities.size(); ++i)
+            {
+              // create a bounding box with tolerance
+              const auto bb =
+                BoundingBox<spacedim>(entities[i]).create_extended(tolerance);
+
+              // determine ranks potentially owning point/bounding box
+              std::set<unsigned int> my_ranks;
+
+              for (const auto &box_and_rank :
+                   tree | boost::geometry::index::adaptors::queried(
+                            boost::geometry::index::intersects(bb)))
+                my_ranks.insert(box_and_rank.second);
+
               for (const auto rank : my_ranks)
                 ranks_and_indices.emplace_back(rank, i);
-              my_ranks.clear();
             }
         }
-#endif
+      else if constexpr (USE_ARBORX == true)
+        {
+          auto fill_ranks_and_indices =
+            [&ranks_and_indices](
+              const std::vector<int> &                offsets,
+              const std::vector<std::pair<int, int>> &indices_ranks) {
+              for (unsigned int i = 0; i < offsets.size() - 1; ++i)
+                for (int j = offsets[i]; j < offsets[i + 1]; ++j)
+                  ranks_and_indices.emplace_back(indices_ranks[j].second, i);
+            };
+
+          unsigned int idx = (global_bboxes.size() == 1) ?
+                               0 :
+                               Utilities::MPI::this_mpi_process(comm);
+          // size of global_bboxes>1
+          if constexpr (spacedim == 2)
+            {
+              // Create query bounding boxes out of entities
+              std::vector<BoundingBox<2>> query_bounding_boxes;
+              for (const auto &entity : entities)
+                query_bounding_boxes.push_back(
+                  BoundingBox<2>(entity).create_extended(tolerance));
+              ArborXWrappers::BoundingBoxIntersectPredicate bb_intersect(
+                query_bounding_boxes);
+
+              ArborXWrappers::DistributedTree distributed_tree(
+                comm, global_bboxes[idx]);
+
+              auto indices_ranks_offset = distributed_tree.query(bb_intersect);
+              auto indices_ranks        = indices_ranks_offset.first;
+              auto offsets              = indices_ranks_offset.second;
+
+              fill_ranks_and_indices(offsets, indices_ranks);
+            }
+          else if constexpr (spacedim == 3)
+            {
+              ArborXWrappers::DistributedTree distributed_tree(
+                comm, global_bboxes[idx]);
+
+              if constexpr (std::is_same<T, Point<3>>::value)
+                {
+                  ArborXWrappers::PointIntersectPredicate bb_intersect(
+                    entities);
+
+                  auto indices_ranks_offset =
+                    distributed_tree.query(bb_intersect);
+                  auto indices_ranks = indices_ranks_offset.first;
+                  auto offsets       = indices_ranks_offset.second;
+
+                  fill_ranks_and_indices(offsets, indices_ranks);
+                }
+              else if constexpr (std::is_same<T, BoundingBox<3>>::value)
+                {
+                  ArborXWrappers::BoundingBoxIntersectPredicate bb_intersect(
+                    entities);
+
+                  auto indices_ranks_offset =
+                    distributed_tree.query(bb_intersect);
+                  auto indices_ranks = indices_ranks_offset.first;
+                  auto offsets       = indices_ranks_offset.second;
+
+                  fill_ranks_and_indices(offsets, indices_ranks);
+                }
+            }
+        }
+      else
+        {
+          // We should never get here:
+          AssertThrow(false, ExcInternalError());
+        }
 
       // convert to CRS
       std::sort(ranks_and_indices.begin(), ranks_and_indices.end());
@@ -6912,7 +6958,8 @@ namespace GridTools
     unsigned int n_bboxes = local_bboxes.size();
     // Dimension of the array to be exchanged (number of double)
     int n_local_data = 2 * spacedim * n_bboxes;
-    // data array stores each entry of each point describing the bounding boxes
+    // data array stores each entry of each point describing the bounding
+    // boxes
     std::vector<double> loc_data_array(n_local_data);
     for (unsigned int i = 0; i < n_bboxes; ++i)
       for (unsigned int d = 0; d < spacedim; ++d)
@@ -7013,8 +7060,8 @@ namespace GridTools
     // Preparing to flatten the vector
     const unsigned int n_procs =
       Utilities::MPI::n_mpi_processes(mpi_communicator);
-    // The i'th element of the following vector contains the index of the first
-    // local bounding box from the process of rank i
+    // The i'th element of the following vector contains the index of the
+    // first local bounding box from the process of rank i
     std::vector<unsigned int> bboxes_position(n_procs);
 
     unsigned int tot_bboxes = 0;

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -24,11 +24,17 @@
 #  include <deal.II/arborx/access_traits.h>
 #  include <deal.II/arborx/distributed_tree.h>
 #else
+template <int dim, typename Number>
+class BoundingBox;
+
 namespace ArborXWrappers
 {
   class DistributedTree
   {
   public:
+    template <int dim, typename Number>
+    DistributedTree(const MPI_Comm &,
+                    const std::vector<BoundingBox<dim, Number>> &);
     template <typename QueryType>
     std::pair<std::vector<std::pair<int, int>>, std::vector<int>>
     query(const QueryType &queries);

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -5968,10 +5968,8 @@ namespace GridTools
           ArborXWrappers::DistributedTree distributed_tree(comm,
                                                            global_bboxes[idx]);
 
-          auto indices_ranks_offset = distributed_tree.query(bb_intersect);
-          auto indices_ranks        = indices_ranks_offset.first;
-          auto offsets              = indices_ranks_offset.second;
-
+          const auto &[indices_ranks, offsets] =
+            distributed_tree.query(bb_intersect);
           fill_ranks_and_indices(offsets, indices_ranks);
         }
       else if constexpr (spacedim == 3)
@@ -5983,10 +5981,8 @@ namespace GridTools
             {
               ArborXWrappers::PointIntersectPredicate bb_intersect(entities);
 
-              auto indices_ranks_offset = distributed_tree.query(bb_intersect);
-              auto indices_ranks        = indices_ranks_offset.first;
-              auto offsets              = indices_ranks_offset.second;
-
+              const auto &[indices_ranks, offsets] =
+                distributed_tree.query(bb_intersect);
               fill_ranks_and_indices(offsets, indices_ranks);
             }
           else if constexpr (std::is_same<T, BoundingBox<3>>::value)
@@ -5994,10 +5990,8 @@ namespace GridTools
               ArborXWrappers::BoundingBoxIntersectPredicate bb_intersect(
                 entities);
 
-              auto indices_ranks_offset = distributed_tree.query(bb_intersect);
-              auto indices_ranks        = indices_ranks_offset.first;
-              auto offsets              = indices_ranks_offset.second;
-
+              const auto &[indices_ranks, offsets] =
+                distributed_tree.query(bb_intersect);
               fill_ranks_and_indices(offsets, indices_ranks);
             }
         }

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -5908,8 +5908,7 @@ namespace GridTools
       ranks_and_indices.reserve(entities.size());
 
 #if defined(DEAL_II_WITH_ARBORX)
-      // ArborXWrappers don't support spacedim==1
-      static constexpr bool use_arborx = spacedim != 1;
+      static constexpr bool use_arborx = true;
 #else
       static constexpr bool use_arborx = false;
 #endif

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -23,6 +23,19 @@
 #ifdef DEAL_II_WITH_ARBORX
 #  include <deal.II/arborx/access_traits.h>
 #  include <deal.II/arborx/distributed_tree.h>
+#else
+namespace ArborXWrappers
+{
+  class DistributedTree
+  {
+  public:
+    template <typename QueryType>
+    std::pair<std::vector<std::pair<int, int>>, std::vector<int>>
+    query(const QueryType &queries);
+  };
+  class BoundingBoxIntersectPredicate
+  {};
+} // namespace ArborXWrappers
 #endif
 
 #ifdef DEAL_II_WITH_CGAL

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -5888,100 +5888,100 @@ namespace GridTools
       std::vector<std::pair<unsigned int, unsigned int>> ranks_and_indices;
       ranks_and_indices.reserve(entities.size());
 
-#if !defined(DEAL_II_WITH_ARBORX)
-      std::vector<std::vector<BoundingBox<spacedim>>> global_bboxes_temp;
-      auto *global_bboxes_to_be_used = &global_bboxes;
-      if (global_bboxes.size() == 1)
-        {
-          global_bboxes_temp =
-            Utilities::MPI::all_gather(comm, global_bboxes[0]);
-          global_bboxes_to_be_used = &global_bboxes_temp;
-        }
-
-
-      // helper function to determine if a bounding box is valid
-      const auto is_valid = [](const auto &bb) {
-        for (unsigned int i = 0; i < spacedim; ++i)
-          if (bb.get_boundary_points().first[i] >
-              bb.get_boundary_points().second[i])
-            return false;
-
-        return true;
-      };
-
-      // linearize vector of vectors
-      std::vector<std::pair<BoundingBox<spacedim>, unsigned int>>
-        boxes_and_ranks;
-
-      for (unsigned rank = 0; rank < global_bboxes_to_be_used->size(); ++rank)
-        for (const auto &box : (*global_bboxes_to_be_used)[rank])
-          if (is_valid(box))
-            boxes_and_ranks.emplace_back(box, rank);
-
-      // pack boxes into r-tree
-      const auto tree = pack_rtree(boxes_and_ranks);
-
-      // loop over all entities
-      for (unsigned int i = 0; i < entities.size(); ++i)
-        {
-          // create a bounding box with tolerance
-          const auto bb =
-            BoundingBox<spacedim>(entities[i]).create_extended(tolerance);
-
-          // determine ranks potentially owning point/bounding box
-          std::set<unsigned int> my_ranks;
-
-          for (const auto &box_and_rank :
-               tree | boost::geometry::index::adaptors::queried(
-                        boost::geometry::index::intersects(bb)))
-            my_ranks.insert(box_and_rank.second);
-
-          for (const auto rank : my_ranks)
-            ranks_and_indices.emplace_back(rank, i);
-        }
-
+#if defined(DEAL_II_WITH_ARBORX)
+#  define USE_ARBORX true
 #else
-      (void)tolerance;
-      auto fill_ranks_and_indices =
-        [&ranks_and_indices](
-          const std::vector<int> &                offsets,
-          const std::vector<std::pair<int, int>> &indices_ranks) {
-          for (unsigned int i = 0; i < offsets.size() - 1; ++i)
-            for (int j = offsets[i]; j < offsets[i + 1]; ++j)
-              ranks_and_indices.emplace_back(indices_ranks[j].second, i);
+#  define USE_ARBORX false
+#endif
+      // Lambda to process bboxes if global_bboxes.size()>1 or ArborX not
+      // available
+      const auto process_bboxes = [&]() -> void {
+        std::vector<std::vector<BoundingBox<spacedim>>> global_bboxes_temp;
+        auto *global_bboxes_to_be_used = &global_bboxes;
+
+        if (global_bboxes.size() == 1 && USE_ARBORX == false)
+          {
+            global_bboxes_temp =
+              Utilities::MPI::all_gather(comm, global_bboxes[0]);
+            global_bboxes_to_be_used = &global_bboxes_temp;
+          }
+
+        // helper function to determine if a bounding box is valid
+        const auto is_valid = [](const auto &bb) {
+          for (unsigned int i = 0; i < spacedim; ++i)
+            if (bb.get_boundary_points().first[i] >
+                bb.get_boundary_points().second[i])
+              return false;
+
+          return true;
         };
 
-      unsigned int idx = (global_bboxes.size() == 1) ?
-                           0 :
-                           Utilities::MPI::this_mpi_process(comm);
-      if constexpr (spacedim != 1)
+        // linearize vector of vectors
+        std::vector<std::pair<BoundingBox<spacedim>, unsigned int>>
+          boxes_and_ranks;
+
+        for (unsigned rank = 0; rank < global_bboxes_to_be_used->size(); ++rank)
+          for (const auto &box : (*global_bboxes_to_be_used)[rank])
+            if (is_valid(box))
+              boxes_and_ranks.emplace_back(box, rank);
+
+        // pack boxes into r-tree
+        const auto tree = pack_rtree(boxes_and_ranks);
+
+        // loop over all entities
+        for (unsigned int i = 0; i < entities.size(); ++i)
+          {
+            // create a bounding box with tolerance
+            const auto bb =
+              BoundingBox<spacedim>(entities[i]).create_extended(tolerance);
+
+            // determine ranks potentially owning point/bounding box
+            std::set<unsigned int> my_ranks;
+
+            for (const auto &box_and_rank :
+                 tree | boost::geometry::index::adaptors::queried(
+                          boost::geometry::index::intersects(bb)))
+              my_ranks.insert(box_and_rank.second);
+
+            for (const auto rank : my_ranks)
+              ranks_and_indices.emplace_back(rank, i);
+          }
+      };
+
+#if defined(DEAL_II_WITH_ARBORX)
+      if (global_bboxes.size() == 1)
         {
-          ArborXWrappers::DistributedTree distributed_tree(comm,
-                                                           global_bboxes[idx]);
-
-          if constexpr (std::is_same<T, Point<spacedim>>::value)
+          if constexpr (spacedim != 1)
             {
-              ArborXWrappers::PointIntersectPredicate bb_intersect(entities);
+              ArborXWrappers::DistributedTree distributed_tree(
+                comm, global_bboxes[0]);
+              std::vector<BoundingBox<spacedim>> query_bounding_boxes;
+              for (const auto &entity : entities)
+                query_bounding_boxes.emplace_back(
+                  BoundingBox<spacedim>(entity).create_extended(tolerance));
 
-              const auto &[indices_ranks, offsets] =
-                distributed_tree.query(bb_intersect);
-              fill_ranks_and_indices(offsets, indices_ranks);
-            }
-          else if constexpr (std::is_same<T, BoundingBox<spacedim>>::value)
-            {
               ArborXWrappers::BoundingBoxIntersectPredicate bb_intersect(
-                entities);
-
+                query_bounding_boxes);
               const auto &[indices_ranks, offsets] =
                 distributed_tree.query(bb_intersect);
-              fill_ranks_and_indices(offsets, indices_ranks);
+              for (unsigned long int i = 0; i < offsets.size() - 1; ++i)
+                for (int j = offsets[i]; j < offsets[i + 1]; ++j)
+                  ranks_and_indices.emplace_back(indices_ranks[j].second, i);
+            }
+          else
+            {
+              AssertThrow(false, ExcInternalError());
+              return {};
             }
         }
       else
         {
-          AssertThrow(false, ExcInternalError());
-          return {};
+          // global_bboxes.size()>1
+          process_bboxes();
         }
+#else
+      // No ArborX
+      process_bboxes();
 #endif
 
       // convert to CRS


### PR DESCRIPTION
As was discussed in #14948 and https://github.com/dealii/dealii/pull/14931#pullrequestreview-1351947707, the spatial search could be done with ArborX, if available. 

This PR is still a WIP, since I would like to:
- [x] choose the right `QueryType` (https://www.dealii.org/developer/doxygen/deal.II/classArborXWrappers_1_1DistributedTree.html#a8ae39e0982adc0e2c5f9f2bdab7ef53f) depending on the type of the primitive (i.e. `BoundingBox` or `Point`). 
- [ ] test it and look at numbers. A comparison with Boost (Geometry.Index) is in the paper (https://arxiv.org/pdf/1908.11807.pdf)


On my workstation all of the tests related to `RemotePointEvaluation` (which uses `guess_owners_of_entities()` in `RPE::reinit(points,tria,mapping)`) are passing. 

