### PR TITLE
Ensure we only set boundary ids on boundary faces.

### DIFF
--- a/examples/step-3/doc/results.dox
+++ b/examples/step-3/doc/results.dox
@@ -122,13 +122,14 @@ suggestions:
   For example, we can label all of the cells along the top and
   bottom boundaries with a boundary indicator 1 by checking to
   see if the cell centers' y-coordinates are within a tolerance
-  (here 1e-12) of -1 and 1. Try this immediately after calling
+  (here `1e-12`) of -1 and 1. Try this immediately after calling
   GridGenerator::hyper_cube(), as before:
   @code
   for (auto &face : triangulation.active_face_iterators())
-    if (std::fabs(face->center()(1) - (-1.0)) < 1e-12 ||
-        std::fabs(face->center()(1) - (1.0)) < 1e-12)
-      face->set_boundary_id(1);
+    if (face->at_boundary())
+      if (std::fabs(face->center()(1) - (-1.0)) < 1e-12 ||
+          std::fabs(face->center()(1) - (1.0)) < 1e-12)
+        face->set_boundary_id(1);
   @endcode
   Although this code is a bit longer than before, it is useful for
   complex geometries, as it does not require knowledge of face labels.


### PR DESCRIPTION
One of my students today set boundary ids in the interior (on purpose) and I was surprised to see that he copied a piece of code from step-3's results section that could be read as suggesting that this possible. (It actually worked, which is a separate issue.) But I think we don't want to suggest that, so change the code snippet to be clear that you should only do that on the boundary.