### PR TITLE
Non-nested transfer: add assert

### DIFF
--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -3884,6 +3884,9 @@ namespace internal
         std::vector<types::global_dof_index> support_point_indices(
           support_points_per_cell);
         std::vector<types::global_dof_index> dof_indices(dofs_per_cell);
+        std::vector<std::pair<unsigned int, types::global_dof_index>>
+          support_point_dofs_comp;
+        support_point_dofs_comp.reserve(n_components);
 
         for (const auto &cell : dof_handler.active_cell_iterators())
           {
@@ -3921,7 +3924,7 @@ namespace internal
                           if (dof_processed[local_dof_idx] == false)
                             {
                               if (!constraint.is_constrained(global_dof_idx))
-                                support_point_dofs.emplace_back(
+                                support_point_dofs_comp.emplace_back(
                                   partitioner_support_points.global_to_local(
                                     support_point_indices[i]),
                                   global_dof_idx);
@@ -3929,6 +3932,18 @@ namespace internal
                               dof_processed[local_dof_idx] = true;
                             }
                         }
+
+                      Assert(support_point_dofs_comp.size() == 0 ||
+                               support_point_dofs_comp.size() == n_components,
+                             ExcNotImplemented());
+
+                      if (support_point_dofs_comp.empty() == false)
+                        support_point_dofs.insert(
+                          support_point_dofs.end(),
+                          support_point_dofs_comp.begin(),
+                          support_point_dofs_comp.end());
+
+                      support_point_dofs_comp.clear();
                     }
               }
           }


### PR DESCRIPTION
Apparently all components need to be constrained or not constrained. This PR adds an assert. I'll work next week on a fix.

~@fdrmrc Could you try this out? Is the assert triggered in your case?~ The issue turned out to be another one. The assert is useful nevertheless.

A minimal failing test is:
```cpp
#include <deal.II/dofs/dof_handler.h>

#include <deal.II/fe/fe_q.h>
#include <deal.II/fe/fe_system.h>
#include <deal.II/fe/mapping_q1.h>

#include <deal.II/grid/grid_generator.h>

#include <deal.II/multigrid/mg_transfer_global_coarsening.h>

using namespace dealii;

int
main()
{
  const int          dim = 2;
  Triangulation<dim> tria;
  GridGenerator::hyper_cube(tria);

  DoFHandler<dim> dof_handler(tria);
  dof_handler.distribute_dofs(FESystem<dim>(FE_Q<dim>(2), dim));

  MappingQ1<dim> mapping;

  AffineConstraints<double> constraints;

  if (true)
    {
      ComponentMask component_mask(dim, true);
      component_mask.set(0, false);
      DoFTools::make_zero_boundary_constraints(dof_handler,
                                               constraints,
                                               component_mask);
    }

  constraints.close();

  MGTwoLevelTransferNonNested<dim, LinearAlgebra::distributed::Vector<double>>
    transfer;
  transfer.reinit(
    dof_handler, dof_handler, mapping, mapping, constraints, constraints);
}
```
with the output:
```
--------------------------------------------------------
An error occurred in line <3936> of file </home/munch/sw-index/dealii/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h> in function
    std::tuple<std::vector<unsigned int, std::allocator<unsigned int> >, std::vector<unsigned int, std::allocator<unsigned int> >, std::vector<unsigned int, std::allocator<unsigned int> > > dealii::internal::{anonymous}::support_point_indices_to_dof_indices(const dealii::DoFHandler<dim, spacedim>&, const dealii::DoFHandler<dim, spacedim>&, const dealii::AffineConstraints<number>&) [with int dim = 2; int spacedim = 2; Number = double]
The violated condition was: 
    support_point_dofs_comp.size() == 0 || support_point_dofs_comp.size() == n_components
Additional information: 
    You are trying to use functionality in deal.II that is currently not
    implemented. In many cases, this indicates that there simply didn't
    appear much of a need for it, or that the author of the original code
    did not have the time to implement a particular case. If you hit this
    exception, it is therefore worth the time to look into the code to
    find out whether you may be able to implement the missing
    functionality. If you do, please consider providing a patch to the
    deal.II development sources (see the deal.II website on how to
    contribute).

Stacktrace:
-----------
#0  /home/munch/sw-index/dealii-build/lib/libdeal_II.g.so.9.6.0-pre: 
#1  /home/munch/sw-index/dealii-build/lib/libdeal_II.g.so.9.6.0-pre: 
#2  /home/munch/sw-index/dealii-build/lib/libdeal_II.g.so.9.6.0-pre: dealii::MGTwoLevelTransferNonNested<2, dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Host> >::reinit(dealii::DoFHandler<2, 2> const&, dealii::DoFHandler<2, 2> const&, dealii::Mapping<2, 2> const&, dealii::Mapping<2, 2> const&, dealii::AffineConstraints<double> const&, dealii::AffineConstraints<double> const&)
#3  ./main: main
--------------------------------------------------------
```