### PR TITLE
Fix issue with colorized cylinder shell

### DIFF
--- a/doc/news/changes/minor/20240227Blais
+++ b/doc/news/changes/minor/20240227Blais
@@ -1,0 +1,3 @@
+Fixed: The colorize option for the cylinder shell could yield inadequate boundary ID for some aspect ratios that were very different from the default one.
+<br>
+(Bruno Blais, 2024/02/27)

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -6484,8 +6484,6 @@ namespace GridGenerator
     // bottom and top cells.
     double eps_z = 1e-6 * length;
 
-
-
     // Gather the inner radius from the faces instead of the argument, this is
     // more robust for some aspect ratios. First initialize the outer to 0 and
     // the inner to a large value

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -6480,8 +6480,41 @@ namespace GridGenerator
     // Top (Z+) part of the cylinder has boundary id 3
 
     // Define tolerance to help detect boundary conditions
-    double eps_z =
-      std::min(1e-3 * (outer_radius - inner_radius), 1e-3 * length);
+    // First we define the tolerance along the z axis to identify 
+    // bottom and top cells.
+    double eps_z = 1e-6 * length;
+
+
+
+      // Gather the inner radius from the faces instead of the argument, this is
+      // more robust for some aspect ratios. First initialize the outer to 0 and
+      // the inner to a large value
+      double inner_radius = DBL_MAX;
+      double outer_radius = 0.;
+
+      // Loop over the cells once to acquire the min and max radius at the face
+      // centers Otherwise, for some cell ratio, the center of the faces can be
+      // at a radius which is significantly different from the one prescribed.
+      for (const auto &cell : triangulation.active_cell_iterators())
+        for (const unsigned int f : GeometryInfo<3>::face_indices())
+          {
+            if (!cell->face(f)->at_boundary())
+              continue;
+
+            const auto   face_center = cell->face(f)->center();
+            const double z           = face_center[2];
+
+            if ((std::fabs(z) > eps_z) &&
+                (std::fabs(z - length) > eps_z)) // Not a zmin or zmax boundary
+              {
+                const double radius =
+                  std::sqrt(face_center[0] * face_center[0] +
+                            face_center[1] * face_center[1]);
+                inner_radius = std::min(inner_radius, radius);
+                outer_radius = std::max(outer_radius, radius);
+              }
+          }
+    
     double mid_radial_distance = 0.5 * (outer_radius - inner_radius);
 
     for (const auto &cell : tria.active_cell_iterators())

--- a/tests/grid/grid_generator_cylinder_shell_colorized.cc
+++ b/tests/grid/grid_generator_cylinder_shell_colorized.cc
@@ -32,40 +32,40 @@ test(std::ostream &out)
 {
   deallog << "cylinder_shell colorized with default aspect ratio" << std::endl;
   {
-  Triangulation<dim> tr;
-  GridGenerator::cylinder_shell(tr, 2., 5., 6., 0, 0, true);
+    Triangulation<dim> tr;
+    GridGenerator::cylinder_shell(tr, 2., 5., 6., 0, 0, true);
 
-  for (const auto &cell : tr.active_cell_iterators())
-    {
-      deallog << "cell:" << std::endl;
+    for (const auto &cell : tr.active_cell_iterators())
+      {
+        deallog << "cell:" << std::endl;
 
-      for (const auto &face : cell->face_iterators())
-        {
-          if (face->at_boundary())
-            deallog << "boundary id = " << face->boundary_id()
-                    << " center = " << face->center()
-                    << " faceidx = " << face->index() << std::endl;
-        }
-    }
+        for (const auto &face : cell->face_iterators())
+          {
+            if (face->at_boundary())
+              deallog << "boundary id = " << face->boundary_id()
+                      << " center = " << face->center()
+                      << " faceidx = " << face->index() << std::endl;
+          }
+      }
   }
 
   deallog << "cylinder_shell colorized with 3:2 ratio " << std::endl;
   {
-  Triangulation<dim> tr;
-  GridGenerator::cylinder_shell(tr, 2., 5., 6., 3, 2, true);
+    Triangulation<dim> tr;
+    GridGenerator::cylinder_shell(tr, 2., 5., 6., 3, 2, true);
 
-  for (const auto &cell : tr.active_cell_iterators())
-    {
-      deallog << "cell:" << std::endl;
+    for (const auto &cell : tr.active_cell_iterators())
+      {
+        deallog << "cell:" << std::endl;
 
-      for (const auto &face : cell->face_iterators())
-        {
-          if (face->at_boundary())
-            deallog << "boundary id = " << face->boundary_id()
-                    << " center = " << face->center()
-                    << " faceidx = " << face->index() << std::endl;
-        }
-    }
+        for (const auto &face : cell->face_iterators())
+          {
+            if (face->at_boundary())
+              deallog << "boundary id = " << face->boundary_id()
+                      << " center = " << face->center()
+                      << " faceidx = " << face->index() << std::endl;
+          }
+      }
   }
 }
 

