### PR TITLE
Add parallel support to TpetraWrappers::Vector.

### DIFF
--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -24,6 +24,7 @@
 #include <deal.II/base/table.h>
 #include <deal.II/base/thread_local_storage.h>
 #include <deal.II/base/thread_management.h>
+#include <deal.II/base/trilinos_utilities.h>
 
 #include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/block_sparse_matrix.h>
@@ -2666,12 +2667,10 @@ namespace internal
     IndexSet parallel_partitioner = locally_owned_elements;
     parallel_partitioner.add_indices(needed_elements);
 
-    const MPI_Comm mpi_comm =
-      Trilinos::teuchos_comm_to_mpi_comm(vec.trilinos_rcp()->getMap()->getComm());
+    const MPI_Comm mpi_comm = Utilities::Trilinos::teuchos_comm_to_mpi_comm(
+      vec.trilinos_rcp()->getMap()->getComm());
 
-    output.reinit(locally_owned_elements,
-                  needed_elements,
-                  mpi_comm);
+    output.reinit(locally_owned_elements, needed_elements, mpi_comm);
 
     output = vec;
   }

--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -2650,6 +2650,35 @@ namespace internal
   }
 #endif
 
+
+
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+  template <typename Number>
+  inline void
+  import_vector_with_ghost_elements(
+    const LinearAlgebra::TpetraWrappers::Vector<Number> &vec,
+    const IndexSet                                      &locally_owned_elements,
+    const IndexSet                                      &needed_elements,
+    LinearAlgebra::TpetraWrappers::Vector<Number>       &output,
+    const std::bool_constant<false> /*is_block_vector*/)
+  {
+    Assert(!vec.has_ghost_elements(), ExcGhostsPresent());
+    IndexSet parallel_partitioner = locally_owned_elements;
+    parallel_partitioner.add_indices(needed_elements);
+
+    const MPI_Comm mpi_comm =
+      Trilinos::teuchos_comm_to_mpi_comm(vec.trilinos_rcp()->getMap()->getComm());
+
+    output.reinit(locally_owned_elements,
+                  needed_elements,
+                  mpi_comm);
+
+    output = vec;
+  }
+#endif // DEAL_II_TRILINOS_WITH_TPETRA
+
+
+
 #ifdef DEAL_II_WITH_PETSC
   inline void
   import_vector_with_ghost_elements(

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -1036,12 +1036,12 @@ namespace LinearAlgebra
     const MPI_Comm  mpi_comm)
   {
     source_stored_elements = source_index_set;
-    TpetraWrappers::CommunicationPattern epetra_comm_pattern(
+    TpetraWrappers::CommunicationPattern tpetra_comm_pattern(
       source_stored_elements, stored_elements, mpi_comm);
     comm_pattern = std::make_shared<TpetraWrappers::CommunicationPattern>(
       source_stored_elements, stored_elements, mpi_comm);
 
-    return epetra_comm_pattern;
+    return tpetra_comm_pattern;
   }
 #  endif
 

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -47,6 +47,7 @@ namespace LinearAlgebra
     template <typename Number>
     Vector<Number>::Vector()
       : Subscriptor()
+      , has_ghost(false)
       , vector(Utilities::Trilinos::internal::make_rcp<VectorType>(
           Utilities::Trilinos::internal::make_rcp<MapType>(
             0,
@@ -59,9 +60,12 @@ namespace LinearAlgebra
     template <typename Number>
     Vector<Number>::Vector(const Vector<Number> &V)
       : Subscriptor()
+      , has_ghost(V.has_ghost)
       , vector(Utilities::Trilinos::internal::make_rcp<VectorType>(
           V.trilinos_vector(),
           Teuchos::Copy))
+      , locally_owned_map(V.locally_owned_map)
+      , locally_relevant_map(V.locally_relevant_map)
     {}
 
 
@@ -69,8 +73,20 @@ namespace LinearAlgebra
     template <typename Number>
     Vector<Number>::Vector(const Teuchos::RCP<VectorType> V)
       : Subscriptor()
+      , has_ghost(false)
       , vector(V)
-    {}
+    {
+      if (vector->getMap()->isOneToOne())
+        {
+          locally_owned_map =
+            Teuchos::rcp_const_cast<MapType>(vector->getMap());
+        }
+      else
+        {
+          locally_relevant_map =
+            Teuchos::rcp_const_cast<MapType>(vector->getMap());
+        }
+    }
 
 
 
@@ -78,9 +94,13 @@ namespace LinearAlgebra
     Vector<Number>::Vector(const IndexSet &parallel_partitioner,
                            const MPI_Comm  communicator)
       : Subscriptor()
-      , vector(Utilities::Trilinos::internal::make_rcp<VectorType>(
-          parallel_partitioner.make_tpetra_map_rcp(communicator, false)))
-    {}
+      , has_ghost(false)
+      , locally_owned_map(
+          parallel_partitioner.make_tpetra_map_rcp(communicator, false))
+    {
+      vector = Utilities::Trilinos::internal::make_rcp<VectorType>(
+        locally_owned_map);
+    }
 
 
 
@@ -90,12 +110,23 @@ namespace LinearAlgebra
                            const MPI_Comm  communicator,
                            const bool      omit_zeroing_entries)
     {
-      Teuchos::RCP<MapType> input_map =
+      // release memory before reallocation
+      vector.reset();
+      locally_owned_map.reset();
+      locally_relevant_map.reset();
+      source_stored_elements.clear();
+
+      // Here we assume, that the index set is non-overlapping.
+      // If the index set is overlapping the function
+      // make_tpetra_map_rcp() will throw an assert.
+      has_ghost = false;
+      locally_owned_map =
         parallel_partitioner.make_tpetra_map_rcp(communicator, false);
 
-      if (vector->getMap()->isSameAs(*input_map) == false)
-        vector = Utilities::Trilinos::internal::make_rcp<VectorType>(input_map);
-      else if (omit_zeroing_entries == false)
+      if (!vector->getMap()->isSameAs(*locally_owned_map))
+        vector = Utilities::Trilinos::internal::make_rcp<VectorType>(
+          locally_owned_map);
+      if (!omit_zeroing_entries)
         {
           vector->putScalar(0.);
         }
@@ -109,13 +140,23 @@ namespace LinearAlgebra
                            const IndexSet &ghost_entries,
                            const MPI_Comm  communicator)
     {
+      // release memory before reallocation
+      vector.reset();
+      locally_owned_map.reset();
+      locally_relevant_map.reset();
+
+      locally_owned_map =
+        locally_owned_entries.make_tpetra_map_rcp(communicator, false);
+
       IndexSet parallel_partitioner = locally_owned_entries;
       parallel_partitioner.add_indices(ghost_entries);
-
-      Teuchos::RCP<MapType> input_map =
+      locally_relevant_map =
         parallel_partitioner.make_tpetra_map_rcp(communicator, true);
 
-      vector = Utilities::Trilinos::internal::make_rcp<VectorType>(input_map);
+      vector = Utilities::Trilinos::internal::make_rcp<VectorType>(
+        locally_relevant_map);
+
+      has_ghost = false;
     }
 
 
@@ -139,11 +180,9 @@ namespace LinearAlgebra
       ArrayView<Number>                              &elements) const
     {
       AssertDimension(indices.size(), elements.size());
-      const auto &vector = trilinos_vector();
-      const auto &map    = vector.getMap();
 
 #  if DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
-      auto vector_2d = vector.template getLocalView<Kokkos::HostSpace>(
+      auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
         Tpetra::Access::ReadOnly);
 #  else
       /*
@@ -156,16 +195,35 @@ namespace LinearAlgebra
        * Let us choose to simply ignore this problem for such an old
        * Trilinos version.
        */
-      auto vector_2d = vector.template getLocalView<Kokkos::HostSpace>();
+      auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>();
 #  endif
       auto vector_1d = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
 
       for (unsigned int i = 0; i < indices.size(); ++i)
         {
           AssertIndexRange(indices[i], size());
-          const auto trilinos_i = map->getLocalElement(
-            static_cast<TrilinosWrappers::types::int_type>(indices[i]));
-          elements[i] = vector_1d(trilinos_i);
+          const size_type                   row = indices[i];
+          TrilinosWrappers::types::int_type local_row =
+            vector->getMap()->getLocalElement(row);
+
+
+          Assert(
+            local_row != Teuchos::OrdinalTraits<int>::invalid(),
+#  if DEAL_II_TRILINOS_VERSION_GTE(14, 0, 0)
+            ExcAccessToNonLocalElement(row,
+                                       vector->getMap()->getLocalNumElements(),
+                                       vector->getMap()->getMinLocalIndex(),
+                                       vector->getMap()->getMaxLocalIndex()));
+#  else
+            ExcAccessToNonLocalElement(row,
+                                       vector->getMap()->getNodeNumElements(),
+                                       vector->getMap()->getMinLocalIndex(),
+                                       vector->getMap()->getMaxLocalIndex()));
+
+#  endif
+
+          if (local_row != Teuchos::OrdinalTraits<int>::invalid())
+            elements[i] = vector_1d(local_row);
         }
     }
 
@@ -179,22 +237,45 @@ namespace LinearAlgebra
       //  - First case: both vectors have the same layout.
       //  - Second case: both vectors have the same size but different layout.
       //  - Third case: the vectors have different size.
-      if (vector->getMap()->isSameAs(*(V.trilinos_vector().getMap())))
-        *vector = V.trilinos_vector();
+      if (vector->getMap()->isSameAs(*V.vector->getMap()))
+        {
+          *vector = *V.vector;
+        }
+      else if (size() == V.size())
+        {
+          // We expect the origin vector to have a one-to-one map, otherwise
+          // we can not call Import
+          Assert(V.vector->getMap()->isOneToOne(),
+                 ExcMessage(
+                   "You are trying to map one vector distributed "
+                   "between processors, where some elements belong "
+                   "to multiple processors, onto another distribution "
+                   "pattern, where some elements belong to multiple "
+                   "processors. It is unclear how to deal with elements "
+                   "in the vector belonging to multiple processors. "
+                   "Therefore, compress() must be called on this "
+                   "vector first."));
+
+          Teuchos::RCP<const ImportType> importer =
+            Tpetra::createImport(V.vector->getMap(), vector->getMap());
+
+          // Since we are distributing the vector from a one-to-one map
+          // we can always use the VectorOperation::insert / Tpetra::INSERT
+          // here.
+          vector->doImport(*V.vector, *importer, Tpetra::INSERT);
+        }
       else
         {
-          if (size() == V.size())
-            {
-              Tpetra::Import<int, types::signed_global_dof_index> data_exchange(
-                vector->getMap(), V.trilinos_vector().getMap());
+          vector.reset();
+          vector = Utilities::Trilinos::internal::make_rcp<VectorType>(
+            V.vector->getMap());
+          Tpetra::deep_copy(*vector, *V.vector);
 
-              vector->doImport(V.trilinos_vector(),
-                               data_exchange,
-                               Tpetra::REPLACE);
-            }
-          else
-            vector = Utilities::Trilinos::internal::make_rcp<VectorType>(
-              V.trilinos_vector());
+          has_ghost              = V.has_ghost;
+          locally_owned_map      = V.locally_owned_map;
+          locally_relevant_map   = V.locally_relevant_map;
+          source_stored_elements = V.source_stored_elements;
+          tpetra_comm_pattern    = V.tpetra_comm_pattern;
         }
 
       return *this;
@@ -253,8 +334,8 @@ namespace LinearAlgebra
               "LinearAlgebra::TpetraWrappers::CommunicationPattern."));
         }
 
