### PR TITLE
Docker: Build images every 12 hours.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - 'docker*'
-      - 'master'
+  schedule:
+  - cron: '0 */12 * * *'
 
 permissions:
   contents: read
@@ -12,6 +13,8 @@ permissions:
 
 jobs:
   build-master-docker:
+    if: (github.event_name == 'schedule' && github.repository == 'dealii/dealii') || github.event_name != 'schedule'
+
     name: build master docker ${{ matrix.ubuntu_version }}
     runs-on: ubuntu-latest
 
@@ -49,5 +52,5 @@ jobs:
             IMG=${{ matrix.ubuntu_version }}
             NJOBS=${{ matrix.n_jobs }}
             VER=master
-          push: ${{ github.ref_name == 'master' }}
+          push: ${{ github.event_name == 'schedule' }}
           tags: dealii/dealii:master-${{ matrix.ubuntu_version }}


### PR DESCRIPTION
Please merge #16061 & #16062 first, to ensure the images are still built properly.

---

We probably do not need to build a docker image with every merge, but maybe once a week is enough. This should reduce the length of the queue.

This PR suggests to build the images every Saturday, so before we check the code-gallery programs on Sunday. Images will no longer be built after every merge.

