### PR TITLE
 NonMatching::MappingInfo: Avoid memory allocations in reinit()

### DIFF
--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -59,6 +59,8 @@ namespace NonMatching
     template <int dim, int spacedim>
     class ComputeMappingDataHelper;
   }
+  template <int dim, int spacedim, typename Number>
+  class MappingInfo;
 } // namespace NonMatching
 
 
@@ -656,6 +658,18 @@ public:
     InternalDataBase(const InternalDataBase &) = delete;
 
     /**
+     * This function initializes the data fields related to evaluation of the
+     * mapping on cells, implemented by (derived) classes. This function is
+     * used both when setting up a field of this class for the first time or
+     * when a new Quadrature formula should be considered without creating an
+     * entirely new object. This is used when the number of evaluation points
+     * is different on each cell, e.g. when using FEPointEvaluation for
+     * handling particles or with certain non-matching problem settings.
+     */
+    virtual void
+    reinit(const UpdateFlags update_flags, const Quadrature<dim> &quadrature);
+
+    /**
      * Virtual destructor for derived classes
      */
     virtual ~InternalDataBase() = default;
@@ -682,7 +696,6 @@ public:
     virtual std::size_t
     memory_consumption() const;
   };
-
 
 protected:
   /**
@@ -1323,6 +1336,8 @@ public:
   friend class FESubfaceValues<dim, spacedim>;
   friend class NonMatching::FEImmersedSurfaceValues<dim>;
   friend class NonMatching::internal::ComputeMappingDataHelper<dim, spacedim>;
+  template <int, int, typename>
+  friend class NonMatching::MappingInfo;
 };
 
 

--- a/include/deal.II/fe/mapping_cartesian.h
+++ b/include/deal.II/fe/mapping_cartesian.h
@@ -218,6 +218,11 @@ public:
      */
     InternalData(const Quadrature<dim> &quadrature);
 
+    // Documentation see Mapping::InternalDataBase.
+    virtual void
+    reinit(const UpdateFlags      update_flags,
+           const Quadrature<dim> &quadrature) override;
+
     /**
      * Return an estimate (in bytes) for the memory consumption of this object.
      */
@@ -243,7 +248,9 @@ public:
     mutable double volume_element;
 
     /**
-     * Vector of all quadrature points. Especially, all points on all faces.
+     * Location of quadrature points of faces or subfaces in 3d with all
+     * possible orientations. Can be accessed with the correct offset provided
+     * via QProjector::DataSetDescriptor. Not needed/used for cells.
      */
     std::vector<Point<dim>> quadrature_points;
   };
@@ -335,7 +342,8 @@ private:
   maybe_update_cell_quadrature_points(
     const typename Triangulation<dim, spacedim>::cell_iterator &cell,
     const InternalData                                         &data,
-    std::vector<Point<dim>> &quadrature_points) const;
+    const ArrayView<const Point<dim>> &unit_quadrature_points,
+    std::vector<Point<dim>>           &quadrature_points) const;
 
   /**
    * Compute the quadrature points if the UpdateFlags of the incoming
@@ -362,19 +370,6 @@ private:
     const unsigned int                                          face_no,
     const unsigned int                                          sub_no,
     const InternalData                                         &data,
-    std::vector<Point<dim>> &quadrature_points) const;
-
-  /**
-   * Transform quadrature points in InternalData to real space by scaling unit
-   * coordinates with cell_extents in each direction.
-   *
-   * Called from the various maybe_update_*_quadrature_points functions.
-   */
-  void
-  transform_quadrature_points(
-    const typename Triangulation<dim, spacedim>::cell_iterator &cell,
-    const InternalData                                         &data,
-    const typename QProjector<dim>::DataSetDescriptor          &offset,
     std::vector<Point<dim>> &quadrature_points) const;
 
   /**

--- a/include/deal.II/fe/mapping_fe.h
+++ b/include/deal.II/fe/mapping_fe.h
@@ -185,23 +185,15 @@ public:
      */
     InternalData(const FiniteElement<dim, spacedim> &fe);
 
