### PR TITLE
Handle zero contour aligning with faces in MeshClassifier.

### DIFF
--- a/include/deal.II/non_matching/mesh_classifier.h
+++ b/include/deal.II/non_matching/mesh_classifier.h
@@ -47,6 +47,7 @@ namespace NonMatching
    * inside      if $\psi(x) < 0$,
    * outside     if $\psi(x) > 0$,
    * intersected if $\psi(x)$ varies in sign,
+   * aligned     if $\psi((x) = 0$,
    *
    * over the cell/face. The value "unassigned" is used to describe that the
    * location of a cell/face has not yet been determined.
@@ -56,7 +57,8 @@ namespace NonMatching
     inside,
     outside,
     intersected,
-    unassigned
+    unassigned,
+    aligned
   };
 
 

--- a/source/non_matching/mesh_classifier.cc
+++ b/source/non_matching/mesh_classifier.cc
@@ -68,9 +68,11 @@ namespace NonMatching
           std::minmax_element(local_levelset_values.begin(),
                               local_levelset_values.end());
 
-        if (*min_max_element.second < 0)
+        if (*min_max_element.first == 0.0 && *min_max_element.second == 0.0)
+          return LocationToLevelSet::aligned;
+        if (*min_max_element.second <= 0)
           return LocationToLevelSet::inside;
-        if (0 < *min_max_element.first)
+        if (0 <= *min_max_element.first)
           return LocationToLevelSet::outside;
 
         return LocationToLevelSet::intersected;
@@ -359,27 +361,48 @@ namespace NonMatching
     face_locations.assign(triangulation->n_raw_faces(),
                           LocationToLevelSet::unassigned);
 
+    // Returns wether the incoming LocationToLevelSet is in the incoming set.
+    // This lambda can be factored away once C++20 is enabled, since set then
+    // has a contains function.
+    const auto contains =
+      [](const std::set<LocationToLevelSet> &local_face_locations,
+         const LocationToLevelSet           &location) {
+        return local_face_locations.count(location) > 0;
+      };
+
     // Loop over all cells and determine the location of all non artificial
     // cells and faces.
     for (const auto &cell : triangulation->active_cell_iterators())
       if (!cell->is_artificial())
         {
-          const LocationToLevelSet face0_location =
-            determine_face_location_to_levelset(cell, 0);
+          std::set<LocationToLevelSet> local_face_locations;
 
-          face_locations[cell->face(0)->index()] = face0_location;
-          LocationToLevelSet cell_location       = face0_location;
-
-          for (unsigned int f = 1; f < GeometryInfo<dim>::faces_per_cell; ++f)
+          for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
             {
               const LocationToLevelSet face_location =
                 determine_face_location_to_levelset(cell, f);
 
               face_locations[cell->face(f)->index()] = face_location;
+              local_face_locations.insert(face_location);
+            }
 
-              if (face_location != face0_location)
+          LocationToLevelSet cell_location = LocationToLevelSet::unassigned;
+
+          const bool all_faces_have_same_location =
+            local_face_locations.size() == 1;
+
+          if (all_faces_have_same_location)
+            cell_location = *local_face_locations.cbegin();
+          else if (contains(local_face_locations, LocationToLevelSet::aligned))
+            {
+              if (contains(local_face_locations, LocationToLevelSet::outside))
+                cell_location = LocationToLevelSet::outside;
+              else
                 cell_location = LocationToLevelSet::intersected;
             }
+          else
+            cell_location = LocationToLevelSet::intersected;
+
           cell_locations[cell->active_cell_index()] = cell_location;
         }
   }

