### PR TITLE
Relicensing: require all new contributions to be dual licensed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,11 @@ else. If you are new to the project then we will work with you to ensure
 your contributions are formatted with this style, so please do not think of
 it as a road block if you would like to contribute some code.
 
-The library is licensed under the GNU Lesser General Public License; while
-you will retain copyright on your contributions, all changes to the core
-library must be provided under this common license.
+As a contributor to this project, you agree that all of your contributions
+to deal.II (a) be governed by the <b>Developer Certificate of Origin
+version 1.1</b> and (b) be dual-licensed under the terms of the <b>Apache
+License 2.0</b> with <b>LLVM Exception</b> and the <b>GNU Lesser General
+Public License v2.1 or later</b>; see LICENSE.md for details. The deal.II
+project does not require copyright assignments for contributions. This
+means that the copyright for code contributions in the deal.II project is
+held by its respective contributors.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -3,36 +3,40 @@ deal.II Copyright and License
 
 This directory contains the deal.II library.
 
-The deal.II library is copyrighted by the deal.II authors. This term
-refers to the people listed in the file `AUTHORS` and in the
-[authors list](https://www.dealii.org/authors.html) on the webpage.
+The deal.II library is copyrighted by the deal.II authors. This term refers
+to the people listed in the file `AUTHORS` and in the [authors
+list](https://www.dealii.org/authors.html) on the webpage.
 
-The deal.II library is free software; you can use it, redistribute it,
-and/or modify it under the terms of the <b>GNU Lesser General Public
-License</b> as published by the Free Software Foundation; either <b>version
-2.1</b> of the License, or (at your option) any later version. The full
-text of the GNU Lesser General Public version 2.1 is quoted below.
-
+The deal.II library is free software; it is licensed under the <b>GNU
+Lesser General Public License v2.1 or later</b>. The deal.II authors are in
+the process of relicensing the library to be dual-licensed under the
+<b>Apache License 2.0</b> with <b>LLVM Exception</b> and the <b>GNU Lesser
+General Public License v2.1 or later</b>. As such we require all new code
+contributions to the library to be dual licensed as outlined below.
 
 
 Contributions
 -------------
 
 As a contributor to this project, you agree that all of your contributions
-be governed by the <b>Developer Certificate of Origin version 1.1</b>.
+to deal.II (a) be governed by the
+[<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/),
+and (b) be dual-licensed under the terms of the
+[<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html)
+with
+[<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html)
+and the
+[<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
 The deal.II project does not require copyright assignments for
 contributions. This means that the copyright for code contributions in the
-deal.II project is held by its respective contributors who have each agreed
-to release their contributed code under a compatible open source license
-(LGPL v2.1 for library code). The full text of the Developer Certificate of
-Origin version 1.1 is quoted below.
+deal.II project is held by its respective contributors.
 
 
 Referencing the library
 -----------------------
 
-In addition to the terms imposed by the LGPL v2.1 or later, we ask for the
-following courtesy:
+In addition to the terms imposed by the licenses, we ask for the following
+courtesy:
 
  -  Every publication presenting numerical results obtained with the help
     of deal.II should state the name of the library and cite appropriate
@@ -73,9 +77,9 @@ but you also are not restricted by their license.
 Contact
 -------
 
-For further questions regarding licensing and commercial use please contact the
-[deal.II principal developers, or project
-administrators](https://www.dealii.org/authors.html) directly.
+For further questions regarding licensing and commercial use please contact
+(one of) the
+[deal.II principal developers](https://www.dealii.org/authors.html) directly.
 
 
 Full text of the [Developer Certificate of Origin version 1.1](https://developercertificate.org/)
@@ -120,10 +124,232 @@ By making a contribution to this project, I certify that:
     this project or the open source license(s) involved.
 ```
 
+Full text of the [Apache License 2.0](https://spdx.org/licenses/Apache-2.0.html)
+--------------------------------------------------------------------------------
+```
+                             Apache License
+                       Version 2.0, January 2004
+                    http://www.apache.org/licenses/
 
-Full license text of the [GNU Lesser General Public License version 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
--------------------------------------------------------------------------------------------------------------------
-----
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+  "License" shall mean the terms and conditions for use, reproduction,
+  and distribution as defined by Sections 1 through 9 of this document.
+
+  "Licensor" shall mean the copyright owner or entity authorized by
+  the copyright owner that is granting the License.
+
+  "Legal Entity" shall mean the union of the acting entity and all
+  other entities that control, are controlled by, or are under common
+  control with that entity. For the purposes of this definition,
+  "control" means (i) the power, direct or indirect, to cause the
+  direction or management of such entity, whether by contract or
+  otherwise, or (ii) ownership of fifty percent (50%) or more of the
+  outstanding shares, or (iii) beneficial ownership of such entity.
+
+  "You" (or "Your") shall mean an individual or Legal Entity
+  exercising permissions granted by this License.
+
+  "Source" form shall mean the preferred form for making modifications,
+  including but not limited to software source code, documentation
+  source, and configuration files.
+
+  "Object" form shall mean any form resulting from mechanical
+  transformation or translation of a Source form, including but
+  not limited to compiled object code, generated documentation,
+  and conversions to other media types.
+
+  "Work" shall mean the work of authorship, whether in Source or
+  Object form, made available under the License, as indicated by a
+  copyright notice that is included in or attached to the work
+  (an example is provided in the Appendix below).
+
+  "Derivative Works" shall mean any work, whether in Source or Object
+  form, that is based on (or derived from) the Work and for which the
+  editorial revisions, annotations, elaborations, or other modifications
+  represent, as a whole, an original work of authorship. For the purposes
+  of this License, Derivative Works shall not include works that remain
+  separable from, or merely link (or bind by name) to the interfaces of,
+  the Work and Derivative Works thereof.
+
+  "Contribution" shall mean any work of authorship, including
+  the original version of the Work and any modifications or additions
+  to that Work or Derivative Works thereof, that is intentionally
+  submitted to Licensor for inclusion in the Work by the copyright owner
+  or by an individual or Legal Entity authorized to submit on behalf of
+  the copyright owner. For the purposes of this definition, "submitted"
+  means any form of electronic, verbal, or written communication sent
+  to the Licensor or its representatives, including but not limited to
+  communication on electronic mailing lists, source code control systems,
+  and issue tracking systems that are managed by, or on behalf of, the
+  Licensor for the purpose of discussing and improving the Work, but
+  excluding communication that is conspicuously marked or otherwise
+  designated in writing by the copyright owner as "Not a Contribution."
+
+  "Contributor" shall mean Licensor and any individual or Legal Entity
+  on behalf of whom a Contribution has been received by Licensor and
+  subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+  this License, each Contributor hereby grants to You a perpetual,
+  worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  copyright license to reproduce, prepare Derivative Works of,
+  publicly display, publicly perform, sublicense, and distribute the
+  Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+  this License, each Contributor hereby grants to You a perpetual,
+  worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  (except as stated in this section) patent license to make, have made,
+  use, offer to sell, sell, import, and otherwise transfer the Work,
+  where such license applies only to those patent claims licensable
+  by such Contributor that are necessarily infringed by their
+  Contribution(s) alone or by combination of their Contribution(s)
+  with the Work to which such Contribution(s) was submitted. If You
+  institute patent litigation against any entity (including a
+  cross-claim or counterclaim in a lawsuit) alleging that the Work
+  or a Contribution incorporated within the Work constitutes direct
+  or contributory patent infringement, then any patent licenses
+  granted to You under this License for that Work shall terminate
+  as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+  Work or Derivative Works thereof in any medium, with or without
+  modifications, and in Source or Object form, provided that You
+  meet the following conditions:
+
+  (a) You must give any other recipients of the Work or
+      Derivative Works a copy of this License; and
+
+  (b) You must cause any modified files to carry prominent notices
+      stating that You changed the files; and
+
+  (c) You must retain, in the Source form of any Derivative Works
+      that You distribute, all copyright, patent, trademark, and
+      attribution notices from the Source form of the Work,
+      excluding those notices that do not pertain to any part of
+      the Derivative Works; and
+
+  (d) If the Work includes a "NOTICE" text file as part of its
+      distribution, then any Derivative Works that You distribute must
+      include a readable copy of the attribution notices contained
+      within such NOTICE file, excluding those notices that do not
+      pertain to any part of the Derivative Works, in at least one
+      of the following places: within a NOTICE text file distributed
+      as part of the Derivative Works; within the Source form or
+      documentation, if provided along with the Derivative Works; or,
+      within a display generated by the Derivative Works, if and
+      wherever such third-party notices normally appear. The contents
+      of the NOTICE file are for informational purposes only and
+      do not modify the License. You may add Your own attribution
+      notices within Derivative Works that You distribute, alongside
+      or as an addendum to the NOTICE text from the Work, provided
+      that such additional attribution notices cannot be construed
+      as modifying the License.
+
+  You may add Your own copyright statement to Your modifications and
+  may provide additional or different license terms and conditions
+  for use, reproduction, or distribution of Your modifications, or
+  for any such Derivative Works as a whole, provided Your use,
+  reproduction, and distribution of the Work otherwise complies with
+  the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+  any Contribution intentionally submitted for inclusion in the Work
+  by You to the Licensor shall be under the terms and conditions of
+  this License, without any additional terms or conditions.
+  Notwithstanding the above, nothing herein shall supersede or modify
+  the terms of any separate license agreement you may have executed
+  with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+  names, trademarks, service marks, or product names of the Licensor,
+  except as required for reasonable and customary use in describing the
+  origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+  agreed to in writing, Licensor provides the Work (and each
+  Contributor provides its Contributions) on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied, including, without limitation, any warranties or conditions
+  of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+  PARTICULAR PURPOSE. You are solely responsible for determining the
+  appropriateness of using or redistributing the Work and assume any
+  risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+  whether in tort (including negligence), contract, or otherwise,
+  unless required by applicable law (such as deliberate and grossly
+  negligent acts) or agreed to in writing, shall any Contributor be
+  liable to You for damages, including any direct, indirect, special,
+  incidental, or consequential damages of any character arising as a
+  result of this License or out of the use or inability to use the
+  Work (including but not limited to damages for loss of goodwill,
+  work stoppage, computer failure or malfunction, or any and all
+  other commercial damages or losses), even if such Contributor
+  has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+  the Work or Derivative Works thereof, You may choose to offer,
+  and charge a fee for, acceptance of support, warranty, indemnity,
+  or other liability obligations and/or rights consistent with this
+  License. However, in accepting such obligations, You may act only
+  on Your own behalf and on Your sole responsibility, not on behalf
+  of any other Contributor, and only if You agree to indemnify,
+  defend, and hold each Contributor harmless for any liability
+  incurred by, or claims asserted against, such Contributor by reason
+  of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+  To apply the Apache License to your work, attach the following
+  boilerplate notice, with the fields enclosed by brackets "[]"
+  replaced with your own identifying information. (Don't include
+  the brackets!)  The text should be enclosed in the appropriate
+  comment syntax for the file format. We also recommend that a
+  file or class name and description of purpose be included on the
+  same "printed page" as the copyright notice for easier
+  identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```
+
+Full text of the [LLVM Exception](https://spdx.org/licenses/LLVM-exception.html)
+--------------------------------------------------------------------------------
+```
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.
+```
+
+Full text of the [GNU Lesser General Public License version 2.1](https://spdx.org/licenses/LGPL-2.1-or-later.html)
+------------------------------------------------------------------------------------------------------------------
 ```
                   GNU LESSER GENERAL PUBLIC LICENSE
                        Version 2.1, February 1999

--- a/doc/README.md
+++ b/doc/README.md
@@ -2,7 +2,7 @@ This folder contains the html documentation of deal.II
 ======================================================
 
 The documentation is generally covered by the same license as the deal.II
-library itself, namely LGPL-2.1+.
+library itself; see LICENSE.md for details.
 
 Exceptions:
 

--- a/doc/readme.html
+++ b/doc/readme.html
@@ -776,53 +776,6 @@
         <a href="developers/cmake-internals.html">build system internals</a>.
     </p>
 
-
-    <a name="license"></a>
-    <h2>License</h2>
-
-    <p>
-        The deal.II library is free software; you can use it, redistribute it, and/or modify it under the terms of the
-        <a href="https://www.gnu.org/licenses/lgpl-2.1.html">GNU Lesser General
-      Public License</a> (LGPL) as published by the Free Software Foundation; either version 2.1 of the License, or (at your option) any later version.
-    </p>
-    <p>
-        This allows you to use the library free of charge for private, academic, or commercial use (under the terms of the LGPL v2.1 or later). You are guaranteed full access to the source code and are encouraged to help in the further development of the library.
-        Follow
-        <a href="https://www.dealii.org/license.html" target="body">this
-        link</a> for detailed information.
-    </p>
-    <p>
-        Please note:</p>
-    <ul>
-        <li>
-            Detailed license information can be found following
-            <a href="https://www.dealii.org/license.html" target="body">this link</a>.
-        </li>
-        <li>
-            <b>As a contributor to this project, you agree that any of your
-          contributions be licensed under the same terms and conditions as
-          the license of the deal.II project granted to you.</b>
-        </li>
-        <li>
-            We, <a href="https://www.dealii.org/authors.html" target="_top">the deal.II Authors</a>, do not require copyright assignments for contributions. This means that the copyright for code contributions in the deal.II project is held by its respective
-            contributors who have each agreed to release their contributed code under the terms of the LGPL v2.1 or later.
-        </li>
-        <li>
-            In addition to the terms imposed by the LGPL (version 2.1 or later), we ask for the courtesy that scientific publications presenting results obtained with this libraries acknowledge its use. Please cite one of the papers referenced
-            <a href="https://www.dealii.org/publications.html">here</a>.
-        </li>
-        <li>
-            <acronym>deal.II</acronym> can interface with a number of <a href="#optional-software">other packages</a> that you either have to install yourself. They are, of course, covered by their own licenses. In addition, deal.II comes bundled with
-            copies of
-            <a href="https://faculty.cse.tamu.edu/davis/suitesparse.html">
-          UMFPACK</a>,
-            <a href="https://threadingbuildingblocks.org/" target="_top">Threading Building Blocks</a>,
-            <a href="https://www.boost.org/" target="_top">BOOST</a>,
-            <a href="https://github.com/kokkos/kokkos" target="_top">Kokkos</a>, and
-            <a href="https://muparser.beltoforion.de/" target="_top">muparser</a>, courtesy of their authors. These are also covered by their own licenses; please refer to their webpages for more information.
-        </li>
-    </ul>
-
     <hr />
     <div class="right">
         <a href="https://validator.w3.org/check?uri=referer" target="_top">


### PR DESCRIPTION
This is a draft PR for changing the contribution guidelines so that new code contributions are dual licensed.

- Relicensing: update LICENSE.md
- Relicensing: update CONTRIBUTING.md

In reference to #16665 
