### PR TITLE
SolverGMRES: Fix loop bound for orthogonalization

### DIFF
--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -930,10 +930,11 @@ namespace internal
     {
       Assert(dim > 0, ExcInternalError());
 
-      for (unsigned int i = 0; i < dim; ++i)
+      for (unsigned int i = 0; i < dim - 1; ++i)
         vv.add(-h(i), orthogonal_vectors[i]);
 
-      return std::sqrt(vv.add_and_dot(-h(dim), orthogonal_vectors[dim], vv));
+      return std::sqrt(
+        vv.add_and_dot(-h(dim - 1), orthogonal_vectors[dim - 1], vv));
     }
 
 
@@ -1366,6 +1367,8 @@ SolverGMRES<VectorType>::solve(const MatrixType         &A,
     }
 
   bool re_orthogonalize = additional_data.force_re_orthogonalization;
+  // reset this vector to the right size
+  h.reinit(n_tmp_vectors - 1);
 
   ///////////////////////////////////////////////////////////////////////////
   // outer iteration: loop until we either reach convergence or the maximum
@@ -1373,9 +1376,6 @@ SolverGMRES<VectorType>::solve(const MatrixType         &A,
   // restart
   do
     {
-      // reset this vector to the right size
-      h.reinit(n_tmp_vectors - 1);
-
       double rho = 0.0;
 
       if (left_precondition)
@@ -1577,7 +1577,7 @@ SolverGMRES<VectorType>::solve(const MatrixType         &A,
             p, dim, h, tmp_vectors, true);
           preconditioner.vmult(v, p);
           x.add(1., v);
-        };
+        }
       // end of outer iteration. restart if no convergence and the number of
       // iterations is not exceeded
     }

--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -1367,8 +1367,6 @@ SolverGMRES<VectorType>::solve(const MatrixType         &A,
     }
 
   bool re_orthogonalize = additional_data.force_re_orthogonalization;
-  // reset this vector to the right size
-  h.reinit(n_tmp_vectors - 1);
 
   ///////////////////////////////////////////////////////////////////////////
   // outer iteration: loop until we either reach convergence or the maximum

--- a/tests/lac/solver_gmres_02.cc
+++ b/tests/lac/solver_gmres_02.cc
@@ -1,0 +1,137 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2022 - 2023 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+// Check the path of SolverGMRES with dealii::Vector and
+// LinearAlgebra::OrthogonalizationStrategy::classical_gram_schmidt. Apart
+// from the vector type, this test case is the same as solver_gmres_01.
+
+
+#include <deal.II/lac/block_vector.h>
+#include <deal.II/lac/diagonal_matrix.h>
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/solver_gmres.h>
+#include <deal.II/lac/vector.h>
+
+#include "../tests.h"
+
+
+struct MyDiagonalMatrix
+{
+  MyDiagonalMatrix(const Vector<double> &diagonal)
+    : diagonal(diagonal)
+  {}
+
+  void
+  vmult(Vector<double> &dst, const Vector<double> &src) const
+  {
+    dst = src;
+    dst.scale(diagonal);
+  }
+
+  void
+  vmult(BlockVector<double> &dst, const BlockVector<double> &src) const
+  {
+    dst = src;
+    for (unsigned int b = 0; b < src.n_blocks(); ++b)
+      dst.block(0).scale(diagonal);
+  }
+
+  unsigned int
+  m() const
+  {
+    return diagonal.size();
+  }
+
+  const Vector<double> &diagonal;
+};
+
+
+
+SolverControl::State
+monitor_norm(const unsigned int iteration,
+             const double       check_value,
+             const Vector<double> &)
+{
+  deallog << "   estimated residual at iteration " << iteration << ": "
+          << check_value << std::endl;
+  return SolverControl::success;
+}
+
+
+
+SolverControl::State
+monitor_norm_block(const unsigned int iteration,
+                   const double       check_value,
+                   const BlockVector<double> &)
+{
+  deallog << "   estimated residual at iteration " << iteration << ": "
+          << check_value << std::endl;
+  return SolverControl::success;
+}
+
+
+int
+main()
+{
+  initlog();
+
+  // Create diagonal matrix with entries between 1 and 30
+  Vector<double> matrix_entries_(30);
+  matrix_entries_ = 1.0;
+  MyDiagonalMatrix unit_matrix(matrix_entries_);
+
+  Vector<double> matrix_entries(unit_matrix.m());
+  for (unsigned int i = 0; i < unit_matrix.m(); ++i)
+    matrix_entries(i) = i + 1;
+  MyDiagonalMatrix matrix(matrix_entries);
+
+  Vector<double> rhs(unit_matrix.m());
+  Vector<double> sol(unit_matrix.m());
+  rhs = 1.;
+
+  {
+    deallog << "Solve with PreconditionIdentity: " << std::endl;
+    SolverControl                               control(40, 1e-4);
+    SolverGMRES<Vector<double>>::AdditionalData data3(8);
+    data3.orthogonalization_strategy =
+      LinearAlgebra::OrthogonalizationStrategy::classical_gram_schmidt;
+    SolverGMRES<Vector<double>> solver(control, data3);
+    solver.connect(&monitor_norm);
+    solver.solve(matrix, sol, rhs, PreconditionIdentity());
+
+    deallog << "Solve with diagonal preconditioner: " << std::endl;
+    sol = 0;
+    solver.solve(matrix, sol, rhs, unit_matrix);
+  }
+
+  {
+    BlockVector<double> rhs_(1);
+    BlockVector<double> sol_(1);
+    rhs_.block(0) = rhs;
+    sol_.block(0) = sol;
+
+    deallog << "Solve with PreconditionIdentity: " << std::endl;
+    SolverControl                                    control(40, 1e-4);
+    SolverGMRES<BlockVector<double>>::AdditionalData data3(8);
+    data3.orthogonalization_strategy =
+      LinearAlgebra::OrthogonalizationStrategy::classical_gram_schmidt;
+    SolverGMRES<BlockVector<double>> solver(control, data3);
+    solver.connect(&monitor_norm_block);
+    solver.solve(matrix, sol_, rhs_, PreconditionIdentity());
+
+    deallog << "Solve with diagonal preconditioner: " << std::endl;
+    sol_ = 0;
+    solver.solve(matrix, sol_, rhs_, unit_matrix);
+  }
+}

