### PR TITLE
Add three GridGenerator functions to the python wrappers

### DIFF
--- a/contrib/python-bindings/include/triangulation_wrapper.h
+++ b/contrib/python-bindings/include/triangulation_wrapper.h
@@ -192,6 +192,22 @@ namespace python
     void
     generate_cheese(boost::python::list &holes);
 
+    /*! @copydoc GridGenerator::plate_with_a_hole
+     */
+    void
+    generate_plate_with_a_hole(const double        inner_radius = 0.4,
+                               const double        outer_radius = 1.,
+                               const double        pad_bottom   = 2.,
+                               const double        pad_top      = 2.,
+                               const double        pad_left     = 1.,
+                               const double        pad_right    = 1.,
+                               const PointWrapper &center = PointWrapper(),
+                               const int           polar_manifold_id = 0,
+                               const int           tfi_manifold_id   = 1,
+                               const double        L                 = 1.,
+                               const unsigned int  n_slices          = 2,
+                               const bool          colorize          = false);
+
     /*! @copydoc GridGenerator::general_cell
      */
     void

--- a/contrib/python-bindings/include/triangulation_wrapper.h
+++ b/contrib/python-bindings/include/triangulation_wrapper.h
@@ -265,6 +265,12 @@ namespace python
     void
     generate_hyper_ball(PointWrapper &center, const double radius = 1.);
 
+    /*! @copydoc GridGenerator::hyper_ball_balanced
+     */
+    void
+    generate_hyper_ball_balanced(const PointWrapper &center = PointWrapper(),
+                                 const double        radius = 1.);
+
     /*! @copydoc GridGenerator::hyper_sphere
      */
     void

--- a/contrib/python-bindings/include/triangulation_wrapper.h
+++ b/contrib/python-bindings/include/triangulation_wrapper.h
@@ -208,6 +208,14 @@ namespace python
                                const unsigned int  n_slices          = 2,
                                const bool          colorize          = false);
 
+    /*! @copydoc GridGenerator::generate_channel_with_cylinder
+     */
+    void
+    generate_channel_with_cylinder(const double       shell_region_width = 0.03,
+                                   const unsigned int n_shells           = 2,
+                                   const double       skewness           = 2.,
+                                   const bool         colorize = false);
+
     /*! @copydoc GridGenerator::general_cell
      */
     void

--- a/contrib/python-bindings/source/export_triangulation.cc
+++ b/contrib/python-bindings/source/export_triangulation.cc
@@ -94,6 +94,10 @@ namespace python
                                          generate_hyper_ball,
                                          1,
                                          2)
+  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(generate_hyper_ball_balanced_overloads,
+                                         generate_hyper_ball_balanced,
+                                         0,
+                                         2)
   BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(generate_hyper_sphere_overloads,
                                          generate_hyper_sphere,
                                          1,
@@ -280,6 +284,13 @@ namespace python
     "boundary cells after one refinement is optimized. You should attach a  \n"
     "SphericalManifold to the cells and faces for correct placement of      \n"
     "vertices upon refinement and to be able to use higher order mappings.  \n";
+
+
+
+  const char generate_hyper_ball_balanced_docstring[] =
+    "This is an alternative to hyper_ball with 12 cells in 2d and 32 cells  \n"
+    "in 3d, which provides a better balance between the size of the cells   \n"
+    "around the outer curved boundaries and the cell in the interior.       \n";
 
 
 
@@ -680,6 +691,11 @@ namespace python
            generate_hyper_ball_overloads(
              boost::python::args("self", "center", "radius"),
              generate_hyper_ball_docstring))
