### PR TITLE
Add TpetraWrapper::BlockVector and TpetraWrappers::BlockSparseMatrix

### DIFF
--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -48,6 +48,8 @@
 #include <deal.II/lac/trilinos_block_sparse_matrix.h>
 #include <deal.II/lac/trilinos_parallel_block_vector.h>
 #include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_tpetra_block_sparse_matrix.h>
+#include <deal.II/lac/trilinos_tpetra_block_vector.h>
 #include <deal.II/lac/trilinos_tpetra_sparse_matrix.h>
 #include <deal.II/lac/trilinos_tpetra_vector.h>
 #include <deal.II/lac/trilinos_vector.h>

--- a/include/deal.II/lac/trilinos_tpetra_block_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_tpetra_block_sparse_matrix.h
@@ -1,0 +1,463 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_tpetra_trilinos_block_sparse_matrix_h
+#define dealii_tpetra_trilinos_block_sparse_matrix_h
+
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+
+#  include <deal.II/base/template_constraints.h>
+
+#  include <deal.II/lac/block_matrix_base.h>
+#  include <deal.II/lac/block_sparse_matrix.h>
+#  include <deal.II/lac/exceptions.h>
+#  include <deal.II/lac/full_matrix.h>
+#  include <deal.II/lac/trilinos_tpetra_block_vector.h>
+#  include <deal.II/lac/trilinos_tpetra_sparse_matrix.h>
+
+#  include <cmath>
+
+DEAL_II_NAMESPACE_OPEN
+
+// forward declarations
+#  ifndef DOXYGEN
+class BlockSparsityPattern;
+template <typename number>
+class BlockSparseMatrix;
+#  endif
+
+namespace LinearAlgebra
+{
+  /**
+   * @addtogroup TpetraWrappers
+   * @{
+   */
+  namespace TpetraWrappers
+  {
+    /**
+     * Blocked sparse matrix based on the
+     * LinearAlgebra::TpetraWrappers::SparseMatrix class. This class implements
+     * the functions that are specific to the Trilinos SparseMatrix base objects
+     * for a blocked sparse matrix, and leaves the actual work relaying most of
+     * the calls to the individual blocks to the functions implemented in the
+     * base class. See there also for a description of when this class is
+     * useful.
+     *
+     * In contrast to the deal.II-type SparseMatrix class, the Trilinos matrices
+     * do not have external objects for the sparsity patterns. Thus, one does
+     * not determine the size of the individual blocks of a block matrix of this
+     * type by attaching a block sparsity pattern, but by calling reinit() to
+     * set the number of blocks and then by setting the size of each block
+     * separately. In order to fix the data structures of the block matrix, it
+     * is then necessary to let it know that we have changed the sizes of the
+     * underlying matrices. For this, one has to call the collect_sizes()
+     * function, for much the same reason as is documented with the
+     * BlockSparsityPattern class.
+     *
+     * @ingroup Matrix1 @see
+     * @ref GlossBlockLA "Block (linear algebra)"
+     */
+    template <typename Number, typename MemorySpace = dealii::MemorySpace::Host>
+    class BlockSparseMatrix
+      : public BlockMatrixBase<SparseMatrix<Number, MemorySpace>>
+    {
+    public:
+      /**
+       * Typedef the base class for simpler access to its own alias.
+       */
+      using BaseClass = BlockMatrixBase<SparseMatrix<Number, MemorySpace>>;
+
+      /**
+       * Typedef the type of the underlying matrix.
+       */
+      using BlockType = typename BaseClass::BlockType;
+
+      /**
+       * Import the alias from the base class.
+       */
+      using value_type      = typename BaseClass::value_type;
+      using pointer         = typename BaseClass::pointer;
+      using const_pointer   = typename BaseClass::const_pointer;
+      using reference       = typename BaseClass::reference;
+      using const_reference = typename BaseClass::const_reference;
+      using size_type       = typename BaseClass::size_type;
+      using iterator        = typename BaseClass::iterator;
+      using const_iterator  = typename BaseClass::const_iterator;
+
+      /**
+       * Constructor; initializes the matrix to be empty, without any structure,
+       * i.e.  the matrix is not usable at all. This constructor is therefore
+       * only useful for matrices which are members of a class. All other
+       * matrices should be created at a point in the data flow where all
+       * necessary information is available.
+       *
+       * You have to initialize the matrix before usage with
+       * reinit(BlockSparsityPattern). The number of blocks per row and column
+       * are then determined by that function.
+       */
+      BlockSparseMatrix() = default;
+
+      /**
+       * Destructor.
+       */
+      ~BlockSparseMatrix() override;
+
+      /**
+       * Pseudo copy operator only copying empty objects. The sizes of the block
+       * matrices need to be the same.
+       */
+      BlockSparseMatrix<Number, MemorySpace> &
+      operator=(const BlockSparseMatrix<Number, MemorySpace> &) = default;
+
+      /**
+       * This operator assigns a scalar to a matrix. Since this does usually not
+       * make much sense (should we set all matrix entries to this value? Only
+       * the nonzero entries of the sparsity pattern?), this operation is only
+       * allowed if the actual value to be assigned is zero. This operator only
+       * exists to allow for the obvious notation <tt>matrix=0</tt>, which sets
+       * all elements of the matrix to zero, but keep the sparsity pattern
+       * previously used.
+       */
+      BlockSparseMatrix<Number, MemorySpace> &
+      operator=(const Number d);
+
+      /**
+       * Resize the matrix, by setting the number of block rows and columns.
+       * This deletes all blocks and replaces them with uninitialized ones, i.e.
+       * ones for which also the sizes are not yet set. You have to do that by
+       * calling the @p reinit functions of the blocks themselves. Do not forget
+       * to call collect_sizes() after that on this object.
+       *
+       * The reason that you have to set sizes of the blocks yourself is that
+       * the sizes may be varying, the maximum number of elements per row may be
+       * varying, etc. It is simpler not to reproduce the interface of the @p
+       * SparsityPattern class here but rather let the user call whatever
+       * function they desire.
+       */
+      void
+      reinit(const size_type n_block_rows, const size_type n_block_columns);
+
+      /**
+       * Resize the matrix, by using an array of index sets to determine the
+       * %parallel distribution of the individual matrices. This function
+       * assumes that a quadratic block matrix is generated.
+       */
+      template <typename BlockSparsityPatternType>
+      void
+      reinit(const std::vector<IndexSet>    &input_maps,
+             const BlockSparsityPatternType &block_sparsity_pattern,
+             const MPI_Comm                  communicator  = MPI_COMM_WORLD,
+             const bool                      exchange_data = false);
+
+      /**
+       * Resize the matrix and initialize it by the given sparsity pattern.
+       * Since no distribution map is given, the result is a block matrix for
+       * which all elements are stored locally.
+       */
+      template <typename BlockSparsityPatternType>
+      void
+      reinit(const BlockSparsityPatternType &block_sparsity_pattern);
+
+      /**
+       * This function initializes the Trilinos matrix using the deal.II sparse
+       * matrix and the entries stored therein. It uses a threshold to copy only
+       * elements whose modulus is larger than the threshold (so zeros in the
+       * deal.II matrix can be filtered away).
+       */
+      void
+      reinit(
+        const std::vector<IndexSet>               &parallel_partitioning,
+        const ::dealii::BlockSparseMatrix<double> &dealii_block_sparse_matrix,
+        const MPI_Comm communicator   = MPI_COMM_WORLD,
+        const double   drop_tolerance = 1e-13);
+
+      /**
+       * This function initializes the Trilinos matrix using the deal.II sparse
+       * matrix and the entries stored therein. It uses a threshold to copy only
+       * elements whose modulus is larger than the threshold (so zeros in the
+       * deal.II matrix can be filtered away). Since no Epetra_Map is given, all
+       * the elements will be locally stored.
+       */
+      void
+      reinit(const ::dealii::BlockSparseMatrix<double> &deal_ii_sparse_matrix,
+             const double                               drop_tolerance = 1e-13);
+
+      /**
+       * Return the state of the matrix, i.e., whether compress() needs to be
+       * called after an operation requiring data exchange. Does only return
+       * non-true values when used in <tt>debug</tt> mode, since it is quite
+       * expensive to keep track of all operations that lead to the need for
+       * compress().
+       */
+      bool
+      is_compressed() const;
+
+      /**
+       * This function collects the sizes of the sub-objects and stores them in
+       * internal arrays, in order to be able to relay global indices into the
+       * matrix to indices into the subobjects. You *must* call this function
+       * each time after you have changed the size of the sub-objects. Note that
+       * this is a @ref GlossCollectiveOperation "collective operation", i.e.,
+       * it needs to be called on all MPI
+       * processes. This command internally calls the method
+       * <tt>compress()</tt>, so you don't need to call that function in case
+       * you use <tt>collect_sizes()</tt>.
+       */
+      void
+      collect_sizes();
+
+      /**
+       * Return the total number of nonzero elements of this matrix (summed
+       * over all MPI processes).
+       */
+      std::uint64_t
+      n_nonzero_elements() const;
+
+      /**
+       * Return the underlying MPI communicator.
+       */
+      MPI_Comm
+      get_mpi_communicator() const;
+
+      /**
+       * Return the partitioning of the domain space for the individual blocks
+       * of this matrix, i.e., the partitioning of the block vectors this matrix
+       * has to be multiplied with.
+       */
+      std::vector<IndexSet>
+      locally_owned_domain_indices() const;
+
+      /**
+       * Return the partitioning of the range space for the individual blocks of
+       * this matrix, i.e., the partitioning of the block vectors that result
+       * from matrix-vector products.
+       */
+      std::vector<IndexSet>
+      locally_owned_range_indices() const;
+
+      /**
+       * Matrix-vector multiplication: let $dst = M*src$ with $M$ being this
+       * matrix. The vector types can be block vectors or non-block vectors
+       * (only if the matrix has only one row or column, respectively), and need
+       * to define TrilinosWrappers::SparseMatrix::vmult.
+       */
+      template <typename VectorType1, typename VectorType2>
+      void
+      vmult(VectorType1 &dst, const VectorType2 &src) const;
+
+      /**
+       * Matrix-vector multiplication: let $dst = M^T*src$ with $M$ being this
+       * matrix. This function does the same as vmult() but takes the transposed
+       * matrix.
+       */
+      template <typename VectorType1, typename VectorType2>
+      void
+      Tvmult(VectorType1 &dst, const VectorType2 &src) const;
+
+      /**
+       * Compute the residual of an equation <i>Mx=b</i>, where the residual is
+       * defined to be <i>r=b-Mx</i>. Write the residual into @p dst. The
+       * <i>l<sub>2</sub></i> norm of the residual vector is returned.
+       *
+       * Source <i>x</i> and destination <i>dst</i> must not be the same vector.
+       *
+       * Note that both vectors have to be distributed vectors generated using
+       * the same Map as was used for the matrix.
+       *
+       * This function only applicable if the matrix only has one block row.
+       */
+      template <typename VectorType1,
+                typename VectorType2,
+                typename VectorType3>
+      Number
+      residual(VectorType1       &dst,
+               const VectorType2 &x,
+               const VectorType3 &b) const;
+
+      /**
+       * Make the clear() function in the base class visible, though it is
+       * protected.
+       */
+      using BlockMatrixBase<SparseMatrix<Number, MemorySpace>>::clear;
+
+    private:
+      /**
+       * Internal version of (T)vmult with two block vectors
+       */
+      template <typename VectorType1, typename VectorType2>
+      void
+      vmult(VectorType1       &dst,
+            const VectorType2 &src,
+            const bool         transpose,
+            const std::bool_constant<true>,
+            const std::bool_constant<true>) const;
+
+      /**
+       * Internal version of (T)vmult where the source vector is a block vector
+       * but the destination vector is a non-block vector
+       */
+      template <typename VectorType1, typename VectorType2>
+      void
+      vmult(VectorType1       &dst,
+            const VectorType2 &src,
+            const bool         transpose,
+            const std::bool_constant<false>,
+            const std::bool_constant<true>) const;
+
+      /**
+       * Internal version of (T)vmult where the source vector is a non-block
+       * vector but the destination vector is a block vector
+       */
+      template <typename VectorType1, typename VectorType2>
+      void
+      vmult(VectorType1       &dst,
+            const VectorType2 &src,
+            const bool         transpose,
+            const std::bool_constant<true>,
+            const std::bool_constant<false>) const;
+
+      /**
+       * Internal version of (T)vmult where both source vector and the
+       * destination vector are non-block vectors (only defined if the matrix
+       * consists of only one block)
+       */
+      template <typename VectorType1, typename VectorType2>
+      void
+      vmult(VectorType1       &dst,
+            const VectorType2 &src,
+            const bool         transpose,
+            const std::bool_constant<false>,
+            const std::bool_constant<false>) const;
+    };
+
+  } // namespace TpetraWrappers
+
+  /** @} */
+
+  // ------------- inline and template functions -----------------
+  namespace TpetraWrappers
+  {
+    template <typename Number, typename MemorySpace>
+    template <typename VectorType1, typename VectorType2>
+    inline void
+    BlockSparseMatrix<Number, MemorySpace>::vmult(VectorType1       &dst,
+                                                  const VectorType2 &src) const
+    {
+      vmult(dst,
+            src,
+            false,
+            std::bool_constant<IsBlockVector<VectorType1>::value>(),
+            std::bool_constant<IsBlockVector<VectorType2>::value>());
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    template <typename VectorType1, typename VectorType2>
+    inline void
+    BlockSparseMatrix<Number, MemorySpace>::Tvmult(VectorType1       &dst,
+                                                   const VectorType2 &src) const
+    {
+      vmult(dst,
+            src,
+            true,
+            std::bool_constant<IsBlockVector<VectorType1>::value>(),
+            std::bool_constant<IsBlockVector<VectorType2>::value>());
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    template <typename VectorType1, typename VectorType2>
+    inline void
+    BlockSparseMatrix<Number, MemorySpace>::vmult(
+      VectorType1       &dst,
+      const VectorType2 &src,
+      const bool         transpose,
+      std::bool_constant<true>,
+      std::bool_constant<true>) const
+    {
+      if (transpose == true)
+        BaseClass::Tvmult_block_block(dst, src);
+      else
+        BaseClass::vmult_block_block(dst, src);
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    template <typename VectorType1, typename VectorType2>
+    inline void
+    BlockSparseMatrix<Number, MemorySpace>::vmult(
+      VectorType1       &dst,
+      const VectorType2 &src,
+      const bool         transpose,
+      std::bool_constant<false>,
+      std::bool_constant<true>) const
+    {
+      if (transpose == true)
+        BaseClass::Tvmult_nonblock_block(dst, src);
+      else
+        BaseClass::vmult_nonblock_block(dst, src);
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    template <typename VectorType1, typename VectorType2>
+    inline void
+    BlockSparseMatrix<Number, MemorySpace>::vmult(
+      VectorType1       &dst,
+      const VectorType2 &src,
+      const bool         transpose,
+      std::bool_constant<true>,
+      std::bool_constant<false>) const
+    {
+      if (transpose == true)
+        BaseClass::Tvmult_block_nonblock(dst, src);
+      else
+        BaseClass::vmult_block_nonblock(dst, src);
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    template <typename VectorType1, typename VectorType2>
+    inline void
+    BlockSparseMatrix<Number, MemorySpace>::vmult(
+      VectorType1       &dst,
+      const VectorType2 &src,
+      const bool         transpose,
+      std::bool_constant<false>,
+      std::bool_constant<false>) const
+    {
+      if (transpose == true)
+        BaseClass::Tvmult_nonblock_nonblock(dst, src);
+      else
+        BaseClass::vmult_nonblock_nonblock(dst, src);
+    }
+  } // namespace TpetraWrappers
+
+} // namespace LinearAlgebra
+
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif // DEAL_II_TRILINOS_WITH_TPETRA
+
+#endif // dealii_tpetra_trilinos_block_sparse_matrix_h

--- a/include/deal.II/lac/trilinos_tpetra_block_sparse_matrix.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_block_sparse_matrix.templates.h
@@ -1,0 +1,340 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_tpetra_trilinos_block_sparse_matrix_templates_h
+#define dealii_tpetra_trilinos_block_sparse_matrix_templates_h
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+
+#  include <deal.II/lac/trilinos_tpetra_block_sparse_matrix.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace LinearAlgebra
+{
+
+  namespace TpetraWrappers
+  {
+
+    template <typename Number, typename MemorySpace>
+    BlockSparseMatrix<Number, MemorySpace>::~BlockSparseMatrix()
+    {
+      // delete previous content of
+      // the subobjects array
+      try
+        {
+          clear();
+        }
+      catch (...)
+        {}
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    BlockSparseMatrix<Number, MemorySpace> &
+    BlockSparseMatrix<Number, MemorySpace>::operator=(const Number d)
+    {
+      Assert(d == 0, ExcScalarAssignmentOnlyForZeroValue());
+
+      for (size_type r = 0; r < this->n_block_rows(); ++r)
+        for (size_type c = 0; c < this->n_block_cols(); ++c)
+          this->block(r, c) = d;
+
+      return *this;
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    void
+    BlockSparseMatrix<Number, MemorySpace>::reinit(
+      const size_type n_block_rows,
+      const size_type n_block_columns)
+    {
+      // first delete previous content of
+      // the subobjects array
+      clear();
+
+      // then resize. set sizes of blocks to
+      // zero. user will later have to call
+      // collect_sizes for this
+      this->sub_objects.reinit(n_block_rows, n_block_columns);
+      this->row_block_indices.reinit(n_block_rows, 0);
+      this->column_block_indices.reinit(n_block_columns, 0);
+
+      // and reinitialize the blocks
+      for (size_type r = 0; r < this->n_block_rows(); ++r)
+        for (size_type c = 0; c < this->n_block_cols(); ++c)
+          {
+            BlockType *p = new BlockType();
+
+            Assert(this->sub_objects[r][c] == nullptr, ExcInternalError());
+            this->sub_objects[r][c] = p;
+          }
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    template <typename BlockSparsityPatternType>
+    void
+    BlockSparseMatrix<Number, MemorySpace>::reinit(
+      const std::vector<IndexSet>    &parallel_partitioning,
+      const BlockSparsityPatternType &block_sparsity_pattern,
+      const MPI_Comm                  communicator,
+      const bool                      exchange_data)
+    {
+#  ifdef DEBUG
+      std::vector<typename BlockType::MapType> tpetra_maps;
+      for (size_type i = 0; i < block_sparsity_pattern.n_block_rows(); ++i)
+        tpetra_maps.push_back(
+          parallel_partitioning[i].make_tpetra_map(communicator, false));
+
+      Assert(tpetra_maps.size() == block_sparsity_pattern.n_block_rows(),
+             ExcDimensionMismatch(tpetra_maps.size(),
+                                  block_sparsity_pattern.n_block_rows()));
+      Assert(tpetra_maps.size() == block_sparsity_pattern.n_block_cols(),
+             ExcDimensionMismatch(tpetra_maps.size(),
+                                  block_sparsity_pattern.n_block_cols()));
+
+      const size_type n_block_rows = tpetra_maps.size();
+      (void)n_block_rows;
+
+      Assert(n_block_rows == block_sparsity_pattern.n_block_rows(),
+             ExcDimensionMismatch(n_block_rows,
+                                  block_sparsity_pattern.n_block_rows()));
+      Assert(n_block_rows == block_sparsity_pattern.n_block_cols(),
+             ExcDimensionMismatch(n_block_rows,
+                                  block_sparsity_pattern.n_block_cols()));
+#  endif
+
+
+      // Call the other basic reinit function, ...
+      reinit(block_sparsity_pattern.n_block_rows(),
+             block_sparsity_pattern.n_block_cols());
+
+      // ... set the correct sizes, ...
+      this->row_block_indices    = block_sparsity_pattern.get_row_indices();
+      this->column_block_indices = block_sparsity_pattern.get_column_indices();
+
+      // ... and then assign the correct
+      // data to the blocks.
+      for (size_type r = 0; r < this->n_block_rows(); ++r)
+        for (size_type c = 0; c < this->n_block_cols(); ++c)
+          {
+            this->sub_objects[r][c]->reinit(parallel_partitioning[r],
+                                            parallel_partitioning[c],
+                                            block_sparsity_pattern.block(r, c),
+                                            communicator,
+                                            exchange_data);
+          }
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    template <typename BlockSparsityPatternType>
+    void
+    BlockSparseMatrix<Number, MemorySpace>::reinit(
+      const BlockSparsityPatternType &block_sparsity_pattern)
+    {
+      std::vector<IndexSet> parallel_partitioning;
+      for (size_type i = 0; i < block_sparsity_pattern.n_block_rows(); ++i)
+        parallel_partitioning.emplace_back(
+          complete_index_set(block_sparsity_pattern.block(i, 0).n_rows()));
+
+      reinit(parallel_partitioning, block_sparsity_pattern);
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    void
+    BlockSparseMatrix<Number, MemorySpace>::reinit(
+      const std::vector<IndexSet>               &parallel_partitioning,
+      const ::dealii::BlockSparseMatrix<double> &dealii_block_sparse_matrix,
+      const MPI_Comm                             communicator,
+      const double                               drop_tolerance)
+    {
+      const size_type n_block_rows = parallel_partitioning.size();
+
+      Assert(n_block_rows == dealii_block_sparse_matrix.n_block_rows(),
+             ExcDimensionMismatch(n_block_rows,
+                                  dealii_block_sparse_matrix.n_block_rows()));
+      Assert(n_block_rows == dealii_block_sparse_matrix.n_block_cols(),
+             ExcDimensionMismatch(n_block_rows,
+                                  dealii_block_sparse_matrix.n_block_cols()));
+
+      // Call the other basic reinit function ...
+      reinit(n_block_rows, n_block_rows);
+
+      // ... and then assign the correct
+      // data to the blocks.
+      for (size_type r = 0; r < this->n_block_rows(); ++r)
+        for (size_type c = 0; c < this->n_block_cols(); ++c)
+          {
+            this->sub_objects[r][c]->reinit(parallel_partitioning[r],
+                                            parallel_partitioning[c],
+                                            dealii_block_sparse_matrix.block(r,
+                                                                             c),
+                                            communicator,
+                                            drop_tolerance);
+          }
+
+      collect_sizes();
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    void
+    BlockSparseMatrix<Number, MemorySpace>::reinit(
+      const ::dealii::BlockSparseMatrix<double> &dealii_block_sparse_matrix,
+      const double                               drop_tolerance)
+    {
+      Assert(dealii_block_sparse_matrix.n_block_rows() ==
+               dealii_block_sparse_matrix.n_block_cols(),
+             ExcDimensionMismatch(dealii_block_sparse_matrix.n_block_rows(),
+                                  dealii_block_sparse_matrix.n_block_cols()));
+      Assert(dealii_block_sparse_matrix.m() == dealii_block_sparse_matrix.n(),
+             ExcDimensionMismatch(dealii_block_sparse_matrix.m(),
+                                  dealii_block_sparse_matrix.n()));
+
+      std::vector<IndexSet> parallel_partitioning;
+      for (size_type i = 0; i < dealii_block_sparse_matrix.n_block_rows(); ++i)
+        parallel_partitioning.emplace_back(
+          complete_index_set(dealii_block_sparse_matrix.block(i, 0).m()));
+
+      reinit(parallel_partitioning,
+             dealii_block_sparse_matrix,
+             MPI_COMM_SELF,
+             drop_tolerance);
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    inline bool
+    BlockSparseMatrix<Number, MemorySpace>::is_compressed() const
+    {
+      bool compressed = true;
+      for (size_type row = 0; row < this->n_block_rows(); ++row)
+        for (size_type col = 0; col < this->n_block_cols(); ++col)
+          if (this->block(row, col).is_compressed() == false)
+            {
+              compressed = false;
+              break;
+            }
+
+      return compressed;
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    void
+    BlockSparseMatrix<Number, MemorySpace>::collect_sizes()
+    {
+      // simply forward to the (non-public) function of the base class
+      BaseClass::collect_sizes();
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    std::uint64_t
+    BlockSparseMatrix<Number, MemorySpace>::n_nonzero_elements() const
+    {
+      std::uint64_t n_nonzero = 0;
+      for (size_type rows = 0; rows < this->n_block_rows(); ++rows)
+        for (size_type cols = 0; cols < this->n_block_cols(); ++cols)
+          n_nonzero += this->block(rows, cols).n_nonzero_elements();
+
+      return n_nonzero;
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    MPI_Comm
+    BlockSparseMatrix<Number, MemorySpace>::get_mpi_communicator() const
+    {
+      Assert(this->n_block_cols() != 0, ExcNotInitialized());
+      Assert(this->n_block_rows() != 0, ExcNotInitialized());
+      return this->sub_objects[0][0]->get_mpi_communicator();
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    inline std::vector<IndexSet>
+    BlockSparseMatrix<Number, MemorySpace>::locally_owned_domain_indices() const
+    {
+      Assert(this->n_block_cols() != 0, ExcNotInitialized());
+      Assert(this->n_block_rows() != 0, ExcNotInitialized());
+
+      std::vector<IndexSet> domain_indices;
+      for (size_type c = 0; c < this->n_block_cols(); ++c)
+        domain_indices.push_back(
+          this->sub_objects[0][c]->locally_owned_domain_indices());
+
+      return domain_indices;
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    inline std::vector<IndexSet>
+    BlockSparseMatrix<Number, MemorySpace>::locally_owned_range_indices() const
+    {
+      Assert(this->n_block_cols() != 0, ExcNotInitialized());
+      Assert(this->n_block_rows() != 0, ExcNotInitialized());
+
+      std::vector<IndexSet> range_indices;
+      for (size_type r = 0; r < this->n_block_rows(); ++r)
+        range_indices.push_back(
+          this->sub_objects[r][0]->locally_owned_range_indices());
+
+      return range_indices;
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    template <typename VectorType1, typename VectorType2, typename VectorType3>
+    Number
+    BlockSparseMatrix<Number, MemorySpace>::residual(VectorType1       &dst,
+                                                     const VectorType2 &x,
+                                                     const VectorType3 &b) const
+    {
+      vmult(dst, x);
+      dst -= b;
+      dst *= -1.;
+
+      return dst.l2_norm();
+    }
+
+  } // namespace TpetraWrappers
+
+} // namespace LinearAlgebra
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif // DEAL_II_TRILINOS_WITH_TPETRA
+
+#endif // dealii_tpetra_trilinos_block_sparse_matrix_templates_h

--- a/include/deal.II/lac/trilinos_tpetra_block_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_block_vector.h
@@ -1,0 +1,249 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_trilinos_tpetra_block_vector_h
+#define dealii_trilinos_tpetra_block_vector_h
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+
+#  include <deal.II/lac/block_indices.h>
+#  include <deal.II/lac/block_vector_base.h>
+#  include <deal.II/lac/trilinos_tpetra_vector.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+// forward declaration
+#  ifndef DOXYGEN
+template <typename Number>
+class BlockVectorBase;
+
+namespace LinearAlgebra
+{
+  // forward declaration
+  namespace TpetraWrappers
+  {
+    template <typename Number, typename MemorySpace>
+    class BlockVector;
+
+    // TODO
+    // template <typename Number, typename MemorySpace>
+    // class BlockSparseMatrix;
+  } // namespace TpetraWrappers
+} // namespace LinearAlgebra
+#  endif // DOXYGEN
+
+namespace LinearAlgebra
+{
+  /**
+   * @addtogroup TpetraWrappers
+   * @{
+   */
+  namespace TpetraWrappers
+  {
+    /**
+     * An implementation of block vectors based on the vector class
+     * implemented in LinearAlgebra::TpetraWrappers.
+     * While the base class provides for most of the interface, this class
+     * handles the actual allocation of vectors and provides functions that
+     * are specific to the underlying vector type.
+     *
+     * The model of distribution of data is such that each of the blocks is
+     * distributed across all MPI processes named in the MPI communicator.
+     * I.e. we don't just distribute the whole vector, but each component. In
+     * the constructors and reinit() functions, one therefore not only has to
+     * specify the sizes of the individual blocks, but also the number of
+     * elements of each of these blocks to be stored on the local process.
+     *
+     * @ingroup Vectors
+     * @ingroup TrilinosWrappers @see
+     * @ref GlossBlockLA "Block (linear algebra)"
+     */
+    template <typename Number, typename MemorySpace = dealii::MemorySpace::Host>
+    class BlockVector : public dealii::BlockVectorBase<
+                          TpetraWrappers::Vector<Number, MemorySpace>>
+    {
+    public:
+      /**
+       * Typedef the base class for simpler access to its own alias.
+       */
+      using BaseClass =
+        dealii::BlockVectorBase<TpetraWrappers::Vector<Number, MemorySpace>>;
+
+      /**
+       * Typedef the type of the underlying vector.
+       */
+      using BlockType = typename BaseClass::BlockType;
+
+      /**
+       * Import the alias from the base class.
+       */
+      using value_type      = typename BaseClass::value_type;
+      using pointer         = typename BaseClass::pointer;
+      using const_pointer   = typename BaseClass::const_pointer;
+      using reference       = typename BaseClass::reference;
+      using const_reference = typename BaseClass::const_reference;
+      using size_type       = typename BaseClass::size_type;
+      using iterator        = typename BaseClass::iterator;
+      using const_iterator  = typename BaseClass::const_iterator;
+
+      /**
+       * Default constructor. Generate an empty vector without any blocks.
+       */
+      BlockVector() = default;
+
+      /**
+       * Constructor. Generate a block vector with as many blocks as there are
+       * entries in @p partitioning.  Each IndexSet together with the MPI
+       * communicator contains the layout of the distribution of data among
+       * the MPI processes.
+       */
+      BlockVector(const std::vector<IndexSet> &parallel_partitioning,
+                  const MPI_Comm               communicator = MPI_COMM_WORLD);
+
+      /**
+       * Creates a BlockVector with ghost elements. See the respective
+       * reinit() method for more details. @p ghost_values may contain any
+       * elements in @p parallel_partitioning, they will be ignored.
+       */
+      BlockVector(const std::vector<IndexSet> &parallel_partitioning,
+                  const std::vector<IndexSet> &ghost_values,
+                  const MPI_Comm               communicator,
+                  const bool                   vector_writable = false);
+
+      /**
+       * Copy-Constructor. Set all the properties of the parallel vector to
+       * those of the given argument and copy the elements.
+       */
+      BlockVector(const BlockVector<Number, MemorySpace> &v);
+
+      /**
+       * Creates a block vector consisting of <tt>num_blocks</tt> components,
+       * but there is no content in the individual components and the user has
+       * to fill appropriate data using a reinit of the blocks.
+       */
+      explicit BlockVector(const size_type num_blocks);
+
+      /**
+       * Destructor. Clears memory
+       */
+      ~BlockVector() override = default;
+
+      /**
+       * Copy operator: fill all components of the vector that are locally
+       * stored with the given scalar value.
+       */
+      BlockVector<Number, MemorySpace> &
+      operator=(const Number s);
+
+      /**
+       * Copy operator for arguments of the same type.
+       */
+      BlockVector<Number, MemorySpace> &
+      operator=(const BlockVector<Number, MemorySpace> &v);
+
+      /**
+       * Reinitialize the BlockVector to contain as many blocks as there are
+       * index sets given in the input argument, according to the parallel
+       * distribution of the individual components described in the maps.
+       *
+       * If <tt>omit_zeroing_entries==false</tt>, the vector is filled with
+       * zeros.
+       */
+      void
+      reinit(const std::vector<IndexSet> &parallel_partitioning,
+             const MPI_Comm               communicator         = MPI_COMM_WORLD,
+             const bool                   omit_zeroing_entries = false);
+
+      /**
+       * Reinit functionality. This function destroys the old vector content
+       * and generates a new one based on the input partitioning. In addition
+       * to just specifying one index set as in all the other methods above,
+       * this method allows to supply an additional set of ghost entries.
+       * There are two different versions of a vector that can be created. If
+       * the flag @p vector_writable is set to @p false, the vector only
+       * allows read access to the joint set of @p parallel_partitioning and
+       * @p ghost_entries. The effect of the reinit method is then equivalent
+       * to calling the other reinit method with an index set containing both
+       * the locally owned entries and the ghost entries.
+       *
+       * If the flag @p vector_writable is set to true, this creates an
+       * alternative storage scheme for ghost elements that allows multiple
+       * threads to write into the vector (for the other reinit methods, only
+       * one thread is allowed to write into the ghost entries at a time).
+       */
+      void
+      reinit(const std::vector<IndexSet> &partitioning,
+             const std::vector<IndexSet> &ghost_values,
+             const MPI_Comm               communicator    = MPI_COMM_WORLD,
+             const bool                   vector_writable = false);
+
+      /**
+       * Change the dimension to that of the vector <tt>V</tt>. The same
+       * applies as for the other reinit() function.
+       *
+       * The elements of <tt>V</tt> are not copied, i.e.  this function is the
+       * same as calling <tt>reinit (V.size(), omit_zeroing_entries)</tt>.
+       *
+       * Note that you must call this (or the other reinit() functions)
+       * function, rather than calling the reinit() functions of an individual
+       * block, to allow the block vector to update its caches of vector
+       * sizes. If you call reinit() on one of the blocks, then subsequent
+       * actions on this object may yield unpredictable results since they may
+       * be routed to the wrong block.
+       */
+      void
+      reinit(const BlockVector<Number, MemorySpace> &V,
+             const bool omit_zeroing_entries = false);
+
+      /**
+       * Change the number of blocks to <tt>num_blocks</tt>. The individual
+       * blocks will get initialized with zero size, so it is assumed that the
+       * user resizes the individual blocks by herself in an appropriate way,
+       * and calls <tt>collect_sizes</tt> afterwards.
+       */
+      void
+      reinit(const size_type num_blocks);
+
+      /**
+       * Return if this Vector contains ghost elements.
+       *
+       * @see
+       * @ref GlossGhostedVector "vectors with ghost elements"
+       */
+      bool
+      has_ghost_elements() const;
+
+      /**
+       * Print to a stream.
+       */
+      void
+      print(std::ostream      &out,
+            const unsigned int precision  = 3,
+            const bool         scientific = true,
+            const bool         across     = true) const;
+    };
+  } // namespace TpetraWrappers
+
+  /** @} */
+
+} // namespace LinearAlgebra
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif // DEAL_II_TRILINOS_WITH_TPETRA
+
+#endif // dealii_trilinos_tpetra_block_vector_h

--- a/include/deal.II/lac/trilinos_tpetra_block_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_block_vector.h
@@ -22,6 +22,7 @@
 
 #  include <deal.II/lac/block_indices.h>
 #  include <deal.II/lac/block_vector_base.h>
+#  include <deal.II/lac/trilinos_tpetra_block_sparse_matrix.h>
 #  include <deal.II/lac/trilinos_tpetra_vector.h>
 
 DEAL_II_NAMESPACE_OPEN
@@ -39,9 +40,8 @@ namespace LinearAlgebra
     template <typename Number, typename MemorySpace>
     class BlockVector;
 
-    // TODO
-    // template <typename Number, typename MemorySpace>
-    // class BlockSparseMatrix;
+    template <typename Number, typename MemorySpace>
+    class BlockSparseMatrix;
   } // namespace TpetraWrappers
 } // namespace LinearAlgebra
 #  endif // DOXYGEN

--- a/include/deal.II/lac/trilinos_tpetra_block_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_block_vector.templates.h
@@ -1,0 +1,237 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_trilinos_tpetra_block_vector_templates_h
+#define dealii_trilinos_tpetra_block_vector_templates_h
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/lac/trilinos_tpetra_block_vector.h>
+
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+
+#  include <deal.II/base/index_set.h>
+#  include <deal.II/base/trilinos_utilities.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace LinearAlgebra
+{
+  namespace TpetraWrappers
+  {
+    template <typename Number, typename MemorySpace>
+    BlockVector<Number, MemorySpace>::BlockVector(
+      const std::vector<IndexSet> &parallel_partitioning,
+      const MPI_Comm               communicator)
+    {
+      reinit(parallel_partitioning, communicator, false);
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    BlockVector<Number, MemorySpace>::BlockVector(
+      const std::vector<IndexSet> &parallel_partitioning,
+      const std::vector<IndexSet> &ghost_values,
+      const MPI_Comm               communicator,
+      const bool                   vector_writable)
+    {
+      reinit(parallel_partitioning,
+             ghost_values,
+             communicator,
+             vector_writable);
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    BlockVector<Number, MemorySpace>::BlockVector(
+      const BlockVector<Number, MemorySpace> &v)
+      : dealii::BlockVectorBase<TpetraWrappers::Vector<Number, MemorySpace>>()
+    {
+      this->block_indices = v.block_indices;
+
+      this->components.resize(this->n_blocks());
+      for (unsigned int i = 0; i < this->n_blocks(); ++i)
+        this->components[i] = v.components[i];
+
+      this->collect_sizes();
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    BlockVector<Number, MemorySpace>::BlockVector(const size_type num_blocks)
+      : dealii::BlockVectorBase<TpetraWrappers::Vector<Number, MemorySpace>>()
+    {
+      reinit(num_blocks);
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    BlockVector<Number, MemorySpace> &
+    BlockVector<Number, MemorySpace>::operator=(const Number s)
+    {
+      BaseClass::operator=(s);
+      return *this;
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    BlockVector<Number, MemorySpace> &
+    BlockVector<Number, MemorySpace>::operator=(const BlockVector &v)
+    {
+      // we only allow assignment to vectors with the same number of blocks
+      // or to an empty BlockVector
+      Assert(this->n_blocks() == 0 || this->n_blocks() == v.n_blocks(),
+             ExcDimensionMismatch(this->n_blocks(), v.n_blocks()));
+
+      if (this->n_blocks() != v.n_blocks())
+        this->block_indices = v.block_indices;
+
+      this->components.resize(this->n_blocks());
+      for (unsigned int i = 0; i < this->n_blocks(); ++i)
+        this->components[i] = v.components[i];
+
+      this->collect_sizes();
+
+      return *this;
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    void
+    BlockVector<Number, MemorySpace>::reinit(
+      const std::vector<IndexSet> &parallel_partitioning,
+      const MPI_Comm               communicator,
+      const bool                   omit_zeroing_entries)
+    {
+      // update the number of blocks
+      this->block_indices.reinit(parallel_partitioning.size(), 0);
+
+      // initialize each block
+      this->components.resize(this->n_blocks());
+      for (unsigned int i = 0; i < this->n_blocks(); ++i)
+        this->components[i].reinit(parallel_partitioning[i],
+                                   communicator,
+                                   omit_zeroing_entries);
+
+      // update block_indices content
+      this->collect_sizes();
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    void
+    BlockVector<Number, MemorySpace>::reinit(
+      const std::vector<IndexSet> &parallel_partitioning,
+      const std::vector<IndexSet> &ghost_values,
+      const MPI_Comm               communicator,
+      const bool                   vector_writable)
+    {
+      AssertDimension(parallel_partitioning.size(), ghost_values.size());
+
+      // update the number of blocks
+      this->block_indices.reinit(parallel_partitioning.size(), 0);
+
+      // initialize each block
+      this->components.resize(this->n_blocks());
+      for (unsigned int i = 0; i < this->n_blocks(); ++i)
+        this->components[i].reinit(parallel_partitioning[i],
+                                   ghost_values[i],
+                                   communicator,
+                                   vector_writable);
+
+      // update block_indices content
+      this->collect_sizes();
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    void
+    BlockVector<Number, MemorySpace>::reinit(
+      const BlockVector<Number, MemorySpace> &v,
+      const bool                              omit_zeroing_entries)
+    {
+      if (this->n_blocks() != v.n_blocks())
+        this->block_indices = v.get_block_indices();
+
+      this->components.resize(this->n_blocks());
+      for (unsigned int i = 0; i < this->n_blocks(); ++i)
+        this->components[i].reinit(v.components[i], omit_zeroing_entries);
+
+      this->collect_sizes();
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    void
+    BlockVector<Number, MemorySpace>::reinit(const size_type num_blocks)
+    {
+      this->block_indices.reinit(num_blocks, 0);
+
+      this->components.resize(this->n_blocks());
+      for (auto &c : this->components)
+        c.clear();
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    bool
+    BlockVector<Number, MemorySpace>::has_ghost_elements() const
+    {
+      bool ghosted = this->block(0).has_ghost_elements();
+#  ifdef DEBUG
+      for (unsigned int i = 0; i < this->n_blocks(); ++i)
+        Assert(this->block(i).has_ghost_elements() == ghosted,
+               ExcInternalError());
+#  endif
+      return ghosted;
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    void
+    BlockVector<Number, MemorySpace>::print(std::ostream      &out,
+                                            const unsigned int precision,
+                                            const bool         scientific,
+                                            const bool         across) const
+    {
+      for (unsigned int i = 0; i < this->n_blocks(); ++i)
+        {
+          if (across)
+            out << 'C' << i << ':';
+          else
+            out << "Component " << i << std::endl;
+          this->components[i].print(out, precision, scientific, across);
+        }
+    }
+
+  } // namespace TpetraWrappers
+} // namespace LinearAlgebra
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif // DEAL_II_TRILINOS_WITH_TPETRA
+
+#endif // dealii_trilinos_tpetra_block_vector_templates_h

--- a/include/deal.II/lac/trilinos_tpetra_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparse_matrix.h
@@ -24,6 +24,8 @@
 #  include <deal.II/base/subscriptor.h>
 #  include <deal.II/base/trilinos_utilities.h>
 
+#  include <deal.II/lac/sparse_matrix.h>
+#  include <deal.II/lac/sparsity_pattern.h>
 #  include <deal.II/lac/trilinos_tpetra_sparsity_pattern.h>
 #  include <deal.II/lac/trilinos_tpetra_vector.h>
 
@@ -369,6 +371,32 @@ namespace LinearAlgebra
              const SparsityPatternType &sparsity_pattern,
              const MPI_Comm             communicator  = MPI_COMM_WORLD,
              const bool                 exchange_data = false);
+
+      /**
+       * This function initializes the Trilinos matrix using the deal.II sparse
+       * matrix and the entries stored therein. It uses a threshold to copy only
+       * elements with modulus larger than the threshold (so zeros in the
+       * deal.II matrix can be filtered away). In contrast to the other reinit
+       * function with deal.II sparse matrix argument, this function takes a
+       * %parallel partitioning specified by the user instead of internally
+       * generating it.
+       *
+       * The optional parameter <tt>copy_values</tt> decides whether only the
+       * sparsity structure of the input matrix should be used or the matrix
+       * entries should be copied, too.
+       *
+       * This is a @ref GlossCollectiveOperation "collective operation" that needs to be called on all
+       * processors in order to avoid a dead lock.
+       */
+      void
+      reinit(const IndexSet                     &row_parallel_partitioning,
+             const IndexSet                     &col_parallel_partitioning,
+             const dealii::SparseMatrix<Number> &dealii_sparse_matrix,
+             const MPI_Comm                      communicator = MPI_COMM_WORLD,
+             const double                        drop_tolerance    = 1e-13,
+             const bool                          copy_values       = true,
+             const dealii::SparsityPattern      *use_this_sparsity = nullptr);
+
       /** @} */
 
       /**

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -208,6 +208,34 @@ namespace LinearAlgebra
                        << "An error with error number " << arg1
                        << " occurred while calling a Trilinos function");
 
+        /*
+         * Access to a an element that is not (locally-)owned.
+         *
+         * @ingroup Exceptions
+         */
+        DeclException4(
+          ExcAccessToNonLocalElement,
+          size_type,
+          size_type,
+          size_type,
+          size_type,
+          << "You are trying to access element " << arg1
+          << " of a distributed vector, but this element is not stored "
+          << "on the current processor. Note: There are " << arg2
+          << " elements stored "
+          << "on the current processor from within the range [" << arg3 << ','
+          << arg4 << "] but Trilinos vectors need not store contiguous "
+          << "ranges on each processor, and not every element in "
+          << "this range may in fact be stored locally."
+          << "\n\n"
+          << "A common source for this kind of problem is that you "
+          << "are passing a 'fully distributed' vector into a function "
+          << "that needs read access to vector elements that correspond "
+          << "to degrees of freedom on ghost cells (or at least to "
+          << "'locally active' degrees of freedom that are not also "
+          << "'locally owned'). You need to pass a vector that has these "
+          << "elements as ghost entries.");
+
       private:
         /**
          * Point to the vector we are referencing.
@@ -261,6 +289,8 @@ namespace LinearAlgebra
       using real_type  = typename numbers::NumberTraits<Number>::real_type;
       using size_type  = types::global_dof_index;
       using reference  = internal::VectorReference<Number, MemorySpace>;
+      using const_reference =
+        const internal::VectorReference<Number, MemorySpace>;
       using MapType =
         Tpetra::Map<int, dealii::types::signed_global_dof_index, NodeType>;
       using VectorType = Tpetra::

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -182,6 +182,7 @@ namespace LinearAlgebra
           0, 0, Utilities::Trilinos::tpetra_comm_self()));
       has_ghost  = false;
       compressed = true;
+      nonlocal_vector.reset();
     }
 
 
@@ -1064,6 +1065,7 @@ namespace LinearAlgebra
       // of the vector
       AssertThrow(out.fail() == false, ExcIO());
     }
+
 
 
     template <typename Number, typename MemorySpace>

--- a/source/lac/CMakeLists.txt
+++ b/source/lac/CMakeLists.txt
@@ -144,6 +144,7 @@ if(DEAL_II_WITH_TRILINOS)
     trilinos_sparse_matrix.cc
     trilinos_sparsity_pattern.cc
     trilinos_tpetra_block_vector.cc
+    trilinos_tpetra_block_sparse_matrix.cc
     trilinos_tpetra_communication_pattern.cc
     trilinos_tpetra_solver_direct.cc
     trilinos_tpetra_sparse_matrix.cc

--- a/source/lac/CMakeLists.txt
+++ b/source/lac/CMakeLists.txt
@@ -143,6 +143,7 @@ if(DEAL_II_WITH_TRILINOS)
     trilinos_solver.cc
     trilinos_sparse_matrix.cc
     trilinos_sparsity_pattern.cc
+    trilinos_tpetra_block_vector.cc
     trilinos_tpetra_communication_pattern.cc
     trilinos_tpetra_solver_direct.cc
     trilinos_tpetra_sparse_matrix.cc

--- a/source/lac/affine_constraints.inst.in
+++ b/source/lac/affine_constraints.inst.in
@@ -256,8 +256,45 @@ for (S : TRILINOS_SCALARS)
       LinearAlgebra::TpetraWrappers::Vector<S> &,
       bool,
       std::integral_constant<bool, false>) const;
-  }
 
+    // BlockSparseMatrix
+    template void AffineConstraints<S>::distribute_local_to_global<
+      LinearAlgebra::TpetraWrappers::BlockSparseMatrix<S>,
+      LinearAlgebra::TpetraWrappers::Vector<S>>(
+      const FullMatrix<S> &,
+      const Vector<S> &,
+      const std::vector<AffineConstraints<S>::size_type> &,
+      LinearAlgebra::TpetraWrappers::BlockSparseMatrix<S> &,
+      LinearAlgebra::TpetraWrappers::Vector<S> &,
+      bool,
+      std::bool_constant<true>) const;
+
+    template void AffineConstraints<S>::distribute_local_to_global<
+      LinearAlgebra::TpetraWrappers::BlockSparseMatrix<S>,
+      LinearAlgebra::TpetraWrappers::BlockVector<S>>(
+      const FullMatrix<S> &,
+      const Vector<S> &,
+      const std::vector<AffineConstraints<S>::size_type> &,
+      LinearAlgebra::TpetraWrappers::BlockSparseMatrix<S> &,
+      LinearAlgebra::TpetraWrappers::BlockVector<S> &,
+      bool,
+      std::bool_constant<true>) const;
+
+    template void AffineConstraints<S>::distribute_local_to_global<
+      LinearAlgebra::TpetraWrappers::BlockSparseMatrix<S>>(
+      const FullMatrix<S> &,
+      const std::vector<AffineConstraints<S>::size_type> &,
+      const std::vector<AffineConstraints<S>::size_type> &,
+      LinearAlgebra::TpetraWrappers::BlockSparseMatrix<S> &) const;
+
+    template void AffineConstraints<S>::distribute_local_to_global<
+      LinearAlgebra::TpetraWrappers::BlockSparseMatrix<S>>(
+      const FullMatrix<S> &,
+      const std::vector<AffineConstraints<S>::size_type> &,
+      const AffineConstraints<S> &,
+      const std::vector<AffineConstraints<S>::size_type> &,
+      LinearAlgebra::TpetraWrappers::BlockSparseMatrix<S> &) const;
+  }
 
 
 // ---------------------------------------------------------------------

--- a/source/lac/trilinos_tpetra_block_sparse_matrix.cc
+++ b/source/lac/trilinos_tpetra_block_sparse_matrix.cc
@@ -52,18 +52,6 @@ namespace LinearAlgebra
     BlockSparseMatrix<double>::Tvmult(
       TpetraWrappers::BlockVector<double> &,
       const TpetraWrappers::BlockVector<double> &) const;
-
-    template void
-    BlockSparseMatrix<double>::vmult(
-      ::dealii::BlockVector<double> &,
-      const ::dealii::BlockVector<double> &) const;
-
-    template void
-    BlockSparseMatrix<double>::Tvmult(
-      ::dealii::BlockVector<double> &,
-      const ::dealii::BlockVector<double> &) const;
-
-
   } // namespace TpetraWrappers
 } // namespace LinearAlgebra
 #  endif // DOXYGEN

--- a/source/lac/trilinos_tpetra_block_sparse_matrix.cc
+++ b/source/lac/trilinos_tpetra_block_sparse_matrix.cc
@@ -1,0 +1,73 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+
+#  include <deal.II/lac/trilinos_tpetra_block_sparse_matrix.templates.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+#  ifndef DOXYGEN
+// explicit instantiations
+namespace LinearAlgebra
+{
+  namespace TpetraWrappers
+  {
+    template class BlockSparseMatrix<double>;
+
+    template void
+    BlockSparseMatrix<double>::reinit(
+      const ::dealii::BlockDynamicSparsityPattern &);
+
+    template void
+    BlockSparseMatrix<double>::vmult(
+      TpetraWrappers::Vector<double> &,
+      const TpetraWrappers::Vector<double> &) const;
+
+    template void
+    BlockSparseMatrix<double>::Tvmult(
+      TpetraWrappers::Vector<double> &,
+      const TpetraWrappers::Vector<double> &) const;
+
+    template void
+    BlockSparseMatrix<double>::vmult(
+      TpetraWrappers::BlockVector<double> &,
+      const TpetraWrappers::BlockVector<double> &) const;
+
+    template void
+    BlockSparseMatrix<double>::Tvmult(
+      TpetraWrappers::BlockVector<double> &,
+      const TpetraWrappers::BlockVector<double> &) const;
+
+    template void
+    BlockSparseMatrix<double>::vmult(
+      ::dealii::BlockVector<double> &,
+      const ::dealii::BlockVector<double> &) const;
+
+    template void
+    BlockSparseMatrix<double>::Tvmult(
+      ::dealii::BlockVector<double> &,
+      const ::dealii::BlockVector<double> &) const;
+
+
+  } // namespace TpetraWrappers
+} // namespace LinearAlgebra
+#  endif // DOXYGEN
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif // DEAL_II_TRILINOS_WITH_TPETRA

--- a/source/lac/trilinos_tpetra_block_vector.cc
+++ b/source/lac/trilinos_tpetra_block_vector.cc
@@ -1,0 +1,67 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#include <deal.II/lac/trilinos_tpetra_block_vector.templates.h>
+
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace LinearAlgebra
+{
+  namespace TpetraWrappers
+  {
+    // Instantiate these vectors types for specific scalar types.
+    //
+    // While there:
+    // Check that the class we declare here satisfies the
+    // vector-space-vector concept. If we catch it here,
+    // any mistake in the vector class declaration would
+    // show up in uses of this class later on as well.
+
+#  ifdef HAVE_TPETRA_INST_FLOAT
+#    ifdef DEAL_II_HAVE_CXX20
+    static_assert(concepts::is_vector_space_vector<BlockVector<float>>);
+#    endif
+    template class BlockVector<float>;
+#  endif
+#  ifdef HAVE_TPETRA_INST_DOUBLE
+#    ifdef DEAL_II_HAVE_CXX20
+    static_assert(concepts::is_vector_space_vector<BlockVector<double>>);
+#    endif
+    template class BlockVector<double>;
+#  endif
+#  ifdef DEAL_II_WITH_COMPLEX_VALUES
+#    ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
+#      ifdef DEAL_II_HAVE_CXX20
+    static_assert(concepts::is_vector_space_vector <
+                  BlockVector<std::complex<float>>);
+#      endif
+    template class BlockVector<std::complex<float>>;
+#    endif
+#    ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
+#      ifdef DEAL_II_HAVE_CXX20
+    static_assert(concepts::is_vector_space_vector <
+                  BlockVector<std::complex<double>>);
+#      endif
+    template class BlockVector<std::complex<double>>;
+#    endif
+#  endif
+  } // namespace TpetraWrappers
+} // namespace LinearAlgebra
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif // DEAL_II_TRILINOS_WITH_TPETRA


### PR DESCRIPTION
This PR adds support for block systems to the TpetraWrappers.
The `TpetraWrappers::BlockVector` class is mainly based on the `TrilinosWrappers:MPI::BlockVector` class. Analogous, the `TpetraWrappers::BlockSparseMatrix` class is primarily based on the `TrilinosWrappers::BlockSparseMatrix`.

For the moment, I separated this PR into several commits. If it is preferred, I can squash it into one.