### PR TITLE
Small markup fixes.

### DIFF
--- a/examples/step-33/step-33.cc
+++ b/examples/step-33/step-33.cc
@@ -1633,7 +1633,7 @@ namespace Step33
   // $\mathbf{z}_i$ is the $i$th vector valued test function.
   //   Furthermore, the scalar product
   // $\left(\mathbf{F}(\mathbf{w}), \nabla\mathbf{z}_i\right)_K$ is
-  // understood as $\int_K \sum_{c=1}^{\text{n\_components}}
+  // understood as $\int_K \sum_{c=1}^{\text{n_components}}
   // \sum_{d=1}^{\text{dim}} \mathbf{F}(\mathbf{w})_{cd}
   // \frac{\partial z^c_i}{x_d}$ where $z^c_i$ is the $c$th component of
   // the $i$th test function.
@@ -1812,21 +1812,21 @@ namespace Step33
     // @f{eqnarray*}{
     // R_i &=&
     // \left(\frac{(\mathbf{w}_{n+1} -
-    // \mathbf{w}_n)_{\text{component\_i}}}{\delta
-    // t},(\mathbf{z}_i)_{\text{component\_i}}\right)_K
+    // \mathbf{w}_n)_{\text{component_i}}}{\delta
+    // t},(\mathbf{z}_i)_{\text{component_i}}\right)_K
     // \\ &-& \sum_{d=1}^{\text{dim}} \left(  \theta \mathbf{F}
-    // ({\mathbf{w}^k_{n+1}})_{\text{component\_i},d} + (1-\theta)
-    // \mathbf{F} ({\mathbf{w}_{n}})_{\text{component\_i},d}  ,
-    // \frac{\partial(\mathbf{z}_i)_{\text{component\_i}}} {\partial
+    // ({\mathbf{w}^k_{n+1}})_{\text{component_i},d} + (1-\theta)
+    // \mathbf{F} ({\mathbf{w}_{n}})_{\text{component_i},d}  ,
+    // \frac{\partial(\mathbf{z}_i)_{\text{component_i}}} {\partial
     // x_d}\right)_K
     // \\ &+& \sum_{d=1}^{\text{dim}} h^{\eta} \left( \theta \frac{\partial
-    // (\mathbf{w}^k_{n+1})_{\text{component\_i}}}{\partial x_d} + (1-\theta)
-    // \frac{\partial (\mathbf{w}_n)_{\text{component\_i}}}{\partial x_d} ,
-    // \frac{\partial (\mathbf{z}_i)_{\text{component\_i}}}{\partial x_d}
+    // (\mathbf{w}^k_{n+1})_{\text{component_i}}}{\partial x_d} + (1-\theta)
+    // \frac{\partial (\mathbf{w}_n)_{\text{component_i}}}{\partial x_d} ,
+    // \frac{\partial (\mathbf{z}_i)_{\text{component_i}}}{\partial x_d}
     // \right)_K
-    // \\ &-& \left( \theta\mathbf{G}({\mathbf{w}^k_n+1} )_{\text{component\_i}}
-    // + (1-\theta)\mathbf{G}({\mathbf{w}_n})_{\text{component\_i}} ,
-    // (\mathbf{z}_i)_{\text{component\_i}} \right)_K ,
+    // \\ &-& \left( \theta\mathbf{G}({\mathbf{w}^k_n+1} )_{\text{component_i}}
+    // + (1-\theta)\mathbf{G}({\mathbf{w}_n})_{\text{component_i}} ,
+    // (\mathbf{z}_i)_{\text{component_i}} \right)_K ,
     // @f}
     // where integrals are
     // understood to be evaluated through summation over quadrature points.

--- a/tests/sundials/kinsol_03.cc
+++ b/tests/sundials/kinsol_03.cc
@@ -28,11 +28,11 @@
 // the Jacobian matrix. For the current case,
 //
 //   F(u) = [  cos(u1 + u2) - 1 + 2*u1  ]
-//          [  sin(u1 - u2)     + 2*u2   ]
+//          [  sin(u1 - u2)     + 2*u2  ]
 //
 // the Jacobian is the 2x2 matrix
 //
-//   J(u) = [ -sin(u1 + u2) + 2      -sin(u1 + u2)]
+//   J(u) = [ -sin(u1 + u2) + 2      -sin(u1 + u2)    ]
 //          [  cos(u1 - u2)          -cos(u1 - u2) + 2]
 //
 // The addition of the +2u_i to the function F does not move the solution


### PR DESCRIPTION
step-33 has all of these places where MathJAX translates `$\text{component\_i}$ to a formula that includes the backslash. Latex requires the backslash, but since we're not using latex, let's get rid of the backslash.

While there, let me also fix a place where the spacing in a test bothered me.