### PR TITLE
Remove extra orientation functions

### DIFF
--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -1090,8 +1090,8 @@ namespace internal
         if (structdim == 3 && fe.max_dofs_per_quad() > 0)
           for (const auto face_no : accessor.face_indices())
             {
-              const auto combined_orientation = TriaAccessorImplementation::
-                Implementation::combined_face_orientation(accessor, face_no);
+              const auto combined_orientation =
+                accessor.combined_face_orientation(face_no);
               const unsigned int quad_index = accessor.quad_index(face_no);
               if (combined_orientation ==
                   ReferenceCell::default_combined_face_orientation())

--- a/include/deal.II/grid/tria_objects_orientations.h
+++ b/include/deal.II/grid/tria_objects_orientations.h
@@ -110,24 +110,6 @@ namespace internal
                                const unsigned char value);
 
       /**
-       * Set the orientation bit of the object.
-       */
-      void
-      set_orientation(const unsigned int object, const bool value);
-
-      /**
-       * Set the rotate bit of the object.
-       */
-      void
-      set_rotation(const unsigned int object, const bool value);
-
-      /**
-       * Set the flip bit of the object.
-       */
-      void
-      set_flip(const unsigned int object, const bool value);
-
-      /**
        * Read or write the data of this object to or from a stream for the
        * purpose of serialization using the [BOOST serialization
        * library](https://www.boost.org/doc/libs/1_74_0/libs/serialization/doc/index.html).
@@ -246,36 +228,6 @@ namespace internal
     {
       AssertIndexRange(object, n_stored_objects);
       flags[object] = value;
-    }
-
-
-
-    inline void
-    TriaObjectsOrientations::set_orientation(const unsigned int object,
-                                             const bool         value)
-    {
-      AssertIndexRange(object, n_stored_objects);
-      Utilities::set_bit(flags[object], 0, value);
-    }
-
-
-
-    inline void
-    TriaObjectsOrientations::set_rotation(const unsigned int object,
-                                          const bool         value)
-    {
-      AssertIndexRange(object, n_stored_objects);
-      Utilities::set_bit(flags[object], 1, value);
-    }
-
-
-
-    inline void
-    TriaObjectsOrientations::set_flip(const unsigned int object,
-                                      const bool         value)
-    {
-      AssertIndexRange(object, n_stored_objects);
-      Utilities::set_bit(flags[object], 2, value);
     }
 
 


### PR DESCRIPTION
Part of #14667. Now that we have `if constexpr ()` we can make a lot of this code simpler. We also never use the `TriaObjectsOrientations::set_*()` functions, so those can all go.