### PR TITLE
Apply prmindent to PRM files

### DIFF
--- a/examples/step-28/project.prm
+++ b/examples/step-28/project.prm
@@ -1,14 +1,18 @@
 # Listing of Parameters
 # ---------------------
 # Polynomial degree of the finite element to be used
-set Finite element degree     = 2
+
+set Finite element degree = 2
 
 # The number of energy different groups considered
-set Number of energy groups   = 2
+
+set Number of energy groups = 2
 
 # Inner power iterations are stopped when the change in k_eff falls below this
 # tolerance
+
 set Power iteration tolerance = 1e-12
 
 # Number of refinement cycles to be performed
-set Refinement cycles         = 5
+
+set Refinement cycles = 5

--- a/examples/step-29/step-29.prm
+++ b/examples/step-29/step-29.prm
@@ -3,21 +3,19 @@
 
 subsection Mesh & geometry parameters
   # Distance of the focal point of the lens to the x-axis
-  set Focal distance        = 0.3
+  set Focal distance = 0.3
 
   # Number of global mesh refinement steps applied to initial coarse grid
   set Number of refinements = 5
 end
 
-
 subsection Physical constants
   # Wave speed
-  set c     = 1.5e5
+  set c = 1.5e5
 
   # Frequency
   set omega = 3.0e7
 end
-
 
 subsection Output parameters
   # Name of the output file (without extension)

--- a/examples/step-32/step-32.prm
+++ b/examples/step-32/step-32.prm
@@ -1,35 +1,40 @@
 # Listing of Parameters
 # ---------------------
 # The end time of the simulation in years.
-set End time                            = 1e8
+
+set End time = 1e8
 
 # Whether graphical output is to be generated or not. You may not want to get
 # graphical output if the number of processors is large.
-set Generate graphical output           = true
+
+set Generate graphical output = true
 
 # The number of adaptive refinement steps performed after initial global
 # refinement.
-set Initial adaptive refinement         = 2
+
+set Initial adaptive refinement = 2
 
 # The number of global refinement steps performed on the initial coarse mesh,
 # before the problem is first solved there.
-set Initial global refinement           = 5
+
+set Initial global refinement = 5
 
 # The number of time steps between each generation of graphical output files.
+
 set Time steps between graphical output = 50
 
 # The number of time steps after which the mesh is to be adapted based on
 # computed error indicators.
-set Time steps between mesh refinement  = 10
 
+set Time steps between mesh refinement = 10
 
 subsection Discretization
   # The polynomial degree to use for the velocity variables in the Stokes
   # system.
-  set Stokes velocity polynomial degree       = 2
+  set Stokes velocity polynomial degree = 2
 
   # The polynomial degree to use for the temperature variable.
-  set Temperature polynomial degree           = 2
+  set Temperature polynomial degree = 2
 
   # Whether to use a Stokes discretization that is locally conservative at the
   # expense of a larger number of degrees of freedom, or to go with a cheaper
@@ -38,15 +43,14 @@ subsection Discretization
   set Use locally conservative discretization = true
 end
 
-
 subsection Stabilization parameters
   # The exponent in the entropy viscosity stabilization.
   set alpha = 2
 
   # The beta factor in the artificial viscosity stabilization. An appropriate
   # value for 2d is 0.052 and 0.078 for 3d.
-  set beta  = 0.078
+  set beta = 0.078
 
   # The c_R factor in the entropy viscosity stabilization.
-  set c_R   = 0.5
+  set c_R = 0.5
 end

--- a/examples/step-33/input.prm
+++ b/examples/step-33/input.prm
@@ -1,16 +1,19 @@
 # Listing of Parameters
 # ---------------------
 
-# The input grid 
+# The input grid
+
 set mesh = slide.inp
 
 # Stabilization parameter
+
 set diffusion power = 2.0
 
 # --------------------------------------------------
 # Boundary conditions
 # We may specify boundary conditions for up to MAX_BD boundaries.
 # Your .inp file should have these boundaries designated.
+
 subsection boundary_1
   set no penetration = true # reflective boundary condition
 end
@@ -46,23 +49,25 @@ end
 
 # --------------------------------------------------
 # Time stepping control
+
 subsection time stepping
-  set final time = 10.0 # simulation end time
-  set time step  = 0.02 # simulation time step
+  set final time         = 10.0 # simulation end time
+  set time step          = 0.02 # simulation time step
   set theta scheme value = 0.5
 end
 
 subsection linear solver
-  set output         = quiet
-  set method         = gmres
-  set ilut fill      = 1.5
-  set ilut drop tolerance = 1e-6
+  set output                  = quiet
+  set method                  = gmres
+  set ilut fill               = 1.5
+  set ilut drop tolerance     = 1e-6
   set ilut absolute tolerance = 1e-6
   set ilut relative tolerance = 1.0
 end
 
 # --------------------------------------------------
 # Output frequency and kind
+
 subsection output
   set step           = 0.01
   set schlieren plot = true
@@ -70,15 +75,17 @@ end
 
 # --------------------------------------------------
 # Refinement control
+
 subsection refinement
-  set refinement = true # none only other option
-  set shock value = 1.5
+  set refinement   = true # none only other option
+  set shock value  = 1.5
   set shock levels = 1 # how many levels of refinement to allow
 end
 
 # --------------------------------------------------
 # Flux parameters
+
 subsection flux
- set stab = constant
- #set stab value = 1.0
+  set stab = constant
+  #set stab value = 1.0
 end

--- a/examples/step-34/parameters.prm
+++ b/examples/step-34/parameters.prm
@@ -1,29 +1,28 @@
 # Listing of Parameters
 # ---------------------
+
 set Extend solution on the -2,2 box = true
 set External refinement             = 5
 set Number of cycles                = 4
 set Run 2d simulation               = true
 set Run 3d simulation               = true
 
-
 subsection Exact solution 2d
   # Any constant used inside the function which is not a variable name.
-  set Function constants  = 
+  set Function constants = 
 
   # Separate vector valued expressions by ';' as ',' is used internally by the
   # function parser.
-  set Function expression = x+y   # default: 0
+  set Function expression = x+y # default: 0
 
   # The name of the variables as they will be used in the function, separated
   # by ','.
-  set Variable names      = x,y,t
+  set Variable names = x,y,t
 end
-
 
 subsection Exact solution 3d
   # Any constant used inside the function which is not a variable name.
-  set Function constants  = 
+  set Function constants = 
 
   # Separate vector valued expressions by ';' as ',' is used internally by the
   # function parser.
@@ -31,16 +30,14 @@ subsection Exact solution 3d
 
   # The name of the variables as they will be used in the function, separated
   # by ','.
-  set Variable names      = x,y,z,t
+  set Variable names = x,y,z,t
 end
-
 
 subsection Quadrature rules
   set Quadrature order          = 4
   set Quadrature type           = gauss
   set Singular quadrature order = 5
 end
-
 
 subsection Solver
   set Log frequency = 1
@@ -50,24 +47,22 @@ subsection Solver
   set Tolerance     = 1.e-10
 end
 
-
 subsection Wind function 2d
   # Any constant used inside the function which is not a variable name.
-  set Function constants  = 
+  set Function constants = 
 
   # Separate vector valued expressions by ';' as ',' is used internally by the
   # function parser.
-  set Function expression = 1; 1  # default: 0; 0
+  set Function expression = 1; 1 # default: 0; 0
 
   # The name of the variables as they will be used in the function, separated
   # by ','.
-  set Variable names      = x,y,t
+  set Variable names = x,y,t
 end
-
 
 subsection Wind function 3d
   # Any constant used inside the function which is not a variable name.
-  set Function constants  = 
+  set Function constants = 
 
   # Separate vector valued expressions by ';' as ',' is used internally by the
   # function parser.
