### PR TITLE
Standardize on 'typename VectorType'.

### DIFF
--- a/include/deal.II/fe/fe_tools_extrapolate.templates.h
+++ b/include/deal.II/fe/fe_tools_extrapolate.templates.h
@@ -1458,23 +1458,23 @@ namespace FETools
     }
 #endif // DEAL_II_WITH_P4EST
 
-    template <class VectorType, typename dummy = void>
+    template <typename VectorType, typename dummy = void>
     struct BlockTypeHelper
     {
       using type = VectorType;
     };
 
-    template <class VectorType>
+    template <typename VectorType>
     struct BlockTypeHelper<VectorType,
                            std::enable_if_t<IsBlockVector<VectorType>::value>>
     {
       using type = typename VectorType::BlockType;
     };
 
-    template <class VectorType>
+    template <typename VectorType>
     using BlockType = typename BlockTypeHelper<VectorType>::type;
 
-    template <class VectorType, class DH>
+    template <typename VectorType, class DH>
     void
     reinit_distributed(const DH &dh, VectorType &vector)
     {
@@ -1568,7 +1568,7 @@ namespace FETools
 
 
 
-    template <class VectorType, class DH>
+    template <typename VectorType, class DH>
     void
     reinit_ghosted(const DH & /*dh*/, VectorType & /*vector*/)
     {

--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -410,7 +410,7 @@ namespace internal
 {
   namespace AffineConstraintsImplementation
   {
-    template <class VectorType>
+    template <typename VectorType>
     void
     set_zero_all(const std::vector<types::global_dof_index> &cm,
                  VectorType &                                vec);
@@ -1089,7 +1089,7 @@ public:
    * @note This function does not work for MPI vectors. Use condense() with
    * two vector arguments instead.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   condense(VectorType &vec) const;
 
@@ -1099,7 +1099,7 @@ public:
    * called in parallel, @p vec_ghosted is supposed to contain ghost elements
    * while @p output should not.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   condense(const VectorType &vec_ghosted, VectorType &output) const;
 
@@ -1115,7 +1115,7 @@ public:
    * See the general documentation of this class for more detailed
    * information.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   condense(SparseMatrix<number> &matrix, VectorType &vector) const;
 
@@ -1123,7 +1123,7 @@ public:
    * Same function as above, but condenses square block sparse matrices and
    * vectors.
    */
-  template <class BlockVectorType>
+  template <typename BlockVectorType>
   void
   condense(BlockSparseMatrix<number> &matrix, BlockVectorType &vector) const;
 
@@ -1133,7 +1133,7 @@ public:
    * BlockVector<tt><...></tt>, a PETSc or Trilinos vector wrapper class, or
    * any other type having the same interface.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   set_zero(VectorType &vec) const;
 
@@ -1284,7 +1284,7 @@ public:
   /**
    * Enter a single value into a result vector, obeying constraints.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   distribute_local_to_global(const size_type index,
                              const number    value,
@@ -1324,7 +1324,7 @@ public:
    */
   template <typename ForwardIteratorVec,
             typename ForwardIteratorInd,
-            class VectorType>
+            typename VectorType>
   void
   distribute_local_to_global(ForwardIteratorVec local_vector_begin,
                              ForwardIteratorVec local_vector_end,
@@ -1580,7 +1580,7 @@ public:
    */
   template <typename ForwardIteratorVec,
             typename ForwardIteratorInd,
-            class VectorType>
+            typename VectorType>
   void
   get_dof_values(const VectorType & global_vector,
                  ForwardIteratorInd local_indices_begin,
@@ -1608,7 +1608,7 @@ public:
    * @note If this function is called with a parallel vector @p vec, then the
    * vector must not contain ghost elements.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   distribute(VectorType &vec) const;
 
@@ -2136,7 +2136,7 @@ AffineConstraints<number>::set_inhomogeneity(
 
 
 template <typename number>
-template <class VectorType>
+template <typename VectorType>
 inline void
 AffineConstraints<number>::set_zero(VectorType &vec) const
 {
@@ -2268,7 +2268,7 @@ AffineConstraints<number>::get_local_lines() const
 }
 
 template <typename number>
-template <class VectorType>
+template <typename VectorType>
 inline void
 AffineConstraints<number>::distribute_local_to_global(
   const size_type index,
@@ -2292,7 +2292,7 @@ AffineConstraints<number>::distribute_local_to_global(
 template <typename number>
 template <typename ForwardIteratorVec,
           typename ForwardIteratorInd,
-          class VectorType>
+          typename VectorType>
 inline void
 AffineConstraints<number>::distribute_local_to_global(
   ForwardIteratorVec local_vector_begin,
@@ -2340,7 +2340,7 @@ AffineConstraints<number>::distribute_local_to_global(
 template <typename number>
 template <typename ForwardIteratorVec,
           typename ForwardIteratorInd,
-          class VectorType>
+          typename VectorType>
 inline void
 AffineConstraints<number>::get_dof_values(
   const VectorType & global_vector,

--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -1761,7 +1761,7 @@ AffineConstraints<number>::condense(
 
 
 template <typename number>
-template <class VectorType>
+template <typename VectorType>
 void
 AffineConstraints<number>::condense(const VectorType &vec_ghosted,
                                     VectorType &      vec) const
@@ -1806,7 +1806,7 @@ AffineConstraints<number>::condense(const VectorType &vec_ghosted,
 
 
 template <typename number>
-template <class VectorType>
+template <typename VectorType>
 void
 AffineConstraints<number>::condense(VectorType &vec) const
 {
@@ -1816,7 +1816,7 @@ AffineConstraints<number>::condense(VectorType &vec) const
 
 
 template <typename number>
-template <class VectorType>
+template <typename VectorType>
 void
 AffineConstraints<number>::condense(SparseMatrix<number> &uncondensed,
                                     VectorType &          vec) const
@@ -1989,7 +1989,7 @@ AffineConstraints<number>::condense(SparseMatrix<number> &uncondensed,
 
 
 template <typename number>
-template <class BlockVectorType>
+template <typename BlockVectorType>
 void
 AffineConstraints<number>::condense(BlockSparseMatrix<number> &uncondensed,
                                     BlockVectorType &          vec) const
@@ -2185,7 +2185,7 @@ namespace internal
   {
     using size_type = types::global_dof_index;
 
-    template <class VectorType>
+    template <typename VectorType>
     void
     set_zero_parallel(const std::vector<size_type> &cm,
                       VectorType &                  vec,
@@ -2272,7 +2272,7 @@ namespace internal
       vec.zero_out_ghost_values();
     }
 
-    template <class VectorType>
+    template <typename VectorType>
     void
     set_zero_in_parallel(const std::vector<size_type> &cm,
                          VectorType &                  vec,
@@ -2282,7 +2282,7 @@ namespace internal
     }
 
     // in parallel for BlockVectors
-    template <class VectorType>
+    template <typename VectorType>
     void
     set_zero_in_parallel(const std::vector<size_type> &cm,
                          VectorType &                  vec,
@@ -2296,7 +2296,7 @@ namespace internal
         }
     }
 
-    template <class VectorType>
+    template <typename VectorType>
     void
     set_zero_serial(const std::vector<size_type> &cm, VectorType &vec)
     {
@@ -2304,7 +2304,7 @@ namespace internal
         vec(index) = 0.;
     }
 
-    template <class VectorType>
+    template <typename VectorType>
     void
     set_zero_all(const std::vector<size_type> &cm, VectorType &vec)
     {
@@ -2535,7 +2535,7 @@ namespace internal
   }
 
   // for block vectors, simply dispatch to the individual blocks
-  template <class VectorType>
+  template <typename VectorType>
   void
   import_vector_with_ghost_elements(
     const VectorType &vec,
@@ -2565,7 +2565,7 @@ namespace internal
 } // namespace internal
 
 template <typename number>
-template <class VectorType>
+template <typename VectorType>
 void
 AffineConstraints<number>::distribute(VectorType &vec) const
 {

--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -671,7 +671,7 @@ public:
    * Adding Matrix-vector multiplication. Add $M*src$ on $dst$ with $M$ being
    * this matrix.
    */
-  template <class BlockVectorType>
+  template <typename BlockVectorType>
   void
   vmult_add(BlockVectorType &dst, const BlockVectorType &src) const;
 
@@ -680,7 +680,7 @@ public:
    * <i>dst</i> with <i>M</i> being this matrix. This function does the same
    * as vmult_add() but takes the transposed matrix.
    */
-  template <class BlockVectorType>
+  template <typename BlockVectorType>
   void
   Tvmult_add(BlockVectorType &dst, const BlockVectorType &src) const;
 
@@ -696,7 +696,7 @@ public:
    *
    * Obviously, the matrix needs to be square for this operation.
    */
-  template <class BlockVectorType>
+  template <typename BlockVectorType>
   value_type
   matrix_norm_square(const BlockVectorType &v) const;
 
@@ -710,7 +710,7 @@ public:
   /**
    * Compute the matrix scalar product $\left(u,Mv\right)$.
    */
-  template <class BlockVectorType>
+  template <typename BlockVectorType>
   value_type
   matrix_scalar_product(const BlockVectorType &u,
                         const BlockVectorType &v) const;
@@ -718,7 +718,7 @@ public:
   /**
    * Compute the residual <i>r=b-Ax</i>. Write the residual into <tt>dst</tt>.
    */
-  template <class BlockVectorType>
+  template <typename BlockVectorType>
   value_type
   residual(BlockVectorType &      dst,
            const BlockVectorType &x,
@@ -884,7 +884,7 @@ protected:
    * calls to the implementations provided here under a unique name for which
    * template arguments can be derived by the compiler.
    */
-  template <class BlockVectorType>
+  template <typename BlockVectorType>
   void
   vmult_block_block(BlockVectorType &dst, const BlockVectorType &src) const;
 
@@ -898,7 +898,7 @@ protected:
    * calls to the implementations provided here under a unique name for which
    * template arguments can be derived by the compiler.
    */
-  template <class BlockVectorType, class VectorType>
+  template <typename BlockVectorType, typename VectorType>
   void
   vmult_block_nonblock(BlockVectorType &dst, const VectorType &src) const;
 
@@ -912,7 +912,7 @@ protected:
    * calls to the implementations provided here under a unique name for which
    * template arguments can be derived by the compiler.
    */
-  template <class BlockVectorType, class VectorType>
+  template <typename BlockVectorType, typename VectorType>
   void
   vmult_nonblock_block(VectorType &dst, const BlockVectorType &src) const;
 
@@ -926,7 +926,7 @@ protected:
    * calls to the implementations provided here under a unique name for which
    * template arguments can be derived by the compiler.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   vmult_nonblock_nonblock(VectorType &dst, const VectorType &src) const;
 
@@ -941,7 +941,7 @@ protected:
    * calls to the implementations provided here under a unique name for which
    * template arguments can be derived by the compiler.
    */
-  template <class BlockVectorType>
+  template <typename BlockVectorType>
   void
   Tvmult_block_block(BlockVectorType &dst, const BlockVectorType &src) const;
 
@@ -955,7 +955,7 @@ protected:
    * calls to the implementations provided here under a unique name for which
    * template arguments can be derived by the compiler.
    */
-  template <class BlockVectorType, class VectorType>
+  template <typename BlockVectorType, typename VectorType>
   void
   Tvmult_block_nonblock(BlockVectorType &dst, const VectorType &src) const;
 
@@ -969,7 +969,7 @@ protected:
    * calls to the implementations provided here under a unique name for which
    * template arguments can be derived by the compiler.
    */
-  template <class BlockVectorType, class VectorType>
+  template <typename BlockVectorType, typename VectorType>
   void
   Tvmult_nonblock_block(VectorType &dst, const BlockVectorType &src) const;
 
@@ -983,7 +983,7 @@ protected:
    * calls to the implementations provided here under a unique name for which
    * template arguments can be derived by the compiler.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   Tvmult_nonblock_nonblock(VectorType &dst, const VectorType &src) const;
 
@@ -2207,7 +2207,7 @@ BlockMatrixBase<MatrixType>::get_column_indices() const
 
 
 template <class MatrixType>
-template <class BlockVectorType>
+template <typename BlockVectorType>
 void
 BlockMatrixBase<MatrixType>::vmult_block_block(BlockVectorType &      dst,
                                                const BlockVectorType &src) const
@@ -2228,7 +2228,7 @@ BlockMatrixBase<MatrixType>::vmult_block_block(BlockVectorType &      dst,
 
 
 template <class MatrixType>
-template <class BlockVectorType, class VectorType>
+template <typename BlockVectorType, typename VectorType>
 void
 BlockMatrixBase<MatrixType>::vmult_nonblock_block(
   VectorType &           dst,
@@ -2246,7 +2246,7 @@ BlockMatrixBase<MatrixType>::vmult_nonblock_block(
 
 
 template <class MatrixType>
-template <class BlockVectorType, class VectorType>
+template <typename BlockVectorType, typename VectorType>
 void
 BlockMatrixBase<MatrixType>::vmult_block_nonblock(BlockVectorType & dst,
                                                   const VectorType &src) const
@@ -2262,7 +2262,7 @@ BlockMatrixBase<MatrixType>::vmult_block_nonblock(BlockVectorType & dst,
 
 
 template <class MatrixType>
-template <class VectorType>
+template <typename VectorType>
 void
 BlockMatrixBase<MatrixType>::vmult_nonblock_nonblock(
   VectorType &      dst,
@@ -2277,7 +2277,7 @@ BlockMatrixBase<MatrixType>::vmult_nonblock_nonblock(
 
 
 template <class MatrixType>
-template <class BlockVectorType>
+template <typename BlockVectorType>
 void
 BlockMatrixBase<MatrixType>::vmult_add(BlockVectorType &      dst,
                                        const BlockVectorType &src) const
@@ -2295,7 +2295,7 @@ BlockMatrixBase<MatrixType>::vmult_add(BlockVectorType &      dst,
 
 
 template <class MatrixType>
-template <class BlockVectorType>
+template <typename BlockVectorType>
 void
 BlockMatrixBase<MatrixType>::Tvmult_block_block(
   BlockVectorType &      dst,
@@ -2318,7 +2318,7 @@ BlockMatrixBase<MatrixType>::Tvmult_block_block(
 
 
 template <class MatrixType>
-template <class BlockVectorType, class VectorType>
+template <typename BlockVectorType, typename VectorType>
 void
 BlockMatrixBase<MatrixType>::Tvmult_block_nonblock(BlockVectorType & dst,
                                                    const VectorType &src) const
@@ -2336,7 +2336,7 @@ BlockMatrixBase<MatrixType>::Tvmult_block_nonblock(BlockVectorType & dst,
 
 
 template <class MatrixType>
-template <class BlockVectorType, class VectorType>
+template <typename BlockVectorType, typename VectorType>
 void
 BlockMatrixBase<MatrixType>::Tvmult_nonblock_block(
   VectorType &           dst,
@@ -2355,7 +2355,7 @@ BlockMatrixBase<MatrixType>::Tvmult_nonblock_block(
 
 
 template <class MatrixType>
-template <class VectorType>
+template <typename VectorType>
 void
 BlockMatrixBase<MatrixType>::Tvmult_nonblock_nonblock(
   VectorType &      dst,
@@ -2370,7 +2370,7 @@ BlockMatrixBase<MatrixType>::Tvmult_nonblock_nonblock(
 
 
 template <class MatrixType>
-template <class BlockVectorType>
+template <typename BlockVectorType>
 void
 BlockMatrixBase<MatrixType>::Tvmult_add(BlockVectorType &      dst,
                                         const BlockVectorType &src) const
@@ -2388,7 +2388,7 @@ BlockMatrixBase<MatrixType>::Tvmult_add(BlockVectorType &      dst,
 
 
 template <class MatrixType>
-template <class BlockVectorType>
+template <typename BlockVectorType>
 typename BlockMatrixBase<MatrixType>::value_type
 BlockMatrixBase<MatrixType>::matrix_norm_square(const BlockVectorType &v) const
 {
@@ -2432,7 +2432,7 @@ BlockMatrixBase<MatrixType>::frobenius_norm() const
 
 
 template <class MatrixType>
-template <class BlockVectorType>
+template <typename BlockVectorType>
 typename BlockMatrixBase<MatrixType>::value_type
 BlockMatrixBase<MatrixType>::matrix_scalar_product(
   const BlockVectorType &u,
@@ -2454,7 +2454,7 @@ BlockMatrixBase<MatrixType>::matrix_scalar_product(
 
 
 template <class MatrixType>
-template <class BlockVectorType>
+template <typename BlockVectorType>
 typename BlockMatrixBase<MatrixType>::value_type
 BlockMatrixBase<MatrixType>::residual(BlockVectorType &      dst,
                                       const BlockVectorType &x,

--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -59,7 +59,7 @@ namespace BlockMatrixIterators
    * Base class for block matrix accessors, implementing the stepping through
    * a matrix.
    */
-  template <class BlockMatrixType>
+  template <typename BlockMatrixType>
   class AccessorBase
   {
   public:
@@ -111,14 +111,14 @@ namespace BlockMatrixIterators
   /**
    * Accessor classes in block matrices.
    */
-  template <class BlockMatrixType, bool Constness>
+  template <typename BlockMatrixType, bool Constness>
   class Accessor;
 
 
   /**
    * Block matrix accessor for non const matrices.
    */
-  template <class BlockMatrixType>
+  template <typename BlockMatrixType>
   class Accessor<BlockMatrixType, false> : public AccessorBase<BlockMatrixType>
   {
   public:
@@ -203,7 +203,7 @@ namespace BlockMatrixIterators
    * Block matrix accessor for constant matrices, implementing the stepping
    * through a matrix.
    */
-  template <class BlockMatrixType>
+  template <typename BlockMatrixType>
   class Accessor<BlockMatrixType, true> : public AccessorBase<BlockMatrixType>
   {
   public:
@@ -401,7 +401,7 @@ public:
    *
    * The function returns a reference to <tt>this</tt>.
    */
-  template <class BlockMatrixType>
+  template <typename BlockMatrixType>
   BlockMatrixBase &
   copy_from(const BlockMatrixType &source);
 
@@ -1083,14 +1083,14 @@ private:
 
 namespace BlockMatrixIterators
 {
-  template <class BlockMatrixType>
+  template <typename BlockMatrixType>
   inline AccessorBase<BlockMatrixType>::AccessorBase()
     : row_block(0)
     , col_block(0)
   {}
 
 
-  template <class BlockMatrixType>
+  template <typename BlockMatrixType>
   inline unsigned int
   AccessorBase<BlockMatrixType>::block_row() const
   {
@@ -1100,7 +1100,7 @@ namespace BlockMatrixIterators
   }
 
 
-  template <class BlockMatrixType>
+  template <typename BlockMatrixType>
   inline unsigned int
   AccessorBase<BlockMatrixType>::block_column() const
   {
@@ -1110,7 +1110,7 @@ namespace BlockMatrixIterators
   }
 
 
-  template <class BlockMatrixType>
+  template <typename BlockMatrixType>
   inline Accessor<BlockMatrixType, true>::Accessor(
     const BlockMatrixType *matrix,
     const size_type        row,
@@ -1161,7 +1161,7 @@ namespace BlockMatrixIterators
   }
 
 
-  //   template <class BlockMatrixType>
+  //   template <typename BlockMatrixType>
   //   inline
   //   Accessor<BlockMatrixType, true>::Accessor (const
   //   Accessor<BlockMatrixType, true>& other)
@@ -1174,7 +1174,7 @@ namespace BlockMatrixIterators
   //   }
 
 
-  template <class BlockMatrixType>
+  template <typename BlockMatrixType>
   inline Accessor<BlockMatrixType, true>::Accessor(
     const Accessor<BlockMatrixType, false> &other)
     : matrix(other.matrix)
@@ -1185,7 +1185,7 @@ namespace BlockMatrixIterators
   }
 
 
-  template <class BlockMatrixType>
+  template <typename BlockMatrixType>
   inline typename Accessor<BlockMatrixType, true>::size_type
   Accessor<BlockMatrixType, true>::row() const
   {
@@ -1197,7 +1197,7 @@ namespace BlockMatrixIterators
   }
 
 
-  template <class BlockMatrixType>
+  template <typename BlockMatrixType>
   inline typename Accessor<BlockMatrixType, true>::size_type
   Accessor<BlockMatrixType, true>::column() const
   {
@@ -1209,7 +1209,7 @@ namespace BlockMatrixIterators
   }
 
 
-  template <class BlockMatrixType>
+  template <typename BlockMatrixType>
   inline typename Accessor<BlockMatrixType, true>::value_type
   Accessor<BlockMatrixType, true>::value() const
   {
@@ -1223,7 +1223,7 @@ namespace BlockMatrixIterators
 
 
 
-  template <class BlockMatrixType>
+  template <typename BlockMatrixType>
   inline void
   Accessor<BlockMatrixType, true>::advance()
   {
@@ -1289,7 +1289,7 @@ namespace BlockMatrixIterators
   }
 
 
-  template <class BlockMatrixType>
+  template <typename BlockMatrixType>
   inline bool
   Accessor<BlockMatrixType, true>::operator==(const Accessor &a) const
   {
@@ -1311,7 +1311,7 @@ namespace BlockMatrixIterators
   //----------------------------------------------------------------------//
 
 
-  template <class BlockMatrixType>
+  template <typename BlockMatrixType>
   inline Accessor<BlockMatrixType, false>::Accessor(BlockMatrixType *matrix,
                                                     const size_type  row,
                                                     const size_type  col)
@@ -1360,7 +1360,7 @@ namespace BlockMatrixIterators
   }
 
 
-  template <class BlockMatrixType>
+  template <typename BlockMatrixType>
   inline typename Accessor<BlockMatrixType, false>::size_type
   Accessor<BlockMatrixType, false>::row() const
   {
@@ -1371,7 +1371,7 @@ namespace BlockMatrixIterators
   }
 
 
-  template <class BlockMatrixType>
+  template <typename BlockMatrixType>
   inline typename Accessor<BlockMatrixType, false>::size_type
   Accessor<BlockMatrixType, false>::column() const
   {
@@ -1382,7 +1382,7 @@ namespace BlockMatrixIterators
   }
 
 
-  template <class BlockMatrixType>
+  template <typename BlockMatrixType>
   inline typename Accessor<BlockMatrixType, false>::value_type
   Accessor<BlockMatrixType, false>::value() const
   {
@@ -1394,7 +1394,7 @@ namespace BlockMatrixIterators
 
 
 
-  template <class BlockMatrixType>
+  template <typename BlockMatrixType>
   inline void
   Accessor<BlockMatrixType, false>::set_value(
     typename Accessor<BlockMatrixType, false>::value_type newval) const
@@ -1407,7 +1407,7 @@ namespace BlockMatrixIterators
 
 
 
-  template <class BlockMatrixType>
+  template <typename BlockMatrixType>
   inline void
   Accessor<BlockMatrixType, false>::advance()
   {
@@ -1472,7 +1472,7 @@ namespace BlockMatrixIterators
 
 
 
-  template <class BlockMatrixType>
+  template <typename BlockMatrixType>
   inline bool
   Accessor<BlockMatrixType, false>::operator==(const Accessor &a) const
   {
@@ -1507,8 +1507,8 @@ inline BlockMatrixBase<MatrixType>::~BlockMatrixBase()
 }
 
 
-template <class MatrixType>
-template <class BlockMatrixType>
+template <typename MatrixType>
+template <typename BlockMatrixType>
 inline BlockMatrixBase<MatrixType> &
 BlockMatrixBase<MatrixType>::copy_from(const BlockMatrixType &source)
 {
@@ -1520,7 +1520,7 @@ BlockMatrixBase<MatrixType>::copy_from(const BlockMatrixType &source)
 }
 
 
-template <class MatrixType>
+template <typename MatrixType>
 std::size_t
 BlockMatrixBase<MatrixType>::memory_consumption() const
 {
@@ -1545,7 +1545,7 @@ BlockMatrixBase<MatrixType>::memory_consumption() const
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 inline void
 BlockMatrixBase<MatrixType>::clear()
 {
@@ -1564,7 +1564,7 @@ BlockMatrixBase<MatrixType>::clear()
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 inline typename BlockMatrixBase<MatrixType>::BlockType &
 BlockMatrixBase<MatrixType>::block(const unsigned int row,
                                    const unsigned int column)
@@ -1577,7 +1577,7 @@ BlockMatrixBase<MatrixType>::block(const unsigned int row,
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 inline const typename BlockMatrixBase<MatrixType>::BlockType &
 BlockMatrixBase<MatrixType>::block(const unsigned int row,
                                    const unsigned int column) const
@@ -1589,7 +1589,7 @@ BlockMatrixBase<MatrixType>::block(const unsigned int row,
 }
 
 
-template <class MatrixType>
+template <typename MatrixType>
 inline typename BlockMatrixBase<MatrixType>::size_type
 BlockMatrixBase<MatrixType>::m() const
 {
@@ -1598,7 +1598,7 @@ BlockMatrixBase<MatrixType>::m() const
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 inline typename BlockMatrixBase<MatrixType>::size_type
 BlockMatrixBase<MatrixType>::n() const
 {
@@ -1607,7 +1607,7 @@ BlockMatrixBase<MatrixType>::n() const
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 inline unsigned int
 BlockMatrixBase<MatrixType>::n_block_cols() const
 {
@@ -1616,7 +1616,7 @@ BlockMatrixBase<MatrixType>::n_block_cols() const
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 inline unsigned int
 BlockMatrixBase<MatrixType>::n_block_rows() const
 {
@@ -1628,7 +1628,7 @@ BlockMatrixBase<MatrixType>::n_block_rows() const
 // Write the single set manually,
 // since the other function has a lot
 // of overhead in that case.
-template <class MatrixType>
+template <typename MatrixType>
 inline void
 BlockMatrixBase<MatrixType>::set(const size_type  i,
                                  const size_type  j,
@@ -1647,7 +1647,7 @@ BlockMatrixBase<MatrixType>::set(const size_type  i,
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 template <typename number>
 inline void
 BlockMatrixBase<MatrixType>::set(const std::vector<size_type> &row_indices,
@@ -1670,7 +1670,7 @@ BlockMatrixBase<MatrixType>::set(const std::vector<size_type> &row_indices,
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 template <typename number>
 inline void
 BlockMatrixBase<MatrixType>::set(const std::vector<size_type> &indices,
@@ -1691,7 +1691,7 @@ BlockMatrixBase<MatrixType>::set(const std::vector<size_type> &indices,
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 template <typename number>
 inline void
 BlockMatrixBase<MatrixType>::set(const size_type               row,
@@ -1714,7 +1714,7 @@ BlockMatrixBase<MatrixType>::set(const size_type               row,
 // This is a very messy function, since
 // we need to calculate to each position
 // the location in the global array.
-template <class MatrixType>
+template <typename MatrixType>
 template <typename number>
 inline void
 BlockMatrixBase<MatrixType>::set(const size_type  row,
@@ -1820,7 +1820,7 @@ BlockMatrixBase<MatrixType>::set(const size_type  row,
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 inline void
 BlockMatrixBase<MatrixType>::add(const size_type  i,
                                  const size_type  j,
@@ -1847,7 +1847,7 @@ BlockMatrixBase<MatrixType>::add(const size_type  i,
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 template <typename number>
 inline void
 BlockMatrixBase<MatrixType>::add(const std::vector<size_type> &row_indices,
@@ -1870,7 +1870,7 @@ BlockMatrixBase<MatrixType>::add(const std::vector<size_type> &row_indices,
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 template <typename number>
 inline void
 BlockMatrixBase<MatrixType>::add(const std::vector<size_type> &indices,
@@ -1891,7 +1891,7 @@ BlockMatrixBase<MatrixType>::add(const std::vector<size_type> &indices,
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 template <typename number>
 inline void
 BlockMatrixBase<MatrixType>::add(const size_type               row,
@@ -1914,7 +1914,7 @@ BlockMatrixBase<MatrixType>::add(const size_type               row,
 // This is a very messy function, since
 // we need to calculate to each position
 // the location in the global array.
-template <class MatrixType>
+template <typename MatrixType>
 template <typename number>
 inline void
 BlockMatrixBase<MatrixType>::add(const size_type  row,
@@ -2077,7 +2077,7 @@ BlockMatrixBase<MatrixType>::add(const size_type  row,
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 inline void
 BlockMatrixBase<MatrixType>::add(const value_type                   factor,
                                  const BlockMatrixBase<MatrixType> &matrix)
@@ -2102,7 +2102,7 @@ BlockMatrixBase<MatrixType>::add(const value_type                   factor,
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 inline typename BlockMatrixBase<MatrixType>::value_type
 BlockMatrixBase<MatrixType>::operator()(const size_type i,
                                         const size_type j) const
@@ -2116,7 +2116,7 @@ BlockMatrixBase<MatrixType>::operator()(const size_type i,
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 inline typename BlockMatrixBase<MatrixType>::value_type
 BlockMatrixBase<MatrixType>::el(const size_type i, const size_type j) const
 {
@@ -2129,7 +2129,7 @@ BlockMatrixBase<MatrixType>::el(const size_type i, const size_type j) const
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 inline typename BlockMatrixBase<MatrixType>::value_type
 BlockMatrixBase<MatrixType>::diag_element(const size_type i) const
 {
@@ -2142,7 +2142,7 @@ BlockMatrixBase<MatrixType>::diag_element(const size_type i) const
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 inline void
 BlockMatrixBase<MatrixType>::compress(VectorOperation::values operation)
 {
@@ -2153,7 +2153,7 @@ BlockMatrixBase<MatrixType>::compress(VectorOperation::values operation)
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 inline BlockMatrixBase<MatrixType> &
 BlockMatrixBase<MatrixType>::operator*=(const value_type factor)
 {
@@ -2169,7 +2169,7 @@ BlockMatrixBase<MatrixType>::operator*=(const value_type factor)
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 inline BlockMatrixBase<MatrixType> &
 BlockMatrixBase<MatrixType>::operator/=(const value_type factor)
 {
@@ -2188,7 +2188,7 @@ BlockMatrixBase<MatrixType>::operator/=(const value_type factor)
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 const BlockIndices &
 BlockMatrixBase<MatrixType>::get_row_indices() const
 {
@@ -2197,7 +2197,7 @@ BlockMatrixBase<MatrixType>::get_row_indices() const
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 const BlockIndices &
 BlockMatrixBase<MatrixType>::get_column_indices() const
 {
@@ -2206,7 +2206,7 @@ BlockMatrixBase<MatrixType>::get_column_indices() const
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 template <typename BlockVectorType>
 void
 BlockMatrixBase<MatrixType>::vmult_block_block(BlockVectorType &      dst,
@@ -2227,7 +2227,7 @@ BlockMatrixBase<MatrixType>::vmult_block_block(BlockVectorType &      dst,
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 template <typename BlockVectorType, typename VectorType>
 void
 BlockMatrixBase<MatrixType>::vmult_nonblock_block(
@@ -2245,7 +2245,7 @@ BlockMatrixBase<MatrixType>::vmult_nonblock_block(
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 template <typename BlockVectorType, typename VectorType>
 void
 BlockMatrixBase<MatrixType>::vmult_block_nonblock(BlockVectorType & dst,
@@ -2261,7 +2261,7 @@ BlockMatrixBase<MatrixType>::vmult_block_nonblock(BlockVectorType & dst,
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 template <typename VectorType>
 void
 BlockMatrixBase<MatrixType>::vmult_nonblock_nonblock(
@@ -2276,7 +2276,7 @@ BlockMatrixBase<MatrixType>::vmult_nonblock_nonblock(
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 template <typename BlockVectorType>
 void
 BlockMatrixBase<MatrixType>::vmult_add(BlockVectorType &      dst,
@@ -2294,7 +2294,7 @@ BlockMatrixBase<MatrixType>::vmult_add(BlockVectorType &      dst,
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 template <typename BlockVectorType>
 void
 BlockMatrixBase<MatrixType>::Tvmult_block_block(
@@ -2317,7 +2317,7 @@ BlockMatrixBase<MatrixType>::Tvmult_block_block(
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 template <typename BlockVectorType, typename VectorType>
 void
 BlockMatrixBase<MatrixType>::Tvmult_block_nonblock(BlockVectorType & dst,
@@ -2335,7 +2335,7 @@ BlockMatrixBase<MatrixType>::Tvmult_block_nonblock(BlockVectorType & dst,
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 template <typename BlockVectorType, typename VectorType>
 void
 BlockMatrixBase<MatrixType>::Tvmult_nonblock_block(
@@ -2354,7 +2354,7 @@ BlockMatrixBase<MatrixType>::Tvmult_nonblock_block(
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 template <typename VectorType>
 void
 BlockMatrixBase<MatrixType>::Tvmult_nonblock_nonblock(
@@ -2369,7 +2369,7 @@ BlockMatrixBase<MatrixType>::Tvmult_nonblock_nonblock(
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 template <typename BlockVectorType>
 void
 BlockMatrixBase<MatrixType>::Tvmult_add(BlockVectorType &      dst,
@@ -2387,7 +2387,7 @@ BlockMatrixBase<MatrixType>::Tvmult_add(BlockVectorType &      dst,
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 template <typename BlockVectorType>
 typename BlockMatrixBase<MatrixType>::value_type
 BlockMatrixBase<MatrixType>::matrix_norm_square(const BlockVectorType &v) const
@@ -2409,7 +2409,7 @@ BlockMatrixBase<MatrixType>::matrix_norm_square(const BlockVectorType &v) const
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 typename BlockMatrixBase<MatrixType>::real_type
 BlockMatrixBase<MatrixType>::frobenius_norm() const
 {
@@ -2431,7 +2431,7 @@ BlockMatrixBase<MatrixType>::frobenius_norm() const
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 template <typename BlockVectorType>
 typename BlockMatrixBase<MatrixType>::value_type
 BlockMatrixBase<MatrixType>::matrix_scalar_product(
@@ -2453,7 +2453,7 @@ BlockMatrixBase<MatrixType>::matrix_scalar_product(
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 template <typename BlockVectorType>
 typename BlockMatrixBase<MatrixType>::value_type
 BlockMatrixBase<MatrixType>::residual(BlockVectorType &      dst,
@@ -2502,7 +2502,7 @@ BlockMatrixBase<MatrixType>::residual(BlockVectorType &      dst,
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 inline void
 BlockMatrixBase<MatrixType>::print(std::ostream &out,
                                    const bool    alternative_output) const
@@ -2519,7 +2519,7 @@ BlockMatrixBase<MatrixType>::print(std::ostream &out,
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 inline typename BlockMatrixBase<MatrixType>::const_iterator
 BlockMatrixBase<MatrixType>::begin() const
 {
@@ -2528,7 +2528,7 @@ BlockMatrixBase<MatrixType>::begin() const
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 inline typename BlockMatrixBase<MatrixType>::const_iterator
 BlockMatrixBase<MatrixType>::end() const
 {
@@ -2537,7 +2537,7 @@ BlockMatrixBase<MatrixType>::end() const
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 inline typename BlockMatrixBase<MatrixType>::const_iterator
 BlockMatrixBase<MatrixType>::begin(const size_type r) const
 {
@@ -2547,7 +2547,7 @@ BlockMatrixBase<MatrixType>::begin(const size_type r) const
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 inline typename BlockMatrixBase<MatrixType>::const_iterator
 BlockMatrixBase<MatrixType>::end(const size_type r) const
 {
@@ -2557,7 +2557,7 @@ BlockMatrixBase<MatrixType>::end(const size_type r) const
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 inline typename BlockMatrixBase<MatrixType>::iterator
 BlockMatrixBase<MatrixType>::begin()
 {
@@ -2566,7 +2566,7 @@ BlockMatrixBase<MatrixType>::begin()
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 inline typename BlockMatrixBase<MatrixType>::iterator
 BlockMatrixBase<MatrixType>::end()
 {
@@ -2575,7 +2575,7 @@ BlockMatrixBase<MatrixType>::end()
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 inline typename BlockMatrixBase<MatrixType>::iterator
 BlockMatrixBase<MatrixType>::begin(const size_type r)
 {
@@ -2585,7 +2585,7 @@ BlockMatrixBase<MatrixType>::begin(const size_type r)
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 inline typename BlockMatrixBase<MatrixType>::iterator
 BlockMatrixBase<MatrixType>::end(const size_type r)
 {
@@ -2595,7 +2595,7 @@ BlockMatrixBase<MatrixType>::end(const size_type r)
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 void
 BlockMatrixBase<MatrixType>::collect_sizes()
 {
@@ -2634,7 +2634,7 @@ BlockMatrixBase<MatrixType>::collect_sizes()
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 void
 BlockMatrixBase<MatrixType>::prepare_add_operation()
 {
@@ -2645,7 +2645,7 @@ BlockMatrixBase<MatrixType>::prepare_add_operation()
 
 
 
-template <class MatrixType>
+template <typename MatrixType>
 void
 BlockMatrixBase<MatrixType>::prepare_set_operation()
 {

--- a/include/deal.II/lac/block_sparse_matrix.h
+++ b/include/deal.II/lac/block_sparse_matrix.h
@@ -297,7 +297,7 @@ public:
    *
    * All diagonal blocks must be square matrices for this operation.
    */
-  template <class BlockVectorType>
+  template <typename BlockVectorType>
   void
   precondition_Jacobi(BlockVectorType &      dst,
                       const BlockVectorType &src,
@@ -479,7 +479,7 @@ BlockSparseMatrix<number>::Tvmult(Vector<nonblock_number> &      dst,
 
 
 template <typename number>
-template <class BlockVectorType>
+template <typename BlockVectorType>
 inline void
 BlockSparseMatrix<number>::precondition_Jacobi(BlockVectorType &      dst,
                                                const BlockVectorType &src,

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -118,7 +118,7 @@ namespace internal
      * constant and we again have that the iterator satisfies the requirements
      * of a random access iterator.
      */
-    template <class BlockVectorType, bool Constness>
+    template <typename BlockVectorType, bool Constness>
     class Iterator
     {
     public:
@@ -438,7 +438,7 @@ namespace internal
  * @see
  * @ref GlossBlockLA "Block (linear algebra)"
  */
-template <class VectorType>
+template <typename VectorType>
 class BlockVectorBase : public Subscriptor,
                         public ReadVector<typename VectorType::value_type>
 {
@@ -714,7 +714,7 @@ public:
   /**
    * Copy operator for template arguments of different types.
    */
-  template <class VectorType2>
+  template <typename VectorType2>
   BlockVectorBase &
   operator=(const BlockVectorBase<VectorType2> &V);
 
@@ -728,7 +728,7 @@ public:
    * Check for equality of two block vector types. This operation is only
    * allowed if the two vectors already have the same block structure.
    */
-  template <class VectorType2>
+  template <typename VectorType2>
   bool
   operator==(const BlockVectorBase<VectorType2> &v) const;
 
@@ -988,7 +988,7 @@ namespace internal
 {
   namespace BlockVectorIterators
   {
-    template <class BlockVectorType, bool Constness>
+    template <typename BlockVectorType, bool Constness>
     inline Iterator<BlockVectorType, Constness>::Iterator(
       const Iterator<BlockVectorType, Constness> &c)
       : parent(c.parent)
@@ -1001,7 +1001,7 @@ namespace internal
 
 
 
-    template <class BlockVectorType, bool Constness>
+    template <typename BlockVectorType, bool Constness>
     inline Iterator<BlockVectorType, Constness>::Iterator(
       const Iterator<BlockVectorType, !Constness> &c)
       : parent(c.parent)
@@ -1021,7 +1021,7 @@ namespace internal
 
 
 
-    template <class BlockVectorType, bool Constness>
+    template <typename BlockVectorType, bool Constness>
     inline Iterator<BlockVectorType, Constness>::Iterator(
       BlockVector &   parent,
       const size_type global_index,
@@ -1039,7 +1039,7 @@ namespace internal
 
 
 
-    template <class BlockVectorType, bool Constness>
+    template <typename BlockVectorType, bool Constness>
     inline Iterator<BlockVectorType, Constness> &
     Iterator<BlockVectorType, Constness>::operator=(const Iterator &c)
     {
@@ -1055,7 +1055,7 @@ namespace internal
 
 
 
-    template <class BlockVectorType, bool Constness>
+    template <typename BlockVectorType, bool Constness>
     inline typename Iterator<BlockVectorType, Constness>::dereference_type
     Iterator<BlockVectorType, Constness>::operator*() const
     {
@@ -1064,7 +1064,7 @@ namespace internal
 
 
 
-    template <class BlockVectorType, bool Constness>
+    template <typename BlockVectorType, bool Constness>
     inline typename Iterator<BlockVectorType, Constness>::dereference_type
     Iterator<BlockVectorType, Constness>::operator[](
       const difference_type d) const
@@ -1090,7 +1090,7 @@ namespace internal
 
 
 
-    template <class BlockVectorType, bool Constness>
+    template <typename BlockVectorType, bool Constness>
     inline Iterator<BlockVectorType, Constness> &
     Iterator<BlockVectorType, Constness>::operator++()
     {
@@ -1100,7 +1100,7 @@ namespace internal
 
 
 
-    template <class BlockVectorType, bool Constness>
+    template <typename BlockVectorType, bool Constness>
     inline Iterator<BlockVectorType, Constness>
     Iterator<BlockVectorType, Constness>::operator++(int)
     {
@@ -1111,7 +1111,7 @@ namespace internal
 
 
 
-    template <class BlockVectorType, bool Constness>
+    template <typename BlockVectorType, bool Constness>
     inline Iterator<BlockVectorType, Constness> &
     Iterator<BlockVectorType, Constness>::operator--()
     {
@@ -1121,7 +1121,7 @@ namespace internal
 
 
 
-    template <class BlockVectorType, bool Constness>
+    template <typename BlockVectorType, bool Constness>
     inline Iterator<BlockVectorType, Constness>
     Iterator<BlockVectorType, Constness>::operator--(int)
     {
@@ -1132,7 +1132,7 @@ namespace internal
 
 
 
-    template <class BlockVectorType, bool Constness>
+    template <typename BlockVectorType, bool Constness>
     template <bool OtherConstness>
     inline bool
     Iterator<BlockVectorType, Constness>::operator==(
@@ -1145,7 +1145,7 @@ namespace internal
 
 
 
-    template <class BlockVectorType, bool Constness>
+    template <typename BlockVectorType, bool Constness>
     template <bool OtherConstness>
     inline bool
     Iterator<BlockVectorType, Constness>::operator!=(
@@ -1158,7 +1158,7 @@ namespace internal
 
 
 
-    template <class BlockVectorType, bool Constness>
+    template <typename BlockVectorType, bool Constness>
     template <bool OtherConstness>
     inline bool
     Iterator<BlockVectorType, Constness>::operator<(
@@ -1171,7 +1171,7 @@ namespace internal
 
 
 
-    template <class BlockVectorType, bool Constness>
+    template <typename BlockVectorType, bool Constness>
     template <bool OtherConstness>
     inline bool
     Iterator<BlockVectorType, Constness>::operator<=(
@@ -1184,7 +1184,7 @@ namespace internal
 
 
 
-    template <class BlockVectorType, bool Constness>
+    template <typename BlockVectorType, bool Constness>
     template <bool OtherConstness>
     inline bool
     Iterator<BlockVectorType, Constness>::operator>(
@@ -1197,7 +1197,7 @@ namespace internal
 
 
 
-    template <class BlockVectorType, bool Constness>
+    template <typename BlockVectorType, bool Constness>
     template <bool OtherConstness>
     inline bool
     Iterator<BlockVectorType, Constness>::operator>=(
@@ -1210,7 +1210,7 @@ namespace internal
 
 
 
-    template <class BlockVectorType, bool Constness>
+    template <typename BlockVectorType, bool Constness>
     template <bool OtherConstness>
     inline typename Iterator<BlockVectorType, Constness>::difference_type
     Iterator<BlockVectorType, Constness>::operator-(
@@ -1224,7 +1224,7 @@ namespace internal
 
 
 
-    template <class BlockVectorType, bool Constness>
+    template <typename BlockVectorType, bool Constness>
     inline Iterator<BlockVectorType, Constness>
     Iterator<BlockVectorType, Constness>::operator+(
       const difference_type &d) const
@@ -1251,7 +1251,7 @@ namespace internal
 
 
 
-    template <class BlockVectorType, bool Constness>
+    template <typename BlockVectorType, bool Constness>
     inline Iterator<BlockVectorType, Constness>
     Iterator<BlockVectorType, Constness>::operator-(
       const difference_type &d) const
@@ -1278,7 +1278,7 @@ namespace internal
 
 
 
-    template <class BlockVectorType, bool Constness>
+    template <typename BlockVectorType, bool Constness>
     inline Iterator<BlockVectorType, Constness> &
     Iterator<BlockVectorType, Constness>::operator+=(const difference_type &d)
     {
@@ -1304,7 +1304,7 @@ namespace internal
 
 
 
-    template <class BlockVectorType, bool Constness>
+    template <typename BlockVectorType, bool Constness>
     inline Iterator<BlockVectorType, Constness> &
     Iterator<BlockVectorType, Constness>::operator-=(const difference_type &d)
     {
@@ -1329,7 +1329,7 @@ namespace internal
     }
 
 
-    template <class BlockVectorType, bool Constness>
+    template <typename BlockVectorType, bool Constness>
     Iterator<BlockVectorType, Constness>::Iterator(BlockVector &   parent,
                                                    const size_type global_index)
       : parent(&parent)
@@ -1368,7 +1368,7 @@ namespace internal
 
 
 
-    template <class BlockVectorType, bool Constness>
+    template <typename BlockVectorType, bool Constness>
     void
     Iterator<BlockVectorType, Constness>::move_forward()
     {
@@ -1402,7 +1402,7 @@ namespace internal
 
 
 
-    template <class BlockVectorType, bool Constness>
+    template <typename BlockVectorType, bool Constness>
     void
     Iterator<BlockVectorType, Constness>::move_backward()
     {
@@ -1444,7 +1444,7 @@ namespace internal
 
 
 
-template <class VectorType>
+template <typename VectorType>
 inline typename BlockVectorBase<VectorType>::size_type
 BlockVectorBase<VectorType>::size() const
 {
@@ -1453,7 +1453,7 @@ BlockVectorBase<VectorType>::size() const
 
 
 
-template <class VectorType>
+template <typename VectorType>
 inline std::size_t
 BlockVectorBase<VectorType>::locally_owned_size() const
 {
@@ -1465,7 +1465,7 @@ BlockVectorBase<VectorType>::locally_owned_size() const
 
 
 
-template <class VectorType>
+template <typename VectorType>
 inline IndexSet
 BlockVectorBase<VectorType>::locally_owned_elements() const
 {
@@ -1486,7 +1486,7 @@ BlockVectorBase<VectorType>::locally_owned_elements() const
 
 
 
-template <class VectorType>
+template <typename VectorType>
 inline unsigned int
 BlockVectorBase<VectorType>::n_blocks() const
 {
@@ -1494,7 +1494,7 @@ BlockVectorBase<VectorType>::n_blocks() const
 }
 
 
-template <class VectorType>
+template <typename VectorType>
 inline typename BlockVectorBase<VectorType>::BlockType &
 BlockVectorBase<VectorType>::block(const unsigned int i)
 {
@@ -1505,7 +1505,7 @@ BlockVectorBase<VectorType>::block(const unsigned int i)
 
 
 
-template <class VectorType>
+template <typename VectorType>
 inline const typename BlockVectorBase<VectorType>::BlockType &
 BlockVectorBase<VectorType>::block(const unsigned int i) const
 {
@@ -1516,7 +1516,7 @@ BlockVectorBase<VectorType>::block(const unsigned int i) const
 
 
 
-template <class VectorType>
+template <typename VectorType>
 inline const BlockIndices &
 BlockVectorBase<VectorType>::get_block_indices() const
 {
@@ -1524,7 +1524,7 @@ BlockVectorBase<VectorType>::get_block_indices() const
 }
 
 
-template <class VectorType>
+template <typename VectorType>
 inline void
 BlockVectorBase<VectorType>::collect_sizes()
 {
@@ -1538,7 +1538,7 @@ BlockVectorBase<VectorType>::collect_sizes()
 
 
 
-template <class VectorType>
+template <typename VectorType>
 inline void
 BlockVectorBase<VectorType>::compress(VectorOperation::values operation)
 {
@@ -1548,7 +1548,7 @@ BlockVectorBase<VectorType>::compress(VectorOperation::values operation)
 
 
 
-template <class VectorType>
+template <typename VectorType>
 inline typename BlockVectorBase<VectorType>::iterator
 BlockVectorBase<VectorType>::begin()
 {
@@ -1557,7 +1557,7 @@ BlockVectorBase<VectorType>::begin()
 
 
 
-template <class VectorType>
+template <typename VectorType>
 inline typename BlockVectorBase<VectorType>::const_iterator
 BlockVectorBase<VectorType>::begin() const
 {
@@ -1565,7 +1565,7 @@ BlockVectorBase<VectorType>::begin() const
 }
 
 
-template <class VectorType>
+template <typename VectorType>
 inline typename BlockVectorBase<VectorType>::iterator
 BlockVectorBase<VectorType>::end()
 {
@@ -1574,7 +1574,7 @@ BlockVectorBase<VectorType>::end()
 
 
 
-template <class VectorType>
+template <typename VectorType>
 inline typename BlockVectorBase<VectorType>::const_iterator
 BlockVectorBase<VectorType>::end() const
 {
@@ -1582,7 +1582,7 @@ BlockVectorBase<VectorType>::end() const
 }
 
 
-template <class VectorType>
+template <typename VectorType>
 inline bool
 BlockVectorBase<VectorType>::in_local_range(const size_type global_index) const
 {
@@ -1593,7 +1593,7 @@ BlockVectorBase<VectorType>::in_local_range(const size_type global_index) const
 }
 
 
-template <class VectorType>
+template <typename VectorType>
 bool
 BlockVectorBase<VectorType>::all_zero() const
 {
@@ -1606,7 +1606,7 @@ BlockVectorBase<VectorType>::all_zero() const
 
 
 
-template <class VectorType>
+template <typename VectorType>
 bool
 BlockVectorBase<VectorType>::is_non_negative() const
 {
@@ -1619,7 +1619,7 @@ BlockVectorBase<VectorType>::is_non_negative() const
 
 
 
-template <class VectorType>
+template <typename VectorType>
 typename BlockVectorBase<VectorType>::value_type
 BlockVectorBase<VectorType>::operator*(
   const BlockVectorBase<VectorType> &v) const
@@ -1635,7 +1635,7 @@ BlockVectorBase<VectorType>::operator*(
 }
 
 
-template <class VectorType>
+template <typename VectorType>
 typename BlockVectorBase<VectorType>::real_type
 BlockVectorBase<VectorType>::norm_sqr() const
 {
@@ -1648,7 +1648,7 @@ BlockVectorBase<VectorType>::norm_sqr() const
 
 
 
-template <class VectorType>
+template <typename VectorType>
 typename BlockVectorBase<VectorType>::value_type
 BlockVectorBase<VectorType>::mean_value() const
 {
@@ -1665,7 +1665,7 @@ BlockVectorBase<VectorType>::mean_value() const
 
 
 
-template <class VectorType>
+template <typename VectorType>
 typename BlockVectorBase<VectorType>::real_type
 BlockVectorBase<VectorType>::l1_norm() const
 {
@@ -1678,7 +1678,7 @@ BlockVectorBase<VectorType>::l1_norm() const
 
 
 
-template <class VectorType>
+template <typename VectorType>
 typename BlockVectorBase<VectorType>::real_type
 BlockVectorBase<VectorType>::l2_norm() const
 {
@@ -1687,7 +1687,7 @@ BlockVectorBase<VectorType>::l2_norm() const
 
 
 
-template <class VectorType>
+template <typename VectorType>
 typename BlockVectorBase<VectorType>::real_type
 BlockVectorBase<VectorType>::linfty_norm() const
 {
@@ -1703,7 +1703,7 @@ BlockVectorBase<VectorType>::linfty_norm() const
 
 
 
-template <class VectorType>
+template <typename VectorType>
 typename BlockVectorBase<VectorType>::value_type
 BlockVectorBase<VectorType>::add_and_dot(
   const typename BlockVectorBase<VectorType>::value_type a,
@@ -1722,7 +1722,7 @@ BlockVectorBase<VectorType>::add_and_dot(
 
 
 
-template <class VectorType>
+template <typename VectorType>
 BlockVectorBase<VectorType> &
 BlockVectorBase<VectorType>::operator+=(const BlockVectorBase<VectorType> &v)
 {
@@ -1739,7 +1739,7 @@ BlockVectorBase<VectorType>::operator+=(const BlockVectorBase<VectorType> &v)
 
 
 
-template <class VectorType>
+template <typename VectorType>
 BlockVectorBase<VectorType> &
 BlockVectorBase<VectorType>::operator-=(const BlockVectorBase<VectorType> &v)
 {
@@ -1755,7 +1755,7 @@ BlockVectorBase<VectorType>::operator-=(const BlockVectorBase<VectorType> &v)
 
 
 
-template <class VectorType>
+template <typename VectorType>
 template <typename Number>
 inline void
 BlockVectorBase<VectorType>::add(const std::vector<size_type> &indices,
@@ -1768,7 +1768,7 @@ BlockVectorBase<VectorType>::add(const std::vector<size_type> &indices,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 template <typename Number>
 inline void
 BlockVectorBase<VectorType>::add(const std::vector<size_type> &indices,
@@ -1783,7 +1783,7 @@ BlockVectorBase<VectorType>::add(const std::vector<size_type> &indices,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 template <typename Number>
 inline void
 BlockVectorBase<VectorType>::add(const size_type  n_indices,
@@ -1796,7 +1796,7 @@ BlockVectorBase<VectorType>::add(const size_type  n_indices,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 void
 BlockVectorBase<VectorType>::add(const value_type a)
 {
@@ -1810,7 +1810,7 @@ BlockVectorBase<VectorType>::add(const value_type a)
 
 
 
-template <class VectorType>
+template <typename VectorType>
 void
 BlockVectorBase<VectorType>::add(const value_type                   a,
                                  const BlockVectorBase<VectorType> &v)
@@ -1828,7 +1828,7 @@ BlockVectorBase<VectorType>::add(const value_type                   a,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 void
 BlockVectorBase<VectorType>::add(const value_type                   a,
                                  const BlockVectorBase<VectorType> &v,
@@ -1852,7 +1852,7 @@ BlockVectorBase<VectorType>::add(const value_type                   a,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 void
 BlockVectorBase<VectorType>::sadd(const value_type                   x,
                                   const BlockVectorBase<VectorType> &v)
@@ -1870,7 +1870,7 @@ BlockVectorBase<VectorType>::sadd(const value_type                   x,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 void
 BlockVectorBase<VectorType>::sadd(const value_type                   x,
                                   const value_type                   a,
@@ -1890,7 +1890,7 @@ BlockVectorBase<VectorType>::sadd(const value_type                   x,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 void
 BlockVectorBase<VectorType>::sadd(const value_type                   x,
                                   const value_type                   a,
@@ -1915,7 +1915,7 @@ BlockVectorBase<VectorType>::sadd(const value_type                   x,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 void
 BlockVectorBase<VectorType>::sadd(const value_type                   x,
                                   const value_type                   a,
@@ -1946,7 +1946,7 @@ BlockVectorBase<VectorType>::sadd(const value_type                   x,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 template <class BlockVector2>
 void
 BlockVectorBase<VectorType>::scale(const BlockVector2 &v)
@@ -1959,7 +1959,7 @@ BlockVectorBase<VectorType>::scale(const BlockVector2 &v)
 
 
 
-template <class VectorType>
+template <typename VectorType>
 std::size_t
 BlockVectorBase<VectorType>::memory_consumption() const
 {
@@ -1969,7 +1969,7 @@ BlockVectorBase<VectorType>::memory_consumption() const
 
 
 
-template <class VectorType>
+template <typename VectorType>
 template <class BlockVector2>
 void
 BlockVectorBase<VectorType>::equ(const value_type a, const BlockVector2 &v)
@@ -1985,7 +1985,7 @@ BlockVectorBase<VectorType>::equ(const value_type a, const BlockVector2 &v)
 
 
 
-template <class VectorType>
+template <typename VectorType>
 void
 BlockVectorBase<VectorType>::update_ghost_values() const
 {
@@ -1995,7 +1995,7 @@ BlockVectorBase<VectorType>::update_ghost_values() const
 
 
 
-template <class VectorType>
+template <typename VectorType>
 BlockVectorBase<VectorType> &
 BlockVectorBase<VectorType>::operator=(const value_type s)
 {
@@ -2008,7 +2008,7 @@ BlockVectorBase<VectorType>::operator=(const value_type s)
 }
 
 
-template <class VectorType>
+template <typename VectorType>
 BlockVectorBase<VectorType> &
 BlockVectorBase<VectorType>::operator=(const BlockVectorBase<VectorType> &v)
 {
@@ -2021,8 +2021,8 @@ BlockVectorBase<VectorType>::operator=(const BlockVectorBase<VectorType> &v)
 }
 
 
-template <class VectorType>
-template <class VectorType2>
+template <typename VectorType>
+template <typename VectorType2>
 BlockVectorBase<VectorType> &
 BlockVectorBase<VectorType>::operator=(const BlockVectorBase<VectorType2> &v)
 {
@@ -2036,7 +2036,7 @@ BlockVectorBase<VectorType>::operator=(const BlockVectorBase<VectorType2> &v)
 
 
 
-template <class VectorType>
+template <typename VectorType>
 BlockVectorBase<VectorType> &
 BlockVectorBase<VectorType>::operator=(const VectorType &v)
 {
@@ -2052,8 +2052,8 @@ BlockVectorBase<VectorType>::operator=(const VectorType &v)
 
 
 
-template <class VectorType>
-template <class VectorType2>
+template <typename VectorType>
+template <typename VectorType2>
 inline bool
 BlockVectorBase<VectorType>::operator==(
   const BlockVectorBase<VectorType2> &v) const
@@ -2069,7 +2069,7 @@ BlockVectorBase<VectorType>::operator==(
 
 
 
-template <class VectorType>
+template <typename VectorType>
 inline BlockVectorBase<VectorType> &
 BlockVectorBase<VectorType>::operator*=(const value_type factor)
 {
@@ -2083,7 +2083,7 @@ BlockVectorBase<VectorType>::operator*=(const value_type factor)
 
 
 
-template <class VectorType>
+template <typename VectorType>
 inline BlockVectorBase<VectorType> &
 BlockVectorBase<VectorType>::operator/=(const value_type factor)
 {
@@ -2099,7 +2099,7 @@ BlockVectorBase<VectorType>::operator/=(const value_type factor)
 }
 
 
-template <class VectorType>
+template <typename VectorType>
 inline typename BlockVectorBase<VectorType>::value_type
 BlockVectorBase<VectorType>::operator()(const size_type i) const
 {
@@ -2110,7 +2110,7 @@ BlockVectorBase<VectorType>::operator()(const size_type i) const
 
 
 
-template <class VectorType>
+template <typename VectorType>
 inline typename BlockVectorBase<VectorType>::reference
 BlockVectorBase<VectorType>::operator()(const size_type i)
 {
@@ -2121,7 +2121,7 @@ BlockVectorBase<VectorType>::operator()(const size_type i)
 
 
 
-template <class VectorType>
+template <typename VectorType>
 inline typename BlockVectorBase<VectorType>::value_type
 BlockVectorBase<VectorType>::operator[](const size_type i) const
 {
@@ -2130,7 +2130,7 @@ BlockVectorBase<VectorType>::operator[](const size_type i) const
 
 
 
-template <class VectorType>
+template <typename VectorType>
 inline typename BlockVectorBase<VectorType>::reference
 BlockVectorBase<VectorType>::operator[](const size_type i)
 {

--- a/include/deal.II/lac/eigen.h
+++ b/include/deal.II/lac/eigen.h
@@ -193,7 +193,7 @@ protected:
 //---------------------------------------------------------------------------
 
 
-template <class VectorType>
+template <typename VectorType>
 EigenPower<VectorType>::EigenPower(SolverControl &           cn,
                                    VectorMemory<VectorType> &mem,
                                    const AdditionalData &    data)
@@ -203,7 +203,7 @@ EigenPower<VectorType>::EigenPower(SolverControl &           cn,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 template <typename MatrixType>
 void
 EigenPower<VectorType>::solve(double &value, const MatrixType &A, VectorType &x)
@@ -276,7 +276,7 @@ EigenPower<VectorType>::solve(double &value, const MatrixType &A, VectorType &x)
 
 //---------------------------------------------------------------------------
 
-template <class VectorType>
+template <typename VectorType>
 EigenInverse<VectorType>::EigenInverse(SolverControl &           cn,
                                        VectorMemory<VectorType> &mem,
                                        const AdditionalData &    data)
@@ -286,7 +286,7 @@ EigenInverse<VectorType>::EigenInverse(SolverControl &           cn,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 template <typename MatrixType>
 void
 EigenInverse<VectorType>::solve(double &          value,

--- a/include/deal.II/lac/householder.h
+++ b/include/deal.II/lac/householder.h
@@ -131,7 +131,7 @@ public:
    * A wrapper to least_squares(), implementing the standard MatrixType
    * interface.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   vmult(VectorType &dst, const VectorType &src) const;
 
@@ -139,7 +139,7 @@ public:
    * A wrapper to least_squares() that implements multiplication with
    * the transpose matrix.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   Tvmult(VectorType &dst, const VectorType &src) const;
 
@@ -330,7 +330,7 @@ Householder<number>::least_squares(BlockVector<number2> &      dst,
 
 
 template <typename number>
-template <class VectorType>
+template <typename VectorType>
 void
 Householder<number>::vmult(VectorType &dst, const VectorType &src) const
 {
@@ -339,7 +339,7 @@ Householder<number>::vmult(VectorType &dst, const VectorType &src) const
 
 
 template <typename number>
-template <class VectorType>
+template <typename VectorType>
 void
 Householder<number>::Tvmult(VectorType &, const VectorType &) const
 {

--- a/include/deal.II/lac/matrix_block.h
+++ b/include/deal.II/lac/matrix_block.h
@@ -253,7 +253,7 @@ public:
    * MatrixType. No index computations are done, thus, the vectors need to
    * have sizes matching #matrix.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   vmult(VectorType &w, const VectorType &v) const;
 
@@ -262,7 +262,7 @@ public:
    * MatrixType. No index computations are done, thus, the vectors need to
    * have sizes matching #matrix.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   vmult_add(VectorType &w, const VectorType &v) const;
 
@@ -271,7 +271,7 @@ public:
    * MatrixType. No index computations are done, thus, the vectors need to
    * have sizes matching #matrix.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   Tvmult(VectorType &w, const VectorType &v) const;
 
@@ -280,7 +280,7 @@ public:
    * MatrixType. No index computations are done, thus, the vectors need to
    * have sizes matching #matrix.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   Tvmult_add(VectorType &w, const VectorType &v) const;
 
@@ -796,7 +796,7 @@ MatrixBlock<MatrixType>::add(const size_type               row,
 
 
 template <typename MatrixType>
-template <class VectorType>
+template <typename VectorType>
 inline void
 MatrixBlock<MatrixType>::vmult(VectorType &w, const VectorType &v) const
 {
@@ -805,7 +805,7 @@ MatrixBlock<MatrixType>::vmult(VectorType &w, const VectorType &v) const
 
 
 template <typename MatrixType>
-template <class VectorType>
+template <typename VectorType>
 inline void
 MatrixBlock<MatrixType>::vmult_add(VectorType &w, const VectorType &v) const
 {
@@ -814,7 +814,7 @@ MatrixBlock<MatrixType>::vmult_add(VectorType &w, const VectorType &v) const
 
 
 template <typename MatrixType>
-template <class VectorType>
+template <typename VectorType>
 inline void
 MatrixBlock<MatrixType>::Tvmult(VectorType &w, const VectorType &v) const
 {
@@ -823,7 +823,7 @@ MatrixBlock<MatrixType>::Tvmult(VectorType &w, const VectorType &v) const
 
 
 template <typename MatrixType>
-template <class VectorType>
+template <typename VectorType>
 inline void
 MatrixBlock<MatrixType>::Tvmult_add(VectorType &w, const VectorType &v) const
 {

--- a/include/deal.II/lac/petsc_snes.h
+++ b/include/deal.II/lac/petsc_snes.h
@@ -170,7 +170,7 @@ namespace PETScWrappers
    * methods:
    *
    * @code
-   * class VectorType : public Subscriptor
+   * typename VectorType : public Subscriptor
    *    ...
    *    explicit VectorType(Vec);
    *    ...

--- a/include/deal.II/lac/petsc_snes.h
+++ b/include/deal.II/lac/petsc_snes.h
@@ -170,7 +170,7 @@ namespace PETScWrappers
    * methods:
    *
    * @code
-   * typename VectorType : public Subscriptor
+   * class VectorType : public Subscriptor
    *    ...
    *    explicit VectorType(Vec);
    *    ...

--- a/include/deal.II/lac/petsc_ts.h
+++ b/include/deal.II/lac/petsc_ts.h
@@ -228,7 +228,7 @@ namespace PETScWrappers
    * methods:
    *
    * @code
-   * typename VectorType : public Subscriptor
+   * class VectorType : public Subscriptor
    *    ...
    *    explicit VectorType(Vec);
    *    ...

--- a/include/deal.II/lac/petsc_ts.h
+++ b/include/deal.II/lac/petsc_ts.h
@@ -228,7 +228,7 @@ namespace PETScWrappers
    * methods:
    *
    * @code
-   * class VectorType : public Subscriptor
+   * typename VectorType : public Subscriptor
    *    ...
    *    explicit VectorType(Vec);
    *    ...

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -117,7 +117,7 @@ public:
   /**
    * Apply preconditioner.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   vmult(VectorType &, const VectorType &) const;
 
@@ -125,14 +125,14 @@ public:
    * Apply transpose preconditioner. Since this is the identity, this function
    * is the same as vmult().
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   Tvmult(VectorType &, const VectorType &) const;
 
   /**
    * Apply preconditioner, adding to the previous value.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   vmult_add(VectorType &, const VectorType &) const;
 
@@ -140,7 +140,7 @@ public:
    * Apply transpose preconditioner, adding. Since this is the identity, this
    * function is the same as vmult_add().
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   Tvmult_add(VectorType &, const VectorType &) const;
 
@@ -245,7 +245,7 @@ public:
   /**
    * Apply preconditioner.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   vmult(VectorType &, const VectorType &) const;
 
@@ -253,13 +253,13 @@ public:
    * Apply transpose preconditioner. Since this is the identity, this function
    * is the same as vmult().
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   Tvmult(VectorType &, const VectorType &) const;
   /**
    * Apply preconditioner, adding to the previous value.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   vmult_add(VectorType &, const VectorType &) const;
 
@@ -267,7 +267,7 @@ public:
    * Apply transpose preconditioner, adding. Since this is the identity, this
    * function is the same as vmult_add().
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   Tvmult_add(VectorType &, const VectorType &) const;
 
@@ -358,7 +358,7 @@ private:
  * @endcode
  */
 template <typename MatrixType = SparseMatrix<double>,
-          class VectorType    = Vector<double>>
+          typename VectorType = Vector<double>>
 class PreconditionUseMatrix : public Subscriptor
 {
 public:
@@ -472,7 +472,7 @@ public:
   /**
    * Apply preconditioner.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   vmult(VectorType &, const VectorType &) const;
 
@@ -480,21 +480,21 @@ public:
    * Apply transpose preconditioner. Since this is a symmetric preconditioner,
    * this function is the same as vmult().
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   Tvmult(VectorType &, const VectorType &) const;
 
   /**
    * Perform one step of the preconditioned Richardson iteration
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   step(VectorType &x, const VectorType &rhs) const;
 
   /**
    * Perform one transposed step of the preconditioned Richardson iteration.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   Tstep(VectorType &x, const VectorType &rhs) const;
 
@@ -2263,7 +2263,7 @@ PreconditionIdentity::initialize(const MatrixType &matrix,
 }
 
 
-template <class VectorType>
+template <typename VectorType>
 inline void
 PreconditionIdentity::vmult(VectorType &dst, const VectorType &src) const
 {
@@ -2272,14 +2272,14 @@ PreconditionIdentity::vmult(VectorType &dst, const VectorType &src) const
 
 
 
-template <class VectorType>
+template <typename VectorType>
 inline void
 PreconditionIdentity::Tvmult(VectorType &dst, const VectorType &src) const
 {
   dst = src;
 }
 
-template <class VectorType>
+template <typename VectorType>
 inline void
 PreconditionIdentity::vmult_add(VectorType &dst, const VectorType &src) const
 {
@@ -2288,7 +2288,7 @@ PreconditionIdentity::vmult_add(VectorType &dst, const VectorType &src) const
 
 
 
-template <class VectorType>
+template <typename VectorType>
 inline void
 PreconditionIdentity::Tvmult_add(VectorType &dst, const VectorType &src) const
 {
@@ -2358,7 +2358,7 @@ PreconditionRichardson::initialize(
 
 
 
-template <class VectorType>
+template <typename VectorType>
 inline void
 PreconditionRichardson::vmult(VectorType &dst, const VectorType &src) const
 {
@@ -2371,7 +2371,7 @@ PreconditionRichardson::vmult(VectorType &dst, const VectorType &src) const
 
 
 
-template <class VectorType>
+template <typename VectorType>
 inline void
 PreconditionRichardson::Tvmult(VectorType &dst, const VectorType &src) const
 {
@@ -2382,7 +2382,7 @@ PreconditionRichardson::Tvmult(VectorType &dst, const VectorType &src) const
   dst.equ(relaxation, src);
 }
 
-template <class VectorType>
+template <typename VectorType>
 inline void
 PreconditionRichardson::vmult_add(VectorType &dst, const VectorType &src) const
 {
@@ -2395,7 +2395,7 @@ PreconditionRichardson::vmult_add(VectorType &dst, const VectorType &src) const
 
 
 
-template <class VectorType>
+template <typename VectorType>
 inline void
 PreconditionRichardson::Tvmult_add(VectorType &dst, const VectorType &src) const
 {
@@ -2465,7 +2465,7 @@ inline
 }
 
 template <typename MatrixType, typename PreconditionerType>
-template <class VectorType>
+template <typename VectorType>
 inline void
 PreconditionRelaxation<MatrixType, PreconditionerType>::vmult(
   VectorType &      dst,
@@ -2482,7 +2482,7 @@ PreconditionRelaxation<MatrixType, PreconditionerType>::vmult(
 }
 
 template <typename MatrixType, typename PreconditionerType>
-template <class VectorType>
+template <typename VectorType>
 inline void
 PreconditionRelaxation<MatrixType, PreconditionerType>::Tvmult(
   VectorType &      dst,
@@ -2499,7 +2499,7 @@ PreconditionRelaxation<MatrixType, PreconditionerType>::Tvmult(
 }
 
 template <typename MatrixType, typename PreconditionerType>
-template <class VectorType>
+template <typename VectorType>
 inline void
 PreconditionRelaxation<MatrixType, PreconditionerType>::step(
   VectorType &      dst,
@@ -2516,7 +2516,7 @@ PreconditionRelaxation<MatrixType, PreconditionerType>::step(
 }
 
 template <typename MatrixType, typename PreconditionerType>
-template <class VectorType>
+template <typename VectorType>
 inline void
 PreconditionRelaxation<MatrixType, PreconditionerType>::Tstep(
   VectorType &      dst,
@@ -2636,7 +2636,7 @@ PreconditionPSOR<MatrixType>::AdditionalData::AdditionalData(
 //---------------------------------------------------------------------------
 
 
-template <typename MatrixType, class VectorType>
+template <typename MatrixType, typename VectorType>
 PreconditionUseMatrix<MatrixType, VectorType>::PreconditionUseMatrix(
   const MatrixType & M,
   const function_ptr method)
@@ -2646,7 +2646,7 @@ PreconditionUseMatrix<MatrixType, VectorType>::PreconditionUseMatrix(
 
 
 
-template <typename MatrixType, class VectorType>
+template <typename MatrixType, typename VectorType>
 void
 PreconditionUseMatrix<MatrixType, VectorType>::vmult(
   VectorType &      dst,
@@ -3444,7 +3444,7 @@ namespace internal
 
 
 
-template <typename MatrixType, class VectorType, typename PreconditionerType>
+template <typename MatrixType, typename VectorType, typename PreconditionerType>
 inline PreconditionChebyshev<MatrixType, VectorType, PreconditionerType>::
   AdditionalData::AdditionalData(const unsigned int        degree,
                                  const double              smoothing_range,
@@ -3464,7 +3464,7 @@ inline PreconditionChebyshev<MatrixType, VectorType, PreconditionerType>::
 
 
 
-template <typename MatrixType, class VectorType, typename PreconditionerType>
+template <typename MatrixType, typename VectorType, typename PreconditionerType>
 inline typename PreconditionChebyshev<MatrixType,
                                       VectorType,
                                       PreconditionerType>::AdditionalData &

--- a/include/deal.II/lac/qr.h
+++ b/include/deal.II/lac/qr.h
@@ -560,7 +560,7 @@ BaseQR<VectorType>::multiply_with_colsT(Vector<Number> &  y,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 boost::signals2::connection
 BaseQR<VectorType>::connect_givens_slot(
   const std::function<void(const unsigned int i,
@@ -572,7 +572,7 @@ BaseQR<VectorType>::connect_givens_slot(
 
 
 
-template <class VectorType>
+template <typename VectorType>
 boost::signals2::connection
 ImplicitQR<VectorType>::connect_append_column_slot(
   const std::function<bool(const Vector<Number> &u,

--- a/include/deal.II/lac/relaxation_block.templates.h
+++ b/include/deal.II/lac/relaxation_block.templates.h
@@ -180,7 +180,7 @@ namespace internal
    * Default implementation for serial vectors. Here we don't need to make a
    * copy into a ghosted vector, so just return a reference to @p prev.
    */
-  template <class VectorType>
+  template <typename VectorType>
   const VectorType &
   prepare_ghost_vector(const VectorType &prev, VectorType *other)
   {

--- a/include/deal.II/lac/solver.h
+++ b/include/deal.II/lac/solver.h
@@ -336,7 +336,7 @@ class Vector;
  *
  * @ingroup Solvers
  */
-template <class VectorType = Vector<double>>
+template <typename VectorType = Vector<double>>
 class SolverBase : public Subscriptor
 {
 public:
@@ -475,7 +475,7 @@ protected:
 /*-------------------------------- Inline functions ------------------------*/
 
 
-template <class VectorType>
+template <typename VectorType>
 inline SolverControl::State
 SolverBase<VectorType>::StateCombiner::operator()(
   const SolverControl::State state1,
@@ -491,7 +491,7 @@ SolverBase<VectorType>::StateCombiner::operator()(
 }
 
 
-template <class VectorType>
+template <typename VectorType>
 template <typename Iterator>
 inline SolverControl::State
 SolverBase<VectorType>::StateCombiner::operator()(const Iterator begin,
@@ -511,7 +511,7 @@ SolverBase<VectorType>::StateCombiner::operator()(const Iterator begin,
 }
 
 
-template <class VectorType>
+template <typename VectorType>
 inline SolverBase<VectorType>::SolverBase(
   SolverControl &           solver_control,
   VectorMemory<VectorType> &vector_memory)
@@ -530,7 +530,7 @@ inline SolverBase<VectorType>::SolverBase(
 
 
 
-template <class VectorType>
+template <typename VectorType>
 inline SolverBase<VectorType>::SolverBase(SolverControl &solver_control)
   : // use the static memory object this class owns
   memory(static_vector_memory)
@@ -548,7 +548,7 @@ inline SolverBase<VectorType>::SolverBase(SolverControl &solver_control)
 
 
 
-template <class VectorType>
+template <typename VectorType>
 inline boost::signals2::connection
 SolverBase<VectorType>::connect(
   const std::function<SolverControl::State(const unsigned int iteration,

--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -190,7 +190,7 @@ namespace internal
  * connect_condition_number_slot and @p connect_eigenvalues_slot. These slots
  * will then be called from the solver with the estimates as argument.
  */
-template <class VectorType = Vector<double>>
+template <typename VectorType = Vector<double>>
 class SolverGMRES : public SolverBase<VectorType>
 {
 public:
@@ -495,7 +495,7 @@ protected:
  *
  * For more details see @cite Saad1991.
  */
-template <class VectorType = Vector<double>>
+template <typename VectorType = Vector<double>>
 class SolverFGMRES : public SolverBase<VectorType>
 {
 public:
@@ -577,7 +577,7 @@ namespace internal
 {
   namespace SolverGMRESImplementation
   {
-    template <class VectorType>
+    template <typename VectorType>
     inline TmpVectors<VectorType>::TmpVectors(const unsigned int max_size,
                                               VectorMemory<VectorType> &vmem)
       : mem(vmem)
@@ -586,7 +586,7 @@ namespace internal
 
 
 
-    template <class VectorType>
+    template <typename VectorType>
     inline VectorType &
     TmpVectors<VectorType>::operator[](const unsigned int i) const
     {
@@ -598,7 +598,7 @@ namespace internal
 
 
 
-    template <class VectorType>
+    template <typename VectorType>
     inline VectorType &
     TmpVectors<VectorType>::operator()(const unsigned int i,
                                        const VectorType & temp)
@@ -614,7 +614,7 @@ namespace internal
 
 
 
-    template <class VectorType>
+    template <typename VectorType>
     unsigned int
     TmpVectors<VectorType>::size() const
     {
@@ -654,7 +654,7 @@ namespace internal
 
 
 
-template <class VectorType>
+template <typename VectorType>
 inline SolverGMRES<VectorType>::AdditionalData::AdditionalData(
   const unsigned int                             max_n_tmp_vectors,
   const bool                                     right_preconditioning,
@@ -676,7 +676,7 @@ inline SolverGMRES<VectorType>::AdditionalData::AdditionalData(
 
 
 
-template <class VectorType>
+template <typename VectorType>
 SolverGMRES<VectorType>::SolverGMRES(SolverControl &           cn,
                                      VectorMemory<VectorType> &mem,
                                      const AdditionalData &    data)
@@ -687,7 +687,7 @@ SolverGMRES<VectorType>::SolverGMRES(SolverControl &           cn,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 SolverGMRES<VectorType>::SolverGMRES(SolverControl &       cn,
                                      const AdditionalData &data)
   : SolverBase<VectorType>(cn)
@@ -697,7 +697,7 @@ SolverGMRES<VectorType>::SolverGMRES(SolverControl &       cn,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 inline void
 SolverGMRES<VectorType>::givens_rotation(Vector<double> &h,
                                          Vector<double> &b,
@@ -827,7 +827,7 @@ namespace internal
 
 
 
-    template <class VectorType,
+    template <typename VectorType,
               std::enable_if_t<
                 !is_dealii_compatible_distributed_vector<VectorType>::value,
                 VectorType> * = nullptr>
@@ -844,7 +844,7 @@ namespace internal
 
 
 
-    template <class VectorType,
+    template <typename VectorType,
               std::enable_if_t<
                 is_dealii_compatible_distributed_vector<VectorType>::value,
                 VectorType> * = nullptr>
@@ -917,7 +917,7 @@ namespace internal
 
 
 
-    template <class VectorType,
+    template <typename VectorType,
               std::enable_if_t<
                 !is_dealii_compatible_distributed_vector<VectorType>::value,
                 VectorType> * = nullptr>
@@ -939,7 +939,7 @@ namespace internal
 
 
 
-    template <class VectorType,
+    template <typename VectorType,
               std::enable_if_t<
                 is_dealii_compatible_distributed_vector<VectorType>::value,
                 VectorType> * = nullptr>
@@ -1027,7 +1027,7 @@ namespace internal
     }
 
 
-    template <class VectorType,
+    template <typename VectorType,
               std::enable_if_t<
                 !is_dealii_compatible_distributed_vector<VectorType>::value,
                 VectorType> * = nullptr>
@@ -1042,7 +1042,7 @@ namespace internal
     }
 
 
-    template <class VectorType,
+    template <typename VectorType,
               std::enable_if_t<
                 is_dealii_compatible_distributed_vector<VectorType>::value,
                 VectorType> * = nullptr>
@@ -1071,7 +1071,7 @@ namespace internal
 
 
 
-    template <class VectorType,
+    template <typename VectorType,
               std::enable_if_t<
                 !is_dealii_compatible_distributed_vector<VectorType>::value,
                 VectorType> * = nullptr>
@@ -1094,7 +1094,7 @@ namespace internal
 
 
 
-    template <class VectorType,
+    template <typename VectorType,
               std::enable_if_t<
                 is_dealii_compatible_distributed_vector<VectorType>::value,
                 VectorType> * = nullptr>
@@ -1129,7 +1129,7 @@ namespace internal
      * All subsequent iterations use re-orthogonalization.
      * Calls the signal re_orthogonalize_signal if it is connected.
      */
-    template <class VectorType>
+    template <typename VectorType>
     inline double
     iterated_gram_schmidt(
       const LinearAlgebra::OrthogonalizationStrategy orthogonalization_strategy,
@@ -1230,7 +1230,7 @@ namespace internal
 
 
 
-template <class VectorType>
+template <typename VectorType>
 inline void
 SolverGMRES<VectorType>::compute_eigs_and_cond(
   const FullMatrix<double> &H_orig,
@@ -1282,7 +1282,7 @@ SolverGMRES<VectorType>::compute_eigs_and_cond(
 
 
 
-template <class VectorType>
+template <typename VectorType>
 template <typename MatrixType, typename PreconditionerType>
 void
 SolverGMRES<VectorType>::solve(const MatrixType &        A,
@@ -1601,7 +1601,7 @@ SolverGMRES<VectorType>::solve(const MatrixType &        A,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 boost::signals2::connection
 SolverGMRES<VectorType>::connect_condition_number_slot(
   const std::function<void(double)> &slot,
@@ -1619,7 +1619,7 @@ SolverGMRES<VectorType>::connect_condition_number_slot(
 
 
 
-template <class VectorType>
+template <typename VectorType>
 boost::signals2::connection
 SolverGMRES<VectorType>::connect_eigenvalues_slot(
   const std::function<void(const std::vector<std::complex<double>> &)> &slot,
@@ -1637,7 +1637,7 @@ SolverGMRES<VectorType>::connect_eigenvalues_slot(
 
 
 
-template <class VectorType>
+template <typename VectorType>
 boost::signals2::connection
 SolverGMRES<VectorType>::connect_hessenberg_slot(
   const std::function<void(const FullMatrix<double> &)> &slot,
@@ -1655,7 +1655,7 @@ SolverGMRES<VectorType>::connect_hessenberg_slot(
 
 
 
-template <class VectorType>
+template <typename VectorType>
 boost::signals2::connection
 SolverGMRES<VectorType>::connect_krylov_space_slot(
   const std::function<void(
@@ -1666,7 +1666,7 @@ SolverGMRES<VectorType>::connect_krylov_space_slot(
 
 
 
-template <class VectorType>
+template <typename VectorType>
 boost::signals2::connection
 SolverGMRES<VectorType>::connect_re_orthogonalization_slot(
   const std::function<void(int)> &slot)
@@ -1676,7 +1676,7 @@ SolverGMRES<VectorType>::connect_re_orthogonalization_slot(
 
 
 
-template <class VectorType>
+template <typename VectorType>
 double
 SolverGMRES<VectorType>::criterion()
 {
@@ -1689,7 +1689,7 @@ SolverGMRES<VectorType>::criterion()
 
 //----------------------------------------------------------------------//
 
-template <class VectorType>
+template <typename VectorType>
 SolverFGMRES<VectorType>::SolverFGMRES(SolverControl &           cn,
                                        VectorMemory<VectorType> &mem,
                                        const AdditionalData &    data)
@@ -1699,7 +1699,7 @@ SolverFGMRES<VectorType>::SolverFGMRES(SolverControl &           cn,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 SolverFGMRES<VectorType>::SolverFGMRES(SolverControl &       cn,
                                        const AdditionalData &data)
   : SolverBase<VectorType>(cn)
@@ -1708,7 +1708,7 @@ SolverFGMRES<VectorType>::SolverFGMRES(SolverControl &       cn,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 template <typename MatrixType, typename PreconditionerType>
 void
 SolverFGMRES<VectorType>::solve(const MatrixType &        A,

--- a/include/deal.II/lac/solver_idr.h
+++ b/include/deal.II/lac/solver_idr.h
@@ -115,7 +115,7 @@ namespace internal
  * these steps is stored and therefore there will be multiple values per
  * iteration.
  */
-template <class VectorType = Vector<double>>
+template <typename VectorType = Vector<double>>
 class SolverIDR : public SolverBase<VectorType>
 {
 public:
@@ -192,7 +192,7 @@ namespace internal
 {
   namespace SolverIDRImplementation
   {
-    template <class VectorType>
+    template <typename VectorType>
     inline TmpVectors<VectorType>::TmpVectors(const unsigned int        s_param,
                                               VectorMemory<VectorType> &vmem)
       : mem(vmem)
@@ -201,7 +201,7 @@ namespace internal
 
 
 
-    template <class VectorType>
+    template <typename VectorType>
     inline VectorType &
     TmpVectors<VectorType>::operator[](const unsigned int i) const
     {
@@ -213,7 +213,7 @@ namespace internal
 
 
 
-    template <class VectorType>
+    template <typename VectorType>
     inline VectorType &
     TmpVectors<VectorType>::operator()(const unsigned int i,
                                        const VectorType & temp)
@@ -278,7 +278,7 @@ namespace internal
 
 
 
-template <class VectorType>
+template <typename VectorType>
 SolverIDR<VectorType>::SolverIDR(SolverControl &           cn,
                                  VectorMemory<VectorType> &mem,
                                  const AdditionalData &    data)
@@ -288,7 +288,7 @@ SolverIDR<VectorType>::SolverIDR(SolverControl &           cn,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 SolverIDR<VectorType>::SolverIDR(SolverControl &cn, const AdditionalData &data)
   : SolverBase<VectorType>(cn)
   , additional_data(data)
@@ -296,7 +296,7 @@ SolverIDR<VectorType>::SolverIDR(SolverControl &cn, const AdditionalData &data)
 
 
 
-template <class VectorType>
+template <typename VectorType>
 void
 SolverIDR<VectorType>::print_vectors(const unsigned int,
                                      const VectorType &,
@@ -306,7 +306,7 @@ SolverIDR<VectorType>::print_vectors(const unsigned int,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 template <typename MatrixType, typename PreconditionerType>
 void
 SolverIDR<VectorType>::solve(const MatrixType &        A,

--- a/include/deal.II/lac/solver_minres.h
+++ b/include/deal.II/lac/solver_minres.h
@@ -66,7 +66,7 @@ DEAL_II_NAMESPACE_OPEN
  * Solver base class to determine convergence. This mechanism can also be used
  * to observe the progress of the iteration.
  */
-template <class VectorType = Vector<double>>
+template <typename VectorType = Vector<double>>
 class SolverMinRes : public SolverBase<VectorType>
 {
 public:
@@ -149,7 +149,7 @@ protected:
 
 #ifndef DOXYGEN
 
-template <class VectorType>
+template <typename VectorType>
 SolverMinRes<VectorType>::SolverMinRes(SolverControl &           cn,
                                        VectorMemory<VectorType> &mem,
                                        const AdditionalData &)
@@ -159,7 +159,7 @@ SolverMinRes<VectorType>::SolverMinRes(SolverControl &           cn,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 SolverMinRes<VectorType>::SolverMinRes(SolverControl &cn,
                                        const AdditionalData &)
   : SolverBase<VectorType>(cn)
@@ -168,7 +168,7 @@ SolverMinRes<VectorType>::SolverMinRes(SolverControl &cn,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 double
 SolverMinRes<VectorType>::criterion()
 {
@@ -176,7 +176,7 @@ SolverMinRes<VectorType>::criterion()
 }
 
 
-template <class VectorType>
+template <typename VectorType>
 void
 SolverMinRes<VectorType>::print_vectors(const unsigned int,
                                         const VectorType &,
@@ -186,7 +186,7 @@ SolverMinRes<VectorType>::print_vectors(const unsigned int,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 template <typename MatrixType, typename PreconditionerType>
 void
 SolverMinRes<VectorType>::solve(const MatrixType &        A,

--- a/include/deal.II/lac/solver_qmrs.h
+++ b/include/deal.II/lac/solver_qmrs.h
@@ -240,7 +240,7 @@ private:
 #ifndef DOXYGEN
 
 
-template <class VectorType>
+template <typename VectorType>
 SolverQMRS<VectorType>::IterationResult::IterationResult(
   const SolverControl::State state,
   const double               last_residual)
@@ -250,7 +250,7 @@ SolverQMRS<VectorType>::IterationResult::IterationResult(
 
 
 
-template <class VectorType>
+template <typename VectorType>
 SolverQMRS<VectorType>::SolverQMRS(SolverControl &           cn,
                                    VectorMemory<VectorType> &mem,
                                    const AdditionalData &    data)
@@ -259,7 +259,7 @@ SolverQMRS<VectorType>::SolverQMRS(SolverControl &           cn,
   , step(0)
 {}
 
-template <class VectorType>
+template <typename VectorType>
 SolverQMRS<VectorType>::SolverQMRS(SolverControl &       cn,
                                    const AdditionalData &data)
   : SolverBase<VectorType>(cn)
@@ -267,7 +267,7 @@ SolverQMRS<VectorType>::SolverQMRS(SolverControl &       cn,
   , step(0)
 {}
 
-template <class VectorType>
+template <typename VectorType>
 void
 SolverQMRS<VectorType>::print_vectors(const unsigned int,
                                       const VectorType &,
@@ -275,7 +275,7 @@ SolverQMRS<VectorType>::print_vectors(const unsigned int,
                                       const VectorType &) const
 {}
 
-template <class VectorType>
+template <typename VectorType>
 template <typename MatrixType, typename PreconditionerType>
 void
 SolverQMRS<VectorType>::solve(const MatrixType &        A,
@@ -323,7 +323,7 @@ SolverQMRS<VectorType>::solve(const MatrixType &        A,
   // otherwise exit as normal
 }
 
-template <class VectorType>
+template <typename VectorType>
 template <typename MatrixType, typename PreconditionerType>
 typename SolverQMRS<VectorType>::IterationResult
 SolverQMRS<VectorType>::iterate(const MatrixType &        A,

--- a/include/deal.II/lac/solver_relaxation.h
+++ b/include/deal.II/lac/solver_relaxation.h
@@ -85,7 +85,7 @@ public:
 
 //----------------------------------------------------------------------//
 
-template <class VectorType>
+template <typename VectorType>
 SolverRelaxation<VectorType>::SolverRelaxation(SolverControl &cn,
                                                const AdditionalData &)
   : SolverBase<VectorType>(cn)
@@ -93,7 +93,7 @@ SolverRelaxation<VectorType>::SolverRelaxation(SolverControl &cn,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 template <typename MatrixType, class RelaxationType>
 void
 SolverRelaxation<VectorType>::solve(const MatrixType &    A,

--- a/include/deal.II/lac/solver_richardson.h
+++ b/include/deal.II/lac/solver_richardson.h
@@ -60,7 +60,7 @@ DEAL_II_NAMESPACE_OPEN
  * Solver base class to determine convergence. This mechanism can also be used
  * to observe the progress of the iteration.
  */
-template <class VectorType = Vector<double>>
+template <typename VectorType = Vector<double>>
 class SolverRichardson : public SolverBase<VectorType>
 {
 public:
@@ -163,7 +163,7 @@ protected:
 
 #ifndef DOXYGEN
 
-template <class VectorType>
+template <typename VectorType>
 inline SolverRichardson<VectorType>::AdditionalData::AdditionalData(
   const double omega,
   const bool   use_preconditioned_residual)
@@ -172,7 +172,7 @@ inline SolverRichardson<VectorType>::AdditionalData::AdditionalData(
 {}
 
 
-template <class VectorType>
+template <typename VectorType>
 SolverRichardson<VectorType>::SolverRichardson(SolverControl &           cn,
                                                VectorMemory<VectorType> &mem,
                                                const AdditionalData &    data)
@@ -182,7 +182,7 @@ SolverRichardson<VectorType>::SolverRichardson(SolverControl &           cn,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 SolverRichardson<VectorType>::SolverRichardson(SolverControl &       cn,
                                                const AdditionalData &data)
   : SolverBase<VectorType>(cn)
@@ -191,7 +191,7 @@ SolverRichardson<VectorType>::SolverRichardson(SolverControl &       cn,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 template <typename MatrixType, typename PreconditionerType>
 void
 SolverRichardson<VectorType>::solve(const MatrixType &        A,
@@ -248,7 +248,7 @@ SolverRichardson<VectorType>::solve(const MatrixType &        A,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 template <typename MatrixType, typename PreconditionerType>
 void
 SolverRichardson<VectorType>::Tsolve(const MatrixType &        A,
@@ -302,7 +302,7 @@ SolverRichardson<VectorType>::Tsolve(const MatrixType &        A,
 }
 
 
-template <class VectorType>
+template <typename VectorType>
 void
 SolverRichardson<VectorType>::print_vectors(const unsigned int,
                                             const VectorType &,
@@ -312,7 +312,7 @@ SolverRichardson<VectorType>::print_vectors(const unsigned int,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 inline typename VectorType::value_type
 SolverRichardson<VectorType>::criterion(const VectorType &r,
                                         const VectorType &d) const
@@ -324,7 +324,7 @@ SolverRichardson<VectorType>::criterion(const VectorType &r,
 }
 
 
-template <class VectorType>
+template <typename VectorType>
 inline void
 SolverRichardson<VectorType>::set_omega(const double om)
 {

--- a/include/deal.II/lac/trilinos_solver.h
+++ b/include/deal.II/lac/trilinos_solver.h
@@ -738,7 +738,7 @@ namespace TrilinosWrappers
      * see
      * https://docs.trilinos.org/latest-release/packages/belos/doc/html/classBelos_1_1MultiVec.html.
      */
-    template <class VectorType>
+    template <typename VectorType>
     class MultiVecWrapper
       : public Belos::MultiVec<typename VectorType::value_type>
     {
@@ -1177,7 +1177,7 @@ namespace TrilinosWrappers
      * operators/preconditioners. For details, see
      * https://docs.trilinos.org/latest-release/packages/belos/doc/html/classBelos_1_1Operator.html.
      */
-    template <class OperatorType, class VectorType>
+    template <class OperatorType, typename VectorType>
     class OperatorWrapper
       : public Belos::Operator<typename VectorType::value_type>
     {

--- a/include/deal.II/matrix_free/type_traits.h
+++ b/include/deal.II/matrix_free/type_traits.h
@@ -194,14 +194,14 @@ namespace internal
    * by seeing whether the `is_serial_vector` type is declared for the
    * given vector type.
    */
-  template <class VectorType>
+  template <typename VectorType>
   using is_vector_type = decltype(is_serial_vector<VectorType>::value);
 
   /**
    * A predicate stating whether something is a vector type and is
    * indeed a serial vector.
    */
-  template <class VectorType>
+  template <typename VectorType>
   using is_serial_vector_type =
     decltype(std::enable_if_t<is_serial_vector<VectorType>::value, int>());
 
@@ -210,7 +210,7 @@ namespace internal
    * a vector type at all, or (ii) if it is a vector type,
    * that it is not a parallel vector type.
    */
-  template <class VectorType>
+  template <typename VectorType>
   constexpr bool is_not_parallel_vector =
     (is_supported_operation<is_vector_type, VectorType> == false) ||
     (is_supported_operation<is_serial_vector_type, VectorType> == true);

--- a/include/deal.II/multigrid/mg_coarse.h
+++ b/include/deal.II/multigrid/mg_coarse.h
@@ -36,7 +36,7 @@ DEAL_II_NAMESPACE_OPEN
  * Coarse grid solver using smoother only. This is a little wrapper,
  * transforming a smoother into a coarse grid solver.
  */
-template <class VectorType = Vector<double>>
+template <typename VectorType = Vector<double>>
 class MGCoarseGridApplySmoother : public MGCoarseGridBase<VectorType>
 {
 public:
@@ -87,7 +87,7 @@ private:
  * This class provides a wrapper for a deal.II iterative solver with a given
  * matrix and preconditioner as a coarse grid operator.
  */
-template <class VectorType,
+template <typename VectorType,
           class SolverType,
           class MatrixType,
           class PreconditionerType>
@@ -173,7 +173,7 @@ private:
  * the operator() uses Householder::least_squares() to compute the action of
  * the inverse.
  */
-template <typename number = double, class VectorType = Vector<number>>
+template <typename number = double, typename VectorType = Vector<number>>
 class MGCoarseGridHouseholder : public MGCoarseGridBase<VectorType>
 {
 public:
@@ -206,7 +206,7 @@ private:
  * Upon initialization, the singular value decomposition of the matrix is
  * computed. then, the operator() uses
  */
-template <typename number = double, class VectorType = Vector<number>>
+template <typename number = double, typename VectorType = Vector<number>>
 class MGCoarseGridSVD : public MGCoarseGridBase<VectorType>
 {
 public:
@@ -243,12 +243,12 @@ private:
 
 #ifndef DOXYGEN
 /* ------------------ Functions for MGCoarseGridApplySmoother -----------*/
-template <class VectorType>
+template <typename VectorType>
 MGCoarseGridApplySmoother<VectorType>::MGCoarseGridApplySmoother()
   : coarse_smooth(nullptr)
 {}
 
-template <class VectorType>
+template <typename VectorType>
 MGCoarseGridApplySmoother<VectorType>::MGCoarseGridApplySmoother(
   const MGSmootherBase<VectorType> &coarse_smooth)
   : coarse_smooth(nullptr)
@@ -257,7 +257,7 @@ MGCoarseGridApplySmoother<VectorType>::MGCoarseGridApplySmoother(
 }
 
 
-template <class VectorType>
+template <typename VectorType>
 void
 MGCoarseGridApplySmoother<VectorType>::initialize(
   const MGSmootherBase<VectorType> &coarse_smooth_)
@@ -269,7 +269,7 @@ MGCoarseGridApplySmoother<VectorType>::initialize(
 }
 
 
-template <class VectorType>
+template <typename VectorType>
 void
 MGCoarseGridApplySmoother<VectorType>::clear()
 {
@@ -277,7 +277,7 @@ MGCoarseGridApplySmoother<VectorType>::clear()
 }
 
 
-template <class VectorType>
+template <typename VectorType>
 void
 MGCoarseGridApplySmoother<VectorType>::operator()(const unsigned int level,
                                                   VectorType &       dst,
@@ -288,7 +288,7 @@ MGCoarseGridApplySmoother<VectorType>::operator()(const unsigned int level,
 
 /* ------------------ Functions for MGCoarseGridIterativeSolver ------------ */
 
-template <class VectorType,
+template <typename VectorType,
           class SolverType,
           class MatrixType,
           class PreconditionerType>
@@ -303,7 +303,7 @@ MGCoarseGridIterativeSolver<VectorType,
 
 
 
-template <class VectorType,
+template <typename VectorType,
           class SolverType,
           class MatrixType,
           class PreconditionerType>
@@ -321,7 +321,7 @@ MGCoarseGridIterativeSolver<VectorType,
 
 
 
-template <class VectorType,
+template <typename VectorType,
           class SolverType,
           class MatrixType,
           class PreconditionerType>
@@ -341,7 +341,7 @@ MGCoarseGridIterativeSolver<
 
 
 
-template <class VectorType,
+template <typename VectorType,
           class SolverType,
           class MatrixType,
           class PreconditionerType>
@@ -363,7 +363,7 @@ namespace internal
   namespace MGCoarseGridIterativeSolver
   {
     template <
-      class VectorType,
+      typename VectorType,
       class SolverType,
       class MatrixType,
       class PreconditionerType,
@@ -381,7 +381,7 @@ namespace internal
     }
 
     template <
-      class VectorType,
+      typename VectorType,
       class SolverType,
       class MatrixType,
       class PreconditionerType,
@@ -410,7 +410,7 @@ namespace internal
 
 
 
-template <class VectorType,
+template <typename VectorType,
           class SolverType,
           class MatrixType,
           class PreconditionerType>
@@ -436,7 +436,7 @@ void
 
 /* ------------------ Functions for MGCoarseGridHouseholder ------------ */
 
-template <typename number, class VectorType>
+template <typename number, typename VectorType>
 MGCoarseGridHouseholder<number, VectorType>::MGCoarseGridHouseholder(
   const FullMatrix<number> *A)
 {
@@ -446,7 +446,7 @@ MGCoarseGridHouseholder<number, VectorType>::MGCoarseGridHouseholder(
 
 
 
-template <typename number, class VectorType>
+template <typename number, typename VectorType>
 void
 MGCoarseGridHouseholder<number, VectorType>::initialize(
   const FullMatrix<number> &A)
@@ -456,7 +456,7 @@ MGCoarseGridHouseholder<number, VectorType>::initialize(
 
 
 
-template <typename number, class VectorType>
+template <typename number, typename VectorType>
 void
 MGCoarseGridHouseholder<number, VectorType>::operator()(
   const unsigned int /*level*/,
@@ -470,7 +470,7 @@ MGCoarseGridHouseholder<number, VectorType>::operator()(
 
 
 
-template <typename number, class VectorType>
+template <typename number, typename VectorType>
 void
 MGCoarseGridSVD<number, VectorType>::initialize(const FullMatrix<number> &A,
                                                 double threshold)
@@ -481,7 +481,7 @@ MGCoarseGridSVD<number, VectorType>::initialize(const FullMatrix<number> &A,
 }
 
 
-template <typename number, class VectorType>
+template <typename number, typename VectorType>
 void
 MGCoarseGridSVD<number, VectorType>::operator()(const unsigned int /*level*/,
                                                 VectorType &      dst,
@@ -491,7 +491,7 @@ MGCoarseGridSVD<number, VectorType>::operator()(const unsigned int /*level*/,
 }
 
 
-template <typename number, class VectorType>
+template <typename number, typename VectorType>
 void
 MGCoarseGridSVD<number, VectorType>::log() const
 {

--- a/include/deal.II/multigrid/mg_coarse.h
+++ b/include/deal.II/multigrid/mg_coarse.h
@@ -88,7 +88,7 @@ private:
  * matrix and preconditioner as a coarse grid operator.
  */
 template <typename VectorType,
-          class SolverType,
+          typename SolverType,
           typename MatrixType,
           class PreconditionerType>
 class MGCoarseGridIterativeSolver : public MGCoarseGridBase<VectorType>
@@ -289,7 +289,7 @@ MGCoarseGridApplySmoother<VectorType>::operator()(const unsigned int level,
 /* ------------------ Functions for MGCoarseGridIterativeSolver ------------ */
 
 template <typename VectorType,
-          class SolverType,
+          typename SolverType,
           typename MatrixType,
           class PreconditionerType>
 MGCoarseGridIterativeSolver<VectorType,
@@ -304,7 +304,7 @@ MGCoarseGridIterativeSolver<VectorType,
 
 
 template <typename VectorType,
-          class SolverType,
+          typename SolverType,
           typename MatrixType,
           class PreconditionerType>
 MGCoarseGridIterativeSolver<VectorType,
@@ -322,7 +322,7 @@ MGCoarseGridIterativeSolver<VectorType,
 
 
 template <typename VectorType,
-          class SolverType,
+          typename SolverType,
           typename MatrixType,
           class PreconditionerType>
 void
@@ -342,7 +342,7 @@ MGCoarseGridIterativeSolver<
 
 
 template <typename VectorType,
-          class SolverType,
+          typename SolverType,
           typename MatrixType,
           class PreconditionerType>
 void
@@ -364,7 +364,7 @@ namespace internal
   {
     template <
       typename VectorType,
-      class SolverType,
+      typename SolverType,
       typename MatrixType,
       class PreconditionerType,
       std::enable_if_t<
@@ -382,7 +382,7 @@ namespace internal
 
     template <
       typename VectorType,
-      class SolverType,
+      typename SolverType,
       typename MatrixType,
       class PreconditionerType,
       std::enable_if_t<
@@ -411,7 +411,7 @@ namespace internal
 
 
 template <typename VectorType,
-          class SolverType,
+          typename SolverType,
           typename MatrixType,
           class PreconditionerType>
 void

--- a/include/deal.II/multigrid/mg_coarse.h
+++ b/include/deal.II/multigrid/mg_coarse.h
@@ -89,7 +89,7 @@ private:
  */
 template <typename VectorType,
           class SolverType,
-          class MatrixType,
+          typename MatrixType,
           class PreconditionerType>
 class MGCoarseGridIterativeSolver : public MGCoarseGridBase<VectorType>
 {
@@ -290,7 +290,7 @@ MGCoarseGridApplySmoother<VectorType>::operator()(const unsigned int level,
 
 template <typename VectorType,
           class SolverType,
-          class MatrixType,
+          typename MatrixType,
           class PreconditionerType>
 MGCoarseGridIterativeSolver<VectorType,
                             SolverType,
@@ -305,7 +305,7 @@ MGCoarseGridIterativeSolver<VectorType,
 
 template <typename VectorType,
           class SolverType,
-          class MatrixType,
+          typename MatrixType,
           class PreconditionerType>
 MGCoarseGridIterativeSolver<VectorType,
                             SolverType,
@@ -323,7 +323,7 @@ MGCoarseGridIterativeSolver<VectorType,
 
 template <typename VectorType,
           class SolverType,
-          class MatrixType,
+          typename MatrixType,
           class PreconditionerType>
 void
 MGCoarseGridIterativeSolver<
@@ -343,7 +343,7 @@ MGCoarseGridIterativeSolver<
 
 template <typename VectorType,
           class SolverType,
-          class MatrixType,
+          typename MatrixType,
           class PreconditionerType>
 void
 MGCoarseGridIterativeSolver<VectorType,
@@ -365,7 +365,7 @@ namespace internal
     template <
       typename VectorType,
       class SolverType,
-      class MatrixType,
+      typename MatrixType,
       class PreconditionerType,
       std::enable_if_t<
         std::is_same<VectorType, typename SolverType::vector_type>::value,
@@ -383,7 +383,7 @@ namespace internal
     template <
       typename VectorType,
       class SolverType,
-      class MatrixType,
+      typename MatrixType,
       class PreconditionerType,
       std::enable_if_t<
         !std::is_same<VectorType, typename SolverType::vector_type>::value,
@@ -412,7 +412,7 @@ namespace internal
 
 template <typename VectorType,
           class SolverType,
-          class MatrixType,
+          typename MatrixType,
           class PreconditionerType>
 void
                        MGCoarseGridIterativeSolver<

--- a/include/deal.II/multigrid/mg_coarse.h
+++ b/include/deal.II/multigrid/mg_coarse.h
@@ -90,7 +90,7 @@ private:
 template <typename VectorType,
           typename SolverType,
           typename MatrixType,
-          class PreconditionerType>
+          typename PreconditionerType>
 class MGCoarseGridIterativeSolver : public MGCoarseGridBase<VectorType>
 {
 public:
@@ -291,7 +291,7 @@ MGCoarseGridApplySmoother<VectorType>::operator()(const unsigned int level,
 template <typename VectorType,
           typename SolverType,
           typename MatrixType,
-          class PreconditionerType>
+          typename PreconditionerType>
 MGCoarseGridIterativeSolver<VectorType,
                             SolverType,
                             MatrixType,
@@ -306,7 +306,7 @@ MGCoarseGridIterativeSolver<VectorType,
 template <typename VectorType,
           typename SolverType,
           typename MatrixType,
-          class PreconditionerType>
+          typename PreconditionerType>
 MGCoarseGridIterativeSolver<VectorType,
                             SolverType,
                             MatrixType,
@@ -324,7 +324,7 @@ MGCoarseGridIterativeSolver<VectorType,
 template <typename VectorType,
           typename SolverType,
           typename MatrixType,
-          class PreconditionerType>
+          typename PreconditionerType>
 void
 MGCoarseGridIterativeSolver<
   VectorType,
@@ -344,7 +344,7 @@ MGCoarseGridIterativeSolver<
 template <typename VectorType,
           typename SolverType,
           typename MatrixType,
-          class PreconditionerType>
+          typename PreconditionerType>
 void
 MGCoarseGridIterativeSolver<VectorType,
                             SolverType,
@@ -366,7 +366,7 @@ namespace internal
       typename VectorType,
       typename SolverType,
       typename MatrixType,
-      class PreconditionerType,
+      typename PreconditionerType,
       std::enable_if_t<
         std::is_same<VectorType, typename SolverType::vector_type>::value,
         VectorType> * = nullptr>
@@ -384,7 +384,7 @@ namespace internal
       typename VectorType,
       typename SolverType,
       typename MatrixType,
-      class PreconditionerType,
+      typename PreconditionerType,
       std::enable_if_t<
         !std::is_same<VectorType, typename SolverType::vector_type>::value,
         VectorType> * = nullptr>
@@ -413,7 +413,7 @@ namespace internal
 template <typename VectorType,
           typename SolverType,
           typename MatrixType,
-          class PreconditionerType>
+          typename PreconditionerType>
 void
                        MGCoarseGridIterativeSolver<
                          VectorType,

--- a/include/deal.II/non_matching/fe_values.h
+++ b/include/deal.II/non_matching/fe_values.h
@@ -167,7 +167,7 @@ namespace NonMatching
      * and @p level_set are stored internally, so these need to have a longer life
      * span than the instance of this class.
      */
-    template <class VectorType>
+    template <typename VectorType>
     FEValues(const hp::FECollection<dim> &fe_collection,
              const Quadrature<1> &        quadrature,
              const RegionUpdateFlags      region_update_flags,
@@ -202,7 +202,7 @@ namespace NonMatching
      * internally, so these need to have a longer life span than the instance of
      * this class.
      */
-    template <class VectorType>
+    template <typename VectorType>
     FEValues(const hp::MappingCollection<dim> &mapping_collection,
              const hp::FECollection<dim> &     fe_collection,
              const hp::QCollection<dim> &      q_collection,
@@ -461,7 +461,7 @@ namespace NonMatching
      * and @p level_set are stored internally, so these need to have a longer life
      * span than the instance of this class.
      */
-    template <class VectorType>
+    template <typename VectorType>
     FEInterfaceValues(const hp::FECollection<dim> &fe_collection,
                       const Quadrature<1> &        quadrature,
                       const RegionUpdateFlags      region_update_flags,
@@ -496,7 +496,7 @@ namespace NonMatching
      * internally, so these need to have a longer life span than the instance of
      * this class.
      */
-    template <class VectorType>
+    template <typename VectorType>
     FEInterfaceValues(const hp::MappingCollection<dim> &mapping_collection,
                       const hp::FECollection<dim> &     fe_collection,
                       const hp::QCollection<dim - 1> &  q_collection,

--- a/include/deal.II/non_matching/mesh_classifier.h
+++ b/include/deal.II/non_matching/mesh_classifier.h
@@ -114,7 +114,7 @@ namespace NonMatching
      * Vector. The triangulation attached to DoFHandler is the one that will be
      * classified.
      */
-    template <class VectorType>
+    template <typename VectorType>
     MeshClassifier(const DoFHandler<dim> &level_set_dof_handler,
                    const VectorType &     level_set);
 

--- a/include/deal.II/non_matching/quadrature_generator.h
+++ b/include/deal.II/non_matching/quadrature_generator.h
@@ -500,7 +500,7 @@ namespace NonMatching
      * class. The hp::QCollection<1> and AdditionalData is passed to the
      * QuadratureGenerator class.
      */
-    template <class VectorType>
+    template <typename VectorType>
     DiscreteQuadratureGenerator(
       const hp::QCollection<1> &quadratures1D,
       const DoFHandler<dim> &   dof_handler,
@@ -556,7 +556,7 @@ namespace NonMatching
      * class. The hp::QCollection<1> and AdditionalData is passed to the
      * QuadratureGenerator class.
      */
-    template <class VectorType>
+    template <typename VectorType>
     DiscreteFaceQuadratureGenerator(
       const hp::QCollection<1> &quadratures1D,
       const DoFHandler<dim> &   dof_handler,

--- a/include/deal.II/numerics/data_out_dof_data.h
+++ b/include/deal.II/numerics/data_out_dof_data.h
@@ -726,7 +726,7 @@ public:
    * which FEValues can extract values on a cell using the
    * FEValuesBase::get_function_values() function.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   add_data_vector(
     const VectorType &              data,
@@ -751,7 +751,7 @@ public:
    * which FEValues can extract values on a cell using the
    * FEValuesBase::get_function_values() function.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   add_data_vector(
     const VectorType &   data,
@@ -775,7 +775,7 @@ public:
    * represents dof data, the data vector type argument present in the other
    * methods above is not necessary.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   add_data_vector(
     const DoFHandler<dim, spacedim> &dof_handler,
@@ -789,7 +789,7 @@ public:
    * This function is an abbreviation of the function above with only a scalar
    * @p dof_handler given and a single data name.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   add_data_vector(
     const DoFHandler<dim, spacedim> &dof_handler,
@@ -824,7 +824,7 @@ public:
    * error by declaring the data postprocessor variable before the DataOut
    * variable as objects are destroyed in reverse order of declaration.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   add_data_vector(const VectorType &                 data,
                   const DataPostprocessor<spacedim> &data_postprocessor);
@@ -835,7 +835,7 @@ public:
    * postprocessor can only read data from the given DoFHandler and solution
    * vector, not other solution vectors or DoFHandlers.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   add_data_vector(const DoFHandler<dim, spacedim> &  dof_handler,
                   const VectorType &                 data,
@@ -858,7 +858,7 @@ public:
    * The handling of @p names and @p data_component_interpretation is identical
    * to the add_data_vector() function.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   add_mg_data_vector(
     const DoFHandler<dim, spacedim> &dof_handler,
@@ -871,7 +871,7 @@ public:
   /**
    * Scalar version of the function above.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   add_mg_data_vector(const DoFHandler<dim, spacedim> &dof_handler,
                      const MGLevelObject<VectorType> &data,
@@ -1030,7 +1030,7 @@ private:
   /**
    * Common function called by the four public add_data_vector methods.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   add_data_vector_internal(
     const DoFHandler<dim, spacedim> *dof_handler,

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -2009,7 +2009,7 @@ DataOut_DoFData<dim, patch_dim, spacedim, patch_spacedim>::
 
 
 template <int dim, int patch_dim, int spacedim, int patch_spacedim>
-template <class VectorType>
+template <typename VectorType>
 void
 DataOut_DoFData<dim, patch_dim, spacedim, patch_spacedim>::add_mg_data_vector(
   const DoFHandler<dim, spacedim> &dof_handler,
@@ -2024,7 +2024,7 @@ DataOut_DoFData<dim, patch_dim, spacedim, patch_spacedim>::add_mg_data_vector(
 
 
 template <int dim, int patch_dim, int spacedim, int patch_spacedim>
-template <class VectorType>
+template <typename VectorType>
 void
 DataOut_DoFData<dim, patch_dim, spacedim, patch_spacedim>::add_mg_data_vector(
   const DoFHandler<dim, spacedim> &dof_handler,

--- a/include/deal.II/numerics/dof_print_solver_step.h
+++ b/include/deal.II/numerics/dof_print_solver_step.h
@@ -51,7 +51,7 @@ DEAL_II_NAMESPACE_OPEN
  *
  * @ingroup output
  */
-template <int dim, typename SolverType, class VectorType = Vector<double>>
+template <int dim, typename SolverType, typename VectorType = Vector<double>>
 class DoFPrintSolverStep : public SolverType
 {
 public:
@@ -91,7 +91,7 @@ private:
 
 /* ----------------------- template functions --------------- */
 
-template <int dim, typename SolverType, class VectorType>
+template <int dim, typename SolverType, typename VectorType>
 DoFPrintSolverStep<dim, SolverType, VectorType>::DoFPrintSolverStep(
   SolverControl &           control,
   VectorMemory<VectorType> &mem,
@@ -103,7 +103,7 @@ DoFPrintSolverStep<dim, SolverType, VectorType>::DoFPrintSolverStep(
 {}
 
 
-template <int dim, typename SolverType, class VectorType>
+template <int dim, typename SolverType, typename VectorType>
 void
 DoFPrintSolverStep<dim, SolverType, VectorType>::print_vectors(
   const unsigned int step,

--- a/include/deal.II/numerics/point_value_history.h
+++ b/include/deal.II/numerics/point_value_history.h
@@ -332,7 +332,7 @@ public:
    * called for each dataset (time step, iteration, etc) for each vector_name,
    * otherwise a @p ExcDataLostSync error can occur.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   evaluate_field(const std::string &name, const VectorType &solution);
 
@@ -354,7 +354,7 @@ public:
    * method must be called for each dataset (time step, iteration, etc) for
    * each vector_name, otherwise a @p ExcDataLostSync error can occur.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   evaluate_field(const std::vector<std::string> &names,
                  const VectorType &              solution,
@@ -366,7 +366,7 @@ public:
    * call the above function. The above function is more efficient if multiple
    * fields use the same @p DataPostprocessor object.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   evaluate_field(const std::string &           name,
                  const VectorType &            solution,
@@ -386,7 +386,7 @@ public:
    * called for each dataset (time step, iteration, etc) for each vector_name,
    * otherwise a @p ExcDataLostSync error can occur.
    */
-  template <class VectorType>
+  template <typename VectorType>
   void
   evaluate_field_at_requested_location(const std::string &name,
                                        const VectorType & solution);

--- a/include/deal.II/numerics/vector_tools_mean_value.h
+++ b/include/deal.II/numerics/vector_tools_mean_value.h
@@ -134,7 +134,7 @@ namespace VectorTools
    *
    * @dealiiConceptRequires{concepts::is_writable_dealii_vector_type<VectorType>}
    */
-  template <class VectorType, int dim, int spacedim = dim>
+  template <typename VectorType, int dim, int spacedim = dim>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
   void add_constant(VectorType &                          solution,
                     const DoFHandler<dim, spacedim> &     dof_handler,

--- a/include/deal.II/numerics/vector_tools_mean_value.templates.h
+++ b/include/deal.II/numerics/vector_tools_mean_value.templates.h
@@ -130,7 +130,7 @@ namespace VectorTools
 
 
 
-  template <class VectorType, int dim, int spacedim>
+  template <typename VectorType, int dim, int spacedim>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
   void add_constant(VectorType &                          solution,
                     const DoFHandler<dim, spacedim> &     dof_handler,

--- a/include/deal.II/optimization/solver_bfgs.h
+++ b/include/deal.II/optimization/solver_bfgs.h
@@ -203,7 +203,7 @@ SolverBFGS<VectorType>::SolverBFGS(SolverControl &       solver_control,
 
 
 
-template <class VectorType>
+template <typename VectorType>
 boost::signals2::connection
 SolverBFGS<VectorType>::connect_line_search_slot(
   const std::function<
@@ -216,7 +216,7 @@ SolverBFGS<VectorType>::connect_line_search_slot(
 
 
 
-template <class VectorType>
+template <typename VectorType>
 boost::signals2::connection
 SolverBFGS<VectorType>::connect_preconditioner_slot(
   const std::function<void(VectorType &                         g,

--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -480,7 +480,7 @@ namespace Particles
      * be interpreted as a displacement vector, or a vector of absolute
      * positions.
      */
-    template <class VectorType>
+    template <typename VectorType>
     std::enable_if_t<
       std::is_convertible<VectorType *, Function<spacedim> *>::value == false>
     set_particle_positions(const VectorType &input_vector,
@@ -560,7 +560,7 @@ namespace Particles
      * @param[in] add_to_output_vector Control if the function should set the
      * entries of the @p output_vector or if should add to them.
      */
-    template <class VectorType>
+    template <typename VectorType>
     void
     get_particle_positions(VectorType &output_vector,
                            const bool  add_to_output_vector = false);
@@ -1330,7 +1330,7 @@ namespace Particles
 
 
   template <int dim, int spacedim>
-  template <class VectorType>
+  template <typename VectorType>
   inline std::enable_if_t<
     std::is_convertible<VectorType *, Function<spacedim> *>::value == false>
   ParticleHandler<dim, spacedim>::set_particle_positions(
@@ -1354,7 +1354,7 @@ namespace Particles
 
 
   template <int dim, int spacedim>
-  template <class VectorType>
+  template <typename VectorType>
   inline void
   ParticleHandler<dim, spacedim>::get_particle_positions(
     VectorType &output_vector,

--- a/source/fe/mapping_q1_eulerian.cc
+++ b/source/fe/mapping_q1_eulerian.cc
@@ -38,7 +38,7 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-template <int dim, class VectorType, int spacedim>
+template <int dim, typename VectorType, int spacedim>
 MappingQ1Eulerian<dim, VectorType, spacedim>::MappingQ1Eulerian(
   const DoFHandler<dim, spacedim> &shiftmap_dof_handler,
   const VectorType &               euler_transform_vectors)
@@ -49,7 +49,7 @@ MappingQ1Eulerian<dim, VectorType, spacedim>::MappingQ1Eulerian(
 
 
 
-template <int dim, class VectorType, int spacedim>
+template <int dim, typename VectorType, int spacedim>
 boost::container::small_vector<Point<spacedim>,
                                GeometryInfo<dim>::vertices_per_cell>
 MappingQ1Eulerian<dim, VectorType, spacedim>::get_vertices(
@@ -103,7 +103,7 @@ MappingQ1Eulerian<dim, VectorType, spacedim>::get_vertices(
 
 
 
-template <int dim, class VectorType, int spacedim>
+template <int dim, typename VectorType, int spacedim>
 std::vector<Point<spacedim>>
 MappingQ1Eulerian<dim, VectorType, spacedim>::compute_mapping_support_points(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell) const
@@ -119,7 +119,7 @@ MappingQ1Eulerian<dim, VectorType, spacedim>::compute_mapping_support_points(
 
 
 
-template <int dim, class VectorType, int spacedim>
+template <int dim, typename VectorType, int spacedim>
 std::unique_ptr<Mapping<dim, spacedim>>
 MappingQ1Eulerian<dim, VectorType, spacedim>::clone() const
 {
@@ -128,7 +128,7 @@ MappingQ1Eulerian<dim, VectorType, spacedim>::clone() const
 
 
 
-template <int dim, class VectorType, int spacedim>
+template <int dim, typename VectorType, int spacedim>
 CellSimilarity::Similarity
 MappingQ1Eulerian<dim, VectorType, spacedim>::fill_fe_values(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell,

--- a/source/fe/mapping_q_eulerian.cc
+++ b/source/fe/mapping_q_eulerian.cc
@@ -44,7 +44,7 @@ DEAL_II_NAMESPACE_OPEN
 // .... MAPPING Q EULERIAN CONSTRUCTOR
 
 
-template <int dim, class VectorType, int spacedim>
+template <int dim, typename VectorType, int spacedim>
 MappingQEulerian<dim, VectorType, spacedim>::MappingQEulerian(
   const unsigned int               degree,
   const DoFHandler<dim, spacedim> &euler_dof_handler,
@@ -62,7 +62,7 @@ MappingQEulerian<dim, VectorType, spacedim>::MappingQEulerian(
 
 
 
-template <int dim, class VectorType, int spacedim>
+template <int dim, typename VectorType, int spacedim>
 std::unique_ptr<Mapping<dim, spacedim>>
 MappingQEulerian<dim, VectorType, spacedim>::clone() const
 {
@@ -74,7 +74,7 @@ MappingQEulerian<dim, VectorType, spacedim>::clone() const
 
 // .... SUPPORT QUADRATURE CONSTRUCTOR
 
-template <int dim, class VectorType, int spacedim>
+template <int dim, typename VectorType, int spacedim>
 MappingQEulerian<dim, VectorType, spacedim>::SupportQuadrature::
   SupportQuadrature(const unsigned int map_degree)
   : Quadrature<dim>(Utilities::fixed_power<dim>(map_degree + 1))
@@ -99,7 +99,7 @@ MappingQEulerian<dim, VectorType, spacedim>::SupportQuadrature::
 
 // .... COMPUTE MAPPING SUPPORT POINTS
 
-template <int dim, class VectorType, int spacedim>
+template <int dim, typename VectorType, int spacedim>
 boost::container::small_vector<Point<spacedim>,
                                GeometryInfo<dim>::vertices_per_cell>
 MappingQEulerian<dim, VectorType, spacedim>::get_vertices(
@@ -118,7 +118,7 @@ MappingQEulerian<dim, VectorType, spacedim>::get_vertices(
 
 
 
-template <int dim, class VectorType, int spacedim>
+template <int dim, typename VectorType, int spacedim>
 std::vector<Point<spacedim>>
 MappingQEulerian<dim, VectorType, spacedim>::compute_mapping_support_points(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell) const
@@ -191,7 +191,7 @@ MappingQEulerian<dim, VectorType, spacedim>::compute_mapping_support_points(
 
 
 
-template <int dim, class VectorType, int spacedim>
+template <int dim, typename VectorType, int spacedim>
 CellSimilarity::Similarity
 MappingQEulerian<dim, VectorType, spacedim>::fill_fe_values(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell,

--- a/source/non_matching/fe_values.cc
+++ b/source/non_matching/fe_values.cc
@@ -45,7 +45,7 @@ namespace NonMatching
 
 
   template <int dim>
-  template <class VectorType>
+  template <typename VectorType>
   FEValues<dim>::FEValues(const hp::FECollection<dim> &fe_collection,
                           const Quadrature<1> &        quadrature,
                           const RegionUpdateFlags      region_update_flags,
@@ -75,7 +75,7 @@ namespace NonMatching
 
 
   template <int dim>
-  template <class VectorType>
+  template <typename VectorType>
   FEValues<dim>::FEValues(const hp::MappingCollection<dim> &mapping_collection,
                           const hp::FECollection<dim> &     fe_collection,
                           const hp::QCollection<dim> &      q_collection,
@@ -270,7 +270,7 @@ namespace NonMatching
 
 
   template <int dim>
-  template <class VectorType>
+  template <typename VectorType>
   FEInterfaceValues<dim>::FEInterfaceValues(
     const hp::FECollection<dim> &fe_collection,
     const Quadrature<1> &        quadrature,
@@ -301,7 +301,7 @@ namespace NonMatching
 
 
   template <int dim>
-  template <class VectorType>
+  template <typename VectorType>
   FEInterfaceValues<dim>::FEInterfaceValues(
     const hp::MappingCollection<dim> &mapping_collection,
     const hp::FECollection<dim> &     fe_collection,

--- a/source/non_matching/mesh_classifier.cc
+++ b/source/non_matching/mesh_classifier.cc
@@ -61,7 +61,7 @@ namespace NonMatching
        * vector are negative/positive, otherwise return
        * LocationToLevelSet::intersected.
        */
-      template <class VectorType>
+      template <typename VectorType>
       LocationToLevelSet
       location_from_dof_signs(const VectorType &local_levelset_values)
       {
@@ -83,7 +83,7 @@ namespace NonMatching
        * The concrete LevelSetDescription used when the level set function is
        * described as a (DoFHandler, Vector)-pair.
        */
-      template <int dim, class VectorType>
+      template <int dim, typename VectorType>
       class DiscreteLevelSetDescription : public LevelSetDescription<dim>
       {
       public:
@@ -132,7 +132,7 @@ namespace NonMatching
 
 
 
-      template <int dim, class VectorType>
+      template <int dim, typename VectorType>
       DiscreteLevelSetDescription<dim, VectorType>::DiscreteLevelSetDescription(
         const DoFHandler<dim> &dof_handler,
         const VectorType &     level_set)
@@ -142,7 +142,7 @@ namespace NonMatching
 
 
 
-      template <int dim, class VectorType>
+      template <int dim, typename VectorType>
       const hp::FECollection<dim> &
       DiscreteLevelSetDescription<dim, VectorType>::get_fe_collection() const
       {
@@ -151,7 +151,7 @@ namespace NonMatching
 
 
 
-      template <int dim, class VectorType>
+      template <int dim, typename VectorType>
       void
       DiscreteLevelSetDescription<dim, VectorType>::get_local_level_set_values(
         const typename Triangulation<dim>::active_cell_iterator &cell,
@@ -179,7 +179,7 @@ namespace NonMatching
 
 
 
-      template <int dim, class VectorType>
+      template <int dim, typename VectorType>
       unsigned int
       DiscreteLevelSetDescription<dim, VectorType>::active_fe_index(
         const typename Triangulation<dim>::active_cell_iterator &cell) const
@@ -311,7 +311,7 @@ namespace NonMatching
 
 
   template <int dim>
-  template <class VectorType>
+  template <typename VectorType>
   MeshClassifier<dim>::MeshClassifier(const DoFHandler<dim> &dof_handler,
                                       const VectorType &     level_set)
     : triangulation(&dof_handler.get_triangulation())

--- a/source/non_matching/quadrature_generator.cc
+++ b/source/non_matching/quadrature_generator.cc
@@ -1308,7 +1308,7 @@ namespace NonMatching
        * function must be called to specify which cell the function should be
        * evaluated on.
        */
-      template <int dim, class VectorType = Vector<double>>
+      template <int dim, typename VectorType = Vector<double>>
       class RefSpaceFEFieldFunction : public CellWiseFunction<dim>
       {
       public:
@@ -1417,7 +1417,7 @@ namespace NonMatching
 
 
 
-      template <int dim, class VectorType>
+      template <int dim, typename VectorType>
       RefSpaceFEFieldFunction<dim, VectorType>::RefSpaceFEFieldFunction(
         const DoFHandler<dim> &dof_handler,
         const VectorType &     dof_values)
@@ -1430,7 +1430,7 @@ namespace NonMatching
 
 
 
-      template <int dim, class VectorType>
+      template <int dim, typename VectorType>
       void
       RefSpaceFEFieldFunction<dim, VectorType>::set_active_cell(
         const typename Triangulation<dim>::active_cell_iterator &cell)
@@ -1493,7 +1493,7 @@ namespace NonMatching
 
 
 
-      template <int dim, class VectorType>
+      template <int dim, typename VectorType>
       bool
       RefSpaceFEFieldFunction<dim, VectorType>::cell_is_set() const
       {
@@ -1504,7 +1504,7 @@ namespace NonMatching
 
 
 
-      template <int dim, class VectorType>
+      template <int dim, typename VectorType>
       double
       RefSpaceFEFieldFunction<dim, VectorType>::value(
         const Point<dim> & point,
@@ -1536,7 +1536,7 @@ namespace NonMatching
 
 
 
-      template <int dim, class VectorType>
+      template <int dim, typename VectorType>
       Tensor<1, dim>
       RefSpaceFEFieldFunction<dim, VectorType>::gradient(
         const Point<dim> & point,
@@ -1569,7 +1569,7 @@ namespace NonMatching
 
 
 
-      template <int dim, class VectorType>
+      template <int dim, typename VectorType>
       SymmetricTensor<2, dim>
       RefSpaceFEFieldFunction<dim, VectorType>::hessian(
         const Point<dim> & point,
@@ -1873,7 +1873,7 @@ namespace NonMatching
 
 
   template <int dim>
-  template <class VectorType>
+  template <typename VectorType>
   DiscreteQuadratureGenerator<dim>::DiscreteQuadratureGenerator(
     const hp::QCollection<1> &quadratures1D,
     const DoFHandler<dim> &   dof_handler,
@@ -1906,7 +1906,7 @@ namespace NonMatching
 
 
   template <int dim>
-  template <class VectorType>
+  template <typename VectorType>
   DiscreteFaceQuadratureGenerator<dim>::DiscreteFaceQuadratureGenerator(
     const hp::QCollection<1> &quadratures1D,
     const DoFHandler<dim> &   dof_handler,


### PR DESCRIPTION
While there, also standardize on `typename MatrixType`.

Fixes #14854.