### PR TITLE
Always inline a new function to restore performance

### DIFF
--- a/include/deal.II/matrix_free/tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/tensor_product_kernels.h
@@ -678,14 +678,17 @@ namespace internal
             bool              add,
             typename Number,
             typename Number2>
-  std::enable_if_t<(variant == evaluate_evenodd), void>
-  apply_matrix_vector_product(const Number2 *matrix,
-                              const Number * in,
-                              Number *       out,
-                              int            n_rows_runtime     = 0,
-                              int            n_columns_runtime  = 0,
-                              int            stride_in_runtime  = 0,
-                              int            stride_out_runtime = 0)
+#ifndef DEBUG
+  inline DEAL_II_ALWAYS_INLINE
+#endif
+    std::enable_if_t<(variant == evaluate_evenodd), void>
+    apply_matrix_vector_product(const Number2 *matrix,
+                                const Number * in,
+                                Number *       out,
+                                int            n_rows_runtime     = 0,
+                                int            n_columns_runtime  = 0,
+                                int            stride_in_runtime  = 0,
+                                int            stride_out_runtime = 0)
   {
     const int n_rows = n_rows_static == 0 ? n_rows_runtime : n_rows_static;
     const int n_columns =


### PR DESCRIPTION
This PR fixes the performance regression introduced by #15891: Before opening that PR, I had only tested and inspected the generated code by clang (which rightfully does not regress), but gcc chooses not to inline an important function, causing performance regressions on the `step_37` and `mg_glob_coarsen` benchmarks (`matvec_double`, `matvec_float`, `smoother`, `setup_dofs`): https://dealii.org/performance_tests//reports/render.html?#!3a0a2a5bdcfca093d445823bef0a285155022272.md

The fix is to force inlining on the relevant function (in release mode), as the compiler's heuristics seem to be wrong. I verified that this works on a machine with gcc-9.