### PR TITLE
Symmetric tensor cleanup

### DIFF
--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -2092,43 +2092,8 @@ namespace internal
                           typename SymmetricTensorAccessors::
                             StorageType<2, dim, Number>::base_tensor_type &data)
   {
-    // 1d is very simple and done first
-    if (dim == 1)
-      return data[0];
-
-    // first treat the main diagonal elements, which are stored consecutively
-    // at the beginning
-    if (indices[0] == indices[1])
-      return data[indices[0]];
-
-    // the rest is messier and requires a few switches.
-    switch (dim)
-      {
-        case 2:
-          // at least for the 2x2 case it is reasonably simple
-          Assert(((indices[0] == 1) && (indices[1] == 0)) ||
-                   ((indices[0] == 0) && (indices[1] == 1)),
-                 ExcInternalError());
-          return data[2];
-
-        default:
-          // to do the rest, sort our indices before comparing
-          {
-            TableIndices<2> sorted_indices(std::min(indices[0], indices[1]),
-                                           std::max(indices[0], indices[1]));
-            for (unsigned int d = 0, c = 0; d < dim; ++d)
-              for (unsigned int e = d + 1; e < dim; ++e, ++c)
-                if ((sorted_indices[0] == d) && (sorted_indices[1] == e))
-                  return data[dim + c];
-            Assert(false, ExcInternalError());
-          }
-      }
-
-    // The code should never reach here.
-    // We cannot return a static variable, as this class must support number
-    // types that require no instances of the number type to be in scope during
-    // a reinitialization procedure (e.g. ADOL-C adtl::adouble).
-    return data[0];
+    return data[SymmetricTensorImplementation::component_to_unrolled_index<dim>(
+      indices)];
   }
 
 
@@ -2139,43 +2104,8 @@ namespace internal
                           const typename SymmetricTensorAccessors::
                             StorageType<2, dim, Number>::base_tensor_type &data)
   {
-    // 1d is very simple and done first
-    if (dim == 1)
-      return data[0];
-
-    // first treat the main diagonal elements, which are stored consecutively
-    // at the beginning
-    if (indices[0] == indices[1])
-      return data[indices[0]];
-
-    // the rest is messier and requires a few switches.
-    switch (dim)
-      {
-        case 2:
-          // at least for the 2x2 case it is reasonably simple
-          Assert(((indices[0] == 1) && (indices[1] == 0)) ||
-                   ((indices[0] == 0) && (indices[1] == 1)),
-                 ExcInternalError());
-          return data[2];
-
-        default:
-          // to do the rest, sort our indices before comparing
-          {
-            TableIndices<2> sorted_indices(std::min(indices[0], indices[1]),
-                                           std::max(indices[0], indices[1]));
-            for (unsigned int d = 0, c = 0; d < dim; ++d)
-              for (unsigned int e = d + 1; e < dim; ++e, ++c)
-                if ((sorted_indices[0] == d) && (sorted_indices[1] == e))
-                  return data[dim + c];
-            Assert(false, ExcInternalError());
-          }
-      }
-
-    // The code should never reach here.
-    // We cannot return a static variable, as this class must support number
-    // types that require no instances of the number type to be in scope during
-    // a reinitialization procedure (e.g. ADOL-C adtl::adouble).
-    return data[0];
+    return data[SymmetricTensorImplementation::component_to_unrolled_index<dim>(
+      indices)];
   }
 
 

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -2055,8 +2055,9 @@ namespace internal
               if (indices[0] == indices[1])
                 return indices[0];
 
-              TableIndices<2> sorted_indices(indices);
-              sorted_indices.sort();
+              const TableIndices<2> sorted_indices(
+                std::min(indices[0], indices[1]),
+                std::max(indices[0], indices[1]));
 
               for (unsigned int d = 0, c = 0; d < dim; ++d)
                 for (unsigned int e = d + 1; e < dim; ++e, ++c)

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -19,6 +19,7 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/ndarray.h>
 #include <deal.II/base/numbers.h>
 #include <deal.II/base/table_indices.h>
 #include <deal.II/base/template_constraints.h>
@@ -2025,30 +2026,27 @@ namespace internal
             {
               return 0;
             }
-
           case 2:
             {
-              constexpr unsigned int table[2][2] = {{0, 2}, {2, 1}};
+              constexpr dealii::ndarray<unsigned int, 2, 2> table = {
+                {{{0, 2}}, {{2, 1}}}};
               return table[indices[0]][indices[1]];
             }
