### PR TITLE
Make spelling of FE_Nothing and FE_DGQ consistent

### DIFF
--- a/doc/news/9.4.0-vs-9.5.0.h
+++ b/doc/news/9.4.0-vs-9.5.0.h
@@ -1052,7 +1052,7 @@ inconvenience this causes.
   New: The new class MatrixFreeTools::ElementActivationAndDeactivationMatrixFree
   is a wrapper around MatrixFree designed to deal with
   DoFHandler objects involving cells without degrees of freedom, i.e.,
-  cells using FENothing as element type. The class helps to implement the
+  cells using FE_Nothing as element type. The class helps to implement the
   "element birth and death technique".
   <br>
   (Peter Munch, Sebastian Proell, 2022/07/09)

--- a/doc/news/changes/minor/20240118Schreter
+++ b/doc/news/changes/minor/20240118Schreter
@@ -1,4 +1,4 @@
 Changed:
-FE_DGQ::get_interpolation_matrix() now also takes as a source element FENothing.
+FE_DGQ::get_interpolation_matrix() now also takes as a source element FE_Nothing.
 <br>
 (Magdalena Schreter, Peter Munch, 2024/01/18)

--- a/doc/news/changes/minor/20240219SchreterRitthaler
+++ b/doc/news/changes/minor/20240219SchreterRitthaler
@@ -1,3 +1,3 @@
-Fixed: Fix make_flux_sparsity_pattern for a FECollection containing FENothing elements. 
+Fixed: Fix make_flux_sparsity_pattern for a FECollection containing FE_Nothing elements. 
 <br>
 (Magdalena Schreter-Fleischhacker, Andreas Ritthaler, 2024/02/19)

--- a/examples/step-85/step-85.cc
+++ b/examples/step-85/step-85.cc
@@ -359,7 +359,7 @@ namespace Step85
                                                       level_set);
 
     // As we iterate over the cells, we don't need to do anything on the cells
