### PR TITLE
Make it not an error to call constrain_dof_to_zero() more than once. Convert a bunch of tests.

### DIFF
--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -825,6 +825,12 @@ public:
    * @code
    *   constraints.add_constraint (42, {}, 0.0);
    * @endcode
+   *
+   * It is not an error to call this function more than once on the same
+   * degree of freedom, but it is an error to call this function on a
+   * degree of freedom that has previously been constrained to either
+   * a different value than zero, or to a linear combination of degrees
+   * of freedom via the add_constraint() function.
    */
   void
   constrain_dof_to_zero(const size_type constrained_dof);

--- a/tests/data_out/data_out_curved_cells.cc
+++ b/tests/data_out/data_out_curved_cells.cc
@@ -158,7 +158,9 @@ curved_grid(std::ostream &out)
       for (const unsigned int vertex_no : GeometryInfo<2>::vertex_indices())
         {
           for (unsigned int i = 0; i < 2; ++i)
-            m[i].add_line(cell->vertex_dof_index(vertex_no, 0));
+            if (m[i].is_constrained(cell->vertex_dof_index(vertex_no, 0)) ==
+                false)
+              m[i].constrain_dof_to_zero(cell->vertex_dof_index(vertex_no, 0));
         }
 
       if (cell->at_boundary())
@@ -174,7 +176,7 @@ curved_grid(std::ostream &out)
                 if (std::fabs(face->vertex(1).norm() - r_i) < eps)
                   for (unsigned int i = 0; i < 2; ++i)
                     {
-                      m[i].add_line(face->dof_index(0));
+                      m[i].constrain_dof_to_zero(face->dof_index(0));
                       m[i].set_inhomogeneity(face->dof_index(0),
                                              (face->center() *
                                               (r_i / face->center().norm() -
@@ -182,7 +184,7 @@ curved_grid(std::ostream &out)
                     }
                 else if (std::fabs(face->vertex(1).norm() - r_a) < eps)
                   for (unsigned int i = 0; i < 2; ++i)
-                    m[i].add_line(face->dof_index(0));
+                    m[i].constrain_dof_to_zero(face->dof_index(0));
                 else
                   Assert(false, ExcInternalError());
               }

--- a/tests/fe/fe_enriched_step-36b.cc
+++ b/tests/fe/fe_enriched_step-36b.cc
@@ -426,7 +426,10 @@ namespace Step36
                       // if
                       // (fe_collection[1].face_system_to_component_index(i).first
                       // /*component*/ > 0)
-                      constraints.add_line(local_face_dof_indices[i]);
+                      if (constraints.is_constrained(
+                            local_face_dof_indices[i]) == false)
+                        constraints.constrain_dof_to_zero(
+                          local_face_dof_indices[i]);
                 }
             }
   }

--- a/tests/integrators/assembler_simple_system_inhom_01.cc
+++ b/tests/integrators/assembler_simple_system_inhom_01.cc
@@ -690,7 +690,7 @@ MeshWorkerAffineConstraintsTest<dim>::createInhomConstraints()
 
           if (std::sqrt(p.square()) < 1e-6)
             {
-              this->constraintsInhom.add_line(dof_index);
+              this->constraintsInhom.constrain_dof_to_zero(dof_index);
               this->constraintsInhom.set_inhomogeneity(dof_index, 2);
             }
         }

--- a/tests/lac/affine_constraints_set_zero.cc
+++ b/tests/lac/affine_constraints_set_zero.cc
@@ -40,8 +40,8 @@ test()
   local_active.add_range(myid * numproc, (myid + 1) * numproc);
 
   AffineConstraints<double> cm;
-  cm.add_line(1);
-  cm.add_line(2);
+  cm.constrain_dof_to_zero(1);
+  cm.constrain_dof_to_zero(2);
   cm.close();
 
   deallog << "CM:" << std::endl;

--- a/tests/lac/constraint_matrix_distribute_local_global.cc
+++ b/tests/lac/constraint_matrix_distribute_local_global.cc
@@ -39,7 +39,7 @@ main()
 
   // set up constraint
   AffineConstraints<double> constraints;
-  constraints.add_line(0);
+  constraints.constrain_dof_to_zero(0);
   constraints.close();
 
   // global matrix and vector

--- a/tests/lac/constraints_01.cc
+++ b/tests/lac/constraints_01.cc
@@ -42,7 +42,7 @@ test()
   for (unsigned int i = 0; i < sizeof(inhoms) / sizeof(inhoms[0]); ++i)
     {
       deallog << inhoms[i] << std::endl;
-      cm.add_line(inhoms[i]);
+      cm.constrain_dof_to_zero(inhoms[i]);
       cm.set_inhomogeneity(inhoms[i], 1.0);
     }
 

