### PR TITLE
Split a mutex into two, give them better names.

### DIFF
--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -1332,9 +1332,11 @@ private:
   };
 
   /**
-   * Mutex for protecting initialization of restriction and embedding matrix.
+   * Mutex variables used for protecting the initialization of restriction
+   * and embedding matrices.
    */
-  mutable std::mutex mutex;
+  mutable std::mutex restriction_matrix_mutex;
+  mutable std::mutex prolongation_matrix_mutex;
 
   friend class FE_Enriched<dim, spacedim>;
 };

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -898,7 +898,7 @@ FESystem<dim, spacedim>::get_restriction_matrix(
   // initialization upon first request
   if (this->restriction[refinement_case - 1][child].n() == 0)
     {
-      std::lock_guard<std::mutex> lock(this->mutex);
+      std::lock_guard<std::mutex> lock(restriction_matrix_mutex);
 
       // check if updated while waiting for lock
       if (this->restriction[refinement_case - 1][child].n() ==
@@ -990,7 +990,7 @@ FESystem<dim, spacedim>::get_prolongation_matrix(
   // restriction matrix
   if (this->prolongation[refinement_case - 1][child].n() == 0)
     {
-      std::lock_guard<std::mutex> lock(this->mutex);
+      std::lock_guard<std::mutex> lock(prolongation_matrix_mutex);
 
       if (this->prolongation[refinement_case - 1][child].n() ==
           this->n_dofs_per_cell())


### PR DESCRIPTION
While looking at one of the places for which #16168 is relevant.