+      .def("generate_hyper_ball_balanced",
+           &TriangulationWrapper::generate_hyper_ball_balanced,
+           generate_hyper_ball_balanced_overloads(
+             boost::python::args("self", "center", "radius"),
+             generate_hyper_ball_balanced_docstring))
       .def("generate_hyper_sphere",
            &TriangulationWrapper::generate_hyper_sphere,
            generate_hyper_sphere_overloads(

--- a/contrib/python-bindings/source/export_triangulation.cc
+++ b/contrib/python-bindings/source/export_triangulation.cc
@@ -81,6 +81,10 @@ namespace python
     generate_hyper_cube_with_cylindrical_hole,
     0,
     5)
+  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(generate_plate_with_a_hole_overloads,
+                                         generate_plate_with_a_hole,
+                                         0,
+                                         12)
   BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(generate_hyper_ball_overloads,
                                          generate_hyper_ball,
                                          1,
@@ -314,6 +318,14 @@ namespace python
     "This function produces a square in the xy-plane with a cylindrical     \n"
     "hole in the middle. In 3d, this geometry is extruded in z direction    \n"
     "to the interval [0,L].                                                 \n";
+
+
+
+  const char generate_plate_with_a_hole_docstring[] =
+    "Generate a rectangular plate with an (offset) cylindrical hole.       \n"
+    "The geometry consists of 2 regions: The first is a square region      \n"
+    "with length outer_radius and a hole of radius inner_radius.           \n"
+    "The second region describes the remainder of the bulk material.       \n";
 
 
 
@@ -591,6 +603,23 @@ namespace python
            &TriangulationWrapper::generate_cheese,
            generate_cheese_docstring,
            boost::python::args("self", "holes"))
+      .def("generate_plate_with_a_hole",
+           &TriangulationWrapper::generate_plate_with_a_hole,
+           generate_plate_with_a_hole_overloads(
+             boost::python::args("self",
+                                 "inner_radius",
+                                 "outer_radius",
+                                 "pad_bottom",
+                                 "pad_top",
+                                 "pad_left",
+                                 "pad_right",
+                                 "center",
+                                 "polar_manifold_id",
+                                 "tfi_manifold_id",
+                                 "L",
+                                 "n_slices",
+                                 "colorize"),
+             generate_plate_with_a_hole_docstring))
       .def("generate_general_cell",
            &TriangulationWrapper::generate_general_cell,
            generate_general_cell_overloads(

--- a/contrib/python-bindings/source/export_triangulation.cc
+++ b/contrib/python-bindings/source/export_triangulation.cc
@@ -85,6 +85,11 @@ namespace python
                                          generate_plate_with_a_hole,
                                          0,
                                          12)
+  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(
+    generate_channel_with_cylinder_overloads,
+    generate_channel_with_cylinder,
+    0,
+    4)
   BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(generate_hyper_ball_overloads,
                                          generate_hyper_ball,
                                          1,
@@ -326,6 +331,17 @@ namespace python
     "The geometry consists of 2 regions: The first is a square region      \n"
     "with length outer_radius and a hole of radius inner_radius.           \n"
     "The second region describes the remainder of the bulk material.       \n";
+
+
+
+  const char generate_channel_with_cylinder_docstring[] =
+    "Generate a grid consisting of a channel with a cylinder.              \n"
+    "The channel has three distinct regions:                               \n"
+    "  1. If n_shells is greater than zero, then there are that many       \n"
+    "     shells centered around the cylinder,                             \n"
+    "  2. a blending region between the shells and the rest of the         \n"
+    "     triangulation, and                                               \n"
+    "  3. a bulk region consisting of Cartesian cells.                     \n";
 
 
 
@@ -620,6 +636,12 @@ namespace python
                                  "n_slices",
                                  "colorize"),
              generate_plate_with_a_hole_docstring))
+      .def("generate_channel_with_cylinder",
+           &TriangulationWrapper::generate_channel_with_cylinder,
+           generate_channel_with_cylinder_overloads(
+             boost::python::args(
+               "shell_region_width", "n_shells", "skewness", "colorize"),
+             generate_channel_with_cylinder_docstring))
       .def("generate_general_cell",
            &TriangulationWrapper::generate_general_cell,
            generate_general_cell_overloads(

--- a/contrib/python-bindings/source/point_wrapper.cc
+++ b/contrib/python-bindings/source/point_wrapper.cc
@@ -557,9 +557,6 @@ namespace python
   {
     dim = other.dim;
 
-    AssertThrow(other.point != nullptr,
-                ExcMessage("Underlying point does not exist."));
-
     if (dim == 2)
       {
         Point<2> *other_point = static_cast<Point<2> *>(other.point);
@@ -572,8 +569,9 @@ namespace python
           new Point<3>((*other_point)[0], (*other_point)[1], (*other_point)[2]);
       }
     else
-      AssertThrow(false,
-                  ExcMessage("The dimension of the point should be 2 or 3."));
+      {
+        point = nullptr;
+      }
   }
 } // namespace python
 

--- a/contrib/python-bindings/source/triangulation_wrapper.cc
+++ b/contrib/python-bindings/source/triangulation_wrapper.cc
@@ -304,6 +304,23 @@ namespace python
 
     template <int dim>
     void
+    generate_channel_with_cylinder(const double       shell_region_width,
+                                   const unsigned int n_shells,
+                                   const double       skewness,
+                                   const bool         colorize,
+                                   void              *triangulation)
+    {
+      Triangulation<dim, dim> *tria =
+        static_cast<Triangulation<dim, dim> *>(triangulation);
+      tria->clear();
+      GridGenerator::channel_with_cylinder(
+        *tria, shell_region_width, n_shells, skewness, colorize);
+    }
+
+
+
+    template <int dim>
+    void
     generate_general_cell(std::vector<PointWrapper> &wrapped_points,
                           const bool                 colorize,
                           void                      *triangulation)
@@ -1272,6 +1289,23 @@ namespace python
                                               n_slices,
                                               colorize,
                                               triangulation);
