### PR TITLE
Annotate Lazy<T> with requirements on T.

### DIFF
--- a/include/deal.II/base/lazy.h
+++ b/include/deal.II/base/lazy.h
@@ -76,8 +76,13 @@ DEAL_II_NAMESPACE_OPEN
  *   Lazy<FullMatrix<double>> prolongation_matrix;
  * };
  * ```
+ *
+ * @dealiiConceptRequires{std::is_constructible_v<T, T> &&
+                          std::is_assignable_v<T &, T &&>}
  */
 template <typename T>
+DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
+                        std::is_assignable_v<T &, T &&>))
 class Lazy
 {
 public:
@@ -241,12 +246,16 @@ private:
 
 
 template <typename T>
+DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
+                        std::is_assignable_v<T &, T &&>))
 inline Lazy<T>::Lazy()
   : object_is_initialized(false)
 {}
 
 
 template <typename T>
+DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
+                        std::is_assignable_v<T &, T &&>))
 inline Lazy<T>::Lazy(const Lazy &other)
   : object(other.object)
 {
@@ -255,6 +264,8 @@ inline Lazy<T>::Lazy(const Lazy &other)
 
 
 template <typename T>
+DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
+                        std::is_assignable_v<T &, T &&>))
 inline Lazy<T>::Lazy(Lazy &&other) noexcept
   : object(other.object)
 {
@@ -263,8 +274,9 @@ inline Lazy<T>::Lazy(Lazy &&other) noexcept
 
 
 template <typename T>
-inline Lazy<T> &
-Lazy<T>::operator=(const Lazy &other)
+DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
+                        std::is_assignable_v<T &, T &&>))
+inline Lazy<T> &Lazy<T>::operator=(const Lazy &other)
 {
   object = other.object;
   object_is_initialized.store(other.object_is_initialized.load());
@@ -273,8 +285,9 @@ Lazy<T>::operator=(const Lazy &other)
 
 
 template <typename T>
-inline Lazy<T> &
-Lazy<T>::operator=(Lazy &&other) noexcept
+DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
+                        std::is_assignable_v<T &, T &&>))
+inline Lazy<T> &Lazy<T>::operator=(Lazy &&other) noexcept
 {
   object = other.object;
   object_is_initialized.store(other.object_is_initialized.load());
@@ -283,8 +296,9 @@ Lazy<T>::operator=(Lazy &&other) noexcept
 
 
 template <typename T>
-inline void
-Lazy<T>::reset() noexcept
+DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
+                        std::is_assignable_v<T &, T &&>))
+inline void Lazy<T>::reset() noexcept
 {
   object_is_initialized.store(false);
   object.reset();
@@ -292,9 +306,11 @@ Lazy<T>::reset() noexcept
 
 
 template <typename T>
+DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
+                        std::is_assignable_v<T &, T &&>))
 template <typename Callable>
-inline DEAL_II_ALWAYS_INLINE void
-Lazy<T>::ensure_initialized(const Callable &creator) const
+inline DEAL_II_ALWAYS_INLINE
+  void Lazy<T>::ensure_initialized(const Callable &creator) const
   DEAL_II_CXX20_REQUIRES((std::is_invocable_r_v<T, Callable>))
 {
   //
@@ -354,8 +370,9 @@ Lazy<T>::ensure_initialized(const Callable &creator) const
 
 
 template <typename T>
-inline DEAL_II_ALWAYS_INLINE bool
-Lazy<T>::has_value() const
+DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
+                        std::is_assignable_v<T &, T &&>))
+inline DEAL_II_ALWAYS_INLINE bool Lazy<T>::has_value() const
 {
   //
   // In principle it would be sufficient to solely check the atomic<bool>
@@ -368,8 +385,9 @@ Lazy<T>::has_value() const
 
 
 template <typename T>
-inline DEAL_II_ALWAYS_INLINE const T &
-Lazy<T>::value() const
+DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
+                        std::is_assignable_v<T &, T &&>))
+inline DEAL_II_ALWAYS_INLINE const T &Lazy<T>::value() const
 {
   Assert(
     object_is_initialized && object.has_value(),
@@ -382,8 +400,9 @@ Lazy<T>::value() const
 
 
 template <typename T>
-inline DEAL_II_ALWAYS_INLINE T &
-Lazy<T>::value()
+DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
+                        std::is_assignable_v<T &, T &&>))
+inline DEAL_II_ALWAYS_INLINE T &Lazy<T>::value()
 {
   Assert(
     object_is_initialized && object.has_value(),
@@ -396,9 +415,11 @@ Lazy<T>::value()
 
 
 template <typename T>
+DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
+                        std::is_assignable_v<T &, T &&>))
 template <typename Callable>
-inline DEAL_II_ALWAYS_INLINE const T &
-Lazy<T>::value_or_initialize(const Callable &creator) const
+inline DEAL_II_ALWAYS_INLINE const T &Lazy<T>::value_or_initialize(
+  const Callable &creator) const
   DEAL_II_CXX20_REQUIRES((std::is_invocable_r_v<T, Callable>))
 {
   ensure_initialized(creator);
@@ -407,9 +428,11 @@ Lazy<T>::value_or_initialize(const Callable &creator) const
 
 
 template <typename T>
+DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
+                        std::is_assignable_v<T &, T &&>))
 template <typename Callable>
-inline DEAL_II_ALWAYS_INLINE T &
-Lazy<T>::value_or_initialize(const Callable &creator)
+inline DEAL_II_ALWAYS_INLINE T &Lazy<T>::value_or_initialize(
+  const Callable &creator)
   DEAL_II_CXX20_REQUIRES((std::is_invocable_r_v<T, Callable>))
 {
   ensure_initialized(creator);
@@ -418,8 +441,9 @@ Lazy<T>::value_or_initialize(const Callable &creator)
 
 
 template <typename T>
-std::size_t
-Lazy<T>::memory_consumption() const
+DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
+                        std::is_assignable_v<T &, T &&>))
+std::size_t Lazy<T>::memory_consumption() const
 {
   return MemoryConsumption::memory_consumption(object) + //
          sizeof(*this) - sizeof(object);

--- a/include/deal.II/base/lazy.h
+++ b/include/deal.II/base/lazy.h
@@ -77,12 +77,12 @@ DEAL_II_NAMESPACE_OPEN
  * };
  * ```
  *
