### PR TITLE
Matrix-free MG transfer: Switch interpolation matrices to double type

### DIFF
--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.h
@@ -651,29 +651,28 @@ private:
     /**
      * Prolongation matrix for non-tensor-product elements.
      */
-    AlignedVector<VectorizedArrayType> prolongation_matrix;
+    AlignedVector<double> prolongation_matrix;
 
     /**
      * 1d prolongation matrix for tensor-product elements.
      */
-    AlignedVector<VectorizedArrayType> prolongation_matrix_1d;
+    AlignedVector<double> prolongation_matrix_1d;
 
     /**
      * Restriction matrix for non-tensor-product elements.
      */
-    AlignedVector<VectorizedArrayType> restriction_matrix;
+    AlignedVector<double> restriction_matrix;
 
     /**
      * 1d restriction matrix for tensor-product elements.
      */
-    AlignedVector<VectorizedArrayType> restriction_matrix_1d;
+    AlignedVector<double> restriction_matrix_1d;
 
     /**
      * ShapeInfo description of the coarse cell. Needed during the
      * fast application of hanging-node constraints.
      */
-    internal::MatrixFreeFunctions::ShapeInfo<VectorizedArrayType>
-      shape_info_coarse;
+    internal::MatrixFreeFunctions::ShapeInfo<double> shape_info_coarse;
   };
 
   /**

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -115,14 +115,14 @@ namespace
   /**
    * Helper class containing the cell-wise prolongation operation.
    */
-  template <int dim, typename Number>
+  template <int dim, typename Number, typename Number2>
   class CellProlongator
   {
   public:
     CellProlongator(const AlignedVector<Number> &prolongation_matrix,
                     const AlignedVector<Number> &prolongation_matrix_1d,
-                    const Number                *evaluation_data_coarse,
-                    Number                      *evaluation_data_fine)
+                    const Number2               *evaluation_data_coarse,
+                    Number2                     *evaluation_data_fine)
       : prolongation_matrix(prolongation_matrix)
       , prolongation_matrix_1d(prolongation_matrix_1d)
       , evaluation_data_coarse(evaluation_data_coarse)
@@ -170,21 +170,21 @@ namespace
   private:
     const AlignedVector<Number> &prolongation_matrix;
     const AlignedVector<Number> &prolongation_matrix_1d;
-    const Number                *evaluation_data_coarse;
-    Number                      *evaluation_data_fine;
+    const Number2               *evaluation_data_coarse;
+    Number2                     *evaluation_data_fine;
   };
 
   /**
    * Helper class containing the cell-wise restriction operation.
    */
-  template <int dim, typename Number>
+  template <int dim, typename Number, typename Number2>
   class CellRestrictor
   {
   public:
     CellRestrictor(const AlignedVector<Number> &prolongation_matrix,
                    const AlignedVector<Number> &prolongation_matrix_1d,
-                   Number                      *evaluation_data_fine,
-                   Number                      *evaluation_data_coarse)
+                   Number2                     *evaluation_data_fine,
+                   Number2                     *evaluation_data_coarse)
       : prolongation_matrix(prolongation_matrix)
       , prolongation_matrix_1d(prolongation_matrix_1d)
       , evaluation_data_fine(evaluation_data_fine)
@@ -235,8 +235,8 @@ namespace
   private:
     const AlignedVector<Number> &prolongation_matrix;
     const AlignedVector<Number> &prolongation_matrix_1d;
-    Number                      *evaluation_data_fine;
-    Number                      *evaluation_data_coarse;
+    Number2                     *evaluation_data_fine;
+    Number2                     *evaluation_data_coarse;
   };
 
   class CellProlongatorTest
