### PR TITLE
Provide some context to an exception.

### DIFF
--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -3982,12 +3982,6 @@ public:
                  int,
                  << "You tried to do something on level " << arg1
                  << ", but this level is empty.");
-  /**
-   * Exception
-   *
-   * @ingroup Exceptions
-   */
-  DeclException0(ExcNonOrientableTriangulation);
 
   /**
    * Exception


### PR DESCRIPTION
We here have an exception that has a name but no error text. That's confusing, because the class name of the exception is not actually printed -- see https://groups.google.com/g/dealii/c/013Qk-WR88I . See also #610.

While there, clean up and document better.