### PR TITLE
General: use diamond inheritance for Subscriptor

### DIFF
--- a/doc/news/changes/minor/20230701MatthiasMaier
+++ b/doc/news/changes/minor/20230701MatthiasMaier
@@ -1,0 +1,7 @@
+Fixed: All deal.II classes now use virtual inheritance for the Subscriptor
+class. This ensures that after inheriting from these classes only one
+Subscriptor copy remains in the object. This in turn enables the use of a
+SmartPointer with classes that inherit two or more deal.II classes that
+inherited from Subscriptor.
+<br>
+(Matthias Maier, 2023/07/01)

--- a/include/deal.II/algorithms/any_data.h
+++ b/include/deal.II/algorithms/any_data.h
@@ -34,7 +34,7 @@ DEAL_II_NAMESPACE_OPEN
  *
  * @todo GK: Deprecate access to AnyData by index and change to a map.
  */
-class AnyData : public Subscriptor
+class AnyData : public virtual Subscriptor
 {
 public:
   /// Default constructor for empty object

--- a/include/deal.II/algorithms/general_data_storage.h
+++ b/include/deal.II/algorithms/general_data_storage.h
@@ -51,7 +51,7 @@ DEAL_II_NAMESPACE_OPEN
  *  Year = {2018}}
  * @endcode
  */
-class GeneralDataStorage : public Subscriptor
+class GeneralDataStorage : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/algorithms/operator.h
+++ b/include/deal.II/algorithms/operator.h
@@ -63,7 +63,7 @@ namespace Algorithms
    * providing additional information and forwarded to the inner Operator
    * objects of the nested iteration.
    */
