### PR TITLE
Tests: add forgotten namespace, fix typo in includes

### DIFF
--- a/tests/bits/q_points.cc
+++ b/tests/bits/q_points.cc
@@ -36,7 +36,7 @@
 
 #include "../tests.h"
 
-#include "../tests/test_grids.h"
+#include "../test_grids.h"
 
 void
 create_two_cubes(Triangulation<3> &coarse_grid)
@@ -69,7 +69,7 @@ create_two_cubes(Triangulation<3> &coarse_grid)
 
   // finally generate a triangulation
   // out of this
-  reorder_old_to_new_style(cells);
+  TestGrids::reorder_old_to_new_style(cells);
   GridTools::consistently_order_cells(cells);
   coarse_grid.create_triangulation(vertices, cells, SubCellData());
 }

--- a/tests/grid/grid_invert.cc
+++ b/tests/grid/grid_invert.cc
@@ -24,7 +24,7 @@
 
 #include "../tests.h"
 
-#include "../tests/test_grids.h"
+#include "../test_grids.h"
 
 template <int dim>
 void
@@ -58,7 +58,7 @@ test(bool second_case = false)
 
   SubCellData subcelldata;
 
-  reorder_old_to_new_style(cells);
+  TestGrids::reorder_old_to_new_style(cells);
   GridTools::invert_all_negative_measure_cells(vertices, cells);
 
   Triangulation<dim> tria;

--- a/tests/grid/mesh_3d.h
+++ b/tests/grid/mesh_3d.h
@@ -20,7 +20,7 @@
 
 #include "../tests.h"
 
-#include "../tests/test_grids.h"
+#include "../test_grids.h"
 
 // generate two cubes that are attached to each other in a way so that
 // the edges are all ok, but the normals of the common face don't
@@ -59,7 +59,7 @@ create_two_cubes(Triangulation<3> &coarse_grid)
   // finally generate a triangulation
   // out of this
   // if necessary, convert to new-style format
-  reorder_old_to_new_style(cells);
+  TestGrids::reorder_old_to_new_style(cells);
   GridTools::consistently_order_cells(cells);
   coarse_grid.create_triangulation(vertices, cells, SubCellData());
 }
@@ -158,7 +158,7 @@ create_L_shape(Triangulation<3> &coarse_grid)
 
   // finally generate a triangulation
   // out of this
-  reorder_old_to_new_style(cells);
+  TestGrids::reorder_old_to_new_style(cells);
   GridTools::consistently_order_cells(cells);
   coarse_grid.create_triangulation(vertices, cells, SubCellData());
 }

--- a/tests/grid/subcelldata.cc
+++ b/tests/grid/subcelldata.cc
@@ -22,7 +22,7 @@
 
 #include "../tests.h"
 
-#include "../tests/test_grids.h"
+#include "../test_grids.h"
 
 
 static unsigned subcells[6][4] = {{0, 1, 2, 3},
@@ -94,7 +94,7 @@ test()
         }
     }
 
-  reorder_old_to_new_style(cells);
+  TestGrids::reorder_old_to_new_style(cells);
   Triangulation<dim> tria;
   tria.create_triangulation(vertices, cells, subcelldata);
 

--- a/tests/lac/constraints.cc
+++ b/tests/lac/constraints.cc
@@ -36,7 +36,7 @@
 
 #include "../tests.h"
 
-#include "../tests/test_grids.h"
+#include "../test_grids.h"
 
 
 
@@ -74,7 +74,7 @@ make_tria(Triangulation<3> &tria, int step)
           cells[0].material_id = 0;
           cells[1].material_id = 0;
 
-          reorder_old_to_new_style(cells);
+          TestGrids::reorder_old_to_new_style(cells);
           tria.create_triangulation(std::vector<Point<3>>(&vertices[0],
                                                           &vertices[12]),
                                     cells,
@@ -118,7 +118,7 @@ make_tria(Triangulation<3> &tria, int step)
           cells[0].material_id = 0;
           cells[1].material_id = 0;
 
-          reorder_old_to_new_style(cells);
+          TestGrids::reorder_old_to_new_style(cells);
           tria.create_triangulation(std::vector<Point<3>>(&vertices[0],
                                                           &vertices[12]),
                                     cells,
@@ -162,7 +162,7 @@ make_tria(Triangulation<3> &tria, int step)
           cells[0].material_id = 0;
           cells[1].material_id = 0;
 
-          reorder_old_to_new_style(cells);
+          TestGrids::reorder_old_to_new_style(cells);
           tria.create_triangulation(std::vector<Point<3>>(&vertices[0],
                                                           &vertices[12]),
                                     cells,
@@ -220,7 +220,7 @@ make_tria(Triangulation<3> &tria, int step)
           cells[2].material_id = 0;
           cells[3].material_id = 0;
 
-          reorder_old_to_new_style(cells);
+          TestGrids::reorder_old_to_new_style(cells);
           tria.create_triangulation(std::vector<Point<3>>(&vertices[0],
                                                           &vertices[18]),
                                     cells,


### PR DESCRIPTION
This removes the majority of the currently failing tests due to the removal
of our legacy reordering routines.

In reference to 0096280440b5ec48af25f810d0c405a94aa4703f