### PR TITLE
Assert* should end with a semicolon

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1561,7 +1561,7 @@ namespace deal_II_exceptions
                 Kokkos::abort(#cond);                                          \
             }))                                                                \
           }                                                                    \
-        while (0)
+        while (false)
 #    else /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 #      define Assert(cond, exc)                                                \
         do                                                                     \
@@ -1583,7 +1583,7 @@ namespace deal_II_exceptions
                 Kokkos::abort(#cond);                                          \
             }))                                                                \
           }                                                                    \
-        while (0)
+        while (false)
 #    endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 #  else    /*if KOKKOS_VERSION >= 30600*/
 #    ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
@@ -1602,7 +1602,7 @@ namespace deal_II_exceptions
                   #exc,                                                        \
                   exc);                                                        \
             }                                                                  \
-          while (0)
+          while (false)
 #      else /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 #        define Assert(cond, exc)                                              \
           do                                                                   \
@@ -1618,7 +1618,7 @@ namespace deal_II_exceptions
                   #exc,                                                        \
                   exc);                                                        \
             }                                                                  \
-          while (0)
+          while (false)
 #      endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 #    else    /*#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST*/
 #      define Assert(cond, exc)     \
@@ -1627,7 +1627,7 @@ namespace deal_II_exceptions
             if (!(cond))            \
               Kokkos::abort(#cond); \
           }                         \
-        while (0)
+        while (false)
 #    endif /*ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST*/
 #  endif   /*KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST*/
 #else      /*ifdef DEBUG*/
@@ -1635,7 +1635,7 @@ namespace deal_II_exceptions
     do                      \
       {                     \
       }                     \
-    while (0)
+    while (false)
 #endif /*ifdef DEBUG*/
 
 
@@ -1675,7 +1675,7 @@ namespace deal_II_exceptions
             ::dealii::deal_II_exceptions::internals::issue_error_nothrow( \
               __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc); \
         }                                                                 \
-      while (0)
+      while (false)
 #  else /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 #    define AssertNothrow(cond, exc)                                      \
       do                                                                  \
@@ -1684,14 +1684,14 @@ namespace deal_II_exceptions
             ::dealii::deal_II_exceptions::internals::issue_error_nothrow( \
               __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc); \
         }                                                                 \
-      while (0)
+      while (false)
 #  endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 #else
 #  define AssertNothrow(cond, exc) \
     do                             \
       {                            \
       }                            \
