### PR TITLE
Make FEValuesViews::* objects movable.

### DIFF
--- a/include/deal.II/fe/fe_values_views.h
+++ b/include/deal.II/fe/fe_values_views.h
@@ -548,13 +548,13 @@ namespace FEValuesViews
     /**
      * A pointer to the FEValuesBase object we operate on.
      */
-    const SmartPointer<const FEValuesBase<dim, spacedim>> fe_values;
+    SmartPointer<const FEValuesBase<dim, spacedim>> fe_values;
 
     /**
      * The single scalar component this view represents of the FEValuesBase
      * object.
      */
-    const unsigned int component;
+    unsigned int component;
 
     /**
      * Store the data about shape functions.
@@ -1271,13 +1271,13 @@ namespace FEValuesViews
     /**
      * A pointer to the FEValuesBase object we operate on.
      */
-    const SmartPointer<const FEValuesBase<dim, spacedim>> fe_values;
+    SmartPointer<const FEValuesBase<dim, spacedim>> fe_values;
 
     /**
      * The first component of the vector this view represents of the
      * FEValuesBase object.
      */
-    const unsigned int first_vector_component;
+    unsigned int first_vector_component;
 
     /**
      * Store the data about shape functions.
@@ -1584,13 +1584,13 @@ namespace FEValuesViews
     /**
      * A pointer to the FEValuesBase object we operate on.
      */
-    const SmartPointer<const FEValuesBase<dim, spacedim>> fe_values;
+    SmartPointer<const FEValuesBase<dim, spacedim>> fe_values;
 
     /**
      * The first component of the vector this view represents of the
      * FEValuesBase object.
      */
-    const unsigned int first_tensor_component;
+    unsigned int first_tensor_component;
 
     /**
      * Store the data about shape functions.
@@ -1958,13 +1958,13 @@ namespace FEValuesViews
     /**
      * A pointer to the FEValuesBase object we operate on.
      */
-    const SmartPointer<const FEValuesBase<dim, spacedim>> fe_values;
+    SmartPointer<const FEValuesBase<dim, spacedim>> fe_values;
 
     /**
      * The first component of the vector this view represents of the
      * FEValuesBase object.
      */
-    const unsigned int first_tensor_component;
+    unsigned int first_tensor_component;
 
     /**
      * Store the data about shape functions.


### PR DESCRIPTION
I found out the hard way (see #16297) that the `FEValuesViews::*` classes are not movable even though the move constructors and move assignment operators are marked with `=default`. That's because these classes have `const` member variables that mean that `=default` equals `=delete` -- not what one thinks about at first.

I want to make these classes movable because then we can lazily construct them with `Lazy<T>`, see #16182. I have a patch ready for this, but it relies on #16295. The changes here can stand on their own, however.