### PR TITLE
Introduce DEAL_II_NOT_IMPLEMENTED() and associated machinery.

### DIFF
--- a/doc/news/changes/major/20240125Bangerth
+++ b/doc/news/changes/major/20240125Bangerth
@@ -1,0 +1,9 @@
+New: There is now a function-like macro `DEAL_II_NOT_IMPLEMENTED();`
+that can be used to indicate places where something is not
+implemented. If a code runs into a place where it appears, the program
+is aborted (or, as documented, an exception is thrown). In contrast to
+the old way of indicating such a thing (namely, writing
+`Assert(false, ExcNotImplemented());`, the error is raised even in
+release mode.
+<br>
+(Wolfgang Bangerth, 2024/01/24)

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1762,6 +1762,33 @@ namespace deal_II_exceptions
 #endif /*ifdef DEAL_II_HAVE_BUILTIN_EXPECT*/
 
 
+/**
+ * `DEAL_II_NOT_IMPLEMENTED` is a macro (that looks like a function call
+ * when used as in `DEAL_II_NOT_IMPLEMENTED();`) that is used to raise an
+ * error in places where a piece of code is not yet implemented. If a code
+ * runs into such a place, it will be aborted with an error message that
+ * explains the situation, along with a backtrace of how the code ended
+ * up in this place.
+ *
+ * Alternatively, if
+ * deal_II_exceptions::internals::ExceptionHandling::abort_or_throw_on_exception
+ * is set to ExceptionHandling::throw_on_exception, then the corresponding
+ * error is thrown as a C++ exception that can be caught (though in
+ * many cases codes will then find it difficult to do what they wanted
+ * to do).
+ */
+#define DEAL_II_NOT_IMPLEMENTED()                                \
+  ::dealii::deal_II_exceptions::internals::issue_error_noreturn( \
+    ::dealii::deal_II_exceptions::internals::ExceptionHandling:: \
+      abort_or_throw_on_exception,                               \
+    __FILE__,                                                    \
+    __LINE__,                                                    \
+    __PRETTY_FUNCTION__,                                         \
+    nullptr,                                                     \
+    nullptr,                                                     \
+    ExcNotImplemented())
+
+
 namespace deal_II_exceptions
 {
   namespace internals

--- a/include/deal.II/base/function_parser.h
+++ b/include/deal.II/base/function_parser.h
@@ -385,7 +385,7 @@ FunctionParser<dim>::default_variable_names()
       case 3:
         return "x,y,z";
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   return "";
 }

--- a/include/deal.II/base/geometry_info.h
+++ b/include/deal.II/base/geometry_info.h
@@ -3001,7 +3001,7 @@ template <int dim>
 inline Point<dim>
 GeometryInfo<dim>::unit_cell_vertex(const unsigned int)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 
   return {};
 }
@@ -3049,7 +3049,7 @@ template <int dim>
 inline unsigned int
 GeometryInfo<dim>::child_cell_from_point(const Point<dim> &)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 
   return 0;
 }
@@ -3188,7 +3188,7 @@ GeometryInfo<dim>::cell_to_child_coordinates(
   const RefinementCase<dim> /*refine_case*/)
 
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return {};
 }
 
@@ -3324,7 +3324,7 @@ GeometryInfo<dim>::child_to_cell_coordinates(
   const unsigned int /*child_index*/,
   const RefinementCase<dim> /*refine_case*/)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return {};
 }
 
@@ -3334,7 +3334,7 @@ template <int dim>
 inline bool
 GeometryInfo<dim>::is_inside_unit_cell(const Point<dim> &)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return false;
 }
 
@@ -3370,7 +3370,7 @@ template <int dim>
 inline bool
 GeometryInfo<dim>::is_inside_unit_cell(const Point<dim> &, const double)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return false;
 }
 
@@ -3457,7 +3457,7 @@ template <>
 inline unsigned int
 GeometryInfo<4>::line_to_cell_vertices(const unsigned int, const unsigned int)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return numbers::invalid_unsigned_int;
 }
 
@@ -3543,7 +3543,7 @@ template <int dim>
 inline unsigned int
 GeometryInfo<dim>::n_subfaces(const internal::SubfaceCase<dim> &)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return 0;
 }
 
@@ -3580,7 +3580,7 @@ inline double
 GeometryInfo<dim>::subface_ratio(const internal::SubfaceCase<dim> &,
                                  const unsigned int)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return 0.;
 }
 
@@ -3699,7 +3699,7 @@ RefinementCase<dim - 1> inline GeometryInfo<dim>::face_refinement_case(
   const bool,
   const bool)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return RefinementCase<dim - 1>::no_refinement;
 }
 
@@ -3837,7 +3837,7 @@ inline RefinementCase<1>
 GeometryInfo<dim>::line_refinement_case(const RefinementCase<dim> &,
                                         const unsigned int)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return RefinementCase<1>::no_refinement;
 }
 
@@ -3915,7 +3915,7 @@ GeometryInfo<dim>::min_cell_refinement_case_for_face_refinement(
   const bool,
   const bool)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 
   return RefinementCase<dim>::no_refinement;
 }
@@ -4021,7 +4021,7 @@ inline RefinementCase<dim>
 GeometryInfo<dim>::min_cell_refinement_case_for_line_refinement(
   const unsigned int)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 
   return RefinementCase<dim>::no_refinement;
 }
@@ -4202,7 +4202,7 @@ GeometryInfo<dim>::standard_to_real_face_line(const unsigned int line,
                                               const bool,
                                               const bool)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return line;
 }
 
@@ -4223,7 +4223,7 @@ inline unsigned int
 GeometryInfo<dim>::standard_to_real_line_vertex(const unsigned int vertex,
                                                 const bool)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return vertex;
 }
 
@@ -4244,7 +4244,7 @@ inline std::array<unsigned int, 2>
 GeometryInfo<dim>::standard_quad_vertex_to_line_vertex_index(
   const unsigned int vertex)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   (void)vertex;
   return {{0, 0}};
 }
@@ -4285,7 +4285,7 @@ template <int dim>
 inline std::array<unsigned int, 2>
 GeometryInfo<dim>::standard_hex_line_to_quad_line_index(const unsigned int line)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   (void)line;
   return {{0, 0}};
 }
@@ -4312,7 +4312,7 @@ inline std::array<unsigned int, 2>
 GeometryInfo<dim>::standard_hex_vertex_to_quad_vertex_index(
   const unsigned int vertex)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   (void)vertex;
   return {{0, 0}};
 }
@@ -4380,7 +4380,7 @@ GeometryInfo<dim>::real_to_standard_face_line(const unsigned int line,
                                               const bool,
                                               const bool)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return line;
 }
 
@@ -4678,7 +4678,7 @@ GeometryInfo<4>::child_cell_on_face(const RefinementCase<4> &,
                                     const bool,
                                     const RefinementCase<3> &)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return numbers::invalid_unsigned_int;
 }
 
@@ -4733,7 +4733,7 @@ GeometryInfo<0>::face_to_cell_lines(const unsigned int,
                                     const bool,
                                     const bool)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return numbers::invalid_unsigned_int;
 }
 
@@ -4747,7 +4747,7 @@ GeometryInfo<dim>::face_to_cell_lines(const unsigned int,
                                       const bool,
                                       const bool)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return numbers::invalid_unsigned_int;
 }
 
@@ -4778,7 +4778,7 @@ GeometryInfo<0>::face_to_cell_vertices(const unsigned int,
                                        const bool,
                                        const bool)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return numbers::invalid_unsigned_int;
 }
 
@@ -4883,7 +4883,7 @@ GeometryInfo<dim>::d_linear_shape_function(const Point<dim>  &xi,
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   return -1e9;
 }
@@ -4977,7 +4977,7 @@ inline Tensor<1, dim>
 GeometryInfo<dim>::d_linear_shape_function_gradient(const Point<dim> &,
                                                     const unsigned int)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return Tensor<1, dim>();
 }
 

--- a/include/deal.II/base/polynomial_space.h
+++ b/include/deal.II/base/polynomial_space.h
@@ -445,7 +445,7 @@ PolynomialSpace<dim>::compute_derivative(const unsigned int i,
         }
       default:
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           return derivative;
         }
     }

--- a/include/deal.II/base/polynomials_adini.h
+++ b/include/deal.II/base/polynomials_adini.h
@@ -181,7 +181,7 @@ inline Tensor<1, dim>
 PolynomialsAdini<dim>::compute_1st_derivative(const unsigned int /*i*/,
                                               const Point<dim> & /*p*/) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return {};
 }
 
@@ -192,7 +192,7 @@ inline Tensor<2, dim>
 PolynomialsAdini<dim>::compute_2nd_derivative(const unsigned int /*i*/,
                                               const Point<dim> & /*p*/) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return {};
 }
 
@@ -203,7 +203,7 @@ inline Tensor<3, dim>
 PolynomialsAdini<dim>::compute_3rd_derivative(const unsigned int /*i*/,
                                               const Point<dim> & /*p*/) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return {};
 }
 
@@ -214,7 +214,7 @@ inline Tensor<4, dim>
 PolynomialsAdini<dim>::compute_4th_derivative(const unsigned int /*i*/,
                                               const Point<dim> & /*p*/) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return {};
 }
 

--- a/include/deal.II/base/polynomials_rannacher_turek.h
+++ b/include/deal.II/base/polynomials_rannacher_turek.h
@@ -183,7 +183,7 @@ namespace internal
                 }
               else
                 {
-                  Assert(false, ExcNotImplemented());
+                  DEAL_II_NOT_IMPLEMENTED();
                 }
               return derivative;
             }

--- a/include/deal.II/base/scalar_polynomials_base.h
+++ b/include/deal.II/base/scalar_polynomials_base.h
@@ -279,7 +279,7 @@ ScalarPolynomialsBase<dim>::compute_derivative(const unsigned int i,
       auto derivative = compute_4th_derivative(i, p);
       return *reinterpret_cast<Tensor<order, dim> *>(&derivative);
     }
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   Tensor<order, dim> empty;
   return empty;
 }

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -2084,7 +2084,7 @@ namespace internal
     component_to_unrolled_index(const TableIndices<rank_> &indices)
     {
       (void)indices;
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return numbers::invalid_unsigned_int;
     }
   } // namespace SymmetricTensorImplementation
@@ -2150,7 +2150,7 @@ namespace internal
           }
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     // The code should never reach here.
@@ -2198,7 +2198,7 @@ namespace internal
           }
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     // The code should never reach here.
@@ -2569,7 +2569,7 @@ namespace internal
                       0,
                       dealii::SymmetricTensor<rank_, dim, double>::
                         n_independent_components));
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return TableIndices<rank_>();
     }
 
@@ -2742,7 +2742,7 @@ determinant(const SymmetricTensor<2, dim, Number> &t)
                   t.data[2] * t.data[3] * t.data[3]);
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return internal::NumberType<Number>::value(0.0);
     }
 }

--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -2533,7 +2533,7 @@ namespace internal
     void
     fill_Fortran_style(InputIterator, TableBase<N, T> &)
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
   } // namespace TableImplementation
 } // namespace internal

--- a/include/deal.II/base/tensor_function_parser.h
+++ b/include/deal.II/base/tensor_function_parser.h
@@ -282,7 +282,7 @@ TensorFunctionParser<rank, dim, Number>::default_variable_names()
       case 3:
         return "x,y,z";
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   return "";
 }

--- a/include/deal.II/base/tensor_product_polynomials.h
+++ b/include/deal.II/base/tensor_product_polynomials.h
@@ -663,7 +663,7 @@ TensorProductPolynomials<dim, PolynomialType>::compute_derivative(
         }
       default:
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           return derivative;
         }
     }
@@ -840,7 +840,7 @@ AnisotropicPolynomials<dim>::compute_derivative(const unsigned int i,
         }
       default:
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           return derivative;
         }
     }

--- a/include/deal.II/base/tensor_product_polynomials_bubbles.h
+++ b/include/deal.II/base/tensor_product_polynomials_bubbles.h
@@ -454,7 +454,7 @@ TensorProductPolynomialsBubbles<dim>::compute_derivative(
         }
       default:
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           return derivative;
         }
     }

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -1876,7 +1876,7 @@ DoFAccessor<0, 1, spacedim, level_dof_access>::set_dof_index(
   const types::global_dof_index /*index*/,
   const types::fe_index /*fe_index*/) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -2002,7 +2002,7 @@ inline bool
 DoFAccessor<0, 1, spacedim, level_dof_access>::fe_index_is_active(
   const types::fe_index /*fe_index*/) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return false;
 }
 
@@ -2058,7 +2058,7 @@ inline typename dealii::internal::DoFHandlerImplementation::
   DoFAccessor<0, 1, spacedim, level_dof_access>::line(
     const unsigned int /*c*/) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return typename dealii::internal::DoFHandlerImplementation::
     Iterators<1, spacedim, level_dof_access>::line_iterator();
 }
@@ -2071,7 +2071,7 @@ inline typename dealii::internal::DoFHandlerImplementation::
   DoFAccessor<0, 1, spacedim, level_dof_access>::quad(
     const unsigned int /*c*/) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return typename dealii::internal::DoFHandlerImplementation::
     Iterators<1, spacedim, level_dof_access>::quad_iterator();
 }

--- a/include/deal.II/fe/fe_dg_vector.templates.h
+++ b/include/deal.II/fe/fe_dg_vector.templates.h
@@ -102,7 +102,7 @@ template <typename PolynomialType, int dim, int spacedim>
 std::size_t
 FE_DGVector<PolynomialType, dim, spacedim>::memory_consumption() const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return 0;
 }
 

--- a/include/deal.II/fe/fe_face.h
+++ b/include/deal.II/fe/fe_face.h
@@ -375,7 +375,7 @@ protected:
     if (data_ptr->update_each & update_gradients ||
         data_ptr->update_each & update_hessians)
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
       }
 
     return data_ptr;

--- a/include/deal.II/fe/fe_poly.templates.h
+++ b/include/deal.II/fe/fe_poly.templates.h
@@ -600,7 +600,7 @@ FE_Poly<dim, spacedim>::get_poly_space_numbering() const
   if (space_tensor_prod_const != nullptr)
     return space_tensor_prod_const->get_numbering();
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return std::vector<unsigned int>();
 }
 

--- a/include/deal.II/fe/fe_poly_face.h
+++ b/include/deal.II/fe/fe_poly_face.h
@@ -161,7 +161,7 @@ protected:
     if (data.update_each & update_gradients ||
         data.update_each & update_hessians)
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
       }
 
     return data_ptr;

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -1061,7 +1061,7 @@ namespace FETools
   std::unique_ptr<FiniteElement<FE::dimension, FE::space_dimension>>
   FEFactory<FE>::get(const Quadrature<1> &) const
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
     return nullptr;
   }
 
@@ -3204,7 +3204,7 @@ namespace FETools
           }
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     return h2l;

--- a/include/deal.II/fe/fe_tools_extrapolate.templates.h
+++ b/include/deal.II/fe/fe_tools_extrapolate.templates.h
@@ -57,7 +57,7 @@ namespace FETools
     public:
       ExtrapolateImplementation()
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
       };
 
       template <class InVector>
@@ -66,7 +66,7 @@ namespace FETools
                            const DoFHandler<dim, spacedim> & /*dof2*/,
                            OutVector & /*u2*/)
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
       }
     };
 
@@ -1571,7 +1571,7 @@ namespace FETools
     void
     reinit_ghosted(const DH & /*dh*/, VectorType & /*vector*/)
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
 
 #ifdef DEAL_II_WITH_PETSC

--- a/include/deal.II/fe/fe_tools_interpolate.templates.h
+++ b/include/deal.II/fe/fe_tools_interpolate.templates.h
@@ -407,7 +407,7 @@ namespace FETools
       const AffineConstraints<PETScWrappers::MPI::BlockVector::value_type> &,
       PETScWrappers::MPI::BlockVector &)
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
 #endif
 

--- a/include/deal.II/fe/fe_values_views.h
+++ b/include/deal.II/fe/fe_values_views.h
@@ -2763,7 +2763,7 @@ namespace FEValuesViews
       }
     else
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         divergence_type return_value;
         return return_value;
       }
@@ -2869,7 +2869,7 @@ namespace FEValuesViews
       }
     else
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         divergence_type return_value;
         return return_value;
       }
@@ -2924,7 +2924,7 @@ namespace FEValuesViews
       }
     else
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         gradient_type return_value;
         return return_value;
       }

--- a/include/deal.II/fe/mapping_q_internal.h
+++ b/include/deal.II/fe/mapping_q_internal.h
@@ -1997,7 +1997,7 @@ namespace internal
                             cross_product_3d(data.aux[0][i], data.aux[1][i]);
                           break;
                         default:
-                          Assert(false, ExcNotImplemented());
+                          DEAL_II_NOT_IMPLEMENTED();
                       }
                 }
               else //(dim < spacedim)
@@ -2242,7 +2242,7 @@ namespace internal
             }
 
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
     }
 
@@ -2344,7 +2344,7 @@ namespace internal
             }
 
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
     }
 
@@ -2520,7 +2520,7 @@ namespace internal
             }
 
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
     }
 
@@ -2563,7 +2563,7 @@ namespace internal
               return;
             }
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
     }
   } // namespace MappingQImplementation

--- a/include/deal.II/grid/connectivity.h
+++ b/include/deal.II/grid/connectivity.h
@@ -50,7 +50,7 @@ namespace internal
       virtual unsigned int
       n_entities(const unsigned int d) const
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         (void)d;
 
         return 0;
@@ -62,7 +62,7 @@ namespace internal
       virtual dealii::ArrayView<const unsigned int>
       vertices_of_entity(const unsigned int d, const unsigned int e) const
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         (void)d;
         (void)e;
 
@@ -75,7 +75,7 @@ namespace internal
       virtual ReferenceCell
       type_of_entity(const unsigned int d, const unsigned int e) const
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         (void)d;
         (void)e;
 
@@ -88,7 +88,7 @@ namespace internal
       virtual unsigned int
       n_lines_of_surface(const unsigned int face) const
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         (void)face;
 
         return 0;
@@ -101,7 +101,7 @@ namespace internal
       nth_line_of_surface(const unsigned int line,
                           const unsigned int face) const
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         (void)line;
         (void)face;
 
@@ -115,7 +115,7 @@ namespace internal
       vertices_of_nth_line_of_surface(const unsigned int line,
                                       const unsigned int face) const
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         (void)line;
         (void)face;
 
@@ -147,7 +147,7 @@ namespace internal
             return {table};
           }
 
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
 
         return {};
       }
@@ -160,7 +160,7 @@ namespace internal
         if (d == 1)
           return ReferenceCells::Line;
 
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
 
         return ReferenceCells::Vertex;
       }
@@ -201,7 +201,7 @@ namespace internal
             return {table[e]};
           }
 
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
 
         return {};
       }
@@ -217,7 +217,7 @@ namespace internal
         if (d == 1)
           return ReferenceCells::Line;
 
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
 
         return ReferenceCells::Vertex;
       }
@@ -258,7 +258,7 @@ namespace internal
             return {table[e]};
           }
 
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
 
         return {};
       }
@@ -274,7 +274,7 @@ namespace internal
         if (d == 1)
           return ReferenceCells::Line;
 
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
 
         return ReferenceCells::Vertex;
       }
@@ -323,7 +323,7 @@ namespace internal
             return {table[e]};
           }
 
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
 
         return {};
       }
@@ -342,7 +342,7 @@ namespace internal
         if (d == 1)
           return ReferenceCells::Line;
 
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
 
         return ReferenceCells::Vertex;
       }
@@ -434,7 +434,7 @@ namespace internal
             return {table[e]};
           }
 
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
 
         return {};
       }
@@ -455,7 +455,7 @@ namespace internal
         if (d == 1)
           return ReferenceCells::Line;
 
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
 
         return ReferenceCells::Vertex;
       }
@@ -560,7 +560,7 @@ namespace internal
             return {table[e]};
           }
 
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
 
         return {};
       }
@@ -581,7 +581,7 @@ namespace internal
         if (d == 1)
           return ReferenceCells::Line;
 
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
 
         return ReferenceCells::Vertex;
       }
@@ -688,7 +688,7 @@ namespace internal
             return {table[e]};
           }
 
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
 
         return {};
       }
@@ -707,7 +707,7 @@ namespace internal
         if (d == 1)
           return ReferenceCells::Line;
 
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
 
         return ReferenceCells::Vertex;
       }
@@ -890,7 +890,7 @@ namespace internal
         else if (from == 1 && to == 0)
           return line_vertices;
 
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
 
         return cell_entities;
       }
@@ -909,7 +909,7 @@ namespace internal
         else if (from == 1 && to == 0)
           return line_vertices;
 
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
 
         return cell_entities;
       }

--- a/include/deal.II/grid/grid_tools_geometry.h
+++ b/include/deal.II/grid/grid_tools_geometry.h
@@ -874,7 +874,7 @@ namespace GridTools
       }
     else
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return projected_point;
       }
 

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -1101,7 +1101,7 @@ ReferenceCell::faces_for_given_vertex(const unsigned int vertex) const
       case ReferenceCells::Hexahedron:
         return {&GeometryInfo<3>::vertex_to_face[vertex][0], 3};
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return {};
@@ -1147,7 +1147,7 @@ ReferenceCell::get_dimension() const
       case ReferenceCells::Hexahedron:
         return 3;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return numbers::invalid_unsigned_int;
@@ -1187,7 +1187,7 @@ ReferenceCell::n_vertices() const
       case ReferenceCells::Hexahedron:
         return 8;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return numbers::invalid_unsigned_int;
@@ -1217,7 +1217,7 @@ ReferenceCell::n_lines() const
       case ReferenceCells::Hexahedron:
         return 12;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return numbers::invalid_unsigned_int;
@@ -1337,10 +1337,10 @@ ReferenceCell::vertex(const unsigned int v) const
           break;
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return Point<dim>();
 }
 
@@ -1367,7 +1367,7 @@ ReferenceCell::n_faces() const
       case ReferenceCells::Hexahedron:
         return 6;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return numbers::invalid_unsigned_int;
@@ -1401,14 +1401,14 @@ ReferenceCell::n_isotropic_children() const
       case ReferenceCells::Pyramid:
         // We haven't yet decided how to refine pyramids. Update this when we
         // have
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return numbers::invalid_unsigned_int;
       case ReferenceCells::Wedge:
         return 8;
       case ReferenceCells::Hexahedron:
         return 8;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return numbers::invalid_unsigned_int;
@@ -1469,7 +1469,7 @@ ReferenceCell::face_reference_cell(const unsigned int face_no) const
       case ReferenceCells::Hexahedron:
         return ReferenceCells::Quadrilateral;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return ReferenceCells::Invalid;
@@ -1512,7 +1512,7 @@ ReferenceCell::child_cell_on_face(
       case ReferenceCells::Vertex:
       case ReferenceCells::Line:
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           break;
         }
       case ReferenceCells::Triangle:
@@ -1539,7 +1539,7 @@ ReferenceCell::child_cell_on_face(
       case ReferenceCells::Pyramid:
       case ReferenceCells::Wedge:
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           break;
         }
       case ReferenceCells::Hexahedron:
