### PR TITLE
Keep track of constraints we have already determined are finalized.

### DIFF
--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -715,6 +715,7 @@ AffineConstraints<number>::close()
   bool                                chained_constraint_replaced = false;
   std::vector<bool>                   line_finalized(lines.size(), false);
   std::vector<const ConstraintLine *> sub_constraints;
+  std::vector<unsigned int>           entries_to_delete;
   do
     {
       chained_constraint_replaced = false;
@@ -775,8 +776,8 @@ AffineConstraints<number>::close()
             // to disturb the order of the correspondence between lines.entries
             // and sub_constraints, we store up which entries we will later
             // have to delete.
-            const unsigned int     n_original_entries = line.entries.size();
-            std::set<unsigned int> entries_to_delete;
+            const unsigned int n_original_entries = line.entries.size();
+            entries_to_delete.clear();
             for (unsigned int entry = 0; entry < n_original_entries; ++entry)
               if (sub_constraints[entry] != nullptr)
                 {
@@ -839,7 +840,7 @@ AffineConstraints<number>::close()
                     // empty). in that case, we can't just overwrite the
                     // current entry, but we have to actually eliminate it
                     {
-                      entries_to_delete.insert(entry);
+                      entries_to_delete.emplace_back(entry);
                     }
 
                   line.inhomogeneity += constrained_line.inhomogeneity * weight;
@@ -851,6 +852,7 @@ AffineConstraints<number>::close()
             // we have already erased earlier elements (as we would have to
             // do if we walked the list of entries to delete in forward
             // order).
+            std::sort(entries_to_delete.begin(), entries_to_delete.end());
             for (auto it = entries_to_delete.rbegin();
                  it != entries_to_delete.rend();
                  ++it)

--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -782,8 +782,9 @@ AffineConstraints<number>::close()
                   chained_constraint_replaced = true;
 
                   // look up the chain of constraints for this entry
-                  const size_type dof_index = line.entries[entry].first;
-                  const number    weight    = line.entries[entry].second;
+                  [[maybe_unused]] const size_type dof_index =
+                    line.entries[entry].first;
+                  const number weight = line.entries[entry].second;
 
                   Assert(dof_index != line.index,
                          ExcMessage("Cycle in constraints detected!"));


### PR DESCRIPTION
Part of #15375.

This optimizes part of `AffineConstraints::close()` to make sure we don't ever look at constraints we know are already finalized because every DoF referenced on the right hand side is not constrained itself (and consequently never will). The patch also removes a small optimization: When we resolve an indirection (a DoF is constrained against another constrained DoF), we add that to the end of a vector *and then walk the rest of the vector* -- so we might resolve multiple levels of indirection over the course of the same loop. This patch stops us from doing that because it would having to keep two arrays in sync and I decided that that's not worth it: We have to iterate the outer loop anyway to resolve all of these levels of indirection, and consequently the microoptimization no longer seems worth it in view of the fact that based on what this patch does, we won't look at finalized constraints again in later outer iterations -- so one or more additional outer iterations does not hurt too much.

I will note that we do not have to do many outer iterations anyway: The number of iterations is bounded by the length of chains of constraints, and these chains are not typically very long (in some extreme cases, equal to the level difference between the finest and coarsest cells -- assuming you have meshes that are refined sufficiently rapidly, and that you're using specific elements such as the DSSY element).