### PR TITLE
Raise error when DSP is used without IndexSet

### DIFF
--- a/source/lac/sparsity_tools.cc
+++ b/source/lac/sparsity_tools.cc
@@ -1022,12 +1022,10 @@ namespace SparsityTools
                               const MPI_Comm          mpi_comm,
                               const IndexSet         &locally_relevant_rows)
   {
-    IndexSet rows_dsp = dsp.row_index_set();
-    rows_dsp.subtract_set(locally_relevant_rows);
     AssertThrow(
-      rows_dsp.n_elements() == 0,
+      dsp.row_index_set() == locally_relevant_rows,
       ExcMessage(
-        "Dynamic Sparsity Pattern must be initialized with locally_relevant_rows."));
+        "The DynamicSparsityPattern must be initialized with an IndexSet that contains locally relevant indices."));
 
     IndexSet requested_rows(locally_relevant_rows);
     requested_rows.subtract_set(locally_owned_rows);

--- a/source/lac/sparsity_tools.cc
+++ b/source/lac/sparsity_tools.cc
@@ -1022,6 +1022,13 @@ namespace SparsityTools
                               const MPI_Comm          mpi_comm,
                               const IndexSet         &locally_relevant_rows)
   {
+    IndexSet rows_dsp = dsp.row_index_set();
+    rows_dsp.subtract_set(locally_relevant_rows);
+    AssertThrow(
+      rows_dsp.n_elements() == 0,
+      ExcMessage(
+        "Dynamic Sparsity Pattern must be initialized with locally_relevant_rows."));
+
     IndexSet requested_rows(locally_relevant_rows);
     requested_rows.subtract_set(locally_owned_rows);
 

--- a/tests/lac/linear_operator_12.cc
+++ b/tests/lac/linear_operator_12.cc
@@ -197,7 +197,7 @@ Step4<dim>::setup_system()
   const IndexSet  locally_relevant_dofs =
     DoFTools::extract_locally_relevant_dofs(dof_handler);
 
-  DynamicSparsityPattern dsp(dof_handler.n_dofs());
+  DynamicSparsityPattern dsp(locally_relevant_dofs);
   DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
   SparsityTools::distribute_sparsity_pattern(dsp,
                                              locally_owned_dofs,

--- a/tests/lac/linear_operator_12a.cc
+++ b/tests/lac/linear_operator_12a.cc
@@ -198,7 +198,7 @@ Step4<dim>::setup_system()
   const IndexSet  locally_relevant_dofs =
     DoFTools::extract_locally_relevant_dofs(dof_handler);
 
-  DynamicSparsityPattern dsp(dof_handler.n_dofs());
+  DynamicSparsityPattern dsp(locally_relevant_dofs);
   DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
   SparsityTools::distribute_sparsity_pattern(dsp,
                                              locally_owned_dofs,

--- a/tests/particles/particle_interpolation_01.cc
+++ b/tests/particles/particle_interpolation_01.cc
@@ -88,15 +88,6 @@ test()
             << "Space FE: " << space_fe.get_name() << std::endl
             << "Space dofs: " << space_dh.n_dofs() << std::endl;
 
-  DynamicSparsityPattern dsp(particle_handler.n_global_particles() * n_comps,
-                             space_dh.n_dofs());
-
-  AffineConstraints<double> constraints;
-
-  // Build the interpolation sparsity
-  Particles::Utilities::create_interpolation_sparsity_pattern(
-    space_dh, particle_handler, dsp, constraints, space_mask);
-
   const auto n_local_particles_dofs =
     particle_handler.n_locally_owned_particles() * n_comps;
 
@@ -115,6 +106,16 @@ test()
 
   auto global_particles_index_set =
     Utilities::MPI::all_gather(MPI_COMM_WORLD, n_local_particles_dofs);
+
+  DynamicSparsityPattern dsp(particle_handler.n_global_particles() * n_comps,
+                             space_dh.n_dofs(),
+                             local_particle_index_set);
+
+  AffineConstraints<double> constraints;
+
+  // Build the interpolation sparsity
+  Particles::Utilities::create_interpolation_sparsity_pattern(
+    space_dh, particle_handler, dsp, constraints, space_mask);
 
   SparsityTools::distribute_sparsity_pattern(dsp,
                                              global_particles_index_set,

--- a/tests/particles/particle_interpolation_02.cc
+++ b/tests/particles/particle_interpolation_02.cc
@@ -92,15 +92,6 @@ test()
             << "Space FE: " << space_fe.get_name() << std::endl
             << "Space dofs: " << space_dh.n_dofs() << std::endl;
 
-  DynamicSparsityPattern dsp(particle_handler.n_global_particles() * n_comps,
-                             space_dh.n_dofs());
-
-  AffineConstraints<double> constraints;
-
-  // Build the interpolation sparsity
-  Particles::Utilities::create_interpolation_sparsity_pattern(
-    space_dh, particle_handler, dsp, constraints, space_mask);
-
   const auto n_local_particles_dofs =
     particle_handler.n_locally_owned_particles() * n_comps;
 
@@ -119,6 +110,16 @@ test()
 
   auto global_particles_index_set =
     Utilities::MPI::all_gather(MPI_COMM_WORLD, n_local_particles_dofs);
+
+  DynamicSparsityPattern dsp(particle_handler.n_global_particles() * n_comps,
+                             space_dh.n_dofs(),
+                             local_particle_index_set);
+
+  AffineConstraints<double> constraints;
+
+  // Build the interpolation sparsity
+  Particles::Utilities::create_interpolation_sparsity_pattern(
+    space_dh, particle_handler, dsp, constraints, space_mask);
 
   SparsityTools::distribute_sparsity_pattern(dsp,
                                              global_particles_index_set,

--- a/tests/particles/particle_interpolation_03.cc
+++ b/tests/particles/particle_interpolation_03.cc
@@ -91,15 +91,6 @@ test()
             << "Space FE: " << space_fe.get_name() << std::endl
             << "Space dofs: " << space_dh.n_dofs() << std::endl;
 
-  DynamicSparsityPattern dsp(particle_handler.n_global_particles() * n_comps,
-                             space_dh.n_dofs());
-
-  AffineConstraints<double> constraints;
-
-  // Build the interpolation sparsity
-  Particles::Utilities::create_interpolation_sparsity_pattern(
-    space_dh, particle_handler, dsp, constraints, space_mask);
-
   const auto n_local_particles_dofs =
     particle_handler.n_locally_owned_particles() * n_comps;
 
@@ -118,6 +109,16 @@ test()
 
   auto global_particles_index_set =
     Utilities::MPI::all_gather(MPI_COMM_WORLD, n_local_particles_dofs);
+
+  DynamicSparsityPattern dsp(particle_handler.n_global_particles() * n_comps,
+                             space_dh.n_dofs(),
+                             local_particle_index_set);
+
+  AffineConstraints<double> constraints;
+
+  // Build the interpolation sparsity
+  Particles::Utilities::create_interpolation_sparsity_pattern(
+    space_dh, particle_handler, dsp, constraints, space_mask);
 
   SparsityTools::distribute_sparsity_pattern(dsp,
                                              global_particles_index_set,

--- a/tests/particles/particle_interpolation_04.cc
+++ b/tests/particles/particle_interpolation_04.cc
@@ -86,15 +86,6 @@ test()
             << "Space FE: " << space_fe.get_name() << std::endl
             << "Space dofs: " << space_dh.n_dofs() << std::endl;
 
-  DynamicSparsityPattern dsp(particle_handler.n_global_particles() * n_comps,
-                             space_dh.n_dofs());
-
-  AffineConstraints<double> constraints;
-
-  // Build the interpolation sparsity
-  Particles::Utilities::create_interpolation_sparsity_pattern(
-    space_dh, particle_handler, dsp, constraints, space_mask);
-
   const auto n_local_particles_dofs =
     particle_handler.n_locally_owned_particles() * n_comps;
 
@@ -113,6 +104,16 @@ test()
 
   auto global_particles_index_set =
     Utilities::MPI::all_gather(MPI_COMM_WORLD, n_local_particles_dofs);
+
+  DynamicSparsityPattern dsp(particle_handler.n_global_particles() * n_comps,
+                             space_dh.n_dofs(),
+                             local_particle_index_set);
+
+  AffineConstraints<double> constraints;
+
+  // Build the interpolation sparsity
+  Particles::Utilities::create_interpolation_sparsity_pattern(
+    space_dh, particle_handler, dsp, constraints, space_mask);
 
   SparsityTools::distribute_sparsity_pattern(dsp,
                                              global_particles_index_set,

--- a/tests/particles/particle_interpolation_05.cc
+++ b/tests/particles/particle_interpolation_05.cc
@@ -88,15 +88,6 @@ test()
             << "Space FE: " << space_fe.get_name() << std::endl
             << "Space dofs: " << space_dh.n_dofs() << std::endl;
 
-  DynamicSparsityPattern dsp(particle_handler.n_global_particles() * n_comps,
-                             space_dh.n_dofs());
-
-  AffineConstraints<double> constraints;
-
-  // Build the interpolation sparsity
-  Particles::Utilities::create_interpolation_sparsity_pattern(
-    space_dh, particle_handler, dsp, constraints, space_mask);
-
   const auto n_local_particles_dofs =
     particle_handler.n_locally_owned_particles() * n_comps;
 
@@ -115,6 +106,16 @@ test()
 
   auto global_particles_index_set =
     Utilities::MPI::all_gather(MPI_COMM_WORLD, n_local_particles_dofs);
+
+  DynamicSparsityPattern dsp(particle_handler.n_global_particles() * n_comps,
+                             space_dh.n_dofs(),
+                             local_particle_index_set);
+
+  AffineConstraints<double> constraints;
+
+  // Build the interpolation sparsity
+  Particles::Utilities::create_interpolation_sparsity_pattern(
+    space_dh, particle_handler, dsp, constraints, space_mask);
 
   SparsityTools::distribute_sparsity_pattern(dsp,
                                              global_particles_index_set,

--- a/tests/trilinos/direct_solver_2.cc
+++ b/tests/trilinos/direct_solver_2.cc
@@ -196,7 +196,7 @@ Step4<dim>::setup_system()
     DoFTools::extract_locally_relevant_dofs(dof_handler);
 
 
-  DynamicSparsityPattern dsp(dof_handler.n_dofs());
+  DynamicSparsityPattern dsp(locally_relevant_dofs);
   DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
   SparsityTools::distribute_sparsity_pattern(dsp,
                                              locally_owned_dofs,

--- a/tests/trilinos/direct_solver_3.cc
+++ b/tests/trilinos/direct_solver_3.cc
@@ -160,7 +160,7 @@ Step4<dim>::setup_system()
     DoFTools::extract_locally_relevant_dofs(dof_handler);
 
 
-  DynamicSparsityPattern dsp(dof_handler.n_dofs());
+  DynamicSparsityPattern dsp(locally_relevant_dofs);
   DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
   SparsityTools::distribute_sparsity_pattern(dsp,
                                              locally_owned_dofs,

--- a/tests/trilinos_tpetra/direct_solver_01.cc
+++ b/tests/trilinos_tpetra/direct_solver_01.cc
@@ -197,7 +197,7 @@ Step4<dim>::setup_system()
     DoFTools::extract_locally_relevant_dofs(dof_handler);
 
 
-  DynamicSparsityPattern dsp(dof_handler.n_dofs());
+  DynamicSparsityPattern dsp(locally_relevant_dofs);
   DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
   SparsityTools::distribute_sparsity_pattern(dsp,
                                              locally_owned_dofs,

--- a/tests/trilinos_tpetra/direct_solver_02.cc
+++ b/tests/trilinos_tpetra/direct_solver_02.cc
@@ -195,7 +195,7 @@ Step4<dim>::setup_system()
     DoFTools::extract_locally_relevant_dofs(dof_handler);
 
 
-  DynamicSparsityPattern dsp(dof_handler.n_dofs());
+  DynamicSparsityPattern dsp(locally_relevant_dofs);
   DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
   SparsityTools::distribute_sparsity_pattern(dsp,
                                              locally_owned_dofs,


### PR DESCRIPTION
Dynamic Sparsity Pattern must be initialized with locally_relevant_rows. Without the suggested assertion, one could easily make a crucial mistake of initializing the sparsity pattern with global DoFs instead of local DoFs.