### PR TITLE
Tpetra: Replace TrilinosScalar

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparse_matrix.h
@@ -424,7 +424,7 @@ namespace LinearAlgebra
        * back to an uncompressed state.
        */
       void
-      add(const size_type i, const size_type j, const TrilinosScalar value);
+      add(const size_type i, const size_type j, const Number value);
 
       /**
        * Add an array of values given by <tt>values</tt> in the given global
@@ -440,12 +440,12 @@ namespace LinearAlgebra
        * back to an uncompressed state.
        */
       void
-      add(const size_type       row,
-          const size_type       n_cols,
-          const size_type      *col_indices,
-          const TrilinosScalar *values,
-          const bool            elide_zero_values      = true,
-          const bool            col_indices_are_sorted = false);
+      add(const size_type  row,
+          const size_type  n_cols,
+          const size_type *col_indices,
+          const Number    *values,
+          const bool       elide_zero_values      = true,
+          const bool       col_indices_are_sorted = false);
 
       /**
        * Set the element (<i>i,j</i>) to @p value.
@@ -836,9 +836,9 @@ namespace LinearAlgebra
 
     template <typename Number, typename MemorySpace>
     inline void
-    SparseMatrix<Number, MemorySpace>::add(const size_type      i,
-                                           const size_type      j,
-                                           const TrilinosScalar value)
+    SparseMatrix<Number, MemorySpace>::add(const size_type i,
+                                           const size_type j,
+                                           const Number    value)
     {
       add(i, 1, &j, &value, false);
     }

--- a/include/deal.II/lac/trilinos_tpetra_sparse_matrix.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparse_matrix.templates.h
@@ -632,11 +632,11 @@ namespace LinearAlgebra
     template <typename Number, typename MemorySpace>
     void
     SparseMatrix<Number, MemorySpace>::add(
-      const size_type       row,
-      const size_type       n_cols,
-      const size_type      *col_indices,
-      const TrilinosScalar *values,
-      const bool            elide_zero_values,
+      const size_type  row,
+      const size_type  n_cols,
+      const size_type *col_indices,
+      const Number    *values,
+      const bool       elide_zero_values,
       const bool /*col_indices_are_sorted*/)
     {
       AssertIndexRange(row, this->m());

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -549,8 +549,8 @@ namespace LinearAlgebra
        * stored in @p values to the vector components specified by @p indices.
        */
       void
-      add(const std::vector<size_type>      &indices,
-          const std::vector<TrilinosScalar> &values);
+      add(const std::vector<size_type> &indices,
+          const std::vector<Number>    &values);
 
 
       /**
@@ -943,8 +943,8 @@ namespace LinearAlgebra
 
     template <typename Number, typename MemorySpace>
     inline void
-    Vector<Number, MemorySpace>::add(const std::vector<size_type>      &indices,
-                                     const std::vector<TrilinosScalar> &values)
+    Vector<Number, MemorySpace>::add(const std::vector<size_type> &indices,
+                                     const std::vector<Number>    &values)
     {
       // if we have ghost values, do not allow
       // writing to this vector at all.


### PR DESCRIPTION
Since we have a template parameter type for the number type, we should use that instead of `TrilinosScalar` to have an interface closer to other linear algebra types templated on a number type.