### PR TITLE
Fix TrilinosWrappers::PreconditionBase special member functions

### DIFF
--- a/include/deal.II/lac/trilinos_precondition.h
+++ b/include/deal.II/lac/trilinos_precondition.h
@@ -97,16 +97,6 @@ namespace TrilinosWrappers
     PreconditionBase();
 
     /**
-     * Copy constructor.
-     */
-    PreconditionBase(const PreconditionBase &);
-
-    /**
-     * Destructor.
-     */
-    ~PreconditionBase() override = default;
-
-    /**
      * Destroys the preconditioner, leaving an object like just after having
      * called the constructor.
      */
@@ -237,12 +227,6 @@ namespace TrilinosWrappers
      * from deal.II format.
      */
     Epetra_MpiComm communicator;
-
-    /**
-     * Internal Trilinos map in case the matrix needs to be copied from
-     * deal.II format.
-     */
-    std::shared_ptr<Epetra_Map> vector_distributor;
   };
 
 

--- a/source/lac/trilinos_precondition.cc
+++ b/source/lac/trilinos_precondition.cc
@@ -36,22 +36,11 @@ namespace TrilinosWrappers
   {}
 
 
-
-  PreconditionBase::PreconditionBase(const PreconditionBase &base)
-    : Subscriptor()
-    , preconditioner(base.preconditioner)
-    , communicator(base.communicator)
-    , vector_distributor(new Epetra_Map(*base.vector_distributor))
-  {}
-
-
-
   void
   PreconditionBase::clear()
   {
     preconditioner.reset();
     communicator = MPI_COMM_SELF;
-    vector_distributor.reset();
   }
 
 


### PR DESCRIPTION
We can only copy the pointee if it exists.

Side note: `vector_distributor` has no uses in the library. Is it intended that users derive from `TrilinosWrappers::PreconditionBase`? If not, can this member be removed? @masterleinad Did you forget to remove this member in 756c54b30c9745be729557d147634c75645e6682?