### PR TITLE
Consistent periodic orientation encoding

### DIFF
--- a/doc/news/changes/incompatibilities/20240525DavidWells
+++ b/doc/news/changes/incompatibilities/20240525DavidWells
@@ -1,0 +1,8 @@
+Changed: GridTools::orthogonal_equality() now returns a
+std::optional<unsigned char> instead of a
+std::optional<std::bitset<3>>. As a consequence,
+PeriodicFacePair now also stores an unsigned char instead of
+a std::bitset<3> to represent the relative orientation of the first face to the
+second face.
+<br>
+(David Wells, 2024/05/25)

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -917,97 +917,9 @@ namespace DoFTools
    * of components of the finite element. This can be used to enforce
    * periodicity in only one variable in a system of equations.
    *
-   * @p face_orientation, @p face_flip and @p face_rotation describe an
-   * orientation that should be applied to @p face_1 prior to matching and
-   * constraining DoFs. This has nothing to do with the actual orientation of
-   * the given faces in their respective cells (which for boundary faces is
-   * always the default) but instead how you want to see periodicity to be
-   * enforced. For example, by using these flags, you can enforce a condition
-   * of the kind $u(0,y)=u(1,1-y)$ (i.e., a Moebius band) or in 3d a twisted
-   * torus. More precisely, these flags match local face DoF indices in the
-   * following manner:
-   *
-   * In 2d: <tt>face_orientation</tt> must always be <tt>true</tt>,
-   * <tt>face_rotation</tt> is always <tt>false</tt>, and face_flip has the
-   * meaning of <tt>line_flip</tt>; this implies e.g. for <tt>Q1</tt>:
-   *
-   * @code
-   *
-   * face_orientation = true, face_flip = false, face_rotation = false:
-   *
-   *     face1:           face2:
-   *
-   *     1                1
-   *     |        <-->    |
-   *     0                0
-   *
-   *     Resulting constraints: 0 <-> 0, 1 <-> 1
-   *
-   *     (Numbers denote local face DoF indices.)
-   *
-   *
-   * face_orientation = true, face_flip = true, face_rotation = false:
-   *
-   *     face1:           face2:
-   *
-   *     0                1
-   *     |        <-->    |
-   *     1                0
-   *
-   *     Resulting constraints: 1 <-> 0, 0 <-> 1
-   * @endcode
-   *
-   * And similarly for the case of Q1 in 3d:
-   *
-   * @code
-   *
-   * face_orientation = true, face_flip = false, face_rotation = false:
-   *
-   *     face1:           face2:
-   *
-   *     2 - 3            2 - 3
-   *     |   |    <-->    |   |
-   *     0 - 1            0 - 1
-   *
-   *     Resulting constraints: 0 <-> 0, 1 <-> 1, 2 <-> 2, 3 <-> 3
-   *
-   *     (Numbers denote local face DoF indices.)
-   *
-   *
-   * face_orientation = false, face_flip = false, face_rotation = false:
-   *
-   *     face1:           face2:
-   *
-   *     1 - 3            2 - 3
-   *     |   |    <-->    |   |
-   *     0 - 2            0 - 1
-   *
-   *     Resulting constraints: 0 <-> 0, 2 <-> 1, 1 <-> 2, 3 <-> 3
-   *
-   *
-   * face_orientation = true, face_flip = true, face_rotation = false:
-   *
-   *     face1:           face2:
-   *
-   *     1 - 0            2 - 3
-   *     |   |    <-->    |   |
-   *     3 - 2            0 - 1
-   *
-   *     Resulting constraints: 3 <-> 0, 2 <-> 1, 1 <-> 2, 0 <-> 3
-   *
-   *
-   * face_orientation = true, face_flip = false, face_rotation = true
-   *
-   *     face1:           face2:
-   *
-   *     0 - 2            2 - 3
-   *     |   |    <-->    |   |
-   *     1 - 3            0 - 1
-   *
-   *     Resulting constraints: 1 <-> 0, 3 <-> 1, 0 <-> 2, 2 <-> 3
-   *
-   * and any combination of that...
-   * @endcode
+   * Here, @p combined_orientation is the relative orientation of @p face_1 with
+   * respect to @p face_2. This is typically computed by
+   * GridTools::orthogonal_equality().
    *
    * Optionally a matrix @p matrix along with a std::vector @p
    * first_vector_components can be specified that describes how DoFs on @p
@@ -1045,10 +957,9 @@ namespace DoFTools
     const FaceIterator                             &face_1,
     const std_cxx20::type_identity_t<FaceIterator> &face_2,
     AffineConstraints<number>                      &constraints,
-    const ComponentMask                            &component_mask   = {},
-    const bool                                      face_orientation = true,
-    const bool                                      face_flip        = false,
-    const bool                                      face_rotation    = false,
+    const ComponentMask                            &component_mask = {},
+    const unsigned char                             combined_orientation =
+      ReferenceCell::default_combined_face_orientation(),
     const FullMatrix<double>        &matrix = FullMatrix<double>(),
     const std::vector<unsigned int> &first_vector_components =
       std::vector<unsigned int>(),
@@ -1198,9 +1109,7 @@ namespace DoFTools
       const FullMatrix<double>                       &transformation,
       AffineConstraints<number>                      &affine_constraints,
       const ComponentMask                            &component_mask,
-      const bool                                      face_orientation,
-      const bool                                      face_flip,
-      const bool                                      face_rotation,
+      const unsigned char                             combined_orientation,
       const number                                    periodicity_factor,
       const unsigned int level = numbers::invalid_unsigned_int);
   } // namespace internal

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -58,7 +58,6 @@
 #  include <boost/iostreams/stream.hpp>
 #endif
 
-#include <bitset>
 #include <optional>
 #include <set>
 
@@ -2336,9 +2335,9 @@ namespace GridTools
     /**
      * The relative orientation of the first face with respect to the second
      * face as described in orthogonal_equality() and
-     * DoFTools::make_periodicity_constraints() (and stored as a bitset).
+     * DoFTools::make_periodicity_constraints().
      */