@@ -1556,7 +1556,7 @@ ReferenceCell::child_cell_on_face(
             face_rotation);
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return numbers::invalid_unsigned_int;
@@ -1577,7 +1577,7 @@ ReferenceCell::standard_vertex_to_face_and_vertex_index(
     {
       case ReferenceCells::Vertex:
       case ReferenceCells::Line:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         break;
       case ReferenceCells::Triangle:
         {
@@ -1618,7 +1618,7 @@ ReferenceCell::standard_vertex_to_face_and_vertex_index(
             vertex);
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return {};
@@ -1639,7 +1639,7 @@ ReferenceCell::standard_line_to_face_and_line_index(
       case ReferenceCells::Triangle:
       case ReferenceCells::Quadrilateral:
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           break;
         }
       case ReferenceCells::Tetrahedron:
@@ -1681,7 +1681,7 @@ ReferenceCell::standard_line_to_face_and_line_index(
           return GeometryInfo<3>::standard_hex_line_to_quad_line_index(line);
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return {};
@@ -1763,7 +1763,7 @@ ReferenceCell::line_to_cell_vertices(const unsigned int line,
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return numbers::invalid_unsigned_int;
@@ -1785,7 +1785,7 @@ ReferenceCell::face_to_cell_lines(
     {
       case ReferenceCells::Vertex:
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           break;
         }
       case ReferenceCells::Line:
@@ -1849,7 +1849,7 @@ ReferenceCell::face_to_cell_lines(
             face, line, face_orientation, face_flip, face_rotation);
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return numbers::invalid_unsigned_int;
@@ -1878,7 +1878,7 @@ ReferenceCell::face_to_cell_vertices(
     {
       case ReferenceCells::Vertex:
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           break;
         }
       case ReferenceCells::Line:
@@ -1950,7 +1950,7 @@ ReferenceCell::face_to_cell_vertices(
             face, vertex, face_orientation, face_flip, face_rotation);
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return numbers::invalid_unsigned_int;
@@ -1982,7 +1982,7 @@ ReferenceCell::standard_to_real_face_vertex(
     {
       case ReferenceCells::Vertex:
       case ReferenceCells::Line:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         break;
       case ReferenceCells::Triangle:
       case ReferenceCells::Quadrilateral:
@@ -2004,10 +2004,10 @@ ReferenceCell::standard_to_real_face_vertex(
       case ReferenceCells::Hexahedron:
         return quadrilateral_vertex_permutations[face_orientation][vertex];
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return numbers::invalid_unsigned_int;
 }
 
@@ -2036,7 +2036,7 @@ ReferenceCell::standard_to_real_face_line(
       case ReferenceCells::Line:
       case ReferenceCells::Triangle:
       case ReferenceCells::Quadrilateral:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         break;
       case ReferenceCells::Tetrahedron:
         return triangle_table[combined_face_orientation][line];
@@ -2082,7 +2082,7 @@ ReferenceCell::standard_to_real_face_line(
           return table[combined_face_orientation][line];
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return numbers::invalid_unsigned_int;
@@ -2107,7 +2107,7 @@ namespace ReferenceCells
         case 3:
           return ReferenceCells::Tetrahedron;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     return ReferenceCells::Invalid;
   }
@@ -2129,7 +2129,7 @@ namespace ReferenceCells
         case 3:
           return ReferenceCells::Hexahedron;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     return ReferenceCells::Invalid;
   }
@@ -2258,7 +2258,7 @@ ReferenceCell::d_linear_shape_function(const Point<dim>  &xi,
                  .d_linear_shape_function<1>(Point<1>(xi[std::min(2, dim - 1)]),
                                              i / 3);
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return 0.0;
@@ -2293,7 +2293,7 @@ ReferenceCell::d_linear_shape_function_gradient(const Point<dim>  &xi,
               Assert(false, ExcInternalError());
           }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return Point<dim>(+0.0, +0.0, +0.0);
@@ -2323,7 +2323,7 @@ ReferenceCell::volume() const
       case ReferenceCells::Hexahedron:
         return 1;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return 0.0;
@@ -2356,7 +2356,7 @@ ReferenceCell::barycenter() const
       case ReferenceCells::Hexahedron:
         return Point<dim>(1. / 2., 1. / 2., 1. / 2.);
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return Point<dim>();
@@ -2465,7 +2465,7 @@ ReferenceCell::contains_point(const Point<dim> &p, const double tolerance) const
           return true;
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return false;
@@ -2545,7 +2545,7 @@ ReferenceCell::unit_tangential_vectors(const unsigned int face_no,
           return table[face_no][i];
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
 
@@ -2578,7 +2578,7 @@ ReferenceCell::unit_normal_vectors(const unsigned int face_no) const
                               unit_tangential_vectors<dim>(face_no, 1));
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 
   return {};
 }
@@ -2865,7 +2865,7 @@ ReferenceCell::get_combined_orientation(
           return 6;
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   Assert(false, (internal::NoPermutation<T>(*this, vertices_0, vertices_1)));
@@ -2922,7 +2922,7 @@ ReferenceCell::permute_by_combined_orientation(
             case 0:
               return {vertices[1], vertices[0]};
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
         break;
       case ReferenceCells::Triangle:
@@ -2941,7 +2941,7 @@ ReferenceCell::permute_by_combined_orientation(
             case 4:
               return {vertices[1], vertices[0], vertices[2]};
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
         break;
       case ReferenceCells::Quadrilateral:
@@ -2964,7 +2964,7 @@ ReferenceCell::permute_by_combined_orientation(
             case 6:
               return {vertices[1], vertices[0], vertices[3], vertices[2]};
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
         break;
       default:

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -113,7 +113,7 @@ namespace internal
                          (vertices[2] - vertices[5]).norm(),
                          (vertices[3] - vertices[4]).norm()});
 
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return -1e10;
     }
   } // namespace TriaAccessorImplementation
@@ -935,7 +935,7 @@ namespace internal
       {
         // it seems like we don't need this
         // one
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
       }
 
 
@@ -1572,7 +1572,7 @@ TriaAccessor<structdim, dim, spacedim>::isotropic_child_index(
         }
 
       case 3:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   return -1;
 }
@@ -1694,7 +1694,7 @@ TriaAccessor<structdim, dim, spacedim>::isotropic_child(
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   // we don't get here but have to return
   // something...
@@ -2099,7 +2099,7 @@ TriaAccessor<structdim, dim, spacedim>::set_all_boundary_ids(
         break;
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -2176,7 +2176,7 @@ TriaAccessor<structdim, dim, spacedim>::set_all_manifold_ids(
           this->line(i)->set_manifold_id(manifold_ind);
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -2302,7 +2302,7 @@ TriaAccessor<structdim, dim, spacedim>::enclosing_ball() const
           break;
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return std::pair<Point<spacedim>, double>();
     }
 
@@ -2365,7 +2365,7 @@ TriaAccessor<structdim, dim, spacedim>::minimum_vertex_distance() const
           return std::sqrt(min);
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return -1e10;
     }
 }
@@ -3009,7 +3009,7 @@ template <int spacedim>
 inline void
 TriaAccessor<0, 1, spacedim>::operator++() const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -3017,7 +3017,7 @@ template <int spacedim>
 inline void
 TriaAccessor<0, 1, spacedim>::operator--() const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 

--- a/include/deal.II/hp/q_collection.h
+++ b/include/deal.II/hp/q_collection.h
@@ -163,7 +163,7 @@ namespace hp
       }
     else
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
       }
   }
 

--- a/include/deal.II/integrators/maxwell.h
+++ b/include/deal.II/integrators/maxwell.h
@@ -106,7 +106,7 @@ namespace LocalIntegrators
             result[2] = h0[2][0] + h1[2][1] - h2[0][0] - h2[1][1];
             break;
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
       return result;
     }
@@ -145,7 +145,7 @@ namespace LocalIntegrators
               normal[1] * (g1[0] - g2[1]) + normal[0] * (g0[2] - g2[0]);
             break;
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
       return result;
     }

--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -2906,7 +2906,7 @@ AffineConstraints<number>::merge(
                   break;
 
                 default:
-                  Assert(false, ExcNotImplemented());
+                  DEAL_II_NOT_IMPLEMENTED();
               }
           }
       }

--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -4766,7 +4766,7 @@ AffineConstraints<number>::add_entries_local_to_global(
     }
 
   // TODO: implement this
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 

--- a/include/deal.II/lac/blas_extension_templates.h
+++ b/include/deal.II/lac/blas_extension_templates.h
@@ -50,7 +50,7 @@ omatcopy(char,
          number3 *,
          dealii::types::blas_int)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 

--- a/include/deal.II/lac/chunk_sparse_matrix.templates.h
+++ b/include/deal.II/lac/chunk_sparse_matrix.templates.h
@@ -520,7 +520,7 @@ ChunkSparseMatrix<number>::symmetrize()
   Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(cols->rows == cols->cols, ExcNotQuadratic());
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -1222,7 +1222,7 @@ ChunkSparseMatrix<number>::precondition_Jacobi(Vector<somenumber>       &dst,
   Assert(dst.size() == n(), ExcDimensionMismatch(dst.size(), n()));
   Assert(src.size() == n(), ExcDimensionMismatch(src.size(), n()));
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -1246,7 +1246,7 @@ ChunkSparseMatrix<number>::precondition_SSOR(Vector<somenumber>       &dst,
   Assert(dst.size() == n(), ExcDimensionMismatch(dst.size(), n()));
   Assert(src.size() == n(), ExcDimensionMismatch(src.size(), n()));
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -1299,7 +1299,7 @@ ChunkSparseMatrix<number>::SOR(Vector<somenumber> &dst,
          ExcMessage("This operation is only valid on square matrices."));
   Assert(m() == dst.size(), ExcDimensionMismatch(m(), dst.size()));
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -1316,7 +1316,7 @@ ChunkSparseMatrix<number>::TSOR(Vector<somenumber> &dst,
          ExcMessage("This operation is only valid on square matrices."));
   Assert(m() == dst.size(), ExcDimensionMismatch(m(), dst.size()));
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -1343,7 +1343,7 @@ ChunkSparseMatrix<number>::PSOR(
   Assert(m() == inverse_permutation.size(),
          ExcDimensionMismatch(m(), inverse_permutation.size()));
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -1370,7 +1370,7 @@ ChunkSparseMatrix<number>::TPSOR(
   Assert(m() == inverse_permutation.size(),
          ExcDimensionMismatch(m(), inverse_permutation.size()));
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -1392,7 +1392,7 @@ ChunkSparseMatrix<number>::SOR_step(Vector<somenumber>       &v,
   Assert(m() == v.size(), ExcDimensionMismatch(m(), v.size()));
   Assert(m() == b.size(), ExcDimensionMismatch(m(), b.size()));
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -1414,7 +1414,7 @@ ChunkSparseMatrix<number>::TSOR_step(Vector<somenumber>       &v,
   Assert(m() == v.size(), ExcDimensionMismatch(m(), v.size()));
   Assert(m() == b.size(), ExcDimensionMismatch(m(), b.size()));
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -1446,7 +1446,7 @@ ChunkSparseMatrix<number>::SSOR(Vector<somenumber> &dst,
 
   Assert(m() == dst.size(), ExcDimensionMismatch(m(), dst.size()));
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -1460,7 +1460,7 @@ ChunkSparseMatrix<number>::print(std::ostream &out) const
   Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 
   AssertThrow(out.fail() == false, ExcIO());
 }
@@ -1483,7 +1483,7 @@ ChunkSparseMatrix<number>::print_formatted(std::ostream      &out,
 
   unsigned int width = width_;
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 
   std::ios::fmtflags old_flags     = out.flags();
   unsigned int       old_precision = out.precision(precision);

--- a/include/deal.II/lac/dynamic_sparsity_pattern.h
+++ b/include/deal.II/lac/dynamic_sparsity_pattern.h
@@ -967,7 +967,7 @@ namespace DynamicSparsityPatternIterators
     (void)other;
     Assert(accessor.sparsity_pattern == other.accessor.sparsity_pattern,
            ExcInternalError());
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 
     return 0;
   }

--- a/include/deal.II/lac/householder.h
+++ b/include/deal.II/lac/householder.h
@@ -343,7 +343,7 @@ template <typename VectorType>
 void
 Householder<number>::Tvmult(VectorType &, const VectorType &) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 

--- a/include/deal.II/lac/lapack_support.h
+++ b/include/deal.II/lac/lapack_support.h
@@ -143,7 +143,7 @@ namespace LAPACKSupport
           return "Hessenberg";
       }
 
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
     return "invalid";
   }
 

--- a/include/deal.II/lac/lapack_templates.h
+++ b/include/deal.II/lac/lapack_templates.h
@@ -1409,7 +1409,7 @@ axpy(const dealii::types::blas_int *,
      number3 *,
      const dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -1528,7 +1528,7 @@ geev(const char *,
      const dealii::types::blas_int *,
      dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -1728,7 +1728,7 @@ geevx(const char *,
       dealii::types::blas_int *,
       dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -2068,7 +2068,7 @@ gelsd(const dealii::types::blas_int *,
       dealii::types::blas_int *,
       dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -2257,7 +2257,7 @@ gemm(const char *,
      number5 *,
      const dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -2432,7 +2432,7 @@ gemv(const char *,
      number5 *,
      const dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -2584,7 +2584,7 @@ geqrf(const dealii::types::blas_int *,
       const dealii::types::blas_int *,
       dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -2718,7 +2718,7 @@ gesdd(const char *,
       dealii::types::blas_int *,
       dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -2908,7 +2908,7 @@ gesvd(const char *,
       const dealii::types::blas_int *,
       dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -3086,7 +3086,7 @@ getrf(const dealii::types::blas_int *,
       dealii::types::blas_int *,
       dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -3193,7 +3193,7 @@ getri(const dealii::types::blas_int *,
       const dealii::types::blas_int *,
       dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -3310,7 +3310,7 @@ getrs(const char *,
       const dealii::types::blas_int *,
       dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -3439,7 +3439,7 @@ template <typename number1>
 inline number1
 lamch(const char *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return number1();
 }
 
@@ -3484,7 +3484,7 @@ lange(const char *,
       const dealii::types::blas_int *,
       number2 *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return number1();
 }
 
@@ -3595,7 +3595,7 @@ lansy(const char *,
       const dealii::types::blas_int *,
       number2 *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return number1();
 }
 
@@ -3710,7 +3710,7 @@ lascl(const char *,
       const dealii::types::blas_int *,
       dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -3855,7 +3855,7 @@ orgqr(const dealii::types::blas_int *,
       const dealii::types::blas_int *,
       dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -3939,7 +3939,7 @@ ormqr(const char *,
       const dealii::types::blas_int *,
       dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -4035,7 +4035,7 @@ pocon(const char *,
       dealii::types::blas_int *,
       dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -4168,7 +4168,7 @@ potrf(const char *,
       const dealii::types::blas_int *,
       dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -4265,7 +4265,7 @@ potri(const char *,
       const dealii::types::blas_int *,
       dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -4365,7 +4365,7 @@ potrs(const char *,
       const dealii::types::blas_int *,
       dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -4492,7 +4492,7 @@ stev(const char *,
      number4 *,
      dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -4563,7 +4563,7 @@ syev(const char *,
      const dealii::types::blas_int *,
      dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -4658,7 +4658,7 @@ syevr(const char *,
       const dealii::types::blas_int *,
       dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -4862,7 +4862,7 @@ syevx(const char *,
       dealii::types::blas_int *,
       dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -5027,7 +5027,7 @@ sygv(const dealii::types::blas_int *,
      const dealii::types::blas_int *,
      dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -5137,7 +5137,7 @@ sygvx(const dealii::types::blas_int *,
       dealii::types::blas_int *,
       dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -5312,7 +5312,7 @@ syr(const char *,
     number3 *,
     const dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -5383,7 +5383,7 @@ syrk(const char *,
      number4 *,
      const dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -5529,7 +5529,7 @@ trcon(const char *,
       dealii::types::blas_int *,
       dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -5673,7 +5673,7 @@ trmv(const char *,
      number2 *,
      const dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -5799,7 +5799,7 @@ trtrs(const char *,
       const dealii::types::blas_int *,
       dealii::types::blas_int *)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 

--- a/include/deal.II/lac/matrix_block.h
+++ b/include/deal.II/lac/matrix_block.h
@@ -869,7 +869,7 @@ MatrixBlockVector<MatrixType>::clear(bool really_clean)
 {
   if (really_clean)
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
   else
     {
@@ -1121,7 +1121,7 @@ MGMatrixBlockVector<MatrixType>::clear(bool really_clean)
 {
   if (really_clean)
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
   else
     {

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -3603,7 +3603,7 @@ PreconditionChebyshev<MatrixType, VectorType, PreconditionerType>::
               data.eig_cg_n_iterations));
         }
       else
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
 
       // read the eigenvalues from the attached eigenvalue tracker
       if (eigenvalue_tracker.values.empty())

--- a/include/deal.II/lac/precondition_block.templates.h
+++ b/include/deal.II/lac/precondition_block.templates.h
@@ -152,7 +152,7 @@ PreconditionBlock<MatrixType, inverse_type>::invert_permuted_diagblocks()
             this->inverse_svd(0).compute_inverse_svd(0.);
             break;
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
     }
   else
@@ -207,7 +207,7 @@ PreconditionBlock<MatrixType, inverse_type>::invert_permuted_diagblocks()
                 this->inverse_svd(cell).compute_inverse_svd(0.);
                 break;
               default:
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
             }
         }
     }
@@ -459,7 +459,7 @@ PreconditionBlock<MatrixType, inverse_type>::invert_diagblocks()
             this->inverse_svd(0).compute_inverse_svd(1.e-12);
             break;
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
     }
   else
@@ -502,7 +502,7 @@ PreconditionBlock<MatrixType, inverse_type>::invert_diagblocks()
                 this->inverse_svd(cell).compute_inverse_svd(1.e-12);
                 break;
               default:
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
             }
         }
     }

--- a/include/deal.II/lac/precondition_block_base.h
+++ b/include/deal.II/lac/precondition_block_base.h
@@ -356,7 +356,7 @@ PreconditionBlockBase<number>::reinit(unsigned int n,
             var_inverse_svd[0].reinit(b, b);
             break;
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
 
       if (store_diagonals())
@@ -400,7 +400,7 @@ PreconditionBlockBase<number>::reinit(unsigned int n,
               break;
             }
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
     }
 }
@@ -437,7 +437,7 @@ PreconditionBlockBase<number>::inverse_vmult(size_type              i,
         var_inverse_svd[ii].vmult(dst, src);
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -466,7 +466,7 @@ PreconditionBlockBase<number>::inverse_Tvmult(size_type              i,
         var_inverse_svd[ii].Tvmult(dst, src);
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -657,7 +657,7 @@ PreconditionBlockBase<number>::log_statistics() const
     }
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
 }
 

--- a/include/deal.II/lac/precondition_selector.h
+++ b/include/deal.II/lac/precondition_selector.h
@@ -272,7 +272,7 @@ PreconditionSelector<MatrixType, VectorType>::vmult(VectorType       &dst,
           A->precondition_SSOR(dst, src, omega);
         }
       else
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -304,7 +304,7 @@ PreconditionSelector<MatrixType, VectorType>::Tvmult(
           A->precondition_SSOR(dst, src, omega); // Symmetric operation
         }
       else
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 

--- a/include/deal.II/lac/relaxation_block.templates.h
+++ b/include/deal.II/lac/relaxation_block.templates.h
@@ -94,7 +94,7 @@ RelaxationBlock<MatrixType, InverseNumberType, VectorType>::invert_diagblocks()
 {
   if (this->same_diagonal())
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
   else
     {
@@ -169,7 +169,7 @@ RelaxationBlock<MatrixType, InverseNumberType, VectorType>::block_kernel(
                 this->additional_data->threshold);
             break;
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
     }
 }

--- a/include/deal.II/lac/sparse_matrix.templates.h
+++ b/include/deal.II/lac/sparse_matrix.templates.h
@@ -1847,7 +1847,7 @@ SparseMatrix<number>::SSOR(Vector<somenumber> &dst, const number omega) const
 {
   // TODO: Is this called anywhere? If so, multiplication with omega(2-omega)D
   // is missing
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 
   Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());

--- a/include/deal.II/lac/tensor_product_matrix.h
+++ b/include/deal.II/lac/tensor_product_matrix.h
@@ -877,7 +877,7 @@ namespace internal
         }
 
       else
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
 

--- a/include/deal.II/lac/trilinos_solver.h
+++ b/include/deal.II/lac/trilinos_solver.h
@@ -1145,7 +1145,7 @@ namespace TrilinosWrappers
                      Teuchos::SerialDenseMatrix<int, value_type> &,
                      const bool = false)
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
       }
 
       virtual int
@@ -1153,7 +1153,7 @@ namespace TrilinosWrappers
         Teuchos::SerialDenseMatrix<int, value_type> &,
         const typename Teuchos::ScalarTraits<value_type>::magnitudeType &)
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
       }
 
 #      endif

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -416,7 +416,7 @@ namespace LinearAlgebra
       else if (operation == VectorOperation::add)
         tpetra_operation = Tpetra::ADD;
       else
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
 
       vector->doExport(source_vector, *tpetra_export, tpetra_operation);
     }
@@ -875,7 +875,7 @@ namespace LinearAlgebra
           else if (operation == VectorOperation::add)
             tpetra_operation = Tpetra::ADD;
           else
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
 
           Teuchos::RCP<const ExportType> exporter =
             Tpetra::createExport(nonlocal_vector->getMap(), vector->getMap());

--- a/include/deal.II/matrix_free/evaluation_kernels_face.h
+++ b/include/deal.II/matrix_free/evaluation_kernels_face.h
@@ -134,7 +134,7 @@ namespace internal
                   values_quad[0] = values_dofs[0];
                   break;
                 default:
-                  Assert(false, ExcNotImplemented());
+                  DEAL_II_NOT_IMPLEMENTED();
               }
             // Note: we always keep storage of values, 1st and 2nd derivatives
             // in an array
@@ -333,7 +333,7 @@ namespace internal
                   values_dofs[0] = values_quad[0];
                   break;
                 default:
-                  Assert(false, ExcNotImplemented());
+                  DEAL_II_NOT_IMPLEMENTED();
               }
             values_dofs += 3 * n_dofs;
             values_quad += n_q_points;
@@ -558,7 +558,7 @@ namespace internal
       // TODO: This is currently not implemented, but the test
       // matrix_vector_rt_face_03 apparently works without it -> check
       // if (subface_index < GeometryInfo<dim - 1>::max_children_per_cell)
-      //  Assert(false, ExcNotImplemented());
+      //  DEAL_II_NOT_IMPLEMENTED();
 
       using Eval = EvaluatorTensorProduct<evaluate_evenodd,
                                           dim - 1,
@@ -2374,7 +2374,7 @@ namespace internal
                   }
                 else
                   {
-                    Assert(false, ExcNotImplemented());
+                    DEAL_II_NOT_IMPLEMENTED();
                   }
               }
             else if (n_face_orientations == n_lanes)

--- a/include/deal.II/matrix_free/evaluation_kernels_hanging_nodes.h
+++ b/include/deal.II/matrix_free/evaluation_kernels_hanging_nodes.h
@@ -449,7 +449,7 @@ namespace internal
         }
       else
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
         }
     }
   };
@@ -1689,7 +1689,7 @@ namespace internal
                 }
               else
                 {
-                  Assert(false, ExcNotImplemented());
+                  DEAL_II_NOT_IMPLEMENTED();
                 }
             }
 

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -4747,7 +4747,7 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
                   (jac[1][1] * jac[2][2]);
                 break;
               default:
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
             }
           for (unsigned int d = 0; d < dim; ++d)
             for (unsigned int e = d + 1; e < dim; ++e)
@@ -6190,7 +6190,7 @@ FEEvaluationAccess<dim, dim, Number, is_face, VectorizedArrayType>::
         symmetrized[5] *= half;
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   return SymmetricTensor<2, dim, VectorizedArrayType>(symmetrized);
 }
@@ -6222,7 +6222,7 @@ inline DEAL_II_ALWAYS_INLINE
         curl[2] = grad[1][0] - grad[0][1];
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   return curl;
 }
@@ -6731,7 +6731,7 @@ FEEvaluationAccess<dim, dim, Number, is_face, VectorizedArrayType>::submit_curl(
         grad[0][1] = -curl[2];
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   submit_gradient(grad, q_point);
 }

--- a/include/deal.II/matrix_free/fe_remote_evaluation.h
+++ b/include/deal.II/matrix_free/fe_remote_evaluation.h
@@ -1040,7 +1040,7 @@ FERemoteEvaluation<dim, n_components, value_type>::gather_evaluate(
                                                        evaluation_flags);
     }
   else
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 }
 
 template <int dim, int n_components, typename value_type>

--- a/include/deal.II/matrix_free/hanging_nodes_internal.h
+++ b/include/deal.II/matrix_free/hanging_nodes_internal.h
@@ -682,10 +682,10 @@ namespace internal
               case 2:
                 return n_dofs_1d * n_dofs_1d * offset + n_dofs_1d * i + j;
               default:
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
             }
 
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
 
         return 0;
       };
@@ -768,7 +768,7 @@ namespace internal
                     }
                   else
                     {
-                      Assert(false, ExcNotImplemented());
+                      DEAL_II_NOT_IMPLEMENTED();
                     }
 
                   // update DoF map

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -2301,7 +2301,7 @@ namespace internal
                     boundary_form = cross_product_3d(tangential_vectors[0],
                                                      tangential_vectors[1]);
                   else
-                    Assert(false, ExcNotImplemented());
+                    DEAL_II_NOT_IMPLEMENTED();
 
                   const VectorizedDouble JxW =
                     boundary_form.norm() *
@@ -3215,7 +3215,7 @@ namespace internal
                           }
                       if (update_flags & update_jacobian_grads)
                         {
-                          Assert(false, ExcNotImplemented());
+                          DEAL_II_NOT_IMPLEMENTED();
                         }
                       if (update_flags & update_normal_vectors)
                         for (unsigned int d = 0; d < dim; ++d)
@@ -3268,7 +3268,7 @@ namespace internal
                           }
                       if (update_flags & update_jacobian_grads)
                         {
-                          Assert(false, ExcNotImplemented());
+                          DEAL_II_NOT_IMPLEMENTED();
                         }
                       if (update_flags & update_normal_vectors)
                         for (unsigned int q = 0; q < fe_val.n_quadrature_points;

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -133,7 +133,7 @@ namespace internal
           // FE_Nothing case -> nothing to do here
         }
       else
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
 
       // Finally store the renumbering into the respective field
       if (fe_in.n_components() == 1)

