### PR TITLE
Allow running step-64 without CUDA

### DIFF
--- a/examples/step-64/CMakeLists.txt
+++ b/examples/step-64/CMakeLists.txt
@@ -37,16 +37,14 @@ endif()
 #
 # Are all dependencies fulfilled?
 #
-if(NOT DEAL_II_WITH_MPI OR NOT DEAL_II_WITH_P4EST OR NOT DEAL_II_WITH_CUDA) # keep in one line
+if(NOT DEAL_II_WITH_MPI OR NOT DEAL_II_WITH_P4EST) # keep in one line
   message(FATAL_ERROR "
 Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_MPI = ON
     DEAL_II_WITH_P4EST = ON
-    DEAL_II_WITH_CUDA = ON
 However, the deal.II library found at ${DEAL_II_PATH} was configured with these options:
     DEAL_II_WITH_MPI = ${DEAL_II_WITH_MPI}
     DEAL_II_WITH_P4EST = ${DEAL_II_WITH_P4EST}
-    DEAL_II_WITH_CUDA = ${DEAL_II_WITH_CUDA}
 This conflicts with the requirements."
     )
 endif()


### PR DESCRIPTION
After basing `CUDAWrappers::MatrixFree` on `Kokkos`, we can run the example without `CUDA` support using the default `Kokkos` spaces.