### PR TITLE
github: update linux runners

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,6 +1,7 @@
 name: github-linux
 
 on:
+  push:
   pull_request:
     types:
     - opened

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -123,6 +123,95 @@ jobs:
           setup_tests_vtk
         ctest --output-on-failure -j2
 
+  ############################
+  # linux-debug-intel-oneapi #
+  ############################
+
+  linux-debug-intel-oneapi:
+    # parallel debug build with Intel oneAPI including MPI and MKL
+    #
+    # Based on https://github.com/oneapi-src/oneapi-ci
+    # For a list of Intel packages see https://oneapi-src.github.io/oneapi-ci/#linux-apt
+
+    name: linux debug intel oneapi
+    runs-on: [ubuntu-22.04]
+
+    # only run on 'push' or if the 'pull_request' is not a draft:
+    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: setup apt repo
+      run: |
+        # oneapi-ci/scripts/setup_apt_repo_linux.sh
+        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+        sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/oneAPI.list" -o APT::Get::List-Cleanup="0"
+    - name: collect versioned dependencies of apt packages
+      run : |
+        # oneapi-ci/scripts/apt_depends.sh
+        apt-cache depends intel-oneapi-compiler-dpcpp-cpp \
+                          intel-oneapi-mpi-devel \
+                          intel-oneapi-mkl-devel \
+                          intel-oneapi-tbb-devel | tee dependencies.txt
+    - name: cache install
+      id: cache-install
+      uses: actions/cache@v3
+      with:
+        path: /opt/intel/oneapi
+        key: install-${{ hashFiles('**/dependencies.txt') }}
+    - name: install
+      if: steps.cache-install.outputs.cache-hit != 'true'
+      run: |
+        # oneapi-ci/scripts/install_linux_apt.sh
+        sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp \
+                                intel-oneapi-mpi-devel \
+                                intel-oneapi-mkl-devel \
+                                intel-oneapi-tbb-devel
+        sudo apt-get clean
+    - name: info
+      run: |
+        source /opt/intel/oneapi/setvars.sh
+        export I_MPI_CXX=icpx
+        mpiicpc -v
+        cmake --version
+    - name: configure deal.II
+      run: |
+        source /opt/intel/oneapi/setvars.sh
+        mkdir build
+        cd build
+        cmake -D CMAKE_BUILD_TYPE=Debug \
+              -D CMAKE_CXX_COMPILER=icpx \
+              -D DEAL_II_CXX_FLAGS='-Werror -Wno-error=tautological-constant-compare' \
+              -D DEAL_II_EARLY_DEPRECATIONS=ON \
+              -D DEAL_II_WITH_MPI=ON \
+              -D DEAL_II_WITH_LAPACK=ON \
+              -D DEAL_II_WITH_TBB=ON \
+              -D MPI_DIR=${I_MPI_ROOT} \
+              -D BLAS_DIR=${MKLROOT} \
+              -D LAPACK_DIR=${MKLROOT} \
+              -D TBB_DIR=${TBBROOT} \
+              ..
+    - name: print detailed.log
+      run: cat build/detailed.log
+    - name: build
+      run: |
+        source /opt/intel/oneapi/setvars.sh
+        cd build
+        make VERBOSE=1 -j2
+    - name: test
+      run: |
+        source /opt/intel/oneapi/setvars.sh
+        cd build
+        make -j2 \
+          setup_tests_examples \
+          setup_tests_quick_tests
+        ctest --output-on-failure -j2
+
+  #######################
+  # linux-debug-cuda-11 #
+  #######################
 
   linux-debug-cuda-11:
     # simple parallel debug build using cuda-11
@@ -206,6 +295,9 @@ jobs:
         cd tests/cuda
         make -j2 compile_test_executables
 
+  #############################
+  # linux-debug-cuda-11-clang #
+  #############################
 
   linux-debug-cuda-11-clang:
     # simple parallel debug build using cuda-11 and clang
@@ -292,82 +384,3 @@ jobs:
         make -j 2 setup_tests_cuda
         cd tests/cuda
         make -j2 compile_test_executables
