### PR TITLE
[9.5] take over pr #16653

### DIFF
--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -1728,8 +1728,8 @@ namespace Utilities
      * not satisfied.
      */
     template <typename T>
-    const MPI_Datatype
-      mpi_type_id_for_type = internal::MPIDataTypes::mpi_type_id(
+    inline const MPI_Datatype mpi_type_id_for_type =
+      internal::MPIDataTypes::mpi_type_id(
         static_cast<std::remove_cv_t<std::remove_reference_t<T>> *>(nullptr));
 #endif
 

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -100,26 +100,6 @@ namespace Utilities
 
   namespace MPI
   {
-#ifdef DEAL_II_WITH_MPI
-    // Provide definitions of template variables for all valid instantiations.
-    template const MPI_Datatype mpi_type_id_for_type<bool>;
-    template const MPI_Datatype mpi_type_id_for_type<char>;
-    template const MPI_Datatype mpi_type_id_for_type<signed char>;
-    template const MPI_Datatype mpi_type_id_for_type<short>;
-    template const MPI_Datatype mpi_type_id_for_type<int>;
-    template const MPI_Datatype mpi_type_id_for_type<long int>;
-    template const MPI_Datatype mpi_type_id_for_type<unsigned char>;
-    template const MPI_Datatype mpi_type_id_for_type<unsigned short>;
-    template const MPI_Datatype mpi_type_id_for_type<unsigned long int>;
-    template const MPI_Datatype mpi_type_id_for_type<unsigned long long int>;
-    template const MPI_Datatype mpi_type_id_for_type<float>;
-    template const MPI_Datatype mpi_type_id_for_type<double>;
-    template const MPI_Datatype mpi_type_id_for_type<long double>;
-    template const MPI_Datatype mpi_type_id_for_type<std::complex<float>>;
-    template const MPI_Datatype mpi_type_id_for_type<std::complex<double>>;
-#endif
-
-
     MinMaxAvg
     min_max_avg(const double my_value, const MPI_Comm mpi_communicator)
     {


### PR DESCRIPTION
- base/mpi.cc: remove superfluous explicit instantiations of template variable
- base/mpi.h: mark a template variable to have "const inline" linkage.
