### PR TITLE
Actually fix Triangulation copydocs

### DIFF
--- a/include/deal.II/distributed/fully_distributed_tria.h
+++ b/include/deal.II/distributed/fully_distributed_tria.h
@@ -134,7 +134,16 @@ namespace parallel
       virtual ~Triangulation() = default;
 
       /**
-       * @copydoc deal.II/grid/tria.h Triangulation::create_triangulation(const TriangulationDescription::Description<dim, spacedim>&)
+       * Create a triangulation from the provided
+       * TriangulationDescription::Description.
+       *
+       * @note Don't forget to attach the manifolds with set_manifold() before
+       *   calling this function if manifolds are needed.
+       *
+       * @note The namespace TriangulationDescription::Utilities contains functions
+       *   to create TriangulationDescription::Description.
+       *
+       * @param construction_data The data needed for this process.
        *
        * @note This is the function to be used instead of
        * Triangulation::create_triangulation() for some of the other

--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -211,7 +211,16 @@ namespace parallel
       const unsigned int level) const override;
 
     /**
-     * @copydoc deal.II/grid/tria.h Triangulation::get_boundary_ids()
+     * Return a vector containing all boundary indicators assigned to boundary
+     * faces of active cells of this Triangulation object. Note, that each
+     * boundary indicator is reported only once. The size of the return vector
+     * will represent the number of different indicators (which is greater or
+     * equal one).
+     *
+     * @ingroup boundary
+     *
+     * @see
+     * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
      *
      * @note This function involves a global communication gathering all current
      *   IDs from all processes.
@@ -220,7 +229,16 @@ namespace parallel
     get_boundary_ids() const override;
 
     /**
-     * @copydoc deal.II/grid/tria.h Triangulation::get_manifold_ids()
+     * Return a vector containing all manifold indicators assigned to the
+     * objects of the active cells of this Triangulation. Note, that each
+     * manifold indicator is reported only once. The size of the return vector
+     * will represent the number of different indicators (which is greater or
+     * equal one).
+     *
+     * @ingroup manifold
+     *
+     * @see
+     * @ref GlossManifoldIndicator "Glossary entry on manifold indicators"
      *
      * @note This function involves a global communication gathering all current
      *   IDs from all processes.
@@ -370,9 +388,6 @@ namespace parallel
     virtual void
     update_number_cache();
 
-    /**
-     * @copydoc deal.II/grid/tria.h Triangulation::update_reference_cells()
-     */
     void
     update_reference_cells() override;
 


### PR DESCRIPTION
Addendum to #16069 
Therein the copydoc functionality for some Triangulation functions was only partially fixed.
Using `@copydoc <filename>  <class>::<function>(<params>)` would add a link to the base `dealii::Triangulation` class function for `parallel::TriangulationBase` and for `parallel::fullydistributed::Triangulation` it would point to itself.
This PR now actually fixes the copydoc relations by moving the documentation and linking to it from the other class.