### PR TITLE
Remove dependence of step-39 on LocalIntegrators.

### DIFF
--- a/doc/news/changes/minor/20240513Bangerth
+++ b/doc/news/changes/minor/20240513Bangerth
@@ -1,0 +1,5 @@
+Changed: step-39 now implements the local integration routines itself,
+rather than relying on deprecated concepts from namespace
+LocalIntegrator.
+<br>
+(Wolfgang Bangerth, 2024/05/13)

--- a/examples/step-39/step-39.cc
+++ b/examples/step-39/step-39.cc
@@ -94,15 +94,14 @@ namespace Step39
   class MatrixIntegrator : public MeshWorker::LocalIntegrator<dim>
   {
   public:
-    void cell(MeshWorker::DoFInfo<dim>                  &dinfo,
-              typename MeshWorker::IntegrationInfo<dim> &info) const override;
-    void
-         boundary(MeshWorker::DoFInfo<dim>                  &dinfo,
-                  typename MeshWorker::IntegrationInfo<dim> &info) const override;
-    void face(MeshWorker::DoFInfo<dim>                  &dinfo1,
-              MeshWorker::DoFInfo<dim>                  &dinfo2,
-              typename MeshWorker::IntegrationInfo<dim> &info1,
-              typename MeshWorker::IntegrationInfo<dim> &info2) const override;
+    void cell(MeshWorker::DoFInfo<dim>         &dinfo,
+              MeshWorker::IntegrationInfo<dim> &info) const override;
+    void boundary(MeshWorker::DoFInfo<dim>         &dinfo,
+                  MeshWorker::IntegrationInfo<dim> &info) const override;
+    void face(MeshWorker::DoFInfo<dim>         &dinfo1,
+              MeshWorker::DoFInfo<dim>         &dinfo2,
+              MeshWorker::IntegrationInfo<dim> &info1,
+              MeshWorker::IntegrationInfo<dim> &info2) const override;
   };
 
 
@@ -147,9 +146,8 @@ namespace Step39
 
 
   template <int dim>
