### PR TITLE
Use target_link_options for link options

### DIFF
--- a/cmake/macros/macro_copy_target_properties.cmake
+++ b/cmake/macros/macro_copy_target_properties.cmake
@@ -152,7 +152,7 @@ function(copy_target_properties _destination_target)
   if(NOT "${_link_options}" STREQUAL "")
     remove_duplicates(_link_options REVERSE)
     message(STATUS "    LINK_OPTIONS: ${_link_options}")
-    target_compile_options(${_destination_target} INTERFACE ${_link_options})
+    target_link_options(${_destination_target} INTERFACE ${_link_options})
   endif()
 endfunction()
 


### PR DESCRIPTION
When compiling with Kokkos+SYCL, I noticed that we don't propagate the target's link options via `target_link_options` but `target_compile_options` which makes compilation fail since those flags really need to appear on the link line for this configuration.