### PR TITLE
Remove redundant defaulted copy assignment operator for VectorizedArrayIterator

### DIFF
--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -135,12 +135,6 @@ public:
   }
 
   /**
-   * Copy assignment.
-   */
-  constexpr VectorizedArrayIterator<T> &
-  operator=(const VectorizedArrayIterator<T> &other) = default;
-
-  /**
    * Dereferencing operator (const version): returns the value of the current
    * lane.
    */


### PR DESCRIPTION
Fixes https://github.com/dealii/dealii/issues/16867.