### PR TITLE
GridTools::compute_active_cell_halo_layer() for periodic meshes

### DIFF
--- a/doc/news/changes/minor/20240212Munch
+++ b/doc/news/changes/minor/20240212Munch
@@ -1,0 +1,4 @@
+Fixed: The function GridTools::compute_active_cell_halo_layer() now
+also supports perodic meshes.
+<br>
+(Peter Munch, 2024/02/12)

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -3240,6 +3240,22 @@ namespace DoFTools
             return;
           }
 
+      // In the case of shared Trinagulation with artificial cells all
+      // cells have valid DoF indices, i.e., the check above does not work.
+      if (const auto tria = dynamic_cast<
+            const parallel::shared::Triangulation<dim, spacedim> *>(
+            &face_1->get_triangulation()))
+        if (tria->with_artificial_cells() &&
+            (affine_constraints.get_local_lines().size() != 0))
+          for (unsigned int i = 0; i < dofs_per_face; ++i)
+            if ((affine_constraints.get_local_lines().is_element(dofs_1[i]) ==
+                 false) ||
+                (affine_constraints.get_local_lines().is_element(dofs_2[i]) ==
+                 false))
+              {
+                return;
+              }
+
       // Well, this is a hack:
       //
       // There is no

--- a/tests/sharedtria/pbc_01.cc
+++ b/tests/sharedtria/pbc_01.cc
@@ -1,0 +1,75 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// Test shared triangulations (with artificial cells) for periodic
+// boundary conditions.
+
+#include <deal.II/distributed/shared_tria.h>
+
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include "../tests.h"
+
+template <int dim>
+void
+test()
+{
+  parallel::shared::Triangulation<dim> tria(MPI_COMM_WORLD,
+                                            Triangulation<dim>::none,
+                                            true);
+
+  GridGenerator::hyper_cube(tria, 0, 1, true);
+
+  std::vector<
+    GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
+    face_pairs;
+  for (unsigned int d = 0; d < dim; ++d)
+    GridTools::collect_periodic_faces(tria, 2 * d, 2 * d + 1, d, face_pairs);
+  tria.add_periodicity(face_pairs);
+
+  tria.refine_global(6 - dim);
+
+  DoFHandler<dim> dof_handler(tria);
+  dof_handler.distribute_dofs(FE_Q<dim>(1));
+
+  AffineConstraints<double> constraints;
+
+  constraints.reinit(DoFTools::extract_locally_relevant_dofs(dof_handler));
+  for (unsigned int d = 0; d < dim; ++d)
+    DoFTools::make_periodicity_constraints(
+      dof_handler, 2 * d, 2 * d + 1, d, constraints);
+  constraints.close();
+
+  deallog << "OK" << std::endl;
+}
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  MPILogInitAll all;
+
+  test<1>();
+  test<2>();
+  test<3>();
+}

--- a/tests/sharedtria/pbc_01.mpirun=2.output
+++ b/tests/sharedtria/pbc_01.mpirun=2.output
@@ -1,0 +1,9 @@
+
+DEAL:0::OK
+DEAL:0::OK
+DEAL:0::OK
+
+DEAL:1::OK
+DEAL:1::OK
+DEAL:1::OK
+


### PR DESCRIPTION
(this is used internally used by `p:s:T`)