### PR TITLE
[9.5] DofTools: add missing codimension-one instantiation

### DIFF
--- a/source/dofs/dof_tools_sparsity.inst.in
+++ b/source/dofs/dof_tools_sparsity.inst.in
@@ -257,15 +257,17 @@ for (deal_II_dimension : DIMENSIONS)
   }
 
 
-for (deal_II_dimension : DIMENSIONS)
+for (deal_II_dimension, deal_II_space_dimension : DIMENSIONS)
   {
+#if deal_II_dimension <= deal_II_space_dimension
     template Table<2, DoFTools::Coupling>
     DoFTools::dof_couplings_from_component_couplings(
-      const FiniteElement<deal_II_dimension> &fe,
-      const Table<2, DoFTools::Coupling> &    component_couplings);
+      const FiniteElement<deal_II_dimension, deal_II_space_dimension> &fe,
+      const Table<2, DoFTools::Coupling> &component_couplings);
 
     template std::vector<Table<2, DoFTools::Coupling>>
     DoFTools::dof_couplings_from_component_couplings(
-      const hp::FECollection<deal_II_dimension> &fe,
-      const Table<2, DoFTools::Coupling> &       component_couplings);
+      const hp::FECollection<deal_II_dimension, deal_II_space_dimension> &fe,
+      const Table<2, DoFTools::Coupling> &component_couplings);
+#endif
   }


### PR DESCRIPTION
In reference to #16494 