### PR TITLE
Extend assert message of `GridTools::exchange_cell_data()`

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -3382,7 +3382,12 @@ namespace GridTools
               "operate on a single layer of ghost cells. However, you have "
               "given a Triangulation object of type "
               "parallel::shared::Triangulation without artificial cells "
-              "resulting in arbitrary numbers of ghost layers."));
+              "resulting in an arbitrary number of ghost layers. "
+              "To use this function for a Triangulation object of type "
+              "parallel::shared::Triangulation, make sure to create the "
+              "Triangulation object with allow_artificial_cells set to true. "
+              "This results in a parallel::shared::Triangulation with only "
+              "a single layer of ghost cells."));
         }
 
       // build list of cells to request for each neighbor


### PR DESCRIPTION
The existing assert message of `GridTools::exchange_cell_data()` made me believe that the functionality could not be used at all with a parallel::shared::Triangulation. Since this is not the case, this PR suggests to extend the assert message by providing guidance on how to use the function with a parallel::shared::Triangulation as well.