### PR TITLE
tests: remove redundant 'using namespace dealii;' directives.

### DIFF
--- a/tests/base/bounding_box_6.cc
+++ b/tests/base/bounding_box_6.cc
@@ -28,7 +28,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 // Print the bounds of the incoming box to deallog.
 template <int dim>

--- a/tests/base/bounding_box_7.cc
+++ b/tests/base/bounding_box_7.cc
@@ -26,7 +26,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 using iota = std_cxx20::ranges::iota_view<unsigned int, unsigned int>;
 

--- a/tests/base/bounding_box_data_out_01.cc
+++ b/tests/base/bounding_box_data_out_01.cc
@@ -20,7 +20,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/base/bounding_box_data_out_02.cc
+++ b/tests/base/bounding_box_data_out_02.cc
@@ -22,7 +22,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/base/bounding_box_data_out_03.cc
+++ b/tests/base/bounding_box_data_out_03.cc
@@ -23,7 +23,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/base/coordinate_restriction.cc
+++ b/tests/base/coordinate_restriction.cc
@@ -26,7 +26,6 @@
 
 namespace
 {
-  using namespace dealii;
 
   /*
    * A simple test-function which is constant in space, but varies

--- a/tests/base/create_higher_dim_point.cc
+++ b/tests/base/create_higher_dim_point.cc
@@ -20,7 +20,6 @@
 
 namespace
 {
-  using namespace dealii;
 
   // Test the function create_higher_dim_point by making sure that we
   // can construct the point (x, y, z),

--- a/tests/base/lazy_01.cc
+++ b/tests/base/lazy_01.cc
@@ -24,7 +24,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/base/lazy_02.cc
+++ b/tests/base/lazy_02.cc
@@ -23,7 +23,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/base/lazy_03.cc
+++ b/tests/base/lazy_03.cc
@@ -23,7 +23,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 class Container
 {

--- a/tests/base/lazy_04.cc
+++ b/tests/base/lazy_04.cc
@@ -23,7 +23,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/base/lazy_05.cc
+++ b/tests/base/lazy_05.cc
@@ -23,7 +23,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/base/point_restriction.cc
+++ b/tests/base/point_restriction.cc
@@ -26,7 +26,6 @@
 
 namespace
 {
-  using namespace dealii;
 
   /*
    * A simple test-function which is constant in space, but varies

--- a/tests/base/quadrature_qiterated_01.cc
+++ b/tests/base/quadrature_qiterated_01.cc
@@ -21,7 +21,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/base/std_cxx20_functional.cc
+++ b/tests/base/std_cxx20_functional.cc
@@ -18,7 +18,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 namespace
 {

--- a/tests/base/taylor_estimate_function_bounds.cc
+++ b/tests/base/taylor_estimate_function_bounds.cc
@@ -24,7 +24,6 @@
 
 namespace
 {
-  using namespace dealii;
 
   /**
    * Returns a bounding box with different side lengths, 2*h_i, in all

--- a/tests/bits/unit_support_points_03.cc
+++ b/tests/bits/unit_support_points_03.cc
@@ -23,7 +23,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim, int spacedim>
 void

--- a/tests/boost/node_visitor_02.cc
+++ b/tests/boost/node_visitor_02.cc
@@ -30,7 +30,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace bg  = boost::geometry;
 namespace bgi = boost::geometry::index;
 

--- a/tests/data_out/write_subdivided_simplex_vtu.cc
+++ b/tests/data_out/write_subdivided_simplex_vtu.cc
@@ -30,7 +30,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class RightHandSideFunction : public Function<dim>

--- a/tests/data_out/write_vtu_with_pvtu_record_no_folder_01.cc
+++ b/tests/data_out/write_vtu_with_pvtu_record_no_folder_01.cc
@@ -37,7 +37,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 int

--- a/tests/distributed_grids/solution_transfer_05.cc
+++ b/tests/distributed_grids/solution_transfer_05.cc
@@ -34,7 +34,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main(int argc, char **argv)

--- a/tests/dofs/dof_accessor_03.cc
+++ b/tests/dofs/dof_accessor_03.cc
@@ -31,7 +31,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim, typename Number>
 void

--- a/tests/dofs/nodal_renumbering_01.cc
+++ b/tests/dofs/nodal_renumbering_01.cc
@@ -46,7 +46,6 @@
 // (x0, y0, z0, x1, y1, z1, ...) and solution1 should contain (u0, v0, w0, u1,
 // v1, w1, ...). Verify that they match when we interpolate.
 
-using namespace dealii;
 
 class Test : public Function<2>
 {

--- a/tests/fe/fe_nothing_02.cc
+++ b/tests/fe/fe_nothing_02.cc
@@ -14,7 +14,6 @@
 // This previously crashed with a segmentation fault inside
 // DoFHandlerImplementation::Policy::Sequential::renumber_dofs().
 
-using namespace dealii;
 int
 main()
 {

--- a/tests/fe/generic_dofs_per_object_01.cc
+++ b/tests/fe/generic_dofs_per_object_01.cc
@@ -22,7 +22,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim, int spacedim>
 void

--- a/tests/feinterface/stokes.cc
+++ b/tests/feinterface/stokes.cc
@@ -70,7 +70,6 @@
 
 namespace StokesTests
 {
-  using namespace dealii;
 
   struct CopyDataFace
   {
@@ -869,7 +868,6 @@ main()
 {
   try
     {
-      using namespace dealii;
       using namespace StokesTests;
       const int dim = 2;
 

--- a/tests/fullydistributed_grids/copy_distributed_tria_01.cc
+++ b/tests/fullydistributed_grids/copy_distributed_tria_01.cc
@@ -32,7 +32,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/fullydistributed_grids/copy_distributed_tria_02.cc
+++ b/tests/fullydistributed_grids/copy_distributed_tria_02.cc
@@ -32,7 +32,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/fullydistributed_grids/copy_distributed_tria_03.cc
+++ b/tests/fullydistributed_grids/copy_distributed_tria_03.cc
@@ -32,7 +32,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/fullydistributed_grids/copy_serial_tria_01.cc
+++ b/tests/fullydistributed_grids/copy_serial_tria_01.cc
@@ -32,7 +32,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/fullydistributed_grids/copy_serial_tria_02.cc
+++ b/tests/fullydistributed_grids/copy_serial_tria_02.cc
@@ -32,7 +32,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/fullydistributed_grids/copy_serial_tria_03.cc
+++ b/tests/fullydistributed_grids/copy_serial_tria_03.cc
@@ -33,7 +33,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/fullydistributed_grids/copy_serial_tria_04.cc
+++ b/tests/fullydistributed_grids/copy_serial_tria_04.cc
@@ -32,7 +32,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/fullydistributed_grids/copy_serial_tria_05.cc
+++ b/tests/fullydistributed_grids/copy_serial_tria_05.cc
@@ -33,7 +33,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/fullydistributed_grids/copy_serial_tria_06.cc
+++ b/tests/fullydistributed_grids/copy_serial_tria_06.cc
@@ -36,7 +36,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/fullydistributed_grids/copy_serial_tria_07.cc
+++ b/tests/fullydistributed_grids/copy_serial_tria_07.cc
@@ -32,7 +32,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/fullydistributed_grids/copy_serial_tria_08.cc
+++ b/tests/fullydistributed_grids/copy_serial_tria_08.cc
@@ -32,7 +32,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/fullydistributed_grids/copy_serial_tria_09.cc
+++ b/tests/fullydistributed_grids/copy_serial_tria_09.cc
@@ -33,7 +33,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/fullydistributed_grids/copy_serial_tria_10.cc
+++ b/tests/fullydistributed_grids/copy_serial_tria_10.cc
@@ -35,7 +35,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/fullydistributed_grids/copy_serial_tria_11.cc
+++ b/tests/fullydistributed_grids/copy_serial_tria_11.cc
@@ -32,7 +32,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 
 int

--- a/tests/fullydistributed_grids/copy_serial_tria_12.cc
+++ b/tests/fullydistributed_grids/copy_serial_tria_12.cc
@@ -32,7 +32,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/fullydistributed_grids/copy_serial_tria_grouped_01.cc
+++ b/tests/fullydistributed_grids/copy_serial_tria_grouped_01.cc
@@ -36,7 +36,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 template <int dim, int spacedim = dim>
 void

--- a/tests/fullydistributed_grids/create_manually_01.cc
+++ b/tests/fullydistributed_grids/create_manually_01.cc
@@ -32,7 +32,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/fullydistributed_grids/memory_consumption_01.cc
+++ b/tests/fullydistributed_grids/memory_consumption_01.cc
@@ -31,7 +31,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/fullydistributed_grids/repartitioning_01.cc
+++ b/tests/fullydistributed_grids/repartitioning_01.cc
@@ -36,7 +36,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 
 template <int dim, int spacedim>

--- a/tests/fullydistributed_grids/repartitioning_02.cc
+++ b/tests/fullydistributed_grids/repartitioning_02.cc
@@ -36,7 +36,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 template <int dim, int spacedim>
 void

--- a/tests/fullydistributed_grids/repartitioning_03.cc
+++ b/tests/fullydistributed_grids/repartitioning_03.cc
@@ -39,7 +39,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 template <int dim, int spacedim>
 void

--- a/tests/fullydistributed_grids/repartitioning_04.cc
+++ b/tests/fullydistributed_grids/repartitioning_04.cc
@@ -39,7 +39,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 template <int dim, int spacedim>
 void

--- a/tests/fullydistributed_grids/repartitioning_05.cc
+++ b/tests/fullydistributed_grids/repartitioning_05.cc
@@ -36,7 +36,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 MPI_Comm
 create_sub_comm(const MPI_Comm comm, const unsigned int size)

--- a/tests/fullydistributed_grids/repartitioning_06.cc
+++ b/tests/fullydistributed_grids/repartitioning_06.cc
@@ -37,7 +37,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 namespace dealii
 {

--- a/tests/fullydistributed_grids/repartitioning_07.cc
+++ b/tests/fullydistributed_grids/repartitioning_07.cc
@@ -35,7 +35,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/fullydistributed_grids/repartitioning_08.cc
+++ b/tests/fullydistributed_grids/repartitioning_08.cc
@@ -37,7 +37,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 
 template <int dim, int spacedim = dim>

--- a/tests/fullydistributed_grids/save_load_01.cc
+++ b/tests/fullydistributed_grids/save_load_01.cc
@@ -34,7 +34,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 template <int dim, typename TriangulationType>
 void

--- a/tests/fullydistributed_grids/solution_transfer_01.cc
+++ b/tests/fullydistributed_grids/solution_transfer_01.cc
@@ -34,7 +34,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class InterpolationFunction : public Function<dim>

--- a/tests/grid/global_ids_01.cc
+++ b/tests/grid/global_ids_01.cc
@@ -30,7 +30,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/grid/global_ids_03.cc
+++ b/tests/grid/global_ids_03.cc
@@ -30,7 +30,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/grid/grid_generator_marching_cube_algorithm_01.cc
+++ b/tests/grid/grid_generator_marching_cube_algorithm_01.cc
@@ -44,7 +44,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 using VectorType = LinearAlgebra::distributed::Vector<double>;

--- a/tests/grid/grid_generator_marching_cube_algorithm_02.cc
+++ b/tests/grid/grid_generator_marching_cube_algorithm_02.cc
@@ -39,7 +39,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 using VectorType = LinearAlgebra::distributed::Vector<double>;
 

--- a/tests/grid/grid_generator_non_standard_orientation_mesh_2d.cc
+++ b/tests/grid/grid_generator_non_standard_orientation_mesh_2d.cc
@@ -30,7 +30,6 @@
 // STL
 #include <map>
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/grid/grid_generator_non_standard_orientation_mesh_3d.cc
+++ b/tests/grid/grid_generator_non_standard_orientation_mesh_3d.cc
@@ -30,7 +30,6 @@
 // STL
 #include <map>
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/grid/grid_in_exodusii.cc
+++ b/tests/grid/grid_in_exodusii.cc
@@ -23,7 +23,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim, int spacedim = dim>
 void

--- a/tests/grid/grid_in_gmsh_02.cc
+++ b/tests/grid/grid_in_gmsh_02.cc
@@ -30,7 +30,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim>

--- a/tests/grid/grid_in_gmsh_03.cc
+++ b/tests/grid/grid_in_gmsh_03.cc
@@ -31,7 +31,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim>

--- a/tests/grid/is_artificial_on_level.cc
+++ b/tests/grid/is_artificial_on_level.cc
@@ -24,7 +24,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main(int argc, char *argv[])

--- a/tests/grid/merge_triangulations_10.cc
+++ b/tests/grid/merge_triangulations_10.cc
@@ -35,8 +35,6 @@ print_boundary_ids(const dealii::Triangulation<dim> &tria)
 int
 main()
 {
-  using namespace dealii;
-
   initlog();
 
   const unsigned int dim = 2;

--- a/tests/grid/reference_cell_type_01.cc
+++ b/tests/grid/reference_cell_type_01.cc
@@ -21,7 +21,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/grid/reference_cell_type_02.cc
+++ b/tests/grid/reference_cell_type_02.cc
@@ -26,7 +26,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/grid/reference_cell_type_02_midpoint.cc
+++ b/tests/grid/reference_cell_type_02_midpoint.cc
@@ -27,7 +27,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/grid/reference_cell_type_02_q.cc
+++ b/tests/grid/reference_cell_type_02_q.cc
@@ -28,7 +28,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/grid/reference_cell_type_03.cc
+++ b/tests/grid/reference_cell_type_03.cc
@@ -26,7 +26,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/grid/reference_cell_type_03_midpoint.cc
+++ b/tests/grid/reference_cell_type_03_midpoint.cc
@@ -27,7 +27,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/grid/reference_cell_type_03_q.cc
+++ b/tests/grid/reference_cell_type_03_q.cc
@@ -27,7 +27,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/grid/reference_cell_type_04.cc
+++ b/tests/grid/reference_cell_type_04.cc
@@ -26,7 +26,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/grid/reference_cell_type_05.cc
+++ b/tests/grid/reference_cell_type_05.cc
@@ -24,7 +24,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/grid/refine_boundary_domain.cc
+++ b/tests/grid/refine_boundary_domain.cc
@@ -23,7 +23,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/grid/save_load_01.cc
+++ b/tests/grid/save_load_01.cc
@@ -32,7 +32,6 @@
 
 #include "./tests.h"
 
-using namespace dealii;
 
 template <int dim, typename TriangulationType>
 void

--- a/tests/grid/serialization_01.cc
+++ b/tests/grid/serialization_01.cc
@@ -33,7 +33,6 @@
 
 #include "./tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class InterpolationFunction : public Function<dim>

--- a/tests/lac/constraints_make_consistent_in_parallel_01.cc
+++ b/tests/lac/constraints_make_consistent_in_parallel_01.cc
@@ -31,7 +31,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 /**
  * mpirun -np 4 ./constraints_01

--- a/tests/lac/distributed_vector_sm.cc
+++ b/tests/lac/distributed_vector_sm.cc
@@ -22,8 +22,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
-
 
 
 int

--- a/tests/lac/step-40-linear_operator_01.cc
+++ b/tests/lac/step-40-linear_operator_01.cc
@@ -63,7 +63,6 @@
 
 namespace Step40
 {
-  using namespace dealii;
 
   template <int dim>
   class LaplaceProblem

--- a/tests/lac/step-40-linear_operator_02.cc
+++ b/tests/lac/step-40-linear_operator_02.cc
@@ -63,7 +63,6 @@
 
 namespace Step40
 {
-  using namespace dealii;
 
   template <int dim>
   class LaplaceProblem

--- a/tests/lac/step-40-linear_operator_03.cc
+++ b/tests/lac/step-40-linear_operator_03.cc
@@ -64,7 +64,6 @@
 
 namespace Step40
 {
-  using namespace dealii;
 
   template <int dim>
   class LaplaceProblem

--- a/tests/lac/step-40-linear_operator_04.cc
+++ b/tests/lac/step-40-linear_operator_04.cc
@@ -64,7 +64,6 @@
 
 namespace Step40
 {
-  using namespace dealii;
 
   template <int dim>
   class LaplaceProblem

--- a/tests/lac/step-40-linear_operator_05.cc
+++ b/tests/lac/step-40-linear_operator_05.cc
@@ -64,7 +64,6 @@
 
 namespace Step40
 {
-  using namespace dealii;
 
   template <int dim>
   class LaplaceProblem

--- a/tests/lac/step-40-linear_operator_06.cc
+++ b/tests/lac/step-40-linear_operator_06.cc
@@ -64,7 +64,6 @@
 
 namespace Step40
 {
-  using namespace dealii;
 
   template <int dim>
   class LaplaceProblem

--- a/tests/lac/vector_memory_01.cc
+++ b/tests/lac/vector_memory_01.cc
@@ -27,7 +27,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <typename VectorType>
 void

--- a/tests/lac/vector_memory_02.cc
+++ b/tests/lac/vector_memory_02.cc
@@ -27,7 +27,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <typename VectorType>
 void

--- a/tests/manifold/transfinite_manifold_11.cc
+++ b/tests/manifold/transfinite_manifold_11.cc
@@ -23,7 +23,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class GradingManifold : public ChartManifold<dim>

--- a/tests/manifold/transfinite_manifold_12.cc
+++ b/tests/manifold/transfinite_manifold_12.cc
@@ -30,7 +30,6 @@ main()
 {
   initlog();
 
-  using namespace dealii;
 
   Triangulation<2, 3> tria;
 

--- a/tests/matrix_free/compute_diagonal_util.h
+++ b/tests/matrix_free/compute_diagonal_util.h
@@ -45,7 +45,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim,

--- a/tests/matrix_free/constraint_info_01.cc
+++ b/tests/matrix_free/constraint_info_01.cc
@@ -31,7 +31,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/matrix_free/element_birth_and_death_01.cc
+++ b/tests/matrix_free/element_birth_and_death_01.cc
@@ -34,7 +34,6 @@
 // Test MatrixFreeTools::ElementActivationAndDeactivationMatrixFree by comparing
 // the results with results obtained on fitted mesh.
 
-using namespace dealii;
 
 template <int dim>
 class Fu : public Function<dim>

--- a/tests/matrix_free/fe_evaluation_shift.cc
+++ b/tests/matrix_free/fe_evaluation_shift.cc
@@ -270,7 +270,6 @@ shift_1d_quadrature(const Quadrature<1> &quadrature_1D, const Number shift)
   return {points_shift, weights};
 }
 
-using namespace dealii;
 
 template <int dim,
           int fe_degree,

--- a/tests/matrix_free/fe_remote_evaluation_01.cc
+++ b/tests/matrix_free/fe_remote_evaluation_01.cc
@@ -29,7 +29,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 using Number = double;
 

--- a/tests/matrix_free/fe_remote_evaluation_02.cc
+++ b/tests/matrix_free/fe_remote_evaluation_02.cc
@@ -29,7 +29,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 using Number = double;
 

--- a/tests/matrix_free/matrix_vector_hessians_cells.cc
+++ b/tests/matrix_free/matrix_vector_hessians_cells.cc
@@ -48,7 +48,6 @@ test_hessians(const dealii::FE_Poly<dim>                    &fe,
               const dealii::Quadrature<dim>                 &quad,
               const dealii::EvaluationFlags::EvaluationFlags evaluation_flags)
 {
-  using namespace dealii;
   using VectorizedArrayType = VectorizedArray<double>;
 
   Triangulation<dim> tria;
@@ -236,7 +235,6 @@ test_hessians(const dealii::FE_Poly<dim>                    &fe,
 void
 test_qiterated(dealii::EvaluationFlags::EvaluationFlags evaluation_flags)
 {
-  using namespace dealii;
   deallog << "test_qiterated" << std::endl;
   for (unsigned int i = 1; i < 4; ++i)
     {
@@ -261,7 +259,6 @@ test_qiterated(dealii::EvaluationFlags::EvaluationFlags evaluation_flags)
 void
 test_qgauss(dealii::EvaluationFlags::EvaluationFlags evaluation_flags)
 {
-  using namespace dealii;
   deallog << "test_qgauss" << std::endl;
   for (unsigned int i = 1; i < 4; ++i)
     {
@@ -283,7 +280,6 @@ test_qgauss(dealii::EvaluationFlags::EvaluationFlags evaluation_flags)
 int
 main(int argc, char **argv)
 {
-  using namespace dealii;
   Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
 
   initlog();

--- a/tests/matrix_free/matrix_vector_hessians_faces.cc
+++ b/tests/matrix_free/matrix_vector_hessians_faces.cc
@@ -49,7 +49,6 @@ test_hessians(const unsigned int                             degree,
               const dealii::FE_Poly<dim>                    &fe,
               const dealii::EvaluationFlags::EvaluationFlags evaluation_flags)
 {
-  using namespace dealii;
   using VectorizedArrayType = VectorizedArray<double>;
 
   Triangulation<dim> tria;

--- a/tests/matrix_free/matrix_vector_hessians_general_cells.cc
+++ b/tests/matrix_free/matrix_vector_hessians_general_cells.cc
@@ -48,7 +48,6 @@ test_hessians(const dealii::FE_Poly<dim>                    &fe,
               const dealii::Quadrature<dim>                 &quad,
               const dealii::EvaluationFlags::EvaluationFlags evaluation_flags)
 {
-  using namespace dealii;
   using VectorizedArrayType = VectorizedArray<double>;
 
   Triangulation<dim> tria;
@@ -239,7 +238,6 @@ test_hessians(const dealii::FE_Poly<dim>                    &fe,
 void
 test_qiterated(dealii::EvaluationFlags::EvaluationFlags evaluation_flags)
 {
-  using namespace dealii;
   deallog << "test_qiterated" << std::endl;
   for (unsigned int i = 1; i < 3; ++i)
     {
@@ -259,7 +257,6 @@ test_qiterated(dealii::EvaluationFlags::EvaluationFlags evaluation_flags)
 void
 test_qgauss(dealii::EvaluationFlags::EvaluationFlags evaluation_flags)
 {
-  using namespace dealii;
   deallog << "test_qgauss" << std::endl;
   for (unsigned int i = 1; i < 4; ++i)
     {
@@ -277,7 +274,6 @@ test_qgauss(dealii::EvaluationFlags::EvaluationFlags evaluation_flags)
 int
 main(int argc, char **argv)
 {
-  using namespace dealii;
   Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
 
   initlog();

--- a/tests/matrix_free/matrix_vector_hessians_general_faces.cc
+++ b/tests/matrix_free/matrix_vector_hessians_general_faces.cc
@@ -52,7 +52,6 @@ test_hessians(const unsigned int                             degree,
               const dealii::FE_Poly<dim>                    &fe,
               const dealii::EvaluationFlags::EvaluationFlags evaluation_flags)
 {
-  using namespace dealii;
   using VectorizedArrayType = VectorizedArray<double>;
 
   Triangulation<dim> tria;
@@ -323,7 +322,6 @@ test_hessians(const unsigned int                             degree,
 int
 main(int argc, char **argv)
 {
-  using namespace dealii;
   dealii::Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
 
   initlog();

--- a/tests/matrix_free/point_evaluation_01.cc
+++ b/tests/matrix_free/point_evaluation_01.cc
@@ -44,7 +44,6 @@ template <int dim, typename Number = double>
 void
 test(const unsigned int degree)
 {
-  using namespace dealii;
   Triangulation<dim> tria;
 
   if (dim > 1)

--- a/tests/matrix_free/point_evaluation_02.cc
+++ b/tests/matrix_free/point_evaluation_02.cc
@@ -44,7 +44,6 @@ template <int dim>
 void
 test(const unsigned int degree)
 {
-  using namespace dealii;
   Triangulation<dim> tria;
 
   if (dim > 1)

--- a/tests/matrix_free/point_evaluation_03.cc
+++ b/tests/matrix_free/point_evaluation_03.cc
@@ -62,7 +62,6 @@ template <int dim>
 void
 test(const unsigned int degree)
 {
-  using namespace dealii;
   Triangulation<dim> tria;
 
   if (dim > 1)

--- a/tests/matrix_free/point_evaluation_04.cc
+++ b/tests/matrix_free/point_evaluation_04.cc
@@ -65,7 +65,6 @@ template <int dim>
 void
 test(const unsigned int degree)
 {
-  using namespace dealii;
   Triangulation<dim> tria;
 
   if (dim > 1)

--- a/tests/matrix_free/point_evaluation_05.cc
+++ b/tests/matrix_free/point_evaluation_05.cc
@@ -45,7 +45,6 @@ template <int dim>
 void
 test(const unsigned int degree)
 {
-  using namespace dealii;
   Triangulation<dim> tria;
 
   if (dim > 1)

--- a/tests/matrix_free/point_evaluation_06.cc
+++ b/tests/matrix_free/point_evaluation_06.cc
@@ -46,7 +46,6 @@ template <int dim>
 void
 test(const unsigned int degree)
 {
-  using namespace dealii;
   Triangulation<dim> tria;
 
   if (dim > 1)

--- a/tests/matrix_free/point_evaluation_07.cc
+++ b/tests/matrix_free/point_evaluation_07.cc
@@ -62,7 +62,6 @@ template <int dim>
 void
 test(const unsigned int degree)
 {
-  using namespace dealii;
   Triangulation<dim> tria;
 
   if (dim > 1)

--- a/tests/matrix_free/point_evaluation_08.cc
+++ b/tests/matrix_free/point_evaluation_08.cc
@@ -65,7 +65,6 @@ template <int dim>
 void
 test(const unsigned int degree)
 {
-  using namespace dealii;
   Triangulation<dim> tria;
 
   if (dim > 1)

--- a/tests/matrix_free/point_evaluation_09.cc
+++ b/tests/matrix_free/point_evaluation_09.cc
@@ -62,7 +62,6 @@ template <int dim>
 void
 test(const unsigned int degree)
 {
-  using namespace dealii;
   Triangulation<dim> tria;
 
   if (dim > 1)

--- a/tests/matrix_free/point_evaluation_10.cc
+++ b/tests/matrix_free/point_evaluation_10.cc
@@ -46,7 +46,6 @@ template <int dim>
 void
 test(const unsigned int degree)
 {
-  using namespace dealii;
   Triangulation<dim> tria;
 
   if (dim > 1)

--- a/tests/matrix_free/point_evaluation_11.cc
+++ b/tests/matrix_free/point_evaluation_11.cc
@@ -46,7 +46,6 @@ template <int dim>
 void
 test(const unsigned int degree)
 {
-  using namespace dealii;
   Triangulation<dim> tria;
 
   if (dim > 1)

--- a/tests/matrix_free/point_evaluation_12.cc
+++ b/tests/matrix_free/point_evaluation_12.cc
@@ -44,7 +44,6 @@ template <int dim>
 void
 test(const unsigned int degree)
 {
-  using namespace dealii;
   Triangulation<dim> tria;
 
   if (dim > 1)

--- a/tests/matrix_free/point_evaluation_13.cc
+++ b/tests/matrix_free/point_evaluation_13.cc
@@ -63,7 +63,6 @@ template <int dim>
 void
 test()
 {
-  using namespace dealii;
   Triangulation<dim> tria;
 
   GridGenerator::subdivided_hyper_cube(tria, 2, 0, 1);

--- a/tests/matrix_free/point_evaluation_14.cc
+++ b/tests/matrix_free/point_evaluation_14.cc
@@ -63,7 +63,6 @@ template <int dim>
 void
 test(const unsigned int degree)
 {
-  using namespace dealii;
   Triangulation<dim> tria;
 
   if (dim > 1)

--- a/tests/matrix_free/point_evaluation_15.cc
+++ b/tests/matrix_free/point_evaluation_15.cc
@@ -62,7 +62,6 @@ template <int dim>
 void
 test()
 {
-  using namespace dealii;
   Triangulation<dim> tria;
 
   GridGenerator::subdivided_hyper_cube(tria, 2, 0, 1);

--- a/tests/matrix_free/point_evaluation_16.cc
+++ b/tests/matrix_free/point_evaluation_16.cc
@@ -63,7 +63,6 @@ template <int dim>
 void
 test(const unsigned int degree)
 {
-  using namespace dealii;
   Triangulation<dim> tria;
 
   if (dim > 1)

--- a/tests/matrix_free/point_evaluation_17.cc
+++ b/tests/matrix_free/point_evaluation_17.cc
@@ -62,7 +62,6 @@ template <int dim>
 void
 test()
 {
-  using namespace dealii;
   Triangulation<dim> tria;
 
   GridGenerator::subdivided_hyper_cube(tria, 2, 0, 1);

--- a/tests/matrix_free/point_evaluation_19.cc
+++ b/tests/matrix_free/point_evaluation_19.cc
@@ -61,7 +61,6 @@ template <int dim>
 void
 test()
 {
-  using namespace dealii;
   Triangulation<dim> tria;
 
   GridGenerator::subdivided_hyper_cube(tria, 2, 0, 1);

--- a/tests/matrix_free/point_evaluation_20.cc
+++ b/tests/matrix_free/point_evaluation_20.cc
@@ -61,7 +61,6 @@ template <int dim>
 void
 test()
 {
-  using namespace dealii;
   Triangulation<dim> tria;
 
   GridGenerator::subdivided_hyper_cube(tria, 2, 0, 1);

--- a/tests/matrix_free/point_evaluation_21.cc
+++ b/tests/matrix_free/point_evaluation_21.cc
@@ -44,7 +44,6 @@ template <int dim, typename Number = double>
 void
 test(const unsigned int degree)
 {
-  using namespace dealii;
   Triangulation<dim> tria;
 
   if (dim > 1)

--- a/tests/matrix_free/point_evaluation_22.cc
+++ b/tests/matrix_free/point_evaluation_22.cc
@@ -40,7 +40,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim,
           typename Number              = double,

--- a/tests/matrix_free/point_evaluation_23.cc
+++ b/tests/matrix_free/point_evaluation_23.cc
@@ -62,7 +62,6 @@ template <int dim>
 void
 test(const unsigned int degree)
 {
-  using namespace dealii;
   Triangulation<dim> tria;
 
   if (dim > 1)

--- a/tests/matrix_free/point_evaluation_24.cc
+++ b/tests/matrix_free/point_evaluation_24.cc
@@ -62,7 +62,6 @@ template <int dim>
 void
 test(const unsigned int degree)
 {
-  using namespace dealii;
   Triangulation<dim> tria;
 
   if (dim > 1)

--- a/tests/matrix_free/point_evaluation_25.cc
+++ b/tests/matrix_free/point_evaluation_25.cc
@@ -44,7 +44,6 @@ template <int dim, typename Number = double>
 void
 test(const unsigned int degree)
 {
-  using namespace dealii;
   Triangulation<dim> tria;
 
   if (dim > 1)

--- a/tests/matrix_free/point_evaluation_26.cc
+++ b/tests/matrix_free/point_evaluation_26.cc
@@ -30,7 +30,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class AnalyticalFunction : public Function<dim>

--- a/tests/matrix_free/point_evaluation_27.cc
+++ b/tests/matrix_free/point_evaluation_27.cc
@@ -35,7 +35,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class AnalyticalFunction : public Function<dim>

--- a/tests/matrix_free/point_evaluation_28.cc
+++ b/tests/matrix_free/point_evaluation_28.cc
@@ -42,7 +42,6 @@ template <int dim, typename Number = double>
 void
 test(const unsigned int degree)
 {
-  using namespace dealii;
   Triangulation<dim> tria;
 
   if (dim > 1)

--- a/tests/matrix_free/poisson_dg_hp.cc
+++ b/tests/matrix_free/poisson_dg_hp.cc
@@ -54,7 +54,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 double

--- a/tests/matrix_free/reinit_matrix_free_threading.cc
+++ b/tests/matrix_free/reinit_matrix_free_threading.cc
@@ -32,7 +32,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim, typename Number>
 void

--- a/tests/mpi/create_mpi_datatype_01.cc
+++ b/tests/mpi/create_mpi_datatype_01.cc
@@ -24,7 +24,6 @@ const bool run_big = false;
 
 #include "../tests.h"
 
-using namespace dealii;
 
 void
 test_data_type(const std::uint64_t n_bytes)

--- a/tests/mpi/is_mpi_type.cc
+++ b/tests/mpi/is_mpi_type.cc
@@ -20,7 +20,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 void
 test()

--- a/tests/mpi/parallel_partitioner_device_08.cc
+++ b/tests/mpi/parallel_partitioner_device_08.cc
@@ -174,8 +174,6 @@ test()
 int
 main(int argc, char **argv)
 {
-  using namespace dealii;
-
   Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
   MPILogInitAll                    log;
 

--- a/tests/mpi/union_01.cc
+++ b/tests/mpi/union_01.cc
@@ -20,7 +20,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 void
 test(const MPI_Comm comm)

--- a/tests/multigrid-global-coarsening/create_geometric_coarsening_sequence_01.cc
+++ b/tests/multigrid-global-coarsening/create_geometric_coarsening_sequence_01.cc
@@ -26,7 +26,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/multigrid-global-coarsening/create_polynomial_coarsening_sequence_01.cc
+++ b/tests/multigrid-global-coarsening/create_polynomial_coarsening_sequence_01.cc
@@ -19,7 +19,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 void
 test(

--- a/tests/multigrid-global-coarsening/mg_transfer_support_01.cc
+++ b/tests/multigrid-global-coarsening/mg_transfer_support_01.cc
@@ -19,7 +19,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 void
 test()

--- a/tests/multigrid-global-coarsening/mg_transfer_util.h
+++ b/tests/multigrid-global-coarsening/mg_transfer_util.h
@@ -23,8 +23,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
-
 
 
 template <typename MeshType, typename Number>

--- a/tests/multigrid/mg_constraints_pbc.cc
+++ b/tests/multigrid/mg_constraints_pbc.cc
@@ -31,7 +31,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/multigrid/mg_level_object_args_01.cc
+++ b/tests/multigrid/mg_level_object_args_01.cc
@@ -24,7 +24,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/non_matching/discrete_quadrature_generator.cc
+++ b/tests/non_matching/discrete_quadrature_generator.cc
@@ -30,7 +30,6 @@
 
 #include "quadrature_printing.h"
 
-using namespace dealii;
 
 template <int dim>
 class Test

--- a/tests/non_matching/fe_immersed_surface_values.cc
+++ b/tests/non_matching/fe_immersed_surface_values.cc
@@ -34,7 +34,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 using NonMatching::FEImmersedSurfaceValues;
 
 // Set up a triangulation with a single Cartesian cell and a finite element

--- a/tests/non_matching/fe_immersed_surface_values_02.cc
+++ b/tests/non_matching/fe_immersed_surface_values_02.cc
@@ -22,7 +22,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 using NonMatching::FEImmersedSurfaceValues;
 
 // Set up a triangulation that we can construct an

--- a/tests/non_matching/fe_interface_values.cc
+++ b/tests/non_matching/fe_interface_values.cc
@@ -30,7 +30,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 // Set up a triangulation with 2 elements in a row: |-0-|-1-|, over
 // [0,2]x[0,1]^{dim-1}, and a level set  function with a cut in the plane

--- a/tests/non_matching/fe_interface_values_non_standard_meshes.cc
+++ b/tests/non_matching/fe_interface_values_non_standard_meshes.cc
@@ -41,7 +41,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class Test

--- a/tests/non_matching/fe_values.cc
+++ b/tests/non_matching/fe_values.cc
@@ -31,7 +31,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 // Assert that the two incoming cells are the same. Throw an exception if not.
 template <int dim>

--- a/tests/non_matching/find_best_height_direction.cc
+++ b/tests/non_matching/find_best_height_direction.cc
@@ -23,7 +23,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 using namespace NonMatching::internal::QuadratureGeneratorImplementation;
 
 

--- a/tests/non_matching/find_extreme_values.cc
+++ b/tests/non_matching/find_extreme_values.cc
@@ -23,7 +23,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 using namespace NonMatching::internal::QuadratureGeneratorImplementation;
 
 

--- a/tests/non_matching/mapping_info.cc
+++ b/tests/non_matching/mapping_info.cc
@@ -38,7 +38,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/non_matching/pointwise_definiteness.cc
+++ b/tests/non_matching/pointwise_definiteness.cc
@@ -27,7 +27,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 using namespace NonMatching::internal::QuadratureGeneratorImplementation;
 
 

--- a/tests/non_matching/quadrature_generator_sphere.cc
+++ b/tests/non_matching/quadrature_generator_sphere.cc
@@ -26,7 +26,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 /**
  * Compute the volume and surface area of a ball/sphere by setting up a

--- a/tests/non_matching/root_finder.cc
+++ b/tests/non_matching/root_finder.cc
@@ -29,7 +29,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 using namespace NonMatching::internal::QuadratureGeneratorImplementation;
 
 // Use RootFinder to find the roots of the incoming functions over the interval

--- a/tests/non_matching/step-70.cc
+++ b/tests/non_matching/step-70.cc
@@ -152,7 +152,6 @@ namespace LA
 
 namespace Step70
 {
-  using namespace dealii;
 
   // @sect3{Run-time parameter handling}
 
@@ -1913,7 +1912,6 @@ int
 main(int argc, char *argv[])
 {
   using namespace Step70;
-  using namespace dealii;
 
   auto          init = Utilities::MPI::MPI_InitFinalize(argc, argv, 1);
   MPILogInitAll log(true);

--- a/tests/non_matching/tensor_point_with_1D_quadrature.cc
+++ b/tests/non_matching/tensor_point_with_1D_quadrature.cc
@@ -26,7 +26,6 @@
 
 #include "quadrature_printing.h"
 
-using namespace dealii;
 using namespace NonMatching::internal::QuadratureGeneratorImplementation;
 
 

--- a/tests/non_matching/up_through_dimension_creator.cc
+++ b/tests/non_matching/up_through_dimension_creator.cc
@@ -29,7 +29,6 @@
 
 #include "quadrature_printing.h"
 
-using namespace dealii;
 using namespace NonMatching::internal::QuadratureGeneratorImplementation;
 
 

--- a/tests/numerics/matrix_creator_01.cc
+++ b/tests/numerics/matrix_creator_01.cc
@@ -36,7 +36,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim, typename MatrixType>
 void

--- a/tests/numerics/nonlinear_solver_selector_01.cc
+++ b/tests/numerics/nonlinear_solver_selector_01.cc
@@ -63,7 +63,6 @@
 
 namespace nonlinear_solver_selector_test
 {
-  using namespace dealii;
 
   using NLSolve = NonlinearSolverSelector<Vector<double>>;
 

--- a/tests/numerics/nonlinear_solver_selector_03.cc
+++ b/tests/numerics/nonlinear_solver_selector_03.cc
@@ -77,7 +77,6 @@ namespace LA
 
 namespace MPI_nonlinear_solver_selector_test
 {
-  using namespace dealii;
 
   using NLSolve = NonlinearSolverSelector<LA::MPI::Vector>;
 

--- a/tests/numerics/smoothness_estimator_01.cc
+++ b/tests/numerics/smoothness_estimator_01.cc
@@ -43,8 +43,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
-
 
 template <int dim>
 class LegendreFunction : public Function<dim>

--- a/tests/numerics/smoothness_estimator_02.cc
+++ b/tests/numerics/smoothness_estimator_02.cc
@@ -63,8 +63,6 @@ print([i,j,k],fullratsimp(C3(i,j,k)))));
 #include "../tests.h"
 
 
-using namespace dealii;
-
 
 template <int dim>
 class PolyFunction : public Function<dim>

--- a/tests/parameter_handler/add_parameter_01.cc
+++ b/tests/parameter_handler/add_parameter_01.cc
@@ -22,7 +22,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/particles/interpolate_on_particle_01.cc
+++ b/tests/particles/interpolate_on_particle_01.cc
@@ -39,7 +39,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim, int spacedim>
 void

--- a/tests/particles/lost_01.cc
+++ b/tests/particles/lost_01.cc
@@ -23,7 +23,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/particles/particle_handler_21.cc
+++ b/tests/particles/particle_handler_21.cc
@@ -56,7 +56,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class VelocityField : public Function<dim>

--- a/tests/particles/particle_handler_22.cc
+++ b/tests/particles/particle_handler_22.cc
@@ -54,7 +54,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class VelocityField : public Function<dim>

--- a/tests/particles/particle_interpolation_01.cc
+++ b/tests/particles/particle_interpolation_01.cc
@@ -38,7 +38,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim, int spacedim>
 void

--- a/tests/particles/particle_interpolation_02.cc
+++ b/tests/particles/particle_interpolation_02.cc
@@ -42,7 +42,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim, int spacedim>
 void

--- a/tests/particles/particle_interpolation_03.cc
+++ b/tests/particles/particle_interpolation_03.cc
@@ -41,7 +41,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim, int spacedim>
 void

--- a/tests/particles/particle_interpolation_04.cc
+++ b/tests/particles/particle_interpolation_04.cc
@@ -41,7 +41,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim, int spacedim>
 void

--- a/tests/particles/particle_interpolation_05.cc
+++ b/tests/particles/particle_interpolation_05.cc
@@ -46,7 +46,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim, int spacedim>
 void

--- a/tests/particles/step-19.cc
+++ b/tests/particles/step-19.cc
@@ -65,8 +65,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
-
 
 // @sect3{Global definitions}
 

--- a/tests/particles/step-68.cc
+++ b/tests/particles/step-68.cc
@@ -75,7 +75,6 @@
 
 namespace Step68
 {
-  using namespace dealii;
 
   // @sect3{Velocity profile}
 
@@ -728,7 +727,6 @@ int
 main(int argc, char *argv[])
 {
   using namespace Step68;
-  using namespace dealii;
   Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
   MPILogInitAll all;

--- a/tests/petsc/step-67-with-petsc-ts.cc
+++ b/tests/petsc/step-67-with-petsc-ts.cc
@@ -67,7 +67,6 @@
 
 namespace Euler_DG
 {
-  using namespace dealii;
 
   // Similarly to the other matrix-free tutorial programs, we collect all
   // parameters that control the execution of the program at the top of the
@@ -2396,7 +2395,6 @@ int
 main(int argc, char **argv)
 {
   using namespace Euler_DG;
-  using namespace dealii;
 
   initlog();
   Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);

--- a/tests/petsc/step-77-snes.cc
+++ b/tests/petsc/step-77-snes.cc
@@ -67,7 +67,6 @@ namespace Step77
 {
   // Before writing the main class to solve the problem, we define
   // shortcuts for the types we are going to use within this tutorial.
-  using namespace dealii;
   using VectorType         = PETScWrappers::MPI::Vector;
   using MatrixType         = PETScWrappers::MPI::SparseMatrix;
   using PreconditionerType = PETScWrappers::PreconditionLU;

--- a/tests/physics/positive_negative_split.cc
+++ b/tests/physics/positive_negative_split.cc
@@ -33,8 +33,6 @@ template <int dim>
 void
 positive_negative_split_test()
 {
-  using namespace dealii;
-
   SymmetricTensor<2, dim> random_tensor;
   srand(time(0));
 

--- a/tests/remote_point_evaluation/convert_intersections_to_rpe_data_01.cc
+++ b/tests/remote_point_evaluation/convert_intersections_to_rpe_data_01.cc
@@ -31,7 +31,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <int dim>
 std::vector<std::vector<BoundingBox<dim>>>

--- a/tests/remote_point_evaluation/convert_intersections_to_rpe_data_02.cc
+++ b/tests/remote_point_evaluation/convert_intersections_to_rpe_data_02.cc
@@ -31,7 +31,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <int dim>
 std::vector<std::vector<BoundingBox<dim>>>

--- a/tests/remote_point_evaluation/convert_intersections_to_rpe_data_03.cc
+++ b/tests/remote_point_evaluation/convert_intersections_to_rpe_data_03.cc
@@ -31,7 +31,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <int dim>
 std::vector<std::vector<BoundingBox<dim>>>

--- a/tests/remote_point_evaluation/convert_intersections_to_rpe_data_04.cc
+++ b/tests/remote_point_evaluation/convert_intersections_to_rpe_data_04.cc
@@ -31,7 +31,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <int dim>
 std::vector<std::vector<BoundingBox<dim>>>

--- a/tests/remote_point_evaluation/data_out_resample_01.cc
+++ b/tests/remote_point_evaluation/data_out_resample_01.cc
@@ -33,7 +33,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class AnalyticalFunction : public Function<dim>

--- a/tests/remote_point_evaluation/data_out_resample_02.cc
+++ b/tests/remote_point_evaluation/data_out_resample_02.cc
@@ -35,7 +35,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class AnalyticalFunction : public Function<dim>

--- a/tests/remote_point_evaluation/distributed_compute_intersection_locations_01.cc
+++ b/tests/remote_point_evaluation/distributed_compute_intersection_locations_01.cc
@@ -29,7 +29,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 std::vector<std::vector<BoundingBox<dim>>>

--- a/tests/remote_point_evaluation/distributed_compute_intersection_locations_02.cc
+++ b/tests/remote_point_evaluation/distributed_compute_intersection_locations_02.cc
@@ -29,7 +29,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 std::vector<std::vector<BoundingBox<dim>>>

--- a/tests/remote_point_evaluation/distributed_compute_intersection_locations_03.cc
+++ b/tests/remote_point_evaluation/distributed_compute_intersection_locations_03.cc
@@ -30,7 +30,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 std::vector<std::vector<BoundingBox<dim>>>

--- a/tests/remote_point_evaluation/distributed_compute_intersection_locations_04.cc
+++ b/tests/remote_point_evaluation/distributed_compute_intersection_locations_04.cc
@@ -30,7 +30,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 std::vector<std::vector<BoundingBox<dim>>>

--- a/tests/remote_point_evaluation/mapping_01.cc
+++ b/tests/remote_point_evaluation/mapping_01.cc
@@ -29,7 +29,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim>

--- a/tests/remote_point_evaluation/mapping_02.cc
+++ b/tests/remote_point_evaluation/mapping_02.cc
@@ -32,7 +32,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim>

--- a/tests/remote_point_evaluation/mapping_03.cc
+++ b/tests/remote_point_evaluation/mapping_03.cc
@@ -29,7 +29,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim>

--- a/tests/remote_point_evaluation/mapping_04.cc
+++ b/tests/remote_point_evaluation/mapping_04.cc
@@ -29,7 +29,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/remote_point_evaluation/remote_point_evaluation_01.cc
+++ b/tests/remote_point_evaluation/remote_point_evaluation_01.cc
@@ -46,7 +46,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 using VectorType = LinearAlgebra::distributed::Vector<double>;

--- a/tests/remote_point_evaluation/remote_point_evaluation_02.cc
+++ b/tests/remote_point_evaluation/remote_point_evaluation_02.cc
@@ -46,7 +46,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 using VectorType = LinearAlgebra::distributed::Vector<double>;

--- a/tests/remote_point_evaluation/remote_point_evaluation_03.cc
+++ b/tests/remote_point_evaluation/remote_point_evaluation_03.cc
@@ -49,7 +49,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 using VectorType = LinearAlgebra::distributed::Vector<double>;

--- a/tests/remote_point_evaluation/setup_rpe_with_intersections_01.cc
+++ b/tests/remote_point_evaluation/setup_rpe_with_intersections_01.cc
@@ -31,7 +31,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <int dim>
 std::vector<std::vector<BoundingBox<dim>>>

--- a/tests/remote_point_evaluation/setup_rpe_with_intersections_02.cc
+++ b/tests/remote_point_evaluation/setup_rpe_with_intersections_02.cc
@@ -31,7 +31,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <int dim>
 std::vector<std::vector<BoundingBox<dim>>>

--- a/tests/remote_point_evaluation/setup_rpe_with_intersections_03.cc
+++ b/tests/remote_point_evaluation/setup_rpe_with_intersections_03.cc
@@ -31,7 +31,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <int dim>
 std::vector<std::vector<BoundingBox<dim>>>

--- a/tests/remote_point_evaluation/setup_rpe_with_intersections_04.cc
+++ b/tests/remote_point_evaluation/setup_rpe_with_intersections_04.cc
@@ -31,7 +31,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <int dim>
 std::vector<std::vector<BoundingBox<dim>>>

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_01.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_01.cc
@@ -42,7 +42,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 namespace dealii
 {

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_02.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_02.cc
@@ -47,7 +47,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <typename MeshType>
 MPI_Comm

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_03.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_03.cc
@@ -43,7 +43,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <typename MeshType>
 MPI_Comm

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_04.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_04.cc
@@ -42,7 +42,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <typename MeshType>
 MPI_Comm

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_05.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_05.cc
@@ -42,7 +42,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <typename MeshType>
 MPI_Comm

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_06.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_06.cc
@@ -42,7 +42,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim, int spacedim>
 std::shared_ptr<const Utilities::MPI::Partitioner>

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_07.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_07.cc
@@ -43,7 +43,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <typename MeshType>
 MPI_Comm

--- a/tests/serialization/parallel_fullydistributed_construction_data_1.cc
+++ b/tests/serialization/parallel_fullydistributed_construction_data_1.cc
@@ -29,7 +29,6 @@
 #include "../grid/tests.h"
 #include "serialization.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/sharedtria/serialization_01.cc
+++ b/tests/sharedtria/serialization_01.cc
@@ -33,7 +33,6 @@
 
 #include "../grid/tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class InterpolationFunction : public Function<dim>

--- a/tests/simplex/barycentric_01.cc
+++ b/tests/simplex/barycentric_01.cc
@@ -26,7 +26,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/simplex/compute_point_locations_01.cc
+++ b/tests/simplex/compute_point_locations_01.cc
@@ -30,7 +30,6 @@
 // Create a simplex mesh in the unit cube. Check points distribute to each cell
 // via GridTools::compute_point_locations
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/simplex/compute_projection_matrices_01.cc
+++ b/tests/simplex/compute_projection_matrices_01.cc
@@ -37,7 +37,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class RightHandSideFunction : public Function<dim>

--- a/tests/simplex/convert_hypercube_to_simplex_mesh_01.cc
+++ b/tests/simplex/convert_hypercube_to_simplex_mesh_01.cc
@@ -32,7 +32,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim, int spacedim>
 void

--- a/tests/simplex/convert_hypercube_to_simplex_mesh_02.cc
+++ b/tests/simplex/convert_hypercube_to_simplex_mesh_02.cc
@@ -28,7 +28,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim, int spacedim>
 void

--- a/tests/simplex/data_out_faces_01.cc
+++ b/tests/simplex/data_out_faces_01.cc
@@ -38,7 +38,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class RightHandSideFunction : public Function<dim>

--- a/tests/simplex/data_out_write_gnuplot_01.cc
+++ b/tests/simplex/data_out_write_gnuplot_01.cc
@@ -38,7 +38,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class RightHandSideFunction : public Function<dim>

--- a/tests/simplex/data_out_write_gnuplot_02.cc
+++ b/tests/simplex/data_out_write_gnuplot_02.cc
@@ -38,7 +38,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class RightHandSideFunction : public Function<dim>

--- a/tests/simplex/data_out_write_gnuplot_03.cc
+++ b/tests/simplex/data_out_write_gnuplot_03.cc
@@ -38,7 +38,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class RightHandSideFunction : public Function<dim>

--- a/tests/simplex/data_out_write_hdf5_01.cc
+++ b/tests/simplex/data_out_write_hdf5_01.cc
@@ -38,7 +38,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class RightHandSideFunction : public Function<dim>

--- a/tests/simplex/data_out_write_hdf5_02.cc
+++ b/tests/simplex/data_out_write_hdf5_02.cc
@@ -42,7 +42,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class RightHandSideFunction : public Function<dim>

--- a/tests/simplex/data_out_write_vtk_01.cc
+++ b/tests/simplex/data_out_write_vtk_01.cc
@@ -38,7 +38,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class RightHandSideFunction : public Function<dim>

--- a/tests/simplex/data_out_write_vtk_02.cc
+++ b/tests/simplex/data_out_write_vtk_02.cc
@@ -41,7 +41,6 @@
 
 #include "./simplex_grids.h"
 
-using namespace dealii;
 
 template <int dim>
 class RightHandSideFunction : public Function<dim>

--- a/tests/simplex/data_out_write_vtk_03.cc
+++ b/tests/simplex/data_out_write_vtk_03.cc
@@ -39,7 +39,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim, int spacedim = dim>
 void

--- a/tests/simplex/data_out_write_vtk_04.cc
+++ b/tests/simplex/data_out_write_vtk_04.cc
@@ -40,7 +40,6 @@
 
 #include "simplex_grids.h"
 
-using namespace dealii;
 
 template <int dim>
 class RightHandSideFunction : public Function<dim>

--- a/tests/simplex/data_out_write_vtu_01.cc
+++ b/tests/simplex/data_out_write_vtu_01.cc
@@ -36,7 +36,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class RightHandSideFunction : public Function<dim>

--- a/tests/simplex/face_scaling.cc
+++ b/tests/simplex/face_scaling.cc
@@ -22,7 +22,6 @@
 // didn't used to work with MappingFEField since it did not apply the sqrt(2)
 // factor in 2D correctly.
 
-using namespace dealii;
 
 template <int dim, int spacedim = dim>
 void
@@ -58,7 +57,6 @@ test(const Triangulation<dim, spacedim> &tria,
 int
 main(int argc, char **argv)
 {
-  using namespace dealii;
   initlog();
 
   {

--- a/tests/simplex/fe_lib_01.cc
+++ b/tests/simplex/fe_lib_01.cc
@@ -24,7 +24,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim, int spacedim>
 void

--- a/tests/simplex/fe_lib_02.cc
+++ b/tests/simplex/fe_lib_02.cc
@@ -26,7 +26,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim, int spacedim>
 void

--- a/tests/simplex/fe_p_bubbles_01.cc
+++ b/tests/simplex/fe_p_bubbles_01.cc
@@ -26,7 +26,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim, int spacedim>
 void

--- a/tests/simplex/fe_p_bubbles_02.cc
+++ b/tests/simplex/fe_p_bubbles_02.cc
@@ -37,7 +37,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim, int spacedim = dim>
 Quadrature<dim>

--- a/tests/simplex/fe_p_bubbles_03.cc
+++ b/tests/simplex/fe_p_bubbles_03.cc
@@ -24,7 +24,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim, int spacedim>
 void

--- a/tests/simplex/get_boundary_ids_01.cc
+++ b/tests/simplex/get_boundary_ids_01.cc
@@ -30,7 +30,6 @@
 // Check that Triangulation::get_boundary_ids() works for
 // simplices. This used to crash.
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/simplex/get_projection_matrix_01.cc
+++ b/tests/simplex/get_projection_matrix_01.cc
@@ -36,7 +36,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class RightHandSideFunction : public Function<dim>

--- a/tests/simplex/mapping_01.cc
+++ b/tests/simplex/mapping_01.cc
@@ -31,7 +31,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class Position : public Function<dim>

--- a/tests/simplex/mapping_fe_01.cc
+++ b/tests/simplex/mapping_fe_01.cc
@@ -34,7 +34,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 void
 test(const unsigned int mapping_degree)

--- a/tests/simplex/mapping_fe_fields_01.cc
+++ b/tests/simplex/mapping_fe_fields_01.cc
@@ -38,7 +38,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 void
 test()

--- a/tests/simplex/mapping_fe_fields_02.cc
+++ b/tests/simplex/mapping_fe_fields_02.cc
@@ -38,7 +38,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class Solution : public Function<dim>

--- a/tests/simplex/mapping_transformations_01.cc
+++ b/tests/simplex/mapping_transformations_01.cc
@@ -34,7 +34,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 void
 make_grid(Triangulation<2> &triangulation)

--- a/tests/simplex/matrix_free_01.cc
+++ b/tests/simplex/matrix_free_01.cc
@@ -50,7 +50,6 @@
 
 #include "./simplex_grids.h"
 
-using namespace dealii;
 
 
 template <int dim>

--- a/tests/simplex/matrix_free_02.cc
+++ b/tests/simplex/matrix_free_02.cc
@@ -52,7 +52,6 @@
 
 #include "./simplex_grids.h"
 
-using namespace dealii;
 
 template <int dim>
 class PoissonOperator

--- a/tests/simplex/matrix_free_03.cc
+++ b/tests/simplex/matrix_free_03.cc
@@ -55,7 +55,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 const double PENALTY = 8;
 

--- a/tests/simplex/matrix_free_04.cc
+++ b/tests/simplex/matrix_free_04.cc
@@ -56,7 +56,6 @@
 
 #include "./simplex_grids.h"
 
-using namespace dealii;
 
 
 double

--- a/tests/simplex/matrix_free_face_integral_01.cc
+++ b/tests/simplex/matrix_free_face_integral_01.cc
@@ -45,7 +45,6 @@
 
 #include "./simplex_grids.h"
 
-using namespace dealii;
 
 
 template <int dim>

--- a/tests/simplex/matrix_free_range_iteration_01.cc
+++ b/tests/simplex/matrix_free_range_iteration_01.cc
@@ -35,7 +35,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/simplex/matrix_free_shape_info_01.cc
+++ b/tests/simplex/matrix_free_shape_info_01.cc
@@ -37,7 +37,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class ExactSolution : public Function<dim>

--- a/tests/simplex/nodal_type_quadrature_01.cc
+++ b/tests/simplex/nodal_type_quadrature_01.cc
@@ -21,7 +21,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/simplex/poisson_01.cc
+++ b/tests/simplex/poisson_01.cc
@@ -62,7 +62,6 @@
 
 #include "simplex_grids.h"
 
-using namespace dealii;
 
 template <int dim>
 struct Parameters

--- a/tests/simplex/poisson_02.cc
+++ b/tests/simplex/poisson_02.cc
@@ -62,7 +62,6 @@
 
 // #define HEX
 
-using namespace dealii;
 
 template <int dim>
 struct ScratchData

--- a/tests/simplex/polynomials_01.cc
+++ b/tests/simplex/polynomials_01.cc
@@ -23,7 +23,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/simplex/q_projection_01.cc
+++ b/tests/simplex/q_projection_01.cc
@@ -24,7 +24,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/simplex/quadrature_lib_01.cc
+++ b/tests/simplex/quadrature_lib_01.cc
@@ -21,7 +21,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/simplex/reference_cell_kind_01.cc
+++ b/tests/simplex/reference_cell_kind_01.cc
@@ -23,7 +23,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/simplex/step-01.cc
+++ b/tests/simplex/step-01.cc
@@ -33,7 +33,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 void
 first_grid()

--- a/tests/simplex/step-02.cc
+++ b/tests/simplex/step-02.cc
@@ -43,7 +43,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 void
 make_grid(Triangulation<2> &triangulation)

--- a/tests/simplex/step-03.cc
+++ b/tests/simplex/step-03.cc
@@ -60,7 +60,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class Step3

--- a/tests/simplex/step-04-data_out_faces.cc
+++ b/tests/simplex/step-04-data_out_faces.cc
@@ -59,7 +59,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <int dim>
 class Step4

--- a/tests/simplex/step-04.cc
+++ b/tests/simplex/step-04.cc
@@ -65,7 +65,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <int dim>
 class Step4

--- a/tests/simplex/step-06.cc
+++ b/tests/simplex/step-06.cc
@@ -77,9 +77,6 @@
 
 
 
-using namespace dealii;
-
-
 template <int dim>
 class Step6
 {

--- a/tests/simplex/step-07.cc
+++ b/tests/simplex/step-07.cc
@@ -72,7 +72,6 @@
 
 namespace Step7
 {
-  using namespace dealii;
 
 
   template <int dim>
@@ -696,7 +695,6 @@ main()
 
   try
     {
-      using namespace dealii;
       using namespace Step7;
 
       {

--- a/tests/simplex/step-08.cc
+++ b/tests/simplex/step-08.cc
@@ -66,7 +66,6 @@
 
 namespace Step8
 {
-  using namespace dealii;
 
   template <int dim>
   class ElasticProblem

--- a/tests/simplex/step-12a.cc
+++ b/tests/simplex/step-12a.cc
@@ -70,7 +70,6 @@
 
 namespace Step12
 {
-  using namespace dealii;
 
   template <int dim>
   class BoundaryValues : public Function<dim>

--- a/tests/simplex/step-17.cc
+++ b/tests/simplex/step-17.cc
@@ -81,7 +81,6 @@
 
 namespace Step17
 {
-  using namespace dealii;
 
   template <int dim>
   class ElasticProblem
@@ -456,7 +455,6 @@ main(int argc, char **argv)
 
   try
     {
-      using namespace dealii;
       using namespace Step17;
 
       ElasticProblem<2> elastic_problem;

--- a/tests/simplex/step-18.cc
+++ b/tests/simplex/step-18.cc
@@ -86,7 +86,6 @@ const unsigned int degree = 1;
 
 namespace Step18
 {
-  using namespace dealii;
 
   template <int dim>
   struct PointHistory
@@ -1022,7 +1021,6 @@ main(int argc, char **argv)
 
   try
     {
-      using namespace dealii;
       using namespace Step18;
 
       Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);

--- a/tests/simplex/step-20.cc
+++ b/tests/simplex/step-20.cc
@@ -68,7 +68,6 @@
 
 namespace Step20
 {
-  using namespace dealii;
 
   template <int dim>
   class MixedLaplaceProblem

--- a/tests/simplex/step-23.cc
+++ b/tests/simplex/step-23.cc
@@ -66,7 +66,6 @@ const unsigned int degree = 1;
 
 namespace Step23
 {
-  using namespace dealii;
 
   template <int dim>
   class WaveEquation
@@ -442,7 +441,6 @@ main(int argc, char **argv)
 
   try
     {
-      using namespace dealii;
       using namespace Step23;
 
       WaveEquation<2> wave_equation_solver;

--- a/tests/simplex/step-31.cc
+++ b/tests/simplex/step-31.cc
@@ -67,7 +67,6 @@
 
 namespace Step31
 {
-  using namespace dealii;
   namespace EquationData
   {
     constexpr double eta     = 1;
@@ -1085,7 +1084,6 @@ main(int argc, char *argv[])
 {
   try
     {
-      using namespace dealii;
       using namespace Step31;
       Utilities::MPI::MPI_InitFinalize mpi_initialization(
         argc, argv, numbers::invalid_unsigned_int);

--- a/tests/simplex/step-40.cc
+++ b/tests/simplex/step-40.cc
@@ -93,7 +93,6 @@ namespace LA
 
 namespace Step40
 {
-  using namespace dealii;
 
   template <int dim>
   class LaplaceProblem
@@ -413,7 +412,6 @@ main(int argc, char *argv[])
 
   try
     {
-      using namespace dealii;
       using namespace Step40;
 
 

--- a/tests/simplex/step-55.cc
+++ b/tests/simplex/step-55.cc
@@ -104,7 +104,6 @@ namespace LA
 
 namespace Step55
 {
-  using namespace dealii;
 
   // @sect3{Linear solvers and preconditioners}
 
@@ -903,7 +902,6 @@ main(int argc, char *argv[])
   mpi_initlog();
   try
     {
-      using namespace dealii;
       using namespace Step55;
 
 

--- a/tests/simplex/step-67.cc
+++ b/tests/simplex/step-67.cc
@@ -93,7 +93,6 @@
 
 namespace Euler_DG
 {
-  using namespace dealii;
 
   // Similarly to the other matrix-free tutorial programs, we collect all
   // parameters that control the execution of the program at the top of the
@@ -2515,7 +2514,6 @@ int
 main(int argc, char **argv)
 {
   using namespace Euler_DG;
-  using namespace dealii;
 
   // tests.h enables floating point exceptions in debug mode, here we disable
   // them to avoid division by zero when some cell lanes might not be occupied

--- a/tests/simplex/step-68.cc
+++ b/tests/simplex/step-68.cc
@@ -73,7 +73,6 @@
 
 namespace Step68
 {
-  using namespace dealii;
 
 
 
@@ -539,7 +538,6 @@ int
 main(int argc, char *argv[])
 {
   using namespace Step68;
-  using namespace dealii;
   Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
   initlog();

--- a/tests/simplex/step-74.cc
+++ b/tests/simplex/step-74.cc
@@ -66,7 +66,6 @@
 
 namespace Step74
 {
-  using namespace dealii;
 
   enum class Test_Case
   {
@@ -986,7 +985,6 @@ main()
 
   try
     {
-      using namespace dealii;
       using namespace Step74;
       Test_Case      test_case = Test_Case::l_singularity;
       SIPGLaplace<2> problem(test_case);

--- a/tests/simplex/unit_tangential_vectors_01.cc
+++ b/tests/simplex/unit_tangential_vectors_01.cc
@@ -24,7 +24,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/simplex/variable_face_quadratures_01.cc
+++ b/tests/simplex/variable_face_quadratures_01.cc
@@ -34,7 +34,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class Fu : public Function<dim>

--- a/tests/simplex/variable_face_quadratures_02.cc
+++ b/tests/simplex/variable_face_quadratures_02.cc
@@ -33,7 +33,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class Fu : public Function<dim>

--- a/tests/simplex/variable_face_quadratures_03.cc
+++ b/tests/simplex/variable_face_quadratures_03.cc
@@ -36,7 +36,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class Fu : public Function<dim>

--- a/tests/simplex/wedge_01.cc
+++ b/tests/simplex/wedge_01.cc
@@ -28,7 +28,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 void
 test_3()

--- a/tests/sparsity/flux_sparsity_pattern_visiting_once.cc
+++ b/tests/sparsity/flux_sparsity_pattern_visiting_once.cc
@@ -30,7 +30,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 Triangulation<dim>

--- a/tests/sundials/step-77.cc
+++ b/tests/sundials/step-77.cc
@@ -52,7 +52,6 @@
 
 namespace Step77
 {
-  using namespace dealii;
 
   template <int dim>
   class MinimalSurfaceProblem

--- a/tests/symengine/cse_01.cc
+++ b/tests/symengine/cse_01.cc
@@ -30,7 +30,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace SE = SymEngine;
 
 int

--- a/tests/symengine/cse_02.cc
+++ b/tests/symengine/cse_02.cc
@@ -30,7 +30,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace SE = SymEngine;
 
 int

--- a/tests/symengine/cse_04.cc
+++ b/tests/symengine/cse_04.cc
@@ -40,7 +40,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace SE = SymEngine;
 namespace SD = dealii::Differentiation::SD;
 

--- a/tests/symengine/cse_05.cc
+++ b/tests/symengine/cse_05.cc
@@ -31,7 +31,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace SD = dealii::Differentiation::SD;
 
 void

--- a/tests/symengine/sd_common_tests/batch_optimizer_02.h
+++ b/tests/symengine/sd_common_tests/batch_optimizer_02.h
@@ -27,7 +27,6 @@
 
 #include "utilities.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 
 template <typename NumberType,

--- a/tests/symengine/sd_common_tests/batch_optimizer_03.h
+++ b/tests/symengine/sd_common_tests/batch_optimizer_03.h
@@ -34,7 +34,6 @@
 
 #include "utilities.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 
 namespace Diff_Test

--- a/tests/symengine/sd_common_tests/batch_optimizer_04.h
+++ b/tests/symengine/sd_common_tests/batch_optimizer_04.h
@@ -22,7 +22,6 @@
 
 #include "serialization.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 
 template <int dim,

--- a/tests/symengine/sd_common_tests/batch_optimizer_05.h
+++ b/tests/symengine/sd_common_tests/batch_optimizer_05.h
@@ -29,7 +29,6 @@
 #include "serialization.h"
 #include "utilities.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 
 template <int dim,

--- a/tests/symengine/sd_common_tests/batch_optimizer_06.h
+++ b/tests/symengine/sd_common_tests/batch_optimizer_06.h
@@ -31,7 +31,6 @@
 #include "utilities.h"
 
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 
 template <int dim,

--- a/tests/symengine/sd_common_tests/batch_optimizer_08.h
+++ b/tests/symengine/sd_common_tests/batch_optimizer_08.h
@@ -20,7 +20,6 @@
 
 #include "../../tests.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 
 template <int dim,

--- a/tests/symengine/sd_common_tests/batch_optimizer_09.h
+++ b/tests/symengine/sd_common_tests/batch_optimizer_09.h
@@ -23,7 +23,6 @@
 
 #include "utilities.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 
 template <int dim,

--- a/tests/symengine/step-44-sd-quadrature_level_01.cc
+++ b/tests/symengine/step-44-sd-quadrature_level_01.cc
@@ -25,7 +25,6 @@
 
 namespace Step44
 {
-  using namespace dealii;
   namespace SD = Differentiation::SD;
 
   template <int dim>
@@ -302,7 +301,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  using namespace dealii;
   using namespace Step44;
   try
     {

--- a/tests/symengine/step-44-sd-quadrature_level_02.cc
+++ b/tests/symengine/step-44-sd-quadrature_level_02.cc
@@ -26,7 +26,6 @@
 
 namespace Step44
 {
-  using namespace dealii;
   namespace SD = Differentiation::SD;
 
   template <int dim>
@@ -319,7 +318,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  using namespace dealii;
   using namespace Step44;
   try
     {

--- a/tests/symengine/step-44-sd-quadrature_level_03.cc
+++ b/tests/symengine/step-44-sd-quadrature_level_03.cc
@@ -28,7 +28,6 @@
 
 namespace Step44
 {
-  using namespace dealii;
   namespace SD = Differentiation::SD;
 
   template <int dim>
@@ -320,7 +319,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  using namespace dealii;
   using namespace Step44;
   try
     {

--- a/tests/trilinos/step-77-with-nox.cc
+++ b/tests/trilinos/step-77-with-nox.cc
@@ -53,7 +53,6 @@
 
 namespace Step77
 {
-  using namespace dealii;
 
   template <int dim>
   class MinimalSurfaceProblem


### PR DESCRIPTION
We already do it in the `tests/tests.h` header, so there is no need to do it in the particular tests.
https://github.com/dealii/dealii/blob/20d2176d317137ec1b5c8fc1334cfef649765c14/tests/tests.h#L75-L77

I prepared the patch with the following command
``sed -i '/using namespace dealii;/d' `grep -r -l "../tests.h" *` ``