--- a/tests/non_matching/fe_values_02.cc
+++ b/tests/non_matching/fe_values_02.cc
@@ -1,0 +1,219 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2021 - 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#include <deal.II/base/function_signed_distance.h>
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_values.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/non_matching/fe_values.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include <optional>
+
+#include "../tests.h"
+
+/*
+ * Set up a triangulation with 2 unit elements in a row: |-0-|-1-|, and a level
+ * set function such that it cuts exactly through the face that is shared
+ * between the elements. Test that the sum of the JxW-values we get from
+ * inside/outside/surface_fe_values is the correct volume/surface area. That is,
+ * all should be equal to 1.
+ */
+template <int dim>
+class Test
+{
+public:
+  Test();
+
+  void
+  run();
+
+private:
+  void
+  setup_mesh();
+
+  /*
+   * Setup a discrete level set function corresponding to
+   * $\psi(x) = x_0$
+   */
+  void
+  setup_discrete_level_set();
+
+  void
+  compute_volumes_and_surface_area(NonMatching::FEValues<dim> &fe_values) const;
+
+  Triangulation<dim>    triangulation;
+  hp::FECollection<dim> fe_collection;
+  DoFHandler<dim>       dof_handler;
+
+  hp::MappingCollection<dim> mapping_collection;
+  hp::QCollection<dim>       q_collection;
+  hp::QCollection<1>         q_collection1D;
+
+  Vector<double>                   level_set;
+  NonMatching::MeshClassifier<dim> mesh_classifier;
+};
+
+
+
+template <int dim>
+Test<dim>::Test()
+  : dof_handler(triangulation)
+  , mesh_classifier(dof_handler, level_set)
+{
+  fe_collection.push_back(FE_Q<dim>(1));
+  mapping_collection.push_back(MappingCartesian<dim>());
+  const unsigned int n_quadrature_points = 1;
+  q_collection.push_back(QGauss<dim>(n_quadrature_points));
+  q_collection1D.push_back(QGauss<1>(n_quadrature_points));
+}
+
+
+
+template <int dim>
+void
+Test<dim>::run()
+{
+  setup_mesh();
+  dof_handler.distribute_dofs(fe_collection);
+  setup_discrete_level_set();
+  mesh_classifier.reclassify();
+
+  NonMatching::RegionUpdateFlags region_update_flags;
+  region_update_flags.inside  = update_JxW_values;
+  region_update_flags.outside = update_JxW_values;
+  region_update_flags.surface = update_JxW_values;
+
+  NonMatching::FEValues<dim> fe_values(fe_collection,
+                                       q_collection1D[0],
+                                       region_update_flags,
+                                       mesh_classifier,
+                                       dof_handler,
+                                       level_set);
+  compute_volumes_and_surface_area(fe_values);
+}
+
+
+
+template <int dim>
+void
+Test<dim>::setup_mesh()
+{
+  Point<dim> lower_left;
+  lower_left[0] = -1;
+  Point<dim> upper_right;
+
+  std::vector<unsigned int> repetitions;
+  upper_right[0] = 1;
+  repetitions.push_back(2);
+  for (unsigned int d = 1; d < dim; ++d)
+    {
+      upper_right[d] = 1;
+      repetitions.push_back(1);
+    }
+
+  GridGenerator::subdivided_hyper_rectangle(triangulation,
+                                            repetitions,
+                                            lower_left,
+                                            upper_right);
+}
+
+
+
+template <int dim>
+void
+Test<dim>::setup_discrete_level_set()
+{
+  const Point<dim> point_on_zero_contour;
+
+  const Functions::SignedDistance::Plane<dim> analytical_levelset(
+    point_on_zero_contour, Point<dim>::unit_vector(0));
+
+  level_set.reinit(dof_handler.n_dofs());
+  VectorTools::interpolate(dof_handler, analytical_levelset, level_set);
+}
+
+
+
+template <class FE_VALUES_TYPE>
+double
+sum_JxW_values(const FE_VALUES_TYPE &fe_values)
+{
+  double sum = 0;
+  for (unsigned int q : fe_values.quadrature_point_indices())
+    sum += fe_values.JxW(q);
+  return sum;
+}
+
+
+
+template <int dim>
+void
+Test<dim>::compute_volumes_and_surface_area(
+  NonMatching::FEValues<dim> &fe_values) const
+{
+  double surface_area   = 0;
+  double inside_volume  = 0;
+  double outside_volume = 0;
+
+  for (auto &cell : dof_handler.active_cell_iterators())
+    {
+      fe_values.reinit(cell);
+
+      const auto &inside_fe_values = fe_values.get_inside_fe_values();
+      if (inside_fe_values)
+        inside_volume += sum_JxW_values(*inside_fe_values);
+
+      const auto &outside_fe_values = fe_values.get_outside_fe_values();
+      if (outside_fe_values)
+        outside_volume += sum_JxW_values(*outside_fe_values);
+
+      const auto &fe_surface_values = fe_values.get_surface_fe_values();
+      if (fe_surface_values)
+        surface_area += sum_JxW_values(*fe_surface_values);
+    }
+
+  deallog << "inside volume = " << inside_volume << std::endl;
+  deallog << "surface area = " << surface_area << std::endl;
+  deallog << "outside volume = " << outside_volume << std::endl;
+}
+
+
+
+template <int dim>
+void
+run_test()
+{
+  deallog << "dim = " << dim << std::endl;
+  Test<dim> test;
+  test.run();
+  deallog << std::endl;
+}
+
+
+
+int
+main()
+{
+  initlog();
+
+  run_test<1>();
+  run_test<2>();
+  run_test<3>();
+}

