### PR TITLE
Use more 'if constexpr' in the matrix-free code.

### DIFF
--- a/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
+++ b/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
@@ -426,7 +426,7 @@ namespace CUDAWrappers
                      scratch_memory_space,
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>> values)
     {
-      if (dim == 2)
+      if constexpr (dim == 2)
         {
           interpolate_boundary_2d<fe_degree, 0, transpose>(team_member,
                                                            constraint_weights,
@@ -438,7 +438,7 @@ namespace CUDAWrappers
                                                            constraint_mask,
                                                            values);
         }
-      else if (dim == 3)
+      else if constexpr (dim == 3)
         {
           // Interpolate y and z faces (x-direction)
           interpolate_boundary_3d<fe_degree, 0, transpose>(team_member,

--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -1011,7 +1011,7 @@ namespace internal
       fe_eval,
       add_into_values_array,
       std::integral_constant<bool, integrate>());
-    if (dim == 3)
+    if constexpr (dim == 3)
       {
         // Third component
         evaluate_tensor_product_per_component<2>(
@@ -1559,7 +1559,7 @@ namespace internal
               eval_val.template values<0, true, false>(values_in, values_out);
               eval_val.template values<1, true, false>(values_out, values_out);
             }
-          else if (dim == 1)
+          else if constexpr (dim == 1)
             eval_val.template values<dim - 1, true, false>(values_in,
                                                            values_out);
           else
@@ -1690,7 +1690,7 @@ namespace internal
                     eval_val.template hessians<0, false, true>(values_in,
                                                                values_out);
                 }
-              else if (dim == 1)
+              else if constexpr (dim == 1)
                 {
                   if (quantity == EvaluatorQuantity::value)
                     eval_val.template values<0, false, false>(values_in,
@@ -1929,10 +1929,10 @@ namespace internal
          (EvaluationFlags::gradients | EvaluationFlags::hessians)) != 0u)
       {
         eval.template gradients<0, true, false>(values_dofs, gradients_quad);
-        if (dim > 1)
+        if constexpr (dim > 1)
           eval.template gradients<1, true, false>(values_dofs,
                                                   gradients_quad + n_points);
-        if (dim > 2)
+        if constexpr (dim > 2)
           eval.template gradients<2, true, false>(values_dofs,
                                                   gradients_quad +
                                                     2 * n_points);
@@ -1940,7 +1940,7 @@ namespace internal
     if (evaluation_flag & EvaluationFlags::hessians)
       {
         eval.template hessians<0, true, false>(values_dofs, hessians_quad);
-        if (dim > 1)
+        if constexpr (dim > 1)
           {
             eval.template gradients<1, true, false>(gradients_quad,
                                                     hessians_quad +
@@ -1948,7 +1948,7 @@ namespace internal
             eval.template hessians<1, true, false>(values_dofs,
                                                    hessians_quad + n_points);
           }
-        if (dim > 2)
+        if constexpr (dim > 2)
           {
             eval.template gradients<2, true, false>(gradients_quad,
                                                     hessians_quad +
@@ -2030,15 +2030,15 @@ namespace internal
         else
           eval.template hessians<0, false, false>(hessians_quad, values_dofs);
         // grad yy
-        if (dim > 1)
+        if constexpr (dim > 1)
           eval.template hessians<1, false, true>(hessians_quad + n_points,
                                                  values_dofs);
         // grad zz
-        if (dim > 2)
+        if constexpr (dim > 2)
           eval.template hessians<2, false, true>(hessians_quad + 2 * n_points,
                                                  values_dofs);
         // off-diagonal
-        if (dim == 2)
+        if constexpr (dim == 2)
           {
             // grad xy, queue into gradient
             if (integration_flag & EvaluationFlags::gradients)
@@ -2050,7 +2050,7 @@ namespace internal
                                                          2 * n_points,
                                                        gradients_quad);
           }
-        if (dim == 3)
+        if constexpr (dim == 3)
           {
             // grad xy, queue into gradient
             if (integration_flag & EvaluationFlags::gradients)
@@ -2092,10 +2092,10 @@ namespace internal
           eval.template gradients<0, false, true>(gradients_quad, values_dofs);
         else
           eval.template gradients<0, false, false>(gradients_quad, values_dofs);
-        if (dim > 1)
+        if constexpr (dim > 1)
           eval.template gradients<1, false, true>(gradients_quad + n_points,
                                                   values_dofs);
-        if (dim > 2)
+        if constexpr (dim > 2)
           eval.template gradients<2, false, true>(gradients_quad + 2 * n_points,
                                                   values_dofs);
       }
@@ -3013,7 +3013,7 @@ namespace internal
                                 subface_index,
                                 std::integral_constant<bool, integrate>());
 
-      if (dim == 3)
+      if constexpr (dim == 3)
         evaluate_in_face_apply<1>(values_dofs,
                                   fe_eval,
                                   scratch_data,
@@ -3638,7 +3638,7 @@ namespace internal
       const unsigned int                             face_no,
       const MatrixFreeFunctions::ShapeInfo<Number2> &shape_info)
     {
-      if (dim == 1)
+      if constexpr (dim == 1)
         {
           // This should never happen since the FE_RaviartThomasNodal is not
           // defined for dim = 1. It prevents compiler warnings of infinite
@@ -3766,11 +3766,6 @@ namespace internal
                                                   shape_info.data[0] :
                                                   shape_info.data[1],
                                                 face_no);
-      Evalf2 evalf2 =
-        create_evaluator_tensor_product<Evalf2>((face_direction == 2) ?
-                                                  shape_info.data[0] :
-                                                  shape_info.data[1],
-                                                face_no);
 
       const unsigned int dofs_per_component_on_cell =
         shape_info.dofs_per_component_on_cell;
@@ -3807,8 +3802,13 @@ namespace internal
                                  add_into_output,
                                  max_derivative>(input, output);
 
-      if (dim == 3)
+      if constexpr (dim == 3)
         {
+          auto evalf2 =
+            create_evaluator_tensor_product<Evalf2>((face_direction == 2) ?
+                                                      shape_info.data[0] :
+                                                      shape_info.data[1],
+                                                    face_no);
           // stride to next component
           input += (face_direction == 1) ? in_stride_after_normal : in_stride;
           output +=
@@ -5580,9 +5580,9 @@ namespace internal
           // Need to select 'apply' method with hessian slot because values
           // assume symmetries that do not exist in the inverse shapes
           evaluator.template hessians<0, true, false>(in, out);
-          if (dim > 1)
+          if constexpr (dim > 1)
             evaluator.template hessians<1, true, false>(out, out);
-          if (dim > 2)
+          if constexpr (dim > 2)
             evaluator.template hessians<2, true, false>(out, out);
         }
       for (unsigned int q = 0; q < dofs_per_component; ++q)
@@ -5594,9 +5594,9 @@ namespace internal
       for (unsigned int d = 0; d < n_components; ++d)
         {
           Number *out = out_array + d * dofs_per_component;
-          if (dim > 2)
+          if constexpr (dim > 2)
             evaluator.template hessians<2, false, false>(out, out);
-          if (dim > 1)
+          if constexpr (dim > 1)
             evaluator.template hessians<1, false, false>(out, out);
           evaluator.template hessians<0, false, false>(out, out);
         }
@@ -5688,9 +5688,9 @@ namespace internal
               const Number *in_  = in + di * dofs_per_component;
               Number       *out_ = out + di * dofs_per_component;
               evaluator.template hessians<0, true, false>(in_, out_);
-              if (dim > 1)
+              if constexpr (dim > 1)
                 evaluator.template hessians<1, true, false>(out_, out_);
-              if (dim > 2)
+              if constexpr (dim > 2)
                 evaluator.template hessians<2, true, false>(out_, out_);
             }
           if (dyadic_coefficients)
@@ -5722,9 +5722,9 @@ namespace internal
           for (unsigned int di = 0; di < n_comp_inner; ++di)
             {
               Number *out_ = out + di * dofs_per_component;
-              if (dim > 2)
+              if constexpr (dim > 2)
                 evaluator.template hessians<2, false, false>(out_, out_);
-              if (dim > 1)
+              if constexpr (dim > 1)
                 evaluator.template hessians<1, false, false>(out_, out_);
               evaluator.template hessians<0, false, false>(out_, out_);
             }
@@ -5826,23 +5826,29 @@ namespace internal
           Number       *out = out_array + d * dofs_per_component;
 
           auto *temp_1 = do_inplace ? out : fe_eval.get_scratch_data().begin();
-          auto *temp_2 = do_inplace ?
-                           out :
-                           (temp_1 + std::max(n_q_points, dofs_per_component));
 
-          if (dim == 3)
+          if constexpr (dim == 3)
             {
+              auto *temp_2 =
+                do_inplace ?
+                  out :
+                  (temp_1 + std::max(n_q_points, dofs_per_component));
               evaluator.template hessians<2, false, false>(in, temp_1);
               evaluator.template hessians<1, false, false>(temp_1, temp_2);
               evaluator.template hessians<0, false, false>(temp_2, out);
             }
-          if (dim == 2)
+          if constexpr (dim == 2)
             {
               evaluator.template hessians<1, false, false>(in, temp_1);
               evaluator.template hessians<0, false, false>(temp_1, out);
             }
-          if (dim == 1)
-            evaluator.template hessians<0, false, false>(in, out);
+          if constexpr (dim == 1)
+            {
+              // avoid an unused variable warning since temp_1 isn't used in
+              // this branch. This spurious warning is fixed in GCC-13.
+              (void)temp_1;
+              evaluator.template hessians<0, false, false>(in, out);
+            }
         }
       return false;
     }

--- a/include/deal.II/matrix_free/evaluation_kernels_hanging_nodes.h
+++ b/include/deal.II/matrix_free/evaluation_kernels_hanging_nodes.h
@@ -197,7 +197,7 @@ namespace internal
       const unsigned int points = given_degree + 1;
       const unsigned int n_dofs = shape_info.dofs_per_component_on_cell;
 
-      if (dim == 2)
+      if constexpr (dim == 2)
         {
           dealii::ndarray<Number, 2>    mask_weights = {};
           dealii::ndarray<Number, 2, 2> mask_write   = {};
@@ -259,7 +259,7 @@ namespace internal
                                                values + c * n_dofs);
           }
         }
-      else if (dim == 3)
+      else if constexpr (dim == 3)
         {
           const unsigned int p0 = 0;
           const unsigned int p1 = points - 1;
@@ -1560,7 +1560,7 @@ namespace internal
                                                          constraint_mask_sorted,
                                                          v);
 
-              if (dim == 2) // 2d: only faces
+              if constexpr (dim == 2) // 2d: only faces
                 {
                   const bool subcell_x = (mask >> 0) & 1;
                   const bool subcell_y = (mask >> 1) & 1;
@@ -1603,7 +1603,7 @@ namespace internal
                                                      values); // face 1
                     }
                 }