--- a/tests/lac/constraints_hanging_nodes_bc.cc
+++ b/tests/lac/constraints_hanging_nodes_bc.cc
@@ -86,7 +86,7 @@ test()
       {
         if (!correct_constraints.is_constrained(boundary_value->first))
           {
-            correct_constraints.add_line(boundary_value->first);
+            correct_constraints.constrain_dof_to_zero(boundary_value->first);
             correct_constraints.set_inhomogeneity(boundary_value->first,
                                                   boundary_value->second);
           }

--- a/tests/lac/constraints_make_consistent_in_parallel_01.cc
+++ b/tests/lac/constraints_make_consistent_in_parallel_01.cc
@@ -75,7 +75,8 @@ test(const DoFHandler<dim, spacedim> &dof_handler,
         {
           cell->face(face)->get_dof_indices(dof_indices);
           for (const auto i : dof_indices)
-            constraints.add_line(i);
+            if (constraints.is_constrained(i) == false)
+              constraints.constrain_dof_to_zero(i);
         }
 
   const auto a = collect_lines(constraints, dof_handler.n_dofs());

--- a/tests/lac/constraints_merge_12.cc
+++ b/tests/lac/constraints_merge_12.cc
@@ -41,11 +41,11 @@ merge_check()
   AffineConstraints<double> c1(local_lines), c2(local_lines);
   for (types::global_dof_index i = 99999800; i < local_lines.size(); ++i)
     if (i % 2 == 1)
-      c1.add_line(i);
+      c1.constrain_dof_to_zero(i);
 
-  c2.add_line(99999800);
-  c2.add_line(99999801);
-  c2.add_line(99999802);
+  c2.constrain_dof_to_zero(99999800);
+  c2.constrain_dof_to_zero(99999801);
+  c2.constrain_dof_to_zero(99999802);
 
   // now merge the two and print the results
   c2.merge(c1, AffineConstraints<double>::right_object_wins);

--- a/tests/lac/constraints_move.cc
+++ b/tests/lac/constraints_move.cc
@@ -30,7 +30,7 @@ main()
   double                    vals[] = {0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
   for (unsigned int i = 0; i < sizeof(IDs) / sizeof(IDs[0]); ++i)
     {
-      constraints.add_line(IDs[i]);
+      constraints.constrain_dof_to_zero(IDs[i]);
       constraints.set_inhomogeneity(IDs[i], vals[i]);
     }
 

--- a/tests/lac/constraints_zero_condense.cc
+++ b/tests/lac/constraints_zero_condense.cc
@@ -36,7 +36,7 @@ test()
   AffineConstraints<double> cm;
 
   for (unsigned int i = 0; i < 5; ++i)
-    cm.add_line(i);
+    cm.constrain_dof_to_zero(i);
   cm.close();
 
   // completely fill a 5x5 matrix

--- a/tests/lac/inhomogeneous_constraints.cc
+++ b/tests/lac/inhomogeneous_constraints.cc
@@ -226,7 +226,7 @@ LaplaceProblem<dim>::setup_system()
       {
         if (!test_all_constraints.is_constrained(boundary_value->first))
           {
-            test_all_constraints.add_line(boundary_value->first);
+            test_all_constraints.constrain_dof_to_zero(boundary_value->first);
             test_all_constraints.set_inhomogeneity(boundary_value->first,
                                                    boundary_value->second);
           }

--- a/tests/lac/inhomogeneous_constraints_04.cc
+++ b/tests/lac/inhomogeneous_constraints_04.cc
@@ -90,11 +90,11 @@ test(bool use_constraint_matrix)
     {
       AffineConstraints<double> cm;
 
-      cm.add_line(1);
+      cm.constrain_dof_to_zero(1);
       cm.set_inhomogeneity(1, -5.0);
-      cm.add_line(3);
+      cm.constrain_dof_to_zero(3);
       cm.set_inhomogeneity(3, 2.0);
-      cm.add_line(4);
+      cm.constrain_dof_to_zero(4);
       cm.set_inhomogeneity(4, 0.0);
 
       cm.close();

--- a/tests/lac/inhomogeneous_constraints_block.cc
+++ b/tests/lac/inhomogeneous_constraints_block.cc
@@ -148,7 +148,7 @@ AdvectionProblem<dim>::setup_system()
       boundary_values.begin();
     for (; boundary_value != boundary_values.end(); ++boundary_value)
       {
-        test_all_constraints.add_line(boundary_value->first);
+        test_all_constraints.constrain_dof_to_zero(boundary_value->first);
         test_all_constraints.set_inhomogeneity(boundary_value->first,
                                                boundary_value->second);
       }

--- a/tests/lac/inhomogeneous_constraints_nonsymmetric.cc
+++ b/tests/lac/inhomogeneous_constraints_nonsymmetric.cc
@@ -153,7 +153,7 @@ AdvectionProblem<dim>::setup_system()
       boundary_values.begin();
     for (; boundary_value != boundary_values.end(); ++boundary_value)
       {
-        test_all_constraints.add_line(boundary_value->first);
+        test_all_constraints.constrain_dof_to_zero(boundary_value->first);
         test_all_constraints.set_inhomogeneity(boundary_value->first,
                                                boundary_value->second);
       }

--- a/tests/matrix_free/matrix_vector_mg.cc
+++ b/tests/matrix_free/matrix_vector_mg.cc
@@ -104,7 +104,7 @@ test()
       std::set<types::global_dof_index>::iterator bc_it =
         boundary_indices[level].begin();
       for (; bc_it != boundary_indices[level].end(); ++bc_it)
-        mg_constraints[level].add_line(*bc_it);
+        mg_constraints[level].constrain_dof_to_zero(*bc_it);
       mg_constraints[level].close();
       typename MatrixFree<dim>::AdditionalData data;
       data.mg_level = level;

--- a/tests/matrix_free/parallel_multigrid.cc
+++ b/tests/matrix_free/parallel_multigrid.cc
@@ -109,7 +109,8 @@ public:
                     {
                       face->get_mg_dof_indices(level, local_dofs);
                       for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
-                        constraints.add_line(local_dofs[i]);
+                        if (constraints.is_constrained(local_dofs[i]) == false)
+                          constraints.constrain_dof_to_zero(local_dofs[i]);
                     }
                 }
           }

--- a/tests/matrix_free/parallel_multigrid_fullydistributed.cc
+++ b/tests/matrix_free/parallel_multigrid_fullydistributed.cc
@@ -114,7 +114,8 @@ public:
                     {
                       face->get_mg_dof_indices(level, local_dofs);
                       for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
-                        constraints.add_line(local_dofs[i]);
+                        if (constraints.is_constrained(local_dofs[i]) == false)
+                          constraints.constrain_dof_to_zero(local_dofs[i]);
                     }
                 }
           }

--- a/tests/matrix_free/parallel_multigrid_interleave.cc
+++ b/tests/matrix_free/parallel_multigrid_interleave.cc
@@ -120,7 +120,8 @@ public:
                     {
                       face->get_mg_dof_indices(level, local_dofs);
                       for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
-                        constraints.add_line(local_dofs[i]);
+                        if (constraints.is_constrained(local_dofs[i]) == false)
+                          constraints.constrain_dof_to_zero(local_dofs[i]);
                     }
                 }
           }

