### PR TITLE
Un-hardcode 2d orientation.

### DIFF
--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -1529,8 +1529,9 @@ public:
    * combined_orientation of that line, return the local dof which accounts for
    * @p combined_orientation.
    *
-   * @note In both 1d and all-quadrilateral meshes in 2d all lines have the
-   * standard orientation.
+   * @note In both 1d and 2d all-quadrilateral meshes all lines have the
+   * standard orientation. However, since 2d meshes may contain both
+   * quadrilaterals and triangles, this assumption cannot be made in this class.
    */
   unsigned int
   adjust_line_dof_index_for_line_orientation(
@@ -2471,13 +2472,11 @@ protected:
   std::vector<Table<2, int>> adjust_quad_dof_index_for_face_orientation_table;
 
   /**
-   * For lines with non-standard line_orientation in 3d, the dofs on lines
+   * For lines with non-standard orientation in 2d or 3d, the dofs on lines
    * have to be permuted in order to be combined with the correct shape
    * functions. Given a local dof @p index on a line, return the shift in the
    * local index, if the line has non-standard line_orientation, i.e.
-   * <code>old_index + shift = new_index</code>. In 2d and 1d there is no need
-   * for permutation so the vector is empty. In 3d it has the size of
-   * #dofs_per_line.
+   * <code>old_index + shift = new_index</code>.
    *
    * The constructor of this class fills this table with zeros, i.e.,
    * no permutation at all. Derived finite element classes have to

--- a/include/deal.II/fe/fe_q_base.h
+++ b/include/deal.II/fe/fe_q_base.h
@@ -307,11 +307,12 @@ protected:
   initialize_unit_face_support_points(const std::vector<Point<1>> &points);
 
   /**
-   * Initialize the @p adjust_quad_dof_index_for_face_orientation_table field
-   * of the FiniteElement class. Called from initialize().
+   * Initialize the @p adjust_quad_dof_index_for_face_orientation_table and
+   * adjust_line_dof_index_for_line_orientation_table tables of the
+   * FiniteElement class. Called from initialize().
    */
   void
-  initialize_quad_dof_index_permutation();
+  initialize_dof_index_permutations();
 
   /**
    * Forward declaration of a class into which we put significant parts of the

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -569,15 +569,6 @@ FiniteElement<dim, spacedim>::face_to_cell_index(
   AssertIndexRange(face_index, this->n_dofs_per_face(face));
   AssertIndexRange(face, this->reference_cell().n_faces());
 
-  // TODO: we could presumably solve the 3d case below using the
-  // adjust_quad_dof_index_for_face_orientation_table field. For the 2d case, we
-  // can't use adjust_line_dof_index_for_line_orientation_table since that array
-  // is not populated for elements with quadrilateral reference cells
-  // (presumably because we thought that there are no flipped edges in 2d, but
-  // these can happen in DoFTools::make_periodicity_constraints(), for example).
-  // so we would need to either fill this field, or rely on derived classes
-  // implementing this function, as we currently do
-
   // see the function's documentation for an explanation of this
   // assertion -- in essence, derived classes have to implement
   // an overloaded version of this function if we are to use any
@@ -591,7 +582,7 @@ FiniteElement<dim, spacedim>::face_to_cell_index(
              "an overloaded version but apparently hasn't done so. See "
              "the documentation of this function for more information."));
 
-  // we need to distinguish between DoFs on vertices, lines and in 3d quads.
+  // we need to distinguish between DoFs on vertices, lines and (in 3d) quads.
   // do so in a sequence of if-else statements
   if (face_index < this->get_first_face_line_index(face))
     // DoF is on a vertex
@@ -685,19 +676,11 @@ FiniteElement<dim, spacedim>::adjust_line_dof_index_for_line_orientation(
   const unsigned int  index,
   const unsigned char combined_orientation) const
 {
-  // We orient quads (and 1D meshes are always oriented) so always skip those
-  // cases
-  //
-  // TODO - we may want to change this in the future: see also the notes in
-  // face_to_cell_index()
   Assert(combined_orientation ==
              ReferenceCell::default_combined_face_orientation() ||
            combined_orientation ==
              ReferenceCell::reversed_combined_line_orientation(),
          ExcInternalError());
-  if (this->reference_cell() == ReferenceCells::Line ||
-      this->reference_cell() == ReferenceCells::Quadrilateral)
-    return index;
 
   AssertIndexRange(index, this->n_dofs_per_line());
   Assert(adjust_line_dof_index_for_line_orientation_table.size() ==

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -1662,9 +1662,7 @@ FE_Q_Base<dim, spacedim>::has_support_on_face(
       const unsigned int quad_index =
         (shape_index - this->get_first_quad_index(0)) /
         this->n_dofs_per_quad(face_index); // this won't work
-      Assert(static_cast<signed int>(quad_index) <
-               static_cast<signed int>(GeometryInfo<dim>::quads_per_cell),
-             ExcInternalError());
+      AssertIndexRange(quad_index, GeometryInfo<dim>::quads_per_cell);
 
       // in 2d, cell bubble are zero on all faces. but we have treated this
       // case above already

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -1641,15 +1641,12 @@ FE_Q_Base<dim, spacedim>::has_support_on_face(
              ExcInternalError());
 
       // in 2d, the line is the face, so get the line index
-      if (dim == 2)
+      if constexpr (dim == 2)
         return (line_index == face_index);
-      else if (dim == 3)
+      else if constexpr (dim == 3)
         {
-          // silence compiler warning
-          const unsigned int lines_per_face =
-            dim == 3 ? GeometryInfo<dim>::lines_per_face : 1;
           // see whether the given line is on the given face.
-          for (unsigned int l = 0; l < lines_per_face; ++l)
+          for (unsigned int l = 0; l < GeometryInfo<3>::lines_per_face; ++l)
             if (GeometryInfo<3>::face_to_cell_lines(face_index, l) ==
                 line_index)
               return true;

--- a/tests/simplex/orientation_06.cc
+++ b/tests/simplex/orientation_06.cc
@@ -1,0 +1,223 @@
+/* ------------------------------------------------------------------------
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright (C) 2023 by the deal.II authors
+ *
+ * This file is part of the deal.II library.
+ *
+ * Part of the source code is dual licensed under Apache-2.0 WITH
+ * LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+ * governing the source code and code contributions can be found in
+ * LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+ *
+ * ------------------------------------------------------------------------
+ */
+
+// Make sure that we get the correct convergence order for a combination of P3
+// and Q3 elements and and two reversed quadrilateral line orientations.
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_simplex_p.h>
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping_fe.h>
+
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_tools_topology.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/hp/fe_collection.h>
+#include <deal.II/hp/fe_values.h>
+#include <deal.II/hp/mapping_collection.h>
+#include <deal.II/hp/q_collection.h>
+
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/sparse_matrix.h>
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/numerics/data_out.h>
+#include <deal.II/numerics/vector_tools_boundary.h>
+#include <deal.II/numerics/vector_tools_integrate_difference.h>
+#include <deal.II/numerics/vector_tools_interpolate.h>
+
+#include "../tests.h"
+
+// u
+class Exact : public Function<2>
+{
+public:
+  double
+  value(const Point<2> &p, unsigned int /*component*/ = 0) const
+  {
+    return std::sin(p[0]) * std::sin(p[1]);
+  }
+};
+
+// -Laplacian(u) + u
+class Forcing : public Function<2>
+{
+public:
+  double
+  value(const Point<2> &p, unsigned int /*component*/ = 0) const
+  {
+    return 3.0 * std::sin(p[0]) * std::sin(p[1]);
+  }
+};
+
+int
+main()
+{
+  initlog();
+
+  const std::vector<Point<2>> vertices{{0.0, 0.0},
+                                       {1.0, 0.0},
+                                       {0.0, 2.0},
+                                       {3.0, 1.0},
+                                       {3.0, 3.0},
+                                       {2.0, 3.0},
+                                       {0.0, 3.0},
+                                       {3.0, 0.0}};
+
+  // faces 1 and 3 of the quadrilateral will have reversed orientations
+  std::vector<CellData<2>> cells(5);
+  cells[0].vertices = {0u, 1u, 2u};
+  cells[1].vertices = {3u, 4u, 5u};
+  cells[2].vertices = {1u, 3u, 7u};
+  cells[3].vertices = {5u, 2u, 6u};
+  cells[4].vertices = {1u, 3u, 2u, 5u};
+
+  const hp::MappingCollection<2> mapping(MappingFE<2>(FE_SimplexP<2>(1)),
+                                         MappingFE<2>(FE_Q<2>(1)));
+
+  const hp::FECollection<2> fe(FE_SimplexP<2>(3),
+                               FE_Q<2>(QIterated<1>(QTrapezoid<1>(), 3)));
+  const hp::QCollection<2>  quadrature_formula(QGaussSimplex<2>(4),
+                                              QGauss<2>(4));
+
+  Triangulation<2> tria;
+  GridTools::invert_cells_with_negative_measure(vertices, cells);
+  tria.create_triangulation(vertices, cells, SubCellData());
+
+  for (unsigned int r = 0; r < 5; ++r)
+    {
+      tria.refine_global(1);
+      DoFHandler<2> dof_handler(tria);
+      for (const auto &cell : dof_handler.active_cell_iterators())
+        {
+          if (cell->reference_cell() == ReferenceCells::Triangle)
+            cell->set_active_fe_index(0);
+          else if (cell->reference_cell() == ReferenceCells::Quadrilateral)
+            cell->set_active_fe_index(1);
+        }
+      dof_handler.distribute_dofs(fe);
+
+      // set up matrices and vectors:
+      AffineConstraints<double> constraints(dof_handler.locally_owned_dofs(),
+                                            dof_handler.locally_owned_dofs());
+      VectorTools::interpolate_boundary_values(
+        mapping, dof_handler, 0, Exact(), constraints);
+      constraints.close();
+      SparsityPattern        sparsity_pattern;
+      DynamicSparsityPattern dsp(dof_handler.n_dofs());
+      DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
+      sparsity_pattern.copy_from(dsp);
+
+      SparseMatrix<double> system_matrix(sparsity_pattern);
+      Vector<double>       system_rhs(dof_handler.n_dofs());
+      Vector<double>       solution(dof_handler.n_dofs());
+
+      hp::FEValues<2> hp_fe_values(mapping,
+                                   fe,
+                                   quadrature_formula,
+                                   update_values | update_gradients |
+                                     update_quadrature_points |
+                                     update_JxW_values);
+
+      FullMatrix<double>                   cell_matrix;
+      Vector<double>                       cell_rhs;
+      std::vector<types::global_dof_index> local_dof_indices;
+
+      Forcing forcing;
+      for (const auto &cell : dof_handler.active_cell_iterators())
+        {
+          hp_fe_values.reinit(cell);
+          const auto &fe_values = hp_fe_values.get_present_fe_values();
+
+          const unsigned int dofs_per_cell = cell->get_fe().n_dofs_per_cell();
+          cell_matrix.reinit(dofs_per_cell, dofs_per_cell);
+          cell_rhs.reinit(dofs_per_cell);
+          local_dof_indices.resize(dofs_per_cell);
+          cell->get_dof_indices(local_dof_indices);
+
+          cell_matrix = 0;
+          cell_rhs    = 0;
+
+          for (const unsigned int q_index :
+               fe_values.quadrature_point_indices())
+            {
+              for (const unsigned int i : fe_values.dof_indices())
+                for (const unsigned int j : fe_values.dof_indices())
+                  cell_matrix(i, j) += (fe_values.shape_grad(i, q_index) *
+                                          fe_values.shape_grad(j, q_index) +
+                                        fe_values.shape_value(i, q_index) *
+                                          fe_values.shape_value(j, q_index)) *
+                                       fe_values.JxW(q_index);
+
+              for (const unsigned int i : fe_values.dof_indices())
+                cell_rhs(i) +=
+                  fe_values.shape_value(i, q_index) *
+                  forcing.value(fe_values.quadrature_point(q_index)) *
+                  fe_values.JxW(q_index);
+            }
+
+          constraints.distribute_local_to_global(cell_matrix,
+                                                 cell_rhs,
+                                                 local_dof_indices,
+                                                 system_matrix,
+                                                 system_rhs);
+        }
+
+      SolverControl            solver_control(1000, 1e-12);
+      SolverCG<Vector<double>> solver(solver_control);
+
+      // Cut down on a lot of solver iterations by interpolating the solution as
+      // the initial guess:
+      VectorTools::interpolate(mapping, dof_handler, Exact(), solution);
+
+      PreconditionSSOR<> precondition;
+      precondition.initialize(system_matrix,
+                              PreconditionSSOR<>::AdditionalData());
+      deallog << "rhs l2 = " << system_rhs.l2_norm() << std::endl;
+      solver.solve(system_matrix, solution, system_rhs, precondition);
+      constraints.distribute(solution);
+
+      Vector<double> cell_errors(tria.n_active_cells());
+      VectorTools::integrate_difference(mapping,
+                                        dof_handler,
+                                        solution,
+                                        Exact(),
+                                        cell_errors,
+                                        quadrature_formula,
+                                        VectorTools::L2_norm);
+
+      deallog << "global error = "
+              << VectorTools::compute_global_error(tria,
+                                                   cell_errors,
+                                                   VectorTools::L2_norm)
+              << std::endl;
+
+      std::ofstream out("out-" + std::to_string(r) + ".vtu");
+      DataOut<2>    data_out;
+      data_out.attach_dof_handler(dof_handler);
+      data_out.add_data_vector(solution, "solution");
+      data_out.add_data_vector(cell_errors, "cell_errors");
+      data_out.build_patches(mapping);
+      data_out.write_vtu(out);
+    }
+}

--- a/tests/simplex/orientation_06.output
+++ b/tests/simplex/orientation_06.output
@@ -1,0 +1,21 @@
+
+DEAL::rhs l2 = 2.27397
+DEAL:cg::Starting value 1.73734
+DEAL:cg::Convergence step 23 value 8.54649e-13
+DEAL::global error = 0.00166288
+DEAL::rhs l2 = 2.08466
+DEAL:cg::Starting value 2.45428
+DEAL:cg::Convergence step 39 value 8.26837e-13
+DEAL::global error = 0.000105423
+DEAL::rhs l2 = 2.69354
+DEAL:cg::Starting value 3.47449
+DEAL:cg::Convergence step 67 value 7.08130e-13
+DEAL::global error = 6.61142e-06
+DEAL::rhs l2 = 3.77050
+DEAL:cg::Starting value 4.91796
+DEAL:cg::Convergence step 105 value 9.99712e-13
+DEAL::global error = 4.13368e-07
+DEAL::rhs l2 = 5.33304
+DEAL:cg::Starting value 6.95866
+DEAL:cg::Convergence step 169 value 9.77791e-13
+DEAL::global error = 2.58314e-08


### PR DESCRIPTION
More on #14667.

The last commit adds a test which aborts on `master` but works correctly with this branch - it attains 4th-order accuracy on a mixed mesh with quadrilateral faces not in the standard orientation, P3, and Q3.