### PR TITLE
Some more FEValuesBase cleanups

### DIFF
--- a/include/deal.II/fe/fe_values_base.h
+++ b/include/deal.II/fe/fe_values_base.h
@@ -1559,7 +1559,7 @@ protected:
    * degrees of freedom on this cell in the get_function_values() and assorted
    * functions.
    */
-  class CellIteratorContainer
+  class CellIteratorWrapper
   {
   public:
     DeclExceptionMsg(
@@ -1576,24 +1576,24 @@ protected:
      * Constructor. Creates an unusable object that is not associated with
      * any cell at all.
      */
-    CellIteratorContainer() = default;
+    CellIteratorWrapper() = default;
 
     /**
      * Constructor.
      */
-    CellIteratorContainer(
+    CellIteratorWrapper(
       const typename Triangulation<dim, spacedim>::cell_iterator &cell);
 
     /**
      * Constructor.
      */
-    CellIteratorContainer(
+    CellIteratorWrapper(
       const typename DoFHandler<dim, spacedim>::cell_iterator &cell);
 
     /**
      * Constructor.
      */
-    CellIteratorContainer(
+    CellIteratorWrapper(
       const typename DoFHandler<dim, spacedim>::level_cell_iterator &cell);
 
     /**
@@ -1644,7 +1644,7 @@ protected:
    * is necessary for the <tt>get_function_*</tt> functions as well as the
    * functions of same name in the extractor classes.
    */
-  CellIteratorContainer present_cell;
+  CellIteratorWrapper present_cell;
 
   /**
    * A signal connection we use to ensure we get informed whenever the

--- a/include/deal.II/fe/fe_values_base.h
+++ b/include/deal.II/fe/fe_values_base.h
@@ -1558,6 +1558,16 @@ protected:
    * to the present cell in order to be able to extract the values of the
    * degrees of freedom on this cell in the get_function_values() and assorted
    * functions.
+   *
+   * The problem is that the iterators given to the various reinit() functions
+   * can either be Triangulation iterators, or DoFHandler cell or level
+   * iterators. All three are valid, and provide different functionality that is
+   * used in different contexts; as a consequence we need to be able to store
+   * all three. This class provides the ability to store an object of any of
+   * these types, via a member variable that is a std::variant that encapsulates
+   * an object of any of the three types. Because a std::variant always stores
+   * an object of *one* of these types, we wrap the std::variant object into a
+   * std::optional that allows us to encode a "not yet initialized" state.
    */
   class CellIteratorWrapper
   {

--- a/include/deal.II/fe/fe_values_base.h
+++ b/include/deal.II/fe/fe_values_base.h
@@ -1626,14 +1626,6 @@ protected:
     get_interpolated_dof_values(const ReadVector<Number> &in,
                                 Vector<Number>           &out) const;
 
-    /**
-     * Call @p get_interpolated_dof_values of the iterator with the
-     * given arguments.
-     */
-    void
-    get_interpolated_dof_values(const IndexSet               &in,
-                                Vector<IndexSet::value_type> &out) const;
-
   private:
     /**
      * The cell in question, if one has been assigned to this object. The

--- a/source/fe/fe_values_base.cc
+++ b/source/fe/fe_values_base.cc
@@ -207,43 +207,6 @@ FEValuesBase<dim, spacedim>::CellIteratorContainer::get_interpolated_dof_values(
 
 
 
-template <int dim, int spacedim>
-void
-FEValuesBase<dim, spacedim>::CellIteratorContainer::get_interpolated_dof_values(
-  const IndexSet               &in,
-  Vector<IndexSet::value_type> &out) const
-{
-  Assert(is_initialized(), ExcNotReinited());
-
-  switch (cell.value().index())
-    {
-      case 1:
-        {
-          const typename DoFHandler<dim, spacedim>::cell_iterator cell =
-            std::get<1>(this->cell.value());
-
-          std::vector<types::global_dof_index> dof_indices(
-            cell->get_fe().n_dofs_per_cell());
-
-          cell->get_dof_indices(dof_indices);
-
-          for (unsigned int i = 0; i < cell->get_fe().n_dofs_per_cell(); ++i)
-            out[i] = (in.is_element(dof_indices[i]) ? 1 : 0);
-
-          break;
-        }
-      case 2:
-        Assert(false, ExcNotImplemented());
-        break;
-
-      default:
-        Assert(false, ExcNeedsDoFHandler());
-        break;
-    }
-}
-
-
-
 /*------------------------------- FEValuesBase ---------------------------*/
 
 

--- a/source/fe/fe_values_base.cc
+++ b/source/fe/fe_values_base.cc
@@ -105,11 +105,11 @@ namespace internal
   } // namespace
 } // namespace internal
 
-/* ------------ FEValuesBase<dim,spacedim>::CellIteratorContainer ----------- */
+/* ------------ FEValuesBase<dim,spacedim>::CellIteratorWrapper ----------- */
 
 
 template <int dim, int spacedim>
-FEValuesBase<dim, spacedim>::CellIteratorContainer::CellIteratorContainer(
+FEValuesBase<dim, spacedim>::CellIteratorWrapper::CellIteratorWrapper(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell)
   : cell(cell)
 {}
@@ -117,7 +117,7 @@ FEValuesBase<dim, spacedim>::CellIteratorContainer::CellIteratorContainer(
 
 
 template <int dim, int spacedim>
-FEValuesBase<dim, spacedim>::CellIteratorContainer::CellIteratorContainer(
+FEValuesBase<dim, spacedim>::CellIteratorWrapper::CellIteratorWrapper(
   const typename DoFHandler<dim, spacedim>::cell_iterator &cell)
   : cell(cell)
 {}
@@ -125,7 +125,7 @@ FEValuesBase<dim, spacedim>::CellIteratorContainer::CellIteratorContainer(
 
 
 template <int dim, int spacedim>
-FEValuesBase<dim, spacedim>::CellIteratorContainer::CellIteratorContainer(
+FEValuesBase<dim, spacedim>::CellIteratorWrapper::CellIteratorWrapper(
   const typename DoFHandler<dim, spacedim>::level_cell_iterator &cell)
   : cell(cell)
 {}
@@ -134,7 +134,7 @@ FEValuesBase<dim, spacedim>::CellIteratorContainer::CellIteratorContainer(
 
 template <int dim, int spacedim>
 bool
-FEValuesBase<dim, spacedim>::CellIteratorContainer::is_initialized() const
+FEValuesBase<dim, spacedim>::CellIteratorWrapper::is_initialized() const
 {
   return cell.has_value();
 }
@@ -142,7 +142,7 @@ FEValuesBase<dim, spacedim>::CellIteratorContainer::is_initialized() const
 
 
 template <int dim, int spacedim>
-FEValuesBase<dim, spacedim>::CellIteratorContainer::
+FEValuesBase<dim, spacedim>::CellIteratorWrapper::
 operator typename Triangulation<dim, spacedim>::cell_iterator() const
 {
   Assert(is_initialized(), ExcNotReinited());
@@ -161,8 +161,7 @@ operator typename Triangulation<dim, spacedim>::cell_iterator() const
 
 template <int dim, int spacedim>
 types::global_dof_index
-FEValuesBase<dim, spacedim>::CellIteratorContainer::n_dofs_for_dof_handler()
-  const
+FEValuesBase<dim, spacedim>::CellIteratorWrapper::n_dofs_for_dof_handler() const
 {
   Assert(is_initialized(), ExcNotReinited());
 
@@ -183,7 +182,7 @@ FEValuesBase<dim, spacedim>::CellIteratorContainer::n_dofs_for_dof_handler()
 template <int dim, int spacedim>
 template <typename Number>
 void
-FEValuesBase<dim, spacedim>::CellIteratorContainer::get_interpolated_dof_values(
+FEValuesBase<dim, spacedim>::CellIteratorWrapper::get_interpolated_dof_values(
   const ReadVector<Number> &in,
   Vector<Number>           &out) const
 {

--- a/source/fe/fe_values_base.inst.in
+++ b/source/fe/fe_values_base.inst.in
@@ -27,8 +27,8 @@ for (S : REAL_AND_COMPLEX_SCALARS; deal_II_dimension : DIMENSIONS;
   {
 #  if deal_II_dimension <= deal_II_space_dimension
     template void FEValuesBase<deal_II_dimension, deal_II_space_dimension>::
-      CellIteratorContainer::get_interpolated_dof_values<S>(
-        const ReadVector<S> &, Vector<S> &) const;
+      CellIteratorWrapper::get_interpolated_dof_values<S>(const ReadVector<S> &,
+                                                          Vector<S> &) const;
 #  endif
   }
 


### PR DESCRIPTION
It turns out that one of the functions I converted in #16355 isn't actually used any more -- we removed support for using `IndexSet` as a vector type quite a long time ago. I also renamed the class to better reflect what it does, and documented it better.

Closes #16346.