### PR TITLE
Export compile definitions for dependent targets

### DIFF
--- a/cmake/config/Config.cmake.in
+++ b/cmake/config/Config.cmake.in
@@ -124,6 +124,14 @@ set(DEAL_II_LINKER_FLAGS_DEBUG "@DEAL_II_LINKER_FLAGS_DEBUG@")
 # _additionally_ used for release targets:
 set(DEAL_II_LINKER_FLAGS_RELEASE "@DEAL_II_LINKER_FLAGS_RELEASE@")
 
+# used for all targets:
+set(DEAL_II_DEFINITIONS "@DEAL_II_DEFINITIONS@")
+
+# _additionally_ used for debug targets:
+set(DEAL_II_DEFINITIONS_DEBUG "@DEAL_II_DEFINITIONS_DEBUG@")
+
+# _additionally_ used for release targets:
+set(DEAL_II_DEFINITIONS_RELEASE "@DEAL_II_DEFINITIONS_RELEASE@")
 #
 # MPI runtime:
 #

--- a/cmake/macros/macro_deal_ii_setup_target.cmake
+++ b/cmake/macros/macro_deal_ii_setup_target.cmake
@@ -93,6 +93,10 @@ macro(deal_ii_setup_target _target)
     "${DEAL_II_WARNING_FLAGS} ${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_${_build}}"
     )
 
+  target_compile_definitions(${_target} PRIVATE
+    ${DEAL_II_DEFINITIONS} ${DEAL_II_DEFINITIONS_${_build}}
+    )
+
   get_property(_type TARGET ${_target} PROPERTY TYPE)
   if(NOT "${_type}" STREQUAL "OBJECT_LIBRARY")
     target_link_flags(${_target} PRIVATE

--- a/cmake/macros/macro_insource_setup_target.cmake
+++ b/cmake/macros/macro_insource_setup_target.cmake
@@ -34,6 +34,10 @@ function(insource_setup_target _target _build)
     "${DEAL_II_WARNING_FLAGS} ${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_${_build}}"
     )
 
+  target_compile_definitions(${_target} PRIVATE
+    ${DEAL_II_DEFINITIONS} ${DEAL_II_DEFINITIONS_${_build}}
+    )
+
   get_property(_type TARGET ${_target} PROPERTY TYPE)
   if(NOT "${_type}" STREQUAL "OBJECT_LIBRARY")
     target_link_flags(${_target} PRIVATE


### PR DESCRIPTION
I think #14491 accidentally removed the export of compile definitions from the cmake system (both from Config.cmake.in and the setup_target macro). They were still correctly set for compiling deal.II itself, but dependent targets would not pick them up and so e.g. algorithms in header files behave differently if they are executed from inside deal.II or outside (e.g. `#ifdef DEBUG` would be evaluated differently). Also the build output looks different (same flags different definitions) on dependent targets, which let me wonder for a while what we do wrong when outputting the ASPECT build configuration.
ASPECT was also relying on the presence of NDEBUG definition for another dependent target to activate optimized mode (see discussion in #12503). 

This change should restore the behavior before #14491.