### PR TITLE
CMake: print a status message after deal_ii_pickup_tests() invocation

### DIFF
--- a/cmake/macros/macro_deal_ii_add_test.cmake
+++ b/cmake/macros/macro_deal_ii_add_test.cmake
@@ -325,6 +325,14 @@ function(deal_ii_add_test _category _test_name _comparison_file)
 
   foreach(_build ${_build_types})
     #
+    # Increment the _number_of_tests counter by one in the parent scope.
+    # Note that the variable can be undefined initially. In this case we
+    # simply store "1" in the first iteration.
+    #
+    math(EXPR _number_of_tests "${_number_of_tests} + 1")
+    set(_number_of_tests "${_number_of_tests}" PARENT_SCOPE)
+
+    #
     # Obey "debug" and "release" keywords in the output file:
     #
     item_matches(_match "${_build}" ${_configuration})
@@ -483,6 +491,17 @@ function(deal_ii_add_test _category _test_name _comparison_file)
       #
 
       if(_shared_target AND NOT TARGET ${_test_executable_target})
+        #
+        # Increment the _number_of_test_dependencies counter by one in the
+        # parent scope. Test dependencies are all tests where we have split
+        # out compiling and linking of an executable into a separate
+        # "test_dependency/" test. Note that the variable can be undefined
+        # initially. In this case we simply store "1" in the first
+        # iteration.
+        #
+        math(EXPR _number_of_test_dependencies "${_number_of_test_dependencies} + 1")
+        set(_number_of_test_dependencies "${_number_of_test_dependencies}" PARENT_SCOPE)
+
         add_custom_target(${_test_executable_target}
           COMMAND echo "${_test_executable_full}: BUILD successful."
           COMMAND echo "${_test_executable_full}: RUN skipped."

--- a/cmake/macros/macro_deal_ii_pickup_tests.cmake
+++ b/cmake/macros/macro_deal_ii_pickup_tests.cmake
@@ -86,6 +86,12 @@ endmacro()
 
 macro(deal_ii_pickup_tests)
   #
+  # Initialize two counters to zero:
+  #
+  set(_number_of_tests 0)
+  set(_number_of_test_dependencies 0)
+
+  #
   # Find bash and perl interpreter:
   #
 
@@ -343,4 +349,6 @@ Comparison operator \"=\" expected for boolean match.\n"
     deal_ii_add_test(${_category} ${_test} ${_comparison})
 
   endforeach()
+
+  message(STATUS "Test category \"${_category}\": ${_number_of_tests} tests (and ${_number_of_test_dependencies} test dependencies)")
 endmacro()

--- a/cmake/macros/macro_deal_ii_pickup_tests.cmake
+++ b/cmake/macros/macro_deal_ii_pickup_tests.cmake
@@ -350,5 +350,7 @@ Comparison operator \"=\" expected for boolean match.\n"
 
   endforeach()
 
-  message(STATUS "Test category \"${_category}\": ${_number_of_tests} tests (and ${_number_of_test_dependencies} test dependencies)")
+  if(NOT "${_number_of_tests}" STREQUAL "0")
+    message(STATUS "Test category \"${_category}\": ${_number_of_tests} tests (and ${_number_of_test_dependencies} test dependencies)")
+  endif()
 endmacro()

--- a/doc/news/changes/minor/20230630MatthiasMaier
+++ b/doc/news/changes/minor/20230630MatthiasMaier
@@ -1,0 +1,7 @@
+Improved: The `deal_ii_pickup_tests()` macro now prints a status line at
+the end summarizing how many tests have been configured for the given test
+category. Similarly, the top level target `setup_tests` concatenates these
+status lines and prints a summary after invocation.
+<br>
+(Matthias Maier, 2023/06/30)
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -107,11 +107,26 @@ endforeach()
 # Custom targets for the testsuite:
 #
 
-# Setup tests:
-add_custom_target(setup_tests)
+#
+# Clear the test summary files that records how many tests have been configured.
+#
+set(_summary_files_prefix "${CMAKE_CURRENT_BINARY_DIR}/test_summary")
 
-# Remove all tests:
-add_custom_target(prune_tests)
+# Set up all tests and print a summary:
+add_custom_target(setup_tests
+  COMMAND ${CMAKE_COMMAND}
+    -D_summary_files_prefix="${_summary_files_prefix}"
+    -P ${CMAKE_CURRENT_SOURCE_DIR}/scripts/print_summary_files.cmake
+  COMMENT "Setting up tests and printing test summary"
+  )
+
+# Remove all tests and also remove all test summary files:
+add_custom_target(prune_tests
+  COMMAND ${CMAKE_COMMAND}
+    -D_summary_files_prefix="${_summary_files_prefix}"
+    -P ${CMAKE_CURRENT_SOURCE_DIR}/scripts/remove_summary_files.cmake
+  COMMENT "Cleaning tests and removing test summary files"
+  )
 
 foreach(_category ${_categories})
   set(_category_dir ${CMAKE_CURRENT_SOURCE_DIR}/${_category})
@@ -124,7 +139,8 @@ foreach(_category ${_categories})
     # Do not pass the generator with -G so that we use make instead of ninja
     # for the test projects. This is because calling ninja several times in
     # parallel for the same project will break the configuration.
-    set(_command ${CMAKE_COMMAND} ${_options} ${_category_dir} > /dev/null)
+
+    set(_command ${CMAKE_COMMAND} ${_options} ${_category_dir} > "${_summary_files_prefix}_${_category}")
   endif()
 
   add_custom_target(setup_tests_${_category}

--- a/tests/scripts/print_summary_files.cmake
+++ b/tests/scripts/print_summary_files.cmake
@@ -1,0 +1,15 @@
+#
+# Glob all test summary files and print them
+#
+
+if("${_summary_files_prefix}" STREQUAL "")
+  message(FATAL_ERROR "The variable _summary_files_prefix is not set.")
+endif()
+
+file(GLOB _files "${_summary_files_prefix}_*")
+foreach(_file ${_files})
+  file(STRINGS "${_file}" _summary_string REGEX "Test category ")
+  if(NOT "${_summary_string}" STREQUAL "")
+    message("${_summary_string}")
+  endif()
+endforeach()

--- a/tests/scripts/remove_summary_files.cmake
+++ b/tests/scripts/remove_summary_files.cmake
@@ -1,0 +1,12 @@
+#
+# Glob all test summary files and remove them
+#
+
+if("${_summary_files_prefix}" STREQUAL "")
+  message(FATAL_ERROR "The variable _summary_files_prefix is not set.")
+endif()
+
+file(GLOB _files "${_summary_files_prefix}_*")
+if(NOT "${_files}" STREQUAL "")
+  file(REMOVE ${_files})
+endif()


### PR DESCRIPTION
As requested by @bangerth. This pull adds a short summary summary that gets
printed after a call to `deal_ii_pickup_tests()` that shows how many tests
have been found.

Similarly, this output is now concatenated in the `setup_tests` macro to
print a status summary at the end:
```
% TEST_PICKUP_REGEX="mpi" ninja setup_tests
[72/72] Setting up tests and printing test summary
-- Test category "base": 62 tests (and 26 test dependencies)
-- Test category "grid": 4 tests (and 4 test dependencies)
-- Test category "meshworker": 2 tests (and 2 test dependencies)
-- Test category "mpi": 1554 tests (and 817 test dependencies)
-- Test category "multigrid": 10 tests (and 6 test dependencies)
-- Test category "quick_tests": 2 tests (and 2 test dependencies)
```
This is particularly useful in combination with the `TEST_PICKUP_REGEX`
variable to get an idea about what is actually being configured.