### PR TITLE
Rename internal functions.

### DIFF
--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -342,28 +342,11 @@ private:
                   const ArrayView<const double>              &weights) const;
 
   /**
-   * Return a point on the spherical manifold which is intermediate
-   * with respect to the surrounding points. This function uses a candidate
-   * point as guess, and performs a Newton-style iteration to compute the
-   * correct point.
+   * This function provides an internal implementation of the get_new_points()
+   * interface.
    *
-   * The main part of the implementation uses the ideas in the publication
-   *
-   * Buss, Samuel R., and Jay P. Fillmore.
-   * "Spherical averages and applications to spherical splines and
-   * interpolation." ACM Transactions on Graphics (TOG) 20.2 (2001): 95-126.
-   *
-   * and in particular the implementation provided at
-   * http://math.ucsd.edu/~sbuss/ResearchWeb/spheremean/
-   */
-  Point<spacedim>
-  get_new_point(const ArrayView<const Tensor<1, spacedim>> &directions,
-                const ArrayView<const double>              &distances,
-                const ArrayView<const double>              &weights,
-                const Point<spacedim> &candidate_point) const;
-
-  /**
-   * Compute a new set of points that interpolate between the given points @p
+   * It computes a new set of points that interpolate between the given points
+   * @p
    * surrounding_points. @p weights is an array view with as many entries as @p
    * surrounding_points.size() times @p new_points.size().
    *
@@ -376,9 +359,9 @@ private:
    * objects into the function.
    */
   void
-  get_new_points(const ArrayView<const Point<spacedim>> &surrounding_points,
-                 const ArrayView<const double>          &weights,
-                 ArrayView<Point<spacedim>>              new_points) const;
+  do_get_new_points(const ArrayView<const Point<spacedim>> &surrounding_points,
+                    const ArrayView<const double>          &weights,
+                    ArrayView<Point<spacedim>>              new_points) const;
 
   /**
    * A manifold description to be used for get_new_point in 2d.


### PR DESCRIPTION
https://github.com/geodynamics/aspect/pull/5474 illustrates that an inadvertant addition of `virtual` to an internal function leads to a complete disaster preventing anyone from deriving from that class in a meaningful way. Here's the summary:

The base class, at least before https://github.com/dealii/dealii/pull/16242 basically looked like this:
```
class X {   // really SphericalManifold
  public:
    virtual void f();
  private:
    virtual void f(int);
};
```
If you derive from it, you don't care about the `private` member function of the same name as the `public` one. It's none of our business. But if we overload only the `public` one, like in
```
class Y : public X {
  public:
    virtual void f() override;
};
```
then the compiler says that this *hides* the other member function, and the warning is converted to an error. So one tries this:
```
class Y : public X {
  public:
    virtual void f() override;
  private:
    virtual void f(int) override;
};
```
This silences the warning about hiding the other function, but now we don't know how to *implement* the overload: It should really just call the function in the base class, but that function is `private` and so we can't do
```
void Y::f(int i) { return X::f(i); }
```

It just isn't possible to derive correctly from a base class that has a `virtual` `private` member function of the same name `virtual` `public` member function. We just shot ourselves in the foot by declaring that internal function as `virtual` by accident :-(

#16242 already removes the `virtual` from the offending function declaration, but I continue to find it awkward that we now have `virtual` and non-`virtual` functions of the same name. Since name lookup happens without regard to access specifiers (`public`, `protected`, `private`), *and only then does a compiler determine whether the function is accessible*, this is not a great design. The patch therefore renames the internal functions so that they have different names than the `public` `virtual` ones.