### PR TITLE
Check if the global vector in distribute_local_to_global has ghost elements.

### DIFF
--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -2629,6 +2629,7 @@ AffineConstraints<number>::distribute_local_to_global(
   const std::vector<size_type> &local_dof_indices,
   OutVector                    &global_vector) const
 {
+  Assert(global_vector.has_ghost_elements() == false, ExcGhostsPresent());
   Assert(local_vector.size() == local_dof_indices.size(),
          ExcDimensionMismatch(local_vector.size(), local_dof_indices.size()));
   distribute_local_to_global(local_vector.begin(),

--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -2531,6 +2531,7 @@ AffineConstraints<number>::distribute_local_to_global(
   AssertDimension(local_vector.size(), local_dof_indices_row.size());
   AssertDimension(local_matrix.m(), local_dof_indices_row.size());
   AssertDimension(local_matrix.n(), local_dof_indices_col.size());
+  Assert(global_vector.has_ghost_elements() == false, ExcGhostsPresent());
 
   // diagonal checks if we have only one index set (if both are equal
   // diagonal should be set to true).
@@ -4210,6 +4211,7 @@ AffineConstraints<number>::distribute_local_to_global(
 
   AssertDimension(local_matrix.n(), local_dof_indices.size());
   AssertDimension(local_matrix.m(), local_dof_indices.size());
+  Assert(global_vector.has_ghost_elements() == false, ExcGhostsPresent());
   Assert(global_matrix.m() == global_matrix.n(), ExcNotQuadratic());
   if (use_vectors == true)
     {
@@ -4367,6 +4369,7 @@ AffineConstraints<number>::distribute_local_to_global(
 
   AssertDimension(local_matrix.n(), local_dof_indices.size());
   AssertDimension(local_matrix.m(), local_dof_indices.size());
+  Assert(global_vector.has_ghost_elements() == false, ExcGhostsPresent());
   Assert(global_matrix.m() == global_matrix.n(), ExcNotQuadratic());
   Assert(global_matrix.n_block_rows() == global_matrix.n_block_cols(),
          ExcNotQuadratic());


### PR DESCRIPTION
This patch is similar to #16378.

It does not make sense to call `AffineConstraints::distribute_local_to_global(local_vector, local_dofs, global_vector)` if the global_vector has ghost entries and is read-only.

During my work on the `TeptraWrappers::Vector` class, I encountered this problem several times. Therefore, I propose to add an asset to distribute_local_to_global to verify that the global vector is non-ghosted.