### PR TITLE
Introduce DEAL_II[_DEPRECATED_EARLY]_WITH_COMMENT

### DIFF
--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -26,8 +26,6 @@
 #   DEAL_II_HAVE_CXX17_BESSEL_FUNCTIONS
 #   DEAL_II_HAVE_CXX17_LEGENDRE_FUNCTIONS
 #   DEAL_II_FALLTHROUGH
-#   DEAL_II_DEPRECATED
-#   DEAL_II_DEPRECATED_EARLY
 #   DEAL_II_CONSTEXPR
 #
 
@@ -376,8 +374,6 @@ unset_if_changed(CHECK_CXX_FEATURES_FLAGS_SAVED
   "${CMAKE_REQUIRED_FLAGS}${CMAKE_CXX_STANDARD}"
   DEAL_II_HAVE_FP_EXCEPTIONS
   DEAL_II_HAVE_COMPLEX_OPERATOR_OVERLOADS
-  DEAL_II_HAVE_CXX17_ATTRIBUTE_DEPRECATED
-  DEAL_II_HAVE_ATTRIBUTE_DEPRECATED
   DEAL_II_HAVE_CXX17_ATTRIBUTE_FALLTHROUGH
   DEAL_II_HAVE_ATTRIBUTE_FALLTHROUGH
   DEAL_II_HAVE_CXX17_BESSEL_FUNCTIONS
@@ -447,79 +443,6 @@ CHECK_CXX_SOURCE_COMPILES(
   }
   "
   DEAL_II_HAVE_COMPLEX_OPERATOR_OVERLOADS)
-
-
-#
-# Even though [[deprecated]] is a C++14 feature we have to check
-# whether we can actually use the [[deprecated]] attribute in all
-# cases we care about; some of the following are C++17 features.
-#
-CHECK_CXX_SOURCE_COMPILES(
-  "
-  [[deprecated]] int old_fn ();
-  int old_fn () { return 0; }
-
-  struct [[deprecated]] bob
-  {
-    [[deprecated]] bob(int i);
-    [[deprecated]] void test();
-  };
-
-  enum color
-  {
-    red [[deprecated]]
-  };
-
-  template <int dim>
-  struct foo {};
-  using bar [[deprecated]] = foo<2>;
-
-  int main () {}
-  "
-  DEAL_II_HAVE_CXX17_ATTRIBUTE_DEPRECATED
-  )
-
-#
-# Also test the corresponding GCC extension
-#
-CHECK_CXX_SOURCE_COMPILES(
-  "
-  __attribute__((deprecated)) int old_fn ();
-  int old_fn () { return 0; }
-
-  struct __attribute__((deprecated)) bob
-  {
-    __attribute__((deprecated)) bob(int i);
-    __attribute__((deprecated)) void test();
-  };
-
-  enum color
-  {
-    red __attribute__((deprecated))
-  };
-
-  template <int dim>
-  struct foo {};
-  using bar __attribute__((deprecated)) = foo<2>;
-
-  int main () {}
-  "
-  DEAL_II_HAVE_ATTRIBUTE_DEPRECATED
-  )
-
-if(DEAL_II_HAVE_CXX17_ATTRIBUTE_DEPRECATED)
-  set(DEAL_II_DEPRECATED "[[deprecated]]")
-elseif(DEAL_II_HAVE_ATTRIBUTE_DEPRECATED AND NOT DEAL_II_WITH_CUDA)
-  set(DEAL_II_DEPRECATED "__attribute__((deprecated))")
-else()
-  set(DEAL_II_DEPRECATED " ")
-endif()
-if(DEAL_II_EARLY_DEPRECATIONS)
-  set(DEAL_II_DEPRECATED_EARLY ${DEAL_II_DEPRECATED})
-else()
-  set(DEAL_II_DEPRECATED_EARLY " ")
-endif()
-
 
 #
 # Try to enable a fallthrough attribute. This is a language feature in C++17,

--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -191,6 +191,7 @@ PREDEFINED             = DOXYGEN=1 \
                          DEAL_II_ADOLC_WITH_ATRIG_ERF=1 \
                          DEAL_II_ADOLC_WITH_TAPELESS_REFCOUNTING=1 \
                          DEAL_II_DEPRECATED_EARLY= \
+                         DEAL_II_DEPRECATED_EARLY_WITH_COMMENT(x)= \
                          DEAL_II_WITH_ARBORX=1 \
                          DEAL_II_ARBORX_WITH_MPI=1 \
                          DEAL_II_WITH_ARPACK=1 \

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -172,7 +172,8 @@
  * Macro indicating that the current feature will be removed in a future
  * release.
  */
