### PR TITLE
Use simpler copy/move initialization in Tensor.

### DIFF
--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1494,20 +1494,16 @@ operator Tensor<1, dim, Tensor<rank_ - 1, dim, OtherNumber>>() const
 template <int rank_, int dim, typename Number>
 constexpr DEAL_II_ALWAYS_INLINE
 Tensor<rank_, dim, Number>::Tensor(const Tensor<rank_, dim, Number> &other)
-{
-  for (unsigned int i = 0; i < dim; ++i)
-    values[i] = other.values[i];
-}
+  : values(other.values)
+{}
 
 
 
 template <int rank_, int dim, typename Number>
 constexpr DEAL_II_ALWAYS_INLINE
 Tensor<rank_, dim, Number>::Tensor(Tensor<rank_, dim, Number> &&other) noexcept
-{
-  for (unsigned int i = 0; i < dim; ++i)
-    values[i] = other.values[i];
-}
+  : values(std::move(other.values))
+{}
 #  endif
 
 


### PR DESCRIPTION
Since #16474, we use a `std::array` instead of a C-style array to store the elements of a tensor. This allows us to do copy- and move-initialization of the whole `values` array, rather than having to do a loop.

Related to #16465.