### PR TITLE
jenkins: test in random order

### DIFF
--- a/contrib/ci/Jenkinsfile.mpi
+++ b/contrib/ci/Jenkinsfile.mpi
@@ -110,7 +110,7 @@ pipeline
                   time ninja test # quicktests
                   time ctest --rerun-failed --output-on-failure -R quick_tests/
                   time ninja setup_tests
-                  time ctest -R "all-headers|mpirun" --output-on-failure --schedule-random -j $NP --no-compress-output -T test
+                  time ctest -R "all-headers|mpirun" --schedule-random --output-on-failure --schedule-random -j $NP --no-compress-output -T test
                  '''
               githubNotify context: 'Jenkins: MPI', description: 'OK',  status: 'SUCCESS'
             }

--- a/contrib/ci/Jenkinsfile.serial
+++ b/contrib/ci/Jenkinsfile.serial
@@ -110,7 +110,7 @@ pipeline
                   time ninja -j 10 # 12 gives OOM
                   time ninja test # quicktests
                   time ninja setup_tests
-                  time ctest --output-on-failure -j $NP --no-compress-output -T test
+                  time ctest --schedule-random --output-on-failure -j $NP --no-compress-output -T test
                  '''
               githubNotify context: 'Jenkins: serial', description: 'OK',  status: 'SUCCESS'
             }


### PR DESCRIPTION
This should speed up testing and reduces maximum memory consumption.