### PR TITLE
Tests: grid/mesh_3d.h: add forgotten GridTests::reorder* call

### DIFF
--- a/tests/grid/mesh_3d.h
+++ b/tests/grid/mesh_3d.h
@@ -108,6 +108,7 @@ create_two_cubes_rotation(Triangulation<3> & coarse_grid,
     }
   // finally generate a triangulation
   // out of this
+  TestGrids::reorder_old_to_new_style(cells);
   coarse_grid.create_triangulation(vertices, cells, SubCellData());
 }
 


### PR DESCRIPTION
In reference to #15654 

This is the remaining fix necessary to get Jenkins running again.