@@ -75,5 +70,5 @@ subsection Wind function 3d
 
   # The name of the variables as they will be used in the function, separated
   # by ','.
-  set Variable names      = x,y,z,t
+  set Variable names = x,y,z,t
 end

--- a/examples/step-35/parameter-file.prm
+++ b/examples/step-35/parameter-file.prm
@@ -1,5 +1,6 @@
 # First a global definition
 # the type of method we want to use
+
 set Method_Form = rotational
 
 subsection Physical data
@@ -20,23 +21,25 @@ subsection Space discretization
   # In this subsection we declare the data that is relevant to the space discretization
   # we set the number of global refines the triangulation must have
   # and the degree k of the pair Q_(k+1)--Q_k of velocity--pressure finite element spaces
-  set n_of_refines = 3
+  set n_of_refines       = 3
   set pressure_fe_degree = 1
 end
 
 subsection Data solve velocity
   # In this section we declare the parameters that are going to control the solution process
   # for the velocity.
-  set max_iterations = 1000  # maximal number of iterations that GMRES must make
-  set eps            = 1e-8  # stopping criterion
-  set Krylov_size    = 30    # size of the Krylov subspace to be used in GMRES
-  set off_diagonals  = 70    # number of off diagonals that ILU must compute
+  set max_iterations = 1000 # maximal number of iterations that GMRES must make
+  set eps            = 1e-8 # stopping criterion
+  set Krylov_size    = 30   # size of the Krylov subspace to be used in GMRES
+  set off_diagonals  = 70   # number of off diagonals that ILU must compute
   set diag_strength  = 0.1  # diagonal strengthening value
-  set update_prec    = 10    # this number indicates how often the preconditioner must be updated
+  set update_prec    = 10   # this number indicates how often the preconditioner must be updated
 end
 
 #The output frequency
+
 set output_interval = 50
 
 #Finally we set the verbosity level
+
 set verbose = false

--- a/examples/step-36/step-36.prm
+++ b/examples/step-36/step-36.prm
@@ -2,10 +2,13 @@
 # ---------------------
 # The number of times the 1-cell coarse mesh should be refined globally for
 # our computations.
-set Global mesh refinement steps         = 5
+
+set Global mesh refinement steps = 5
 
 # The number of eigenvalues/eigenfunctions to be computed.
+
 set Number of eigenvalues/eigenfunctions = 5
 
 # A functional description of the potential.
-set Potential                            = 0
+
+set Potential = 0

--- a/examples/step-42/p2_adaptive.prm
+++ b/examples/step-42/p2_adaptive.prm
@@ -2,24 +2,30 @@
 # ---------------------
 
 # polynomial degree of the FE_Q finite element space, typically 1 or 2
-set polynomial degree             = 2
+
+set polynomial degree = 2
 
 # number of initial global refinements before the first computation
+
 set number of initial refinements = 2
 
 # number of adaptive cycles to run
-set number of cycles              = 11
+
+set number of cycles = 11
 
 # refinement strategy for each cycle:
 # global: one global refinement
 # percentage: fixed percentage gets refined using kelly
 # fix dofs: tries to achieve 2^initial_refinement*300 dofs after cycle 1 (only
 # use 2 cycles!). Changes the coarse mesh!
-set refinement strategy           = percentage
+
+set refinement strategy = percentage
 
 # obstacle file to read, leave empty to use a sphere or 'obstacle_file.pbm'
-set obstacle filename             = 
+
+set obstacle filename = 
 
 # directory to put output files (graphical output and benchmark statistics,
 # leave empty to put into current directory
-set output directory              = p2adaptive
+
+set output directory = p2adaptive

--- a/examples/step-44/parameters.prm
+++ b/examples/step-44/parameters.prm
@@ -1,25 +1,24 @@
 # Listing of Parameters
 # ---------------------
+
 subsection Finite element system
   # Displacement system polynomial order
   set Polynomial degree = 2
 
   # Gauss quadrature order
-  set Quadrature order  = 3
+  set Quadrature order = 3
 end
-
 
 subsection Geometry
   # Global refinement level
-  set Global refinement   = 2
+  set Global refinement = 2
 
   # Global grid scaling factor
-  set Grid scale          = 1e-3
+  set Grid scale = 1e-3
 
   # Ratio of applied pressure to reference pressure
   set Pressure ratio p/p0 = 100
 end
-
 
 subsection Linear solver
   # Linear solver iterations (multiples of the system matrix size)
@@ -27,48 +26,45 @@ subsection Linear solver
   set Max iteration multiplier = 2
 
   # Linear solver residual (scaled by residual norm)
-  set Residual                 = 1e-6
-  
+  set Residual = 1e-6
+
   # Use static condensation and solve a 1-block system, or solve
   # the full 3-block system using Linear Operators and the Schur
   # complement
   set Use static condensation = false
 
   # Preconditioner type
-  set Preconditioner type  = ssor
+  set Preconditioner type = ssor
 
   # Preconditioner relaxation value
-  set Preconditioner relaxation  = 0.65
+  set Preconditioner relaxation = 0.65
 
   # Type of solver used to solve the linear system
-  set Solver type              = CG
+  set Solver type = CG
 end
-
 
 subsection Material properties
   # Poisson's ratio
   set Poisson's ratio = 0.4999
 
   # Shear modulus
-  set Shear modulus   = 80.194e6
+  set Shear modulus = 80.194e6
 end
-
 
 subsection Nonlinear solver
   # Number of Newton-Raphson iterations allowed
   set Max iterations Newton-Raphson = 10
 
   # Displacement error tolerance
-  set Tolerance displacement        = 1.0e-6
+  set Tolerance displacement = 1.0e-6
 
   # Force residual tolerance
-  set Tolerance force               = 1.0e-9
+  set Tolerance force = 1.0e-9
 end
-
 
 subsection Time
   # End time
-  set End time       = 1
+  set End time = 1
 
   # Time step size
   set Time step size = 0.1

--- a/examples/step-50/amg_2d.prm
+++ b/examples/step-50/amg_2d.prm
@@ -1,19 +1,25 @@
 # Listing of Parameters
 # ---------------------
 # The problem dimension.
-set dim             = 2
+
+set dim = 2
 
 # Number of adaptive refinement steps.
-set n_steps         = 16
+
+set n_steps = 16
 
 # Output graphical results.
-set output          = true
+
+set output = true
 
 # Dampen factor for the smoother.
+
 set smoother dampen = 1.0
 
 # Number of smoother steps.
-set smoother steps  = 1
+
+set smoother steps = 1
 
 # Switch between GMG and AMG.
-set solver          = AMG
+
+set solver = AMG

--- a/examples/step-50/amg_3d.prm
+++ b/examples/step-50/amg_3d.prm
@@ -1,19 +1,25 @@
 # Listing of Parameters
 # ---------------------
 # The problem dimension.
-set dim             = 3
+
+set dim = 3
 
 # Number of adaptive refinement steps.
-set n_steps         = 12
+
+set n_steps = 12
 
 # Output graphical results.
-set output          = true
+
+set output = true
 
 # Dampen factor for the smoother.
+
 set smoother dampen = 1.0
 
 # Number of smoother steps.
-set smoother steps  = 1
+
+set smoother steps = 1
 
 # Switch between GMG and AMG.
-set solver          = AMG
+
+set solver = AMG

--- a/examples/step-50/gmg_mb_2d.prm
+++ b/examples/step-50/gmg_mb_2d.prm
@@ -1,19 +1,25 @@
 # Listing of Parameters
 # ---------------------
 # The problem dimension.
-set dim             = 2
+
+set dim = 2
 
 # Number of adaptive refinement steps.
-set n_steps         = 16
+
+set n_steps = 16
 
 # Output graphical results.
-set output          = true
+
+set output = true
 
 # Dampen factor for the smoother.
