### PR TITLE
Fix doxygen warnings for template instantiations

### DIFF
--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -3077,7 +3077,7 @@ protected:
 
 
 //----------------------------------------------------------------------//
-
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 inline std::pair<unsigned int, unsigned int>
@@ -3332,7 +3332,7 @@ FiniteElement<dim, spacedim>::get_associated_geometry_primitive(
     return GeometryPrimitive::hex;
 }
 
-
+#endif
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/include/deal.II/lac/solver.h
+++ b/include/deal.II/lac/solver.h
@@ -473,7 +473,7 @@ protected:
 
 
 /*-------------------------------- Inline functions ------------------------*/
-
+#ifndef DOXYGEN
 
 template <typename VectorType>
 inline SolverControl::State
@@ -559,7 +559,7 @@ SolverBase<VectorType>::connect(
   return iteration_status.connect(slot);
 }
 
-
+#endif
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/source/base/numbers.cc
+++ b/source/base/numbers.cc
@@ -26,9 +26,10 @@ namespace numbers
   template <typename number>
   constexpr bool NumberTraits<number>::is_complex;
 
+#ifndef DOXYGEN
   template <typename number>
   constexpr bool NumberTraits<std::complex<number>>::is_complex;
-
+#endif
   // explicit instantiations
   template struct NumberTraits<double>;
   template struct NumberTraits<float>;

--- a/source/base/partitioner.cc
+++ b/source/base/partitioner.cc
@@ -23,6 +23,7 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifndef DOXYGEN
 namespace Utilities
 {
   namespace MPI
@@ -79,7 +80,7 @@ namespace Utilities
     {
       types::global_dof_index prefix_sum = 0;
 
-#ifdef DEAL_II_WITH_MPI
+#  ifdef DEAL_II_WITH_MPI
       const int ierr =
         MPI_Exscan(&local_size,
                    &prefix_sum,
@@ -88,7 +89,7 @@ namespace Utilities
                    MPI_SUM,
                    communicator);
       AssertThrowMPI(ierr);
-#endif
+#  endif
 
       local_range_data = {prefix_sum, prefix_sum + local_size};
 
@@ -216,7 +217,7 @@ namespace Utilities
 
       // find out the end index for each processor and communicate it (this
       // implies the start index for the next processor)
-#ifdef DEAL_II_WITH_MPI
+#  ifdef DEAL_II_WITH_MPI
       if (n_procs < 2)
         {
           Assert(ghost_indices_data.n_elements() == 0, ExcInternalError());
@@ -339,7 +340,7 @@ namespace Utilities
                                                local_range_data.first);
         }
 
-#  ifdef DEBUG
+#    ifdef DEBUG
 
       // simple check: the number of processors to which we want to send
       // ghosts and the processors to which ghosts reference should be the
@@ -387,9 +388,9 @@ namespace Utilities
       for (unsigned int i = 0; i < ghost_indices.size(); ++i)
         AssertDimension(ghost_indices[i], ghost_indices_ref[i]);
 
-#  endif
+#    endif
 
-#endif // #ifdef DEAL_II_WITH_MPI
+#  endif // #ifdef DEAL_II_WITH_MPI
 
       if (larger_ghost_index_set.size() == 0)
         {
@@ -471,7 +472,7 @@ namespace Utilities
       // processor
       if (&part == this)
         return true;
-#ifdef DEAL_II_WITH_MPI
+#  ifdef DEAL_II_WITH_MPI
       if (Utilities::MPI::job_supports_mpi())
         {
           int       communicators_same = 0;
@@ -483,7 +484,7 @@ namespace Utilities
                 communicators_same == MPI_CONGRUENT))
             return false;
         }
-#endif
+#  endif
       return (global_size == part.global_size &&
               local_range_data == part.local_range_data &&
               ghost_indices_data == part.ghost_indices_data);
@@ -569,7 +570,7 @@ namespace Utilities
 
 } // end of namespace Utilities
 
