### PR TITLE
Use the standard form of lambda expressions.

### DIFF
--- a/include/deal.II/lac/sparse_vanka.templates.h
+++ b/include/deal.II/lac/sparse_vanka.templates.h
@@ -568,8 +568,9 @@ SparseBlockVanka<number>::vmult(Vector<number2>       &dst,
 
   Threads::TaskGroup<> tasks;
   for (unsigned int block = 0; block < n_blocks; ++block)
-    tasks += Threads::new_task(
-      [&, block] { this->apply_preconditioner(dst, src, &dof_masks[block]); });
+    tasks += Threads::new_task([&, block]() {
+      this->apply_preconditioner(dst, src, &dof_masks[block]);
+    });
   tasks.join_all();
 }
 

--- a/source/base/kokkos.cc
+++ b/source/base/kokkos.cc
@@ -37,7 +37,7 @@ namespace internal
     )
       {
         // only execute once
-        static bool dummy = [] {
+        static bool dummy = []() {
           dealii_initialized_kokkos = true;
 #if KOKKOS_VERSION >= 30700
           const auto settings =

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -2741,7 +2741,7 @@ void DoFHandler<dim, spacedim>::connect_to_triangulation_signals()
           [this]() { this->pre_distributed_transfer_action(); }));
       this->tria_listeners_for_transfer.push_back(
         this->tria->signals.post_distributed_repartition.connect(
-          [this] { this->post_distributed_transfer_action(); }));
+          [this]() { this->post_distributed_transfer_action(); }));
 
       // refinement signals
       this->tria_listeners_for_transfer.push_back(
@@ -2778,20 +2778,20 @@ void DoFHandler<dim, spacedim>::connect_to_triangulation_signals()
         }));
       this->tria_listeners_for_transfer.push_back(
         this->tria->signals.pre_refinement.connect(
-          [this] { this->pre_transfer_action(); }));
+          [this]() { this->pre_transfer_action(); }));
       this->tria_listeners_for_transfer.push_back(
         this->tria->signals.post_refinement.connect(
-          [this] { this->post_transfer_action(); }));
+          [this]() { this->post_transfer_action(); }));
     }
   else
     {
       // refinement signals
       this->tria_listeners_for_transfer.push_back(
         this->tria->signals.pre_refinement.connect(
-          [this] { this->pre_transfer_action(); }));
+          [this]() { this->pre_transfer_action(); }));
       this->tria_listeners_for_transfer.push_back(
         this->tria->signals.post_refinement.connect(
-          [this] { this->post_transfer_action(); }));
+          [this]() { this->post_transfer_action(); }));
     }
 }
 


### PR DESCRIPTION
For lambda functions not taking arguments, it is *possible* to omit the `()` part. But we don't do it in all but a handful of places. Introduce the parentheses there as well.