### PR TITLE
FEEvaluation for simplices: Arrange gradients contiguously

### DIFF
--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -375,8 +375,7 @@ namespace internal
                 const auto grad = fe.shape_grad(i, quad.point(q));
 
                 for (unsigned int d = 0; d < dim; ++d)
-                  shape_gradients[d * n_dofs * n_q_points + i * n_q_points +
-                                  q] = grad[d];
+                  shape_gradients[i * dim * n_q_points + q * dim + d] = grad[d];
               }
 
           {

--- a/tests/simplex/matrix_free_shape_info_01.cc
+++ b/tests/simplex/matrix_free_shape_info_01.cc
@@ -83,7 +83,7 @@ public:
           for (unsigned int i = 0; i < n_dofs; ++i)
             gradients[n_q_points * d + q] +=
               shape_info.data[0]
-                .shape_gradients[d * n_dofs * n_q_points + i * n_q_points + q] *
+                .shape_gradients[i * dim * n_q_points + q * dim + d] *
               dof_values[i];
         }
   }


### PR DESCRIPTION
This PR does two things:
- Arrange all components of the gradient contiguously in `ShapeInfo::shape_gradients` for the non-tensor-product elements (simplices), as this is the order in which we store the result of the gradient operation nowadays anyway, so it saves us one of the loops
- Instead of setting up a one-dimensional `EvaluatorTensorProduct` object that gets called through a layer of function calls, directly call the `apply_matrix_vector_product` function that was introduced by #15891. This is slightly more verbose at the caller site, but since it is only called a handful of times (4 times to be precise, or 6 if considering the add-into/overwrite case of `integrate`), I think this is still clearer than to introduce several indirections (that also need to be read and understood).

I plan to rearrange some instructions inside the non-templated `apply_matrix_vector_product` function to increase performance in a later PR, where this more direct call stack also helps to track dependencies.