### PR TITLE
MappingCartesian: Some performance improvements

### DIFF
--- a/doc/news/changes/minor/20240401Kronbichler
+++ b/doc/news/changes/minor/20240401Kronbichler
@@ -1,0 +1,5 @@
+Improved: Several functions in MappingCartesian have been carefully rewritten
+for better performance, e.g., by avoiding divisions and making use of recurring
+operations.
+<br>
+(Martin Kronbichler, 2024/04/01)

--- a/include/deal.II/fe/mapping_cartesian.h
+++ b/include/deal.II/fe/mapping_cartesian.h
@@ -109,6 +109,13 @@ public:
     const typename Triangulation<dim, spacedim>::cell_iterator &cell,
     const Point<spacedim> &p) const override;
 
+  // for documentation, see the Mapping base class
+  virtual void
+  transform_points_real_to_unit_cell(
+    const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+    const ArrayView<const Point<spacedim>>                     &real_points,
+    const ArrayView<Point<dim>> &unit_points) const override;
+
   /**
    * @}
    */
@@ -222,6 +229,13 @@ public:
      * i.e., <i>h<sub>x</sub></i>, <i>h<sub>y</sub></i>, <i>h<sub>z</sub></i>.
      */
     mutable Tensor<1, dim> cell_extents;
+
+    /**
+     * Reciprocal of the extents of the last cell we have seen in the
+     * coordinate directions, i.e., <i>h<sub>x</sub></i>,
+     * <i>h<sub>y</sub></i>, <i>h<sub>z</sub></i>.
+     */
+    mutable Tensor<1, dim> inverse_cell_extents;
 
     /**
      * The volume element
@@ -352,7 +366,7 @@ private:
 
   /**
    * Transform quadrature points in InternalData to real space by scaling unit
-   * coordinates with cell_extends in each direction.
+   * coordinates with cell_extents in each direction.
    *
    * Called from the various maybe_update_*_quadrature_points functions.
    */

