### PR TITLE
Rename a poorly named variable.

### DIFF
--- a/examples/step-15/step-15.cc
+++ b/examples/step-15/step-15.cc
@@ -695,8 +695,8 @@ int main()
     {
       using namespace Step15;
 
-      MinimalSurfaceProblem<2> laplace_problem_2d;
-      laplace_problem_2d.run();
+      MinimalSurfaceProblem<2> problem;
+      problem.run();
     }
   catch (std::exception &exc)
     {


### PR DESCRIPTION
Noticed while reading #16967.