### PR TITLE
Make Utilities::pow() available for floating point types.

### DIFF
--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -437,12 +437,15 @@ namespace Utilities
   T
   fixed_power(const T t);
 
+
   /**
    * A replacement for <code>std::pow</code> that allows compile-time
-   * calculations for constant expression arguments. The @p base must
-   * be an integer type and the exponent @p iexp must not be negative.
+   * calculations for constant expression arguments and if the exponent
+   * is a positive integer. The @p base must be an arithmetic type
+   * (i.e., an integer or floating point type),
+   * and the exponent @p iexp must not be negative.
    */
-  template <typename T>
+  template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
   constexpr DEAL_II_HOST_DEVICE T
   pow(const T base, const int iexp)
   {
@@ -477,8 +480,6 @@ namespace Utilities
 #    endif
 #  endif
 #endif
-    static_assert(std::is_integral_v<T>, "Only integral types supported");
-
     // The "exponentiation by squaring" algorithm used below has to be expressed
     // in an iterative version since SYCL doesn't allow recursive functions used
     // in device code.

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -437,7 +437,6 @@ namespace Utilities
   T
   fixed_power(const T t);
 
-
   /**
    * A replacement for <code>std::pow</code> that allows compile-time
    * calculations for constant expression arguments and if the exponent
@@ -447,58 +446,7 @@ namespace Utilities
    */
   template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
   constexpr DEAL_II_HOST_DEVICE T
-  pow(const T base, const int iexp)
-  {
-#if defined(DEBUG) && !defined(DEAL_II_CXX14_CONSTEXPR_BUG)
-    // Up to __builtin_expect this is the same code as in the 'Assert' macro.
-    // The call to __builtin_expect turns out to be problematic.
-#  if KOKKOS_VERSION >= 30600
-    KOKKOS_IF_ON_HOST(({
-      if (!(iexp >= 0))
-        ::dealii::deal_II_exceptions::internals::issue_error_noreturn(
-          ::dealii::deal_II_exceptions::internals::ExceptionHandling::
-            abort_or_throw_on_exception,
-          __FILE__,
-          __LINE__,
-          __PRETTY_FUNCTION__,
-          "iexp>=0",
-          "ExcMessage(\"The exponent must not be negative!\")",
-          ExcMessage("The exponent must not be negative!"));
-    }))
-#  else
-#    ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
-    if (!(iexp >= 0))
-      ::dealii::deal_II_exceptions::internals::issue_error_noreturn(
-        ::dealii::deal_II_exceptions::internals::ExceptionHandling::
-          abort_or_throw_on_exception,
-        __FILE__,
-        __LINE__,
-        __PRETTY_FUNCTION__,
-        "iexp>=0",
-        "ExcMessage(\"The exponent must not be negative!\")",
-        ExcMessage("The exponent must not be negative!"));
-#    endif
-#  endif
-#endif
-    // The "exponentiation by squaring" algorithm used below has to be expressed
-    // in an iterative version since SYCL doesn't allow recursive functions used
-    // in device code.
-
-    if (iexp <= 0)
-      return 1;
-
-    int exp = iexp;
-    T   x   = base;
-    T   y   = 1;
-    while (exp > 1)
-      {
-        if (exp % 2 == 1)
-          y *= x;
-        x *= x;
-        exp /= 2;
-      }
-    return x * y;
-  }
+  pow(const T base, const int iexp);
 
   /**
    * Optimized replacement for <tt>std::lower_bound</tt> for searching within
@@ -524,7 +472,6 @@ namespace Utilities
   template <typename Iterator, typename T>
   Iterator
   lower_bound(Iterator first, Iterator last, const T &val);
-
 
   /**
    * The same function as above, but taking an argument that is used to
@@ -991,6 +938,63 @@ namespace Utilities
       // by repeated squaring:
       return ((N % 2 == 1) ? x * fixed_power<N / 2>(x * x) :
                              fixed_power<N / 2>(x * x));
+  }
+
+
+
+  template <typename T, typename>
+  constexpr DEAL_II_HOST_DEVICE T
+  pow(const T base, const int iexp)
+  {
+#if defined(DEBUG) && !defined(DEAL_II_CXX14_CONSTEXPR_BUG)
+    // Up to __builtin_expect this is the same code as in the 'Assert' macro.
+    // The call to __builtin_expect turns out to be problematic.
+#  if KOKKOS_VERSION >= 30600
+    KOKKOS_IF_ON_HOST(({
+      if (!(iexp >= 0))
+        ::dealii::deal_II_exceptions::internals::issue_error_noreturn(
+          ::dealii::deal_II_exceptions::internals::ExceptionHandling::
+            abort_or_throw_on_exception,
+          __FILE__,
+          __LINE__,
+          __PRETTY_FUNCTION__,
+          "iexp>=0",
+          "ExcMessage(\"The exponent must not be negative!\")",
+          ExcMessage("The exponent must not be negative!"));
+    }))
+#  else
+#    ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
+    if (!(iexp >= 0))
+      ::dealii::deal_II_exceptions::internals::issue_error_noreturn(
+        ::dealii::deal_II_exceptions::internals::ExceptionHandling::
+          abort_or_throw_on_exception,
+        __FILE__,
+        __LINE__,
+        __PRETTY_FUNCTION__,
+        "iexp>=0",
+        "ExcMessage(\"The exponent must not be negative!\")",
+        ExcMessage("The exponent must not be negative!"));
+#    endif
+#  endif
+#endif
+    // The "exponentiation by squaring" algorithm used below has to be expressed
+    // in an iterative version since SYCL doesn't allow recursive functions used
+    // in device code.
+
+    if (iexp <= 0)
+      return 1;
+
+    int exp = iexp;
+    T   x   = base;
+    T   y   = 1;
+    while (exp > 1)
+      {
+        if (exp % 2 == 1)
+          y *= x;
+        x *= x;
+        exp /= 2;
+      }
+    return x * y;
   }
 
 


### PR DESCRIPTION
In looking at #13321, I realized that our own replacement function `Utilities::pow()` states that it can only be used for integer arguments, but that the implementation is correct for any kind of "arithmetic" type (i.e., integers and floating point types). This patch relaxes the assertion and moves it from a `static_assert` to a `std::enable_if`. 

While there, I also moved the body of the function from the section where we have only declarations to the definitions at the bottom of the file. 

This is a follow-up to #9764.