### PR TITLE
Erronius VectorTools::NormType::* has been replaced with VectorTools:…

### DIFF
--- a/doc/news/8.2.1-vs-8.3.0.h
+++ b/doc/news/8.2.1-vs-8.3.0.h
@@ -753,7 +753,7 @@ inconvenience this causes.
 
   <li> New: The VectorTools::integrate_difference() function can now
   also compute the $H_\text{div}$ seminorm, using the
-  VectorTools::NormType::Hdiv_seminorm argument.
+  VectorTools::Hdiv_seminorm argument.
   <br>
   (Zhen Tao, Arezou Ghesmati, Wolfgang Bangerth, 2015/04/17)
   </li>

--- a/include/deal.II/distributed/grid_refinement.h
+++ b/include/deal.II/distributed/grid_refinement.h
@@ -204,8 +204,8 @@ namespace parallel
        * @param[in] norm_type To determine thresholds, combined errors on
        * subsets of cells are calculated as norms of the criteria on these
        * cells. Different types of norms can be used for this purpose, from
-       * which VectorTools::NormType::L1_norm and
-       * VectorTools::NormType::L2_norm are currently supported.
+       * which VectorTools::L1_norm and
+       * VectorTools::L2_norm are currently supported.
        */
       template <int dim, typename Number, int spacedim>
       void
@@ -214,7 +214,7 @@ namespace parallel
         const dealii::Vector<Number>         &criteria,
         const double                          top_fraction_of_error,
         const double                          bottom_fraction_of_error,
-        const VectorTools::NormType norm_type = VectorTools::NormType::L1_norm);
+        const VectorTools::NormType           norm_type = VectorTools::L1_norm);
     } // namespace GridRefinement
   }   // namespace distributed
 } // namespace parallel

--- a/include/deal.II/grid/grid_refinement.h
+++ b/include/deal.II/grid/grid_refinement.h
@@ -226,8 +226,8 @@ namespace GridRefinement
    * @param[in] norm_type To determine thresholds, combined errors on
    * subsets of cells are calculated as norms of the criteria on these
    * cells. Different types of norms can be used for this purpose, from
-   * which VectorTools::NormType::L1_norm and
-   * VectorTools::NormType::L2_norm are currently supported.
+   * which VectorTools::L1_norm and
+   * VectorTools::L2_norm are currently supported.
    */
   template <int dim, typename Number, int spacedim>
   void
@@ -237,7 +237,7 @@ namespace GridRefinement
     const double                  top_fraction,
     const double                  bottom_fraction,
     const unsigned int max_n_cells = std::numeric_limits<unsigned int>::max(),
-    const VectorTools::NormType norm_type = VectorTools::NormType::L1_norm);
+    const VectorTools::NormType norm_type = VectorTools::L1_norm);
 
 
 

--- a/source/distributed/grid_refinement.cc
+++ b/source/distributed/grid_refinement.cc
@@ -595,7 +595,7 @@ namespace parallel
 
         switch (norm_type)
           {
-            case VectorTools::NormType::L1_norm:
+            case VectorTools::L1_norm:
               // evaluate norms on subsets and compare them as
               //   c_0 + c_1 + ... < fraction * l1-norm(c)
               refine_and_coarsen_fixed_fraction_via_l1_norm(
@@ -605,7 +605,7 @@ namespace parallel
                 bottom_fraction_of_error);
               break;
 
-            case VectorTools::NormType::L2_norm:
+            case VectorTools::L2_norm:
               {
                 // we do not want to evaluate norms on subsets as:
                 //   sqrt(c_0^2 + c_1^2 + ...) < fraction * l2-norm(c)

--- a/source/grid/grid_refinement.cc
+++ b/source/grid/grid_refinement.cc
@@ -404,14 +404,14 @@ GridRefinement::refine_and_coarsen_fixed_fraction(
 
   switch (norm_type)
     {
-      case VectorTools::NormType::L1_norm:
+      case VectorTools::L1_norm:
         // evaluate norms on subsets and compare them as
         //   c_0 + c_1 + ... < fraction * l1-norm(c)
         refine_and_coarsen_fixed_fraction_via_l1_norm(
           tria, criteria, top_fraction, bottom_fraction, max_n_cells);
         break;
 
-      case VectorTools::NormType::L2_norm:
+      case VectorTools::L2_norm:
         {
           // we do not want to evaluate norms on subsets as:
           //   sqrt(c_0^2 + c_1^2 + ...) < fraction * l2-norm(c)

--- a/tests/grid/refine_and_coarsen_fixed_fraction_03.cc
+++ b/tests/grid/refine_and_coarsen_fixed_fraction_03.cc
@@ -73,7 +73,7 @@ test()
     0.3,
     0.3,
     std::numeric_limits<unsigned int>::max(),
-    VectorTools::NormType::L1_norm);
+    VectorTools::L1_norm);
   count_flags(tria);
   deallog << std::endl;
 
@@ -91,7 +91,7 @@ test()
     0.3,
     0.3,
     std::numeric_limits<unsigned int>::max(),
-    VectorTools::NormType::L2_norm);
+    VectorTools::L2_norm);
   count_flags(tria);
   deallog << std::endl;
 }

