### PR TITLE
Assert that AffineConstraints got index sets when running in parallel.

### DIFF
--- a/tests/gla/block_vec_02.cc
+++ b/tests/gla/block_vec_02.cc
@@ -77,7 +77,8 @@ test()
 
 
   using scalar_type = typename LA::MPI::BlockVector::value_type;
-  AffineConstraints<scalar_type> cm;
+  AffineConstraints<scalar_type> cm(complete_index_set(v.size()),
+                                    complete_index_set(v.size()));
   cm.add_line(0);
   cm.add_entry(0, 1, 3.0);
   cm.close();

--- a/tests/gla/vec_03.cc
+++ b/tests/gla/vec_03.cc
@@ -80,7 +80,8 @@ test()
          ExcInternalError());
 
   using scalar_type = typename LA::MPI::BlockVector::value_type;
-  AffineConstraints<scalar_type> cm;
+  AffineConstraints<scalar_type> cm(local_active,
+                                    complete_index_set(local_active.size()));
   cm.add_line(1);
   cm.add_entry(1, 2, 3.0);
   cm.close();

--- a/tests/hp/field_transfer_05.cc
+++ b/tests/hp/field_transfer_05.cc
@@ -148,7 +148,9 @@ main(int argc, char *argv[])
   LinearAlgebra::distributed::Vector<double> new_solution(
     dof_handler.locally_owned_dofs(), locally_relevant_dofs, MPI_COMM_WORLD);
 
-  AffineConstraints<double> affine_constraints;
+  AffineConstraints<double> affine_constraints(
+    dof_handler.locally_owned_dofs(),
+    DoFTools::extract_locally_relevant_dofs(dof_handler));
   DoFTools::make_hanging_node_constraints(dof_handler, affine_constraints);
   affine_constraints.close();
 

--- a/tests/lac/linear_operator_12.cc
+++ b/tests/lac/linear_operator_12.cc
@@ -186,6 +186,8 @@ Step4<dim>::setup_system()
   dof_handler.distribute_dofs(fe);
 
   constraints.clear();
