### PR TITLE
Make a function not 'virtual'.

### DIFF
--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -375,7 +375,7 @@ private:
    * @p new_points to point to the same array, so make sure to pass different
    * objects into the function.
    */
-  virtual void
+  void
   get_new_points(const ArrayView<const Point<spacedim>> &surrounding_points,
                  const ArrayView<const double>          &weights,
                  ArrayView<Point<spacedim>>              new_points) const;


### PR DESCRIPTION
In https://github.com/geodynamics/aspect/pull/5474, I'm running into an issue for which I have truly no explanation because the compiler error appears to be truncated. But @gassmoeller 's comment in https://github.com/geodynamics/aspect/pull/5474#issuecomment-1792925751 pointed me to the fact that the `SphericalManifold` class has a `private` `virtual` function of the same name as the public interface methods of the class to which the various variations of `get_new_point()` and `get_new_points()` functions defer. This *additional* function is also called `get_new_points()` *and* it is `virtual`. I bet that is by mistake -- there is really no good reason to make a `private` function `virtual` unless your goal is to confuse everyone involved or make the program pointlessly slow.

This patch removes the `virtual` from the function.