### PR TITLE
Template TpetraWrappers::SparseMatrix::vmult on the vector type.

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparse_matrix.h
@@ -27,10 +27,13 @@
 #  include <deal.II/lac/sparsity_pattern.h>
 #  include <deal.II/lac/trilinos_tpetra_sparsity_pattern.h>
 #  include <deal.II/lac/trilinos_tpetra_vector.h>
+#  include <deal.II/lac/vector.h>
 
 // Tpetra includes
 #  include <Tpetra_Core.hpp>
 #  include <Tpetra_CrsMatrix.hpp>
+
+#  include <type_traits>
 
 
 DEAL_II_NAMESPACE_OPEN
@@ -161,6 +164,12 @@ namespace LinearAlgebra
        */
       using GraphType =
         Tpetra::CrsGraph<int, dealii::types::signed_global_dof_index, NodeType>;
+
+      /**
+       * Typedef for Tpetra::Vector
+       */
+      using VectorType = Tpetra::
+        Vector<Number, int, dealii::types::signed_global_dof_index, NodeType>;
 
       /**
        * @name Constructors and initialization.
@@ -799,9 +808,9 @@ namespace LinearAlgebra
        * initialized with the same IndexSet that was used for the column indices
        * of the matrix.
        */
+      template <typename InputVectorType>
       void
-      vmult(Vector<Number, MemorySpace>       &dst,
-            const Vector<Number, MemorySpace> &src) const;
+      vmult(InputVectorType &dst, const InputVectorType &src) const;
 
       /*
        * Matrix-vector multiplication: let <i>dst = M<sup>T</sup>*src</i> with
@@ -810,9 +819,9 @@ namespace LinearAlgebra
        *
        * Source and destination must not be the same vector.
        */
+      template <typename InputVectorType>
       void
-      Tvmult(Vector<Number, MemorySpace>       &dst,
-             const Vector<Number, MemorySpace> &src) const;
+      Tvmult(InputVectorType &dst, const InputVectorType &src) const;
 
       /**
        * Adding matrix-vector multiplication. Add <i>M*src</i> on <i>dst</i>
@@ -820,10 +829,9 @@ namespace LinearAlgebra
        *
        * Source and destination must not be the same vector.
        */
+      template <typename InputVectorType>
       void
-      vmult_add(Vector<Number, MemorySpace>       &dst,
-                const Vector<Number, MemorySpace> &src) const;
-
+      vmult_add(InputVectorType &dst, const InputVectorType &src) const;
 
       /**
        * Adding matrix-vector multiplication. Add <i>M<sup>T</sup>*src</i> to
@@ -832,9 +840,9 @@ namespace LinearAlgebra
        *
        * Source and destination must not be the same vector.
        */
+      template <typename InputVectorType>
       void
-      Tvmult_add(Vector<Number, MemorySpace>       &dst,
-                 const Vector<Number, MemorySpace> &src) const;
+      Tvmult_add(InputVectorType &dst, const InputVectorType &src) const;
 
       /**
        * Return the square of the norm of the vector $v$ with respect to the

--- a/source/lac/trilinos_tpetra_sparse_matrix.cc
+++ b/source/lac/trilinos_tpetra_sparse_matrix.cc
@@ -46,6 +46,37 @@ namespace LinearAlgebra
     template void
     SparseMatrix<double>::reinit(const dealii::DynamicSparsityPattern &);
 
+    template void
+    SparseMatrix<double>::vmult(Vector<double>       &dst,
+                                const Vector<double> &src) const;
+
+    template void
+    SparseMatrix<double>::Tvmult(Vector<double>       &dst,
+                                 const Vector<double> &src) const;
+
+    template void
+    SparseMatrix<double>::vmult_add(Vector<double>       &dst,
+                                    const Vector<double> &src) const;
+
+    template void
+    SparseMatrix<double>::Tvmult_add(Vector<double>       &dst,
+                                     const Vector<double> &src) const;
+
+    template void
+    SparseMatrix<double>::vmult(::dealii::Vector<double>       &dst,
+                                const ::dealii::Vector<double> &src) const;
+
+    template void
+    SparseMatrix<double>::Tvmult(::dealii::Vector<double>       &dst,
+                                 const ::dealii::Vector<double> &src) const;
+
+    template void
+    SparseMatrix<double>::vmult_add(::dealii::Vector<double>       &dst,
+                                    const ::dealii::Vector<double> &src) const;
+
+    template void
+    SparseMatrix<double>::Tvmult_add(::dealii::Vector<double>       &dst,
+                                     const ::dealii::Vector<double> &src) const;
   } // namespace TpetraWrappers
 } // namespace LinearAlgebra
 #  endif // DOXYGEN


### PR DESCRIPTION
Rework from `LinearAlgebra::TpetraWrappers::SparseMatrix<Number, MemorySpace>::vmult` (and `Tvmult`, `vmult_add`, `Tvmult_add`) such that it takes arbritraty vector types.

Initially, this was part of #16588, but I moved it into a separate pull request because it contains a few points I would like to discuss.

Each function of vmult, Tvmult, vmult_add, and Tvmult_add contains a part that converts the raw data of the input vectors into a Kokkos::DualView. I was thinking about moving that conversion into a separate (internal) function (and marking that function as inline).
And this is the most convenient way to convert the raw data from a vector into a Kokkos::DualView I came up with. But if there is a more elegant way to do that, please let me know!

Furthermore, we need a more elegant way to initialize all templates.

Since some tests include a `vmult` between a `TrilinosWrappers::SparseMatrix`  and a `dealii::Vector`, this should help with #16611 as well. 