-      Teuchos::RCP<const Tpetra::Export<int, types::signed_global_dof_index>>
-        tpetra_export = tpetra_comm_pattern->get_tpetra_export_rcp();
+      Teuchos::RCP<const ExportType> tpetra_export =
+        tpetra_comm_pattern->get_tpetra_export_rcp();
 
       VectorType source_vector(tpetra_export->getSourceMap());
 
@@ -280,12 +361,15 @@ namespace LinearAlgebra
             device_type::memory_space>();
 #  endif
       }
+      Tpetra::CombineMode tpetra_operation = Tpetra::ZERO;
       if (operation == VectorOperation::insert)
-        vector->doExport(source_vector, *tpetra_export, Tpetra::REPLACE);
+        tpetra_operation = Tpetra::INSERT;
       else if (operation == VectorOperation::add)
-        vector->doExport(source_vector, *tpetra_export, Tpetra::ADD);
+        tpetra_operation = Tpetra::ADD;
       else
-        AssertThrow(false, ExcNotImplemented());
+        Assert(false, ExcNotImplemented());
+
+      vector->doExport(source_vector, *tpetra_export, tpetra_operation);
     }
 
 
@@ -299,6 +383,7 @@ namespace LinearAlgebra
     {
       import_elements(V, operation);
     }