-
+#endif
 
 // explicit instantiations from .templates.h file
 #include "partitioner.inst"

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -42,10 +42,11 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifndef DOXYGEN
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 const types::fe_index DoFHandler<dim, spacedim>::default_fe_index;
-
+#endif
 
 namespace internal
 {
@@ -1714,7 +1715,7 @@ namespace internal
   }   // namespace hp
 } // namespace internal
 
-
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
@@ -1799,10 +1800,9 @@ void DoFHandler<dim, spacedim>::reinit(const Triangulation<dim, spacedim> &tria)
   this->create_active_fe_table();
 }
 
-
-
+#endif
 /*------------------------ Cell iterator functions ------------------------*/
-
+#ifndef DOXYGEN
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename DoFHandler<dim, spacedim>::cell_iterator
@@ -2168,7 +2168,7 @@ void DoFHandler<dim, spacedim>::distribute_dofs(
          ExcMessage("The given hp::FECollection contains more finite elements "
                     "than the DoFHandler can cover with active FE indices."));
 
-#ifdef DEBUG
+#  ifdef DEBUG
   // make sure that the provided FE collection is large enough to
   // cover all FE indices presently in use on the mesh
   if ((hp_cell_active_fe_indices.size() > 0) &&
@@ -2185,7 +2185,7 @@ void DoFHandler<dim, spacedim>::distribute_dofs(
                  ExcInvalidFEIndex(cell->future_fe_index(), ff.size()));
         }
     }
-#endif
+#  endif
 
   //
   // register the new finite element collection
