### PR TITLE
Test examples/step-40: avoid std::cout race condition

### DIFF
--- a/tests/examples/example_test.h
+++ b/tests/examples/example_test.h
@@ -50,28 +50,26 @@ cat_file(const char *filename)
  * steps.
  */
 
-#define check_solver_within_range(SolverType_COMMAND,                  \
-                                  CONTROL_COMMAND,                     \
-                                  MIN_ALLOWED,                         \
-                                  MAX_ALLOWED)                         \
-  {                                                                    \
-    try                                                                \
-      {                                                                \
-        SolverType_COMMAND;                                            \
-      }                                                                \
-    catch (SolverControl::NoConvergence & exc)                         \
-      {}                                                               \
-    const unsigned int steps = CONTROL_COMMAND;                        \
-    if (steps >= MIN_ALLOWED && steps <= MAX_ALLOWED)                  \
-      {                                                                \
-        std::cout << "Solver stopped within " << MIN_ALLOWED << " - "  \
-                  << MAX_ALLOWED << " iterations" << std::endl;        \
-      }                                                                \
-    else                                                               \
-      {                                                                \
-        std::cout << "Solver stopped after " << steps << " iterations" \
-                  << std::endl;                                        \
-      }                                                                \
+#define check_solver_within_range(                                        \
+  OSTREAM, SolverType_COMMAND, CONTROL_COMMAND, MIN_ALLOWED, MAX_ALLOWED) \
+  {                                                                       \
+    try                                                                   \
+      {                                                                   \
+        SolverType_COMMAND;                                               \
+      }                                                                   \
+    catch (SolverControl::NoConvergence & exc)                            \
+      {}                                                                  \
+    const unsigned int steps = CONTROL_COMMAND;                           \
+    if (steps >= MIN_ALLOWED && steps <= MAX_ALLOWED)                     \
+      {                                                                   \
+        OSTREAM << "Solver stopped within " << MIN_ALLOWED << " - "       \
+                << MAX_ALLOWED << " iterations" << std::endl;             \
+      }                                                                   \
+    else                                                                  \
+      {                                                                   \
+        OSTREAM << "Solver stopped after " << steps << " iterations"      \
+                << std::endl;                                             \
+      }                                                                   \
   }
 
 

--- a/tests/examples/step-40.diff
+++ b/tests/examples/step-40.diff
@@ -25,11 +25,12 @@
   
       constraints.distribute(completely_distributed_solution);
   
---- 494,506 ----
+--- 494,507 ----
       LA::MPI::PreconditionAMG preconditioner;
       preconditioner.initialize(system_matrix, data);
   
-!     check_solver_within_range(solver.solve(system_matrix,
+!     check_solver_within_range(pcout,
+!                               solver.solve(system_matrix,
 !                                            completely_distributed_solution,
 !                                            system_rhs,
 !                                            preconditioner),

--- a/tests/examples/step-40.mpirun=2.with_p4est=true.with_petsc=true.output
+++ b/tests/examples/step-40.mpirun=2.with_p4est=true.with_petsc=true.output
@@ -3,17 +3,14 @@ Cycle 0:
    Number of active cells:       1024
    Number of degrees of freedom: 4225
 Solver stopped within 8 - 15 iterations
-Solver stopped within 8 - 15 iterations
 
 Cycle 1:
    Number of active cells:       1960
    Number of degrees of freedom: 8421
 Solver stopped within 8 - 15 iterations
-Solver stopped within 8 - 15 iterations
 
 Cycle 2:
    Number of active cells:       3658
    Number of degrees of freedom: 16109
-Solver stopped within 8 - 15 iterations
 Solver stopped within 8 - 15 iterations
 


### PR DESCRIPTION
Use pcout instead of std::cout to avoid a race condition when outputting from `check_solver_withing_range` macro.

*ping* @bangherth @tjhei

In reference to #15671
In reference to #15665
