### PR TITLE
Disable DEAL_II(_CXX23)_ASSUME macro for now

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -155,6 +155,17 @@
 #cmakedefine DEAL_II_HAVE_CXX20
 #cmakedefine DEAL_II_HAVE_CXX23
 
+#cmakedefine DEAL_II_HAVE_FP_EXCEPTIONS
+#cmakedefine DEAL_II_HAVE_COMPLEX_OPERATOR_OVERLOADS
+#cmakedefine DEAL_II_HAVE_CXX17_BESSEL_FUNCTIONS
+#cmakedefine DEAL_II_CXX14_CONSTEXPR_BUG
+
+// The following three are defined for backwards compatibility with older
+// deal.II versions:
+#define DEAL_II_WITH_CXX11
+#define DEAL_II_WITH_CXX14
+#define DEAL_II_WITH_CXX17
+
 /**
  * If we have C++20 available, we can have concepts and requires
  * clauses. We want to avoid using too many `#ifdef` statements, so
@@ -167,10 +178,33 @@
 #  define DEAL_II_CXX20_REQUIRES(condition)
 #endif
 
-#cmakedefine DEAL_II_HAVE_FP_EXCEPTIONS
-#cmakedefine DEAL_II_HAVE_COMPLEX_OPERATOR_OVERLOADS
-#cmakedefine DEAL_II_HAVE_CXX17_BESSEL_FUNCTIONS
-#cmakedefine DEAL_II_CXX14_CONSTEXPR_BUG
+/**
+ * Provide support for the C++23 [[assume]] attribute. To mimic the
+ * attribute for older standards we rely on compiler intrinsics when
+ * available.
+ */
+#if defined(__clang__)
+#  define DEAL_II_ASSUME(expr) __builtin_assume(static_cast<bool>(expr))
+#elif defined(__GNUC__) && !defined(__ICC) && __GNUC__ >= 13
+#  define DEAL_II_ASSUME(expr)                                         \
+    do                                                                 \
+      {                                                                \
+        _Pragma("GCC diagnostic push")                                 \
+          _Pragma("GCC diagnostic ignored \"-Wimplicit-fallthrough\"") \
+            [[assume(expr)]];                                          \
+        _Pragma("GCC diagnostic pop")                                  \
+      }                                                                \
+    while (false)
+#elif defined(_MSC_VER) || defined(__ICC)
+#  define DEAL_II_ASSUME(expr) __assume(expr);
+#else
+/* no way with GCC to express this without evaluating 'expr' */
+#  define DEAL_II_ASSUME(expr) \
+    do                         \
+      {                        \
+      }                        \
+    while (false)
+#endif
 
 /**
  * Macro indicating that the current feature will be removed in a future
@@ -206,11 +240,6 @@
 
 #cmakedefine DEAL_II_FALLTHROUGH @DEAL_II_FALLTHROUGH@
 #cmakedefine DEAL_II_CONSTEXPR @DEAL_II_CONSTEXPR@
-
-// The following three are defined for backwards compatibility with older deal.II versions:
-#define DEAL_II_WITH_CXX11
-#define DEAL_II_WITH_CXX14
-#define DEAL_II_WITH_CXX17
 
 
 /***********************************************************************

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -184,9 +184,9 @@
  * available.
  */
 #if defined(__clang__)
-#  define DEAL_II_ASSUME(expr) __builtin_assume(static_cast<bool>(expr))
+#  define DEAL_II_CXX23_ASSUME(expr) __builtin_assume(static_cast<bool>(expr))
 #elif defined(__GNUC__) && !defined(__ICC) && __GNUC__ >= 13
-#  define DEAL_II_ASSUME(expr)                                         \
+#  define DEAL_II_CXX23_ASSUME(expr)                                   \
     do                                                                 \
       {                                                                \
         _Pragma("GCC diagnostic push")                                 \
@@ -196,13 +196,13 @@
       }                                                                \
     while (false)
 #elif defined(_MSC_VER) || defined(__ICC)
-#  define DEAL_II_ASSUME(expr) __assume(expr);
+#  define DEAL_II_CXX23_ASSUME(expr) __assume(expr);
 #else
 /* no way with GCC to express this without evaluating 'expr' */
-#  define DEAL_II_ASSUME(expr) \
-    do                         \
-      {                        \
-      }                        \
+#  define DEAL_II_CXX23_ASSUME(expr) \
+    do                               \
+      {                              \
+      }                              \
     while (false)
 #endif
 

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -183,22 +183,31 @@
  * attribute for older standards we rely on compiler intrinsics when
  * available.
  */