--- a/tests/non_matching/fe_values_02.output
+++ b/tests/non_matching/fe_values_02.output
@@ -1,0 +1,16 @@
+
+DEAL::dim = 1
+DEAL::inside volume = 1.00000
+DEAL::surface area = 1.00000
+DEAL::outside volume = 1.00000
+DEAL::
+DEAL::dim = 2
+DEAL::inside volume = 1.00000
+DEAL::surface area = 1.00000
+DEAL::outside volume = 1.00000
+DEAL::
+DEAL::dim = 3
+DEAL::inside volume = 1.00000
+DEAL::surface area = 1.00000
+DEAL::outside volume = 1.00000
+DEAL::

--- a/tests/non_matching/mesh_classifier.cc
+++ b/tests/non_matching/mesh_classifier.cc
@@ -56,6 +56,9 @@ location_to_string(const NonMatching::LocationToLevelSet location)
       case NonMatching::LocationToLevelSet::unassigned:
         name = "unassigned";
         break;
+      case NonMatching::LocationToLevelSet::aligned:
+        name = "aligned";
+        break;
       default:
         AssertThrow(false, ExcInternalError());
     }
@@ -189,6 +192,20 @@ test_negative_function()
 
 
 
+// Test MeshClassifier with a level set function that is constant zero.
+template <int dim>
+void
+test_zero_function()
+{
+  deallog << "test_zero_function";
+
+  const Functions::ZeroFunction<dim> level_set;
+
+  classify_with_discrete_and_analytic_level_set(level_set);
+}
+
+
+
 // Test MeshClassifier with a level set function corresponding to the plane
 // (x = 0) intersecting the hypercube [-1, 1]^dim.
 template <int dim>
@@ -202,6 +219,32 @@ test_intersection_x_eq_0_plane()
   const Point<dim> origo;
 
   const Functions::SignedDistance::Plane<dim> level_set(origo, plane_normal);
+
+  classify_with_discrete_and_analytic_level_set(level_set);
+}
+
+
+
+// Test MeshClassifier with a plane level set that has a zero contour that goes
+// straight through the center of a hypercube cell [-1,1]^dim,  with a normal
+// in the direction n = [1,1] in 2D. This test case is mainly of interest in 2D,
+// because then the zero contour goes straight through 2 of the nodes and there
+// are no faces tha are intersected, i.e., two faces are inside and two are
+// outside.
+template <int dim>
+void
+test_intersection_diagonally_through_vertices()
+{
+  deallog << "test_intersection_diagonally_through_vertices" << std::endl;
+
+  Tensor<1, dim> plane_normal;
+  plane_normal[0] = 1;
+  plane_normal[1] = 1;
+
+  const Point<dim> point_in_plane;
+
+  const Functions::SignedDistance::Plane<dim> level_set(point_in_plane,
+                                                        plane_normal);
 
   classify_with_discrete_and_analytic_level_set(level_set);
 }
@@ -356,6 +399,56 @@ test_reclassify_called_multiple_times()
 
 
 
