### PR TITLE
Mark DEAL_II_ALWAYS_INLINE functions as 'inline'.

### DIFF
--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -2658,10 +2658,19 @@ DEAL_II_HOST constexpr inline DEAL_II_ALWAYS_INLINE
  * @relatesalso SymmetricTensor
  */
 template <int rank_, int dim, typename Number, typename OtherNumber>
+<<<<<<< Updated upstream
 DEAL_II_HOST constexpr DEAL_II_ALWAYS_INLINE
   Tensor<rank_, dim, typename ProductType<Number, OtherNumber>::type>
   operator+(const SymmetricTensor<rank_, dim, Number> &left,
             const Tensor<rank_, dim, OtherNumber>     &right)
+=======
+DEAL_II_HOST DEAL_II_ALWAYS_INLINE inline Tensor<
+  rank_,
+  dim,
+  typename ProductType<Number, OtherNumber>::type>
+operator+(const SymmetricTensor<rank_, dim, Number> &left,
+          const Tensor<rank_, dim, OtherNumber>     &right)
+>>>>>>> Stashed changes
 {
   return Tensor<rank_, dim, Number>(left) + right;
 }
@@ -2675,10 +2684,19 @@ DEAL_II_HOST constexpr DEAL_II_ALWAYS_INLINE
  * @relatesalso SymmetricTensor
  */
 template <int rank_, int dim, typename Number, typename OtherNumber>
+<<<<<<< Updated upstream
 DEAL_II_HOST constexpr DEAL_II_ALWAYS_INLINE
   Tensor<rank_, dim, typename ProductType<Number, OtherNumber>::type>
   operator+(const Tensor<rank_, dim, Number>               &left,
             const SymmetricTensor<rank_, dim, OtherNumber> &right)
+=======
+DEAL_II_HOST DEAL_II_ALWAYS_INLINE inline Tensor<
+  rank_,
+  dim,
+  typename ProductType<Number, OtherNumber>::type>
+operator+(const Tensor<rank_, dim, Number>               &left,
+          const SymmetricTensor<rank_, dim, OtherNumber> &right)
+>>>>>>> Stashed changes
 {
   return left + Tensor<rank_, dim, OtherNumber>(right);
 }
@@ -2692,10 +2710,19 @@ DEAL_II_HOST constexpr DEAL_II_ALWAYS_INLINE
  * @relatesalso SymmetricTensor
  */
 template <int rank_, int dim, typename Number, typename OtherNumber>
+<<<<<<< Updated upstream
 DEAL_II_HOST constexpr DEAL_II_ALWAYS_INLINE
   Tensor<rank_, dim, typename ProductType<Number, OtherNumber>::type>
   operator-(const SymmetricTensor<rank_, dim, Number> &left,
             const Tensor<rank_, dim, OtherNumber>     &right)
+=======
+DEAL_II_HOST DEAL_II_ALWAYS_INLINE inline Tensor<
+  rank_,
+  dim,
+  typename ProductType<Number, OtherNumber>::type>
+operator-(const SymmetricTensor<rank_, dim, Number> &left,
+          const Tensor<rank_, dim, OtherNumber>     &right)
+>>>>>>> Stashed changes
 {
   return Tensor<rank_, dim, Number>(left) - right;
 }
@@ -2709,10 +2736,19 @@ DEAL_II_HOST constexpr DEAL_II_ALWAYS_INLINE
  * @relatesalso SymmetricTensor
  */
 template <int rank_, int dim, typename Number, typename OtherNumber>
+<<<<<<< Updated upstream
 DEAL_II_HOST constexpr DEAL_II_ALWAYS_INLINE
   Tensor<rank_, dim, typename ProductType<Number, OtherNumber>::type>
   operator-(const Tensor<rank_, dim, Number>               &left,
             const SymmetricTensor<rank_, dim, OtherNumber> &right)
+=======
+DEAL_II_HOST DEAL_II_ALWAYS_INLINE inline Tensor<
+  rank_,
+  dim,
+  typename ProductType<Number, OtherNumber>::type>
+operator-(const Tensor<rank_, dim, Number>               &left,
+          const SymmetricTensor<rank_, dim, OtherNumber> &right)
+>>>>>>> Stashed changes
 {
   return left - Tensor<rank_, dim, OtherNumber>(right);
 }


### PR DESCRIPTION
For some reason unknown to me, my compiler started to warn as follows:
```
/home/bangerth/p/deal.II/1/dealii/include/deal.II/base/symmetric_tensor.h:2678:3: warning: ‘always_inline’ function might not be inlinable [-Wattributes]
 2678 |   operator+(const Tensor<rank_, dim, Number>               &left,
      |   ^~~~~~~~
/home/bangerth/p/deal.II/1/dealii/include/deal.II/base/symmetric_tensor.h:2678:3: warning: ‘always_inline’ function might not be inlinable [-Wattributes]
/home/bangerth/p/deal.II/1/dealii/include/deal.II/base/symmetric_tensor.h:2678:3: warning: ‘always_inline’ function might not be inlinable [-Wattributes]
```
After some searching, it turns out that the "always inline" attribute is only always honored if the function is actually marked as `inline`, which a number of functions in `symmetric_tensor.h` are not. This patch accordingly annotates them.