### PR TITLE
No longer output the size of tensors into output file of a test.

### DIFF
--- a/tests/tensors/constexpr_tensor.cc
+++ b/tests/tensors/constexpr_tensor.cc
@@ -147,8 +147,12 @@ main()
     Tensor<2, 3>::component_to_unrolled_index(TableIndices<2>{});
   Assert(index == 0, ExcInternalError());
 
+  // Also make sure one can call memory_consumption() in a constexpr
+  // context. The actual amount of memory used depends on the platform
+  // and vectorization level, so compute it but don't output it to a
+  // file.
   DEAL_II_CONSTEXPR const auto used_memory = Tensor<2, 3>::memory_consumption();
-  deallog << "Used memory: " << used_memory << std::endl;
+  (void)used_memory;
 
   {
     constexpr double a_init[3][3] = {{1., 0., 0.}, {2., 1., 0.}, {3., 2., 1.}};

--- a/tests/tensors/constexpr_tensor.output
+++ b/tests/tensors/constexpr_tensor.output
@@ -165,5 +165,4 @@ DEAL:double::0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.0
 DEAL::Using Tensor within constexpr functions
 DEAL::15.2000
 DEAL::116.000
-DEAL::Used memory: 72
 DEAL::OK


### PR DESCRIPTION
Addresses one other of the tests reported to be failing in #16796, and caused by #16771.