- * @dealiiConceptRequires{std::is_constructible_v<T, T> &&
-                          std::is_assignable_v<T &, T &&>}
+ * @dealiiConceptRequires{std::is_move_constructible_v<T> &&
+                          std::is_move_assignable_v<T >}
  */
 template <typename T>
-DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
-                        std::is_assignable_v<T &, T &&>))
+DEAL_II_CXX20_REQUIRES((std::is_move_constructible_v<T> &&
+                        std::is_move_assignable_v<T>))
 class Lazy
 {
 public:
@@ -246,16 +246,16 @@ private:
 
 
 template <typename T>
-DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
-                        std::is_assignable_v<T &, T &&>))
+DEAL_II_CXX20_REQUIRES((std::is_move_constructible_v<T> &&
+                        std::is_move_assignable_v<T>))
 inline Lazy<T>::Lazy()
   : object_is_initialized(false)
 {}
 
 
 template <typename T>
-DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
-                        std::is_assignable_v<T &, T &&>))
+DEAL_II_CXX20_REQUIRES((std::is_move_constructible_v<T> &&
+                        std::is_move_assignable_v<T>))
 inline Lazy<T>::Lazy(const Lazy &other)
   : object(other.object)
 {
@@ -264,8 +264,8 @@ inline Lazy<T>::Lazy(const Lazy &other)
 
 
 template <typename T>
-DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
-                        std::is_assignable_v<T &, T &&>))
+DEAL_II_CXX20_REQUIRES((std::is_move_constructible_v<T> &&
+                        std::is_move_assignable_v<T>))
 inline Lazy<T>::Lazy(Lazy &&other) noexcept
   : object(other.object)
 {
@@ -274,8 +274,8 @@ inline Lazy<T>::Lazy(Lazy &&other) noexcept
 
 
 template <typename T>
-DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
-                        std::is_assignable_v<T &, T &&>))
+DEAL_II_CXX20_REQUIRES((std::is_move_constructible_v<T> &&
+                        std::is_move_assignable_v<T>))
 inline Lazy<T> &Lazy<T>::operator=(const Lazy &other)
 {
   object = other.object;
@@ -285,8 +285,8 @@ inline Lazy<T> &Lazy<T>::operator=(const Lazy &other)
 
 
 template <typename T>
-DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
-                        std::is_assignable_v<T &, T &&>))
+DEAL_II_CXX20_REQUIRES((std::is_move_constructible_v<T> &&
+                        std::is_move_assignable_v<T>))
 inline Lazy<T> &Lazy<T>::operator=(Lazy &&other) noexcept
 {
   object = other.object;
@@ -296,8 +296,8 @@ inline Lazy<T> &Lazy<T>::operator=(Lazy &&other) noexcept
 
 
 template <typename T>
-DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
-                        std::is_assignable_v<T &, T &&>))
+DEAL_II_CXX20_REQUIRES((std::is_move_constructible_v<T> &&
+                        std::is_move_assignable_v<T>))
 inline void Lazy<T>::reset() noexcept
 {
   object_is_initialized.store(false);
@@ -306,8 +306,8 @@ inline void Lazy<T>::reset() noexcept
 
 
 template <typename T>
-DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
-                        std::is_assignable_v<T &, T &&>))
+DEAL_II_CXX20_REQUIRES((std::is_move_constructible_v<T> &&
+                        std::is_move_assignable_v<T>))
 template <typename Callable>
 inline DEAL_II_ALWAYS_INLINE
   void Lazy<T>::ensure_initialized(const Callable &creator) const
