### PR TITLE
base/exceptions.h: avoid warnings in Trilinos / Kokkos headers

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -18,7 +18,9 @@
 
 #include <deal.II/base/config.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <Kokkos_Core.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <exception>
 #include <ostream>


### PR DESCRIPTION
gcc might emit a warning depending on inlining and optimization, even though we include the header in question with -isystem. Thus, let us explicitly disable diagnostics while parsing the Kokkos header.

Otherwise, the following warning might get emitted:
```
[1/1] Building CXX object source/base/CMakeFiles/object_base_release.dir/partitioner.cc.o
In file included from /usr/include/trilinos/desul/atomics/Fetch_Op.hpp:30,
                 from /usr/include/trilinos/desul/atomics/Generic.hpp:13,
                 from /usr/include/trilinos/desul/atomics/Atomic_Ref.hpp:14,
                 from /usr/include/trilinos/desul/atomics.hpp:12,
                 from /usr/include/trilinos/Kokkos_Atomics_Desul_Wrapper.hpp:28,
                 from /usr/include/trilinos/Kokkos_Atomic.hpp:50,
                 from /usr/include/trilinos/impl/Kokkos_Atomic_View.hpp:20,
                 from /usr/include/trilinos/impl/Kokkos_ViewMapping.hpp:32,
                 from /usr/include/trilinos/Kokkos_View.hpp:489,
                 from /usr/include/trilinos/Kokkos_Parallel.hpp:31,
                 from /usr/include/trilinos/Kokkos_MemoryPool.hpp:26,
                 from /usr/include/trilinos/Kokkos_TaskScheduler.hpp:34,
                 from /usr/include/trilinos/Kokkos_Serial.hpp:36,
                 from /usr/include/trilinos/decl/Kokkos_Declare_SERIAL.hpp:21,
                 from /usr/include/trilinos/KokkosCore_Config_DeclareBackend.hpp:22,
                 from /usr/include/trilinos/Kokkos_Core.hpp:45,
                 from /home/tamiko/workspace/dealii/include/deal.II/base/exceptions.h:21,
                 from /home/tamiko/workspace/dealii/include/deal.II/base/array_view.h:21,
                 from /home/tamiko/workspace/dealii/include/deal.II/base/mpi.h:21,
                 from /home/tamiko/workspace/dealii/include/deal.II/base/mpi_consensus_algorithms.h:21,
                 from /home/tamiko/workspace/dealii/include/deal.II/base/mpi_compute_index_owner_internal.h:21,
                 from /home/tamiko/workspace/dealii/source/base/partitioner.cc:16:
In function ‘T desul::Impl::host_atomic_fetch_oper(const Oper&, T*, dont_deduce_this_parameter_t<const T>, MemoryOrder, desul::MemoryScopeCaller) [with Oper = sub_operator<int, const int>; T = int; MemoryOrder = desul::MemoryOrderRelaxed]’,
    inlined from ‘T desul::Impl::host_atomic_fetch_sub(T*, T, MemoryOrder, MemoryScope) [with T = int; MemoryOrder = desul::MemoryOrderRelaxed; MemoryScope = desul::MemoryScopeCaller]’ at /usr/include/trilinos/desul/atomics/Fetch_Op_Generic.hpp:40:1,
    inlined from ‘T desul::atomic_fetch_sub(T*, T, MemoryOrder, MemoryScope) [with T = int; MemoryOrder = MemoryOrderRelaxed; MemoryScope = MemoryScopeCaller]’ at /usr/include/trilinos/desul/atomics/Generic.hpp:54:3,
    inlined from ‘T Kokkos::atomic_fetch_sub(T*, desul::Impl::dont_deduce_this_parameter_t<const T>) [with T = int]’ at /usr/include/trilinos/Kokkos_Atomics_Desul_Wrapper.hpp:85:125,
    inlined from ‘void Kokkos::Impl::HostSharedPtr<T>::cleanup() [with T = Kokkos::Impl::SerialInternal]’ at /usr/include/trilinos/impl/Kokkos_HostSharedPtr.hpp:120:5,
    inlined from ‘Kokkos::Impl::HostSharedPtr<T>::~HostSharedPtr() [with T = Kokkos::Impl::SerialInternal]’ at /usr/include/trilinos/impl/Kokkos_HostSharedPtr.hpp:92:45,
    inlined from ‘Kokkos::Serial::~Serial()’ at /usr/include/trilinos/Kokkos_Serial.hpp:87:7,
    inlined from ‘Kokkos::RangePolicy<Kokkos::Serial, Kokkos::IndexType<int> >::~RangePolicy()’ at /usr/include/trilinos/Kokkos_ExecPolicy.hpp:67:7,
    inlined from ‘void Kokkos::parallel_for(const std::string&, const ExecPolicy&, const FunctorType&) [with ExecPolicy = RangePolicy<Serial, IndexType<int> >; FunctorType = Impl::ViewFill<View<int*, LayoutRight, Device<Serial, AnonymousSpace>, MemoryTraits<0> >, LayoutRight, Serial, 1, int>; Enable = void]’ at /usr/include/trilinos/Kokkos_Parallel.hpp:147:1:
/usr/include/trilinos/desul/atomics/Fetch_Op_ScopeCaller.hpp:44:1: warning: pointer used after ‘void operator delete(void*, std::size_t)’ [-Wuse-after-free]
   44 | DESUL_IMPL_ATOMIC_FETCH_OPER(DESUL_IMPL_HOST_FUNCTION, host)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/tamiko/workspace/dealii/include/deal.II/base/numbers.h:28,
                 from /home/tamiko/workspace/dealii/build/include/deal.II/base/config.h:579,
                 from /home/tamiko/workspace/dealii/include/deal.II/base/mpi_compute_index_owner_internal.h:19:
In member function ‘void Kokkos::Impl::HostSharedPtr<T>::cleanup() [with T = Kokkos::Impl::SerialInternal]’,
    inlined from ‘Kokkos::Impl::HostSharedPtr<T>::~HostSharedPtr() [with T = Kokkos::Impl::SerialInternal]’ at /usr/include/trilinos/impl/Kokkos_HostSharedPtr.hpp:92:45,
    inlined from ‘Kokkos::Serial::~Serial()’ at /usr/include/trilinos/Kokkos_Serial.hpp:87:7,
    inlined from ‘Kokkos::RangePolicy<Kokkos::Serial, Kokkos::IndexType<int> >::~RangePolicy()’ at /usr/include/trilinos/Kokkos_ExecPolicy.hpp:67:7,
    inlined from ‘Kokkos::Impl::ParallelFor<Kokkos::Impl::ViewFill<Kokkos::View<int*, Kokkos::LayoutRight, Kokkos::Device<Kokkos::Serial, Kokkos::AnonymousSpace>, Kokkos::MemoryTraits<0> >, Kokkos::LayoutRight, Kokkos::Serial, 1, int>, Kokkos::RangePolicy<Kokkos::Serial, Kokkos::IndexType<int> >, Kokkos::Serial>::~ParallelFor()’ at /usr/include/trilinos/Serial/Kokkos_Serial_Parallel_Range.hpp:26:7,
    inlined from ‘void Kokkos::parallel_for(const std::string&, const ExecPolicy&, const FunctorType&) [with ExecPolicy = RangePolicy<Serial, IndexType<int> >; FunctorType = Impl::ViewFill<View<int*, LayoutRight, Device<Serial, AnonymousSpace>, MemoryTraits<0> >, LayoutRight, Serial, 1, int>; Enable = void]’ at /usr/include/trilinos/Kokkos_Parallel.hpp:147:1:
/usr/include/trilinos/impl/Kokkos_HostSharedPtr.hpp:120:5: note: call to ‘void operator delete(void*, std::size_t)’ here
  120 |     KOKKOS_IF_ON_HOST((
      |     ^~~~~~~~~~~~~~~~~
```