### PR TITLE
Enable a couple unit tests for LinearAlgebra::TpetraWrappers::Vector

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparse_matrix.h
@@ -599,6 +599,28 @@ namespace LinearAlgebra
       /** @} */
 
       /**
+       * @name Partitioners
+       */
+      /** @{ */
+
+      /**
+       * Return the partitioning of the domain space of this matrix, i.e., the
+       * partitioning of the vectors this matrix has to be multiplied with.
+       */
+      IndexSet
+      locally_owned_domain_indices() const;
+
+      /**
+       * Return the partitioning of the range space of this matrix, i.e., the
+       * partitioning of the vectors that are result from matrix-vector
+       * products.
+       */
+      IndexSet
+      locally_owned_range_indices() const;
+
+      /** @} */
+
+      /**
        * @addtogroup Exceptions
        */
       /** @{ */
@@ -758,6 +780,24 @@ namespace LinearAlgebra
     SparseMatrix<Number, MemorySpace>::trilinos_rcp()
     {
       return matrix;
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    inline IndexSet
+    SparseMatrix<Number, MemorySpace>::locally_owned_domain_indices() const
+    {
+      return IndexSet(matrix->getDomainMap());
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    inline IndexSet
+    SparseMatrix<Number, MemorySpace>::locally_owned_range_indices() const
+    {
+      return IndexSet(matrix->getRangeMap());
     }
 
   } // namespace TpetraWrappers

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -1200,6 +1200,51 @@ namespace LinearAlgebra
 
 } // namespace LinearAlgebra
 
+
+namespace internal
+{
+  namespace LinearOperatorImplementation
+  {
+    template <typename>
+    class ReinitHelper;
+
+    /**
+     * A helper class used internally in linear_operator.h. Specialization for
+     * LinearAlgebra::TpetraWrappers::Vector<Number, MemorySpace>.
+     */
+    template <typename Number, typename MemorySpace>
+    class ReinitHelper<
+      LinearAlgebra::TpetraWrappers::Vector<Number, MemorySpace>>
+    {
+    public:
+      template <typename Matrix>
+      static void
+      reinit_range_vector(
+        const Matrix                                               &matrix,
+        LinearAlgebra::TpetraWrappers::Vector<Number, MemorySpace> &v,
+        bool omit_zeroing_entries)
+      {
+        v.reinit(matrix.locally_owned_range_indices(),
+                 matrix.get_mpi_communicator(),
+                 omit_zeroing_entries);
+      }
+
+      template <typename Matrix>
+      static void
+      reinit_domain_vector(
+        const Matrix                                               &matrix,
+        LinearAlgebra::TpetraWrappers::Vector<Number, MemorySpace> &v,
+        bool omit_zeroing_entries)
+      {
+        v.reinit(matrix.locally_owned_domain_indices(),
+                 matrix.get_mpi_communicator(),
+                 omit_zeroing_entries);
+      }
+    };
+
+  } // namespace LinearOperatorImplementation
+} /* namespace internal */
+
 /**
  * Declare dealii::LinearAlgebra::TpetraWrappers::Vector as distributed vector.
  */

--- a/tests/lac/linear_operator_04.cc
+++ b/tests/lac/linear_operator_04.cc
@@ -20,6 +20,8 @@
 #include <deal.II/lac/linear_operator.h>
 #include <deal.II/lac/trilinos_block_sparse_matrix.h>
 #include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_tpetra_sparse_matrix.h>
+#include <deal.II/lac/trilinos_tpetra_vector.h>
 #include <deal.II/lac/trilinos_vector.h>
 
 #include "../tests.h"
@@ -33,15 +35,27 @@ main(int argc, char *argv[])
   initlog();
   deallog << std::setprecision(10);
 
-  TrilinosWrappers::SparseMatrix a;
+  {
+    TrilinosWrappers::SparseMatrix a;
+    auto op_a  = linear_operator<TrilinosWrappers::MPI::Vector>(a);
+    auto op_a2 = linear_operator<TrilinosWrappers::MPI::Vector>(a);
+  }
 
-  auto op_a  = linear_operator<TrilinosWrappers::MPI::Vector>(a);
-  auto op_a2 = linear_operator<TrilinosWrappers::MPI::Vector>(a);
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+  {
+    LinearAlgebra::TpetraWrappers::SparseMatrix<double> a;
+    auto                                                op_a =
+      linear_operator<LinearAlgebra::TpetraWrappers::Vector<double>>(a);
+    auto op_a2 =
+      linear_operator<LinearAlgebra::TpetraWrappers::Vector<double>>(a);
+  }
+#endif
 
-  TrilinosWrappers::BlockSparseMatrix b;
-
-  auto op_b  = linear_operator<TrilinosWrappers::MPI::BlockVector>(b);
-  auto op_b3 = linear_operator<TrilinosWrappers::MPI::BlockVector>(b);
+  {
+    TrilinosWrappers::BlockSparseMatrix b;
+    auto op_b  = linear_operator<TrilinosWrappers::MPI::BlockVector>(b);
+    auto op_b3 = linear_operator<TrilinosWrappers::MPI::BlockVector>(b);
+  }
 
   deallog << "OK" << std::endl;
 

--- a/tests/lac/vector_reinit_02.cc
+++ b/tests/lac/vector_reinit_02.cc
@@ -21,6 +21,7 @@
 
 #include <deal.II/base/mpi.h>
 
+#include <deal.II/lac/trilinos_tpetra_vector.h>
 #include <deal.II/lac/trilinos_vector.h>
 #include <deal.II/lac/vector_memory.h>
 
@@ -113,4 +114,9 @@ main(int argc, char **argv)
 
   do_test<TrilinosWrappers::MPI::Vector>();
   do_test<TrilinosWrappers::MPI::Vector>();
+
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+  do_test<LinearAlgebra::TpetraWrappers::Vector<double>>();
+  do_test<LinearAlgebra::TpetraWrappers::Vector<double>>();
+#endif
 }


### PR DESCRIPTION
We need to implement a `ReinitHelper` specialization, `locally_owned_domain_indices` and `locally_owned_range_indices` indices for these tests.