### PR TITLE
Hand back used quadratures during conversion of intersections to points

### DIFF
--- a/doc/news/changes/minor/20231229Heinz
+++ b/doc/news/changes/minor/20231229Heinz
@@ -1,0 +1,6 @@
+Improved: convert_to_distributed_compute_point_locations_internal() takes a pointer to a vector
+of quadratures as an additional argument. In case this pointer is not a null pointer, the vector is
+populated by the mapped quadratures that are internally used during the conversion.
+<br>
+(Johannes Heinz, 2023/12/29)
+

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -877,6 +877,11 @@ namespace GridTools
        * from class members. This can be done without searching for points again
        * since all information is locally known.
        *
+       * @p mapped_quadratures_recv_comp is a pointer to an empty vector of
+       * mapped quadratures. By default it is a `nullptr` and the parameter is
+       * ignored. Otherwise, the vector is filled with the mapped quadrature
+       * rules (in real coordinates) corresponding to recv_components.
+       *
        * The parameter @p consistent_numbering_of_sender_and_receiver can be used to ensure
        * points on sender and receiver side are numbered consistently.
        * This parameter is optional if DistributedComputePointLocationsInternal
@@ -892,6 +897,8 @@ namespace GridTools
         const unsigned int                  n_points_1D,
         const Triangulation<dim, spacedim> &tria,
         const Mapping<dim, spacedim>       &mapping,
+        std::vector<Quadrature<spacedim>>  *mapped_quadratures_recv_comp =
+          nullptr,
         const bool consistent_numbering_of_sender_and_receiver = false) const;
 
     private:

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -4105,10 +4105,17 @@ namespace GridTools
         const unsigned int                  n_points_1D,
         const Triangulation<dim, spacedim> &tria,
         const Mapping<dim, spacedim>       &mapping,
+        std::vector<Quadrature<spacedim>>  *mapped_quadratures_recv_comp,
         const bool consistent_numbering_of_sender_and_receiver) const
     {
       using CellIterator =
         typename Triangulation<dim, spacedim>::active_cell_iterator;
+
+      if (mapped_quadratures_recv_comp != nullptr)
+        {
+          AssertDimension(mapped_quadratures_recv_comp->size(), 0);
+          mapped_quadratures_recv_comp->reserve(recv_components.size());
+        }
 
       GridTools::internal::DistributedComputePointLocationsInternal<dim,
                                                                     spacedim>
@@ -4141,6 +4148,10 @@ namespace GridTools
                 result.recv_components.size(), // number of point
                 numbers::invalid_unsigned_int);
             }
+
+          // append quadrature
+          if (mapped_quadratures_recv_comp != nullptr)
+            mapped_quadratures_recv_comp->push_back(quad);
         }
 
       // since empty quadratures might be present we have to set the number

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -193,6 +193,7 @@ for (deal_II_struct_dimension : DIMENSIONS; deal_II_dimension : DIMENSIONS;
           const unsigned int,
           const Triangulation<deal_II_dimension, deal_II_space_dimension> &,
           const Mapping<deal_II_dimension, deal_II_space_dimension> &,
+          std::vector<Quadrature<deal_II_space_dimension>> *,
           const bool) const;
 
       template internal::DistributedComputeIntersectionLocationsInternal<

--- a/tests/remote_point_evaluation/convert_intersections_to_rpe_data_01.cc
+++ b/tests/remote_point_evaluation/convert_intersections_to_rpe_data_01.cc
@@ -99,7 +99,7 @@ do_test(const unsigned int n_quad_points)
 
   auto rpe_data = intersection_location
                     .convert_to_distributed_compute_point_locations_internal(
-                      n_quad_points, tria, mapping, true);
+                      n_quad_points, tria, mapping, nullptr, true);
 
   deallog << "Recv Components " << std::endl;
   for (const auto &rc : rpe_data.recv_components)

--- a/tests/remote_point_evaluation/convert_intersections_to_rpe_data_02.cc
+++ b/tests/remote_point_evaluation/convert_intersections_to_rpe_data_02.cc
@@ -99,7 +99,7 @@ do_test(const unsigned int n_quad_points)
 
   auto rpe_data = intersection_location
                     .convert_to_distributed_compute_point_locations_internal(
-                      n_quad_points, tria, mapping, true);
+                      n_quad_points, tria, mapping, nullptr, true);
 
   deallog << "Recv Components " << std::endl;
   for (const auto &rc : rpe_data.recv_components)

--- a/tests/remote_point_evaluation/convert_intersections_to_rpe_data_03.cc
+++ b/tests/remote_point_evaluation/convert_intersections_to_rpe_data_03.cc
@@ -96,7 +96,7 @@ do_test(const unsigned int n_quad_points)
 
   auto rpe_data = intersection_location
                     .convert_to_distributed_compute_point_locations_internal(
-                      n_quad_points, tria, mapping, true);
+                      n_quad_points, tria, mapping, nullptr, true);
 
   deallog << "Recv Components " << std::endl;
   for (const auto &rc : rpe_data.recv_components)

--- a/tests/remote_point_evaluation/convert_intersections_to_rpe_data_04.cc
+++ b/tests/remote_point_evaluation/convert_intersections_to_rpe_data_04.cc
@@ -96,7 +96,7 @@ do_test(const unsigned int n_quad_points)
 
   auto rpe_data = intersection_location
                     .convert_to_distributed_compute_point_locations_internal(
-                      n_quad_points, tria, mapping, true);
+                      n_quad_points, tria, mapping, nullptr, true);
 
   deallog << "Recv Components " << std::endl;
   for (const auto &rc : rpe_data.recv_components)

--- a/tests/remote_point_evaluation/setup_rpe_with_intersections_02.cc
+++ b/tests/remote_point_evaluation/setup_rpe_with_intersections_02.cc
@@ -91,7 +91,7 @@ do_test(const unsigned int n_quad_points)
           intersection_requests.emplace_back(vertices);
         }
     }
-  std::cout << "CALLING FUNCTION" << std::endl;
+
   auto intersection_location =
     GridTools::internal::distributed_compute_intersection_locations<structdim>(
       cache,
@@ -100,15 +100,11 @@ do_test(const unsigned int n_quad_points)
       std::vector<bool>(),
       1.0e-9);
 
-  std::cout << "FINISHED" << std::endl;
-
   auto rpe_intersection_data =
     intersection_location
       .convert_to_distributed_compute_point_locations_internal(n_quad_points,
                                                                tria,
                                                                mapping);
-  std::cout << "WTF" << std::endl;
-
   // setup rpe without additional search
   dealii::Utilities::MPI::RemotePointEvaluation<dim> rpe_intersections;
   rpe_intersections.reinit(rpe_intersection_data, tria, mapping);


### PR DESCRIPTION
@peterrum @fdrmrc @blaisb In the case of Nitsche-type mortaring, we are computing intersections. These intersections are converted to the data, needed by RPE given the number of quadrature points per intersection. During this conversion, mapped quadratures are computed. In a later stage, we need these quadratures again. In
https://github.com/dealii/dealii/pull/16299/files#diff-6aa609a8649d3a50906faf50bbfe0dbbfe68b6ea07585ceb9554851648f41b2dR1677-R1720
we are currently recomputing the mapped quadratures. 

To avoid this, this PR introduces a pointer to a vector of quadratures as an additional function parameter for the converter function. In case a `nullptr` is given, nothing is done in addition, otherwise, the vector is populated with the mapped quadratures which can now be used by the caller. This way, we can skip recomputing the quadrature rules. 

When I went through the tests I found some print statements from a debugging session. This PR additionally deletes the unnecessary lines.