### PR TITLE
CMake: avoid "binding to none" for performance tests

### DIFF
--- a/cmake/macros/macro_deal_ii_add_test.cmake
+++ b/cmake/macros/macro_deal_ii_add_test.cmake
@@ -637,7 +637,10 @@ function(deal_ii_add_test _category _test_name _comparison_file)
         # Ensure that the test is not executed concurrently with any other
         # tests.
         #
-        set_tests_properties(${_test_full} PROPERTIES RUN_SERIAL TRUE)
+        set_tests_properties(${_test_full} PROPERTIES
+          RUN_SERIAL TRUE
+          ENVIRONMENT "TEST_IS_EXCLUSIVE=true"
+          )
 
       else()
         #

--- a/cmake/scripts/run_test.sh
+++ b/cmake/scripts/run_test.sh
@@ -91,8 +91,15 @@ case $STAGE in
     #    cores/processors/sockets. Otherwise we run the risk that multiple
     #    mpi tests (for example with two ranks) are all pinned to the same
     #    processor core, bringing everything to a grinding halt.
+    #
+    #    If the test runs exclusively, however, do not override MPI binding
+    #    policies. This is important to ensure that performance tests are
+    #    scheduled properly.
+    #
     export OMPI_MCA_rmaps_base_oversubscribe=1
-    export OMPI_MCA_hwloc_base_binding_policy=none
+    if [ -z "${TEST_IS_EXCLUSIVE+x}" ]; then
+      export OMPI_MCA_hwloc_base_binding_policy=none
+    fi
 
     #
     # Kokkos parameters:


### PR DESCRIPTION
It turns out that this change introduces a lot of noise. Let us thus not override the mpi binding policy if we already run exclusively.

@kronbichler *ping*
