### PR TITLE
[C++17] Use std::is_same_v instead of std::is_same<...>::value.

### DIFF
--- a/examples/step-67/step-67.cc
+++ b/examples/step-67/step-67.cc
@@ -2202,8 +2202,8 @@ namespace Euler_DG
             << Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD)
             << " MPI processes" << std::endl;
       pcout << "Vectorization over " << n_vect_number << ' '
-            << (std::is_same<Number, double>::value ? "doubles" : "floats")
-            << " = " << n_vect_bits << " bits ("
+            << (std::is_same_v<Number, double> ? "doubles" : "floats") << " = "
+            << n_vect_bits << " bits ("
             << Utilities::System::get_current_vectorization_level() << ')'
             << std::endl;
     }

--- a/examples/step-76/step-76.cc
+++ b/examples/step-76/step-76.cc
@@ -1521,8 +1521,8 @@ namespace Euler_DG
             << Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD)
             << " MPI processes" << std::endl;
       pcout << "Vectorization over " << n_vect_number << ' '
-            << (std::is_same<Number, double>::value ? "doubles" : "floats")
-            << " = " << n_vect_bits << " bits ("
+            << (std::is_same_v<Number, double> ? "doubles" : "floats") << " = "
+            << n_vect_bits << " bits ("
             << Utilities::System::get_current_vectorization_level() << ')'
             << std::endl;
     }

