### PR TITLE
SUNDIALS N_Vector: implement efficient operations

### DIFF
--- a/doc/news/changes/minor/20240215Proell
+++ b/doc/news/changes/minor/20240215Proell
@@ -1,0 +1,4 @@
+New: Add potentially more efficient vector operation to SUNDIALS wrappers. These operations are used automatically
+for deal.II's distributed vectors.
+<br>
+(Sebastian Proell, 2024/02/15)

--- a/tests/sundials/n_vector.cc
+++ b/tests/sundials/n_vector.cc
@@ -16,8 +16,6 @@
 // Test SUNDIALS' vector operations on N_Vector implementation. The N_Vectors
 // are created by calling NVectorView on one of the internal vector types.
 
-#include "../../include/deal.II/sundials/n_vector.h"
-
 #include <deal.II/base/logstream.h>
 
 #include <deal.II/lac/block_vector.h>
@@ -26,8 +24,8 @@
 #include <deal.II/lac/trilinos_parallel_block_vector.h>
 #include <deal.II/lac/trilinos_vector.h>
 
-#include "../../include/deal.II/sundials/n_vector.templates.h"
 #include <deal.II/sundials/n_vector.h>
+#include <deal.II/sundials/n_vector.templates.h>
 
 #ifdef DEAL_II_WITH_MPI
 #  include <mpi.h>
@@ -468,6 +466,66 @@ test_linear_sum()
 
 template <typename VectorType>
 void
+test_linear_combination()
+{
+  auto va       = create_test_vector<VectorType>();
+  auto vb       = create_test_vector<VectorType>();
+  auto vc       = create_test_vector<VectorType>();
+  auto v_dst    = create_test_vector<VectorType>();
+  auto expected = create_test_vector<VectorType>();
+
+  auto nv_a = make_nvector_view(va
+#if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+                                ,
+                                global_nvector_context
+#endif
+  );
+  auto nv_b = make_nvector_view(vb
+#if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+                                ,
+                                global_nvector_context
+#endif
+  );
+  auto nv_c = make_nvector_view(vc
+#if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+                                ,
+                                global_nvector_context
+#endif
+  );
+  auto nv_dst = make_nvector_view(v_dst
+#if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+                                  ,
+                                  global_nvector_context
+#endif
+  );
+
+  va = 1.0;
+  vb = 2.0;
+  vc = 3.0;
+
+  expected = 1. * 1. + 2. * 2. + 3. * 3.;
+
+  // Make a contiguous array of N_Vectors for consumption by SUNDIALS
+  // N.B. The array needs to contain N_Vector and not our NVectorView, so we use
+  // the conversion operator.
+  std::array<N_Vector, 3> n_vectors{
+    {(N_Vector)nv_a, (N_Vector)nv_b, (N_Vector)nv_c}};
+
+  std::array<double, 3> weights{{1., 2., 3.}};
+  // test sum three vectors
+  N_VLinearCombination(3, weights.data(), n_vectors.data(), nv_dst);
+  Assert(vector_equal(v_dst, expected), NVectorTestError());
+  // repeat to test that sum overwrites initial content
+  N_VLinearCombination(3, weights.data(), n_vectors.data(), nv_dst);
+  Assert(vector_equal(v_dst, expected), NVectorTestError());
+
+  deallog << "test_linear_combination OK" << std::endl;
+}
+
+
+
+template <typename VectorType>
+void
 test_dot_product()
 {
   const auto va   = create_test_vector<VectorType>(2.0);
@@ -497,6 +555,49 @@ test_dot_product()
   Assert(std::fabs(result - expected) < 1e-12, NVectorTestError());
 
   deallog << "test_dot_product OK" << std::endl;
+}
+
+
+
+template <typename VectorType>
+void
+test_dot_product_multi()
+{
+  const auto va   = create_test_vector<VectorType>(1.0);
+  const auto vb   = create_test_vector<VectorType>(2.0);
+  const auto vc   = create_test_vector<VectorType>(3.0);
+  const auto size = va.size();
+
+  auto nv_a = make_nvector_view(va
+#if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+                                ,
+                                global_nvector_context
+#endif
+  );
+  auto nv_b = make_nvector_view(vb
+#if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+                                ,
+                                global_nvector_context
+#endif
+  );
+  auto nv_c = make_nvector_view(vc
+#if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+                                ,
+                                global_nvector_context
+#endif
+  );
+
+  std::array<N_Vector, 2> nv_array{{(N_Vector)nv_b, (N_Vector)nv_c}};
+  std::array<double, 2>   dst;
+
+  int status =
+    N_VDotProdMulti(nv_array.size(), nv_a, nv_array.data(), dst.data());
+  Assert(status == 0, NVectorTestError());
+
+  Assert(std::fabs(dst[0] - 2. * size) < 1e-12, NVectorTestError());
+  Assert(std::fabs(dst[1] - 3. * size) < 1e-12, NVectorTestError());
+
+  deallog << "test_dot_product_multi OK" << std::endl;
 }
 
 
