### PR TITLE
Use DEAL_II_CXX23_ASSERT in the Tensor class.

### DIFF
--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1537,6 +1537,7 @@ constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE
   Assert(dim != 0,
          ExcMessage("Cannot access an object of type Tensor<rank_,0,Number>"));
   AssertIndexRange(i, dim);
+  DEAL_II_CXX23_ASSUME(i < dim);
 
   return values[i];
 }
@@ -1550,6 +1551,7 @@ constexpr DEAL_II_ALWAYS_INLINE
   Assert(dim != 0,
          ExcMessage("Cannot access an object of type Tensor<rank_,0,Number>"));
   AssertIndexRange(i, dim);
+  DEAL_II_CXX23_ASSUME(i < dim);
 
   return values[i];
 }


### PR DESCRIPTION
As requested elsewhere, let's at least have a place where we're actually using this construct. Let's see what the various compilers say about that.