--- a/tests/matrix_free/parallel_multigrid_interleave_renumber.cc
+++ b/tests/matrix_free/parallel_multigrid_interleave_renumber.cc
@@ -121,7 +121,8 @@ public:
                     {
                       face->get_mg_dof_indices(level, local_dofs);
                       for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
-                        constraints.add_line(local_dofs[i]);
+                        if (constraints.is_constrained(local_dofs[i]) == false)
+                          constraints.constrain_dof_to_zero(local_dofs[i]);
                     }
                 }
           }
@@ -161,7 +162,8 @@ public:
                     {
                       face->get_mg_dof_indices(level, local_dofs);
                       for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
-                        constraints.add_line(local_dofs[i]);
+                        if (constraints.is_constrained(local_dofs[i]) == false)
+                          constraints.constrain_dof_to_zero(local_dofs[i]);
                     }
                 }
           }

--- a/tests/matrix_free/parallel_multigrid_mf.cc
+++ b/tests/matrix_free/parallel_multigrid_mf.cc
@@ -109,7 +109,8 @@ public:
                     {
                       face->get_mg_dof_indices(level, local_dofs);
                       for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
-                        constraints.add_line(local_dofs[i]);
+                        if (constraints.is_constrained(local_dofs[i]) == false)
+                          constraints.constrain_dof_to_zero(local_dofs[i]);
                     }
                 }
           }

