### PR TITLE
Use Kokkos::abort() where necessary.

### DIFF
--- a/source/base/exceptions.cc
+++ b/source/base/exceptions.cc
@@ -516,7 +516,21 @@ namespace deal_II_exceptions
             }
         }
 #endif
+
+#if KOKKOS_VERSION >= 30600
+      KOKKOS_IF_ON_HOST(({ std::abort(); }))
+      KOKKOS_IF_ON_DEVICE(({
+        Kokkos::abort(
+          "Abort() was called during dealing with an assertion or exception.");
+      }))
+#else /*if KOKKOS_VERSION >= 30600*/
+#  ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
       std::abort();
+#  else
+      Kokkos::abort(
+        "Abort() was called during dealing with an assertion or exception.");
+#  endif
+#endif
     }
 
 

--- a/source/base/exceptions.cc
+++ b/source/base/exceptions.cc
@@ -517,20 +517,11 @@ namespace deal_II_exceptions
         }
 #endif
 
-#if KOKKOS_VERSION >= 30600
-      KOKKOS_IF_ON_HOST(({ std::abort(); }))
-      KOKKOS_IF_ON_DEVICE(({
-        Kokkos::abort(
-          "Abort() was called during dealing with an assertion or exception.");
-      }))
-#else /*if KOKKOS_VERSION >= 30600*/
-#  ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
-      std::abort();
-#  else
+      // Let's abort the program here. On the host, we need to call std::abort,
+      // on devices we need to do something different. Kokkos::abort() does
+      // the right thing in all circumstances.
       Kokkos::abort(
         "Abort() was called during dealing with an assertion or exception.");
-#  endif
-#endif
     }
 
 


### PR DESCRIPTION
@masterleinad I must admit that I don't know the intricacies of what is or isn't available in Kokkos for specific versions. Does this seem right to address your comment that we can't call straight `std::abort()` in our assertion machinery?

If so, this fixes #16553.