### PR TITLE
Standardize on 'const X' instead of 'X const'.

### DIFF
--- a/include/deal.II/base/cuda.h
+++ b/include/deal.II/base/cuda.h
@@ -51,7 +51,7 @@ namespace Utilities
       /**
        * Copy constructor is deleted.
        */
-      Handle(Handle const &) = delete;
+      Handle(const Handle &) = delete;
 
       /**
        * Destructor. Destroy the handles.

--- a/include/deal.II/base/partitioner.templates.h
+++ b/include/deal.II/base/partitioner.templates.h
@@ -599,7 +599,7 @@ namespace Utilities
             {
               if (vector_operation == VectorOperation::add)
                 {
-                  for (auto const &import_indices_plain :
+                  for (const auto &import_indices_plain :
                        import_indices_plain_dev)
                     {
                       const auto chunk_size = import_indices_plain.size();
@@ -623,7 +623,7 @@ namespace Utilities
                 }
               else if (vector_operation == VectorOperation::min)
                 {
-                  for (auto const &import_indices_plain :
+                  for (const auto &import_indices_plain :
                        import_indices_plain_dev)
                     {
                       const auto chunk_size = import_indices_plain.size();
@@ -650,7 +650,7 @@ namespace Utilities
                 }
               else if (vector_operation == VectorOperation::max)
                 {
-                  for (auto const &import_indices_plain :
+                  for (const auto &import_indices_plain :
                        import_indices_plain_dev)
                     {
                       const auto chunk_size = import_indices_plain.size();
@@ -677,7 +677,7 @@ namespace Utilities
                 }
               else
                 {
-                  for (auto const &import_indices_plain :
+                  for (const auto &import_indices_plain :
                        import_indices_plain_dev)
                     {
                       // We can't easily assert here, so we just move the

--- a/include/deal.II/base/template_constraints.h
+++ b/include/deal.II/base/template_constraints.h
@@ -94,9 +94,9 @@ namespace internal
     struct nonesuch : private nonesuch_base
     {
       ~nonesuch()                = delete;
-      nonesuch(nonesuch const &) = delete;
+      nonesuch(const nonesuch &) = delete;
       void
-      operator=(nonesuch const &) = delete;
+      operator=(const nonesuch &) = delete;
     };
 
     template <class Default, template <class...> class Op, class... Args>

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -1813,7 +1813,7 @@ namespace FETools
             // sufficiently large so that there
             // are more than about 5000
             // operations in the inner loop
-            // (which is basically const * n^2
+            // (which is const basically * n^2
             // operations).
             if (n > 30)
               {

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -47,13 +47,13 @@ DEAL_II_NAMESPACE_OPEN
 namespace internal
 {
   template <typename T>
-  using has_block_t = decltype(std::declval<T const>().block(0));
+  using has_block_t = decltype(std::declval<const T>().block(0));
 
   template <typename T>
   constexpr bool has_block = internal::is_supported_operation<has_block_t, T>;
 
   template <typename T>
-  using has_n_blocks_t = decltype(std::declval<T const>().n_blocks());
+  using has_n_blocks_t = decltype(std::declval<const T>().n_blocks());
 
   template <typename T>
   constexpr bool has_n_blocks =

--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -1342,9 +1342,9 @@ namespace PETScWrappers
     prepare_action(VectorOperation::insert);
 
     const PetscInt  petsc_i = row;
-    PetscInt const *col_index_ptr;
+    const PetscInt *col_index_ptr;
 
-    PetscScalar const *col_value_ptr;
+    const PetscScalar *col_value_ptr;
     int                n_columns;
 
     // If we don't elide zeros, the pointers are already available...
@@ -1486,9 +1486,9 @@ namespace PETScWrappers
     prepare_action(VectorOperation::add);
 
     const PetscInt  petsc_i = row;
-    PetscInt const *col_index_ptr;
+    const PetscInt *col_index_ptr;
 
-    PetscScalar const *col_value_ptr;
+    const PetscScalar *col_value_ptr;
     int                n_columns;
 
     // If we don't elide zeros, the pointers are already available...

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -530,7 +530,7 @@ namespace internal
   // ... MatrixType::vmult(VectorType &, const VectorType&,
   // std::function<...>, std::function<...>) const
   template <typename MatrixType, typename VectorType>
-  using vmult_functions_t = decltype(std::declval<MatrixType const>().vmult(
+  using vmult_functions_t = decltype(std::declval<const MatrixType>().vmult(
     std::declval<VectorType &>(),
     std::declval<const VectorType &>(),
     std::declval<
@@ -560,7 +560,7 @@ namespace internal
   {
     template <typename T, typename VectorType>
     using Tvmult_t = decltype(
-      std::declval<T const>().Tvmult(std::declval<VectorType &>(),
+      std::declval<const T>().Tvmult(std::declval<VectorType &>(),
                                      std::declval<const VectorType &>()));
 
     template <typename T, typename VectorType>
@@ -568,7 +568,7 @@ namespace internal
 
     template <typename T, typename VectorType>
     using step_t = decltype(
-      std::declval<T const>().step(std::declval<VectorType &>(),
+      std::declval<const T>().step(std::declval<VectorType &>(),
                                    std::declval<const VectorType &>()));
 
     template <typename T, typename VectorType>
@@ -576,7 +576,7 @@ namespace internal
 
     template <typename T, typename VectorType>
     using step_omega_t =
-      decltype(std::declval<T const>().step(std::declval<VectorType &>(),
+      decltype(std::declval<const T>().step(std::declval<VectorType &>(),
                                             std::declval<const VectorType &>(),
                                             std::declval<const double>()));
 
@@ -586,7 +586,7 @@ namespace internal
 
     template <typename T, typename VectorType>
     using Tstep_t = decltype(
-      std::declval<T const>().Tstep(std::declval<VectorType &>(),
+      std::declval<const T>().Tstep(std::declval<VectorType &>(),
                                     std::declval<const VectorType &>()));
 
     template <typename T, typename VectorType>
@@ -594,7 +594,7 @@ namespace internal
 
     template <typename T, typename VectorType>
     using Tstep_omega_t =
-      decltype(std::declval<T const>().Tstep(std::declval<VectorType &>(),
+      decltype(std::declval<const T>().Tstep(std::declval<VectorType &>(),
                                              std::declval<const VectorType &>(),
                                              std::declval<const double>()));
 
@@ -604,7 +604,7 @@ namespace internal
 
     template <typename T, typename VectorType>
     using jacobi_step_t = decltype(
-      std::declval<T const>().Jacobi_step(std::declval<VectorType &>(),
+      std::declval<const T>().Jacobi_step(std::declval<VectorType &>(),
                                           std::declval<const VectorType &>(),
                                           std::declval<const double>()));
 
@@ -614,7 +614,7 @@ namespace internal
 
     template <typename T, typename VectorType>
     using SOR_step_t = decltype(
-      std::declval<T const>().SOR_step(std::declval<VectorType &>(),
+      std::declval<const T>().SOR_step(std::declval<VectorType &>(),
                                        std::declval<const VectorType &>(),
                                        std::declval<const double>()));
 
@@ -624,7 +624,7 @@ namespace internal
 
     template <typename T, typename VectorType>
     using SSOR_step_t = decltype(
-      std::declval<T const>().SSOR_step(std::declval<VectorType &>(),
+      std::declval<const T>().SSOR_step(std::declval<VectorType &>(),
                                         std::declval<const VectorType &>(),
                                         std::declval<const double>()));
 

--- a/include/deal.II/lac/scalapack.templates.h
+++ b/include/deal.II/lac/scalapack.templates.h
@@ -505,7 +505,7 @@ extern "C"
    * norm, or the element of largest absolute value of a distributed matrix
    */
   double