+
 set smoother dampen = 1.0
 
 # Number of smoother steps.
-set smoother steps  = 1
+
+set smoother steps = 1
 
 # Switch between GMG and AMG.
-set solver          = MB
+
+set solver = MB

--- a/examples/step-50/gmg_mb_3d.prm
+++ b/examples/step-50/gmg_mb_3d.prm
@@ -1,19 +1,25 @@
 # Listing of Parameters
 # ---------------------
 # The problem dimension.
-set dim             = 3
+
+set dim = 3
 
 # Number of adaptive refinement steps.
-set n_steps         = 12
+
+set n_steps = 12
 
 # Output graphical results.
-set output          = true
+
+set output = true
 
 # Dampen factor for the smoother.
+
 set smoother dampen = 1.0
 
 # Number of smoother steps.
-set smoother steps  = 1
+
+set smoother steps = 1
 
 # Switch between GMG and AMG.
-set solver          = MB
+
+set solver = MB

--- a/examples/step-50/gmg_mf_2d.prm
+++ b/examples/step-50/gmg_mf_2d.prm
@@ -1,19 +1,25 @@
 # Listing of Parameters
 # ---------------------
 # The problem dimension.
-set dim             = 2
+
+set dim = 2
 
 # Number of adaptive refinement steps.
-set n_steps         = 16
+
+set n_steps = 16
 
 # Output graphical results.
-set output          = true
+
+set output = true
 
 # Dampen factor for the smoother.
+
 set smoother dampen = 1.0
 
 # Number of smoother steps.
-set smoother steps  = 1
+
+set smoother steps = 1
 
 # Switch between GMG and AMG.
-set solver          = MF
+
+set solver = MF

--- a/examples/step-50/gmg_mf_3d.prm
+++ b/examples/step-50/gmg_mf_3d.prm
@@ -1,19 +1,25 @@
 # Listing of Parameters
 # ---------------------
 # The problem dimension.
-set dim             = 3
+
+set dim = 3
 
 # Number of adaptive refinement steps.
-set n_steps         = 12
+
+set n_steps = 12
 
 # Output graphical results.
-set output          = true
+
+set output = true
 
 # Dampen factor for the smoother.
+
 set smoother dampen = 1.0
 
 # Number of smoother steps.
-set smoother steps  = 1
+
+set smoother steps = 1
 
 # Switch between GMG and AMG.
-set solver          = MF
+
+set solver = MF

--- a/examples/step-63/block_jacobi.prm
+++ b/examples/step-63/block_jacobi.prm
@@ -1,20 +1,27 @@
 # Diffusion parameter
-set Epsilon                   = 0.005
+
+set Epsilon = 0.005
 
 # Finite Element degree
-set Fe degree                 = 1
+
+set Fe degree = 1
 
 # Select smoother: SOR|Jacobi|block SOR|block Jacobi
-set Smoother type             = block Jacobi
+
+set Smoother type = block Jacobi
 
 # Select DoF renumbering: none|downstream|upstream|random
-set DoF renumbering           = downstream
+
+set DoF renumbering = downstream
 
 # Number of smoothing steps
-set Smoothing steps           = 3
+
+set Smoothing steps = 3
 
 # Enable streamline diffusion stabilization: true|false
+
 set With streamline diffusion = true
 
 # Generate graphical output: true|false
-set Output                    = true
+
+set Output = true

--- a/examples/step-63/block_sor.prm
+++ b/examples/step-63/block_sor.prm
@@ -1,20 +1,27 @@
 # Diffusion parameter
-set Epsilon                   = 0.005
+
+set Epsilon = 0.005
 
 # Finite Element degree
-set Fe degree                 = 1
+
+set Fe degree = 1
 
 # Select smoother: SOR|Jacobi|block SOR|block Jacobi
-set Smoother type             = block SOR
+
+set Smoother type = block SOR
 
 # Select DoF renumbering: none|downstream|upstream|random
-set DoF renumbering           = downstream
+
+set DoF renumbering = downstream
 
 # Number of smoothing steps
-set Smoothing steps           = 1
+
+set Smoothing steps = 1
 
 # Enable streamline diffusion stabilization: true|false
+
 set With streamline diffusion = true
 
 # Generate graphical output: true|false
-set Output                    = true
+
+set Output = true

--- a/examples/step-63/jacobi.prm
+++ b/examples/step-63/jacobi.prm
@@ -1,20 +1,27 @@
 # Diffusion parameter
-set Epsilon                   = 0.005
+
+set Epsilon = 0.005
 
 # Finite Element degree
-set Fe degree                 = 1
+
+set Fe degree = 1
 
 # Select smoother: SOR|Jacobi|block SOR|block Jacobi
-set Smoother type             = Jacobi
+
+set Smoother type = Jacobi
 
 # Select DoF renumbering: none|downstream|upstream|random
-set DoF renumbering           = downstream
+
+set DoF renumbering = downstream
 
 # Number of smoothing steps
-set Smoothing steps           = 6
+
+set Smoothing steps = 6
 
 # Enable streamline diffusion stabilization: true|false
+
 set With streamline diffusion = true
 
 # Generate graphical output: true|false
-set Output                    = true
+
+set Output = true

--- a/examples/step-63/sor.prm
+++ b/examples/step-63/sor.prm
@@ -1,20 +1,27 @@
 # Diffusion parameter
-set Epsilon                   = 0.005
+
+set Epsilon = 0.005
 
 # Finite Element degree
-set Fe degree                 = 1
+
+set Fe degree = 1
 
 # Select smoother: SOR|Jacobi|block SOR|block Jacobi
-set Smoother type             = SOR
+
+set Smoother type = SOR
 
 # Select DoF renumbering: none|downstream|upstream|random
-set DoF renumbering           = downstream
+
+set DoF renumbering = downstream
 
 # Number of smoothing steps
-set Smoothing steps           = 3
+
+set Smoothing steps = 3
 
 # Enable streamline diffusion stabilization: true|false
+
 set With streamline diffusion = true
 
 # Generate graphical output: true|false
-set Output                    = true
+
+set Output = true

--- a/examples/step-68/parameters.prm
+++ b/examples/step-68/parameters.prm
@@ -1,21 +1,22 @@
 # Listing of Parameters
 # ---------------------
+
 subsection Particle Tracking Problem
   # End time of the simulation
-  set Final time                    = 4
+  set Final time = 4
 
   # Refinement level of the fluid domain
-  set Fluid refinement              = 4
-  set Output directory              = ./
+  set Fluid refinement = 4
+  set Output directory = ./
 
   # Iteration frequency at which output results are written
-  set Output interval               = 10
+  set Output interval = 10
 
   # Refinement of the volumetric mesh used to insert the particles
   set Particle insertion refinement = 3
 
   # Iteration frequency at which the mesh is load balanced
-  set Repartition interval          = 5
-  set Time step                     = 0.002
-  set Velocity degree               = 1
+  set Repartition interval = 5
+  set Time step            = 0.002
+  set Velocity degree      = 1
 end

--- a/examples/step-69/step-69.prm
+++ b/examples/step-69/step-69.prm
@@ -1,29 +1,29 @@
 # Listing of Parameters
 # ---------------------
+
 subsection A - MainLoop
   # Write out solution in a background thread performing IO
   set asynchronous writeback = true
 
   # Base name for all output files
-  set basename               = test
+  set basename = test
 
   # Final time
-  set final time             = 4
+  set final time = 4
 
   # Time interval for output
-  set output granularity     = 0.02
+  set output granularity = 0.02
 
   # Resume an interrupted computation.
-  set resume                 = false
+  set resume = false
 end
-
 
 subsection B - Discretization
   # Height of computational domain
-  set height          = 2
+  set height = 2
 
   # Length of computational domain
-  set length          = 4
+  set length = 4
 
   # Diameter of immersed disk
   set object diameter = 0.5
