### PR TITLE
Fix mistaken std::move assignment.

### DIFF
--- a/examples/step-31/step-31.cc
+++ b/examples/step-31/step-31.cc
@@ -1975,8 +1975,8 @@ namespace Step31
       TrilinosWrappers::MPI::Vector(temperature_solution)};
     temperature_trans.interpolate(x_temperature, tmp);
 
-    temperature_solution     = std::move(tmp[0]);
-    old_temperature_solution = std::move(tmp[1]);
+    temperature_solution     = tmp[0];
+    old_temperature_solution = tmp[1];
 
     // After the solution has been transferred we then enforce the constraints
     // on the transferred solution.

--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -3326,8 +3326,11 @@ namespace Step32
         temperature_constraints.distribute(distributed_temp1);
         temperature_constraints.distribute(distributed_temp2);
 
-        temperature_solution     = std::move(distributed_temp1);
-        old_temperature_solution = std::move(distributed_temp2);
+        temperature_solution     = distributed_temp1;
+        old_temperature_solution = distributed_temp2;
+
+        Assert(old_temperature_solution.has_ghost_elements(),
+               ExcInternalError());
       }
 
       {
@@ -3344,8 +3347,8 @@ namespace Step32
         stokes_constraints.distribute(distributed_stokes);
         stokes_constraints.distribute(old_distributed_stokes);
 
-        stokes_solution     = std::move(distributed_stokes);
-        old_stokes_solution = std::move(old_distributed_stokes);
+        stokes_solution     = distributed_stokes;
+        old_stokes_solution = old_distributed_stokes;
       }
     }
   }


### PR DESCRIPTION
This fixes #16332. The issue here is that the assignment 
```
temperature_solution     = tmp[0];
```
doesn't just copy the rhs to the lhs, but because the lhs is a ghosted vector and the rhs is not, it also imports elements. We do not get these semantics if we make this into a move assignment
```
temperature_solution     = std::move(tmp[0]);
```
as I had mistakenly done in #15438.