### PR TITLE
AffineConstraints: fix warnings

### DIFF
--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -2524,8 +2524,7 @@ AffineConstraints<number>::merge(
 
               const number weight = entry.second;
 
-              for (const std::pair<size_type, number> &other_entry :
-                   *other_entries)
+              for (const auto &other_entry : *other_entries)
                 tmp.emplace_back(other_entry.first,
                                  other_entry.second * weight);
 
@@ -2600,7 +2599,7 @@ AffineConstraints<number>::merge(
                     line.index,
                     typename ConstraintLine::Entries(line.entries.begin(),
                                                      line.entries.end()),
-                    line.inhomogeneity};
+                    static_cast<number>(line.inhomogeneity)};
                   break;
 
                 default:


### PR DESCRIPTION
```
In file included from /home/munch/sw-adaflo-simplex2/dealii/include/deal.II/dofs/dof_accessor.templates.h:31,
                 from /home/munch/sw-adaflo-simplex2/dealii/include/deal.II/dofs/dof_accessor.h:2146,
                 from /home/munch/sw-adaflo-simplex2/dealii/include/deal.II/dofs/dof_handler.h:31,
                 from /home/munch/sw-adaflo-simplex2/dealii/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h:30,
                 from /home/munch/sw-adaflo-simplex2/dealii/source/multigrid/mg_transfer_global_coarsening.cc:16:
/home/munch/sw-adaflo-simplex2/dealii/include/deal.II/lac/affine_constraints.h: In instantiation of ‘void dealii::AffineConstraints<number>::merge(const dealii::AffineConstraints<other_number>&, dealii::AffineConstraints<number>::MergeConflictBehavior, bool) [with other_number = double; number = float]’:
/home/munch/sw-adaflo-simplex2/dealii/include/deal.II/multigrid/mg_constrained_dofs.h:624:24:   required from ‘void dealii::MGConstrainedDoFs::merge_constraints(dealii::AffineConstraints<number>&, unsigned int, bool, bool, bool, bool) const [with Number = float]’
/home/munch/sw-adaflo-simplex2/dealii/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h:3477:45:   required from ‘void dealii::MGTransferMF<dim, Number>::intitialize_internal_transfer(const dealii::DoFHandler<dim>&, const dealii::SmartPointer<const dealii::MGConstrainedDoFs>&) [with int dim = 1; Number = float]’
/home/munch/sw-adaflo-simplex2/dealii-build/source/multigrid/mg_transfer_global_coarsening.inst:43:17:   required from here
/home/munch/sw-adaflo-simplex2/dealii/include/deal.II/lac/affine_constraints.h:2527:56: warning: loop variable ‘other_entry’ of type ‘const std::pair<unsigned int, float>&’ binds to a temporary constructed from type ‘const std::pair<unsigned int, double>’ [-Wrange-loop-construct]
 2527 |               for (const std::pair<size_type, number> &other_entry :
      |                                                        ^~~~~~~~~~~
/home/munch/sw-adaflo-simplex2/dealii/include/deal.II/lac/affine_constraints.h:2527:56: note: use non-reference type ‘const std::pair<unsigned int, float>’ to make the copy explicit or ‘const std::pair<unsigned int, double>&’ to prevent copying
/home/munch/sw-adaflo-simplex2/dealii/include/deal.II/lac/affine_constraints.h:2603:26: warning: narrowing conversion of ‘(double)line.dealii::AffineConstraints<double>::ConstraintLine::inhomogeneity’ from ‘double’ to ‘float’ [-Wnarrowing]
 2603 |                     line.inhomogeneity};
```