### PR TITLE
Remove Quadrature(unsigned int) from the public interface.

### DIFF
--- a/doc/news/changes/incompatibilities/20240513Bangerth-2
+++ b/doc/news/changes/incompatibilities/20240513Bangerth-2
@@ -1,0 +1,14 @@
+Changed: The Quadrature class used to have a constructor that took an
+integer argument. This was error-prone because it was easy to accidentally
+write
+@code
+  Quadrature<dim> quadrature(3);
+@endcode
+where
+@code
+  QGauss<dim> quadrature(3);
+@endcode
+was meant. As a consequence, this constructor has been removed from the `public`
+interface of the class.
+<br>
+(Wolfgang Bangerth, 2024/05/13)

--- a/include/deal.II/base/quadrature.h
+++ b/include/deal.II/base/quadrature.h
@@ -130,14 +130,9 @@ public:
   using SubQuadrature = Quadrature<dim == 0 ? 0 : dim - 1>;
 
   /**
-   * Constructor.
-   *
-   * This constructor is marked as explicit to avoid involuntary accidents
-   * like in <code>hp::QCollection@<dim@> q_collection(3)</code> where
-   * <code>hp::QCollection@<dim@> q_collection(QGauss@<dim@>(3))</code> was
-   * meant.
+   * Default constructor.
    */
-  explicit Quadrature(const unsigned int n_quadrature_points = 0);
+  Quadrature();
 
   /**
    * Build this quadrature formula as the tensor product of a formula in a
@@ -336,6 +331,21 @@ public:
   get_tensor_basis() const;
 
 protected:
+  /**
+   * Constructor.
+   *
+   * This constructor is marked as explicit to avoid involuntary accidents
+   * like in <code>hp::QCollection@<dim@> q_collection(3)</code> where
+   * <code>hp::QCollection@<dim@> q_collection(QGauss@<dim@>(3))</code> was
+   * meant. Nonetheless, it is easy to accidentally write
+   * @code
+   *   Quadrature<dim> quadrature(3);
+   * @endcode
+   * where QGauss was meant. As a consequence, this constructor is `protected`
+   * and so only available to derived classes initializing their base class.
+   */
+  explicit Quadrature(const unsigned int n_quadrature_points);
+
   /**
    * List of quadrature points. To be filled by the constructors of derived
    * classes.

--- a/include/deal.II/numerics/vector_tools_project.h
+++ b/include/deal.II/numerics/vector_tools_project.h
@@ -152,7 +152,7 @@ namespace VectorTools
     VectorType                                                &vec,
     const bool                 enforce_zero_boundary = false,
     const Quadrature<dim - 1> &q_boundary = (dim > 1 ? QGauss<dim - 1>(2) :
-                                                       Quadrature<dim - 1>(0)),
+                                                       Quadrature<dim - 1>()),
     const bool                 project_to_boundary_first = false);
 
   /**
@@ -171,7 +171,7 @@ namespace VectorTools
     VectorType                                                &vec,
     const bool                 enforce_zero_boundary = false,
     const Quadrature<dim - 1> &q_boundary = (dim > 1 ? QGauss<dim - 1>(2) :
-                                                       Quadrature<dim - 1>(0)),
+                                                       Quadrature<dim - 1>()),
     const bool                 project_to_boundary_first = false);
 
   /**
@@ -190,7 +190,7 @@ namespace VectorTools
     VectorType                                                &vec,
     const bool                      enforce_zero_boundary = false,
     const hp::QCollection<dim - 1> &q_boundary = hp::QCollection<dim - 1>(
-      dim > 1 ? QGauss<dim - 1>(2) : Quadrature<dim - 1>(0)),
+      dim > 1 ? QGauss<dim - 1>(2) : Quadrature<dim - 1>()),
     const bool project_to_boundary_first = false);
 
   /**
@@ -209,7 +209,7 @@ namespace VectorTools
     VectorType                                                &vec,
     const bool                      enforce_zero_boundary = false,
     const hp::QCollection<dim - 1> &q_boundary = hp::QCollection<dim - 1>(
-      dim > 1 ? QGauss<dim - 1>(2) : Quadrature<dim - 1>(0)),
+      dim > 1 ? QGauss<dim - 1>(2) : Quadrature<dim - 1>()),
     const bool project_to_boundary_first = false);
 
   /**

--- a/source/base/quadrature.cc
+++ b/source/base/quadrature.cc
@@ -28,12 +28,24 @@ DEAL_II_NAMESPACE_OPEN
 
 #ifndef DOXYGEN
 template <>
+Quadrature<0>::Quadrature()
+  : is_tensor_product_flag(false)
+{}
+
+template <>
 Quadrature<0>::Quadrature(const unsigned int n_q)
   : quadrature_points(n_q)
   , weights(n_q, 0)
   , is_tensor_product_flag(false)
 {}
 #endif
+
+
+
+template <int dim>
+Quadrature<dim>::Quadrature()
+  : is_tensor_product_flag(dim == 1)
+{}
 
 
 

--- a/tests/base/qprojector.cc
+++ b/tests/base/qprojector.cc
@@ -180,7 +180,7 @@ main()
   deallog << std::setprecision(2);
 
 
-  Quadrature<1> none(0);
+  Quadrature<1> none;
   check(none);
 
   QGauss<1> midpoint(1);

--- a/tests/base/quadrature_is_tensor_product.cc
+++ b/tests/base/quadrature_is_tensor_product.cc
@@ -26,7 +26,8 @@ template <int dim>
 void
 print_is_tensor_product()
 {
-  Quadrature<dim> q_0(1);
+  Quadrature<dim> q_0(std::vector<Point<dim>>{Point<dim>()},
+                      std::vector<double>{0.});
   deallog << "Quadrature<" << dim << ">: " << q_0.is_tensor_product()
           << std::endl;
 

--- a/tests/hp/fe_nothing_dominates_01.cc
+++ b/tests/hp/fe_nothing_dominates_01.cc
@@ -46,7 +46,10 @@ test(const bool fe_nothing_dominates)
     hp::FECollection<dim> fe_collection(FE_Nothing<dim>(/*n_components=*/1,
                                                         fe_nothing_dominates),
                                         FE_Q<dim>(1));