-    std::bitset<3> orientation;
+    unsigned char orientation;
 
     /**
      * A @p dim $\times$ @p dim rotation matrix that describes how vector
@@ -2377,59 +2376,14 @@ namespace GridTools
    * identity matrix.
    *
    * If the matching was successful, the _relative_ orientation of @p face1 with
-   * respect to @p face2 is returned a std::optional<std::bitset<3>> object
-   * orientation in which
-   * @code
-   * orientation.value()[0] = face_orientation
-   * orientation.value()[1] = face_flip
-   * orientation.value()[2] = face_rotation
-   * @endcode
-   *
-   * In 2d <tt>face_orientation</tt> is always <tt>true</tt>,
-   * <tt>face_rotation</tt> is always <tt>false</tt>, and face_flip has the
-   * meaning of <tt>line_flip</tt>. More precisely in 3d:
-   *
-   * <tt>face_orientation</tt>: <tt>true</tt> if @p face1 and @p face2 have
-   * the same orientation. Otherwise, the vertex indices of @p face1 match the
-   * vertex indices of @p face2 in the following manner:
-   *
-   * @code
-   * face1:           face2:
-   *
-   * 1 - 3            2 - 3
-   * |   |    <-->    |   |
-   * 0 - 2            0 - 1
-   * @endcode
-   *
-   * <tt>face_flip</tt>: <tt>true</tt> if the matched vertices are rotated by
-   * 180 degrees:
-   *
-   * @code
-   * face1:           face2:
-   *
-   * 1 - 0            2 - 3
-   * |   |    <-->    |   |
-   * 3 - 2            0 - 1
-   * @endcode
-   *
-   * <tt>face_rotation</tt>: <tt>true</tt> if the matched vertices are rotated
-   * by 90 degrees counterclockwise:
-   *
-   * @code
-   * face1:           face2:
-   *
-   * 0 - 2            2 - 3
-   * |   |    <-->    |   |
-   * 1 - 3            0 - 1
-   * @endcode
-   *
-   * and any combination of that... More information on the topic can be found
-   * in the
+   * respect to @p face2 is returned a std::optional<unsigned char>, in which
+   * the stored value is the same orientation bit format used elsewhere in the
+   * library. More information on that topic can be found in the
    * @ref GlossFaceOrientation "glossary"
    * article.
    */
   template <typename FaceIterator>
-  std::optional<std::bitset<3>>
+  std::optional<unsigned char>
   orthogonal_equality(
     const FaceIterator                                           &face1,
     const FaceIterator                                           &face2,
@@ -2451,7 +2405,7 @@ namespace GridTools
    * with faces belonging to the second boundary with the help of
    * orthogonal_equality().
    *
-   * The bitset that is returned inside of PeriodicFacePair encodes the
+   * The unsigned char that is returned inside of PeriodicFacePair encodes the
    * _relative_ orientation of the first face with respect to the second face,
    * see the documentation of orthogonal_equality() for further details.
    *

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -712,6 +712,14 @@ public:
                                   const unsigned char       orientation) const;
 
   /**
+   * Return the inverse orientation. This is the value such that calling
+   * permute_by_combined_orientation() with <tt>o</tt> and then calling it again
+   * with get_inverse_combined_orientation(o) is the identity operation.
+   */
+  unsigned char
+  get_inverse_combined_orientation(const unsigned char orientation) const;
+
+  /**
    * Return a vector of faces a given @p vertex_index belongs to.
    */
   ArrayView<const unsigned int>
@@ -2971,6 +2979,43 @@ ReferenceCell::permute_by_combined_orientation(
     }
 
   return {};
+}
+
+
+
+inline unsigned char
+ReferenceCell::get_inverse_combined_orientation(
+  const unsigned char orientation) const
+{
+  switch (this->kind)
+    {
+      case ReferenceCells::Vertex:
+        // Things are always default-oriented in 1D
+        return orientation;
+
+      case ReferenceCells::Line:
+        // the 1d orientations are the identity and a flip: i.e., the identity
+        // and an involutory mapping
+        return orientation;
+
+      case ReferenceCells::Triangle:
+        {
+          AssertIndexRange(orientation, 6);
+          constexpr std::array<unsigned char, 6> inverses{{0, 1, 2, 5, 4, 3}};
+          return inverses[orientation];
+        }
+      case ReferenceCells::Quadrilateral:
+        {
+          AssertIndexRange(orientation, 8);
+          constexpr std::array<unsigned char, 8> inverses{
+            {0, 1, 2, 7, 4, 5, 6, 3}};
+          return inverses[orientation];
+        }
+      default:
+        DEAL_II_NOT_IMPLEMENTED();
+    }
+
+  return std::numeric_limits<unsigned char>::max();
 }
 
 

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -3649,7 +3649,7 @@ public:
    */
   const std::map<
     std::pair<cell_iterator, unsigned int>,
-    std::pair<std::pair<cell_iterator, unsigned int>, std::bitset<3>>> &
+    std::pair<std::pair<cell_iterator, unsigned int>, unsigned char>> &
   get_periodic_face_map() const;
 
   /**
@@ -4089,7 +4089,7 @@ private:
    * face pairs.
    */
   std::map<std::pair<cell_iterator, unsigned int>,
