### PR TITLE
Fix a second place where particles compute the size of a buffer.

### DIFF
--- a/include/deal.II/particles/particle_accessor.h
+++ b/include/deal.II/particles/particle_accessor.h
@@ -883,8 +883,9 @@ namespace Particles
   {
     Assert(state() == IteratorState::valid, ExcInternalError());
 
-    std::size_t size = sizeof(get_id()) + sizeof(get_location()) +
-                       sizeof(get_reference_location());
+    std::size_t size = sizeof(get_id()) +
+                       sizeof(double) * spacedim + // get_location()
+                       sizeof(double) * dim;       // get_reference_location()
 
     if (has_properties())
       {

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -2366,7 +2366,19 @@ namespace Particles
           &(*data_range.begin()) + (data_range.end() - data_range.begin()));
 
         while (data < end)
-          insert_particle(data, cell_to_store_particles);
+          {
+            const void *old_data = data;
+            const auto  x = insert_particle(data, cell_to_store_particles);
+
+            // Ensure that the particle read exactly as much data as
+            // it promised it needs to store its data
+            const void *new_data = data;
+            (void)old_data;
+            (void)new_data;
+            (void)x;
+            AssertDimension((const char *)new_data - (const char *)old_data,
+                            x->serialized_size_in_bytes());
+          }
 
         Assert(data == end,
                ExcMessage(


### PR DESCRIPTION
Like #16813. This fixes the remaining 5 of the 16 particle-related failures mentioned in #16796.

It turns out that we have duplicate code to compute the size of the buffer, in `class Particle` and `class ParticleAccessor`. #16813 fixes the first of these, this patch the second. This is perhaps not the best design, but it is what it is and my interest for the moment is just fixing the bug.

While there, I'm also adding an assertion I found useful in debugging.