### PR TITLE
GitHub CI OSX and Windows: Upload CMakeConfigureLog

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -46,20 +46,13 @@ jobs:
       run: |
         make VERBOSE=1 -j2
         make -j3 test # quicktests
-    - name: archive error 1
+    - name: upload CMakeCongiureLog
       uses: actions/upload-artifact@v3
       if: always()
       continue-on-error: true
       with:
-        name: osx-serial-CMakeOutput.log
-        path: CMakeFiles/CMakeOutput.log
-    - name: archive error 2
-      uses: actions/upload-artifact@v3
-      if: always()
-      continue-on-error: true
-      with:
-        name: osx-serial-CMakeError.log
-        path: CMakeFiles/CMakeError.log
+        name: osx-serial-CMakeConfigureLog.yaml
+        path: CMakeFiles/CMakeConfigureLog.yaml
 
   osx-parallel64:
     # MPI build using apple clang and 64 bit indices
@@ -97,18 +90,11 @@ jobs:
       run: |
         make VERBOSE=1 -j2
         make -j3 test #quicktests
-    - name: archive error 1
+    - name: upload CMakeConfigureLog
       uses: actions/upload-artifact@v3
       if: always()
       continue-on-error: true
       with:
-        name: osx-parallel64-CMakeOutput.log
-        path: CMakeFiles/CMakeOutput.log
-    - name: archive error 2
-      uses: actions/upload-artifact@v3
-      if: always()
-      continue-on-error: true
-      with:
-        name: osx-parallel64-CMakeError.log
-        path: CMakeFiles/CMakeError.log
+        name: osx-parallel64-CMakeConfigureLog.yaml
+        path: CMakeFiles/CMakeConfigureLog.yaml
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -74,17 +74,10 @@ jobs:
       with:
         name: dealii-windows.zip
         path: c:/project/dealii-windows.zip
-    - name: upload CMakeOutput
+    - name: upload CMakeConfigureLog
       uses: actions/upload-artifact@v3
       if: always()
       continue-on-error: true
       with:
-        name: windows-serial-CMakeOutput.log
-        path: build/CMakeFiles/CMakeOutput.log
-    - name: upload CMakeError
-      uses: actions/upload-artifact@v3
-      if: always()
-      continue-on-error: true
-      with:
-        name: windows-serial-CMakeError.log
-        path: build/CMakeFiles/CMakeError.log
+        name: windows-serial-CMakeConfigureLog.yaml
+        path: build/CMakeFiles/CMakeConfigureLog.yaml


### PR DESCRIPTION
This fixes warnings in the CI that CMake[Error|Output].log doesn't exist anymore since CMake 3.26. The affected builds use newer versions.