-           std::pair<std::pair<cell_iterator, unsigned int>, std::bitset<3>>>
+           std::pair<std::pair<cell_iterator, unsigned int>, unsigned char>>
     periodic_face_map;
 
   /**

--- a/include/deal.II/matrix_free/face_setup_internal.h
+++ b/include/deal.II/matrix_free/face_setup_internal.h
@@ -1004,21 +1004,16 @@ namespace internal
       // special treatment of periodic boundaries
       if (dim == 3 && cell->has_periodic_neighbor(face_no))
         {
-          const unsigned int exterior_face_orientation =
-            !cell->get_triangulation()
-               .get_periodic_face_map()
-               .at({cell, face_no})
-               .second[0] +
-            2 * cell->get_triangulation()
-                  .get_periodic_face_map()
-                  .at({cell, face_no})
-                  .second[1] +
-            4 * cell->get_triangulation()
-                  .get_periodic_face_map()
-                  .at({cell, face_no})
-                  .second[2];
+          unsigned char exterior_face_orientation = cell->get_triangulation()
+                                                      .get_periodic_face_map()
+                                                      .at({cell, face_no})
+                                                      .second;
+          const auto [orientation, rotation, flip] =
+            ::dealii::internal::split_face_orientation(
+              exterior_face_orientation);
 
-          info.face_orientation = exterior_face_orientation;
+          info.face_orientation =
+            (orientation ? 0u : 1u) + 2 * flip + 4 * rotation;
 
           return info;
         }

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -3779,6 +3779,7 @@ namespace parallel
       // the level subdomain ids correct in the multigrid case
       dealii::Triangulation<dim, spacedim>::add_periodicity(periodicity_vector);
 
+      const auto reference_cell      = ReferenceCells::get_hypercube<dim>();
       const auto face_reference_cell = ReferenceCells::get_hypercube<dim - 1>();
       for (const auto &face_pair : periodicity_vector)
         {
@@ -3864,13 +3865,10 @@ namespace parallel
                   face_idx_list[lower_idx],
                   orientation);
               const unsigned int second_dealii_idx_on_cell =
-                GeometryInfo<dim>::face_to_cell_vertices(
+                reference_cell.face_to_cell_vertices(
                   face_idx_list[higher_idx],
                   second_dealii_idx_on_face,
-                  cell_list[higher_idx]->face_orientation(
-                    face_idx_list[higher_idx]),
-                  cell_list[higher_idx]->face_flip(face_idx_list[higher_idx]),
-                  cell_list[higher_idx]->face_rotation(
+                  cell_list[higher_idx]->combined_face_orientation(
                     face_idx_list[higher_idx]));
               // map back to p4est
               const unsigned int second_p4est_idx_on_face =

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -3780,14 +3780,15 @@ namespace DoFTools
             // face_flip has to be toggled if face_rotation is true: In case of
             // inverted orientation, nothing has to be done.
 
+            const auto face_reference_cell = face_1->reference_cell();
             internal::set_periodicity_constraints(
               face_1,
               face_2,
               transformation,
               affine_constraints,
               component_mask,
-              ::dealii::internal::combined_face_orientation(
-                orientation, rotation, orientation ? rotation ^ flip : flip),
+              face_reference_cell.get_inverse_combined_orientation(
+                combined_orientation),
               periodicity_factor);
           }
       }

--- a/source/dofs/dof_tools_constraints.inst.in
+++ b/source/dofs/dof_tools_constraints.inst.in
@@ -23,9 +23,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
                        deal_II_space_dimension>::face_iterator &,
       AffineConstraints<S> &,
       const ComponentMask &,
-      bool,
-      bool,
-      bool,
+      const unsigned char,
       const FullMatrix<double> &,
       const std::vector<unsigned int> &,
       const S);
@@ -38,9 +36,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
       const FullMatrix<double>                                 &transformation,
       AffineConstraints<S> &affine_constraints,
       const ComponentMask  &component_mask,
-      const bool            face_orientation,
-      const bool            face_flip,
-      const bool            face_rotation,
+      const unsigned char   combined_orientation,
       const S               periodicity_factor,
       const unsigned int    level);
 
@@ -52,9 +48,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
       const FullMatrix<double> &transformation,
       AffineConstraints<S>     &affine_constraints,
       const ComponentMask      &component_mask,
-      const bool                face_orientation,
-      const bool                face_flip,
-      const bool                face_rotation,
+      const unsigned char       combined_orientation,
       const S                   periodicity_factor,
       const unsigned int        level);
 #endif

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -4826,16 +4826,16 @@ namespace GridTools
           const auto face_a = pair.first.first->face(pair.first.second);
           const auto face_b =
             pair.second.first.first->face(pair.second.first.second);
-          const auto mask = pair.second.second;
+          const unsigned char combined_orientation = pair.second.second;
 
           AssertDimension(face_a->n_vertices(), face_b->n_vertices());
 
           // loop over all vertices on face
           for (unsigned int i = 0; i < face_a->n_vertices(); ++i)
             {
-              const bool face_orientation = mask[0];
-              const bool face_flip        = mask[1];
-              const bool face_rotation    = mask[2];
+              const auto [face_orientation, face_rotation, face_flip] =
+                ::dealii::internal::split_face_orientation(
+                  combined_orientation);
 
               // find the right local vertex index for the second face
               unsigned int j = 0;

--- a/source/grid/grid_tools_dof_handlers.cc
+++ b/source/grid/grid_tools_dof_handlers.cc
@@ -2163,7 +2163,7 @@ namespace GridTools
             const CellIterator cell2     = it2->first;
             const unsigned int face_idx1 = it1->second;
             const unsigned int face_idx2 = it2->second;
-            if (const std::optional<std::bitset<3>> orientation =
+            if (const std::optional<unsigned char> orientation =
                   GridTools::orthogonal_equality(cell1->face(face_idx1),
                                                  cell2->face(face_idx2),
                                                  direction,
@@ -2419,7 +2419,7 @@ namespace GridTools
 
 
   template <typename FaceIterator>
-  std::optional<std::bitset<3>>
+  std::optional<unsigned char>
   orthogonal_equality(
     const FaceIterator                                           &face1,
     const FaceIterator                                           &face2,
@@ -2472,7 +2472,7 @@ namespace GridTools
                             face1_vertices.cbegin() + face1->n_vertices()),
             make_array_view(face2_vertices.cbegin(),
                             face2_vertices.cbegin() + face2->n_vertices()));
-        std::bitset<3> orientation;
+        unsigned char orientation = std::numeric_limits<unsigned char>::max();
         if (dim == 1)
           {
             // In 1D things are always well-oriented
@@ -2489,20 +2489,11 @@ namespace GridTools
         else
           {
             Assert(dim == 3, ExcInternalError());
-            // There are two differences between the orientation implementation
-            // used in the periodicity code and that used in ReferenceCell:
-            //
-            // 1. The bitset is unpacked as (orientation, flip, rotation)
-            //    instead of the standard (orientation, rotation, flip).
-            //
-            // 2. The 90 degree rotations are always clockwise, so the third and
-            //    seventh (in the combined orientation) are switched.
-            //
-            // Both translations are encoded in this table. This matches
-            // OrientationLookupTable<3> which was present in previous revisions
-            // of this file.
+            // Unlike the standard orientation, here the 90 degree rotations are
+            // always clockwise, so the third and seventh (in the combined
+            // orientation) are switched.
             constexpr std::array<unsigned int, 8> translation{
-              {0, 1, 4, 7, 2, 3, 6, 5}};
+              {0, 1, 2, 7, 4, 5, 6, 3}};
             AssertIndexRange(combined_orientation, translation.size());
             orientation =
               translation[std::min<unsigned int>(combined_orientation, 7u)];

--- a/source/grid/grid_tools_dof_handlers.cc
+++ b/source/grid/grid_tools_dof_handlers.cc
@@ -2463,43 +2463,16 @@ namespace GridTools
           }
       }
 
-    // And finally, a lookup to determine the ordering bitmask:
     if (face2_vertices_set.empty())
       {
-        const auto combined_orientation =
-          face1->reference_cell().get_combined_orientation(
-            make_array_view(face1_vertices.cbegin(),
-                            face1_vertices.cbegin() + face1->n_vertices()),
-            make_array_view(face2_vertices.cbegin(),
-                            face2_vertices.cbegin() + face2->n_vertices()));
-        unsigned char orientation = std::numeric_limits<unsigned char>::max();
-        if (dim == 1)
-          {
-            // In 1D things are always well-oriented
-            orientation = ReferenceCell::default_combined_face_orientation();
-          }
-        // The original version of this doesn't use the standardized orientation
-        // value so we have to do an additional translation step
-        else if (dim == 2)
-          {
-            // In 2D only the first bit (orientation) is set
-            AssertIndexRange(combined_orientation, 2);
-            orientation = combined_orientation;
-          }
-        else
-          {
-            Assert(dim == 3, ExcInternalError());
-            // Unlike the standard orientation, here the 90 degree rotations are
-            // always clockwise, so the third and seventh (in the combined
-            // orientation) are switched.
-            constexpr std::array<unsigned int, 8> translation{
-              {0, 1, 2, 7, 4, 5, 6, 3}};
-            AssertIndexRange(combined_orientation, translation.size());
-            orientation =
-              translation[std::min<unsigned int>(combined_orientation, 7u)];
-          }
-
-        return std::make_optional(orientation);
+        const auto reference_cell = face1->reference_cell();
+        // We want the relative orientation of face1 with respect to face2 so
+        // the order is flipped here:
+        return std::make_optional(reference_cell.get_combined_orientation(
+          make_array_view(face2_vertices.cbegin(),
+                          face2_vertices.cbegin() + face2->n_vertices()),
+          make_array_view(face1_vertices.cbegin(),
+                          face1_vertices.cbegin() + face1->n_vertices())));
       }
     else
       return std::nullopt;

--- a/source/grid/grid_tools_dof_handlers.inst.in
+++ b/source/grid/grid_tools_dof_handlers.inst.in
@@ -249,7 +249,7 @@ for (X : SEQUENTIAL_TRIANGULATION_AND_DOFHANDLER;
     namespace GridTools
     \{
 
-      template std::optional<std::bitset<3>>
+      template std::optional<unsigned char>
       orthogonal_equality<X::active_face_iterator>(
         const X::active_face_iterator &,
         const X::active_face_iterator &,
@@ -257,7 +257,7 @@ for (X : SEQUENTIAL_TRIANGULATION_AND_DOFHANDLER;
         const Tensor<1, deal_II_space_dimension> &,
         const FullMatrix<double> &);
 
-      template std::optional<std::bitset<3>>
+      template std::optional<unsigned char>
       orthogonal_equality<X::face_iterator>(
         const X::face_iterator &,
         const X::face_iterator &,

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -16025,21 +16025,16 @@ void Triangulation<dim, spacedim>::update_periodic_face_map()
                                                           it->orientation,
                                                           periodic_face_map);
 
+      const auto face_reference_cell =
+        it->cell[0]->reference_cell().face_reference_cell(it->face_idx[0]);
       // for the other way, we need to invert the orientation
-      unsigned char inverted_orientation;
-      {
-        auto [orientation, rotation, flip] =
-          internal::split_face_orientation(it->orientation);
-        flip = orientation ? rotation ^ flip : flip;
-        inverted_orientation =
-          internal::combined_face_orientation(orientation, rotation, flip);
-      }
-      update_periodic_face_map_recursively<dim, spacedim>(it->cell[1],
-                                                          it->cell[0],
-                                                          it->face_idx[1],
-                                                          it->face_idx[0],
-                                                          inverted_orientation,
-                                                          periodic_face_map);
+      update_periodic_face_map_recursively<dim, spacedim>(
+        it->cell[1],
+        it->cell[0],
+        it->face_idx[1],
+        it->face_idx[0],
+        face_reference_cell.get_inverse_combined_orientation(it->orientation),
+        periodic_face_map);
     }
 
   // check consistency

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -2801,13 +2801,17 @@ CellAccessor<dim, spacedim>::periodic_neighbor_child_on_subface(
    * number of children as i_subface.
    */
   AssertIndexRange(i_subface, nb_parent_face_it->n_children());
