### PR TITLE
MatrixFree::reinit: Fix case with MPI and threading

### DIFF
--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -1044,6 +1044,7 @@ namespace internal
                                         > &map,
     DynamicSparsityPattern                &connectivity_direct)
   {
+    const unsigned int locally_owned_size = connectivity_direct.n_rows();
     std::vector<types::global_dof_index> new_indices;
     for (unsigned int cell = begin; cell < end; ++cell)
       {
@@ -1064,7 +1065,8 @@ namespace internal
                 if (it != map.end())
                   {
                     const unsigned int neighbor_cell = it->second;
-                    if (neighbor_cell != cell)
+                    if (neighbor_cell != cell &&
+                        neighbor_cell < locally_owned_size)
                       new_indices.push_back(neighbor_cell);
                   }
               }


### PR DESCRIPTION
Fixes #16337: We should not access the cells not owned locally for the dependency graph. It seems we somehow missed that limitations. I am not entirely sure if the dependencies are all set up correctly (I believe they are because we check neighbors in the indirect connectivity a few lines below), but that is unrelated to the present fix as it is a possible run-time problem, and there is presently no test for that aspect.