### PR TITLE
Do not use deprecated extract_locally_* functions in library.

### DIFF
--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -3195,9 +3195,8 @@ namespace Step32
 
     joint_solution.compress(VectorOperation::insert);
 
-    IndexSet locally_relevant_joint_dofs(joint_dof_handler.n_dofs());
-    DoFTools::extract_locally_relevant_dofs(joint_dof_handler,
-                                            locally_relevant_joint_dofs);
+    const IndexSet locally_relevant_joint_dofs =
+      DoFTools::extract_locally_relevant_dofs(joint_dof_handler);
     TrilinosWrappers::MPI::Vector locally_relevant_joint_solution;
     locally_relevant_joint_solution.reinit(locally_relevant_joint_dofs,
                                            MPI_COMM_WORLD);

--- a/include/deal.II/distributed/solution_transfer.h
+++ b/include/deal.II/distributed/solution_transfer.h
@@ -89,9 +89,9 @@ namespace parallel
      * process):
      * @code
      * // Create initial indexsets pertaining to the grid before refinement
-     * const IndexSet locally_owned_dofs    = dof_handler.locally_owned_dofs();
-     * const IndexSet locally_relevant_dofs =
-     * DoFTools::extract_locally_relevant_dofs(dof_handler);
+     * const IndexSet &locally_owned_dofs    = dof_handler.locally_owned_dofs();
+     * const IndexSet  locally_relevant_dofs =
+     *   DoFTools::extract_locally_relevant_dofs(dof_handler);
      *
      * // The solution vector only knows about locally owned DoFs
      * TrilinosWrappers::MPI::Vector solution;

--- a/include/deal.II/numerics/solution_transfer.h
+++ b/include/deal.II/numerics/solution_transfer.h
@@ -129,9 +129,9 @@ DEAL_II_NAMESPACE_OPEN
  * required for the interpolation process):
  * @code
  * // Create initial indexsets pertaining to the grid before refinement
- * const IndexSet locally_owned_dofs    = dof_handler.locally_owned_dofs();
- * const IndexSet locally_relevant_dofs =
- * DoFTools::extract_locally_relevant_dofs(dof_handler);
+ * const IndexSet &locally_owned_dofs    = dof_handler.locally_owned_dofs();
+ * const IndexSet  locally_relevant_dofs =
+ *   DoFTools::extract_locally_relevant_dofs(dof_handler);
  *
  * // The solution vector only knows about locally owned DoFs
  * TrilinosWrappers::MPI::Vector solution;

--- a/tests/arpack/parpack_advection_diffusion_petsc.cc
+++ b/tests/arpack/parpack_advection_diffusion_petsc.cc
@@ -188,9 +188,8 @@ test()
   std::vector<dealii::IndexSet> locally_owned_dofs_per_processor =
     locally_owned_dofs_per_subdomain(dof_handler);
   locally_owned_dofs = locally_owned_dofs_per_processor[this_mpi_process];
-  locally_relevant_dofs.clear();
-  dealii::DoFTools::extract_locally_relevant_dofs(dof_handler,
-                                                  locally_relevant_dofs);
+  locally_relevant_dofs =
+    dealii::DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   constraints.clear();
   constraints.reinit(locally_relevant_dofs);

--- a/tests/arpack/parpack_advection_diffusion_trilinos.cc
+++ b/tests/arpack/parpack_advection_diffusion_trilinos.cc
@@ -161,9 +161,8 @@ test()
   DoFRenumbering::subdomain_wise(dof_handler);
   std::vector<IndexSet> locally_owned_dofs_per_processor =
     locally_owned_dofs_per_subdomain(dof_handler);
-  locally_owned_dofs = locally_owned_dofs_per_processor[this_mpi_process];
-  locally_relevant_dofs.clear();
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  locally_owned_dofs    = locally_owned_dofs_per_processor[this_mpi_process];
+  locally_relevant_dofs = DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   constraints.clear();
   constraints.reinit(locally_relevant_dofs);

--- a/tests/arpack/step-36_parpack.cc
+++ b/tests/arpack/step-36_parpack.cc
@@ -190,9 +190,8 @@ test()
   std::vector<dealii::IndexSet> locally_owned_dofs_per_processor =
     locally_owned_dofs_per_subdomain(dof_handler);
   locally_owned_dofs = locally_owned_dofs_per_processor[this_mpi_process];
-  locally_relevant_dofs.clear();
-  dealii::DoFTools::extract_locally_relevant_dofs(dof_handler,
-                                                  locally_relevant_dofs);
+  locally_relevant_dofs =
+    dealii::DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   constraints.clear();
   constraints.reinit(locally_relevant_dofs);

--- a/tests/arpack/step-36_parpack_mf.cc
+++ b/tests/arpack/step-36_parpack_mf.cc
@@ -83,8 +83,8 @@ test()
   dof_handler.distribute_dofs(fe);
 
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
   AffineConstraints<double> constraints;
   constraints.reinit(locally_relevant_dofs);
   DoFTools::make_hanging_node_constraints(dof_handler, constraints);

--- a/tests/arpack/step-36_parpack_mf_02.cc
+++ b/tests/arpack/step-36_parpack_mf_02.cc
@@ -83,8 +83,8 @@ test()
   dof_handler.distribute_dofs(fe);
 
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
   AffineConstraints<double> constraints;
   constraints.reinit(locally_relevant_dofs);
   DoFTools::make_hanging_node_constraints(dof_handler, constraints);

--- a/tests/arpack/step-36_parpack_mf_03.cc
+++ b/tests/arpack/step-36_parpack_mf_03.cc
@@ -84,8 +84,8 @@ test()
   dof_handler.distribute_dofs(fe);
 
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
   AffineConstraints<double> constraints;
   constraints.reinit(locally_relevant_dofs);
   DoFTools::make_hanging_node_constraints(dof_handler, constraints);

--- a/tests/arpack/step-36_parpack_trilinos.cc
+++ b/tests/arpack/step-36_parpack_trilinos.cc
@@ -163,9 +163,8 @@ test()
   DoFRenumbering::subdomain_wise(dof_handler);
   std::vector<IndexSet> locally_owned_dofs_per_processor =
     locally_owned_dofs_per_subdomain(dof_handler);
-  locally_owned_dofs = locally_owned_dofs_per_processor[this_mpi_process];
-  locally_relevant_dofs.clear();
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  locally_owned_dofs    = locally_owned_dofs_per_processor[this_mpi_process];
+  locally_relevant_dofs = DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   constraints.clear();
   constraints.reinit(locally_relevant_dofs);

--- a/tests/distributed_grids/checkpointing_02.cc
+++ b/tests/distributed_grids/checkpointing_02.cc
@@ -107,8 +107,8 @@ void
 LaplaceProblem<dim>::setup_system()
 {
   dof_handler.distribute_dofs(fe);
-  locally_owned_dofs = dof_handler.locally_owned_dofs();
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  locally_owned_dofs    = dof_handler.locally_owned_dofs();
+  locally_relevant_dofs = DoFTools::extract_locally_relevant_dofs(dof_handler);
 }
 
 template <int dim>

--- a/tests/distributed_grids/checkpointing_03.cc
+++ b/tests/distributed_grids/checkpointing_03.cc
@@ -106,8 +106,8 @@ void
 LaplaceProblem<dim>::setup_system()
 {
   dof_handler.distribute_dofs(fe);
-  locally_owned_dofs = dof_handler.locally_owned_dofs();
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  locally_owned_dofs    = dof_handler.locally_owned_dofs();
+  locally_relevant_dofs = DoFTools::extract_locally_relevant_dofs(dof_handler);
 }
 
 template <int dim>

--- a/tests/distributed_grids/large_vtu_01.cc
+++ b/tests/distributed_grids/large_vtu_01.cc
@@ -81,8 +81,8 @@ run()
   DoFHandler<dim> dof_handler(triangulation);
   dof_handler.distribute_dofs(fe);
   // Make FE vector
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   using VectorType = LinearAlgebra::distributed::Vector<double>;
   VectorType global_dof_vector;

--- a/tests/dofs/dof_tools_04a.cc
+++ b/tests/dofs/dof_tools_04a.cc
@@ -50,8 +50,8 @@ check_this(const DoFHandler<dim> &dof_handler)
 {
   const types::global_dof_index n_dofs = dof_handler.n_dofs();
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   const IndexSet is_hanging_node_constrained =
     DoFTools::extract_hanging_node_dofs(dof_handler);

--- a/tests/dofs/dof_tools_22a.cc
+++ b/tests/dofs/dof_tools_22a.cc
@@ -93,8 +93,8 @@ test()
   coupling[1][1]      = DoFTools::always;
   flux_coupling[1][1] = DoFTools::always;
 
-  IndexSet relevant_partitioning(dh.n_dofs());
-  DoFTools::extract_locally_relevant_dofs(dh, relevant_partitioning);
+  const IndexSet relevant_partitioning =
+    DoFTools::extract_locally_relevant_dofs(dh);
 
   // Generate hanging node constraints
   AffineConstraints<double> constraints;

--- a/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_02.cc
+++ b/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_02.cc
@@ -95,8 +95,8 @@ test(const unsigned int flag)
   FE_Q<dim> fe(2);
   dh.distribute_dofs(fe);
 
-  IndexSet locally_relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dh, locally_relevant_set);
+  const IndexSet locally_relevant_set =
+    DoFTools::extract_locally_relevant_dofs(dh);
 
   AffineConstraints<double> cm;
   cm.reinit(locally_relevant_set);

--- a/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_04.cc
+++ b/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_04.cc
@@ -98,8 +98,8 @@ test()
   dh.distribute_dofs(fe);
 
   const IndexSet &locally_owned_set = dh.locally_owned_dofs();
-  IndexSet        locally_relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dh, locally_relevant_set);
+  const IndexSet  locally_relevant_set =
+    DoFTools::extract_locally_relevant_dofs(dh);
 
   AffineConstraints<double> cm;
   cm.reinit(locally_relevant_set);

--- a/tests/dofs/sparsity_pattern_06.cc
+++ b/tests/dofs/sparsity_pattern_06.cc
@@ -62,12 +62,10 @@ main(int argc, char **argv)
   dof_handler_0.distribute_dofs(fe_0);
   dof_handler_1.distribute_dofs(fe_1);
 
-  IndexSet locally_relevant_dofs_0;
-  IndexSet locally_relevant_dofs_1;
-  DoFTools::extract_locally_relevant_dofs(dof_handler_0,
-                                          locally_relevant_dofs_0);
-  DoFTools::extract_locally_relevant_dofs(dof_handler_1,
-                                          locally_relevant_dofs_1);
+  const IndexSet locally_relevant_dofs_0 =
+    DoFTools::extract_locally_relevant_dofs(dof_handler_0);
+  const IndexSet locally_relevant_dofs_1 =
+    DoFTools::extract_locally_relevant_dofs(dof_handler_1);
   deallog << "locally owned dofs 0: ";
   dof_handler_0.locally_owned_dofs().print(deallog);
   deallog << std::endl;

--- a/tests/dofs/sparsity_pattern_07.cc
+++ b/tests/dofs/sparsity_pattern_07.cc
@@ -79,12 +79,10 @@ main(int argc, char **argv)
   dof_handler_0.distribute_dofs(fe_0);
   dof_handler_1.distribute_dofs(fe_1);
 
-  IndexSet locally_relevant_dofs_0;
-  IndexSet locally_relevant_dofs_1;
-  DoFTools::extract_locally_relevant_dofs(dof_handler_0,
-                                          locally_relevant_dofs_0);
-  DoFTools::extract_locally_relevant_dofs(dof_handler_1,
-                                          locally_relevant_dofs_1);
+  const IndexSet locally_relevant_dofs_0 =
+    DoFTools::extract_locally_relevant_dofs(dof_handler_0);
+  const IndexSet locally_relevant_dofs_1 =
+    DoFTools::extract_locally_relevant_dofs(dof_handler_1);
   deallog << "locally owned dofs 0: ";
   dof_handler_0.locally_owned_dofs().print(deallog);
   deallog << std::endl;

--- a/tests/fe/fe_enriched_color_07.cc
+++ b/tests/fe/fe_enriched_color_07.cc
@@ -1439,9 +1439,8 @@ LaplaceProblem<dim>::setup_system()
   DoFRenumbering::subdomain_wise(dof_handler);
   std::vector<IndexSet> locally_owned_dofs_per_proc =
     DoFTools::locally_owned_dofs_per_subdomain(dof_handler);
-  locally_owned_dofs = locally_owned_dofs_per_proc[this_mpi_process];
-  locally_relevant_dofs.clear();
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  locally_owned_dofs    = locally_owned_dofs_per_proc[this_mpi_process];
+  locally_relevant_dofs = DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   constraints.clear();
   constraints.reinit(locally_relevant_dofs);

--- a/tests/fe/fe_enriched_step-36.cc
+++ b/tests/fe/fe_enriched_step-36.cc
@@ -287,8 +287,8 @@ namespace Step36
     std::vector<IndexSet> locally_owned_dofs_per_processor =
       DoFTools::locally_owned_dofs_per_subdomain(dof_handler);
     locally_owned_dofs = locally_owned_dofs_per_processor[this_mpi_process];
-    locally_relevant_dofs.clear();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     constraints.clear();
     constraints.reinit(locally_relevant_dofs);

--- a/tests/fe/fe_enriched_step-36b.cc
+++ b/tests/fe/fe_enriched_step-36b.cc
@@ -297,8 +297,8 @@ namespace Step36
     std::vector<IndexSet> locally_owned_dofs_per_processor =
       DoFTools::locally_owned_dofs_per_subdomain(dof_handler);
     locally_owned_dofs = locally_owned_dofs_per_processor[this_mpi_process];
-    locally_relevant_dofs.clear();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     constraints.clear();
     constraints.reinit(locally_relevant_dofs);

--- a/tests/fullydistributed_grids/solution_transfer_01.cc
+++ b/tests/fullydistributed_grids/solution_transfer_01.cc
@@ -58,8 +58,8 @@ test(TriangulationType &triangulation)
   DoFHandler<dim> dof_handler(triangulation);
   dof_handler.distribute_dofs(FE_Q<dim>(2));
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   using VectorType = LinearAlgebra::distributed::Vector<double>;
 

--- a/tests/gla/block_mat_02.cc
+++ b/tests/gla/block_mat_02.cc
@@ -90,9 +90,8 @@ test()
   stokes_partitioning.push_back(stokes_index_set.get_view(0, n_u));
   stokes_partitioning.push_back(stokes_index_set.get_view(n_u, n_u + n_p));
 
-  IndexSet stokes_relevant_set;
-  DoFTools::extract_locally_relevant_dofs(stokes_dof_handler,
-                                          stokes_relevant_set);
+  const IndexSet stokes_relevant_set =
+    DoFTools::extract_locally_relevant_dofs(stokes_dof_handler);
   stokes_relevant_partitioning.push_back(stokes_relevant_set.get_view(0, n_u));
   stokes_relevant_partitioning.push_back(
     stokes_relevant_set.get_view(n_u, n_u + n_p));
@@ -185,9 +184,8 @@ test_LA_Trilinos()
   stokes_partitioning.push_back(stokes_index_set.get_view(0, n_u));
   stokes_partitioning.push_back(stokes_index_set.get_view(n_u, n_u + n_p));
 
-  IndexSet stokes_relevant_set;
-  DoFTools::extract_locally_relevant_dofs(stokes_dof_handler,
-                                          stokes_relevant_set);
+  const IndexSet stokes_relevant_set =
+    DoFTools::extract_locally_relevant_dofs(stokes_dof_handler);
   stokes_relevant_partitioning.push_back(stokes_relevant_set.get_view(0, n_u));
   stokes_relevant_partitioning.push_back(
     stokes_relevant_set.get_view(n_u, n_u + n_p));

--- a/tests/gla/block_mat_03.cc
+++ b/tests/gla/block_mat_03.cc
@@ -82,8 +82,8 @@ test()
   std::vector<IndexSet> locally_relevant_partitioning;
   std::vector<IndexSet> locally_owned_partitioning;
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
   locally_relevant_partitioning.push_back(
     locally_relevant_dofs.get_view(0, dofs_per_block[0]));
   locally_relevant_partitioning.push_back(
@@ -187,8 +187,8 @@ test_alt()
   std::vector<IndexSet> locally_relevant_partitioning;
   std::vector<IndexSet> locally_owned_partitioning;
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
   locally_relevant_partitioning.push_back(
     locally_relevant_dofs.get_view(0, dofs_per_block[0]));
   locally_relevant_partitioning.push_back(

--- a/tests/gla/mat_03.cc
+++ b/tests/gla/mat_03.cc
@@ -70,9 +70,9 @@ test()
   DoFHandler<dim> dof_handler(triangulation);
   dof_handler.distribute_dofs(temperature_fe);
 
-  IndexSet owned = dof_handler.locally_owned_dofs();
-  IndexSet relevant;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, relevant);
+  const IndexSet &owned = dof_handler.locally_owned_dofs();
+  const IndexSet  relevant =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   // this causes a crash in PETSc, but is ignored in Trilinos:
   // DynamicSparsityPattern sp (owned);

--- a/tests/gla/mat_04.cc
+++ b/tests/gla/mat_04.cc
@@ -71,9 +71,9 @@ test()
   DoFHandler<dim> dof_handler(triangulation);
   dof_handler.distribute_dofs(temperature_fe);
 
-  IndexSet owned = dof_handler.locally_owned_dofs();
-  IndexSet relevant;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, relevant);
+  const IndexSet &owned = dof_handler.locally_owned_dofs();
+  const IndexSet  relevant =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   DynamicSparsityPattern         sp(relevant);
   typename LA::MPI::SparseMatrix matrix;

--- a/tests/grid/grid_generator_marching_cube_algorithm_01.cc
+++ b/tests/grid/grid_generator_marching_cube_algorithm_01.cc
@@ -129,9 +129,8 @@ template <int dim, int spacedim>
 std::shared_ptr<const Utilities::MPI::Partitioner>
 create_partitioner(const DoFHandler<dim, spacedim> &dof_handler)
 {
-  IndexSet locally_relevant_dofs;
-
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   return std::make_shared<const Utilities::MPI::Partitioner>(
     dof_handler.locally_owned_dofs(),

--- a/tests/grid/grid_generator_marching_cube_algorithm_02.cc
+++ b/tests/grid/grid_generator_marching_cube_algorithm_02.cc
@@ -86,10 +86,9 @@ create_mca_tria(const unsigned int   n_subdivisions,
   background_dof_handler.reinit(triangulation);
   background_dof_handler.distribute_dofs(fe);
 
-  VectorType ls_vector;
-  IndexSet   locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(background_dof_handler,
-                                          locally_relevant_dofs);
+  VectorType     ls_vector;
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(background_dof_handler);
 
 
   ls_vector.reinit(background_dof_handler.locally_owned_dofs(),

--- a/tests/hp/field_transfer_04.cc
+++ b/tests/hp/field_transfer_04.cc
@@ -110,7 +110,6 @@ main(int argc, char *argv[])
   AffineConstraints<double> affine_constraints;
   const double              new_value = 2.;
 
-  locally_relevant_dofs.clear();
   locally_relevant_dofs = DoFTools::extract_locally_relevant_dofs(dof_handler);
   LinearAlgebra::distributed::Vector<double> new_solution(
     dof_handler.locally_owned_dofs(), locally_relevant_dofs, MPI_COMM_WORLD);

--- a/tests/hp/laplace.h
+++ b/tests/hp/laplace.h
@@ -255,8 +255,7 @@ Laplace<dim>::setup_system()
 
   locally_owned_dofs = dof_handler.locally_owned_dofs();
 
-  locally_relevant_dofs.clear();
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  locally_relevant_dofs = DoFTools::extract_locally_relevant_dofs(dof_handler);
   AssertThrow(locally_relevant_dofs.n_elements() == dof_handler.n_dofs(),
               ExcInternalError());
 

--- a/tests/lac/constraints_make_consistent_in_parallel_01.cc
+++ b/tests/lac/constraints_make_consistent_in_parallel_01.cc
@@ -111,11 +111,11 @@ main(int argc, char **argv)
     if (cell->center()[0] > 0.5 && cell->center()[1] > 0.5)
       cell->set_material_id(1);
 
-  IndexSet locally_active_dofs;
-  DoFTools::extract_locally_active_dofs(dof_handler, locally_active_dofs);
+  const IndexSet locally_active_dofs =
+    DoFTools::extract_locally_active_dofs(dof_handler);
   test(dof_handler, locally_active_dofs);
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
   test(dof_handler, locally_relevant_dofs);
 }

--- a/tests/lac/diagonal_matrix_02.cc
+++ b/tests/lac/diagonal_matrix_02.cc
@@ -67,9 +67,8 @@ test(const bool hanging_nodes = true)
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/lac/linear_operator_12.cc
+++ b/tests/lac/linear_operator_12.cc
@@ -193,10 +193,9 @@ Step4<dim>::setup_system()
                                            constraints);
   constraints.close();
 
-  IndexSet locally_owned_dofs = dof_handler.locally_owned_dofs();
-  IndexSet locally_relevant_dofs;
-
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet &locally_owned_dofs = dof_handler.locally_owned_dofs();
+  const IndexSet  locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   DynamicSparsityPattern dsp(dof_handler.n_dofs());
   DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);

--- a/tests/lac/linear_operator_12a.cc
+++ b/tests/lac/linear_operator_12a.cc
@@ -194,10 +194,9 @@ Step4<dim>::setup_system()
                                            constraints);
   constraints.close();
 
-  IndexSet locally_owned_dofs = dof_handler.locally_owned_dofs();
-  IndexSet locally_relevant_dofs;
-
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet &locally_owned_dofs = dof_handler.locally_owned_dofs();
+  const IndexSet  locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   DynamicSparsityPattern dsp(dof_handler.n_dofs());
   DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);

