### PR TITLE
[9.5] lac/scalapack.cc: fix an out-of-bounds write that leads to a double free

### DIFF
--- a/doc/news/9.4.0-vs-9.5.0.h
+++ b/doc/news/9.4.0-vs-9.5.0.h
@@ -406,6 +406,13 @@ inconvenience this causes.
 <ol>
 
  <li>
+  Fixed: An out-of-bounds write due to an insufficiently sized buffer in
+  the Scalapack wrappers has been fixed.
+  <br>
+  (Matthias Maier, 2023/07/03)
+ </li>
+
+ <li>
   Fixed: With some compilers, calling Threads::Task::Task() with a
   function object that ends with an exception lead to a segmentation
   fault. This is now fixed.

--- a/source/lac/scalapack.cc
+++ b/source/lac/scalapack.cc
@@ -1592,8 +1592,18 @@ ScaLAPACKMatrix<NumberType>::eigenpairs_symmetric(
       int         liwork = -1;
       NumberType *eigenvectors_loc =
         (compute_eigenvectors ? eigenvectors->values.data() : nullptr);
-      work.resize(1);
-      iwork.resize(1);
+      /*
+       * According to the official "documentation" found on the internet
+       * (aka source file ppsyevx.f [1]) the work array has to have a
+       * minimal size of max(3, lwork). Because we query for optimal size
+       * (lwork == -1) we have to guarantee at least three doubles. The
+       * necessary size of iwork is not specified, so let's use three as
+       * well.
+       * [1]
+       * https://netlib.org/scalapack/explore-html/df/d1a/pdsyevx_8f_source.html
+       */
+      work.resize(3);
+      iwork.resize(3);
 
       if (all_eigenpairs)
         {


### PR DESCRIPTION
Take over #15600

In reference to #15383