@@ -2410,7 +2410,7 @@ void DoFHandler<dim, spacedim>::renumber_dofs(
 
       AssertDimension(new_numbers.size(), this->n_locally_owned_dofs());
 
-#ifdef DEBUG
+#  ifdef DEBUG
       // assert that the new indices are consecutively numbered if we are
       // working on a single processor. this doesn't need to
       // hold in the case of a parallel mesh since we map the interval
@@ -2429,7 +2429,7 @@ void DoFHandler<dim, spacedim>::renumber_dofs(
           Assert(new_number < this->n_dofs(),
                  ExcMessage(
                    "New DoF index is not less than the total number of dofs."));
-#endif
+#  endif
 
       // uncompress the internal storage scheme of dofs on cells so that
       // we can access dofs in turns. uncompress in parallel, starting
@@ -2464,7 +2464,7 @@ void DoFHandler<dim, spacedim>::renumber_dofs(
              ExcMessage(
                "You need to distribute DoFs before you can renumber them."));
 
-#ifdef DEBUG
+#  ifdef DEBUG
       if (dynamic_cast<const parallel::shared::Triangulation<dim, spacedim> *>(
             &*this->tria) != nullptr)
         {
@@ -2501,7 +2501,7 @@ void DoFHandler<dim, spacedim>::renumber_dofs(
           Assert(new_number < this->n_dofs(),
                  ExcMessage(
                    "New DoF index is not less than the total number of dofs."));
-#endif
+#  endif
 
       this->number_cache = this->policy->renumber_dofs(new_numbers);
     }
@@ -2525,7 +2525,7 @@ void DoFHandler<dim, spacedim>::renumber_dofs(
   AssertDimension(new_numbers.size(),
                   this->locally_owned_mg_dofs(level).n_elements());
 
-#ifdef DEBUG
+#  ifdef DEBUG
   // assert that the new indices are consecutively numbered if we are working
   // on a single processor. this doesn't need to hold in the case of a
   // parallel mesh since we map the interval [0...n_dofs(level)) into itself
@@ -2544,7 +2544,7 @@ void DoFHandler<dim, spacedim>::renumber_dofs(
       Assert(new_number < this->n_dofs(level),
              ExcMessage(
                "New DoF index is not less than the total number of dofs."));
-#endif
+#  endif
 
   this->mg_number_cache[level] =
     this->policy->renumber_mg_dofs(level, new_numbers);
@@ -2904,13 +2904,13 @@ template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 void DoFHandler<dim, spacedim>::pre_distributed_transfer_action()
 {
-#ifndef DEAL_II_WITH_P4EST
+#  ifndef DEAL_II_WITH_P4EST
   Assert(false,
          ExcMessage(
            "You are attempting to use a functionality that is only available "
            "if deal.II was configured to use p4est, but cmake did not find a "
            "valid p4est library."));
-#else
+#  else
   // the implementation below requires a p:d:T currently
   Assert(
     (dynamic_cast<const parallel::distributed::Triangulation<dim, spacedim> *>(
@@ -2962,7 +2962,7 @@ void DoFHandler<dim, spacedim>::pre_distributed_transfer_action()
   active_fe_index_transfer->cell_data_transfer
     ->prepare_for_coarsening_and_refinement(
       active_fe_index_transfer->active_fe_indices);
-#endif
+#  endif
 }
 
 
@@ -2994,9 +2994,9 @@ template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 void DoFHandler<dim, spacedim>::post_distributed_transfer_action()
 {
-#ifndef DEAL_II_WITH_P4EST
+#  ifndef DEAL_II_WITH_P4EST
   Assert(false, ExcInternalError());
-#else
+#  else
   update_active_fe_table();
 
   Assert(this->active_fe_index_transfer != nullptr, ExcInternalError());
@@ -3017,7 +3017,7 @@ void DoFHandler<dim, spacedim>::post_distributed_transfer_action()
 
   // Free memory.
   this->active_fe_index_transfer.reset();
-#endif
+#  endif
 }
 
 
@@ -3026,13 +3026,13 @@ template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 void DoFHandler<dim, spacedim>::prepare_for_serialization_of_active_fe_indices()
 {
-#ifndef DEAL_II_WITH_P4EST
+#  ifndef DEAL_II_WITH_P4EST
   Assert(false,
          ExcMessage(
            "You are attempting to use a functionality that is only available "
            "if deal.II was configured to use p4est, but cmake did not find a "
            "valid p4est library."));
-#else
+#  else
   // the implementation below requires a p:d:T currently
   Assert(
     (dynamic_cast<const parallel::distributed::Triangulation<dim, spacedim> *>(
@@ -3075,7 +3075,7 @@ void DoFHandler<dim, spacedim>::prepare_for_serialization_of_active_fe_indices()
   // Attach to transfer object
   active_fe_index_transfer->cell_data_transfer->prepare_for_serialization(
     active_fe_index_transfer->active_fe_indices);
-#endif
+#  endif
 }
 
 
@@ -3084,13 +3084,13 @@ template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 void DoFHandler<dim, spacedim>::deserialize_active_fe_indices()
 {
-#ifndef DEAL_II_WITH_P4EST
+#  ifndef DEAL_II_WITH_P4EST
   Assert(false,
          ExcMessage(
            "You are attempting to use a functionality that is only available "
            "if deal.II was configured to use p4est, but cmake did not find a "
            "valid p4est library."));
-#else
+#  else
   // the implementation below requires a p:d:T currently
   Assert(
     (dynamic_cast<const parallel::distributed::Triangulation<dim, spacedim> *>(
@@ -3139,7 +3139,7 @@ void DoFHandler<dim, spacedim>::deserialize_active_fe_indices()
 
   // Free memory.
   active_fe_index_transfer.reset();
-#endif
+#  endif
 }
 
 
@@ -3194,7 +3194,7 @@ unsigned int DoFHandler<dim, spacedim>::MGVertexDoFs::get_finest_level() const
 {
   return finest_level;
 }
-
+#endif
 /*-------------- Explicit Instantiations -------------------------------*/
 #include "dof_handler.inst"
 

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -35,7 +35,7 @@ DEAL_II_NAMESPACE_OPEN
 
 
 /*------------------------------- FiniteElement ----------------------*/
-
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 FiniteElement<dim, spacedim>::InternalDataBase::InternalDataBase()
@@ -1175,7 +1175,7 @@ FiniteElement<dim, spacedim>::get_sub_fe(const ComponentMask &mask) const
   const unsigned int first_selected =
     mask.first_selected_component(n_total_components);
 
-#ifdef DEBUG
+#  ifdef DEBUG
   // check that it is contiguous:
   for (unsigned int c = 0; c < n_total_components; ++c)
     Assert((c < first_selected && (!mask[c])) ||
@@ -1183,7 +1183,7 @@ FiniteElement<dim, spacedim>::get_sub_fe(const ComponentMask &mask) const
               mask[c]) ||
              (c >= first_selected + n_selected && !mask[c]),
            ExcMessage("Error: the given ComponentMask is not contiguous!"));
-#endif
+#  endif
 
   return get_sub_fe(first_selected, n_selected);
 }
@@ -1275,7 +1275,7 @@ FiniteElement<dim, spacedim>::compute_n_nonzero_components(
 
 /*------------------------------- FiniteElement ----------------------*/
 
-#ifndef DOXYGEN
+#  ifndef DOXYGEN
 template <int dim, int spacedim>
 std::unique_ptr<typename FiniteElement<dim, spacedim>::InternalDataBase>
 FiniteElement<dim, spacedim>::get_face_data(
@@ -1370,7 +1370,7 @@ FiniteElement<dim, spacedim>::fill_fe_face_values(
   (void)fe_internal;
   (void)output_data;
 }
-#endif
+#  endif
 
 
 
@@ -1406,7 +1406,7 @@ FiniteElement<dim, spacedim>::base_element(const unsigned int index) const
 }
 
 
-
+#endif
 /*------------------------------- Explicit Instantiations -------------*/
 #include "fe.inst"
 

--- a/source/fe/fe_poly.cc
+++ b/source/fe/fe_poly.cc
@@ -28,6 +28,7 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 FE_Poly<dim, spacedim>::FE_Poly(const FE_Poly &fe)
@@ -35,7 +36,7 @@ FE_Poly<dim, spacedim>::FE_Poly(const FE_Poly &fe)
   , poly_space(fe.poly_space->clone())
 {}
 
-
+#endif
 
 #include "fe_poly.inst"
 

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -174,6 +174,7 @@ namespace internal
   }   // namespace FE_PolyTensor
 } // namespace internal
 
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 FE_PolyTensor<dim, spacedim>::FE_PolyTensor(
@@ -2504,7 +2505,7 @@ FE_PolyTensor<dim, spacedim>::requires_update_flags(
   return out;
 }
 
-
+#endif
 // explicit instantiations
 #include "fe_poly_tensor.inst"
 

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -412,7 +412,7 @@ struct FE_Q_Base<xdim, xspacedim>::Implementation
   }
 };
 
-
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 FE_Q_Base<dim, spacedim>::FE_Q_Base(
@@ -570,7 +570,7 @@ FE_Q_Base<dim, spacedim>::get_interpolation_matrix(
           if (std::fabs(interpolation_matrix(i, j)) < eps)
             interpolation_matrix(i, j) = 0.;
 
-#ifdef DEBUG
+#  ifdef DEBUG
       // make sure that the row sum of each of the matrices is 1 at this
       // point. this must be so since the shape functions sum up to 1
       for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
@@ -581,7 +581,7 @@ FE_Q_Base<dim, spacedim>::get_interpolation_matrix(
 
           Assert(std::fabs(sum - 1) < eps, ExcInternalError());
         }
-#endif
+#  endif
     }
   else if (dynamic_cast<const FE_Nothing<dim> *>(&x_source_fe))
     {
@@ -700,7 +700,7 @@ FE_Q_Base<dim, spacedim>::get_subface_interpolation_matrix(
             }
         }
 
-#ifdef DEBUG
+#  ifdef DEBUG
       // make sure that the row sum of each of the matrices is 1 at this
       // point. this must be so since the shape functions sum up to 1
       for (unsigned int j = 0; j < source_fe.n_dofs_per_face(face_no); ++j)
@@ -712,7 +712,7 @@ FE_Q_Base<dim, spacedim>::get_subface_interpolation_matrix(
 
           Assert(std::fabs(sum - 1) < eps, ExcInternalError());
         }
-#endif
+#  endif
     }
   else if (dynamic_cast<const FE_Nothing<dim> *>(&source_fe) != nullptr)
     {
@@ -1285,7 +1285,7 @@ FE_Q_Base<dim, spacedim>::get_prolongation_matrix(
       // evaluations of the Lagrange polynomials are zero or one.
       const double eps = 1e-15 * q_degree * dim;
 
-#ifdef DEBUG
+#  ifdef DEBUG
       // in DEBUG mode, check that the evaluation of support points in the
       // current numbering gives the identity operation
       for (unsigned int i = 0; i < q_dofs_per_cell; ++i)
@@ -1310,7 +1310,7 @@ FE_Q_Base<dim, spacedim>::get_prolongation_matrix(
                        "ill-conditioned such that round-off "
                        "prevents the sum to be one."));
         }
-#endif
+#  endif
 
       // to efficiently evaluate the polynomial at the subcell, make use of
       // the tensor product structure of this element and only evaluate 1d
@@ -1421,7 +1421,7 @@ FE_Q_Base<dim, spacedim>::get_prolongation_matrix(
 
         // and make sure that the row sum is 1. this must be so since for this
         // element, the shape functions add up to one
-#ifdef DEBUG
+#  ifdef DEBUG
       for (unsigned int row = 0; row < this->n_dofs_per_cell(); ++row)
         {
           double sum = 0;
@@ -1436,7 +1436,7 @@ FE_Q_Base<dim, spacedim>::get_prolongation_matrix(
                                   "ill-conditioned such that round-off "
                                   "prevents the sum to be one."));
         }
-#endif
+#  endif
 
       // swap matrices
       prolongate.swap(const_cast<FullMatrix<double> &>(
@@ -1533,9 +1533,9 @@ FE_Q_Base<dim, spacedim>::get_restriction_matrix(
                   }
               unsigned int j_indices[dim];
               internal::FE_Q_Base::zero_indices<dim>(j_indices);
-#ifdef DEBUG
+#  ifdef DEBUG
               double sum_check = 0;
-#endif
+#  endif
               for (unsigned int j = 0; j < q_dofs_per_cell; j += dofs1d)
                 {
                   double val_extra_dim = 1.;
@@ -1555,9 +1555,9 @@ FE_Q_Base<dim, spacedim>::get_restriction_matrix(
                         my_restriction(mother_dof, child_dof) = 1.;
                       else if (std::fabs(val) > eps)
                         my_restriction(mother_dof, child_dof) = val;
-#ifdef DEBUG
+#  ifdef DEBUG
                       sum_check += val;
-#endif
+#  endif
                     }
                   internal::FE_Q_Base::increment_indices<dim>(j_indices,
                                                               dofs1d);
@@ -1714,7 +1714,7 @@ FE_Q_Base<dim, spacedim>::get_constant_modes() const
     constant_modes, std::vector<unsigned int>(1, 0));
 }
 
-
+#endif
 
 // explicit instantiations
 #include "fe_q_base.inst"

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -232,6 +232,7 @@ namespace internal
 } // namespace internal
 
 /* ----------------------- FESystem::InternalData ------------------- */
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 FESystem<dim, spacedim>::InternalData::InternalData(
@@ -1978,7 +1979,7 @@ FESystem<dim, spacedim>::initialize(
           }
       }
 
-#ifdef DEBUG
+#  ifdef DEBUG
     // check generalized_support_points_index_table for consistency
     for (unsigned int i = 0; i < base_elements.size(); ++i)
       {
@@ -1994,7 +1995,7 @@ FESystem<dim, spacedim>::initialize(
                    ExcInternalError());
           }
       }
-#endif /* DEBUG */
+#  endif /* DEBUG */
   });
 
   // initialize quad dof index permutation in 3d and higher
@@ -2760,7 +2761,7 @@ FESystem<dim, spacedim>::memory_consumption() const
   return mem;
 }
 
-
+#endif
 
 // explicit instantiations
 #include "fe_system.inst"

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -151,6 +151,7 @@ namespace internal
 } // namespace internal
 
 /*------------------------------- FEValues -------------------------------*/
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 const unsigned int FEValues<dim, spacedim>::integral_dimension;
@@ -369,9 +370,9 @@ FEValues<dim, spacedim>::memory_consumption() const
           MemoryConsumption::memory_consumption(quadrature));
 }
 
-
+#endif
 /*------------------------------- FEFaceValuesBase --------------------------*/
-
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 FEFaceValuesBase<dim, spacedim>::FEFaceValuesBase(
@@ -430,9 +431,11 @@ FEFaceValuesBase<dim, spacedim>::memory_consumption() const
   return (FEValuesBase<dim, spacedim>::memory_consumption() +
           MemoryConsumption::memory_consumption(quadrature));
 }
-
+#endif
 
 /*------------------------------- FEFaceValues -------------------------------*/
+
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 const unsigned int FEFaceValues<dim, spacedim>::dimension;
@@ -991,7 +994,7 @@ FESubfaceValues<dim, spacedim>::do_reinit(const unsigned int face_no,
                                         *this->fe_data,
                                         this->finite_element_output);
 }
-
+#endif
 
 /*------------------------- Explicit Instantiations --------------------------*/
 

--- a/source/fe/mapping.cc
+++ b/source/fe/mapping.cc
@@ -31,7 +31,7 @@
 #include <limits>
 
 DEAL_II_NAMESPACE_OPEN
-
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 boost::container::small_vector<Point<spacedim>,
@@ -192,7 +192,7 @@ Mapping<dim, spacedim>::project_real_point_to_unit_point_on_face(
 
 
 
-#ifndef DOXYGEN
+#  ifndef DOXYGEN
 template <int dim, int spacedim>
 void
 Mapping<dim, spacedim>::fill_fe_face_values(
@@ -258,7 +258,7 @@ Mapping<dim, spacedim>::get_face_data(
 
   return std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>();
 }
-#endif
+#  endif
 
 /* ---------------------------- InternalDataBase --------------------------- */
 
@@ -276,7 +276,7 @@ Mapping<dim, spacedim>::InternalDataBase::memory_consumption() const
 {
   return sizeof(*this);
 }
-
+#endif
 
 /* ------------------------------ Global functions ------------------------- */
 

--- a/source/grid/manifold.cc
+++ b/source/grid/manifold.cc
@@ -34,6 +34,8 @@
 DEAL_II_NAMESPACE_OPEN
 
 /* -------------------------- Manifold --------------------- */
+#ifndef DOXYGEN
+
 template <int dim, int spacedim>
 Point<spacedim>
 Manifold<dim, spacedim>::project_to_manifold(
@@ -522,7 +524,7 @@ Manifold<dim, spacedim>::get_tangent_vector(const Point<spacedim> &x1,
                   make_array_view(weights.begin(), weights.end()));
   return (neighbor_point - x1) / epsilon;
 }
-
+#endif
 /* -------------------------- FlatManifold --------------------- */
 
 namespace internal
@@ -550,6 +552,8 @@ namespace internal
 
   } // namespace
 } // namespace internal
+
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 FlatManifold<dim, spacedim>::FlatManifold(
@@ -1004,7 +1008,7 @@ FlatManifold<dim, spacedim>::normal_vector(
   // vectors given by grad_F
   return internal::normalized_alternating_product(grad_F);
 }
-
+#endif
 
 /* -------------------------- ChartManifold --------------------- */
 template <int dim, int spacedim, int chartdim>

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -12083,7 +12083,7 @@ namespace internal
   } // namespace TriangulationImplementation
 } // namespace internal
 
-
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
@@ -12221,7 +12221,6 @@ void Triangulation<dim, spacedim>::clear()
   cell_attached_data = {0, 0, {}, {}};
   data_serializer.clear();
 }
