### PR TITLE
Use AffineConstraints::add_constraint() throughout.

### DIFF
--- a/examples/step-16/step-16.cc
+++ b/examples/step-16/step-16.cc
@@ -436,10 +436,13 @@ namespace Step16
         boundary_constraints[level].reinit(
           dof_handler.locally_owned_mg_dofs(level),
           DoFTools::extract_locally_relevant_level_dofs(dof_handler, level));
-        boundary_constraints[level].add_lines(
-          mg_constrained_dofs.get_refinement_edge_indices(level));
-        boundary_constraints[level].add_lines(
-          mg_constrained_dofs.get_boundary_indices(level));
+
+        for (const types::global_dof_index dof_index :
+             mg_constrained_dofs.get_refinement_edge_indices(level))
+          boundary_constraints[level].add_constraint(dof_index, {}, 0.);
+        for (const types::global_dof_index dof_index :
+             mg_constrained_dofs.get_boundary_indices(level))
+          boundary_constraints[level].add_constraint(dof_index, {}, 0.);
         boundary_constraints[level].close();
       }
 

--- a/examples/step-37/step-37.cc
+++ b/examples/step-37/step-37.cc
@@ -852,8 +852,9 @@ namespace Step37
           AffineConstraints<double> level_constraints(
             dof_handler.locally_owned_mg_dofs(level),
             DoFTools::extract_locally_relevant_level_dofs(dof_handler, level));
-          level_constraints.add_lines(
-            mg_constrained_dofs.get_boundary_indices(level));
+          for (const types::global_dof_index dof_index :
+               mg_constrained_dofs.get_boundary_indices(level))
+            level_constraints.add_constraint(dof_index, {}, 0.);
           level_constraints.close();
 
           typename MatrixFree<dim, float>::AdditionalData additional_data;

--- a/examples/step-42/step-42.cc
+++ b/examples/step-42/step-42.cc
@@ -1275,9 +1275,9 @@ namespace Step42
                            0) &&
                           !constraints_hanging_nodes.is_constrained(index_z))
                         {
-                          all_constraints.add_line(index_z);
-                          all_constraints.set_inhomogeneity(index_z,
-                                                            undeformed_gap);
+                          all_constraints.add_constraint(index_z,
+                                                         {},
+                                                         undeformed_gap);
                           distributed_solution(index_z) = undeformed_gap;
 
                           active_set.add_index(index_z);

--- a/examples/step-50/step-50.cc
+++ b/examples/step-50/step-50.cc
@@ -596,8 +596,9 @@ void LaplaceProblem<dim, degree>::setup_multigrid()
                 dof_handler.locally_owned_mg_dofs(level),
                 DoFTools::extract_locally_relevant_level_dofs(dof_handler,
                                                               level));
-              level_constraints.add_lines(
-                mg_constrained_dofs.get_boundary_indices(level));
+              for (const types::global_dof_index dof_index :
+                   mg_constrained_dofs.get_boundary_indices(level))
+                level_constraints.add_constraint(dof_index, {}, 0.);
               level_constraints.close();
 
               typename MatrixFree<dim, float>::AdditionalData additional_data;
@@ -826,11 +827,13 @@ void LaplaceProblem<dim, degree>::assemble_multigrid()
       boundary_constraints[level].reinit(
         dof_handler.locally_owned_mg_dofs(level),
         DoFTools::extract_locally_relevant_level_dofs(dof_handler, level));
-      boundary_constraints[level].add_lines(
-        mg_constrained_dofs.get_refinement_edge_indices(level));
-      boundary_constraints[level].add_lines(
-        mg_constrained_dofs.get_boundary_indices(level));
 
+      for (const types::global_dof_index dof_index :
+           mg_constrained_dofs.get_refinement_edge_indices(level))
+        boundary_constraints[level].add_constraint(dof_index, {}, 0.);
+      for (const types::global_dof_index dof_index :
+           mg_constrained_dofs.get_boundary_indices(level))
+        boundary_constraints[level].add_constraint(dof_index, {}, 0.);
       boundary_constraints[level].close();
     }
 

