### PR TITLE
Fix Doxygen copydoc references

### DIFF
--- a/.github/workflows/indent.yml
+++ b/.github/workflows/indent.yml
@@ -43,14 +43,6 @@ jobs:
         # warning: Inheritance graph for 'Subscriptor' not generated, too many nodes (209), threshold is 50. Consider increasing DOT_GRAPH_MAX_NODES.
         sed -i '/Inheritance graph/d' doxygen.log
         # Suppress:
-        # warning: @copybrief or @copydoc target '<name>' not found
-        # warning: Found recursive @copybrief or @copydoc relation for argument '<arg>'
-        sed -i '/@copybrief or @copydoc/d' doxygen.log 
-        # Suppress:
-        # warning: @copydetails or @copydoc target '<name>' not found
-        # warning: Found recursive @copydetails or @copydoc relation for argument '<arg>'
-        sed -i '/@copydetails or @copydoc/d' doxygen.log 
-        # Suppress:
         # warning: explicit link request to '<function>' could not be resolved
         sed -i '/explicit link request to/d' doxygen.log
         # Remove empty lines

--- a/include/deal.II/distributed/fully_distributed_tria.h
+++ b/include/deal.II/distributed/fully_distributed_tria.h
@@ -134,7 +134,7 @@ namespace parallel
       virtual ~Triangulation() = default;
 
       /**
-       * @copydoc dealii::Triangulation::create_triangulation()
+       * @copydoc deal.II/grid/tria.h Triangulation::create_triangulation(const TriangulationDescription::Description<dim, spacedim>&)
        *
        * @note This is the function to be used instead of
        * Triangulation::create_triangulation() for some of the other

--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -211,7 +211,7 @@ namespace parallel
       const unsigned int level) const override;
 
     /**
-     * @copydoc dealii::Triangulation::get_boundary_ids()
+     * @copydoc deal.II/grid/tria.h Triangulation::get_boundary_ids()
      *
      * @note This function involves a global communication gathering all current
      *   IDs from all processes.
@@ -220,7 +220,7 @@ namespace parallel
     get_boundary_ids() const override;
 
     /**
-     * @copydoc dealii::Triangulation::get_manifold_ids()
+     * @copydoc deal.II/grid/tria.h Triangulation::get_manifold_ids()
      *
      * @note This function involves a global communication gathering all current
      *   IDs from all processes.
@@ -371,7 +371,7 @@ namespace parallel
     update_number_cache();
 
     /**
-     * @copydoc dealii::Triangulation::update_reference_cells()
+     * @copydoc deal.II/grid/tria.h Triangulation::update_reference_cells()
      */
     void
     update_reference_cells() override;

--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -605,7 +605,7 @@ public:
   using FiniteElement<dim, spacedim>::get_sub_fe;
 
   /**
-   * @copydoc FiniteElement<dim,spacedim>::get_sub_fe()
+   * @copydoc FiniteElement::get_sub_fe()
    */
   virtual const FiniteElement<dim, spacedim> &
   get_sub_fe(const unsigned int first_component,

--- a/include/deal.II/fe/mapping_q_cache.h
+++ b/include/deal.II/fe/mapping_q_cache.h
@@ -193,7 +193,7 @@ public:
              const bool vector_describes_relative_displacement);
 
   /**
-   * @copydoc Mapping<dim,spacedim>::get_vertices()
+   * @copydoc Mapping::get_vertices()
    */
   virtual boost::container::small_vector<Point<spacedim>,
                                          GeometryInfo<dim>::vertices_per_cell>

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -1466,7 +1466,7 @@ operator<<(std::ostream &out, const Vector<number> &v)
 
 
 /**
- * Declare dealii::Vector< Number > as serial vector.
+ * Declare Vector<Number> as serial vector.
  *
  * @relatesalso Vector
  */


### PR DESCRIPTION
For Triangulation specifying the exact file (i.e. `deal.II/grid/tria.h` fixed the ambiguity between `dealii::Triangulation` 
and `dealii::parallel::distributed::Triangulation` and the likes for the documentation of `TriangulationBase`.

For other references either template parameters or the namespace `dealii::` had to be removed 
as they are not understood by/known to Doxygen.

Related to #16024 