### PR TITLE
Mark deprecated functions with DEAL_II_DEPRECATE_EARLY.

### DIFF
--- a/include/deal.II/distributed/solution_transfer.h
+++ b/include/deal.II/distributed/solution_transfer.h
@@ -89,10 +89,9 @@ namespace parallel
      * process):
      * @code
      * // Create initial indexsets pertaining to the grid before refinement
-     * IndexSet locally_owned_dofs, locally_relevant_dofs;
-     * locally_owned_dofs = dof_handler.locally_owned_dofs();
-     * DoFTools::extract_locally_relevant_dofs(dof_handler,
-     *                                         locally_relevant_dofs);
+     * const IndexSet locally_owned_dofs    = dof_handler.locally_owned_dofs();
+     * const IndexSet locally_relevant_dofs =
+     * DoFTools::extract_locally_relevant_dofs(dof_handler);
      *
      * // The solution vector only knows about locally owned DoFs
      * TrilinosWrappers::MPI::Vector solution;

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -1575,7 +1575,7 @@ namespace DoFTools
    * @deprecated Use the previous function instead.
    */
   template <int dim, int spacedim>
-  void
+  DEAL_II_DEPRECATED_EARLY void
   extract_locally_active_dofs(const DoFHandler<dim, spacedim> &dof_handler,
                               IndexSet                        &dof_set);
 
@@ -1600,7 +1600,7 @@ namespace DoFTools
    * @deprecated Use the previous function instead.
    */
   template <int dim, int spacedim>
-  void
+  DEAL_II_DEPRECATED_EARLY void
   extract_locally_active_level_dofs(
     const DoFHandler<dim, spacedim> &dof_handler,
     IndexSet                        &dof_set,
@@ -1630,7 +1630,7 @@ namespace DoFTools
    * @deprecated Use the previous function instead.
    */
   template <int dim, int spacedim>
-  void
+  DEAL_II_DEPRECATED_EARLY void
   extract_locally_relevant_dofs(const DoFHandler<dim, spacedim> &dof_handler,
                                 IndexSet                        &dof_set);
 
@@ -1702,7 +1702,7 @@ namespace DoFTools
    * @deprecated Use the previous function instead.
    */
   template <int dim, int spacedim>
-  void
+  DEAL_II_DEPRECATED_EARLY void
   extract_locally_relevant_level_dofs(
     const DoFHandler<dim, spacedim> &dof_handler,
     const unsigned int               level,

--- a/include/deal.II/fe/fe_tools_extrapolate.templates.h
+++ b/include/deal.II/fe/fe_tools_extrapolate.templates.h
@@ -1586,8 +1586,8 @@ namespace FETools
           &dh.get_triangulation());
       Assert(parallel_tria != nullptr, ExcNotImplemented());
       const IndexSet &locally_owned_dofs = dh.locally_owned_dofs();
-      IndexSet        locally_relevant_dofs;
-      DoFTools::extract_locally_relevant_dofs(dh, locally_relevant_dofs);
+      const IndexSet  locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(dh);
       vector.reinit(locally_owned_dofs,
                     locally_relevant_dofs,
                     parallel_tria->get_communicator());
@@ -1606,8 +1606,8 @@ namespace FETools
           &dh.get_triangulation());
       Assert(parallel_tria != nullptr, ExcNotImplemented());
       const IndexSet &locally_owned_dofs = dh.locally_owned_dofs();
-      IndexSet        locally_relevant_dofs;
-      DoFTools::extract_locally_relevant_dofs(dh, locally_relevant_dofs);
+      const IndexSet  locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(dh);
       vector.reinit(locally_owned_dofs,
                     locally_relevant_dofs,
                     parallel_tria->get_communicator());
@@ -1625,8 +1625,8 @@ namespace FETools
           &dh.get_triangulation());
       Assert(parallel_tria != nullptr, ExcNotImplemented());
       const IndexSet &locally_owned_dofs = dh.locally_owned_dofs();