@@ -976,7 +1077,9 @@ run_all_tests(const std::string &prefix)
   test_get_communicator<VectorType>();
   test_length<VectorType>();
   test_linear_sum<VectorType>();
+  test_linear_combination<VectorType>();
   test_dot_product<VectorType>();
+  test_dot_product_multi<VectorType>();
   test_set_constant<VectorType>();
   test_add_constant<VectorType>();
   test_elementwise_product<VectorType>();

--- a/tests/sundials/n_vector.mpirun=1.with_trilinos=off.with_petsc=on.output
+++ b/tests/sundials/n_vector.mpirun=1.with_trilinos=off.with_petsc=on.output
@@ -6,7 +6,9 @@ DEAL:0:Vector<double>::test_destroy OK
 DEAL:0:Vector<double>::test_get_communicator OK
 DEAL:0:Vector<double>::test_length OK
 DEAL:0:Vector<double>::test_linear_sum OK
+DEAL:0:Vector<double>::test_linear_combination OK
 DEAL:0:Vector<double>::test_dot_product OK
+DEAL:0:Vector<double>::test_dot_product_multi OK
 DEAL:0:Vector<double>::test_set_constant OK
 DEAL:0:Vector<double>::test_add_constant OK
 DEAL:0:Vector<double>::test_elementwise_product OK
@@ -28,7 +30,9 @@ DEAL:0:BlockVector<double>::test_destroy OK
 DEAL:0:BlockVector<double>::test_get_communicator OK
 DEAL:0:BlockVector<double>::test_length OK
 DEAL:0:BlockVector<double>::test_linear_sum OK
+DEAL:0:BlockVector<double>::test_linear_combination OK
 DEAL:0:BlockVector<double>::test_dot_product OK
+DEAL:0:BlockVector<double>::test_dot_product_multi OK
 DEAL:0:BlockVector<double>::test_set_constant OK
 DEAL:0:BlockVector<double>::test_add_constant OK
 DEAL:0:BlockVector<double>::test_elementwise_product OK
@@ -50,7 +54,9 @@ DEAL:0:LinearAlgebra::distributed::Vector<double>::test_destroy OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_get_communicator OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_length OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_linear_sum OK
+DEAL:0:LinearAlgebra::distributed::Vector<double>::test_linear_combination OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_dot_product OK
+DEAL:0:LinearAlgebra::distributed::Vector<double>::test_dot_product_multi OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_set_constant OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_add_constant OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_elementwise_product OK
@@ -72,7 +78,9 @@ DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_destroy OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_get_communicator OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_length OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_linear_sum OK
+DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_linear_combination OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_dot_product OK
+DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_dot_product_multi OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_set_constant OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_add_constant OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_elementwise_product OK
@@ -94,7 +102,9 @@ DEAL:0:PETScWrappers::MPI::Vector::test_destroy OK
 DEAL:0:PETScWrappers::MPI::Vector::test_get_communicator OK
 DEAL:0:PETScWrappers::MPI::Vector::test_length OK
 DEAL:0:PETScWrappers::MPI::Vector::test_linear_sum OK
+DEAL:0:PETScWrappers::MPI::Vector::test_linear_combination OK
 DEAL:0:PETScWrappers::MPI::Vector::test_dot_product OK