+/*
+ * Test MeshClassifier with a plane level set function such that the zero
+ * contour is aligned with face 0 of the cell. This makes the level set function
+ * positive over the cell except over face 0, where it is zero.
+ */
+template <int dim>
+void
+test_positive_but_face_aligned()
+{
+  deallog << "test_positive_but_face_aligned";
+
+  Tensor<1, dim> plane_normal;
+  plane_normal[0] = 1;
+
+  Point<dim> point_in_plane;
+  point_in_plane[0] = -1;
+
+  const Functions::SignedDistance::Plane<dim> level_set(point_in_plane,
+                                                        plane_normal);
+
+  classify_with_discrete_and_analytic_level_set(level_set);
+}
+
+
+
+/*
+ * Test MeshClassifier with a plane level set function such that the zero
+ * contour is aligned with face 1 of the cell. This makes the level set function
+ * negative over the cell except over face 1, where it is zero.
+ */
+template <int dim>
+void
+test_negative_but_face_aligned()
+{
+  deallog << "test_negative_but_face_aligned";
+
+  Tensor<1, dim> plane_normal;
+  plane_normal[0] = 1;
+
+  Point<dim> point_in_plane;
+  point_in_plane[0] = 1;
+
+  const Functions::SignedDistance::Plane<dim> level_set(point_in_plane,
+                                                        plane_normal);
+
+  classify_with_discrete_and_analytic_level_set(level_set);
+}
+
+
+
 template <int dim>
 void
 run_test()
@@ -364,12 +457,20 @@ run_test()
 
   test_negative_function<dim>();
   test_positive_function<dim>();
+  test_zero_function<dim>();
+
   test_intersection_x_eq_0_plane<dim>();
-  // This test doesn't make sense in 1D.
+  // These tests do not make sense in 1D.
   if (dim != 1)
     test_lagrange_coefficents_positive<dim>();
 
+  if (dim == 2)
+    test_intersection_diagonally_through_vertices<dim>();
+
   test_reclassify_called_multiple_times<dim>();
+
+  test_negative_but_face_aligned<dim>();
+  test_positive_but_face_aligned<dim>();
 }
 
 

--- a/tests/non_matching/mesh_classifier.with_lapack=on.output
+++ b/tests/non_matching/mesh_classifier.with_lapack=on.output
@@ -24,6 +24,17 @@ DEAL::cell outside
 DEAL::face 0 outside
 DEAL::face 1 outside
 DEAL::
+DEAL::test_zero_function
+DEAL::discrete:
+DEAL::cell aligned
+DEAL::face 0 aligned
+DEAL::face 1 aligned
+DEAL::
+DEAL::analytic:
+DEAL::cell aligned
+DEAL::face 0 aligned
+DEAL::face 1 aligned
+DEAL::
 DEAL::test_intersection_x_eq_0_plane
 DEAL::
 DEAL::discrete:
@@ -44,6 +55,28 @@ DEAL::face 1 inside
 DEAL::Level set positive
 DEAL::cell outside
 DEAL::face 0 outside
+DEAL::face 1 outside
+DEAL::
+DEAL::test_negative_but_face_aligned
+DEAL::discrete:
+DEAL::cell intersected
+DEAL::face 0 inside
+DEAL::face 1 aligned
+DEAL::
+DEAL::analytic:
+DEAL::cell intersected
+DEAL::face 0 inside
+DEAL::face 1 aligned
+DEAL::
+DEAL::test_positive_but_face_aligned
+DEAL::discrete:
+DEAL::cell outside
+DEAL::face 0 aligned
+DEAL::face 1 outside
+DEAL::
+DEAL::analytic:
+DEAL::cell outside
+DEAL::face 0 aligned
 DEAL::face 1 outside
 DEAL::
 DEAL::dim = 2
@@ -79,6 +112,21 @@ DEAL::face 1 outside
 DEAL::face 2 outside
 DEAL::face 3 outside
 DEAL::
+DEAL::test_zero_function
+DEAL::discrete:
+DEAL::cell aligned
+DEAL::face 0 aligned
+DEAL::face 1 aligned
+DEAL::face 2 aligned
+DEAL::face 3 aligned
+DEAL::
+DEAL::analytic:
+DEAL::cell aligned
+DEAL::face 0 aligned
+DEAL::face 1 aligned
+DEAL::face 2 aligned
+DEAL::face 3 aligned
+DEAL::
 DEAL::test_intersection_x_eq_0_plane
 DEAL::
 DEAL::discrete:
@@ -102,6 +150,22 @@ DEAL::face 1 outside
 DEAL::face 2 intersected
 DEAL::face 3 outside
 DEAL::