-#if defined(__clang__)
-#  define DEAL_II_CXX23_ASSUME(expr) __builtin_assume(static_cast<bool>(expr))
-#elif defined(__GNUC__) && !defined(__ICC) && __GNUC__ >= 13
-#  define DEAL_II_CXX23_ASSUME(expr)                                   \
-    do                                                                 \
-      {                                                                \
-        _Pragma("GCC diagnostic push")                                 \
-          _Pragma("GCC diagnostic ignored \"-Wimplicit-fallthrough\"") \
-            [[assume(expr)]];                                          \
-        _Pragma("GCC diagnostic pop")                                  \
-      }                                                                \
-    while (false)
-#elif defined(_MSC_VER) || defined(__ICC)
-#  define DEAL_II_CXX23_ASSUME(expr) __assume(expr);
-#else
+#ifdef DEAL_II_EXPERIMENTAL_ASSUME
+#  error "Test"
+#  if defined(__clang__)
+#    define DEAL_II_CXX23_ASSUME(expr) __builtin_assume(static_cast<bool>(expr))
+#  elif defined(__GNUC__) && !defined(__ICC) && __GNUC__ >= 13
+#    define DEAL_II_CXX23_ASSUME(expr)                                   \
+      do                                                                 \
+        {                                                                \
+          _Pragma("GCC diagnostic push")                                 \
+            _Pragma("GCC diagnostic ignored \"-Wimplicit-fallthrough\"") \
+              [[assume(expr)]];                                          \
+          _Pragma("GCC diagnostic pop")                                  \
+        }                                                                \
+      while (false)
+#  elif defined(_MSC_VER) || defined(__ICC)
+#    define DEAL_II_CXX23_ASSUME(expr) __assume(expr);
+#  else
 /* no way with GCC to express this without evaluating 'expr' */
+#    define DEAL_II_CXX23_ASSUME(expr) \
+      do                               \
+        {                              \
+        }                              \
+      while (false)
+#  endif
+#else
 #  define DEAL_II_CXX23_ASSUME(expr) \
     do                               \
       {                              \

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1519,38 +1519,6 @@ namespace deal_II_exceptions
 } /*namespace deal_II_exceptions*/
 
 
-#if defined(__clang__)
-#  define DEAL_II_ASSUME(expr) __builtin_assume(static_cast<bool>(expr))
-#elif defined(__GNUC__) && !defined(__ICC)
-#  if __GNUC__ >= 13
-#    define DEAL_II_ASSUME(expr)                                         \
-      do                                                                 \
-        {                                                                \
-          _Pragma("GCC diagnostic push")                                 \
-            _Pragma("GCC diagnostic ignored \"-Wimplicit-fallthrough\"") \
-              [[assume(expr)]];                                          \
-          _Pragma("GCC diagnostic pop")                                  \
-        }                                                                \
-      while (false)
-#  else
-/* no way with GCC to express this without evaluating 'expr' */
-#    define DEAL_II_ASSUME(expr) \
-      do                         \
-        {                        \
-        }                        \
-      while (false)
-#  endif
-#elif defined(_MSC_VER) || defined(__ICC)
-#  define DEAL_II_ASSUME(expr) __assume(expr);
-#else
-#  define DEAL_II_ASSUME(expr) \
-    do                         \
-      {                        \
-      }                        \
-    while (false)
-#endif
-
-
 /**
  * A macro that serves as the main routine in the exception mechanism for debug
  * mode error checking. It asserts that a certain condition is fulfilled,

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1637,7 +1637,7 @@ namespace deal_II_exceptions
 #    endif /*ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST*/
 #  endif   /*KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST*/
 #else      /*ifdef DEBUG*/
-#  define Assert(cond, exc) DEAL_II_ASSUME(cond)
+#  define Assert(cond, exc) DEAL_II_CXX23_ASSUME(cond)
 #endif /*ifdef DEBUG*/
 
 
@@ -1689,7 +1689,7 @@ namespace deal_II_exceptions
       while (false)
 #  endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 #else
-#  define AssertNothrow(cond, exc) DEAL_II_ASSUME(cond)
+#  define AssertNothrow(cond, exc) DEAL_II_CXX23_ASSUME(cond)
 #endif
 
 /**


### PR DESCRIPTION
Let us disable the DEAL_II_CXX23_ASSUME macro for now.

While at it, this pull request contains some small refactoring that makes the
macro more consistent with other language features we support such as
DEAL_II_CXX20_REQUIRES.

@masterleinad @bangerth Currently, this PR simply disables the macro
altogether. I am contemplating to move part of the logic to CMake in a
follow-up PR. In particular when we have an idea how to check for a sane
compiler.

- config.h: for consistency move DEAL_II_ASSUME macro to config.h.in
- config.h: for consistency rename DEAL_II_ASSUME to DEAL_II_CXX23_ASSUME
- config.h: disable DEAL_II_CXX23_ASSUME for now

In reference to #16463
