### PR TITLE
Convert tutorial programs to use DEAL_II_NOT_IMPLEMENTED().

### DIFF
--- a/examples/doxygen/step_3_mixed.cc
+++ b/examples/doxygen/step_3_mixed.cc
@@ -252,7 +252,7 @@ void Step3::setup_system()
       else if (cell->reference_cell() == ReferenceCells::Quadrilateral)
         cell->set_active_fe_index(1);
       else
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 
   dof_handler.distribute_dofs(fe);

--- a/examples/step-18/step-18.cc
+++ b/examples/step-18/step-18.cc
@@ -1177,7 +1177,7 @@ namespace Step18
           solution_names.emplace_back("delta_z");
           break;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     data_out.add_data_vector(incremental_displacement, solution_names);

--- a/examples/step-21/step-21.cc
+++ b/examples/step-21/step-21.cc
@@ -995,7 +995,7 @@ namespace Step21
           break;
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     DataOut<dim> data_out;

--- a/examples/step-25/step-25.cc
+++ b/examples/step-25/step-25.cc
@@ -203,7 +203,7 @@ namespace Step25
             }
 
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
             return -1e8;
         }
     }

--- a/examples/step-33/step-33.cc
+++ b/examples/step-33/step-33.cc
@@ -418,7 +418,7 @@ namespace Step33
               }
 
             default:
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
           }
     }
 
@@ -2054,7 +2054,7 @@ namespace Step33
           alpha = face_diameter / (2.0 * parameters.time_step);
           break;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           alpha = 1;
       }
 
@@ -2210,7 +2210,7 @@ namespace Step33
           }
       }
 
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
     return {0, 0};
   }
 

--- a/examples/step-34/step-34.cc
+++ b/examples/step-34/step-34.cc
@@ -505,7 +505,7 @@ namespace Step34
           break;
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     GridIn<dim - 1, dim> gi;

--- a/examples/step-35/step-35.cc
+++ b/examples/step-35/step-35.cc
@@ -1079,7 +1079,7 @@ namespace Step35
                     boundary_values);
                   break;
                 default:
-                  Assert(false, ExcNotImplemented());
+                  DEAL_II_NOT_IMPLEMENTED();
               }
           }
         MatrixTools::apply_boundary_values(boundary_values,
@@ -1260,7 +1260,7 @@ namespace Step35
           pres_n += phi_n;
           break;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       };
   }
 

--- a/examples/step-42/step-42.cc
+++ b/examples/step-42/step-42.cc
@@ -385,7 +385,7 @@ namespace Step42
             return 1000;
         }
 
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return 1e9; // an unreasonable value; ignored in debug mode because of the
                   // preceding Assert
     }
@@ -559,7 +559,7 @@ namespace Step42
             return z_surface + 0.999 - input_obstacle.get_value(p[0], p[1]);
         }
 
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
       return 1e9; // an unreasonable value; ignored in debug mode because of the
                   // preceding Assert
     }

--- a/examples/step-46/step-46.cc
+++ b/examples/step-46/step-46.cc
@@ -182,7 +182,7 @@ namespace Step46
           case 3:
             return std::sin(numbers::PI * p[0]) * std::sin(numbers::PI * p[1]);
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
 
     return 0;
@@ -306,7 +306,7 @@ namespace Step46
         else if (cell_is_in_solid_domain(cell))
           cell->set_active_fe_index(1);
         else
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
   }
 

--- a/examples/step-50/step-50.cc
+++ b/examples/step-50/step-50.cc
@@ -553,7 +553,7 @@ void LaplaceProblem<dim, degree>::setup_system()
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 
@@ -711,7 +711,7 @@ void LaplaceProblem<dim, degree>::setup_multigrid()
         }
 
       default:
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
     }
 }
 

--- a/examples/step-51/step-51.cc
+++ b/examples/step-51/step-51.cc
@@ -218,7 +218,7 @@ namespace Step51
             convection[2] = 1;
             break;
           default:
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
         }
       return convection;
     }
@@ -1208,7 +1208,7 @@ namespace Step51
           filename = "solution-adaptive";
           break;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     std::string face_out(filename);
@@ -1332,7 +1332,7 @@ namespace Step51
 
           default:
             {
-              Assert(false, ExcNotImplemented());
+              DEAL_II_NOT_IMPLEMENTED();
             }
         }
 

