### PR TITLE
Address more unnecessary calls to .c_str().

### DIFF
--- a/examples/step-33/step-33.cc
+++ b/examples/step-33/step-33.cc
@@ -2373,7 +2373,7 @@ namespace Step33
       grid_in.attach_triangulation(triangulation);
 
       std::ifstream input_file(parameters.mesh_filename);
-      Assert(input_file, ExcFileNotOpen(parameters.mesh_filename.c_str()));
+      Assert(input_file, ExcFileNotOpen(parameters.mesh_filename));
 
       grid_in.read_ucd(input_file);
     }

--- a/examples/step-35/step-35.cc
+++ b/examples/step-35/step-35.cc
@@ -726,7 +726,7 @@ namespace Step35
     {
       std::string   filename = "nsbench2.inp";
       std::ifstream file(filename);
-      Assert(file, ExcFileNotOpen(filename.c_str()));
+      Assert(file, ExcFileNotOpen(filename));
       grid_in.read_ucd(file);
     }
 

--- a/examples/step-62/step-62.cc
+++ b/examples/step-62/step-62.cc
@@ -1189,7 +1189,7 @@ namespace step62
                              << std::setfill('0') << frequency_idx;
         std::string filename = (parameters.simulation_name + "_" +
                                 frequency_idx_stream.str() + ".vtu");
-        data_out.write_vtu_in_parallel(filename.c_str(), mpi_communicator);
+        data_out.write_vtu_in_parallel(filename, mpi_communicator);
       }
   }
 

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -7889,7 +7889,7 @@ DataOutInterface<dim, spacedim>::write_vtu_with_pvtu_record(
   else if (n_groups == 1)
     {
       // write only a single data file in parallel
-      this->write_vtu_in_parallel(filename.c_str(), mpi_communicator);
+      this->write_vtu_in_parallel(filename, mpi_communicator);
     }
   else
     {
@@ -7898,7 +7898,7 @@ DataOutInterface<dim, spacedim>::write_vtu_with_pvtu_record(
       MPI_Comm comm_group;
       int ierr = MPI_Comm_split(mpi_communicator, color, rank, &comm_group);
       AssertThrowMPI(ierr);
-      this->write_vtu_in_parallel(filename.c_str(), comm_group);
+      this->write_vtu_in_parallel(filename, comm_group);
       Utilities::MPI::free_communicator(comm_group);
 #else
       AssertThrow(false, ExcMessage("Logical error. Should not arrive here."));


### PR DESCRIPTION
Follow-up to #15694.