### PR TITLE
Introduce make_rcp(...)

### DIFF
--- a/doc/news/changes/minor/20231115SebastianKinnewig
+++ b/doc/news/changes/minor/20231115SebastianKinnewig
@@ -1,0 +1,4 @@
+New: Introduce a new function, Utilities::Trilinos::internal::make_rcp(),
+to create Teuchos::RCP objects, avoiding the usage of 'operator new'.
+<br>
+(Sebastian Kinnewig, 2023/11/15)

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -21,6 +21,7 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/mpi_stub.h>
 #include <deal.II/base/mutex.h>
+#include <deal.II/base/trilinos_utilities.h>
 
 #include <boost/container/small_vector.hpp>
 

--- a/include/deal.II/base/trilinos_utilities.h
+++ b/include/deal.II/base/trilinos_utilities.h
@@ -32,6 +32,10 @@
 #  endif
 #endif
 
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#  include <Teuchos_RCPDecl.hpp>
+#endif // DEAL_II_TRILINOS_WITH_TPETRA
+
 DEAL_II_NAMESPACE_OPEN
 
 /**
@@ -180,6 +184,35 @@ namespace Utilities
     duplicate_map(const Epetra_BlockMap &map, const Epetra_Comm &comm);
   } // namespace Trilinos
 #endif
+
+
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+  namespace Trilinos
+  {
+    namespace internal
+    {
+      /**
+       * Creates and returns a
+       * <a
+       * href="https://docs.trilinos.org/dev/packages/teuchos/doc/html/classTeuchos_1_1RCP.html">Teuchos::RCP</a>
+       * object for type T.
+       *
+       * @note In Trilinos 14.0.0, the function
+       * <a
+       * href="https://docs.trilinos.org/dev/packages/teuchos/doc/html/namespaceTeuchos.html#a280c0ab8c9ee8d0481114d4edf5a3393">Teuchos::make_rcp()</a>
+       * was introduced, which should be preferred to this function.
+       */
+#  if defined(DOXYGEN) || !DEAL_II_TRILINOS_VERSION_GTE(14, 0, 0)
+      template <class T, class... Args>
+      Teuchos::RCP<T>
+      make_rcp(Args &&...args);
+#  else
+      using Teuchos::make_rcp;
+#  endif // defined DOXYGEN || !DEAL_II_TRILINOS_VERSION_GTE(14, 0, 0)
+    }    // namespace internal
+  }      // namespace Trilinos
+#endif   // DEAL_II_TRILINOS_WITH_TPETRA
+
 } // namespace Utilities
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -47,8 +47,11 @@ namespace LinearAlgebra
     template <typename Number>
     Vector<Number>::Vector()
       : Subscriptor()
-      , vector(new VectorType(Teuchos::rcp(
-          new MapType(0, 0, Utilities::Trilinos::tpetra_comm_self()))))
+      , vector(Utilities::Trilinos::internal::make_rcp<VectorType>(
+          Utilities::Trilinos::internal::make_rcp<MapType>(
+            0,
+            0,
+            Utilities::Trilinos::tpetra_comm_self())))
     {}
 
 
@@ -56,7 +59,9 @@ namespace LinearAlgebra
     template <typename Number>
     Vector<Number>::Vector(const Vector<Number> &V)
       : Subscriptor()
-      , vector(new VectorType(V.trilinos_vector(), Teuchos::Copy))
+      , vector(Utilities::Trilinos::internal::make_rcp<VectorType>(
+          V.trilinos_vector(),
+          Teuchos::Copy))
     {}
 
 
@@ -73,7 +78,7 @@ namespace LinearAlgebra
     Vector<Number>::Vector(const IndexSet &parallel_partitioner,
                            const MPI_Comm  communicator)
       : Subscriptor()
-      , vector(new VectorType(
+      , vector(Utilities::Trilinos::internal::make_rcp<VectorType>(
           parallel_partitioner.make_tpetra_map_rcp(communicator, false)))
     {}
 
@@ -89,7 +94,7 @@ namespace LinearAlgebra
         parallel_partitioner.make_tpetra_map_rcp(communicator, false);
 
       if (vector->getMap()->isSameAs(*input_map) == false)
-        vector = Teuchos::rcp(new VectorType(input_map));
+        Utilities::Trilinos::internal::make_rcp<VectorType>(input_map);
       else if (omit_zeroing_entries == false)
         {
           vector->putScalar(0.);
@@ -110,7 +115,7 @@ namespace LinearAlgebra
       Teuchos::RCP<MapType> input_map =
         parallel_partitioner.make_tpetra_map_rcp(communicator, true);
 
-      vector = Teuchos::rcp(new VectorType(input_map));
+      Utilities::Trilinos::internal::make_rcp<VectorType>(input_map);
     }
 
 
@@ -188,7 +193,8 @@ namespace LinearAlgebra
                                Tpetra::REPLACE);
             }
           else
