### PR TITLE
Fix Tpetra vector element access.

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -1013,9 +1013,6 @@ namespace LinearAlgebra
       ViewType2d vector_2d_local =
         vector->template getLocalView<Kokkos::HostSpace>(
           Tpetra::Access::ReadWrite);
-      ViewType2d vector_2d_nonlocal =
-        nonlocal_vector->template getLocalView<Kokkos::HostSpace>(
-          Tpetra::Access::ReadWrite);
 #  else
       vector->template sync<Kokkos::HostSpace>();
 
@@ -1023,23 +1020,25 @@ namespace LinearAlgebra
         decltype(vector->template getLocalView<Kokkos::HostSpace>());
       ViewType2d vector_2d_local =
         vector->template getLocalView<Kokkos::HostSpace>();
-      ViewType2d vector_2d_nonlocal =
-        nonlocal_vector->template getLocalView<Kokkos::HostSpace>();
 #  endif
 
       // Having extracted a view into the multivectors above, now also
-      // extract a view into the one vector we actually store.
+      // extract a view into the one vector we actually store. We can
+      // do this right away for the locally owned part. We defer creating
+      // the view into the nonlocal part to when we know that we actually
+      // need it; this also makes sure that we correctly deal with the
+      // case where we do not actually store a nonlocal part.
       using ViewType1d =
         decltype(Kokkos::subview(vector_2d_local, Kokkos::ALL(), 0));
 
       ViewType1d vector_1d_local =
         Kokkos::subview(vector_2d_local, Kokkos::ALL(), 0);
-      ViewType1d vector_1d_nonlocal =
-        Kokkos::subview(vector_2d_nonlocal, Kokkos::ALL(), 0);
+      std::optional<ViewType1d> vector_1d_nonlocal;
 
 #  if !DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
+      // Mark vector as to-be-modified. We may do the same with
+      // the nonlocal part too if we end up writing into it.
       vector->template modify<Kokkos::HostSpace>();
-      nonlocal_vector->template modify<Kokkos::HostSpace>();
 #  endif
 
       for (size_type i = 0; i < n_elements; ++i)
@@ -1060,6 +1059,7 @@ namespace LinearAlgebra
               // If the element was not in the locally owned part,
               // we need to figure out whether it is in the nonlocal
               // part. It better be:
+              Assert(nonlocal_vector.get() != nullptr, ExcInternalError());
               TrilinosWrappers::types::int_type nonlocal_row =
                 nonlocal_vector->getMap()->getLocalElement(row);
 
@@ -1081,7 +1081,29 @@ namespace LinearAlgebra
 #  endif
 
               // Having asserted that it is, write into the nonlocal part.
-              vector_1d_nonlocal(nonlocal_row) += values[i];
+              // To do so, we first need to make sure that we have a view
+              // of the nonlocal part of the vectors, since we have
+              // deferred creating this view previously:
+              if (!vector_1d_nonlocal)
+                {
+#  if DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
+                  ViewType2d vector_2d_nonlocal =
+                    nonlocal_vector->template getLocalView<Kokkos::HostSpace>(
+                      Tpetra::Access::ReadWrite);
+#  else
+                  ViewType2d vector_2d_nonlocal =
+                    nonlocal_vector->template getLocalView<Kokkos::HostSpace>();
+#  endif
+
+                  vector_1d_nonlocal =
+                    Kokkos::subview(vector_2d_nonlocal, Kokkos::ALL(), 0);
+
+#  if !DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
+                  // Mark the nonlocal vector as to-be-modified as well.
+                  nonlocal_vector->template modify<Kokkos::HostSpace>();
+#  endif
+                }
+              (*vector_1d_nonlocal)(nonlocal_row) += values[i];
               compressed = false;
             }
         }
@@ -1090,9 +1112,13 @@ namespace LinearAlgebra
       vector->template sync<
         typename Tpetra::Vector<Number, int, types::signed_global_dof_index>::
           device_type::memory_space>();
-      nonlocal_vector->template sync<
-        typename Tpetra::Vector<Number, int, types::signed_global_dof_index>::
-          device_type::memory_space>();
+
+      // If we have created a view to the nonlocal part, then we have also
+      // written into it. Flush these modifications.
+      if (vector_1d_nonlocal)
+        nonlocal_vector->template sync<
+          typename Tpetra::Vector<Number, int, types::signed_global_dof_index>::
+            device_type::memory_space>();
 #  endif
     }
 

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -1138,48 +1138,122 @@ namespace LinearAlgebra
       // writing to this vector at all.
       Assert(!has_ghost_elements(), ExcGhostsPresent());
 
