### PR TITLE
Fix error message in step-50

### DIFF
--- a/examples/step-50/step-50.cc
+++ b/examples/step-50/step-50.cc
@@ -106,7 +106,7 @@ namespace ChangeVectorTypes
     rwv.import_elements(in, VectorOperation::insert);
 #ifdef USE_PETSC_LA
     AssertThrow(false,
-                ExcMessage("CopyVectorTypes::copy() not implemented for "
+                ExcMessage("ChangeVectorTypes::copy() not implemented for "
                            "PETSc vector types."));
 #else
     out.import_elements(rwv, VectorOperation::insert);
@@ -123,7 +123,7 @@ namespace ChangeVectorTypes
 #ifdef USE_PETSC_LA
     (void)in;
     AssertThrow(false,
-                ExcMessage("CopyVectorTypes::copy() not implemented for "
+                ExcMessage("ChangeVectorTypes::copy() not implemented for "
                            "PETSc vector types."));
 #else
     rwv.reinit(in);


### PR DESCRIPTION
The error messages come from `copy` in the `namespace ChangeVectorTypes`. Thus, I changed the error messages accordingly.