### PR TITLE
TpetraWrappers: fix various compiler warnings

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_sparse_matrix.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparse_matrix.templates.h
@@ -685,7 +685,7 @@ namespace LinearAlgebra
             {
               matrix->getLocalRowView(i, indices, values);
 
-              for (size_t j = 0; j < indices.size(); ++j)
+              for (size_type j = 0; j < indices.size(); ++j)
                 out << "(" << matrix->getRowMap()->getGlobalElement(i) << ","
                     << matrix->getColMap()->getGlobalElement(indices[j]) << ") "
                     << values[j] << std::endl;

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -1001,10 +1001,12 @@ namespace LinearAlgebra
 #  endif
 
           if (local_row != Teuchos::OrdinalTraits<int>::invalid())
-            if (nonlocal)
-              vector_1d_nonlocal(local_row) += values[i];
-            else
-              vector_1d_local(local_row) += values[i];
+            {
+              if (nonlocal)
+                vector_1d_nonlocal(local_row) += values[i];
+              else
+                vector_1d_local(local_row) += values[i];
+            }
         }
 
 #  if !DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -247,14 +247,16 @@ namespace LinearAlgebra
             vector->getMap()->getLocalElement(row);
 
 
+#  if DEAL_II_TRILINOS_VERSION_GTE(14, 0, 0)
           Assert(
             local_row != Teuchos::OrdinalTraits<int>::invalid(),
-#  if DEAL_II_TRILINOS_VERSION_GTE(14, 0, 0)
             ExcAccessToNonLocalElement(row,
                                        vector->getMap()->getLocalNumElements(),
                                        vector->getMap()->getMinLocalIndex(),
                                        vector->getMap()->getMaxLocalIndex()));
 #  else
+          Assert(
+            local_row != Teuchos::OrdinalTraits<int>::invalid(),
             ExcAccessToNonLocalElement(row,
                                        vector->getMap()->getNodeNumElements(),
                                        vector->getMap()->getMinLocalIndex(),

--- a/source/lac/trilinos_tpetra_sparsity_pattern.cc
+++ b/source/lac/trilinos_tpetra_sparsity_pattern.cc
@@ -831,6 +831,8 @@ namespace LinearAlgebra
 
       return static_cast<size_t>(local_col_index) != col_indices.size();
 #  else
+      (void)i;
+      (void)j;
       Assert(false, ExcNotImplemented());
       return false;
 #  endif


### PR DESCRIPTION
Fixes various compiler warnings triggered by gcc-9.4 on Ubuntu LTS 20.04

    - TpetraWrappers: fix signed unsigned comparison warning
    - TpetraWrappers: fix dangling else warning, fix embedded macro warning
    - TpetraWrappers: fix unused variable warning

In reference to #16491
