### PR TITLE
Use static bool for initializing restriction and prolongation matrices once

### DIFF
--- a/source/fe/fe_dgq.cc
+++ b/source/fe/fe_dgq.cc
@@ -419,61 +419,51 @@ FE_DGQ<dim, spacedim>::get_prolongation_matrix(
   AssertIndexRange(child, GeometryInfo<dim>::n_children(refinement_case));
 
   // initialization upon first request
-  if (this->prolongation[refinement_case - 1][child].n() == 0)
-    {
-      std::lock_guard<std::mutex> lock(this->mutex);
-
-      // if matrix got updated while waiting for the lock
-      if (this->prolongation[refinement_case - 1][child].n() ==
-          this->n_dofs_per_cell())
-        return this->prolongation[refinement_case - 1][child];
-
-      // now do the work. need to get a non-const version of data in order to
-      // be able to modify them inside a const function
-      FE_DGQ<dim, spacedim> &this_nonconst =
-        const_cast<FE_DGQ<dim, spacedim> &>(*this);
-      if (refinement_case == RefinementCase<dim>::isotropic_refinement)
-        {
-          std::vector<std::vector<FullMatrix<double>>> isotropic_matrices(
-            RefinementCase<dim>::isotropic_refinement);
-          isotropic_matrices.back().resize(
-            GeometryInfo<dim>::n_children(RefinementCase<dim>(refinement_case)),
-            FullMatrix<double>(this->n_dofs_per_cell(),
-                               this->n_dofs_per_cell()));
-          if (dim == spacedim)
+  [[maybe_unused]] static bool once = [&]() {
+    // now do the work. need to get a non-const version of data in order to
+    // be able to modify them inside a const function
+    FE_DGQ<dim, spacedim> &this_nonconst =
+      const_cast<FE_DGQ<dim, spacedim> &>(*this);
+    if (refinement_case == RefinementCase<dim>::isotropic_refinement)
+      {
+        std::vector<std::vector<FullMatrix<double>>> isotropic_matrices(
+          RefinementCase<dim>::isotropic_refinement);
+        isotropic_matrices.back().resize(
+          GeometryInfo<dim>::n_children(RefinementCase<dim>(refinement_case)),
+          FullMatrix<double>(this->n_dofs_per_cell(), this->n_dofs_per_cell()));
+        if (dim == spacedim)
+          FETools::compute_embedding_matrices(*this, isotropic_matrices, true);
+        else
+          FETools::compute_embedding_matrices(FE_DGQ<dim>(this->degree),
+                                              isotropic_matrices,
+                                              true);
+        this_nonconst.prolongation[refinement_case - 1].swap(
+          isotropic_matrices.back());
+      }
+    else
+      {
+        // must compute both restriction and prolongation matrices because
+        // we only check for their size and the reinit call initializes them
+        // all
+        this_nonconst.reinit_restriction_and_prolongation_matrices();
+        if (dim == spacedim)
+          {
             FETools::compute_embedding_matrices(*this,
-                                                isotropic_matrices,
-                                                true);
-          else
-            FETools::compute_embedding_matrices(FE_DGQ<dim>(this->degree),
-                                                isotropic_matrices,
-                                                true);
-          this_nonconst.prolongation[refinement_case - 1].swap(
-            isotropic_matrices.back());
-        }
-      else
-        {
-          // must compute both restriction and prolongation matrices because
-          // we only check for their size and the reinit call initializes them
-          // all
-          this_nonconst.reinit_restriction_and_prolongation_matrices();
-          if (dim == spacedim)
-            {
-              FETools::compute_embedding_matrices(*this,
-                                                  this_nonconst.prolongation);
-              FETools::compute_projection_matrices(*this,
-                                                   this_nonconst.restriction);
-            }
-          else
-            {
-              FE_DGQ<dim> tmp(this->degree);
-              FETools::compute_embedding_matrices(tmp,
-                                                  this_nonconst.prolongation);
-              FETools::compute_projection_matrices(tmp,
-                                                   this_nonconst.restriction);
-            }
-        }
-    }
+                                                this_nonconst.prolongation);
+            FETools::compute_projection_matrices(*this,
+                                                 this_nonconst.restriction);
+          }
+        else
+          {
+            FE_DGQ<dim> tmp(this->degree);
+            FETools::compute_embedding_matrices(tmp,
+                                                this_nonconst.prolongation);
+            FETools::compute_projection_matrices(tmp,
+                                                 this_nonconst.restriction);
+          }
+      }
+    return true;
+  }();
 
   // finally return the matrix
   return this->prolongation[refinement_case - 1][child];
