### PR TITLE
Optimize setting a matrix to zero.

### DIFF
--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -1761,14 +1761,23 @@ namespace TrilinosWrappers
   SparseMatrix &
   SparseMatrix::operator=(const double d)
   {
+    (void)d;
     Assert(d == 0, ExcScalarAssignmentOnlyForZeroValue());
     compress(VectorOperation::unknown); // TODO: why do we do this? Should we
                                         // not check for is_compressed?
 
-    const int ierr = matrix->PutScalar(d);
+    // As checked above, we are only allowed to use d==0.0, so pass
+    // a constant zero (instead of a run-time value 'd' that *happens* to
+    // have a zero value) to the underlying class in hopes that the compiler
+    // can optimize this somehow.
+    const int ierr = matrix->PutScalar(/*d=*/0.0);
     AssertThrow(ierr == 0, ExcTrilinosError(ierr));
+
     if (nonlocal_matrix.get() != nullptr)
-      nonlocal_matrix->PutScalar(d);
+      {
+        const int ierr = nonlocal_matrix->PutScalar(/*d=*/0.0);
+        AssertThrow(ierr == 0, ExcTrilinosError(ierr));
+      }
 
     return *this;
   }


### PR DESCRIPTION
We only allow setting matrices and vectors to zero when implementing `operator=(double)`. It turns out that `0.0` has a binary representation that consists of only zeros, so setting all elements of an array can be done by the compiler via `memzero()` if we make sure we tell the compiler that it's a zero, and that should be substantially more efficient than a loop over the elements and a copy.

I suspect that this could be done for all other matrix and vector types. This is also a reasonably frequent operation, so perhaps worth doing universally -- just not on New Year's Eve :-) If this patch finds favor, I'll open a github issue to remind us of it.