### PR TITLE
documentation: switch all hyperlinks in the documentation to https://

### DIFF
--- a/doc/developers/cmake-internals.html
+++ b/doc/developers/cmake-internals.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	  "http://www.w3.org/TR/html4/loose.dtd">
+	  "https://www.w3.org/TR/html4/loose.dtd">
 <html>
   <head>
     <title>Build system internals</title>
@@ -746,10 +746,10 @@ expand_instantiations(obj_dofs "${_inst}")
 
 <hr />
 <div class="right">
-  <a href="http://validator.w3.org/check?uri=referer" target="_top">
-    <img style="border:0" src="http://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
-  <a href="http://jigsaw.w3.org/css-validator/check/referer" target="_top">
-    <img style="border:0;width:88px;height:31px" src="http://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
+  <a href="https://validator.w3.org/check?uri=referer" target="_top">
+    <img style="border:0" src="https://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
+  <a href="https://jigsaw.w3.org/css-validator/check/referer" target="_top">
+    <img style="border:0;width:88px;height:31px" src="https://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
 </div>
 
 </body>

--- a/doc/developers/packaging.html
+++ b/doc/developers/packaging.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	  "http://www.w3.org/TR/html4/loose.dtd">
+	  "https://www.w3.org/TR/html4/loose.dtd">
 <html>
   <head>
     <title>Packaging deal.II</title>
@@ -99,9 +99,9 @@
 
 <hr />
 <div class="right">
-  <a href="http://validator.w3.org/check?uri=referer" target="_top">
-    <img style="border:0" src="http://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
-  <a href="http://jigsaw.w3.org/css-validator/check/referer" target="_top">
-    <img style="border:0;width:88px;height:31px" src="http://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
+  <a href="https://validator.w3.org/check?uri=referer" target="_top">
+    <img style="border:0" src="https://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
+  <a href="https://jigsaw.w3.org/css-validator/check/referer" target="_top">
+    <img style="border:0;width:88px;height:31px" src="https://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
   </body>
 </html>

--- a/doc/developers/porting.html
+++ b/doc/developers/porting.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	  "http://www.w3.org/TR/html4/loose.dtd">
+	  "https://www.w3.org/TR/html4/loose.dtd">
 <html>
   <head>
     <title>Porting deal.II</title>
@@ -15,7 +15,7 @@
 
     <p>
       <acronym>deal.II</acronym> uses very few
-      <a href="http://www.opengroup.org/austin/">POSIX</a> specific system
+      <a href="https://www.opengroup.org/austin/">POSIX</a> specific system
       features and is otherwise fairly ISO (2011) C++ Standard compliant.
 
       Consequently, there is a good chance that <acronym>deal.II</acronym>
@@ -29,9 +29,9 @@
     <p>
       Currently, the <acronym>deal.II</acronym> CMake build system
       recognizes
-      <a href="http://gcc.gnu.org/">gcc</a>,
-      <a href="http://clang.llvm.org/">clang</a>, as well as
-      <a href="http://software.intel.com/en-us/intel-compilers">icc</a>, and
+      <a href="https://gcc.gnu.org/">gcc</a>,
+      <a href="https://clang.llvm.org/">clang</a>, as well as
+      <a href="https://software.intel.com/en-us/intel-compilers">icc</a>, and
       sets up reasonable default compiler flags.
       <ul>
         <li>
@@ -54,7 +54,7 @@ cmake/setup_compiler_flags.cmake
 cmake/setup_compiler_flags_gnu.cmake
 cmake/setup_compiler_flags_icc.cmake
 </pre>
-          Patches are highly welcome! See <a href="http://www.dealii.org/participate.html">here</a>
+          Patches are highly welcome! See <a href="https://www.dealii.org/participate.html">here</a>
           for information on how to get in contact with us.
         <li>
           You might want to have a look at
@@ -72,26 +72,26 @@ include/deal.II/base/config.h.in
 
     <p>
       <acronym>deal.II</acronym> should support almost all reasonably
-      <a href="http://www.opengroup.org/austin/">POSIX</a> compliant
+      <a href="https://www.opengroup.org/austin/">POSIX</a> compliant
       platforms out of the box. Nevertheless, the following bits of
       information might help:
       <ul>
         <li>
           The build system of <acronym>deal.II</acronym> uses <a
-          href="http://www.cmake.org/" target="_top">CMake</a>.  So,
+          href="https://www.cmake.org/" target="_top">CMake</a>.  So,
           in order to port <acronym>deal.II</acronym> to a new platform,
-          it is obviously necessary that <a href="http://www.cmake.org/"
+          it is obviously necessary that <a href="https://www.cmake.org/"
           target="_top">CMake</a> supports the platform in question
           with at least one generator for a native build tool, see <a
-          href="http://www.cmake.org/cmake/help/documentation.html">here</a>.
+          href="https://www.cmake.org/cmake/help/documentation.html">here</a>.
         <li>
           <acronym>deal.II</acronym> is mainly developed with <a
-          href="http://gcc.gnu.org/">gcc</a> on GNU/Linux, so it is
+          href="https://gcc.gnu.org/">gcc</a> on GNU/Linux, so it is
           best to begin porting to a new platform with the help of <a
-          href="http://gcc.gnu.org/">gcc</a>.
+          href="https://gcc.gnu.org/">gcc</a>.
           After that a platform specific compiler might be tried.
         <li>
-          Almost all <a href="http://www.opengroup.org/austin/">POSIX</a>
+          Almost all <a href="https://www.opengroup.org/austin/">POSIX</a>
           specific code is well guarded with fall-back code in case the
           specific POSIX function is not available. There is (currently)
           one exception, though: Routines that measure elapsed CPU time in

--- a/doc/developers/testsuite.html
+++ b/doc/developers/testsuite.html
@@ -965,10 +965,10 @@ $ ctest -DCONFIG_FILE="[...]/config.sample" [...]
 
     <hr />
     <div class="right">
-      <a href="http://validator.w3.org/check?uri=referer" target="_top">
-        <img style="border:0" src="http://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
-      <a href="http://jigsaw.w3.org/css-validator/check/referer" target="_top">
-        <img style="border:0;width:88px;height:31px" src="http://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
+      <a href="https://validator.w3.org/check?uri=referer" target="_top">
+        <img style="border:0" src="https://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
+      <a href="https://jigsaw.w3.org/css-validator/check/referer" target="_top">
+        <img style="border:0;width:88px;height:31px" src="https://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
     </div>
 
   </body>

--- a/doc/developers/writing-documentation.html
+++ b/doc/developers/writing-documentation.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-                 "http://www.w3.org/TR/html4/loose.dtd">
+                 "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
   <meta http-equiv="Content-type" content="text/html;charset=UTF-8">
@@ -57,10 +57,10 @@
     <p>
     In order to extract documentation from the header files of the
     project, we use
-    <a href="http://www.doxygen.org/" target="_top">doxygen</a>.
+    <a href="https://www.doxygen.org/" target="_top">doxygen</a>.
     It requires that documentation is written in a form which
     closely follows the
-    <a href="http://java.sun.com/products/jdk/javadoc/index.html" target="_top">
+    <a href="https://java.sun.com/products/jdk/javadoc/index.html" target="_top">
     JavaDoc</a> standard.
     </p>
 
@@ -108,7 +108,7 @@ class TestClass
     In order to allow better structured output for long comments,
     doxygen supports a great number of tags for enumerations,
     sectioning, markup, and other fields. We encourage you to take a
-    look at the <a href="http://www.doxygen.org/"
+    look at the <a href="https://www.doxygen.org/"
     target="_top">doxygen webpage</a> to get an overview. However,
     here is a brief summary of the most often used features:
     </p>
@@ -183,7 +183,7 @@ void foobar ()
          <tt>function_name()</tt> to reference member functions and
          <tt>#variable_name</tt> for member variables to create links
          automatically. Refer to the documentation of <a
-         href="http:www.doxygen.org"><acronym>doxygen</acronym></a> to
+         href="https://www.doxygen.org"><acronym>doxygen</acronym></a> to
          get even more options for global variables.
          </p>
 
@@ -451,10 +451,10 @@ void foobar ()
 
     <hr />
     <div class="right">
-      <a href="http://validator.w3.org/check?uri=referer" target="_top">
-        <img style="border:0" src="http://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
-      <a href="http://jigsaw.w3.org/css-validator/check/referer" target="_top">
-        <img style="border:0;width:88px;height:31px" src="http://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
+      <a href="https://validator.w3.org/check?uri=referer" target="_top">
+        <img style="border:0" src="https://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
+      <a href="https://jigsaw.w3.org/css-validator/check/referer" target="_top">
+        <img style="border:0;width:88px;height:31px" src="https://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
     </div>
 
   </body>

--- a/doc/doxygen/DoxygenLayout.xml
+++ b/doc/doxygen/DoxygenLayout.xml
@@ -22,7 +22,7 @@
       <tab type="globals" visible="yes" title="" intro=""/>
     </tab>
     <tab type="examples" visible="yes" title="" intro=""/>  
-    <tab type="user" visible="yes" title="dealii.org" url="http://www.dealii.org/" />
+    <tab type="user" visible="yes" title="dealii.org" url="https://www.dealii.org/" />
   </navindex>
 
   <!-- Layout definition for a class page -->

--- a/doc/doxygen/code-gallery/code-gallery.h.in
+++ b/doc/doxygen/code-gallery/code-gallery.h.in
@@ -24,7 +24,7 @@
  * implemented with deal.II, but without the requirement to have these code
  * documented at the same, extensive level as used in the tutorial.
  * Instructions for obtaining the code gallery programs can be found at
- * http://dealii.org/code-gallery.html .
+ * https://dealii.org/code-gallery.html .
  *
  * @warning The programs that form part of the code gallery are contributed by
  *   others and are not part of deal.II itself. The deal.II authors make

--- a/doc/doxygen/code-gallery/no-code-gallery.h
+++ b/doc/doxygen/code-gallery/no-code-gallery.h
@@ -23,5 +23,5 @@
  * such copy was found when configuring your version of deal.II.
  *
  * Instructions for obtaining the code gallery can be found at
- * http://dealii.org/code-gallery.html .
+ * https://dealii.org/code-gallery.html .
  */

--- a/doc/doxygen/headers/c++.h
+++ b/doc/doxygen/headers/c++.h
@@ -18,12 +18,12 @@
  * @defgroup CPP11 deal.II and Modern C++ standards
  *
  * Since version 9.6, deal.II requires a compiler that supports at least
- * <a href="http://en.wikipedia.org/wiki/C%2B%2B17">C++17</a>. Large parts
+ * <a href="https://en.wikipedia.org/wiki/C%2B%2B17">C++17</a>. Large parts
  * of the library now depend on modern language constructs which are
  * documented here.
  *
  * One example is support for C++11
- * <a href="http://en.wikipedia.org/wiki/C++11#Range-based_for_loop">range-based
+ * <a href="https://en.wikipedia.org/wiki/C++11#Range-based_for_loop">range-based
  * for loops</a>. deal.II-based codes often have many loops of the kind
  * @code
  *   Triangulation<dim> triangulation;

--- a/doc/doxygen/headers/coding_conventions.h
+++ b/doc/doxygen/headers/coding_conventions.h
@@ -155,7 +155,7 @@ See deal.II's wiki on github: <a href="https://github.com/dealii/dealii/wiki/Ind
 
 <li> Classes, namespaces and types generally are named using uppercase letters
   to denote word beginnings (e.g. TriaIterator) &mdash; sometimes called
-  <a href="http://en.wikipedia.org/wiki/Camel_case"><i>camel
+  <a href="https://en.wikipedia.org/wiki/Camel_case"><i>camel
   case</i></a> &mdash; while functions and variables
   use lowercase letters and underscores to separate words.
   The only exception are the iterator alias in Triangulation

--- a/doc/doxygen/headers/distributed.h
+++ b/doc/doxygen/headers/distributed.h
@@ -134,7 +134,7 @@
  * areas, disregarding the blue areas.
  *
  * @note The decomposition of this "real" mesh into the pieces stored
- *   by each processes is provided by the <a href="http://www.p4est.org">p4est</a>
+ *   by each processes is provided by the <a href="https://www.p4est.org">p4est</a>
  *   library. p4est stores the complete mesh in a distributed data structure
  *   called a parallel forest (thus the name). A parallel forest consists of
  *   quad-trees (in 2d) or oct-trees (in 3d) originating in each
@@ -157,7 +157,7 @@
  *   proven that each subdomain consists of at most two disconnected
  *   pieces; see C. Burstedde, J. Holke, T. Isaac: "Bounds on the number of
  *   discontinuities of Morton-type space-filling curves",
- *   <a href="http://arxiv.org/abs/1505.05055">arXiv 1505.05055</a>,
+ *   <a href="https://arxiv.org/abs/1505.05055">arXiv 1505.05055</a>,
  *   2017.)
  *
  *

--- a/doc/doxygen/headers/exceptions.h
+++ b/doc/doxygen/headers/exceptions.h
@@ -250,7 +250,7 @@
  *  happened: exceptions that can be triggered by <tt>throw</tt> statements
  *  and captured by <tt>catch</tt> clauses, see for example
  *  https://en.wikipedia.org/wiki/C%2B%2B#Exception_handling and
