### PR TITLE
Docker: Use one process to decrease memory usage.

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -50,7 +50,7 @@ RUN cd /usr/src && \
     -DDEAL_II_WITH_VTK=ON \
     -DDEAL_II_WITH_ZLIB=ON \
     .. \
-    && ninja -j 2 install \
+    && ninja -j 1 install \
     && cd ../ && rm -rf .git build
 
 USER $USER


### PR DESCRIPTION
This is another attempt to get the docker workflow fixed. The message we get from github is rather vague:
> The hosted runner: GitHub Actions X lost communication with the server. Anything in your workflow that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error.

I believe the only thing that could potentially fail from the description is that we run out of memory. I suggest to limit the number of processes explicitly to `1` with which we build deal.II in the Dockerfile.

@masterleinad can build the Docker image without problems, see https://github.com/dealii/dealii/pull/16047#issuecomment-1738096799. It could be the system specs of the github machines that cause this.

Probably a nicer approach is to introduce a new argument for the number of processes to remain flexible, i.e., `ARG NPROCS=2`, and then set it explicitly to `1` for the `focal` image. But we could leave that for a follow-up PR. Let's try this out first!