### PR TITLE
Make the elements of FEValuesViews::Cache lazily constructed.

### DIFF
--- a/doc/news/changes/minor/20231128Bangerth
+++ b/doc/news/changes/minor/20231128Bangerth
@@ -1,0 +1,6 @@
+New: The FEValuesBase class now lazily computes the FEValuesViews
+objects it returns when you do something like `fe_values[velocities]`,
+whenever they are needed first, rather than *always* creating these
+objects.
+<br>
+(Wolfgang Bangerth, 2023/11/28)

--- a/include/deal.II/base/lazy.h
+++ b/include/deal.II/base/lazy.h
@@ -379,6 +379,7 @@ inline DEAL_II_ALWAYS_INLINE
       //
       if (!object_is_initialized.load(std::memory_order_relaxed))
         {
+          Assert(object.has_value() == false, ExcInternalError());
           object.emplace(std::move(creator()));
 
           //

--- a/include/deal.II/base/lazy.h
+++ b/include/deal.II/base/lazy.h
@@ -379,7 +379,7 @@ inline DEAL_II_ALWAYS_INLINE
       //
       if (!object_is_initialized.load(std::memory_order_relaxed))
         {
-          object = std::move(creator());
+          object.emplace(std::move(creator()));
 
           //
           // Flip the object_is_initialized boolean with "release"

--- a/include/deal.II/fe/fe_values_base.h
+++ b/include/deal.II/fe/fe_values_base.h
@@ -1804,7 +1804,10 @@ FEValuesBase<dim, spacedim>::operator[](
 {
   AssertIndexRange(scalar.component, fe_values_views_cache.scalars.size());
 
-  return fe_values_views_cache.scalars[scalar.component];
+  return fe_values_views_cache.scalars[scalar.component].value_or_initialize(
+    [scalar, this]() {
+      return FEValuesViews::Scalar<dim, spacedim>(*this, scalar.component);
+    });
 }
 
 
@@ -1817,7 +1820,11 @@ FEValuesBase<dim, spacedim>::operator[](
   AssertIndexRange(vector.first_vector_component,
                    fe_values_views_cache.vectors.size());
 
-  return fe_values_views_cache.vectors[vector.first_vector_component];
+  return fe_values_views_cache.vectors[vector.first_vector_component]
+    .value_or_initialize([vector, this]() {
+      return FEValuesViews::Vector<dim, spacedim>(
+        *this, vector.first_vector_component);
+    });
 }
 
 
@@ -1835,7 +1842,11 @@ FEValuesBase<dim, spacedim>::operator[](
                   fe_values_views_cache.symmetric_second_order_tensors.size()));
 
   return fe_values_views_cache
-    .symmetric_second_order_tensors[tensor.first_tensor_component];
+    .symmetric_second_order_tensors[tensor.first_tensor_component]
+    .value_or_initialize([tensor, this]() {
+      return FEValuesViews::SymmetricTensor<2, dim, spacedim>(
+        *this, tensor.first_tensor_component);
+    });
 }
 
 
@@ -1849,7 +1860,11 @@ FEValuesBase<dim, spacedim>::operator[](
                    fe_values_views_cache.second_order_tensors.size());
 
   return fe_values_views_cache
-    .second_order_tensors[tensor.first_tensor_component];
+    .second_order_tensors[tensor.first_tensor_component]
+    .value_or_initialize([tensor, this]() {
+      return FEValuesViews::Tensor<2, dim, spacedim>(
+        *this, tensor.first_tensor_component);
+    });
 }
 
 

--- a/include/deal.II/fe/fe_values_views.h
+++ b/include/deal.II/fe/fe_values_views.h
@@ -19,6 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/lazy.h>
 #include <deal.II/base/smartpointer.h>
 #include <deal.II/base/symmetric_tensor.h>
 #include <deal.II/base/tensor.h>
@@ -2054,11 +2055,12 @@ namespace internal
        * Caches for scalar and vector, and symmetric second-order tensor
        * valued views.
        */
-      std::vector<dealii::FEValuesViews::Scalar<dim, spacedim>> scalars;
-      std::vector<dealii::FEValuesViews::Vector<dim, spacedim>> vectors;
-      std::vector<dealii::FEValuesViews::SymmetricTensor<2, dim, spacedim>>
+      std::vector<Lazy<dealii::FEValuesViews::Scalar<dim, spacedim>>> scalars;
+      std::vector<Lazy<dealii::FEValuesViews::Vector<dim, spacedim>>> vectors;
+      std::vector<
+        Lazy<dealii::FEValuesViews::SymmetricTensor<2, dim, spacedim>>>
         symmetric_second_order_tensors;
-      std::vector<dealii::FEValuesViews::Tensor<2, dim, spacedim>>
+      std::vector<Lazy<dealii::FEValuesViews::Tensor<2, dim, spacedim>>>
         second_order_tensors;
 
       /**

--- a/source/fe/fe_values_views.cc
+++ b/source/fe/fe_values_views.cc
@@ -1314,9 +1314,7 @@ namespace internal
       const FiniteElement<dim, spacedim> &fe = fe_values.get_fe();
 
       const unsigned int n_scalars = fe.n_components();
-      scalars.reserve(n_scalars);
-      for (unsigned int component = 0; component < n_scalars; ++component)
-        scalars.emplace_back(fe_values, component);
+      scalars.resize(n_scalars);
 
       // compute number of vectors that we can fit into this finite element.
       // note that this is based on the dimensionality 'dim' of the manifold,
@@ -1326,9 +1324,7 @@ namespace internal
            fe.n_components() - Tensor<1, spacedim>::n_independent_components +
              1 :
            0);
-      vectors.reserve(n_vectors);
-      for (unsigned int component = 0; component < n_vectors; ++component)
-        vectors.emplace_back(fe_values, component);
+      vectors.resize(n_vectors);
 
       // compute number of symmetric tensors in the same way as above
       const unsigned int n_symmetric_second_order_tensors =
@@ -1337,12 +1333,7 @@ namespace internal
            fe.n_components() -
              SymmetricTensor<2, spacedim>::n_independent_components + 1 :
            0);
-      symmetric_second_order_tensors.reserve(n_symmetric_second_order_tensors);
-      for (unsigned int component = 0;
-           component < n_symmetric_second_order_tensors;
-           ++component)
-        symmetric_second_order_tensors.emplace_back(fe_values, component);
-
+      symmetric_second_order_tensors.resize(n_symmetric_second_order_tensors);
 
       // compute number of symmetric tensors in the same way as above
       const unsigned int n_second_order_tensors =
@@ -1350,10 +1341,7 @@ namespace internal
            fe.n_components() - Tensor<2, spacedim>::n_independent_components +
              1 :
            0);
-      second_order_tensors.reserve(n_second_order_tensors);
-      for (unsigned int component = 0; component < n_second_order_tensors;
-           ++component)
-        second_order_tensors.emplace_back(fe_values, component);
+      second_order_tensors.resize(n_second_order_tensors);
     }
   } // namespace FEValuesViews
 } // namespace internal


### PR DESCRIPTION
The FEValuesBase class now lazily computes the FEValuesViews objects it returns when you do something like `fe_values[velocities]`, whenever they are needed first, rather than *always* creating these objects. This makes the first call to `operator[]` a bit more expensive, but few programs will use *all* possible views so this should save some overall time.

Related to #16182.