### PR TITLE
Avoid a warning.

### DIFF
--- a/source/lac/trilinos_tpetra_sparsity_pattern.cc
+++ b/source/lac/trilinos_tpetra_sparsity_pattern.cc
@@ -1031,8 +1031,8 @@ namespace LinearAlgebra
     SparsityPattern<MemorySpace>::print_gnuplot(std::ostream &out) const
     {
       Assert(graph->isFillComplete() == true, ExcInternalError());
-      for (dealii::types::signed_global_dof_index row = 0; row < local_size();
-           ++row)
+
+      for (unsigned int row = 0; row < local_size(); ++row)
         {
 #  if DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
           typename GraphType::local_inds_host_view_type indices;


### PR DESCRIPTION
`local_size()` returns an `unsigned int`, so make the counting index `unsigned int` as well to avoid the warning about comparing different integer types.

Follow-up to #16288 and #16448.