### PR TITLE
Declare conversion assignments for Tpetra vectors.

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -27,6 +27,7 @@
 
 #  include <deal.II/lac/read_vector.h>
 #  include <deal.II/lac/trilinos_tpetra_communication_pattern.h>
+#  include <deal.II/lac/vector.h>
 #  include <deal.II/lac/vector_operation.h>
 #  include <deal.II/lac/vector_type_traits.h>
 
@@ -400,6 +401,15 @@ namespace LinearAlgebra
        */
       Vector &
       operator=(const Vector &V);
+
+      /**
+       * Copy function. This function takes a Vector and copies all the
+       * elements. The Vector will have the same parallel distribution as @p
+       * V.
+       */
+      template <typename OtherNumber>
+      Vector &
+      operator=(const dealii::Vector<OtherNumber> &V);
 
       /**
        * Sets all elements of the vector to the scalar @p s. This operation is

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -412,6 +412,30 @@ namespace LinearAlgebra
 
 
     template <typename Number, typename MemorySpace>
+    template <typename OtherNumber>
+    Vector<Number, MemorySpace> &
+    Vector<Number, MemorySpace>::operator=(const dealii::Vector<OtherNumber> &V)
+    {
+      static_assert(
+        std::is_same<Number, OtherNumber>::value,
+        "TpetraWrappers::Vector and dealii::Vector must use the same number type here.");
+
+      vector.reset();
+      nonlocal_vector.reset();
+
+      Teuchos::Array<OtherNumber> vector_data(V.begin(), V.end());
+      vector = Utilities::Trilinos::internal::make_rcp<VectorType>(
+        V.locally_owned_elements().make_tpetra_map_rcp(), vector_data);
+
+      has_ghost  = false;
+      compressed = true;
+
+      return *this;
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
     Vector<Number, MemorySpace> &
     Vector<Number, MemorySpace>::operator=(const Number s)
     {

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -58,6 +58,17 @@ namespace TrilinosWrappers
 } // namespace TrilinosWrappers
 #  endif
 
+#  ifdef DEAL_II_TRILINOS_WITH_TPETRA
+namespace LinearAlgebra
+{
+  namespace TpetraWrappers
+  {
+    template <typename Number, typename MemorySpace>
+    class Vector;
+  }
+} // namespace LinearAlgebra
+#  endif
+
 template <typename number>
 class LAPACKFullMatrix;
 
@@ -232,6 +243,26 @@ public:
    * that needs to be executed by all MPI processes that jointly share @p v.
    */
   explicit Vector(const TrilinosWrappers::MPI::Vector &v);
+#endif
+
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+  /**
+   * Another copy constructor: copy the values from a Trilinos wrapper vector.
+   * This copy constructor is only available if Trilinos was detected during
+   * configuration time.
+   *
+   * @note Due to the communication model used in MPI, this operation can
+   * only succeed if all processes that have knowledge of @p v
+   * (i.e. those given by <code>v.get_mpi_communicator()</code>) do it at
+   * the same time. This means that unless you use a split MPI communicator
+   * then it is not normally possible for only one or a subset of processes
+   * to obtain a copy of a parallel vector while the other jobs do something
+   * else. In other words, calling this function is a @ref GlossCollectiveOperation "collective operation"
+   * that needs to be executed by all MPI processes that jointly share @p v.
+   */
+  template <typename OtherNumber, typename MemorySpace>
+  explicit Vector(
+    const LinearAlgebra::TpetraWrappers::Vector<OtherNumber, MemorySpace> &v);
 #endif
 
   /**
@@ -438,6 +469,28 @@ public:
    */
   Vector<Number> &
   operator=(const TrilinosWrappers::MPI::Vector &v);
