### PR TITLE
Deprecate two fields in MeshWorker::LocalIntegrator.

### DIFF
--- a/doc/news/changes/minor/20240514Bangerth
+++ b/doc/news/changes/minor/20240514Bangerth
@@ -1,0 +1,6 @@
+Deprecated: The member variables `input_vector_names` and
+`output_names` of MeshWorker::LocalIntegrator are not used in the
+library. They are now deprecated. If you use them, simply introduce
+variables of the same name and type in your own derived class.
+<br>
+(Wolfgang Bangerth, 2024/05/14)

--- a/include/deal.II/meshworker/local_integrator.h
+++ b/include/deal.II/meshworker/local_integrator.h
@@ -120,7 +120,11 @@ namespace MeshWorker
      *
      * @note This variable is currently not used by the library, but it is
      * provided to help develop application programs.
+     *
+     * @deprecated Because the library itself does not use this field, it is
+     *   better placed in derived classes.
      */
+    DEAL_II_DEPRECATE_EARLY
     std::vector<std::string> input_vector_names;
 
     /**
@@ -130,7 +134,11 @@ namespace MeshWorker
      *
      * @note This variable is currently not used by the library, but it is
      * provided to help develop application programs.
+     *
+     * @deprecated Because the library itself does not use this field, it is
+     *   better placed in derived classes.
      */
+    DEAL_II_DEPRECATE_EARLY
     std::vector<std::string> output_names;
 
     /**

--- a/include/deal.II/meshworker/local_integrator.h
+++ b/include/deal.II/meshworker/local_integrator.h
@@ -124,7 +124,7 @@ namespace MeshWorker
      * @deprecated Because the library itself does not use this field, it is
      *   better placed in derived classes.
      */
-    DEAL_II_DEPRECATE_EARLY
+    DEAL_II_DEPRECATED_EARLY
     std::vector<std::string> input_vector_names;
 
     /**
@@ -138,7 +138,7 @@ namespace MeshWorker
      * @deprecated Because the library itself does not use this field, it is
      *   better placed in derived classes.
      */
-    DEAL_II_DEPRECATE_EARLY
+    DEAL_II_DEPRECATED_EARLY
     std::vector<std::string> output_names;
 
     /**


### PR DESCRIPTION
These fields are not used in the library. They are better placed in derived classes.

Related to #15604 .