--- a/include/deal.II/matrix_free/vector_access_internal.h
+++ b/include/deal.II/matrix_free/vector_access_internal.h
@@ -425,7 +425,7 @@ namespace internal
       VectorizedArrayType *,
       std::bool_constant<false>) const
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
 
 
@@ -674,7 +674,7 @@ namespace internal
       VectorizedArrayType *,
       std::bool_constant<false>) const
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
 
 
@@ -910,7 +910,7 @@ namespace internal
       VectorizedArrayType *,
       std::bool_constant<false>) const
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
 
 

--- a/include/deal.II/meshworker/vector_selector.templates.h
+++ b/include/deal.II/meshworker/vector_selector.templates.h
@@ -56,7 +56,7 @@ namespace MeshWorker
     const unsigned int,
     const unsigned int) const
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 
@@ -74,7 +74,7 @@ namespace MeshWorker
     const unsigned int,
     const unsigned int) const
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -2716,7 +2716,7 @@ namespace MGTransferGlobalCoarseningTools
       coarse_grid_triangulations(fine_triangulation_in.n_global_levels());
 
 #ifndef DEAL_II_WITH_P4EST
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
     (void)policy;
     (void)keep_fine_triangulation;
     (void)repartition_fine_triangulation;
@@ -3809,7 +3809,7 @@ MGTransferMF<dim, Number>::get_dof_handler_fine() const
     }
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return {nullptr, numbers::invalid_unsigned_int};
     }
 }

--- a/include/deal.II/multigrid/multigrid.h
+++ b/include/deal.II/multigrid/multigrid.h
@@ -966,7 +966,7 @@ PreconditionMG<dim, VectorType, TransferType>::Tvmult(
   OtherVectorType &,
   const OtherVectorType &) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -977,7 +977,7 @@ PreconditionMG<dim, VectorType, TransferType>::Tvmult_add(
   OtherVectorType &,
   const OtherVectorType &) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -97,7 +97,7 @@ namespace internal
     {
       (void)n_subdivisions;
 
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
 
       return {};
     }
@@ -353,7 +353,7 @@ namespace internal
                       else if (reference_cell == ReferenceCells::Pyramid)
                         quadrature.push_back(*quadrature_pyramid);
                       else
-                        Assert(false, ExcNotImplemented());
+                        DEAL_II_NOT_IMPLEMENTED();
                     }
 
                   x_fe_values[i] =
@@ -1532,7 +1532,7 @@ namespace internal
         const ComponentExtractor /*extract_component*/,
         std::vector<Tensor<1, spacedim>> & /*patch_gradients*/) const override
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
       }
 
       /**
@@ -1547,7 +1547,7 @@ namespace internal
         std::vector<std::vector<Tensor<1, spacedim>>>
           & /*patch_gradients_system*/) const override
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
       }
 
 
@@ -1561,7 +1561,7 @@ namespace internal
         const ComponentExtractor /*extract_component*/,
         std::vector<Tensor<2, spacedim>> & /*patch_hessians*/) const override
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
       }
 
       /**
@@ -1576,7 +1576,7 @@ namespace internal
         std::vector<std::vector<Tensor<2, spacedim>>>
           & /*patch_hessians_system*/) const override
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
       }
 
       /**
@@ -1636,7 +1636,7 @@ namespace internal
       const unsigned int       cell_number,
       const ComponentExtractor extract_component) const
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
 
       (void)cell_number;
       (void)extract_component;
@@ -2375,7 +2375,7 @@ DataOut_DoFData<dim, patch_dim, spacedim, patch_spacedim>::
             }
 
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
 
   // note that we do not have to traverse the list of cell data here because
@@ -2454,7 +2454,7 @@ DataOut_DoFData<dim, patch_dim, spacedim, patch_spacedim>::get_fes() const
               std::make_shared<dealii::hp::FECollection<dim, spacedim>>(
                 FE_PyramidDGP<dim, spacedim>(1)));
           else
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
     }
   return finite_elements;

--- a/include/deal.II/numerics/error_estimator.templates.h
+++ b/include/deal.II/numerics/error_estimator.templates.h
@@ -512,7 +512,7 @@ namespace internal
           }
         default:
           {
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
             return std::numeric_limits<double>::lowest();
           }
       }
@@ -556,7 +556,7 @@ namespace internal
           }
         default:
           {
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
             return std::numeric_limits<double>::lowest();
           }
       }
@@ -602,7 +602,7 @@ namespace internal
           }
         default:
           {
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
             return std::numeric_limits<double>::lowest();
           }
       }
@@ -637,7 +637,7 @@ namespace internal
           }
         default:
           {
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
             return std::numeric_limits<double>::lowest();
           }
       }

--- a/include/deal.II/numerics/matrix_creator.templates.h
+++ b/include/deal.II/numerics/matrix_creator.templates.h
@@ -119,7 +119,7 @@ namespace MatrixCreator
         Scratch &
         operator=(const Scratch &)
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           return *this;
         }
 
@@ -1101,11 +1101,11 @@ namespace MatrixCreator
                     if (!base.conforms(FiniteElementData<dim>::H1) &&
                         base.conforms(FiniteElementData<dim>::Hdiv) &&
                         fe_is_primitive)
-                      Assert(false, ExcNotImplemented());
+                      DEAL_II_NOT_IMPLEMENTED();
 
                     if (!base.conforms(FiniteElementData<dim>::H1) &&
                         base.conforms(FiniteElementData<dim>::Hcurl))
-                      Assert(false, ExcNotImplemented());
+                      DEAL_II_NOT_IMPLEMENTED();
 
                     if (!base.conforms(FiniteElementData<dim>::H1) &&
                         base.conforms(FiniteElementData<dim>::Hdiv))
@@ -1307,7 +1307,7 @@ namespace MatrixCreator
       const Function<3, float> *const /*coefficient*/,
       const std::vector<unsigned int> & /*component_mapping*/)
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
 
     template <>
@@ -1324,7 +1324,7 @@ namespace MatrixCreator
       const Function<3, double> *const /*coefficient*/,
       const std::vector<unsigned int> & /*component_mapping*/)
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
 
   } // namespace internal
@@ -1350,7 +1350,7 @@ namespace MatrixCreator
     // dofs?
     if (dim == 1)
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return;
       }
 
@@ -1552,11 +1552,11 @@ namespace MatrixCreator
                     if (!base.conforms(FiniteElementData<dim>::H1) &&
                         base.conforms(FiniteElementData<dim>::Hdiv) &&
                         fe_is_primitive)
-                      Assert(false, ExcNotImplemented());
+                      DEAL_II_NOT_IMPLEMENTED();
 
                     if (!base.conforms(FiniteElementData<dim>::H1) &&
                         base.conforms(FiniteElementData<dim>::Hcurl))
-                      Assert(false, ExcNotImplemented());
+                      DEAL_II_NOT_IMPLEMENTED();
 
                     if (!base.conforms(FiniteElementData<dim>::H1) &&
                         base.conforms(FiniteElementData<dim>::Hdiv))
@@ -1825,7 +1825,7 @@ namespace MatrixCreator
     // dofs?
     if (dim == 1)
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return;
       }
 

--- a/include/deal.II/numerics/vector_tools_boundary.templates.h
+++ b/include/deal.II/numerics/vector_tools_boundary.templates.h
@@ -1154,7 +1154,7 @@ namespace VectorTools
               dof_is_of_interest = true;
             }
           else
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
 
           if (dof_is_of_interest)
             {
@@ -1590,7 +1590,7 @@ namespace VectorTools
                           dof_is_of_interest = true;
                         }
                       else
-                        Assert(false, ExcNotImplemented());
+                        DEAL_II_NOT_IMPLEMENTED();
 
                       if (dof_is_of_interest)
                         {
@@ -1780,7 +1780,7 @@ namespace VectorTools
               break;
             }
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
     }
 
@@ -2081,7 +2081,7 @@ namespace VectorTools
               break;
             }
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
     }
 
@@ -2233,7 +2233,7 @@ namespace VectorTools
       const std::vector<DerivativeForm<1, dim, dim>> &,
       AffineConstraints<number> &)
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
 
     // This function computes the projection of the boundary function on the
@@ -2339,7 +2339,7 @@ namespace VectorTools
       std::vector<number> &,
       std::vector<types::global_dof_index> &)
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
   } // namespace internals
 
@@ -2512,7 +2512,7 @@ namespace VectorTools
           }
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
   }
 
@@ -2670,7 +2670,7 @@ namespace VectorTools
           }
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
   }
 } // namespace VectorTools

--- a/include/deal.II/numerics/vector_tools_constraints.templates.h
+++ b/include/deal.II/numerics/vector_tools_constraints.templates.h
@@ -337,7 +337,7 @@ namespace VectorTools
             }
 
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
     }
 
@@ -508,7 +508,7 @@ namespace VectorTools
             }
 
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
     }
 
@@ -1209,7 +1209,7 @@ namespace VectorTools
                               cross_product_3d(normals[0], normals[dim - 2]);
                             break;
                           default:
-                            Assert(false, ExcNotImplemented());
+                            DEAL_II_NOT_IMPLEMENTED();
                         }
 
                       Assert(

--- a/include/deal.II/numerics/vector_tools_evaluate.h
+++ b/include/deal.II/numerics/vector_tools_evaluate.h
@@ -376,7 +376,7 @@ namespace VectorTools
           case EvaluationFlags::insert:
             return values[0];
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
             return values[0];
         }
     }
@@ -403,7 +403,7 @@ namespace VectorTools
           case EvaluationFlags::insert:
             return values[0];
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
             return values[0];
         }
     }
@@ -439,7 +439,7 @@ namespace VectorTools
           case EvaluationFlags::insert:
             return values[0];
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
             return values[0];
         }
     }

--- a/include/deal.II/numerics/vector_tools_integrate_difference.templates.h
+++ b/include/deal.II/numerics/vector_tools_integrate_difference.templates.h
@@ -333,7 +333,7 @@ namespace VectorTools
             break;
 
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
             break;
         }
 

--- a/include/deal.II/trilinos/nox.templates.h
+++ b/include/deal.II/trilinos/nox.templates.h
@@ -1091,7 +1091,7 @@ namespace TrilinosWrappers
                 "solve_with_jacobian_and_track_n_linear_iterations function "
                 "has been attached to the NOXSolver object."));
 
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
             ret_code = 1;
           }
 

--- a/source/base/auto_derivative_function.cc
+++ b/source/base/auto_derivative_function.cc
@@ -116,7 +116,7 @@ AutoDerivativeFunction<dim>::gradient(const Point<dim>  &p,
           break;
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   return grad;
 }
@@ -194,7 +194,7 @@ AutoDerivativeFunction<dim>::vector_gradient(
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -257,7 +257,7 @@ AutoDerivativeFunction<dim>::gradient_list(
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -326,7 +326,7 @@ AutoDerivativeFunction<dim>::vector_gradient_list(
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -346,7 +346,7 @@ AutoDerivativeFunction<dim>::get_formula_of_order(const unsigned int ord)
       case 4:
         return FourthOrder;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   return Euler;
 }

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -96,7 +96,7 @@ namespace
         case (DataOutBase::CompressionLevel::default_compression):
           return Z_DEFAULT_COMPRESSION;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           return Z_NO_COMPRESSION;
       }
   }
@@ -120,7 +120,7 @@ namespace
         case (DataOutBase::CompressionLevel::default_compression):
           return boost::iostreams::zlib::default_compression;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           return boost::iostreams::zlib::no_compression;
       }
   }
@@ -626,7 +626,7 @@ namespace DataOutBase
           }
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
   }
 
@@ -757,7 +757,7 @@ namespace
       }
     else
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
       }
 
     return vtk_cell_id;
@@ -814,7 +814,7 @@ namespace
               break;
 
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
         Point<spacedim> node;
         for (unsigned int d = 0; d < spacedim; ++d)
@@ -1514,7 +1514,7 @@ namespace
           }
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     stream << '\n';
   }
@@ -1586,7 +1586,7 @@ namespace
           }
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     stream << '\n';
   }
@@ -1714,7 +1714,7 @@ namespace
           }
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     stream << '\n';
   }
@@ -2525,7 +2525,7 @@ namespace DataOutBase
         case svg:
           return ".svg";
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           return "";
       }
   }
@@ -2701,7 +2701,7 @@ namespace DataOutBase
                     break;
                   }
                 default:
-                  Assert(false, ExcNotImplemented());
+                  DEAL_II_NOT_IMPLEMENTED();
               }
 
             // Update the number of the first vertex of this patch
@@ -2809,7 +2809,7 @@ namespace DataOutBase
                     break;
                   }
                 default:
-                  Assert(false, ExcNotImplemented());
+                  DEAL_II_NOT_IMPLEMENTED();
               }
 
             // Having so set up the 'connectivity' data structure,
@@ -3928,13 +3928,13 @@ namespace DataOutBase
                   }
                 else
                   // No other reference cells are currently implemented
-                  Assert(false, ExcNotImplemented());
+                  DEAL_II_NOT_IMPLEMENTED();
 
                 break;
               }
 
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
       }
     // make sure everything now gets to disk
@@ -4428,7 +4428,7 @@ namespace DataOutBase
                       heights[i] = points[i][2];
                     break;
                   default:
-                    Assert(false, ExcNotImplemented());
+                    DEAL_II_NOT_IMPLEMENTED();
                 }
 
 
@@ -4854,7 +4854,7 @@ namespace DataOutBase
             out << "\"x\", \"y\", \"z\"";
             break;
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
 
       for (unsigned int data_set = 0; data_set < n_data_sets; ++data_set)
@@ -5636,7 +5636,7 @@ namespace DataOutBase
                         }
 
                       default:
-                        Assert(false, ExcNotImplemented());
+                        DEAL_II_NOT_IMPLEMENTED();
                     }
                 }
               else // use higher-order output
@@ -5724,7 +5724,7 @@ namespace DataOutBase
                           break;
                         }
                       default:
-                        Assert(false, ExcNotImplemented());
+                        DEAL_II_NOT_IMPLEMENTED();
                     }
                 }
 
@@ -6379,7 +6379,7 @@ namespace DataOutBase
     const SvgFlags &,
     std::ostream &)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
   template <int spacedim>
@@ -8843,7 +8843,7 @@ DataOutInterface<dim, spacedim>::write(
         break;
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -8891,7 +8891,7 @@ DataOutInterface<dim, spacedim>::set_flags(const FlagType &flags)
     deal_II_intermediate_flags =
       *reinterpret_cast<const DataOutBase::Deal_II_IntermediateFlags *>(&flags);
   else
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 }
 
 

--- a/source/base/exceptions.cc
+++ b/source/base/exceptions.cc
@@ -187,7 +187,7 @@ ExceptionBase::print_exc_data(std::ostream &out) const
 
   // If the exception stores a string representation of the violated
   // condition, then output it. Not all exceptions do (e.g., when
-  // creating an exception inside DEAL_II_NOT_IMPLEMENTED()), so
+  // creating an exception inside DEAL_II_NOT_IMPLEMENTED();), so
   // we have to check whether there is anything to print.
   if (cond != nullptr)
     out << "The violated condition was: " << std::endl

--- a/source/base/flow_function.cc
+++ b/source/base/flow_function.cc
@@ -180,7 +180,7 @@ namespace Functions
   std::size_t
   FlowFunction<dim>::memory_consumption() const
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
     return 0;
   }
 
@@ -343,7 +343,7 @@ namespace Functions
           }
         else
           {
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
           }
       }
   }
@@ -409,7 +409,7 @@ namespace Functions
           }
         else
           {
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
           }
       }
   }
@@ -480,7 +480,7 @@ namespace Functions
           }
         else
           {
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
           }
       }
   }

--- a/source/base/function_derivative.cc
+++ b/source/base/function_derivative.cc
@@ -111,7 +111,7 @@ FunctionDerivative<dim>::value(const Point<dim>  &p,
                 f.value(p - 2 * incr[0], component)) /
                (12 * h);
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   return 0.;
 }
@@ -154,7 +154,7 @@ FunctionDerivative<dim>::vector_value(const Point<dim> &p,
         result /= (12. * h);
         return;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -220,7 +220,7 @@ FunctionDerivative<dim>::value_list(const std::vector<Point<dim>> &points,
           values[i] = (values[i] - 8. * aux[i]) / (12 * h);
         return;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 

--- a/source/base/function_lib.cc
+++ b/source/base/function_lib.cc
@@ -270,7 +270,7 @@ namespace Functions
           return (1. - p[0] * p[0]) * (1. - p[1] * p[1]) * (1. - p[2] * p[2]) +
                  offset;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     return 0.;
   }
@@ -301,7 +301,7 @@ namespace Functions
                 offset;
               break;
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
       }
   }
@@ -323,7 +323,7 @@ namespace Functions
                         (1. - p[1] * p[1]) * (1. - p[2] * p[2]) +
                         (1. - p[2] * p[2]) * (1. - p[0] * p[0]));
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     return 0.;
   }
@@ -354,7 +354,7 @@ namespace Functions
                                  (1. - p[2] * p[2]) * (1. - p[0] * p[0]));
               break;
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
       }
   }
@@ -379,7 +379,7 @@ namespace Functions
           result[2] = -2. * p[2] * (1. - p[0] * p[0]) * (1. - p[1] * p[1]);
           break;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     return result;
   }
@@ -414,7 +414,7 @@ namespace Functions
                 -2. * p[2] * (1. - p[0] * p[0]) * (1. - p[1] * p[1]);
               break;
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
       }
   }
@@ -444,7 +444,7 @@ namespace Functions
                  std::cos(numbers::PI_2 * p[1]) *
                  std::cos(numbers::PI_2 * p[2]);
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     return 0.;
   }
@@ -500,7 +500,7 @@ namespace Functions
                  std::cos(numbers::PI_2 * p[1]) *
                  std::cos(numbers::PI_2 * p[2]);
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     return 0.;
   }
@@ -546,7 +546,7 @@ namespace Functions
                       std::sin(numbers::PI_2 * p[2]);
           break;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     return result;
   }
@@ -588,7 +588,7 @@ namespace Functions
                 std::cos(numbers::PI_2 * p[1]) * std::sin(numbers::PI_2 * p[2]);
               break;
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
       }
   }
@@ -642,7 +642,7 @@ namespace Functions
           }
           break;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     return result;
   }
@@ -704,7 +704,7 @@ namespace Functions
               }
               break;
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
       }
   }
@@ -737,7 +737,7 @@ namespace Functions
                   std::cos(numbers::PI_2 * p[d1]) *
                   std::cos(numbers::PI_2 * p[d2]));
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     return 0.;
   }
@@ -772,7 +772,7 @@ namespace Functions
                       std::sin(numbers::PI_2 * p[2]);
           break;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
   }
 
@@ -807,7 +807,7 @@ namespace Functions
                           std::cos(numbers::PI_2 * p[d2]);
               break;
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
       }
   }
@@ -848,7 +848,7 @@ namespace Functions
                              std::sin(numbers::PI_2 * p[2]);
               break;
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
       }
   }
@@ -897,7 +897,7 @@ namespace Functions
                        std::sin(numbers::PI_2 * p[d2]);
           break;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     return result;
   }
@@ -944,7 +944,7 @@ namespace Functions
                            std::sin(numbers::PI_2 * p[d2]);
               break;
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
       }
   }
@@ -1006,7 +1006,7 @@ namespace Functions
               }
               break;
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
       }
   }
@@ -1027,7 +1027,7 @@ namespace Functions
         case 3:
           return std::exp(p[0]) * std::exp(p[1]) * std::exp(p[2]);
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     return 0.;
   }
@@ -1056,7 +1056,7 @@ namespace Functions
               values[i] = std::exp(p[0]) * std::exp(p[1]) * std::exp(p[2]);
               break;
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
       }
   }
@@ -1074,7 +1074,7 @@ namespace Functions
         case 3:
           return 3 * std::exp(p[0]) * std::exp(p[1]) * std::exp(p[2]);
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     return 0.;
   }
@@ -1103,7 +1103,7 @@ namespace Functions
               values[i] = 3 * std::exp(p[0]) * std::exp(p[1]) * std::exp(p[2]);
               break;
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
       }
   }
@@ -1128,7 +1128,7 @@ namespace Functions
           result[2] = result[0];
           break;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     return result;
   }
@@ -1161,7 +1161,7 @@ namespace Functions
               gradients[i][2] = gradients[i][0];
               break;
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
       }
   }
@@ -1443,7 +1443,7 @@ namespace Functions
   LSingularityGradFunction::gradient(const Point<2> & /*p*/,
                                      const unsigned int /*component*/) const
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
     return {};
   }
 
@@ -1454,7 +1454,7 @@ namespace Functions
     std::vector<Tensor<1, 2>> & /*gradients*/,
     const unsigned int /*component*/) const
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 
@@ -1463,7 +1463,7 @@ namespace Functions
     const std::vector<Point<2>> & /*points*/,
     std::vector<std::vector<Tensor<1, 2>>> & /*gradients*/) const
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
   //--------------------------------------------------------------------
@@ -1813,7 +1813,7 @@ namespace Functions
           angle = std::atan2(direction[0], direction[1]);
           break;
         case 3:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     sine   = std::sin(angle);
     cosine = std::cos(angle);

--- a/source/base/function_signed_distance.cc
+++ b/source/base/function_signed_distance.cc
@@ -160,7 +160,7 @@ namespace Functions
       else if (dim == 2)
         return compute_signed_distance_ellipse(point);
       else
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
 
       return 0.0;
     }

--- a/source/base/function_spherical.cc
+++ b/source/base/function_spherical.cc
@@ -184,7 +184,7 @@ namespace Functions
                            const unsigned int /*component*/) const
 
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
     return {};
   }
 
@@ -239,7 +239,7 @@ namespace Functions
   Spherical<dim>::hessian(const Point<dim> & /*p*/,
                           const unsigned int /*component*/) const
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
     return {};
   }
 

