### PR TITLE
WIP: Adds Ginkgo interface

### DIFF
--- a/include/deal.II/lac/ginkgo_interface.h
+++ b/include/deal.II/lac/ginkgo_interface.h
@@ -100,6 +100,140 @@ namespace GinkgoWrappers
     return create_vector(std::move(exec), array);
   }
 
+
+  namespace detail
+  {
+    template <typename F>
+    void
+    run_with_device_exec(std::shared_ptr<const gko::Executor> exec, F &&f)
+    {
+      if (auto p = std::dynamic_pointer_cast<const gko::CudaExecutor>(exec))
+        {
+          f(std::move(p));
+        }
+      else if (auto p = std::dynamic_pointer_cast<const gko::HipExecutor>(exec))
+        {
+          f(std::move(p));
+        }
+      else if (auto p =
+                 std::dynamic_pointer_cast<const gko::DpcppExecutor>(exec))
+        {
+          f(std::move(p));
+        }
+      else
+        {
+          Assert(false,
+                 ExcMessage(" encountered unknown device Executor type "));
+        }
+    }
+
+    template <typename Matrix, typename DealValueType, typename... ExtraArgs>
+    std::unique_ptr<Matrix>
+    create_matrix(std::shared_ptr<const gko::Executor> exec,
+                  const SparseMatrix<DealValueType>   &deal_csr,
+                  ExtraArgs &&...args)
+    {
+      using value_type = typename Matrix::value_type;
+      using index_type = typename Matrix::index_type;
+
+      static_assert(
+        std::is_base_of_v<gko::ReadableFromMatrixData<value_type, index_type>,
+                          Matrix>);
+
+      gko::dim<2> size = {static_cast<gko::size_type>(deal_csr.m()),
+                                                       static_cast<gko::size_type>(deal_csr.n())};
+      gko::matrix_data<value_type, index_type> md{size};
+      md.nonzeros.reserve(deal_csr.n_nonzero_elements());
+
+      for (const auto &e : deal_csr)
+        {
+          md.nonzeros.emplace_back(static_cast<index_type>(e.row()),
+                                   static_cast<index_type>(e.column()),
+                                   static_cast<value_type>(e.value()));
+        }
+
+      auto device_md =
+        gko::device_matrix_data<value_type, index_type>::create_from_host(exec,
+                                                                          md);
+      device_md.sort_row_major();
+
+      auto gko_mtx = Matrix::create(exec, std::forward<ExtraArgs>(args)...);
+      gko_mtx->read(std::move(device_md));
+
+      return gko_mtx;
+    }
+  } // namespace detail
+
+  enum class csr_strategy
+  {
+    exec_based,
+    classical,
+    merge_path,
+    sparselib,
+    load_balance,
+    automatical
+  };
+
+  template <typename ValueType, typename IndexType, typename DealValueType>
+  std::unique_ptr<gko::matrix::Csr<ValueType, IndexType>>
+  create_csr_matrix(std::shared_ptr<const gko::Executor> exec,
+                    const SparseMatrix<DealValueType>   &deal_csr,
+                    csr_strategy strategy = csr_strategy::exec_based)
+  {
+    using CsrType = gko::matrix::Csr<ValueType, IndexType>;
+    std::shared_ptr<typename CsrType ::strategy_type> strategy_ptr;
+    if (strategy == csr_strategy::exec_based)
+      {
+        strategy =
+          std::dynamic_pointer_cast<const gko::ReferenceExecutor>(exec) ||
+              std::dynamic_pointer_cast<const gko::OmpExecutor>(exec) ?
+            csr_strategy::classical :
+            csr_strategy::automatical;
+      }
+    switch (strategy)
+      {
+        case csr_strategy::classical:
+          strategy_ptr = std::make_shared<typename CsrType::classical>();
+          break;
+        case csr_strategy::merge_path:
+          strategy_ptr = std::make_shared<typename CsrType::merge_path>();
+          break;
+        case csr_strategy::sparselib:
+          strategy_ptr = std::make_shared<typename CsrType::sparselib>();
+          break;
+        case csr_strategy::load_balance:
+          detail::run_with_device_exec(exec, [&](auto concrete_exec) {
+            strategy_ptr =
+              std::make_shared<typename CsrType::load_balance>(concrete_exec);
+          });
+          break;
+        case csr_strategy::automatical:
+          detail::run_with_device_exec(exec, [&](auto concrete_exec) {
+            strategy_ptr =
+              std::make_shared<typename CsrType::automatical>(concrete_exec);
+          });
+          break;
+        default:
+          Assert(false, ExcMessage(" encountered unknown Csr strategy type "));
+      }
+
+    return detail::create_matrix<CsrType>(std::move(exec),
+                                          deal_csr,
+                                          std::move(strategy_ptr));
+  }
+
+  template <typename IndexType = gko::int32, typename DealValueType>
+  std::unique_ptr<gko::matrix::Csr<DealValueType, IndexType>>
+  create_csr_matrix(std::shared_ptr<const gko::Executor> exec,
+                    const SparseMatrix<DealValueType>   &deal_csr,
+                    csr_strategy strategy = csr_strategy::exec_based)
+  {
+    return create_csr_matrix<DealValueType, IndexType>(std::move(exec),
+                                                       deal_csr,
+                                                       strategy);
+  }
+
+
 } // namespace GinkgoWrappers
 
 

