### PR TITLE
Avoid use of old AffineConstraints functions.

### DIFF
--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -705,6 +705,17 @@ public:
   can_store_line(const size_type line_n) const;
 
   /**
+   * Return the index set describing which part of the degrees of freedom to
+   * which this object stores constraints are "locally owned". Typically,
+   * these would be the
+   * @ref GlossLocallyOwnedDof "locally owned degrees of freedom".
+   * This function returns the corresponding index set provided to either
+   * the constructor or the reinit() function of this class.
+   */
+  const IndexSet &
+  get_locally_owned_indices() const;
+
+  /**
    * Return the index set describing locally relevant lines if any are
    * present. Note that if no local lines were given, this represents an empty
    * IndexSet, whereas otherwise it contains the global problem size and the
@@ -2378,6 +2389,8 @@ AffineConstraints<number>::calculate_line_index(const size_type line_n) const
   return local_lines.index_within_set(line_n);
 }
 
+
+
 template <typename number>
 inline bool
 AffineConstraints<number>::can_store_line(size_type line_n) const
@@ -2385,12 +2398,25 @@ AffineConstraints<number>::can_store_line(size_type line_n) const
   return local_lines.size() == 0 || local_lines.is_element(line_n);
 }
 
+
+
+template <typename number>
+inline const IndexSet &
+AffineConstraints<number>::get_locally_owned_indices() const
+{
+  return locally_owned_dofs;
+}
+
+
+
 template <typename number>
 inline const IndexSet &
 AffineConstraints<number>::get_local_lines() const
 {
   return local_lines;
 }
+
+
 
 template <typename number>
 template <typename VectorType>

--- a/include/deal.II/multigrid/mg_constrained_dofs.h
+++ b/include/deal.II/multigrid/mg_constrained_dofs.h
@@ -298,13 +298,15 @@ MGConstrainedDoFs::initialize(
     {
       if (user_level_dofs)
         {
-          level_constraints[l].reinit(level_relevant_dofs[l]);
+          level_constraints[l].reinit(dof.locally_owned_mg_dofs(l),
+                                      level_relevant_dofs[l]);
         }
       else
         {
           const IndexSet relevant_dofs =
             DoFTools::extract_locally_relevant_level_dofs(dof, l);
-          level_constraints[l].reinit(relevant_dofs);
+          level_constraints[l].reinit(dof.locally_owned_mg_dofs(l),
+                                      relevant_dofs);
         }
 
       // Loop through relevant cells and faces finding those which are periodic
@@ -478,7 +480,9 @@ MGConstrainedDoFs::add_user_constraints(
   // Get the relevant DoFs from level_constraints if
   // the user constraint matrix has not been initialized
   if (user_constraints[level].get_local_lines().size() == 0)
-    user_constraints[level].reinit(level_constraints[level].get_local_lines());
+    user_constraints[level].reinit(
+      level_constraints[level].get_locally_owned_indices(),
+      level_constraints[level].get_local_lines());
 
   user_constraints[level].merge(
     constraints_on_level,
@@ -613,7 +617,7 @@ MGConstrainedDoFs::merge_constraints(AffineConstraints<Number> &constraints,
     index_set.add_indices(
       this->get_user_constraint_matrix(level).get_local_lines());
 
-  constraints.reinit(index_set);
+  constraints.reinit(constraints.get_locally_owned_indices(), index_set);
 
   // merge constraints
   if (add_boundary_indices && this->have_boundary_indices())

--- a/include/deal.II/numerics/vector_tools_constraints.templates.h
+++ b/include/deal.II/numerics/vector_tools_constraints.templates.h
@@ -1314,7 +1314,7 @@ namespace VectorTools
     const Mapping<dim, spacedim> &mapping)
   {
     AffineConstraints<double> no_normal_flux_constraints(
-      constraints.get_local_lines());
+      constraints.get_locally_owned_indices(), constraints.get_local_lines());
     compute_nonzero_normal_flux_constraints(dof_handler,
                                             first_vector_component,
                                             boundary_ids,

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -429,7 +429,7 @@ namespace DoFRenumbering
         // reordering with constraints is not yet implemented on a level basis
         Assert(reorder_level_dofs == false, ExcNotImplemented());
 
-        constraints.reinit(locally_relevant_dofs);
+        constraints.reinit(locally_owned_dofs, locally_relevant_dofs);
         DoFTools::make_hanging_node_constraints(dof_handler, constraints);
       }
     constraints.close();


### PR DESCRIPTION
This is a companion to #16032, but for places in the library itself. It turns out that I need access to which DoFs the `AffineConstraint` object considers as "locally owned" in a couple of places, so I'm adding an accessor function.

Follow-up to #15789.

In reference to #15375.