### PR TITLE
Fix compilation error arising with Intel ICC compiler in `trilinos_tpetra_sparsity_pattern.cc`

### DIFF
--- a/source/lac/trilinos_tpetra_sparsity_pattern.cc
+++ b/source/lac/trilinos_tpetra_sparsity_pattern.cc
@@ -958,7 +958,7 @@ namespace LinearAlgebra
 
 
     template <typename MemorySpace>
-    Teuchos::RCP<const MapType<MemorySpace>>
+    Teuchos::RCP<const typename SparsityPattern<MemorySpace>::MapType>
     SparsityPattern<MemorySpace>::domain_partitioner() const
     {
       return graph->getDomainMap();
@@ -967,7 +967,7 @@ namespace LinearAlgebra
 
 
     template <typename MemorySpace>
-    Teuchos::RCP<const MapType<MemorySpace>>
+    Teuchos::RCP<const typename SparsityPattern<MemorySpace>::MapType>
     SparsityPattern<MemorySpace>::range_partitioner() const
     {
       return graph->getRangeMap();


### PR DESCRIPTION
Intel ICC compilers fail to compile Trilinos Tpetra sparsity pattern raising the following error:

```
In file included from dealii-build/source/lac/unity_2.cc(5):
dealii/source/lac/trilinos_tpetra_sparsity_pattern.cc(961): error: declaration is incompatible with "Teuchos::RCP<const dealii::LinearAlgebra::TpetraWrappers::SparsityPattern<MemorySpace>::MapType> dealii::LinearAlgebra::TpetraWrappers::SparsityPattern<MemorySpace>::domain_partitioner() const" (declared at line 868 of "dealii/include/deal.II/lac/trilinos_tpetra_sparsity_pattern.h")
      SparsityPattern<MemorySpace>::domain_partitioner() const
                                    ^

In file included from dealii-build/source/lac/unity_2.cc(5):
dealii/source/lac/trilinos_tpetra_sparsity_pattern.cc(971): error: declaration is incompatible with "Teuchos::RCP<const dealii::LinearAlgebra::TpetraWrappers::SparsityPattern<MemorySpace>::MapType> dealii::LinearAlgebra::TpetraWrappers::SparsityPattern<MemorySpace>::range_partitioner() const" (declared at line 877 of "dealii/include/deal.II/lac/trilinos_tpetra_sparsity_pattern.h")
      SparsityPattern<MemorySpace>::range_partitioner() const
                                    ^
```
The proposed modification fixes this.

All versions of ICC are prone to this issue as can be seen in this toy example: https://godbolt.org/z/qc6cMqf3a