### PR TITLE
Use p[index] instead of p(index) for class Point in tests/.

### DIFF
--- a/tests/aniso/up_and_down.cc
+++ b/tests/aniso/up_and_down.cc
@@ -55,11 +55,11 @@ transform(const Point<dim> p)
       case 1:
         return p;
       case 2:
-        return Point<dim>(p(0) * (1 + p(1)), p(1) * (1 + p(0)));
+        return Point<dim>(p[0] * (1 + p[1]), p[1] * (1 + p[0]));
       case 3:
-        return Point<dim>(p(0) * (1 + p(1)) * (1 + p(2)),
-                          p(1) * (1 + p(0)) * (1 + p(2)),
-                          p(2) * (1 + p(0)) * (1 + p(1)));
+        return Point<dim>(p[0] * (1 + p[1]) * (1 + p[2]),
+                          p[1] * (1 + p[0]) * (1 + p[2]),
+                          p[2] * (1 + p[0]) * (1 + p[1]));
       default:
         AssertThrow(false, ExcNotImplemented());
         return Point<dim>();

--- a/tests/base/auto_derivative_function.cc
+++ b/tests/base/auto_derivative_function.cc
@@ -62,7 +62,7 @@ template <int dim>
 double
 AutoSinExp<dim>::value(const Point<dim> &p, const unsigned int) const
 {
-  return std::sin(2 * p(0)) * std::exp(3 * p(1));
+  return std::sin(2 * p[0]) * std::exp(3 * p[1]);
 }
 
 
@@ -102,8 +102,8 @@ Tensor<1, dim>
 ExactSinExp<dim>::gradient(const Point<dim> &p, const unsigned int) const
 {
   Tensor<1, dim> grad;
-  grad[0] = 2 * std::cos(2 * p(0)) * std::exp(3 * p(1));
-  grad[1] = 3 * std::sin(2 * p(0)) * std::exp(3 * p(1));
+  grad[0] = 2 * std::cos(2 * p[0]) * std::exp(3 * p[1]);
+  grad[1] = 3 * std::sin(2 * p[0]) * std::exp(3 * p[1]);
   return grad;
 }
 

--- a/tests/base/function_derivative.cc
+++ b/tests/base/function_derivative.cc
@@ -116,7 +116,7 @@ check_sine(unsigned int nquad)
 
   Point<dim> wave_vector;
   for (unsigned int d = 0; d < dim; ++d)
-    wave_vector(d) = d + 2.;
+    wave_vector[d] = d + 2.;
 
   Functions::FourierSineFunction<dim> f(wave_vector);
 
@@ -131,7 +131,7 @@ check_sine(unsigned int nquad)
     {
       deallog << "Direction " << d << std::endl;
       Point<dim> dir;
-      dir(d) = 1.;
+      dir[d] = 1.;
       deallog.push("Euler");
       FunctionDerivative<dim> df(f, dir, 1.e-4);
       check_derivative_order(gradients, df, quadrature, d, 2);

--- a/tests/base/functions_04.cc
+++ b/tests/base/functions_04.cc
@@ -50,11 +50,11 @@ check_function(const Functions::FlowFunction<dim> &f,
       for (unsigned int ix = 0; ix < 2; ++ix)
         {
           if (dim > 0)
-            patches[0].vertices[vertex_number](0) = -1. + 2. * ix;
+            patches[0].vertices[vertex_number][0] = -1. + 2. * ix;
           if (dim > 1)
-            patches[0].vertices[vertex_number](1) = -1. + 2. * iy;
+            patches[0].vertices[vertex_number][1] = -1. + 2. * iy;
           if (dim > 2)
-            patches[0].vertices[vertex_number](2) = -1. + 2. * iz;
+            patches[0].vertices[vertex_number][2] = -1. + 2. * iz;
           ++vertex_number;
         }
   for (const unsigned int i : GeometryInfo<dim>::face_indices())
@@ -78,11 +78,11 @@ check_function(const Functions::FlowFunction<dim> &f,
       for (unsigned int ix = 0; ix <= sub; ++ix)
         {
           if (dim > 0)
-            points[vertex_number](0) = -1. + ix * h;
+            points[vertex_number][0] = -1. + ix * h;
           if (dim > 1)
-            points[vertex_number](1) = -1. + iy * h;
+            points[vertex_number][1] = -1. + iy * h;
           if (dim > 2)
-            points[vertex_number](2) = -1. + iz * h;
+            points[vertex_number][2] = -1. + iz * h;
           ++vertex_number;
         }
 

--- a/tests/base/functions_09.cc
+++ b/tests/base/functions_09.cc
@@ -91,7 +91,7 @@ check()
 
   Point<dim> point;
   for (int i = 0; i < dim; ++i)
-    point(i) = i;
+    point[i] = i;
 
   deallog << "->value:" << std::endl;
   PrintTensor<rank, dim>::print_tensor(foo->value(point));
@@ -106,7 +106,7 @@ check()
   points.push_back(point);
 
   for (int i = 0; i < dim; ++i)
-    point(i) = dim - i;
+    point[i] = dim - i;
   points.push_back(point);
 
   std::vector<Tensor<rank, dim>>     tensors;

--- a/tests/base/kokkos_point.cc
+++ b/tests/base/kokkos_point.cc
@@ -55,9 +55,9 @@ test_gpu()
       auto p_3 = Point<dim, Number>::unit_vector(0);
       check[3] = p_3.norm_square();
 
-      auto entry_1 = p_1(0);
+      auto entry_1 = p_1[0];
       check[4]     = entry_1;
-      p_1(0)       = Number{1.};
+      p_1[0]       = Number{1.};
       check[5]     = p_1.norm_square();
       auto p_4     = p_1 + Tensor<1, dim, Number>{};
       check[6]     = p_4.norm_square();

--- a/tests/base/point_01.cc
+++ b/tests/base/point_01.cc
@@ -32,7 +32,7 @@ check()
     p[i] = i;
 
   for (unsigned int i = 0; i < dim; ++i)
-    deallog << p(i) << ' ';
+    deallog << p[i] << ' ';
   deallog << std::endl;
 }
 

--- a/tests/base/point_04.cc
+++ b/tests/base/point_04.cc
@@ -34,7 +34,7 @@ check3d()
   Point<3> p(point);
 
   for (unsigned int i = 0; i < 3; ++i)
-    deallog << p(i) << ' ';
+    deallog << p[i] << ' ';
   deallog << std::endl;
 }
 
@@ -46,7 +46,7 @@ check2d()
   Point<2> p(point);
 
   for (unsigned int i = 0; i < 2; ++i)
-    deallog << p(i) << ' ';
+    deallog << p[i] << ' ';
   deallog << std::endl;
 }
 
@@ -57,7 +57,7 @@ check1d()
 
   Point<1> p(point);
 
-  deallog << p(0) << ' ';
+  deallog << p[0] << ' ';
   deallog << std::endl;
 }
 

--- a/tests/base/point_05.cc
+++ b/tests/base/point_05.cc
@@ -42,19 +42,19 @@ check()
 
 
     for (unsigned int i = 0; i < dim; ++i)
-      deallog << p_float(i) << ' ';
+      deallog << p_float[i] << ' ';
     deallog << std::endl;
 
     for (unsigned int i = 0; i < dim; ++i)
-      deallog << p_double(i) << ' ';
+      deallog << p_double[i] << ' ';
     deallog << std::endl;
 
     for (unsigned int i = 0; i < dim; ++i)
-      deallog << p_complex_float(i) << ' ';
+      deallog << p_complex_float[i] << ' ';
     deallog << std::endl;
 
     for (unsigned int i = 0; i < dim; ++i)
-      deallog << p_complex_double(i) << ' ';
+      deallog << p_complex_double[i] << ' ';
     deallog << std::endl;
   }
 
@@ -70,15 +70,15 @@ check()
     p_complex_double = p_double;
 
     for (unsigned int i = 0; i < dim; ++i)
-      deallog << p_double(i) << ' ';
+      deallog << p_double[i] << ' ';
     deallog << std::endl;
 
     for (unsigned int i = 0; i < dim; ++i)
-      deallog << p_complex_float(i) << ' ';
+      deallog << p_complex_float[i] << ' ';
     deallog << std::endl;
 
     for (unsigned int i = 0; i < dim; ++i)
-      deallog << p_complex_double(i) << ' ';
+      deallog << p_complex_double[i] << ' ';
     deallog << std::endl;
   }
 }

--- a/tests/base/point_constexpr.cc
+++ b/tests/base/point_constexpr.cc
@@ -24,7 +24,7 @@
 template <int dim>
 constexpr bool val =
   Point<dim>((Point<dim>::unit_vector(0) + Point<dim>::unit_vector(0)) -
-             2. * Point<dim>::unit_vector(0))(0) == 0.;
+             2. * Point<dim>::unit_vector(0))[0] == 0.;
 
 
 int