+DEAL:0:PETScWrappers::MPI::Vector::test_dot_product_multi OK
 DEAL:0:PETScWrappers::MPI::Vector::test_set_constant OK
 DEAL:0:PETScWrappers::MPI::Vector::test_add_constant OK
 DEAL:0:PETScWrappers::MPI::Vector::test_elementwise_product OK
@@ -116,7 +126,9 @@ DEAL:0:PETScWrappers::MPI::BlockVector::test_destroy OK
 DEAL:0:PETScWrappers::MPI::BlockVector::test_get_communicator OK
 DEAL:0:PETScWrappers::MPI::BlockVector::test_length OK
 DEAL:0:PETScWrappers::MPI::BlockVector::test_linear_sum OK
+DEAL:0:PETScWrappers::MPI::BlockVector::test_linear_combination OK
 DEAL:0:PETScWrappers::MPI::BlockVector::test_dot_product OK
+DEAL:0:PETScWrappers::MPI::BlockVector::test_dot_product_multi OK
 DEAL:0:PETScWrappers::MPI::BlockVector::test_set_constant OK
 DEAL:0:PETScWrappers::MPI::BlockVector::test_add_constant OK
 DEAL:0:PETScWrappers::MPI::BlockVector::test_elementwise_product OK

--- a/tests/sundials/n_vector.mpirun=1.with_trilinos=on.with_petsc=off.output
+++ b/tests/sundials/n_vector.mpirun=1.with_trilinos=on.with_petsc=off.output
@@ -6,7 +6,9 @@ DEAL:0:Vector<double>::test_destroy OK
 DEAL:0:Vector<double>::test_get_communicator OK
 DEAL:0:Vector<double>::test_length OK
 DEAL:0:Vector<double>::test_linear_sum OK
+DEAL:0:Vector<double>::test_linear_combination OK
 DEAL:0:Vector<double>::test_dot_product OK
+DEAL:0:Vector<double>::test_dot_product_multi OK
 DEAL:0:Vector<double>::test_set_constant OK
 DEAL:0:Vector<double>::test_add_constant OK
 DEAL:0:Vector<double>::test_elementwise_product OK
@@ -28,7 +30,9 @@ DEAL:0:BlockVector<double>::test_destroy OK
 DEAL:0:BlockVector<double>::test_get_communicator OK
 DEAL:0:BlockVector<double>::test_length OK
 DEAL:0:BlockVector<double>::test_linear_sum OK
+DEAL:0:BlockVector<double>::test_linear_combination OK
 DEAL:0:BlockVector<double>::test_dot_product OK
+DEAL:0:BlockVector<double>::test_dot_product_multi OK
 DEAL:0:BlockVector<double>::test_set_constant OK
 DEAL:0:BlockVector<double>::test_add_constant OK
 DEAL:0:BlockVector<double>::test_elementwise_product OK
@@ -50,7 +54,9 @@ DEAL:0:LinearAlgebra::distributed::Vector<double>::test_destroy OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_get_communicator OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_length OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_linear_sum OK
+DEAL:0:LinearAlgebra::distributed::Vector<double>::test_linear_combination OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_dot_product OK
+DEAL:0:LinearAlgebra::distributed::Vector<double>::test_dot_product_multi OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_set_constant OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_add_constant OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_elementwise_product OK
@@ -72,7 +78,9 @@ DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_destroy OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_get_communicator OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_length OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_linear_sum OK
+DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_linear_combination OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_dot_product OK
+DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_dot_product_multi OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_set_constant OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_add_constant OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_elementwise_product OK
@@ -94,7 +102,9 @@ DEAL:0:TrilinosWrappers::MPI::Vector::test_destroy OK
 DEAL:0:TrilinosWrappers::MPI::Vector::test_get_communicator OK
 DEAL:0:TrilinosWrappers::MPI::Vector::test_length OK
 DEAL:0:TrilinosWrappers::MPI::Vector::test_linear_sum OK
+DEAL:0:TrilinosWrappers::MPI::Vector::test_linear_combination OK
 DEAL:0:TrilinosWrappers::MPI::Vector::test_dot_product OK
