### PR TITLE
Use size_type as return type of SparseMatrix::m().

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparse_matrix.h
@@ -406,13 +406,13 @@ namespace LinearAlgebra
       /**
        * Return the number of rows in this matrix.
        */
-      dealii::types::signed_global_dof_index
+      size_type
       m() const;
 
       /**
        * Return the number of columns in this matrix.
        */
-      dealii::types::signed_global_dof_index
+      size_type
       n() const;
 
 
@@ -1110,7 +1110,7 @@ namespace LinearAlgebra
 
 
     template <typename Number, typename MemorySpace>
-    inline dealii::types::signed_global_dof_index
+    inline typename SparseMatrix<Number, MemorySpace>::size_type
     SparseMatrix<Number, MemorySpace>::m() const
     {
       return matrix->getRowMap()->getGlobalNumElements();
@@ -1119,7 +1119,7 @@ namespace LinearAlgebra
 
 
     template <typename Number, typename MemorySpace>
-    inline dealii::types::signed_global_dof_index
+    inline typename SparseMatrix<Number, MemorySpace>::size_type
     SparseMatrix<Number, MemorySpace>::n() const
     {
       // If the matrix structure has not been fixed (i.e., we did not have a

--- a/include/deal.II/lac/trilinos_tpetra_sparse_matrix.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparse_matrix.templates.h
@@ -594,7 +594,7 @@ namespace LinearAlgebra
       const bool                          copy_values,
       const dealii::SparsityPattern      *use_this_sparsity)
     {
-      dealii::types::signed_global_dof_index n_rows = dealii_sparse_matrix.m();
+      const size_type n_rows = dealii_sparse_matrix.m();
       AssertDimension(row_parallel_partitioning.size(), n_rows);
       AssertDimension(col_parallel_partitioning.size(),
                       dealii_sparse_matrix.n());
@@ -631,7 +631,7 @@ namespace LinearAlgebra
       std::vector<size_type> row_indices(maximum_row_length);
       std::vector<Number>    values(maximum_row_length);
 
-      for (dealii::types::signed_global_dof_index row = 0; row < n_rows; ++row)
+      for (size_type row = 0; row < n_rows; ++row)
         // see if the row is locally stored on this processor
         if (row_parallel_partitioning.is_element(row) == true)
           {


### PR DESCRIPTION
This makes these functions consistent with what we have in the Epetra wrappers, and (that was my original motivation) avoids warnings in the block matrix class about comparing integers of different sizes/signedness.

Conceptually, it makes sense to use `size_type` for these functions. `size_type` is defined as
```
include/deal.II/lac/trilinos_tpetra_sparse_matrix.h:      using size_type = dealii::types::global_dof_index;
```
So it is unsigned, which is exactly what these functions should return.

(I will note as an aside that different parts of the Tpetra wrappers define their own `size_type` types, and some of these are signed:
```
include/deal.II/lac/trilinos_tpetra_block_sparse_matrix.h:      using size_type       = typename BaseClass::size_type;
include/deal.II/lac/trilinos_tpetra_block_vector.h:      using size_type       = typename BaseClass::size_type;
include/deal.II/lac/trilinos_tpetra_solver_direct.h:      using size_type = dealii::types::signed_global_dof_index;   ******
include/deal.II/lac/trilinos_tpetra_sparse_matrix.h:      using size_type = dealii::types::global_dof_index;
include/deal.II/lac/trilinos_tpetra_sparse_matrix.templates.h:      using size_type = dealii::types::signed_global_dof_index;  ******
include/deal.II/lac/trilinos_tpetra_sparsity_pattern.h:        using size_type = dealii::types::signed_global_dof_index;  ******
include/deal.II/lac/trilinos_tpetra_sparsity_pattern.h:        using size_type = size_t;  ******
include/deal.II/lac/trilinos_tpetra_sparsity_pattern.h:      using size_type = dealii::types::signed_global_dof_index;  ******
include/deal.II/lac/trilinos_tpetra_vector.h:      using size_type = dealii::types::global_dof_index;
include/deal.II/lac/trilinos_tpetra_vector.h:      using size_type  = types::global_dof_index;
```
This is perhaps not great design. I'll open an issue about this.)