### PR TITLE
Improve cuthill mckee

### DIFF
--- a/doc/news/changes/minor/20230920Kronbichler
+++ b/doc/news/changes/minor/20230920Kronbichler
@@ -1,0 +1,4 @@
+Improved: SparsityTools::reorder_Cuthill_McKee now runs considerably faster,
+especially for the case with many couplings between matrix rows.
+<br>
+(Martin Kronbichler, 2023/09/20)


### PR DESCRIPTION
I hit a case where `SparsityTools::reorder_Cuthill_McKee` would run incredibly slowly. It turned out that our previous implementation made several bad choices:
- We would add indices to a vector, only to later sort it, throw away duplicates and throw away indices already touched; since we have a contiguous index space, this should be rather done with direct array access through a 'touched' field, which is the new indices that get assigned.
- We used a slow `iterator` class to pass through `DynamicSparsityPattern`. We should use `column_number()` instead, which is the fastest way to access its data.
- We used a `std::multimap` for sorting data. Since the data is unique at this point, we should just put the data and use `std::sort`, which has the same `O(n log n)` complexity but much better constants due to much fewer memory allocations (this is really bad)
- We had some more arrays that got reallocated frequently. This is also easy to fix by pulling out the arrays from the surrounding loop.

On my test case (multi-component `FESystem`, 3d, cubic polynomials) the renumbering runs more than 10 times quicker.