@@ -32,32 +32,28 @@ subsection B - Discretization
   set object position = 0.6
 
   # Number of refinement steps of the geometry
-  set refinement      = 5
+  set refinement = 5
 end
-
 
 subsection C - OfflineData
 end
 
-
 subsection D - InitialValues
   # Initial 1d state (rho, u, p) of the uniform flow field
-  set initial 1d state  = 1.4, 3, 1
+  set initial 1d state = 1.4, 3, 1
 
   # Initial direction of the uniform flow field
   set initial direction = 1, 0
 end
-
 
 subsection E - TimeStepping
   # Relative CFL constant used for update
   set cfl update = 0.8
 end
 
-
 subsection F - SchlierenPostprocessor
   # Beta factor used in Schlieren-type postprocessor
-  set schlieren beta  = 10
+  set schlieren beta = 10
 
   # Use the corresponding component of the state vector for the schlieren
   # plot

--- a/examples/step-70/parameters.prm
+++ b/examples/step-70/parameters.prm
@@ -1,5 +1,6 @@
 # This is a parameter file that can be used to reproduce the two dimensional
 # results of the tutorial program step-70.
+
 subsection Stokes Immersed Problem
   set Final time                         = 1
   set Homogeneous Dirichlet boundary ids = 0
@@ -24,7 +25,7 @@ subsection Stokes Immersed Problem
     set Solid grid generator              = hyper_rectangle
     set Solid grid generator arguments    = -.5, -.1: .5, .1: false
   end
-  
+
   subsection Refinement and remeshing
     set Maximum number of cells        = 20000
     set Refinement coarsening fraction = 0.3
@@ -34,7 +35,6 @@ subsection Stokes Immersed Problem
     set Refinement step frequency      = 5
     set Refinement strategy            = fixed_fraction
   end
-
 
   subsection Right hand side
     set Function constants  = 

--- a/examples/step-70/parameters_23.prm
+++ b/examples/step-70/parameters_23.prm
@@ -2,11 +2,12 @@
 # results of the tutorial program step-70. The name of the parameter file
 # indicates that the program will expect to work with a fluid grid in three
 # dimensions, and a solid grid representing a surface embedded in three
-# dimensions. 
+# dimensions.
 #
 # With this parameter file, we generate a hyper rectangular grid slightly
 # larger w.r.t. to a impeller grid that was generated from the CAD files
 # downloaded from https://grabcad.com/library/lungstors-blower-1
+
 subsection Stokes Immersed Problem
   set Final time                            = 1
   set Homogeneous Dirichlet boundary ids    = 0
@@ -26,10 +27,10 @@ subsection Stokes Immersed Problem
     set Variable names      = x,y,z,t
   end
   subsection Grid generation
-    set Fluid grid generator                = hyper_rectangle
-    set Fluid grid generator arguments      = -50,-50, -10: 50, 50, 40: false
-    set Solid grid generator                = impeller.vtk
-    set Solid grid generator arguments      = 
+    set Fluid grid generator              = hyper_rectangle
+    set Fluid grid generator arguments    = -50,-50, -10: 50, 50, 40: false
+    set Solid grid generator              = impeller.vtk
+    set Solid grid generator arguments    = 
     set Particle grid generator           = hyper_ball
     set Particle grid generator arguments = 30, 30, 20: 10: false
   end

--- a/examples/step-72/parameters.prm
+++ b/examples/step-72/parameters.prm
@@ -1,17 +1,16 @@
 # Listing of Parameters
 # ---------------------
+
 subsection Minimal Surface Problem
   # Selection for the formulation and corresponding AD framework to be used.
   #   formulation = 0 : Unassisted implementation (full hand linearization)
   #   formulation = 1 : Automated linearization of the finite element
-  #                     residual 
+  #                     residual
   #   formulation = 2 : Automated computation of finite element
-  #                     residual and linearization using a 
+  #                     residual and linearization using a
   #                     variational formulation
   set Formulation = 0
 
   # The maximum acceptable tolerance for the linear system residual
-  set Tolerance   = 0.01
+  set Tolerance = 0.01
 end
-
-

--- a/examples/step-81/parameters.prm
+++ b/examples/step-81/parameters.prm
@@ -1,52 +1,51 @@
 # Listing of Parameters
 # ---------------------
+
 subsection Maxwell
   # use absorbing boundary conditions?
   set absorbing boundary condition = true
 
   # order of the finite element space
-  set fe order                     = 0
+  set fe order = 0
 
   # order of the quadrature
-  set quadrature order             = 1
+  set quadrature order = 1
 
   # number of refinements of the geometry
-  set refinements                  = 8
+  set refinements = 8
 
   # scale of the hypercube geometry
-  set scaling                      = 20
+  set scaling = 20
 end
-
 
 subsection Parameters
   # orientation of the dipole
   set dipole orientation = 0, 1
 
   # position of the dipole
-  set dipole position    = 0, 0.8
+  set dipole position = 0, 0.8
 
   # radius of the dipole
-  set dipole radius      = 0.3
+  set dipole radius = 0.3
 
   # strength of the dipole
-  set dipole strength    = 1, 0
+  set dipole strength = 1, 0
 
   # relative permittivity of material 1
   set material 1 epsilon = 1, 0; 0, 0| 0, 0; 1, 0
 
   # inverse of relative permeability of material 1
-  set material 1 mu_inv  = 1, 0
+  set material 1 mu_inv = 1, 0
 
   # relative permittivity of material 2
   set material 2 epsilon = 1, 0; 0, 0| 0, 0; 1, 0
 
   # inverse of relative permeability of material 2
-  set material 2 mu_inv  = 1, 0
+  set material 2 mu_inv = 1, 0
 
   # surface conductivity between material 1 and material 2
-  set sigma              = 0.001, 0.2; 0, 0| 0, 0; 0.001, 0.2
+  set sigma = 0.001, 0.2; 0, 0| 0, 0; 0.001, 0.2
 end
-
 
 subsection PerfectlyMatchedLayer
   # inner radius of the PML shell
@@ -56,7 +55,5 @@ subsection PerfectlyMatchedLayer
   set outer radius = 20
 
   # strength of the PML
-  set strength     = 8
+  set strength = 8
 end
-
-

--- a/tests/adolc/prm/parameters-step-44.prm
+++ b/tests/adolc/prm/parameters-step-44.prm
@@ -1,29 +1,28 @@
 # Listing of Parameters
 # ---------------------
+
 subsection Finite element system
   # Displacement system polynomial order
   set Polynomial degree = 1
 
   # Gauss quadrature order
-  set Quadrature order  = 2
+  set Quadrature order = 2
 end
-
 
 subsection Geometry
   # Global refinement level
-  set Global refinement   = 1
+  set Global refinement = 1
 
   # Global grid scaling factor
-  set Grid scale          = 1e-3
+  set Grid scale = 1e-3
 
   # Ratio of applied pressure to reference pressure
   set Pressure ratio p/p0 = 100
 end
 
-
 subsection Linear solver
   # Linear solver residual (scaled by residual norm)
-  set Residual                 = 1e-6
+  set Residual = 1e-6
 
   # Use static condensation and solve a 1-block system, or solve
   # the full 3-block system using Linear Operators and the Schur
@@ -31,40 +30,37 @@ subsection Linear solver
   set Use static condensation = true
 
   # Preconditioner type
-  set Preconditioner type  = ssor
+  set Preconditioner type = ssor
 
   # Preconditioner relaxation value
-  set Preconditioner relaxation  = 0.65
+  set Preconditioner relaxation = 0.65
 
   # Type of solver used to solve the linear system
-  set Solver type              = CG
+  set Solver type = CG
 end
-
 
 subsection Material properties
   # Poisson's ratio
   set Poisson's ratio = 0.4999
 
   # Shear modulus
