### PR TITLE
Testsuite: let run_testsuite() print a summary

### DIFF
--- a/tests/run_testsuite.cmake
+++ b/tests/run_testsuite.cmake
@@ -625,7 +625,9 @@ if("${_status}" STREQUAL "neutral")
     set(_status "success")
     file(STRINGS "${_path}/Configure.xml" _warnings LIMIT_COUNT 1 REGEX "CMake Warning at")
     if(NOT "${_warnings}" STREQUAL "")
-      set(_status "failure")
+      # for the time being configure warnings are not a "failure"
+      # condition. This would otherwise create a lot of noise on the
+      # regression tester.
       string(APPEND _summary "\n#   - configure warnings")
     endif()
     file(STRINGS "${_path}/Build.xml" _warnings LIMIT_COUNT 1 REGEX "<Warning>")

--- a/tests/run_testsuite.cmake
+++ b/tests/run_testsuite.cmake
@@ -95,7 +95,7 @@
 # For details, consult the ./README file.
 #
 
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.15.0)
 message("-- This is CTest ${CMAKE_VERSION}")
 
 #
@@ -582,11 +582,16 @@ endif()
 
 if(NOT SKIP_SUBMISSION)
   message("-- Running ctest_submit()")
-  ctest_submit(RETURN_VALUE _res)
+  ctest_submit(RETURN_VALUE _res BUILD_ID _build_id)
 
   if("${_res}" STREQUAL "0")
-    message("-- Submission successful. Goodbye!")
+    message("-- Submission successful.")
+    message("###
+#
+# Site:          ${CTEST_SITE}
+# Configuration: ${CTEST_BUILD_NAME}
+# Results:       https://cdash.dealii.org/build/${_build_id}
+#
+###
   endif()
 endif()
-
-# .oO( This script is freaky 606 lines long... )

--- a/tests/run_testsuite.cmake
+++ b/tests/run_testsuite.cmake
@@ -638,6 +638,11 @@ if("${_status}" STREQUAL "neutral")
       set(_status "failure")
       string(APPEND _summary "\n#   - test failures")
     endif()
+
+    if("${_status}" STREQUAL "success")
+      string(APPEND _summary "\n#
+# 🎉  🎉  🎉  🎉      Testsuite run succeeded.     🎉  🎉  🎉  🎉")
+    endif()
   else()
     message(WARNING "Unable to locate test submission files from TAG.")
   endif()


### PR DESCRIPTION
I am a bit frustrated by the lack of informative output when running our testsuite with run_testsuite.cmake (or similar). Concretely, I want to have a quick way of determining whether a testsuite run was successful or not (in order to update CI statuses).

- Testsuite: Print submission URL after successful upload in run_testsuite.cmake
- Testsuite: also record revision and start to report on status
- Testsuite: print summary also for SKIP_SUBMISSION=true
- Testsuite: also report status and summary
- Testsuite: add more emojis
