### PR TITLE
Mark an expression as 'constexpr'.

### DIFF
--- a/include/deal.II/base/geometry_info.h
+++ b/include/deal.II/base/geometry_info.h
@@ -4425,9 +4425,9 @@ GeometryInfo<2>::child_cell_on_face(const RefinementCase<2> &ref_case,
   // this cell adjacent to the subface of a possibly
   // refined neighbor. this simplifies setting neighbor
   // information in execute_refinement.
-  const unsigned int
-    subcells[2][RefinementCase<2>::isotropic_refinement][faces_per_cell]
-            [max_children_per_face] = {
+  constexpr unsigned int
+    subcells[2][RefinementPossibilities<2>::isotropic_refinement]
+            [faces_per_cell][max_children_per_face] = {
               {
                 // Normal orientation (face_flip = false)
                 {{0, 0}, {1, 1}, {0, 1}, {0, 1}}, // cut_x


### PR DESCRIPTION
In trying out what might be the problem with #16254, I thought this is a worthwhile change to make anyway. I also changed the scoping of the enum value `isotropic_refinement`, not because that's necessary but because that just happens to be the scope in which it is declared.