### PR TITLE
NonMatching::MappingInfo: Adjust tolerance for GeometryType detection

### DIFF
--- a/include/deal.II/non_matching/mapping_info.h
+++ b/include/deal.II/non_matching/mapping_info.h
@@ -192,7 +192,7 @@ namespace NonMatching
     {
       const auto   jac_0 = inverse_jacobians[0];
       const double zero_tolerance_double =
-        1. / diameter * std::numeric_limits<double>::epsilon() * 1024.;
+        1e4 / diameter * std::numeric_limits<double>::epsilon() * 1024.;
       bool jacobian_constant = true;
       for (unsigned int q = 1; q < inverse_jacobians.size(); ++q)
         {


### PR DESCRIPTION
While looking at fine mesh with > 100M DoFs I observed that mapping compression failed due to the strict tolerance. The inverse Jacobian (which is checked) is apparently subject to roundoff when looking at fine meshes.

@kronbichler 