### PR TITLE
Disable the PETSc reference counting check for 3.20 and newer.

### DIFF
--- a/tests/tests.h
+++ b/tests/tests.h
@@ -461,6 +461,11 @@ namespace
   void
   check_petsc_allocations()
   {
+#  if DEAL_II_PETSC_VERSION_GTE(3, 20, 0)
+    // TODO: the logging code below no longer works with PETSc 3.20 and newer. A
+    // new implementation should use the approach in sys/tutorials/ex7.c to log
+    // object creations and destructions globally.
+#  else
     PetscStageLog  stageLog;
     PetscErrorCode ierr;
 
@@ -494,6 +499,7 @@ namespace
 
     if (errors)
       throw dealii::ExcMessage("PETSc memory leak");
+#  endif
   }
 } // namespace
 #endif


### PR DESCRIPTION
The 3.20 release completely rewrote the way logging works in PETSc and this old approach now crashes. I know more-or-less how to fix it (there's a relevant PETSc example) but I don't have time to do it this week - for now lets just disable this extra check with the latest PETSc version.