### PR TITLE
PETScWrappers::TimeStepper: fix  typo

### DIFF
--- a/include/deal.II/lac/petsc_ts.templates.h
+++ b/include/deal.II/lac/petsc_ts.templates.h
@@ -1092,8 +1092,8 @@ namespace PETScWrappers
         AssertPETSc(VecDuplicate(py, &av));
         AssertPETSc(VecDuplicate(py, &rv));
 
-        VectorBase avdealii(av);
-        VectorBase rvdealii(rv);
+        VectorType avdealii(av);
+        VectorType rvdealii(rv);
         avdealii = atol;
         rvdealii = rtol;
         for (auto i : algebraic_components())


### PR DESCRIPTION
 use VectorType, not VectorBase