### PR TITLE
Make a deep-copy of the Tpetra::Vector in the assignment operator.

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -289,7 +289,43 @@ namespace LinearAlgebra
       //  - Third case: the vectors have different size.
       if (vector->getMap()->isSameAs(*V.vector->getMap()))
         {
-          *vector = Tpetra::createCopy(*V.vector);
+          // Create a read-only Kokkos view from the source vector
+#  if DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
+          auto source_vector_2d =
+            V.vector->template getLocalView<Kokkos::HostSpace>(
+              Tpetra::Access::ReadOnly);
+#  else
+          auto source_vector_2d =
+            V.vector->template getLocalView<Kokkos::HostSpace>();
+#  endif
+          auto source_vector_1d =
+            Kokkos::subview(source_vector_2d, Kokkos::ALL(), 0);
+
+          // Create a read/write Kokkos view from the target vector
+#  if DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
+          auto target_vector_2d =
+            vector->template getLocalView<Kokkos::HostSpace>(
+              Tpetra::Access::ReadWrite);
+#  else
+          vector->template sync<Kokkos::HostSpace>();
+          auto target_vector_2d =
+            vector->template getLocalView<Kokkos::HostSpace>();
+#  endif
+          auto target_vector_1d =
+            Kokkos::subview(target_vector_2d, Kokkos::ALL(), 0);
+#  if !DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
+          vector->template modify<Kokkos::HostSpace>();
+#  endif
+
+          // Copy the data
+          Kokkos::deep_copy(target_vector_1d, source_vector_1d);
+
+#  if !DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
+          vector->template sync<typename Tpetra::Vector<
+            Number,
+            int,
+            types::signed_global_dof_index>::device_type::memory_space>();
+#  endif
         }
       else if (size() == V.size())
         {

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -289,7 +289,7 @@ namespace LinearAlgebra
       //  - Third case: the vectors have different size.
       if (vector->getMap()->isSameAs(*V.vector->getMap()))
         {
-          *vector = *V.vector;
+          *vector = Tpetra::createCopy(*V.vector);
         }
       else if (size() == V.size())
         {
@@ -317,9 +317,9 @@ namespace LinearAlgebra
       else
         {
           vector.reset();
-          vector = Utilities::Trilinos::internal::make_rcp<VectorType>(
-            V.vector->getMap());
-          Tpetra::deep_copy(*vector, *V.vector);
+          vector =
+            Utilities::Trilinos::internal::make_rcp<VectorType>(*V.vector,
+                                                                Teuchos::Copy);
 
           compressed             = V.compressed;
           has_ghost              = V.has_ghost;


### PR DESCRIPTION
Follow up of the PR #16545.

In the assignment operator, we must perform a deep-copy of the vector instead of a shallow copy.
This should fix the assignment operator.