### PR TITLE
Docker: Build images with different number of jobs.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ubuntu_version: ["focal", "jammy"]
+        ubuntu_version: [focal, jammy]
+        # Use 2 jobs to build, but only 1 for the focal image
+        # as it starves the github machine for memory.
+        include:
+          - n_jobs: 2
+          - n_jobs: 1
+            ubuntu_version: focal
 
     steps:
       - name: Checkout code
@@ -42,7 +48,8 @@ jobs:
           cache-from: type=registry,ref=dealii/dependencies:${{ matrix.ubuntu_version }}
           cache-to: type=inline
           build-args: |
-            VER=master
             IMG=${{ matrix.ubuntu_version }}
-          push: ${{github.ref_name == 'master'}}
+            NJOBS=${{ matrix.n_jobs }}
+            VER=master
+          push: ${{ github.ref_name == 'master' }}
           tags: dealii/dealii:master-${{ matrix.ubuntu_version }}

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,12 +1,13 @@
-ARG IMG=focal
+ARG IMG=focal    # Ubuntu image that contains all corresponding dependencies.
+ARG NJOBS=0      # Jobs used for building. Default: Use all available jobs.
+ARG VER=master   # deal.II branch that gets checked out.
 
 FROM dealii/dependencies:$IMG
 
 LABEL maintainer="luca.heltai@gmail.com"
 
-ARG VER=master
-
 USER root
+
 RUN cd /usr/src && \
     git clone https://github.com/dealii/dealii dealii-$VER && \
     cd dealii-$VER && \
@@ -49,9 +50,9 @@ RUN cd /usr/src && \
     -DDEAL_II_WITH_UMFPACK=ON \
     -DDEAL_II_WITH_VTK=ON \
     -DDEAL_II_WITH_ZLIB=ON \
-    .. \
-    && ninja -j 1 install \
-    && cd ../ && rm -rf .git build
+    .. && \
+    ninja -j $NJOBS install && \
+    cd ../ && rm -rf .git build
 
 USER $USER
 WORKDIR $HOME


### PR DESCRIPTION
~Please merge #16061 first, to ensure the images are still built properly.~ (EDIT: merged)

---

#16060 succeeds! So it probably was a memory issue. https://github.com/dealii/dealii/actions/runs/6342478809

This PR changes Dockerfile and workflow so that 2 jobs are used for building, except for `focal` which will use 1 job.