### PR TITLE
Improve two error messages.

### DIFF
--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -1879,13 +1879,25 @@ public:
    *
    * @ingroup Exceptions
    */
-  DeclException0(ExcMatrixIsClosed);
+  DeclExceptionMsg(
+    ExcMatrixIsClosed,
+    "You are attempting an operation on an AffineConstraints object "
+    "that requires the object to be 'closed', i.e., for which you "
+    "needed to call the close() member function. But the object "
+    "is not currently closed, and so the operation can not be "
+    "performed.");
   /**
    * Exception
    *
    * @ingroup Exceptions
    */
-  DeclException0(ExcMatrixNotClosed);
+  DeclExceptionMsg(
+    ExcMatrixNotClosed,
+    "You are attempting an operation on an AffineConstraints object "
+    "that requires the object to not be 'closed', i.e., for which you "
+    "must not already have called the close() member function. But the "
+    "object is already closed, and so the operation can not be "
+    "performed.");
   /**
    * Exception
    *


### PR DESCRIPTION
This is part of #610. Assertion classes without a message are just not very useful unless you know what the class name is supposed to mean.