### PR TITLE
Copy periodic faces when copying triangulation

### DIFF
--- a/doc/news/changes/minor/20231019PrietoSaavedraMunch
+++ b/doc/news/changes/minor/20231019PrietoSaavedraMunch
@@ -1,0 +1,4 @@
+Fixed: The periodic faces information was not being copied
+when using the `Triangulation::copy_triangulation()` function. This is now fixed.
+<br>
+(Laura Prieto Saavedra, Peter Munch, 2023/10/19)

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -12520,6 +12520,34 @@ void Triangulation<dim, spacedim>::copy_triangulation(
   if (other_tria.policy)
     this->policy = other_tria.policy->clone();
 
+  // periodic faces
+  this->periodic_face_pairs_level_0.reserve(
+    other_tria.periodic_face_pairs_level_0.size());
+
+  for (auto entry : other_tria.periodic_face_pairs_level_0)
+    {
+      entry.cell[0] =
+        cell_iterator(this, entry.cell[0]->level(), entry.cell[0]->index());
+      entry.cell[1] =
+        cell_iterator(this, entry.cell[1]->level(), entry.cell[1]->index());
+      periodic_face_pairs_level_0.emplace_back(entry);
+    }
+
+  for (auto [first_cell_, second_cell_and_orientation] :
+       other_tria.periodic_face_map)
+    {
+      auto first_cell  = first_cell_; // make copy since key is const
+      first_cell.first = cell_iterator(this,
+                                       first_cell.first->level(),
+                                       first_cell.first->index());
+      second_cell_and_orientation.first.first =
+        cell_iterator(this,
+                      second_cell_and_orientation.first.first->level(),
+                      second_cell_and_orientation.first.first->index());
+
+      this->periodic_face_map[first_cell] = second_cell_and_orientation;
+    }
+
   // inform those who are listening on other_tria of the copy operation
   other_tria.signals.copy(*this);
   // also inform all listeners of the current triangulation that the

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -12524,8 +12524,9 @@ void Triangulation<dim, spacedim>::copy_triangulation(
   this->periodic_face_pairs_level_0.reserve(
     other_tria.periodic_face_pairs_level_0.size());
 
-  for (auto entry : other_tria.periodic_face_pairs_level_0)
+  for (const auto &other_entry : other_tria.periodic_face_pairs_level_0)
     {
+      auto entry = other_entry;
       entry.cell[0] =
         cell_iterator(this, entry.cell[0]->level(), entry.cell[0]->index());
       entry.cell[1] =

--- a/tests/grid/copy_triangulation_pbc.cc
+++ b/tests/grid/copy_triangulation_pbc.cc
@@ -1,0 +1,75 @@
+/* ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2023 by the deal.II authors
+ *
+ * This file is part of the deal.II library.
+ *
+ * The deal.II library is free software; you can use it, redistribute
+ * it, and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * The full text of the license can be found in the file LICENSE.md at
+ * the top level directory of deal.II.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * Test that when copy_triangulation is used also the information about
+ * periodic faces is copied.
+ */
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/tria.h>
+
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  const unsigned int dim           = 2;
+  const unsigned int n_components  = 1;
+  const unsigned int n_refinements = 1;
+
+  Triangulation<dim> tria;
+  GridGenerator::hyper_cube(tria, 0, 1, true);
+
+  std::vector<
+    GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
+    periodic_faces;
+
+  GridTools::collect_periodic_faces(tria, 0, 1, 0, periodic_faces);
+
+  tria.add_periodicity(periodic_faces);
+  tria.refine_global(n_refinements);
+
+  DoFHandler<dim> dof_handler(tria);
+  dof_handler.distribute_dofs(FESystem<dim>(FE_Q<dim>(1), n_components));
+
+  deallog << "Tria:" << std::endl;
+  for (const auto &elem : tria.get_periodic_face_map())
+    {
+      deallog << elem.first.first << " " << elem.first.second << " "
+              << elem.second.first.first << " " << elem.second.first.second
+              << std::endl;
+    }
+
+  Triangulation<dim> other_tria;
+  other_tria.copy_triangulation(tria);
+
+  deallog << "Copy of tria:" << std::endl;
+  for (const auto &elem : other_tria.get_periodic_face_map())
+    {
+      deallog << elem.first.first << " " << elem.first.second << " "
+              << elem.second.first.first << " " << elem.second.first.second
+              << std::endl;
+    }
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/grid/copy_triangulation_pbc.output
+++ b/tests/grid/copy_triangulation_pbc.output
@@ -1,0 +1,16 @@
+
+DEAL::Tria:
+DEAL::0.0 0 0.0 1 
+DEAL::0.0 1 0.0 0 
+DEAL::1.0 0 1.1 1 
+DEAL::1.1 1 1.0 0 
+DEAL::1.2 0 1.3 1 
+DEAL::1.3 1 1.2 0 
+DEAL::Copy of tria:
+DEAL::0.0 0 0.0 1 
+DEAL::0.0 1 0.0 0 
+DEAL::1.0 0 1.1 1 
+DEAL::1.1 1 1.0 0 
+DEAL::1.2 0 1.3 1 
+DEAL::1.3 1 1.2 0
+DEAL::OK


### PR DESCRIPTION
The periodic faces information was not being copied when the `copy_triangulation` function was used. This PR fixes this issue and adds a small test to verify. 