### PR TITLE
Demote an assertion from AssertThrow to Assert.

### DIFF
--- a/source/particles/property_pool.cc
+++ b/source/particles/property_pool.cc
@@ -53,13 +53,13 @@ namespace Particles
         const unsigned int n_open_handles =
           properties.size() / n_properties - currently_available_handles.size();
         (void)n_open_handles;
-        AssertThrow(n_open_handles == 0,
-                    ExcMessage("This property pool currently still holds " +
-                               std::to_string(n_open_handles) +
-                               " open handles to memory that was allocated "
-                               "via allocate_properties_array() but that has "
-                               "not been returned via "
-                               "deregister_particle()."));
+        Assert(n_open_handles == 0,
+               ExcMessage("This property pool currently still holds " +
+                          std::to_string(n_open_handles) +
+                          " open handles to memory that was allocated "
+                          "via allocate_properties_array() but that has "
+                          "not been returned via "
+                          "deregister_particle()."));
       }
 
     // Clear vectors and ensure deallocation of memory


### PR DESCRIPTION
In ASPECT, we have a user who ran into an issue where we are perhaps running out of memory, the propagating exception then starts to destroy the objects on the call stack, and one of those is a `ParticleHandler` object that in its destructor calls `PropertyPool::clear()`. But that latter function can throw an exception (and does in that case) and that leads to nothing good because throwing exceptions in destructors is not allowed.

So I demote the `AssertThrow` in `clear()` to an `Assert`. I think that should be safe, pending particles is almost certainly a programming error rather than a run-time error.