@@ -370,8 +370,8 @@ inline DEAL_II_ALWAYS_INLINE
 
 
 template <typename T>
-DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
-                        std::is_assignable_v<T &, T &&>))
+DEAL_II_CXX20_REQUIRES((std::is_move_constructible_v<T> &&
+                        std::is_move_assignable_v<T>))
 inline DEAL_II_ALWAYS_INLINE bool Lazy<T>::has_value() const
 {
   //
@@ -385,8 +385,8 @@ inline DEAL_II_ALWAYS_INLINE bool Lazy<T>::has_value() const
 
 
 template <typename T>
-DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
-                        std::is_assignable_v<T &, T &&>))
+DEAL_II_CXX20_REQUIRES((std::is_move_constructible_v<T> &&
+                        std::is_move_assignable_v<T>))
 inline DEAL_II_ALWAYS_INLINE const T &Lazy<T>::value() const
 {
   Assert(
@@ -400,8 +400,8 @@ inline DEAL_II_ALWAYS_INLINE const T &Lazy<T>::value() const
 
 
 template <typename T>
-DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
-                        std::is_assignable_v<T &, T &&>))
+DEAL_II_CXX20_REQUIRES((std::is_move_constructible_v<T> &&
+                        std::is_move_assignable_v<T>))
 inline DEAL_II_ALWAYS_INLINE T &Lazy<T>::value()
 {
   Assert(
@@ -415,8 +415,8 @@ inline DEAL_II_ALWAYS_INLINE T &Lazy<T>::value()
 
 
 template <typename T>
-DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
-                        std::is_assignable_v<T &, T &&>))
+DEAL_II_CXX20_REQUIRES((std::is_move_constructible_v<T> &&
+                        std::is_move_assignable_v<T>))
 template <typename Callable>
 inline DEAL_II_ALWAYS_INLINE const T &Lazy<T>::value_or_initialize(
   const Callable &creator) const
@@ -428,8 +428,8 @@ inline DEAL_II_ALWAYS_INLINE const T &Lazy<T>::value_or_initialize(
 
 
 template <typename T>
-DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
-                        std::is_assignable_v<T &, T &&>))
+DEAL_II_CXX20_REQUIRES((std::is_move_constructible_v<T> &&
+                        std::is_move_assignable_v<T>))
 template <typename Callable>
 inline DEAL_II_ALWAYS_INLINE T &Lazy<T>::value_or_initialize(
   const Callable &creator)