--- a/source/base/geometric_utilities.cc
+++ b/source/base/geometric_utilities.cc
@@ -102,7 +102,7 @@ namespace GeometricUtilities
               break;
             }
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
             break;
         }
 

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -1370,7 +1370,7 @@ ParameterHandler::print_parameters(std::ostream     &out,
     }
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
 
   // dive recursively into the subsections
@@ -1682,7 +1682,7 @@ ParameterHandler::recursively_print_parameters(
     }
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
 
 
@@ -1740,7 +1740,7 @@ ParameterHandler::recursively_print_parameters(
           }
         else
           {
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
           }
 
         // then the contents of the subsection
@@ -1780,7 +1780,7 @@ ParameterHandler::recursively_print_parameters(
           }
         else
           {
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
           }
       }
 }

--- a/source/base/patterns.cc
+++ b/source/base/patterns.cc
@@ -97,7 +97,7 @@ namespace Patterns
               return u;
             }
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
       return "";
     }
@@ -179,7 +179,7 @@ namespace Patterns
     if (p != nullptr)
       return p;
 
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 
     return p;
   }

--- a/source/base/polynomials_abf.cc
+++ b/source/base/polynomials_abf.cc
@@ -173,7 +173,7 @@ PolynomialsABF<dim>::n_polynomials(const unsigned int k)
         return 3 * (k + 3) * (k + 1) * (k + 1);
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return 0;

--- a/source/base/polynomials_barycentric.cc
+++ b/source/base/polynomials_barycentric.cc
@@ -144,7 +144,7 @@ BarycentricPolynomials<dim>::get_fe_p_basis(const unsigned int degree)
           break;
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return BarycentricPolynomials<dim>(polys);

--- a/source/base/polynomials_bdm.cc
+++ b/source/base/polynomials_bdm.cc
@@ -45,7 +45,7 @@ PolynomialsBDM<dim>::PolynomialsBDM(const unsigned int k)
           monomials[i] = Polynomials::Monomial<double>(i);
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -367,7 +367,7 @@ PolynomialsBDM<dim>::n_polynomials(const unsigned int k)
     return (k + 1) * (k + 2) + 2;
   if (dim == 3)
     return ((k + 1) * (k + 2) * (k + 3)) / 2 + 3 * (k + 1);
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return 0;
 }
 

--- a/source/base/polynomials_bernardi_raugel.cc
+++ b/source/base/polynomials_bernardi_raugel.cc
@@ -244,7 +244,7 @@ PolynomialsBernardiRaugel<dim>::n_polynomials(const unsigned int k)
            GeometryInfo<dim>::faces_per_cell;
   // 2*4+4=12 polynomials in 2d and 3*8+6=30 polynomials in 3d
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return 0;
 }
 

--- a/source/base/polynomials_nedelec.cc
+++ b/source/base/polynomials_nedelec.cc
@@ -1474,7 +1474,7 @@ PolynomialsNedelec<dim>::evaluate(
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -1496,7 +1496,7 @@ PolynomialsNedelec<dim>::n_polynomials(const unsigned int k)
 
       default:
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           return 0;
         }
     }

--- a/source/base/polynomials_pyramid.cc
+++ b/source/base/polynomials_pyramid.cc
@@ -31,7 +31,7 @@ namespace
           return 5;
       }
 
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 
     return 0;
   }
@@ -153,7 +153,7 @@ ScalarLagrangePolynomialPyramid<dim>::compute_grad(const unsigned int i,
         }
       else
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
         }
     }
 
@@ -171,7 +171,7 @@ ScalarLagrangePolynomialPyramid<dim>::compute_grad_grad(
   (void)i;
   (void)p;
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return Tensor<2, dim>();
 }
 
@@ -223,7 +223,7 @@ ScalarLagrangePolynomialPyramid<dim>::compute_2nd_derivative(
   (void)i;
   (void)p;
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 
   return {};
 }
@@ -239,7 +239,7 @@ ScalarLagrangePolynomialPyramid<dim>::compute_3rd_derivative(
   (void)i;
   (void)p;
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 
   return {};
 }
@@ -255,7 +255,7 @@ ScalarLagrangePolynomialPyramid<dim>::compute_4th_derivative(
   (void)i;
   (void)p;
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 
   return {};
 }

--- a/source/base/polynomials_rannacher_turek.cc
+++ b/source/base/polynomials_rannacher_turek.cc
@@ -58,7 +58,7 @@ PolynomialsRannacherTurek<dim>::compute_value(const unsigned int i,
               1.5 * (p[0] * p[0] - p[1] * p[1]));
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return 0;
 }
 
@@ -94,7 +94,7 @@ PolynomialsRannacherTurek<dim>::compute_grad(const unsigned int i,
         }
       else
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
         }
 
       return grad;
@@ -102,7 +102,7 @@ PolynomialsRannacherTurek<dim>::compute_grad(const unsigned int i,
 
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return {};
     }
 }
@@ -151,7 +151,7 @@ PolynomialsRannacherTurek<dim>::compute_grad_grad(
 
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return {};
     }
 }

--- a/source/base/polynomials_rt_bubbles.cc
+++ b/source/base/polynomials_rt_bubbles.cc
@@ -844,7 +844,7 @@ PolynomialsRT_Bubbles<dim>::n_polynomials(const unsigned int k)
   if (dim == 1 || dim == 2 || dim == 3)
     return dim * Utilities::fixed_power<dim>(k + 1);
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return 0;
 }
 

--- a/source/base/polynomials_wedge.cc
+++ b/source/base/polynomials_wedge.cc
@@ -32,7 +32,7 @@ namespace
           return 18;
       }
 
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 
     return 0;
   }
@@ -103,7 +103,7 @@ ScalarLagrangePolynomialWedge<dim>::compute_grad_grad(const unsigned int i,
   (void)i;
   (void)p;
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return Tensor<2, dim>();
 }
 
@@ -155,7 +155,7 @@ ScalarLagrangePolynomialWedge<dim>::compute_2nd_derivative(
   (void)i;
   (void)p;
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 
   return {};
 }
@@ -171,7 +171,7 @@ ScalarLagrangePolynomialWedge<dim>::compute_3rd_derivative(
   (void)i;
   (void)p;
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 
   return {};
 }
@@ -187,7 +187,7 @@ ScalarLagrangePolynomialWedge<dim>::compute_4th_derivative(
   (void)i;
   (void)p;
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 
   return {};
 }

--- a/source/base/quadrature.cc
+++ b/source/base/quadrature.cc
@@ -485,7 +485,7 @@ template <>
 QIterated<0>::QIterated(const Quadrature<1> &, const std::vector<Point<1>> &)
   : Quadrature<0>()
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -494,7 +494,7 @@ template <>
 QIterated<0>::QIterated(const Quadrature<1> &, const unsigned int)
   : Quadrature<0>()
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 

--- a/source/base/quadrature_lib.cc
+++ b/source/base/quadrature_lib.cc
@@ -217,7 +217,7 @@ namespace internal
             q_points[7] = 0.977520613561287499;
             break;
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
             break;
         }
       return q_points;
@@ -624,7 +624,7 @@ QGaussLog<1>::get_quadrature_points(const unsigned int n)
         break;
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         break;
     }
 
@@ -756,7 +756,7 @@ QGaussLog<1>::get_quadrature_weights(const unsigned int n)
         break;
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         break;
     }
 
@@ -1903,7 +1903,7 @@ QWitherdenVincentSimplex<dim>::QWitherdenVincentSimplex(
                 }
               break;
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
         break;
       case 2:
@@ -2160,7 +2160,7 @@ QWitherdenVincentSimplex<dim>::QWitherdenVincentSimplex(
                 }
               break;
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
         break;
       case 6:
@@ -2251,7 +2251,7 @@ QWitherdenVincentSimplex<dim>::QWitherdenVincentSimplex(
           }
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   Assert(b_point_permutations.size() == b_weights.size(), ExcInternalError());
@@ -2342,7 +2342,7 @@ QIteratedSimplex<dim>::QIteratedSimplex(const Quadrature<dim> &base_quad,
           break;
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 

--- a/source/base/scalar_polynomials_base.cc
+++ b/source/base/scalar_polynomials_base.cc
@@ -38,7 +38,7 @@ template <int dim>
 std::size_t
 ScalarPolynomialsBase<dim>::memory_consumption() const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return 0;
 }
 

--- a/source/base/tensor_product_polynomials.cc
+++ b/source/base/tensor_product_polynomials.cc
@@ -42,7 +42,7 @@ namespace internal
                          const unsigned int,
                          std::array<unsigned int, dim> &)
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
 
     inline void

--- a/source/base/tensor_product_polynomials_bubbles.cc
+++ b/source/base/tensor_product_polynomials_bubbles.cc
@@ -99,7 +99,7 @@ double
 TensorProductPolynomialsBubbles<0>::compute_value(const unsigned int,
                                                   const Point<0> &) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return 0.;
 }
 

--- a/source/base/tensor_product_polynomials_const.cc
+++ b/source/base/tensor_product_polynomials_const.cc
@@ -87,7 +87,7 @@ double
 TensorProductPolynomialsConst<0>::compute_value(const unsigned int,
                                                 const Point<0> &) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return 0.;
 }
 

--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -522,7 +522,7 @@ TimerOutput::get_summary_data(const OutputData kind) const
             output[section.first] = section.second.n_calls;
             break;
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
     }
   return output;

--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -876,7 +876,7 @@ namespace Utilities
           return std::make_pair(i, 7U);
         else
           {
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
             return std::make_pair(-1, numbers::invalid_unsigned_int);
           }
       }

--- a/source/cgal/intersections.cc
+++ b/source/cgal/intersections.cc
@@ -811,7 +811,7 @@ namespace CGALWrappers
       }
     else
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return {};
       }
     (void)tol;

--- a/source/distributed/fully_distributed_tria.cc
+++ b/source/distributed/fully_distributed_tria.cc
@@ -351,7 +351,7 @@ namespace parallel
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     void Triangulation<dim, spacedim>::execute_coarsening_and_refinement()
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
 
 

--- a/source/distributed/grid_refinement.cc
+++ b/source/distributed/grid_refinement.cc
@@ -628,7 +628,7 @@ namespace parallel
               break;
 
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
               break;
           }
       }

--- a/source/distributed/p4est_wrappers.cc
+++ b/source/distributed/p4est_wrappers.cc
@@ -793,7 +793,7 @@ namespace internal
               P8EST_QUADRANT_INIT(&p4est_children[c]);
               break;
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
 
 
@@ -813,7 +813,7 @@ namespace internal
             P8EST_QUADRANT_INIT(&quad);
             break;
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
       functions<dim>::quadrant_set_morton(&quad,
                                           /*level=*/0,

--- a/source/distributed/shared_tria.cc
+++ b/source/distributed/shared_tria.cc
@@ -494,7 +494,7 @@ namespace parallel
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     bool Triangulation<dim, spacedim>::with_artificial_cells() const
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return true;
     }
 
@@ -515,7 +515,7 @@ namespace parallel
     const std::vector<unsigned int>
       &Triangulation<dim, spacedim>::get_true_subdomain_ids_of_cells() const
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return true_subdomain_ids_of_cells;
     }
 
@@ -527,7 +527,7 @@ namespace parallel
       &Triangulation<dim, spacedim>::get_true_level_subdomain_ids_of_cells(
         const unsigned int) const
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return true_level_subdomain_ids_of_cells;
     }
   } // namespace shared

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -247,7 +247,7 @@ namespace
                     }
 
                   default:
-                    Assert(false, ExcNotImplemented());
+                    DEAL_II_NOT_IMPLEMENTED();
                 }
             }
           else
@@ -419,7 +419,7 @@ namespace
                 P8EST_QUADRANT_INIT(&p4est_child[c]);
                 break;
               default:
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
             }
 
 
@@ -487,7 +487,7 @@ namespace
                     P8EST_QUADRANT_INIT(&p4est_child[c]);
                     break;
                   default:
-                    Assert(false, ExcNotImplemented());
+                    DEAL_II_NOT_IMPLEMENTED();
                 }
 
 
@@ -1345,7 +1345,7 @@ namespace
                 P8EST_QUADRANT_INIT(&p4est_child[c]);
                 break;
               default:
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
             }
         internal::p4est::functions<dim>::quadrant_childrenv(&p4est_cell,
                                                             p4est_child);
@@ -1635,7 +1635,7 @@ namespace
                 P8EST_QUADRANT_INIT(&p4est_child[c]);
                 break;
               default:
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
             }
 
         dealii::internal::p4est::functions<dim>::quadrant_childrenv(
@@ -1676,7 +1676,7 @@ namespace
                 P8EST_QUADRANT_INIT(&p4est_child[c]);
                 break;
               default:
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
             }
 
         dealii::internal::p4est::functions<dim>::quadrant_childrenv(
@@ -4133,7 +4133,7 @@ namespace parallel
           smooth_grid,
           false)
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
 
 
@@ -4165,7 +4165,7 @@ namespace parallel
       compute_level_vertices_with_ghost_neighbors(
         const unsigned int /*level*/) const
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
 
       return std::map<unsigned int, std::set<dealii::types::subdomain_id>>();
     }
@@ -4177,7 +4177,7 @@ namespace parallel
     std::vector<bool> Triangulation<1, spacedim>::
       mark_locally_active_vertices_on_level(const unsigned int) const
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return std::vector<bool>();
     }
 
@@ -4188,7 +4188,7 @@ namespace parallel
     unsigned int Triangulation<1, spacedim>::
       coarse_cell_id_to_coarse_cell_index(const types::coarse_cell_id) const
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return 0;
     }
 
@@ -4200,7 +4200,7 @@ namespace parallel
       Triangulation<1, spacedim>::coarse_cell_index_to_coarse_cell_id(
         const unsigned int) const
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return 0;
     }
 
@@ -4210,7 +4210,7 @@ namespace parallel
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<1, spacedim>))
     void Triangulation<1, spacedim>::load(const std::string &)
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
 
 
@@ -4219,7 +4219,7 @@ namespace parallel
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<1, spacedim>))
     void Triangulation<1, spacedim>::load(const std::string &, const bool)
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
 
 
@@ -4228,7 +4228,7 @@ namespace parallel
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<1, spacedim>))
     void Triangulation<1, spacedim>::save(const std::string &) const
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
 
 
@@ -4237,7 +4237,7 @@ namespace parallel
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<1, spacedim>))
     bool Triangulation<1, spacedim>::is_multilevel_hierarchy_constructed() const
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return false;
     }
 
@@ -4247,7 +4247,7 @@ namespace parallel
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<1, spacedim>))
     bool Triangulation<1, spacedim>::are_vertices_communicated_to_p4est() const
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return false;
     }
 
@@ -4257,7 +4257,7 @@ namespace parallel
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<1, spacedim>))
     void Triangulation<1, spacedim>::update_cell_relations()
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
 
   } // namespace distributed

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -218,7 +218,7 @@ namespace internal
               break;
 
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
               max_couplings = 0;
           }
         return std::min(max_couplings, dof_handler.n_dofs());
@@ -249,7 +249,7 @@ namespace internal
             27 * dof_handler.fe_collection.max_dofs_per_hex();
         else
           {
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
             max_couplings = 0;
           }
 
@@ -2580,7 +2580,7 @@ unsigned int DoFHandler<dim, spacedim>::max_couplings_between_boundary_dofs()
                 28 * this->fe_collection.max_dofs_per_line() +
                 8 * this->fe_collection.max_dofs_per_quad());
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return 0;
     }
 }

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -125,7 +125,7 @@ namespace internal
                     }
 
                   default:
-                    Assert(false, ExcNotImplemented());
+                    DEAL_II_NOT_IMPLEMENTED();
                 }
 
 #ifdef DEBUG
@@ -3225,7 +3225,7 @@ namespace internal
       {
 #ifndef DEAL_II_WITH_MPI
         (void)new_numbers;
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return NumberCache();
 #else
         // Similar to distribute_dofs() we need to have a special treatment in
@@ -3386,7 +3386,7 @@ namespace internal
         const std::vector<types::global_dof_index> & /*new_numbers*/) const
       {
         // multigrid is not currently implemented for shared triangulations
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
 
         return {};
       }
@@ -3503,7 +3503,7 @@ namespace internal
         {
 #  ifndef DEAL_II_WITH_MPI
           (void)dof_handler;
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
 #  else
 
           // define functions that pack data on cells that are ghost cells
@@ -3605,7 +3605,7 @@ namespace internal
       ParallelDistributed<dim, spacedim>::distribute_dofs() const
       {
 #ifndef DEAL_II_WITH_MPI
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return NumberCache();
 #else
 
@@ -3813,7 +3813,7 @@ namespace internal
       ParallelDistributed<dim, spacedim>::distribute_mg_dofs() const
       {
 #ifndef DEAL_II_WITH_MPI
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return std::vector<NumberCache>();
 #else
 
@@ -3995,7 +3995,7 @@ namespace internal
                ExcInternalError());
 
 #ifndef DEAL_II_WITH_MPI
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return NumberCache();
 #else
 
@@ -4129,7 +4129,7 @@ namespace internal
         (void)level;
         (void)new_numbers;
 
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return NumberCache();
 #else
 

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -1406,7 +1406,7 @@ namespace DoFRenumbering
                                                   renumbering);
           }
 #else
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
 #endif
       }
     else

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -913,7 +913,7 @@ FiniteElement<dim, spacedim>::interface_constraints_size() const
                   4 * this->n_dofs_per_quad(face_no),
                 this->n_dofs_per_face(face_no)};
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   return {numbers::invalid_unsigned_int, numbers::invalid_unsigned_int};
 }
@@ -976,7 +976,7 @@ std::vector<std::pair<unsigned int, unsigned int>>
 FiniteElement<dim, spacedim>::hp_vertex_dof_identities(
   const FiniteElement<dim, spacedim> &) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return std::vector<std::pair<unsigned int, unsigned int>>();
 }
 
@@ -987,7 +987,7 @@ std::vector<std::pair<unsigned int, unsigned int>>
 FiniteElement<dim, spacedim>::hp_line_dof_identities(
   const FiniteElement<dim, spacedim> &) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return std::vector<std::pair<unsigned int, unsigned int>>();
 }
 
@@ -999,7 +999,7 @@ FiniteElement<dim, spacedim>::hp_quad_dof_identities(
   const FiniteElement<dim, spacedim> &,
   const unsigned int) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return std::vector<std::pair<unsigned int, unsigned int>>();
 }
 
@@ -1011,7 +1011,7 @@ FiniteElement<dim, spacedim>::compare_for_domination(
   const FiniteElement<dim, spacedim> &,
   const unsigned int) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return FiniteElementDomination::neither_element_dominates;
 }
 
@@ -1212,7 +1212,7 @@ template <int dim, int spacedim>
 std::pair<Table<2, bool>, std::vector<unsigned int>>
 FiniteElement<dim, spacedim>::get_constant_modes() const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return std::pair<Table<2, bool>, std::vector<unsigned int>>(
     Table<2, bool>(this->n_components(), this->n_dofs_per_cell()),
     std::vector<unsigned int>(this->n_components()));
@@ -1233,7 +1233,7 @@ FiniteElement<dim, spacedim>::
                     "the glossary for a definition of generalized support "
                     "points). Consequently, the current function can not "
                     "be defined and is not implemented by the element."));
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 

--- a/source/fe/fe_abf.cc
+++ b/source/fe/fe_abf.cc
@@ -645,7 +645,7 @@ template <int dim>
 std::size_t
 FE_ABF<dim>::memory_consumption() const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return 0;
 }
 

--- a/source/fe/fe_bernstein.cc
+++ b/source/fe/fe_bernstein.cc
@@ -248,7 +248,7 @@ FE_Bernstein<dim, spacedim>::hp_vertex_dof_identities(
     }
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
 }
@@ -327,7 +327,7 @@ FE_Bernstein<dim, spacedim>::compare_for_domination(
         return FiniteElementDomination::no_requirements;
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return FiniteElementDomination::neither_element_dominates;
 }
 

--- a/source/fe/fe_dgp.cc
+++ b/source/fe/fe_dgp.cc
@@ -174,7 +174,7 @@ FE_DGP<dim, spacedim>::hp_vertex_dof_identities(
     return std::vector<std::pair<unsigned int, unsigned int>>();
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
 }
@@ -191,7 +191,7 @@ FE_DGP<dim, spacedim>::hp_line_dof_identities(
     return std::vector<std::pair<unsigned int, unsigned int>>();
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
 }
@@ -209,7 +209,7 @@ FE_DGP<dim, spacedim>::hp_quad_dof_identities(
     return std::vector<std::pair<unsigned int, unsigned int>>();
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
 }
@@ -256,7 +256,7 @@ FE_DGP<dim, spacedim>::compare_for_domination(
         return FiniteElementDomination::no_requirements;
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return FiniteElementDomination::neither_element_dominates;
 }
 
@@ -289,7 +289,7 @@ template <int dim, int spacedim>
 std::size_t
 FE_DGP<dim, spacedim>::memory_consumption() const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return 0;
 }
 

--- a/source/fe/fe_dgp_monomial.cc
+++ b/source/fe/fe_dgp_monomial.cc
@@ -252,7 +252,7 @@ template <int dim>
 void
 FE_DGPMonomial<dim>::initialize_restriction()
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -351,7 +351,7 @@ FE_DGPMonomial<dim>::hp_vertex_dof_identities(
     return std::vector<std::pair<unsigned int, unsigned int>>();
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
 }
@@ -369,7 +369,7 @@ FE_DGPMonomial<dim>::hp_line_dof_identities(
     return std::vector<std::pair<unsigned int, unsigned int>>();
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
 }
@@ -387,7 +387,7 @@ FE_DGPMonomial<dim>::hp_quad_dof_identities(const FiniteElement<dim> &fe_other,
     return std::vector<std::pair<unsigned int, unsigned int>>();
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
 }
@@ -433,7 +433,7 @@ FE_DGPMonomial<dim>::compare_for_domination(const FiniteElement<dim> &fe_other,
         return FiniteElementDomination::no_requirements;
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return FiniteElementDomination::neither_element_dominates;
 }
 
@@ -504,7 +504,7 @@ template <int dim>
 std::size_t
 FE_DGPMonomial<dim>::memory_consumption() const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return 0;
 }
 

--- a/source/fe/fe_dgp_nonparametric.cc
+++ b/source/fe/fe_dgp_nonparametric.cc
@@ -545,7 +545,7 @@ FE_DGPNonparametric<dim, spacedim>::hp_vertex_dof_identities(
     return std::vector<std::pair<unsigned int, unsigned int>>();
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
 }
@@ -564,7 +564,7 @@ FE_DGPNonparametric<dim, spacedim>::hp_line_dof_identities(
     return std::vector<std::pair<unsigned int, unsigned int>>();
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
 }
@@ -584,7 +584,7 @@ FE_DGPNonparametric<dim, spacedim>::hp_quad_dof_identities(
     return std::vector<std::pair<unsigned int, unsigned int>>();
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
 }
@@ -631,7 +631,7 @@ FE_DGPNonparametric<dim, spacedim>::compare_for_domination(
         return FiniteElementDomination::no_requirements;
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return FiniteElementDomination::neither_element_dominates;
 }
 
@@ -652,7 +652,7 @@ template <int dim, int spacedim>
 std::size_t
 FE_DGPNonparametric<dim, spacedim>::memory_consumption() const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return 0;
 }
 

--- a/source/fe/fe_dgq.cc
+++ b/source/fe/fe_dgq.cc
@@ -261,7 +261,7 @@ FE_DGQ<dim, spacedim>::rotate_indices(std::vector<unsigned int> &numbers,
                   }
             break;
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
     }
 }
@@ -737,7 +737,7 @@ FE_DGQ<dim, spacedim>::compare_for_domination(
         return FiniteElementDomination::no_requirements;
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return FiniteElementDomination::neither_element_dominates;
 }
 
@@ -827,7 +827,7 @@ FE_DGQ<dim, spacedim>::has_support_on_face(const unsigned int shape_index,
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   return true;
 }

