### PR TITLE
Fix the type of an array.

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparsity_pattern.h
@@ -1368,7 +1368,8 @@ namespace LinearAlgebra
       // TODO: The following line creates an array by copying the entries.
       //       Perhaps there is a way to only create a 'view' of these arrays
       //       and pass that to Tpetra?
-      Teuchos::Array<long long> array(col_index_ptr_begin, col_index_ptr_end);
+      Teuchos::Array<TrilinosWrappers::types::int_type> array(
+        col_index_ptr_begin, col_index_ptr_end);
 
       if (row_is_stored_locally(row))
         graph->insertGlobalIndices(trilinos_row_index, array());


### PR DESCRIPTION
This is a follow-up to #16288 and #16448. On my machine, Trilinos is apparently compiled with 32-bit integers, and the calls below the place I'm fixing here fail because the array being created do not have the right type.

@kinnewig FYI.