### PR TITLE
Fix TpetraWrappers::Vector::operator=(double)

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -338,7 +338,7 @@ namespace LinearAlgebra
       // can optimize this somehow.
       vector->putScalar(/*s=*/0.0);
 
-      if (nonlocal_vector.is_null())
+      if (!nonlocal_vector.is_null())
         nonlocal_vector->putScalar(/*s=*/0.0);
 
       return *this;


### PR DESCRIPTION
As highlighted by @tamiko in #16508,  in the function
```
   327     template <typename Number>                                                   
   328     Vector<Number> &                                                             
   329     Vector<Number>::operator=(const Number s)                                    
   330     {                                                                            
   331       (void)s;                                                                   
   332       Assert(s == Number(0.0),                                                   
   333              ExcMessage("Only 0 can be assigned to a vector."));                 
   334                                                                                  
   335       // As checked above, we are only allowed to use d==0.0, so pass            
   336       // a constant zero (instead of a run-time value 'd' that *happens* to      
   337       // have a zero value) to the underlying class in hopes that the compiler   
   338       // can optimize this somehow.                                              
   339       vector->putScalar(/*s=*/0.0);                                              
   340                                                                                  
   341       if (nonlocal_vector.is_null())                                             
   342         nonlocal_vector->putScalar(/*s=*/0.0);                                   
   343                                                                                  
   344       return *this;                                                              
   345     } 
```
should read `if(!nonlocal_vector.is_null()) ...`.

The current form of this function leads to a runtime error whenever the function is called and `nonlocal_vector.is_null() == true`.