### PR TITLE
`MGTransferMF::interpolate_to_mg()`: zero out ghost values

### DIFF
--- a/doc/news/changes/incompatibilities/20230725Munch
+++ b/doc/news/changes/incompatibilities/20230725Munch
@@ -1,0 +1,4 @@
+Changed: MGTransferMatrixFree::interpolate_to_mg()
+returns now non-ghosted vectors.
+<br>
+(Peter Munch, 2023/07/25)

--- a/include/deal.II/multigrid/mg_transfer_matrix_free.h
+++ b/include/deal.II/multigrid/mg_transfer_matrix_free.h
@@ -632,6 +632,9 @@ MGTransferMatrixFree<dim, Number>::interpolate_to_mg(
 
       dst[level - 1].update_ghost_values();
     }
+
+  for (unsigned int level = min_level; level <= max_level; ++level)
+    dst[level].zero_out_ghost_values();
 }
 
 

--- a/tests/mappings/mapping_q_eulerian_08.cc
+++ b/tests/mappings/mapping_q_eulerian_08.cc
@@ -305,6 +305,8 @@ test(const unsigned int n_ref = 0)
 
       MatrixFree<dim, LevelNumberType> mg_level_euler;
 
+      displacement_level[level].update_ghost_values();
+
       MappingQEulerian<dim, LinearAlgebra::distributed::Vector<LevelNumberType>>
         euler_level(euler_fe_degree,
                     dof_handler_euler,

--- a/tests/mappings/mapping_q_eulerian_14.cc
+++ b/tests/mappings/mapping_q_eulerian_14.cc
@@ -346,6 +346,8 @@ test(const unsigned int n_ref = 0)
 
       MatrixFree<dim, LevelNumberType> mg_level_euler;
 
+      displacement_level[level].update_ghost_values();
+
       MappingQEulerian<dim, LinearAlgebra::distributed::Vector<LevelNumberType>>
         euler_level(euler_fe_degree,
                     dof_handler_euler,

--- a/tests/matrix_free/interpolate_to_mg.cc
+++ b/tests/matrix_free/interpolate_to_mg.cc
@@ -211,6 +211,8 @@ test(const unsigned int n_glob_ref = 2, const unsigned int n_ref = 0)
     {
       --level;
 
+      level_projection[level].update_ghost_values();
+
       std::vector<types::global_dof_index>    dof_indices(fe.dofs_per_cell);
       typename DoFHandler<dim>::cell_iterator cell = dof_handler.begin(level);
       typename DoFHandler<dim>::cell_iterator endc = dof_handler.end(level);


### PR DESCRIPTION
... and `DataOut::add_mg_data_vector()`: copy vector and update ghost values (similar to `DataOut::add_data_vector()`). Latter is needed, since the vectors are not ghosted.

~Depends on #15792, #15797.~