### PR TITLE
Pre-compute what's needed for AffineConstraints::distribute().

### DIFF
--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -1955,6 +1955,16 @@ private:
   IndexSet local_lines;
 
   /**
+   * The set of elements that are necessary to call distribute(). Because
+   * we need to set locally owned constrained elements of a vector, the
+   * needed elements include all vector entries that these constrained
+   * elements depend on -- which may be owned by other processes.
+   *
+   * This variable is set in close().
+   */
+  IndexSet needed_elements_for_distribute;
+
+  /**
    * Store whether the arrays are sorted.  If so, no new entries can be added.
    */
   bool sorted;

--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -2560,6 +2560,18 @@ AffineConstraints<number>::distribute(VectorType &vec) const
 
   if (dealii::is_serial_vector<VectorType>::value == false)
     {
+      // Check that the set of indices we will import is a superset of
+      // the locally-owned ones. This *should* be the case if, as one
+      // would expect, the AffineConstraint object was initialized
+      // with a locally-relevant index set that is indeed a superset
+      // of the locally-owned indices. But you never know what people
+      // pass as arguments...
+#ifdef DEBUG
+      for (const auto i : vec_owned_elements)
+        Assert(needed_elements_for_distribute.is_element(i),
+               ExcInternalError());
+#endif
+
       VectorType ghosted_vector;
       internal::import_vector_with_ghost_elements(
         vec,


### PR DESCRIPTION
This addresses one of the things mentioned in #15375: `AffineConstraints::distribute()` requires an index set that describes what elements to import from other processes. This is the index set creation that originally tripped up @marcfehling and that led us to write #15366. This patch moves the computation of this index set into `close()`, which means that it has to be done only once for cases where one calls `distribute()` multiple times, where previously it is done in every call to `distribute()`.

There is one point where I would appreciate discussion. In the existing code, we build the index set of elements to import in the following way:
* We ask the vector on which `distribute()` is called about its locally-owned index set.
* Then we add to that all of the elements necessary to resolve constraints among the locally-owned vector elements.

The problem is that I don't have access to the locally owned set in `close()`. All I have is the locally-relevant set. So I build the index set starting from the locally-relevant set, and add what is necessary to resolve constraints within it. I end up with a bigger index set than strictly necessary, and consequently the import operation in `distribute()` will import a larger set of elements from other processes. Possible solutions to this pessimization:
* We decide that the whole optimization is simply not worth it. After #15366, the index set construction is perhaps not the bottleneck any more. (Perhaps, I have not actually measured whether that's true. I will also say that it would actually be nice to not only build the index set, but also a partitioner/communicator that we can then use in the import operation.)
* We decide that the real cost in importing elements is in the latency, and adding a few more indices is not that bad. To be clear, the additional elements are dependencies of constrained DoFs located on ghost cells but not locally owned.
* We add an argument to `close()` where callers can pass in the locally-owned index set. This allows building the same index set we do right now, at the expense of having to change our codes. We can make it backward compatible by defaulting the argument to an empty index set in which case I fall back to the algorithm with the locally-relevant index set to which I have access.

Opinions?