### PR TITLE
Also instantiate the Trilinos Tpetra VectorReference class.

### DIFF
--- a/source/lac/trilinos_tpetra_vector.cc
+++ b/source/lac/trilinos_tpetra_vector.cc
@@ -36,13 +36,23 @@ namespace LinearAlgebra
     static_assert(concepts::is_vector_space_vector<Vector<float>>);
 #    endif
     template class Vector<float>;
+    namespace internal
+    {
+      template class VectorReference<float>;
+    }
 #  endif
+
 #  ifdef HAVE_TPETRA_INST_DOUBLE
 #    ifdef DEAL_II_HAVE_CXX20
     static_assert(concepts::is_vector_space_vector<Vector<double>>);
 #    endif
     template class Vector<double>;
+    namespace internal
+    {
+      template class VectorReference<double>;
+    }
 #  endif
+
 #  ifdef DEAL_II_WITH_COMPLEX_VALUES
 #    ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
 #      ifdef DEAL_II_HAVE_CXX20
@@ -50,13 +60,22 @@ namespace LinearAlgebra
                   Vector<std::complex<float>>);
 #      endif
     template class Vector<std::complex<float>>;
+    namespace internal
+    {
+      template class VectorReference<std::complex<float>>;
+    }
 #    endif
+
 #    ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
 #      ifdef DEAL_II_HAVE_CXX20
     static_assert(concepts::is_vector_space_vector <
                   Vector<std::complex<double>>);
 #      endif
     template class Vector<std::complex<double>>;
+    namespace internal
+    {
+      template class VectorReference<std::complex<double>>;
+    }
 #    endif
 #  endif
   } // namespace TpetraWrappers


### PR DESCRIPTION
I'm trying to get some tests for Tpetra going, and this is a linker error I'm addressing. However, it does not address what is *really* underlying the issue I see: Namely, that `VectorReference::operator Number()` is declared but not implemented. We need another patch for this.

@masterleinad @kinnewig @jpthiele 