--- a/tests/matrix_free/step-37.cc
+++ b/tests/matrix_free/step-37.cc
@@ -448,7 +448,7 @@ namespace Step37
         std::set<types::global_dof_index>::iterator bc_it =
           boundary_indices[level].begin();
         for (; bc_it != boundary_indices[level].end(); ++bc_it)
-          mg_constraints[level].add_line(*bc_it);
+          mg_constraints[level].constrain_dof_to_zero(*bc_it);
 
         mg_constraints[level].close();
         mg_matrices[level].reinit(dof_handler, mg_constraints[level], level);

--- a/tests/mpi/constraint_matrix_set_zero_01.cc
+++ b/tests/mpi/constraint_matrix_set_zero_01.cc
@@ -59,7 +59,7 @@ test()
   local_active_together.add_range(numproc + myid * 2, numproc + myid * 2 + 2);
 
   AffineConstraints<PetscScalar> cm(local_active_together);
-  cm.add_line(numproc + myid * 2);
+  cm.constrain_dof_to_zero(numproc + myid * 2);
   cm.close();
 
   deallog << "vector before:" << std::endl;

--- a/tests/mpi/constraint_matrix_set_zero_02.cc
+++ b/tests/mpi/constraint_matrix_set_zero_02.cc
@@ -63,7 +63,7 @@ test()
   local_active_together.add_range(numproc + myid * 2, numproc + myid * 2 + 2);
 
   AffineConstraints<double> cm(local_active_together);
-  cm.add_line(numproc + myid * 2);
+  cm.constrain_dof_to_zero(numproc + myid * 2);
   cm.close();
 
   deallog << "vector before:" << std::endl;

--- a/tests/mpi/constraints_crash_01.cc
+++ b/tests/mpi/constraints_crash_01.cc
@@ -40,7 +40,7 @@ test()
   // local_active_together.compress();
 
   AffineConstraints<double> cm(local_active_together);
-  cm.add_line(1);
+  cm.constrain_dof_to_zero(1);
   cm.close();
   deallog << "OK" << std::endl;
 }

--- a/tests/mpi/constraints_crash_02.cc
+++ b/tests/mpi/constraints_crash_02.cc
@@ -47,7 +47,7 @@ test()
 
 
   AffineConstraints<double> cm(owned, relevant);
-  cm.add_line(0);
+  cm.constrain_dof_to_zero(0);
   cm.close();
 
   AffineConstraints<double> cm2;

--- a/tests/mpi/constraints_crash_03.cc
+++ b/tests/mpi/constraints_crash_03.cc
@@ -41,7 +41,7 @@ test()
 
 
   AffineConstraints<double> cm(owned, relevant);
-  cm.add_line(0);
+  cm.constrain_dof_to_zero(0);
   cm.close();
 
   AffineConstraints<double> cm2(cm);

--- a/tests/mpi/crash_05.cc
+++ b/tests/mpi/crash_05.cc
@@ -22,7 +22,7 @@
 905: An error occurred in line <1898> of file
 </scratch/deal-trunk/deal.II/include/deal.II/lac/affine_constraints.h> in
 function 905:     void
-dealii::AffineConstraints<double>::add_line(dealii::AffineConstraints<double>::size_type)
+dealii::AffineConstraints<double>::constrain_dof_to_zero(dealii::AffineConstraints<double>::size_type)
 905: The violated condition was: 905:     line != numbers::invalid_size_type
 905: The name and call sequence of the exception was: 905: ExcInternalError()
 905: Additional Information: 905: (none) 905:

--- a/tests/multigrid-global-coarsening/parallel_multigrid.cc
+++ b/tests/multigrid-global-coarsening/parallel_multigrid.cc
@@ -109,7 +109,8 @@ public:
                     {
                       face->get_mg_dof_indices(level, local_dofs);
                       for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
-                        constraints.add_line(local_dofs[i]);
+                        if (constraints.is_constrained(local_dofs[i]) == false)
+                          constraints.constrain_dof_to_zero(local_dofs[i]);
                     }
                 }
           }

--- a/tests/multigrid-global-coarsening/parallel_multigrid_fullydistributed.cc
+++ b/tests/multigrid-global-coarsening/parallel_multigrid_fullydistributed.cc
@@ -114,7 +114,8 @@ public:
                     {
                       face->get_mg_dof_indices(level, local_dofs);
                       for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
-                        constraints.add_line(local_dofs[i]);
+                        if (constraints.is_constrained(local_dofs[i]) == false)
+                          constraints.constrain_dof_to_zero(local_dofs[i]);
                     }
                 }
           }

