### PR TITLE
Fix type in Tensor initialization.

### DIFF
--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1313,7 +1313,7 @@ template <typename ArrayLike, std::size_t... indices>
 constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE
 Tensor<rank_, dim, Number>::Tensor(const ArrayLike &initializer,
                                    std::index_sequence<indices...>)
-  : values{{Tensor<rank_ - 1, dim, Number>(initializer[indices])...}}
+  : values{{value_type(initializer[indices])...}}
 {
   static_assert(sizeof...(indices) == dim,
                 "dim should match the number of indices");


### PR DESCRIPTION
Since #16480, we store scalars instead of objects of type `Tensor<0,dim>` as base elements of `Tensor<1,dim>`. Reflect this in the type of an initializer.

Related to #16465.