### PR TITLE
Use a relative tolerance.

### DIFF
--- a/source/grid/tria_description.cc
+++ b/source/grid/tria_description.cc
@@ -268,21 +268,24 @@ namespace TriangulationDescription
           {
             std::sort(this->coarse_cell_vertices.begin(),
                       this->coarse_cell_vertices.end(),
-                      [](const auto &a, const auto &b) {
+                      [](const std::pair<unsigned int, Point<spacedim>> &a,
+                         const std::pair<unsigned int, Point<spacedim>> &b) {
                         return a.first < b.first;
                       });
             this->coarse_cell_vertices.erase(
-              std::unique(this->coarse_cell_vertices.begin(),
-                          this->coarse_cell_vertices.end(),
-                          [](const auto &a, const auto &b) {
-                            if (a.first == b.first)
-                              {
-                                Assert(a.second.distance(b.second) < 10e-8,
-                                       ExcInternalError());
-                                return true;
-                              }
-                            return false;
-                          }),
+              std::unique(
+                this->coarse_cell_vertices.begin(),
+                this->coarse_cell_vertices.end(),
+                [](const std::pair<unsigned int, Point<spacedim>> &a,
+                   const std::pair<unsigned int, Point<spacedim>> &b) {
+                  if (a.first == b.first)
+                    {
+                      Assert(a.second.distance(b.second) < 10e-8,
+                             ExcInternalError());
+                      return true;
+                    }
+                  return false;
+                }),
               this->coarse_cell_vertices.end());
           }
 

--- a/source/grid/tria_description.cc
+++ b/source/grid/tria_description.cc
@@ -280,7 +280,9 @@ namespace TriangulationDescription
                    const std::pair<unsigned int, Point<spacedim>> &b) {
                   if (a.first == b.first)
                     {
-                      Assert(a.second.distance(b.second) < 10e-8,
+                      Assert(a.second.distance(b.second) <=
+                               1e-7 *
+                                 std::max(a.second.norm(), b.second.norm()),
                              ExcInternalError());
                       return true;
                     }


### PR DESCRIPTION
In debugging something unrelated, I had to look at a piece of code that compares two vertex locations for equality. The existing code uses an absolute tolerance, but that isn't going to work well when using meshes at atomic or cosmic length scales. Use a relative tolerance instead.

While there, I also made the types used in this lambda function explicit.