--- a/tests/multigrid-global-coarsening/parallel_multigrid_interleave.cc
+++ b/tests/multigrid-global-coarsening/parallel_multigrid_interleave.cc
@@ -120,7 +120,8 @@ public:
                     {
                       face->get_mg_dof_indices(level, local_dofs);
                       for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
-                        constraints.add_line(local_dofs[i]);
+                        if (constraints.is_constrained(local_dofs[i]) == false)
+                          constraints.constrain_dof_to_zero(local_dofs[i]);
                     }
                 }
           }

--- a/tests/multigrid-global-coarsening/parallel_multigrid_interleave_renumber.cc
+++ b/tests/multigrid-global-coarsening/parallel_multigrid_interleave_renumber.cc
@@ -121,7 +121,8 @@ public:
                     {
                       face->get_mg_dof_indices(level, local_dofs);
                       for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
-                        constraints.add_line(local_dofs[i]);
+                        if (constraints.is_constrained(local_dofs[i]) == false)
+                          constraints.constrain_dof_to_zero(local_dofs[i]);
                     }
                 }
           }
@@ -161,7 +162,8 @@ public:
                     {
                       face->get_mg_dof_indices(level, local_dofs);
                       for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
-                        constraints.add_line(local_dofs[i]);
+                        if (constraints.is_constrained(local_dofs[i]) == false)
+                          constraints.constrain_dof_to_zero(local_dofs[i]);
                     }
                 }
           }

--- a/tests/multigrid-global-coarsening/parallel_multigrid_mf.cc
+++ b/tests/multigrid-global-coarsening/parallel_multigrid_mf.cc
@@ -109,7 +109,8 @@ public:
                     {
                       face->get_mg_dof_indices(level, local_dofs);
                       for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
-                        constraints.add_line(local_dofs[i]);
+                        if (constraints.is_constrained(local_dofs[i]) == false)
+                          constraints.constrain_dof_to_zero(local_dofs[i]);
                     }
                 }
           }

--- a/tests/multigrid/constrained_dofs_07.cc
+++ b/tests/multigrid/constrained_dofs_07.cc
@@ -64,7 +64,7 @@ check()
         {
           if (level_constraints.can_store_line(face_dofs[i]))
             {
-              level_constraints.add_line(face_dofs[i]);
+              level_constraints.constrain_dof_to_zero(face_dofs[i]);
               level_constraints.set_inhomogeneity(face_dofs[i], 5.0);
             }
         }

--- a/tests/multigrid/step-16-02.cc
+++ b/tests/multigrid/step-16-02.cc
@@ -412,17 +412,20 @@ LaplaceProblem<dim>::assemble_multigrid(const bool &use_mw)
         triangulation.n_levels());
       for (unsigned int level = 0; level < triangulation.n_levels(); ++level)
         {
-          boundary_constraints[level].add_lines(
-            mg_constrained_dofs.get_refinement_edge_indices(level));
-          boundary_constraints[level].add_lines(
-            mg_constrained_dofs.get_boundary_indices(level));
-          boundary_constraints[level].close();
+          for (const types::global_dof_index dof_index :
+               mg_constrained_dofs.get_refinement_edge_indices(level))
+            boundary_constraints[level].constrain_dof_to_zero(dof_index);
+          for (const types::global_dof_index dof_index :
+               mg_constrained_dofs.get_boundary_indices(level))
+            boundary_constraints[level].constrain_dof_to_zero(dof_index);
 
-          IndexSet idx =
+          const IndexSet idx =
             mg_constrained_dofs.get_refinement_edge_indices(level) &
             mg_constrained_dofs.get_boundary_indices(level);
 
-          boundary_interface_constraints[level].add_lines(idx);
+          for (const types::global_dof_index idx :
+               mg_constrained_dofs.get_boundary_indices(level))
+            boundary_constraints[level].constrain_dof_to_zero(idx);
           boundary_interface_constraints[level].close();
         }
 

--- a/tests/multigrid/step-16-03.cc
+++ b/tests/multigrid/step-16-03.cc
@@ -293,10 +293,12 @@ LaplaceProblem<dim>::assemble_multigrid()
   for (unsigned int level = min_level; level < triangulation.n_levels();
        ++level)
     {
-      boundary_constraints[level].add_lines(
-        mg_constrained_dofs.get_refinement_edge_indices(level));
-      boundary_constraints[level].add_lines(
-        mg_constrained_dofs.get_boundary_indices(level));
+      for (const types::global_dof_index dof_index :
+           mg_constrained_dofs.get_refinement_edge_indices(level))
+        boundary_constraints[level].constrain_dof_to_zero(dof_index);
+      for (const types::global_dof_index dof_index :
+           mg_constrained_dofs.get_boundary_indices(level))
+        boundary_constraints[level].constrain_dof_to_zero(dof_index);
       boundary_constraints[level].close();
     }
 

