### PR TITLE
Fix table of content anchors in tutorials

### DIFF
--- a/doc/doxygen/scripts/make_step.pl
+++ b/doc/doxygen/scripts/make_step.pl
@@ -51,29 +51,29 @@ print
 <tr><th colspan=\"2\"><b><small>Table of contents</small></b></th></tr>
 <tr><td width=\"50%\" valign=\"top\">
 <ol>
-  <li> <a href=\"#$step-Intro\" class=bold>Introduction</a>
+  <li> <a href=\"#$step_underscore-Intro\" class=bold>Introduction</a>
 ";
 
-system $^X, "$cmake_source_dir/doc/doxygen/scripts/intro2toc.pl", "$cmake_source_dir/examples/$step/doc/intro.dox" , "--prefix=$step";
+system $^X, "$cmake_source_dir/doc/doxygen/scripts/intro2toc.pl", "$cmake_source_dir/examples/$step/doc/intro.dox" , "--prefix=$step_underscore";
 
-print "  <li> <a href=\"#$step-CommProg\" class=bold>The commented program</a>\n";
+print "  <li> <a href=\"#$step_underscore-CommProg\" class=bold>The commented program</a>\n";
 
-system $^X, "$cmake_source_dir/doc/doxygen/scripts/program2toc.pl", "$cmake_source_dir/examples/$step/$step.cc" , "--prefix=$step";
+system $^X, "$cmake_source_dir/doc/doxygen/scripts/program2toc.pl", "$cmake_source_dir/examples/$step/$step.cc" , "--prefix=$step_underscore";
 
 print
 "</ol></td><td width=\"50%\" valign=\"top\"><ol>
-  <li value=\"3\"> <a href=\"#$step-Results\" class=bold>Results</a>
+  <li value=\"3\"> <a href=\"#$step_underscore-Results\" class=bold>Results</a>
 ";
 
-system $^X, "$cmake_source_dir/doc/doxygen/scripts/intro2toc.pl", "$cmake_source_dir/examples/$step/doc/results.dox" , "--prefix=$step";
+system $^X, "$cmake_source_dir/doc/doxygen/scripts/intro2toc.pl", "$cmake_source_dir/examples/$step/doc/results.dox" , "--prefix=$step_underscore";
 
 print
-"  <li> <a href=\"#$step-PlainProg\" class=bold>The plain program</a>
+"  <li> <a href=\"#$step_underscore-PlainProg\" class=bold>The plain program</a>
 </ol> </td> </tr> </table>
 \@endhtmlonly
 ";
 
-system $^X, "$cmake_source_dir/doc/doxygen/scripts/create_anchors.pl", "$cmake_source_dir/examples/$step/doc/intro.dox" , "--prefix=$step";
+system $^X, "$cmake_source_dir/doc/doxygen/scripts/create_anchors.pl", "$cmake_source_dir/examples/$step/doc/intro.dox" , "--prefix=$step_underscore";
 
 
 # Start the commented program by writing two empty lines. We have had
@@ -87,12 +87,12 @@ system $^X, "$cmake_source_dir/doc/doxygen/scripts/create_anchors.pl", "$cmake_s
 # solves the problem -- so a second newline character.
 print " *\n";
 print " *\n";
-print " * <a name=\"$step-CommProg\"></a>\n";
+print " * <a name=\"$step_underscore-CommProg\"></a>\n";
 print " * <h1> The commented program</h1>\n";
 
-system $^X, "$cmake_source_dir/doc/doxygen/scripts/program2doxygen.pl", "$cmake_source_dir/examples/$step/$step.cc" , "--prefix=$step";
+system $^X, "$cmake_source_dir/doc/doxygen/scripts/program2doxygen.pl", "$cmake_source_dir/examples/$step/$step.cc" , "--prefix=$step_underscore";
 
-system $^X, "$cmake_source_dir/doc/doxygen/scripts/create_anchors.pl", "$cmake_source_dir/examples/$step/doc/results.dox" , "--prefix=$step";
+system $^X, "$cmake_source_dir/doc/doxygen/scripts/create_anchors.pl", "$cmake_source_dir/examples/$step/doc/results.dox" , "--prefix=$step_underscore";
 
 
 # Move to the stripped, plain program. The same principle as above
@@ -100,7 +100,7 @@ system $^X, "$cmake_source_dir/doc/doxygen/scripts/create_anchors.pl", "$cmake_s
 print " *\n";
 print " *\n";
 print
-"<a name=\"$step-PlainProg\"></a>
+"<a name=\"$step_underscore-PlainProg\"></a>
 <h1> The plain program</h1>
 \@include \"$step.cc\"
 */


### PR DESCRIPTION
Fixes #16256.
Due to `filter.pl` the `step-x` in all hyperlink anchors was wrongly replaced.
The hyperlink anchors are now prefixed with `step_x` keeping them unique
and not changed by the filter script.