### PR TITLE
Switch SolverFGMRES to new delayed classical Gram-Schmidt

### DIFF
--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -650,11 +650,11 @@ public:
     /**
      * Constructor. By default, set the maximum basis size to 30.
      */
-    explicit AdditionalData(
-      const unsigned int max_basis_size = 30,
-      const LinearAlgebra::OrthogonalizationStrategy
-        orthogonalization_strategy =
-          LinearAlgebra::OrthogonalizationStrategy::modified_gram_schmidt)
+    explicit AdditionalData(const unsigned int max_basis_size = 30,
+                            const LinearAlgebra::OrthogonalizationStrategy
+                              orthogonalization_strategy =
+                                LinearAlgebra::OrthogonalizationStrategy::
+                                  delayed_classical_gram_schmidt)
       : max_basis_size(max_basis_size)
       , orthogonalization_strategy(orthogonalization_strategy)
     {}


### PR DESCRIPTION
I forgot to switch `SolverFGMRES` to the new classical Gram-Schmidt algorithm with delayed orthogonalization in #16760, see also #16749.

@gassmoeller regarding the tests and sensitive changes we have been discussing, this should be the last one remaining that could make noise. Do you have a list with tests in ASPECT for me that you think could be sensitive? Or I simply run all tests I have on my installation tomorrow.