### PR TITLE
Fix ensure_single_trailing_newline() on macs.

### DIFF
--- a/contrib/utilities/indent_common.sh
+++ b/contrib/utilities/indent_common.sh
@@ -325,24 +325,10 @@ process_changed()
 #
 ensure_single_trailing_newline()
 {
-  f=$1
+  file="${1}"
 
-  # Remove newlines at end of file
-  # Check that the current line only contains newlines
-  # If it doesn't match, print it
-  # If it does match and we're not at the end of the file,
-  # append the next line to the current line and repeat the check
-  # If it does match and we're at the end of the file,
-  # remove the line.
-  sed -e :a -e '/^\n*$/{$d;N;};/\n$/ba' $f >$f.tmpi
-
-  # Then add a newline to the end of the file
-  # '$' denotes the end of file
-  # 'a\' appends the following text (which in this case is nothing)
-  # on a new line
-  sed -e '$a\' $f.tmpi >$f.tmp
-
-  diff -q $f $f.tmp >/dev/null || mv $f.tmp $f
-  rm -f $f.tmp $f.tmpi
+  if test $(tail -c1 "$file") ; then
+    echo '' >> "$file"
+  fi
 }
 export -f ensure_single_trailing_newline


### PR DESCRIPTION
I'm not sure exactly why mac's version of sed produces different output here but it is easy enough to use something simpler. Just check if the last character is a newline: if not, then append a newline character.