### PR TITLE
Disable eliminate_unrefined_islands in create_geometric_coarsening_sequence().

### DIFF
--- a/doc/news/changes/incompatibilities/20230822Fehling
+++ b/doc/news/changes/incompatibilities/20230822Fehling
@@ -1,0 +1,8 @@
+Changed: For Triangulations created with
+MGTransferGlobalCoarseningTools::create_geometric_coarsening_sequence(),
+the MeshSmoothing flag Triangulation::eliminate_unrefined_islands will
+be removed. It caused unintentional refinement during coarsening which
+led to problems in GlobalCoarseningFineDoFHandlerView. See also
+<a href="https://github.com/dealii/dealii/issues/15541">#15541</a>.
+<br>
+(Marc Fehling, 2023/08/22)

--- a/doc/news/changes/minor/20230822Fehling
+++ b/doc/news/changes/minor/20230822Fehling
@@ -1,0 +1,4 @@
+Changed: You can now set MeshSmoothing flags in non-empty triangulations
+with Triangulation::set_mesh_smoothing().
+<br>
+(Marc Fehling, 2023/08/22)

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1849,8 +1849,7 @@ public:
 
   /**
    * Set the mesh smoothing to @p mesh_smoothing. This overrides the
-   * MeshSmoothing given to the constructor. It is allowed to call this
-   * function only if the triangulation is empty.
+   * MeshSmoothing given to the constructor.
    */
   virtual void
   set_mesh_smoothing(const MeshSmoothing mesh_smoothing);

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -2380,8 +2380,7 @@ namespace MGTransferGlobalCoarseningTools
             &fine_triangulation_in))
         return std::make_shared<
           parallel::distributed::Triangulation<dim, spacedim>>(
-          fine_triangulation->get_communicator(),
-          fine_triangulation->get_mesh_smoothing());
+          fine_triangulation->get_communicator());
       else
 #endif
 #ifdef DEAL_II_WITH_MPI
@@ -2390,23 +2389,29 @@ namespace MGTransferGlobalCoarseningTools
               &fine_triangulation_in))
         return std::make_shared<parallel::shared::Triangulation<dim, spacedim>>(
           fine_triangulation->get_communicator(),
-          fine_triangulation->get_mesh_smoothing(),
+          Triangulation<dim, spacedim>::none,
           fine_triangulation->with_artificial_cells());
       else
 #endif
-        return std::make_shared<Triangulation<dim, spacedim>>(
-          fine_triangulation_in.get_mesh_smoothing());
+        return std::make_shared<Triangulation<dim, spacedim>>();
     };
 
     const unsigned int max_level = fine_triangulation_in.n_global_levels() - 1;
+
+    // clear 'eliminate_unrefined_islands' from MeshSmoothing flags
+    // to prevent unintentional refinement during coarsen_global()
+    const auto mesh_smoothing =
+      static_cast<typename Triangulation<dim, spacedim>::MeshSmoothing>(
+        fine_triangulation_in.get_mesh_smoothing() &
+        ~(Triangulation<dim, spacedim>::eliminate_unrefined_islands));
 
     // create coarse meshes
     for (unsigned int l = max_level; l > 0; --l)
       {
         // copy triangulation
         auto new_tria = create_new_empty_triangulation();
-
         new_tria->copy_triangulation(*coarse_grid_triangulations[l]);
+        new_tria->set_mesh_smoothing(mesh_smoothing);
 
         // coarsen mesh
         new_tria->coarsen_global();
@@ -2446,9 +2451,6 @@ namespace MGTransferGlobalCoarseningTools
     Assert(fine_triangulation, ExcNotImplemented());
 
     const auto comm = fine_triangulation->get_communicator();
-
-    parallel::distributed::Triangulation<dim, spacedim> temp_triangulation(
-      comm, fine_triangulation->get_mesh_smoothing());
 
     if (keep_fine_triangulation == true &&
         repartition_fine_triangulation == false)
@@ -2492,11 +2494,22 @@ namespace MGTransferGlobalCoarseningTools
     if (fine_triangulation_in.n_global_levels() == 1)
       return coarse_grid_triangulations;
 
+    parallel::distributed::Triangulation<dim, spacedim> temp_triangulation(
+      comm);
+
     if (keep_fine_triangulation == true)
       temp_triangulation.copy_triangulation(*fine_triangulation);
 
     auto *temp_triangulation_ptr =
       keep_fine_triangulation ? &temp_triangulation : fine_triangulation;
+
+    // clear 'eliminate_unrefined_islands' from MeshSmoothing flags
+    // to prevent unintentional refinement during coarsen_global()
+    const auto mesh_smoothing =
+      static_cast<typename Triangulation<dim, spacedim>::MeshSmoothing>(
+        temp_triangulation_ptr->get_mesh_smoothing() &
+        ~(Triangulation<dim, spacedim>::eliminate_unrefined_islands));
+    temp_triangulation_ptr->set_mesh_smoothing(mesh_smoothing);
 
     const unsigned int max_level = fine_triangulation->n_global_levels() - 1;
 
@@ -2525,6 +2538,12 @@ namespace MGTransferGlobalCoarseningTools
         // save mesh
         coarse_grid_triangulations[l - 1] = level_triangulation;
       }
+
+    // recover MeshSmoothing flags in case we used the fine_triangulation
+    // to build the sequence
+    if (keep_fine_triangulation == false)
+      fine_triangulation->set_mesh_smoothing(
+        coarse_grid_triangulations.back()->get_mesh_smoothing());
 #endif
 
     AssertDimension(coarse_grid_triangulations[0]->n_global_levels(), 1);

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -12259,8 +12259,6 @@ DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 void Triangulation<dim, spacedim>::set_mesh_smoothing(
   const MeshSmoothing mesh_smoothing)
 {
-  Assert(n_levels() == 0,
-         ExcTriangulationNotEmpty(vertices.size(), levels.size()));
   smooth_grid = mesh_smoothing;
 }
 


### PR DESCRIPTION
After some more research in #15541 and #15901, I found out that the MeshSmoothing flag [`eliminate_unrefined_islands`](https://www.dealii.org/developer/doxygen/deal.II/classTriangulation.html#a0633dd17e535a59162b79f338c6ff5aeaf065376600b9b08c1c65d00505225e2f) is responsible for unintentional refinement during coarsening as reported in https://github.com/dealii/dealii/issues/15541#issuecomment-1686565309.

This PR removes the problematic flag from all triangulations in the coarsening sequence (without altering the input triangulation).


More details
---

The `static_cast` for the MeshSmoothing flags is necessary, otherwise gcc can't convert from int and complains.

`copy_triangulation()` and `create_description_from_triangulation()` also copy MeshSmoothing flags, so we don't have to set them in the dummy objects.

It is currently not possible to change the MeshSmoothing flags after a triangulation has been created: The `set_mesh_smoothing()` function checks whether the triangulation is empty with an assertion. I had to remove this assertion for this patch. Alternatively, we can make the `create_geometric_coarsening_sequence()` friend functions and manipulate the field directly. What do you think?