### PR TITLE
Fix bundled boost 1.70.0 to avoid using std::unary_function

### DIFF
--- a/bundled/boost-1.70.0/include/boost/container_hash/hash.hpp
+++ b/bundled/boost-1.70.0/include/boost/container_hash/hash.hpp
@@ -118,7 +118,7 @@ namespace boost
 {
     namespace hash_detail
     {
-#if defined(_HAS_AUTO_PTR_ETC) && !_HAS_AUTO_PTR_ETC
+#if defined(BOOST_NO_CXX98_FUNCTION_BASE)
         template <typename T>
         struct hash_base
         {


### PR DESCRIPTION
Fixes #16662 by cherry-picking https://github.com/boostorg/container_hash/pull/6. Of course, #16621 would supersede this pull request.