### PR TITLE
Remove an unnecessary friend declaration.

### DIFF
--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -100,10 +100,6 @@ namespace BlockMatrixIterators
      * Block column into which we presently point.
      */
     unsigned int col_block;
-
-    // Let the iterator class be a friend.
-    template <typename>
-    friend class MatrixIterator;
   };
 
 


### PR DESCRIPTION
While looking into #16225. This is in the base class of the const and non-const accessors. It holds details of these accessors. The iterator does not need to know about it, and apparently doesn't care because this compiles and tests cleanly for me.