+  }
+
+
+
+  void
+  TriangulationWrapper::generate_channel_with_cylinder(
+    const double       shell_region_width,
+    const unsigned int n_shells,
+    const double       skewness,
+    const bool         colorize)
+  {
+    if (dim == 2)
+      internal::generate_channel_with_cylinder<2>(
+        shell_region_width, n_shells, skewness, colorize, triangulation);
+    else
+      internal::generate_channel_with_cylinder<3>(
+        shell_region_width, n_shells, skewness, colorize, triangulation);
   }
 
 

--- a/contrib/python-bindings/source/triangulation_wrapper.cc
+++ b/contrib/python-bindings/source/triangulation_wrapper.cc
@@ -469,6 +469,26 @@ namespace python
 
 
 
+    template <int dim>
+    void
+    generate_hyper_ball_balanced(const PointWrapper &center,
+                                 const double        radius,
+                                 void               *triangulation)
+    {
+      // Cast the PointWrapper object to Point<dim>
+      Point<dim> center_point =
+        center.get_point() ?
+          *(static_cast<const Point<dim> *>(center.get_point())) :
+          Point<dim>();
+
+      Triangulation<dim> *tria =
+        static_cast<Triangulation<dim> *>(triangulation);
+      tria->clear();
+      GridGenerator::hyper_ball_balanced(*tria, center_point, radius);
+    }
+
+
+
     template <int dim, int spacedim>
     void
     generate_hyper_sphere(PointWrapper &center,
@@ -1496,6 +1516,22 @@ namespace python
       internal::generate_hyper_ball<2>(center, radius, triangulation);
     else
       internal::generate_hyper_ball<3>(center, radius, triangulation);
+  }
+
+
+
+  void
+  TriangulationWrapper::generate_hyper_ball_balanced(const PointWrapper &center,
+                                                     const double        radius)
+  {
+    AssertThrow(
+      dim == spacedim,
+      ExcMessage(
+        "This function is only implemented for dim equal to spacedim."));
+    if (dim == 2)
+      internal::generate_hyper_ball_balanced<2>(center, radius, triangulation);
+    else
+      internal::generate_hyper_ball_balanced<3>(center, radius, triangulation);
   }
 
 

--- a/contrib/python-bindings/source/triangulation_wrapper.cc
+++ b/contrib/python-bindings/source/triangulation_wrapper.cc
@@ -262,6 +262,48 @@ namespace python
 
     template <int dim>
     void
+    generate_plate_with_a_hole(const double        inner_radius,
+                               const double        outer_radius,
+                               const double        pad_bottom,
+                               const double        pad_top,
+                               const double        pad_left,
+                               const double        pad_right,
+                               const PointWrapper &center,
+                               const int           polar_manifold_id,
+                               const int           tfi_manifold_id,
+                               const double        L,
+                               const unsigned int  n_slices,
+                               const bool          colorize,
+                               void               *triangulation)
+    {
+      // Cast the PointWrapper object to Point<dim>
+      Point<dim> point =
+        center.get_point() ?
+          *(static_cast<const Point<dim> *>(center.get_point())) :
+          Point<dim>();
+
+      Triangulation<dim, dim> *tria =
+        static_cast<Triangulation<dim, dim> *>(triangulation);
+      tria->clear();
+      GridGenerator::plate_with_a_hole(*tria,
+                                       inner_radius,
+                                       outer_radius,
+                                       pad_bottom,
+                                       pad_top,
+                                       pad_left,
+                                       pad_right,
+                                       point,
+                                       polar_manifold_id,
+                                       tfi_manifold_id,
+                                       L,
+                                       n_slices,
+                                       colorize);
+    }
+
+
+
+    template <int dim>
+    void
     generate_general_cell(std::vector<PointWrapper> &wrapped_points,
                           const bool                 colorize,
                           void                      *triangulation)
@@ -1184,6 +1226,52 @@ namespace python
       internal::generate_cheese<2, 3>(holes, triangulation);
     else
       internal::generate_cheese<3, 3>(holes, triangulation);