-      IndexSet        locally_relevant_dofs;
-      DoFTools::extract_locally_relevant_dofs(dh, locally_relevant_dofs);
+      const IndexSet  locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(dh);
       vector.reinit(locally_owned_dofs,
                     locally_relevant_dofs,
                     parallel_tria->get_communicator());

--- a/include/deal.II/fe/fe_tools_interpolate.templates.h
+++ b/include/deal.II/fe/fe_tools_interpolate.templates.h
@@ -382,8 +382,8 @@ namespace FETools
       // vector u2 with based on the sets of locally owned and relevant
       // dofs of dof2
       const IndexSet &dof2_locally_owned_dofs = dof2.locally_owned_dofs();
-      IndexSet        dof2_locally_relevant_dofs;
-      DoFTools::extract_locally_relevant_dofs(dof2, dof2_locally_relevant_dofs);
+      const IndexSet  dof2_locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(dof2);
 
       PETScWrappers::MPI::Vector u2_out(dof2_locally_owned_dofs,
                                         u1.get_mpi_communicator());
@@ -431,8 +431,8 @@ namespace FETools
       // vector u2 with based on the sets of locally owned and relevant
       // dofs of dof2
       const IndexSet &dof2_locally_owned_dofs = dof2.locally_owned_dofs();
-      IndexSet        dof2_locally_relevant_dofs;
-      DoFTools::extract_locally_relevant_dofs(dof2, dof2_locally_relevant_dofs);
+      const IndexSet  dof2_locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(dof2);
 
       TrilinosWrappers::MPI::Vector u2_out(dof2_locally_owned_dofs,
                                            u1.get_mpi_communicator());
@@ -462,8 +462,8 @@ namespace FETools
         return;
       const MPI_Comm  mpi_communicator = u1.block(0).get_mpi_communicator();
       const IndexSet &dof2_locally_owned_dofs = dof2.locally_owned_dofs();
-      IndexSet        dof2_locally_relevant_dofs;
-      DoFTools::extract_locally_relevant_dofs(dof2, dof2_locally_relevant_dofs);
+      const IndexSet  dof2_locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(dof2);
 
       TrilinosWrappers::MPI::Vector u2_out(dof2_locally_owned_dofs,
                                            mpi_communicator);
@@ -524,8 +524,8 @@ namespace FETools
       LinearAlgebra::distributed::Vector<Number>       &u1_interpolated)
     {
       const IndexSet &dof2_locally_owned_dofs = dof2.locally_owned_dofs();
-      IndexSet        dof2_locally_relevant_dofs;
-      DoFTools::extract_locally_relevant_dofs(dof2, dof2_locally_relevant_dofs);
+      const IndexSet  dof2_locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(dof2);
 
       LinearAlgebra::distributed::Vector<Number> u2(dof2_locally_owned_dofs,
                                                     dof2_locally_relevant_dofs,

--- a/include/deal.II/numerics/solution_transfer.h
+++ b/include/deal.II/numerics/solution_transfer.h
@@ -129,9 +129,9 @@ DEAL_II_NAMESPACE_OPEN
  * required for the interpolation process):
  * @code
  * // Create initial indexsets pertaining to the grid before refinement
- * IndexSet locally_owned_dofs, locally_relevant_dofs;
- * locally_owned_dofs = dof_handler.locally_owned_dofs();
- * DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+ * const IndexSet locally_owned_dofs    = dof_handler.locally_owned_dofs();
+ * const IndexSet locally_relevant_dofs =
+ * DoFTools::extract_locally_relevant_dofs(dof_handler);
  *
  * // The solution vector only knows about locally owned DoFs
  * TrilinosWrappers::MPI::Vector solution;

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -415,17 +415,16 @@ namespace DoFRenumbering
     const IndexSet &locally_owned_dofs = [&]() -> const IndexSet & {
       if (reorder_level_dofs == false)
         {
-          DoFTools::extract_locally_relevant_dofs(dof_handler,
-                                                  locally_relevant_dofs);
+          locally_relevant_dofs =
+            DoFTools::extract_locally_relevant_dofs(dof_handler);
           return dof_handler.locally_owned_dofs();
         }
       else
         {
           Assert(dof_handler.n_dofs(level) != numbers::invalid_dof_index,
                  ExcDoFHandlerNotInitialized());
-          DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                        level,
-                                                        locally_relevant_dofs);
+          locally_relevant_dofs =
+            DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
           return dof_handler.locally_owned_mg_dofs(level);
         }
     }();
