### PR TITLE
matrix_free/fe_evaluation.h: avoid a warning with g++-13

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -3917,7 +3917,11 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
     }
 
   std::array<unsigned int, n_lanes> dof_indices;
+  std::fill(dof_indices.begin(),
+            dof_indices.end(),
+            numbers::invalid_unsigned_int);
 
+  Assert(n_filled_lanes <= n_lanes, ExcInternalError());
   for (unsigned int v = 0; v < n_filled_lanes; ++v)
     {
       Assert(mask[v] == false || cells[v] != numbers::invalid_unsigned_int,
@@ -3932,9 +3936,6 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
       else
         dof_indices[v] = numbers::invalid_unsigned_int;
     }
-
-  for (unsigned int v = n_filled_lanes; v < n_lanes; ++v)
-    dof_indices[v] = numbers::invalid_unsigned_int;
 
   // In the case with contiguous cell indices, we know that there are no
   // constraints and that the indices within each element are contiguous

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -3933,8 +3933,6 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
               ->component_dof_indices_offset[this->active_fe_index]
                                             [this->first_selected_component] *
             dof_info.dof_indices_interleave_strides[ind][cells[v]];
-      else
-        dof_indices[v] = numbers::invalid_unsigned_int;
     }
 
   // In the case with contiguous cell indices, we know that there are no


### PR DESCRIPTION
g++-13 is a bit too eager to warn about an array bounds violation here after its optimizer pass introduced a `__builtin_memset()`:
```
In file included from include/deal.II/matrix_free/operators.h:30,
                 from include/deal.II/numerics/vector_tools_project.templates.h:36,
                 from source/numerics/vector_tools_project_qpmf.cc:17:
                 In member function ‘void dealii::FEEvaluationBase<...>:
                 inlined from ‘void dealii::FEEvaluationBase<...>:
include/deal.II/matrix_free/fe_evaluation.h:3937:20: warning: ‘void* __builtin_memset(void*, int, long unsigned int)’ offset [20, 1020] is out of the bounds [0, 16] of object ‘dof_indices’ with type ‘std::array<unsigned int, 4>’ [-Warray-bounds=]
 3937 |     dof_indices[v] = numbers::invalid_unsigned_int;
      |     ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
which is a bit silly as the statement reads:
```
// implied Assert(n_filled_lanes <= n_lanes, ExcInternalError());
for (unsigned int v = n_filled_lanes; v < n_lanes; ++v)
  dof_indices[v] = numbers::invalid_unsigned_int;
```
So instead let's simply initialize all elements of `dof_indices` to `numbers::invalid_unsigned_int` via `std::fill` instead. I doubt that this has much performance influence in practice as it gets replaced by a `__builtin_memset()` right away.

This was probably "introduced" due to the refactoring in #15635

*ping* @kronbichler @bergbauer