+DEAL:0:TrilinosWrappers::MPI::Vector::test_dot_product_multi OK
 DEAL:0:TrilinosWrappers::MPI::Vector::test_set_constant OK
 DEAL:0:TrilinosWrappers::MPI::Vector::test_add_constant OK
 DEAL:0:TrilinosWrappers::MPI::Vector::test_elementwise_product OK
@@ -116,7 +126,9 @@ DEAL:0:TrilinosWrappers::MPI::BlockVector::test_destroy OK
 DEAL:0:TrilinosWrappers::MPI::BlockVector::test_get_communicator OK
 DEAL:0:TrilinosWrappers::MPI::BlockVector::test_length OK
 DEAL:0:TrilinosWrappers::MPI::BlockVector::test_linear_sum OK
+DEAL:0:TrilinosWrappers::MPI::BlockVector::test_linear_combination OK
 DEAL:0:TrilinosWrappers::MPI::BlockVector::test_dot_product OK
+DEAL:0:TrilinosWrappers::MPI::BlockVector::test_dot_product_multi OK
 DEAL:0:TrilinosWrappers::MPI::BlockVector::test_set_constant OK
 DEAL:0:TrilinosWrappers::MPI::BlockVector::test_add_constant OK
 DEAL:0:TrilinosWrappers::MPI::BlockVector::test_elementwise_product OK

--- a/tests/sundials/n_vector.mpirun=1.with_trilinos=true.with_petsc=true.output
+++ b/tests/sundials/n_vector.mpirun=1.with_trilinos=true.with_petsc=true.output
@@ -6,7 +6,9 @@ DEAL:0:Vector<double>::test_destroy OK
 DEAL:0:Vector<double>::test_get_communicator OK
 DEAL:0:Vector<double>::test_length OK
 DEAL:0:Vector<double>::test_linear_sum OK
+DEAL:0:Vector<double>::test_linear_combination OK
 DEAL:0:Vector<double>::test_dot_product OK
+DEAL:0:Vector<double>::test_dot_product_multi OK
 DEAL:0:Vector<double>::test_set_constant OK
 DEAL:0:Vector<double>::test_add_constant OK
 DEAL:0:Vector<double>::test_elementwise_product OK
@@ -28,7 +30,9 @@ DEAL:0:BlockVector<double>::test_destroy OK
 DEAL:0:BlockVector<double>::test_get_communicator OK
 DEAL:0:BlockVector<double>::test_length OK
 DEAL:0:BlockVector<double>::test_linear_sum OK
+DEAL:0:BlockVector<double>::test_linear_combination OK
 DEAL:0:BlockVector<double>::test_dot_product OK
+DEAL:0:BlockVector<double>::test_dot_product_multi OK
 DEAL:0:BlockVector<double>::test_set_constant OK
 DEAL:0:BlockVector<double>::test_add_constant OK
 DEAL:0:BlockVector<double>::test_elementwise_product OK
@@ -50,7 +54,9 @@ DEAL:0:LinearAlgebra::distributed::Vector<double>::test_destroy OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_get_communicator OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_length OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_linear_sum OK
+DEAL:0:LinearAlgebra::distributed::Vector<double>::test_linear_combination OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_dot_product OK
+DEAL:0:LinearAlgebra::distributed::Vector<double>::test_dot_product_multi OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_set_constant OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_add_constant OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_elementwise_product OK
@@ -72,7 +78,9 @@ DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_destroy OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_get_communicator OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_length OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_linear_sum OK
+DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_linear_combination OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_dot_product OK
+DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_dot_product_multi OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_set_constant OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_add_constant OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_elementwise_product OK
@@ -94,7 +102,9 @@ DEAL:0:TrilinosWrappers::MPI::Vector::test_destroy OK
 DEAL:0:TrilinosWrappers::MPI::Vector::test_get_communicator OK
 DEAL:0:TrilinosWrappers::MPI::Vector::test_length OK
 DEAL:0:TrilinosWrappers::MPI::Vector::test_linear_sum OK
+DEAL:0:TrilinosWrappers::MPI::Vector::test_linear_combination OK
 DEAL:0:TrilinosWrappers::MPI::Vector::test_dot_product OK