-    hp::QCollection<dim>  q_collection(Quadrature<dim>(1), QGauss<dim>(2));
+    hp::QCollection<dim>  q_collection(
+      Quadrature<dim>(std::vector<Point<dim>>{Point<dim>()},
+                      std::vector<double>{0.}),
+      QGauss<dim>(2));
     project(fe_collection, q_collection, function);
   }
 
@@ -55,7 +58,10 @@ test(const bool fe_nothing_dominates)
     hp::FECollection<dim> fe_collection(FE_Q<dim>(1),
                                         FE_Nothing<dim>(/*n_components=*/1,
                                                         fe_nothing_dominates));
-    hp::QCollection<dim>  q_collection(QGauss<dim>(2), Quadrature<dim>(1));
+    hp::QCollection<dim>  q_collection(
+      QGauss<dim>(2),
+      Quadrature<dim>(std::vector<Point<dim>>{Point<dim>()},
+                      std::vector<double>{0.}));
     project(fe_collection, q_collection, function);
   }
 }

--- a/tests/hp/fe_nothing_dominates_02.cc
+++ b/tests/hp/fe_nothing_dominates_02.cc
@@ -48,7 +48,10 @@ test()
     hp::FECollection<dim> fe_collection(
       FESystem<dim>(FE_Q<dim>(1), FE_Q<dim>(1)),
       FESystem<dim>(FE_Nothing<dim>(1, true), FE_Nothing<dim>(1, false)));
-    hp::QCollection<dim> q_collection(QGauss<dim>(2), Quadrature<dim>(1));
+    hp::QCollection<dim> q_collection(
+      QGauss<dim>(2),
+      Quadrature<dim>(std::vector<Point<dim>>{Point<dim>()},
+                      std::vector<double>{0.}));
     project(fe_collection, q_collection, function);
   }
   {
@@ -56,7 +59,10 @@ test()
     hp::FECollection<dim> fe_collection(
       FESystem<dim>(FE_Nothing<dim>(1, true), FE_Nothing<dim>(1, false)),
       FESystem<dim>(FE_Q<dim>(1), FE_Q<dim>(1)));
-    hp::QCollection<dim> q_collection(Quadrature<dim>(1), QGauss<dim>(2));
+    hp::QCollection<dim> q_collection(
+      Quadrature<dim>(std::vector<Point<dim>>{Point<dim>()},
+                      std::vector<double>{0.}),
+      QGauss<dim>(2));
     project(fe_collection, q_collection, function);
   }
 }


### PR DESCRIPTION
Fixes #16818.

This is strictly speaking an incompatible change. I don't think there should be many places where someone creates a correctly sized but otherwise invalid quadrature object, so the impact is likely small to zero.

I did think about alternatives. The obvious one is the introduction of a default constructor `Quadrature()` and removing the default value from the constructor in question here, followed by marking the latter as deprecated. That could work to retain backward compatibility. But because derived classes uniformly seem to be using this constructor, once we remove deprecated functions, we have to remember that this one cannot be removed but must be made `protected` instead. That just seemed unnecessary use of brain power, so I decided that the impact here is small enough to warrant outright removal.