### PR TITLE
Matrix-free FEEvaluation: Avoid indirection in call to sum factorization

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -31,7 +31,6 @@
 
 #include <deal.II/matrix_free/evaluation_flags.h>
 #include <deal.II/matrix_free/evaluation_kernels.h>
-#include <deal.II/matrix_free/evaluation_selector.h>
 #include <deal.II/matrix_free/evaluation_template_factory.h>
 #include <deal.II/matrix_free/fe_evaluation_data.h>
 #include <deal.II/matrix_free/hanging_nodes_internal.h>
@@ -7855,8 +7854,11 @@ FEEvaluation<dim,
 
   if constexpr (fe_degree > -1)
     {
-      SelectEvaluator<dim, fe_degree, n_q_points_1d, VectorizedArrayType>::
-        evaluate(n_components, evaluation_flag_actual, values_array, *this);
+      internal::FEEvaluationImplSelector<dim, VectorizedArrayType, false>::
+        template run<fe_degree, n_q_points_1d>(n_components,
+                                               evaluation_flag_actual,
+                                               values_array,
+                                               *this);
     }
   else
     {
@@ -8084,12 +8086,12 @@ FEEvaluation<dim,
 
   if constexpr (fe_degree > -1)
     {
-      SelectEvaluator<dim, fe_degree, n_q_points_1d, VectorizedArrayType>::
-        integrate(n_components,
-                  integration_flag_actual,
-                  values_array,
-                  *this,
-                  sum_into_values_array);
+      internal::FEEvaluationImplSelector<dim, VectorizedArrayType, true>::
+        template run<fe_degree, n_q_points_1d>(n_components,
+                                               integration_flag_actual,
+                                               values_array,
+                                               *this,
+                                               sum_into_values_array);
     }
   else
     {


### PR DESCRIPTION
We simply forward the call to an internal function in https://github.com/dealii/dealii/blob/45ca30f1fa415e67a24674a6854cc9953eb8d833/include/deal.II/matrix_free/evaluation_selector.h#L71-L82 so I think we should simply call that function in `FEEvaluation::evaluate` and `FEEvaluation::integrate`.