### PR TITLE
Timing step-68: Fix warnings + remove unnecessary mpi call

### DIFF
--- a/tests/performance/timing_step_68.cc
+++ b/tests/performance/timing_step_68.cc
@@ -264,9 +264,6 @@ namespace Step68
     if (dim == 3)
       center[2] = 0.0;
 
-    const double outer_radius = 0.50;
-    const double inner_radius = 0.01;
-
     parallel::distributed::Triangulation<dim> particle_triangulation(
       MPI_COMM_WORLD);
 
@@ -328,6 +325,9 @@ namespace Step68
 
     FEPointEvaluation<dim, dim> evaluator(mapping, fluid_fe, update_values);
 
+    const double this_mpi_process =
+      (double)Utilities::MPI::this_mpi_process(mpi_communicator);
+
     auto particle = particle_handler.begin();
     while (particle != particle_handler.end())
       {
@@ -360,8 +360,7 @@ namespace Step68
             for (int d = 0; d < dim; ++d)
               properties[d] = particle_velocity[d];
 
-            properties[dim] =
-              Utilities::MPI::this_mpi_process(mpi_communicator);
+            properties[dim] = this_mpi_process;
           }
       }
   }

--- a/tests/performance/timing_step_68.cc
+++ b/tests/performance/timing_step_68.cc
@@ -326,7 +326,7 @@ namespace Step68
     FEPointEvaluation<dim, dim> evaluator(mapping, fluid_fe, update_values);
 
     const double this_mpi_process =
-      (double)Utilities::MPI::this_mpi_process(mpi_communicator);
+      static_cast<double>(Utilities::MPI::this_mpi_process(mpi_communicator));
 
     auto particle = particle_handler.begin();
     while (particle != particle_handler.end())


### PR DESCRIPTION
This PR addresses #15712 
It also takes the opportunity to address one of the simple point of #15650, which is the redundant call to this_mpi_process
