### PR TITLE
Make IndexSet compatible with Teuchos::RCP<Tpetra::Map>>

### DIFF
--- a/doc/news/changes/minor/20231017SebastianKinnewig
+++ b/doc/news/changes/minor/20231017SebastianKinnewig
@@ -1,0 +1,6 @@
+New: New constructor for IndexSet that takes a 
+Teuchos::RCP<Tpetra::Map> as input. And the 
+function IndexSet::make_tpetra_map_rcp() 
+returning a Teuchos::RCP<Tpetra::Map>.
+<br>
+(Sebastian Kinnewig, 2023/10/17)

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -131,11 +131,20 @@ public:
   operator=(IndexSet &&is) noexcept;
 
 #ifdef DEAL_II_WITH_TRILINOS
+
+#  ifdef DEAL_II_TRILINOS_WITH_TPETRA
+  /**
+   * Constructor from a Trilinos Teuchos::RCP<Tpetra::Map>.
+   */
+  explicit IndexSet(
+    Teuchos::RCP<const Tpetra::Map<int, types::signed_global_dof_index>> map);
+#  endif // DEAL_II_TRILINOS_WITH_TPETRA
+
   /**
    * Constructor from a Trilinos Epetra_BlockMap.
    */
   explicit IndexSet(const Epetra_BlockMap &map);
-#endif
+#endif // DEAL_II_WITH_TRILINOS
 
   /**
    * Remove all indices from this index set. The index set retains its size,
@@ -596,6 +605,10 @@ public:
   Tpetra::Map<int, types::signed_global_dof_index>
   make_tpetra_map(const MPI_Comm communicator = MPI_COMM_WORLD,
                   const bool     overlapping  = false) const;
+
+  Teuchos::RCP<Tpetra::Map<int, types::signed_global_dof_index>>
+  make_tpetra_map_rcp(const MPI_Comm communicator = MPI_COMM_WORLD,
+                      const bool     overlapping  = false) const;
 #  endif
 #endif
 

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -72,8 +72,7 @@ namespace LinearAlgebra
                            const MPI_Comm  communicator)
       : Subscriptor()
       , vector(new Tpetra::Vector<Number, int, types::signed_global_dof_index>(
-          Teuchos::rcp(new Tpetra::Map<int, types::signed_global_dof_index>(
-            parallel_partitioner.make_tpetra_map(communicator, false)))))
+          parallel_partitioner.make_tpetra_map_rcp(communicator, false)))
     {}
 
 
@@ -84,13 +83,12 @@ namespace LinearAlgebra
                            const MPI_Comm  communicator,
                            const bool      omit_zeroing_entries)
     {
-      Tpetra::Map<int, types::signed_global_dof_index> input_map =
-        parallel_partitioner.make_tpetra_map(communicator, false);
-      if (vector->getMap()->isSameAs(input_map) == false)
+      Teuchos::RCP<Tpetra::Map<int, types::signed_global_dof_index>> input_map =
+        parallel_partitioner.make_tpetra_map_rcp(communicator, false);
+      if (vector->getMap()->isSameAs(*input_map) == false)
         vector = std::make_unique<
           Tpetra::Vector<Number, int, types::signed_global_dof_index>>(
-          Teuchos::rcp(
-            new Tpetra::Map<int, types::signed_global_dof_index>(input_map)));
+          input_map);
       else if (omit_zeroing_entries == false)
         {
           vector->putScalar(0.);

--- a/source/lac/trilinos_tpetra_communication_pattern.cc
+++ b/source/lac/trilinos_tpetra_communication_pattern.cc
@@ -52,11 +52,9 @@ namespace LinearAlgebra
       comm = std::make_shared<const MPI_Comm>(communicator);
 
       auto vector_space_vector_map =
-        Teuchos::rcp(new Tpetra::Map<int, types::signed_global_dof_index>(
-          locally_owned_indices.make_tpetra_map(*comm, false)));
+        locally_owned_indices.make_tpetra_map_rcp(*comm, false);
       auto read_write_vector_map =
-        Teuchos::rcp(new Tpetra::Map<int, types::signed_global_dof_index>(
-          ghost_indices.make_tpetra_map(*comm, true)));
+        ghost_indices.make_tpetra_map_rcp(*comm, true);
 
       // Target map is read_write_vector_map
       // Source map is vector_space_vector_map. This map must have uniquely


### PR DESCRIPTION
Adding a constructor for the `IndexSet` class that takes a `Teuchos::RCP<Tpetra::Map>` as input. Furthermore, let `IndexSet::make_tpetra_map` return a `Teuchos::RCP<Tpetra::Map>` (instead of `Tpetra::Map`).

Some more background: As mentioned in pull request #16052, I am working on a Tpetra interface for deal.II. This pull request is some first preparation for the Tpetra interface.