+
 
 
     template <typename Number>
@@ -358,9 +443,8 @@ namespace LinearAlgebra
           // elements, maybe there is a better workaround.
           Tpetra::Vector<Number, int, types::signed_global_dof_index> dummy(
             vector->getMap(), false);
-          Tpetra::Import<int, types::signed_global_dof_index> data_exchange(
-            V.trilinos_vector().getMap(), dummy.getMap());
-
+          ImportType data_exchange(V.trilinos_vector().getMap(),
+                                   dummy.getMap());
           dummy.doImport(V.trilinos_vector(), data_exchange, Tpetra::INSERT);
 
           vector->update(1.0, dummy, 1.0);
@@ -392,6 +476,45 @@ namespace LinearAlgebra
              ExcDifferentParallelPartitioning());
 
       return vector->dot(V.trilinos_vector());
+    }
+
+
+
+    template <typename Number>
+    Number
+    Vector<Number>::operator()(const size_type index) const
+    {
+      // Get the local index
+      const TrilinosWrappers::types::int_type local_index =
+        vector->getMap()->getLocalElement(
+          static_cast<TrilinosWrappers::types::int_type>(index));
+
+      Number value = 0.0;
+
+      // If the element is not present on the current processor, we can't
+      // continue. This is the main difference to the el() function.
+      if (local_index == -1)
+        {
+#  if DEAL_II_TRILINOS_VERSION_GTE(14, 0, 0)
+          Assert(
+            false,
+            ExcAccessToNonLocalElement(index,
+                                       vector->getMap()->getLocalNumElements(),
+                                       vector->getMap()->getMinLocalIndex(),
+                                       vector->getMap()->getMaxLocalIndex()));
+#  else
+          Assert(
+            false,
+            ExcAccessToNonLocalElement(index,
+                                       vector->getMap()->getNodeNumElements(),
+                                       vector->getMap()->getMinLocalIndex(),
+                                       vector->getMap()->getMaxLocalIndex()));
+#  endif
+        }
+      else
+        value = vector->getData()[local_index];
+
+      return value;
     }
 
 