+  }
+
+
+
+  void
+  TriangulationWrapper::generate_plate_with_a_hole(const double inner_radius,
+                                                   const double outer_radius,
+                                                   const double pad_bottom,
+                                                   const double pad_top,
+                                                   const double pad_left,
+                                                   const double pad_right,
+                                                   const PointWrapper &center,
+                                                   const int polar_manifold_id,
+                                                   const int tfi_manifold_id,
+                                                   const double       L,
+                                                   const unsigned int n_slices,
+                                                   const bool         colorize)
+  {
+    if (dim == 2)
+      internal::generate_plate_with_a_hole<2>(inner_radius,
+                                              outer_radius,
+                                              pad_bottom,
+                                              pad_top,
+                                              pad_left,
+                                              pad_right,
+                                              center,
+                                              polar_manifold_id,
+                                              tfi_manifold_id,
+                                              L,
+                                              n_slices,
+                                              colorize,
+                                              triangulation);
+    else
+      internal::generate_plate_with_a_hole<3>(inner_radius,
+                                              outer_radius,
+                                              pad_bottom,
+                                              pad_top,
+                                              pad_left,
+                                              pad_right,
+                                              center,
+                                              polar_manifold_id,
+                                              tfi_manifold_id,
+                                              L,
+                                              n_slices,
+                                              colorize,
+                                              triangulation);
   }
 
 

--- a/contrib/python-bindings/tests/triangulation_wrapper.py
+++ b/contrib/python-bindings/tests/triangulation_wrapper.py
@@ -333,6 +333,16 @@ class TestTriangulationWrapper(unittest.TestCase):
             n_cells = triangulation.n_active_cells()
             self.assertEqual(n_cells, n_cells_ref)
 
+    def test_hyper_ball_balanced(self):
+        for dim in self.dim:
+            triangulation = Triangulation(dim[0])
+            triangulation.generate_hyper_ball_balanced()
+            n_cells = triangulation.n_active_cells()
+            if (dim[0] == '2D'):
+                self.assertEqual(n_cells, 12)
+            else:
+                self.assertEqual(n_cells, 32)
+
     def test_hyper_sphere(self):
          triangulation = Triangulation('2D', '3D')
          center = Point([0, 0])

--- a/contrib/python-bindings/tests/triangulation_wrapper.py
+++ b/contrib/python-bindings/tests/triangulation_wrapper.py
@@ -188,6 +188,16 @@ class TestTriangulationWrapper(unittest.TestCase):
             n_cells = triangulation.n_active_cells()
             self.assertEqual(n_cells, 28)
 
+    def test_generate_channel_with_cylinder(self):
+        for dim in self.dim:
+            triangulation = Triangulation(dim[0])
+            triangulation.generate_channel_with_cylinder()
+            n_cells = triangulation.n_active_cells()
+            if (dim[0] == '2D'):
+                self.assertEqual(n_cells, 108)
+            else:
+                self.assertEqual(n_cells, 432)
+
     def test_generate_general_cell(self):
         for dim in self.restricted_dim:
             triangulation = Triangulation(dim[0], dim[1])

--- a/contrib/python-bindings/tests/triangulation_wrapper.py
+++ b/contrib/python-bindings/tests/triangulation_wrapper.py
@@ -181,6 +181,13 @@ class TestTriangulationWrapper(unittest.TestCase):
                 n_cells = triangulation.n_active_cells()
                 self.assertEqual(n_cells, 175)
 
+    def test_generate_plate_with_hole(self):
+        for dim in self.dim:
+            triangulation = Triangulation(dim[0])
+            triangulation.generate_plate_with_a_hole()
+            n_cells = triangulation.n_active_cells()
+            self.assertEqual(n_cells, 28)
+
     def test_generate_general_cell(self):
         for dim in self.restricted_dim:
             triangulation = Triangulation(dim[0], dim[1])

--- a/doc/news/changes/minor/20240327Turcksin
+++ b/doc/news/changes/minor/20240327Turcksin
@@ -1,0 +1,5 @@
+New: Add GridGenerator::plate_with_a_hole, GridGenerator::channel_with_cylinder,
+and GridGenerator::hyper_ball_balanced to the python wrappers
+<br>
+(Bruno Turcksin, 2024/03/27)
+


### PR DESCRIPTION
Add `GridGenerator::plate_with_a_hole`, `GridGenerator::channel_with_cylinder`, and `GridGenerator::hyper_ball_balanced` to the python wrappers. The change in `point_wrapper` is to deal with the copy of default constructed `point_wrapper` done inside Boost.Python