### PR TITLE
Remove unnecessary <sstream> header include.

### DIFF
--- a/tests/mpi/constraint_matrix_trilinos_bug.cc
+++ b/tests/mpi/constraint_matrix_trilinos_bug.cc
@@ -45,8 +45,6 @@
 #include <deal.II/numerics/data_out.h>
 #include <deal.II/numerics/vector_tools.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 

--- a/tests/mpi/derivative_approximation_01.cc
+++ b/tests/mpi/derivative_approximation_01.cc
@@ -51,8 +51,6 @@
 #include <deal.II/numerics/derivative_approximation.h>
 #include <deal.II/numerics/vector_tools.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 

--- a/tests/mpi/derivative_approximation_02.cc
+++ b/tests/mpi/derivative_approximation_02.cc
@@ -38,8 +38,6 @@
 #include <deal.II/numerics/derivative_approximation.h>
 #include <deal.II/numerics/vector_tools.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 

--- a/tests/mpi/interpolate_01.cc
+++ b/tests/mpi/interpolate_01.cc
@@ -45,8 +45,6 @@
 #include <deal.II/numerics/data_out.h>
 #include <deal.II/numerics/vector_tools.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 

--- a/tests/mpi/interpolate_02.cc
+++ b/tests/mpi/interpolate_02.cc
@@ -46,8 +46,6 @@
 #include <deal.II/numerics/data_out.h>
 #include <deal.II/numerics/vector_tools.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 

--- a/tests/mpi/interpolate_05.cc
+++ b/tests/mpi/interpolate_05.cc
@@ -46,8 +46,6 @@
 #include <deal.II/numerics/data_out.h>
 #include <deal.II/numerics/vector_tools.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 

--- a/tests/mpi/multigrid_adaptive.cc
+++ b/tests/mpi/multigrid_adaptive.cc
@@ -61,8 +61,6 @@
 
 #include "../tests.h"
 