@@ -643,8 +766,43 @@ namespace LinearAlgebra
 
     template <typename Number>
     void
-    Vector<Number>::compress(const VectorOperation::values /*operation*/)
-    {}
+    Vector<Number>::compress(const VectorOperation::values operation)
+    {
+      Assert(has_ghost == false,
+             ExcMessage("Calling compress() is only useful if a vector "
+                        "has been written into, but this is a vector with ghost "
+                        "elements and consequently is read-only. It does "
+                        "not make sense to call compress() for such "
+                        "vectors."));
+
+      if (!vector->getMap()->isOneToOne())
+        {
+          Tpetra::CombineMode tpetra_operation = Tpetra::ZERO;
+          if (operation == VectorOperation::insert)
+            tpetra_operation = Tpetra::INSERT;
+          else if (operation == VectorOperation::add)
+            tpetra_operation = Tpetra::ADD;
+          else
+            Assert(false, ExcNotImplemented());
+
+          if (locally_relevant_map.is_null())
+            locally_relevant_map =
+              Teuchos::rcp_const_cast<MapType>(vector->getMap());
+
+          Assert(!locally_relevant_map.is_null(), ExcMissingIndexSet());
+          Assert(!locally_owned_map.is_null(), ExcMissingIndexSet());
+
+          VectorType dummy = VectorType(locally_owned_map.getConst());
+
+          Teuchos::RCP<const ExportType> exporter =
+            Tpetra::createExport(locally_relevant_map.getConst(),
+                                 locally_owned_map.getConst());
+          dummy.doExport(*vector, *exporter, tpetra_operation);
+
+          *vector = dummy;
+        }
+    }
+
 
 
     template <typename Number>
