### PR TITLE
Avoid memory allocations in step 68

### DIFF
--- a/examples/step-68/step-68.cc
+++ b/examples/step-68/step-68.cc
@@ -541,6 +541,7 @@ namespace Step68
     Vector<double> local_dof_values(fluid_fe.dofs_per_cell);
 
     FEPointEvaluation<dim, dim> evaluator(mapping, fluid_fe, update_values);
+    std::vector<Point<dim>>     particle_positions;
 
     // We loop over all the local particles. Although this could be achieved
     // directly by looping over all the cells, this would force us
@@ -564,7 +565,7 @@ namespace Step68
         // This is achieved using FEPointEvaluation object.
         const auto pic = particle_handler.particles_in_cell(cell);
         Assert(pic.begin() == particle, ExcInternalError());
-        std::vector<Point<dim>> particle_positions;
+        particle_positions.clear();
         for (auto &p : pic)
           particle_positions.push_back(p.get_reference_location());
 

--- a/tests/performance/timing_step_68.cc
+++ b/tests/performance/timing_step_68.cc
@@ -324,6 +324,7 @@ namespace Step68
     Vector<double> local_dof_values(fluid_fe.dofs_per_cell);
 
     FEPointEvaluation<dim, dim> evaluator(mapping, fluid_fe, update_values);
+    std::vector<Point<dim>>     particle_positions;
 
     const double this_mpi_process =
       static_cast<double>(Utilities::MPI::this_mpi_process(mpi_communicator));
@@ -339,7 +340,7 @@ namespace Step68
 
         const auto pic = particle_handler.particles_in_cell(cell);
         Assert(pic.begin() == particle, ExcInternalError());
-        std::vector<Point<dim>> particle_positions;
+        particle_positions.clear();
         for (auto &p : pic)
           particle_positions.push_back(p.get_reference_location());
 


### PR DESCRIPTION
This includes a small optimization for step-68 as suggested in #15650. Avoiding the allocations speeds up the function `euler_step_interpolated` by about 5% for me, but this would increase if the number of particles would increase, so I think it is worth it. 