-  set Shear modulus   = 80.194e6
+  set Shear modulus = 80.194e6
 end
-
 
 subsection Nonlinear solver
   # Number of Newton-Raphson iterations allowed
   set Max iterations Newton-Raphson = 10
 
   # Displacement error tolerance
-  set Tolerance displacement        = 1.0e-6
+  set Tolerance displacement = 1.0e-6
 
   # Force residual tolerance
-  set Tolerance force               = 1.0e-9
+  set Tolerance force = 1.0e-9
 end
-
 
 subsection Time
   # End time
-  set End time       = 1
+  set End time = 1
 
   # Time step size
   set Time step size = 0.1

--- a/tests/non_matching/step-70.in.prm
+++ b/tests/non_matching/step-70.in.prm
@@ -1,5 +1,6 @@
 # This is a parameter file that can be used to reproduce the two dimensional
 # results of the tutorial program step-70.
+
 subsection Stokes Immersed Problem
   set Final time                         = 0.01
   set Homogeneous Dirichlet boundary ids = 0
@@ -24,7 +25,7 @@ subsection Stokes Immersed Problem
     set Solid grid generator              = hyper_rectangle
     set Solid grid generator arguments    = -.5, -.1: .5, .1: false
   end
-  
+
   subsection Refinement and remeshing
     set Maximum number of cells        = 20000
     set Refinement coarsening fraction = 0.3
@@ -34,7 +35,6 @@ subsection Stokes Immersed Problem
     set Refinement step frequency      = 5
     set Refinement strategy            = fixed_fraction
   end
-
 
   subsection Right hand side
     set Function constants  = 

--- a/tests/optimization/prm/parameters-step-44-with_linesearch.prm
+++ b/tests/optimization/prm/parameters-step-44-with_linesearch.prm
@@ -1,25 +1,24 @@
 # Listing of Parameters
 # ---------------------
+
 subsection Finite element system
   # Displacement system polynomial order
   set Polynomial degree = 1
 
   # Gauss quadrature order
-  set Quadrature order  = 2
+  set Quadrature order = 2
 end
-
 
 subsection Geometry
   # Global refinement level
-  set Global refinement   = 2
+  set Global refinement = 2
 
   # Global grid scaling factor
-  set Grid scale          = 1e-3
+  set Grid scale = 1e-3
 
   # Ratio of applied pressure to reference pressure
   set Pressure ratio p/p0 = 100
 end
-
 
 subsection Linear solver
   # Linear solver iterations (multiples of the system matrix size)
@@ -27,7 +26,7 @@ subsection Linear solver
   set Max iteration multiplier = 2
 
   # Linear solver residual (scaled by residual norm)
-  set Residual                 = 1e-6
+  set Residual = 1e-6
 
   # Use static condensation and solve a 1-block system, or solve
   # the full 3-block system using Linear Operators and the Schur
@@ -35,46 +34,43 @@ subsection Linear solver
   set Use static condensation = true
 
   # Preconditioner type
-  set Preconditioner type  = ssor
+  set Preconditioner type = ssor
 
   # Preconditioner relaxation value
-  set Preconditioner relaxation  = 0.65
+  set Preconditioner relaxation = 0.65
 
   # Type of solver used to solve the linear system
-  set Solver type              = CG
+  set Solver type = CG
 end
-
 
 subsection Material properties
   # Poisson's ratio
   set Poisson's ratio = 0.4999
 
   # Shear modulus
-  set Shear modulus   = 80.194e6
+  set Shear modulus = 80.194e6
 end
-
 
 subsection Nonlinear solver
   # Number of Newton-Raphson iterations allowed
-  set Max iterations Newton-Raphson        = 10
+  set Max iterations Newton-Raphson = 10
 
   # Displacement error tolerance
-  set Tolerance displacement               = 1.0e-6
+  set Tolerance displacement = 1.0e-6
 
   # Force residual tolerance
-  set Tolerance force                      = 1.0e-9
-  
+  set Tolerance force = 1.0e-9
+
   # Use line-search minimization algorithm
-  set Use line search                      = true
-  
+  set Use line search = true
+
   # Use an approximation for the gradient during line search
   set Use line search approximate gradient = false
 end
 
-
 subsection Time
   # End time
-  set End time       = 1
+  set End time = 1
 
   # Time step size
   set Time step size = 0.5

--- a/tests/optimization/prm/parameters-step-44-with_linesearch_ptrb.prm
+++ b/tests/optimization/prm/parameters-step-44-with_linesearch_ptrb.prm
@@ -1,25 +1,24 @@
 # Listing of Parameters
 # ---------------------
+
 subsection Finite element system
   # Displacement system polynomial order
   set Polynomial degree = 1
 
   # Gauss quadrature order
-  set Quadrature order  = 2
+  set Quadrature order = 2
 end
-
 
 subsection Geometry
   # Global refinement level
-  set Global refinement   = 2
+  set Global refinement = 2
 
   # Global grid scaling factor
-  set Grid scale          = 1e-3
+  set Grid scale = 1e-3
 
   # Ratio of applied pressure to reference pressure
   set Pressure ratio p/p0 = 100
 end
-
 
 subsection Linear solver
   # Linear solver iterations (multiples of the system matrix size)
@@ -27,7 +26,7 @@ subsection Linear solver
   set Max iteration multiplier = 2
 
   # Linear solver residual (scaled by residual norm)
-  set Residual                 = 1e-6
+  set Residual = 1e-6
 
   # Use static condensation and solve a 1-block system, or solve
   # the full 3-block system using Linear Operators and the Schur
@@ -35,46 +34,43 @@ subsection Linear solver
   set Use static condensation = true
 
   # Preconditioner type
-  set Preconditioner type  = ssor
+  set Preconditioner type = ssor
 
   # Preconditioner relaxation value
-  set Preconditioner relaxation  = 0.65
+  set Preconditioner relaxation = 0.65
 
   # Type of solver used to solve the linear system
-  set Solver type              = CG
+  set Solver type = CG
 end
-
 
 subsection Material properties
   # Poisson's ratio
   set Poisson's ratio = 0.4999
 
   # Shear modulus
-  set Shear modulus   = 80.194e6
+  set Shear modulus = 80.194e6
 end
-
 
 subsection Nonlinear solver
   # Number of Newton-Raphson iterations allowed
-  set Max iterations Newton-Raphson        = 10
+  set Max iterations Newton-Raphson = 10
 
   # Displacement error tolerance
-  set Tolerance displacement               = 1.0e-6
+  set Tolerance displacement = 1.0e-6
 
   # Force residual tolerance
-  set Tolerance force                      = 1.0e-9
-  
+  set Tolerance force = 1.0e-9
+
   # Use line-search minimization algorithm
-  set Use line search                      = true
-  
+  set Use line search = true
+
   # Use an approximation for the gradient during line search
   set Use line search approximate gradient = true
 end
 
-
 subsection Time
   # End time
-  set End time       = 1
+  set End time = 1
 
   # Time step size
   set Time step size = 0.5

--- a/tests/optimization/prm/parameters-step-44-without_linesearch.prm
+++ b/tests/optimization/prm/parameters-step-44-without_linesearch.prm
@@ -1,25 +1,24 @@
 # Listing of Parameters
 # ---------------------
+
 subsection Finite element system
   # Displacement system polynomial order
   set Polynomial degree = 1
 
   # Gauss quadrature order
-  set Quadrature order  = 2
+  set Quadrature order = 2
 end
-
 
 subsection Geometry
   # Global refinement level
-  set Global refinement   = 2
+  set Global refinement = 2
 
   # Global grid scaling factor
-  set Grid scale          = 1e-3
+  set Grid scale = 1e-3
 
   # Ratio of applied pressure to reference pressure
   set Pressure ratio p/p0 = 100
 end
