### PR TITLE
Use gmres in step 12

### DIFF
--- a/examples/step-12/doc/intro.dox
+++ b/examples/step-12/doc/intro.dox
@@ -73,7 +73,7 @@ $u^{\text{upwind}}$ is defined to be $u^+$ if $\beta \cdot n>0$ and $u^-$ otherw
 
 As a result, the mesh-dependent weak form reads:
 @f[
-\sum_{T\in \mathbb T_h} -\bigl(\nabla \phi_i,{\mathbf \beta}\cdot \phi_j \bigr)_T +
+\sum_{T\in \mathbb T_h} -\bigl(\nabla \phi_i,{\mathbf \beta} \phi_j \bigr)_T +
 \sum_{F\in\mathbb F_h^i} \bigl< [\phi_i], \phi_j^{upwind} \beta\cdot \mathbf n\bigr>_{F} +
 \bigl<\phi_i, \phi_j \beta\cdot \mathbf n\bigr>_{\Gamma_+}
 = -\bigl<\phi_i, g \beta\cdot\mathbf n\bigr>_{\Gamma_-}.

--- a/examples/step-12/step-12.cc
+++ b/examples/step-12/step-12.cc
@@ -468,19 +468,20 @@ namespace Step12
   // field. If the DoFs are renumbered in the downstream direction of the flow,
   // then a block Gauss-Seidel preconditioner (see the PreconditionBlockSOR
   // class with relaxation=1) does a much better job.
+
+  // We create an additional data object for the GMRES solver to increase the
+  // maximum number of basis vectors of the Krylov subspace. When this number
+  // is reached the GMRES algorithm is restarted using the solution of the
+  // previous iteration as the starting approximation. The choice of the
+  // number of basis vectors is a trade-off between memory consumption and
+  // convergence speed, since a longer basis means minimization over a larger
+  // space.
   template <int dim>
   void AdvectionProblem<dim>::solve()
   {
-    SolverControl solver_control(1000, 1e-12);
-    // We create an additional data object for the GMRES solver to increase the
-    // maximum number of basis vectors of the Krylov subspace. When this number
-    // is reached the GMRES algorithm is restarted using the solution of the
-    // previous iteration as the starting approximation. The choice of the
-    // number of basis vectors is a trade-off between memory consumption and
-    // convergence speed, since a longer basis means minimization over a larger
-    // space.
+    SolverControl solver_control(1000, 1e-6 * right_hand_side.l2_norm());
     SolverGMRES<Vector<double>>::AdditionalData additional_data;
-    additional_data.max_n_tmp_vectors = 100;
+    additional_data.max_n_tmp_vectors = 85;
     SolverGMRES<Vector<double>> solver(solver_control, additional_data);
 
     // Here we create the preconditioner,

--- a/examples/step-12/step-12.cc
+++ b/examples/step-12/step-12.cc
@@ -45,12 +45,12 @@
 // This header is needed for FEInterfaceValues to compute integrals on
 // interfaces:
 #include <deal.II/fe/fe_interface_values.h>
-// We are going to use the simplest possible solver, called Richardson
-// iteration, that represents a simple defect correction. This, in combination
-// with a block SSOR preconditioner (defined in precondition_block.h), that
-// uses the special block matrix structure of system matrices arising from DG
-// discretizations.
-#include <deal.II/lac/solver_richardson.h>
+// We are going to use a standard solver, called Generalized minimal residual
+// method (GMRES). It is a iterative solver which is applicable to arbitrary
+// invertible matrices. This, in combination with a block SSOR preconditioner
+// (defined in precondition_block.h), that uses the special block matrix
+// structure of system matrices arising from DG discretizations.
+#include <deal.II/lac/solver_gmres.h>
 #include <deal.II/lac/precondition_block.h>
 // We are going to use gradients as refinement indicator.
 #include <deal.II/numerics/derivative_approximation.h>

--- a/examples/step-12/step-12.cc
+++ b/examples/step-12/step-12.cc
@@ -46,7 +46,7 @@
 // interfaces:
 #include <deal.II/fe/fe_interface_values.h>
 // We are going to use a standard solver, called Generalized minimal residual
-// method (GMRES). It is a iterative solver which is applicable to arbitrary
+// method (GMRES). It is an iterative solver which is applicable to arbitrary
 // invertible matrices. This, in combination with a block SSOR preconditioner
 // (defined in precondition_block.h), that uses the special block matrix
 // structure of system matrices arising from DG discretizations.
@@ -459,7 +459,7 @@ namespace Step12
   // @sect3{All the rest}
   //
   // For this simple problem we use a standard iterative solver, called GMRES,
-  // that creates approximate solutions minimising the residual in each
+  // that creates approximate solutions minimizing the residual in each
   // iterations by adding a new basis vector to the Krylov subspace. This, in
   // combination with a block SSOR preconditioner, that uses the special block
   // matrix structure of system matrices arising from DG discretizations. The
@@ -476,7 +476,7 @@ namespace Step12
     // maximum number of basis vectors of the Krylov subspace. When this number
     // is reached the GMRES algorithm is restarted using the solution of the
     // previous iteration as the starting approximation. The choice of the
-    // number of basis vectors is a trade- off between memory consumption and
+    // number of basis vectors is a trade-off between memory consumption and
     // convergence speed, since a longer basis means minimization over a larger
     // space.
     SolverGMRES<Vector<double>>::AdditionalData additional_data;

--- a/examples/step-12/step-12.cc
+++ b/examples/step-12/step-12.cc
@@ -480,8 +480,9 @@ namespace Step12
   void AdvectionProblem<dim>::solve()
   {
     SolverControl solver_control(1000, 1e-6 * right_hand_side.l2_norm());
+
     SolverGMRES<Vector<double>>::AdditionalData additional_data;
-    additional_data.max_n_tmp_vectors = 85;
+    additional_data.max_n_tmp_vectors = 100;
     SolverGMRES<Vector<double>> solver(solver_control, additional_data);
 
     // Here we create the preconditioner,


### PR DESCRIPTION
This pull request addresses  #15984.
Use GMRES instead of a Richardson solver in Step-12. Adapt the tutorial where necessary and fix a small error in the introduction of the tutorial. 

A short comment concerning the error in the introduction: Two different scalar products are used:
1. $$( \mathbf{v}, \mathbf{w} )_T = \int_T \mathbf{v} \cdot \mathbf{w} $$
2. $$\langle f, g \rangle_F = \int_F fg$$

The first one is for vector quantities and the second one for scalar quantities. In the discrete weak form a scalar is "dotted" with a vector. The meaning of this is unclear to me. So I replaced $(\nabla \phi_i, \mathbf{\beta} \cdot \phi_j)_T$ with $(\nabla \phi_i, \mathbf{\beta}\phi_i)_T$. The dot product is implicit in the definition of the scalar product, which admittedly is not explicitly given in the introduction.