### PR TITLE
Docker: Use the default driver again.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          driver: docker
 
       - name: Login to DockerHub
         uses: docker/login-action@v3


### PR DESCRIPTION
Changing the driver in #16045 and #16047 did not do the trick. Let's revert back to the default.