### PR TITLE
Enable clang-tidy's bugprone-reserved-identifier check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,6 +18,7 @@
 
 Checks: >
   -*,
+  bugprone-reserved-identifier,
   cppcoreguidelines-pro-type-static-cast-downcast,
   modernize-*,
   -modernize-avoid-c-arrays,


### PR DESCRIPTION
As requested in https://github.com/dealii/dealii/pull/15870#issuecomment-1678860589