### PR TITLE
Tensor product kernels: Remove unnecessary include files

### DIFF
--- a/include/deal.II/matrix_free/tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/tensor_product_kernels.h
@@ -19,8 +19,6 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/aligned_vector.h>
-#include <deal.II/base/ndarray.h>
-#include <deal.II/base/polynomial.h>
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/matrix_free/shape_info.h>

--- a/include/deal.II/matrix_free/tensor_product_point_kernels.h
+++ b/include/deal.II/matrix_free/tensor_product_point_kernels.h
@@ -18,7 +18,6 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/aligned_vector.h>
 #include <deal.II/base/ndarray.h>
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/utilities.h>


### PR DESCRIPTION
Follow-up to #16736: We do not need certain include files in either one or the other file for the `tensor_product_kernels.h` and `tensor_product_point_kernels.h`, respectively.