### PR TITLE
MatrixFree::get_face_iterator: Change assert

### DIFF
--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -308,9 +308,6 @@ MatrixFree<dim, Number, VectorizedArrayType>::get_face_iterator(
   const unsigned int fe_component) const
 {
   AssertIndexRange(fe_component, dof_handlers.size());
-  AssertIndexRange(face_batch_index,
-                   n_inner_face_batches() +
-                     (interior ? n_boundary_face_batches() : 0));
 
   AssertIndexRange(lane_index,
                    n_active_entries_per_face_batch(face_batch_index));
@@ -322,6 +319,11 @@ MatrixFree<dim, Number, VectorizedArrayType>::get_face_iterator(
   const unsigned int cell_index = interior ?
                                     face2cell_info.cells_interior[lane_index] :
                                     face2cell_info.cells_exterior[lane_index];
+
+  Assert(cell_index != numbers::invalid_unsigned_int,
+         ExcMessage(
+           "Invalid cell index for requested face. Exterior cells cannot be"
+           " accessed on boundaries."));
 
   std::pair<unsigned int, unsigned int> index = cell_level_index[cell_index];
 


### PR DESCRIPTION
This change allows to access the face iterator on ghosted inner faces.

We check for a valid `FaceToCellTopology` here: https://github.com/dealii/dealii/blob/c1ddcf411dc8720c70556e72ba18131f320d2130/include/deal.II/matrix_free/matrix_free.h#L2875-L2883

The new check provides a useful error message if someone tries to access the exterior face iterator on a boundary.