### PR TITLE
Be uniform in the order of things we start the assembly loop with.

### DIFF
--- a/examples/step-20/step-20.cc
+++ b/examples/step-20/step-20.cc
@@ -488,6 +488,7 @@ namespace Step20
     for (const auto &cell : dof_handler.active_cell_iterators())
       {
         fe_values.reinit(cell);
+
         local_matrix = 0;
         local_rhs    = 0;
 

--- a/examples/step-22/step-22.cc
+++ b/examples/step-22/step-22.cc
@@ -659,6 +659,7 @@ namespace Step22
     for (const auto &cell : dof_handler.active_cell_iterators())
       {
         fe_values.reinit(cell);
+
         local_matrix                = 0;
         local_preconditioner_matrix = 0;
         local_rhs                   = 0;

--- a/examples/step-4/step-4.cc
+++ b/examples/step-4/step-4.cc
@@ -354,6 +354,7 @@ void Step4<dim>::assemble_system()
   for (const auto &cell : dof_handler.active_cell_iterators())
     {
       fe_values.reinit(cell);
+
       cell_matrix = 0;
       cell_rhs    = 0;
 

--- a/examples/step-40/step-40.cc
+++ b/examples/step-40/step-40.cc
@@ -399,10 +399,10 @@ namespace Step40
     for (const auto &cell : dof_handler.active_cell_iterators())
       if (cell->is_locally_owned())
         {
+          fe_values.reinit(cell);
+
           cell_matrix = 0.;
           cell_rhs    = 0.;
-
-          fe_values.reinit(cell);
 
           for (unsigned int q_point = 0; q_point < n_q_points; ++q_point)
             {

--- a/examples/step-5/step-5.cc
+++ b/examples/step-5/step-5.cc
@@ -178,10 +178,10 @@ void Step5<dim>::assemble_system()
   // coefficient value at each quadrature point.
   for (const auto &cell : dof_handler.active_cell_iterators())
     {
+      fe_values.reinit(cell);
+
       cell_matrix = 0.;
       cell_rhs    = 0.;
-
-      fe_values.reinit(cell);
 
       for (const unsigned int q_index : fe_values.quadrature_point_indices())
         {

--- a/examples/step-6/step-6.cc
+++ b/examples/step-6/step-6.cc
@@ -271,10 +271,10 @@ void Step6<dim>::assemble_system()
 
   for (const auto &cell : dof_handler.active_cell_iterators())
     {
+      fe_values.reinit(cell);
+
       cell_matrix = 0;
       cell_rhs    = 0;
-
-      fe_values.reinit(cell);
 
       for (const unsigned int q_index : fe_values.quadrature_point_indices())
         {

--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -583,10 +583,10 @@ namespace Step7
     // previous examples, so we only comment on the things that have changed.
     for (const auto &cell : dof_handler.active_cell_iterators())
       {
+        fe_values.reinit(cell);
+
         cell_matrix = 0.;
         cell_rhs    = 0.;
-
-        fe_values.reinit(cell);
 
         right_hand_side.value_list(fe_values.get_quadrature_points(),
                                    rhs_values);

--- a/examples/step-8/step-8.cc
+++ b/examples/step-8/step-8.cc
@@ -318,10 +318,10 @@ namespace Step8
     // Now we can begin with the loop over all cells:
     for (const auto &cell : dof_handler.active_cell_iterators())
       {
+        fe_values.reinit(cell);
+
         cell_matrix = 0;
         cell_rhs    = 0;
-
-        fe_values.reinit(cell);
 
         // Next we get the values of the coefficients at the quadrature
         // points. Likewise for the right hand side:


### PR DESCRIPTION
In step-3, we use the following order:
```
  for (const auto &cell : dof_handler.active_cell_iterators())
    {
      fe_values.reinit(cell);

      cell_matrix = 0;
      cell_rhs    = 0;
```
In other programs we deviate from this order, but there is really no good reason. I've learned to really value uniformity in everything that remains the same from one tutorial to the next. This patch makes sure that the "usual suspects" all follow exactly this order so that we can say "the rest of the program is exactly as in previous programs".