### PR TITLE
Revert aligning tensors

### DIFF
--- a/doc/news/changes/minor/20240323Bangerth
+++ b/doc/news/changes/minor/20240323Bangerth
@@ -1,5 +1,0 @@
-Changed: The Tensor class now has an alignment greater than what the
-compiler would automatically choose to enable more efficient memory
-operations on these objects.
-<br>
-(Wolfgang Bangerth, 2024/03/23)

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -393,55 +393,6 @@ private:
 
 
 
-namespace internal
-{
-  namespace TensorImplementation
-  {
-    /**
-     * Whether or not the 'values' array of Tensor can be treated as (i.e.,
-     * bitcasted to) a vectorized array (of possibly more than 'dim' elements,
-     * where the padding elements would then have to
-     * be ignored by all functions).
-     *
-     * We can store the values as an array that can be casted to VectorizedArray
-     * if we are considering a rank-1 tensor, and if it stores `double` or
-     * `float` values, and if there are at most 4 values -- we do not try to
-     * vectorize the uncommon case of `dim>4`. We also don't consider the case
-     * `dim==1` because in that case vectorization does not provide any benefit.
-     *
-     * Note that this leads to a platform dependent alignment given that
-     * we want to treat the elements as VectorizedArray and that whether
-     * or not a VectorizedArray of sufficiently large size exists depends
-     * on the platform we're on.
-     */
-    template <int rank, int dim, typename Number>
-    constexpr bool can_treat_values_as_vectorized_array =
-      ((rank == 1) &&
-       /* Only if dim==2,3,4 */
-       (dim > 1) && (dim <= 4) &&
-       /* Only for float and double tensors */
-       (std::is_same_v<Number, double> || std::is_same_v<Number, float>)&&
-       /* Only if a VectorizedArray<Number,N> is avaiable where N>=dim
-          (but we only have to consider N=2 or 4 because dim==2,3,4). */
-       (internal::VectorizedArrayWidthSpecifier<Number>::max_width >=
-        (dim <= 2 ? 2 : 4)));
-
-    /**
-     * Compute the alignment to be used for Tensor objects. We align it
-     * by 2 or 4 times the size of the scalar object for rank-1 tensors if
-     * rank-1 tensors can be treated as vectorized arrays (which makes sure that
-     * the higher-rank tensors are then also so aligned). Otherwise, set the
-     * alignment to the alignment of `Number`.
-     */
-    template <int rank, int dim, typename Number>
-    constexpr size_t tensor_alignment =
-      (can_treat_values_as_vectorized_array<1, dim, Number> ?
-         (dim <= 2 ? 2 : 4) * sizeof(Number) :
-         alignof(Number));
-  } // namespace TensorImplementation
-} // namespace internal
-
-
 /**
  * A general tensor class with an arbitrary rank, i.e. with an arbitrary
  * number of indices. The Tensor class provides an indexing operator and a bit
@@ -516,8 +467,7 @@ namespace internal
  * @ingroup geomprimitives
  */
 template <int rank_, int dim, typename Number>
-class alignas(
-  internal::TensorImplementation::tensor_alignment<rank_, dim, Number>) Tensor
+class Tensor
 {
 public:
   static_assert(rank_ >= 1,

--- a/tests/tensors/constexpr_tensor.cc
+++ b/tests/tensors/constexpr_tensor.cc
@@ -147,12 +147,8 @@ main()
     Tensor<2, 3>::component_to_unrolled_index(TableIndices<2>{});
   Assert(index == 0, ExcInternalError());
 
-  // Also make sure one can call memory_consumption() in a constexpr
-  // context. The actual amount of memory used depends on the platform
-  // and vectorization level, so compute it but don't output it to a
-  // file.
   DEAL_II_CONSTEXPR const auto used_memory = Tensor<2, 3>::memory_consumption();
-  (void)used_memory;
+  deallog << "Used memory: " << used_memory << std::endl;
 
   {
     constexpr double a_init[3][3] = {{1., 0., 0.}, {2., 1., 0.}, {3., 2., 1.}};

--- a/tests/tensors/constexpr_tensor.output
+++ b/tests/tensors/constexpr_tensor.output
@@ -165,4 +165,5 @@ DEAL:double::0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.0
 DEAL::Using Tensor within constexpr functions
 DEAL::15.2000
 DEAL::116.000
+DEAL::Used memory: 72
 DEAL::OK


### PR DESCRIPTION
Let me propose that we revert the alignment of tensors for now. I will post a patch at a later time that re-enables this at the same time as it switches on the use of vector intrinsics -- I think this will make fair comparisons easier, and it avoids us getting stuck halfway.

This patch reverts #16771 and #16816. I believe that all of the other patches we merged in response to the failures caused by #16771 and tracked in #16796 were independently correct and should stay in.

In relation to #16465.