### PR TITLE
Tensor<k, dim, Number::unroll(): fix copy statement

### DIFF
--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1872,7 +1872,7 @@ Tensor<rank_, dim, Number>::unroll(const Iterator begin,
              ExcMessage(
                "The provided iterator range must contain at least 'dim' "
                "elements."));
-      std::copy(&values[0], &values[dim], begin);
+      std::copy(std::begin(values), std::end(values), begin);
     }
 }
 


### PR DESCRIPTION
The task for the rank-1 case is to copy all values from the internal values array to the iterator range, so let us just use
```
std::copy(std::begin(values), std::end(values), begin);
```
for this.

The problem with the `&values[dim]` statement is the fact that values[dim] is an out-of-bounds access and the address of if is undefined. And it does not need to coincide with `std::end(values)`.

In reference to #16511
