### PR TITLE
FEValues: Allow checking for cell similarities in multi-threaded mode

### DIFF
--- a/include/deal.II/fe/fe_values_base.h
+++ b/include/deal.II/fe/fe_values_base.h
@@ -222,6 +222,12 @@ public:
    */
   virtual ~FEValuesBase() override;
 
+  /**
+   * Explicitly allow to check for cell similarity. By default, this is only
+   * enabled when the number of threads is 1.
+   */
+  void
+  allow_check_for_cell_similarity(bool allow);
 
   /// @name Access to shape function values
   ///
@@ -1740,6 +1746,11 @@ private:
    * A cache for all possible FEValuesViews objects.
    */
   dealii::internal::FEValuesViews::Cache<dim, spacedim> fe_values_views_cache;
+
+  /**
+   * Whether checking for cell similarity is allowed.
+   */
+  bool check_for_cell_similarity_allowed;
 
   // Make the view classes friends of this class, since they access internal
   // data.

--- a/include/deal.II/fe/fe_values_base.h
+++ b/include/deal.II/fe/fe_values_base.h
@@ -227,13 +227,23 @@ public:
    * The detection of simple geometries with CellSimilarity is sensitive to the
    * first cell detected. When using multiple threads, each thread might get a
    * thread local copy of the FEValues object that is initialized to the first
-   * cell the thread sees. As this cell might be differ between runs and number
-   * of threads used, this slight deviation leads to difference in roundoff
-   * errors that propagate through the program. Therefore, the CellSimilarity
-   * check is disabled by default in case more than one thread is used.
+   * cell the thread sees. As this cell might be different between runs and
+   * number of threads used, this slight deviation leads to difference in
+   * roundoff errors that propagate through the program. Therefore, deal.II
+   * disables the CellSimilarity check by default in programs that use more than
+   * one thread. This function can be used to disable this behavior: When
+   * called, FEValues objects will always do the similarity check, even in cases
+   * where the program uses multiple threads. This substantially accelerates the
+   * operations of FEValues because many operations can be avoided if a cell is,
+   * for example, just a translation of the previous cell. On the other hand,
+   * you might get results that differ by an amount proportional to round-off
+   * between the case of using or not using cell similarity information, and
+   * because the order of cells assigned to individual threads may differ from
+   * run to run, when you call this function you may end up with results that
+   * differ by round-off between runs of the same program.
    */
   void
-  allow_check_for_cell_similarity(bool allow);
+  always_allow_check_for_cell_similarity(const bool allow);
 
   /// @name Access to shape function values
   ///

--- a/include/deal.II/fe/fe_values_base.h
+++ b/include/deal.II/fe/fe_values_base.h
@@ -223,8 +223,14 @@ public:
   virtual ~FEValuesBase() override;
 
   /**
-   * Explicitly allow to check for cell similarity. By default, this is only
-   * enabled when the number of threads is 1.
+   * Explicitly allow to check for cell similarity.
+   * The detection of simple geometries with CellSimilarity is sensitive to the
+   * first cell detected. When using multiple threads, each thread might get a
+   * thread local copy of the FEValues object that is initialized to the first
+   * cell the thread sees. As this cell might be differ between runs and number
+   * of threads used, this slight deviation leads to difference in roundoff
+   * errors that propagate through the program. Therefore, the CellSimilarity
+   * check is disabled by default in case more than one thread is used.
    */
   void
   allow_check_for_cell_similarity(bool allow);

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -118,6 +118,7 @@ namespace CUDAWrappers
     {
       local_dof_indices.resize(data->dofs_per_cell);
       lexicographic_dof_indices.resize(dofs_per_cell);
+      fe_values.allow_check_for_cell_similarity(true);
     }
 
 

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -118,7 +118,7 @@ namespace CUDAWrappers
     {
       local_dof_indices.resize(data->dofs_per_cell);
       lexicographic_dof_indices.resize(dofs_per_cell);
-      fe_values.allow_check_for_cell_similarity(true);
+      fe_values.always_allow_check_for_cell_similarity(true);
     }
 
 

--- a/source/fe/fe_values_base.cc
+++ b/source/fe/fe_values_base.cc
@@ -249,7 +249,8 @@ FEValuesBase<dim, spacedim>::~FEValuesBase()
 
 template <int dim, int spacedim>
 void
-FEValuesBase<dim, spacedim>::allow_check_for_cell_similarity(bool allow)
+FEValuesBase<dim, spacedim>::always_allow_check_for_cell_similarity(
+  const bool allow)
 {
   check_for_cell_similarity_allowed = allow;
 }
@@ -1416,19 +1417,7 @@ inline void
 FEValuesBase<dim, spacedim>::check_cell_similarity(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell)
 {
-  // Unfortunately, the detection of simple geometries with CellSimilarity is
-  // sensitive to the first cell detected. When doing this with multiple
-  // threads, each thread will get its own scratch data object with an
-  // FEValues object in the implementation framework from late 2013, which is
-  // initialized to the first cell the thread sees. As this number might
-  // different between different runs (after all, the tasks are scheduled
-  // dynamically onto threads), this slight deviation leads to difference in
-  // roundoff errors that propagate through the program. Therefore, we
-  // disable CellSimilarity by default in case there is more than one thread in
-  // the problem. This will likely not affect many MPI test cases as there
-  // multithreading is disabled on default, but in many other situations
-  // because we rarely explicitly set the number of threads.
-  if (!check_for_cell_similarity_allowed)
+  if (check_for_cell_similarity_allowed == false)
     {
       cell_similarity = CellSimilarity::none;
       return;


### PR DESCRIPTION
Looking at the `Kokkos` `MatricxFree` benchmark, I noticed that the setup takes a long time without setting `DEAL_II_NUM_THREADS=1`. It seems that not checking for cell similarity is responsible. At the moment, we only allow doing that check when we set the number of threads to 1. There might be contexts where we know that we would not run into the danger of initializing `FEValues` objects by multiple threads (and getting possibly slightly different results depending on which thread looked at which cell).
This pull request introduces an option to explicitly allow this check and enables it in the `Kokkos` `MatrixFree` implementation.