### PR TITLE
Create a vector space vector concept.

### DIFF
--- a/include/deal.II/base/template_constraints.h
+++ b/include/deal.II/base/template_constraints.h
@@ -977,7 +977,97 @@ namespace concepts
   template <typename MeshType>
   concept is_triangulation_or_dof_handler =
     internal::is_triangulation_or_dof_handler<MeshType>;
+
+  /**
+   * A concept that tests whether a class `VectorType` has the required
+   * interface to serve as a vector in vector-space operations -- principally
+   * what is required to run iterative solvers: things such as norms, dot
+   * products, etc.
+   */
+  template <typename VectorType>
+  concept is_vector_space_vector = requires(VectorType                      U,
+                                            VectorType                      V,
+                                            VectorType                      W,
+                                            typename VectorType::value_type a,
+                                            typename VectorType::value_type b,
+                                            typename VectorType::value_type s)
+  {
+    // Check local type requirements:
+    typename VectorType::value_type;
+    typename VectorType::size_type;
+    typename VectorType::real_type;
+
+    // Check some assignment and reinit operations;
+    U.reinit(V);
+    U.reinit(V, /* omit_zeroing_entries= */ true);
+
+    U = V;
+    U = a; // assignment of scalar
+
+    U.equ(a, V);
+
+    // Check scaling operations
+    U *= a;
+    U /= a;
+
+    U.scale(V);
+
+    // Vector additions:
+    U += V;
+    U -= V;
+
+    U.add(a);
+    U.add(a, V);
+    U.add(a, V, b, W);
+
+    U.sadd(s, a, V);
+
+    // Norms and similar stuff:
+    {
+      U.mean_value()
+    }
+    ->std::convertible_to<typename VectorType::value_type>;
+
+    {
+      U.l1_norm()
+    }
+    ->std::convertible_to<typename VectorType::real_type>;
+
+    {
+      U.l2_norm()
+    }
+    ->std::convertible_to<typename VectorType::real_type>;
+
+    {
+      U.linfty_norm()
+    }
+    ->std::convertible_to<typename VectorType::real_type>;
+
+    // Dot products:
+    {
+      U *V
+    }
+    ->std::convertible_to<typename VectorType::value_type>;
+
+    {
+      U.add_and_dot(a, V, W)
+    }
+    ->std::convertible_to<typename VectorType::value_type>;
+
+    // Some queries:
+    {
+      U.size()
+    }
+    ->std::convertible_to<typename VectorType::size_type>;
+
+    {
+      U.all_zero()
+    }
+    ->std::same_as<bool>;
+  };
+
 #endif
+
 } // namespace concepts
 
 

--- a/source/lac/block_vector.inst.in
+++ b/source/lac/block_vector.inst.in
@@ -17,6 +17,13 @@
 
 for (S : REAL_AND_COMPLEX_SCALARS)
   {
+    // Check that the class we declare here satisfies the
+    // vector-space-vector concept. If we catch it here,
+    // any mistake in the vector class declaration would
+    // show up in uses of this class later on as well.
+#ifdef DEAL_II_HAVE_CXX20
+    static_assert(concepts::is_vector_space_vector<BlockVector<S>>);
+#endif
     template class BlockVector<S>;
   }
 

