### PR TITLE
Fix various typos

### DIFF
--- a/cmake/macros/macro_deal_ii_pickup_tests.cmake
+++ b/cmake/macros/macro_deal_ii_pickup_tests.cmake
@@ -163,7 +163,7 @@ macro(deal_ii_pickup_tests)
          "running mpi tests within the testsuite. As a consequence all "
          "tests that require an mpi launcher have been disabled.\n"
          "If you want to run tests with mpi then please configure deal.II "
-         "by either setting the MPIEXEC environemt variable or the CMake "
+         "by either setting the MPIEXEC environment variable or the CMake "
          "variable MPIEXEC_EXECUTABLE to a full path to the MPI launcher "
          "program.\n\n"
          )

--- a/cmake/macros/macro_define_interface_target.cmake
+++ b/cmake/macros/macro_define_interface_target.cmake
@@ -46,7 +46,7 @@
 #   targets), respectively.
 #
 # The default name, i.e., interface_<feature>(|_debug|_release) can be
-# overriden by the optional second argument. For example,
+# overridden by the optional second argument. For example,
 #   define_interface_target(DEAL_II base_configuration)
 # will define interface_base_configuration* targets but query all
 # information from DEAL_II_* variables.

--- a/cmake/macros/macro_populate_target_properties.cmake
+++ b/cmake/macros/macro_populate_target_properties.cmake
@@ -65,7 +65,7 @@ function(populate_target_properties _target _build)
 
   #
   # Do not add bundled include directories to bundled_ targets. First of
-  # all this is unnecessary, secondly, this severly trips up ICC-19 that
+  # all this is unnecessary, secondly, this severely trips up ICC-19 that
   # cannot handle the additional -isystem include properly...
   #
   if(NOT "${_target}" MATCHES "^bundled_")

--- a/cmake/macros/macro_shell_escape_option_groups.cmake
+++ b/cmake/macros/macro_shell_escape_option_groups.cmake
@@ -53,7 +53,7 @@ macro(shell_escape_option_groups _variable)
 
   #
   # In addition try to merge options of the form "-Wl,-flag -Wl,/path". We
-  # do this by detecting all occurences of a flag ("-Wl,-[-]flag") followed
+  # do this by detecting all occurrences of a flag ("-Wl,-[-]flag") followed
   # by an option that doesn't start with a dash ("-Wl,[option]"):
   #
   string(REGEX REPLACE

--- a/cmake/setup_compiler_flags_gnu.cmake
+++ b/cmake/setup_compiler_flags_gnu.cmake
@@ -199,7 +199,7 @@ if (CMAKE_BUILD_TYPE MATCHES "Debug")
 
   #
   # We have to ensure that we emit floating-point instructions in debug
-  # mode that preserve the occurence of floating-point exceptions and don't
+  # mode that preserve the occurrence of floating-point exceptions and don't
   # introduce new ones. gcc plays nicely in this regard by enabling
   # `-ftrapping-math` per default, at least for the level of optimization
   # we have in debug mode. clang however is more aggressive and assumes

--- a/examples/step-77/doc/results.dox
+++ b/examples/step-77/doc/results.dox
@@ -269,7 +269,7 @@ Mesh refinement step 0
 By default, PETSc uses a Newton solver with cubic backtracking,
 resampling the Jacobian matrix at each Newton step.  That is, we
 compute and factorize the matrix once per Newton step, and then sample
-the residual to check for a successul line-search.
+the residual to check for a successful line-search.
 
 The attentive reader should have noticed that in this case we are
 computing one more extra residual per Newton step.  This is because

--- a/examples/step-79/step-79.cc
+++ b/examples/step-79/step-79.cc
@@ -1687,7 +1687,7 @@ namespace SAND
       }
 
     // Then compute the residual and take the $l_1$ norms of the