+DEAL::test_intersection_diagonally_through_vertices
+DEAL::
+DEAL::discrete:
+DEAL::cell intersected
+DEAL::face 0 inside
+DEAL::face 1 outside
+DEAL::face 2 inside
+DEAL::face 3 outside
+DEAL::
+DEAL::analytic:
+DEAL::cell intersected
+DEAL::face 0 inside
+DEAL::face 1 outside
+DEAL::face 2 inside
+DEAL::face 3 outside
+DEAL::
 DEAL::test_reclassify_called_multiple_times
 DEAL::Level set negative
 DEAL::cell inside
@@ -112,6 +176,36 @@ DEAL::face 3 inside
 DEAL::Level set positive
 DEAL::cell outside
 DEAL::face 0 outside
+DEAL::face 1 outside
+DEAL::face 2 outside
+DEAL::face 3 outside
+DEAL::
+DEAL::test_negative_but_face_aligned
+DEAL::discrete:
+DEAL::cell intersected
+DEAL::face 0 inside
+DEAL::face 1 aligned
+DEAL::face 2 inside
+DEAL::face 3 inside
+DEAL::
+DEAL::analytic:
+DEAL::cell intersected
+DEAL::face 0 inside
+DEAL::face 1 aligned
+DEAL::face 2 inside
+DEAL::face 3 inside
+DEAL::
+DEAL::test_positive_but_face_aligned
+DEAL::discrete:
+DEAL::cell outside
+DEAL::face 0 aligned
+DEAL::face 1 outside
+DEAL::face 2 outside
+DEAL::face 3 outside
+DEAL::
+DEAL::analytic:
+DEAL::cell outside
+DEAL::face 0 aligned
 DEAL::face 1 outside
 DEAL::face 2 outside
 DEAL::face 3 outside
@@ -157,6 +251,25 @@ DEAL::face 3 outside
 DEAL::face 4 outside
 DEAL::face 5 outside
 DEAL::
+DEAL::test_zero_function
+DEAL::discrete:
+DEAL::cell aligned
+DEAL::face 0 aligned
+DEAL::face 1 aligned
+DEAL::face 2 aligned
+DEAL::face 3 aligned
+DEAL::face 4 aligned
+DEAL::face 5 aligned
+DEAL::
+DEAL::analytic:
+DEAL::cell aligned
+DEAL::face 0 aligned
+DEAL::face 1 aligned
+DEAL::face 2 aligned
+DEAL::face 3 aligned
+DEAL::face 4 aligned
+DEAL::face 5 aligned
+DEAL::
 DEAL::test_intersection_x_eq_0_plane
 DEAL::
 DEAL::discrete:
@@ -198,6 +311,44 @@ DEAL::face 5 inside
 DEAL::Level set positive
 DEAL::cell outside
 DEAL::face 0 outside
+DEAL::face 1 outside
+DEAL::face 2 outside
+DEAL::face 3 outside
+DEAL::face 4 outside
+DEAL::face 5 outside
+DEAL::
+DEAL::test_negative_but_face_aligned
+DEAL::discrete:
+DEAL::cell intersected
+DEAL::face 0 inside
+DEAL::face 1 aligned
+DEAL::face 2 inside
+DEAL::face 3 inside
+DEAL::face 4 inside
+DEAL::face 5 inside
+DEAL::
+DEAL::analytic:
+DEAL::cell intersected
+DEAL::face 0 inside
+DEAL::face 1 aligned
+DEAL::face 2 inside
+DEAL::face 3 inside
+DEAL::face 4 inside
+DEAL::face 5 inside
+DEAL::
+DEAL::test_positive_but_face_aligned
+DEAL::discrete:
+DEAL::cell outside
+DEAL::face 0 aligned
+DEAL::face 1 outside
+DEAL::face 2 outside
+DEAL::face 3 outside
+DEAL::face 4 outside
+DEAL::face 5 outside
+DEAL::
+DEAL::analytic:
+DEAL::cell outside
+DEAL::face 0 aligned
 DEAL::face 1 outside
 DEAL::face 2 outside
 DEAL::face 3 outside


### PR DESCRIPTION
Change logic in `MeshClassifier` to handle the situation described  issue #16888. Add a new type to the enum `LocationToLevelSet` that  describes that the zero contour is exactly aligned with a face. Change the logic in `MeshClassifier` to set the "inside" cell sharing an aligned face to intersected and the other cell to outside.