@@ -495,61 +485,51 @@ FE_DGQ<dim, spacedim>::get_restriction_matrix(
   AssertIndexRange(child, GeometryInfo<dim>::n_children(refinement_case));
 
   // initialization upon first request
-  if (this->restriction[refinement_case - 1][child].n() == 0)
-    {
-      std::lock_guard<std::mutex> lock(this->mutex);
-
-      // if matrix got updated while waiting for the lock...
-      if (this->restriction[refinement_case - 1][child].n() ==
-          this->n_dofs_per_cell())
-        return this->restriction[refinement_case - 1][child];
-
-      // now do the work. need to get a non-const version of data in order to
-      // be able to modify them inside a const function
-      FE_DGQ<dim, spacedim> &this_nonconst =
-        const_cast<FE_DGQ<dim, spacedim> &>(*this);
-      if (refinement_case == RefinementCase<dim>::isotropic_refinement)
-        {
-          std::vector<std::vector<FullMatrix<double>>> isotropic_matrices(
-            RefinementCase<dim>::isotropic_refinement);
-          isotropic_matrices.back().resize(
-            GeometryInfo<dim>::n_children(RefinementCase<dim>(refinement_case)),
-            FullMatrix<double>(this->n_dofs_per_cell(),
-                               this->n_dofs_per_cell()));
-          if (dim == spacedim)
+  [[maybe_unused]] static bool once = [&]() {
+    // now do the work. need to get a non-const version of data in order to
+    // be able to modify them inside a const function
+    FE_DGQ<dim, spacedim> &this_nonconst =
+      const_cast<FE_DGQ<dim, spacedim> &>(*this);
+    if (refinement_case == RefinementCase<dim>::isotropic_refinement)
+      {
+        std::vector<std::vector<FullMatrix<double>>> isotropic_matrices(
+          RefinementCase<dim>::isotropic_refinement);
+        isotropic_matrices.back().resize(
+          GeometryInfo<dim>::n_children(RefinementCase<dim>(refinement_case)),
+          FullMatrix<double>(this->n_dofs_per_cell(), this->n_dofs_per_cell()));
+        if (dim == spacedim)
+          FETools::compute_projection_matrices(*this, isotropic_matrices, true);
+        else
+          FETools::compute_projection_matrices(FE_DGQ<dim>(this->degree),
+                                               isotropic_matrices,
+                                               true);
+        this_nonconst.restriction[refinement_case - 1].swap(
+          isotropic_matrices.back());
+      }
+    else
+      {
+        // must compute both restriction and prolongation matrices because
+        // we only check for their size and the reinit call initializes them
+        // all
+        this_nonconst.reinit_restriction_and_prolongation_matrices();
+        if (dim == spacedim)
+          {
+            FETools::compute_embedding_matrices(*this,
+                                                this_nonconst.prolongation);
             FETools::compute_projection_matrices(*this,
-                                                 isotropic_matrices,
-                                                 true);
-          else
-            FETools::compute_projection_matrices(FE_DGQ<dim>(this->degree),
-                                                 isotropic_matrices,
-                                                 true);
-          this_nonconst.restriction[refinement_case - 1].swap(
-            isotropic_matrices.back());
-        }
-      else
-        {
-          // must compute both restriction and prolongation matrices because
-          // we only check for their size and the reinit call initializes them
-          // all
-          this_nonconst.reinit_restriction_and_prolongation_matrices();
-          if (dim == spacedim)
-            {
-              FETools::compute_embedding_matrices(*this,
-                                                  this_nonconst.prolongation);
-              FETools::compute_projection_matrices(*this,
-                                                   this_nonconst.restriction);
-            }
-          else
-            {
-              FE_DGQ<dim> tmp(this->degree);
-              FETools::compute_embedding_matrices(tmp,
-                                                  this_nonconst.prolongation);
-              FETools::compute_projection_matrices(tmp,
-                                                   this_nonconst.restriction);
-            }
-        }
-    }
+                                                 this_nonconst.restriction);
+          }
+        else
+          {
+            FE_DGQ<dim> tmp(this->degree);
+            FETools::compute_embedding_matrices(tmp,
+                                                this_nonconst.prolongation);
+            FETools::compute_projection_matrices(tmp,
+                                                 this_nonconst.restriction);
+          }
+      }
+    return true;
+  }();
 
   // finally return the matrix
   return this->restriction[refinement_case - 1][child];

