### PR TITLE
Properly deregister a particle if deleted during refinement

### DIFF
--- a/doc/news/changes/minor/20240307Gassmoeller
+++ b/doc/news/changes/minor/20240307Gassmoeller
@@ -1,0 +1,6 @@
+Fixed: The memory of particles which are deleted during refinement was not
+correctly freed in the memory pool.  This could lead to a minor memory leak and
+error messages about an inconsistent state during destruction of the property
+pool. This is fixed now.
+<br>
+(Rene Gassmoeller, 2024/03/07)

--- a/source/particles/property_pool.cc
+++ b/source/particles/property_pool.cc
@@ -47,19 +47,16 @@ namespace Particles
   void
   PropertyPool<dim, spacedim>::clear()
   {
-    if (n_properties > 0)
-      {
-        const unsigned int n_open_handles =
-          properties.size() / n_properties - currently_available_handles.size();
-        (void)n_open_handles;
-        Assert(n_open_handles == 0,
-               ExcMessage("This property pool currently still holds " +
-                          std::to_string(n_open_handles) +
-                          " open handles to memory that was allocated "
-                          "via allocate_properties_array() but that has "
-                          "not been returned via "
-                          "deregister_particle()."));
-      }
+    const unsigned int n_open_handles =
+      locations.size() - currently_available_handles.size();
+    (void)n_open_handles;
+    Assert(n_open_handles == 0,
+           ExcMessage("This property pool currently still holds " +
+                      std::to_string(n_open_handles) +
+                      " open handles to memory that was allocated "
+                      "via allocate_properties_array() but that has "
+                      "not been returned via "
+                      "deregister_particle()."));
 
     // Clear vectors and ensure deallocation of memory
     locations.clear();

--- a/tests/particles/particle_handler_refinement_outside_cell.cc
+++ b/tests/particles/particle_handler_refinement_outside_cell.cc
@@ -33,47 +33,6 @@
 
 template <int dim, int spacedim>
 void
-create_regular_particle_distribution(
-  Particles::ParticleHandler<dim, spacedim>                 &particle_handler,
-  const parallel::distributed::Triangulation<dim, spacedim> &tr,
-  const unsigned int particles_per_direction = 3)
-{
-  for (unsigned int i = 0; i < particles_per_direction; ++i)
-    for (unsigned int j = 0; j < particles_per_direction; ++j)
-      {
-        Point<spacedim> position;
-        Point<dim>      reference_position;
-        unsigned int    id = i * particles_per_direction + j;
-
-        position[0] = static_cast<double>(i) /
-                      static_cast<double>(particles_per_direction - 1);
-        position[1] = static_cast<double>(j) /
-                      static_cast<double>(particles_per_direction - 1);
-
-        if (dim > 2)
-          for (unsigned int k = 0; k < particles_per_direction; ++k)
-            {
-              position[2] = static_cast<double>(j) /
-                            static_cast<double>(particles_per_direction - 1);
-            }
-        else
-          {
-            Particles::Particle<dim, spacedim> particle(position,
-                                                        reference_position,
-                                                        id);
-
-            typename parallel::distributed::Triangulation<dim, spacedim>::
-              active_cell_iterator cell =
-                GridTools::find_active_cell_around_point(
-                  tr, particle.get_location());
-
-            particle_handler.insert_particle(particle, cell);
-          }
-      }
-}
-
-template <int dim, int spacedim>
-void
 test()
 {
   {

--- a/tests/particles/particle_handler_refinement_outside_cell_02.cc
+++ b/tests/particles/particle_handler_refinement_outside_cell_02.cc
@@ -1,0 +1,115 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2017 - 2023 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+
+// Check that particles are correctly deleted during grid
+// refinement/coarsening.
+// Like particle_handler_refinement_outside_cell.cc, but
+// with particles that carry properties.
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/fe/mapping_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include <deal.II/particles/particle_handler.h>
+
+#include "../tests.h"
+
+template <int dim, int spacedim>
+void
+test()
+{
+  {
+    parallel::distributed::Triangulation<dim, spacedim> tr(MPI_COMM_WORLD);
+
+    GridGenerator::hyper_cube(tr);
+    MappingQ<dim, spacedim> mapping(1);
+
+    Particles::ParticleHandler<dim, spacedim> particle_handler(tr, mapping, 2);
+
+    // Create a particle outside of the domain
+    Point<spacedim> position;
+    position[0] = 3;
+    Point<dim> reference_position;
+    reference_position[0]    = 0.5;
+    types::particle_index id = 0;
+
+    particle_handler.insert_particle(position,
+                                     reference_position,
+                                     id,
+                                     tr.begin_active());
+
+    position[0] = 1.0 + 1e-13;
+    id          = 1;
+
+    particle_handler.insert_particle(position,
+                                     reference_position,
+                                     id,
+                                     tr.begin_active());
+
+    for (const auto &particle : particle_handler)
+      deallog << "Before refinement particle id " << particle.get_id()
+              << " is in cell " << particle.get_surrounding_cell(tr)
+              << std::endl;
+
+    // Check that all particles are moved to children
+    particle_handler.prepare_for_coarsening_and_refinement();
+    tr.refine_global(1);
+    particle_handler.unpack_after_coarsening_and_refinement();
+
+    for (const auto &particle : particle_handler)
+      deallog << "After refinement particle id " << particle.get_id()
+              << " is in cell " << particle.get_surrounding_cell(tr)
+              << std::endl;
+
+    // Reverse the refinement and check again
+    for (auto cell = tr.begin_active(); cell != tr.end(); ++cell)
+      cell->set_coarsen_flag();
+
+    particle_handler.prepare_for_coarsening_and_refinement();
+    tr.execute_coarsening_and_refinement();
+    particle_handler.unpack_after_coarsening_and_refinement();
+
+    for (const auto &particle : particle_handler)
+      deallog << "After coarsening particle id " << particle.get_id()
+              << " is in cell " << particle.get_surrounding_cell(tr)
+              << std::endl;
+  }
+
+  deallog << "OK" << std::endl;
+}
+
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  MPILogInitAll all;
+
+  deallog.push("2d/2d");
+  test<2, 2>();
+  deallog.pop();
+  deallog.push("2d/3d");
+  test<2, 3>();
+  deallog.pop();
+  deallog.push("3d/3d");
+  test<3, 3>();
+  deallog.pop();
+}

--- a/tests/particles/particle_handler_refinement_outside_cell_02.with_p4est=true.mpirun=1.output
+++ b/tests/particles/particle_handler_refinement_outside_cell_02.with_p4est=true.mpirun=1.output
@@ -1,0 +1,16 @@
+
+DEAL:0:2d/2d::Before refinement particle id 0 is in cell 0.0
+DEAL:0:2d/2d::Before refinement particle id 1 is in cell 0.0
+DEAL:0:2d/2d::After refinement particle id 1 is in cell 1.1
+DEAL:0:2d/2d::After coarsening particle id 1 is in cell 0.0
+DEAL:0:2d/2d::OK
+DEAL:0:2d/3d::Before refinement particle id 0 is in cell 0.0
+DEAL:0:2d/3d::Before refinement particle id 1 is in cell 0.0
+DEAL:0:2d/3d::After refinement particle id 1 is in cell 1.1
+DEAL:0:2d/3d::After coarsening particle id 1 is in cell 0.0
+DEAL:0:2d/3d::OK
+DEAL:0:3d/3d::Before refinement particle id 0 is in cell 0.0
+DEAL:0:3d/3d::Before refinement particle id 1 is in cell 0.0
+DEAL:0:3d/3d::After refinement particle id 1 is in cell 1.1
+DEAL:0:3d/3d::After coarsening particle id 1 is in cell 0.0
+DEAL:0:3d/3d::OK


### PR DESCRIPTION
During mesh refinement with particles, we search all children of a parent cell for the child that contains the particle. Sometimes we do not find the particle in any child, in which case we delete the particle. Presumably for performance reasons we do not call the `remove_particle` function (which repeats a bunch of operations we already did here), but we forget to properly de-register the particle handle with the property pool, which means the particle memory is never returned. This is not terrible, as the memory leak will be fixed the next time  `sort_particles_into_subdomains_and_cells` is called and only the memory of still existing particles is kept. However this bug can trigger an Assert if we call `PropertyPool<dim, spacedim>::clear()` before doing that, because the PropertyPool notices that there are dangling handles that have not been de-registered (and of course it leads to an inconsistent state of the property pool as well). This PR should fix the issue and make some minor improvements to the code, but I still need to make a test and changelog entry. I opened this early to let @ryanstoner1 and @vaturino who reported this first in https://github.com/geodynamics/aspect/issues/5594 test if this change fixes their issues (it did for my test model).