### PR TITLE
MappingQ: Favor get_vertices() over compute_mapping_support_points() if possible

### DIFF
--- a/include/deal.II/fe/mapping_q_internal.h
+++ b/include/deal.II/fe/mapping_q_internal.h
@@ -833,8 +833,8 @@ namespace internal
        * points in real space by a polynomial map.
        */
       InverseQuadraticApproximation(
-        const std::vector<Point<spacedim>> &real_support_points,
-        const std::vector<Point<dim>>      &unit_support_points)
+        const ArrayView<const Point<spacedim>> &real_support_points,
+        const std::vector<Point<dim>>          &unit_support_points)
         : normalization_shift(real_support_points[0])
         , normalization_length(
             1. / real_support_points[0].distance(real_support_points[1]))


### PR DESCRIPTION
This PR uses that for linear `MappingQ`, we do not need to call `compute_mapping_support_points()`, but we can actually use `get_vertices()`, which also returns the deformed state underlying the `MappingQ` object. The advantage is that the latter uses `boost::container::small_vector`, which avoids memory allocations. Since the interfaces use `ArrayView` with my change #16844, not much changes. Of course, we need to introduce logic to use either one or the other case, but I think it is worth it due to the better computational properties.