--- a/tests/lac/linear_operator_14.cc
+++ b/tests/lac/linear_operator_14.cc
@@ -105,7 +105,7 @@ build_matrix_vector(TrilinosWrappers::BlockSparseMatrix &matrix,
   locally_owned_partitioning.push_back(
     locally_owned_dofs.get_view(dofs_per_block[0],
                                 dofs_per_block[0] + dofs_per_block[1]));
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  locally_relevant_dofs = DoFTools::extract_locally_relevant_dofs(dof_handler);
   locally_relevant_partitioning.push_back(
     locally_relevant_dofs.get_view(0, dofs_per_block[0]));
   locally_relevant_partitioning.push_back(

--- a/tests/lac/step-40-linear_operator_01.cc
+++ b/tests/lac/step-40-linear_operator_01.cc
@@ -125,7 +125,8 @@ namespace Step40
     dof_handler.distribute_dofs(fe);
 
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     locally_relevant_solution.reinit(locally_owned_dofs,
                                      locally_relevant_dofs,

--- a/tests/lac/step-40-linear_operator_02.cc
+++ b/tests/lac/step-40-linear_operator_02.cc
@@ -125,7 +125,8 @@ namespace Step40
     dof_handler.distribute_dofs(fe);
 
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     locally_relevant_solution.reinit(locally_owned_dofs,
                                      locally_relevant_dofs,

--- a/tests/lac/step-40-linear_operator_03.cc
+++ b/tests/lac/step-40-linear_operator_03.cc
@@ -126,7 +126,8 @@ namespace Step40
     dof_handler.distribute_dofs(fe);
 
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     locally_relevant_solution.reinit(locally_owned_dofs,
                                      locally_relevant_dofs,

--- a/tests/lac/step-40-linear_operator_04.cc
+++ b/tests/lac/step-40-linear_operator_04.cc
@@ -126,7 +126,8 @@ namespace Step40
     dof_handler.distribute_dofs(fe);
 
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     locally_relevant_solution.reinit(locally_owned_dofs,
                                      locally_relevant_dofs,

--- a/tests/lac/step-40-linear_operator_05.cc
+++ b/tests/lac/step-40-linear_operator_05.cc
@@ -126,7 +126,8 @@ namespace Step40
     dof_handler.distribute_dofs(fe);
 
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     locally_relevant_solution.reinit(locally_owned_dofs,
                                      locally_relevant_dofs,

--- a/tests/lac/step-40-linear_operator_06.cc
+++ b/tests/lac/step-40-linear_operator_06.cc
@@ -126,7 +126,8 @@ namespace Step40
     dof_handler.distribute_dofs(fe);
 
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     locally_relevant_solution.reinit(locally_owned_dofs,
                                      locally_relevant_dofs,

--- a/tests/lac/utilities_02.cc
+++ b/tests/lac/utilities_02.cc
@@ -94,8 +94,8 @@ test()
   dof_handler.distribute_dofs(fe);
 
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
   AffineConstraints<double> constraints;
   constraints.reinit(locally_relevant_dofs);
   DoFTools::make_hanging_node_constraints(dof_handler, constraints);

--- a/tests/mappings/mapping_fe_field_03.cc
+++ b/tests/mappings/mapping_fe_field_03.cc
@@ -65,8 +65,8 @@ test()
   // Create a Mapping
   LinearAlgebra::distributed::Vector<double> map_vector;
 
-  IndexSet locally_relevant_euler;
-  DoFTools::extract_locally_relevant_dofs(dh, locally_relevant_euler);
+  const IndexSet locally_relevant_euler =
+    DoFTools::extract_locally_relevant_dofs(dh);
   map_vector.reinit(dh.locally_owned_dofs(),
                     locally_relevant_euler,
                     MPI_COMM_WORLD);

--- a/tests/mappings/mapping_fe_field_06.cc
+++ b/tests/mappings/mapping_fe_field_06.cc
@@ -75,8 +75,8 @@ test()
                                 update_quadrature_points);
   for (unsigned int level = 0; level < tria.n_global_levels(); ++level)
     {
-      IndexSet relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dh, level, relevant_dofs);
+      const IndexSet relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dh, level);
       level_vectors[level].reinit(dh.locally_owned_mg_dofs(level),
                                   relevant_dofs,
                                   tria.get_communicator());

--- a/tests/mappings/mapping_q_cache_06.cc
+++ b/tests/mappings/mapping_q_cache_06.cc
@@ -76,8 +76,8 @@ do_test(const unsigned int degree,
   dof_handler.distribute_dofs(fe);
   dof_handler.distribute_mg_dofs();
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
   LinearAlgebra::distributed::Vector<double> vector(
     dof_handler.locally_owned_dofs(),
     locally_relevant_dofs,

--- a/tests/mappings/mapping_q_eulerian_07.cc
+++ b/tests/mappings/mapping_q_eulerian_07.cc
@@ -106,9 +106,9 @@ test()
   DoFHandler<dim> dof_handler(triangulation);
   dof_handler.distribute_dofs(fe);
 
-  IndexSet locally_owned_dofs = dof_handler.locally_owned_dofs();
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet &locally_owned_dofs = dof_handler.locally_owned_dofs();
+  const IndexSet  locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   PETScWrappers::MPI::Vector x(locally_owned_dofs, MPI_COMM_WORLD);
   PETScWrappers::MPI::Vector x_relevant(locally_owned_dofs,

--- a/tests/mappings/mapping_q_eulerian_08.cc
+++ b/tests/mappings/mapping_q_eulerian_08.cc
@@ -158,13 +158,12 @@ test(const unsigned int n_ref = 0)
 
   const IndexSet &locally_owned_dofs_euler =
     dof_handler_euler.locally_owned_dofs();
-  IndexSet locally_relevant_dofs_euler;
-  DoFTools::extract_locally_relevant_dofs(dof_handler_euler,
-                                          locally_relevant_dofs_euler);
+  const IndexSet locally_relevant_dofs_euler =
+    DoFTools::extract_locally_relevant_dofs(dof_handler_euler);
 
   const IndexSet &locally_owned_dofs = dof_handler.locally_owned_dofs();
-  IndexSet        locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet  locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   // constraints:
   AffineConstraints<double> constraints_euler;
@@ -211,10 +210,8 @@ test(const unsigned int n_ref = 0)
   // all relevant ghost indices is required to certain meshes.
   for (unsigned int level = min_level; level <= max_level; ++level)
     {
-      IndexSet relevant_mg_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof_handler_euler,
-                                                    level,
-                                                    relevant_mg_dofs);
+      const IndexSet relevant_mg_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof_handler_euler, level);
       displacement_level[level].reinit(dof_handler_euler.locally_owned_mg_dofs(
                                          level),
                                        relevant_mg_dofs,
@@ -294,10 +291,8 @@ test(const unsigned int n_ref = 0)
         update_quadrature_points;
 
       AffineConstraints<double> level_constraints;
-      IndexSet                  relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                    level,
-                                                    relevant_dofs);
+      const IndexSet            relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
       level_constraints.reinit(relevant_dofs);
       level_constraints.add_lines(
         mg_constrained_dofs.get_boundary_indices(level));

--- a/tests/mappings/mapping_q_eulerian_09.cc
+++ b/tests/mappings/mapping_q_eulerian_09.cc
@@ -102,13 +102,12 @@ test()
   // IndexSets and constraints
   const IndexSet &locally_owned_dofs_euler =
     dof_handler_euler.locally_owned_dofs();
-  IndexSet locally_relevant_dofs_euler;
-  DoFTools::extract_locally_relevant_dofs(dof_handler_euler,
-                                          locally_relevant_dofs_euler);
+  const IndexSet locally_relevant_dofs_euler =
+    DoFTools::extract_locally_relevant_dofs(dof_handler_euler);
 
   const IndexSet &locally_owned_dofs = dof_handler.locally_owned_dofs();
-  IndexSet        locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet  locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   // constraints:
   AffineConstraints<double> constraints_euler;

--- a/tests/mappings/mapping_q_eulerian_11.cc
+++ b/tests/mappings/mapping_q_eulerian_11.cc
@@ -105,9 +105,9 @@ test()
   DoFHandler<dim> dof_handler(triangulation);
   dof_handler.distribute_dofs(fe);
 
-  IndexSet locally_owned_dofs = dof_handler.locally_owned_dofs();
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet &locally_owned_dofs = dof_handler.locally_owned_dofs();
+  const IndexSet  locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   TrilinosWrappers::MPI::Vector x(locally_owned_dofs, MPI_COMM_WORLD);
   TrilinosWrappers::MPI::Vector x_relevant(locally_owned_dofs,

--- a/tests/mappings/mapping_q_eulerian_14.cc
+++ b/tests/mappings/mapping_q_eulerian_14.cc
@@ -200,13 +200,12 @@ test(const unsigned int n_ref = 0)
   // IndexSets and constraints
   const IndexSet &locally_owned_dofs_euler =
     dof_handler_euler.locally_owned_dofs();
-  IndexSet locally_relevant_dofs_euler;
-  DoFTools::extract_locally_relevant_dofs(dof_handler_euler,
-                                          locally_relevant_dofs_euler);
+  const IndexSet locally_relevant_dofs_euler =
+    DoFTools::extract_locally_relevant_dofs(dof_handler_euler);
 
   const IndexSet &locally_owned_dofs = dof_handler.locally_owned_dofs();
-  IndexSet        locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet  locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   // constraints:
   AffineConstraints<double> constraints_euler;
@@ -253,10 +252,8 @@ test(const unsigned int n_ref = 0)
   // the bug observed.
   for (unsigned int level = min_level; level <= max_level; ++level)
     {
-      IndexSet relevant_mg_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof_handler_euler,
-                                                    level,
-                                                    relevant_mg_dofs);
+      const IndexSet relevant_mg_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof_handler_euler, level);
       displacement_level[level].reinit(dof_handler_euler.locally_owned_mg_dofs(
                                          level),
                                        relevant_mg_dofs,
@@ -335,10 +332,8 @@ test(const unsigned int n_ref = 0)
         update_quadrature_points;
 
       AffineConstraints<double> level_constraints;
-      IndexSet                  relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                    level,
-                                                    relevant_dofs);
+      const IndexSet            relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
       level_constraints.reinit(relevant_dofs);
       level_constraints.add_lines(
         mg_constrained_dofs.get_boundary_indices(level));

--- a/tests/matrix_free/cell_categorization_02.cc
+++ b/tests/matrix_free/cell_categorization_02.cc
@@ -146,8 +146,8 @@ test()
   for (unsigned int level = 0; level <= max_level; ++level)
     {
       AffineConstraints<double> level_constraints;
-      IndexSet                  relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof, level, relevant_dofs);
+      const IndexSet            relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof, level);
       level_constraints.reinit(relevant_dofs);
       level_constraints.add_lines(
         mg_constrained_dofs.get_boundary_indices(level));

--- a/tests/matrix_free/compute_diagonal_02.cc
+++ b/tests/matrix_free/compute_diagonal_02.cc
@@ -67,8 +67,8 @@ test()
   dof_handler.distribute_dofs(fe);
 
   AffineConstraints<Number> constraints;
-  IndexSet                  locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet            locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   constraints.reinit(locally_relevant_dofs);
 

--- a/tests/matrix_free/dof_info_01.cc
+++ b/tests/matrix_free/dof_info_01.cc
@@ -73,9 +73,8 @@ test(const bool adaptive_ref = true)
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/matrix_free/dof_info_02.cc
+++ b/tests/matrix_free/dof_info_02.cc
@@ -75,9 +75,8 @@ test(const bool adaptive_ref = true)
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/matrix_free/interpolate_to_mg.cc
+++ b/tests/matrix_free/interpolate_to_mg.cc
@@ -126,9 +126,11 @@ test(const unsigned int n_glob_ref = 2, const unsigned int n_ref = 0)
   dof_handler.distribute_dofs(fe);
   dof_handler.distribute_mg_dofs();
 
-  IndexSet locally_owned_dofs, locally_relevant_dofs;
-  locally_owned_dofs = dof_handler.locally_owned_dofs();
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet &locally_owned_dofs = dof_handler.locally_owned_dofs();
+  const IndexSet  locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
+
+
 
   // constraints:
   AffineConstraints<double> constraints;
@@ -191,8 +193,8 @@ test(const unsigned int n_glob_ref = 2, const unsigned int n_ref = 0)
     level_projection(min_level, max_level);
   for (unsigned int level = min_level; level <= max_level; ++level)
     {
-      IndexSet set;
-      DoFTools::extract_locally_relevant_level_dofs(dof_handler, level, set);
+      const IndexSet set =
+        DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
       level_projection[level].reinit(dof_handler.locally_owned_mg_dofs(level),
                                      set,
                                      mpi_communicator);

--- a/tests/matrix_free/laplace_operator_01.cc
+++ b/tests/matrix_free/laplace_operator_01.cc
@@ -88,9 +88,8 @@ test()
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/matrix_free/laplace_operator_02.cc
+++ b/tests/matrix_free/laplace_operator_02.cc
@@ -129,9 +129,8 @@ test()
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/matrix_free/laplace_operator_03.cc
+++ b/tests/matrix_free/laplace_operator_03.cc
@@ -83,9 +83,8 @@ test()
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/matrix_free/laplace_operator_05.cc
+++ b/tests/matrix_free/laplace_operator_05.cc
@@ -89,9 +89,8 @@ test()
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/matrix_free/mass_operator_01.cc
+++ b/tests/matrix_free/mass_operator_01.cc
@@ -95,9 +95,8 @@ test()
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/matrix_free/mass_operator_02.cc
+++ b/tests/matrix_free/mass_operator_02.cc
@@ -60,9 +60,8 @@ test()
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/matrix_free/mass_operator_03.cc
+++ b/tests/matrix_free/mass_operator_03.cc
@@ -61,9 +61,8 @@ test()
   DoFHandler<dim>        dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/matrix_free/mass_operator_04.cc
+++ b/tests/matrix_free/mass_operator_04.cc
@@ -55,9 +55,8 @@ test()
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints_0(relevant_set),
     constraints_1(relevant_set);

--- a/tests/matrix_free/matrix_free_device_initialize_vector.cc
+++ b/tests/matrix_free/matrix_free_device_initialize_vector.cc
@@ -74,9 +74,8 @@ test()
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   deallog << "locally owned dofs :" << std::endl;
   owned_set.print(deallog.get_file_stream());

--- a/tests/matrix_free/matrix_free_device_matrix_vector_10.cc
+++ b/tests/matrix_free/matrix_free_device_matrix_vector_10.cc
@@ -91,9 +91,8 @@ test()
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/matrix_free/matrix_free_device_matrix_vector_10a.cc
+++ b/tests/matrix_free/matrix_free_device_matrix_vector_10a.cc
@@ -93,9 +93,8 @@ test()
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/matrix_free/matrix_free_device_matrix_vector_19.cc
+++ b/tests/matrix_free/matrix_free_device_matrix_vector_19.cc
@@ -87,9 +87,8 @@ test()
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/matrix_free/matrix_free_device_matrix_vector_25.cc
+++ b/tests/matrix_free/matrix_free_device_matrix_vector_25.cc
@@ -93,9 +93,8 @@ test()
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/matrix_free/matrix_free_device_matrix_vector_26.cc
+++ b/tests/matrix_free/matrix_free_device_matrix_vector_26.cc
@@ -99,9 +99,8 @@ test()
       }
   dof.distribute_dofs(fe_collection);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/matrix_free/matrix_free_device_precondition_chebyshev.cc
+++ b/tests/matrix_free/matrix_free_device_precondition_chebyshev.cc
@@ -92,9 +92,8 @@ test()
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/matrix_free/matrix_free_device_reinit_01.cc
+++ b/tests/matrix_free/matrix_free_device_reinit_01.cc
@@ -50,9 +50,8 @@ test()
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   deallog << "locally owned dofs :" << std::endl;
   owned_set.print(deallog.get_file_stream());

--- a/tests/matrix_free/matrix_vector_11.cc
+++ b/tests/matrix_free/matrix_vector_11.cc
@@ -87,9 +87,8 @@ test()
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/matrix_free/matrix_vector_12.cc
+++ b/tests/matrix_free/matrix_vector_12.cc
@@ -152,9 +152,8 @@ test()
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/matrix_free/matrix_vector_13.cc
+++ b/tests/matrix_free/matrix_vector_13.cc
@@ -150,9 +150,8 @@ test()
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/matrix_free/matrix_vector_19.cc
+++ b/tests/matrix_free/matrix_vector_19.cc
@@ -88,9 +88,8 @@ test()
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/matrix_free/matrix_vector_22.cc
+++ b/tests/matrix_free/matrix_vector_22.cc
@@ -153,9 +153,8 @@ test()
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/matrix_free/matrix_vector_23.cc
+++ b/tests/matrix_free/matrix_vector_23.cc
@@ -165,9 +165,8 @@ test()
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/matrix_free/matrix_vector_blocks.cc
+++ b/tests/matrix_free/matrix_vector_blocks.cc
@@ -133,9 +133,8 @@ test()
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/matrix_free/matrix_vector_large_degree_02.cc
+++ b/tests/matrix_free/matrix_vector_large_degree_02.cc
@@ -73,9 +73,8 @@ test()
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/matrix_free/parallel_multigrid_02.cc
+++ b/tests/matrix_free/parallel_multigrid_02.cc
@@ -98,8 +98,8 @@ do_test(const DoFHandler<dim> &dof)
   deallog << std::endl;
   deallog << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof);
 
   // Dirichlet BC
   Functions::ZeroFunction<dim>                        zero_function;
@@ -173,8 +173,8 @@ do_test(const DoFHandler<dim> &dof)
       mg_additional_data.mg_level = level;
 
       AffineConstraints<double> level_constraints;
-      IndexSet                  relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof, level, relevant_dofs);
+      const IndexSet            relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof, level);
       level_constraints.reinit(relevant_dofs);
       level_constraints.add_lines(
         mg_constrained_dofs.get_boundary_indices(level));

--- a/tests/matrix_free/parallel_multigrid_adaptive_01.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_01.cc
@@ -78,8 +78,8 @@ public:
     AffineConstraints<double> constraints;
     if (level == numbers::invalid_unsigned_int)
       {
-        IndexSet relevant_dofs;
-        DoFTools::extract_locally_relevant_dofs(dof_handler, relevant_dofs);
+        const IndexSet relevant_dofs =
+          DoFTools::extract_locally_relevant_dofs(dof_handler);
         constraints.reinit(relevant_dofs);
         DoFTools::make_hanging_node_constraints(dof_handler, constraints);
         VectorTools::interpolate_boundary_values(dof_handler,
@@ -88,10 +88,8 @@ public:
       }
     else
       {
-        IndexSet relevant_dofs;
-        DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                      level,
-                                                      relevant_dofs);
+        const IndexSet relevant_dofs =
+          DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
         constraints.reinit(relevant_dofs);
         constraints.add_lines(mg_constrained_dofs.get_boundary_indices(level));
 
@@ -479,8 +477,8 @@ do_test(const DoFHandler<dim> &dof)
   deallog << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
 
   AffineConstraints<double> hanging_node_constraints;
-  IndexSet                  locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof, locally_relevant_dofs);
+  const IndexSet            locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof);
   hanging_node_constraints.reinit(locally_relevant_dofs);
   DoFTools::make_hanging_node_constraints(dof, hanging_node_constraints);
   hanging_node_constraints.close();

--- a/tests/matrix_free/parallel_multigrid_adaptive_02.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_02.cc
@@ -99,8 +99,8 @@ do_test(const DoFHandler<dim> &dof)
   deallog << std::endl;
   deallog << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof);
 
   // Dirichlet BC
   Functions::ZeroFunction<dim>                        zero_function;
@@ -187,8 +187,8 @@ do_test(const DoFHandler<dim> &dof)
       mg_additional_data.mg_level         = level;
 
       AffineConstraints<double> level_constraints;
-      IndexSet                  relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof, level, relevant_dofs);
+      const IndexSet            relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof, level);
       level_constraints.reinit(relevant_dofs);
       level_constraints.add_lines(
         mg_constrained_dofs.get_boundary_indices(level));

--- a/tests/matrix_free/parallel_multigrid_adaptive_03.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_03.cc
@@ -85,8 +85,8 @@ public:
     AffineConstraints<double> constraints;
     if (level == numbers::invalid_unsigned_int)
       {
-        IndexSet relevant_dofs;
-        DoFTools::extract_locally_relevant_dofs(dof_handler, relevant_dofs);
+        const IndexSet relevant_dofs =
+          DoFTools::extract_locally_relevant_dofs(dof_handler);
         constraints.reinit(relevant_dofs);
         DoFTools::make_hanging_node_constraints(dof_handler, constraints);
         VectorTools::interpolate_boundary_values(dof_handler,
@@ -95,10 +95,8 @@ public:
       }
     else
       {
-        IndexSet relevant_dofs;
-        DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                      level,
-                                                      relevant_dofs);
+        const IndexSet relevant_dofs =
+          DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
         constraints.reinit(relevant_dofs);
         constraints.add_lines(mg_constrained_dofs.get_boundary_indices(level));
 
@@ -483,8 +481,8 @@ do_test(const DoFHandler<dim> &dof, const bool threaded)
   deallog << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
 
   AffineConstraints<double> hanging_node_constraints;
-  IndexSet                  locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof, locally_relevant_dofs);
+  const IndexSet            locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof);
   hanging_node_constraints.reinit(locally_relevant_dofs);
   DoFTools::make_hanging_node_constraints(dof, hanging_node_constraints);
   hanging_node_constraints.close();

--- a/tests/matrix_free/parallel_multigrid_adaptive_04.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_04.cc
@@ -99,8 +99,8 @@ do_test(const DoFHandler<dim> &dof)
   deallog << std::endl;
   deallog << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof);
 
   // Dirichlet BC
   Functions::ZeroFunction<dim>                        zero_function;
@@ -187,8 +187,8 @@ do_test(const DoFHandler<dim> &dof)
       mg_additional_data.mg_level         = level;
 
       AffineConstraints<double> level_constraints;
-      IndexSet                  relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof, level, relevant_dofs);
+      const IndexSet            relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof, level);
       level_constraints.reinit(relevant_dofs);
       level_constraints.add_lines(
         mg_constrained_dofs.get_boundary_indices(level));

--- a/tests/matrix_free/parallel_multigrid_adaptive_05.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_05.cc
@@ -82,8 +82,8 @@ public:
     AffineConstraints<double> constraints;
     if (level == numbers::invalid_unsigned_int)
       {
-        IndexSet relevant_dofs;
-        DoFTools::extract_locally_relevant_dofs(dof_handler, relevant_dofs);
+        const IndexSet relevant_dofs =
+          DoFTools::extract_locally_relevant_dofs(dof_handler);
         constraints.reinit(relevant_dofs);
         DoFTools::make_hanging_node_constraints(dof_handler, constraints);
         VectorTools::interpolate_boundary_values(dof_handler,
@@ -92,10 +92,8 @@ public:
       }
     else
       {
-        IndexSet relevant_dofs;
-        DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                      level,
-                                                      relevant_dofs);
+        const IndexSet relevant_dofs =
+          DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
         constraints.reinit(relevant_dofs);
         constraints.add_lines(mg_constrained_dofs.get_boundary_indices(level));
 
@@ -480,8 +478,8 @@ do_test(const DoFHandler<dim> &dof, const bool threaded)
   deallog << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
 
   AffineConstraints<double> hanging_node_constraints;
-  IndexSet                  locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof, locally_relevant_dofs);
+  const IndexSet            locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof);
   hanging_node_constraints.reinit(locally_relevant_dofs);
   DoFTools::make_hanging_node_constraints(dof, hanging_node_constraints);
   hanging_node_constraints.close();

--- a/tests/matrix_free/parallel_multigrid_adaptive_06.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_06.cc
@@ -221,8 +221,8 @@ do_test(const DoFHandler<dim> &dof, const unsigned int nb)
   deallog << std::endl;
   deallog << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof);
 
   // Dirichlet BC
   Functions::ZeroFunction<dim>                        zero_function;
@@ -315,8 +315,8 @@ do_test(const DoFHandler<dim> &dof, const unsigned int nb)
       mg_additional_data.mg_level         = level;
 
       AffineConstraints<double> level_constraints;
-      IndexSet                  relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof, level, relevant_dofs);
+      const IndexSet            relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof, level);
       level_constraints.reinit(relevant_dofs);
       level_constraints.add_lines(
         mg_constrained_dofs.get_boundary_indices(level));

--- a/tests/matrix_free/parallel_multigrid_adaptive_06ref.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_06ref.cc
@@ -100,8 +100,8 @@ do_test(const DoFHandler<dim> &dof)
   deallog << std::endl;
   deallog << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof);
 
   // Dirichlet BC
   Functions::ZeroFunction<dim>                        zero_function;
@@ -188,8 +188,8 @@ do_test(const DoFHandler<dim> &dof)
       mg_additional_data.mg_level         = level;
 
       AffineConstraints<double> level_constraints;
-      IndexSet                  relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof, level, relevant_dofs);
+      const IndexSet            relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof, level);
       level_constraints.reinit(relevant_dofs);
       level_constraints.add_lines(
         mg_constrained_dofs.get_boundary_indices(level));

--- a/tests/matrix_free/parallel_multigrid_adaptive_07.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_07.cc
@@ -241,7 +241,7 @@ do_test(const std::vector<const DoFHandler<dim> *> &dof)
 
   std::vector<IndexSet> locally_relevant_dofs(dof.size());
   for (unsigned int i = 0; i < dof.size(); ++i)
-    DoFTools::extract_locally_relevant_dofs(*dof[i], locally_relevant_dofs[i]);
+    locally_relevant_dofs[i] = DoFTools::extract_locally_relevant_dofs(*dof[i]);
 
   // Dirichlet BC
   Functions::ZeroFunction<dim>                        zero_function;
@@ -349,10 +349,8 @@ do_test(const std::vector<const DoFHandler<dim> *> &dof)
         dof.size());
       for (unsigned int i = 0; i < dof.size(); ++i)
         {
-          IndexSet relevant_dofs;
-          DoFTools::extract_locally_relevant_level_dofs(*dof[i],
-                                                        level,
-                                                        relevant_dofs);
+          const IndexSet relevant_dofs =
+            DoFTools::extract_locally_relevant_level_dofs(*dof[i], level);
           level_constraints[i].reinit(relevant_dofs);
           level_constraints[i].add_lines(
             mg_constrained_dofs[i].get_boundary_indices(level));

--- a/tests/matrix_free/parallel_multigrid_adaptive_08.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_08.cc
@@ -217,8 +217,8 @@ do_test(const DoFHandler<dim> &dof)
   deallog << std::endl;
   deallog << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof);
 
   // Dirichlet BC
   Functions::ZeroFunction<dim>                        zero_function;
@@ -295,8 +295,8 @@ do_test(const DoFHandler<dim> &dof)
       mg_additional_data.mg_level         = level;
 
       AffineConstraints<double> level_constraints;
-      IndexSet                  relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof, level, relevant_dofs);
+      const IndexSet            relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof, level);
       level_constraints.reinit(relevant_dofs);
       level_constraints.add_lines(
         mg_constrained_dofs.get_boundary_indices(level));

--- a/tests/matrix_free/parallel_multigrid_mf_02.cc
+++ b/tests/matrix_free/parallel_multigrid_mf_02.cc
@@ -105,8 +105,8 @@ do_test(const DoFHandler<dim> &dof)
   dirichlet_boundary[0] = &zero_function;
 
   // fine-level constraints
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof);
   AffineConstraints<double> constraints;
   constraints.reinit(locally_relevant_dofs);
   VectorTools::interpolate_boundary_values(dof,
@@ -160,8 +160,8 @@ do_test(const DoFHandler<dim> &dof)
       mg_additional_data.mg_level         = level;
 
       AffineConstraints<double> level_constraints;
-      IndexSet                  relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof, level, relevant_dofs);
+      const IndexSet            relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof, level);
       level_constraints.reinit(relevant_dofs);
       level_constraints.add_lines(
         mg_constrained_dofs.get_boundary_indices(level));

--- a/tests/matrix_free/pre_and_post_loops_02.cc
+++ b/tests/matrix_free/pre_and_post_loops_02.cc
@@ -141,8 +141,7 @@ test()
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
   AffineConstraints<double> constraints;