+DEAL:0:TrilinosWrappers::MPI::Vector::test_dot_product_multi OK
 DEAL:0:TrilinosWrappers::MPI::Vector::test_set_constant OK
 DEAL:0:TrilinosWrappers::MPI::Vector::test_add_constant OK
 DEAL:0:TrilinosWrappers::MPI::Vector::test_elementwise_product OK
@@ -116,7 +126,9 @@ DEAL:0:TrilinosWrappers::MPI::BlockVector::test_destroy OK
 DEAL:0:TrilinosWrappers::MPI::BlockVector::test_get_communicator OK
 DEAL:0:TrilinosWrappers::MPI::BlockVector::test_length OK
 DEAL:0:TrilinosWrappers::MPI::BlockVector::test_linear_sum OK
+DEAL:0:TrilinosWrappers::MPI::BlockVector::test_linear_combination OK
 DEAL:0:TrilinosWrappers::MPI::BlockVector::test_dot_product OK
+DEAL:0:TrilinosWrappers::MPI::BlockVector::test_dot_product_multi OK
 DEAL:0:TrilinosWrappers::MPI::BlockVector::test_set_constant OK
 DEAL:0:TrilinosWrappers::MPI::BlockVector::test_add_constant OK
 DEAL:0:TrilinosWrappers::MPI::BlockVector::test_elementwise_product OK
@@ -138,7 +150,9 @@ DEAL:0:PETScWrappers::MPI::Vector::test_destroy OK
 DEAL:0:PETScWrappers::MPI::Vector::test_get_communicator OK
 DEAL:0:PETScWrappers::MPI::Vector::test_length OK
 DEAL:0:PETScWrappers::MPI::Vector::test_linear_sum OK
+DEAL:0:PETScWrappers::MPI::Vector::test_linear_combination OK
 DEAL:0:PETScWrappers::MPI::Vector::test_dot_product OK
+DEAL:0:PETScWrappers::MPI::Vector::test_dot_product_multi OK
 DEAL:0:PETScWrappers::MPI::Vector::test_set_constant OK
 DEAL:0:PETScWrappers::MPI::Vector::test_add_constant OK
 DEAL:0:PETScWrappers::MPI::Vector::test_elementwise_product OK
@@ -160,7 +174,9 @@ DEAL:0:PETScWrappers::MPI::BlockVector::test_destroy OK
 DEAL:0:PETScWrappers::MPI::BlockVector::test_get_communicator OK
 DEAL:0:PETScWrappers::MPI::BlockVector::test_length OK
 DEAL:0:PETScWrappers::MPI::BlockVector::test_linear_sum OK
+DEAL:0:PETScWrappers::MPI::BlockVector::test_linear_combination OK
 DEAL:0:PETScWrappers::MPI::BlockVector::test_dot_product OK
+DEAL:0:PETScWrappers::MPI::BlockVector::test_dot_product_multi OK
 DEAL:0:PETScWrappers::MPI::BlockVector::test_set_constant OK
 DEAL:0:PETScWrappers::MPI::BlockVector::test_add_constant OK
 DEAL:0:PETScWrappers::MPI::BlockVector::test_elementwise_product OK

--- a/tests/sundials/n_vector.mpirun=2.with_trilinos=true.with_petsc=true.output
+++ b/tests/sundials/n_vector.mpirun=2.with_trilinos=true.with_petsc=true.output
@@ -6,7 +6,9 @@ DEAL:0:Vector<double>::test_destroy OK
 DEAL:0:Vector<double>::test_get_communicator OK
 DEAL:0:Vector<double>::test_length OK
 DEAL:0:Vector<double>::test_linear_sum OK
+DEAL:0:Vector<double>::test_linear_combination OK
 DEAL:0:Vector<double>::test_dot_product OK
+DEAL:0:Vector<double>::test_dot_product_multi OK
 DEAL:0:Vector<double>::test_set_constant OK
 DEAL:0:Vector<double>::test_add_constant OK
 DEAL:0:Vector<double>::test_elementwise_product OK
