### PR TITLE
Add AffineConstraint::add_constraint().

### DIFF
--- a/doc/news/changes/minor/20231002Bangerth_2
+++ b/doc/news/changes/minor/20231002Bangerth_2
@@ -1,0 +1,7 @@
+New: The new function AffineConstraints::add_constraint() adds an
+entire constraint all at once, rather than splitting the task across
+AffineConstraint::add_line(), multiple calls to
+AffineConstraint::add_entry(), and
+AffineConstraint::set_inhomogeneity().
+<br>
+(Wolfgang Bangerth, 2023/10/05)

--- a/examples/step-11/step-11.cc
+++ b/examples/step-11/step-11.cc
@@ -151,16 +151,17 @@ namespace Step11
 
     // Then generate a constraints object with just this one constraint. First
     // clear all previous content (which might reside there from the previous
-    // computation on a once coarser grid), then add this one line
+    // computation on a once coarser grid), then add this one constraint,
     // constraining the <code>first_boundary_dof</code> to the sum of other
     // boundary DoFs each with weight -1. Finally, close the constraints
     // object, i.e. do some internal bookkeeping on it for faster processing
     // of what is to come later:
     mean_value_constraints.clear();
-    mean_value_constraints.add_line(first_boundary_dof);
+    std::vector<std::pair<types::global_dof_index, double>> rhs;
     for (const types::global_dof_index i : boundary_dofs)
       if (i != first_boundary_dof)
-        mean_value_constraints.add_entry(first_boundary_dof, i, -1);
+        rhs.emplace_back(i, -1.);
+    mean_value_constraints.add_constraint(first_boundary_dof, rhs);
     mean_value_constraints.close();
 
     // Next task is to generate a sparsity pattern. This is indeed a tricky

--- a/examples/step-41/step-41.cc
+++ b/examples/step-41/step-41.cc
@@ -479,8 +479,7 @@ namespace Step41
               0)
             {
               active_set.add_index(dof_index);
-              constraints.add_line(dof_index);
-              constraints.set_inhomogeneity(dof_index, obstacle_value);
+              constraints.add_constraint(dof_index, {}, obstacle_value);
 
               solution(dof_index) = obstacle_value;
 

--- a/examples/step-46/doc/intro.dox
+++ b/examples/step-46/doc/intro.dox
@@ -494,21 +494,16 @@ for (const auto &cell: dof_handler.active_cell_iterators())
              cell->face(f)->get_dof_indices (local_face_dof_indices, 0);
              for (unsigned int i=0; i<local_face_dof_indices.size(); ++i)
              if (stokes_fe.face_system_to_component_index(i).first < dim)
-               constraints.add_line (local_face_dof_indices[i]);
+               constraints.add_constraint (local_face_dof_indices[i], {}, 0.);
            }
         }
 @endcode
 
-The call <code>constraints.add_line(t)</code> tells the
-AffineConstraints to start a new constraint for degree of freedom
-<code>t</code> of the form $x_t=\sum_{l=0}^{N-1} c_{tl} x_l +
-b_t$. Typically, one would then proceed to set individual coefficients
-$c_{tl}$ to nonzero values (using AffineConstraints::add_entry) or set
-$b_t$ to something nonzero (using
-AffineConstraints::set_inhomogeneity); doing nothing as above, funny as
-it looks, simply leaves the constraint to be $x_t=0$, which is exactly
+The last line calls
+AffineConstraints::add_constraint() and adds the constraint
+<i>x<sub>local_face_dof_indices[i]</sub>=0</i>, which is exactly
 what we need in the current context. The call to
-FiniteElement::face_system_to_component_index makes sure that we only set
+FiniteElement::face_system_to_component_index() makes sure that we only set
 boundary values to zero for velocity but not pressure components.
 
 Note that there are cases where this may yield incorrect results:

--- a/examples/step-46/step-46.cc
+++ b/examples/step-46/step-46.cc
@@ -385,7 +385,9 @@ namespace Step46
                          ++i)
                       if (stokes_fe.face_system_to_component_index(i).first <
                           dim)
-                        constraints.add_line(local_face_dof_indices[i]);
+                        constraints.add_constraint(local_face_dof_indices[i],
+                                                   {},
+                                                   0.);
                   }
               }
     }

--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -246,9 +246,10 @@ namespace internal
                        const size_type index_in_constraint) const;
 
       /**
-       * Return whether there is one row with indirect contributions (i.e.,
-       * there has been at least one constraint with non-trivial
-       * ConstraintLine).
+       * Return whether this object stores a constraint in which one degree
+       * of freedom is constrained against another degree of freedom (as
+       * opposed to having only constraints of the form $x_i=42$ where
+       * no other degree of freedom appears on the right side).
        */
       bool
       have_indirect_rows() const;