+
+  const auto [orientation, rotation, flip] =
+    internal::split_face_orientation(my_face_pair->second.second);
+
   unsigned int sub_neighbor_num =
     GeometryInfo<dim>::child_cell_on_face(parent_nb_it->refinement_case(),
                                           nb_face_num,
                                           i_subface,
-                                          my_face_pair->second.second[0],
-                                          my_face_pair->second.second[1],
-                                          my_face_pair->second.second[2],
+                                          orientation,
+                                          flip,
+                                          rotation,
                                           nb_parent_face_it->refinement_case());
   return parent_nb_it->child(sub_neighbor_num);
 }

--- a/source/multigrid/mg_constrained_dofs.cc
+++ b/source/multigrid/mg_constrained_dofs.cc
@@ -88,9 +88,7 @@ MGConstrainedDoFs::initialize(
         transformation,
         level_constraints[first_cell.first->level()],
         component_mask,
-        second_cell.second[0],
-        second_cell.second[1],
-        second_cell.second[2],
+        second_cell.second,
         periodicity_factor,
         first_cell.first->level());
     }

--- a/tests/bits/periodicity_09.cc
+++ b/tests/bits/periodicity_09.cc
@@ -72,9 +72,7 @@ test()
     (std::next(dof_handler.begin(0)))->face(1),
     cm,
     ComponentMask(),
-    true,
-    false,
-    false,
+    ReferenceCell::default_combined_face_orientation(),
     FullMatrix<double>(),
     std::vector<unsigned int>(),
     periodicity_factor);

--- a/tests/dofs/dof_tools_21.cc
+++ b/tests/dofs/dof_tools_21.cc
@@ -32,10 +32,9 @@
 
 // A simple test for
 //   DoFTools::
-//   make_periodicity_constraints (const FaceIterator       &,
-//                                 const FaceIterator       &,
-//                                 dealii::AffineConstraints<double> &,
-//                                 const std::vector<bool>  &)
+//   make_periodicity_constraints(const FaceIterator        &,
+//                                const FaceIterator        &,
+//                                AffineConstraints<double> &)
 //
 // We project an already periodic function onto the FE space of
 // periodic functions and store the resulting L2 difference

--- a/tests/dofs/dof_tools_21_b.cc
+++ b/tests/dofs/dof_tools_21_b.cc
@@ -26,6 +26,7 @@
 
 #include <deal.II/lac/affine_constraints.h>
 
+#include <bitset>
 #include <iostream>
 #include <utility>
 
@@ -34,11 +35,11 @@
 //
 // Test
 //   DoFTools::
-//   make_periodicity_constraints (const FaceIterator       &,
-//                                 const FaceIterator       &,
-//                                 dealii::AffineConstraints<double> &,
-//                                 const std::vector<bool>  &,
-//                                 bool, bool, bool)
+//   make_periodicity_constraints(const FaceIterator       &,
+//                                const FaceIterator       &,
+//                                dealii::AffineConstraints<double> &,
+//                                const std::vector<bool>  &,
+//                                unsigned char)
 // for correct behavior on non standard oriented meshes.
 //
 