@@ -28,7 +30,9 @@ DEAL:0:BlockVector<double>::test_destroy OK
 DEAL:0:BlockVector<double>::test_get_communicator OK
 DEAL:0:BlockVector<double>::test_length OK
 DEAL:0:BlockVector<double>::test_linear_sum OK
+DEAL:0:BlockVector<double>::test_linear_combination OK
 DEAL:0:BlockVector<double>::test_dot_product OK
+DEAL:0:BlockVector<double>::test_dot_product_multi OK
 DEAL:0:BlockVector<double>::test_set_constant OK
 DEAL:0:BlockVector<double>::test_add_constant OK
 DEAL:0:BlockVector<double>::test_elementwise_product OK
@@ -50,7 +54,9 @@ DEAL:0:LinearAlgebra::distributed::Vector<double>::test_destroy OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_get_communicator OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_length OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_linear_sum OK
+DEAL:0:LinearAlgebra::distributed::Vector<double>::test_linear_combination OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_dot_product OK
+DEAL:0:LinearAlgebra::distributed::Vector<double>::test_dot_product_multi OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_set_constant OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_add_constant OK
 DEAL:0:LinearAlgebra::distributed::Vector<double>::test_elementwise_product OK
@@ -72,7 +78,9 @@ DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_destroy OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_get_communicator OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_length OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_linear_sum OK
+DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_linear_combination OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_dot_product OK
+DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_dot_product_multi OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_set_constant OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_add_constant OK
 DEAL:0:LinearAlgebra::distributed::BlockVector<double>::test_elementwise_product OK
@@ -94,7 +102,9 @@ DEAL:0:TrilinosWrappers::MPI::Vector::test_destroy OK
 DEAL:0:TrilinosWrappers::MPI::Vector::test_get_communicator OK
 DEAL:0:TrilinosWrappers::MPI::Vector::test_length OK
 DEAL:0:TrilinosWrappers::MPI::Vector::test_linear_sum OK
+DEAL:0:TrilinosWrappers::MPI::Vector::test_linear_combination OK
 DEAL:0:TrilinosWrappers::MPI::Vector::test_dot_product OK
+DEAL:0:TrilinosWrappers::MPI::Vector::test_dot_product_multi OK
 DEAL:0:TrilinosWrappers::MPI::Vector::test_set_constant OK
 DEAL:0:TrilinosWrappers::MPI::Vector::test_add_constant OK
 DEAL:0:TrilinosWrappers::MPI::Vector::test_elementwise_product OK
@@ -116,7 +126,9 @@ DEAL:0:TrilinosWrappers::MPI::BlockVector::test_destroy OK
 DEAL:0:TrilinosWrappers::MPI::BlockVector::test_get_communicator OK
 DEAL:0:TrilinosWrappers::MPI::BlockVector::test_length OK
 DEAL:0:TrilinosWrappers::MPI::BlockVector::test_linear_sum OK
+DEAL:0:TrilinosWrappers::MPI::BlockVector::test_linear_combination OK
 DEAL:0:TrilinosWrappers::MPI::BlockVector::test_dot_product OK
+DEAL:0:TrilinosWrappers::MPI::BlockVector::test_dot_product_multi OK
 DEAL:0:TrilinosWrappers::MPI::BlockVector::test_set_constant OK
 DEAL:0:TrilinosWrappers::MPI::BlockVector::test_add_constant OK
 DEAL:0:TrilinosWrappers::MPI::BlockVector::test_elementwise_product OK
@@ -138,7 +150,9 @@ DEAL:0:PETScWrappers::MPI::Vector::test_destroy OK
 DEAL:0:PETScWrappers::MPI::Vector::test_get_communicator OK
 DEAL:0:PETScWrappers::MPI::Vector::test_length OK
 DEAL:0:PETScWrappers::MPI::Vector::test_linear_sum OK
+DEAL:0:PETScWrappers::MPI::Vector::test_linear_combination OK
 DEAL:0:PETScWrappers::MPI::Vector::test_dot_product OK
+DEAL:0:PETScWrappers::MPI::Vector::test_dot_product_multi OK
 DEAL:0:PETScWrappers::MPI::Vector::test_set_constant OK
 DEAL:0:PETScWrappers::MPI::Vector::test_add_constant OK
 DEAL:0:PETScWrappers::MPI::Vector::test_elementwise_product OK
