### PR TITLE
In an internal function called from a virtual function, do not call virtual functions.

### DIFF
--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -766,9 +766,10 @@ SphericalManifold<dim, spacedim>::do_get_new_points(
     {
       for (unsigned int row = 0; row < weight_rows; ++row)
         new_points[row] =
-          get_intermediate_point(surrounding_points[0],
-                                 surrounding_points[1],
-                                 weights[row * weight_columns + 1]);
+          SphericalManifold<dim, spacedim>::get_intermediate_point(
+            surrounding_points[0],
+            surrounding_points[1],
+            weights[row * weight_columns + 1]);
       return;
     }
 


### PR DESCRIPTION
Finding this bug took probably on the order of half a week of actual work, for the addition of 34 characters. That probably comes out to $100+ for each character. My many failed attempts at figuring out what is going on are chronicled in https://github.com/geodynamics/aspect/issues/5421 and https://github.com/geodynamics/aspect/pull/5577 .

The root cause here is that in ASPECT, we derive a class from `SphericalManifold` in which we create a sphere with topography (the Earth) by stacking operations in the same way as we often do with manifolds: You just concatenate operations to form the pull back and push forward operations. As a consequence, the overriding functions then call back into the functions in the base class. Then, our implementation of functions in `SphericalManifold` calls internal functions that do certain things and, in at least one case, further delegate to yet another function -- which is `virtual`! So we end back up in user space, apply our own secondary transformation one more time, and then call back into the `SphericalManifold` class. This is not desirable. The internal function only calls the other function for convenience, and so it needs to call the one in `SphericalManifold`, not the one in user space.

This patch fixes this. I cannot express how relieved I am to have fixed this.

(For the purposes of cross linking: We have had trouble with this class before. See #16242 and what is linked from there.)