--- a/examples/step-56/step-56.cc
+++ b/examples/step-56/step-56.cc
@@ -572,7 +572,7 @@ namespace Step56
       // this here by marking the first pressure dof, which has index n_u as a
       // constrained dof.
       if (solver_type == SolverType::UMFPACK)
-        constraints.add_line(n_u);
+        constraints.add_constraint(n_u, {}, 0.);
 
       constraints.close();
     }
@@ -732,16 +732,22 @@ namespace Step56
       triangulation.n_levels());
     for (unsigned int level = 0; level < triangulation.n_levels(); ++level)
       {
-        boundary_constraints[level].add_lines(
-          mg_constrained_dofs.get_refinement_edge_indices(level));
-        boundary_constraints[level].add_lines(
-          mg_constrained_dofs.get_boundary_indices(level));
+        for (const types::global_dof_index dof_index :
+             mg_constrained_dofs.get_refinement_edge_indices(level))
+          boundary_constraints[level].add_constraint(dof_index, {}, 0.);
+        for (const types::global_dof_index dof_index :
+             mg_constrained_dofs.get_boundary_indices(level))
+          boundary_constraints[level].add_constraint(dof_index, {}, 0.);
         boundary_constraints[level].close();
 
-        IndexSet idx = mg_constrained_dofs.get_refinement_edge_indices(level) &
-                       mg_constrained_dofs.get_boundary_indices(level);
+        const IndexSet idx =
+          mg_constrained_dofs.get_refinement_edge_indices(level) &
+          mg_constrained_dofs.get_boundary_indices(level);
 
-        boundary_interface_constraints[level].add_lines(idx);
+        for (const types::global_dof_index dof_index : idx)
+          boundary_interface_constraints[level].add_constraint(dof_index,
+                                                               {},
+                                                               0.);
         boundary_interface_constraints[level].close();
       }
 

--- a/examples/step-63/step-63.cc
+++ b/examples/step-63/step-63.cc
@@ -817,10 +817,13 @@ namespace Step63
         boundary_constraints[level].reinit(
           dof_handler.locally_owned_mg_dofs(level),
           DoFTools::extract_locally_relevant_level_dofs(dof_handler, level));
-        boundary_constraints[level].add_lines(
-          mg_constrained_dofs.get_refinement_edge_indices(level));
-        boundary_constraints[level].add_lines(
-          mg_constrained_dofs.get_boundary_indices(level));
+
+        for (const types::global_dof_index dof_index :
+             mg_constrained_dofs.get_refinement_edge_indices(level))
+          boundary_constraints[level].add_constraint(dof_index, {}, 0.);
+        for (const types::global_dof_index dof_index :
+             mg_constrained_dofs.get_boundary_indices(level))
+          boundary_constraints[level].add_constraint(dof_index, {}, 0.);
         boundary_constraints[level].close();
       }
 

--- a/examples/step-66/step-66.cc
+++ b/examples/step-66/step-66.cc
@@ -593,8 +593,10 @@ namespace Step66
         AffineConstraints<double> level_constraints(
           dof_handler.locally_owned_mg_dofs(level),
           DoFTools::extract_locally_relevant_level_dofs(dof_handler, level));
-        level_constraints.add_lines(
-          mg_constrained_dofs.get_boundary_indices(level));
+
+        for (const types::global_dof_index dof_index :
+             mg_constrained_dofs.get_boundary_indices(level))
+          level_constraints.add_constraint(dof_index, {}, 0.);
         level_constraints.close();
 
         typename MatrixFree<dim, float>::AdditionalData additional_data;

--- a/examples/step-79/step-79.cc
+++ b/examples/step-79/step-79.cc
@@ -536,13 +536,16 @@ namespace SAND
     types::global_dof_index last_density_dof =
       density_dofs.nth_index_in_set(density_dofs.n_elements() - 1);
     constraints.clear();
