### PR TITLE
Add a changelog entry.

### DIFF
--- a/doc/news/changes/minor/20231109Bangerth
+++ b/doc/news/changes/minor/20231109Bangerth
@@ -1,0 +1,5 @@
+Fixed: A mistake in marking a `private` member function of the
+SphericalManifold class made it impossible to derive from this class
+in any meaningful way. This is now fixed.
+<br>
+(Wolfgang Bangerth, 2023/11/09)


### PR DESCRIPTION
This should have gone with #16242 and #16248.