### PR TITLE
Fix deal.II CMake flag in Tpetra configure warning

### DIFF
--- a/cmake/configure/configure_20_trilinos.cmake
+++ b/cmake/configure/configure_20_trilinos.cmake
@@ -285,7 +285,7 @@ macro(feature_trilinos_find_external var)
             STATUS
             "  Tpetra wasn't configured with support for 64-bit global indices\n"
             "  but deal.II is configured to use 64-bit global indices.\n"
-            "  Either reconfigure deal.II with -DDEAL_II_WITH_64_BIT_INDICES=OFF.\n"
+            "  Either reconfigure deal.II with -DDEAL_II_WITH_64BIT_INDICES=OFF.\n"
             "  or rebuild Trilinos with -DTPETRA_INST_INT_LONG_LONG=ON"
           )
           if(DEAL_II_HAVE_TPETRA_INT_LONG)
@@ -304,7 +304,7 @@ macro(feature_trilinos_find_external var)
             STATUS
             "  Tpetra wasn't configured with support for 32-bit global indices\n"
             "  but deal.II is configured to use 32-bit global indices.\n"
-            "  Either reconfigure deal.II with -DDEAL_II_WITH_64_BIT_INDICES=ON.\n"
+            "  Either reconfigure deal.II with -DDEAL_II_WITH_64BIT_INDICES=ON.\n"
             "  or rebuild Trilinos with -DTPETRA_INST_INT_INT=ON"
           )
           if(DEAL_II_HAVE_TPETRA_INT_LONG)


### PR DESCRIPTION
The warning suggested to switch `-DDEAL_II_WITH_64_BIT_INDICES` from `ON` to `OFF` or vice versa.
However, the correct flag is without an underscore between `64` and `BIT`.