### PR TITLE
Fix Doxygen warnings for anchors

### DIFF
--- a/doc/doxygen/scripts/create_anchors.pl
+++ b/doc/doxygen/scripts/create_anchors.pl
@@ -15,7 +15,8 @@
 
 
 # If we find a heading in a .dox file, create an HTML anchor for it.
-
+use Getopt::Long;
+GetOptions("prefix:s" => \$prefix);
 while (<>) {
     if ( /<h.>(.*)<\/h.>\s*/ ) {
 	$reftext = $1;
@@ -24,7 +25,7 @@ while (<>) {
 	# everything except for letters, numbers, and underscores
 	$reftext =~ s/[^a-zA-Z0-9_]//g;
 
-	print "<a name=\"$reftext\"></a>$_\n";
+	print "<a name=\"$prefix-$reftext\"></a>$_\n";
     } else {
         print;
     }

--- a/doc/doxygen/scripts/intro2toc.pl
+++ b/doc/doxygen/scripts/intro2toc.pl
@@ -14,6 +14,8 @@
 ## ---------------------------------------------------------------------
 
 print "    <ul>\n";
+use Getopt::Long;
+GetOptions("prefix:s" => \$prefix);
 
 $level = 3;
 while (<>) {
@@ -54,7 +56,7 @@ while (<>) {
           # hyperref, so get rid of the percent sign
           $text =~ s!\%!!g;
 
-          print "        <li><a href=\"#$reftext\">$text</a>\n";
+          print "        <li><a href=\"#$prefix-$reftext\">$text</a>\n";
 
           $level = $newlevel;
        }

--- a/doc/doxygen/scripts/make_gallery.pl
+++ b/doc/doxygen/scripts/make_gallery.pl
@@ -163,7 +163,7 @@ foreach my $file (@src_files)
         print "<a name=\"ann-$file\"></a>\n";
         print "<h1>Annotated version of $file</h1>\n";
 
-        system $^X, "$cmake_source_dir/doc/doxygen/scripts/program2doxygen.pl", "$gallery_dir/$file";
+        system $^X, "$cmake_source_dir/doc/doxygen/scripts/program2doxygen.pl", "$gallery_dir/$file" , "--prefix=$file";
 
         print "\n\n";
     }

--- a/doc/doxygen/scripts/make_step.pl
+++ b/doc/doxygen/scripts/make_step.pl
@@ -51,29 +51,29 @@ print
 <tr><th colspan=\"2\"><b><small>Table of contents</small></b></th></tr>
 <tr><td width=\"50%\" valign=\"top\">
 <ol>
-  <li> <a href=\"#Intro\" class=bold>Introduction</a>
+  <li> <a href=\"#$step-Intro\" class=bold>Introduction</a>
 ";
 
-system $^X, "$cmake_source_dir/doc/doxygen/scripts/intro2toc.pl", "$cmake_source_dir/examples/$step/doc/intro.dox";
+system $^X, "$cmake_source_dir/doc/doxygen/scripts/intro2toc.pl", "$cmake_source_dir/examples/$step/doc/intro.dox" , "--prefix=$step";
 
-print "  <li> <a href=\"#CommProg\" class=bold>The commented program</a>\n";
+print "  <li> <a href=\"#$step-CommProg\" class=bold>The commented program</a>\n";
 
-system $^X, "$cmake_source_dir/doc/doxygen/scripts/program2toc.pl", "$cmake_source_dir/examples/$step/$step.cc";
+system $^X, "$cmake_source_dir/doc/doxygen/scripts/program2toc.pl", "$cmake_source_dir/examples/$step/$step.cc" , "--prefix=$step";
 
 print
 "</ol></td><td width=\"50%\" valign=\"top\"><ol>
-  <li value=\"3\"> <a href=\"#Results\" class=bold>Results</a>
+  <li value=\"3\"> <a href=\"#$step-Results\" class=bold>Results</a>
 ";
 
-system $^X, "$cmake_source_dir/doc/doxygen/scripts/intro2toc.pl", "$cmake_source_dir/examples/$step/doc/results.dox";
+system $^X, "$cmake_source_dir/doc/doxygen/scripts/intro2toc.pl", "$cmake_source_dir/examples/$step/doc/results.dox" , "--prefix=$step";
 
 print
-"  <li> <a href=\"#PlainProg\" class=bold>The plain program</a>
+"  <li> <a href=\"#$step-PlainProg\" class=bold>The plain program</a>
 </ol> </td> </tr> </table>
 \@endhtmlonly
 ";
 
-system $^X, "$cmake_source_dir/doc/doxygen/scripts/create_anchors.pl", "$cmake_source_dir/examples/$step/doc/intro.dox";
+system $^X, "$cmake_source_dir/doc/doxygen/scripts/create_anchors.pl", "$cmake_source_dir/examples/$step/doc/intro.dox" , "--prefix=$step";
 
 
 # Start the commented program by writing two empty lines. We have had
@@ -87,12 +87,12 @@ system $^X, "$cmake_source_dir/doc/doxygen/scripts/create_anchors.pl", "$cmake_s
 # solves the problem -- so a second newline character.
 print " *\n";
 print " *\n";
-print " * <a name=\"CommProg\"></a>\n";
+print " * <a name=\"$step-CommProg\"></a>\n";
 print " * <h1> The commented program</h1>\n";
 
-system $^X, "$cmake_source_dir/doc/doxygen/scripts/program2doxygen.pl", "$cmake_source_dir/examples/$step/$step.cc";
+system $^X, "$cmake_source_dir/doc/doxygen/scripts/program2doxygen.pl", "$cmake_source_dir/examples/$step/$step.cc" , "--prefix=$step";
 
-system $^X, "$cmake_source_dir/doc/doxygen/scripts/create_anchors.pl", "$cmake_source_dir/examples/$step/doc/results.dox";
+system $^X, "$cmake_source_dir/doc/doxygen/scripts/create_anchors.pl", "$cmake_source_dir/examples/$step/doc/results.dox" , "--prefix=$step";
 
 
 # Move to the stripped, plain program. The same principle as above
@@ -100,7 +100,7 @@ system $^X, "$cmake_source_dir/doc/doxygen/scripts/create_anchors.pl", "$cmake_s
 print " *\n";
 print " *\n";
 print
-"<a name=\"PlainProg\"></a>
+"<a name=\"$step-PlainProg\"></a>
 <h1> The plain program</h1>
 \@include \"$step.cc\"
 */

--- a/doc/doxygen/scripts/program2doxygen.pl
+++ b/doc/doxygen/scripts/program2doxygen.pl
@@ -18,6 +18,9 @@
 # license information, if the file is a step-xx.cc tutorial. Here, xx
 # is either a number like step-32 or a number plus a letter like step-12b.
 # Don't skip for other files such as code-gallery files
+use Getopt::Long;
+GetOptions("prefix:s" => \$prefix);
+
 if ($ARGV[0] =~ /step-\d+[a-z]?.cc/)
 {
   $_ = <>;
@@ -101,7 +104,7 @@ do {
            # everything except for letters, numbers, and underscores
            $sect_name =~ s/[^a-zA-Z0-9_]//g;
 
-           $_ = "\n * <a name=\"$sect_name\"></a> \n * $_";
+           $_ = "\n * <a name=\"$prefix-$sect_name\"></a> \n * $_";
         }
 
         # finally print this line

--- a/doc/doxygen/scripts/program2toc.pl
+++ b/doc/doxygen/scripts/program2toc.pl
@@ -14,6 +14,8 @@
 ## ---------------------------------------------------------------------
 
 print "    <ul>\n";
+use Getopt::Long;
+GetOptions("prefix:s" => \$prefix);
 
 $level = 3;
 while (<>) {
@@ -52,7 +54,7 @@ while (<>) {
         # replace double dashes in comments by &mdash;
 	$text =~ s!--!&mdash;!g;
 
-	print "        <li><a href=\"#$reftext\">$text</a>\n";
+	print "        <li><a href=\"#$prefix-$reftext\">$text</a>\n";
 
 	$level = $newlevel;
     } 

--- a/doc/news/3.0.0-vs-3.1.0.h
+++ b/doc/news/3.0.0-vs-3.1.0.h
@@ -23,7 +23,7 @@ All entries are signed with the names of the author.
 
 
 
-<a name="general"></a>
+<a name="300-310-general"></a>
 <h3>General</h3>
 
 <ol>
@@ -161,7 +161,7 @@ All entries are signed with the names of the author.
 
 
 
-<a name="base"></a>
+<a name="300-310-base"></a>
 <h3>base</h3>
 
 <ol>
@@ -283,7 +283,7 @@ All entries are signed with the names of the author.
 
 
 
-<a name="lac"></a>
+<a name="300-310-lac"></a>
 <h3>lac</h3>
 
 <ol>
@@ -579,7 +579,7 @@ All entries are signed with the names of the author.
 
 
 
-<a name="deal.II"></a>
+<a name="300-310-deal.II"></a>
 <h3>deal.II</h3>
 
 <ol>

--- a/doc/news/3.1.0-vs-3.2.0.h
+++ b/doc/news/3.1.0-vs-3.2.0.h
@@ -22,7 +22,7 @@ All entries are signed with the names of the author.
 </p>
 
 
-<a name="general"></a>
+<a name="310-320-general"></a>
 <h3>General</h3>
 
 <ol>
@@ -88,7 +88,7 @@ All entries are signed with the names of the author.
        (GK 2001/03/14)
        </p>
 
-  <li> <a name="new_fe_mapping_design"></a>
+  <li> <a name="310-320-new_fe_mapping_design"></a>
        <i> New Design of <code>FiniteElements</code>
        and <code>Mappings</code></i>
 
@@ -161,7 +161,7 @@ All entries are signed with the names of the author.
 
 
 
-<a name="base"></a>
+<a name="310-320-base"></a>
 <h3>base</h3>
 
 <ol>
@@ -355,7 +355,7 @@ All entries are signed with the names of the author.
 
 
 
-<a name="lac"></a>
+<a name="310-320-lac"></a>
 <h3>lac</h3>
 
 <ol>
@@ -604,7 +604,7 @@ All entries are signed with the names of the author.
 
 
 
-<a name="deal.II"></a>
+<a name="310-320-deal.II"></a>
 <h3>deal.II</h3>
 
 <ol>

--- a/doc/news/3.2.0-vs-3.3.0.h
+++ b/doc/news/3.2.0-vs-3.3.0.h
@@ -22,7 +22,7 @@ All entries are signed with the names of the author.
 </p>
 
 
-<a name="general"></a>
+<a name="320-330-general"></a>
 <h3>General</h3>
 
 <ol>
@@ -121,7 +121,7 @@ All entries are signed with the names of the author.
 
 
 
-<a name="base"></a>
+<a name="320-330-base"></a>
 <h3>base</h3>
 
 <ol>
@@ -227,7 +227,7 @@ All entries are signed with the names of the author.
 
 
 
-<a name="lac"></a>
+<a name="320-330-lac"></a>
 <h3>lac</h3>
 
 <ol>
@@ -336,7 +336,7 @@ All entries are signed with the names of the author.
 
 
 
-<a name="deal.II"></a>
+<a name="320-330-deal.II"></a>
 <h3>deal.II</h3>
 
 <ol>

--- a/doc/news/3.3.0-vs-3.4.0.h
+++ b/doc/news/3.3.0-vs-3.4.0.h
@@ -21,7 +21,7 @@ This is the list of changes made between the deal.II releases listed above.
 All entries are signed with the names of the author.
 </p>
 
-<a name="general"></a>
+<a name="330-340-general"></a>
 <h3>General</h3>
 
 <ol>
@@ -159,7 +159,7 @@ All entries are signed with the names of the author.
 
 
 
-<a name="base"></a>
+<a name="330-340-base"></a>
 <h3>base</h3>
 
 <ol>
@@ -283,7 +283,7 @@ All entries are signed with the names of the author.
 
 
 
-<a name="lac"></a>
+<a name="330-340-lac"></a>
 <h3>lac</h3>
 
 <ol>
@@ -317,7 +317,7 @@ All entries are signed with the names of the author.
 
 
 
-<a name="deal.II"></a>
+<a name="330-340-deal.II"></a>
 <h3>deal.II</h3>
 
 <ol>

--- a/doc/news/3.4.0-vs-4.0.0.h
+++ b/doc/news/3.4.0-vs-4.0.0.h
@@ -24,7 +24,7 @@ contributor's names are abbreviated by WB (Wolfgang Bangerth), GK
 </p>
 
 
-<a name="general"></a>
+<a name="340-400-general"></a>
 <h3>General</h3>
 
 <ol>
@@ -312,7 +312,7 @@ contributor's names are abbreviated by WB (Wolfgang Bangerth), GK
 
 
 
-<a name="base"></a>
+<a name="340-400-base"></a>
 <h3>base</h3>
 
 <ol>
@@ -603,7 +603,7 @@ contributor's names are abbreviated by WB (Wolfgang Bangerth), GK
 
 
 
-<a name="lac"></a>
+<a name="340-400-lac"></a>
 <h3>lac</h3>
 
 <ol>
@@ -843,7 +843,7 @@ contributor's names are abbreviated by WB (Wolfgang Bangerth), GK
 
 
 
-<a name="deal.II"></a>
+<a name="340-400-deal.II"></a>
 <h3>deal.II</h3>
 
 <ol>

--- a/doc/news/4.0.0-vs-5.0.0.h
+++ b/doc/news/4.0.0-vs-5.0.0.h
@@ -24,7 +24,7 @@ contributor's names are abbreviated by WB (Wolfgang Bangerth), GK
 </p>
 
 
-<a name="incompatible"></a>
+<a name="400-500-incompatible"></a>
 <h3 style="color:red">Incompatibilities</h3>
 
 <p style="color:red">
@@ -145,7 +145,7 @@ inconvenience this causes.
 </ol>
 
 
-<a name="general"></a>
+<a name="400-500-general"></a>
 <h3>General</h3>
 
 <ol>
@@ -337,7 +337,7 @@ inconvenience this causes.
 
 
 
-<a name="base"></a>
+<a name="400-500-base"></a>
 <h3>base</h3>
 
 <ol>
@@ -439,7 +439,7 @@ inconvenience this causes.
 
 
 
-<a name="lac"></a>
+<a name="400-500-lac"></a>
 <h3>lac</h3>
 
 <ol>
@@ -569,7 +569,7 @@ inconvenience this causes.
 
 
 
-<a name="deal.II"></a>
+<a name="400-500-deal.II"></a>
 <h3>deal.II</h3>
 
 <ol>

--- a/doc/news/5.0.0-vs-5.1.0.h
+++ b/doc/news/5.0.0-vs-5.1.0.h
@@ -24,7 +24,7 @@ contributor's names are abbreviated by WB (Wolfgang Bangerth), GK
 </p>
 
 
-<a name="incompatible"></a>
+<a name="500-510-incompatible"></a>
 <h3 style="color:red">Incompatibilities</h3>
 
 <p style="color:red">
@@ -65,7 +65,7 @@ inconvenience this causes.
 
 
 
-<a name="general"></a>
+<a name="500-510-general"></a>
 <h3>General</h3>
 
 <ol>
@@ -143,7 +143,7 @@ inconvenience this causes.
 </ol>
 
 
-<a name="base"></a>
+<a name="500-510-base"></a>
 <h3>base</h3>
 
 <ol>
@@ -237,7 +237,7 @@ inconvenience this causes.
 
 
 
-<a name="lac"></a>
+<a name="500-510-lac"></a>
 <h3>lac</h3>
 
 <ol>
@@ -420,7 +420,7 @@ inconvenience this causes.
 
 
 
-<a name="deal.II"></a>
+<a name="500-510-deal.II"></a>
 <h3>deal.II</h3>
 
 <ol>

--- a/doc/news/5.1.0-vs-5.2.0.h
+++ b/doc/news/5.1.0-vs-5.2.0.h
@@ -24,7 +24,7 @@ contributor's names are abbreviated by WB (Wolfgang Bangerth), GK
 </p>
 
 
-<a name="incompatible"></a>
+<a name="510-520-incompatible"></a>
 <h3 style="color:red">Incompatibilities</h3>
 
 <p style="color:red">
@@ -134,7 +134,7 @@ inconvenience this causes.
        </p>
 </ol>
 
-<a name="general"></a>
+<a name="510-520-general"></a>
 <h3>General</h3>
 
 <ol>
@@ -269,7 +269,7 @@ inconvenience this causes.
 
 
 
-<a name="base"></a>
+<a name="510-520-base"></a>
 <h3>base</h3>
 
 <ol>
@@ -524,7 +524,7 @@ inconvenience this causes.
 
 
 
-<a name="lac"></a>
+<a name="510-520-lac"></a>
 <h3>lac</h3>
 
 <ol>
@@ -638,7 +638,7 @@ inconvenience this causes.
 
 
 
-<a name="deal.II"></a>
+<a name="510-520-deal.II"></a>
 <h3>deal.II</h3>
 
 <ol>

--- a/doc/news/5.2.0-vs-6.0.0.h
+++ b/doc/news/5.2.0-vs-6.0.0.h
@@ -24,7 +24,7 @@ contributor's names are abbreviated by WB (Wolfgang Bangerth), GK
 </p>
 
 
-<a name="incompatible"></a>
+<a name="520-600-incompatible"></a>
 <h3 style="color:red">Incompatibilities</h3>
 
 <p style="color:red">
@@ -202,7 +202,7 @@ inconvenience this causes.
 </ol>
 
 
-<a name="general"></a>
+<a name="520-600-general"></a>
 <h3>General</h3>
 
 <ol>
@@ -444,7 +444,7 @@ inconvenience this causes.
 
 
 
-<a name="base"></a>
+<a name="520-600-base"></a>
 <h3>base</h3>
 
 <ol>
@@ -763,7 +763,7 @@ inconvenience this causes.
 
 
 
-<a name="lac"></a>
+<a name="520-600-lac"></a>
 <h3>lac</h3>
 
 <ol>
@@ -1040,7 +1040,7 @@ inconvenience this causes.
 
 
 
-<a name="deal.II"></a>
+<a name="520-600-deal.II"></a>
 <h3>deal.II</h3>
 
 <ol>

--- a/doc/news/6.0.0-vs-6.1.0.h
+++ b/doc/news/6.0.0-vs-6.1.0.h
@@ -31,7 +31,7 @@ contributor's names are abbreviated by WB (Wolfgang Bangerth), GK
 </p>
 
 
-<a name="incompatible"></a>
+<a name="600-610-incompatible"></a>
 <h3 style="color:red">Incompatibilities</h3>
 
 <p style="color:red">
@@ -111,7 +111,7 @@ inconvenience this causes.
 
 
 
-<a name="general"></a>
+<a name="600-610-general"></a>
 <h3>General</h3>
 
 <ol>
@@ -171,7 +171,7 @@ inconvenience this causes.
 
 
 
-<a name="base"></a>
+<a name="600-610-base"></a>
 <h3>base</h3>
 
 <ol>
@@ -270,7 +270,7 @@ an integer id of the current thread.
 
 
 
-<a name="lac"></a>
+<a name="600-610-lac"></a>
 <h3>lac</h3>
 
 <ol>
@@ -354,7 +354,7 @@ constraints individually.
 
 
 
-<a name="deal.II"></a>
+<a name="600-610-deal.II"></a>
 <h3>deal.II</h3>
 
 <ol>

--- a/doc/news/6.1.0-vs-6.2.0.h
+++ b/doc/news/6.1.0-vs-6.2.0.h
@@ -31,7 +31,7 @@ contributor's names are abbreviated by WB (Wolfgang Bangerth), GK
 </p>
 
 
-<a name="incompatible"></a>
+<a name="610-620-incompatible"></a>
 <h3 style="color:red">Incompatibilities</h3>
 
 <p style="color:red">
@@ -178,7 +178,7 @@ inconvenience this causes.
 </ol>
 
 
-<a name="general"></a>
+<a name="610-620-general"></a>
 <h3>General</h3>
 
 <ol>
@@ -453,7 +453,7 @@ inconvenience this causes.
 
 
 
-<a name="base"></a>
+<a name="610-620-base"></a>
 <h3>base</h3>
 
 <ol>
@@ -637,7 +637,7 @@ inconvenience this causes.
 
 
 
-<a name="lac"></a>
+<a name="610-620-lac"></a>
 <h3>lac</h3>
 
 <ol>
@@ -853,7 +853,7 @@ inconvenience this causes.
 
 
 
-<a name="deal.II"></a>
+<a name="610-620-deal.II"></a>
 <h3>deal.II</h3>
 
 <ol>

--- a/doc/news/6.2.0-vs-6.3.0.h
+++ b/doc/news/6.2.0-vs-6.3.0.h
@@ -31,7 +31,7 @@ contributor's names are abbreviated by WB (Wolfgang Bangerth), GK
 </p>
 
 
-<a name="incompatible"></a>
+<a name="620-630-incompatible"></a>
 <h3 style="color:red">Incompatibilities</h3>
 
 <p style="color:red">
@@ -115,7 +115,7 @@ inconvenience this causes.
 </ol>
 
 
-<a name="general"></a>
+<a name="620-630-general"></a>
 <h3>General</h3>
 
 <ol>
@@ -321,7 +321,7 @@ inconvenience this causes.
 
 
 
-<a name="base"></a>
+<a name="620-630-base"></a>
 <h3>base</h3>
 
 <ol>
@@ -493,7 +493,7 @@ inconvenience this causes.
 
 
 
-<a name="lac"></a>
+<a name="620-630-lac"></a>
 <h3>lac</h3>
 
 <ol>
@@ -715,7 +715,7 @@ inconvenience this causes.
 </ol>
 
 
-<a name="deal.II"></a>
+<a name="620-630-deal.II"></a>
 <h3>deal.II</h3>
 
 <ol>

--- a/doc/news/6.3.0-vs-6.3.1.h
+++ b/doc/news/6.3.0-vs-6.3.1.h
@@ -27,7 +27,7 @@ contributor's names are abbreviated by WB (Wolfgang Bangerth), GK
 </p>
 
 
-<a name="incompatible"></a>
+<a name="630-631-incompatible"></a>
 <h3 style="color:red">Incompatibilities</h3>
 
 <p style="color:red">
@@ -44,7 +44,7 @@ inconvenience this causes.
 </ol>
 
 
-<a name="general"></a>
+<a name="630-631-general"></a>
 <h3>General</h3>
 
 <ol>
@@ -136,7 +136,7 @@ inconvenience this causes.
 
 
 
-<a name="base"></a>
+<a name="630-631-base"></a>
 <h3>base</h3>
 
 <ol>
@@ -144,7 +144,7 @@ inconvenience this causes.
 </ol>
 
 
-<a name="lac"></a>
+<a name="630-631-lac"></a>
 <h3>lac</h3>
 
 <ol>
@@ -152,7 +152,7 @@ inconvenience this causes.
 </ol>
 
 
-<a name="deal.II"></a>
+<a name="630-631-deal.II"></a>
 <h3>deal.II</h3>
 
 <ol>

--- a/doc/news/6.3.0-vs-7.0.0.h
+++ b/doc/news/6.3.0-vs-7.0.0.h
@@ -31,7 +31,7 @@ contributor's names are abbreviated by WB (Wolfgang Bangerth), GK
 </p>
 
 
-<a name="incompatible"></a>
+<a name="630-700-incompatible"></a>
 <h3 style="color:red">Incompatibilities</h3>
 
 <p style="color:red">
@@ -103,7 +103,7 @@ through DoFHandler::get_tria() and DoFHandler::get_fe(), respectively.
 </ol>
 
 
-<a name="general"></a>
+<a name="630-700-general"></a>
 <h3>General</h3>
 
 <ol>
@@ -297,7 +297,7 @@ through DoFHandler::get_tria() and DoFHandler::get_fe(), respectively.
 
 
 
-<a name="base"></a>
+<a name="630-700-base"></a>
 <h3>base</h3>
 
 
@@ -373,7 +373,7 @@ independent of the dimension.
 </ol>
 
 
-<a name="lac"></a>
+<a name="630-700-lac"></a>
 <h3>lac</h3>
 
 <ol>
@@ -430,7 +430,7 @@ independent of the dimension.
 
 
 
-<a name="deal.II"></a>
+<a name="630-700-deal.II"></a>
 <h3>deal.II</h3>
 
 <ol>

--- a/doc/news/7.0.0-vs-7.1.0.h
+++ b/doc/news/7.0.0-vs-7.1.0.h
@@ -22,7 +22,7 @@ All entries are signed with the names of the author.
 </p>
 
 
-<a name="incompatible"></a>
+<a name="700-710-incompatible"></a>
 <h3 style="color:red">Incompatibilities</h3>
 
 <p style="color:red">
@@ -113,7 +113,7 @@ changed to use std_cxx1x::_1, std_cxx1x::_2, etc from now on.
 
 <!-- ----------- GENERAL IMPROVEMENTS ----------------- -->
 
-<a name="general"></a>
+<a name="700-710-general"></a>
 <h3>General</h3>
 
 <ol>
@@ -342,7 +342,7 @@ and DoF handlers embedded in higher dimensional space have been added.
 
 <!-- ----------- SPECIFIC IMPROVEMENTS ----------------- -->
 
-<a name="specific"></a>
+<a name="700-710-specific"></a>
 <h3>Specific improvements</h3>
 
 <ol>

--- a/doc/news/7.1.0-vs-7.2.0.h
+++ b/doc/news/7.1.0-vs-7.2.0.h
@@ -25,7 +25,7 @@ All entries are signed with the names of the author.
 
 <!-- ----------- INCOMPATIBILITIES ----------------- -->
 
-<a name="incompatible"></a>
+<a name="710-720-incompatible"></a>
 <h3 style="color:red">Incompatibilities</h3>
 
 <p style="color:red">
@@ -71,7 +71,7 @@ used to store boundary indicators internally.
 
 <!-- ----------- GENERAL IMPROVEMENTS ----------------- -->
 
-<a name="general"></a>
+<a name="710-720-general"></a>
 <h3>General</h3>
 
 
@@ -320,7 +320,7 @@ enabled due to a missing include file in file
 
 <!-- ----------- SPECIFIC IMPROVEMENTS ----------------- -->
 
-<a name="specific"></a>
+<a name="710-720-specific"></a>
 <h3>Specific improvements</h3>
 
 <ol>

--- a/doc/news/7.2.0-vs-7.3.0.h
+++ b/doc/news/7.2.0-vs-7.3.0.h
@@ -25,7 +25,7 @@ All entries are signed with the names of the author.
 
 <!-- ----------- INCOMPATIBILITIES ----------------- -->
 
-<a name="incompatible"></a>
+<a name="720-730-incompatible"></a>
 <h3 style="color:red">Incompatibilities</h3>
 
 <p style="color:red">
@@ -171,7 +171,7 @@ never working correctly and it is not used.
 
 <!-- ----------- GENERAL IMPROVEMENTS ----------------- -->
 
-<a name="general"></a>
+<a name="720-730-general"></a>
 <h3>General</h3>
 
 
@@ -224,7 +224,7 @@ DoFHandler, in particular removal of specializations.
 
 <!-- ----------- SPECIFIC IMPROVEMENTS ----------------- -->
 
-<a name="specific"></a>
+<a name="720-730-specific"></a>
 <h3>Specific improvements</h3>
 
 <ol>

--- a/doc/news/7.3.0-vs-8.0.0.h
+++ b/doc/news/7.3.0-vs-8.0.0.h
@@ -25,7 +25,7 @@ All entries are signed with the names of the authors.
 
 <!-- ----------- INCOMPATIBILITIES ----------------- -->
 
-<a name="incompatible"></a>
+<a name="730-800-incompatible"></a>
 <h3 style="color:red">Incompatibilities</h3>
 
 <p style="color:red">
@@ -80,7 +80,7 @@ this function.
 
 <!-- ----------- GENERAL IMPROVEMENTS ----------------- -->
 
-<a name="general"></a>
+<a name="730-800-general"></a>
 <h3>General</h3>
 
 
@@ -173,7 +173,7 @@ this function.
 
 <!-- ----------- SPECIFIC IMPROVEMENTS ----------------- -->
 
-<a name="specific"></a>
+<a name="730-800-specific"></a>
 <h3>Specific improvements</h3>
 
 <ol>

--- a/doc/news/8.0.0-vs-8.1.0.h
+++ b/doc/news/8.0.0-vs-8.1.0.h
@@ -25,7 +25,7 @@ All entries are signed with the names of the author.
 
 <!-- ----------- INCOMPATIBILITIES ----------------- -->
 
-<a name="incompatible"></a>
+<a name="800-810-incompatible"></a>
 <h3 style="color:red">Incompatibilities</h3>
 
 <p style="color:red">
@@ -119,7 +119,7 @@ inconvenience this causes.
 
 <!-- ----------- GENERAL IMPROVEMENTS ----------------- -->
 
-<a name="general"></a>
+<a name="800-810-general"></a>
 <h3>General</h3>
 
 
@@ -262,7 +262,7 @@ inconvenience this causes.
 
 <!-- ----------- SPECIFIC IMPROVEMENTS ----------------- -->
 
-<a name="specific"></a>
+<a name="800-810-specific"></a>
 <h3>Specific improvements</h3>
 
 <ol>

--- a/doc/news/8.1.0-vs-8.2.0.h
+++ b/doc/news/8.1.0-vs-8.2.0.h
@@ -26,7 +26,7 @@ authors.
 
 <!-- ----------- INCOMPATIBILITIES ----------------- -->
 
-<a name="incompatible"></a>
+<a name="810-820-incompatible"></a>
 <h3 style="color:red">Incompatibilities</h3>
 
 <p style="color:red">
@@ -114,7 +114,7 @@ inconvenience this causes.
 
 <!-- ----------- GENERAL IMPROVEMENTS ----------------- -->
 
-<a name="general"></a>
+<a name="810-820-general"></a>
 <h3>General</h3>
 
 
@@ -336,7 +336,7 @@ inconvenience this causes.
 
 <!-- ----------- SPECIFIC IMPROVEMENTS ----------------- -->
 
-<a name="specific"></a>
+<a name="810-820-specific"></a>
 <h3>Specific improvements</h3>
 
 <ol>

--- a/doc/news/8.2.0-vs-8.2.1.h
+++ b/doc/news/8.2.0-vs-8.2.1.h
@@ -24,7 +24,7 @@ authors.
 
 <!-- ----------- SPECIFIC IMPROVEMENTS ----------------- -->
 
-<a name="specific"></a>
+<a name="820-821-specific"></a>
 <h3>Specific improvements</h3>
 
 <ol>

--- a/doc/news/8.2.1-vs-8.3.0.h
+++ b/doc/news/8.2.1-vs-8.3.0.h
@@ -26,7 +26,7 @@ author.
 
 <!-- ----------- INCOMPATIBILITIES ----------------- -->
 
-<a name="incompatible"></a>
+<a name="821-830-incompatible"></a>
 <h3 style="color:red">Incompatibilities</h3>
 
 <p style="color:red">
@@ -388,7 +388,7 @@ inconvenience this causes.
 
 <!-- ----------- GENERAL IMPROVEMENTS ----------------- -->
 
-<a name="general"></a>
+<a name="821-830-general"></a>
 <h3>General</h3>
 
 
@@ -547,7 +547,7 @@ inconvenience this causes.
 
 <!-- ----------- SPECIFIC IMPROVEMENTS ----------------- -->
 
-<a name="specific"></a>
+<a name="821-830-specific"></a>
 <h3>Specific improvements</h3>
 
 

--- a/doc/news/8.3.0-vs-8.4.0.h
+++ b/doc/news/8.3.0-vs-8.4.0.h
@@ -26,7 +26,7 @@ author.
 
 <!-- ----------- INCOMPATIBILITIES ----------------- -->
 
-<a name="incompatible"></a>
+<a name="830-840-incompatible"></a>
 <h3 style="color:red">Incompatibilities</h3>
 
 <p style="color:red">
@@ -218,7 +218,7 @@ inconvenience this causes.
 
 <!-- ----------- GENERAL IMPROVEMENTS ----------------- -->
 
-<a name="general"></a>
+<a name="830-840-general"></a>
 <h3>General</h3>
 <ol>
   <li> New: A variant for GridGenerator::subdivided_parallelepiped() was added
@@ -514,7 +514,7 @@ inconvenience this causes.
 
 <!-- ----------- SPECIFIC IMPROVEMENTS ----------------- -->
 
-<a name="specific"></a>
+<a name="830-840-specific"></a>
 <h3>Specific improvements</h3>
 
 

--- a/doc/news/8.4.0-vs-8.4.1.h
+++ b/doc/news/8.4.0-vs-8.4.1.h
@@ -25,7 +25,7 @@ author.
 
 <!-- ----------- SPECIFIC IMPROVEMENTS ----------------- -->
 
-<a name="specific"></a>
+<a name="840-841-specific"></a>
 <h3>Specific improvements</h3>
 
 <ol>

--- a/doc/news/8.4.1-vs-8.4.2.h
+++ b/doc/news/8.4.1-vs-8.4.2.h
@@ -25,7 +25,7 @@ author.
 
 <!-- ----------- SPECIFIC IMPROVEMENTS ----------------- -->
 
-<a name="specific"></a>
+<a name="841-842-specific"></a>
 <h3>Specific improvements</h3>
 
 <ol>

--- a/doc/news/8.4.2-vs-8.5.0.h
+++ b/doc/news/8.4.2-vs-8.5.0.h
@@ -26,7 +26,7 @@ author.
 
 <!-- ----------- INCOMPATIBILITIES ----------------- -->
 
-<a name="incompatible"></a>
+<a name="842-850-incompatible"></a>
 <h3 style="color:red">Incompatibilities</h3>
 
 <p style="color:red">
@@ -313,7 +313,7 @@ inconvenience this causes.
 
 <!-- ----------- GENERAL IMPROVEMENTS ----------------- -->
 
-<a name="general"></a>
+<a name="842-850-general"></a>
 <h3>General</h3>
 
 <ol>
@@ -637,7 +637,7 @@ inconvenience this causes.
 
 <!-- ----------- SPECIFIC IMPROVEMENTS ----------------- -->
 
-<a name="specific"></a>
+<a name="842-850-specific"></a>
 <h3>Specific improvements</h3>
 
 <ol>

--- a/doc/news/8.5.0-vs-9.0.0.h
+++ b/doc/news/8.5.0-vs-9.0.0.h
@@ -26,7 +26,7 @@ author.
 
 <!-- ----------- INCOMPATIBILITIES ----------------- -->
 
-<a name="incompatible"></a>
+<a name="850-900-incompatible"></a>
 <h3 style="color:red">Incompatibilities</h3>
 
 <p style="color:red">
@@ -693,7 +693,7 @@ inconvenience this causes.
 
 <!-- ----------- GENERAL IMPROVEMENTS ----------------- -->
 
-<a name="general"></a>
+<a name="850-900-general"></a>
 <h3>General</h3>
 
 <ol>
@@ -960,7 +960,7 @@ inconvenience this causes.
 
 <!-- ----------- SPECIFIC IMPROVEMENTS ----------------- -->
 
-<a name="specific"></a>
+<a name="850-900-specific"></a>
 <h3>Specific improvements</h3>
 
 <ol>

--- a/doc/news/9.0.0-vs-9.0.1.h
+++ b/doc/news/9.0.0-vs-9.0.1.h
@@ -26,7 +26,7 @@ author.
 
 <!-- ----------- INCOMPATIBILITIES ----------------- -->
 
-<a name="incompatible"></a>
+<a name="900-901-incompatible"></a>
 <h3 style="color:red">Incompatibilities</h3>
 
 <p style="color:red">
@@ -41,13 +41,13 @@ inconvenience this causes.
 
 <!-- ----------- GENERAL IMPROVEMENTS ----------------- -->
 
-<a name="general"></a>
+<a name="900-901-general"></a>
 <h3>General</h3>
 
 
 <!-- ----------- SPECIFIC IMPROVEMENTS ----------------- -->
 
-<a name="specific"></a>
+<a name="900-901-specific"></a>
 <h3>Specific improvements</h3>
 
 <ol>

--- a/doc/news/9.0.1-vs-9.1.0.h
+++ b/doc/news/9.0.1-vs-9.1.0.h
@@ -26,7 +26,7 @@ author.
 
 <!-- ----------- INCOMPATIBILITIES ----------------- -->
 
-<a name="incompatible"></a>
+<a name="901-910-incompatible"></a>
 <h3 style="color:red">Incompatibilities</h3>
 
 <p style="color:red">
@@ -201,7 +201,7 @@ inconvenience this causes.
 
 <!-- ----------- GENERAL IMPROVEMENTS ----------------- -->
 
-<a name="general"></a>
+<a name="901-910-general"></a>
 <h3>General</h3>
 
 <ol>
@@ -493,7 +493,7 @@ inconvenience this causes.
 
 <!-- ----------- SPECIFIC IMPROVEMENTS ----------------- -->
 
-<a name="specific"></a>
+<a name="901-910-specific"></a>
 <h3>Specific improvements</h3>
 
 <ol>

--- a/doc/news/9.1.0-vs-9.1.1.h
+++ b/doc/news/9.1.0-vs-9.1.1.h
@@ -26,7 +26,7 @@ author.
 
 <!-- ----------- SPECIFIC IMPROVEMENTS ----------------- -->
 
-<a name="specific"></a>
+<a name="910-911-specific"></a>
 <h3>Specific improvements</h3>
 
 <ol>

--- a/doc/news/9.1.1-vs-9.2.0.h
+++ b/doc/news/9.1.1-vs-9.2.0.h
@@ -26,7 +26,7 @@ author.
 
 <!-- ----------- INCOMPATIBILITIES ----------------- -->
 
-<a name="incompatible"></a>
+<a name="911-920-incompatible"></a>
 <h3 style="color:red">Incompatibilities</h3>
 
 <p style="color:red">
@@ -582,7 +582,7 @@ inconvenience this causes.
 
 <!-- ----------- GENERAL IMPROVEMENTS ----------------- -->
 
-<a name="general"></a>
+<a name="911-920-general"></a>
 <h3>General</h3>
 
 <ol>
@@ -785,7 +785,7 @@ inconvenience this causes.
 
 <!-- ----------- SPECIFIC IMPROVEMENTS ----------------- -->
 
-<a name="specific"></a>
+<a name="911-920-specific"></a>
 <h3>Specific improvements</h3>
 
 <ol>

--- a/doc/news/9.2.0-vs-9.3.0.h
+++ b/doc/news/9.2.0-vs-9.3.0.h
@@ -23,7 +23,7 @@ author.
 </p>
 <!-- ----------- INCOMPATIBILITIES ----------------- -->
 
-<a name="incompatible"></a>
+<a name="920-930-incompatible"></a>
 <h3 style="color:red">Incompatibilities</h3>
 
 <p style="color:red">
@@ -452,7 +452,7 @@ inconvenience this causes.
 
 <!-- ----------- GENERAL IMPROVEMENTS ----------------- -->
 
-<a name="general"></a>
+<a name="920-930-general"></a>
 <h3>General</h3>
 <ol>
 
@@ -630,7 +630,7 @@ inconvenience this causes.
 
 <!-- ----------- SPECIFIC IMPROVEMENTS ----------------- -->
 
-<a name="specific"></a>
+<a name="920-930-specific"></a>
 <h3>Specific improvements</h3>
 <ol>
 

--- a/doc/news/9.3.0-vs-9.3.1.h
+++ b/doc/news/9.3.0-vs-9.3.1.h
@@ -24,7 +24,7 @@ author.
 
 <!-- ----------- SPECIFIC IMPROVEMENTS ----------------- -->
 
-<a name="specific"></a>
+<a name="930-931-specific"></a>
 <h3>Specific improvements</h3>
 <ol>
 

--- a/doc/news/9.3.1-vs-9.3.2.h
+++ b/doc/news/9.3.1-vs-9.3.2.h
@@ -24,7 +24,7 @@ author.
 
 <!-- ----------- SPECIFIC IMPROVEMENTS ----------------- -->
 
-<a name="specific"></a>
+<a name="931-932-specific"></a>
 <h3>Specific improvements</h3>
 <ol>
 

--- a/doc/news/9.3.2-vs-9.3.3.h
+++ b/doc/news/9.3.2-vs-9.3.3.h
@@ -24,7 +24,7 @@ author.
 
 <!-- ----------- SPECIFIC IMPROVEMENTS ----------------- -->
 
-<a name="specific"></a>
+<a name="932-933-specific"></a>
 <h3>Specific improvements</h3>
 <ol>
 

--- a/doc/news/9.3.3-vs-9.4.0.h
+++ b/doc/news/9.3.3-vs-9.4.0.h
@@ -23,7 +23,7 @@ author.
 </p>
 <!-- ----------- INCOMPATIBILITIES ----------------- -->
 
-<a name="incompatible"></a>
+<a name="933-940-incompatible"></a>
 <h3 style="color:red">Incompatibilities</h3>
 
 <p style="color:red">
@@ -452,7 +452,7 @@ inconvenience this causes.
 
 <!-- ----------- GENERAL IMPROVEMENTS ----------------- -->
 
-<a name="general"></a>
+<a name="933-940-general"></a>
 <h3>General</h3>
 <ol>
 
@@ -612,7 +612,7 @@ inconvenience this causes.
 
 <!-- ----------- SPECIFIC IMPROVEMENTS ----------------- -->
 
-<a name="specific"></a>
+<a name="933-940-specific"></a>
 <h3>Specific improvements</h3>
 <ol>
 

--- a/doc/news/9.4.0-vs-9.5.0.h
+++ b/doc/news/9.4.0-vs-9.5.0.h
@@ -23,7 +23,7 @@ author.
 </p>
 <!-- ----------- INCOMPATIBILITIES ----------------- -->
 
-<a name="incompatible"></a>
+<a name="940-950-incompatible"></a>
 <h3 style="color:red">Incompatibilities</h3>
 
 <p style="color:red">
@@ -328,7 +328,7 @@ inconvenience this causes.
 
 <!-- ----------- GENERAL IMPROVEMENTS ----------------- -->
 
-<a name="general"></a>
+<a name="940-950-general"></a>
 <h3>General</h3>
 <ol>
 
@@ -401,7 +401,7 @@ inconvenience this causes.
 
 <!-- ----------- SPECIFIC IMPROVEMENTS ----------------- -->
 
-<a name="specific"></a>
+<a name="940-950-specific"></a>
 <h3>Specific improvements</h3>
 <ol>
 

--- a/examples/step-1/doc/intro.dox
+++ b/examples/step-1/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="Intro"></a>
+<a name="step-1-Intro"></a>
 <h1>Introduction</h1>
 
 <h3> About the tutorial </h3>

--- a/examples/step-10/doc/intro.dox
+++ b/examples/step-10/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="Intro"></a>
+<a name="step-10-Intro"></a>
 <h1>Introduction</h1>
 
 

--- a/examples/step-10/doc/results.dox
+++ b/examples/step-10/doc/results.dox
@@ -230,7 +230,7 @@ eigenfunctions of the Laplace-Beltrami operator", submitted, 2018.)
 
 
 <h3>Possibilities for extensions</h3>
-<a name="extensions"></a>
+<a name="step-10-extensions"></a>
 
 As the table of numbers copied from the output of the program shows above,
 it is not very difficult to compute the value of $\pi$ to 13 or 15 digits. But,

--- a/examples/step-11/doc/intro.dox
+++ b/examples/step-11/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="Intro"></a>
+<a name="step-11-Intro"></a>
 <h1>Introduction</h1>
 
 The problem we will be considering is the solution of Laplace's problem with

--- a/examples/step-12/doc/intro.dox
+++ b/examples/step-12/doc/intro.dox
@@ -5,7 +5,7 @@ MeshWorker and LocalIntegrators instead of assembling matrices using
 FEInterfaceValues as is done in this tutorial.
 </i>
 
-<a name="Intro"></a>
+<a name="step-12-Intro"></a>
 <h1>An example of an advection problem using the Discountinuous Galerkin method</h1>
 
 <h3>Overview</h3>

--- a/examples/step-12/doc/results.dox
+++ b/examples/step-12/doc/results.dox
@@ -53,7 +53,7 @@ And finally we show a plot of a 3d computation.
 <img src="https://www.dealii.org/images/steps/developer/step-12.sol-5-3d.png" alt="">
 
 
-<a name="dg-vs-cg"></a>
+<a name="step-12-dg-vs-cg"></a>
 <h3>Why use discontinuous elements</h3>
 
 In this program we have used discontinuous elements. It is a legitimate
@@ -131,7 +131,7 @@ take a look at step-31.
 
 
 
-<a name="extensions"></a>
+<a name="step-12-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 Given that the exact solution is known in this case, one interesting

--- a/examples/step-13/doc/intro.dox
+++ b/examples/step-13/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="Intro"></a>
+<a name="step-13-Intro"></a>
 <h1>Introduction</h1>
 
 <h3>Background and purpose</h3>

--- a/examples/step-14/doc/intro.dox
+++ b/examples/step-14/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="Intro"></a>
+<a name="step-14-Intro"></a>
 <h1>Introduction</h1>
 
 <h3>The maths</h3>

--- a/examples/step-15/doc/intro.dox
+++ b/examples/step-15/doc/intro.dox
@@ -8,7 +8,7 @@ is by him.
 <br>
 
 
-<a name="Intro"></a>
+<a name="step-15-Intro"></a>
 <h1>Introduction</h1>
 
 <h3>Foreword</h3>

--- a/examples/step-15/doc/results.dox
+++ b/examples/step-15/doc/results.dox
@@ -96,7 +96,7 @@ solution and mesh are shown here:
 
 
 
-<a name="extensions"></a>
+<a name="step-15-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 The program shows the basic structure of a solver for a nonlinear, stationary

--- a/examples/step-16/doc/intro.dox
+++ b/examples/step-16/doc/intro.dox
@@ -5,7 +5,7 @@ MeshWorker and LocalIntegrators instead of assembling matrices manually as it
 is done in this tutorial.
 </i>
 
-<a name="Intro"></a>
+<a name="step-16-Intro"></a>
 <h1>Introduction</h1>
 
 

--- a/examples/step-17/doc/intro.dox
+++ b/examples/step-17/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="Intro"></a>
+<a name="step-17-Intro"></a>
 <h1>Introduction</h1>
 
 <h3>Overview</h3>

--- a/examples/step-17/doc/results.dox
+++ b/examples/step-17/doc/results.dox
@@ -231,7 +231,7 @@ the right one shows the x-displacement along two cutplanes through the cube.
 
 
 
-<a name="extensions"></a>
+<a name="step-17-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 The program keeps a complete copy of the Triangulation and DoFHandler objects

--- a/examples/step-18/doc/intro.dox
+++ b/examples/step-18/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="Intro"></a>
+<a name="step-18-Intro"></a>
 <h1>Introduction</h1>
 
 
@@ -145,7 +145,7 @@ changes with time, with the boundary moving according to the
 displacements $\mathbf{u}(\mathbf{x},t)$ of the points on the boundary. To
 complete this system, we have to specify the incremental relationship between
 the stress and the strain, as follows:
-<a name="step_18.stress-strain"></a>
+<a name="step-18-stress-strain"></a>
 @f[
   \dot\sigma = C \varepsilon (\dot{\mathbf{u}}),
   \qquad
@@ -189,7 +189,7 @@ The weak form of this set of equations, which as usual is the basis for the
 finite element formulation, reads as follows: find $\Delta \mathbf{u}^n \in
 \{v\in H^1(\Omega(t_{n-1}))^d: v|_{\Gamma_D}=\mathbf{d}(\cdot,t_n) - \mathbf{d}(\cdot,t_{n-1})\}$
 such that
-<a name="step_18.linear-system"></a>
+<a name="step-18-linear-system"></a>
 @f{align*}{
   (C \varepsilon(\Delta\mathbf{u}^n), \varepsilon(\varphi) )_{\Omega(t_{n-1})}
   &=
@@ -260,7 +260,7 @@ complicated and will be discussed in the next section.
 
 As indicated above, we need to have the stress variable $\sigma^n$ available
 when computing time step $n+1$, and we can compute it using
-<a name="step_18.stress-update"></a>
+<a name="step-18-stress-update"></a>
 @f[
   \sigma^n = \sigma^{n-1} + C \varepsilon (\Delta \mathbf{u}^n).
   \qquad
@@ -331,7 +331,7 @@ the increment describe translations, its divergence the dilational modes, and
 the curl the rotational modes). Since the exact form of $R$ is cumbersome, we
 only state it in the program code, and note that the correct updating formula
 for the stress variable is then
-<a name="step_18.stress-update+rot"></a>
+<a name="step-18-stress-update+rot"></a>
 @f[
   \sigma^n
   =

--- a/examples/step-19/doc/intro.dox
+++ b/examples/step-19/doc/intro.dox
@@ -13,7 +13,7 @@ awards DMS-1821210, EAR-1550901, and OAC-1835673.
   the publication @cite GLHPW2018 if you use particle functionality in your
   own work.
 
-<a name="Intro"></a>
+<a name="step-19-Intro"></a>
 <h1>Introduction</h1>
 
 The finite element method in general, and deal.II in particular, were invented

--- a/examples/step-19/doc/results.dox
+++ b/examples/step-19/doc/results.dox
@@ -160,7 +160,7 @@ the magnitude exceeds the threshold necessary to draw an electron out of the
 electrode.
 
 
-<a name="extensions"></a>
+<a name="step-19-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 

--- a/examples/step-2/doc/intro.dox
+++ b/examples/step-2/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="Intro"></a>
+<a name="step-2-Intro"></a>
 <h1>Introduction</h1>
 
 @dealiiVideoLecture{9}

--- a/examples/step-20/doc/intro.dox
+++ b/examples/step-20/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="Intro"></a>
+<a name="step-20-Intro"></a>
 <h1>Introduction</h1>
 
 @dealiiVideoLecture{19,20,21}
@@ -800,5 +800,5 @@ hand side equals $f=0$, and as boundary values we have to choose
 $g=p|_{\partial\Omega}$.
 
 For the computations in this program, we choose $\alpha=0.3,\beta=1$. You can
-find the resulting solution in the <a name="#Results">results section
+find the resulting solution in the <a name="step-20-#Results">results section
 below</a>, after the commented program.

--- a/examples/step-20/doc/results.dox
+++ b/examples/step-20/doc/results.dox
@@ -159,7 +159,7 @@ The result concerning the convergence order is the same here.
 
 
 
-<a name="extensions"></a>
+<a name="step-20-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 <h4>More realistic permeability fields</h4>

--- a/examples/step-21/doc/intro.dox
+++ b/examples/step-21/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="Intro"></a> <h1>Introduction</h1>
+<a name="step-21-Intro"></a> <h1>Introduction</h1>
 
 This program grew out of a student project by Yan Li at Texas A&amp;M
 University. Most of the work for this program is by her.

--- a/examples/step-21/doc/results.dox
+++ b/examples/step-21/doc/results.dox
@@ -109,7 +109,7 @@ saturation less than 0.5. However, it appears that most visualization programs
 are not equipped to do this kind of transformation.
 
 
-<a name="extensions"></a>
+<a name="step-21-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 There are a number of areas where this program can be improved. Three of them

--- a/examples/step-22/doc/intro.dox
+++ b/examples/step-22/doc/intro.dox
@@ -13,7 +13,7 @@ California Institute of Technology.
 
 
 
-<a name="Intro"></a>
+<a name="step-22-Intro"></a>
 <h1>Introduction</h1>
 
 This program deals with the Stokes system of equations which reads as
@@ -823,7 +823,7 @@ MatrixTools::apply_boundary_values for implementing Dirichlet boundary
 conditions.
 
 
-<a name="constraint-matrix">
+<a name="step-22-constraint-matrix">
 <h4>Using AffineConstraints for increasing performance</h4>
 </a>
 

--- a/examples/step-22/doc/results.dox
+++ b/examples/step-22/doc/results.dox
@@ -1,4 +1,4 @@
-<a name="Results"></a>
+<a name="step-22-Results"></a>
 <h1>Results</h1>
 
 <h3>Output of the program and graphical visualization</h3>
@@ -280,7 +280,7 @@ is not a good choice in 3D - a full decomposition needs many new entries that
 
 <h3>Possibilities for extensions</h3>
 
-<a name="improved-solver">
+<a name="step-22-improved-solver">
 <h4>Improved linear solver in 3D</h4>
 </a>
 
@@ -318,7 +318,7 @@ size. Either way, we will introduce below a number of improvements to the
 linear solver, a discussion that we will re-consider again with additional
 options in the step-31 program.
 
-<a name="improved-ilu">
+<a name="step-22-improved-ilu">
 <h5>Better ILU decomposition by smart reordering</h5>
 </a>
 A first attempt to improve the speed of the linear solution process is to choose
@@ -346,7 +346,7 @@ mesh-independent number of iterations, say 10 to 30. We have seen such a
 candidate in step-16: multigrid.
 
 <h5>Block Schur complement preconditioner</h5>
-<a name="block-schur"></a>
+<a name="step-22-block-schur"></a>
 Even with a good preconditioner for $A$, we still
 need to solve of the same linear system repeatedly (with different
 right hand sides, though) in order to make the Schur complement solve

--- a/examples/step-23/doc/intro.dox
+++ b/examples/step-23/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="Intro"></a>
+<a name="step-23-Intro"></a>
 <h1>Introduction</h1>
 
 @dealiiVideoLecture{28}

--- a/examples/step-23/doc/results.dox
+++ b/examples/step-23/doc/results.dox
@@ -73,7 +73,7 @@ wave, an artifact of a too-large mesh size that can be reduced by reducing the
 mesh width and the time step.
 
 
-<a name="extensions"></a>
+<a name="step-23-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 If you want to explore a bit, try out some of the following things:

--- a/examples/step-24/doc/intro.dox
+++ b/examples/step-24/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="Intro"></a>
+<a name="step-24-Intro"></a>
 <h1>Introduction</h1>
 
 This program grew out of a student project by Xing Jin at Texas A&amp;M

--- a/examples/step-25/doc/intro.dox
+++ b/examples/step-25/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="Intro"></a> <h1>Introduction</h1>
+<a name="step-25-Intro"></a> <h1>Introduction</h1>
 
 This program grew out of a student project by Ivan Christov at Texas A&amp;M
 University. Most of the work for this program is by him.

--- a/examples/step-25/doc/results.dox
+++ b/examples/step-25/doc/results.dox
@@ -97,7 +97,7 @@ it appears to break up and reassemble, rather than just oscillate.
 <img src="https://www.dealii.org/images/steps/developer/step-25.2d-pseudobreather.gif" alt="Animation of a 2D pseudobreather.">
 
 
-<a name="extensions"></a>
+<a name="step-25-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 It is instructive to change the initial conditions. Most choices will not lead

--- a/examples/step-26/doc/intro.dox
+++ b/examples/step-26/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="Intro"></a>
+<a name="step-26-Intro"></a>
 <h1>Introduction</h1>
 
 @dealiiVideoLecture{29,30}

--- a/examples/step-26/doc/results.dox
+++ b/examples/step-26/doc/results.dox
@@ -48,7 +48,7 @@ to this. It is quite obvious that the mesh as is is probably not the best we
 could come up with. We'll get back to this in the next section.
 
 
-<a name="extensions"></a>
+<a name="step-26-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 There are at least two areas where one can improve this program significantly:

--- a/examples/step-27/doc/intro.dox
+++ b/examples/step-27/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="Intro"></a>
+<a name="step-27-Intro"></a>
 <h1>Introduction</h1>
 
 This tutorial program attempts to show how to use $hp$-finite element methods

--- a/examples/step-27/doc/results.dox
+++ b/examples/step-27/doc/results.dox
@@ -217,7 +217,7 @@ sub-optimal refinement criterion.
 
 
 
-<a name="extensions"></a>
+<a name="step-27-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 <h4>Different hp-decision strategies</h4>

--- a/examples/step-28/doc/intro.dox
+++ b/examples/step-28/doc/intro.dox
@@ -23,7 +23,7 @@ href="https://www.semanticscholar.org/paper/Three-dimensional-h-adaptivity-for-t
 <br>
 
 
-<a name="Intro"></a> <h1>Introduction</h1>
+<a name="step-28-Intro"></a> <h1>Introduction</h1>
 In this example, we intend to solve the multigroup diffusion approximation of
 the neutron transport equation. Essentially, the way to view this is as follows: In a
 nuclear reactor, neutrons are speeding around at different energies, get

--- a/examples/step-29/doc/intro.dox
+++ b/examples/step-29/doc/intro.dox
@@ -11,7 +11,7 @@ the UMFPACK sparse direct solver. Refer to the <a
 href="../../readme.html#umfpack">ReadMe</a> for instructions how to do this.
 
 
-<a name="Intro"></a>
+<a name="step-29-Intro"></a>
 <h1>Introduction</h1>
 
 

--- a/examples/step-29/doc/results.dox
+++ b/examples/step-29/doc/results.dox
@@ -1,4 +1,4 @@
-<a name="Results"></a>
+<a name="step-29-Results"></a>
 <h1>Results</h1>
 
 The current program reads its run-time parameters from an input file
@@ -183,7 +183,7 @@ other parts of the program scale very nicely.
 
 
 
-<a name="extensions"></a>
+<a name="step-29-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 An obvious possible extension for this program is to run it in 3d

--- a/examples/step-3/doc/intro.dox
+++ b/examples/step-3/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="Intro"></a>
+<a name="step-3-Intro"></a>
 <h1>Introduction</h1>
 
 @dealiiVideoLecture{10}

--- a/examples/step-3/doc/results.dox
+++ b/examples/step-3/doc/results.dox
@@ -54,7 +54,7 @@ of the solution. Several video lectures show how to use these programs.
 
 
 
-<a name="extensions"></a>
+<a name="step-3-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 If you want to play around a little bit with this program, here are a few

--- a/examples/step-30/doc/intro.dox
+++ b/examples/step-30/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="Intro"></a>
+<a name="step-30-Intro"></a>
 <h1>Introduction</h1>
 
 

--- a/examples/step-31/doc/intro.dox
+++ b/examples/step-31/doc/intro.dox
@@ -12,7 +12,7 @@ California Institute of Technology.
 </i>
 
 
-<a name="Intro"></a>
+<a name="step-31-Intro"></a>
 <h1>Introduction</h1>
 
 <h3>The Boussinesq equations</h3>

--- a/examples/step-32/doc/intro.dox
+++ b/examples/step-32/doc/intro.dox
@@ -27,7 +27,7 @@ more flexible in solving many kinds of related problems.
 </i>
 
 
-<a name="Intro"></a>
+<a name="step-32-Intro"></a>
 <h1>Introduction</h1>
 
 This program does pretty much exactly what step-31 already does: it

--- a/examples/step-32/doc/results.dox
+++ b/examples/step-32/doc/results.dox
@@ -283,7 +283,7 @@ with the mesh) onto 512 processors:
 </p>
 
 
-<a name="extensions"></a>
+<a name="step-32-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 There are many directions in which this program could be extended. As

--- a/examples/step-33/doc/intro.dox
+++ b/examples/step-33/doc/intro.dox
@@ -31,7 +31,7 @@ can be solved more efficiently.
 
 
 
-<a name="Intro"></a> <h1>Introduction</h1>
+<a name="step-33-Intro"></a> <h1>Introduction</h1>
 
 <h3>Euler flow</h3>
 

--- a/examples/step-33/doc/results.dox
+++ b/examples/step-33/doc/results.dox
@@ -1,4 +1,4 @@
-<a name="Results"></a>
+<a name="step-33-Results"></a>
 <h1>Results</h1>
 
 We run the problem with the mesh <code>slide.inp</code> (this file is in the
@@ -219,7 +219,7 @@ refinement scheme discussed above.
 
 
 
-<a name="extensions"></a>
+<a name="step-33-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 <h4>Stabilization</h4>

--- a/examples/step-34/doc/intro.dox
+++ b/examples/step-34/doc/intro.dox
@@ -6,7 +6,7 @@ the three dimensional case).  </i>
 
 @dealiiTutorialDOI{10.5281/zenodo.495473,https://zenodo.org/badge/DOI/10.5281/zenodo.495473.svg}
 
-<a name="Intro"></a>
+<a name="step-34-Intro"></a>
 
 <h1>Introduction</h1>
 

--- a/examples/step-34/doc/results.dox
+++ b/examples/step-34/doc/results.dox
@@ -209,7 +209,7 @@ and then the external contour plot of the potential, with opacity set to 25%:
 <img src="https://www.dealii.org/images/steps/developer/step-34_3d-2.png" alt="">
 
 
-<a name="extensions"></a>
+<a name="step-34-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 This is the first tutorial program that considers solving equations defined on

--- a/examples/step-35/doc/intro.dox
+++ b/examples/step-35/doc/intro.dox
@@ -5,10 +5,10 @@ This program grew out of a student project by Abner Salgado at Texas A&M
 University. Most of the work for this program is by him.
 </i>
 
-<a name="Intro"></a>
+<a name="step-35-Intro"></a>
 <h1> Introduction </h1>
 
-<a name="Motivation"></a>
+<a name="step-35-Motivation"></a>
 <h3> Motivation </h3>
 The purpose of this program is to show how to effectively solve the incompressible time-dependent
 Navier-Stokes equations. These equations describe the flow of a viscous incompressible fluid and read
@@ -52,7 +52,7 @@ Schur complement is proportional to $\tau^{-2}$. This makes the system very
 difficult to solve, and means that for the Navier-Stokes equations, this is
 not a useful avenue to the solution.
 
-<a name="Projection"></a>
+<a name="step-35-Projection"></a>
 <h3> Projection methods </h3>
 
 Rather, we need to come up with a different approach to solve the time-dependent Navier-Stokes

--- a/examples/step-35/doc/results.dox
+++ b/examples/step-35/doc/results.dox
@@ -1,7 +1,7 @@
-<a name="results"></a>
+<a name="step-35-results"></a>
 <h1>Results</h1>
 
-<a name="Re100"></a>
+<a name="step-35-Re100"></a>
 <h3> Re = 100 </h3>
 
 We run the code with the following <code>parameter-file.prm</code>, which can be found in the
@@ -89,7 +89,7 @@ behind the obstacles, with the sign of the vorticity indicating
 whether this is a left or right turning vortex.
 
 
-<a name="Re500"></a>
+<a name="step-35-Re500"></a>
 <h3> Re = 500 </h3>
 
 We can change the Reynolds number, $Re$, in the parameter file to a
@@ -130,7 +130,7 @@ one should take measures to obtain a robust scheme in the limit of coarse
 resolutions, as described below.
 
 
-<a name="extensions"></a>
+<a name="step-35-extensions"></a>
 <h3> Possibilities for extensions </h3>
 
 This program can be extended in the following directions:

--- a/examples/step-36/doc/intro.dox
+++ b/examples/step-36/doc/intro.dox
@@ -3,7 +3,7 @@
 <i>This program was contributed by Toby D. Young and Wolfgang
 Bangerth.  </i>
 
-<a name="Preamble"></a>
+<a name="step-36-Preamble"></a>
 <h1>Preamble</h1>
 
 The problem we want to solve in this example is an eigenspectrum
@@ -48,7 +48,7 @@ library; SLEPc itself builds on the <a
 href="http://www.mcs.anl.gov/petsc/" target="_top">PETSc</a> library
 for linear algebra contents.
 
-<a name="Intro"></a>
+<a name="step-36-Intro"></a>
 <h1>Introduction</h1>
 
 The basic equation of stationary quantum mechanics is the

--- a/examples/step-37/doc/intro.dox
+++ b/examples/step-37/doc/intro.dox
@@ -20,7 +20,7 @@ were supported by Gauss Centre for Supercomputing e.V. (www.gauss-centre.eu)
 by providing computing time on the GCS Supercomputer SuperMUC at Leibniz
 Supercomputing Centre (LRZ, www.lrz.de) through project id pr83te. </i>
 
-<a name="Intro"></a>
+<a name="step-37-Intro"></a>
 <h1>Introduction</h1>
 
 This example shows how to implement a matrix-free method, that is, a method

--- a/examples/step-38/doc/intro.dox
+++ b/examples/step-38/doc/intro.dox
@@ -10,7 +10,7 @@ do not necessarily reflect the views of the National Science Foundation
 (NSF).
 </i>
 
-<a name="Intro"></a>
+<a name="step-38-Intro"></a>
 
 <h1>Introduction</h1>
 

--- a/examples/step-38/doc/results.dox
+++ b/examples/step-38/doc/results.dox
@@ -53,7 +53,7 @@ as the curve moves from one quadrant of the domain into the adjacent one):
 <img src="https://www.dealii.org/images/steps/developer/step-38.solution-2d.png" alt="">
 
 
-<a name="extensions"></a>
+<a name="step-38-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 Computing on surfaces only becomes interesting if the surface is more

--- a/examples/step-39/doc/intro.dox
+++ b/examples/step-39/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="Intro"></a>
+<a name="step-39-Intro"></a>
 
 In this program, we use the interior penalty method and Nitsche's weak
 boundary conditions to solve Poisson's equation. We use multigrid

--- a/examples/step-4/doc/intro.dox
+++ b/examples/step-4/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="Intro"></a>
+<a name="step-4-Intro"></a>
 <h1>Introduction</h1>
 
 @dealiiVideoLecture{12,13}

--- a/examples/step-4/doc/results.dox
+++ b/examples/step-4/doc/results.dox
@@ -100,7 +100,7 @@ wants to see, but no more.
 
 
 
-<a name="postprocessing"></a>
+<a name="step-4-postprocessing"></a>
 <h3> Postprocessing: What to do with the solution? </h3>
 
 This tutorial -- like most of the other programs -- principally only shows how
@@ -308,7 +308,7 @@ should expect (and obtain!) a negative value.
 
 
 
-<a name="extensions"></a>
+<a name="step-4-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 There are many ways with which one can play with this program. The simpler

--- a/examples/step-40/doc/intro.dox
+++ b/examples/step-40/doc/intro.dox
@@ -23,7 +23,7 @@ PETSc configuration; see the page linked to from the installation
 instructions for PETSc.
 
 
-<a name="Intro"></a>
+<a name="step-40-Intro"></a>
 <h1>Introduction</h1>
 
 @dealiiVideoLecture{41.5,41.75}

--- a/examples/step-40/doc/results.dox
+++ b/examples/step-40/doc/results.dox
@@ -151,7 +151,7 @@ here.
 
 
 
-<a name="extensions"></a>
+<a name="step-40-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 In a sense, this program is the ultimate solver for the Laplace

--- a/examples/step-41/doc/intro.dox
+++ b/examples/step-41/doc/intro.dox
@@ -7,7 +7,7 @@ This material is based upon work partly supported by ThyssenKrupp Steel Europe.
 </i>
 
 
-<a name="Intro"></a>
+<a name="step-41-Intro"></a>
 <h3>Introduction</h3>
 
 This example is based on the Laplace equation in 2d and deals with the

--- a/examples/step-41/doc/results.dox
+++ b/examples/step-41/doc/results.dox
@@ -209,7 +209,7 @@ algorithm has converged.
 
 
 
-<a name="extensions"></a>
+<a name="step-41-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 As with any of the programs of this tutorial, there are a number of

--- a/examples/step-42/doc/intro.dox
+++ b/examples/step-42/doc/intro.dox
@@ -15,7 +15,7 @@ in the following paper:
 
 
 
-<a name="Intro"></a>
+<a name="step-42-Intro"></a>
 <h3>Introduction</h3>
 
 This example is an extension of step-41, considering a 3d contact problem with an

--- a/examples/step-42/doc/results.dox
+++ b/examples/step-42/doc/results.dox
@@ -187,7 +187,7 @@ Further discussion of results that can be obtained using this program is
 provided in the publication mentioned at the very top of this page.
 
 
-<a name="extensions"></a>
+<a name="step-42-extensions"></a>
 <h1>Possibilities for extensions</h1>
 
 There are, as always, multiple possibilities for extending this program. From

--- a/examples/step-43/doc/intro.dox
+++ b/examples/step-43/doc/intro.dox
@@ -32,7 +32,7 @@ California Institute of Technology, or of The University of California
 </i>
 
 
-<a name="Intro"></a> <h1>Introduction</h1>
+<a name="step-43-Intro"></a> <h1>Introduction</h1>
 
 The simulation of multiphase flow in porous media is a ubiquitous problem, and
 we have previously addressed it already in some form in step-20 and

--- a/examples/step-43/doc/results.dox
+++ b/examples/step-43/doc/results.dox
@@ -51,7 +51,7 @@ pictures, so here is some output of a run in 3d:
 </table>
 
 
-<a name="extensions"></a>
+<a name="step-43-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 The primary objection one may have to this program is that it is still too

--- a/examples/step-44/doc/intro.dox
+++ b/examples/step-44/doc/intro.dox
@@ -8,7 +8,7 @@ Forschungsgemeinschaft, DFG), grant STE 544/39-1,  and the National Research Fou
 
 @dealiiTutorialDOI{10.5281/zenodo.439772,https://zenodo.org/badge/DOI/10.5281/zenodo.439772.svg}
 
-<a name="Intro"></a>
+<a name="step-44-Intro"></a>
 <h1>Introduction</h1>
 
 The subject of this tutorial is nonlinear solid mechanics.

--- a/examples/step-44/doc/results.dox
+++ b/examples/step-44/doc/results.dox
@@ -256,7 +256,7 @@ displacement field, although qualitatively similar, is different to that of the 
   </tr>
 </table>
 
-<a name="extensions"></a>
+<a name="step-44-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 There are a number of obvious extensions for this work:

--- a/examples/step-45/doc/intro.dox
+++ b/examples/step-45/doc/intro.dox
@@ -1,7 +1,7 @@
 <br>
 
 <i>This program was contributed by Daniel Arndt and Matthias Maier.</i>
-<a name="Intro"></a>
+<a name="step-45-Intro"></a>
 <h1>Introduction</h1>
 
 In this example we present how to use periodic boundary conditions in
@@ -16,7 +16,7 @@ be able to proceed this way one has to assume that the model can be
 periodically extended to the other boxes; this requires the solution to
 have a periodic structure.
 
-<a name="Procedure"></a>
+<a name="step-45-Procedure"></a>
 <h1>Procedure</h1>
 
 deal.II provides a number of high level entry points to impose periodic
@@ -143,7 +143,7 @@ The remaining parameters are the same as for the high level interface apart
 from the self-explaining @p component_mask and @p affine_constraints.
 
 
-<a name="problem"></a>
+<a name="step-45-problem"></a>
 <h1>A practical example</h1>
 
 In the following, we show how to use the above functions in a more involved

--- a/examples/step-46/doc/intro.dox
+++ b/examples/step-46/doc/intro.dox
@@ -10,7 +10,7 @@ reflect the views of the National Science Foundation or of The University of
 California &ndash; Davis.  </i>
 
 
-<a name="Intro"></a>
+<a name="step-46-Intro"></a>
 <h1>Introduction</h1>
 
 This program deals with the problem of coupling different physics in different

--- a/examples/step-46/doc/results.dox
+++ b/examples/step-46/doc/results.dox
@@ -1,4 +1,4 @@
-<a name="Results"></a>
+<a name="step-46-Results"></a>
 <h1>Results</h1>
 
 <h3>2d results</h3>
@@ -130,7 +130,7 @@ of error indicators in the two subdomains is important if one wanted
 to go on doing more 3d computations.
 
 
-<a name="extensions"></a>
+<a name="step-46-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 <h4>Linear solvers and preconditioners</h4>

--- a/examples/step-47/doc/intro.dox
+++ b/examples/step-47/doc/intro.dox
@@ -10,7 +10,7 @@ Timo Heister and Wolfgang Bangerth acknowledge support through NSF
 awards DMS-1821210, EAR-1550901, and OAC-1835673.
 </i>
 
-<a name="Intro"></a>
+<a name="step-47-Intro"></a>
 <h1>Introduction</h1>
 
 This program deals with the <a

--- a/examples/step-48/doc/intro.dox
+++ b/examples/step-48/doc/intro.dox
@@ -12,7 +12,7 @@ application: Graph partitioning and coloring&quot; by Katharina
 Kormann and Martin Kronbichler in: Proceedings of the 7th IEEE
 International Conference on e-Science, 2011.  </i>
 
-<a name="Intro"></a>
+<a name="step-48-Intro"></a>
 <h1>Introduction</h1>
 
 This program demonstrates how to use the cell-based implementation of finite

--- a/examples/step-49/doc/intro.dox
+++ b/examples/step-49/doc/intro.dox
@@ -1,7 +1,7 @@
 <i>This program was contributed by Timo Heister. Parts of the results section
 were contributed by Yuhan Zhou, Wolfgang Bangerth, David Wells, and Sean Ingimarson.</i>
 
-<a name="Intro"></a>
+<a name="step-49-Intro"></a>
 <h1> Introduction </h1>
 This tutorial is an extension to step-1 and demonstrates several ways to
 obtain more involved meshes than the ones shown there.

--- a/examples/step-5/doc/intro.dox
+++ b/examples/step-5/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="Intro"></a>
+<a name="step-5-Intro"></a>
 <h1>Introduction</h1>
 
 @dealiiVideoLecture{14}

--- a/examples/step-50/doc/intro.dox
+++ b/examples/step-50/doc/intro.dox
@@ -16,7 +16,7 @@ or Trilinos library installed. The installation of deal.II together with these a
 libraries is described in the <a href="../../readme.html" target="body">README</a> file.
 
 
-<a name="Intro"></a>
+<a name="step-50-Intro"></a>
 <h1>Introduction</h1>
 
 

--- a/examples/step-51/doc/intro.dox
+++ b/examples/step-51/doc/intro.dox
@@ -4,7 +4,7 @@
 This program was contributed by Martin Kronbichler and Scott Miller.
 </i>
 
-<a name="Intro"></a>
+<a name="step-51-Intro"></a>
 <h1>Introduction</h1>
 
 This tutorial program presents the implementation of a hybridizable

--- a/examples/step-52/doc/intro.dox
+++ b/examples/step-52/doc/intro.dox
@@ -6,7 +6,7 @@
 the UMFPACK sparse direct solver. Refer to the <a
 href="../../readme.html#umfpack">ReadMe</a> for instructions how to do this.
 
-<a name="Intro"></a>
+<a name="step-52-Intro"></a>
 <h1>Introduction</h1>
 
 This program shows how to use Runge-Kutta methods to solve a time-dependent

--- a/examples/step-53/doc/intro.dox
+++ b/examples/step-53/doc/intro.dox
@@ -15,7 +15,7 @@ information.
 href="https://github.com/dealii/dealii/blob/master/examples/step-53/step-53.ipynb">github</a>.
 
 
-<a name="Intro"></a>
+<a name="step-53-Intro"></a>
 <h1>Introduction</h1>
 
 Partial differential equations for realistic problems are often posed on

--- a/examples/step-54/doc/intro.dox
+++ b/examples/step-54/doc/intro.dox
@@ -9,7 +9,7 @@ your geometries.
 
 @dealiiTutorialDOI{10.5281/zenodo.546220,https://zenodo.org/badge/DOI/10.5281/zenodo.546220.svg}
 
-<a name="Intro"></a>
+<a name="step-54-Intro"></a>
 <h1>Introduction</h1>
 
 

--- a/examples/step-55/doc/intro.dox
+++ b/examples/step-55/doc/intro.dox
@@ -20,7 +20,7 @@ and the p4est library installed. The installation of deal.II together with
 these additional libraries is described in the <a href="../../readme.html"
 target="body">README</a> file.
 
-<a name="Intro"></a>
+<a name="step-55-Intro"></a>
 <h1>Introduction</h1>
 
 Building on step-40, this tutorial shows how to solve linear PDEs with several

--- a/examples/step-55/doc/results.dox
+++ b/examples/step-55/doc/results.dox
@@ -217,7 +217,7 @@ solve (we are using LU by default), a change in number of levels will
 influence the quality of a V-cycle. Therefore, a V-cycle is closer to an exact
 solver for smaller problem sizes.
 
-<a name="extensions"></a>
+<a name="step-55-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 <h4>Investigate Trilinos iterations</h4>

--- a/examples/step-56/doc/intro.dox
+++ b/examples/step-56/doc/intro.dox
@@ -13,7 +13,7 @@ undertaken. This work was supported by EPSRC grant no EP/K032208/1.
 
 @dealiiTutorialDOI{10.5281/zenodo.400995,https://zenodo.org/badge/DOI/10.5281/zenodo.400995.svg}
 
-<a name="Intro"></a>
+<a name="step-56-Intro"></a>
 <h1>Introduction</h1>
 
 <h3> Stokes Problem </h3>

--- a/examples/step-57/doc/intro.dox
+++ b/examples/step-57/doc/intro.dox
@@ -10,7 +10,7 @@ Award No. EAR-0949446 and The University of California-Davis.
 
 @dealiiTutorialDOI{10.5281/zenodo.484156,https://zenodo.org/badge/DOI/10.5281/zenodo.484156.svg}
 
-<a name="Intro"></a>
+<a name="step-57-Intro"></a>
 <h1>Introduction</h1>
 
 <h3> Navier Stokes Equations </h3>

--- a/examples/step-57/doc/results.dox
+++ b/examples/step-57/doc/results.dox
@@ -338,7 +338,7 @@ meshes:
 <img src="https://www.dealii.org/images/steps/developer/step-57.converge-Re7500.svg" style="width:50%" alt="">
 
 
-<a name="extensions"></a>
+<a name="step-57-extensions"></a>
 
 <h3>Possibilities for extensions</h3>
 

--- a/examples/step-58/doc/intro.dox
+++ b/examples/step-58/doc/intro.dox
@@ -12,7 +12,7 @@ Geodynamics initiative (CIG), through the National Science Foundation under
 Award No. EAR-1550901 and The University of California-Davis.
 </i>
 
-<a name="Intro"></a>
+<a name="step-58-Intro"></a>
 <h1>Introduction</h1>
 
 The <a

--- a/examples/step-58/doc/results.dox
+++ b/examples/step-58/doc/results.dox
@@ -148,7 +148,7 @@ actually see the radiating waves that are easy to see at the beginning
 of the video.
 
 
-<a name="extensions"></a>
+<a name="step-58-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 <h4> Better linear solvers </h4>

--- a/examples/step-59/doc/intro.dox
+++ b/examples/step-59/doc/intro.dox
@@ -8,7 +8,7 @@ This work was partly supported by the German Research Foundation (DFG) through
 the project "High-order discontinuous Galerkin for the exa-scale" (ExaDG)
 within the priority program "Software for Exascale Computing" (SPPEXA). </i>
 
-<a name="Intro"></a>
+<a name="step-59-Intro"></a>
 <h1>Introduction</h1>
 
 Matrix-free operator evaluation enables very efficient implementations of

--- a/examples/step-6/doc/intro.dox
+++ b/examples/step-6/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="Intro"></a>
+<a name="step-6-Intro"></a>
 <h1>Introduction</h1>
 
 @dealiiVideoLecture{15,16,17,17.25,17.5,17.75}

--- a/examples/step-6/doc/results.dox
+++ b/examples/step-6/doc/results.dox
@@ -111,7 +111,7 @@ from the optimal square.
 
 
 
-<a name="extensions"></a>
+<a name="step-6-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 <h4>Solvers and preconditioners</h4>

--- a/examples/step-60/doc/results.dox
+++ b/examples/step-60/doc/results.dox
@@ -458,7 +458,7 @@ produces the saddle on the right.
   </div>
 </div>
 
-<a name="extensions"></a>
+<a name="step-60-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 <h4> Running with `spacedim` equal to three</h4>

--- a/examples/step-61/doc/intro.dox
+++ b/examples/step-61/doc/intro.dox
@@ -6,7 +6,7 @@ Some more information about this program, as well as more numerical
 results, are presented in @cite Wang2019 .
 </i>
 
-<a name="Intro"></a>
+<a name="step-61-Intro"></a>
 <h1>Introduction</h1>
 
 This tutorial program presents an implementation of the "weak Galerkin"

--- a/examples/step-63/doc/intro.dox
+++ b/examples/step-63/doc/intro.dox
@@ -11,7 +11,7 @@ Davis.
 
 @dealiiTutorialDOI{10.5281/zenodo.3382899,https://zenodo.org/badge/DOI/10.5281/zenodo.3382899.svg}
 
-<a name="Intro"></a>
+<a name="step-63-Intro"></a>
 <h1>Introduction</h1>
 
 This program solves an advection-diffusion problem using a geometric multigrid

--- a/examples/step-64/doc/results.dox
+++ b/examples/step-64/doc/results.dox
@@ -42,7 +42,7 @@ of the size of the problem. But having such a solver would require
 using a better preconditioner than the identity matrix we have used here.
 
 
-<a name="extensions"></a>
+<a name="step-64-extensions"></a>
 <h3> Possibilities for extensions </h3>
 
 Currently, this program uses no preconditioner at all. This is mainly

--- a/examples/step-65/doc/intro.dox
+++ b/examples/step-65/doc/intro.dox
@@ -5,7 +5,7 @@
 This program was contributed by Martin Kronbichler.
 </i>
 
-<a name="Intro"></a>
+<a name="step-65-Intro"></a>
 <h1>Introduction</h1>
 
 This tutorial program presents an advanced manifold class,

--- a/examples/step-66/doc/intro.dox
+++ b/examples/step-66/doc/intro.dox
@@ -19,7 +19,7 @@ and advice in writing this tutorial.
 </i>
 
 
-<a name="Intro"></a>
+<a name="step-66-Intro"></a>
 <h1>Introduction</h1>
 
 The aim of this tutorial program is to demonstrate how to solve a nonlinear

--- a/examples/step-67/doc/intro.dox
+++ b/examples/step-67/doc/intro.dox
@@ -11,7 +11,7 @@ the project "High-order discontinuous Galerkin for the exa-scale" (ExaDG)
 within the priority program "Software for Exascale Computing" (SPPEXA).
 </i>
 
-<a name="Intro"></a>
+<a name="step-67-Intro"></a>
 <h1>Introduction</h1>
 
 This tutorial program solves the Euler equations of fluid dynamics using an

--- a/examples/step-69/doc/intro.dox
+++ b/examples/step-69/doc/intro.dox
@@ -25,7 +25,7 @@ integration, see @cite GuermondEtAl2018
 
 @dealiiTutorialDOI{10.5281/zenodo.3698223,https://zenodo.org/badge/DOI/10.5281/zenodo.3698223.svg}
 
-<a name="Intro"></a>
+<a name="step-69-Intro"></a>
 <h1>Introduction</h1>
 
 This tutorial presents a first-order scheme for solving compressible
@@ -51,7 +51,7 @@ the programming techniques) before jumping into full research codes such as
 the second-order scheme discussed in @cite GuermondEtAl2018.
 
 
-<a name="eulerequations"></a>
+<a name="step-69-eulerequations"></a>
 <h3>Euler's equations of gas dynamics</h3>
 
 The compressible Euler's equations of gas dynamics are written in

--- a/examples/step-69/doc/results.dox
+++ b/examples/step-69/doc/results.dox
@@ -1,4 +1,4 @@
-<a name="Results"></a>
+<a name="step-69-Results"></a>
 <h1>Results</h1>
 
 Running the program with default parameters in release mode takes about 1
@@ -155,7 +155,7 @@ the code for roughly 2 hours on 16 cores.
 
 
 
-<a name="extensions"></a>
+<a name="step-69-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 The program showcased here is really only first-order accurate, as

--- a/examples/step-7/doc/intro.dox
+++ b/examples/step-7/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="Intro"></a>
+<a name="step-7-Intro"></a>
 <h1>Introduction</h1>
 
 In this program, we will mainly consider two aspects:

--- a/examples/step-70/doc/results.dox
+++ b/examples/step-70/doc/results.dox
@@ -456,7 +456,7 @@ unimportant as far as run time is concerned.
 @endhtmlonly
 
 
-<a name="extensions"></a>
+<a name="step-70-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 The current tutorial program shows a one-way coupling between the fluid and the

--- a/examples/step-74/doc/intro.dox
+++ b/examples/step-74/doc/intro.dox
@@ -11,7 +11,7 @@ EAR-0949446 and EAR-1550901 and The University of California -- Davis.
 
 @dealiiTutorialDOI{10.5281/zenodo.5812174,https://zenodo.org/badge/DOI/10.5281/zenodo.5812174.svg}
 
-<a name="Intro"></a>
+<a name="step-74-Intro"></a>
 <h1><em>Symmetric interior penalty Galerkin</em> (SIPG) method for Poisson's equation</h1>
 
 <h3>Overview</h3>

--- a/examples/step-75/doc/intro.dox
+++ b/examples/step-75/doc/intro.dox
@@ -22,7 +22,7 @@ href="../../readme.html" target="body">README</a> file.
 
 
 
-<a name="Intro"></a>
+<a name="step-75-Intro"></a>
 <h1>Introduction</h1>
 
 In the finite element context, more degrees of freedom usually yield a

--- a/examples/step-75/doc/results.dox
+++ b/examples/step-75/doc/results.dox
@@ -115,7 +115,7 @@ to degree six:
 
 
 
-<a name="extensions"></a>
+<a name="step-75-extensions"></a>
 <h3>Possibilities for extensions</h3>
 
 This tutorial shows only one particular way how to use parallel

--- a/examples/step-76/doc/intro.dox
+++ b/examples/step-76/doc/intro.dox
@@ -19,7 +19,7 @@ element implementations with hybrid parallelization and improved data locality"
 within the KONWIHR program.
 </i>
 
-<a name="Intro"></a>
+<a name="step-76-Intro"></a>
 <h1>Introduction</h1>
 
 This tutorial program solves the Euler equations of fluid dynamics, using an

--- a/examples/step-77/doc/intro.dox
+++ b/examples/step-77/doc/intro.dox
@@ -15,7 +15,7 @@ discussed in the <a href="#Results">results section</a> below.
 </i>
 <br>
 
-<a name="Intro"></a>
+<a name="step-77-Intro"></a>
 <h1>Introduction</h1>
 
 The step-15 program solved the following, nonlinear equation

--- a/examples/step-77/doc/results.dox
+++ b/examples/step-77/doc/results.dox
@@ -177,7 +177,7 @@ The key takeaway messages of this program are the following:
   that determine when we need to rebuild this information.
 
 
-<a name="extensions"></a>
+<a name="step-77-extensions"></a>
 <h3> Possibilities for extensions </h3>
 
 <h4> Better linear solvers </h4>

--- a/examples/step-78/doc/intro.dox
+++ b/examples/step-78/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="Intro"></a>
+<a name="step-78-Intro"></a>
 <h1>Introduction</h1>
 
 The Black-Scholes equation is a partial differential equation that falls a bit

--- a/examples/step-79/doc/intro.dox
+++ b/examples/step-79/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="Intro"></a>
+<a name="step-79-Intro"></a>
 <h1>Introduction</h1>
 
 Topology Optimization of Elastic Media is a technique used to optimize a

--- a/examples/step-8/doc/intro.dox
+++ b/examples/step-8/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="Intro"></a>
+<a name="step-8-Intro"></a>
 <h1>Introduction</h1>
 
 

--- a/examples/step-81/doc/intro.dox
+++ b/examples/step-81/doc/intro.dox
@@ -3,7 +3,7 @@
   and Matthias Maier (Texas A&M University).
 </i>
 
-<a name="Intro"></a>
+<a name="step-81-Intro"></a>
 
 <h1> Introduction </h1>
 

--- a/examples/step-82/doc/intro.dox
+++ b/examples/step-82/doc/intro.dox
@@ -7,7 +7,7 @@
 
 @dealiiTutorialDOI{10.5281/zenodo.5598180,https://zenodo.org/badge/DOI/10.5281/zenodo.5598180.svg}
 
-<a name="Intro"></a>
+<a name="step-82-Intro"></a>
 <h1>Introduction</h1>
 <h3>Problem Statement</h3>
 

--- a/examples/step-85/doc/intro.dox
+++ b/examples/step-85/doc/intro.dox
@@ -6,7 +6,7 @@ eSSENCE of e-Science and the Swedish Research Council
 under grants 2014-6088 (Kreiss) and 2017-05038 (Massing).
 </i>
 
-<a name="Intro"></a>
+<a name="step-85-Intro"></a>
 <h1>Introduction</h1>
 
 <h3>The Cut Finite Element Method</h3>

--- a/examples/step-9/doc/intro.dox
+++ b/examples/step-9/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="Intro"></a>
+<a name="step-9-Intro"></a>
 <h1>Introduction</h1>
 
 


### PR DESCRIPTION
This fixes the anchors in news, step and (auto generated) gallery files,
such that Doxygen does not throw 'multiple use of section label' warnings.