### PR TITLE
Make FERemoteEvaluation work for FCL

### DIFF
--- a/tests/matrix_free/fe_remote_evaluation_01.cc
+++ b/tests/matrix_free/fe_remote_evaluation_01.cc
@@ -206,7 +206,7 @@ FERemoteEvaluationCommunicator<dim>
 construct_comm_for_cell_face_nos(const MatrixFree<dim, Number> &matrix_free)
 {
   // Setup Communication objects for all boundary faces
-  FERemoteCommunicationObjectFaces<dim> co;
+  FERemoteCommunicationObjectTwoLevel<dim> co;
 
   // Get range of boundary face indices
   const auto face_batch_range =

--- a/tests/matrix_free/fe_remote_evaluation_02.cc
+++ b/tests/matrix_free/fe_remote_evaluation_02.cc
@@ -208,7 +208,7 @@ FERemoteEvaluationCommunicator<dim>
 construct_comm_for_cell_face_nos(const MatrixFree<dim, Number> &matrix_free)
 {
   // Setup Communication objects for all boundary faces
-  FERemoteCommunicationObjectFaces<dim> co;
+  FERemoteCommunicationObjectTwoLevel<dim> co;
 
   // Get range of boundary face indices
   const auto face_batch_range =


### PR DESCRIPTION
Prerequisite for https://github.com/dealii/dealii/pull/16394.

To be able to work with `FERemoteEvaluation` and FCL I renamed internal data structures (`CommObjectsCell` can also be used for FCL if indices are stored instead of iterators) and added a new `reinit_faces()` function. A test is added in https://github.com/dealii/dealii/pull/16394, which introduces utility functions for an easy setup of `FERemoteEvaluationCommunicator`.

@peterrum @bergbauer 