### PR TITLE
Let `hp::Refinement::choose_p_over_h()` communicate future FE indices and refinement flags on all types of parallel Triangulation.

### DIFF
--- a/doc/news/changes/minor/20240318Fehling
+++ b/doc/news/changes/minor/20240318Fehling
@@ -1,0 +1,6 @@
+Changed: hp::Refinement::choose_p_over_h() now communicates
+refinement flags and future FE indices on ghost cells for
+all types of parallel Triangulation objects to decide between
+p- and h-refinement.
+<br>
+(Marc Fehling, 2024/03/18)

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -48,10 +48,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-#ifdef DEAL_II_WITH_P4EST
-
 // Forward declarations
-#  ifndef DOXYGEN
+#ifndef DOXYGEN
 
 namespace FETools
 {
@@ -77,7 +75,28 @@ namespace parallel
     class TemporarilyMatchRefineFlags;
   }
 } // namespace parallel
-#  endif
+
+namespace internal
+{
+  namespace parallel
+  {
+    namespace distributed
+    {
+      namespace TriangulationImplementation
+      {
+        template <int dim, int spacedim>
+        void
+        exchange_refinement_flags(
+          dealii::parallel::distributed::Triangulation<dim, spacedim> &);
+      }
+    } // namespace distributed
+  }   // namespace parallel
+} // namespace internal
+#endif
+
+
+
+#ifdef DEAL_II_WITH_P4EST
 
 namespace parallel
 {
@@ -1094,6 +1113,7 @@ namespace parallel
 
 
 #endif
+
 
 
 namespace parallel

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -1782,7 +1782,7 @@ namespace internal
        * @note This function can only be called on direct parent cells, i.e.,
        * non-active cells whose children are all active.
        *
-       * @note On parallel::shared::Triangulation objects where sibling cells
+       * @note On parallel Triangulation objects where sibling cells
        * can be ghost cells, make sure that future FE indices have been properly
        * communicated with communicate_future_fe_indices() first. Otherwise,
        * results might differ on different processors. There is no check for

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -36,6 +36,59 @@
 DEAL_II_NAMESPACE_OPEN
 
 
+namespace internal
+{
+  namespace parallel
+  {
+    namespace distributed
+    {
+      namespace TriangulationImplementation
+      {
+        /**
+         * Communicate refinement flags on ghost cells from the owner of the
+         * cell.
+         *
+         * This is necessary to get consistent refinement, as mesh smoothing
+         * would undo some of the requested coarsening/refinement.
+         */
+        template <int dim, int spacedim>
+        void
+        exchange_refinement_flags(
+          dealii::parallel::distributed::Triangulation<dim, spacedim> &tria)
+        {
+          auto pack =
+            [](const typename Triangulation<dim, spacedim>::active_cell_iterator
+                 &cell) -> std::uint8_t {
+            if (cell->refine_flag_set())
+              return 1;
+            if (cell->coarsen_flag_set())
+              return 2;
+            return 0;
+          };
+
+          auto unpack =
+            [](const typename Triangulation<dim, spacedim>::active_cell_iterator
+                                  &cell,
+               const std::uint8_t &flag) -> void {
+            cell->clear_coarsen_flag();
+            cell->clear_refine_flag();
+            if (flag == 1)
+              cell->set_refine_flag();
+            else if (flag == 2)
+              cell->set_coarsen_flag();
+          };
+
+          GridTools::exchange_cell_data_to_ghosts<std::uint8_t>(tria,
+                                                                pack,
+                                                                unpack);
+        }
+      } // namespace TriangulationImplementation
+    }   // namespace distributed
+  }     // namespace parallel
+} // namespace internal
+
+
+
 #ifdef DEAL_II_WITH_P4EST
 
 namespace
@@ -562,40 +615,6 @@ namespace
         cell->clear_coarsen_flag();
         cell->set_subdomain_id(ghost_owner);
       }
-  }
-  template <int dim, int spacedim>
-  void
-  exchange_refinement_flags(Triangulation<dim, spacedim> &tria)
-  {
-    // Communicate refinement flags on ghost cells from the owner of the
-    // cell. This is necessary to get consistent refinement, as mesh
-    // smoothing would undo some of the requested coarsening/refinement.
-
-    auto pack =
-      [](
-        const typename Triangulation<dim, spacedim>::active_cell_iterator &cell)
-      -> std::uint8_t {
-      if (cell->refine_flag_set())
-        return 1;
-      if (cell->coarsen_flag_set())
-        return 2;
-      return 0;
-    };
-    auto unpack =
-      [](
-        const typename Triangulation<dim, spacedim>::active_cell_iterator &cell,
-        const std::uint8_t &flag) -> void {
-      cell->clear_coarsen_flag();
-      cell->clear_refine_flag();
-      if (flag == 1)
-        cell->set_refine_flag();
-      else if (flag == 2)
-        cell->set_coarsen_flag();
-    };
-
-    GridTools::exchange_cell_data_to_ghosts<std::uint8_t,
-                                            Triangulation<dim, spacedim>>(
-      tria, pack, unpack);
   }
 
 #  ifdef P4EST_SEARCH_LOCAL
@@ -2776,7 +2795,8 @@ namespace parallel
       // First exchange coarsen/refinement flags on ghost cells. After this
       // collective communication call all flags on ghost cells match the
       // flags set by the user on the owning rank.