--- a/source/fe/fe_enriched.cc
+++ b/source/fe/fe_enriched.cc
@@ -950,7 +950,7 @@ FE_Enriched<dim, spacedim>::hp_vertex_dof_identities(
     }
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
 }
@@ -968,7 +968,7 @@ FE_Enriched<dim, spacedim>::hp_line_dof_identities(
     }
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
 }
@@ -988,7 +988,7 @@ FE_Enriched<dim, spacedim>::hp_quad_dof_identities(
     }
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
 }
@@ -1022,7 +1022,7 @@ FE_Enriched<dim, spacedim>::compare_for_domination(
     }
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return FiniteElementDomination::neither_element_dominates;
     }
 }

--- a/source/fe/fe_face.cc
+++ b/source/fe/fe_face.cc
@@ -356,7 +356,7 @@ FE_FaceQ<dim, spacedim>::hp_line_dof_identities(
         }
       else
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           return std::vector<std::pair<unsigned int, unsigned int>>();
         }
     }
@@ -435,7 +435,7 @@ FE_FaceQ<dim, spacedim>::hp_quad_dof_identities(
         }
       else
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           return std::vector<std::pair<unsigned int, unsigned int>>();
         }
     }
@@ -476,7 +476,7 @@ FE_FaceQ<dim, spacedim>::compare_for_domination(
         return FiniteElementDomination::no_requirements;
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return FiniteElementDomination::neither_element_dominates;
 }
 
@@ -861,7 +861,7 @@ FE_FaceP<dim, spacedim>::compare_for_domination(
         return FiniteElementDomination::no_requirements;
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return FiniteElementDomination::neither_element_dominates;
 }
 

--- a/source/fe/fe_hermite.cc
+++ b/source/fe/fe_hermite.cc
@@ -584,12 +584,12 @@ FE_Hermite<dim, spacedim>::hp_vertex_dof_identities(
   else if (const FE_Hermite<dim, spacedim> *fe_herm_other =
              dynamic_cast<const FE_Hermite<dim, spacedim> *>(&fe_other))
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return {};
     }
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return {};
     }
 }
@@ -733,7 +733,7 @@ FE_Hermite<dim, spacedim>::compare_for_domination(
         return FiniteElementDomination::no_requirements;
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return FiniteElementDomination::neither_element_dominates;
 }
 

--- a/source/fe/fe_nedelec.cc
+++ b/source/fe/fe_nedelec.cc
@@ -203,7 +203,7 @@ FE_Nedelec<dim>::FE_Nedelec(const unsigned int order)
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   // We need to initialize the dof permutation table and the one for the sign
@@ -266,7 +266,7 @@ template <>
 void
 FE_Nedelec<1>::initialize_support_points(const unsigned int)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -2049,7 +2049,7 @@ FE_Nedelec<dim>::initialize_restriction()
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -2139,7 +2139,7 @@ FE_Nedelec<dim>::has_support_on_face(const unsigned int shape_index,
 
             default:
               {
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
                 return false;
               }
           }
@@ -2318,14 +2318,14 @@ FE_Nedelec<dim>::has_support_on_face(const unsigned int shape_index,
 
             default:
               {
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
                 return false;
               }
           }
 
       default:
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           return false;
         }
     }
@@ -2363,7 +2363,7 @@ FE_Nedelec<dim>::compare_for_domination(const FiniteElement<dim> &fe_other,
         return FiniteElementDomination::no_requirements;
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return FiniteElementDomination::neither_element_dominates;
 }
 
@@ -2420,7 +2420,7 @@ FE_Nedelec<dim>::hp_line_dof_identities(
 
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
 }
@@ -2467,7 +2467,7 @@ FE_Nedelec<dim>::hp_quad_dof_identities(const FiniteElement<dim> &fe_other,
 
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
 }
@@ -2565,7 +2565,7 @@ FE_Nedelec<1>::get_subface_interpolation_matrix(const FiniteElement<1, 1> &,
                                                 FullMatrix<double> &,
                                                 const unsigned int) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -3021,7 +3021,7 @@ FE_Nedelec<dim>::get_subface_interpolation_matrix(
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -4090,7 +4090,7 @@ FE_Nedelec<dim>::convert_generalized_support_point_values_to_dof_values(
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -4116,7 +4116,7 @@ template <int dim>
 std::size_t
 FE_Nedelec<dim>::memory_consumption() const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return 0;
 }
 
@@ -4173,7 +4173,7 @@ FE_Nedelec<dim>::get_embedding_dofs(const unsigned int sub_degree) const
           return embedding_dofs;
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return std::vector<unsigned int>();
     }
 }

--- a/source/fe/fe_nedelec_sz.cc
+++ b/source/fe/fe_nedelec_sz.cc
@@ -142,7 +142,7 @@ FE_NedelecSZ<dim, spacedim>::FE_NedelecSZ(const unsigned int order)
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -168,7 +168,7 @@ FE_NedelecSZ<dim, spacedim>::shape_value_component(
   const unsigned int /*component*/) const
 {
   // Not implemented yet:
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return 0.;
 }
 
@@ -192,7 +192,7 @@ FE_NedelecSZ<dim, spacedim>::shape_grad_component(
   const Point<dim> & /*p*/,
   const unsigned int /*component*/) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return Tensor<1, dim>();
 }
 
@@ -216,7 +216,7 @@ FE_NedelecSZ<dim, spacedim>::shape_grad_grad_component(
   const Point<dim> & /*p*/,
   const unsigned int /*component*/) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return Tensor<2, dim>();
 }
 
@@ -1558,7 +1558,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
         }
       default:
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
         }
     }
   return data_ptr;
@@ -2257,7 +2257,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
         }
       default:
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
         }
     }
 }
@@ -3305,7 +3305,7 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_subface_values(
   dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, dim>
     & /*data*/) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -3399,7 +3399,7 @@ FE_NedelecSZ<dim, spacedim>::compute_num_dofs(const unsigned int degree) const
 
       default:
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           return 0;
         }
     }

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -613,7 +613,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
                 }
 
               default:
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
             }
         }
 
@@ -756,7 +756,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
                 }
 
               default:
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
             }
         }
 
@@ -1030,7 +1030,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
                 }
 
               default:
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
             }
         }
 
@@ -1041,7 +1041,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
             (mapping_kind == mapping_raviart_thomas) ||
             (mapping_kind == mapping_nedelec))))
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
         }
     }
 }
@@ -1252,7 +1252,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_face_values(
                 }
 
               default:
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
             }
         }
 
@@ -1420,7 +1420,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_face_values(
                 }
 
               default:
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
             }
         }
 
@@ -1718,14 +1718,14 @@ FE_PolyTensor<dim, spacedim>::fill_fe_face_values(
                 }
 
               default:
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
             }
         }
 
       // third derivatives are not implemented
       if (fe_data.update_each & update_3rd_derivatives)
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
         }
     }
 }
@@ -1940,7 +1940,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_subface_values(
                 }
 
               default:
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
             }
         }
 
@@ -2094,7 +2094,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_subface_values(
                 }
 
               default:
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
             }
         }
 
@@ -2391,14 +2391,14 @@ FE_PolyTensor<dim, spacedim>::fill_fe_subface_values(
                 }
 
               default:
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
             }
         }
 
       // third derivatives are not implemented
       if (fe_data.update_each & update_3rd_derivatives)
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
         }
     }
 }
@@ -2497,7 +2497,7 @@ FE_PolyTensor<dim, spacedim>::requires_update_flags(
 
           default:
             {
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
             }
         }
     }

--- a/source/fe/fe_pyramid_p.cc
+++ b/source/fe/fe_pyramid_p.cc
@@ -48,7 +48,7 @@ namespace
       }
     else
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
       }
 
     return dpo;
@@ -65,7 +65,7 @@ namespace
     if (degree == 1)
       n_dofs = 5;
     else
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
 
     return internal::expand(3, {{0, 0, 0, n_dofs}}, ReferenceCells::Pyramid);
   }
@@ -114,7 +114,7 @@ FE_PyramidPoly<dim, spacedim>::FE_PyramidPoly(
         }
     }
   else
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -235,7 +235,7 @@ FE_PyramidP<dim, spacedim>::compare_for_domination(
         return FiniteElementDomination::no_requirements;
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return FiniteElementDomination::neither_element_dominates;
 }
 

--- a/source/fe/fe_q.cc
+++ b/source/fe/fe_q.cc
@@ -268,7 +268,7 @@ FE_Q<dim, spacedim>::compare_for_domination(
         return FiniteElementDomination::neither_element_dominates;
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return FiniteElementDomination::neither_element_dominates;
 }
 

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -487,7 +487,7 @@ FE_Q_Base<dim, spacedim>::initialize(const std::vector<Point<1>> &points)
         tensor_const_poly_space_ptr->set_numbering(renumber);
         return;
       }
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }();
 
   // Finally fill in support points on cell and face and initialize
@@ -782,7 +782,7 @@ FE_Q_Base<dim, spacedim>::hp_vertex_dof_identities(
     }
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return {};
     }
 }
@@ -877,7 +877,7 @@ FE_Q_Base<dim, spacedim>::hp_line_dof_identities(
     }
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return {};
     }
 }
@@ -947,7 +947,7 @@ FE_Q_Base<dim, spacedim>::hp_quad_dof_identities(
     }
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
 }
@@ -1658,7 +1658,7 @@ FE_Q_Base<dim, spacedim>::has_support_on_face(
           return false;
         }
       else
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   else if (shape_index < this->get_first_hex_index())
     // dof is on a quad
@@ -1678,13 +1678,13 @@ FE_Q_Base<dim, spacedim>::has_support_on_face(
       if (dim == 3)
         return (quad_index == face_index);
       else
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   else
     // dof on hex
     {
       // can only happen in 3d, but this case has already been covered above
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return false;
     }
 

--- a/source/fe/fe_q_bubbles.cc
+++ b/source/fe/fe_q_bubbles.cc
@@ -545,7 +545,7 @@ FE_Q_Bubbles<dim, spacedim>::compare_for_domination(
         return FiniteElementDomination::no_requirements;
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return FiniteElementDomination::neither_element_dominates;
 }
 

--- a/source/fe/fe_q_dg0.cc
+++ b/source/fe/fe_q_dg0.cc
@@ -333,7 +333,7 @@ FE_Q_DG0<dim, spacedim>::compare_for_domination(
         return FiniteElementDomination::no_requirements;
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return FiniteElementDomination::neither_element_dominates;
 }
 

--- a/source/fe/fe_q_hierarchical.cc
+++ b/source/fe/fe_q_hierarchical.cc
@@ -252,7 +252,7 @@ FE_Q_Hierarchical<dim>::hp_vertex_dof_identities(
     }
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
 }
@@ -290,7 +290,7 @@ FE_Q_Hierarchical<dim>::hp_line_dof_identities(
     }
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
 }
@@ -334,7 +334,7 @@ FE_Q_Hierarchical<dim>::hp_quad_dof_identities(
     }
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
 }
@@ -381,7 +381,7 @@ FE_Q_Hierarchical<dim>::compare_for_domination(
         return FiniteElementDomination::no_requirements;
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return FiniteElementDomination::neither_element_dominates;
 }
 
@@ -667,7 +667,7 @@ FE_Q_Hierarchical<dim>::initialize_constraints(
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -806,7 +806,7 @@ FE_Q_Hierarchical<dim>::initialize_embedding_and_restriction(
             }
 
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
 }
 
@@ -2152,7 +2152,7 @@ FE_Q_Hierarchical<dim>::hierarchic_to_fe_q_hierarchical_numbering(
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   return h2l;
 }
@@ -2271,7 +2271,7 @@ FE_Q_Hierarchical<dim>::has_support_on_face(const unsigned int shape_index,
       if (dim == 3)
         return (quad_index == face_index);
       else
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   else
     // dof on hex
@@ -2279,7 +2279,7 @@ FE_Q_Hierarchical<dim>::has_support_on_face(const unsigned int shape_index,
       // can only happen in 3d, but
       // this case has already been
       // covered above
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return false;
     }
 
@@ -2423,7 +2423,7 @@ FE_Q_Hierarchical<dim>::get_embedding_dofs(const unsigned int sub_degree) const
     }
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return std::vector<unsigned int>();
     }
 }
@@ -2451,7 +2451,7 @@ template <int dim>
 std::size_t
 FE_Q_Hierarchical<dim>::memory_consumption() const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return 0;
 }
 

--- a/source/fe/fe_q_iso_q1.cc
+++ b/source/fe/fe_q_iso_q1.cc
@@ -174,7 +174,7 @@ FE_Q_iso_Q1<dim, spacedim>::compare_for_domination(
         return FiniteElementDomination::no_requirements;
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return FiniteElementDomination::neither_element_dominates;
 }
 

--- a/source/fe/fe_raviart_thomas.cc
+++ b/source/fe/fe_raviart_thomas.cc
@@ -725,7 +725,7 @@ template <int dim>
 std::size_t
 FE_RaviartThomas<dim>::memory_consumption() const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return 0;
 }
 

--- a/source/fe/fe_raviart_thomas_nodal.cc
+++ b/source/fe/fe_raviart_thomas_nodal.cc
@@ -314,7 +314,7 @@ FE_RaviartThomasNodal<dim>::hp_vertex_dof_identities(
     return std::vector<std::pair<unsigned int, unsigned int>>();
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
 }
@@ -370,7 +370,7 @@ FE_RaviartThomasNodal<dim>::hp_line_dof_identities(
     }
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
 }
@@ -416,7 +416,7 @@ FE_RaviartThomasNodal<dim>::hp_quad_dof_identities(
     }
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
 }
@@ -455,7 +455,7 @@ FE_RaviartThomasNodal<dim>::compare_for_domination(
         return FiniteElementDomination::no_requirements;
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return FiniteElementDomination::neither_element_dominates;
 }
 

--- a/source/fe/fe_rt_bubbles.cc
+++ b/source/fe/fe_rt_bubbles.cc
@@ -237,7 +237,7 @@ FE_RT_Bubbles<dim>::initialize_support_points(const unsigned int deg)
                                                   ((d == 2) ? low : high));
             break;
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
 
       for (unsigned int k = 0; k < quadrature->size(); ++k)

--- a/source/fe/fe_simplex_p.cc
+++ b/source/fe/fe_simplex_p.cc
@@ -72,7 +72,7 @@ namespace
               case 3:
                 return {1, 2};
               default:
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
             }
         case 2:
           switch (degree)
@@ -84,7 +84,7 @@ namespace
               case 3:
                 return {1, 2, 1};
               default:
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
             }
         case 3:
           switch (degree)
@@ -96,11 +96,11 @@ namespace
               case 3:
                 return {1, 2, 1, 0};
               default:
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
             }
       }
 
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
     return {};
   }
 
@@ -312,7 +312,7 @@ namespace
                   continuous_dpo[dim]};
           }
 
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return {};
       }
   }
@@ -709,7 +709,7 @@ FE_SimplexP<dim, spacedim>::compare_for_domination(
         return FiniteElementDomination::no_requirements;
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return FiniteElementDomination::neither_element_dominates;
 }
 
@@ -753,7 +753,7 @@ FE_SimplexP<dim, spacedim>::hp_vertex_dof_identities(
     }
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return {};
     }
 }
@@ -857,7 +857,7 @@ FE_SimplexP<dim, spacedim>::hp_line_dof_identities(
     }
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return {};
     }
 }
@@ -950,7 +950,7 @@ FE_SimplexDGP<dim, spacedim>::compare_for_domination(
         return FiniteElementDomination::no_requirements;
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return FiniteElementDomination::neither_element_dominates;
 }
 

--- a/source/fe/fe_simplex_p_bubbles.cc
+++ b/source/fe/fe_simplex_p_bubbles.cc
@@ -111,7 +111,7 @@ namespace FE_P_BubblesImplementation
             return points;
           }
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     return points;
   }

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -1718,7 +1718,7 @@ FESystem<dim, spacedim>::build_interface_constraints()
               }
 
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
 
         // now that we gathered all information: use it to build the
@@ -2356,7 +2356,7 @@ FESystem<dim, spacedim>::hp_object_dof_identities(
                   base.hp_quad_dof_identities(base_other, face_no);
                 break;
               default:
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
             }
 
           for (const auto &base_identity : base_identities)
@@ -2404,7 +2404,7 @@ FESystem<dim, spacedim>::hp_object_dof_identities(
     }
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
 }
@@ -2484,7 +2484,7 @@ FESystem<dim, spacedim>::compare_for_domination(
       return domination;
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return FiniteElementDomination::neither_element_dominates;
 }
 

--- a/source/fe/fe_trace.cc
+++ b/source/fe/fe_trace.cc
@@ -207,7 +207,7 @@ FE_TraceQ<dim, spacedim>::compare_for_domination(
         return FiniteElementDomination::no_requirements;
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return FiniteElementDomination::neither_element_dominates;
 }
 

--- a/source/fe/fe_values_views_internal.cc
+++ b/source/fe/fe_values_views_internal.cc
@@ -914,7 +914,7 @@ namespace FEValuesViews
                 if (shape_function_data[shape_function]
                       .is_nonzero_shape_function_component[d])
                   {
-                    Assert(false, ExcNotImplemented());
+                    DEAL_II_NOT_IMPLEMENTED();
 
                     // the following implementation needs to be looked over -- I
                     // think it can't be right, because we are in a case where
@@ -1084,7 +1084,7 @@ namespace FEValuesViews
                 if (shape_function_data[shape_function]
                       .is_nonzero_shape_function_component[d])
                   {
-                    Assert(false, ExcNotImplemented());
+                    DEAL_II_NOT_IMPLEMENTED();
                   }
             }
         }
@@ -1154,7 +1154,7 @@ namespace FEValuesViews
                 if (shape_function_data[shape_function]
                       .is_nonzero_shape_function_component[d])
                   {
-                    Assert(false, ExcNotImplemented());
+                    DEAL_II_NOT_IMPLEMENTED();
                   }
             }
         }

--- a/source/fe/fe_wedge_p.cc
+++ b/source/fe/fe_wedge_p.cc
@@ -55,7 +55,7 @@ namespace
       }
     else
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
       }
 
     return dpo;
@@ -74,7 +74,7 @@ namespace
     else if (degree == 2)
       n_dofs = 18;
     else
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
 
     return internal::expand(3, {{0, 0, 0, n_dofs}}, ReferenceCells::Wedge);
   }
@@ -256,7 +256,7 @@ FE_WedgeP<dim, spacedim>::compare_for_domination(
         return FiniteElementDomination::no_requirements;
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return FiniteElementDomination::neither_element_dominates;
 }
 

--- a/source/fe/mapping_c1.cc
+++ b/source/fe/mapping_c1.cc
@@ -160,7 +160,7 @@ MappingC1<dim, spacedim>::add_line_support_points(
   const typename Triangulation<dim>::cell_iterator &,
   std::vector<Point<dim>> &) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -195,7 +195,7 @@ MappingC1<dim, spacedim>::add_quad_support_points(
   const typename Triangulation<dim>::cell_iterator &,
   std::vector<Point<dim>> &) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 

--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -255,7 +255,7 @@ MappingCartesian<dim, spacedim>::update_cell_extents(
             data.cell_extents[2] = cell->vertex(4)[2] - start[2];
             break;
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
     }
 }
@@ -811,7 +811,7 @@ MappingCartesian<dim, spacedim>::transform(
           return;
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -921,7 +921,7 @@ MappingCartesian<dim, spacedim>::transform(
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -1031,7 +1031,7 @@ MappingCartesian<dim, spacedim>::transform(
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -1070,7 +1070,7 @@ MappingCartesian<dim, spacedim>::transform(
           return;
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -1158,7 +1158,7 @@ MappingCartesian<dim, spacedim>::transform(
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -1189,7 +1189,7 @@ MappingCartesian<dim, spacedim>::transform_unit_to_real_cell(
         length[2] = cell->vertex(4)[2] - start[2];
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   Point<dim> p_real = cell->vertex(0);
@@ -1210,7 +1210,7 @@ MappingCartesian<dim, spacedim>::transform_real_to_unit_cell(
   Assert(is_cartesian(cell), ExcCellNotCartesian());
 
   if (dim != spacedim)
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   const Point<dim> &start = cell->vertex(0);
   Point<dim>        real  = p;
   real -= start;
@@ -1230,7 +1230,7 @@ MappingCartesian<dim, spacedim>::transform_real_to_unit_cell(
         real[2] /= cell->vertex(4)[2] - start[2];
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   return real;
 }

--- a/source/fe/mapping_fe.cc
+++ b/source/fe/mapping_fe.cc
@@ -1420,7 +1420,7 @@ namespace internal
                               cross_product_3d(data.aux[0][i], data.aux[1][i]);
                             break;
                           default:
-                            Assert(false, ExcNotImplemented());
+                            DEAL_II_NOT_IMPLEMENTED();
                         }
                   }
                 else //(dim < spacedim)
@@ -1478,7 +1478,7 @@ namespace internal
                           cell->subface_case(face_no), subface_no);
                        output_data.JxW_values[i] *= area_ratio;
 #else
-                      Assert(false, ExcNotImplemented());
+                      DEAL_II_NOT_IMPLEMENTED();
 #endif
                     }
                 }
@@ -1763,7 +1763,7 @@ namespace internal
               }
 
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
       }
 
@@ -1865,7 +1865,7 @@ namespace internal
               }
 
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
       }
 
@@ -2035,7 +2035,7 @@ namespace internal
               }
 
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
       }
 
@@ -2075,7 +2075,7 @@ namespace internal
                 return;
               }
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
       }
     } // namespace
@@ -2142,7 +2142,7 @@ MappingFE<dim, spacedim>::transform(
                                                                output);
         return;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -2191,7 +2191,7 @@ MappingFE<dim, spacedim>::transform(
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -2216,7 +2216,7 @@ MappingFE<dim, spacedim>::transform(
                                                               output);
         return;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -74,7 +74,7 @@ std::size_t
 MappingFEField<dim, spacedim, VectorType>::InternalData::memory_consumption()
   const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return 0;
 }
 
@@ -412,7 +412,7 @@ MappingFEField<dim, spacedim, VectorType>::get_vertices(
             for (const unsigned int v : cell->vertex_indices())
               vertices[v][comp] += fe_values.shape_value(i, v) * value;
           else
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
     }
 
@@ -1314,7 +1314,7 @@ namespace internal
                           cross_product_3d(data.aux[0][i], data.aux[1][i]);
                         break;
                       default:
-                        Assert(false, ExcNotImplemented());
+                        DEAL_II_NOT_IMPLEMENTED();
                     }
               }
             else //(dim < spacedim)
@@ -2016,7 +2016,7 @@ namespace internal
               }
 
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
       }
 
@@ -2055,7 +2055,7 @@ namespace internal
                 return;
               }
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
       }
     } // namespace
@@ -2162,7 +2162,7 @@ MappingFEField<dim, spacedim, VectorType>::transform(
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 

--- a/source/fe/mapping_manifold.cc
+++ b/source/fe/mapping_manifold.cc
@@ -161,7 +161,7 @@ MappingManifold<dim, spacedim>::transform_real_to_unit_cell(
   const typename Triangulation<dim, spacedim>::cell_iterator &,
   const Point<spacedim> &) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return {};
 }
 
@@ -685,7 +685,7 @@ namespace internal
                           cross_product_3d(data.aux[0][i], data.aux[1][i]);
                         break;
                       default:
-                        Assert(false, ExcNotImplemented());
+                        DEAL_II_NOT_IMPLEMENTED();
                     }
               }
             else //(dim < spacedim)
@@ -732,7 +732,7 @@ namespace internal
                           }
 
                         default:
-                          Assert(false, ExcNotImplemented());
+                          DEAL_II_NOT_IMPLEMENTED();
                       }
                   }
               }
@@ -886,7 +886,7 @@ namespace internal
               }
 
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
       }
 