-// This is C++:
-#include <sstream>
 
 namespace Step50
 {

--- a/tests/mpi/multigrid_uniform.cc
+++ b/tests/mpi/multigrid_uniform.cc
@@ -61,9 +61,6 @@
 
 #include "../tests.h"
 
-// This is C++:
-#include <sstream>
-
 namespace Step50
 {
   template <int dim>

--- a/tests/mpi/no_flux_constraints.cc
+++ b/tests/mpi/no_flux_constraints.cc
@@ -39,8 +39,6 @@
 
 #include <deal.II/numerics/vector_tools.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 template <int dim>

--- a/tests/mpi/no_flux_constraints_02.cc
+++ b/tests/mpi/no_flux_constraints_02.cc
@@ -40,8 +40,6 @@
 
 #include <deal.II/numerics/vector_tools.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 template <int dim>

--- a/tests/mpi/no_flux_constraints_03.cc
+++ b/tests/mpi/no_flux_constraints_03.cc
@@ -40,8 +40,6 @@
 
 #include <deal.II/numerics/vector_tools.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 template <int dim>

--- a/tests/mpi/normal_flux_constraints.cc
+++ b/tests/mpi/normal_flux_constraints.cc
@@ -39,8 +39,6 @@
 
 #include <deal.II/numerics/vector_tools.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 template <int dim>

--- a/tests/mpi/p4est_2d_constraintmatrix_01.cc
+++ b/tests/mpi/p4est_2d_constraintmatrix_01.cc
@@ -35,8 +35,6 @@
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/tria_iterator.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 template <int dim>

--- a/tests/mpi/p4est_2d_constraintmatrix_02.cc
+++ b/tests/mpi/p4est_2d_constraintmatrix_02.cc
@@ -35,8 +35,6 @@
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/tria_iterator.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 template <int dim>

--- a/tests/mpi/p4est_2d_constraintmatrix_03.cc
+++ b/tests/mpi/p4est_2d_constraintmatrix_03.cc
@@ -45,8 +45,6 @@
 #include <deal.II/numerics/data_out.h>
 #include <deal.II/numerics/vector_tools.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 

--- a/tests/mpi/p4est_2d_constraintmatrix_04.cc
+++ b/tests/mpi/p4est_2d_constraintmatrix_04.cc
@@ -45,8 +45,6 @@
 #include <deal.II/numerics/data_out.h>
 #include <deal.II/numerics/vector_tools.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 const double R0 = 0.5; // 6371000.-2890000.;

--- a/tests/mpi/p4est_3d_constraintmatrix_01.cc
+++ b/tests/mpi/p4est_3d_constraintmatrix_01.cc
@@ -35,8 +35,6 @@
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/tria_iterator.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 template <int dim>

--- a/tests/mpi/p4est_3d_constraintmatrix_02.cc
+++ b/tests/mpi/p4est_3d_constraintmatrix_02.cc
@@ -36,8 +36,6 @@
 
 #include <deal.II/lac/trilinos_vector.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 template <int dim>

--- a/tests/mpi/p4est_3d_constraintmatrix_03.cc
+++ b/tests/mpi/p4est_3d_constraintmatrix_03.cc
@@ -45,8 +45,6 @@
 #include <deal.II/numerics/data_out.h>
 #include <deal.II/numerics/vector_tools.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 const double R0 = 0.5; // 6371000.-2890000.;

--- a/tests/mpi/petsc_distribute_01.cc
+++ b/tests/mpi/petsc_distribute_01.cc
@@ -30,8 +30,6 @@
 #include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/petsc_vector.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 

--- a/tests/mpi/petsc_distribute_01_block.cc
+++ b/tests/mpi/petsc_distribute_01_block.cc
@@ -24,8 +24,6 @@
 #include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/petsc_block_vector.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 

--- a/tests/mpi/petsc_distribute_01_inhomogenous.cc
+++ b/tests/mpi/petsc_distribute_01_inhomogenous.cc
@@ -22,8 +22,6 @@
 #include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/petsc_vector.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 

--- a/tests/mpi/petsc_locally_owned_elements.cc
+++ b/tests/mpi/petsc_locally_owned_elements.cc
@@ -24,8 +24,6 @@
 #include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/petsc_block_vector.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 

--- a/tests/mpi/solution_transfer_01.cc
+++ b/tests/mpi/solution_transfer_01.cc
@@ -44,8 +44,6 @@
 #include <deal.II/numerics/data_out.h>
 #include <deal.II/numerics/vector_tools.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 

--- a/tests/mpi/trilinos_distribute_01.cc
+++ b/tests/mpi/trilinos_distribute_01.cc
@@ -30,8 +30,6 @@
 #include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/trilinos_vector.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 

--- a/tests/mpi/trilinos_distribute_01_block.cc
+++ b/tests/mpi/trilinos_distribute_01_block.cc
@@ -24,8 +24,6 @@
 #include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/trilinos_parallel_block_vector.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 

--- a/tests/mpi/trilinos_distribute_01_inhomogenous.cc
+++ b/tests/mpi/trilinos_distribute_01_inhomogenous.cc
@@ -22,8 +22,6 @@
 #include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/trilinos_vector.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 

--- a/tests/mpi/trilinos_distribute_03.cc
+++ b/tests/mpi/trilinos_distribute_03.cc
@@ -21,8 +21,6 @@
 #include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/trilinos_vector.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 

--- a/tests/mpi/trilinos_distribute_04.cc
+++ b/tests/mpi/trilinos_distribute_04.cc
@@ -53,8 +53,6 @@ constraint?
 
 #include <deal.II/numerics/vector_tools.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 

--- a/tests/mpi/trilinos_locally_owned_elements_01.cc
+++ b/tests/mpi/trilinos_locally_owned_elements_01.cc
@@ -20,8 +20,6 @@
 
 #include <deal.II/lac/trilinos_vector.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 

--- a/tests/mpi/trilinos_locally_owned_elements_02.cc
+++ b/tests/mpi/trilinos_locally_owned_elements_02.cc
@@ -20,8 +20,6 @@
 
 #include <deal.II/lac/trilinos_vector.h>
 
-#include <sstream>
-
 #include "../tests.h"
 
 


### PR DESCRIPTION
None of these tests using `std::[io]stringstream`.