### PR TITLE
reset ghost state in MG_transfer_global_coarsening interpolate

### DIFF
--- a/doc/news/changes/minor/20230904Schussnig
+++ b/doc/news/changes/minor/20230904Schussnig
@@ -1,0 +1,4 @@
+Improved: MGTwoLevelTransferBase does not clear the
+ghost state of the source vector anymore.
+<br>
+(Richard Schussnig, Martin Kronbichler, Peter Munch, 2023/09/04)

--- a/doc/news/changes/minor/20230904Schussnig
+++ b/doc/news/changes/minor/20230904Schussnig
@@ -1,4 +1,4 @@
-Improved: MGTwoLevelTransferBase does not clear the
-ghost state of the source vector anymore.
+Fixed: MGTwoLevelTransferBase now preserves the
+ghost state of the source vector in all call scenarios.
 <br>
 (Richard Schussnig, Martin Kronbichler, Peter Munch, 2023/09/04)


### PR DESCRIPTION
the clean-up related to ghost values should consider if the input *const reference* had ghost values or not