### PR TITLE
Remove/deprecate Tensor::begin/end_raw().

### DIFF
--- a/doc/news/changes/incompatibilities/20240326Bangerth
+++ b/doc/news/changes/incompatibilities/20240326Bangerth
@@ -1,0 +1,14 @@
+Removed: The Tensor<0,dim> template had functions `begin_raw()` and
+`end_raw()`, which had been deprecated for a couple of releases
+already. They have been removed now.
+<br>
+Furthermore, the corresponding functions for the general
+Tensor<rank,dim> template have been deprecated. They can still be used
+for the time being, but only for the specific case `rank==1`. This is
+because the underlying assumption of these functions is that tensors
+store their elements in memory in a contiguous fashion, but that is
+only true for the case `rank==1`. Similarly, the `make_array_view()`
+function that takes tensors as input has been marked as deprecated,
+and can only be used for rank-1 tensors from now on.
+<br>
+(Wolfgang Bangerth, 2024/03/26)

--- a/include/deal.II/base/array_view.h
+++ b/include/deal.II/base/array_view.h
@@ -1055,6 +1055,11 @@ template <int rank, int dim, typename Number>
 DEAL_II_DEPRECATED inline ArrayView<const Number>
 make_array_view(const Tensor<rank, dim, Number> &tensor)
 {
+  static_assert(rank == 1,
+                "This function is only available for rank-1 tensors "
+                "because higher-rank tensors may not store their elements "
+                "in a contiguous array.");
+
   return make_array_view(tensor.begin_raw(), tensor.end_raw());
 }
 
@@ -1085,6 +1090,11 @@ template <int rank, int dim, typename Number>
 DEAL_II_DEPRECATED inline ArrayView<Number>
 make_array_view(Tensor<rank, dim, Number> &tensor)
 {
+  static_assert(rank == 1,
+                "This function is only available for rank-1 tensors "
+                "because higher-rank tensors may not store their elements "
+                "in a contiguous array.");
+
   return make_array_view(tensor.begin_raw(), tensor.end_raw());
 }
 

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -192,55 +192,6 @@ public:
 #endif
 
   /**
-   * Return a pointer to the first element of the underlying storage.
-   *
-   * @deprecated This function suggests that the elements of a Tensor
-   *   object are stored as a contiguous array, but this is not in fact true
-   *   and one should not pretend that this so. As a consequence, this function
-   *   is deprecated.
-   */
-  DEAL_II_DEPRECATED
-  Number *
-  begin_raw();
-
-  /**
-   * Return a const pointer to the first element of the underlying storage.
-   *
-   * @deprecated This function suggests that the elements of a Tensor
-   *   object are stored as a contiguous array, but this is not in fact true
-   *   and one should not pretend that this so. As a consequence, this function
-   *   is deprecated.
-   */
-  DEAL_II_DEPRECATED
-  const Number *
-  begin_raw() const;
-
-  /**
-   * Return a pointer to the element past the end of the underlying storage.
-   *
-   * @deprecated This function suggests that the elements of a Tensor
-   *   object are stored as a contiguous array, but this is not in fact true
-   *   and one should not pretend that this so. As a consequence, this function
-   *   is deprecated.
-   */
-  DEAL_II_DEPRECATED
-  Number *
-  end_raw();
-
-  /**
-   * Return a const pointer to the element past the end of the underlying
-   * storage.
-   *
-   * @deprecated This function suggests that the elements of a Tensor
-   *   object are stored as a contiguous array, but this is not in fact true
-   *   and one should not pretend that this so. As a consequence, this function
-   *   is deprecated.
-   */
-  DEAL_II_DEPRECATED
-  const Number *
-  end_raw() const;
-
-  /**
    * Return a reference to the encapsulated Number object. Since rank-0
    * tensors are scalars, this is a natural operation.
    *
@@ -668,24 +619,28 @@ public:
   /**
    * Return a pointer to the first element of the underlying storage.
    */
+  DEAL_II_DEPRECATED_EARLY
   Number *
   begin_raw();
 
   /**
    * Return a const pointer to the first element of the underlying storage.
    */