-#cmakedefine DEAL_II_DEPRECATED @DEAL_II_DEPRECATED@
+#define DEAL_II_DEPRECATED [[deprecated]]
+#define DEAL_II_DEPRECATED_WITH_COMMENT(comment) [[deprecated(comment)]]
 
 /**
  * Same as above, but for things that have been deprecated during the current
@@ -180,10 +181,25 @@
  * deprecated prior to a release until <em>after</em> that release has been
  * finalized - see DEAL_II_EARLY_DEPRECATIONS for more information.
  */
+#cmakedefine DEAL_II_EARLY_DEPRECATIONS
 #ifndef DEAL_II_DEPRECATED_EARLY
 // guard to allow user to override DEAL_II_DEPRECATED_EARLY
-#cmakedefine DEAL_II_DEPRECATED_EARLY @DEAL_II_DEPRECATED_EARLY@
+#ifdef DEAL_II_EARLY_DEPRECATIONS
+#define DEAL_II_DEPRECATED_EARLY [[deprecated]]
+#else
+#define DEAL_II_DEPRECATED_EARLY
 #endif
+#endif
+
+#ifndef DEAL_II_DEPRECATED_EARLY_WITH_COMMENT
+// guard to allow user to override DEAL_II_DEPRECATED_EARLY
+#ifdef DEAL_II_EARLY_DEPRECATIONS
+#define DEAL_II_DEPRECATED_EARLY_WITH_COMMENT(comment) [[deprecated(comment)]]
+#else
+#define DEAL_II_DEPRECATED_EARLY_WITH_COMMENT(comment)
+#endif
+#endif
+
 #cmakedefine DEAL_II_FALLTHROUGH @DEAL_II_FALLTHROUGH@
 #cmakedefine DEAL_II_CONSTEXPR @DEAL_II_CONSTEXPR@
 

--- a/include/deal.II/fe/block_mask.h
+++ b/include/deal.II/fe/block_mask.h
@@ -81,6 +81,14 @@ public:
   BlockMask() = default;
 
   /**
+   * Deprecated constructor allowing implicit conversion.
+   */
+  template <typename = void>
+  DEAL_II_DEPRECATED_EARLY_WITH_COMMENT(
+    "Implicit conversions from std::vector<bool> to BlockMask are deprecated!")
+  BlockMask(const std::vector<bool> &block_mask);
+
+  /**
    * Initialize an object of this type with a set of selected blocks specified
    * by the argument.
    *
@@ -237,6 +245,12 @@ operator<<(std::ostream &out, const BlockMask &mask);
 
 #ifndef DOXYGEN
 // -------------------- inline functions ---------------------
+
+template <typename>
+inline BlockMask::BlockMask(const std::vector<bool> &block_mask)
+  : block_mask(block_mask)
+{}
+
 
 inline BlockMask::BlockMask(const std::vector<bool> &block_mask)
   : block_mask(block_mask)

--- a/include/deal.II/fe/component_mask.h
+++ b/include/deal.II/fe/component_mask.h
@@ -90,6 +90,14 @@ public:
   ComponentMask() = default;
 
   /**
+   * Deprecated constructor allowing implicit conversion.
+   */
+  template <typename = void>
+  DEAL_II_DEPRECATED_EARLY_WITH_COMMENT(
+    "Implicit conversions from std::vector<bool> to ComponentMask are deprecated!")
+  ComponentMask(const std::vector<bool> &block_mask);
+
+  /**
    * Initialize an object of this type with a set of selected components
    * specified by the argument.
    *
@@ -258,6 +266,12 @@ operator<<(std::ostream &out, const ComponentMask &mask);
 
 #ifndef DOXYGEN
 // -------------------- inline functions ---------------------
+
+template <typename>
+inline ComponentMask::ComponentMask(const std::vector<bool> &component_mask)
+  : component_mask(component_mask)
+{}
+
 
 inline ComponentMask::ComponentMask(const std::vector<bool> &component_mask)
   : component_mask(component_mask)


### PR DESCRIPTION
#15401 made the constructors for `ComponentMask` and `BlockMask` taking a `std::vector` `explicit`. This pull request adds deprecated constructors that only deprecated the implicit conversion.
This pull request also cleans up the detection for `[[deprecated]]` and introduces `DEAL_II_DEPRECATED_WITH_COMMENT` and `DEAL_II_DEPREACTED_EARLY_WITH_COMMENT` that allows providing a (better) deprecation message.