### PR TITLE
Fix bug in AffineConstraints::shift

### DIFF
--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -1025,7 +1025,7 @@ AffineConstraints<number>::shift(const size_type offset)
   else
     {
       // shift local_lines
-      IndexSet new_local_lines(local_lines.size());
+      IndexSet new_local_lines(local_lines.size() + offset);
       new_local_lines.add_indices(local_lines, offset);
       std::swap(local_lines, new_local_lines);
     }

--- a/tests/dofs/dof_constraints_12.cc
+++ b/tests/dofs/dof_constraints_12.cc
@@ -1,0 +1,76 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2023 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check that the AffineConstraints::shift() method works as expected.
+
+#include <deal.II/lac/affine_constraints.h>
+
+#include "../tests.h"
+
+
+int
+main()
+{
+  initlog();
+
+  unsigned int n1 = 10, n2 = 5;
+
+  auto local_lines1 = complete_index_set(n1);
+  auto local_lines2 = complete_index_set(n2);
+  auto local_lines  = complete_index_set(n1 + n2);
+
+  // Fake two independent constraints on two independent dofs.
+  AffineConstraints<double> constraints1; //(local_lines1);
+  AffineConstraints<double> constraints2; //(local_lines2);
+  AffineConstraints<double> constraints;  //(local_lines);
+
+  constraints1.add_line(1);
+  constraints1.add_entry(1, 2, 1.0);
+
+  constraints2.add_line(2);
+  constraints2.add_entry(2, 3, 2.0);
+
+  constraints1.close();
+  constraints2.close();
+
+  deallog << "constraints1: " << std::endl;
+  constraints1.print(deallog.get_file_stream());
+  deallog << "constraints2: " << std::endl;
+  constraints2.print(deallog.get_file_stream());
+
+  // Now I want to build the union of the two constraints.
+  // According to the documentation, I can shift the second, then merge.
+  // Since in applications you usually need also the second constraints,
+  // do this on a copy.
+  {
+    AffineConstraints<double> tmp; //(local_lines2);
+    tmp.merge(constraints2);
+    tmp.shift(n1);
+    deallog << "constraints2 shifted:" << std::endl;
+    tmp.print(deallog.get_file_stream());
+
+    constraints.merge(constraints1,
+                      AffineConstraints<double>::no_conflicts_allowed,
+                      true);
+    constraints.merge(tmp,
+                      AffineConstraints<double>::no_conflicts_allowed,
+                      true);
+  }
+  constraints.close();
+  deallog << "constraints: " << std::endl;
+  constraints.print(deallog.get_file_stream());
+}

--- a/tests/dofs/dof_constraints_12.output
+++ b/tests/dofs/dof_constraints_12.output
@@ -1,0 +1,10 @@
+
+DEAL::constraints1: 
+    1 2:  1.00000
+DEAL::constraints2: 
+    2 3:  2.00000
+DEAL::constraints2 shifted:
+    12 13:  2.00000
+DEAL::constraints: 
+    1 2:  1.00000
+    12 13:  2.00000

--- a/tests/dofs/dof_constraints_13.cc
+++ b/tests/dofs/dof_constraints_13.cc
@@ -1,0 +1,76 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2023 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check that the AffineConstraints::shift() method works as expected.
+
+#include <deal.II/lac/affine_constraints.h>
+
+#include "../tests.h"
+
+
+int
+main()
+{
+  initlog();
+
+  unsigned int n1 = 10, n2 = 5;
+
+  auto local_lines1 = complete_index_set(n1);
+  auto local_lines2 = complete_index_set(n2);
+  auto local_lines  = complete_index_set(n1 + n2);
+
+  // Fake two independent constraints on two independent dofs.
+  AffineConstraints<double> constraints1(local_lines1);
+  AffineConstraints<double> constraints2(local_lines2);
+  AffineConstraints<double> constraints(local_lines);
+
+  constraints1.add_line(1);
+  constraints1.add_entry(1, 2, 1.0);
+
+  constraints2.add_line(2);
+  constraints2.add_entry(2, 3, 2.0);
+
+  constraints1.close();
+  constraints2.close();
+
+  deallog << "constraints1: " << std::endl;
+  constraints1.print(deallog.get_file_stream());
+  deallog << "constraints2: " << std::endl;
+  constraints2.print(deallog.get_file_stream());
+
+  // Now I want to build the union of the two constraints.
+  // According to the documentation, I can shift the second, then merge.
+  // Since in applications you usually need also the second constraints,
+  // do this on a copy.
+  {
+    AffineConstraints<double> tmp(local_lines2);
+    tmp.merge(constraints2);
+    tmp.shift(n1);
+    deallog << "constraints2 shifted:" << std::endl;
+    tmp.print(deallog.get_file_stream());
+
+    constraints.merge(constraints1,
+                      AffineConstraints<double>::no_conflicts_allowed,
+                      true);
+    constraints.merge(tmp,
+                      AffineConstraints<double>::no_conflicts_allowed,
+                      true);
+  }
+  constraints.close();
+  deallog << "constraints: " << std::endl;
+  constraints.print(deallog.get_file_stream());
+}

--- a/tests/dofs/dof_constraints_13.output
+++ b/tests/dofs/dof_constraints_13.output
@@ -1,0 +1,10 @@
+
+DEAL::constraints1: 
+    1 2:  1.00000
+DEAL::constraints2: 
+    2 3:  2.00000
+DEAL::constraints2 shifted:
+    12 13:  2.00000
+DEAL::constraints: 
+    1 2:  1.00000
+    12 13:  2.00000


### PR DESCRIPTION
I was trying to create a coupled constrained object from two separate ones, following the description of the documentation, and I found out that this works in serial, but when using an IndexSet at construction time, the `local_lines` object, somehow, does not get updated correctly, even though the code seems to do it.

<s>I'm investigating what is happening.</s>

The second test sould give the exact same output of the first. the only difference is that in the second I initialize the constraints with complete index sets. 

I get the following Assertion in the second test:

```
--------------------------------------------------------
An error occurred in line <1898> of file <../include/deal.II/base/index_set.h> in function
    IndexSet::size_type dealii::IndexSet::index_within_set(const dealii::IndexSet::size_type) const
The violated condition was: 
    ::dealii::deal_II_exceptions::internals::compare_less_than(n, size())
Additional information: 
    Index 12 is not in the half-open range [0,5).
--------------------------------------------------------
```
This happens inside the `shift` method:
```c++
template <typename number>
void
AffineConstraints<number>::shift(const size_type offset)
{
  if (local_lines.size() == 0)
    lines_cache.insert(lines_cache.begin(), offset, numbers::invalid_size_type);
  else
    {
      // shift local_lines
      IndexSet new_local_lines(local_lines.size());
      new_local_lines.add_indices(local_lines, offset);
      std::swap(local_lines, new_local_lines);
    }

  for (ConstraintLine &line : lines)
    {
      line.index += offset;
      for (std::pair<size_type, number> &entry : line.entries)
        entry.first += offset;
    }

#ifdef DEBUG
  // make sure that lines, lines_cache and local_lines
  // are still linked correctly
  for (size_type index = 0; index < lines_cache.size(); ++index)
    Assert(lines_cache[index] == numbers::invalid_size_type ||
             calculate_line_index(lines[lines_cache[index]].index) == index,
           ExcInternalError());
#endif
}
```
the offending function is `calculate_line_index`, which checks if the constraint entries are within the locally_owned set. They should be, as the set has been shifted (a few lines above), but somehow `calculate_line_index` still uses the old index set.