@@ -714,13 +872,27 @@ namespace LinearAlgebra
       auto         vector_1d    = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
       const size_t local_length = vector->getLocalLength();
 
-      if (across)
-        for (unsigned int i = 0; i < local_length; ++i)
-          out << vector_1d(i) << ' ';
+      if (size() != local_length)
+        {
+          out << "size:" << size() << " locally_owned_size:" << local_length
+              << " :" << std::endl;
+          for (size_type i = 0; i < local_length; ++i)
+            {
+              const TrilinosWrappers::types::int_type global_row =
+                vector->getMap()->getGlobalElement(i);
+              out << "[" << global_row << "]: " << vector_1d(i) << std::endl;
+            }
+        }
       else
-        for (unsigned int i = 0; i < local_length; ++i)
-          out << vector_1d(i) << std::endl;
-      out << std::endl;
+        {
+          if (across)
+            for (unsigned int i = 0; i < local_length; ++i)
+              out << vector_1d(i) << ' ';
+          else
+            for (unsigned int i = 0; i < local_length; ++i)
+              out << vector_1d(i) << std::endl;
+          out << std::endl;
+        }
 
       // restore the representation
       // of the vector
@@ -754,10 +926,10 @@ namespace LinearAlgebra
                                                const MPI_Comm  mpi_comm)
     {
       source_stored_elements = source_index_set;
-      tpetra_comm_pattern    = Utilities::Trilinos::internal::make_rcp<
-        TpetraWrappers::CommunicationPattern>(locally_owned_elements(),
-                                              source_index_set,
-                                              mpi_comm);
+
+      tpetra_comm_pattern =
+        Teuchos::rcp(new TpetraWrappers::CommunicationPattern(
+          locally_owned_elements(), source_index_set, mpi_comm));
     }
   } // namespace TpetraWrappers
 } // namespace LinearAlgebra

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -829,6 +829,21 @@ namespace internal
       }
 #endif
 
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+      template <typename Number>
+      void
+      copy_locally_owned_data_from(
+        const LinearAlgebra::TpetraWrappers::Vector<Number> &src,
+        LinearAlgebra::distributed::Vector<Number>          &dst)
+      {
+        // ReadWriteVector does not work for ghosted
+        // TrilinosWrappers::MPI::Vector objects. Fall back to copy the
+        // entries manually.
+        for (const auto i : dst.locally_owned_elements())
+          dst[i] = src[i];
+      }
+#endif
+
       /**
        * Create a ghosted-copy of a block dof vector.
        */