@@ -2975,11 +2975,13 @@ MGTwoLevelTransfer<dim, LinearAlgebra::distributed::Vector<Number>>::
           if (needs_interpolation)
             for (int c = n_components - 1; c >= 0; --c)
               {
-                CellProlongator<dim, VectorizedArrayType> cell_prolongator(
-                  scheme.prolongation_matrix,
-                  scheme.prolongation_matrix_1d,
-                  evaluation_data_coarse.begin() + c * n_scalar_dofs_coarse,
-                  evaluation_data_fine.begin() + c * n_scalar_dofs_fine);
+                CellProlongator<dim, double, VectorizedArrayType>
+                  cell_prolongator(scheme.prolongation_matrix,
+                                   scheme.prolongation_matrix_1d,
+                                   evaluation_data_coarse.begin() +
+                                     c * n_scalar_dofs_coarse,
+                                   evaluation_data_fine.begin() +
+                                     c * n_scalar_dofs_fine);
 
                 if (scheme.prolongation_matrix_1d.size() > 0)
                   cell_transfer.run(cell_prolongator);
@@ -3173,11 +3175,13 @@ MGTwoLevelTransfer<dim, LinearAlgebra::distributed::Vector<Number>>::
           if (needs_interpolation)
             for (int c = n_components - 1; c >= 0; --c)
               {
-                CellRestrictor<dim, VectorizedArrayType> cell_restrictor(
-                  scheme.prolongation_matrix,
-                  scheme.prolongation_matrix_1d,
-                  evaluation_data_fine.begin() + c * n_scalar_dofs_fine,
-                  evaluation_data_coarse.begin() + c * n_scalar_dofs_coarse);
+                CellRestrictor<dim, double, VectorizedArrayType>
+                  cell_restrictor(scheme.prolongation_matrix,
+                                  scheme.prolongation_matrix_1d,
+                                  evaluation_data_fine.begin() +
+                                    c * n_scalar_dofs_fine,
+                                  evaluation_data_coarse.begin() +
+                                    c * n_scalar_dofs_coarse);
 
                 if (scheme.prolongation_matrix_1d.size() > 0)
                   cell_transfer.run(cell_restrictor);
@@ -3296,11 +3300,13 @@ MGTwoLevelTransfer<dim, LinearAlgebra::distributed::Vector<Number>>::
           if (needs_interpolation)
             for (int c = n_components - 1; c >= 0; --c)
               {
-                CellRestrictor<dim, VectorizedArrayType> cell_restrictor(
-                  scheme.restriction_matrix,
-                  scheme.restriction_matrix_1d,
-                  evaluation_data_fine.begin() + c * n_scalar_dofs_fine,
-                  evaluation_data_coarse.begin() + c * n_scalar_dofs_coarse);
+                CellRestrictor<dim, double, VectorizedArrayType>
+                  cell_restrictor(scheme.restriction_matrix,
+                                  scheme.restriction_matrix_1d,
+                                  evaluation_data_fine.begin() +
+                                    c * n_scalar_dofs_fine,
+                                  evaluation_data_coarse.begin() +
+                                    c * n_scalar_dofs_coarse);
 
                 if (scheme.restriction_matrix_1d.size() > 0)
                   cell_transfer.run(cell_restrictor);


### PR DESCRIPTION
As discussed in #16719, the extension of the matrix-free multigrid infrastructure to complex numbers (which is a desirable goal) necessitates some different choices. Thanks to #15207 and #15217, that switch is rather easy from a software point of view, as the tensor product evaluators already support that setting.

This pull request might not be the final step, because storing the tabulated shape functions as `double` entries is not the right choice when the work arrays are of type `VectorizedArray<float>`, but the compiler generates surprisingly good code nonetheless, keeping it to a single conversion `double` -> `float` in reading the array. On AMD CPUs I tested, I can hardly see performance impact of the additional instructions, albeit I believe that Intel CPUs (up to Ice Lake at least) will lead to half the throughput on the inner kernel because the conversion/broadcast from register is on the same execution units as the arithmetic work; on the other hand, the vector access is a much larger share of the instructions in this scenario. So given the background, I am happy to pull this to our main branch right away, and find a better solution later when we have made a step towards complex numbers elsewhere. The idea for the better solution is to select `float` as the number type when there is `VectorizedArray<float>` or `VectorizedArray<std::complex<float>>` or `std::complex<VectorizedArray<float>>` or something like that, and `double` in the other cases. But that can wait, as surprising as this might sound coming from me.