-    // components that correspond to Lagrange mulipliers. We add
+    // components that correspond to Lagrange multipliers. We add
     // those to the objective function computed above, and return
     // the sum at the bottom:
     const BlockVector<double> test_rhs = calculate_test_rhs(test_solution);

--- a/include/deal.II/cgal/utilities.h
+++ b/include/deal.II/cgal/utilities.h
@@ -37,7 +37,7 @@
 #  include <CGAL/Mesh_complex_3_in_triangulation_3.h>
 #  include <CGAL/Mesh_criteria_3.h>
 #  include <CGAL/Mesh_triangulation_3.h>
-// Disable a warnung that we get with gcc-13 about a potential unitialized
+// Disable a warnung that we get with gcc-13 about a potential uninitialized
 // usage of an <anonymous> lambda function in this external CGAL header.
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <CGAL/Polygon_mesh_processing/corefinement.h>

--- a/include/deal.II/grid/tensor_product_manifold.h
+++ b/include/deal.II/grid/tensor_product_manifold.h
@@ -54,10 +54,10 @@ DEAL_II_NAMESPACE_OPEN
  * @tparam dim Dimension of cells (needs to match first template argument of
  * the Triangulation to be attached to.
  * @tparam dim_A Dimension of ChartManifold A.
- * @tparam spacedim_A Spacial dimension of ChartManifold A.
+ * @tparam spacedim_A Spatial dimension of ChartManifold A.
  * @tparam chartdim_A Chart dimension of ChartManifold A.
  * @tparam dim_B Dimension of ChartManifold B.
- * @tparam spacedim_B Spacial dimension of ChartManifold B.
+ * @tparam spacedim_B Spatial dimension of ChartManifold B.
  * @tparam chartdim_B Chart dimension of ChartManifold B.
  */
 template <int dim,

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -3606,7 +3606,7 @@ public:
 
   /**
    * Save the triangulation into the given file. Internally, this
-   * function calls the save funtion which uses BOOST archives. This
+   * function calls the save function which uses BOOST archives. This
    * is a placeholder implementation that, in the near future, will also
    * attach the data associated with the triangulation
    */

--- a/include/deal.II/matrix_free/constraint_info.h
+++ b/include/deal.II/matrix_free/constraint_info.h
@@ -78,7 +78,7 @@ namespace internal
 
     /**
      * A helper class to apply constraints in matrix-free loops in
-     * user code. It combines constraint related functionalties from
+     * user code. It combines constraint related functionalities from
      * MatrixFree and FEEvaluation.
      */
     template <int dim, typename Number>

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.h
@@ -1013,7 +1013,7 @@ public:
   /** @} */
 
   /**
-   * @name Tranfer functions.
+   * @name Transfer functions.
    */
   /** @{ */
 
@@ -1349,7 +1349,7 @@ MGTransferMF<dim, Number>::initialize_dof_vector(
       partitioner = external_partitioners[level - transfer.min_level()];
     }
 
-  // check if vectors are already correctly initalized
+  // check if vectors are already correctly initialized
 
   // yes: same partitioners are used
   if (vec.get_partitioner().get() == partitioner.get())

--- a/include/deal.II/numerics/vector_tools_boundary.templates.h
+++ b/include/deal.II/numerics/vector_tools_boundary.templates.h
@@ -2272,7 +2272,7 @@ namespace VectorTools
       std::vector<number>                        &dof_values,
       std::vector<types::global_dof_index>       &projected_dofs)
     {
-      // Compute the intergral over the product of the normal components of
+      // Compute the integral over the product of the normal components of
       // the boundary function times the normal components of the shape
       // functions supported on the boundary.
       const FEValuesExtractors::Vector vec(first_vector_component);

--- a/include/deal.II/opencascade/utilities.h
+++ b/include/deal.II/opencascade/utilities.h
@@ -142,7 +142,7 @@ namespace OpenCASCADE
    * mesh it automatically. We remark that the automatic mesh generation in
    * OpenCASCADE takes care only of the geometrical resemblance between the
    * shape and the mesh, to control the shape and regularity of the triangles
-   * you should use other meshing softwares. The two arguments `deflection` and
+   * you should use other meshing software. The two arguments `deflection` and
    * `angular_deflection` select the accuracy of the created triangulation with
    * respect to the original topological shape. The argument
    * `sew_different_faces` gives the possibility to use a Sewer from OpenCASCADE

--- a/include/deal.II/optimization/line_minimization.h
+++ b/include/deal.II/optimization/line_minimization.h
@@ -216,7 +216,7 @@ namespace LineMinimization
    *     // Ensure that the Dirichlet constraints are correctly applied,
    *     // irrespective of the step size
    *     constraints.distribute(newton_update_trial);
-   *     // Now add the constribution from the previously accepted solution
+   *     // Now add the contribution from the previously accepted solution
    *     // history.
    *     const Vector<double> solution_total_trial =
    *       get_solution_total(newton_update_trial);

--- a/source/differentiation/ad/adolc_number_types.cc
+++ b/source/differentiation/ad/adolc_number_types.cc
@@ -36,7 +36,7 @@ namespace numbers
     namespace
     {
       // Apply some comparator and extract the boolean result of the operation,
-      // instead of the "adub" return type tpyically returned by ADOL-C for
+      // instead of the "adub" return type typically returned by ADOL-C for
       // such a comparison. This is implemented as a general function so that
       // the list of implemented comparative operations can be easily extended.
       bool

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -2725,7 +2725,7 @@ namespace DoFTools
         // when on cell 1, we compute the weights of dof 'x' to be 1/2 from
         // parameter dofs 0 and 1, respectively. however, when later we are on
         // cell 2, we again compute the prolongation of shape function 1
-        // restricted to cell 2 to the globla grid and find that the weight of
+        // restricted to cell 2 to the global grid and find that the weight of
         // global dof 'x' now is zero. however, we should not overwrite the old
         // value.
         //

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -1369,7 +1369,7 @@ GridIn<dim, spacedim>::read_dbmesh(std::istream &in)
   // of fields of which I have no
   // clue what they mean. skip them
   // all and leave the interpretation
-  // to other implementors...
+  // to other implementers...
   while (getline(in, line), ((line.find("End") == std::string::npos) && (in)))
     ;
   // ok, so we are not at the end of

--- a/source/hp/refinement.cc
+++ b/source/hp/refinement.cc
@@ -308,7 +308,7 @@ namespace hp
       //     that apply to all or none of the cells at once. However here, we
       //     do not know which threshold would suffice for this task because the
       //     user could provide any comparison function. Thus if necessary, we
-      //     overwrite the user's choice with suitable functions simplying
+      //     overwrite the user's choice with suitable functions simply
       //     returning 'true' and 'false' for any cell with reference wrappers.
       //     Thus, no function object copies are stored.
       //

--- a/source/lac/trilinos_precondition_ml.cc
+++ b/source/lac/trilinos_precondition_ml.cc
@@ -74,7 +74,7 @@ namespace TrilinosWrappers
         ML_Epetra::SetDefaults("SA", parameter_list);
 
         // uncoupled mode can give a lot of warnings or even fail when there
-        // are too many entries per row and aggreggation gets complicated, but
+        // are too many entries per row and aggregation gets complicated, but
         // MIS does not work if too few elements are located on one
         // processor. work around these warnings by choosing the different
         // strategies in different situations: for low order, always use the

--- a/source/matrix_free/vector_data_exchange.cc
+++ b/source/matrix_free/vector_data_exchange.cc
@@ -389,7 +389,7 @@ namespace internal
         const auto &ghost_indices_within_larger_ghost_set =
           partitioner->ghost_indices_within_larger_ghost_set();
 
-        // temporal data strucutures
+        // temporal data structures
         std::vector<unsigned int> n_ghost_indices_in_larger_set_by_remote_rank;
 
         std::vector<std::array<unsigned int, 3>> ghost_targets_data;

--- a/tests/base/bounding_box_1.cc
+++ b/tests/base/bounding_box_1.cc
@@ -105,7 +105,7 @@ test_bounding_box()
   }
   deallog << std::endl;
 
-  // Initalize box with point
+  // Initialize box with point
   {
     Point<spacedim> p;
     for (unsigned int i = 0; i < spacedim; ++i)
@@ -118,7 +118,7 @@ test_bounding_box()
   }
   deallog << std::endl;
 
-  // Initalize box with box
+  // Initialize box with box
   {
     BoundingBox<spacedim> bb(b);
     deallog << "Boundary points: " << std::endl;
@@ -127,7 +127,7 @@ test_bounding_box()
   }
   deallog << std::endl;
 
-  // Initalize box with box
+  // Initialize box with box
   {
     BoundingBox<spacedim> bb;
     bb = b;

--- a/tests/boost/node_visitor_02.cc
+++ b/tests/boost/node_visitor_02.cc
@@ -13,7 +13,7 @@
 //
 // ---------------------------------------------------------------------
 
-// Use information from NodeVisitor to print show explicitely the boxes
+// Use information from NodeVisitor to print show explicitly the boxes
 // associated to each parent node on the previous level
 
 #include <deal.II/base/bounding_box.h>

--- a/tests/cgal/cgal_intersect_simplices_3d_3d_02.cc
+++ b/tests/cgal/cgal_intersect_simplices_3d_3d_02.cc
@@ -13,7 +13,7 @@
 //
 // ---------------------------------------------------------------------
 
-// Compute intersection of two 3D cells. This additional test is added becase
+// Compute intersection of two 3D cells. This additional test is added because
 // intersections are not found with inexact kernels.
 
 #include <deal.II/fe/mapping_q1.h>

--- a/tests/codim_one/bem.cc
+++ b/tests/codim_one/bem.cc
@@ -122,7 +122,7 @@ BEM<spacedim>::run()
       SphericalManifold<spacedim - 1, spacedim> boundary(p);
       tria.set_manifold(1, boundary);
 
-      // works up to cycle<9, but for testin purpose, we stop at 4
+      // works up to cycle<9, but for testing purpose, we stop at 4
       for (unsigned int cycle = 0; cycle < 4; ++cycle)
         {
           tria.set_manifold(1, boundary);

--- a/tests/codim_one/integrate_one_over_r.cc
+++ b/tests/codim_one/integrate_one_over_r.cc
@@ -93,7 +93,7 @@ main()
                     deallog << std::endl;
                   else
                     deallog
-                      << ", desing: " << approx_integral_2 - exact_integral
+                      << ", design: " << approx_integral_2 - exact_integral
                       << std::endl;
                 }
             }

--- a/tests/fe/fe_enriched_compare_to_fe_system.cc
+++ b/tests/fe/fe_enriched_compare_to_fe_system.cc
@@ -51,7 +51,7 @@ const double eps = 1e-10;
 // move nodes randomly
 // and compare FEEnriched to FESystem with explicit treatment of
 // the product rule for
-// valus, gradients, hessians on
+// values, gradients, hessians on
 // elements and faces.
 // The comparison is straight forward because local dofs are enumerated
 // in the same way for FE_System and FEEnriched.

--- a/tests/fe/fe_enriched_compare_to_fe_system_2.cc
+++ b/tests/fe/fe_enriched_compare_to_fe_system_2.cc
@@ -51,7 +51,7 @@ const double eps = 1e-10;
 // move nodes randomly
 // and compare FEEnriched to FESystem with explicit treatment of
 // the product rule for
-// valus, gradients, hessians on
+// values, gradients, hessians on
 // elements and faces.
 // The comparison is straight forward because local dofs are enumerated
 // in the same way for FE_System and FEEnriched.

--- a/tests/grid/distributed_compute_point_locations_03.cc
+++ b/tests/grid/distributed_compute_point_locations_03.cc
@@ -49,7 +49,7 @@ test_distributed_cpt(unsigned int ref_cube)
           << std::endl;
   deallog << "Cube refinements: " << ref_cube << std::endl;
 
-  // Creeating the cube on which to run distributed cpt loc
+  // Creating the cube on which to run distributed cpt loc
   parallel::distributed::Triangulation<dim> cube_d(mpi_communicator);
   GridGenerator::hyper_cube(cube_d);
   cube_d.refine_global(ref_cube);

--- a/tests/hp/fe_nothing_18.cc
+++ b/tests/hp/fe_nothing_18.cc
@@ -242,7 +242,7 @@ ElasticProblem<dim>::ElasticProblem()
   , degree(1)
   , dofs_per_block(n_blocks)
   , dof_handler(triangulation)
-  , /*assotiate dof_handler to the triangulation */
+  , /*associate dof_handler to the triangulation */
   elasticity_fe(
     FE_Q<dim>(degree),
     dim, // use dim FE_Q of a given degree to represent displacements

--- a/tests/lac/packaged_operation_02.cc
+++ b/tests/lac/packaged_operation_02.cc
@@ -20,7 +20,7 @@
 
 #include "../tests.h"
 
-// and a _lot_ of stuff to create a linera oprator
+// and a _lot_ of stuff to create a linear operator
 #include <deal.II/base/quadrature_lib.h>
 
 #include <deal.II/dofs/dof_handler.h>
@@ -67,7 +67,7 @@ main()
 
   static const int dim = 2;
 
-  // Create mass marix M, and an iterative inverse MInv:
+  // Create mass matrix M, and an iterative inverse MInv:
 
   Triangulation<dim> triangulation;
   GridGenerator::hyper_cube(triangulation);

--- a/tests/lac/tensor_product_matrix.h
+++ b/tests/lac/tensor_product_matrix.h
@@ -65,7 +65,7 @@ namespace dealii
     }
 
     // Compute harmonic extent of each locally owned cell including of each
-    // of its neighbors. If there is no neigbor, its extent is zero.
+    // of its neighbors. If there is no neighbor, its extent is zero.
     template <int dim>
     std::vector<dealii::ndarray<double, dim, 3>>
     compute_harmonic_patch_extent(const Mapping<dim>        &mapping,
@@ -79,7 +79,7 @@ namespace dealii
                                                 quadrature);
 
       // 2) accumulate for each face the normal extent for the
-      // neigboring cell(s); here we also consider periodicies
+      // neighboring cell(s); here we also consider periodicies
       std::vector<double> face_extent(triangulation.n_faces(), 0.0);
 
       for (const auto &cell : triangulation.active_cell_iterators())

--- a/tests/matrix_free/parallel_multigrid_adaptive_07.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_07.cc
@@ -18,7 +18,7 @@
 // This test is similar to parallel_multigrid_adaptive_06 but we also test
 // for different polynomial degree in different blocks.
 // We expect to have the same iteration numbers as in
-// parallel_multigrid_adaptive_06 with repsect to the highest polynomial
+// parallel_multigrid_adaptive_06 with respect to the highest polynomial
 // degree used.
 
 

--- a/tests/multigrid-global-coarsening/parallel_multigrid_adaptive_07.cc
+++ b/tests/multigrid-global-coarsening/parallel_multigrid_adaptive_07.cc
@@ -18,7 +18,7 @@
 // This test is similar to parallel_multigrid_adaptive_06 but we also test
 // for different polynomial degree in different blocks.
 // We expect to have the same iteration numbers as in
-// parallel_multigrid_adaptive_06 with repsect to the highest polynomial
+// parallel_multigrid_adaptive_06 with respect to the highest polynomial
 // degree used.
 
 

--- a/tests/optimization/step-44.h
+++ b/tests/optimization/step-44.h
@@ -1331,7 +1331,7 @@ namespace Step44
             BlockVector<double> solution_delta_trial(newton_update);
             solution_delta_trial *= ss;
             this->constraints.distribute(solution_delta_trial);
-            // Now add the constribution from the previously accepted solution
+            // Now add the contribution from the previously accepted solution
             // history.
             solution_delta_trial += solution_delta;
 

--- a/tests/performance/collect_measurements
+++ b/tests/performance/collect_measurements
@@ -23,7 +23,7 @@
 #
 
 #
-# First, collect some metatadata:
+# First, collect some metadata:
 #
 
 site="${1}"

--- a/tests/petsc/petsc_ts_03.cc
+++ b/tests/petsc/petsc_ts_03.cc
@@ -171,7 +171,7 @@ public:
               << ')' << std::endl;
     };
 
