### PR TITLE
Micro-optimize a loop.

### DIFF
--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -1486,10 +1486,11 @@ namespace internal
         }
     }
 
-    bool hp_functionality_enabled = false;
-    for (const auto &dh : dof_handler)
-      if (dh->get_fe_collection().size() > 1)
-        hp_functionality_enabled = true;
+    const bool hp_functionality_enabled =
+      std::any_of(dof_handler.begin(), dof_handler.end(), [](const auto &dh) {
+        return (dh->get_fe_collection().size() > 1);
+      });
+
     const unsigned int         n_lanes = task_info.vectorization_length;
     std::vector<unsigned int>  renumbering;
     std::vector<unsigned char> irregular_cells;

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -1488,7 +1488,7 @@ namespace internal
 
     const bool hp_functionality_enabled =
       std::any_of(dof_handlers.begin(), dof_handlers.end(), [](const auto &dh) {
-        return (dh->get_fe_collection().size() > 1);
+        return dh->has_hp_capabilities();
       });
 
     const unsigned int         n_lanes = task_info.vectorization_length;


### PR DESCRIPTION
The loop implements an "any of" query, so just use `std::any_of()`. This has the advantage that it will also have a `break` in it whereas here we keep looping over all elements even if we have already found a positive one.