### PR TITLE
Use pinned memory when MPI is not GPU aware

### DIFF
--- a/include/deal.II/base/memory_space_data.h
+++ b/include/deal.II/base/memory_space_data.h
@@ -64,7 +64,11 @@ namespace MemorySpace
      * Kokkos View owning a host buffer used for MPI communication.
      */
     // FIXME Should we move this somewhere else?
+#if KOKKOS_VERSION < 40000
     Kokkos::View<T *, Kokkos::HostSpace> values_host_buffer;
+#else
+    Kokkos::View<T *, Kokkos::SharedHostPinnedSpace> values_host_buffer;
+#endif
 
     /**
      * Kokkos View owning the data on the @ref GlossDevice "device" (unless @p values_sm_ptr is used).
@@ -105,7 +109,12 @@ namespace MemorySpace
   MemorySpaceData<T, MemorySpace>::MemorySpaceData()
     : values_host_buffer(
         (dealii::internal::ensure_kokkos_initialized(),
+#  if KOKKOS_VERSION < 40000
          Kokkos::View<T *, Kokkos::HostSpace>("host buffer", 0)))
+#  else
+         Kokkos::View<T *, Kokkos::SharedHostPinnedSpace>("host pinned buffer",
+                                                          0)))
+#  endif
     , values(Kokkos::View<T *, typename MemorySpace::kokkos_space>(
         "memoryspace data",
         0))


### PR DESCRIPTION
Using pinned memory  instead of "regular" memory makes the transfer to host much faster. In some cases it's faster to use MPI + pinned memory instead of using GPU-aware MPI.