-    while (0)
+    while (false)
 #endif
 
 /**
@@ -1736,7 +1736,7 @@ namespace deal_II_exceptions
             #exc,                                                        \
             exc);                                                        \
       }                                                                  \
-    while (0)
+    while (false)
 #else /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 #  define AssertThrow(cond, exc)                                         \
     do                                                                   \
@@ -1752,7 +1752,7 @@ namespace deal_II_exceptions
             #exc,                                                        \
             exc);                                                        \
       }                                                                  \
-    while (0)
+    while (false)
 #endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 
 
@@ -1944,7 +1944,7 @@ namespace internal
     do                               \
       {                              \
       }                              \
-    while (0)
+    while (false)
 #endif // DEAL_II_WITH_MPI
 
 #ifdef DEAL_II_WITH_CUDA
@@ -1975,7 +1975,7 @@ namespace internal
         {                          \
           (void)(error_code);      \
         }                          \
-      while (0)
+      while (false)
 #  endif
 
 /**
@@ -2004,7 +2004,7 @@ namespace internal
         {                                 \
           (void)(error_code);             \
         }                                 \
-      while (0)
+      while (false)
 #  endif
 
 /**
@@ -2033,13 +2033,13 @@ namespace internal
           local_error_code = cudaDeviceSynchronize();           \
           AssertCuda(local_error_code);                         \
         }                                                       \
-      while (0)
+      while (false)
 #  else
 #    define AssertCudaKernel() \
       do                       \
         {                      \
         }                      \
-      while (0)
+      while (false)
 #  endif
 
 /**
@@ -2072,7 +2072,7 @@ namespace internal
         {                              \
           (void)(error_code);          \
         }                              \
-      while (0)
+      while (false)
 #  endif
 
 /**
@@ -2104,7 +2104,7 @@ namespace internal
         {                                     \
           (void)(error_code);                 \
         }                                     \
-      while (0)
+      while (false)
 #  endif
 
 /**
@@ -2137,7 +2137,7 @@ namespace internal
         {                              \
           (void)(error_code);          \
         }                              \
-      while (0)
+      while (false)
 #  endif
 
 #endif

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1541,88 +1541,101 @@ namespace deal_II_exceptions
 #ifdef DEBUG
 #  if KOKKOS_VERSION >= 30600
 #    ifdef DEAL_II_HAVE_BUILTIN_EXPECT
-#      define Assert(cond, exc)                                              \
-        {                                                                    \
-          KOKKOS_IF_ON_HOST(({                                               \
-            if (__builtin_expect(!(cond), false))                            \
-              ::dealii::deal_II_exceptions::internals::issue_error_noreturn( \
-                ::dealii::deal_II_exceptions::internals::ExceptionHandling:: \
-                  abort_or_throw_on_exception,                               \
-                __FILE__,                                                    \
-                __LINE__,                                                    \
-                __PRETTY_FUNCTION__,                                         \
-                #cond,                                                       \
-                #exc,                                                        \
-                exc);                                                        \
-          }))                                                                \
-          KOKKOS_IF_ON_DEVICE(({                                             \
-            if (!(cond))                                                     \
-              Kokkos::abort(#cond);                                          \
-          }))                                                                \
-        }
+#      define Assert(cond, exc)                                                \
+        do                                                                     \
+          {                                                                    \
+            KOKKOS_IF_ON_HOST(({                                               \
+              if (__builtin_expect(!(cond), false))                            \
+                ::dealii::deal_II_exceptions::internals::issue_error_noreturn( \
+                  ::dealii::deal_II_exceptions::internals::ExceptionHandling:: \
+                    abort_or_throw_on_exception,                               \
+                  __FILE__,                                                    \
+                  __LINE__,                                                    \
+                  __PRETTY_FUNCTION__,                                         \
+                  #cond,                                                       \
+                  #exc,                                                        \
+                  exc);                                                        \
+            }))                                                                \
+            KOKKOS_IF_ON_DEVICE(({                                             \
+              if (!(cond))                                                     \
+                Kokkos::abort(#cond);                                          \
+            }))                                                                \
+          }                                                                    \
+        while (0)
 #    else /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
-#      define Assert(cond, exc)                                              \
-        {                                                                    \
-          KOKKOS_IF_ON_HOST(({                                               \
-            if (!(cond))                                                     \
-              ::dealii::deal_II_exceptions::internals::issue_error_noreturn( \
-                ::dealii::deal_II_exceptions::internals::ExceptionHandling:: \
-                  abort_or_throw_on_exception,                               \
-                __FILE__,                                                    \
-                __LINE__,                                                    \
-                __PRETTY_FUNCTION__,                                         \
-                #cond,                                                       \
-                #exc,                                                        \
-                exc);                                                        \
-          }))                                                                \
-          KOKKOS_IF_ON_DEVICE(({                                             \
-            if (!(cond))                                                     \
-              Kokkos::abort(#cond);                                          \
-          }))                                                                \
-        }
+#      define Assert(cond, exc)                                                \
+        do                                                                     \
+          {                                                                    \
+            KOKKOS_IF_ON_HOST(({                                               \
+              if (!(cond))                                                     \
+                ::dealii::deal_II_exceptions::internals::issue_error_noreturn( \
+                  ::dealii::deal_II_exceptions::internals::ExceptionHandling:: \
+                    abort_or_throw_on_exception,                               \
+                  __FILE__,                                                    \
+                  __LINE__,                                                    \
+                  __PRETTY_FUNCTION__,                                         \
+                  #cond,                                                       \
+                  #exc,                                                        \
+                  exc);                                                        \
+            }))                                                                \
+            KOKKOS_IF_ON_DEVICE(({                                             \
+              if (!(cond))                                                     \
+                Kokkos::abort(#cond);                                          \
+            }))                                                                \
+          }                                                                    \
+        while (0)
 #    endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 #  else    /*if KOKKOS_VERSION >= 30600*/
 #    ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
 #      ifdef DEAL_II_HAVE_BUILTIN_EXPECT
