### PR TITLE
Make sure ArrayView of an empty array really is a nullptr.

### DIFF
--- a/include/deal.II/base/array_view.h
+++ b/include/deal.II/base/array_view.h
@@ -110,7 +110,10 @@ public:
    * Constructor.
    *
    * @param[in] starting_element A pointer to the first element of the array
-   * this object should represent.
+   * this object should represent. The value of this argument is only evaluated
+   * if `n_elements` is larger than zero. Otherwise, the value of this
+   * argument is ignored as if the ArrayView object used a `nullptr`
+   * to point to the first element of the array.
    * @param[in] n_elements The length (in elements) of the chunk of memory
    * this object should represent.
    *
@@ -400,7 +403,7 @@ template <typename ElementType, typename MemorySpaceType>
 inline ArrayView<ElementType, MemorySpaceType>::ArrayView(
   value_type       *starting_element,
   const std::size_t n_elements)
-  : starting_element(starting_element)
+  : starting_element(n_elements > 0 ? starting_element : nullptr)
   , n_elements(n_elements)
 {}
 
@@ -411,8 +414,11 @@ inline void
 ArrayView<ElementType, MemorySpaceType>::reinit(value_type *starting_element,
                                                 const std::size_t n_elements)
 {
-  this->starting_element = starting_element;
-  this->n_elements       = n_elements;
+  if (n_elements > 0)
+    this->starting_element = starting_element;
+  else
+    this->starting_element = nullptr;
+  this->n_elements = n_elements;
 }
 
 


### PR DESCRIPTION
When calling `ArrayView` on other container objects, we generally defer to one of the other constructors of the class:
```
template <typename ElementType, typename MemorySpaceType>
inline ArrayView<ElementType, MemorySpaceType>::ArrayView(
  const std::vector<std::remove_cv_t<value_type>> &vector)
  : // use delegating constructor
  ArrayView(vector.data(), vector.size())     // ************
{...}
```
This relies on the fact that `vector.data()` returns `nullptr` if it's an empty vector -- but I'm not sure we should be relying on this. This patch *explicitly* sets the pointer to the first array element to `nullptr` whenever the specified size is zero. In other words, we never examine the first argument (the pointer) if the second argument is zero. That just seems safer to me.