### PR TITLE
Revert "PETScWrappers::TimeStepper: fix  typo"

### DIFF
--- a/include/deal.II/lac/petsc_ts.templates.h
+++ b/include/deal.II/lac/petsc_ts.templates.h
@@ -1093,8 +1093,8 @@ namespace PETScWrappers
         AssertPETSc(VecDuplicate(py, &av));
         AssertPETSc(VecDuplicate(py, &rv));
 
-        VectorType avdealii(av);
-        VectorType rvdealii(rv);
+        VectorBase avdealii(av);
+        VectorBase rvdealii(rv);
         avdealii = atol;
         rvdealii = rtol;
         for (auto i : algebraic_components())


### PR DESCRIPTION
I think the use of `VectorBase` in this case was indeed correct as the purpose
of the `avdealii` and `rvdealii` objects might have been to conveniently use
the dealii-specific `compress()` function.

This reverts commit 938003d90aa8ac845f7f36184e05d232ad5cfc67.

In reference to #15880
Closes #15882