-
 
 subsection Linear solver
   # Linear solver iterations (multiples of the system matrix size)
@@ -27,7 +26,7 @@ subsection Linear solver
   set Max iteration multiplier = 2
 
   # Linear solver residual (scaled by residual norm)
-  set Residual                 = 1e-6
+  set Residual = 1e-6
 
   # Use static condensation and solve a 1-block system, or solve
   # the full 3-block system using Linear Operators and the Schur
@@ -35,46 +34,43 @@ subsection Linear solver
   set Use static condensation = true
 
   # Preconditioner type
-  set Preconditioner type  = ssor
+  set Preconditioner type = ssor
 
   # Preconditioner relaxation value
-  set Preconditioner relaxation  = 0.65
+  set Preconditioner relaxation = 0.65
 
   # Type of solver used to solve the linear system
-  set Solver type              = CG
+  set Solver type = CG
 end
-
 
 subsection Material properties
   # Poisson's ratio
   set Poisson's ratio = 0.4999
 
   # Shear modulus
-  set Shear modulus   = 80.194e6
+  set Shear modulus = 80.194e6
 end
-
 
 subsection Nonlinear solver
   # Number of Newton-Raphson iterations allowed
   set Max iterations Newton-Raphson = 10
 
   # Displacement error tolerance
-  set Tolerance displacement        = 1.0e-6
+  set Tolerance displacement = 1.0e-6
 
   # Force residual tolerance
-  set Tolerance force               = 1.0e-9
-  
+  set Tolerance force = 1.0e-9
+
   # Use line-search minimization algorithm
-  set Use line search               = false
-  
+  set Use line search = false
+
   # Use an approximation for the gradient during line search
   set Use line search approximate gradient = false
 end
 
-
 subsection Time
   # End time
-  set End time       = 1
+  set End time = 1
 
   # Time step size
   set Time step size = 0.5

--- a/tests/petsc/petsc_snes_00_in.prm
+++ b/tests/petsc/petsc_snes_00_in.prm
@@ -1,8 +1,8 @@
 subsection Running parameters
-  set solver type       = newtonls
-  set absolute error tolerance = 1.e-9
-  set relative error tolerance = 2.e-9
-  set step tolerance = 3.e-9
-  set maximum iterations = 23
+  set solver type                  = newtonls
+  set absolute error tolerance     = 1.e-9
+  set relative error tolerance     = 2.e-9
+  set step tolerance               = 3.e-9
+  set maximum iterations           = 23
   set maximum function evaluations = 77
 end

--- a/tests/petsc/petsc_ts_00_in.prm
+++ b/tests/petsc/petsc_ts_00_in.prm
@@ -1,9 +1,10 @@
 subsection Running parameters
   set initial time      = 1.0
   set final time        = 6.0
-  set solver type       = bdf 
+  set solver type       = bdf
   set initial step size = 0.0625
 end
+
 subsection Error control
   set minimum step size = 1e-7
   set maximum step size = 1e+7

--- a/tests/petsc/petsc_ts_03_in.prm
+++ b/tests/petsc/petsc_ts_03_in.prm
@@ -1,11 +1,12 @@
 subsection Running parameters
   set initial time      = 0
   set final time        = 2.0
-  set solver type       = bdf 
+  set solver type       = bdf
   set initial step size = 0.2
 end
+
 subsection Error control
   set absolute error tolerance = 0.0001
-  set minimum step size = 1e-7
-  set maximum step size = 1e+7
+  set minimum step size        = 1e-7
+  set maximum step size        = 1e+7
 end

--- a/tests/physics/prm/parameters-step-44.prm
+++ b/tests/physics/prm/parameters-step-44.prm
@@ -1,25 +1,24 @@
 # Listing of Parameters
 # ---------------------
+
 subsection Finite element system
   # Displacement system polynomial order
   set Polynomial degree = 1
 
   # Gauss quadrature order
-  set Quadrature order  = 2
+  set Quadrature order = 2
 end
-
 
 subsection Geometry
   # Global refinement level
-  set Global refinement   = 2
+  set Global refinement = 2
 
   # Global grid scaling factor
-  set Grid scale          = 1e-3
+  set Grid scale = 1e-3
 
   # Ratio of applied pressure to reference pressure
   set Pressure ratio p/p0 = 100
 end
-
 
 subsection Linear solver
   # Linear solver iterations (multiples of the system matrix size)
@@ -27,7 +26,7 @@ subsection Linear solver
   set Max iteration multiplier = 2
 
   # Linear solver residual (scaled by residual norm)
-  set Residual                 = 1e-6
+  set Residual = 1e-6
 
   # Use static condensation and solve a 1-block system, or solve
   # the full 3-block system using Linear Operators and the Schur
@@ -35,40 +34,37 @@ subsection Linear solver
   set Use static condensation = true
 
   # Preconditioner type
-  set Preconditioner type  = ssor
+  set Preconditioner type = ssor
 
   # Preconditioner relaxation value
-  set Preconditioner relaxation  = 0.65
+  set Preconditioner relaxation = 0.65
 
   # Type of solver used to solve the linear system
-  set Solver type              = CG
+  set Solver type = CG
 end
-
 
 subsection Material properties
   # Poisson's ratio
   set Poisson's ratio = 0.4999
 
   # Shear modulus
-  set Shear modulus   = 80.194e6
+  set Shear modulus = 80.194e6
 end
-
 
 subsection Nonlinear solver
   # Number of Newton-Raphson iterations allowed
   set Max iterations Newton-Raphson = 10
 
   # Displacement error tolerance
-  set Tolerance displacement        = 1.0e-6
+  set Tolerance displacement = 1.0e-6
 
   # Force residual tolerance
-  set Tolerance force               = 1.0e-9
+  set Tolerance force = 1.0e-9
 end
-
 
 subsection Time
   # End time
-  set End time       = 1
+  set End time = 1
 
   # Time step size
   set Time step size = 0.1

--- a/tests/sacado/prm/parameters-step-44.prm
+++ b/tests/sacado/prm/parameters-step-44.prm
@@ -1,29 +1,28 @@
 # Listing of Parameters
 # ---------------------
+
 subsection Finite element system
   # Displacement system polynomial order
   set Polynomial degree = 1
 
   # Gauss quadrature order
-  set Quadrature order  = 2
+  set Quadrature order = 2
 end
-
 
 subsection Geometry
   # Global refinement level
-  set Global refinement   = 1
+  set Global refinement = 1
 
   # Global grid scaling factor
-  set Grid scale          = 1e-3
+  set Grid scale = 1e-3
 
   # Ratio of applied pressure to reference pressure
   set Pressure ratio p/p0 = 100
 end
 
-
 subsection Linear solver
   # Linear solver residual (scaled by residual norm)
-  set Residual                 = 1e-6
+  set Residual = 1e-6
 
   # Use static condensation and solve a 1-block system, or solve
   # the full 3-block system using Linear Operators and the Schur
@@ -31,40 +30,37 @@ subsection Linear solver
   set Use static condensation = true
 
   # Preconditioner type
-  set Preconditioner type  = ssor
+  set Preconditioner type = ssor
 
   # Preconditioner relaxation value
-  set Preconditioner relaxation  = 0.65
+  set Preconditioner relaxation = 0.65
 
   # Type of solver used to solve the linear system
-  set Solver type              = CG
+  set Solver type = CG
 end
-
 
 subsection Material properties
   # Poisson's ratio
   set Poisson's ratio = 0.4999
 
   # Shear modulus
-  set Shear modulus   = 80.194e6
+  set Shear modulus = 80.194e6
 end
-
 
 subsection Nonlinear solver
   # Number of Newton-Raphson iterations allowed
   set Max iterations Newton-Raphson = 10
 
   # Displacement error tolerance
