### PR TITLE
FEEvaluation: Ensure assertions in get_value/gradient are working

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -6636,12 +6636,12 @@ FEEvaluation<dim,
     }
 
 #  ifdef DEBUG
-  if (evaluation_flag_actual & EvaluationFlags::values)
-    this->values_quad_initialized = true;
-  if (evaluation_flag_actual & EvaluationFlags::gradients)
-    this->gradients_quad_initialized = true;
-  if (evaluation_flag_actual & EvaluationFlags::hessians)
-    this->hessians_quad_initialized = true;
+  this->values_quad_initialized =
+    evaluation_flag_actual & EvaluationFlags::values;
+  this->gradients_quad_initialized =
+    evaluation_flag_actual & EvaluationFlags::gradients;
+  this->hessians_quad_initialized =
+    evaluation_flag_actual & EvaluationFlags::hessians;
 #  endif
 }
 
@@ -7340,12 +7340,12 @@ FEFaceEvaluation<dim,
       n_components, evaluation_flag_actual, values_array, *this);
 
 #  ifdef DEBUG
-  if (evaluation_flag_actual & EvaluationFlags::values)
-    this->values_quad_initialized = true;
-  if (evaluation_flag_actual & EvaluationFlags::gradients)
-    this->gradients_quad_initialized = true;
-  if ((evaluation_flag_actual & EvaluationFlags::hessians) != 0u)
-    this->hessians_quad_initialized = true;
+  this->values_quad_initialized =
+    evaluation_flag_actual & EvaluationFlags::values;
+  this->gradients_quad_initialized =
+    evaluation_flag_actual & EvaluationFlags::gradients;
+  this->hessians_quad_initialized =
+    evaluation_flag_actual & EvaluationFlags::hessians;
 #  endif
 }
 
@@ -7474,12 +7474,12 @@ FEFaceEvaluation<dim,
       evaluate_in_face(n_components, evaluation_flag_actual, *this);
 
 #  ifdef DEBUG
-  if (evaluation_flag_actual & EvaluationFlags::values)
-    this->values_quad_initialized = true;
-  if (evaluation_flag_actual & EvaluationFlags::gradients)
-    this->gradients_quad_initialized = true;
-  if ((evaluation_flag_actual & EvaluationFlags::hessians) != 0u)
-    this->hessians_quad_initialized = true;
+  this->values_quad_initialized =
+    evaluation_flag_actual & EvaluationFlags::values;
+  this->gradients_quad_initialized =
+    evaluation_flag_actual & EvaluationFlags::gradients;
+  this->hessians_quad_initialized =
+    evaluation_flag_actual & EvaluationFlags::hessians;
 #  endif
 }
 
@@ -7821,12 +7821,10 @@ FEFaceEvaluation<dim,
     }
 
 #  ifdef DEBUG
-  if (evaluation_flag & EvaluationFlags::values)
-    this->values_quad_initialized = true;
-  if (evaluation_flag & EvaluationFlags::gradients)
-    this->gradients_quad_initialized = true;
-  if (evaluation_flag & EvaluationFlags::hessians)
-    this->hessians_quad_initialized = true;
+  this->values_quad_initialized = evaluation_flag & EvaluationFlags::values;
+  this->gradients_quad_initialized =
+    evaluation_flag & EvaluationFlags::gradients;
+  this->hessians_quad_initialized = evaluation_flag & EvaluationFlags::hessians;
 #  endif
 }
 


### PR DESCRIPTION
While working on #16787, I was trapped by the fact that `FEEvaluationBase::get_value/get_gradient` etc. did not warn when not called without a prior evaluation flag passed to `FEEvaluation::evaluate`. The reason is that the function https://github.com/dealii/dealii/blob/f6081edf3194bc74d3884a06a2efbc27549fc42f/include/deal.II/matrix_free/evaluation_kernels.h#L194-L198 calls https://github.com/dealii/dealii/blob/f6081edf3194bc74d3884a06a2efbc27549fc42f/include/deal.II/matrix_free/evaluation_kernels.h#L276-L277 which in turn calls https://github.com/dealii/dealii/blob/f6081edf3194bc74d3884a06a2efbc27549fc42f/include/deal.II/matrix_free/fe_evaluation_data.h#L1410-L1414 The latter is needed because we allow users to manually fill the arrays, so we must set the fields to initialized state. This has existed for some year now (I think late 2021, but I would have to look it up), and is of course undesired because errors do not get detected.