+#endif
+
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+  /**
+   * Another copy operator: copy the values from a (sequential or parallel,
+   * depending on the underlying compiler) Trilinos wrapper vector class. This
+   * operator is only available if Trilinos was detected during configuration
+   * time.
+   *
+   * @note Due to the communication model used in MPI, this operation can
+   * only succeed if all processes that have knowledge of @p v
+   * (i.e. those given by <code>v.get_mpi_communicator()</code>) do it at
+   * the same time. This means that unless you use a split MPI communicator
+   * then it is not normally possible for only one or a subset of processes
+   * to obtain a copy of a parallel vector while the other jobs do something
+   * else. In other words, calling this function is a @ref GlossCollectiveOperation "collective operation"
+   * that needs to be executed by all MPI processes that jointly share @p v.
+   */
+  template <typename OtherNumber, typename MemorySpace>
+  Vector<Number> &
+  operator=(
+    const LinearAlgebra::TpetraWrappers::Vector<OtherNumber, MemorySpace> &v);
 #endif
 
   /**

--- a/source/lac/trilinos_tpetra_vector.cc
+++ b/source/lac/trilinos_tpetra_vector.cc
@@ -36,6 +36,8 @@ namespace LinearAlgebra
     static_assert(concepts::is_vector_space_vector<Vector<float>>);
 #    endif
     template class Vector<float>;
+    template Vector<float> &
+    Vector<float>::operator=<float>(const dealii::Vector<float> &);
     namespace internal
     {
       template class VectorReference<float>;
@@ -47,6 +49,8 @@ namespace LinearAlgebra
     static_assert(concepts::is_vector_space_vector<Vector<double>>);
 #    endif
     template class Vector<double>;
+    template Vector<double> &
+    Vector<double>::operator=<double>(const dealii::Vector<double> &);
     namespace internal
     {
       template class VectorReference<double>;
@@ -60,6 +64,9 @@ namespace LinearAlgebra
                   Vector<std::complex<float>>);
 #      endif
     template class Vector<std::complex<float>>;
+    template Vector<std::complex<float>> &
+    Vector<std::complex<float>>::operator=
+      <std::complex<float>>(const dealii::Vector<std::complex<float>> &);
     namespace internal
     {
       template class VectorReference<std::complex<float>>;
@@ -72,6 +79,9 @@ namespace LinearAlgebra
                   Vector<std::complex<double>>);
 #      endif
     template class Vector<std::complex<double>>;
+    template Vector<std::complex<double>> &
+    Vector<std::complex<double>>::operator=
+      <std::complex<double>>(const dealii::Vector<std::complex<double>> &);
     namespace internal
     {
       template class VectorReference<std::complex<double>>;

--- a/source/lac/vector.cc
+++ b/source/lac/vector.cc
@@ -83,4 +83,40 @@ Vector<int>::lp_norm(const real_type) const
   return -1;
 }
 
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#  ifdef HAVE_TPETRA_INST_FLOAT
+template Vector<float>::Vector(
+  const LinearAlgebra::TpetraWrappers::Vector<float> &);
+template Vector<float> &
+Vector<float>::operator=
+  <float>(const LinearAlgebra::TpetraWrappers::Vector<float> &);
+#  endif
+
+#  ifdef HAVE_TPETRA_INST_DOUBLE
+template Vector<double>::Vector(
+  const LinearAlgebra::TpetraWrappers::Vector<double> &);
+template Vector<double> &
+Vector<double>::operator=
+  <double>(const LinearAlgebra::TpetraWrappers::Vector<double> &);
+#  endif
+
+#  ifdef DEAL_II_WITH_COMPLEX_VALUES
+#    ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
+template Vector<std::complex<float>>::Vector(
+  const LinearAlgebra::TpetraWrappers::Vector<std::complex<float>> &);
+template Vector<std::complex<float>> &
+Vector<std::complex<float>>::operator=<std::complex<float>>(
+  const LinearAlgebra::TpetraWrappers::Vector<std::complex<float>> &);
+#    endif
+
+#    ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
+template Vector<std::complex<double>>::Vector(
+  const LinearAlgebra::TpetraWrappers::Vector<std::complex<double>> &);
+template Vector<std::complex<double>> &
+Vector<std::complex<double>>::operator=<std::complex<double>>(
+  const LinearAlgebra::TpetraWrappers::Vector<std::complex<double>> &);
+#    endif
+#  endif
+#endif
+
 DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
I picked up PR #16639 from @bangerth.

One remark: I already tested this against all tests introduced by  #16611.
The test `tests/trilinos_tpetra/vector_local_copy_01.cc` creates a deadlock (the goal of that test is to test whether a deadlock is created when the conversion functions are only called by one MPI rank). The way I implemented the conversion functions, this can not be avoided.

But actually, I don't see the reason for this test at all since the documentation of the corresponding functions clearly states that they are collective operations that need to be executed by all MPI processes. 