@@ -320,10 +321,13 @@ print_matching(DoFHandler<dim, spacedim> &dof_handler,
     face_1, face_2, dim == 2 ? 1 : 2, Tensor<1, spacedim>());
   AssertThrow(orientation, ExcInternalError());
   const auto o = *orientation;
-  deallog << "Orientation: " << o[0] << o[1] << o[2] << std::endl;
+  // Preserve old output by printing a bitset and also using the old
+  // (orientation, flip, rotation) format
+  std::bitset<3> bo(o);
+  deallog << "Orientation: " << bo[0] << bo[2] << bo[1] << std::endl;
 
   DoFTools::make_periodicity_constraints(
-    face_1, face_2, constraint_matrix, velocity_mask, o[0], o[1], o[2]);
+    face_1, face_2, constraint_matrix, velocity_mask, o);
   deallog << "Matching:" << std::endl;
   constraint_matrix.print(deallog.get_file_stream());
   constraint_matrix.close();
@@ -332,13 +336,8 @@ print_matching(DoFHandler<dim, spacedim> &dof_handler,
     face_2, face_1, dim == 2 ? 1 : 2, Tensor<1, spacedim>());
   AssertThrow(reverse_orientation, ExcInternalError());
   const auto ro = *reverse_orientation;
-  DoFTools::make_periodicity_constraints(face_2,
-                                         face_1,
-                                         constraint_matrix_reverse,
-                                         velocity_mask,
-                                         ro[0],
-                                         ro[1],
-                                         ro[2]);
+  DoFTools::make_periodicity_constraints(
+    face_2, face_1, constraint_matrix_reverse, velocity_mask, ro);
   deallog << "Reverse Matching:" << std::endl;
   constraint_matrix_reverse.print(deallog.get_file_stream());
   constraint_matrix_reverse.close();

--- a/tests/dofs/dof_tools_21_b.cc
+++ b/tests/dofs/dof_tools_21_b.cc
@@ -35,10 +35,10 @@
 //
 // Test
 //   DoFTools::
-//   make_periodicity_constraints(const FaceIterator       &,
-//                                const FaceIterator       &,
-//                                dealii::AffineConstraints<double> &,
-//                                const std::vector<bool>  &,
+//   make_periodicity_constraints(const FaceIterator        &,
+//                                const FaceIterator        &,
+//                                AffineConstraints<double> &,
+//                                const ComponentMask       &,
 //                                unsigned char)
 // for correct behavior on non standard oriented meshes.
 //
@@ -237,7 +237,7 @@ generate_grid(Triangulation<3> &triangulation, int orientation)
 
 /*
  * Print out all face DoFs and support points as well as the actual
- * matching via make_periodicity_constraints
+ * matching via make_periodicity_constraints()
  */
 template <int dim, int spacedim>
 void

--- a/tests/dofs/dof_tools_21_b_x.cc
+++ b/tests/dofs/dof_tools_21_b_x.cc
@@ -15,11 +15,11 @@
 //
 // Test
 //   DoFTools::
-//   make_periodicity_constraints (const FaceIterator       &,
-//                                 const FaceIterator       &,
-//                                 dealii::AffineConstraints<double> &,
-//                                 const std::vector<bool>  &,
-//                                 bool, bool, bool)
+//   make_periodicity_constraints(const FaceIterator        &,
+//                                const FaceIterator        &,
+//                                AffineConstraints<double> &,
+//                                const ComponentMask       &,
+//                                unsigned char)
 // for correct behavior on non standard oriented meshes.
 //
 // a redux of why the 21_b test failed starting in r29525. in essence,
@@ -157,7 +157,7 @@ generate_grid(Triangulation<2, 3> &triangulation)
 
 /*
  * Print out all face DoFs and support points as well as the actual
- * matching via make_periodicity_constraints
+ * matching via make_periodicity_constraints()
  */
 template <int dim, int spacedim>
 void
@@ -196,7 +196,11 @@ print_matching(DoFHandler<dim, spacedim> &dof_handler)
             << std::endl;
 
   DoFTools::make_periodicity_constraints(
-    face_1, face_2, constraint_matrix, ComponentMask(), 0u);
+    face_1,
+    face_2,
+    constraint_matrix,
+    ComponentMask(),
+    ReferenceCell::reversed_combined_line_orientation());
   constraint_matrix.print(deallog.get_file_stream());
   constraint_matrix.close();
   deallog << "Matching:" << std::endl;

--- a/tests/dofs/dof_tools_21_b_x.cc
+++ b/tests/dofs/dof_tools_21_b_x.cc
@@ -195,19 +195,8 @@ print_matching(DoFHandler<dim, spacedim> &dof_handler)
     deallog << dofs_2[i] << " is located at " << support_points[dofs_2[i]]
             << std::endl;
 
-
-  std::bitset<3> orientation;
-  orientation[0] = 0;
-  orientation[1] = 0;
-  orientation[2] = 0;
-
-  DoFTools::make_periodicity_constraints(face_1,
-                                         face_2,
-                                         constraint_matrix,
-                                         ComponentMask(),
-                                         orientation[0],
-                                         orientation[1],
-                                         orientation[2]);
+  DoFTools::make_periodicity_constraints(
+    face_1, face_2, constraint_matrix, ComponentMask(), 0u);
   constraint_matrix.print(deallog.get_file_stream());
   constraint_matrix.close();
   deallog << "Matching:" << std::endl;

--- a/tests/dofs/dof_tools_21_b_x_q3.cc
+++ b/tests/dofs/dof_tools_21_b_x_q3.cc
@@ -229,19 +229,8 @@ print_matching(DoFHandler<dim, spacedim> &dof_handler)
     deallog << dofs_2[i] << " is located at " << support_points[dofs_2[i]]
             << std::endl;
 
-
-  std::bitset<3> orientation;
-  orientation[0] = 0;
-  orientation[1] = 0;
-  orientation[2] = 0;
-
-  DoFTools::make_periodicity_constraints(face_1,
-                                         face_2,
-                                         constraint_matrix,
-                                         ComponentMask(),
-                                         orientation[0],
-                                         orientation[1],
-                                         orientation[2]);
+  DoFTools::make_periodicity_constraints(
+    face_1, face_2, constraint_matrix, ComponentMask(), 0u);
   constraint_matrix.print(deallog.get_file_stream());
   constraint_matrix.close();
   deallog << "Matching:" << std::endl;

--- a/tests/dofs/dof_tools_21_b_x_q3.cc
+++ b/tests/dofs/dof_tools_21_b_x_q3.cc
@@ -15,11 +15,11 @@
 //
 // Test
 //   DoFTools::
