### PR TITLE
Compatibility with SUNDIALS 7.

### DIFF
--- a/include/deal.II/sundials/sundials_types.h
+++ b/include/deal.II/sundials/sundials_types.h
@@ -25,11 +25,13 @@ DEAL_II_NAMESPACE_OPEN
 namespace SUNDIALS
 {
 /**
- * Alias for the real type used by SUNDIALS.
+ * Alias for the bool and real types used by SUNDIALS.
  */
 #  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+  using booltype = sunbooleantype;
   using realtype = ::sunrealtype;
 #  else
+  using booltype = booleantype;
   using realtype = ::realtype;
 #  endif
 } // namespace SUNDIALS

--- a/include/deal.II/sundials/sunlinsol_wrapper.h
+++ b/include/deal.II/sundials/sunlinsol_wrapper.h
@@ -59,7 +59,9 @@ namespace SUNDIALS
      * @param a_times_fn A function pointer to the function that computes A*v
      * @param linsol_ctx The context object used to set up the linear solver and all vectors
      */
-    SundialsOperator(void *A_data, ATimesFn a_times_fn, SUNContext linsol_ctx);
+    SundialsOperator(void       *A_data,
+                     SUNATimesFn a_times_fn,
+                     SUNContext  linsol_ctx);
 #  else
     /**
      * Constructor.
@@ -76,17 +78,23 @@ namespace SUNDIALS
      */
     void *A_data;
 
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+    /**
+     * %Function pointer declared by SUNDIALS to evaluate the matrix vector
+     * product.
+     */
+    SUNATimesFn a_times_fn;
+
+    /**
+     * Context object used for SUNDIALS logging.
+     */
+    SUNContext linsol_ctx;
+#  else
     /**
      * %Function pointer declared by SUNDIALS to evaluate the matrix vector
      * product.
      */
     ATimesFn a_times_fn;
-
-#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
-    /**
-     * Context object used for SUNDIALS logging.
-     */
-    SUNContext linsol_ctx;
 #  endif
   };
 
@@ -124,10 +132,10 @@ namespace SUNDIALS
      * 6.0.0. If you are using an earlier version of SUNDIALS then you need to
      * use the other constructor.
      */
-    SundialsPreconditioner(void      *P_data,
-                           PSolveFn   p_solve_fn,
-                           SUNContext linsol_ctx,
-                           double     tol);
+    SundialsPreconditioner(void       *P_data,
+                           SUNPSolveFn p_solve_fn,
+                           SUNContext  linsol_ctx,
+                           double      tol);
 #  else
     /**
      * Constructor.
@@ -150,17 +158,23 @@ namespace SUNDIALS
      */
     void *P_data;
 
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+    /**
+     * %Function pointer to a function that computes the preconditioner
+     * application.
+     */
+    SUNPSolveFn p_solve_fn;
+
+    /**
+     * Context object used for SUNDIALS logging.
+     */
+    SUNContext linsol_ctx;
+#  else
     /**
      * %Function pointer to a function that computes the preconditioner
      * application.
      */
     PSolveFn p_solve_fn;
