### PR TITLE
Matrix-free kernels: Try to fix Cuda warning

### DIFF
--- a/include/deal.II/matrix_free/evaluation_kernels_face.h
+++ b/include/deal.II/matrix_free/evaluation_kernels_face.h
@@ -562,7 +562,7 @@ namespace internal
 
       using Eval = EvaluatorTensorProduct<evaluate_evenodd,
                                           dim - 1,
-                                          fe_degree,
+                                          (fe_degree > 0 ? fe_degree : 0),
                                           n_q_points_1d,
                                           Number,
                                           Number2>;


### PR DESCRIPTION
This PR tries to fix a long list of warnings observed on the `linux debug cuda-11` CI system, which go something like this:
```
/home/runner/work/dealii/dealii/include/deal.II/matrix_free/tensor_product_kernels.h(807): warning #284-D: NULL reference is not allowed
          detected during:
            instantiation of "std::enable_if_t<<expression>, void> dealii::internal::apply_matrix_vector_product<variant,quantity,n_rows_static,n_columns_static,stride_in_static,stride_out_static,transpose_matrix,add,Number,Number2>(const Number2 *, const Number *, Number *, int, int, int, int) [with variant=dealii::internal::evaluate_evenodd, quantity=dealii::internal::EvaluatorQuantity::hessian, n_rows_static=2, n_columns_static=1, stride_in_static=1, stride_out_static=1, transpose_matrix=false, add=false, Number=dealii::VectorizedArray<float, 1UL>, Number2=dealii::VectorizedArray<float, 1UL>]" 
(1389): here
            instantiation of "void dealii::internal::EvaluatorTensorProduct<variant, dim, n_rows, n_columns, Number, Number2>::apply<direction,contract_over_rows,add,one_line,quantity,stride>(const Number2 *, const Number *, Number *) [with variant=dealii::internal::evaluate_evenodd, dim=0, n_rows=2, n_columns=1, Number=dealii::VectorizedArray<float, 1UL>, Number2=dealii::VectorizedArray<float, 1UL>, direction=0, contract_over_rows=false, add=false, one_line=false, quantity=dealii::internal::EvaluatorQuantity::hessian, stride=1]" 
(1226): here
            instantiation of "void dealii::internal::EvaluatorTensorProduct<variant, dim, n_rows, n_columns, Number, Number2>::hessians<direction,contract_over_rows,add>(const Number *, Number *)
```
As far as I understand the warning, the compiler is complaining that we have a zero-sized array `xp` or `xm` which gets accessed inside a block checking `mid > 0` with the index 0. Other compilers don't show the warning, but I think we can still try to just have one more entry in the array to be safe. While there, I observed that the aforementioned variable `mid` is, like `n_cols`, not named very intuitively. I chose the descriptive names `n_half` and `m_half` to indicate that they are half of the nominal loop length (due to the even-odd decomposition).