-  set Tolerance displacement        = 1.0e-6
+  set Tolerance displacement = 1.0e-6
 
   # Force residual tolerance
-  set Tolerance force               = 1.0e-9
+  set Tolerance force = 1.0e-9
 end
-
 
 subsection Time
   # End time
-  set End time       = 1
+  set End time = 1
 
   # Time step size
   set Time step size = 0.1

--- a/tests/sundials/arkode_01_in.prm
+++ b/tests/sundials/arkode_01_in.prm
@@ -1,10 +1,12 @@
 set Final time                        = 6.28
 set Initial time                      = 0
 set Time interval between each output = 0.05
+
 subsection Error control
   set Absolute error tolerance = 0.000001
   set Relative error tolerance = 0.000010
 end
+
 subsection Running parameters
   set Initial step size                      = 0.010000
   set Maximum number of nonlinear iterations = 10

--- a/tests/sundials/arkode_03_in.prm
+++ b/tests/sundials/arkode_03_in.prm
@@ -1,12 +1,14 @@
 set Final time                        = 10
 set Initial time                      = 0
 set Time interval between each output = 0.1
+
 subsection Error control
   # making this tolerance any lower prevents convergence in 5.4:
   # this is fixed in 6.2
   set Absolute error tolerance = 5e-9
   set Relative error tolerance = 5e-9
 end
+
 subsection Running parameters
   set Implicit function is linear            = true
   set Implicit function is time independent  = true
@@ -15,5 +17,5 @@ subsection Running parameters
   set Maximum order of ARK                   = 5
   set Minimum step size                      = 1e-7
   # A larger subspace, combined with looser tolerances, are required by 5.4
-  set Anderson-acceleration subspace         = 10
+  set Anderson-acceleration subspace = 10
 end

--- a/tests/sundials/arkode_04_in.prm
+++ b/tests/sundials/arkode_04_in.prm
@@ -1,11 +1,13 @@
 set Final time                        = 10.
 set Initial time                      = 0.
 set Time interval between each output = 0.1
+
 subsection Error control
   # This test is somewhat easier since we have a way to evaluate the Jacobian
   set Absolute error tolerance = 4e-9
   set Relative error tolerance = 4e-9
 end
+
 subsection Running parameters
   set Implicit function is linear            = true
   set Implicit function is time independent  = true

--- a/tests/sundials/arkode_05_in.prm
+++ b/tests/sundials/arkode_05_in.prm
@@ -1,10 +1,12 @@
 set Final time                        = 10.
 set Initial time                      = 0.
 set Time interval between each output = 0.1
+
 subsection Error control
   set Absolute error tolerance = 0.000001
   set Relative error tolerance = 0.000010
 end
+
 subsection Running parameters
   set Implicit function is linear            = true
   set Implicit function is time independent  = true

--- a/tests/sundials/arkode_06_in.prm
+++ b/tests/sundials/arkode_06_in.prm
@@ -1,10 +1,12 @@
 set Final time                        = 10.
 set Initial time                      = 0.
 set Time interval between each output = 0.1
+
 subsection Error control
   set Absolute error tolerance = 0.000001
   set Relative error tolerance = 0.000010
 end
+
 subsection Running parameters
   set Implicit function is linear            = true
   set Implicit function is time independent  = true

--- a/tests/sundials/arkode_07_in.prm
+++ b/tests/sundials/arkode_07_in.prm
@@ -1,10 +1,12 @@
 set Final time                        = 10.
 set Initial time                      = 0.
 set Time interval between each output = 0.1
+
 subsection Error control
   set Absolute error tolerance = 0.000001
   set Relative error tolerance = 0.000010
 end
+
 subsection Running parameters
   set Implicit function is linear            = true
   set Implicit function is time independent  = true

--- a/tests/sundials/arkode_08_in.prm
+++ b/tests/sundials/arkode_08_in.prm
@@ -1,10 +1,12 @@
 set Final time                        = 1.
 set Initial time                      = 0.
 set Time interval between each output = 0.1
+
 subsection Error control
   set Absolute error tolerance = 0.000001
   set Relative error tolerance = 0.000010
 end
+
 subsection Running parameters
   set Implicit function is linear            = true
   set Implicit function is time independent  = true

--- a/tests/sundials/arkode_09_in.prm
+++ b/tests/sundials/arkode_09_in.prm
@@ -1,10 +1,12 @@
 set Final time                        = 6
 set Initial time                      = 0
 set Time interval between each output = 2
+
 subsection Error control
   set Absolute error tolerance = 0.001
   set Relative error tolerance = 0.010
 end
+
 subsection Running parameters
   set Initial step size                      = 3
   set Maximum number of nonlinear iterations = 10

--- a/tests/sundials/arkode_10_in.prm
+++ b/tests/sundials/arkode_10_in.prm
@@ -1,10 +1,12 @@
 set Final time                        = 1.
 set Initial time                      = 0.
 set Time interval between each output = 0.1
+
 subsection Error control
   set Absolute error tolerance = 0.000001
   set Relative error tolerance = 0.000010
 end
+
 subsection Running parameters
   set Implicit function is linear            = true
   set Implicit function is time independent  = true

--- a/tests/sundials/arkode_11_in.prm
+++ b/tests/sundials/arkode_11_in.prm
@@ -1,10 +1,12 @@
 set Final time                        = 1.
 set Initial time                      = 0.
 set Time interval between each output = 0.1
+
 subsection Error control
   set Absolute error tolerance = 0.000001
   set Relative error tolerance = 0.000010
 end
+
 subsection Running parameters
   set Implicit function is linear            = true
   set Implicit function is time independent  = true

--- a/tests/sundials/arkode_repeated_solve_in.prm
+++ b/tests/sundials/arkode_repeated_solve_in.prm
@@ -1,10 +1,12 @@
 set Final time                        = 2.0
 set Initial time                      = 0
 set Time interval between each output = 0.1
+
 subsection Error control
   set Absolute error tolerance = 1e-8
   set Relative error tolerance = 1e-8
 end
+
 subsection Running parameters
   set Initial step size                      = 1e-6
   set Maximum number of nonlinear iterations = 10

--- a/tests/sundials/ida_01_in.prm
+++ b/tests/sundials/ida_01_in.prm
@@ -1,16 +1,19 @@
 set Final time                        = 6.3
 set Initial time                      = 0
 set Time interval between each output = 0.2
+
 subsection Error control
   set Absolute error tolerance                      = 1e-10
   set Ignore algebraic terms for error computations = true
   set Relative error tolerance                      = 1e-10
 end
+
 subsection Initial condition correction parameters
   set Correction type at initial time        = none
   set Correction type after restart          = none
   set Maximum number of nonlinear iterations = 10
 end
+
 subsection Running parameters
   set Initial step size                      = 1e-6
   set Maximum number of nonlinear iterations = 10

--- a/tests/sundials/ida_03_in.prm
+++ b/tests/sundials/ida_03_in.prm
@@ -1,16 +1,19 @@
 set Final time                        = 2
 set Initial time                      = 0
 set Time interval between each output = 0.2
+
 subsection Error control
   set Absolute error tolerance                      = 1e-10
   set Ignore algebraic terms for error computations = true
   set Relative error tolerance                      = 1e-10
 end
+
 subsection Initial condition correction parameters
   set Correction type at initial time        = none
   set Correction type after restart          = none
   set Maximum number of nonlinear iterations = 10
 end
+
 subsection Running parameters
   set Initial step size                      = 1e-6
   set Maximum number of nonlinear iterations = 10

--- a/tests/sundials/ida_04_in.prm
+++ b/tests/sundials/ida_04_in.prm
@@ -1,16 +1,19 @@
 set Final time                        = 2
 set Initial time                      = 0
 set Time interval between each output = 0.2
