### PR TITLE
Precompute weights for parallel::CellWeights.

### DIFF
--- a/doc/news/changes/minor/20260619Fehling
+++ b/doc/news/changes/minor/20260619Fehling
@@ -1,0 +1,5 @@
+New: parallel::CellWeights can now work with pre-computed weights.
+This requires that the weights are determined only by information
+about finite elements.
+<br>
+(Marc Fehling, 2026/06/19)

--- a/examples/step-75/step-75.cc
+++ b/examples/step-75/step-75.cc
@@ -878,8 +878,8 @@ namespace Step75
     LinearAlgebra::distributed::Vector<double> locally_relevant_solution;
     LinearAlgebra::distributed::Vector<double> system_rhs;
 
-    std::unique_ptr<FESeries::Legendre<dim>>    legendre;
-    std::unique_ptr<parallel::CellWeights<dim>> cell_weights;
+    std::unique_ptr<FESeries::Legendre<dim>> legendre;
+    parallel::CellWeights<dim>               cell_weights;
 
     Vector<float> estimated_error_per_cell;
     Vector<float> hp_decision_indicators;
@@ -986,15 +986,22 @@ namespace Step75
     // the form that $a (n_\text{dofs})^b$ with a provided pair of parameters
     // $(a,b)$. We register such a function in the following.
     //
+    // Since we are only using information about the number of degrees of
+    // freedom per cell, which is a quantity unique to every finite element, we
+    // can compute the weights in advance.
+    //
     // For load balancing, efficient solvers like the one we use should scale
     // linearly with the number of degrees of freedom owned. We set the
     // parameters for cell weighting correspondingly: A weighting factor of $1$
     // and an exponent of $1$ (see the definitions of the `weighting_factor` and
     // `weighting_exponent` above).
-    cell_weights = std::make_unique<parallel::CellWeights<dim>>(
-      dof_handler,
-      parallel::CellWeights<dim>::ndofs_weighting(
-        {prm.weighting_factor, prm.weighting_exponent}));
+    const typename parallel::CellWeights<dim>::WeightingFunction
+      weighting_function = parallel::CellWeights<dim>::ndofs_weighting(
+        {prm.weighting_factor, prm.weighting_exponent});
+    const std::vector<unsigned int> precomputed_weights =
+      parallel::CellWeights<dim>::precompute_weights(fe_collection,
+                                                     weighting_function);
+    cell_weights.reinit(dof_handler, precomputed_weights);
 
     // In h-adaptive applications, we ensure a 2:1 mesh balance by limiting the
     // difference of refinement levels of neighboring cells to one. With the

--- a/include/deal.II/distributed/cell_weights.h
+++ b/include/deal.II/distributed/cell_weights.h
@@ -79,8 +79,19 @@ namespace parallel
    *   hp_dof_handler.get_triangulation().signals.weight.connect(
    *     parallel::CellWeights<dim, spacedim>::make_weighting_callback(
    *       hp_dof_handler,
-   *       parallel::CellWeights<dim, spacedim>::ndofs_weighting({1, 1}));
+   *       parallel::CellWeights<dim, spacedim>::ndofs_weighting({1, 1})));
    * @endcode
+   *
+   * Oftentimes, the weighting function only requires information about the
+   * finite element (for example about the number of degrees of freedom per
+   * cell), but not the cell we are currently considering (even though the
+   * weighting function takes a cell iterator as argument). In this case, it is
+   * wasteful to re-compute the weight on every cell we visit; instead, the
+   * weights can be computed in advance for each finite element in use on the
+   * DoFHandler with precompute_weights(). The returned container can then be
+   * either passed to the corresponding constructor, reinit() or
+   * make_weighting_callback() function. Of course, in this case no other
+   * cell-specific information can be used in the computation of the weights.
    *
    * The use of this class is demonstrated in step-75.
    *
