### PR TITLE
Mark an input argument as 'const', and in the process give it a reasonable type.

### DIFF
--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -602,13 +602,15 @@ private:
 
   /**
    * Transform the point @p p on the real cell to the corresponding point on
-   * the unit cell @p cell by a Newton iteration.
+   * the unit cell @p cell by a Newton iteration. @p starting_guess is
+   * a guess for the position on the unit cell at which this function will
+   * start its Newton iteration.
    *
    * Takes a reference to an @p InternalData that is assumed to be previously
    * created by the @p get_data function with @p UpdateFlags including @p
    * update_transformation_values and @p update_transformation_gradients and a
    * one point Quadrature that includes the given initial guess specified
-   * through the given @p point_quadrature object.
+   * through the given @p starting_guess.
    *
    * @p mdata will be changed by this function.
    */
@@ -616,8 +618,8 @@ private:
   do_transform_real_to_unit_cell(
     const typename Triangulation<dim, spacedim>::cell_iterator &cell,
     const Point<spacedim>                                      &p,
-    Quadrature<dim> &point_quadrature,
-    InternalData    &mdata) const;
+    const Point<dim>                                           &starting_guess,
+    InternalData                                               &mdata) const;
 
   /**
    * Update internal degrees of freedom.


### PR DESCRIPTION
In one of my recent patches, I tried to make a `Quadrature` object `const` but couldn't because it is passed as a non-`const` reference argument to an internal function (namely, `MappingFEField::do_transform_real_to_unit_cell()`). Indeed, that function modifies the argument (which is not documented), but it's hard to see why a caller would care because the only quadrature point in the `Quadrature` object is also returned by the function itself.

So I decided to let the function modify things internally, rather than modifying one of its reference arguments. But then I also realized that we pass a single point via a `Quadrature` object, which is due to the fact that that's how it is used internally. So I also changed the type of the argument in question from `Quadrature` to `Point<dim>`.

There is only one caller of that function, and the function is `private`, so there are no other implications to worry about.