--- a/tests/grid/refine_and_coarsen_fixed_fraction_04.cc
+++ b/tests/grid/refine_and_coarsen_fixed_fraction_04.cc
@@ -74,7 +74,7 @@ test()
     0.3,
     0.3,
     std::numeric_limits<unsigned int>::max(),
-    VectorTools::NormType::L1_norm);
+    VectorTools::L1_norm);
   count_flags(tria);
   deallog << std::endl;
 
@@ -92,7 +92,7 @@ test()
     0.3,
     0.3,
     std::numeric_limits<unsigned int>::max(),
-    VectorTools::NormType::L2_norm);
+    VectorTools::L2_norm);
   count_flags(tria);
   deallog << std::endl;
 }

--- a/tests/matrix_free/poisson_dg_hp.cc
+++ b/tests/matrix_free/poisson_dg_hp.cc
@@ -301,12 +301,10 @@ test(const unsigned int degree)
                                       Functions::ZeroFunction<dim>(),
                                       difference,
                                       quad,
-                                      VectorTools::NormType::L2_norm);
+                                      VectorTools::L2_norm);
 
     const double error =
-      VectorTools::compute_global_error(tria,
-                                        difference,
-                                        VectorTools::NormType::L2_norm);
+      VectorTools::compute_global_error(tria, difference, VectorTools::L2_norm);
 
     if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
       printf("Error %f.\n", error);

--- a/tests/matrix_free/step-37-inhomogeneous-1.cc
+++ b/tests/matrix_free/step-37-inhomogeneous-1.cc
@@ -595,7 +595,7 @@ namespace Step37
                                       ManufacturedSolution<dim>(),
                                       errors,
                                       QIterated<dim>(QTrapezoid<1>(), 4),
-                                      VectorTools::NormType::Linfty_norm);
+                                      VectorTools::Linfty_norm);
     double max_cell_error = 1.0;
     if (errors.begin() != errors.end())
       max_cell_error = *std::max_element(errors.begin(), errors.end());

--- a/tests/mpi/refine_and_coarsen_fixed_fraction_08.cc
+++ b/tests/mpi/refine_and_coarsen_fixed_fraction_08.cc
@@ -77,7 +77,7 @@ test()
 
   deallog << "l1-norm: ";
   parallel::distributed::GridRefinement::refine_and_coarsen_fixed_fraction(
-    tria, indicator, 0.3, 0.3, VectorTools::NormType::L1_norm);
+    tria, indicator, 0.3, 0.3, VectorTools::L1_norm);
   count_flags(tria);
   deallog << std::endl;
 
@@ -91,7 +91,7 @@ test()
 
   deallog << "l2-norm: ";
   parallel::distributed::GridRefinement::refine_and_coarsen_fixed_fraction(
-    tria, indicator, 0.3, 0.3, VectorTools::NormType::L2_norm);
+    tria, indicator, 0.3, 0.3, VectorTools::L2_norm);
   count_flags(tria);
   deallog << std::endl;
 }

--- a/tests/mpi/refine_and_coarsen_fixed_fraction_09.cc
+++ b/tests/mpi/refine_and_coarsen_fixed_fraction_09.cc
@@ -78,7 +78,7 @@ test()
 
   deallog << "l1-norm: ";
   parallel::distributed::GridRefinement::refine_and_coarsen_fixed_fraction(
-    tria, indicator, 0.3, 0.3, VectorTools::NormType::L1_norm);
+    tria, indicator, 0.3, 0.3, VectorTools::L1_norm);
   count_flags(tria);
   deallog << std::endl;
 
@@ -92,7 +92,7 @@ test()
 
   deallog << "l2-norm: ";
   parallel::distributed::GridRefinement::refine_and_coarsen_fixed_fraction(
-    tria, indicator, 0.3, 0.3, VectorTools::NormType::L2_norm);
+    tria, indicator, 0.3, 0.3, VectorTools::L2_norm);
   count_flags(tria);
   deallog << std::endl;
 }

--- a/tests/multigrid-global-coarsening/step-37-inhomogeneous-1.cc
+++ b/tests/multigrid-global-coarsening/step-37-inhomogeneous-1.cc
@@ -595,7 +595,7 @@ namespace Step37
                                       ManufacturedSolution<dim>(),
                                       errors,
                                       QIterated<dim>(QTrapezoid<1>(), 4),
-                                      VectorTools::NormType::Linfty_norm);
+                                      VectorTools::Linfty_norm);
     double max_cell_error = 1.0;
     if (errors.begin() != errors.end())
       max_cell_error = *std::max_element(errors.begin(), errors.end());

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_01.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_01.cc
@@ -249,12 +249,10 @@ test()
                                     AnalyticalFunction<dim>(),
                                     difference,
                                     quadrature_2,