-  class OperatorBase : public Subscriptor
+  class OperatorBase : public virtual Subscriptor
   {
   public:
     /**
@@ -102,7 +102,7 @@ namespace Algorithms
    * in each step of an iteration.
    */
   template <typename VectorType>
-  class OutputOperator : public Subscriptor
+  class OutputOperator : public virtual Subscriptor
   {
   public:
     /**

--- a/include/deal.II/algorithms/timestep_control.h
+++ b/include/deal.II/algorithms/timestep_control.h
@@ -58,7 +58,7 @@ namespace Algorithms
    * with a more modern interface and better programming guarantees. Consider
    * using DiscreteTime instead of TimestepControl.
    */
-  class TimestepControl : public Subscriptor
+  class TimestepControl : public virtual Subscriptor
   {
   public:
     /**

--- a/include/deal.II/base/function.h
+++ b/include/deal.II/base/function.h
@@ -149,7 +149,7 @@ class TensorFunction;
 template <int dim, typename RangeNumberType = double>
 class Function : public FunctionTime<
                    typename numbers::NumberTraits<RangeNumberType>::real_type>,
-                 public Subscriptor
+                 public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/base/logstream.h
+++ b/include/deal.II/base/logstream.h
@@ -78,7 +78,7 @@ DEAL_II_NAMESPACE_OPEN
  *
  * @ingroup textoutput
  */
-class LogStream : public Subscriptor
+class LogStream : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/base/mg_level_object.h
+++ b/include/deal.II/base/mg_level_object.h
@@ -46,7 +46,7 @@ DEAL_II_NAMESPACE_OPEN
  * @ingroup data
  */
 template <class Object>
-class MGLevelObject : public Subscriptor
+class MGLevelObject : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/base/parameter_acceptor.h
+++ b/include/deal.II/base/parameter_acceptor.h
@@ -357,7 +357,7 @@ namespace internal
  *
  * See the tutorial program step-60 for an example on how to use this class.
  */
-class ParameterAcceptor : public Subscriptor
+class ParameterAcceptor : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -852,7 +852,7 @@ class MultipleParameterLoop;
  *
  * @ingroup input
  */
-class ParameterHandler : public Subscriptor
+class ParameterHandler : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/base/polynomial.h
+++ b/include/deal.II/base/polynomial.h
@@ -62,7 +62,7 @@ namespace Polynomials
    * TensorProductPolynomials class.
    */
   template <typename number>
-  class Polynomial : public Subscriptor
+  class Polynomial : public virtual Subscriptor
   {
   public:
     /**

--- a/include/deal.II/base/polynomials_piecewise.h
+++ b/include/deal.II/base/polynomials_piecewise.h
@@ -61,7 +61,7 @@ namespace Polynomials
    * @ingroup Polynomials
    */
   template <typename number>
-  class PiecewisePolynomial : public Subscriptor
+  class PiecewisePolynomial : public virtual Subscriptor
   {
   public:
     /**

--- a/include/deal.II/base/quadrature.h
+++ b/include/deal.II/base/quadrature.h
@@ -119,7 +119,7 @@ DEAL_II_NAMESPACE_OPEN
  * as "list of evaluation points".
  */
 template <int dim>
-class Quadrature : public Subscriptor
+class Quadrature : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/base/quadrature_point_data.h
+++ b/include/deal.II/base/quadrature_point_data.h
@@ -61,7 +61,7 @@ DEAL_II_NAMESPACE_OPEN
  * for example, adopting a level-set approach to describe material behavior.
  */
 template <typename CellIteratorType, typename DataType>
-class CellDataStorage : public Subscriptor
+class CellDataStorage : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -438,7 +438,7 @@ namespace internal
  * @ingroup data
  */
 template <int N, typename T>
-class TableBase : public Subscriptor
+class TableBase : public virtual Subscriptor
 {
 public:
   using value_type = T;

--- a/include/deal.II/base/tensor_function.h
+++ b/include/deal.II/base/tensor_function.h
@@ -55,7 +55,7 @@ DEAL_II_NAMESPACE_OPEN
 template <int rank, int dim, typename Number = double>
 class TensorFunction
   : public FunctionTime<typename numbers::NumberTraits<Number>::real_type>,
-    public Subscriptor
+    public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/distributed/repartitioning_policy_tools.h
+++ b/include/deal.II/distributed/repartitioning_policy_tools.h
@@ -46,7 +46,7 @@ namespace RepartitioningPolicyTools
    * See the description of RepartitioningPolicyTools for more information.
    */
   template <int dim, int spacedim = dim>
-  class Base : public Subscriptor
+  class Base : public virtual Subscriptor
   {
   public:
     /**

--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -515,7 +515,7 @@ namespace internal
        * for more information about artificial cells.
        */
       template <int dim, int spacedim = dim>
-      class TemporarilyRestoreSubdomainIds : public Subscriptor
+      class TemporarilyRestoreSubdomainIds : public virtual Subscriptor
       {
       public:
         /**

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -1111,7 +1111,7 @@ namespace parallel
      * The use of this class is demonstrated in step-75.
      */
     template <int dim, int spacedim = dim>
-    class TemporarilyMatchRefineFlags : public Subscriptor
+    class TemporarilyMatchRefineFlags : public virtual Subscriptor
     {
     public:
       /**

--- a/include/deal.II/dofs/block_info.h
+++ b/include/deal.II/dofs/block_info.h
@@ -92,7 +92,7 @@ class DoFHandler;
  *
  * @ingroup dofs
  */
-class BlockInfo : public Subscriptor
+class BlockInfo : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -314,7 +314,7 @@ namespace parallel
  */
 template <int dim, int spacedim = dim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-class DoFHandler : public Subscriptor
+class DoFHandler : public virtual Subscriptor
 {
   using ActiveSelector =
     dealii::internal::DoFHandlerImplementation::Iterators<dim, spacedim, false>;

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -652,7 +652,7 @@ class FESystem;
  * @ingroup febase fe
  */
 template <int dim, int spacedim = dim>
-class FiniteElement : public Subscriptor, public FiniteElementData<dim>
+class FiniteElement : public virtual Subscriptor, public FiniteElementData<dim>
 {
 public:
   /**

--- a/include/deal.II/fe/fe_series.h
+++ b/include/deal.II/fe/fe_series.h
@@ -87,7 +87,7 @@ namespace FESeries
    * $ \bf k $ .
    */
   template <int dim, int spacedim = dim>
-  class Fourier : public Subscriptor
+  class Fourier : public virtual Subscriptor
   {
   public:
     using CoefficientType = typename std::complex<double>;
@@ -257,7 +257,7 @@ namespace FESeries
    * $ \widetilde P_m(x) $ using tensor product rule.
    */
   template <int dim, int spacedim = dim>
-  class Legendre : public Subscriptor
+  class Legendre : public virtual Subscriptor
   {
   public:
     using CoefficientType = double;

--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -86,7 +86,7 @@ namespace FETools
    * FETools::add_fe_name() functions.
    */
   template <int dim, int spacedim = dim>
-  class FEFactoryBase : public Subscriptor
+  class FEFactoryBase : public virtual Subscriptor
   {
   public:
     /**

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -2226,7 +2226,7 @@ namespace FEValuesViews
  * @ingroup feaccess
  */
 template <int dim, int spacedim>
-class FEValuesBase : public Subscriptor
+class FEValuesBase : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -313,7 +313,7 @@ enum MappingKind
  * @ingroup mapping
  */
 template <int dim, int spacedim = dim>
-class Mapping : public Subscriptor
+class Mapping : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/grid/grid_tools_cache.h
+++ b/include/deal.II/grid/grid_tools_cache.h
@@ -62,7 +62,7 @@ namespace GridTools
    * method mark_for_update() manually.
    */
   template <int dim, int spacedim = dim>
-  class Cache : public Subscriptor
+  class Cache : public virtual Subscriptor
   {
   public:
     /**

--- a/include/deal.II/grid/intergrid_map.h
+++ b/include/deal.II/grid/intergrid_map.h
@@ -114,7 +114,7 @@ DEAL_II_NAMESPACE_OPEN
  */
 template <class MeshType>
 DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
-class InterGridMap : public Subscriptor
+class InterGridMap : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/grid/manifold.h
+++ b/include/deal.II/grid/manifold.h
@@ -283,7 +283,7 @@ namespace Manifolds
  * @ingroup manifold
  */
 template <int dim, int spacedim = dim>
-class Manifold : public Subscriptor
+class Manifold : public virtual Subscriptor
 {
 public:
   // explicitly check for sensible template arguments

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1133,7 +1133,7 @@ namespace internal
  */
 template <int dim, int spacedim = dim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-class Triangulation : public Subscriptor
+class Triangulation : public virtual Subscriptor
 {
 private:
   /**

--- a/include/deal.II/hp/collection.h
+++ b/include/deal.II/hp/collection.h
@@ -178,7 +178,7 @@ namespace hp
    * @ingroup hp hpcollection
    */
   template <typename T>
-  class Collection : public Subscriptor
+  class Collection : public virtual Subscriptor
   {
   public:
     /**

--- a/include/deal.II/hp/fe_values.h
+++ b/include/deal.II/hp/fe_values.h
@@ -65,7 +65,7 @@ namespace hp
    * @ingroup hp
    */
   template <int dim, int q_dim, class FEValuesType>
-  class FEValuesBase : public Subscriptor
+  class FEValuesBase : public virtual Subscriptor
   {
   public:
     /**

--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -511,7 +511,7 @@ namespace internal
  * @ingroup constraints
  */
 template <typename number = double>
-class AffineConstraints : public Subscriptor
+class AffineConstraints : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/lac/arpack_solver.h
+++ b/include/deal.II/lac/arpack_solver.h
@@ -164,7 +164,7 @@ dseupd_(int *         rvec,
  * @ref step_36 "step-36"
  * for an example.
  */
-class ArpackSolver : public Subscriptor
+class ArpackSolver : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/lac/block_indices.h
+++ b/include/deal.II/lac/block_indices.h
@@ -57,7 +57,7 @@ DEAL_II_NAMESPACE_OPEN
  * @see
  * @ref GlossBlockLA "Block (linear algebra)"
  */
-class BlockIndices : public Subscriptor
+class BlockIndices : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -348,7 +348,7 @@ namespace BlockMatrixIterators
  * @ref GlossBlockLA "Block (linear algebra)"
  */
 template <typename MatrixType>
-class BlockMatrixBase : public Subscriptor
+class BlockMatrixBase : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/lac/block_sparse_matrix_ez.h
+++ b/include/deal.II/lac/block_sparse_matrix_ez.h
@@ -58,7 +58,7 @@ class BlockVector;
  * @ref GlossBlockLA "Block (linear algebra)"
  */
 template <typename Number>
-class BlockSparseMatrixEZ : public Subscriptor
+class BlockSparseMatrixEZ : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -438,7 +438,7 @@ namespace internal
  * @ref GlossBlockLA "Block (linear algebra)"
  */
 template <class VectorType>
-class BlockVectorBase : public Subscriptor
+class BlockVectorBase : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/lac/chunk_sparsity_pattern.h
+++ b/include/deal.II/lac/chunk_sparsity_pattern.h
@@ -242,7 +242,7 @@ namespace ChunkSparsityPatternIterators
  *
  * The use of this class is demonstrated in step-51.
  */
-class ChunkSparsityPattern : public Subscriptor
+class ChunkSparsityPattern : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/lac/diagonal_matrix.h
+++ b/include/deal.II/lac/diagonal_matrix.h
@@ -59,7 +59,7 @@ namespace LinearAlgebra
  * @endcode
  */
 template <typename VectorType = Vector<double>>
-class DiagonalMatrix : public Subscriptor
+class DiagonalMatrix : public virtual Subscriptor
 {
 public:
   using value_type = typename VectorType::value_type;

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -248,7 +248,7 @@ namespace LinearAlgebra
      */
     template <typename Number, typename MemorySpace = MemorySpace::Host>
     class Vector : public ::dealii::LinearAlgebra::VectorSpaceVector<Number>,
-                   public Subscriptor
+                   public virtual Subscriptor
     {
     public:
       using memory_space    = MemorySpace;

--- a/include/deal.II/lac/lapack_full_matrix.h
+++ b/include/deal.II/lac/lapack_full_matrix.h
@@ -1005,7 +1005,7 @@ private:
  * @ingroup Preconditioners
  */
 template <typename number>
-class PreconditionLU : public Subscriptor
+class PreconditionLU : public virtual Subscriptor
 {
 public:
   void

--- a/include/deal.II/lac/matrix_block.h
+++ b/include/deal.II/lac/matrix_block.h
@@ -108,7 +108,7 @@ namespace internal
  * @ref GlossBlockLA "Block (linear algebra)"
  */
 template <typename MatrixType>
-class MatrixBlock : public Subscriptor
+class MatrixBlock : public virtual Subscriptor
 {
 public:
   /**
@@ -438,7 +438,7 @@ public:
  * @ingroup vector_valued
  */
 template <typename MatrixType>
-class MGMatrixBlockVector : public Subscriptor
+class MGMatrixBlockVector : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/lac/parpack_solver.h
+++ b/include/deal.II/lac/parpack_solver.h
@@ -208,7 +208,7 @@ extern "C"
  * PARPACK manual.
  */
 template <typename VectorType>
-class PArpackSolver : public Subscriptor
+class PArpackSolver : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -281,7 +281,7 @@ namespace PETScWrappers
    * @ingroup PETScWrappers
    * @ingroup Matrix1
    */
-  class MatrixBase : public Subscriptor
+  class MatrixBase : public virtual Subscriptor
   {
   public:
     /**

--- a/include/deal.II/lac/petsc_precondition.h
+++ b/include/deal.II/lac/petsc_precondition.h
@@ -57,7 +57,7 @@ namespace PETScWrappers
    *
    * @ingroup PETScWrappers
    */
-  class PreconditionBase : public Subscriptor
+  class PreconditionBase : public virtual Subscriptor
   {
   public:
     /**

--- a/include/deal.II/lac/petsc_snes.h
+++ b/include/deal.II/lac/petsc_snes.h
@@ -170,7 +170,7 @@ namespace PETScWrappers
    * methods:
    *
    * @code
-   * class VectorType : public Subscriptor
+   * class VectorType : public virtual Subscriptor
    *    ...
    *    explicit VectorType(Vec);
    *    ...
@@ -179,7 +179,7 @@ namespace PETScWrappers
    * @endcode
    *
    * @code
-   * class MatrixType : public Subscriptor
+   * class MatrixType : public virtual Subscriptor
    *    ...
    *    explicit MatrixType(Mat);
    *    ...

--- a/include/deal.II/lac/petsc_ts.h
+++ b/include/deal.II/lac/petsc_ts.h
@@ -228,7 +228,7 @@ namespace PETScWrappers
    * methods:
    *
    * @code
-   * class VectorType : public Subscriptor
+   * class VectorType : public virtual Subscriptor
    *    ...
    *    explicit VectorType(Vec);
    *    ...
@@ -237,7 +237,7 @@ namespace PETScWrappers
    * @endcode
    *
    * @code
-   * class MatrixType : public Subscriptor
+   * class MatrixType : public virtual Subscriptor
    *    ...
    *    explicit MatrixType(Mat);
    *    ...

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -247,7 +247,7 @@ namespace PETScWrappers
    *
    * @ingroup PETScWrappers
    */
-  class VectorBase : public Subscriptor
+  class VectorBase : public virtual Subscriptor
   {
   public:
     /**

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -80,7 +80,7 @@ namespace LinearAlgebra
  * Alternatively, the IdentityMatrix class can be used to precondition in this
  * way.
  */
-class PreconditionIdentity : public Subscriptor
+class PreconditionIdentity : public virtual Subscriptor
 {
 public:
   /**
@@ -195,7 +195,7 @@ private:
  * multiplied. Still, this class is useful in multigrid smoother objects
  * (MGSmootherRelaxation).
  */
-class PreconditionRichardson : public Subscriptor
+class PreconditionRichardson : public virtual Subscriptor
 {
 public:
   /**
@@ -359,7 +359,7 @@ private:
  */
 template <typename MatrixType = SparseMatrix<double>,
           class VectorType    = Vector<double>>
-class PreconditionUseMatrix : public Subscriptor
+class PreconditionUseMatrix : public virtual Subscriptor
 {
 public:
   /**
@@ -403,7 +403,7 @@ private:
  */
 template <typename MatrixType         = SparseMatrix<double>,
           typename PreconditionerType = IdentityMatrix>
-class PreconditionRelaxation : public Subscriptor
+class PreconditionRelaxation : public virtual Subscriptor
 {
 public:
   /**
@@ -1929,7 +1929,7 @@ public:
 template <typename MatrixType         = SparseMatrix<double>,
           typename VectorType         = Vector<double>,
           typename PreconditionerType = DiagonalMatrix<VectorType>>
-class PreconditionChebyshev : public Subscriptor
+class PreconditionChebyshev : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/lac/precondition_selector.h
+++ b/include/deal.II/lac/precondition_selector.h
@@ -98,7 +98,7 @@ class SparseMatrix;
  */
 template <typename MatrixType = SparseMatrix<double>,
           typename VectorType = dealii::Vector<double>>
-class PreconditionSelector : public Subscriptor
+class PreconditionSelector : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -133,7 +133,7 @@ namespace LinearAlgebra
    * get the first index of the largest range.
    */
   template <typename Number>
-  class ReadWriteVector : public Subscriptor
+  class ReadWriteVector : public virtual Subscriptor
   {
   public:
     /**

--- a/include/deal.II/lac/relaxation_block.h
+++ b/include/deal.II/lac/relaxation_block.h
@@ -78,7 +78,7 @@ public:
    * structure in #block_list and an optional ordering of the blocks in
    * #order.
    */
-  class AdditionalData : public Subscriptor
+  class AdditionalData : public virtual Subscriptor
   {
   public:
     /**

--- a/include/deal.II/lac/solver.h
+++ b/include/deal.II/lac/solver.h
@@ -337,7 +337,7 @@ class Vector;
  * @ingroup Solvers
  */
 template <class VectorType = Vector<double>>
-class SolverBase : public Subscriptor
+class SolverBase : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/lac/solver_control.h
+++ b/include/deal.II/lac/solver_control.h
@@ -64,7 +64,7 @@ class ParameterHandler;
  * number of iterations.
  * </ul>
  */
-class SolverControl : public Subscriptor
+class SolverControl : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/lac/solver_selector.h
+++ b/include/deal.II/lac/solver_selector.h
@@ -88,7 +88,7 @@ DEAL_II_NAMESPACE_OPEN
  * access to that new solver.
  */
 template <typename VectorType = Vector<double>>
-class SolverSelector : public Subscriptor
+class SolverSelector : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/lac/sparse_direct.h
+++ b/include/deal.II/lac/sparse_direct.h
@@ -84,7 +84,7 @@ namespace types
  *
  * @ingroup Solvers Preconditioners
  */
-class SparseDirectUMFPACK : public Subscriptor
+class SparseDirectUMFPACK : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/lac/sparse_matrix_ez.h
+++ b/include/deal.II/lac/sparse_matrix_ez.h
@@ -101,7 +101,7 @@ class FullMatrix;
  *   where "EZ" is pronounced the same way as the word "easy".
  */
 template <typename number>
-class SparseMatrixEZ : public Subscriptor
+class SparseMatrixEZ : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/lac/sparsity_pattern_base.h
+++ b/include/deal.II/lac/sparsity_pattern_base.h
@@ -36,7 +36,7 @@ DEAL_II_NAMESPACE_OPEN
  * Base class for all sparsity patterns, defining a common interface by which
  * new values can be added.
  */
-class SparsityPatternBase : public Subscriptor
+class SparsityPatternBase : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/lac/trilinos_epetra_vector.h
+++ b/include/deal.II/lac/trilinos_epetra_vector.h
@@ -61,7 +61,7 @@ namespace LinearAlgebra
      * @ingroup TrilinosWrappers
      * @ingroup Vectors
      */
-    class Vector : public VectorSpaceVector<double>, public Subscriptor
+    class Vector : public VectorSpaceVector<double>, public virtual Subscriptor
     {
     public:
       /**

--- a/include/deal.II/lac/trilinos_precondition.h
+++ b/include/deal.II/lac/trilinos_precondition.h
@@ -74,7 +74,7 @@ namespace TrilinosWrappers
    * @ingroup TrilinosWrappers
    * @ingroup Preconditioners
    */
-  class PreconditionBase : public Subscriptor
+  class PreconditionBase : public virtual Subscriptor
   {
   public:
     /**

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -547,7 +547,7 @@ namespace TrilinosWrappers
    * @ingroup TrilinosWrappers
    * @ingroup Matrix1
    */
-  class SparseMatrix : public Subscriptor
+  class SparseMatrix : public virtual Subscriptor
   {
   public:
     /**

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -113,7 +113,7 @@ namespace LinearAlgebra
      * @ingroup Vectors
      */
     template <typename Number>
-    class Vector : public VectorSpaceVector<Number>, public Subscriptor
+    class Vector : public VectorSpaceVector<Number>, public virtual Subscriptor
     {
     public:
       using value_type = Number;

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -394,7 +394,7 @@ namespace TrilinosWrappers
      * @ingroup TrilinosWrappers
      * @ingroup Vectors
      */
-    class Vector : public Subscriptor
+    class Vector : public virtual Subscriptor
     {
     public:
       /**

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -105,7 +105,7 @@ namespace parallel
  * in the manual).
  */
 template <typename Number>
-class Vector : public Subscriptor
+class Vector : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/lac/vector_memory.h
+++ b/include/deal.II/lac/vector_memory.h
@@ -103,7 +103,7 @@ DEAL_II_NAMESPACE_OPEN
  * <i>always</i> returned.
  */
 template <typename VectorType = dealii::Vector<double>>
-class VectorMemory : public Subscriptor
+class VectorMemory : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -91,7 +91,7 @@ namespace CUDAWrappers
    * @ingroup CUDAWrappers
    */
   template <int dim, typename Number = double>
-  class MatrixFree : public Subscriptor
+  class MatrixFree : public virtual Subscriptor
   {
   public:
     using jacobian_type = Tensor<2, dim, Tensor<1, dim, Number>>;

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -110,7 +110,7 @@ DEAL_II_NAMESPACE_OPEN
 template <int dim,
           typename Number              = double,
           typename VectorizedArrayType = VectorizedArray<Number>>
-class MatrixFree : public Subscriptor
+class MatrixFree : public virtual Subscriptor
 {
   static_assert(
     std::is_same<Number, typename VectorizedArrayType::value_type>::value,

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -185,7 +185,7 @@ namespace MatrixFreeOperators
             typename VectorType = LinearAlgebra::distributed::Vector<double>,
             typename VectorizedArrayType =
               VectorizedArray<typename VectorType::value_type>>
-  class Base : public Subscriptor
+  class Base : public virtual Subscriptor
   {
   public:
     /**
@@ -535,7 +535,7 @@ namespace MatrixFreeOperators
    * prolongation phase.
    */
   template <typename OperatorType>
-  class MGInterfaceOperator : public Subscriptor
+  class MGInterfaceOperator : public virtual Subscriptor
   {
   public:
     /**

--- a/include/deal.II/meshworker/local_integrator.h
+++ b/include/deal.II/meshworker/local_integrator.h
@@ -53,7 +53,7 @@ namespace MeshWorker
    * @ingroup MeshWorker
    */
   template <int dim, int spacedim = dim, typename number = double>
-  class LocalIntegrator : public Subscriptor
+  class LocalIntegrator : public virtual Subscriptor
   {
   public:
     /**

--- a/include/deal.II/meshworker/vector_selector.h
+++ b/include/deal.II/meshworker/vector_selector.h
@@ -48,7 +48,7 @@ namespace MeshWorker
    *
    * @ingroup MeshWorker
    */
-  class VectorSelector : public Subscriptor
+  class VectorSelector : public virtual Subscriptor
   {
   public:
     /**

--- a/include/deal.II/multigrid/mg_base.h
+++ b/include/deal.II/multigrid/mg_base.h
@@ -45,7 +45,7 @@ DEAL_II_NAMESPACE_OPEN
  * of matrices, will be sufficient for applications.
  */
 template <typename VectorType>
-class MGMatrixBase : public Subscriptor
+class MGMatrixBase : public virtual Subscriptor
 {
 public:
   /*
@@ -105,7 +105,7 @@ public:
  * will be done by derived classes.
  */
 template <typename VectorType>
-class MGCoarseGridBase : public Subscriptor
+class MGCoarseGridBase : public virtual Subscriptor
 {
 public:
   /**
@@ -169,7 +169,7 @@ public:
  * needed.
  */
 template <typename VectorType>
-class MGTransferBase : public Subscriptor
+class MGTransferBase : public virtual Subscriptor
 {
 public:
   /**
@@ -249,7 +249,7 @@ public:
  * in the vector @p u given the right hand side, which is done by smooth().
  */
 template <typename VectorType>
-class MGSmootherBase : public Subscriptor
+class MGSmootherBase : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/multigrid/mg_constrained_dofs.h
+++ b/include/deal.II/multigrid/mg_constrained_dofs.h
@@ -44,7 +44,7 @@ class DoFHandler;
  *
  * @ingroup mg
  */
-class MGConstrainedDoFs : public Subscriptor
+class MGConstrainedDoFs : public virtual Subscriptor
 {
 public:
   using size_dof = std::vector<std::set<types::global_dof_index>>::size_type;

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.h
@@ -161,7 +161,7 @@ namespace MGTransferGlobalCoarseningTools
  * Abstract base class for transfer operators between two multigrid levels.
  */
 template <typename VectorType>
-class MGTwoLevelTransferBase : public Subscriptor
+class MGTwoLevelTransferBase : public virtual Subscriptor
 {
 public:
   /**
@@ -213,7 +213,7 @@ public:
  */
 template <typename Number>
 class MGTwoLevelTransferBase<LinearAlgebra::distributed::Vector<Number>>
-  : public Subscriptor
+  : public virtual Subscriptor
 {
 public:
   using VectorType = LinearAlgebra::distributed::Vector<Number>;

--- a/include/deal.II/multigrid/multigrid.h
+++ b/include/deal.II/multigrid/multigrid.h
@@ -160,7 +160,7 @@ namespace mg
  * MGTransferBase.
  */
 template <typename VectorType>
-class Multigrid : public Subscriptor
+class Multigrid : public virtual Subscriptor
 {
 public:
   /**
@@ -498,7 +498,7 @@ private:
  * to be initialized with a separate DoFHandler for each block.
  */
 template <int dim, typename VectorType, class TRANSFER>
-class PreconditionMG : public Subscriptor
+class PreconditionMG : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/multigrid/sparse_matrix_collection.h
+++ b/include/deal.II/multigrid/sparse_matrix_collection.h
@@ -39,7 +39,7 @@ namespace mg
    * multigrid with local refinement.
    */
   template <typename number>
-  class SparseMatrixCollection : public Subscriptor
+  class SparseMatrixCollection : public virtual Subscriptor
   {
   public:
     void

--- a/include/deal.II/non_matching/mapping_info.h
+++ b/include/deal.II/non_matching/mapping_info.h
@@ -198,7 +198,7 @@ namespace NonMatching
    * MappingInfo and FEPointEvaluation has to be identical.
    */
   template <int dim, int spacedim = dim, typename Number = double>
-  class MappingInfo : public Subscriptor
+  class MappingInfo : public virtual Subscriptor
   {
   public:
     /**

--- a/include/deal.II/non_matching/mesh_classifier.h
+++ b/include/deal.II/non_matching/mesh_classifier.h
@@ -106,7 +106,7 @@ namespace NonMatching
    * same way as for the discrete level set function.
    */
   template <int dim>
-  class MeshClassifier : public Subscriptor
+  class MeshClassifier : public virtual Subscriptor
   {
   public:
     /**

--- a/include/deal.II/numerics/data_postprocessor.h
+++ b/include/deal.II/numerics/data_postprocessor.h
@@ -581,7 +581,7 @@ namespace DataPostprocessorInputs
  * @ingroup output
  */
 template <int dim>
-class DataPostprocessor : public Subscriptor
+class DataPostprocessor : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/numerics/time_dependent.h
+++ b/include/deal.II/numerics/time_dependent.h
@@ -660,7 +660,7 @@ private:
  * following grids, and some functions to be called before a new loop over all
  * time steps is started.
  */
-class TimeStepBase : public Subscriptor
+class TimeStepBase : public virtual Subscriptor
 {
 public:
   /**

--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -62,7 +62,7 @@ namespace Particles
    * @ingroup Particle
    */
   template <int dim, int spacedim = dim>
-  class ParticleHandler : public Subscriptor
+  class ParticleHandler : public virtual Subscriptor
   {
   public:
     /**

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -1431,39 +1431,29 @@ FESystem<dim, spacedim>::compute_fill(
         // static cast through the common base class:
         if (face_no == invalid_face_number)
           {
-            const Subscriptor *quadrature_base_pointer = &quadrature;
-            Assert(dynamic_cast<const Quadrature<dim> *>(
-                     quadrature_base_pointer) != nullptr,
-                   ExcInternalError());
-
             cell_quadrature =
-              static_cast<const Quadrature<dim> *>(quadrature_base_pointer);
+              dynamic_cast<const Quadrature<dim> *>(&quadrature);
+            Assert(cell_quadrature != nullptr, ExcInternalError());
             n_q_points = cell_quadrature->size();
           }
         else if (sub_no == invalid_face_number)
           {
-            const Subscriptor *quadrature_base_pointer = &quadrature;
-            Assert(dynamic_cast<const hp::QCollection<dim - 1> *>(
-                     quadrature_base_pointer) != nullptr,
-                   ExcInternalError());
-
             // If we don't have wedges or pyramids then there should only be one
             // quadrature rule here
-            face_quadrature = static_cast<const hp::QCollection<dim - 1> *>(
-              quadrature_base_pointer);
+            face_quadrature =
+              dynamic_cast<const hp::QCollection<dim - 1> *>(&quadrature);
+            Assert(face_quadrature != nullptr, ExcInternalError());
+
             n_q_points =
               (*face_quadrature)[face_quadrature->size() == 1 ? 0 : face_no]
                 .size();
           }
         else
           {
-            const Subscriptor *quadrature_base_pointer = &quadrature;
-            Assert(dynamic_cast<const Quadrature<dim - 1> *>(
-                     quadrature_base_pointer) != nullptr,
-                   ExcInternalError());
-
             sub_face_quadrature =
-              static_cast<const Quadrature<dim - 1> *>(quadrature_base_pointer);
+              dynamic_cast<const Quadrature<dim - 1> *>(&quadrature);
+            Assert(sub_face_quadrature != nullptr, ExcInternalError());
+
             n_q_points = sub_face_quadrature->size();
           }
         Assert(n_q_points != numbers::invalid_unsigned_int, ExcInternalError());


### PR DESCRIPTION
This fixes a long standing defect in the library: It is currently not possible to use a SmartPointer with an object that inherits from two classes that itself have inherited from the Subscriptor class:
```
class Foo : public Subscriptor { };
class Bar : public Subscriptor { };
class FooBar : public Foo, public Bar { };
```
This leads to the following inheritance diagram:
```
    FooBar
      /\
     /  \
    /    \
 Foo      Bar
   |      |
   |      |
   |      |
Subscr.  Subscr.
```
This unfortunately means that `FooBar` cannot be used with our `SmartPointer` because there is no single `Subscriptor` base class available.

The solution is to use virtual inheritance to create a diamond shaped inheritance:
```
   FooBar
     /\
    /  \
   /    \
Foo      Bar
   \    /
    \  /
     \/
 Subscriptor
```
by using virtual inheritance
```
class Foo : public virtual Subscriptor { };
class Bar : public virtual Subscriptor { };
class FooBar : public Foo, public Bar { };
```