-#        define Assert(cond, exc)                                            \
-          {                                                                  \
-            if (__builtin_expect(!(cond), false))                            \
-              ::dealii::deal_II_exceptions::internals::issue_error_noreturn( \
-                ::dealii::deal_II_exceptions::internals::ExceptionHandling:: \
-                  abort_or_throw_on_exception,                               \
-                __FILE__,                                                    \
-                __LINE__,                                                    \
-                __PRETTY_FUNCTION__,                                         \
-                #cond,                                                       \
-                #exc,                                                        \
-                exc);                                                        \
-          }
+#        define Assert(cond, exc)                                              \
+          do                                                                   \
+            {                                                                  \
+              if (__builtin_expect(!(cond), false))                            \
+                ::dealii::deal_II_exceptions::internals::issue_error_noreturn( \
+                  ::dealii::deal_II_exceptions::internals::ExceptionHandling:: \
+                    abort_or_throw_on_exception,                               \
+                  __FILE__,                                                    \
+                  __LINE__,                                                    \
+                  __PRETTY_FUNCTION__,                                         \
+                  #cond,                                                       \
+                  #exc,                                                        \
+                  exc);                                                        \
+            }                                                                  \
+          while (0)
 #      else /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
-#        define Assert(cond, exc)                                            \
-          {                                                                  \
-            if (!(cond))                                                     \
-              ::dealii::deal_II_exceptions::internals::issue_error_noreturn( \
-                ::dealii::deal_II_exceptions::internals::ExceptionHandling:: \
-                  abort_or_throw_on_exception,                               \
-                __FILE__,                                                    \
-                __LINE__,                                                    \
-                __PRETTY_FUNCTION__,                                         \
-                #cond,                                                       \
-                #exc,                                                        \
-                exc);                                                        \
-          }
+#        define Assert(cond, exc)                                              \
+          do                                                                   \
+            {                                                                  \
+              if (!(cond))                                                     \
+                ::dealii::deal_II_exceptions::internals::issue_error_noreturn( \
+                  ::dealii::deal_II_exceptions::internals::ExceptionHandling:: \
+                    abort_or_throw_on_exception,                               \
+                  __FILE__,                                                    \
+                  __LINE__,                                                    \
+                  __PRETTY_FUNCTION__,                                         \
+                  #cond,                                                       \
+                  #exc,                                                        \
+                  exc);                                                        \
+            }                                                                  \
+          while (0)
 #      endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 #    else    /*#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST*/
