### PR TITLE
Add a default constructor to AffineConstraints. (And be more terse about default arguments.)

### DIFF
--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -424,7 +424,7 @@ namespace DoFTools
   make_sparsity_pattern(
     const DoFHandler<dim, spacedim> &dof_handler,
     SparsityPatternBase &            sparsity_pattern,
-    const AffineConstraints<number> &constraints = AffineConstraints<number>(),
+    const AffineConstraints<number> &constraints           = {},
     const bool                       keep_constrained_dofs = true,
     const types::subdomain_id subdomain_id = numbers::invalid_subdomain_id);
 
@@ -499,7 +499,7 @@ namespace DoFTools
     const DoFHandler<dim, spacedim> &dof_handler,
     const Table<2, Coupling> &       coupling,
     SparsityPatternBase &            sparsity_pattern,
-    const AffineConstraints<number> &constraints = AffineConstraints<number>(),
+    const AffineConstraints<number> &constraints           = {},
     const bool                       keep_constrained_dofs = true,
     const types::subdomain_id subdomain_id = numbers::invalid_subdomain_id);
 
@@ -1378,7 +1378,7 @@ namespace DoFTools
     const std::function<
       bool(const typename DoFHandler<dim, spacedim>::active_cell_iterator &)>
       &                              predicate,
-    const AffineConstraints<number> &constraints = AffineConstraints<number>());
+    const AffineConstraints<number> &constraints = {});
 
   /**
    * Extract a vector that represents the constant modes of the DoFHandler for

--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -2038,15 +2038,8 @@ private:
 
 template <typename number>
 inline AffineConstraints<number>::AffineConstraints()
-  : lines()
-  , local_lines()
-  , sorted(false)
-{
-  // make sure the IndexSet is compressed. Otherwise this can lead to crashes
-  // that are hard to find (only happen in release mode).
-  // see tests/mpi/affine_constraints_crash_01
-  local_lines.compress();
-}
+  : AffineConstraints<number>(IndexSet())
+{}
 
 
 

--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -548,23 +548,38 @@ public:
   };
 
   /**
+   * Default constructor.
+   *
+   * This constructor sets up an object that stores all constraints eventually
+   * given to it. (This is in contrast to the following constructor that
+   * restricts which degrees of freedom we should care about -- for example,
+   * in a parallel context one would typically only store constraints
+   * for the locally relevant DoFs, see
+   * @ref GlossLocallyRelevantDof .)
+   * Consequently, this constructor creates internal data structures for
+   * <i>all</i> possible
+   * indices will be created, leading to memory consumption on every
+   * processor that is proportional to the <i>overall</i> size of the
+   * problem, not just proportional to the size of the portion of the
+   * overall problem that is handled by the current processor. Calling
+   * this constructor in a parallel program is a common bug: Call the
+   * other one, with an index set, instead.
+   */
+  AffineConstraints();
+
+  /**
    * Constructor. The supplied IndexSet defines which indices might be
    * constrained inside this AffineConstraints container. In a calculation
    * with a DoFHandler object based on parallel::distributed::Triangulation
    * or parallel::shared::Triangulation, one should use the set of locally
-   * relevant dofs (see
+   * relevant DoFs (see
    * @ref GlossLocallyRelevantDof).
    *
    * The given IndexSet allows the AffineConstraints container to save
    * memory by just not caring about degrees of freedom that are not of
-   * importance to the current processor. Alternatively, if no such
-   * IndexSet is provided, internal data structures for <i>all</i> possible
-   * indices will be created, leading to memory consumption on every
-   * processor that is proportional to the <i>overall</i> size of the
-   * problem, not just proportional to the size of the portion of the
-   * overall problem that is handled by the current processor.
+   * importance to the current processor.
    */
-  explicit AffineConstraints(const IndexSet &local_constraints = IndexSet());
+  explicit AffineConstraints(const IndexSet &local_constraints);
 
   /**
    * Copy constructor
@@ -2023,6 +2038,20 @@ private:
 /* ---------------- template and inline functions ----------------- */
 
 template <typename number>
+inline AffineConstraints<number>::AffineConstraints()
+  : lines()
+  , local_lines()
+  , sorted(false)
+{
+  // make sure the IndexSet is compressed. Otherwise this can lead to crashes
+  // that are hard to find (only happen in release mode).
+  // see tests/mpi/affine_constraints_crash_01
+  local_lines.compress();
+}
+
+
+
+template <typename number>
 inline AffineConstraints<number>::AffineConstraints(
   const IndexSet &local_constraints)
   : lines()
@@ -2035,6 +2064,8 @@ inline AffineConstraints<number>::AffineConstraints(
   local_lines.compress();
 }
 
