### PR TITLE
Use std::any instead of boost::any.

### DIFF
--- a/include/deal.II/numerics/data_postprocessor.h
+++ b/include/deal.II/numerics/data_postprocessor.h
@@ -32,8 +32,7 @@
 
 #include <deal.II/numerics/data_component_interpretation.h>
 
-#include <boost/any.hpp>
-
+#include <any>
 #include <string>
 #include <vector>
 
@@ -94,7 +93,7 @@ namespace DataPostprocessorInputs
    * is obvious.
    *
    * To make the cell iterator accessible nevertheless, this class uses
-   * an object of type boost::any to store the cell iterator. You can
+   * an object of type std::any to store the cell iterator. You can
    * think of this as being a void pointer that can point to anything.
    * To use what is being used therefore requires the user to know the
    * data type of the thing being pointed to.
@@ -290,11 +289,11 @@ namespace DataPostprocessorInputs
     /**
      * The place where set_cell() stores the cell. Since the actual data
      * type of the cell iterator can be many different things, the
-     * interface uses boost::any here. This makes assignment in set_cell()
+     * interface uses std::any here. This makes assignment in set_cell()
      * simple, but requires knowing the data type of the stored object in
      * get_cell().
      */
-    boost::any cell;
+    std::any cell;
 
     /**
      * The place where set_cell_and_face() stores the number of the face
@@ -1371,14 +1370,14 @@ namespace DataPostprocessorInputs
   {
     // see if we had previously already stored a cell that has the same
     // data type; if so, reuse the memory location and avoid calling 'new'
-    // inside boost::any
+    // inside std::any
     if (typename DoFHandler<dim, spacedim>::cell_iterator *storage_location =
-          boost::any_cast<typename DoFHandler<dim, spacedim>::cell_iterator>(
+          std::any_cast<typename DoFHandler<dim, spacedim>::cell_iterator>(
             &cell))
       *storage_location = new_cell;
     else
       // if we had nothing stored before, or if we had stored a different
-      // data type, just let boost::any replace things
+      // data type, just let std::any replace things
       cell = new_cell;
 
     // Also reset the face number, just to make sure nobody
@@ -1406,12 +1405,12 @@ namespace DataPostprocessorInputs
   typename DoFHandler<dim, spacedim>::cell_iterator
   CommonInputs<spacedim>::get_cell() const
   {
-    Assert(cell.empty() == false,
+    Assert(cell.has_value(),
            ExcMessage(
              "You are trying to access the cell associated with a "
              "DataPostprocessorInputs::Scalar object for which no cell has "
              "been set."));
-    Assert((boost::any_cast<typename DoFHandler<dim, spacedim>::cell_iterator>(
+    Assert((std::any_cast<typename DoFHandler<dim, spacedim>::cell_iterator>(
               &cell) != nullptr),
            ExcMessage(
              "You are trying to access the cell associated with a "
@@ -1423,7 +1422,7 @@ namespace DataPostprocessorInputs
              "DoFHandler<2, 3>, but not with any other class type or dimension "
              "template argument."));
 
-    return boost::any_cast<typename DoFHandler<dim, spacedim>::cell_iterator>(
+    return std::any_cast<typename DoFHandler<dim, spacedim>::cell_iterator>(
       cell);
   }
 } // namespace DataPostprocessorInputs


### PR DESCRIPTION
`std::any` is part of C++17, so we can use that now.