+      // First create an alias for the type of a view into our vectors.
+      // The actual type is declared through several re-directions in
+      // Tpetra, so instead of spelling it out, we get it via decltype:
 #  if DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
-      auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
-        Tpetra::Access::ReadWrite);
+      using ViewType2d =
+        decltype(vector->template getLocalView<Kokkos::HostSpace>(
+          Tpetra::Access::ReadWrite));
+      ViewType2d vector_2d_local =
+        vector->template getLocalView<Kokkos::HostSpace>(
+          Tpetra::Access::ReadWrite);
 #  else
       vector->template sync<Kokkos::HostSpace>();
-      auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>();
+
+      using ViewType2d =
+        decltype(vector->template getLocalView<Kokkos::HostSpace>());
+      ViewType2d vector_2d_local =
+        vector->template getLocalView<Kokkos::HostSpace>();
 #  endif
-      auto vector_1d = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
+
+      // Having extracted a view into the multivectors above, now also
+      // extract a view into the one vector we actually store. We can
+      // do this right away for the locally owned part. We defer creating
+      // the view into the nonlocal part to when we know that we actually
+      // need it; this also makes sure that we correctly deal with the
+      // case where we do not actually store a nonlocal part.
+      using ViewType1d =
+        decltype(Kokkos::subview(vector_2d_local, Kokkos::ALL(), 0));
+
+      ViewType1d vector_1d_local =
+        Kokkos::subview(vector_2d_local, Kokkos::ALL(), 0);
+      std::optional<ViewType1d> vector_1d_nonlocal;
+
 #  if !DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
+      // Mark vector as to-be-modified. We may do the same with
+      // the nonlocal part too if we end up writing into it.
       vector->template modify<Kokkos::HostSpace>();
 #  endif
 
       for (size_type i = 0; i < n_elements; ++i)
         {
-          const size_type                   row = indices[i];
-          TrilinosWrappers::types::int_type local_row =
-            vector->getMap()->getLocalElement(row);
+          const size_type row = indices[i];
+
+          // Check if the index is in the locally owned index set.
+          // If so, we can write right into the locally owned
+          // part of the vector.
+          if (TrilinosWrappers::types::int_type local_row =
+                vector->getMap()->getLocalElement(row);
+              local_row != Teuchos::OrdinalTraits<int>::invalid())
+            {
+              vector_1d_local(local_row) = values[i];
+            }
+          else
+            {
+              // If the element was not in the locally owned part,
+              // we need to figure out whether it is in the nonlocal
+              // part. It better be:
+              Assert(nonlocal_vector.get() != nullptr, ExcInternalError());
+              TrilinosWrappers::types::int_type nonlocal_row =
+                nonlocal_vector->getMap()->getLocalElement(row);
 
 #  if DEAL_II_TRILINOS_VERSION_GTE(14, 0, 0)
-          Assert(
-            local_row != Teuchos::OrdinalTraits<int>::invalid(),
-            ExcAccessToNonLocalElement(row,
-                                       vector->getMap()->getLocalNumElements(),
-                                       vector->getMap()->getMinLocalIndex(),
-                                       vector->getMap()->getMaxLocalIndex()));
+              Assert(nonlocal_row != Teuchos::OrdinalTraits<int>::invalid(),
+                     ExcAccessToNonLocalElement(
+                       row,
+                       vector->getMap()->getLocalNumElements(),
+                       vector->getMap()->getMinLocalIndex(),
+                       vector->getMap()->getMaxLocalIndex()));
 #  else
-          Assert(
-            local_row != Teuchos::OrdinalTraits<int>::invalid(),
-            ExcAccessToNonLocalElement(row,
-                                       vector->getMap()->getNodeNumElements(),
-                                       vector->getMap()->getMinLocalIndex(),
-                                       vector->getMap()->getMaxLocalIndex()));
+              Assert(nonlocal_row != Teuchos::OrdinalTraits<int>::invalid(),
+                     ExcAccessToNonLocalElement(
+                       row,
+                       vector->getMap()->getNodeNumElements(),
+                       vector->getMap()->getMinLocalIndex(),
+                       vector->getMap()->getMaxLocalIndex()));
+
 #  endif
 
-          if (local_row != Teuchos::OrdinalTraits<int>::invalid())
-            vector_1d(local_row) = values[i];
+              // Having asserted that it is, write into the nonlocal part.
+              // To do so, we first need to make sure that we have a view
+              // of the nonlocal part of the vectors, since we have
+              // deferred creating this view previously:
+              if (!vector_1d_nonlocal)
+                {
+#  if DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
+                  ViewType2d vector_2d_nonlocal =
+                    nonlocal_vector->template getLocalView<Kokkos::HostSpace>(
+                      Tpetra::Access::ReadWrite);
+#  else
+                  ViewType2d vector_2d_nonlocal =
+                    nonlocal_vector->template getLocalView<Kokkos::HostSpace>();
+#  endif
+
+                  vector_1d_nonlocal =
+                    Kokkos::subview(vector_2d_nonlocal, Kokkos::ALL(), 0);
+
+#  if !DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
+                  // Mark the nonlocal vector as to-be-modified as well.
+                  nonlocal_vector->template modify<Kokkos::HostSpace>();
+#  endif
+                }
+              (*vector_1d_nonlocal)(nonlocal_row) = values[i];
+              compressed                          = false;
+            }
         }
 
 #  if !DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
       vector->template sync<
         typename Tpetra::Vector<Number, int, types::signed_global_dof_index>::
           device_type::memory_space>();
