### PR TITLE
When outputting numbers of tests, align the text.

### DIFF
--- a/cmake/macros/macro_deal_ii_pickup_tests.cmake
+++ b/cmake/macros/macro_deal_ii_pickup_tests.cmake
@@ -84,6 +84,47 @@ macro(set_if_empty _variable)
 endmacro()
 
 
+function(pad_string_right output _str _length)
+  string(LENGTH "${_str}" _strlen)
+  math(EXPR _strlen "${_length} - ${_strlen}")
+
+  if(_strlen GREATER 0)
+    if(${CMAKE_VERSION} VERSION_LESS "3.14")
+      unset(_pad)
+      foreach(_i RANGE 1 ${_strlen}) # inclusive
+        string(APPEND _pad " ")
+      endforeach()
+    else()
+      string(REPEAT " " ${_strlen} _pad)
+    endif()
+    set(_str "${_str}${_pad}")
+  endif()
+
+  set(${output} "${_str}" PARENT_SCOPE)
+endfunction()
+
+
+function(pad_string_left output _str _length)
+  string(LENGTH "${_str}" _strlen)
+  math(EXPR _strlen "${_length} - ${_strlen}")
+
+  if(_strlen GREATER 0)
+    if(${CMAKE_VERSION} VERSION_LESS "3.14")
+      unset(_pad)
+      foreach(_i RANGE 1 ${_strlen}) # inclusive
+        string(APPEND _pad " ")
+      endforeach()
+    else()
+      string(REPEAT " " ${_strlen} _pad)
+    endif()
+    set(_str "${_pad}${_str}")
+  endif()
+
+  set(${output} "${_str}" PARENT_SCOPE)
+endfunction()
+
+
+
 macro(deal_ii_pickup_tests)
   #
   # Initialize two counters to zero:
@@ -345,6 +386,11 @@ Comparison operator \"=\" expected for boolean match.\n"
   endforeach()
 
   if(NOT "${_number_of_tests}" STREQUAL "0")
-    message(STATUS "Test category \"${_category}\": ${_number_of_tests} tests (and ${_number_of_test_dependencies} test dependencies)")
+    # Pad the category to 27 characters -- that's currently the longest
+    # category (namely, 'multigrid-global-coarsening'). Pad numbers to 4 digits
+    pad_string_right(_category ${_category} 27)
+    pad_string_left(_number_of_tests ${_number_of_tests} 4)
+    pad_string_left(_number_of_test_dependencies ${_number_of_test_dependencies} 4)
+    message(STATUS "Test category ${_category}: ${_number_of_tests} tests (and ${_number_of_test_dependencies} test dependencies)")
   endif()
 endmacro()


### PR DESCRIPTION
This then looks as follows:
```
-- Test category codim_one                  :    8 tests (and    0 test dependencies)
-- Test category distributed_grids          :  156 tests (and   28 test dependencies)
-- Test category feinterface                :    2 tests (and    0 test dependencies)
-- Test category fullydistributed_grids     :   80 tests (and   54 test dependencies)
-- Test category grid                       :  764 tests (and   54 test dependencies)
-- Test category mappings                   :    2 tests (and    0 test dependencies)
-- Test category matrix_free                :   52 tests (and   38 test dependencies)
-- Test category mpi                        :    8 tests (and    4 test dependencies)
-- Test category multigrid                  :  270 tests (and   79 test dependencies)
-- Test category multigrid-global-coarsening:   78 tests (and   50 test dependencies)
-- Test category sharedtria                 :    4 tests (and    4 test dependencies)
-- Test category simplex                    :   14 tests (and    0 test dependencies)
```