### PR TITLE
Rename FPE::real_point() to FPE::quadrature_point()

### DIFF
--- a/doc/news/changes/incompatibilities/20240107Munch
+++ b/doc/news/changes/incompatibilities/20240107Munch
@@ -1,0 +1,5 @@
+Removed: The function FEPointEvaluation::real_point() has been
+renamed to FEPointEvaluation::quadrature_point(). The old function
+has been deprecated.
+<br>
+(Peter Munch, 2024/01/01)

--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -848,9 +848,18 @@ public:
   /**
    * Return the position in real coordinates of the given point index among
    * the points passed to reinit().
+   *
+   * @deprecated Use the function quadrature_point() instead.
+   */
+  DEAL_II_DEPRECATED_EARLY Point<spacedim, Number>
+                           real_point(const unsigned int point_index) const;
+
+  /**
+   * Return the position in real coordinates of the given point index among
+   * the points passed to reinit().
    */
   Point<spacedim, Number>
-  real_point(const unsigned int point_index) const;
+  quadrature_point(const unsigned int point_index) const;
 
   /**
    * Return the position in unit/reference coordinates of the given point
@@ -2244,6 +2253,17 @@ FEPointEvaluationBase<n_components_, dim, spacedim, Number>::JxW(
 template <int n_components_, int dim, int spacedim, typename Number>
 inline Point<spacedim, Number>
 FEPointEvaluationBase<n_components_, dim, spacedim, Number>::real_point(
+  const unsigned int point_index) const
+{
+  return quadrature_point(point_index);
+  ;
+}
+
+
+
+template <int n_components_, int dim, int spacedim, typename Number>
+inline Point<spacedim, Number>
+FEPointEvaluationBase<n_components_, dim, spacedim, Number>::quadrature_point(
   const unsigned int point_index) const
 {
   AssertIndexRange(point_index, n_q_points);

--- a/tests/matrix_free/point_evaluation_12.cc
+++ b/tests/matrix_free/point_evaluation_12.cc
@@ -13,7 +13,7 @@
 // ------------------------------------------------------------------------
 
 
-// check FEPointEvaluation::real_point(), FEPointEvaluation::unit_point(),
+// check FEPointEvaluation::quadrature_point(), FEPointEvaluation::unit_point(),
 // FEPointEvaluation::jacobian(), FEPointEvaluation::inverse_jacobian(),
 // FEPointEvaluation::get_unit_gradient().
 
@@ -97,7 +97,7 @@ test(const unsigned int degree)
         deallog << "unit point " << unit_points[i] << std::endl
                 << "unit point via evaluator: " << evaluator.unit_point(i)
                 << std::endl
-                << "real point: " << evaluator.real_point(i) << std::endl
+                << "real point: " << evaluator.quadrature_point(i) << std::endl
                 << "jacobian: " << Tensor<2, dim>(evaluator.jacobian(i))
                 << std::endl
                 << "inverse jacobian: "


### PR DESCRIPTION
To be consistent with `FEValues` and `FEEvaluation`.

@kronbichler What do you think?