@@ -441,8 +441,8 @@ inline DEAL_II_ALWAYS_INLINE T &Lazy<T>::value_or_initialize(
 
 
 template <typename T>
-DEAL_II_CXX20_REQUIRES((std::is_constructible_v<T, T> &&
-                        std::is_assignable_v<T &, T &&>))
+DEAL_II_CXX20_REQUIRES((std::is_move_constructible_v<T> &&
+                        std::is_move_assignable_v<T>))
 std::size_t Lazy<T>::memory_consumption() const
 {
   return MemoryConsumption::memory_consumption(object) + //


### PR DESCRIPTION
This is the result of an hour trying to figure out why an intended use of `Lazy<T>` did not want to compile -- I got wild errors of the kind 
```
/home/bangerth/p/deal.II/1/dealii/include/deal.II/base/lazy.h:259:5: error: use of deleted function ‘std::optional<dealii::FEValuesViews::SymmetricTensor<2, 1, 1> >::optional(const std::optional<dealii::FEValuesViews::SymmetricTensor<2, 1, 1> >&)’
  259 |   : object(other.object)
      |     ^~~~~~~~~~~~~~~~~~~~
In file included from /home/bangerth/p/deal.II/1/dealii/include/deal.II/base/memory_consumption.h:27,
                 from /home/bangerth/p/deal.II/1/dealii/include/deal.II/base/aligned_vector.h:23,
                 from /home/bangerth/p/deal.II/1/dealii/include/deal.II/base/table.h:21,
                 from /home/bangerth/p/deal.II/1/dealii/include/deal.II/lac/full_matrix.h:23,
                 from /home/bangerth/p/deal.II/1/dealii/include/deal.II/differentiation/ad/ad_drivers.h:27,
                 from /home/bangerth/p/deal.II/1/dealii/include/deal.II/differentiation/ad/ad_helpers.h:27,
                 from /home/bangerth/p/deal.II/1/dealii/include/deal.II/differentiation/ad.h:21,
                 from /home/bangerth/p/deal.II/1/dealii/source/fe/fe_values_views.cc:19:
/usr/include/c++/11/optional:662:11: note: ‘std::optional<dealii::FEValuesViews::SymmetricTensor<2, 1, 1> >::optional(const std::optional<dealii::FEValuesViews::SymmetricTensor<2, 1, 1> >&)’ is implicitly deleted because the default definition would be ill-formed:
  662 |     class optional
      |           ^~~~~~~~
/usr/include/c++/11/optional:662:11: error: use of deleted function ‘constexpr std::_Enable_copy_move<false, false, true, false, _Tag>::_Enable_copy_move(const std::_Enable_copy_move<false, false, true, false, _Tag>&) [with _Tag = std::optional<dealii::FEValuesViews::SymmetricTensor<2, 1, 1> >]’
In file included from /usr/include/c++/11/bits/hashtable.h:36,
                 from /usr/include/c++/11/unordered_map:46,
                 from /usr/include/c++/11/functional:61,
                 from /usr/include/c++/11/pstl/glue_algorithm_defs.h:13,
                 from /usr/include/c++/11/algorithm:74,
                 from /home/bangerth/bin/candi-install/trilinos-release-13-2-0/include/Kokkos_View.hpp:50,
                 from /home/bangerth/bin/candi-install/trilinos-release-13-2-0/include/Kokkos_Parallel.hpp:53,
                 from /home/bangerth/bin/candi-install/trilinos-release-13-2-0/include/Kokkos_Serial.hpp:57,
                 from /home/bangerth/bin/candi-install/trilinos-release-13-2-0/include/decl/Kokkos_Declare_SERIAL.hpp:49,
                 from /home/bangerth/bin/candi-install/trilinos-release-13-2-0/include/KokkosCore_Config_DeclareBackend.hpp:47,
                 from /home/bangerth/bin/candi-install/trilinos-release-13-2-0/include/Kokkos_Core.hpp:56,
                 from /home/bangerth/p/deal.II/1/dealii/include/deal.II/base/exceptions.h:26,
                 from /home/bangerth/p/deal.II/1/dealii/include/deal.II/base/array_view.h:21,
                 from /home/bangerth/p/deal.II/1/dealii/source/fe/fe_values_views.cc:16:
/usr/include/c++/11/bits/enable_special_members.h:256:15: note: declared here
  256 |     constexpr _Enable_copy_move(_Enable_copy_move const&) noexcept  = delete;
      |               ^~~~~~~~~~~~~~~~~
In file included from /home/bangerth/p/deal.II/1/dealii/include/deal.II/fe/fe_values_views.h:22,
                 from /home/bangerth/p/deal.II/1/dealii/include/deal.II/fe/fe_values_base.h:36,
                 from /home/bangerth/p/deal.II/1/dealii/source/fe/fe_values_views.cc:22:
/home/bangerth/p/deal.II/1/dealii/include/deal.II/base/lazy.h: In instantiation of ‘dealii::Lazy<T>::Lazy(dealii::Lazy<T>&&) [with T = dealii::FEValuesViews::Tensor<2, 1, 1>]’:
/usr/include/c++/11/bits/stl_construct.h:97:14:   required from ‘constexpr decltype (::new(void*(0)) _Tp) std::construct_at(_Tp*, _Args&& ...) [with _Tp = dealii::Lazy<dealii::FEValuesViews::Tensor<2, 1, 1> >; _Args = {dealii::Lazy<dealii::FEValuesViews::Tensor<2, 1, 1> >}; decltype (::new(void*(0)) _Tp) = dealii::Lazy<dealii::FEValuesViews::Tensor<2, 1, 1> >*]’
```
but it took me quite a long time to figure out what is happening: The class `T` I wanted to use is not move assignable or copy constructible, and so one can't use `optional<T>::operator= (T &&)`. That was not clear from the error message.

One gets a substantially better error message if one adds a `requires` clause to `Lazy<T>` that ensures that one can't even instantiate `Lazy` with such types:
```
/home/bangerth/p/deal.II/1/dealii/include/deal.II/fe/fe_values_views.h:2058:71: error: template constraint failure for ‘template<class T>  requires (is_constructible_v<T, T>) && (is_assignable_v<T&, T&&>) class dealii::Lazy’
 2058 |       std::vector<Lazy<dealii::FEValuesViews::Scalar<dim, spacedim>>> scalars;
      |                                                                       ^~~~~~~
/home/bangerth/p/deal.II/1/dealii/include/deal.II/fe/fe_values_views.h:2058:71: note: constraints not satisfied
In file included from /home/bangerth/p/deal.II/1/dealii/include/deal.II/fe/fe_values.h:20,
                 from /home/bangerth/p/deal.II/1/dealii/include/deal.II/numerics/vector_tools_point_value.templates.h:20,
                 from /home/bangerth/p/deal.II/1/dealii/source/numerics/vector_tools_point_value.cc:17:
/home/bangerth/p/deal.II/1/dealii/include/deal.II/base/lazy.h: In substitution of ‘template<class T>  requires (is_constructible_v<T, T>) && (is_assignable_v<T&, T&&>) class dealii::Lazy [with T = dealii::FEValuesViews::Scalar<1, 1>]’:
/home/bangerth/p/deal.II/1/dealii/include/deal.II/fe/fe_values_views.h:2058:71:   required from ‘struct dealii::internal::FEValuesViews::Cache<1, 1>’
/home/bangerth/p/deal.II/1/dealii/include/deal.II/fe/fe_values_base.h:1764:57:   required from ‘class dealii::FEValuesBase<1, 1>’
/home/bangerth/p/deal.II/1/dealii/include/deal.II/fe/fe_values.h:63:7:   required from ‘class dealii::FEValues<1, 1>’
/home/bangerth/p/deal.II/1/dealii/include/deal.II/hp/fe_values.h:75:5:   required from ‘class dealii::hp::FEValuesBase<1, 1, dealii::FEValues<1, 1> >’
/home/bangerth/p/deal.II/1/dealii/include/deal.II/hp/fe_values.h:314:9:   required from ‘class dealii::hp::FEValues<1, 1>’
/home/bangerth/p/deal.II/1/dealii/include/deal.II/numerics/vector_tools_point_value.templates.h:158:33:   required from ‘void dealii::VectorTools::point_value(const dealii::hp::MappingCollection<dim, spacedim>&, const dealii::DoFHandler<dim, spacedim>&, const VectorType&, const dealii::Point<spacedim>&, dealii::Vector<typename VectorType::value_type>&) [with int dim = 1; VectorType = dealii::Vector<double>; int spacedim = 1; typename VectorType::value_type = double]’
/home/bangerth/p/deal.II/1/build/source/numerics/vector_tools_point_value.inst:21:40:   required from here
/home/bangerth/p/deal.II/1/dealii/include/deal.II/base/lazy.h:86:7:   required by the constraints of ‘template<class T>  requires (is_constructible_v<T, T>) && (is_assignable_v<T&, T&&>) class dealii::Lazy’
/home/bangerth/p/deal.II/1/dealii/include/deal.II/base/lazy.h:85:30: note: the expression ‘is_assignable_v<T&, T&&> [with T = dealii::FEValuesViews::Scalar<1, 1>]’ evaluated to ‘false’
   85 |                         std::is_assignable_v<T &, T &&>))
      |                         ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
```

@tamiko FYI.