### PR TITLE
Fix Copy Constructor in TpetraWrappers::Vector.

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -63,9 +63,17 @@ namespace LinearAlgebra
       : Subscriptor()
       , compressed(V.compressed)
       , has_ghost(V.has_ghost)
-      , vector(V.vector)
-      , nonlocal_vector(V.nonlocal_vector)
-    {}
+      , vector(Utilities::Trilinos::internal::make_rcp<VectorType>(
+          V.vector->getMap()))
+    {
+      Tpetra::deep_copy(*vector, *V.vector);
+      if (!V.nonlocal_vector.is_null())
+        {
+          nonlocal_vector = Utilities::Trilinos::internal::make_rcp<VectorType>(
+            V.nonlocal_vector->getMap());
+          Tpetra::deep_copy(*nonlocal_vector, *V.nonlocal_vector);
+        }
+    }
 
 
 


### PR DESCRIPTION
I finally chased down the bug that caused the test trilinos/tpetra_vector_01 to fail.

The problem originated from the copy constructor of TpetraWrappers::Vector. 

This should finally close #16508.