### PR TITLE
Triangulation::CellStatus: provide proper compatibility type

### DIFF
--- a/include/deal.II/grid/cell_status.h
+++ b/include/deal.II/grid/cell_status.h
@@ -46,7 +46,27 @@ enum class CellStatus : unsigned int
   /**
    * Invalid status. Will not occur for the user.
    */
-  cell_invalid
+  cell_invalid,
+
+  /**
+   * @deprecated Use CellStatus::cell_will_persist instead
+   */
+  CELL_PERSIST DEAL_II_DEPRECATED_EARLY = cell_will_persist,
+
+  /**
+   * @deprecated Use CellStatus::cell_will_be_refined instead
+   */
+  CELL_REFINE DEAL_II_DEPRECATED_EARLY = cell_will_be_refined,
+
+  /**
+   * @deprecated Use CellStatus::cell_will_be_coarsened instead
+   */
+  CELL_COARSEN DEAL_II_DEPRECATED_EARLY = children_will_be_coarsened,
+
+  /**
+   * @deprecated Use CellStatus::cell_invalid instead
+   */
+  CELL_INVALID DEAL_II_DEPRECATED_EARLY = cell_invalid,
 };
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -2226,26 +2226,18 @@ public:
   /** @} */
 
   /**
-   * Alias for backward compatibility.
+   * The elements of this `enum` are used to inform functions how a
+   * specific cell is going to change. This is used in the course of
+   * transferring data from one mesh to a refined or coarsened version of
+   * the mesh, for example. Note that this may me different than the
+   * refine_flag() and coarsen_flag() set on a cell, for example in
+   * parallel calculations, because of refinement constraints that an
+   * individual machine does not see.
    *
-   * @deprecated This enumeration has been moved to the global namespace.
-   * Use ::dealii::CellStatus instead. Also, its values have been renamed
-   * (CELL_PERSIST -> cell_will_persist,
-   * CELL_REFINE -> cell_will_be_refined,
-   * CELL_COARSEN -> children_will_be_coarsened,
-   * CELL_INVALID -> cell_invalid).
+   * @deprecated This is an alias for backward compatibility. Use
+   * ::dealii::CellStatus directly.
    */
-  enum CellStatus
-  {
-    CELL_PERSIST DEAL_II_DEPRECATED =
-      static_cast<unsigned int>(::dealii::CellStatus::cell_will_persist),
-    CELL_REFINE DEAL_II_DEPRECATED =
-      static_cast<unsigned int>(::dealii::CellStatus::cell_will_be_refined),
-    CELL_COARSEN DEAL_II_DEPRECATED = static_cast<unsigned int>(
-      ::dealii::CellStatus::children_will_be_coarsened),
-    CELL_INVALID DEAL_II_DEPRECATED =
-      static_cast<unsigned int>(::dealii::CellStatus::cell_invalid)
-  };
+  using CellStatus DEAL_II_DEPRECATED_EARLY = ::dealii::CellStatus;
 
   /**
    * A structure used to accumulate the results of the `weight` signal slot

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -2240,6 +2240,35 @@ public:
   using CellStatus DEAL_II_DEPRECATED_EARLY = ::dealii::CellStatus;
 
   /**
+   * @deprecated This is an alias for backward compatibility. Use
+   * ::dealii::CellStatus directly.
+   */
+  static constexpr auto CELL_PERSIST DEAL_II_DEPRECATED_EARLY =
+    ::dealii::CellStatus::cell_will_persist;
+
+  /**
+   * @deprecated This is an alias for backward compatibility. Use
+   * ::dealii::CellStatus directly.
+   */
+  static constexpr auto CELL_REFINE DEAL_II_DEPRECATED_EARLY =
+    ::dealii::CellStatus::cell_will_be_refined;
+
+  /**
+   * @deprecated This is an alias for backward compatibility. Use
+   * ::dealii::CellStatus directly.
+   */
+  static constexpr auto CELL_COARSEN DEAL_II_DEPRECATED_EARLY =
+    ::dealii::CellStatus::children_will_be_coarsened;
+
+  /**
+   * @deprecated This is an alias for backward compatibility. Use
+   * ::dealii::CellStatus directly.
+   */
+  static constexpr auto CELL_INVALID DEAL_II_DEPRECATED_EARLY =
+    ::dealii::CellStatus::cell_invalid;
+
+
+  /**
    * A structure used to accumulate the results of the `weight` signal slot
    * functions below. It takes an iterator range and returns the sum of
    * values.


### PR DESCRIPTION
- CellStatus: provide old name aliases
- Triangulation: include compatibility CellStatus via using instead of defining a new enum

In reference to #15576
In reference to #15698 
