### PR TITLE
'explicit' on default constructors is redundant.

### DIFF
--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -371,7 +371,7 @@ namespace Utilities
       /**
        * Constructor of this class.
        */
-      explicit CollectiveMutex();
+      CollectiveMutex();
 
       /**
        * Destroy the mutex. Assumes the lock is not currently held.

--- a/include/deal.II/meshworker/copy_data.h
+++ b/include/deal.II/meshworker/copy_data.h
@@ -58,7 +58,7 @@ namespace MeshWorker
      * @p local_dof_indices are empty, and should be initialized using
      * one of the reinit() functions.
      */
-    explicit CopyData() = default;
+    CopyData() = default;
 
     /**
      * Initialize everything with the same @p size. This is usually the number


### PR DESCRIPTION
See https://stackoverflow.com/questions/2836939/what-is-the-purpose-of-explicit-for-a-default-constructor

I looked for this based on this comment: https://github.com/dealii/dealii/pull/16288/files/6bdd83e4ec62511db83e679aedcb42b37ef39d8d#diff-f988d9384ce4df86c70684bb289cdddb3b06337351beb9266df10812f40e2d52