### PR TITLE
Update oneAPI CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -162,11 +162,11 @@ jobs:
     - uses: actions/checkout@v4
     - name: setup apt repo
       run: |
-        # oneapi-ci/scripts/setup_apt_repo_linux.sh
-        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-        echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-        sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/oneAPI.list" -o APT::Get::List-Cleanup="0"
+        # download the key to system keyring
+        wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+        # add signed entry to apt sources and configure the APT client to use Intel repository:
+        echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+        sudo apt-get update
     - name: collect versioned dependencies of apt packages
       run : |
         # oneapi-ci/scripts/apt_depends.sh


### PR DESCRIPTION
The oneAPI are currently outdated, see https://community.intel.com/t5/Intel-oneAPI-Base-Toolkit/The-GPG-PUB-KEY-INTEL-SW-PRODUCTS-PUB-expired/m-p/1529173#M3153. While looking at that, I noticed
```
Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
```
which should be fixed by following the instructions at https://www.intel.com/content/www/us/en/docs/oneapi/installation-guide-linux/2023-2/apt.html#GUID-A127A14F-A303-40FC-A0A9-FF69E446AEE6.