--- a/tests/trilinos/tpetra_vector_03.with_trilinos_with_tpetra=on.with_complex_values=off.mpirun=2.output
+++ b/tests/trilinos/tpetra_vector_03.with_trilinos_with_tpetra=on.with_complex_values=off.mpirun=2.output
@@ -1,13 +1,17 @@
 
 DEAL:0::Tpetra first import add:
-2.000e+00 1.000e+02 
+size:4 locally_owned_size:2 :
+[0]: 2.000e+00
+[1]: 1.000e+02
 IndexSet: {[0,2]}
 
 [0]: 1.000e+00
 [1]: 1.000e+02
 [2]: 1.000e+01
 DEAL:0::Tpetra second import add:
-4.000e+00 2.000e+02 
+size:4 locally_owned_size:2 :
+[0]: 4.000e+00
+[1]: 2.000e+02
 IndexSet: {[0,2]}
 
 [0]: 2.000e+00
@@ -33,13 +37,17 @@ IndexSet: {[0,2]}
 [2]: 1.000e+02
 
 DEAL:1::Tpetra first import add:
-1.000e+01 1.010e+02 
+size:4 locally_owned_size:2 :
+[2]: 1.000e+01
+[3]: 1.010e+02
 IndexSet: {0, 3}
 
 [0]: 1.000e+00
 [3]: 1.010e+02
 DEAL:1::Tpetra second import add:
-3.000e+01 2.010e+02 
+size:4 locally_owned_size:2 :
+[2]: 3.000e+01
+[3]: 2.010e+02
 IndexSet: {0, 3}
 
 [0]: 2.000e+00

--- a/tests/trilinos/tpetra_vector_03.with_trilinos_with_tpetra=on.with_complex_values=off.mpirun=4.output
+++ b/tests/trilinos/tpetra_vector_03.with_trilinos_with_tpetra=on.with_complex_values=off.mpirun=4.output
@@ -1,13 +1,17 @@
 
 DEAL:0::Tpetra first import add:
-4.000e+00 1.000e+02 
+size:8 locally_owned_size:2 :
+[0]: 4.000e+00
+[1]: 1.000e+02
 IndexSet: {[0,2]}
 
 [0]: 1.000e+00
 [1]: 1.000e+02
 [2]: 1.000e+01
 DEAL:0::Tpetra second import add:
-8.000e+00 2.000e+02 
+size:8 locally_owned_size:2 :
+[0]: 8.000e+00
+[1]: 2.000e+02
 IndexSet: {[0,2]}
 
 [0]: 2.000e+00
@@ -33,14 +37,18 @@ IndexSet: {[0,2]}
 [2]: 1.000e+02
 
 DEAL:1::Tpetra first import add:
-1.000e+01 1.010e+02 
+size:8 locally_owned_size:2 :
+[2]: 1.000e+01
+[3]: 1.010e+02
 IndexSet: {0, [3,4]}
 
 [0]: 1.000e+00
 [3]: 1.010e+02
 [4]: 1.100e+01
 DEAL:1::Tpetra second import add:
-3.000e+01 2.010e+02 
+size:8 locally_owned_size:2 :
+[2]: 3.000e+01
+[3]: 2.010e+02
 IndexSet: {0, [3,4]}
 
 [0]: 2.000e+00
@@ -67,14 +75,18 @@ IndexSet: {0, [3,4]}
 
 
 DEAL:2::Tpetra first import add:
-1.100e+01 1.020e+02 
+size:8 locally_owned_size:2 :
+[4]: 1.100e+01
+[5]: 1.020e+02
 IndexSet: {0, [5,6]}
 
 [0]: 1.000e+00
 [5]: 1.020e+02
 [6]: 1.200e+01
 DEAL:2::Tpetra second import add:
-3.200e+01 2.020e+02 
+size:8 locally_owned_size:2 :
+[4]: 3.200e+01
+[5]: 2.020e+02
 IndexSet: {0, [5,6]}
 
 [0]: 2.000e+00
