### PR TITLE
[9.5] Fix compiling with PETSc with complex scalar type

### DIFF
--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -277,8 +277,8 @@ namespace PETScWrappers
         // numbers back as integers later on, we get the same thing.
         for (PetscInt i = 0; i < end_index - ghost_start_index; i++)
           {
-            Assert(static_cast<PetscInt>(static_cast<PetscScalar>(
-                     ghost_start_index + i)) == (ghost_start_index + i),
+            Assert(static_cast<PetscInt>(std::real(static_cast<PetscScalar>(
+                     ghost_start_index + i))) == (ghost_start_index + i),
                    ExcInternalError());
             array[i] = ghost_start_index + i;
           }


### PR DESCRIPTION
Cherry-picking #15852 in case we decide to do another patch release.