- *  http://www.cplusplus.com/doc/tutorial/exceptions/ .
+ *  https://www.cplusplus.com/doc/tutorial/exceptions/ .
  *
  *  At some fundamental level, a typical C++ exception is an object that
  *  is placed in some special place, and then the function exits the current

--- a/doc/doxygen/headers/geodynamics.h
+++ b/doc/doxygen/headers/geodynamics.h
@@ -42,7 +42,7 @@ Some of these programs were developed under contract from the California
 Institute of Technology with support by the National Science Foundation
 under Award No. EAR-0426271, the first of the grants that funded
 the <a target="_top"
-href="http://www.geodynamics.org">Computational Infrastructure in
+href="https://www.geodynamics.org">Computational Infrastructure in
 Geodynamics</a> initiative. The recipient, Wolfgang Bangerth, gratefully
 acknowledges this source of support.
 

--- a/doc/doxygen/headers/glossary.h
+++ b/doc/doxygen/headers/glossary.h
@@ -959,7 +959,7 @@
  *
  * For massively %parallel
  * computations, deal.II builds on the
- * <a href="http://www.p4est.org/" target="_top">p4est</a>
+ * <a href="https://www.p4est.org/" target="_top">p4est</a>
  * library. If you use this functionality, please also cite the
  * p4est paper listed at their website.
  * </dd>
@@ -1212,7 +1212,7 @@
   pages =        {4/1--4/31}
 }
  * @endcode
- * It is available from <a href="http://www.math.colostate.edu/~bangerth/publications.html">http://www.math.colostate.edu/~bangerth/publications.html</a>, also see <a href="https://www.dealii.org/publications.html#details">deal.II publications</a> for details.
+ * It is available from <a href="https://www.math.colostate.edu/~bangerth/publications.html">https://www.math.colostate.edu/~bangerth/publications.html</a>, also see <a href="https://www.dealii.org/publications.html#details">deal.II publications</a> for details.
  *
  * The numerical examples shown in that paper are generated with a slightly
  * modified version of step-27. The main difference to that
@@ -1592,7 +1592,7 @@
   publisher={SIAM}}
  * @endcode
  * See
- * <a href="http://dx.doi.org/10.1137/090778523">DOI:10.1137/090778523</a>
+ * <a href="https://dx.doi.org/10.1137/090778523">DOI:10.1137/090778523</a>
  * for the paper and <a href="https://www.dealii.org/publications.html#details">deal.II publications</a> for more details.
  * </dd>
  *
@@ -1871,7 +1871,7 @@
  *
  * deal.II implements serialization facilities by implementing the necessary
  * interfaces for the <a
- * href="http://www.boost.org/doc/libs/1_62_0/libs/serialization/doc/index.html"
+ * href="https://www.boost.org/doc/libs/1_62_0/libs/serialization/doc/index.html"
  * target="_top">BOOST serialization</a> library. See there for examples on
  * how to save and restore objects.
  * </dd>
@@ -2258,7 +2258,7 @@
   year =         2016
 }
  * @endcode
- * It is available from <a href="http://www.math.colostate.edu/~bangerth/publications.html">http://www.math.colostate.edu/~bangerth/publications.html</a>, also see <a href="https://www.dealii.org/publications.html#details">deal.II publications</a> for details.
+ * It is available from <a href="https://www.math.colostate.edu/~bangerth/publications.html">https://www.math.colostate.edu/~bangerth/publications.html</a>, also see <a href="https://www.dealii.org/publications.html#details">deal.II publications</a> for details.
  * </dd>
  *
  *

--- a/doc/doxygen/headers/main.h
+++ b/doc/doxygen/headers/main.h
@@ -299,7 +299,7 @@
  * to use the tag file, you have to download it into a place where Doxygen can find it.
  * After that, find the key <code>TAGFILES</code> in your Doxygen options file and write something like
  * <pre>
- * TAGFILES = deal.tag=http://www.dealii.org/X.Y.Z/doxygen/deal.II
+ * TAGFILES = deal.tag=https://www.dealii.org/X.Y.Z/doxygen/deal.II
  * </pre>
  * where <code>X.Y.Z</code> refers to the release you want to link to. Be sure you use
  * the matching tag file. In theory, you can also link against the developing revisions

--- a/doc/doxygen/headers/multithreading.h
+++ b/doc/doxygen/headers/multithreading.h
@@ -151,7 +151,7 @@
  * vein, it often pays off to use tasks, rather than threads, in a program.
  *
  * deal.II does not implement scheduling tasks to threads itself. For this, we
- * use the <a href="http://www.threadingbuildingblocks.org" target="_top">Threading Building
+ * use the <a href="https://www.threadingbuildingblocks.org" target="_top">Threading Building
  * Blocks (TBB) library</a> for which we provide simple wrappers. TBB
  * abstracts the details of how to start or stop threads, start tasks on
  * individual threads, etc, and provides interfaces that are portable across

--- a/doc/doxygen/headers/reordering.h
+++ b/doc/doxygen/headers/reordering.h
@@ -455,7 +455,7 @@
  * unstructured two- and three-dimensional meshes", R. Agelek,
  * M. Anderson, W.  Bangerth, W. L. Barth, ACM Transactions on
  * Mathematical Software, vol. 44, article 5, 2017. A preprint is
- * available as <a href="http://arxiv.org/abs/1512.02137">arxiv
+ * available as <a href="https://arxiv.org/abs/1512.02137">arxiv
  * 1512.02137</a>.
  *
  *

--- a/doc/doxygen/references.bib
+++ b/doc/doxygen/references.bib
@@ -294,7 +294,7 @@
   issue = { 1 },
   pages = { 191--211 },
   doi = {10.1137/20M1342902},
