### PR TITLE
Remove a funny exit path in AffineConstraints::close().

### DIFF
--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -772,8 +772,6 @@ AffineConstraints<number>::close()
                     ++n_replacements;
                     Assert(n_replacements / 2 < largest_idx,
                            ExcMessage("Cycle in constraints detected!"));
-                    if (n_replacements / 2 >= largest_idx)
-                      return; // this enables us to test for this Exception.
 #endif
                   }
                 else


### PR DESCRIPTION
This is wild. We have
```
#ifdef DEBUG
  Assert (cond, ...);
  if (!cond)
    return;
#endif
```
I really don't understand what that is supposed to even mean. All of this code only happens in debug mode. So if the condition is not satisfied, we trip the assertion. We can't get to the `return`.