@@ -101,13 +113,17 @@ IndexSet: {0, [5,6]}
 
 
 DEAL:3::Tpetra first import add:
-1.200e+01 1.030e+02 
+size:8 locally_owned_size:2 :
+[6]: 1.200e+01
+[7]: 1.030e+02
 IndexSet: {0, 7}
 
 [0]: 1.000e+00
 [7]: 1.030e+02
 DEAL:3::Tpetra second import add:
-3.400e+01 2.030e+02 
+size:8 locally_owned_size:2 :
+[6]: 3.400e+01
+[7]: 2.030e+02
 IndexSet: {0, 7}
 
 [0]: 2.000e+00

--- a/tests/trilinos/tpetra_vector_03.with_trilinos_with_tpetra=on.with_complex_values=on.mpirun=2.output
+++ b/tests/trilinos/tpetra_vector_03.with_trilinos_with_tpetra=on.with_complex_values=on.mpirun=2.output
@@ -1,13 +1,17 @@
 
 DEAL:0::Tpetra first import add:
-2.000e+00 1.000e+02 
+size:4 locally_owned_size:2 :
+[0]: 2.000e+00
+[1]: 1.000e+02
 IndexSet: {[0,2]}
 
 [0]: 1.000e+00
 [1]: 1.000e+02
 [2]: 1.000e+01
 DEAL:0::Tpetra second import add:
-4.000e+00 2.000e+02 
+size:4 locally_owned_size:2 :
+[0]: 4.000e+00
+[1]: 2.000e+02
 IndexSet: {[0,2]}
 
 [0]: 2.000e+00
@@ -33,13 +37,17 @@ IndexSet: {[0,2]}
 [2]: 1.000e+02
 
 DEAL:1::Tpetra first import add:
-1.000e+01 1.010e+02 
+size:4 locally_owned_size:2 :
+[2]: 1.000e+01
+[3]: 1.010e+02
 IndexSet: {0, 3}
 
 [0]: 1.000e+00
 [3]: 1.010e+02
 DEAL:1::Tpetra second import add:
-3.000e+01 2.010e+02 
+size:4 locally_owned_size:2 :
+[2]: 3.000e+01
+[3]: 2.010e+02
 IndexSet: {0, 3}
 
 [0]: 2.000e+00

--- a/tests/trilinos/tpetra_vector_03.with_trilinos_with_tpetra=on.with_complex_values=on.mpirun=4.output
+++ b/tests/trilinos/tpetra_vector_03.with_trilinos_with_tpetra=on.with_complex_values=on.mpirun=4.output
@@ -1,13 +1,17 @@
 
 DEAL:0::Tpetra first import add:
-4.000e+00 1.000e+02 
+size:8 locally_owned_size:2 :
+[0]: 4.000e+00
+[1]: 1.000e+02
 IndexSet: {[0,2]}
 
 [0]: 1.000e+00
 [1]: 1.000e+02
 [2]: 1.000e+01
 DEAL:0::Tpetra second import add:
-8.000e+00 2.000e+02 
+size:8 locally_owned_size:2 :
+[0]: 8.000e+00
+[1]: 2.000e+02
 IndexSet: {[0,2]}
 
 [0]: 2.000e+00
@@ -33,14 +37,18 @@ IndexSet: {[0,2]}
 [2]: 1.000e+02
 
 DEAL:1::Tpetra first import add:
-1.000e+01 1.010e+02 
+size:8 locally_owned_size:2 :
+[2]: 1.000e+01
+[3]: 1.010e+02
 IndexSet: {0, [3,4]}
 
 [0]: 1.000e+00
 [3]: 1.010e+02
 [4]: 1.100e+01
 DEAL:1::Tpetra second import add:
