### PR TITLE
Add `spacedim` template parameter of DoFHandler

### DIFF
--- a/include/deal.II/numerics/vector_tools_interpolate.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.h
@@ -305,12 +305,12 @@ namespace VectorTools
    * The opposite operation, interpolation from a coarser to a finer mesh,
    * is implemented in the interpolate_to_finer_mesh() function.
    */
-  template <int dim, typename VectorType>
+  template <int dim, int spacedim, typename VectorType>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
   void interpolate_to_coarser_mesh(
-    const DoFHandler<dim> &dof_handler_fine,
-    const VectorType      &u_fine,
-    const DoFHandler<dim> &dof_handler_coarse,
+    const DoFHandler<dim, spacedim> &dof_handler_fine,
+    const VectorType                &u_fine,
+    const DoFHandler<dim, spacedim> &dof_handler_coarse,
     const AffineConstraints<typename VectorType::value_type>
                &constraints_coarse,
     VectorType &u_coarse);
@@ -338,12 +338,12 @@ namespace VectorTools
    * The opposite operation, interpolation from a finer to a coarser mesh,
    * is implemented in the interpolate_to_coarser_mesh() function.
    */
-  template <int dim, typename VectorType>
+  template <int dim, int spacedim, typename VectorType>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
   void interpolate_to_finer_mesh(
-    const DoFHandler<dim> &dof_handler_coarse,
-    const VectorType      &u_coarse,
-    const DoFHandler<dim> &dof_handler_fine,
+    const DoFHandler<dim, spacedim> &dof_handler_coarse,
+    const VectorType                &u_coarse,
+    const DoFHandler<dim, spacedim> &dof_handler_fine,
     const AffineConstraints<typename VectorType::value_type> &constraints_fine,
     VectorType                                               &u_fine);
 

--- a/include/deal.II/numerics/vector_tools_interpolate.templates.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.templates.h
@@ -1104,12 +1104,12 @@ namespace VectorTools
   } // namespace InterpolateBetweenMeshes
 
 
-  template <int dim, typename VectorType>
+  template <int dim, int spacedim, typename VectorType>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
   void interpolate_to_coarser_mesh(
-    const DoFHandler<dim> &dof_handler_fine,
-    const VectorType      &u_fine,
-    const DoFHandler<dim> &dof_handler_coarse,
+    const DoFHandler<dim, spacedim> &dof_handler_fine,
+    const VectorType                &u_fine,
+    const DoFHandler<dim, spacedim> &dof_handler_coarse,
     const AffineConstraints<typename VectorType::value_type>
                &constraints_coarse,
     VectorType &u_coarse)
@@ -1174,12 +1174,12 @@ namespace VectorTools
 
 
 
-  template <int dim, typename VectorType>
+  template <int dim, int spacedim, typename VectorType>
   DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<VectorType>)
   void interpolate_to_finer_mesh(
-    const DoFHandler<dim> &dof_handler_coarse,
-    const VectorType      &u_coarse,
-    const DoFHandler<dim> &dof_handler_fine,
+    const DoFHandler<dim, spacedim> &dof_handler_coarse,
+    const VectorType                &u_coarse,
+    const DoFHandler<dim, spacedim> &dof_handler_fine,
     const AffineConstraints<typename VectorType::value_type> &constraints_fine,
     VectorType                                               &u_fine)
   {


### PR DESCRIPTION
Since introduction of https://github.com/dealii/dealii/pull/16734, the CI of our developer code ran into a compile error:

```bash
In file included from /__w/MeltPoolDG-dev/MeltPoolDG-dev/source/heat/heat_transfer_operation.cpp:3:
/usr/local/include/deal.II/numerics/vector_tools_interpolate.h:311:25: error: wrong number of template arguments (1, should be 2)
  311 |     const DoFHandler<dim> &dof_handler_fine,
      |                         ^
In file included from /usr/local/include/deal.II/numerics/vector_tools_interpolate.h:20,
                 from /__w/MeltPoolDG-dev/MeltPoolDG-dev/source/heat/heat_transfer_operation.cpp:3:
```

This PR should fix this issue. @bangerth may I ask you to check whether this change is reasonable? The forward declaration of the `DoFHandler` class in `vector_tools_interpolate.h` is done here https://github.com/bangerth/dealii/blob/2cc871e19e6042524687811f6f3ad64b29744b11/include/deal.II/numerics/vector_tools_interpolate.h#L31-L33. 