### PR TITLE
Only use necessary vector_tools include file

### DIFF
--- a/include/deal.II/numerics/smoothness_estimator.h
+++ b/include/deal.II/numerics/smoothness_estimator.h
@@ -21,7 +21,7 @@
 
 #include <deal.II/fe/component_mask.h>
 
-#include <deal.II/numerics/vector_tools.h>
+#include <deal.II/numerics/vector_tools_common.h>
 
 #include <functional>
 #include <vector>

--- a/source/numerics/smoothness_estimator.cc
+++ b/source/numerics/smoothness_estimator.cc
@@ -13,7 +13,7 @@
 //
 // ---------------------------------------------------------------------
 
-#include <deal.II/base/quadrature.h>
+#include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/signaling_nan.h>
 
 #include <deal.II/dofs/dof_handler.h>


### PR DESCRIPTION
We do not need the full `VectorTools` include, only the declaration of the norm types, in `smoothness_estimator`.