--- a/tests/base/polynomial1d.cc
+++ b/tests/base/polynomial1d.cc
@@ -38,7 +38,7 @@ scalar_product(const Polynomial<double> &p1, const Polynomial<double> &p2)
   double sum = 0.;
   for (unsigned int i = 0; i < gauss.size(); ++i)
     {
-      double x  = gauss.point(i)(0);
+      double x  = gauss.point(i)[0];
       double P1 = p1.value(x);
       double P2 = p2.value(x);
       sum += gauss.weight(i) * P1 * P2;

--- a/tests/base/polynomial_lagrange.cc
+++ b/tests/base/polynomial_lagrange.cc
@@ -33,7 +33,7 @@ check_interpolation(const std::vector<Polynomial<double>> &p,
       for (unsigned int k = 0; k < x.size(); ++k)
         {
           deallog << '.';
-          const double y = p[i].value(x[k](0));
+          const double y = p[i].value(x[k][0]);
           if (i == k)
             {
               if (std::fabs(y - 1.) > 2.e-10)
@@ -71,7 +71,7 @@ check_lge(unsigned int n)
   std::vector<Point<1>> x(n + 1);
   const double          h = 1. / n;
   for (unsigned int i = 0; i <= n; ++i)
-    x[i](0) = h * i;
+    x[i][0] = h * i;
   check_interpolation(p, x);
 }
 

--- a/tests/base/polynomial_lagrange_order.cc
+++ b/tests/base/polynomial_lagrange_order.cc
@@ -37,7 +37,7 @@ check_interpolation(const std::vector<Polynomial<double>> &p,
       for (unsigned int k = 0; k < x.size(); ++k)
         {
           deallog << '.';
-          const double y = p[i].value(x[k](0));
+          const double y = p[i].value(x[k][0]);
           if (i == k)
             {
               if (std::fabs(y - 1.) > 1e-13)
@@ -103,7 +103,7 @@ check_lge(unsigned int n)
   std::vector<Point<1>> x(n + 1);
   const double          h = 1. / n;
   for (unsigned int i = 0; i <= n; ++i)
-    x[i](0) = h * i;
+    x[i][0] = h * i;
   check_interpolation(p, x);
   check_constant(p);
   deallog << std::endl;

--- a/tests/base/polynomials_tensor.cc
+++ b/tests/base/polynomials_tensor.cc
@@ -65,10 +65,10 @@ check_bdm()
   PolynomialsBDM<dim> p3(3);
   PolynomialsBDM<dim> p4(4);
 
-  x(0) = 2.;
-  x(1) = 3.;
+  x[0] = 2.;
+  x[1] = 3.;
   if (dim > 2)
-    x(2) = 4;
+    x[2] = 4;
 
   check_point(x, p1);
   check_point(x, p2);
@@ -87,10 +87,10 @@ check_rt()
   PolynomialsRaviartThomas<dim> p2(2);
   PolynomialsRaviartThomas<dim> p3(3);
 
-  x(0) = 2.;
-  x(1) = 3.;
+  x[0] = 2.;
+  x[1] = 3.;
   if (dim > 2)
-    x(2) = 4;
+    x[2] = 4;
 
   check_point(x, p0);
   check_point(x, p1);

--- a/tests/base/qprojector.cc
+++ b/tests/base/qprojector.cc
@@ -30,17 +30,17 @@ check_line(Quadrature<1> &quadrature)
 {
   Point<dim> p1;
   Point<dim> p2;
-  p1(0) = 1.;
-  p2(0) = 7.;
+  p1[0] = 1.;
+  p2[0] = 7.;
   if (dim > 1)
     {
-      p1(1) = 3;
-      p2(1) = -5.;
+      p1[1] = 3;
+      p2[1] = -5.;
     }
   if (dim > 2)
     {
-      p1(2) = 0;
-      p2(2) = 10.;
+      p1[2] = 0;
+      p2[2] = 10.;
     }
   Quadrature<dim> q = QProjector<dim>::project_to_line(
     ReferenceCells::get_hypercube<dim>(), quadrature, p1, p2);

--- a/tests/base/quadrature_chebyshev.cc
+++ b/tests/base/quadrature_chebyshev.cc
@@ -113,7 +113,7 @@ check_quadrature(double *exact_monomials)
           long double f = 1.;
           for (unsigned int x = 0; x < quadrature.size(); ++x)
             {
-              f = std::pow(static_cast<long double>(points[x](0)), i * 1.0L);
+              f = std::pow(static_cast<long double>(points[x][0]), i * 1.0L);
               quadrature_int += f * static_cast<long double>(weights[x]);
             }
           err = std::fabs(quadrature_int - exact_monomials[i]);
@@ -150,7 +150,7 @@ check_GRC_right(double *exact_monomials)
           long double f = 1.;
           for (unsigned int x = 0; x < quadrature.size(); ++x)
             {
-              f = std::pow(static_cast<long double>(points[x](0)), i * 1.0L);
+              f = std::pow(static_cast<long double>(points[x][0]), i * 1.0L);
               quadrature_int += f * static_cast<long double>(weights[x]);
             }
           err = std::fabs(quadrature_int - exact_monomials[i]);

--- a/tests/base/quadrature_sorted_test.cc
+++ b/tests/base/quadrature_sorted_test.cc
@@ -79,11 +79,11 @@ check_cells(std::vector<Quadrature<dim> *> &quadratures)
               switch (dim)
                 {
                   case 3:
-                    f *= std::pow(static_cast<double>(points[x](2)), i * 1.0);
+                    f *= std::pow(static_cast<double>(points[x][2]), i * 1.0);
                   case 2:
-                    f *= std::pow(static_cast<double>(points[x](1)), i * 1.0);
+                    f *= std::pow(static_cast<double>(points[x][1]), i * 1.0);
                   case 1:
-                    f *= std::pow(static_cast<double>(points[x](0)), i * 1.0);
+                    f *= std::pow(static_cast<double>(points[x][0]), i * 1.0);
                 }
               quadrature_int += f * weights[x];
             }
@@ -142,11 +142,11 @@ check_faces(const std::vector<Quadrature<dim - 1> *> &quadratures,
               switch (dim)
                 {
                   case 3:
-                    f *= std::pow((long double)points[x](2), i * 1.0L);
+                    f *= std::pow((long double)points[x][2], i * 1.0L);
                   case 2:
-                    f *= std::pow((long double)points[x](1), i * 1.0L);
+                    f *= std::pow((long double)points[x][1], i * 1.0L);
                   case 1:
-                    f *= std::pow((long double)points[x](0), i * 1.0L);
+                    f *= std::pow((long double)points[x][0], i * 1.0L);
                 }
               quadrature_int += f * weights[x];
             }

--- a/tests/base/quadrature_test.cc
+++ b/tests/base/quadrature_test.cc
@@ -85,11 +85,11 @@ check_cells(std::vector<Quadrature<dim> *> &quadratures)
               switch (dim)
                 {
                   case 3:
-                    f *= std::pow(static_cast<double>(points[x](2)), i * 1.0);
+                    f *= std::pow(static_cast<double>(points[x][2]), i * 1.0);
                   case 2:
-                    f *= std::pow(static_cast<double>(points[x](1)), i * 1.0);
+                    f *= std::pow(static_cast<double>(points[x][1]), i * 1.0);
                   case 1:
-                    f *= std::pow(static_cast<double>(points[x](0)), i * 1.0);
+                    f *= std::pow(static_cast<double>(points[x][0]), i * 1.0);
                 }
               quadrature_int += f * weights[x];
             }
@@ -110,7 +110,7 @@ check_cells(std::vector<Quadrature<dim> *> &quadratures)
           bool in_order = true;
           for (unsigned int x = 1; x < quadrature.size(); ++x)
             {
-              if (points[x](0) <= points[x - 1](0))
+              if (points[x][0] <= points[x - 1][0])
                 in_order = false;
             }
           if (!in_order)
@@ -163,11 +163,11 @@ check_faces(const std::vector<Quadrature<dim - 1> *> &quadratures,
               switch (dim)
                 {
                   case 3:
-                    f *= std::pow((long double)points[x](2), i * 1.0L);
+                    f *= std::pow((long double)points[x][2], i * 1.0L);
                   case 2:
-                    f *= std::pow((long double)points[x](1), i * 1.0L);
+                    f *= std::pow((long double)points[x][1], i * 1.0L);
                   case 1:
-                    f *= std::pow((long double)points[x](0), i * 1.0L);
+                    f *= std::pow((long double)points[x][0], i * 1.0L);
                 }
               quadrature_int += f * weights[x];
             }

--- a/tests/bits/anna_4.cc
+++ b/tests/bits/anna_4.cc
@@ -72,7 +72,7 @@ VectorBoundaryValues<dim>::vector_value(const Point<dim> &p,
   Assert(values.size() == 2, ExcDimensionMismatch(values.size(), 2));
 
   for (unsigned int i = 0; i < 2; ++i)
-    values(i) = p(i) * p(i);
+    values(i) = p[i] * p[i];
 }
 
 

--- a/tests/bits/christian_1.cc
+++ b/tests/bits/christian_1.cc
@@ -108,7 +108,7 @@ public:
   virtual double
   value(const Point<2> &p, const unsigned int) const
   {
-    return std::sin(3.14159 * p(0)) * std::sin(3.14159 * p(1));
+    return std::sin(3.14159 * p[0]) * std::sin(3.14159 * p[1]);
   }
 };
 

--- a/tests/bits/cone_04.cc
+++ b/tests/bits/cone_04.cc
@@ -48,7 +48,7 @@ check()
                ++v)
             {
               const Point<dim>     vertex = face->vertex(v);
-              const Tensor<1, dim> tangent_1({-vertex(2), 0., vertex(0)});
+              const Tensor<1, dim> tangent_1({-vertex[2], 0., vertex[0]});
               const Tensor<1, dim> tangent_2 = vertex - Point<dim>(0, 3, 0);
 
               // get the normal vector and test it

--- a/tests/bits/denis_1.cc
+++ b/tests/bits/denis_1.cc
@@ -51,8 +51,8 @@ public:
   {
     double delta = 0.05;
     double x, y, r;
-    x = p(0);
-    y = p(1);
+    x = p[0];
+    y = p[1];
     r = std::sqrt(x * x + y * y);
     return 0.5 * (1 - std::tanh((r - 0.5) / (2 * M_SQRT2 * delta)));
   }

--- a/tests/bits/error_estimator_01.cc
+++ b/tests/bits/error_estimator_01.cc
@@ -106,7 +106,7 @@ make_mesh(Triangulation<dim> &tria)
     {
       unsigned int subdomain = 0;
       for (unsigned int d = 0; d < dim; ++d)
-        if (cell->center()(d) > 0)
+        if (cell->center()[d] > 0)
           subdomain |= (1 << d);
       AssertThrow(subdomain < (1 << dim), ExcInternalError());
 

--- a/tests/bits/error_estimator_02.cc
+++ b/tests/bits/error_estimator_02.cc
@@ -106,7 +106,7 @@ make_mesh(Triangulation<dim> &tria)
     {
       unsigned int material = 0;
       for (unsigned int d = 0; d < dim; ++d)
-        if (cell->center()(d) > 0)
+        if (cell->center()[d] > 0)
           material |= (1 << d);
       AssertThrow(material < (1 << dim), ExcInternalError());
 

--- a/tests/bits/fe_q_constraints.cc
+++ b/tests/bits/fe_q_constraints.cc
@@ -86,9 +86,9 @@ double
 TestFunction<dim>::value(const Point<dim> &p,
                          const unsigned int /*component*/) const
 {
-  double val = base[0].value(p(0));
+  double val = base[0].value(p[0]);
   for (unsigned int i = 1; i < dim; ++i)
-    val *= base[i].value(p(i));
+    val *= base[i].value(p[i]);
   return val;
 }
 

--- a/tests/bits/find_cell_10.cc
+++ b/tests/bits/find_cell_10.cc
@@ -96,8 +96,8 @@ test()
   grid_in1.read_msh(input_file1);
 
   Point<2> ePos;
-  ePos(0) = 0.0653630060373507487669897386695;
-  ePos(1) = 1125.59175030825804242340382189;
+  ePos[0] = 0.0653630060373507487669897386695;
+  ePos[1] = 1125.59175030825804242340382189;
 
   MappingQ<2>  mapping(1);
   MappingQ<2> &mapping2 = StaticMappingQ1<2>::mapping;

--- a/tests/bits/find_cell_10a.cc
+++ b/tests/bits/find_cell_10a.cc
@@ -84,8 +84,8 @@ test()
   deallog.precision(16);
 
   Point<2> ePos;
-  ePos(0) = 0.0653630060373507487669897386695;
-  ePos(1) = 1125.59175030825804242340382189;
+  ePos[0] = 0.0653630060373507487669897386695;
+  ePos[1] = 1125.59175030825804242340382189;
 
   MappingQ<2>  mapping(1);
   MappingQ<2> &mapping2 = StaticMappingQ1<2>::mapping;

--- a/tests/bits/find_cell_11.cc
+++ b/tests/bits/find_cell_11.cc
@@ -51,8 +51,8 @@ test()
   GridGenerator::hyper_cube(tr);
 
   Point<2> p;
-  p(0) = -0.1;
-  p(1) = 0.5;
+  p[0] = -0.1;
+  p[1] = 0.5;
 
   MappingQ<2> mapping(1);
 

--- a/tests/bits/find_cell_12.cc
+++ b/tests/bits/find_cell_12.cc
@@ -64,7 +64,7 @@ test()
   for (; cell != endc; ++cell)
     {
       Point<2> cell_center = cell->center();
-      if (std::abs(cell_center(0) - 1500) < 550)
+      if (std::abs(cell_center[0] - 1500) < 550)
         {
           cell->set_refine_flag();
         }

--- a/tests/bits/periodicity_06.cc
+++ b/tests/bits/periodicity_06.cc
@@ -128,8 +128,8 @@ public:
   value(const Point<dim> &p, const unsigned int component = 0) const override
   {
     if (dim == 3)
-      return std::sin(p(0) + 1.) * std::sin(p(1) + 2.) * std::sin(p(2) + 3.);
-    return std::sin(p(0) + 1.) * std::sin(p(1) + 2.);
+      return std::sin(p[0] + 1.) * std::sin(p[1] + 2.) * std::sin(p[2] + 3.);
+    return std::sin(p[0] + 1.) * std::sin(p[1] + 2.);
   }
 };
 
@@ -164,11 +164,11 @@ check_periodicity(const DoFHandler<2> &dof_handler,
       Vector<double> value2(1);
 
       Point<2> point1;
-      point1(0) = -numbers::PI + 2. * i / n_points + eps;
-      point1(1) = -numbers::PI;
+      point1[0] = -numbers::PI + 2. * i / n_points + eps;
+      point1[1] = -numbers::PI;
       Point<2> point2;
-      point2(0) = -numbers::PI + 2. * i / n_points + eps;
-      point2(1) = numbers::PI;
+      point2[0] = -numbers::PI + 2. * i / n_points + eps;
+      point2[1] = numbers::PI;
 
       VectorTools::point_value(dof_handler, solution, point1, value1);
       VectorTools::point_value(dof_handler, solution, point2, value2);
@@ -193,11 +193,11 @@ check_periodicity(const DoFHandler<2> &dof_handler,
       Vector<double> value2(1);
 
       Point<2> point1;
-      point1(1) = -numbers::PI + 2. * i / n_points + eps;
-      point1(0) = -numbers::PI;
+      point1[1] = -numbers::PI + 2. * i / n_points + eps;
+      point1[0] = -numbers::PI;
       Point<2> point2;
-      point2(1) = -numbers::PI + 2. * i / n_points + eps;
-      point2(0) = numbers::PI;
+      point2[1] = -numbers::PI + 2. * i / n_points + eps;
+      point2[0] = numbers::PI;
 
       VectorTools::point_value(dof_handler, solution, point1, value1);
       VectorTools::point_value(dof_handler, solution, point2, value2);

--- a/tests/bits/periodicity_07.cc
+++ b/tests/bits/periodicity_07.cc
@@ -117,8 +117,8 @@ public:
   value(const Point<dim> &p, const unsigned int component = 0) const override
   {
     if (dim == 3)
-      return std::sin(p(0) + 1.) * std::sin(p(1) + 2.) * std::sin(p(2) + 3.);
-    return std::sin(p(0) + 1.) * std::sin(p(1) + 2.);
+      return std::sin(p[0] + 1.) * std::sin(p[1] + 2.) * std::sin(p[2] + 3.);
+    return std::sin(p[0] + 1.) * std::sin(p[1] + 2.);
   }
 };
 
@@ -154,13 +154,13 @@ check_periodicity(const DoFHandler<3> &dof_handler,
         Vector<double> value2(1);
 
         Point<3> point1;
-        point1(0) = -numbers::PI + 2. * i / n_points + eps;
-        point1(1) = -numbers::PI;
-        point1(2) = -numbers::PI + 2. * j / n_points + eps;
+        point1[0] = -numbers::PI + 2. * i / n_points + eps;
+        point1[1] = -numbers::PI;
+        point1[2] = -numbers::PI + 2. * j / n_points + eps;
         Point<3> point2;
-        point2(0) = -numbers::PI + 2. * i / n_points + eps;
-        point2(1) = numbers::PI;
-        point2(2) = -numbers::PI + 2. * j / n_points + eps;
+        point2[0] = -numbers::PI + 2. * i / n_points + eps;
+        point2[1] = numbers::PI;
+        point2[2] = -numbers::PI + 2. * j / n_points + eps;
 
         VectorTools::point_value(dof_handler, solution, point1, value1);
         VectorTools::point_value(dof_handler, solution, point2, value2);
@@ -187,13 +187,13 @@ check_periodicity(const DoFHandler<3> &dof_handler,
         Vector<double> value2(1);
 
         Point<3> point1;
-        point1(2) = -numbers::PI + 2. * j / n_points + eps;
-        point1(1) = -numbers::PI + 2. * i / n_points + eps;
-        point1(0) = -numbers::PI;
+        point1[2] = -numbers::PI + 2. * j / n_points + eps;
+        point1[1] = -numbers::PI + 2. * i / n_points + eps;
+        point1[0] = -numbers::PI;
         Point<3> point2;
-        point2(2) = -numbers::PI + 2. * j / n_points + eps;
-        point2(1) = -numbers::PI + 2. * i / n_points + eps;
-        point2(0) = numbers::PI;
+        point2[2] = -numbers::PI + 2. * j / n_points + eps;
+        point2[1] = -numbers::PI + 2. * i / n_points + eps;
+        point2[0] = numbers::PI;
 
         VectorTools::point_value(dof_handler, solution, point1, value1);
         VectorTools::point_value(dof_handler, solution, point2, value2);
@@ -220,13 +220,13 @@ check_periodicity(const DoFHandler<3> &dof_handler,
         Vector<double> value2(1);
 
         Point<3> point1;
-        point1(0) = -numbers::PI + 2. * j / n_points + eps;
-        point1(1) = -numbers::PI + 2. * i / n_points + eps;
-        point1(2) = -numbers::PI;
+        point1[0] = -numbers::PI + 2. * j / n_points + eps;
+        point1[1] = -numbers::PI + 2. * i / n_points + eps;
+        point1[2] = -numbers::PI;
         Point<3> point2;
-        point2(0) = -numbers::PI + 2. * j / n_points + eps;
-        point2(1) = -numbers::PI + 2. * i / n_points + eps;
-        point2(2) = numbers::PI;
+        point2[0] = -numbers::PI + 2. * j / n_points + eps;
+        point2[1] = -numbers::PI + 2. * i / n_points + eps;
+        point2[2] = numbers::PI;
 
         VectorTools::point_value(dof_handler, solution, point1, value1);
         VectorTools::point_value(dof_handler, solution, point2, value2);

--- a/tests/bits/point_gradient_01.cc
+++ b/tests/bits/point_gradient_01.cc
@@ -64,7 +64,7 @@ public:
   {
     Tensor<1, dim> return_value;
     for (unsigned int i = 0; i < dim; ++i)
-      return_value[i] = 2 * (component + 1) * p(component);
+      return_value[i] = 2 * (component + 1) * p[component];
     return return_value;
   }
 

--- a/tests/bits/point_gradient_02.cc
+++ b/tests/bits/point_gradient_02.cc
@@ -65,7 +65,7 @@ public:
   {
     Tensor<1, dim> return_value;
     for (unsigned int i = 0; i < dim; ++i)
-      return_value[i] = 2 * (component + 1) * p(component);
+      return_value[i] = 2 * (component + 1) * p[component];
     return return_value;
   }
 

--- a/tests/bits/point_gradient_hp_01.cc
+++ b/tests/bits/point_gradient_hp_01.cc
@@ -66,7 +66,7 @@ public:
   {
     Tensor<1, dim> return_value;
     for (unsigned int i = 0; i < dim; ++i)
-      return_value[i] = 2 * (component + 1) * p(component);
+      return_value[i] = 2 * (component + 1) * p[component];
     return return_value;
   }
 

--- a/tests/bits/point_gradient_hp_02.cc
+++ b/tests/bits/point_gradient_hp_02.cc
@@ -67,7 +67,7 @@ public:
   {
     Tensor<1, dim> return_value;
     for (unsigned int i = 0; i < dim; ++i)
-      return_value[i] = 2 * (component + 1) * p(component);
+      return_value[i] = 2 * (component + 1) * p[component];
     return return_value;
   }
 

--- a/tests/bits/point_inside_1.cc
+++ b/tests/bits/point_inside_1.cc
@@ -58,10 +58,10 @@ check()
   for (int i = 0; i < 11; ++i)
     {
       Point<dim> testpoint;
-      testpoint(0) = testcoord[i][0];
-      testpoint(1) = testcoord[i][1];
+      testpoint[0] = testcoord[i][0];
+      testpoint[1] = testcoord[i][1];
       if (dim == 3)
-        testpoint(2) = testcoord[i][2];
+        testpoint[2] = testcoord[i][2];
 
       bool res = cell->point_inside(testpoint);
       deallog << testpoint << " inside " << res << std::endl;

--- a/tests/bits/point_inside_2.cc
+++ b/tests/bits/point_inside_2.cc
@@ -49,7 +49,7 @@ check()
 
   // Now get the cell
   const typename Triangulation<dim>::cell_iterator cell = triangulation.begin();
-  cell->vertex(0)(0)                                    = -1.;
+  cell->vertex(0)[0]                                    = -1.;
 
   // and test it.
   double testcoord[14][3] = {{0.5, 0.5, 0.5},
@@ -73,10 +73,10 @@ check()
   for (int i = 0; i < 14; ++i)
     {
       Point<dim> testpoint;
-      testpoint(0) = testcoord[i][0];
-      testpoint(1) = testcoord[i][1];
+      testpoint[0] = testcoord[i][0];
+      testpoint[1] = testcoord[i][1];
       if (dim == 3)
-        testpoint(2) = testcoord[i][2];
+        testpoint[2] = testcoord[i][2];
 
       bool res = cell->point_inside(testpoint);
       deallog << testpoint << "  \t inside " << res << " expected "

--- a/tests/bits/static_condensation.cc
+++ b/tests/bits/static_condensation.cc
@@ -631,8 +631,8 @@ HelmholtzProblem<dim>::run()
                                                      endc = triangulation.end();
           for (; cell != endc; ++cell)
             for (const unsigned int face : GeometryInfo<dim>::face_indices())
-              if ((cell->face(face)->center()(0) == -1) ||
-                  (cell->face(face)->center()(1) == -1))
+              if ((cell->face(face)->center()[0] == -1) ||
+                  (cell->face(face)->center()[1] == -1))
                 cell->face(face)->set_boundary_id(1);
         }
       else

--- a/tests/bits/step-12.cc
+++ b/tests/bits/step-12.cc
@@ -110,8 +110,8 @@ Beta<dim>::value_list(const std::vector<Point<dim>> &points,
       const Point<dim> &p    = points[i];
       Point<dim>       &beta = values[i];
 
-      beta(0) = -p(1);
-      beta(1) = p(0);
+      beta[0] = -p[1];
+      beta[1] = p[0];
       beta /= std::sqrt(beta.square());
     }
 }
@@ -128,7 +128,7 @@ BoundaryValues<dim>::value_list(const std::vector<Point<dim>> &points,
 
   for (unsigned int i = 0; i < values.size(); ++i)
     {
-      if (points[i](0) < 0.5)
+      if (points[i][0] < 0.5)
         values[i] = 1.;
       else
         values[i] = 0.;

--- a/tests/bits/step-13.cc
+++ b/tests/bits/step-13.cc
@@ -663,9 +663,9 @@ double
 Solution<dim>::value(const Point<dim> &p,
                      const unsigned int /*component*/) const
 {
-  double q = p(0);
+  double q = p[0];
   for (unsigned int i = 1; i < dim; ++i)
-    q += std::sin(10 * p(i) + 5 * p(0) * p(0));
+    q += std::sin(10 * p[i] + 5 * p[0] * p[0]);
   const double exponential = std::exp(q);
   return exponential;
 }
@@ -690,19 +690,19 @@ double
 RightHandSide<dim>::value(const Point<dim> &p,
                           const unsigned int /*component*/) const
 {
-  double q = p(0);
+  double q = p[0];
   for (unsigned int i = 1; i < dim; ++i)
-    q += std::sin(10 * p(i) + 5 * p(0) * p(0));
+    q += std::sin(10 * p[i] + 5 * p[0] * p[0]);
   const double u  = std::exp(q);
   double       t1 = 1, t2 = 0, t3 = 0;
   for (unsigned int i = 1; i < dim; ++i)
     {
-      t1 += std::cos(10 * p(i) + 5 * p(0) * p(0)) * 10 * p(0);
-      t2 += 10 * std::cos(10 * p(i) + 5 * p(0) * p(0)) -
-            100 * std::sin(10 * p(i) + 5 * p(0) * p(0)) * p(0) * p(0);
-      t3 += 100 * std::cos(10 * p(i) + 5 * p(0) * p(0)) *
-              std::cos(10 * p(i) + 5 * p(0) * p(0)) -
-            100 * std::sin(10 * p(i) + 5 * p(0) * p(0));
+      t1 += std::cos(10 * p[i] + 5 * p[0] * p[0]) * 10 * p[0];
+      t2 += 10 * std::cos(10 * p[i] + 5 * p[0] * p[0]) -
+            100 * std::sin(10 * p[i] + 5 * p[0] * p[0]) * p[0] * p[0];
+      t3 += 100 * std::cos(10 * p[i] + 5 * p[0] * p[0]) *
+              std::cos(10 * p[i] + 5 * p[0] * p[0]) -
+            100 * std::sin(10 * p[i] + 5 * p[0] * p[0]);
     };
   t1 = t1 * t1;
 

--- a/tests/bits/step-4.cc
+++ b/tests/bits/step-4.cc
@@ -113,7 +113,7 @@ RightHandSide<dim>::value(const Point<dim> &p,
 {
   double return_value = 0;
   for (unsigned int i = 0; i < dim; ++i)
-    return_value += 4 * std::pow(p(i), 4);
+    return_value += 4 * std::pow(p[i], 4);
 
   return return_value;
 }

--- a/tests/bits/step-4_dg_periodic.cc
+++ b/tests/bits/step-4_dg_periodic.cc
@@ -269,11 +269,11 @@ Step4<2>::check_periodicity(const unsigned int cycle) const
       Vector<double> value2(1);
 
       Point<2> point1;
-      point1(0) = 2 * (1. * i / n_points + eps) - 1;
-      point1(1) = -1.;
+      point1[0] = 2 * (1. * i / n_points + eps) - 1;
+      point1[1] = -1.;
       Point<2> point2;
-      point2(0) = 2 * (1. * i / n_points + eps) - 1;
-      point2(1) = 1.;
+      point2[0] = 2 * (1. * i / n_points + eps) - 1;
+      point2[1] = 1.;
 
       VectorTools::point_value(dof_handler, solution, point1, value1);
       VectorTools::point_value(dof_handler, solution, point2, value2);

--- a/tests/bits/step-4_dg_periodic_coupling.cc
+++ b/tests/bits/step-4_dg_periodic_coupling.cc
@@ -276,11 +276,11 @@ Step4<2>::check_periodicity(const unsigned int cycle) const
       Vector<double> value2(1);
 
       Point<2> point1;
-      point1(0) = 2 * (1. * i / n_points + eps) - 1;
-      point1(1) = -1.;
+      point1[0] = 2 * (1. * i / n_points + eps) - 1;
+      point1[1] = -1.;
       Point<2> point2;
-      point2(0) = 2 * (1. * i / n_points + eps) - 1;
-      point2(1) = 1.;
+      point2[0] = 2 * (1. * i / n_points + eps) - 1;
+      point2[1] = 1.;
 
       VectorTools::point_value(dof_handler, solution, point1, value1);
       VectorTools::point_value(dof_handler, solution, point2, value2);

--- a/tests/bits/step-51.cc
+++ b/tests/bits/step-51.cc
@@ -967,7 +967,7 @@ namespace Step51
       for (const unsigned int face : GeometryInfo<dim>::face_indices())
         if (cell->face(face)->at_boundary())
           for (unsigned int d = 0; d < dim; ++d)
-            if ((std::fabs(cell->face(face)->center()(d) - (1)) < 1e-12))
+            if ((std::fabs(cell->face(face)->center()[d] - (1)) < 1e-12))
               cell->face(face)->set_boundary_id(1);
   }
 

--- a/tests/bits/step-51p.cc
+++ b/tests/bits/step-51p.cc
@@ -965,7 +965,7 @@ namespace Step51
       for (const unsigned int face : GeometryInfo<dim>::face_indices())
         if (cell->face(face)->at_boundary())
           for (unsigned int d = 0; d < dim; ++d)
-            if ((std::fabs(cell->face(face)->center()(d) - (1)) < 1e-12))
+            if ((std::fabs(cell->face(face)->center()[d] - (1)) < 1e-12))
               cell->face(face)->set_boundary_id(1);
   }
 

--- a/tests/bits/step-7.cc
+++ b/tests/bits/step-7.cc
@@ -497,8 +497,8 @@ HelmholtzProblem<dim>::run()
                                                      endc = triangulation.end();
           for (; cell != endc; ++cell)
             for (const unsigned int face : GeometryInfo<dim>::face_indices())
-              if ((cell->face(face)->center()(0) == -1) ||
-                  (cell->face(face)->center()(1) == -1))
+              if ((cell->face(face)->center()[0] == -1) ||
+                  (cell->face(face)->center()[1] == -1))
                 cell->face(face)->set_boundary_id(1);
         }
       else

--- a/tests/bits/step-8.cc
+++ b/tests/bits/step-8.cc
@@ -119,8 +119,8 @@ RightHandSide<dim>::vector_value(const Point<dim> &p,
   Assert(dim >= 2, ExcNotImplemented());
 
   Point<dim> point_1, point_2;
-  point_1(0) = 0.5;
-  point_2(0) = -0.5;
+  point_1[0] = 0.5;
+  point_2[0] = -0.5;
 
   if (((p - point_1).norm_square() < 0.2 * 0.2) ||
       ((p - point_2).norm_square() < 0.2 * 0.2))

--- a/tests/bits/subdomain_ids_01.cc
+++ b/tests/bits/subdomain_ids_01.cc
@@ -54,7 +54,7 @@ test()
     {
       unsigned int subdomain = 0;
       for (unsigned int d = 0; d < dim; ++d)
-        if (cell->center()(d) > 0)
+        if (cell->center()[d] > 0)
           subdomain |= (1 << d);
       AssertThrow(subdomain < (1 << dim), ExcInternalError());
 

--- a/tests/bits/subdomain_ids_02.cc
+++ b/tests/bits/subdomain_ids_02.cc
@@ -54,7 +54,7 @@ test()
     {
       unsigned int subdomain = 0;
       for (unsigned int d = 0; d < dim; ++d)
-        if (cell->center()(d) > 0)
+        if (cell->center()[d] > 0)
           subdomain |= (1 << d);
       AssertThrow(subdomain < (1 << dim), ExcInternalError());
 

--- a/tests/bits/subdomain_ids_03.cc
+++ b/tests/bits/subdomain_ids_03.cc
@@ -55,7 +55,7 @@ test()
     {
       unsigned int subdomain = 0;
       for (unsigned int d = 0; d < dim; ++d)
-        if (cell->center()(d) > 0)
+        if (cell->center()[d] > 0)
           subdomain |= (1 << d);
       AssertThrow(subdomain < (1 << dim), ExcInternalError());
 

--- a/tests/bits/subdomain_ids_04.cc
+++ b/tests/bits/subdomain_ids_04.cc
@@ -55,7 +55,7 @@ test()
     {
       unsigned int subdomain = 0;
       for (unsigned int d = 0; d < dim; ++d)
-        if (cell->center()(d) > 0)
+        if (cell->center()[d] > 0)
           subdomain |= (1 << d);
       AssertThrow(subdomain < (1 << dim), ExcInternalError());
 

--- a/tests/bits/subdomain_ids_05.cc
+++ b/tests/bits/subdomain_ids_05.cc
@@ -54,7 +54,7 @@ test()
     {
       unsigned int subdomain = 0;
       for (unsigned int d = 0; d < dim; ++d)
-        if (cell->center()(d) > 0)
+        if (cell->center()[d] > 0)
           subdomain |= (1 << d);
       AssertThrow(subdomain < (1 << dim), ExcInternalError());
 

--- a/tests/bits/subdomain_ids_06.cc
+++ b/tests/bits/subdomain_ids_06.cc
@@ -55,7 +55,7 @@ test()
     {
       unsigned int subdomain = 0;
       for (unsigned int d = 0; d < dim; ++d)
-        if (cell->center()(d) > 0)
+        if (cell->center()[d] > 0)
           subdomain |= (1 << d);
       AssertThrow(subdomain < (1 << dim), ExcInternalError());
 

--- a/tests/bits/subdomain_ids_07.cc
+++ b/tests/bits/subdomain_ids_07.cc
@@ -54,7 +54,7 @@ test()
     {
       unsigned int subdomain = 0;
       for (unsigned int d = 0; d < dim; ++d)
-        if (cell->center()(d) > 0)
+        if (cell->center()[d] > 0)
           subdomain |= (1 << d);
       AssertThrow(subdomain < (1 << dim), ExcInternalError());
 

--- a/tests/codim_one/data_out_03.cc
+++ b/tests/codim_one/data_out_03.cc
@@ -51,14 +51,14 @@ public:
   virtual double
   value(const Point<dim> &p, const unsigned int component) const
   {
-    return p(component);
+    return p[component];
   }
 
   virtual void
   vector_value(const Point<dim> &p, Vector<double> &values) const
   {
     for (unsigned int i = 0; i < dim; ++i)
-      values(i) = p(i);
+      values(i) = p[i];
   }
 };
 

--- a/tests/codim_one/error_estimator_01.cc
+++ b/tests/codim_one/error_estimator_01.cc
@@ -106,7 +106,7 @@ make_mesh(Triangulation<dim, spacedim> &tria)
     {
       unsigned int subdomain = 0;
       for (unsigned int d = 0; d < dim; ++d)
-        if (cell->center()(d) > 0)
+        if (cell->center()[d] > 0)
           subdomain |= (1 << d);
       AssertThrow(subdomain < (1 << dim), ExcInternalError());
 

--- a/tests/codim_one/error_estimator_02.cc
+++ b/tests/codim_one/error_estimator_02.cc
@@ -55,7 +55,7 @@ public:
   virtual double
   value(const Point<dim> &p, const unsigned int component) const
   {
-    return p(0) * p(0) + 2.0 * p(0) * p(1);
+    return p[0] * p[0] + 2.0 * p[0] * p[1];
   }
 
   virtual void
@@ -79,7 +79,7 @@ public:
   value(const Point<dim> &p, const unsigned int component) const
   {
     double val = 0.0;
-    if (std::abs(p(1) - 1.0) < 1e-5)
+    if (std::abs(p[1] - 1.0) < 1e-5)
       val = 2.0;
 
     deallog << "evaluate normal derivative at " << p << " with value " << val

--- a/tests/codim_one/extract_boundary_mesh_09.cc
+++ b/tests/codim_one/extract_boundary_mesh_09.cc
@@ -54,9 +54,9 @@ cylinder(Triangulation<3> &tria,
   // Turn cylinder such that y->x
   for (unsigned int i = 0; i < 16; ++i)
     {
-      const double h = vertices[i](1);
-      vertices[i](1) = -vertices[i](0);
-      vertices[i](0) = h;
+      const double h = vertices[i][1];
+      vertices[i][1] = -vertices[i][0];
+      vertices[i][0] = h;
     }
 
   int cell_vertices[5][8] = {{0, 1, 8, 9, 2, 3, 10, 11},

--- a/tests/codim_one/mesh_bug.cc
+++ b/tests/codim_one/mesh_bug.cc
@@ -45,7 +45,7 @@ main()
   const std::vector<Point<3>> &vertices = tria.get_vertices();
 
   for (unsigned int i = 0; i < vertices.size(); ++i)
-    if (vertices[i](2) > 1e-7)
+    if (vertices[i][2] > 1e-7)
       std::cout << "Error!" << std::endl;
 
 

--- a/tests/data_out/data_out_base.cc
+++ b/tests/data_out/data_out_base.cc
@@ -165,7 +165,7 @@ create_patches(std::vector<DataOutBase::Patch<dim, spacedim>> &patches)
 
       for (unsigned int i = 0; i < ncells; ++i)
         for (unsigned int j = 0; j < spacedim; ++j)
-          p.vertices[i](j) =
+          p.vertices[i][j] =
             PatchInfo<dim>::vertices[i][j] + PatchInfo<dim>::offsets[c][j];
 
       for (const unsigned int i : GeometryInfo<dim>::face_indices())

--- a/tests/data_out/data_out_curved_cells.cc
+++ b/tests/data_out/data_out_curved_cells.cc
@@ -180,7 +180,7 @@ curved_grid(std::ostream &out)
                       m[i].set_inhomogeneity(face->dof_index(0),
                                              (face->center() *
                                               (r_i / face->center().norm() -
-                                               1))(i));
+                                               1))[i]);
                     }
                 else if (std::fabs(face->vertex(1).norm() - r_a) < eps)
                   for (unsigned int i = 0; i < 2; ++i)

--- a/tests/data_out/data_out_postprocessor_tensor_01.cc
+++ b/tests/data_out/data_out_postprocessor_tensor_01.cc
@@ -104,8 +104,8 @@ namespace Step8
     Assert(dim >= 2, ExcNotImplemented());
 
     Point<dim> point_1, point_2;
-    point_1(0) = 0.5;
-    point_2(0) = -0.5;
+    point_1[0] = 0.5;
+    point_2[0] = -0.5;
 
     for (unsigned int point_n = 0; point_n < points.size(); ++point_n)
       {

--- a/tests/data_out/data_out_postprocessor_tensor_02.cc
+++ b/tests/data_out/data_out_postprocessor_tensor_02.cc
@@ -109,8 +109,8 @@ namespace Step8
     Assert(dim >= 2, ExcNotImplemented());
 
     Point<dim> point_1, point_2;
-    point_1(0) = 0.5;
-    point_2(0) = -0.5;
+    point_1[0] = 0.5;
+    point_2[0] = -0.5;
 
     for (unsigned int point_n = 0; point_n < points.size(); ++point_n)
       {

--- a/tests/data_out/patches.h
+++ b/tests/data_out/patches.h
@@ -42,7 +42,7 @@ create_patches(std::vector<DataOutBase::Patch<dim, spacedim>> &patches)
 
       for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
         for (unsigned int d = 0; d < spacedim; ++d)
-          patch.vertices[v](d) =
+          patch.vertices[v][d] =
             p + cell_coordinates[d][v] + ((d >= dim) ? v : 0);
 
       unsigned int n1 = (dim > 0) ? nsubp : 1;
@@ -93,7 +93,7 @@ create_continuous_patches(std::vector<DataOutBase::Patch<dim, dim>> &patches,
 
   Point<dim> midpoint;
   for (unsigned int d = 0; d < dim; ++d)
-    midpoint(d) = n_cells / 2.;
+    midpoint[d] = n_cells / 2.;
 
   Functions::CutOffFunctionCinfty<dim> function(2., midpoint);
 
@@ -108,22 +108,22 @@ create_continuous_patches(std::vector<DataOutBase::Patch<dim, dim>> &patches,
             {
               Point<dim> p = trapez.point(k);
               if (dim >= 1)
-                p(0) += i1;
+                p[0] += i1;
               if (dim >= 2)
-                p(1) += i2;
+                p[1] += i2;
               if (dim >= 3)
-                p(2) += i3;
+                p[2] += i3;
               patch.vertices[k] = p;
             }
           std::vector<Point<dim>> points = trapezsub.get_points();
           for (unsigned int k = 0; k < points.size(); ++k)
             {
               if (dim >= 1)
-                points[k](0) += i1;
+                points[k][0] += i1;
               if (dim >= 2)
-                points[k](1) += i2;
+                points[k][1] += i2;
               if (dim >= 3)
-                points[k](2) += i3;
+                points[k][2] += i3;
             }
           std::vector<double> values(points.size());
           function.value_list(points, values);

--- a/tests/distributed_grids/3d_coarse_grid_05.cc
+++ b/tests/distributed_grids/3d_coarse_grid_05.cc
@@ -58,22 +58,22 @@ create_disconnected_mesh(Triangulation<dim> &tria)
           vertices[0] = vertices[1] = p1;
           vertices[2] = vertices[3] = p2;
 
-          vertices[1](0) = p2(0);
-          vertices[2](0) = p1(0);
+          vertices[1][0] = p2[0];
+          vertices[2][0] = p1[0];
           break;
         case 3:
           vertices[0] = vertices[1] = vertices[2] = vertices[3] = p1;
           vertices[4] = vertices[5] = vertices[6] = vertices[7] = p2;
 
-          vertices[1](0) = p2(0);
-          vertices[2](1) = p2(1);
-          vertices[3](0) = p2(0);
-          vertices[3](1) = p2(1);
+          vertices[1][0] = p2[0];
+          vertices[2][1] = p2[1];
+          vertices[3][0] = p2[0];
+          vertices[3][1] = p2[1];
 
-          vertices[4](0) = p1(0);
-          vertices[4](1) = p1(1);
-          vertices[5](1) = p1(1);
-          vertices[6](0) = p1(0);
+          vertices[4][0] = p1[0];
+          vertices[4][1] = p1[1];
+          vertices[5][1] = p1[1];
+          vertices[6][0] = p1[0];
 
           break;
         default:
@@ -104,8 +104,8 @@ create_disconnected_mesh(Triangulation<dim> &tria)
           vertices[GeometryInfo<dim>::vertices_per_cell + 2] =
             vertices[GeometryInfo<dim>::vertices_per_cell + 3] = p2;
 
-          vertices[GeometryInfo<dim>::vertices_per_cell + 1](0) = p2(0);
-          vertices[GeometryInfo<dim>::vertices_per_cell + 2](0) = p1(0);
+          vertices[GeometryInfo<dim>::vertices_per_cell + 1][0] = p2[0];
+          vertices[GeometryInfo<dim>::vertices_per_cell + 2][0] = p1[0];
           break;
         case 3:
           vertices[GeometryInfo<dim>::vertices_per_cell + 0] =
@@ -117,15 +117,15 @@ create_disconnected_mesh(Triangulation<dim> &tria)
               vertices[GeometryInfo<dim>::vertices_per_cell + 6] =
                 vertices[GeometryInfo<dim>::vertices_per_cell + 7] = p2;
 
-          vertices[GeometryInfo<dim>::vertices_per_cell + 1](0) = p2(0);
-          vertices[GeometryInfo<dim>::vertices_per_cell + 2](1) = p2(1);
-          vertices[GeometryInfo<dim>::vertices_per_cell + 3](0) = p2(0);
-          vertices[GeometryInfo<dim>::vertices_per_cell + 3](1) = p2(1);
+          vertices[GeometryInfo<dim>::vertices_per_cell + 1][0] = p2[0];
+          vertices[GeometryInfo<dim>::vertices_per_cell + 2][1] = p2[1];
+          vertices[GeometryInfo<dim>::vertices_per_cell + 3][0] = p2[0];
+          vertices[GeometryInfo<dim>::vertices_per_cell + 3][1] = p2[1];
 
-          vertices[GeometryInfo<dim>::vertices_per_cell + 4](0) = p1(0);
-          vertices[GeometryInfo<dim>::vertices_per_cell + 4](1) = p1(1);
-          vertices[GeometryInfo<dim>::vertices_per_cell + 5](1) = p1(1);
-          vertices[GeometryInfo<dim>::vertices_per_cell + 6](0) = p1(0);
+          vertices[GeometryInfo<dim>::vertices_per_cell + 4][0] = p1[0];
+          vertices[GeometryInfo<dim>::vertices_per_cell + 4][1] = p1[1];
+          vertices[GeometryInfo<dim>::vertices_per_cell + 5][1] = p1[1];
+          vertices[GeometryInfo<dim>::vertices_per_cell + 6][0] = p1[0];
 
           break;
         default:

--- a/tests/distributed_grids/get_boundary_ids_01.cc
+++ b/tests/distributed_grids/get_boundary_ids_01.cc
@@ -33,13 +33,13 @@ test()
     if (cell->is_locally_owned())
       for (const unsigned int face : GeometryInfo<dim>::face_indices())
         {
-          if (std::fabs(cell->face(face)->center()(0) - 0.0) < 1e-12)
+          if (std::fabs(cell->face(face)->center()[0] - 0.0) < 1e-12)
             cell->face(face)->set_all_boundary_ids(1);
-          if (std::fabs(cell->face(face)->center()(0) - 1.0) < 1e-12)
+          if (std::fabs(cell->face(face)->center()[0] - 1.0) < 1e-12)
             cell->face(face)->set_all_boundary_ids(2);
-          if (std::fabs(cell->face(face)->center()(1) - 0.0) < 1e-12)
+          if (std::fabs(cell->face(face)->center()[1] - 0.0) < 1e-12)
             cell->face(face)->set_all_boundary_ids(3);
-          if (std::fabs(cell->face(face)->center()(1) - 1.0) < 1e-12)
+          if (std::fabs(cell->face(face)->center()[1] - 1.0) < 1e-12)
             cell->face(face)->set_all_boundary_ids(4);
         }
 

--- a/tests/dofs/dof_test.cc
+++ b/tests/dofs/dof_test.cc
@@ -52,11 +52,11 @@ public:
     Point<dim> middle = FlatManifold<dim>::get_new_point_on_line(line);
 
     for (int i = 0; i < dim; ++i)
-      middle(i) -= .5;
+      middle[i] -= .5;
     middle *=
       std::sqrt(static_cast<double>(dim)) / (std::sqrt(middle.square()) * 2);
     for (int i = 0; i < dim; ++i)
-      middle(i) += .5;
+      middle[i] += .5;
 
     return middle;
   }
@@ -69,11 +69,11 @@ public:
     Point<dim> middle = FlatManifold<dim>::get_new_point_on_quad(quad);
 
     for (int i = 0; i < dim; ++i)
-      middle(i) -= .5;
+      middle[i] -= .5;
     middle *=
       std::sqrt(static_cast<double>(dim)) / (std::sqrt(middle.square()) * 2);
     for (int i = 0; i < dim; ++i)
-      middle(i) += .5;
+      middle[i] += .5;
 
     return middle;
   }
@@ -108,7 +108,7 @@ CurvedLine<dim>::get_new_point_on_line(
   // 0 or 1, then the z-values of all
   // vertices of the line is like that
   if (dim >= 3)
-    if (((middle(2) == 0) || (middle(2) == 1))
+    if (((middle[2] == 0) || (middle[2] == 1))
         // find out, if the line is in the
         // interior of the top or bottom face
         // of the domain, or at the edge.
@@ -125,18 +125,18 @@ CurvedLine<dim>::get_new_point_on_line(
       return middle;
 
 
-  double x = middle(0), y = middle(1);
+  double x = middle[0], y = middle[1];
 
   if (y < x)
     if (y < 1 - x)
-      middle(1) = 0.04 * std::sin(6 * numbers::PI * middle(0));
+      middle[1] = 0.04 * std::sin(6 * numbers::PI * middle[0]);
     else
-      middle(0) = 1 + 0.04 * std::sin(6 * numbers::PI * middle(1));
+      middle[0] = 1 + 0.04 * std::sin(6 * numbers::PI * middle[1]);
 
   else if (y < 1 - x)
-    middle(0) = 0.04 * std::sin(6 * numbers::PI * middle(1));
+    middle[0] = 0.04 * std::sin(6 * numbers::PI * middle[1]);
   else
-    middle(1) = 1 + 0.04 * std::sin(6 * numbers::PI * middle(0));
+    middle[1] = 1 + 0.04 * std::sin(6 * numbers::PI * middle[0]);
 
   return middle;
 }
@@ -156,21 +156,21 @@ CurvedLine<dim>::get_new_point_on_quad(
   // z-value of the midpoint is either
   // 0 or 1, then the z-values of all
   // vertices of the quad is like that
-  if (dim == 3 && ((middle(dim - 1) == 0) || (middle(dim - 1) == 1)))
+  if (dim == 3 && ((middle[dim - 1] == 0) || (middle[dim - 1] == 1)))
     return middle;
 
-  double x = middle(0), y = middle(1);
+  double x = middle[0], y = middle[1];
 
   if (y < x)
     if (y < 1 - x)
-      middle(1) = 0.04 * std::sin(6 * numbers::PI * middle(0));
+      middle[1] = 0.04 * std::sin(6 * numbers::PI * middle[0]);
     else
-      middle(0) = 1 + 0.04 * std::sin(6 * numbers::PI * middle(1));
+      middle[0] = 1 + 0.04 * std::sin(6 * numbers::PI * middle[1]);
 
   else if (y < 1 - x)
-    middle(0) = 0.04 * std::sin(6 * numbers::PI * middle(1));
+    middle[0] = 0.04 * std::sin(6 * numbers::PI * middle[1]);
   else
-    middle(1) = 1 + 0.04 * std::sin(6 * numbers::PI * middle(0));
+    middle[1] = 1 + 0.04 * std::sin(6 * numbers::PI * middle[0]);
 
   return middle;
 }

--- a/tests/dofs/dof_tools_04a.cc
+++ b/tests/dofs/dof_tools_04a.cc
@@ -88,8 +88,8 @@ check(const FiniteElement<dim> &fe, const std::string &name)
   for (unsigned int ref = 0; ref < 2; ++ref)
     {
       for (auto &cell : tria.active_cell_iterators())
-        if (cell->is_locally_owned() && cell->center()(0) < .5 &&
-            cell->center()(1) < .5)
+        if (cell->is_locally_owned() && cell->center()[0] < .5 &&
+            cell->center()[1] < .5)
           cell->set_refine_flag();
       tria.execute_coarsening_and_refinement();
     }

--- a/tests/dofs/dof_tools_21_b.cc
+++ b/tests/dofs/dof_tools_21_b.cc
@@ -97,9 +97,9 @@ generate_grid(Triangulation<2> &triangulation, int orientation)
   // Look for the two outermost faces:
   for (const unsigned int j : GeometryInfo<2>::face_indices())
     {
-      if (cell_1->face(j)->center()(1) > 2.9)
+      if (cell_1->face(j)->center()[1] > 2.9)
         face_1 = cell_1->face(j);
-      if (cell_2->face(j)->center()(1) < -2.9)
+      if (cell_2->face(j)->center()[1] < -2.9)
         face_2 = cell_2->face(j);
     }
   face_1->set_boundary_id(42);
@@ -153,9 +153,9 @@ generate_grid(Triangulation<2, 3> &triangulation, int orientation)
   // Look for the two outermost faces:
   for (const unsigned int j : GeometryInfo<2>::face_indices())
     {
-      if (cell_1->face(j)->center()(1) > 2.9)
+      if (cell_1->face(j)->center()[1] > 2.9)
         face_1 = cell_1->face(j);
-      if (cell_2->face(j)->center()(1) < -2.9)
+      if (cell_2->face(j)->center()[1] < -2.9)
         face_2 = cell_2->face(j);
     }
   face_1->set_boundary_id(42);
@@ -223,9 +223,9 @@ generate_grid(Triangulation<3> &triangulation, int orientation)
   // Look for the two outermost faces:
   for (const unsigned int j : GeometryInfo<3>::face_indices())
     {
-      if (cell_1->face(j)->center()(2) > 2.9)
+      if (cell_1->face(j)->center()[2] > 2.9)
         face_1 = cell_1->face(j);
-      if (cell_2->face(j)->center()(2) < -2.9)
+      if (cell_2->face(j)->center()[2] < -2.9)
         face_2 = cell_2->face(j);
     }
   face_1->set_boundary_id(42);
@@ -274,9 +274,9 @@ print_matching(DoFHandler<dim, spacedim> &dof_handler,
     {
       for (const unsigned int j : GeometryInfo<dim>::face_indices())
         {
-          if (cell->face(j)->center()(dim == 2 ? 1 : 2) > 2.9)
+          if (cell->face(j)->center()[dim == 2 ? 1 : 2] > 2.9)
             face_1 = cell->face(j);
-          if (cell->face(j)->center()(dim == 2 ? 1 : 2) < -2.9)
+          if (cell->face(j)->center()[dim == 2 ? 1 : 2] < -2.9)
             face_2 = cell->face(j);
         }
     }

--- a/tests/dofs/dof_tools_21_b_x.cc
+++ b/tests/dofs/dof_tools_21_b_x.cc
@@ -95,9 +95,9 @@ generate_grid(Triangulation<2> &triangulation)
   // Look for the two outermost faces:
   for (const unsigned int j : GeometryInfo<2>::face_indices())
     {
-      if (cell_1->face(j)->center()(1) > 2.9)
+      if (cell_1->face(j)->center()[1] > 2.9)
         face_1 = cell_1->face(j);
-      if (cell_2->face(j)->center()(1) < -2.9)
+      if (cell_2->face(j)->center()[1] < -2.9)
         face_2 = cell_2->face(j);
     }
   face_1->set_boundary_id(42);
@@ -146,9 +146,9 @@ generate_grid(Triangulation<2, 3> &triangulation)
   // Look for the two outermost faces:
   for (const unsigned int j : GeometryInfo<2>::face_indices())
     {
-      if (cell_1->face(j)->center()(1) > 2.9)
+      if (cell_1->face(j)->center()[1] > 2.9)
         face_1 = cell_1->face(j);
-      if (cell_2->face(j)->center()(1) < -2.9)
+      if (cell_2->face(j)->center()[1] < -2.9)
         face_2 = cell_2->face(j);
     }
   face_1->set_boundary_id(42);

--- a/tests/dofs/dof_tools_21_b_x_q3.cc
+++ b/tests/dofs/dof_tools_21_b_x_q3.cc
@@ -129,9 +129,9 @@ generate_grid(Triangulation<2> &triangulation)
   // Look for the two outermost faces:
   for (const unsigned int j : GeometryInfo<2>::face_indices())
     {
-      if (cell_1->face(j)->center()(1) > 2.9)
+      if (cell_1->face(j)->center()[1] > 2.9)
         face_1 = cell_1->face(j);
-      if (cell_2->face(j)->center()(1) < -2.9)
+      if (cell_2->face(j)->center()[1] < -2.9)
         face_2 = cell_2->face(j);
     }
   face_1->set_boundary_id(42);
@@ -180,9 +180,9 @@ generate_grid(Triangulation<2, 3> &triangulation)
   // Look for the two outermost faces:
   for (const unsigned int j : GeometryInfo<2>::face_indices())
     {
-      if (cell_1->face(j)->center()(1) > 2.9)
+      if (cell_1->face(j)->center()[1] > 2.9)
         face_1 = cell_1->face(j);
-      if (cell_2->face(j)->center()(1) < -2.9)
+      if (cell_2->face(j)->center()[1] < -2.9)
         face_2 = cell_2->face(j);
     }
   face_1->set_boundary_id(42);

--- a/tests/dofs/dof_tools_21_b_y.cc
+++ b/tests/dofs/dof_tools_21_b_y.cc
@@ -94,9 +94,9 @@ generate_grid(Triangulation<2> &triangulation)
   // Look for the two outermost faces:
   for (const unsigned int j : GeometryInfo<2>::face_indices())
     {
-      if (cell_1->face(j)->center()(1) > 2.9)
+      if (cell_1->face(j)->center()[1] > 2.9)
         face_1 = cell_1->face(j);
-      if (cell_2->face(j)->center()(1) < -2.9)
+      if (cell_2->face(j)->center()[1] < -2.9)
         face_2 = cell_2->face(j);
     }
   face_1->set_boundary_id(42);
@@ -146,9 +146,9 @@ generate_grid(Triangulation<2, 3> &triangulation)
   // Look for the two outermost faces:
   for (const unsigned int j : GeometryInfo<2>::face_indices())
     {
-      if (cell_1->face(j)->center()(1) > 2.9)
+      if (cell_1->face(j)->center()[1] > 2.9)
         face_1 = cell_1->face(j);
-      if (cell_2->face(j)->center()(1) < -2.9)
+      if (cell_2->face(j)->center()[1] < -2.9)
         face_2 = cell_2->face(j);
     }
   face_1->set_boundary_id(42);

--- a/tests/dofs/dof_tools_21_c.cc
+++ b/tests/dofs/dof_tools_21_c.cc
@@ -100,9 +100,9 @@ generate_grid(Triangulation<2> &triangulation, int orientation)
   // Look for the two outermost faces:
   for (const unsigned int j : GeometryInfo<2>::face_indices())
     {
-      if (cell_1->face(j)->center()(1) > 2.9)
+      if (cell_1->face(j)->center()[1] > 2.9)
         face_1 = cell_1->face(j);
-      if (cell_2->face(j)->center()(1) < -2.9)
+      if (cell_2->face(j)->center()[1] < -2.9)
         face_2 = cell_2->face(j);
     }
   face_1->set_boundary_id(42);
@@ -157,9 +157,9 @@ generate_grid(Triangulation<2, 3> &triangulation, int orientation)
   // Look for the two outermost faces:
   for (const unsigned int j : GeometryInfo<2>::face_indices())
     {
-      if (cell_1->face(j)->center()(1) > 2.9)
+      if (cell_1->face(j)->center()[1] > 2.9)
         face_1 = cell_1->face(j);
-      if (cell_2->face(j)->center()(1) < -2.9)
+      if (cell_2->face(j)->center()[1] < -2.9)
         face_2 = cell_2->face(j);
     }
   face_1->set_boundary_id(42);
@@ -228,9 +228,9 @@ generate_grid(Triangulation<3> &triangulation, int orientation)
   // Look for the two outermost faces:
   for (const unsigned int j : GeometryInfo<3>::face_indices())
     {
-      if (cell_1->face(j)->center()(2) > 2.9)
+      if (cell_1->face(j)->center()[2] > 2.9)
         face_1 = cell_1->face(j);
-      if (cell_2->face(j)->center()(2) < -2.9)
+      if (cell_2->face(j)->center()[2] < -2.9)
         face_2 = cell_2->face(j);
     }
   face_1->set_boundary_id(42);
@@ -280,9 +280,9 @@ print_matching(DoFHandler<dim, spacedim> &dof_handler,
     {
       for (const unsigned int j : GeometryInfo<dim>::face_indices())
         {
-          if (cell->face(j)->center()(dim == 2 ? 1 : 2) > 2.9)
+          if (cell->face(j)->center()[dim == 2 ? 1 : 2] > 2.9)
             face_1 = cell->face(j);
-          if (cell->face(j)->center()(dim == 2 ? 1 : 2) < -2.9)
+          if (cell->face(j)->center()[dim == 2 ? 1 : 2] < -2.9)
             face_2 = cell->face(j);
         }
     }

--- a/tests/dofs/dof_tools_22a.cc
+++ b/tests/dofs/dof_tools_22a.cc
@@ -64,7 +64,7 @@ test()
          triangulation.begin_active();
        cell != triangulation.end();
        ++cell)
-    if (cell->center()(0) > 0.49)
+    if (cell->center()[0] > 0.49)
       cell->set_refine_flag();
 
   triangulation.prepare_coarsening_and_refinement();

--- a/tests/dofs/dof_tools_common_parallel.h
+++ b/tests/dofs/dof_tools_common_parallel.h
@@ -84,8 +84,8 @@ check(const FiniteElement<dim> &fe, const std::string &name)
   for (unsigned int ref = 0; ref < 2; ++ref)
     {
       for (auto &cell : tria.active_cell_iterators())
-        if (cell->is_locally_owned() && cell->center()(0) < .5 &&
-            cell->center()(1) < .5)
+        if (cell->is_locally_owned() && cell->center()[0] < .5 &&
+            cell->center()[1] < .5)
           cell->set_refine_flag();
       tria.execute_coarsening_and_refinement();
     }

--- a/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_01.cc
+++ b/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_01.cc
@@ -40,7 +40,7 @@ template <int dim>
 bool
 pred_d(const typename DoFHandler<dim>::active_cell_iterator &cell)
 {
-  return (cell->center()(0) < 0.49 && cell->center()(1) < 0.49);
+  return (cell->center()[0] < 0.49 && cell->center()[1] < 0.49);
 }
 
 template <int dim>

--- a/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_02.cc
+++ b/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_02.cc
@@ -48,7 +48,7 @@ template <int dim>
 bool
 pred_d(const typename DoFHandler<dim>::active_cell_iterator &cell)
 {
-  return (cell->center()(0) < 0.5 && cell->center()(1) < 0.5);
+  return (cell->center()[0] < 0.5 && cell->center()[1] < 0.5);
 }
 
 

--- a/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_03.cc
+++ b/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_03.cc
@@ -41,14 +41,14 @@ template <int dim>
 bool
 pred_left(const typename DoFHandler<dim>::active_cell_iterator &cell)
 {
-  return (cell->center()(0) < 0.49);
+  return (cell->center()[0] < 0.49);
 }
 
 template <int dim>
 bool
 pred_right(const typename DoFHandler<dim>::active_cell_iterator &cell)
 {
-  return (cell->center()(0) > 0.51);
+  return (cell->center()[0] > 0.51);
 }
 
 
@@ -56,8 +56,8 @@ template <int dim>
 bool
 pred_r(const typename Triangulation<dim>::active_cell_iterator &cell)
 {
-  return (cell->center()(0) < 0.49 && cell->center()(1) < 0.49) ||
-         (cell->center()(0) > 0.49 && cell->center()(1) > 0.49);
+  return (cell->center()[0] < 0.49 && cell->center()[1] < 0.49) ||
+         (cell->center()[0] > 0.49 && cell->center()[1] > 0.49);
 }
 
 

--- a/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_04.cc
+++ b/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_04.cc
@@ -55,15 +55,15 @@ template <int dim>
 bool
 pred_d(const typename DoFHandler<dim>::active_cell_iterator &cell)
 {
-  return (cell->center()(0) < 0.49);
+  return (cell->center()[0] < 0.49);
 }
 
 template <int dim>
 bool
 pred_r(const typename Triangulation<dim>::active_cell_iterator &cell)
 {
-  return (cell->center()(0) < 0.49 && cell->center()(1) < 0.49) ||
-         (cell->center()(0) > 0.49 && cell->center()(1) > 0.49);
+  return (cell->center()[0] < 0.49 && cell->center()[1] < 0.49) ||
+         (cell->center()[0] > 0.49 && cell->center()[1] > 0.49);
 }
 
 

--- a/tests/fe/2d_grid_projection_hermite.cc
+++ b/tests/fe/2d_grid_projection_hermite.cc
@@ -71,7 +71,7 @@ public:
   value(const Point<2> &p, unsigned int c = 0) const override
   {
     (void)c;
-    return p(0) * p(1);
+    return p[0] * p[1];
   }
 
 
@@ -98,7 +98,7 @@ test_fe_on_domain(const unsigned int regularity)
   double   left = -1.0, right = 1.0;
   Point<2> left_point, right_point;
   for (unsigned int i = 0; i < 2; ++i)
-    left_point(i) = left, right_point(i) = right;
+    left_point[i] = left, right_point[i] = right;
   GridGenerator::subdivided_hyper_cube(tr, 4, left, right);
 
   FE_Hermite<2> herm(2 * regularity + 1);

--- a/tests/fe/bdm_2.cc
+++ b/tests/fe/bdm_2.cc
@@ -45,7 +45,7 @@
 Point<2>
 stretch_coordinates(const Point<2> p)
 {
-  return Point<2>(2 * p(0), p(1));
+  return Point<2>(2 * p[0], p[1]);
 }
 
 
@@ -53,7 +53,7 @@ stretch_coordinates(const Point<2> p)
 Point<2>
 tilt_coordinates(const Point<2> p)
 {
-  return Point<2>(p(0) + p(1), p(1));
+  return Point<2>(p[0] + p[1], p[1]);
 }
 
 

--- a/tests/fe/br_approximation_01.cc
+++ b/tests/fe/br_approximation_01.cc
@@ -134,10 +134,10 @@ double
 TestDef1<dim>::value(const Point<dim> &p, const unsigned int component) const
 {
   Point<2> center;
-  center(0)    = 0.5;
-  center(1)    = 0.5;
+  center[0]    = 0.5;
+  center[1]    = 0.5;
   double rad   = p.distance(center),
-         phi_p = atan2(p(0) - center(0), p(1) - center(1));
+         phi_p = atan2(p[0] - center[0], p[1] - center[1]);
 
   if (component == 0)
     return rad * (sin(phi + phi_p) - sin(phi_p));
@@ -188,7 +188,7 @@ template <int dim>
 double
 TestDef2<dim>::value(const Point<dim> &p, const unsigned int component) const
 {
-  double x = p(0), y = p(1);
+  double x = p[0], y = p[1];
 
   if (component == 0)
     return scale * x;
@@ -240,7 +240,7 @@ template <int dim>
 double
 TestDef3<dim>::value(const Point<dim> &p, const unsigned int component) const
 {
-  double y = p(1);
+  double y = p[1];
 
   if (component == 0)
     return scale * y;
@@ -297,7 +297,7 @@ template <int dim>
 double
 TestPoly<dim>::value(const Point<dim> &p, const unsigned int component) const
 {
-  double x = p(0), y = p(1);
+  double x = p[0], y = p[1];
 
   if (component == 0)
     return polys[0].value(x) + polys[1].value(y);

--- a/tests/fe/curl_curl_01.cc
+++ b/tests/fe/curl_curl_01.cc
@@ -164,9 +164,9 @@ ExactSolution<dim>::value(const Point<dim>  &p,
   switch (component)
     {
       case 0:
-        val = cos(numbers::PI * p(0)) * sin(numbers::PI * p(1)) + bc_constant;
+        val = cos(numbers::PI * p[0]) * sin(numbers::PI * p[1]) + bc_constant;
       case 1:
-        val = -sin(numbers::PI * p(0)) * cos(numbers::PI * p(1)) + bc_constant;
+        val = -sin(numbers::PI * p[0]) * cos(numbers::PI * p[1]) + bc_constant;
     }
   return val;
 }
@@ -176,8 +176,8 @@ ExactSolution<dim>::vector_value(const Point<dim> &p,
                                  Vector<double>   &result) const
 {
   Assert(dim >= 2, ExcNotImplemented());
-  result(0) = cos(numbers::PI * p(0)) * sin(numbers::PI * p(1)) + bc_constant;
-  result(1) = -sin(numbers::PI * p(0)) * cos(numbers::PI * p(1)) + bc_constant;
+  result(0) = cos(numbers::PI * p[0]) * sin(numbers::PI * p[1]) + bc_constant;
+  result(1) = -sin(numbers::PI * p[0]) * cos(numbers::PI * p[1]) + bc_constant;
 }
 template <int dim>
 void
@@ -195,10 +195,10 @@ ExactSolution<dim>::value_list(const std::vector<Point<dim>> &points,
         {
           case 0:
             values[i] =
-              cos(numbers::PI * p(0)) * sin(numbers::PI * p(1)) + bc_constant;
+              cos(numbers::PI * p[0]) * sin(numbers::PI * p[1]) + bc_constant;
           case 1:
             values[i] =
-              -sin(numbers::PI * p(0)) * cos(numbers::PI * p(1)) + bc_constant;
+              -sin(numbers::PI * p[0]) * cos(numbers::PI * p[1]) + bc_constant;
         }
     }
 }
@@ -215,9 +215,9 @@ ExactSolution<dim>::vector_value_list(const std::vector<Point<dim>> &points,
     {
       const Point<dim> &p = points[i];
       values[i](0) =
-        cos(numbers::PI * p(0)) * sin(numbers::PI * p(1)) + bc_constant;
+        cos(numbers::PI * p[0]) * sin(numbers::PI * p[1]) + bc_constant;
       values[i](1) =
-        -sin(numbers::PI * p(0)) * cos(numbers::PI * p(1)) + bc_constant;
+        -sin(numbers::PI * p[0]) * cos(numbers::PI * p[1]) + bc_constant;
     }
 }
 // END EXACT SOLUTION MEMBERS
@@ -236,11 +236,11 @@ RightHandSide<dim>::vector_value(const Point<dim> &p,
   Assert(dim >= 2, ExcNotImplemented());
 
   // 2D solution
-  values(0) = (2 * numbers::PI * numbers::PI + 1) * cos(numbers::PI * p(0)) *
-                sin(numbers::PI * p(1)) +
+  values(0) = (2 * numbers::PI * numbers::PI + 1) * cos(numbers::PI * p[0]) *
+                sin(numbers::PI * p[1]) +
               bc_constant;
-  values(1) = -(2 * numbers::PI * numbers::PI + 1) * sin(numbers::PI * p(0)) *
-                cos(numbers::PI * p(1)) +
+  values(1) = -(2 * numbers::PI * numbers::PI + 1) * sin(numbers::PI * p[0]) *
+                cos(numbers::PI * p[1]) +
               bc_constant;
 }
 template <int dim>

--- a/tests/fe/fe_abf_gradient_divergence_theorem.cc
+++ b/tests/fe/fe_abf_gradient_divergence_theorem.cc
@@ -160,8 +160,8 @@ test_hyper_cube(const double tolerance)
   for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
     {
       Point<dim> &point = cell->vertex(i);
-      if (std::abs(point(dim - 1) - 1.0) < 1e-5)
-        point(dim - 1) += 0.15;
+      if (std::abs(point[dim - 1] - 1.0) < 1e-5)
+        point[dim - 1] += 0.15;
     }
 
   FE_ABF<dim> fe(1);

--- a/tests/fe/fe_br.cc
+++ b/tests/fe/fe_br.cc
@@ -118,8 +118,8 @@ test_hyper_cube(const double tolerance)
   for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
     {
       Point<dim> &point = cell->vertex(i);
-      if (std::abs(point(dim - 1) - 1.0) < 1e-5)
-        point(dim - 1) += 0.15;
+      if (std::abs(point[dim - 1] - 1.0) < 1e-5)
+        point[dim - 1] += 0.15;
     }
 
   FE_BernardiRaugel<dim> fe(1);

--- a/tests/fe/fe_nedelec_sz_non_rect_face.cc
+++ b/tests/fe/fe_nedelec_sz_non_rect_face.cc
@@ -113,9 +113,9 @@ namespace Maxwell
         const Point<dim> &p = points[i];
 
         /* quadratic: */
-        value_list[i](0) = p(0) * p(0);
-        value_list[i](1) = p(1) * p(1);
-        value_list[i](2) = p(2) * p(2);
+        value_list[i](0) = p[0] * p[0];
+        value_list[i](1) = p[1] * p[1];
+        value_list[i](2) = p[2] * p[2];
       }
   }
   // Additional functions to create Neumann conditions, zero in this case.

--- a/tests/fe/fe_project_2d.cc
+++ b/tests/fe/fe_project_2d.cc
@@ -123,10 +123,10 @@ VectorFunction<2>::value(const Point<2> &p, const unsigned int component) const
   switch (component)
     {
       case 0:
-        val = cos(PI * p(0)) * sin(PI * p(1));
+        val = cos(PI * p[0]) * sin(PI * p[1]);
         break;
       case 1:
-        val = -sin(PI * p(0)) * cos(PI * p(1));
+        val = -sin(PI * p[0]) * cos(PI * p[1]);
         break;
     }
   return val;

--- a/tests/fe/fe_project_3d.cc
+++ b/tests/fe/fe_project_3d.cc
@@ -139,13 +139,13 @@ VectorFunction<3>::value(const Point<3> &p, const unsigned int component) const
   switch (component)
     {
       case 0:
-        val = -sin(PI * p(0)) * cos(PI * p(1)) * cos(PI * p(2));
+        val = -sin(PI * p[0]) * cos(PI * p[1]) * cos(PI * p[2]);
         break;
       case 1:
-        val = -cos(PI * p(0)) * sin(PI * p(1)) * cos(PI * p(2));
+        val = -cos(PI * p[0]) * sin(PI * p[1]) * cos(PI * p[2]);
         break;
       case 2:
-        val = 2 * cos(PI * p(0)) * cos(PI * p(1)) * sin(PI * p(2));
+        val = 2 * cos(PI * p[0]) * cos(PI * p[1]) * sin(PI * p[2]);
         break;
     }
   return val;
@@ -167,7 +167,7 @@ VectorFunction<3>::gradient(const Point<3>    &p,
 {
   const double PI = numbers::PI;
   Tensor<1, 3> val;
-  double       x = p(0), y = p(1), z = p(2);
+  double       x = p[0], y = p[1], z = p[2];
 
   switch (component)
     {

--- a/tests/fe/fe_q_bubbles.cc
+++ b/tests/fe/fe_q_bubbles.cc
@@ -82,8 +82,8 @@ BubbleFunction<dim>::value(const Point<dim> &p, const unsigned int) const
 {
   double return_value = 1.;
   for (unsigned int i = 0; i < dim; ++i)
-    return_value *= (1 - p(i) * p(i));
-  return_value *= std::pow(p(m_direction), m_degree - 1);
+    return_value *= (1 - p[i] * p[i]);
+  return_value *= std::pow(p[m_direction], m_degree - 1);
 
   return return_value;
 }
@@ -99,9 +99,9 @@ BubbleFunction<dim>::gradient(const Point<dim> &p, const unsigned int) const
       grad[d] = 1.;
       // compute grad(\prod_{i=1}^d (1-x_i^2))(p)
       for (unsigned j = 0; j < dim; ++j)
-        grad[d] *= (d == j ? -2 * p(j) : (1 - p(j) * p(j)));
+        grad[d] *= (d == j ? -2 * p[j] : (1 - p[j] * p[j]));
       // and multiply with x_i^{r-1}
-      grad[d] *= std::pow(p(m_direction), m_degree - 1);
+      grad[d] *= std::pow(p[m_direction], m_degree - 1);
     }
 
   if (m_degree >= 2)
@@ -109,10 +109,10 @@ BubbleFunction<dim>::gradient(const Point<dim> &p, const unsigned int) const
       // add \prod_{i=1}^d (1-x_i^2))(p)
       double value = 1.;
       for (unsigned int j = 0; j < dim; ++j)
-        value *= (1 - p(j) * p(j));
+        value *= (1 - p[j] * p[j]);
       // and multiply with grad(x_i^{r-1})
       grad[m_direction] +=
-        value * (m_degree - 1) * std::pow(p(m_direction), m_degree - 2);
+        value * (m_degree - 1) * std::pow(p[m_direction], m_degree - 2);
     }
 
   return grad;

--- a/tests/fe/fe_rt_gradient_divergence_theorem.cc
+++ b/tests/fe/fe_rt_gradient_divergence_theorem.cc
@@ -161,8 +161,8 @@ test_hyper_cube(const double tolerance)
   for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
     {
       Point<dim> &point = cell->vertex(i);
-      if (std::abs(point(dim - 1) - 1.0) < 1e-5)
-        point(dim - 1) += 0.15;
+      if (std::abs(point[dim - 1] - 1.0) < 1e-5)
+        point[dim - 1] += 0.15;
     }
 
   FE_RaviartThomas<dim> fe(2);

--- a/tests/fe/fe_rt_hessian_divergence_theorem.cc
+++ b/tests/fe/fe_rt_hessian_divergence_theorem.cc
@@ -159,8 +159,8 @@ test_hyper_cube(const double tolerance)
   for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
     {
       Point<dim> &point = cell->vertex(i);
-      if (std::abs(point(dim - 1) - 1.0) < 1e-5)
-        point(dim - 1) += 0.15;
+      if (std::abs(point[dim - 1] - 1.0) < 1e-5)
+        point[dim - 1] += 0.15;
     }
 
   FE_RaviartThomas<dim> fe(2);

--- a/tests/fe/fe_tools_test.cc
+++ b/tests/fe/fe_tools_test.cc
@@ -64,7 +64,7 @@ double
 TestFunction::value(const Point<2> &p, const unsigned int component) const
 {
   Assert(component == 0, ExcInternalError());
-  return std::sin(pi * p(0)) * std::cos(pi * p(1));
+  return std::sin(pi * p[0]) * std::cos(pi * p[1]);
 }
 
 

--- a/tests/fe/fe_values_no_mapping.cc
+++ b/tests/fe/fe_values_no_mapping.cc
@@ -70,12 +70,12 @@ test()
   // Jacobian contains many nonzero entries
   Point<dim> quad_p;
   for (int d = 0; d < dim; ++d)
-    quad_p(d) = 0.42 + 0.11 * d;
+    quad_p[d] = 0.42 + 0.11 * d;
   Quadrature<dim> quad(quad_p);
 
   Point<dim - 1> f_quad_p;
   for (int d = 0; d < dim - 1; ++d)
-    f_quad_p(d) = 0.42 + 0.11 * d;
+    f_quad_p[d] = 0.42 + 0.11 * d;
   Quadrature<dim - 1> f_quad(f_quad_p);
 
 

--- a/tests/fe/fe_values_view_30.cc
+++ b/tests/fe/fe_values_view_30.cc
@@ -66,10 +66,10 @@ VectorFunction<2>::value(const Point<2> &p, const unsigned int component) const
   switch (component)
     {
       case 0:
-        val = pow(p(0), 3);
+        val = pow(p[0], 3);
         break;
       case 1:
-        val = pow(p(1), 2) * p(0);
+        val = pow(p[1], 2) * p[0];
         break;
     }
   return val;
@@ -86,13 +86,13 @@ VectorFunction<3>::value(const Point<3> &p, const unsigned int component) const
   switch (component)
     {
       case 0:
-        val = pow(p(0), 3);
+        val = pow(p[0], 3);
         break;
       case 1:
-        val = pow(p(1), 2) * p(0);
+        val = pow(p[1], 2) * p[0];
         break;
       case 2:
-        val = p(2) * p(1) * p(0);
+        val = p[2] * p[1] * p[0];
         break;
     }
   return val;

--- a/tests/fe/interpolate_common.h
+++ b/tests/fe/interpolate_common.h
@@ -101,7 +101,7 @@ public:
     double result = 1.;
     for (unsigned int d = 0; d < dim; ++d)
       for (unsigned int k = 0; k < degree; ++k)
-        result *= p(d) + c;
+        result *= p[d] + c;
     return result;
   }
 
@@ -119,7 +119,7 @@ public:
         double            result = 1.;
         for (unsigned int d = 0; d < dim; ++d)
           for (unsigned int k = 0; k < degree; ++k)
-            result *= p(d) + c;
+            result *= p[d] + c;
         values[i] = result;
       }
   }
@@ -141,7 +141,7 @@ public:
             double result = 1.;
             for (unsigned int d = 0; d < dim; ++d)
               for (unsigned int k = 0; k < degree; ++k)
-                result *= p(d);
+                result *= p[d];
             values[i](c) = result;
           }
       }

--- a/tests/fe/jacobians.cc
+++ b/tests/fe/jacobians.cc
@@ -47,7 +47,7 @@ do_test(const Triangulation<dim> &tria, const Mapping<dim> &mapping)
   // contains many nonzero entries
   Point<dim> quad_p;
   for (int d = 0; d < dim; ++d)
-    quad_p(d) = 0.42 + 0.11 * d;
+    quad_p[d] = 0.42 + 0.11 * d;
   Quadrature<dim> quad(quad_p);
 
   {

--- a/tests/fe/jacobians_face.cc
+++ b/tests/fe/jacobians_face.cc
@@ -47,7 +47,7 @@ test()
   // Jacobian contains many nonzero entries
   Point<dim - 1> quad_p;
   for (int d = 0; d < dim - 1; ++d)
-    quad_p(d) = 0.42 + 0.11 * d;
+    quad_p[d] = 0.42 + 0.11 * d;
   Quadrature<dim - 1> quad(quad_p);
 
   {

--- a/tests/fe/jacobians_face_cartesian.cc
+++ b/tests/fe/jacobians_face_cartesian.cc
@@ -45,7 +45,7 @@ test()
   // Jacobian contains many nonzero entries
   Point<dim - 1> quad_p;
   for (int d = 0; d < dim - 1; ++d)
-    quad_p(d) = 0.42 + 0.11 * d;
+    quad_p[d] = 0.42 + 0.11 * d;
   Quadrature<dim - 1> quad(quad_p);
 
   {

--- a/tests/fe/jacobians_face_fe_field.cc
+++ b/tests/fe/jacobians_face_fe_field.cc
@@ -63,7 +63,7 @@ test()
   // Jacobian contains many nonzero entries
   Point<dim - 1> quad_p;
   for (int d = 0; d < dim - 1; ++d)
-    quad_p(d) = 0.42 + 0.11 * d;
+    quad_p[d] = 0.42 + 0.11 * d;
   Quadrature<dim - 1> quad(quad_p);
 
   {

--- a/tests/fe/nedelec.cc
+++ b/tests/fe/nedelec.cc
@@ -51,7 +51,7 @@
 Point<2>
 stretch_coordinates(const Point<2> p)
 {
-  return Point<2>(2 * p(0), p(1));
+  return Point<2>(2 * p[0], p[1]);
 }
 
 
@@ -59,7 +59,7 @@ stretch_coordinates(const Point<2> p)
 Point<2>
 tilt_coordinates(const Point<2> p)
 {
-  return Point<2>(p(0) + p(1), p(1));
+  return Point<2>(p[0] + p[1], p[1]);
 }
 
 

--- a/tests/fe/nedelec_non_rect_face.cc
+++ b/tests/fe/nedelec_non_rect_face.cc
@@ -114,9 +114,9 @@ namespace Maxwell
         const Point<dim> &p = points[i];
 
         /* quadratic: */
-        value_list[i](0) = p(0) * p(0);
-        value_list[i](1) = p(1) * p(1);
-        value_list[i](2) = p(2) * p(2);
+        value_list[i](0) = p[0] * p[0];
+        value_list[i](1) = p[1] * p[1];
+        value_list[i](2) = p[2] * p[2];
       }
   }
   // Additional functions to create Neumann conditions, zero in this case.

--- a/tests/fe/p1nc_02.cc
+++ b/tests/fe/p1nc_02.cc
@@ -39,7 +39,7 @@ Point<dim>
 stretch(const Point<dim> &p)
 {
   Point<dim> q = p;
-  q(dim - 1) *= 2.;
+  q[dim - 1] *= 2.;
 
   return q;
 }

--- a/tests/fe/p1nc_03.cc
+++ b/tests/fe/p1nc_03.cc
@@ -41,8 +41,8 @@ affine(const Point<dim> &p)
   Point<dim> q = p;
   if (dim >= 2)
     {
-      q(0) = 2. * p(0) + p(1);
-      q(1) = p(0) + 3. * p(1);
+      q[0] = 2. * p[0] + p[1];
+      q[1] = p[0] + 3. * p[1];
     }
 
   return q;

--- a/tests/fe/p1nc_04.cc
+++ b/tests/fe/p1nc_04.cc
@@ -41,8 +41,8 @@ bilinear(const Point<dim> &p)
   Point<dim> q = p;
   if (dim >= 2)
     {
-      q(0) = 16. * p(0) + 4. * p(1) - 10. * p(0) * p(1);
-      q(1) = 6. * p(1) + 4. * p(0) * p(1);
+      q[0] = 16. * p[0] + 4. * p[1] - 10. * p[0] * p[1];
+      q[1] = 6. * p[1] + 4. * p[0] * p[1];
     }
 
   return q;

--- a/tests/fe/p1nc_06.cc
+++ b/tests/fe/p1nc_06.cc
@@ -39,7 +39,7 @@ Point<dim>
 stretch(const Point<dim> &p)
 {
   Point<dim> q = p;
-  q(dim - 1) *= 2.;
+  q[dim - 1] *= 2.;
 
   return q;
 }

--- a/tests/fe/p1nc_07.cc
+++ b/tests/fe/p1nc_07.cc
@@ -41,8 +41,8 @@ affine(const Point<dim> &p)
   Point<dim> q = p;
   if (dim >= 2)
     {
-      q(0) = 2. * p(0) + p(1);
-      q(1) = p(0) + 3. * p(1);
+      q[0] = 2. * p[0] + p[1];
+      q[1] = p[0] + 3. * p[1];
     }
 
   return q;

--- a/tests/fe/p1nc_08.cc
+++ b/tests/fe/p1nc_08.cc
@@ -41,8 +41,8 @@ bilinear(const Point<dim> &p)
   Point<dim> q = p;
   if (dim >= 2)
     {
-      q(0) = 16. * p(0) + 4. * p(1) - 10. * p(0) * p(1);
-      q(1) = 6. * p(1) + 4. * p(0) * p(1);
+      q[0] = 16. * p[0] + 4. * p[1] - 10. * p[0] * p[1];
+      q[1] = 6. * p[1] + 4. * p[0] * p[1];
     }
 
   return q;

--- a/tests/fe/rt_2.cc
+++ b/tests/fe/rt_2.cc
@@ -45,7 +45,7 @@
 Point<2>
 stretch_coordinates(const Point<2> p)
 {
-  return Point<2>(2 * p(0), p(1));
+  return Point<2>(2 * p[0], p[1]);
 }
 
 
@@ -53,7 +53,7 @@ stretch_coordinates(const Point<2> p)
 Point<2>
 tilt_coordinates(const Point<2> p)
 {
-  return Point<2>(p(0) + p(1), p(1));
+  return Point<2>(p[0] + p[1], p[1]);
 }
 
 

--- a/tests/fe/rt_approximation_01.cc
+++ b/tests/fe/rt_approximation_01.cc
@@ -143,10 +143,10 @@ double
 TestDef1<dim>::value(const Point<dim> &p, const unsigned int component) const
 {
   Point<2> center;
-  center(0)    = 0.5;
-  center(1)    = 0.5;
+  center[0]    = 0.5;
+  center[1]    = 0.5;
   double rad   = p.distance(center),
-         phi_p = atan2(p(0) - center(0), p(1) - center(1));
+         phi_p = atan2(p[0] - center[0], p[1] - center[1]);
 
   if (component == 0)
     return rad * (sin(phi + phi_p) - sin(phi_p));
@@ -197,7 +197,7 @@ template <int dim>
 double
 TestDef2<dim>::value(const Point<dim> &p, const unsigned int component) const
 {
-  double x = p(0), y = p(1);
+  double x = p[0], y = p[1];
 
   if (component == 0)
     return scale * x;
@@ -249,7 +249,7 @@ template <int dim>
 double
 TestDef3<dim>::value(const Point<dim> &p, const unsigned int component) const
 {
-  double y = p(1);
+  double y = p[1];
 
   if (component == 0)
     return scale * y;
@@ -308,7 +308,7 @@ template <int dim>
 double
 TestPoly<dim>::value(const Point<dim> &p, const unsigned int component) const
 {
-  double x = p(0), y = p(1);
+  double x = p[0], y = p[1];
 
   // Ugly hack, but should do the job ...
   if (component == 0)

--- a/tests/fe/rt_bubbles_2.cc
+++ b/tests/fe/rt_bubbles_2.cc
@@ -44,7 +44,7 @@
 Point<2>
 stretch_coordinates(const Point<2> p)
 {
-  return Point<2>(2 * p(0), p(1));
+  return Point<2>(2 * p[0], p[1]);
 }
 
 
@@ -52,7 +52,7 @@ stretch_coordinates(const Point<2> p)
 Point<2>
 tilt_coordinates(const Point<2> p)
 {
-  return Point<2>(p(0) + p(1), p(1));
+  return Point<2>(p[0] + p[1], p[1]);
 }
 
 

--- a/tests/fe/up_and_down.cc
+++ b/tests/fe/up_and_down.cc
@@ -49,11 +49,11 @@ transform(const Point<dim> p)
       case 1:
         return p;
       case 2:
-        return Point<dim>(p(0) * (1 + p(1)), p(1) * (1 + p(0)));
+        return Point<dim>(p[0] * (1 + p[1]), p[1] * (1 + p[0]));
       case 3:
-        return Point<dim>(p(0) * (1 + p(1)) * (1 + p(2)),
-                          p(1) * (1 + p(0)) * (1 + p(2)),
-                          p(2) * (1 + p(0)) * (1 + p(1)));
+        return Point<dim>(p[0] * (1 + p[1]) * (1 + p[2]),
+                          p[1] * (1 + p[0]) * (1 + p[2]),
+                          p[2] * (1 + p[0]) * (1 + p[1]));
       default:
         Assert(false, ExcNotImplemented());
         return Point<dim>();

--- a/tests/feinterface/step-12.cc
+++ b/tests/feinterface/step-12.cc
@@ -176,7 +176,7 @@ namespace Step12
 
     for (unsigned int i = 0; i < values.size(); ++i)
       {
-        if (points[i](0) < 0.5)
+        if (points[i][0] < 0.5)
           values[i] = 1.;
         else
           values[i] = 0.;
@@ -191,8 +191,8 @@ namespace Step12
     Assert(dim >= 2, ExcNotImplemented());
 
     Point<dim> wind_field;
-    wind_field(0) = -p(1);
-    wind_field(1) = p(0);
+    wind_field[0] = -p[1];
+    wind_field[1] = p[0];
     wind_field /= wind_field.norm();
 
     return wind_field;

--- a/tests/feinterface/stokes.cc
+++ b/tests/feinterface/stokes.cc
@@ -157,8 +157,8 @@ namespace StokesTests
   Solution<2>::value(const Point<2> &p, const unsigned int component) const
   {
     using numbers::PI;
-    const double x = p(0);
-    const double y = p(1);
+    const double x = p[0];
+    const double y = p[1];
     // zero on BD's
     if (component == 0)
       return PI * sin(PI * x) * sin(PI * x) * sin(2.0 * PI * y);
@@ -177,9 +177,9 @@ namespace StokesTests
     Assert(component <= 3 + 1, ExcIndexRange(component, 0, 3 + 1));
 
     using numbers::PI;
-    const double x = p(0);
-    const double y = p(1);
-    const double z = p(2);
+    const double x = p[0];
+    const double y = p[1];
+    const double z = p[2];
 
     if (component == 0)
       return 2. * PI * sin(PI * x) * sin(PI * x) * sin(2.0 * PI * y) *
@@ -204,8 +204,8 @@ namespace StokesTests
     Assert(component <= 2, ExcIndexRange(component, 0, 2 + 1));
 
     using numbers::PI;
-    const double x = p(0);
-    const double y = p(1);
+    const double x = p[0];
+    const double y = p[1];
 
     Tensor<1, 2> return_value;
     if (component == 0)
@@ -236,9 +236,9 @@ namespace StokesTests
     Assert(component <= 3, ExcIndexRange(component, 0, 3 + 1));
 
     using numbers::PI;
-    const double x = p(0);
-    const double y = p(1);
-    const double z = p(2);
+    const double x = p[0];
+    const double y = p[1];
+    const double z = p[2];
 
     Tensor<1, 3> return_value;
     if (component == 0)
@@ -300,8 +300,8 @@ namespace StokesTests
     Assert(component <= 2, ExcIndexRange(component, 0, 2 + 1));
 
     using numbers::PI;
-    double x  = p(0);
-    double y  = p(1);
+    double x  = p[0];
+    double y  = p[1];
     double nu = 1.0;
 
     // RHS for 0 BD's
@@ -327,9 +327,9 @@ namespace StokesTests
     Assert(component <= 3, ExcIndexRange(component, 0, 3 + 1));
 
     using numbers::PI;
-    double x = p(0);
-    double y = p(1);
-    double z = p(2);
+    double x = p[0];
+    double y = p[1];
+    double z = p[2];
 
     if (component == 0)
       return 4. * PI * PI * PI *

--- a/tests/fullydistributed_grids/copy_serial_tria_04.cc
+++ b/tests/fullydistributed_grids/copy_serial_tria_04.cc
@@ -49,21 +49,21 @@ test(const int n_refinements, const int n_subdivisions, MPI_Comm comm)
     auto endc = tria.end();
     for (; cell != endc; ++cell)
       for (const unsigned int face_number : GeometryInfo<dim>::face_indices())
-        if (std::fabs(cell->face(face_number)->center()(0) - left) < 1e-12)
+        if (std::fabs(cell->face(face_number)->center()[0] - left) < 1e-12)
           cell->face(face_number)->set_all_boundary_ids(1);
-        else if (std::fabs(cell->face(face_number)->center()(0) - right) <
+        else if (std::fabs(cell->face(face_number)->center()[0] - right) <
                  1e-12)
           cell->face(face_number)->set_all_boundary_ids(2);
         else if (dim >= 2 &&
-                 std::fabs(cell->face(face_number)->center()(1) - left) < 1e-12)
+                 std::fabs(cell->face(face_number)->center()[1] - left) < 1e-12)
           cell->face(face_number)->set_all_boundary_ids(3);
-        else if (dim >= 2 && std::fabs(cell->face(face_number)->center()(1) -
+        else if (dim >= 2 && std::fabs(cell->face(face_number)->center()[1] -
                                        right) < 1e-12)
           cell->face(face_number)->set_all_boundary_ids(4);
         else if (dim >= 3 &&
-                 std::fabs(cell->face(face_number)->center()(2) - left) < 1e-12)
+                 std::fabs(cell->face(face_number)->center()[2] - left) < 1e-12)
           cell->face(face_number)->set_all_boundary_ids(5);
-        else if (dim >= 3 && std::fabs(cell->face(face_number)->center()(2) -
+        else if (dim >= 3 && std::fabs(cell->face(face_number)->center()[2] -
                                        right) < 1e-12)
           cell->face(face_number)->set_all_boundary_ids(6);
 

--- a/tests/grid/enclosing_sphere_01.cc
+++ b/tests/grid/enclosing_sphere_01.cc
@@ -55,16 +55,16 @@ create_triangulation(const unsigned int case_no, Triangulation<2> &tria)
         {
           GridGenerator::hyper_cube(tria, 1., 3.);
           Point<2> &v0 = tria.begin_active()->vertex(0);
-          v0(0)        = 0.;
+          v0[0]        = 0.;
           break;
         }
       case 2:
         {
           GridGenerator::hyper_cube(tria, 1., 3.);
           Point<2> &v0 = tria.begin_active()->vertex(0);
-          v0(0)        = 0.;
+          v0[0]        = 0.;
           Point<2> &v3 = tria.begin_active()->vertex(3);
-          v3(0)        = 4.;
+          v3[0]        = 4.;
           break;
         }
       case 3:
@@ -120,7 +120,7 @@ create_triangulation(const unsigned int case_no, Triangulation<3> &tria)
         {
           GridGenerator::hyper_cube(tria, 1., 3.);
           Point<3> &v0 = tria.begin_active()->vertex(0);
-          v0(0)        = 0.;
+          v0[0]        = 0.;
           break;
         }
       case 3:

--- a/tests/grid/extent_in_direction.cc
+++ b/tests/grid/extent_in_direction.cc
@@ -55,10 +55,10 @@ create_triangulation(const unsigned int case_no, Triangulation<2> &tria)
         {
           GridGenerator::hyper_cube(tria, 1., 3.);
           Point<2> &v0 = tria.begin_active()->vertex(0);
-          v0(0)        = 0.;
+          v0[0]        = 0.;
           Point<2> &v2 = tria.begin_active()->vertex(3);
-          v2(0)        = 5.;
-          v2(1)        = 4.;
+          v2[0]        = 5.;
+          v2[1]        = 4.;
           break;
         }
       default:
@@ -79,7 +79,7 @@ create_triangulation(const unsigned int case_no, Triangulation<3> &tria)
         {
           GridGenerator::hyper_cube(tria, 1., 3.);
           Point<3> &v0 = tria.begin_active()->vertex(0);
-          v0(0)        = 0.;
+          v0[0]        = 0.;
           break;
         }
       default:

--- a/tests/grid/filtered_iterator.cc
+++ b/tests/grid/filtered_iterator.cc
@@ -76,7 +76,7 @@ test()
     {
       unsigned int subdomain = 0;
       for (unsigned int d = 0; d < 2; ++d)
-        if (cell->center()(d) > 0)
+        if (cell->center()[d] > 0)
           subdomain |= (1 << d);
       AssertThrow(subdomain < (1 << 2), ExcInternalError());
 

--- a/tests/grid/filtered_iterator_02.cc
+++ b/tests/grid/filtered_iterator_02.cc
@@ -76,7 +76,7 @@ test()
     {
       unsigned int subdomain = 0;
       for (unsigned int d = 0; d < 2; ++d)
-        if (cell->center()(d) > 0)
+        if (cell->center()[d] > 0)
           subdomain |= (1 << d);
       AssertThrow(subdomain < (1 << 2), ExcInternalError());
 

--- a/tests/grid/filtered_iterator_03.cc
+++ b/tests/grid/filtered_iterator_03.cc
@@ -68,7 +68,7 @@ test()
     {
       unsigned int subdomain = 0;
       for (unsigned int d = 0; d < 2; ++d)
-        if (cell->center()(d) > 0)
+        if (cell->center()[d] > 0)
           subdomain |= (1 << d);
       AssertThrow(subdomain < (1 << 2), ExcInternalError());
 

--- a/tests/grid/grid_generator_09.cc
+++ b/tests/grid/grid_generator_09.cc
@@ -35,8 +35,8 @@ check_rect1(unsigned int n, bool color, bool log)
 
   for (unsigned int d = 0; d < dim; ++d)
     {
-      left(d)         = -1.;
-      right(d)        = d + 2;
+      left[d]         = -1.;
+      right[d]        = d + 2;
       subdivisions[d] = n * (d + 3);
     }
   Triangulation<dim> tria;

--- a/tests/grid/grid_generator_10.cc
+++ b/tests/grid/grid_generator_10.cc
@@ -56,9 +56,9 @@ my_cylinder(Triangulation<3> &tria,
   // Turn cylinder such that y->x
   for (unsigned int i = 0; i < 16; ++i)
     {
-      const double h = vertices[i](1);
-      vertices[i](1) = -vertices[i](0);
-      vertices[i](0) = h;
+      const double h = vertices[i][1];
+      vertices[i][1] = -vertices[i][0];
+      vertices[i][0] = h;
     }
 
   int cell_vertices[5][8] = {{0, 1, 8, 9, 2, 3, 10, 11},

--- a/tests/grid/grid_generator_general_cell_01.cc
+++ b/tests/grid/grid_generator_general_cell_01.cc
@@ -25,14 +25,14 @@ void
 dim_2(std::ostream &os)
 {
   std::vector<Point<2>> vertices(4);
-  vertices[0](0) = -1.;
-  vertices[0](1) = -1.;
-  vertices[1](0) = 1.;
-  vertices[1](1) = -1.5;
-  vertices[2](0) = 1.5;
-  vertices[2](1) = 1.5;
-  vertices[3](0) = 2.;
-  vertices[3](1) = 0.5;
+  vertices[0][0] = -1.;
+  vertices[0][1] = -1.;
+  vertices[1][0] = 1.;
+  vertices[1][1] = -1.5;
+  vertices[2][0] = 1.5;
+  vertices[2][1] = 1.5;
+  vertices[3][0] = 2.;
+  vertices[3][1] = 0.5;
 
   Triangulation<2> tria;
   GridGenerator::general_cell<2>(tria, vertices);
@@ -45,30 +45,30 @@ void
 dim_3(std::ostream &os)
 {
   std::vector<Point<3>> vertices(8);
-  vertices[0](0) = -1.;
-  vertices[0](1) = -1.;
-  vertices[0](2) = -1.;
-  vertices[1](0) = 1.;
-  vertices[1](1) = -1.5;
-  vertices[1](2) = -1.5;
-  vertices[2](0) = 2.;
-  vertices[2](1) = 1.5;
-  vertices[2](2) = -2.;
-  vertices[3](0) = 2.5;
-  vertices[3](1) = 0.5;
-  vertices[3](2) = -3.;
-  vertices[4](0) = -1.;
-  vertices[4](1) = -1.;
-  vertices[4](2) = 1.;
-  vertices[5](0) = 1.;
-  vertices[5](1) = -1.5;
-  vertices[5](2) = 1.5;
-  vertices[6](0) = 2.;
-  vertices[6](1) = 1.5;
-  vertices[6](2) = 2.;
-  vertices[7](0) = 2.;
-  vertices[7](1) = 0.5;
-  vertices[7](2) = 3.;
+  vertices[0][0] = -1.;
+  vertices[0][1] = -1.;
+  vertices[0][2] = -1.;
+  vertices[1][0] = 1.;
+  vertices[1][1] = -1.5;
+  vertices[1][2] = -1.5;
+  vertices[2][0] = 2.;
+  vertices[2][1] = 1.5;
+  vertices[2][2] = -2.;
+  vertices[3][0] = 2.5;
+  vertices[3][1] = 0.5;
+  vertices[3][2] = -3.;
+  vertices[4][0] = -1.;
+  vertices[4][1] = -1.;
+  vertices[4][2] = 1.;
+  vertices[5][0] = 1.;
+  vertices[5][1] = -1.5;
+  vertices[5][2] = 1.5;
+  vertices[6][0] = 2.;
+  vertices[6][1] = 1.5;
+  vertices[6][2] = 2.;
+  vertices[7][0] = 2.;
+  vertices[7][1] = 0.5;
+  vertices[7][2] = 3.;
 
   Triangulation<3> tria;
   GridGenerator::general_cell<3>(tria, vertices);

--- a/tests/grid/grid_generator_general_cell_02.cc
+++ b/tests/grid/grid_generator_general_cell_02.cc
@@ -25,21 +25,21 @@ void
 dim_2_3(std::ostream &os)
 {
   std::vector<Point<3>> vertices(4);
-  vertices[0](0) = -1.;
-  vertices[0](1) = -1.;
-  vertices[0](0) = 0.;
+  vertices[0][0] = -1.;
+  vertices[0][1] = -1.;
+  vertices[0][0] = 0.;
 
-  vertices[1](0) = 1.;
-  vertices[1](1) = -1.5;
-  vertices[1](2) = 0.;
+  vertices[1][0] = 1.;
+  vertices[1][1] = -1.5;
+  vertices[1][2] = 0.;
 
-  vertices[2](0) = 1.5;
-  vertices[2](1) = 1.5;
-  vertices[2](2) = 0.;
+  vertices[2][0] = 1.5;
+  vertices[2][1] = 1.5;
+  vertices[2][2] = 0.;
 
-  vertices[3](0) = 2.;
-  vertices[3](1) = 0.5;
-  vertices[3](2) = 0.;
+  vertices[3][0] = 2.;
+  vertices[3][1] = 0.5;
+  vertices[3][2] = 0.;
 
   Triangulation<2, 3> tria;
   GridGenerator::general_cell<2, 3>(tria, vertices);
@@ -52,12 +52,12 @@ void
 dim_1_3(std::ostream &os)
 {
   std::vector<Point<3>> vertices(2);
-  vertices[0](0) = -1.;
-  vertices[0](1) = -1.;
-  vertices[0](2) = -1.;
-  vertices[1](0) = 1.;
-  vertices[1](1) = -1.5;
-  vertices[1](2) = -1.5;
+  vertices[0][0] = -1.;
+  vertices[0][1] = -1.;
+  vertices[0][2] = -1.;
+  vertices[1][0] = 1.;
+  vertices[1][1] = -1.5;
+  vertices[1][2] = -1.5;
 
   Triangulation<1, 3> tria;
   GridGenerator::general_cell<1, 3>(tria, vertices);
@@ -70,11 +70,11 @@ void
 dim_1_2(std::ostream &os)
 {
   std::vector<Point<2>> vertices(2);
-  vertices[0](0) = -1.;
-  vertices[0](1) = -1.;
+  vertices[0][0] = -1.;
+  vertices[0][1] = -1.;
 
-  vertices[1](0) = 1.;
-  vertices[1](1) = -1.5;
+  vertices[1][0] = 1.;
+  vertices[1][1] = -1.5;
 
   Triangulation<1, 2> tria;
   GridGenerator::general_cell<1, 2>(tria, vertices);

--- a/tests/grid/grid_generator_simplex.cc
+++ b/tests/grid/grid_generator_simplex.cc
@@ -32,10 +32,10 @@ dim_2(std::ostream &os)
   Triangulation<d>   tr;
 
   std::vector<Point<d>> vertices(d + 1);
-  vertices[1](0) = 0.5;
-  vertices[1](1) = .85;
-  vertices[2](0) = -0.5;
-  vertices[2](1) = .85;
+  vertices[1][0] = 0.5;
+  vertices[1][1] = .85;
+  vertices[2][0] = -0.5;
+  vertices[2][1] = .85;
   GridGenerator::simplex(tr, vertices);
 
   GridOut gout;
@@ -49,18 +49,18 @@ dim_3(std::ostream &os)
   Triangulation<d>   tr;
 
   std::vector<Point<d>> vertices(d + 1);
-  vertices[0](0) = 1.;
-  vertices[0](1) = 0.;
-  vertices[0](2) = .7;
-  vertices[1](0) = -1.;
-  vertices[1](1) = 0.;
-  vertices[1](2) = .7;
-  vertices[2](0) = 0.;
-  vertices[2](1) = 1.;
-  vertices[2](2) = -.7;
-  vertices[3](0) = 0.;
-  vertices[3](1) = -1.;
-  vertices[3](2) = -.7;
+  vertices[0][0] = 1.;
+  vertices[0][1] = 0.;
+  vertices[0][2] = .7;
+  vertices[1][0] = -1.;
+  vertices[1][1] = 0.;
+  vertices[1][2] = .7;
+  vertices[2][0] = 0.;
+  vertices[2][1] = 1.;
+  vertices[2][2] = -.7;
+  vertices[3][0] = 0.;
+  vertices[3][1] = -1.;
+  vertices[3][2] = -.7;
   GridGenerator::simplex(tr, vertices);
 
   GridOut gout;

--- a/tests/grid/grid_invert.cc
+++ b/tests/grid/grid_invert.cc
@@ -31,18 +31,18 @@ void
 test(bool second_case = false)
 {
   std::vector<Point<dim>> vertices(GeometryInfo<dim>::vertices_per_cell);
-  vertices[1](1) = 1;
-  vertices[2](0) = 1;
-  vertices[2](1) = 1;
-  vertices[3](0) = 1;
+  vertices[1][1] = 1;
+  vertices[2][0] = 1;
+  vertices[2][1] = 1;
+  vertices[3][0] = 1;
   if (dim == 3)
     {
       for (unsigned int i = 4; i < GeometryInfo<dim>::vertices_per_cell; ++i)
-        vertices[i](2) = -1;
-      vertices[5](1) = 1;
-      vertices[6](0) = 1;
-      vertices[6](1) = 1;
-      vertices[7](0) = 1;
+        vertices[i][2] = -1;
+      vertices[5][1] = 1;
+      vertices[6][0] = 1;
+      vertices[6][1] = 1;
+      vertices[7][0] = 1;
     }
   std::vector<CellData<dim>> cells(1);
   for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
@@ -53,7 +53,7 @@ test(bool second_case = false)
       std::swap(cells[0].vertices[1], cells[0].vertices[3]);
       std::swap(cells[0].vertices[5], cells[0].vertices[7]);
       for (unsigned int i = 4; i < GeometryInfo<dim>::vertices_per_cell; ++i)
-        vertices[i](2) = 1;
+        vertices[i][2] = 1;
     }
 
   SubCellData subcelldata;

--- a/tests/grid/grid_invert_02.cc
+++ b/tests/grid/grid_invert_02.cc
@@ -36,13 +36,13 @@ test()
 {
   const static int        dim = 2;
   std::vector<Point<dim>> vertices(6);
-  vertices[1](1) = 1;
-  vertices[2](0) = 1;
-  vertices[3](0) = 1;
-  vertices[3](1) = 1;
-  vertices[4](0) = 2;
-  vertices[5](0) = 2;
-  vertices[5](1) = 1;
+  vertices[1][1] = 1;
+  vertices[2][0] = 1;
+  vertices[3][0] = 1;
+  vertices[3][1] = 1;
+  vertices[4][0] = 2;
+  vertices[5][0] = 2;
+  vertices[5][1] = 1;
 
   std::vector<CellData<dim>> cells(2);
   for (const unsigned int i : GeometryInfo<dim>::vertex_indices())

--- a/tests/grid/grid_test.cc
+++ b/tests/grid/grid_test.cc
@@ -43,11 +43,11 @@ public:
       FlatManifold<dim>::get_new_point(surrounding_points, weights);
 
     for (int i = 0; i < dim; ++i)
-      middle(i) -= .5;
+      middle[i] -= .5;
     middle *=
       std::sqrt(static_cast<double>(dim)) / (std::sqrt(middle.square()) * 2);
     for (int i = 0; i < dim; ++i)
-      middle(i) += .5;
+      middle[i] += .5;
 
     return middle;
   }
@@ -88,7 +88,7 @@ CurvedLine<dim>::get_new_point_on_line(
   // 0 or 1, then the z-values of all
   // vertices of the line is like that
   if (dim >= 3)
-    if (((middle(2) == 0) || (middle(2) == 1))
+    if (((middle[2] == 0) || (middle[2] == 1))
         // find out, if the line is in the
         // interior of the top or bottom face
         // of the domain, or at the edge.
@@ -105,18 +105,18 @@ CurvedLine<dim>::get_new_point_on_line(
       return middle;
 
 
-  double x = middle(0), y = middle(1);
+  double x = middle[0], y = middle[1];
 
   if (y < x)
     if (y < 1 - x)
-      middle(1) = 0.04 * std::sin(6 * numbers::PI * middle(0));
+      middle[1] = 0.04 * std::sin(6 * numbers::PI * middle[0]);
     else
-      middle(0) = 1 + 0.04 * std::sin(6 * numbers::PI * middle(1));
+      middle[0] = 1 + 0.04 * std::sin(6 * numbers::PI * middle[1]);
 
   else if (y < 1 - x)
-    middle(0) = 0.04 * std::sin(6 * numbers::PI * middle(1));
+    middle[0] = 0.04 * std::sin(6 * numbers::PI * middle[1]);
   else
-    middle(1) = 1 + 0.04 * std::sin(6 * numbers::PI * middle(0));
+    middle[1] = 1 + 0.04 * std::sin(6 * numbers::PI * middle[0]);
 
   return middle;
 }
@@ -135,21 +135,21 @@ CurvedLine<dim>::get_new_point_on_quad(
   // z-value of the midpoint is either
   // 0 or 1, then the z-values of all
   // vertices of the quad is like that
-  if (dim == 3 && ((middle(dim - 1) == 0) || (middle(dim - 1) == 1)))
+  if (dim == 3 && ((middle[dim - 1] == 0) || (middle[dim - 1] == 1)))
     return middle;
 
-  double x = middle(0), y = middle(1);
+  double x = middle[0], y = middle[1];
 
   if (y < x)
     if (y < 1 - x)
-      middle(1) = 0.04 * std::sin(6 * numbers::PI * middle(0));
+      middle[1] = 0.04 * std::sin(6 * numbers::PI * middle[0]);
     else
-      middle(0) = 1 + 0.04 * std::sin(6 * numbers::PI * middle(1));
+      middle[0] = 1 + 0.04 * std::sin(6 * numbers::PI * middle[1]);
 
   else if (y < 1 - x)
-    middle(0) = 0.04 * std::sin(6 * numbers::PI * middle(1));
+    middle[0] = 0.04 * std::sin(6 * numbers::PI * middle[1]);
   else
-    middle(1) = 1 + 0.04 * std::sin(6 * numbers::PI * middle(0));
+    middle[1] = 1 + 0.04 * std::sin(6 * numbers::PI * middle[0]);
 
   return middle;
 }

--- a/tests/grid/grid_tools_05.cc
+++ b/tests/grid/grid_tools_05.cc
@@ -74,9 +74,9 @@ generate_grid(Triangulation<2> &triangulation)
   // Look for the two outermost faces:
   for (const unsigned int j : GeometryInfo<2>::face_indices())
     {
-      if (cell_1->face(j)->center()(1) > 2.9)
+      if (cell_1->face(j)->center()[1] > 2.9)
         face_1 = cell_1->face(j);
-      if (cell_2->face(j)->center()(1) < -2.9)
+      if (cell_2->face(j)->center()[1] < -2.9)
         face_2 = cell_2->face(j);
     }
   face_1->set_boundary_id(42);
@@ -137,9 +137,9 @@ generate_grid(Triangulation<3> &triangulation)
   // Look for the two outermost faces:
   for (const unsigned int j : GeometryInfo<3>::face_indices())
     {
-      if (cell_1->face(j)->center()(2) > 2.9)
+      if (cell_1->face(j)->center()[2] > 2.9)
         face_1 = cell_1->face(j);
-      if (cell_2->face(j)->center()(2) < -2.9)
+      if (cell_2->face(j)->center()[2] < -2.9)
         face_2 = cell_2->face(j);
     }
   face_1->set_boundary_id(42);

--- a/tests/grid/grid_tools_06.cc
+++ b/tests/grid/grid_tools_06.cc
@@ -79,9 +79,9 @@ generate_grid(Triangulation<2> &triangulation, int orientation)
   // Look for the two outermost faces:
   for (const unsigned int j : GeometryInfo<2>::face_indices())
     {
-      if (cell_1->face(j)->center()(1) > 2.9)
+      if (cell_1->face(j)->center()[1] > 2.9)
         face_1 = cell_1->face(j);
-      if (cell_2->face(j)->center()(1) < -2.9)
+      if (cell_2->face(j)->center()[1] < -2.9)
         face_2 = cell_2->face(j);
     }
   face_1->set_boundary_id(42);
@@ -150,9 +150,9 @@ generate_grid(Triangulation<3> &triangulation, int orientation)
   // Look for the two outermost faces:
   for (const unsigned int j : GeometryInfo<3>::face_indices())
     {
-      if (cell_1->face(j)->center()(2) > 2.9)
+      if (cell_1->face(j)->center()[2] > 2.9)
         face_1 = cell_1->face(j);
-      if (cell_2->face(j)->center()(2) < -2.9)
+      if (cell_2->face(j)->center()[2] < -2.9)
         face_2 = cell_2->face(j);
     }
   face_1->set_boundary_id(42);

--- a/tests/grid/grid_tools_transform_01.cc
+++ b/tests/grid/grid_tools_transform_01.cc
@@ -31,14 +31,14 @@ template <>
 Point<2>
 trans_func(const Point<2> &p)
 {
-  Point<2> r(p(0) + p(1) * p(1), p(1));
+  Point<2> r(p[0] + p[1] * p[1], p[1]);
   return r;
 }
 template <>
 Point<3>
 trans_func(const Point<3> &p)
 {
-  Point<3> r(p(0) + p(1) * p(1), p(1), p(2));
+  Point<3> r(p[0] + p[1] * p[1], p[1], p[2]);
   return r;
 }
 

--- a/tests/grid/measure_et_al.cc
+++ b/tests/grid/measure_et_al.cc
@@ -47,10 +47,10 @@ create_triangulation(const unsigned int case_no, Triangulation<2> &tria)
         {
           GridGenerator::hyper_cube(tria, 1., 3.);
           Point<2> &v0 = tria.begin_active()->vertex(0);
-          v0(0)        = 0.;
+          v0[0]        = 0.;
           Point<2> &v2 = tria.begin_active()->vertex(3);
-          v2(0)        = 5.;
-          v2(1)        = 4.;
+          v2[0]        = 5.;
+          v2[1]        = 4.;
           //      exact_areas.push_back(7.);
           break;
         }
@@ -73,7 +73,7 @@ create_triangulation(const unsigned int case_no, Triangulation<3> &tria)
         {
           GridGenerator::hyper_cube(tria, 1., 3.);
           Point<3> &v0 = tria.begin_active()->vertex(0);
-          v0(0)        = 0.;
+          v0[0]        = 0.;
           break;
         }
       default:

--- a/tests/grid/measure_et_al_02.cc
+++ b/tests/grid/measure_et_al_02.cc
@@ -48,16 +48,16 @@ create_triangulation(const unsigned int case_no, Triangulation<2> &tria)
         {
           GridGenerator::hyper_cube(tria, 1., 3.);
           Point<2> &v0 = tria.begin_active()->vertex(0);
-          v0(0)        = 0.;
+          v0[0]        = 0.;
           break;
         }
       case 2:
         {
           GridGenerator::hyper_cube(tria, 1., 3.);
           Point<2> &v0 = tria.begin_active()->vertex(0);
-          v0(0)        = 0.;
+          v0[0]        = 0.;
           Point<2> &v3 = tria.begin_active()->vertex(3);
-          v3(0)        = 4.;
+          v3[0]        = 4.;
           break;
         }
       default:
@@ -80,7 +80,7 @@ create_triangulation(const unsigned int case_no, Triangulation<3> &tria)
         {
           GridGenerator::hyper_cube(tria, 1., 3.);
           Point<3> &v0 = tria.begin_active()->vertex(0);
-          v0(0)        = 0.;
+          v0[0]        = 0.;
           break;
         }
       default:

--- a/tests/grid/measure_of_3d_face_01.cc
+++ b/tests/grid/measure_of_3d_face_01.cc
@@ -31,9 +31,9 @@
 Point<3>
 distort_planar(Point<3> p)
 {
-  if (p(1) > 0.5 && p(2) > 0.5)
+  if (p[1] > 0.5 && p[2] > 0.5)
     {
-      p(1) += 1;
+      p[1] += 1;
     }
   return p;
 }
@@ -44,9 +44,9 @@ distort_planar(Point<3> p)
 Point<3>
 distort_twisted(Point<3> p)
 {
-  if (p(2) > 0.5 && ((p(0) > 0.5) ^ (p(1) > 0.5)))
+  if (p[2] > 0.5 && ((p[0] > 0.5) ^ (p[1] > 0.5)))
     {
-      p(2) += 1;
+      p[2] += 1;
     }
   return p;
 }

--- a/tests/grid/subcelldata.cc
+++ b/tests/grid/subcelldata.cc
@@ -41,14 +41,14 @@ test()
   Assert(dim == 2 || dim == 3, ExcNotImplemented());
 
   std::vector<Point<dim>> vertices(GeometryInfo<dim>::vertices_per_cell);
-  vertices[0](0) = 0;
-  vertices[0](1) = 0;
-  vertices[1](0) = 2;
-  vertices[1](1) = 1;
-  vertices[2](0) = 3;
-  vertices[2](1) = 3;
-  vertices[3](0) = 0;
-  vertices[3](1) = 1;
+  vertices[0][0] = 0;
+  vertices[0][1] = 0;
+  vertices[1][0] = 2;
+  vertices[1][1] = 1;
+  vertices[2][0] = 3;
+  vertices[2][1] = 3;
+  vertices[3][0] = 0;
+  vertices[3][1] = 1;
   if (dim == 3)
     {
       // for the new numbering
@@ -60,9 +60,9 @@ test()
       // for the old numbering
       for (unsigned int i = 0; i < 4; ++i)
         {
-          std::swap(vertices[i](1), vertices[i](2));
+          std::swap(vertices[i][1], vertices[i][2]);
           vertices[i + 4]    = vertices[i];
-          vertices[i + 4](1) = 1;
+          vertices[i + 4][1] = 1;
         }
     }
 

--- a/tests/grid/subdomain_ids.cc
+++ b/tests/grid/subdomain_ids.cc
@@ -59,7 +59,7 @@ test()
     {
       unsigned int subdomain = 0;
       for (unsigned int d = 0; d < dim; ++d)
-        if (cell->center()(d) > 0)
+        if (cell->center()[d] > 0)
           subdomain |= (1 << d);
       AssertThrow(subdomain < (1 << dim), ExcInternalError());
 

--- a/tests/hp/compare_hp_vs_nonhp_01.cc
+++ b/tests/hp/compare_hp_vs_nonhp_01.cc
@@ -62,7 +62,7 @@ template <int dim>
 double
 ExactSolution<dim>::value(const Point<dim> &p, const unsigned int) const
 {
-  return p(0) * p(0);
+  return p[0] * p[0];
 }
 
 template <int dim>

--- a/tests/hp/crash_19.cc
+++ b/tests/hp/crash_19.cc
@@ -66,7 +66,7 @@ public:
   virtual double
   value(const Point<dim> &p, const unsigned int) const
   {
-    return p(0);
+    return p[0];
   }
 };
 

--- a/tests/hp/crash_22.cc
+++ b/tests/hp/crash_22.cc
@@ -39,15 +39,15 @@ test()
 
   /*Make a square*/
   Point<dim> point_1, point_2;
-  point_1(0) = 0;
-  point_1(1) = 0;
-  point_2(0) = 1;
-  point_2(1) = 1;
+  point_1[0] = 0;
+  point_1[1] = 0;
+  point_2[0] = 1;
+  point_2[1] = 1;
   GridGenerator::hyper_rectangle(triangulation, point_1, point_2);
 
   Triangulation<dim> triangulation_temp;
-  point_1(0) = 1;
-  point_2(0) = 2;
+  point_1[0] = 1;
+  point_2[0] = 2;
   GridGenerator::hyper_rectangle(triangulation_temp, point_1, point_2);
   /*glue squares together*/
   GridGenerator::merge_triangulations(triangulation_temp,

--- a/tests/hp/hp_hanging_nodes_01.cc
+++ b/tests/hp/hp_hanging_nodes_01.cc
@@ -62,8 +62,8 @@ generate_grid(Triangulation<dim, spacedim> &tria)
   // Define a rectangular shape
   for (unsigned int d = 0; d < dim; ++d)
     {
-      p1(d) = 0;
-      p2(d) = (d == 0) ? 2.0 : 1.0;
+      p1[d] = 0;
+      p2[d] = (d == 0) ? 2.0 : 1.0;
       sub_div.push_back((d == 0) ? 2 : 1);
     }
   GridGenerator::subdivided_hyper_rectangle(tria, sub_div, p1, p2, true);

--- a/tests/hp/step-12.cc
+++ b/tests/hp/step-12.cc
@@ -112,8 +112,8 @@ Beta<dim>::value_list(const std::vector<Point<dim>> &points,
       const Point<dim> &p    = points[i];
       Point<dim>       &beta = values[i];
 
-      beta(0) = -p(1);
-      beta(1) = p(0);
+      beta[0] = -p[1];
+      beta[1] = p[0];
       beta /= std::sqrt(beta.square());
     }
 }
@@ -130,7 +130,7 @@ BoundaryValues<dim>::value_list(const std::vector<Point<dim>> &points,
 
   for (unsigned int i = 0; i < values.size(); ++i)
     {
-      if (points[i](0) < 0.5)
+      if (points[i][0] < 0.5)
         values[i] = 1.;
       else
         values[i] = 0.;

--- a/tests/hp/step-13.cc
+++ b/tests/hp/step-13.cc
@@ -671,9 +671,9 @@ double
 Solution<dim>::value(const Point<dim> &p,
                      const unsigned int /*component*/) const
 {
-  double q = p(0);
+  double q = p[0];
   for (unsigned int i = 1; i < dim; ++i)
-    q += std::sin(10 * p(i) + 5 * p(0) * p(0));
+    q += std::sin(10 * p[i] + 5 * p[0] * p[0]);
   const double exponential = std::exp(q);
   return exponential;
 }
@@ -698,19 +698,19 @@ double
 RightHandSide<dim>::value(const Point<dim> &p,
                           const unsigned int /*component*/) const
 {
-  double q = p(0);
+  double q = p[0];
   for (unsigned int i = 1; i < dim; ++i)
-    q += std::sin(10 * p(i) + 5 * p(0) * p(0));
+    q += std::sin(10 * p[i] + 5 * p[0] * p[0]);
   const double u  = std::exp(q);
   double       t1 = 1, t2 = 0, t3 = 0;
   for (unsigned int i = 1; i < dim; ++i)
     {
-      t1 += std::cos(10 * p(i) + 5 * p(0) * p(0)) * 10 * p(0);
-      t2 += 10 * std::cos(10 * p(i) + 5 * p(0) * p(0)) -
-            100 * std::sin(10 * p(i) + 5 * p(0) * p(0)) * p(0) * p(0);
-      t3 += 100 * std::cos(10 * p(i) + 5 * p(0) * p(0)) *
-              std::cos(10 * p(i) + 5 * p(0) * p(0)) -
-            100 * std::sin(10 * p(i) + 5 * p(0) * p(0));
+      t1 += std::cos(10 * p[i] + 5 * p[0] * p[0]) * 10 * p[0];
+      t2 += 10 * std::cos(10 * p[i] + 5 * p[0] * p[0]) -
+            100 * std::sin(10 * p[i] + 5 * p[0] * p[0]) * p[0] * p[0];
+      t3 += 100 * std::cos(10 * p[i] + 5 * p[0] * p[0]) *
+              std::cos(10 * p[i] + 5 * p[0] * p[0]) -
+            100 * std::sin(10 * p[i] + 5 * p[0] * p[0]);
     };
   t1 = t1 * t1;
 

--- a/tests/hp/step-4.cc
+++ b/tests/hp/step-4.cc
@@ -116,7 +116,7 @@ RightHandSide<dim>::value(const Point<dim> &p,
 {
   double return_value = 0;
   for (unsigned int i = 0; i < dim; ++i)
-    return_value += 4 * std::pow(p(i), 4);
+    return_value += 4 * std::pow(p[i], 4);
 
   return return_value;
 }

--- a/tests/hp/step-7.cc
+++ b/tests/hp/step-7.cc
@@ -500,8 +500,8 @@ HelmholtzProblem<dim>::run()
                                                      endc = triangulation.end();
           for (; cell != endc; ++cell)
             for (const unsigned int face : GeometryInfo<dim>::face_indices())
-              if ((cell->face(face)->center()(0) == -1) ||
-                  (cell->face(face)->center()(1) == -1))
+              if ((cell->face(face)->center()[0] == -1) ||
+                  (cell->face(face)->center()[1] == -1))
                 cell->face(face)->set_boundary_id(1);
         }
       else

--- a/tests/hp/step-8.cc
+++ b/tests/hp/step-8.cc
@@ -122,8 +122,8 @@ RightHandSide<dim>::vector_value(const Point<dim> &p,
   Assert(dim >= 2, ExcNotImplemented());
 
   Point<dim> point_1, point_2;
-  point_1(0) = 0.5;
-  point_2(0) = -0.5;
+  point_1[0] = 0.5;
+  point_2[0] = -0.5;
 
   if (((p - point_1).norm_square() < 0.2 * 0.2) ||
       ((p - point_2).norm_square() < 0.2 * 0.2))

--- a/tests/lac/constraints_block_01.cc
+++ b/tests/lac/constraints_block_01.cc
@@ -92,7 +92,7 @@ main()
        ++cell)
     {
       real_cell_center = cell->center();
-      if (real_cell_center(0) < 0.5 && real_cell_center(1) < 0.5)
+      if (real_cell_center[0] < 0.5 && real_cell_center[1] < 0.5)
         cell->set_material_id(0); // solid
       else
         cell->set_material_id(1); // fluid

--- a/tests/lac/linear_operator_11.cc
+++ b/tests/lac/linear_operator_11.cc
@@ -109,7 +109,7 @@ RightHandSide<dim>::value(const Point<dim> &p,
 {
   double return_value = 0;
   for (unsigned int i = 0; i < dim; ++i)
-    return_value += 4 * std::pow(p(i), 4);
+    return_value += 4 * std::pow(p[i], 4);
 
   return return_value;
 }

--- a/tests/lac/linear_operator_12.cc
+++ b/tests/lac/linear_operator_12.cc
@@ -129,7 +129,7 @@ RightHandSide<dim>::value(const Point<dim> &p,
 {
   double return_value = 0;
   for (unsigned int i = 0; i < dim; ++i)
-    return_value += 2 * std::pow(p(i), 2);
+    return_value += 2 * std::pow(p[i], 2);
 
   return return_value;
 }

--- a/tests/lac/linear_operator_12a.cc
+++ b/tests/lac/linear_operator_12a.cc
@@ -130,7 +130,7 @@ RightHandSide<dim>::value(const Point<dim> &p,
 {
   double return_value = 0;
   for (unsigned int i = 0; i < dim; ++i)
-    return_value += 2 * std::pow(p(i), 2);
+    return_value += 2 * std::pow(p[i], 2);
 
   return return_value;
 }

--- a/tests/manifold/flat_manifold_09.cc
+++ b/tests/manifold/flat_manifold_09.cc
@@ -128,8 +128,8 @@ test()
 
 
   Point<dim> p;
-  p(0) = 0.45;
-  p(1) = 0.16;
+  p[0] = 0.45;
+  p[1] = 0.16;
   for (unsigned int step = 0; step < 10; ++step)
     {
       std::cout << "step " << step << std::endl;

--- a/tests/mappings/mapping.cc
+++ b/tests/mappings/mapping.cc
@@ -288,10 +288,10 @@ create_triangulations(std::vector<Triangulation<2> *> &tria_ptr,
       tria_ptr.push_back(tria);
       GridGenerator::hyper_cube(*tria, 1., 3.);
       Point<2> &v0 = tria->begin_active()->vertex(0);
-      v0(0)        = 0.;
+      v0[0]        = 0.;
       Point<2> &v3 = tria->begin_active()->vertex(3);
-      v3(0)        = 5.;
-      v3(1)        = 4.;
+      v3[0]        = 5.;
+      v3[1]        = 4.;
       exact_areas.push_back(7.);
       show[1][0] = 1;
     }
@@ -308,10 +308,10 @@ create_triangulations(std::vector<Triangulation<2> *> &tria_ptr,
       GridGenerator::hyper_cube(*tria, 1., 5.);
       Point<2> &v2 = tria->begin_active()->vertex(2);
       Point<2> &v3 = tria->begin_active()->vertex(3);
-      v2(0)        = 1.;
-      v2(1)        = 3.;
-      v3(0)        = 3.;
-      v3(1)        = 3.;
+      v2[0]        = 1.;
+      v2[1]        = 3.;
+      v3[0]        = 3.;
+      v3[1]        = 3.;
       tria->set_manifold(1, *boundary1);
       tria->set_manifold(2, *boundary2);
       tria->begin_active()->face(1)->set_manifold_id(1);
@@ -329,10 +329,10 @@ create_triangulations(std::vector<Triangulation<2> *> &tria_ptr,
       tria_ptr.push_back(tria);
       Point<2> p0;
       Point<2> p1;
-      p0(0) = 1.;
-      p0(1) = 2.5;
-      p1(0) = 2.;
-      p1(1) = 4.;
+      p0[0] = 1.;
+      p0[1] = 2.5;
+      p1[0] = 2.;
+      p1[1] = 4.;
       GridGenerator::hyper_rectangle(*tria, p0, p1);
       exact_areas.push_back(1.5);
       show[3][4] = 1;
@@ -347,10 +347,10 @@ create_triangulations(std::vector<Triangulation<2> *> &tria_ptr,
       GridGenerator::hyper_cube(*tria, 0., 1.);
       Point<2> &v2 = tria->begin_active()->vertex(2);
       Point<2> &v3 = tria->begin_active()->vertex(3);
-      v2(0)        = 2.;
-      v2(1)        = 1.;
-      v3(0)        = 0.5;
-      v3(1)        = 1.5;
+      v2[0]        = 2.;
+      v2[1]        = 1.;
+      v3[0]        = 0.5;
+      v3[1]        = 1.5;
       tria->set_manifold(1, *boundary1);
       tria->begin_active()->face(1)->set_manifold_id(1);
       exact_areas.push_back(0.);
@@ -387,9 +387,9 @@ create_triangulations(std::vector<Triangulation<3> *> &tria_ptr,
       tria_ptr.push_back(tria);
       GridGenerator::hyper_cube(*tria, 1., 3.);
       Point<3> &v = tria->begin()->vertex(7);
-      v(0)        = 5.;
-      v(1)        = 4.;
-      v(2)        = 4.5;
+      v[0]        = 5.;
+      v[1]        = 4.;
+      v[2]        = 4.5;
       exact_areas.push_back(12.5);
     }
 
@@ -417,12 +417,12 @@ create_triangulations(std::vector<Triangulation<3> *> &tria_ptr,
       tria_ptr.push_back(tria);
       Point<3> p0;
       Point<3> p1;
-      p0(0) = 1.;
-      p0(1) = 2.5;
-      p0(2) = 3.;
-      p1(0) = 2.;
-      p1(1) = 4.;
-      p1(2) = 6.;
+      p0[0] = 1.;
+      p0[1] = 2.5;
+      p0[2] = 3.;
+      p1[0] = 2.;
+      p1[1] = 4.;
+      p1[2] = 6.;
       GridGenerator::hyper_rectangle(*tria, p0, p1);
       exact_areas.push_back(4.5);
       show[3][4] = 1;

--- a/tests/mappings/mapping_q1_eulerian.cc
+++ b/tests/mappings/mapping_q1_eulerian.cc
@@ -47,7 +47,7 @@ show_values(FiniteElement<dim> &fe, const char *name)
   // shift one point of the cell
   // somehow
   if (dim > 1)
-    tr.begin_active()->vertex(dim == 2 ? 3 : 5)(dim - 1) += 1. / std::sqrt(2.);
+    tr.begin_active()->vertex(dim == 2 ? 3 : 5)[dim - 1] += 1. / std::sqrt(2.);
   DoFHandler<dim> dof(tr);
   dof.distribute_dofs(fe);
 

--- a/tests/mappings/mapping_q_eulerian.cc
+++ b/tests/mappings/mapping_q_eulerian.cc
@@ -67,10 +67,10 @@ void
 ImposedDisplacement<2>::vector_value(const Point<2> &p,
                                      Vector<double> &value) const
 {
-  double radius = 1 + (sqrt(5) - 1) * p(0);
-  double angle  = 0.5 * numbers::PI * (1 - p(1));
-  value(0)      = radius * sin(angle) - p(0);
-  value(1)      = radius * cos(angle) - p(1);
+  double radius = 1 + (sqrt(5) - 1) * p[0];
+  double angle  = 0.5 * numbers::PI * (1 - p[1]);
+  value(0)      = radius * sin(angle) - p[0];
+  value(1)      = radius * cos(angle) - p[1];
 }
 
 

--- a/tests/mappings/mapping_q_manifold_01.cc
+++ b/tests/mappings/mapping_q_manifold_01.cc
@@ -128,14 +128,14 @@ template <>
 double
 VectorFunction<3>::value(const Point<3> &p, const unsigned int component) const
 {
-  return (1 - p(0) * p(0)) * (1 - p(1) * p(1)) * (1 - p(2) * p(2));
+  return (1 - p[0] * p[0]) * (1 - p[1] * p[1]) * (1 - p[2] * p[2]);
 }
 
 template <>
 double
 VectorFunction<2>::value(const Point<2> &p, const unsigned int component) const
 {
-  return (1 - p(0) * p(0)) * (1 - p(1) * p(1));
+  return (1 - p[0] * p[0]) * (1 - p[1] * p[1]);
 }
 
 template <int dim>

--- a/tests/mappings/mapping_real_to_unit_02.cc
+++ b/tests/mappings/mapping_real_to_unit_02.cc
@@ -66,8 +66,8 @@ test2()
       for (unsigned int j = 0; j < 19; ++j)
         {
           /// all points are inside
-          points[19 * i + j](0) = -0.7 + (i + 1) * .07;
-          points[19 * i + j](1) = -0.7 + (j + 1) * .07;
+          points[19 * i + j][0] = -0.7 + (i + 1) * .07;
+          points[19 * i + j][1] = -0.7 + (j + 1) * .07;
         }
   points[95] = p;
   fe_function.value_list(points, m); // <<<< this fails at point[95] but only if

--- a/tests/matrix_free/interpolate_rt_deformed.cc
+++ b/tests/matrix_free/interpolate_rt_deformed.cc
@@ -384,10 +384,10 @@ public:
     double sinval = deformation;
     for (unsigned int d = 0; d < dim; ++d)
       sinval *= std::sin(frequency * dealii::numbers::PI *
-                         (chart_point(d) - left) / (right - left));
+                         (chart_point[d] - left) / (right - left));
     dealii::Point<dim> space_point;
     for (unsigned int d = 0; d < dim; ++d)
-      space_point(d) = chart_point(d) + sinval;
+      space_point[d] = chart_point[d] + sinval;
     return space_point;
   }
 
@@ -397,12 +397,12 @@ public:
     dealii::Point<dim> x = space_point;
     dealii::Point<dim> one;
     for (unsigned int d = 0; d < dim; ++d)
-      one(d) = 1.;
+      one[d] = 1.;
 
     // Newton iteration to solve the nonlinear equation given by the point
     dealii::Tensor<1, dim> sinvals;
     for (unsigned int d = 0; d < dim; ++d)
-      sinvals[d] = std::sin(frequency * dealii::numbers::PI * (x(d) - left) /
+      sinvals[d] = std::sin(frequency * dealii::numbers::PI * (x[d] - left) /
                             (right - left));
 
     double sinval = deformation;
@@ -420,7 +420,7 @@ public:
             double sinval_der = deformation * frequency / (right - left) *
                                 dealii::numbers::PI *
                                 std::cos(frequency * dealii::numbers::PI *
-                                         (x(d) - left) / (right - left));
+                                         (x[d] - left) / (right - left));
             for (unsigned int e = 0; e < dim; ++e)
               if (e != d)
                 sinval_der *= sinvals[e];
@@ -432,7 +432,7 @@ public:
 
         for (unsigned int d = 0; d < dim; ++d)
           sinvals[d] = std::sin(frequency * dealii::numbers::PI *
-                                (x(d) - left) / (right - left));
+                                (x[d] - left) / (right - left));
 
         sinval = deformation;
         for (unsigned int d = 0; d < dim; ++d)

--- a/tests/matrix_free/matrix_vector_rt_04.cc
+++ b/tests/matrix_free/matrix_vector_rt_04.cc
@@ -46,10 +46,10 @@ public:
     double sinval = deformation;
     for (unsigned int d = 0; d < dim; ++d)
       sinval *= std::sin(frequency * dealii::numbers::PI *
-                         (chart_point(d) - left) / (right - left));
+                         (chart_point[d] - left) / (right - left));
     dealii::Point<dim> space_point;
     for (unsigned int d = 0; d < dim; ++d)
-      space_point(d) = chart_point(d) + sinval;
+      space_point[d] = chart_point[d] + sinval;
     return space_point;
   }
 
@@ -59,12 +59,12 @@ public:
     dealii::Point<dim> x = space_point;
     dealii::Point<dim> one;
     for (unsigned int d = 0; d < dim; ++d)
-      one(d) = 1.;
+      one[d] = 1.;
 
     // Newton iteration to solve the nonlinear equation given by the point
     dealii::Tensor<1, dim> sinvals;
     for (unsigned int d = 0; d < dim; ++d)
-      sinvals[d] = std::sin(frequency * dealii::numbers::PI * (x(d) - left) /
+      sinvals[d] = std::sin(frequency * dealii::numbers::PI * (x[d] - left) /
                             (right - left));
 
     double sinval = deformation;
@@ -82,7 +82,7 @@ public:
             double sinval_der = deformation * frequency / (right - left) *
                                 dealii::numbers::PI *
                                 std::cos(frequency * dealii::numbers::PI *
-                                         (x(d) - left) / (right - left));
+                                         (x[d] - left) / (right - left));
             for (unsigned int e = 0; e < dim; ++e)
               if (e != d)
                 sinval_der *= sinvals[e];
@@ -94,7 +94,7 @@ public:
 
         for (unsigned int d = 0; d < dim; ++d)
           sinvals[d] = std::sin(frequency * dealii::numbers::PI *
-                                (x(d) - left) / (right - left));
+                                (x[d] - left) / (right - left));
 
         sinval = deformation;
         for (unsigned int d = 0; d < dim; ++d)

--- a/tests/matrix_free/matrix_vector_rt_face_04.cc
+++ b/tests/matrix_free/matrix_vector_rt_face_04.cc
@@ -47,10 +47,10 @@ public:
     double sinval = deformation;
     for (unsigned int d = 0; d < dim; ++d)
       sinval *= std::sin(frequency * dealii::numbers::PI *
-                         (chart_point(d) - left) / (right - left));
+                         (chart_point[d] - left) / (right - left));
     dealii::Point<dim> space_point;
     for (unsigned int d = 0; d < dim; ++d)
-      space_point(d) = chart_point(d) + sinval;
+      space_point[d] = chart_point[d] + sinval;
     return space_point;
   }
 
@@ -60,12 +60,12 @@ public:
     dealii::Point<dim> x = space_point;
     dealii::Point<dim> one;
     for (unsigned int d = 0; d < dim; ++d)
-      one(d) = 1.;
+      one[d] = 1.;
 
     // Newton iteration to solve the nonlinear equation given by the point
     dealii::Tensor<1, dim> sinvals;
     for (unsigned int d = 0; d < dim; ++d)
-      sinvals[d] = std::sin(frequency * dealii::numbers::PI * (x(d) - left) /
+      sinvals[d] = std::sin(frequency * dealii::numbers::PI * (x[d] - left) /
                             (right - left));
 
     double sinval = deformation;
@@ -83,7 +83,7 @@ public:
             double sinval_der = deformation * frequency / (right - left) *
                                 dealii::numbers::PI *
                                 std::cos(frequency * dealii::numbers::PI *
-                                         (x(d) - left) / (right - left));
+                                         (x[d] - left) / (right - left));
             for (unsigned int e = 0; e < dim; ++e)
               if (e != d)
                 sinval_der *= sinvals[e];
@@ -95,7 +95,7 @@ public:
 
         for (unsigned int d = 0; d < dim; ++d)
           sinvals[d] = std::sin(frequency * dealii::numbers::PI *
-                                (x(d) - left) / (right - left));
+                                (x[d] - left) / (right - left));
 
         sinval = deformation;
         for (unsigned int d = 0; d < dim; ++d)

--- a/tests/matrix_free/stokes_computation.cc
+++ b/tests/matrix_free/stokes_computation.cc
@@ -494,7 +494,7 @@ namespace StokesClass
                 Point<dim> p;
                 for (unsigned int d = 0; d < dim; ++d)
                   {
-                    p(d) = velocity.quadrature_point(q)(d)[i];
+                    p[d] = velocity.quadrature_point(q)[d][i];
                   }
                 return_value[i] = 2.0 * viscosity_function.value(p);
               }
@@ -628,7 +628,7 @@ namespace StokesClass
               {
                 Point<dim> p;
                 for (unsigned int d = 0; d < dim; ++d)
-                  p(d) = pressure.quadrature_point(q)(d)[i];
+                  p[d] = pressure.quadrature_point(q)[d][i];
                 return_value[i] = 1.0 / viscosity_function.value(p);
               }
             one_over_viscosity(cell, q) = return_value;
@@ -807,7 +807,7 @@ namespace StokesClass
                 Point<dim> p;
                 for (unsigned int d = 0; d < dim; ++d)
                   {
-                    p(d) = velocity.quadrature_point(q)(d)[i];
+                    p[d] = velocity.quadrature_point(q)[d][i];
                   }
                 return_value[i] = 2.0 * viscosity_function.value(p);
               }
@@ -1227,7 +1227,7 @@ namespace StokesClass
               {
                 Point<dim> p;
                 for (unsigned int d = 0; d < dim; ++d)
-                  p(d) = velocity.quadrature_point(q)(d)[i];
+                  p[d] = velocity.quadrature_point(q)[d][i];
 
                 Vector<double> rhs_temp(dim + 1);
                 right_hand_side.vector_value(p, rhs_temp);

--- a/tests/matrix_free_kokkos/coefficient_eval_device.cc
+++ b/tests/matrix_free_kokkos/coefficient_eval_device.cc
@@ -71,7 +71,7 @@ DummyOperator<dim, fe_degree>::operator()(
 
       auto point = gpu_data->get_quadrature_point(cell, q_point);
       dst[pos] =
-        dim == 2 ? point(0) + point(1) : point(0) + point(1) + point(2);
+        dim == 2 ? point[0] + point[1] : point[0] + point[1] + point[2];
     });
 }
 
@@ -166,7 +166,7 @@ test()
               const unsigned int pos =
                 gpu_data_host.local_q_point_id(cell_id, n_q_points_per_cell, i);
               auto         p = gpu_data_host.get_quadrature_point(cell_id, i);
-              const double p_val = dim == 2 ? p(0) + p(1) : p(0) + p(1) + p(2);
+              const double p_val = dim == 2 ? p[0] + p[1] : p[0] + p[1] + p[2];
               AssertThrow(std::abs(coef[pos] - p_val) < 1e-12,
                           ExcInternalError());
             }

--- a/tests/mpi/communicate_moved_vertices_03.cc
+++ b/tests/mpi/communicate_moved_vertices_03.cc
@@ -64,7 +64,7 @@ test()
           if (!vertex_moved[global_vertex_no] &&
               locally_owned_vertices[global_vertex_no])
             {
-              cell->vertex(vertex_no)(0) += 1.e-1;
+              cell->vertex(vertex_no)[0] += 1.e-1;
               vertex_moved[global_vertex_no] = true;
             }
         }
@@ -77,7 +77,7 @@ test()
       for (const unsigned int vertex_no : GeometryInfo<dim>::vertex_indices())
         {
           Point<dim> point = cell->vertex(vertex_no);
-          point(0) -= 1.e-1;
+          point[0] -= 1.e-1;
           non_artificial_vertices_new[cell->vertex_index(vertex_no)] = point;
         }
 

--- a/tests/mpi/distort_random_02.cc
+++ b/tests/mpi/distort_random_02.cc
@@ -47,7 +47,7 @@ test1(const bool keep_boundary)
         const Point<dim> &p            = cell->center();
         bool              all_positive = true;
         for (unsigned int d = 0; d < dim; ++d)
-          if (p(d) <= 0.)
+          if (p[d] <= 0.)
             all_positive = false;
         if (all_positive)
           cell->set_refine_flag();

--- a/tests/mpi/fe_tools_extrapolate_common.h
+++ b/tests/mpi/fe_tools_extrapolate_common.h
@@ -59,7 +59,7 @@ public:
   {
     double return_value = 0.;
     for (unsigned int d = 0; d < dim; ++d)
-      return_value += std::pow(std::abs(.5 - p(d)), degree);
+      return_value += std::pow(std::abs(.5 - p[d]), degree);
 
     return return_value;
   }

--- a/tests/mpi/hp_hanging_node_constraints_02.cc
+++ b/tests/mpi/hp_hanging_node_constraints_02.cc
@@ -64,7 +64,7 @@ test()
   for (unsigned int n_ref = 0; n_ref < 2; ++n_ref)
     {
       for (const auto &cell : triangulation.active_cell_iterators())
-        if (cell->is_locally_owned() && cell->center()(1) < 0.5)
+        if (cell->is_locally_owned() && cell->center()[1] < 0.5)
           cell->set_refine_flag();
 
       triangulation.prepare_coarsening_and_refinement();
@@ -85,7 +85,7 @@ test()
   for (const auto &cell : dof_handler.active_cell_iterators() |
                             IteratorFilters::LocallyOwnedCell())
     {
-      if (cell->center()(0) < 0.5)
+      if (cell->center()[0] < 0.5)
         cell->set_active_fe_index(0);
       else
         cell->set_active_fe_index(1);

--- a/tests/mpi/interpolate_to_different_mesh_01.cc
+++ b/tests/mpi/interpolate_to_different_mesh_01.cc
@@ -53,7 +53,7 @@ public:
   double
   value(const Point<dim> &p, const unsigned int) const
   {
-    return 1 + p(0) * p(0);
+    return 1 + p[0] * p[0];
   }
 };
 

--- a/tests/mpi/mg_ghost_layer_periodic.cc
+++ b/tests/mpi/mg_ghost_layer_periodic.cc
@@ -39,9 +39,9 @@ test()
   for (const auto &cell : tria.cell_iterators())
     for (const unsigned int face_index : GeometryInfo<dim>::face_indices())
       {
-        if (std::abs(cell->face(face_index)->center()(face_index / 2)) < 1e-12)
+        if (std::abs(cell->face(face_index)->center()[face_index / 2]) < 1e-12)
           cell->face(face_index)->set_all_boundary_ids(face_index);
-        if (std::abs(cell->face(face_index)->center()(face_index / 2) - 1.) <
+        if (std::abs(cell->face(face_index)->center()[face_index / 2] - 1.) <
             1e-12)
           cell->face(face_index)->set_all_boundary_ids(face_index);
       }

--- a/tests/mpi/p4est_2d_constraintmatrix_04.cc
+++ b/tests/mpi/p4est_2d_constraintmatrix_04.cc
@@ -76,7 +76,7 @@ double
 TemperatureInitialValues<dim>::value(const Point<dim> &p,
                                      const unsigned int) const
 {
-  return p(0) * T1 + p(1) * (T0 - T1); // simple
+  return p[0] * T1 + p[1] * (T0 - T1); // simple
 }
 
 

--- a/tests/mpi/p4est_3d_constraintmatrix_03.cc
+++ b/tests/mpi/p4est_3d_constraintmatrix_03.cc
@@ -76,7 +76,7 @@ double
 TemperatureInitialValues<dim>::value(const Point<dim> &p,
                                      const unsigned int) const
 {
-  return p(0) * T1 + p(1) * (T0 - T1); // simple
+  return p[0] * T1 + p[1] * (T0 - T1); // simple
 }
 
 

--- a/tests/mpi/periodicity_01.cc
+++ b/tests/mpi/periodicity_01.cc
@@ -375,11 +375,11 @@ namespace Step40
         Vector<PetscScalar> value2(1);
 
         Point<2> point1;
-        point1(0) = 1. * i / n_points + eps;
-        point1(1) = 0.;
+        point1[0] = 1. * i / n_points + eps;
+        point1[1] = 0.;
         Point<2> point2;
-        point2(0) = 1. * i / n_points + eps;
-        point2(1) = 1.;
+        point2[0] = 1. * i / n_points + eps;
+        point2[1] = 1.;
 
         get_point_value(point1, 0, value1);
         get_point_value(point2, 0, value2);
@@ -424,21 +424,21 @@ namespace Step40
           Vector<PetscScalar> value4(1);
 
           Point<3> point1;
-          point1(0) = 1. * i / n_points + eps;
-          point1(1) = 1. * j / n_points + eps;
-          point1(2) = 0;
+          point1[0] = 1. * i / n_points + eps;
+          point1[1] = 1. * j / n_points + eps;
+          point1[2] = 0;
           Point<3> point2;
-          point2(0) = 1. * i / n_points + eps;
-          point2(1) = 1. * j / n_points + eps;
-          point2(2) = 1.;
+          point2[0] = 1. * i / n_points + eps;
+          point2[1] = 1. * j / n_points + eps;
+          point2[2] = 1.;
           Point<3> point3;
-          point3(0) = 1. * i / n_points + eps;
-          point3(1) = 0.;
-          point3(2) = 1. * j / n_points + eps;
+          point3[0] = 1. * i / n_points + eps;
+          point3[1] = 0.;
+          point3[2] = 1. * j / n_points + eps;
           Point<3> point4;
-          point4(0) = 1. * i / n_points + eps;
-          point4(1) = 1.;
-          point4(2) = 1. * j / n_points + eps;
+          point4[0] = 1. * i / n_points + eps;
+          point4[1] = 1.;
+          point4[2] = 1. * j / n_points + eps;
 
           get_point_value(point1, 0, value1);
           get_point_value(point2, 0, value2);
@@ -528,7 +528,7 @@ namespace Step40
             Point<dim> p1;
             Point<dim> p2;
             for (unsigned int i = 0; i < dim; ++i)
-              p2(i) = 1.0;
+              p2[i] = 1.0;
 
             GridGenerator::subdivided_hyper_rectangle(
               triangulation, reps, p1, p2, true);

--- a/tests/mpi/periodicity_02.cc
+++ b/tests/mpi/periodicity_02.cc
@@ -642,11 +642,11 @@ namespace Step22
         Vector<double> value2(3);
 
         Point<2> point1;
-        point1(0) = 0;
-        point1(1) = .5 * (1. + 1. * i / n_points + eps);
+        point1[0] = 0;
+        point1[1] = .5 * (1. + 1. * i / n_points + eps);
         Point<2> point2;
-        point2(0) = .5 * (1. + 1. * i / n_points + eps);
-        point2(1) = 0.;
+        point2[0] = .5 * (1. + 1. * i / n_points + eps);
+        point2[1] = 0.;
 
         get_point_value(point1, 0, value1);
         get_point_value(point2, 0, value2);

--- a/tests/mpi/periodicity_03.cc
+++ b/tests/mpi/periodicity_03.cc
@@ -573,7 +573,7 @@ namespace Step22
                       fe_face_values.get_quadrature_points();
                     for (unsigned int i = 0; i < tmp_points.size(); ++i)
                       for (unsigned int c = 0; c < dim; ++c)
-                        local_quad_points_first.push_back(tmp_points[i](c));
+                        local_quad_points_first.push_back(tmp_points[i][c]);
                   }
                 else if (face->boundary_id() == 4)
                   {
@@ -582,7 +582,7 @@ namespace Step22
                       fe_face_values.get_quadrature_points();
                     for (unsigned int i = 0; i < tmp_points.size(); ++i)
                       for (unsigned int c = 0; c < dim; ++c)
-                        local_quad_points_second.push_back(tmp_points[i](c));
+                        local_quad_points_second.push_back(tmp_points[i][c]);
                   }
               }
           }
@@ -660,12 +660,12 @@ namespace Step22
           for (unsigned int c = 0; c < dim; ++c)
             {
               vector_point_1(c) = global_quad_points_first[i + c];
-              point_1(c)        = vector_point_1(c);
+              point_1[c]        = vector_point_1(c);
             }
           Vector<double> vector_point_2(dim);
           rot_matrix.Tvmult(vector_point_2, vector_point_1);
           for (unsigned int c = 0; c < dim; ++c)
-            point_2(c) = vector_point_2(c) + offset[c];
+            point_2[c] = vector_point_2(c) + offset[c];
 
           get_point_value(point_1, 0, value_1);
           get_point_value(point_2, 0, value_2);
@@ -712,14 +712,14 @@ namespace Step22
           for (unsigned int c = 0; c < dim; ++c)
             {
               vector_point_1(c) = global_quad_points_second[i + c];
-              point_1(c)        = vector_point_1(c);
+              point_1[c]        = vector_point_1(c);
             }
           Vector<double> vector_point_2(dim);
           for (unsigned int c = 0; c < dim; ++c)
             vector_point_1(c) -= offset[c];
           rot_matrix.vmult(vector_point_2, vector_point_1);
           for (unsigned int c = 0; c < dim; ++c)
-            point_2(c) = vector_point_2(c);
+            point_2[c] = vector_point_2(c);
 
           get_point_value(point_1, 0, value_1);
           get_point_value(point_2, 0, value_2);

--- a/tests/mpi/periodicity_04.cc
+++ b/tests/mpi/periodicity_04.cc
@@ -50,9 +50,9 @@ set_periodicity(parallel::distributed::Triangulation<dim> &triangulation,
   // Look for the two outermost faces:
   for (const unsigned int j : GeometryInfo<dim>::face_indices())
     {
-      if (cell_1->face(j)->center()(dim - 1) > 2.9)
+      if (cell_1->face(j)->center()[dim - 1] > 2.9)
         face_1 = cell_1->face(j);
-      if (cell_2->face(j)->center()(dim - 1) < -2.9)
+      if (cell_2->face(j)->center()[dim - 1] < -2.9)
         face_2 = cell_2->face(j);
     }
   face_1->set_boundary_id(42);
@@ -255,7 +255,7 @@ check(const unsigned int orientation, bool reverse)
   // now refine and check if the neighboring faces are correctly found
   typename Triangulation<dim>::active_cell_iterator cell;
   for (cell = triangulation.begin_active(); cell != triangulation.end(); ++cell)
-    if (cell->is_locally_owned() && cell->center()(dim - 1) > 0)
+    if (cell->is_locally_owned() && cell->center()[dim - 1] > 0)
       cell->set_refine_flag();
 
   triangulation.execute_coarsening_and_refinement();
@@ -284,15 +284,15 @@ check(const unsigned int orientation, bool reverse)
       const unsigned int face_no_2     = it->second.first.second;
       const Point<dim>   face_center_1 = cell_1->face(face_no_1)->center();
       const Point<dim>   face_center_2 = cell_2->face(face_no_2)->center();
-      Assert(std::min(std::abs(face_center_1(dim - 1) - 3.),
-                      std::abs(face_center_1(dim - 1) + 3.)) < 1.e-8,
+      Assert(std::min(std::abs(face_center_1[dim - 1] - 3.),
+                      std::abs(face_center_1[dim - 1] + 3.)) < 1.e-8,
              ExcInternalError());
-      Assert(std::min(std::abs(face_center_2(dim - 1) - 3.),
-                      std::abs(face_center_2(dim - 1) + 3.)) < 1.e-8,
+      Assert(std::min(std::abs(face_center_2[dim - 1] - 3.),
+                      std::abs(face_center_2[dim - 1] + 3.)) < 1.e-8,
              ExcInternalError());
       if (cell_1->level() == cell_2->level())
         for (unsigned int c = 0; c < dim - 1; ++c)
-          if (std::abs(face_center_1(c) - face_center_2(c)) > 1.e-8)
+          if (std::abs(face_center_1[c] - face_center_2[c]) > 1.e-8)
             {
               std::cout << "face_center_1: " << face_center_1 << std::endl;
               std::cout << "face_center_2: " << face_center_2 << std::endl;

--- a/tests/multigrid-global-coarsening/stokes_computation.cc
+++ b/tests/multigrid-global-coarsening/stokes_computation.cc
@@ -494,7 +494,7 @@ namespace StokesClass
                 Point<dim> p;
                 for (unsigned int d = 0; d < dim; ++d)
                   {
-                    p(d) = velocity.quadrature_point(q)(d)[i];
+                    p[d] = velocity.quadrature_point(q)[d][i];
                   }
                 return_value[i] = 2.0 * viscosity_function.value(p);
               }
@@ -628,7 +628,7 @@ namespace StokesClass
               {
                 Point<dim> p;
                 for (unsigned int d = 0; d < dim; ++d)
-                  p(d) = pressure.quadrature_point(q)(d)[i];
+                  p[d] = pressure.quadrature_point(q)[d][i];
                 return_value[i] = 1.0 / viscosity_function.value(p);
               }
             one_over_viscosity(cell, q) = return_value;
@@ -807,7 +807,7 @@ namespace StokesClass
                 Point<dim> p;
                 for (unsigned int d = 0; d < dim; ++d)
                   {
-                    p(d) = velocity.quadrature_point(q)(d)[i];
+                    p[d] = velocity.quadrature_point(q)[d][i];
                   }
                 return_value[i] = 2.0 * viscosity_function.value(p);
               }
@@ -1227,7 +1227,7 @@ namespace StokesClass
               {
                 Point<dim> p;
                 for (unsigned int d = 0; d < dim; ++d)
-                  p(d) = velocity.quadrature_point(q)(d)[i];
+                  p[d] = velocity.quadrature_point(q)[d][i];
 
                 Vector<double> rhs_temp(dim + 1);
                 right_hand_side.vector_value(p, rhs_temp);

--- a/tests/multigrid/renumbering_02.cc
+++ b/tests/multigrid/renumbering_02.cc
@@ -59,7 +59,7 @@ check()
   mg_dof_handler.distribute_dofs(fe);
   mg_dof_handler.distribute_mg_dofs();
   Point<dim> a;
-  a(0) = 1;
+  a[0] = 1;
   for (unsigned int level = 0; level < tria.n_levels(); ++level)
     DoFRenumbering::downstream(mg_dof_handler, level, a);
 }

--- a/tests/multigrid/transfer_02.cc
+++ b/tests/multigrid/transfer_02.cc
@@ -70,7 +70,7 @@ refine_mesh(Triangulation<dim> &triangulation)
        ++cell)
     {
       const Point<dim> p        = cell->center();
-      bool             positive = p(0) > 0;
+      bool             positive = p[0] > 0;
       if (positive)
         {
           cell->set_refine_flag();

--- a/tests/multigrid/transfer_system_adaptive_01.cc
+++ b/tests/multigrid/transfer_system_adaptive_01.cc
@@ -98,7 +98,7 @@ refine_mesh(Triangulation<dim> &triangulation)
        ++cell)
     {
       const Point<dim> p        = cell->center();
-      bool             positive = p(0) > 0;
+      bool             positive = p[0] > 0;
       if (positive)
         {
           cell->set_refine_flag();

--- a/tests/multigrid/transfer_system_adaptive_02.cc
+++ b/tests/multigrid/transfer_system_adaptive_02.cc
@@ -98,7 +98,7 @@ refine_mesh(Triangulation<dim> &triangulation)
        ++cell)
     {
       const Point<dim> p        = cell->center();
-      bool             positive = p(0) > 0;
+      bool             positive = p[0] > 0;
       if (positive)
         {
           cell->set_refine_flag();

--- a/tests/multigrid/transfer_system_adaptive_03.cc
+++ b/tests/multigrid/transfer_system_adaptive_03.cc
@@ -99,7 +99,7 @@ refine_mesh(Triangulation<dim> &triangulation)
        ++cell)
     {
       const Point<dim> p        = cell->center();
-      bool             positive = p(0) > 0;
+      bool             positive = p[0] > 0;
       if (positive)
         {
           cell->set_refine_flag();

--- a/tests/multigrid/transfer_system_adaptive_04.cc
+++ b/tests/multigrid/transfer_system_adaptive_04.cc
@@ -98,7 +98,7 @@ refine_mesh(Triangulation<dim> &triangulation)
        ++cell)
     {
       const Point<dim> p        = cell->center();
-      bool             positive = p(0) > 0;
+      bool             positive = p[0] > 0;
       if (positive)
         {
           cell->set_refine_flag();

--- a/tests/multigrid/transfer_system_adaptive_05.cc
+++ b/tests/multigrid/transfer_system_adaptive_05.cc
@@ -100,7 +100,7 @@ refine_mesh(Triangulation<dim> &triangulation)
        ++cell)
     {
       const Point<dim> p        = cell->center();
-      bool             positive = p(0) > 0;
+      bool             positive = p[0] > 0;
       if (positive)
         {
           cell->set_refine_flag();

--- a/tests/multigrid/transfer_system_adaptive_06.cc
+++ b/tests/multigrid/transfer_system_adaptive_06.cc
@@ -98,7 +98,7 @@ refine_mesh(Triangulation<dim> &triangulation)
        ++cell)
     {
       const Point<dim> p        = cell->center();
-      bool             positive = p(0) > 0;
+      bool             positive = p[0] > 0;
       if (positive)
         {
           cell->set_refine_flag();

--- a/tests/multigrid/transfer_system_adaptive_07.cc
+++ b/tests/multigrid/transfer_system_adaptive_07.cc
@@ -100,7 +100,7 @@ refine_mesh(Triangulation<dim> &triangulation)
        ++cell)
     {
       const Point<dim> p        = cell->center();
-      bool             positive = p(0) > 0;
+      bool             positive = p[0] > 0;
       if (positive)
         {
           cell->set_refine_flag();

--- a/tests/multigrid/transfer_system_adaptive_08.cc
+++ b/tests/multigrid/transfer_system_adaptive_08.cc
@@ -99,7 +99,7 @@ refine_mesh(Triangulation<dim> &triangulation)
        ++cell)
     {
       const Point<dim> p        = cell->center();
-      bool             positive = p(0) > 0;
+      bool             positive = p[0] > 0;
       if (positive)
         {
           cell->set_refine_flag();

--- a/tests/multigrid/transfer_system_adaptive_09.cc
+++ b/tests/multigrid/transfer_system_adaptive_09.cc
@@ -54,7 +54,7 @@ refine_mesh(Triangulation<dim> &triangulation)
        ++cell)
     {
       const Point<dim> p        = cell->center();
-      bool             positive = p(0) > 0;
+      bool             positive = p[0] > 0;
       if (positive)
         {
           cell->set_refine_flag();

--- a/tests/non_matching/face_quadrature_generator.cc
+++ b/tests/non_matching/face_quadrature_generator.cc
@@ -79,7 +79,7 @@ test_plane_cuts_through_center()
 
   Point<dim> center;
   for (int d = 0; d < dim; ++d)
-    center(d) = .5;
+    center[d] = .5;
 
   // For each coordinate direction set up a plane through the center.
   for (int plane_direction = 0; plane_direction < dim; ++plane_direction)

--- a/tests/non_matching/fe_interface_values_non_standard_meshes.cc
+++ b/tests/non_matching/fe_interface_values_non_standard_meshes.cc
@@ -98,7 +98,7 @@ Test<dim>::setup_discrete_level_set()
   Tensor<1, dim> plane_normal;
   for (unsigned int i = 1; i < dim; i++)
     {
-      point_on_zero_contour(i) = 0.25;
+      point_on_zero_contour[i] = 0.25;
       plane_normal[i]          = 1;
     }
 

--- a/tests/non_matching/quadrature_generator.cc
+++ b/tests/non_matching/quadrature_generator.cc
@@ -92,7 +92,7 @@ test_vertical_cuts_through_center()
   Point<dim> center;
   for (int d = 0; d < dim; ++d)
     {
-      center(d) = .5;
+      center[d] = .5;
     }
   for (int direction = 0; direction < dim; ++direction)
     {
@@ -174,7 +174,7 @@ test_epsilon_cut_at_bottom_corner()
   for (int i = 0; i < dim; ++i)
     {
       normal[i] = 1;
-      center(i) += epsilon;
+      center[i] += epsilon;
     }
   const Functions::SignedDistance::Plane<dim> level_set(center, normal);
 
@@ -229,7 +229,7 @@ public:
     : Functions::ConstantFunction<dim>(1)
   {
     for (int d = 0; d < dim; ++d)
-      unit_box_center(d) = .5;
+      unit_box_center[d] = .5;
   }
 
   SymmetricTensor<2, dim>

--- a/tests/non_matching/root_finder.cc
+++ b/tests/non_matching/root_finder.cc
@@ -102,7 +102,7 @@ public:
   double
   value(const Point<1> &point, const unsigned int component = 0) const override
   {
-    return C * std::pow(point(0) - x_0, 2) + y_0;
+    return C * std::pow(point[0] - x_0, 2) + y_0;
   };
 
   Tensor<1, 1>
@@ -110,7 +110,7 @@ public:
            const unsigned int component = 0) const override
   {
     Tensor<1, 1> grad;
-    grad[0] = 2 * C * (point(0) - x_0);
+    grad[0] = 2 * C * (point[0] - x_0);
 
     return grad;
   };

--- a/tests/non_matching/tensor_point_with_1D_quadrature.cc
+++ b/tests/non_matching/tensor_point_with_1D_quadrature.cc
@@ -48,7 +48,7 @@ create_and_output_quadrature_for_each_direction()
   Point<dim - 1> point;
   for (int i = 0; i < dim - 1; ++i)
     {
-      point(i) = 10 * (i + 1);
+      point[i] = 10 * (i + 1);
     }
   // Both points in the 1D-quadrature have weight 1/2 so
   // this should also be the weight of the points in the final

--- a/tests/numerics/create_point_source.cc
+++ b/tests/numerics/create_point_source.cc
@@ -46,7 +46,7 @@ check()
   Point<dim> p(tria.begin_active()->center());
 
   for (unsigned int i = 0; i < dim; ++i)
-    orientation(i) = i;
+    orientation[i] = i;
 
   Vector<double> vector(dof.n_dofs());
 

--- a/tests/numerics/create_point_source_hp.cc
+++ b/tests/numerics/create_point_source_hp.cc
@@ -52,7 +52,7 @@ check()
   Point<dim> p(tria.begin_active()->center());
 
   for (unsigned int i = 0; i < dim; ++i)
-    orientation(i) = i;
+    orientation[i] = i;
 
   Vector<double> vector(dof.n_dofs());
 

--- a/tests/numerics/interpolate_to_different_mesh_01.cc
+++ b/tests/numerics/interpolate_to_different_mesh_01.cc
@@ -43,7 +43,7 @@ public:
   virtual double
   value(const Point<spacedim> &p, const unsigned int component = 0) const
   {
-    return p(0) * p(0);
+    return p[0] * p[0];
   }
 };
 

--- a/tests/numerics/interpolate_to_different_mesh_02.cc
+++ b/tests/numerics/interpolate_to_different_mesh_02.cc
@@ -45,7 +45,7 @@ public:
   virtual double
   value(const Point<spacedim> &p, const unsigned int component = 0) const
   {
-    return p(0) * p(0);
+    return p[0] * p[0];
   }
 };
 

--- a/tests/numerics/no_flux_10.cc
+++ b/tests/numerics/no_flux_10.cc
@@ -72,8 +72,8 @@ colorize_sixty_deg_hyper_shell(Triangulation<3> &tria,
           continue;
 
         double radius = cell->face(f)->center().norm() - center.norm();
-        if (std::fabs(cell->face(f)->center()(2) -
-                      sqrt(3.) * cell->face(f)->center()(0)) <
+        if (std::fabs(cell->face(f)->center()[2] -
+                      sqrt(3.) * cell->face(f)->center()[0]) <
             eps) // z = sqrt(3)x set boundary 2
           {
             cell->face(f)->set_boundary_id(2);
@@ -83,8 +83,8 @@ colorize_sixty_deg_hyper_shell(Triangulation<3> &tria,
                               cell->face(f)->line(j)->vertex(1).norm()) > eps)
                   cell->face(f)->line(j)->set_boundary_id(2);
           }
-        else if (std::fabs(cell->face(f)->center()(2) +
-                           sqrt(3.) * cell->face(f)->center()(0)) <
+        else if (std::fabs(cell->face(f)->center()[2] +
+                           sqrt(3.) * cell->face(f)->center()[0]) <
                  eps) // z = -sqrt(3)x set boundary 3
           {
             cell->face(f)->set_boundary_id(3);
@@ -94,8 +94,8 @@ colorize_sixty_deg_hyper_shell(Triangulation<3> &tria,
                               cell->face(f)->line(j)->vertex(1).norm()) > eps)
                   cell->face(f)->line(j)->set_boundary_id(3);
           }
-        else if (std::fabs(cell->face(f)->center()(2) -
-                           sqrt(3.) * cell->face(f)->center()(1)) <
+        else if (std::fabs(cell->face(f)->center()[2] -
+                           sqrt(3.) * cell->face(f)->center()[1]) <
                  eps) // z = sqrt(3)y set boundary 4
           {
             cell->face(f)->set_boundary_id(4);
@@ -105,8 +105,8 @@ colorize_sixty_deg_hyper_shell(Triangulation<3> &tria,
                               cell->face(f)->line(j)->vertex(1).norm()) > eps)
                   cell->face(f)->line(j)->set_boundary_id(4);
           }
-        else if (std::fabs(cell->face(f)->center()(2) +
-                           sqrt(3.) * cell->face(f)->center()(1)) <
+        else if (std::fabs(cell->face(f)->center()[2] +
+                           sqrt(3.) * cell->face(f)->center()[1]) <
                  eps) // z = -sqrt(3)y set boundary 5
           {
             cell->face(f)->set_boundary_id(5);

--- a/tests/numerics/no_flux_11.cc
+++ b/tests/numerics/no_flux_11.cc
@@ -66,30 +66,30 @@ run()
               {
                 if (cell->face(face)->at_boundary())
                   {
-                    if ((std::fabs(cell->face(face)->center()(0)) < 0.1) &&
-                        (std::fabs(cell->face(face)->center()(dim - 1)) <
+                    if ((std::fabs(cell->face(face)->center()[0]) < 0.1) &&
+                        (std::fabs(cell->face(face)->center()[dim - 1]) <
                          1e-12))
                       {
                         cell->face(face)->set_boundary_id(1);
                       }
 
-                    if ((std::fabs(cell->face(face)->center()(0)) < 1e-12) &&
-                        (std::fabs(cell->face(face)->center()(dim - 1)) < 0.1))
+                    if ((std::fabs(cell->face(face)->center()[0]) < 1e-12) &&
+                        (std::fabs(cell->face(face)->center()[dim - 1]) < 0.1))
                       {
                         cell->face(face)->set_boundary_id(1);
                       }
 
-                    if ((std::fabs(1.0 - cell->face(face)->center()(0)) <
+                    if ((std::fabs(1.0 - cell->face(face)->center()[0]) <
                          0.1) &&
-                        (std::fabs(1.0 - cell->face(face)->center()(dim - 1)) <
+                        (std::fabs(1.0 - cell->face(face)->center()[dim - 1]) <
                          1e-12))
                       {
                         cell->face(face)->set_boundary_id(2);
                       }
 
-                    if ((std::fabs(1.0 - cell->face(face)->center()(0)) <
+                    if ((std::fabs(1.0 - cell->face(face)->center()[0]) <
                          1e-12) &&
-                        (std::fabs(1.0 - cell->face(face)->center()(dim - 1)) <
+                        (std::fabs(1.0 - cell->face(face)->center()[dim - 1]) <
                          0.1))
                       {
                         cell->face(face)->set_boundary_id(2);
@@ -97,35 +97,35 @@ run()
 
                     // no normal flux boundary
 
-                    if ((std::fabs(cell->face(face)->center()(0)) >= 0.1 &&
-                         std::fabs(cell->face(face)->center()(0)) <= 1.0) &&
-                        (std::fabs(cell->face(face)->center()(dim - 1)) <
+                    if ((std::fabs(cell->face(face)->center()[0]) >= 0.1 &&
+                         std::fabs(cell->face(face)->center()[0]) <= 1.0) &&
+                        (std::fabs(cell->face(face)->center()[dim - 1]) <
                          1e-12))
                       {
                         cell->face(face)->set_boundary_id(3);
                       }
 
-                    if ((std::fabs(cell->face(face)->center()(0)) >= 0.0 &&
-                         std::fabs(cell->face(face)->center()(0)) <= 0.9) &&
-                        (std::fabs(1.0 - cell->face(face)->center()(dim - 1)) <
+                    if ((std::fabs(cell->face(face)->center()[0]) >= 0.0 &&
+                         std::fabs(cell->face(face)->center()[0]) <= 0.9) &&
+                        (std::fabs(1.0 - cell->face(face)->center()[dim - 1]) <
                          1e-12))
                       {
                         cell->face(face)->set_boundary_id(5);
                       }
 
-                    if ((std::fabs(1.0 - cell->face(face)->center()(0)) <
+                    if ((std::fabs(1.0 - cell->face(face)->center()[0]) <
                          1e-12) &&
-                        (std::fabs(cell->face(face)->center()(dim - 1)) >=
+                        (std::fabs(cell->face(face)->center()[dim - 1]) >=
                            0.0 &&
-                         std::fabs(cell->face(face)->center()(dim - 1)) <= 0.9))
+                         std::fabs(cell->face(face)->center()[dim - 1]) <= 0.9))
                       {
                         cell->face(face)->set_boundary_id(4);
                       }
 
-                    if ((std::fabs(cell->face(face)->center()(0)) < 1e-12) &&
-                        (std::fabs(cell->face(face)->center()(dim - 1)) >=
+                    if ((std::fabs(cell->face(face)->center()[0]) < 1e-12) &&
+                        (std::fabs(cell->face(face)->center()[dim - 1]) >=
                            0.1 &&
-                         std::fabs(cell->face(face)->center()(dim - 1)) <= 1.0))
+                         std::fabs(cell->face(face)->center()[dim - 1]) <= 1.0))
                       {
                         cell->face(face)->set_boundary_id(6);
                       }

--- a/tests/numerics/no_flux_18.cc
+++ b/tests/numerics/no_flux_18.cc
@@ -495,7 +495,7 @@ namespace StokesClass
                 Point<dim> p;
                 for (unsigned int d = 0; d < dim; ++d)
                   {
-                    p(d) = velocity.quadrature_point(q)(d)[i];
+                    p[d] = velocity.quadrature_point(q)[d][i];
                   }
                 return_value[i] = 2.0 * viscosity_function.value(p);
               }
@@ -629,7 +629,7 @@ namespace StokesClass
               {
                 Point<dim> p;
                 for (unsigned int d = 0; d < dim; ++d)
-                  p(d) = pressure.quadrature_point(q)(d)[i];
+                  p[d] = pressure.quadrature_point(q)[d][i];
                 return_value[i] = 1.0 / viscosity_function.value(p);
               }
             one_over_viscosity(cell, q) = return_value;
@@ -809,7 +809,7 @@ namespace StokesClass
                 Point<dim> p;
                 for (unsigned int d = 0; d < dim; ++d)
                   {
-                    p(d) = velocity.quadrature_point(q)(d)[i];
+                    p[d] = velocity.quadrature_point(q)[d][i];
                   }
                 return_value[i] = 2.0 * viscosity_function.value(p);
               }
@@ -1251,7 +1251,7 @@ namespace StokesClass
               {
                 Point<dim> p;
                 for (unsigned int d = 0; d < dim; ++d)
-                  p(d) = velocity.quadrature_point(q)(d)[i];
+                  p[d] = velocity.quadrature_point(q)[d][i];
 
                 Vector<double> rhs_temp(dim + 1);
                 right_hand_side.vector_value(p, rhs_temp);

--- a/tests/numerics/point_value_history_01.cc
+++ b/tests/numerics/point_value_history_01.cc
@@ -137,7 +137,7 @@ TestPointValueHistory<dim>::run()
                  ++q_point)
               {
                 cell_pole(dof) += (fe_values.shape_value(dof, q_point) *
-                                   dof_locations[q_point](dof_component % dim));
+                                   dof_locations[q_point][dof_component % dim]);
               }
             solution(local_dof_indices[dof]) = 1; // start all solutions at 1
             poles(local_dof_indices[dof]) -= cell_pole(dof);

--- a/tests/numerics/point_value_history_02.cc
+++ b/tests/numerics/point_value_history_02.cc
@@ -237,7 +237,7 @@ TestPointValueHistory<dim>::run()
               finite_element.system_to_component_index(dof).first;
 
             poles(local_dof_indices[dof]) =
-              -dof_locations[dof](dof_component % dim);
+              -dof_locations[dof][dof_component % dim];
 
             if (dof_component == dim) // components start numbering at 0
               poles(local_dof_indices[dof]) =

--- a/tests/numerics/point_value_history_03.cc
+++ b/tests/numerics/point_value_history_03.cc
@@ -203,7 +203,7 @@ TestPointValueHistory<dim>::run()
             // simplifying the remaining lines
 
             poles(local_dof_indices[dof]) =
-              -dof_locations[dof](dof_component % dim);
+              -dof_locations[dof][dof_component % dim];
 
             if (dof_component == dim) // components start numbering at 0
               poles(local_dof_indices[dof]) =

--- a/tests/numerics/project_boundary_rt_01.cc
+++ b/tests/numerics/project_boundary_rt_01.cc
@@ -70,7 +70,7 @@ TestFunction<dim>::vector_value_list(const std::vector<Point<dim>> &points,
       if (degree < 2)
         {
           for (unsigned int d = 0; d < dim; ++d)
-            values[k](d) = points[k](d) - d;
+            values[k](d) = points[k][d] - d;
         }
       else
         {
@@ -82,7 +82,7 @@ TestFunction<dim>::vector_value_list(const std::vector<Point<dim>> &points,
             {
               Point<dim> p = points[k];
               for (unsigned int dd = 0; dd < dim; ++dd)
-                p(dd) -= d;
+                p[dd] -= d;
               const double r2 = p.square();
               values[k](d)    = std::pow(r2, (int)degree / 2);
             }

--- a/tests/numerics/project_complex.cc
+++ b/tests/numerics/project_complex.cc
@@ -68,7 +68,7 @@ public:
   ComplexNumber
   value(const Position &x, const unsigned int) const
   {
-    return x(0) + x(1) - ComplexNumber(0.2, 0.7) * x(2);
+    return x[0] + x[1] - ComplexNumber(0.2, 0.7) * x[2];
   }
 };
 

--- a/tests/numerics/project_to_surface_01.cc
+++ b/tests/numerics/project_to_surface_01.cc
@@ -43,8 +43,8 @@ public:
   operator()(const Point<spacedim> p) const
   {
     Point<spacedim> q;
-    q[0] = std::cos(angle) * p(0) - std::sin(angle) * p(1);
-    q[1] = std::sin(angle) * p(0) + std::cos(angle) * p(1);
+    q[0] = std::cos(angle) * p[0] - std::sin(angle) * p[1];
+    q[1] = std::sin(angle) * p[0] + std::cos(angle) * p[1];
     for (unsigned d = 2; d < spacedim; ++d)
       q[d] = p[d];
     return q;

--- a/tests/numerics/project_to_surface_02.cc
+++ b/tests/numerics/project_to_surface_02.cc
@@ -43,8 +43,8 @@ public:
   operator()(const Point<spacedim> p) const
   {
     Point<spacedim> q;
-    q[0] = std::cos(angle) * p(0) - std::sin(angle) * p(1);
-    q[1] = std::sin(angle) * p(0) + std::cos(angle) * p(1);
+    q[0] = std::cos(angle) * p[0] - std::sin(angle) * p[1];
+    q[1] = std::sin(angle) * p[0] + std::cos(angle) * p[1];
     for (unsigned d = 2; d < spacedim; ++d)
       q[d] = p[d];
     return q;

--- a/tests/particles/data_out_01.cc
+++ b/tests/particles/data_out_01.cc
@@ -50,8 +50,8 @@ test()
 
     for (unsigned int i = 0; i < dim; ++i)
       {
-        position[0](i) = 0.125;
-        position[1](i) = 0.525;
+        position[0][i] = 0.125;
+        position[1][i] = 0.525;
       }
 
     Particles::Particle<dim, spacedim> particle1(position[0],

--- a/tests/particles/data_out_05.cc
+++ b/tests/particles/data_out_05.cc
@@ -54,7 +54,7 @@ test()
 
     for (unsigned int i = 0; i < dim; ++i)
       {
-        position[0](i) = 0.125;
+        position[0][i] = 0.125;
       }
 
     for (unsigned int i = 0; i < spacedim; ++i)

--- a/tests/particles/exchange_ghosts_01.cc
+++ b/tests/particles/exchange_ghosts_01.cc
@@ -49,10 +49,10 @@ test()
 
     if (Utilities::MPI::this_mpi_process(tr.get_communicator()) == 0)
       for (unsigned int i = 0; i < dim; ++i)
-        position(i) = 0.475;
+        position[i] = 0.475;
     else
       for (unsigned int i = 0; i < dim; ++i)
-        position(i) = 0.525;
+        position[i] = 0.525;
 
     Particles::Particle<dim, spacedim> particle(
       position,

--- a/tests/particles/generators_02.cc
+++ b/tests/particles/generators_02.cc
@@ -46,7 +46,7 @@ test()
     std::vector<Point<dim>> particle_reference_locations(1, Point<dim>());
 
     for (unsigned int i = 0; i < dim; ++i)
-      particle_reference_locations[0](i) = 0.5;
+      particle_reference_locations[0][i] = 0.5;
 
     Particles::Generators::regular_reference_locations(
       tr, particle_reference_locations, particle_handler);

--- a/tests/particles/particle_01.cc
+++ b/tests/particles/particle_01.cc
@@ -30,7 +30,7 @@ test()
     Particles::Particle<dim> particle;
 
     Point<dim> position;
-    position(0) = 1.0;
+    position[0] = 1.0;
     particle.set_location(position);
 
     deallog << "Particle location: " << particle.get_location() << std::endl;

--- a/tests/particles/particle_02.cc
+++ b/tests/particles/particle_02.cc
@@ -28,12 +28,12 @@ test()
 {
   {
     Point<2> position;
-    position(0) = 0.3;
-    position(1) = 0.5;
+    position[0] = 0.3;
+    position[1] = 0.5;
 
     Point<2> reference_position;
-    reference_position(0) = 0.2;
-    reference_position(1) = 0.4;
+    reference_position[0] = 0.2;
+    reference_position[1] = 0.4;
 
     const types::particle_index index(7);
 

--- a/tests/particles/particle_03.cc
+++ b/tests/particles/particle_03.cc
@@ -33,12 +33,12 @@ test()
     Particles::PropertyPool<dim> pool(n_properties_per_particle);
 
     Point<2> position;
-    position(0) = 0.3;
-    position(1) = 0.5;
+    position[0] = 0.3;
+    position[1] = 0.5;
 
     Point<2> reference_position;
-    reference_position(0) = 0.2;
-    reference_position(1) = 0.4;
+    reference_position[0] = 0.2;
+    reference_position[1] = 0.4;
 
     const types::particle_index index(7);
 

--- a/tests/particles/particle_04.cc
+++ b/tests/particles/particle_04.cc
@@ -31,18 +31,18 @@ test()
   {
     Point<spacedim> position;
 
-    position(0) = 0.3;
+    position[0] = 0.3;
     if (spacedim > 1)
-      position(1) = 0.5;
+      position[1] = 0.5;
     if (spacedim > 2)
-      position(2) = 0.7;
+      position[2] = 0.7;
 
     Point<dim> reference_position;
-    reference_position(0) = 0.2;
+    reference_position[0] = 0.2;
     if (dim > 1)
-      reference_position(1) = 0.4;
+      reference_position[1] = 0.4;
     if (dim > 2)
-      reference_position(2) = 0.6;
+      reference_position[2] = 0.6;
 
     const types::particle_index index(7);
 

--- a/tests/particles/particle_05.cc
+++ b/tests/particles/particle_05.cc
@@ -34,18 +34,18 @@ test()
   {
     Point<spacedim> position;
 
-    position(0) = 0.3;
+    position[0] = 0.3;
     if (spacedim > 1)
-      position(1) = 0.5;
+      position[1] = 0.5;
     if (spacedim > 2)
-      position(2) = 0.7;
+      position[2] = 0.7;
 
     Point<dim> reference_position;
-    reference_position(0) = 0.2;
+    reference_position[0] = 0.2;
     if (dim > 1)
-      reference_position(1) = 0.4;
+      reference_position[1] = 0.4;
     if (dim > 2)
-      reference_position(2) = 0.6;
+      reference_position[2] = 0.6;
 
     const types::particle_index index(7);
 

--- a/tests/particles/particle_06.cc
+++ b/tests/particles/particle_06.cc
@@ -34,18 +34,18 @@ test()
 
     Point<spacedim> position;
 
-    position(0) = 0.3;
+    position[0] = 0.3;
     if (spacedim > 1)
-      position(1) = 0.5;
+      position[1] = 0.5;
     if (spacedim > 2)
-      position(2) = 0.7;
+      position[2] = 0.7;
 
     Point<dim> reference_position;
-    reference_position(0) = 0.2;
+    reference_position[0] = 0.2;
     if (dim > 1)
-      reference_position(1) = 0.4;
+      reference_position[1] = 0.4;
     if (dim > 2)
-      reference_position(2) = 0.6;
+      reference_position[2] = 0.6;
 
     const types::particle_index index(7);
 

--- a/tests/particles/particle_07.cc
+++ b/tests/particles/particle_07.cc
@@ -33,12 +33,12 @@ test()
     Particles::PropertyPool<dim> pool(n_properties_per_particle);
 
     Point<2> position;
-    position(0) = 0.3;
-    position(1) = 0.5;
+    position[0] = 0.3;
+    position[1] = 0.5;
 
     Point<2> reference_position;
-    reference_position(0) = 0.2;
-    reference_position(1) = 0.4;
+    reference_position[0] = 0.2;
+    reference_position[1] = 0.4;
 
     const types::particle_index index(7);
 

--- a/tests/particles/particle_08.cc
+++ b/tests/particles/particle_08.cc
@@ -28,12 +28,12 @@ test()
 {
   {
     Point<2> position;
-    position(0) = 0.3;
-    position(1) = 0.5;
+    position[0] = 0.3;
+    position[1] = 0.5;
 
     Point<2> reference_position;
-    reference_position(0) = 0.2;
-    reference_position(1) = 0.4;
+    reference_position[0] = 0.2;
+    reference_position[1] = 0.4;
 
     const types::particle_index index(7);
 

--- a/tests/particles/particle_handler_01.cc
+++ b/tests/particles/particle_handler_01.cc
@@ -43,18 +43,18 @@ test()
 
 
     Point<spacedim> position;
-    position(0) = 0.3;
+    position[0] = 0.3;
     if (spacedim > 1)
-      position(1) = 0.5;
+      position[1] = 0.5;
     if (spacedim > 2)
-      position(2) = 0.7;
+      position[2] = 0.7;
 
     Point<dim> reference_position;
-    reference_position(0) = 0.2;
+    reference_position[0] = 0.2;
     if (dim > 1)
-      reference_position(1) = 0.4;
+      reference_position[1] = 0.4;
     if (dim > 2)
-      reference_position(2) = 0.6;
+      reference_position[2] = 0.6;
 
     Particles::Particle<dim, spacedim> particle(position,
                                                 reference_position,

--- a/tests/particles/particle_handler_02.cc
+++ b/tests/particles/particle_handler_02.cc
@@ -44,18 +44,18 @@ test()
 
 
     Point<spacedim> position;
-    position(0) = 0.3;
+    position[0] = 0.3;
     if (spacedim > 1)
-      position(1) = 0.5;
+      position[1] = 0.5;
     if (spacedim > 2)
-      position(2) = 0.7;
+      position[2] = 0.7;
 
     Point<dim> reference_position;
-    reference_position(0) = 0.2;
+    reference_position[0] = 0.2;
     if (dim > 1)
-      reference_position(1) = 0.4;
+      reference_position[1] = 0.4;
     if (dim > 2)
-      reference_position(2) = 0.6;
+      reference_position[2] = 0.6;
 
     Particles::Particle<dim, spacedim> particle(position,
                                                 reference_position,
@@ -74,7 +74,7 @@ test()
     particle_handler.insert_particle(particle, cell_position.first);
     particle_handler.insert_particle(particle, cell_position.first);
 
-    position(0) = 0.7;
+    position[0] = 0.7;
     Particles::Particle<dim, spacedim> particle2(position,
                                                  reference_position,
                                                  9);

--- a/tests/particles/particle_handler_03.cc
+++ b/tests/particles/particle_handler_03.cc
@@ -46,8 +46,8 @@ test()
 
     for (unsigned int i = 0; i < dim; ++i)
       {
-        position[0](i) = 0.25;
-        position[1](i) = 0.75;
+        position[0][i] = 0.25;
+        position[1][i] = 0.75;
       }
 
     Particles::Particle<dim, spacedim> particle1(position[0],
@@ -83,7 +83,7 @@ test()
     // move particle 2 out of the domain. Note that we need to change the
     // coordinate dim-1 despite having a spacedim point.
     Point<spacedim> shift;
-    shift(dim - 1) = 0.5;
+    shift[dim - 1] = 0.5;
     for (auto &particle : particle_handler)
       particle.set_location(particle.get_location() + shift);
 

--- a/tests/particles/particle_handler_04.cc
+++ b/tests/particles/particle_handler_04.cc
@@ -51,8 +51,8 @@ test()
 
         for (unsigned int i = 0; i < dim; ++i)
           {
-            position[0](i) = 0.125;
-            position[1](i) = 0.525;
+            position[0][i] = 0.125;
+            position[1][i] = 0.525;
           }
 
         Particles::Particle<dim, spacedim> particle1(position[0],
@@ -95,7 +95,7 @@ test()
     // move particle 2 out of the domain. Note that we need to change the
     // coordinate dim-1 despite having a spacedim point.
     Point<spacedim> shift;
-    shift(dim - 1) = 0.5;
+    shift[dim - 1] = 0.5;
     for (auto &particle : particle_handler)
       particle.set_location(particle.get_location() + shift);
 

--- a/tests/particles/particle_handler_06.cc
+++ b/tests/particles/particle_handler_06.cc
@@ -48,10 +48,10 @@ test()
 
     if (Utilities::MPI::this_mpi_process(tr.get_communicator()) == 0)
       for (unsigned int i = 0; i < dim; ++i)
-        position(i) = 0.475;
+        position[i] = 0.475;
     else
       for (unsigned int i = 0; i < dim; ++i)
-        position(i) = 0.525;
+        position[i] = 0.525;
 
     Particles::Particle<dim, spacedim> particle(
       position,

--- a/tests/particles/particle_handler_19.cc
+++ b/tests/particles/particle_handler_19.cc
@@ -50,10 +50,10 @@ test()
 
     if (Utilities::MPI::this_mpi_process(tr.get_communicator()) == 0)
       for (unsigned int i = 0; i < dim; ++i)
-        position(i) = 0.475;
+        position[i] = 0.475;
     else
       for (unsigned int i = 0; i < dim; ++i)
-        position(i) = 0.525;
+        position[i] = 0.525;
 
     Particles::Particle<dim, spacedim> particle(
       position,

--- a/tests/particles/particle_handler_20.cc
+++ b/tests/particles/particle_handler_20.cc
@@ -54,7 +54,7 @@ test()
         if (Utilities::MPI::this_mpi_process(tr.get_communicator()) == 0)
           {
             for (unsigned int i = 0; i < dim; ++i)
-              position(i) = 0.410 + 0.01 * p;
+              position[i] = 0.410 + 0.01 * p;
 
             Particles::Particle<dim, spacedim> particle(
               position,

--- a/tests/particles/particle_handler_fully_distributed_01.cc
+++ b/tests/particles/particle_handler_fully_distributed_01.cc
@@ -67,8 +67,8 @@ test()
 
         for (unsigned int i = 0; i < dim; ++i)
           {
-            position[0](i) = 0.125;
-            position[1](i) = 0.525;
+            position[0][i] = 0.125;
+            position[1][i] = 0.525;
           }
 
         Particles::Particle<dim, spacedim> particle1(position[0],
@@ -110,7 +110,7 @@ test()
     // move particle 2 out of the domain. Note that we need to change the
     // coordinate dim-1 despite having a spacedim point.
     Point<spacedim> shift;
-    shift(dim - 1) = 0.5;
+    shift[dim - 1] = 0.5;
     for (auto &particle : particle_handler)
       particle.set_location(particle.get_location() + shift);
 

--- a/tests/particles/particle_handler_serial_01.cc
+++ b/tests/particles/particle_handler_serial_01.cc
@@ -42,18 +42,18 @@ test()
 
 
   Point<spacedim> position;
-  position(0) = 0.3;
+  position[0] = 0.3;
   if (spacedim > 1)
-    position(1) = 0.5;
+    position[1] = 0.5;
   if (spacedim > 2)
-    position(2) = 0.7;
+    position[2] = 0.7;
 
   Point<dim> reference_position;
-  reference_position(0) = 0.2;
+  reference_position[0] = 0.2;
   if (dim > 1)
-    reference_position(1) = 0.4;
+    reference_position[1] = 0.4;
   if (dim > 2)
-    reference_position(2) = 0.6;
+    reference_position[2] = 0.6;
 
   Particles::Particle<dim, spacedim> particle(position, reference_position, 7);
   deallog << "Particle location: " << particle.get_location() << std::endl;

--- a/tests/particles/particle_handler_serial_02.cc
+++ b/tests/particles/particle_handler_serial_02.cc
@@ -44,18 +44,18 @@ test()
 
 
     Point<spacedim> position;
-    position(0) = 0.3;
+    position[0] = 0.3;
     if (spacedim > 1)
-      position(1) = 0.5;
+      position[1] = 0.5;
     if (spacedim > 2)
-      position(2) = 0.7;
+      position[2] = 0.7;
 
     Point<dim> reference_position;
-    reference_position(0) = 0.2;
+    reference_position[0] = 0.2;
     if (dim > 1)
-      reference_position(1) = 0.4;
+      reference_position[1] = 0.4;
     if (dim > 2)
-      reference_position(2) = 0.6;
+      reference_position[2] = 0.6;
 
     Particles::Particle<dim, spacedim> particle(position,
                                                 reference_position,
@@ -71,7 +71,7 @@ test()
     particle_handler.insert_particle(particle, cell_position.first);
     particle_handler.insert_particle(particle, cell_position.first);
 
-    position(0) = 0.7;
+    position[0] = 0.7;
     Particles::Particle<dim, spacedim> particle2(position,
                                                  reference_position,
                                                  9);

--- a/tests/particles/particle_handler_serial_03.cc
+++ b/tests/particles/particle_handler_serial_03.cc
@@ -47,8 +47,8 @@ test()
 
     for (unsigned int i = 0; i < dim; ++i)
       {
-        position[0](i) = 0.25;
-        position[1](i) = 0.75;
+        position[0][i] = 0.25;
+        position[1][i] = 0.75;
       }
 
     Particles::Particle<dim, spacedim> particle1(position[0],
@@ -84,7 +84,7 @@ test()
     // move particle 2 out of the domain. Note that we need to change the
     // coordinate dim-1 despite having a spacedim point.
     Point<spacedim> shift;
-    shift(dim - 1) = 0.5;
+    shift[dim - 1] = 0.5;
     for (auto &particle : particle_handler)
       particle.set_location(particle.get_location() + shift);
 

--- a/tests/particles/particle_handler_shared_01.cc
+++ b/tests/particles/particle_handler_shared_01.cc
@@ -63,8 +63,8 @@ test()
 
         for (unsigned int i = 0; i < dim; ++i)
           {
-            position[0](i) = 0.125;
-            position[1](i) = 0.525;
+            position[0][i] = 0.125;
+            position[1][i] = 0.525;
           }
 
         Particles::Particle<dim, spacedim> particle1(position[0],
@@ -108,7 +108,7 @@ test()
     // move particle 2 out of the domain. Note that we need to change the
     // coordinate dim-1 despite having a spacedim point.
     Point<spacedim> shift;
-    shift(dim - 1) = 0.5;
+    shift[dim - 1] = 0.5;
     for (auto &particle : particle_handler)
       particle.set_location(particle.get_location() + shift);
 

--- a/tests/particles/particle_iterator_01.cc
+++ b/tests/particles/particle_iterator_01.cc
@@ -48,16 +48,16 @@ test()
                                                      n_properties_per_particle);
 
     Point<dim> position;
-    position(0) = 0.3;
+    position[0] = 0.3;
 
     if (dim > 1)
-      position(1) = 0.5;
+      position[1] = 0.5;
 
     Point<dim> reference_position;
-    reference_position(0) = 0.2;
+    reference_position[0] = 0.2;
 
     if (dim > 1)
-      reference_position(1) = 0.4;
+      reference_position[1] = 0.4;
 
     const types::particle_index index(7);
 

--- a/tests/particles/particle_iterator_02.cc
+++ b/tests/particles/particle_iterator_02.cc
@@ -46,16 +46,16 @@ test()
     Particles::PropertyPool<dim> pool(n_properties_per_particle);
 
     Point<dim> position;
-    position(0) = 0.3;
+    position[0] = 0.3;
 
     if (dim > 1)
-      position(1) = 0.5;
+      position[1] = 0.5;
 
     Point<dim> reference_position;
-    reference_position(0) = 0.2;
+    reference_position[0] = 0.2;
 
     if (dim > 1)
-      reference_position(1) = 0.4;
+      reference_position[1] = 0.4;
 
     const types::particle_index index(7);
 

--- a/tests/particles/remove_particle_01.cc
+++ b/tests/particles/remove_particle_01.cc
@@ -46,9 +46,9 @@ test()
 
     for (unsigned int i = 0; i < dim; ++i)
       {
-        particle_reference_locations[0](i) = 0.25;
-        particle_reference_locations[1](i) = 0.5;
-        particle_reference_locations[2](i) = 0.75;
+        particle_reference_locations[0][i] = 0.25;
+        particle_reference_locations[1][i] = 0.5;
+        particle_reference_locations[2][i] = 0.75;
       }
 
     Particles::Generators::regular_reference_locations(

--- a/tests/particles/step-68.cc
+++ b/tests/particles/step-68.cc
@@ -108,8 +108,8 @@ namespace Step68
     const double T = 4;
     const double t = this->get_time();
 
-    const double px = numbers::PI * point(0);
-    const double py = numbers::PI * point(1);
+    const double px = numbers::PI * point[0];
+    const double py = numbers::PI * point[1];
     const double pt = numbers::PI / T * t;
 
     values[0] = -2 * cos(pt) * pow(sin(px), 2) * sin(py) * cos(py);

--- a/tests/simplex/poisson_02.cc
+++ b/tests/simplex/poisson_02.cc
@@ -138,10 +138,10 @@ public:
   value(const Point<dim> &p, const unsigned int /*component*/ = 0) const
   {
     if (dim == 2)
-      return -2. * M_PI * M_PI * std::sin(M_PI * p(0)) * std::sin(M_PI * p(1));
+      return -2. * M_PI * M_PI * std::sin(M_PI * p[0]) * std::sin(M_PI * p[1]);
     else /* if(dim == 3)*/
-      return -3. * M_PI * M_PI * std::sin(M_PI * p(0)) * std::sin(M_PI * p(1)) *
-             std::sin(M_PI * p(2));
+      return -3. * M_PI * M_PI * std::sin(M_PI * p[0]) * std::sin(M_PI * p[1]) *
+             std::sin(M_PI * p[2]);
   }
 };
 

--- a/tests/simplex/simplex_grids.h
+++ b/tests/simplex/simplex_grids.h
@@ -415,12 +415,12 @@ namespace dealii
 #ifdef DEBUG
       // all vertices should be in a plane
       for (const auto &vertex : vertices)
-        Assert(midpoint(coordinate) == vertex(coordinate), ExcInternalError());
+        Assert(midpoint[coordinate] == vertex[coordinate], ExcInternalError());
 #endif
 
       // add another vertex as tip of triangle/pyramid
       Point<spacedim> tip = midpoint;
-      tip(coordinate) += (face_no % 2 == 1) ? 1. : -1.;
+      tip[coordinate] += (face_no % 2 == 1) ? 1. : -1.;
       vertices.push_back(tip);
 
       CellData<dim> simplex(vertices.size());

--- a/tests/simplex/simplex_project_cg.cc
+++ b/tests/simplex/simplex_project_cg.cc
@@ -57,7 +57,7 @@ public:
   {
     double u = 1.0;
     for (int d = 0; d < dim; ++d)
-      u *= std::sin(numbers::PI * p(d));
+      u *= std::sin(numbers::PI * p[d]);
 
     return u;
   }
@@ -72,7 +72,7 @@ public:
   {
     double u = 1.0;
     for (int d = 0; d < dim; ++d)
-      u *= std::sin(numbers::PI * p(d));
+      u *= std::sin(numbers::PI * p[d]);
 
     return (1 + 0.0 * dim * numbers::PI * numbers::PI) * u;
   }

--- a/tests/simplex/step-04-data_out_faces.cc
+++ b/tests/simplex/step-04-data_out_faces.cc
@@ -120,7 +120,7 @@ RightHandSide<dim>::value(const Point<dim> &p,
 {
   double return_value = 0.0;
   for (unsigned int i = 0; i < dim; ++i)
-    return_value += 4.0 * std::pow(p(i), 4.0);
+    return_value += 4.0 * std::pow(p[i], 4.0);
 
   return return_value;
 }

--- a/tests/simplex/step-04.cc
+++ b/tests/simplex/step-04.cc
@@ -126,7 +126,7 @@ RightHandSide<dim>::value(const Point<dim> &p,
 {
   double return_value = 0.0;
   for (unsigned int i = 0; i < dim; ++i)
-    return_value += 4.0 * std::pow(p(i), 4.0);
+    return_value += 4.0 * std::pow(p[i], 4.0);
 
   return return_value;
 }

--- a/tests/simplex/step-07.cc
+++ b/tests/simplex/step-07.cc
@@ -524,8 +524,8 @@ namespace Step7
               for (const auto &face : cell->face_iterators())
                 {
                   const auto center = face->center();
-                  if ((std::fabs(center(0) - (-1.0)) < 1e-12) ||
-                      (std::fabs(center(1) - (-1.0)) < 1e-12))
+                  if ((std::fabs(center[0] - (-1.0)) < 1e-12) ||
+                      (std::fabs(center[1] - (-1.0)) < 1e-12))
                     face->set_boundary_id(1);
                 }
           }

--- a/tests/simplex/step-08.cc
+++ b/tests/simplex/step-08.cc
@@ -113,8 +113,8 @@ namespace Step8
     Assert(dim >= 2, ExcNotImplemented());
 
     Point<dim> point_1, point_2;
-    point_1(0) = 0.5;
-    point_2(0) = -0.5;
+    point_1[0] = 0.5;
+    point_2[0] = -0.5;
 
     for (unsigned int point_n = 0; point_n < points.size(); ++point_n)
       {

--- a/tests/simplex/step-12.cc
+++ b/tests/simplex/step-12.cc
@@ -89,7 +89,7 @@ namespace Step12
 
     for (unsigned int i = 0; i < values.size(); ++i)
       {
-        if (points[i](0) < 0.5)
+        if (points[i][0] < 0.5)
           values[i] = 1.;
         else
           values[i] = 0.;
@@ -104,8 +104,8 @@ namespace Step12
     Assert(dim >= 2, ExcNotImplemented());
 
     Point<dim> wind_field;
-    wind_field(0) = -p(1);
-    wind_field(1) = p(0);
+    wind_field[0] = -p[1];
+    wind_field[1] = p[0];
 
     if (wind_field.norm() > 1e-10)
       wind_field /= wind_field.norm();

--- a/tests/simplex/step-12a.cc
+++ b/tests/simplex/step-12a.cc
@@ -96,7 +96,7 @@ namespace Step12
 
     for (unsigned int i = 0; i < values.size(); ++i)
       {
-        if (points[i](0) < 0.5)
+        if (points[i][0] < 0.5)
           values[i] = 1.;
         else
           values[i] = 0.;
@@ -111,8 +111,8 @@ namespace Step12
     Assert(dim >= 2, ExcNotImplemented());
 
     Point<dim> wind_field;
-    wind_field(0) = -p(1);
-    wind_field(1) = p(0);
+    wind_field[0] = -p[1];
+    wind_field[1] = p[0];
 
     if (wind_field.norm() > 1e-6)
       wind_field /= wind_field.norm();

--- a/tests/simplex/step-12b.cc
+++ b/tests/simplex/step-12b.cc
@@ -130,8 +130,8 @@ Beta<dim>::value_list(const std::vector<Point<dim>> &points,
       const Point<dim> &p    = points[i];
       Point<dim>       &beta = values[i];
 
-      beta(0) = -p(1);
-      beta(1) = p(0);
+      beta[0] = -p[1];
+      beta[1] = p[0];
 
       if (beta.norm() > 1e-10)
         beta /= std::sqrt(beta.square());
@@ -150,7 +150,7 @@ BoundaryValues<dim>::value_list(const std::vector<Point<dim>> &points,
 
   for (unsigned int i = 0; i < std::min(values.size(), points.size()); ++i)
     {
-      if (points[i](0) < 0.5)
+      if (points[i][0] < 0.5)
         values[i] = 1.;
       else
         values[i] = 0.;

--- a/tests/simplex/step-12c.cc
+++ b/tests/simplex/step-12c.cc
@@ -133,8 +133,8 @@ Beta<dim>::value_list(const std::vector<Point<dim>> &points,
       const Point<dim> &p    = points[i];
       Point<dim>       &beta = values[i];
 
-      beta(0) = -p(1);
-      beta(1) = p(0);
+      beta[0] = -p[1];
+      beta[1] = p[0];
 
       if (beta.norm() > 1e-10)
         beta /= std::sqrt(beta.square());
@@ -153,7 +153,7 @@ BoundaryValues<dim>::value_list(const std::vector<Point<dim>> &points,
 
   for (unsigned int i = 0; i < std::min(values.size(), points.size()); ++i)
     {
-      if (points[i](0) < 0.5)
+      if (points[i][0] < 0.5)
         values[i] = 1.;
       else
         values[i] = 0.;

--- a/tests/simplex/step-17.cc
+++ b/tests/simplex/step-17.cc
@@ -139,8 +139,8 @@ namespace Step17
       Assert(dim >= 2, ExcInternalError());
 
       Point<dim> point_1, point_2;
-      point_1(0) = 0.5;
-      point_2(0) = -0.5;
+      point_1[0] = 0.5;
+      point_2[0] = -0.5;
 
       if (((p - point_1).norm_square() < 0.2 * 0.2) ||
           ((p - point_2).norm_square() < 0.2 * 0.2))

--- a/tests/simplex/step-38.cc
+++ b/tests/simplex/step-38.cc
@@ -120,7 +120,7 @@ namespace Step38
   double
   Solution<2>::value(const Point<2> &p, const unsigned int) const
   {
-    return (-2. * p(0) * p(1));
+    return (-2. * p[0] * p[1]);
   }
 
   template <>
@@ -128,8 +128,8 @@ namespace Step38
   Solution<2>::gradient(const Point<2> &p, const unsigned int) const
   {
     Tensor<1, 2> return_value;
-    return_value[0] = -2. * p(1) * (1 - 2. * p(0) * p(0));
-    return_value[1] = -2. * p(0) * (1 - 2. * p(1) * p(1));
+    return_value[0] = -2. * p[1] * (1 - 2. * p[0] * p[0]);
+    return_value[1] = -2. * p[0] * (1 - 2. * p[1] * p[1]);
 
     return return_value;
   }
@@ -138,8 +138,8 @@ namespace Step38
   double
   Solution<3>::value(const Point<3> &p, const unsigned int) const
   {
-    return (std::sin(numbers::PI * p(0)) * std::cos(numbers::PI * p(1)) *
-            exp(p(2)));
+    return (std::sin(numbers::PI * p[0]) * std::cos(numbers::PI * p[1]) *
+            exp(p[2]));
   }
 
   template <>
@@ -150,9 +150,9 @@ namespace Step38
 
     Tensor<1, 3> return_value;
 
-    return_value[0] = PI * cos(PI * p(0)) * cos(PI * p(1)) * exp(p(2));
-    return_value[1] = -PI * sin(PI * p(0)) * sin(PI * p(1)) * exp(p(2));
-    return_value[2] = sin(PI * p(0)) * cos(PI * p(1)) * exp(p(2));
+    return_value[0] = PI * cos(PI * p[0]) * cos(PI * p[1]) * exp(p[2]);
+    return_value[1] = -PI * sin(PI * p[0]) * sin(PI * p[1]) * exp(p[2]);
+    return_value[2] = sin(PI * p[0]) * cos(PI * p[1]) * exp(p[2]);
 
     return return_value;
   }
@@ -170,7 +170,7 @@ namespace Step38
   RightHandSide<2>::value(const Point<2> &p,
                           const unsigned int /*component*/) const
   {
-    return (-8. * p(0) * p(1));
+    return (-8. * p[0] * p[1]);
   }
 
   template <>
@@ -182,23 +182,23 @@ namespace Step38
 
     Tensor<2, 3> hessian;
 
-    hessian[0][0] = -PI * PI * sin(PI * p(0)) * cos(PI * p(1)) * exp(p(2));
-    hessian[1][1] = -PI * PI * sin(PI * p(0)) * cos(PI * p(1)) * exp(p(2));
-    hessian[2][2] = sin(PI * p(0)) * cos(PI * p(1)) * exp(p(2));
+    hessian[0][0] = -PI * PI * sin(PI * p[0]) * cos(PI * p[1]) * exp(p[2]);
+    hessian[1][1] = -PI * PI * sin(PI * p[0]) * cos(PI * p[1]) * exp(p[2]);
+    hessian[2][2] = sin(PI * p[0]) * cos(PI * p[1]) * exp(p[2]);
 
-    hessian[0][1] = -PI * PI * cos(PI * p(0)) * sin(PI * p(1)) * exp(p(2));
-    hessian[1][0] = -PI * PI * cos(PI * p(0)) * sin(PI * p(1)) * exp(p(2));
+    hessian[0][1] = -PI * PI * cos(PI * p[0]) * sin(PI * p[1]) * exp(p[2]);
+    hessian[1][0] = -PI * PI * cos(PI * p[0]) * sin(PI * p[1]) * exp(p[2]);
 
-    hessian[0][2] = PI * cos(PI * p(0)) * cos(PI * p(1)) * exp(p(2));
-    hessian[2][0] = PI * cos(PI * p(0)) * cos(PI * p(1)) * exp(p(2));
+    hessian[0][2] = PI * cos(PI * p[0]) * cos(PI * p[1]) * exp(p[2]);
+    hessian[2][0] = PI * cos(PI * p[0]) * cos(PI * p[1]) * exp(p[2]);
 
-    hessian[1][2] = -PI * sin(PI * p(0)) * sin(PI * p(1)) * exp(p(2));
-    hessian[2][1] = -PI * sin(PI * p(0)) * sin(PI * p(1)) * exp(p(2));
+    hessian[1][2] = -PI * sin(PI * p[0]) * sin(PI * p[1]) * exp(p[2]);
+    hessian[2][1] = -PI * sin(PI * p[0]) * sin(PI * p[1]) * exp(p[2]);
 
     Tensor<1, 3> gradient;
-    gradient[0] = PI * cos(PI * p(0)) * cos(PI * p(1)) * exp(p(2));
-    gradient[1] = -PI * sin(PI * p(0)) * sin(PI * p(1)) * exp(p(2));
-    gradient[2] = sin(PI * p(0)) * cos(PI * p(1)) * exp(p(2));
+    gradient[0] = PI * cos(PI * p[0]) * cos(PI * p[1]) * exp(p[2]);
+    gradient[1] = -PI * sin(PI * p[0]) * sin(PI * p[1]) * exp(p[2]);
+    gradient[2] = sin(PI * p[0]) * cos(PI * p[1]) * exp(p[2]);
 
     Point<3> normal = p;
     normal /= p.norm();

--- a/tests/simplex/step-68.cc
+++ b/tests/simplex/step-68.cc
@@ -100,8 +100,8 @@ namespace Step68
     const double T = 4;
     const double t = this->get_time();
 
-    const double px = numbers::PI * point(0);
-    const double py = numbers::PI * point(1);
+    const double px = numbers::PI * point[0];
+    const double py = numbers::PI * point[1];
     const double pt = numbers::PI / T * t;
 
     values[0] = -2 * cos(pt) * pow(sin(px), 2) * sin(py) * cos(py);

--- a/tests/sparsity/flux_sparsity_pattern_visiting_once.cc
+++ b/tests/sparsity/flux_sparsity_pattern_visiting_once.cc
@@ -53,7 +53,7 @@ is_face_on_OY(const typename DoFHandler<dim>::active_cell_iterator &cell,
   deallog
     << "This sentence should appear once when the corresponding face is visited only once on cell "
     << cell->index() << std::endl;
-  return (std::abs(cell->face(face_index)->center()(0)) < 0.01);
+  return (std::abs(cell->face(face_index)->center()[0]) < 0.01);
 }
 
 template <int dim>

--- a/tests/test_grids.h
+++ b/tests/test_grids.h
@@ -81,7 +81,7 @@ namespace TestGrids
                 const Point<dim> &p        = cell->center();
                 bool              negative = true;
                 for (unsigned int d = 0; d < dim; ++d)
-                  if (p(d) >= 0.)
+                  if (p[d] >= 0.)
                     negative = false;
                 if (negative)
                   cell->set_refine_flag();

--- a/tests/trilinos/direct_solver.cc
+++ b/tests/trilinos/direct_solver.cc
@@ -108,7 +108,7 @@ RightHandSide<dim>::value(const Point<dim> &p,
 {
   double return_value = 0;
   for (unsigned int i = 0; i < dim; ++i)
-    return_value += 4 * std::pow(p(i), 4);
+    return_value += 4 * std::pow(p[i], 4);
 
   return return_value;
 }

--- a/tests/trilinos/direct_solver_2.cc
+++ b/tests/trilinos/direct_solver_2.cc
@@ -128,7 +128,7 @@ RightHandSide<dim>::value(const Point<dim> &p,
 {
   double return_value = 0;
   for (unsigned int i = 0; i < dim; ++i)
-    return_value += 2 * std::pow(p(i), 2);
+    return_value += 2 * std::pow(p[i], 2);
 
   return return_value;
 }

--- a/tests/trilinos/precondition.cc
+++ b/tests/trilinos/precondition.cc
@@ -109,7 +109,7 @@ RightHandSide<dim>::value(const Point<dim> &p,
 {
   double return_value = 0;
   for (unsigned int i = 0; i < dim; ++i)
-    return_value += 4 * std::pow(p(i), 4);
+    return_value += 4 * std::pow(p[i], 4);
 
   return return_value;
 }

--- a/tests/trilinos/precondition_amg_smoother.cc
+++ b/tests/trilinos/precondition_amg_smoother.cc
@@ -108,7 +108,7 @@ RightHandSide<dim>::value(const Point<dim> &p,
 {
   double return_value = 0;
   for (unsigned int i = 0; i < dim; ++i)
-    return_value += 4 * std::pow(p(i), 4);
+    return_value += 4 * std::pow(p[i], 4);
 
   return return_value;
 }

--- a/tests/trilinos/precondition_q_iso_q1.cc
+++ b/tests/trilinos/precondition_q_iso_q1.cc
@@ -115,7 +115,7 @@ RightHandSide<dim>::value(const Point<dim> &p,
 {
   double return_value = 0;
   for (unsigned int i = 0; i < dim; ++i)
-    return_value += 4 * std::pow(p(i), 4);
+    return_value += 4 * std::pow(p[i], 4);
 
   return return_value;
 }


### PR DESCRIPTION
#16488 dealt with the source directories. This one is for `tests/`. It required a substantial amount of scripting, but in the end this now compiles without `Point<dim>::operator()` once #16503 is also in place.

Relates to #11294.