### PR TITLE
Suppress some messages when normalizing test output.

### DIFF
--- a/cmake/scripts/normalize.pl
+++ b/cmake/scripts/normalize.pl
@@ -100,3 +100,20 @@ s/.*<PDataArray type.*(mpirank|level).*\n//g;
 #     {
 #
 s/^(\s*)(".*":) \{$/\1\2\n\1\{/;
+
+
+#
+# Some of the dependency libraries use the X protocol and want to communicate
+# with the X server of the system from which the terminal was opened. This
+# requires privileges that the owner of the system may not have provided, and
+# one then gets warning messages that clutter the test output.
+#
+# Because these dependency libraries do not (and should not) actually do on the
+# user's screen, these warnings are entirely harmless, but they break the
+# tests on which these messages appear.
+#
+if (m/Authorization required, but no authorization protocol specified/)
+{
+    <>;
+    $_ = "";
+}


### PR DESCRIPTION
This is really more of a nuisance: My systems have been updated, and now some dependency library has some X stuff compiled in and that leads to warnings every time I execute a test that loads this library :-(

I haven't been able to find anyone talk about this warning online, and don't really know how to track it down otherwise either. So my solution for the past couple of weeks has been to just suppress it in the normalize script. I recognize that this is a solution for one (=myself), but then this is perhaps also not the worst hack we have in the library. Opinions?

More description:
```
+# Some of the dependency libraries use the X protocol and want to communicate
+# with the X server of the system from which the terminal was opened. This
+# requires privileges that the owner of the system may not have provided, and
+# one then gets warning messages that clutter the test output.
+#
+# Because these dependency libraries do not (and should not) actually do on the
+# user's screen, these warnings are entirely harmless, but they break the
+# tests on which these messages appear.
```