### PR TITLE
Implementation for TpetraWrappers::Vector::operator Number()

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -44,6 +44,37 @@ namespace LinearAlgebra
 {
   namespace TpetraWrappers
   {
+    namespace internal
+    {
+      template <typename Number, typename MemorySpace>
+      VectorReference<Number, MemorySpace>::operator Number() const
+      {
+        // Get the local index
+        const TrilinosWrappers::types::int_type local_index =
+          vector.vector->getMap()->getLocalElement(
+            static_cast<TrilinosWrappers::types::int_type>(index));
+
+#  if DEAL_II_TRILINOS_VERSION_GTE(14, 0, 0)
+        Assert((local_index != Teuchos::OrdinalTraits<int>::invalid()),
+               ExcAccessToNonLocalElement(
+                 index,
+                 vector.vector->getMap()->getLocalNumElements(),
+                 vector.vector->getMap()->getMinLocalIndex(),
+                 vector.vector->getMap()->getMaxLocalIndex()));
+#  else
+        Assert((local_index != Teuchos::OrdinalTraits<int>::invalid()),
+               ExcAccessToNonLocalElement(
+                 index,
+                 vector.vector->getMap()->getNodeNumElements(),
+                 vector.vector->getMap()->getMinLocalIndex(),
+                 vector.vector->getMap()->getMaxLocalIndex()));
+#  endif
+        return vector.vector->getData()[local_index];
+      }
+    } // namespace internal
+
+
+
     template <typename Number, typename MemorySpace>
     Vector<Number, MemorySpace>::Vector()
       : Subscriptor()


### PR DESCRIPTION
This adds an implementation for `LinearAlgebra::TpetraWrappers::Vector<Number, MemorySpace>::operator Number()`

Initially, this was part of #16588, but as discussed in #16610, I moved it into a separate pull request.
This is also necessary for #16611.