-    // that have FENothing elements. To disregard them we use an iterator
+    // that have FE_Nothing elements. To disregard them we use an iterator
     // filter.
     for (const auto &cell :
          dof_handler.active_cell_iterators() |

--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -4714,7 +4714,7 @@ AffineConstraints<number>::add_entries_local_to_global(
   const size_type n_local_cols = col_indices.size();
 
   // Early return if the length of row and column indices is zero, relevant
-  // for the usage with FENothing.
+  // for the usage with FE_Nothing.
   if (n_local_cols == 0 && n_local_rows == 0)
     return;
 

--- a/include/deal.II/matrix_free/shape_info.h
+++ b/include/deal.II/matrix_free/shape_info.h
@@ -430,9 +430,9 @@ namespace internal
        * Return whether an element is supported by MatrixFree.
        *
        * The following scalar elements are supported:
-       * - FENothing, FE_DGP, and FE_Q_DG0
+       * - FE_Nothing, FE_DGP, and FE_Q_DG0
        * - polynomial tensor-product elements based on
-       *   Polynomials::Polynomial (FE_Q, FE_DG_Q, FE_DGQArbitraryNodes,
+       *   Polynomials::Polynomial (FE_Q, FE_DGQ, FE_DGQArbitraryNodes,
        *   FE_DGQHermite, FE_DGQLegendre) or Polynomials::PiecewisePolynomial
        *   (FE_Q_iso_Q1).
        * - elements for simplex, pyramids, and wedges (FE_SimplexP,

--- a/include/deal.II/matrix_free/tools.h
+++ b/include/deal.II/matrix_free/tools.h
@@ -160,10 +160,10 @@ namespace MatrixFreeTools
   /**
    * A wrapper around MatrixFree to help users to deal with DoFHandler
    * objects involving cells without degrees of freedom, i.e.,
-   * cells using FENothing as element type.  In the following we call such cells
-   * deactivated. All other cells are activated. In contrast to MatrixFree,
-   * this class skips deactivated cells and faces between activated and
-   * deactivated cells are treated as boundary faces.
+   * cells using FE_Nothing as element type.  In the following we call such
+   * cells deactivated. All other cells are activated. In contrast to
+   * MatrixFree, this class skips deactivated cells and faces between activated
+   * and deactivated cells are treated as boundary faces.
    */
   template <int dim,
             typename Number,
@@ -196,7 +196,7 @@ namespace MatrixFreeTools
      *
      * @note At the moment, only DoFHandler objects are accepted
      * that are initialized with FECollection objects with at most
-     * two finite elements (i.e., `FENothing` and another finite
+     * two finite elements (i.e., `FE_Nothing` and another finite
      * element).
      */
     void

--- a/tests/hp/fe_nothing_05.cc
+++ b/tests/hp/fe_nothing_05.cc
@@ -43,7 +43,7 @@
 
 
 // Create a mesh with hanging
-// nodes and FEQ/FENothing interfaces
+// nodes and FEQ/FE_Nothing interfaces
 // in several admissible configurations
 // we'd like to check.  In 2D the mesh
 // looks like the following (with 0

--- a/tests/hp/fe_nothing_06.cc
+++ b/tests/hp/fe_nothing_06.cc
@@ -43,7 +43,7 @@
 
 
 // Create a mesh with hanging
-// nodes and FEQ/FENothing interfaces
+// nodes and FEQ/FE_Nothing interfaces
 // in several admissible configurations
 // we'd like to check.  In 2D the mesh
 // looks like the following.

--- a/tests/hp/fe_nothing_07.cc
+++ b/tests/hp/fe_nothing_07.cc
@@ -16,7 +16,7 @@
 
 // test that FE_Nothing works as intended
 
-// Create a mesh with hanging nodes and FEQ/FENothing interfaces in
+// Create a mesh with hanging nodes and FEQ/FE_Nothing interfaces in
 // several admissible configurations we'd like to check.  In 2D the
 // mesh looks like the following.
 //

--- a/tests/hp/fe_nothing_12.cc
+++ b/tests/hp/fe_nothing_12.cc
@@ -15,7 +15,7 @@
 
 
 // check the case where the two children on a face with a hanging node
-// have different FENothing structure:
+// have different FE_Nothing structure:
 
 // active_fe_index
 // *-----*--*--*

--- a/tests/hp/fe_nothing_13.cc
+++ b/tests/hp/fe_nothing_13.cc
@@ -15,7 +15,7 @@
 
 
 // check the case where the two children on a face with a hanging node have
-// different FENothing structure. while all cells in the _12 test had degrees
+// different FE_Nothing structure. while all cells in the _12 test had degrees
 // of freedom, here, cells with active_fe_index==1 are simply FE_Nothing:
 
 // active_fe_index

--- a/tests/hp/fe_nothing_14.cc
+++ b/tests/hp/fe_nothing_14.cc
@@ -15,7 +15,7 @@
 
 
 // check the case where the two children on a face with a hanging node have
-// different FENothing structure. compared to _12 and _13, the situation is
+// different FE_Nothing structure. compared to _12 and _13, the situation is
 // even more wicked since in the picture below 0=FE_Q(1), 1=FE_Nothing,
 // 2=FE_Q(2), i.e. 2 dominates 1
 

--- a/tests/hp/solution_transfer_03.cc
+++ b/tests/hp/solution_transfer_03.cc
@@ -15,7 +15,7 @@
 
 
 // SolutionTransfer got into trouble when interpolating between an old and a
-// new mesh where some cells are set to use FENothing, see bug #83
+// new mesh where some cells are set to use FE_Nothing, see bug #83
 // (https://code.google.com/p/dealii/issues/detail?id=83)
 //
 // the testcase is really invalid -- it forgot to call

--- a/tests/mpi/hp_step-4.cc
+++ b/tests/mpi/hp_step-4.cc
@@ -16,8 +16,9 @@
 // A lightly adapted version of the step-4 tutorial program. Compared
 // to step-4, this test uses hp::DoFHandler and
 // parallel::distributed::Triangulation. In the upper half of the domain
-// FENothing is used to save effort, as these elements would only be used later.
-// The test checks whether the hanging-node constraints are setup correctly.
+// FE_Nothing is used to save effort, as these elements would only be used
+// later. The test checks whether the hanging-node constraints are setup
+// correctly.
 
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/function.h>


### PR DESCRIPTION
This PR proposes to correct the spelling of `FE_Nothing` and `FE_DGQ` throughout the library to fix corresponding broken links in the documentation, as e.g. in

https://dealii.org/developer/doxygen/deal.II/structinternal_1_1MatrixFreeFunctions_1_1ShapeInfo.html#a6ce48fb30e9d2fd83ecbefb66a725162
![image](https://github.com/dealii/dealii/assets/70260016/1a63130d-7bb8-4c35-870c-486db59ac771)