+  DEAL_II_DEPRECATED_EARLY
   const Number *
   begin_raw() const;
 
   /**
    * Return a pointer to the element past the end of the underlying storage.
    */
+  DEAL_II_DEPRECATED_EARLY
   Number *
   end_raw();
 
   /**
    * Return a pointer to the element past the end of the underlying storage.
    */
+  DEAL_II_DEPRECATED_EARLY
   const Number *
   end_raw() const;
 
@@ -1028,41 +983,6 @@ Tensor<0, dim, Number>::Tensor(Tensor<0, dim, Number> &&other) noexcept
   : value{std::move(other.value)}
 {}
 #  endif
-
-
-template <int dim, typename Number>
-inline Number *
-Tensor<0, dim, Number>::begin_raw()
-{
-  return std::addressof(value);
-}
-
-
-
-template <int dim, typename Number>
-inline const Number *
-Tensor<0, dim, Number>::begin_raw() const
-{
-  return std::addressof(value);
-}
-
-
-
-template <int dim, typename Number>
-inline Number *
-Tensor<0, dim, Number>::end_raw()
-{
-  return begin_raw() + n_independent_components;
-}
-
-
-
-template <int dim, typename Number>
-const Number *
-Tensor<0, dim, Number>::end_raw() const
-{
-  return begin_raw() + n_independent_components;
-}
 
 
 
@@ -1584,6 +1504,11 @@ template <int rank_, int dim, typename Number>
 inline Number *
 Tensor<rank_, dim, Number>::begin_raw()
 {
+  static_assert(rank_ == 1,
+                "This function is only available for rank-1 tensors "
+                "because higher-rank tensors may not store their elements "
+                "in a contiguous array.");
+
   return std::addressof(
     this->operator[](this->unrolled_to_component_indices(0)));
 }
@@ -1594,6 +1519,11 @@ template <int rank_, int dim, typename Number>
 inline const Number *
 Tensor<rank_, dim, Number>::begin_raw() const
 {
+  static_assert(rank_ == 1,
+                "This function is only available for rank-1 tensors "
+                "because higher-rank tensors may not store their elements "
+                "in a contiguous array.");
+
   return std::addressof(
     this->operator[](this->unrolled_to_component_indices(0)));
 }
@@ -1604,6 +1534,11 @@ template <int rank_, int dim, typename Number>
 inline Number *
 Tensor<rank_, dim, Number>::end_raw()
 {
+  static_assert(rank_ == 1,
+                "This function is only available for rank-1 tensors "
+                "because higher-rank tensors may not store their elements "
+                "in a contiguous array.");
+
   return begin_raw() + n_independent_components;
 }
 
@@ -1613,6 +1548,11 @@ template <int rank_, int dim, typename Number>
 inline const Number *
 Tensor<rank_, dim, Number>::end_raw() const
 {
+  static_assert(rank_ == 1,
+                "This function is only available for rank-1 tensors "
+                "because higher-rank tensors may not store their elements "
+                "in a contiguous array.");
+
   return begin_raw() + n_independent_components;
 }
 

--- a/include/deal.II/grid/grid_tools_geometry.h
+++ b/include/deal.II/grid/grid_tools_geometry.h
@@ -593,6 +593,8 @@ namespace GridTools
     }
   } // namespace internal
 
+
+
   template <typename Iterator>
   Point<Iterator::AccessorType::space_dimension>
   project_to_object(


### PR DESCRIPTION
The `Tensor<0,dim>::begin/end_raw()` functions were already moved to deprecated status (from deprecated-early) after the 2022 release. This patch removes them.

Unfortunately, we apparently missed the `Tensor<rank,dim>::begin/end_raw()` functions. They were not already marked as deprecated, and this patch marks them so. In addition, I'm also disabling them for the case `rank>1` where they can only work if we store data contiguously, which we currently do but which I want to change in #16465. As a consequence, I'm also disabling `make_array_view()` for that case -- that function is already deprecated.
