### PR TITLE
Only set direction flags in the codim-1 case.

### DIFF
--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -12682,7 +12682,7 @@ void Triangulation<dim, spacedim>::create_triangulation(
       more readable.
 
     */
-  if (dim < spacedim && all_reference_cells_are_hyper_cube())
+  if ((dim == spacedim - 1) && all_reference_cells_are_hyper_cube())
     {
       Table<2, bool> correct(GeometryInfo<dim>::faces_per_cell,
                              GeometryInfo<dim>::faces_per_cell);


### PR DESCRIPTION
In #16326, we run into a place where we are trying to determine whether the orientation of 1d cells in 3d allows for consistent directions. But this makes no sense, we shouldn't be asking this in the codim-2 case, see #16343. We only want to run this code for the codim-1 case -- which is what this patch does.