### PR TITLE
Remove static declaration from a few tests

### DIFF
--- a/tests/matrix_free/matrix_vector_faces_12.cc
+++ b/tests/matrix_free/matrix_vector_faces_12.cc
@@ -282,7 +282,7 @@ test()
   triangulation.add_periodicity(periodic_faces);
   triangulation.set_all_manifold_ids(111);
 
-  static PeriodicHillManifold<dim> manifold;
+  PeriodicHillManifold<dim> manifold;
   triangulation.set_manifold(111, manifold);
   triangulation.refine_global(2);
 

--- a/tests/matrix_free/matrix_vector_rt_04.cc
+++ b/tests/matrix_free/matrix_vector_rt_04.cc
@@ -130,9 +130,9 @@ test()
   Triangulation<dim> tria;
   GridGenerator::hyper_cube(tria);
   tria.refine_global(2);
-  const unsigned int               frequency   = 2;
-  const double                     deformation = 0.05;
-  static DeformedCubeManifold<dim> manifold(0.0, 1.0, deformation, frequency);
+  const unsigned int        frequency   = 2;
+  const double              deformation = 0.05;
+  DeformedCubeManifold<dim> manifold(0.0, 1.0, deformation, frequency);
   tria.set_all_manifold_ids(1);
   tria.set_manifold(1, manifold);
 

--- a/tests/matrix_free/matrix_vector_rt_face_04.cc
+++ b/tests/matrix_free/matrix_vector_rt_face_04.cc
@@ -131,9 +131,9 @@ test()
   Triangulation<dim> tria;
   GridGenerator::hyper_cube(tria);
   tria.refine_global(2);
-  const unsigned int               frequency   = 2;
-  const double                     deformation = 0.05;
-  static DeformedCubeManifold<dim> manifold(0.0, 1.0, deformation, frequency);
+  const unsigned int        frequency   = 2;
+  const double              deformation = 0.05;
+  DeformedCubeManifold<dim> manifold(0.0, 1.0, deformation, frequency);
   tria.set_all_manifold_ids(1);
   tria.set_manifold(1, manifold);
 


### PR DESCRIPTION
These are some leftovers from when we did not clone the manifolds inside the triangulation.