### PR TITLE
github-actions: max out cores on macos and windows.

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -30,7 +30,7 @@ jobs:
     - name: build
       run: |
         make VERBOSE=1 -j2
-        make -j2 test # quicktests
+        make -j3 test # quicktests
     - name: archive error 1
       uses: actions/upload-artifact@v3
       if: always()
@@ -73,7 +73,7 @@ jobs:
     - name: build
       run: |
         make VERBOSE=1 -j2
-        make -j2 test #quicktests
+        make -j3 test #quicktests
     - name: archive error 1
       uses: actions/upload-artifact@v3
       if: always()

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,13 +38,13 @@ jobs:
     - name: build library
       shell: bash
       run: |
-        cmake --build build  --target install -- -m
+        cmake --build build --parallel 2 --target install
         cd c:/project
         7z a dealii-windows.zip *
     - name: test library
       shell: bash
       run: |
-        cmake --build build  --target test -- -m
+        cmake --build build --parallel 2 --target test
     - name: archive library
       # run only if a PR is merged into master
       if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
These are the specifications of the github-hosted runners:
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

The `macos` runners actually come with 3 cores, so let's use 3 jobs to build on them.

We can also explicitly tell the `windows` builds to use the 2 cores its runners come with. This can be done through `cmake` since version `3.12`, and the runners come with `3.26.4`.
https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-build-j

Do the runners come with hyper-threading? In that case, we could try to use more jobs than cores.