### PR TITLE
base/tensor.h: work around bogus compiler warning

### DIFF
--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1871,6 +1871,7 @@ Tensor<rank_, dim, Number>::unroll(const Iterator begin,
       // For rank-1 tensors, we can simply copy the current elements from
       // our linear array into the output range, and then return the
       // iterator moved forward by 'dim' elements:
+      (void)end;
       Assert(std::distance(begin, end) >= dim,
              ExcMessage(
                "The provided iterator range must contain at least 'dim' "


### PR DESCRIPTION
gcc-9.4 warnings loudly about an unused argument "end":

```
In file included from ../include/deal.II/base/symmetric_tensor.h:26,
                 from ../include/deal.II/base/array_view.h:23,
                 from ../source/base/tensor.cc:16:
../include/deal.II/base/tensor.h: In instantiation of 'void dealii::Tensor<rank_, dim, Number>::unroll(Iterator, Iterator) const [with Iterator = float*; int rank_ = 1; int dim = 1; Number = float]':
../include/deal.II/base/tensor.h:1736:11:   required from 'void dealii::Tensor<rank_, dim, Number>::unroll(Iterator, Iterator) const [with Iterator = float*; int rank_ = 2; int dim = 1; Number = float]'
../source/base/tensor.cc:52:5:   required from 'void dealii::{anonymous}::calculate_svd_in_place(dealii::Tensor<2, dim, Number>&, dealii::Tensor<2, dim, Number>&) [with int dim = 1; Number = float]'
../source/base/tensor.cc:85:25:   required from 'dealii::Tensor<2, dim, Number> dealii::project_onto_orthogonal_tensors(const dealii::Tensor<2, dim, Number>&) [with int dim = 1; Number = float]'
../source/base/tensor.cc:92:60:   required from here
../include/deal.II/base/tensor.h:1728:51: warning: parameter 'end' set but not used [-Wunused-but-set-parameter]
 1728 |                                    const Iterator end) const
      |
```

This is of course bogus, the compiler simply lost track of the `if constexpr(...)` branch. This is fixed in later gcc versions. Let's simply use the usual `(void)parameter` strategy to make gcc-9.4 happy.

<s>In reference to #16491 (for tracking purposes).</s>
Closes #16491