-
-  linux-debug-intel-oneapi:
-    # parallel debug build with Intel oneAPI including MPI and MKL
-    #
-    # Based on https://github.com/oneapi-src/oneapi-ci
-    # For a list of Intel packages see https://oneapi-src.github.io/oneapi-ci/#linux-apt
-
-    name: linux debug intel oneapi
-    runs-on: [ubuntu-20.04]
-
-    # only run on 'push' or if the 'pull_request' is not a draft:
-    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: setup apt repo
-      run: |
-        # oneapi-ci/scripts/setup_apt_repo_linux.sh
-        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-        echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-        sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/oneAPI.list" -o APT::Get::List-Cleanup="0"
-    - name: collect versioned dependencies of apt packages
-      run : |
-        # oneapi-ci/scripts/apt_depends.sh
-        apt-cache depends intel-oneapi-compiler-dpcpp-cpp \
-                          intel-oneapi-mpi-devel \
-                          intel-oneapi-mkl-devel \
-                          intel-oneapi-tbb-devel | tee dependencies.txt
-    - name: cache install
-      id: cache-install
-      uses: actions/cache@v3
-      with:
-        path: /opt/intel/oneapi
-        key: install-${{ hashFiles('**/dependencies.txt') }}
-    - name: install
-      if: steps.cache-install.outputs.cache-hit != 'true'
-      run: |
-        # oneapi-ci/scripts/install_linux_apt.sh
-        sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp \
-                                intel-oneapi-mpi-devel \
-                                intel-oneapi-mkl-devel \
-                                intel-oneapi-tbb-devel
-        sudo apt-get clean
-    - name: info
-      run: |
-        source /opt/intel/oneapi/setvars.sh
-        export I_MPI_CXX=icpx
-        mpiicpc -v
-        cmake --version
-    - name: configure deal.II
-      run: |
-        source /opt/intel/oneapi/setvars.sh
-        mkdir build
-        cd build
-        cmake -D CMAKE_BUILD_TYPE=Debug \
-              -D CMAKE_CXX_COMPILER=icpx \
-              -D DEAL_II_CXX_FLAGS='-Werror -Wno-error=tautological-constant-compare' \
-              -D DEAL_II_EARLY_DEPRECATIONS=ON \
-              -D DEAL_II_WITH_MPI=ON \
-              -D DEAL_II_WITH_LAPACK=ON \
-              -D DEAL_II_WITH_TBB=ON \
-              -D MPI_DIR=${I_MPI_ROOT} \
-              -D BLAS_DIR=${MKLROOT} \
-              -D LAPACK_DIR=${MKLROOT} \
-              -D TBB_DIR=${TBBROOT} \
-              ..
-    - name: print detailed.log
-      run: cat build/detailed.log
-    - name: build
-      run: |
-        source /opt/intel/oneapi/setvars.sh
-        cd build
-        make VERBOSE=1 -j2
-    - name: quicktest
-      run: |
-        source /opt/intel/oneapi/setvars.sh
-        cd build
-        make test

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,44 +16,35 @@ permissions:
   contents: read
 
 jobs:
+
+  ########################
+  # linux-release-serial #
+  ########################
+
   linux-release-serial:
     # simple serial release build using g++
 
     name: linux release serial
-    runs-on: [ubuntu-20.04]
+    runs-on: [ubuntu-22.04]
 
     # only run on 'push' or if the 'pull_request' is not a draft:
     if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
 
+    container:
+      image: dealii/dependencies:jammy
+      options: --user root
+
     steps:
     - uses: actions/checkout@v3
-    - name: setup
-      run: |
-        ./contrib/utilities/download_clang_format
     - name: info
       run: |
         g++ -v
         cmake --version
-    - name: modules
-      run: |
-        sudo apt-get install g++-10
-    - name: Build Boost
-      id: boost
-      uses: egor-tensin/build-boost@v1
-      with:
-        version: 1.74.0
-        libraries: container iostreams python serialization system thread
-        platform: x64
-        configuration: Release
     - name: configure deal.II
       run: |
         mkdir build
         cd build
-        cmake -D BOOST_DIR=/home/runner/work/dealii/boost \
-              -D BOOST_INCLUDEDIR=/home/runner/work/dealii/boost \
-              -D BOOST_LIBRARYDIR=/home/runner/work/dealii/boost/stage/x64/Release/lib \
-              -D CMAKE_BUILD_TYPE=Release \
-              -D CMAKE_CXX_COMPILER=g++-10 \
+        cmake -D CMAKE_BUILD_TYPE=Release \
               -D DEAL_II_CXX_FLAGS='-Werror -std=c++20' \
               -D DEAL_II_EARLY_DEPRECATIONS=ON \
               -DDEAL_II_COMPONENT_PYTHON_BINDINGS=ON \
