### PR TITLE
Fix github badges.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 [![jenkins/dealii-mpi](https://ci.tjhei.info/job/dealii-mpi/job/master/badge/icon?style=plastic&subject=jenkins-MPI)](https://ci.tjhei.info/job/dealii-mpi/job/master/)
 [![jenkins/dealii-osx](https://ci.tjhei.info/job/dealii-osx/job/master/badge/icon?style=plastic&subject=jenkins-OSX)](https://ci.tjhei.info/job/dealii-osx/job/master/)
 [![jenkins/dealii-ampere](https://ci.tjhei.info/job/dealii-ampere/job/master/badge/icon?style=plastic&subject=jenkins-ampere)](https://ci.tjhei.info/job/dealii-ampere/job/master/)
-[![workflows/github-docker](https://github.com/dealii/dealii/workflows/github-docker/badge.svg)](https://github.com/dealii/dealii/actions?query=workflow%3Agithub-docker)
-[![workflows/indent](https://github.com/dealii/dealii/workflows/indent/badge.svg)](https://github.com/dealii/dealii/actions?query=workflow%3Aindent)
-[![workflows/tidy](https://github.com/dealii/dealii/workflows/tidy/badge.svg)](https://github.com/dealii/dealii/actions?query=workflow%3Atidy)
-[![workflows/github-linux](https://github.com/dealii/dealii/workflows/github-linux/badge.svg)](https://github.com/dealii/dealii/actions?query=workflow%3Agithub-linux)
-[![workflows/github-OSX](https://github.com/dealii/dealii/workflows/github-OSX/badge.svg)](https://github.com/dealii/dealii/actions?query=workflow%3Agithub-OSX)
-[![workflows/github-windows](https://github.com/dealii/dealii/workflows/github-windows/badge.svg)](https://github.com/dealii/dealii/actions?query=workflow%3Agithub-windows)
+[![workflows/github-docker](https://github.com/dealii/dealii/actions/workflows/docker.yml/badge.svg?branch=master)](https://github.com/dealii/dealii/actions/workflows/docker.yml?query=branch%3Amaster)
+[![workflows/indent](https://github.com/dealii/dealii/actions/workflows/indent.yml/badge.svg?branch=master)](https://github.com/dealii/dealii/actions/workflows/indent.yml?query=branch%3Amaster)
+[![workflows/tidy](https://github.com/dealii/dealii/actions/workflows/tidy.yml/badge.svg?branch=master)](https://github.com/dealii/dealii/actions/workflows/tidy.yml?query=branch%3Amaster)
+[![workflows/github-linux](https://github.com/dealii/dealii/actions/workflows/linux.yml/badge.svg?branch=master)](https://github.com/dealii/dealii/actions/workflows/linux.yml?query=branch%3Amaster)
+[![workflows/github-OSX](https://github.com/dealii/dealii/actions/workflows/osx.yml/badge.svg?branch=master)](https://github.com/dealii/dealii/actions/workflows/osx.yml?query=branch%3Amaster)
+[![workflows/github-windows](https://github.com/dealii/dealii/actions/workflows/windows.yml/badge.svg?branch=master)](https://github.com/dealii/dealii/actions/workflows/windows.yml?query=branch%3Amaster)
 
 What is deal.II?
 ================


### PR DESCRIPTION
Github changed the links to access the badges which is why some of them were stuck in the `failing` stage.

See also:
- https://github.com/actions/starter-workflows/issues/1525#issuecomment-1763431305
- https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge

These are the updated badges/links:
[![workflows/github-docker](https://github.com/dealii/dealii/actions/workflows/docker.yml/badge.svg)](https://github.com/dealii/dealii/actions/workflows/docker.yml)
[![workflows/indent](https://github.com/dealii/dealii/actions/workflows/indent.yml/badge.svg)](https://github.com/dealii/dealii/actions/workflows/indent.yml)
[![workflows/tidy](https://github.com/dealii/dealii/actions/workflows/tidy.yml/badge.svg)](https://github.com/dealii/dealii/actions/workflows/tidy.yml)
[![workflows/github-linux](https://github.com/dealii/dealii/actions/workflows/linux.yml/badge.svg)](https://github.com/dealii/dealii/actions/workflows/linux.yml)
[![workflows/github-OSX](https://github.com/dealii/dealii/actions/workflows/osx.yml/badge.svg)](https://github.com/dealii/dealii/actions/workflows/osx.yml)
[![workflows/github-windows](https://github.com/dealii/dealii/actions/workflows/windows.yml/badge.svg)](https://github.com/dealii/dealii/actions/workflows/windows.yml)