### PR TITLE
Making hanging constraints: Reduce number of memory allocations

### DIFF
--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -573,6 +573,7 @@ AffineConstraints<number>::add_entries(
   //
   // in any case: skip this entry if an entry for this column already
   // exists, since we don't want to enter it twice
+  line.entries.reserve(line.entries.size() + col_weight_pairs.size());
   for (const std::pair<size_type, number> &col_weight_pair : col_weight_pairs)
     {
       Assert(constrained_dof_index != col_weight_pair.first,


### PR DESCRIPTION
This is another observation when looking at the `mg_glob_coarsen` (global coarsening multigrid) benchmark. When we fill hanging node constraints into an `AffineConstraints` object, we would fill one entry at a time into an `std::vector`. Since that vector allocates memory on demand (by approximately doubling the size each time the capacity is exhausted), it does approximately 5 memory allocations per constrained unknown for the case of the benchmark (3d, polynomial degree 4). We can of course do much better if we first collect all entries to be added in an auxiliary vector and then move them in to `AffineConstraints` all at once via `add_entries`. When we do that, we should not forget to reserve enough memory in the `lines.entries` vector beforehand.

There are several additional things that could be done in that file, in particular in `close`, but I think they are less important.