### PR TITLE
Enable std::unique_ptr in MGSmootherRelaxation

### DIFF
--- a/doc/news/changes/minor/20230816Kronbichler
+++ b/doc/news/changes/minor/20230816Kronbichler
@@ -1,0 +1,7 @@
+Improved: The classes MGSmootherRelaxation and mg::SmootherRelaxation can now
+also handle matrices of types `MGLevelObject<std::unique_ptr<...>>` or
+`MGLevelObject<std::shared_ptr<...>>` in their `initialize()` functions by the
+use of Utilities::get_underlying_value(), rather than MGLevelObject of the
+actual matrix type only.
+<br>
+(Martin Kronbichler, 2023/08/16)

--- a/include/deal.II/multigrid/mg_smoother.h
+++ b/include/deal.II/multigrid/mg_smoother.h
@@ -689,7 +689,7 @@ namespace mg
     this->resize(min, max);
 
     for (unsigned int i = min; i <= max; ++i)
-      (*this)[i].initialize(m[i], data);
+      (*this)[i].initialize(Utilities::get_underlying_value(m[i]), data);
   }
 
 
@@ -706,7 +706,7 @@ namespace mg
     this->resize(min, max);
 
     for (unsigned int i = min; i <= max; ++i)
-      (*this)[i].initialize(m[i], data[i]);
+      (*this)[i].initialize(Utilities::get_underlying_value(m[i]), data[i]);
   }
 
 
@@ -833,8 +833,9 @@ MGSmootherRelaxation<MatrixType, RelaxationType, VectorType>::initialize(
       // enough interface to populate reinit_(domain|range)_vector. Thus,
       // apply an empty LinearOperator exemplar.
       matrices[i] =
-        linear_operator<VectorType>(LinearOperator<VectorType>(), m[i]);
-      smoothers[i].initialize(m[i], data);
+        linear_operator<VectorType>(LinearOperator<VectorType>(),
+                                    Utilities::get_underlying_value(m[i]));
+      smoothers[i].initialize(Utilities::get_underlying_value(m[i]), data);
     }
 }
 
@@ -860,8 +861,9 @@ MGSmootherRelaxation<MatrixType, RelaxationType, VectorType>::initialize(
       // enough interface to populate reinit_(domain|range)_vector. Thus,
       // apply an empty LinearOperator exemplar.
       matrices[i] =
-        linear_operator<VectorType>(LinearOperator<VectorType>(), m[i]);
-      smoothers[i].initialize(m[i], data[i]);
+        linear_operator<VectorType>(LinearOperator<VectorType>(),
+                                    Utilities::get_underlying_value(m[i]));
+      smoothers[i].initialize(Utilities::get_underlying_value(m[i]), data[i]);
     }
 }
 


### PR DESCRIPTION
This commit aims to make the interface to `MGSmootherRelaxation` more similar to `MGSmootherPrecondition`, by also accepting `std::unique_ptr<...>` and `std::shared_ptr` around the matrix type in their `initialize()` functions.