### PR TITLE
Add info for TPLs to testsuite doc.

### DIFF
--- a/doc/developers/testsuite.html
+++ b/doc/developers/testsuite.html
@@ -479,6 +479,11 @@ category/test.with_umfpack=on.output, or
 category/test.with_zlib=off.output
 </pre>
       These tests will only be set up if the specified feature was configured.
+<p><b>Note:</b> For CMake variables indicating whether sub-packages of third party libraries
+      were detected, like <code>DEAL_II_TRILINOS_WITH_BELOS</code> or <code>DEAL_II_PETSC_WITH_HYPRE</code>
+      the correct syntax is adding an additional <code>with_</code>,
+      i.e. <code>with_trilinos_with_belos=on|off</code>.
+</p>
       It is possible to provide different output files for disabled/enabled
       features, e.g.,
 <pre>


### PR DESCRIPTION
Fixes #16643.
This adds a short paragraph describing how to limit the test run
to a more specific third party library configuration like `DEAL_II_TRILINOS_WITH_BELOS`
such that a test can be run if the optional dependency is fulfilled.