### PR TITLE
Use -Werror again in enable_if_supported

### DIFF
--- a/cmake/macros/macro_enable_if_supported.cmake
+++ b/cmake/macros/macro_enable_if_supported.cmake
@@ -22,7 +22,14 @@
 #
 
 macro(enable_if_supported _variable _flag)
+  # First check if we can use -Werror
+  CHECK_CXX_COMPILER_FLAG("-Werror" DEAL_II_HAVE_FLAG_werror)
+
   string(STRIP "${_flag}" _flag_stripped)
+
+  if(DEAL_II_HAVE_FLAG_werror)
+    set(CMAKE_REQUIRED_FLAGS "-Werror")
+  endif()
 
   #
   # Gcc does not emit a warning if testing -Wno-... flags which leads to
@@ -47,5 +54,7 @@ macro(enable_if_supported _variable _flag)
       string(STRIP "${${_variable}}" ${_variable})
     endif()
   endif()
+
+  unset(CMAKE_REQUIRED_FLAGS)
 endmacro()
 

--- a/cmake/macros/macro_enable_if_supported.cmake
+++ b/cmake/macros/macro_enable_if_supported.cmake
@@ -23,11 +23,11 @@
 
 macro(enable_if_supported _variable _flag)
   # First check if we can use -Werror
-  CHECK_CXX_COMPILER_FLAG("-Werror" DEAL_II_HAVE_FLAG_werror)
+  CHECK_CXX_COMPILER_FLAG("-Werror" DEAL_II_HAVE_FLAG_Werror)
 
   string(STRIP "${_flag}" _flag_stripped)
 
-  if(DEAL_II_HAVE_FLAG_werror)
+  if(DEAL_II_HAVE_FLAG_Werror)
     set(CMAKE_REQUIRED_FLAGS "-Werror")
   endif()
 

--- a/cmake/setup_compiler_flags_gnu.cmake
+++ b/cmake/setup_compiler_flags_gnu.cmake
@@ -212,19 +212,7 @@ if (CMAKE_BUILD_TYPE MATCHES "Debug")
   #
   # https://github.com/dealii/dealii/issues/15496
   #
-  # ... except this doesn't presently work with AppleClang versions before 16.0.
-  # They support this flag but it is not compatible with C++14: see
-  #
-  # https://github.com/dealii/dealii/issues/15531
-  #
-  # This flag works with standard Clang 13.0 or newer.
-  #
-  if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang"
-        AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "13.0")
-      OR (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"
-        AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "16.0"))
-    enable_if_supported(DEAL_II_CXX_FLAGS_DEBUG "-ffp-exception-behavior=strict")
-  endif()
+  enable_if_supported(DEAL_II_CXX_FLAGS_DEBUG "-ffp-exception-behavior=strict")
 
   #
   # In recent versions, gcc often eliminates too much debug information


### PR DESCRIPTION
Reverts #15532. Let's see if there is any other reason for not using `-Werror`.