-    // This callback is invoked after a successfull stage.
+    // This callback is invoked after a successful stage.
     // Here we only print that the callback is invoked.
     time_stepper.distribute = [&](const real_type t, VectorType &) -> void {
       deallog << "Distribute at time " << t << std::endl;

--- a/tests/petsc/step-77-snes.cc
+++ b/tests/petsc/step-77-snes.cc
@@ -496,7 +496,7 @@ namespace Step77
         // reach; but you might want to look into what other members of the
         // PETScWrappers::NonlinearSolverData class has and play with them).
         //
-        // When using the PETSc nonlinear solver, we have two possibilites,
+        // When using the PETSc nonlinear solver, we have two possibilities,
         // both of them are coded below for this example.
         //  - In the case with `user_control` set to true
         //    there is complete control of the linear system solution process

--- a/tests/symengine/basic_05.cc
+++ b/tests/symengine/basic_05.cc
@@ -13,7 +13,7 @@
 //
 // ---------------------------------------------------------------------
 
-// Check that SymEngine can do some optimsation on diffentiated expressions
+// Check that SymEngine can do some optimsation on differentiated expressions
 // using lambda functions
 // This is an extension of basic_04.cc
 

--- a/tests/symengine/batch_optimizer_03_1a.cc
+++ b/tests/symengine/batch_optimizer_03_1a.cc
@@ -20,7 +20,7 @@
 // See tests/symengine/basic_06.cc and tests/symengine/basic_07.cc for
 // a more simple example of differentiation of symbols with
 // explicit/implicit relationships.
-// We invoke the batch optimzer before symbolic evaluation takes place.
+// We invoke the batch optimizer before symbolic evaluation takes place.
 //
 // Here we use only dictionary substitution, and invoke no symbolic
 // optimizations.

--- a/tests/symengine/sd_common_tests/batch_optimizer_02.h
+++ b/tests/symengine/sd_common_tests/batch_optimizer_02.h
@@ -17,7 +17,7 @@
 // Check that the wrapper for symengine numbers can be integrated into the
 // tensor class and works as expected.
 // This test is the same as symengine_wrapper_03.cc, except that we invoke the
-// batch optimzer  before symbolic evaluation takes place.
+// batch optimizer before symbolic evaluation takes place.
 
 #include <deal.II/base/timer.h>
 

--- a/tests/symengine/sd_common_tests/batch_optimizer_03.h
+++ b/tests/symengine/sd_common_tests/batch_optimizer_03.h
@@ -20,7 +20,7 @@
 // See tests/symengine/basic_06.cc and tests/symengine/basic_07.cc for
 // a more simple example of differentiation of symbols with
 // explicit/implicit relationships.
-// We invoke the batch optimzer before symbolic evaluation takes place.
+// We invoke the batch optimizer before symbolic evaluation takes place.
 
 #include <deal.II/base/symmetric_tensor.h>
 #include <deal.II/base/tensor.h>


### PR DESCRIPTION
Found via `codespell -q 3 -S ./bundled,./doc/news -L ans,ba,bu,clen,commend,compontent,inout,nd,pres,re-use,ro,rotat,stoer,workd`