### PR TITLE
Tensor polynomials: Remove nonsensical comments

### DIFF
--- a/include/deal.II/base/polynomials_abf.h
+++ b/include/deal.II/base/polynomials_abf.h
@@ -69,11 +69,6 @@ public:
    *
    * The size of the vectors must either be zero or equal <tt>n()</tt>.  In
    * the first case, the function will not compute these values.
-   *
-   * If you need values or derivatives of all tensor product polynomials then
-   * use this function, rather than using any of the <tt>compute_value</tt>,
-   * <tt>compute_grad</tt> or <tt>compute_grad_grad</tt> functions, see below,
-   * in a loop over all tensor product polynomials.
    */
   void
   evaluate(const Point<dim> &           unit_point,

--- a/include/deal.II/base/polynomials_bdm.h
+++ b/include/deal.II/base/polynomials_bdm.h
@@ -115,11 +115,6 @@ public:
    *
    * The size of the vectors must either be zero or equal <tt>n()</tt>.  In
    * the first case, the function will not compute these values.
-   *
-   * If you need values or derivatives of all tensor product polynomials then
-   * use this function, rather than using any of the <tt>compute_value</tt>,
-   * <tt>compute_grad</tt> or <tt>compute_grad_grad</tt> functions, see below,
-   * in a loop over all tensor product polynomials.
    */
   void
   evaluate(const Point<dim> &           unit_point,

--- a/include/deal.II/base/polynomials_bernardi_raugel.h
+++ b/include/deal.II/base/polynomials_bernardi_raugel.h
@@ -106,11 +106,6 @@ public:
    *
    * The size of the vectors must either be zero or equal <tt>n()</tt>.  In
    * the first case, the function will not compute these values.
-   *
-   * If you need values or derivatives of all tensor product polynomials then
-   * use this function, rather than using any of the <tt>compute_value</tt>,
-   * <tt>compute_grad</tt> or <tt>compute_grad_grad</tt> functions, see below,
-   * in a loop over all tensor product polynomials.
    */
   void
   evaluate(const Point<dim> &           unit_point,

--- a/include/deal.II/base/polynomials_nedelec.h
+++ b/include/deal.II/base/polynomials_nedelec.h
@@ -66,11 +66,6 @@ public:
    *
    * The size of the vectors must either be zero or equal <tt>n()</tt>.  In
    * the first case, the function will not compute these values.
-   *
-   * If you need values or derivatives of all tensor product polynomials then
-   * use this function, rather than using any of the <tt>compute_value</tt>,
-   * <tt>compute_grad</tt> or <tt>compute_grad_grad</tt> functions, see below,
-   * in a loop over all tensor product polynomials.
    */
   void
   evaluate(const Point<dim> &           unit_point,

--- a/include/deal.II/base/polynomials_raviart_thomas.h
+++ b/include/deal.II/base/polynomials_raviart_thomas.h
@@ -80,11 +80,6 @@ public:
    *
    * The size of the vectors must either be zero or equal <tt>n()</tt>. In
    * the first case, the function will not compute these values.
-   *
-   * If you need values or derivatives of all tensor product polynomials then
-   * use this function, rather than using any of the <tt>compute_value</tt>,
-   * <tt>compute_grad</tt> or <tt>compute_grad_grad</tt> functions, see below,
-   * in a loop over all tensor product polynomials.
    */
   void
   evaluate(const Point<dim> &           unit_point,

--- a/include/deal.II/base/polynomials_rt_bubbles.h
+++ b/include/deal.II/base/polynomials_rt_bubbles.h
@@ -103,11 +103,6 @@ public:
    *
    * The size of the vectors must either be zero or equal <tt>n()</tt>.  In
    * the first case, the function will not compute these values.
-   *
-   * If you need values or derivatives of all tensor product polynomials then
-   * use this function, rather than using any of the <tt>compute_value</tt>,
-   * <tt>compute_grad</tt> or <tt>compute_grad_grad</tt> functions, see below,
-   * in a loop over all tensor product polynomials.
    */
   void
   evaluate(const Point<dim> &           unit_point,

--- a/include/deal.II/base/tensor_polynomials_base.h
+++ b/include/deal.II/base/tensor_polynomials_base.h
@@ -91,11 +91,6 @@ public:
    *
    * The size of the vectors must either be zero or equal <tt>n()</tt>.  In
    * the first case, the function will not compute these values.
-   *
-   * If you need values or derivatives of all polynomials then use this
-   * function, rather than using any of the <tt>compute_value</tt>,
-   * <tt>compute_grad</tt> or <tt>compute_grad_grad</tt> functions, see below,
-   * in a loop over all tensor product polynomials.
    */
   virtual void
   evaluate(const Point<dim> &           unit_point,


### PR DESCRIPTION
Looking at #15913, I realized that all classes derived from `TensorPolynomialsBase` refer to some `compute_value`, `compute_grad`, `compute_grad_grad` functions that are not even present in these classes. I guess this is a copy-paste effect from the scalar tensor product polynomial class https://github.com/dealii/dealii/blob/e3b4ff4147fac613da3b1ab607c9689182491c47/include/deal.II/base/tensor_product_polynomials.h#L126-L129 that actually has these functions https://github.com/dealii/dealii/blob/e3b4ff4147fac613da3b1ab607c9689182491c47/include/deal.II/base/tensor_product_polynomials.h#L151-L152 etc. While I would be tempted to introduce such a function to evaluate a single basis function at a point at least for the class `PolynomialsRaviartThomas` to get the matrix-free initialization reasonably fast (the current method has a quadratic complexity in `ShapeInfo::reinit()` because it evaluates the complete basis for every basis function we request via `FE_PolyTensor::shape_value_component()`), that is a wrong assumption, and it is in fact better to work towards #9655.