@@ -987,7 +987,7 @@ namespace internal
               }
 
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
       }
 
@@ -1156,7 +1156,7 @@ namespace internal
               }
 
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
       }
 
@@ -1195,7 +1195,7 @@ namespace internal
                 return;
               }
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
       }
     } // namespace
@@ -1331,7 +1331,7 @@ MappingManifold<dim, spacedim>::transform(
           input, mapping_kind, mapping_data, output);
         return;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -1380,7 +1380,7 @@ MappingManifold<dim, spacedim>::transform(
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -1403,7 +1403,7 @@ MappingManifold<dim, spacedim>::transform(
           input, mapping_kind, mapping_data, output);
         return;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -462,7 +462,7 @@ MappingQ<1, 3>::transform_real_to_unit_cell_internal(
   const Point<3> &,
   const Point<1> &) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return {};
 }
 
@@ -1370,7 +1370,7 @@ MappingQ<dim, spacedim>::transform(
                                                               output);
         return;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -1422,7 +1422,7 @@ MappingQ<dim, spacedim>::transform(
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -1447,7 +1447,7 @@ MappingQ<dim, spacedim>::transform(
                                                              output);
         return;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -1719,7 +1719,7 @@ MappingQ<dim, spacedim>::compute_mapping_support_points(
               break;
 
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
               break;
           }
     }

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -1435,7 +1435,7 @@ namespace GridGenerator
           Assert(count == 48, ExcInternalError());
         }
       else
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
 
@@ -1578,7 +1578,7 @@ namespace GridGenerator
 
           break;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     // Prepare cell data
@@ -1723,7 +1723,7 @@ namespace GridGenerator
           cells[3].material_id = 0;
           break;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     tria.create_triangulation(points, cells, SubCellData());
   }
@@ -2148,7 +2148,7 @@ namespace GridGenerator
                 const Point<3> (& /*corners*/)[3],
                 const bool /*colorize*/)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
   template <>
@@ -2157,7 +2157,7 @@ namespace GridGenerator
                 const Point<1> (& /*corners*/)[1],
                 const bool /*colorize*/)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
   // Implementation for 2d only
@@ -2367,7 +2367,7 @@ namespace GridGenerator
           break;
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     // Prepare cell data
@@ -2448,7 +2448,7 @@ namespace GridGenerator
           }
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     // Create triangulation
@@ -2557,7 +2557,7 @@ namespace GridGenerator
           break;
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     // next create the cells
@@ -2620,7 +2620,7 @@ namespace GridGenerator
           }
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     tria.create_triangulation(points, cells, SubCellData());
@@ -2773,7 +2773,7 @@ namespace GridGenerator
           }
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     // next create the cells
@@ -2841,7 +2841,7 @@ namespace GridGenerator
           }
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     tria.create_triangulation(points, cells, SubCellData());
@@ -2926,7 +2926,7 @@ namespace GridGenerator
 
     // set boundary indicator
     if (colorize)
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
   }
 
 
@@ -3184,7 +3184,7 @@ namespace GridGenerator
           break;
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     // next create the cells
@@ -3242,7 +3242,7 @@ namespace GridGenerator
           }
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     tria.create_triangulation(points, cells, SubCellData());
@@ -3266,7 +3266,7 @@ namespace GridGenerator
                     const unsigned int /*n_slices*/,
                     const bool /*colorize*/)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 
@@ -3279,7 +3279,7 @@ namespace GridGenerator
                         const double /*skewness*/,
                         const bool /*colorize*/)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 
@@ -3904,7 +3904,7 @@ namespace GridGenerator
   void
   hyper_cube_slit(Triangulation<1> &, const double, const double, const bool)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 
@@ -3917,7 +3917,7 @@ namespace GridGenerator
                       const double,
                       const bool)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 
@@ -3926,7 +3926,7 @@ namespace GridGenerator
   void
   hyper_L(Triangulation<1> &, const double, const double, const bool)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 
@@ -3935,7 +3935,7 @@ namespace GridGenerator
   void
   hyper_ball(Triangulation<1> &, const Point<1> &, const double, const bool)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 
@@ -3944,7 +3944,7 @@ namespace GridGenerator
   void
   hyper_ball_balanced(Triangulation<1> &, const Point<1> &, const double)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 
@@ -3953,7 +3953,7 @@ namespace GridGenerator
   void
   cylinder(Triangulation<1> &, const double, const double)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 
@@ -3964,7 +3964,7 @@ namespace GridGenerator
                       const double,
                       const double)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 
@@ -3973,7 +3973,7 @@ namespace GridGenerator
   void
   truncated_cone(Triangulation<1> &, const double, const double, const double)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 
@@ -3987,7 +3987,7 @@ namespace GridGenerator
               const unsigned int,
               const bool)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
   template <>
@@ -3999,7 +3999,7 @@ namespace GridGenerator
                  const unsigned int,
                  const unsigned int)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 
@@ -4007,7 +4007,7 @@ namespace GridGenerator
   void
   quarter_hyper_ball(Triangulation<1> &, const Point<1> &, const double)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 
@@ -4015,7 +4015,7 @@ namespace GridGenerator
   void
   half_hyper_ball(Triangulation<1> &, const Point<1> &, const double)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 
@@ -4028,7 +4028,7 @@ namespace GridGenerator
                    const unsigned int,
                    const bool)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
   template <>
@@ -4040,7 +4040,7 @@ namespace GridGenerator
                       const unsigned int,
                       const bool)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
   template <>
@@ -4504,7 +4504,7 @@ namespace GridGenerator
                       const double,
                       const double)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 
@@ -4519,7 +4519,7 @@ namespace GridGenerator
                  const unsigned int,
                  const unsigned int)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 
@@ -5043,7 +5043,7 @@ namespace GridGenerator
 
     if (colorize)
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
       }
   }
 
@@ -7258,7 +7258,7 @@ namespace GridGenerator
                                    const unsigned int,
                                    const bool)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 
@@ -8123,7 +8123,7 @@ namespace GridGenerator
             }
           else
             {
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
             }
         };
 
@@ -8173,7 +8173,7 @@ namespace GridGenerator
                        manifold_id_cell);
           }
         else
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
 
         // Set up sub-cell data.
         for (const auto f : cell->face_indices())
@@ -8202,7 +8202,7 @@ namespace GridGenerator
                   add_cell(1, edge_vertices, bid, mid);
               }
             else
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
 
         // set manifold ids of edges that were already present in the

--- a/source/grid/grid_generator_pipe_junction.cc
+++ b/source/grid/grid_generator_pipe_junction.cc
@@ -269,7 +269,7 @@ namespace GridGenerator
                 const std::pair<Point<spacedim>, double> &,
                 const double)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -1769,7 +1769,7 @@ GridIn<dim, spacedim>::read_comsol_mphtxt(std::istream &in)
                 Assert(false, ExcInternalError());
             }
           else
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
 
       // Then also read the "geometric entity indices". There need to
@@ -1828,7 +1828,7 @@ GridIn<dim, spacedim>::read_comsol_mphtxt(std::istream &in)
                     Assert(false, ExcInternalError());
                 }
               else
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
             }
         }
     }
@@ -3391,7 +3391,7 @@ template <int dim, int spacedim>
 void
 GridIn<dim, spacedim>::read_tecplot(std::istream &)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -3600,7 +3600,7 @@ namespace
     else if (type_name_2 == "HEX" || type_name_2 == "HEXAHEDRON")
       return ReferenceCells::Hexahedron;
 
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
     return ReferenceCells::Invalid;
   }
 
@@ -3994,7 +3994,7 @@ GridIn<dim, spacedim>::debug_output_grid(
   const std::vector<Point<spacedim>> & /*vertices*/,
   std::ostream & /*out*/)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -4270,7 +4270,7 @@ GridIn<dim, spacedim>::default_suffix(const Format format)
       case tecplot:
         return ".dat";
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return ".unknown_format";
     }
 }

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -583,7 +583,7 @@ GridOut::default_suffix(const OutputFormat output_format)
       case vtu:
         return ".vtu";
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return "";
     }
 }
@@ -758,21 +758,21 @@ template <>
 void
 GridOut::write_dx(const Triangulation<1> &, std::ostream &) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 template <>
 void
 GridOut::write_dx(const Triangulation<1, 2> &, std::ostream &) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 template <>
 void
 GridOut::write_dx(const Triangulation<1, 3> &, std::ostream &) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -1096,7 +1096,7 @@ GridOut::write_msh(const Triangulation<dim, spacedim> &tria,
           else if (cell->reference_cell() == ReferenceCells::get_simplex<dim>())
             out << cell->vertex_index(vertex) + 1 << ' ';
           else
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
       out << '\n';
     }
@@ -1195,7 +1195,7 @@ GridOut::write_ucd(const Triangulation<dim, spacedim> &tria,
             out << "hex     ";
             break;
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
 
       // it follows a list of the
@@ -1245,7 +1245,7 @@ GridOut::write_xfig(const Triangulation<dim, spacedim> &,
                     std::ostream &,
                     const Mapping<dim, spacedim> *) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -2973,7 +2973,7 @@ void
 GridOut::write_mathgl(const Triangulation<1> &, std::ostream &) const
 {
   // 1d specialization not done yet
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -3032,7 +3032,7 @@ GridOut::write_mathgl(const Triangulation<dim, spacedim> &tria,
         out << "\nrotate 60 40";
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   out << '\n';
 
@@ -3056,7 +3056,7 @@ GridOut::write_mathgl(const Triangulation<dim, spacedim> &tria,
           << '\n';
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   // (iv) write a list of vertices of cells
@@ -3414,7 +3414,7 @@ GridOut::write_vtk(const Triangulation<dim, spacedim> &tria,
                 out << cell->vertex_index(permutation_table[i]);
               }
             else
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
         out << '\n';
       }
@@ -4077,7 +4077,7 @@ GridOut::write_ucd_faces(const Triangulation<dim, spacedim> &tria,
               out << "quad    ";
               break;
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
         // note: vertex numbers are 1-base
         for (unsigned int vertex = 0;
@@ -4482,7 +4482,7 @@ namespace internal
                   out << '\n'; // end of second line
                 }
               else
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
             }
           else // need to handle curved boundaries
             {
@@ -4634,7 +4634,7 @@ namespace internal
               const GridOutFlags::Eps<2> &,
               const GridOutFlags::Eps<3> &)
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
 
     void
@@ -4644,7 +4644,7 @@ namespace internal
               const GridOutFlags::Eps<2> &,
               const GridOutFlags::Eps<3> &)
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
 
     void
@@ -4654,7 +4654,7 @@ namespace internal
               const GridOutFlags::Eps<2> &,
               const GridOutFlags::Eps<3> &)
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
 
     void
@@ -4664,7 +4664,7 @@ namespace internal
               const GridOutFlags::Eps<2> &,
               const GridOutFlags::Eps<3> &)
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
 
 
@@ -4906,7 +4906,7 @@ namespace internal
             }
 
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
 
 

--- a/source/grid/grid_refinement.cc
+++ b/source/grid/grid_refinement.cc
@@ -436,7 +436,7 @@ GridRefinement::refine_and_coarsen_fixed_fraction(
         break;
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         break;
     }
 }

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -304,7 +304,7 @@ namespace GridTools
                     const bool solve_for_absolute_positions)
   {
     if (dim == 1)
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
 
     // first provide everything that is needed for solving a Laplace
     // equation.
@@ -2200,7 +2200,7 @@ namespace GridTools
         const std::vector<CellId> &,
         std::vector<types::subdomain_id> &)
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
       }
     } // anonymous namespace
   }   // namespace internal
@@ -2219,7 +2219,7 @@ namespace GridTools
           const parallel::fullydistributed::Triangulation<dim, spacedim> *>(
           &triangulation) != nullptr)
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
       }
     else if (const parallel::distributed::Triangulation<dim, spacedim>
                *parallel_tria = dynamic_cast<
@@ -3128,7 +3128,7 @@ namespace GridTools
           }
         else
           {
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
           }
 
         if (angle_fraction > limit_angle_fraction)
@@ -3221,7 +3221,7 @@ namespace GridTools
               }
             else
               {
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
               }
           }
       }

--- a/source/grid/grid_tools_topology.cc
+++ b/source/grid/grid_tools_topology.cc
@@ -518,7 +518,7 @@ namespace GridTools
     if (dim == 1)
       return 0;
     if (dim == 2 && spacedim == 3)
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
 
     std::size_t n_negative_cells = 0;
     std::size_t cell_no          = 0;
@@ -1378,7 +1378,7 @@ namespace GridTools
                                 throw ExcMeshNotOrientable();
                             }
                           else
-                            Assert(false, ExcNotImplemented());
+                            DEAL_II_NOT_IMPLEMENTED();
                         }
                     }
                 }
@@ -1472,7 +1472,7 @@ namespace GridTools
             }
 
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
 
       // now rotate raw_cells[cell_index] in such a way that its orientation
@@ -1536,7 +1536,7 @@ namespace GridTools
 
           default:
             {
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
             }
         }
     }

--- a/source/grid/manifold.cc
+++ b/source/grid/manifold.cc
@@ -537,7 +537,7 @@ namespace internal
       // we get here from FlatManifold<2,3>::normal_vector, but
       // the implementation below is bogus for this case anyway
       // (see the assert at the beginning of that function).
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return {};
     }
 
@@ -775,7 +775,7 @@ FlatManifold<1, 2>::get_normals_at_vertices(
   const Triangulation<1, 2>::face_iterator &,
   Manifold<1, 2>::FaceVertexNormals &) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -786,7 +786,7 @@ FlatManifold<1, 3>::get_normals_at_vertices(
   const Triangulation<1, 3>::face_iterator &,
   Manifold<1, 3>::FaceVertexNormals &) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -812,7 +812,7 @@ FlatManifold<2, 3>::get_normals_at_vertices(
   const Triangulation<2, 3>::face_iterator & /*face*/,
   Manifold<2, 3>::FaceVertexNormals & /*face_vertex_normals*/) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -850,7 +850,7 @@ Tensor<1, 1>
 FlatManifold<1, 1>::normal_vector(const Triangulation<1, 1>::face_iterator &,
                                   const Point<1> &) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return {};
 }
 
@@ -861,7 +861,7 @@ Tensor<1, 2>
 FlatManifold<1, 2>::normal_vector(const Triangulation<1, 2>::face_iterator &,
                                   const Point<2> &) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return {};
 }
 
@@ -872,7 +872,7 @@ Tensor<1, 3>
 FlatManifold<1, 3>::normal_vector(const Triangulation<1, 3>::face_iterator &,
                                   const Point<3> &) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return {};
 }
 

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -186,7 +186,7 @@ PolarManifold<dim, spacedim>::push_forward(
             break;
           }
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
   return p + center;
 }
@@ -225,7 +225,7 @@ PolarManifold<dim, spacedim>::pull_back(
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   return p;
 }
@@ -273,7 +273,7 @@ PolarManifold<dim, spacedim>::push_forward_gradient(
           }
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
   return DX;
 }
@@ -618,7 +618,7 @@ namespace internal
         const ArrayView<const double> & /*weights*/,
         const Point<spacedim> & /*candidate_point*/)
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return {};
       }
 
@@ -1221,7 +1221,7 @@ template <int dim, int spacedim>
 Point<spacedim>
 EllipticalManifold<dim, spacedim>::push_forward(const Point<spacedim> &) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return {};
 }
 
@@ -1249,7 +1249,7 @@ template <int dim, int spacedim>
 Point<spacedim>
 EllipticalManifold<dim, spacedim>::pull_back(const Point<spacedim> &) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return {};
 }
 
@@ -1292,7 +1292,7 @@ DerivativeForm<1, spacedim, spacedim>
 EllipticalManifold<dim, spacedim>::push_forward_gradient(
   const Point<spacedim> &) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return {};
 }
 

--- a/source/grid/reference_cell.cc
+++ b/source/grid/reference_cell.cc
@@ -109,7 +109,7 @@ ReferenceCell::to_string() const
       case ReferenceCells::Invalid:
         return "Invalid";
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return "Invalid";
@@ -136,7 +136,7 @@ ReferenceCell::get_default_mapping(const unsigned int degree) const
       FE_WedgeP<dim, spacedim>(degree));
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
 
   return std::make_unique<MappingQ<dim, spacedim>>(degree);
@@ -174,7 +174,7 @@ ReferenceCell::get_default_linear_mapping() const
     }
   else
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
     }
 
   return StaticMappingQ1<dim, spacedim>::mapping; // never reached
@@ -197,7 +197,7 @@ ReferenceCell::get_gauss_type_quadrature(const unsigned n_points_1d) const
   else if (*this == ReferenceCells::Wedge)
     return QGaussWedge<dim>(n_points_1d);
   else
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 
   return Quadrature<dim>(); // never reached
 }
@@ -242,7 +242,7 @@ ReferenceCell::get_nodal_type_quadrature() const
       return quadrature;
     }
   else
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 
   static const Quadrature<dim> dummy;
   return dummy; // never reached
@@ -285,7 +285,7 @@ ReferenceCell::exodusii_vertex_to_deal_vertex(const unsigned int vertex_n) const
           return exodus_to_deal[vertex_n];
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return numbers::invalid_unsigned_int;
@@ -332,7 +332,7 @@ ReferenceCell::exodusii_face_to_deal_face(const unsigned int face_n) const
           return exodus_to_deal[face_n];
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return numbers::invalid_unsigned_int;
@@ -369,7 +369,7 @@ ReferenceCell::unv_vertex_to_deal_vertex(const unsigned int vertex_n) const
       return unv_to_deal[vertex_n];
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 
   return numbers::invalid_unsigned_int;
 }
@@ -400,7 +400,7 @@ ReferenceCell::vtk_linear_type() const
       case ReferenceCells::Invalid:
         return VTKCellType::VTK_INVALID;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return VTKCellType::VTK_INVALID;
@@ -432,7 +432,7 @@ ReferenceCell::vtk_quadratic_type() const
       case ReferenceCells::Invalid:
         return VTKCellType::VTK_INVALID;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return VTKCellType::VTK_INVALID;
@@ -464,7 +464,7 @@ ReferenceCell::vtk_lagrange_type() const
       case ReferenceCells::Invalid:
         return VTKCellType::VTK_INVALID;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return VTKCellType::VTK_INVALID;
@@ -479,7 +479,7 @@ ReferenceCell::vtk_lexicographic_to_node_index<0>(
   const std::array<unsigned, 0> &,
   const bool) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return 0;
 }
 
@@ -492,7 +492,7 @@ ReferenceCell::vtk_lexicographic_to_node_index<1>(
   const std::array<unsigned, 1> &,
   const bool) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return 0;
 }
 
@@ -712,11 +712,11 @@ ReferenceCell::vtk_vertex_to_deal_vertex(const unsigned int vertex_index) const
         }
       case ReferenceCells::Invalid:
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           return numbers::invalid_unsigned_int;
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return numbers::invalid_unsigned_int;
@@ -800,7 +800,7 @@ ReferenceCell::gmsh_element_type() const
         return 5;
       case ReferenceCells::Invalid:
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   return numbers::invalid_unsigned_int;
@@ -1115,7 +1115,7 @@ ReferenceCell::closest_point(const Point<dim> &p) const
             }
             break;
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
     }
   // We should be within 4 * eps of the cell by this point. The roundoff error

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -6311,7 +6311,7 @@ namespace internal
                 }
               else
                 {
-                  Assert(false, ExcNotImplemented());
+                  DEAL_II_NOT_IMPLEMENTED();
                 }
 
               for (const unsigned int line : quad->line_indices())
@@ -6482,7 +6482,7 @@ namespace internal
                        line_indices[quad_lines[i][2]],
                        line_indices[quad_lines[i][3]]});
                   else
-                    Assert(false, ExcNotImplemented());
+                    DEAL_II_NOT_IMPLEMENTED();
 
                   new_quad->set_used_flag();
                   new_quad->clear_user_flag();
@@ -6593,7 +6593,7 @@ namespace internal
                     n_new_hexes = 8;
                   }
                 else
-                  Assert(false, ExcNotImplemented());
+                  DEAL_II_NOT_IMPLEMENTED();
 
                 std::array<raw_line_iterator, 6> new_lines;
                 for (unsigned int i = 0; i < n_new_lines; ++i)
@@ -6832,7 +6832,7 @@ namespace internal
                         AssertDimension(k, 13);
                       }
                     else
-                      Assert(false, ExcNotImplemented());
+                      DEAL_II_NOT_IMPLEMENTED();
 
                     boost::container::small_vector<unsigned int, 30>
                       relevant_line_indices(relevant_lines.size());
@@ -6928,7 +6928,7 @@ namespace internal
                              relevant_line_indices[new_quad_lines[q][2]],
                              relevant_line_indices[new_quad_lines[q][3]]});
                         else
-                          Assert(false, ExcNotImplemented());
+                          DEAL_II_NOT_IMPLEMENTED();
 
                         // On hexes, we must only determine a single line
                         // according to the representative_lines array above
@@ -7020,7 +7020,7 @@ namespace internal
                       }
                     else
                       {
-                        Assert(false, ExcNotImplemented());
+                        DEAL_II_NOT_IMPLEMENTED();
                       }
 
                     static constexpr dealii::ndarray<unsigned int, 8, 6>
@@ -7155,7 +7155,7 @@ namespace internal
                              quad_indices[cell_quads[c][4]],
                              quad_indices[cell_quads[c][5]]});
                         else
-                          Assert(false, ExcNotImplemented());
+                          DEAL_II_NOT_IMPLEMENTED();
                       }
 
                     // for hexes, we can simply inherit the orientation values
@@ -12711,7 +12711,7 @@ void Triangulation<dim, spacedim>::create_triangulation(
               break;
             }
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
 
 
@@ -13233,7 +13233,7 @@ namespace
       }
     else
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
       }
   }
 } // namespace
@@ -13273,7 +13273,7 @@ namespace
       }
     else
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
       }
   }
 } // namespace
@@ -13313,7 +13313,7 @@ namespace
       }
     else
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
       }
   }
 } // namespace
@@ -13352,7 +13352,7 @@ void Triangulation<dim, spacedim>::save_user_flags(std::ostream &out) const
     save_user_flags_hex(out);
 
   if (dim >= 4)
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -13383,7 +13383,7 @@ void Triangulation<dim, spacedim>::save_user_flags(std::vector<bool> &v) const
     }
 
   if (dim >= 4)
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -13401,7 +13401,7 @@ void Triangulation<dim, spacedim>::load_user_flags(std::istream &in)
     load_user_flags_hex(in);
 
   if (dim >= 4)
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -13438,7 +13438,7 @@ void Triangulation<dim, spacedim>::load_user_flags(const std::vector<bool> &v)
     }
 
   if (dim >= 4)
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -13735,7 +13735,7 @@ void Triangulation<dim, spacedim>::save_user_indices(
     }
 
   if (dim >= 4)
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -13773,7 +13773,7 @@ void Triangulation<dim, spacedim>::load_user_indices(
     }
 
   if (dim >= 4)
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 }
 
 template <int dim, int spacedim>
@@ -14013,7 +14013,7 @@ void Triangulation<dim, spacedim>::save_user_pointers(
     }
 
   if (dim >= 4)
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -14051,7 +14051,7 @@ void Triangulation<dim, spacedim>::load_user_pointers(
     }
 
   if (dim >= 4)
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -14174,7 +14174,7 @@ typename Triangulation<dim, spacedim>::raw_cell_iterator
       case 3:
         return begin_raw_hex(level);
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return raw_cell_iterator();
     }
 }
@@ -14216,7 +14216,7 @@ typename Triangulation<dim, spacedim>::active_cell_iterator
       case 3:
         return begin_active_hex(level);
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return active_cell_iterator();
     }
 }
@@ -14491,7 +14491,7 @@ typename Triangulation<dim, spacedim>::face_iterator
       case 3:
         return begin_quad();
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return face_iterator();
     }
 }
