### PR TITLE
Add missing include path for `ReadVector`

### DIFF
--- a/include/deal.II/numerics/error_estimator.h
+++ b/include/deal.II/numerics/error_estimator.h
@@ -24,6 +24,8 @@
 
 #include <deal.II/fe/component_mask.h>
 
+#include <deal.II/lac/read_vector.h>
+
 #include <map>
 
 DEAL_II_NAMESPACE_OPEN


### PR DESCRIPTION
Compilation of our user code is currently failing due to a missing reference to `ReadVector` triggered by calling the `KellyErrorEstimator`. I was able to fix it by adding the include path of the corresponding header file.

Probably related to https://github.com/dealii/dealii/pull/15197.