### PR TITLE
Update macro_check_compiler_setup.cmake to correct the conflict betwe…

### DIFF
--- a/cmake/macros/macro_check_compiler_setup.cmake
+++ b/cmake/macros/macro_check_compiler_setup.cmake
@@ -78,6 +78,11 @@ macro(check_compiler_setup _compiler_flags _linker_flags _var)
     endif()
   endforeach()
 
+  if( ("${_var}" MATCHES "DEAL_II_HAVE_USABLE_FLAGS_RELEASE") AND
+      (CMAKE_CXX_COMPILER_ID MATCHES "MSVC") )
+    set(CMAKE_TRY_COMPILE_CONFIGURATION Release)
+  endif()
+
   try_compile(
     ${_var}
     ${CMAKE_CURRENT_BINARY_DIR}/check_compiler_setup/${_var}


### PR DESCRIPTION
Update macro_check_compiler_setup.cmake to correct the conflict between /O2 and /RTC1 under the default DEBUG configuration.

Set the CMAKE_TRY_COMPILE_CONFIGURATION flag independently for the combination of MSVC and DEAL_II_HAVE_USABLE_FLAGS_RELEASE.

Fixed the problem originally posted by @gsegon in https://github.com/dealii/dealii/issues/1921#issuecomment-1615624858