### PR TITLE
dealii::Vector: Simplify reset of vector size

### DIFF
--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -1092,27 +1092,15 @@ Vector<Number>::do_reinit(const size_type new_size,
                           const bool      omit_zeroing_entries,
                           const bool      reset_partitioner)
 {
-  if (new_size <= size())
+  if (new_size == 0)
     {
-      if (new_size == 0)
-        {
-          values.clear();
-        }
-      else
-        {
-          values.resize_fast(new_size);
-          if (!omit_zeroing_entries)
-            values.fill();
-        }
+      values.clear();
     }
   else
     {
-      // otherwise size() < new_size and we must allocate
-      AlignedVector<Number> new_values;
-      new_values.resize_fast(new_size);
+      values.resize_fast(new_size);
       if (!omit_zeroing_entries)
-        new_values.fill();
-      new_values.swap(values);
+        values.fill();
     }
 
   if (reset_partitioner)

--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -1092,16 +1092,9 @@ Vector<Number>::do_reinit(const size_type new_size,
                           const bool      omit_zeroing_entries,
                           const bool      reset_partitioner)
 {
-  if (new_size == 0)
-    {
-      values.clear();
-    }
-  else
-    {
-      values.resize_fast(new_size);
-      if (!omit_zeroing_entries)
-        values.fill();
-    }
+  values.resize_fast(new_size);
+  if (!omit_zeroing_entries)
+    values.fill();
 
   if (reset_partitioner)
     maybe_reset_thread_partitioner();


### PR DESCRIPTION
According to our description https://github.com/dealii/dealii/blob/3ccc91fdd08c6f46fa3b5c87b61b99526bdcff43/include/deal.II/lac/vector.h#L308-L314 and the already existing implementation of the data element in https://github.com/dealii/dealii/blob/3ccc91fdd08c6f46fa3b5c87b61b99526bdcff43/include/deal.II/lac/vector.h#L1079-L1082 we should let `AlignedVector` do all work for re-allocation memory, rather than doing it on our own (and, in fact, wrong, because we re-allocate even though the capacity of the underlying storage would suffice).