### PR TITLE
AffineConstraints::close(): Replace divisions by multiplication with reciprocal

### DIFF
--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -1030,11 +1030,13 @@ AffineConstraints<number>::close()
           number sum = 0.;
           for (const std::pair<size_type, number> &entry : line.entries)
             sum += entry.second;
-          if (std::abs(sum - number(1.)) < 1.e-13)
+          if (std::abs(sum - number(1.)) < 1.e-13 &&
+              std::abs(sum - number(1.)) > 0.)
             {
+              const number inverse_sum = number(1.) / sum;
               for (std::pair<size_type, number> &entry : line.entries)
-                entry.second /= sum;
-              line.inhomogeneity /= sum;
+                entry.second *= inverse_sum;
+              line.inhomogeneity *= inverse_sum;
             }
         }
     },


### PR DESCRIPTION
Observed while working on #16132: We divide by the same number many times. As divisions are considerably more expensive than multiplications, compute the reciprocal once. Furthermore, in case we happen to hit `1.0` exactly (which is more common than one would think, low polynomial degrees get that), we do not need to normalize.