+
+
 template <typename number>
 inline AffineConstraints<number>::AffineConstraints(
   const AffineConstraints &affine_constraints)
@@ -2044,6 +2075,8 @@ inline AffineConstraints<number>::AffineConstraints(
   , local_lines(affine_constraints.local_lines)
   , sorted(affine_constraints.sorted)
 {}
+
+
 
 template <typename number>
 inline void

--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -557,8 +557,7 @@ public:
    * for the locally relevant DoFs, see
    * @ref GlossLocallyRelevantDof .)
    * Consequently, this constructor creates internal data structures for
-   * <i>all</i> possible
-   * indices will be created, leading to memory consumption on every
+   * <i>all</i> possible indices, leading to memory consumption on every
    * processor that is proportional to the <i>overall</i> size of the
    * problem, not just proportional to the size of the portion of the
    * overall problem that is handled by the current processor. Calling

--- a/include/deal.II/multigrid/mg_tools.h
+++ b/include/deal.II/multigrid/mg_tools.h
@@ -88,12 +88,11 @@ namespace MGTools
    */
   template <int dim, int spacedim, typename number = double>
   void
-  make_sparsity_pattern(
-    const DoFHandler<dim, spacedim> &dof_handler,
-    SparsityPatternBase &            sparsity,
-    const unsigned int               level,
-    const AffineConstraints<number> &constraints = AffineConstraints<number>(),
-    const bool                       keep_constrained_dofs = true);
+  make_sparsity_pattern(const DoFHandler<dim, spacedim> &dof_handler,
+                        SparsityPatternBase &            sparsity,
+                        const unsigned int               level,
+                        const AffineConstraints<number> &constraints = {},
+                        const bool keep_constrained_dofs             = true);
 
   /**
    * Make a sparsity pattern including fluxes of discontinuous Galerkin
@@ -105,12 +104,11 @@ namespace MGTools
    */
   template <int dim, int spacedim, typename number = double>
   void
-  make_flux_sparsity_pattern(
-    const DoFHandler<dim, spacedim> &dof_handler,
-    SparsityPatternBase &            sparsity,
-    const unsigned int               level,
-    const AffineConstraints<number> &constraints = AffineConstraints<number>(),
-    const bool                       keep_constrained_dofs = true);
+  make_flux_sparsity_pattern(const DoFHandler<dim, spacedim> &dof_handler,
+                             SparsityPatternBase &            sparsity,
+                             const unsigned int               level,
+                             const AffineConstraints<number> &constraints = {},
+                             const bool keep_constrained_dofs = true);
 
 
   /**

--- a/include/deal.II/non_matching/coupling.h
+++ b/include/deal.II/non_matching/coupling.h
@@ -97,8 +97,8 @@ namespace NonMatching
     const DoFHandler<dim1, spacedim> &immersed_dh,
     const Quadrature<dim1> &          quad,
     SparsityPatternBase &             sparsity,
-    const AffineConstraints<number> & constraints = AffineConstraints<number>(),
-    const ComponentMask &             space_comps = {},
+    const AffineConstraints<number> & constraints    = {},
+    const ComponentMask &             space_comps    = {},
     const ComponentMask &             immersed_comps = {},
     const Mapping<dim0, spacedim> &   space_mapping =
       StaticMappingQ1<dim0, spacedim>::mapping,
@@ -121,10 +121,10 @@ namespace NonMatching
     const DoFHandler<dim1, spacedim> &      immersed_dh,
     const Quadrature<dim1> &                quad,
     SparsityPatternBase &                   sparsity,
-    const AffineConstraints<number> &constraints = AffineConstraints<number>(),
-    const ComponentMask &            space_comps = {},
-    const ComponentMask &            immersed_comps = {},
-    const Mapping<dim1, spacedim> &  immersed_mapping =
+    const AffineConstraints<number> &       constraints    = {},
+    const ComponentMask &                   space_comps    = {},
+    const ComponentMask &                   immersed_comps = {},
+    const Mapping<dim1, spacedim> &         immersed_mapping =
       StaticMappingQ1<dim1, spacedim>::mapping,
     const AffineConstraints<number> &immersed_constraints =
       AffineConstraints<number>());


### PR DESCRIPTION
We already have a default constructor for `AffineConstraints`, but it looks like this:
```
  explicit AffineConstraints (const IndexSet &relevant_constraints = IndexSet());
```
The problem with this is that it is not possible to do something like this:
```
  void f(const AffineConstraints &constraints = {});
```
Here, the compiler complains about the *implicit* conversion of `{}` to `AffineConstraints`. This isn't what we had in mind when we made the constructor `explicit`: We just didn't want to allow the implicit conversion of an `IndexSet` to an `AffineConstraint` object.

With this constructor, I can now write the default argument, and the second commit does exactly this.