--- a/include/deal.II/lac/ginkgo_interface.h
+++ b/include/deal.II/lac/ginkgo_interface.h
@@ -1,0 +1,110 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 - 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+#ifndef dealii_ginkgo_interface_h
+#define dealii_ginkgo_interface_h
+
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_GINKGO
+
+#  include <deal.II/base/array_view.h>
+
+#  include <deal.II/lac/sparse_matrix.h>
+
+#  include <ginkgo/core/matrix/csr.hpp>
+#  include <ginkgo/core/matrix/dense.hpp>
+#  include <ginkgo/extensions/kokkos.hpp>
+
+
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace GinkgoWrappers
+{
+
+  template <typename ValueType, typename MemorySpace>
+  std::unique_ptr<gko::matrix::Dense<ValueType>>
+  create_vector(std::shared_ptr<const gko::Executor> exec,
+                ArrayView<ValueType, MemorySpace>   &array)
+  {
+    std::shared_ptr<const gko::Executor> array_exec =
+      gko::ext::kokkos::get_executor(
+        typename MemorySpace::kokkos_space::execution_space{});
+
+    gko::dim<2> size = {static_cast<gko::size_type>(array.size()), 1};
+
+    return gko::matrix::Dense<ValueType>::create(
+      exec, size, gko::make_array_view(array_exec, size[0], array.data()), 1);
+  }
+
+  template <typename ValueType, typename MemorySpace>
+  std::unique_ptr<gko::matrix::Dense<ValueType>>
+  create_vector(ArrayView<ValueType, MemorySpace> &array)
+  {
+    std::shared_ptr<const gko::Executor> exec = gko::ext::kokkos::get_executor(
+      typename MemorySpace::kokkos_space::execution_space{});
+
+    return create_vector(std::move(exec), array);
+  }
+
+  template <typename ValueType, typename MemorySpace, typename = std::enable_if_t<!std::is_const_v<ValueType>>>
+  std::unique_ptr<gko::matrix::Dense<ValueType>>
+  create_vector(ArrayView<ValueType, MemorySpace> &&array)
+  {
+    std::shared_ptr<const gko::Executor> exec = gko::ext::kokkos::get_executor(
+      typename MemorySpace::kokkos_space::execution_space{});
+
+    return create_vector(std::move(exec), array);
+  }
+
+  template <typename ValueType, typename MemorySpace>
+  std::unique_ptr<const gko::matrix::Dense<std::decay_t<ValueType>>>
+  create_vector(std::shared_ptr<const gko::Executor>           exec,
+                const ArrayView<ValueType, MemorySpace> &array)
+  {
+    std::shared_ptr<const gko::Executor> array_exec =
+      gko::ext::kokkos::get_executor(
+        typename MemorySpace::kokkos_space::execution_space{});
+
+    gko::dim<2> size = {static_cast<gko::size_type>(array.size()), 1};
+
+    return gko::matrix::Dense<std::decay_t<ValueType>>::create_const(
+      exec,
+      size,
+      gko::make_const_array_view(array_exec, size[0], array.data()),
+      1);
+  }
+
+  template <typename ValueType, typename MemorySpace>
+  std::unique_ptr<const gko::matrix::Dense<std::decay_t<ValueType>>>
+  create_vector(const ArrayView<ValueType, MemorySpace> &array)
+  {
+    std::shared_ptr<const gko::Executor> exec = gko::ext::kokkos::get_executor(
+      typename MemorySpace::kokkos_space::execution_space{});
+
+    return create_vector(std::move(exec), array);
+  }
+
+} // namespace GinkgoWrappers
+
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif
+
+#endif // dealii_ginkgo_interface_h

--- a/include/deal.II/lac/ginkgo_interface.h
+++ b/include/deal.II/lac/ginkgo_interface.h
@@ -41,8 +41,8 @@ namespace GinkgoWrappers
 
   template <typename ValueType, typename MemorySpace>
   std::unique_ptr<gko::matrix::Dense<ValueType>>
