### PR TITLE
Remove authors from steps 1-8.

### DIFF
--- a/examples/step-2/step-2.cc
+++ b/examples/step-2/step-2.cc
@@ -11,8 +11,6 @@
  * LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
  *
  * ------------------------------------------------------------------------
- *
- * Author: Wolfgang Bangerth, University of Heidelberg, 1999
  */
 
 

--- a/examples/step-3/step-3.cc
+++ b/examples/step-3/step-3.cc
@@ -11,9 +11,6 @@
  * LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
  *
  * ------------------------------------------------------------------------
- *
- * Authors: Wolfgang Bangerth, 1999,
- *          Guido Kanschat, 2011
  */
 
 

--- a/examples/step-4/step-4.cc
+++ b/examples/step-4/step-4.cc
@@ -11,8 +11,6 @@
  * LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
  *
  * ------------------------------------------------------------------------
- *
- * Author: Wolfgang Bangerth, University of Heidelberg, 1999
  */
 
 

--- a/examples/step-5/step-5.cc
+++ b/examples/step-5/step-5.cc
@@ -11,8 +11,6 @@
  * LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
  *
  * ------------------------------------------------------------------------
- *
- * Author: Wolfgang Bangerth, University of Heidelberg, 1999
  */
 
 

--- a/examples/step-6/step-6.cc
+++ b/examples/step-6/step-6.cc
@@ -11,8 +11,6 @@
  * LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
  *
  * ------------------------------------------------------------------------
- *
- * Author: Wolfgang Bangerth, University of Heidelberg, 2000
  */
 
 

--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -11,8 +11,6 @@
  * LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
  *
  * ------------------------------------------------------------------------
- *
- * Authors: Wolfgang Bangerth and Ralf Hartmann, University of Heidelberg, 2000
  */
 
 

--- a/examples/step-8/step-8.cc
+++ b/examples/step-8/step-8.cc
@@ -11,8 +11,6 @@
  * LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
  *
  * ------------------------------------------------------------------------
- *
- * Author: Wolfgang Bangerth, University of Heidelberg, 2000
  */
 
 


### PR DESCRIPTION
By now, pretty much everyone who has ever worked on deal.II, has contributed to one or the other of these tutorial programs.