### PR TITLE
Test petsc/petsc_ts_05: avoid stack-use-after-return

### DIFF
--- a/tests/petsc/petsc_ts_05.cc
+++ b/tests/petsc/petsc_ts_05.cc
@@ -50,7 +50,7 @@ public:
     , testerrrecoverable(_testerrrec)
     , testcase(_testcase)
   {
-    bool throw_error = false;
+    throw_error = false;
 
     time_stepper.explicit_function =
       [&](const real_type t, const VectorType &y, VectorType &res) -> void {
@@ -197,6 +197,7 @@ private:
   bool        testerr;
   bool        testerrrecoverable;
   int         testcase;
+  bool        throw_error;
 };
 
 


### PR DESCRIPTION
Fixes:
```
134: ==1438450==ERROR: AddressSanitizer: stack-use-after-return on address 0x7fa4f4d4bfb0 at pc 0x56248d8610c2 bp 0x7ffeebad19b0 sp 0x7ffeebad19a8
134: READ of size 1 at 0x7fa4f4d4bfb0 thread T0
134:     #0 0x56248d8610c1 in ExponentialDecay::ExponentialDecay(double, dealii::PETScWrappers::TimeStepperData const&, bool, bool, int)::'lambda'(double, dealii::[148/1839]
ers::MPI::Vector const&, dealii::PETScWrappers::MPI::Vector const&, double, dealii::PETScWrappers::MatrixBase&, dealii::PETScWrappers::MatrixBase&)::operator()(double, deali
i::PETScWrappers::MPI::Vector const&, dealii::PETScWrappers::MPI::Vector const&, double, dealii::PETScWrappers::MatrixBase&, dealii::PETScWrappers::MatrixBase&) const /srv/t
estsuite/dealii/tests/petsc/petsc_ts_05.cc:91:15
134:     #1 0x7fa538cf812b in std::__1::__function::__value_func<void (double, dealii::PETScWrappers::MPI::Vector const&, dealii::PETScWrappers::MPI::Vector const&, double,
dealii::PETScWrappers::MatrixBase&, dealii::PETScWrappers::MatrixBase&)>::operator()[abi:v160006](double&&, dealii::PETScWrappers::MPI::Vector const&, dealii::PETScWrappers:
:MPI::Vector const&, double&&, dealii::PETScWrappers::MatrixBase&, dealii::PETScWrappers::MatrixBase&) const /usr/include/c++/v1/__functional/function.h:510:16
134:     #2 0x7fa538cf812b in std::__1::function<void (double, dealii::PETScWrappers::MPI::Vector const&, dealii::PETScWrappers::MPI::Vector const&, double, dealii::PETScWra
ppers::MatrixBase&, dealii::PETScWrappers::MatrixBase&)>::operator()(double, dealii::PETScWrappers::MPI::Vector const&, dealii::PETScWrappers::MPI::Vector const&, double, de
alii::PETScWrappers::MatrixBase&, dealii::PETScWrappers::MatrixBase&) const /usr/include/c++/v1/__functional/function.h:1156:12                                              134:     #3 0x7fa538cf812b in int dealii::PETScWrappers::call_and_possibly_capture_ts_exception<std::__1::function<void (double, dealii::PETScWrappers::MPI::Vector const&, d
ealii::PETScWrappers::MPI::Vector const&, double, dealii::PETScWrappers::MatrixBase&, dealii::PETScWrappers::MatrixBase&)>, double&, dealii::PETScWrappers::MPI::Vector&, dea
lii::PETScWrappers::MPI::Vector&, double&, dealii::PETScWrappers::MatrixBase&, dealii::PETScWrappers::MatrixBase&>(std::__1::function<void (double, dealii::PETScWrappers::MP
I::Vector const&, dealii::PETScWrappers::MPI::Vector const&, double, dealii::PETScWrappers::MatrixBase&, dealii::PETScWrappers::MatrixBase&)> const&, std::exception_ptr&, st
d::__1::function<void ()> const&, double&, dealii::PETScWrappers::MPI::Vector&, dealii::PETScWrappers::MPI::Vector&, double&, dealii::PETScWrappers::MatrixBase&, dealii::PET
ScWrappers::MatrixBase&) /srv/testsuite/dealii/include/deal.II/lac/petsc_ts.templates.h:87:9
134:     #4 0x7fa538cf78cc in dealii::PETScWrappers::TimeStepper<dealii::PETScWrappers::MPI::Vector, dealii::PETScWrappers::MatrixBase, dealii::PETScWrappers::MatrixBase>::s
olve(dealii::PETScWrappers::MPI::Vector&)::'lambda'(_p_TS*, double, _p_Vec*, _p_Vec*, double, _p_Mat*, _p_Mat*, void*)::operator()(_p_TS*, double, _p_Vec*, _p_Vec*, double,
_p_Mat*, _p_Mat*, void*) const /srv/testsuite/dealii/include/deal.II/lac/petsc_ts.templates.h:489:26
134:     #5 0x7fa538cf73d7 in dealii::PETScWrappers::TimeStepper<dealii::PETScWrappers::MPI::Vector, dealii::PETScWrappers::MatrixBase, dealii::PETScWrappers::MatrixBase>::s
olve(dealii::PETScWrappers::MPI::Vector&)::'lambda'(_p_TS*, double, _p_Vec*, _p_Vec*, double, _p_Mat*, _p_Mat*, void*)::__invoke(_p_TS*, double, _p_Vec*, _p_Vec*, double, _p
_Mat*, _p_Mat*, void*) /srv/testsuite/dealii/include/deal.II/lac/petsc_ts.templates.h:472:31
134:     #6 0x7fa504afbcac in TSComputeIJacobian (/usr/lib64/libpetsc.so.3.19+0x10fbcac)
134:     #7 0x7fa504aa1672  (/usr/lib64/libpetsc.so.3.19+0x10a1672)
134:     #8 0x7fa504afd307 in SNESTSFormJacobian (/usr/lib64/libpetsc.so.3.19+0x10fd307)
134:     #9 0x7fa504a43e66 in SNESComputeJacobian (/usr/lib64/libpetsc.so.3.19+0x1043e66)
134:     #10 0x7fa504a35e98 in SNESSolve_NEWTONLS (/usr/lib64/libpetsc.so.3.19+0x1035e98)
134:     #11 0x7fa504a4968e in SNESSolve (/usr/lib64/libpetsc.so.3.19+0x104968e)
134:     #12 0x7fa504aa25e4  (/usr/lib64/libpetsc.so.3.19+0x10a25e4)
134:     #13 0x7fa504aa014a  (/usr/lib64/libpetsc.so.3.19+0x10a014a)
134:     #14 0x7fa504b03013 in TSStep (/usr/lib64/libpetsc.so.3.19+0x1103013)
134:     #15 0x7fa504b03e02 in TSSolve (/usr/lib64/libpetsc.so.3.19+0x1103e02)
134:     #16 0x7fa538cd2ccc in dealii::PETScWrappers::TimeStepper<dealii::PETScWrappers::MPI::Vector, dealii::PETScWrappers::MatrixBase, dealii::PETScWrappers::MatrixBase>::
solve(dealii::PETScWrappers::MPI::Vector&) /srv/testsuite/dealii/include/deal.II/lac/petsc_ts.templates.h:880:24
134:     #17 0x56248d85849f in ExponentialDecay::run() /srv/testsuite/dealii/tests/petsc/petsc_ts_05.cc:182:32
134:     #18 0x56248d855ca6 in main /srv/testsuite/dealii/tests/petsc/petsc_ts_05.cc:242:20
134:     #19 0x7fa502a50989  (/usr/lib64/libc.so.6+0x23989)
134:     #20 0x7fa502a50a44 in __libc_start_main (/usr/lib64/libc.so.6+0x23a44)
134:     #21 0x56248d73e2d0 in _start (/srv/temp/build/tests/petsc/petsc_ts_05.debug/petsc_ts_05.debug+0x742d0)
```