### PR TITLE
Fix swapped error messages.

### DIFF
--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -1882,9 +1882,9 @@ public:
   DeclExceptionMsg(
     ExcMatrixIsClosed,
     "You are attempting an operation on an AffineConstraints object "
-    "that requires the object to be 'closed', i.e., for which you "
-    "needed to call the close() member function. But the object "
-    "is not currently closed, and so the operation can not be "
+    "that requires the object to not be 'closed', i.e., for which you "
+    "must not already have called the close() member function. But the "
+    "object is already closed, and so the operation can not be "
     "performed.");
   /**
    * Exception
@@ -1894,9 +1894,9 @@ public:
   DeclExceptionMsg(
     ExcMatrixNotClosed,
     "You are attempting an operation on an AffineConstraints object "
-    "that requires the object to not be 'closed', i.e., for which you "
-    "must not already have called the close() member function. But the "
-    "object is already closed, and so the operation can not be "
+    "that requires the object to be 'closed', i.e., for which you "
+    "needed to call the close() member function. But the object "
+    "is not currently closed, and so the operation can not be "
     "performed.");
   /**
    * Exception


### PR DESCRIPTION
in #16092, I got the two error messages the wrong way around. In writing #16099, I promptly triggered one of these and found myself entirely perplexed by the error. Doh.