### PR TITLE
`VectorizedArray`: Add missing overloads of trigonometric and hyperbolic functions from cmath

### DIFF
--- a/doc/news/changes/minor/20240515Schreter
+++ b/doc/news/changes/minor/20240515Schreter
@@ -1,0 +1,4 @@
+New: Added overloads of missing trigonometric functions (acos, asin, atan) and 
+hyperbolic functions (cosh, sinh, tanh, acosh, asinh, atanh) for VectorizedArray.
+<br>
+(Magdalena Schreter-Fleischhacker, Johannes Resch, Martin Kronbichler 2024/05/15)

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -6649,6 +6649,186 @@ namespace std
 
 
   /**
+   * Compute the arc cosine of a vectorized data field. The result is
+   * returned as vectorized array in the form <tt>{acos(x[0]), acos(x[1]), ...,
+   * acos(x[size()-1])}</tt>.
+   *
+   * @relatesalso VectorizedArray
+   */
+  template <typename Number, std::size_t width>
+  inline ::dealii::VectorizedArray<Number, width>
+  acos(const ::dealii::VectorizedArray<Number, width> &x)
+  {
+    ::dealii::VectorizedArray<Number, width> out;
+    for (unsigned int i = 0; i < dealii::VectorizedArray<Number, width>::size();
+         ++i)
+      out[i] = std::acos(x[i]);
+    return out;
+  }
+
+
+
+  /**
+   * Compute the arc sine of a vectorized data field. The result is
+   * returned as vectorized array in the form <tt>{asin(x[0]), asin(x[1]), ...,
+   * asin(x[size()-1])}</tt>.
+   *
+   * @relatesalso VectorizedArray
+   */
+  template <typename Number, std::size_t width>
+  inline ::dealii::VectorizedArray<Number, width>
+  asin(const ::dealii::VectorizedArray<Number, width> &x)
+  {
+    ::dealii::VectorizedArray<Number, width> out;
+    for (unsigned int i = 0; i < dealii::VectorizedArray<Number, width>::size();
+         ++i)
+      out[i] = std::asin(x[i]);
+    return out;
+  }
+
+
+
+  /**
+   * Compute the arc tangent of a vectorized data field. The result is
+   * returned as vectorized array in the form <tt>{atan(x[0]), atan(x[1]), ...,
+   * atan(x[size()-1])}</tt>.
+   *
+   * @relatesalso VectorizedArray
+   */
+  template <typename Number, std::size_t width>
+  inline ::dealii::VectorizedArray<Number, width>
+  atan(const ::dealii::VectorizedArray<Number, width> &x)
+  {
+    ::dealii::VectorizedArray<Number, width> out;
+    for (unsigned int i = 0; i < dealii::VectorizedArray<Number, width>::size();
+         ++i)
+      out[i] = std::atan(x[i]);
+    return out;
+  }
+
+
+
+  /**
+   * Compute the hyperbolic cosine of a vectorized data field. The result is
+   * returned as vectorized array in the form <tt>{cosh(x[0]), cosh(x[1]), ...,
+   * cosh(x[size()-1])}</tt>.
+   *
+   * @relatesalso VectorizedArray
+   */
+  template <typename Number, std::size_t width>
+  inline ::dealii::VectorizedArray<Number, width>
+  cosh(const ::dealii::VectorizedArray<Number, width> &x)
+  {
+    ::dealii::VectorizedArray<Number, width> out;
+    for (unsigned int i = 0; i < dealii::VectorizedArray<Number, width>::size();
+         ++i)
+      out[i] = std::cosh(x[i]);
+    return out;
+  }
+
+
+
+  /**
+   * Compute the hyperbolic sine of a vectorized data field. The result is
+   * returned as vectorized array in the form <tt>{sinh(x[0]), sinh(x[1]), ...,
+   * sinh(x[size()-1])}</tt>.
+   *
+   * @relatesalso VectorizedArray
+   */
+  template <typename Number, std::size_t width>
+  inline ::dealii::VectorizedArray<Number, width>
+  sinh(const ::dealii::VectorizedArray<Number, width> &x)
+  {
+    ::dealii::VectorizedArray<Number, width> out;
+    for (unsigned int i = 0; i < dealii::VectorizedArray<Number, width>::size();
+         ++i)
+      out[i] = std::sinh(x[i]);
+    return out;
+  }
+
+
+
+  /**
+   * Compute the hyperbolic tangent of a vectorized data field. The result is
+   * returned as vectorized array in the form <tt>{tanh(x[0]), tanh(x[1]), ...,
+   * tanh(x[size()-1])}</tt>.
+   *
+   * @relatesalso VectorizedArray
+   */
+  template <typename Number, std::size_t width>
+  inline ::dealii::VectorizedArray<Number, width>
+  tanh(const ::dealii::VectorizedArray<Number, width> &x)
+  {
+    ::dealii::VectorizedArray<Number, width> out;
+    for (unsigned int i = 0; i < dealii::VectorizedArray<Number, width>::size();
+         ++i)
+      out[i] = std::tanh(x[i]);
+    return out;
+  }
+
+
+
+  /**
+   * Compute the area hyperbolic cosine of a vectorized data field. The result
+   * is returned as vectorized array in the form <tt>{acosh(x[0]), acosh(x[1]),
+   * ..., acosh(x[size()-1])}</tt>.
+   *
+   * @relatesalso VectorizedArray
+   */
+  template <typename Number, std::size_t width>
+  inline ::dealii::VectorizedArray<Number, width>
+  acosh(const ::dealii::VectorizedArray<Number, width> &x)
+  {
+    ::dealii::VectorizedArray<Number, width> out;
+    for (unsigned int i = 0; i < dealii::VectorizedArray<Number, width>::size();
+         ++i)
+      out[i] = std::acosh(x[i]);
+    return out;
+  }
+
+
+
+  /**
+   * Compute the area hyperbolic sine of a vectorized data field. The result is
+   * returned as vectorized array in the form <tt>{asinh(x[0]), asinh(x[1]),
+   * ..., asinh(x[size()-1])}</tt>.
+   *
+   * @relatesalso VectorizedArray
+   */
+  template <typename Number, std::size_t width>
+  inline ::dealii::VectorizedArray<Number, width>
+  asinh(const ::dealii::VectorizedArray<Number, width> &x)
+  {
+    ::dealii::VectorizedArray<Number, width> out;
+    for (unsigned int i = 0; i < dealii::VectorizedArray<Number, width>::size();
+         ++i)
+      out[i] = std::asinh(x[i]);
+    return out;
+  }
+
+
+
+  /**
+   * Compute the area hyperbolic tangent of a vectorized data field. The result
+   * is returned as vectorized array in the form <tt>{atanh(x[0]), atanh(x[1]),
+   * ..., atanh(x[size()-1])}</tt>.
+   *
+   * @relatesalso VectorizedArray
+   */
+  template <typename Number, std::size_t width>
+  inline ::dealii::VectorizedArray<Number, width>
+  atanh(const ::dealii::VectorizedArray<Number, width> &x)
+  {
+    ::dealii::VectorizedArray<Number, width> out;
+    for (unsigned int i = 0; i < dealii::VectorizedArray<Number, width>::size();
+         ++i)
+      out[i] = std::atanh(x[i]);
+    return out;
+  }
+
+
+
+  /**
    * Compute the exponential of a vectorized data field. The result is
    * returned as vectorized array in the form <tt>{exp(x[0]), exp(x[1]), ...,
    * exp(x[size()-1])}</tt>.

--- a/tests/base/vectorization_01.cc
+++ b/tests/base/vectorization_01.cc
@@ -105,16 +105,70 @@ test()
     AssertThrow(std::fabs(e[i] - std::sin(d[i])) <
                   10. * std::numeric_limits<Number>::epsilon(),
                 ExcInternalError());
+  deallog << "OK" << std::endl << "Arc sine: ";
+  d = std::asin(e);
+  for (unsigned int i = 0; i < n_vectors; ++i)
+    AssertThrow(std::fabs(d[i] - std::asin(e[i])) <
+                  10. * std::numeric_limits<Number>::epsilon(),
+                ExcInternalError());
   deallog << "OK" << std::endl << "Cosine: ";
   e = std::cos(c);
   for (unsigned int i = 0; i < n_vectors; ++i)
     AssertThrow(std::fabs(e[i] - std::cos(c[i])) <
                   10. * std::numeric_limits<Number>::epsilon(),
                 ExcInternalError());
+  deallog << "OK" << std::endl << "Arc cosine: ";
+  c = std::acos(e);
+  for (unsigned int i = 0; i < n_vectors; ++i)
+    AssertThrow(std::fabs(c[i] - std::acos(e[i])) <
+                  10. * std::numeric_limits<Number>::epsilon(),
+                ExcInternalError());
   deallog << "OK" << std::endl << "Tangent: ";
   d = std::tan(e);
   for (unsigned int i = 0; i < n_vectors; ++i)
     AssertThrow(std::fabs(d[i] - std::tan(e[i])) <
+                  10. * std::numeric_limits<Number>::epsilon(),
+                ExcInternalError());
+  deallog << "OK" << std::endl << "Arc tangent: ";
+  d = std::atan(e);
+  for (unsigned int i = 0; i < n_vectors; ++i)
+    AssertThrow(std::fabs(d[i] - std::atan(e[i])) <
+                  10. * std::numeric_limits<Number>::epsilon(),
+                ExcInternalError());
+  deallog << "OK" << std::endl << "Hyperbolic cosine: ";
+  e = std::cosh(c);
+  for (unsigned int i = 0; i < n_vectors; ++i)
+    AssertThrow(std::fabs(e[i] - std::cosh(c[i])) <
+                  10. * std::numeric_limits<Number>::epsilon(),
+                ExcInternalError());
+  deallog << "OK" << std::endl << "Area hyperbolic cosine: ";
+  c = std::acosh(e);
+  for (unsigned int i = 0; i < n_vectors; ++i)
+    AssertThrow(std::fabs(c[i] - std::acosh(e[i])) <
+                  10. * std::numeric_limits<Number>::epsilon(),
+                ExcInternalError());
+  deallog << "OK" << std::endl << "Hyperbolic sine: ";
+  e = std::sinh(d);
+  for (unsigned int i = 0; i < n_vectors; ++i)
+    AssertThrow(std::fabs(e[i] - std::sinh(d[i])) <
+                  10. * std::numeric_limits<Number>::epsilon(),
+                ExcInternalError());
+  deallog << "OK" << std::endl << "Area hyperbolic sine: ";
+  d = std::asinh(e);
+  for (unsigned int i = 0; i < n_vectors; ++i)
+    AssertThrow(std::fabs(d[i] - std::asinh(e[i])) <
+                  10. * std::numeric_limits<Number>::epsilon(),
+                ExcInternalError());
+  deallog << "OK" << std::endl << "Hyperbolic tangent: ";
+  d = std::tanh(e);
+  for (unsigned int i = 0; i < n_vectors; ++i)
+    AssertThrow(std::fabs(d[i] - std::tanh(e[i])) <
+                  10. * std::numeric_limits<Number>::epsilon(),
+                ExcInternalError());
+  deallog << "OK" << std::endl << "Area hyperbolic tangent: ";
+  e = std::atanh(d);
+  for (unsigned int i = 0; i < n_vectors; ++i)
+    AssertThrow(std::fabs(e[i] - std::atanh(d[i])) <
                   10. * std::numeric_limits<Number>::epsilon(),
                 ExcInternalError());
   deallog << "OK" << std::endl << "Exponential: ";

--- a/tests/base/vectorization_01.output
+++ b/tests/base/vectorization_01.output
@@ -13,8 +13,17 @@ DEAL:double::Absolute value: OK
 DEAL:double::Maximum value: OK
 DEAL:double::Minimum value: OK
 DEAL:double::Sine: OK
+DEAL:double::Arc sine: OK
 DEAL:double::Cosine: OK
+DEAL:double::Arc cosine: OK
 DEAL:double::Tangent: OK
+DEAL:double::Arc tangent: OK
+DEAL:double::Hyperbolic cosine: OK
+DEAL:double::Area hyperbolic cosine: OK
+DEAL:double::Hyperbolic sine: OK
+DEAL:double::Area hyperbolic sine: OK
+DEAL:double::Hyperbolic tangent: OK
+DEAL:double::Area hyperbolic tangent: OK
 DEAL:double::Exponential: OK
 DEAL:double::Logarithm: OK
 DEAL:float::Addition: OK
@@ -31,8 +40,17 @@ DEAL:float::Absolute value: OK
 DEAL:float::Maximum value: OK
 DEAL:float::Minimum value: OK
 DEAL:float::Sine: OK
+DEAL:float::Arc sine: OK
 DEAL:float::Cosine: OK
+DEAL:float::Arc cosine: OK
 DEAL:float::Tangent: OK
+DEAL:float::Arc tangent: OK
+DEAL:float::Hyperbolic cosine: OK
+DEAL:float::Area hyperbolic cosine: OK
+DEAL:float::Hyperbolic sine: OK
+DEAL:float::Area hyperbolic sine: OK
+DEAL:float::Hyperbolic tangent: OK
+DEAL:float::Area hyperbolic tangent: OK
 DEAL:float::Exponential: OK
 DEAL:float::Logarithm: OK
 DEAL:long double::Addition: OK
@@ -49,7 +67,16 @@ DEAL:long double::Absolute value: OK
 DEAL:long double::Maximum value: OK
 DEAL:long double::Minimum value: OK
 DEAL:long double::Sine: OK
+DEAL:long double::Arc sine: OK
 DEAL:long double::Cosine: OK
+DEAL:long double::Arc cosine: OK
 DEAL:long double::Tangent: OK
+DEAL:long double::Arc tangent: OK
+DEAL:long double::Hyperbolic cosine: OK
+DEAL:long double::Area hyperbolic cosine: OK
+DEAL:long double::Hyperbolic sine: OK
+DEAL:long double::Area hyperbolic sine: OK
+DEAL:long double::Hyperbolic tangent: OK
+DEAL:long double::Area hyperbolic tangent: OK
 DEAL:long double::Exponential: OK
 DEAL:long double::Logarithm: OK


### PR DESCRIPTION
This PR suggests to implement missing overloads of trigonometric/hyperbolic functions for `VectorizedArray` from `cmath` (https://cplusplus.com/reference/cmath/). I've generated the code with the following python script:

```py

mystring="""/**
* Compute the @description of a vectorized data field. The result is
* returned as vectorized array in the form <tt>{@func(x[0]), @func(x[1]), ...,
* @func(x[size()-1])}</tt>.
*
* @relatesalso VectorizedArray
*/
template <typename Number, std::size_t width>
inline ::dealii::VectorizedArray<Number, width>
@func(const ::dealii::VectorizedArray<Number, width> &x)
{
  ::dealii::VectorizedArray<Number, width> out;
  for (unsigned int i = 0; i < dealii::VectorizedArray<Number, width>::size();
       ++i)
    out[i] = std::@func(x[i]);
  return out;
}
"""

des = ["arc cosine", "arc sine", "arc tangent", "hyperbolic cosine", "hyperbolic sine", "hyperbolic tangent", "area hyperbolic cosine","area hyperbolic sine","area hyperbolic tangent"]
fun = ["acos", "asin", "atan", "cosh", "sinh", "tanh", "acosh", "asinh", "atanh"]

assert len(des)==len(fun)

for (d,f) in zip(des,fun):
    new = mystring.replace("@description", d)
    new = new.replace("@func", f)
    print(new)
    print()
    print()
```

As a follow-up, the following functions could be incorporated.

**Trigonometric functions**
atan2	Compute arc tangent with two parameters (function)

**Exponential and logarithmic functions**
frexp	Get significand and exponent (function)
ldexp	Generate value from significand and exponent (function)
log10	Compute common logarithm (function)
modf	Break into fractional and integral parts (function)
exp2	Compute binary exponential function (function)
expm1	Compute exponential minus one (function)
ilogb	Integer binary logarithm (function)
log1p	Compute logarithm plus one (function)
log2	Compute binary logarithm (function)
logb	Compute floating-point base logarithm (function)
scalbn	Scale significand using floating-point base exponent (function)
scalbln	Scale significand using floating-point base exponent (long) (function)

@johannes-resch @kronbichler FYI