### PR TITLE
disable github CI build of branches

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,6 +1,6 @@
 name: github-linux
 
-on: [push, pull_request]
+on: [pull_request]
 
 concurrency:
   group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -1,6 +1,6 @@
 name: github-OSX
 
-on: [push, pull_request]
+on: [pull_request]
 
 concurrency:
   group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -1,6 +1,6 @@
 name: tidy
 
-on: [push, pull_request]
+on: [pull_request]
 
 concurrency:
   group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,6 @@
 name: github-windows
 
-on: [push, pull_request]
+on: [pull_request]
 
 concurrency:
   group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Let's disable building of master for now to speed up CI.

FYI @tamiko 