### PR TITLE
Remove verbose output from Tpetra direct solver

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_solver_direct.h
+++ b/include/deal.II/lac/trilinos_tpetra_solver_direct.h
@@ -153,9 +153,7 @@ namespace LinearAlgebra
        * Constructor. Takes the solver control object and name
        * and creates the solver.
        */
-      SolverDirectBase(SolverControl     &cn,
-                       const std::string &solver_type,
-                       const bool         output_solver_details = false);
+      SolverDirectBase(SolverControl &cn, const std::string &solver_type);
       /**
        * Actually performs the operations for solving the linear system,
        * including the factorization and forward and backward substitution.
@@ -183,13 +181,6 @@ namespace LinearAlgebra
        * The set solver type to be handed to the solver factory of Amesos2.
        */
       std::string solver_type;
-
-      /**
-       * Enables/disables the output of solver details (residual in each
-       * iterations etc.).
-       */
-      bool output_solver_details;
-
 
       /**
        * An optional Teuchos::ParameterList for fine tuning the solver.
@@ -225,8 +216,7 @@ namespace LinearAlgebra
        */
       struct AdditionalData
       {
-        AdditionalData(const std::string &solver_name,
-                       const bool         output_solver_details = false);
+        AdditionalData(const std::string &solver_name);
 
 
         /**
@@ -253,12 +243,6 @@ namespace LinearAlgebra
          * that can nevertheless be used if configured.
          */
         std::string solver_name;
-
-        /**
-         * Enables/disables the output of solver details (residual in each
-         * iterations etc.).
-         */
-        bool output_solver_details;
       };
 
       /**
@@ -299,12 +283,11 @@ namespace LinearAlgebra
        */
       struct AdditionalData
       {
-        AdditionalData(const std::string &transpose_mode        = "NOTRANS",
-                       const bool         symmetric_mode        = false,
-                       const bool         equilibrate_matrix    = true,
-                       const std::string &column_permutation    = "COLAMD",
-                       const std::string &iterative_refinement  = "NO",
-                       const bool         output_solver_details = false);
+        AdditionalData(const std::string &transpose_mode       = "NOTRANS",
+                       const bool         symmetric_mode       = false,
+                       const bool         equilibrate_matrix   = true,
+                       const std::string &column_permutation   = "COLAMD",
+                       const std::string &iterative_refinement = "NO");
         /**
          * Decide which system to solve
          * "NOTRANS": Ax=b (default)
@@ -340,13 +323,6 @@ namespace LinearAlgebra
          * "EXTRA": ??
          */
         std::string iterative_refinement;
-
-
-        /**
-         * Enables/disables the output of solver details (residual in each
-         * iterations etc.).
-         */
-        bool output_solver_details;
       };
 
       /**

--- a/include/deal.II/lac/trilinos_tpetra_solver_direct.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_solver_direct.templates.h
@@ -43,11 +43,9 @@ namespace LinearAlgebra
     template <typename Number, typename MemorySpace>
     SolverDirectBase<Number, MemorySpace>::SolverDirectBase(
       SolverControl     &cn,
-      const std::string &solver_type,
-      const bool         output_solver_details)
+      const std::string &solver_type)
       : solver_control(cn)
       , solver_type(solver_type)
-      , output_solver_details(output_solver_details)
     {
       AssertThrow(Amesos2::query(solver_type),
                   ExcTrilinosAmesos2SolverUnsupported(solver_type));
@@ -69,11 +67,7 @@ namespace LinearAlgebra
     SolverDirectBase<Number, MemorySpace>::initialize(
       const SparseMatrix<Number, MemorySpace> &A)
     {
-      // First set whether we want to print the solver information to screen or
-      // not.
-      ConditionalOStream verbose_cout(std::cout, output_solver_details);
-
-      // Next allocate the Amesos2 solver with the concrete solver, if possible.
+      // Allocate the Amesos2 solver with the concrete solver, if possible.
       solver =
         Amesos2::create<typename SparseMatrix<Number, MemorySpace>::MatrixType,
                         MultiVector>(solver_type, A.trilinos_rcp());
@@ -82,10 +76,8 @@ namespace LinearAlgebra
       // Now do the actual factorization, which is a two step procedure.
       // The symbolic factorization determines the structure of the inverse,
       // while the numeric factorization does to actual computation of L and U
-      verbose_cout << "Starting symbolic factorization" << std::endl;
       solver->symbolicFactorization();
 
-      verbose_cout << "Starting numeric factorization" << std::endl;
       solver->numericFactorization();
     }
 
@@ -102,11 +94,7 @@ namespace LinearAlgebra
 
       // Assign the RHS vector
       solver->setB(b.trilinos_rcp());
-      // First set whether we want to print the solver information to screen
-      // or not.
-      ConditionalOStream verbose_cout(std::cout, output_solver_details);
 
-      verbose_cout << "Starting solve" << std::endl;
       solver->solve();
 
       // Finally, force the SolverControl object to report convergence
@@ -123,21 +111,15 @@ namespace LinearAlgebra
     void
     SolverDirectBase<Number, MemorySpace>::do_solve()
     {
-      // First set whether we want to print the solver information to screen or
-      // not.
-      ConditionalOStream verbose_cout(std::cout, output_solver_details);
-
+      // Set the parameter list. If it is empty defaults will be used.
       solver->setParameters(Teuchos::rcpFromRef(parameter_list));
       // Now do the actual factorization, which is a two step procedure.
       // The symbolic factorization determines the structure of the inverse,
       // while the numeric factorization does to actual computation of L and U
-      verbose_cout << "Starting symbolic factorization" << std::endl;
       solver->symbolicFactorization();
 
-      verbose_cout << "Starting numeric factorization" << std::endl;
       solver->numericFactorization();
 
-      verbose_cout << "Starting solve" << std::endl;
       solver->solve();
 
       // Finally, force the SolverControl object to report convergence
@@ -171,10 +153,8 @@ namespace LinearAlgebra
 
     template <typename Number, typename MemorySpace>
     SolverDirect<Number, MemorySpace>::AdditionalData::AdditionalData(
-      const std::string &solver_name,
-      const bool         output_solver_details)
+      const std::string &solver_name)
       : solver_name(solver_name)
-      , output_solver_details(output_solver_details)
     {}
 
 
@@ -182,9 +162,7 @@ namespace LinearAlgebra
     template <typename Number, typename MemorySpace>
     SolverDirect<Number, MemorySpace>::SolverDirect(SolverControl        &cn,
                                                     const AdditionalData &ad)
-      : SolverDirectBase<Number, MemorySpace>(cn,
-                                              ad.solver_name,
-                                              ad.output_solver_details)
+      : SolverDirectBase<Number, MemorySpace>(cn, ad.solver_name)
     {}
 
 
@@ -205,14 +183,12 @@ namespace LinearAlgebra
       const bool         symmetric_mode,
       const bool         equilibrate_matrix,
       const std::string &column_permutation,
-      const std::string &iterative_refinement,
-      const bool         output_solver_details)
+      const std::string &iterative_refinement)
       : transpose_mode(transpose_mode)
       , symmetric_mode(symmetric_mode)
       , equilibrate_matrix(equilibrate_matrix)
       , column_permutation(column_permutation)
       , iterative_refinement(iterative_refinement)
-      , output_solver_details(output_solver_details)
     {}
 
 
@@ -221,9 +197,7 @@ namespace LinearAlgebra
     SolverDirectKLU2<Number, MemorySpace>::SolverDirectKLU2(
       SolverControl        &cn,
       const AdditionalData &ad)
-      : SolverDirectBase<Number, MemorySpace>(cn,
-                                              "KLU2",
-                                              ad.output_solver_details)
+      : SolverDirectBase<Number, MemorySpace>(cn, "KLU2")
     {
       this->parameter_list               = Teuchos::ParameterList("Amesos2");
       Teuchos::ParameterList klu2_params = this->parameter_list.sublist("KLU2");

--- a/tests/trilinos_tpetra/direct_solver_01.cc
+++ b/tests/trilinos_tpetra/direct_solver_01.cc
@@ -341,7 +341,7 @@ Step4<dim>::solve()
   {
     deallog.push("DirectKLU2");
     LinearAlgebra::TpetraWrappers::SolverDirect<double>::AdditionalData data(
-      "KLU2", true);
+      "KLU2");
     LinearAlgebra::TpetraWrappers::SolverDirect<double> direct_solver(
       solver_control, data);
 
@@ -394,7 +394,7 @@ Step4<dim>::solve()
     // independent of the Amesos2 configuration.
     deallog.push("DirectMEASLES");
     LinearAlgebra::TpetraWrappers::SolverDirect<double>::AdditionalData data(
-      "MEASLES", true);
+      "MEASLES");
     try
       {
         LinearAlgebra::TpetraWrappers::SolverDirect<double> direct_solver(


### PR DESCRIPTION
As suggested by @bangerth the verbose_cout did not really provide a large benefit.
For that reason I removed it from the SolverDirect class.