### PR TITLE
Avoid std::pow in BarycentricPolynomials

### DIFF
--- a/include/deal.II/base/polynomials_barycentric.h
+++ b/include/deal.II/base/polynomials_barycentric.h
@@ -687,7 +687,7 @@ BarycentricPolynomial<dim, Number>::value(const Point<dim> &point) const
 
       auto temp = Number(1);
       for (unsigned int d = 0; d < dim + 1; ++d)
-        temp *= std::pow(b_point[d], indices[d]);
+        temp *= Utilities::pow(b_point[d], indices[d]);
       result += coef * temp;
     }
 


### PR DESCRIPTION
Fix #14117. Thanks to #16439, there is not much to do any more, so let's close this old issue.