### PR TITLE
Remove reference to VectorSpacevector from the documentation.

### DIFF
--- a/include/deal.II/lac/trilinos_epetra_communication_pattern.h
+++ b/include/deal.II/lac/trilinos_epetra_communication_pattern.h
@@ -42,14 +42,20 @@ namespace LinearAlgebra
     {
     public:
       /**
-       * Initialize the communication pattern. The first argument @p
-       * vector_space_vector_index_set is the index set associated to a
-       * VectorSpaceVector object. The second argument @p
-       * read_write_vector_index_set is the index set associated to a
-       * ReadWriteVector object.
+       * Initialize the communication pattern.
+       *
+       * @param[in] locally_owned_indices The set of indices of elements
+       *   in the array mentioned in the class documentation that are
+       *   stored on the current process.
+       * @param[in] ghost_indices The set of indices of elements in the
+       *   array mentioned in the class documentation that the current
+       *   process will need to be able to import.
+       * @param[in] communicator The MPI communicator used to describe the
+       *   entire set of processes that participate in the storage and
+       *   access to elements of the array.
        */
-      CommunicationPattern(const IndexSet &vector_space_vector_index_set,
-                           const IndexSet &read_write_vector_index_set,
+      CommunicationPattern(const IndexSet &locally_owned_indices,
+                           const IndexSet &ghost_indices,
                            const MPI_Comm  communicator);
 
       /**

--- a/include/deal.II/lac/trilinos_tpetra_communication_pattern.h
+++ b/include/deal.II/lac/trilinos_tpetra_communication_pattern.h
@@ -41,14 +41,20 @@ namespace LinearAlgebra
     {
     public:
       /**
-       * Reinitialize the communication pattern. The first argument @p
-       * vector_space_vector_index_set is the index set associated to a
-       * VectorSpaceVector object. The second argument @p
-       * read_write_vector_index_set is the index set associated to a
-       * ReadWriteVector object.
+       * Initialize the communication pattern.
+       *
+       * @param[in] locally_owned_indices The set of indices of elements
+       *   in the array mentioned in the class documentation that are
+       *   stored on the current process.
+       * @param[in] ghost_indices The set of indices of elements in the
+       *   array mentioned in the class documentation that the current
+       *   process will need to be able to import.
+       * @param[in] communicator The MPI communicator used to describe the
+       *   entire set of processes that participate in the storage and
+       *   access to elements of the array.
        */
-      CommunicationPattern(const IndexSet &vector_space_vector_index_set,
-                           const IndexSet &read_write_vector_index_set,
+      CommunicationPattern(const IndexSet &locally_owned_indices,
+                           const IndexSet &ghost_indices,
                            const MPI_Comm  communicator);
 
       /**

--- a/source/lac/trilinos_epetra_communication_pattern.cc
+++ b/source/lac/trilinos_epetra_communication_pattern.cc
@@ -30,15 +30,15 @@ namespace LinearAlgebra
   namespace EpetraWrappers
   {
     CommunicationPattern::CommunicationPattern(
-      const IndexSet &vector_space_vector_index_set,
-      const IndexSet &read_write_vector_index_set,
+      const IndexSet &locally_owned_indices,
+      const IndexSet &ghost_indices,
       const MPI_Comm  communicator)
     {
       // virtual functions called in constructors and destructors never use the
       // override in a derived class
       // for clarity be explicit on which function is called
-      CommunicationPattern::reinit(vector_space_vector_index_set,
-                                   read_write_vector_index_set,
+      CommunicationPattern::reinit(locally_owned_indices,
+                                   ghost_indices,
                                    communicator);
     }
 

--- a/source/lac/trilinos_tpetra_communication_pattern.cc
+++ b/source/lac/trilinos_tpetra_communication_pattern.cc
@@ -30,15 +30,15 @@ namespace LinearAlgebra
   namespace TpetraWrappers
   {
     CommunicationPattern::CommunicationPattern(
-      const IndexSet &vector_space_vector_index_set,
-      const IndexSet &read_write_vector_index_set,
+      const IndexSet &locally_owned_indices,
+      const IndexSet &ghost_indices,
       const MPI_Comm  communicator)
     {
       // virtual functions called in constructors and destructors never use the
       // override in a derived class
       // for clarity be explicit on which function is called
-      CommunicationPattern::reinit(vector_space_vector_index_set,
-                                   read_write_vector_index_set,
+      CommunicationPattern::reinit(locally_owned_indices,
+                                   ghost_indices,
                                    communicator);
     }
 


### PR DESCRIPTION
While there, rename some function arguments to match their real intent. The new names match those in the reinit() functions right below.

More work for #3073.