### PR TITLE
github-actions: fix a race condition.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -79,5 +79,5 @@ jobs:
       if: always()
       continue-on-error: true
       with:
-        name: windows-serial-CMakeConfigureLog.yaml
+        name: ${{ matrix.os }}-serial-CMakeConfigureLog.yaml
         path: build/CMakeFiles/CMakeConfigureLog.yaml


### PR DESCRIPTION
Both runners from the same workflow will upload the same file. We do not know if it is from the `windows-2019` or `windows-2022` runner.

The PR suggests to be more specific by proposing a different filename.