### PR TITLE
Instantiate MappingC1 for dim <= spacedim

### DIFF
--- a/include/deal.II/fe/mapping_c1.h
+++ b/include/deal.II/fe/mapping_c1.h
@@ -63,8 +63,8 @@ public:
    */
   virtual void
   add_line_support_points(
-    const typename Triangulation<dim>::cell_iterator &cell,
-    std::vector<Point<dim>>                          &a) const override;
+    const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+    std::vector<Point<spacedim>> &a) const override;
 
   /**
    * For <tt>dim=3</tt>. Append the support points of all shape functions
@@ -77,8 +77,8 @@ public:
    */
   virtual void
   add_quad_support_points(
-    const typename Triangulation<dim>::cell_iterator &cell,
-    std::vector<Point<dim>>                          &a) const override;
+    const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+    std::vector<Point<spacedim>> &a) const override;
 };
 
 /** @} */

--- a/source/fe/mapping_c1.cc
+++ b/source/fe/mapping_c1.cc
@@ -31,6 +31,7 @@ MappingC1<dim, spacedim>::MappingC1()
   : MappingQ<dim, spacedim>(3)
 {
   Assert(dim > 1, ExcImpossibleInDim(dim));
+  Assert(dim == spacedim, ExcNotImplemented());
 }
 
 
@@ -156,8 +157,8 @@ MappingC1<2>::add_line_support_points(
 template <int dim, int spacedim>
 void
 MappingC1<dim, spacedim>::add_line_support_points(
-  const typename Triangulation<dim>::cell_iterator &,
-  std::vector<Point<dim>> &) const
+  const typename Triangulation<dim, spacedim>::cell_iterator &,
+  std::vector<Point<spacedim>> &) const
 {
   DEAL_II_NOT_IMPLEMENTED();
 }
@@ -191,8 +192,8 @@ MappingC1<2>::add_quad_support_points(const Triangulation<2>::cell_iterator &,
 template <int dim, int spacedim>
 void
 MappingC1<dim, spacedim>::add_quad_support_points(
-  const typename Triangulation<dim>::cell_iterator &,
-  std::vector<Point<dim>> &) const
+  const typename Triangulation<dim, spacedim>::cell_iterator &,
+  std::vector<Point<spacedim>> &) const
 {
   DEAL_II_NOT_IMPLEMENTED();
 }

--- a/source/fe/mapping_c1.inst.in
+++ b/source/fe/mapping_c1.inst.in
@@ -14,7 +14,9 @@
 
 
 
-for (deal_II_dimension : DIMENSIONS)
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
   {
-    template class MappingC1<deal_II_dimension>;
+#if deal_II_dimension <= deal_II_space_dimension
+    template class MappingC1<deal_II_dimension, deal_II_space_dimension>;
+#endif
   }


### PR DESCRIPTION
The mapping is not implemened for dim!=spacedim, but it is better to get ExcNotImplemented than missing symbols.