### PR TITLE
Use ReferenceCell::closest_point() in more places.

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -1637,7 +1637,7 @@ namespace GridTools
    * local position might be located slightly outside an actual unit cell,
    * due to numerical roundoff. Therefore, the point returned by this function
    * should be projected onto the unit cell, using
-   * GeometryInfo::project_to_unit_cell().  This is not automatically performed
+   * ReferenceCell::closest_point(). This is not automatically performed
    * by the algorithm. The returned cell can be a locally-owned cell or a
    * ghost cell (but not an artificial cell). The returned cell might be a
    * ghost cell even if the given point is a vertex of a locally owned cell.

--- a/include/deal.II/numerics/vector_tools_point_gradient.templates.h
+++ b/include/deal.II/numerics/vector_tools_point_gradient.templates.h
@@ -113,7 +113,7 @@ namespace VectorTools
            ExcInternalError());
 
     const Quadrature<dim> quadrature(
-      GeometryInfo<dim>::project_to_unit_cell(cell_point.second));
+      cell_point.first->reference_cell().closest_point(cell_point.second));
 
     FEValues<dim> fe_values(mapping, fe, quadrature, update_gradients);
     fe_values.reinit(cell_point.first);
@@ -159,7 +159,7 @@ namespace VectorTools
            ExcInternalError());
 
     const Quadrature<dim> quadrature(
-      GeometryInfo<dim>::project_to_unit_cell(cell_point.second));
+      cell_point.first->reference_cell().closest_point(cell_point.second));
     hp::FEValues<dim, spacedim> hp_fe_values(mapping,
                                              fe,
                                              hp::QCollection<dim>(quadrature),

--- a/include/deal.II/numerics/vector_tools_point_value.templates.h
+++ b/include/deal.II/numerics/vector_tools_point_value.templates.h
@@ -112,7 +112,7 @@ namespace VectorTools
            ExcInternalError());
 
     const Quadrature<dim> quadrature(
-      GeometryInfo<dim>::project_to_unit_cell(cell_point.second));
+      cell_point.first->reference_cell().closest_point(cell_point.second));
 
     FEValues<dim> fe_values(mapping, fe, quadrature, update_values);
     fe_values.reinit(cell_point.first);
@@ -155,7 +155,7 @@ namespace VectorTools
            ExcInternalError());
 
     const Quadrature<dim> quadrature(
-      GeometryInfo<dim>::project_to_unit_cell(cell_point.second));
+      cell_point.first->reference_cell().closest_point(cell_point.second));
     hp::FEValues<dim, spacedim> hp_fe_values(mapping,
                                              fe,
                                              hp::QCollection<dim>(quadrature),
@@ -260,7 +260,7 @@ namespace VectorTools
            ExcInternalError());
 
     const Quadrature<dim> quadrature(
-      GeometryInfo<dim>::project_to_unit_cell(cell_point.second));
+      cell_point.first->reference_cell().closest_point(cell_point.second));
     FEValues<dim> fe_values(mapping, fe, quadrature, update_values);
     fe_values.reinit(cell_point.first);
 
@@ -300,12 +300,12 @@ namespace VectorTools
     AssertThrow(cell_point.first.state() == IteratorState::valid,
                 ExcPointNotAvailableHere());
 
-    Quadrature<dim> q(
-      GeometryInfo<dim>::project_to_unit_cell(cell_point.second));
+    const Quadrature<dim> quadrature(
+      cell_point.first->reference_cell().closest_point(cell_point.second));
 
     FEValues<dim, spacedim> fe_values(mapping,
                                       dof_handler.get_fe(),
-                                      q,
+                                      quadrature,
                                       UpdateFlags(update_values));
     fe_values.reinit(cell_point.first);
 
@@ -364,12 +364,12 @@ namespace VectorTools
     AssertThrow(cell_point.first.state() == IteratorState::valid,
                 ExcPointNotAvailableHere());
 
-    Quadrature<dim> q(
-      GeometryInfo<dim>::project_to_unit_cell(cell_point.second));
+    const Quadrature<dim> quadrature(
+      cell_point.first->reference_cell().closest_point(cell_point.second));
 
     FEValues<dim> fe_values(mapping[cell_point.first->active_fe_index()],
                             cell_point.first->get_fe(),
-                            q,
+                            quadrature,
                             UpdateFlags(update_values));
     fe_values.reinit(cell_point.first);
 
@@ -409,13 +409,13 @@ namespace VectorTools
     AssertThrow(cell_point.first.state() == IteratorState::valid,
                 ExcPointNotAvailableHere());
 
-    const Quadrature<dim> q(
-      GeometryInfo<dim>::project_to_unit_cell(cell_point.second));
+    const Quadrature<dim> quadrature(
+      cell_point.first->reference_cell().closest_point(cell_point.second));
 
     const FEValuesExtractors::Vector vec(0);
     FEValues<dim, spacedim>          fe_values(mapping,
                                       dof_handler.get_fe(),
-                                      q,
+                                      quadrature,
                                       UpdateFlags(update_values));
     fe_values.reinit(cell_point.first);
 
@@ -480,13 +480,13 @@ namespace VectorTools
     AssertThrow(cell_point.first.state() == IteratorState::valid,
                 ExcPointNotAvailableHere());
 
-    Quadrature<dim> q(
-      GeometryInfo<dim>::project_to_unit_cell(cell_point.second));
+    const Quadrature<dim> quadrature(
+      cell_point.first->reference_cell().closest_point(cell_point.second));
 
     const FEValuesExtractors::Vector vec(0);
     FEValues<dim> fe_values(mapping[cell_point.first->active_fe_index()],
                             cell_point.first->get_fe(),
-                            q,
+                            quadrature,
                             UpdateFlags(update_values));
     fe_values.reinit(cell_point.first);
 

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -2252,11 +2252,7 @@ MappingFEField<dim, spacedim, VectorType>::transform_real_to_unit_cell(
         initial_p_unit[d] = 0.5;
     }
 
-  // TODO
-  initial_p_unit = GeometryInfo<dim>::project_to_unit_cell(initial_p_unit);
-
-  // for (unsigned int d=0; d<dim; ++d)
-  //   initial_p_unit[d] = 0.;
+  initial_p_unit = cell->reference_cell().closest_point(initial_p_unit);
 
   const Quadrature<dim> point_quadrature(initial_p_unit);
 

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -6281,12 +6281,8 @@ namespace GridTools
                     auto       reference_position =
                       cell_and_reference_position.second;
 
-                    // TODO: we need to implement
-                    // ReferenceCell::project_to_unit_cell()
-                    if (cell->reference_cell().is_hyper_cube())
-                      reference_position =
-                        GeometryInfo<dim>::project_to_unit_cell(
-                          reference_position);
+                    reference_position =
+                      cell->reference_cell().closest_point(reference_position);
 
                     send_components.emplace_back(
                       std::pair<int, int>(cell->level(), cell->index()),

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -2093,8 +2093,7 @@ TransfiniteInterpolationManifold<dim, spacedim>::pull_back(
     outside[d] = internal::invalid_pull_back_coordinate;
 
   // project the user-given input to unit cell
-  Point<dim> chart_point =
-    GeometryInfo<dim>::project_to_unit_cell(initial_guess);
+  Point<dim> chart_point = cell->reference_cell().closest_point(initial_guess);
 
   // run quasi-Newton iteration with a combination of finite differences for
   // the exact Jacobian and "Broyden's good method". As opposed to the various


### PR DESCRIPTION
Fixes #14260. Follow-up to #15218.