-
-#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
-    /**
-     * Context object used for SUNDIALS logging.
-     */
-    SUNContext linsol_ctx;
 #  endif
 
     /**

--- a/source/sundials/arkode.cc
+++ b/source/sundials/arkode.cc
@@ -520,18 +520,14 @@ namespace SUNDIALS
                 lr);
             };
 
-            auto jacobian_solver_setup_callback = [](SUNDIALS::realtype t,
-                                                     N_Vector           y,
-                                                     N_Vector           fy,
-#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
-                                                     sunbooleantype  jok,
-                                                     sunbooleantype *jcurPtr,
-#  else
-                                                     booleantype  jok,
-                                                     booleantype *jcurPtr,
-#  endif
-                                                     SUNDIALS::realtype gamma,
-                                                     void *user_data) -> int {
+            auto jacobian_solver_setup_callback =
+              [](SUNDIALS::realtype  t,
+                 N_Vector            y,
+                 N_Vector            fy,
+                 SUNDIALS::booltype  jok,
+                 SUNDIALS::booltype *jcurPtr,
+                 SUNDIALS::realtype  gamma,
+                 void               *user_data) -> int {
               Assert(user_data != nullptr, ExcInternalError());
               ARKode<VectorType> &solver =
                 *static_cast<ARKode<VectorType> *>(user_data);
@@ -641,13 +637,8 @@ namespace SUNDIALS
 #  endif
           }
 
-#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
-        sunbooleantype mass_time_dependent =
+        SUNDIALS::booltype mass_time_dependent =
           data.mass_is_time_independent ? SUNFALSE : SUNTRUE;
-#  else
-        booleantype mass_time_dependent =
-          data.mass_is_time_independent ? SUNFALSE : SUNTRUE;
-#  endif
 
         status = ARKStepSetMassLinearSolver(arkode_mem,
                                             sun_mass_linear_solver,

--- a/source/sundials/arkode.cc
+++ b/source/sundials/arkode.cc
@@ -69,12 +69,19 @@ namespace SUNDIALS
   {
     set_functions_to_trigger_an_assert();
 
-#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
     // SUNDIALS will always duplicate communicators if we provide them. This
     // can cause problems if SUNDIALS is configured with MPI and we pass along
     // MPI_COMM_SELF in a serial application as MPI won't be
     // initialized. Hence, work around that by just not providing a
     // communicator in that case.
+#  if DEAL_II_SUNDIALS_VERSION_GTE(7, 0, 0)
+    const int status =
+      SUNContext_Create(mpi_communicator == MPI_COMM_SELF ? SUN_COMM_NULL :
+                                                            mpi_communicator,
+                        &arkode_ctx);
+    (void)status;
+    AssertARKode(status);
+#  elif DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
     const int status =
       SUNContext_Create(mpi_communicator == MPI_COMM_SELF ? nullptr :
                                                             &mpi_communicator,
@@ -239,9 +246,20 @@ namespace SUNDIALS
     int status;
     (void)status;
 
-#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+#  if DEAL_II_SUNDIALS_VERSION_GTE(7, 0, 0)
     status = SUNContext_Free(&arkode_ctx);
     AssertARKode(status);
+
+    // Same comment applies as in class constructor:
+    status =
+      SUNContext_Create(mpi_communicator == MPI_COMM_SELF ? SUN_COMM_NULL :
+                                                            mpi_communicator,
+                        &arkode_ctx);
+    AssertARKode(status);
+#  elif DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+    status = SUNContext_Free(&arkode_ctx);
+    AssertARKode(status);
+
     // Same comment applies as in class constructor:
     status =
       SUNContext_Create(mpi_communicator == MPI_COMM_SELF ? nullptr :
@@ -409,7 +427,7 @@ namespace SUNDIALS
 #  else
             sun_linear_solver =
               SUNLinSol_SPGMR(y_template,
-                              PREC_NONE,
+                              SUN_PREC_NONE,
                               0 /*krylov subvectors, 0 uses default*/,
                               arkode_ctx);
 #  endif
@@ -505,8 +523,13 @@ namespace SUNDIALS
             auto jacobian_solver_setup_callback = [](SUNDIALS::realtype t,
                                                      N_Vector           y,
                                                      N_Vector           fy,
-                                                     booleantype        jok,
-                                                     booleantype       *jcurPtr,
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+                                                     sunbooleantype  jok,
+                                                     sunbooleantype *jcurPtr,
+#  else
+                                                     booleantype  jok,
+                                                     booleantype *jcurPtr,
+#  endif
                                                      SUNDIALS::realtype gamma,
                                                      void *user_data) -> int {
               Assert(user_data != nullptr, ExcInternalError());
@@ -612,13 +635,20 @@ namespace SUNDIALS
 #  else
             sun_mass_linear_solver =
               SUNLinSol_SPGMR(y_template,
-                              PREC_NONE,
+                              SUN_PREC_NONE,
                               0 /*krylov subvectors, 0 uses default*/,
                               arkode_ctx);
 #  endif
           }
+
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+        sunbooleantype mass_time_dependent =
+          data.mass_is_time_independent ? SUNFALSE : SUNTRUE;
+#  else
         booleantype mass_time_dependent =
           data.mass_is_time_independent ? SUNFALSE : SUNTRUE;
+#  endif
+
         status = ARKStepSetMassLinearSolver(arkode_mem,
                                             sun_mass_linear_solver,
                                             nullptr,

--- a/source/sundials/sunlinsol_wrapper.cc
+++ b/source/sundials/sunlinsol_wrapper.cc
@@ -144,12 +144,16 @@ namespace SUNDIALS
         , pending_exception(pending_exception)
       {}
 
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+      SUNATimesFn a_times_fn;
+      SUNPSetupFn preconditioner_setup;
+      SUNPSolveFn preconditioner_solve;
+
+      SUNContext linsol_ctx;
+#  else
       ATimesFn a_times_fn;
       PSetupFn preconditioner_setup;
       PSolveFn preconditioner_solve;
-
-#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
-      SUNContext linsol_ctx;
 #  endif
 
       LinearSolveFunction<VectorType> lsolve;
@@ -254,10 +258,15 @@ namespace SUNDIALS
     }
 
 
-
     template <typename VectorType>
     int