--- a/tests/lac/solver_gmres_02.output
+++ b/tests/lac/solver_gmres_02.output
@@ -1,0 +1,137 @@
+
+DEAL::Solve with PreconditionIdentity: 
+DEAL:GMRES::Starting value 5.47723
+DEAL:GMRES::   estimated residual at iteration 0: 5.47723
+DEAL:GMRES::   estimated residual at iteration 1: 2.67042
+DEAL:GMRES::   estimated residual at iteration 2: 1.70538
+DEAL:GMRES::   estimated residual at iteration 3: 1.20190
+DEAL:GMRES::   estimated residual at iteration 4: 0.884567
+DEAL:GMRES::   estimated residual at iteration 5: 0.662215
+DEAL:GMRES::   estimated residual at iteration 6: 0.496462
+DEAL:GMRES::   estimated residual at iteration 6: 0.496462
+DEAL:GMRES::   estimated residual at iteration 7: 0.419909
+DEAL:GMRES::   estimated residual at iteration 8: 0.339229
+DEAL:GMRES::   estimated residual at iteration 9: 0.260767
+DEAL:GMRES::   estimated residual at iteration 10: 0.189115
+DEAL:GMRES::   estimated residual at iteration 11: 0.126467
+DEAL:GMRES::   estimated residual at iteration 12: 0.0736025
+DEAL:GMRES::   estimated residual at iteration 12: 0.0736025
+DEAL:GMRES::   estimated residual at iteration 13: 0.0505275
+DEAL:GMRES::   estimated residual at iteration 14: 0.0360998
+DEAL:GMRES::   estimated residual at iteration 15: 0.0253697
+DEAL:GMRES::   estimated residual at iteration 16: 0.0184200
+DEAL:GMRES::   estimated residual at iteration 17: 0.0142333
+DEAL:GMRES::   estimated residual at iteration 18: 0.0116662
+DEAL:GMRES::   estimated residual at iteration 18: 0.0116662
+DEAL:GMRES::   estimated residual at iteration 19: 0.00989870
+DEAL:GMRES::   estimated residual at iteration 20: 0.00800703
+DEAL:GMRES::   estimated residual at iteration 21: 0.00604107
+DEAL:GMRES::   estimated residual at iteration 22: 0.00431736
+DEAL:GMRES::   estimated residual at iteration 23: 0.00304828
+DEAL:GMRES::   estimated residual at iteration 24: 0.00203679
+DEAL:GMRES::   estimated residual at iteration 24: 0.00203679
+DEAL:GMRES::   estimated residual at iteration 25: 0.00141669
+DEAL:GMRES::   estimated residual at iteration 26: 0.00101755
+DEAL:GMRES::   estimated residual at iteration 27: 0.000724887
+DEAL:GMRES::   estimated residual at iteration 28: 0.000535249
+DEAL:GMRES::   estimated residual at iteration 29: 0.000423665
+DEAL:GMRES::   estimated residual at iteration 30: 0.000358414
+DEAL:GMRES::   estimated residual at iteration 30: 0.000358414
+DEAL:GMRES::   estimated residual at iteration 31: 0.000307521
+DEAL:GMRES::   estimated residual at iteration 32: 0.000247031
+DEAL:GMRES::   estimated residual at iteration 33: 0.000183614
+DEAL:GMRES::   estimated residual at iteration 34: 0.000129847
+DEAL:GMRES::Convergence step 35 value 9.20930e-05
+DEAL:GMRES::   estimated residual at iteration 35: 9.20930e-05
+DEAL::Solve with diagonal preconditioner: 
+DEAL:GMRES::Starting value 5.47723
+DEAL:GMRES::   estimated residual at iteration 0: 5.47723
+DEAL:GMRES::   estimated residual at iteration 1: 2.67042
+DEAL:GMRES::   estimated residual at iteration 2: 1.70538
+DEAL:GMRES::   estimated residual at iteration 3: 1.20190
+DEAL:GMRES::   estimated residual at iteration 4: 0.884567
+DEAL:GMRES::   estimated residual at iteration 5: 0.662215
+DEAL:GMRES::   estimated residual at iteration 6: 0.496462
+DEAL:GMRES::   estimated residual at iteration 6: 0.496462
+DEAL:GMRES::   estimated residual at iteration 7: 0.419909
+DEAL:GMRES::   estimated residual at iteration 8: 0.339229
+DEAL:GMRES::   estimated residual at iteration 9: 0.260767
+DEAL:GMRES::   estimated residual at iteration 10: 0.189115
+DEAL:GMRES::   estimated residual at iteration 11: 0.126467
+DEAL:GMRES::   estimated residual at iteration 12: 0.0736025
+DEAL:GMRES::   estimated residual at iteration 12: 0.0736025
+DEAL:GMRES::   estimated residual at iteration 13: 0.0505275
+DEAL:GMRES::   estimated residual at iteration 14: 0.0360998
+DEAL:GMRES::   estimated residual at iteration 15: 0.0253697
+DEAL:GMRES::   estimated residual at iteration 16: 0.0184200
+DEAL:GMRES::   estimated residual at iteration 17: 0.0142333
+DEAL:GMRES::   estimated residual at iteration 18: 0.0116662
+DEAL:GMRES::   estimated residual at iteration 18: 0.0116662
+DEAL:GMRES::   estimated residual at iteration 19: 0.00989870
+DEAL:GMRES::   estimated residual at iteration 20: 0.00800703
+DEAL:GMRES::   estimated residual at iteration 21: 0.00604107
+DEAL:GMRES::   estimated residual at iteration 22: 0.00431736
+DEAL:GMRES::   estimated residual at iteration 23: 0.00304828
+DEAL:GMRES::   estimated residual at iteration 24: 0.00203679
+DEAL:GMRES::   estimated residual at iteration 24: 0.00203679
+DEAL:GMRES::   estimated residual at iteration 25: 0.00141669
+DEAL:GMRES::   estimated residual at iteration 26: 0.00101755
+DEAL:GMRES::   estimated residual at iteration 27: 0.000724887
+DEAL:GMRES::   estimated residual at iteration 28: 0.000535249
+DEAL:GMRES::   estimated residual at iteration 29: 0.000423665
+DEAL:GMRES::   estimated residual at iteration 30: 0.000358414
+DEAL:GMRES::   estimated residual at iteration 30: 0.000358414
+DEAL:GMRES::   estimated residual at iteration 31: 0.000307521
+DEAL:GMRES::   estimated residual at iteration 32: 0.000247031
+DEAL:GMRES::   estimated residual at iteration 33: 0.000183614
+DEAL:GMRES::   estimated residual at iteration 34: 0.000129847
+DEAL:GMRES::Convergence step 35 value 9.20930e-05
+DEAL:GMRES::   estimated residual at iteration 35: 9.20930e-05
+DEAL::Solve with PreconditionIdentity: 
+DEAL:GMRES::Starting value 9.20930e-05
+DEAL:GMRES::Convergence step 0 value 9.20930e-05
+DEAL:GMRES::   estimated residual at iteration 0: 9.20930e-05
+DEAL::Solve with diagonal preconditioner: 
+DEAL:GMRES::Starting value 5.47723
+DEAL:GMRES::   estimated residual at iteration 0: 5.47723
+DEAL:GMRES::   estimated residual at iteration 1: 2.67042
+DEAL:GMRES::   estimated residual at iteration 2: 1.70538
+DEAL:GMRES::   estimated residual at iteration 3: 1.20190
+DEAL:GMRES::   estimated residual at iteration 4: 0.884567
+DEAL:GMRES::   estimated residual at iteration 5: 0.662215
+DEAL:GMRES::   estimated residual at iteration 6: 0.496462
+DEAL:GMRES::   estimated residual at iteration 6: 0.496462
+DEAL:GMRES::   estimated residual at iteration 7: 0.419909
+DEAL:GMRES::   estimated residual at iteration 8: 0.339229
+DEAL:GMRES::   estimated residual at iteration 9: 0.260767
+DEAL:GMRES::   estimated residual at iteration 10: 0.189115
+DEAL:GMRES::   estimated residual at iteration 11: 0.126467
+DEAL:GMRES::   estimated residual at iteration 12: 0.0736025
+DEAL:GMRES::   estimated residual at iteration 12: 0.0736025
+DEAL:GMRES::   estimated residual at iteration 13: 0.0505275
+DEAL:GMRES::   estimated residual at iteration 14: 0.0360998
+DEAL:GMRES::   estimated residual at iteration 15: 0.0253697
+DEAL:GMRES::   estimated residual at iteration 16: 0.0184200
+DEAL:GMRES::   estimated residual at iteration 17: 0.0142333
+DEAL:GMRES::   estimated residual at iteration 18: 0.0116662
+DEAL:GMRES::   estimated residual at iteration 18: 0.0116662
+DEAL:GMRES::   estimated residual at iteration 19: 0.00989870
+DEAL:GMRES::   estimated residual at iteration 20: 0.00800703
+DEAL:GMRES::   estimated residual at iteration 21: 0.00604107
+DEAL:GMRES::   estimated residual at iteration 22: 0.00431736
+DEAL:GMRES::   estimated residual at iteration 23: 0.00304828
+DEAL:GMRES::   estimated residual at iteration 24: 0.00203679
+DEAL:GMRES::   estimated residual at iteration 24: 0.00203679
+DEAL:GMRES::   estimated residual at iteration 25: 0.00141669
+DEAL:GMRES::   estimated residual at iteration 26: 0.00101755
+DEAL:GMRES::   estimated residual at iteration 27: 0.000724887
+DEAL:GMRES::   estimated residual at iteration 28: 0.000535249
+DEAL:GMRES::   estimated residual at iteration 29: 0.000423665
+DEAL:GMRES::   estimated residual at iteration 30: 0.000358414
+DEAL:GMRES::   estimated residual at iteration 30: 0.000358414
+DEAL:GMRES::   estimated residual at iteration 31: 0.000307521
+DEAL:GMRES::   estimated residual at iteration 32: 0.000247031
+DEAL:GMRES::   estimated residual at iteration 33: 0.000183614
+DEAL:GMRES::   estimated residual at iteration 34: 0.000129847
+DEAL:GMRES::Convergence step 35 value 9.20930e-05
+DEAL:GMRES::   estimated residual at iteration 35: 9.20930e-05


### PR DESCRIPTION
When doing a seemingly innocent change in `SolverGMRES` (move a reinitialization out of a loop where it is done repeatedly), `SolverGMRES` would suddenly not converge any more. The problem can be traced back to the non-optimized case that was mistakenly updated the actual fix proposed in #14416.
The code would not be wrong before, because the move of the `reinit` in the loop always made sure that a value that was left uninitialized was actually 0, but that then means that we did work in vain.
I added a test that would have failed when just moving `h.reinit()` outside the loop (without also addressing the actual bug) to make sure these parts are better covered. I do not feel strongly if we want to keep `h.reinit()` inside the loop, but I think it is safer to expose the underlying assumption that we always add into `h` and do not use data that is not computed yet.