### PR TITLE
VectorTools::interpolate: Make common case of vector problem faster

### DIFF
--- a/doc/news/changes/minor/20240403Kronbichler
+++ b/doc/news/changes/minor/20240403Kronbichler
@@ -1,0 +1,5 @@
+Improved: VectorTools::interpolate is now faster for the case of a DoFHandler
+based on an FESystem with a single base element that has classical support
+points (like FE_Q or FE_DGQ).
+<br>
+(Martin Kronbichler, 2024/04/03)


### PR DESCRIPTION
In several applications, I have observed that `VectorTools::interpolate` is quite slow, most recently when looking at our `timing-step_68` benchmark case. The reason is that we ask a `DoFHandler`'s `FESystem` for the generalized support points and mix/match the local results inside https://github.com/dealii/dealii/blob/c76154b11ff0536a7c315ed6335f98e904476711/include/deal.II/numerics/vector_tools_interpolate.templates.h#L396-L397 via https://github.com/dealii/dealii/blob/c76154b11ff0536a7c315ed6335f98e904476711/source/fe/fe_system.cc#L2674-L2693
This is quite expensive and involves a lot of memory allocations. While we can't change the underlying interfaces easily, we can at least detect when the `FiniteElement` consists of a single base element that has support points, in which case we can just pick up the values directly without the indirections.

While there, also avoid some `dynamic_cast` to detect the case of `FESystem` recursively: We can use `n_base_elements()` for that query.