### PR TITLE
Polynomial: Make values_of_array always inline in release mode

### DIFF
--- a/include/deal.II/base/polynomial.h
+++ b/include/deal.II/base/polynomial.h
@@ -157,10 +157,13 @@ namespace Polynomials
      * `number` by `operator=`.
      */
     template <std::size_t n_entries, typename Number2>
-    void
-    values_of_array(const std::array<Number2, n_entries> &points,
-                    const unsigned int                    n_derivatives,
-                    std::array<Number2, n_entries>       *values) const;
+#ifndef DEBUG
+    DEAL_II_ALWAYS_INLINE
+#endif
+      void
+      values_of_array(const std::array<Number2, n_entries> &points,
+                      const unsigned int                    n_derivatives,
+                      std::array<Number2, n_entries>       *values) const;
 
     /**
      * Degree of the polynomial. This is the degree reflected by the number of
@@ -863,11 +866,15 @@ namespace Polynomials
 
   template <typename number>
   template <std::size_t n_entries, typename Number2>
-  inline void
-  Polynomial<number>::values_of_array(
-    const std::array<Number2, n_entries> &x,
-    const unsigned int                    n_derivatives,
-    std::array<Number2, n_entries>       *values) const
+  inline
+#ifndef DEBUG
+    DEAL_II_ALWAYS_INLINE
+#endif
+    void
+    Polynomial<number>::values_of_array(
+      const std::array<Number2, n_entries> &x,
+      const unsigned int                    n_derivatives,
+      std::array<Number2, n_entries>       *values) const
   {
     // evaluate Lagrange polynomial and derivatives
     if (in_lagrange_product_form == true)


### PR DESCRIPTION
This is a separate PR to #16910, but crucial to gain the full performance in the change of the other PR: After extensive experiments, I realized that the typical compilers (I checked clang-17/clang-18 regularly, gcc-13 sporadically) will both create a separate function for `Polynomial::values_of_array`. It is understandable, because the function is huge with around 100 lines of code in total. However, the loop lengths and operations are typically quite short, especially when used with relatively low-order polynomials (our default case) and low-order derivatives (say only values, or only up to first derivative), e.g. for the values https://github.com/dealii/dealii/blob/master/include/deal.II/base/polynomial.h#L924-L934. This starts to matter in `FEPointEvaluation` and related arbitrary-point operations, including the Newton iteration inside `MappingQ::transform_real_to_unit_points`, where the full 1D basis should be evaluated, i.e., all 1D polynomials get queried with the same code.

Auditing all uses of this function, I saw that we call it very few times within other functions, e.g. https://github.com/dealii/dealii/blob/81ec8648500a910743e28cef437c843d84a469e6/include/deal.II/matrix_free/tensor_product_point_kernels.h#L60-L74 with a tight loop. These two reasons, the gain in performance and the controlled increase in code size due to the few uses, make me suggest to make this function always inline (in release mode only). It gives me a considerable speedups for the `MGTwoLevelTransferNonNested` in a joint project with @fdrmrc: This is only a small function within the overall evaluation, but I still measured a 10-15% speedup for polynomials of degree 4 in 3D.