### PR TITLE
Improve assert message for non-matching reference cell types

### DIFF
--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -2636,9 +2636,8 @@ DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::get_fe() const
   const auto &fe = this->dof_handler->get_fe(active_fe_index());
 
   Assert(this->reference_cell() == fe.reference_cell(),
-         ExcMessage(
-           "The reference-cell type of the cell does not match the one of the "
-           "finite element!"));
+         internal::ExcNonMatchingReferenceCellTypes(this->reference_cell(),
+                                                    fe.reference_cell()));
 
   return fe;
 }

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -2687,6 +2687,25 @@ namespace internal
      */
     const ArrayView<const T> vertices_1;
   };
+
+  /**
+   * This exception is raised whenever the types of two reference cell objects
+   * were assumed to be equal, but were not.
+   *
+   * Parameters to the constructor are the first and second reference cells,
+   * both of type <tt>ReferenceCell</tt>.
+   */
+  DeclException2(
+    ExcNonMatchingReferenceCellTypes,
+    ReferenceCell,
+    ReferenceCell,
+    << "The reference-cell type used on this cell (" << arg1.to_string()
+    << ") does not match the reference-cell type of the finite element "
+    << "associated with this cell (" << arg2.to_string() << "). "
+    << "Did you accidentally use simplex elements on hypercube meshes "
+    << "(or the other way around), or are you using a mixed mesh and "
+    << "assigned a simplex element to a hypercube cell (or the other "
+    << "way around) via the active_fe_index?");
 } // namespace internal
 
 

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -9560,7 +9560,7 @@ XDMFEntry::get_xdmf_content(const unsigned int   indent_level,
   // We now store the type of cell in the XDMFEntry:
   (void)reference_cell;
   Assert(cell_type == reference_cell,
-         ExcMessage("Incorrect ReferenceCell type passed in."));
+         internal::ExcNonMatchingReferenceCellTypes(cell_type, reference_cell));
   return get_xdmf_content(indent_level);
 }
 


### PR DESCRIPTION
This PR suggest to improve the assert message if two reference cell types don't match, from

```
(old) 

An error occurred in line <2644> of file </scratch/lib/dealii/include/deal.II/dofs/dof_accessor.templates.h> in function
    const dealii::FiniteElement<dimension_, space_dimension_>& dealii::DoFCellAccessor<dim, spacedim, lda>::get_fe() const [with int dimension_ = 2; int space_dimension_ = 3; bool level_dof_access = false]
The violated condition was: 
    this->reference_cell() == fe.reference_cell()
Additional information: 
    The reference-cell type of the cell does not match the one of the
    finite element!
```

to

```
(new)
--------------------------------------------------------
An error occurred in line <2641> of file </home/magdalena/code/external_libs/dealii-work/include/deal.II/dofs/dof_accessor.templates.h> in function
    const dealii::FiniteElement<dimension_, space_dimension_>& dealii::DoFCellAccessor<dim, spacedim, lda>::get_fe() const [with int dimension_ = 2; int space_dimension_ = 3; bool level_dof_access = false]
The violated condition was: 
    this->reference_cell() == fe.reference_cell()
Additional information: 
    The reference-cell type of Tri does not match with Quad. This could
    happen if one object (e.g. Triangulation) holds reference cells from a hexahedral mesh and
    the other one (e.g. FiniteElement) from a simplex mesh.
```

This can happen if one attaches a simplex triangulation to the `DoFHandler` and subsequently calls `DoFHandler::distribute_dofs(fe)` with a FE type for hexahedral elements, e.g. `FE_Q<dim>`.

@tinhvo-tum @peterrum FYI