### PR TITLE
Fix range-based for loop in performance test

### DIFF
--- a/tests/performance/timing_navier_stokes.cc
+++ b/tests/performance/timing_navier_stokes.cc
@@ -1163,7 +1163,7 @@ namespace NavierStokes_DG
                             EvaluationFlags::values |
                               EvaluationFlags::gradients);
 
-        for (const unsigned int q : quadrature_point_indices())
+        for (const unsigned int q : phi.quadrature_point_indices())
           {
             const auto w_q      = phi.get_value(q);
             const auto grad_w_q = phi.get_gradient(q);


### PR DESCRIPTION
In #15936, I must have messed up my changes after I ran `sed`, resulting in a missing `phi.` in front of `quadrature_point_indices()`. This prevents the `timing_navier_stokes` test from compiling and running. Now I checked that it is working again.