@@ -64,10 +55,13 @@ jobs:
       run: |
         cd build
         make VERBOSE=1 -j2
-    - name: quicktest
+    - name: test
       run: |
         cd build
-        make test
+        make -j2 \
+          setup_tests_examples \
+          setup_tests_quick_tests
+        ctest --output-on-failure -j2
 
   linux-debug-parallel-simplex:
     # simple parallel debug build using g++ with simplex configuration enabled

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -61,7 +61,7 @@ jobs:
         make -j2 \
           setup_tests_examples \
           setup_tests_quick_tests
-        ctest --output-on-failure -j2
+        ctest --output-on-failure -j2 -VV
 
   ########################
   # linux-debug-parallel #
@@ -121,7 +121,7 @@ jobs:
           setup_tests_quick_tests \
           setup_tests_simplex \
           setup_tests_vtk
-        ctest --output-on-failure -j2
+        ctest --output-on-failure -j2 -VV
 
   ############################
   # linux-debug-intel-oneapi #
@@ -207,7 +207,7 @@ jobs:
         make -j2 \
           setup_tests_examples \
           setup_tests_quick_tests
-        ctest --output-on-failure -j2
+        ctest --output-on-failure -j2 -VV
 
   #######################
   # linux-debug-cuda-11 #

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -63,10 +63,14 @@ jobs:
           setup_tests_quick_tests
         ctest --output-on-failure -j2
 
-  linux-debug-parallel-simplex:
-    # simple parallel debug build using g++ with simplex configuration enabled
+  ########################
+  # linux-debug-parallel #
+  ########################
 
-    name: linux debug parallel simplex
+  linux-debug-parallel:
+    # simple parallel debug build using g++
+
+    name: linux debug parallel
     runs-on: [ubuntu-22.04]
 
     # only run on 'push' or if the 'pull_request' is not a draft:
@@ -87,16 +91,16 @@ jobs:
         mkdir build
         cd build
         cmake -D CMAKE_BUILD_TYPE=Debug \
-              -D DEAL_II_CXX_FLAGS='-Werror -std=c++17' \
+              -D DEAL_II_CXX_FLAGS='-Werror -std=c++20' \
               -D DEAL_II_EARLY_DEPRECATIONS=ON \
-              -D DEAL_II_WITH_CGAL="ON" \
-              -D DEAL_II_WITH_MPI="ON" \
-              -D DEAL_II_WITH_TRILINOS="ON" \
-              -D DEAL_II_WITH_PETSC="ON" \
-              -D DEAL_II_WITH_METIS="ON" \
-              -D DEAL_II_WITH_HDF5="ON" \
-              -D DEAL_II_WITH_VTK="ON" \
               -D DEAL_II_COMPONENT_EXAMPLES="OFF" \
+              -D DEAL_II_WITH_MPI="ON" \
+              -D DEAL_II_WITH_CGAL="ON" \
+              -D DEAL_II_WITH_HDF5="ON" \
+              -D DEAL_II_WITH_METIS="ON" \
+              -D DEAL_II_WITH_PETSC="ON" \
+              -D DEAL_II_WITH_TRILINOS="ON" \
+              -D DEAL_II_WITH_VTK="ON" \
               ..
     - name: print detailed.log
       run: cat build/detailed.log
@@ -112,16 +116,12 @@ jobs:
         export OMPI_MCA_btl_base_warn_component_unused='0'
 
         cd build
-        make -j2 setup_tests_simplex setup_tests_vtk
+        make -j2 \
+          setup_tests_examples \
+          setup_tests_quick_tests \
+          setup_tests_simplex \
+          setup_tests_vtk
         ctest --output-on-failure -j2
-    - name: failed test log
-      if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
-      with:
-        name: test-log
-        path: |
-          build/tests/**/*output*
-          build/tests/**/*stdout*
 
 
   linux-debug-cuda-11:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,10 +39,13 @@ jobs:
     - uses: actions/checkout@v3
     - name: info
       run: |
+        python --version
         g++ -v
         cmake --version
     - name: configure deal.II
       run: |
+        # sanitize PYTHONPATH
+        unset PYTHONPATH
         mkdir build
         cd build
         cmake -D CMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -1,6 +1,7 @@
 name: github-OSX
 
 on:
+  push:
   pull_request:
     types:
     - opened

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -1,6 +1,7 @@
 name: tidy
 
 on:
+  push:
   pull_request:
     types:
     - opened

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,7 @@
 name: github-windows
 
 on:
+  push:
   pull_request:
     types:
     - opened

