### PR TITLE
Also run check for symmetry for fe_degree = 0

### DIFF
--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -1004,9 +1004,6 @@ namespace internal
     bool
     UnivariateShapeData<Number>::check_and_set_shapes_symmetric()
     {
-      if (fe_degree == 0)
-        return false;
-
       const double zero_tol =
         std::is_same_v<Number, double> == true ? 1e-12 : 1e-7;
       // symmetry for values


### PR DESCRIPTION
When we check for symmetry in shape functions, there is no reason not to check the symmetry about the center of the unit interval also for degree 0 (which is trivially symmetric).