### PR TITLE
RemotePointEvaluation: add AdditionalData struct

### DIFF
--- a/doc/news/changes/minor/20231206Schreter
+++ b/doc/news/changes/minor/20231206Schreter
@@ -1,0 +1,6 @@
+New: Add AdditionalData struct for configuring the RemotePointEvaluation class. 
+The latter is passed into a new constructor.
+Deprecated: The old constructor of RemotePointEvaluation class taking the 
+parameters value-by-value is marked as deprecated.
+<br>
+(Magdalena Schreter-Fleischhacker, Peter Munch, 2023/12/06)

--- a/include/deal.II/base/mpi_remote_point_evaluation.h
+++ b/include/deal.II/base/mpi_remote_point_evaluation.h
@@ -54,7 +54,60 @@ namespace Utilities
     {
     public:
       /**
+       * AdditionalData structure that can be used to tweak parameters
+       * of RemotePointEvaluation.
+       */
+      struct AdditionalData
+      {
+      public:
+        /**
+         *  Constructor.
+         */
+        AdditionalData(
+          const double       tolerance                              = 1e-6,
+          const bool         enforce_unique_mapping                 = false,
+          const unsigned int rtree_level                            = 0,
+          const std::function<std::vector<bool>()> &marked_vertices = {});
+
+        /**
+         * Tolerance in terms of unit cell coordinates for determining all cells
+         * around a point passed to RemotePointEvaluation during reinit().
+         * Depending on the problem, it might be necessary to adjust the
+         * tolerance in order to be able to identify a cell. Floating point
+         * arithmetic implies that a point will, in general, not lie exactly on
+         * a vertex, edge, or face.
+         */
+        double tolerance;
+
+        /**
+         * Enforce unique mapping, i.e., (one-to-one) relation of points and
+         * cells.
+         */
+        bool enforce_unique_mapping;
+
+        /**
+         * RTree level to be used during the construction of the bounding boxes.
+         */
+        unsigned int rtree_level;
+
+        /**
+         * Function that marks relevant vertices to make search of active cells
+         * around point more efficient.
+         */
+        std::function<std::vector<bool>()> marked_vertices;
+      };
+
+      /**
        * Constructor.
+       *
+       * @param additional_data Configure options for RemotePointEvaluation.
+       */
+      RemotePointEvaluation(
+        const AdditionalData &additional_data = AdditionalData());
+
+      /**
+       * Constructor. This constructor is deprecated. Use the other constructor
+       * taking AdditionalData instead.
        *
        * @param tolerance Tolerance in terms of unit cell coordinates for
        *   determining all cells around a point passed to the class during
@@ -67,9 +120,13 @@ namespace Utilities
        * @param rtree_level RTree level to be used during the construction of the bounding boxes.
        * @param marked_vertices Function that marks relevant vertices to make search
        *   of active cells around point more efficient.
+       *
+       * @deprecated
        */
+      DEAL_II_DEPRECATED_EARLY_WITH_COMMENT(
+        "Use the constructor with AdditionalData struct.")
       RemotePointEvaluation(
-        const double       tolerance                              = 1e-6,
+        const double       tolerance,
         const bool         enforce_unique_mapping                 = false,
         const unsigned int rtree_level                            = 0,
         const std::function<std::vector<bool>()> &marked_vertices = {});
@@ -312,27 +369,9 @@ namespace Utilities
 
     private:
       /**
-       * Tolerance to be used while determining the surrounding cells of a
-       * point.
+       * Additional data with basic settings.
        */
-      const double tolerance;
-
-      /**
-       * Enforce unique mapping, i.e., (one-to-one) relation of points and
-       * cells.
-       */
-      const bool enforce_unique_mapping;
-
-      /**
-       * RTree level to be used during the construction of the bounding boxes.
-       */
-      const unsigned int rtree_level;
-
-      /**
-       * Function that marks relevant vertices to make search of active cells
-       * around point more efficient.
-       */
-      const std::function<std::vector<bool>()> marked_vertices;
+      const AdditionalData additional_data;
 
       /**
        * Storage for the status of the triangulation signal.

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -4991,7 +4991,11 @@ template <int dim, typename Number>
 MGTwoLevelTransferNonNested<dim, LinearAlgebra::distributed::Vector<Number>>::
   MGTwoLevelTransferNonNested(const AdditionalData &data)
   : additional_data(data)
-  , rpe(data.tolerance, false, data.rtree_level, {})
+  , rpe(typename Utilities::MPI::RemotePointEvaluation<dim>::AdditionalData(
+      data.tolerance,
+      false,
+      data.rtree_level,
+      {}))
 {}
 
 template <int dim, typename Number>

--- a/tests/remote_point_evaluation/mapping_01.cc
+++ b/tests/remote_point_evaluation/mapping_01.cc
@@ -58,7 +58,11 @@ test(const bool enforce_unique_map)
     for (unsigned int i = 0; i <= 4; ++i)
       evaluation_points.emplace_back(i * 0.25, j * 0.25);
 
-  Utilities::MPI::RemotePointEvaluation<dim> eval(1e-6, enforce_unique_map);
+  typename Utilities::MPI::RemotePointEvaluation<dim>::AdditionalData
+    additional_data;
+  additional_data.enforce_unique_mapping = enforce_unique_map;
+  additional_data.tolerance              = 1e-6;
+  Utilities::MPI::RemotePointEvaluation<dim> eval(additional_data);
 
   const auto result_avg =
     VectorTools::point_values<1>(mapping,

--- a/tests/remote_point_evaluation/mapping_03.cc
+++ b/tests/remote_point_evaluation/mapping_03.cc
@@ -55,7 +55,12 @@ test(const bool enforce_unique_map)
     // should be assigned to rank 0 for unique mapping
     evaluation_points.emplace_back(0.5, 0.5 + std::pow<double>(10.0, -i));
 
-  Utilities::MPI::RemotePointEvaluation<dim> eval(1e-6, enforce_unique_map);
+  typename Utilities::MPI::RemotePointEvaluation<dim>::AdditionalData
+    additional_data;
+  additional_data.enforce_unique_mapping = enforce_unique_map;
+  additional_data.tolerance              = 1e-6;
+
+  Utilities::MPI::RemotePointEvaluation<dim> eval(additional_data);
 
   const auto result_avg =
     VectorTools::point_values<1>(mapping,

--- a/tests/remote_point_evaluation/mapping_04.cc
+++ b/tests/remote_point_evaluation/mapping_04.cc
@@ -42,7 +42,11 @@ do_test(const bool                     enforce_unique_map,
 
   MappingQ1<dim> mapping;
 
-  Utilities::MPI::RemotePointEvaluation<dim> eval(1.e-6, enforce_unique_map);
+  typename Utilities::MPI::RemotePointEvaluation<dim>::AdditionalData
+    additional_data;
+  additional_data.enforce_unique_mapping = enforce_unique_map;
+
+  Utilities::MPI::RemotePointEvaluation<dim> eval(additional_data);
 
   eval.reinit(evaluation_points, tria, mapping);
 

--- a/tests/remote_point_evaluation/search_adjacent_cells.cc
+++ b/tests/remote_point_evaluation/search_adjacent_cells.cc
@@ -158,7 +158,10 @@ test(const unsigned int mapping_degree,
     }
 
   // initialize RPE without any marked points
-  dealii::Utilities::MPI::RemotePointEvaluation<dim> rpe(tolerance);
+  typename Utilities::MPI::RemotePointEvaluation<dim>::AdditionalData
+    additional_data;
+  additional_data.tolerance = tolerance;
+  dealii::Utilities::MPI::RemotePointEvaluation<dim> rpe(additional_data);
   rpe.reinit(points, tria, mapping);
 
   unsigned int                    n_points_not_found_rpe = 0;
@@ -182,8 +185,13 @@ test(const unsigned int mapping_degree,
 
   // initialize RPE with all points marked
   std::vector<bool> marked_vertices(tria.n_vertices(), true);
-  dealii::Utilities::MPI::RemotePointEvaluation<dim> rpe2(
-    tolerance, false, 0, [marked_vertices]() { return marked_vertices; });
+
+  typename Utilities::MPI::RemotePointEvaluation<dim>::AdditionalData
+    additional_data2(tolerance, false, 0, [marked_vertices]() {
+      return marked_vertices;
+    });
+
+  dealii::Utilities::MPI::RemotePointEvaluation<dim> rpe2(additional_data2);
 
   rpe2.reinit(points, tria, mapping);
 


### PR DESCRIPTION
This PR proposes to introduce an `AdditionalData` struct for `RemotePointEvaluation` since there are already a number of parameters for configuration. I marked the old constructor as deprecated.

@peterrum FYI