### PR TITLE
Make an assertion text more informative.

### DIFF
--- a/source/grid/tria_description.cc
+++ b/source/grid/tria_description.cc
@@ -171,7 +171,7 @@ namespace TriangulationDescription
               std::map<unsigned int, unsigned int>
                 map_old_to_new_local_vertex_index;
 
-              // 1) renumerate vertices in other and insert into maps
+              // 1) re-enumerate vertices in other and insert into maps
               unsigned int counter = coarse_cell_vertices.size();
               for (const auto &p : other.coarse_cell_vertices)
                 if (map_point_to_local_vertex_index.find(p.second) ==
@@ -185,7 +185,7 @@ namespace TriangulationDescription
                   map_old_to_new_local_vertex_index[p.first] =
                     map_point_to_local_vertex_index[p.second];
 
-              // 2) renumerate vertices of cells
+              // 2) re-enumerate vertices of cells
               auto other_coarse_cells_copy = other.coarse_cells;
 
               for (auto &cell : other_coarse_cells_copy)
@@ -283,7 +283,14 @@ namespace TriangulationDescription
                       Assert(a.second.distance(b.second) <=
                                1e-7 *
                                  std::max(a.second.norm(), b.second.norm()),
-                             ExcInternalError());
+                             ExcMessage(
+                               "In the process of merging the vertices of "
+                               "the coarse meshes used on different processes, "
+                               "there were two processes that used the same "
+                               "vertex index for points that are not the same. "
+                               "This suggests that you are using different "
+                               "coarse meshes on different processes. This "
+                               "should not happen."));
                       return true;
                     }
                   return false;


### PR DESCRIPTION
I have spent a good amount puzzling what exactly is going wrong with one of the tests (`fullydistributed_grids/repartitioning_01.mpirun=4.debug`) on the branch for #15689. The patch clarifies the exception we get for the test.

@peterrum Underlying the issue is that the code that builds the `TriangulationDescription` assumes that different processes use the same vertex indices for the vertices on the coarse mesh. This is true at the moment on `master` because vertex numbers for the coarse mesh never change. But it is not true any more on the branch, and so we get this assertion. I don't know the code that builds the `TriangulationDescription` well, so let me ask here whether you see the right place right away to work around this? Currently, the branch is failing in this piece of code:
```
        /**
         * Remove all duplicate information obtained during merge().
         */
        void
        reduce()
        {
          // make coarse cells unique
          {
            std::vector<std::tuple<types::coarse_cell_id,
                                   dealii::CellData<dim>,
                                   unsigned int>>
              temp;

            for (unsigned int i = 0; i < this->coarse_cells.size(); ++i)
              temp.emplace_back(this->coarse_cell_index_to_coarse_cell_id[i],
                                this->coarse_cells[i],
                                i);

            std::sort(temp.begin(),
                      temp.end(),
                      [](const auto &a, const auto &b) {
                        return std::get<0>(a) < std::get<0>(b);
                      });
            temp.erase(std::unique(temp.begin(),
                                   temp.end(),
                                   [](const auto &a, const auto &b) {
                                     return std::get<0>(a) == std::get<0>(b);
                                   }),
                       temp.end());
            std::sort(temp.begin(),
                      temp.end(),
                      [](const auto &a, const auto &b) {
                        return std::get<2>(a) < std::get<2>(b);
                      });

            this->coarse_cell_index_to_coarse_cell_id.resize(temp.size());
            this->coarse_cells.resize(temp.size());

            for (unsigned int i = 0; i < temp.size(); ++i)
              {
                this->coarse_cell_index_to_coarse_cell_id[i] =
                  std::get<0>(temp[i]);
                this->coarse_cells[i] = std::get<1>(temp[i]);
              }
          }

          // make coarse cell vertices unique
          {
            std::sort(this->coarse_cell_vertices.begin(),
                      this->coarse_cell_vertices.end(),
                      [](const std::pair<unsigned int, Point<spacedim>> &a,
                         const std::pair<unsigned int, Point<spacedim>> &b) {
                        return a.first < b.first;
                      });
            this->coarse_cell_vertices.erase(
              std::unique(
                this->coarse_cell_vertices.begin(),
                this->coarse_cell_vertices.end(),
                [](const std::pair<unsigned int, Point<spacedim>> &a,
                   const std::pair<unsigned int, Point<spacedim>> &b) {
                  if (a.first == b.first)
                    {
                      Assert(a.second.distance(b.second) <=                                   // ************* We fail here
                               1e-7 *
                                 std::max(a.second.norm(), b.second.norm()),
                             ExcMessage(
                               "In the process of merging the vertices of "
                               "the coarse meshes used on different processes, "
                               "there were two processes that used the same "
                               "vertex index for points that are not the same. "
                               "This suggests that you are using different "
                               "coarse meshes on different processes. This "
                               "should not happen."));
                      return true;
                    }
                  return false;
                }),
              this->coarse_cell_vertices.end());
          }
```
We fail in the marked assertion because we end up with a merged list of vertices from the different processes in which the same vertex index is now associated with different locations because processes no longer agree on which index to use for the same vertex. 