### PR TITLE
Add MemoryConsumption::memory_consumption() overloads for Lazy<T>

### DIFF
--- a/include/deal.II/base/lazy.h
+++ b/include/deal.II/base/lazy.h
@@ -20,6 +20,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/mutex.h>
 
 #include <atomic>
@@ -193,6 +194,12 @@ public:
   DEAL_II_ALWAYS_INLINE inline T &
   value_or_initialize(const Callable &creator);
 
+
+  /**
+   * Compute the memory consumption of this structure.
+   */
+  std::size_t
+  memory_consumption() const;
 
 private:
   /**
@@ -393,6 +400,15 @@ Lazy<T>::value_or_initialize(const Callable &creator)
 {
   ensure_initialized(creator);
   return object.value();
+}
+
+
+template <typename T>
+std::size_t
+Lazy<T>::memory_consumption() const
+{
+  return MemoryConsumption::memory_consumption(object) + //
+         sizeof(*this) - sizeof(object);
 }
 
 

--- a/include/deal.II/base/memory_consumption.h
+++ b/include/deal.II/base/memory_consumption.h
@@ -24,6 +24,7 @@
 #include <cstddef>
 #include <cstring>
 #include <memory>
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -221,6 +222,14 @@ namespace MemoryConsumption
   memory_consumption(const std::pair<A, B> &p);
 
   /**
+   * Determine an estimate of the amount of memory in bytes consumed by a
+   * value wrapped in a std::optional.
+   */
+  template <typename A>
+  inline std::size_t
+  memory_consumption(const std::optional<A> &o);
+
+  /**
    * Calculate the memory consumption of a pointer.
    *
    * @note This function is overloaded for C-style strings; see the
@@ -376,6 +385,31 @@ namespace MemoryConsumption
   memory_consumption(const std::pair<A, B> &p)
   {
     return (memory_consumption(p.first) + memory_consumption(p.second));
+  }
+
+
+
+  template <typename A>
+  inline std::size_t
+  memory_consumption(const std::optional<A> &o)
+  {
+    if (o.has_value())
+      {
+        //
+        // If the optional carries a value then we query the contained
+        // value for memory consumption and estimate the size of the
+        // control overhead.
+        //
+        return memory_consumption(o.value()) + sizeof(o) - sizeof(A);
+      }
+    else
+      {
+        //
+        // The optional contains no value, so simply return its plain size
+        // (consisting of space for the value and control overhead):
+        //
+        return sizeof(o);
+      }
   }
 
 


### PR DESCRIPTION
- base/memory_consumption.h: add specialization for std::optional<T>
- base/lazy.h: add memory_consumption method to Lazy<T>

In reference to #16204
