### PR TITLE
MappingQ: Remove outdated documentation

### DIFF
--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -312,10 +312,6 @@ public:
     /**
      * Initialize the object's member variables related to cell data based on
      * the given arguments.
-     *
-     * The function also calls compute_shape_function_values() to actually set
-     * the member variables related to the values and derivatives of the
-     * mapping shape functions.
      */
     void
     initialize(const UpdateFlags      update_flags,


### PR DESCRIPTION
I saw some mention of arrays in `MappingQ` that we removed with #15125.