### PR TITLE
Add a couple missing includes

### DIFF
--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -39,6 +39,7 @@
 #endif
 
 
+#include <array>
 #include <cmath>
 #include <ostream>
 #include <type_traits>

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -22,6 +22,7 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/template_constraints.h>
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 


### PR DESCRIPTION
I noticed that I need them when compiling with `gcc-13.2.0`.
`array` for `std::array` and `algorithm` for `std::copy_n`,