@@ -126,6 +137,68 @@ namespace parallel
                    const FiniteElement<dim, spacedim> &)>;
 
     /**
+     * @name Selection of weighting functions
+     * @{
+     */
+
+    /**
+     * This function returns a WeightingFunction which determines the weight to
+     * be applied on each cell. It is used to initialize a CellWeights object.
+     *
+     * Chooses a constant weight @p factor on each cell.
+     */
+    static WeightingFunction
+    constant_weighting(const unsigned int factor = 1);
+
+    /**
+     * This function returns a WeightingFunction which determines the weight to
+     * be applied on each cell. It is used to initialize a CellWeights object.
+     *
+     * The pair of floating point numbers $(a,b)$ provided via
+     * @p coefficients determines the weight $w_K$ of each cell $K$ with
+     * $n_K$ degrees of freedom in the following way: $w_K =
+     * a \, n_K^b$.
+     *
+     * The right hand side will be rounded to the nearest integer since cell
+     * weights are required to be integers.
+     */
+    static WeightingFunction
+    ndofs_weighting(const std::pair<float, float> &coefficients);
+
+    /**
+     * This function returns a WeightingFunction which determines the weight to
+     * be applied on each cell. It is used to initialize a CellWeights object.
+     *
+     * The container @p coefficients provides pairs of floating point numbers
+     * $(a_i, b_i)$ that determine the weight $w_K$ of each cell
+     * $K$ with $n_K$ degrees of freedom in the following way: $w_K =
+     * \sum_i a_i \, n_K^{b_i}$.
+     *
+     * The right hand side will be rounded to the nearest integer since cell
+     * weights are required to be integers.
+     */
+    static WeightingFunction
+    ndofs_weighting(const std::vector<std::pair<float, float>> &coefficients);
+
+    /**
+     * For a given WeightingFunction, this function returns pre-computed weights
+     * for each finite element in @p fe_collection. Pass the container to the
+     * corresponding constructor, reinit() or make_weighting_callback()
+     * functions.
+     *
+     * If your weights only require information about the finite element on each
+     * cell, consider pre-computing them with this function. All other
+     * cell-specific characteristics in determining weights will be omitted.
+     */
+    static std::vector<unsigned int>
+    precompute_weights(const hp::FECollection<dim, spacedim> &fe_collection,
+                       const WeightingFunction &weighting_function);
+
+    /**
+     * @}
+     */
+
+    /**
      * Constructor.
      *
      * No weighting function will be connected yet. Please call reinit().
@@ -142,6 +215,19 @@ namespace parallel
      */
     CellWeights(const DoFHandler<dim, spacedim> &dof_handler,
                 const WeightingFunction         &weighting_function);
+
+    /**
+     * Constructor.
+     *
+     * @param[in] dof_handler The DoFHandler which will be used to
+     *    determine each cell's finite element.
+     * @param[in] precomputed_weights Weights for each finite element of the
+     *    hp::FECollection used by @p dof_handler. On each cell, we query its
+     *    active finite element index and use this index to look up its weight
+     *    during load balancing.
+     */
+    CellWeights(const DoFHandler<dim, spacedim> &dof_handler,
+                const std::vector<unsigned int> &precomputed_weights);
 
     /**
      * Destructor.
@@ -161,6 +247,19 @@ namespace parallel
            const WeightingFunction         &weighting_function);
 
     /**
+     * Connect a different weighting mechanism to the Triangulation
+     * associated with the @p dof_handler. Values in @p precomputed_weights will
+     * be used as weights for each finite element. On each cell, we query its
+     * active finite element index and use this index to look up its weight
+     * during load balancing.
+     *
+     * Disconnects the function previously connected to the weighting signal.
+     */
+    void
+    reinit(const DoFHandler<dim, spacedim> &dof_handler,
+           const std::vector<unsigned int> &precomputed_weights);
+
+    /**
      * Converts a @p weighting_function to a different type that qualifies as
      * a callback function, which can be connected to a weighting signal of a
      * Triangulation.
@@ -175,43 +274,19 @@ namespace parallel
                             const WeightingFunction &weighting_function);
 
     /**
-     * @name Selection of weighting functions
-     * @{
-     */
-
-    /**
-     * Choose a constant weight @p factor on each cell.
-     */
-    static WeightingFunction
-    constant_weighting(const unsigned int factor = 1);
-
-    /**
-     * The pair of floating point numbers $(a,b)$ provided via
-     * @p coefficients determines the weight $w_K$ of each cell $K$ with
-     * $n_K$ degrees of freedom in the following way: \f[ w_K =
-     * a \, n_K^b \f]
+     * Use @p precomputed_weights as weights for each finite element of
+     * @p dof_handler. Returns a callback function, which can be connected to a
+     * weighting signal of a Triangulation.
      *
-     * The right hand side will be rounded to the nearest integer since cell
-     * weights are required to be integers.
+     * This function does <b>not</b> connect the callback function to the
+     * Triangulation associated with the @p dof_handler.
      */
