### PR TITLE
Make it clearer what an integer argument means.

### DIFF
--- a/examples/step-3/doc/results.dox
+++ b/examples/step-3/doc/results.dox
@@ -140,7 +140,7 @@ suggestions:
   call to <code>interpolate_boundary_values</code> for boundary indicator one:
   @code
   VectorTools::interpolate_boundary_values(dof_handler,
-					   1,
+					   types::boundary_id(1),
 					   Functions::ConstantFunction<2>(1.),
 					   boundary_values);
   @endcode

--- a/examples/step-3/step-3.cc
+++ b/examples/step-3/step-3.cc
@@ -490,8 +490,9 @@ void Step3::assemble_system()
   // boundary by indicators, and tell the interpolate_boundary_values
   // function to only compute the boundary values on a certain part of the
   // boundary (e.g. the clamped part, or the inflow boundary). By default,
-  // all boundaries have a 0 boundary indicator, unless otherwise specified. If
-  // sections of the boundary have different boundary conditions, you have to
+  // all boundaries have a 0 boundary indicator, unless otherwise specified.
+  // (For example, many functions in namespace GridGenerator specify otherwise.)
+  // If sections of the boundary have different boundary conditions, you have to
   // number those parts with different boundary indicators. The function call
   // below will then only determine boundary values for those parts of the
   // boundary for which the boundary indicator is in fact the zero specified as
@@ -510,7 +511,7 @@ void Step3::assemble_system()
   // class.
   std::map<types::global_dof_index, double> boundary_values;
   VectorTools::interpolate_boundary_values(dof_handler,
-                                           0,
+                                           types::boundary_id(0),
                                            Functions::ZeroFunction<2>(),
                                            boundary_values);
   // Now that we got the list of boundary DoFs and their respective boundary

--- a/examples/step-4/step-4.cc
+++ b/examples/step-4/step-4.cc
@@ -425,12 +425,12 @@ void Step4<dim>::assemble_system()
   // on faces that have been marked with boundary indicator 0 (because that's
   // what we say the function should work on with the second argument below).
   // If there are faces with boundary id other than 0, then the function
-  // interpolate_boundary_values will do nothing on these faces. For
+  // interpolate_boundary_values() will do nothing on these faces. For
   // the Laplace equation doing nothing is equivalent to assuming that
   // on those parts of the boundary a zero Neumann boundary condition holds.
   std::map<types::global_dof_index, double> boundary_values;
   VectorTools::interpolate_boundary_values(dof_handler,
-                                           0,
+                                           types::boundary_id(0),
                                            BoundaryValues<dim>(),
                                            boundary_values);
   MatrixTools::apply_boundary_values(boundary_values,

--- a/examples/step-5/step-5.cc
+++ b/examples/step-5/step-5.cc
@@ -218,7 +218,7 @@ void Step5<dim>::assemble_system()
   // With the matrix so built, we use zero boundary values again:
   std::map<types::global_dof_index, double> boundary_values;
   VectorTools::interpolate_boundary_values(dof_handler,
-                                           0,
+                                           types::boundary_id(0),
                                            Functions::ZeroFunction<dim>(),
                                            boundary_values);
   MatrixTools::apply_boundary_values(boundary_values,

--- a/examples/step-6/step-6.cc
+++ b/examples/step-6/step-6.cc
@@ -194,7 +194,7 @@ void Step6<dim>::setup_system()
   // order: if two constraints conflict then the constraint matrix either abort
   // or throw an exception via the Assert macro.
   VectorTools::interpolate_boundary_values(dof_handler,
-                                           0,
+                                           types::boundary_id(0),
                                            Functions::ZeroFunction<dim>(),
                                            constraints);
 

--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -688,7 +688,7 @@ namespace Step7
 
     std::map<types::global_dof_index, double> boundary_values;
     VectorTools::interpolate_boundary_values(dof_handler,
-                                             0,
+                                             types::boundary_id(0),
                                              Solution<dim>(),
                                              boundary_values);
     MatrixTools::apply_boundary_values(boundary_values,

--- a/examples/step-8/step-8.cc
+++ b/examples/step-8/step-8.cc
@@ -245,7 +245,7 @@ namespace Step8
     constraints.clear();
     DoFTools::make_hanging_node_constraints(dof_handler, constraints);
     VectorTools::interpolate_boundary_values(dof_handler,
-                                             0,
+                                             types::boundary_id(0),
                                              Functions::ZeroFunction<dim>(dim),
                                              constraints);
     constraints.close();


### PR DESCRIPTION
Pretty much every time I teach deal.II, someone (often multiple someones) does not understand what the bare zero in
```
  VectorTools::interpolate_boundary_values(dof_handler,
                                           0,
                                           BoundaryValues<dim>(),
                                           boundary_values);
```
represents. That's understandable, nothing here helps with understanding it without having to look up what the function does. I've long wished that I didn't have to explain that so often.

Here is the solution:
```
  VectorTools::interpolate_boundary_values(dof_handler,
                                           types::boundary_id(0),
                                           BoundaryValues<dim>(),
                                           boundary_values);
```
I think this should make it clearer, and so made the change everywhere in the single-digit tutorials. I also thought about writing it as
```
  VectorTools::interpolate_boundary_values(dof_handler,
                                           /* boundary_id= */ 0,
                                           BoundaryValues<dim>(),
                                           boundary_values);
```
but in the end thought that the former was clearer. Opinions about the matter are welcome.