### PR TITLE
attempting to fix redundant letters "td" in documentation

### DIFF
--- a/doc/doxygen/headers/distributed.h
+++ b/doc/doxygen/headers/distributed.h
@@ -100,12 +100,20 @@
  *
  * <table align="center">
  *   <tr>
- *     <td> @image html distributed_mesh_0.png </td>
- *     <td> @image html distributed_mesh_1.png </td>
- *   </tr>
+ *     <td>
+ *		@image html distributed_mesh_0.png
+ * 	</td>
+ *     <td>
+ * 		@image html distributed_mesh_1.png
+ *	</td>
+ *</tr>
  *   <tr>
- *     <td> @image html distributed_mesh_2.png </td>
- *     <td> @image html distributed_mesh_3.png </td>
+ *     <td>
+ * 		@image html distributed_mesh_2.png
+ * 	</td>
+ *     <td>
+ *		@image html distributed_mesh_3.png
+ *	</td>
  *   </tr>
  * </table>
  *


### PR DESCRIPTION
in the figure of https://www.dealii.org/current/doxygen/deal.II/group__distributed.html

Note that these visible td's are not locally reproducible always.