### PR TITLE
AffineConstraints: Use more efficient function in add_constraint

### DIFF
--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -2305,8 +2305,7 @@ AffineConstraints<number>::add_constraint(
                     "that is already constrained."));
 
   add_line(constrained_dof);
-  for (const auto &dep : dependencies)
-    add_entry(constrained_dof, dep.first, dep.second);
+  add_entries(constrained_dof, dependencies);
   set_inhomogeneity(constrained_dof, inhomogeneity);
 }
 


### PR DESCRIPTION
As indicated in https://github.com/dealii/dealii/pull/16103#discussion_r1354303955, we should use a compound function to add all entries, not manually loop through it. Locally, it fixes some of the performance problems I observed and posted in #16121, but we need to look at the performance tester before we can close the issue.