-      exchange_refinement_flags(*this);
+      dealii::internal::parallel::distributed::TriangulationImplementation::
+        exchange_refinement_flags(*this);
 
       // Now we can call the sequential version to apply mesh smoothing and
       // other modifications:

--- a/source/distributed/tria.inst.in
+++ b/source/distributed/tria.inst.in
@@ -29,4 +29,23 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
 #endif
       \}
     \}
+
+    namespace internal
+    \{
+      namespace parallel
+      \{
+        namespace distributed
+        \{
+          namespace TriangulationImplementation
+          \{
+#if deal_II_dimension <= deal_II_space_dimension
+            template void
+            exchange_refinement_flags(
+              dealii::parallel::distributed::
+                Triangulation<deal_II_dimension, deal_II_space_dimension> &);
+#endif
+          \}
+        \}
+      \}
+    \}
   }

--- a/tests/mpi/hp_choose_p_over_h.cc
+++ b/tests/mpi/hp_choose_p_over_h.cc
@@ -1,0 +1,103 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2019 - 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+
+// verify hp::Refinement::choose_p_over_h() on strongly distributed meshes
+
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/filtered_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/hp/fe_collection.h>
+#include <deal.II/hp/refinement.h>
+
+#include "../tests.h"
+
+
+
+void
+test()
+{
+  constexpr unsigned int dim = 2;
+
+  // Setup distributed triangulation.
+  parallel::distributed::Triangulation<dim> tr(MPI_COMM_WORLD);
+  GridGenerator::hyper_cube(tr, -1, 1);
+  tr.refine_global(1);
+
+  tr.begin_active()->set_refine_flag();
+  tr.execute_coarsening_and_refinement();
+
+  // For two dimensions in this particular scenario, each quadrant in the
+  // coordinate system will be assigned to single MPI process.
+  //
+  // See also the corresponding output file and this ASCII sketch on how p4est
+  // decided to partition this mesh with four MPI processes.
+  //
+  //  +---+---+
+  //  |   |   |
+  //  | 3 | 3 |
+  //  |   |   |
+  //  +-+-+---+
+  //  |1|1|   |
+  //  +-+-+ 2 |
+  //  |1|1|   |
+  //  +-+-+---+
+
+  // Set h-coarsen and p-refinement flags on the coarser cells.
+  DoFHandler<dim> dh(tr);
+  for (const auto &cell : dh.active_cell_iterators_on_level(1) |
+                            IteratorFilters::LocallyOwnedCell())
+    {
+      cell->set_coarsen_flag();
+      cell->set_future_fe_index(1);
+    }
+
+  // Setup FEs.
+  hp::FECollection<dim> fes;
+  for (unsigned int d = 1; d <= 2; ++d)
+    fes.push_back(FE_Q<dim>(d));
+  dh.distribute_dofs(fes);
+
+  // Check whether choose_p_over_h() finishes.
+  // (It triggered an assertion in the past.)
+  hp::Refinement::choose_p_over_h(dh);
+
+  // Check the new flags.
+  for (const auto &cell :
+       dh.active_cell_iterators() | IteratorFilters::LocallyOwnedCell())
+    deallog << cell->id().to_string()
+            << ": future_fe=" << cell->future_fe_index()
+            << " coarsen=" << cell->coarsen_flag_set() << std::endl;
+
+  deallog << "OK" << std::endl;
+}
+
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPILogInitAll                    log;
+
+  test();
+}

--- a/tests/mpi/hp_choose_p_over_h.with_p4est=true.mpirun=4.output
+++ b/tests/mpi/hp_choose_p_over_h.with_p4est=true.mpirun=4.output
@@ -1,0 +1,18 @@
+
+DEAL:0::OK
+
+DEAL:1::0_2:00: future_fe=0 coarsen=0
+DEAL:1::0_2:01: future_fe=0 coarsen=0
+DEAL:1::0_2:02: future_fe=0 coarsen=0
+DEAL:1::0_2:03: future_fe=0 coarsen=0
+DEAL:1::OK
+
+
+DEAL:2::0_1:1: future_fe=1 coarsen=0
+DEAL:2::OK
+
+
+DEAL:3::0_1:2: future_fe=1 coarsen=0
+DEAL:3::0_1:3: future_fe=1 coarsen=0
+DEAL:3::OK
+


### PR DESCRIPTION
In #11980 I've added the following assertion in the code. It was meant for parallel shared Triangulation as some error occurred with that type of Triangulation. I didn't notice it on other parallel Triangulation types at that time, assuming that sibling cells always belonged to the same subdomain for parallel distributed Triangulations.
https://github.com/dealii/dealii/blob/b80d0be4af61de21a4d6d5e02bb87a115556af8c/source/hp/refinement.cc#L752-L759

In my recent hp-related experiments, this assertion triggers when using parallel distributed Triangulation objects. So was my assumption wrong, or did that behavior change recently?

EDIT: A bit of context: I used checkpointing to run the particular scenario that triggered the assertion. I noticed for some time now that the mesh is partitioned slightly different after recovering from a checkpoint. After loading a mesh with the same number of processes, it is possible that siblings won't belong to the same subdomain, while they previously have been when the checkpoint was created. But I need to do more research on this hypothesis.

Anyways, this PR changes the behavior to communicate future FE indices on ghost cells for any type of parallel Triangulation.

I do not have a test yet, as I do not have a minimal example ready. I can try to come up with something if you think we need to.