### PR TITLE
Allow creation of an ArrayView from a std::initializer_list.

### DIFF
--- a/doc/news/changes/minor/20231010Bangerth
+++ b/doc/news/changes/minor/20231010Bangerth
@@ -1,0 +1,4 @@
+New: The ArrayView class now has a constructor that allows creation of
+an ArrayView object from a `std::initializer_list`.
+<br>
+(Wolfgang Bangerth, 2023/10/10)

--- a/include/deal.II/base/array_view.h
+++ b/include/deal.II/base/array_view.h
@@ -222,7 +222,7 @@ public:
    * This constructor allows for cases such as where one has a function
    * that takes an ArrayView object:
    * @code
-   *   void f(const ArrayView<int> &a);
+   *   void f(const ArrayView<const int> &a);
    * @endcode
    * and then to call this function with a list of integers:
    * @code
@@ -232,6 +232,12 @@ public:
    * @code
    *   f({});
    * @encode
+   *
+   * @note This constructor only works if the template type is `const`
+   * qualified. That is, you can initialize an `ArrayView<const int>`
+   * object from a `std::initializer_list<int>`, but not an
+   * `ArrayView<int>` object. This is because the elements of initializer
+   * lists are `const`.
    *
    * @note `std::initializer_list` objects are temporary. They are constructed
    * where the compiler finds a brace-enclosed list, and so they only live
@@ -253,8 +259,9 @@ public:
    *   f(a);
    * @endcode
    */
-  ArrayView(const std::initializer_list<std::remove_cv_t<value_type>>
-              &initializer_list);
+  ArrayView(
+    const std::initializer_list<std::remove_cv_t<value_type>> &initializer_list)
+    DEAL_II_CXX20_REQUIRES(std::is_const_v<ElementType>);
 
   /**
    * Reinitialize a view.
@@ -554,6 +561,7 @@ inline ArrayView<ElementType, MemorySpaceType>::ArrayView(
 template <typename ElementType, typename MemorySpaceType>
 inline ArrayView<ElementType, MemorySpaceType>::ArrayView(
   const std::initializer_list<std::remove_cv_t<value_type>> &initializer)
+  DEAL_II_CXX20_REQUIRES(std::is_const_v<ElementType>)
   : // use delegating constructor
   ArrayView((initializer.size() > 0 ? initializer.begin() : nullptr),
             initializer.size())

--- a/include/deal.II/base/array_view.h
+++ b/include/deal.II/base/array_view.h
@@ -217,6 +217,46 @@ public:
   ArrayView(std::array<std::remove_cv_t<value_type>, N> &vector);
 
   /**
+   * A constructor that creates a view of the array that underlies a
+   * [std::initializer_list](https://en.cppreference.com/w/cpp/utility/initializer_list).
+   * This constructor allows for cases such as where one has a function
+   * that takes an ArrayView object:
+   * @code
+   *   void f(const ArrayView<int> &a);
+   * @endcode
+   * and then to call this function with a list of integers:
+   * @code
+   *   f({1,2,3});
+   * @endcode
+   * This also works with an empty list:
+   * @code
+   *   f({});
+   * @encode
+   *
+   * @note `std::initializer_list` objects are temporary. They are constructed
+   * where the compiler finds a brace-enclosed list, and so they only live
+   * for at most the time it takes to execute the current statement. As a
+   * consequence, creating an ArrayView object of such a `std::initializer_list`
+   * also results in a view object that points to valid memory only for as long
+   * as the current statement is executed. You shouldn't expect that the
+   * resulting ArrayView can be used to point to useful memory content past
+   * that point. In other words, while this code...
+   * @code
+   *   std::vector<int> v(10);
+   *   ArrayView<int> a(v);
+   *   f(a);
+   * @endcode
+   * ...works because the array `v` pointed to exists until after the call to
+   * `f()`, the following code will not likely work as expected:
+   * @code
+   *   ArrayView<int> a({1,2,3});
+   *   f(a);
+   * @endcode
+   */
+  ArrayView(const std::initializer_list<std::remove_cv_t<value_type>>
+              &initializer_list);
+
+  /**
    * Reinitialize a view.
    *
    * @param[in] starting_element A pointer to the first element of the array
@@ -507,6 +547,16 @@ inline ArrayView<ElementType, MemorySpaceType>::ArrayView(
   std::array<std::remove_cv_t<value_type>, N> &vector)
   : // use delegating constructor
   ArrayView(vector.data(), vector.size())
+{}
+
+
+
+template <typename ElementType, typename MemorySpaceType>
+inline ArrayView<ElementType, MemorySpaceType>::ArrayView(
+  const std::initializer_list<std::remove_cv_t<value_type>> &initializer)
+  : // use delegating constructor
+  ArrayView((initializer.size() > 0 ? initializer.begin() : nullptr),
+            initializer.size())
 {}
 
 

--- a/include/deal.II/base/array_view.h
+++ b/include/deal.II/base/array_view.h
@@ -563,8 +563,7 @@ inline ArrayView<ElementType, MemorySpaceType>::ArrayView(
   const std::initializer_list<std::remove_cv_t<value_type>> &initializer)
   DEAL_II_CXX20_REQUIRES(std::is_const_v<ElementType>)
   : // use delegating constructor
-  ArrayView((initializer.size() > 0 ? initializer.begin() : nullptr),
-            initializer.size())
+  ArrayView(initializer.begin(), initializer.size())
 {}
 
 

--- a/tests/base/array_view_21.cc
+++ b/tests/base/array_view_21.cc
@@ -1,0 +1,40 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2023 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// test for class ArrayView initialized from a std::initializer_list.
+
+#include <deal.II/base/array_view.h>
+
+#include "../tests.h"
+
+
+void
+test(const ArrayView<const int> &a)
+{
+  deallog << "Size=" << a.size() << std::endl;
+  for (const auto &i : a)
+    deallog << "  " << i << std::endl;
+}
+
+
+int
+main()
+{
+  initlog();
+
+  test({});
+  test({1, 2, 3});
+}

--- a/tests/base/array_view_21.output
+++ b/tests/base/array_view_21.output
@@ -1,0 +1,6 @@
+
+DEAL::Size=0
+DEAL::Size=3
+DEAL::  1
+DEAL::  2
+DEAL::  3


### PR DESCRIPTION
I want to have a function that takes an `ArrayView` as argument, and be able to call that via
```
  f({1,2,3});
```
or
```
  f({});
```
Here, the compiler creates a `std::initializer_list` out of the brace-enclosed thing, so we need a way to initialize array views from initializer lists.