### PR TITLE
Turn make_rcp() into an inline function.

### DIFF
--- a/include/deal.II/base/trilinos_utilities.h
+++ b/include/deal.II/base/trilinos_utilities.h
@@ -210,8 +210,24 @@ namespace Utilities
       using Teuchos::make_rcp;
 #  endif // defined DOXYGEN || !DEAL_II_TRILINOS_VERSION_GTE(14, 0, 0)
     }    // namespace internal
-  }      // namespace Trilinos
-#endif   // DEAL_II_TRILINOS_WITH_TPETRA
+
+
+
+    /* ------------------------- Inline functions ---------------------- */
+    namespace internal
+    {
+#  if !DEAL_II_TRILINOS_VERSION_GTE(14, 0, 0)
+      template <class T, class... Args>
+      inline Teuchos::RCP<T>
+      make_rcp(Args &&...args)
+      {
+        return Teuchos::RCP<T>(new T(std::forward<Args>(args)...));
+      }
+#  endif // !DEAL_II_TRILINOS_VERSION_GTE(14, 0, 0)
+    }    // namespace internal
+
+  }    // namespace Trilinos
+#endif // DEAL_II_TRILINOS_WITH_TPETRA
 
 } // namespace Utilities
 

--- a/source/base/trilinos_utilities.cc
+++ b/source/base/trilinos_utilities.cc
@@ -169,23 +169,6 @@ namespace Utilities
     }
   } // namespace Trilinos
 #endif
-
-
-#ifdef DEAL_II_TRILINOS_WITH_TPETRA
-  namespace Trilinos
-  {
-#  if !DEAL_II_TRILINOS_VERSION_GTE(14, 0, 0)
-    template <class T, class... Args>
-    Teuchos::RCP<T>
-    make_rcp(Args &&...args)
-    {
-      return Teuchos::RCP<T>(new T(std::forward<Args>(args)...));
-    }
-#  endif // !DEAL_II_TRILINOS_VERSION_GTE(14, 0, 0)
-
-  }    // namespace Trilinos
-#endif // DEAL_II_TRILINOS_WITH_TPETRA
-
 } // namespace Utilities
 
 DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
Turning the function `Utilities::Trilinos::inline::make_rcp()` into an inline function, as it is impossible to initialize that function for all possible template parameters.

This problem was highlighted by the regression tester in issue #16277.