-  IndexSet                  relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_dofs);
+  const IndexSet relevant_dofs = DoFTools::extract_locally_relevant_dofs(dof);
   constraints.reinit(relevant_dofs);
   VectorTools::interpolate_boundary_values(dof,
                                            0,

--- a/tests/matrix_free/solver_cg_interleave.cc
+++ b/tests/matrix_free/solver_cg_interleave.cc
@@ -201,14 +201,14 @@ test(const unsigned int fe_degree)
     MatrixFree<dim, number>::AdditionalData::none;
 
   {
-    DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+    relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
     constraints.close();
 
     DoFRenumbering::matrix_free_data_locality(dof, constraints, addit_data);
   }
 
   constraints.clear();
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
   constraints.close();
 
   const QGauss<1>         quadrature(dof.get_fe().degree + 1);

--- a/tests/matrix_free/step-37-inhomogeneous-1.cc
+++ b/tests/matrix_free/step-37-inhomogeneous-1.cc
@@ -399,8 +399,8 @@ namespace Step37
     pcout << "Number of degrees of freedom: " << dof_handler.n_dofs()
           << std::endl;
 
-    IndexSet locally_relevant_dofs;
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    const IndexSet locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     constraints.clear();
     constraints.reinit(locally_relevant_dofs);
@@ -442,10 +442,8 @@ namespace Step37
 
     for (unsigned int level = 0; level < nlevels; ++level)
       {
-        IndexSet relevant_dofs;
-        DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                      level,
-                                                      relevant_dofs);
+        const IndexSet relevant_dofs =
+          DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
         AffineConstraints<double> level_constraints;
         level_constraints.reinit(relevant_dofs);
         level_constraints.add_lines(

--- a/tests/matrix_free/step-48.cc
+++ b/tests/matrix_free/step-48.cc
@@ -294,7 +294,8 @@ namespace Step48
             << std::endl;
 
 
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
     constraints.clear();
     constraints.reinit(locally_relevant_dofs);
     DoFTools::make_hanging_node_constraints(dof_handler, constraints);

--- a/tests/matrix_free/step-48b.cc
+++ b/tests/matrix_free/step-48b.cc
@@ -261,7 +261,8 @@ namespace Step48
             << std::endl;
 
 
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
     constraints.close();
 
     QGaussLobatto<1>                         quadrature(fe_degree + 1);

--- a/tests/matrix_free/step-48c.cc
+++ b/tests/matrix_free/step-48c.cc
@@ -264,7 +264,8 @@ namespace Step48
             << std::endl;
 
 
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
     constraints.clear();
     constraints.reinit(locally_relevant_dofs);
     DoFTools::make_hanging_node_constraints(dof_handler, constraints);

--- a/tests/matrix_free/stokes_computation.cc
+++ b/tests/matrix_free/stokes_computation.cc
@@ -1035,9 +1035,8 @@ namespace StokesClass
     dof_handler_p.clear();
     dof_handler_p.distribute_dofs(fe_p);
 
-    IndexSet locally_relevant_dofs_u;
-    DoFTools::extract_locally_relevant_dofs(dof_handler_u,
-                                            locally_relevant_dofs_u);
+    const IndexSet locally_relevant_dofs_u =
+      DoFTools::extract_locally_relevant_dofs(dof_handler_u);
     constraints_u.reinit(locally_relevant_dofs_u);
     DoFTools::make_hanging_node_constraints(dof_handler_u, constraints_u);
 
@@ -1045,9 +1044,8 @@ namespace StokesClass
       dof_handler_u, 0, ExactSolution_BoundaryValues_u<dim>(), constraints_u);
     constraints_u.close();
 
-    IndexSet locally_relevant_dofs_p;
-    DoFTools::extract_locally_relevant_dofs(dof_handler_p,
-                                            locally_relevant_dofs_p);
+    const IndexSet locally_relevant_dofs_p =
+      DoFTools::extract_locally_relevant_dofs(dof_handler_p);
     constraints_p.reinit(locally_relevant_dofs_p);
     DoFTools::make_hanging_node_constraints(dof_handler_p, constraints_p);
     constraints_p.close();
@@ -1112,10 +1110,8 @@ namespace StokesClass
 
     for (unsigned int level = 0; level < n_levels; ++level)
       {
-        IndexSet relevant_dofs;
-        DoFTools::extract_locally_relevant_level_dofs(dof_handler_u,
-                                                      level,
-                                                      relevant_dofs);
+        const IndexSet relevant_dofs =
+          DoFTools::extract_locally_relevant_level_dofs(dof_handler_u, level);
         AffineConstraints<double> level_constraints;
         level_constraints.reinit(relevant_dofs);
         level_constraints.add_lines(
@@ -1173,9 +1169,8 @@ namespace StokesClass
 
     // Create constraints with no Dirchlet info
     AffineConstraints<double> constraints_u_no_dirchlet;
-    IndexSet                  locally_relevant_dofs_u;
-    DoFTools::extract_locally_relevant_dofs(dof_handler_u,
-                                            locally_relevant_dofs_u);
+    const IndexSet            locally_relevant_dofs_u =
+      DoFTools::extract_locally_relevant_dofs(dof_handler_u);
     constraints_u_no_dirchlet.reinit(locally_relevant_dofs_u);
     DoFTools::make_hanging_node_constraints(dof_handler_u,
                                             constraints_u_no_dirchlet);

--- a/tests/meshworker/step-50-mesh_loop.cc
+++ b/tests/meshworker/step-50-mesh_loop.cc
@@ -231,8 +231,8 @@ namespace Step50
     mg_dof_handler.distribute_dofs(fe);
     mg_dof_handler.distribute_mg_dofs();
 
-    DoFTools::extract_locally_relevant_dofs(mg_dof_handler,
-                                            locally_relevant_set);
+    locally_relevant_set =
+      DoFTools::extract_locally_relevant_dofs(mg_dof_handler);
 
     solution.reinit(mg_dof_handler.locally_owned_dofs(), MPI_COMM_WORLD);
     system_rhs.reinit(mg_dof_handler.locally_owned_dofs(), MPI_COMM_WORLD);
@@ -362,10 +362,8 @@ namespace Step50
     for (unsigned int level = 0; level < triangulation.n_global_levels();
          ++level)
       {
-        IndexSet dofset;
-        DoFTools::extract_locally_relevant_level_dofs(mg_dof_handler,
-                                                      level,
-                                                      dofset);
+        const IndexSet dofset =
+          DoFTools::extract_locally_relevant_level_dofs(mg_dof_handler, level);
         boundary_constraints[level].reinit(dofset);
         boundary_constraints[level].add_lines(
           mg_constrained_dofs.get_refinement_edge_indices(level));

--- a/tests/mpi/compute_mean_value_01.cc
+++ b/tests/mpi/compute_mean_value_01.cc
@@ -73,8 +73,7 @@ test()
                                              MPI_COMM_WORLD);
   VectorTools::interpolate(dofh, LinearFunction<dim>(), interpolated);
 
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
+  const IndexSet relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
   TrilinosWrappers::MPI::Vector x_rel(relevant_set, MPI_COMM_WORLD);
   x_rel = interpolated;
 

--- a/tests/mpi/compute_mean_value_02.cc
+++ b/tests/mpi/compute_mean_value_02.cc
@@ -94,8 +94,7 @@ test()
     dofh.distribute_dofs(fe_collection);
   }
 
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
+  const IndexSet relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
   TrilinosWrappers::MPI::Vector x_rel(relevant_set, dofh.get_communicator());
   {
     TrilinosWrappers::MPI::Vector interpolated(dofh.locally_owned_dofs(),

--- a/tests/mpi/condense_01.cc
+++ b/tests/mpi/condense_01.cc
@@ -75,9 +75,9 @@ test()
   DoFTools::make_hanging_node_constraints(dof_handler, constraints);
   constraints.close();
 
-  IndexSet locally_owned_dofs, locally_relevant_dofs;
-  locally_owned_dofs = dof_handler.locally_owned_dofs();
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet &locally_owned_dofs = dof_handler.locally_owned_dofs();
+  const IndexSet  locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   PETScWrappers::MPI::Vector vec(locally_owned_dofs, MPI_COMM_WORLD);
   PETScWrappers::MPI::Vector vec_ghosted(locally_owned_dofs,

--- a/tests/mpi/constraint_matrix_condense_01.cc
+++ b/tests/mpi/constraint_matrix_condense_01.cc
@@ -47,10 +47,9 @@ test()
 
   dof_handler.distribute_dofs(fe);
 
-  IndexSet locally_owned_dofs;
-  locally_owned_dofs = dof_handler.locally_owned_dofs();
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet &locally_owned_dofs = dof_handler.locally_owned_dofs();
+  const IndexSet  locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   PETScWrappers::MPI::Vector force;
   force.reinit(locally_owned_dofs, mpi_communicator);

--- a/tests/mpi/constraint_matrix_trilinos_bug.cc
+++ b/tests/mpi/constraint_matrix_trilinos_bug.cc
@@ -80,10 +80,9 @@ test()
 
   dofh.distribute_dofs(fe);
 
-  IndexSet owned_set = dofh.locally_owned_dofs();
+  const IndexSet &owned_set = dofh.locally_owned_dofs();
 
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
+  const IndexSet relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
 
   TrilinosWrappers::MPI::Vector x;
   x.reinit(owned_set, MPI_COMM_WORLD);

--- a/tests/mpi/constraints_consistent_01.cc
+++ b/tests/mpi/constraints_consistent_01.cc
@@ -50,13 +50,11 @@ check(parallel::distributed::Triangulation<dim> &tria)
 
   dof_handler.distribute_dofs(fe);
 
-  IndexSet locally_owned_dofs = dof_handler.locally_owned_dofs();
-  IndexSet locally_active_dofs;
-
-  DoFTools::extract_locally_active_dofs(dof_handler, locally_active_dofs);
-
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet &locally_owned_dofs = dof_handler.locally_owned_dofs();
+  const IndexSet  locally_active_dofs =
+    DoFTools::extract_locally_active_dofs(dof_handler);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   AffineConstraints<double> constraints;
 

--- a/tests/mpi/crash_05.cc
+++ b/tests/mpi/crash_05.cc
@@ -77,8 +77,8 @@ test()
   AffineConstraints<double> constraints;
   DoFTools::make_hanging_node_constraints(dof_handler, constraints);
 
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, relevant_set);
+  const IndexSet relevant_set =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
   deallog << "relevant set:" << std::endl;
   relevant_set.print(deallog.get_file_stream());
   deallog << "constraints:" << std::endl;

--- a/tests/mpi/data_out_faces_01.cc
+++ b/tests/mpi/data_out_faces_01.cc
@@ -114,7 +114,8 @@ namespace pdd
 
     // Initialize the solution
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
     locally_relevant_solution.reinit(locally_owned_dofs, mpi_communicator);
 
     locally_relevant_solution = 0;

--- a/tests/mpi/data_out_faces_02.cc
+++ b/tests/mpi/data_out_faces_02.cc
@@ -80,7 +80,8 @@ main(int argc, char *argv[])
     IndexSet                           locally_relevant_dofs;
 
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
     locally_relevant_sol.reinit(locally_owned_dofs,
                                 locally_relevant_dofs,
                                 mpi_communicator);

--- a/tests/mpi/derivative_approximation_01.cc
+++ b/tests/mpi/derivative_approximation_01.cc
@@ -74,8 +74,8 @@ test()
   DoFHandler<dim> dofh(tr);
   dofh.distribute_dofs(fe);
 
-  IndexSet locally_relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, locally_relevant_set);
+  const IndexSet locally_relevant_set =
+    DoFTools::extract_locally_relevant_dofs(dofh);
 
   TrilinosWrappers::MPI::Vector vec(dofh.locally_owned_dofs(), MPI_COMM_WORLD);
   for (unsigned int i = vec.local_range().first; i < vec.local_range().second;

--- a/tests/mpi/derivative_approximation_02.cc
+++ b/tests/mpi/derivative_approximation_02.cc
@@ -72,8 +72,8 @@ test()
   DoFHandler<dim> dofh(tr);
   dofh.distribute_dofs(fe);
 
-  IndexSet locally_relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, locally_relevant_set);
+  const IndexSet locally_relevant_set =
+    DoFTools::extract_locally_relevant_dofs(dofh);
 
   // create a vector representing a function that is independent of the number
   // of processors involved

--- a/tests/mpi/distribute_flux_sparsity_pattern.cc
+++ b/tests/mpi/distribute_flux_sparsity_pattern.cc
@@ -108,7 +108,8 @@ namespace LinearAdvectionTest
   {
     dof_handler.distribute_dofs(fe);
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     DynamicSparsityPattern dynamic_sparsity_pattern(locally_relevant_dofs);
     Table<2, DoFTools::Coupling> cell_integral_mask(fe.n_components(),

--- a/tests/mpi/extract_boundary_dofs.cc
+++ b/tests/mpi/extract_boundary_dofs.cc
@@ -50,8 +50,7 @@ test()
 
   // the result of extract_boundary_dofs is supposed to be a subset of the
   // locally relevant dofs, so test this
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
+  const IndexSet relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
   boundary_dofs.subtract_set(relevant_set);
   AssertThrow(boundary_dofs.n_elements() == 0, ExcInternalError());
 }

--- a/tests/mpi/extract_locally_active_dofs.cc
+++ b/tests/mpi/extract_locally_active_dofs.cc
@@ -51,8 +51,7 @@ test()
   DoFHandler<dim> dofh(tr);
   dofh.distribute_dofs(fe);
 
-  IndexSet locally_active;
-  DoFTools::extract_locally_active_dofs(dofh, locally_active);
+  const IndexSet locally_active = DoFTools::extract_locally_active_dofs(dofh);
 
   Assert(locally_active == DoFTools::dof_indices_with_subdomain_association(
                              dofh, tr.locally_owned_subdomain()),

--- a/tests/mpi/extract_locally_active_level_dofs.cc
+++ b/tests/mpi/extract_locally_active_level_dofs.cc
@@ -55,12 +55,10 @@ test()
   dofh.distribute_dofs(fe);
   dofh.distribute_mg_dofs();
 
-  IndexSet locally_level_active;
   for (unsigned int level = 0; level < tr.n_levels(); ++level)
     {
-      DoFTools::extract_locally_active_level_dofs(dofh,
-                                                  locally_level_active,
-                                                  level);
+      const IndexSet locally_level_active =
+        DoFTools::extract_locally_active_level_dofs(dofh, level);
 
       if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
         {

--- a/tests/mpi/fe_field_function_01.cc
+++ b/tests/mpi/fe_field_function_01.cc
@@ -76,8 +76,7 @@ test()
                                              MPI_COMM_WORLD);
   VectorTools::interpolate(dofh, LinearFunction<dim>(), interpolated);
 
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
+  const IndexSet relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
   TrilinosWrappers::MPI::Vector x_rel(relevant_set, MPI_COMM_WORLD);
   x_rel = interpolated;
 

--- a/tests/mpi/fe_field_function_02.cc
+++ b/tests/mpi/fe_field_function_02.cc
@@ -99,8 +99,7 @@ test()
                                              MPI_COMM_WORLD);
   VectorTools::interpolate(dofh, LinearFunction<dim>(), interpolated);
 
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
+  const IndexSet relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
   TrilinosWrappers::MPI::Vector x_rel(relevant_set, MPI_COMM_WORLD);
   x_rel = interpolated;
 

--- a/tests/mpi/fe_field_function_03.cc
+++ b/tests/mpi/fe_field_function_03.cc
@@ -88,8 +88,7 @@ test()
                                              MPI_COMM_WORLD);
   VectorTools::interpolate(dofh, LinearFunction<dim>(), interpolated);
 
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
+  const IndexSet relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
   TrilinosWrappers::MPI::Vector x_rel(relevant_set, MPI_COMM_WORLD);
   x_rel = interpolated;
 

--- a/tests/mpi/fe_tools_extrapolate_common.h
+++ b/tests/mpi/fe_tools_extrapolate_common.h
@@ -200,12 +200,12 @@ check_this(const FiniteElement<dim> &fe1, const FiniteElement<dim> &fe2)
   DoFTools::make_hanging_node_constraints(*dof2, cm2);
   cm2.close();
 
-  IndexSet locally_owned_dofs1 = dof1->locally_owned_dofs();
-  IndexSet locally_relevant_dofs1;
-  DoFTools::extract_locally_relevant_dofs(*dof1, locally_relevant_dofs1);
-  IndexSet locally_owned_dofs2 = dof2->locally_owned_dofs();
-  IndexSet locally_relevant_dofs2;
-  DoFTools::extract_locally_relevant_dofs(*dof2, locally_relevant_dofs2);
+  const IndexSet &locally_owned_dofs1 = dof1->locally_owned_dofs();
+  const IndexSet  locally_relevant_dofs1 =
+    DoFTools::extract_locally_relevant_dofs(*dof1);
+  const IndexSet &locally_owned_dofs2 = dof2->locally_owned_dofs();
+  const IndexSet  locally_relevant_dofs2 =
+    DoFTools::extract_locally_relevant_dofs(*dof2);
 
   VectorType in_ghosted =
     build_ghosted<VectorType>(locally_owned_dofs1, locally_relevant_dofs1);
@@ -331,12 +331,12 @@ check_this_dealii(const FiniteElement<dim> &fe1, const FiniteElement<dim> &fe2)
   DoFTools::make_hanging_node_constraints(*dof2, cm2);
   cm2.close();
 
-  IndexSet locally_owned_dofs1 = dof1->locally_owned_dofs();
-  IndexSet locally_relevant_dofs1;
-  DoFTools::extract_locally_relevant_dofs(*dof1, locally_relevant_dofs1);
-  IndexSet locally_owned_dofs2 = dof2->locally_owned_dofs();
-  IndexSet locally_relevant_dofs2;
-  DoFTools::extract_locally_relevant_dofs(*dof2, locally_relevant_dofs2);
+  const IndexSet &locally_owned_dofs1 = dof1->locally_owned_dofs();
+  const IndexSet  locally_relevant_dofs1 =
+    DoFTools::extract_locally_relevant_dofs(*dof1);
+  const IndexSet &locally_owned_dofs2 = dof2->locally_owned_dofs();
+  const IndexSet  locally_relevant_dofs2 =
+    DoFTools::extract_locally_relevant_dofs(*dof2);
 
   VectorType in_ghosted =
     build_ghosted<VectorType>(locally_owned_dofs1, locally_relevant_dofs1);

--- a/tests/mpi/flux_edge_01.cc
+++ b/tests/mpi/flux_edge_01.cc
@@ -115,7 +115,7 @@ namespace Step39
     dof_handler.distribute_dofs(fe);
     dof_handler.distribute_mg_dofs();
 
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_set);
+    locally_relevant_set = DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     DynamicSparsityPattern c_sparsity(dof_handler.n_dofs(),
                                       dof_handler.n_dofs());

--- a/tests/mpi/hp_constraints_consistent_01.cc
+++ b/tests/mpi/hp_constraints_consistent_01.cc
@@ -102,8 +102,8 @@ test(const unsigned int degree_center,
   dh.distribute_dofs(fe_collection);
 
   // ---- constrain ----
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dh, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dh);
 
   AffineConstraints<double> constraints;
   constraints.clear();
@@ -117,8 +117,8 @@ test(const unsigned int degree_center,
   std::vector<IndexSet> locally_owned_dofs_per_processor =
     Utilities::MPI::all_gather(dh.get_communicator(), dh.locally_owned_dofs());
 
-  IndexSet locally_active_dofs;
-  DoFTools::extract_locally_active_dofs(dh, locally_active_dofs);
+  const IndexSet locally_active_dofs =
+    DoFTools::extract_locally_active_dofs(dh);
 
   if (print_constraints)
     {

--- a/tests/mpi/hp_constraints_consistent_02.cc
+++ b/tests/mpi/hp_constraints_consistent_02.cc
@@ -102,8 +102,8 @@ test(const unsigned int degree_center,
   dh.distribute_dofs(fe_collection);
 
   // ---- constrain ----
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dh, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dh);
 
   AffineConstraints<double> constraints;
   constraints.clear();
@@ -123,8 +123,8 @@ test(const unsigned int degree_center,
   std::vector<IndexSet> locally_owned_dofs_per_processor =
     Utilities::MPI::all_gather(dh.get_communicator(), dh.locally_owned_dofs());
 
-  IndexSet locally_active_dofs;
-  DoFTools::extract_locally_active_dofs(dh, locally_active_dofs);
+  const IndexSet locally_active_dofs =
+    DoFTools::extract_locally_active_dofs(dh);
 
   if (print_constraints)
     {

--- a/tests/mpi/hp_constraints_consistent_03.cc
+++ b/tests/mpi/hp_constraints_consistent_03.cc
@@ -117,8 +117,8 @@ test(const unsigned int degree_center,
   dh.distribute_dofs(fe_collection);
 
   // ---- constrain ----
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dh, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dh);
 
   AffineConstraints<double> constraints;
   constraints.clear();
@@ -138,8 +138,8 @@ test(const unsigned int degree_center,
   std::vector<IndexSet> locally_owned_dofs_per_processor =
     Utilities::MPI::all_gather(dh.get_communicator(), dh.locally_owned_dofs());
 
-  IndexSet locally_active_dofs;
-  DoFTools::extract_locally_active_dofs(dh, locally_active_dofs);
+  const IndexSet locally_active_dofs =
+    DoFTools::extract_locally_active_dofs(dh);
 
   if (print_constraints)
     {

--- a/tests/mpi/hp_hanging_node_constraints_01.cc
+++ b/tests/mpi/hp_hanging_node_constraints_01.cc
@@ -74,8 +74,8 @@ test()
   dh.distribute_dofs(fes);
 
   // make constraints
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dh, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dh);
 
   AffineConstraints<double> constraints;
   constraints.reinit(locally_relevant_dofs);

--- a/tests/mpi/hp_hanging_node_constraints_02.cc
+++ b/tests/mpi/hp_hanging_node_constraints_02.cc
@@ -94,8 +94,8 @@ test()
   dof_handler.distribute_dofs(fe_collection);
 
   // make constraints
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   AffineConstraints<double> hanging_node_constraints;
   hanging_node_constraints.reinit(locally_relevant_dofs);

--- a/tests/mpi/hp_integrate_difference.cc
+++ b/tests/mpi/hp_integrate_difference.cc
@@ -163,8 +163,8 @@ test()
   hanging_node_constraints.distribute(interpolated);
 
   // extract a vector that has ghost elements
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, relevant_set);
+  const IndexSet relevant_set =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
   TrilinosWrappers::MPI::Vector x_rel(relevant_set, MPI_COMM_WORLD);
   x_rel = interpolated;
 

--- a/tests/mpi/hp_step-4.cc
+++ b/tests/mpi/hp_step-4.cc
@@ -185,8 +185,8 @@ namespace Step4
     dof_handler.distribute_dofs(fe);
 
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    locally_relevant_dofs.clear();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
     locally_relevant_dofs.compress();
 
     constraints.clear();
@@ -204,8 +204,8 @@ namespace Step4
       Utilities::MPI::all_gather(communicator,
                                  dof_handler.locally_owned_dofs());
 
-    IndexSet locally_active_dofs;
-    DoFTools::extract_locally_active_dofs(dof_handler, locally_active_dofs);
+    const IndexSet locally_active_dofs =
+      DoFTools::extract_locally_active_dofs(dof_handler);
 
     AssertThrow(
       constraints.is_consistent_in_parallel(locally_owned_dofs_per_processor,

--- a/tests/mpi/hp_step-40.cc
+++ b/tests/mpi/hp_step-40.cc
@@ -137,7 +137,8 @@ namespace Step40
     dof_handler.distribute_dofs(fe);
 
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     locally_relevant_solution.reinit(locally_owned_dofs,
                                      locally_relevant_dofs,

--- a/tests/mpi/hp_step-40_variable_01.cc
+++ b/tests/mpi/hp_step-40_variable_01.cc
@@ -145,7 +145,8 @@ namespace Step40
     dof_handler.distribute_dofs(fe);
 
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     locally_relevant_solution.reinit(locally_owned_dofs,
                                      locally_relevant_dofs,

--- a/tests/mpi/integrate_difference.cc
+++ b/tests/mpi/integrate_difference.cc
@@ -71,8 +71,7 @@ test()
                                              MPI_COMM_WORLD);
   VectorTools::interpolate(dofh, LinearFunction<dim>(), interpolated);
 
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
+  const IndexSet relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
   TrilinosWrappers::MPI::Vector x_rel(relevant_set, MPI_COMM_WORLD);
   x_rel = interpolated;
 

--- a/tests/mpi/interpolate_04.cc
+++ b/tests/mpi/interpolate_04.cc
@@ -65,12 +65,13 @@ test()
   AffineConstraints<PetscScalar> cm2;
   cm2.close();
 
-  IndexSet dof1_locally_owned_dofs = dofh1.locally_owned_dofs();
-  IndexSet dof2_locally_owned_dofs = dofh2.locally_owned_dofs();
-  IndexSet dof1_locally_relevant_dofs;
-  IndexSet dof2_locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dofh2, dof2_locally_relevant_dofs);
-  DoFTools::extract_locally_relevant_dofs(dofh1, dof1_locally_relevant_dofs);
+  const IndexSet &dof1_locally_owned_dofs = dofh1.locally_owned_dofs();
+  const IndexSet &dof2_locally_owned_dofs = dofh2.locally_owned_dofs();
+  const IndexSet  dof1_locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dofh1);
+  const IndexSet dof2_locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dofh2);
+
 
   PETScWrappers::MPI::Vector u1(dof1_locally_owned_dofs,
                                 dof1_locally_relevant_dofs,

--- a/tests/mpi/interpolate_05.cc
+++ b/tests/mpi/interpolate_05.cc
@@ -85,8 +85,7 @@ test()
 
   // Integrate the difference in the first component, if everything went
   // well, this should be zero.
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
+  const IndexSet relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
   TrilinosWrappers::MPI::Vector x_rel(relevant_set, MPI_COMM_WORLD);
   x_rel = x;
   Vector<double>               error(tr.n_active_cells());

--- a/tests/mpi/interpolate_to_different_mesh_01.cc
+++ b/tests/mpi/interpolate_to_different_mesh_01.cc
@@ -66,8 +66,7 @@ setup(DoFHandler<dim> &dh,
 {
   dh.distribute_dofs(fe);
   vec.reinit(dh.locally_owned_dofs(), MPI_COMM_WORLD);
-  IndexSet locally_relevant;
-  DoFTools::extract_locally_relevant_dofs(dh, locally_relevant);
+  const IndexSet locally_relevant = DoFTools::extract_locally_relevant_dofs(dh);
   lr_vec.reinit(locally_relevant, MPI_COMM_WORLD);
 }
 

--- a/tests/mpi/interpolate_to_different_mesh_02.cc
+++ b/tests/mpi/interpolate_to_different_mesh_02.cc
@@ -133,8 +133,8 @@ void
 SeventhProblem<dim>::setup_system()
 {
   dof_handler.distribute_dofs(fe);
-  locally_owned_dofs = dof_handler.locally_owned_dofs();
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  locally_owned_dofs    = dof_handler.locally_owned_dofs();
+  locally_relevant_dofs = DoFTools::extract_locally_relevant_dofs(dof_handler);
   locally_relevant_solution.reinit(locally_owned_dofs,
                                    locally_relevant_dofs,
                                    mpi_communicator);
@@ -166,8 +166,8 @@ SeventhProblem<dim>::setup_second_system()
 {
   second_dof_handler.distribute_dofs(fe);
   second_locally_owned_dofs = second_dof_handler.locally_owned_dofs();
-  DoFTools::extract_locally_relevant_dofs(second_dof_handler,
-                                          second_locally_relevant_dofs);
+  second_locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(second_dof_handler);
   second_locally_relevant_solution.reinit(second_locally_owned_dofs,
                                           second_locally_relevant_dofs,
                                           mpi_communicator);

--- a/tests/mpi/make_zero_boundary_values.cc
+++ b/tests/mpi/make_zero_boundary_values.cc
@@ -53,8 +53,7 @@ test()
   // the result of extract_boundary_dofs is supposed to be a subset of the
   // locally relevant dofs, so do the test again with that
   {
-    IndexSet relevant_set(dofh.n_dofs());
-    DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
+    const IndexSet relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
     AffineConstraints<double> boundary_values(relevant_set);
     DoFTools::make_zero_boundary_constraints(dofh, boundary_values);
     if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)

--- a/tests/mpi/map_dofs_to_support_points.cc
+++ b/tests/mpi/map_dofs_to_support_points.cc
@@ -60,8 +60,7 @@ test()
   // supposed to be a map that
   // contains exactly the locally
   // relevant dofs, so test this
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
+  const IndexSet relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
 
   for (unsigned int i = 0; i < dofh.n_dofs(); ++i)
     {

--- a/tests/mpi/muelu_periodicity.cc
+++ b/tests/mpi/muelu_periodicity.cc
@@ -330,9 +330,8 @@ namespace Step22
       owned_partitioning.push_back(locally_owned_dofs.get_view(n_u, n_u + n_p));
 
       relevant_partitioning.clear();
-      IndexSet locally_relevant_dofs;
-      DoFTools::extract_locally_relevant_dofs(dof_handler,
-                                              locally_relevant_dofs);
+      const IndexSet locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(dof_handler);
       relevant_partitioning.push_back(locally_relevant_dofs.get_view(0, n_u));
       relevant_partitioning.push_back(
         locally_relevant_dofs.get_view(n_u, n_u + n_p));

--- a/tests/mpi/multigrid_adaptive.cc
+++ b/tests/mpi/multigrid_adaptive.cc
@@ -489,8 +489,8 @@ namespace Step50
     Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
 
     TrilinosWrappers::MPI::Vector temp_solution;
-    IndexSet                      idx;
-    DoFTools::extract_locally_relevant_dofs(mg_dof_handler, idx);
+    const IndexSet                idx =
+      DoFTools::extract_locally_relevant_dofs(mg_dof_handler);
     temp_solution.reinit(idx, MPI_COMM_WORLD);
     temp_solution = solution;
 

--- a/tests/mpi/no_flux_constraints.cc
+++ b/tests/mpi/no_flux_constraints.cc
@@ -106,8 +106,7 @@ test()
   if (myid == 0)
     deallog << "#dofs = " << dofh.locally_owned_dofs().size() << std::endl;
 
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
+  const IndexSet relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
 
   AffineConstraints<double> constraints;
   constraints.reinit(relevant_set);

--- a/tests/mpi/no_flux_constraints_02.cc
+++ b/tests/mpi/no_flux_constraints_02.cc
@@ -108,8 +108,7 @@ test()
   if (myid == 0)
     deallog << "#dofs = " << dofh.locally_owned_dofs().size() << std::endl;
 
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
+  const IndexSet relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
 
   AffineConstraints<double> constraints;
   constraints.reinit(relevant_set);

--- a/tests/mpi/no_flux_constraints_03.cc
+++ b/tests/mpi/no_flux_constraints_03.cc
@@ -84,8 +84,7 @@ test()
   if (myid == 0)
     deallog << "#dofs = " << dofh.locally_owned_dofs().size() << std::endl;
 
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
+  const IndexSet relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
 
   AffineConstraints<double> constraints;
   constraints.reinit(relevant_set);

--- a/tests/mpi/normal_flux_constraints.cc
+++ b/tests/mpi/normal_flux_constraints.cc
@@ -105,8 +105,7 @@ test()
   if (myid == 0)
     deallog << "#dofs = " << dofh.locally_owned_dofs().size() << std::endl;
 
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
+  const IndexSet relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
 
   AffineConstraints<double> constraints;
   constraints.reinit(relevant_set);

--- a/tests/mpi/p4est_2d_constraintmatrix_01.cc
+++ b/tests/mpi/p4est_2d_constraintmatrix_01.cc
@@ -61,8 +61,7 @@ test()
   static const FE_Q<dim> fe(1);
   dofh.distribute_dofs(fe);
 
-  IndexSet dof_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, dof_set);
+  const IndexSet dof_set = DoFTools::extract_locally_relevant_dofs(dofh);
 
   AffineConstraints<double> cm;
   DoFTools::make_hanging_node_constraints(dofh, cm);

--- a/tests/mpi/p4est_2d_constraintmatrix_02.cc
+++ b/tests/mpi/p4est_2d_constraintmatrix_02.cc
@@ -63,8 +63,7 @@ test()
       static const FE_Q<dim> fe(1);
       dofh.distribute_dofs(fe);
 
-      IndexSet dof_set;
-      DoFTools::extract_locally_relevant_dofs(dofh, dof_set);
+      const IndexSet dof_set = DoFTools::extract_locally_relevant_dofs(dofh);
 
       AffineConstraints<double> cm;
       DoFTools::make_hanging_node_constraints(dofh, cm);

--- a/tests/mpi/p4est_2d_constraintmatrix_03.cc
+++ b/tests/mpi/p4est_2d_constraintmatrix_03.cc
@@ -89,13 +89,9 @@ test()
 
   dofh.distribute_dofs(fe);
 
-  IndexSet owned_set = dofh.locally_owned_dofs();
-
-  IndexSet dof_set;
-  DoFTools::extract_locally_active_dofs(dofh, dof_set);
-
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
+  const IndexSet &owned_set    = dofh.locally_owned_dofs();
+  const IndexSet  dof_set      = DoFTools::extract_locally_active_dofs(dofh);
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
 
   TrilinosWrappers::MPI::Vector x;
   x.reinit(owned_set, MPI_COMM_WORLD);

--- a/tests/mpi/p4est_2d_constraintmatrix_04.cc
+++ b/tests/mpi/p4est_2d_constraintmatrix_04.cc
@@ -129,13 +129,9 @@ test()
 
   dofh.distribute_dofs(fe);
 
-  IndexSet owned_set = dofh.locally_owned_dofs();
-
-  IndexSet dof_set;
-  DoFTools::extract_locally_active_dofs(dofh, dof_set);
-
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
+  IndexSet owned_set    = dofh.locally_owned_dofs();
+  IndexSet dof_set      = DoFTools::extract_locally_active_dofs(dofh);
+  IndexSet relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
 
   TrilinosWrappers::MPI::Vector x;
   x.reinit(owned_set, MPI_COMM_WORLD);
@@ -203,11 +199,9 @@ test()
 
       dofh.distribute_dofs(fe);
 
-      owned_set = dofh.locally_owned_dofs();
-
-      DoFTools::extract_locally_active_dofs(dofh, dof_set);
-
-      DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
+      owned_set    = dofh.locally_owned_dofs();
+      dof_set      = DoFTools::extract_locally_active_dofs(dofh);
+      relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
 
       x.reinit(owned_set, MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_2d_constraintmatrix_05.cc
+++ b/tests/mpi/p4est_2d_constraintmatrix_05.cc
@@ -56,10 +56,8 @@ test()
 
   dofh.distribute_dofs(fe);
 
-  IndexSet owned_set = dofh.locally_owned_dofs();
-
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
+  const IndexSet &owned_set    = dofh.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
 
   TrilinosWrappers::MPI::Vector x_ref;
   x_ref.reinit(owned_set, MPI_COMM_WORLD);

--- a/tests/mpi/p4est_2d_dofhandler_04.cc
+++ b/tests/mpi/p4est_2d_dofhandler_04.cc
@@ -100,8 +100,7 @@ test()
                   << dofh.n_locally_owned_dofs() << std::endl;
         }
 
-      IndexSet dof_set;
-      DoFTools::extract_locally_active_dofs<>(dofh, dof_set);
+      const IndexSet dof_set = DoFTools::extract_locally_active_dofs<>(dofh);
       std::set<unsigned int> control_dof_set;
 
       typename DoFHandler<dim>::active_cell_iterator cell = dofh.begin_active();

--- a/tests/mpi/p4est_2d_renumber_01.cc
+++ b/tests/mpi/p4est_2d_renumber_01.cc
@@ -61,8 +61,7 @@ test()
     dofh.distribute_dofs(fe);
 
     {
-      IndexSet dof_set;
-      DoFTools::extract_locally_active_dofs(dofh, dof_set);
+      const IndexSet dof_set = DoFTools::extract_locally_active_dofs(dofh);
       if (myid == 0)
         dof_set.print(deallog);
     }
@@ -76,8 +75,7 @@ test()
     // correct. This was a bug at some point.
     Assert(n_dofs == dofh.n_dofs(), ExcInternalError());
     {
-      IndexSet dof_set;
-      DoFTools::extract_locally_active_dofs(dofh, dof_set);
+      const IndexSet dof_set = DoFTools::extract_locally_active_dofs(dofh);
 
       if (myid == 0)
         dof_set.print(deallog);

--- a/tests/mpi/p4est_2d_renumber_02.cc
+++ b/tests/mpi/p4est_2d_renumber_02.cc
@@ -66,8 +66,7 @@ test()
     deallog << "Total dofs=" << dofh.n_dofs() << std::endl;
 
   {
-    IndexSet dof_set;
-    DoFTools::extract_locally_active_dofs(dofh, dof_set);
+    const IndexSet dof_set = DoFTools::extract_locally_active_dofs(dofh);
     if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
       dof_set.print(deallog);
   }
@@ -77,8 +76,7 @@ test()
 
   DoFRenumbering::component_wise(dofh);
   {
-    IndexSet dof_set;
-    DoFTools::extract_locally_active_dofs(dofh, dof_set);
+    const IndexSet dof_set = DoFTools::extract_locally_active_dofs(dofh);
 
     const std::vector<IndexSet> owned_dofs =
       Utilities::MPI::all_gather(MPI_COMM_WORLD, dofh.locally_owned_dofs());

--- a/tests/mpi/p4est_3d_constraintmatrix_01.cc
+++ b/tests/mpi/p4est_3d_constraintmatrix_01.cc
@@ -71,8 +71,7 @@ test()
   static const FE_Q<dim> fe(1);
   dofh.distribute_dofs(fe);
 
-  IndexSet dof_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, dof_set);
+  const IndexSet dof_set = DoFTools::extract_locally_relevant_dofs(dofh);
 
   AffineConstraints<double> cm;
   DoFTools::make_hanging_node_constraints(dofh, cm);

--- a/tests/mpi/p4est_3d_constraintmatrix_02.cc
+++ b/tests/mpi/p4est_3d_constraintmatrix_02.cc
@@ -72,13 +72,9 @@ test()
   static const FE_Q<dim> fe(1);
   dofh.distribute_dofs(fe);
 
-  IndexSet owned_set = dofh.locally_owned_dofs();
-
-  IndexSet dof_set;
-  DoFTools::extract_locally_active_dofs(dofh, dof_set);
-
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
+  const IndexSet &owned_set    = dofh.locally_owned_dofs();
+  const IndexSet  dof_set      = DoFTools::extract_locally_active_dofs(dofh);
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
 
   TrilinosWrappers::MPI::Vector x;
   x.reinit(owned_set, MPI_COMM_WORLD);

--- a/tests/mpi/p4est_3d_constraintmatrix_03.cc
+++ b/tests/mpi/p4est_3d_constraintmatrix_03.cc
@@ -130,13 +130,9 @@ test()
 
   dofh.distribute_dofs(fe);
 
-  IndexSet owned_set = dofh.locally_owned_dofs();
-
-  IndexSet dof_set;
-  DoFTools::extract_locally_active_dofs(dofh, dof_set);
-
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
+  IndexSet owned_set    = dofh.locally_owned_dofs();
+  IndexSet dof_set      = DoFTools::extract_locally_active_dofs(dofh);
+  IndexSet relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
 
   TrilinosWrappers::MPI::Vector x;
   x.reinit(owned_set, MPI_COMM_WORLD);
@@ -203,11 +199,9 @@ test()
 
       dofh.distribute_dofs(fe);
 
-      owned_set = dofh.locally_owned_dofs();
-
-      DoFTools::extract_locally_active_dofs(dofh, dof_set);
-
-      DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
+      owned_set    = dofh.locally_owned_dofs();
+      dof_set      = DoFTools::extract_locally_active_dofs(dofh);
+      relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
 
       x.reinit(owned_set, MPI_COMM_WORLD);
 

--- a/tests/mpi/p4est_3d_constraintmatrix_04.cc
+++ b/tests/mpi/p4est_3d_constraintmatrix_04.cc
@@ -67,8 +67,8 @@ test()
   dof.distribute_dofs(fe);
 
   // build constraint matrix
-  IndexSet locally_relevant(dof.n_dofs());
-  DoFTools::extract_locally_relevant_dofs(dof, locally_relevant);
+  const IndexSet locally_relevant =
+    DoFTools::extract_locally_relevant_dofs(dof);
   AffineConstraints<double> constraints(locally_relevant);
   DoFTools::make_hanging_node_constraints(dof, constraints);
   constraints.close();
@@ -78,9 +78,8 @@ test()
   const unsigned int myid    = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
   const unsigned int numproc = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
 
-  IndexSet locally_active(dof.n_dofs());
-  DoFTools::extract_locally_active_dofs(dof, locally_active);
-  std::ofstream file(
+  const IndexSet locally_active = DoFTools::extract_locally_active_dofs(dof);
+  std::ofstream  file(
     (std::string("dat.") + Utilities::int_to_string(myid)).c_str());
   file << "**** proc " << myid << ": \n\n";
   file << "Constraints:\n";

--- a/tests/mpi/p4est_save_02.cc
+++ b/tests/mpi/p4est_save_02.cc
@@ -73,10 +73,9 @@ test()
 
     dh.distribute_dofs(fe);
 
-    IndexSet locally_owned_dofs = dh.locally_owned_dofs();
-    IndexSet locally_relevant_dofs;
-
-    DoFTools::extract_locally_relevant_dofs(dh, locally_relevant_dofs);
+    const IndexSet &locally_owned_dofs = dh.locally_owned_dofs();
+    const IndexSet  locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dh);
 
     PETScWrappers::MPI::Vector x(locally_owned_dofs, MPI_COMM_WORLD);
     PETScWrappers::MPI::Vector solution(locally_owned_dofs,
@@ -120,10 +119,9 @@ test()
 
     dh.distribute_dofs(fe);
 
-    IndexSet locally_owned_dofs = dh.locally_owned_dofs();
-    IndexSet locally_relevant_dofs;
-
-    DoFTools::extract_locally_relevant_dofs(dh, locally_relevant_dofs);
+    const IndexSet &locally_owned_dofs = dh.locally_owned_dofs();
+    const IndexSet  locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dh);
 
     PETScWrappers::MPI::Vector solution(locally_owned_dofs, MPI_COMM_WORLD);
     parallel::distributed::SolutionTransfer<dim, PETScWrappers::MPI::Vector>

--- a/tests/mpi/p4est_save_03.cc
+++ b/tests/mpi/p4est_save_03.cc
@@ -74,10 +74,9 @@ test()
 
     dh.distribute_dofs(fe);
 
-    IndexSet locally_owned_dofs = dh.locally_owned_dofs();
-    IndexSet locally_relevant_dofs;
-
-    DoFTools::extract_locally_relevant_dofs(dh, locally_relevant_dofs);
+    const IndexSet &locally_owned_dofs = dh.locally_owned_dofs();
+    const IndexSet  locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dh);
 
     PETScWrappers::MPI::Vector x(locally_owned_dofs, MPI_COMM_WORLD);
     PETScWrappers::MPI::Vector x2(locally_owned_dofs, MPI_COMM_WORLD);
@@ -132,10 +131,9 @@ test()
 
     dh.distribute_dofs(fe);
 
-    IndexSet locally_owned_dofs = dh.locally_owned_dofs();
-    IndexSet locally_relevant_dofs;
-
-    DoFTools::extract_locally_relevant_dofs(dh, locally_relevant_dofs);
+    const IndexSet &locally_owned_dofs = dh.locally_owned_dofs();
+    const IndexSet  locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dh);
 
     PETScWrappers::MPI::Vector solution(locally_owned_dofs, MPI_COMM_WORLD);
     PETScWrappers::MPI::Vector solution2(locally_owned_dofs, MPI_COMM_WORLD);

--- a/tests/mpi/p4est_save_04.cc
+++ b/tests/mpi/p4est_save_04.cc
@@ -76,9 +76,9 @@ test()
       DoFHandler<dim> dh(tr);
       dh.distribute_dofs(fe);
 
-      IndexSet locally_owned_dofs = dh.locally_owned_dofs();
-      IndexSet locally_relevant_dofs;
-      DoFTools::extract_locally_relevant_dofs(dh, locally_relevant_dofs);
+      const IndexSet &locally_owned_dofs = dh.locally_owned_dofs();
+      const IndexSet  locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(dh);
 
       PETScWrappers::MPI::Vector x(locally_owned_dofs, com_small);
       PETScWrappers::MPI::Vector rel_x(locally_owned_dofs,
@@ -123,10 +123,9 @@ test()
     DoFHandler<dim> dh(tr);
     dh.distribute_dofs(fe);
 
-    IndexSet locally_owned_dofs = dh.locally_owned_dofs();
-    IndexSet locally_relevant_dofs;
-
-    DoFTools::extract_locally_relevant_dofs(dh, locally_relevant_dofs);
+    const IndexSet &locally_owned_dofs = dh.locally_owned_dofs();
+    const IndexSet  locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dh);
 
     PETScWrappers::MPI::Vector solution(locally_owned_dofs, com_all);
     solution = PetscScalar();

--- a/tests/mpi/p4est_save_06.cc
+++ b/tests/mpi/p4est_save_06.cc
@@ -83,9 +83,9 @@ test()
 
       dh.distribute_dofs(fe_collection);
 
-      IndexSet locally_owned_dofs = dh.locally_owned_dofs();
-      IndexSet locally_relevant_dofs;
-      DoFTools::extract_locally_relevant_dofs(dh, locally_relevant_dofs);
+      const IndexSet &locally_owned_dofs = dh.locally_owned_dofs();
+      const IndexSet  locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(dh);
 
       PETScWrappers::MPI::Vector x(locally_owned_dofs, com_small);
       PETScWrappers::MPI::Vector rel_x(locally_owned_dofs,
@@ -137,10 +137,9 @@ test()
     dh.deserialize_active_fe_indices();
     dh.distribute_dofs(fe_collection);
 
-    IndexSet locally_owned_dofs = dh.locally_owned_dofs();
-    IndexSet locally_relevant_dofs;
-
-    DoFTools::extract_locally_relevant_dofs(dh, locally_relevant_dofs);
+    const IndexSet &locally_owned_dofs = dh.locally_owned_dofs();
+    const IndexSet  locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dh);
 
     PETScWrappers::MPI::Vector solution(locally_owned_dofs, com_all);
     solution = PetscScalar();

--- a/tests/mpi/parallel_block_vector_05.cc
+++ b/tests/mpi/parallel_block_vector_05.cc
@@ -87,9 +87,8 @@ test(const unsigned int n_blocks = 5)
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/mpi/parallel_block_vector_06.cc
+++ b/tests/mpi/parallel_block_vector_06.cc
@@ -89,9 +89,8 @@ test(const unsigned int n_blocks = 5)
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/mpi/parallel_block_vector_07.cc
+++ b/tests/mpi/parallel_block_vector_07.cc
@@ -87,9 +87,8 @@ test(const unsigned int n_blocks = 5)
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/mpi/parallel_block_vector_08.cc
+++ b/tests/mpi/parallel_block_vector_08.cc
@@ -87,9 +87,8 @@ test(const unsigned int n_blocks = 5)
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/mpi/parallel_block_vector_09.cc
+++ b/tests/mpi/parallel_block_vector_09.cc
@@ -90,9 +90,8 @@ test(const unsigned int n_blocks = 5)
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/mpi/parallel_block_vector_10.cc
+++ b/tests/mpi/parallel_block_vector_10.cc
@@ -86,9 +86,8 @@ test(const unsigned int n_blocks = 5)
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/mpi/parallel_block_vector_11.cc
+++ b/tests/mpi/parallel_block_vector_11.cc
@@ -88,9 +88,8 @@ test(const unsigned int n_blocks = 5)
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/mpi/parallel_block_vector_12.cc
+++ b/tests/mpi/parallel_block_vector_12.cc
@@ -88,9 +88,8 @@ test(const unsigned int n = 5, const unsigned int m = 3)
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
 
-  IndexSet owned_set = dof.locally_owned_dofs();
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+  const IndexSet &owned_set    = dof.locally_owned_dofs();
+  const IndexSet  relevant_set = DoFTools::extract_locally_relevant_dofs(dof);
 
   AffineConstraints<double> constraints(relevant_set);
   DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/mpi/parallel_vector_back_interpolate.cc
+++ b/tests/mpi/parallel_vector_back_interpolate.cc
@@ -62,8 +62,8 @@ test()
   DoFTools::make_hanging_node_constraints(dof2, c2);
   c2.close();
 
-  IndexSet locally_relevant_dofs2;
-  DoFTools::extract_locally_relevant_dofs(dof2, locally_relevant_dofs2);
+  const IndexSet locally_relevant_dofs2 =
+    DoFTools::extract_locally_relevant_dofs(dof2);
 
   LinearAlgebra::distributed::Vector<double> v2(dof2.locally_owned_dofs(),
                                                 locally_relevant_dofs2,

--- a/tests/mpi/parallel_vector_back_interpolate_02.cc
+++ b/tests/mpi/parallel_vector_back_interpolate_02.cc
@@ -64,9 +64,9 @@ test()
   DoFRenumbering::component_wise(dof1);
   DoFRenumbering::component_wise(dof2);
 
-  IndexSet locally_owned_dofs1 = dof1.locally_owned_dofs();
-  IndexSet locally_relevant_dofs1;
-  DoFTools::extract_locally_relevant_dofs(dof1, locally_relevant_dofs1);
+  const IndexSet locally_owned_dofs1 = dof1.locally_owned_dofs();
+  const IndexSet locally_relevant_dofs1 =
+    DoFTools::extract_locally_relevant_dofs(dof1);
 
   std::vector<IndexSet> owned_partitioning1;
   std::vector<IndexSet> relevant_partitioning1;

--- a/tests/mpi/parallel_vector_interpolate.cc
+++ b/tests/mpi/parallel_vector_interpolate.cc
@@ -54,9 +54,10 @@ test()
   dof1.distribute_dofs(fe1);
   dof2.distribute_dofs(fe2);
 
-  IndexSet locally_relevant_dofs1, locally_relevant_dofs2;
-  DoFTools::extract_locally_relevant_dofs(dof1, locally_relevant_dofs1);
-  DoFTools::extract_locally_relevant_dofs(dof2, locally_relevant_dofs2);
+  const IndexSet locally_relevant_dofs1 =
+    DoFTools::extract_locally_relevant_dofs(dof1);
+  const IndexSet locally_relevant_dofs2 =
+    DoFTools::extract_locally_relevant_dofs(dof2);
 
   LinearAlgebra::distributed::Vector<double> v1(dof1.locally_owned_dofs(),
                                                 locally_relevant_dofs1,

--- a/tests/mpi/periodicity_01.cc
+++ b/tests/mpi/periodicity_01.cc
@@ -139,7 +139,8 @@ namespace Step40
     dof_handler.distribute_dofs(fe);
 
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
     locally_relevant_solution.reinit(locally_owned_dofs,
                                      locally_relevant_dofs,
                                      mpi_communicator);
@@ -168,8 +169,8 @@ namespace Step40
     const std::vector<IndexSet> &locally_owned_dofs =
       Utilities::MPI::all_gather(MPI_COMM_WORLD,
                                  dof_handler.locally_owned_dofs());
-    IndexSet locally_active_dofs;
-    DoFTools::extract_locally_active_dofs(dof_handler, locally_active_dofs);
+    const IndexSet locally_active_dofs =
+      DoFTools::extract_locally_active_dofs(dof_handler);
     AssertThrow(constraints.is_consistent_in_parallel(locally_owned_dofs,
                                                       locally_active_dofs,
                                                       mpi_communicator,

--- a/tests/mpi/periodicity_02.cc
+++ b/tests/mpi/periodicity_02.cc
@@ -332,9 +332,8 @@ namespace Step22
       owned_partitioning.push_back(locally_owned_dofs.get_view(n_u, n_u + n_p));
 
       relevant_partitioning.clear();
-      IndexSet locally_relevant_dofs;
-      DoFTools::extract_locally_relevant_dofs(dof_handler,
-                                              locally_relevant_dofs);
+      const IndexSet locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(dof_handler);
       relevant_partitioning.push_back(locally_relevant_dofs.get_view(0, n_u));
       relevant_partitioning.push_back(
         locally_relevant_dofs.get_view(n_u, n_u + n_p));
@@ -394,8 +393,8 @@ namespace Step22
     const std::vector<IndexSet> &locally_owned_dofs =
       Utilities::MPI::all_gather(MPI_COMM_WORLD,
                                  dof_handler.locally_owned_dofs());
-    IndexSet locally_active_dofs;
-    DoFTools::extract_locally_active_dofs(dof_handler, locally_active_dofs);
+    const IndexSet locally_active_dofs =
+      DoFTools::extract_locally_active_dofs(dof_handler);
     AssertThrow(constraints.is_consistent_in_parallel(locally_owned_dofs,
                                                       locally_active_dofs,
                                                       mpi_communicator,

--- a/tests/mpi/periodicity_03.cc
+++ b/tests/mpi/periodicity_03.cc
@@ -260,9 +260,8 @@ namespace Step22
       owned_partitioning.push_back(locally_owned_dofs.get_view(n_u, n_u + n_p));
 
       relevant_partitioning.clear();
-      IndexSet locally_relevant_dofs;
-      DoFTools::extract_locally_relevant_dofs(dof_handler,
-                                              locally_relevant_dofs);
+      const IndexSet locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(dof_handler);
       relevant_partitioning.push_back(locally_relevant_dofs.get_view(0, n_u));
       relevant_partitioning.push_back(
         locally_relevant_dofs.get_view(n_u, n_u + n_p));
@@ -324,8 +323,8 @@ namespace Step22
     const std::vector<IndexSet> &locally_owned_dofs =
       Utilities::MPI::all_gather(MPI_COMM_WORLD,
                                  dof_handler.locally_owned_dofs());
-    IndexSet locally_active_dofs;
-    DoFTools::extract_locally_active_dofs(dof_handler, locally_active_dofs);
+    const IndexSet locally_active_dofs =
+      DoFTools::extract_locally_active_dofs(dof_handler);
     AssertThrow(constraints.is_consistent_in_parallel(locally_owned_dofs,
                                                       locally_active_dofs,
                                                       mpi_communicator,

--- a/tests/mpi/periodicity_04.cc
+++ b/tests/mpi/periodicity_04.cc
@@ -185,9 +185,9 @@ check(const unsigned int orientation, bool reverse)
 
   AffineConstraints<double> constraints;
 
-  IndexSet locally_owned_dofs = dof_handler.locally_owned_dofs();
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet &locally_owned_dofs = dof_handler.locally_owned_dofs();
+  const IndexSet  locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   constraints.reinit(locally_relevant_dofs);
   {
@@ -209,8 +209,8 @@ check(const unsigned int orientation, bool reverse)
   const std::vector<IndexSet> locally_owned_dofs_vector =
     Utilities::MPI::all_gather(MPI_COMM_WORLD,
                                dof_handler.locally_owned_dofs());
-  IndexSet locally_active_dofs;
-  DoFTools::extract_locally_active_dofs(dof_handler, locally_active_dofs);
+  const IndexSet locally_active_dofs =
+    DoFTools::extract_locally_active_dofs(dof_handler);
   AssertThrow(constraints.is_consistent_in_parallel(locally_owned_dofs_vector,
                                                     locally_active_dofs,
                                                     MPI_COMM_WORLD,

--- a/tests/mpi/periodicity_06.cc
+++ b/tests/mpi/periodicity_06.cc
@@ -160,8 +160,8 @@ test(const unsigned numRefinementLevels = 2)
   data_out.write_vtu_in_parallel(std::string("mesh.vtu").c_str(),
                                  mpi_communicator);
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   std::map<types::global_dof_index, Point<dim>> supportPoints;
   DoFTools::map_dofs_to_support_points(MappingQ1<dim>(),
@@ -190,8 +190,8 @@ test(const unsigned numRefinementLevels = 2)
   const std::vector<IndexSet> &locally_owned_dofs =
     Utilities::MPI::all_gather(MPI_COMM_WORLD,
                                dof_handler.locally_owned_dofs());
-  IndexSet locally_active_dofs;
-  DoFTools::extract_locally_active_dofs(dof_handler, locally_active_dofs);
+  const IndexSet locally_active_dofs =
+    DoFTools::extract_locally_active_dofs(dof_handler);
   AssertThrow(constraints.is_consistent_in_parallel(locally_owned_dofs,
                                                     locally_active_dofs,
                                                     mpi_communicator,

--- a/tests/mpi/periodicity_07.cc
+++ b/tests/mpi/periodicity_07.cc
@@ -132,11 +132,10 @@ test(const unsigned numRefinementLevels = 2)
   data_out.write_vtu_in_parallel(std::string("mesh.vtu").c_str(),
                                  mpi_communicator);
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
-
-  IndexSet locally_active_dofs;
-  DoFTools::extract_locally_active_dofs(dof_handler, locally_active_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
+  const IndexSet locally_active_dofs =
+    DoFTools::extract_locally_active_dofs(dof_handler);
 
   const std::vector<IndexSet> locally_owned_dofs =
     Utilities::MPI::all_gather(MPI_COMM_WORLD,

--- a/tests/mpi/periodicity_08.cc
+++ b/tests/mpi/periodicity_08.cc
@@ -126,11 +126,10 @@ test()
   data_out.write_vtu_in_parallel(std::string("mesh.vtu").c_str(),
                                  mpi_communicator);
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
-
-  IndexSet locally_active_dofs;
-  DoFTools::extract_locally_active_dofs(dof_handler, locally_active_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
+  const IndexSet locally_active_dofs =
+    DoFTools::extract_locally_active_dofs(dof_handler);
 
   const std::vector<IndexSet> locally_owned_dofs =
     Utilities::MPI::all_gather(MPI_COMM_WORLD,

--- a/tests/mpi/petsc_bug_ghost_vector_01.cc
+++ b/tests/mpi/petsc_bug_ghost_vector_01.cc
@@ -222,9 +222,9 @@ test()
     DoFHandler<2> handler(fluid_triangulation);
     handler.distribute_dofs(fe);
 
-    IndexSet locally_owned_dofs    = handler.locally_owned_dofs();
-    IndexSet locally_relevant_dofs = handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(handler, locally_relevant_dofs);
+    const IndexSet &locally_owned_dofs = handler.locally_owned_dofs();
+    const IndexSet  locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(handler);
 
 
     PETScWrappers::MPI::Vector vector;

--- a/tests/mpi/petsc_step-27.cc
+++ b/tests/mpi/petsc_step-27.cc
@@ -207,7 +207,8 @@ namespace Step27
     dof_handler.distribute_dofs(fe_collection);
 
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     solution.reinit(locally_owned_dofs,
                     locally_relevant_dofs,
@@ -228,8 +229,8 @@ namespace Step27
       Utilities::MPI::all_gather(dof_handler.get_communicator(),
                                  dof_handler.locally_owned_dofs());
 
-    IndexSet locally_active_dofs;
-    DoFTools::extract_locally_active_dofs(dof_handler, locally_active_dofs);
+    const IndexSet locally_active_dofs =
+      DoFTools::extract_locally_active_dofs(dof_handler);
 
     AssertThrow(
       constraints.is_consistent_in_parallel(locally_owned_dofs_per_processor,

--- a/tests/mpi/project_bv_div_conf.cc
+++ b/tests/mpi/project_bv_div_conf.cc
@@ -186,8 +186,8 @@ namespace ResFlow
           << owned_partitioning[1].n_elements() << ')' << std::endl
           << std::endl;
 
-    IndexSet locally_relevant_dofs;
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    const IndexSet locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
     relevant_partitioning.resize(2);
     relevant_partitioning[0] = locally_relevant_dofs.get_view(0, n_u);
     relevant_partitioning[1] = locally_relevant_dofs.get_view(n_u, n_u + n_p);

--- a/tests/mpi/solution_transfer_01.cc
+++ b/tests/mpi/solution_transfer_01.cc
@@ -66,10 +66,8 @@ test()
 
   dh.distribute_dofs(fe);
 
-  IndexSet locally_owned_dofs = dh.locally_owned_dofs();
-  IndexSet locally_relevant_dofs;
-
-  DoFTools::extract_locally_relevant_dofs(dh, locally_relevant_dofs);
+  IndexSet locally_owned_dofs    = dh.locally_owned_dofs();
+  IndexSet locally_relevant_dofs = DoFTools::extract_locally_relevant_dofs(dh);
 
   PETScWrappers::MPI::Vector solution(locally_owned_dofs,
                                       locally_relevant_dofs,
@@ -87,8 +85,8 @@ test()
   tria.execute_coarsening_and_refinement();
 
   dh.distribute_dofs(fe);
-  locally_owned_dofs = dh.locally_owned_dofs();
-  DoFTools::extract_locally_relevant_dofs(dh, locally_relevant_dofs);
+  locally_owned_dofs    = dh.locally_owned_dofs();
+  locally_relevant_dofs = DoFTools::extract_locally_relevant_dofs(dh);
 
   PETScWrappers::MPI::Vector tmp(locally_owned_dofs, MPI_COMM_WORLD);
 

--- a/tests/mpi/solution_transfer_04.cc
+++ b/tests/mpi/solution_transfer_04.cc
@@ -81,9 +81,8 @@ test()
 
   // ----- prepare solution -----
   dh.distribute_dofs(fe_collection);
-  IndexSet locally_owned_dofs = dh.locally_owned_dofs();
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dh, locally_relevant_dofs);
+  IndexSet locally_owned_dofs    = dh.locally_owned_dofs();
+  IndexSet locally_relevant_dofs = DoFTools::extract_locally_relevant_dofs(dh);
 
   TrilinosWrappers::MPI::Vector solution;
   solution.reinit(locally_owned_dofs, MPI_COMM_WORLD);
@@ -106,8 +105,8 @@ test()
   tria.execute_coarsening_and_refinement();
 
   dh.distribute_dofs(fe_collection);
-  locally_owned_dofs = dh.locally_owned_dofs();
-  DoFTools::extract_locally_relevant_dofs(dh, locally_relevant_dofs);
+  locally_owned_dofs    = dh.locally_owned_dofs();
+  locally_relevant_dofs = DoFTools::extract_locally_relevant_dofs(dh);
 
   TrilinosWrappers::MPI::Vector new_solution;
   new_solution.reinit(locally_owned_dofs, MPI_COMM_WORLD);

--- a/tests/mpi/solution_transfer_05.cc
+++ b/tests/mpi/solution_transfer_05.cc
@@ -69,9 +69,8 @@ test()
 
   // prepare index sets
   IndexSet dgq_locally_owned_dofs = dgq_dof_handler.locally_owned_dofs();
-  IndexSet dgq_locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dgq_dof_handler,
-                                          dgq_locally_relevant_dofs);
+  IndexSet dgq_locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dgq_dof_handler);
   IndexSet dgq_ghost_dofs = dgq_locally_relevant_dofs;
   dgq_ghost_dofs.subtract_set(dgq_locally_owned_dofs);
 
@@ -108,8 +107,8 @@ test()
 
   // prepare index sets
   dgq_locally_owned_dofs = dgq_dof_handler.locally_owned_dofs();
-  DoFTools::extract_locally_relevant_dofs(dgq_dof_handler,
-                                          dgq_locally_relevant_dofs);
+  dgq_locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dgq_dof_handler);
   dgq_ghost_dofs = dgq_locally_relevant_dofs;
   dgq_ghost_dofs.subtract_set(dgq_locally_owned_dofs);
 

--- a/tests/mpi/solution_transfer_06.cc
+++ b/tests/mpi/solution_transfer_06.cc
@@ -63,8 +63,8 @@ transfer(const MPI_Comm comm)
   DoFHandler<dim> dof_handler(tria);
   dof_handler.begin(0)->child(0)->set_active_fe_index(1);
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   LinearAlgebra::distributed::Vector<double> solution(
     dof_handler.locally_owned_dofs(), locally_relevant_dofs, comm);

--- a/tests/mpi/step-37.cc
+++ b/tests/mpi/step-37.cc
@@ -180,9 +180,8 @@ namespace Step37
 
     dof_euler.distribute_dofs(fe_system);
     {
-      IndexSet locally_relevant_euler;
-      DoFTools::extract_locally_relevant_dofs(dof_euler,
-                                              locally_relevant_euler);
+      const IndexSet locally_relevant_euler =
+        DoFTools::extract_locally_relevant_dofs(dof_euler);
       euler_positions.reinit(dof_euler.locally_owned_dofs(),
                              locally_relevant_euler,
                              MPI_COMM_WORLD);
@@ -209,7 +208,8 @@ namespace Step37
     pcout << "Number of degrees of freedom: " << dof_handler.n_dofs()
           << std::endl;
 
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     constraints.clear();
     constraints.reinit(locally_relevant_dofs);
@@ -251,10 +251,8 @@ namespace Step37
 
     for (unsigned int level = 0; level < nlevels; ++level)
       {
-        IndexSet relevant_dofs;
-        DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                      level,
-                                                      relevant_dofs);
+        const IndexSet relevant_dofs =
+          DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
         AffineConstraints<double> level_constraints;
         level_constraints.reinit(relevant_dofs);
         level_constraints.add_lines(

--- a/tests/mpi/step-39-block.cc
+++ b/tests/mpi/step-39-block.cc
@@ -462,7 +462,7 @@ namespace Step39
     dof_handler.distribute_dofs(fe);
     dof_handler.distribute_mg_dofs();
 
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_set);
+    locally_relevant_set = DoFTools::extract_locally_relevant_dofs(dof_handler);
     solution.reinit(dof_handler.locally_owned_dofs(), MPI_COMM_WORLD);
     right_hand_side.reinit(dof_handler.locally_owned_dofs(), MPI_COMM_WORLD);
 
@@ -665,10 +665,8 @@ namespace Step39
         smoother_data[l].relaxation = 0.7;
         smoother_data[l].inversion  = PreconditionBlockBase<double>::svd;
         TrilinosWrappers::MPI::Vector *ghost = &(temp_vectors[l]);
-        IndexSet                       relevant_dofs;
-        DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                      l,
-                                                      relevant_dofs);
+        const IndexSet                 relevant_dofs =
+          DoFTools::extract_locally_relevant_level_dofs(dof_handler, l);
         ghost->reinit(dof_handler.locally_owned_mg_dofs(l),
                       relevant_dofs,
                       MPI_COMM_WORLD);

--- a/tests/mpi/step-39.cc
+++ b/tests/mpi/step-39.cc
@@ -463,7 +463,7 @@ namespace Step39
     dof_handler.distribute_dofs(fe);
     dof_handler.distribute_mg_dofs();
 
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_set);
+    locally_relevant_set = DoFTools::extract_locally_relevant_dofs(dof_handler);
     solution.reinit(dof_handler.locally_owned_dofs(), MPI_COMM_WORLD);
     right_hand_side.reinit(dof_handler.locally_owned_dofs(), MPI_COMM_WORLD);
 

--- a/tests/mpi/step-40.cc
+++ b/tests/mpi/step-40.cc
@@ -131,7 +131,8 @@ namespace Step40
     dof_handler.distribute_dofs(fe);
 
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     locally_relevant_solution.reinit(locally_owned_dofs,
                                      locally_relevant_dofs,

--- a/tests/mpi/step-40_cuthill_mckee.cc
+++ b/tests/mpi/step-40_cuthill_mckee.cc
@@ -135,7 +135,8 @@ namespace Step40
   {
     dof_handler.distribute_dofs(fe);
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     {
       std::vector<types::global_dof_index> starting_indices;
@@ -191,8 +192,8 @@ namespace Step40
       DoFRenumbering::Cuthill_McKee(dof_handler, false, true, starting_indices);
 
       locally_owned_dofs = dof_handler.locally_owned_dofs();
-      DoFTools::extract_locally_relevant_dofs(dof_handler,
-                                              locally_relevant_dofs);
+      locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(dof_handler);
     }
 
     locally_relevant_solution.reinit(locally_owned_dofs,

--- a/tests/mpi/step-40_cuthill_mckee_MPI-subset.cc
+++ b/tests/mpi/step-40_cuthill_mckee_MPI-subset.cc
@@ -136,7 +136,8 @@ namespace Step40
   {
     dof_handler.distribute_dofs(fe);
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     {
       std::vector<types::global_dof_index> starting_indices;
@@ -192,8 +193,8 @@ namespace Step40
       DoFRenumbering::Cuthill_McKee(dof_handler, false, true, starting_indices);
 
       locally_owned_dofs = dof_handler.locally_owned_dofs();
-      DoFTools::extract_locally_relevant_dofs(dof_handler,
-                                              locally_relevant_dofs);
+      locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(dof_handler);
     }
 
     locally_relevant_solution.reinit(locally_owned_dofs,

--- a/tests/mpi/step-40_direct_solver.cc
+++ b/tests/mpi/step-40_direct_solver.cc
@@ -131,7 +131,8 @@ namespace Step40
     dof_handler.distribute_dofs(fe);
 
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     locally_relevant_solution.reinit(locally_owned_dofs,
                                      locally_relevant_dofs,

--- a/tests/mpi/trilinos_distribute_04.cc
+++ b/tests/mpi/trilinos_distribute_04.cc
@@ -90,8 +90,8 @@ test()
   DoFHandler<dim> dofh(tr);
   dofh.distribute_dofs(fe);
 
-  IndexSet locally_relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, locally_relevant_set);
+  const IndexSet locally_relevant_set =
+    DoFTools::extract_locally_relevant_dofs(dofh);
 
   AffineConstraints<double> cm;
   cm.reinit(locally_relevant_set);

--- a/tests/mpi/trilinos_step-27.cc
+++ b/tests/mpi/trilinos_step-27.cc
@@ -211,7 +211,8 @@ namespace Step27
     dof_handler.distribute_dofs(fe_collection);
 
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     solution.reinit(locally_owned_dofs,
                     locally_relevant_dofs,
@@ -232,8 +233,8 @@ namespace Step27
       Utilities::MPI::all_gather(dof_handler.get_communicator(),
                                  dof_handler.locally_owned_dofs());
 
-    IndexSet locally_active_dofs;
-    DoFTools::extract_locally_active_dofs(dof_handler, locally_active_dofs);
+    const IndexSet locally_active_dofs =
+      DoFTools::extract_locally_active_dofs(dof_handler);
 
     AssertThrow(
       constraints.is_consistent_in_parallel(locally_owned_dofs_per_processor,

--- a/tests/multigrid-global-coarsening/interpolate_to_mg.cc
+++ b/tests/multigrid-global-coarsening/interpolate_to_mg.cc
@@ -126,9 +126,9 @@ test(const unsigned int n_glob_ref = 2, const unsigned int n_ref = 0)
   dof_handler.distribute_dofs(fe);
   dof_handler.distribute_mg_dofs();
 
-  IndexSet locally_owned_dofs, locally_relevant_dofs;
-  locally_owned_dofs = dof_handler.locally_owned_dofs();
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet &locally_owned_dofs = dof_handler.locally_owned_dofs();
+  const IndexSet  locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   // constraints:
   AffineConstraints<double> constraints;
@@ -191,8 +191,8 @@ test(const unsigned int n_glob_ref = 2, const unsigned int n_ref = 0)
     level_projection(min_level, max_level);
   for (unsigned int level = min_level; level <= max_level; ++level)
     {
-      IndexSet set;
-      DoFTools::extract_locally_relevant_level_dofs(dof_handler, level, set);
+      const IndexSet set =
+        DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
       level_projection[level].reinit(dof_handler.locally_owned_mg_dofs(level),
                                      set,
                                      mpi_communicator);

--- a/tests/multigrid-global-coarsening/interpolate_to_mg_01.cc
+++ b/tests/multigrid-global-coarsening/interpolate_to_mg_01.cc
@@ -80,8 +80,8 @@ test()
   dof_handler.distribute_dofs(fe);
   dof_handler.distribute_mg_dofs();
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   AffineConstraints<double> constraints;
   constraints.reinit(locally_relevant_dofs);

--- a/tests/multigrid-global-coarsening/mg_data_out_04.cc
+++ b/tests/multigrid-global-coarsening/mg_data_out_04.cc
@@ -55,8 +55,8 @@ do_test()
   dof_handler.distribute_mg_dofs();
 
   // Make FE vector
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   using VectorType = LinearAlgebra::distributed::Vector<double>;
   VectorType global_dof_vector;

--- a/tests/multigrid-global-coarsening/mg_data_out_05.cc
+++ b/tests/multigrid-global-coarsening/mg_data_out_05.cc
@@ -59,8 +59,8 @@ do_test()
   dof_handler.distribute_mg_dofs();
 
   // Make FE vector
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   using VectorType = LinearAlgebra::distributed::Vector<double>;
   VectorType global_dof_vector;

--- a/tests/multigrid-global-coarsening/mg_transfer_util.h
+++ b/tests/multigrid-global-coarsening/mg_transfer_util.h
@@ -35,11 +35,11 @@ initialize_dof_vector(LinearAlgebra::distributed::Vector<Number> &vec,
 {
   IndexSet locally_relevant_dofs;
   if (level == numbers::invalid_unsigned_int)
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
   else
-    DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                  level,
-                                                  locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
 
 
   const parallel::TriangulationBase<MeshType::dimension> *dist_tria =

--- a/tests/multigrid-global-coarsening/multigrid_a_01.cc
+++ b/tests/multigrid-global-coarsening/multigrid_a_01.cc
@@ -81,9 +81,8 @@ test(const unsigned int n_refinements,
       dof_handler.distribute_dofs(*fe);
 
       // set up constraints
-      IndexSet locally_relevant_dofs;
-      DoFTools::extract_locally_relevant_dofs(dof_handler,
-                                              locally_relevant_dofs);
+      const IndexSet locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(dof_handler);
       constraint.reinit(locally_relevant_dofs);
       VectorTools::interpolate_boundary_values(
         *mapping, dof_handler, 0, Functions::ZeroFunction<dim>(), constraint);

--- a/tests/multigrid-global-coarsening/multigrid_a_02.cc
+++ b/tests/multigrid-global-coarsening/multigrid_a_02.cc
@@ -67,10 +67,8 @@ test(const unsigned int n_refinements, const unsigned int fe_degree_fine)
       auto &op         = operators[l];
 
       // set up constraints
-      IndexSet relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                    l,
-                                                    relevant_dofs);
+      const IndexSet relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof_handler, l);
       constraint.reinit(relevant_dofs);
       constraint.add_lines(mg_constrained_dofs.get_boundary_indices(l));
       constraint.close();

--- a/tests/multigrid-global-coarsening/multigrid_a_03.cc
+++ b/tests/multigrid-global-coarsening/multigrid_a_03.cc
@@ -65,10 +65,8 @@ test(const unsigned int n_refinements, const unsigned int fe_degree_fine)
       auto &op         = operators[l];
 
       // set up constraints
-      IndexSet relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                    l,
-                                                    relevant_dofs);
+      const IndexSet relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof_handler, l);
       constraint.reinit(relevant_dofs);
       constraint.add_lines(mg_constrained_dofs.get_boundary_indices(l));
       constraint.close();

--- a/tests/multigrid-global-coarsening/multigrid_p_01.cc
+++ b/tests/multigrid-global-coarsening/multigrid_p_01.cc
@@ -108,9 +108,8 @@ test(const unsigned int n_refinements,
       dof_handler.distribute_dofs(*fe);
 
       // set up constraints
-      IndexSet locally_relevant_dofs;
-      DoFTools::extract_locally_relevant_dofs(dof_handler,
-                                              locally_relevant_dofs);
+      const IndexSet locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(dof_handler);
       constraint.reinit(locally_relevant_dofs);
       VectorTools::interpolate_boundary_values(
         *mapping, dof_handler, 0, Functions::ZeroFunction<dim>(), constraint);

--- a/tests/multigrid-global-coarsening/multigrid_p_02.cc
+++ b/tests/multigrid-global-coarsening/multigrid_p_02.cc
@@ -79,10 +79,8 @@ test(const unsigned int n_refinements, const unsigned int fe_degree_fine)
       mg_constrained_dofs.make_zero_boundary_constraints(dof_handler,
                                                          dirichlet_boundary);
 
-      IndexSet relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                    0 /*level*/,
-                                                    relevant_dofs);
+      const IndexSet relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof_handler, 0 /*level*/);
       constraint.reinit(relevant_dofs);
       constraint.add_lines(
         mg_constrained_dofs.get_boundary_indices(0 /*level*/));

--- a/tests/multigrid-global-coarsening/multigrid_p_03.cc
+++ b/tests/multigrid-global-coarsening/multigrid_p_03.cc
@@ -82,10 +82,8 @@ test(const unsigned int n_refinements,
       mg_constrained_dofs.make_zero_boundary_constraints(dof_handler,
                                                          dirichlet_boundary);
 
-      IndexSet relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                    level,
-                                                    relevant_dofs);
+      const IndexSet relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
       constraint.reinit(relevant_dofs);
       constraint.add_lines(mg_constrained_dofs.get_boundary_indices(level));
       constraint.close();

--- a/tests/multigrid-global-coarsening/non_nested_multigrid_01.cc
+++ b/tests/multigrid-global-coarsening/non_nested_multigrid_01.cc
@@ -82,9 +82,8 @@ test(const unsigned int n_refinements,
       dof_handler.distribute_dofs(*fe);
 
       // set up constraints
-      IndexSet locally_relevant_dofs;
-      DoFTools::extract_locally_relevant_dofs(dof_handler,
-                                              locally_relevant_dofs);
+      const IndexSet locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(dof_handler);
       constraint.reinit(locally_relevant_dofs);
       VectorTools::interpolate_boundary_values(
         *mapping, dof_handler, 0, Functions::ZeroFunction<dim>(), constraint);

--- a/tests/multigrid-global-coarsening/non_nested_multigrid_02.cc
+++ b/tests/multigrid-global-coarsening/non_nested_multigrid_02.cc
@@ -73,9 +73,8 @@ test(const unsigned int n_refinements,
       dof_handler.distribute_dofs(*fe);
 
       // set up constraints
-      IndexSet locally_relevant_dofs;
-      DoFTools::extract_locally_relevant_dofs(dof_handler,
-                                              locally_relevant_dofs);
+      const IndexSet locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(dof_handler);
       constraint.reinit(locally_relevant_dofs);
       VectorTools::interpolate_boundary_values(
         *_mapping, dof_handler, 0, Functions::ZeroFunction<dim>(), constraint);

--- a/tests/multigrid-global-coarsening/non_nested_multigrid_03.cc
+++ b/tests/multigrid-global-coarsening/non_nested_multigrid_03.cc
@@ -64,9 +64,8 @@ test(const unsigned int n_refinements, const unsigned int fe_degree_fine)
       dof_handler.distribute_dofs(*fe);
 
       // set up constraints
-      IndexSet locally_relevant_dofs;
-      DoFTools::extract_locally_relevant_dofs(dof_handler,
-                                              locally_relevant_dofs);
+      const IndexSet locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(dof_handler);
       constraint.reinit(locally_relevant_dofs);
       VectorTools::interpolate_boundary_values(
         mapping, dof_handler, 0, Functions::ZeroFunction<dim>(), constraint);

--- a/tests/multigrid-global-coarsening/non_nested_multigrid_04.cc
+++ b/tests/multigrid-global-coarsening/non_nested_multigrid_04.cc
@@ -139,9 +139,8 @@ test(const unsigned int n_refinements,
       dof_handler.distribute_dofs(*fe);
 
       // set up constraints
-      IndexSet locally_relevant_dofs;
-      DoFTools::extract_locally_relevant_dofs(dof_handler,
-                                              locally_relevant_dofs);
+      const IndexSet locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(dof_handler);
       constraint.reinit(locally_relevant_dofs);
       VectorTools::interpolate_boundary_values(
         *mapping, dof_handler, 0, Functions::ZeroFunction<dim>(), constraint);

--- a/tests/multigrid-global-coarsening/parallel_multigrid_02.cc
+++ b/tests/multigrid-global-coarsening/parallel_multigrid_02.cc
@@ -98,8 +98,8 @@ do_test(const DoFHandler<dim> &dof)
   deallog << std::endl;
   deallog << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof);
 
   // Dirichlet BC
   Functions::ZeroFunction<dim>                        zero_function;
@@ -173,8 +173,8 @@ do_test(const DoFHandler<dim> &dof)
       mg_additional_data.mg_level = level;
 
       AffineConstraints<double> level_constraints;
-      IndexSet                  relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof, level, relevant_dofs);
+      const IndexSet            relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof, level);
       level_constraints.reinit(relevant_dofs);
       level_constraints.add_lines(
         mg_constrained_dofs.get_boundary_indices(level));

--- a/tests/multigrid-global-coarsening/parallel_multigrid_adaptive_01.cc
+++ b/tests/multigrid-global-coarsening/parallel_multigrid_adaptive_01.cc
@@ -78,8 +78,8 @@ public:
     AffineConstraints<double> constraints;
     if (level == numbers::invalid_unsigned_int)
       {
-        IndexSet relevant_dofs;
-        DoFTools::extract_locally_relevant_dofs(dof_handler, relevant_dofs);
+        const IndexSet relevant_dofs =
+          DoFTools::extract_locally_relevant_dofs(dof_handler);
         constraints.reinit(relevant_dofs);
         DoFTools::make_hanging_node_constraints(dof_handler, constraints);
         VectorTools::interpolate_boundary_values(dof_handler,
@@ -88,10 +88,8 @@ public:
       }
     else
       {
-        IndexSet relevant_dofs;
-        DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                      level,
-                                                      relevant_dofs);
+        const IndexSet relevant_dofs =
+          DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
         constraints.reinit(relevant_dofs);
         constraints.add_lines(mg_constrained_dofs.get_boundary_indices(level));
 
@@ -479,8 +477,8 @@ do_test(const DoFHandler<dim> &dof)
   deallog << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
 
   AffineConstraints<double> hanging_node_constraints;
-  IndexSet                  locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof, locally_relevant_dofs);
+  const IndexSet            locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof);
   hanging_node_constraints.reinit(locally_relevant_dofs);
   DoFTools::make_hanging_node_constraints(dof, hanging_node_constraints);
   hanging_node_constraints.close();

--- a/tests/multigrid-global-coarsening/parallel_multigrid_adaptive_02.cc
+++ b/tests/multigrid-global-coarsening/parallel_multigrid_adaptive_02.cc
@@ -99,8 +99,8 @@ do_test(const DoFHandler<dim> &dof)
   deallog << std::endl;
   deallog << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof);
 
   // Dirichlet BC
   Functions::ZeroFunction<dim>                        zero_function;
@@ -187,8 +187,8 @@ do_test(const DoFHandler<dim> &dof)
       mg_additional_data.mg_level         = level;
 
       AffineConstraints<double> level_constraints;
-      IndexSet                  relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof, level, relevant_dofs);
+      const IndexSet            relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof, level);
       level_constraints.reinit(relevant_dofs);
       level_constraints.add_lines(
         mg_constrained_dofs.get_boundary_indices(level));

--- a/tests/multigrid-global-coarsening/parallel_multigrid_adaptive_03.cc
+++ b/tests/multigrid-global-coarsening/parallel_multigrid_adaptive_03.cc
@@ -85,8 +85,8 @@ public:
     AffineConstraints<double> constraints;
     if (level == numbers::invalid_unsigned_int)
       {
-        IndexSet relevant_dofs;
-        DoFTools::extract_locally_relevant_dofs(dof_handler, relevant_dofs);
+        const IndexSet relevant_dofs =
+          DoFTools::extract_locally_relevant_dofs(dof_handler);
         constraints.reinit(relevant_dofs);
         DoFTools::make_hanging_node_constraints(dof_handler, constraints);
         VectorTools::interpolate_boundary_values(dof_handler,
@@ -95,10 +95,8 @@ public:
       }
     else
       {
-        IndexSet relevant_dofs;
-        DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                      level,
-                                                      relevant_dofs);
+        const IndexSet relevant_dofs =
+          DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
         constraints.reinit(relevant_dofs);
         constraints.add_lines(mg_constrained_dofs.get_boundary_indices(level));
 
@@ -483,8 +481,8 @@ do_test(const DoFHandler<dim> &dof, const bool threaded)
   deallog << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
 
   AffineConstraints<double> hanging_node_constraints;
-  IndexSet                  locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof, locally_relevant_dofs);
+  const IndexSet            locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof);
   hanging_node_constraints.reinit(locally_relevant_dofs);
   DoFTools::make_hanging_node_constraints(dof, hanging_node_constraints);
   hanging_node_constraints.close();

--- a/tests/multigrid-global-coarsening/parallel_multigrid_adaptive_04.cc
+++ b/tests/multigrid-global-coarsening/parallel_multigrid_adaptive_04.cc
@@ -99,8 +99,8 @@ do_test(const DoFHandler<dim> &dof)
   deallog << std::endl;
   deallog << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof);
 
   // Dirichlet BC
   Functions::ZeroFunction<dim>                        zero_function;
@@ -187,8 +187,8 @@ do_test(const DoFHandler<dim> &dof)
       mg_additional_data.mg_level         = level;
 
       AffineConstraints<double> level_constraints;
-      IndexSet                  relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof, level, relevant_dofs);
+      const IndexSet            relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof, level);
       level_constraints.reinit(relevant_dofs);
       level_constraints.add_lines(
         mg_constrained_dofs.get_boundary_indices(level));

--- a/tests/multigrid-global-coarsening/parallel_multigrid_adaptive_05.cc
+++ b/tests/multigrid-global-coarsening/parallel_multigrid_adaptive_05.cc
@@ -82,8 +82,8 @@ public:
     AffineConstraints<double> constraints;
     if (level == numbers::invalid_unsigned_int)
       {
-        IndexSet relevant_dofs;
-        DoFTools::extract_locally_relevant_dofs(dof_handler, relevant_dofs);
+        const IndexSet relevant_dofs =
+          DoFTools::extract_locally_relevant_dofs(dof_handler);
         constraints.reinit(relevant_dofs);
         DoFTools::make_hanging_node_constraints(dof_handler, constraints);
         VectorTools::interpolate_boundary_values(dof_handler,
@@ -92,10 +92,8 @@ public:
       }
     else
       {
-        IndexSet relevant_dofs;
-        DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                      level,
-                                                      relevant_dofs);
+        const IndexSet relevant_dofs =
+          DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
         constraints.reinit(relevant_dofs);
         constraints.add_lines(mg_constrained_dofs.get_boundary_indices(level));
 
@@ -480,8 +478,8 @@ do_test(const DoFHandler<dim> &dof, const bool threaded)
   deallog << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
 
   AffineConstraints<double> hanging_node_constraints;
-  IndexSet                  locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof, locally_relevant_dofs);
+  const IndexSet            locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof);
   hanging_node_constraints.reinit(locally_relevant_dofs);
   DoFTools::make_hanging_node_constraints(dof, hanging_node_constraints);
   hanging_node_constraints.close();

--- a/tests/multigrid-global-coarsening/parallel_multigrid_adaptive_06.cc
+++ b/tests/multigrid-global-coarsening/parallel_multigrid_adaptive_06.cc
@@ -221,8 +221,8 @@ do_test(const DoFHandler<dim> &dof, const unsigned int nb)
   deallog << std::endl;
   deallog << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof);
 
   // Dirichlet BC
   Functions::ZeroFunction<dim>                        zero_function;
@@ -315,8 +315,8 @@ do_test(const DoFHandler<dim> &dof, const unsigned int nb)
       mg_additional_data.mg_level         = level;
 
       AffineConstraints<double> level_constraints;
-      IndexSet                  relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof, level, relevant_dofs);
+      const IndexSet            relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof, level);
       level_constraints.reinit(relevant_dofs);
       level_constraints.add_lines(
         mg_constrained_dofs.get_boundary_indices(level));

--- a/tests/multigrid-global-coarsening/parallel_multigrid_adaptive_06ref.cc
+++ b/tests/multigrid-global-coarsening/parallel_multigrid_adaptive_06ref.cc
@@ -100,8 +100,8 @@ do_test(const DoFHandler<dim> &dof)
   deallog << std::endl;
   deallog << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof);
 
   // Dirichlet BC
   Functions::ZeroFunction<dim>                        zero_function;
@@ -188,8 +188,8 @@ do_test(const DoFHandler<dim> &dof)
       mg_additional_data.mg_level         = level;
 
       AffineConstraints<double> level_constraints;
-      IndexSet                  relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof, level, relevant_dofs);
+      const IndexSet            relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof, level);
       level_constraints.reinit(relevant_dofs);
       level_constraints.add_lines(
         mg_constrained_dofs.get_boundary_indices(level));

--- a/tests/multigrid-global-coarsening/parallel_multigrid_adaptive_07.cc
+++ b/tests/multigrid-global-coarsening/parallel_multigrid_adaptive_07.cc
@@ -241,7 +241,7 @@ do_test(const std::vector<const DoFHandler<dim> *> &dof)
 
   std::vector<IndexSet> locally_relevant_dofs(dof.size());
   for (unsigned int i = 0; i < dof.size(); ++i)
-    DoFTools::extract_locally_relevant_dofs(*dof[i], locally_relevant_dofs[i]);
+    locally_relevant_dofs[i] = DoFTools::extract_locally_relevant_dofs(*dof[i]);
 
   // Dirichlet BC
   Functions::ZeroFunction<dim>                        zero_function;
@@ -349,10 +349,8 @@ do_test(const std::vector<const DoFHandler<dim> *> &dof)
         dof.size());
       for (unsigned int i = 0; i < dof.size(); ++i)
         {
-          IndexSet relevant_dofs;
-          DoFTools::extract_locally_relevant_level_dofs(*dof[i],
-                                                        level,
-                                                        relevant_dofs);
+          const IndexSet relevant_dofs =
+            DoFTools::extract_locally_relevant_level_dofs(*dof[i], level);
           level_constraints[i].reinit(relevant_dofs);
           level_constraints[i].add_lines(
             mg_constrained_dofs[i].get_boundary_indices(level));

--- a/tests/multigrid-global-coarsening/parallel_multigrid_adaptive_08.cc
+++ b/tests/multigrid-global-coarsening/parallel_multigrid_adaptive_08.cc
@@ -217,8 +217,8 @@ do_test(const DoFHandler<dim> &dof)
   deallog << std::endl;
   deallog << "Number of degrees of freedom: " << dof.n_dofs() << std::endl;
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof);
 
   // Dirichlet BC
   Functions::ZeroFunction<dim>                        zero_function;
@@ -295,8 +295,8 @@ do_test(const DoFHandler<dim> &dof)
       mg_additional_data.mg_level         = level;
 
       AffineConstraints<double> level_constraints;
-      IndexSet                  relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof, level, relevant_dofs);
+      const IndexSet            relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof, level);
       level_constraints.reinit(relevant_dofs);
       level_constraints.add_lines(
         mg_constrained_dofs.get_boundary_indices(level));

--- a/tests/multigrid-global-coarsening/parallel_multigrid_mf_02.cc
+++ b/tests/multigrid-global-coarsening/parallel_multigrid_mf_02.cc
@@ -105,8 +105,8 @@ do_test(const DoFHandler<dim> &dof)
   dirichlet_boundary[0] = &zero_function;
 
   // fine-level constraints
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof);
   AffineConstraints<double> constraints;
   constraints.reinit(locally_relevant_dofs);
   VectorTools::interpolate_boundary_values(dof,
@@ -160,8 +160,8 @@ do_test(const DoFHandler<dim> &dof)
       mg_additional_data.mg_level         = level;
 
       AffineConstraints<double> level_constraints;
-      IndexSet                  relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof, level, relevant_dofs);
+      const IndexSet            relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof, level);
       level_constraints.reinit(relevant_dofs);
       level_constraints.add_lines(
         mg_constrained_dofs.get_boundary_indices(level));

--- a/tests/multigrid-global-coarsening/step-37-inhomogeneous-1.cc
+++ b/tests/multigrid-global-coarsening/step-37-inhomogeneous-1.cc
@@ -399,8 +399,8 @@ namespace Step37
     pcout << "Number of degrees of freedom: " << dof_handler.n_dofs()
           << std::endl;
 
-    IndexSet locally_relevant_dofs;
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    const IndexSet locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     constraints.clear();
     constraints.reinit(locally_relevant_dofs);
@@ -442,10 +442,8 @@ namespace Step37
 
     for (unsigned int level = 0; level < nlevels; ++level)
       {
-        IndexSet relevant_dofs;
-        DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                      level,
-                                                      relevant_dofs);
+        const IndexSet relevant_dofs =
+          DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
         AffineConstraints<double> level_constraints;
         level_constraints.reinit(relevant_dofs);
         level_constraints.add_lines(

--- a/tests/multigrid-global-coarsening/stokes_computation.cc
+++ b/tests/multigrid-global-coarsening/stokes_computation.cc
@@ -1035,9 +1035,8 @@ namespace StokesClass
     dof_handler_p.clear();
     dof_handler_p.distribute_dofs(fe_p);
 
-    IndexSet locally_relevant_dofs_u;
-    DoFTools::extract_locally_relevant_dofs(dof_handler_u,
-                                            locally_relevant_dofs_u);
+    const IndexSet locally_relevant_dofs_u =
+      DoFTools::extract_locally_relevant_dofs(dof_handler_u);
     constraints_u.reinit(locally_relevant_dofs_u);
     DoFTools::make_hanging_node_constraints(dof_handler_u, constraints_u);
 
@@ -1045,9 +1044,8 @@ namespace StokesClass
       dof_handler_u, 0, ExactSolution_BoundaryValues_u<dim>(), constraints_u);
     constraints_u.close();
 
-    IndexSet locally_relevant_dofs_p;
-    DoFTools::extract_locally_relevant_dofs(dof_handler_p,
-                                            locally_relevant_dofs_p);
+    const IndexSet locally_relevant_dofs_p =
+      DoFTools::extract_locally_relevant_dofs(dof_handler_p);
     constraints_p.reinit(locally_relevant_dofs_p);
     DoFTools::make_hanging_node_constraints(dof_handler_p, constraints_p);
     constraints_p.close();
@@ -1112,10 +1110,8 @@ namespace StokesClass
 
     for (unsigned int level = 0; level < n_levels; ++level)
       {
-        IndexSet relevant_dofs;
-        DoFTools::extract_locally_relevant_level_dofs(dof_handler_u,
-                                                      level,
-                                                      relevant_dofs);
+        const IndexSet relevant_dofs =
+          DoFTools::extract_locally_relevant_level_dofs(dof_handler_u, level);
         AffineConstraints<double> level_constraints;
         level_constraints.reinit(relevant_dofs);
         level_constraints.add_lines(
@@ -1173,9 +1169,8 @@ namespace StokesClass
 
     // Create constraints with no Dirchlet info
     AffineConstraints<double> constraints_u_no_dirchlet;
-    IndexSet                  locally_relevant_dofs_u;
-    DoFTools::extract_locally_relevant_dofs(dof_handler_u,
-                                            locally_relevant_dofs_u);
+    const IndexSet            locally_relevant_dofs_u =
+      DoFTools::extract_locally_relevant_dofs(dof_handler_u);
     constraints_u_no_dirchlet.reinit(locally_relevant_dofs_u);
     DoFTools::make_hanging_node_constraints(dof_handler_u,
                                             constraints_u_no_dirchlet);

--- a/tests/multigrid-global-coarsening/transfer_matrix_free_04.cc
+++ b/tests/multigrid-global-coarsening/transfer_matrix_free_04.cc
@@ -87,10 +87,8 @@ check(const unsigned int fe_degree)
           LinearAlgebra::distributed::Vector<Number> v1, v2;
           LinearAlgebra::distributed::Vector<double> v1_cpy, v2_cpy, v3;
           v1.reinit(mgdof.locally_owned_mg_dofs(level - 1), MPI_COMM_WORLD);
-          IndexSet relevant_set;
-          DoFTools::extract_locally_relevant_level_dofs(mgdof,
-                                                        level,
-                                                        relevant_set);
+          const IndexSet relevant_set =
+            DoFTools::extract_locally_relevant_level_dofs(mgdof, level);
           v2.reinit(mgdof.locally_owned_mg_dofs(level),
                     relevant_set,
                     MPI_COMM_WORLD);

--- a/tests/multigrid/constrained_dofs_01.cc
+++ b/tests/multigrid/constrained_dofs_01.cc
@@ -147,8 +147,8 @@ check_fe(FiniteElement<dim> &fe)
       deallog << "get_boundary_indices:" << std::endl;
       bi.print(deallog);
 
-      IndexSet relevant;
-      DoFTools::extract_locally_relevant_level_dofs(dofh, level, relevant);
+      const IndexSet relevant =
+        DoFTools::extract_locally_relevant_level_dofs(dofh, level);
       deallog << "relevant:" << std::endl;
       relevant.print(deallog);
 
@@ -184,8 +184,8 @@ check_fe(FiniteElement<dim> &fe)
       {
         deallog << "Level " << level << ':' << std::endl;
 
-        IndexSet relevant;
-        DoFTools::extract_locally_relevant_level_dofs(dofh, level, relevant);
+        const IndexSet relevant =
+          DoFTools::extract_locally_relevant_level_dofs(dofh, level);
         mg_boundary_constraints[level].reinit(relevant);
         mg_boundary_constraints[level].add_lines(boundary_indices[level]);
 
@@ -229,8 +229,8 @@ check_fe(FiniteElement<dim> &fe)
                                                    level_boundary_indices);
         const auto &bi = mg_constrained_dofs_1.get_boundary_indices(level);
 
-        IndexSet relevant;
-        DoFTools::extract_locally_relevant_level_dofs(dofh, level, relevant);
+        const IndexSet relevant =
+          DoFTools::extract_locally_relevant_level_dofs(dofh, level);
 
         deallog << ((bi ==
                      (relevant &

--- a/tests/multigrid/constrained_dofs_02.cc
+++ b/tests/multigrid/constrained_dofs_02.cc
@@ -207,8 +207,8 @@ check_fe(FiniteElement<dim> &fe)
       deallog << "get_boundary_indices:" << std::endl;
       bi.print(deallog);
 
-      IndexSet relevant;
-      DoFTools::extract_locally_relevant_level_dofs(dofh, level, relevant);
+      const IndexSet relevant =
+        DoFTools::extract_locally_relevant_level_dofs(dofh, level);
       deallog << "relevant:" << std::endl;
       relevant.print(deallog);
 

--- a/tests/multigrid/constrained_dofs_07.cc
+++ b/tests/multigrid/constrained_dofs_07.cc
@@ -51,10 +51,8 @@ check()
 
   for (unsigned int level = 0; level < tr.n_levels(); ++level)
     {
-      IndexSet relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(mgdof,
-                                                    level,
-                                                    relevant_dofs);
+      const IndexSet relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(mgdof, level);
       AffineConstraints<double> level_constraints;
       level_constraints.reinit(relevant_dofs);
 

--- a/tests/multigrid/events_01.cc
+++ b/tests/multigrid/events_01.cc
@@ -144,8 +144,8 @@ namespace Step50
     mg_dof_handler.distribute_dofs(fe);
     mg_dof_handler.distribute_mg_dofs();
 
-    DoFTools::extract_locally_relevant_dofs(mg_dof_handler,
-                                            locally_relevant_set);
+    locally_relevant_set =
+      DoFTools::extract_locally_relevant_dofs(mg_dof_handler);
 
     solution.reinit(mg_dof_handler.locally_owned_dofs(), MPI_COMM_WORLD);
     system_rhs.reinit(mg_dof_handler.locally_owned_dofs(), MPI_COMM_WORLD);
@@ -281,10 +281,8 @@ namespace Step50
     for (unsigned int level = 0; level < triangulation.n_global_levels();
          ++level)
       {
-        IndexSet dofset;
-        DoFTools::extract_locally_relevant_level_dofs(mg_dof_handler,
-                                                      level,
-                                                      dofset);
+        const IndexSet dofset =
+          DoFTools::extract_locally_relevant_level_dofs(mg_dof_handler, level);
         boundary_constraints[level].reinit(dofset);
         boundary_constraints[level].add_lines(
           mg_constrained_dofs.get_refinement_edge_indices(level));

--- a/tests/multigrid/interface_matrix_entry_01.cc
+++ b/tests/multigrid/interface_matrix_entry_01.cc
@@ -82,14 +82,14 @@ test()
 
   FE_Q<dim>                 fe(2);
   DoFHandler<dim>           mg_dof_handler(tria);
-  IndexSet                  locally_relevant_set;
   AffineConstraints<double> constraints;
   MGConstrainedDoFs         mg_constrained_dofs;
 
   mg_dof_handler.distribute_dofs(fe);
   mg_dof_handler.distribute_mg_dofs();
 
-  DoFTools::extract_locally_relevant_dofs(mg_dof_handler, locally_relevant_set);
+  const IndexSet locally_relevant_set =
+    DoFTools::extract_locally_relevant_dofs(mg_dof_handler);
 
   constraints.reinit(locally_relevant_set);
   DoFTools::make_hanging_node_constraints(mg_dof_handler, constraints);

--- a/tests/multigrid/interpolate_to_mg_01.cc
+++ b/tests/multigrid/interpolate_to_mg_01.cc
@@ -80,8 +80,8 @@ test()
   dof_handler.distribute_dofs(fe);
   dof_handler.distribute_mg_dofs();
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   AffineConstraints<double> constraints;
   constraints.reinit(locally_relevant_dofs);

--- a/tests/multigrid/mg_coarse_01.cc
+++ b/tests/multigrid/mg_coarse_01.cc
@@ -201,8 +201,8 @@ namespace Step50
     mg_dof_handler.distribute_dofs(fe);
     mg_dof_handler.distribute_mg_dofs();
 
-    DoFTools::extract_locally_relevant_dofs(mg_dof_handler,
-                                            locally_relevant_set);
+    locally_relevant_set =
+      DoFTools::extract_locally_relevant_dofs(mg_dof_handler);
 
     solution.reinit(mg_dof_handler.locally_owned_dofs(), MPI_COMM_WORLD);
     system_rhs.reinit(mg_dof_handler.locally_owned_dofs(), MPI_COMM_WORLD);
@@ -348,10 +348,8 @@ namespace Step50
     for (unsigned int level = 0; level < triangulation.n_global_levels();
          ++level)
       {
-        IndexSet dofset;
-        DoFTools::extract_locally_relevant_level_dofs(mg_dof_handler,
-                                                      level,
-                                                      dofset);
+        const IndexSet dofset =
+          DoFTools::extract_locally_relevant_level_dofs(mg_dof_handler, level);
         boundary_constraints[level].reinit(dofset);
         boundary_constraints[level].add_lines(
           mg_constrained_dofs.get_refinement_edge_indices(level));

--- a/tests/multigrid/mg_data_out_04.cc
+++ b/tests/multigrid/mg_data_out_04.cc
@@ -55,8 +55,8 @@ do_test()
   dof_handler.distribute_mg_dofs();
 
   // Make FE vector
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   using VectorType = LinearAlgebra::distributed::Vector<double>;
   VectorType global_dof_vector;

--- a/tests/multigrid/mg_data_out_05.cc
+++ b/tests/multigrid/mg_data_out_05.cc
@@ -59,8 +59,8 @@ do_test()
   dof_handler.distribute_mg_dofs();
 
   // Make FE vector
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   using VectorType = LinearAlgebra::distributed::Vector<double>;
   VectorType global_dof_vector;

--- a/tests/multigrid/step-16-50-mpi-linear-operator.cc
+++ b/tests/multigrid/step-16-50-mpi-linear-operator.cc
@@ -194,8 +194,8 @@ namespace Step50
     mg_dof_handler.distribute_dofs(fe);
     mg_dof_handler.distribute_mg_dofs();
 
-    DoFTools::extract_locally_relevant_dofs(mg_dof_handler,
-                                            locally_relevant_set);
+    locally_relevant_set =
+      DoFTools::extract_locally_relevant_dofs(mg_dof_handler);
 
     solution.reinit(mg_dof_handler.locally_owned_dofs(), MPI_COMM_WORLD);
     system_rhs.reinit(mg_dof_handler.locally_owned_dofs(), MPI_COMM_WORLD);
@@ -347,10 +347,8 @@ namespace Step50
     for (unsigned int level = 0; level < triangulation.n_global_levels();
          ++level)
       {
-        IndexSet dofset;
-        DoFTools::extract_locally_relevant_level_dofs(mg_dof_handler,
-                                                      level,
-                                                      dofset);
+        const IndexSet dofset =
+          DoFTools::extract_locally_relevant_level_dofs(mg_dof_handler, level);
         boundary_constraints[level].reinit(dofset);
         boundary_constraints[level].add_lines(
           mg_constrained_dofs.get_refinement_edge_indices(level));

--- a/tests/multigrid/step-16-50-mpi-smoother.cc
+++ b/tests/multigrid/step-16-50-mpi-smoother.cc
@@ -194,8 +194,8 @@ namespace Step50
     mg_dof_handler.distribute_dofs(fe);
     mg_dof_handler.distribute_mg_dofs();
 
-    DoFTools::extract_locally_relevant_dofs(mg_dof_handler,
-                                            locally_relevant_set);
+    locally_relevant_set =
+      DoFTools::extract_locally_relevant_dofs(mg_dof_handler);
 
     solution.reinit(mg_dof_handler.locally_owned_dofs(), MPI_COMM_WORLD);
     system_rhs.reinit(mg_dof_handler.locally_owned_dofs(), MPI_COMM_WORLD);
@@ -346,10 +346,8 @@ namespace Step50
     for (unsigned int level = 0; level < triangulation.n_global_levels();
          ++level)
       {
-        IndexSet dofset;
-        DoFTools::extract_locally_relevant_level_dofs(mg_dof_handler,
-                                                      level,
-                                                      dofset);
+        const IndexSet dofset =
+          DoFTools::extract_locally_relevant_level_dofs(mg_dof_handler, level);
         boundary_constraints[level].reinit(dofset);
         boundary_constraints[level].add_lines(
           mg_constrained_dofs.get_refinement_edge_indices(level));

--- a/tests/multigrid/step-16-50-mpi.cc
+++ b/tests/multigrid/step-16-50-mpi.cc
@@ -194,8 +194,8 @@ namespace Step50
     mg_dof_handler.distribute_dofs(fe);
     mg_dof_handler.distribute_mg_dofs();
 
-    DoFTools::extract_locally_relevant_dofs(mg_dof_handler,
-                                            locally_relevant_set);
+    locally_relevant_set =
+      DoFTools::extract_locally_relevant_dofs(mg_dof_handler);
 
     solution.reinit(mg_dof_handler.locally_owned_dofs(), MPI_COMM_WORLD);
     system_rhs.reinit(mg_dof_handler.locally_owned_dofs(), MPI_COMM_WORLD);
@@ -347,10 +347,8 @@ namespace Step50
     for (unsigned int level = 0; level < triangulation.n_global_levels();
          ++level)
       {
-        IndexSet dofset;
-        DoFTools::extract_locally_relevant_level_dofs(mg_dof_handler,
-                                                      level,
-                                                      dofset);
+        const IndexSet dofset =
+          DoFTools::extract_locally_relevant_level_dofs(mg_dof_handler, level);
         boundary_constraints[level].reinit(dofset);
         boundary_constraints[level].add_lines(
           mg_constrained_dofs.get_refinement_edge_indices(level));

--- a/tests/multigrid/step-50_01.cc
+++ b/tests/multigrid/step-50_01.cc
@@ -198,8 +198,8 @@ namespace Step50
     mg_dof_handler.distribute_dofs(fe);
     mg_dof_handler.distribute_mg_dofs();
 
-    DoFTools::extract_locally_relevant_dofs(mg_dof_handler,
-                                            locally_relevant_set);
+    locally_relevant_set =
+      DoFTools::extract_locally_relevant_dofs(mg_dof_handler);
 
     solution.reinit(mg_dof_handler.locally_owned_dofs(), MPI_COMM_WORLD);
     system_rhs.reinit(mg_dof_handler.locally_owned_dofs(), MPI_COMM_WORLD);
@@ -345,10 +345,8 @@ namespace Step50
     for (unsigned int level = 0; level < triangulation.n_global_levels();
          ++level)
       {
-        IndexSet dofset;
-        DoFTools::extract_locally_relevant_level_dofs(mg_dof_handler,
-                                                      level,
-                                                      dofset);
+        const IndexSet dofset =
+          DoFTools::extract_locally_relevant_level_dofs(mg_dof_handler, level);
         boundary_constraints[level].reinit(dofset);
         boundary_constraints[level].add_lines(
           mg_constrained_dofs.get_refinement_edge_indices(level));

--- a/tests/multigrid/step-50_02.cc
+++ b/tests/multigrid/step-50_02.cc
@@ -198,8 +198,8 @@ namespace Step50
     mg_dof_handler.distribute_dofs(fe);
     mg_dof_handler.distribute_mg_dofs();
 
-    DoFTools::extract_locally_relevant_dofs(mg_dof_handler,
-                                            locally_relevant_set);
+    locally_relevant_set =
+      DoFTools::extract_locally_relevant_dofs(mg_dof_handler);
 
     solution.reinit(mg_dof_handler.locally_owned_dofs(), MPI_COMM_WORLD);
     system_rhs.reinit(mg_dof_handler.locally_owned_dofs(), MPI_COMM_WORLD);
@@ -353,10 +353,8 @@ namespace Step50
     for (unsigned int level = 0; level < triangulation.n_global_levels();
          ++level)
       {
-        IndexSet dofset;
-        DoFTools::extract_locally_relevant_level_dofs(mg_dof_handler,
-                                                      level,
-                                                      dofset);
+        const IndexSet dofset =
+          DoFTools::extract_locally_relevant_level_dofs(mg_dof_handler, level);
         boundary_constraints[level].reinit(dofset);
         boundary_constraints[level].add_lines(
           mg_constrained_dofs.get_refinement_edge_indices(level));

--- a/tests/multigrid/transfer_04.cc
+++ b/tests/multigrid/transfer_04.cc
@@ -129,8 +129,8 @@ check_fe(FiniteElement<dim> &fe)
   mg_constrained_dofs.initialize(dofh);
 
   AffineConstraints<double> hanging_node_constraints;
-  IndexSet                  locally_relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, locally_relevant_set);
+  const IndexSet            locally_relevant_set =
+    DoFTools::extract_locally_relevant_dofs(dofh);
   hanging_node_constraints.reinit(locally_relevant_set);
   DoFTools::make_hanging_node_constraints(dofh, hanging_node_constraints);
   hanging_node_constraints.close();

--- a/tests/multigrid/transfer_matrix_free_04.cc
+++ b/tests/multigrid/transfer_matrix_free_04.cc
@@ -87,10 +87,8 @@ check(const unsigned int fe_degree)
           LinearAlgebra::distributed::Vector<Number> v1, v2;
           LinearAlgebra::distributed::Vector<double> v1_cpy, v2_cpy, v3;
           v1.reinit(mgdof.locally_owned_mg_dofs(level - 1), MPI_COMM_WORLD);
-          IndexSet relevant_set;
-          DoFTools::extract_locally_relevant_level_dofs(mgdof,
-                                                        level,
-                                                        relevant_set);
+          const IndexSet relevant_set =
+            DoFTools::extract_locally_relevant_level_dofs(mgdof, level);
           v2.reinit(mgdof.locally_owned_mg_dofs(level),
                     relevant_set,
                     MPI_COMM_WORLD);

--- a/tests/multigrid/transfer_matrix_free_13.cc
+++ b/tests/multigrid/transfer_matrix_free_13.cc
@@ -50,8 +50,8 @@ check()
   MGConstrainedDoFs mg_constrained_dofs;
   mg_constrained_dofs.initialize(mgdof);
 
-  IndexSet relevant_dofs;
-  DoFTools::extract_locally_relevant_level_dofs(mgdof, 0, relevant_dofs);
+  const IndexSet relevant_dofs =
+    DoFTools::extract_locally_relevant_level_dofs(mgdof, 0);
   AffineConstraints<double> user_constraints;
   user_constraints.reinit(relevant_dofs);
 

--- a/tests/multigrid/transfer_prebuilt_05.cc
+++ b/tests/multigrid/transfer_prebuilt_05.cc
@@ -47,8 +47,8 @@ check()
   MGConstrainedDoFs mg_constrained_dofs;
   mg_constrained_dofs.initialize(mgdof);
 
-  IndexSet relevant_dofs;
-  DoFTools::extract_locally_relevant_level_dofs(mgdof, 0, relevant_dofs);
+  const IndexSet relevant_dofs =
+    DoFTools::extract_locally_relevant_level_dofs(mgdof, 0);
   AffineConstraints<double> user_constraints;
   user_constraints.reinit(relevant_dofs);
 

--- a/tests/numerics/matrix_creator_01.cc
+++ b/tests/numerics/matrix_creator_01.cc
@@ -55,8 +55,8 @@ test()
   const auto      mpi_comm   = dof_handler.get_communicator();
   const IndexSet &owned_dofs = dof_handler.locally_owned_dofs();
 
-  IndexSet relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, relevant_dofs);
+  const IndexSet relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   AffineConstraints<typename MatrixType::value_type> constraints;
 

--- a/tests/numerics/no_flux_18.cc
+++ b/tests/numerics/no_flux_18.cc
@@ -1037,9 +1037,8 @@ namespace StokesClass
     dof_handler_p.clear();
     dof_handler_p.distribute_dofs(fe_p);
 
-    IndexSet locally_relevant_dofs_u;
-    DoFTools::extract_locally_relevant_dofs(dof_handler_u,
-                                            locally_relevant_dofs_u);
+    const IndexSet locally_relevant_dofs_u =
+      DoFTools::extract_locally_relevant_dofs(dof_handler_u);
     constraints_u.reinit(locally_relevant_dofs_u);
     DoFTools::make_hanging_node_constraints(dof_handler_u, constraints_u);
 
@@ -1054,9 +1053,8 @@ namespace StokesClass
                                                     constraints_u);
     constraints_u.close();
 
-    IndexSet locally_relevant_dofs_p;
-    DoFTools::extract_locally_relevant_dofs(dof_handler_p,
-                                            locally_relevant_dofs_p);
+    const IndexSet locally_relevant_dofs_p =
+      DoFTools::extract_locally_relevant_dofs(dof_handler_p);
     constraints_p.reinit(locally_relevant_dofs_p);
     DoFTools::make_hanging_node_constraints(dof_handler_p, constraints_p);
     constraints_p.close();
@@ -1121,10 +1119,8 @@ namespace StokesClass
 
     for (unsigned int level = 0; level < n_levels; ++level)
       {
-        IndexSet relevant_dofs;
-        DoFTools::extract_locally_relevant_level_dofs(dof_handler_u,
-                                                      level,
-                                                      relevant_dofs);
+        const IndexSet relevant_dofs =
+          DoFTools::extract_locally_relevant_level_dofs(dof_handler_u, level);
         AffineConstraints<double> level_constraints;
         level_constraints.reinit(relevant_dofs);
         // level_constraints.add_lines(
@@ -1197,9 +1193,8 @@ namespace StokesClass
 
     // Create constraints with no Dirchlet info
     AffineConstraints<double> constraints_u_no_dirchlet;
-    IndexSet                  locally_relevant_dofs_u;
-    DoFTools::extract_locally_relevant_dofs(dof_handler_u,
-                                            locally_relevant_dofs_u);
+    const IndexSet            locally_relevant_dofs_u =
+      DoFTools::extract_locally_relevant_dofs(dof_handler_u);
     constraints_u_no_dirchlet.reinit(locally_relevant_dofs_u);
     DoFTools::make_hanging_node_constraints(dof_handler_u,
                                             constraints_u_no_dirchlet);

--- a/tests/numerics/project_parallel_qp_common.h
+++ b/tests/numerics/project_parallel_qp_common.h
@@ -111,8 +111,8 @@ do_project(const parallel::distributed::Triangulation<dim> &triangulation,
   deallog << "n_cells=" << triangulation.n_global_active_cells() << std::endl;
   deallog << "n_dofs=" << dof_handler.n_dofs() << std::endl;
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   AffineConstraints<double> constraints;
   constraints.reinit(locally_relevant_dofs);

--- a/tests/numerics/project_parallel_qpmf_common.h
+++ b/tests/numerics/project_parallel_qpmf_common.h
@@ -124,8 +124,8 @@ do_project(const parallel::distributed::Triangulation<dim> &triangulation,
       dof_handlers[i]->distribute_dofs(*fes[i]);
       deallog << "n_dofs=" << dof_handlers[i]->n_dofs() << std::endl;
 
-      DoFTools::extract_locally_relevant_dofs(*dof_handlers[i],
-                                              locally_relevant_dofs[i]);
+      locally_relevant_dofs[i] =
+        DoFTools::extract_locally_relevant_dofs(*dof_handlers[i]);
 
       constraints[i].reinit(locally_relevant_dofs[i]);
       DoFTools::make_hanging_node_constraints(*dof_handlers[i], constraints[i]);

--- a/tests/particles/interpolate_on_particle_01.cc
+++ b/tests/particles/interpolate_on_particle_01.cc
@@ -69,9 +69,9 @@ test()
   DoFHandler<dim, spacedim> space_dh(tria);
   space_dh.distribute_dofs(fe);
 
-  IndexSet locally_owned_dofs = space_dh.locally_owned_dofs();
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(space_dh, locally_relevant_dofs);
+  const IndexSet &locally_owned_dofs = space_dh.locally_owned_dofs();
+  const IndexSet  locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(space_dh);
 
   if (my_mpi_id == 0)
     deallog << "dim: " << dim << ", spacedim: " << spacedim << std::endl

--- a/tests/particles/particle_interpolation_01.cc
+++ b/tests/particles/particle_interpolation_01.cc
@@ -78,9 +78,9 @@ test()
   DoFHandler<dim, spacedim> space_dh(space_tria);
   space_dh.distribute_dofs(space_fe);
 
-  IndexSet locally_owned_dofs = space_dh.locally_owned_dofs();
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(space_dh, locally_relevant_dofs);
+  const IndexSet &locally_owned_dofs = space_dh.locally_owned_dofs();
+  const IndexSet  locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(space_dh);
 
   if (my_mpi_id == 0)
     deallog << "dim: " << dim << ", spacedim: " << spacedim << std::endl

--- a/tests/particles/particle_interpolation_02.cc
+++ b/tests/particles/particle_interpolation_02.cc
@@ -82,9 +82,9 @@ test()
   DoFHandler<dim, spacedim> space_dh(space_tria);
   space_dh.distribute_dofs(space_fe);
 
-  IndexSet locally_owned_dofs = space_dh.locally_owned_dofs();
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(space_dh, locally_relevant_dofs);
+  const IndexSet &locally_owned_dofs = space_dh.locally_owned_dofs();
+  const IndexSet  locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(space_dh);
 
   if (my_mpi_id == 0)
     deallog << "dim: " << dim << ", spacedim: " << spacedim << std::endl

--- a/tests/particles/particle_interpolation_03.cc
+++ b/tests/particles/particle_interpolation_03.cc
@@ -81,9 +81,9 @@ test()
   DoFHandler<dim, spacedim> space_dh(space_tria);
   space_dh.distribute_dofs(space_fe);
 
-  IndexSet locally_owned_dofs = space_dh.locally_owned_dofs();
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(space_dh, locally_relevant_dofs);
+  const IndexSet &locally_owned_dofs = space_dh.locally_owned_dofs();
+  const IndexSet  locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(space_dh);
 
   if (my_mpi_id == 0)
     deallog << "dim: " << dim << ", spacedim: " << spacedim << std::endl

--- a/tests/particles/particle_interpolation_04.cc
+++ b/tests/particles/particle_interpolation_04.cc
@@ -76,9 +76,9 @@ test()
   DoFHandler<dim, spacedim> space_dh(space_tria);
   space_dh.distribute_dofs(space_fe);
 
-  IndexSet locally_owned_dofs = space_dh.locally_owned_dofs();
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(space_dh, locally_relevant_dofs);
+  const IndexSet &locally_owned_dofs = space_dh.locally_owned_dofs();
+  const IndexSet  locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(space_dh);
 
   if (my_mpi_id == 0)
     deallog << "dim: " << dim << ", spacedim: " << spacedim << std::endl

--- a/tests/particles/particle_interpolation_05.cc
+++ b/tests/particles/particle_interpolation_05.cc
@@ -78,9 +78,9 @@ test()
   DoFHandler<dim, spacedim> space_dh(space_tria);
   space_dh.distribute_dofs(space_fe);
 
-  IndexSet locally_owned_dofs = space_dh.locally_owned_dofs();
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(space_dh, locally_relevant_dofs);
+  const IndexSet &locally_owned_dofs = space_dh.locally_owned_dofs();
+  const IndexSet  locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(space_dh);
 
   if (my_mpi_id == 0)
     deallog << "dim: " << dim << ", spacedim: " << spacedim << std::endl

--- a/tests/particles/step-68.cc
+++ b/tests/particles/step-68.cc
@@ -398,9 +398,9 @@ namespace Step68
   ParticleTracking<dim>::setup_background_dofs()
   {
     fluid_dh.distribute_dofs(fluid_fe);
-    const IndexSet locally_owned_dofs = fluid_dh.locally_owned_dofs();
-    IndexSet       locally_relevant_dofs;
-    DoFTools::extract_locally_relevant_dofs(fluid_dh, locally_relevant_dofs);
+    const IndexSet &locally_owned_dofs = fluid_dh.locally_owned_dofs();
+    const IndexSet  locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(fluid_dh);
 
     velocity_field.reinit(locally_owned_dofs,
                           locally_relevant_dofs,

--- a/tests/performance/timing_mg_glob_coarsen.cc
+++ b/tests/performance/timing_mg_glob_coarsen.cc
@@ -502,8 +502,7 @@ LaplaceProblem<dim>::setup_dofs()
       else
         dof_h.distribute_dofs(*fes[level + 1 - coarse_triangulations.size()]);
 
-      IndexSet relevant_dofs;
-      DoFTools::extract_locally_relevant_dofs(dof_h, relevant_dofs);
+      IndexSet relevant_dofs = DoFTools::extract_locally_relevant_dofs(dof_h);
       AffineConstraints<float> &constraints = level_constraints[level];
       constraints.reinit(relevant_dofs);
       DoFTools::make_hanging_node_constraints(dof_h, constraints);
@@ -517,7 +516,7 @@ LaplaceProblem<dim>::setup_dofs()
                                                 additional_data);
 
       // now create the final constraints object
-      DoFTools::extract_locally_relevant_dofs(dof_h, relevant_dofs);
+      relevant_dofs = DoFTools::extract_locally_relevant_dofs(dof_h);
       constraints.clear();
       constraints.reinit(relevant_dofs);
       DoFTools::make_hanging_node_constraints(dof_h, constraints);

--- a/tests/performance/timing_step_37.cc
+++ b/tests/performance/timing_step_37.cc
@@ -369,8 +369,8 @@ LaplaceProblem<dim>::setup_dofs()
 
   debug_output << "Number of DoFs: " << dof_handler.n_dofs() << std::endl;
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   constraints.clear();
   constraints.reinit(locally_relevant_dofs);
@@ -391,10 +391,8 @@ LaplaceProblem<dim>::setup_dofs()
 
   for (unsigned int level = 0; level < triangulation.n_global_levels(); ++level)
     {
-      IndexSet relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                    level,
-                                                    relevant_dofs);
+      const IndexSet relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
       AffineConstraints<double> level_constraints;
       level_constraints.reinit(relevant_dofs);
       level_constraints.add_lines(
@@ -442,10 +440,8 @@ LaplaceProblem<dim>::setup_matrix_free()
 
   for (unsigned int level = 0; level < nlevels; ++level)
     {
-      IndexSet relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                    level,
-                                                    relevant_dofs);
+      const IndexSet relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
       AffineConstraints<double> level_constraints;
       level_constraints.reinit(relevant_dofs);
       level_constraints.add_lines(

--- a/tests/performance/timing_step_37_gc.cc
+++ b/tests/performance/timing_step_37_gc.cc
@@ -369,8 +369,8 @@ LaplaceProblem<dim>::setup_dofs()
 
   debug_output << "Number of DoFs: " << dof_handler.n_dofs() << std::endl;
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   constraints.clear();
   constraints.reinit(locally_relevant_dofs);
@@ -391,10 +391,8 @@ LaplaceProblem<dim>::setup_dofs()
 
   for (unsigned int level = 0; level < triangulation.n_global_levels(); ++level)
     {
-      IndexSet relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                    level,
-                                                    relevant_dofs);
+      const IndexSet relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
       AffineConstraints<double> level_constraints;
       level_constraints.reinit(relevant_dofs);
       level_constraints.add_lines(
@@ -442,10 +440,8 @@ LaplaceProblem<dim>::setup_matrix_free()
 
   for (unsigned int level = 0; level < nlevels; ++level)
     {
-      IndexSet relevant_dofs;
-      DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                    level,
-                                                    relevant_dofs);
+      const IndexSet relevant_dofs =
+        DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
       AffineConstraints<double> level_constraints;
       level_constraints.reinit(relevant_dofs);
       level_constraints.add_lines(

--- a/tests/performance/timing_step_68.cc
+++ b/tests/performance/timing_step_68.cc
@@ -263,8 +263,8 @@ namespace Step68
   ParticleTracking<dim>::setup_background_dofs()
   {
     fluid_dh.distribute_dofs(fluid_fe);
-    const IndexSet locally_owned_dofs = fluid_dh.locally_owned_dofs();
-    const IndexSet locally_relevant_dofs =
+    const IndexSet &locally_owned_dofs = fluid_dh.locally_owned_dofs();
+    const IndexSet  locally_relevant_dofs =
       DoFTools::extract_locally_relevant_dofs(fluid_dh);
 
     velocity_field.reinit(locally_owned_dofs,

--- a/tests/petsc/bddc.cc
+++ b/tests/petsc/bddc.cc
@@ -69,16 +69,13 @@ main(int argc, char *argv[])
   GridGenerator::hyper_cube(triangulation);
   triangulation.refine_global(3);
 
-
-  IndexSet locally_owned_dofs;
-  IndexSet locally_relevant_dofs;
-  IndexSet locally_active_dofs;
-
   dof_handler.distribute_dofs(fe);
 
-  locally_owned_dofs    = dof_handler.locally_owned_dofs();
-  locally_relevant_dofs = DoFTools::extract_locally_relevant_dofs(dof_handler);
-  locally_active_dofs   = DoFTools::extract_locally_active_dofs(dof_handler);
+  const IndexSet &locally_owned_dofs = dof_handler.locally_owned_dofs();
+  const IndexSet  locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
+  const IndexSet locally_active_dofs =
+    DoFTools::extract_locally_active_dofs(dof_handler);
 
   DynamicSparsityPattern dsp(locally_relevant_dofs);
 

--- a/tests/petsc/step-77-snes.cc
+++ b/tests/petsc/step-77-snes.cc
@@ -178,8 +178,8 @@ namespace Step77
         dof_handler.distribute_dofs(fe);
       }
 
-    IndexSet locally_owned_dofs = dof_handler.locally_owned_dofs();
-    IndexSet locally_relevant_dofs =
+    const IndexSet &locally_owned_dofs = dof_handler.locally_owned_dofs();
+    const IndexSet  locally_relevant_dofs =
       DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     // Specifically, we need two types of AffineConstraints.

--- a/tests/petsc_complex/fe_get_function_values.cc
+++ b/tests/petsc_complex/fe_get_function_values.cc
@@ -80,9 +80,9 @@ test()
   DoFHandler<dim> dof_handler(tria);
   dof_handler.distribute_dofs(fe);
 
-  IndexSet locally_owned_dofs = dof_handler.locally_owned_dofs();
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet &locally_owned_dofs = dof_handler.locally_owned_dofs();
+  const IndexSet  locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   PETScWrappers::MPI::Vector                 vector, vector_locally_relevant;
   LinearAlgebra::distributed::Vector<double> vector_Re,

--- a/tests/petsc_complex/parallel_sparse_matrix_01.cc
+++ b/tests/petsc_complex/parallel_sparse_matrix_01.cc
@@ -74,9 +74,9 @@ test(const unsigned int poly_degree = 1)
   DoFHandler<dim> dof_handler(tria);
   dof_handler.distribute_dofs(fe);
 
-  IndexSet locally_owned_dofs = dof_handler.locally_owned_dofs();
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet &locally_owned_dofs = dof_handler.locally_owned_dofs();
+  const IndexSet  locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   PETScWrappers::MPI::Vector       vector;
   PETScWrappers::MPI::SparseMatrix mass_matrix;

--- a/tests/physics/step-18-rotation_matrix.cc
+++ b/tests/physics/step-18-rotation_matrix.cc
@@ -352,7 +352,8 @@ namespace Step18
   {
     dof_handler.distribute_dofs(fe);
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
     hanging_node_constraints.clear();
     DoFTools::make_hanging_node_constraints(dof_handler,
                                             hanging_node_constraints);

--- a/tests/physics/step-18.cc
+++ b/tests/physics/step-18.cc
@@ -368,7 +368,8 @@ namespace Step18
   {
     dof_handler.distribute_dofs(fe);
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
     hanging_node_constraints.clear();
     DoFTools::make_hanging_node_constraints(dof_handler,
                                             hanging_node_constraints);

--- a/tests/remote_point_evaluation/data_out_resample_01.cc
+++ b/tests/remote_point_evaluation/data_out_resample_01.cc
@@ -57,9 +57,8 @@ template <int dim, int spacedim>
 std::shared_ptr<const Utilities::MPI::Partitioner>
 create_partitioner(const DoFHandler<dim, spacedim> &dof_handler)
 {
-  IndexSet locally_relevant_dofs;
-
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   return std::make_shared<const Utilities::MPI::Partitioner>(
     dof_handler.locally_owned_dofs(),

--- a/tests/remote_point_evaluation/data_out_resample_02.cc
+++ b/tests/remote_point_evaluation/data_out_resample_02.cc
@@ -57,9 +57,8 @@ template <int dim, int spacedim>
 std::shared_ptr<const Utilities::MPI::Partitioner>
 create_partitioner(const DoFHandler<dim, spacedim> &dof_handler)
 {
-  IndexSet locally_relevant_dofs;
-
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   return std::make_shared<const Utilities::MPI::Partitioner>(
     dof_handler.locally_owned_dofs(),

--- a/tests/remote_point_evaluation/remote_point_evaluation_01.cc
+++ b/tests/remote_point_evaluation/remote_point_evaluation_01.cc
@@ -68,9 +68,8 @@ template <int dim, int spacedim>
 std::shared_ptr<const Utilities::MPI::Partitioner>
 create_partitioner(const DoFHandler<dim, spacedim> &dof_handler)
 {
-  IndexSet locally_relevant_dofs;
-
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   return std::make_shared<const Utilities::MPI::Partitioner>(
     dof_handler.locally_owned_dofs(),

--- a/tests/remote_point_evaluation/remote_point_evaluation_02.cc
+++ b/tests/remote_point_evaluation/remote_point_evaluation_02.cc
@@ -103,9 +103,8 @@ template <int dim, int spacedim>
 std::shared_ptr<const Utilities::MPI::Partitioner>
 create_partitioner(const DoFHandler<dim, spacedim> &dof_handler)
 {
-  IndexSet locally_relevant_dofs;
-
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   return std::make_shared<const Utilities::MPI::Partitioner>(
     dof_handler.locally_owned_dofs(),

--- a/tests/remote_point_evaluation/remote_point_evaluation_03.cc
+++ b/tests/remote_point_evaluation/remote_point_evaluation_03.cc
@@ -86,9 +86,8 @@ template <int dim, int spacedim>
 std::shared_ptr<const Utilities::MPI::Partitioner>
 create_partitioner(const DoFHandler<dim, spacedim> &dof_handler)
 {
-  IndexSet locally_relevant_dofs;
-
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   return std::make_shared<const Utilities::MPI::Partitioner>(
     dof_handler.locally_owned_dofs(),

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_01.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_01.cc
@@ -93,9 +93,8 @@ template <int dim, int spacedim>
 std::shared_ptr<const Utilities::MPI::Partitioner>
 create_partitioner(const DoFHandler<dim, spacedim> &dof_handler)
 {
-  IndexSet locally_relevant_dofs;
-
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   return std::make_shared<const Utilities::MPI::Partitioner>(
     dof_handler.locally_owned_dofs(),

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_02.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_02.cc
@@ -66,9 +66,8 @@ template <int dim, int spacedim>
 std::shared_ptr<const Utilities::MPI::Partitioner>
 create_partitioner(const DoFHandler<dim, spacedim> &dof_handler)
 {
-  IndexSet locally_relevant_dofs;
-
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   return std::make_shared<const Utilities::MPI::Partitioner>(
     dof_handler.locally_owned_dofs(),

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_03.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_03.cc
@@ -62,9 +62,8 @@ template <int dim, int spacedim>
 std::shared_ptr<const Utilities::MPI::Partitioner>
 create_partitioner(const DoFHandler<dim, spacedim> &dof_handler)
 {
-  IndexSet locally_relevant_dofs;
-
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   return std::make_shared<const Utilities::MPI::Partitioner>(
     dof_handler.locally_owned_dofs(),

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_04.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_04.cc
@@ -61,9 +61,8 @@ template <int dim, int spacedim>
 std::shared_ptr<const Utilities::MPI::Partitioner>
 create_partitioner(const DoFHandler<dim, spacedim> &dof_handler)
 {
-  IndexSet locally_relevant_dofs;
-
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   return std::make_shared<const Utilities::MPI::Partitioner>(
     dof_handler.locally_owned_dofs(),

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_05.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_05.cc
@@ -61,9 +61,8 @@ template <int dim, int spacedim>
 std::shared_ptr<const Utilities::MPI::Partitioner>
 create_partitioner(const DoFHandler<dim, spacedim> &dof_handler)
 {
-  IndexSet locally_relevant_dofs;
-
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   return std::make_shared<const Utilities::MPI::Partitioner>(
     dof_handler.locally_owned_dofs(),

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_06.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_06.cc
@@ -48,9 +48,8 @@ template <int dim, int spacedim>
 std::shared_ptr<const Utilities::MPI::Partitioner>
 create_partitioner(const DoFHandler<dim, spacedim> &dof_handler)
 {
-  IndexSet locally_relevant_dofs;
-
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   return std::make_shared<const Utilities::MPI::Partitioner>(
     dof_handler.locally_owned_dofs(),

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_07.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_07.cc
@@ -62,9 +62,8 @@ template <int dim, int spacedim>
 std::shared_ptr<const Utilities::MPI::Partitioner>
 create_partitioner(const DoFHandler<dim, spacedim> &dof_handler)
 {
-  IndexSet locally_relevant_dofs;
-
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   return std::make_shared<const Utilities::MPI::Partitioner>(
     dof_handler.locally_owned_dofs(),

--- a/tests/simplex/data_out_write_hdf5_02.cc
+++ b/tests/simplex/data_out_write_hdf5_02.cc
@@ -84,9 +84,9 @@ test(const FiniteElement<dim, spacedim> &fe, const unsigned int n_components)
   DoFHandler<dim> dof_handler(tria);
   dof_handler.distribute_dofs(fe);
 
-  IndexSet owned_dofs = dof_handler.locally_owned_dofs();
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet &owned_dofs = dof_handler.locally_owned_dofs();
+  const IndexSet  locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   LinearAlgebra::distributed::Vector<double> solution;
 

--- a/tests/simplex/extract_boundary_dofs.cc
+++ b/tests/simplex/extract_boundary_dofs.cc
@@ -56,8 +56,7 @@ test()
 
   // the result of extract_boundary_dofs is supposed to be a subset of the
   // locally relevant dofs, so test this
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
+  const IndexSet relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
   boundary_dofs.subtract_set(relevant_set);
   AssertThrow(boundary_dofs.n_elements() == 0, ExcInternalError());
 }

--- a/tests/simplex/poisson_01.cc
+++ b/tests/simplex/poisson_01.cc
@@ -149,8 +149,8 @@ test(const Triangulation<dim, spacedim> &tria,
 
   const MPI_Comm comm = get_communicator(dof_handler.get_triangulation());
 
-  IndexSet locally_relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
 
 #ifdef DEAL_II_WITH_TRILINOS

--- a/tests/simplex/step-18.cc
+++ b/tests/simplex/step-18.cc
@@ -495,7 +495,8 @@ namespace Step18
   {
     dof_handler.distribute_dofs(fe);
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     // The next step is to set up constraints due to hanging nodes. This has
     // been handled many times before:

--- a/tests/simplex/step-40.cc
+++ b/tests/simplex/step-40.cc
@@ -165,7 +165,8 @@ namespace Step40
     dof_handler.distribute_dofs(fe);
 
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     locally_relevant_solution.reinit(locally_owned_dofs,
                                      locally_relevant_dofs,

--- a/tests/simplex/step-55.cc
+++ b/tests/simplex/step-55.cc
@@ -455,8 +455,8 @@ namespace Step55
     owned_partitioning[1] =
       dof_handler.locally_owned_dofs().get_view(n_u, n_u + n_p);
 
-    IndexSet locally_relevant_dofs;
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    const IndexSet locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
     relevant_partitioning.resize(2);
     relevant_partitioning[0] = locally_relevant_dofs.get_view(0, n_u);
     relevant_partitioning[1] = locally_relevant_dofs.get_view(n_u, n_u + n_p);

--- a/tests/simplex/step-68.cc
+++ b/tests/simplex/step-68.cc
@@ -299,8 +299,8 @@ namespace Step68
   {
     fluid_dh.distribute_dofs(fluid_fe);
     const IndexSet locally_owned_dofs = fluid_dh.locally_owned_dofs();
-    IndexSet       locally_relevant_dofs;
-    DoFTools::extract_locally_relevant_dofs(fluid_dh, locally_relevant_dofs);
+    const IndexSet locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(fluid_dh);
 
     velocity_field.reinit(locally_owned_dofs,
                           locally_relevant_dofs,

--- a/tests/slepc/step-36_parallel.cc
+++ b/tests/slepc/step-36_parallel.cc
@@ -104,9 +104,8 @@ test(std::string solver_name, std::string preconditioner_name)
   std::vector<dealii::IndexSet> locally_owned_dofs_per_processor =
     DoFTools::locally_owned_dofs_per_subdomain(dof_handler);
   locally_owned_dofs = locally_owned_dofs_per_processor[this_mpi_process];
-  locally_relevant_dofs.clear();
-  dealii::DoFTools::extract_locally_relevant_dofs(dof_handler,
-                                                  locally_relevant_dofs);
+  locally_relevant_dofs =
+    dealii::DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   constraints.clear();
   constraints.reinit(locally_relevant_dofs);

--- a/tests/slepc/step-36_parallel_02.cc
+++ b/tests/slepc/step-36_parallel_02.cc
@@ -104,9 +104,8 @@ test(std::string solver_name, std::string preconditioner_name)
   std::vector<dealii::IndexSet> locally_owned_dofs_per_processor =
     DoFTools::locally_owned_dofs_per_subdomain(dof_handler);
   locally_owned_dofs = locally_owned_dofs_per_processor[this_mpi_process];
-  locally_relevant_dofs.clear();
-  dealii::DoFTools::extract_locally_relevant_dofs(dof_handler,
-                                                  locally_relevant_dofs);
+  locally_relevant_dofs =
+    dealii::DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   constraints.clear();
   constraints.reinit(locally_relevant_dofs);

--- a/tests/slepc/step-36_parallel_03.cc
+++ b/tests/slepc/step-36_parallel_03.cc
@@ -104,9 +104,8 @@ test(std::string solver_name, std::string preconditioner_name)
   std::vector<dealii::IndexSet> locally_owned_dofs_per_processor =
     DoFTools::locally_owned_dofs_per_subdomain(dof_handler);
   locally_owned_dofs = locally_owned_dofs_per_processor[this_mpi_process];
-  locally_relevant_dofs.clear();
-  dealii::DoFTools::extract_locally_relevant_dofs(dof_handler,
-                                                  locally_relevant_dofs);
+  locally_relevant_dofs =
+    dealii::DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   constraints.clear();
   constraints.reinit(locally_relevant_dofs);

--- a/tests/trilinos/assemble_matrix_parallel_02.cc
+++ b/tests/trilinos/assemble_matrix_parallel_02.cc
@@ -284,8 +284,8 @@ LaplaceProblem<dim>::setup_system()
   }
   {
     TrilinosWrappers::SparsityPattern csp;
-    IndexSet                          relevant_set;
-    DoFTools::extract_locally_relevant_dofs(dof_handler, relevant_set);
+    const IndexSet                    relevant_set =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
     csp.reinit(locally_owned, locally_owned, relevant_set, MPI_COMM_WORLD);
     DoFTools::make_sparsity_pattern(dof_handler, csp, constraints, false);
     csp.compress();

--- a/tests/trilinos/assemble_matrix_parallel_03.cc
+++ b/tests/trilinos/assemble_matrix_parallel_03.cc
@@ -285,8 +285,8 @@ LaplaceProblem<dim>::setup_system()
   }
   {
     TrilinosWrappers::SparsityPattern csp;
-    IndexSet                          relevant_set;
-    DoFTools::extract_locally_relevant_dofs(dof_handler, relevant_set);
+    const IndexSet                    relevant_set =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
     csp.reinit(locally_owned, locally_owned, relevant_set, MPI_COMM_WORLD);
     DoFTools::make_sparsity_pattern(dof_handler, csp, constraints, false);
     csp.compress();

--- a/tests/trilinos/assemble_matrix_parallel_04.cc
+++ b/tests/trilinos/assemble_matrix_parallel_04.cc
@@ -279,13 +279,14 @@ LaplaceProblem<dim>::setup_system()
                        std::placeholders::_1)));
 
   TrilinosWrappers::BlockSparsityPattern csp(2, 2);
-  std::vector<IndexSet>                  locally_owned(2), relevant_set(2);
-  IndexSet locally_owned_total = dof_handler.locally_owned_dofs(),
-           relevant_total;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, relevant_total);
+  const IndexSet &locally_owned_total = dof_handler.locally_owned_dofs();
+  const IndexSet  relevant_total =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   const std::vector<types::global_dof_index> dofs_per_block =
     DoFTools::count_dofs_per_fe_block(dof_handler, blocks);
+
+  std::vector<IndexSet> locally_owned(2), relevant_set(2);
   locally_owned[0] = locally_owned_total.get_view(0, dofs_per_block[0]);
   locally_owned[1] =
     locally_owned_total.get_view(dofs_per_block[0], dof_handler.n_dofs());

--- a/tests/trilinos/assemble_matrix_parallel_05.cc
+++ b/tests/trilinos/assemble_matrix_parallel_05.cc
@@ -285,8 +285,8 @@ LaplaceProblem<dim>::setup_system()
     reference_rhs.reinit(locally_owned, MPI_COMM_WORLD);
   }
   {
-    IndexSet relevant_set;
-    DoFTools::extract_locally_relevant_dofs(dof_handler, relevant_set);
+    const IndexSet relevant_set =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
     DynamicSparsityPattern csp(dof_handler.n_dofs(),
                                dof_handler.n_dofs(),
                                relevant_set);

--- a/tests/trilinos/assemble_matrix_parallel_06.cc
+++ b/tests/trilinos/assemble_matrix_parallel_06.cc
@@ -281,13 +281,14 @@ LaplaceProblem<dim>::setup_system()
                        std::placeholders::_1)));
 
   TrilinosWrappers::BlockSparsityPattern csp(2, 2);
-  std::vector<IndexSet>                  locally_owned(2), relevant_set(2);
-  IndexSet locally_owned_total = dof_handler.locally_owned_dofs(),
-           relevant_total;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, relevant_total);
+  const IndexSet &locally_owned_total = dof_handler.locally_owned_dofs();
+  const IndexSet  relevant_total =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   const std::vector<types::global_dof_index> dofs_per_block =
     DoFTools::count_dofs_per_fe_block(dof_handler, blocks);
+
+  std::vector<IndexSet> locally_owned(2), relevant_set(2);
   locally_owned[0] = locally_owned_total.get_view(0, dofs_per_block[0]);
   locally_owned[1] =
     locally_owned_total.get_view(dofs_per_block[0], dof_handler.n_dofs());

--- a/tests/trilinos/assemble_matrix_parallel_07.cc
+++ b/tests/trilinos/assemble_matrix_parallel_07.cc
@@ -285,8 +285,8 @@ LaplaceProblem<dim>::setup_system()
   }
   {
     TrilinosWrappers::SparsityPattern csp;
-    IndexSet                          relevant_set;
-    DoFTools::extract_locally_relevant_dofs(dof_handler, relevant_set);
+    const IndexSet                    relevant_set =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
     // TODO: currently no Trilinos version is capable of doing this...
     // #if DEAL_II_TRILINOS_VERSION_GTE(11,14,0)
     // Cannot pre-build sparsity pattern, Trilinos must provide it...

--- a/tests/trilinos/direct_solver_2.cc
+++ b/tests/trilinos/direct_solver_2.cc
@@ -192,10 +192,9 @@ Step4<dim>::setup_system()
                                            constraints);
   constraints.close();
 
-  IndexSet locally_owned_dofs = dof_handler.locally_owned_dofs();
-  IndexSet locally_relevant_dofs;
-
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet &locally_owned_dofs = dof_handler.locally_owned_dofs();
+  const IndexSet  locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
 
   DynamicSparsityPattern dsp(dof_handler.n_dofs());

--- a/tests/trilinos/direct_solver_3.cc
+++ b/tests/trilinos/direct_solver_3.cc
@@ -154,10 +154,9 @@ Step4<dim>::setup_system()
                                            constraints);
   constraints.close();
 
-  IndexSet locally_owned_dofs = dof_handler.locally_owned_dofs();
-  IndexSet locally_relevant_dofs;
-
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  const IndexSet &locally_owned_dofs = dof_handler.locally_owned_dofs();
+  const IndexSet  locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
 
   DynamicSparsityPattern dsp(dof_handler.n_dofs());

--- a/tests/trilinos/elide_zeros.cc
+++ b/tests/trilinos/elide_zeros.cc
@@ -153,7 +153,8 @@ namespace LinearAdvectionTest
   {
     dof_handler.distribute_dofs(fe);
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     DynamicSparsityPattern dynamic_sparsity_pattern(locally_relevant_dofs);
     Table<2, DoFTools::Coupling> cell_integral_mask(1, 1);

--- a/tests/trilinos/n_nonzeros_02_parallel.cc
+++ b/tests/trilinos/n_nonzeros_02_parallel.cc
@@ -48,9 +48,9 @@ test()
   Table<2, DoFTools::Coupling> coupling(1, 1);
   coupling.fill(DoFTools::none);
 
-  const IndexSet system_partitioning = dof_handler.locally_owned_dofs();
-  IndexSet       system_relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dof_handler, system_relevant_set);
+  const IndexSet &system_partitioning = dof_handler.locally_owned_dofs();
+  const IndexSet  system_relevant_set =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
 
 
   // create an empty sparsity pattern

--- a/tests/trilinos/renumbering_01.cc
+++ b/tests/trilinos/renumbering_01.cc
@@ -116,7 +116,8 @@ private:
   {
     locally_owned_dofs = dof_handler.locally_owned_dofs();
     locally_owned_dofs.print(deallog);
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
     locally_relevant_dofs.print(deallog);
 
     DynamicSparsityPattern sparsity_pattern(locally_relevant_dofs);

--- a/tests/trilinos/solver_control_06.cc
+++ b/tests/trilinos/solver_control_06.cc
@@ -196,8 +196,8 @@ Test_Solver_Output::setup_system()
   TimerOutput::Scope t(timer, "setup");
 
   dof_handler.distribute_dofs(fe);
-  locally_owned_dofs = dof_handler.locally_owned_dofs();
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  locally_owned_dofs    = dof_handler.locally_owned_dofs();
+  locally_relevant_dofs = DoFTools::extract_locally_relevant_dofs(dof_handler);
 
   locally_relevant_solution.reinit(locally_owned_dofs,
                                    locally_relevant_dofs,

--- a/tests/trilinos/trilinos_sparsity_pattern_02.cc
+++ b/tests/trilinos/trilinos_sparsity_pattern_02.cc
@@ -99,9 +99,8 @@ namespace Step22
       owned_partitioning.push_back(locally_owned_dofs.get_view(n_u, n_u + n_p));
 
       relevant_partitioning.clear();
-      IndexSet locally_relevant_dofs;
-      DoFTools::extract_locally_relevant_dofs(dof_handler,
-                                              locally_relevant_dofs);
+      const IndexSet locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(dof_handler);
       relevant_partitioning.push_back(locally_relevant_dofs.get_view(0, n_u));
       relevant_partitioning.push_back(
         locally_relevant_dofs.get_view(n_u, n_u + n_p));

--- a/tests/trilinos/trilinos_sparsity_pattern_05.cc
+++ b/tests/trilinos/trilinos_sparsity_pattern_05.cc
@@ -46,8 +46,8 @@ test()
   DoFHandler<dim> dh(triangulation);
   dh.distribute_dofs(fe_system);
 
-  IndexSet relevant_partitioning(dh.n_dofs());
-  DoFTools::extract_locally_relevant_dofs(dh, relevant_partitioning);
+  const IndexSet relevant_partitioning =
+    DoFTools::extract_locally_relevant_dofs(dh);
 
   // generate empty constraints
   AffineConstraints<double> constraints;

--- a/tests/vector_tools/add_constant_02.cc
+++ b/tests/vector_tools/add_constant_02.cc
@@ -101,8 +101,8 @@ test()
   QIterated<dim> quadrature(QTrapezoid<1>(), 5);
 
   const dealii::Function<dim, double> *w = nullptr;
-  IndexSet                             relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dofhandler, relevant_dofs);
+  const IndexSet                       relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dofhandler);
   VectorType ghosted(dofhandler.locally_owned_dofs(),
                      relevant_dofs,
                      MPI_COMM_WORLD);
@@ -150,8 +150,8 @@ test_simplex()
   const dealii::Function<dim, double> *w = nullptr;
   MappingFE<dim>                       mapping(FE_SimplexP<dim>(1));
 
-  IndexSet relevant_dofs;
-  DoFTools::extract_locally_relevant_dofs(dofhandler, relevant_dofs);
+  const IndexSet relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dofhandler);
   VectorType ghosted(dofhandler.locally_owned_dofs(),
                      relevant_dofs,
                      MPI_COMM_WORLD);

--- a/tests/vector_tools/integrate_difference_03.cc
+++ b/tests/vector_tools/integrate_difference_03.cc
@@ -83,8 +83,7 @@ test(VectorTools::NormType norm, double value, double exp = 2.0)
 
   VectorTools::interpolate(dofh, Ref<dim>(), interpolated);
 
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
+  const IndexSet relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
   TrilinosWrappers::MPI::Vector solution(relevant_set, MPI_COMM_WORLD);
   solution = interpolated;
 

--- a/tests/vector_tools/integrate_difference_04.cc
+++ b/tests/vector_tools/integrate_difference_04.cc
@@ -87,8 +87,7 @@ test(VectorTools::NormType norm, double value, double exp = 2.0)
 
   VectorTools::interpolate(dofh, Ref<dim>(), interpolated);
 
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
+  const IndexSet relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
   TrilinosWrappers::MPI::Vector solution(relevant_set, MPI_COMM_WORLD);
   solution = interpolated;
 

--- a/tests/vector_tools/integrate_difference_04_hp.cc
+++ b/tests/vector_tools/integrate_difference_04_hp.cc
@@ -94,8 +94,7 @@ test(VectorTools::NormType norm, double value, double exp = 2.0)
 
   VectorTools::interpolate(dofh, Ref<dim>(), interpolated);
 
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
+  const IndexSet relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
   TrilinosWrappers::MPI::Vector solution(relevant_set, MPI_COMM_WORLD);
   solution = interpolated;
 

--- a/tests/vector_tools/integrate_difference_04_hp_02.cc
+++ b/tests/vector_tools/integrate_difference_04_hp_02.cc
@@ -105,8 +105,7 @@ test(VectorTools::NormType norm, double value, double exp = 2.0)
 
   VectorTools::interpolate(dofh, Ref<dim>(), interpolated);
 
-  IndexSet relevant_set;
-  DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
+  const IndexSet relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
   TrilinosWrappers::MPI::Vector solution(relevant_set, MPI_COMM_WORLD);
   solution = interpolated;
 

--- a/tests/vector_tools/interpolate.cc
+++ b/tests/vector_tools/interpolate.cc
@@ -53,12 +53,11 @@ run(const dealii::Triangulation<dim> &triangulation)
   const dealii::FESystem<dim> fe_system_coarse(fe_q_coarse, dim);
   dof_handler_coarse.distribute_dofs(fe_system_coarse);
 
-  Vector           solution_coarse;
-  dealii::IndexSet locally_owned_dofs_coarse =
+  Vector                 solution_coarse;
+  const dealii::IndexSet locally_owned_dofs_coarse =
     dof_handler_coarse.locally_owned_dofs();
-  dealii::IndexSet ghost_dofs_coarse;
-  dealii::DoFTools::extract_locally_relevant_dofs(dof_handler_coarse,
-                                                  ghost_dofs_coarse);
+  dealii::IndexSet ghost_dofs_coarse =
+    dealii::DoFTools::extract_locally_relevant_dofs(dof_handler_coarse);
   dealii::IndexSet locally_relevant_dofs_coarse = ghost_dofs_coarse;
   ghost_dofs_coarse.subtract_set(locally_owned_dofs_coarse);
 
@@ -91,12 +90,11 @@ run(const dealii::Triangulation<dim> &triangulation)
   const dealii::FESystem<dim> fe_system_fine(fe_q_fine, dim);
   dof_handler_fine.distribute_dofs(fe_system_fine);
 
-  Vector           solution_fine;
-  dealii::IndexSet locally_owned_dofs_fine =
+  Vector                 solution_fine;
+  const dealii::IndexSet locally_owned_dofs_fine =
     dof_handler_fine.locally_owned_dofs();
-  dealii::IndexSet ghost_dofs_fine;
-  dealii::DoFTools::extract_locally_relevant_dofs(dof_handler_fine,
-                                                  ghost_dofs_fine);
+  dealii::IndexSet ghost_dofs_fine =
+    dealii::DoFTools::extract_locally_relevant_dofs(dof_handler_fine);
   dealii::IndexSet locally_relevant_dofs_fine = ghost_dofs_fine;
   ghost_dofs_fine.subtract_set(locally_owned_dofs_fine);
 


### PR DESCRIPTION
Follow-up to #15966.

This will make it easier for us to remove the deprecated functions in the future.