-
 
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
@@ -12462,8 +12461,10 @@ std::vector<types::manifold_id> Triangulation<dim, spacedim>::get_manifold_ids()
   return {m_ids.begin(), m_ids.end()};
 }
 
+#endif
 /*-----------------------------------------------------------------*/
 
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
@@ -12929,9 +12930,10 @@ void Triangulation<dim, spacedim>::coarsen_global(const unsigned int times)
 }
 
 
+#endif
 /*-------------------- refine/coarsen flags -------------------------*/
 
-
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
@@ -13077,6 +13079,7 @@ bool Triangulation<dim, spacedim>::get_anisotropic_refinement_flag() const
 }
 
 
+#endif
 
 namespace internal
 {
@@ -13140,6 +13143,7 @@ namespace
   }
 } // namespace
 
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
@@ -13446,6 +13450,7 @@ void Triangulation<dim, spacedim>::load_user_flags_line(
   Assert(i == v.end(), ExcInternalError());
 }
 
+#endif
 
 namespace
 {
@@ -13504,6 +13509,7 @@ namespace
   }
 } // namespace
 
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
@@ -13735,6 +13741,7 @@ void Triangulation<dim, spacedim>::load(const std::string &filename)
   load(ia, 0);
 }
 
+#endif
 namespace
 {
   template <typename Iterator>
@@ -13776,6 +13783,7 @@ namespace
   }
 } // namespace
 
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
@@ -13874,6 +13882,7 @@ void Triangulation<dim, spacedim>::load_user_indices_hex(
     }
 }
 
