### PR TITLE
Simplify constructors/operators of AffineConstraints::ConstraintLine.

### DIFF
--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -1651,9 +1651,10 @@ public:
     /**
      * Default constructor.
      */
-    ConstraintLine(const size_type &index         = numbers::invalid_dof_index,
-                   const Entries &  entries       = {},
-                   const number &   inhomogeneity = 0.0);
+    ConstraintLine(const size_type &index = numbers::invalid_dof_index,
+                   const typename AffineConstraints<
+                     number>::ConstraintLine::Entries &entries       = {},
+                   const number &                      inhomogeneity = 0.0);
 
     /**
      * Copy constructor.

--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -1654,7 +1654,7 @@ public:
     ConstraintLine(const size_type &index = numbers::invalid_dof_index,
                    const typename AffineConstraints<
                      number>::ConstraintLine::Entries &entries       = {},
-                   const number &                      inhomogeneity = 0.0);
+                   const number                        inhomogeneity = 0.0);
 
     /**
      * Copy constructor.
@@ -2532,7 +2532,7 @@ template <typename number>
 inline AffineConstraints<number>::ConstraintLine::ConstraintLine(
   const size_type &                                                  index,
   const typename AffineConstraints<number>::ConstraintLine::Entries &entries,
-  const number &inhomogeneity)
+  const number inhomogeneity)
   : index(index)
   , entries(entries)
   , inhomogeneity(inhomogeneity)

--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -1658,15 +1658,24 @@ public:
     /**
      * Copy constructor.
      */
-    template <typename ConstraintLineType>
-    ConstraintLine(const ConstraintLineType &other);
+    ConstraintLine(const ConstraintLine &other) = default;
+
+    /**
+     * Move constructor.
+     */
+    ConstraintLine(ConstraintLine &&other) noexcept = default;
 
     /**
      * Copy assignment.
      */
-    template <typename ConstraintLineType>
     ConstraintLine &
-    operator=(const ConstraintLineType &other);
+    operator=(const ConstraintLine &other) = default;
+
+    /**
+     * Move assignment.
+     */
+    ConstraintLine &
+    operator=(ConstraintLine &&other) noexcept = default;
 
     /**
      * This operator is a bit weird and unintuitive: it compares the line
@@ -2451,7 +2460,14 @@ AffineConstraints<number>::copy_from(
   const AffineConstraints<other_number> &other)
 {
   lines.clear();
-  lines.insert(lines.begin(), other.lines.begin(), other.lines.end());
+  lines.reserve(other.lines.size());
+
+  for (const auto l : other.lines)
+    lines.emplace_back(l.index,
+                       typename ConstraintLine::Entries(l.entries.begin(),
+                                                        l.entries.end()),
+                       l.inhomogeneity);
+
   lines_cache = other.lines_cache;
   local_lines = other.local_lines;
   sorted      = other.sorted;
@@ -2522,37 +2538,6 @@ inline AffineConstraints<number>::ConstraintLine::ConstraintLine(
 {}
 
 
-
-template <typename number>
-template <typename ConstraintLineType>
-inline AffineConstraints<number>::ConstraintLine::ConstraintLine(
-  const ConstraintLineType &other)
-{
-  this->index = other.index;
-
-  entries.clear();
-  entries.insert(entries.begin(), other.entries.begin(), other.entries.end());
-
-  this->inhomogeneity = other.inhomogeneity;
-}
-
-
-
-template <typename number>
-template <typename ConstraintLineType>
-inline typename AffineConstraints<number>::ConstraintLine &
-AffineConstraints<number>::ConstraintLine::operator=(
-  const ConstraintLineType &other)
-{
-  this->index = other.index;
-
-  entries.clear();
-  entries.insert(entries.begin(), other.entries.begin(), other.entries.end());
-
-  this->inhomogeneity = other.inhomogeneity;
-
-  return *this;
-}
 
 DEAL_II_NAMESPACE_CLOSE
 


### PR DESCRIPTION
In `AffineConstraints::close()`, we sort objects of type `AffineConstraints::ConstraintLine`. For this, it is useful if objects are move constructible and move assignable. This patch makes sure this is so by adding move constructors and move operators.

Interestingly, the copy constructor and copy operator of this class are templatized to take objects that for all practical purposes need to look exactly like `ConstraintLine`, down to the level of naming of their member variables. That's definitely weird -- I have no idea why this is the case, so I removed it and now only allow `ConstraintLine` objects as arguments. This seems to work when compiling the library; let's see whether that also works for the test suite and if someone remembers why we did it that way.