### PR TITLE
Fix Doxygen graphs in dark mode

### DIFF
--- a/doc/doxygen/headers/main.h
+++ b/doc/doxygen/headers/main.h
@@ -38,8 +38,8 @@
 
   node [fontname="FreeSans",fontsize=15,
         shape=record,height=0.2,width=0.4,
-        color="black", fillcolor="white", style="filled"];
-  edge [color="black", weight=10];
+        color="cornflowerblue", fillcolor="white", style="filled"];
+  edge [color="cornflowerblue", weight=10];
 
   tria       [label="Triangulation",    URL="\ref grid"];
   fe         [label="Finite elements",    URL="\ref feall"];
@@ -52,17 +52,17 @@
   output     [label="Graphical output", URL="\ref output"];
   manifold   [label="Manifold",         URL="\ref manifold"];
 
-  tria -> dh              [color="black",style="solid"];
-  fe -> dh                [color="black",style="solid"];
-  fe -> fevalues          [color="black",style="solid"];
-  mapping -> fevalues     [color="black",style="solid"];
-  quadrature -> fevalues  [color="black",style="solid"];
-  dh -> systems           [color="black",style="solid"];
-  fevalues -> systems     [color="black",style="solid"];
-  systems -> solvers      [color="black",style="solid"];
-  solvers -> output       [color="black",style="solid"];
-  manifold -> tria        [color="black",style="solid"];
-  manifold -> mapping     [color="black",style="solid"];
+  tria -> dh              [style="solid"];
+  fe -> dh                [style="solid"];
+  fe -> fevalues          [style="solid"];
+  mapping -> fevalues     [style="solid"];
+  quadrature -> fevalues  [style="solid"];
+  dh -> systems           [style="solid"];
+  fevalues -> systems     [style="solid"];
+  systems -> solvers      [style="solid"];
+  solvers -> output       [style="solid"];
+  manifold -> tria        [style="solid"];
+  manifold -> mapping     [style="solid"];
 
 
 

--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -288,8 +288,9 @@ CALL_GRAPH             = NO
 CALLER_GRAPH           = NO
 GRAPHICAL_HIERARCHY    = NO
 DIRECTORY_GRAPH        = YES
-DOT_IMAGE_FORMAT       = svg
+DOT_IMAGE_FORMAT       = png
 MAX_DOT_GRAPH_DEPTH    = 5
+DOT_EDGE_ATTR          = "color=cornflowerblue"
 GENERATE_LEGEND        = YES
 
 DOT_CLEANUP            = YES

--- a/doc/doxygen/scripts/steps.pl
+++ b/doc/doxygen/scripts/steps.pl
@@ -33,8 +33,8 @@ my %colors = (
  "basic"          => 'green',
  "techniques"     => 'orange',
  "fluids"         => 'yellow2',
- "solids"         => 'lightblue',
- "time dependent" => 'dodgerblue1',
+ "solids"         => 'coral',
+ "time dependent" => 'darkolivegreen1',
  "unfinished"     => 'white',
  "code-gallery"   => 'white',
     );
@@ -53,19 +53,20 @@ my %style = (
 print << 'EOT'
 digraph StepsMap
 {
+  bgcolor=transparent;
   overlap=false;
   edge [fontname="FreeSans",
         fontsize="10",
         labelfontname="FreeSans",
         labelfontsize="10",
-        color="black",
+        color="cornflowerblue",
         style="solid"];
   node [fontname="FreeSans",
         fontsize="10",
         shape="rectangle",
         height=0.2,
         width=0.4,
-        color="black",
+        color="cornflowerblue",
         fillcolor="white",
         style="filled"];
 EOT
@@ -298,21 +299,20 @@ while (my $line = <TUTORIAL>)
 print << 'EOT'
 graph StepsDescription
 {
+  bgcolor=transparent;
   overlap=false;
   edge [fontname="FreeSans",
-        fontsize="10",
+        fontsize="12",
         labelfontname="FreeSans",
         labelfontsize="10",
-        color="black",
+        color="cornflowerblue",
         style="solid"];
   node [fontname="FreeSans",
-        fontsize="10",
+        fontsize="11",
         shape="rectangle",
         height=0.2,
         width=0.4,
-        color="black",
-        fillcolor="white",
-        style="filled"];
+        color="cornflowerblue"];
 EOT
     ;
 
@@ -334,9 +334,9 @@ foreach $kind (keys %style)
 {
     my $escaped_kind = $kind;
     $escaped_kind =~ s/[^a-zA-Z]/_/g;
-    printf "  $escaped_kind [label=\"\" $style{$kind}, fillcolor=\"$colors{$kind}\"];\n";
-    printf "  fake_$escaped_kind [label=\"$kind_descriptions{$kind}\", shape=plaintext];\n";
-    printf "  $escaped_kind -- fake_$escaped_kind [style=dotted, arrowhead=odot, arrowsize=1];\n";
+    printf "  $escaped_kind [label=\"\" $style{$kind}, style=\"filled\" fillcolor=\"$colors{$kind}\"];\n";
+    printf "  fake_$escaped_kind [label=\"$kind_descriptions{$kind}\", fontcolor=\"cornflowerblue\" fontsize=12 shape=plaintext];\n";
+    printf "  $escaped_kind -- fake_$escaped_kind [style=\"bold,dotted\", arrowhead=odot, arrowsize=1];\n";
 }
 # now add connections to make sure they appear nicely next to each other
 # in the legend


### PR DESCRIPTION
This fixes #16001 such that all dot generated graphs are also visible in dark mode.
This changes some default colors for the Tutorial map to be visible in both modes.
File type has to be png because 'color=transparent' is not officially supported by svg.