### PR TITLE
Fix assert in import_elements from ReadWriteVector

### DIFF
--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -586,7 +586,7 @@ namespace LinearAlgebra
 
     using size_type = std::decay_t<decltype(size)>;
 
-    Assert(size == 0 || values != nullptr, ExcInternalError("Import failed."));
+    Assert(size == 0 || !values.empty(), ExcInternalError("Import failed."));
     AssertDimension(size, stored_elements.n_elements());
 
     switch (operation)


### PR DESCRIPTION
A small follow-up to #16568. With the use of AlignedVector in ReadWriteVector the assert
```
Assert(size == 0 || values != nullptr, ExcInternalError("Import failed."));
```
does not compile anymore. This should fix that problem.  