-    static WeightingFunction
-    ndofs_weighting(const std::pair<float, float> &coefficients);
-
-    /**
-     * The container @p coefficients provides pairs of floating point numbers
-     * $(a_i, b_i)$ that determine the weight $w_K$ of each cell
-     * $K$ with $n_K$ degrees of freedom in the following way: \f[ w_K =
-     * \sum_i a_i \, n_K^{b_i} \f]
-     *
-     * The right hand side will be rounded to the nearest integer since cell
-     * weights are required to be integers.
-     */
-    static WeightingFunction
-    ndofs_weighting(const std::vector<std::pair<float, float>> &coefficients);
-
-    /**
-     * @}
-     */
+    static std::function<unsigned int(
+      const typename dealii::Triangulation<dim, spacedim>::cell_iterator &cell,
+      const CellStatus status)>
+    make_weighting_callback(
+      const DoFHandler<dim, spacedim> &dof_handler,
+      const std::vector<unsigned int> &precomputed_weights);
 
   private:
     /**
@@ -221,7 +296,7 @@ namespace parallel
     boost::signals2::connection connection;
 
     /**
-     * A callback function that will be connected to the `weight` signal of
+     * A callback function that can be connected to the `weight` signal of
      * the @p triangulation, to which the @p dof_handler is attached. Ultimately
      * returns the weight for each cell, determined by the @p weighting_function
      * provided as a parameter. Returns zero if @p dof_handler has not been
@@ -234,6 +309,21 @@ namespace parallel
       const DoFHandler<dim, spacedim>                  &dof_handler,
       const parallel::TriangulationBase<dim, spacedim> &triangulation,
       const WeightingFunction                          &weighting_function);
+
+    /**
+     * A callback function that can be connected to the `weight` signal of
+     * the @p triangulation, to which the @p dof_handler is attached. Ultimately
+     * returns the weight for each cell, determined by the @p precomputed_weights
+     * provided as a parameter. Returns zero if @p dof_handler has not been
+     * initialized yet.
+     */
+    static unsigned int
+    weighting_callback(
+      const typename dealii::Triangulation<dim, spacedim>::cell_iterator &cell,
+      const CellStatus                                  status,
+      const DoFHandler<dim, spacedim>                  &dof_handler,
+      const parallel::TriangulationBase<dim, spacedim> &triangulation,
+      const std::vector<unsigned int>                  &precomputed_weights);
   };
 } // namespace parallel
 

