### PR TITLE
Treat ICPX as gcc-style compiler

### DIFF
--- a/cmake/setup_compiler_flags.cmake
+++ b/cmake/setup_compiler_flags.cmake
@@ -98,7 +98,8 @@ endforeach()
 ########################################################################
 
 if( CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR
-    CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
+    CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR
+    CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM")
   #
   # General setup for GCC and compilers sufficiently close to GCC:
   #

--- a/cmake/setup_compiler_flags_gnu.cmake
+++ b/cmake/setup_compiler_flags_gnu.cmake
@@ -96,7 +96,7 @@ enable_if_supported(DEAL_II_WARNING_FLAGS "-Wno-literal-suffix")
 #
 enable_if_supported(DEAL_II_WARNING_FLAGS "-Wno-psabi")
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM")
   # Enable warnings for conversion from real types to integer types.
   # The warning is too noisy in gcc and therefore only enabled for clang.
   enable_if_supported(DEAL_II_WARNING_FLAGS "-Wfloat-conversion")


### PR DESCRIPTION
`ICPX` is more `Clang` than `Intel`-like so we should rather use the compiler flags for the former.