### PR TITLE
Make ParticleHandler serialization tests consistent

### DIFF
--- a/cmake/config/template-arguments.in
+++ b/cmake/config/template-arguments.in
@@ -224,6 +224,7 @@ GENERAL_CONTAINER_TYPES := { std::vector;
 TRIANGULATION_AND_DOFHANDLER_TEMPLATES := { Triangulation;
                                             parallel::shared::Triangulation;
                                             parallel::distributed::Triangulation;
+                                            parallel::fullydistributed::Triangulation;
                                             DoFHandler }
 
 // concrete sequential Triangulation and DoFHandler with hard-coded
@@ -241,13 +242,15 @@ SEQUENTIAL_TRIANGULATION_AND_DOFHANDLERS := { Triangulation<deal_II_dimension, d
 TRIANGULATION_AND_DOFHANDLERS := { Triangulation<deal_II_dimension, deal_II_space_dimension>;
                                    parallel::shared::Triangulation<deal_II_dimension, deal_II_space_dimension>;
                                    parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension>;
+                                   parallel::fullydistributed::Triangulation<deal_II_dimension, deal_II_space_dimension>;
                                    DoFHandler<deal_II_dimension, deal_II_space_dimension> }
 
 // concrete Triangulation types (all types you can iterate over cells from)
 // with hard-coded <deal_II_dimension, deal_II_space_dimension>
 TRIANGULATIONS := { Triangulation<deal_II_dimension, deal_II_space_dimension>;
                     parallel::shared::Triangulation<deal_II_dimension, deal_II_space_dimension>;
-                    parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension>;}
+                    parallel::distributed::Triangulation<deal_II_dimension, deal_II_space_dimension>;
+                    parallel::fullydistributed::Triangulation<deal_II_dimension, deal_II_space_dimension>; }
 
 // all supported logical dimensions
 DIMENSIONS := { 1; 2; 3 }

--- a/source/grid/intergrid_map.cc
+++ b/source/grid/intergrid_map.cc
@@ -16,6 +16,7 @@
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/smartpointer.h>
 
+#include <deal.II/distributed/fully_distributed_tria.h>
 #include <deal.II/distributed/shared_tria.h>
 #include <deal.II/distributed/tria.h>
 

--- a/tests/serialization/particle_handler_04.mpirun=1.output
+++ b/tests/serialization/particle_handler_04.mpirun=1.output
@@ -1,28 +1,103 @@
 
 DEAL:0:2d/2d::Before serialization particle id 0 is in cell 2.0
-DEAL:0:2d/2d::Before serialization particle id 1 is in cell 2.12
-DEAL:0:2d/2d::0 0 2 1 2
+DEAL:0:2d/2d::Before serialization particle id 3 is in cell 2.1
+DEAL:0:2d/2d::Before serialization particle id 1 is in cell 2.2
+DEAL:0:2d/2d::Before serialization particle id 4 is in cell 2.3
+DEAL:0:2d/2d::Before serialization particle id 6 is in cell 2.5
+DEAL:0:2d/2d::Before serialization particle id 7 is in cell 2.7
+DEAL:0:2d/2d::Before serialization particle id 2 is in cell 2.10
+DEAL:0:2d/2d::Before serialization particle id 5 is in cell 2.11
+DEAL:0:2d/2d::Before serialization particle id 8 is in cell 2.15
+DEAL:0:2d/2d::0 0 9 1 9
 
-DEAL:0:2d/2d::After deserialization global number of particles is: 2
 DEAL:0:2d/2d::After serialization particle id 0 is in cell 2.0
-DEAL:0:2d/2d::After serialization particle id 1 is in cell 2.12
+DEAL:0:2d/2d::After serialization particle id 3 is in cell 2.1
+DEAL:0:2d/2d::After serialization particle id 1 is in cell 2.2
+DEAL:0:2d/2d::After serialization particle id 4 is in cell 2.3
+DEAL:0:2d/2d::After serialization particle id 6 is in cell 2.5
+DEAL:0:2d/2d::After serialization particle id 7 is in cell 2.7
+DEAL:0:2d/2d::After serialization particle id 2 is in cell 2.10
+DEAL:0:2d/2d::After serialization particle id 5 is in cell 2.11
+DEAL:0:2d/2d::After serialization particle id 8 is in cell 2.15
 DEAL:0:2d/2d::OK
 DEAL:0:2d/2d::
 DEAL:0:2d/3d::Before serialization particle id 0 is in cell 2.0
-DEAL:0:2d/3d::Before serialization particle id 1 is in cell 2.12
-DEAL:0:2d/3d::0 0 2 1 2
+DEAL:0:2d/3d::Before serialization particle id 3 is in cell 2.1
+DEAL:0:2d/3d::Before serialization particle id 1 is in cell 2.2
+DEAL:0:2d/3d::Before serialization particle id 4 is in cell 2.3
+DEAL:0:2d/3d::Before serialization particle id 6 is in cell 2.5
+DEAL:0:2d/3d::Before serialization particle id 7 is in cell 2.7
+DEAL:0:2d/3d::Before serialization particle id 2 is in cell 2.10
+DEAL:0:2d/3d::Before serialization particle id 5 is in cell 2.11
+DEAL:0:2d/3d::Before serialization particle id 8 is in cell 2.15
+DEAL:0:2d/3d::0 0 9 1 9
 
-DEAL:0:2d/3d::After deserialization global number of particles is: 2
 DEAL:0:2d/3d::After serialization particle id 0 is in cell 2.0
-DEAL:0:2d/3d::After serialization particle id 1 is in cell 2.12
+DEAL:0:2d/3d::After serialization particle id 3 is in cell 2.1
+DEAL:0:2d/3d::After serialization particle id 1 is in cell 2.2
+DEAL:0:2d/3d::After serialization particle id 4 is in cell 2.3
+DEAL:0:2d/3d::After serialization particle id 6 is in cell 2.5
+DEAL:0:2d/3d::After serialization particle id 7 is in cell 2.7
+DEAL:0:2d/3d::After serialization particle id 2 is in cell 2.10
+DEAL:0:2d/3d::After serialization particle id 5 is in cell 2.11
+DEAL:0:2d/3d::After serialization particle id 8 is in cell 2.15
 DEAL:0:2d/3d::OK
 DEAL:0:2d/3d::
 DEAL:0:3d/3d::Before serialization particle id 0 is in cell 2.0
-DEAL:0:3d/3d::Before serialization particle id 1 is in cell 2.56
-DEAL:0:3d/3d::0 0 2 1 2
+DEAL:0:3d/3d::Before serialization particle id 1 is in cell 2.0
+DEAL:0:3d/3d::Before serialization particle id 2 is in cell 2.0
+DEAL:0:3d/3d::Before serialization particle id 9 is in cell 2.1
+DEAL:0:3d/3d::Before serialization particle id 10 is in cell 2.1
+DEAL:0:3d/3d::Before serialization particle id 11 is in cell 2.1
+DEAL:0:3d/3d::Before serialization particle id 3 is in cell 2.6
+DEAL:0:3d/3d::Before serialization particle id 4 is in cell 2.6
+DEAL:0:3d/3d::Before serialization particle id 5 is in cell 2.6
+DEAL:0:3d/3d::Before serialization particle id 12 is in cell 2.7
+DEAL:0:3d/3d::Before serialization particle id 13 is in cell 2.7
+DEAL:0:3d/3d::Before serialization particle id 14 is in cell 2.7
+DEAL:0:3d/3d::Before serialization particle id 18 is in cell 2.9
+DEAL:0:3d/3d::Before serialization particle id 19 is in cell 2.9
+DEAL:0:3d/3d::Before serialization particle id 20 is in cell 2.9
+DEAL:0:3d/3d::Before serialization particle id 21 is in cell 2.15
+DEAL:0:3d/3d::Before serialization particle id 22 is in cell 2.15
+DEAL:0:3d/3d::Before serialization particle id 23 is in cell 2.15
+DEAL:0:3d/3d::Before serialization particle id 6 is in cell 2.54
+DEAL:0:3d/3d::Before serialization particle id 7 is in cell 2.54
+DEAL:0:3d/3d::Before serialization particle id 8 is in cell 2.54
+DEAL:0:3d/3d::Before serialization particle id 15 is in cell 2.55
+DEAL:0:3d/3d::Before serialization particle id 16 is in cell 2.55
+DEAL:0:3d/3d::Before serialization particle id 17 is in cell 2.55
+DEAL:0:3d/3d::Before serialization particle id 24 is in cell 2.63
+DEAL:0:3d/3d::Before serialization particle id 25 is in cell 2.63
+DEAL:0:3d/3d::Before serialization particle id 26 is in cell 2.63
+DEAL:0:3d/3d::0 0 27 3 27
 
-DEAL:0:3d/3d::After deserialization global number of particles is: 2
 DEAL:0:3d/3d::After serialization particle id 0 is in cell 2.0
-DEAL:0:3d/3d::After serialization particle id 1 is in cell 2.56
+DEAL:0:3d/3d::After serialization particle id 1 is in cell 2.0
+DEAL:0:3d/3d::After serialization particle id 2 is in cell 2.0
+DEAL:0:3d/3d::After serialization particle id 9 is in cell 2.1
+DEAL:0:3d/3d::After serialization particle id 10 is in cell 2.1
+DEAL:0:3d/3d::After serialization particle id 11 is in cell 2.1
+DEAL:0:3d/3d::After serialization particle id 3 is in cell 2.6
+DEAL:0:3d/3d::After serialization particle id 4 is in cell 2.6
+DEAL:0:3d/3d::After serialization particle id 5 is in cell 2.6
+DEAL:0:3d/3d::After serialization particle id 12 is in cell 2.7
+DEAL:0:3d/3d::After serialization particle id 13 is in cell 2.7
+DEAL:0:3d/3d::After serialization particle id 14 is in cell 2.7
+DEAL:0:3d/3d::After serialization particle id 18 is in cell 2.9
+DEAL:0:3d/3d::After serialization particle id 19 is in cell 2.9
+DEAL:0:3d/3d::After serialization particle id 20 is in cell 2.9
+DEAL:0:3d/3d::After serialization particle id 21 is in cell 2.15
+DEAL:0:3d/3d::After serialization particle id 22 is in cell 2.15
+DEAL:0:3d/3d::After serialization particle id 23 is in cell 2.15
+DEAL:0:3d/3d::After serialization particle id 6 is in cell 2.54
+DEAL:0:3d/3d::After serialization particle id 7 is in cell 2.54
+DEAL:0:3d/3d::After serialization particle id 8 is in cell 2.54
+DEAL:0:3d/3d::After serialization particle id 15 is in cell 2.55
+DEAL:0:3d/3d::After serialization particle id 16 is in cell 2.55
+DEAL:0:3d/3d::After serialization particle id 17 is in cell 2.55
+DEAL:0:3d/3d::After serialization particle id 24 is in cell 2.63
+DEAL:0:3d/3d::After serialization particle id 25 is in cell 2.63
+DEAL:0:3d/3d::After serialization particle id 26 is in cell 2.63
 DEAL:0:3d/3d::OK
 DEAL:0:3d/3d::


### PR DESCRIPTION
Depends on #15559.

#15559 instantiates, among others, `GridTools::find_active_cell_around_point()` for `p::f::T`.

This allows to make all `serialization/particle_handler_*.cc` tests consistent, including `serialization/particle_handler_04.cc`.