-3.000e+01 2.010e+02 
+size:8 locally_owned_size:2 :
+[2]: 3.000e+01
+[3]: 2.010e+02
 IndexSet: {0, [3,4]}
 
 [0]: 2.000e+00
@@ -67,14 +75,18 @@ IndexSet: {0, [3,4]}
 
 
 DEAL:2::Tpetra first import add:
-1.100e+01 1.020e+02 
+size:8 locally_owned_size:2 :
+[4]: 1.100e+01
+[5]: 1.020e+02
 IndexSet: {0, [5,6]}
 
 [0]: 1.000e+00
 [5]: 1.020e+02
 [6]: 1.200e+01
 DEAL:2::Tpetra second import add:
-3.200e+01 2.020e+02 
+size:8 locally_owned_size:2 :
+[4]: 3.200e+01
+[5]: 2.020e+02
 IndexSet: {0, [5,6]}
 
 [0]: 2.000e+00
@@ -101,13 +113,17 @@ IndexSet: {0, [5,6]}
 
 
 DEAL:3::Tpetra first import add:
-1.200e+01 1.030e+02 
+size:8 locally_owned_size:2 :
+[6]: 1.200e+01
+[7]: 1.030e+02
 IndexSet: {0, 7}
 
 [0]: 1.000e+00
 [7]: 1.030e+02
 DEAL:3::Tpetra second import add:
-3.400e+01 2.030e+02 
+size:8 locally_owned_size:2 :
+[6]: 3.400e+01
+[7]: 2.030e+02
 IndexSet: {0, 7}
 
 [0]: 2.000e+00


### PR DESCRIPTION
When I tried to use it in parallel, I discovered several bugs in the TpetraWrappers::Vector class. I bundled all fixes into this one pull request.

There are some changes I would like to highlight so that we can discuss them:

### `operator=` 
I have several issues with the original implementation:
1. The existing implementation of the `operator=` does not work in parallel (see issue #16286). 
2. It does not copy the complete content of the vector, which is not the behavior I would expect. (Here, I should highlight that the original implementation behaves similarly to the Epetra implementation. But still, this differs from what I would expect when I call the `operator=`.)
3. There is a separation by cases, which isn't necessary. In one case, it calls the `Tpetra::import()` function without checking that the conditions are met to call that function. Moreover, `import()` requires communication between the ranks. So, I don't know if this is faster.

So, I propose making a deep copy of the right-hand side.

### `compress()`/`decompress()`
So far, the `compress()` function has not been implemented. But for parallel usage, we need a way to communicate changes from one rank to another rank. But in contrast to the Epetra::Vector, the Tpetra::Vector can not write into off-processor entries and then communicate that later.  The way to overcome that problem, I came up with is to introduce two maps: 
- owned_elements: containing a non-overlapping map of all elements of the vector. So, each rank can only access the values that belong to that rank.
- relevant_elements: an overlapping map of all elements so each rank can access all elements that belong to that rank, as well as all necessary ghost elements.

We call a vector compressed if and only if the underlying map of the Tpetra::Vector is non-overlapping.
When we want to access a ghost element (that only lives in the relevant_elements map), we must first call `decompress()` (in case the vector is compressed).
And once we are done, we have to call compress() to communicate the changes between all ranks.

decompress() uses import() to distribute the internal TpetraVector from the owned_elements map to the relevant_elements map.

compress() uses export() to distribute the internal Tpetra::Vector from the relevant_elements map to the owned_elements map.

### `print()`
I reworked the print() function to match the output from the Epetra-based TrilinosWrappers::MPI::Vector. This should make reusing tests from the Epetra-based vector for the Tpetra-based vector easier.
Since I made some changes to the print() function, I had to adapt the expected output from some already existing tests for the Tpetra-based vector.

Edit:
In the original draft of this pull request, I included an additional template parameter for Kokkos::Nodes.
I removed that template parameter from this pull request and will create later an individual pull request to add that additional template parameter.