### PR TITLE
Deprecate the contents of the LocalIntegrators namespace.

### DIFF
--- a/doc/news/changes/major/20230703Bangerth
+++ b/doc/news/changes/major/20230703Bangerth
@@ -1,0 +1,10 @@
+Deprecated: The entire LocalIntegrators namespace has been
+deprecated. The namespace represents an effort at making integration
+simpler by providing a library of terms that appear frequently in
+equations. But this only made the simple case simple -- everything
+that exceeded the simplest case still needed to be done by hand, and
+using these pre-built integrators did not help teaching how to do
+that. As a consequence, these pre-built integrators will be removed in
+a future version of the library.
+<br>
+(Wolfgang Bangerth, 2023/07/03)

--- a/include/deal.II/integrators/advection.h
+++ b/include/deal.II/integrators/advection.h
@@ -70,7 +70,7 @@ namespace LocalIntegrators
      * @param factor is an optional multiplication factor for the result.
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     cell_matrix(FullMatrix<double>                         &M,
                 const FEValuesBase<dim>                    &fe,
                 const FEValuesBase<dim>                    &fetest,
@@ -126,7 +126,7 @@ namespace LocalIntegrators
      * with its transpose.
      */
     template <int dim>
-    inline void
+    DEAL_II_DEPRECATED_EARLY inline void
     cell_residual(Vector<double>                             &result,
                   const FEValuesBase<dim>                    &fe,
                   const std::vector<Tensor<1, dim>>          &input,
@@ -169,7 +169,7 @@ namespace LocalIntegrators
      * with its transpose.
      */
     template <int dim>
-    inline void
+    DEAL_II_DEPRECATED_EARLY inline void
     cell_residual(Vector<double>                                     &result,
                   const FEValuesBase<dim>                            &fe,
                   const ArrayView<const std::vector<Tensor<1, dim>>> &input,
@@ -211,7 +211,7 @@ namespace LocalIntegrators
      * \f[ r_i = \int_Z  (\mathbf w \cdot \nabla)v\, u_i \, dx. \f]
      */
     template <int dim>
-    inline void
+    DEAL_II_DEPRECATED_EARLY inline void
     cell_residual(Vector<double>                             &result,
                   const FEValuesBase<dim>                    &fe,
                   const std::vector<double>                  &input,
@@ -251,7 +251,7 @@ namespace LocalIntegrators
      * \cdot\mathbf u_i \, dx. \f]
      */
     template <int dim>
-    inline void
+    DEAL_II_DEPRECATED_EARLY inline void
     cell_residual(Vector<double>                             &result,
                   const FEValuesBase<dim>                    &fe,
                   const ArrayView<const std::vector<double>> &input,
@@ -305,7 +305,7 @@ namespace LocalIntegrators
      * component is advected by the same velocity.
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     upwind_value_matrix(FullMatrix<double>                         &M,
                         const FEValuesBase<dim>                    &fe,
                         const FEValuesBase<dim>                    &fetest,
@@ -378,7 +378,7 @@ namespace LocalIntegrators
      * component is advected by the same velocity.
      */
     template <int dim>
-    inline void
+    DEAL_II_DEPRECATED_EARLY inline void
     upwind_value_residual(Vector<double>                             &result,
                           const FEValuesBase<dim>                    &fe,
                           const std::vector<double>                  &input,
@@ -445,7 +445,7 @@ namespace LocalIntegrators
      * component is advected by the same velocity.
      */
     template <int dim>
-    inline void
+    DEAL_II_DEPRECATED_EARLY inline void
     upwind_value_residual(Vector<double>                             &result,
                           const FEValuesBase<dim>                    &fe,
                           const ArrayView<const std::vector<double>> &input,
@@ -512,7 +512,7 @@ namespace LocalIntegrators
      * component is advected the same way.
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     upwind_value_matrix(FullMatrix<double>                         &M11,
                         FullMatrix<double>                         &M12,
                         FullMatrix<double>                         &M21,
@@ -597,7 +597,7 @@ namespace LocalIntegrators
      * component is advected the same way.
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     upwind_face_residual(Vector<double>                             &result1,
                          Vector<double>                             &result2,
                          const FEValuesBase<dim>                    &fe1,
@@ -674,7 +674,7 @@ namespace LocalIntegrators
      * component is advected the same way.
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     upwind_face_residual(Vector<double>                             &result1,
                          Vector<double>                             &result2,
                          const FEValuesBase<dim>                    &fe1,

--- a/include/deal.II/integrators/divergence.h
+++ b/include/deal.II/integrators/divergence.h
@@ -49,7 +49,7 @@ namespace LocalIntegrators
      * <b>H</b><sup>div</sup>. The test functions may be discontinuous.
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     cell_matrix(FullMatrix<double>      &M,
                 const FEValuesBase<dim> &fe,
                 const FEValuesBase<dim> &fetest,
@@ -88,7 +88,7 @@ namespace LocalIntegrators
      * with respect to the test functions.
      */
     template <int dim, typename number>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     cell_residual(Vector<number>                                     &result,
                   const FEValuesBase<dim>                            &fetest,
                   const ArrayView<const std::vector<Tensor<1, dim>>> &input,
@@ -121,7 +121,7 @@ namespace LocalIntegrators
      * this function with respect to the test functions.
      */
     template <int dim, typename number>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     cell_residual(Vector<number>                             &result,
                   const FEValuesBase<dim>                    &fetest,
                   const ArrayView<const std::vector<double>> &input,
@@ -152,7 +152,7 @@ namespace LocalIntegrators
      * <i>H</i><sup>1</sup>. The test functions can be discontinuous.
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     gradient_matrix(FullMatrix<double>      &M,
                     const FEValuesBase<dim> &fe,
                     const FEValuesBase<dim> &fetest,
@@ -192,7 +192,7 @@ namespace LocalIntegrators
      * function with respect to the test functions.
      */
     template <int dim, typename number>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     gradient_residual(Vector<number>                    &result,
                       const FEValuesBase<dim>           &fetest,
                       const std::vector<Tensor<1, dim>> &input,
@@ -225,7 +225,7 @@ namespace LocalIntegrators
      * of this function with respect to the test functions.
      */
     template <int dim, typename number>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     gradient_residual(Vector<number>            &result,
                       const FEValuesBase<dim>   &fetest,
                       const std::vector<double> &input,
@@ -254,7 +254,7 @@ namespace LocalIntegrators
      * @f[ \int_F (\mathbf u\cdot \mathbf n) v \,ds @f]
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     u_dot_n_matrix(FullMatrix<double>      &M,
                    const FEValuesBase<dim> &fe,
                    const FEValuesBase<dim> &fetest,
@@ -287,7 +287,7 @@ namespace LocalIntegrators
      * @f]
      */
     template <int dim, typename number>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     u_dot_n_residual(Vector<number>                             &result,
                      const FEValuesBase<dim>                    &fe,
                      const FEValuesBase<dim>                    &fetest,
@@ -319,7 +319,7 @@ namespace LocalIntegrators
      * @f]
      */
     template <int dim, typename number>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     u_times_n_residual(Vector<number>            &result,
                        const FEValuesBase<dim>   &fetest,
                        const std::vector<double> &data,
@@ -353,7 +353,7 @@ namespace LocalIntegrators
      * @f]
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     u_dot_n_matrix(FullMatrix<double>      &M11,
                    FullMatrix<double>      &M12,
                    FullMatrix<double>      &M21,
@@ -412,7 +412,7 @@ namespace LocalIntegrators
      * @f]
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     u_dot_n_jump_matrix(FullMatrix<double>      &M11,
                         FullMatrix<double>      &M12,
                         FullMatrix<double>      &M21,
@@ -467,7 +467,7 @@ namespace LocalIntegrators
      * element has to be equal to the space dimension.
      */
     template <int dim>
-    double
+    DEAL_II_DEPRECATED_EARLY double
     norm(const FEValuesBase<dim>                            &fe,
          const ArrayView<const std::vector<Tensor<1, dim>>> &Du)
     {

--- a/include/deal.II/integrators/elasticity.h
+++ b/include/deal.II/integrators/elasticity.h
@@ -46,7 +46,7 @@ namespace LocalIntegrators
      * \f[ \int_Z \varepsilon(u): \varepsilon(v)\,dx \f]
      */
     template <int dim>
-    inline void
+    DEAL_II_DEPRECATED_EARLY inline void
     cell_matrix(FullMatrix<double>      &M,
                 const FEValuesBase<dim> &fe,
                 const double             factor = 1.)
@@ -79,7 +79,7 @@ namespace LocalIntegrators
      * \f[ - \int_Z \varepsilon(u): \varepsilon(v) \,dx \f]
      */
     template <int dim, typename number>
-    inline void
+    DEAL_II_DEPRECATED_EARLY inline void
     cell_residual(Vector<number>                                     &result,
                   const FEValuesBase<dim>                            &fe,
                   const ArrayView<const std::vector<Tensor<1, dim>>> &input,
@@ -118,7 +118,7 @@ namespace LocalIntegrators
      * @f]
      */
     template <int dim>
-    inline void
+    DEAL_II_DEPRECATED_EARLY inline void
     nitsche_matrix(FullMatrix<double>      &M,
                    const FEValuesBase<dim> &fe,
                    double                   penalty,
@@ -173,7 +173,7 @@ namespace LocalIntegrators
      * @f]
      */
     template <int dim>
-    inline void
+    DEAL_II_DEPRECATED_EARLY inline void
     nitsche_tangential_matrix(FullMatrix<double>      &M,
                               const FEValuesBase<dim> &fe,
                               double                   penalty,
@@ -252,7 +252,7 @@ namespace LocalIntegrators
      * the usual penalty parameter.
      */
     template <int dim, typename number>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     nitsche_residual(Vector<number>                                     &result,
                      const FEValuesBase<dim>                            &fe,
                      const ArrayView<const std::vector<double>>         &input,
@@ -304,7 +304,7 @@ namespace LocalIntegrators
      * @f]
      */
     template <int dim, typename number>
-    inline void
+    DEAL_II_DEPRECATED_EARLY inline void
     nitsche_tangential_residual(
       Vector<number>                                     &result,
       const FEValuesBase<dim>                            &fe,
@@ -382,7 +382,7 @@ namespace LocalIntegrators
      * penalty parameter.
      */
     template <int dim, typename number>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     nitsche_residual_homogeneous(
       Vector<number>                                     &result,
       const FEValuesBase<dim>                            &fe,
@@ -427,7 +427,7 @@ namespace LocalIntegrators
      * The interior penalty flux for symmetric gradients.
      */
     template <int dim>
-    inline void
+    DEAL_II_DEPRECATED_EARLY inline void
     ip_matrix(FullMatrix<double>      &M11,
               FullMatrix<double>      &M12,
               FullMatrix<double>      &M21,
@@ -535,7 +535,7 @@ namespace LocalIntegrators
      * Elasticity residual term for the symmetric interior penalty method.
      */
     template <int dim, typename number>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     ip_residual(Vector<number>                                     &result1,
                 Vector<number>                                     &result2,
                 const FEValuesBase<dim>                            &fe1,

--- a/include/deal.II/integrators/grad_div.h
+++ b/include/deal.II/integrators/grad_div.h
@@ -47,7 +47,7 @@ namespace LocalIntegrators
      * @f]
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     cell_matrix(FullMatrix<double>      &M,
                 const FEValuesBase<dim> &fe,
                 double                   factor = 1.)
@@ -81,7 +81,7 @@ namespace LocalIntegrators
      * @f]
      */
     template <int dim, typename number>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     cell_residual(Vector<number>                                     &result,
                   const FEValuesBase<dim>                            &fetest,
                   const ArrayView<const std::vector<Tensor<1, dim>>> &input,
@@ -117,7 +117,7 @@ namespace LocalIntegrators
      * @f]
      */
     template <int dim>
-    inline void
+    DEAL_II_DEPRECATED_EARLY inline void
     nitsche_matrix(FullMatrix<double>      &M,
                    const FEValuesBase<dim> &fe,
                    double                   penalty,
@@ -169,7 +169,7 @@ namespace LocalIntegrators
      * argument <tt>data</tt>. $\gamma$ is the usual penalty parameter.
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     nitsche_residual(Vector<double>                                     &result,
                      const FEValuesBase<dim>                            &fe,
                      const ArrayView<const std::vector<double>>         &input,
@@ -215,9 +215,8 @@ namespace LocalIntegrators
      * The interior penalty flux for the grad-div operator. See
      * ip_residual() for details.
      */
-
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     ip_matrix(FullMatrix<double>      &M11,
               FullMatrix<double>      &M12,
               FullMatrix<double>      &M21,
@@ -297,7 +296,7 @@ namespace LocalIntegrators
      * See for instance Hansbo and Larson, 2002
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     ip_residual(Vector<double>                                     &result1,
                 Vector<double>                                     &result2,
                 const FEValuesBase<dim>                            &fe1,

--- a/include/deal.II/integrators/l2.h
+++ b/include/deal.II/integrators/l2.h
@@ -53,7 +53,7 @@ namespace LocalIntegrators
      * @param factor A constant that multiplies the mass matrix.
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     mass_matrix(FullMatrix<double>      &M,
                 const FEValuesBase<dim> &fe,
                 const double             factor = 1.)
@@ -104,7 +104,7 @@ namespace LocalIntegrators
      * quadrature points in the element).
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     weighted_mass_matrix(FullMatrix<double>        &M,
                          const FEValuesBase<dim>   &fe,
                          const std::vector<double> &weights)
@@ -155,7 +155,7 @@ namespace LocalIntegrators
      * @param factor A constant that multiplies the result.
      */
     template <int dim, typename number>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     L2(Vector<number>            &result,
        const FEValuesBase<dim>   &fe,
        const std::vector<double> &input,
@@ -185,7 +185,7 @@ namespace LocalIntegrators
      * @param factor A constant that multiplies the result.
      */
     template <int dim, typename number>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     L2(Vector<number>                             &result,
        const FEValuesBase<dim>                    &fe,
        const ArrayView<const std::vector<double>> &input,
@@ -233,7 +233,7 @@ namespace LocalIntegrators
      * second cell.
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     jump_matrix(FullMatrix<double>      &M11,
                 FullMatrix<double>      &M12,
                 FullMatrix<double>      &M21,

--- a/include/deal.II/integrators/laplace.h
+++ b/include/deal.II/integrators/laplace.h
@@ -47,7 +47,7 @@ namespace LocalIntegrators
      * latter case, the Laplacian is applied to each component separately.
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     cell_matrix(FullMatrix<double>      &M,
                 const FEValuesBase<dim> &fe,
                 const double             factor = 1.)
@@ -87,7 +87,7 @@ namespace LocalIntegrators
      * \f[ \int_Z \nu \nabla u \cdot \nabla v \, dx. \f]
      */
     template <int dim>
-    inline void
+    DEAL_II_DEPRECATED_EARLY inline void
     cell_residual(Vector<double>                    &result,
                   const FEValuesBase<dim>           &fe,
                   const std::vector<Tensor<1, dim>> &input,
@@ -114,7 +114,7 @@ namespace LocalIntegrators
      * \f[ \int_Z \nu \nabla u : \nabla v \, dx. \f]
      */
     template <int dim>
-    inline void
+    DEAL_II_DEPRECATED_EARLY inline void
     cell_residual(Vector<double>                                     &result,
                   const FEValuesBase<dim>                            &fe,
                   const ArrayView<const std::vector<Tensor<1, dim>>> &input,
@@ -152,7 +152,7 @@ namespace LocalIntegrators
      * compute_penalty().
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     nitsche_matrix(FullMatrix<double>      &M,
                    const FEValuesBase<dim> &fe,
                    double                   penalty,
@@ -193,7 +193,7 @@ namespace LocalIntegrators
      * compute_penalty().
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     nitsche_tangential_matrix(FullMatrix<double>      &M,
                               const FEValuesBase<dim> &fe,
                               double                   penalty,
@@ -256,7 +256,7 @@ namespace LocalIntegrators
      * argument <tt>data</tt>. $\gamma$ is the usual penalty parameter.
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     nitsche_residual(Vector<double>                    &result,
                      const FEValuesBase<dim>           &fe,
                      const std::vector<double>         &input,
@@ -303,7 +303,7 @@ namespace LocalIntegrators
      * argument <tt>data</tt>. $\gamma$ is the usual penalty parameter.
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     nitsche_residual(Vector<double>                                     &result,
                      const FEValuesBase<dim>                            &fe,
                      const ArrayView<const std::vector<double>>         &input,
@@ -354,7 +354,7 @@ namespace LocalIntegrators
      * has to be computed accordingly.
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     ip_matrix(FullMatrix<double>      &M11,
               FullMatrix<double>      &M12,
               FullMatrix<double>      &M21,
@@ -427,7 +427,7 @@ namespace LocalIntegrators
      * @warning This function is still under development!
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     ip_tangential_matrix(FullMatrix<double>      &M11,
                          FullMatrix<double>      &M12,
                          FullMatrix<double>      &M21,
@@ -539,7 +539,7 @@ namespace LocalIntegrators
      * @f]
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     ip_residual(Vector<double>                    &result1,
                 Vector<double>                    &result2,
                 const FEValuesBase<dim>           &fe1,
@@ -606,7 +606,7 @@ namespace LocalIntegrators
      * @f]
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     ip_residual(Vector<double>                                     &result1,
                 Vector<double>                                     &result2,
                 const FEValuesBase<dim>                            &fe1,
@@ -680,7 +680,7 @@ namespace LocalIntegrators
      * <i>Z<sub>i</sub></i> orthogonal to the current face.
      */
     template <int dim, int spacedim, typename number>
-    double
+    DEAL_II_DEPRECATED_EARLY double
     compute_penalty(const MeshWorker::DoFInfo<dim, spacedim, number> &dinfo1,
                     const MeshWorker::DoFInfo<dim, spacedim, number> &dinfo2,
                     unsigned int                                      deg1,

--- a/include/deal.II/integrators/local_integrators.h
+++ b/include/deal.II/integrators/local_integrators.h
@@ -27,6 +27,9 @@ DEAL_II_NAMESPACE_OPEN
 /**
  * @brief Library of integrals over cells and faces
  *
+ * @note The contents of this namespace are deprecated and will be removed in
+ *   one of the next releases.
+ *
  * This namespace contains application specific local integrals for bilinear
  * forms, forms and error estimates. It is a collection of functions organized
  * into namespaces devoted to certain applications. For instance, the

--- a/include/deal.II/integrators/maxwell.h
+++ b/include/deal.II/integrators/maxwell.h
@@ -87,10 +87,10 @@ namespace LocalIntegrators
      * for instance duplicate one of the previous.
      */
     template <int dim>
-    Tensor<1, dim>
-    curl_curl(const Tensor<2, dim> &h0,
-              const Tensor<2, dim> &h1,
-              const Tensor<2, dim> &h2)
+    DEAL_II_DEPRECATED_EARLY Tensor<1, dim>
+                             curl_curl(const Tensor<2, dim> &h0,
+                                       const Tensor<2, dim> &h1,
+                                       const Tensor<2, dim> &h2)
     {
       Tensor<1, dim> result;
       switch (dim)
@@ -121,11 +121,11 @@ namespace LocalIntegrators
      * for instance duplicate one of the previous.
      */
     template <int dim>
-    Tensor<1, dim>
-    tangential_curl(const Tensor<1, dim> &g0,
-                    const Tensor<1, dim> &g1,
-                    const Tensor<1, dim> &g2,
-                    const Tensor<1, dim> &normal)
+    DEAL_II_DEPRECATED_EARLY Tensor<1, dim>
+                             tangential_curl(const Tensor<1, dim> &g0,
+                                             const Tensor<1, dim> &g1,
+                                             const Tensor<1, dim> &g2,
+                                             const Tensor<1, dim> &normal)
     {
       Tensor<1, dim> result;
 
@@ -158,7 +158,7 @@ namespace LocalIntegrators
      * in weak form.
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     curl_curl_matrix(FullMatrix<double>      &M,
                      const FEValuesBase<dim> &fe,
                      const double             factor = 1.)
@@ -211,7 +211,7 @@ namespace LocalIntegrators
      * functions.
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     curl_matrix(FullMatrix<double>      &M,
                 const FEValuesBase<dim> &fe,
                 const FEValuesBase<dim> &fetest,
@@ -323,7 +323,7 @@ namespace LocalIntegrators
      * @f]
      */
     template <int dim>
-    void
+    DEAL_II_DEPRECATED_EARLY void
     tangential_trace_matrix(FullMatrix<double>      &M,
                             const FEValuesBase<dim> &fe,
                             double                   factor = 1.)
@@ -380,7 +380,7 @@ namespace LocalIntegrators
      * @f]
      */
     template <int dim>
-    inline void
+    DEAL_II_DEPRECATED_EARLY inline void
     ip_curl_matrix(FullMatrix<double>      &M11,
                    FullMatrix<double>      &M12,
                    FullMatrix<double>      &M21,

--- a/include/deal.II/integrators/patches.h
+++ b/include/deal.II/integrators/patches.h
@@ -36,7 +36,7 @@ namespace LocalIntegrators
   namespace Patches
   {
     template <int dim>
-    inline void
+    DEAL_II_DEPRECATED_EARLY inline void
     points_and_values(Table<2, double>                           &result,
                       const FEValuesBase<dim>                    &fe,
                       const ArrayView<const std::vector<double>> &input)


### PR DESCRIPTION
I think it's time. 

This patch deprecates all classes in namespace `LocalIntegrators`. These implement concrete integration routines. It also deprecates step-16b, one of two programs that use them. When we remove the integrators, we can also just remove step-16b (which is the old version of step-16: the current step-16 but still using `LocalIntegrators`). We won't lose much.

The bigger issue is that step-39 still uses these integrators as well, along with `MeshWorker::LocalIntegrator`. Replacing the `LocalIntegrators` use there isn't going to be terribly difficult: We can simply plop the current implementation of these functions into the places where they are used -- that should not be more than perhaps 20-40 lines of code.

Anyone opposed to this deprecation?