### PR TITLE
matrix_free/point_evaluation_33 test: add two more output variants

### DIFF
--- a/tests/matrix_free/point_evaluation_33.output.avx
+++ b/tests/matrix_free/point_evaluation_33.output.avx
@@ -1,0 +1,56 @@
+
+DEAL::Mapping of degree 1 with vectorization length 4
+DEAL::2 
+DEAL::2 
+DEAL::Mapping of degree 3 with vectorization length 4
+DEAL::4 
+DEAL::4 
+DEAL::Mapping of degree 1 with vectorization length 4
+DEAL::4 
+DEAL::4 
+DEAL::4 
+DEAL::4 
+DEAL::4 
+DEAL::4 
+DEAL::Mapping of degree 2 with vectorization length 4
+DEAL::4 4 1 
+DEAL::4 4 1 
+DEAL::4 4 1 
+DEAL::4 4 1 
+DEAL::4 4 1 
+DEAL::4 4 1 
+DEAL::Mapping of degree 6 with vectorization length 4
+DEAL::4 4 4 4 4 4 4 4 4 4 4 4 1 
+DEAL::4 4 4 4 4 4 4 4 4 4 4 4 1 
+DEAL::4 4 4 4 4 4 4 4 4 4 4 4 1 
+DEAL::4 4 4 4 4 4 4 4 4 4 4 4 1 
+DEAL::4 4 4 4 4 4 4 4 4 4 4 4 1 
+DEAL::4 4 4 4 4 4 4 4 4 4 4 4 1 
+DEAL::Mapping of degree 1 with vectorization length 4
+DEAL::4 4 
+DEAL::4 4 
+DEAL::4 4 
+DEAL::4 4 
+DEAL::4 4 
+DEAL::4 4 
+DEAL::Mapping of degree 5 with vectorization length 2
+DEAL::2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+DEAL::2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+DEAL::2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+DEAL::2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+DEAL::2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+DEAL::2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+DEAL::Mapping of degree 5 with vectorization length 4
+DEAL::4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 
+DEAL::4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 
+DEAL::4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 
+DEAL::4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 
+DEAL::4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 
+DEAL::4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 
+DEAL::Mapping of degree 1 with vectorization length 4
+DEAL::4 4 
+DEAL::4 4 
+DEAL::4 4 
+DEAL::4 4 
+DEAL::4 4 
+DEAL::4 4 

--- a/tests/matrix_free/point_evaluation_33.output.avx512
+++ b/tests/matrix_free/point_evaluation_33.output.avx512
@@ -1,0 +1,56 @@
+
+DEAL::Mapping of degree 1 with vectorization length 8
+DEAL::2 
+DEAL::2 
+DEAL::Mapping of degree 3 with vectorization length 8
+DEAL::4 
+DEAL::4 
+DEAL::Mapping of degree 1 with vectorization length 8
+DEAL::4 
+DEAL::4 
+DEAL::4 
+DEAL::4 
+DEAL::4 
+DEAL::4 
+DEAL::Mapping of degree 2 with vectorization length 8
+DEAL::8 1 
+DEAL::8 1 
+DEAL::8 1 
+DEAL::8 1 
+DEAL::8 1 
+DEAL::8 1 
+DEAL::Mapping of degree 6 with vectorization length 8
+DEAL::8 8 8 8 8 8 1 
+DEAL::8 8 8 8 8 8 1 
+DEAL::8 8 8 8 8 8 1 
+DEAL::8 8 8 8 8 8 1 
+DEAL::8 8 8 8 8 8 1 
+DEAL::8 8 8 8 8 8 1 
+DEAL::Mapping of degree 1 with vectorization length 8
+DEAL::8 
+DEAL::8 
+DEAL::8 
+DEAL::8 
+DEAL::8 
+DEAL::8 
+DEAL::Mapping of degree 5 with vectorization length 2
+DEAL::2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+DEAL::2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+DEAL::2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+DEAL::2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+DEAL::2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+DEAL::2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+DEAL::Mapping of degree 5 with vectorization length 4
+DEAL::4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 
+DEAL::4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 
+DEAL::4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 
+DEAL::4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 
+DEAL::4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 
+DEAL::4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 
+DEAL::Mapping of degree 1 with vectorization length 8
+DEAL::8 
+DEAL::8 
+DEAL::8 
+DEAL::8 
+DEAL::8 
+DEAL::8 


### PR DESCRIPTION
This addresses the second part of the failures reported by #16915: The recently introduced test from #16891 prints information that depends on the SIMD configuration of a system. However, output was only provided for no vectorization and 128-bit vectorization, not the 256 bit and 512 bit cases. This is done by the present PR.

FYI @bergbauer