@@ -14513,7 +14513,7 @@ typename Triangulation<dim, spacedim>::active_face_iterator
       case 3:
         return begin_active_quad();
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return active_face_iterator();
     }
 }
@@ -14535,7 +14535,7 @@ typename Triangulation<dim, spacedim>::face_iterator
       case 3:
         return end_quad();
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return raw_face_iterator();
     }
 }
@@ -14742,7 +14742,7 @@ typename Triangulation<dim, spacedim>::raw_quad_iterator
 
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return raw_hex_iterator();
     }
 }
@@ -14840,7 +14840,7 @@ typename Triangulation<dim, spacedim>::raw_hex_iterator
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return raw_hex_iterator();
     }
 }
@@ -14992,7 +14992,7 @@ unsigned int Triangulation<dim, spacedim>::n_faces() const
       case 3:
         return n_quads();
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   return 0;
 }
@@ -15011,7 +15011,7 @@ unsigned int Triangulation<dim, spacedim>::n_raw_faces() const
       case 3:
         return n_raw_quads();
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   return 0;
 }
@@ -15030,7 +15030,7 @@ unsigned int Triangulation<dim, spacedim>::n_active_faces() const
       case 3:
         return n_active_quads();
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   return 0;
 }
@@ -15050,7 +15050,7 @@ unsigned int Triangulation<dim, spacedim>::n_raw_cells(
       case 3:
         return n_raw_hexs(level);
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   return 0;
 }
@@ -15071,7 +15071,7 @@ unsigned int Triangulation<dim, spacedim>::n_cells(
       case 3:
         return n_hexs(level);
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   return 0;
 }
@@ -15092,7 +15092,7 @@ unsigned int Triangulation<dim, spacedim>::n_active_cells(
       case 3:
         return n_active_hexs(level);
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   return 0;
 }
@@ -15150,7 +15150,7 @@ unsigned int Triangulation<dim, spacedim>::n_raw_lines() const
 {
   if (dim == 1)
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return 0;
     }
 
@@ -15388,7 +15388,7 @@ template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 unsigned int Triangulation<dim, spacedim>::n_raw_quads() const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return 0;
 }
 

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -1279,7 +1279,7 @@ namespace
   {
     // this function catches all the cases not
     // explicitly handled above
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
     return {};
   }
 
@@ -1396,7 +1396,7 @@ namespace
         return 0.5 * cross_product_3d(v01, v02).norm();
       }
 
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
     return 0.0;
   }
 
@@ -1408,7 +1408,7 @@ namespace
   {
     // catch-all for all cases not explicitly
     // listed above
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
     return std::numeric_limits<double>::quiet_NaN();
   }
 
@@ -1568,7 +1568,7 @@ double
 TriaAccessor<structdim, dim, spacedim>::extent_in_direction(
   const unsigned int /*axis*/) const
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return std::numeric_limits<double>::signaling_NaN();
 }
 
@@ -1736,7 +1736,7 @@ bool
 TriaAccessor<0, 1, spacedim>::user_flag_set() const
 {
   Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return true;
 }
 
@@ -1747,7 +1747,7 @@ void
 TriaAccessor<0, 1, spacedim>::set_user_flag() const
 {
   Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -1757,7 +1757,7 @@ void
 TriaAccessor<0, 1, spacedim>::clear_user_flag() const
 {
   Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -1793,7 +1793,7 @@ void
 TriaAccessor<0, 1, spacedim>::clear_user_data() const
 {
   Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -1803,7 +1803,7 @@ void
 TriaAccessor<0, 1, spacedim>::set_user_pointer(void *) const
 {
   Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -1813,7 +1813,7 @@ void
 TriaAccessor<0, 1, spacedim>::clear_user_pointer() const
 {
   Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -1823,7 +1823,7 @@ void *
 TriaAccessor<0, 1, spacedim>::user_pointer() const
 {
   Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return nullptr;
 }
 
@@ -1860,7 +1860,7 @@ void
 TriaAccessor<0, 1, spacedim>::set_user_index(const unsigned int) const
 {
   Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -1870,7 +1870,7 @@ void
 TriaAccessor<0, 1, spacedim>::clear_user_index() const
 {
   Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -1880,7 +1880,7 @@ unsigned int
 TriaAccessor<0, 1, spacedim>::user_index() const
 {
   Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return 0;
 }
 
@@ -3109,7 +3109,7 @@ CellAccessor<dim, spacedim>::neighbor_child_on_subface(
             }
 
           // if no reference cell type matches
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           return TriaIterator<CellAccessor<dim, spacedim>>();
         }
 
@@ -3459,13 +3459,13 @@ CellAccessor<dim, spacedim>::neighbor_child_on_subface(
             }
 
           // if no reference cell type matches
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           return TriaIterator<CellAccessor<dim, spacedim>>();
         }
 
       default:
         // if 1d or more than 3d
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return TriaIterator<CellAccessor<dim, spacedim>>();
     }
 }

--- a/source/lac/cuda_precondition.cc
+++ b/source/lac/cuda_precondition.cc
@@ -1808,7 +1808,7 @@ namespace CUDAWrappers
     LinearAlgebra::CUDAWrappers::Vector<Number> & /*dst*/,
     const LinearAlgebra::CUDAWrappers::Vector<Number> & /*src*/) const
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 

--- a/source/lac/petsc_precondition.cc
+++ b/source/lac/petsc_precondition.cc
@@ -524,7 +524,7 @@ namespace PETScWrappers
             string_type = "None";
             break;
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
       return string_type;
     }

--- a/source/lac/petsc_solver.cc
+++ b/source/lac/petsc_solver.cc
@@ -195,7 +195,7 @@ namespace PETScWrappers
           break;
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     PetscFunctionReturn(PETSC_SUCCESS);

--- a/source/lac/slepc_solver.cc
+++ b/source/lac/slepc_solver.cc
@@ -324,7 +324,7 @@ namespace SLEPcWrappers
           break;
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
   }
 

--- a/source/lac/trilinos_solver.cc
+++ b/source/lac/trilinos_solver.cc
@@ -442,7 +442,7 @@ namespace TrilinosWrappers
           solver.SetAztecOption(AZ_solver, AZ_tfqmr);
           break;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     // Set the preconditioner

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -2247,7 +2247,7 @@ namespace TrilinosWrappers
   void
   SparseMatrix::write_ascii()
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 

--- a/source/lac/trilinos_sparsity_pattern.cc
+++ b/source/lac/trilinos_sparsity_pattern.cc
@@ -637,7 +637,7 @@ namespace TrilinosWrappers
   SparsityPattern &
   SparsityPattern::operator=(const SparsityPattern &)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
     return *this;
   }
 
@@ -1003,7 +1003,7 @@ namespace TrilinosWrappers
   void
   SparsityPattern::write_ascii()
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 
@@ -1072,7 +1072,7 @@ namespace TrilinosWrappers
   std::size_t
   SparsityPattern::memory_consumption() const
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
     return 0;
   }
 

--- a/source/lac/trilinos_tpetra_sparsity_pattern.cc
+++ b/source/lac/trilinos_tpetra_sparsity_pattern.cc
@@ -656,7 +656,7 @@ namespace LinearAlgebra
     SparsityPattern<MemorySpace>::operator=(
       const SparsityPattern<MemorySpace> &)
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return *this;
     }
 
@@ -833,7 +833,7 @@ namespace LinearAlgebra
 #  else
       (void)i;
       (void)j;
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return false;
 #  endif
     }
@@ -1070,7 +1070,7 @@ namespace LinearAlgebra
     std::size_t
     SparsityPattern<MemorySpace>::memory_consumption() const
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return 0;
     }
 

--- a/source/matrix_free/fe_point_evaluation.cc
+++ b/source/matrix_free/fe_point_evaluation.cc
@@ -112,7 +112,7 @@ namespace internal
               &fe_poly_ptr->get_poly_space()))
         return polyspace->get_underlying_polynomials();
       else
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
       return {};
     }
   } // namespace FEPointEvaluation

--- a/source/matrix_free/vector_data_exchange.cc
+++ b/source/matrix_free/vector_data_exchange.cc
@@ -1049,7 +1049,7 @@ namespace internal
                       }
                     else
                       {
-                        Assert(false, ExcNotImplemented());
+                        DEAL_II_NOT_IMPLEMENTED();
                       }
 
                     ++ki;
@@ -1159,7 +1159,7 @@ namespace internal
                   }
                 else
                   {
-                    Assert(false, ExcNotImplemented());
+                    DEAL_II_NOT_IMPLEMENTED();
                   }
 
                 if (++ki == ghost_indices_subset_data.second[ko].second)

--- a/source/multigrid/mg_tools.cc
+++ b/source/multigrid/mg_tools.cc
@@ -59,7 +59,7 @@ namespace MGTools
                             std::vector<unsigned int> &,
                             const DoFTools::Coupling)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 
@@ -72,7 +72,7 @@ namespace MGTools
                             const Table<2, DoFTools::Coupling> &,
                             const Table<2, DoFTools::Coupling> &)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 
@@ -84,7 +84,7 @@ namespace MGTools
                             std::vector<unsigned int> &,
                             const DoFTools::Coupling)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 
@@ -96,7 +96,7 @@ namespace MGTools
                             const Table<2, DoFTools::Coupling> &,
                             const Table<2, DoFTools::Coupling> &)
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -865,7 +865,7 @@ DataOut<dim, spacedim>::build_one_patch(
                                   }
 
                                 default:
-                                  Assert(false, ExcNotImplemented());
+                                  DEAL_II_NOT_IMPLEMENTED();
                               }
                           }
                       }
@@ -948,7 +948,7 @@ DataOut<dim, spacedim>::build_one_patch(
                                   }
 
                                 default:
-                                  Assert(false, ExcNotImplemented());
+                                  DEAL_II_NOT_IMPLEMENTED();
                               }
                           }
                       }

--- a/source/numerics/data_out_rotation.cc
+++ b/source/numerics/data_out_rotation.cc
@@ -115,7 +115,7 @@ DataOutRotation<dim, spacedim>::build_one_patch(
     {
       // would this function make any sense after all? who would want to
       // output/compute in four space dimensions?
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return;
     }
 
@@ -188,7 +188,7 @@ DataOutRotation<dim, spacedim>::build_one_patch(
             }
 
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
 
       // then fill in data
@@ -326,7 +326,7 @@ DataOutRotation<dim, spacedim>::build_one_patch(
                             break;
 
                           default:
-                            Assert(false, ExcNotImplemented());
+                            DEAL_II_NOT_IMPLEMENTED();
                         }
                     }
                 }
@@ -359,7 +359,7 @@ DataOutRotation<dim, spacedim>::build_one_patch(
                         break;
 
                       default:
-                        Assert(false, ExcNotImplemented());
+                        DEAL_II_NOT_IMPLEMENTED();
                     }
                 }
               else
@@ -400,7 +400,7 @@ DataOutRotation<dim, spacedim>::build_one_patch(
                             break;
 
                           default:
-                            Assert(false, ExcNotImplemented());
+                            DEAL_II_NOT_IMPLEMENTED();
                         }
                     }
                 }
@@ -444,7 +444,7 @@ DataOutRotation<dim, spacedim>::build_one_patch(
                     break;
 
                   default:
-                    Assert(false, ExcNotImplemented());
+                    DEAL_II_NOT_IMPLEMENTED();
                 }
             }
         }

--- a/source/numerics/data_out_stack.cc
+++ b/source/numerics/data_out_stack.cc
@@ -370,7 +370,7 @@ DataOutStack<dim, spacedim>::build_patches(const unsigned int nnnn_subdivisions)
             break;
 
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
 
 

--- a/source/numerics/derivative_approximation.cc
+++ b/source/numerics/derivative_approximation.cc
@@ -503,7 +503,7 @@ namespace DerivativeApproximation
       // needs to be employed. maybe some
       // steps of the power method would
       // suffice?
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return 0;
     }
 

--- a/source/opencascade/manifold_lib.cc
+++ b/source/opencascade/manifold_lib.cc
@@ -220,7 +220,7 @@ namespace OpenCASCADE
                                  const ArrayView<const Point<spacedim>> &,
                                  const Point<spacedim> &)
     {
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return {};
     }
 

--- a/source/particles/data_out.cc
+++ b/source/particles/data_out.cc
@@ -246,7 +246,7 @@ namespace Particles
             }
 
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
 
     return ranges;

--- a/tests/base/quadrature_check_tensor_product.cc
+++ b/tests/base/quadrature_check_tensor_product.cc
@@ -28,7 +28,7 @@ void
 check_tensor_product(const std::vector<Quadrature<dim>> &quadratures,
                      const std::vector<std::string>     &quadrature_names)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 template <>

--- a/tests/bits/distorted_cells_01.cc
+++ b/tests/bits/distorted_cells_01.cc
@@ -56,7 +56,7 @@ check(const unsigned int testcase)
         std::swap(vertices[0], vertices[1]);
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
 

--- a/tests/bits/distorted_cells_07.cc
+++ b/tests/bits/distorted_cells_07.cc
@@ -52,7 +52,7 @@ check(const unsigned int testcase)
         std::swap(vertices[1], vertices[0]);
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
 

--- a/tests/bits/static_condensation.cc
+++ b/tests/bits/static_condensation.cc
@@ -549,7 +549,7 @@ HelmholtzProblem<dim>::refine_grid()
 
       default:
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
         }
     }
 }

--- a/tests/bits/step-51.cc
+++ b/tests/bits/step-51.cc
@@ -207,7 +207,7 @@ namespace Step51
           convection[2] = 1;
           break;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     return convection;
   }

--- a/tests/bits/step-51p.cc
+++ b/tests/bits/step-51p.cc
@@ -207,7 +207,7 @@ namespace Step51
           convection[2] = 1;
           break;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     return convection;
   }

--- a/tests/bits/step-7.cc
+++ b/tests/bits/step-7.cc
@@ -426,7 +426,7 @@ HelmholtzProblem<dim>::refine_grid()
 
       default:
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
         }
     }
 }
@@ -526,7 +526,7 @@ HelmholtzProblem<dim>::run()
             gmv_filename = "solution-adaptive";
             break;
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
 
       switch ((*fe).degree)
@@ -539,7 +539,7 @@ HelmholtzProblem<dim>::run()
             break;
 
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
 
       gmv_filename += ".gmv";
@@ -584,7 +584,7 @@ HelmholtzProblem<dim>::run()
         error_filename += "-adaptive";
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   switch ((*fe).degree)
@@ -596,7 +596,7 @@ HelmholtzProblem<dim>::run()
         error_filename += "-q2";
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   error_filename += ".tex";
@@ -636,7 +636,7 @@ HelmholtzProblem<dim>::run()
             conv_filename += "-adaptive";
             break;
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
       switch ((*fe).degree)
         {
@@ -647,7 +647,7 @@ HelmholtzProblem<dim>::run()
             conv_filename += "-q2";
             break;
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
       conv_filename += ".tex";
 

--- a/tests/bits/step-8.cc
+++ b/tests/bits/step-8.cc
@@ -379,7 +379,7 @@ ElasticProblem<dim>::output_results(const unsigned int cycle) const
         solution_names.push_back("z_displacement");
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   data_out.add_data_vector(solution, solution_names);

--- a/tests/codim_one/bem.cc
+++ b/tests/codim_one/bem.cc
@@ -150,7 +150,7 @@ BEM<spacedim>::run()
         }
     }
   else
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 
   table.set_scientific("L^2 norm error", true);
   table.evaluate_convergence_rates("L^2 norm error",

--- a/tests/data_out/data_out_postprocessor_01-new.cc
+++ b/tests/data_out/data_out_postprocessor_01-new.cc
@@ -111,7 +111,7 @@ public:
         case 1:
           return std::cos(p.norm());
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           return 0;
       }
   }

--- a/tests/data_out/data_out_postprocessor_scalar_01-new.cc
+++ b/tests/data_out/data_out_postprocessor_scalar_01-new.cc
@@ -114,7 +114,7 @@ public:
         case 1:
           return std::cos(p.norm());
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           return 0;
       }
   }

--- a/tests/data_out/data_out_postprocessor_vector_01-new.cc
+++ b/tests/data_out/data_out_postprocessor_vector_01-new.cc
@@ -114,7 +114,7 @@ public:
         case 1:
           return std::cos(p.norm());
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           return 0;
       }
   }

--- a/tests/data_out/data_out_postprocessor_vector_complex_01.cc
+++ b/tests/data_out/data_out_postprocessor_vector_complex_01.cc
@@ -114,7 +114,7 @@ public:
         case 1:
           return std::cos(p.norm());
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           return 0;
       }
   }

--- a/tests/distributed_grids/3d_coarse_grid_05.cc
+++ b/tests/distributed_grids/3d_coarse_grid_05.cc
@@ -77,7 +77,7 @@ create_disconnected_mesh(Triangulation<dim> &tria)
 
           break;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     // Prepare cell data
@@ -129,7 +129,7 @@ create_disconnected_mesh(Triangulation<dim> &tria)
 
           break;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     // Prepare cell data

--- a/tests/dofs/nodal_renumbering_01.cc
+++ b/tests/dofs/nodal_renumbering_01.cc
@@ -64,7 +64,7 @@ public:
         case 1:
           return std::cos(p[0]) * std::cos(3.0 * p[1]) + 2.0;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     return 0.0;
   }

