### PR TITLE
Matrix-free diagonal: Ensure constant loop bounds

### DIFF
--- a/include/deal.II/matrix_free/tools.h
+++ b/include/deal.II/matrix_free/tools.h
@@ -861,9 +861,10 @@ namespace MatrixFreeTools
         // compute i-th column of element stiffness matrix:
         // this could be simply performed as done at the moment with
         // matrix-free operator evaluation applied to a ith-basis vector
-        for (unsigned int j = 0; j < phi->dofs_per_cell; ++j)
-          phi->begin_dof_values()[j] = VectorizedArrayType();
-        phi->begin_dof_values()[i] = Number(1);
+        VectorizedArrayType *dof_values = phi->begin_dof_values();
+        for (const unsigned int j : phi->dof_indices())
+          dof_values[j] = VectorizedArrayType();
+        dof_values[i] = Number(1);
       }
 
       void


### PR DESCRIPTION
When looking at something else, I realized that the compiler would not realize that `phi->dofs_per_cell` is constant across the loop, because we write into members of `phi` and the compiler would not understand that we never touch `dofs_per_cell`. This can be done more nicely by a range-based for loop.
There is also a second potential for repeated accesses, namely the pointer `phi->begin_dof_values()` where again my compiler would not see that we do not modify the base address. We can fix this by creating a temporary. (Then, the compiler uses `memset` to set the field to zero, which is often a good choice also when we have SIMD vectors.