+#endif
 
 
 //---------------- user pointers ----------------------------------------//
@@ -13920,6 +13929,7 @@ namespace
   }
 } // namespace
 
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
@@ -14089,10 +14099,11 @@ void Triangulation<dim, spacedim>::load_user_pointers_hex(
     }
 }
 
-
+#endif
 
 /*------------------------ Cell iterator functions ------------------------*/
 
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
@@ -14404,10 +14415,11 @@ IteratorRange<typename Triangulation<dim, spacedim>::
     typename Triangulation<dim, spacedim>::active_cell_iterator>(
     begin_active(level), end_active(level));
 }
-
+#endif
 
 /*------------------------ Face iterator functions ------------------------*/
 
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
@@ -14528,11 +14540,12 @@ typename Triangulation<dim, spacedim>::vertex_iterator
                              numbers::invalid_unsigned_int);
 }
 
+#endif
 
 
 /*------------------------ Line iterator functions ------------------------*/
 
-
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
@@ -14620,10 +14633,11 @@ typename Triangulation<dim, spacedim>::line_iterator
                            -1);
 }
 
-
+#endif
 
 /*------------------------ Quad iterator functions ------------------------*/
 
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
@@ -14725,9 +14739,11 @@ typename Triangulation<dim, spacedim>::quad_iterator
                            -1);
 }
 
