### PR TITLE
Matrix-free Raviart-Thomas: Set symmetry/even-odd in ShapeInfo

### DIFF
--- a/include/deal.II/matrix_free/shape_info.h
+++ b/include/deal.II/matrix_free/shape_info.h
@@ -168,10 +168,10 @@ namespace internal
        */
       template <int dim, int spacedim>
       void
-      evaluate_collocation_space(
-        const FiniteElement<dim, spacedim> &fe,
-        const Quadrature<1>                &quad,
-        const std::vector<unsigned int>    &lexicographic);
+      evaluate_collocation_space(const FiniteElement<dim, spacedim> &fe,
+                                 const Quadrature<1>                &quad,
+                                 const std::vector<unsigned int> &lexicographic,
+                                 const unsigned int               direction);
 
       /**
        * Check whether we have symmetries in the shape values. In that case,


### PR DESCRIPTION
With the re-structuring of #15905 and #15913, I can now easily compute the even-odd parts and detect symmetries in the Raviart-Thomas case.