-            vector = Teuchos::rcp(new VectorType(V.trilinos_vector()));
+            vector = Utilities::Trilinos::internal::make_rcp<VectorType>(
+              V.trilinos_vector());
         }
 
       return *this;
@@ -763,10 +769,10 @@ namespace LinearAlgebra
                                                const MPI_Comm  mpi_comm)
     {
       source_stored_elements = source_index_set;
-
-      tpetra_comm_pattern =
-        Teuchos::rcp(new TpetraWrappers::CommunicationPattern(
-          locally_owned_elements(), source_index_set, mpi_comm));
+      tpetra_comm_pattern    = Utilities::Trilinos::internal::make_rcp<
+        TpetraWrappers::CommunicationPattern>(locally_owned_elements(),
+                                              source_index_set,
+                                              mpi_comm);
     }
   } // namespace TpetraWrappers
 } // namespace LinearAlgebra

--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -995,17 +995,18 @@ IndexSet::make_tpetra_map_rcp(const MPI_Comm communicator,
   const bool linear =
     overlapping ? false : is_ascending_and_one_to_one(communicator);
   if (linear)
-    return Teuchos::RCP<Tpetra::Map<int, types::signed_global_dof_index>>(
-      new Tpetra::Map<int, types::signed_global_dof_index>(
-        size(),
-        n_elements(),
-        0,
+    return Utilities::Trilinos::internal::make_rcp<
+      Tpetra::Map<int, types::signed_global_dof_index>>(
+      size(),
+      n_elements(),
+      0,
 #    ifdef DEAL_II_WITH_MPI
-        Teuchos::rcp(new Teuchos::MpiComm<int>(communicator))
+      Utilities::Trilinos::internal::make_rcp<Teuchos::MpiComm<int>>(
+        communicator)
 #    else
-        Teuchos::rcp(new Teuchos::Comm<int>())
-#    endif
-          ));
+      Utilities::Trilinos::internal::make_rcp<Teuchos::Comm<int>>()
+#    endif // DEAL_WITH_MPI
+    );
   else
     {
       const std::vector<size_type>                indices = get_index_vector();
@@ -1013,17 +1014,19 @@ IndexSet::make_tpetra_map_rcp(const MPI_Comm communicator,
       std::copy(indices.begin(), indices.end(), int_indices.begin());
       const Teuchos::ArrayView<types::signed_global_dof_index> arr_view(
         int_indices);
-      return Teuchos::RCP<Tpetra::Map<int, types::signed_global_dof_index>>(
-        new Tpetra::Map<int, types::signed_global_dof_index>(
-          size(),
-          arr_view,
-          0,
+
+      return Utilities::Trilinos::internal::make_rcp<
+        Tpetra::Map<int, types::signed_global_dof_index>>(
+        size(),
+        arr_view,
+        0,
 #    ifdef DEAL_II_WITH_MPI
-          Teuchos::rcp(new Teuchos::MpiComm<int>(communicator))
+        Utilities::Trilinos::internal::make_rcp<Teuchos::MpiComm<int>>(
+          communicator)
 #    else
-          Teuchos::rcp(new Teuchos::Comm<int>())
-#    endif
-            ));
+        Utilities::Trilinos::internal::make_rcp<Teuchos::Comm<int>>()
+#    endif // DEAL_II_WITH_MPI
+      );
     }
 }
 #  endif

--- a/source/base/trilinos_utilities.cc
+++ b/source/base/trilinos_utilities.cc
@@ -169,6 +169,23 @@ namespace Utilities
     }
   } // namespace Trilinos
 #endif
+
+
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+  namespace Trilinos
+  {
+#  if !DEAL_II_TRILINOS_VERSION_GTE(14, 0, 0)
+    template <class T, class... Args>
+    Teuchos::RCP<T>
+    make_rcp(Args &&...args)
+    {
+      return Teuchos::RCP<T>(new T(std::forward<Args>(args)...));
+    }
+#  endif // !DEAL_II_TRILINOS_VERSION_GTE(14, 0, 0)
+
+  }    // namespace Trilinos
+#endif // DEAL_II_TRILINOS_WITH_TPETRA
+
 } // namespace Utilities
 
 DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
As highlighted in Issue #16202, we want to avoid using the `operator new` directly. In Trilinos Version 14.0.0, the function `Teuchos::make_rcp()` was introduced, which does precisely that. But to ensure backward compatibility with older Trilinos Versions, I introduce `Utilities::Trilinos::make_rcp()` (as suggested in Issue #16202).
Depending on the used Trilinos version, either `Teuchos::make_rcp()` or `Utilities::Trilinos::make_rcp()` is used. In my opinion, this is the best approach to ensure compatibility with future Trilinos versions. 

An alternative to my approach would be to use `Utilities::Trilinos::make_rcp()` independent of the Trilinos version. Please let me know your thoughts!