--- a/tests/grid/grid_generator_cylinder_shell_colorized.cc
+++ b/tests/grid/grid_generator_cylinder_shell_colorized.cc
@@ -30,7 +30,8 @@ template <int dim>
 void
 test(std::ostream &out)
 {
-  deallog << "cylinder_shell colorized" << std::endl;
+  deallog << "cylinder_shell colorized with default aspect ratio" << std::endl;
+  {
   Triangulation<dim> tr;
   GridGenerator::cylinder_shell(tr, 2., 5., 6., 0, 0, true);
 
@@ -46,6 +47,26 @@ test(std::ostream &out)
                     << " faceidx = " << face->index() << std::endl;
         }
     }
+  }
+
+  deallog << "cylinder_shell colorized with 3:2 ratio " << std::endl;
+  {
+  Triangulation<dim> tr;
+  GridGenerator::cylinder_shell(tr, 2., 5., 6., 3, 2, true);
+
+  for (const auto &cell : tr.active_cell_iterators())
+    {
+      deallog << "cell:" << std::endl;
+
+      for (const auto &face : cell->face_iterators())
+        {
+          if (face->at_boundary())
+            deallog << "boundary id = " << face->boundary_id()
+                    << " center = " << face->center()
+                    << " faceidx = " << face->index() << std::endl;
+        }
+    }
+  }
 }
 
 

--- a/tests/grid/grid_generator_cylinder_shell_colorized.output
+++ b/tests/grid/grid_generator_cylinder_shell_colorized.output
@@ -1,5 +1,5 @@
 
-DEAL::cylinder_shell colorized
+DEAL::cylinder_shell colorized with default aspect ratio
 DEAL::cell:
 DEAL::boundary id = 2 center = 5.45581 0.491031 0.00000 faceidx = 0
 DEAL::boundary id = 1 center = 5.95179 0.535671 0.333333 faceidx = 35
@@ -385,3 +385,28 @@ DEAL::cell:
 DEAL::boundary id = 3 center = 5.45581 -0.491031 2.00000 faceidx = 418
 DEAL::boundary id = 1 center = 5.95179 -0.535671 1.66667 faceidx = 417
 DEAL::boundary id = 0 center = 4.95982 -0.446392 1.66667 faceidx = 454
+DEAL::cylinder_shell colorized with 3:2 ratio 
+DEAL::cell:
+DEAL::boundary id = 2 center = 1.37500 2.38157 0.00000 faceidx = 0
+DEAL::boundary id = 1 center = 1.50000 2.59808 0.500000 faceidx = 3
+DEAL::boundary id = 0 center = 1.25000 2.16506 0.500000 faceidx = 12
+DEAL::cell:
+DEAL::boundary id = 2 center = -2.75000 1.11022e-15 0.00000 faceidx = 1
+DEAL::boundary id = 1 center = -3.00000 8.88178e-16 0.500000 faceidx = 6
+DEAL::boundary id = 0 center = -2.50000 8.88178e-16 0.500000 faceidx = 13
+DEAL::cell:
+DEAL::boundary id = 2 center = 1.37500 -2.38157 0.00000 faceidx = 2
+DEAL::boundary id = 1 center = 1.50000 -2.59808 0.500000 faceidx = 9
+DEAL::boundary id = 0 center = 1.25000 -2.16506 0.500000 faceidx = 14
+DEAL::cell:
+DEAL::boundary id = 3 center = 1.37500 2.38157 2.00000 faceidx = 16
+DEAL::boundary id = 1 center = 1.50000 2.59808 1.50000 faceidx = 15
+DEAL::boundary id = 0 center = 1.25000 2.16506 1.50000 faceidx = 24
+DEAL::cell:
+DEAL::boundary id = 3 center = -2.75000 1.11022e-15 2.00000 faceidx = 19
+DEAL::boundary id = 1 center = -3.00000 8.88178e-16 1.50000 faceidx = 18
+DEAL::boundary id = 0 center = -2.50000 8.88178e-16 1.50000 faceidx = 25
+DEAL::cell:
+DEAL::boundary id = 3 center = 1.37500 -2.38157 2.00000 faceidx = 22
+DEAL::boundary id = 1 center = 1.50000 -2.59808 1.50000 faceidx = 21
+DEAL::boundary id = 0 center = 1.25000 -2.16506 1.50000 faceidx = 26


### PR DESCRIPTION
The cylinder shell grid generator lead to wrongly numbers boundary IDs when very specific ratios were used for the last two arguments (e.g. 3:2). These edge cases led to faces on the inner level being numbers with the inappropriate boundary ID.
This PR fixes this by using a double mechanism to identify the cells. First we loop over the cells to obtain (rapidly) the inner and outer radius on the center of the faces and we use these radius to establish the boundary id.

In essence it adds a little bit of calculations, but it makes the process more robust to any type of ratios. I have added a test for the case that broke down with wrong Ids.
