### PR TITLE
SymmetricTensor: Minimize number of instructions for multiply by Tensor

### DIFF
--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -4207,8 +4207,11 @@ operator*(const SymmetricTensor<2, dim, Number> &src1,
 {
   Tensor<1, dim, typename ProductType<Number, OtherNumber>::type> dest;
   for (unsigned int i = 0; i < dim; ++i)
-    for (unsigned int j = 0; j < dim; ++j)
-      dest[i] += src1[i][j] * src2[j];
+    {
+      dest[i] = src1[i][0] * src2[0];
+      for (unsigned int j = 1; j < dim; ++j)
+        dest[i] += src1[i][j] * src2[j];
+    }
   return dest;
 }
 


### PR DESCRIPTION
As discussed in https://github.com/dealii/dealii/pull/16261#issuecomment-1807250549, we should try to minimize the instruction depth in the tensor contraction.