### PR TITLE
Prefer trilinos_vector over trilinos_rcp

### DIFF
--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -2671,7 +2671,7 @@ namespace internal
     parallel_partitioner.add_indices(needed_elements);
 
     const MPI_Comm mpi_comm = Utilities::Trilinos::teuchos_comm_to_mpi_comm(
-      vec.trilinos_rcp()->getMap()->getComm());
+      vec.trilinos_vector().getMap()->getComm());
 
     output.reinit(locally_owned_elements, needed_elements, mpi_comm);
 

--- a/include/deal.II/lac/trilinos_tpetra_sparse_matrix.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparse_matrix.templates.h
@@ -590,11 +590,11 @@ namespace LinearAlgebra
     {
       Assert(&src != &dst, ExcSourceEqualsDestination());
       Assert(matrix->isFillComplete(), ExcMatrixNotCompressed());
-      Assert(src.trilinos_rcp()->getMap()->isSameAs(*matrix->getDomainMap()),
+      Assert(src.trilinos_vector().getMap()->isSameAs(*matrix->getDomainMap()),
              ExcColMapMissmatch());
-      Assert(dst.trilinos_rcp()->getMap()->isSameAs(*matrix->getRangeMap()),
+      Assert(dst.trilinos_vector().getMap()->isSameAs(*matrix->getRangeMap()),
              ExcDomainMapMissmatch());
-      matrix->apply(*src.trilinos_rcp(), *dst.trilinos_rcp());
+      matrix->apply(src.trilinos_vector(), dst.trilinos_vector());
     }
 
 
@@ -606,11 +606,13 @@ namespace LinearAlgebra
     {
       Assert(&src != &dst, ExcSourceEqualsDestination());
       Assert(matrix->isFillComplete(), ExcMatrixNotCompressed());
-      Assert(dst.trilinos_rcp()->getMap()->isSameAs(*matrix->getDomainMap()),
+      Assert(dst.trilinos_vector().getMap()->isSameAs(*matrix->getDomainMap()),
              ExcColMapMissmatch());
-      Assert(src.trilinos_rcp()->getMap()->isSameAs(*matrix->getRangeMap()),
+      Assert(src.trilinos_vector().getMap()->isSameAs(*matrix->getRangeMap()),
              ExcDomainMapMissmatch());
-      matrix->apply(*src.trilinos_rcp(), *dst.trilinos_rcp(), Teuchos::TRANS);
+      matrix->apply(src.trilinos_vector(),
+                    dst.trilinos_vector(),
+                    Teuchos::TRANS);
     }
 
 
@@ -623,12 +625,12 @@ namespace LinearAlgebra
     {
       Assert(&src != &dst, ExcSourceEqualsDestination());
       Assert(matrix->isFillComplete(), ExcMatrixNotCompressed());
-      Assert(src.trilinos_rcp()->getMap()->isSameAs(*matrix->getDomainMap()),
+      Assert(src.trilinos_vector().getMap()->isSameAs(*matrix->getDomainMap()),
              ExcColMapMissmatch());
-      Assert(dst.trilinos_rcp()->getMap()->isSameAs(*matrix->getRangeMap()),
+      Assert(dst.trilinos_vector().getMap()->isSameAs(*matrix->getRangeMap()),
              ExcDomainMapMissmatch());
-      matrix->apply(*src.trilinos_rcp(),
-                    *dst.trilinos_rcp(),
+      matrix->apply(src.trilinos_vector(),
+                    dst.trilinos_vector(),
                     Teuchos::NO_TRANS,
                     Teuchos::ScalarTraits<Number>::one(),
                     Teuchos::ScalarTraits<Number>::one());
@@ -644,12 +646,12 @@ namespace LinearAlgebra
     {
       Assert(&src != &dst, ExcSourceEqualsDestination());
       Assert(matrix->isFillComplete(), ExcMatrixNotCompressed());
-      Assert(dst.trilinos_rcp()->getMap()->isSameAs(*matrix->getDomainMap()),
+      Assert(dst.trilinos_vector().getMap()->isSameAs(*matrix->getDomainMap()),
              ExcColMapMissmatch());
-      Assert(src.trilinos_rcp()->getMap()->isSameAs(*matrix->getRangeMap()),
+      Assert(src.trilinos_vector().getMap()->isSameAs(*matrix->getRangeMap()),
              ExcDomainMapMissmatch());
-      matrix->apply(*src.trilinos_rcp(),
-                    *dst.trilinos_rcp(),
+      matrix->apply(src.trilinos_vector(),
+                    dst.trilinos_vector(),
                     Teuchos::TRANS,
                     Teuchos::ScalarTraits<Number>::one(),
                     Teuchos::ScalarTraits<Number>::one());


### PR DESCRIPTION
Extracted from #16549. We can use one less level of abstraction (from the interface perspective) by using `trilinos_vector` instead of `trilinos_rcp` in the places changed here.