### PR TITLE
Fix Compiler warning in `tria.cc`

### DIFF
--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -7052,15 +7052,15 @@ namespace internal
                                   {
                                     vertex_indices
                                       [new_hex_vertices
-                                         [hex->reference_cell()
+                                         [ReferenceCells::Tetrahedron
                                             .face_to_cell_vertices(f, 0, 1)]],
                                     vertex_indices
                                       [new_hex_vertices
-                                         [hex->reference_cell()
+                                         [ReferenceCells::Tetrahedron
                                             .face_to_cell_vertices(f, 1, 1)]],
                                     vertex_indices
                                       [new_hex_vertices
-                                         [hex->reference_cell()
+                                         [ReferenceCells::Tetrahedron
                                             .face_to_cell_vertices(f, 2, 1)]],
                                   }};
 


### PR DESCRIPTION
Part of #16949, fixes the warning: https://cdash.dealii.org/viewBuildError.php?type=1&buildid=3972.