### PR TITLE
Vectorize Function

### DIFF
--- a/include/deal.II/base/function.h
+++ b/include/deal.II/base/function.h
@@ -25,6 +25,7 @@
 #include <deal.II/base/subscriptor.h>
 #include <deal.II/base/symmetric_tensor.h>
 #include <deal.II/base/tensor.h>
+#include <deal.II/base/vectorization.h>
 
 #include <functional>
 #include <vector>
@@ -35,7 +36,7 @@ DEAL_II_NAMESPACE_OPEN
 #ifndef DOXYGEN
 template <typename number>
 class Vector;
-template <int rank, int dim, typename Number>
+template <int rank, int dim, typename Number, typename Number2>
 class TensorFunction;
 #endif
 
@@ -57,12 +58,12 @@ class TensorFunction;
  * @code
  * // access to one component at one point
  * double
- * value(const Point<dim> & p,
+ * value(const Point<dim, PointNumberType> & p,
  *       const unsigned int component = 0) const;
  *
  * // return all components at one point
  * void
- * vector_value(const Point<dim> &p,
+ * vector_value(const Point<dim, PointNumberType> &p,
  *              Vector<double>   &value) const;
  * @endcode
  *
@@ -71,13 +72,13 @@ class TensorFunction;
  * @code
  * // access to one component at several points
  * void
- * value_list(const std::vector<Point<dim>> &point_list,
+ * value_list(const std::vector<Point<dim, PointNumberType>> &point_list,
  *            std::vector<double>           &value_list,
  *            const unsigned int             component = 0) const;
  *
  * // return all components at several points
  * void
- * vector_value_list(const std::vector<Point<dim>> &point_list,
+ * vector_value_list(const std::vector<Point<dim, PointNumberType>> &point_list,
  *                   std::vector<Vector<double>>   &value_list) const;
  * @endcode
  *
@@ -136,7 +137,7 @@ class TensorFunction;
  *
  * @tparam dim The space dimension of the range space within which the domain
  *   $\Omega$ of the function lies. Consequently, the function will be
- *   evaluated at objects of type @p Point<dim>.
+ *   evaluated at objects of type @p Point<dim, PointNumberType>.
  * @tparam RangeNumberType The scalar type of the vector space that is
  *   the range (or image) of this function. As discussed above,
  *   objects of the current type represent functions from ${\mathbb
@@ -146,11 +147,20 @@ class TensorFunction;
  *
  * @ingroup functions
  */
-template <int dim, typename RangeNumberType = double>
-class Function : public FunctionTime<
-                   typename numbers::NumberTraits<RangeNumberType>::real_type>,
-                 public Subscriptor
+template <int dim,
+          typename RangeNumberType = double,
+          typename PointNumberType = double>
+class Function
+  : public FunctionTime<
+      typename numbers::NumberTraits<typename internal::VectorizedArrayTrait<
+        RangeNumberType>::value_type>::real_type>,
+    public Subscriptor
 {
+  static_assert(
+    internal::VectorizedArrayTrait<RangeNumberType>::width() ==
+      internal::VectorizedArrayTrait<PointNumberType>::width(),
+    "Range number type and point number type need to have the same vectorization width!");
+
 public:
   /**
    * Export the value of the template parameter as a static member constant.
@@ -167,7 +177,8 @@ public:
    * The scalar-valued real type used for representing time.
    */
   using time_type = typename FunctionTime<
-    typename numbers::NumberTraits<RangeNumberType>::real_type>::time_type;
+    typename numbers::NumberTraits<typename internal::VectorizedArrayTrait<
+      RangeNumberType>::value_type>::real_type>::time_type;
 
   /**
    * Constructor. May take an initial value for the number of components
@@ -221,7 +232,8 @@ public:
    * component.
    */
   virtual RangeNumberType
-  value(const Point<dim> &p, const unsigned int component = 0) const;
+  value(const Point<dim, PointNumberType> &p,
+        const unsigned int                 component = 0) const;
 
   /**
    * Return all components of a vector-valued function at a given point.
@@ -231,7 +243,8 @@ public:
    * The default implementation will call value() for each component.
    */
   virtual void
-  vector_value(const Point<dim> &p, Vector<RangeNumberType> &values) const;
+  vector_value(const Point<dim, PointNumberType> &p,
+               Vector<RangeNumberType>           &values) const;
 
   /**
    * Set <tt>values</tt> to the point values of the specified component of the
@@ -243,9 +256,9 @@ public:
    * separately, to fill the output array.
    */
   virtual void
-  value_list(const std::vector<Point<dim>> &points,
-             std::vector<RangeNumberType>  &values,
-             const unsigned int             component = 0) const;
+  value_list(const std::vector<Point<dim, PointNumberType>> &points,
+             std::vector<RangeNumberType>                   &values,
+             const unsigned int component = 0) const;
 
   /**
    * Set <tt>values</tt> to the point values of the function at the
@@ -258,7 +271,7 @@ public:
    * separately, to fill the output array.
    */
   virtual void
-  vector_value_list(const std::vector<Point<dim>>        &points,
+  vector_value_list(const std::vector<Point<dim, PointNumberType>> &points,
                     std::vector<Vector<RangeNumberType>> &values) const;
 
   /**
@@ -270,22 +283,23 @@ public:
    * can be reimplemented in derived classes to speed up performance.
    */
   virtual void
-  vector_values(const std::vector<Point<dim>>             &points,
-                std::vector<std::vector<RangeNumberType>> &values) const;
+  vector_values(const std::vector<Point<dim, PointNumberType>> &points,
+                std::vector<std::vector<RangeNumberType>>      &values) const;
 
   /**
    * Return the gradient of the specified component of the function at the
    * given point.
    */
   virtual Tensor<1, dim, RangeNumberType>
-  gradient(const Point<dim> &p, const unsigned int component = 0) const;
+  gradient(const Point<dim, PointNumberType> &p,
+           const unsigned int                 component = 0) const;
 
   /**
    * Return the gradient of all components of the function at the given point.
    */
   virtual void
   vector_gradient(
-    const Point<dim>                             &p,
+    const Point<dim, PointNumberType>            &p,
     std::vector<Tensor<1, dim, RangeNumberType>> &gradients) const;
 
   /**
@@ -295,8 +309,8 @@ public:
    * array.
    */
   virtual void
-  gradient_list(const std::vector<Point<dim>>                &points,
-                std::vector<Tensor<1, dim, RangeNumberType>> &gradients,
+  gradient_list(const std::vector<Point<dim, PointNumberType>> &points,
+                std::vector<Tensor<1, dim, RangeNumberType>>   &gradients,
                 const unsigned int component = 0) const;
 
   /**
@@ -309,7 +323,7 @@ public:
    */
   virtual void
   vector_gradients(
-    const std::vector<Point<dim>>                             &points,
+    const std::vector<Point<dim, PointNumberType>>            &points,
     std::vector<std::vector<Tensor<1, dim, RangeNumberType>>> &gradients) const;
 
   /**
@@ -323,35 +337,37 @@ public:
    */
   virtual void
   vector_gradient_list(
-    const std::vector<Point<dim>>                             &points,
+    const std::vector<Point<dim, PointNumberType>>            &points,
     std::vector<std::vector<Tensor<1, dim, RangeNumberType>>> &gradients) const;
 
   /**
    * Compute the Laplacian of a given component at point <tt>p</tt>.
    */
   virtual RangeNumberType
-  laplacian(const Point<dim> &p, const unsigned int component = 0) const;
+  laplacian(const Point<dim, PointNumberType> &p,
+            const unsigned int                 component = 0) const;
 
   /**
    * Compute the Laplacian of all components at point <tt>p</tt> and store
    * them in <tt>values</tt>.
    */
   virtual void
-  vector_laplacian(const Point<dim> &p, Vector<RangeNumberType> &values) const;
+  vector_laplacian(const Point<dim, PointNumberType> &p,
+                   Vector<RangeNumberType>           &values) const;
 
   /**
    * Compute the Laplacian of one component at a set of points.
    */
   virtual void
-  laplacian_list(const std::vector<Point<dim>> &points,
-                 std::vector<RangeNumberType>  &values,
-                 const unsigned int             component = 0) const;
+  laplacian_list(const std::vector<Point<dim, PointNumberType>> &points,
+                 std::vector<RangeNumberType>                   &values,
+                 const unsigned int component = 0) const;
 
   /**
    * Compute the Laplacians of all components at a set of points.
    */
   virtual void
-  vector_laplacian_list(const std::vector<Point<dim>>        &points,
+  vector_laplacian_list(const std::vector<Point<dim, PointNumberType>> &points,
                         std::vector<Vector<RangeNumberType>> &values) const;
 
   /**
@@ -359,7 +375,8 @@ public:
    * gradient of the gradient of the function.
    */
   virtual SymmetricTensor<2, dim, RangeNumberType>
-  hessian(const Point<dim> &p, const unsigned int component = 0) const;
+  hessian(const Point<dim, PointNumberType> &p,
+          const unsigned int                 component = 0) const;
 
   /**
    * Compute the Hessian of all components at point <tt>p</tt> and store them
@@ -367,14 +384,14 @@ public:
    */
   virtual void
   vector_hessian(
-    const Point<dim>                                      &p,
+    const Point<dim, PointNumberType>                     &p,
     std::vector<SymmetricTensor<2, dim, RangeNumberType>> &values) const;
 
   /**
    * Compute the Hessian of one component at a set of points.
    */
   virtual void
-  hessian_list(const std::vector<Point<dim>>                         &points,
+  hessian_list(const std::vector<Point<dim, PointNumberType>>        &points,
                std::vector<SymmetricTensor<2, dim, RangeNumberType>> &values,
                const unsigned int component = 0) const;
 
@@ -383,7 +400,7 @@ public:
    */
   virtual void
   vector_hessian_list(
-    const std::vector<Point<dim>>                                      &points,
+    const std::vector<Point<dim, PointNumberType>>                     &points,
     std::vector<std::vector<SymmetricTensor<2, dim, RangeNumberType>>> &values)
     const;
 
@@ -406,8 +423,11 @@ namespace Functions
    *
    * @ingroup functions
    */
-  template <int dim, typename RangeNumberType = double>
-  class ConstantFunction : public Function<dim, RangeNumberType>
+  template <int dim,
+            typename RangeNumberType = double,
+            typename PointNumberType = double>
+  class ConstantFunction
+    : public Function<dim, RangeNumberType, PointNumberType>
   {
   public:
     /**
@@ -439,49 +459,50 @@ namespace Functions
                      const unsigned int     n_components);
 
     virtual RangeNumberType
-    value(const Point<dim> &p, const unsigned int component = 0) const override;
+    value(const Point<dim, PointNumberType> &p,
+          const unsigned int                 component = 0) const override;
 
     virtual void
-    vector_value(const Point<dim>        &p,
+    vector_value(const Point<dim, PointNumberType> &p,
                  Vector<RangeNumberType> &return_value) const override;
 
     virtual void
-    value_list(const std::vector<Point<dim>> &points,
-               std::vector<RangeNumberType>  &return_values,
-               const unsigned int             component = 0) const override;
+    value_list(const std::vector<Point<dim, PointNumberType>> &points,
+               std::vector<RangeNumberType>                   &return_values,
+               const unsigned int component = 0) const override;
 
     virtual void
     vector_value_list(
-      const std::vector<Point<dim>>        &points,
+      const std::vector<Point<dim, PointNumberType>> &points,
       std::vector<Vector<RangeNumberType>> &return_values) const override;
 
     virtual Tensor<1, dim, RangeNumberType>
-    gradient(const Point<dim>  &p,
-             const unsigned int component = 0) const override;
+    gradient(const Point<dim, PointNumberType> &p,
+             const unsigned int                 component = 0) const override;
 
     virtual void
     vector_gradient(
-      const Point<dim>                             &p,
+      const Point<dim, PointNumberType>            &p,
       std::vector<Tensor<1, dim, RangeNumberType>> &gradients) const override;
 
     virtual void
-    gradient_list(const std::vector<Point<dim>>                &points,
-                  std::vector<Tensor<1, dim, RangeNumberType>> &gradients,
+    gradient_list(const std::vector<Point<dim, PointNumberType>> &points,
+                  std::vector<Tensor<1, dim, RangeNumberType>>   &gradients,
                   const unsigned int component = 0) const override;
 
     virtual void
     vector_gradient_list(
-      const std::vector<Point<dim>>                             &points,
+      const std::vector<Point<dim, PointNumberType>>            &points,
       std::vector<std::vector<Tensor<1, dim, RangeNumberType>>> &gradients)
       const override;
 
     virtual SymmetricTensor<2, dim, RangeNumberType>
-    hessian(const Point<dim>  &point,
-            const unsigned int component = 0) const override;
+    hessian(const Point<dim, PointNumberType> &point,
+            const unsigned int                 component = 0) const override;
 
     virtual RangeNumberType
-    laplacian(const Point<dim>  &point,
-              const unsigned int component = 0) const override;
+    laplacian(const Point<dim, PointNumberType> &point,
+              const unsigned int                 component = 0) const override;
 
     virtual std::size_t
     memory_consumption() const override;
@@ -506,8 +527,11 @@ namespace Functions
    *
    * @ingroup functions
    */
-  template <int dim, typename RangeNumberType = double>
-  class ZeroFunction : public ConstantFunction<dim, RangeNumberType>
+  template <int dim,
+            typename RangeNumberType = double,
+            typename PointNumberType = double>
+  class ZeroFunction
+    : public ConstantFunction<dim, RangeNumberType, PointNumberType>
   {
   public:
     /**
@@ -526,8 +550,11 @@ namespace Functions
    *
    * @ingroup functions
    */
-  template <int dim, typename RangeNumberType = double>
-  class IdentityFunction : public Function<dim, RangeNumberType>
+  template <int dim,
+            typename RangeNumberType = double,
+            typename PointNumberType = double>
+  class IdentityFunction
+    : public Function<dim, RangeNumberType, PointNumberType>
   {
   public:
     /**
@@ -539,28 +566,29 @@ namespace Functions
      * @copydoc Function::value()
      */
     virtual RangeNumberType
-    value(const Point<dim> &p, const unsigned int component = 0) const override;
+    value(const Point<dim, PointNumberType> &p,
+          const unsigned int                 component = 0) const override;
 
     /**
      * @copydoc Function::gradient()
      */
     virtual Tensor<1, dim, RangeNumberType>
-    gradient(const Point<dim>  &p,
-             const unsigned int component = 0) const override;
+    gradient(const Point<dim, PointNumberType> &p,
+             const unsigned int                 component = 0) const override;
 
     /**
      * @copydoc Function::laplacian()
      */
     virtual RangeNumberType
-    laplacian(const Point<dim>  &p,
-              const unsigned int component = 0) const override;
+    laplacian(const Point<dim, PointNumberType> &p,
+              const unsigned int                 component = 0) const override;
 
     /**
      * @copydoc Function::hessian()
      */
     virtual SymmetricTensor<2, dim, RangeNumberType>
-    hessian(const Point<dim>  &p,
-            const unsigned int component = 0) const override;
+    hessian(const Point<dim, PointNumberType> &p,
+            const unsigned int                 component = 0) const override;
   };
 } // namespace Functions
 
@@ -577,9 +605,11 @@ namespace Functions
  *
  * @ingroup functions
  */
-template <int dim, typename RangeNumberType = double>
+template <int dim,
+          typename RangeNumberType = double,
+          typename PointNumberType = double>
 class ComponentSelectFunction
-  : public Functions::ConstantFunction<dim, RangeNumberType>
+  : public Functions::ConstantFunction<dim, RangeNumberType, PointNumberType>
 {
 public:
   /**
@@ -624,14 +654,15 @@ public:
    */
   virtual void
   substitute_function_value_with(
-    const Functions::ConstantFunction<dim, RangeNumberType> &f);
+    const Functions::ConstantFunction<dim, RangeNumberType, PointNumberType>
+      &f);
 
   /**
    * Return the value of the function at the given point for all components.
    */
   virtual void
-  vector_value(const Point<dim>        &p,
-               Vector<RangeNumberType> &return_value) const override;
+  vector_value(const Point<dim, PointNumberType> &p,
+               Vector<RangeNumberType>           &return_value) const override;
 
   /**
    * Set <tt>values</tt> to the point values of the function at the
@@ -641,8 +672,8 @@ public:
    */
   virtual void
   vector_value_list(
-    const std::vector<Point<dim>>        &points,
-    std::vector<Vector<RangeNumberType>> &values) const override;
+    const std::vector<Point<dim, PointNumberType>> &points,
+    std::vector<Vector<RangeNumberType>>           &values) const override;
 
   /**
    * Return an estimate for the memory consumption, in bytes, of this object.
@@ -662,7 +693,7 @@ protected:
 /**
  * This class provides a way to convert a scalar function of the kind
  * @code
- * RangeNumberType foo (const Point<dim> &);
+ * RangeNumberType foo (const Point<dim, PointNumberType> &);
  * @endcode
  * into an object of type Function@<dim@>. Since the argument returns a
  * scalar, the result is clearly a Function object for which
@@ -689,11 +720,11 @@ protected:
  * could write it like so:
  * @code
  * template <int dim, typename RangeNumberType>
- * class Norm : public Function<dim, RangeNumberType>
+ * class Norm : public Function<dim, RangeNumberType, PointNumberType>
  * {
  * public:
  *   virtual RangeNumberType
- *   value(const Point<dim> & p,
+ *   value(const Point<dim, PointNumberType> & p,
  *         const unsigned int component) const
  *   {
  *     Assert (component == 0, ExcMessage ("This object is scalar!"));
@@ -707,27 +738,27 @@ protected:
  * like so:
  * @code
  * ScalarFunctionFromFunctionObject<dim, RangeNumberType> my_norm_object(
- *   &Point<dim>::norm);
+ *   &Point<dim, PointNumberType>::norm);
  * @endcode
  *
  * Similarly, to generate an object that computes the distance to a point
  * <code>q</code>, we could do this:
  * @code
  * template <int dim, typename RangeNumberType>
- * class DistanceTo : public Function<dim, RangeNumberType>
+ * class DistanceTo : public Function<dim, RangeNumberType, PointNumberType>
  * {
  * public:
- *   DistanceTo (const Point<dim> &q) : q(q) {}
+ *   DistanceTo (const Point<dim, PointNumberType> &q) : q(q) {}
  *
  *   virtual RangeNumberType
- *   value (const Point<dim> & p,
+ *   value (const Point<dim, PointNumberType> & p,
  *          const unsigned int component) const
  *   {
  *     Assert(component == 0, ExcMessage("This object is scalar!"));
  *     return q.distance(p);
  *   }
  * private:
- *   const Point<dim> q;
+ *   const Point<dim, PointNumberType> q;
  * };
  *
  * Point<2> q (2, 3);
@@ -736,7 +767,7 @@ protected:
  * or we could write it like so:
  * @code
  * ScalarFunctionFromFunctionObject<dim, RangeNumberType> my_distance_object(
- *   [&q](const Point<dim> &p){return q.distance(p);});
+ *   [&q](const Point<dim, PointNumberType> &p){return q.distance(p);});
  * @endcode
  * The savings in work to write this are apparent.
  *
@@ -799,8 +830,11 @@ protected:
  *
  * @ingroup functions
  */
-template <int dim, typename RangeNumberType = double>
-class ScalarFunctionFromFunctionObject : public Function<dim, RangeNumberType>
+template <int dim,
+          typename RangeNumberType = double,
+          typename PointNumberType = double>
+class ScalarFunctionFromFunctionObject
+  : public Function<dim, RangeNumberType, PointNumberType>
 {
 public:
   /**
@@ -809,21 +843,24 @@ public:
    * RangeNumberType> interface.
    */
   explicit ScalarFunctionFromFunctionObject(
-    const std::function<RangeNumberType(const Point<dim> &)> &function_object);
+    const std::function<RangeNumberType(const Point<dim, PointNumberType> &)>
+      &function_object);
 
   /**
    * Return the value of the function at the given point. Returns the value
    * the function given to the constructor produces for this point.
    */
   virtual RangeNumberType
-  value(const Point<dim> &p, const unsigned int component = 0) const override;
+  value(const Point<dim, PointNumberType> &p,
+        const unsigned int                 component = 0) const override;
 
 private:
   /**
    * The function object which we call when this class's value() or
    * value_list() functions are called.
    */
-  const std::function<RangeNumberType(const Point<dim> &)> function_object;
+  const std::function<RangeNumberType(const Point<dim, PointNumberType> &)>
+    function_object;
 };
 
 
@@ -866,9 +903,11 @@ private:
  *
  * @ingroup functions
  */
-template <int dim, typename RangeNumberType = double>
+template <int dim,
+          typename RangeNumberType = double,
+          typename PointNumberType = double>
 class VectorFunctionFromScalarFunctionObject
-  : public Function<dim, RangeNumberType>
+  : public Function<dim, RangeNumberType, PointNumberType>
 {
 public:
   /**
@@ -884,7 +923,8 @@ public:
    * the first argument.
    */
   VectorFunctionFromScalarFunctionObject(
-    const std::function<RangeNumberType(const Point<dim> &)> &function_object,
+    const std::function<RangeNumberType(const Point<dim, PointNumberType> &)>
+                      &function_object,
     const unsigned int selected_component,
     const unsigned int n_components);
 
@@ -893,7 +933,8 @@ public:
    * the function given to the constructor produces for this point.
    */
   virtual RangeNumberType
-  value(const Point<dim> &p, const unsigned int component = 0) const override;
+  value(const Point<dim, PointNumberType> &p,
+        const unsigned int                 component = 0) const override;
 
   /**
    * Return all components of a vector-valued function at a given point.
@@ -901,15 +942,16 @@ public:
    * <tt>values</tt> shall have the right size beforehand, i.e. #n_components.
    */
   virtual void
-  vector_value(const Point<dim>        &p,
-               Vector<RangeNumberType> &values) const override;
+  vector_value(const Point<dim, PointNumberType> &p,
+               Vector<RangeNumberType>           &values) const override;
 
 private:
   /**
    * The function object which we call when this class's value() or
    * value_list() functions are called.
    */
-  const std::function<RangeNumberType(const Point<dim> &)> function_object;
+  const std::function<RangeNumberType(const Point<dim, PointNumberType> &)>
+    function_object;
 
   /**
    * The vector component whose value is to be filled by the given scalar
@@ -954,8 +996,11 @@ private:
  *                     {&zero_gradient, &zero_gradient});
  * @endcode
  */
-template <int dim, typename RangeNumberType = double>
-class FunctionFromFunctionObjects : public Function<dim, RangeNumberType>
+template <int dim,
+          typename RangeNumberType = double,
+          typename PointNumberType = double>
+class FunctionFromFunctionObjects
+  : public Function<dim, RangeNumberType, PointNumberType>
 {
 public:
   /**
@@ -978,7 +1023,8 @@ public:
    * set_function_gradients() method.
    */
   explicit FunctionFromFunctionObjects(
-    const std::vector<std::function<RangeNumberType(const Point<dim> &)>>
+    const std::vector<
+      std::function<RangeNumberType(const Point<dim, PointNumberType> &)>>
                 &values,
     const double initial_time = 0.0);
 
@@ -991,12 +1037,12 @@ public:
    * match, an exception is triggered.
    */
   FunctionFromFunctionObjects(
-    const std::vector<std::function<RangeNumberType(const Point<dim> &)>>
-      &values,
     const std::vector<
-      std::function<Tensor<1, dim, RangeNumberType>(const Point<dim> &)>>
-                &gradients,
-    const double initial_time = 0.0);
+      std::function<RangeNumberType(const Point<dim, PointNumberType> &)>>
+                                             &values,
+    const std::vector<std::function<Tensor<1, dim, RangeNumberType>(
+      const Point<dim, PointNumberType> &)>> &gradients,
+    const double                              initial_time = 0.0);
 
 
   /**
@@ -1006,7 +1052,8 @@ public:
    * component.
    */
   virtual RangeNumberType
-  value(const Point<dim> &p, const unsigned int component = 0) const override;
+  value(const Point<dim, PointNumberType> &p,
+        const unsigned int                 component = 0) const override;
 
   /**
    * Return the gradient of the function at the given point. Unless there is
@@ -1015,8 +1062,8 @@ public:
    * component.
    */
   virtual Tensor<1, dim, RangeNumberType>
-  gradient(const Point<dim>  &p,
-           const unsigned int component = 0) const override;
+  gradient(const Point<dim, PointNumberType> &p,
+           const unsigned int                 component = 0) const override;
 
   /**
    * Reset the function values of this object. An assertion is thrown if the
@@ -1024,9 +1071,8 @@ public:
    * this object.
    */
   void
-  set_function_values(
-    const std::vector<std::function<RangeNumberType(const Point<dim> &)>>
-      &values);
+  set_function_values(const std::vector<std::function<RangeNumberType(
+                        const Point<dim, PointNumberType> &)>> &values);
 
   /**
    * Reset the function gradients of this object. An assertion is thrown if the
@@ -1035,22 +1081,22 @@ public:
    */
   void
   set_function_gradients(
-    const std::vector<
-      std::function<Tensor<1, dim, RangeNumberType>(const Point<dim> &)>>
-      &gradients);
+    const std::vector<std::function<Tensor<1, dim, RangeNumberType>(
+      const Point<dim, PointNumberType> &)>> &gradients);
 
 private:
   /**
    * The actual function values.
    */
-  std::vector<std::function<RangeNumberType(const Point<dim> &)>>
+  std::vector<
+    std::function<RangeNumberType(const Point<dim, PointNumberType> &)>>
     function_values;
 
   /**
    * The actual function gradients.
    */
-  std::vector<
-    std::function<Tensor<1, dim, RangeNumberType>(const Point<dim> &)>>
+  std::vector<std::function<Tensor<1, dim, RangeNumberType>(
+    const Point<dim, PointNumberType> &)>>
     function_gradients;
 };
 
@@ -1090,8 +1136,11 @@ private:
  *
  * @ingroup functions
  */
-template <int dim, typename RangeNumberType = double>
-class VectorFunctionFromTensorFunction : public Function<dim, RangeNumberType>
+template <int dim,
+          typename RangeNumberType = double,
+          typename PointNumberType = double>
+class VectorFunctionFromTensorFunction
+  : public Function<dim, RangeNumberType, PointNumberType>
 {
 public:
   /**
@@ -1111,9 +1160,10 @@ public:
    * fits inside the <tt>n_component</tt> length return vector.
    */
   explicit VectorFunctionFromTensorFunction(
-    const TensorFunction<1, dim, RangeNumberType> &tensor_function,
-    const unsigned int                             selected_component = 0,
-    const unsigned int                             n_components       = dim);
+    const TensorFunction<1, dim, RangeNumberType, PointNumberType>
+                      &tensor_function,
+    const unsigned int selected_component = 0,
+    const unsigned int n_components       = dim);
 
   /**
    * This destructor is defined as virtual so as to coincide with all other
@@ -1125,7 +1175,8 @@ public:
    * Return a single component of a vector-valued function at a given point.
    */
   virtual RangeNumberType
-  value(const Point<dim> &p, const unsigned int component = 0) const override;
+  value(const Point<dim, PointNumberType> &p,
+        const unsigned int                 component = 0) const override;
 
   /**
    * Return all components of a vector-valued function at a given point.
@@ -1133,8 +1184,8 @@ public:
    * <tt>values</tt> shall have the right size beforehand, i.e. #n_components.
    */
   virtual void
-  vector_value(const Point<dim>        &p,
-               Vector<RangeNumberType> &values) const override;
+  vector_value(const Point<dim, PointNumberType> &p,
+               Vector<RangeNumberType>           &values) const override;
 
   /**
    * Return all components of a vector-valued function at a list of points.
@@ -1145,23 +1196,23 @@ public:
    */
   virtual void
   vector_value_list(
-    const std::vector<Point<dim>>        &points,
-    std::vector<Vector<RangeNumberType>> &value_list) const override;
+    const std::vector<Point<dim, PointNumberType>> &points,
+    std::vector<Vector<RangeNumberType>>           &value_list) const override;
 
   /**
    * Return the gradient of the specified component of the function at the given
    * point.
    */
   virtual Tensor<1, dim, RangeNumberType>
-  gradient(const Point<dim>  &p,
-           const unsigned int component = 0) const override;
+  gradient(const Point<dim, PointNumberType> &p,
+           const unsigned int                 component = 0) const override;
 
   /**
    * Return the gradient of all components of the function at the given point.
    */
   virtual void
   vector_gradient(
-    const Point<dim>                             &p,
+    const Point<dim, PointNumberType>            &p,
     std::vector<Tensor<1, dim, RangeNumberType>> &gradients) const override;
 
   /**
@@ -1171,8 +1222,8 @@ public:
    * array.
    */
   virtual void
-  gradient_list(const std::vector<Point<dim>>                &points,
-                std::vector<Tensor<1, dim, RangeNumberType>> &gradients,
+  gradient_list(const std::vector<Point<dim, PointNumberType>> &points,
+                std::vector<Tensor<1, dim, RangeNumberType>>   &gradients,
                 const unsigned int component = 0) const override;
 
   /**
@@ -1184,7 +1235,7 @@ public:
    * can be reimplemented in derived classes to speed up performance.
    */
   virtual void
-  vector_gradients(const std::vector<Point<dim>> &points,
+  vector_gradients(const std::vector<Point<dim, PointNumberType>> &points,
                    std::vector<std::vector<Tensor<1, dim, RangeNumberType>>>
                      &gradients) const override;
 
@@ -1198,7 +1249,7 @@ public:
    * the inner loop over the different components of the function.
    */
   virtual void
-  vector_gradient_list(const std::vector<Point<dim>> &points,
+  vector_gradient_list(const std::vector<Point<dim, PointNumberType>> &points,
                        std::vector<std::vector<Tensor<1, dim, RangeNumberType>>>
                          &gradients) const override;
 
@@ -1207,7 +1258,8 @@ private:
    * The TensorFunction object which we call when this class's vector_value()
    * or vector_value_list() functions are called.
    */
-  const TensorFunction<1, dim, RangeNumberType> &tensor_function;
+  const TensorFunction<1, dim, RangeNumberType, PointNumberType>
+    &tensor_function;
 
   /**
    * The first vector component whose value is to be filled by the given
@@ -1225,8 +1277,8 @@ private:
 //
 // The destructor is pure virtual so we can't default it
 // in the declaration.
-template <int dim, typename RangeNumberType>
-inline Function<dim, RangeNumberType>::~Function() = default;
+template <int dim, typename RangeNumberType, typename PointNumberType>
+inline Function<dim, RangeNumberType, PointNumberType>::~Function() = default;
 #endif
 
 

--- a/include/deal.II/base/function.templates.h
+++ b/include/deal.II/base/function.templates.h
@@ -30,15 +30,17 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-template <int dim, typename RangeNumberType>
-const unsigned int Function<dim, RangeNumberType>::dimension;
+template <int dim, typename RangeNumberType, typename PointNumberType>
+const unsigned int Function<dim, RangeNumberType, PointNumberType>::dimension;
 
 
-template <int dim, typename RangeNumberType>
-Function<dim, RangeNumberType>::Function(
-  const unsigned int                                       n_components,
-  const typename Function<dim, RangeNumberType>::time_type initial_time)
-  : FunctionTime<typename Function<dim, RangeNumberType>::time_type>(
+template <int dim, typename RangeNumberType, typename PointNumberType>
+Function<dim, RangeNumberType, PointNumberType>::Function(
+  const unsigned int n_components,
+  const typename Function<dim, RangeNumberType, PointNumberType>::time_type
+    initial_time)
+  : FunctionTime<
+      typename Function<dim, RangeNumberType, PointNumberType>::time_type>(
       initial_time)
   , n_components(n_components)
 {
@@ -50,9 +52,9 @@ Function<dim, RangeNumberType>::Function(
 
 
 
-template <int dim, typename RangeNumberType>
-Function<dim, RangeNumberType> &
-Function<dim, RangeNumberType>::operator=(const Function &f)
+template <int dim, typename RangeNumberType, typename PointNumberType>
+Function<dim, RangeNumberType, PointNumberType> &
+Function<dim, RangeNumberType, PointNumberType>::operator=(const Function &f)
 {
   (void)f;
   AssertDimension(n_components, f.n_components);
@@ -60,20 +62,22 @@ Function<dim, RangeNumberType>::operator=(const Function &f)
 }
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 RangeNumberType
-Function<dim, RangeNumberType>::value(const Point<dim> &,
-                                      const unsigned int) const
+Function<dim, RangeNumberType, PointNumberType>::value(
+  const Point<dim, PointNumberType> &,
+  const unsigned int) const
 {
   Assert(false, ExcPureFunctionCalled());
   return 0;
 }
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 void
-Function<dim, RangeNumberType>::vector_value(const Point<dim>        &p,
-                                             Vector<RangeNumberType> &v) const
+Function<dim, RangeNumberType, PointNumberType>::vector_value(
+  const Point<dim, PointNumberType> &p,
+  Vector<RangeNumberType>           &v) const
 {
   AssertDimension(v.size(), this->n_components);
   for (unsigned int i = 0; i < this->n_components; ++i)
@@ -81,12 +85,12 @@ Function<dim, RangeNumberType>::vector_value(const Point<dim>        &p,
 }
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 void
-Function<dim, RangeNumberType>::value_list(
-  const std::vector<Point<dim>> &points,
-  std::vector<RangeNumberType>  &values,
-  const unsigned int             component) const
+Function<dim, RangeNumberType, PointNumberType>::value_list(
+  const std::vector<Point<dim, PointNumberType>> &points,
+  std::vector<RangeNumberType>                   &values,
+  const unsigned int                              component) const
 {
   // check whether component is in the valid range is up to the derived
   // class
@@ -98,11 +102,11 @@ Function<dim, RangeNumberType>::value_list(
 }
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 void
-Function<dim, RangeNumberType>::vector_value_list(
-  const std::vector<Point<dim>>        &points,
-  std::vector<Vector<RangeNumberType>> &values) const
+Function<dim, RangeNumberType, PointNumberType>::vector_value_list(
+  const std::vector<Point<dim, PointNumberType>> &points,
+  std::vector<Vector<RangeNumberType>>           &values) const
 {
   // check whether component is in the valid range is up to the derived
   // class
@@ -114,11 +118,11 @@ Function<dim, RangeNumberType>::vector_value_list(
 }
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 void
-Function<dim, RangeNumberType>::vector_values(
-  const std::vector<Point<dim>>             &points,
-  std::vector<std::vector<RangeNumberType>> &values) const
+Function<dim, RangeNumberType, PointNumberType>::vector_values(
+  const std::vector<Point<dim, PointNumberType>> &points,
+  std::vector<std::vector<RangeNumberType>>      &values) const
 {
   const unsigned int n = this->n_components;
   AssertDimension(values.size(), n);
@@ -127,20 +131,21 @@ Function<dim, RangeNumberType>::vector_values(
 }
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 Tensor<1, dim, RangeNumberType>
-Function<dim, RangeNumberType>::gradient(const Point<dim> &,
-                                         const unsigned int) const
+Function<dim, RangeNumberType, PointNumberType>::gradient(
+  const Point<dim, PointNumberType> &,
+  const unsigned int) const
 {
   Assert(false, ExcPureFunctionCalled());
   return Tensor<1, dim, RangeNumberType>();
 }
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 void
-Function<dim, RangeNumberType>::vector_gradient(
-  const Point<dim>                             &p,
+Function<dim, RangeNumberType, PointNumberType>::vector_gradient(
+  const Point<dim, PointNumberType>            &p,
   std::vector<Tensor<1, dim, RangeNumberType>> &v) const
 {
   AssertDimension(v.size(), this->n_components);
@@ -149,12 +154,12 @@ Function<dim, RangeNumberType>::vector_gradient(
 }
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 void
-Function<dim, RangeNumberType>::gradient_list(
-  const std::vector<Point<dim>>                &points,
-  std::vector<Tensor<1, dim, RangeNumberType>> &gradients,
-  const unsigned int                            component) const
+Function<dim, RangeNumberType, PointNumberType>::gradient_list(
+  const std::vector<Point<dim, PointNumberType>> &points,
+  std::vector<Tensor<1, dim, RangeNumberType>>   &gradients,
+  const unsigned int                              component) const
 {
   Assert(gradients.size() == points.size(),
          ExcDimensionMismatch(gradients.size(), points.size()));
@@ -164,10 +169,10 @@ Function<dim, RangeNumberType>::gradient_list(
 }
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 void
-Function<dim, RangeNumberType>::vector_gradient_list(
-  const std::vector<Point<dim>>                             &points,
+Function<dim, RangeNumberType, PointNumberType>::vector_gradient_list(
+  const std::vector<Point<dim, PointNumberType>>            &points,
   std::vector<std::vector<Tensor<1, dim, RangeNumberType>>> &gradients) const
 {
   Assert(gradients.size() == points.size(),
@@ -182,10 +187,10 @@ Function<dim, RangeNumberType>::vector_gradient_list(
 }
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 void
-Function<dim, RangeNumberType>::vector_gradients(
-  const std::vector<Point<dim>>                             &points,
+Function<dim, RangeNumberType, PointNumberType>::vector_gradients(
+  const std::vector<Point<dim, PointNumberType>>            &points,
   std::vector<std::vector<Tensor<1, dim, RangeNumberType>>> &values) const
 {
   const unsigned int n = this->n_components;
@@ -196,20 +201,21 @@ Function<dim, RangeNumberType>::vector_gradients(
 
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 RangeNumberType
-Function<dim, RangeNumberType>::laplacian(const Point<dim> &,
-                                          const unsigned int) const
+Function<dim, RangeNumberType, PointNumberType>::laplacian(
+  const Point<dim, PointNumberType> &,
+  const unsigned int) const
 {
   Assert(false, ExcPureFunctionCalled());
   return 0;
 }
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 void
-Function<dim, RangeNumberType>::vector_laplacian(
-  const Point<dim> &,
+Function<dim, RangeNumberType, PointNumberType>::vector_laplacian(
+  const Point<dim, PointNumberType> &,
   Vector<RangeNumberType> &) const
 {
   Assert(false, ExcPureFunctionCalled());
@@ -217,12 +223,12 @@ Function<dim, RangeNumberType>::vector_laplacian(
 
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 void
-Function<dim, RangeNumberType>::laplacian_list(
-  const std::vector<Point<dim>> &points,
-  std::vector<RangeNumberType>  &laplacians,
-  const unsigned int             component) const
+Function<dim, RangeNumberType, PointNumberType>::laplacian_list(
+  const std::vector<Point<dim, PointNumberType>> &points,
+  std::vector<RangeNumberType>                   &laplacians,
+  const unsigned int                              component) const
 {
   // check whether component is in the valid range is up to the derived
   // class
@@ -234,11 +240,11 @@ Function<dim, RangeNumberType>::laplacian_list(
 }
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 void
-Function<dim, RangeNumberType>::vector_laplacian_list(
-  const std::vector<Point<dim>>        &points,
-  std::vector<Vector<RangeNumberType>> &laplacians) const
+Function<dim, RangeNumberType, PointNumberType>::vector_laplacian_list(
+  const std::vector<Point<dim, PointNumberType>> &points,
+  std::vector<Vector<RangeNumberType>>           &laplacians) const
 {
   // check whether component is in the valid range is up to the derived
   // class
@@ -250,20 +256,21 @@ Function<dim, RangeNumberType>::vector_laplacian_list(
 }
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 SymmetricTensor<2, dim, RangeNumberType>
-Function<dim, RangeNumberType>::hessian(const Point<dim> &,
-                                        const unsigned int) const
+Function<dim, RangeNumberType, PointNumberType>::hessian(
+  const Point<dim, PointNumberType> &,
+  const unsigned int) const
 {
   Assert(false, ExcPureFunctionCalled());
   return SymmetricTensor<2, dim, RangeNumberType>();
 }
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 void
-Function<dim, RangeNumberType>::vector_hessian(
-  const Point<dim>                                      &p,
+Function<dim, RangeNumberType, PointNumberType>::vector_hessian(
+  const Point<dim, PointNumberType>                     &p,
   std::vector<SymmetricTensor<2, dim, RangeNumberType>> &v) const
 {
   AssertDimension(v.size(), this->n_components);
@@ -272,10 +279,10 @@ Function<dim, RangeNumberType>::vector_hessian(
 }
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 void
-Function<dim, RangeNumberType>::hessian_list(
-  const std::vector<Point<dim>>                         &points,
+Function<dim, RangeNumberType, PointNumberType>::hessian_list(
+  const std::vector<Point<dim, PointNumberType>>        &points,
   std::vector<SymmetricTensor<2, dim, RangeNumberType>> &hessians,
   const unsigned int                                     component) const
 {
@@ -287,10 +294,10 @@ Function<dim, RangeNumberType>::hessian_list(
 }
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 void
-Function<dim, RangeNumberType>::vector_hessian_list(
-  const std::vector<Point<dim>>                                      &points,
+Function<dim, RangeNumberType, PointNumberType>::vector_hessian_list(
+  const std::vector<Point<dim, PointNumberType>>                     &points,
   std::vector<std::vector<SymmetricTensor<2, dim, RangeNumberType>>> &hessians)
   const
 {
@@ -307,9 +314,9 @@ Function<dim, RangeNumberType>::vector_hessian_list(
 
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 std::size_t
-Function<dim, RangeNumberType>::memory_consumption() const
+Function<dim, RangeNumberType, PointNumberType>::memory_consumption() const
 {
   // only simple data elements, so use sizeof operator
   return sizeof(*this);
@@ -321,29 +328,29 @@ Function<dim, RangeNumberType>::memory_consumption() const
 
 namespace Functions
 {
-  template <int dim, typename RangeNumberType>
-  ConstantFunction<dim, RangeNumberType>::ConstantFunction(
+  template <int dim, typename RangeNumberType, typename PointNumberType>
+  ConstantFunction<dim, RangeNumberType, PointNumberType>::ConstantFunction(
     const RangeNumberType value,
     const unsigned int    n_components)
-    : Function<dim, RangeNumberType>(n_components)
+    : Function<dim, RangeNumberType, PointNumberType>(n_components)
     , function_value_vector(n_components, value)
   {}
 
 
 
-  template <int dim, typename RangeNumberType>
-  ConstantFunction<dim, RangeNumberType>::ConstantFunction(
+  template <int dim, typename RangeNumberType, typename PointNumberType>
+  ConstantFunction<dim, RangeNumberType, PointNumberType>::ConstantFunction(
     const std::vector<RangeNumberType> &values)
-    : Function<dim, RangeNumberType>(values.size())
+    : Function<dim, RangeNumberType, PointNumberType>(values.size())
     , function_value_vector(values)
   {}
 
 
 
-  template <int dim, typename RangeNumberType>
-  ConstantFunction<dim, RangeNumberType>::ConstantFunction(
+  template <int dim, typename RangeNumberType, typename PointNumberType>
+  ConstantFunction<dim, RangeNumberType, PointNumberType>::ConstantFunction(
     const Vector<RangeNumberType> &values)
-    : Function<dim, RangeNumberType>(values.size())
+    : Function<dim, RangeNumberType, PointNumberType>(values.size())
     , function_value_vector(values.size())
   {
     Assert(values.size() == function_value_vector.size(),
@@ -353,11 +360,11 @@ namespace Functions
 
 
 
-  template <int dim, typename RangeNumberType>
-  ConstantFunction<dim, RangeNumberType>::ConstantFunction(
+  template <int dim, typename RangeNumberType, typename PointNumberType>
+  ConstantFunction<dim, RangeNumberType, PointNumberType>::ConstantFunction(
     const RangeNumberType *begin_ptr,
     const unsigned int     n_components)
-    : Function<dim, RangeNumberType>(n_components)
+    : Function<dim, RangeNumberType, PointNumberType>(n_components)
     , function_value_vector(n_components)
   {
     Assert(begin_ptr != nullptr, ExcMessage("Null pointer encountered!"));
@@ -368,10 +375,10 @@ namespace Functions
 
 
 
-  template <int dim, typename RangeNumberType>
+  template <int dim, typename RangeNumberType, typename PointNumberType>
   RangeNumberType
-  ConstantFunction<dim, RangeNumberType>::value(
-    const Point<dim> &,
+  ConstantFunction<dim, RangeNumberType, PointNumberType>::value(
+    const Point<dim, PointNumberType> &,
     const unsigned int component) const
   {
     AssertIndexRange(component, this->n_components);
@@ -380,10 +387,10 @@ namespace Functions
 
 
 
-  template <int dim, typename RangeNumberType>
+  template <int dim, typename RangeNumberType, typename PointNumberType>
   void
-  ConstantFunction<dim, RangeNumberType>::vector_value(
-    const Point<dim> &,
+  ConstantFunction<dim, RangeNumberType, PointNumberType>::vector_value(
+    const Point<dim, PointNumberType> &,
     Vector<RangeNumberType> &return_value) const
   {
     Assert(return_value.size() == this->n_components,
@@ -396,12 +403,12 @@ namespace Functions
 
 
 
-  template <int dim, typename RangeNumberType>
+  template <int dim, typename RangeNumberType, typename PointNumberType>
   void
-  ConstantFunction<dim, RangeNumberType>::value_list(
-    const std::vector<Point<dim>> &points,
-    std::vector<RangeNumberType>  &return_values,
-    const unsigned int             component) const
+  ConstantFunction<dim, RangeNumberType, PointNumberType>::value_list(
+    const std::vector<Point<dim, PointNumberType>> &points,
+    std::vector<RangeNumberType>                   &return_values,
+    const unsigned int                              component) const
   {
     // To avoid warning of unused parameter
     (void)points;
@@ -416,11 +423,11 @@ namespace Functions
 
 
 
-  template <int dim, typename RangeNumberType>
+  template <int dim, typename RangeNumberType, typename PointNumberType>
   void
-  ConstantFunction<dim, RangeNumberType>::vector_value_list(
-    const std::vector<Point<dim>>        &points,
-    std::vector<Vector<RangeNumberType>> &return_values) const
+  ConstantFunction<dim, RangeNumberType, PointNumberType>::vector_value_list(
+    const std::vector<Point<dim, PointNumberType>> &points,
+    std::vector<Vector<RangeNumberType>>           &return_values) const
   {
     Assert(return_values.size() == points.size(),
            ExcDimensionMismatch(return_values.size(), points.size()));
@@ -438,9 +445,10 @@ namespace Functions
 
 
 
-  template <int dim, typename RangeNumberType>
+  template <int dim, typename RangeNumberType, typename PointNumberType>
   std::size_t
-  ConstantFunction<dim, RangeNumberType>::memory_consumption() const
+  ConstantFunction<dim, RangeNumberType, PointNumberType>::memory_consumption()
+    const
   {
     // Here we assume RangeNumberType is a simple type.
     return (sizeof(*this) + this->n_components * sizeof(RangeNumberType));
@@ -448,20 +456,21 @@ namespace Functions
 
 
 
-  template <int dim, typename RangeNumberType>
+  template <int dim, typename RangeNumberType, typename PointNumberType>
   Tensor<1, dim, RangeNumberType>
-  ConstantFunction<dim, RangeNumberType>::gradient(const Point<dim> &,
-                                                   const unsigned int) const
+  ConstantFunction<dim, RangeNumberType, PointNumberType>::gradient(
+    const Point<dim, PointNumberType> &,
+    const unsigned int) const
   {
     return Tensor<1, dim, RangeNumberType>();
   }
 
 
 
-  template <int dim, typename RangeNumberType>
+  template <int dim, typename RangeNumberType, typename PointNumberType>
   void
-  ConstantFunction<dim, RangeNumberType>::vector_gradient(
-    const Point<dim> &,
+  ConstantFunction<dim, RangeNumberType, PointNumberType>::vector_gradient(
+    const Point<dim, PointNumberType> &,
     std::vector<Tensor<1, dim, RangeNumberType>> &gradients) const
   {
     Assert(gradients.size() == this->n_components,
@@ -473,11 +482,11 @@ namespace Functions
 
 
 
-  template <int dim, typename RangeNumberType>
+  template <int dim, typename RangeNumberType, typename PointNumberType>
   void
-  ConstantFunction<dim, RangeNumberType>::gradient_list(
-    const std::vector<Point<dim>>                &points,
-    std::vector<Tensor<1, dim, RangeNumberType>> &gradients,
+  ConstantFunction<dim, RangeNumberType, PointNumberType>::gradient_list(
+    const std::vector<Point<dim, PointNumberType>> &points,
+    std::vector<Tensor<1, dim, RangeNumberType>>   &gradients,
     const unsigned int /*component*/) const
   {
     Assert(gradients.size() == points.size(),
@@ -489,10 +498,10 @@ namespace Functions
 
 
 
-  template <int dim, typename RangeNumberType>
+  template <int dim, typename RangeNumberType, typename PointNumberType>
   void
-  ConstantFunction<dim, RangeNumberType>::vector_gradient_list(
-    const std::vector<Point<dim>>                             &points,
+  ConstantFunction<dim, RangeNumberType, PointNumberType>::vector_gradient_list(
+    const std::vector<Point<dim, PointNumberType>>            &points,
     std::vector<std::vector<Tensor<1, dim, RangeNumberType>>> &gradients) const
   {
     Assert(gradients.size() == points.size(),
@@ -508,46 +517,49 @@ namespace Functions
 
 
 
-  template <int dim, typename RangeNumberType>
+  template <int dim, typename RangeNumberType, typename PointNumberType>
   SymmetricTensor<2, dim, RangeNumberType>
-  ConstantFunction<dim, RangeNumberType>::hessian(const Point<dim> &,
-                                                  const unsigned int) const
+  ConstantFunction<dim, RangeNumberType, PointNumberType>::hessian(
+    const Point<dim, PointNumberType> &,
+    const unsigned int) const
   {
     return SymmetricTensor<2, dim, RangeNumberType>();
   }
 
 
 
-  template <int dim, typename RangeNumberType>
+  template <int dim, typename RangeNumberType, typename PointNumberType>
   RangeNumberType
-  ConstantFunction<dim, RangeNumberType>::laplacian(const Point<dim> &,
-                                                    const unsigned int) const
+  ConstantFunction<dim, RangeNumberType, PointNumberType>::laplacian(
+    const Point<dim, PointNumberType> &,
+    const unsigned int) const
   {
     return 0;
   }
 
 
 
-  template <int dim, typename RangeNumberType>
-  ZeroFunction<dim, RangeNumberType>::ZeroFunction(
+  template <int dim, typename RangeNumberType, typename PointNumberType>
+  ZeroFunction<dim, RangeNumberType, PointNumberType>::ZeroFunction(
     const unsigned int n_components)
-    : ConstantFunction<dim, RangeNumberType>(RangeNumberType(), n_components)
+    : ConstantFunction<dim, RangeNumberType, PointNumberType>(RangeNumberType(),
+                                                              n_components)
   {}
 
 
 
-  template <int dim, typename RangeNumberType>
-  IdentityFunction<dim, RangeNumberType>::IdentityFunction()
-    : Function<dim, RangeNumberType>(dim)
+  template <int dim, typename RangeNumberType, typename PointNumberType>
+  IdentityFunction<dim, RangeNumberType, PointNumberType>::IdentityFunction()
+    : Function<dim, RangeNumberType, PointNumberType>(dim)
   {}
 
 
 
-  template <int dim, typename RangeNumberType>
+  template <int dim, typename RangeNumberType, typename PointNumberType>
   RangeNumberType
-  IdentityFunction<dim, RangeNumberType>::value(
-    const Point<dim>  &p,
-    const unsigned int component) const
+  IdentityFunction<dim, RangeNumberType, PointNumberType>::value(
+    const Point<dim, PointNumberType> &p,
+    const unsigned int                 component) const
   {
     AssertIndexRange(component, this->n_components);
     return p[component];
@@ -555,10 +567,10 @@ namespace Functions
 
 
 
-  template <int dim, typename RangeNumberType>
+  template <int dim, typename RangeNumberType, typename PointNumberType>
   Tensor<1, dim, RangeNumberType>
-  IdentityFunction<dim, RangeNumberType>::gradient(
-    const Point<dim> &,
+  IdentityFunction<dim, RangeNumberType, PointNumberType>::gradient(
+    const Point<dim, PointNumberType> &,
     const unsigned int component) const
   {
     AssertIndexRange(component, this->n_components);
@@ -569,20 +581,22 @@ namespace Functions
 
 
 
-  template <int dim, typename RangeNumberType>
+  template <int dim, typename RangeNumberType, typename PointNumberType>
   SymmetricTensor<2, dim, RangeNumberType>
-  IdentityFunction<dim, RangeNumberType>::hessian(const Point<dim> &,
-                                                  const unsigned int) const
+  IdentityFunction<dim, RangeNumberType, PointNumberType>::hessian(
+    const Point<dim, PointNumberType> &,
+    const unsigned int) const
   {
     return SymmetricTensor<2, dim, RangeNumberType>();
   }
 
 
 
-  template <int dim, typename RangeNumberType>
+  template <int dim, typename RangeNumberType, typename PointNumberType>
   RangeNumberType
-  IdentityFunction<dim, RangeNumberType>::laplacian(const Point<dim> &,
-                                                    const unsigned int) const
+  IdentityFunction<dim, RangeNumberType, PointNumberType>::laplacian(
+    const Point<dim, PointNumberType> &,
+    const unsigned int) const
   {
     return 0;
   }
@@ -590,22 +604,26 @@ namespace Functions
 
 //---------------------------------------------------------------------------
 
-template <int dim, typename RangeNumberType>
-ComponentSelectFunction<dim, RangeNumberType>::ComponentSelectFunction(
-  const unsigned int    selected,
-  const RangeNumberType value,
-  const unsigned int    n_components)
-  : Functions::ConstantFunction<dim, RangeNumberType>(value, n_components)
+template <int dim, typename RangeNumberType, typename PointNumberType>
+ComponentSelectFunction<dim, RangeNumberType, PointNumberType>::
+  ComponentSelectFunction(const unsigned int    selected,
+                          const RangeNumberType value,
+                          const unsigned int    n_components)
+  : Functions::ConstantFunction<dim, RangeNumberType, PointNumberType>(
+      value,
+      n_components)
   , selected_components(std::make_pair(selected, selected + 1))
 {}
 
 
 
-template <int dim, typename RangeNumberType>
-ComponentSelectFunction<dim, RangeNumberType>::ComponentSelectFunction(
-  const unsigned int selected,
-  const unsigned int n_components)
-  : Functions::ConstantFunction<dim, RangeNumberType>(1., n_components)
+template <int dim, typename RangeNumberType, typename PointNumberType>
+ComponentSelectFunction<dim, RangeNumberType, PointNumberType>::
+  ComponentSelectFunction(const unsigned int selected,
+                          const unsigned int n_components)
+  : Functions::ConstantFunction<dim, RangeNumberType, PointNumberType>(
+      1.,
+      n_components)
   , selected_components(std::make_pair(selected, selected + 1))
 {
   AssertIndexRange(selected, n_components);
@@ -613,11 +631,13 @@ ComponentSelectFunction<dim, RangeNumberType>::ComponentSelectFunction(
 
 
 
-template <int dim, typename RangeNumberType>
-ComponentSelectFunction<dim, RangeNumberType>::ComponentSelectFunction(
-  const std::pair<unsigned int, unsigned int> &selected,
-  const unsigned int                           n_components)
-  : Functions::ConstantFunction<dim, RangeNumberType>(1., n_components)
+template <int dim, typename RangeNumberType, typename PointNumberType>
+ComponentSelectFunction<dim, RangeNumberType, PointNumberType>::
+  ComponentSelectFunction(const std::pair<unsigned int, unsigned int> &selected,
+                          const unsigned int n_components)
+  : Functions::ConstantFunction<dim, RangeNumberType, PointNumberType>(
+      1.,
+      n_components)
   , selected_components(selected)
 {
   Assert(selected_components.first < selected_components.second,
@@ -630,22 +650,23 @@ ComponentSelectFunction<dim, RangeNumberType>::ComponentSelectFunction(
 
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 void
-ComponentSelectFunction<dim, RangeNumberType>::substitute_function_value_with(
-  const Functions::ConstantFunction<dim, RangeNumberType> &f)
+ComponentSelectFunction<dim, RangeNumberType, PointNumberType>::
+  substitute_function_value_with(
+    const Functions::ConstantFunction<dim, RangeNumberType, PointNumberType> &f)
 {
-  Point<dim> p;
+  Point<dim, PointNumberType> p;
   for (unsigned int i = 0; i < this->function_value_vector.size(); ++i)
     this->function_value_vector[i] = f.value(p, i);
 }
 
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 void
-ComponentSelectFunction<dim, RangeNumberType>::vector_value(
-  const Point<dim> &,
+ComponentSelectFunction<dim, RangeNumberType, PointNumberType>::vector_value(
+  const Point<dim, PointNumberType> &,
   Vector<RangeNumberType> &return_value) const
 {
   Assert(return_value.size() == this->n_components,
@@ -659,51 +680,55 @@ ComponentSelectFunction<dim, RangeNumberType>::vector_value(
 
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 void
-ComponentSelectFunction<dim, RangeNumberType>::vector_value_list(
-  const std::vector<Point<dim>>        &points,
-  std::vector<Vector<RangeNumberType>> &values) const
+ComponentSelectFunction<dim, RangeNumberType, PointNumberType>::
+  vector_value_list(const std::vector<Point<dim, PointNumberType>> &points,
+                    std::vector<Vector<RangeNumberType>> &values) const
 {
   Assert(values.size() == points.size(),
          ExcDimensionMismatch(values.size(), points.size()));
 
   for (unsigned int i = 0; i < points.size(); ++i)
-    ComponentSelectFunction<dim, RangeNumberType>::vector_value(points[i],
-                                                                values[i]);
+    ComponentSelectFunction<dim, RangeNumberType, PointNumberType>::
+      vector_value(points[i], values[i]);
 }
 
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 std::size_t
-ComponentSelectFunction<dim, RangeNumberType>::memory_consumption() const
+ComponentSelectFunction<dim, RangeNumberType, PointNumberType>::
+  memory_consumption() const
 {
   // No new complex data structure is introduced here, just evaluate how much
   // more memory is used *inside* the class via sizeof() and add that value to
   // parent class's memory_consumption()
   return (
-    sizeof(*this) - sizeof(Functions::ConstantFunction<dim, RangeNumberType>) +
-    Functions::ConstantFunction<dim, RangeNumberType>::memory_consumption());
+    sizeof(*this) -
+    sizeof(Functions::ConstantFunction<dim, RangeNumberType, PointNumberType>) +
+    Functions::ConstantFunction<dim, RangeNumberType, PointNumberType>::
+      memory_consumption());
 }
 
 //---------------------------------------------------------------------------
 
-template <int dim, typename RangeNumberType>
-ScalarFunctionFromFunctionObject<dim, RangeNumberType>::
+template <int dim, typename RangeNumberType, typename PointNumberType>
+ScalarFunctionFromFunctionObject<dim, RangeNumberType, PointNumberType>::
   ScalarFunctionFromFunctionObject(
-    const std::function<RangeNumberType(const Point<dim> &)> &function_object)
-  : Function<dim, RangeNumberType>(1)
+    const std::function<RangeNumberType(const Point<dim, PointNumberType> &)>
+      &function_object)
+  : Function<dim, RangeNumberType, PointNumberType>(1)
   , function_object(function_object)
 {}
 
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 RangeNumberType
-ScalarFunctionFromFunctionObject<dim, RangeNumberType>::value(
-  const Point<dim>  &p,
-  const unsigned int component) const
+ScalarFunctionFromFunctionObject<dim, RangeNumberType, PointNumberType>::value(
+  const Point<dim, PointNumberType> &p,
+  const unsigned int                 component) const
 {
   (void)component;
   Assert(component == 0,
@@ -713,13 +738,14 @@ ScalarFunctionFromFunctionObject<dim, RangeNumberType>::value(
 
 
 
-template <int dim, typename RangeNumberType>
-VectorFunctionFromScalarFunctionObject<dim, RangeNumberType>::
+template <int dim, typename RangeNumberType, typename PointNumberType>
+VectorFunctionFromScalarFunctionObject<dim, RangeNumberType, PointNumberType>::
   VectorFunctionFromScalarFunctionObject(
-    const std::function<RangeNumberType(const Point<dim> &)> &function_object,
+    const std::function<RangeNumberType(const Point<dim, PointNumberType> &)>
+                      &function_object,
     const unsigned int selected_component,
     const unsigned int n_components)
-  : Function<dim, RangeNumberType>(n_components)
+  : Function<dim, RangeNumberType, PointNumberType>(n_components)
   , function_object(function_object)
   , selected_component(selected_component)
 {
@@ -728,11 +754,11 @@ VectorFunctionFromScalarFunctionObject<dim, RangeNumberType>::
 
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 RangeNumberType
-VectorFunctionFromScalarFunctionObject<dim, RangeNumberType>::value(
-  const Point<dim>  &p,
-  const unsigned int component) const
+VectorFunctionFromScalarFunctionObject<dim, RangeNumberType, PointNumberType>::
+  value(const Point<dim, PointNumberType> &p,
+        const unsigned int                 component) const
 {
   AssertIndexRange(component, this->n_components);
 
@@ -744,11 +770,11 @@ VectorFunctionFromScalarFunctionObject<dim, RangeNumberType>::value(
 
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 void
-VectorFunctionFromScalarFunctionObject<dim, RangeNumberType>::vector_value(
-  const Point<dim>        &p,
-  Vector<RangeNumberType> &values) const
+VectorFunctionFromScalarFunctionObject<dim, RangeNumberType, PointNumberType>::
+  vector_value(const Point<dim, PointNumberType> &p,
+               Vector<RangeNumberType>           &values) const
 {
   AssertDimension(values.size(), this->n_components);
 
@@ -764,13 +790,14 @@ VectorFunctionFromScalarFunctionObject<dim, RangeNumberType>::vector_value(
  * The constructor for <tt>VectorFunctionFromTensorFunction</tt> which
  * initiates the return vector to be size <tt>n_components</tt>.
  */
-template <int dim, typename RangeNumberType>
-VectorFunctionFromTensorFunction<dim, RangeNumberType>::
+template <int dim, typename RangeNumberType, typename PointNumberType>
+VectorFunctionFromTensorFunction<dim, RangeNumberType, PointNumberType>::
   VectorFunctionFromTensorFunction(
-    const TensorFunction<1, dim, RangeNumberType> &tensor_function,
-    const unsigned int                             selected_component,
-    const unsigned int                             n_components)
-  : Function<dim, RangeNumberType>(n_components)
+    const TensorFunction<1, dim, RangeNumberType, PointNumberType>
+                      &tensor_function,
+    const unsigned int selected_component,
+    const unsigned int n_components)
+  : Function<dim, RangeNumberType, PointNumberType>(n_components)
   , tensor_function(tensor_function)
   , selected_component(selected_component)
 {
@@ -781,11 +808,11 @@ VectorFunctionFromTensorFunction<dim, RangeNumberType>::
 
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 inline RangeNumberType
-VectorFunctionFromTensorFunction<dim, RangeNumberType>::value(
-  const Point<dim>  &p,
-  const unsigned int component) const
+VectorFunctionFromTensorFunction<dim, RangeNumberType, PointNumberType>::value(
+  const Point<dim, PointNumberType> &p,
+  const unsigned int                 component) const
 {
   AssertIndexRange(component, this->n_components);
 
@@ -805,11 +832,11 @@ VectorFunctionFromTensorFunction<dim, RangeNumberType>::value(
 }
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 inline void
-VectorFunctionFromTensorFunction<dim, RangeNumberType>::vector_value(
-  const Point<dim>        &p,
-  Vector<RangeNumberType> &values) const
+VectorFunctionFromTensorFunction<dim, RangeNumberType, PointNumberType>::
+  vector_value(const Point<dim, PointNumberType> &p,
+               Vector<RangeNumberType>           &values) const
 {
   Assert(values.size() == this->n_components,
          ExcDimensionMismatch(values.size(), this->n_components));
@@ -832,16 +859,16 @@ VectorFunctionFromTensorFunction<dim, RangeNumberType>::vector_value(
 
 /**
  * Member function <tt>vector_value_list </tt> is the interface for giving a
- * list of points (<code>vector<Point<dim> ></code>) of which to evaluate
- * using the <tt>vector_value</tt> member function.  Again, this function is
- * written so as to not replicate the function definition but passes each
- * point on to <tt>vector_value</tt> to be evaluated.
+ * list of points (<code>vector<Point<dim, PointNumberType> ></code>) of which
+ * to evaluate using the <tt>vector_value</tt> member function.  Again, this
+ * function is written so as to not replicate the function definition but passes
+ * each point on to <tt>vector_value</tt> to be evaluated.
  */
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 void
-VectorFunctionFromTensorFunction<dim, RangeNumberType>::vector_value_list(
-  const std::vector<Point<dim>>        &points,
-  std::vector<Vector<RangeNumberType>> &value_list) const
+VectorFunctionFromTensorFunction<dim, RangeNumberType, PointNumberType>::
+  vector_value_list(const std::vector<Point<dim, PointNumberType>> &points,
+                    std::vector<Vector<RangeNumberType>> &value_list) const
 {
   Assert(value_list.size() == points.size(),
          ExcDimensionMismatch(value_list.size(), points.size()));
@@ -849,15 +876,15 @@ VectorFunctionFromTensorFunction<dim, RangeNumberType>::vector_value_list(
   const unsigned int n_points = points.size();
 
   for (unsigned int p = 0; p < n_points; ++p)
-    VectorFunctionFromTensorFunction<dim, RangeNumberType>::vector_value(
-      points[p], value_list[p]);
+    VectorFunctionFromTensorFunction<dim, RangeNumberType, PointNumberType>::
+      vector_value(points[p], value_list[p]);
 }
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 inline Tensor<1, dim, RangeNumberType>
-VectorFunctionFromTensorFunction<dim, RangeNumberType>::gradient(
-  const Point<dim>  &p,
-  const unsigned int component) const
+VectorFunctionFromTensorFunction<dim, RangeNumberType, PointNumberType>::
+  gradient(const Point<dim, PointNumberType> &p,
+           const unsigned int                 component) const
 {
   AssertIndexRange(component, this->n_components);
 
@@ -877,11 +904,11 @@ VectorFunctionFromTensorFunction<dim, RangeNumberType>::gradient(
   return tensor_gradient[component - selected_component];
 }
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 void
-VectorFunctionFromTensorFunction<dim, RangeNumberType>::vector_gradient(
-  const Point<dim>                             &p,
-  std::vector<Tensor<1, dim, RangeNumberType>> &gradients) const
+VectorFunctionFromTensorFunction<dim, RangeNumberType, PointNumberType>::
+  vector_gradient(const Point<dim, PointNumberType>            &p,
+                  std::vector<Tensor<1, dim, RangeNumberType>> &gradients) const
 {
   AssertDimension(gradients.size(), this->n_components);
 
@@ -890,12 +917,12 @@ VectorFunctionFromTensorFunction<dim, RangeNumberType>::vector_gradient(
     gradients[i] = gradient(p, i);
 }
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 void
-VectorFunctionFromTensorFunction<dim, RangeNumberType>::gradient_list(
-  const std::vector<Point<dim>>                &points,
-  std::vector<Tensor<1, dim, RangeNumberType>> &gradients,
-  const unsigned int                            component) const
+VectorFunctionFromTensorFunction<dim, RangeNumberType, PointNumberType>::
+  gradient_list(const std::vector<Point<dim, PointNumberType>> &points,
+                std::vector<Tensor<1, dim, RangeNumberType>>   &gradients,
+                const unsigned int                              component) const
 {
   Assert(gradients.size() == points.size(),
          ExcDimensionMismatch(gradients.size(), points.size()));
@@ -907,11 +934,12 @@ VectorFunctionFromTensorFunction<dim, RangeNumberType>::gradient_list(
 
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 void
-VectorFunctionFromTensorFunction<dim, RangeNumberType>::vector_gradient_list(
-  const std::vector<Point<dim>>                             &points,
-  std::vector<std::vector<Tensor<1, dim, RangeNumberType>>> &gradients) const
+VectorFunctionFromTensorFunction<dim, RangeNumberType, PointNumberType>::
+  vector_gradient_list(
+    const std::vector<Point<dim, PointNumberType>>            &points,
+    std::vector<std::vector<Tensor<1, dim, RangeNumberType>>> &gradients) const
 {
   Assert(gradients.size() == points.size(),
          ExcDimensionMismatch(gradients.size(), points.size()));
@@ -925,11 +953,12 @@ VectorFunctionFromTensorFunction<dim, RangeNumberType>::vector_gradient_list(
     }
 }
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 void
-VectorFunctionFromTensorFunction<dim, RangeNumberType>::vector_gradients(
-  const std::vector<Point<dim>>                             &points,
-  std::vector<std::vector<Tensor<1, dim, RangeNumberType>>> &gradients) const
+VectorFunctionFromTensorFunction<dim, RangeNumberType, PointNumberType>::
+  vector_gradients(
+    const std::vector<Point<dim, PointNumberType>>            &points,
+    std::vector<std::vector<Tensor<1, dim, RangeNumberType>>> &gradients) const
 {
   const unsigned int n = this->n_components;
   AssertDimension(gradients.size(), n);
@@ -938,47 +967,50 @@ VectorFunctionFromTensorFunction<dim, RangeNumberType>::vector_gradients(
 }
 
 
-template <int dim, typename RangeNumberType>
-FunctionFromFunctionObjects<dim, RangeNumberType>::FunctionFromFunctionObjects(
-  const unsigned int n_components,
-  const double       initial_time)
-  : Function<dim, RangeNumberType>(n_components, initial_time)
+template <int dim, typename RangeNumberType, typename PointNumberType>
+FunctionFromFunctionObjects<dim, RangeNumberType, PointNumberType>::
+  FunctionFromFunctionObjects(const unsigned int n_components,
+                              const double       initial_time)
+  : Function<dim, RangeNumberType, PointNumberType>(n_components, initial_time)
   , function_values(n_components)
   , function_gradients(n_components)
 {}
 
 
 
-template <int dim, typename RangeNumberType>
-FunctionFromFunctionObjects<dim, RangeNumberType>::FunctionFromFunctionObjects(
-  const std::vector<std::function<RangeNumberType(const Point<dim> &)>> &values,
-  const double initial_time)
-  : Function<dim, RangeNumberType>(values.size(), initial_time)
+template <int dim, typename RangeNumberType, typename PointNumberType>
+FunctionFromFunctionObjects<dim, RangeNumberType, PointNumberType>::
+  FunctionFromFunctionObjects(const std::vector<std::function<RangeNumberType(
+                                const Point<dim, PointNumberType> &)>> &values,
+                              const double initial_time)
+  : Function<dim, RangeNumberType, PointNumberType>(values.size(), initial_time)
   , function_values(values)
   , function_gradients(values.size())
 {}
 
 
 
-template <int dim, typename RangeNumberType>
-FunctionFromFunctionObjects<dim, RangeNumberType>::FunctionFromFunctionObjects(
-  const std::vector<std::function<RangeNumberType(const Point<dim> &)>> &values,
-  const std::vector<
-    std::function<Tensor<1, dim, RangeNumberType>(const Point<dim> &)>>
-              &gradients,
-  const double initial_time)
-  : Function<dim, RangeNumberType>(values.size(), initial_time)
+template <int dim, typename RangeNumberType, typename PointNumberType>
+FunctionFromFunctionObjects<dim, RangeNumberType, PointNumberType>::
+  FunctionFromFunctionObjects(
+    const std::vector<
+      std::function<RangeNumberType(const Point<dim, PointNumberType> &)>>
+                                             &values,
+    const std::vector<std::function<Tensor<1, dim, RangeNumberType>(
+      const Point<dim, PointNumberType> &)>> &gradients,
+    const double                              initial_time)
+  : Function<dim, RangeNumberType, PointNumberType>(values.size(), initial_time)
   , function_values(values)
   , function_gradients(gradients)
 {}
 
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 RangeNumberType
-FunctionFromFunctionObjects<dim, RangeNumberType>::value(
-  const Point<dim>  &p,
-  const unsigned int component) const
+FunctionFromFunctionObjects<dim, RangeNumberType, PointNumberType>::value(
+  const Point<dim, PointNumberType> &p,
+  const unsigned int                 component) const
 {
   AssertIndexRange(component, this->n_components);
   Assert(function_values[component],
@@ -989,11 +1021,11 @@ FunctionFromFunctionObjects<dim, RangeNumberType>::value(
 
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 Tensor<1, dim, RangeNumberType>
-FunctionFromFunctionObjects<dim, RangeNumberType>::gradient(
-  const Point<dim>  &p,
-  const unsigned int component) const
+FunctionFromFunctionObjects<dim, RangeNumberType, PointNumberType>::gradient(
+  const Point<dim, PointNumberType> &p,
+  const unsigned int                 component) const
 {
   AssertIndexRange(component, this->n_components);
   Assert(function_gradients[component],
@@ -1005,10 +1037,11 @@ FunctionFromFunctionObjects<dim, RangeNumberType>::gradient(
 
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 void
-FunctionFromFunctionObjects<dim, RangeNumberType>::set_function_values(
-  const std::vector<std::function<RangeNumberType(const Point<dim> &)>> &values)
+FunctionFromFunctionObjects<dim, RangeNumberType, PointNumberType>::
+  set_function_values(const std::vector<std::function<RangeNumberType(
+                        const Point<dim, PointNumberType> &)>> &values)
 {
   AssertDimension(this->n_components, values.size());
   function_values = values;
@@ -1016,12 +1049,12 @@ FunctionFromFunctionObjects<dim, RangeNumberType>::set_function_values(
 
 
 
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 void
-FunctionFromFunctionObjects<dim, RangeNumberType>::set_function_gradients(
-  const std::vector<
-    std::function<Tensor<1, dim, RangeNumberType>(const Point<dim> &)>>
-    &gradients)
+FunctionFromFunctionObjects<dim, RangeNumberType, PointNumberType>::
+  set_function_gradients(
+    const std::vector<std::function<Tensor<1, dim, RangeNumberType>(
+      const Point<dim, PointNumberType> &)>> &gradients)
 {
   AssertDimension(this->n_components, gradients.size());
   function_gradients = gradients;

--- a/include/deal.II/base/tensor_function.h
+++ b/include/deal.II/base/tensor_function.h
@@ -52,11 +52,20 @@ DEAL_II_NAMESPACE_OPEN
  *
  * @ingroup functions
  */
-template <int rank, int dim, typename Number = double>
+template <int rank,
+          int dim,
+          typename Number  = double,
+          typename Number2 = double>
 class TensorFunction
-  : public FunctionTime<typename numbers::NumberTraits<Number>::real_type>,
+  : public FunctionTime<typename numbers::NumberTraits<
+      typename internal::VectorizedArrayTrait<Number>::value_type>::real_type>,
     public Subscriptor
 {
+  static_assert(
+    internal::VectorizedArrayTrait<Number>::width() ==
+      internal::VectorizedArrayTrait<Number2>::width(),
+    "Range number type and point number type need to have the same vectorization width!");
+
 public:
   /**
    * Alias for the return types of the <tt>value</tt> function.
@@ -71,8 +80,9 @@ public:
   /**
    * The scalar-valued real type used for representing time.
    */
-  using time_type = typename FunctionTime<
-    typename numbers::NumberTraits<Number>::real_type>::time_type;
+  using time_type = typename FunctionTime<typename numbers::NumberTraits<
+    typename internal::VectorizedArrayTrait<Number>::value_type>::real_type>::
+    time_type;
 
   /**
    * Constructor. May take an initial value for the time variable, which
@@ -91,7 +101,7 @@ public:
    * Return the value of the function at the given point.
    */
   virtual value_type
-  value(const Point<dim> &p) const;
+  value(const Point<dim, Number2> &p) const;
 
   /**
    * Set <tt>values</tt> to the point values of the function at the
@@ -99,14 +109,14 @@ public:
    * right size, i.e.  the same size as the <tt>points</tt> array.
    */
   virtual void
-  value_list(const std::vector<Point<dim>> &points,
-             std::vector<value_type>       &values) const;
+  value_list(const std::vector<Point<dim, Number2>> &points,
+             std::vector<value_type>                &values) const;
 
   /**
    * Return the gradient of the function at the given point.
    */
   virtual gradient_type
-  gradient(const Point<dim> &p) const;
+  gradient(const Point<dim, Number2> &p) const;
 
   /**
    * Set <tt>gradients</tt> to the gradients of the function at the
@@ -114,8 +124,8 @@ public:
    * right size, i.e.  the same size as the <tt>points</tt> array.
    */
   virtual void
-  gradient_list(const std::vector<Point<dim>> &points,
-                std::vector<gradient_type>    &gradients) const;
+  gradient_list(const std::vector<Point<dim, Number2>> &points,
+                std::vector<gradient_type>             &gradients) const;
 };
 
 
@@ -126,14 +136,18 @@ public:
  *
  * @ingroup functions
  */
-template <int rank, int dim, typename Number = double>
-class ConstantTensorFunction : public TensorFunction<rank, dim, Number>
+template <int rank,
+          int dim,
+          typename Number  = double,
+          typename Number2 = double>
+class ConstantTensorFunction : public TensorFunction<rank, dim, Number, Number2>
 {
 public:
   /**
    * The scalar-valued real type used for representing time.
    */
-  using time_type = typename TensorFunction<rank, dim, Number>::time_type;
+  using time_type =
+    typename TensorFunction<rank, dim, Number, Number2>::time_type;
 
   /**
    * Constructor; takes the constant tensor value as an argument. The
@@ -147,24 +161,26 @@ public:
 
   virtual ~ConstantTensorFunction() override = default;
 
-  virtual typename dealii::TensorFunction<rank, dim, Number>::value_type
-  value(const Point<dim> &p) const override;
+  virtual
+    typename dealii::TensorFunction<rank, dim, Number, Number2>::value_type
+    value(const Point<dim, Number2> &p) const override;
 
   virtual void
   value_list(
-    const std::vector<Point<dim>> &points,
-    std::vector<typename dealii::TensorFunction<rank, dim, Number>::value_type>
+    const std::vector<Point<dim, Number2>> &points,
+    std::vector<
+      typename dealii::TensorFunction<rank, dim, Number, Number2>::value_type>
       &values) const override;
 
-  virtual typename dealii::TensorFunction<rank, dim, Number>::gradient_type
-  gradient(const Point<dim> &p) const override;
+  virtual
+    typename dealii::TensorFunction<rank, dim, Number, Number2>::gradient_type
+    gradient(const Point<dim, Number2> &p) const override;
 
   virtual void
   gradient_list(
-    const std::vector<Point<dim>> &points,
-    std::vector<
-      typename dealii::TensorFunction<rank, dim, Number>::gradient_type>
-      &gradients) const override;
+    const std::vector<Point<dim, Number2>> &points,
+    std::vector<typename dealii::TensorFunction<rank, dim, Number, Number2>::
+                  gradient_type>           &gradients) const override;
 
 private:
   const dealii::Tensor<rank, dim, Number> _value;
@@ -178,15 +194,19 @@ private:
  *
  * @ingroup functions
  */
-template <int rank, int dim, typename Number = double>
-class ZeroTensorFunction : public ConstantTensorFunction<rank, dim, Number>
+template <int rank,
+          int dim,
+          typename Number  = double,
+          typename Number2 = double>
+class ZeroTensorFunction
+  : public ConstantTensorFunction<rank, dim, Number, Number2>
 {
 public:
   /**
    * The scalar-valued real type used for representing time.
    */
   using time_type =
-    typename ConstantTensorFunction<rank, dim, Number>::time_type;
+    typename ConstantTensorFunction<rank, dim, Number, Number2>::time_type;
 
   /**
    * Constructor.

--- a/include/deal.II/base/tensor_function.templates.h
+++ b/include/deal.II/base/tensor_function.templates.h
@@ -29,29 +29,32 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-template <int rank, int dim, typename Number>
-TensorFunction<rank, dim, Number>::TensorFunction(
-  const typename TensorFunction<rank, dim, Number>::time_type initial_time)
-  : FunctionTime<typename TensorFunction<rank, dim, Number>::time_type>(
+template <int rank, int dim, typename Number, typename Number2>
+TensorFunction<rank, dim, Number, Number2>::TensorFunction(
+  const typename TensorFunction<rank, dim, Number, Number2>::time_type
+    initial_time)
+  : FunctionTime<
+      typename TensorFunction<rank, dim, Number, Number2>::time_type>(
       initial_time)
 {}
 
 
 
-template <int rank, int dim, typename Number>
-typename TensorFunction<rank, dim, Number>::value_type
-TensorFunction<rank, dim, Number>::value(const Point<dim> &) const
+template <int rank, int dim, typename Number, typename Number2>
+typename TensorFunction<rank, dim, Number, Number2>::value_type
+TensorFunction<rank, dim, Number, Number2>::value(
+  const Point<dim, Number2> &) const
 {
   Assert(false, ExcPureFunctionCalled());
   return Tensor<rank, dim, Number>();
 }
 
 
-template <int rank, int dim, typename Number>
+template <int rank, int dim, typename Number, typename Number2>
 void
-TensorFunction<rank, dim, Number>::value_list(
-  const std::vector<Point<dim>> &points,
-  std::vector<value_type>       &values) const
+TensorFunction<rank, dim, Number, Number2>::value_list(
+  const std::vector<Point<dim, Number2>> &points,
+  std::vector<value_type>                &values) const
 {
   Assert(values.size() == points.size(),
          ExcDimensionMismatch(values.size(), points.size()));
@@ -61,20 +64,21 @@ TensorFunction<rank, dim, Number>::value_list(
 }
 
 
-template <int rank, int dim, typename Number>
-typename TensorFunction<rank, dim, Number>::gradient_type
-TensorFunction<rank, dim, Number>::gradient(const Point<dim> &) const
+template <int rank, int dim, typename Number, typename Number2>
+typename TensorFunction<rank, dim, Number, Number2>::gradient_type
+TensorFunction<rank, dim, Number, Number2>::gradient(
+  const Point<dim, Number2> &) const
 {
   Assert(false, ExcPureFunctionCalled());
   return Tensor<rank + 1, dim, Number>();
 }
 
 
-template <int rank, int dim, typename Number>
+template <int rank, int dim, typename Number, typename Number2>
 void
-TensorFunction<rank, dim, Number>::gradient_list(
-  const std::vector<Point<dim>> &points,
-  std::vector<gradient_type>    &gradients) const
+TensorFunction<rank, dim, Number, Number2>::gradient_list(
+  const std::vector<Point<dim, Number2>> &points,
+  std::vector<gradient_type>             &gradients) const
 {
   Assert(gradients.size() == points.size(),
          ExcDimensionMismatch(gradients.size(), points.size()));
@@ -85,32 +89,32 @@ TensorFunction<rank, dim, Number>::gradient_list(
 
 
 
-template <int rank, int dim, typename Number>
-ConstantTensorFunction<rank, dim, Number>::ConstantTensorFunction(
+template <int rank, int dim, typename Number, typename Number2>
+ConstantTensorFunction<rank, dim, Number, Number2>::ConstantTensorFunction(
   const Tensor<rank, dim, Number> &value,
-  const typename ConstantTensorFunction<rank, dim, Number>::time_type
+  const typename ConstantTensorFunction<rank, dim, Number, Number2>::time_type
     initial_time)
-  : TensorFunction<rank, dim, Number>(initial_time)
+  : TensorFunction<rank, dim, Number, Number2>(initial_time)
   , _value(value)
 {}
 
 
 
-template <int rank, int dim, typename Number>
-typename TensorFunction<rank, dim, Number>::value_type
-ConstantTensorFunction<rank, dim, Number>::value(
-  const Point<dim> & /*point*/) const
+template <int rank, int dim, typename Number, typename Number2>
+typename TensorFunction<rank, dim, Number, Number2>::value_type
+ConstantTensorFunction<rank, dim, Number, Number2>::value(
+  const Point<dim, Number2> & /*point*/) const
 {
   return _value;
 }
 
 
-template <int rank, int dim, typename Number>
+template <int rank, int dim, typename Number, typename Number2>
 void
-ConstantTensorFunction<rank, dim, Number>::value_list(
-  const std::vector<Point<dim>>                                       &points,
-  std::vector<typename TensorFunction<rank, dim, Number>::value_type> &values)
-  const
+ConstantTensorFunction<rank, dim, Number, Number2>::value_list(
+  const std::vector<Point<dim, Number2>> &points,
+  std::vector<typename TensorFunction<rank, dim, Number, Number2>::value_type>
+    &values) const
 {
   (void)points;
   Assert(values.size() == points.size(),
@@ -121,20 +125,22 @@ ConstantTensorFunction<rank, dim, Number>::value_list(
 }
 
 
-template <int rank, int dim, typename Number>
-typename TensorFunction<rank, dim, Number>::gradient_type
-ConstantTensorFunction<rank, dim, Number>::gradient(const Point<dim> &) const
+template <int rank, int dim, typename Number, typename Number2>
+typename TensorFunction<rank, dim, Number, Number2>::gradient_type
+ConstantTensorFunction<rank, dim, Number, Number2>::gradient(
+  const Point<dim, Number2> &) const
 {
   // Return a zero (=default initialized) tensor
   return {};
 }
 
 
-template <int rank, int dim, typename Number>
+template <int rank, int dim, typename Number, typename Number2>
 void
-ConstantTensorFunction<rank, dim, Number>::gradient_list(
-  const std::vector<Point<dim>> &points,
-  std::vector<typename TensorFunction<rank, dim, Number>::gradient_type>
+ConstantTensorFunction<rank, dim, Number, Number2>::gradient_list(
+  const std::vector<Point<dim, Number2>> &points,
+  std::vector<
+    typename TensorFunction<rank, dim, Number, Number2>::gradient_type>
     &gradients) const
 {
   (void)points;
@@ -142,17 +148,19 @@ ConstantTensorFunction<rank, dim, Number>::gradient_list(
          ExcDimensionMismatch(gradients.size(), points.size()));
 
   // Return an array of zero tensors.
-  std::fill(gradients.begin(),
-            gradients.end(),
-            typename TensorFunction<rank, dim, Number>::gradient_type());
+  std::fill(
+    gradients.begin(),
+    gradients.end(),
+    typename TensorFunction<rank, dim, Number, Number2>::gradient_type());
 }
 
 
 
-template <int rank, int dim, typename Number>
-ZeroTensorFunction<rank, dim, Number>::ZeroTensorFunction(
-  const typename ZeroTensorFunction<rank, dim, Number>::time_type initial_time)
-  : ConstantTensorFunction<rank, dim, Number>(
+template <int rank, int dim, typename Number, typename Number2>
+ZeroTensorFunction<rank, dim, Number, Number2>::ZeroTensorFunction(
+  const typename ZeroTensorFunction<rank, dim, Number, Number2>::time_type
+    initial_time)
+  : ConstantTensorFunction<rank, dim, Number, Number2>(
       dealii::Tensor<rank, dim, Number>(),
       initial_time)
 {}

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -41,7 +41,7 @@ DEAL_II_NAMESPACE_OPEN
 // Forward declarations
 #ifndef DOXYGEN
 class BlockMask;
-template <int dim, typename RangeNumberType>
+template <int dim, typename RangeNumberType, typename PointNumberType>
 class Function;
 template <int dim, int spacedim>
 class FiniteElement;

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -24,6 +24,7 @@
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/numbers.h>
 #include <deal.II/base/subscriptor.h>
+#include <deal.II/base/vectorization.h>
 
 #include <deal.II/lac/read_vector.h>
 #include <deal.II/lac/vector_operation.h>
@@ -110,19 +111,6 @@ class Vector : public Subscriptor, public ReadVector<Number>
 {
 public:
   /**
-   * This class only supports basic numeric types (i.e., we support double and
-   * float but not automatically differentiated numbers).
-   *
-   * @note we test real_type here to get the underlying scalar type when using
-   * std::complex.
-   */
-  static_assert(
-    std::is_arithmetic<
-      typename numbers::NumberTraits<Number>::real_type>::value,
-    "The Vector class only supports basic numeric types. In particular, it "
-    "does not support automatically differentiated numbers.");
-
-  /**
    * Declare standard types used in all containers. These types parallel those
    * in the <tt>C++</tt> standard libraries <tt>vector<...></tt> class.
    */
@@ -135,6 +123,11 @@ public:
   using const_reference = const value_type &;
   using size_type       = types::global_dof_index;
 
+  static constexpr std::size_t width =
+    internal::VectorizedArrayTrait<Number>::width();
+  using scalar_value_type =
+    typename internal::VectorizedArrayTrait<Number>::value_type;
+
   /**
    * Declare a type that has holds real-valued numbers with the same precision
    * as the template argument to this class. If the template argument of this
@@ -144,7 +137,21 @@ public:
    *
    * This alias is used to represent the return type of norms.
    */
-  using real_type = typename numbers::NumberTraits<Number>::real_type;
+  using real_type = typename numbers::NumberTraits<value_type>::real_type;
+  using scalar_real_type =
+    typename numbers::NumberTraits<scalar_value_type>::real_type;
+
+  /**
+   * This class only supports basic numeric types (i.e., we support double and
+   * float but not automatically differentiated numbers).
+   *
+   * @note we test real_type here to get the underlying scalar type when using
+   * std::complex.
+   */
+  static_assert(
+    std::is_arithmetic<scalar_real_type>::value,
+    "The Vector class only supports basic numeric types. In particular, it "
+    "does not support automatically differentiated numbers.");
 
   /**
    * @name Basic object handling
@@ -510,7 +517,7 @@ public:
    * with the same order of summation in every run, which gives fully
    * repeatable results from one run to another.
    */
-  real_type
+  scalar_real_type
   l1_norm() const;
 
   /**
@@ -521,7 +528,7 @@ public:
    * with the same order of summation in every run, which gives fully
    * repeatable results from one run to another.
    */
-  real_type
+  scalar_real_type
   l2_norm() const;
 
   /**
@@ -532,13 +539,13 @@ public:
    * with the same order of summation in every run, which gives fully
    * repeatable results from one run to another.
    */
-  real_type
-  lp_norm(const real_type p) const;
+  scalar_real_type
+  lp_norm(const scalar_real_type p) const;
 
   /**
    * Maximum absolute value of the elements.
    */
-  real_type
+  scalar_real_type
   linfty_norm() const;
 
   /**
@@ -1266,8 +1273,13 @@ template <typename Number>
 inline Vector<Number> &
 Vector<Number>::operator/=(const Number factor)
 {
-  AssertIsFinite(factor);
-  Assert(factor != Number(0.), ExcZero());
+  for (unsigned int v = 0; v < width; ++v)
+    {
+      AssertIsFinite(internal::VectorizedArrayTrait<Number>::get(factor, v));
+      Assert(internal::VectorizedArrayTrait<Number>::get(factor, v) !=
+               scalar_value_type(0.),
+             ExcZero());
+    }
 
   this->operator*=(Number(1.) / factor);
   return *this;

--- a/include/deal.II/numerics/vector_tools_boundary.h
+++ b/include/deal.II/numerics/vector_tools_boundary.h
@@ -32,7 +32,7 @@ class AffineConstraints;
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
-template <int dim, typename Number>
+template <int dim, typename Number, typename Number2>
 class Function;
 namespace hp
 {

--- a/include/deal.II/numerics/vector_tools_constraints.h
+++ b/include/deal.II/numerics/vector_tools_constraints.h
@@ -32,7 +32,7 @@ template <typename number>
 class AffineConstraints;
 template <int dim, int spacedim>
 struct StaticMappingQ1;
-template <int dim, typename Number>
+template <int dim, typename Number, typename Number2>
 class Function;
 template <int dim, int spacedim>
 class Mapping;

--- a/include/deal.II/numerics/vector_tools_integrate_difference.h
+++ b/include/deal.II/numerics/vector_tools_integrate_difference.h
@@ -27,7 +27,7 @@ template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 
-template <int dim, typename Number>
+template <int dim, typename Number, typename Number2>
 class Function;
 template <int dim, int spacedim>
 class Mapping;

--- a/include/deal.II/numerics/vector_tools_interpolate.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.h
@@ -33,7 +33,7 @@ class DoFHandler;
 
 template <typename number>
 class FullMatrix;
-template <int dim, typename Number>
+template <int dim, typename Number, typename Number2>
 class Function;
 template <typename MeshType>
 DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)

--- a/include/deal.II/numerics/vector_tools_point_gradient.h
+++ b/include/deal.II/numerics/vector_tools_point_gradient.h
@@ -28,7 +28,7 @@ template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 
-template <int dim, typename Number>
+template <int dim, typename Number, typename Number2>
 class Function;
 template <int dim, int spacedim>
 class Mapping;

--- a/include/deal.II/numerics/vector_tools_point_value.h
+++ b/include/deal.II/numerics/vector_tools_point_value.h
@@ -25,7 +25,7 @@ template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 
-template <int dim, typename Number>
+template <int dim, typename Number, typename Number2>
 class Function;
 template <int dim, int spacedim>
 class Mapping;

--- a/include/deal.II/numerics/vector_tools_project.h
+++ b/include/deal.II/numerics/vector_tools_project.h
@@ -31,7 +31,7 @@ template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 
-template <int dim, typename Number>
+template <int dim, typename Number, typename Number2>
 class Function;
 template <int dim, int spacedim>
 class Mapping;

--- a/include/deal.II/numerics/vector_tools_rhs.h
+++ b/include/deal.II/numerics/vector_tools_rhs.h
@@ -29,7 +29,7 @@ template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 
-template <int dim, typename Number>
+template <int dim, typename Number, typename Number2>
 class Function;
 template <int dim, int spacedim>
 class Mapping;

--- a/source/base/function.inst.in
+++ b/source/base/function.inst.in
@@ -27,6 +27,19 @@ for (S : REAL_SCALARS; dim : SPACE_DIMENSIONS)
     template class VectorFunctionFromTensorFunction<dim, S>;
   }
 
+for (S : REAL_SCALARS_VECTORIZED; dim : SPACE_DIMENSIONS)
+  {
+    template class Function<dim, S, S>;
+    template class Functions::ZeroFunction<dim, S, S>;
+    template class Functions::ConstantFunction<dim, S, S>;
+    template class Functions::IdentityFunction<dim, S, S>;
+    template class ComponentSelectFunction<dim, S, S>;
+    template class ScalarFunctionFromFunctionObject<dim, S, S>;
+    template class VectorFunctionFromScalarFunctionObject<dim, S, S>;
+    template class FunctionFromFunctionObjects<dim, S, S>;
+    template class VectorFunctionFromTensorFunction<dim, S, S>;
+  }
+
 for (S : COMPLEX_SCALARS; dim : SPACE_DIMENSIONS)
   {
     template class Function<dim, S>;

--- a/source/base/tensor_function.inst.in
+++ b/source/base/tensor_function.inst.in
@@ -21,6 +21,13 @@ for (S : REAL_SCALARS; rank : RANKS; dim : SPACE_DIMENSIONS)
     template class ZeroTensorFunction<rank, dim, S>;
   }
 
+for (S : REAL_SCALARS_VECTORIZED; rank : RANKS; dim : SPACE_DIMENSIONS)
+  {
+    template class TensorFunction<rank, dim, S, S>;
+    template class ConstantTensorFunction<rank, dim, S, S>;
+    template class ZeroTensorFunction<rank, dim, S, S>;
+  }
+
 for (S : COMPLEX_SCALARS; rank : RANKS; dim : SPACE_DIMENSIONS)
   {
     template class TensorFunction<rank, dim, S>;

--- a/source/lac/vector.inst.in
+++ b/source/lac/vector.inst.in
@@ -28,6 +28,19 @@ for (SCALAR : REAL_AND_COMPLEX_SCALARS)
     template class Vector<SCALAR>;
   }
 
+for (SCALAR : REAL_SCALARS_VECTORIZED)
+  {
+    // Check that the class we declare here satisfies the
+    // vector-space-vector concept. If we catch it here,
+    // any mistake in the vector class declaration would
+    // show up in uses of this class later on as well.
+#ifdef DEAL_II_HAVE_CXX20
+    static_assert(concepts::is_vector_space_vector<Vector<SCALAR>>);
+#endif
+
+    template class Vector<SCALAR>;
+  }
+
 for (S1, S2 : REAL_SCALARS)
   {
     template bool Vector<S1>::operator==<S2>(const Vector<S2> &) const;


### PR DESCRIPTION
In the matrix-free context with vectorization over cells or quadrature points it is useful to use `Function` vectorized.

The problem is that this means also `Vector` has to work with `VectorizedArray` which is unfortunately not straightforward for the norm calculations.

Opening as a draft to get some input if this is useful at all before I put more work into it and write some tests.