### PR TITLE
Fix some comparisons operator for g++-13 with C++20

### DIFF
--- a/include/deal.II/base/linear_index_iterator.h
+++ b/include/deal.II/base/linear_index_iterator.h
@@ -254,25 +254,23 @@ public:
    * the same entry in the same container.
    */
   template <typename OtherIterator>
-  friend std::enable_if_t<
-    std::is_convertible<OtherIterator, DerivedIterator>::value,
-    bool>
-  operator==(const LinearIndexIterator &left, const OtherIterator &right)
+  std::enable_if_t<std::is_convertible<OtherIterator, DerivedIterator>::value,
+                   bool>
+  operator==(const OtherIterator &right) const
   {
     const auto &right_2 = static_cast<const DerivedIterator &>(right);
-    return left.accessor == right_2.accessor;
+    return this->accessor == right_2.accessor;
   }
 
   /**
    * Opposite of operator==().
    */
   template <typename OtherIterator>
-  friend std::enable_if_t<
-    std::is_convertible<OtherIterator, DerivedIterator>::value,
-    bool>
-  operator!=(const LinearIndexIterator &left, const OtherIterator &right)
+  std::enable_if_t<std::is_convertible<OtherIterator, DerivedIterator>::value,
+                   bool>
+  operator!=(const OtherIterator &right) const
   {
-    return !(left == right);
+    return !(*this == right);
   }
 
   /**


### PR DESCRIPTION
Fixes the warnings in https://cdash.dealii.org/viewBuildError.php?type=1&buildid=836.