### PR TITLE
 Support PETSc's new logging infrastructure in our test suite.

### DIFF
--- a/tests/a-framework/petsc_leak.cc
+++ b/tests/a-framework/petsc_leak.cc
@@ -1,0 +1,35 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2023 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// test the testsuite framework. Verify that we correctly fail when there is a
+// PETSc object leak
+
+#include <petscvec.h>
+
+#include "../tests.h"
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_context(argc, argv, 1);
+  MPILogInitAll                    mpi_log;
+
+  Vec x;
+  VecCreateSeq(PETSC_COMM_SELF, 42, &x);
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/a-framework/petsc_leak.with_petsc=on.mpirun=2.expect=run.output
+++ b/tests/a-framework/petsc_leak.with_petsc=on.mpirun=2.expect=run.output
@@ -1,0 +1,6 @@
+
+# we should not get here!
+
+DEAL:0::OK
+
+DEAL:1::OK


### PR DESCRIPTION
Followup to #16310 - we don't need to mess with PETSc internals any more to get the number of creations and destructions.

@knepley FYI - this is what I posted about on the mailing list a few weeks ago. ex7 was the right place to look (thanks!).