+#endif
 
 /*------------------------ Hex iterator functions ------------------------*/
 
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
@@ -14820,7 +14836,7 @@ typename Triangulation<dim, spacedim>::hex_iterator
                           -1);
 }
 
-
+#endif
 
 // -------------------------------- number of cells etc ---------------
 
@@ -14875,7 +14891,7 @@ namespace internal
   } // namespace TriangulationImplementation
 } // namespace internal
 
-
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
@@ -15116,7 +15132,7 @@ unsigned int Triangulation<dim, spacedim>::n_active_lines(
 
   return number_cache.n_active_lines_level[level];
 }
-
+#endif
 
 template <>
 unsigned int
@@ -15262,7 +15278,7 @@ Triangulation<1, 3>::n_active_quads() const
   return 0;
 }
 
-
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
@@ -15282,7 +15298,7 @@ unsigned int Triangulation<dim, spacedim>::n_quads(
   return number_cache.n_quads_level[level];
 }
 
-
+#endif
 
 template <>
 unsigned int
@@ -15311,7 +15327,7 @@ Triangulation<3, 3>::n_raw_quads(const unsigned int) const
   return 0;
 }
 
-
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
@@ -15321,7 +15337,7 @@ unsigned int Triangulation<dim, spacedim>::n_raw_quads() const
   return 0;
 }
 
