### PR TITLE
Make the p::s::T serialization test use zorder.

### DIFF
--- a/tests/sharedtria/serialization_01.cc
+++ b/tests/sharedtria/serialization_01.cc
@@ -104,7 +104,7 @@ main(int argc, char *argv[])
       MPI_COMM_WORLD,
       ::Triangulation<dim>::none,
       false,
-      parallel::shared::Triangulation<dim>::partition_metis);
+      parallel::shared::Triangulation<dim>::partition_zorder);
     GridGenerator::hyper_cube(triangulation);
     triangulation.refine_global(3);
 
@@ -120,7 +120,7 @@ main(int argc, char *argv[])
       MPI_COMM_WORLD,
       ::Triangulation<dim>::none,
       false,
-      parallel::shared::Triangulation<dim>::partition_metis);
+      parallel::shared::Triangulation<dim>::partition_zorder);
     GridGenerator::hyper_cube(triangulation);
     triangulation.refine_global(3);
 


### PR DESCRIPTION
This partitioner is always available.