### PR TITLE
Reenable assume macro

### DIFF
--- a/cmake/setup_compiler_flags_gnu.cmake
+++ b/cmake/setup_compiler_flags_gnu.cmake
@@ -176,12 +176,6 @@ if (CMAKE_BUILD_TYPE MATCHES "Release")
   # mode.
   #
   enable_if_supported(DEAL_II_CXX_FLAGS_RELEASE "-Wno-unused-local-typedefs")
-
-  #
-  # We are using __builtin_assume in Assert in Release mode and the compiler is
-  # warning about ignored side effects which we don't care about.
-  #
-  enable_if_supported(DEAL_II_CXX_FLAGS_RELEASE "-Wno-assume")
 endif()
 
 

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -183,31 +183,22 @@
  * attribute for older standards we rely on compiler intrinsics when
  * available.
  */
-#ifdef DEAL_II_EXPERIMENTAL_ASSUME
-#  error "Test"
-#  if defined(__clang__)
-#    define DEAL_II_CXX23_ASSUME(expr) __builtin_assume(static_cast<bool>(expr))
-#  elif defined(__GNUC__) && !defined(__ICC) && __GNUC__ >= 13
-#    define DEAL_II_CXX23_ASSUME(expr)                                   \
-      do                                                                 \
-        {                                                                \
-          _Pragma("GCC diagnostic push")                                 \
-            _Pragma("GCC diagnostic ignored \"-Wimplicit-fallthrough\"") \
-              [[assume(expr)]];                                          \
-          _Pragma("GCC diagnostic pop")                                  \
-        }                                                                \
-      while (false)
-#  elif defined(_MSC_VER) || defined(__ICC)
-#    define DEAL_II_CXX23_ASSUME(expr) __assume(expr);
-#  else
-/* no way with GCC to express this without evaluating 'expr' */
-#    define DEAL_II_CXX23_ASSUME(expr) \
-      do                               \
-        {                              \
-        }                              \
-      while (false)
-#  endif
+#if defined(__clang__)
+#  define DEAL_II_CXX23_ASSUME(expr) __builtin_assume(static_cast<bool>(expr))
+#elif defined(__GNUC__) && !defined(__ICC) && __GNUC__ >= 13
+#  define DEAL_II_CXX23_ASSUME(expr)                                   \
+    do                                                                 \
+      {                                                                \
+        _Pragma("GCC diagnostic push")                                 \
+          _Pragma("GCC diagnostic ignored \"-Wimplicit-fallthrough\"") \
+            [[assume(expr)]];                                          \
+        _Pragma("GCC diagnostic pop")                                  \
+      }                                                                \
+    while (false)
+#elif defined(_MSC_VER) || defined(__ICC)
+#  define DEAL_II_CXX23_ASSUME(expr) __assume(expr);
 #else
+/* no way with GCC to express this without evaluating 'expr' */
 #  define DEAL_II_CXX23_ASSUME(expr) \
     do                               \
       {                              \

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1637,7 +1637,11 @@ namespace deal_II_exceptions
 #    endif /*ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST*/
 #  endif   /*KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST*/
 #else      /*ifdef DEBUG*/
-#  define Assert(cond, exc) DEAL_II_CXX23_ASSUME(cond)
+#  define Assert(cond, exc) \
+    do                      \
+      {                     \
+      }                     \
+    while (false)
 #endif /*ifdef DEBUG*/
 
 
@@ -1689,7 +1693,11 @@ namespace deal_II_exceptions
       while (false)
 #  endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 #else
-#  define AssertNothrow(cond, exc) DEAL_II_CXX23_ASSUME(cond)
+#  define AssertNothrow(cond, exc) \
+    do                             \
+      {                            \
+      }                            \
+    while (false)
 #endif
 
 /**


### PR DESCRIPTION
Following up on our discussion on slack: let us reenable the
DEAL_II_CXX23_ASSUME macro so that we can use it for select cases.

- base/config.h: enable DEAL_II_CXX23_ASSUME macro
- base/exceptions.h: remove DEAL_II_CXX23_ASSUME from Assert macro

In reference to #16502
