### PR TITLE
Fix 64-bit compilation with old PETSc versions.

### DIFF
--- a/source/lac/petsc_communication_pattern.cc
+++ b/source/lac/petsc_communication_pattern.cc
@@ -204,8 +204,12 @@ namespace PETScWrappers
     const PetscInt *ranges;
     AssertPETSc(PetscLayoutGetRanges(layout, &ranges));
 
-    PetscInt    cnt   = 0;
+    PetscInt cnt = 0;
+#  if DEAL_II_PETSC_VERSION_GTE(3, 13, 0)
     PetscMPIInt owner = 0;
+#  else
+    PetscInt owner = 0;
+#  endif
     for (const auto idx : inidx)
       {
         // short-circuit the search if the last owner owns this index too


### PR DESCRIPTION
This function switched from taking a pointer to `PetscInt` to a pointer to `PetscMPIInt` in PETSc 3.13, see https://petsc.org/release/changes/313/ . These are the same types in 32-bit compilations, which is why it was never a problem for me, but I tried to compile with 64-bit integers and there this triggers.