--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -1168,8 +1168,7 @@ MappingCartesian<dim, spacedim>::transform_unit_to_real_cell(
   const Point<dim>                                           &p) const
 {
   Assert(is_cartesian(cell), ExcCellNotCartesian());
-  if (dim != spacedim)
-    DEAL_II_NOT_IMPLEMENTED();
+  Assert(dim == spacedim, ExcNotImplemented());
 
   Point<dim> unit = cell->vertex(0);
 
@@ -1189,9 +1188,8 @@ MappingCartesian<dim, spacedim>::transform_real_to_unit_cell(
   const Point<spacedim>                                      &p) const
 {
   Assert(is_cartesian(cell), ExcCellNotCartesian());
+  Assert(dim == spacedim, ExcNotImplemented());
 
-  if (dim != spacedim)
-    DEAL_II_NOT_IMPLEMENTED();
   const Point<dim> start = cell->vertex(0);
   Point<dim>       real  = p;
 

--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -91,6 +91,7 @@ template <int dim, int spacedim>
 MappingCartesian<dim, spacedim>::InternalData::InternalData(
   const Quadrature<dim> &q)
   : cell_extents(numbers::signaling_nan<Tensor<1, dim>>())
+  , inverse_cell_extents(numbers::signaling_nan<Tensor<1, dim>>())
   , volume_element(numbers::signaling_nan<double>())
   , quadrature_points(q.get_points())
 {}
@@ -103,6 +104,7 @@ MappingCartesian<dim, spacedim>::InternalData::memory_consumption() const
 {
   return (Mapping<dim, spacedim>::InternalDataBase::memory_consumption() +
           MemoryConsumption::memory_consumption(cell_extents) +
+          MemoryConsumption::memory_consumption(inverse_cell_extents) +
           MemoryConsumption::memory_consumption(volume_element) +
           MemoryConsumption::memory_consumption(quadrature_points));
 }
@@ -232,29 +234,18 @@ MappingCartesian<dim, spacedim>::update_cell_extents(
   const CellSimilarity::Similarity                            cell_similarity,
   const InternalData                                         &data) const
 {
-  // Compute start point and sizes
-  // along axes.  Strange vertex
-  // numbering makes this complicated
-  // again.
+  // Compute start point and sizes along axes. The vertices to be looked at
+  // are 1, 2, 4 compared to the base vertex 0.
   if (cell_similarity != CellSimilarity::translation)
     {
-      const Point<dim> &start = cell->vertex(0);
-      switch (dim)
+      const Point<dim> start = cell->vertex(0);
+      for (unsigned int d = 0; d < dim; ++d)
         {
-          case 1:
-            data.cell_extents[0] = cell->vertex(1)[0] - start[0];
-            break;
-          case 2:
-            data.cell_extents[0] = cell->vertex(1)[0] - start[0];
-            data.cell_extents[1] = cell->vertex(2)[1] - start[1];
-            break;
-          case 3:
-            data.cell_extents[0] = cell->vertex(1)[0] - start[0];
-            data.cell_extents[1] = cell->vertex(2)[1] - start[1];
-            data.cell_extents[2] = cell->vertex(4)[2] - start[2];
-            break;
-          default:
-            DEAL_II_NOT_IMPLEMENTED();
+          const double cell_extent_d = cell->vertex(1 << d)[d] - start[d];
+          data.cell_extents[d]       = cell_extent_d;
+          Assert(cell_extent_d != 0.,
+                 ExcMessage("Cell does not appear to be Cartesian!"));
+          data.inverse_cell_extents[d] = 1. / cell_extent_d;
         }
     }
 }
@@ -345,7 +336,7 @@ MappingCartesian<dim, spacedim>::transform_quadrature_points(
 {
   // let @p{start} be the origin of a local coordinate system. it is chosen
   // as the (lower) left vertex
-  const Point<dim> &start = cell->vertex(0);
+  const Point<dim> start = cell->vertex(0);
 
   for (unsigned int i = 0; i < quadrature_points.size(); ++i)
     {
@@ -483,7 +474,8 @@ MappingCartesian<dim, spacedim>::maybe_update_inverse_jacobians(
         {
           output_data.inverse_jacobians[i] = Tensor<2, dim>();
           for (unsigned int j = 0; j < dim; ++j)
-            output_data.inverse_jacobians[i][j][j] = 1. / data.cell_extents[j];
+            output_data.inverse_jacobians[i][j][j] =
+              data.inverse_cell_extents[j];
         }
 }
 
@@ -721,7 +713,7 @@ MappingCartesian<dim, spacedim>::fill_fe_immersed_surface_values(
         const Tensor<1, dim> &ref_space_normal = quadrature.normal_vector(i);
         for (unsigned int d = 0; d < dim; ++d)
           {
-            normal[d] = ref_space_normal[d] / data.cell_extents[d];
+            normal[d] = ref_space_normal[d] * data.inverse_cell_extents[d];
           }
         normal /= normal.norm();
         output_data.normal_vectors[i] = normal;
@@ -738,7 +730,8 @@ MappingCartesian<dim, spacedim>::fill_fe_immersed_surface_values(
         for (unsigned int d = 0; d < dim; ++d)
           {
             det_jacobian *= data.cell_extents[d];
-            invJTxNormal[d] = ref_space_normal[d] / data.cell_extents[d];
+            invJTxNormal[d] =
+              ref_space_normal[d] * data.inverse_cell_extents[d];
           }
         output_data.JxW_values[i] =
           det_jacobian * invJTxNormal.norm() * quadrature.weight(i);
@@ -775,7 +768,7 @@ MappingCartesian<dim, spacedim>::transform(
 
           for (unsigned int i = 0; i < output.size(); ++i)
             for (unsigned int d = 0; d < dim; ++d)
-              output[i][d] = input[i][d] / data.cell_extents[d];
+              output[i][d] = input[i][d] * data.inverse_cell_extents[d];
           return;
         }
 
@@ -836,7 +829,8 @@ MappingCartesian<dim, spacedim>::transform(
           for (unsigned int i = 0; i < output.size(); ++i)
             for (unsigned int d1 = 0; d1 < dim; ++d1)
               for (unsigned int d2 = 0; d2 < dim; ++d2)
-                output[i][d1][d2] = input[i][d1][d2] / data.cell_extents[d2];
+                output[i][d1][d2] =
+                  input[i][d1][d2] * data.inverse_cell_extents[d2];
           return;
         }
 
@@ -862,8 +856,9 @@ MappingCartesian<dim, spacedim>::transform(
           for (unsigned int i = 0; i < output.size(); ++i)
             for (unsigned int d1 = 0; d1 < dim; ++d1)
               for (unsigned int d2 = 0; d2 < dim; ++d2)
-                output[i][d1][d2] = input[i][d1][d2] / data.cell_extents[d2] /
-                                    data.cell_extents[d1];
+                output[i][d1][d2] = input[i][d1][d2] *
+                                    data.inverse_cell_extents[d2] *
+                                    data.inverse_cell_extents[d1];
           return;
         }
 
@@ -876,8 +871,8 @@ MappingCartesian<dim, spacedim>::transform(
           for (unsigned int i = 0; i < output.size(); ++i)
             for (unsigned int d1 = 0; d1 < dim; ++d1)
               for (unsigned int d2 = 0; d2 < dim; ++d2)
-                output[i][d1][d2] = input[i][d1][d2] * data.cell_extents[d2] /
-                                    data.cell_extents[d1];
+                output[i][d1][d2] = input[i][d1][d2] * data.cell_extents[d2] *
+                                    data.inverse_cell_extents[d1];
           return;
         }
 
@@ -910,8 +905,9 @@ MappingCartesian<dim, spacedim>::transform(
           for (unsigned int i = 0; i < output.size(); ++i)
             for (unsigned int d1 = 0; d1 < dim; ++d1)
               for (unsigned int d2 = 0; d2 < dim; ++d2)
-                output[i][d1][d2] = input[i][d1][d2] * data.cell_extents[d2] /
-                                    data.cell_extents[d1] / data.volume_element;
+                output[i][d1][d2] = input[i][d1][d2] * data.cell_extents[d2] *
+                                    data.inverse_cell_extents[d1] /
+                                    data.volume_element;
           return;
         }
 
@@ -946,7 +942,8 @@ MappingCartesian<dim, spacedim>::transform(
           for (unsigned int i = 0; i < output.size(); ++i)
             for (unsigned int d1 = 0; d1 < dim; ++d1)
               for (unsigned int d2 = 0; d2 < dim; ++d2)
-                output[i][d1][d2] = input[i][d1][d2] / data.cell_extents[d2];
+                output[i][d1][d2] =
+                  input[i][d1][d2] * data.inverse_cell_extents[d2];
           return;
         }
 
@@ -972,8 +969,9 @@ MappingCartesian<dim, spacedim>::transform(
           for (unsigned int i = 0; i < output.size(); ++i)
             for (unsigned int d1 = 0; d1 < dim; ++d1)
               for (unsigned int d2 = 0; d2 < dim; ++d2)
-                output[i][d1][d2] = input[i][d1][d2] / data.cell_extents[d2] /
-                                    data.cell_extents[d1];
+                output[i][d1][d2] = input[i][d1][d2] *
+                                    data.inverse_cell_extents[d2] *
+                                    data.inverse_cell_extents[d1];
           return;
         }
 
@@ -986,8 +984,8 @@ MappingCartesian<dim, spacedim>::transform(
           for (unsigned int i = 0; i < output.size(); ++i)
             for (unsigned int d1 = 0; d1 < dim; ++d1)
               for (unsigned int d2 = 0; d2 < dim; ++d2)
-                output[i][d1][d2] = input[i][d1][d2] * data.cell_extents[d2] /
-                                    data.cell_extents[d1];
+                output[i][d1][d2] = input[i][d1][d2] * data.cell_extents[d2] *
+                                    data.inverse_cell_extents[d1];
           return;
         }
 
@@ -1020,8 +1018,9 @@ MappingCartesian<dim, spacedim>::transform(
           for (unsigned int i = 0; i < output.size(); ++i)
             for (unsigned int d1 = 0; d1 < dim; ++d1)
               for (unsigned int d2 = 0; d2 < dim; ++d2)
-                output[i][d1][d2] = input[i][d1][d2] * data.cell_extents[d2] /
-                                    data.cell_extents[d1] / data.volume_element;
+                output[i][d1][d2] = input[i][d1][d2] * data.cell_extents[d2] *
+                                    data.inverse_cell_extents[d1] /
+                                    data.volume_element;
           return;
         }
 
@@ -1058,9 +1057,9 @@ MappingCartesian<dim, spacedim>::transform(
               for (unsigned int j = 0; j < spacedim; ++j)
                 for (unsigned int k = 0; k < spacedim; ++k)
                   {
-                    output[q][i][j][k] = input[q][i][j][k] /
-                                         data.cell_extents[j] /
-                                         data.cell_extents[k];
+                    output[q][i][j][k] = input[q][i][j][k] *
+                                         data.inverse_cell_extents[j] *
+                                         data.inverse_cell_extents[k];
                   }
           return;
         }
@@ -1100,9 +1099,10 @@ MappingCartesian<dim, spacedim>::transform(
               for (unsigned int j = 0; j < spacedim; ++j)
                 for (unsigned int k = 0; k < spacedim; ++k)
                   {
-                    output[q][i][j][k] =
-                      input[q][i][j][k] * data.cell_extents[i] /
-                      data.cell_extents[j] / data.cell_extents[k];
+                    output[q][i][j][k] = input[q][i][j][k] *
+                                         data.cell_extents[i] *
+                                         data.inverse_cell_extents[j] *
+                                         data.inverse_cell_extents[k];
                   }
           return;
         }
@@ -1118,9 +1118,10 @@ MappingCartesian<dim, spacedim>::transform(
               for (unsigned int j = 0; j < spacedim; ++j)
                 for (unsigned int k = 0; k < spacedim; ++k)
                   {
-                    output[q][i][j][k] =
-                      input[q][i][j][k] / data.cell_extents[i] /
-                      data.cell_extents[j] / data.cell_extents[k];
+                    output[q][i][j][k] = input[q][i][j][k] *
+                                         (data.inverse_cell_extents[i] *
+                                          data.inverse_cell_extents[j]) *
+                                         data.inverse_cell_extents[k];
                   }
 
           return;
@@ -1144,9 +1145,10 @@ MappingCartesian<dim, spacedim>::transform(
                 for (unsigned int k = 0; k < spacedim; ++k)
                   {
                     output[q][i][j][k] =
-                      input[q][i][j][k] * data.cell_extents[i] /
-                      data.volume_element / data.cell_extents[j] /
-                      data.cell_extents[k];
+                      input[q][i][j][k] *
+                      (data.cell_extents[i] / data.volume_element *
+                       data.inverse_cell_extents[j]) *
+                      data.inverse_cell_extents[k];
                   }
 
           return;
@@ -1166,32 +1168,16 @@ MappingCartesian<dim, spacedim>::transform_unit_to_real_cell(
   const Point<dim>                                           &p) const
 {
   Assert(is_cartesian(cell), ExcCellNotCartesian());
+  if (dim != spacedim)
+    DEAL_II_NOT_IMPLEMENTED();
 
-  Tensor<1, dim>   length;
-  const Point<dim> start = cell->vertex(0);
-  switch (dim)
-    {
-      case 1:
-        length[0] = cell->vertex(1)[0] - start[0];
-        break;
-      case 2:
-        length[0] = cell->vertex(1)[0] - start[0];
-        length[1] = cell->vertex(2)[1] - start[1];
-        break;
-      case 3:
-        length[0] = cell->vertex(1)[0] - start[0];
-        length[1] = cell->vertex(2)[1] - start[1];
-        length[2] = cell->vertex(4)[2] - start[2];
-        break;
-      default:
-        DEAL_II_NOT_IMPLEMENTED();
-    }
+  Point<dim> unit = cell->vertex(0);
 
-  Point<dim> p_real = cell->vertex(0);
+  // Go through vertices with numbers 1, 2, 4
   for (unsigned int d = 0; d < dim; ++d)
-    p_real[d] += length[d] * p[d];
+    unit[d] += (cell->vertex(1 << d)[d] - unit[d]) * p[d];
 
-  return p_real;
+  return unit;
 }
 
 
@@ -1206,28 +1192,41 @@ MappingCartesian<dim, spacedim>::transform_real_to_unit_cell(
 
   if (dim != spacedim)
     DEAL_II_NOT_IMPLEMENTED();
-  const Point<dim> &start = cell->vertex(0);
-  Point<dim>        real  = p;
-  real -= start;
+  const Point<dim> start = cell->vertex(0);
+  Point<dim>       real  = p;
 
-  switch (dim)
-    {
-      case 1:
-        real[0] /= cell->vertex(1)[0] - start[0];
-        break;
-      case 2:
-        real[0] /= cell->vertex(1)[0] - start[0];
-        real[1] /= cell->vertex(2)[1] - start[1];
-        break;
-      case 3:
-        real[0] /= cell->vertex(1)[0] - start[0];
-        real[1] /= cell->vertex(2)[1] - start[1];
-        real[2] /= cell->vertex(4)[2] - start[2];
-        break;
-      default:
-        DEAL_II_NOT_IMPLEMENTED();
-    }
+  // Go through vertices with numbers 1, 2, 4
+  for (unsigned int d = 0; d < dim; ++d)
+    real[d] = (real[d] - start[d]) / (cell->vertex(1 << d)[d] - start[d]);
+
   return real;
+}
+
+
+
+template <int dim, int spacedim>
+void
+MappingCartesian<dim, spacedim>::transform_points_real_to_unit_cell(
+  const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+  const ArrayView<const Point<spacedim>>                     &real_points,
+  const ArrayView<Point<dim>>                                &unit_points) const
+{
+  Assert(is_cartesian(cell), ExcCellNotCartesian());
+  AssertDimension(real_points.size(), unit_points.size());
+
+  if (dim != spacedim)
+    DEAL_II_NOT_IMPLEMENTED();
+
+  const Point<dim> start = cell->vertex(0);
+
+  // Go through vertices with numbers 1, 2, 4
+  std::array<double, dim> inverse_lengths;
+  for (unsigned int d = 0; d < dim; ++d)
+    inverse_lengths[d] = 1. / (cell->vertex(1 << d)[d] - start[d]);
+
+  for (unsigned int i = 0; i < real_points.size(); ++i)
+    for (unsigned int d = 0; d < dim; ++d)
+      unit_points[i][d] = (real_points[i][d] - start[d]) * inverse_lengths[d];
 }
 
 

--- a/tests/mappings/mapping_cartesian_points_real_to_unit.cc
+++ b/tests/mappings/mapping_cartesian_points_real_to_unit.cc
@@ -1,0 +1,109 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+
+// check MappingCartesian::transform_points_real_to_unit_cell, using a case
+// otherwise similar to mapping_points_real_to_unit.cc
+
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/fe/mapping_cartesian.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include "../tests.h"
+
+
+template <int dim>
+void
+test()
+{
+  Triangulation<dim> triangulation;
+  Point<dim>         lower, upper;
+  for (unsigned int d = 0; d < dim; ++d)
+    lower[d] = -0.3 + d * 0.07;
+  for (unsigned int d = 0; d < dim; ++d)
+    upper[d] = 0.45 - d * 0.03;
+
+  GridGenerator::hyper_rectangle(triangulation, lower, upper);
+
+  deallog << "dim=" << dim << std::endl;
+  deallog << "MappingCartesian: ";
+  const unsigned int      n_points = 5;
+  std::vector<Point<dim>> unit_points(Utilities::pow(n_points, dim));
+
+  switch (dim)
+    {
+      case 1:
+        for (unsigned int x = 0; x < n_points; ++x)
+          unit_points[x][0] = static_cast<double>(x) / n_points;
+        break;
+
+      case 2:
+        for (unsigned int x = 0; x < n_points; ++x)
+          for (unsigned int y = 0; y < n_points; ++y)
+            {
+              unit_points[y * n_points + x][0] =
+                static_cast<double>(x) / n_points;
+              unit_points[y * n_points + x][1] =
+                static_cast<double>(y) / n_points;
+            }
+        break;
+
+      case 3:
+        for (unsigned int x = 0; x < n_points; ++x)
+          for (unsigned int y = 0; y < n_points; ++y)
+            for (unsigned int z = 0; z < n_points; ++z)
+              {
+                unit_points[z * n_points * n_points + y * n_points + x][0] =
+                  static_cast<double>(x) / n_points;
+                unit_points[z * n_points * n_points + y * n_points + x][1] =
+                  static_cast<double>(y) / n_points;
+                unit_points[z * n_points * n_points + y * n_points + x][2] =
+                  static_cast<double>(z) / n_points;
+              }
+        break;
+    }
+
+  MappingCartesian<dim>                             mapping;
+  typename Triangulation<dim>::active_cell_iterator cell =
+    triangulation.begin_active();
+  std::vector<Point<dim>> real_points(unit_points.size());
+  for (unsigned int i = 0; i < unit_points.size(); ++i)
+    real_points[i] = mapping.transform_unit_to_real_cell(cell, unit_points[i]);
+  std::vector<Point<dim>> new_points(unit_points.size());
+  mapping.transform_points_real_to_unit_cell(cell, real_points, new_points);
+  for (unsigned int i = 0; i < unit_points.size(); ++i)
+    {
+      // for each of the points, verify that applying the forward map and
+      // then pull back get the same point again
+      AssertThrow(unit_points[i].distance(new_points[i]) < 1e-10,
+                  ExcInternalError());
+    }
+  deallog << "OK" << std::endl;
+}
+
+
+
+int
+main()
+{
+  initlog();
+
+  test<1>();
+  test<2>();
+  test<3>();
+}

--- a/tests/mappings/mapping_cartesian_points_real_to_unit.output
+++ b/tests/mappings/mapping_cartesian_points_real_to_unit.output
@@ -1,0 +1,7 @@
+
+DEAL::dim=1
+DEAL::MappingCartesian: OK
+DEAL::dim=2
+DEAL::MappingCartesian: OK
+DEAL::dim=3
+DEAL::MappingCartesian: OK


### PR DESCRIPTION
Looking at the performance case in https://github.com/dealii/dealii/issues/16796#issuecomment-2027794215 I realized that some internal functions in `MappingCartesian` are somewhat wasteful, performing unnecessary divisions or doing operations for one point at a time in `transform_real_to_unit_cell`. Improve those places and test the new code.