### PR TITLE
Test fe/fe_enriched_step-36: make a test less expensive

### DIFF
--- a/tests/fe/fe_enriched_step-36.cc
+++ b/tests/fe/fe_enriched_step-36.cc
@@ -610,7 +610,7 @@ namespace Step36
   void
   EigenvalueProblem<dim>::run()
   {
-    for (unsigned int cycle = 0; cycle < 4; ++cycle)
+    for (unsigned int cycle = 0; cycle < 2; ++cycle)
       {
         pcout << "Cycle " << cycle << std::endl;
         const std::pair<unsigned int, unsigned int> n_cells = setup_system();

--- a/tests/fe/fe_enriched_step-36.with_petsc=on.with_slepc=on.with_cxx14=on.with_petsc_with_complex=false.output
+++ b/tests/fe/fe_enriched_step-36.with_petsc=on.with_slepc=on.with_cxx14=on.with_petsc_with_complex=false.output
@@ -10,15 +10,3 @@ Cycle 1
    Number of degrees of freedom: 2206
 
       Eigenvalue 0 : -0.498786
-Cycle 2
-   Number of active cells:       512
-     FE / POUFE :                504 / 72
-   Number of degrees of freedom: 5734
-
-      Eigenvalue 0 : -0.499788
-Cycle 3
-   Number of active cells:       568
-     FE / POUFE :                504 / 136
-   Number of degrees of freedom: 6508
-
-      Eigenvalue 0 : -0.499818


### PR DESCRIPTION
The debug variant of fe/fe_enriched_step-36 takes about 6 minute to execute with clang and -fsanitize=address. Let's make it a bit less expensive.