### PR TITLE
Template TrilinosWrappers::Vector on memory space

### DIFF
--- a/include/deal.II/base/template_constraints.h
+++ b/include/deal.II/base/template_constraints.h
@@ -668,7 +668,7 @@ namespace LinearAlgebra
 #  ifdef DEAL_II_TRILINOS_WITH_TPETRA
   namespace TpetraWrappers
   {
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     class Vector;
 
     template <typename Number, typename MemorySpace>

--- a/include/deal.II/lac/trilinos_tpetra_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparse_matrix.h
@@ -464,7 +464,8 @@ namespace LinearAlgebra
        * of the matrix.
        */
       void
-      vmult(Vector<Number> &dst, const Vector<Number> &src) const;
+      vmult(Vector<Number, MemorySpace>       &dst,
+            const Vector<Number, MemorySpace> &src) const;
 
       /*
        * Matrix-vector multiplication: let <i>dst = M<sup>T</sup>*src</i> with
@@ -474,7 +475,8 @@ namespace LinearAlgebra
        * Source and destination must not be the same vector.
        */
       void
-      Tvmult(Vector<Number> &dst, const Vector<Number> &src) const;
+      Tvmult(Vector<Number, MemorySpace>       &dst,
+             const Vector<Number, MemorySpace> &src) const;
 
       /**
        * Adding matrix-vector multiplication. Add <i>M*src</i> on <i>dst</i>
@@ -483,7 +485,8 @@ namespace LinearAlgebra
        * Source and destination must not be the same vector.
        */
       void
-      vmult_add(Vector<Number> &dst, const Vector<Number> &src) const;
+      vmult_add(Vector<Number, MemorySpace>       &dst,
+                const Vector<Number, MemorySpace> &src) const;
 
 
       /**
@@ -494,7 +497,8 @@ namespace LinearAlgebra
        * Source and destination must not be the same vector.
        */
       void
-      Tvmult_add(Vector<Number> &dst, const Vector<Number> &src) const;
+      Tvmult_add(Vector<Number, MemorySpace>       &dst,
+                 const Vector<Number, MemorySpace> &src) const;
       /** @} */
 
       /**

--- a/include/deal.II/lac/trilinos_tpetra_sparse_matrix.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparse_matrix.templates.h
@@ -585,8 +585,9 @@ namespace LinearAlgebra
 
     template <typename Number, typename MemorySpace>
     void
-    SparseMatrix<Number, MemorySpace>::vmult(Vector<Number>       &dst,
-                                             const Vector<Number> &src) const
+    SparseMatrix<Number, MemorySpace>::vmult(
+      Vector<Number, MemorySpace>       &dst,
+      const Vector<Number, MemorySpace> &src) const
     {
       Assert(&src != &dst, ExcSourceEqualsDestination());
       Assert(matrix->isFillComplete(), ExcMatrixNotCompressed());
@@ -601,8 +602,9 @@ namespace LinearAlgebra
 
     template <typename Number, typename MemorySpace>
     void
-    SparseMatrix<Number, MemorySpace>::Tvmult(Vector<Number>       &dst,
-                                              const Vector<Number> &src) const
+    SparseMatrix<Number, MemorySpace>::Tvmult(
+      Vector<Number, MemorySpace>       &dst,
+      const Vector<Number, MemorySpace> &src) const
     {
       Assert(&src != &dst, ExcSourceEqualsDestination());
       Assert(matrix->isFillComplete(), ExcMatrixNotCompressed());
@@ -618,8 +620,8 @@ namespace LinearAlgebra
     template <typename Number, typename MemorySpace>
     void
     SparseMatrix<Number, MemorySpace>::vmult_add(
-      Vector<Number>       &dst,
-      const Vector<Number> &src) const
+      Vector<Number, MemorySpace>       &dst,
+      const Vector<Number, MemorySpace> &src) const
     {
       Assert(&src != &dst, ExcSourceEqualsDestination());
       Assert(matrix->isFillComplete(), ExcMatrixNotCompressed());
@@ -639,8 +641,8 @@ namespace LinearAlgebra
     template <typename Number, typename MemorySpace>
     void
     SparseMatrix<Number, MemorySpace>::Tvmult_add(
-      Vector<Number>       &dst,
-      const Vector<Number> &src) const
+      Vector<Number, MemorySpace>       &dst,
+      const Vector<Number, MemorySpace> &src) const
     {
       Assert(&src != &dst, ExcSourceEqualsDestination());
       Assert(matrix->isFillComplete(), ExcMatrixNotCompressed());

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -125,7 +125,8 @@ namespace LinearAlgebra
        *
        * @ingroup TpetraWrappers
        */
-      template <typename Number, typename MemorySpace>
+      template <typename Number,
+                typename MemorySpace = dealii::MemorySpace::Host>
       class VectorReference
       {
       private:

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -44,8 +44,8 @@ namespace LinearAlgebra
 {
   namespace TpetraWrappers
   {
-    template <typename Number>
-    Vector<Number>::Vector()
+    template <typename Number, typename MemorySpace>
+    Vector<Number, MemorySpace>::Vector()
       : Subscriptor()
       , compressed(true)
       , has_ghost(false)
@@ -58,8 +58,8 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
-    Vector<Number>::Vector(const Vector<Number> &V)
+    template <typename Number, typename MemorySpace>
+    Vector<Number, MemorySpace>::Vector(const Vector<Number, MemorySpace> &V)
       : Subscriptor()
       , compressed(V.compressed)
       , has_ghost(V.has_ghost)
@@ -69,8 +69,8 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
-    Vector<Number>::Vector(const Teuchos::RCP<VectorType> V)
+    template <typename Number, typename MemorySpace>
+    Vector<Number, MemorySpace>::Vector(const Teuchos::RCP<VectorType> V)
       : Subscriptor()
       , compressed(true)
       , has_ghost(V->getMap()->isOneToOne() == false)
@@ -79,9 +79,9 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
-    Vector<Number>::Vector(const IndexSet &parallel_partitioner,
-                           const MPI_Comm  communicator)
+    template <typename Number, typename MemorySpace>
+    Vector<Number, MemorySpace>::Vector(const IndexSet &parallel_partitioner,
+                                        const MPI_Comm  communicator)
       : Subscriptor()
       , compressed(true)
       , has_ghost(false)
@@ -91,11 +91,11 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
-    Vector<Number>::Vector(const IndexSet &locally_owned_entries,
-                           const IndexSet &ghost_entries,
-                           const MPI_Comm  communicator,
-                           const bool      vector_writable)
+    template <typename Number, typename MemorySpace>
+    Vector<Number, MemorySpace>::Vector(const IndexSet &locally_owned_entries,
+                                        const IndexSet &ghost_entries,
+                                        const MPI_Comm  communicator,
+                                        const bool      vector_writable)
       : Subscriptor()
     {
       if (!vector_writable)
@@ -135,11 +135,11 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     void
-    Vector<Number>::reinit(const IndexSet &parallel_partitioner,
-                           const MPI_Comm  communicator,
-                           const bool /*omit_zeroing_entries*/)
+    Vector<Number, MemorySpace>::reinit(const IndexSet &parallel_partitioner,
+                                        const MPI_Comm  communicator,
+                                        const bool /*omit_zeroing_entries*/)
     {
       vector.reset();
       nonlocal_vector.reset();
@@ -152,12 +152,12 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     void
-    Vector<Number>::reinit(const IndexSet &locally_owned_entries,
-                           const IndexSet &ghost_entries,
-                           const MPI_Comm  communicator,
-                           const bool      vector_writable)
+    Vector<Number, MemorySpace>::reinit(const IndexSet &locally_owned_entries,
+                                        const IndexSet &ghost_entries,
+                                        const MPI_Comm  communicator,
+                                        const bool      vector_writable)
     {
       // release memory before reallocation
       nonlocal_vector.reset();
@@ -201,10 +201,10 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     void
-    Vector<Number>::reinit(const Vector<Number> &V,
-                           const bool            omit_zeroing_entries)
+    Vector<Number, MemorySpace>::reinit(const Vector<Number, MemorySpace> &V,
+                                        const bool omit_zeroing_entries)
     {
       reinit(V.locally_owned_elements(),
              V.get_mpi_communicator(),
@@ -213,9 +213,9 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     void
-    Vector<Number>::extract_subvector_to(
+    Vector<Number, MemorySpace>::extract_subvector_to(
       const ArrayView<const types::global_dof_index> &indices,
       ArrayView<Number>                              &elements) const
     {
@@ -271,9 +271,9 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
-    Vector<Number> &
-    Vector<Number>::operator=(const Vector<Number> &V)
+    template <typename Number, typename MemorySpace>
+    Vector<Number, MemorySpace> &
+    Vector<Number, MemorySpace>::operator=(const Vector<Number, MemorySpace> &V)
     {
       // Distinguish three cases:
       //  - First case: both vectors have the same layout.
@@ -324,9 +324,9 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
-    Vector<Number> &
-    Vector<Number>::operator=(const Number s)
+    template <typename Number, typename MemorySpace>
+    Vector<Number, MemorySpace> &
+    Vector<Number, MemorySpace>::operator=(const Number s)
     {
       (void)s;
       Assert(s == Number(0.0),
@@ -346,9 +346,9 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     void
-    Vector<Number>::import_elements(
+    Vector<Number, MemorySpace>::import_elements(
       const ReadWriteVector<Number> &V,
       VectorOperation::values        operation,
       const Teuchos::RCP<const Utilities::MPI::CommunicationPatternBase>
@@ -423,9 +423,9 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     void
-    Vector<Number>::import_elements(
+    Vector<Number, MemorySpace>::import_elements(
       const ReadWriteVector<Number> &V,
       VectorOperation::values        operation,
       const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase> &)
@@ -435,10 +435,11 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     void
-    Vector<Number>::import_elements(const ReadWriteVector<Number> &V,
-                                    VectorOperation::values        operation)
+    Vector<Number, MemorySpace>::import_elements(
+      const ReadWriteVector<Number> &V,
+      VectorOperation::values        operation)
     {
       // Create an empty CommunicationPattern
       const Teuchos::RCP<const Utilities::MPI::CommunicationPatternBase>
@@ -449,9 +450,9 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
-    Vector<Number> &
-    Vector<Number>::operator*=(const Number factor)
+    template <typename Number, typename MemorySpace>
+    Vector<Number, MemorySpace> &
+    Vector<Number, MemorySpace>::operator*=(const Number factor)
     {
       AssertIsFinite(factor);
       vector->scale(factor);
@@ -461,9 +462,9 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
-    Vector<Number> &
-    Vector<Number>::operator/=(const Number factor)
+    template <typename Number, typename MemorySpace>
+    Vector<Number, MemorySpace> &
+    Vector<Number, MemorySpace>::operator/=(const Number factor)
     {
       AssertIsFinite(factor);
       Assert(factor != Number(0.), ExcZero());
@@ -474,9 +475,10 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
-    Vector<Number> &
-    Vector<Number>::operator+=(const Vector<Number> &V)
+    template <typename Number, typename MemorySpace>
+    Vector<Number, MemorySpace> &
+    Vector<Number, MemorySpace>::operator+=(
+      const Vector<Number, MemorySpace> &V)
     {
       // If the maps are the same we can update right away.
       if (vector->getMap()->isSameAs(*(V.trilinos_vector().getMap())))
@@ -504,9 +506,10 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
-    Vector<Number> &
-    Vector<Number>::operator-=(const Vector<Number> &V)
+    template <typename Number, typename MemorySpace>
+    Vector<Number, MemorySpace> &
+    Vector<Number, MemorySpace>::operator-=(
+      const Vector<Number, MemorySpace> &V)
     {
       this->add(-1., V);
 
@@ -515,9 +518,10 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     Number
-    Vector<Number>::operator*(const Vector<Number> &V) const
+    Vector<Number, MemorySpace>::operator*(
+      const Vector<Number, MemorySpace> &V) const
     {
       Assert(this->size() == V.size(),
              ExcDimensionMismatch(this->size(), V.size()));
@@ -530,9 +534,9 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     Number
-    Vector<Number>::operator()(const size_type index) const
+    Vector<Number, MemorySpace>::operator()(const size_type index) const
     {
       // Get the local index
       const TrilinosWrappers::types::int_type local_index =
@@ -569,9 +573,9 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     void
-    Vector<Number>::add(const Number a)
+    Vector<Number, MemorySpace>::add(const Number a)
     {
       AssertIsFinite(a);
 
@@ -604,9 +608,10 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     void
-    Vector<Number>::add(const Number a, const Vector<Number> &V)
+    Vector<Number, MemorySpace>::add(const Number                       a,
+                                     const Vector<Number, MemorySpace> &V)
     {
       AssertIsFinite(a);
 
@@ -622,12 +627,12 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     void
-    Vector<Number>::add(const Number          a,
-                        const Vector<Number> &V,
-                        const Number          b,
-                        const Vector<Number> &W)
+    Vector<Number, MemorySpace>::add(const Number                       a,
+                                     const Vector<Number, MemorySpace> &V,
+                                     const Number                       b,
+                                     const Vector<Number, MemorySpace> &W)
     {
       AssertIsFinite(a);
       AssertIsFinite(b);
@@ -646,11 +651,11 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     void
-    Vector<Number>::sadd(const Number          s,
-                         const Number          a,
-                         const Vector<Number> &V)
+    Vector<Number, MemorySpace>::sadd(const Number                       s,
+                                      const Number                       a,
+                                      const Vector<Number, MemorySpace> &V)
     {
       AssertIsFinite(s);
       AssertIsFinite(a);
@@ -661,16 +666,17 @@ namespace LinearAlgebra
 
       *this *= s;
 
-      Vector<Number> tmp(V);
+      Vector<Number, MemorySpace> tmp(V);
       tmp *= a;
       *this += tmp;
     }
 
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     void
-    Vector<Number>::scale(const Vector<Number> &scaling_factors)
+    Vector<Number, MemorySpace>::scale(
+      const Vector<Number, MemorySpace> &scaling_factors)
     {
       Assert(vector->getMap()->isSameAs(
                *(scaling_factors.trilinos_vector().getMap())),
@@ -685,9 +691,10 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     void
-    Vector<Number>::equ(const Number a, const Vector<Number> &V)
+    Vector<Number, MemorySpace>::equ(const Number                       a,
+                                     const Vector<Number, MemorySpace> &V)
     {
       AssertIsFinite(a);
 
@@ -707,9 +714,9 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     bool
-    Vector<Number>::all_zero() const
+    Vector<Number, MemorySpace>::all_zero() const
     {
       // get a representation of the vector and
       // loop over all the elements
@@ -738,9 +745,9 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     Number
-    Vector<Number>::mean_value() const
+    Vector<Number, MemorySpace>::mean_value() const
     {
       Assert(!has_ghost_elements(), ExcGhostsPresent());
 
@@ -749,9 +756,9 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
-    typename Vector<Number>::real_type
-    Vector<Number>::l1_norm() const
+    template <typename Number, typename MemorySpace>
+    typename Vector<Number, MemorySpace>::real_type
+    Vector<Number, MemorySpace>::l1_norm() const
     {
       Assert(!has_ghost_elements(), ExcGhostsPresent());
 
@@ -760,9 +767,9 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
-    typename Vector<Number>::real_type
-    Vector<Number>::l2_norm() const
+    template <typename Number, typename MemorySpace>
+    typename Vector<Number, MemorySpace>::real_type
+    Vector<Number, MemorySpace>::l2_norm() const
     {
       Assert(!has_ghost_elements(), ExcGhostsPresent());
 
@@ -771,9 +778,9 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
-    typename Vector<Number>::real_type
-    Vector<Number>::linfty_norm() const
+    template <typename Number, typename MemorySpace>
+    typename Vector<Number, MemorySpace>::real_type
+    Vector<Number, MemorySpace>::linfty_norm() const
     {
       Assert(!has_ghost_elements(), ExcGhostsPresent());
 
@@ -782,11 +789,12 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     Number
-    Vector<Number>::add_and_dot(const Number          a,
-                                const Vector<Number> &V,
-                                const Vector<Number> &W)
+    Vector<Number, MemorySpace>::add_and_dot(
+      const Number                       a,
+      const Vector<Number, MemorySpace> &V,
+      const Vector<Number, MemorySpace> &W)
     {
       AssertIsFinite(a);
 
@@ -797,27 +805,27 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
-    typename Vector<Number>::size_type
-    Vector<Number>::size() const
+    template <typename Number, typename MemorySpace>
+    typename Vector<Number, MemorySpace>::size_type
+    Vector<Number, MemorySpace>::size() const
     {
       return vector->getGlobalLength();
     }
 
 
 
-    template <typename Number>
-    typename Vector<Number>::size_type
-    Vector<Number>::locally_owned_size() const
+    template <typename Number, typename MemorySpace>
+    typename Vector<Number, MemorySpace>::size_type
+    Vector<Number, MemorySpace>::locally_owned_size() const
     {
       return vector->getLocalLength();
     }
 
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     MPI_Comm
-    Vector<Number>::get_mpi_communicator() const
+    Vector<Number, MemorySpace>::get_mpi_communicator() const
     {
       return Utilities::Trilinos::teuchos_comm_to_mpi_comm(
         vector->getMap()->getComm());
@@ -825,18 +833,19 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     IndexSet
-    Vector<Number>::locally_owned_elements() const
+    Vector<Number, MemorySpace>::locally_owned_elements() const
     {
       return IndexSet(vector->getMap());
     }
 
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     void
-    Vector<Number>::compress(const VectorOperation::values operation)
+    Vector<Number, MemorySpace>::compress(
+      const VectorOperation::values operation)
     {
       Assert(has_ghost == false,
              ExcMessage(
@@ -866,49 +875,49 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     const Tpetra::Vector<Number, int, types::signed_global_dof_index> &
-    Vector<Number>::trilinos_vector() const
+    Vector<Number, MemorySpace>::trilinos_vector() const
     {
       return *vector;
     }
 
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     Tpetra::Vector<Number, int, types::signed_global_dof_index> &
-    Vector<Number>::trilinos_vector()
+    Vector<Number, MemorySpace>::trilinos_vector()
     {
       return *vector;
     }
 
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     Teuchos::RCP<Tpetra::Vector<Number, int, types::signed_global_dof_index>>
-    Vector<Number>::trilinos_rcp()
+    Vector<Number, MemorySpace>::trilinos_rcp()
     {
       return vector;
     }
 
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     Teuchos::RCP<
       const Tpetra::Vector<Number, int, types::signed_global_dof_index>>
-    Vector<Number>::trilinos_rcp() const
+    Vector<Number, MemorySpace>::trilinos_rcp() const
     {
       return vector.getConst();
     }
 
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     void
-    Vector<Number>::print(std::ostream      &out,
-                          const unsigned int precision,
-                          const bool         scientific,
-                          const bool         across) const
+    Vector<Number, MemorySpace>::print(std::ostream      &out,
+                                       const unsigned int precision,
+                                       const bool         scientific,
+                                       const bool         across) const
     {
       AssertThrow(out.fail() == false, ExcIO());
       boost::io::ios_flags_saver restore_flags(out);
@@ -961,18 +970,18 @@ namespace LinearAlgebra
     }
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     MPI_Comm
-    Vector<Number>::mpi_comm() const
+    Vector<Number, MemorySpace>::mpi_comm() const
     {
       return Utilities::Trilinos::teuchos_comm_to_mpi_comm(
         vector->getMap()->getComm());
     }
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     std::size_t
-    Vector<Number>::memory_consumption() const
+    Vector<Number, MemorySpace>::memory_consumption() const
     {
       return sizeof(*this) +
              vector->getLocalLength() *
@@ -981,10 +990,11 @@ namespace LinearAlgebra
 
 
 
-    template <typename Number>
+    template <typename Number, typename MemorySpace>
     void
-    Vector<Number>::create_tpetra_comm_pattern(const IndexSet &source_index_set,
-                                               const MPI_Comm  mpi_comm)
+    Vector<Number, MemorySpace>::create_tpetra_comm_pattern(
+      const IndexSet &source_index_set,
+      const MPI_Comm  mpi_comm)
     {
       source_stored_elements = source_index_set;
 


### PR DESCRIPTION
For consistency with `TpetraWarappers::SparseMatrix`, `TpetraWrappes::SparsityPattern`, and `LinearAlgebra::distributed::Vector`, we should also template `TpetraWrappers::Vector` on the memory space being used.
In particular, we need matching memory spaces for the sparse matrix-vector product anyway.
This also avoids allocating a second `View` when compiling with a GPU backend but only using host capabilities for these classes.