### PR TITLE
Revert "Export compile definitions for dependent targets"

### DIFF
--- a/cmake/config/Config.cmake.in
+++ b/cmake/config/Config.cmake.in
@@ -124,14 +124,6 @@ set(DEAL_II_LINKER_FLAGS_DEBUG "@DEAL_II_LINKER_FLAGS_DEBUG@")
 # _additionally_ used for release targets:
 set(DEAL_II_LINKER_FLAGS_RELEASE "@DEAL_II_LINKER_FLAGS_RELEASE@")
 
-# used for all targets:
-set(DEAL_II_DEFINITIONS "@DEAL_II_DEFINITIONS@")
-
-# _additionally_ used for debug targets:
-set(DEAL_II_DEFINITIONS_DEBUG "@DEAL_II_DEFINITIONS_DEBUG@")
-
-# _additionally_ used for release targets:
-set(DEAL_II_DEFINITIONS_RELEASE "@DEAL_II_DEFINITIONS_RELEASE@")
 #
 # MPI runtime:
 #

--- a/cmake/macros/macro_deal_ii_setup_target.cmake
+++ b/cmake/macros/macro_deal_ii_setup_target.cmake
@@ -93,10 +93,6 @@ macro(deal_ii_setup_target _target)
     "${DEAL_II_WARNING_FLAGS} ${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_${_build}}"
     )
 
-  target_compile_definitions(${_target} PRIVATE
-    ${DEAL_II_DEFINITIONS} ${DEAL_II_DEFINITIONS_${_build}}
-    )
-
   get_property(_type TARGET ${_target} PROPERTY TYPE)
   if(NOT "${_type}" STREQUAL "OBJECT_LIBRARY")
     target_link_flags(${_target} PRIVATE

--- a/cmake/macros/macro_insource_setup_target.cmake
+++ b/cmake/macros/macro_insource_setup_target.cmake
@@ -34,10 +34,6 @@ function(insource_setup_target _target _build)
     "${DEAL_II_WARNING_FLAGS} ${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_${_build}}"
     )
 
-  target_compile_definitions(${_target} PRIVATE
-    ${DEAL_II_DEFINITIONS} ${DEAL_II_DEFINITIONS_${_build}}
-    )
-
   get_property(_type TARGET ${_target} PROPERTY TYPE)
   if(NOT "${_type}" STREQUAL "OBJECT_LIBRARY")
     target_link_flags(${_target} PRIVATE


### PR DESCRIPTION
We have switched to adding target compile definitions to the interface targets recorded in `cmake/deal.II/deal.IITargets.cmake`.

Here, for the deal.II targets themselves and all external features we configure we record everything that is necessary to compile and link against deal.II successfully. On my system this looks as follows:
```
# Create imported target dealii::dealii_debug
add_library(dealii::dealii_debug SHARED IMPORTED)

set_target_properties(dealii::dealii_debug PROPERTIES
  INTERFACE_COMPILE_DEFINITIONS "DEBUG"
  INTERFACE_COMPILE_FEATURES "cxx_std_17"
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
  INTERFACE_LINK_LIBRARIES "dealii::interface_lapack;dealii::interface_mpi;dealii::interface_tbb;dealii::interface_zlib;dealii::interface_boost;dealii::interface_ginkgo;dealii::interface_metis;dealii::interface_petsc;dealii::interface_trilinos;dealii::interface_umfpack;dealii::interface_kokkos;dealii::interface_adolc;dealii::interface_arborx;dealii::interface_arpack;dealii::interface_assimp;dealii::interface_cgal;dealii::interface_gmsh;dealii::interface_gsl;dealii::interface_hdf5;dealii::interface_muparser;dealii::interface_opencascade;dealii::interface_p4est;dealii::interface_scalapack;dealii::interface_slepc;dealii::interface_sundials;dealii::interface_symengine"
  INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "include"
)

# Create imported target dealii::dealii_release
add_library(dealii::dealii_release SHARED IMPORTED)

set_target_properties(dealii::dealii_release PROPERTIES
  INTERFACE_COMPILE_DEFINITIONS "NDEBUG"
  INTERFACE_COMPILE_FEATURES "cxx_std_17"
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
  INTERFACE_LINK_LIBRARIES "dealii::interface_lapack;dealii::interface_mpi;dealii::interface_tbb;dealii::interface_zlib;dealii::interface_boost;dealii::interface_ginkgo;dealii::interface_metis;dealii::interface_petsc;dealii::interface_trilinos;dealii::interface_umfpack;dealii::interface_kokkos;dealii::interface_adolc;dealii::interface_arborx;dealii::interface_arpack;dealii::interface_assimp;dealii::interface_cgal;dealii::interface_gmsh;dealii::interface_gsl;dealii::interface_hdf5;dealii::interface_muparser;dealii::interface_opencascade;dealii::interface_p4est;dealii::interface_scalapack;dealii::interface_slepc;dealii::interface_sundials;dealii::interface_symengine"
  INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "include"
)

<snip>

set_target_properties(dealii::interface_trilinos PROPERTIES
  INTERFACE_COMPILE_DEFINITIONS "KOKKOS_DEPENDENCE"
  INTERFACE_INCLUDE_DIRECTORIES "/usr/include;/usr/include/trilinos;/usr/include/eigen3;/usr/include/scotch;/usr/include/blacs"
  INTERFACE_LINK_LIBRARIES "<snip>"
  INTERFACE_LINK_OPTIONS "-DKOKKOS_DEPENDENCE"
  INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "/usr/include;/usr/include/trilinos;/usr/include/eigen3;/usr/include/scotch;/usr/include/blacs"
)

<snip>
```

Now, when linking to deal.II with either the macro `deal_ii_setup_target()`, or with `target_link_libraries(<target> dealii::dealii<|_debug|_release>)`
CMake automatically constructs final compile and link options for the target:

```
/usr/lib/llvm/18/bin/clang++ -DKOKKOS_DEPENDENCE -DNDEBUG <includes> <compile flags> <warning flags> <...> -c .../examples/step-1/step-1.cc
/usr/lib/llvm/18/bin/clang++ <linker flags> -DKOKKOS_DEPENDENCE .../step-1.cc.o <libraries>
```

Reverified on my machine.


This reverts commit a29f491fc2a054b0545212d34261ea0270b0dc64.

In reference to #16834
