### PR TITLE
Check for the Trilinos version when calling getLocalNumElements.

### DIFF
--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -57,7 +57,11 @@ IndexSet::IndexSet(
               size_type(map->getMaxGlobalIndex() + 1));
   else
     {
+#    if DEAL_II_TRILINOS_VERSION_GTE(13, 4, 0)
       const size_type n_indices = map->getLocalNumElements();
+#    else
+      const size_type n_indices = map->getNodeNumElements();
+#    endif
       const types::signed_global_dof_index *indices =
         map->getMyGlobalIndices().data();
       add_indices(indices, indices + n_indices);


### PR DESCRIPTION
Fix the issue introduced by pull request #16153, which was noticed in regression test #16158.

With the change from Trilinos version 13.2 to Trilinos version 13.4, the function `getLocalNumElements` was renamed to `getNodeNumElements`.

Therefore, one must check for the Trilinos version when calling this function.