### PR TITLE
Fix missing include file for optimization/line_minimization.h

### DIFF
--- a/include/deal.II/optimization/line_minimization.h
+++ b/include/deal.II/optimization/line_minimization.h
@@ -29,6 +29,7 @@
 #include <fstream>
 #include <functional>
 #include <limits>
+#include <optional>
 #include <string>
 
 


### PR DESCRIPTION
Fixes most of the test in https://cdash.dealii.org/viewTest.php?onlyfailed&buildid=678.