### PR TITLE
CMake: remove support for ctest_memcheck() and run_memorycheck.cmake

### DIFF
--- a/doc/developers/testsuite.html
+++ b/doc/developers/testsuite.html
@@ -306,33 +306,6 @@ xx: ===============================    OUTPUT END   ============================
     </p>
 
 
-    <a name="memcheck"></a>
-     <h3>Running with valgrind</h3>
-
-     <p>
-       The testsuite can also be run using <a href="http://valgrind.org/">valgrind</a>
-       to check for <i>memory corruption</i> in the library.
-     </p>
-
-     <p>
-       You can do so by invoking
- <pre>
- ctest -DMEMORYCHECK=ON <...> -S ../tests/run_testsuite.cmake
- </pre>
-       when running the testsuite, or directly by
- <pre>
- ctest <...> -S ../tests/run_memorycheck.cmake
- </pre>
-     </p>
-
-     <p>
-       At the end of all of this, results will be shown in a separate section
-       "Dynamic Analysis" at the
-       <a href="https://cdash.dealii.org/index.php?project=deal.II&display=project"
-       target="_top">deal.II cdash site</a>.
-     </p>
-
-
     <a name="coverage"></a>
     <h3>Generating coverage information</h3>
 

--- a/tests/run_memorycheck.cmake
+++ b/tests/run_memorycheck.cmake
@@ -1,3 +1,0 @@
-set(TRACK "Experimental")
-set(MEMORYCHECK TRUE)
-include(${CMAKE_CURRENT_LIST_DIR}/run_testsuite.cmake)

--- a/tests/run_testsuite.cmake
+++ b/tests/run_testsuite.cmake
@@ -81,10 +81,6 @@
 #     ctest_coverage() stage will be run. Test results must go into the
 #     "Experimental" section.
 #
-#   MEMORYCHECK
-#     - If set to ON the CTEST_MEMORYCHECK() stage will be run.
-#     Test results must go into the "Experimental" section.
-#
 #   MAKEOPTS
 #     - Additional options that will be passed directly to make (or ninja).
 #
@@ -436,35 +432,6 @@ endif()
 message("-- COVERAGE:               ${COVERAGE}")
 
 
-#
-# Setup memcheck:
-#
-
-if(MEMORYCHECK)
-  if(NOT TRACK MATCHES "Experimental")
-    message(FATAL_ERROR "
-TRACK must be set to  \"Experimental\" if Memcheck is enabled via
-MEMORYCHECK=TRUE.
-"
-      )
-  endif()
-
-  find_program(MEMORYCHECK_COMMAND NAMES valgrind)
-  if(MEMORYCOMMAND MATCHES "-NOTFOUND")
-    message(FATAL_ERROR "
-Memcheck enabled but could not find the valgrind executable. Please install
-valgrind.
-"
-       )
-  endif()
-
-  set(CTEST_MEMORYCHECK_COMMAND "${MEMORYCHECK_COMMAND}")
-endif()
-
-message("-- MEMORYCHECK:               ${MEMORYCHECK}")
-
-
-
 macro(create_targetdirectories_txt)
   #
   # It gets tricky: Fake a TargetDirectories.txt containing _all_ target
@@ -563,13 +530,9 @@ if("${_res}" STREQUAL "0")
     if(DEAL_II_MSVC)
       set(CTEST_BUILD_CONFIGURATION "${JOB_BUILD_CONFIGURATION}")
     endif()
-    if(MEMORYCHECK)
-      message("-- Running ctest_memcheck()")
-      ctest_memcheck()
-    else()
-      message("-- Running CTEST_TESTS()")
-      ctest_test()
-    endif()
+
+    message("-- Running CTEST_TESTS()")
+    ctest_test()
 
     if(COVERAGE)
       CREATE_TARGETDIRECTORIES_TXT()


### PR DESCRIPTION
Instead of using valgrind it is much better to use compiler sanitizers such as "-fsanitize=address,undefined,leak" with clang.
