### PR TITLE
MG transfer global coarsening: Avoid sending empty messages

### DIFF
--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -866,7 +866,11 @@ namespace internal
 
         for (const auto &i : targets_with_indexset)
           {
-            if (i.first == my_rank)
+            // Skip communication in case we would send to ourselves or when
+            // there are no indices to send (this can still happen in the run
+            // of the consensus algorithms above if the index spaces are
+            // sparse).
+            if (i.first == my_rank || i.second.begin() == i.second.end())
               continue;
 
             indices_to_be_sent[i.first] = {};


### PR DESCRIPTION
To make a test case of @marcfehling run on my MPI implementation, I had to ensure that there were no empty messages in addition to #16631, otherwise an MPI process would get stuck in the `BlackBoxFineDoFHandlerView::reinit()` function here: https://github.com/dealii/dealii/blob/d29226465a864be493f51fd051dfe811256ce4be/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h#L972-L974 I believe the empty index sets in the `MPI::internal::ComputeIndexOwner` functions can happen when we have sparse index ranges as we might touch an `std::map` entry without filling it somewhere. I did not investigate that closer, but I think that all tests we have do not rely on empty messages, so I think we should expect that this is more robust anyway. @peterrum there might a place where we could filter out that earlier, but I can't say for sure where the empty index sets come from, so I would appreciate some help.

Furthermore, I can't give a test case because the one used by @marcfehling is rather large, and I could not understand what geometric configuration would be needed: Whenever I tried to reduce the complexity, the MPI deadlock would go away, so it seems my MPI implementation might simply have run out of buffers or something. @marcfehling would you mind testing your full case also with this patch, to ensure that nothing else happens here?