--- a/tests/multigrid/step-16-04.cc
+++ b/tests/multigrid/step-16-04.cc
@@ -302,10 +302,12 @@ LaplaceProblem<dim>::assemble_multigrid()
   for (unsigned int level = min_level; level < triangulation.n_levels();
        ++level)
     {
-      boundary_constraints[level].add_lines(
-        mg_constrained_dofs.get_refinement_edge_indices(level));
-      boundary_constraints[level].add_lines(
-        mg_constrained_dofs.get_boundary_indices(level));
+      for (const types::global_dof_index dof_index :
+           mg_constrained_dofs.get_refinement_edge_indices(level))
+        boundary_constraints[level].constrain_dof_to_zero(dof_index);
+      for (const types::global_dof_index dof_index :
+           mg_constrained_dofs.get_boundary_indices(level))
+        boundary_constraints[level].constrain_dof_to_zero(dof_index);
       boundary_constraints[level].close();
     }
 

--- a/tests/multigrid/step-16-05.cc
+++ b/tests/multigrid/step-16-05.cc
@@ -303,10 +303,12 @@ LaplaceProblem<dim>::assemble_multigrid()
   for (unsigned int level = min_level; level < triangulation.n_levels();
        ++level)
     {
-      boundary_constraints[level].add_lines(
-        mg_constrained_dofs.get_refinement_edge_indices(level));
-      boundary_constraints[level].add_lines(
-        mg_constrained_dofs.get_boundary_indices(level));
+      for (const types::global_dof_index dof_index :
+           mg_constrained_dofs.get_refinement_edge_indices(level))
+        boundary_constraints[level].constrain_dof_to_zero(dof_index);
+      for (const types::global_dof_index dof_index :
+           mg_constrained_dofs.get_boundary_indices(level))
+        boundary_constraints[level].constrain_dof_to_zero(dof_index);
       boundary_constraints[level].close();
     }
 

--- a/tests/multigrid/step-16-06.cc
+++ b/tests/multigrid/step-16-06.cc
@@ -303,10 +303,12 @@ LaplaceProblem<dim>::assemble_multigrid()
   for (unsigned int level = min_level; level < triangulation.n_levels();
        ++level)
     {
-      boundary_constraints[level].add_lines(
-        mg_constrained_dofs.get_refinement_edge_indices(level));
-      boundary_constraints[level].add_lines(
-        mg_constrained_dofs.get_boundary_indices(level));
+      for (const types::global_dof_index dof_index :
+           mg_constrained_dofs.get_refinement_edge_indices(level))
+        boundary_constraints[level].constrain_dof_to_zero(dof_index);
+      for (const types::global_dof_index dof_index :
+           mg_constrained_dofs.get_boundary_indices(level))
+        boundary_constraints[level].constrain_dof_to_zero(dof_index);
       boundary_constraints[level].close();
     }
 

--- a/tests/multigrid/step-16-07.cc
+++ b/tests/multigrid/step-16-07.cc
@@ -298,10 +298,12 @@ LaplaceProblem<dim>::assemble_multigrid()
   AffineConstraints<double> empty_constraints;
   for (unsigned int level = 0; level < triangulation.n_levels(); ++level)
     {
-      boundary_constraints[level].add_lines(
-        mg_constrained_dofs.get_refinement_edge_indices(level));
-      boundary_constraints[level].add_lines(
-        mg_constrained_dofs.get_boundary_indices(level));
+      for (const types::global_dof_index dof_index :
+           mg_constrained_dofs.get_refinement_edge_indices(level))
+        boundary_constraints[level].constrain_dof_to_zero(dof_index);
+      for (const types::global_dof_index dof_index :
+           mg_constrained_dofs.get_boundary_indices(level))
+        boundary_constraints[level].constrain_dof_to_zero(dof_index);
       boundary_constraints[level].close();
     }
 