-//   make_periodicity_constraints (const FaceIterator       &,
-//                                 const FaceIterator       &,
-//                                 dealii::AffineConstraints<double> &,
-//                                 const std::vector<bool>  &,
-//                                 bool, bool, bool)
+//   make_periodicity_constraints(const FaceIterator        &,
+//                                const FaceIterator        &,
+//                                AffineConstraints<double> &,
+//                                const ComponentMask       &,
+//                                unsigned char)
 // for correct behavior on non standard oriented meshes.
 //
 // like _21_b_x but use a Q3 element. For this, the face_flip has a
@@ -191,7 +191,7 @@ generate_grid(Triangulation<2, 3> &triangulation)
 
 /*
  * Print out all face DoFs and support points as well as the actual
- * matching via make_periodicity_constraints
+ * matching via make_periodicity_constraints()
  */
 template <int dim, int spacedim>
 void
@@ -230,7 +230,11 @@ print_matching(DoFHandler<dim, spacedim> &dof_handler)
             << std::endl;
 
   DoFTools::make_periodicity_constraints(
-    face_1, face_2, constraint_matrix, ComponentMask(), 0u);
+    face_1,
+    face_2,
+    constraint_matrix,
+    ComponentMask(),
+    ReferenceCell::reversed_combined_line_orientation());
   constraint_matrix.print(deallog.get_file_stream());
   constraint_matrix.close();
   deallog << "Matching:" << std::endl;

--- a/tests/dofs/dof_tools_21_b_y.cc
+++ b/tests/dofs/dof_tools_21_b_y.cc
@@ -15,11 +15,11 @@
 //
 // Test
 //   DoFTools::
-//   make_periodicity_constraints (const FaceIterator       &,
-//                                 const FaceIterator       &,
-//                                 dealii::AffineConstraints<double> &,
-//                                 const std::vector<bool>  &,
-//                                 bool, bool, bool)
+//   make_periodicity_constraints(const FaceIterator        &,
+//                                const FaceIterator        &,
+//                                AffineConstraints<double> &,
+//                                const ComponentMask       &,
+//                                unsigned char)
 // for correct behavior on non standard oriented meshes.
 //
 // like _21_b_x, but with a once refined mesh
@@ -157,7 +157,7 @@ generate_grid(Triangulation<2, 3> &triangulation)
 
 /*
  * Print out all face DoFs and support points as well as the actual
- * matching via make_periodicity_constraints
+ * matching via make_periodicity_constraints()
  */
 template <int dim, int spacedim>
 void

--- a/tests/dofs/dof_tools_21_b_y.cc
+++ b/tests/dofs/dof_tools_21_b_y.cc
@@ -195,19 +195,8 @@ print_matching(DoFHandler<dim, spacedim> &dof_handler)
     deallog << dofs_2[i] << " is located at " << support_points[dofs_2[i]]
             << std::endl;
 
-
-  std::bitset<3> orientation;
-  orientation[0] = 0;
-  orientation[1] = 0;
-  orientation[2] = 0;
-
-  DoFTools::make_periodicity_constraints(face_1,
-                                         face_2,
-                                         constraint_matrix,
-                                         ComponentMask(),
-                                         orientation[0],
-                                         orientation[1],
-                                         orientation[2]);
+  DoFTools::make_periodicity_constraints(
+    face_1, face_2, constraint_matrix, ComponentMask(), 0u);
   constraint_matrix.print(deallog.get_file_stream());
   constraint_matrix.close();
   deallog << "Matching:" << std::endl;

--- a/tests/dofs/dof_tools_21_c.cc
+++ b/tests/dofs/dof_tools_21_c.cc
@@ -35,10 +35,10 @@
 //
 // Test
 //   DoFTools::
-//   make_periodicity_constraints(const FaceIterator       &,
-//                                const FaceIterator       &,
-//                                dealii::AffineConstraints<double> &,
-//                                const std::vector<bool>  &,
+//   make_periodicity_constraints(const FaceIterator        &,
+//                                const FaceIterator        &,
+//                                AffineConstraints<double> &,
+//                                const ComponentMask       &,
 //                                unsigned char)
 //
 // for correct behavior with hanging nodes. This is done by additionally
@@ -243,7 +243,7 @@ generate_grid(Triangulation<3> &triangulation, int orientation)
 
 /*
  * Print out all face DoFs and support points as well as the actual
- * matching via make_periodicity_constraints
+ * matching via make_periodicity_constraints()
  */
 template <int dim, int spacedim>
 void

--- a/tests/dofs/dof_tools_21_c.cc
+++ b/tests/dofs/dof_tools_21_c.cc
@@ -26,6 +26,7 @@
 
 #include <deal.II/lac/affine_constraints.h>
 
+#include <bitset>
 #include <iostream>
 #include <utility>
 
@@ -34,11 +35,11 @@
 //
 // Test
 //   DoFTools::
-//   make_periodicity_constraints (const FaceIterator       &,
-//                                 const FaceIterator       &,
-//                                 dealii::AffineConstraints<double> &,
-//                                 const std::vector<bool>  &,
-//                                 bool, bool, bool)
+//   make_periodicity_constraints(const FaceIterator       &,
+//                                const FaceIterator       &,
+//                                dealii::AffineConstraints<double> &,
+//                                const std::vector<bool>  &,
+//                                unsigned char)
 //
 // for correct behavior with hanging nodes. This is done by additionally
 // refining the second cube once. Test that constraining face_1 -> face_2
@@ -326,10 +327,13 @@ print_matching(DoFHandler<dim, spacedim> &dof_handler,
     face_1, face_2, dim == 2 ? 1 : 2, Tensor<1, spacedim>());
   AssertThrow(orientation, ExcInternalError());
   const auto o = *orientation;
-  deallog << "Orientation: " << o[0] << o[1] << o[2] << std::endl;
+  // Preserve old output by printing a bitset and also using the old
+  // (orientation, flip, rotation) format
+  std::bitset<3> bo(o);
+  deallog << "Orientation: " << bo[0] << bo[2] << bo[1] << std::endl;
 
   DoFTools::make_periodicity_constraints(
-    face_1, face_2, constraint_matrix, velocity_mask, o[0], o[1], o[2]);
+    face_1, face_2, constraint_matrix, velocity_mask, o);
   deallog << "Matching:" << std::endl;
   constraint_matrix.print(deallog.get_file_stream());
   constraint_matrix.close();
@@ -338,13 +342,8 @@ print_matching(DoFHandler<dim, spacedim> &dof_handler,
     face_2, face_1, dim == 2 ? 1 : 2, Tensor<1, spacedim>());
   AssertThrow(reverse_orientation, ExcInternalError());
   const auto ro = *reverse_orientation;