--- a/contrib/python-bindings/tests/cell_accessor_wrapper.py
+++ b/contrib/python-bindings/tests/cell_accessor_wrapper.py
@@ -14,7 +14,11 @@
 # ---------------------------------------------------------------------
 
 import unittest
-from PyDealII.Debug import *
+
+try:
+    from PyDealII.Debug import *
+except ImportError:
+    from PyDealII.Release import *
 
 class TestCellAccessorWrapper(unittest.TestCase):
 

--- a/contrib/python-bindings/tests/manifold_wrapper.py
+++ b/contrib/python-bindings/tests/manifold_wrapper.py
@@ -16,7 +16,11 @@
 import math
 import os
 import unittest
-from PyDealII.Debug import *
+
+try:
+    from PyDealII.Debug import *
+except ImportError:
+    from PyDealII.Release import *
 
 class TestManifoldWrapperShell(unittest.TestCase):
 

--- a/contrib/python-bindings/tests/mapping_wrapper.py
+++ b/contrib/python-bindings/tests/mapping_wrapper.py
@@ -14,7 +14,11 @@
 # ---------------------------------------------------------------------
 
 import unittest
-from PyDealII.Debug import *
+
+try:
+    from PyDealII.Debug import *
+except ImportError:
+    from PyDealII.Release import *
 
 class TestMappingWrapperCube(unittest.TestCase):
 

--- a/contrib/python-bindings/tests/point_wrapper.py
+++ b/contrib/python-bindings/tests/point_wrapper.py
@@ -15,7 +15,11 @@
 
 import unittest
 import math
-from PyDealII.Debug import *
+
+try:
+    from PyDealII.Debug import *
+except ImportError:
+    from PyDealII.Release import *
 
 
 class TestPointWrapper(unittest.TestCase):

--- a/contrib/python-bindings/tests/quadrature_wrapper.py
+++ b/contrib/python-bindings/tests/quadrature_wrapper.py
@@ -14,28 +14,32 @@
 # ---------------------------------------------------------------------
 
 import unittest
-from PyDealII.Debug import *
+
+try:
+    from PyDealII.Debug import *
+except ImportError:
+    from PyDealII.Release import *
 
 class TestQuadratureWrapper(unittest.TestCase):
 
     def test_gauss(self):
         quadrature = Quadrature(dim = 3)
         quadrature.create_gauss(n = 1);
-        
+
         w_sum = 0.
         for weight in quadrature.weights():
             w_sum += weight
-            
+
         self.assertTrue(abs(1. - w_sum) < 1e-10)
 
     def test_gauss_lobatto(self):
         quadrature = Quadrature(dim = 3)
         quadrature.create_gauss_lobatto(n = 2);
-        
+
         w_sum = 0.
         for weight in quadrature.weights():
             w_sum += weight
-            
+
         self.assertTrue(abs(1. - w_sum) < 1e-10)
 
 if __name__ == '__main__':

--- a/contrib/python-bindings/tests/triangulation_wrapper.py
+++ b/contrib/python-bindings/tests/triangulation_wrapper.py
@@ -14,7 +14,11 @@
 # ---------------------------------------------------------------------
 
 import unittest
-from PyDealII.Debug import *
+
+try:
+    from PyDealII.Debug import *
+except ImportError:
+    from PyDealII.Release import *
 
 class TestTriangulationWrapper(unittest.TestCase):
 

--- a/tests/quick_tests/adolc.cc
+++ b/tests/quick_tests/adolc.cc
@@ -64,6 +64,7 @@ main()
 
   deallog << "Error (function 1): " << error_func_1 << std::endl;
   deallog << "Error (function 2): " << error_func_2 << std::endl;
+  (void)tol;
   Assert(error_func_1 < tol, ExcMessage("Should be zero!"));
   Assert(error_func_2 < tol, ExcMessage("Should be zero!"));
 

--- a/tests/quick_tests/gmsh.cc
+++ b/tests/quick_tests/gmsh.cc
@@ -51,6 +51,7 @@ main()
 
   const int ierr = std::system(DEAL_II_GMSH_EXECUTABLE_PATH
                                " -2 file.geo 1>file.log 2>file_warn.log");
+  (void)ierr;
   Assert(ierr == 0, dealii::ExcInternalError());
 
   std::remove("file.geo");


### PR DESCRIPTION
 - bump all runners to Ubuntu 22.04. It's time.
 - unify output between linux runners, enable quick_tests and example tests