### PR TITLE
Explicitly use the inverse orientation instead of hard-coding.

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -2942,9 +2942,9 @@ ReferenceCell::permute_by_combined_orientation(
             case 1:
               return {vertices[0], vertices[1], vertices[2]};
             case 3:
-              return {vertices[1], vertices[2], vertices[0]};
-            case 5:
               return {vertices[2], vertices[0], vertices[1]};
+            case 5:
+              return {vertices[1], vertices[2], vertices[0]};
             case 0:
               return {vertices[0], vertices[2], vertices[1]};
             case 2:

--- a/tests/simplex/orientation_02.cc
+++ b/tests/simplex/orientation_02.cc
@@ -23,7 +23,7 @@
 #include "../tests.h"
 
 void
-test(const unsigned int orientation)
+test(const unsigned char orientation)
 {
   const unsigned int face_no = 0;
 
@@ -43,11 +43,11 @@ test(const unsigned int orientation)
   }
 
   {
-    const auto &face = dummy.begin()->face(face_no);
+    const auto &face                = dummy.begin()->face(face_no);
+    const auto  face_reference_cell = face->reference_cell();
     const auto  permuted =
-      ReferenceCell(ReferenceCells::Triangle)
-        .permute_according_orientation(std::array<unsigned int, 3>{{0, 1, 2}},
-                                       orientation);
+      ReferenceCells::Triangle.permute_according_orientation(
+        std::array<unsigned int, 3>{{0, 1, 2}}, orientation);
 
     auto direction =
       cross_product_3d(vertices[permuted[1]] - vertices[permuted[0]],
@@ -57,13 +57,10 @@ test(const unsigned int orientation)
     vertices.push_back(face->center() + direction);
 
     CellData<3> cell;
-    cell.vertices.resize(4);
-
-    cell.vertices[permuted[0]] = face->vertex_index(0);
-    cell.vertices[permuted[1]] = face->vertex_index(1);
-    cell.vertices[permuted[2]] = face->vertex_index(2);
-    cell.vertices[3]           = 4;
-
+    cell.vertices    = {face->vertex_index(permuted[0]),
+                        face->vertex_index(permuted[1]),
+                        face->vertex_index(permuted[2]),
+                        4};
     cell.material_id = 1;
     cells.push_back(cell);
   }
@@ -74,7 +71,7 @@ test(const unsigned int orientation)
   cell++;
 
   // check orientation
-  deallog << "face orientation: " << orientation << ' '
+  deallog << "face orientation: " << int(orientation) << ' '
           << int(cell->combined_face_orientation(0)) << ' ' << std::endl;
 
   // check vertices


### PR DESCRIPTION
Partially reverts #15678.

While #15678 fixed the permutation bug, it didn't address the true cause of the problem: since face orientations are computed in the "apply this permutation to face 1 to get face 2" direction, QProjector should use inverse orientations. Since 2d orientations are their own inverses this only shows up in 3d.

Whenever two faces abutt, the first face is always in the default orientation and the second face's orientation is computed relative to that (as decribed here). Hence, when we project quadrature points onto the first face they do not need to reoriented. However, we need to apply the *reverse* permutation on the second face so that they end up in the same positions as the first face. More formally: most, but not all, orientations are their own inverses. In particular, triangle orientations 3 and 5 are each-other's inverses.

This matches the notion of inverse orientation used in #16828 for hypercubes. In the future, we should combine the hypercube and non-hypercube implementations to avoid these kinds of inconsistencies.

Part of #14667.