-              else if (dim == 3) // 3d faces and edges
+              else if constexpr (dim == 3) // 3d faces and edges
                 {
                   const bool type_x = (mask >> 0) & 1;
                   const bool type_y = (mask >> 1) & 1;

--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -1712,7 +1712,7 @@ FEPointEvaluation<n_components_, dim, spacedim, Number>::do_reinit()
       for (unsigned int qb = 0; qb < n_batches; ++qb)
         if (use_face_path)
           {
-            if (dim > 1)
+            if constexpr (dim > 1)
               {
                 shapes_faces.resize_fast(n_batches * n_shapes);
                 internal::compute_values_of_array(
@@ -1854,28 +1854,28 @@ FEPointEvaluation<n_components_, dim, spacedim, Number>::compute_evaluate_fast(
           if (current_face_number / 2 == 0)
             {
               gradient[0] = interpolated_value[dim];
-              if (dim > 1)
+              if constexpr (dim > 1)
                 gradient[1] = interpolated_value[0];
-              if (dim > 2)
+              if constexpr (dim > 2)
                 gradient[2] = interpolated_value[1];
             }
           else if (current_face_number / 2 == 1)
             {
-              if (dim > 1)
+              if constexpr (dim > 1)
                 gradient[1] = interpolated_value[dim];
-              if (dim == 3)
+              if constexpr (dim == 3)
                 {
                   gradient[0] = interpolated_value[1];
                   gradient[2] = interpolated_value[0];
                 }
-              else if (dim == 2)
+              else if constexpr (dim == 2)
                 gradient[0] = interpolated_value[0];
               else
                 Assert(false, ExcInternalError());
             }
           else if (current_face_number / 2 == 2)
             {
-              if (dim > 2)
+              if constexpr (dim > 2)
                 {
                   gradient[0] = interpolated_value[0];
                   gradient[1] = interpolated_value[1];
@@ -1922,9 +1922,9 @@ FEPointEvaluation<n_components_, dim, spacedim, Number>::compute_evaluate_fast(
                        n_shapes,
                        solution_renumbered.data());
           gradient[0] = result[0];
-          if (dim > 1)
+          if constexpr (dim > 1)
             gradient[1] = result[1];
-          if (dim > 2)
+          if constexpr (dim > 2)
             gradient[2] = result[2];
           value = result[dim];
         }
@@ -2124,28 +2124,28 @@ FEPointEvaluation<n_components_, dim, spacedim, Number>::compute_integrate_fast(
           if (current_face_number / 2 == 0)
             {
               value_face[1] = gradient[0];
-              if (dim > 1)
+              if constexpr (dim > 1)
                 gradient_in_face[0] = gradient[1];
-              if (dim > 2)
+              if constexpr (dim > 2)
                 gradient_in_face[1] = gradient[2];
             }
           else if (current_face_number / 2 == 1)
             {
-              if (dim > 1)
+              if constexpr (dim > 1)
                 value_face[1] = gradient[1];
-              if (dim == 3)
+              if constexpr (dim == 3)
                 {
                   gradient_in_face[0] = gradient[2];
                   gradient_in_face[1] = gradient[0];
                 }
-              else if (dim == 2)
+              else if constexpr (dim == 2)
                 gradient_in_face[0] = gradient[0];
               else
                 Assert(false, ExcInternalError());
             }
           else if (current_face_number / 2 == 2)
             {
-              if (dim > 2)
+              if constexpr (dim > 2)
                 {
                   value_face[1]       = gradient[2];
                   gradient_in_face[0] = gradient[0];

--- a/include/deal.II/matrix_free/hanging_nodes_internal.h
+++ b/include/deal.II/matrix_free/hanging_nodes_internal.h
@@ -565,7 +565,7 @@ namespace internal
           face |= 1 << direction;
         }
 
-      if (dim == 3)
+      if constexpr (dim == 3)
         for (unsigned int direction = 0; direction < dim; ++direction)
           if (face == 0 || face == (1 << direction))
             {
@@ -667,23 +667,27 @@ namespace internal
         const auto side      = face_no % 2;
         const auto offset    = (side == 1) ? (n_dofs_1d - 1) : 0;
 
-        if (dim == 2)
-          return (direction == 0) ? (n_dofs_1d * i + offset) :
-                                    (n_dofs_1d * offset + i);
-        else if (dim == 3)
-          switch (direction)
-            {
-              case 0:
-                return n_dofs_1d * n_dofs_1d * i + n_dofs_1d * j + offset;
-              case 1:
-                return n_dofs_1d * n_dofs_1d * j + n_dofs_1d * offset + i;
-              case 2:
-                return n_dofs_1d * n_dofs_1d * offset + n_dofs_1d * i + j;
-              default:
-                Assert(false, ExcNotImplemented());
-            }
-
-        Assert(false, ExcNotImplemented());
+        switch (dim)
+          {
+            case 2:
+              return (direction == 0) ? (n_dofs_1d * i + offset) :
+                                        (n_dofs_1d * offset + i);
+            case 3:
+              switch (direction)
+                {
+                  case 0:
+                    return n_dofs_1d * n_dofs_1d * i + n_dofs_1d * j + offset;
+                  case 1:
+                    return n_dofs_1d * n_dofs_1d * j + n_dofs_1d * offset + i;
+                  case 2:
+                    return n_dofs_1d * n_dofs_1d * offset + n_dofs_1d * i + j;
+                  default:
+                    Assert(false, ExcNotImplemented());
+                }
+              break;
+            default:
+              Assert(false, ExcNotImplemented());
+          }
 
         return 0;
       };
@@ -696,6 +700,12 @@ namespace internal
       const std::uint16_t subcell_z = (subcell >> 2) & 1;
       const std::uint16_t face      = (kind >> 3) & 7;
       const std::uint16_t edge      = (kind >> 6) & 7;
+
+      // avoid unused variable warnings since subcell_x etc. aren't used in
+      // all branch. This spurious warning is fixed in GCC-13.
+      (void)subcell_x;
+      (void)subcell_y;
+      (void)subcell_z;
 
       for (unsigned int direction = 0; direction < dim; ++direction)
         if ((face >> direction) & 1U)
@@ -744,14 +754,14 @@ namespace internal
                       [component_to_system_index_face_array[comp][i]];
 
                   // fix DoFs depending on orientation, flip, and rotation
-                  if (dim == 2)
+                  if constexpr (dim == 2)
                     {
                       // TODO: for mixed meshes we need to take care of
                       // orientation here
                       Assert(cell->face_orientation(face_no),
                              ExcNotImplemented());
                     }
-                  else if (dim == 3)
+                  else if constexpr (dim == 3)
                     {
                       int rotate = 0;                   // TODO
                       if (cell->face_rotation(face_no)) //
@@ -779,7 +789,7 @@ namespace internal
                 }
           }
 
-      if (dim == 3)
+      if constexpr (dim == 3)
         for (unsigned int direction = 0; direction < dim; ++direction)
           if ((edge >> direction) & 1U)
             {

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -1549,17 +1549,17 @@ namespace internal
             return index;
           }
 
-        if (dim == 3)
+        if constexpr (dim == 3)
           {
             unsigned int table[3][3] = {{1, 2, 0}, {2, 0, 1}, {0, 1, 2}};
             return table[face_no / 2][index];
           }
-        else if (dim == 2)
+        else if constexpr (dim == 2)
           {
             unsigned int table[2][2] = {{1, 0}, {0, 1}};
             return table[face_no / 2][index];
           }
-        else if (dim == 1)
+        else if constexpr (dim == 1)
           return 0;
         else
           Assert(false,
@@ -2293,11 +2293,11 @@ namespace internal
                                         [interior_face_no][d][f];
 
                   Tensor<1, dim, VectorizedDouble> boundary_form;
-                  if (dim == 1)
+                  if constexpr (dim == 1)
                     boundary_form[0] = interior_face_no == 0 ? -1. : 1.;
-                  else if (dim == 2)
+                  else if constexpr (dim == 2)
                     boundary_form = cross_product_2d(tangential_vectors[0]);
-                  else if (dim == 3)
+                  else if constexpr (dim == 3)
                     boundary_form = cross_product_3d(tangential_vectors[0],
                                                      tangential_vectors[1]);
                   else

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -678,7 +678,7 @@ namespace internal
 
           // face orientation for faces in 3d
           // (similar to MappingInfoStorage::QuadratureDescriptor::initialize)
-          if (dim == 3)
+          if constexpr (dim == 3)
             {
               face_orientations_dofs = compute_orientation_table(fe_degree + 1);
               face_orientations_quad = compute_orientation_table(n_q_points_1d);

--- a/include/deal.II/matrix_free/tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/tensor_product_kernels.h
@@ -1478,7 +1478,7 @@ namespace internal
                   // faces 2 and 3 in 3d use local coordinate system zx, which
                   // is the other way around compared to the tensor
                   // product. Need to take that into account.
-                  if (dim == 3)
+                  if constexpr (dim == 3)
                     {
                       if (contract_onto_face)
                         out += n_rows - 1;
@@ -1867,7 +1867,7 @@ namespace internal
                   // faces 2 and 3 in 3d use local coordinate system zx, which
                   // is the other way around compared to the tensor
                   // product. Need to take that into account.
-                  if (dim == 3)
+                  if constexpr (dim == 3)
                     {
                       if (contract_onto_face)
                         out += n_rows - 1;
@@ -2327,7 +2327,7 @@ namespace internal
                   // faces 2 and 3 in 3d use local coordinate system zx, which
                   // is the other way around compared to the tensor
                   // product. Need to take that into account.
-                  if (dim == 3)
+                  if constexpr (dim == 3)
                     {
                       if (normal_dir == 0)
                         {
@@ -2531,7 +2531,7 @@ namespace internal
                 inner_result[2] += shapes[i0][0][0] * values_2[i];
             }
 
-        if (dim > 1)
+        if constexpr (dim > 1)
           {
             // Interpolation + derivative in y direction
             // gradient
@@ -2581,7 +2581,7 @@ namespace internal
     using Number3 = typename ProductTypeNoPoint<Number, Number2>::type;
 
     std::array<Number3, dim + n_values> result = {};
-    if (dim == 0)
+    if constexpr (dim == 0)
       {
         // We only need the interpolation of the value and normal derivatives on
         // faces of a 1d element. As the interpolation is the value at the
@@ -2623,7 +2623,7 @@ namespace internal
           inner_result =
             do_interpolate_xy<dim, -1, Number2, Number, n_values, do_renumber>(
               values, renumber, shapes, n_shapes, i);
-        if (dim == 3)
+        if constexpr (dim == 3)
           {
             // derivative + interpolation in z direction
             // gradient
@@ -2635,7 +2635,7 @@ namespace internal
             if (n_values > 1)
               result[4] += inner_result[3] * shapes[i2][0][2];
           }
-        else if (dim == 2)
+        else if constexpr (dim == 2)
           {
             // gradient
             result[0] = inner_result[0];
@@ -2691,14 +2691,14 @@ namespace internal
       AssertDimension(renumber[i], i);
 
     std::array<Number3, dim + n_values> result;
-    if (dim == 0)
+    if constexpr (dim == 0)
       {
         // we only need the value on faces of a 1d element
         result[0] = values[0];
         if (n_values > 1)
           result[1] = values_2[0];
       }
-    else if (dim == 1)
+    else if constexpr (dim == 1)
       {
         // gradient
         result[0] = Number3(values[1] - values[0]);
@@ -2707,7 +2707,7 @@ namespace internal
         if (n_values > 1)
           result[2] = Number3(values_2[0]) + p[0] * (values_2[1] - values_2[0]);
       }
-    else if (dim == 2)
+    else if constexpr (dim == 2)
       {
         const Number3 val10 = Number3(values[1] - values[0]);
         const Number3 val32 = Number3(values[3] - values[2]);
@@ -2730,8 +2730,12 @@ namespace internal
             result[3] = tmp0_2 + p[1] * (tmp1_2 - tmp0_2);
           }
       }
-    else if (dim == 3)
+    else if constexpr (dim == 3)
       {
+        // avoid an unused variable warning since values_2 isn't used in this
+        // branch. This spurious warning is fixed in GCC-13.
+        (void)values_2;
+
         const Number3 val10 = Number3(values[1] - values[0]);
         const Number3 val32 = Number3(values[3] - values[2]);
         const Number3 tmp0  = Number3(values[0]) + p[0] * val10;
@@ -2865,7 +2869,7 @@ namespace internal
           for (int i0 = 0; i0 < n_shapes; ++i0, ++i)
             value += shapes[i0][0][0] * values[i];
 
-        if (dim > 1)
+        if constexpr (dim > 1)
           result += value * shapes[i1][0][1];
         else
           result = value;
@@ -2886,7 +2890,7 @@ namespace internal
     static_assert(dim >= 0 && dim <= 3, "Only dim=0,1,2,3 implemented");
 
     // we only need the value on faces of a 1d element
-    if (dim == 0)
+    if constexpr (dim == 0)
       {
         return values[0];
       }
@@ -2925,7 +2929,7 @@ namespace internal
           inner_result =
             do_interpolate_xy_value<dim, -1, Number2, Number, do_renumber>(
               values, renumber, shapes, n_shapes, i);
-        if (dim == 3)
+        if constexpr (dim == 3)
           {
             // Interpolation + derivative in z direction
             result += inner_result * shapes[i2][0][2];
@@ -2958,16 +2962,16 @@ namespace internal
     for (unsigned int i = 0; i < renumber.size(); ++i)
       AssertDimension(renumber[i], i);
 
-    if (dim == 0)
+    if constexpr (dim == 0)
       {
         // we only need the value on faces of a 1d element
         return values[0];
       }
-    else if (dim == 1)
+    else if constexpr (dim == 1)
       {
         return Number3(values[0]) + p[0] * Number3(values[1] - values[0]);
       }
-    else if (dim == 2)
+    else if constexpr (dim == 2)
       {
         const Number3 val10 = Number3(values[1] - values[0]);
         const Number3 val32 = Number3(values[3] - values[2]);
@@ -2975,7 +2979,7 @@ namespace internal
         const Number3 tmp1  = Number3(values[2]) + p[0] * val32;
         return tmp0 + p[1] * (tmp1 - tmp0);
       }
-    else if (dim == 3)
+    else if constexpr (dim == 3)
       {
         const Number3 val10 = Number3(values[1] - values[0]);
         const Number3 val32 = Number3(values[3] - values[2]);
@@ -3208,16 +3212,16 @@ namespace internal
 
     using Number3 = typename ProductTypeNoPoint<Number, Number2>::type;
     SymmetricTensor<2, dim, Number3> result;
-    if (dim == 1)
+    if constexpr (dim == 1)
       result[0][0] = hessian[0];
-    else if (dim >= 2)
+    else if constexpr (dim >= 2)
       {
         // derivatives in Hessian are xx, xy, yy, xz, yz, zz, so must re-order
         // them for 3D
         for (unsigned int d = 0, c = 0; d < 2; ++d)
           for (unsigned int e = d; e < 2; ++e, ++c)
             result[d][e] = hessian[c];
-        if (dim == 3)
+        if constexpr (dim == 3)
           {
             for (unsigned int d = 0; d < 2; ++d)
               result[d][2] = hessian[3 + d];
@@ -3370,7 +3374,7 @@ namespace internal
 
     // Note that 'add' is a template argument, so the compiler will remove
     // these checks
-    if (dim == 0)
+    if constexpr (dim == 0)
       {
         if (add)
           values[0] += value[0];
@@ -3457,7 +3461,7 @@ namespace internal
 
     // Note that 'add' is a template argument, so the compiler will remove
     // these checks
-    if (dim == 0)
+    if constexpr (dim == 0)
       {
         if (add)
           values[0] += value[0];
@@ -3471,7 +3475,7 @@ namespace internal
               values[1] = value[1];
           }
       }
-    else if (dim == 1)
+    else if constexpr (dim == 1)
       {
         const Number2 difference = value[0] * p[0] + gradient[0];
         if (add)
@@ -3499,7 +3503,7 @@ namespace internal
               }
           }
       }
-    else if (dim == 2)
+    else if constexpr (dim == 2)
       {
         const Number2 test_value_y1 = value[0] * p[1] + gradient[1];
         const Number2 test_value_y0 = value[0] - test_value_y1;
@@ -3546,7 +3550,7 @@ namespace internal
               }
           }
       }
-    else if (dim == 3)
+    else if constexpr (dim == 3)
       {
         Assert(n_values == 1, ExcNotImplemented());
 
@@ -3728,7 +3732,7 @@ namespace internal
 
     // as in evaluate, use `int` type to produce better code in this context
 
-    if (dim == 0)
+    if constexpr (dim == 0)
       {
         if (add)
           values[0] += value;
@@ -3785,14 +3789,14 @@ namespace internal
 
     AssertDimension(n_shapes, 2);
 
-    if (dim == 0)
+    if constexpr (dim == 0)
       {
         if (add)
           values[0] += value;
         else
           values[0] = value;
       }
-    else if (dim == 1)
+    else if constexpr (dim == 1)
       {
         const auto x0 = 1. - p[0], x1 = p[0];
 
@@ -3807,7 +3811,7 @@ namespace internal
             values[1] = value * x1;
           }
       }
-    else if (dim == 2)
+    else if constexpr (dim == 2)
       {
         const auto x0 = 1. - p[0], x1 = p[0], y0 = 1. - p[1], y1 = p[1];
 
@@ -3829,7 +3833,7 @@ namespace internal
             values[3] = x1 * test_value_y1;
           }
       }
-    else if (dim == 3)
+    else if constexpr (dim == 3)
       {
         const auto x0 = 1. - p[0], x1 = p[0], y0 = 1. - p[1], y1 = p[1],
                    z0 = 1. - p[2], z1 = p[2];

--- a/include/deal.II/matrix_free/util.h
+++ b/include/deal.II/matrix_free/util.h
@@ -59,7 +59,7 @@ namespace internal
                         QWitherdenVincentSimplex<dim - 1>(i))};
         }
 
-      if (dim == 3)
+      if constexpr (dim == 3)
         for (unsigned int i = 1; i <= 3; ++i)
           if (quad == QGaussWedge<dim>(i))
             {
@@ -71,7 +71,7 @@ namespace internal
                 dealii::hp::QCollection<dim - 1>(tri, tri, quad, quad, quad)};
             }
 
-      if (dim == 3)
+      if constexpr (dim == 3)
         for (unsigned int i = 1; i <= 2; ++i)
           if (quad == QGaussPyramid<dim>(i))
             {
@@ -122,7 +122,7 @@ namespace internal
           for (unsigned int i = 1; i <= 4; ++i)
             if (quad == QGaussSimplex<dim>(i))
               {
-                if (dim == 2)
+                if constexpr (dim == 2)
                   return {QGaussSimplex<dim - 1>(i), // line!
                           Quadrature<dim - 1>()};
                 else
@@ -132,7 +132,7 @@ namespace internal
           for (unsigned int i = 1; i <= 5; ++i)
             if (quad == QWitherdenVincentSimplex<dim>(i))
               {
-                if (dim == 2)
+                if constexpr (dim == 2)
                   return {QWitherdenVincentSimplex<dim - 1>(i), // line!
                           Quadrature<dim - 1>()};
                 else
@@ -141,12 +141,12 @@ namespace internal
               }
         }
 
-      if (dim == 3)
+      if constexpr (dim == 3)
         for (unsigned int i = 1; i <= 3; ++i)
           if (quad == QGaussWedge<dim>(i))
             return {QGauss<dim - 1>(i), QGaussSimplex<dim - 1>(i)};
 
-      if (dim == 3)
+      if constexpr (dim == 3)
         for (unsigned int i = 1; i <= 2; ++i)
           if (quad == QGaussPyramid<dim>(i))
             return {QGauss<dim - 1>(i), QGaussSimplex<dim - 1>(i)};


### PR DESCRIPTION
This doesn't significantly help compile times right now:
- with patch and make -j2 object_matrix_free_release: 17:15
- on master and make -j2 object_matrix_free_release: 17:08

but I suspect it will help us clean things up in other ways in the future.