### PR TITLE
Documentation of `DataOutResample`: fix formatting

### DIFF
--- a/include/deal.II/numerics/data_out_resample.h
+++ b/include/deal.II/numerics/data_out_resample.h
@@ -46,10 +46,12 @@ DEAL_II_NAMESPACE_OPEN
  * data_out.build_patches(mapping);
  *
  * // ... no changes in triangulation and mapping -> reuse internal data
- * structures data_out.build_patches();
+ * // structures
+ * data_out.build_patches();
  *
  * // ... changes in triangulation or mapping -> reinitialize internal data
- * structures data_out.build_patches(mapping);
+ * // structures
+ * data_out.build_patches(mapping);
  * @endcode
  *
  * @note While the dimension of the two triangulations might differ, their


### PR DESCRIPTION
This PR suggests to fix the formatting of the code snippet (last four lines) in the documentation of `DataOutResample`

![image](https://github.com/dealii/dealii/assets/70260016/0ffd5f51-01f9-4712-93e2-47b6b207f1df)