@@ -428,14 +429,7 @@ namespace internal
 } // namespace internal
 #endif
 
-// TODO[WB]: We should have a function of the kind
-//   AffineConstraints::add_constraint (const size_type constrained_dof,
-//     const std::vector<std::pair<size_type, number> > &entries,
-//     const number inhomogeneity = 0);
-// rather than building up constraints piecemeal through add_line/add_entry
-// etc. This would also eliminate the possibility of accidentally changing
-// existing constraints into something pointless, see the discussion on the
-// mailing list on "Tiny bug in interpolate_boundary_values" in Sept. 2010.
+
 
 /**
  * This class implements dealing with linear (possibly inhomogeneous)
@@ -759,6 +753,41 @@ public:
    * @name Adding constraints
    * @{
    */
+
+  /**
+   * Add a constraint to this object. This function adds a constraint
+   * of the form
+   * @f[
+   *  x_i = \sum_{j=1}^n w_j x_{k_j} + b
+   * @f]
+   * where $i$ is the number of the degree of freedom to be constrained
+   * and is provided by the @p constrained_dofs argument. The weights
+   * $w_j$ and indices $k_j$ are provided as pairs in the
+   * @p dependencies argument, and the inhomogeneity $b$ is
+   * provided by the last argument.
+   *
+   * As an example, if you want to add the constraint
+   * @f[
+   *   x_{42} = 0.5 x_{12} + 0.5 x_{36} + 27
+   * @f]
+   * you would call this function as follows:
+   * @code
+   *   constraints.add_constraint (42, {{12, 0.5}, {36, 0.5}}, 27.0);
+   * @endcode
+   * On the other hand, if (as one often wants to) you need a constraint
+   * of the kind
+   * @f[
+   *   x_{42} = 27
+   * @f]
+   * you would call this function as follows:
+   * @code
+   *   constraints.add_constraint (42, {}, 27.0);
+   * @endcode
+   */
+  void
+  add_constraint(const size_type constrained_dof,
+                 const std::vector<std::pair<size_type, number>> &dependencies,
+                 const number inhomogeneity = 0);
 
   /**
    * Add a new line to the matrix. If the line already exists, then the
@@ -2200,6 +2229,25 @@ inline AffineConstraints<number>::AffineConstraints(
       affine_constraints.needed_elements_for_distribute)
   , sorted(affine_constraints.sorted)
 {}
+
+
+
+template <typename number>
+inline void
+AffineConstraints<number>::add_constraint(
+  const size_type                                  constrained_dof,
+  const std::vector<std::pair<size_type, number>> &dependencies,
+  const number                                     inhomogeneity)
+{
+  Assert(is_constrained(constrained_dof) == false,
+         ExcMessage("You cannot add a constraint for a degree of freedom "
+                    "that is already constrained."));
+
+  add_line(constrained_dof);
+  for (const auto &dep : dependencies)
+    add_entry(constrained_dof, dep.first, dep.second);
+  set_inhomogeneity(constrained_dof, inhomogeneity);
+}
 
 
 

--- a/include/deal.II/numerics/vector_tools_boundary.templates.h
+++ b/include/deal.II/numerics/vector_tools_boundary.templates.h
@@ -519,11 +519,9 @@ namespace VectorTools
       {
         if (constraints.can_store_line(boundary_value.first) &&
             !constraints.is_constrained(boundary_value.first))
-          {
-            constraints.add_line(boundary_value.first);
-            constraints.set_inhomogeneity(boundary_value.first,
-                                          boundary_value.second);
-          }
+          constraints.add_constraint(boundary_value.first,
+                                     {},
+                                     boundary_value.second);
       }
   }
 
@@ -564,11 +562,9 @@ namespace VectorTools
       {
         if (constraints.can_store_line(boundary_value.first) &&
             !constraints.is_constrained(boundary_value.first))
-          {
-            constraints.add_line(boundary_value.first);
-            constraints.set_inhomogeneity(boundary_value.first,
-                                          boundary_value.second);
-          }
+          constraints.add_constraint(boundary_value.first,
+                                     {},
+                                     boundary_value.second);
       }
   }
 
@@ -955,16 +951,13 @@ namespace VectorTools
     std::map<types::global_dof_index, number> boundary_values;
     project_boundary_values(
       mapping, dof, boundary_functions, q, boundary_values, component_mapping);
-    typename std::map<types::global_dof_index, number>::const_iterator
-      boundary_value = boundary_values.begin();
-    for (; boundary_value != boundary_values.end(); ++boundary_value)
+
+    for (const auto &boundary_value : boundary_values)
       {
-        if (!constraints.is_constrained(boundary_value->first))
-          {
-            constraints.add_line(boundary_value->first);
-            constraints.set_inhomogeneity(boundary_value->first,
-                                          boundary_value->second);
-          }
+        if (!constraints.is_constrained(boundary_value.first))
+          constraints.add_constraint(boundary_value.first,
+                                     {},
+                                     boundary_value.second);
       }
   }
 
@@ -1934,16 +1927,12 @@ namespace VectorTools
                                         face_dof_indices[dof]) &&
                                       !(constraints.is_constrained(
                                         face_dof_indices[dof])))
-                                    {
-                                      constraints.add_line(
-                                        face_dof_indices[dof]);
-                                      if (std::abs(dof_values[dof]) > 1e-13)
-                                        {
-                                          constraints.set_inhomogeneity(
-                                            face_dof_indices[dof],
-                                            dof_values[dof]);
-                                        }
-                                    }
+                                    constraints.add_constraint(
+                                      face_dof_indices[dof],
+                                      {},
+                                      (std::abs(dof_values[dof]) > 1e-13 ?
+                                         dof_values[dof] :
+                                         0));
                                 }
                             }
                         }
@@ -2078,17 +2067,12 @@ namespace VectorTools
                                         face_dof_indices[dof]) &&
                                       !(constraints.is_constrained(
                                         face_dof_indices[dof])))
-                                    {
-                                      constraints.add_line(
-                                        face_dof_indices[dof]);
-
-                                      if (std::abs(dof_values[dof]) > 1e-13)
-                                        {
-                                          constraints.set_inhomogeneity(
-                                            face_dof_indices[dof],
-                                            dof_values[dof]);
-                                        }
-                                    }
+                                    constraints.add_constraint(
+                                      face_dof_indices[dof],
+                                      {},
+                                      (std::abs(dof_values[dof]) > 1e-13 ?
+                                         dof_values[dof] :
+                                         0));
                                 }
                             }
                         }
@@ -2232,12 +2216,11 @@ namespace VectorTools
               cell->face_orientation(face),
               cell->face_flip(face),
               cell->face_rotation(face)))[first_vector_component])
-          {
-            constraints.add_line(face_dof_indices[i]);
-
-            if (std::abs(dof_values(i)) > 1e-14)
-              constraints.set_inhomogeneity(face_dof_indices[i], dof_values(i));
-          }
+          constraints.add_constraint(face_dof_indices[i],
+                                     {},
+                                     (std::abs(dof_values[i]) > 1e-14 ?
+                                        dof_values[i] :
+                                        0));
     }
 
     // dummy implementation of above function for all other dimensions
@@ -2529,12 +2512,11 @@ namespace VectorTools
             for (unsigned int dof = 0; dof < n_dofs; ++dof)
               if ((projected_dofs[dof] != 0) &&
                   !(constraints.is_constrained(dof)))
-                {
-                  constraints.add_line(dof);
-
-                  if (std::abs(dof_values[dof]) > 1e-14)
-                    constraints.set_inhomogeneity(dof, dof_values[dof]);
-                }
+                constraints.add_constraint(dof,
+                                           {},
+                                           (std::abs(dof_values[dof]) > 1e-14 ?
+                                              dof_values[dof] :
+                                              0));
 
             break;
           }
@@ -2688,12 +2670,11 @@ namespace VectorTools
             for (unsigned int dof = 0; dof < n_dofs; ++dof)
               if ((projected_dofs[dof] != 0) &&
                   !(constraints.is_constrained(dof)))
-                {
-                  constraints.add_line(dof);
-
-                  if (std::abs(dof_values[dof]) > 1e-14)
-                    constraints.set_inhomogeneity(dof, dof_values[dof]);
-                }
+                constraints.add_constraint(dof,
+                                           {},
+                                           (std::abs(dof_values[dof]) > 1e-14 ?
+                                              dof_values[dof] :
+                                              0));
 
             break;
           }

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -571,9 +571,9 @@ namespace DoFTools
                 if (std::fabs(face_constraints(row, i)) >= 1e-14 * abs_sum)
                   entries.emplace_back(primary_dofs[i],
                                        face_constraints(row, i));
-              constraints.add_line(dependent_dofs[row]);
-              constraints.add_entries(dependent_dofs[row], entries);
-              constraints.set_inhomogeneity(dependent_dofs[row], 0.);
+              constraints.add_constraint(dependent_dofs[row],
+                                         entries,
+                                         /* inhomogeneity= */ 0.);
             }
       }
 


### PR DESCRIPTION
For a long time, I had wished that `AffineConstraint` had a function to add a whole constraint all at once, rather than doing it via `add_line()`, `add_entry()`, `set_inhomogeneity()`. This has also been mentioned in #334, and it has come up in #15375. This patch implements it.

Rather than write a new test, I decided to just convert a whole bunch of places in functions we use extensively. Also a few of the tutorials.

In the end, I would love to deprecate the three functions mentioned above. I think that interface is just not very good. What do people think about that?