### PR TITLE
Docker: fix order of ARGS in Dockerfile.

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,8 +1,9 @@
 ARG IMG=focal    # Ubuntu image that contains all corresponding dependencies.
-ARG NJOBS=0      # Jobs used for building. Default: Use all available jobs.
-ARG VER=master   # deal.II branch that gets checked out.
 
 FROM dealii/dependencies:$IMG
+
+ARG NJOBS=0      # Jobs used for building. Default: Use all available jobs.
+ARG VER=master   # deal.II branch that gets checked out.
 
 LABEL maintainer="luca.heltai@gmail.com"
 


### PR DESCRIPTION
I accidentally broke the Dockerfile in #16062. All `ARG` fields get reset after the `FROM` statement, so we need to change the order to make it work.

More info: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact

I verified that it starts building the library on my laptop.