-    constraints.add_line(last_density_dof);
-    for (unsigned int i = 0; i < density_dofs.n_elements() - 1; ++i)
-      constraints.add_entry(last_density_dof,
-                            density_dofs.nth_index_in_set(i),
-                            -1);
-    constraints.set_inhomogeneity(last_density_dof, 0);
+    {
+      std::vector<std::pair<types::global_dof_index, double>>
+        constraint_entries;
+      constraint_entries.reserve(density_dofs.n_elements() - 1);
+      for (const types::global_dof_index dof_index : density_dofs)
+        if (dof_index != last_density_dof)
+          constraint_entries.emplace_back(dof_index, -1.);
 
+      constraints.add_constraint(last_density_dof, constraint_entries, 0.);
+    }
     constraints.close();
 
     // We can now finally create the sparsity pattern for the

--- a/include/deal.II/multigrid/mg_constrained_dofs.h
+++ b/include/deal.II/multigrid/mg_constrained_dofs.h
@@ -356,8 +356,9 @@ MGConstrainedDoFs::initialize(
                       !level_constraints[l].is_constrained(dofs_2[i]) &&
                       !level_constraints[l].is_constrained(dofs_1[i]))
                     {
-                      level_constraints[l].add_line(dofs_2[i]);
-                      level_constraints[l].add_entry(dofs_2[i], dofs_1[i], 1.);
+                      level_constraints[l].add_constraint(dofs_2[i],
+                                                          {{dofs_1[i], 1.}},
+                                                          0.);
                     }
               }
       level_constraints[l].close();
