### PR TITLE
Close the correct constraints objects.

### DIFF
--- a/tests/multigrid-global-coarsening/mg_transfer_a_01.cc
+++ b/tests/multigrid-global-coarsening/mg_transfer_a_01.cc
@@ -103,7 +103,7 @@ do_test(const FiniteElement<dim> &fe_fine, const FiniteElement<dim> &fe_coarse)
 
   AffineConstraints<Number> constraint_fine;
   DoFTools::make_hanging_node_constraints(dof_handler_fine, constraint_fine);
-  constraint_coarse.close();
+  constraint_fine.close();
 
   // setup transfer operator
   MGTwoLevelTransfer<dim, LinearAlgebra::distributed::Vector<Number>> transfer;

--- a/tests/multigrid-global-coarsening/mg_transfer_a_02.cc
+++ b/tests/multigrid-global-coarsening/mg_transfer_a_02.cc
@@ -90,7 +90,7 @@ do_test(const FiniteElement<dim> &fe_fine, const FiniteElement<dim> &fe_coarse)
 
   AffineConstraints<Number> constraint_fine;
   DoFTools::make_hanging_node_constraints(dof_handler_fine, constraint_fine);
-  constraint_coarse.close();
+  constraint_fine.close();
 
   // setup transfer operator
   MGTwoLevelTransfer<dim, LinearAlgebra::distributed::Vector<Number>> transfer;

--- a/tests/multigrid-global-coarsening/mg_transfer_a_03.cc
+++ b/tests/multigrid-global-coarsening/mg_transfer_a_03.cc
@@ -99,7 +99,7 @@ do_test(const FiniteElement<dim> &fe_fine, const FiniteElement<dim> &fe_coarse)
 
   AffineConstraints<Number> constraint_fine;
   DoFTools::make_hanging_node_constraints(dof_handler_fine, constraint_fine);
-  constraint_coarse.close();
+  constraint_fine.close();
 
   // setup transfer operator
   MGTwoLevelTransfer<dim, LinearAlgebra::distributed::Vector<Number>> transfer;

--- a/tests/multigrid-global-coarsening/mg_transfer_a_04.cc
+++ b/tests/multigrid-global-coarsening/mg_transfer_a_04.cc
@@ -83,7 +83,7 @@ do_test(const FiniteElement<dim> &fe_fine, const FiniteElement<dim> &fe_coarse)
 
   AffineConstraints<Number> constraint_fine;
   DoFTools::make_hanging_node_constraints(dof_handler_fine, constraint_fine);
-  constraint_coarse.close();
+  constraint_fine.close();
 
   // setup transfer operator
   MGTwoLevelTransfer<dim, LinearAlgebra::distributed::Vector<Number>> transfer;


### PR DESCRIPTION
This is a copy-paste error from several lines up where we did indeed have to close `constraint_coarse`, but here we work on `constraint_fine`. This mistake is then copy-pasted into three more tests :-)

Note that the various `mg_transfer_p_*` tests are all correct. It's only the `mg_transfer_a_*` tests that have the problem. 