### PR TITLE
Don't use BuildKit for docker CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,7 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        driver: docker driver
 
       - name: Login to DockerHub
         uses: docker/login-action@v3


### PR DESCRIPTION
According to https://github.com/orgs/community/discussions/63974#discussioncomment-6785045, this should fix the failing docker CI on `master`. Also, see https://github.com/docker/setup-buildx-action#inputs and https://docs.docker.com/engine/reference/commandline/buildx_create/#driver.