-  void MatrixIntegrator<dim>::cell(
-    MeshWorker::DoFInfo<dim>                  &dinfo,
-    typename MeshWorker::IntegrationInfo<dim> &info) const
+  void MatrixIntegrator<dim>::cell(MeshWorker::DoFInfo<dim>         &dinfo,
+                                   MeshWorker::IntegrationInfo<dim> &info) const
   {
     FullMatrix<double> &M = dinfo.matrix(0, false).matrix;
 
@@ -221,11 +219,11 @@ namespace Step39
 
   // Interior faces use the interior penalty method:
   template <int dim>
-  void MatrixIntegrator<dim>::face(
-    MeshWorker::DoFInfo<dim>                  &dinfo1,
-    MeshWorker::DoFInfo<dim>                  &dinfo2,
-    typename MeshWorker::IntegrationInfo<dim> &info1,
-    typename MeshWorker::IntegrationInfo<dim> &info2) const
+  void
+  MatrixIntegrator<dim>::face(MeshWorker::DoFInfo<dim>         &dinfo1,
+                              MeshWorker::DoFInfo<dim>         &dinfo2,
+                              MeshWorker::IntegrationInfo<dim> &info1,
+                              MeshWorker::IntegrationInfo<dim> &info2) const
   {
     const FEValuesBase<dim> &fe_face_values_1 = info1.fe_values(0);
     const FEValuesBase<dim> &fe_face_values_2 = info2.fe_values(0);
@@ -306,29 +304,27 @@ namespace Step39
   class RHSIntegrator : public MeshWorker::LocalIntegrator<dim>
   {
   public:
-    void cell(MeshWorker::DoFInfo<dim>                  &dinfo,
-              typename MeshWorker::IntegrationInfo<dim> &info) const override;
-    void
-         boundary(MeshWorker::DoFInfo<dim>                  &dinfo,
-                  typename MeshWorker::IntegrationInfo<dim> &info) const override;
-    void face(MeshWorker::DoFInfo<dim>                  &dinfo1,
-              MeshWorker::DoFInfo<dim>                  &dinfo2,
-              typename MeshWorker::IntegrationInfo<dim> &info1,
-              typename MeshWorker::IntegrationInfo<dim> &info2) const override;
+    void cell(MeshWorker::DoFInfo<dim>         &dinfo,
+              MeshWorker::IntegrationInfo<dim> &info) const override;
+    void boundary(MeshWorker::DoFInfo<dim>         &dinfo,
+                  MeshWorker::IntegrationInfo<dim> &info) const override;
+    void face(MeshWorker::DoFInfo<dim>         &dinfo1,
+              MeshWorker::DoFInfo<dim>         &dinfo2,
+              MeshWorker::IntegrationInfo<dim> &info1,
+              MeshWorker::IntegrationInfo<dim> &info2) const override;
   };
 
 
   template <int dim>
-  void
-  RHSIntegrator<dim>::cell(MeshWorker::DoFInfo<dim> &,
-                           typename MeshWorker::IntegrationInfo<dim> &) const
+  void RHSIntegrator<dim>::cell(MeshWorker::DoFInfo<dim> &,
+                                MeshWorker::IntegrationInfo<dim> &) const
   {}
 
 
   template <int dim>
-  void RHSIntegrator<dim>::boundary(
-    MeshWorker::DoFInfo<dim>                  &dinfo,
-    typename MeshWorker::IntegrationInfo<dim> &info) const
+  void
+  RHSIntegrator<dim>::boundary(MeshWorker::DoFInfo<dim>         &dinfo,
+                               MeshWorker::IntegrationInfo<dim> &info) const
   {
     const FEValuesBase<dim> &fe           = info.fe_values();
     Vector<double>          &local_vector = dinfo.vector(0).block(0);
@@ -350,11 +346,10 @@ namespace Step39
 
 
   template <int dim>
-  void
-  RHSIntegrator<dim>::face(MeshWorker::DoFInfo<dim> &,
-                           MeshWorker::DoFInfo<dim> &,
-                           typename MeshWorker::IntegrationInfo<dim> &,
-                           typename MeshWorker::IntegrationInfo<dim> &) const
+  void RHSIntegrator<dim>::face(MeshWorker::DoFInfo<dim> &,
+                                MeshWorker::DoFInfo<dim> &,
+                                MeshWorker::IntegrationInfo<dim> &,
+                                MeshWorker::IntegrationInfo<dim> &) const
   {}
 
 
@@ -365,24 +360,22 @@ namespace Step39
   class Estimator : public MeshWorker::LocalIntegrator<dim>
   {
   public:
-    void cell(MeshWorker::DoFInfo<dim>                  &dinfo,
-              typename MeshWorker::IntegrationInfo<dim> &info) const override;
-    void
-         boundary(MeshWorker::DoFInfo<dim>                  &dinfo,
-                  typename MeshWorker::IntegrationInfo<dim> &info) const override;
-    void face(MeshWorker::DoFInfo<dim>                  &dinfo1,
-              MeshWorker::DoFInfo<dim>                  &dinfo2,
-              typename MeshWorker::IntegrationInfo<dim> &info1,
-              typename MeshWorker::IntegrationInfo<dim> &info2) const override;
+    void cell(MeshWorker::DoFInfo<dim>         &dinfo,
+              MeshWorker::IntegrationInfo<dim> &info) const override;
+    void boundary(MeshWorker::DoFInfo<dim>         &dinfo,
+                  MeshWorker::IntegrationInfo<dim> &info) const override;
+    void face(MeshWorker::DoFInfo<dim>         &dinfo1,
+              MeshWorker::DoFInfo<dim>         &dinfo2,
+              MeshWorker::IntegrationInfo<dim> &info1,
+              MeshWorker::IntegrationInfo<dim> &info2) const override;
   };
 
 
   // The cell contribution is the Laplacian of the discrete solution, since
   // the right hand side is zero.
   template <int dim>
-  void
-  Estimator<dim>::cell(MeshWorker::DoFInfo<dim>                  &dinfo,
-                       typename MeshWorker::IntegrationInfo<dim> &info) const
+  void Estimator<dim>::cell(MeshWorker::DoFInfo<dim>         &dinfo,
+                            MeshWorker::IntegrationInfo<dim> &info) const
   {
     const FEValuesBase<dim> &fe = info.fe_values();
 
@@ -399,9 +392,8 @@ namespace Step39
   // namely the norm of the difference between the finite element solution and
   // the correct boundary condition.
   template <int dim>
-  void Estimator<dim>::boundary(
-    MeshWorker::DoFInfo<dim>                  &dinfo,
-    typename MeshWorker::IntegrationInfo<dim> &info) const
+  void Estimator<dim>::boundary(MeshWorker::DoFInfo<dim>         &dinfo,
+                                MeshWorker::IntegrationInfo<dim> &info) const
   {
     const FEValuesBase<dim> &fe = info.fe_values();
 
@@ -426,11 +418,10 @@ namespace Step39
   // Finally, on interior faces, the estimator consists of the jumps of the
   // solution and its normal derivative, weighted appropriately.
   template <int dim>
-  void
-  Estimator<dim>::face(MeshWorker::DoFInfo<dim>                  &dinfo1,
-                       MeshWorker::DoFInfo<dim>                  &dinfo2,
-                       typename MeshWorker::IntegrationInfo<dim> &info1,
-                       typename MeshWorker::IntegrationInfo<dim> &info2) const
+  void Estimator<dim>::face(MeshWorker::DoFInfo<dim>         &dinfo1,
+                            MeshWorker::DoFInfo<dim>         &dinfo2,
+                            MeshWorker::IntegrationInfo<dim> &info1,
+                            MeshWorker::IntegrationInfo<dim> &info2) const
   {
     const FEValuesBase<dim>           &fe   = info1.fe_values();
     const std::vector<double>         &uh1  = info1.values[0][0];
@@ -475,15 +466,14 @@ namespace Step39
   class ErrorIntegrator : public MeshWorker::LocalIntegrator<dim>
   {
   public:
-    void cell(MeshWorker::DoFInfo<dim>                  &dinfo,
-              typename MeshWorker::IntegrationInfo<dim> &info) const override;
-    void
-         boundary(MeshWorker::DoFInfo<dim>                  &dinfo,
-                  typename MeshWorker::IntegrationInfo<dim> &info) const override;
-    void face(MeshWorker::DoFInfo<dim>                  &dinfo1,
-              MeshWorker::DoFInfo<dim>                  &dinfo2,
-              typename MeshWorker::IntegrationInfo<dim> &info1,
-              typename MeshWorker::IntegrationInfo<dim> &info2) const override;
+    void cell(MeshWorker::DoFInfo<dim>         &dinfo,
+              MeshWorker::IntegrationInfo<dim> &info) const override;
+    void boundary(MeshWorker::DoFInfo<dim>         &dinfo,
+                  MeshWorker::IntegrationInfo<dim> &info) const override;
+    void face(MeshWorker::DoFInfo<dim>         &dinfo1,
+              MeshWorker::DoFInfo<dim>         &dinfo2,
+              MeshWorker::IntegrationInfo<dim> &info1,
+              MeshWorker::IntegrationInfo<dim> &info2) const override;
   };
 
   // Here we have the integration on cells. There is currently no good
@@ -499,9 +489,8 @@ namespace Step39
   // this one does not have any jump terms and only appears in the integration
   // on cells.
   template <int dim>
-  void ErrorIntegrator<dim>::cell(
-    MeshWorker::DoFInfo<dim>                  &dinfo,
-    typename MeshWorker::IntegrationInfo<dim> &info) const
+  void ErrorIntegrator<dim>::cell(MeshWorker::DoFInfo<dim>         &dinfo,
+                                  MeshWorker::IntegrationInfo<dim> &info) const
   {
     const FEValuesBase<dim>    &fe = info.fe_values();
     std::vector<Tensor<1, dim>> exact_gradients(fe.n_quadrature_points);
@@ -531,9 +520,9 @@ namespace Step39
 
 
   template <int dim>
-  void ErrorIntegrator<dim>::boundary(
-    MeshWorker::DoFInfo<dim>                  &dinfo,
-    typename MeshWorker::IntegrationInfo<dim> &info) const
+  void
+  ErrorIntegrator<dim>::boundary(MeshWorker::DoFInfo<dim>         &dinfo,
+                                 MeshWorker::IntegrationInfo<dim> &info) const
   {
     const FEValuesBase<dim> &fe = info.fe_values();
 
@@ -556,11 +545,10 @@ namespace Step39
 
 
   template <int dim>
-  void ErrorIntegrator<dim>::face(
-    MeshWorker::DoFInfo<dim>                  &dinfo1,
-    MeshWorker::DoFInfo<dim>                  &dinfo2,
-    typename MeshWorker::IntegrationInfo<dim> &info1,
-    typename MeshWorker::IntegrationInfo<dim> &info2) const
+  void ErrorIntegrator<dim>::face(MeshWorker::DoFInfo<dim>         &dinfo1,
+                                  MeshWorker::DoFInfo<dim>         &dinfo2,
+                                  MeshWorker::IntegrationInfo<dim> &info1,
+                                  MeshWorker::IntegrationInfo<dim> &info2) const
   {
     const FEValuesBase<dim>   &fe  = info1.fe_values();
     const std::vector<double> &uh1 = info1.values[0][0];

--- a/examples/step-39/step-39.cc
+++ b/examples/step-39/step-39.cc
@@ -584,7 +584,7 @@ namespace Step39
   public:
     using CellInfo = MeshWorker::IntegrationInfo<dim>;
 
-    InteriorPenaltyProblem(const FiniteElement<dim> &fe);
+    InteriorPenaltyProblem();
 
     void run(unsigned int n_steps);
 
@@ -599,10 +599,10 @@ namespace Step39
     void   output_results(const unsigned int cycle) const;
 
     // The member objects related to the discretization are here.
-    Triangulation<dim>        triangulation;
-    const MappingQ1<dim>      mapping;
-    const FiniteElement<dim> &fe;
-    DoFHandler<dim>           dof_handler;
+    Triangulation<dim>   triangulation;
+    const MappingQ1<dim> mapping;
+    const FE_DGQ<2>      fe;
+    DoFHandler<dim>      dof_handler;
 
     // Then, we have the matrices and vectors related to the global discrete
     // system.
@@ -634,14 +634,12 @@ namespace Step39
   };
 
 
-  // The constructor simply sets up the coarse grid and the DoFHandler. The
-  // FiniteElement is provided as a parameter to allow flexibility.
+  // The constructor simply sets up the coarse grid and the DoFHandler.
   template <int dim>
-  InteriorPenaltyProblem<dim>::InteriorPenaltyProblem(
-    const FiniteElement<dim> &fe)
+  InteriorPenaltyProblem<dim>::InteriorPenaltyProblem()
     : triangulation(Triangulation<dim>::limit_level_difference_at_vertices)
     , mapping()
-    , fe(fe)
+    , fe(3)
     , dof_handler(triangulation)
     , estimates(1)
   {
@@ -1117,8 +1115,8 @@ int main()
       deallog.depth_console(2);
       std::ofstream logfile("deallog");
       deallog.attach(logfile);
-      const FE_DGQ<2>           fe1(3);
-      InteriorPenaltyProblem<2> test1(fe1);
+
+      InteriorPenaltyProblem<2> test1;
       test1.run(12);
     }
   catch (std::exception &exc)


### PR DESCRIPTION
Related to #15604, #16690. The first commit, in essence, inlines the contents of the `LocalIntegrators` functions into step-39 plus some minor clean-ups. The second commit is just a C++ issue. The third commit fixes the issue in the computation of the IP penalty factor mentioned in #15604.