### PR TITLE
autopilot distclean: also remove `compile_commands.json`.

### DIFF
--- a/cmake/macros/macro_deal_ii_invoke_autopilot.cmake
+++ b/cmake/macros/macro_deal_ii_invoke_autopilot.cmake
@@ -210,7 +210,7 @@ macro(deal_ii_invoke_autopilot)
     COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target runclean
     COMMAND ${CMAKE_COMMAND} -E remove_directory CMakeFiles
     COMMAND ${CMAKE_COMMAND} -E remove
-      CMakeCache.txt cmake_install.cmake Makefile
+      CMakeCache.txt cmake_install.cmake compile_commands.json Makefile
       build.ninja rules.ninja .ninja_deps .ninja_log
     COMMENT "distclean invoked"
     )


### PR DESCRIPTION
Since [`cmake 3.5`](https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html),  a file `compile_commands.json` will be generated.

Also clean up this file if the `distclean` target is invoked.