+
 subsection Error control
   set Absolute error tolerance                      = 1e-10
   set Ignore algebraic terms for error computations = true
   set Relative error tolerance                      = 1e-10
 end
+
 subsection Initial condition correction parameters
   set Correction type at initial time        = none
   set Correction type after restart          = none
   set Maximum number of nonlinear iterations = 10
 end
+
 subsection Running parameters
   set Initial step size                      = 0.2 # start with a large time step
   set Maximum number of nonlinear iterations = 10

--- a/tests/sundials/kinsol_fixed_point.prm
+++ b/tests/sundials/kinsol_fixed_point.prm
@@ -2,12 +2,15 @@ set Function norm stopping tolerance       = 1e-10
 set Maximum number of nonlinear iterations = 200
 set Scaled step stopping tolerance         = 1e-10
 set Solution strategy                      = fixed_point
+
 subsection Fixed point and Picard parameters
   set Anderson acceleration subspace size = 2
 end
+
 subsection Linesearch parameters
   set Maximum number of beta-condition failures = 0
 end
+
 subsection Newton parameters
   set Maximum allowable scaled length of the Newton step = 0.000000
   set Maximum iterations without matrix setup            = 0

--- a/tests/sundials/kinsol_linesearch.prm
+++ b/tests/sundials/kinsol_linesearch.prm
@@ -2,12 +2,15 @@ set Function norm stopping tolerance       = 0.000000
 set Maximum number of nonlinear iterations = 200
 set Scaled step stopping tolerance         = 0.000000
 set Solution strategy                      = linesearch
+
 subsection Fixed point and Picard parameters
   set Anderson acceleration subspace size = 5
 end
+
 subsection Linesearch parameters
   set Maximum number of beta-condition failures = 0
 end
+
 subsection Newton parameters
   set Maximum allowable scaled length of the Newton step = 0.000000
   set Maximum iterations without matrix setup            = 0

--- a/tests/sundials/kinsol_newton.prm
+++ b/tests/sundials/kinsol_newton.prm
@@ -2,12 +2,15 @@ set Function norm stopping tolerance       = 0.000000
 set Maximum number of nonlinear iterations = 200
 set Scaled step stopping tolerance         = 0.000000
 set Solution strategy                      = newton
+
 subsection Fixed point and Picard parameters
   set Anderson acceleration subspace size = 5
 end
+
 subsection Linesearch parameters
   set Maximum number of beta-condition failures = 0
 end
+
 subsection Newton parameters
   set Maximum allowable scaled length of the Newton step = 0.000000
   set Maximum iterations without matrix setup            = 0

--- a/tests/sundials/kinsol_picard.prm
+++ b/tests/sundials/kinsol_picard.prm
@@ -2,12 +2,15 @@ set Function norm stopping tolerance       = 1e-10
 set Maximum number of nonlinear iterations = 200
 set Scaled step stopping tolerance         = 1e-10
 set Solution strategy                      = picard
+
 subsection Fixed point and Picard parameters
   set Anderson acceleration subspace size = 2
 end
+
 subsection Linesearch parameters
   set Maximum number of beta-condition failures = 0
 end
+
 subsection Newton parameters
   set Maximum allowable scaled length of the Newton step = 0.000000
   set Maximum iterations without matrix setup            = 0

--- a/tests/symengine/prm/parameters-step-44.prm
+++ b/tests/symengine/prm/parameters-step-44.prm
@@ -1,26 +1,25 @@
 # Listing of Parameters
 # ---------------------
+
 subsection Finite element system
   # Displacement system polynomial order
   set Polynomial degree = 1
 
   # Gauss quadrature order
-  set Quadrature order  = 2
+  set Quadrature order = 2
 end
-
 
 subsection Geometry
   # Global refinement level
   # Low refinement level because symbolic computations are (apparently) rather slow at the moment...
-  set Global refinement   = 1
+  set Global refinement = 1
 
   # Global grid scaling factor
-  set Grid scale          = 1e-3
+  set Grid scale = 1e-3
 
   # Ratio of applied pressure to reference pressure
   set Pressure ratio p/p0 = 100
 end
-
 
 subsection Linear solver
   # Linear solver iterations (multiples of the system matrix size)
@@ -28,7 +27,7 @@ subsection Linear solver
   set Max iteration multiplier = 2
 
   # Linear solver residual (scaled by residual norm)
-  set Residual                 = 1e-6
+  set Residual = 1e-6
 
   # Use static condensation and solve a 1-block system, or solve
   # the full 3-block system using Linear Operators and the Schur
@@ -36,40 +35,37 @@ subsection Linear solver
   set Use static condensation = true
 
   # Preconditioner type
-  set Preconditioner type  = ssor
+  set Preconditioner type = ssor
 
   # Preconditioner relaxation value
-  set Preconditioner relaxation  = 0.65
+  set Preconditioner relaxation = 0.65
 
   # Type of solver used to solve the linear system
-  set Solver type              = CG
+  set Solver type = CG
 end
-
 
 subsection Material properties
   # Poisson's ratio
   set Poisson's ratio = 0.4999
 
   # Shear modulus
-  set Shear modulus   = 80.194e6
+  set Shear modulus = 80.194e6
 end
-
 
 subsection Nonlinear solver
   # Number of Newton-Raphson iterations allowed
   set Max iterations Newton-Raphson = 10
 
   # Displacement error tolerance
-  set Tolerance displacement        = 1.0e-6
+  set Tolerance displacement = 1.0e-6
 
   # Force residual tolerance
-  set Tolerance force               = 1.0e-9
+  set Tolerance force = 1.0e-9
 end
-
 
 subsection Time
   # End time
-  set End time       = 1
+  set End time = 1
 
   # Time step size
   set Time step size = 0.1


### PR DESCRIPTION
This PR applies the PRM formatter [prmindent][] to almost all PRM files in deal.II. Assuming prmindent is available in PATH, you can reproduce the results by running the following in the root directory of deal.II:

```sh
find . -path ./tests/parameter_handler -prune -o -name '*.prm' -execdir prmindent -i '{}' \;
```

(If you have mawk or gawk installed, installing prmindent should be just a question of making the script executable and placing it somewhere in your PATH. Or you could also read its installation instructions.)

This PR is a follow-up to @bangerth's [suggestion][] on the mailing list. To summarize the situation: I wrote prmindent for use in [Lethe][] some time ago, and @bangerth said it could be added to deal.II's contrib/utilities. This PR is an opportunity to discuss prmindent's formatting (and eventually to format deal.II's PRM files). If it is accepted, I will submit another PR adding prmindent to contrib/utilities.

On the whole, I am quite happy with the changes, which are few. However, there are some issues, which I will discuss presently.

The main difference with the current PRM style in deal.II is that values are aligned only if not separated by blank lines or comments. This style is not scrupulously followed throughout deal.II, so I do not foresee it being an issue. Also, top-level blocks, i.e., subsections or groups of entries, are separated by a blank line.

One discrepant formatting style currently applied by prmindent is the addition of blank lines between comments and top-level subsections or entries (this is actually an artifact of separating top-level blocks). Another is that prmindent currently adds a trailing space for entries with no value. I will fix these.

Finally, some of the pathological ParameterHandler test cases in tests/parameter_handler are handled somewhat poorly, specifically those involving backslashes. I have not applied prmindent to the ParameterHandler test files, as they have presumably been carefully crafted.

Also, I do not know if multiline multiple parameter loops are common, but prmindent treats them only as ordinary values, so it will not align them in any way.

Feel free to comment on prmindent's style and make any requests. The time for bikeshedding is now.

[prmindent]: https://git.sr.ht/~paulapatience/prmindent
[suggestion]: https://groups.google.com/g/dealii/c/wDeQWIyUWpQ/m/2VfTHgsIEQAJ
[Lethe]: https://github.com/chaos-polymtl/lethe