@@ -160,7 +174,9 @@ DEAL:0:PETScWrappers::MPI::BlockVector::test_destroy OK
 DEAL:0:PETScWrappers::MPI::BlockVector::test_get_communicator OK
 DEAL:0:PETScWrappers::MPI::BlockVector::test_length OK
 DEAL:0:PETScWrappers::MPI::BlockVector::test_linear_sum OK
+DEAL:0:PETScWrappers::MPI::BlockVector::test_linear_combination OK
 DEAL:0:PETScWrappers::MPI::BlockVector::test_dot_product OK
+DEAL:0:PETScWrappers::MPI::BlockVector::test_dot_product_multi OK
 DEAL:0:PETScWrappers::MPI::BlockVector::test_set_constant OK
 DEAL:0:PETScWrappers::MPI::BlockVector::test_add_constant OK
 DEAL:0:PETScWrappers::MPI::BlockVector::test_elementwise_product OK
@@ -183,7 +199,9 @@ DEAL:1:Vector<double>::test_destroy OK
 DEAL:1:Vector<double>::test_get_communicator OK
 DEAL:1:Vector<double>::test_length OK
 DEAL:1:Vector<double>::test_linear_sum OK
+DEAL:1:Vector<double>::test_linear_combination OK
 DEAL:1:Vector<double>::test_dot_product OK
+DEAL:1:Vector<double>::test_dot_product_multi OK
 DEAL:1:Vector<double>::test_set_constant OK
 DEAL:1:Vector<double>::test_add_constant OK
 DEAL:1:Vector<double>::test_elementwise_product OK
@@ -205,7 +223,9 @@ DEAL:1:BlockVector<double>::test_destroy OK
 DEAL:1:BlockVector<double>::test_get_communicator OK
 DEAL:1:BlockVector<double>::test_length OK
 DEAL:1:BlockVector<double>::test_linear_sum OK
+DEAL:1:BlockVector<double>::test_linear_combination OK
 DEAL:1:BlockVector<double>::test_dot_product OK
+DEAL:1:BlockVector<double>::test_dot_product_multi OK
 DEAL:1:BlockVector<double>::test_set_constant OK
 DEAL:1:BlockVector<double>::test_add_constant OK
 DEAL:1:BlockVector<double>::test_elementwise_product OK
@@ -227,7 +247,9 @@ DEAL:1:LinearAlgebra::distributed::Vector<double>::test_destroy OK
 DEAL:1:LinearAlgebra::distributed::Vector<double>::test_get_communicator OK
 DEAL:1:LinearAlgebra::distributed::Vector<double>::test_length OK
 DEAL:1:LinearAlgebra::distributed::Vector<double>::test_linear_sum OK
+DEAL:1:LinearAlgebra::distributed::Vector<double>::test_linear_combination OK
 DEAL:1:LinearAlgebra::distributed::Vector<double>::test_dot_product OK
+DEAL:1:LinearAlgebra::distributed::Vector<double>::test_dot_product_multi OK
 DEAL:1:LinearAlgebra::distributed::Vector<double>::test_set_constant OK
 DEAL:1:LinearAlgebra::distributed::Vector<double>::test_add_constant OK
 DEAL:1:LinearAlgebra::distributed::Vector<double>::test_elementwise_product OK
@@ -249,7 +271,9 @@ DEAL:1:LinearAlgebra::distributed::BlockVector<double>::test_destroy OK
 DEAL:1:LinearAlgebra::distributed::BlockVector<double>::test_get_communicator OK
 DEAL:1:LinearAlgebra::distributed::BlockVector<double>::test_length OK
 DEAL:1:LinearAlgebra::distributed::BlockVector<double>::test_linear_sum OK
+DEAL:1:LinearAlgebra::distributed::BlockVector<double>::test_linear_combination OK
 DEAL:1:LinearAlgebra::distributed::BlockVector<double>::test_dot_product OK