+
+      // If we have created a view to the nonlocal part, then we have also
+      // written into it. Flush these modifications.
+      if (vector_1d_nonlocal)
+        nonlocal_vector->template sync<
+          typename Tpetra::Vector<Number, int, types::signed_global_dof_index>::
+            device_type::memory_space>();
 #  endif
     }
 

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -1003,6 +1003,10 @@ namespace LinearAlgebra
                                      const size_type *indices,
                                      const Number    *values)
     {
+      // if we have ghost values, do not allow
+      // writing to this vector at all.
+      Assert(!has_ghost_elements(), ExcGhostsPresent());
+
       // First create an alias for the type of a view into our vectors.
       // The actual type is declared through several re-directions in
       // Tpetra, so instead of spelling it out, we get it via decltype:

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -1007,23 +1007,13 @@ namespace LinearAlgebra
       // writing to this vector at all.
       Assert(!has_ghost_elements(), ExcGhostsPresent());
 
-      // First create an alias for the type of a view into our vectors.
-      // The actual type is declared through several re-directions in
-      // Tpetra, so instead of spelling it out, we get it via decltype:
 #  if DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
-      using ViewType2d =
-        decltype(vector->template getLocalView<Kokkos::HostSpace>(
-          Tpetra::Access::ReadWrite));
-      ViewType2d vector_2d_local =
-        vector->template getLocalView<Kokkos::HostSpace>(
-          Tpetra::Access::ReadWrite);
+      auto vector_2d_local = vector->template getLocalView<Kokkos::HostSpace>(
+        Tpetra::Access::ReadWrite);
 #  else
       vector->template sync<Kokkos::HostSpace>();
 
-      using ViewType2d =
-        decltype(vector->template getLocalView<Kokkos::HostSpace>());
-      ViewType2d vector_2d_local =
-        vector->template getLocalView<Kokkos::HostSpace>();
+      auto vector_2d_local = vector->template getLocalView<Kokkos::HostSpace>();
 #  endif
 
       // Having extracted a view into the multivectors above, now also
@@ -1032,11 +1022,8 @@ namespace LinearAlgebra
       // the view into the nonlocal part to when we know that we actually
       // need it; this also makes sure that we correctly deal with the
       // case where we do not actually store a nonlocal part.
-      using ViewType1d =
-        decltype(Kokkos::subview(vector_2d_local, Kokkos::ALL(), 0));
-
-      ViewType1d vector_1d_local =
-        Kokkos::subview(vector_2d_local, Kokkos::ALL(), 0);
+      auto vector_1d_local = Kokkos::subview(vector_2d_local, Kokkos::ALL(), 0);
+      using ViewType1d     = decltype(vector_1d_local);
       std::optional<ViewType1d> vector_1d_nonlocal;
 
 #  if !DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
@@ -1091,11 +1078,11 @@ namespace LinearAlgebra
               if (!vector_1d_nonlocal)
                 {
 #  if DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
-                  ViewType2d vector_2d_nonlocal =
+                  auto vector_2d_nonlocal =
                     nonlocal_vector->template getLocalView<Kokkos::HostSpace>(
                       Tpetra::Access::ReadWrite);
 #  else
-                  ViewType2d vector_2d_nonlocal =
+                  auto vector_2d_nonlocal =
                     nonlocal_vector->template getLocalView<Kokkos::HostSpace>();
 #  endif
 
@@ -1138,23 +1125,13 @@ namespace LinearAlgebra
       // writing to this vector at all.
       Assert(!has_ghost_elements(), ExcGhostsPresent());
 
-      // First create an alias for the type of a view into our vectors.
-      // The actual type is declared through several re-directions in
-      // Tpetra, so instead of spelling it out, we get it via decltype:
 #  if DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
-      using ViewType2d =
-        decltype(vector->template getLocalView<Kokkos::HostSpace>(
-          Tpetra::Access::ReadWrite));
-      ViewType2d vector_2d_local =
-        vector->template getLocalView<Kokkos::HostSpace>(
-          Tpetra::Access::ReadWrite);
+      auto vector_2d_local = vector->template getLocalView<Kokkos::HostSpace>(
+        Tpetra::Access::ReadWrite);
 #  else
       vector->template sync<Kokkos::HostSpace>();
 
-      using ViewType2d =
-        decltype(vector->template getLocalView<Kokkos::HostSpace>());
-      ViewType2d vector_2d_local =
-        vector->template getLocalView<Kokkos::HostSpace>();
+      auto vector_2d_local = vector->template getLocalView<Kokkos::HostSpace>();
 #  endif
 
       // Having extracted a view into the multivectors above, now also
@@ -1163,11 +1140,8 @@ namespace LinearAlgebra
       // the view into the nonlocal part to when we know that we actually
       // need it; this also makes sure that we correctly deal with the
       // case where we do not actually store a nonlocal part.
-      using ViewType1d =
-        decltype(Kokkos::subview(vector_2d_local, Kokkos::ALL(), 0));
-
-      ViewType1d vector_1d_local =
-        Kokkos::subview(vector_2d_local, Kokkos::ALL(), 0);
+      auto vector_1d_local = Kokkos::subview(vector_2d_local, Kokkos::ALL(), 0);
+      using ViewType1d     = decltype(vector_1d_local);
       std::optional<ViewType1d> vector_1d_nonlocal;
 
 #  if !DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
@@ -1222,11 +1196,11 @@ namespace LinearAlgebra
               if (!vector_1d_nonlocal)
                 {
 #  if DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
-                  ViewType2d vector_2d_nonlocal =
+                  auto vector_2d_nonlocal =
                     nonlocal_vector->template getLocalView<Kokkos::HostSpace>(
                       Tpetra::Access::ReadWrite);
 #  else
-                  ViewType2d vector_2d_nonlocal =
+                  auto vector_2d_nonlocal =
                     nonlocal_vector->template getLocalView<Kokkos::HostSpace>();
 #  endif
 


### PR DESCRIPTION
This fixes #16635. I broke this up into different commits to make it easier to review:
* Commit 6c3f975fba617869038c66b8f888bc4306eb9abd just moves things around. Specifically, I move all of the nonlocal accesses into one `else` branch, rather than first determining that we have a nonlocal access in a first `if`, and then later in a second `if` dealing with it.
* Commit d65bdc9d2c0269a00ec3a5343b0fe1452fded532 is the consequential one: We can only access nonlocal elements if we have a `nonlocal_vector`. This commit defers creating the view into the nonlocal vector to the point where we need it the first time, by using `std::optional<View>` that we leave uninitialized at the top.
* Commit cd2e8f9a54a9efb7b4d2fe141d02bd82d12fbfbd copies an assertion from the `set()` function also to the `add()` function where I believe that it needs to be equally present.
* Commit da4eea746a178b11a6619860c62224a7a124b08f applies the equivalent changes from the first and second commits (there addressing `add()`) also to the `set()` function that has the same problems.

With all of this, I get to 87/284 tests in #16611 succeeding.