### PR TITLE
Fix constraint_info.h for g++-13 on MacOS X

### DIFF
--- a/include/deal.II/matrix_free/constraint_info.h
+++ b/include/deal.II/matrix_free/constraint_info.h
@@ -683,8 +683,9 @@ namespace internal
 
       if (hn_available == true)
         {
-          for (unsigned int v = n_lanes_filled; v < Number::size(); ++v)
-            constraint_mask[v] = unconstrained_compressed_constraint_kind;
+          std::fill(constraint_mask.begin() + n_lanes_filled,
+                    constraint_mask.end(),
+                    unconstrained_compressed_constraint_kind);
 
           for (unsigned int i = 1; i < n_lanes_filled; ++i)
             AssertDimension(active_fe_indices[first_cell],


### PR DESCRIPTION
With gcc-13 on MacOS X, I am seeing
```
In member function 'void dealii::internal::MatrixFreeFunctions::ConstraintInfo<dim, Number>::apply_hanging_node_constraints(unsigned int, unsigned int, bool, dealii::AlignedVector<T>&) const [with int dim = 2; Number = dealii::VectorizedArray<float, 4>]',
    inlined from 'void dealii::MGTwoLevelTransfer<dim, dealii::LinearAlgebra::distributed::Vector<Number> >::prolongate_and_add_internal(dealii::LinearAlgebra::distributed::Vector<Number>&, const dealii::LinearAlgebra::distributed::Vector<Number>&) const [with int dim = 2; Number = float]' at /tmp/Software/dealii/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h:3209:64:
/tmp/Software/dealii/include/deal.II/matrix_free/constraint_info.h:687:32: error: 'void* __builtin_memset(void*, int, long unsigned int)' offset [5, 4294967295] is out of the bounds [0, 4] of object 'constraint_mask' with type 'std::array<unsigned char, 4>' [-Werror=array-bounds=]
  687 |             constraint_mask[v] = unconstrained_compressed_constraint_kind;
      |             ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Using `std::fill` instead seems to avoid the warning.