+  constraints.reinit(dof_handler.locally_owned_dofs(),
+                     DoFTools::extract_locally_relevant_dofs(dof_handler));
   std::map<unsigned int, double> boundary_values;
   VectorTools::interpolate_boundary_values(dof_handler,
                                            0,

--- a/tests/lac/linear_operator_12a.cc
+++ b/tests/lac/linear_operator_12a.cc
@@ -187,6 +187,8 @@ Step4<dim>::setup_system()
   dof_handler.distribute_dofs(fe);
 
   constraints.clear();
+  constraints.reinit(dof_handler.locally_owned_dofs(),
+                     DoFTools::extract_locally_relevant_dofs(dof_handler));
   std::map<unsigned int, double> boundary_values;
   VectorTools::interpolate_boundary_values(dof_handler,
                                            0,

--- a/tests/mpi/fe_tools_extrapolate_common.h
+++ b/tests/mpi/fe_tools_extrapolate_common.h
@@ -193,12 +193,6 @@ check_this(const FiniteElement<dim> &fe1, const FiniteElement<dim> &fe2)
 
   std::unique_ptr<DoFHandler<dim>> dof1(make_dof_handler(*tria, fe1));
   std::unique_ptr<DoFHandler<dim>> dof2(make_dof_handler(*tria, fe2));
-  AffineConstraints<double>        cm1;
-  DoFTools::make_hanging_node_constraints(*dof1, cm1);
-  cm1.close();
-  AffineConstraints<double> cm2;
-  DoFTools::make_hanging_node_constraints(*dof2, cm2);
-  cm2.close();
 
   const IndexSet &locally_owned_dofs1 = dof1->locally_owned_dofs();
   const IndexSet  locally_relevant_dofs1 =
@@ -206,6 +200,16 @@ check_this(const FiniteElement<dim> &fe1, const FiniteElement<dim> &fe2)
   const IndexSet &locally_owned_dofs2 = dof2->locally_owned_dofs();
   const IndexSet  locally_relevant_dofs2 =
     DoFTools::extract_locally_relevant_dofs(*dof2);
+
+  AffineConstraints<PetscScalar> cm1(locally_owned_dofs1,
+                                     locally_relevant_dofs1);
+  DoFTools::make_hanging_node_constraints(*dof1, cm1);
+  cm1.close();
+  AffineConstraints<PetscScalar> cm2(locally_owned_dofs2,
+                                     locally_relevant_dofs2);
+  DoFTools::make_hanging_node_constraints(*dof2, cm2);
+  cm2.close();
+
 
   VectorType in_ghosted =
     build_ghosted<VectorType>(locally_owned_dofs1, locally_relevant_dofs1);
@@ -324,12 +328,6 @@ check_this_dealii(const FiniteElement<dim> &fe1, const FiniteElement<dim> &fe2)
 
   std::unique_ptr<DoFHandler<dim>> dof1(make_dof_handler(*tria, fe1));
   std::unique_ptr<DoFHandler<dim>> dof2(make_dof_handler(*tria, fe2));
-  AffineConstraints<double>        cm1;
-  DoFTools::make_hanging_node_constraints(*dof1, cm1);
-  cm1.close();
-  AffineConstraints<double> cm2;
-  DoFTools::make_hanging_node_constraints(*dof2, cm2);
-  cm2.close();
 
   const IndexSet &locally_owned_dofs1 = dof1->locally_owned_dofs();
   const IndexSet  locally_relevant_dofs1 =
@@ -337,6 +335,13 @@ check_this_dealii(const FiniteElement<dim> &fe1, const FiniteElement<dim> &fe2)
   const IndexSet &locally_owned_dofs2 = dof2->locally_owned_dofs();
   const IndexSet  locally_relevant_dofs2 =
     DoFTools::extract_locally_relevant_dofs(*dof2);
+
+  AffineConstraints<double> cm1(locally_owned_dofs1, locally_relevant_dofs1);
+  DoFTools::make_hanging_node_constraints(*dof1, cm1);
+  cm1.close();
+  AffineConstraints<double> cm2(locally_owned_dofs2, locally_relevant_dofs2);
+  DoFTools::make_hanging_node_constraints(*dof2, cm2);
+  cm2.close();
 
   VectorType in_ghosted =
     build_ghosted<VectorType>(locally_owned_dofs1, locally_relevant_dofs1);

--- a/tests/mpi/hp_integrate_difference.cc
+++ b/tests/mpi/hp_integrate_difference.cc
@@ -156,15 +156,16 @@ test()
   VectorTools::interpolate(dof_handler, CheckFunction<dim>(), interpolated);
 
   // then also apply constraints
-  AffineConstraints<double> hanging_node_constraints;
+  const IndexSet relevant_set =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
+  AffineConstraints<double> hanging_node_constraints(
+    dof_handler.locally_owned_dofs(), relevant_set);
   DoFTools::make_hanging_node_constraints(dof_handler,
                                           hanging_node_constraints);
   hanging_node_constraints.close();
   hanging_node_constraints.distribute(interpolated);
 
   // extract a vector that has ghost elements
-  const IndexSet relevant_set =
-    DoFTools::extract_locally_relevant_dofs(dof_handler);
   TrilinosWrappers::MPI::Vector x_rel(relevant_set, MPI_COMM_WORLD);
   x_rel = interpolated;
 

--- a/tests/mpi/interpolate_04.cc
+++ b/tests/mpi/interpolate_04.cc
@@ -60,17 +60,19 @@ test()
   dofh1.distribute_dofs(fe);
   dofh2.distribute_dofs(fe);
 
-  AffineConstraints<PetscScalar> cm1;
-  cm1.close();
-  AffineConstraints<PetscScalar> cm2;
-  cm2.close();
-
   const IndexSet &dof1_locally_owned_dofs = dofh1.locally_owned_dofs();
   const IndexSet &dof2_locally_owned_dofs = dofh2.locally_owned_dofs();
   const IndexSet  dof1_locally_relevant_dofs =
     DoFTools::extract_locally_relevant_dofs(dofh1);
   const IndexSet dof2_locally_relevant_dofs =
     DoFTools::extract_locally_relevant_dofs(dofh2);
+
+  AffineConstraints<PetscScalar> cm1(dof1_locally_owned_dofs,
+                                     dof1_locally_relevant_dofs);
+  cm1.close();
+  AffineConstraints<PetscScalar> cm2(dof2_locally_owned_dofs,
+                                     dof2_locally_relevant_dofs);
+  cm2.close();
 
 
   PETScWrappers::MPI::Vector u1(dof1_locally_owned_dofs,

--- a/tests/mpi/multigrid_adaptive.cc
+++ b/tests/mpi/multigrid_adaptive.cc
@@ -189,6 +189,8 @@ namespace Step50
     system_rhs.reinit(mg_dof_handler.locally_owned_dofs(), MPI_COMM_WORLD);
 
     constraints.clear();
+    constraints.reinit(mg_dof_handler.locally_owned_dofs(),
+                       DoFTools::extract_locally_relevant_dofs(mg_dof_handler));
     DoFTools::make_hanging_node_constraints(mg_dof_handler, constraints);
 
     std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;

--- a/tests/mpi/multigrid_uniform.cc
+++ b/tests/mpi/multigrid_uniform.cc
@@ -189,6 +189,8 @@ namespace Step50
     system_rhs.reinit(mg_dof_handler.locally_owned_dofs(), MPI_COMM_WORLD);
 
     constraints.clear();
+    constraints.reinit(mg_dof_handler.locally_owned_dofs(),
+                       DoFTools::extract_locally_relevant_dofs(mg_dof_handler));
     DoFTools::make_hanging_node_constraints(mg_dof_handler, constraints);
 
     std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;

--- a/tests/mpi/step-37.cc
+++ b/tests/mpi/step-37.cc
@@ -195,6 +195,9 @@ namespace Step37
 
     // Apply hanging node constraints on that vector
     constraints_euler.clear();
+    constraints_euler.reinit(dof_euler.locally_owned_dofs(),
+                             DoFTools::extract_locally_relevant_dofs(
+                               dof_euler));
     DoFTools::make_hanging_node_constraints(dof_euler, constraints_euler);
     constraints_euler.close();
     constraints_euler.distribute(euler_positions);

--- a/tests/multigrid-global-coarsening/mg_data_out_05.cc
+++ b/tests/multigrid-global-coarsening/mg_data_out_05.cc
@@ -73,7 +73,8 @@ do_test()
   FunctionParser<dim> function(dim == 2 ? "y;-x;x*x+y*y" :
                                           "y;-x;0;x*x+y*y+z*z");
 
-  AffineConstraints<double> constraints;
+  AffineConstraints<double> constraints(dof_handler.locally_owned_dofs(),
+                                        locally_relevant_dofs);
   DoFTools::make_hanging_node_constraints(dof_handler, constraints);
   constraints.close();
   VectorTools::project(

--- a/tests/multigrid-global-coarsening/mg_transfer_p_01.cc
+++ b/tests/multigrid-global-coarsening/mg_transfer_p_01.cc
@@ -81,12 +81,18 @@ do_test(const FiniteElement<dim> &fe_fine, const FiniteElement<dim> &fe_coarse)
   DoFHandler<dim> dof_handler_coarse(tria);
   dof_handler_coarse.distribute_dofs(fe_coarse);
 
-  AffineConstraints<Number> constraint_coarse;
+  AffineConstraints<Number> constraint_coarse(
+    dof_handler_coarse.locally_owned_dofs(),
+    DoFTools::extract_locally_relevant_dofs(dof_handler_coarse));
+
+  AffineConstraints<Number> constraint_fine(
+    dof_handler_fine.locally_owned_dofs(),
+    DoFTools::extract_locally_relevant_dofs(dof_handler_fine));
+
   DoFTools::make_hanging_node_constraints(dof_handler_coarse,
                                           constraint_coarse);
   constraint_coarse.close();
 
-  AffineConstraints<Number> constraint_fine;
   DoFTools::make_hanging_node_constraints(dof_handler_fine, constraint_fine);
   constraint_fine.close();
 

--- a/tests/multigrid-global-coarsening/mg_transfer_p_02.cc
+++ b/tests/multigrid-global-coarsening/mg_transfer_p_02.cc
@@ -126,12 +126,18 @@ do_test()
       dof_handler_fine.distribute_dofs(fe_collection);
       dof_handler_coarse.distribute_dofs(fe_collection);
 
-      AffineConstraints<Number> constraint_coarse;
+      AffineConstraints<Number> constraint_coarse(
+        dof_handler_coarse.locally_owned_dofs(),
+        DoFTools::extract_locally_relevant_dofs(dof_handler_coarse));
+
+      AffineConstraints<Number> constraint_fine(
+        dof_handler_fine.locally_owned_dofs(),
+        DoFTools::extract_locally_relevant_dofs(dof_handler_fine));
+
       DoFTools::make_hanging_node_constraints(dof_handler_coarse,
                                               constraint_coarse);
       constraint_coarse.close();
 
-      AffineConstraints<Number> constraint_fine;
       DoFTools::make_hanging_node_constraints(dof_handler_fine,
                                               constraint_fine);
       constraint_fine.close();

--- a/tests/multigrid-global-coarsening/mg_transfer_p_03.cc
+++ b/tests/multigrid-global-coarsening/mg_transfer_p_03.cc
@@ -68,12 +68,18 @@ do_test(const FiniteElement<dim> &fe_fine, const FiniteElement<dim> &fe_coarse)
   DoFHandler<dim> dof_handler_coarse(tria);
   dof_handler_coarse.distribute_dofs(FESystem<dim>(fe_coarse, dim));
 
-  AffineConstraints<Number> constraint_coarse;
+  AffineConstraints<Number> constraint_coarse(
+    dof_handler_coarse.locally_owned_dofs(),
+    DoFTools::extract_locally_relevant_dofs(dof_handler_coarse));
+
+  AffineConstraints<Number> constraint_fine(
+    dof_handler_fine.locally_owned_dofs(),
+    DoFTools::extract_locally_relevant_dofs(dof_handler_fine));
+
   DoFTools::make_hanging_node_constraints(dof_handler_coarse,
                                           constraint_coarse);
   constraint_coarse.close();
 
-  AffineConstraints<Number> constraint_fine;
   DoFTools::make_hanging_node_constraints(dof_handler_fine, constraint_fine);
   constraint_fine.close();
 

--- a/tests/multigrid-global-coarsening/mg_transfer_p_04.cc
+++ b/tests/multigrid-global-coarsening/mg_transfer_p_04.cc
@@ -111,12 +111,18 @@ do_test(const FiniteElement<dim> &fe_fine, const FiniteElement<dim> &fe_coarse)
   DoFHandler<dim> dof_handler_coarse(tria_coarse);
   dof_handler_coarse.distribute_dofs(fe_coarse);
 
-  AffineConstraints<Number> constraint_coarse;
+  AffineConstraints<Number> constraint_coarse(
+    dof_handler_coarse.locally_owned_dofs(),
+    DoFTools::extract_locally_relevant_dofs(dof_handler_coarse));
+
+  AffineConstraints<Number> constraint_fine(
+    dof_handler_fine.locally_owned_dofs(),
+    DoFTools::extract_locally_relevant_dofs(dof_handler_fine));
+
   DoFTools::make_hanging_node_constraints(dof_handler_coarse,
                                           constraint_coarse);
   constraint_coarse.close();
 
-  AffineConstraints<Number> constraint_fine;
   DoFTools::make_hanging_node_constraints(dof_handler_fine, constraint_fine);
   constraint_fine.close();
 

--- a/tests/multigrid-global-coarsening/mg_transfer_p_05.cc
+++ b/tests/multigrid-global-coarsening/mg_transfer_p_05.cc
@@ -81,10 +81,14 @@ do_test(const FiniteElement<dim> &fe_fine, const FiniteElement<dim> &fe_coarse)
   dof_handler_coarse.distribute_dofs(fe_coarse);
   dof_handler_coarse.distribute_mg_dofs();
 
-  AffineConstraints<Number> constraint_coarse;
+  AffineConstraints<Number> constraint_coarse(
+    dof_handler_coarse.locally_owned_dofs(),
+    DoFTools::extract_locally_relevant_dofs(dof_handler_coarse));
   constraint_coarse.close();
 
-  AffineConstraints<Number> constraint_fine;
+  AffineConstraints<Number> constraint_fine(
+    dof_handler_fine.locally_owned_dofs(),
+    DoFTools::extract_locally_relevant_dofs(dof_handler_fine));
   constraint_fine.close();
 
   // setup transfer operator

--- a/tests/multigrid-global-coarsening/mg_transfer_p_06.cc
+++ b/tests/multigrid-global-coarsening/mg_transfer_p_06.cc
@@ -85,10 +85,14 @@ do_test(const FiniteElement<dim> &fe_fine, const FiniteElement<dim> &fe_coarse)
   DoFHandler<dim> dof_handler_coarse(tria);
   dof_handler_coarse.distribute_dofs(fe_coarse);
 
-  AffineConstraints<Number> constraint_coarse;
+  AffineConstraints<Number> constraint_coarse(
+    dof_handler_coarse.locally_owned_dofs(),
+    DoFTools::extract_locally_relevant_dofs(dof_handler_coarse));
   constraint_coarse.close();
 
-  AffineConstraints<Number> constraint_fine;
+  AffineConstraints<Number> constraint_fine(
+    dof_handler_fine.locally_owned_dofs(),
+    DoFTools::extract_locally_relevant_dofs(dof_handler_fine));
   constraint_fine.close();
 
   // setup transfer operator

--- a/tests/multigrid-global-coarsening/mg_transfer_util.h
+++ b/tests/multigrid-global-coarsening/mg_transfer_util.h
@@ -76,7 +76,9 @@ test_transfer_operator(
   const unsigned int mg_level_fine   = numbers::invalid_unsigned_int,
   const unsigned int mg_level_coarse = numbers::invalid_unsigned_int)
 {
-  AffineConstraints<Number> constraint_fine;
+  AffineConstraints<Number> constraint_fine(
+    dof_handler_fine.locally_owned_dofs(),
+    DoFTools::extract_locally_relevant_dofs(dof_handler_fine));
   DoFTools::make_hanging_node_constraints(dof_handler_fine, constraint_fine);
   constraint_fine.close();
 
@@ -186,7 +188,9 @@ test_non_nested_transfer(
   const unsigned int mg_level_fine   = numbers::invalid_unsigned_int,
   const unsigned int mg_level_coarse = numbers::invalid_unsigned_int)
 {
-  AffineConstraints<Number> constraint_fine;
+  AffineConstraints<Number> constraint_fine(
+    dof_handler_fine.locally_owned_dofs(),
+    DoFTools::extract_locally_relevant_dofs(dof_handler_fine));
   DoFTools::make_hanging_node_constraints(dof_handler_fine, constraint_fine);
   constraint_fine.close();
 

--- a/tests/multigrid/mg_data_out_05.cc
+++ b/tests/multigrid/mg_data_out_05.cc
@@ -73,7 +73,8 @@ do_test()
   FunctionParser<dim> function(dim == 2 ? "y;-x;x*x+y*y" :
                                           "y;-x;0;x*x+y*y+z*z");
 
-  AffineConstraints<double> constraints;
+  AffineConstraints<double> constraints(dof_handler.locally_owned_dofs(),
+                                        locally_relevant_dofs);
   DoFTools::make_hanging_node_constraints(dof_handler, constraints);
   constraints.close();
   VectorTools::project(

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_02.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_02.cc
@@ -137,7 +137,9 @@ public:
         const LinearAlgebra::distributed::Vector<double> &solution_other,
         const Mapping<dim>                               &mapping_other)
   {
-    AffineConstraints<double> constraints;
+    AffineConstraints<double> constraints(
+      dof_handler.locally_owned_dofs(),
+      DoFTools::extract_locally_relevant_dofs(dof_handler));
     {
       std::map<types::global_dof_index, Point<dim>> support_points;
 

--- a/tests/simplex/step-67.cc
+++ b/tests/simplex/step-67.cc
@@ -864,7 +864,9 @@ namespace Euler_DG
     const DoFHandler<dim> &dof_handler)
   {
     const std::vector<const DoFHandler<dim> *> dof_handlers = {&dof_handler};
-    const AffineConstraints<double>            dummy;
+    const AffineConstraints<double>            dummy(
+      dof_handler.locally_owned_dofs(),
+      DoFTools::extract_locally_relevant_dofs(dof_handler));
     const std::vector<const AffineConstraints<double> *> constraints = {&dummy};
 #ifdef HEX
     const std::vector<Quadrature<1>> quadratures = {QGauss<1>(n_q_points_1d),
@@ -2320,7 +2322,9 @@ namespace Euler_DG
           euler_operator.project(ExactSolution<dim>(time), reference);
 #else
 
-          AffineConstraints<double> dummy;
+          AffineConstraints<double> dummy(
+            dof_handler.locally_owned_dofs(),
+            DoFTools::extract_locally_relevant_dofs(dof_handler));
           dummy.close();
           VectorTools::project(mapping,
                                dof_handler,
@@ -2414,7 +2418,9 @@ namespace Euler_DG
 #ifdef HEX
     euler_operator.project(ExactSolution<dim>(time), solution);
 #else
-    AffineConstraints<double> dummy;
+    AffineConstraints<double> dummy(dof_handler.locally_owned_dofs(),
+                                    DoFTools::extract_locally_relevant_dofs(
+                                      dof_handler));
     dummy.close();
     VectorTools::project(mapping,
                          dof_handler,

--- a/tests/trilinos/direct_solver_3.cc
+++ b/tests/trilinos/direct_solver_3.cc
@@ -147,6 +147,8 @@ Step4<dim>::setup_system()
   dof_handler.distribute_dofs(fe);
 
   constraints.clear();
+  constraints.reinit(dof_handler.locally_owned_dofs(),
+                     DoFTools::extract_locally_relevant_dofs(dof_handler));
   std::map<unsigned int, double> boundary_values;
   VectorTools::interpolate_boundary_values(dof_handler,
                                            0,


### PR DESCRIPTION
Fixes #15987. In reference to #15375.