-  DoFTools::make_periodicity_constraints(face_2,
-                                         face_1,
-                                         constraint_matrix_reverse,
-                                         velocity_mask,
-                                         ro[0],
-                                         ro[1],
-                                         ro[2]);
+  DoFTools::make_periodicity_constraints(
+    face_2, face_1, constraint_matrix_reverse, velocity_mask, ro);
   deallog << "Reverse Matching:" << std::endl;
   constraint_matrix_reverse.print(deallog.get_file_stream());
   constraint_matrix_reverse.close();

--- a/tests/dofs/dof_tools_23.cc
+++ b/tests/dofs/dof_tools_23.cc
@@ -32,10 +32,9 @@
 
 // A simple test for
 //   DoFTools::
-//   make_periodicity_constraints (const FaceIterator       &,
-//                                 const FaceIterator       &,
-//                                 dealii::AffineConstraints<double> &,
-//                                 const std::vector<bool>  &)
+//   make_periodicity_constraints(const FaceIterator       &,
+//                                const FaceIterator       &,
+//                                AffineConstraints<std::complex<double>> &)
 //
 // We project an already periodic function onto the FE space of
 // periodic functions and store the resulting L2 difference

--- a/tests/dofs/dof_tools_periodic.h
+++ b/tests/dofs/dof_tools_periodic.h
@@ -15,7 +15,7 @@
 
 // Code duplication:
 // This is a copy of dof_tools_common.h with a slightly different mesh
-// generation to fit the assumptions made by make_periodicity_constraints
+// generation to fit the assumptions made by make_periodicity_constraints()
 
 #include <deal.II/base/logstream.h>
 

--- a/tests/grid/grid_tools_05.cc
+++ b/tests/grid/grid_tools_05.cc
@@ -154,9 +154,9 @@ generate_grid(Triangulation<3> &triangulation)
  */
 template <typename FaceIterator>
 void
-print_match(const FaceIterator   &face_1,
-            const FaceIterator   &face_2,
-            const std::bitset<3> &orientation)
+print_match(const FaceIterator &face_1,
+            const FaceIterator &face_2,
+            const unsigned char combined_orientation)
 {
   static const int dim = FaceIterator::AccessorType::dimension;
 
@@ -170,8 +170,10 @@ print_match(const FaceIterator   &face_1,
     deallog << " :: " << face_2->vertex(j);
   deallog << std::endl;
 
-  deallog << "orientation: " << orientation[0] << "  flip: " << orientation[1]
-          << "  rotation: " << orientation[2] << std::endl
+  const auto [orientation, rotation, flip] =
+    internal::split_face_orientation(combined_orientation);
+  deallog << "orientation: " << orientation << "  flip: " << flip
+          << "  rotation: " << rotation << std::endl
           << std::endl;
 }
 

--- a/tests/grid/grid_tools_06.cc
+++ b/tests/grid/grid_tools_06.cc
@@ -167,9 +167,9 @@ generate_grid(Triangulation<3> &triangulation, int orientation)
  */
 template <typename FaceIterator>
 void
-print_match(const FaceIterator   &face_1,
-            const FaceIterator   &face_2,
-            const std::bitset<3> &orientation)
+print_match(const FaceIterator &face_1,
+            const FaceIterator &face_2,
+            const unsigned char combined_orientation)
 {
   static const int dim = FaceIterator::AccessorType::dimension;
 
@@ -183,8 +183,10 @@ print_match(const FaceIterator   &face_1,
     deallog << " :: " << face_2->vertex(j);
   deallog << std::endl;
 
-  deallog << "orientation: " << orientation[0] << "  flip: " << orientation[1]
-          << "  rotation: " << orientation[2] << std::endl
+  const auto [orientation, rotation, flip] =
+    internal::split_face_orientation(combined_orientation);
+  deallog << "orientation: " << orientation << "  flip: " << flip
+          << "  rotation: " << rotation << std::endl
           << std::endl;
 }
 

--- a/tests/grid/periodicity_1d.cc
+++ b/tests/grid/periodicity_1d.cc
@@ -20,6 +20,7 @@
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/tria.h>
 
+#include <bitset>
 #include <string>
 
 #include "../tests.h"
@@ -50,8 +51,10 @@ check()
       deallog << periodic_faces[i].cell[0]->index() << ' '
               << periodic_faces[i].cell[1]->index() << ' '
               << periodic_faces[i].face_idx[0] << ' '
-              << periodic_faces[i].face_idx[1] << ' '
-              << periodic_faces[i].orientation << std::endl;
+              << periodic_faces[i].face_idx[1]
+              << ' '
+              // maintain old output by converting to a a bitset
+              << std::bitset<3>(periodic_faces[i].orientation) << std::endl;
     }
 }
 

