### PR TITLE
[C++23] When using C++23, use [[assume]] attribute.

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -188,16 +188,6 @@
 #else
 #  if defined(__clang__)
 #    define DEAL_II_CXX23_ASSUME(expr) __builtin_assume(static_cast<bool>(expr))
-#  elif defined(__GNUC__) && !defined(__ICC) && __GNUC__ >= 13
-#    define DEAL_II_CXX23_ASSUME(expr)                                   \
-    do                                                                 \
-      {                                                                \
-        _Pragma("GCC diagnostic push")                                 \
-          _Pragma("GCC diagnostic ignored \"-Wimplicit-fallthrough\"") \
-            [[assume(expr)]];                                          \
-        _Pragma("GCC diagnostic pop")                                  \
-      }                                                                \
-    while (false)
 #  elif defined(_MSC_VER) || defined(__ICC)
 #    define DEAL_II_CXX23_ASSUME(expr) __assume(expr);
 #  else

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -183,10 +183,13 @@
  * attribute for older standards we rely on compiler intrinsics when
  * available.
  */
-#if defined(__clang__)
-#  define DEAL_II_CXX23_ASSUME(expr) __builtin_assume(static_cast<bool>(expr))
-#elif defined(__GNUC__) && !defined(__ICC) && __GNUC__ >= 13
-#  define DEAL_II_CXX23_ASSUME(expr)                                   \
+#ifdef DEAL_II_HAVE_CXX23
+#  define define DEAL_II_ASSUME(expr) [[assume(expr)]]
+#else
+#  if defined(__clang__)
+#    define DEAL_II_CXX23_ASSUME(expr) __builtin_assume(static_cast<bool>(expr))
+#  elif defined(__GNUC__) && !defined(__ICC) && __GNUC__ >= 13
+#    define DEAL_II_CXX23_ASSUME(expr)                                   \
     do                                                                 \
       {                                                                \
         _Pragma("GCC diagnostic push")                                 \
@@ -195,16 +198,18 @@
         _Pragma("GCC diagnostic pop")                                  \
       }                                                                \
     while (false)
-#elif defined(_MSC_VER) || defined(__ICC)
-#  define DEAL_II_CXX23_ASSUME(expr) __assume(expr);
-#else
+#  elif defined(_MSC_VER) || defined(__ICC)
+#    define DEAL_II_CXX23_ASSUME(expr) __assume(expr);
+#  else
 /* no way with GCC to express this without evaluating 'expr' */
-#  define DEAL_II_CXX23_ASSUME(expr) \
+#    define DEAL_II_CXX23_ASSUME(expr) \
     do                               \
       {                              \
       }                              \
     while (false)
+#  endif
 #endif
+
 
 /**
  * Macro indicating that the current feature will be removed in a future

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1519,6 +1519,7 @@ namespace deal_II_exceptions
 } /*namespace deal_II_exceptions*/
 
 
+
 /**
  * A macro that serves as the main routine in the exception mechanism for debug
  * mode error checking. It asserts that a certain condition is fulfilled,


### PR DESCRIPTION
This is a follow-up to #16437 and #16393 : When using C++23, we can avoid all of the compiler-specific stuff.

We don't currently configure for C++23 at all, but this at least makes sure we don't forget about it when the time comes to add the cmake bits to at least recognize C++23.