### PR TITLE
Add a function to convert a Teuchos::Comm into an MPI_Comm.

### DIFF
--- a/doc/news/changes/minor/20231120SebastianKinnewig
+++ b/doc/news/changes/minor/20231120SebastianKinnewig
@@ -1,0 +1,4 @@
+New: Introduce a new function, Utilities::Trilinos::teuchos_comm_to_mpi_comm(),
+to convert a Teuchos::RCP<Teuchos::Comm<int>> communicator into an MPI_Comm communicator.
+<br>
+(Sebastian Kinnewig, 2023/11/20)

--- a/include/deal.II/base/trilinos_utilities.h
+++ b/include/deal.II/base/trilinos_utilities.h
@@ -189,6 +189,16 @@ namespace Utilities
 #ifdef DEAL_II_TRILINOS_WITH_TPETRA
   namespace Trilinos
   {
+    /**
+     * Return the underlying MPI_Comm communicator from the
+     * <a
+     * href="https://docs.trilinos.org/dev/packages/teuchos/doc/html/classTeuchos_1_1Comm.html">Teuchos::Comm</a>
+     * communicator.
+     */
+    MPI_Comm
+    teuchos_comm_to_mpi_comm(
+      const Teuchos::RCP<const Teuchos::Comm<int>> &teuchos_comm);
+
     namespace internal
     {
       /**

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -235,12 +235,10 @@ namespace LinearAlgebra
                V.get_stored_elements().size()) ||
               (source_stored_elements != V.get_stored_elements()))
             {
-              const Teuchos::MpiComm<int> *mpi_comm =
-                dynamic_cast<const Teuchos::MpiComm<int> *>(
-                  vector->getMap()->getComm().get());
-              Assert(mpi_comm != nullptr, ExcInternalError());
-              create_tpetra_comm_pattern(V.get_stored_elements(),
-                                         *(mpi_comm->getRawMpiComm())());
+              create_tpetra_comm_pattern(
+                V.get_stored_elements(),
+                Utilities::Trilinos::teuchos_comm_to_mpi_comm(
+                  vector->getMap()->getComm()));
             }
         }
       else
@@ -526,12 +524,10 @@ namespace LinearAlgebra
         }
 
       // Check that the vector is zero on _all_ processors.
-      const Teuchos::MpiComm<int> *mpi_comm =
-        dynamic_cast<const Teuchos::MpiComm<int> *>(
-          vector->getMap()->getComm().get());
-      Assert(mpi_comm != nullptr, ExcInternalError());
       unsigned int num_nonzero =
-        Utilities::MPI::sum(flag, *(mpi_comm->getRawMpiComm())());
+        Utilities::MPI::sum(flag,
+                            Utilities::Trilinos::teuchos_comm_to_mpi_comm(
+                              vector->getMap()->getComm()));
 
       return num_nonzero == 0;
     }
@@ -609,11 +605,8 @@ namespace LinearAlgebra
     MPI_Comm
     Vector<Number>::get_mpi_communicator() const
     {
-      const auto *const tpetra_comm =
-        dynamic_cast<const Teuchos::MpiComm<int> *>(
-          vector->getMap()->getComm().get());
-      Assert(tpetra_comm != nullptr, ExcInternalError());
-      return *(tpetra_comm->getRawMpiComm())();
+      return Utilities::Trilinos::teuchos_comm_to_mpi_comm(
+        vector->getMap()->getComm());
     }
 
 
@@ -739,16 +732,8 @@ namespace LinearAlgebra
     MPI_Comm
     Vector<Number>::mpi_comm() const
     {
-      MPI_Comm out;
-#  ifdef DEAL_II_WITH_MPI
-      const Teuchos::MpiComm<int> *mpi_comm =
-        dynamic_cast<const Teuchos::MpiComm<int> *>(
-          vector->getMap()->getComm().get());
-      out = *mpi_comm->getRawMpiComm();
-#  else
-      out            = MPI_COMM_SELF;
-#  endif
-      return out;
+      return Utilities::Trilinos::teuchos_comm_to_mpi_comm(
+        vector->getMap()->getComm());
     }
 
 

--- a/source/base/trilinos_utilities.cc
+++ b/source/base/trilinos_utilities.cc
@@ -169,6 +169,32 @@ namespace Utilities
     }
   } // namespace Trilinos
 #endif
+
+
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+  namespace Trilinos
+  {
+    MPI_Comm
+    teuchos_comm_to_mpi_comm(
+      const Teuchos::RCP<const Teuchos::Comm<int>> &teuchos_comm)
+    {
+      MPI_Comm out;
+#  ifdef DEAL_II_WITH_MPI
+      // Cast from Teuchos::Comm<int> to Teuchos::MpiComm<int>.
+      const Teuchos::MpiComm<int> *mpi_comm =
+        dynamic_cast<const Teuchos::MpiComm<int> *>(teuchos_comm.get());
+      Assert(mpi_comm != nullptr, ExcInternalError());
+      // From the Teuchos::MpiComm<int> object we can extract
+      // the MPI_Comm object via the getRawMpiComm() function.
+      out = *(mpi_comm->getRawMpiComm())();
+#  else
+      out = MPI_COMM_SELF;
+#  endif
+      return out;
+    }
+  }    // namespace Trilinos
+#endif // DEAL_II_TRILINOS_WITH_TPETRA
+
 } // namespace Utilities
 
 DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
There is a need to convert a `Teuchos::RCP<Teuchos::Comm<int>>` communicator into an `MPI_Comm` communicator at several places, so I added this handy function that does exactly that.