--- a/tests/grid/reference_cell_reverse_orientation.cc
+++ b/tests/grid/reference_cell_reverse_orientation.cc
@@ -1,0 +1,126 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2024 - 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// Test that we get the correct reversed orientations (i.e., the composition of
+// permutations is the identity operation)
+
+#include <deal.II/grid/reference_cell.h>
+#include <deal.II/grid/tria_orientation.h>
+
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  deallog << "lines" << std::endl;
+  {
+    const std::array<unsigned char, 2> inverse_permutations{{0u, 1u}};
+
+    for (unsigned char o = 0; o < 2; ++o)
+      {
+        deallog << "o = " << int(o) << std::endl;
+        std::array<unsigned int, 2> vs{{0u, 1u}};
+
+        const auto result1 =
+          ReferenceCells::Line.permute_by_combined_orientation(
+            make_const_array_view(vs), o);
+
+        ArrayView<const unsigned int> view1(result1.data(), result1.size());
+        const auto                    result2 =
+          ReferenceCells::Line.permute_by_combined_orientation(
+            view1, inverse_permutations[o]);
+
+        for (const auto &v : result2)
+          deallog << "  " << v << std::endl;
+      }
+  }
+
+  deallog << "triangles" << std::endl;
+  {
+    const std::array<unsigned char, 6> inverse_permutations{
+      {0u, 1u, 2u, 5u, 4u, 3u}};
+
+    for (unsigned char o = 0; o < 6; ++o)
+      {
+        deallog << "o = " << int(o) << std::endl;
+        std::array<unsigned int, 3> vs{{0u, 1u, 2u}};
+
+        const auto result1 =
+          ReferenceCells::Triangle.permute_by_combined_orientation(
+            make_const_array_view(vs), o);
+
+        ArrayView<const unsigned int> view1(result1.data(), result1.size());
+        const auto                    result2 =
+          ReferenceCells::Triangle.permute_by_combined_orientation(
+            view1, inverse_permutations[o]);
+
+        for (const auto &v : result2)
+          deallog << "  " << v << std::endl;
+      }
+  }
+
+  deallog << "quadrilaterals" << std::endl;
+  {
+    const std::array<unsigned char, 8> inverse_permutations{
+      {0u, 1u, 2u, 7u, 4u, 5u, 6u, 3u}};
+
+    for (unsigned char o = 0; o < 8; ++o)
+      {
+        deallog << "o = " << int(o) << std::endl;
+        std::array<unsigned int, 4> vs{{0u, 1u, 2u, 3u}};
+
+        const auto result1 =
+          ReferenceCells::Quadrilateral.permute_by_combined_orientation(
+            make_const_array_view(vs), o);
+
+        ArrayView<const unsigned int> view1(result1.data(), result1.size());
+        const auto                    result2 =
+          ReferenceCells::Quadrilateral.permute_by_combined_orientation(
+            view1, inverse_permutations[o]);
+
+        for (const auto &v : result2)
+          deallog << "  " << v << std::endl;
+      }
+  }
+
+  // Verify that the manual version created the same results.
+  deallog << "quadrilaterals (manual)" << std::endl;
+  {
+    for (unsigned char o = 0; o < 8; ++o)
+      {
+        deallog << "o = " << int(o) << std::endl;
+        std::array<unsigned int, 4> vs{{0u, 1u, 2u, 3u}};
+
+        const auto result1 =
+          ReferenceCells::Quadrilateral.permute_by_combined_orientation(
+            make_const_array_view(vs), o);
+
+        ArrayView<const unsigned int> view1(result1.data(), result1.size());
+
+        auto [orientation, rotation, flip] =
+          internal::split_face_orientation(o);
+        flip = orientation ? rotation ^ flip : flip;
+        const auto result2 =
+          ReferenceCells::Quadrilateral.permute_by_combined_orientation(
+            view1,
+            internal::combined_face_orientation(orientation, rotation, flip));
+
+        for (const auto &v : result2)
+          deallog << "  " << v << std::endl;
+      }
+  }
+}

--- a/tests/grid/reference_cell_reverse_orientation.output
+++ b/tests/grid/reference_cell_reverse_orientation.output
@@ -1,0 +1,115 @@
+
+DEAL::lines
+DEAL::o = 0
+DEAL::  0
+DEAL::  1
+DEAL::o = 1
+DEAL::  0
+DEAL::  1
+DEAL::triangles
+DEAL::o = 0
+DEAL::  0
+DEAL::  1
+DEAL::  2
+DEAL::o = 1
+DEAL::  0
+DEAL::  1
+DEAL::  2
+DEAL::o = 2
+DEAL::  0
+DEAL::  1
+DEAL::  2
+DEAL::o = 3
+DEAL::  0
+DEAL::  1
+DEAL::  2
+DEAL::o = 4
+DEAL::  0
+DEAL::  1
+DEAL::  2
+DEAL::o = 5
+DEAL::  0
+DEAL::  1
+DEAL::  2
+DEAL::quadrilaterals
+DEAL::o = 0
+DEAL::  0
+DEAL::  1
+DEAL::  2
+DEAL::  3
+DEAL::o = 1
+DEAL::  0
+DEAL::  1
+DEAL::  2
+DEAL::  3
+DEAL::o = 2
+DEAL::  0
+DEAL::  1
+DEAL::  2
+DEAL::  3
+DEAL::o = 3
+DEAL::  0
+DEAL::  1
+DEAL::  2
+DEAL::  3
+DEAL::o = 4
+DEAL::  0
+DEAL::  1
+DEAL::  2
+DEAL::  3
+DEAL::o = 5
+DEAL::  0
+DEAL::  1
+DEAL::  2
+DEAL::  3
+DEAL::o = 6
+DEAL::  0
+DEAL::  1
+DEAL::  2
+DEAL::  3
+DEAL::o = 7
+DEAL::  0
+DEAL::  1
+DEAL::  2
+DEAL::  3
+DEAL::quadrilaterals (manual)
+DEAL::o = 0
+DEAL::  0
+DEAL::  1
+DEAL::  2
+DEAL::  3
+DEAL::o = 1
+DEAL::  0
+DEAL::  1
+DEAL::  2
+DEAL::  3
+DEAL::o = 2
+DEAL::  0
+DEAL::  1
+DEAL::  2
+DEAL::  3
+DEAL::o = 3
+DEAL::  0
+DEAL::  1
+DEAL::  2
+DEAL::  3
+DEAL::o = 4
+DEAL::  0
+DEAL::  1
+DEAL::  2
+DEAL::  3
+DEAL::o = 5
+DEAL::  0
+DEAL::  1
+DEAL::  2
+DEAL::  3
+DEAL::o = 6
+DEAL::  0
+DEAL::  1
+DEAL::  2
+DEAL::  3
+DEAL::o = 7
+DEAL::  0
+DEAL::  1
+DEAL::  2
+DEAL::  3

--- a/tests/mpi/periodicity_04.cc
+++ b/tests/mpi/periodicity_04.cc
@@ -261,10 +261,10 @@ check(const unsigned int orientation, bool reverse)
 
   using CellFace =
     std::pair<typename Triangulation<dim>::cell_iterator, unsigned int>;
-  const typename std::map<CellFace, std::pair<CellFace, std::bitset<3>>>
+  const typename std::map<CellFace, std::pair<CellFace, unsigned char>>
     &face_map = triangulation.get_periodic_face_map();
   typename std::map<CellFace,
-                    std::pair<CellFace, std::bitset<3>>>::const_iterator it;
+                    std::pair<CellFace, unsigned char>>::const_iterator it;
   int sum_of_pairs_local = face_map.size();
   int sum_of_pairs_global;
   MPI_Allreduce(&sum_of_pairs_local,
@@ -295,7 +295,7 @@ check(const unsigned int orientation, bool reverse)
             {
               std::cout << "face_center_1: " << face_center_1 << std::endl;
               std::cout << "face_center_2: " << face_center_2 << std::endl;
-              typename std::map<CellFace, std::pair<CellFace, std::bitset<3>>>::
+              typename std::map<CellFace, std::pair<CellFace, unsigned char>>::
                 const_iterator it;
               for (it = triangulation.get_periodic_face_map().begin();
                    it != triangulation.get_periodic_face_map().end();


### PR DESCRIPTION
One major thing I'd like to get done before this release is the orientation cleanup. This set of patches completely removes our use of `std::bitset<3>` to encode orientation - that's one fewer orientation encoding in the library.