--- a/tests/multigrid/step-16-08.cc
+++ b/tests/multigrid/step-16-08.cc
@@ -273,10 +273,12 @@ LaplaceProblem<dim>::assemble_multigrid()
   AffineConstraints<double> empty_constraints;
   for (unsigned int level = 0; level < n_levels; ++level)
     {
-      boundary_constraints[level].add_lines(
-        mg_constrained_dofs.get_refinement_edge_indices(level));
-      boundary_constraints[level].add_lines(
-        mg_constrained_dofs.get_boundary_indices(level));
+      for (const types::global_dof_index dof_index :
+           mg_constrained_dofs.get_refinement_edge_indices(level))
+        boundary_constraints[level].constrain_dof_to_zero(dof_index);
+      for (const types::global_dof_index dof_index :
+           mg_constrained_dofs.get_boundary_indices(level))
+        boundary_constraints[level].constrain_dof_to_zero(dof_index);
       boundary_constraints[level].close();
 
       DynamicSparsityPattern csp;

--- a/tests/multigrid/step-16-50-mpi-linear-operator.cc
+++ b/tests/multigrid/step-16-50-mpi-linear-operator.cc
@@ -350,11 +350,13 @@ namespace Step50
         const IndexSet dofset =
           DoFTools::extract_locally_relevant_level_dofs(mg_dof_handler, level);
         boundary_constraints[level].reinit(dofset);
-        boundary_constraints[level].add_lines(
-          mg_constrained_dofs.get_refinement_edge_indices(level));
-        boundary_constraints[level].add_lines(
-          mg_constrained_dofs.get_boundary_indices(level));
 
+        for (const types::global_dof_index dof_index :
+             mg_constrained_dofs.get_refinement_edge_indices(level))
+          boundary_constraints[level].constrain_dof_to_zero(dof_index);
+        for (const types::global_dof_index dof_index :
+             mg_constrained_dofs.get_boundary_indices(level))
+          boundary_constraints[level].constrain_dof_to_zero(dof_index);
         boundary_constraints[level].close();
       }
 

--- a/tests/multigrid/step-16-50-mpi-smoother.cc
+++ b/tests/multigrid/step-16-50-mpi-smoother.cc
@@ -349,11 +349,13 @@ namespace Step50
         const IndexSet dofset =
           DoFTools::extract_locally_relevant_level_dofs(mg_dof_handler, level);
         boundary_constraints[level].reinit(dofset);
-        boundary_constraints[level].add_lines(
-          mg_constrained_dofs.get_refinement_edge_indices(level));
-        boundary_constraints[level].add_lines(
-          mg_constrained_dofs.get_boundary_indices(level));
 
+        for (const types::global_dof_index dof_index :
+             mg_constrained_dofs.get_refinement_edge_indices(level))
+          boundary_constraints[level].constrain_dof_to_zero(dof_index);
+        for (const types::global_dof_index dof_index :
+             mg_constrained_dofs.get_boundary_indices(level))
+          boundary_constraints[level].constrain_dof_to_zero(dof_index);
         boundary_constraints[level].close();
       }
 

--- a/tests/multigrid/step-16-50-mpi.cc
+++ b/tests/multigrid/step-16-50-mpi.cc
@@ -350,11 +350,12 @@ namespace Step50
         const IndexSet dofset =
           DoFTools::extract_locally_relevant_level_dofs(mg_dof_handler, level);
         boundary_constraints[level].reinit(dofset);
-        boundary_constraints[level].add_lines(
-          mg_constrained_dofs.get_refinement_edge_indices(level));
-        boundary_constraints[level].add_lines(
-          mg_constrained_dofs.get_boundary_indices(level));
-
+        for (const types::global_dof_index dof_index :
+             mg_constrained_dofs.get_refinement_edge_indices(level))
+          boundary_constraints[level].constrain_dof_to_zero(dof_index);
+        for (const types::global_dof_index dof_index :
+             mg_constrained_dofs.get_boundary_indices(level))
+          boundary_constraints[level].constrain_dof_to_zero(dof_index);
         boundary_constraints[level].close();
       }
 

--- a/tests/multigrid/step-16-50-serial.cc
+++ b/tests/multigrid/step-16-50-serial.cc
@@ -296,10 +296,12 @@ LaplaceProblem<dim>::assemble_multigrid()
   AffineConstraints<double> empty_constraints;
   for (unsigned int level = 0; level < triangulation.n_levels(); ++level)
     {
-      boundary_constraints[level].add_lines(
-        mg_constrained_dofs.get_refinement_edge_indices(level));
-      boundary_constraints[level].add_lines(
-        mg_constrained_dofs.get_boundary_indices(level));
+      for (const types::global_dof_index dof_index :
+           mg_constrained_dofs.get_refinement_edge_indices(level))
+        boundary_constraints[level].constrain_dof_to_zero(dof_index);
+      for (const types::global_dof_index dof_index :
+           mg_constrained_dofs.get_boundary_indices(level))
+        boundary_constraints[level].constrain_dof_to_zero(dof_index);
       boundary_constraints[level].close();
     }
 

