### PR TITLE
Fix the assert condition in trilinos_tpetra_vector.templates.h

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -243,7 +243,7 @@ namespace LinearAlgebra
             const TpetraWrappers::CommunicationPattern>(communication_pattern);
 
           AssertThrow(
-            tpetra_comm_pattern.is_null(),
+            !tpetra_comm_pattern.is_null(),
             ExcMessage(
               std::string("The communication pattern is not of type ") +
               "LinearAlgebra::TpetraWrappers::CommunicationPattern."));


### PR DESCRIPTION
As pointed out by @bangerth, pull request #16156 introduces a mistake in one of the asserts in `trilinos_tpetra_vector.templates.h`.

This is the fix for that mistake.