### PR TITLE
Avoid unnecessary reinitialization.

### DIFF
--- a/examples/step-26/step-26.cc
+++ b/examples/step-26/step-26.cc
@@ -567,9 +567,6 @@ namespace Step26
                           n_adaptive_pre_refinement_steps);
             ++pre_refinement_step;
 
-            tmp.reinit(solution.size());
-            forcing_terms.reinit(solution.size());
-
             std::cout << std::endl;
 
             goto start_time_iteration;


### PR DESCRIPTION
The code here reinitializes two vectors, and then performs a `goto` to a label after which the two vectors are reinitialized:
https://github.com/dealii/dealii/blob/master/examples/step-26/step-26.cc#L453-L459
That is duplicative. We need it after the label, so we can drop it before the `goto`.