### PR TITLE
Prohibit calling compress() on vectors with ghost elements.

### DIFF
--- a/doc/news/changes/incompatibilities/20231227Bangerth
+++ b/doc/news/changes/incompatibilities/20231227Bangerth
@@ -1,0 +1,16 @@
+Changed: We have always considered PETSc- and Trilinos-based vectors
+that have ghost elements as immutable, i.e., it is possible to read
+elements (including the ghost elements) but not to write into them. On
+the other hand, the `compress()` function available in all vector
+types is meant to communicate values written into non-locally-owned
+vector elements to their proper owners, for example during assembly of
+a right hand side vector. This `compress()` operation clearly only
+makes sense if a vector does not have ghost elements, because only
+then is it possible to write into the vector at all, but this
+restriction was not enforced -- the `compress()` function simply did
+not do anything at all in these cases. This has now changed: Because
+it does not make sense to call `compress()` on vectors that have ghost
+elements, it is now forbidden to call it and this case will be caught
+by an assertion.
+<br>
+(Wolfgang Bangerth, 2023/12/27)

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -540,6 +540,13 @@ namespace PETScWrappers
   void
   VectorBase::compress(const VectorOperation::values operation)
   {
+    Assert(has_ghost_elements() == false,
+           ExcMessage("Calling compress() is only useful if a vector "
+                      "has been written into, but this is a vector with ghost "
+                      "elements and consequently is read-only. It does "
+                      "not make sense to call compress() for such "
+                      "vectors."));
+
     {
 #  ifdef DEBUG
       // Check that all processors agree that last_action is the same (or none!)

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -599,6 +599,14 @@ namespace TrilinosWrappers
     void
     Vector::compress(VectorOperation::values given_last_action)
     {
+      Assert(has_ghost_elements() == false,
+             ExcMessage(
+               "Calling compress() is only useful if a vector "
+               "has been written into, but this is a vector with ghost "
+               "elements and consequently is read-only. It does "
+               "not make sense to call compress() for such "
+               "vectors."));
+
       // Select which mode to send to Trilinos. Note that we use last_action if
       // available and ignore what the user tells us to detect wrongly mixed
       // operations. Typically given_last_action is only used on machines that


### PR DESCRIPTION
This patch is something we'd need to discuss first. I figure that this is going to trip up a lot of tests -- let's see what happens. 

Conceptually, we have ghosted vectors (read-only) and non-ghosted vectors (which one can write into, into both locally owned and remotely-owned elements). Then we also have the `compress()` operation, which is intended to communicate remotely-owned entries we have written into to their proper owners. Given what the function does, it only makes sense to call it on non-ghosted vectors -- but we don't enforce this.

This patch adds an assertion to the `compress()` function of PETSc and Trilinos vectors that checks that `compress()` is not called on vectors that have ghost elements. This is perhaps not strictly necessary because it should be a no-op for vectors with ghost elements, but it is a semantic error to call this function nonetheless and that's what I'm trying to check.