--- a/examples/step-63/step-63.cc
+++ b/examples/step-63/step-63.cc
@@ -633,7 +633,7 @@ namespace Step63
               DoFRenumbering::random(dof_handler, level);
           }
         else
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     // The rest of the function just sets up data structures. The last

--- a/examples/step-67/step-67.cc
+++ b/examples/step-67/step-67.cc
@@ -206,7 +206,7 @@ namespace Euler_DG
           }
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           return 0.;
       }
   }
@@ -615,7 +615,7 @@ namespace Euler_DG
 
         default:
           {
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
             return {};
           }
       }
@@ -2011,7 +2011,7 @@ namespace Euler_DG
           }
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     triangulation.refine_global(n_global_refinements);

--- a/examples/step-74/step-74.cc
+++ b/examples/step-74/step-74.cc
@@ -996,7 +996,7 @@ namespace Step74
 
             default:
               {
-                Assert(false, ExcNotImplemented());
+                DEAL_II_NOT_IMPLEMENTED();
               }
           }
 

--- a/examples/step-75/step-75.cc
+++ b/examples/step-75/step-75.cc
@@ -377,7 +377,7 @@ namespace Step75
   template <int dim, typename number>
   number LaplaceOperator<dim, number>::el(unsigned int, unsigned int) const
   {
-    Assert(false, ExcNotImplemented());
+    DEAL_II_NOT_IMPLEMENTED();
     return 0;
   }
 

--- a/examples/step-76/step-76.cc
+++ b/examples/step-76/step-76.cc
@@ -259,7 +259,7 @@ namespace Euler_DG
           }
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
           return 0.;
       }
   }
@@ -380,7 +380,7 @@ namespace Euler_DG
 
         default:
           {
-            Assert(false, ExcNotImplemented());
+            DEAL_II_NOT_IMPLEMENTED();
             return {};
           }
       }
@@ -526,7 +526,7 @@ namespace Euler_DG
       }
     else
       {
-        Assert(false, ExcNotImplemented());
+        DEAL_II_NOT_IMPLEMENTED();
       }
 #else
     (void)subcommunicator;
@@ -1399,7 +1399,7 @@ namespace Euler_DG
           }
 
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
 
     triangulation.refine_global(n_global_refinements);

--- a/examples/step-78/step-78.cc
+++ b/examples/step-78/step-78.cc
@@ -675,7 +675,7 @@ namespace BlackScholesSolver
           conv_filename += "-q2";
           break;
         default:
-          Assert(false, ExcNotImplemented());
+          DEAL_II_NOT_IMPLEMENTED();
       }
     conv_filename += ".tex";
     std::ofstream table_file(conv_filename);

--- a/examples/step-82/step-82.cc
+++ b/examples/step-82/step-82.cc
@@ -193,7 +193,7 @@ namespace Step82
                          Utilities::fixed_power<2>(p[0] * (1.0 - p[0]));
       }
     else
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
 
     return return_value;
   }
@@ -241,7 +241,7 @@ namespace Step82
           p[0] * (1.0 - p[0]) * p[1] * (1.0 - p[1]) * p[2] * (1.0 - p[2]));
       }
     else
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
 
     return return_value;
   }
@@ -282,7 +282,7 @@ namespace Step82
           Utilities::fixed_power<2>(p[0] * (1.0 - p[0]) * p[1] * (1.0 - p[1]));
       }
     else
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
 
     return return_gradient;
   }
@@ -339,7 +339,7 @@ namespace Step82
           Utilities::fixed_power<2>(p[0] * (1.0 - p[0]) * p[1] * (1.0 - p[1]));
       }
     else
-      Assert(false, ExcNotImplemented());
+      DEAL_II_NOT_IMPLEMENTED();
 
     return return_hessian;
   }


### PR DESCRIPTION
This addresses #16552 in parts: It converts a bunch of places to use `DEAL_II_NOT_IMPLEMENTED()` where we used `Assert (false, ExcNotImplemented());` before. I did not change any of the accompanying documentation because there are earlier programs than the ones I'm touching here (specifically step-7 and step-8) where that can be done, and I will do that in a separate PR -- this is the one where things can be changed by script.