### PR TITLE
Boost-1.83 compatibility: remove long double overloads of special functions

### DIFF
--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -556,7 +556,6 @@ CHECK_CXX_SOURCE_COMPILES(
   #include <cmath>
   using std::cyl_bessel_j;
   using std::cyl_bessel_jf;
-  using std::cyl_bessel_jl;
   int main()
   {
   }
@@ -574,7 +573,6 @@ CHECK_CXX_SOURCE_COMPILES(
   #include <cmath>
   using std::legendre;
   using std::legendref;
-  using std::legendrel;
   int main()
   {
   }

--- a/doc/news/changes/incompatibilities/20240108Maier
+++ b/doc/news/changes/incompatibilities/20240108Maier
@@ -1,0 +1,7 @@
+Removed: The rarely used long double variants `std_cxx17::legendrel` and
+`std_cxx17::cyl_bessel_jl` have been removed due to a compatibility issue
+with boost-1.83. If you happen to use these functions in your project
+you can change to using `std::legendrel` and `std::cyl_bessel_jl` directly,
+which are provided by the C++ standard template library.
+<br>
+(Matthias Maier, 2024/01/08)

--- a/include/deal.II/base/std_cxx17/cmath.h
+++ b/include/deal.II/base/std_cxx17/cmath.h
@@ -91,28 +91,8 @@ namespace std_cxx17
 
 
 
-  inline long double
-  legendre(unsigned int l, long double x)
-  {
-    Assert(static_cast<int>(l) >= 0,
-           ExcIndexRange(l, 0, std::numeric_limits<int>::max()));
-    return boost::math::legendre_p(static_cast<int>(l), x);
-  }
-
-
-
   inline float
   legendref(unsigned int l, float x)
-  {
-    Assert(static_cast<int>(l) >= 0,
-           ExcIndexRange(l, 0, std::numeric_limits<int>::max()));
-    return boost::math::legendre_p(static_cast<int>(l), x);
-  }
-
-
-
-  inline long double
-  legendrel(unsigned int l, long double x)
   {
     Assert(static_cast<int>(l) >= 0,
            ExcIndexRange(l, 0, std::numeric_limits<int>::max()));
@@ -122,7 +102,6 @@ namespace std_cxx17
 #else
   using std::legendre;
   using std::legendref;
-  using std::legendrel;
 #endif
 } // namespace std_cxx17
 

--- a/include/deal.II/base/std_cxx17/cmath.h
+++ b/include/deal.II/base/std_cxx17/cmath.h
@@ -55,18 +55,9 @@ namespace std_cxx17
     return boost::math::cyl_bessel_j(nu, x);
   }
 
-
-
-  inline long double
-  cyl_bessel_jl(long double nu, long double x)
-  {
-    return boost::math::cyl_bessel_j(nu, x);
-  }
-
 #else
   using std::cyl_bessel_j;
   using std::cyl_bessel_jf;
-  using std::cyl_bessel_jl;
 #endif
 
 #ifndef DEAL_II_HAVE_CXX17_LEGENDRE_FUNCTIONS


### PR DESCRIPTION
- CMake: do not check for std::legendrel and std::cyl_bessel_jl
- base/std_cxx17: remove std::legendrel boost substitutes
- base/std_cxx17: remove std::cyl_bessel_jl boost substitutes
- doc/news: add a changes entry

Closes #16390
