### PR TITLE
Don't define BOOST_NO_CXX98_FUNCTION_BASE manually in bundled boost

### DIFF
--- a/bundled/setup_bundled.cmake
+++ b/bundled/setup_bundled.cmake
@@ -56,16 +56,6 @@ macro(feature_boost_configure_bundled)
     list(APPEND DEAL_II_DEFINITIONS "BOOST_ALL_NO_LIB")
   endif()
 
-  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    #
-    # std::unary_function has been removed in C++17. Fix compilation with
-    # clang (that enforces strict standard compliance) by exporting
-    # BOOST_NO_CXX98_FUNCTION_BASE,
-    # https://github.com/boostorg/config/pull/430
-    #
-    list(APPEND DEAL_II_DEFINITIONS "BOOST_NO_CXX98_FUNCTION_BASE")
-  endif()
-
   enable_if_supported(DEAL_II_WARNING_FLAGS "-Wno-unused-local-typedefs")
   enable_if_supported(DEAL_II_WARNING_FLAGS "-Wno-parentheses")
 


### PR DESCRIPTION
After #16621, we shouldn't need to define `BOOST_NO_CXX98_FUNCTION_BASE` anymore manually since a relevant patch was part of Boost 1.80.0, see https://github.com/boostorg/config/pull/430. This define also causes issues in the Mac OS X build, see, e.g., https://github.com/dealii/dealii/actions/runs/8792815112/job/24129672144?pr=16922.

The define was introduced in https://github.com/dealii/dealii/pull/16486 for Boost 1.70.0.