-#      define Assert(cond, exc)   \
-        {                         \
-          if (!(cond))            \
-            Kokkos::abort(#cond); \
-        }
+#      define Assert(cond, exc)     \
+        do                          \
+          {                         \
+            if (!(cond))            \
+              Kokkos::abort(#cond); \
+          }                         \
+        while (0)
 #    endif /*ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST*/
 #  endif   /*KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST*/
 #else      /*ifdef DEBUG*/
 #  define Assert(cond, exc) \
-    {}
+    do                      \
+      {                     \
+      }                     \
+    while (0)
 #endif /*ifdef DEBUG*/
 
 
@@ -1655,23 +1668,30 @@ namespace deal_II_exceptions
  */
 #ifdef DEBUG
 #  ifdef DEAL_II_HAVE_BUILTIN_EXPECT
-#    define AssertNothrow(cond, exc)                                    \
-      {                                                                 \
-        if (__builtin_expect(!(cond), false))                           \
-          ::dealii::deal_II_exceptions::internals::issue_error_nothrow( \
-            __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc); \
-      }
+#    define AssertNothrow(cond, exc)                                      \
+      do                                                                  \
+        {                                                                 \
+          if (__builtin_expect(!(cond), false))                           \
+            ::dealii::deal_II_exceptions::internals::issue_error_nothrow( \
+              __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc); \
+        }                                                                 \
+      while (0)
 #  else /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
-#    define AssertNothrow(cond, exc)                                    \
-      {                                                                 \
-        if (!(cond))                                                    \
-          ::dealii::deal_II_exceptions::internals::issue_error_nothrow( \
-            __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc); \
-      }
+#    define AssertNothrow(cond, exc)                                      \
+      do                                                                  \
+        {                                                                 \
+          if (!(cond))                                                    \
+            ::dealii::deal_II_exceptions::internals::issue_error_nothrow( \
+              __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, #exc, exc); \
+        }                                                                 \
+      while (0)
 #  endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 #else
 #  define AssertNothrow(cond, exc) \
-    {}
+    do                             \
+      {                            \
+      }                            \
+    while (0)
 #endif
 
 /**
@@ -1702,33 +1722,37 @@ namespace deal_II_exceptions
  * @ingroup Exceptions
  */
 #ifdef DEAL_II_HAVE_BUILTIN_EXPECT
-#  define AssertThrow(cond, exc)                                       \
-    {                                                                  \
-      if (__builtin_expect(!(cond), false))                            \
-        ::dealii::deal_II_exceptions::internals::issue_error_noreturn( \
-          ::dealii::deal_II_exceptions::internals::ExceptionHandling:: \
-            throw_on_exception,                                        \
-          __FILE__,                                                    \
-          __LINE__,                                                    \
-          __PRETTY_FUNCTION__,                                         \
-          #cond,                                                       \
-          #exc,                                                        \
-          exc);                                                        \
-    }
+#  define AssertThrow(cond, exc)                                         \
+    do                                                                   \
+      {                                                                  \
+        if (__builtin_expect(!(cond), false))                            \
+          ::dealii::deal_II_exceptions::internals::issue_error_noreturn( \
+            ::dealii::deal_II_exceptions::internals::ExceptionHandling:: \
+              throw_on_exception,                                        \
+            __FILE__,                                                    \
+            __LINE__,                                                    \
+            __PRETTY_FUNCTION__,                                         \
+            #cond,                                                       \
+            #exc,                                                        \
+            exc);                                                        \
+      }                                                                  \
+    while (0)
 #else /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
-#  define AssertThrow(cond, exc)                                       \
-    {                                                                  \
-      if (!(cond))                                                     \
-        ::dealii::deal_II_exceptions::internals::issue_error_noreturn( \
-          ::dealii::deal_II_exceptions::internals::ExceptionHandling:: \
-            throw_on_exception,                                        \
-          __FILE__,                                                    \
-          __LINE__,                                                    \
-          __PRETTY_FUNCTION__,                                         \
-          #cond,                                                       \
-          #exc,                                                        \
-          exc);                                                        \
-    }
+#  define AssertThrow(cond, exc)                                         \
+    do                                                                   \
+      {                                                                  \
+        if (!(cond))                                                     \
+          ::dealii::deal_II_exceptions::internals::issue_error_noreturn( \
+            ::dealii::deal_II_exceptions::internals::ExceptionHandling:: \
+              throw_on_exception,                                        \
+            __FILE__,                                                    \
+            __LINE__,                                                    \
+            __PRETTY_FUNCTION__,                                         \
+            #cond,                                                       \
+            #exc,                                                        \
+            exc);                                                        \
+      }                                                                  \
+    while (0)
 #endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 
 
@@ -1917,7 +1941,10 @@ namespace internal
     AssertThrow(error_code == MPI_SUCCESS, dealii::ExcMPI(error_code))
 #else
 #  define AssertThrowMPI(error_code) \
-    {}
+    do                               \
+      {                              \
+      }                              \
+    while (0)
 #endif // DEAL_II_WITH_MPI
 
 #ifdef DEAL_II_WITH_CUDA
@@ -1944,9 +1971,11 @@ namespace internal
              dealii::ExcCudaError(cudaGetErrorString(error_code)))
 #  else
 #    define AssertCuda(error_code) \
-      {                            \
-        (void)(error_code);        \
-      }
+      do                           \
+        {                          \
+          (void)(error_code);      \
+        }                          \
+      while (0)
 #  endif
 
 /**
@@ -1971,9 +2000,11 @@ namespace internal
                     dealii::ExcCudaError(cudaGetErrorString(error_code)))
 #  else
 #    define AssertNothrowCuda(error_code) \
-      {                                   \
-        (void)(error_code);               \
-      }
+      do                                  \
+        {                                 \
+          (void)(error_code);             \
+        }                                 \
+      while (0)
 #  endif
 
 /**
@@ -1994,16 +2025,21 @@ namespace internal
  * @ingroup Exceptions
  */
 #  ifdef DEBUG
-#    define AssertCudaKernel()                                \
-      {                                                       \
-        cudaError_t local_error_code = cudaPeekAtLastError(); \
-        AssertCuda(local_error_code);                         \
-        local_error_code = cudaDeviceSynchronize();           \
-        AssertCuda(local_error_code)                          \
-      }
+#    define AssertCudaKernel()                                  \
+      do                                                        \
+        {                                                       \
+          cudaError_t local_error_code = cudaPeekAtLastError(); \
+          AssertCuda(local_error_code);                         \
+          local_error_code = cudaDeviceSynchronize();           \
+          AssertCuda(local_error_code);                         \
+        }                                                       \
+      while (0)
 #  else
 #    define AssertCudaKernel() \
-      {}
+      do                       \
+        {                      \
+        }                      \
+      while (0)
 #  endif
 
 /**
@@ -2032,9 +2068,11 @@ namespace internal
             error_code)))
 #  else
 #    define AssertCusparse(error_code) \
-      {                                \
-        (void)(error_code);            \
-      }
+      do                               \
+        {                              \
+          (void)(error_code);          \
+        }                              \
+      while (0)
 #  endif
 
 /**
@@ -2062,9 +2100,11 @@ namespace internal
             error_code)))
 #  else
 #    define AssertNothrowCusparse(error_code) \
-      {                                       \
-        (void)(error_code);                   \
-      }
+      do                                      \
+        {                                     \
+          (void)(error_code);                 \
+        }                                     \
+      while (0)
 #  endif
 
 /**
@@ -2093,9 +2133,11 @@ namespace internal
             error_code)))
 #  else
 #    define AssertCusolver(error_code) \
-      {                                \
-        (void)(error_code);            \
-      }
+      do                               \
+        {                              \
+          (void)(error_code);          \
+        }                              \
+      while (0)
 #  endif
 
 #endif

--- a/include/deal.II/lac/petsc_snes.templates.h
+++ b/include/deal.II/lac/petsc_snes.templates.h
@@ -37,7 +37,7 @@ DEAL_II_NAMESPACE_OPEN
         PetscErrorCode ierr = (code);                \
         AssertThrow(ierr == 0, ExcPETScError(ierr)); \
       }                                              \
-    while (0)
+    while (false)
 
 // Macro to wrap PETSc inside callbacks.
 // This is used to raise "PETSc" exceptions, i.e.
@@ -49,7 +49,7 @@ DEAL_II_NAMESPACE_OPEN
           PetscErrorCode ierr = (code); \
           CHKERRQ(ierr);                \
         }                               \
-      while (0)
+      while (false)
 #    define undefPetscCall
 #  endif
 

--- a/include/deal.II/lac/petsc_ts.templates.h
+++ b/include/deal.II/lac/petsc_ts.templates.h
@@ -37,7 +37,7 @@ DEAL_II_NAMESPACE_OPEN
         PetscErrorCode ierr = (code);                \
         AssertThrow(ierr == 0, ExcPETScError(ierr)); \
       }                                              \
-    while (0)
+    while (false)
 
 // Macro to wrap PETSc inside callbacks.
 // This is used to raise "PETSc" exceptions, i.e.
@@ -49,7 +49,7 @@ DEAL_II_NAMESPACE_OPEN
           PetscErrorCode ierr = (code); \
           CHKERRQ(ierr);                \
         }                               \
-      while (0)
+      while (false)
 #    define undefPetscCall
 #  endif
 

--- a/source/lac/petsc_communication_pattern.cc
+++ b/source/lac/petsc_communication_pattern.cc
@@ -29,7 +29,7 @@ DEAL_II_NAMESPACE_OPEN
         PetscErrorCode ierr = (code);                \
         AssertThrow(ierr == 0, ExcPETScError(ierr)); \
       }                                              \
-    while (0)
+    while (false)
 
 namespace PETScWrappers
 {

--- a/source/lac/petsc_compatibility.cc
+++ b/source/lac/petsc_compatibility.cc
@@ -35,7 +35,7 @@
         PetscErrorCode ierr = (code);                \
         AssertThrow(ierr == 0, ExcPETScError(ierr)); \
       }                                              \
-    while (0)
+    while (false)
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/lac/petsc_precondition.cc
+++ b/source/lac/petsc_precondition.cc
@@ -1103,7 +1103,7 @@ namespace PETScWrappers
           PetscErrorCode ierr = (code); \
           CHKERRQ(ierr);                \
         }                               \
-      while (0)
+      while (false)
 #  endif
 
   PetscErrorCode

--- a/source/lac/petsc_solver.cc
+++ b/source/lac/petsc_solver.cc
@@ -33,7 +33,7 @@
         PetscErrorCode ierr = (code);                \
         AssertThrow(ierr == 0, ExcPETScError(ierr)); \
       }                                              \
-    while (0)
+    while (false)
 
 DEAL_II_NAMESPACE_OPEN
 


### PR DESCRIPTION
I noticed that we still have a bunch of places where we use `Assert*` without a semicolon at the end.
This pull request enforces that semicolon using the technique described in https://gcc.gnu.org/onlinedocs/cpp/Swallowing-the-Semicolon.html; we are using it already in other places.

Most of the pull request is whitespace changes so it's best to ignore those while reviewing.