-  create_vector(std::shared_ptr<const gko::Executor> exec,
-                ArrayView<ValueType, MemorySpace>    array)
+  create_vector(const std::shared_ptr<const gko::Executor> &exec,
+                ArrayView<ValueType, MemorySpace>           array)
   {
     Assert(gko::ext::kokkos::detail::check_compatibility<
              typename MemorySpace::kokkos_space>(exec),
@@ -55,8 +55,8 @@ namespace GinkgoWrappers
 
   template <typename ValueType, typename MemorySpace>
   std::unique_ptr<const gko::matrix::Dense<std::decay_t<ValueType>>>
-  create_vector(std::shared_ptr<const gko::Executor>    exec,
-                ArrayView<const ValueType, MemorySpace> array)
+  create_vector(const std::shared_ptr<const gko::Executor> &exec,
+                ArrayView<const ValueType, MemorySpace>     array)
   {
     Assert(gko::ext::kokkos::detail::check_compatibility<
              typename MemorySpace::kokkos_space>(exec),
@@ -237,9 +237,9 @@ namespace GinkgoWrappers
     LinearAlgebra::distributed::Vector<DomainValueType, DomainMemorySpace>,
     LinearAlgebra::distributed::Vector<RangeValueType, RangeMemorySpace>,
     detail::GinkgoPayload>
-  linear_operator(std::shared_ptr<const gko::Executor> domain_exec,
-                  std::shared_ptr<const gko::Executor> range_exec,
-                  const std::shared_ptr<gko::LinOp>   &gko_op)
+  linear_operator(const std::shared_ptr<const gko::Executor> &domain_exec,
+                  const std::shared_ptr<const gko::Executor> &range_exec,
+                  const std::shared_ptr<gko::LinOp>          &gko_op)
   {
     using Domain =
       LinearAlgebra::distributed::Vector<DomainValueType, DomainMemorySpace>;
@@ -333,10 +333,10 @@ namespace GinkgoWrappers
     LinearAlgebra::distributed::Vector<DomainValueType, DomainMemorySpace>,
     LinearAlgebra::distributed::Vector<RangeValueType, RangeMemorySpace>,
     detail::GinkgoPayload>
-  inverse_operator(std::shared_ptr<const gko::Executor>      domain_exec,
-                   std::shared_ptr<const gko::Executor>      range_exec,
-                   const std::shared_ptr<gko::LinOp>        &gko_op,
-                   const std::shared_ptr<gko::LinOpFactory> &solver)
+  inverse_operator(const std::shared_ptr<const gko::Executor> &domain_exec,
+                   const std::shared_ptr<const gko::Executor> &range_exec,
+                   const std::shared_ptr<gko::LinOp>          &gko_op,
+                   const std::shared_ptr<gko::LinOpFactory>   &solver)
   {
     auto solver_op = gko::share(solver->generate(gko_op));
     return linear_operator<RangeValueType,
@@ -358,13 +358,13 @@ namespace GinkgoWrappers
   inverse_operator(const std::shared_ptr<gko::LinOp>        &gko_op,
                    const std::shared_ptr<gko::LinOpFactory> &solver)
   {
-    auto solver_op = gko::share(solver->generate(gko_op));
-    return linear_operator<RangeValueType,
-                           DomainValueType,
-                           RangeMemorySpace,
-                           DomainMemorySpace>(solver_op->get_executor(),
-                                              solver_op->get_executor(),
-                                              solver_op);
+    return inverse_operator<DomainValueType,
+                            RangeValueType,
+                            DomainMemorySpace,
+                            RangeMemorySpace>(gko_op->get_executor(),
+                                              gko_op->get_executor(),
+                                              gko_op,
+                                              solver);
   }
 
 

--- a/include/deal.II/lac/ginkgo_interface.h
+++ b/include/deal.II/lac/ginkgo_interface.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2018 - 2022 by the deal.II authors
+// Copyright (C) 2018 - 2025 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,7 +67,7 @@ if(DEFINED DEAL_II_HAVE_TESTS_DIRECTORY)
   #
   # Write minimalistic CTestTestfile.cmake files to CMAKE_BINARY_DIR:
   #
-  file(WRITE ${CMAKE_BINARY_DIR}/CTestTestfile.cmake "subdirs(tests)\n")
+  file(WRITE ${CMAKE_BINARY_DIR}/CTestTestfile.cmake "add_subdirectory(tests)\n")
 
   set(_options "-DDEAL_II_DIR=${CMAKE_BINARY_DIR}")
 endif()
@@ -87,6 +87,11 @@ foreach(_var
     list(APPEND _options "-D${_var}=${${_var}}")
   endif()
 endforeach()
+
+#
+# Preserve the currently used CXX compiler
+#
+list(APPEND _options "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}")
 
 #
 # Find all testsuite subprojects, i.e., every directory that contains a

--- a/tests/ginkgo/interface.cc
+++ b/tests/ginkgo/interface.cc
@@ -1,0 +1,469 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 - 2023 by the deal.II Authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Tests the GinkgoWrappers interface
+
+#include "../tests.h"
+
+#include "test_macros.h"
+
+// all include files you need here
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/lac/ginkgo_interface.h>
+#include <deal.II/lac/la_parallel_vector.h>
+#include <deal.II/lac/sparse_matrix.templates.h>
+
+#include <Kokkos_Random.hpp>
+
+
+using namespace dealii;
+
+
+template <typename View, typename ValueType>
+bool
+check_equality(View view, gko::matrix::Dense<ValueType> *vector)
+{
+  using exec_space = typename View::execution_space;
+  auto data        = vector->get_values();
+  bool success     = true;
+  Kokkos::parallel_reduce(
+    Kokkos::RangePolicy<exec_space>(0, view.size()),
+    KOKKOS_LAMBDA(const int i, bool &lsuccess) {
+      lsuccess = lsuccess && (view(i) == data[i]);
+    },
+    Kokkos::LAnd<bool, exec_space>{success});
+  return success;
+}
+
+
+template <typename View>
+void
+fill_view(View view)
+{
+  using exec_space = typename View::execution_space;
+  Kokkos::Random_XorShift1024_Pool<exec_space> pool(/*seed=*/12345);
+  Kokkos::parallel_for(
+    Kokkos::RangePolicy<exec_space>(0, view.size()),
+    KOKKOS_LAMBDA(const int i) {
+      auto generator = pool.get_state();
+      view(i)        = generator.drand(0., 1.);
+      pool.free_state(generator);
+    });
+}
+
+
+
+TEST(can_create_vector_host)
+{
+  Kokkos::View<double[5], MemorySpace::Host::kokkos_space> view{"name"};
+  ArrayView<double, MemorySpace::Host> array_view(view.data(), view.size());
+  fill_view(view);
+
+  auto vector = GinkgoWrappers::create_vector(array_view);
+
+  TEST_ASSERT(vector->get_values() == view.data());
+}
+
+
+TEST(can_create_vector_host_const)
+{
+  using array_view_type = ArrayView<double, MemorySpace::Host>;
+  Kokkos::View<double[5], MemorySpace::Host::kokkos_space> view{"name"};
+  array_view_type array_view(view.data(), view.size());
+  fill_view(view);
+
+  auto vector = GinkgoWrappers::create_vector(
+    const_cast<const array_view_type &>(array_view));
+
+  using gko_type = typename decltype(vector)::element_type;
+  TEST_ASSERT(std::is_const_v<gko_type>);
+}
+
+
+TEST(can_create_vector_default)
+{
+  Kokkos::View<double[5], MemorySpace::Default::kokkos_space> view{"name"};
+  ArrayView<double, MemorySpace::Default> array_view(view.data(), view.size());
+  fill_view(view);
+
+  auto vector = GinkgoWrappers::create_vector(array_view);
+
+  TEST_ASSERT(vector->get_values() == array_view.begin());
+}
+
+
+TEST(can_create_vector_with_executor)
+{
+  if (!std::is_same_v<MemorySpace::Host::kokkos_space,
+                      MemorySpace::Default::kokkos_space>)
+    {
+      Kokkos::View<double[5], MemorySpace::Default::kokkos_space> view{"name"};
+      ArrayView<double, MemorySpace::Default> array_view(view.data(),
+                                                         view.size());
+      fill_view(view);
+
+      auto ref    = gko::ReferenceExecutor::create();
+      auto vector = GinkgoWrappers::create_vector(ref, array_view);
+
+      auto mirror = Kokkos::create_mirror(view);
+      Kokkos::deep_copy(mirror, view);
+      TEST_ASSERT(vector->get_values() != array_view.begin());
+      TEST_ASSERT(check_equality(mirror, vector.get()));
+    }
+}
+
+
+TEST(can_create_csr)
+{
+  std::vector<std::vector<unsigned int>> col_idxs{{0, 3}, {1}, {0, 2}};
+  dealii::SparsityPattern                pattern;
+  pattern.copy_from(3, 4, col_idxs.begin(), col_idxs.end());
+  dealii::SparseMatrix<double> dealii_obj(pattern);
+  dealii_obj.set(0, 0, 1);
+  dealii_obj.set(0, 3, 2);
+  dealii_obj.set(1, 1, 3);
+  dealii_obj.set(2, 0, 4);
+  dealii_obj.set(2, 2, 5);
+  auto exec = gko::ext::kokkos::get_default_executor();
+
+  auto obj = GinkgoWrappers::create_csr_matrix(exec, dealii_obj);
+  TEST_ASSERT(obj->get_num_stored_elements() == 5);
+  TEST_ASSERT(obj->get_const_col_idxs()[0] == 0);
+  TEST_ASSERT(obj->get_const_col_idxs()[1] == 3);
+  TEST_ASSERT(obj->get_const_col_idxs()[2] == 1);
+  TEST_ASSERT(obj->get_const_col_idxs()[3] == 0);
+  TEST_ASSERT(obj->get_const_col_idxs()[4] == 2);
+  TEST_ASSERT(obj->get_const_values()[0] == 1);
+  TEST_ASSERT(obj->get_const_values()[1] == 2);
+  TEST_ASSERT(obj->get_const_values()[2] == 3);
+  TEST_ASSERT(obj->get_const_values()[3] == 4);
+  TEST_ASSERT(obj->get_const_values()[4] == 5);
+  TEST_ASSERT(obj->get_const_row_ptrs()[0] == 0);
+  TEST_ASSERT(obj->get_const_row_ptrs()[1] == 2);
+  TEST_ASSERT(obj->get_const_row_ptrs()[2] == 3);
+  TEST_ASSERT(obj->get_const_row_ptrs()[3] == 5);
+}
+
+
+TEST(can_create_csr_with_strategy)
+{
+  std::vector<std::vector<unsigned int>> col_idxs{{0, 3}, {1}, {0, 2}};
+  dealii::SparsityPattern                pattern;
+  pattern.copy_from(3, 4, col_idxs.begin(), col_idxs.end());
+  dealii::SparseMatrix<double> dealii_obj(pattern);
+  dealii_obj.set(0, 0, 1);
+  dealii_obj.set(0, 3, 2);
+  dealii_obj.set(1, 1, 3);
+  dealii_obj.set(2, 0, 4);
+  dealii_obj.set(2, 2, 5);
+  auto exec = gko::ext::kokkos::get_default_executor();
+
+  auto obj =
+    GinkgoWrappers::create_csr_matrix(exec,
+                                      dealii_obj,
+                                      GinkgoWrappers::csr_strategy::merge_path);
+
+  using csr_type =
+    std::remove_cv_t<std::remove_reference_t<decltype(obj)>>::element_type;
+  TEST_ASSERT(std::dynamic_pointer_cast<typename csr_type::merge_path>(
+    obj->get_strategy()));
+}
+
+
+TEST(can_create_csr_with_index_type)
+{
+  std::vector<std::vector<unsigned int>> col_idxs{{0, 3}, {1}, {0, 2}};
+  dealii::SparsityPattern                pattern;
+  pattern.copy_from(3, 4, col_idxs.begin(), col_idxs.end());
+  dealii::SparseMatrix<double> dealii_obj(pattern);
+  dealii_obj.set(0, 0, 1);
+  dealii_obj.set(0, 3, 2);
+  dealii_obj.set(1, 1, 3);
+  dealii_obj.set(2, 0, 4);
+  dealii_obj.set(2, 2, 5);
+  auto exec = gko::ext::kokkos::get_default_executor();
+
+  auto obj = GinkgoWrappers::create_csr_matrix<gko::int64>(
+    exec, dealii_obj, GinkgoWrappers::csr_strategy::merge_path);
+
+  using csr_type =
+    std::remove_cv_t<std::remove_reference_t<decltype(obj)>>::element_type;
+  auto same_index_type =
+    std::is_same_v<typename csr_type::index_type, gko::int64>;
+  TEST_ASSERT(same_index_type);
+}
+
+
+TEST(can_create_csr_with_value_index_type)
+{
+  std::vector<std::vector<unsigned int>> col_idxs{{0, 3}, {1}, {0, 2}};
+  dealii::SparsityPattern                pattern;
+  pattern.copy_from(3, 4, col_idxs.begin(), col_idxs.end());
+  dealii::SparseMatrix<double> dealii_obj(pattern);
+  dealii_obj.set(0, 0, 1);
+  dealii_obj.set(0, 3, 2);
+  dealii_obj.set(1, 1, 3);
+  dealii_obj.set(2, 0, 4);
+  dealii_obj.set(2, 2, 5);
+  auto exec = gko::ext::kokkos::get_default_executor();
+
+  auto obj = GinkgoWrappers::create_csr_matrix<float, gko::int64>(
+    exec, dealii_obj, GinkgoWrappers::csr_strategy::merge_path);
+
+  using csr_type =
+    std::remove_cv_t<std::remove_reference_t<decltype(obj)>>::element_type;
+  auto same_value_type = std::is_same_v<typename csr_type::value_type, float>;
+  auto same_index_type =
+    std::is_same_v<typename csr_type::index_type, gko::int64>;
+  TEST_ASSERT(same_value_type);
+  TEST_ASSERT(same_index_type);
+}
+
+
+template <typename MemorySpace>
+struct linop_data
+{
+  linop_data()
+  {
+    std::vector<std::vector<unsigned int>> col_idxs{{0, 3}, {1}, {0, 2}};
+    pattern.copy_from(3, 4, col_idxs.begin(), col_idxs.end());
+
+    dealii_obj = dealii::SparseMatrix<double>(pattern);
+    dealii_obj.set(0, 0, 1);
+    dealii_obj.set(0, 3, 2);
+    dealii_obj.set(1, 1, 3);
+    dealii_obj.set(2, 0, 4);
+    dealii_obj.set(2, 2, 5);
+
+    exec = gko::ext::kokkos::get_executor(
+      typename MemorySpace::kokkos_space::execution_space{});
+    gko_obj = gko::share(GinkgoWrappers::create_csr_matrix(exec, dealii_obj));
+  }
+
+  dealii::SparsityPattern      pattern;
+  dealii::SparseMatrix<double> dealii_obj;
+
+  std::shared_ptr<gko::Executor> exec;
+  std::shared_ptr<gko::LinOp>    gko_obj;
+};
+
+template <typename MemorySpace>
+struct linop_vectors
+{
+  using Vector = LinearAlgebra::distributed::Vector<double, MemorySpace>;
+  using VectorHost =
+    LinearAlgebra::distributed::Vector<double, ::dealii::MemorySpace::Host>;
+
+  linop_vectors(size_t n, size_t m)
+  {
+    auto init_vectors = [](auto &x, auto &x_ref, auto size) {
+      auto get_view = [](auto &vector) {
+        return Kokkos::View<double *,
+                            typename MemorySpace::kokkos_space,
+                            Kokkos::MemoryTraits<Kokkos::Unmanaged>>{
+          vector.begin(), vector.size()};
+      };
+
+      x.reinit(size);
+      auto view_x = get_view(x);
+      fill_view(view_x);
+
+      x_ref.reinit(size);
+      auto view_x_ref = Kokkos::create_mirror(view_x);
+      Kokkos::deep_copy(view_x, view_x_ref);
+    };
+
+    init_vectors(u, u_ref, n);
+    init_vectors(v, v_ref, m);
+  }
+
+  Vector     u;
+  Vector     v;
+  VectorHost u_ref;
+  VectorHost v_ref;
+};
+
+
+
+TEST(can_create_linop_host)
+{
+  linop_data<MemorySpace::Host> data{};
+
+  auto linop = GinkgoWrappers::linear_operator(data.gko_obj);
+
+  {
+    linop_vectors<MemorySpace::Host> vectors(data.dealii_obj.n(),
+                                             data.dealii_obj.m());
+
+    linop.vmult(vectors.v, vectors.u);
+    data.dealii_obj.vmult(vectors.v_ref, vectors.u_ref);
+
+    vectors.v_ref -= vectors.v;
+    TEST_ASSERT(vectors.v_ref.linfty_norm() < 1e-12);
+  }
+  {
+    linop_vectors<MemorySpace::Host> vectors(data.dealii_obj.n(),
+                                             data.dealii_obj.m());
+
+    linop.vmult_add(vectors.v, vectors.u);
+    data.dealii_obj.vmult_add(vectors.v_ref, vectors.u_ref);
+
+    vectors.v_ref -= vectors.v;
+    TEST_ASSERT(vectors.v_ref.linfty_norm() < 1e-12);
+  }
+  {
+    linop_vectors<MemorySpace::Host> vectors(data.dealii_obj.n(),
+                                             data.dealii_obj.m());
+
+    linop.Tvmult(vectors.u, vectors.v);
+    data.dealii_obj.Tvmult(vectors.u_ref, vectors.v_ref);
+
+    vectors.u_ref -= vectors.u;
+    TEST_ASSERT(vectors.u_ref.linfty_norm() < 1e-12);
+  }
+  {
+    linop_vectors<MemorySpace::Host> vectors(data.dealii_obj.n(),
+                                             data.dealii_obj.m());
+
+    linop.Tvmult_add(vectors.u, vectors.v);
+    data.dealii_obj.Tvmult_add(vectors.u_ref, vectors.v_ref);
+
+    vectors.u_ref -= vectors.u;
+    TEST_ASSERT(vectors.u_ref.linfty_norm() < 1e-12);
+  }
+}
+
+TEST(can_create_linop_default)
+{
+  linop_data<MemorySpace::Default> data{};
+  linop_data<MemorySpace::Host>    data_host{};
+
+  auto linop = GinkgoWrappers::
+    linear_operator<double, double, MemorySpace::Default, MemorySpace::Default>(
+      data.gko_obj);
+  auto host_linop = GinkgoWrappers::linear_operator(data_host.gko_obj);
+
+  auto compare = [&](const auto &u, const auto &u_ref) {
+    LinearAlgebra::distributed::Vector<double, MemorySpace::Default> mirror(
+      u_ref.size());
+
+    auto default_exec = gko::ext::kokkos::get_default_executor();
+    auto host_exec    = gko::ext::kokkos::get_default_host_executor();
+
+    default_exec->copy_from(host_exec,
+                            mirror.size(),
+                            u_ref.begin(),
+                            mirror.begin());
+
+    mirror -= u;
+    TEST_ASSERT(mirror.linfty_norm() < 1e-12);
+  };
+  {
+    linop_vectors<MemorySpace::Default> vectors(data.dealii_obj.n(),
+                                                data.dealii_obj.m());
+
+    linop.vmult(vectors.v, vectors.u);
+    host_linop.vmult(vectors.v_ref, vectors.u_ref);
+
+    compare(vectors.v, vectors.v_ref);
+  }
+  {
+    linop_vectors<MemorySpace::Default> vectors(data.dealii_obj.n(),
+                                                data.dealii_obj.m());
+
+    linop.vmult_add(vectors.v, vectors.u);
+    host_linop.vmult_add(vectors.v_ref, vectors.u_ref);
+
+    compare(vectors.v, vectors.v_ref);
+  }
+  {
+    linop_vectors<MemorySpace::Default> vectors(data.dealii_obj.n(),
+                                                data.dealii_obj.m());
+
+    linop.Tvmult(vectors.u, vectors.v);
+    host_linop.Tvmult(vectors.u_ref, vectors.v_ref);
+
+    compare(vectors.v, vectors.v_ref);
+  }
+  {
+    linop_vectors<MemorySpace::Default> vectors(data.dealii_obj.n(),
+                                                data.dealii_obj.m());
+
+    linop.Tvmult_add(vectors.u, vectors.v);
+    host_linop.Tvmult_add(vectors.u_ref, vectors.v_ref);
+
+    compare(vectors.v, vectors.v_ref);
+  }
+}
+
+
+TEST(can_create_inverse_linop)
+{
+  auto exec            = gko::ext::kokkos::get_default_executor();
+  auto gko_obj         = gko::share(gko::initialize<gko::matrix::Csr<>>(
+    {{2, -1, 0, 0}, {-1, 2, -1, 0}, {0, -1, 2, -1}, {0, 0, -1, 2}}, exec));
+  auto linear_operator = GinkgoWrappers::
+    linear_operator<double, double, MemorySpace::Default, MemorySpace::Default>(
+      gko_obj);
+  LinearAlgebra::distributed::Vector<double, MemorySpace::Default> u(
+    gko_obj->get_size()[0]);
+  LinearAlgebra::distributed::Vector<double, MemorySpace::Default> v(
+    gko_obj->get_size()[0]);
+  u             = 1.0;
+  v             = 0.0;
+  linear_operator.vmult(v, u);
+
+  auto inverse_operator =
+    GinkgoWrappers::inverse_operator<double,
+                                     double,
+                                     MemorySpace::Default,
+                                     MemorySpace::Default>(
+      gko_obj,
+      gko::solver::Cg<>::build()
+        .with_criteria(
+          gko::stop::Iteration::build().with_max_iters(4u).on(exec))
+        .on(exec));
+  auto solution = u;
+  u = 0.0;
+  inverse_operator.vmult(u, v);
+
+  solution -= u;
+  TEST_ASSERT(solution.linfty_norm() < 1e-12);
+}
+
+
+int
+main(int argc, char **argv)
+{
+  Kokkos::ScopeGuard guard(argc, argv);
+
+  // Initialize deallog for test output.
+  // This also reroutes deallog output to a file "output".
+  initlog();
+
+  can_create_vector_host();
+  can_create_vector_host_const();
+  can_create_vector_default();
+  can_create_vector_with_executor();
+  can_create_csr();
+  can_create_csr_with_index_type();
+  can_create_csr_with_value_index_type();
+  can_create_linop_host();
+  can_create_linop_default();
+  can_create_inverse_linop();
+
+  return 0;
+}

--- a/tests/ginkgo/interface.cc
+++ b/tests/ginkgo/interface.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2015 - 2023 by the deal.II Authors
+// Copyright (C) 2015 - 2025 by the deal.II Authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/ginkgo/interface.output
+++ b/tests/ginkgo/interface.output
@@ -1,0 +1,11 @@
+
+DEAL:can_create_vector_host:OK
+DEAL:can_create_vector_host_const:OK
+DEAL:can_create_vector_default:OK
+DEAL:can_create_vector_with_executor:OK
+DEAL:can_create_csr:OK
+DEAL:can_create_csr_with_index_type:OK
+DEAL:can_create_csr_with_value_index_type:OK
+DEAL:can_create_linop_host:OK
+DEAL:can_create_linop_default:OK
+DEAL:can_create_inverse_linop:OK

--- a/tests/ginkgo/interface.output
+++ b/tests/ginkgo/interface.output
@@ -2,7 +2,7 @@
 DEAL:can_create_vector_host:OK
 DEAL:can_create_vector_host_const:OK
 DEAL:can_create_vector_default:OK
-DEAL:can_create_vector_with_executor:OK
+DEAL:throws_on_incompatible_executor:OK
 DEAL:can_create_csr:OK
 DEAL:can_create_csr_with_index_type:OK
 DEAL:can_create_csr_with_value_index_type:OK

--- a/tests/ginkgo/test_macros.h
+++ b/tests/ginkgo/test_macros.h
@@ -1,0 +1,95 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 - 2023 by the deal.II Authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_test_setup_h
+#define dealii_test_setup_h
+
+#include <ginkgo/ginkgo.hpp>
+
+
+template <typename T>
+gko::remove_complex<T>
+get_relative_error(const T a, const T b)
+{
+  return std::abs(a - b) / std::max(std::abs(a), std::abs(b));
+}
+
+template <typename T>
+constexpr gko::remove_complex<T> tol =
+  10 * std::numeric_limits<gko::remove_complex<T>>::epsilon();
+
+
+#define TEST_ASSERT(_assertion)                                           \
+  if (!(_assertion))                                                      \
+    {                                                                     \
+      deallog << std::string(self->TEST_name) + ":FAIL with " #_assertion \
+              << std::endl;                                               \
+      self->test_success = false;                                         \
+      return;                                                             \
+    }                                                                     \
+  static_assert(true, "Enforce ; after macro")
+
+
+#define TEST_ASSERT_NEAR(_a, _b, _tol)                                  \
+  {                                                                     \
+    auto rel_err = get_relative_error(_a, _b);                          \
+    if (!(rel_err <= _tol))                                             \
+      {                                                                 \
+        deallog << std::string(TEST_name) + ":FAIL with rel_error(" #_a \
+                                            ", " #_b ")["               \
+                << rel_err << "] <= " << _tol << std::endl;             \
+        self->test_success = false;                                     \
+        return;                                                         \
+      }                                                                 \
+  }                                                                     \
+  static_assert(true, "Enforce ; after macro")
+
+
+#define TEST_ASSERT_THROW(_cmd, _expected_exc) \
+  try                                          \
+    {                                          \
+      _cmd;                                    \
+      self->test_success = false;              \
+      return;                                  \
+    }                                          \
+  catch (const _expected_exc &)                \
+    {}                                         \
+  static_assert(true, "Enforce ; after macro")
+
+
+
+#define TEST(_name)                                             \
+  struct _name                                                  \
+  {                                                             \
+    _name()                                                     \
+      : test_success(true)                                      \
+    {                                                           \
+      _name::run(this);                                         \
+      if (test_success)                                         \
+        deallog << std::string(TEST_name) + ":OK" << std::endl; \
+    }                                                           \
+                                                                \
+    static void                                                 \
+    run(_name *self);                                           \
+                                                                \
+    static constexpr char TEST_name[] = #_name;                 \
+                                                                \
+    bool test_success;                                          \
+  };                                                            \
+  constexpr char _name::TEST_name[];                            \
+  void           _name::run(_name *self)
+
+
+#endif // dealii_test_setup_h


### PR DESCRIPTION
This is a draft for the Ginkgo interface as discussed in #15190. As suggested in the discussion, instead of adding new wrapper classes for Ginkgo objects, this interface allows for easy conversion between deal.II and Ginkgo objects. 

Currently it implements the following:
- create a Ginkgo vector (dense matrix) from a deal.II array view. ~~This comes in a two different flavors: `create_vector(ArrayView)` creates a view, while `create_vector(Executor, ArrayView)` will create a copy if the Ginkgo Executor doesn't match the memory space of the array view (otherwise it also creates a view).~~ It is always required to pass-in a Ginkgo `Executor` that matches the `MemorySpace` used by the array view. If the executor doesn't match, an exception will be thrown.
- create a Ginkgo Csr matrix from a deal.II SparseMatrix. This always copies the data. Other Ginkgo sparse matrix formats can be added easily.
- create a deal.II LinearOperator from a Ginkgo LinOp. The domain and range is fixed to `LinearAlgebra::distributed::Vector`, since that is the only native deal.II vector type that supports device memory.

I've also added a fix that preserves the C++ compiler for testing. This was necessary since I ran these tests on a HIP system, which requires using the hip compiler as C++ compiler.