### PR TITLE
Fix compatibility issues of TpetraWrappers with older Trilinos versions.

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparse_matrix.h
@@ -107,9 +107,15 @@ namespace LinearAlgebra
       /**
        * Typedef for the NodeType
        */
+#  if DEAL_II_TRILINOS_VERSION_GTE(14, 2, 0)
       using NodeType = Tpetra::KokkosCompat::KokkosDeviceWrapperNode<
         typename MemorySpace::kokkos_space::execution_space,
         typename MemorySpace::kokkos_space>;
+#  else
+      using NodeType = Kokkos::Compat::KokkosDeviceWrapperNode<
+        typename MemorySpace::kokkos_space::execution_space,
+        typename MemorySpace::kokkos_space>;
+#  endif
 
       /**
        * Typedef for Tpetra::CrsMatrix

--- a/include/deal.II/lac/trilinos_tpetra_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparsity_pattern.h
@@ -89,9 +89,15 @@ namespace LinearAlgebra
         /**
          * Typedef for the NodeType
          */
+#  if DEAL_II_TRILINOS_VERSION_GTE(14, 2, 0)
         using NodeType = Tpetra::KokkosCompat::KokkosDeviceWrapperNode<
           typename MemorySpace::kokkos_space::execution_space,
           typename MemorySpace::kokkos_space>;
+#  else
+        using NodeType = Kokkos::Compat::KokkosDeviceWrapperNode<
+          typename MemorySpace::kokkos_space::execution_space,
+          typename MemorySpace::kokkos_space>;
+#  endif
 
         /**
          * Constructor.
@@ -195,9 +201,15 @@ namespace LinearAlgebra
         /**
          * Typedef for the NodeType
          */
+#  if DEAL_II_TRILINOS_VERSION_GTE(14, 2, 0)
         using NodeType = Tpetra::KokkosCompat::KokkosDeviceWrapperNode<
           typename MemorySpace::kokkos_space::execution_space,
           typename MemorySpace::kokkos_space>;
+#  else
+        using NodeType = Kokkos::Compat::KokkosDeviceWrapperNode<
+          typename MemorySpace::kokkos_space::execution_space,
+          typename MemorySpace::kokkos_space>;
+#  endif
 
         /**
          * Constructor. Create an iterator into the matrix @p matrix for the
@@ -307,9 +319,15 @@ namespace LinearAlgebra
       /**
        * Typedef for the NodeType
        */
+#  if DEAL_II_TRILINOS_VERSION_GTE(14, 2, 0)
       using NodeType = Tpetra::KokkosCompat::KokkosDeviceWrapperNode<
         typename MemorySpace::kokkos_space::execution_space,
         typename MemorySpace::kokkos_space>;
+#  else
+      using NodeType = Kokkos::Compat::KokkosDeviceWrapperNode<
+        typename MemorySpace::kokkos_space::execution_space,
+        typename MemorySpace::kokkos_space>;
+#  endif
 
       /**
        * Declare an alias for the iterator class.


### PR DESCRIPTION
Fix compatibility issues of TpetraWrappers with older Trilinos versions.

As highlighted by the Regression Tester in Issue #16446 and in Issue #16445 the TpetraWrappers do not compile with older Trilinos versions.

I found two Issues:

1. The namespace `Tpetra::KokkosCompat` was introduced in Trilinos 14.2. Before that, one had to use `Kokkos::Compat` instead. I added an `#if DEAL_II_TRILINOS_VERSION_GTE(14, 2, 0)` to choose the correct namespace (Unfortunately, `Kokkos::Compat` does not work with Trilinos >= 14.2. Therefore, we must use the `#if ...` here.)

2. The second problem is that getNodeNumRows was renamed to getLocalNumRows in Trilinos 14.0