-  url = {http://doi.org/10.1137/20M1342902},
+  url = {https://doi.org/10.1137/20M1342902},
 }
 
 
@@ -649,7 +649,7 @@
   issue = { 6 },
   pages = { 2095--2113 },
   doi = {10.1137/050646421},
-  url = {http://doi.org/10.1137/050646421},
+  url = {https://doi.org/10.1137/050646421},
 }
 
 @article{HeisterRapin2013,
@@ -661,7 +661,7 @@
   issue = { 1 },
   pages = { 118--134 },
   doi = {10.1002/fld.3654},
-  url = {http://doi.org/10.1002/fld.3654},
+  url = {https://doi.org/10.1002/fld.3654},
 }
 
 @article{Ghia1982,
@@ -673,7 +673,7 @@
   issue = { 3 },
   pages = { 387--411 },
   doi = {10.1016/0021-9991(82)90058-4},
-  url = {http://doi.org/10.1016/0021-9991(82)90058-4},
+  url = {https://doi.org/10.1016/0021-9991(82)90058-4},
 }
 
 @article{Erturk2005,
@@ -685,7 +685,7 @@
   issue = { 7 },
   pages = { 747--774 },
   doi = {10.1002/fld.953},
-  url = {http://doi.org/10.1002/fld.953},
+  url = {https://doi.org/10.1002/fld.953},
 }
 
 @article{Yang1998,
@@ -697,7 +697,7 @@
   issue = { 1 },
   pages = { 464--487 },
   doi = {10.1006/jcph.1998.6062},
-  url = {http://doi.org/10.1006/jcph.1998.6062},
+  url = {https://doi.org/10.1006/jcph.1998.6062},
 }
 
 @article{Bruneau2006,
@@ -709,7 +709,7 @@
   issue = { 3 },
   pages = { 326--348 },
   doi = {10.1016/j.compfluid.2004.12.004},
-  url = {http://doi.org/10.1016/j.compfluid.2004.12.004},
+  url = {https://doi.org/10.1016/j.compfluid.2004.12.004},
 }
 
 
@@ -726,7 +726,7 @@
   issue = { 2 },
   pages = { 228--238 },
   doi = {10.1145/1067967.1067970},
-  url = {http://doi.org/10.1145/1067967.1067970},
+  url = {https://doi.org/10.1145/1067967.1067970},
 }
 
 @article{Day2001,
@@ -738,7 +738,7 @@
   issue = { 2 },
   pages = { 480--498 },
   doi = {10.1137/S1064827500372262},
-  url = {http://doi.org/10.1137/S1064827500372262},
+  url = {https://doi.org/10.1137/S1064827500372262},
 }
 
 @article{Axelsson2014,
@@ -750,7 +750,7 @@
   issue = { 4 },
   pages = { 811--841 },
   doi = {10.1007/s11075-013-9764-1},
-  url = {http://doi.org/10.1007/s11075-013-9764-1},
+  url = {https://doi.org/10.1007/s11075-013-9764-1},
 }
 
 @article{Liao2016,
@@ -762,7 +762,7 @@
   issue = { 9 },
   pages = { 2473--2485 },
   doi = {10.1016/j.camwa.2016.09.004},
-  url = {http://doi.org/10.1016/j.camwa.2016.09.004},
+  url = {https://doi.org/10.1016/j.camwa.2016.09.004},
 }
 
 
@@ -1026,7 +1026,7 @@
     NUMBER = {5},
      PAGES = {A3211--A3239},
        DOI = {10.1137/17M1149961},
-       URL = {http://doi.org/10.1137/17M1149961}
+       URL = {https://doi.org/10.1137/17M1149961}
 }
 
 @book {GuermondErn2004,
@@ -1652,7 +1652,7 @@
   title = {High-{Order} {Quadrature} {Methods} for {Implicitly} {Defined} {Surfaces} and {Volumes} in {Hyperrectangles}},
   volume = {37},
   issn = {1064-8275, 1095-7197},
-  url = {http://epubs.siam.org/doi/10.1137/140966290},
+  url = {https://epubs.siam.org/doi/10.1137/140966290},
   doi = {10.1137/140966290},
   language = {en},
   number = {2},
@@ -1668,7 +1668,7 @@
   title = {Fictitious domain finite element methods using cut elements: {II}. {A} stabilized {Nitsche} method},
   volume = {62},
   issn = {01689274},
-  url = {http://linkinghub.elsevier.com/retrieve/pii/S0168927411000298},
+  url = {https://linkinghub.elsevier.com/retrieve/pii/S0168927411000298},
   doi = {10.1016/j.apnum.2011.01.008},
   language = {en},
   number = {4},
@@ -1684,7 +1684,7 @@
   title = {{CutFEM}: {Discretizing} geometry and partial differential equations},
   volume = {104},
   issn = {00295981},
-  url = {http://doi.wiley.com/10.1002/nme.4823},
+  url = {https://doi.wiley.com/10.1002/nme.4823},
   doi = {10.1002/nme.4823},
   language = {en},
   number = {7},
@@ -2052,7 +2052,7 @@
   school    = {Virginia Tech},
   year      = {1996},
   month     = jun,
-  url       = {http://hdl.handle.net/10919/9579}
+  url       = {https://hdl.handle.net/10919/9579}
 }
 
 @article{Boffi2012,
@@ -2064,7 +2064,7 @@
   issue = {2},
   pages = {383--400},
   doi = {10.1007/s10915-011-9549-4},
-  url = {http://doi.org/10.1007/s10915-011-9549-4}
+  url = {https://doi.org/10.1007/s10915-011-9549-4}
 }
 
 @PhDThesis{Richter2005,

--- a/doc/doxygen/scripts/filter.pl
+++ b/doc/doxygen/scripts/filter.pl
@@ -136,7 +136,7 @@ while (<>)
         $text = "\@note The material presented here is also discussed in ";
 
         # add links to the individual lectures
-        $text = $text . "<a href=\"http://www.math.colostate.edu/~bangerth/videos.676.$2.html\">video lecture $2</a>";
+        $text = $text . "<a href=\"https://www.math.colostate.edu/~bangerth/videos.676.$2.html\">video lecture $2</a>";
         
         if (length($3) > 0)
         {
@@ -147,11 +147,11 @@ while (<>)
 
             foreach $lecture (@otherlectures)
             {
-                $text = $text . ", <a href=\"http://www.math.colostate.edu/~bangerth/videos.676.$lecture.html\">video lecture $lecture</a>";
+                $text = $text . ", <a href=\"https://www.math.colostate.edu/~bangerth/videos.676.$lecture.html\">video lecture $lecture</a>";
             }
         }
 
-        $text = $text . ". (All video lectures are also available <a href=\"http://www.math.colostate.edu/~bangerth/videos.html\">here</a>.)";
+        $text = $text . ". (All video lectures are also available <a href=\"https://www.math.colostate.edu/~bangerth/videos.html\">here</a>.)";
         s/(\@dealiiVideoLecture\{([0-9\.]+)((, *[0-9\.]+ *)*)\})/$text/;
     }
 
@@ -165,7 +165,7 @@ while (<>)
         $text = "See also ";
 
         # add links to the individual lectures
-        $text = $text . "<a href=\"http://www.math.colostate.edu/~bangerth/videos.676.$2.html\">video lecture $2</a>";
+        $text = $text . "<a href=\"https://www.math.colostate.edu/~bangerth/videos.676.$2.html\">video lecture $2</a>";
         
         if (length($3) > 0)
         {
@@ -175,7 +175,7 @@ while (<>)
 
             foreach $lecture (@otherlectures)
             {
-                $text = $text . ", <a href=\"http://www.math.colostate.edu/~bangerth/videos.676.$lecture.html\">video lecture $lecture</a>";
+                $text = $text . ", <a href=\"https://www.math.colostate.edu/~bangerth/videos.676.$lecture.html\">video lecture $lecture</a>";
             }
         }
 

--- a/doc/doxygen/scripts/mod_footer.pl.in
+++ b/doc/doxygen/scripts/mod_footer.pl.in
@@ -23,8 +23,8 @@ my $host = hostname;
 
 my $hosting = << 'EOT'
 &nbsp;&nbsp;Hosting provided by&nbsp;
-<a href="http://www.iwr.uni-heidelberg.de/"><img src="https://www.dealii.org/pictures/IWRlogo4.png" alt="IWR"></a>
-<a href="http://www.uni-heidelberg.de/"><img src="https://www.dealii.org/pictures/UniLogo4.png" alt="Universität Heidelberg"></a>
+<a href="https://www.iwr.uni-heidelberg.de/"><img src="https://www.dealii.org/pictures/IWRlogo4.png" alt="IWR"></a>
+<a href="https://www.uni-heidelberg.de/"><img src="https://www.dealii.org/pictures/UniLogo4.png" alt="Universität Heidelberg"></a>
 EOT
     ;
 

--- a/doc/doxygen/scripts/validate-xrefs.pl
+++ b/doc/doxygen/scripts/validate-xrefs.pl
@@ -99,8 +99,8 @@ foreach $filename (@ARGV)
 		$external_file = $1;
 		$external_ref = $2;
 
-		# if the file name was prepended with http: (but is a local file,
-		# so no double-slash), then split off http:
+		# if the file name was prepended with https: (but is a local file,
+		# so no double-slash), then split off https:
 		$external_file =~ s/^http(s)?://g;
 
 		print "external reference: $link\n" if $debug;
@@ -129,8 +129,8 @@ foreach $filename (@ARGV)
 		# this must now be a regular file which is
 		# referenced. the file must be local
 
-		# if the file name was prepended with http: (but is a local file,
-		# so no double-slash), then split off http:
+		# if the file name was prepended with https: (but is a local file,
+		# so no double-slash), then split off https:
 		$link =~ s/^http(s)?://g;
 
 		die "---Local file `$link' not found in file `$filename'\n This line is: $this_line.\n"

--- a/doc/external-libs/arpack.html
+++ b/doc/external-libs/arpack.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	  "http://www.w3.org/TR/html4/loose.dtd">
+	  "https://www.w3.org/TR/html4/loose.dtd">
 
 <html>
   <head>
@@ -14,10 +14,10 @@
     <h2>Installation of <acronym>ARPACK</acronym></h2>
 
     <p>
-      <a href="http://www.caam.rice.edu/software/ARPACK/">ARPACK</a>
+      <a href="https://www.caam.rice.edu/software/ARPACK/">ARPACK</a>
       is a collection of Fortran77 subroutines designed to solve large
       scale eigenvalue problems.
-      <a href="http://www.caam.rice.edu/software/ARPACK/" target="_top">ARPACK</a>
+      <a href="https://www.caam.rice.edu/software/ARPACK/" target="_top">ARPACK</a>
       should be readily packaged by most Linux distributions.
       Don't forget to install a development version of the library.
     </p>
@@ -43,7 +43,7 @@
       and the patch, unzip the files you got. That will create
       a directory named <acronym>ARPACK</acronym>. If you need
       further instructions please read the README file or the
-      <a href="http://www.caam.rice.edu/software/ARPACK/SRC/instruction.arpack">instructions</a>.
+      <a href="https://www.caam.rice.edu/software/ARPACK/SRC/instruction.arpack">instructions</a>.
       We will explain here in a few steps what has to be done to be able
       to compile <acronym>ARPACK</acronym>.
     </p>
@@ -145,10 +145,10 @@
 
     <hr />
     <div class="right">
-      <a href="http://validator.w3.org/check?uri=referer" target="_top">
-        <img style="border:0" src="http://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
-      <a href="http://jigsaw.w3.org/css-validator/check/referer" target="_top">
-        <img style="border:0;width:88px;height:31px" src="http://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
+      <a href="https://validator.w3.org/check?uri=referer" target="_top">
+        <img style="border:0" src="https://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
+      <a href="https://jigsaw.w3.org/css-validator/check/referer" target="_top">
+        <img style="border:0;width:88px;height:31px" src="https://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
     </div>
 
   </body>

--- a/doc/external-libs/cuda.html
+++ b/doc/external-libs/cuda.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	  "http://www.w3.org/TR/html4/loose.dtd">
+	  "https://www.w3.org/TR/html4/loose.dtd">
 <html>
   <head>
     <title>The deal.II Readme on interfacing to CUDA</title>

--- a/doc/external-libs/ginkgo.html
+++ b/doc/external-libs/ginkgo.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	  "http://www.w3.org/TR/html4/loose.dtd">
+	  "https://www.w3.org/TR/html4/loose.dtd">
 <html>
   <head>
     <title>The deal.II Readme on interfacing to Ginkgo</title>
@@ -87,10 +87,10 @@
 
     <hr />
     <div class="right">
-      <a href="http://validator.w3.org/check?uri=referer" target="_top">
-        <img style="border:0" src="http://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
-      <a href="http://jigsaw.w3.org/css-validator/check/referer" target="_top">
-        <img style="border:0;width:88px;height:31px" src="http://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
+      <a href="https://validator.w3.org/check?uri=referer" target="_top">
+        <img style="border:0" src="https://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
+      <a href="https://jigsaw.w3.org/css-validator/check/referer" target="_top">
+        <img style="border:0;width:88px;height:31px" src="https://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
     </div>
   </body>
 </html>

--- a/doc/external-libs/gsl.html
+++ b/doc/external-libs/gsl.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	  "http://www.w3.org/TR/html4/loose.dtd">
+	  "https://www.w3.org/TR/html4/loose.dtd">
 
 <html>
   <head>
@@ -14,10 +14,10 @@
     <h2>Installation of <acronym>GSL</acronym></h2>
 
     <p>
-      <a href="http://www.gnu.org/software/gsl/">GNU Scientific Library</a>
+      <a href="https://www.gnu.org/software/gsl/">GNU Scientific Library</a>
       provides a wide range of mathematical routines such as random number
   	  generators, special functions and least-squares fitting.
-      <a href="http://www.gnu.org/software/gsl/" target="_top">GSL</a>
+      <a href="https://www.gnu.org/software/gsl/" target="_top">GSL</a>
       should be readily packaged by most Linux distributions.
       Don't forget to install a development version of the library.
     </p>
@@ -59,10 +59,10 @@
 
     <hr />
     <div class="right">
-      <a href="http://validator.w3.org/check?uri=referer" target="_top">
-        <img style="border:0" src="http://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
-      <a href="http://jigsaw.w3.org/css-validator/check/referer" target="_top">
-        <img style="border:0;width:88px;height:31px" src="http://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
+      <a href="https://validator.w3.org/check?uri=referer" target="_top">
+        <img style="border:0" src="https://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
+      <a href="https://jigsaw.w3.org/css-validator/check/referer" target="_top">
+        <img style="border:0;width:88px;height:31px" src="https://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
     </div>
 
   </body>

--- a/doc/external-libs/lapack.html
+++ b/doc/external-libs/lapack.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	  "http://www.w3.org/TR/html4/loose.dtd">
+	  "https://www.w3.org/TR/html4/loose.dtd">
 
 <html>
   <head>
@@ -98,10 +98,10 @@
 
     <hr />
     <div class="right">
-      <a href="http://validator.w3.org/check?uri=referer" target="_top">
-        <img style="border:0" src="http://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
-      <a href="http://jigsaw.w3.org/css-validator/check/referer" target="_top">
-        <img style="border:0;width:88px;height:31px" src="http://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
+      <a href="https://validator.w3.org/check?uri=referer" target="_top">
+        <img style="border:0" src="https://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
+      <a href="https://jigsaw.w3.org/css-validator/check/referer" target="_top">
+        <img style="border:0;width:88px;height:31px" src="https://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
     </div>
 
   </body>

--- a/doc/external-libs/opencascade.html
+++ b/doc/external-libs/opencascade.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	  "http://www.w3.org/TR/html4/loose.dtd">
+	  "https://www.w3.org/TR/html4/loose.dtd">
 
 <html>
   <head>
@@ -13,7 +13,7 @@
 
     <h2>Installation of <acronym>OpenCASCADE</acronym></h2>
 
-    <p> <a href="http://www.opencascade.org/">OpenCASCADE</a> is a
+    <p> <a href="https://www.opencascade.org/">OpenCASCADE</a> is a
       software development kit (SDK) intended for development of
       applications dealing with 3D CAD data, freely available in open
       source. It includes a set of C++ class libraries providing
@@ -74,10 +74,10 @@ This will turn off some packages we don't need. The default package options also
 
     <hr />
     <div class="right">
-      <a href="http://validator.w3.org/check?uri=referer" target="_top">
-        <img style="border:0" src="http://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
-      <a href="http://jigsaw.w3.org/css-validator/check/referer" target="_top">
-        <img style="border:0;width:88px;height:31px" src="http://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
+      <a href="https://validator.w3.org/check?uri=referer" target="_top">
+        <img style="border:0" src="https://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
+      <a href="https://jigsaw.w3.org/css-validator/check/referer" target="_top">
+        <img style="border:0;width:88px;height:31px" src="https://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
     </div>
 
   </body>

--- a/doc/external-libs/p4est-setup.sh
+++ b/doc/external-libs/p4est-setup.sh
@@ -15,7 +15,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 #
-# [1] http://www.p4est.org
+# [1] https://www.p4est.org
 #
 
 # This program comes with ABSOLUTELY NO WARRANTY.

--- a/doc/external-libs/p4est.html
+++ b/doc/external-libs/p4est.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Frameset//EN"
-   "http://www.w3.org/TR/REC-html40/frameset.dtd">
+   "https://www.w3.org/TR/REC-html40/frameset.dtd">
 <html>
   <head>
     <title>The deal.II Readme on interfacing to p4est</title>
@@ -14,7 +14,7 @@
     <h1>Using and installing instructions for the p4est library</h1>
 
     <p>
-      <a href="http://www.p4est.org/" target="_top">p4est</a> is a
+      <a href="https://www.p4est.org/" target="_top">p4est</a> is a
       library that manages meshes that are distributed across multiple
       processors. It forms the basis of deal.II's implementation of
       finite element solvers that can use meshes that are too large to
@@ -23,7 +23,7 @@
 
     <p>
       You need to install p4est before deal.II. To do so, you can
-      download it from <a href="http://www.p4est.org/" target="_top">here</a>.
+      download it from <a href="https://www.p4est.org/" target="_top">here</a>.
       You can either choose to manually compile and install p4est (as
       explained in documentation of p4est), or alternatively use
       <a href="p4est-setup.sh">a script</a> that will automatically compile
@@ -58,10 +58,10 @@ cmake -DP4EST_DIR=/path/to/installation -DDEAL_II_WITH_P4EST=ON -DDEAL_II_WITH_M
 
     <hr />
     <div class="right">
-      <a href="http://validator.w3.org/check?uri=referer" target="_top">
-        <img style="border:0" src="http://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
-      <a href="http://jigsaw.w3.org/css-validator/check/referer" target="_top">
-        <img style="border:0;width:88px;height:31px" src="http://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
+      <a href="https://validator.w3.org/check?uri=referer" target="_top">
+        <img style="border:0" src="https://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
+      <a href="https://jigsaw.w3.org/css-validator/check/referer" target="_top">
+        <img style="border:0;width:88px;height:31px" src="https://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
     </div>
   </body>
 </html>

--- a/doc/external-libs/petsc.html
+++ b/doc/external-libs/petsc.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	  "http://www.w3.org/TR/html4/loose.dtd">
+	  "https://www.w3.org/TR/html4/loose.dtd">
 <html>
   <head>
     <title>The deal.II Readme on interfacing to PETSc</title>
@@ -13,7 +13,7 @@
     <h1>Interfacing <acronym>deal.II</acronym> to PETSc</h1>
 
     <p>
-      <a href="http://www.mcs.anl.gov/petsc/"
+      <a href="https://www.mcs.anl.gov/petsc/"
       target="_top">PETSc</a> is a
       software package that provides lots of functionality for linear
       algebra, among other things. For example, it includes implementations of a variety of
@@ -97,7 +97,7 @@
     <p>
       Installing PETSc correctly can be a bit of a
       challenge. To start, take a look at
-      the <a href="http://www.mcs.anl.gov/petsc/documentation/installation.html"
+      the <a href="https://www.mcs.anl.gov/petsc/documentation/installation.html"
       target="_top">PETSc installation instructions</a>. We have found that
       the following steps generally appear to work where we simply unpack and
       build PETSc in its final location (i.e., we do not first build and then
@@ -154,10 +154,10 @@
 
     <hr />
     <div class="right">
-      <a href="http://validator.w3.org/check?uri=referer" target="_top">
-        <img style="border:0" src="http://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
-      <a href="http://jigsaw.w3.org/css-validator/check/referer" target="_top">
-        <img style="border:0;width:88px;height:31px" src="http://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
+      <a href="https://validator.w3.org/check?uri=referer" target="_top">
+        <img style="border:0" src="https://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
+      <a href="https://jigsaw.w3.org/css-validator/check/referer" target="_top">
+        <img style="border:0;width:88px;height:31px" src="https://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
     </div>
   </body>
 </html>

--- a/doc/external-libs/slepc.html
+++ b/doc/external-libs/slepc.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	  "http://www.w3.org/TR/html4/loose.dtd">
+	  "https://www.w3.org/TR/html4/loose.dtd">
 <html>
   <head>
     <title>The deal.II Readme on interfacing to SLEPc</title>
@@ -107,10 +107,10 @@
 
     <hr />
     <div class="right">
-      <a href="http://validator.w3.org/check?uri=referer" target="_top">
-        <img style="border:0" src="http://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
-      <a href="http://jigsaw.w3.org/css-validator/check/referer" target="_top">
-        <img style="border:0;width:88px;height:31px" src="http://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
+      <a href="https://validator.w3.org/check?uri=referer" target="_top">
+        <img style="border:0" src="https://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
+      <a href="https://jigsaw.w3.org/css-validator/check/referer" target="_top">
+        <img style="border:0;width:88px;height:31px" src="https://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
     </div>
   </body>
 </html>

--- a/doc/external-libs/trilinos.html
+++ b/doc/external-libs/trilinos.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	  "http://www.w3.org/TR/html4/loose.dtd">
+	  "https://www.w3.org/TR/html4/loose.dtd">
 <html>
   <head>
     <title>The deal.II Readme on interfacing to Trilinos</title>
@@ -23,7 +23,7 @@
       engines, etc. Of particular interest to deal.II is their ability to
       provide this functionality both on sequential and parallel (using MPI)
       computers.
-      Compared to <a href="http://www.mcs.anl.gov/petsc/" target="_top">PETSc</a>,
+      Compared to <a href="https://www.mcs.anl.gov/petsc/" target="_top">PETSc</a>,
       which is written in C, Trilinos is written in C++ and can be considered to
       be a more modern version of PETSc though both packages are under
       continuing development at their respective national laboratories.
@@ -74,7 +74,7 @@
         <li> Zoltan (optional).
       </ul>
 
-      Trilinos uses <a href="http://cmake.org/">cmake</a> to configure and
+      Trilinos uses <a href="https://cmake.org/">cmake</a> to configure and
       build. The following slightly longish set of commands will set up a
       reasonable configuration (<code>trilinos-x.y.z</code> is the
       version-specific path into which the
@@ -134,7 +134,7 @@
       Note: At the time of writing (November 2016) Trilinos (at least up to
       v12.8.1) cannot link against LAPACK 3.6.0 or later, due to two symbols
       that were deprecated (and removed by default) in LAPACK 3.6.0 (see the
-      <a href="http://www.netlib.org/lapack/lapack-3.6.0.html">
+      <a href="https://www.netlib.org/lapack/lapack-3.6.0.html">
       release notes</a>). To fix this, edit the Trilinos file
       <code>packages/epetra/src/Epetra_LAPACK_wrappers.h</code> and change the
       lines
@@ -176,7 +176,7 @@
     <p>
       Trilinos (via its Amesos package) can interface with a number of direct
       solvers (see, for example,
-      <a href="http://trilinos.org/docs/r11.8/packages/amesos/doc/html/index.html"
+      <a href="https://trilinos.org/docs/r11.8/packages/amesos/doc/html/index.html"
 	 target="_top">this page for Trilinos 11.8</a>). Most of them are external
       packages to Trilinos and you will need to tell Trilinos configuration
       scripts that you want to use them, for example via the
@@ -211,10 +211,10 @@
     </p>
     <hr />
     <div class="right">
-      <a href="http://validator.w3.org/check?uri=referer" target="_top">
-        <img style="border:0" src="http://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
-      <a href="http://jigsaw.w3.org/css-validator/check/referer" target="_top">
-        <img style="border:0;width:88px;height:31px" src="http://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
+      <a href="https://validator.w3.org/check?uri=referer" target="_top">
+        <img style="border:0" src="https://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
+      <a href="https://jigsaw.w3.org/css-validator/check/referer" target="_top">
+        <img style="border:0;width:88px;height:31px" src="https://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
     </div>
   </body>
 </html>

--- a/doc/index.html
+++ b/doc/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Frameset//EN"
-          "http://www.w3.org/TR/REC-html40/frameset.dtd">
+          "https://www.w3.org/TR/REC-html40/frameset.dtd">
 <html>
   <head>
     <title>deal.II Documentation</title>
@@ -32,11 +32,11 @@
                   installation instructions</a></li>
               <li> <a href="https://github.com/dealii/dealii/wiki/Frequently-Asked-Questions">Frequently asked questions</a></li>
               <li><a href="doxygen/deal.II/Tutorial.html">Tutorial</a></li>
-              <li><a href="http://www.dealii.org/code-gallery.html">Code gallery</a></li>
+              <li><a href="https://www.dealii.org/code-gallery.html">Code gallery</a></li>
               <li><a href="doxygen/deal.II/index.html">Manual</a></li>
-              <li><a href="http://www.math.colostate.edu/~bangerth/videos.html">Video lectures</a></li>
+              <li><a href="https://www.math.colostate.edu/~bangerth/videos.html">Video lectures</a></li>
               <li><a href="users/gdb.html">Configuration for debugging via GDB</a></li>
-              <li><a href="http://www.dealii.org/publications.html">Publications on and using deal.II</a></li>
+              <li><a href="https://www.dealii.org/publications.html">Publications on and using deal.II</a></li>
             </ul>
           </div>
         </div>
@@ -51,7 +51,7 @@
               <li><a href="users/cmake_dealii.html">CMake documentation</a></li>
               <li><a href="users/cmake_user.html">CMake in user projects</a></li>
               <li><a href="users/testsuite.html">Setting up a testsuite in user projects</a></li>
-              <li><a href="http://www.dealii.org/reports.html">Technical reports</a></li>
+              <li><a href="https://www.dealii.org/reports.html">Technical reports</a></li>
             </ul>
           </div>
         </div>
@@ -83,13 +83,13 @@
           <div style="border:1px solid #aaa; background-color: #f9f9f9;
                       padding: 5px; font-size: 88%; text-align: left;">
             <ul>
-              <li> <a href="http://www.dealii.org/news.html">News</a></li>
-              <li> <a href="http://www.dealii.org/download.html">Download</a></li>
-              <li> <a href="http://www.dealii.org/mail.html">Mailing list</a></li>
+              <li> <a href="https://www.dealii.org/news.html">News</a></li>
+              <li> <a href="https://www.dealii.org/download.html">Download</a></li>
+              <li> <a href="https://www.dealii.org/mail.html">Mailing list</a></li>
               <li> <a href="https://github.com/dealii/dealii/wiki">Wiki</a></li>
               <li> <a href="https://github.com/dealii/dealii/issues">Bug tracker</a></li>
-              <li> <a href="http://www.dealii.org/authors.html">Authors</a> </li>
-              <li> <a href="http://www.dealii.org/license.html">License</a> </li>
+              <li> <a href="https://www.dealii.org/authors.html">Authors</a> </li>
+              <li> <a href="https://www.dealii.org/license.html">License</a> </li>
             </ul>
           </div>
         </div>

--- a/doc/news/2.0.0-vs-3.0.0.h
+++ b/doc/news/2.0.0-vs-3.0.0.h
@@ -21,8 +21,8 @@ Version 3.0  of the deal.II object-oriented finite  element library is
 available on the deal.II home-page at
 </p>
 <p align="center">
-<a href="http://www.dealii.org" target="_top">
-      http://www.dealii.org
+<a href="https://www.dealii.org" target="_top">
+      https://www.dealii.org
 </a>
 </p>
 

--- a/doc/news/3.0.0-vs-3.1.0.h
+++ b/doc/news/3.0.0-vs-3.1.0.h
@@ -29,7 +29,7 @@ All entries are signed with the names of the author.
 <ol>
   <li> <p>
        New: All identifiers that the C++ standard (see
-       <a href="http://www.cygnus.com/misc/wp/dec96pub/"
+       <a href="https://www.cygnus.com/misc/wp/dec96pub/"
        target="_top"> this page</a> for the public draft -- the
        standard itself is not available online for copyright reasons)
        mandates to be in namespace <code>std::</code> are correctly

--- a/doc/news/3.1.0-vs-3.2.0.h
+++ b/doc/news/3.1.0-vs-3.2.0.h
@@ -142,7 +142,7 @@ All entries are signed with the names of the author.
 
   <li> <p>
        New: There is now some support to include and use routines from the
-       <a href="http://www.cse.clrc.ac.uk/Activity/HSL"
+       <a href="https://www.cse.clrc.ac.uk/Activity/HSL"
        target="_top">Harwell Subroutine Library</a>.
        <br>
        (WB 2001/01/30)
@@ -273,7 +273,7 @@ All entries are signed with the names of the author.
 
   <li> <p>
        New: We now support the output format of the <a
-       href="http://www.kitware.com/vtk.html"
+       href="https://www.kitware.com/vtk.html"
        target="_top">Visualization Toolkit (Vtk)</a> from the <code
        class="class">DataOutBase</code> class and all derived classes.
        <br>
@@ -591,7 +591,7 @@ All entries are signed with the names of the author.
 
   <li> <p>
        New: There is now some support to include and use routines from the
-       <a href="http://www.cse.clrc.ac.uk/Activity/HSL"
+       <a href="https://www.cse.clrc.ac.uk/Activity/HSL"
        target="_top">Harwell Subroutine Library</a>, and support
        classes
        <code>SparseDirectMA27</code> and

--- a/doc/news/3.1.1-vs-3.1.2.h
+++ b/doc/news/3.1.1-vs-3.1.2.h
@@ -28,7 +28,7 @@ All entries are signed with the names of the author.
        the file <code>tria_accessor.cc(3d)</code> without optimization
        flags even for optimized libraries. The gcc bug is documented
        at the <a
-       href="http://gcc.gnu.org/cgi-bin/gnatsweb.pl?database=gcc&user=guest&password=guest&cmd=login"
+       href="https://gcc.gnu.org/cgi-bin/gnatsweb.pl?database=gcc&user=guest&password=guest&cmd=login"
        target="_top">gcc bug tracking system page</a>, as bugs reports c++/615 and
        optimization/2938.
        <br>

--- a/doc/news/3.2.0-vs-3.3.0.h
+++ b/doc/news/3.2.0-vs-3.3.0.h
@@ -28,7 +28,7 @@ All entries are signed with the names of the author.
 <ol>
   <li> <p>
        New: Output for
-       <a href="http://www.amtec.org" target="_top">Tecplot</a> has
+       <a href="https://www.amtec.org" target="_top">Tecplot</a> has
        been added. It can be used by choosing output format «tecplot».
        <br>
        (<a href="mailto:benkirk@cfdlab.ae.utexas.edu">Benjamin Shelton Kirk</a> 2002/01/29)
@@ -52,7 +52,7 @@ All entries are signed with the names of the author.
 
   <li> <p>
        New: Output for
-       <a href="http://www.opendx.org" target="_top">OpenDX</a> has
+       <a href="https://www.opendx.org" target="_top">OpenDX</a> has
        been added. It can be used by choosing output format «dx» (not
        yet for grid output). The data format is very basic now, but it
        is planned to improve this to make use of the excellent

--- a/doc/news/3.3.0-vs-3.4.0.h
+++ b/doc/news/3.3.0-vs-3.4.0.h
@@ -40,7 +40,7 @@ All entries are signed with the names of the author.
        functions as a replacement.
        <br>
        For more information, read
-       <a href="http://www.dealii.org/mail/msg00638.html" target="body">this mail</a>.
+       <a href="https://www.dealii.org/mail/msg00638.html" target="body">this mail</a>.
        </strong>
        <br>
        (WB 2002/06/03)
@@ -64,7 +64,7 @@ All entries are signed with the names of the author.
 
   <li> <p>
        New: In all previous versions, deal.II used
-       the <a href="http://www.cs.wustl.edu/~schmidt/ACE.html"
+       the <a href="https://www.cs.wustl.edu/~schmidt/ACE.html"
        target="_top">ACE (Adaptive Communications Environment)</a>
        library to support cross-platform threading
        facilities. While this is still supported, the default way

--- a/doc/news/3.4.0-vs-4.0.0.h
+++ b/doc/news/3.4.0-vs-4.0.0.h
@@ -52,7 +52,7 @@ contributor's names are abbreviated by WB (Wolfgang Bangerth), GK
 
   <li> <p>
        New: deal.II now makes use of some parts of
-       the <a href="http://www.boost.org/">boost</a> library, which is
+       the <a href="https://www.boost.org/">boost</a> library, which is
        supposed to be a testground for the next generation C++ standard
        library. The parts which we use are now in
        <code>contrib/boost/include/boost_local/</code> and can be
@@ -119,7 +119,7 @@ contributor's names are abbreviated by WB (Wolfgang Bangerth), GK
   <li> <p>
        Removed: Thread support now relies solely on the use of POSIX
        functions. The use of the
-       <a href="http://www.cs.wustl.edu/~schmidt/ACE.html" target="_top">ACE
+       <a href="https://www.cs.wustl.edu/~schmidt/ACE.html" target="_top">ACE
        (Adaptive Communications Environment)</a> library for this is now no
        longer supported. However, application programs can of course still use
        ACE, but they will need to generate paths to this library in their
@@ -281,7 +281,7 @@ contributor's names are abbreviated by WB (Wolfgang Bangerth), GK
        functions as a replacement.
        <br>
        For more information, read
-       <a href="http://www.dealii.org/mail/msg00638.html" target="body">this mail</a>.
+       <a href="https://www.dealii.org/mail/msg00638.html" target="body">this mail</a>.
        <br>
        (WB 2002/06/10)
        </p>

--- a/doc/news/4.0.0-vs-5.0.0.h
+++ b/doc/news/4.0.0-vs-5.0.0.h
@@ -151,7 +151,7 @@ inconvenience this causes.
 <ol>
 
   <li> <p> New: After the documentation tool for deal.II has been
-  changed to <a href="http://www.doxygen.org">Doxygen</a>, it is delivered in two
+  changed to <a href="https://www.doxygen.org">Doxygen</a>, it is delivered in two
   tar-files. Additional to the traditional source tarball, the preprocessed
   documentation is available ready for reading with a web browser.
   <br>
@@ -179,7 +179,7 @@ inconvenience this causes.
        </p>
 
   <li> <p> New: deal.II is now able to interface to the
-       <a href="http://www-users.cs.umn.edu/~karypis/metis/index.html"
+       <a href="https://www-users.cs.umn.edu/~karypis/metis/index.html"
        target="_top">METIS</a> library to generate domain partitionings. This
        is enabled if a METIS installation is detected, which either happens
        automatically in <code>./configure</code>, or
@@ -203,7 +203,7 @@ inconvenience this causes.
        </p>
 
   <li> <p> New: deal.II now comes with a complete set of
-       wrappers classes for <a href="http://www.mcs.anl.gov/petsc/"
+       wrappers classes for <a href="https://www.mcs.anl.gov/petsc/"
        target="_top">PETSc</a> vectors, matrices, linear solvers and
        preconditioners. Many of the algorithms in deal.II have also been
        updated to make use of these wrappers. All of this is only enabled if a
@@ -325,9 +325,9 @@ inconvenience this causes.
        </p>
 
   <li> <p> New: First steps to a migration of the documentation from
-       <tt>kdoc</tt> to <a href="http://www.doxygen.org">Doxygen</a> have
+       <tt>kdoc</tt> to <a href="https://www.doxygen.org">Doxygen</a> have
        been done. It can be generated after installing <a
-       href="http://www.doxygen.org">Doxygen</a> by calling <tt>make</tt>
+       href="https://www.doxygen.org">Doxygen</a> by calling <tt>make</tt>
        in <tt>doc/doxygen</tt> and using the preliminary link page <a
        href="../doxygen/index.html">index.html</a> in that directory.
        <br>
@@ -593,7 +593,7 @@ inconvenience this causes.
   </p>
 
   <li> <p>
-       New: Added support for <a href="http://www.gmsh.info"
+       New: Added support for <a href="https://www.gmsh.info"
        target="_top">gmsh</a> mesh format in <code>GridIn::read_msh</code>.
        <br>
        (Luca Heltai 2004/04/21)

--- a/doc/news/5.0.0-vs-5.1.0.h
+++ b/doc/news/5.0.0-vs-5.1.0.h
@@ -123,7 +123,7 @@ inconvenience this causes.
        Wolfgang.
        <br>
        Deal.II comes with its own copy of the <a
-       href="http://www.cise.ufl.edu/research/sparse/umfpack/">UMFPACK</a>
+       href="https://www.cise.ufl.edu/research/sparse/umfpack/">UMFPACK</a>
        library, courtesy of its author. In order to use, follow the steps
        listed <a href="../readme.html#umfpack">here</a>. Note that UMFPACK
        comes with its own license; to use UMFPACK, please read the <a

--- a/doc/news/5.1.0-vs-5.2.0.h
+++ b/doc/news/5.1.0-vs-5.2.0.h
@@ -504,8 +504,8 @@ inconvenience this causes.
   <li> <p>
        New: Class <code>FunctionParser</code>. Wrapper
        class for the fparser library (see
-       <a href="http://warp.povusers.org/FunctionParser/">
-       http://warp.povusers.org/FunctionParser/</a>).
+       <a href="https://warp.povusers.org/FunctionParser/">
+       https://warp.povusers.org/FunctionParser/</a>).
        <br>
        (Luca Heltai, 2005/03/07).
        </p>

--- a/doc/news/5.2.0-vs-6.0.0.h
+++ b/doc/news/5.2.0-vs-6.0.0.h
@@ -187,7 +187,7 @@ inconvenience this causes.
        lexicographic ordering (with x running fastest) wherever
        possible. For more information on the new numbering scheme, see
        the <a
-       href="http://ganymed.iwr.uni-heidelberg.de/pipermail/dealii/2005/000827.html">announcement</a>
+       href="https://ganymed.iwr.uni-heidelberg.de/pipermail/dealii/2005/000827.html">announcement</a>
        on the mailing list.  <br> The ordering of vertices in <code>CellData</code> given to the <code>Triangulation::create_triangulation</code>
        function has been changed accordingly. For backward
        compatibility there is now a new <code>Triangulation::create_triangulation_compatibility</code>

--- a/doc/news/6.1.0-vs-6.2.0.h
+++ b/doc/news/6.1.0-vs-6.2.0.h
@@ -238,7 +238,7 @@ inconvenience this causes.
   <p>
   Changed: The subversion repository for deal.II development is now
   located on commercially hosted space at <a
-  href="http://www.dealii.org/svn/dealii/">http://www.dealii.org/svn/dealii/</a>.
+  href="https://www.dealii.org/svn/dealii/">https://www.dealii.org/svn/dealii/</a>.
   <br>
   (GK 2009/01/20)
   </p>
@@ -247,7 +247,7 @@ inconvenience this causes.
   <li>
   <p>
   Changed: Some parts of the library used to use classes and functions
-  from the <a href="http://www.boost.org/">BOOST</a> library. Since
+  from the <a href="https://www.boost.org/">BOOST</a> library. Since
   many of the components of BOOST have been voted into what will be the
   next C++ standard, we now use a namespace std_cxx1x (coined on the
   provisional name C++0x used for the next C++ standard) into which we
@@ -273,7 +273,7 @@ inconvenience this causes.
 
   <li>
   <p>
-  Updated: The version of the <a href="http://www.boost.org/">BOOST</a>
+  Updated: The version of the <a href="https://www.boost.org/">BOOST</a>
   library that is in the <code>contrib/</code> directory and is used in
   various places of the library has been upgraded to 1.37.
   <br>
@@ -378,7 +378,7 @@ inconvenience this causes.
 
   <li>
   <p>
-  Updated: The version of the <a href="http://www.boost.org/">BOOST</a>
+  Updated: The version of the <a href="https://www.boost.org/">BOOST</a>
   library that is in the <code>contrib/</code> directory and is used in
   various places of the library has been upgraded to 1.36.
   <br>
@@ -1080,7 +1080,7 @@ inconvenience this causes.
   <li>
   <p>
   New: The GridIn::read_msh function can now read version 2 of the MSH format described
-  <a target="_top" href="http://gmsh.info/doc/texinfo/gmsh.html">here</a>.
+  <a target="_top" href="https://gmsh.info/doc/texinfo/gmsh.html">here</a>.
   <br>
   (WB 2008/10/07)
   </p>

--- a/doc/news/6.2.0-vs-6.3.0.h
+++ b/doc/news/6.2.0-vs-6.3.0.h
@@ -173,7 +173,7 @@ inconvenience this causes.
 
    <li>
    <p>
-   New: The version of <a href="http://www.boost.org/">boost</a>
+   New: The version of <a href="https://www.boost.org/">boost</a>
    included in the <code>contrib/</code> directory has been updated
    to 1.41.0.
    <br>
@@ -195,7 +195,7 @@ inconvenience this causes.
    <li>
    <p>
    New: A report has been added on the
-   <a href="http://www.dealii.org/reports/codimension-one/desimone-heltai-manigrasso.pdf"
+   <a href="https://www.dealii.org/reports/codimension-one/desimone-heltai-manigrasso.pdf"
    target="body">codimension one</a> capabilities
    of the library (by Antonio DeSimone, Luca Heltai
    and Cataldo Manigrasso, SISSA, Trieste, Italy). It
@@ -278,7 +278,7 @@ inconvenience this causes.
    a task-based, rather than thread-based approach, in which one
    uses a high-level description of <i>what</i> needs to be done,
    rather than how these jobs have to be mapped onto threads. We then
-   use the <a href="http://www.threadingbuildingblocks.org">Threading
+   use the <a href="https://www.threadingbuildingblocks.org">Threading
    Building Blocks (TBB) library</a> to schedule tasks onto available
    hardware resources. This new scheme of describing parallism and
    various abstractions to make programming in this framework easier

--- a/doc/news/6.3.0-vs-6.3.1.h
+++ b/doc/news/6.3.0-vs-6.3.1.h
@@ -98,7 +98,7 @@ inconvenience this causes.
   <li>
   <p>Fixed: Linking with more than one of the deal.II 1d, 2d, or 3d libraries
   when using static libraries did not work. This is now fixed. However, due to
-  GCC bug <a href="http://gcc.gnu.org/bugzilla/show_bug.cgi?id=10591"
+  GCC bug <a href="https://gcc.gnu.org/bugzilla/show_bug.cgi?id=10591"
   target="_top">10591</a>, GCC versions prior to and including 4.1.x will
   still not work. Working with shared libraries was not and is not affected
   by this problem.

--- a/doc/news/6.3.0-vs-7.0.0.h
+++ b/doc/news/6.3.0-vs-7.0.0.h
@@ -135,7 +135,7 @@ through DoFHandler::get_tria() and DoFHandler::get_fe(), respectively.
   (Sebastian Pauletti, Andrea Bonito, Luca Heltai, WB, 2010/12/06)
   </p></li>
 
-  <li><p>Updated: The version of the <a href="http://www.threadingbuildingblocks.org">Threading
+  <li><p>Updated: The version of the <a href="https://www.threadingbuildingblocks.org">Threading
   Building Blocks (TBB)</a> shipped with deal.II has been updated
   to release 3.0 Update 3 (Commercially aligned version).
   <br>
@@ -243,7 +243,7 @@ through DoFHandler::get_tria() and DoFHandler::get_fe(), respectively.
   <li>
   <p>Fixed: Linking with more than one of the deal.II 1d, 2d, or 3d libraries
   when using static libraries did not work. This is now fixed. However, due to
-  GCC bug <a href="http://gcc.gnu.org/bugzilla/show_bug.cgi?id=10591"
+  GCC bug <a href="https://gcc.gnu.org/bugzilla/show_bug.cgi?id=10591"
   target="_top">10591</a>, GCC versions prior to and including 4.1.x will
   still not work. Working with shared libraries was not and is not affected
   by this problem.
@@ -252,7 +252,7 @@ through DoFHandler::get_tria() and DoFHandler::get_fe(), respectively.
   </p>
 
   <li>
-  <p>Updated: The version of <a href="http://www.boost.org/">boost</a>
+  <p>Updated: The version of <a href="https://www.boost.org/">boost</a>
    included in the <code>contrib/</code> directory has been updated
    to 1.43.0.
   <br>
@@ -318,7 +318,7 @@ independent of the dimension.
   </p>
 
   <li><p> New: The ParameterHandler class is now built on the
-  <a href="http://www.boost.org" target="_top">boost</a>
+  <a href="https://www.boost.org" target="_top">boost</a>
   <code>property_tree</code> library which provides a much better
   foundation for extensions. In particular, the description of parameters
   can now be exported in XML and JSON formats for processing with external

--- a/doc/news/7.0.0-vs-7.1.0.h
+++ b/doc/news/7.0.0-vs-7.1.0.h
@@ -156,7 +156,7 @@ flag, resulting in savings in disk space on the order of 230 MB.
 (Wolfgang Bangerth, 2011/09/22)
 
 <li> New: deal.II can now be configured and built with the
-<a href="http://clang.llvm.org">Clang C++ frontend of the LLVM compiler</a>.
+<a href="https://clang.llvm.org">Clang C++ frontend of the LLVM compiler</a>.
 <br>
 (Timo Heister, Wolfgang Bangerth, 2011/08/20)
 

--- a/doc/news/7.1.0-vs-7.2.0.h
+++ b/doc/news/7.1.0-vs-7.2.0.h
@@ -429,7 +429,7 @@ into a ConstraintMatrix.
 (Matthias Maier, 2012/05/22)
 
 <li> New: The GridIn::read_unv function can now read meshes generated
-by the Salome framework, see http://www.salome-platform.org/ .
+by the Salome framework, see https://www.salome-platform.org/ .
 <br>
 (Valentin Zingan, 2012/04/27)
 

--- a/doc/news/7.3.0-vs-8.0.0.h
+++ b/doc/news/7.3.0-vs-8.0.0.h
@@ -151,7 +151,7 @@ this function.
   (Juan Carlos Araujo Cabarcas, 2013/03/25)
   </li>
 
-  <li> New: deal.II now uses <a href="http://www.cmake.org/">CMake</a>
+  <li> New: deal.II now uses <a href="https://www.cmake.org/">CMake</a>
   as its configuration and build tool. Please read through the
   readme and other installation files for information about how the
   installation process has changed.

--- a/doc/news/8.0.0-vs-8.1.0.h
+++ b/doc/news/8.0.0-vs-8.1.0.h
@@ -176,7 +176,7 @@ inconvenience this causes.
   (Bruno Turcksin, Wolfgang Bangerth, 2013/10/26)
   </li>
 
-  <li> New: The testsuite is now ported to <a href="http://www.cmake.org/">
+  <li> New: The testsuite is now ported to <a href="https://www.cmake.org/">
   CMake</a> and uses CTest as test driver.
   <br>
   (Wolfgang Bangerth, Timo Heister, Matthias Maier, Bruno Turcksin, 2013/10/20)
@@ -606,7 +606,7 @@ inconvenience this causes.
   </li>
 
   <li>
-  Fixed: Under some circumstances (see http://code.google.com/p/dealii/issues/detail?id=82)
+  Fixed: Under some circumstances (see https://code.google.com/p/dealii/issues/detail?id=82)
   the DoFTools::make_periodicity_constraints() function could create cycles in
   the ConstraintMatrix object. This is now fixed.
   <br>
@@ -621,7 +621,7 @@ inconvenience this causes.
 
   <li>
   New: TableHandler::write_text() now also supports output in
-  org-mode (http://orgmode.org/) format via a new entry in the
+  org-mode (https://orgmode.org/) format via a new entry in the
   TableHandler::TextOutputFormat enumeration.
   <br>
   (Oleh Krehel, 2013/08/15)

--- a/doc/news/8.5.0-vs-9.0.0.h
+++ b/doc/news/8.5.0-vs-9.0.0.h
@@ -835,7 +835,7 @@ inconvenience this causes.
 
  <li>
   New: Added support for the Open Asset Import Library (Assimp)
-  (http://assimp.sourceforge.net/). This library can be used
+  (https://assimp.sourceforge.net/). This library can be used
   to read about 40 different 3D graphics formats, used in 3D
   modelers (such as Blender, Maya, etc.). Some of these formats
   contain mesh information, that in turn can be read

--- a/doc/readme.html
+++ b/doc/readme.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+"https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="https://www.w3.org/1999/xhtml">
 
 <head>
     <title>The deal.II Readme</title>
@@ -54,7 +54,7 @@
 
     <p>
       <acronym>deal.II</acronym> is mostly developed on Linux using the
-      <a href="http://gcc.gnu.org">GCC</a> compiler. However, it is
+      <a href="https://gcc.gnu.org">GCC</a> compiler. However, it is
       not platform specific and we strive to keep the source code
       compliant with
       the <a href="https://en.cppreference.com/w/cpp/links">C++ 2014
@@ -90,47 +90,47 @@
     </p>
     <ul>
         <li>
-            <a href="http://www.cmake.org/" target="_top">CMake</a> version 3.3.0 or later
+            <a href="https://www.cmake.org/" target="_top">CMake</a> version 3.3.0 or later
         </li>
 
         <li>
-            <a href="http://www.gnu.org/software/make/" target="_top">GNU make</a>, version 3.78 or later (or any other generator supported by CMake)
+            <a href="https://www.gnu.org/software/make/" target="_top">GNU make</a>, version 3.78 or later (or any other generator supported by CMake)
         </li>
 
         <li>
             For generating the documentation:
-            <a href="http://www.perl.org/" target="_top">Perl 5.x</a>,
-            <a href="http://www.doxygen.org/" target="_top">doxygen</a> and <code>dot</code>, which is part of the
-            <a href="http://www.graphviz.org" target="_top">GraphViz</a> package
+            <a href="https://www.perl.org/" target="_top">Perl 5.x</a>,
+            <a href="https://www.doxygen.org/" target="_top">doxygen</a> and <code>dot</code>, which is part of the
+            <a href="https://www.graphviz.org" target="_top">GraphViz</a> package
         </li>
 
         <li>
             For debugging programs, we have found that the
-            <a href="http://www.gnu.org/software/gdb/" target="_top">GNU
-	    debugger GDB</a> is an invaluable tool. GDB is a text-based tool not always easy to use; <a href="http://www.kdbg.org/" target="_top">kdbg</a>, is one of many graphical user interfaces for it. Most integrated development environments
-            like <a href="http://www.kdevelop.org/" target="_top">kdevelop</a> or <a href="http://eclipse.org/" target="_top">Eclipse</a> have built in debuggers as well. <acronym>deal.II</acronym> has some support for pretty printing its own classes
+            <a href="https://www.gnu.org/software/gdb/" target="_top">GNU
+	    debugger GDB</a> is an invaluable tool. GDB is a text-based tool not always easy to use; <a href="https://www.kdbg.org/" target="_top">kdbg</a>, is one of many graphical user interfaces for it. Most integrated development environments
+            like <a href="https://www.kdevelop.org/" target="_top">kdevelop</a> or <a href="https://eclipse.org/" target="_top">Eclipse</a> have built in debuggers as well. <acronym>deal.II</acronym> has some support for pretty printing its own classes
             through GDB; see <a href="users/gdb.html">the GDB configuration guide</a> for setup information.
         </li>
 
         <li>
             <p>
                 The library generates output in formats readable by
-                <a href="http://www.gnuplot.info/" target="_top">GNUPLOT</a>,
-                <a href="http://www.generalmeshviewer.com/" target="_top">GMV
+                <a href="https://www.gnuplot.info/" target="_top">GNUPLOT</a>,
+                <a href="https://www.generalmeshviewer.com/" target="_top">GMV
  	  (general mesh viewer)</a>,
-                <a href="http://www.tecplot.com/" target="_top">Tecplot</a> (ASCII and binary),
-                <a href="http://www.vtk.org/" target="_top">Visualization Toolkit (Vtk)</a>,
-                <a href="http://www.avs.com" target="_top">AVS Explorer</a>,
-                <a href="http://www.opendx.org" target="_top">Open DX</a>,
-                <a href="http://www.povray.org" target="_top">Povray</a>, and directly to Encapsulated Postscript.
+                <a href="https://www.tecplot.com/" target="_top">Tecplot</a> (ASCII and binary),
+                <a href="https://www.vtk.org/" target="_top">Visualization Toolkit (Vtk)</a>,
+                <a href="https://www.avs.com" target="_top">AVS Explorer</a>,
+                <a href="https://www.opendx.org" target="_top">Open DX</a>,
+                <a href="https://www.povray.org" target="_top">Povray</a>, and directly to Encapsulated Postscript.
             </p>
 
             <p>
                 <code>gnuplot</code> and a postscript viewer (for <code>eps</code>) should be available almost everywhere. In the last few years, most new visualization programs have moved to support
                 <code>vtk</code>/<code>vtu</code> format. There are a number of excellent programs that can read <code>vtk</code> and
                 <code>vtu</code>, such as
-                <a href="http://www.llnl.gov/visit/" target="_top">VisIt</a>,
-                <a href="http://www.paraview.org/" target="_top">ParaView</a>, as well as others. Povray is freely available for almost all platforms. AVS is a commercial program available for most Unix flavors. Tecplot is a commercial program available
+                <a href="https://www.llnl.gov/visit/" target="_top">VisIt</a>,
+                <a href="https://www.paraview.org/" target="_top">ParaView</a>, as well as others. Povray is freely available for almost all platforms. AVS is a commercial program available for most Unix flavors. Tecplot is a commercial program available
                 for Windows and most Unix platforms.
             </p>
             <p>
@@ -167,7 +167,7 @@
 
     <p>
         <acronym>deal.II</acronym> uses the
-        <a href="http://www.cmake.org/" target="_top">CMake</a> integrated configuration and build system. Unpacking will create a subdirectory <tt>deal.II/</tt> in the current directory. Then do the following steps to configure the build process (make sure the installation directory is not the same as the location where you unpacked <tt>deal.II/</tt>):</p>
+        <a href="https://www.cmake.org/" target="_top">CMake</a> integrated configuration and build system. Unpacking will create a subdirectory <tt>deal.II/</tt> in the current directory. Then do the following steps to configure the build process (make sure the installation directory is not the same as the location where you unpacked <tt>deal.II/</tt>):</p>
 
     <pre>
   mkdir build
@@ -267,8 +267,8 @@
     <h3>Configuring and building the documentation</h3>
 
     <p>
-        All the documentation about the version that you downloaded and that can be found at the <a href="http://www.dealii.org/" target="_top">
-      http://www.dealii.org/</a> domain can also be generated locally. To do so, invoke <code>cmake</code> in the build instructions above as follows:
+        All the documentation about the version that you downloaded and that can be found at the <a href="https://www.dealii.org/" target="_top">
+      https://www.dealii.org/</a> domain can also be generated locally. To do so, invoke <code>cmake</code> in the build instructions above as follows:
     </p>
 
     <pre>
@@ -280,8 +280,8 @@
     <p>
         As usual, you can pass <code>-jN</code> to <code>make</code>
         in order to use more than one processor.
-        For this to succeed, you will need <a href="http://www.perl.org/" target="_top">Perl 5.x</a>,
-        <a href="http://www.doxygen.org/" target="_top">doxygen</a> and <code>dot</code> (which is part of the <a href="http://www.graphviz.org" target="_top">GraphViz</a> package) to be installed.
+        For this to succeed, you will need <a href="https://www.perl.org/" target="_top">Perl 5.x</a>,
+        <a href="https://www.doxygen.org/" target="_top">doxygen</a> and <code>dot</code> (which is part of the <a href="https://www.graphviz.org" target="_top">GraphViz</a> package) to be installed.
     </p>
 
     <p>
@@ -327,13 +327,13 @@
         <li>
             <p>
                 <i>Threading</i>: By default, deal.II supports parallelism between multiple cores on the same machine using threads and a task-based model built on the
-                <a href="http://threadingbuildingblocks.org/" target="_top">Threading Building Blocks</a>. You can switch threading inside the library off by passing the <code>-DDEAL_II_WITH_TBB=OFF</code> argument to <code>cmake</code>.
+                <a href="https://threadingbuildingblocks.org/" target="_top">Threading Building Blocks</a>. You can switch threading inside the library off by passing the <code>-DDEAL_II_WITH_TBB=OFF</code> argument to <code>cmake</code>.
             </p>
         </li>
 
         <li>
             <p>
-                <i>MPI</i>: To enable parallel computations beyond a single node using the <a href="http://mpi-forum.org/" target="_top">Message
+                <i>MPI</i>: To enable parallel computations beyond a single node using the <a href="https://mpi-forum.org/" target="_top">Message
 	  Passing Interface (MPI)</a>, pass the
                 <code>-DDEAL_II_WITH_MPI=ON</code> argument to <code>cmake</code>. If <code>cmake</code> found MPI but you specifically do not want to use it, then pass <code>-DDEAL_II_WITH_MPI=OFF</code>.
                 The minimal supported version is MPI-3.0.
@@ -365,7 +365,7 @@
     <p>
         When configuring interfacing to external libraries, the
         <code>cmake</code> script by default tries to find all of these libraries in a number of standard locations on your file system. For <i>optional</i> interfaces, it gives up if the library is not found and <acronym>deal.II</acronym> will be built
-        without support for them. However, there is one interface that we <i>need</i> to have: <a href="http://www.boost.org/" target="_top">BOOST 1.59</a> or newer. If it is not found externally <code>cmake</code> will resort to the bundled boost version
+        without support for them. However, there is one interface that we <i>need</i> to have: <a href="https://www.boost.org/" target="_top">BOOST 1.59</a> or newer. If it is not found externally <code>cmake</code> will resort to the bundled boost version
         that is part of the <acronym>deal.II</acronym> tar file.
     </p>
 
@@ -417,23 +417,23 @@
         </dd>
 
         <dt><a name="ARPACK"/>
-	<a href="http://www.caam.rice.edu/software/ARPACK/" target="_top">ARPACK</a></dt>
+	<a href="https://www.caam.rice.edu/software/ARPACK/" target="_top">ARPACK</a></dt>
         <dd>
             <p>
-                <a href="http://www.caam.rice.edu/software/ARPACK/" target="_top">ARPACK</a> is a library for computing large scale eigenvalue problems.
-                <a href="http://www.caam.rice.edu/software/ARPACK/" target="_top">ARPACK</a> should be readily packaged by most Linux distributions. To use a self compiled version, pass
+                <a href="https://www.caam.rice.edu/software/ARPACK/" target="_top">ARPACK</a> is a library for computing large scale eigenvalue problems.
+                <a href="https://www.caam.rice.edu/software/ARPACK/" target="_top">ARPACK</a> should be readily packaged by most Linux distributions. To use a self compiled version, pass
                 <code>-DARPACK_DIR=/path/to/arpack</code> to the deal.II CMake call. For a detailed description on how to compile ARPACK and linking with deal.II, see
                 <a href="external-libs/arpack.html" target="body">this page</a>.
             </p>
         </dd>
 
         <dt><a name="Assimp"/>
-             <a href="http://www.assimp.org/" target="_top">Assimp</a></dt>
+             <a href="https://www.assimp.org/" target="_top">Assimp</a></dt>
         <dd>
             <p>
-                <a href="http://www.assimp.org/" target="_top"></a> is a portable Open Source library to import various well-known 3D model formats in a uniform manner. A subset of these formats can be read from within deal.II to generate two-dimensional
+                <a href="https://www.assimp.org/" target="_top"></a> is a portable Open Source library to import various well-known 3D model formats in a uniform manner. A subset of these formats can be read from within deal.II to generate two-dimensional
                 meshes, possibly embedded in a three-dimensional space.
-                <a href="http://www.assimp.org/" target="_top">Assimp</a> should be readily packaged by most Linux distributions. To use a self compiled version, pass
+                <a href="https://www.assimp.org/" target="_top">Assimp</a> should be readily packaged by most Linux distributions. To use a self compiled version, pass
                 <code>-DASSIMP_DIR=/path/to/assimp</code> to the deal.II CMake call.
             </p>
         </dd>
@@ -441,13 +441,13 @@
 
         <dt>
 	<a name="blas"></a>
-	<a href="http://www.netlib.org/blas/" target="_top">BLAS</a>,
-	<a href="http://www.netlib.org/lapack/" target="_top">LAPACK</a>
+	<a href="https://www.netlib.org/blas/" target="_top">BLAS</a>,
+	<a href="https://www.netlib.org/lapack/" target="_top">LAPACK</a>
       </dt>
         <dd>
             <p>
-                <a href="http://www.netlib.org/blas/" target="_top">BLAS</a> (the <i>Basic Linear Algebra Subroutines</i>) and
-                <a href="http://www.netlib.org/lapack/" target="_top">LAPACK</a> (
+                <a href="https://www.netlib.org/blas/" target="_top">BLAS</a> (the <i>Basic Linear Algebra Subroutines</i>) and
+                <a href="https://www.netlib.org/lapack/" target="_top">LAPACK</a> (
                 <i>Linear Algebra Package</i>) are two packages that support low-level linear algebra operations on vectors and dense matrices. Both libraries should be packaged by almost all Linux distributions and found automatically whenever available.
                 (You might have to install development versions of the libraries for <acronym>deal.II</acronym> being able to use them). For details on how to set up <acronym>deal.II</acronym> with a non standard BLAS/LAPACK implementation,
                 see <a href="external-libs/lapack.html" target="body">this page</a>.
@@ -505,10 +505,10 @@
             </dd>
 
             <dt><a name="Gmsh"/>
-             <a href="http://gmsh.info/" target="_top">Gmsh</a></dt>
+             <a href="https://gmsh.info/" target="_top">Gmsh</a></dt>
             <dd>
                 <p>
-                    <a href="http://gmsh.info/" target="_top">Gmsh</a>
+                    <a href="https://gmsh.info/" target="_top">Gmsh</a>
                     is a 3D mesh generator. The executable can be used
                     to create meshes from within deal.II by specifying
                     the relevant input data. Gmsh should be readily
@@ -520,20 +520,20 @@
                 </p>
             </dd>
 
-            <dt><a name="GSL"></a><a href="http://www.gnu.org/software/gsl/">GSL</a></dt>
+            <dt><a name="GSL"></a><a href="https://www.gnu.org/software/gsl/">GSL</a></dt>
             <dd>
                 <p>
-                    The <a href="http://www.gnu.org/software/gsl/">GNU Scientific Library</a> provides a wide range of mathematical routines such as random number generators, special functions and least-squares fitting.
-                    <a href="http://www.gnu.org/software/gsl/">GSL</a> should be readily packaged by most Linux distributions. To use a self compiled version, pass
+                    The <a href="https://www.gnu.org/software/gsl/">GNU Scientific Library</a> provides a wide range of mathematical routines such as random number generators, special functions and least-squares fitting.
+                    <a href="https://www.gnu.org/software/gsl/">GSL</a> should be readily packaged by most Linux distributions. To use a self compiled version, pass
                     <code>-DGSL_DIR=/path/to/gsl</code> to the deal.II CMake call.
                 </p>
             </dd>
 
-            <dt><a name="HDF5"></a><a href="http://www.hdfgroup.org/HDF5/">HDF5</a></dt>
+            <dt><a name="HDF5"></a><a href="https://www.hdfgroup.org/HDF5/">HDF5</a></dt>
             <dd>
                 <p>
-                    The <a href="http://www.hdfgroup.org/HDF5/">HDF5 library</a> provides graphical output capabilities in <code>HDF5/XDMF</code> format.
-                    <a href="http://www.hdfgroup.org/HDF5/">HDF5</a> should be readily packaged by most Linux distributions. To use a self compiled version, pass
+                    The <a href="https://www.hdfgroup.org/HDF5/">HDF5 library</a> provides graphical output capabilities in <code>HDF5/XDMF</code> format.
+                    <a href="https://www.hdfgroup.org/HDF5/">HDF5</a> should be readily packaged by most Linux distributions. To use a self compiled version, pass
                     <code>-DHDF5_DIR=/path/to/hdf5</code> to the deal.II CMake call.
                 </p>
             </dd>
@@ -551,11 +551,11 @@
             </dd>
 
 
-            <dt><a name="metis"></a><a href="http://glaros.dtc.umn.edu/gkhome/metis/metis/overview"
+            <dt><a name="metis"></a><a href="https://glaros.dtc.umn.edu/gkhome/metis/metis/overview"
 	     target="_top">METIS</a></dt>
             <dd>
                 <p>
-                    <a href="http://glaros.dtc.umn.edu/gkhome/metis/metis/overview" target="_top">METIS</a> is a library that provides various methods to partition graphs. <acronym>deal.II</acronym> uses it in programs like the step-17 tutorial to partition
+                    <a href="https://glaros.dtc.umn.edu/gkhome/metis/metis/overview" target="_top">METIS</a> is a library that provides various methods to partition graphs. <acronym>deal.II</acronym> uses it in programs like the step-17 tutorial to partition
                     a mesh for parallel computing. To use a self compiled version, pass
                     <code>-DMETIS_DIR=/path/to/metis</code> to the deal.II CMake call.
                     <acronym>deal.II</acronym> supports METIS 5 and later.
@@ -569,32 +569,32 @@
 
             <dt>
 	<a name="muparser"></a>
-	<a href="http://muparser.beltoforion.de/">muparser</a>
+	<a href="https://muparser.beltoforion.de/">muparser</a>
       </dt>
             <dd>
                 <p>
-                    <a href="http://muparser.beltoforion.de/">muparser</a> is a library that allows to enter functions in text form and have them interpreted at run time. This is particularly useful in input parameter files. <code>cmake</code> will usually
+                    <a href="https://muparser.beltoforion.de/">muparser</a> is a library that allows to enter functions in text form and have them interpreted at run time. This is particularly useful in input parameter files. <code>cmake</code> will usually
                     find the version of this library that comes bundled with <acronym>deal.II</acronym>, but you can specify <code>-DMUPARSER_DIR=/path/to/muparser</code> if desired.
                 </p>
             </dd>
 
             <dt>
 	<a name="opencascade"></a>
-	<a href="http://www.opencascade.org/">OpenCASCADE</a>
+	<a href="https://www.opencascade.org/">OpenCASCADE</a>
       </dt>
             <dd>
                 Open CASCADE Technology is a software development kit for applications dealing with 3D CAD data, freely available in open source. Our internal interface works with the legacy version of OpenCASCADE, which you can download and install from the official
                 website, as well as with the OpenCASCADE Community Edition (OCE, available at
                 <a href="https://github.com/tpaviot/oce">https://github.com/tpaviot/oce</a>), which offers a cmake interface for its compilation. Alternatively, you can install one of the many external applications that ship with OpenCASCADE internally
                 (for example
-                <a href="http://www.salome-platform.org/">SALOME</a>, or
-                <a href="http://www.freecadweb.org/">FreeCAD</a>). Further installation instructions can be found <a href="external-libs/opencascade.html" target="body">here</a>.
+                <a href="https://www.salome-platform.org/">SALOME</a>, or
+                <a href="https://www.freecadweb.org/">FreeCAD</a>). Further installation instructions can be found <a href="external-libs/opencascade.html" target="body">here</a>.
             </dd>
 
-            <dt><a name="p4est"></a><a href="http://www.p4est.org/" target="_top">p4est</a></dt>
+            <dt><a name="p4est"></a><a href="https://www.p4est.org/" target="_top">p4est</a></dt>
             <dd>
                 <p>
-                    <a href="http://www.p4est.org/" target="_top">p4est</a> is a library that <acronym>deal.II</acronym> uses to distribute very large meshes across multiple processors (think meshes with a billion cells on 10,000 processors). Using and
+                    <a href="https://www.p4est.org/" target="_top">p4est</a> is a library that <acronym>deal.II</acronym> uses to distribute very large meshes across multiple processors (think meshes with a billion cells on 10,000 processors). Using and
                     installing p4est is discussed <a href="external-libs/p4est.html" target="body">here</a>. To use a self compiled version, pass the argument
                     <code>-DP4EST_DIR=/path/to/p4est</code> to the
                     <code>cmake</code> command.
@@ -602,13 +602,13 @@
             </dd>
 
 
-            <dt><a name="petsc"></a><a href="http://www.mcs.anl.gov/petsc/"
+            <dt><a name="petsc"></a><a href="https://www.mcs.anl.gov/petsc/"
 		 target="_top">PETSc</a></dt>
             <dd>
                 <p>
-                    <a href="http://www.mcs.anl.gov/petsc/" target="_top">PETSc</a> is a library that supports parallel linear algebra and many other things.
+                    <a href="https://www.mcs.anl.gov/petsc/" target="_top">PETSc</a> is a library that supports parallel linear algebra and many other things.
 
-                    <a href="http://www.mcs.anl.gov/petsc/" target="_top">PETSc</a> is already packaged by some Linux distributions and should be found automatically if present. To use a
+                    <a href="https://www.mcs.anl.gov/petsc/" target="_top">PETSc</a> is already packaged by some Linux distributions and should be found automatically if present. To use a
                     self compiled version of PETSc, add <code>-DPETSC_DIR=/path/to/petsc
 	  -DPETSC_ARCH=architecture</code> to the argument list for
                     <code>cmake</code>. The values for these arguments must be the same as those specified when building PETSc.
@@ -623,11 +623,11 @@
 
             <dt>
 	<a name="scalapack"></a>
-	<a href="http://www.netlib.org/scalapack/">ScaLAPACK</a>
+	<a href="https://www.netlib.org/scalapack/">ScaLAPACK</a>
       </dt>
             <dd>
                 <p>
-                    <a href="http://www.netlib.org/scalapack/">scalapack</a> is a library of high-performance linear algebra routines for parallel distributed memory machines. ScaLAPACK solves dense and banded linear systems, least squares problems, eigenvalue
+                    <a href="https://www.netlib.org/scalapack/">scalapack</a> is a library of high-performance linear algebra routines for parallel distributed memory machines. ScaLAPACK solves dense and banded linear systems, least squares problems, eigenvalue
                     problems, and singular value problems. In order to enable this feature, add
                     <code>-DSCALAPACK_DIR=/path/to/scalapack</code> to the argument list for
                     <code>cmake</code>. If ScaLAPACK does not have embedded BLACS, you might need to pass <code>-DBLACS_DIR=/path/to/blacs</code> as well.
@@ -669,23 +669,23 @@
                 </p>
             </dd>
 
-            <dt><a name="tbb"></a><a href="http://www.threadingbuildingblocks.org/"
+            <dt><a name="tbb"></a><a href="https://www.threadingbuildingblocks.org/"
 	     target="_top">Threading Building Blocks (TBB)</a></dt>
             <dd>
                 <p>
-                    The <a href="http://www.threadingbuildingblocks.org/" target="_top">Threading Building Blocks (TBB)</a> is a library that provides advanced services for using multiple processor cores on a single machine and is used in <acronym>deal.II</acronym>                    to parallelize many operations. If not found in a system-wide location, <code>cmake</code> will resort to the version bundled as part of the <acronym>deal.II</acronym> download. It is always enabled unless threads are explicitly disabled,
+                    The <a href="https://www.threadingbuildingblocks.org/" target="_top">Threading Building Blocks (TBB)</a> is a library that provides advanced services for using multiple processor cores on a single machine and is used in <acronym>deal.II</acronym>                    to parallelize many operations. If not found in a system-wide location, <code>cmake</code> will resort to the version bundled as part of the <acronym>deal.II</acronym> download. It is always enabled unless threads are explicitly disabled,
                     see <a href="#optional">above</a>.
                 </p>
             </dd>
 
-            <dt><a name="trilinos"></a><a href="http://trilinos.org" target="_top">Trilinos</a></dt>
+            <dt><a name="trilinos"></a><a href="https://trilinos.org" target="_top">Trilinos</a></dt>
             <dd>
                 <p>
-                  <a href="http://trilinos.org"
+                  <a href="https://trilinos.org"
                      target="_top">Trilinos</a> is a library for
                   parallel linear algebra and all sorts of other
                   things as well. To interface with a self compiled
-                  version of <a href="http://trilinos.org"
+                  version of <a href="https://trilinos.org"
                                 target="_top">Trilinos</a>
                   add <code>-DTRILINOS_DIR=/path/to/trilinos</code>
                   to the argument list
@@ -704,11 +704,11 @@
             </dd>
 
 
-            <dt><a name="umfpack"></a><a href="http://faculty.cse.tamu.edu/davis/suitesparse.html"
+            <dt><a name="umfpack"></a><a href="https://faculty.cse.tamu.edu/davis/suitesparse.html"
 	     target="_top">UMFPACK</a></dt>
             <dd>
                 <p>
-                    <a href="http://faculty.cse.tamu.edu/davis/suitesparse.html">UMFPACK</a>, which is part of SuiteSparse, is a sparse direct solver that we often use in prototype codes where the goal is to simply get a linear system solved robustly.
+                    <a href="https://faculty.cse.tamu.edu/davis/suitesparse.html">UMFPACK</a>, which is part of SuiteSparse, is a sparse direct solver that we often use in prototype codes where the goal is to simply get a linear system solved robustly.
                     The interface will be enabled by default, either using a version installed on your system of using a version that comes bundled with
                     <acronym>deal.II</acronym>. It can be disabled explicitly by using the
                     <code>-DDEAL_II_WITH_UMFPACK=OFF</code> argument. To use a self compiled version, pass the argument
@@ -722,7 +722,7 @@
                     with it. You can find the license of SuiteSparse inside
                     the SuiteSparse download at the link given above. We
                     include UMFPACK in the deal.II repository courtesy of
-                    its author, <a href="http://faculty.cse.tamu.edu/davis/welcome.html">Timothy A. Davis</a>.
+                    its author, <a href="https://faculty.cse.tamu.edu/davis/welcome.html">Timothy A. Davis</a>.
                 </p>
             </dd>
     </dl>
@@ -745,11 +745,11 @@
     </dd>
 
     <dt><a name="zlib"/>
-              <a href="http://zlib.net/" target="_top">zlib</a></dt>
+              <a href="https://zlib.net/" target="_top">zlib</a></dt>
     <dd>
         <p>
-            <a href="http://zlib.net/" target="_top">zlib</a> is a software library used for lossless data-compression. It is used in deal.II whenever compressed data is to be written.
-            <a href="http://zlib.net/" target="_top">zlib</a> should be readily packaged by most Linux distributions. To use a self compiled version, pass
+            <a href="https://zlib.net/" target="_top">zlib</a> is a software library used for lossless data-compression. It is used in deal.II whenever compressed data is to be written.
+            <a href="https://zlib.net/" target="_top">zlib</a> should be readily packaged by most Linux distributions. To use a self compiled version, pass
             <code>-DZLIB_DIR=/path/to/zlib</code> to the deal.II CMake call.
         </p>
     </dd>
@@ -770,13 +770,13 @@
 
     <p>
         The deal.II library is free software; you can use it, redistribute it, and/or modify it under the terms of the
-        <a href="http://www.gnu.org/licenses/lgpl-2.1.html">GNU Lesser General
+        <a href="https://www.gnu.org/licenses/lgpl-2.1.html">GNU Lesser General
       Public License</a> (LGPL) as published by the Free Software Foundation; either version 2.1 of the License, or (at your option) any later version.
     </p>
     <p>
         This allows you to use the library free of charge for private, academic, or commercial use (under the terms of the LGPL v2.1 or later). You are guaranteed full access to the source code and are encouraged to help in the further development of the library.
         Follow
-        <a href="http://www.dealii.org/license.html" target="body">this
+        <a href="https://www.dealii.org/license.html" target="body">this
         link</a> for detailed information.
     </p>
     <p>
@@ -784,7 +784,7 @@
     <ul>
         <li>
             Detailed license information can be found following
-            <a href="http://www.dealii.org/license.html" target="body">this link</a>.
+            <a href="https://www.dealii.org/license.html" target="body">this link</a>.
         </li>
         <li>
             <b>As a contributor to this project, you agree that any of your
@@ -792,31 +792,31 @@
           the license of the deal.II project granted to you.</b>
         </li>
         <li>
-            We, <a href="http://www.dealii.org/authors.html" target="_top">the deal.II Authors</a>, do not require copyright assignments for contributions. This means that the copyright for code contributions in the deal.II project is held by its respective
+            We, <a href="https://www.dealii.org/authors.html" target="_top">the deal.II Authors</a>, do not require copyright assignments for contributions. This means that the copyright for code contributions in the deal.II project is held by its respective
             contributors who have each agreed to release their contributed code under the terms of the LGPL v2.1 or later.
         </li>
         <li>
             In addition to the terms imposed by the LGPL (version 2.1 or later), we ask for the courtesy that scientific publications presenting results obtained with this libraries acknowledge its use. Please cite one of the papers referenced
-            <a href="http://www.dealii.org/publications.html">here</a>.
+            <a href="https://www.dealii.org/publications.html">here</a>.
         </li>
         <li>
             <acronym>deal.II</acronym> can interface with a number of <a href="#optional-software">other packages</a> that you either have to install yourself. They are, of course, covered by their own licenses. In addition, deal.II comes bundled with
             copies of
-            <a href="http://faculty.cse.tamu.edu/davis/suitesparse.html">
+            <a href="https://faculty.cse.tamu.edu/davis/suitesparse.html">
           UMFPACK</a>,
-            <a href="http://threadingbuildingblocks.org/" target="_top">Threading Building Blocks</a>,
-            <a href="http://www.boost.org/" target="_top">BOOST</a>,
-            <a href="http://github.com/kokkos/kokkos" target="_top">Kokkos</a>, and
-            <a href="http://muparser.beltoforion.de/" target="_top">muparser</a>, courtesy of their authors. These are also covered by their own licenses; please refer to their webpages for more information.
+            <a href="https://threadingbuildingblocks.org/" target="_top">Threading Building Blocks</a>,
+            <a href="https://www.boost.org/" target="_top">BOOST</a>,
+            <a href="https://github.com/kokkos/kokkos" target="_top">Kokkos</a>, and
+            <a href="https://muparser.beltoforion.de/" target="_top">muparser</a>, courtesy of their authors. These are also covered by their own licenses; please refer to their webpages for more information.
         </li>
     </ul>
 
     <hr />
     <div class="right">
-        <a href="http://validator.w3.org/check?uri=referer" target="_top">
-      <img style="border:0" src="http://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
-        <a href="http://jigsaw.w3.org/css-validator/check/referer" target="_top">
-      <img style="border:0;width:88px;height:31px" src="http://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
+        <a href="https://validator.w3.org/check?uri=referer" target="_top">
+      <img style="border:0" src="https://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
+        <a href="https://jigsaw.w3.org/css-validator/check/referer" target="_top">
+      <img style="border:0;width:88px;height:31px" src="https://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
     </div>
 
 </body>

--- a/doc/users/cmake_dealii.html
+++ b/doc/users/cmake_dealii.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	  "http://www.w3.org/TR/html4/loose.dtd">
+	  "https://www.w3.org/TR/html4/loose.dtd">
 <html>
   <head>
     <title>deal.II CMake documentation</title>
@@ -1013,10 +1013,10 @@ make  deal_II.g VERBOSE=ON
 
     <hr />
     <div class="right">
-      <a href="http://validator.w3.org/check?uri=referer" target="_top">
-        <img style="border:0" src="http://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
-      <a href="http://jigsaw.w3.org/css-validator/check/referer" target="_top">
-        <img style="border:0;width:88px;height:31px" src="http://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
+      <a href="https://validator.w3.org/check?uri=referer" target="_top">
+        <img style="border:0" src="https://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
+      <a href="https://jigsaw.w3.org/css-validator/check/referer" target="_top">
+        <img style="border:0;width:88px;height:31px" src="https://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
     </div>
 
   </body>

--- a/doc/users/cmake_user.html
+++ b/doc/users/cmake_user.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	  "http://www.w3.org/TR/html4/loose.dtd">
+	  "https://www.w3.org/TR/html4/loose.dtd">
 <html>
   <head>
     <title>User CMake configuration - deal.II</title>
@@ -871,10 +871,10 @@ DEAL_II_WITH_ZLIB
 
 <hr />
 <div class="right">
-  <a href="http://validator.w3.org/check?uri=referer" target="_top">
-    <img style="border:0" src="http://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
-  <a href="http://jigsaw.w3.org/css-validator/check/referer" target="_top">
-    <img style="border:0;width:88px;height:31px" src="http://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
+  <a href="https://validator.w3.org/check?uri=referer" target="_top">
+    <img style="border:0" src="https://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
+  <a href="https://jigsaw.w3.org/css-validator/check/referer" target="_top">
+    <img style="border:0;width:88px;height:31px" src="https://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
 </div>
 
 </body>

--- a/doc/users/cmake_user.html
+++ b/doc/users/cmake_user.html
@@ -370,8 +370,8 @@ Please note the (somehow uncommon) empty, opening and closing brackets
 behind <code>else()</code> and <code>endif()</code>.
 <code>&lt;expression&gt;</code> can take a multitude of different forms,
 have a look at the
-<a href="http://cmake.org/cmake/help/v2.8.8/cmake.html">CMake
-documentation</a> for a complete list. Important examples are:
+<a href="https://cmake.org/documentation">CMake documentation</a> for a
+complete list. Important examples are:
 <pre class="cmake">
 if(${variable})
   - the body will be evaluated if the variable "variable" is defined and
@@ -536,8 +536,8 @@ for further details.
 <p>
 You can specify custom include directories and compile definitions prior to
 a target definition on a per directory basis (have a look at the <a
-href="http://cmake.org/cmake/help/v2.8.8/cmake.html">CMake
-documentation</a> for further details):
+href="https://cmake.org/documentation/">CMake documentation</a> for further
+details):
 
 <pre class="cmake">
 include_directories(include1 include2)

--- a/doc/users/gdb.html
+++ b/doc/users/gdb.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-          "http://www.w3.org/TR/html4/loose.dtd">
+          "https://www.w3.org/TR/html4/loose.dtd">
 <html>
   <head>
     <meta http-equiv="Content-type" content="text/html;charset=UTF-8">
@@ -86,10 +86,10 @@ import deal</pre>
 </p>
 <hr />
 <div class="right">
-  <a href="http://validator.w3.org/check?uri=referer" target="_top">
-    <img style="border:0" src="http://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
-  <a href="http://jigsaw.w3.org/css-validator/check/referer" target="_top">
-    <img style="border:0;width:88px;height:31px" src="http://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
+  <a href="https://validator.w3.org/check?uri=referer" target="_top">
+    <img style="border:0" src="https://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
+  <a href="https://jigsaw.w3.org/css-validator/check/referer" target="_top">
+    <img style="border:0;width:88px;height:31px" src="https://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
 </div>
 
 </body>

--- a/doc/users/testsuite.html
+++ b/doc/users/testsuite.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-                 "http://www.w3.org/TR/html4/loose.dtd">
+                 "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
   <meta http-equiv="Content-type" content="text/html;charset=UTF-8">
@@ -330,10 +330,10 @@ TEST_THREAD_LIMIT
     threads. The special value 0 enforces no limit. Defaults to 0.</pre>
     <hr />
     <div class="right">
-      <a href="http://validator.w3.org/check?uri=referer" target="_top">
-        <img style="border:0" src="http://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
-      <a href="http://jigsaw.w3.org/css-validator/check/referer" target="_top">
-        <img style="border:0;width:88px;height:31px" src="http://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
+      <a href="https://validator.w3.org/check?uri=referer" target="_top">
+        <img style="border:0" src="https://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!"></a>
+      <a href="https://jigsaw.w3.org/css-validator/check/referer" target="_top">
+        <img style="border:0;width:88px;height:31px" src="https://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a>
     </div>
 
   </body>


### PR DESCRIPTION
It is 2023... This pull request switches all external urls from `http://` over to `https://`. Otherwise, modern browsers will complain loudly about our website...

Note that some (for example most in the `doc/news/` subdirectory) are probably dead links. But let's convert them nevertheless. It's better if a browser fails at trying to establish a secure connection than an insecure one and fail afterwards with an http 404.
