### PR TITLE
Provide an error message that is more meaningful for global MG transfer operator.

### DIFF
--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -1438,13 +1438,21 @@ namespace internal
                   dof_handler_fine.get_triangulation().create_cell_iterator(
                     cell_id);
 
-                if (cell_fine->has_children() == false)
+                if (cell_fine->is_active())
                   {
                     if (cell_fine->subdomain_id() != cell->subdomain_id())
                       flag = false;
                   }
                 else
                   {
+                    Assert(
+                      cell_fine->child(0)->is_active(),
+                      ExcMessage(
+                        "In building a transfer operator, we are "
+                        "expecting that a cell is not or at most once refined "
+                        "on the other multigrid level. But it is refined more than once. "
+                        "Are you trying to build a transfer operator across "
+                        "more than one level of mesh refinement?"));
                     if (cell_fine->child(0)->subdomain_id() !=
                         cell->subdomain_id())
                       flag = false;


### PR DESCRIPTION
One of my students, @jerett-cc, was trying to use the new across-mesh interpolate function from #16734 to build a transfer operator across more than one mesh refinement. This failed with a non-informative message, see https://github.com/jerett-cc/ryujin/issues/30. This patch adds an assertion that ensures that we're not calling `cell->subdomain_id()` if the cell is not actually active, and give a useful error message for the case where the condition is violated.