### PR TITLE
Change step-68 + timing_step-68 to use FEPointEvaluator

### DIFF
--- a/examples/step-68/step-68.cc
+++ b/examples/step-68/step-68.cc
@@ -568,31 +568,31 @@ namespace Step68
         Assert(pic.begin() == particle, ExcInternalError());
         std::vector<Point<dim>> particle_positions;
         for (auto &p : pic)
-            particle_positions.push_back(p.get_reference_location());
+          particle_positions.push_back(p.get_reference_location());
 
         evaluator.reinit(cell, particle_positions);
         evaluator.evaluate(make_array_view(local_dof_values),
-                             EvaluationFlags::values);
+                           EvaluationFlags::values);
 
         // We move the particles using the interpolated velocity field
-        for (unsigned int particle_index = 0;
-            particle != pic.end();
-            ++particle, ++particle_index)
-        {
-          Point<dim> particle_location = particle->get_location();
-          const Tensor<1, dim> &particle_velocity = evaluator.get_value(particle_index) ;                
-          particle_location += particle_velocity*dt;
-          particle->set_location(particle_location);
+        for (unsigned int particle_index = 0; particle != pic.end();
+             ++particle, ++particle_index)
+          {
+            Point<dim>            particle_location = particle->get_location();
+            const Tensor<1, dim> &particle_velocity =
+              evaluator.get_value(particle_index);
+            particle_location += particle_velocity * dt;
+            particle->set_location(particle_location);
 
-          // Again, we store the particle velocity and the processor id in the
-          // particle properties for visualization purposes.
-          ArrayView<double> properties = particle->get_properties();
-          for (int d = 0; d < dim; ++d)
-            properties[d] = particle_velocity[d];
+            // Again, we store the particle velocity and the processor id in the
+            // particle properties for visualization purposes.
+            ArrayView<double> properties = particle->get_properties();
+            for (int d = 0; d < dim; ++d)
+              properties[d] = particle_velocity[d];
 
-          properties[dim] =
-            Utilities::MPI::this_mpi_process(mpi_communicator);
-        }
+            properties[dim] =
+              Utilities::MPI::this_mpi_process(mpi_communicator);
+          }
       }
   }
 

--- a/examples/step-68/step-68.cc
+++ b/examples/step-68/step-68.cc
@@ -543,8 +543,6 @@ namespace Step68
     Vector<double> local_dof_values(fluid_fe.dofs_per_cell);
 
     FEPointEvaluation<dim, dim> evaluator(mapping, fluid_fe, update_values);
-    const FEValuesExtractors::Vector velocity(0);
-
 
     // We loop over all the local particles. Although this could be achieved
     // directly by looping over all the cells, this would force us

--- a/tests/performance/timing_step_68.cc
+++ b/tests/performance/timing_step_68.cc
@@ -321,7 +321,8 @@ namespace Step68
   }
 
   template <int dim>
-  void ParticleTracking<dim>::euler_step_interpolated(const double dt)
+  void
+  ParticleTracking<dim>::euler_step_interpolated(const double dt)
   {
     Vector<double> local_dof_values(fluid_fe.dofs_per_cell);
 
@@ -340,32 +341,30 @@ namespace Step68
         Assert(pic.begin() == particle, ExcInternalError());
         std::vector<Point<dim>> particle_positions;
         for (auto &p : pic)
-            particle_positions.push_back(p.get_reference_location());
+          particle_positions.push_back(p.get_reference_location());
 
         evaluator.reinit(cell, particle_positions);
         evaluator.evaluate(make_array_view(local_dof_values),
-                             EvaluationFlags::values);
+                           EvaluationFlags::values);
 
-        for (unsigned int particle_index = 0;
-            particle != pic.end();
-            ++particle, ++particle_index)
-        {
-          Point<dim> particle_location = particle->get_location();
-          const Tensor<1, dim> &particle_velocity = evaluator.get_value(particle_index) ;                
-          particle_location += particle_velocity*dt;
-          particle->set_location(particle_location);
+        for (unsigned int particle_index = 0; particle != pic.end();
+             ++particle, ++particle_index)
+          {
+            Point<dim>            particle_location = particle->get_location();
+            const Tensor<1, dim> &particle_velocity =
+              evaluator.get_value(particle_index);
+            particle_location += particle_velocity * dt;
+            particle->set_location(particle_location);
 
-          ArrayView<double> properties = particle->get_properties();
-          for (int d = 0; d < dim; ++d)
-            properties[d] = particle_velocity[d];
+            ArrayView<double> properties = particle->get_properties();
+            for (int d = 0; d < dim; ++d)
+              properties[d] = particle_velocity[d];
 
-          properties[dim] =
-            Utilities::MPI::this_mpi_process(mpi_communicator);
-        }
+            properties[dim] =
+              Utilities::MPI::this_mpi_process(mpi_communicator);
+          }
       }
   }
-
-
 
 
 


### PR DESCRIPTION
In step-68 we do not use FEPointEvaluator under the guise that is faster to manually interpolate at the point location. It turns out that this is absolutely false and using FEPointEvaluator can be significantly faster (like 1.5-1.75X on my laptop). This PR changes step-68 to use the FEPointEvaluator mechanism. It also modifies the performance test associated with step-68 to also use this mechanism.
This addresses @kronbichler comment on the step-68 performance test.