### PR TITLE
Make GridGenerator::hyper_cube_with_cylindrical_hole<2>() more robust.

### DIFF
--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -3353,7 +3353,7 @@ namespace GridGenerator
     auto min_line_length = [](const Triangulation<2> &tria) -> double {
       double length = std::numeric_limits<double>::max();
       for (const auto &cell : tria.active_cell_iterators())
-        for (unsigned int n = 0; n < GeometryInfo<2>::lines_per_cell; ++n)
+        for (unsigned int n = 0; n < cell->n_lines(); ++n)
           length = std::min(length, cell->line(n)->diameter());
       return length;
     };
@@ -3444,7 +3444,7 @@ namespace GridGenerator
         // grid around the cylinder to the new TFI manifold id.
         if (cell->manifold_id() == tfi_manifold_id)
           {
-            for (const unsigned int face_n : GeometryInfo<2>::face_indices())
+            for (const unsigned int face_n : cell->face_indices())
               {
                 const auto &face = cell->face(face_n);
                 if (face->at_boundary() &&
@@ -3468,7 +3468,7 @@ namespace GridGenerator
       std::numeric_limits<double>::epsilon() * 10000;
     if (colorize)
       for (const auto &cell : tria.active_cell_iterators())
-        for (const unsigned int face_n : GeometryInfo<2>::face_indices())
+        for (const unsigned int face_n : cell->face_indices())
           {
             const auto face = cell->face(face_n);
             if (face->at_boundary())

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -3450,7 +3450,7 @@ namespace GridGenerator
                 if (face->at_boundary() &&
                     internal::point_in_2d_box(face->center(),
                                               center,
-                                              outer_radius))
+                                              outer_radius * (1. - 1e-12)))
                   face->set_manifold_id(polar_manifold_id);
                 else
                   face->set_manifold_id(tfi_manifold_id);

--- a/tests/grid/grid_generator_plate_with_a_hole_4.cc
+++ b/tests/grid/grid_generator_plate_with_a_hole_4.cc
@@ -68,7 +68,7 @@ test()
               return std::get<2>(t1) < std::get<2>(t2);
             });
 
-  for (const auto el : boundary_faces)
+  for (const auto & el : boundary_faces)
     deallog << "center: " << std::get<0>(el)
             << " boundary id: " << std::get<1>(el)
             << " manifold id: " << std::get<2>(el) << std::endl;

--- a/tests/grid/grid_generator_plate_with_a_hole_4.cc
+++ b/tests/grid/grid_generator_plate_with_a_hole_4.cc
@@ -68,7 +68,7 @@ test()
               return std::get<2>(t1) < std::get<2>(t2);
             });
 
-  for (const auto & el : boundary_faces)
+  for (const auto &el : boundary_faces)
     deallog << "center: " << std::get<0>(el)
             << " boundary id: " << std::get<1>(el)
             << " manifold id: " << std::get<2>(el) << std::endl;


### PR DESCRIPTION
Chipping away at the test failures in #15689: This here is a function that makes specific assumptions about the vertex numbers of a triangulation. We do better by testing for the vertices' geometric location and save a few lines of code in the process.