### PR TITLE
Testsuite: remove implicit target dependencies when possible (ninja support)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,7 +76,8 @@ endif()
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/CTestTestfile.cmake "")
 
 #
-# Always undefine the following variables in the setup_tests target:
+# Ensure that the following variables are set correctly in the test
+# subprojects:
 #
 foreach(_var
     DIFF_DIR NUMDIFF_DIR TEST_PICKUP_REGEX TEST_TIME_LIMIT

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -134,15 +134,11 @@ foreach(_category ${_categories})
 
   file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${_category})
 
+  set(_redirect ">" "/dev/null")
   if(DEAL_II_MSVC)
-    set(_command ${CMAKE_COMMAND} -G${CMAKE_GENERATOR} ${_options} ${_category_dir})
-  else()
-    # Do not pass the generator with -G so that we use make instead of ninja
-    # for the test projects. This is because calling ninja several times in
-    # parallel for the same project will break the configuration.
-
-    set(_command ${CMAKE_COMMAND} ${_options} ${_category_dir} > "${_summary_files_prefix}_${_category}")
+    set (_redirect "")
   endif()
+  set(_command ${CMAKE_COMMAND} -G${CMAKE_GENERATOR} ${_options} ${_category_dir} ${_redirect})
 
   add_custom_target(setup_tests_${_category}
     COMMAND ${_command}


### PR DESCRIPTION
This is a first part in a series of testsuite performance improvements.

Remove unnecessary, implicit target dependencies in our testsuite between for  tests with shared executable targets. These are all test variants where multiple tests share a single executable target, such as, for example MPI tests:
```
foobar.cc
foobar.mpirun=2.output
foobar.mpirun=4.output
```
Here, we ensure that an executable `foobar` is built from the `foobar.cc` sources before running either of the two test variants. This happens by first creating an executable target for `foobar` and then creating a test `test_dependency/category.foobar.(debug|release).executable` and require it to run before the `category/foobar.(debug|release)` with the help of CTEST's `FIXTURES_REQUIRED` mechanism.  

We need this in order to support ninja for the testsuite: concurrent invocation of ninja (as we do in the testsuite) can lead to an incomplete `.ninja_log` file so that subsequent invocations do not rebuild the executable (which leads to unnecessary compilation times, and worse, race conditions).


- CMake: split implicit target dependencies for shared executable dependencies
- CMake: chain CMAKE_GENERATOR through to test subprojects