-    arkode_linsol_set_a_times(SUNLinearSolver LS, void *A_data, ATimesFn ATimes)
+    arkode_linsol_set_a_times(SUNLinearSolver LS,
+                              void           *A_data,
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+                              SUNATimesFn ATimes)
+#  else
+                              ATimesFn        ATimes)
+#  endif
     {
       LinearSolverContent<VectorType> *content = access_content<VectorType>(LS);
 
@@ -272,8 +281,13 @@ namespace SUNDIALS
     int
     arkode_linsol_set_preconditioner(SUNLinearSolver LS,
                                      void           *P_data,
-                                     PSetupFn        p_setup,
-                                     PSolveFn        p_solve)
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+                                     SUNPSetupFn p_setup,
+                                     SUNPSolveFn p_solve)
+#  else
+                                     PSetupFn p_setup,
+                                     PSolveFn p_solve)
+#  endif
     {
       LinearSolverContent<VectorType> *content = access_content<VectorType>(LS);
 
@@ -342,9 +356,9 @@ namespace SUNDIALS
 
 #  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
   template <typename VectorType>
-  SundialsOperator<VectorType>::SundialsOperator(void      *A_data,
-                                                 ATimesFn   a_times_fn,
-                                                 SUNContext linsol_ctx)
+  SundialsOperator<VectorType>::SundialsOperator(void       *A_data,
+                                                 SUNATimesFn a_times_fn,
+                                                 SUNContext  linsol_ctx)
     : A_data(A_data)
     , a_times_fn(a_times_fn)
     , linsol_ctx(linsol_ctx)
@@ -394,10 +408,10 @@ namespace SUNDIALS
 #  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
   template <typename VectorType>
   SundialsPreconditioner<VectorType>::SundialsPreconditioner(
-    void      *P_data,
-    PSolveFn   p_solve_fn,
-    SUNContext linsol_ctx,
-    double     tol)
+    void       *P_data,
+    SUNPSolveFn p_solve_fn,
+    SUNContext  linsol_ctx,
+    double      tol)
     : P_data(P_data)
     , p_solve_fn(p_solve_fn)
     , linsol_ctx(linsol_ctx)

--- a/source/sundials/sunlinsol_wrapper.cc
+++ b/source/sundials/sunlinsol_wrapper.cc
@@ -263,10 +263,11 @@ namespace SUNDIALS
     arkode_linsol_set_a_times(SUNLinearSolver LS,
                               void           *A_data,
 #  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
-                              SUNATimesFn ATimes)
+                              SUNATimesFn ATimes
 #  else
-                              ATimesFn        ATimes)
+                              ATimesFn        ATimes
 #  endif
+    )
     {
       LinearSolverContent<VectorType> *content = access_content<VectorType>(LS);
 
@@ -283,11 +284,12 @@ namespace SUNDIALS
                                      void           *P_data,
 #  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
                                      SUNPSetupFn p_setup,
-                                     SUNPSolveFn p_solve)
+                                     SUNPSolveFn p_solve
 #  else
                                      PSetupFn p_setup,
-                                     PSolveFn p_solve)
+                                     PSolveFn p_solve
 #  endif
+    )
     {
       LinearSolverContent<VectorType> *content = access_content<VectorType>(LS);
 


### PR DESCRIPTION
On my laptop I cannot compile deal.II with SUNDIALS 7.

In their changelog, I have found that various types have been deprecated.
https://sundials.readthedocs.io/en/latest/kinsol/Introduction_link.html#changes-from-previous-versions

Deprecated in SUNDIALS 6:
- ATimesFn -> SUNATimesFn
- PSetupFn -> SUNPSetupFn
- PSolveFn -> SUNPSolveFn
- PREC_NONE -> SUN_PREC_NONE
- booleantype -> sunbooleantype
- kinsol/kinsol_direct.h -> kinsol/kinsol_ls.h

Since SUNDIALS 7, they introduced the SUNComm type, and `SUNContext_Create` now expects such a type and no longer takes `void*`.

---

This patch does not restore compatibility entirely. I need help with the `n_vector.h` construct. A simple switch from `get_communicator_as_void_ptr` to `get_communicator` does not work. (FYI @bangerth https://github.com/LLNL/sundials/issues/275)

```
.../dealii/include/deal.II/sundials/n_vector.templates.h:1241:33: error: no matches converting function ‘get_communicator_as_void_ptr’ to type ‘struct ompi_communicator_t* (*)(N_Vector)’ {aka ‘struct ompi_communicator_t* (*)(struct _generic_N_Vector*)’}
 1241 |       v->ops->nvgetcommunicator =
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~^
 1242 |         &NVectorOperations::get_communicator_as_void_ptr<VectorType>;
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.../dealii/include/deal.II/sundials/n_vector.templates.h:733:7: note: candidate is: ‘template<class VectorType> void* dealii::SUNDIALS::internal::NVectorOperations::get_communicator_as_void_ptr(N_Vector)’
  733 |       get_communicator_as_void_ptr(N_Vector v)
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```