@@ -476,14 +475,13 @@ namespace DoFRenumbering
         IndexSet locally_active_dofs;
         if (reorder_level_dofs == false)
           {
-            DoFTools::extract_locally_active_dofs(dof_handler,
-                                                  locally_active_dofs);
+            locally_active_dofs =
+              DoFTools::extract_locally_active_dofs(dof_handler);
           }
         else
           {
-            DoFTools::extract_locally_active_level_dofs(dof_handler,
-                                                        locally_active_dofs,
-                                                        level);
+            locally_active_dofs =
+              DoFTools::extract_locally_active_level_dofs(dof_handler, level);
           }
 
         bool needs_locally_active = false;

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -2894,10 +2894,9 @@ namespace DoFTools
               }
 
 
-            IndexSet locally_relevant_dofs;
-            DoFTools::extract_locally_relevant_dofs(
-              coarse_to_fine_grid_map.get_destination_grid(),
-              locally_relevant_dofs);
+            const IndexSet locally_relevant_dofs =
+              DoFTools::extract_locally_relevant_dofs(
+                coarse_to_fine_grid_map.get_destination_grid());
 
             copy_data.global_parameter_representation[i].reinit(
               coarse_to_fine_grid_map.get_destination_grid()

--- a/source/fe/mapping_q_cache.cc
+++ b/source/fe/mapping_q_cache.cc
@@ -311,9 +311,9 @@ MappingQCache<dim, spacedim>::initialize(
   // Step 1: copy global vector so that the ghost values are such that the
   // cache can be set up for all ghost cells
   LinearAlgebra::distributed::Vector<typename VectorType::value_type>
-           vector_ghosted;
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+                 vector_ghosted;
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
   vector_ghosted.reinit(dof_handler.locally_owned_dofs(),
                         locally_relevant_dofs,
                         dof_handler.get_communicator());
@@ -515,10 +515,8 @@ MappingQCache<dim, spacedim>::initialize(
 
   for (unsigned int l = vectors.min_level(); l <= vectors.max_level(); ++l)
     {
-      IndexSet locally_relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                    l,
-                                                    locally_relevant_dofs);
+      const IndexSet locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof_handler, l);
       vectors_ghosted[l].reinit(dof_handler.locally_owned_mg_dofs(l),
                                 locally_relevant_dofs,
                                 dof_handler.get_communicator());

--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -211,10 +211,8 @@ MGTransferPrebuilt<VectorType>::build(
       //
       // increment dofs_per_cell since a useless diagonal element will be
       // stored
-      IndexSet level_p1_relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                    level + 1,
-                                                    level_p1_relevant_dofs);
+      const IndexSet level_p1_relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof_handler, level + 1);
       DynamicSparsityPattern dsp(this->sizes[level + 1],
                                  this->sizes[level],
                                  level_p1_relevant_dofs);

--- a/source/numerics/data_out_resample.cc
+++ b/source/numerics/data_out_resample.cc
@@ -64,8 +64,8 @@ DataOutResample<dim, patch_dim, spacedim>::update_mapping(
 
   std::vector<types::global_dof_index> dof_indices(fe.n_dofs_per_cell());
 
-  IndexSet active_dofs;
-  DoFTools::extract_locally_active_dofs(patch_dof_handler, active_dofs);
+  const IndexSet active_dofs =
+    DoFTools::extract_locally_active_dofs(patch_dof_handler);
   partitioner = std::make_shared<Utilities::MPI::Partitioner>(
     patch_dof_handler.locally_owned_dofs(), active_dofs, MPI_COMM_WORLD);
 


### PR DESCRIPTION
These functions were marked as `@deprecated` a while ago already. I don't know why we didn't mark them with `DEAL_II_DEPRECATE_EARLY`, but this is clearly what should have happened.