+DEAL:1:LinearAlgebra::distributed::BlockVector<double>::test_dot_product_multi OK
 DEAL:1:LinearAlgebra::distributed::BlockVector<double>::test_set_constant OK
 DEAL:1:LinearAlgebra::distributed::BlockVector<double>::test_add_constant OK
 DEAL:1:LinearAlgebra::distributed::BlockVector<double>::test_elementwise_product OK
@@ -271,7 +295,9 @@ DEAL:1:TrilinosWrappers::MPI::Vector::test_destroy OK
 DEAL:1:TrilinosWrappers::MPI::Vector::test_get_communicator OK
 DEAL:1:TrilinosWrappers::MPI::Vector::test_length OK
 DEAL:1:TrilinosWrappers::MPI::Vector::test_linear_sum OK
+DEAL:1:TrilinosWrappers::MPI::Vector::test_linear_combination OK
 DEAL:1:TrilinosWrappers::MPI::Vector::test_dot_product OK
+DEAL:1:TrilinosWrappers::MPI::Vector::test_dot_product_multi OK
 DEAL:1:TrilinosWrappers::MPI::Vector::test_set_constant OK
 DEAL:1:TrilinosWrappers::MPI::Vector::test_add_constant OK
 DEAL:1:TrilinosWrappers::MPI::Vector::test_elementwise_product OK
@@ -293,7 +319,9 @@ DEAL:1:TrilinosWrappers::MPI::BlockVector::test_destroy OK
 DEAL:1:TrilinosWrappers::MPI::BlockVector::test_get_communicator OK
 DEAL:1:TrilinosWrappers::MPI::BlockVector::test_length OK
 DEAL:1:TrilinosWrappers::MPI::BlockVector::test_linear_sum OK
+DEAL:1:TrilinosWrappers::MPI::BlockVector::test_linear_combination OK
 DEAL:1:TrilinosWrappers::MPI::BlockVector::test_dot_product OK
+DEAL:1:TrilinosWrappers::MPI::BlockVector::test_dot_product_multi OK
 DEAL:1:TrilinosWrappers::MPI::BlockVector::test_set_constant OK
 DEAL:1:TrilinosWrappers::MPI::BlockVector::test_add_constant OK
 DEAL:1:TrilinosWrappers::MPI::BlockVector::test_elementwise_product OK
@@ -315,7 +343,9 @@ DEAL:1:PETScWrappers::MPI::Vector::test_destroy OK
 DEAL:1:PETScWrappers::MPI::Vector::test_get_communicator OK
 DEAL:1:PETScWrappers::MPI::Vector::test_length OK
 DEAL:1:PETScWrappers::MPI::Vector::test_linear_sum OK
+DEAL:1:PETScWrappers::MPI::Vector::test_linear_combination OK
 DEAL:1:PETScWrappers::MPI::Vector::test_dot_product OK
+DEAL:1:PETScWrappers::MPI::Vector::test_dot_product_multi OK
 DEAL:1:PETScWrappers::MPI::Vector::test_set_constant OK
 DEAL:1:PETScWrappers::MPI::Vector::test_add_constant OK
 DEAL:1:PETScWrappers::MPI::Vector::test_elementwise_product OK
@@ -337,7 +367,9 @@ DEAL:1:PETScWrappers::MPI::BlockVector::test_destroy OK
 DEAL:1:PETScWrappers::MPI::BlockVector::test_get_communicator OK
 DEAL:1:PETScWrappers::MPI::BlockVector::test_length OK
 DEAL:1:PETScWrappers::MPI::BlockVector::test_linear_sum OK
+DEAL:1:PETScWrappers::MPI::BlockVector::test_linear_combination OK
 DEAL:1:PETScWrappers::MPI::BlockVector::test_dot_product OK
+DEAL:1:PETScWrappers::MPI::BlockVector::test_dot_product_multi OK
 DEAL:1:PETScWrappers::MPI::BlockVector::test_set_constant OK
 DEAL:1:PETScWrappers::MPI::BlockVector::test_add_constant OK
 DEAL:1:PETScWrappers::MPI::BlockVector::test_elementwise_product OK


### PR DESCRIPTION
This PR complements what I started in #16239.

Note: The new supposedly more efficient operations are only supported by deal.II vectors. Other vectors use a less efficient implementation.