### PR TITLE
Testsuite: use `./serial` subdirectory

### DIFF
--- a/cmake/macros/macro_deal_ii_add_test.cmake
+++ b/cmake/macros/macro_deal_ii_add_test.cmake
@@ -407,6 +407,10 @@ function(deal_ii_add_test _category _test_name _comparison_file)
       set(_test_full      ${_category}/${_test_name}) # full test name
       set(_test_directory ${CMAKE_CURRENT_BINARY_DIR}/${_test_name}.${_build_lowercase}) # directory to run the test in
 
+      if("${_n_cpu}" STREQUAL "0" AND "${_n_threads}" STREQUAL "0")
+        string(APPEND _test_directory "/serial")
+      endif()
+
       if(NOT "${_n_cpu}" STREQUAL "0")
         string(APPEND _test_target   ".mpirun${_n_cpu}")
         string(APPEND _test_full     ".mpirun=${_n_cpu}")

--- a/cmake/macros/macro_deal_ii_add_test.cmake
+++ b/cmake/macros/macro_deal_ii_add_test.cmake
@@ -65,7 +65,7 @@
 #
 # The following variables must be set:
 #
-#  BASH
+#   BASH
 #     - Complete path to the bash shell.
 #
 #   NUMDIFF_EXECUTABLE
@@ -92,8 +92,7 @@
 #       to 0.
 #
 #   ENABLE_PERFORMANCE_TESTS
-#     - If defined and set to true the execution of performance tests will
-#       be enabled.
+#     - If set to true the execution of performance tests will be enabled.
 #
 #   TESTING_ENVIRONMENT
 #     - Specifies the performance test testing environment. Valid options

--- a/cmake/macros/macro_deal_ii_pickup_tests.cmake
+++ b/cmake/macros/macro_deal_ii_pickup_tests.cmake
@@ -20,9 +20,9 @@
 # If TEST_PICKUP_REGEX is set, only tests matching the regex will be
 # processed.
 #
-# Furthermore, the macro sets up (if necessary) deal.II, perl, numdiff,
-# and the following variables, that can be overwritten by environment or
-# command line:
+# Furthermore, the macro sets up (if necessary) deal.II, bash, perl,
+# numdiff, and the following variables, that can be overwritten by
+# environment or command line:
 #
 #     TEST_LIBRARIES
 #     TEST_LIBRARIES_DEBUG


### PR DESCRIPTION
As suggested by @peterrum

    - CMake: update comments
    - CMake: deal_ii_add_test(): use ./serial subdirectory for output of serial tests
