### PR TITLE
Doxygen/Tutorials remove unnecessary anchors

### DIFF
--- a/examples/step-16b/doc/intro.dox
+++ b/examples/step-16b/doc/intro.dox
@@ -1,6 +1,6 @@
 <br>
 
-<a name="Intro"></a>
+<a name="step-16b-Intro"></a>
 <h1>Introduction</h1>
 
 This is a variant of step-16 with the only change that we are using the

--- a/examples/step-22/doc/results.dox
+++ b/examples/step-22/doc/results.dox
@@ -1,4 +1,3 @@
-<a name="step-22-Results"></a>
 <h1>Results</h1>
 
 <h3>Output of the program and graphical visualization</h3>

--- a/examples/step-29/doc/results.dox
+++ b/examples/step-29/doc/results.dox
@@ -1,4 +1,3 @@
-<a name="step-29-Results"></a>
 <h1>Results</h1>
 
 The current program reads its run-time parameters from an input file

--- a/examples/step-33/doc/results.dox
+++ b/examples/step-33/doc/results.dox
@@ -1,4 +1,3 @@
-<a name="step-33-Results"></a>
 <h1>Results</h1>
 
 We run the problem with the mesh <code>slide.inp</code> (this file is in the

--- a/examples/step-35/doc/intro.dox
+++ b/examples/step-35/doc/intro.dox
@@ -8,7 +8,6 @@ University. Most of the work for this program is by him.
 <a name="step-35-Intro"></a>
 <h1> Introduction </h1>
 
-<a name="step-35-Motivation"></a>
 <h3> Motivation </h3>
 The purpose of this program is to show how to effectively solve the incompressible time-dependent
 Navier-Stokes equations. These equations describe the flow of a viscous incompressible fluid and read

--- a/examples/step-35/doc/results.dox
+++ b/examples/step-35/doc/results.dox
@@ -1,7 +1,5 @@
-<a name="step-35-results"></a>
 <h1>Results</h1>
 
-<a name="step-35-Re100"></a>
 <h3> Re = 100 </h3>
 
 We run the code with the following <code>parameter-file.prm</code>, which can be found in the
@@ -89,7 +87,6 @@ behind the obstacles, with the sign of the vorticity indicating
 whether this is a left or right turning vortex.
 
 
-<a name="step-35-Re500"></a>
 <h3> Re = 500 </h3>
 
 We can change the Reynolds number, $Re$, in the parameter file to a

--- a/examples/step-36/doc/intro.dox
+++ b/examples/step-36/doc/intro.dox
@@ -3,7 +3,6 @@
 <i>This program was contributed by Toby D. Young and Wolfgang
 Bangerth.  </i>
 
-<a name="step-36-Preamble"></a>
 <h1>Preamble</h1>
 
 The problem we want to solve in this example is an eigenspectrum

--- a/examples/step-45/doc/intro.dox
+++ b/examples/step-45/doc/intro.dox
@@ -16,7 +16,6 @@ be able to proceed this way one has to assume that the model can be
 periodically extended to the other boxes; this requires the solution to
 have a periodic structure.
 
-<a name="step-45-Procedure"></a>
 <h1>Procedure</h1>
 
 deal.II provides a number of high level entry points to impose periodic

--- a/examples/step-46/doc/results.dox
+++ b/examples/step-46/doc/results.dox
@@ -1,4 +1,3 @@
-<a name="step-46-Results"></a>
 <h1>Results</h1>
 
 <h3>2d results</h3>

--- a/examples/step-69/doc/results.dox
+++ b/examples/step-69/doc/results.dox
@@ -1,4 +1,3 @@
-<a name="step-69-Results"></a>
 <h1>Results</h1>
 
 Running the program with default parameters in release mode takes about 1


### PR DESCRIPTION
In #16051 I missed some cases where both an anchor and a heading exist 
such that the Perl scripts automatically generate a second anchor based on the heading.
This leads to a doubly defined anchor of the same name.