### PR TITLE
Add missing <optional> header for trilinos_tpetra_vector.h

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -37,6 +37,7 @@
 #  include <Tpetra_Version.hpp>
 
 #  include <memory>
+#  include <optional>
 
 DEAL_II_NAMESPACE_OPEN
 


### PR DESCRIPTION
This should fix the newly added CI for Trilinos+Tpetra.