### PR TITLE
Move the save and load function to serial tria

### DIFF
--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -321,6 +321,22 @@ namespace parallel
         const dealii::Triangulation<dim, spacedim> &other_tria) override;
 
       /**
+       * Save the triangulation into the given file. This file needs to be
+       * reachable from all nodes in the computation on a shared network file
+       * system. See the SolutionTransfer class on how to store solution vectors
+       * into this file. Additional cell-based data can be saved using
+       * register_data_attach().
+       */
+      using parallel::TriangulationBase<dim, spacedim>::save;
+
+      /**
+       * Load the triangulation saved with save() back in. Cell-based data that
+       * was saved with register_data_attach() can be read in with
+       * notify_ready_to_unpack() after calling load().
+       */
+      using parallel::TriangulationBase<dim, spacedim>::load;
+
+      /**
        * Read the data of this object from a stream for the purpose of
        * serialization. Throw away the previous content.
        *

--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -493,13 +493,14 @@ namespace parallel
     /**
      * Load the triangulation saved with save() back in. Cell-based data that
      * was saved with register_data_attach() can be read in with
-     * notify_ready_to_unpack() after calling load().
+     * notify_ready_to_unpack() after calling Triangulation<dim,
+     * spacedim>::load.
      */
     using Triangulation<dim, spacedim>::load;
 
 
     /**
-     * @copydoc load()
+     * Same as the function above.
      *
      * @deprecated The autopartition parameter has been removed.
      */

--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -487,16 +487,16 @@ namespace parallel
      * into this file. Additional cell-based data can be saved using
      * register_data_attach().
      */
-    virtual void
-    save(const std::string &filename) const = 0;
+    using Triangulation<dim, spacedim>::save;
+
 
     /**
      * Load the triangulation saved with save() back in. Cell-based data that
      * was saved with register_data_attach() can be read in with
      * notify_ready_to_unpack() after calling load().
      */
-    virtual void
-    load(const std::string &filename) = 0;
+    using Triangulation<dim, spacedim>::load;
+
 
     /**
      * @copydoc load()

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -3412,6 +3412,22 @@ public:
 
 
   /**
+   * Save the triangulation into the given file. Internally, this
+   * function calls the save funtion which uses BOOST archives. This
+   * is a placeholder implementation that, in the near future, will also
+   * attach the data associated with the triangulation
+   */
+  virtual void
+  save(const std::string &filename) const;
+
+  /**
+   * Load the triangulation saved with save() back in.
+   */
+  virtual void
+  load(const std::string &filename);
+
+
+  /**
    * Declare the (coarse) face pairs given in the argument of this function as
    * periodic. This way it is possible to obtain neighbors across periodic
    * boundaries.

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -28,9 +28,13 @@
 #include <deal.II/grid/tria_iterator.h>
 #include <deal.II/grid/tria_levels.h>
 
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <fstream>
 #include <functional>
 #include <list>
 #include <map>
@@ -12751,7 +12755,25 @@ void Triangulation<dim, spacedim>::load_user_indices(
     Assert(false, ExcNotImplemented());
 }
 
+template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::save(const std::string &filename) const
+{
+  // Create boost archive then call alternative version of the save function
+  std::ofstream                 ofs(filename);
+  boost::archive::text_oarchive oa(ofs, boost::archive::no_header);
+  save(oa, 0);
+}
 
+template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+void Triangulation<dim, spacedim>::load(const std::string &filename)
+{
+  // Create boost archive then call alternative version of the load function
+  std::ifstream                 ifs(filename);
+  boost::archive::text_iarchive ia(ifs, boost::archive::no_header);
+  load(ia, 0);
+}
 
 namespace
 {


### PR DESCRIPTION
In the work we are doing @pcafrica and I, we need to be able to serialize the serial triangulations while saving the data attached to it. This PR moves the save and load function to the serial triangulation where it only does save an archive. This is a first towards a full serialization of particles for all triangulation type.


@pcafrica @peterrum 