-                                    VectorTools::NormType::L2_norm);
+                                    VectorTools::L2_norm);
 
   double error =
-    VectorTools::compute_global_error(tria_2,
-                                      difference,
-                                      VectorTools::NormType::L2_norm);
+    VectorTools::compute_global_error(tria_2, difference, VectorTools::L2_norm);
 
 
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD))

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_03.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_03.cc
@@ -228,12 +228,10 @@ test()
                                     Functions::CosineFunction<2>(),
                                     difference,
                                     quadrature_2,
-                                    VectorTools::NormType::L2_norm);
+                                    VectorTools::L2_norm);
 
   double error =
-    VectorTools::compute_global_error(tria_2,
-                                      difference,
-                                      VectorTools::NormType::L2_norm);
+    VectorTools::compute_global_error(tria_2, difference, VectorTools::L2_norm);
 
 
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD))

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_05.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_05.cc
@@ -218,12 +218,10 @@ test()
                                     AnalyticalFunction<dim>(),
                                     difference,
                                     quadrature_2,
-                                    VectorTools::NormType::L2_norm);
+                                    VectorTools::L2_norm);
 
   double error =
-    VectorTools::compute_global_error(tria_2,
-                                      difference,
-                                      VectorTools::NormType::L2_norm);
+    VectorTools::compute_global_error(tria_2, difference, VectorTools::L2_norm);
 
 
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD))

--- a/tests/simplex/matrix_free_02.cc
+++ b/tests/simplex/matrix_free_02.cc
@@ -206,7 +206,7 @@ test(const unsigned version, const unsigned int degree, const bool do_helmholtz)
                                       Functions::ZeroFunction<dim>(),
                                       difference,
                                       quads,
-                                      VectorTools::NormType::L2_norm);
+                                      VectorTools::L2_norm);
 
     std::tuple<unsigned int, double, double, double> result(
       reduction_control.last_step(),
@@ -214,7 +214,7 @@ test(const unsigned version, const unsigned int degree, const bool do_helmholtz)
       x.linfty_norm(),
       VectorTools::compute_global_error(tria,
                                         difference,
-                                        VectorTools::NormType::L2_norm));
+                                        VectorTools::L2_norm));
 
     return result;
   };

--- a/tests/simplex/matrix_free_03.cc
+++ b/tests/simplex/matrix_free_03.cc
@@ -363,11 +363,11 @@ test(const unsigned int degree)
                                       Functions::ZeroFunction<dim>(),
                                       difference,
                                       quadrature,
-                                      VectorTools::NormType::L2_norm);
+                                      VectorTools::L2_norm);
 
     deallog << VectorTools::compute_global_error(tria,
                                                  difference,
-                                                 VectorTools::NormType::L2_norm)
+                                                 VectorTools::L2_norm)
             << std::endl;
 
     return {reduction_control.last_step(), reduction_control.last_value()};

--- a/tests/simplex/matrix_free_04.cc
+++ b/tests/simplex/matrix_free_04.cc
@@ -312,12 +312,10 @@ test(const unsigned version, const unsigned int degree)
                                       Functions::ZeroFunction<dim>(),
                                       difference,
                                       quads,
-                                      VectorTools::NormType::L2_norm);
+                                      VectorTools::L2_norm);
 
     const double error =
-      VectorTools::compute_global_error(tria,
-                                        difference,
-                                        VectorTools::NormType::L2_norm);
+      VectorTools::compute_global_error(tria, difference, VectorTools::L2_norm);
 
     if (error < 0.042)
       deallog << "OK" << std::endl;

--- a/tests/simplex/poisson_01.cc
+++ b/tests/simplex/poisson_01.cc
@@ -317,10 +317,11 @@ test(const Triangulation<dim, spacedim> &tria,
                                         Functions::ZeroFunction<dim>(),
                                         difference,
                                         quad,
-                                        VectorTools::NormType::L2_norm);
+                                        VectorTools::L2_norm);
 
-      deallog << VectorTools::compute_global_error(
-                   tria, difference, VectorTools::NormType::L2_norm)
+      deallog << VectorTools::compute_global_error(tria,
+                                                   difference,
+                                                   VectorTools::L2_norm)
               << std::endl;
       DataOut<dim> data_out;
 

--- a/tests/simplex/step-40.cc
+++ b/tests/simplex/step-40.cc
@@ -310,11 +310,11 @@ namespace Step40
                                       Functions::ZeroFunction<dim>(),
                                       difference,
                                       quadrature_formula,
-                                      VectorTools::NormType::L2_norm);
+                                      VectorTools::L2_norm);
 
     deallog << VectorTools::compute_global_error(triangulation,
                                                  difference,
-                                                 VectorTools::NormType::L2_norm)
+                                                 VectorTools::L2_norm)
             << std::endl;
   }
 


### PR DESCRIPTION
…:* in all files. Primarily, this fixes the clickability in doxygen for the two grid_refinement.h files.