### PR TITLE
Work around an issue in Teuchos::rcpFromRef() with types only forward declared.

### DIFF
--- a/source/lac/trilinos_tpetra_communication_pattern.cc
+++ b/source/lac/trilinos_tpetra_communication_pattern.cc
@@ -49,7 +49,7 @@ namespace LinearAlgebra
                                  const IndexSet &ghost_indices,
                                  const MPI_Comm  communicator)
     {
-      comm = Teuchos::rcpFromRef(communicator);
+      comm = Teuchos::rcpFromUndefRef(communicator);
 
       auto vector_space_vector_map =
         locally_owned_indices.make_tpetra_map_rcp(*comm, false);


### PR DESCRIPTION
Specifically, calling `Teuchos::rcpFromRef(T*)` internally calls `typeid(T)` which only works if `T` is a complete type. Unfortunately, my MPI library only forward declares the MPI communicator class and makes `MPI_Comm` a pointer to this incomplete class. This leads to an error in `rcpFromRef()`.

It turns out that this is documented, see the documentation of `rcpFromRef()` at https://docs.trilinos.org/dev/packages/teuchos/doc/html/classTeuchos_1_1RCP.html#a6c754d72d6d232c97e38bc359ab6ef82 and the reference to `rcpFromUndefRef()` there (see https://docs.trilinos.org/dev/packages/teuchos/doc/html/classTeuchos_1_1RCP.html#a823eee3138de3b23dab97b3f37e197f3).