### PR TITLE
Matrix-free evaluation kernels: Do not template tensor_none case

### DIFF
--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -2060,6 +2060,16 @@ namespace internal
             fe_eval,
             sum_into_values_array);
         }
+      else if (element_type == ElementType::tensor_none)
+        {
+          evaluate_or_integrate<
+            FEEvaluationImpl<ElementType::tensor_none, dim, -1, 0, Number>>(
+            n_components,
+            actual_flag,
+            values_dofs,
+            fe_eval,
+            sum_into_values_array);
+        }
       else if (element_type == ElementType::tensor_symmetric_plus_dg0)
         {
           evaluate_or_integrate<
@@ -2076,19 +2086,6 @@ namespace internal
       else if (element_type == ElementType::truncated_tensor)
         {
           evaluate_or_integrate<FEEvaluationImpl<ElementType::truncated_tensor,
-                                                 dim,
-                                                 fe_degree,
-                                                 n_q_points_1d,
-                                                 Number>>(
-            n_components,
-            actual_flag,
-            values_dofs,
-            fe_eval,
-            sum_into_values_array);
-        }
-      else if (element_type == ElementType::tensor_none)
-        {
-          evaluate_or_integrate<FEEvaluationImpl<ElementType::tensor_none,
                                                  dim,
                                                  fe_degree,
                                                  n_q_points_1d,


### PR DESCRIPTION
Since the simplex code for the matrix-free evaluators does not use the `fe_degree` and `n_q_points_1d` arguments, see e.g. https://github.com/dealii/dealii/blob/d86056192fa80352f814da4706ab4eab686ffc1d/include/deal.II/matrix_free/evaluation_kernels.h#L613-L634 we should not template the function at the call site, which allows the compiler (at least in theory) to create a more compact code representation. For my compilation, the release library size is reduced by around 1.5 MB from around 308 MB to around 306 MB.

While there, also move the `tensor_none` above some weird elements such as `FE_Q_DG0` or the truncated tensor products, as this is the more natural place.