### PR TITLE
Fix two places where TriaAccessor::n_vertices is called repeatedly

### DIFF
--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -1081,11 +1081,12 @@ namespace GridTools
     const Point<spacedim>                                             &position,
     const Mapping<dim, spacedim>                                      &mapping)
   {
-    const auto   vertices         = mapping.get_vertices(cell);
-    double       minimum_distance = position.distance_square(vertices[0]);
-    unsigned int closest_vertex   = 0;
+    const auto         vertices         = mapping.get_vertices(cell);
+    double             minimum_distance = position.distance_square(vertices[0]);
+    unsigned int       closest_vertex   = 0;
+    const unsigned int n_vertices       = cell->n_vertices();
 
-    for (unsigned int v = 1; v < cell->n_vertices(); ++v)
+    for (unsigned int v = 1; v < n_vertices; ++v)
       {
         const double vertex_distance = position.distance_square(vertices[v]);
         if (vertex_distance < minimum_distance)

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -1547,9 +1547,10 @@ TriaAccessor<structdim, dim, spacedim>::bounding_box() const
   std::pair<Point<spacedim>, Point<spacedim>> boundary_points =
     std::make_pair(this->vertex(0), this->vertex(0));
 
-  for (unsigned int v = 1; v < this->n_vertices(); ++v)
+  const unsigned int n_vertices = this->n_vertices();
+  for (unsigned int v = 1; v < n_vertices; ++v)
     {
-      const Point<spacedim> &x = this->vertex(v);
+      const Point<spacedim> x = this->vertex(v);
       for (unsigned int k = 0; k < spacedim; ++k)
         {
           boundary_points.first[k]  = std::min(boundary_points.first[k], x[k]);


### PR DESCRIPTION
Found while looking at the case from https://github.com/dealii/dealii/issues/16796#issuecomment-2027794215. The compiler apparently decides that inlining `n_vertices` is not useful. While we could force inlining, I think it is a better idea to simply set up an integer to have it invariant in the loops.