### PR TITLE
Allocate the right amount of memory when serializing particles.

### DIFF
--- a/source/particles/particle.cc
+++ b/source/particles/particle.cc
@@ -285,8 +285,9 @@ namespace Particles
   std::size_t
   Particle<dim, spacedim>::serialized_size_in_bytes() const
   {
-    std::size_t size = sizeof(get_id()) + sizeof(get_location()) +
-                       sizeof(get_reference_location());
+    std::size_t size = sizeof(get_id()) +
+                       sizeof(double) * spacedim + // get_location()
+                       sizeof(double) * dim;       // get_reference_location()
 
     if (has_properties())
       {


### PR DESCRIPTION
This fixes 11 of the 16 particle-related failures mentioned in #16796.

The issue here is that when we serialize particles we do this:
```
  template <int dim, int spacedim>
  void *
  Particle<dim, spacedim>::write_particle_data_to_memory(
    void *data_pointer) const
  {
    types::particle_index *id_data =
      static_cast<types::particle_index *>(data_pointer);
    *id_data = get_id();
    ++id_data;
    double *pdata = reinterpret_cast<double *>(id_data);

    // Write location
    for (unsigned int i = 0; i < spacedim; ++i, ++pdata)
      *pdata = get_location()[i];

    // Write reference location
    for (unsigned int i = 0; i < dim; ++i, ++pdata)
      *pdata = get_reference_location()[i];
...
```
That is, we write exactly `spacedim` `double` numbers for the location, and `dim` `double` numbers for the reference location. But in the function where we tell the upstream caller of the code above, we say that this is the number of bytes we need:
```
  template <int dim, int spacedim>
  std::size_t
  Particle<dim, spacedim>::serialized_size_in_bytes() const
  {
    std::size_t size = sizeof(get_id()) + sizeof(get_location()) +
                       sizeof(get_reference_location());
```
That is, we say that we need `sizeof(Point<spacedim>) + sizeof(Point<dim>)` bytes. This used to be correct but really only by chance because there were no padding bytes we didn't serialize. In other words, it was accidentally correct.
```