### PR TITLE
Add a missing typedef to the epetra vector wrapper.

### DIFF
--- a/include/deal.II/lac/trilinos_epetra_vector.h
+++ b/include/deal.II/lac/trilinos_epetra_vector.h
@@ -65,6 +65,7 @@ namespace LinearAlgebra
     public:
       using value_type = double;
       using size_type  = types::global_dof_index;
+      using real_type  = double;
 
       /**
        * Constructor. Create a vector of dimension zero.


### PR DESCRIPTION
Fixes #15663.

We need this to satisfy the vector space vector concept.

 Excellent work @tamiko: working on these is extremely easy with the provided links.