### PR TITLE
Fix use of flags in CUDAWrappers::MatrixFree

### DIFF
--- a/include/deal.II/matrix_free/cuda_fe_evaluation.h
+++ b/include/deal.II/matrix_free/cuda_fe_evaluation.h
@@ -419,12 +419,12 @@ namespace CUDAWrappers
         evaluator_tensor_product.integrate_value_and_gradient(
           shared_data->values, shared_data->gradients);
       }
-    else if (integration_flag & EvaluationFlags::gradients)
+    else if (integration_flag & EvaluationFlags::values)
       {
         evaluator_tensor_product.integrate_value(shared_data->values);
         shared_data->team_member.team_barrier();
       }
-    else if (integration_flag & EvaluationFlags::values)
+    else if (integration_flag & EvaluationFlags::gradients)
       {
         evaluator_tensor_product.template integrate_gradient<false>(
           shared_data->values, shared_data->gradients);

--- a/tests/performance/timing_matrix_free_kokkos.cc
+++ b/tests/performance/timing_matrix_free_kokkos.cc
@@ -145,10 +145,10 @@ public:
     CUDAWrappers::FEEvaluation<dim, fe_degree, fe_degree + 1, 1, Number>
       fe_eval(/*cell,*/ gpu_data, shared_data);
     fe_eval.read_dof_values(src);
-    fe_eval.evaluate(false, true);
+    fe_eval.evaluate(EvaluationFlags::gradients);
     fe_eval.apply_for_each_quad_point(
       LaplaceOperatorQuad<dim, fe_degree, Number>());
-    fe_eval.integrate(false, true);
+    fe_eval.integrate(EvaluationFlags::gradients);
     fe_eval.distribute_local_to_global(dst);
   }
   static const unsigned int n_dofs_1d    = fe_degree + 1;


### PR DESCRIPTION
Bug introduced in https://github.com/dealii/dealii/pull/16203. For some reasons the statements are switched in `integrate()` and `evaluate()`.