### PR TITLE
DoFTools: Remove unnecessary template specializations

### DIFF
--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -591,43 +591,6 @@ namespace DoFTools
     } // namespace
 
 
-    template <typename number>
-    void
-    make_hp_hanging_node_constraints(const DoFHandler<1> &,
-                                     AffineConstraints<number> &)
-    {
-      // nothing to do for regular dof handlers in 1d
-    }
-
-
-    template <typename number>
-    void
-    make_hp_hanging_node_constraints(const DoFHandler<1, 2> &,
-                                     AffineConstraints<number> &)
-    {
-      // nothing to do for regular dof handlers in 1d
-    }
-
-
-    template <typename number>
-    void
-    make_hanging_node_constraints_nedelec(const dealii::DoFHandler<1, 2> &,
-                                          AffineConstraints<number> &,
-                                          std::integral_constant<int, 1>)
-    {
-      // nothing to do for regular dof handlers in 1d
-    }
-
-
-    template <typename number>
-    void
-    make_oldstyle_hanging_node_constraints(const DoFHandler<1, 2> &,
-                                           AffineConstraints<number> &,
-                                           std::integral_constant<int, 1>)
-    {
-      // nothing to do for regular dof handlers in 1d
-    }
-
 
     template <typename number, int spacedim>
     void
@@ -637,6 +600,7 @@ namespace DoFTools
     {
       // nothing to do for dof handlers in 1d
     }
+
 
 
     template <typename number, int spacedim>
@@ -650,6 +614,7 @@ namespace DoFTools
     }
 
 
+
     template <typename number, int spacedim>
     void
     make_oldstyle_hanging_node_constraints(
@@ -659,6 +624,8 @@ namespace DoFTools
     {
       // nothing to do for dof handlers in 1d
     }
+
+
 
     template <int dim_, int spacedim, typename number>
     void


### PR DESCRIPTION
We have specializations for `DoFHandler<1, spacedim>` of these functions a few lines down, doing exactly the same (= nothing), so I see no reason to keep these additional specializations.

Observed when looking at #16304.