### PR TITLE
Specify when Tpetra tests should be run

### DIFF
--- a/tests/trilinos_tpetra/CMakeLists.txt
+++ b/tests/trilinos_tpetra/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.13.4)
 include(../scripts/setup_testsubproject.cmake)
 project(testsuite CXX)
-if(DEAL_II_WITH_TRILINOS)
+if(DEAL_II_WITH_TRILINOS AND DEAL_II_TRILINOS_WITH_TPETRA)
   deal_ii_pickup_tests()
 endif()


### PR DESCRIPTION
This is related to #16627 and also to #16623.
Adds `DEAL_II_TRILINOS_WITH_TPETRA` to the if clause in the local CMakeLists.txt.