--- a/source/distributed/cell_weights.cc
+++ b/source/distributed/cell_weights.cc
@@ -22,40 +22,6 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace parallel
 {
-  template <int dim, int spacedim>
-  CellWeights<dim, spacedim>::CellWeights(
-    const DoFHandler<dim, spacedim> &dof_handler,
-    const WeightingFunction         &weighting_function)
-  {
-    reinit(dof_handler, weighting_function);
-  }
-
-
-
-  template <int dim, int spacedim>
-  CellWeights<dim, spacedim>::~CellWeights()
-  {
-    connection.disconnect();
-  }
-
-
-
-  template <int dim, int spacedim>
-  void
-  CellWeights<dim, spacedim>::reinit(
-    const DoFHandler<dim, spacedim> &dof_handler,
-    const typename CellWeights<dim, spacedim>::WeightingFunction
-      &weighting_function)
-  {
-    connection.disconnect();
-    connection = dof_handler.get_triangulation().signals.weight.connect(
-      make_weighting_callback(dof_handler, weighting_function));
-  }
-
-
-
-  // ---------- static member functions ----------
-
   // ---------- selection of weighting functions ----------
 
   template <int dim, int spacedim>
@@ -120,7 +86,85 @@ namespace parallel
 
 
 
-  // ---------- handling callback functions ----------
+  // ---------- precompute weights ----------
+
+  template <int dim, int spacedim>
+  std::vector<unsigned int>
+  CellWeights<dim, spacedim>::precompute_weights(
+    const hp::FECollection<dim, spacedim> &fe_collection,
+    const WeightingFunction               &weighting_function)
+  {
+    std::vector<unsigned int> precomputed_weights;
+    precomputed_weights.reserve(fe_collection.size());
+
+    const typename DoFHandler<dim, spacedim>::cell_iterator dummy;
+    for (const auto &fe : fe_collection)
+      precomputed_weights.push_back(weighting_function(dummy, fe));
+
+    return precomputed_weights;
+  }
+
+
+
+  // ---------- handle connection ----------
+
+  template <int dim, int spacedim>
+  CellWeights<dim, spacedim>::CellWeights(
+    const DoFHandler<dim, spacedim> &dof_handler,
+    const WeightingFunction         &weighting_function)
+  {
+    reinit(dof_handler, weighting_function);
+  }
+
+
+
+  template <int dim, int spacedim>
+  CellWeights<dim, spacedim>::CellWeights(
+    const DoFHandler<dim, spacedim> &dof_handler,
+    const std::vector<unsigned int> &precomputed_weights)
+  {
+    reinit(dof_handler, precomputed_weights);
+  }
+
+
+
+  template <int dim, int spacedim>
+  CellWeights<dim, spacedim>::~CellWeights()
+  {
+    connection.disconnect();
+  }
+
+
+
+  template <int dim, int spacedim>
+  void
+  CellWeights<dim, spacedim>::reinit(
+    const DoFHandler<dim, spacedim> &dof_handler,
+    const WeightingFunction         &weighting_function)
+  {
+    connection.disconnect();
+
+    connection = dof_handler.get_triangulation().signals.weight.connect(
+      make_weighting_callback(dof_handler, weighting_function));
+  }
+
+
+
+  template <int dim, int spacedim>
+  void
+  CellWeights<dim, spacedim>::reinit(
+    const DoFHandler<dim, spacedim> &dof_handler,
+    const std::vector<unsigned int> &precomputed_weights)
+  {
+    connection.disconnect();
+
+    connection = dof_handler.get_triangulation().signals.weight.connect(
+      make_weighting_callback(dof_handler, precomputed_weights));
+  }
+
+
+
+  // ---------- handle callback functions ----------
 
   template <int dim, int spacedim>
   std::function<unsigned int(
@@ -128,8 +172,7 @@ namespace parallel
     const CellStatus                                                    status)>
   CellWeights<dim, spacedim>::make_weighting_callback(
     const DoFHandler<dim, spacedim> &dof_handler,
-    const typename CellWeights<dim, spacedim>::WeightingFunction
-      &weighting_function)
+    const WeightingFunction         &weighting_function)
   {
     const parallel::TriangulationBase<dim, spacedim> *tria =
       dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
@@ -158,8 +201,7 @@ namespace parallel
     const CellStatus                                                    status,
     const DoFHandler<dim, spacedim>                  &dof_handler,
     const parallel::TriangulationBase<dim, spacedim> &triangulation,
-    const typename CellWeights<dim, spacedim>::WeightingFunction
-      &weighting_function)
+    const WeightingFunction                          &weighting_function)
   {
     // Check if we are still working with the correct combination of
     // Triangulation and DoFHandler.
@@ -178,7 +220,7 @@ namespace parallel
 
     // Determine which FiniteElement object will be present on this cell after
     // refinement and will thus specify the number of degrees of freedom.
-    unsigned int fe_index = numbers::invalid_unsigned_int;
+    types::fe_index fe_index = numbers::invalid_fe_index;
     switch (status)
       {
         case CellStatus::cell_will_persist:
@@ -206,6 +248,95 @@ namespace parallel
 
     // Return the cell weight determined by the function of choice.
     return weighting_function(cell, dof_handler.get_fe(fe_index));
+  }
+
+
+
+  template <int dim, int spacedim>
+  std::function<unsigned int(
+    const typename dealii::Triangulation<dim, spacedim>::cell_iterator &cell,
+    const CellStatus                                                    status)>
+  CellWeights<dim, spacedim>::make_weighting_callback(
+    const DoFHandler<dim, spacedim> &dof_handler,
+    const std::vector<unsigned int> &precomputed_weights)
+  {
+    // create callback function
+    const parallel::TriangulationBase<dim, spacedim> *tria =
+      dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
+        &(dof_handler.get_triangulation()));
+
+    Assert(
+      tria != nullptr,
+      ExcMessage(
+        "parallel::CellWeights requires a parallel::TriangulationBase object."));
+
+    // capture the weights by copy
+    return [&dof_handler, tria, precomputed_weights](
+             const typename dealii::Triangulation<dim, spacedim>::cell_iterator
+                             &cell,
+             const CellStatus status) -> unsigned int {
+      return CellWeights<dim, spacedim>::weighting_callback(
+        cell, status, dof_handler, *tria, precomputed_weights);
+    };
+  }
+
+
+
+  template <int dim, int spacedim>
+  unsigned int
+  CellWeights<dim, spacedim>::weighting_callback(
+    const typename dealii::Triangulation<dim, spacedim>::cell_iterator &cell_,
+    const CellStatus                                                    status,
+    const DoFHandler<dim, spacedim>                  &dof_handler,
+    const parallel::TriangulationBase<dim, spacedim> &triangulation,
+    const std::vector<unsigned int>                  &precomputed_weights)
+  {
+    // Check if we are still working with the correct combination of
+    // Triangulation and DoFHandler.
+    Assert(&triangulation == &(dof_handler.get_triangulation()),
+           ExcMessage(
+             "Triangulation associated with the DoFHandler has changed!"));
+    (void)triangulation;
+
+    // Skip if the DoFHandler has not been initialized yet.
+    if (dof_handler.get_fe_collection().size() == 0)
+      return 0;
+
+    // Convert cell type from Triangulation to DoFHandler to be able
+    // to access the information about the degrees of freedom.
+    const typename DoFHandler<dim, spacedim>::cell_iterator cell(*cell_,
+                                                                 &dof_handler);
+
+    // Determine which FiniteElement object will be present on this cell after
+    // refinement and will thus specify the number of degrees of freedom.
+    types::fe_index fe_index = numbers::invalid_fe_index;
+    switch (status)
+      {
+        case CellStatus::cell_will_persist:
+        case CellStatus::cell_will_be_refined:
+        case CellStatus::cell_invalid:
+          fe_index = cell->future_fe_index();
+          break;
+
+        case CellStatus::children_will_be_coarsened:
+          if constexpr (running_in_debug_mode())
+            {
+              for (const auto &child : cell->child_iterators())
+                Assert(child->is_active() && child->coarsen_flag_set(),
+                       StandardExceptions::ExcInconsistentCoarseningFlags());
+            }
+
+          fe_index = dealii::internal::hp::DoFHandlerImplementation::
+            dominated_future_fe_on_children<dim, spacedim>(cell);
+          break;
+
+        default:
+          DEAL_II_ASSERT_UNREACHABLE();
+          break;
+      }
+
+    // Return the precomputed weight.
+    return precomputed_weights[fe_index];
   }
 } // namespace parallel
 