--- a/tests/epetraext/trilinos_sparse_matrix_mmult_01.cc
+++ b/tests/epetraext/trilinos_sparse_matrix_mmult_01.cc
@@ -60,7 +60,7 @@ test()
         }
     }
   else
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 
   /* A is
 

--- a/tests/fe/bdm_2.cc
+++ b/tests/fe/bdm_2.cc
@@ -90,7 +90,7 @@ transform_grid(Triangulation<2> &tria, const unsigned int transform)
         break;
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     };
 }
 

--- a/tests/fe/fe_enriched_step-36.cc
+++ b/tests/fe/fe_enriched_step-36.cc
@@ -278,7 +278,7 @@ namespace Step36
         else if (cell->material_id() == pou_material_id)
           cell->set_active_fe_index(pou_fe_index);
         else
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     GridTools::partition_triangulation(n_mpi_processes, triangulation);

--- a/tests/fe/fe_enriched_step-36b.cc
+++ b/tests/fe/fe_enriched_step-36b.cc
@@ -288,7 +288,7 @@ namespace Step36
         else if (cell->material_id() == pou_material_id)
           cell->set_active_fe_index(pou_fe_index);
         else
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     GridTools::partition_triangulation(n_mpi_processes, triangulation);

--- a/tests/fe/fe_tools_test.cc
+++ b/tests/fe/fe_tools_test.cc
@@ -152,7 +152,7 @@ test(const Triangulation<dim> &tria,
                                           function1_back);
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   DataOut<dim> data_out;
@@ -184,7 +184,7 @@ test(const Triangulation<dim> &tria,
         file2_name += fe_string2 + "_interpolation_diff.gnuplot";
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   deallog << file2_name << std::endl;
 

--- a/tests/fe/fe_values_function_manifold.cc
+++ b/tests/fe/fe_values_function_manifold.cc
@@ -144,7 +144,7 @@ public:
             return point[1] + 0.25 * (2 * x - 1.0) * (x - 1.0) * x;
           }
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     return std::numeric_limits<double>::quiet_NaN();
   }
@@ -171,7 +171,7 @@ public:
             return point[1] - 0.25 * (2 * x - 1.0) * (x - 1.0) * x;
           }
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     return std::numeric_limits<double>::quiet_NaN();
   }

--- a/tests/fe/nedelec.cc
+++ b/tests/fe/nedelec.cc
@@ -96,7 +96,7 @@ transform_grid(Triangulation<2> &tria, const unsigned int transform)
         break;
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     };
 }
 

--- a/tests/fe/numbering.cc
+++ b/tests/fe/numbering.cc
@@ -220,7 +220,7 @@ check(const FE_Q<dim> &fe)
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   // now check with data from the

--- a/tests/fe/rt_2.cc
+++ b/tests/fe/rt_2.cc
@@ -90,7 +90,7 @@ transform_grid(Triangulation<2> &tria, const unsigned int transform)
         break;
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     };
 }
 

--- a/tests/fe/rt_bubbles_2.cc
+++ b/tests/fe/rt_bubbles_2.cc
@@ -86,7 +86,7 @@ transform_grid(Triangulation<2> &tria, const unsigned int transform)
         break;
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     };
 }
 

--- a/tests/fe/up_and_down.cc
+++ b/tests/fe/up_and_down.cc
@@ -55,7 +55,7 @@ transform(const Point<dim> p)
                           p[1] * (1 + p[0]) * (1 + p[2]),
                           p[2] * (1 + p[0]) * (1 + p[1]));
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         return Point<dim>();
     };
 }

--- a/tests/grid/enclosing_sphere_01.cc
+++ b/tests/grid/enclosing_sphere_01.cc
@@ -38,7 +38,7 @@ template <int dim>
 void
 create_triangulation(const unsigned int, Triangulation<dim> &)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -101,7 +101,7 @@ create_triangulation(const unsigned int case_no, Triangulation<2> &tria)
           //   *------------>x
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     };
 }
 
@@ -170,7 +170,7 @@ create_triangulation(const unsigned int case_no, Triangulation<3> &tria)
           break;
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     };
 }
 

--- a/tests/grid/extent_in_direction.cc
+++ b/tests/grid/extent_in_direction.cc
@@ -38,7 +38,7 @@ create_triangulation(const unsigned int case_no, Triangulation<1> &tria)
         GridGenerator::hyper_cube(tria, 1., 4.);
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     };
 }
 
@@ -62,7 +62,7 @@ create_triangulation(const unsigned int case_no, Triangulation<2> &tria)
           break;
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     };
 }
 
@@ -83,7 +83,7 @@ create_triangulation(const unsigned int case_no, Triangulation<3> &tria)
           break;
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     };
 }
 

--- a/tests/grid/get_dof_to_support_patch_map_01.cc
+++ b/tests/grid/get_dof_to_support_patch_map_01.cc
@@ -88,7 +88,7 @@ test()
         coarsen_centers.push_back(Point<dim>(5. / 8., 5. / 8., 5. / 8.));
       }
     else
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
 
     unsigned int index = 0;
     for (typename Triangulation<dim>::active_cell_iterator cell =

--- a/tests/grid/measure_et_al.cc
+++ b/tests/grid/measure_et_al.cc
@@ -30,7 +30,7 @@ template <int dim>
 void
 create_triangulation(const unsigned int, Triangulation<dim> &)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -55,7 +55,7 @@ create_triangulation(const unsigned int case_no, Triangulation<2> &tria)
           break;
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     };
 }
 
@@ -77,7 +77,7 @@ create_triangulation(const unsigned int case_no, Triangulation<3> &tria)
           break;
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     };
 }
 

--- a/tests/grid/measure_et_al_02.cc
+++ b/tests/grid/measure_et_al_02.cc
@@ -31,7 +31,7 @@ template <int dim>
 void
 create_triangulation(const unsigned int, Triangulation<dim> &)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 
@@ -61,7 +61,7 @@ create_triangulation(const unsigned int case_no, Triangulation<2> &tria)
           break;
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     };
 }
 
@@ -84,7 +84,7 @@ create_triangulation(const unsigned int case_no, Triangulation<3> &tria)
           break;
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     };
 }
 

--- a/tests/grid/merge_triangulations_01.cc
+++ b/tests/grid/merge_triangulations_01.cc
@@ -54,7 +54,7 @@ test(const int testcase)
           shift[d] = 1;
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   GridTools::shift(shift, tria_2);
 

--- a/tests/grid/normal_vector_01.cc
+++ b/tests/grid/normal_vector_01.cc
@@ -50,7 +50,7 @@ create_triangulation(const unsigned int case_no, Triangulation<3> &tria)
           break;
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     };
 }
 

--- a/tests/grid/normal_vector_01_2d.cc
+++ b/tests/grid/normal_vector_01_2d.cc
@@ -50,7 +50,7 @@ create_triangulation(const unsigned int case_no, Triangulation<2> &tria)
           break;
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     };
 }
 

--- a/tests/grid/normal_vector_03.cc
+++ b/tests/grid/normal_vector_03.cc
@@ -52,7 +52,7 @@ create_triangulation(const unsigned int case_no, Triangulation<3> &tria)
           break;
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     };
 }
 

--- a/tests/grid/normal_vector_03_2d.cc
+++ b/tests/grid/normal_vector_03_2d.cc
@@ -52,7 +52,7 @@ create_triangulation(const unsigned int case_no, Triangulation<2> &tria)
           break;
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     };
 }
 

--- a/tests/grid/normals_at_vertices_01.cc
+++ b/tests/grid/normals_at_vertices_01.cc
@@ -49,7 +49,7 @@ create_triangulation(const unsigned int case_no, Triangulation<3> &tria)
           break;
         }
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     };
 }
 

--- a/tests/hp/crash_17.cc
+++ b/tests/hp/crash_17.cc
@@ -347,7 +347,7 @@ LaplaceProblem<dim>::estimate_smoothness(
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   const unsigned      n_fourier_modes = k_vectors.size();

--- a/tests/hp/crash_18.cc
+++ b/tests/hp/crash_18.cc
@@ -355,7 +355,7 @@ LaplaceProblem<dim>::estimate_smoothness(
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   const unsigned      n_fourier_modes = k_vectors.size();

--- a/tests/hp/flux_sparsity.cc
+++ b/tests/hp/flux_sparsity.cc
@@ -66,7 +66,7 @@ check()
         p2[1] = p2[2] = 1.0;
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   GridGenerator::subdivided_hyper_rectangle(triangulation,

--- a/tests/hp/flux_sparsity_02.cc
+++ b/tests/hp/flux_sparsity_02.cc
@@ -62,7 +62,7 @@ check()
         p2[1] = p2[2] = 1.0;
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   GridGenerator::subdivided_hyper_rectangle(triangulation,

--- a/tests/hp/hp_constraints_common.h
+++ b/tests/hp/hp_constraints_common.h
@@ -310,7 +310,7 @@ test_with_2d_deformed_refined_mesh(const hp::FECollection<dim> &fe)
             (std::next((++(triangulation.begin_active()))))->set_refine_flag();
             break;
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
       triangulation.execute_coarsening_and_refinement();
 

--- a/tests/hp/hp_constraints_common_no_support.h
+++ b/tests/hp/hp_constraints_common_no_support.h
@@ -311,7 +311,7 @@ test_with_2d_deformed_refined_mesh(const hp::FECollection<dim> &fe)
             (std::next((++(triangulation.begin_active()))))->set_refine_flag();
             break;
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
       triangulation.execute_coarsening_and_refinement();
 

--- a/tests/hp/interpolate_nothing_02.cc
+++ b/tests/hp/interpolate_nothing_02.cc
@@ -181,7 +181,7 @@ diffusionMechanics<dim>::set_active_fe_indices()
       else if (cell_is_in_omega2_domain(cell))
         cell->set_active_fe_index(1);
       else
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 

--- a/tests/hp/step-7.cc
+++ b/tests/hp/step-7.cc
@@ -429,7 +429,7 @@ HelmholtzProblem<dim>::refine_grid()
 
       default:
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
         }
     }
 }
@@ -529,7 +529,7 @@ HelmholtzProblem<dim>::run()
             gmv_filename = "solution-adaptive";
             break;
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
 
       switch ((*fe)[0].degree)
@@ -542,7 +542,7 @@ HelmholtzProblem<dim>::run()
             break;
 
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
 
       gmv_filename += ".gmv";
@@ -587,7 +587,7 @@ HelmholtzProblem<dim>::run()
         error_filename += "-adaptive";
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   switch ((*fe)[0].degree)
@@ -599,7 +599,7 @@ HelmholtzProblem<dim>::run()
         error_filename += "-q2";
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   error_filename += ".tex";
@@ -639,7 +639,7 @@ HelmholtzProblem<dim>::run()
             conv_filename += "-adaptive";
             break;
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
       switch ((*fe)[0].degree)
         {
@@ -650,7 +650,7 @@ HelmholtzProblem<dim>::run()
             conv_filename += "-q2";
             break;
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
       conv_filename += ".tex";
 

--- a/tests/hp/step-8.cc
+++ b/tests/hp/step-8.cc
@@ -382,7 +382,7 @@ ElasticProblem<dim>::output_results(const unsigned int cycle) const
         solution_names.push_back("z_displacement");
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   data_out.add_data_vector(solution, solution_names);

--- a/tests/lac/inhomogeneous_constraints.cc
+++ b/tests/lac/inhomogeneous_constraints.cc
@@ -694,7 +694,7 @@ LaplaceProblem<dim>::estimate_smoothness(
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   const unsigned      n_fourier_modes = k_vectors.size();

--- a/tests/lac/sparse_ilu.cc
+++ b/tests/lac/sparse_ilu.cc
@@ -79,7 +79,7 @@ main()
                 break;
 
               default:
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
             };
           ilu_pattern.compress();
 

--- a/tests/lac/sparse_ilu_t.cc
+++ b/tests/lac/sparse_ilu_t.cc
@@ -79,7 +79,7 @@ main()
                 break;
 
               default:
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
             };
           ilu_pattern.compress();
           SparseILU<double>::AdditionalData data;

--- a/tests/lac/sparse_mic.cc
+++ b/tests/lac/sparse_mic.cc
@@ -82,7 +82,7 @@ main()
                 break;
 
               default:
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
             };
           mic_pattern.compress();
           SparseMIC<double>::AdditionalData data;

--- a/tests/mappings/mapping.cc
+++ b/tests/mappings/mapping.cc
@@ -220,7 +220,7 @@ create_triangulations(std::vector<Triangulation<dim> *> &,
                       std::vector<Manifold<dim> *> &,
                       std::vector<double> &)
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 

--- a/tests/matrix_free/ecl.h
+++ b/tests/matrix_free/ecl.h
@@ -67,7 +67,7 @@ test(const unsigned int geometry      = 0,
   else if (geometry == 2)
     GridGenerator::hyper_ball(tria);
   else
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 
   tria.reset_all_manifolds();
 

--- a/tests/matrix_free/ecl_fe_q.h
+++ b/tests/matrix_free/ecl_fe_q.h
@@ -69,7 +69,7 @@ test(const unsigned int geometry      = 0,
   else if (geometry == 2)
     GridGenerator::hyper_ball(tria);
   else
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 
   tria.reset_all_manifolds();
 

--- a/tests/matrix_free/mixed_mesh_hn_algorithm_01.cc
+++ b/tests/matrix_free/mixed_mesh_hn_algorithm_01.cc
@@ -93,7 +93,7 @@ main()
       else if (cell->reference_cell() == ReferenceCells::Quadrilateral)
         cell->set_active_fe_index(1);
       else
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   const hp::MappingCollection<2> mapping(MappingFE<2>(FE_SimplexP<2>(1)),

--- a/tests/matrix_free/poisson_dg_hp.cc
+++ b/tests/matrix_free/poisson_dg_hp.cc
@@ -80,7 +80,7 @@ get_penalty_parameter(const unsigned int i,
         return 64.0;
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 
   return 0.0;
 }

--- a/tests/matrix_free/stokes_computation.cc
+++ b/tests/matrix_free/stokes_computation.cc
@@ -271,7 +271,7 @@ namespace StokesClass
       // iterations of our two-stage outer GMRES iteration)
       if (do_solve_A == true)
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
         }
       else
         {
@@ -559,7 +559,7 @@ namespace StokesClass
   void
   StokesOperator<dim, degree_v, number>::compute_diagonal()
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 

--- a/tests/matrix_free_kokkos/matrix_vector_device_mf.h
+++ b/tests/matrix_free_kokkos/matrix_vector_device_mf.h
@@ -236,7 +236,7 @@ MatrixFreeTest<dim, fe_degree, Number, VectorType, n_q_points_1d>::el(
   const unsigned int col) const
 {
   (void)col;
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
   return 0.;
 }
 

--- a/tests/mpi/trilinos_matvec_01.cc
+++ b/tests/mpi/trilinos_matvec_01.cc
@@ -66,7 +66,7 @@ test()
         }
     }
   else
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 
   TrilinosWrappers::SparsityPattern sp(row_partitioning,
                                        col_partitioning,

--- a/tests/mpi/trilinos_matvec_02.cc
+++ b/tests/mpi/trilinos_matvec_02.cc
@@ -66,7 +66,7 @@ test()
         }
     }
   else
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 
   TrilinosWrappers::SparsityPattern sp(row_partitioning,
                                        col_partitioning,

--- a/tests/mpi/trilinos_matvec_03.cc
+++ b/tests/mpi/trilinos_matvec_03.cc
@@ -62,7 +62,7 @@ test()
         }
     }
   else
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 
   TrilinosWrappers::SparsityPattern sp(row_partitioning,
                                        col_partitioning,

--- a/tests/mpi/trilinos_sparse_matrix_01.cc
+++ b/tests/mpi/trilinos_sparse_matrix_01.cc
@@ -66,7 +66,7 @@ test()
         }
     }
   else
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 
   TrilinosWrappers::SparsityPattern sp(row_partitioning,
                                        col_partitioning,

--- a/tests/mpi/trilinos_sparse_matrix_02.cc
+++ b/tests/mpi/trilinos_sparse_matrix_02.cc
@@ -55,7 +55,7 @@ test()
         locally_owned.add_range(2, n_rows);
     }
   else
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 
   TrilinosWrappers::SparsityPattern sp(locally_owned,
                                        locally_owned,

--- a/tests/mpi/trilinos_sparse_matrix_03.cc
+++ b/tests/mpi/trilinos_sparse_matrix_03.cc
@@ -65,7 +65,7 @@ test()
         }
     }
   else
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 
   TrilinosWrappers::SparsityPattern sp(row_partitioning,
                                        col_partitioning,

--- a/tests/mpi/trilinos_sparse_matrix_04.cc
+++ b/tests/mpi/trilinos_sparse_matrix_04.cc
@@ -66,7 +66,7 @@ test()
         }
     }
   else
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 
   TrilinosWrappers::SparsityPattern sp(row_partitioning,
                                        col_partitioning,

--- a/tests/mpi/trilinos_sparse_matrix_05.cc
+++ b/tests/mpi/trilinos_sparse_matrix_05.cc
@@ -69,7 +69,7 @@ test()
         }
     }
   else
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 
   TrilinosWrappers::SparsityPattern sp(row_partitioning,
                                        col_partitioning,

--- a/tests/mpi/trilinos_sparse_matrix_print_01.cc
+++ b/tests/mpi/trilinos_sparse_matrix_print_01.cc
@@ -63,7 +63,7 @@ test()
         }
     }
   else
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 
   TrilinosWrappers::SparsityPattern sp(row_partitioning,
                                        col_partitioning,

--- a/tests/multigrid-global-coarsening/multigrid_util.h
+++ b/tests/multigrid-global-coarsening/multigrid_util.h
@@ -114,7 +114,7 @@ public:
   Number
   el(unsigned int, unsigned int) const
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
     return 0;
   }
 

--- a/tests/multigrid-global-coarsening/stokes_computation.cc
+++ b/tests/multigrid-global-coarsening/stokes_computation.cc
@@ -271,7 +271,7 @@ namespace StokesClass
       // iterations of our two-stage outer GMRES iteration)
       if (do_solve_A == true)
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
         }
       else
         {
@@ -559,7 +559,7 @@ namespace StokesClass
   void
   StokesOperator<dim, degree_v, number>::compute_diagonal()
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 

--- a/tests/numerics/no_flux_04.cc
+++ b/tests/numerics/no_flux_04.cc
@@ -70,7 +70,7 @@ public:
           v(2) = p[2];
           break;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
   }
 };

--- a/tests/numerics/no_flux_18.cc
+++ b/tests/numerics/no_flux_18.cc
@@ -272,7 +272,7 @@ namespace StokesClass
       // iterations of our two-stage outer GMRES iteration)
       if (do_solve_A == true)
         {
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
         }
       else
         {
@@ -560,7 +560,7 @@ namespace StokesClass
   void
   StokesOperator<dim, degree_v, number>::compute_diagonal()
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
   }
 
 

--- a/tests/numerics/no_flux_hp_04.cc
+++ b/tests/numerics/no_flux_hp_04.cc
@@ -64,7 +64,7 @@ public:
           v(2) = p[2];
           break;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
   }
 };

--- a/tests/numerics/project_common.h
+++ b/tests/numerics/project_common.h
@@ -334,7 +334,7 @@ test_with_2d_deformed_refined_mesh(const FiniteElement<dim> &fe,
             (std::next((++(triangulation.begin_active()))))->set_refine_flag();
             break;
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
       triangulation.execute_coarsening_and_refinement();
 

--- a/tests/numerics/project_parallel_common.h
+++ b/tests/numerics/project_parallel_common.h
@@ -347,7 +347,7 @@ test_with_2d_deformed_refined_mesh(const FiniteElement<dim> &fe,
             (std::next((++(triangulation.begin_active()))))->set_refine_flag();
             break;
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
       triangulation.execute_coarsening_and_refinement();
 

--- a/tests/numerics/smoothness_estimator_02.cc
+++ b/tests/numerics/smoothness_estimator_02.cc
@@ -246,7 +246,7 @@ test(const unsigned int poly_degree)
           exact[3] = std::complex<double>(3. * pi, 1. - 6. * pi2) / (36. * pi3);
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
         break;
     }
 

--- a/tests/performance/timing_navier_stokes.cc
+++ b/tests/performance/timing_navier_stokes.cc
@@ -544,7 +544,7 @@ namespace NavierStokes_DG
       }
     else
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
       }
 #else
     (void)subcommunicator;

--- a/tests/petsc/70.cc
+++ b/tests/petsc/70.cc
@@ -32,5 +32,5 @@ main()
   else if (typeid(PetscScalar) == typeid(float))
     deallog << "float" << std::endl;
   else
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 }

--- a/tests/petsc/step-67-with-petsc-ts.cc
+++ b/tests/petsc/step-67-with-petsc-ts.cc
@@ -216,7 +216,7 @@ namespace Euler_DG
           }
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           return 0.;
       }
   }
@@ -626,7 +626,7 @@ namespace Euler_DG
 
         default:
           {
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
             return {};
           }
       }
@@ -2060,7 +2060,7 @@ namespace Euler_DG
           }
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     triangulation.refine_global(n_global_refinements);

--- a/tests/physics/step-18-rotation_matrix.cc
+++ b/tests/physics/step-18-rotation_matrix.cc
@@ -515,7 +515,7 @@ namespace Step18
           solution_names.push_back("delta_z");
           break;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     data_out.add_data_vector(incremental_displacement, solution_names);
     Vector<double> norm_of_stress(triangulation.n_active_cells());

--- a/tests/physics/step-18.cc
+++ b/tests/physics/step-18.cc
@@ -531,7 +531,7 @@ namespace Step18
           solution_names.push_back("delta_z");
           break;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     data_out.add_data_vector(incremental_displacement, solution_names);
     Vector<double> norm_of_stress(triangulation.n_active_cells());

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_04.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_04.cc
@@ -164,7 +164,7 @@ test()
         if (std::abs(evaluation_points[i][0] - evaluation_point_results[i]) >
               1e-10 ||
             std::abs(evaluation_point_gradient_results[i][0] - 1.0) > 1e-10)
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
   deallog << "OK!" << std::endl;

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_06.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_06.cc
@@ -127,7 +127,7 @@ test()
                      evaluation_point_results_2[i]) > 1e-10 ||
             std::abs(evaluation_point_results_1[i] -
                      evaluation_point_results_3[i]) > 1e-10)
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
   deallog << "OK!" << std::endl;

--- a/tests/simplex/cell_measure_01.cc
+++ b/tests/simplex/cell_measure_01.cc
@@ -83,7 +83,7 @@ template <int dim>
 void
 test()
 {
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 }
 
 template <>

--- a/tests/simplex/data_out_write_vtk_02.cc
+++ b/tests/simplex/data_out_write_vtk_02.cc
@@ -91,7 +91,7 @@ test(const FiniteElement<dim, spacedim> &fe_0,
       else if (cell->reference_cell() == ReferenceCells::Quadrilateral)
         cell->set_active_fe_index(1);
       else
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   dof_handler.distribute_dofs(fe);

--- a/tests/simplex/matrix_free_01.cc
+++ b/tests/simplex/matrix_free_01.cc
@@ -163,7 +163,7 @@ test(const unsigned int v, const unsigned int degree, const bool do_helmholtz)
       fe_mapping = std::make_shared<FE_PyramidP<dim>>(1);
     }
   else
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 
   MappingFE<dim> mapping(*fe_mapping);
 
@@ -326,7 +326,7 @@ main(int argc, char **argv)
       else if (i == 2)
         deallog.push("PYRAMID");
       else
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
 
       if (i == 0) // 2D makes only sense for simplex
         {

--- a/tests/simplex/matrix_free_04.cc
+++ b/tests/simplex/matrix_free_04.cc
@@ -82,7 +82,7 @@ get_penalty_parameter(const unsigned int i,
         return 64.0;
     }
 
-  Assert(false, ExcNotImplemented());
+  DEAL_II_NOT_IMPLEMENTED();
 
   return 0.0;
 }

--- a/tests/simplex/matrix_free_face_integral_01.cc
+++ b/tests/simplex/matrix_free_face_integral_01.cc
@@ -93,7 +93,7 @@ test(const unsigned int v, const unsigned int degree)
                                             QGaussSimplex<dim - 1>(degree + 1)};
     }
   else
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 
   MappingFE<dim> mapping(*fe_mapping);
 
@@ -219,7 +219,7 @@ main(int argc, char **argv)
       else if (i == 2)
         deallog.push("PYRAMID");
       else
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
 
       if (i == 0) // 2D makes only sense for simplex
         {

--- a/tests/simplex/step-07.cc
+++ b/tests/simplex/step-07.cc
@@ -425,7 +425,7 @@ namespace Step7
 
         default:
           {
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
           }
       }
   }
@@ -549,7 +549,7 @@ namespace Step7
           vtk_filename = "solution-adaptive";
           break;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     switch (fe->degree)
@@ -562,7 +562,7 @@ namespace Step7
           break;
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     vtk_filename += ".vtk";
@@ -611,7 +611,7 @@ namespace Step7
           error_filename += "-adaptive";
           break;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     switch (fe->degree)
@@ -623,7 +623,7 @@ namespace Step7
           error_filename += "-q2";
           break;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     error_filename += ".tex";
@@ -664,7 +664,7 @@ namespace Step7
               conv_filename += "-adaptive";
               break;
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
         switch (fe->degree)
           {
@@ -675,7 +675,7 @@ namespace Step7
               conv_filename += "-q2";
               break;
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
         conv_filename += ".tex";
 

--- a/tests/simplex/step-08.cc
+++ b/tests/simplex/step-08.cc
@@ -301,7 +301,7 @@ namespace Step8
           solution_names.emplace_back("z_displacement");
           break;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     data_out.add_data_vector(solution, solution_names);

--- a/tests/simplex/step-67.cc
+++ b/tests/simplex/step-67.cc
@@ -242,7 +242,7 @@ namespace Euler_DG
           }
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           return 0.;
       }
   }
@@ -653,7 +653,7 @@ namespace Euler_DG
 
         default:
           {
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
             return {};
           }
       }
@@ -2187,7 +2187,7 @@ namespace Euler_DG
           }
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 #ifdef HEX
     triangulation.refine_global(n_global_refinements);

--- a/tests/simplex/step-74.cc
+++ b/tests/simplex/step-74.cc
@@ -915,7 +915,7 @@ namespace Step74
               }
             default:
               {
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
               }
           }
         deallog << "  Number of active cells       : "

--- a/tests/slepc/solve_04.cc
+++ b/tests/slepc/solve_04.cc
@@ -104,7 +104,7 @@ check_solve(SolverType               &solver,
                                   51);
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   deallog << "Eigenvalues:";

--- a/tests/tensors/project_orthogonal.cc
+++ b/tests/tensors/project_orthogonal.cc
@@ -28,7 +28,7 @@ print_type(const Tensor<2, dim, number> &)
   else if (std::is_same_v<number, double>)
     deallog << " Tensor<2, " << dim << ", double>" << std::endl;
   else
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 }
 
 template <int dim, typename number>

--- a/tests/tensors/symmetric_tensor_19.cc
+++ b/tests/tensors/symmetric_tensor_19.cc
@@ -107,7 +107,7 @@ test()
         break;
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
   check(A);
 }

--- a/tests/trilinos/70.cc
+++ b/tests/trilinos/70.cc
@@ -38,5 +38,5 @@ main(int argc, char **argv)
   else if (typeid(TrilinosScalar) == typeid(float))
     deallog << "float" << std::endl;
   else
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
 }

--- a/tests/umfpack/umfpack_04.cc
+++ b/tests/umfpack/umfpack_04.cc
@@ -199,7 +199,7 @@ test()
                                   26);
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   SolverCG<Vector<double>> cg(control,
@@ -226,7 +226,7 @@ test()
                                   26);
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   deallog << "Sparse Factorization" << std::endl;

--- a/tests/vector_tools/integrate_difference_05.cc
+++ b/tests/vector_tools/integrate_difference_05.cc
@@ -75,7 +75,7 @@ public:
           values[5] = 2 * (p[2] + p[0] * p[1]);
           break;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
   }
 };
@@ -147,7 +147,7 @@ test()
         true_value = std::sqrt(29.0 / 3.0);
         break;
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   test<dim>(VectorTools::Hdiv_seminorm, true_value);


### PR DESCRIPTION
This addresses a part of #16536: It introduces a function-like macro `DEAL_II_NOT_IMPLEMENTED()` that we can use instead of the awkward `Assert(false, ExcNotImplemented());`. The outcome is the same, but we don't have to use the fake condition.

There are changes using this macro introduces. First, the error text is different/better for not printing extraneous stuff. As an example, this is what the existing mechanism looks like:
```
--------------------------------------------------------
An error occurred in line <48> of file </home/fac/g/bangerth/p/deal.II/1/install/examples/step-1/step-1.cc> in function
    void first_grid()
The violated condition was: 
    false
Additional information: 
    You are trying to use functionality in deal.II that is currently not
    implemented. In many cases, this indicates that there simply didn't
    appear much of a need for it, or that the author of the original code
    did not have the time to implement a particular case. If you hit this
    exception, it is therefore worth the time to look into the code to
    find out whether you may be able to implement the missing
    functionality. If you do, please consider providing a patch to the
    deal.II development sources (see the deal.II website on how to
    contribute).

Stacktrace:
-----------
#0  ./step-1: first_grid()
#1  ./step-1: main
--------------------------------------------------------
```
whereas we now get this:
```
--------------------------------------------------------
An error occurred in line <48> of file </home/fac/g/bangerth/p/deal.II/1/install/examples/step-1/step-1.cc> in function
    void first_grid()
Additional information: 
    You are trying to use functionality in deal.II that is currently not
    implemented. In many cases, this indicates that there simply didn't
    appear much of a need for it, or that the author of the original code
    did not have the time to implement a particular case. If you hit this
    exception, it is therefore worth the time to look into the code to
    find out whether you may be able to implement the missing
    functionality. If you do, please consider providing a patch to the
    deal.II development sources (see the deal.II website on how to
    contribute).

Stacktrace:
-----------
#0  ./step-1: first_grid()
#1  ./step-1: main
--------------------------------------------------------
```

Second, the new macro unconditionally raises the error (i.e., either aborts the program, or throws an exception), whereas the current system lets the code run in release mode. I think this is the right decision; because there is no condition that needs to be evaluated when hitting this macro, there is also no runtime cost implied.

In cases where the question of whether something is implemented or not depends on a condition, we will continue to use
```
  Assert (cond, ExcNotImplemented());
```

This patch converts all places I could find in the library itself, but does not touch the tutorials. I'll get to that in a later PR.