### PR TITLE
make_flux_sparsity_pattern: Reduce compile time by joining code

### DIFF
--- a/source/dofs/dof_tools_sparsity.cc
+++ b/source/dofs/dof_tools_sparsity.cc
@@ -802,10 +802,10 @@ namespace DoFTools
               neighbor->get_fe().has_support_on_face(j, neighbor_face_no);
           }
 
-        // For the parallel setting, must include also the off-diagonal
-        // coupling, otherwise we will include those on the other cell
-        for (unsigned int f = 0; f < (neighbor->is_locally_owned() ? 1 : 2);
-             ++f)
+        // For the parallel setting, must include also the diagonal
+        // neighbor-neighbor coupling, otherwise those get included on the
+        // other cell
+        for (int f = 0; f < (neighbor->is_locally_owned() ? 1 : 2); ++f)
           {
             const auto &fe = (f == 0) ? cell->get_fe() : neighbor->get_fe();
             const auto &dofs_i =


### PR DESCRIPTION
In #16065, one could see that `dealii::DoFTools::internal::(anonymous namespace)::make_flux_sp...` is one of the most expensive functions to compile in the whole library. This can be made substantially cheaper by factoring out some common code cases (to add indices from subfaces and faces) and by avoiding a separate `non-hp` and `hp` case. It also reduces code by more than 300 lines. ~~While doing this, I observed that the old code for hp must have had some bugs, because I had to add more cases, to pass the `dof_tools_18{abcd}` test cases. Let's see if the CI is happy with this in all cases.~~