### PR TITLE
Fix a bug in AffineConstraints::clear().

### DIFF
--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -1097,6 +1097,7 @@ AffineConstraints<number>::clear()
   }
 
   locally_owned_dofs             = {};
+  local_lines                    = {};
   needed_elements_for_distribute = {};
 
   sorted = false;


### PR DESCRIPTION
This predates the work I started in #15375: We just forgot to clear a member variable in a `clear()` function. I don't know whether I can come up with a test, but the situation is pretty obvious.