### PR TITLE
FEEvaluation: Make sure that compiler can identify no-overlap of pointers

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -5052,19 +5052,21 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
   this->values_quad_submitted = true;
 #  endif
 
-  const std::size_t nqp = this->n_quadrature_points;
+  const std::size_t    nqp    = this->n_quadrature_points;
+  VectorizedArrayType *values = this->values_quad + q_point;
+
   if (this->cell_type <= internal::MatrixFreeFunctions::affine)
     {
       const VectorizedArrayType JxW =
         this->J_value[0] * this->quadrature_weights[q_point];
       for (unsigned int comp = 0; comp < n_components; ++comp)
-        this->values_quad[comp * nqp + q_point] = val_in[comp] * JxW;
+        values[comp * nqp] = val_in[comp] * JxW;
     }
   else
     {
       const VectorizedArrayType JxW = this->J_value[q_point];
       for (unsigned int comp = 0; comp < n_components; ++comp)
-        this->values_quad[comp * nqp + q_point] = val_in[comp] * JxW;
+        values[comp * nqp] = val_in[comp] * JxW;
     }
 }
 


### PR DESCRIPTION
By creating a local copy of a pointer, the compiler can be sure that the values written into the `values_quad` array do not overlap with the memory region that stores the actual pointer. Without this patch, the clang compiler would reload the start pointer to the array in every iteration of the loop over `comp`. (One could argue why this is the case, because those are different types that should not alias in principle, but I think it still makes sense to help the compiler here.)