### PR TITLE
Implement AffineConstraints::ConstraintLine::swap().

### DIFF
--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -1704,6 +1704,17 @@ public:
     {
       ar &index &entries &inhomogeneity;
     }
+
+    /**
+     * Swap function.
+     */
+    friend void
+    swap(ConstraintLine &l1, ConstraintLine &l2)
+    {
+      std::swap(l1.index, l2.index);
+      std::swap(l1.entries, l2.entries);
+      std::swap(l1.inhomogeneity, l2.inhomogeneity);
+    }
   };
 
   /**


### PR DESCRIPTION
Interestingly, I don't believe that this function can be out-of-lined: It would result in
```
template <typename number>
void swap (typename AffineConstraints<number>::ConstraintLine &l1,
                    typename AffineConstraints<number>::ConstraintLine &l2) { ...}
```
in which `number` is non-deducible. I just don't see how the compiler can find this function if needed, but assume that an instantiation of the class `AffineConstraints<number>::ConstraintLine` for a concrete template argument results in injection of the `swap` function defined herein injects it into the relevant namespace as an overload (not as a template).

This is another step towards making `std::sort` of constraint lines faster, see #15544.