### PR TITLE
tests/examples/ fix script return value

### DIFF
--- a/tests/examples/update_diffs.sh
+++ b/tests/examples/update_diffs.sh
@@ -28,3 +28,5 @@ for file in ${diff_files}; do
     exit 1
   fi
 done
+
+exit 0


### PR DESCRIPTION
The target update_diffs fails for me without the explicit ``exit 0``