### PR TITLE
Fix CI using Kokkos+Cuda and CMake 3.28.4 and later

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -334,9 +334,11 @@ jobs:
             numdiff \
             openmpi-bin \
             libboost-all-dev
+    - uses: lukka/get-cmake@v3.28.4
     - name: info
       run: |
         mpicc -v
+        which cmake
         cmake --version
     - uses: actions/checkout@v4
       with:
@@ -428,9 +430,11 @@ jobs:
             numdiff \
             openmpi-bin \
             libboost-all-dev
+    - uses: lukka/get-cmake@v3.28.4
     - name: info
       run: |
         mpicc -v
+        which cmake
         cmake --version
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -334,11 +334,10 @@ jobs:
             numdiff \
             openmpi-bin \
             libboost-all-dev
-    - uses: lukka/get-cmake@v3.28.4
+    - uses: lukka/get-cmake@v3.27.9
     - name: info
       run: |
         mpicc -v
-        which cmake
         cmake --version
     - uses: actions/checkout@v4
       with:
@@ -430,11 +429,10 @@ jobs:
             numdiff \
             openmpi-bin \
             libboost-all-dev
-    - uses: lukka/get-cmake@v3.28.4
+    - uses: lukka/get-cmake@v3.27.9
     - name: info
       run: |
         mpicc -v
-        which cmake
         cmake --version
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Fixes #16792 by pinning the CMake version to 3.27.9 for the affected builds.