### PR TITLE
Add a DEAL_II_ASSUME macro.

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1520,6 +1520,30 @@ namespace deal_II_exceptions
 
 
 
+#if defined(__clang__)
+#  define DEAL_II_ASSUME(expr) __builtin_assume(expr)
+#elif defined(__GNUC__) && !defined(__ICC)
+#  if __GNUC__ >= 13
+#    define DEAL_II_ASSUME(expr) __attribute__((__assume__(expr)))
+#  else
+/* no way with GCC to express this without evaluating 'expr' */
+#    define DEAL_II_ASSUME(expr) \
+      do                         \
+        {                        \
+        }                        \
+      while (false)
+#  endif
+#elif defined(_MSC_VER) || defined(__ICC)
+#  define DEAL_II_ASSUME(expr) __assume(expr)
+#else
+#  define DEAL_II_ASSUME(expr) \
+    do                         \
+      {                        \
+      }                        \
+    while (false)
+#endif
+
+
 /**
  * A macro that serves as the main routine in the exception mechanism for debug
  * mode error checking. It asserts that a certain condition is fulfilled,
@@ -1638,11 +1662,7 @@ namespace deal_II_exceptions
 #    endif /*ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST*/
 #  endif   /*KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST*/
 #else      /*ifdef DEBUG*/
-#  define Assert(cond, exc) \
-    do                      \
-      {                     \
-      }                     \
-    while (false)
+#  define Assert(cond, exc) DEAL_II_ASSUME(cond)
 #endif /*ifdef DEBUG*/
 
 
@@ -1694,11 +1714,7 @@ namespace deal_II_exceptions
       while (false)
 #  endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 #else
-#  define AssertNothrow(cond, exc) \
-    do                             \
-      {                            \
-      }                            \
-    while (false)
+#  define AssertNothrow(cond, exc) DEAL_II_ASSUME(cond)
 #endif
 
 /**


### PR DESCRIPTION
C++23 has a nice feature, `[[assume(expr)]]` that allows giving compilers hints about invariants that must be satisfied at a specific point -- see https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p1774r8.pdf. I wanted to see whether we can perhaps use that in the "NO-DEBUG" definition of `Assert` to give the compiler a hint, but it turns out that I do not have access to a compiler that supports any of the various incompatible ways compilers have provided this sort of feature pre-C++23.

Let's see what the testers have to say. I would be curious to see what happens if anyone looks at the release mode library size without and with this patch, with a compiler that supports any of this.

(Separate question: We could of course also add the assumption after the `if` in the DEBUG version of the `Assert` macro. Opinions?)