### PR TITLE
Docker: Fix quotation marks for driver argument

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        driver: docker driver
+        driver: "docker driver"
 
       - name: Login to DockerHub
         uses: docker/login-action@v3


### PR DESCRIPTION
Follow-up to https://github.com/dealii/dealii/pull/16045. https://github.com/dealii/dealii/actions/runs/6316465186 shows that the argument for `driver` is invalid and should be a string.