### PR TITLE
Multiply right hand side value from the left with phi_i.

### DIFF
--- a/examples/step-6/step-6.cc
+++ b/examples/step-6/step-6.cc
@@ -289,8 +289,8 @@ void Step6<dim>::assemble_system()
                    fe_values.shape_grad(j, q_index) * // grad phi_j(x_q)
                    fe_values.JxW(q_index));           // dx
 
-              cell_rhs(i) += (1.0 *                               // f(x)
-                              fe_values.shape_value(i, q_index) * // phi_i(x_q)
+              cell_rhs(i) += (fe_values.shape_value(i, q_index) * // phi_i(x_q)
+                              1.0 *                               // f(x)
                               fe_values.JxW(q_index));            // dx
             }
         }


### PR DESCRIPTION
We're consistent in always multiplying the right hand side function from the left by a shape function in all the single digit tutorials, with the exception of step-6. Adjust that.