-
+#endif
 
 template <>
 unsigned int
@@ -15330,7 +15346,7 @@ Triangulation<3, 3>::n_raw_quads() const
   return faces->quads.n_objects();
 }
 
-
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
@@ -15395,6 +15411,7 @@ unsigned int Triangulation<dim, spacedim>::n_active_hexs(
   return 0;
 }
 
+#endif
 
 template <>
 unsigned int
@@ -15443,7 +15460,7 @@ Triangulation<3, 3>::n_active_hexs(const unsigned int level) const
   return number_cache.n_active_hexes_level[level];
 }
 
-
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
@@ -15461,7 +15478,7 @@ const std::vector<bool> &Triangulation<dim, spacedim>::get_used_vertices() const
   return vertices_used;
 }
 
-
+#endif
 
 template <>
 unsigned int
@@ -15487,6 +15504,7 @@ Triangulation<1, 3>::max_adjacent_cells() const
   return 2;
 }
 
+#ifndef DOXYGEN
 
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
@@ -15627,7 +15645,7 @@ void Triangulation<dim, spacedim>::execute_coarsening_and_refinement()
 
   update_periodic_face_map();
 
-#ifdef DEBUG
+#  ifdef DEBUG
 
   // In debug mode, we want to check for some consistency of the
   // result of this function. Because there are multiple exit
