### PR TITLE
Split building docker images to two separate workers.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,14 @@ permissions:
 
 jobs:
   build-master-docker:
+    name: build master docker ${{ matrix.ubuntu_version }}
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ubuntu_version: ["focal", "jammy"]
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -26,26 +33,14 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push Docker image of master focal
+      - name: Build and push Docker image of master ${{ matrix.ubuntu_version }}
         uses: docker/build-push-action@v5
         with:
           context: ./contrib/docker/
-          cache-from: type=registry,ref=dealii/dependencies:focal
+          cache-from: type=registry,ref=dealii/dependencies:${{ matrix.ubuntu_version }}
           cache-to: type=inline
           build-args: |
             VER=master
-            IMG=focal
+            IMG=${{ matrix.ubuntu_version }}
           push: ${{github.ref_name == 'master'}}
-          tags: dealii/dealii:master-focal
-
-      - name: Build and push Docker image of master jammy
-        uses: docker/build-push-action@v5
-        with:
-          context: ./contrib/docker/
-          cache-from: type=registry,ref=dealii/dependencies:jammy
-          cache-to: type=inline
-          build-args: |
-            VER=master
-            IMG=jammy
-          push: ${{github.ref_name == 'master'}}
-          tags: dealii/dealii:master-jammy
+          tags: dealii/dealii:master-${{ matrix.ubuntu_version }}


### PR DESCRIPTION
This is one attempt to fix the `github-docker` worker: https://github.com/dealii/dealii/actions/workflows/docker.yml

Currently, it seems like the worker spends about 2 hours on building the `focal` image, and only 20 minutes on the `jammy` image. My best guess is that the worker potentially terminates during the building phase of the second image, presumably running out of memory. Unfortunately, github doesn't store the logs, as it "[...] lost communication with the server. Anything in your workflow that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error."

This PR splits building the `focal` and `jammy` image into two separate  workers using a [matrix strategy](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs). Hopefully, this will fix the issue.

The syntax of the yml script seems okay as github-actions accepts it on my fork. Of course it fails on my fork since I have no login credentials set up: https://github.com/marcfehling/dealii/actions/runs/6242540269