### PR TITLE
SolverGMRES: Fix a test case

### DIFF
--- a/tests/petsc/deal_solver_03.cc
+++ b/tests/petsc/deal_solver_03.cc
@@ -64,9 +64,10 @@ main(int argc, char **argv)
     f = 1.;
     A.compress(VectorOperation::insert);
 
-    GrowingVectorMemory<PETScWrappers::MPI::Vector> mem;
-    SolverGMRES<PETScWrappers::MPI::Vector>         solver(control, mem);
-    PreconditionIdentity                            preconditioner;
+    GrowingVectorMemory<PETScWrappers::MPI::Vector>         mem;
+    SolverGMRES<PETScWrappers::MPI::Vector>::AdditionalData data(28);
+    SolverGMRES<PETScWrappers::MPI::Vector> solver(control, mem, data);
+    PreconditionIdentity                    preconditioner;
     deallog << "Solver type: " << typeid(solver).name() << std::endl;
     check_solver_within_range(solver.solve(A, u, f, preconditioner),
                               control.last_step(),

--- a/tests/trilinos/deal_solver_03.cc
+++ b/tests/trilinos/deal_solver_03.cc
@@ -74,15 +74,16 @@ main(int argc, char **argv)
     f.compress(VectorOperation::insert);
     u.compress(VectorOperation::insert);
 
-    GrowingVectorMemory<TrilinosWrappers::MPI::Vector> mem;
-    SolverGMRES<TrilinosWrappers::MPI::Vector>         solver(control, mem);
-    PreconditionIdentity                               preconditioner;
+    GrowingVectorMemory<TrilinosWrappers::MPI::Vector>         mem;
+    SolverGMRES<TrilinosWrappers::MPI::Vector>::AdditionalData data(28);
+    SolverGMRES<TrilinosWrappers::MPI::Vector> solver(control, mem, data);
+    PreconditionIdentity                       preconditioner;
 
     deallog << "Solver type: " << typeid(solver).name() << std::endl;
 
     check_solver_within_range(solver.solve(A, u, f, preconditioner),
                               control.last_step(),
-                              71,
+                              74,
                               76);
   }
 }

--- a/tests/trilinos/deal_solver_03.output
+++ b/tests/trilinos/deal_solver_03.output
@@ -1,4 +1,4 @@
 
 DEAL::Size 32 Unknowns 961
 DEAL::Solver type: N6dealii11SolverGMRESINS_16TrilinosWrappers3MPI6VectorEEE
-DEAL::Solver stopped within 71 - 76 iterations
+DEAL::Solver stopped within 74 - 76 iterations


### PR DESCRIPTION
This fixes #16756, i.e., the test failure https://cdash.dealii.org/test/15552375
It was introduced by #16745 where I changed the default size of the Arnoldi basis in the GMRES solver from 28 to 30 (by introducing a new parameter). For the test, we should avoid changing the iteration count, so I manually set the basis size to 28 here. While there, also make sure to make `trilinos/deal_solver_03.cc` uniform again with the Tpetra and PETSc tests of the same kind - in #16745, I mistakenly took the other path there and adjusted the number of iterations, while changing the basis size seems to be more appropriate for a long-term picture.