### PR TITLE
Update shasum for clang-format mac.

### DIFF
--- a/contrib/utilities/download_clang_format
+++ b/contrib/utilities/download_clang_format
@@ -40,7 +40,7 @@ case "${OSTYPE}" in
   darwin*)
     FILENAME="clang-format-${VERSION}-darwin-intel.tar.gz"
     CHECKSUM_CMD="shasum"
-    CHECKSUM="5b8c310a660102a1aa46cc0242294fb14271797a4027883a698651411f8e51bf  $FILENAME"
+    CHECKSUM="edff4341fb3b9e25c670902227538be6348d3b91ff88aa676ff8e7bb589b2ae5  $FILENAME"
     ;;
   *)
     echo "unknown: ${OSTYPE}"


### PR DESCRIPTION
Added `clang-format` 16 for intel-mac.