--- a/source/fe/fe_nedelec.cc
+++ b/source/fe/fe_nedelec.cc
@@ -3039,40 +3039,32 @@ FE_Nedelec<dim>::get_prolongation_matrix(
   AssertIndexRange(child, GeometryInfo<dim>::n_children(refinement_case));
 
   // initialization upon first request
-  if (this->prolongation[refinement_case - 1][child].n() == 0)
-    {
-      std::lock_guard<std::mutex> lock(this->mutex);
+  [[maybe_unused]] static bool once = [&]() {
+    // now do the work. need to get a non-const version of data in order to
+    // be able to modify them inside a const function
+    FE_Nedelec<dim> &this_nonconst = const_cast<FE_Nedelec<dim> &>(*this);
 
-      // if matrix got updated while waiting for the lock
-      if (this->prolongation[refinement_case - 1][child].n() ==
-          this->n_dofs_per_cell())
-        return this->prolongation[refinement_case - 1][child];
-
-      // now do the work. need to get a non-const version of data in order to
-      // be able to modify them inside a const function
-      FE_Nedelec<dim> &this_nonconst = const_cast<FE_Nedelec<dim> &>(*this);
-
-      // Reinit the vectors of
-      // restriction and prolongation
-      // matrices to the right sizes.
-      // Restriction only for isotropic
-      // refinement
+    // Reinit the vectors of
+    // restriction and prolongation
+    // matrices to the right sizes.
+    // Restriction only for isotropic
+    // refinement
 #ifdef DEBUG_NEDELEC
-      deallog << "Embedding" << std::endl;
+    deallog << "Embedding" << std::endl;
 #endif
-      this_nonconst.reinit_restriction_and_prolongation_matrices();
-      // Fill prolongation matrices with embedding operators
-      FETools::compute_embedding_matrices(
-        this_nonconst,
-        this_nonconst.prolongation,
-        true,
-        internal::FE_Nedelec::get_embedding_computation_tolerance(
-          this->degree));
+    this_nonconst.reinit_restriction_and_prolongation_matrices();
+    // Fill prolongation matrices with embedding operators
+    FETools::compute_embedding_matrices(
+      this_nonconst,
+      this_nonconst.prolongation,
+      true,
+      internal::FE_Nedelec::get_embedding_computation_tolerance(this->degree));
 #ifdef DEBUG_NEDELEC
-      deallog << "Restriction" << std::endl;
+    deallog << "Restriction" << std::endl;
 #endif
-      this_nonconst.initialize_restriction();
-    }
+    this_nonconst.initialize_restriction();
+    return true;
+  }();
 
   // we use refinement_case-1 here. the -1 takes care of the origin of the
   // vector, as for RefinementCase<dim>::no_refinement (=0) there is no data
@@ -3095,40 +3087,32 @@ FE_Nedelec<dim>::get_restriction_matrix(
     child, GeometryInfo<dim>::n_children(RefinementCase<dim>(refinement_case)));
 
   // initialization upon first request
-  if (this->restriction[refinement_case - 1][child].n() == 0)
-    {
-      std::lock_guard<std::mutex> lock(this->mutex);
+  [[maybe_unused]] static bool once = [&]() {
+    // now do the work. need to get a non-const version of data in order to
+    // be able to modify them inside a const function
+    FE_Nedelec<dim> &this_nonconst = const_cast<FE_Nedelec<dim> &>(*this);
 
-      // if matrix got updated while waiting for the lock...
-      if (this->restriction[refinement_case - 1][child].n() ==
-          this->n_dofs_per_cell())
-        return this->restriction[refinement_case - 1][child];
-
-      // now do the work. need to get a non-const version of data in order to
-      // be able to modify them inside a const function
-      FE_Nedelec<dim> &this_nonconst = const_cast<FE_Nedelec<dim> &>(*this);
-
-      // Reinit the vectors of
-      // restriction and prolongation
-      // matrices to the right sizes.
-      // Restriction only for isotropic
-      // refinement
+    // Reinit the vectors of
+    // restriction and prolongation
+    // matrices to the right sizes.
+    // Restriction only for isotropic
+    // refinement
 #ifdef DEBUG_NEDELEC
-      deallog << "Embedding" << std::endl;
+    deallog << "Embedding" << std::endl;
 #endif
-      this_nonconst.reinit_restriction_and_prolongation_matrices();
-      // Fill prolongation matrices with embedding operators
-      FETools::compute_embedding_matrices(
-        this_nonconst,
-        this_nonconst.prolongation,
-        true,
-        internal::FE_Nedelec::get_embedding_computation_tolerance(
-          this->degree));
+    this_nonconst.reinit_restriction_and_prolongation_matrices();
+    // Fill prolongation matrices with embedding operators
+    FETools::compute_embedding_matrices(
+      this_nonconst,
+      this_nonconst.prolongation,
+      true,
+      internal::FE_Nedelec::get_embedding_computation_tolerance(this->degree));
 #ifdef DEBUG_NEDELEC
-      deallog << "Restriction" << std::endl;
+    deallog << "Restriction" << std::endl;
 #endif
-      this_nonconst.initialize_restriction();
-    }
+    this_nonconst.initialize_restriction();
+    return true;
+  }();
 
   // we use refinement_case-1 here. the -1 takes care of the origin of the
   // vector, as for RefinementCase<dim>::no_refinement (=0) there is no data


### PR DESCRIPTION
This should fix #16169 using the
```
static bool once  = [](){
// code to be executed once
}();
```
pattern.