### PR TITLE
Evaluation template factory: Remove unused template

### DIFF
--- a/include/deal.II/matrix_free/evaluation_kernels_hanging_nodes.h
+++ b/include/deal.II/matrix_free/evaluation_kernels_hanging_nodes.h
@@ -1704,7 +1704,7 @@ namespace internal
   struct FEEvaluationImplHangingNodes
   {
   public:
-    template <int fe_degree, int n_q_points_1d>
+    template <int fe_degree>
     static bool
     run(const unsigned int                            n_desired_components,
         const MatrixFreeFunctions::ShapeInfo<Number> &shape_info,

--- a/include/deal.II/matrix_free/evaluation_template_factory_internal.h
+++ b/include/deal.II/matrix_free/evaluation_template_factory_internal.h
@@ -82,7 +82,7 @@ namespace internal
   {
     if (given_degree == degree)
       {
-        return EvaluatorType::template run<degree, degree + 1>(args...);
+        return EvaluatorType::template run<degree>(args...);
       }
     else if (degree < FE_EVAL_FACTORY_DEGREE_MAX)
       return instantiation_helper_degree_run<
@@ -90,7 +90,7 @@ namespace internal
         EvaluatorType>(given_degree, args...);
     else
       // slow path
-      return EvaluatorType::template run<-1, 0>(args...);
+      return EvaluatorType::template run<-1>(args...);
   }
 
 } // end of namespace internal

--- a/tests/matrix_free/hanging_node_kernels_01.cc
+++ b/tests/matrix_free/hanging_node_kernels_01.cc
@@ -44,7 +44,7 @@ namespace dealii
     template <int dim, typename Number, bool is_face>
     struct FEEvaluationImplHangingNodesReference
     {
-      template <int fe_degree, int n_q_points_1d>
+      template <int fe_degree>
       static bool
       run(
         const FEEvaluationData<dim, Number, is_face> &fe_eval,
@@ -486,9 +486,9 @@ test(const unsigned int                                           degree,
       internal::FEEvaluationImplHangingNodesReference<
         dim,
         VectorizedArray<double>,
-        false>::template run<-1, -1>(eval, b == 1, cmask_, values1.data());
+        false>::template run<-1>(eval, b == 1, cmask_, values1.data());
       internal::FEEvaluationImplHangingNodes<dim, VectorizedArray<double>>::
-        template run<-1, -1>(
+        template run<-1>(
           1, eval.get_shape_info(), b == 1, cmask, values2.data());
 
       for (const auto i : values1)


### PR DESCRIPTION
This specialization only depends on the degree. We should remove the template on `n_q_points_1d`.