-    /**
-     * Initialize the object's member variables related to cell data based on
-     * the given arguments.
-     *
-     * The function also calls compute_shape_function_values() to actually set
-     * the member variables related to the values and derivatives of the
-     * mapping shape functions.
-     */
-    void
-    initialize(const UpdateFlags      update_flags,
-               const Quadrature<dim> &quadrature,
-               const unsigned int     n_original_q_points);
+    // Documentation see Mapping::InternalDataBase.
+    virtual void
+    reinit(const UpdateFlags      update_flags,
+           const Quadrature<dim> &quadrature) override;
 
     /**
      * Initialize the object's member variables related to cell and face data
      * based on the given arguments. In order to initialize cell data, this
-     * function calls initialize().
+     * function calls reinit().
      */
     void
     initialize_face(const UpdateFlags      update_flags,

--- a/include/deal.II/fe/mapping_manifold.h
+++ b/include/deal.II/fe/mapping_manifold.h
@@ -167,18 +167,10 @@ public:
      */
     InternalData() = default;
 
-    /**
-     * Initialize the object's member variables related to cell data based on
-     * the given arguments.
-     *
-     * The function also calls compute_shape_function_values() to actually set
-     * the member variables related to the values and derivatives of the
-     * mapping shape functions.
-     */
-    void
-    initialize(const UpdateFlags      update_flags,
-               const Quadrature<dim> &quadrature,
-               const unsigned int     n_original_q_points);
+    // Documentation see Mapping::InternalDataBase.
+    virtual void
+    reinit(const UpdateFlags      update_flags,
+           const Quadrature<dim> &quadrature) override;
 
     /**
      * Initialize the object's member variables related to cell and face data
@@ -390,37 +382,6 @@ private:
 /*----------------------------------------------------------------------*/
 
 #ifndef DOXYGEN
-
-template <int dim, int spacedim>
-inline void
-MappingManifold<dim, spacedim>::InternalData::store_vertices(
-  const typename Triangulation<dim, spacedim>::cell_iterator &cell) const
-{
-  vertices.resize(GeometryInfo<dim>::vertices_per_cell);
-  for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
-    vertices[i] = cell->vertex(i);
-  this->cell = cell;
-}
-
-
-template <int dim, int spacedim>
-inline void
-MappingManifold<dim, spacedim>::InternalData::
-  compute_manifold_quadrature_weights(const Quadrature<dim> &quad)
-{
-  cell_manifold_quadrature_weights.resize(
-    quad.size(), std::vector<double>(GeometryInfo<dim>::vertices_per_cell));
-  for (unsigned int q = 0; q < quad.size(); ++q)
-    {
-      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
-        {
-          cell_manifold_quadrature_weights[q][i] =
-            GeometryInfo<dim>::d_linear_shape_function(quad.point(q), i);
-        }
-    }
-}
-
-
 
 template <int dim, int spacedim>
 inline bool

--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -309,14 +309,10 @@ public:
      */
     InternalData(const unsigned int polynomial_degree);
 
-    /**
-     * Initialize the object's member variables related to cell data based on
-     * the given arguments.
-     */
-    void
-    initialize(const UpdateFlags      update_flags,
-               const Quadrature<dim> &quadrature,
-               const unsigned int     n_original_q_points);
+    // Documentation see Mapping::InternalDataBase.
+    virtual void
+    reinit(const UpdateFlags      update_flags,
+           const Quadrature<dim> &quadrature) override;
 
     /**
      * Initialize the object's member variables related to cell and face data

--- a/source/fe/fe_hermite.cc
+++ b/source/fe/fe_hermite.cc
@@ -247,8 +247,7 @@ namespace internal
       const typename Mapping<1, spacedim>::InternalDataBase &mapping_data,
       Table<2, Number>                                      &value_list)
     {
-      unsigned int n_q_points;
-      double       cell_extent = 1.0;
+      double cell_extent = 1.0;
 
       // Check mapping_data is associated with a compatible mapping class
       if (dynamic_cast<const typename MappingCartesian<1>::InternalData *>(
@@ -257,7 +256,6 @@ namespace internal
           const typename MappingCartesian<1>::InternalData *data =
             dynamic_cast<const typename MappingCartesian<1>::InternalData *>(
               &mapping_data);
-          n_q_points  = data->quadrature_points.size();
           cell_extent = data->cell_extents[0];
         }
       else
@@ -270,8 +268,6 @@ namespace internal
 
       AssertDimension(value_list.size(0), n_dofs_per_cell);
       AssertDimension(n_dofs_per_cell, 2 * regularity + 2);
-      AssertIndexRange(n_q_points_out, n_q_points + 1);
-      (void)n_q_points;
 
       std::vector<unsigned int> l2h =
         hermite_lexicographic_to_hierarchic_numbering<1>(regularity);
@@ -306,7 +302,6 @@ namespace internal
       const typename Mapping<2, spacedim>::InternalDataBase &mapping_data,
       Table<2, Number>                                      &value_list)
     {
-      unsigned int n_q_points;
       Tensor<1, 2> cell_extents;
 
       // Check mapping_data is associated with a compatible mapping class
@@ -316,7 +311,6 @@ namespace internal
           const typename MappingCartesian<2>::InternalData *data =
             dynamic_cast<const typename MappingCartesian<2>::InternalData *>(
               &mapping_data);
-          n_q_points   = data->quadrature_points.size();
           cell_extents = data->cell_extents;
         }
       else
@@ -330,8 +324,6 @@ namespace internal
 
       AssertDimension(value_list.size(0), n_dofs_per_cell);
       AssertDimension(n_dofs_per_dim * n_dofs_per_dim, n_dofs_per_cell);
-      AssertIndexRange(n_q_points_out, n_q_points + 1);
-      (void)n_q_points;
 
       std::vector<unsigned int> l2h =
         hermite_lexicographic_to_hierarchic_numbering<2>(regularity);
@@ -380,7 +372,6 @@ namespace internal
       const typename Mapping<3, spacedim>::InternalDataBase &mapping_data,
       Table<2, Number>                                      &value_list)
     {
-      unsigned int n_q_points;
       Tensor<1, 3> cell_extents;
 
       // Check mapping_data is associated with a compatible mapping class
@@ -390,7 +381,6 @@ namespace internal
           const typename MappingCartesian<3>::InternalData *data =
             dynamic_cast<const typename MappingCartesian<3>::InternalData *>(
               &mapping_data);
-          n_q_points   = data->quadrature_points.size();
           cell_extents = data->cell_extents;
         }
       else
@@ -405,8 +395,6 @@ namespace internal
 
       AssertDimension(value_list.size(0), n_dofs_per_cell);
       AssertDimension(Utilities::pow(n_dofs_per_dim, 3), n_dofs_per_cell);
-      AssertIndexRange(n_q_points_out, n_q_points + 1);
-      (void)n_q_points;
 
       std::vector<unsigned int> l2h =
         hermite_lexicographic_to_hierarchic_numbering<3>(regularity);

--- a/source/fe/mapping.cc
+++ b/source/fe/mapping.cc
@@ -270,6 +270,16 @@ Mapping<dim, spacedim>::InternalDataBase::InternalDataBase()
 
 
 template <int dim, int spacedim>
+void
+Mapping<dim, spacedim>::InternalDataBase::reinit(const UpdateFlags,
+                                                 const Quadrature<dim> &)
+{
+  DEAL_II_ASSERT_UNREACHABLE();
+}
+
+
+
+template <int dim, int spacedim>
 std::size_t
 Mapping<dim, spacedim>::InternalDataBase::memory_consumption() const
 {

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -78,10 +78,8 @@ MappingQ<dim, spacedim>::InternalData::memory_consumption() const
 
 template <int dim, int spacedim>
 void
-MappingQ<dim, spacedim>::InternalData::initialize(
-  const UpdateFlags      update_flags,
-  const Quadrature<dim> &quadrature,
-  const unsigned int     n_original_q_points)
+MappingQ<dim, spacedim>::InternalData::reinit(const UpdateFlags update_flags,
+                                              const Quadrature<dim> &quadrature)
 {
   // store the flags in the internal data object so we can access them
   // in fill_fe_*_values()
@@ -90,7 +88,7 @@ MappingQ<dim, spacedim>::InternalData::initialize(
   const unsigned int n_q_points = quadrature.size();
 
   if (this->update_each & update_volume_elements)
-    volume_elements.resize(n_original_q_points);
+    volume_elements.resize(n_q_points);
 
   tensor_product_quadrature = quadrature.is_tensor_product();
 
@@ -163,7 +161,7 @@ MappingQ<dim, spacedim>::InternalData::initialize_face(
   const Quadrature<dim> &quadrature,
   const unsigned int     n_original_q_points)
 {
-  initialize(update_flags, quadrature, n_original_q_points);
+  reinit(update_flags, quadrature);
 
   quadrature_points = quadrature.get_points();
 
@@ -785,9 +783,7 @@ MappingQ<dim, spacedim>::get_data(const UpdateFlags      update_flags,
 {
   std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
     std::make_unique<InternalData>(polynomial_degree);
-  auto &data = dynamic_cast<InternalData &>(*data_ptr);
-  data.initialize(this->requires_update_flags(update_flags), q, q.size());
-
+  data_ptr->reinit(update_flags, q);
   return data_ptr;
 }
 


### PR DESCRIPTION
This PR ~~building on top of #16853~~ avoids several expensive memory allocations in `MappingInfo::reinit(cell_iterator, ArrayView)`, by using a `Quadrature` object that keeps a copy of the points. We might have further ideas to avoid data copies in the future, but this PR does the most fundamental part of avoiding frequent reallocations.

Fixes #15650.