### PR TITLE
Avoid deprecated AffineConstraints functions in the tutorials.

### DIFF
--- a/examples/step-16/step-16.cc
+++ b/examples/step-16/step-16.cc
@@ -433,9 +433,9 @@ namespace Step16
     std::vector<AffineConstraints<double>> boundary_constraints(n_levels);
     for (unsigned int level = 0; level < n_levels; ++level)
       {
-        const IndexSet dofset =
-          DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
-        boundary_constraints[level].reinit(dofset);
+        boundary_constraints[level].reinit(
+          dof_handler.locally_owned_mg_dofs(level),
+          DoFTools::extract_locally_relevant_level_dofs(dof_handler, level));
         boundary_constraints[level].add_lines(
           mg_constrained_dofs.get_refinement_edge_indices(level));
         boundary_constraints[level].add_lines(

--- a/examples/step-40/step-40.cc
+++ b/examples/step-40/step-40.cc
@@ -282,15 +282,23 @@ namespace Step40
     // expect any information to store. In our case, as explained in the
     // @ref distributed module, the degrees of freedom we need to care about on
     // each processor are the locally relevant ones, so we pass this to the
-    // AffineConstraints::reinit function. As a side note, if you forget to
-    // pass this argument, the AffineConstraints class will allocate an array
+    // AffineConstraints::reinit() function as a second argument. A further
+    // optimization, AffineConstraint can avoid certain operations if you also
+    // provide it with the set of locally owned degrees of freedom -- the
+    // first argument to AffineConstraints::reinit().
+    //
+    // (What would happen if we didn't pass this information to
+    // AffineConstraints, for example if we called the argument-less version of
+    // AffineConstraints::reinit() typically used in non-parallel codes? In that
+    // case, the AffineConstraints class will allocate an array
     // with length equal to the largest DoF index it has seen so far. For
-    // processors with high MPI process number, this may be very large --
+    // processors with large numbers of MPI processes, this may be very large --
     // maybe on the order of billions. The program would then allocate more
     // memory than for likely all other operations combined for this single
-    // array.
+    // array. Fortunately, recent versions of deal.II would trigger an assertion
+    // that tells you that this is considered a bug.)
     constraints.clear();
-    constraints.reinit(locally_relevant_dofs);
+    constraints.reinit(locally_owned_dofs, locally_relevant_dofs);
     DoFTools::make_hanging_node_constraints(dof_handler, constraints);
     VectorTools::interpolate_boundary_values(dof_handler,
                                              0,

--- a/examples/step-42/step-42.cc
+++ b/examples/step-42/step-42.cc
@@ -979,7 +979,8 @@ namespace Step42
     /* setup hanging nodes and Dirichlet constraints */
     {
       TimerOutput::Scope t(computing_timer, "Setup: constraints");
-      constraints_hanging_nodes.reinit(locally_relevant_dofs);
+      constraints_hanging_nodes.reinit(locally_owned_dofs,
+                                       locally_relevant_dofs);
       DoFTools::make_hanging_node_constraints(dof_handler,
                                               constraints_hanging_nodes);
       constraints_hanging_nodes.close();
@@ -1059,7 +1060,8 @@ namespace Step42
   template <int dim>
   void PlasticityContactProblem<dim>::compute_dirichlet_constraints()
   {
-    constraints_dirichlet_and_hanging_nodes.reinit(locally_relevant_dofs);
+    constraints_dirichlet_and_hanging_nodes.reinit(locally_owned_dofs,
+                                                   locally_relevant_dofs);
     constraints_dirichlet_and_hanging_nodes.merge(constraints_hanging_nodes);
 
     if (base_mesh == "box")
@@ -1197,7 +1199,7 @@ namespace Step42
     diag_mass_matrix_vector_relevant = diag_mass_matrix_vector;
 
 
-    all_constraints.reinit(locally_relevant_dofs);
+    all_constraints.reinit(locally_owned_dofs, locally_relevant_dofs);
     active_set.clear();
 
     // The second part is a loop over all cells in which we look at each

--- a/examples/step-45/step-45.cc
+++ b/examples/step-45/step-45.cc
@@ -366,7 +366,7 @@ namespace Step45
 
     {
       owned_partitioning.clear();
-      IndexSet locally_owned_dofs = dof_handler.locally_owned_dofs();
+      const IndexSet &locally_owned_dofs = dof_handler.locally_owned_dofs();
       owned_partitioning.push_back(locally_owned_dofs.get_view(0, n_u));
       owned_partitioning.push_back(locally_owned_dofs.get_view(n_u, n_u + n_p));
 
@@ -378,7 +378,7 @@ namespace Step45
         locally_relevant_dofs.get_view(n_u, n_u + n_p));
 
       constraints.clear();
-      constraints.reinit(locally_relevant_dofs);
+      constraints.reinit(locally_owned_dofs, locally_relevant_dofs);
 
       const FEValuesExtractors::Vector velocities(0);
 

--- a/examples/step-48/step-48.cc
+++ b/examples/step-48/step-48.cc
@@ -409,9 +409,9 @@ namespace Step48
 
     // We generate hanging node constraints for ensuring continuity of the
     // solution. As in step-40, we need to equip the constraint matrix with
-    // the IndexSet of locally relevant degrees of freedom to avoid it to
-    // consume too much memory for big problems. Next, the <code> MatrixFree
-    // </code> object for the problem is set up. Note that we specify a
+    // the IndexSet of locally active and locally relevant degrees of freedom
+    // to avoid it consuming too much memory for big problems. Next, the
+    // MatrixFree object for the problem is set up. Note that we specify a
     // particular scheme for shared-memory parallelization (hence one would
     // use multithreading for intra-node parallelism and not MPI; we here
     // choose the standard option &mdash; if we wanted to disable shared
@@ -428,7 +428,7 @@ namespace Step48
     locally_relevant_dofs =
       DoFTools::extract_locally_relevant_dofs(dof_handler);
     constraints.clear();
-    constraints.reinit(locally_relevant_dofs);
+    constraints.reinit(dof_handler.locally_owned_dofs(), locally_relevant_dofs);
     DoFTools::make_hanging_node_constraints(dof_handler, constraints);
     constraints.close();
 

--- a/examples/step-55/step-55.cc
+++ b/examples/step-55/step-55.cc
@@ -382,10 +382,10 @@ namespace Step55
     // We split up the IndexSet for locally owned and locally relevant DoFs
     // into two IndexSets based on how we want to create the block matrices
     // and vectors.
+    const IndexSet &locally_owned_dofs = dof_handler.locally_owned_dofs();
     owned_partitioning.resize(2);
-    owned_partitioning[0] = dof_handler.locally_owned_dofs().get_view(0, n_u);
-    owned_partitioning[1] =
-      dof_handler.locally_owned_dofs().get_view(n_u, n_u + n_p);
+    owned_partitioning[0] = locally_owned_dofs.get_view(0, n_u);
+    owned_partitioning[1] = locally_owned_dofs.get_view(n_u, n_u + n_p);
 
     const IndexSet locally_relevant_dofs =
       DoFTools::extract_locally_relevant_dofs(dof_handler);
@@ -399,7 +399,7 @@ namespace Step55
     // to put this function call in, in case adaptive refinement gets
     // introduced later.
     {
-      constraints.reinit(locally_relevant_dofs);
+      constraints.reinit(locally_owned_dofs, locally_relevant_dofs);
 
       const FEValuesExtractors::Vector velocities(0);
       DoFTools::make_hanging_node_constraints(dof_handler, constraints);

--- a/examples/step-63/step-63.cc
+++ b/examples/step-63/step-63.cc
@@ -814,9 +814,9 @@ namespace Step63
     for (unsigned int level = 0; level < triangulation.n_global_levels();
          ++level)
       {
-        const IndexSet locally_owned_level_dof_indices =
-          DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
-        boundary_constraints[level].reinit(locally_owned_level_dof_indices);
+        boundary_constraints[level].reinit(
+          dof_handler.locally_owned_mg_dofs(level),
+          DoFTools::extract_locally_relevant_level_dofs(dof_handler, level));
         boundary_constraints[level].add_lines(
           mg_constrained_dofs.get_refinement_edge_indices(level));
         boundary_constraints[level].add_lines(

--- a/examples/step-64/step-64.cc
+++ b/examples/step-64/step-64.cc
@@ -415,7 +415,7 @@ namespace Step64
     system_rhs_dev.reinit(locally_owned_dofs, mpi_communicator);
 
     constraints.clear();
-    constraints.reinit(locally_relevant_dofs);
+    constraints.reinit(locally_owned_dofs, locally_relevant_dofs);
     DoFTools::make_hanging_node_constraints(dof_handler, constraints);
     VectorTools::interpolate_boundary_values(dof_handler,
                                              0,

--- a/examples/step-66/step-66.cc
+++ b/examples/step-66/step-66.cc
@@ -544,11 +544,9 @@ namespace Step66
     dof_handler.distribute_dofs(fe);
     dof_handler.distribute_mg_dofs();
 
-    const IndexSet locally_relevant_dofs =
-      DoFTools::extract_locally_relevant_dofs(dof_handler);
-
     constraints.clear();
-    constraints.reinit(locally_relevant_dofs);
+    constraints.reinit(dof_handler.locally_owned_dofs(),
+                       DoFTools::extract_locally_relevant_dofs(dof_handler));
     DoFTools::make_hanging_node_constraints(dof_handler, constraints);
     VectorTools::interpolate_boundary_values(dof_handler,
                                              0,
@@ -592,11 +590,9 @@ namespace Step66
 
     for (unsigned int level = 0; level < nlevels; ++level)
       {
-        const IndexSet relevant_dofs =
-          DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
-
-        AffineConstraints<double> level_constraints;
-        level_constraints.reinit(relevant_dofs);
+        AffineConstraints<double> level_constraints(
+          dof_handler.locally_owned_mg_dofs(level),
+          DoFTools::extract_locally_relevant_level_dofs(dof_handler, level));
         level_constraints.add_lines(
           mg_constrained_dofs.get_boundary_indices(level));
         level_constraints.close();

--- a/examples/step-70/step-70.cc
+++ b/examples/step-70/step-70.cc
@@ -1250,7 +1250,7 @@ namespace Step70
     fluid_relevant_dofs[1] = locally_relevant_dofs.get_view(n_u, n_u + n_p);
 
     {
-      constraints.reinit(locally_relevant_dofs);
+      constraints.reinit(fluid_dh.locally_owned_dofs(), locally_relevant_dofs);
 
       const FEValuesExtractors::Vector velocities(0);
       DoFTools::make_hanging_node_constraints(fluid_dh, constraints);
@@ -1263,7 +1263,7 @@ namespace Step70
       constraints.close();
     }
 
-    auto locally_owned_dofs_per_processor =
+    const auto locally_owned_dofs_per_processor =
       Utilities::MPI::all_gather(mpi_communicator,
                                  fluid_dh.locally_owned_dofs());
     {

--- a/examples/step-75/step-75.cc
+++ b/examples/step-75/step-75.cc
@@ -325,11 +325,9 @@ namespace Step75
     // operator is applied to a vector with only the Dirichlet values set. The
     // result is the negative right-hand-side vector.
     {
-      AffineConstraints<number> constraints_without_dbc;
-
-      const IndexSet locally_relevant_dofs =
-        DoFTools::extract_locally_relevant_dofs(dof_handler);
-      constraints_without_dbc.reinit(locally_relevant_dofs);
+      AffineConstraints<number> constraints_without_dbc(
+        dof_handler.locally_owned_dofs(),
+        DoFTools::extract_locally_relevant_dofs(dof_handler));
 
       DoFTools::make_hanging_node_constraints(dof_handler,
                                               constraints_without_dbc);
@@ -779,9 +777,8 @@ namespace Step75
         const auto &dof_handler = dof_handlers[level];
         auto       &constraint  = constraints[level];
 
-        const IndexSet locally_relevant_dofs =
-          DoFTools::extract_locally_relevant_dofs(dof_handler);
-        constraint.reinit(locally_relevant_dofs);
+        constraint.reinit(dof_handler.locally_owned_dofs(),
+                          DoFTools::extract_locally_relevant_dofs(dof_handler));
 
         DoFTools::make_hanging_node_constraints(dof_handler, constraint);
         VectorTools::interpolate_boundary_values(mapping_collection,
@@ -1117,7 +1114,7 @@ namespace Step75
     system_rhs.reinit(locally_owned_dofs, mpi_communicator);
 
     constraints.clear();
-    constraints.reinit(locally_relevant_dofs);
+    constraints.reinit(locally_owned_dofs, locally_relevant_dofs);
     DoFTools::make_hanging_node_constraints(dof_handler, constraints);
     VectorTools::interpolate_boundary_values(
       mapping_collection, dof_handler, 0, Solution<dim>(), constraints);


### PR DESCRIPTION
This patch changes the tutorials to use the functions introduced in #15789 and, where appropriate, adjust the documentation. Fixes #16014. Related to #15375.

There were numerous places where we created locally-relevant index set variables and used it exactly once in a `reinit()` call. Historically, we did it this way because the function that extracted the locally-relevant set returned via-argument, so a named variable was necessary. But it now returns by-value, and so can be used in place of an argument. I've generally removed the named variable in this case.