### PR TITLE
Python: Triangulation::write outputs a serialized mesh

### DIFF
--- a/contrib/python-bindings/source/triangulation_wrapper.cc
+++ b/contrib/python-bindings/source/triangulation_wrapper.cc
@@ -812,7 +812,7 @@ namespace python
       else if (format.compare("vtu") == 0)
         {
           output_format = GridOut::OutputFormat::vtu;
-          GridOutFlags::Vtu flags(true);
+          GridOutFlags::Vtu flags(/* serialize_triangulation = */ true);
           mesh_writer.set_flags(flags);
         }
       else

--- a/contrib/python-bindings/source/triangulation_wrapper.cc
+++ b/contrib/python-bindings/source/triangulation_wrapper.cc
@@ -788,6 +788,8 @@ namespace python
       const Triangulation<dim, spacedim> *tria =
         static_cast<const Triangulation<dim, spacedim> *>(triangulation);
 
+      GridOut mesh_writer;
+
       GridOut::OutputFormat output_format;
       if (format.compare("dx") == 0)
         output_format = GridOut::OutputFormat::dx;
@@ -808,11 +810,14 @@ namespace python
       else if (format.compare("vtk") == 0)
         output_format = GridOut::OutputFormat::vtk;
       else if (format.compare("vtu") == 0)
-        output_format = GridOut::OutputFormat::vtu;
+        {
+          output_format = GridOut::OutputFormat::vtu;
+          GridOutFlags::Vtu flags(true);
+          mesh_writer.set_flags(flags);
+        }
       else
         output_format = GridOut::OutputFormat::none;
 
-      GridOut       mesh_writer;
       std::ofstream ofs(filename);
       mesh_writer.write(*tria, ofs, output_format);
       ofs.close();


### PR DESCRIPTION
I use our Python wrappers to create simple meshes. Right now the only wait to serialize the mesh from Python is to use Boost, with this PR we can also VTU files. 