### PR TITLE
Fix step-46 tutorial program

### DIFF
--- a/examples/step-46/step-46.cc
+++ b/examples/step-46/step-46.cc
@@ -220,12 +220,12 @@ namespace Step46
     : stokes_degree(stokes_degree)
     , elasticity_degree(elasticity_degree)
     , triangulation(Triangulation<dim>::maximum_smoothing)
-    , stokes_fe(FE_Q<dim>(stokes_degree + 1) ^ dim, // for the fluid velocity
-                FE_Q<dim>(stokes_degree),           // for the fluid pressure
-                FE_Nothing<dim>() ^ dim)          // for the solid displacement
-    , elasticity_fe(FE_Nothing<dim>() ^ dim,      // for the fluid velocity
-                    FE_Nothing<dim>(),            // for the fluid pressure
-                    FE_Q<dim>(elasticity_degree)) // for the solid displacement
+    , stokes_fe(FE_Q<dim>(stokes_degree + 1) ^ dim,     // fluid velocity
+                FE_Q<dim>(stokes_degree),               // fluid pressure
+                FE_Nothing<dim>() ^ dim)                // solid displacement
+    , elasticity_fe(FE_Nothing<dim>() ^ dim,            // fluid velocity
+                    FE_Nothing<dim>(),                  // fluid pressure
+                    FE_Q<dim>(elasticity_degree) ^ dim) // solid displacement
     , dof_handler(triangulation)
     , viscosity(2)
     , lambda(1)


### PR DESCRIPTION
#11066 has introduced a bug in the step-46 tutorial program, leading to 
```
--------------------------------------------------------
An error occurred in line <74> of file </home/kronbichler/deal/deal.II/source/hp/fe_collection.cc> in function
    void dealii::hp::FECollection<2>::push_back(const FiniteElement<dim, spacedim> &) [dim = 2, spacedim = 2]
The violated condition was: 
    this->size() == 0 || new_fe.n_components() == this->operator[](0).n_components()
Additional information: 
    All elements inside a collection need to have the same number of
    vector components!
```

To add the missing `^ dim` field without causing a line break, I shortened "for the fluid velocity" to "fluid velocity" and similarly, which I find visually most pleasing. Feel free to suggest different forms in case of disagreement.