### PR TITLE
Remove duplicate indices if ArborX is available

### DIFF
--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -5981,9 +5981,16 @@ namespace GridTools
                 query_bounding_boxes);
               const auto &[indices_ranks, offsets] =
                 distributed_tree.query(bb_intersect);
+
               for (unsigned long int i = 0; i < offsets.size() - 1; ++i)
-                for (int j = offsets[i]; j < offsets[i + 1]; ++j)
-                  ranks_and_indices.emplace_back(indices_ranks[j].second, i);
+                {
+                  std::set<unsigned int> my_ranks;
+                  for (int j = offsets[i]; j < offsets[i + 1]; ++j)
+                    my_ranks.insert(indices_ranks[j].second);
+
+                  for (const auto rank : my_ranks)
+                    ranks_and_indices.emplace_back(rank, i);
+                }
             }
           else
             {


### PR DESCRIPTION
Related to #15749

This should only fix the failing tests. I haven’t tried to fix the compilation issues occuring with C++20 yet