### PR TITLE
Manually fix up some std::is_same<...> places.

### DIFF
--- a/include/deal.II/base/array_view.h
+++ b/include/deal.II/base/array_view.h
@@ -704,12 +704,12 @@ ArrayView<typename std::remove_reference<
 make_array_view(const Iterator begin, const Iterator end)
 {
   static_assert(
-    std::is_same<typename std::iterator_traits<Iterator>::iterator_category,
-                 typename std::random_access_iterator_tag>::value
+    std::is_same_v<typename std::iterator_traits<Iterator>::iterator_category,
+                   typename std::random_access_iterator_tag>
 #ifdef DEAL_II_HAVE_CXX20
       ||
-      std::is_same<typename std::iterator_traits<Iterator>::iterator_category,
-                   typename std::contiguous_iterator_tag>::value
+      std::is_same_v<typename std::iterator_traits<Iterator>::iterator_category,
+                     typename std::contiguous_iterator_tag>
 #endif
     ,
     "The provided iterator needs to be a random access iterator.");

--- a/include/deal.II/base/hdf5.h
+++ b/include/deal.II/base/hdf5.h
@@ -1211,8 +1211,7 @@ namespace HDF5
      */
     template <typename Container>
     std::enable_if_t<
-      std::is_same<Container,
-                   std::vector<typename Container::value_type>>::value,
+      std::is_same_v<Container, std::vector<typename Container::value_type>>,
       Container>
     initialize_container(const std::vector<hsize_t> &dimensions);
 
@@ -1230,8 +1229,7 @@ namespace HDF5
      */
     template <typename Container>
     std::enable_if_t<
-      std::is_same<Container,
-                   FullMatrix<typename Container::value_type>>::value,
+      std::is_same_v<Container, FullMatrix<typename Container::value_type>>,
       Container>
     initialize_container(const std::vector<hsize_t> &dimensions);
 
@@ -1419,8 +1417,7 @@ namespace HDF5
 
     template <typename Container>
     std::enable_if_t<
-      std::is_same<Container,
-                   std::vector<typename Container::value_type>>::value,
+      std::is_same_v<Container, std::vector<typename Container::value_type>>,
       Container>
     initialize_container(const std::vector<hsize_t> &dimensions)
     {
@@ -1444,8 +1441,7 @@ namespace HDF5
 
     template <typename Container>
     std::enable_if_t<
-      std::is_same<Container,
-                   FullMatrix<typename Container::value_type>>::value,
+      std::is_same_v<Container, FullMatrix<typename Container::value_type>>,
       Container>
     initialize_container(const std::vector<hsize_t> &dimensions)
     {

--- a/include/deal.II/base/mpi.templates.h
+++ b/include/deal.II/base/mpi.templates.h
@@ -157,8 +157,8 @@ namespace Utilities
     void
     sum(const T &values, const MPI_Comm mpi_communicator, U &sums)
     {
-      static_assert(std::is_same<typename std::decay<T>::type,
-                                 typename std::decay<U>::type>::value,
+      static_assert(std::is_same_v<typename std::decay<T>::type,
+                                   typename std::decay<U>::type>,
                     "Input and output arguments must have the same type!");
       const auto array_view_values = make_array_view(values);
       using const_type =
@@ -272,8 +272,8 @@ namespace Utilities
     void
     max(const T &values, const MPI_Comm mpi_communicator, U &maxima)
     {
-      static_assert(std::is_same<typename std::decay<T>::type,
-                                 typename std::decay<U>::type>::value,
+      static_assert(std::is_same_v<typename std::decay<T>::type,
+                                   typename std::decay<U>::type>,
                     "Input and output arguments must have the same type!");
       const auto array_view_values = make_array_view(values);
       using const_type =
@@ -314,8 +314,8 @@ namespace Utilities
     void
     min(const T &values, const MPI_Comm mpi_communicator, U &minima)
     {
-      static_assert(std::is_same<typename std::decay<T>::type,
-                                 typename std::decay<U>::type>::value,
+      static_assert(std::is_same_v<typename std::decay<T>::type,
+                                   typename std::decay<U>::type>,
                     "Input and output arguments must have the same type!");
       const auto array_view_values = make_array_view(values);
       using const_type =
@@ -359,8 +359,8 @@ namespace Utilities
     void
     logical_or(const T &values, const MPI_Comm mpi_communicator, U &results)
     {
-      static_assert(std::is_same<typename std::decay<T>::type,
-                                 typename std::decay<U>::type>::value,
+      static_assert(std::is_same_v<typename std::decay<T>::type,
+                                   typename std::decay<U>::type>,
                     "Input and output arguments must have the same type!");
 
       static_assert(std::is_integral<typename T::value_type>::value,

--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -715,8 +715,8 @@ namespace internal
     template <typename F>
     static constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE T
     value(const F &f,
-          std::enable_if_t<!std::is_same<typename std::decay<T>::type,
-                                         typename std::decay<F>::type>::value &&
+          std::enable_if_t<!std::is_same_v<typename std::decay<T>::type,
+                                           typename std::decay<F>::type> &&
                            std::is_constructible<T, F>::value> * = nullptr)
     {
       return T(f);
@@ -726,8 +726,8 @@ namespace internal
     template <typename F>
     static constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE T
     value(const F &f,
-          std::enable_if_t<!std::is_same<typename std::decay<T>::type,
-                                         typename std::decay<F>::type>::value &&
+          std::enable_if_t<!std::is_same_v<typename std::decay<T>::type,
+                                           typename std::decay<F>::type> &&
                            !std::is_constructible<T, F>::value &&
                            is_explicitly_convertible<const F, T>::value> * =
             nullptr)
@@ -743,8 +743,8 @@ namespace internal
     static T
     value(
       const F &f,
-      std::enable_if_t<!std::is_same<typename std::decay<T>::type,
-                                     typename std::decay<F>::type>::value &&
+      std::enable_if_t<!std::is_same_v<typename std::decay<T>::type,
+                                       typename std::decay<F>::type> &&
                        !std::is_constructible<T, F>::value &&
                        !is_explicitly_convertible<const F, T>::value &&
                        Differentiation::AD::is_ad_number<F>::value> * = nullptr)

--- a/include/deal.II/base/partitioner.templates.h
+++ b/include/deal.II/base/partitioner.templates.h
@@ -119,8 +119,7 @@ namespace Utilities
       for (unsigned int i = 0; i < n_import_targets; ++i)
         {
 #    if defined(DEAL_II_MPI_WITH_DEVICE_SUPPORT)
-          if constexpr (std::is_same<MemorySpaceType,
-                                     MemorySpace::Default>::value)
+          if constexpr (std::is_same_v<MemorySpaceType, MemorySpace::Default>)
             {
               const auto chunk_size = import_indices_plain_dev[i].size();
               using IndexType       = decltype(chunk_size);
@@ -218,8 +217,8 @@ namespace Utilities
                 {
                   const unsigned int chunk_size =
                     ghost_range.second - ghost_range.first;
-                  if constexpr (std::is_same<MemorySpaceType,
-                                             MemorySpace::Host>::value)
+                  if constexpr (std::is_same_v<MemorySpaceType,
+                                               MemorySpace::Host>)
                     {
                       // If source and destination are overlapping, we must be
                       // careful to use an appropriate copy function.
@@ -390,8 +389,8 @@ namespace Utilities
                   if (ghost_array_ptr + offset !=
                       ghost_array.data() + my_ghosts->first)
                     {
-                      if constexpr (std::is_same<MemorySpaceType,
-                                                 MemorySpace::Host>::value)
+                      if constexpr (std::is_same_v<MemorySpaceType,
+                                                   MemorySpace::Host>)
                         {
                           if (offset > my_ghosts->first)
                             std::copy_backward(ghost_array.data() +
@@ -596,8 +595,7 @@ namespace Utilities
 
           const Number *read_position = temporary_storage.data();
 #    if defined(DEAL_II_MPI_WITH_DEVICE_SUPPORT)
-          if constexpr (std::is_same<MemorySpaceType,
-                                     MemorySpace::Default>::value)
+          if constexpr (std::is_same_v<MemorySpaceType, MemorySpace::Default>)
             {
               if (vector_operation == VectorOperation::add)
                 {
@@ -775,8 +773,7 @@ namespace Utilities
           Assert(ghost_array.begin() != nullptr, ExcInternalError());
 
 #    if defined(DEAL_II_MPI_WITH_DEVICE_SUPPORT)
-          if constexpr (std::is_same<MemorySpaceType,
-                                     MemorySpace::Default>::value)
+          if constexpr (std::is_same_v<MemorySpaceType, MemorySpace::Default>)
             {
               Kokkos::deep_copy(
                 Kokkos::View<Number *, MemorySpace::Default::kokkos_space>(

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -780,9 +780,9 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArrayType
 make_vectorized_array(const typename VectorizedArrayType::value_type &u)
 {
   static_assert(
-    std::is_same<VectorizedArrayType,
-                 VectorizedArray<typename VectorizedArrayType::value_type,
-                                 VectorizedArrayType::size()>>::value,
+    std::is_same_v<VectorizedArrayType,
+                   VectorizedArray<typename VectorizedArrayType::value_type,
+                                   VectorizedArrayType::size()>>,
     "VectorizedArrayType is not a VectorizedArray.");
 
   VectorizedArrayType result = u;

--- a/include/deal.II/differentiation/ad/sacado_number_types.h
+++ b/include/deal.II/differentiation/ad/sacado_number_types.h
@@ -143,9 +143,9 @@ namespace Differentiation
       template <typename SacadoNumber>
       struct SacadoNumberInfo<
         SacadoNumber,
-        std::enable_if_t<std::is_same<
-          SacadoNumber,
-          Sacado::Fad::DFad<typename SacadoNumber::value_type>>::value>>
+        std::enable_if_t<
+          std::is_same_v<SacadoNumber,
+                         Sacado::Fad::DFad<typename SacadoNumber::value_type>>>>
       {
         using ad_type         = SacadoNumber;
         using scalar_type     = typename ad_type::scalar_type;
@@ -163,9 +163,9 @@ namespace Differentiation
       template <typename SacadoNumber>
       struct SacadoNumberInfo<
         SacadoNumber,
-        std::enable_if_t<std::is_same<
+        std::enable_if_t<std::is_same_v<
           SacadoNumber,
-          Sacado::Rad::ADvar<typename SacadoNumber::value_type>>::value>>
+          Sacado::Rad::ADvar<typename SacadoNumber::value_type>>>>
       {
         using ad_type         = SacadoNumber;
         using scalar_type     = typename ad_type::ADVari::scalar_type;
@@ -477,9 +477,9 @@ namespace Differentiation
     template <typename ADNumberType>
     struct ADNumberTraits<
       ADNumberType,
-      std::enable_if_t<std::is_same<
-        ADNumberType,
-        Sacado::Fad::DFad<typename ADNumberType::scalar_type>>::value>>
+      std::enable_if_t<
+        std::is_same_v<ADNumberType,
+                       Sacado::Fad::DFad<typename ADNumberType::scalar_type>>>>
       : NumberTraits<typename ADNumberType::scalar_type,
                      NumberTypes::sacado_dfad>
     {};
@@ -494,10 +494,10 @@ namespace Differentiation
     template <typename ADNumberType>
     struct ADNumberTraits<
       ADNumberType,
-      std::enable_if_t<std::is_same<
-        ADNumberType,
-        std::complex<Sacado::Fad::DFad<
-          typename ADNumberType::value_type::scalar_type>>>::value>>
+      std::enable_if_t<
+        std::is_same_v<ADNumberType,
+                       std::complex<Sacado::Fad::DFad<
+                         typename ADNumberType::value_type::scalar_type>>>>>
       : NumberTraits<
           std::complex<typename ADNumberType::value_type::scalar_type>,
           NumberTypes::sacado_dfad>
@@ -566,9 +566,9 @@ namespace Differentiation
     template <typename ADNumberType>
     struct ADNumberTraits<
       ADNumberType,
-      std::enable_if_t<std::is_same<
+      std::enable_if_t<std::is_same_v<
         ADNumberType,
-        Sacado::Rad::ADvar<typename ADNumberType::ADVari::scalar_type>>::value>>
+        Sacado::Rad::ADvar<typename ADNumberType::ADVari::scalar_type>>>>
       : NumberTraits<typename ADNumberType::ADVari::scalar_type,
                      NumberTypes::sacado_rad>
     {};
@@ -610,10 +610,10 @@ namespace Differentiation
     template <typename ADNumberType>
     struct ADNumberTraits<
       ADNumberType,
-      std::enable_if_t<std::is_same<
+      std::enable_if_t<std::is_same_v<
         ADNumberType,
         std::complex<Sacado::Rad::ADvar<
-          typename ADNumberType::value_type::ADVari::scalar_type>>>::value>>
+          typename ADNumberType::value_type::ADVari::scalar_type>>>>>
       : NumberTraits<
           std::complex<typename ADNumberType::value_type::ADVari::scalar_type>,
           NumberTypes::sacado_rad>
@@ -659,11 +659,11 @@ namespace Differentiation
      * a floating point type.
      */
     template <typename ADNumberType>
-    struct ADNumberTraits<ADNumberType,
-                          std::enable_if_t<std::is_same<
-                            ADNumberType,
-                            Sacado::Fad::DFad<Sacado::Fad::DFad<
-                              typename ADNumberType::scalar_type>>>::value>>
+    struct ADNumberTraits<
+      ADNumberType,
+      std::enable_if_t<std::is_same_v<ADNumberType,
+                                      Sacado::Fad::DFad<Sacado::Fad::DFad<
+                                        typename ADNumberType::scalar_type>>>>>
       : NumberTraits<typename ADNumberType::scalar_type,
                      NumberTypes::sacado_dfad_dfad>
     {};
@@ -679,10 +679,10 @@ namespace Differentiation
     template <typename ADNumberType>
     struct ADNumberTraits<
       ADNumberType,
-      std::enable_if_t<std::is_same<
-        ADNumberType,
-        std::complex<Sacado::Fad::DFad<Sacado::Fad::DFad<
-          typename ADNumberType::value_type::scalar_type>>>>::value>>
+      std::enable_if_t<
+        std::is_same_v<ADNumberType,
+                       std::complex<Sacado::Fad::DFad<Sacado::Fad::DFad<
+                         typename ADNumberType::value_type::scalar_type>>>>>>
       : NumberTraits<
           std::complex<typename ADNumberType::value_type::scalar_type>,
           NumberTypes::sacado_dfad_dfad>
@@ -753,12 +753,11 @@ namespace Differentiation
      * a floating point type.
      */
     template <typename ADNumberType>
-    struct ADNumberTraits<
-      ADNumberType,
-      std::enable_if_t<
-        std::is_same<ADNumberType,
-                     Sacado::Rad::ADvar<Sacado::Fad::DFad<
-                       typename ADNumberType::ADVari::scalar_type>>>::value>>
+    struct ADNumberTraits<ADNumberType,
+                          std::enable_if_t<std::is_same_v<
+                            ADNumberType,
+                            Sacado::Rad::ADvar<Sacado::Fad::DFad<
+                              typename ADNumberType::ADVari::scalar_type>>>>>
       : NumberTraits<typename ADNumberType::ADVari::scalar_type,
                      NumberTypes::sacado_rad_dfad>
     {};
@@ -803,10 +802,10 @@ namespace Differentiation
     template <typename ADNumberType>
     struct ADNumberTraits<
       ADNumberType,
-      std::enable_if_t<std::is_same<
+      std::enable_if_t<std::is_same_v<
         ADNumberType,
         std::complex<Sacado::Rad::ADvar<Sacado::Fad::DFad<
-          typename ADNumberType::value_type::ADVari::scalar_type>>>>::value>>
+          typename ADNumberType::value_type::ADVari::scalar_type>>>>>>
       : NumberTraits<
           std::complex<typename ADNumberType::value_type::ADVari::scalar_type>,
           NumberTypes::sacado_rad_dfad>
@@ -861,9 +860,9 @@ namespace Differentiation
     template <typename NumberType>
     struct is_sacado_dfad_number<
       NumberType,
-      std::enable_if_t<std::is_same<
-        NumberType,
-        Sacado::Fad::Expr<typename NumberType::value_type>>::value>>
+      std::enable_if_t<
+        std::is_same_v<NumberType,
+                       Sacado::Fad::Expr<typename NumberType::value_type>>>>
       : std::true_type
     {};
 
@@ -883,9 +882,9 @@ namespace Differentiation
     struct is_sacado_rad_number<
       NumberType,
       std::enable_if_t<
-        std::is_same<NumberType,
-                     Sacado::Rad::ADvari<Sacado::Fad::DFad<
-                       typename NumberType::ADVari::scalar_type>>>::value>>
+        std::is_same_v<NumberType,
+                       Sacado::Rad::ADvari<Sacado::Fad::DFad<
+                         typename NumberType::ADVari::scalar_type>>>>>
       : std::true_type
     {};
 

--- a/include/deal.II/differentiation/sd/symengine_tensor_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_tensor_operations.h
@@ -1020,18 +1020,19 @@ namespace Differentiation
                   out[indices_out] *= 0.5;
 
                 // TODO: Implement for SymmetricTensor<4,dim,...>
-                if (std::is_same<TensorType_1<rank_1, dim, ValueType>,
-                                 SymmetricTensor<2, dim, ValueType>>::
-                      value) // Symmetric function
+                if (std::is_same_v<
+                      TensorType_1<rank_1, dim, ValueType>,
+                      SymmetricTensor<2, dim, ValueType>>) // Symmetric function
                   {
                     const TableIndices<rank_1 + rank_2> indices_out_t =
                       concatenate_indices(transpose_indices(indices_i),
                                           indices_j);
                     out[indices_out_t] = out[indices_out];
                   }
-                else if (std::is_same<TensorType_2<rank_2, dim, ValueType>,
-                                      SymmetricTensor<2, dim, ValueType>>::
-                           value) // Symmetric operator
+                else if (std::is_same_v<
+                           TensorType_2<rank_2, dim, ValueType>,
+                           SymmetricTensor<2, dim, ValueType>>) // Symmetric
+                                                                // operator
                   {
                     const TableIndices<rank_1 + rank_2> indices_out_t =
                       concatenate_indices(indices_i,

--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -537,9 +537,9 @@ public:
   template <
     class... FEPairs,
     typename = enable_if_all_t<
-      (std::is_same<typename std::decay<FEPairs>::type,
-                    std::pair<std::unique_ptr<FiniteElement<dim, spacedim>>,
-                              unsigned int>>::value ||
+      (std::is_same_v<typename std::decay<FEPairs>::type,
+                      std::pair<std::unique_ptr<FiniteElement<dim, spacedim>>,
+                                unsigned int>> ||
        std::is_base_of_v<FiniteElement<dim, spacedim>,
                          typename std::decay<FEPairs>::type>)...>>
   FESystem(FEPairs &&...fe_pairs);

--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -2433,8 +2433,8 @@ namespace internal
        * types).
        */
       static const bool value =
-        std::is_same<decltype(check(std::declval<MatrixType *>())),
-                     std::true_type>::value;
+        std::is_same_v<decltype(check(std::declval<MatrixType *>())),
+                       std::true_type>;
     };
 
     // instantiation of the static member

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -978,8 +978,7 @@ namespace LinearAlgebra
       if (partitioner->n_import_indices() > 0)
         {
 #  if !defined(DEAL_II_MPI_WITH_DEVICE_SUPPORT)
-          if (std::is_same<MemorySpaceType,
-                           dealii::MemorySpace::Default>::value)
+          if (std::is_same_v<MemorySpaceType, dealii::MemorySpace::Default>)
             {
               if (import_data.values_host_buffer.size() == 0)
                 Kokkos::resize(import_data.values_host_buffer,

--- a/include/deal.II/lac/linear_operator.h
+++ b/include/deal.II/lac/linear_operator.h
@@ -1503,8 +1503,7 @@ template <
   typename =
     std::enable_if_t<!std::is_lvalue_reference<OperatorExemplar>::value>,
   typename = std::enable_if_t<
-    !std::is_same<OperatorExemplar,
-                  LinearOperator<Range, Domain, Payload>>::value>>
+    !std::is_same_v<OperatorExemplar, LinearOperator<Range, Domain, Payload>>>>
 LinearOperator<Range, Domain, Payload>
 linear_operator(OperatorExemplar &&, const Matrix &) = delete;
 
@@ -1518,8 +1517,7 @@ template <
   typename =
     std::enable_if_t<!std::is_lvalue_reference<OperatorExemplar>::value>,
   typename = std::enable_if_t<
-    !std::is_same<OperatorExemplar,
-                  LinearOperator<Range, Domain, Payload>>::value>>
+    !std::is_same_v<OperatorExemplar, LinearOperator<Range, Domain, Payload>>>>
 LinearOperator<Range, Domain, Payload>
 linear_operator(OperatorExemplar &&, Matrix &&) = delete;
 
@@ -1552,8 +1550,7 @@ template <
   typename =
     std::enable_if_t<!std::is_same_v<Preconditioner, PreconditionIdentity>>,
   typename = std::enable_if_t<
-    !std::is_same<Preconditioner,
-                  LinearOperator<Range, Domain, Payload>>::value>>
+    !std::is_same_v<Preconditioner, LinearOperator<Range, Domain, Payload>>>>
 LinearOperator<Domain, Range, Payload>
 inverse_operator(const LinearOperator<Range, Domain, Payload> &,
                  Solver &,

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -543,14 +543,13 @@ namespace internal
             typename PreconditionerType>
   constexpr bool has_vmult_with_std_functions =
     is_supported_operation<vmult_functions_t, MatrixType, VectorType> &&
-      std::is_same<PreconditionerType,
-                   dealii::DiagonalMatrix<VectorType>>::value &&
-    (std::is_same<VectorType,
-                  dealii::Vector<typename VectorType::value_type>>::value ||
-     std::is_same<
+      std::is_same_v<PreconditionerType, dealii::DiagonalMatrix<VectorType>> &&
+    (std::is_same_v<VectorType,
+                    dealii::Vector<typename VectorType::value_type>> ||
+     std::is_same_v<
        VectorType,
        LinearAlgebra::distributed::Vector<typename VectorType::value_type,
-                                          MemorySpace::Host>>::value);
+                                          MemorySpace::Host>>);
 
 
   template <typename MatrixType, typename VectorType>
@@ -3664,17 +3663,16 @@ PreconditionChebyshev<MatrixType, VectorType, PreconditionerType>::
   // We do not need the second temporary vector in case we have a
   // DiagonalMatrix as preconditioner and use deal.II's own vectors
   using NumberType = typename VectorType::value_type;
-  if (std::is_same<PreconditionerType,
-                   dealii::DiagonalMatrix<VectorType>>::value == false ||
+  if (std::is_same_v<PreconditionerType, dealii::DiagonalMatrix<VectorType>> ==
+        false ||
       (std::is_same_v<VectorType, dealii::Vector<NumberType>> == false &&
-       ((std::is_same<VectorType,
-                      LinearAlgebra::distributed::
-                        Vector<NumberType, MemorySpace::Host>>::value ==
+       ((std::is_same_v<
+           VectorType,
+           LinearAlgebra::distributed::Vector<NumberType, MemorySpace::Host>> ==
          false) ||
-        (std::is_same<VectorType,
-                      LinearAlgebra::distributed::
-                        Vector<NumberType, MemorySpace::Default>>::value ==
-         false))))
+        (std::is_same_v<VectorType,
+                        LinearAlgebra::distributed::
+                          Vector<NumberType, MemorySpace::Default>> == false))))
     temp_vector2.reinit(src, true);
   else
     {

--- a/include/deal.II/lac/solver_cg.h
+++ b/include/deal.II/lac/solver_cg.h
@@ -705,10 +705,10 @@ namespace internal
       std::enable_if_t<has_vmult_functions<MatrixType, VectorType> &&
                          (has_apply_to_subrange<PreconditionerType> ||
                           has_apply<PreconditionerType>)&&std::
-                           is_same<VectorType,
-                                   LinearAlgebra::distributed::Vector<
-                                     typename VectorType::value_type,
-                                     MemorySpace::Host>>::value,
+                           is_same_v<VectorType,
+                                     LinearAlgebra::distributed::Vector<
+                                       typename VectorType::value_type,
+                                       MemorySpace::Host>>,
                        int>>
       : public IterationWorkerBase<VectorType, MatrixType, PreconditionerType>
     {

--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -736,10 +736,10 @@ namespace internal
       VectorType,
       typename std::enable_if<!internal::is_block_vector<VectorType>>::type>
     {
-      static constexpr bool value = std::is_same<
+      static constexpr bool value = std::is_same_v<
         VectorType,
         LinearAlgebra::distributed::Vector<typename VectorType::value_type,
-                                           MemorySpace::Host>>::value;
+                                           MemorySpace::Host>>;
     };
 
 
@@ -749,10 +749,10 @@ namespace internal
       VectorType,
       typename std::enable_if<internal::is_block_vector<VectorType>>::type>
     {
-      static constexpr bool value = std::is_same<
+      static constexpr bool value = std::is_same_v<
         typename VectorType::BlockType,
         LinearAlgebra::distributed::Vector<typename VectorType::value_type,
-                                           MemorySpace::Host>>::value;
+                                           MemorySpace::Host>>;
     };
 
 

--- a/include/deal.II/lac/trilinos_block_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_block_sparse_matrix.h
@@ -601,9 +601,9 @@ namespace TrilinosWrappers
         TrilinosBlockPayload(const Args &...)
         {
           static_assert(
-            std::is_same<
+            std::is_same_v<
               PayloadBlockType,
-              internal::LinearOperatorImplementation::TrilinosPayload>::value,
+              internal::LinearOperatorImplementation::TrilinosPayload>,
             "TrilinosBlockPayload can only accept a payload of type TrilinosPayload.");
         }
       };

--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -2286,8 +2286,7 @@ namespace internal
       // `OtherNumber` is either `const Number` (evaluate()) or `Number`
       // (integrate())
       static_assert(
-        std::is_same<Number,
-                     typename std::remove_const<OtherNumber>::type>::value,
+        std::is_same_v<Number, typename std::remove_const<OtherNumber>::type>,
         "Type of Number and of OtherNumber do not match.");
 
       const auto element_type = fe_eval.get_shape_info().element_type;

--- a/include/deal.II/matrix_free/tools.h
+++ b/include/deal.II/matrix_free/tools.h
@@ -1112,11 +1112,11 @@ namespace MatrixFreeTools
      */
     template <typename MatrixType,
               typename Number,
-              std::enable_if_t<std::is_same<
+              std::enable_if_t<std::is_same_v<
                 typename std::remove_const<typename std::remove_reference<
                   typename MatrixType::value_type>::type>::type,
                 typename std::remove_const<typename std::remove_reference<
-                  Number>::type>::type>::value> * = nullptr>
+                  Number>::type>::type>> * = nullptr>
     const AffineConstraints<typename MatrixType::value_type> &
     create_new_affine_constraints_if_needed(
       const MatrixType &,
@@ -1133,11 +1133,11 @@ namespace MatrixFreeTools
      */
     template <typename MatrixType,
               typename Number,
-              std::enable_if_t<!std::is_same<
+              std::enable_if_t<!std::is_same_v<
                 typename std::remove_const<typename std::remove_reference<
                   typename MatrixType::value_type>::type>::type,
                 typename std::remove_const<typename std::remove_reference<
-                  Number>::type>::type>::value> * = nullptr>
+                  Number>::type>::type>> * = nullptr>
     const AffineConstraints<typename MatrixType::value_type> &
     create_new_affine_constraints_if_needed(
       const MatrixType &,

--- a/source/dofs/dof_accessor_set.cc
+++ b/source/dofs/dof_accessor_set.cc
@@ -76,16 +76,16 @@ namespace internal
    */
   template <typename VectorType>
   constexpr bool is_dealii_vector =
-    std::is_same<VectorType,
-                 dealii::Vector<typename VectorType::value_type>>::value ||
-    std::is_same<VectorType,
-                 dealii::BlockVector<typename VectorType::value_type>>::value ||
-    std::is_same<VectorType,
-                 dealii::LinearAlgebra::distributed::Vector<
-                   typename VectorType::value_type>>::value ||
-    std::is_same<VectorType,
-                 dealii::LinearAlgebra::distributed::BlockVector<
-                   typename VectorType::value_type>>::value;
+    std::is_same_v<VectorType,
+                   dealii::Vector<typename VectorType::value_type>> ||
+    std::is_same_v<VectorType,
+                   dealii::BlockVector<typename VectorType::value_type>> ||
+    std::is_same_v<VectorType,
+                   dealii::LinearAlgebra::distributed::Vector<
+                     typename VectorType::value_type>> ||
+    std::is_same_v<VectorType,
+                   dealii::LinearAlgebra::distributed::BlockVector<
+                     typename VectorType::value_type>>;
 
   /**
    * Helper functions that call set_ghost_state() if the vector supports this


### PR DESCRIPTION
I was getting some weird error messages about undefined symbols. I did not try to track this down in detail, but I believe that what happened is that the function declaration used `std::is_same_v`, but the definition continues to use `std::is_same`. If this is just a namespace-level function, then the compiler will simply treat these as different overloads of the same name -- leading to linker errors.

So I simply went through the entire library and replaced all occurrences of `std::same_as` by `std::same_as_v` (except for one place where we used the *type*, not `::value`). The places I had missed previously are the ones where `std::is_same` appears on a different line than `::value` -- hard to catch by script.