### PR TITLE
Include allocated vectors in GrowingVectorMemory's memory consumption

### DIFF
--- a/include/deal.II/lac/vector_memory.templates.h
+++ b/include/deal.II/lac/vector_memory.templates.h
@@ -204,9 +204,9 @@ GrowingVectorMemory<VectorType>::memory_consumption() const
   std::lock_guard<std::mutex> lock(mutex);
 
   std::size_t result = sizeof(*this);
-  for (const entry_type &i : *get_pool().data)
-    result +=
-      sizeof(entry_type) + MemoryConsumption::memory_consumption(i.second);
+  for (const auto &[_, ptr] : *get_pool().data)
+    result += sizeof(ptr) + (ptr ? MemoryConsumption::memory_consumption(*ptr) :
+                                   MemoryConsumption::memory_consumption(ptr));
 
   return result;
 }


### PR DESCRIPTION
If the pointer is non-null, ask the vectors for their allocated memory. I believe this is what is advertised in the documentation: 

```
 /**
  * Memory consumed by this class and all currently allocated vectors.
  */
```

Additional thought: I guess the conditional access on pointers is not done by default in the `MemoryConsumption` namespace because pointers can have unclear ownership and the memory should not be counted multiple times. I can see that for a raw pointer and shared_ptr, this makes sense, but for a unique_ptr, it seems I would always want the memory of the pointee included since there is only one owner. Of course, changing this would break the symmetry between different pointer types.