@@ -15670,7 +15688,7 @@ void Triangulation<dim, spacedim>::execute_coarsening_and_refinement()
                 }
             }
     }
-#endif
+#  endif
 }
 
 
@@ -16117,7 +16135,7 @@ typename Triangulation<dim, spacedim>::DistortedCellList
   internal::TriangulationImplementation::Implementation::compute_number_cache(
     *this, levels.size(), number_cache);
 
-#ifdef DEBUG
+#  ifdef DEBUG
   for (const auto &level : levels)
     monitor_memory(level->cells, dim);
 
@@ -16127,7 +16145,7 @@ typename Triangulation<dim, spacedim>::DistortedCellList
   // since the cell-accessors should have caught this)
   for (const auto &cell : this->cell_iterators())
     Assert(!cell->refine_flag_set(), ExcInternalError());
-#endif
+#  endif
 
   return cells_with_distorted_children;
 }
@@ -16378,7 +16396,7 @@ void Triangulation<dim, spacedim>::fix_coarsen_flags()
   while (continue_iterating == true);
 }
 
-
+#endif
 
 // TODO: merge the following 3 functions since they are the same
 template <>
@@ -16619,7 +16637,7 @@ namespace
   }
 } // namespace
 
-
+#ifndef DOXYGEN
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 bool Triangulation<dim, spacedim>::prepare_coarsening_and_refinement()
@@ -17733,6 +17751,7 @@ DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 Triangulation<dim, spacedim>::DistortedCellList::~DistortedCellList() noexcept =
   default;
 
+#endif
 
 // explicit instantiations
 #include "tria.inst"

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -1463,6 +1463,7 @@ namespace
 
 
 /*-------------------- Static variables: TriaAccessorBase -------------------*/
+#ifndef DOXYGEN
 
 template <int structdim, int dim, int spacedim>
 const unsigned int TriaAccessorBase<structdim, dim, spacedim>::dimension;
@@ -1474,8 +1475,9 @@ template <int structdim, int dim, int spacedim>
 const unsigned int
   TriaAccessorBase<structdim, dim, spacedim>::structure_dimension;
 
-
+#endif
 /*------------------------ Functions: TriaAccessor ---------------------------*/
+#ifndef DOXYGEN
 
 template <int structdim, int dim, int spacedim>
 void
@@ -1570,7 +1572,7 @@ TriaAccessor<structdim, dim, spacedim>::extent_in_direction(
   return std::numeric_limits<double>::signaling_NaN();
 }
 
-
+#endif
 
 template <>
 double

--- a/source/lac/petsc_communication_pattern.cc
+++ b/source/lac/petsc_communication_pattern.cc
@@ -361,7 +361,7 @@ namespace PETScWrappers
     import_from_ghosted_array_finish(op, src, dst);
   }
 
-
+#  ifndef DOXYGEN
 
   // Partitioner
 
@@ -510,7 +510,7 @@ namespace PETScWrappers
     import_from_ghosted_array_start(op, src, dst);
     import_from_ghosted_array_finish(op, src, dst);
   }
-
+#  endif
 } // namespace PETScWrappers
 
 // Explicit instantiations


### PR DESCRIPTION
Related to #16024 this fixes some warnings thrown by doxygen in newer versions
by hiding some instantiations without doxygen comments from it.