-
           case 3:
             {
-              constexpr unsigned int table[3][3] = {{0, 3, 4},
-                                                    {3, 1, 5},
-                                                    {4, 5, 2}};
+              constexpr dealii::ndarray<unsigned int, 3, 3> table = {
+                {{{0, 3, 4}}, {{3, 1, 5}}, {{4, 5, 2}}}};
               return table[indices[0]][indices[1]];
             }
-
           case 4:
             {
-              constexpr unsigned int table[4][4] = {{0, 4, 5, 6},
-                                                    {4, 1, 7, 8},
-                                                    {5, 7, 2, 9},
-                                                    {6, 8, 9, 3}};
+              constexpr dealii::ndarray<unsigned int, 4, 4> table = {
+                {{{0, 4, 5, 6}},
+                 {{4, 1, 7, 8}},
+                 {{5, 7, 2, 9}},
+                 {{6, 8, 9, 3}}}};
               return table[indices[0]][indices[1]];
             }
-
           default:
             // for the remainder, manually figure out the numbering
             {

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -2333,41 +2333,16 @@ SymmetricTensor<rank_, dim, Number>::end_raw() const
 
 
 
-namespace internal
-{
-  namespace SymmetricTensorImplementation
-  {
-    template <int dim, typename Number>
-    constexpr unsigned int
-    entry_to_indices(const dealii::SymmetricTensor<2, dim, Number> &,
-                     const unsigned int index)
-    {
-      return index;
-    }
-
-
-    template <int dim, typename Number>
-    constexpr dealii::TableIndices<2>
-    entry_to_indices(const dealii::SymmetricTensor<4, dim, Number> &,
-                     const unsigned int index)
-    {
-      return internal::SymmetricTensorAccessors::StorageType<4, dim, Number>::
-        base_tensor_type::unrolled_to_component_indices(index);
-    }
-
-  } // namespace SymmetricTensorImplementation
-} // namespace internal
-
-
-
 template <int rank_, int dim, typename Number>
 DEAL_II_HOST constexpr inline const Number &
 SymmetricTensor<rank_, dim, Number>::access_raw_entry(
   const unsigned int index) const
 {
   AssertIndexRange(index, n_independent_components);
-  return data[internal::SymmetricTensorImplementation::entry_to_indices(*this,
-                                                                        index)];
+  if constexpr (rank == 2)
+    return data[index];
+  else
+    return data[decltype(data)::unrolled_to_component_indices(index)];
 }
 
 
@@ -2377,8 +2352,10 @@ DEAL_II_HOST constexpr inline Number &
 SymmetricTensor<rank_, dim, Number>::access_raw_entry(const unsigned int index)
 {
   AssertIndexRange(index, n_independent_components);
-  return data[internal::SymmetricTensorImplementation::entry_to_indices(*this,
-                                                                        index)];
+  if constexpr (rank == 2)
+    return data[index];
+  else
+    return data[decltype(data)::unrolled_to_component_indices(index)];
 }
 
 

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -2057,7 +2057,11 @@ namespace internal
                 std::min(indices[0], indices[1]),
                 std::max(indices[0], indices[1]));
 
-              for (unsigned int d = 0, c = 0; d < dim; ++d)
+              // Here (d, e) are the row and column of the symmetric matrix and
+              // 'dim + c' is the index into the Tensor<1, dim> actually used
+              // for storage.
+              unsigned int c = 0;
+              for (unsigned int d = 0; d < dim; ++d)
                 for (unsigned int e = d + 1; e < dim; ++e, ++c)
                   if ((sorted_indices[0] == d) && (sorted_indices[1] == e))
                     return dim + c;


### PR DESCRIPTION
I'm using `SymmetricTensor` for some solid mechanics operations and I noticed (via callgrind) that this loop

https://github.com/dealii/dealii/blob/8d0257005b44273c51e31a0c8fa08e511ec7e245/include/deal.II/base/symmetric_tensor.h#L2038-L2041

is inlined but run multiple times per SymmetricTensor-Tensor multiplication. In the process of optimizing this I found a bunch of things that can be cleaned up in SymmetricTensor; e.g., we have three different copies of that loop in `symmetric_tensor.h`: this PR gets rid of two of them (and uses the version with index lookup tables for small tensors).