### PR TITLE
PETScWrappers: Support with-strict-petscerrorcode configurations

### DIFF
--- a/include/deal.II/lac/petsc_compatibility.h
+++ b/include/deal.II/lac/petsc_compatibility.h
@@ -32,12 +32,14 @@
 
 #ifdef DEAL_II_WITH_PETSC
 
-#  include <petscconf.h>
 #  include <petscksp.h>
 #  include <petscmat.h>
 #  include <petscpc.h>
 #  include <petscsnes.h>
 #  include <petscts.h>
+#  if DEAL_II_PETSC_VERSION_LT(3, 19, 0)
+#    define PETSC_SUCCESS 0
+#  endif
 
 #  include <string>
 

--- a/source/lac/exceptions.cc
+++ b/source/lac/exceptions.cc
@@ -18,7 +18,6 @@
 #include <deal.II/lac/exceptions.h>
 
 #ifdef DEAL_II_WITH_PETSC
-#  include <petscconf.h>
 #  include <petscsys.h>
 #endif // DEAL_II_WITH_PETSC
 
@@ -39,9 +38,10 @@ namespace LACExceptions
     // PetscErrorMessage changes the value in a pointer to refer to a
     // statically allocated description of the current error message.
     const char *         petsc_message;
-    const PetscErrorCode ierr = PetscErrorMessage(error_code,
-                                                  &petsc_message,
-                                                  /*specific=*/nullptr);
+    const PetscErrorCode ierr =
+      PetscErrorMessage(static_cast<PetscErrorCode>(error_code),
+                        &petsc_message,
+                        /*specific=*/nullptr);
     if (ierr == 0 && petsc_message != nullptr)
       {
         out << "The description of the error provided by PETSc is \""

--- a/source/lac/petsc_matrix_base.cc
+++ b/source/lac/petsc_matrix_base.cc
@@ -168,16 +168,18 @@ namespace PETScWrappers
     // since this is a collective operation
     IS index_set;
 
-    ISCreateGeneral(get_mpi_communicator(),
-                    rows.size(),
-                    petsc_rows.data(),
-                    PETSC_COPY_VALUES,
-                    &index_set);
-
-    const PetscErrorCode ierr =
-      MatZeroRowsIS(matrix, index_set, new_diag_value, nullptr, nullptr);
+    PetscErrorCode ierr;
+    ierr = ISCreateGeneral(get_mpi_communicator(),
+                           rows.size(),
+                           petsc_rows.data(),
+                           PETSC_COPY_VALUES,
+                           &index_set);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
-    ISDestroy(&index_set);
+
+    ierr = MatZeroRowsIS(matrix, index_set, new_diag_value, nullptr, nullptr);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
+    ierr = ISDestroy(&index_set);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 
   void
@@ -195,16 +197,19 @@ namespace PETScWrappers
     // since this is a collective operation
     IS index_set;
 
-    ISCreateGeneral(get_mpi_communicator(),
-                    rows.size(),
-                    petsc_rows.data(),
-                    PETSC_COPY_VALUES,
-                    &index_set);
+    PetscErrorCode ierr;
+    ierr = ISCreateGeneral(get_mpi_communicator(),
+                           rows.size(),
+                           petsc_rows.data(),
+                           PETSC_COPY_VALUES,
+                           &index_set);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
 
-    const PetscErrorCode ierr =
+    ierr =
       MatZeroRowsColumnsIS(matrix, index_set, new_diag_value, nullptr, nullptr);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
-    ISDestroy(&index_set);
+    ierr = ISDestroy(&index_set);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 
 

--- a/source/lac/petsc_precondition.cc
+++ b/source/lac/petsc_precondition.cc
@@ -1114,7 +1114,7 @@ namespace PETScWrappers
     // interface code of PCSetUp in PETSc.
     // We handle it here.
     PetscCall(pc_set_failed_reason(ppc, PC_NOERROR));
-    PetscFunctionReturn(0);
+    PetscFunctionReturn(PETSC_SUCCESS);
   }
 
   PetscErrorCode
@@ -1155,7 +1155,7 @@ namespace PETScWrappers
           "Failure in pcapply from dealii::PETScWrappers::NonlinearSolver");
       }
     petsc_increment_state_counter(y);
-    PetscFunctionReturn(0);
+    PetscFunctionReturn(PETSC_SUCCESS);
   }
 
   PetscErrorCode
@@ -1196,7 +1196,7 @@ namespace PETScWrappers
           "Failure in pcapply_transpose from dealii::PETScWrappers::NonlinearSolver");
       }
     petsc_increment_state_counter(y);
-    PetscFunctionReturn(0);
+    PetscFunctionReturn(PETSC_SUCCESS);
   }
 
 

--- a/source/lac/petsc_solver.cc
+++ b/source/lac/petsc_solver.cc
@@ -163,13 +163,14 @@ namespace PETScWrappers
   }
 
 
-  int
+  PetscErrorCode
   SolverBase::convergence_test(KSP /*ksp*/,
                                const PetscInt      iteration,
                                const PetscReal     residual_norm,
                                KSPConvergedReason *reason,
                                void *              solver_control_x)
   {
+    PetscFunctionBeginUser;
     SolverControl &solver_control =
       *reinterpret_cast<SolverControl *>(solver_control_x);
 
@@ -197,8 +198,7 @@ namespace PETScWrappers
           Assert(false, ExcNotImplemented());
       }
 
-    // return without failure
-    return 0;
+    PetscFunctionReturn(PETSC_SUCCESS);
   }
 
 

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -461,8 +461,11 @@ namespace
   void
   check_petsc_allocations()
   {
-    PetscStageLog stageLog;
-    PetscLogGetStageLog(&stageLog);
+    PetscStageLog  stageLog;
+    PetscErrorCode ierr;
+
+    ierr = PetscLogGetStageLog(&stageLog);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
 
     // I don't quite understand petsc and it looks like
     // stageLog->stageInfo->classLog->classInfo[i].id is always -1, so we look


### PR DESCRIPTION
This specific PETSc configuration allows us to check that error codes are not ignored by the user.
SNES and TS were intentionally left out since those changes will be in separate PRs
For SNES, it is here https://github.com/dealii/dealii/pull/15769