-  pdlange_(char const *  norm,
+  pdlange_(const char *  norm,
            const int *   m,
            const int *   n,
            const double *A,

--- a/include/deal.II/lac/solver_cg.h
+++ b/include/deal.II/lac/solver_cg.h
@@ -656,7 +656,7 @@ namespace internal
     // ... MatrixType::vmult(VectorType &, const VectorType&,
     // std::function<...>, std::function<...>) const
     template <typename MatrixType, typename VectorType>
-    using vmult_functions_t = decltype(std::declval<MatrixType const>().vmult(
+    using vmult_functions_t = decltype(std::declval<const MatrixType>().vmult(
       std::declval<VectorType &>(),
       std::declval<const VectorType &>(),
       std::declval<
@@ -673,7 +673,7 @@ namespace internal
     // unsigned int, const unsigned int, const Number*, Number*) const
     template <typename PreconditionerType>
     using apply_to_subrange_t =
-      decltype(std::declval<PreconditionerType const>()
+      decltype(std::declval<const PreconditionerType>()
                  .apply_to_subrange(0U, 0U, nullptr, nullptr));
 
     template <typename PreconditionerType>
@@ -685,7 +685,7 @@ namespace internal
     // unsigned int, const Number) const
     template <typename PreconditionerType>
     using apply_t =
-      decltype(std::declval<PreconditionerType const>().apply(0U, 0.0));
+      decltype(std::declval<const PreconditionerType>().apply(0U, 0.0));
 
     template <typename PreconditionerType>
     constexpr bool has_apply =

--- a/include/deal.II/lac/sparse_matrix_tools.h
+++ b/include/deal.II/lac/sparse_matrix_tools.h
@@ -170,14 +170,14 @@ namespace SparseMatrixTools
 
     template <typename T>
     using get_mpi_communicator_t =
-      decltype(std::declval<T const>().get_mpi_communicator());
+      decltype(std::declval<const T>().get_mpi_communicator());
 
     template <typename T>
     constexpr bool has_get_mpi_communicator =
       dealii::internal::is_supported_operation<get_mpi_communicator_t, T>;
 
     template <typename T>
-    using local_size_t = decltype(std::declval<T const>().local_size());
+    using local_size_t = decltype(std::declval<const T>().local_size());
 
     template <typename T>
     constexpr bool has_local_size =

--- a/include/deal.II/matrix_free/type_traits.h
+++ b/include/deal.II/matrix_free/type_traits.h
@@ -38,7 +38,7 @@ namespace internal
   // a helper type-trait that leverage SFINAE to figure out if type T has
   // ... T::local_element() const
   template <typename T>
-  using local_element_t = decltype(std::declval<T const>().local_element(0));
+  using local_element_t = decltype(std::declval<const T>().local_element(0));
 
   template <typename T>
   constexpr bool has_local_element = is_supported_operation<local_element_t, T>;
@@ -74,7 +74,7 @@ namespace internal
   // const
   template <typename T>
   using partitioners_are_compatible_t =
-    decltype(std::declval<T const>().partitioners_are_compatible(
+    decltype(std::declval<const T>().partitioners_are_compatible(
       std::declval<Utilities::MPI::Partitioner>()));
 
   template <typename T>
@@ -86,7 +86,7 @@ namespace internal
   // same as above to check
   // ... T::begin() const
   template <typename T>
-  using begin_t = decltype(std::declval<T const>().begin());
+  using begin_t = decltype(std::declval<const T>().begin());
 
   template <typename T>
   constexpr bool has_begin = is_supported_operation<begin_t, T>;
@@ -97,7 +97,7 @@ namespace internal
   // ... T::shared_vector_data() const
   template <typename T>
   using shared_vector_data_t =
-    decltype(std::declval<T const>().shared_vector_data());
+    decltype(std::declval<const T>().shared_vector_data());
 
   template <typename T>
   constexpr bool has_shared_vector_data =
@@ -138,7 +138,7 @@ namespace internal
   // void T::update_ghost_values_start(const uint) const
   template <typename T>
   using update_ghost_values_start_t =
-    decltype(std::declval<T const>().update_ghost_values_start(0));
+    decltype(std::declval<const T>().update_ghost_values_start(0));
 
   template <typename T>
   constexpr bool has_update_ghost_values_start =

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -2000,7 +2000,7 @@ namespace internal
       }
 
       // ------------------------- prolongation matrix -------------------------
-      for (auto const &fe_index_pair_ : fe_index_pairs)
+      for (const auto &fe_index_pair_ : fe_index_pairs)
         {
           const auto &fe_index_pair = fe_index_pair_.first;
           const auto &fe_index_no   = fe_index_pair_.second;

--- a/include/deal.II/numerics/matrix_creator.templates.h
+++ b/include/deal.II/numerics/matrix_creator.templates.h
@@ -982,8 +982,8 @@ namespace MatrixCreator
   {
     template <int dim, int spacedim, typename number>
     void static inline create_boundary_mass_matrix_1(
-      typename DoFHandler<dim, spacedim>::active_cell_iterator const &cell,
-      MatrixCreator::internal::AssemblerBoundary::Scratch const &,
+      const typename DoFHandler<dim, spacedim>::active_cell_iterator &cell,
+      const MatrixCreator::internal::AssemblerBoundary::Scratch &,
       MatrixCreator::internal::AssemblerBoundary::
         CopyData<dim, spacedim, number> & copy_data,
       Mapping<dim, spacedim> const &      mapping,
@@ -1291,8 +1291,8 @@ namespace MatrixCreator
 
     template <>
     void inline create_boundary_mass_matrix_1<1, 3, float>(
-      DoFHandler<1, 3>::active_cell_iterator const & /*cell*/,
-      MatrixCreator::internal::AssemblerBoundary::Scratch const &,
+      const DoFHandler<1, 3>::active_cell_iterator & /*cell*/,
+      const MatrixCreator::internal::AssemblerBoundary::Scratch &,
       MatrixCreator::internal::AssemblerBoundary::CopyData<1, 3, float>
         & /*copy_data*/,
       Mapping<1, 3> const &,
@@ -1308,8 +1308,8 @@ namespace MatrixCreator
 
     template <>
     void inline create_boundary_mass_matrix_1<1, 3, double>(
-      DoFHandler<1, 3>::active_cell_iterator const & /*cell*/,
-      MatrixCreator::internal::AssemblerBoundary::Scratch const &,
+      const DoFHandler<1, 3>::active_cell_iterator & /*cell*/,
+      const MatrixCreator::internal::AssemblerBoundary::Scratch &,
       MatrixCreator::internal::AssemblerBoundary::CopyData<1, 3, double>
         & /*copy_data*/,
       Mapping<1, 3> const &,
@@ -1381,8 +1381,8 @@ namespace MatrixCreator
       dof.begin_active(),
       dof.end(),
       [&mapping, &fe, &q, &boundary_functions, coefficient, &component_mapping](
-        typename DoFHandler<dim, spacedim>::active_cell_iterator const &cell,
-        MatrixCreator::internal::AssemblerBoundary::Scratch const &scratch_data,
+        const typename DoFHandler<dim, spacedim>::active_cell_iterator &cell,
+        const MatrixCreator::internal::AssemblerBoundary::Scratch &scratch_data,
         MatrixCreator::internal::AssemblerBoundary::
           CopyData<dim, spacedim, number> &copy_data) {
         internal::create_boundary_mass_matrix_1(cell,
@@ -1415,8 +1415,8 @@ namespace MatrixCreator
     template <int dim, int spacedim, typename number>
     void
     create_hp_boundary_mass_matrix_1(
-      typename DoFHandler<dim, spacedim>::active_cell_iterator const &cell,
-      MatrixCreator::internal::AssemblerBoundary::Scratch const &,
+      const typename DoFHandler<dim, spacedim>::active_cell_iterator &cell,
+      const MatrixCreator::internal::AssemblerBoundary::Scratch &,
       MatrixCreator::internal::AssemblerBoundary ::
         CopyData<dim, spacedim, number> &         copy_data,
       hp::MappingCollection<dim, spacedim> const &mapping,
@@ -1857,8 +1857,8 @@ namespace MatrixCreator
        &boundary_functions,
        coefficient,
        &component_mapping](
-        typename DoFHandler<dim, spacedim>::active_cell_iterator const &cell,
-        MatrixCreator::internal::AssemblerBoundary::Scratch const &scratch_data,
+        const typename DoFHandler<dim, spacedim>::active_cell_iterator &cell,
+        const MatrixCreator::internal::AssemblerBoundary::Scratch &scratch_data,
         MatrixCreator::internal::AssemblerBoundary ::
           CopyData<dim, spacedim, number> &copy_data) {
         internal::create_hp_boundary_mass_matrix_1(cell,

--- a/include/deal.II/numerics/rtree.h
+++ b/include/deal.II/numerics/rtree.h
@@ -216,7 +216,7 @@ public:
   /**
    * Constructor. Store a const reference to a container.
    */
-  explicit IndexableGetterFromIndices(Container const &c)
+  explicit IndexableGetterFromIndices(const Container &c)
     : container(c)
   {}
 
@@ -334,7 +334,7 @@ struct ExtractLevelVisitor
    * @p target_level of the tree.
    */
   inline ExtractLevelVisitor(
-    Translator const & translator,
+    const Translator & translator,
     const unsigned int target_level,
     std::vector<BoundingBox<boost::geometry::dimension<Box>::value>> &boxes);
 
@@ -364,18 +364,18 @@ struct ExtractLevelVisitor
    * belongs to the @p target_level, then fill the bounding box vector.
    */
   inline void
-  operator()(InternalNode const &node);
+  operator()(const InternalNode &node);
 
   /**
    * Implements the visitor interface for Leaf objects.
    */
   inline void
-  operator()(Leaf const &);
+  operator()(const Leaf &);
 
   /**
    * Translator interface, required by the boost implementation of the rtree.
    */
-  Translator const &translator;
+  const Translator &translator;
 
   /**
    * Store the level we are currently visiting.
@@ -683,18 +683,18 @@ struct NodeVisitor : public boost::geometry::index::detail::rtree::visitor<
    * belongs to the level next to @p target_level, then fill the bounding box vector for that node.
    */
   inline void
-  operator()(InternalNode const &node);
+  operator()(const InternalNode &node);
 
   /**
    * Implements the visitor interface for Leaf objects.
    */
   inline void
-  operator()(Leaf const &);
+  operator()(const Leaf &);
 
   /**
    * Translator interface, required by the boost implementation of the rtree.
    */
-  Translator const &translator;
+  const Translator &translator;
 
   /**
    * Store the level we are currently visiting.

--- a/include/deal.II/numerics/vector_tools_boundary.templates.h
+++ b/include/deal.II/numerics/vector_tools_boundary.templates.h
@@ -232,7 +232,7 @@ namespace VectorTools
             q_collection,
             update_quadrature_points);
 
-          for (auto const &cell : dof.active_cell_iterators())
+          for (const auto &cell : dof.active_cell_iterators())
             if (!cell->is_artificial())
               for (const unsigned int face_no : cell->face_indices())
                 {

--- a/source/base/polynomial.cc
+++ b/source/base/polynomial.cc
@@ -626,7 +626,7 @@ namespace Polynomials
 
     unsigned int n_functions = n + 1;
     AssertIndexRange(support_point, n_functions);
-    double const *x = nullptr;
+    const double *x = nullptr;
 
     switch (n)
       {

--- a/source/distributed/field_transfer.cc
+++ b/source/distributed/field_transfer.cc
@@ -191,7 +191,7 @@ namespace parallel
           out.local_element(i) = std::numeric_limits<Number>::infinity();
 
         unsigned int cell_i = 0;
-        for (auto const &cell : dof_handler.active_cell_iterators())
+        for (const auto &cell : dof_handler.active_cell_iterators())
           {
             if ((cell->is_locally_owned()) &&
                 (transferred_data[cell_i][0] !=

--- a/source/distributed/p4est_wrappers.cc
+++ b/source/distributed/p4est_wrappers.cc
@@ -908,8 +908,8 @@ namespace internal
 
     template <>
     bool
-    quadrant_is_ancestor<1>(types<1>::quadrant const &q1,
-                            types<1>::quadrant const &q2)
+    quadrant_is_ancestor<1>(const types<1>::quadrant &q1,
+                            const types<1>::quadrant &q2)
     {
       // determine level of quadrants
       const int level_1 = (q1 << types<1>::max_n_child_indices_bits) >>

--- a/source/dofs/dof_accessor_set.cc
+++ b/source/dofs/dof_accessor_set.cc
@@ -93,7 +93,7 @@ namespace internal
    */
   template <typename T>
   using set_ghost_state_t =
-    decltype(std::declval<T const>().set_ghost_state(std::declval<bool>()));
+    decltype(std::declval<const T>().set_ghost_state(std::declval<bool>()));
 
   template <typename T>
   constexpr bool has_set_ghost_state =

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -6561,7 +6561,7 @@ namespace GridGenerator
           {
             for (const auto &cell : tria->cell_iterators())
               {
-                for (auto const &f : cell->face_indices())
+                for (const auto &f : cell->face_indices())
                   if (result_cell->face(f)->at_boundary())
                     result_cell->face(f)->set_boundary_id(
                       cell->face(f)->boundary_id());

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -6402,7 +6402,7 @@ namespace GridTools
       // requested intersections are unique also the resulting quadrature
       // points are unique and we can simply number the points in an
       // ascending way.
-      for (auto const &recv_component : recv_components)
+      for (const auto &recv_component : recv_components)
         {
           // dependent on the size of the intersection an empty quadrature
           // is returned. Therefore, we have to compute the quadrature also
@@ -6755,7 +6755,7 @@ namespace GridTools
                     CGALWrappers::resort_dealii_vertices_to_cgal_order(
                       structdim, requested_intersection);
 
-                    auto const &try_intersection =
+                    const auto &try_intersection =
                       CGALWrappers::get_vertices_in_cgal_order(
                         cell, cache.get_mapping());
 

--- a/source/numerics/derivative_approximation.cc
+++ b/source/numerics/derivative_approximation.cc
@@ -993,12 +993,12 @@ namespace DerivativeApproximation
         end,
         [&mapping, &dof_handler, &solution, component](
           SynchronousIterators<Iterators> const &cell,
-          Assembler::Scratch const &,
+          const Assembler::Scratch &,
           Assembler::CopyData &) {
           approximate<DerivativeDescription, dim, InputVector, spacedim>(
             cell, mapping, dof_handler, solution, component);
         },
-        std::function<void(internal::Assembler::CopyData const &)>(),
+        std::function<void(const internal::Assembler::CopyData &)>(),
         internal::Assembler::Scratch(),
         internal::Assembler::CopyData());
     }

--- a/source/particles/generators.cc
+++ b/source/particles/generators.cc
@@ -476,7 +476,7 @@ namespace Particles
       // Memory is reserved for efficiency reasons
       std::vector<Point<spacedim>> support_points_vec;
       support_points_vec.reserve(support_points_map.size());
-      for (auto const &element : support_points_map)
+      for (const auto &element : support_points_map)
         support_points_vec.push_back(element.second);
 
       particle_handler.insert_global_particles(support_points_vec,

--- a/tests/base/graph_coloring_01.cc
+++ b/tests/base/graph_coloring_01.cc
@@ -38,7 +38,7 @@
 template <int dim>
 std::vector<types::global_dof_index>
 get_conflict_indices_cfem(
-  typename DoFHandler<dim>::active_cell_iterator const &it)
+  typename DoFHandler<dim>::active_cell_const iterator &it)
 {
   std::vector<types::global_dof_index> local_dof_indices(
     it->get_fe().dofs_per_cell);
@@ -67,7 +67,7 @@ check()
       cell,
       dof_handler.end(),
       std::function<std::vector<types::global_dof_index>(
-        typename DoFHandler<dim>::active_cell_iterator const &)>(
+        typename DoFHandler<dim>::active_cell_const iterator &)>(
         &get_conflict_indices_cfem<dim>)));
 
   // Output the coloring

--- a/tests/base/graph_coloring_02.cc
+++ b/tests/base/graph_coloring_02.cc
@@ -38,7 +38,7 @@
 template <int dim>
 std::vector<types::global_dof_index>
 get_conflict_indices_cfem(
-  typename DoFHandler<dim>::active_cell_iterator const &it)
+  typename DoFHandler<dim>::active_cell_const iterator &it)
 {
   std::vector<types::global_dof_index> local_dof_indices(
     it->get_fe().dofs_per_cell);
@@ -76,7 +76,7 @@ check()
       dof_handler.begin_active(),
       dof_handler.end(),
       std::function<std::vector<types::global_dof_index>(
-        typename DoFHandler<dim>::active_cell_iterator const &)>(
+        typename DoFHandler<dim>::active_cell_const iterator &)>(
         &get_conflict_indices_cfem<dim>)));
 
   // Output the coloring

--- a/tests/base/graph_coloring_02a.cc
+++ b/tests/base/graph_coloring_02a.cc
@@ -38,7 +38,7 @@
 template <int dim>
 std::vector<types::global_dof_index>
 get_conflict_indices_cfem(
-  typename DoFHandler<dim>::active_cell_iterator const &it)
+  typename DoFHandler<dim>::active_cell_const iterator &it)
 {
   std::vector<types::global_dof_index> local_dof_indices(
     it->get_fe().dofs_per_cell);
@@ -78,7 +78,7 @@ check()
       dof_handler.begin_active(),
       dof_handler.end(),
       std::function<std::vector<types::global_dof_index>(
-        typename DoFHandler<dim>::active_cell_iterator const &)>(
+        typename DoFHandler<dim>::active_cell_const iterator &)>(
         &get_conflict_indices_cfem<dim>)));
 
   // verify that within each color, there is no conflict

--- a/tests/base/graph_coloring_03.cc
+++ b/tests/base/graph_coloring_03.cc
@@ -38,7 +38,7 @@
 template <int dim>
 std::vector<types::global_dof_index>
 get_conflict_indices_cfem(
-  typename DoFHandler<dim>::active_cell_iterator const &it)
+  typename DoFHandler<dim>::active_cell_const iterator &it)
 {
   std::vector<types::global_dof_index> local_dof_indices(
     it->get_fe().dofs_per_cell);
@@ -79,7 +79,7 @@ check()
       dof_handler.begin_active(),
       dof_handler.end(),
       std::function<std::vector<types::global_dof_index>(
-        typename DoFHandler<dim>::active_cell_iterator const &)>(
+        typename DoFHandler<dim>::active_cell_const iterator &)>(
         &get_conflict_indices_cfem<dim>)));
 
   // Output the coloring

--- a/tests/base/graph_coloring_05.cc
+++ b/tests/base/graph_coloring_05.cc
@@ -39,7 +39,7 @@
 template <int dim>
 std::vector<types::global_dof_index>
 get_conflict_indices_cfem(
-  typename DoFHandler<dim>::active_cell_iterator const &it)
+  typename DoFHandler<dim>::active_cell_const iterator &it)
 {
   std::vector<types::global_dof_index> local_dof_indices(
     it->get_fe().dofs_per_cell);
@@ -77,7 +77,7 @@ check()
       dof_handler.begin_active(),
       dof_handler.end(),
       std::function<std::vector<types::global_dof_index>(
-        typename DoFHandler<dim>::active_cell_iterator const &)>(
+        typename DoFHandler<dim>::active_cell_const iterator &)>(
         &get_conflict_indices_cfem<dim>)));
 
   // Check that a color does not contain a conflict index twice

--- a/tests/base/graph_coloring_06.cc
+++ b/tests/base/graph_coloring_06.cc
@@ -38,7 +38,7 @@
 template <int dim>
 std::vector<types::global_dof_index>
 get_conflict_indices_cfem(
-  typename DoFHandler<dim>::active_cell_iterator const &it)
+  typename DoFHandler<dim>::active_cell_const iterator &it)
 {
   std::vector<types::global_dof_index> local_dof_indices(
     it->get_fe().dofs_per_cell);
@@ -82,7 +82,7 @@ check()
       dof_handler.begin_active(),
       dof_handler.end(),
       std::function<std::vector<types::global_dof_index>(
-        typename DoFHandler<dim>::active_cell_iterator const &)>(
+        typename DoFHandler<dim>::active_cell_const iterator &)>(
         &get_conflict_indices_cfem<dim>));
 
   for (unsigned int color = 0; color < coloring.size(); ++color)

--- a/tests/base/mpi_some_to_some_01.cc
+++ b/tests/base/mpi_some_to_some_01.cc
@@ -41,7 +41,7 @@ main(int argc, char *argv[])
   auto received_pts = Utilities::MPI::some_to_some(MPI_COMM_WORLD, m);
 
   bool test_passed = true;
-  for (auto const &pt : received_pts)
+  for (const auto &pt : received_pts)
     if (std::abs(pt.first - pt.second[0][0]) > 1e-12 ||
         std::abs(2.0 * pt.first + pt.second[0][1]) > 1e-12)
       {

--- a/tests/mappings/mapping_get_vertices_on_face.cc
+++ b/tests/mappings/mapping_get_vertices_on_face.cc
@@ -54,9 +54,9 @@ test_vertex_order()
   for (const auto &cell : tria.active_cell_iterators())
     for (unsigned int f = 0; f < cell->n_faces(); ++f)
       {
-        auto const &vertices_detour =
+        const auto &vertices_detour =
           get_vertices(cell, cell->face(f), mapping);
-        auto const &vertices = mapping.get_vertices(cell, f);
+        const auto &vertices = mapping.get_vertices(cell, f);
 
         AssertDimension(vertices_detour.size(), vertices.size());
 

--- a/tests/matrix_free/matrix_vector_rt_04.cc
+++ b/tests/matrix_free/matrix_vector_rt_04.cc
@@ -140,7 +140,7 @@ test()
 
   for (auto cell : tria.cell_iterators())
     {
-      for (auto const &v : cell->vertex_indices())
+      for (const auto &v : cell->vertex_indices())
         {
           if (vertex_touched[cell->vertex_index(v)] == false)
             {

--- a/tests/matrix_free/matrix_vector_rt_face_04.cc
+++ b/tests/matrix_free/matrix_vector_rt_face_04.cc
@@ -141,7 +141,7 @@ test()
 
   for (auto cell : tria.cell_iterators())
     {
-      for (auto const &v : cell->vertex_indices())
+      for (const auto &v : cell->vertex_indices())
         {
           if (vertex_touched[cell->vertex_index(v)] == false)
             {

--- a/tests/numerics/assemble_matrix_parallel_01.cc
+++ b/tests/numerics/assemble_matrix_parallel_01.cc
@@ -128,7 +128,7 @@ private:
 
   std::vector<types::global_dof_index>
   get_conflict_indices(
-    typename DoFHandler<dim>::active_cell_iterator const &cell) const;
+    typename DoFHandler<dim>::active_cell_const iterator &cell) const;
 
   Triangulation<dim> triangulation;
 
@@ -238,7 +238,7 @@ LaplaceProblem<dim>::~LaplaceProblem()
 template <int dim>
 std::vector<types::global_dof_index>
 LaplaceProblem<dim>::get_conflict_indices(
-  typename DoFHandler<dim>::active_cell_iterator const &cell) const
+  typename DoFHandler<dim>::active_cell_const iterator &cell) const
 {
   std::vector<types::global_dof_index> local_dof_indices(
     cell->get_fe().dofs_per_cell);
@@ -278,7 +278,7 @@ LaplaceProblem<dim>::setup_system()
     dof_handler.begin_active(),
     dof_handler.end(),
     static_cast<std::function<std::vector<types::global_dof_index>(
-      typename DoFHandler<dim>::active_cell_iterator const &)>>(
+      typename DoFHandler<dim>::active_cell_const iterator &)>>(
       std::bind(&LaplaceProblem<dim>::get_conflict_indices,
                 this,
                 std::placeholders::_1)));

--- a/tests/numerics/assemble_matrix_parallel_02.cc
+++ b/tests/numerics/assemble_matrix_parallel_02.cc
@@ -143,7 +143,7 @@ private:
 
   std::vector<types::global_dof_index>
   get_conflict_indices(
-    typename DoFHandler<dim>::active_cell_iterator const &cell) const;
+    typename DoFHandler<dim>::active_cell_const iterator &cell) const;
 
   Triangulation<dim> triangulation;
 
@@ -255,7 +255,7 @@ LaplaceProblem<dim>::~LaplaceProblem()
 template <int dim>
 std::vector<types::global_dof_index>
 LaplaceProblem<dim>::get_conflict_indices(
-  typename DoFHandler<dim>::active_cell_iterator const &cell) const
+  typename DoFHandler<dim>::active_cell_const iterator &cell) const
 {
   std::vector<types::global_dof_index> local_dof_indices(
     cell->get_fe().dofs_per_cell);
@@ -296,7 +296,7 @@ LaplaceProblem<dim>::setup_system()
     dof_handler.begin_active(),
     dof_handler.end(),
     static_cast<std::function<std::vector<types::global_dof_index>(
-      typename DoFHandler<dim>::active_cell_iterator const &)>>(
+      typename DoFHandler<dim>::active_cell_const iterator &)>>(
       std::bind(&LaplaceProblem<dim>::get_conflict_indices,
                 this,
                 std::placeholders::_1)));

--- a/tests/numerics/assemble_matrix_parallel_03.cc
+++ b/tests/numerics/assemble_matrix_parallel_03.cc
@@ -128,7 +128,7 @@ private:
 
   std::vector<types::global_dof_index>
   get_conflict_indices(
-    typename DoFHandler<dim>::active_cell_iterator const &cell) const;
+    typename DoFHandler<dim>::active_cell_const iterator &cell) const;
 
   Triangulation<dim> triangulation;
 
@@ -238,7 +238,7 @@ LaplaceProblem<dim>::~LaplaceProblem()
 template <int dim>
 std::vector<types::global_dof_index>
 LaplaceProblem<dim>::get_conflict_indices(
-  typename DoFHandler<dim>::active_cell_iterator const &cell) const
+  typename DoFHandler<dim>::active_cell_const iterator &cell) const
 {
   std::vector<types::global_dof_index> local_dof_indices(
     cell->get_fe().dofs_per_cell);
@@ -278,7 +278,7 @@ LaplaceProblem<dim>::setup_system()
     dof_handler.begin_active(),
     dof_handler.end(),
     static_cast<std::function<std::vector<types::global_dof_index>(
-      typename DoFHandler<dim>::active_cell_iterator const &)>>(
+      typename DoFHandler<dim>::active_cell_const iterator &)>>(
       std::bind(&LaplaceProblem<dim>::get_conflict_indices,
                 this,
                 std::placeholders::_1)));

--- a/tests/numerics/assemble_matrix_parallel_04.cc
+++ b/tests/numerics/assemble_matrix_parallel_04.cc
@@ -142,7 +142,7 @@ private:
 
   std::vector<types::global_dof_index>
   get_conflict_indices(
-    typename DoFHandler<dim>::active_cell_iterator const &cell) const;
+    typename DoFHandler<dim>::active_cell_const iterator &cell) const;
 
   Triangulation<dim> triangulation;
 
@@ -254,7 +254,7 @@ LaplaceProblem<dim>::~LaplaceProblem()
 template <int dim>
 std::vector<types::global_dof_index>
 LaplaceProblem<dim>::get_conflict_indices(
-  typename DoFHandler<dim>::active_cell_iterator const &cell) const
+  typename DoFHandler<dim>::active_cell_const iterator &cell) const
 {
   std::vector<types::global_dof_index> local_dof_indices(
     cell->get_fe().dofs_per_cell);
@@ -308,7 +308,7 @@ LaplaceProblem<dim>::setup_system()
     dof_handler.begin_active(),
     dof_handler.end(),
     static_cast<std::function<std::vector<types::global_dof_index>(
-      typename DoFHandler<dim>::active_cell_iterator const &)>>(
+      typename DoFHandler<dim>::active_cell_const iterator &)>>(
       std::bind(&LaplaceProblem<dim>::get_conflict_indices,
                 this,
                 std::placeholders::_1)));

--- a/tests/petsc/assemble_matrix_parallel_01.cc
+++ b/tests/petsc/assemble_matrix_parallel_01.cc
@@ -127,7 +127,7 @@ private:
 
   std::vector<types::global_dof_index>
   get_conflict_indices(
-    typename DoFHandler<dim>::active_cell_iterator const &cell) const;
+    typename DoFHandler<dim>::active_cell_const iterator &cell) const;
 
   Triangulation<dim> triangulation;
 
@@ -235,7 +235,7 @@ LaplaceProblem<dim>::~LaplaceProblem()
 template <int dim>
 std::vector<types::global_dof_index>
 LaplaceProblem<dim>::get_conflict_indices(
-  typename DoFHandler<dim>::active_cell_iterator const &cell) const
+  typename DoFHandler<dim>::active_cell_const iterator &cell) const
 {
   std::vector<types::global_dof_index> local_dof_indices(
     cell->get_fe().dofs_per_cell);
@@ -271,7 +271,7 @@ LaplaceProblem<dim>::setup_system()
     dof_handler.begin_active(),
     dof_handler.end(),
     static_cast<std::function<std::vector<types::global_dof_index>(
-      typename DoFHandler<dim>::active_cell_iterator const &)>>(
+      typename DoFHandler<dim>::active_cell_const iterator &)>>(
       std::bind(&LaplaceProblem<dim>::get_conflict_indices,
                 this,
                 std::placeholders::_1)));

--- a/tests/trilinos/assemble_matrix_parallel_01.cc
+++ b/tests/trilinos/assemble_matrix_parallel_01.cc
@@ -124,7 +124,7 @@ private:
 
   std::vector<types::global_dof_index>
   get_conflict_indices(
-    typename DoFHandler<dim>::active_cell_iterator const &cell) const;
+    typename DoFHandler<dim>::active_cell_const iterator &cell) const;
 
   Triangulation<dim> triangulation;
 
@@ -232,7 +232,7 @@ LaplaceProblem<dim>::~LaplaceProblem()
 template <int dim>
 std::vector<types::global_dof_index>
 LaplaceProblem<dim>::get_conflict_indices(
-  typename DoFHandler<dim>::active_cell_iterator const &cell) const
+  typename DoFHandler<dim>::active_cell_const iterator &cell) const
 {
   std::vector<types::global_dof_index> local_dof_indices(
     cell->get_fe().dofs_per_cell);
@@ -271,7 +271,7 @@ LaplaceProblem<dim>::setup_system()
     dof_handler.begin_active(),
     dof_handler.end(),
     static_cast<std::function<std::vector<types::global_dof_index>(
-      typename DoFHandler<dim>::active_cell_iterator const &)>>(
+      typename DoFHandler<dim>::active_cell_const iterator &)>>(
       std::bind(&LaplaceProblem<dim>::get_conflict_indices,
                 this,
                 std::placeholders::_1)));


### PR DESCRIPTION
As mentioned in #15903. I think this catches a good share of the non-whitespace changes in #15903. There are a few of the form `X const` where `X` is a template type that I cannot easily catch with a regex -- but this is better than nothing I figure.