--- a/include/deal.II/base/aligned_vector.h
+++ b/include/deal.II/base/aligned_vector.h
@@ -890,7 +890,7 @@ namespace internal
       // completely fill its memory and may lead to false positives in
       // e.g. valgrind
       if (std::is_trivial<T>::value == true &&
-          std::is_same<T, long double>::value == false)
+          std::is_same_v<T, long double> == false)
         {
           const unsigned char zero[sizeof(T)] = {};
           // cast element to (void*) to silence compiler warning for virtual

--- a/include/deal.II/base/hdf5.h
+++ b/include/deal.II/base/hdf5.h
@@ -1221,7 +1221,7 @@ namespace HDF5
      */
     template <typename Container>
     std::enable_if_t<
-      std::is_same<Container, Vector<typename Container::value_type>>::value,
+      std::is_same_v<Container, Vector<typename Container::value_type>>,
       Container>
     initialize_container(const std::vector<hsize_t> &dimensions);
 
@@ -1277,37 +1277,37 @@ namespace HDF5
     std::shared_ptr<hid_t>
     get_hdf5_datatype()
     {
-      static_assert(std::is_same<number, float>::value ||
-                      std::is_same<number, double>::value ||
-                      std::is_same<number, int>::value ||
-                      std::is_same<number, bool>::value ||
-                      std::is_same<number, unsigned int>::value ||
-                      std::is_same<number, std::complex<float>>::value ||
-                      std::is_same<number, std::complex<double>>::value,
+      static_assert(std::is_same_v<number, float> ||
+                      std::is_same_v<number, double> ||
+                      std::is_same_v<number, int> ||
+                      std::is_same_v<number, bool> ||
+                      std::is_same_v<number, unsigned int> ||
+                      std::is_same_v<number, std::complex<float>> ||
+                      std::is_same_v<number, std::complex<double>>,
                     "The data type you are trying to get the HDF5 tag for "
                     "is not supported by this function.");
 
-      if (std::is_same<number, float>::value)
+      if (std::is_same_v<number, float>)
         {
           return std::make_shared<hid_t>(H5T_NATIVE_FLOAT);
         }
-      else if (std::is_same<number, double>::value)
+      else if (std::is_same_v<number, double>)
         {
           return std::make_shared<hid_t>(H5T_NATIVE_DOUBLE);
         }
-      else if (std::is_same<number, int>::value)
+      else if (std::is_same_v<number, int>)
         {
           return std::make_shared<hid_t>(H5T_NATIVE_INT);
         }
-      else if (std::is_same<number, unsigned int>::value)
+      else if (std::is_same_v<number, unsigned int>)
         {
           return std::make_shared<hid_t>(H5T_NATIVE_UINT);
         }
-      else if (std::is_same<number, bool>::value)
+      else if (std::is_same_v<number, bool>)
         {
           return std::make_shared<hid_t>(H5T_NATIVE_HBOOL);
         }
-      else if (std::is_same<number, std::complex<float>>::value)
+      else if (std::is_same_v<number, std::complex<float>>)
         {
           std::shared_ptr<hid_t> t_type =
             std::shared_ptr<hid_t>(new hid_t, [](hid_t *pointer) {
@@ -1330,7 +1330,7 @@ namespace HDF5
           (void)ret;
           return t_type;
         }
-      else if (std::is_same<number, std::complex<double>>::value)
+      else if (std::is_same_v<number, std::complex<double>>)
         {
           std::shared_ptr<hid_t> t_type =
             std::shared_ptr<hid_t>(new hid_t, [](hid_t *pointer) {
@@ -1432,7 +1432,7 @@ namespace HDF5
 
     template <typename Container>
     std::enable_if_t<
-      std::is_same<Container, Vector<typename Container::value_type>>::value,
+      std::is_same_v<Container, Vector<typename Container::value_type>>,
       Container>
     initialize_container(const std::vector<hsize_t> &dimensions)
     {

--- a/include/deal.II/base/partitioner.templates.h
+++ b/include/deal.II/base/partitioner.templates.h
@@ -111,8 +111,8 @@ namespace Utilities
       // performance reasons as this can significantly decrease the number of
       // kernel launched. The indices are expanded the first time the function
       // is called.
-      if ((std::is_same<MemorySpaceType, MemorySpace::Default>::value) &&
-          (import_indices_plain_dev.size() == 0))
+      if ((std::is_same_v<MemorySpaceType, MemorySpace::Default>)&&(
+            import_indices_plain_dev.size() == 0))
         initialize_import_indices_plain_dev();
 #    endif
 
@@ -449,7 +449,7 @@ namespace Utilities
             ExcMessage("Index overflow: Maximum message size in MPI is 2GB. "
                        "The number of ghost entries times the size of 'Number' "
                        "exceeds this value. This is not supported."));
-          if (std::is_same<MemorySpaceType, MemorySpace::Default>::value)
+          if (std::is_same_v<MemorySpaceType, MemorySpace::Default>)
             Kokkos::fence();
           const int ierr =
             MPI_Isend(ghost_array_ptr,
@@ -579,8 +579,8 @@ namespace Utilities
       // performance reasons as this can significantly decrease the number of
       // kernel launched. The indices are expanded the first time the function
       // is called.
-      if ((std::is_same<MemorySpaceType, MemorySpace::Default>::value) &&
-          (import_indices_plain_dev.size() == 0))
+      if ((std::is_same_v<MemorySpaceType, MemorySpace::Default>)&&(
+            import_indices_plain_dev.size() == 0))
         initialize_import_indices_plain_dev();
 #    endif
 

--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -1484,8 +1484,8 @@ namespace Patterns
     struct Convert<T, std::enable_if_t<std::is_arithmetic<T>::value>>
     {
       template <typename Dummy = T>
-      static std::enable_if_t<std::is_same<Dummy, T>::value &&
-                                std::is_same<T, bool>::value,
+      static std::enable_if_t<std::is_same_v<Dummy, T> &&
+                                std::is_same_v<T, bool>,
                               std::unique_ptr<Patterns::PatternBase>>
       to_pattern()
       {
@@ -1493,8 +1493,8 @@ namespace Patterns
       }
 
       template <typename Dummy = T>
-      static std::enable_if_t<std::is_same<Dummy, T>::value &&
-                                !std::is_same<T, bool>::value &&
+      static std::enable_if_t<std::is_same_v<Dummy, T> &&
+                                !std::is_same_v<T, bool> &&
                                 std::is_integral<T>::value,
                               std::unique_ptr<Patterns::PatternBase>>
       to_pattern()
@@ -1504,8 +1504,8 @@ namespace Patterns
       }
 
       template <typename Dummy = T>
-      static std::enable_if_t<std::is_same<Dummy, T>::value &&
-                                !std::is_same<T, bool>::value &&
+      static std::enable_if_t<std::is_same_v<Dummy, T> &&
+                                !std::is_same_v<T, bool> &&
                                 std::is_floating_point<T>::value,
                               std::unique_ptr<Patterns::PatternBase>>
       to_pattern()
@@ -1519,10 +1519,10 @@ namespace Patterns
                 const Patterns::PatternBase &p = *Convert<T>::to_pattern())
       {
         std::stringstream str;
-        if (std::is_same<T, unsigned char>::value ||
-            std::is_same<T, signed char>::value || std::is_same<T, char>::value)
+        if (std::is_same_v<T, unsigned char> ||
+            std::is_same_v<T, signed char> || std::is_same_v<T, char>)
           str << static_cast<int>(value);
-        else if (std::is_same<T, bool>::value)
+        else if (std::is_same_v<T, bool>)
           str << (static_cast<bool>(value) ? "true" : "false");
         else
           str << value;
@@ -1536,14 +1536,13 @@ namespace Patterns
       {
         AssertThrow(p.match(s), ExcNoMatch(s, p.description()));
         T value;
-        if (std::is_same<T, bool>::value)
+        if (std::is_same_v<T, bool>)
           value = (s == "true");
         else
           {
             std::istringstream is(s);
-            if (std::is_same<T, unsigned char>::value ||
-                std::is_same<T, signed char>::value ||
-                std::is_same<T, char>::value)
+            if (std::is_same_v<T, unsigned char> ||
+                std::is_same_v<T, signed char> || std::is_same_v<T, char>)
               {
                 int i;
                 is >> i;

--- a/include/deal.II/base/template_constraints.h
+++ b/include/deal.II/base/template_constraints.h
@@ -217,7 +217,7 @@ template <typename Type, class... Types>
 struct all_same_as
 {
   static constexpr bool value = internal::TemplateConstraints::all_true<
-    std::is_same<Type, Types>::value...>::value;
+    std::is_same_v<Type, Types>...>::value;
 };
 
 
@@ -232,7 +232,7 @@ template <typename Type, class... Types>
 struct is_same_as_any_of
 {
   static constexpr bool value = internal::TemplateConstraints::any_true<
-    std::is_same<Type, Types>::value...>::value;
+    std::is_same_v<Type, Types>...>::value;
 };
 
 

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1125,8 +1125,8 @@ constexpr inline bool
 Tensor<0, dim, Number>::operator==(const Tensor<0, dim, OtherNumber> &p) const
 {
 #  ifdef DEAL_II_ADOLC_WITH_ADVANCED_BRANCHING
-  Assert(!(std::is_same<Number, adouble>::value ||
-           std::is_same<OtherNumber, adouble>::value),
+  Assert(!(std::is_same_v<Number, adouble> ||
+           std::is_same_v<OtherNumber, adouble>),
          ExcMessage(
            "The Tensor equality operator for ADOL-C taped numbers has not yet "
            "been extended to support advanced branching."));
@@ -1681,7 +1681,7 @@ namespace internal
               std::enable_if_t<
                 !std::is_integral<
                   typename ProductType<Number, OtherNumber>::type>::value &&
-                  !std::is_same<Number, Differentiation::SD::Expression>::value,
+                  !std::is_same_v<Number, Differentiation::SD::Expression>,
                 int> = 0>
     constexpr DEAL_II_HOST_DEVICE inline DEAL_II_ALWAYS_INLINE void
     division_operator(Tensor<rank, dim, Number> (&t)[dim],
@@ -1701,7 +1701,7 @@ namespace internal
               std::enable_if_t<
                 std::is_integral<
                   typename ProductType<Number, OtherNumber>::type>::value ||
-                  std::is_same<Number, Differentiation::SD::Expression>::value,
+                  std::is_same_v<Number, Differentiation::SD::Expression>,
                 int> = 0>
     constexpr DEAL_II_HOST_DEVICE inline DEAL_II_ALWAYS_INLINE void
     division_operator(Tensor<rank, dim, Number> (&t)[dim],

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -1137,7 +1137,7 @@ namespace Utilities
     struct IsVectorOfTriviallyCopyable<std::vector<T>>
     {
       static constexpr bool value =
-        std::is_trivially_copyable<T>::value && !std::is_same<T, bool>::value;
+        std::is_trivially_copyable<T>::value && !std::is_same_v<T, bool>;
     };
 
 
@@ -1146,7 +1146,7 @@ namespace Utilities
     struct IsVectorOfTriviallyCopyable<std::vector<std::vector<T>>>
     {
       static constexpr bool value =
-        std::is_trivially_copyable<T>::value && !std::is_same<T, bool>::value;
+        std::is_trivially_copyable<T>::value && !std::is_same_v<T, bool>;
     };
 
 
@@ -1171,7 +1171,7 @@ namespace Utilities
 
 
     template <typename T,
-              typename = std::enable_if_t<!std::is_same<T, bool>::value &&
+              typename = std::enable_if_t<!std::is_same_v<T, bool> &&
                                           std::is_trivially_copyable<T>::value>>
     inline void
     append_vector_of_trivially_copyable_to_buffer(
@@ -1201,7 +1201,7 @@ namespace Utilities
 
 
     template <typename T,
-              typename = std::enable_if_t<!std::is_same<T, bool>::value &&
+              typename = std::enable_if_t<!std::is_same_v<T, bool> &&
                                           std::is_trivially_copyable<T>::value>>
     inline void
     append_vector_of_trivially_copyable_to_buffer(
@@ -1261,7 +1261,7 @@ namespace Utilities
 
 
     template <typename T,
-              typename = std::enable_if_t<!std::is_same<T, bool>::value &&
+              typename = std::enable_if_t<!std::is_same_v<T, bool> &&
                                           std::is_trivially_copyable<T>::value>>
     inline void
     create_vector_of_trivially_copyable_from_buffer(
@@ -1296,7 +1296,7 @@ namespace Utilities
 
 
     template <typename T,
-              typename = std::enable_if_t<!std::is_same<T, bool>::value &&
+              typename = std::enable_if_t<!std::is_same_v<T, bool> &&
                                           std::is_trivially_copyable<T>::value>>
     inline void
     create_vector_of_trivially_copyable_from_buffer(
@@ -1366,7 +1366,7 @@ namespace Utilities
         // sizeof(...) because that is the minimum possible for objects --
         // objects need to have distinct addresses, so they need to have a size
         // of at least one. But we can special case this situation.
-        size = (std::is_same<T, std::tuple<>>::value ? 0 : sizeof(T));
+        size = (std::is_same_v<T, std::tuple<>> ? 0 : sizeof(T));
 
         (void)allow_compression;
         const std::size_t previous_size = dest_buffer.size();
@@ -1450,7 +1450,7 @@ namespace Utilities
         // objects need to have distinct addresses, so they need to have a size
         // of at least one. But we can special case this situation.
         const std::size_t size =
-          (std::is_same<T, std::tuple<>>::value ? 0 : sizeof(T));
+          (std::is_same_v<T, std::tuple<>> ? 0 : sizeof(T));
 
         T object;
 

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -155,7 +155,7 @@ public:
    * current lane.
    */
   template <typename U = T>
-  std::enable_if_t<!std::is_same<U, const U>::value, typename T::value_type> &
+  std::enable_if_t<!std::is_same_v<U, const U>, typename T::value_type> &
   operator*()
   {
     AssertIndexRange(lane, T::size());

--- a/include/deal.II/differentiation/ad/ad_number_traits.h
+++ b/include/deal.II/differentiation/ad/ad_number_traits.h
@@ -922,8 +922,8 @@ namespace Differentiation
 
 
       static_assert((is_real_valued == true ?
-                       std::is_same<ad_type, real_type>::value :
-                       std::is_same<ad_type, complex_type>::value),
+                       std::is_same_v<ad_type, real_type> :
+                       std::is_same_v<ad_type, complex_type>),
                     "Incorrect template type selected for ad_type");
 
       static_assert((is_complex_valued == true ?

--- a/include/deal.II/differentiation/ad/adolc_number_types.h
+++ b/include/deal.II/differentiation/ad/adolc_number_types.h
@@ -330,10 +330,10 @@ namespace Differentiation
     template <typename ADNumberType>
     struct ADNumberTraits<
       ADNumberType,
-      std::enable_if_t<std::is_same<ADNumberType, adouble>::value>>
+      std::enable_if_t<std::is_same_v<ADNumberType, adouble>>>
       : NumberTraits<double, NumberTypes::adolc_taped>
     {
-      static_assert(std::is_same<ad_type, adouble>::value,
+      static_assert(std::is_same_v<ad_type, adouble>,
                     "Incorrect template type selected for taped ad_type");
       static_assert(is_taped == true, "Incorrect setting for taping");
     };
@@ -352,11 +352,10 @@ namespace Differentiation
     template <typename ADNumberType>
     struct ADNumberTraits<
       ADNumberType,
-      std::enable_if_t<
-        std::is_same<ADNumberType, std::complex<adouble>>::value>>
+      std::enable_if_t<std::is_same_v<ADNumberType, std::complex<adouble>>>>
       : NumberTraits<std::complex<double>, NumberTypes::adolc_taped>
     {
-      static_assert(std::is_same<ad_type, std::complex<adouble>>::value,
+      static_assert(std::is_same_v<ad_type, std::complex<adouble>>,
                     "Incorrect template type selected for taped ad_type");
       static_assert(is_taped == true, "Incorrect setting for taping");
     };
@@ -374,10 +373,10 @@ namespace Differentiation
     template <typename ADNumberType>
     struct ADNumberTraits<
       ADNumberType,
-      std::enable_if_t<std::is_same<ADNumberType, adtl::adouble>::value>>
+      std::enable_if_t<std::is_same_v<ADNumberType, adtl::adouble>>>
       : NumberTraits<double, NumberTypes::adolc_tapeless>
     {
-      static_assert(std::is_same<ad_type, adtl::adouble>::value,
+      static_assert(std::is_same_v<ad_type, adtl::adouble>,
                     "Incorrect template type selected for tapeless ad_type");
       static_assert(is_tapeless == true, "Incorrect setting for taping");
     };
@@ -397,10 +396,10 @@ namespace Differentiation
     struct ADNumberTraits<
       ADNumberType,
       std::enable_if_t<
-        std::is_same<ADNumberType, std::complex<adtl::adouble>>::value>>
+        std::is_same_v<ADNumberType, std::complex<adtl::adouble>>>>
       : NumberTraits<std::complex<double>, NumberTypes::adolc_tapeless>
     {
-      static_assert(std::is_same<ad_type, std::complex<adtl::adouble>>::value,
+      static_assert(std::is_same_v<ad_type, std::complex<adtl::adouble>>,
                     "Incorrect template type selected for tapeless ad_type");
       static_assert(is_tapeless == true, "Incorrect setting for taping");
     };

--- a/include/deal.II/differentiation/sd/symengine_math.h
+++ b/include/deal.II/differentiation/sd/symengine_math.h
@@ -69,7 +69,7 @@ namespace Differentiation
      */
     template <
       typename NumberType,
-      typename = std::enable_if_t<!std::is_same<NumberType, Expression>::value>>
+      typename = std::enable_if_t<!std::is_same_v<NumberType, Expression>>>
     Expression
     pow(const Expression &base, const NumberType &exponent)
     {
@@ -88,7 +88,7 @@ namespace Differentiation
      */
     template <
       typename NumberType,
-      typename = std::enable_if_t<!std::is_same<NumberType, Expression>::value>>
+      typename = std::enable_if_t<!std::is_same_v<NumberType, Expression>>>
     Expression
     pow(const NumberType &base, const Expression &exponent)
     {
@@ -154,7 +154,7 @@ namespace Differentiation
      */
     template <
       typename NumberType,
-      typename = std::enable_if_t<!std::is_same<NumberType, Expression>::value>>
+      typename = std::enable_if_t<!std::is_same_v<NumberType, Expression>>>
     Expression
     log(const Expression &x, const NumberType &base)
     {
@@ -173,7 +173,7 @@ namespace Differentiation
      */
     template <
       typename NumberType,
-      typename = std::enable_if_t<!std::is_same<NumberType, Expression>::value>>
+      typename = std::enable_if_t<!std::is_same_v<NumberType, Expression>>>
     Expression
     log(const NumberType &x, const Expression &base)
     {
@@ -313,7 +313,7 @@ namespace Differentiation
      */
     template <
       typename NumberType,
-      typename = std::enable_if_t<!std::is_same<NumberType, Expression>::value>>
+      typename = std::enable_if_t<!std::is_same_v<NumberType, Expression>>>
     Expression
     atan2(const NumberType &y, const Expression &x)
     {
@@ -333,7 +333,7 @@ namespace Differentiation
      */
     template <
       typename NumberType,
-      typename = std::enable_if_t<!std::is_same<NumberType, Expression>::value>>
+      typename = std::enable_if_t<!std::is_same_v<NumberType, Expression>>>
     Expression
     atan2(const Expression &y, const NumberType &x)
     {
@@ -602,7 +602,7 @@ namespace Differentiation
      */
     template <
       typename NumberType,
-      typename = std::enable_if_t<!std::is_same<NumberType, Expression>::value>>
+      typename = std::enable_if_t<!std::is_same_v<NumberType, Expression>>>
     Expression
     max(const Expression &a, const NumberType &b)
     {
@@ -621,7 +621,7 @@ namespace Differentiation
      */
     template <
       typename NumberType,
-      typename = std::enable_if_t<!std::is_same<NumberType, Expression>::value>>
+      typename = std::enable_if_t<!std::is_same_v<NumberType, Expression>>>
     Expression
     max(const NumberType &a, const Expression &b)
     {
@@ -650,7 +650,7 @@ namespace Differentiation
      */
     template <
       typename NumberType,
-      typename = std::enable_if_t<!std::is_same<NumberType, Expression>::value>>
+      typename = std::enable_if_t<!std::is_same_v<NumberType, Expression>>>
     Expression
     min(const Expression &a, const NumberType &b)
     {
@@ -669,7 +669,7 @@ namespace Differentiation
      */
     template <
       typename NumberType,
-      typename = std::enable_if_t<!std::is_same<NumberType, Expression>::value>>
+      typename = std::enable_if_t<!std::is_same_v<NumberType, Expression>>>
     Expression
     min(const NumberType &a, const Expression &b)
     {

--- a/include/deal.II/differentiation/sd/symengine_optimizer.h
+++ b/include/deal.II/differentiation/sd/symengine_optimizer.h
@@ -372,10 +372,8 @@ namespace Differentiation
       {
         static const bool is_supported = true;
 
-        using ReturnType =
-          typename std::conditional<std::is_same<ReturnType_, float>::value,
-                                    float,
-                                    double>::type;
+        using ReturnType = typename std::
+          conditional<std::is_same_v<ReturnType_, float>, float, double>::type;
       };
 
 
@@ -391,7 +389,7 @@ namespace Differentiation
         static const bool is_supported = true;
 
         using ReturnType = typename std::conditional<
-          std::is_same<ReturnType_, std::complex<float>>::value,
+          std::is_same_v<ReturnType_, std::complex<float>>,
           std::complex<float>,
           std::complex<double>>::type;
       };
@@ -601,12 +599,10 @@ namespace Differentiation
         ReturnType_,
         std::enable_if_t<std::is_arithmetic<ReturnType_>::value>>
       {
-        using ReturnType =
-          typename std::conditional<std::is_same<ReturnType_, float>::value,
-                                    float,
-                                    double>::type;
+        using ReturnType = typename std::
+          conditional<std::is_same_v<ReturnType_, float>, float, double>::type;
         using OptimizerType =
-          typename std::conditional<std::is_same<ReturnType_, float>::value,
+          typename std::conditional<std::is_same_v<ReturnType_, float>,
                                     SymEngine::LLVMFloatVisitor,
                                     SymEngine::LLVMDoubleVisitor>::type;
 
@@ -819,7 +815,7 @@ namespace Differentiation
         ReturnType,
         Optimizer,
         std::enable_if_t<
-          std::is_same<ReturnType, typename Optimizer::ReturnType>::value>>
+          std::is_same_v<ReturnType, typename Optimizer::ReturnType>>>
       {
         /**
          * Initialize an instance of an optimizer.
@@ -961,7 +957,7 @@ namespace Differentiation
         ReturnType,
         Optimizer,
         std::enable_if_t<
-          !std::is_same<ReturnType, typename Optimizer::ReturnType>::value>>
+          !std::is_same_v<ReturnType, typename Optimizer::ReturnType>>>
       {
         /**
          * Initialize an instance of an optimizer.

--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -3947,7 +3947,7 @@ AffineConstraints<number>::distribute_local_to_global(
   const bool use_vectors =
     (local_vector.size() == 0 && global_vector.size() == 0) ? false : true;
   const bool use_dealii_matrix =
-    std::is_same<MatrixType, SparseMatrix<number>>::value;
+    std::is_same_v<MatrixType, SparseMatrix<number>>;
 
   AssertDimension(local_matrix.n(), local_dof_indices.size());
   AssertDimension(local_matrix.m(), local_dof_indices.size());
@@ -4060,7 +4060,7 @@ AffineConstraints<number>::distribute_local_to_global(
   // add must be equal if we have a Trilinos or PETSc vector but do not have to
   // be if we have a deal.II native vector: one could further optimize this for
   // Vector, LinearAlgebra::distributed::vector, etc.
-  if (std::is_same<typename VectorType::value_type, number>::value)
+  if (std::is_same_v<typename VectorType::value_type, number>)
     {
       global_vector.add(vector_indices,
                         *reinterpret_cast<std::vector<number> *>(
@@ -4104,7 +4104,7 @@ AffineConstraints<number>::distribute_local_to_global(
   const bool use_vectors =
     (local_vector.size() == 0 && global_vector.size() == 0) ? false : true;
   const bool use_dealii_matrix =
-    std::is_same<MatrixType, BlockSparseMatrix<number>>::value;
+    std::is_same_v<MatrixType, BlockSparseMatrix<number>>;
 
   AssertDimension(local_matrix.n(), local_dof_indices.size());
   AssertDimension(local_matrix.m(), local_dof_indices.size());

--- a/include/deal.II/lac/full_matrix.templates.h
+++ b/include/deal.II/lac/full_matrix.templates.h
@@ -519,9 +519,8 @@ FullMatrix<number>::mmult(FullMatrix<number2> &      dst,
   // matrices):
 #ifdef DEAL_II_WITH_LAPACK
   const size_type max_blas_int = std::numeric_limits<types::blas_int>::max();
-  if ((std::is_same<number, double>::value ||
-       std::is_same<number, float>::value) &&
-      std::is_same<number, number2>::value)
+  if ((std::is_same_v<number, double> ||
+       std::is_same_v<number, float>)&&std::is_same_v<number, number2>)
     if (this->n() * this->m() * src.n() > 300 && src.n() <= max_blas_int &&
         this->m() <= max_blas_int && this->n() <= max_blas_int)
       {
@@ -602,9 +601,8 @@ FullMatrix<number>::Tmmult(FullMatrix<number2> &      dst,
   // matrices):
 #ifdef DEAL_II_WITH_LAPACK
   const size_type max_blas_int = std::numeric_limits<types::blas_int>::max();
-  if ((std::is_same<number, double>::value ||
-       std::is_same<number, float>::value) &&
-      std::is_same<number, number2>::value)
+  if ((std::is_same_v<number, double> ||
+       std::is_same_v<number, float>)&&std::is_same_v<number, number2>)
     if (this->n() * this->m() * src.n() > 300 && src.n() <= max_blas_int &&
         this->n() <= max_blas_int && this->m() <= max_blas_int)
       {
@@ -706,9 +704,8 @@ FullMatrix<number>::mTmult(FullMatrix<number2> &      dst,
   // matrices):
 #ifdef DEAL_II_WITH_LAPACK
   const size_type max_blas_int = std::numeric_limits<types::blas_int>::max();
-  if ((std::is_same<number, double>::value ||
-       std::is_same<number, float>::value) &&
-      std::is_same<number, number2>::value)
+  if ((std::is_same_v<number, double> ||
+       std::is_same_v<number, float>)&&std::is_same_v<number, number2>)
     if (this->n() * this->m() * src.m() > 300 && src.m() <= max_blas_int &&
         this->n() <= max_blas_int && this->m() <= max_blas_int)
       {
@@ -808,9 +805,8 @@ FullMatrix<number>::TmTmult(FullMatrix<number2> &      dst,
   // matrices):
 #ifdef DEAL_II_WITH_LAPACK
   const size_type max_blas_int = std::numeric_limits<types::blas_int>::max();
-  if ((std::is_same<number, double>::value ||
-       std::is_same<number, float>::value) &&
-      std::is_same<number, number2>::value)
+  if ((std::is_same_v<number, double> ||
+       std::is_same_v<number, float>)&&std::is_same_v<number, number2>)
     if (this->n() * this->m() * src.m() > 300 && src.m() <= max_blas_int &&
         this->n() <= max_blas_int && this->m() <= max_blas_int)
       {
@@ -1218,8 +1214,8 @@ namespace internal
   // floats and doubles
   template <typename number>
   struct Determinant<number,
-                     std::enable_if_t<std::is_same<number, float>::value ||
-                                      std::is_same<number, double>::value>>
+                     std::enable_if_t<std::is_same_v<number, float> ||
+                                      std::is_same_v<number, double>>>
   {
 #ifdef DEAL_II_WITH_LAPACK
     static number
@@ -1755,7 +1751,7 @@ FullMatrix<number>::gauss_jordan()
   // efficient to use Lapack for very small
   // matrices):
 #ifdef DEAL_II_WITH_LAPACK
-  if (std::is_same<number, double>::value || std::is_same<number, float>::value)
+  if (std::is_same_v<number, double> || std::is_same_v<number, float>)
     if (this->n_cols() > 15 && static_cast<types::blas_int>(this->n_cols()) <=
                                  std::numeric_limits<types::blas_int>::max())
       {

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -262,8 +262,8 @@ namespace LinearAlgebra
       using real_type       = typename numbers::NumberTraits<Number>::real_type;
 
       static_assert(
-        std::is_same<MemorySpace, ::dealii::MemorySpace::Host>::value ||
-          std::is_same<MemorySpace, ::dealii::MemorySpace::Default>::value,
+        std::is_same_v<MemorySpace, ::dealii::MemorySpace::Host> ||
+          std::is_same_v<MemorySpace, ::dealii::MemorySpace::Default>,
         "MemorySpace should be Host or Default");
 
       /**
@@ -1549,7 +1549,7 @@ namespace LinearAlgebra
     inline Number
     Vector<Number, MemorySpace>::operator()(const size_type global_index) const
     {
-      Assert((std::is_same<MemorySpace, ::dealii::MemorySpace::Host>::value),
+      Assert((std::is_same_v<MemorySpace, ::dealii::MemorySpace::Host>),
              ExcMessage(
                "This function is only implemented for the Host memory space"));
       Assert(
@@ -1575,7 +1575,7 @@ namespace LinearAlgebra
     inline Number &
     Vector<Number, MemorySpace>::operator()(const size_type global_index)
     {
-      Assert((std::is_same<MemorySpace, ::dealii::MemorySpace::Host>::value),
+      Assert((std::is_same_v<MemorySpace, ::dealii::MemorySpace::Host>),
              ExcMessage(
                "This function is only implemented for the Host memory space"));
       Assert(
@@ -1621,7 +1621,7 @@ namespace LinearAlgebra
     Vector<Number, MemorySpace>::local_element(
       const size_type local_index) const
     {
-      Assert((std::is_same<MemorySpace, ::dealii::MemorySpace::Host>::value),
+      Assert((std::is_same_v<MemorySpace, ::dealii::MemorySpace::Host>),
              ExcMessage(
                "This function is only implemented for the Host memory space"));
       AssertIndexRange(local_index,
@@ -1641,7 +1641,7 @@ namespace LinearAlgebra
     inline Number &
     Vector<Number, MemorySpace>::local_element(const size_type local_index)
     {
-      Assert((std::is_same<MemorySpace, ::dealii::MemorySpace::Host>::value),
+      Assert((std::is_same_v<MemorySpace, ::dealii::MemorySpace::Host>),
              ExcMessage(
                "This function is only implemented for the Host memory space"));
 

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -84,10 +84,9 @@ namespace LinearAlgebra
       template <typename Number, typename MemorySpaceType>
       struct la_parallel_vector_templates_functions
       {
-        static_assert(
-          std::is_same<MemorySpaceType, MemorySpace::Host>::value ||
-            std::is_same<MemorySpaceType, MemorySpace::Default>::value,
-          "MemorySpace should be Host or Default");
+        static_assert(std::is_same_v<MemorySpaceType, MemorySpace::Host> ||
+                        std::is_same_v<MemorySpaceType, MemorySpace::Default>,
+                      "MemorySpace should be Host or Default");
 
         static void
         resize_val(
@@ -334,8 +333,7 @@ namespace LinearAlgebra
           (void)comm_sm;
 
           static_assert(
-            std::is_same<Number, float>::value ||
-              std::is_same<Number, double>::value,
+            std::is_same_v<Number, float> || std::is_same_v<Number, double>,
             "Number should be float or double for Default memory space");
 
           if (new_alloc_size > allocated_size)
@@ -470,7 +468,7 @@ namespace LinearAlgebra
                           const unsigned int                 size,
                           RealType &                         result)
         {
-          static_assert(std::is_same<Number, RealType>::value,
+          static_assert(std::is_same_v<Number, RealType>,
                         "RealType should be the same type as Number");
 
           typename ::dealii::MemorySpace::Default::kokkos_space::execution_space
@@ -997,7 +995,7 @@ namespace LinearAlgebra
         }
 
 #  if !defined(DEAL_II_MPI_WITH_DEVICE_SUPPORT)
-      if (std::is_same<MemorySpaceType, dealii::MemorySpace::Default>::value)
+      if (std::is_same_v<MemorySpaceType, dealii::MemorySpace::Default>)
         {
           // Move the data to the host and then move it back to the
           // device. We use values to store the elements because the function
@@ -1059,7 +1057,7 @@ namespace LinearAlgebra
       // make this function thread safe
       std::lock_guard<std::mutex> lock(mutex);
 #  if !defined(DEAL_II_MPI_WITH_DEVICE_SUPPORT)
-      if (std::is_same<MemorySpaceType, MemorySpace::Default>::value)
+      if (std::is_same_v<MemorySpaceType, MemorySpace::Default>)
         {
           Assert(partitioner->n_import_indices() == 0 ||
                    import_data.values_host_buffer.size() != 0,
@@ -1129,7 +1127,7 @@ namespace LinearAlgebra
       if (partitioner->n_import_indices() > 0)
         {
 #  if !defined(DEAL_II_MPI_WITH_DEVICE_SUPPORT)
-          if (std::is_same<MemorySpaceType, MemorySpace::Default>::value)
+          if (std::is_same_v<MemorySpaceType, MemorySpace::Default>)
             {
               if (import_data.values_host_buffer.size() == 0)
                 Kokkos::resize(import_data.values_host_buffer,
@@ -1145,7 +1143,7 @@ namespace LinearAlgebra
         }
 
 #  if !defined(DEAL_II_MPI_WITH_DEVICE_SUPPORT)
-      if (std::is_same<MemorySpaceType, MemorySpace::Default>::value)
+      if (std::is_same_v<MemorySpaceType, MemorySpace::Default>)
         {
           // Move the data to the host and then move it back to the
           // device. We use values to store the elements because the function
@@ -1212,7 +1210,7 @@ namespace LinearAlgebra
           std::lock_guard<std::mutex> lock(mutex);
 
 #  if !defined(DEAL_II_MPI_WITH_DEVICE_SUPPORT)
-          if (std::is_same<MemorySpaceType, MemorySpace::Default>::value)
+          if (std::is_same_v<MemorySpaceType, MemorySpace::Default>)
             {
               partitioner->export_to_ghosted_array_finish(
                 ArrayView<Number, MemorySpace::Host>(

--- a/include/deal.II/lac/linear_operator.h
+++ b/include/deal.II/lac/linear_operator.h
@@ -1551,8 +1551,8 @@ template <
   typename Range  = typename Solver::vector_type,
   typename Domain = Range,
   typename = std::enable_if_t<!std::is_lvalue_reference<Preconditioner>::value>,
-  typename = std::enable_if_t<
-    !std::is_same<Preconditioner, PreconditionIdentity>::value>,
+  typename =
+    std::enable_if_t<!std::is_same_v<Preconditioner, PreconditionIdentity>>,
   typename = std::enable_if_t<
     !std::is_same<Preconditioner,
                   LinearOperator<Range, Domain, Payload>>::value>>

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -2363,7 +2363,7 @@ inline void
 PreconditionRichardson::vmult(VectorType &dst, const VectorType &src) const
 {
   static_assert(
-    std::is_same<size_type, typename VectorType::size_type>::value,
+    std::is_same_v<size_type, typename VectorType::size_type>,
     "PreconditionRichardson and VectorType must have the same size_type.");
 
   dst.equ(relaxation, src);
@@ -2376,7 +2376,7 @@ inline void
 PreconditionRichardson::Tvmult(VectorType &dst, const VectorType &src) const
 {
   static_assert(
-    std::is_same<size_type, typename VectorType::size_type>::value,
+    std::is_same_v<size_type, typename VectorType::size_type>,
     "PreconditionRichardson and VectorType must have the same size_type.");
 
   dst.equ(relaxation, src);
@@ -2387,7 +2387,7 @@ inline void
 PreconditionRichardson::vmult_add(VectorType &dst, const VectorType &src) const
 {
   static_assert(
-    std::is_same<size_type, typename VectorType::size_type>::value,
+    std::is_same_v<size_type, typename VectorType::size_type>,
     "PreconditionRichardson and VectorType must have the same size_type.");
 
   dst.add(relaxation, src);
@@ -2400,7 +2400,7 @@ inline void
 PreconditionRichardson::Tvmult_add(VectorType &dst, const VectorType &src) const
 {
   static_assert(
-    std::is_same<size_type, typename VectorType::size_type>::value,
+    std::is_same_v<size_type, typename VectorType::size_type>,
     "PreconditionRichardson and VectorType must have the same size_type.");
 
   dst.add(relaxation, src);
@@ -3420,11 +3420,11 @@ namespace internal
       eigenvector /= eigenvector.l2_norm();
       VectorType vector1, vector2;
       vector1.reinit(eigenvector, true);
-      if (!std::is_same<PreconditionerType, PreconditionIdentity>::value)
+      if (!std::is_same_v<PreconditionerType, PreconditionIdentity>)
         vector2.reinit(eigenvector, true);
       for (unsigned int i = 0; i < n_iterations; ++i)
         {
-          if (!std::is_same<PreconditionerType, PreconditionIdentity>::value)
+          if (!std::is_same_v<PreconditionerType, PreconditionIdentity>)
             {
               matrix.vmult(vector2, eigenvector);
               preconditioner.vmult(vector1, vector2);
@@ -3494,7 +3494,7 @@ inline PreconditionChebyshev<MatrixType, VectorType, PreconditionerType>::
   , eigenvalues_are_initialized(false)
 {
   static_assert(
-    std::is_same<size_type, typename VectorType::size_type>::value,
+    std::is_same_v<size_type, typename VectorType::size_type>,
     "PreconditionChebyshev and VectorType must have the same size_type.");
 }
 
@@ -3666,7 +3666,7 @@ PreconditionChebyshev<MatrixType, VectorType, PreconditionerType>::
   using NumberType = typename VectorType::value_type;
   if (std::is_same<PreconditionerType,
                    dealii::DiagonalMatrix<VectorType>>::value == false ||
-      (std::is_same<VectorType, dealii::Vector<NumberType>>::value == false &&
+      (std::is_same_v<VectorType, dealii::Vector<NumberType>> == false &&
        ((std::is_same<VectorType,
                       LinearAlgebra::distributed::
                         Vector<NumberType, MemorySpace::Host>>::value ==

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -418,7 +418,7 @@ namespace LinearAlgebra
      * performance.
      */
     template <typename Dummy = Number>
-    std::enable_if_t<std::is_same<Dummy, Number>::value &&
+    std::enable_if_t<std::is_same_v<Dummy, Number> &&
                      dealii::is_tpetra_type<Number>::value>
     import_elements(
       const TpetraWrappers::Vector<Number> &tpetra_vec,
@@ -430,7 +430,7 @@ namespace LinearAlgebra
      * @deprecated Use import_elements() instead.
      */
     template <typename Dummy = Number>
-    DEAL_II_DEPRECATED std::enable_if_t<std::is_same<Dummy, Number>::value &&
+    DEAL_II_DEPRECATED std::enable_if_t<std::is_same_v<Dummy, Number> &&
                                         dealii::is_tpetra_type<Number>::value>
                        import(const TpetraWrappers::Vector<Number> &V,
                               VectorOperation::values               operation,
@@ -742,7 +742,7 @@ namespace LinearAlgebra
      * used directly.
      */
     template <typename Dummy = Number>
-    std::enable_if_t<std::is_same<Dummy, Number>::value &&
+    std::enable_if_t<std::is_same_v<Dummy, Number> &&
                      dealii::is_tpetra_type<Number>::value>
     import_elements(
       const Tpetra::Vector<Number, int, types::signed_global_dof_index>

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -108,8 +108,8 @@ namespace LinearAlgebra
         (void)rw_vector;
 
         static_assert(
-          std::is_same<MemorySpace, ::dealii::MemorySpace::Host>::value ||
-            std::is_same<MemorySpace, ::dealii::MemorySpace::Default>::value,
+          std::is_same_v<MemorySpace, ::dealii::MemorySpace::Host> ||
+            std::is_same_v<MemorySpace, ::dealii::MemorySpace::Default>,
           "MemorySpace should be Host or Default");
       }
     };
@@ -563,7 +563,7 @@ namespace LinearAlgebra
 #  ifdef DEAL_II_TRILINOS_WITH_TPETRA
   template <typename Number>
   template <typename Dummy>
-  std::enable_if_t<std::is_same<Dummy, Number>::value &&
+  std::enable_if_t<std::is_same_v<Dummy, Number> &&
                    dealii::is_tpetra_type<Number>::value>
   ReadWriteVector<Number>::import_elements(
     const Tpetra::Vector<Number, int, types::signed_global_dof_index> &vector,
@@ -848,7 +848,7 @@ namespace LinearAlgebra
 #  ifdef DEAL_II_TRILINOS_WITH_TPETRA
   template <typename Number>
   template <typename Dummy>
-  std::enable_if_t<std::is_same<Dummy, Number>::value &&
+  std::enable_if_t<std::is_same_v<Dummy, Number> &&
                    dealii::is_tpetra_type<Number>::value>
   ReadWriteVector<Number>::import_elements(
     const LinearAlgebra::TpetraWrappers::Vector<Number> &trilinos_vec,

--- a/include/deal.II/lac/solver_cg.h
+++ b/include/deal.II/lac/solver_cg.h
@@ -603,8 +603,7 @@ namespace internal
         const Number previous_r_dot_preconditioner_dot_r =
           r_dot_preconditioner_dot_r;
 
-        if (std::is_same<PreconditionerType, PreconditionIdentity>::value ==
-            false)
+        if (std::is_same_v<PreconditionerType, PreconditionIdentity> == false)
           {
             preconditioner.vmult(v, r);
             r_dot_preconditioner_dot_r = r * v;
@@ -613,7 +612,7 @@ namespace internal
           r_dot_preconditioner_dot_r = residual_norm * residual_norm;
 
         const VectorType &direction =
-          std::is_same<PreconditionerType, PreconditionIdentity>::value ? r : v;
+          std::is_same_v<PreconditionerType, PreconditionIdentity> ? r : v;
 
         if (iteration_index > 1)
           {

--- a/include/deal.II/lac/sparse_decomposition.templates.h
+++ b/include/deal.II/lac/sparse_decomposition.templates.h
@@ -171,7 +171,7 @@ SparseLUDecomposition<number>::copy_from(const SparseMatrix<somenumber> &matrix)
       const somenumber *  input_ptr = matrix.val.get();
       number *            this_ptr  = this->val.get();
       const number *const end_ptr   = this_ptr + this->n_nonzero_elements();
-      if (std::is_same<somenumber, number>::value == true)
+      if (std::is_same_v<somenumber, number> == true)
         std::memcpy(this_ptr,
                     input_ptr,
                     this->n_nonzero_elements() * sizeof(number));

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -845,7 +845,7 @@ namespace TrilinosWrappers
      */
     template <typename SparsityPatternType>
     std::enable_if_t<
-      !std::is_same<SparsityPatternType, dealii::SparseMatrix<double>>::value>
+      !std::is_same_v<SparsityPatternType, dealii::SparseMatrix<double>>>
     reinit(const IndexSet &           row_parallel_partitioning,
            const IndexSet &           col_parallel_partitioning,
            const SparsityPatternType &sparsity_pattern,
@@ -1442,7 +1442,7 @@ namespace TrilinosWrappers
      */
     template <typename VectorType>
     std::enable_if_t<
-      std::is_same<typename VectorType::value_type, TrilinosScalar>::value>
+      std::is_same_v<typename VectorType::value_type, TrilinosScalar>>
     vmult(VectorType &dst, const VectorType &src) const;
 
     /**
@@ -1453,7 +1453,7 @@ namespace TrilinosWrappers
      */
     template <typename VectorType>
     std::enable_if_t<
-      !std::is_same<typename VectorType::value_type, TrilinosScalar>::value>
+      !std::is_same_v<typename VectorType::value_type, TrilinosScalar>>
     vmult(VectorType &dst, const VectorType &src) const;
 
     /**
@@ -1472,7 +1472,7 @@ namespace TrilinosWrappers
      */
     template <typename VectorType>
     std::enable_if_t<
-      std::is_same<typename VectorType::value_type, TrilinosScalar>::value>
+      std::is_same_v<typename VectorType::value_type, TrilinosScalar>>
     Tvmult(VectorType &dst, const VectorType &src) const;
 
     /**
@@ -1483,7 +1483,7 @@ namespace TrilinosWrappers
      */
     template <typename VectorType>
     std::enable_if_t<
-      !std::is_same<typename VectorType::value_type, TrilinosScalar>::value>
+      !std::is_same_v<typename VectorType::value_type, TrilinosScalar>>
     Tvmult(VectorType &dst, const VectorType &src) const;
 
     /**

--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -242,7 +242,7 @@ namespace internal
         Assert(end >= begin, ExcInternalError());
 
         if constexpr (std::is_trivially_copyable<Number>() &&
-                      std::is_same<Number, OtherNumber>::value)
+                      std::is_same_v<Number, OtherNumber>)
           std::memcpy(dst + begin, src + begin, (end - begin) * sizeof(Number));
         else
           {
@@ -753,7 +753,7 @@ namespace internal
     template <typename Number, typename Number2>
     struct Dot
     {
-      static constexpr bool vectorizes = std::is_same<Number, Number2>::value &&
+      static constexpr bool vectorizes = std::is_same_v<Number, Number2> &&
                                          (VectorizedArray<Number>::size() > 1);
 
       Dot(const Number *const X, const Number2 *const Y)
@@ -1473,8 +1473,8 @@ namespace internal
         ::dealii::MemorySpace::MemorySpaceData<Number, MemorySpace> & /*data*/)
       {
         static_assert(
-          std::is_same<MemorySpace, ::dealii::MemorySpace::Default>::value &&
-            std::is_same<Number, Number2>::value,
+          std::is_same_v<MemorySpace, ::dealii::MemorySpace::Default> &&
+            std::is_same_v<Number, Number2>,
           "For the Default MemorySpace Number and Number2 should be the same type");
       }
 
@@ -2069,7 +2069,7 @@ namespace internal
                                                ::dealii::MemorySpace::Host>
           &data,
         std::enable_if_t<
-          std::is_same<MemorySpace2, dealii::MemorySpace::Host>::value,
+          std::is_same_v<MemorySpace2, dealii::MemorySpace::Host>,
           int> = 0)
       {
         if (operation == VectorOperation::insert)
@@ -2099,7 +2099,7 @@ namespace internal
                                                ::dealii::MemorySpace::Host>
           &data,
         std::enable_if_t<
-          std::is_same<MemorySpace2, ::dealii::MemorySpace::Default>::value,
+          std::is_same_v<MemorySpace2, ::dealii::MemorySpace::Default>,
           int> = 0)
       {
         if (operation == VectorOperation::insert)
@@ -2606,7 +2606,7 @@ namespace internal
                                                ::dealii::MemorySpace::Default>
           &data,
         std::enable_if_t<
-          std::is_same<MemorySpace2, ::dealii::MemorySpace::Default>::value,
+          std::is_same_v<MemorySpace2, ::dealii::MemorySpace::Default>,
           int> = 0)
       {
         if (operation == VectorOperation::insert)
@@ -2636,7 +2636,7 @@ namespace internal
                                                ::dealii::MemorySpace::Default>
           &data,
         std::enable_if_t<
-          std::is_same<MemorySpace2, ::dealii::MemorySpace::Host>::value,
+          std::is_same_v<MemorySpace2, ::dealii::MemorySpace::Host>,
           int> = 0)
       {
         if (operation == VectorOperation::insert)

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -506,7 +506,7 @@ namespace CUDAWrappers
                                                    VectorType &      dst) const
   {
     static_assert(
-      std::is_same<Number, typename VectorType::value_type>::value,
+      std::is_same_v<Number, typename VectorType::value_type>,
       "VectorType::value_type and Number should be of the same type.");
     Assert(src.size() == dst.size(),
            ExcMessage("src and dst vectors have different size."));
@@ -539,7 +539,7 @@ namespace CUDAWrappers
                                                   VectorType &dst) const
   {
     static_assert(
-      std::is_same<Number, typename VectorType::value_type>::value,
+      std::is_same_v<Number, typename VectorType::value_type>,
       "VectorType::value_type and Number should be of the same type.");
     Number *dst_ptr = dst.get_values();
     // FIXME When using C++17, we can use KOKKOS_CLASS_LAMBDA and this

--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -3099,8 +3099,7 @@ namespace internal
       const std::size_t n_dofs_normal =
         n_dofs_tangent - Utilities::pow(fe_degree, dim - 2);
       const std::size_t dofs_stride =
-        (std::is_same<Eval0, EvalGeneral>::value) ? n_dofs_normal :
-                                                    n_dofs_tangent;
+        (std::is_same_v<Eval0, EvalGeneral>) ? n_dofs_normal : n_dofs_tangent;
 
       static constexpr dealii::ndarray<unsigned int, 3, 3> component_table = {
         {{{1, 2, 0}}, {{2, 0, 1}}, {{0, 1, 2}}}};
@@ -3304,8 +3303,7 @@ namespace internal
       const std::size_t n_dofs_normal =
         n_dofs_tangent - Utilities::pow(fe_degree, dim - 2);
       const std::size_t dofs_stride =
-        (std::is_same<Eval0, EvalGeneral>::value) ? n_dofs_normal :
-                                                    n_dofs_tangent;
+        (std::is_same_v<Eval0, EvalGeneral>) ? n_dofs_normal : n_dofs_tangent;
 
       static constexpr dealii::ndarray<unsigned int, 3, 3> component_table = {
         {{{1, 2, 0}}, {{2, 0, 1}}, {{0, 1, 2}}}};

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -763,7 +763,7 @@ class FEEvaluationAccess : public FEEvaluationBase<dim,
                                                    VectorizedArrayType>
 {
   static_assert(
-    std::is_same<Number, typename VectorizedArrayType::value_type>::value,
+    std::is_same_v<Number, typename VectorizedArrayType::value_type>,
     "Type of Number and of VectorizedArrayType do not match.");
 
 public:
@@ -835,7 +835,7 @@ class FEEvaluationAccess<dim, 1, Number, is_face, VectorizedArrayType>
   : public FEEvaluationBase<dim, 1, Number, is_face, VectorizedArrayType>
 {
   static_assert(
-    std::is_same<Number, typename VectorizedArrayType::value_type>::value,
+    std::is_same_v<Number, typename VectorizedArrayType::value_type>,
     "Type of Number and of VectorizedArrayType do not match.");
 
 public:
@@ -993,7 +993,7 @@ class FEEvaluationAccess<dim, dim, Number, is_face, VectorizedArrayType>
   : public FEEvaluationBase<dim, dim, Number, is_face, VectorizedArrayType>
 {
   static_assert(
-    std::is_same<Number, typename VectorizedArrayType::value_type>::value,
+    std::is_same_v<Number, typename VectorizedArrayType::value_type>,
     "Type of Number and of VectorizedArrayType do not match.");
 
 public:
@@ -1169,7 +1169,7 @@ class FEEvaluationAccess<1, 1, Number, is_face, VectorizedArrayType>
   : public FEEvaluationBase<1, 1, Number, is_face, VectorizedArrayType>
 {
   static_assert(
-    std::is_same<Number, typename VectorizedArrayType::value_type>::value,
+    std::is_same_v<Number, typename VectorizedArrayType::value_type>,
     "Type of Number and of VectorizedArrayType do not match.");
 
 public:
@@ -1914,7 +1914,7 @@ class FEEvaluation : public FEEvaluationAccess<dim,
                                                VectorizedArrayType>
 {
   static_assert(
-    std::is_same<Number, typename VectorizedArrayType::value_type>::value,
+    std::is_same_v<Number, typename VectorizedArrayType::value_type>,
     "Type of Number and of VectorizedArrayType do not match.");
 
 public:
@@ -2378,7 +2378,7 @@ class FEFaceEvaluation : public FEEvaluationAccess<dim,
                                                    VectorizedArrayType>
 {
   static_assert(
-    std::is_same<Number, typename VectorizedArrayType::value_type>::value,
+    std::is_same_v<Number, typename VectorizedArrayType::value_type>,
     "Type of Number and of VectorizedArrayType do not match.");
 
 public:
@@ -7900,7 +7900,7 @@ namespace internal
     // into the vector to the evaluate() and integrate() calls, without
     // reading the vector entries into a separate data field. This saves some
     // operations.
-    if (std::is_same<typename VectorType::value_type, Number>::value &&
+    if (std::is_same_v<typename VectorType::value_type, Number> &&
         dof_info.index_storage_variants
             [internal::MatrixFreeFunctions::DoFInfo::dof_access_cell][cell] ==
           internal::MatrixFreeFunctions::DoFInfo::IndexStorageVariants::

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -2685,7 +2685,7 @@ namespace internal
 
       using VectorizedDouble =
         VectorizedArray<double,
-                        ((std::is_same<Number, float>::value &&
+                        ((std::is_same_v<Number, float> &&
                           VectorizedArrayType::size() > 1) ?
                            VectorizedArrayType::size() / 2 :
                            VectorizedArrayType::size())>;

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -113,7 +113,7 @@ template <int dim,
 class MatrixFree : public Subscriptor
 {
   static_assert(
-    std::is_same<Number, typename VectorizedArrayType::value_type>::value,
+    std::is_same_v<Number, typename VectorizedArrayType::value_type>,
     "Type of Number and of VectorizedArrayType do not match.");
 
 public:
@@ -3458,9 +3458,8 @@ namespace internal
     update_ghost_values_start(const unsigned int component_in_block_vector,
                               const VectorType & vec)
     {
-      static_assert(
-        std::is_same<Number, typename VectorType::value_type>::value,
-        "Type mismatch between VectorType and VectorDataExchange");
+      static_assert(std::is_same_v<Number, typename VectorType::value_type>,
+                    "Type mismatch between VectorType and VectorDataExchange");
       (void)component_in_block_vector;
       const bool ghosts_set = vec.has_ghost_elements();
 
@@ -3552,9 +3551,8 @@ namespace internal
     update_ghost_values_finish(const unsigned int component_in_block_vector,
                                const VectorType & vec)
     {
-      static_assert(
-        std::is_same<Number, typename VectorType::value_type>::value,
-        "Type mismatch between VectorType and VectorDataExchange");
+      static_assert(std::is_same_v<Number, typename VectorType::value_type>,
+                    "Type mismatch between VectorType and VectorDataExchange");
       (void)component_in_block_vector;
 
       if (vec.size() != 0)
@@ -3658,9 +3656,8 @@ namespace internal
     compress_start(const unsigned int component_in_block_vector,
                    VectorType &       vec)
     {
-      static_assert(
-        std::is_same<Number, typename VectorType::value_type>::value,
-        "Type mismatch between VectorType and VectorDataExchange");
+      static_assert(std::is_same_v<Number, typename VectorType::value_type>,
+                    "Type mismatch between VectorType and VectorDataExchange");
       (void)component_in_block_vector;
       Assert(vec.has_ghost_elements() == false, ExcNotImplemented());
 
@@ -3745,9 +3742,8 @@ namespace internal
     compress_finish(const unsigned int component_in_block_vector,
                     VectorType &       vec)
     {
-      static_assert(
-        std::is_same<Number, typename VectorType::value_type>::value,
-        "Type mismatch between VectorType and VectorDataExchange");
+      static_assert(std::is_same_v<Number, typename VectorType::value_type>,
+                    "Type mismatch between VectorType and VectorDataExchange");
       (void)component_in_block_vector;
       if (vec.size() != 0)
         {
@@ -3833,9 +3829,8 @@ namespace internal
     void
     reset_ghost_values(const VectorType &vec) const
     {
-      static_assert(
-        std::is_same<Number, typename VectorType::value_type>::value,
-        "Type mismatch between VectorType and VectorDataExchange");
+      static_assert(std::is_same_v<Number, typename VectorType::value_type>,
+                    "Type mismatch between VectorType and VectorDataExchange");
       if (ghosts_were_set == true)
         return;
 
@@ -3877,9 +3872,8 @@ namespace internal
     void
     zero_vector_region(const unsigned int range_index, VectorType &vec) const
     {
-      static_assert(
-        std::is_same<Number, typename VectorType::value_type>::value,
-        "Type mismatch between VectorType and VectorDataExchange");
+      static_assert(std::is_same_v<Number, typename VectorType::value_type>,
+                    "Type mismatch between VectorType and VectorDataExchange");
       if (range_index == numbers::invalid_unsigned_int)
         vec = Number();
       else

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -622,7 +622,7 @@ namespace MatrixFreeOperators
   class CellwiseInverseMassMatrix
   {
     static_assert(
-      std::is_same<Number, typename VectorizedArrayType::value_type>::value,
+      std::is_same_v<Number, typename VectorizedArrayType::value_type>,
       "Type of Number and of VectorizedArrayType do not match.");
 
   public:
@@ -1838,7 +1838,7 @@ namespace MatrixFreeOperators
   {
 #ifndef DEAL_II_MSVC
     static_assert(
-      std::is_same<typename VectorType::value_type, value_type>::value,
+      std::is_same_v<typename VectorType::value_type, value_type>,
       "The vector type must be based on the same value type as this "
       "operator");
 #endif
@@ -1858,7 +1858,7 @@ namespace MatrixFreeOperators
   {
 #ifndef DEAL_II_MSVC
     static_assert(
-      std::is_same<typename VectorType::value_type, value_type>::value,
+      std::is_same_v<typename VectorType::value_type, value_type>,
       "The vector type must be based on the same value type as this "
       "operator");
 #endif

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -1086,7 +1086,7 @@ namespace internal
         univariate_shape_data.inverse_shape_values_eo;
 
       const double zero_tol =
-        std::is_same<Number, double>::value == true ? 1e-12 : 1e-7;
+        std::is_same_v<Number, double> == true ? 1e-12 : 1e-7;
       // symmetry for values
       const unsigned int n_dofs_1d = fe_degree + 1;
       for (unsigned int i = 0; i < (n_dofs_1d + 1) / 2; ++i)
@@ -1206,7 +1206,7 @@ namespace internal
       auto &     shape_values = univariate_shape_data.shape_values;
 
       const double zero_tol =
-        std::is_same<Number, double>::value == true ? 1e-12 : 1e-7;
+        std::is_same_v<Number, double> == true ? 1e-12 : 1e-7;
       // check: identity operation for shape values
       const unsigned int n_points_1d = fe_degree + 1;
       for (unsigned int i = 0; i < n_points_1d; ++i)

--- a/include/deal.II/matrix_free/type_traits.h
+++ b/include/deal.II/matrix_free/type_traits.h
@@ -117,7 +117,7 @@ namespace internal
       has_begin<T> &&
       (has_local_element<T> ||
        is_serial_vector<typename std::remove_const<T>::type>::value) &&
-      std::is_same<typename T::value_type, Number>::value;
+      std::is_same_v<typename T::value_type, Number>;
   };
 
   // We need to have a separate declaration for static const members

--- a/include/deal.II/multigrid/mg_coarse.h
+++ b/include/deal.II/multigrid/mg_coarse.h
@@ -362,14 +362,13 @@ namespace internal
 {
   namespace MGCoarseGridIterativeSolver
   {
-    template <
-      typename VectorType,
-      typename SolverType,
-      typename MatrixType,
-      typename PreconditionerType,
-      std::enable_if_t<
-        std::is_same<VectorType, typename SolverType::vector_type>::value,
-        VectorType> * = nullptr>
+    template <typename VectorType,
+              typename SolverType,
+              typename MatrixType,
+              typename PreconditionerType,
+              std::enable_if_t<
+                std::is_same_v<VectorType, typename SolverType::vector_type>,
+                VectorType> * = nullptr>
     void
     solve(SolverType &              solver,
           const MatrixType &        matrix,
@@ -380,14 +379,13 @@ namespace internal
       solver.solve(matrix, dst, src, preconditioner);
     }
 
-    template <
-      typename VectorType,
-      typename SolverType,
-      typename MatrixType,
-      typename PreconditionerType,
-      std::enable_if_t<
-        !std::is_same<VectorType, typename SolverType::vector_type>::value,
-        VectorType> * = nullptr>
+    template <typename VectorType,
+              typename SolverType,
+              typename MatrixType,
+              typename PreconditionerType,
+              std::enable_if_t<
+                !std::is_same_v<VectorType, typename SolverType::vector_type>,
+                VectorType> * = nullptr>
     void
     solve(SolverType &              solver,
           const MatrixType &        matrix,

--- a/include/deal.II/numerics/adaptation_strategies.h
+++ b/include/deal.II/numerics/adaptation_strategies.h
@@ -230,7 +230,7 @@ namespace AdaptationStrategies
           const value_type parent_value)
     {
       static_assert(std::is_arithmetic<value_type>::value &&
-                      !std::is_same<value_type, bool>::value,
+                      !std::is_same_v<value_type, bool>,
                     "The provided value_type may not meet the requirements "
                     "of this function.");
 
@@ -248,7 +248,7 @@ namespace AdaptationStrategies
             const value_type parent_value)
     {
       static_assert(std::is_arithmetic<value_type>::value &&
-                      !std::is_same<value_type, bool>::value,
+                      !std::is_same_v<value_type, bool>,
                     "The provided value_type may not meet the requirements "
                     "of this function.");
 
@@ -290,7 +290,7 @@ namespace AdaptationStrategies
         const std::vector<value_type> &children_values)
     {
       static_assert(std::is_arithmetic<value_type>::value &&
-                      !std::is_same<value_type, bool>::value,
+                      !std::is_same_v<value_type, bool>,
                     "The provided value_type may not meet the requirements "
                     "of this function.");
 
@@ -309,7 +309,7 @@ namespace AdaptationStrategies
       const std::vector<value_type> &children_values)
     {
       static_assert(std::is_arithmetic<value_type>::value &&
-                      !std::is_same<value_type, bool>::value,
+                      !std::is_same_v<value_type, bool>,
                     "The provided value_type may not meet the requirements "
                     "of this function.");
 

--- a/include/deal.II/sundials/arkode.h
+++ b/include/deal.II/sundials/arkode.h
@@ -1099,14 +1099,13 @@ namespace SUNDIALS
 
 #  ifdef DEAL_II_WITH_PETSC
 #    ifdef PETSC_USE_COMPLEX
-    static_assert(!std::is_same<VectorType, PETScWrappers::MPI::Vector>::value,
+    static_assert(!std::is_same_v<VectorType, PETScWrappers::MPI::Vector>,
                   "Sundials does not support complex scalar types, "
                   "but PETSc is configured to use a complex scalar type!");
 
-    static_assert(
-      !std::is_same<VectorType, PETScWrappers::MPI::BlockVector>::value,
-      "Sundials does not support complex scalar types, "
-      "but PETSc is configured to use a complex scalar type!");
+    static_assert(!std::is_same_v<VectorType, PETScWrappers::MPI::BlockVector>,
+                  "Sundials does not support complex scalar types, "
+                  "but PETSc is configured to use a complex scalar type!");
 #    endif // PETSC_USE_COMPLEX
 #  endif   // DEAL_II_WITH_PETSC
   };

--- a/include/deal.II/sundials/ida.h
+++ b/include/deal.II/sundials/ida.h
@@ -874,14 +874,13 @@ namespace SUNDIALS
 
 #  ifdef DEAL_II_WITH_PETSC
 #    ifdef PETSC_USE_COMPLEX
-    static_assert(!std::is_same<VectorType, PETScWrappers::MPI::Vector>::value,
+    static_assert(!std::is_same_v<VectorType, PETScWrappers::MPI::Vector>,
                   "Sundials does not support complex scalar types, "
                   "but PETSc is configured to use a complex scalar type!");
 
-    static_assert(
-      !std::is_same<VectorType, PETScWrappers::MPI::BlockVector>::value,
-      "Sundials does not support complex scalar types, "
-      "but PETSc is configured to use a complex scalar type!");
+    static_assert(!std::is_same_v<VectorType, PETScWrappers::MPI::BlockVector>,
+                  "Sundials does not support complex scalar types, "
+                  "but PETSc is configured to use a complex scalar type!");
 #    endif // PETSC_USE_COMPLEX
 #  endif   // DEAL_II_WITH_PETSC
   };

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -81,10 +81,9 @@ namespace Utilities
     const unsigned int            n_partitions,
     const types::global_dof_index total_size)
   {
-    static_assert(
-      std::is_same<types::global_dof_index, IndexSet::size_type>::value,
-      "IndexSet::size_type must match types::global_dof_index for "
-      "using this function");
+    static_assert(std::is_same_v<types::global_dof_index, IndexSet::size_type>,
+                  "IndexSet::size_type must match types::global_dof_index for "
+                  "using this function");
     const unsigned int remain = total_size % n_partitions;
 
     const IndexSet::size_type min_size = total_size / n_partitions;
@@ -237,7 +236,7 @@ namespace Utilities
       const types::global_dof_index locally_owned_size)
     {
       static_assert(
-        std::is_same<types::global_dof_index, IndexSet::size_type>::value,
+        std::is_same_v<types::global_dof_index, IndexSet::size_type>,
         "IndexSet::size_type must match types::global_dof_index for "
         "using this function");
       const unsigned int                     n_proc = n_mpi_processes(comm);

--- a/source/differentiation/ad/adolc_number_types.cc
+++ b/source/differentiation/ad/adolc_number_types.cc
@@ -50,7 +50,7 @@ namespace numbers
           double,
           Differentiation::AD::NumberTypes::adolc_taped>::ad_type;
         static_assert(
-          std::is_same<adouble, ad_type>::value,
+          std::is_same_v<adouble, ad_type>,
           "The type of the AD number is not that which was expected.");
         const ad_type result = comparator(value_1, value_2);
         return !(Differentiation::AD::ADNumberTraits<ad_type>::get_scalar_value(

--- a/source/lac/lapack_full_matrix.cc
+++ b/source/lac/lapack_full_matrix.cc
@@ -57,8 +57,7 @@ namespace internal
                 const types::blas_int work_flag,
                 types::blas_int &     info)
     {
-      static_assert(std::is_same<T, double>::value ||
-                      std::is_same<T, float>::value,
+      static_assert(std::is_same_v<T, double> || std::is_same_v<T, float>,
                     "Only implemented for double and float");
       Assert(matrix.size() == static_cast<std::size_t>(n_rows * n_rows),
              ExcInternalError());
@@ -113,7 +112,7 @@ namespace internal
                 types::blas_int &             info)
     {
       static_assert(
-        std::is_same<T, double>::value || std::is_same<T, float>::value,
+        std::is_same_v<T, double> || std::is_same_v<T, float>,
         "Only implemented for std::complex<double> and std::complex<float>");
       Assert(matrix.size() == static_cast<std::size_t>(n_rows * n_rows),
              ExcInternalError());

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -796,7 +796,7 @@ namespace TrilinosWrappers
 
   template <typename SparsityPatternType>
   inline std::enable_if_t<
-    !std::is_same<SparsityPatternType, dealii::SparseMatrix<double>>::value>
+    !std::is_same_v<SparsityPatternType, dealii::SparseMatrix<double>>>
   SparseMatrix::reinit(const IndexSet &           row_parallel_partitioning,
                        const IndexSet &           col_parallel_partitioning,
                        const SparsityPatternType &sparsity_pattern,
@@ -1972,7 +1972,7 @@ namespace TrilinosWrappers
 
   template <typename VectorType>
   std::enable_if_t<
-    std::is_same<typename VectorType::value_type, TrilinosScalar>::value>
+    std::is_same_v<typename VectorType::value_type, TrilinosScalar>>
   SparseMatrix::vmult(VectorType &dst, const VectorType &src) const
   {
     Assert(&src != &dst, ExcSourceEqualsDestination());
@@ -2006,7 +2006,7 @@ namespace TrilinosWrappers
 
   template <typename VectorType>
   std::enable_if_t<
-    !std::is_same<typename VectorType::value_type, TrilinosScalar>::value>
+    !std::is_same_v<typename VectorType::value_type, TrilinosScalar>>
   SparseMatrix::vmult(VectorType & /*dst*/, const VectorType & /*src*/) const
   {
     AssertThrow(false, ExcNotImplemented());
@@ -2016,7 +2016,7 @@ namespace TrilinosWrappers
 
   template <typename VectorType>
   std::enable_if_t<
-    std::is_same<typename VectorType::value_type, TrilinosScalar>::value>
+    std::is_same_v<typename VectorType::value_type, TrilinosScalar>>
   SparseMatrix::Tvmult(VectorType &dst, const VectorType &src) const
   {
     Assert(&src != &dst, ExcSourceEqualsDestination());
@@ -2047,7 +2047,7 @@ namespace TrilinosWrappers
 
   template <typename VectorType>
   std::enable_if_t<
-    !std::is_same<typename VectorType::value_type, TrilinosScalar>::value>
+    !std::is_same_v<typename VectorType::value_type, TrilinosScalar>>
   SparseMatrix::Tvmult(VectorType & /*dst*/, const VectorType & /*src*/) const
   {
     AssertThrow(false, ExcNotImplemented());

--- a/source/matrix_free/dof_info.cc
+++ b/source/matrix_free/dof_info.cc
@@ -34,7 +34,7 @@ namespace internal
   {
     // ensure that the type defined in both dof_info.h and
     // hanging_nodes_internal.h is consistent
-    static_assert(std::is_same<compressed_constraint_kind, std::uint8_t>::value,
+    static_assert(std::is_same_v<compressed_constraint_kind, std::uint8_t>,
                   "Unexpected type for compressed hanging node indicators!");
 
 

--- a/tests/base/functions_13.cc
+++ b/tests/base/functions_13.cc
@@ -50,20 +50,18 @@ main()
                 "Wrong return type for FunctionTime<float>::get_time().");
 
   MyFunction<1, std::complex<double>> function_1;
-  static_assert(std::is_same<decltype(function_1.get_time()), double>::value,
+  static_assert(std::is_same_v<decltype(function_1.get_time()), double>,
                 "Wrong return type for Function<double>::get_time().");
   MyFunction<2, std::complex<float>> function_2;
-  static_assert(std::is_same<decltype(function_2.get_time()), float>::value,
+  static_assert(std::is_same_v<decltype(function_2.get_time()), float>,
                 "Wrong return type for Function<float>::get_time().");
 
   MyTensorFunction<1, 1, std::complex<double>> tensor_function_1;
-  static_assert(
-    std::is_same<decltype(tensor_function_1.get_time()), double>::value,
-    "Wrong return type for TensorFunction<double>::get_time().");
+  static_assert(std::is_same_v<decltype(tensor_function_1.get_time()), double>,
+                "Wrong return type for TensorFunction<double>::get_time().");
   MyTensorFunction<2, 2, std::complex<float>> tensor_function_2;
-  static_assert(
-    std::is_same<decltype(tensor_function_2.get_time()), float>::value,
-    "Wrong return type for TensorFunction<float>::get_time().");
+  static_assert(std::is_same_v<decltype(tensor_function_2.get_time()), float>,
+                "Wrong return type for TensorFunction<float>::get_time().");
 
   deallog << "OK" << std::endl;
 }

--- a/tests/base/hdf5_03.cc
+++ b/tests/base/hdf5_03.cc
@@ -29,7 +29,7 @@
 
 // This function initializes a container of Number type
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, std::vector<Number>>::value,
+std::enable_if_t<std::is_same_v<Container<Number>, std::vector<Number>>,
                  Container<Number>>
 initialize_container(std::vector<hsize_t> dimensions)
 {
@@ -38,7 +38,7 @@ initialize_container(std::vector<hsize_t> dimensions)
 }
 
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, Vector<Number>>::value,
+std::enable_if_t<std::is_same_v<Container<Number>, Vector<Number>>,
                  Container<Number>>
 initialize_container(std::vector<hsize_t> dimensions)
 {
@@ -47,7 +47,7 @@ initialize_container(std::vector<hsize_t> dimensions)
 }
 
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, FullMatrix<Number>>::value,
+std::enable_if_t<std::is_same_v<Container<Number>, FullMatrix<Number>>,
                  Container<Number>>
 initialize_container(std::vector<hsize_t> dimensions)
 {
@@ -56,23 +56,21 @@ initialize_container(std::vector<hsize_t> dimensions)
 
 // This function calculates the sum of the elements in a container
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, std::vector<Number>>::value,
-                 Number>
+std::enable_if_t<std::is_same_v<Container<Number>, std::vector<Number>>, Number>
 container_sum(Container<Number> data)
 {
   return std::accumulate(data.begin(), data.end(), static_cast<Number>(0));
 }
 
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, Vector<Number>>::value, Number>
+std::enable_if_t<std::is_same_v<Container<Number>, Vector<Number>>, Number>
 container_sum(Container<Number> data)
 {
   return std::accumulate(data.begin(), data.end(), static_cast<Number>(0));
 }
 
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, FullMatrix<Number>>::value,
-                 Number>
+std::enable_if_t<std::is_same_v<Container<Number>, FullMatrix<Number>>, Number>
 container_sum(Container<Number> data)
 {
   Number sum = 0;
@@ -106,8 +104,7 @@ get_factor()
 
 // This function assigns data to the elements of the container
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, std::vector<Number>>::value,
-                 void>
+std::enable_if_t<std::is_same_v<Container<Number>, std::vector<Number>>, void>
 assign_data(Container<Number> &data)
 {
   for (unsigned int idx = 0; idx < data.size(); ++idx)
@@ -117,7 +114,7 @@ assign_data(Container<Number> &data)
 }
 
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, Vector<Number>>::value, void>
+std::enable_if_t<std::is_same_v<Container<Number>, Vector<Number>>, void>
 assign_data(Container<Number> &data)
 {
   for (unsigned int idx = 0; idx < data.size(); ++idx)
@@ -127,8 +124,7 @@ assign_data(Container<Number> &data)
 }
 
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, FullMatrix<Number>>::value,
-                 void>
+std::enable_if_t<std::is_same_v<Container<Number>, FullMatrix<Number>>, void>
 assign_data(Container<Number> &data)
 {
   for (unsigned int row_idx = 0; row_idx < data.m(); ++row_idx)
@@ -155,36 +151,36 @@ write_test(HDF5::Group &              root_group,
   std::string container_name;
   std::string type_name;
 
-  if (std::is_same<Container<Number>, std::vector<Number>>::value)
+  if (std::is_same_v<Container<Number>, std::vector<Number>>)
     {
       container_name = std::string("std::vector");
     }
-  else if (std::is_same<Container<Number>, FullMatrix<Number>>::value)
+  else if (std::is_same_v<Container<Number>, FullMatrix<Number>>)
     {
       container_name = std::string("FullMatrix");
     }
 
-  if (std::is_same<Number, float>::value)
+  if (std::is_same_v<Number, float>)
     {
       type_name = std::string("float");
     }
-  else if (std::is_same<Number, double>::value)
+  else if (std::is_same_v<Number, double>)
     {
       type_name = std::string("double");
     }
-  else if (std::is_same<Number, std::complex<float>>::value)
+  else if (std::is_same_v<Number, std::complex<float>>)
     {
       type_name = std::string("std::complex<float>");
     }
-  else if (std::is_same<Number, std::complex<double>>::value)
+  else if (std::is_same_v<Number, std::complex<double>>)
     {
       type_name = std::string("std::complex<double>");
     }
-  else if (std::is_same<Number, int>::value)
+  else if (std::is_same_v<Number, int>)
     {
       type_name = std::string("int");
     }
-  else if (std::is_same<Number, unsigned int>::value)
+  else if (std::is_same_v<Number, unsigned int>)
     {
       type_name = std::string("unsigned int");
     }
@@ -318,7 +314,7 @@ write_test(HDF5::Group &              root_group,
   {
     // In this dataset, data conversion is tested. The test is only performed
     // for float and double.
-    if (std::is_same<Number, float>::value)
+    if (std::is_same_v<Number, float>)
       {
         std::string dataset_name("dataset_3");
         auto        dataset =
@@ -347,7 +343,7 @@ write_test(HDF5::Group &              root_group,
                 << type_name << '>' << " (Write): " << container_sum(data)
                 << std::endl;
       }
-    else if (std::is_same<Number, double>::value)
+    else if (std::is_same_v<Number, double>)
       {
         std::string dataset_name("dataset_3");
         auto        dataset =
@@ -483,36 +479,36 @@ read_test(HDF5::Group        root_group,
   std::string container_name;
   std::string type_name;
 
-  if (std::is_same<Container<Number>, std::vector<Number>>::value)
+  if (std::is_same_v<Container<Number>, std::vector<Number>>)
     {
       container_name = std::string("std::vector");
     }
-  else if (std::is_same<Container<Number>, FullMatrix<Number>>::value)
+  else if (std::is_same_v<Container<Number>, FullMatrix<Number>>)
     {
       container_name = std::string("FullMatrix");
     }
 
-  if (std::is_same<Number, float>::value)
+  if (std::is_same_v<Number, float>)
     {
       type_name = std::string("float");
     }
-  else if (std::is_same<Number, double>::value)
+  else if (std::is_same_v<Number, double>)
     {
       type_name = std::string("double");
     }
-  else if (std::is_same<Number, std::complex<float>>::value)
+  else if (std::is_same_v<Number, std::complex<float>>)
     {
       type_name = std::string("std::complex<float>");
     }
-  else if (std::is_same<Number, std::complex<double>>::value)
+  else if (std::is_same_v<Number, std::complex<double>>)
     {
       type_name = std::string("std::complex<double>");
     }
-  else if (std::is_same<Number, int>::value)
+  else if (std::is_same_v<Number, int>)
     {
       type_name = std::string("int");
     }
-  else if (std::is_same<Number, unsigned int>::value)
+  else if (std::is_same_v<Number, unsigned int>)
     {
       type_name = std::string("unsigned int");
     }
@@ -615,8 +611,7 @@ read_test(HDF5::Group        root_group,
   {
     // In this test data conversion is tested. The dataset only exists for
     // float and double.
-    if (std::is_same<Number, float>::value ||
-        std::is_same<Number, double>::value)
+    if (std::is_same_v<Number, float> || std::is_same_v<Number, double>)
       {
         std::string dataset_name("dataset_3");
         auto        dataset = group.open_dataset(dataset_name);

--- a/tests/base/hdf5_04.cc
+++ b/tests/base/hdf5_04.cc
@@ -28,7 +28,7 @@
 
 // This function initializes a container of Number type
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, std::vector<Number>>::value,
+std::enable_if_t<std::is_same_v<Container<Number>, std::vector<Number>>,
                  Container<Number>>
 initialize_container(std::vector<hsize_t> dimensions)
 {
@@ -37,7 +37,7 @@ initialize_container(std::vector<hsize_t> dimensions)
 }
 
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, Vector<Number>>::value,
+std::enable_if_t<std::is_same_v<Container<Number>, Vector<Number>>,
                  Container<Number>>
 initialize_container(std::vector<hsize_t> dimensions)
 {
@@ -46,7 +46,7 @@ initialize_container(std::vector<hsize_t> dimensions)
 }
 
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, FullMatrix<Number>>::value,
+std::enable_if_t<std::is_same_v<Container<Number>, FullMatrix<Number>>,
                  Container<Number>>
 initialize_container(std::vector<hsize_t> dimensions)
 {
@@ -55,23 +55,21 @@ initialize_container(std::vector<hsize_t> dimensions)
 
 // This function calculates the sum of the elements in a container
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, std::vector<Number>>::value,
-                 Number>
+std::enable_if_t<std::is_same_v<Container<Number>, std::vector<Number>>, Number>
 container_sum(Container<Number> data)
 {
   return std::accumulate(data.begin(), data.end(), static_cast<Number>(0));
 }
 
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, Vector<Number>>::value, Number>
+std::enable_if_t<std::is_same_v<Container<Number>, Vector<Number>>, Number>
 container_sum(Container<Number> data)
 {
   return std::accumulate(data.begin(), data.end(), static_cast<Number>(0));
 }
 
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, FullMatrix<Number>>::value,
-                 Number>
+std::enable_if_t<std::is_same_v<Container<Number>, FullMatrix<Number>>, Number>
 container_sum(Container<Number> data)
 {
   Number sum = 0;
@@ -105,8 +103,7 @@ get_factor()
 
 // This function assigns data to the elements of the container
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, std::vector<Number>>::value,
-                 void>
+std::enable_if_t<std::is_same_v<Container<Number>, std::vector<Number>>, void>
 assign_data(Container<Number> &data)
 {
   for (unsigned int idx = 0; idx < data.size(); ++idx)
@@ -116,7 +113,7 @@ assign_data(Container<Number> &data)
 }
 
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, Vector<Number>>::value, void>
+std::enable_if_t<std::is_same_v<Container<Number>, Vector<Number>>, void>
 assign_data(Container<Number> &data)
 {
   for (unsigned int idx = 0; idx < data.size(); ++idx)
@@ -126,8 +123,7 @@ assign_data(Container<Number> &data)
 }
 
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, FullMatrix<Number>>::value,
-                 void>
+std::enable_if_t<std::is_same_v<Container<Number>, FullMatrix<Number>>, void>
 assign_data(Container<Number> &data)
 {
   for (unsigned int row_idx = 0; row_idx < data.m(); ++row_idx)
@@ -152,36 +148,36 @@ write_test(HDF5::Group &              root_group,
   std::string container_name;
   std::string type_name;
 
-  if (std::is_same<Container<Number>, std::vector<Number>>::value)
+  if (std::is_same_v<Container<Number>, std::vector<Number>>)
     {
       container_name = std::string("std::vector");
     }
-  else if (std::is_same<Container<Number>, FullMatrix<Number>>::value)
+  else if (std::is_same_v<Container<Number>, FullMatrix<Number>>)
     {
       container_name = std::string("FullMatrix");
     }
 
-  if (std::is_same<Number, float>::value)
+  if (std::is_same_v<Number, float>)
     {
       type_name = std::string("float");
     }
-  else if (std::is_same<Number, double>::value)
+  else if (std::is_same_v<Number, double>)
     {
       type_name = std::string("double");
     }
-  else if (std::is_same<Number, std::complex<float>>::value)
+  else if (std::is_same_v<Number, std::complex<float>>)
     {
       type_name = std::string("std::complex<float>");
     }
-  else if (std::is_same<Number, std::complex<double>>::value)
+  else if (std::is_same_v<Number, std::complex<double>>)
     {
       type_name = std::string("std::complex<double>");
     }
-  else if (std::is_same<Number, int>::value)
+  else if (std::is_same_v<Number, int>)
     {
       type_name = std::string("int");
     }
-  else if (std::is_same<Number, unsigned int>::value)
+  else if (std::is_same_v<Number, unsigned int>)
     {
       type_name = std::string("unsigned int");
     }
@@ -295,7 +291,7 @@ write_test(HDF5::Group &              root_group,
   {
     // In this dataset, data conversion is tested. The test is only performed
     // for float and double.
-    if (std::is_same<Number, float>::value)
+    if (std::is_same_v<Number, float>)
       {
         std::string dataset_name("dataset_3");
         auto        dataset =
@@ -317,7 +313,7 @@ write_test(HDF5::Group &              root_group,
                 << type_name << '>' << " (Write): " << container_sum(data)
                 << std::endl;
       }
-    else if (std::is_same<Number, double>::value)
+    else if (std::is_same_v<Number, double>)
       {
         std::string dataset_name("dataset_3");
         auto        dataset =
@@ -437,36 +433,36 @@ read_test(HDF5::Group root_group)
   std::string container_name;
   std::string type_name;
 
-  if (std::is_same<Container<Number>, std::vector<Number>>::value)
+  if (std::is_same_v<Container<Number>, std::vector<Number>>)
     {
       container_name = std::string("std::vector");
     }
-  else if (std::is_same<Container<Number>, FullMatrix<Number>>::value)
+  else if (std::is_same_v<Container<Number>, FullMatrix<Number>>)
     {
       container_name = std::string("FullMatrix");
     }
 
-  if (std::is_same<Number, float>::value)
+  if (std::is_same_v<Number, float>)
     {
       type_name = std::string("float");
     }
-  else if (std::is_same<Number, double>::value)
+  else if (std::is_same_v<Number, double>)
     {
       type_name = std::string("double");
     }
-  else if (std::is_same<Number, std::complex<float>>::value)
+  else if (std::is_same_v<Number, std::complex<float>>)
     {
       type_name = std::string("std::complex<float>");
     }
-  else if (std::is_same<Number, std::complex<double>>::value)
+  else if (std::is_same_v<Number, std::complex<double>>)
     {
       type_name = std::string("std::complex<double>");
     }
-  else if (std::is_same<Number, int>::value)
+  else if (std::is_same_v<Number, int>)
     {
       type_name = std::string("int");
     }
-  else if (std::is_same<Number, unsigned int>::value)
+  else if (std::is_same_v<Number, unsigned int>)
     {
       type_name = std::string("unsigned int");
     }
@@ -569,8 +565,7 @@ read_test(HDF5::Group root_group)
   {
     // In this test data conversion is tested. The dataset only exists for
     // float and double.
-    if (std::is_same<Number, float>::value ||
-        std::is_same<Number, double>::value)
+    if (std::is_same_v<Number, float> || std::is_same_v<Number, double>)
       {
         std::string dataset_name("dataset_3");
         auto        dataset = group.open_dataset(dataset_name);

--- a/tests/base/hdf5_05.cc
+++ b/tests/base/hdf5_05.cc
@@ -31,7 +31,7 @@
 
 // This function initializes a container of Number type
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, std::vector<Number>>::value,
+std::enable_if_t<std::is_same_v<Container<Number>, std::vector<Number>>,
                  Container<Number>>
 initialize_container(std::vector<hsize_t> dimensions)
 {
@@ -42,7 +42,7 @@ initialize_container(std::vector<hsize_t> dimensions)
 
 
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, Vector<Number>>::value,
+std::enable_if_t<std::is_same_v<Container<Number>, Vector<Number>>,
                  Container<Number>>
 initialize_container(std::vector<hsize_t> dimensions)
 {
@@ -53,7 +53,7 @@ initialize_container(std::vector<hsize_t> dimensions)
 
 
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, FullMatrix<Number>>::value,
+std::enable_if_t<std::is_same_v<Container<Number>, FullMatrix<Number>>,
                  Container<Number>>
 initialize_container(std::vector<hsize_t> dimensions)
 {
@@ -64,8 +64,7 @@ initialize_container(std::vector<hsize_t> dimensions)
 
 // This function assigns data to the elements of the container
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, std::vector<Number>>::value,
-                 void>
+std::enable_if_t<std::is_same_v<Container<Number>, std::vector<Number>>, void>
 assign_data(Container<Number> &data)
 {
   for (unsigned int idx = 0; idx < data.size(); ++idx)
@@ -77,7 +76,7 @@ assign_data(Container<Number> &data)
 
 
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, Vector<Number>>::value, void>
+std::enable_if_t<std::is_same_v<Container<Number>, Vector<Number>>, void>
 assign_data(Container<Number> &data)
 {
   for (unsigned int idx = 0; idx < data.size(); ++idx)
@@ -89,8 +88,7 @@ assign_data(Container<Number> &data)
 
 
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, FullMatrix<Number>>::value,
-                 void>
+std::enable_if_t<std::is_same_v<Container<Number>, FullMatrix<Number>>, void>
 assign_data(Container<Number> &data)
 {
   for (unsigned int row_idx = 0; row_idx < data.m(); ++row_idx)
@@ -175,27 +173,27 @@ type_to_string()
 {
   std::string type_name;
 
-  if (std::is_same<Number, float>::value)
+  if (std::is_same_v<Number, float>)
     {
       type_name = std::string("float");
     }
-  else if (std::is_same<Number, double>::value)
+  else if (std::is_same_v<Number, double>)
     {
       type_name = std::string("double");
     }
-  else if (std::is_same<Number, std::complex<float>>::value)
+  else if (std::is_same_v<Number, std::complex<float>>)
     {
       type_name = std::string("std::complex<float>");
     }
-  else if (std::is_same<Number, std::complex<double>>::value)
+  else if (std::is_same_v<Number, std::complex<double>>)
     {
       type_name = std::string("std::complex<double>");
     }
-  else if (std::is_same<Number, int>::value)
+  else if (std::is_same_v<Number, int>)
     {
       type_name = std::string("int");
     }
-  else if (std::is_same<Number, unsigned int>::value)
+  else if (std::is_same_v<Number, unsigned int>)
     {
       type_name = std::string("unsigned int");
     }

--- a/tests/base/hdf5_06.cc
+++ b/tests/base/hdf5_06.cc
@@ -31,7 +31,7 @@
 
 // This function initializes a container of Number type
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, std::vector<Number>>::value,
+std::enable_if_t<std::is_same_v<Container<Number>, std::vector<Number>>,
                  Container<Number>>
 initialize_container(std::vector<hsize_t> dimensions)
 {
@@ -42,7 +42,7 @@ initialize_container(std::vector<hsize_t> dimensions)
 
 
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, Vector<Number>>::value,
+std::enable_if_t<std::is_same_v<Container<Number>, Vector<Number>>,
                  Container<Number>>
 initialize_container(std::vector<hsize_t> dimensions)
 {
@@ -53,7 +53,7 @@ initialize_container(std::vector<hsize_t> dimensions)
 
 
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, FullMatrix<Number>>::value,
+std::enable_if_t<std::is_same_v<Container<Number>, FullMatrix<Number>>,
                  Container<Number>>
 initialize_container(std::vector<hsize_t> dimensions)
 {
@@ -64,8 +64,7 @@ initialize_container(std::vector<hsize_t> dimensions)
 
 // This function assigns data to the elements of the container
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, std::vector<Number>>::value,
-                 void>
+std::enable_if_t<std::is_same_v<Container<Number>, std::vector<Number>>, void>
 assign_data(Container<Number> &data)
 {
   for (unsigned int idx = 0; idx < data.size(); ++idx)
@@ -77,7 +76,7 @@ assign_data(Container<Number> &data)
 
 
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, Vector<Number>>::value, void>
+std::enable_if_t<std::is_same_v<Container<Number>, Vector<Number>>, void>
 assign_data(Container<Number> &data)
 {
   for (unsigned int idx = 0; idx < data.size(); ++idx)
@@ -89,8 +88,7 @@ assign_data(Container<Number> &data)
 
 
 template <template <class...> class Container, typename Number>
-std::enable_if_t<std::is_same<Container<Number>, FullMatrix<Number>>::value,
-                 void>
+std::enable_if_t<std::is_same_v<Container<Number>, FullMatrix<Number>>, void>
 assign_data(Container<Number> &data)
 {
   for (unsigned int row_idx = 0; row_idx < data.m(); ++row_idx)
@@ -175,27 +173,27 @@ type_to_string()
 {
   std::string type_name;
 
-  if (std::is_same<Number, float>::value)
+  if (std::is_same_v<Number, float>)
     {
       type_name = std::string("float");
     }
-  else if (std::is_same<Number, double>::value)
+  else if (std::is_same_v<Number, double>)
     {
       type_name = std::string("double");
     }
-  else if (std::is_same<Number, std::complex<float>>::value)
+  else if (std::is_same_v<Number, std::complex<float>>)
     {
       type_name = std::string("std::complex<float>");
     }
-  else if (std::is_same<Number, std::complex<double>>::value)
+  else if (std::is_same_v<Number, std::complex<double>>)
     {
       type_name = std::string("std::complex<double>");
     }
-  else if (std::is_same<Number, int>::value)
+  else if (std::is_same_v<Number, int>)
     {
       type_name = std::string("int");
     }
-  else if (std::is_same<Number, unsigned int>::value)
+  else if (std::is_same_v<Number, unsigned int>)
     {
       type_name = std::string("unsigned int");
     }

--- a/tests/base/ndarray.cc
+++ b/tests/base/ndarray.cc
@@ -33,12 +33,11 @@ main()
   dealii::ndarray<double, 1, 2, 3>    r3;
   dealii::ndarray<double, 1, 2, 3, 4> r4;
 
-  static_assert(std::is_same<decltype(r0), double>::value,
-                "types must be the same");
-  static_assert(std::is_same<decltype(r1), std::array<double, 1>>::value,
+  static_assert(std::is_same_v<decltype(r0), double>, "types must be the same");
+  static_assert(std::is_same_v<decltype(r1), std::array<double, 1>>,
                 "types must be the same");
   static_assert(
-    std::is_same<decltype(r2), std::array<std::array<double, 2>, 1>>::value,
+    std::is_same_v<decltype(r2), std::array<std::array<double, 2>, 1>>,
     "types must be the same");
   static_assert(
     std::is_same<decltype(r3),

--- a/tests/base/transpose_table_iterators_1.cc
+++ b/tests/base/transpose_table_iterators_1.cc
@@ -66,19 +66,17 @@ main()
 
   // test some type equalities
   static_assert(
-    std::is_same<decltype(table.begin()->value()), double &>::value,
+    std::is_same_v<decltype(table.begin()->value()), double &>,
     "The iterator value for a non-const table should not be const.");
   static_assert(
-    std::is_same<decltype(table.end()->value()), double &>::value,
+    std::is_same_v<decltype(table.end()->value()), double &>,
     "The iterator value for a non-const table should not be const.");
 
   const TransposeTable<double> &ref = table;
-  static_assert(
-    std::is_same<decltype(ref.begin()->value()), const double &>::value,
-    "The iterator value for a constant table should be const.");
-  static_assert(
-    std::is_same<decltype(ref.end()->value()), const double &>::value,
-    "The iterator value for a constant table should be const.");
+  static_assert(std::is_same_v<decltype(ref.begin()->value()), const double &>,
+                "The iterator value for a constant table should be const.");
+  static_assert(std::is_same_v<decltype(ref.end()->value()), const double &>,
+                "The iterator value for a constant table should be const.");
 
   deallog << "OK" << std::endl;
 }

--- a/tests/fe/fe_values_view_get_function_from_local_dof_values_01.cc
+++ b/tests/fe/fe_values_view_get_function_from_local_dof_values_01.cc
@@ -57,8 +57,7 @@ test_view(const Vector<double> &            solution,
   using View = typename std::remove_reference<
     typename std::remove_const<decltype(fe_values[extractor])>::type>::type;
   const View &     fe_values_view = fe_values[extractor];
-  const NumberType tolerance =
-    std::is_same<NumberType, float>::value ? 1e-5 : 1e-13;
+  const NumberType tolerance = std::is_same_v<NumberType, float> ? 1e-5 : 1e-13;
 
   // Typedefs
   using value_type =
@@ -152,8 +151,7 @@ test_view(const Vector<double> &            solution,
   using View = typename std::remove_reference<
     typename std::remove_const<decltype(fe_values[extractor])>::type>::type;
   const View &     fe_values_view = fe_values[extractor];
-  const NumberType tolerance =
-    std::is_same<NumberType, float>::value ? 1e-5 : 1e-13;
+  const NumberType tolerance = std::is_same_v<NumberType, float> ? 1e-5 : 1e-13;
 
   // Typedefs
   using value_type =
@@ -295,8 +293,7 @@ test_view(const Vector<double> &                        solution,
   using View = typename std::remove_reference<
     typename std::remove_const<decltype(fe_values[extractor])>::type>::type;
   const View &     fe_values_view = fe_values[extractor];
-  const NumberType tolerance =
-    std::is_same<NumberType, float>::value ? 1e-5 : 1e-13;
+  const NumberType tolerance = std::is_same_v<NumberType, float> ? 1e-5 : 1e-13;
 
   // Typedefs
   using value_type =
@@ -353,8 +350,7 @@ test_view(const Vector<double> &               solution,
     typename ProductType<typename View::gradient_type, NumberType>::type;
   using divergence_type =
     typename ProductType<typename View::divergence_type, NumberType>::type;
-  const NumberType tolerance =
-    std::is_same<NumberType, float>::value ? 1e-5 : 1e-13;
+  const NumberType tolerance = std::is_same_v<NumberType, float> ? 1e-5 : 1e-13;
 
   // Values
   std::vector<typename View::template solution_value_type<NumberType>>

--- a/tests/grid/filtered_iterator_08.cc
+++ b/tests/grid/filtered_iterator_08.cc
@@ -65,7 +65,7 @@ test()
           //
           // using C1 = typename std::decay<decltype(cell)>::type;
           // using C2 = typename std::decay<decltype(cell_neighbor)>::type;
-          // static_assert(std::is_same<C1, C2>::value,
+          // static_assert(std::is_same_v<C1, C2>,
           //               "Cell iterator types are not identical.");
 
           fe_interface_values.reinit(cell,

--- a/tests/lac/gmres_eigenvalues.cc
+++ b/tests/lac/gmres_eigenvalues.cc
@@ -68,7 +68,7 @@ test(unsigned int variant)
       }
   else
     Assert(false, ExcMessage("Invalid variant"));
-  if (std::is_same<number, float>::value == true)
+  if (std::is_same_v<number, float> == true)
     Assert(variant < 4, ExcMessage("Invalid_variant"));
 
   deallog.push(Utilities::int_to_string(variant, 1));

--- a/tests/lac/gmres_reorthogonalize_01.cc
+++ b/tests/lac/gmres_reorthogonalize_01.cc
@@ -63,7 +63,7 @@ test(unsigned int variant, unsigned int min_convergence_steps)
       matrix(i, i) = 1e30 * (i + 1) * (i + 1) * (i + 1) * (i + 1);
   else
     Assert(false, ExcMessage("Invalid variant"));
-  if (std::is_same<number, float>::value == true)
+  if (std::is_same_v<number, float> == true)
     Assert(variant < 4, ExcMessage("Invalid_variant"));
 
   deallog.push(Utilities::int_to_string(variant, 1));

--- a/tests/lac/gmres_reorthogonalize_03.cc
+++ b/tests/lac/gmres_reorthogonalize_03.cc
@@ -61,7 +61,7 @@ test(unsigned int variant)
       matrix(i, i) = 1e30 * (i + 1) * (i + 1) * (i + 1) * (i + 1);
   else
     Assert(false, ExcMessage("Invalid variant"));
-  if (std::is_same<number, float>::value == true)
+  if (std::is_same_v<number, float> == true)
     Assert(variant < 4, ExcMessage("Invalid_variant"));
 
   deallog.push(Utilities::int_to_string(variant, 1));

--- a/tests/lac/la_parallel_vector_add_and_dot_complex.cc
+++ b/tests/lac/la_parallel_vector_add_and_dot_complex.cc
@@ -53,7 +53,7 @@ check()
 
       // then do it a second time with the add_and_dot function
       const std::complex<number> prod_check = check.add_and_dot(factor, v2, v3);
-      if (test == 0 && std::is_same<number, double>::value)
+      if (test == 0 && std::is_same_v<number, double>)
         {
           deallog << "Vector add reference:   ";
           v1.print(deallog.get_file_stream());

--- a/tests/lac/sparse_matrices.cc
+++ b/tests/lac/sparse_matrices.cc
@@ -126,7 +126,7 @@ check_vmult_quadratic(std::vector<double> &residuals,
 
   // vanka needs to match the type
   using value_type = typename MatrixType::value_type;
-  if (std::is_same<MatrixType, SparseMatrix<value_type>>::value)
+  if (std::is_same_v<MatrixType, SparseMatrix<value_type>>)
     {
       deallog << "Vanka" << std::endl;
       const SparseMatrix<value_type> &B =

--- a/tests/lac/vector_add_and_dot.cc
+++ b/tests/lac/vector_add_and_dot.cc
@@ -47,7 +47,7 @@ check()
 
       // then do it a second time with the add_and_dot function
       const number prod_check = check.add_and_dot(factor, v2, v3);
-      if (test == 0 && std::is_same<number, double>::value)
+      if (test == 0 && std::is_same_v<number, double>)
         {
           deallog << "Vector add reference:   " << std::flush;
           v1.print(deallog.get_file_stream(), 7);

--- a/tests/lac/vector_add_and_dot_complex.cc
+++ b/tests/lac/vector_add_and_dot_complex.cc
@@ -49,7 +49,7 @@ check()
 
       // then do it a second time with the add_and_dot function
       const std::complex<number> prod_check = check.add_and_dot(factor, v2, v3);
-      if (test == 0 && std::is_same<number, double>::value)
+      if (test == 0 && std::is_same_v<number, double>)
         {
           deallog << "Vector add reference:   " << std::flush;
           v1.print(deallog.get_file_stream(), 7);

--- a/tests/matrix_free/dof_info_01.cc
+++ b/tests/matrix_free/dof_info_01.cc
@@ -145,7 +145,7 @@ test(const bool adaptive_ref = true)
       DoFTools::map_dofs_to_support_points(mapping, dof, support_points);
 
       const std::string prefix =
-        std::is_same<float, number>::value ? "float_" : "double_";
+        std::is_same_v<float, number> ? "float_" : "double_";
       const std::string href = (adaptive_ref ? "" : "global_");
       const std::string base_filename =
         prefix + href + "grid" + dealii::Utilities::int_to_string(dim) + "_" +

--- a/tests/matrix_free/dof_info_02.cc
+++ b/tests/matrix_free/dof_info_02.cc
@@ -147,7 +147,7 @@ test(const bool adaptive_ref = true)
       DoFTools::map_dofs_to_support_points(mapping, dof, support_points);
 
       const std::string prefix =
-        std::is_same<float, number>::value ? "float_" : "double_";
+        std::is_same_v<float, number> ? "float_" : "double_";
       const std::string href = (adaptive_ref ? "" : "global_");
       const std::string base_filename =
         prefix + href + "grid" + dealii::Utilities::int_to_string(dim) + "_" +

--- a/tests/matrix_free/get_functions_common.h
+++ b/tests/matrix_free/get_functions_common.h
@@ -163,7 +163,7 @@ public:
 
     // for doubles, use a stricter condition than
     // for floats for the relative error size
-    if (std::is_same<Number, double>::value == true)
+    if (std::is_same_v<Number, double> == true)
       {
         deallog << "Error function values: " << errors[0] / total[0]
                 << std::endl;
@@ -186,7 +186,7 @@ public:
         const double output4 = total[4] == 0 ? 0. : errors[4] / total[4];
         deallog << "Error function Hessians: " << output4 << std::endl;
       }
-    else if (std::is_same<Number, float>::value == true)
+    else if (std::is_same_v<Number, float> == true)
       {
         deallog << "Error function values: " << errors[0] / total[0]
                 << std::endl;

--- a/tests/matrix_free/get_functions_multife.cc
+++ b/tests/matrix_free/get_functions_multife.cc
@@ -160,7 +160,7 @@ public:
     // for floats for the relative error size
     for (unsigned int i = 0; i < 2; ++i)
       {
-        if (std::is_same<Number, double>::value == true)
+        if (std::is_same_v<Number, double> == true)
           {
             deallog << "Error function values FE " << i << ": "
                     << errors[i * 3 + 0] / total[i * 3 + 0] << std::endl;
@@ -180,7 +180,7 @@ public:
             deallog << "Error function Laplacians FE " << i << ": " << output2
                     << std::endl;
           }
-        else if (std::is_same<Number, float>::value == true)
+        else if (std::is_same_v<Number, float> == true)
           {
             deallog << "Error function values FE " << i << ": "
                     << errors[i * 3 + 0] / total[i * 3 + 0] << std::endl;

--- a/tests/matrix_free/get_functions_multife2.cc
+++ b/tests/matrix_free/get_functions_multife2.cc
@@ -200,7 +200,7 @@ public:
     // for floats for the relative error size
     for (unsigned int i = 0; i < 3; ++i)
       {
-        if (std::is_same<Number, double>::value == true)
+        if (std::is_same_v<Number, double> == true)
           {
             deallog << "Error function values FE " << i << ": "
                     << errors[i * 3 + 0] / total[i * 3 + 0] << std::endl;
@@ -220,7 +220,7 @@ public:
             deallog << "Error function Laplacians FE " << i << ": " << output2
                     << std::endl;
           }
-        else if (std::is_same<Number, float>::value == true)
+        else if (std::is_same_v<Number, float> == true)
           {
             deallog << "Error function values FE " << i << ": "
                     << errors[i * 3 + 0] / total[i * 3 + 0] << std::endl;

--- a/tests/matrix_free/interpolate_functions_common.h
+++ b/tests/matrix_free/interpolate_functions_common.h
@@ -258,7 +258,7 @@ public:
               dst_dummy,
               src);
 
-    if (std::is_same<Number, float>::value)
+    if (std::is_same_v<Number, float>)
       for (unsigned int i = 0; i < 4; ++i)
         {
           if (cell_errors[i] / cell_times < 1e-5)

--- a/tests/matrix_free/matrix_vector_faces_common.h
+++ b/tests/matrix_free/matrix_vector_faces_common.h
@@ -765,7 +765,7 @@ do_test(const DoFHandler<dim> &          dof,
         const AffineConstraints<double> &constraints,
         const bool                       also_test_parallel = false)
 {
-  if (std::is_same<number, float>::value == true)
+  if (std::is_same_v<number, float> == true)
     deallog.push("float");
 
   deallog << "Testing " << dof.get_fe().get_name();
@@ -876,7 +876,7 @@ do_test(const DoFHandler<dim> &          dof,
     }
   deallog << std::endl;
 
-  if (std::is_same<number, float>::value == true)
+  if (std::is_same_v<number, float> == true)
     deallog.pop();
 }
 

--- a/tests/matrix_free/parallel_multigrid.cc
+++ b/tests/matrix_free/parallel_multigrid.cc
@@ -339,7 +339,7 @@ template <int dim, int fe_degree, int n_q_points_1d, typename number>
 void
 do_test(const DoFHandler<dim> &dof)
 {
-  if (std::is_same<number, float>::value == true)
+  if (std::is_same_v<number, float> == true)
     {
       deallog.push("float");
     }
@@ -420,7 +420,7 @@ do_test(const DoFHandler<dim> &dof)
     solver.solve(fine_matrix, sol, in, preconditioner);
   }
 
-  if (std::is_same<number, float>::value == true)
+  if (std::is_same_v<number, float> == true)
     deallog.pop();
 }
 

--- a/tests/matrix_free/parallel_multigrid_02.cc
+++ b/tests/matrix_free/parallel_multigrid_02.cc
@@ -86,7 +86,7 @@ template <int dim, int fe_degree, int n_q_points_1d, typename number>
 void
 do_test(const DoFHandler<dim> &dof)
 {
-  if (std::is_same<number, float>::value == true)
+  if (std::is_same_v<number, float> == true)
     {
       deallog.push("float");
     }
@@ -234,7 +234,7 @@ do_test(const DoFHandler<dim> &dof)
     solver.solve(fine_matrix, sol, in, preconditioner);
   }
 
-  if (std::is_same<number, float>::value == true)
+  if (std::is_same_v<number, float> == true)
     deallog.pop();
 
   fine_matrix.clear();

--- a/tests/matrix_free/parallel_multigrid_adaptive_01.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_01.cc
@@ -496,7 +496,7 @@ template <int dim, int fe_degree, int n_q_points_1d, typename number>
 void
 do_test(const DoFHandler<dim> &dof)
 {
-  if (std::is_same<number, float>::value == true)
+  if (std::is_same_v<number, float> == true)
     {
       deallog.push("float");
     }
@@ -611,7 +611,7 @@ do_test(const DoFHandler<dim> &dof)
     solver.solve(fine_matrix, sol, in, preconditioner);
   }
 
-  if (std::is_same<number, float>::value == true)
+  if (std::is_same_v<number, float> == true)
     deallog.pop();
 }
 

--- a/tests/matrix_free/parallel_multigrid_adaptive_02.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_02.cc
@@ -124,7 +124,7 @@ template <int dim, int fe_degree, int n_q_points_1d, typename number>
 void
 do_test(const DoFHandler<dim> &dof)
 {
-  if (std::is_same<number, float>::value == true)
+  if (std::is_same_v<number, float> == true)
     {
       deallog.push("float");
     }
@@ -299,7 +299,7 @@ do_test(const DoFHandler<dim> &dof)
     solver.solve(fine_matrix, sol, in, preconditioner);
   }
 
-  if (std::is_same<number, float>::value == true)
+  if (std::is_same_v<number, float> == true)
     deallog.pop();
 
   fine_matrix.clear();

--- a/tests/matrix_free/parallel_multigrid_adaptive_04.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_04.cc
@@ -124,7 +124,7 @@ template <int dim, int fe_degree, int n_q_points_1d, typename number>
 void
 do_test(const DoFHandler<dim> &dof)
 {
-  if (std::is_same<number, float>::value == true)
+  if (std::is_same_v<number, float> == true)
     {
       deallog.push("float");
     }
@@ -297,7 +297,7 @@ do_test(const DoFHandler<dim> &dof)
     solver.solve(fine_matrix, sol, in, preconditioner);
   }
 
-  if (std::is_same<number, float>::value == true)
+  if (std::is_same_v<number, float> == true)
     deallog.pop();
 
   fine_matrix.clear();

--- a/tests/matrix_free/parallel_multigrid_adaptive_06.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_06.cc
@@ -209,7 +209,7 @@ template <int dim, int fe_degree, int n_q_points_1d, typename number>
 void
 do_test(const DoFHandler<dim> &dof, const unsigned int nb)
 {
-  if (std::is_same<number, float>::value == true)
+  if (std::is_same_v<number, float> == true)
     {
       deallog.push("float");
     }
@@ -377,7 +377,7 @@ do_test(const DoFHandler<dim> &dof, const unsigned int nb)
     solver.solve(fine_matrix, sol, in, preconditioner);
   }
 
-  if (std::is_same<number, float>::value == true)
+  if (std::is_same_v<number, float> == true)
     deallog.pop();
 
   fine_matrix.clear();

--- a/tests/matrix_free/parallel_multigrid_adaptive_06ref.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_06ref.cc
@@ -125,7 +125,7 @@ template <int dim, int fe_degree, int n_q_points_1d, typename number>
 void
 do_test(const DoFHandler<dim> &dof)
 {
-  if (std::is_same<number, float>::value == true)
+  if (std::is_same_v<number, float> == true)
     {
       deallog.push("float");
     }
@@ -286,7 +286,7 @@ do_test(const DoFHandler<dim> &dof)
     solver.solve(fine_matrix, sol, in, preconditioner);
   }
 
-  if (std::is_same<number, float>::value == true)
+  if (std::is_same_v<number, float> == true)
     deallog.pop();
 
   fine_matrix.clear();

--- a/tests/matrix_free/parallel_multigrid_adaptive_07.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_07.cc
@@ -223,7 +223,7 @@ void
 do_test(const std::vector<const DoFHandler<dim> *> &dof)
 {
   const unsigned int nb = 2;
-  if (std::is_same<number, float>::value == true)
+  if (std::is_same_v<number, float> == true)
     {
       deallog.push("float");
     }
@@ -413,7 +413,7 @@ do_test(const std::vector<const DoFHandler<dim> *> &dof)
     solver.solve(fine_matrix, sol, in, preconditioner);
   }
 
-  if (std::is_same<number, float>::value == true)
+  if (std::is_same_v<number, float> == true)
     deallog.pop();
 
   fine_matrix.clear();

--- a/tests/matrix_free/point_evaluation_01.cc
+++ b/tests/matrix_free/point_evaluation_01.cc
@@ -91,7 +91,7 @@ test(const unsigned int degree)
   // For float numbers that are sensitive to roundoff in the numdiff
   // tolerances (absolute 1e-8), we multiply by 1e-3 to ensure that the test
   // remains robust
-  const double factor_float = std::is_same<Number, float>::value ? 0.001 : 1.;
+  const double factor_float = std::is_same_v<Number, float> ? 0.001 : 1.;
 
   for (const auto &cell : dof_handler.active_cell_iterators())
     {

--- a/tests/matrix_free/point_evaluation_21.cc
+++ b/tests/matrix_free/point_evaluation_21.cc
@@ -90,7 +90,7 @@ test(const unsigned int degree)
   // For float numbers that are sensitive to roundoff in the numdiff
   // tolerances (absolute 1e-8), we multiply by 1e-3 to ensure that the test
   // remains robust
-  const double factor_float = std::is_same<Number, float>::value ? 0.001 : 1.;
+  const double factor_float = std::is_same_v<Number, float> ? 0.001 : 1.;
 
   for (const auto &cell : dof_handler.active_cell_iterators())
     {

--- a/tests/matrix_free/point_evaluation_22.cc
+++ b/tests/matrix_free/point_evaluation_22.cc
@@ -99,7 +99,7 @@ test(const unsigned int degree, const bool is_mapping_q = true)
   // For float numbers that are sensitive to roundoff in the numdiff
   // tolerances (absolute 1e-8), we multiply by 1e-3 to ensure that the test
   // remains robust
-  const double factor_float = std::is_same<Number, float>::value ? 0.001 : 1.;
+  const double factor_float = std::is_same_v<Number, float> ? 0.001 : 1.;
 
   for (const auto &cell : dof_handler.active_cell_iterators())
     {

--- a/tests/matrix_free/point_evaluation_25.cc
+++ b/tests/matrix_free/point_evaluation_25.cc
@@ -89,7 +89,7 @@ test(const unsigned int degree)
   // For float numbers that are sensitive to roundoff in the numdiff
   // tolerances (absolute 1e-8), we multiply by 1e-3 to ensure that the test
   // remains robust
-  const double factor_float = std::is_same<Number, float>::value ? 0.001 : 1.;
+  const double factor_float = std::is_same_v<Number, float> ? 0.001 : 1.;
 
   for (const auto &cell : dof_handler.active_cell_iterators())
     {

--- a/tests/matrix_free/thread_correctness.cc
+++ b/tests/matrix_free/thread_correctness.cc
@@ -131,8 +131,7 @@ sub_test()
 
       // make 10 sweeps in order to get in some
       // variation to the threaded program
-      const double float_factor =
-        std::is_same<number, float>::value ? 0.01 : 1.;
+      const double float_factor = std::is_same_v<number, float> ? 0.01 : 1.;
       for (unsigned int sweep = 0; sweep < 10; ++sweep)
         {
           mf_color.vmult(out_color, in_dist);

--- a/tests/matrix_free/thread_correctness_dg.cc
+++ b/tests/matrix_free/thread_correctness_dg.cc
@@ -139,14 +139,14 @@ sub_test()
 
           out_color -= out_dist;
           double diff_norm = out_color.linfty_norm();
-          if (std::is_same<number, float>::value && diff_norm < 5e-6)
+          if (std::is_same_v<number, float> && diff_norm < 5e-6)
             diff_norm = 0;
           deallog << "Sweep " << sweep
                   << ", error in partition/color:                  "
                   << diff_norm << std::endl;
           out_partition -= out_dist;
           diff_norm = out_partition.linfty_norm();
-          if (std::is_same<number, float>::value && diff_norm < 5e-6)
+          if (std::is_same_v<number, float> && diff_norm < 5e-6)
             diff_norm = 0;
           deallog << "Sweep " << sweep
                   << ", error in partition/partition:              "

--- a/tests/multithreading/work_stream_01b.cc
+++ b/tests/multithreading/work_stream_01b.cc
@@ -38,7 +38,7 @@ using IteratorType      = typename std::vector<unsigned int>::iterator;
 using IteratorRangeType = IteratorRange<IteratorType>;
 
 static_assert(
-  std::is_same<typename IteratorRangeType::iterator, IteratorType>::value,
+  std::is_same_v<typename IteratorRangeType::iterator, IteratorType>,
   "Iterator types not the same");
 
 struct X

--- a/tests/petsc/step-67-with-petsc-ts.cc
+++ b/tests/petsc/step-67-with-petsc-ts.cc
@@ -2248,7 +2248,7 @@ namespace Euler_DG
             << Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD)
             << " MPI processes" << std::endl;
       // pcout << "Vectorization over " << n_vect_number << ' '
-      //       << (std::is_same<Number, double>::value ? "doubles" : "floats")
+      //       << (std::is_same_v<Number, double> ? "doubles" : "floats")
       //       << " = " << n_vect_bits << " bits ("
       //       << Utilities::System::get_current_vectorization_level() << ')'
       //       << std::endl;

--- a/tests/simplex/step-67.cc
+++ b/tests/simplex/step-67.cc
@@ -2395,7 +2395,7 @@ namespace Euler_DG
             << Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD)
             << " MPI processes" << std::endl;
       pcout << "Vectorization over " << n_vect_number << ' '
-            << (std::is_same<Number, double>::value ? "doubles" : "floats")
+            << (std::is_same_v<Number, double> ? "doubles" : "floats")
             << " = " << n_vect_bits << " bits ("
             << Utilities::System::get_current_vectorization_level() << ')'
             << std::endl;

--- a/tests/tensors/project_orthogonal.cc
+++ b/tests/tensors/project_orthogonal.cc
@@ -23,9 +23,9 @@ template <int dim, typename number>
 void
 print_type(const Tensor<2, dim, number> &)
 {
-  if (std::is_same<number, float>::value)
+  if (std::is_same_v<number, float>)
     deallog << " Tensor<2, " << dim << ", float>" << std::endl;
-  else if (std::is_same<number, double>::value)
+  else if (std::is_same_v<number, double>)
     deallog << " Tensor<2, " << dim << ", double>" << std::endl;
   else
     Assert(false, ExcNotImplemented());

--- a/tests/tensors/symmetric_tensor_46.cc
+++ b/tests/tensors/symmetric_tensor_46.cc
@@ -30,7 +30,7 @@ main()
 
   {
     const SymmetricTensor<2, 3, double> st{};
-    static_assert(std::is_same<decltype(st[0][0]), const double &>::value);
+    static_assert(std::is_same_v<decltype(st[0][0]), const double &>);
   }
 
   {


### PR DESCRIPTION
C++17 now has these nice shortcuts. Let's use them.