--- a/tests/mpi/hp_cell_weights_05.cc
+++ b/tests/mpi/hp_cell_weights_05.cc
@@ -1,0 +1,105 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2018 - 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+
+// Same as test _01, but with precomputed weights.
+
+
+#include <deal.II/distributed/cell_weights.h>
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include "../tests.h"
+
+
+template <int dim>
+void
+test()
+{
+  parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD);
+
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(2);
+
+  // Apply ndof cell weights.
+  hp::FECollection<dim> fes;
+  fes.push_back(FE_Q<dim>(1));
+  fes.push_back(FE_Q<dim>(5));
+
+  DoFHandler<dim> dh(tria);
+
+  // default: active_fe_index = 0
+  for (auto &cell : dh.active_cell_iterators())
+    if (cell->is_locally_owned())
+      if (cell->id().to_string() == "0_2:00")
+        cell->set_active_fe_index(1);
+
+  dh.distribute_dofs(fes);
+
+  deallog << "Number of cells before repartitioning: "
+          << tria.n_locally_owned_active_cells() << std::endl;
+  {
+    unsigned int dof_counter = 0;
+    for (auto &cell : dh.active_cell_iterators())
+      if (cell->is_locally_owned())
+        dof_counter += cell->get_fe().dofs_per_cell;
+    deallog << "  Cumulative dofs per cell: " << dof_counter << std::endl;
+  }
+
+
+  const auto weighting_function =
+    parallel::CellWeights<dim>::ndofs_weighting({1, 1});
+  const auto precomputed_weights =
+    parallel::CellWeights<dim>::precompute_weights(fes, weighting_function);
+  const parallel::CellWeights<dim> cell_weights(dh, precomputed_weights);
+
+  tria.repartition();
+
+
+  deallog << "Number of cells after repartitioning: "
+          << tria.n_locally_owned_active_cells() << std::endl;
+  {
+    unsigned int dof_counter = 0;
+    for (auto &cell : dh.active_cell_iterators())
+      if (cell->is_locally_owned())
+        dof_counter += cell->get_fe().dofs_per_cell;
+    deallog << "  Cumulative dofs per cell: " << dof_counter << std::endl;
+  }
+
+  // make sure no processor is hanging
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  deallog << "OK" << std::endl;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPILogInitAll                    log;
+
+  deallog.push("2d");
+  test<2>();
+  deallog.pop();
+  deallog.push("3d");
+  test<3>();
+  deallog.pop();
+}

