### PR TITLE
Mark a 'virtual' function as such.

### DIFF
--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -549,7 +549,7 @@ public:
    * Return dimension of the vector. This is the sum of the dimensions of all
    * components.
    */
-  size_type
+  virtual size_type
   size() const override;
 
   /**


### PR DESCRIPTION
As far as I know, we do that everywhere.