### PR TITLE
Introduce a function Utilities::MPI::partial_and_total_sum().

### DIFF
--- a/doc/news/changes/minor/20231219Bangerth
+++ b/doc/news/changes/minor/20231219Bangerth
@@ -1,0 +1,3 @@
+New: There is now a function Utilities::MPI::partial_and_total_sum().
+<br>
+(Wolfgang Bangerth, 2023/12/19)


### PR DESCRIPTION
Instead of writing a test, I decided to use it in half a dozen places where we currently use `MPI_Exscan` explicitly (and *also* compute the sum right next to it). This will lead to dozens or hundreds of tests running through the new function.

I looked at all places in the library where we use `MPI_Exscan`, and converted all that also compute the total sum. That's about 1/3 of all places where `MPI_Exscan` appears. The rest only do the `MPI_Exscan`, and could probably benefit from a separate function `Utilities::MPI::partial_sum()`.