### PR TITLE
Fix segmentation fault when using mpich

### DIFF
--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -1745,7 +1745,7 @@ namespace Utilities
      * not satisfied.
      */
     template <typename T>
-    const MPI_Datatype mpi_type_id_for_type =
+    inline const MPI_Datatype mpi_type_id_for_type =
       internal::MPIDataTypes::mpi_type_id(
         static_cast<std::remove_cv_t<std::remove_reference_t<T>> *>(nullptr));
 #endif

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -99,26 +99,6 @@ namespace Utilities
 
   namespace MPI
   {
-#ifdef DEAL_II_WITH_MPI
-    // Provide definitions of template variables for all valid instantiations.
-    template const MPI_Datatype mpi_type_id_for_type<bool>;
-    template const MPI_Datatype mpi_type_id_for_type<char>;
-    template const MPI_Datatype mpi_type_id_for_type<signed char>;
-    template const MPI_Datatype mpi_type_id_for_type<short>;
-    template const MPI_Datatype mpi_type_id_for_type<int>;
-    template const MPI_Datatype mpi_type_id_for_type<long int>;
-    template const MPI_Datatype mpi_type_id_for_type<unsigned char>;
-    template const MPI_Datatype mpi_type_id_for_type<unsigned short>;
-    template const MPI_Datatype mpi_type_id_for_type<unsigned long int>;
-    template const MPI_Datatype mpi_type_id_for_type<unsigned long long int>;
-    template const MPI_Datatype mpi_type_id_for_type<float>;
-    template const MPI_Datatype mpi_type_id_for_type<double>;
-    template const MPI_Datatype mpi_type_id_for_type<long double>;
-    template const MPI_Datatype mpi_type_id_for_type<std::complex<float>>;
-    template const MPI_Datatype mpi_type_id_for_type<std::complex<double>>;
-#endif
-
-
     MinMaxAvg
     min_max_avg(const double my_value, const MPI_Comm mpi_communicator)
     {


### PR DESCRIPTION
This is an attempt at fixing #16652 <s>by marking an already static</s> converting a template variable to "inline" linkage and avoid explicitly instantiating it in the `mpi.cc` compilation unit.

- base/mpi.cc: remove superfluous explicit instantiations of template variable
- base/mpi.h: annotate that a const template variable has static linkage

The `mpi.h` header already contains:
```
template <typename T>
const MPI_Datatype mpi_type_id_for_type = /* implementation detail */;
```
Meaning, the variable is known fully after including the header. Furthermore, the `const` qualifier marks the (template) variable as `static`. I.e., it has internal linkage.

Thus, we must not explicitly instantiate the variables (suggesting "extern" linkage in all but the `mpi.cc` compilation unit). This apparently was not an issue with OpenMPI because `MPI_Datatype` is a complex data structure. But it is an issue with mpich where `MPI_Datatype` is a simple `int` - leading to a segmentation fault during program startup.

Closes #16652
