### PR TITLE
Only include Kokkos_Abort.hpp in exceptions.h for Kokkos 4.2.0 and higher

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -19,7 +19,12 @@
 #include <deal.II/base/config.h>
 
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
-#include <Kokkos_Core.hpp>
+#include <Kokkos_Macros.hpp>
+#if KOKKOS_VERSION >= 40200
+#  include <Kokkos_Abort.hpp>
+#else
+#  include <Kokkos_Core.hpp>
+#endif
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <exception>


### PR DESCRIPTION
The Kokkos 4.2.0 release introduces a `Kokkos_Abort.hpp` header that only provides `Kokkos::abort`. Using it in `exceptions.h`, should help some with https://github.com/dealii/dealii/issues/16065 given that we see
```
**** Expensive headers:
1223179 ms: /home/darndt/dealii/include/deal.II/base/exceptions.h (included 780 times, avg 1568 ms), included via:
  86x: quadrature_lib.h quadrature.h point.h 
  42x: <direct include>
  28x: logstream.h 
  28x: array_view.h 
  26x: function.h 
  24x: block_vector.h 
  ...
```