### PR TITLE
Test: cgal/cgal_mesh_criteria: disable floating point exceptions

### DIFF
--- a/tests/cgal/cgal_mesh_criteria.cc
+++ b/tests/cgal/cgal_mesh_criteria.cc
@@ -65,6 +65,13 @@ test()
 int
 main()
 {
+  // CGAL uses hand-optimized AVX instructions for certain performance
+  // critical operations that can create (temporary) signalling NaNs and
+  // trigger a spurious floating point exception. Thus disable FE_INVALID:
+#if defined(DEBUG) && defined(DEAL_II_HAVE_FP_EXCEPTIONS)
+  fedisableexcept(FE_INVALID);
+#endif
+
   initlog();
   test();
 }


### PR DESCRIPTION
We seem to trigger a floating point exception for certain versions of the CGAL (header) library. Thus, disable floating point exceptions for the test.

In reference to #16822