@@ -624,10 +625,12 @@ MGConstrainedDoFs::merge_constraints(AffineConstraints<Number> &constraints,
 
   // merge constraints
   if (add_boundary_indices && this->have_boundary_indices())
-    constraints.add_lines(this->get_boundary_indices(level));
+    for (const auto i : this->get_boundary_indices(level))
+      constraints.add_constraint(i, {}, 0.);
 
   if (add_refinement_edge_indices)
-    constraints.add_lines(this->get_refinement_edge_indices(level));
+    for (const auto i : this->get_refinement_edge_indices(level))
+      constraints.add_constraint(i, {}, 0.);
 
   if (add_level_constraints)
     constraints.merge(this->get_level_constraints(level),

--- a/include/deal.II/numerics/vector_tools_constraints.templates.h
+++ b/include/deal.II/numerics/vector_tools_constraints.templates.h
@@ -242,15 +242,17 @@ namespace VectorTools
                                     constraining_vector[0]) >
                           std::numeric_limits<double>::epsilon())
                         constraint_entries.emplace_back(
-                          dof_indices.dof_indices[1],
-                          -constraining_vector[1] / constraining_vector[0]);
+                          std::make_pair(dof_indices.dof_indices[1],
+                                         -constraining_vector[1] /
+                                           constraining_vector[0]));
 
                       if (std::fabs(constraining_vector[2] /
                                     constraining_vector[0]) >
                           std::numeric_limits<double>::epsilon())
                         constraint_entries.emplace_back(
-                          dof_indices.dof_indices[2],
-                          -constraining_vector[2] / constraining_vector[0]);
+                          std::make_pair(dof_indices.dof_indices[2],
+                                         -constraining_vector[2] /
+                                           constraining_vector[0]));
 
                       const double normalized_inhomogeneity =
                         (std::fabs(inhomogeneity / constraining_vector[0]) >
@@ -275,15 +277,17 @@ namespace VectorTools
                                     constraining_vector[1]) >
                           std::numeric_limits<double>::epsilon())
                         constraint_entries.emplace_back(
-                          dof_indices.dof_indices[0],
-                          -constraining_vector[0] / constraining_vector[1]);
+                          std::make_pair(dof_indices.dof_indices[0],
+                                         -constraining_vector[0] /
+                                           constraining_vector[1]));
 
                       if (std::fabs(constraining_vector[2] /
                                     constraining_vector[1]) >
                           std::numeric_limits<double>::epsilon())
                         constraint_entries.emplace_back(
-                          dof_indices.dof_indices[2],
-                          -constraining_vector[2] / constraining_vector[1]);
+                          std::make_pair(dof_indices.dof_indices[2],
+                                         -constraining_vector[2] /
+                                           constraining_vector[1]));
 
                       const double normalized_inhomogeneity =
                         (std::fabs(inhomogeneity / constraining_vector[1]) >
@@ -305,15 +309,17 @@ namespace VectorTools
                                     constraining_vector[2]) >
                           std::numeric_limits<double>::epsilon())
                         constraint_entries.emplace_back(
-                          dof_indices.dof_indices[0],
-                          -constraining_vector[0] / constraining_vector[2]);
+                          std::make_pair(dof_indices.dof_indices[0],
+                                         -constraining_vector[0] /
+                                           constraining_vector[2]));
 
                       if (std::fabs(constraining_vector[1] /
                                     constraining_vector[2]) >
                           std::numeric_limits<double>::epsilon())
                         constraint_entries.emplace_back(
-                          dof_indices.dof_indices[1],
-                          -constraining_vector[1] / constraining_vector[2]);
+                          std::make_pair(dof_indices.dof_indices[1],
+                                         -constraining_vector[1] /
+                                           constraining_vector[2]));
 
                       const double normalized_inhomogeneity =
                         (std::fabs(inhomogeneity / constraining_vector[2]) >

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -2297,9 +2297,9 @@ namespace GridTools
             if (map_iter != map_end)
               for (unsigned int i = 0; i < dim; ++i)
                 {
-                  constraints[i].add_line(cell->vertex_dof_index(vertex_no, 0));
-                  constraints[i].set_inhomogeneity(
+                  constraints[i].add_constraint(
                     cell->vertex_dof_index(vertex_no, 0),
+                    {},
                     (solve_for_absolute_positions ?
                        map_iter->second(i) :
                        map_iter->second(i) - vertex_point[i]));

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -2281,11 +2281,13 @@ namespace GridTools
     typename std::map<unsigned int, Point<dim>>::const_iterator map_end =
       new_points.end();
 
-    // fill these maps using the data given by new_points
+    // Fill these maps using the data given by new_points
     for (const auto &cell : dof_handler.active_cell_iterators())
       {
-        // loop over all vertices of the cell and see if it is listed in the map
-        // given as first argument of the function
+        // Loop over all vertices of the cell and see if it is listed in the map
+        // given as first argument of the function. We visit vertices multiple
+        // times, so also check that if we have already added a constraint, we
+        // don't do it a second time again.
         for (const unsigned int vertex_no : cell->vertex_indices())
           {
             const unsigned int vertex_index = cell->vertex_index(vertex_no);
@@ -2296,14 +2298,16 @@ namespace GridTools
 
             if (map_iter != map_end)
               for (unsigned int i = 0; i < dim; ++i)
-                {
-                  constraints[i].add_constraint(
-                    cell->vertex_dof_index(vertex_no, 0),
-                    {},
-                    (solve_for_absolute_positions ?
-                       map_iter->second(i) :
-                       map_iter->second(i) - vertex_point[i]));
-                }
+                if (constraints[i].is_constrained(
+                      cell->vertex_dof_index(vertex_no, 0)) == false)
+                  {
+                    constraints[i].add_constraint(
+                      cell->vertex_dof_index(vertex_no, 0),
+                      {},
+                      (solve_for_absolute_positions ?
+                         map_iter->second(i) :
+                         map_iter->second(i) - vertex_point[i]));
+                  }
           }
       }
 


### PR DESCRIPTION
This patch replaces the `add_line()`, `add_entry/entries()`, and `set_inhomogeneity()` calls by `add_constraints() as introduced in #16103 .

There remain a number of places in the test suite where I will have to fix things before the old functions can be deprecated.

Related to #15375.