### PR TITLE
Also test MUMPS symmetric mode.

### DIFF
--- a/tests/petsc/sparse_direct_mumps.with_petsc_with_mumps=on.with_64bit_indices=off.output
+++ b/tests/petsc/sparse_direct_mumps.with_petsc_with_mumps=on.with_64bit_indices=off.output
@@ -1,4 +1,8 @@
 
 DEAL::Size 32 Unknowns 961
-DEAL::Convergence step 1 value 0
-DEAL::residual = 0
+DEAL::Testing non-symmetric mode
+DEAL::Convergence step 1 value 0.000
+DEAL::residual = 7.366e-13
+DEAL::Testing symmetric mode
+DEAL::Convergence step 1 value 0.000
+DEAL::residual = 5.412e-13


### PR DESCRIPTION
Our PETSc-based MUMPS interfaces allow specifying whether the matrix is symmetric or not, but we only tested the latter. This patch extends the test to also check the symmetric case.

While there, also rename a few variables to make their intents clearer.