--- a/tests/mpi/hp_cell_weights_05.with_p4est=true.mpirun=2.output
+++ b/tests/mpi/hp_cell_weights_05.with_p4est=true.mpirun=2.output
@@ -1,0 +1,23 @@
+
+DEAL:0:2d::Number of cells before repartitioning: 8
+DEAL:0:2d::  Cumulative dofs per cell: 64
+DEAL:0:2d::Number of cells after repartitioning: 4
+DEAL:0:2d::  Cumulative dofs per cell: 48
+DEAL:0:2d::OK
+DEAL:0:3d::Number of cells before repartitioning: 32
+DEAL:0:3d::  Cumulative dofs per cell: 464
+DEAL:0:3d::Number of cells after repartitioning: 16
+DEAL:0:3d::  Cumulative dofs per cell: 336
+DEAL:0:3d::OK
+
+DEAL:1:2d::Number of cells before repartitioning: 8
+DEAL:1:2d::  Cumulative dofs per cell: 32
+DEAL:1:2d::Number of cells after repartitioning: 12
+DEAL:1:2d::  Cumulative dofs per cell: 48
+DEAL:1:2d::OK
+DEAL:1:3d::Number of cells before repartitioning: 32
+DEAL:1:3d::  Cumulative dofs per cell: 256
+DEAL:1:3d::Number of cells after repartitioning: 48
+DEAL:1:3d::  Cumulative dofs per cell: 384
+DEAL:1:3d::OK
+


### PR DESCRIPTION
In most cases of weighted load balancing, we only require information about the number of degrees of freedom. Currently, we calculate these weights for each cell individually. This is wasteful, as cells with the same finite element assigned will ultimately get the same weight.

This PR proposes to introduce a cache option: we compute the weights for each finite element in advance, and use these values as weights for each cell.

---

Currently, the interface of the WeightingFunction type uses both a cell_iterator and a finite element. We might discuss if we want to keep that interface for the future, or if we would like to simplify it to only take a finite element as an argument. The only possible use cases for this class at the moment are those in which weights are only determined via finite elements, so I would favor to keep it simple. Please tell me if you use this class for other purposes, or if you see other use cases.

I moved the selection of possible weighting functions to the top of the h and cc files. We might also want to move them into a separate namespace.