--- a/tests/multigrid/step-16-bdry1.cc
+++ b/tests/multigrid/step-16-bdry1.cc
@@ -418,10 +418,12 @@ LaplaceProblem<dim>::assemble_multigrid(bool use_mw)
 
       for (unsigned int level = 0; level < triangulation.n_levels(); ++level)
         {
-          boundary_constraints[level].add_lines(
-            mg_constrained_dofs.get_refinement_edge_indices(level));
-          boundary_constraints[level].add_lines(
-            mg_constrained_dofs.get_boundary_indices(level));
+          for (const types::global_dof_index dof_index :
+               mg_constrained_dofs.get_refinement_edge_indices(level))
+            boundary_constraints[level].constrain_dof_to_zero(dof_index);
+          for (const types::global_dof_index dof_index :
+               mg_constrained_dofs.get_boundary_indices(level))
+            boundary_constraints[level].constrain_dof_to_zero(dof_index);
           boundary_constraints[level].close();
         }
 

--- a/tests/multigrid/step-16.cc
+++ b/tests/multigrid/step-16.cc
@@ -298,10 +298,12 @@ LaplaceProblem<dim>::assemble_multigrid()
   AffineConstraints<double> empty_constraints;
   for (unsigned int level = 0; level < triangulation.n_levels(); ++level)
     {
-      boundary_constraints[level].add_lines(
-        mg_constrained_dofs.get_refinement_edge_indices(level));
-      boundary_constraints[level].add_lines(
-        mg_constrained_dofs.get_boundary_indices(level));
+      for (const types::global_dof_index dof_index :
+           mg_constrained_dofs.get_refinement_edge_indices(level))
+        boundary_constraints[level].constrain_dof_to_zero(dof_index);
+      for (const types::global_dof_index dof_index :
+           mg_constrained_dofs.get_boundary_indices(level))
+        boundary_constraints[level].constrain_dof_to_zero(dof_index);
       boundary_constraints[level].close();
     }
 

--- a/tests/multigrid/transfer_matrix_free_13.cc
+++ b/tests/multigrid/transfer_matrix_free_13.cc
@@ -62,7 +62,7 @@ check()
     {
       if (user_constraints.can_store_line(face_dofs[i]))
         {
-          user_constraints.add_line(face_dofs[i]);
+          user_constraints.constrain_dof_to_zero(face_dofs[i]);
           user_constraints.set_inhomogeneity(face_dofs[i], 5.0);
         }
     }

--- a/tests/multigrid/transfer_prebuilt_05.cc
+++ b/tests/multigrid/transfer_prebuilt_05.cc
@@ -59,7 +59,7 @@ check()
     {
       if (user_constraints.can_store_line(face_dofs[i]))
         {
-          user_constraints.add_line(face_dofs[i]);
+          user_constraints.constrain_dof_to_zero(face_dofs[i]);
           user_constraints.set_inhomogeneity(face_dofs[i], 5.0);
         }
     }

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_02.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_02.cc
@@ -193,9 +193,9 @@ public:
           if (global_ids[i] == numbers::invalid_size_type)
             continue;
 
-          constraints.add_line(global_ids[i]);
-          constraints.set_inhomogeneity(global_ids[i],
-                                        evaluation_point_results[i]);
+          constraints.add_constraint(global_ids[i],
+                                     {},
+                                     evaluation_point_results[i]);
         }
     }
     constraints.close();


### PR DESCRIPTION
In #16163 , I added `AffineConstraints::constrain_dof_to_zero()` and gave that function the semantics that it can only be called once. But it turns out that we have a lot of places in the multigrid tests where we do this:
```
        for (const types::global_dof_index dof_index :
             mg_constrained_dofs.get_refinement_edge_indices(level))
          boundary_constraints[level].constrain_dof_to_zero(dof_index);

        for (const types::global_dof_index dof_index :
             mg_constrained_dofs.get_boundary_indices(level))
          boundary_constraints[level].constrain_dof_to_zero(dof_index);
```
If there is overlap between the two index sets, this will lead to errors. I decided that this is not worth it -- if you want to constrain a degree of freedom to zero again, after having done so before already, that seems reasonable. This avoids having to guard all of these places, but furthermore the guard is expensive because calling `oundary_constraints[level].is_constrained(dof_index)` involves a look-up in an `IndexSet` object. This patch therefore also avoids the index set lookup.

The second and third part of the patch convert a whole bunch of tests and replaces calls to deprecated functions.

Related to #15375.