### PR TITLE
Do not query direction flags for Triangulation<1,3> objects.

### DIFF
--- a/source/fe/fe_values_base.cc
+++ b/source/fe/fe_values_base.cc
@@ -1440,7 +1440,7 @@ FEValuesBase<dim, spacedim>::check_cell_similarity(
            CellSimilarity::translation :
            CellSimilarity::none);
 
-  if ((dim < spacedim) && (cell_similarity == CellSimilarity::translation))
+  if ((dim == spacedim - 1) && (cell_similarity == CellSimilarity::translation))
     {
       if (static_cast<const typename Triangulation<dim, spacedim>::cell_iterator
                         &>(this->present_cell)


### PR DESCRIPTION
I believe that this is the only place where we query direction flags for 1d triangulations in 3d. See #16343 why I think this is wrong.