### PR TITLE
Fix an equation in the tutorial of step-41

### DIFF
--- a/doc/news/changes/minor/20231112TaoJin
+++ b/doc/news/changes/minor/20231112TaoJin
@@ -1,0 +1,6 @@
+Fixed: In step-41, the mass matrix B is missing in the expressions
+of the residuals of the nonlinear system. See the equation under the
+line "This suggest a semismooth Newton step of the form" in the tutorial.
+This is fixed.
+<br>
+(Tao Jin, 2023/11/12)

--- a/examples/step-41/doc/intro.dox
+++ b/examples/step-41/doc/intro.dox
@@ -314,7 +314,7 @@ This suggest a semismooth Newton step of the form
 \end{pmatrix}
 =
 -\begin{pmatrix}
- (AU^k + \Lambda^k - F)_{\mathcal{F}_k}\\ (AU^k + \Lambda^k - F)_{\mathcal{A}_k}\\ -\Lambda^k_{\mathcal{F}_k}\\ c(B_{\mathcal{A}_k} U^k - G)_{\mathcal{A}_k}
+ (AU^k + B\Lambda^k - F)_{\mathcal{F}_k}\\ (AU^k + B\Lambda^k - F)_{\mathcal{A}_k}\\ -\Lambda^k_{\mathcal{F}_k}\\ c(B_{\mathcal{A}_k} U^k - G)_{\mathcal{A}_k}
 \end{pmatrix},
 @f}
 where we have split matrices $A,B$ as well as vectors in the natural way into


### PR DESCRIPTION
In the tutorial document of step-41, the mass matrix B is missing in the expressions of the residuals of the nonlinear system. See the equation under the line "This suggest a semismooth Newton step of the form" in the tutorial doc. This is now fixed.