### PR TITLE
Better structure some code in the gmsh wrappers.

### DIFF
--- a/include/deal.II/gmsh/utilities.h
+++ b/include/deal.II/gmsh/utilities.h
@@ -70,12 +70,15 @@ namespace Gmsh
     double characteristic_length = 1.0;
 
     /**
-     * Basename for the output files.
+     * Base name for the output files. The base name may contain a directory
+     * (followed by a slash), and must contain the base of the names of files
+     * to be created.
      *
-     * If this is left empty, then temporary files are used, and removed when
-     * not needed any more.
+     * If this variable is left empty, then a temporary directory will be used,
+     * and both the files written into it as well as the temporary directory
+     * will be removed when not needed any more.
      */
-    std::string output_base_name = "";
+    std::string output_base_name = {};
   };
 
 #  ifdef DEAL_II_WITH_OPENCASCADE

--- a/source/gmsh/utilities.cc
+++ b/source/gmsh/utilities.cc
@@ -59,11 +59,16 @@ namespace Gmsh
                                            Triangulation<2, spacedim> &tria,
                                            const AdditionalParameters &prm)
   {
-    std::string base_name      = prm.output_base_name;
-    char        dir_template[] = "ctfbc-XXXXXX";
-    if (base_name.empty())
+    std::string base_name = prm.output_base_name;
+
+    // If necessary, create a temp directory to put files into. The
+    // following variable will hold the name of the tmp dir; it is
+    // initialized with a template, and 'mkdtemp' then overwrites it
+    // with the name of the directory it creates.
+    char tmp_dir_name[] = "ctfbc-XXXXXX";
+    if (prm.output_base_name.empty())
       {
-        const char *temp = mkdtemp(dir_template);
+        const char *temp = mkdtemp(tmp_dir_name);
         AssertThrow(temp != nullptr,
                     ExcMessage("Creating temporary directory failed!"));
         base_name = temp;
@@ -105,7 +110,8 @@ namespace Gmsh
     gridin.attach_triangulation(tria);
     gridin.read_msh(grid_file);
 
-    if (base_name != prm.output_base_name)
+    // Clean up files if a tmp directory was used:
+    if (prm.output_base_name.empty())
       {
         // declaring the list without a type, i.e.,
         //
@@ -125,10 +131,12 @@ namespace Gmsh
             AssertThrow(ret_value == 0,
                         ExcMessage("Failed to remove " + *filename));
           }
-        const auto ret_value = std::remove(dir_template);
+
+        // Finally also remove the tmp directory:
+        const auto ret_value = std::remove(tmp_dir_name);
         AssertThrow(ret_value == 0,
                     ExcMessage("Failed to remove " +
-                               std::string(dir_template)));
+                               std::string(tmp_dir_name)));
       }
   }
 #  endif


### PR DESCRIPTION
While looking into #6510. The `dir_template` variable had me stumped for a while until I realized that `mkdtemp` writes something into this variable.