### PR TITLE
Add Quadrature::initialize() function taking ArrayView

### DIFF
--- a/include/deal.II/base/quadrature.h
+++ b/include/deal.II/base/quadrature.h
@@ -238,14 +238,6 @@ public:
 
   /**
    * Set the quadrature points and weights to the values provided in the
-   * arguments.
-   */
-  void
-  initialize(const std::vector<Point<dim>> &points,
-             const std::vector<double>     &weights);
-
-  /**
-   * Set the quadrature points and weights to the values provided in the
    * arguments. The weights array is allowed to be empty, in which case the
    * weights are set to infinity. The resulting object is therefore not meant
    * to actually perform integrations, but rather to be used with FEValues

--- a/include/deal.II/base/quadrature.h
+++ b/include/deal.II/base/quadrature.h
@@ -18,6 +18,7 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/array_view.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/subscriptor.h>
 
@@ -242,6 +243,18 @@ public:
   void
   initialize(const std::vector<Point<dim>> &points,
              const std::vector<double>     &weights);
+
+  /**
+   * Set the quadrature points and weights to the values provided in the
+   * arguments. The weights array is allowed to be empty, in which case the
+   * weights are set to infinity. The resulting object is therefore not meant
+   * to actually perform integrations, but rather to be used with FEValues
+   * objects in order to find the position of some points (the quadrature
+   * points in this object) on the transformed cell in real space.
+   */
+  void
+  initialize(const ArrayView<const Point<dim>> &points,
+             const ArrayView<const double>     &weights = {});
 
   /**
    * Number of quadrature points.

--- a/source/base/quadrature.cc
+++ b/source/base/quadrature.cc
@@ -48,24 +48,11 @@ Quadrature<dim>::Quadrature(const unsigned int n_q)
 
 template <int dim>
 void
-Quadrature<dim>::initialize(const std::vector<Point<dim>> &p,
-                            const std::vector<double>     &w)
-{
-  AssertDimension(w.size(), p.size());
-  quadrature_points      = p;
-  weights                = w;
-  is_tensor_product_flag = dim == 1;
-}
-
-
-
-template <int dim>
-void
 Quadrature<dim>::initialize(const ArrayView<const Point<dim>> &points,
                             const ArrayView<const double>     &weights)
 {
   this->weights.clear();
-  if (!weights.empty())
+  if (weights.size() > 0)
     {
       AssertDimension(weights.size(), points.size());
       this->weights.insert(this->weights.end(), weights.begin(), weights.end());

--- a/source/base/quadrature.cc
+++ b/source/base/quadrature.cc
@@ -60,6 +60,31 @@ Quadrature<dim>::initialize(const std::vector<Point<dim>> &p,
 
 
 template <int dim>
+void
+Quadrature<dim>::initialize(const ArrayView<const Point<dim>> &points,
+                            const ArrayView<const double>     &weights)
+{
+  this->weights.clear();
+  if (!weights.empty())
+    {
+      AssertDimension(weights.size(), points.size());
+      this->weights.insert(this->weights.end(), weights.begin(), weights.end());
+    }
+  else
+    this->weights.resize(points.size(),
+                         std::numeric_limits<double>::infinity());
+
+  quadrature_points.clear();
+  quadrature_points.insert(quadrature_points.end(),
+                           points.begin(),
+                           points.end());
+
+  is_tensor_product_flag = dim == 1;
+}
+
+
+
+template <int dim>
 Quadrature<dim>::Quadrature(const std::vector<Point<dim>> &points,
                             const std::vector<double>     &weights)
   : quadrature_points(points)

--- a/tests/base/quadrature_initialize.cc
+++ b/tests/base/quadrature_initialize.cc
@@ -1,0 +1,85 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+
+// test various Quadrature::initialize functions
+
+
+#include <deal.II/base/quadrature_lib.h>
+
+#include "../tests.h"
+
+template <int dim>
+void
+compare_quadratures(const Quadrature<dim> &reference,
+                    const Quadrature<dim> &check)
+{
+  AssertDimension(reference.size(), check.size());
+  for (unsigned int i = 0; i < reference.size(); ++i)
+    {
+      // Check for exact equality because data gets copied, so there should be
+      // no roundoff
+      if (reference.point(i).distance(check.point(i)) > 0)
+        deallog << " error point " << i << reference.point(i) << " vs "
+                << check.point(i);
+      if (reference.weight(i) != check.weight(i))
+        deallog << " error weight " << i << reference.weight(i) << " vs "
+                << check.weight(i);
+    }
+  deallog << "OK" << std::endl;
+}
+
+template <int dim>
+void
+test()
+{
+  deallog.push(std::to_string(dim) + "d");
+  Quadrature<dim> quadrature_2;
+  {
+    QGauss<dim> quad(2);
+    quadrature_2.initialize(quad.get_points(), quad.get_weights());
+    deallog << "Testing initialize(vector&, vector&): ";
+    compare_quadratures(quad, quadrature_2);
+  }
+  {
+    QGauss<dim> quad(3);
+    quadrature_2.initialize(quad.get_points(), quad.get_weights());
+    deallog << "Testing initialize(vector&, vector&): ";
+    compare_quadratures(quad, quadrature_2);
+  }
+  {
+    QGauss<dim> quad(2);
+    quadrature_2.initialize(make_array_view(quad.get_points()),
+                            make_array_view(quad.get_weights()));
+    deallog << "Testing initialize(ArrayView, ArrayView): ";
+    compare_quadratures(quad, quadrature_2);
+  }
+  {
+    Quadrature<dim> quad(quadrature_2.get_points());
+    quadrature_2.initialize(make_array_view(quad.get_points()));
+    deallog << "Testing initialize(ArrayView): ";
+    compare_quadratures(quad, quadrature_2);
+  }
+  deallog.pop();
+}
+
+int
+main()
+{
+  initlog();
+
+  test<1>();
+  test<2>();
+}

--- a/tests/base/quadrature_initialize.output
+++ b/tests/base/quadrature_initialize.output
@@ -1,0 +1,9 @@
+
+DEAL:1d::Testing initialize(vector&, vector&): OK
+DEAL:1d::Testing initialize(vector&, vector&): OK
+DEAL:1d::Testing initialize(ArrayView, ArrayView): OK
+DEAL:1d::Testing initialize(ArrayView): OK
+DEAL:2d::Testing initialize(vector&, vector&): OK
+DEAL:2d::Testing initialize(vector&, vector&): OK
+DEAL:2d::Testing initialize(ArrayView, ArrayView): OK
+DEAL:2d::Testing initialize(ArrayView): OK


### PR DESCRIPTION
In a follow-up PR, I would like to fill entries into a quadrature formula from an already existing data contained in `ArrayView`. Since we already have `Quadrature::initialize(std::vector<Point<dim>>&, std::vector<double>&)`, I think it makes sense to also add a similar `initialize` function taking `ArrayView` objects instead.

When writing a test, I could not find an existing test for `Quadrature::initialize()`, so I decided to test both options with my new test.