--- a/source/lac/la_parallel_block_vector.inst.in
+++ b/source/lac/la_parallel_block_vector.inst.in
@@ -21,7 +21,12 @@ for (SCALAR : REAL_AND_COMPLEX_SCALARS)
     \{
       namespace distributed
       \{
+#ifdef DEAL_II_HAVE_CXX20
+        static_assert(concepts::is_vector_space_vector<BlockVector<SCALAR>>);
+#endif
+
         template class BlockVector<SCALAR>;
+
         template void
         BlockVector<SCALAR>::multivector_inner_product(
           FullMatrix<SCALAR> &,

--- a/source/lac/la_parallel_vector.inst.in
+++ b/source/lac/la_parallel_vector.inst.in
@@ -21,7 +21,13 @@ for (SCALAR : REAL_AND_COMPLEX_SCALARS)
     \{
       namespace distributed
       \{
+#ifdef DEAL_II_HAVE_CXX20
+        static_assert(concepts::is_vector_space_vector<
+                      Vector<SCALAR, ::dealii::MemorySpace::Host>>);
+#endif
+
         template class Vector<SCALAR, ::dealii::MemorySpace::Host>;
+
         template void
         Vector<SCALAR, ::dealii::MemorySpace::Host>::import_elements<
           ::dealii::MemorySpace::Host>(

--- a/source/lac/petsc_parallel_block_vector.cc
+++ b/source/lac/petsc_parallel_block_vector.cc
@@ -25,6 +25,14 @@ namespace PETScWrappers
 {
   namespace MPI
   {
+    // Check that the class we declare here satisfies the
+    // vector-space-vector concept. If we catch it here,
+    // any mistake in the vector class declaration would
+    // show up in uses of this class later on as well.
+#  ifdef DEAL_II_HAVE_CXX20
+    static_assert(concepts::is_vector_space_vector<BlockVector>);
+#  endif
+
     using size_type = types::global_dof_index;
 
     BlockVector::~BlockVector()

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -28,6 +28,14 @@ namespace PETScWrappers
 {
   namespace MPI
   {
+    // Check that the class we declare here satisfies the
+    // vector-space-vector concept. If we catch it here,
+    // any mistake in the vector class declaration would
+    // show up in uses of this class later on as well.
+#  ifdef DEAL_II_HAVE_CXX20
+    static_assert(concepts::is_vector_space_vector<Vector>);
+#  endif
+
     Vector::Vector()
     {
       // virtual functions called in constructors and destructors never use the

--- a/source/lac/trilinos_epetra_vector.cc
+++ b/source/lac/trilinos_epetra_vector.cc
@@ -38,6 +38,14 @@ namespace LinearAlgebra
 {
   namespace EpetraWrappers
   {
+    // Check that the class we declare here satisfies the
+    // vector-space-vector concept. If we catch it here,
+    // any mistake in the vector class declaration would
+    // show up in uses of this class later on as well.
+#  ifdef DEAL_II_HAVE_CXX20
+    static_assert(concepts::is_vector_space_vector<Vector>);
+#  endif
+
     Vector::Vector()
       : Subscriptor()
       , vector(new Epetra_FEVector(

--- a/source/lac/trilinos_tpetra_vector.cc
+++ b/source/lac/trilinos_tpetra_vector.cc
@@ -23,17 +23,39 @@ namespace LinearAlgebra
 {
   namespace TpetraWrappers
   {
+    // Instantiate these vectors types for specific scalar types.
+    //
+    // While there:
+    // Check that the class we declare here satisfies the
+    // vector-space-vector concept. If we catch it here,
+    // any mistake in the vector class declaration would
+    // show up in uses of this class later on as well.
+
 #  ifdef HAVE_TPETRA_INST_FLOAT
+#    ifdef DEAL_II_HAVE_CXX20
+    static_assert(concepts::is_vector_space_vector<Vector<float>>);
+#    endif
     template class Vector<float>;
 #  endif
 #  ifdef HAVE_TPETRA_INST_DOUBLE
+#    ifdef DEAL_II_HAVE_CXX20
+    static_assert(concepts::is_vector_space_vector<Vector<double>>);
+#    endif
     template class Vector<double>;
 #  endif
 #  ifdef DEAL_II_WITH_COMPLEX_VALUES
 #    ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
+#      ifdef DEAL_II_HAVE_CXX20
+    static_assert(concepts::is_vector_space_vector <
+                  Vector<std::complex<float>>);
+#      endif
     template class Vector<std::complex<float>>;
 #    endif
 #    ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
+#      ifdef DEAL_II_HAVE_CXX20
+    static_assert(concepts::is_vector_space_vector <
+                  Vector<std::complex<double>>);
+#      endif
     template class Vector<std::complex<double>>;
 #    endif
 #  endif

--- a/source/lac/vector.inst.in
+++ b/source/lac/vector.inst.in
@@ -17,6 +17,14 @@
 
 for (SCALAR : REAL_AND_COMPLEX_SCALARS)
   {
+    // Check that the class we declare here satisfies the
+    // vector-space-vector concept. If we catch it here,
+    // any mistake in the vector class declaration would
+    // show up in uses of this class later on as well.
+#ifdef DEAL_II_HAVE_CXX20
+    static_assert(concepts::is_vector_space_vector<Vector<SCALAR>>);
+#endif
+
     template class Vector<SCALAR>;
   }
 


### PR DESCRIPTION
Another step for #3073: If we no longer have a base class, we might as well have a concept that checks that our vector classes have the interface we need.

While there, I thought it might be a nice idea to place checks right next to the instantiations of our vector classes so that we check early that they really have the required interface.