### PR TITLE
Different changes to `FEInterfaceValues` and `NM::FEInterfaceValues`

### DIFF
--- a/include/deal.II/fe/fe_interface_values.h
+++ b/include/deal.II/fe/fe_interface_values.h
@@ -1441,6 +1441,8 @@ public:
    *   finite element across the interface (only used if the FEInterface object
    *   is initialized with an hp::FECollection, an hp::QCollection, and possibly
    *   an hp::MappingCollection).
+   * @param[in] fe_index_neighbor Active fe index of neighboring cell. Useful
+   *   if hp capabilities are used and for non-DoFHandler iterators.
    */
   template <typename CellIteratorType, typename CellNeighborIteratorType>
   void
@@ -1450,9 +1452,10 @@ public:
          const CellNeighborIteratorType &cell_neighbor,
          const unsigned int              face_no_neighbor,
          const unsigned int              sub_face_no_neighbor,
-         const unsigned int q_index       = numbers::invalid_unsigned_int,
-         const unsigned int mapping_index = numbers::invalid_unsigned_int,
-         const unsigned int fe_index      = numbers::invalid_unsigned_int);
+         const unsigned int q_index           = numbers::invalid_unsigned_int,
+         const unsigned int mapping_index     = numbers::invalid_unsigned_int,
+         const unsigned int fe_index          = numbers::invalid_unsigned_int,
+         const unsigned int fe_index_neighbor = numbers::invalid_unsigned_int);
 
   /**
    * Re-initialize this object to be used on an interface given by a single face
@@ -2318,10 +2321,23 @@ FEInterfaceValues<dim, spacedim>::reinit(
   const unsigned int              sub_face_no_neighbor,
   const unsigned int              q_index,
   const unsigned int              mapping_index,
-  const unsigned int              fe_index)
+  const unsigned int              fe_index_in,
+  const unsigned int              fe_index_neighbor_in)
 {
   Assert(internal_fe_face_values || internal_hp_fe_face_values,
          ExcNotInitialized());
+
+  constexpr bool is_dof_cell_accessor =
+    std::is_same_v<DoFCellAccessor<dim, spacedim, true>,
+                   typename CellIteratorType::AccessorType> ||
+    std::is_same_v<DoFCellAccessor<dim, spacedim, false>,
+                   typename CellIteratorType::AccessorType>;
+
+  constexpr bool is_dof_cell_accessor_neighbor =
+    std::is_same_v<DoFCellAccessor<dim, spacedim, true>,
+                   typename CellNeighborIteratorType::AccessorType> ||
+    std::is_same_v<DoFCellAccessor<dim, spacedim, false>,
+                   typename CellNeighborIteratorType::AccessorType>;
 
   if (internal_fe_face_values)
     {
@@ -2357,6 +2373,28 @@ FEInterfaceValues<dim, spacedim>::reinit(
     }
   else if (internal_hp_fe_face_values)
     {
+      unsigned int active_fe_index = fe_index_in;
+      unsigned int active_fe_index_neighbor =
+        (fe_index_neighbor_in != numbers::invalid_unsigned_int) ?
+          fe_index_neighbor_in :
+          fe_index_in;
+
+      if (active_fe_index == numbers::invalid_unsigned_int)
+        {
+          if constexpr (is_dof_cell_accessor)
+            active_fe_index = cell->active_fe_index();
+          else
+            active_fe_index = 0;
+        }
+
+      if (active_fe_index_neighbor == numbers::invalid_unsigned_int)
+        {
+          if constexpr (is_dof_cell_accessor_neighbor)
+            active_fe_index_neighbor = cell_neighbor->active_fe_index();
+          else
+            active_fe_index_neighbor = 0;
+        }
+
       unsigned int used_q_index       = q_index;
       unsigned int used_mapping_index = mapping_index;
 
@@ -2376,10 +2414,10 @@ FEInterfaceValues<dim, spacedim>::reinit(
       // same :-(
       if (used_q_index == numbers::invalid_unsigned_int)
         if (internal_hp_fe_face_values
-              ->get_quadrature_collection()[cell->active_fe_index()] ==
+              ->get_quadrature_collection()[active_fe_index] ==
             internal_hp_fe_face_values
-              ->get_quadrature_collection()[cell_neighbor->active_fe_index()])
-          used_q_index = cell->active_fe_index();
+              ->get_quadrature_collection()[active_fe_index_neighbor])
+          used_q_index = active_fe_index;
 
       // Third check, if the above did not already suffice. We see if we
       // can get somewhere via the dominated's finite element index.
@@ -2387,7 +2425,7 @@ FEInterfaceValues<dim, spacedim>::reinit(
         ((used_q_index == numbers::invalid_unsigned_int) ||
              (used_mapping_index == numbers::invalid_unsigned_int) ?
            internal_hp_fe_face_values->get_fe_collection().find_dominated_fe(
-             {cell->active_fe_index(), cell_neighbor->active_fe_index()}) :
+             {active_fe_index, active_fe_index_neighbor}) :
            numbers::invalid_unsigned_int);
 
       if (used_q_index == numbers::invalid_unsigned_int)
@@ -2420,14 +2458,18 @@ FEInterfaceValues<dim, spacedim>::reinit(
       if (sub_face_no == numbers::invalid_unsigned_int)
         {
           internal_hp_fe_face_values->reinit(
-            cell, face_no, used_q_index, used_mapping_index, fe_index);
+            cell, face_no, used_q_index, used_mapping_index, active_fe_index);
           fe_face_values = &const_cast<FEFaceValues<dim, spacedim> &>(
             internal_hp_fe_face_values->get_present_fe_values());
         }
       else
         {
-          internal_hp_fe_subface_values->reinit(
-            cell, face_no, sub_face_no, used_q_index, used_mapping_index);
+          internal_hp_fe_subface_values->reinit(cell,
+                                                face_no,
+                                                sub_face_no,
+                                                used_q_index,
+                                                used_mapping_index,
+                                                active_fe_index);
 
           fe_face_values = &const_cast<FESubfaceValues<dim, spacedim> &>(
             internal_hp_fe_subface_values->get_present_fe_values());
@@ -2437,18 +2479,21 @@ FEInterfaceValues<dim, spacedim>::reinit(
           internal_hp_fe_face_values_neighbor->reinit(cell_neighbor,
                                                       face_no_neighbor,
                                                       used_q_index,
-                                                      used_mapping_index);
+                                                      used_mapping_index,
+                                                      active_fe_index_neighbor);
 
           fe_face_values_neighbor = &const_cast<FEFaceValues<dim, spacedim> &>(
             internal_hp_fe_face_values_neighbor->get_present_fe_values());
         }
       else
         {
-          internal_hp_fe_subface_values_neighbor->reinit(cell_neighbor,
-                                                         face_no_neighbor,
-                                                         sub_face_no_neighbor,
-                                                         used_q_index,
-                                                         used_mapping_index);
+          internal_hp_fe_subface_values_neighbor->reinit(
+            cell_neighbor,
+            face_no_neighbor,
+            sub_face_no_neighbor,
+            used_q_index,
+            used_mapping_index,
+            active_fe_index_neighbor);
 
           fe_face_values_neighbor =
             &const_cast<FESubfaceValues<dim, spacedim> &>(
@@ -2463,47 +2508,48 @@ FEInterfaceValues<dim, spacedim>::reinit(
     }
 
   // Set up dof mapping and remove duplicates (for continuous elements).
-  {
-    // Get dof indices first:
-    std::vector<types::global_dof_index> v(
-      fe_face_values->get_fe().n_dofs_per_cell());
-    cell->get_active_or_mg_dof_indices(v);
-    std::vector<types::global_dof_index> v2(
-      fe_face_values_neighbor->get_fe().n_dofs_per_cell());
-    cell_neighbor->get_active_or_mg_dof_indices(v2);
+  if constexpr (is_dof_cell_accessor_neighbor && is_dof_cell_accessor)
+    {
+      // Get dof indices first:
+      std::vector<types::global_dof_index> v(
+        fe_face_values->get_fe().n_dofs_per_cell());
+      cell->get_active_or_mg_dof_indices(v);
+      std::vector<types::global_dof_index> v2(
+        fe_face_values_neighbor->get_fe().n_dofs_per_cell());
+      cell_neighbor->get_active_or_mg_dof_indices(v2);
 
-    // Fill a map from the global dof index to the left and right
-    // local index.
-    std::map<types::global_dof_index, std::pair<unsigned int, unsigned int>>
-                                          tempmap;
-    std::pair<unsigned int, unsigned int> invalid_entry(
-      numbers::invalid_unsigned_int, numbers::invalid_unsigned_int);
+      // Fill a map from the global dof index to the left and right
+      // local index.
+      std::map<types::global_dof_index, std::pair<unsigned int, unsigned int>>
+                                            tempmap;
+      std::pair<unsigned int, unsigned int> invalid_entry(
+        numbers::invalid_unsigned_int, numbers::invalid_unsigned_int);
 
-    for (unsigned int i = 0; i < v.size(); ++i)
-      {
-        // If not already existing, add an invalid entry:
-        auto result = tempmap.insert(std::make_pair(v[i], invalid_entry));
-        result.first->second.first = i;
-      }
+      for (unsigned int i = 0; i < v.size(); ++i)
+        {
+          // If not already existing, add an invalid entry:
+          auto result = tempmap.insert(std::make_pair(v[i], invalid_entry));
+          result.first->second.first = i;
+        }
 
-    for (unsigned int i = 0; i < v2.size(); ++i)
-      {
-        // If not already existing, add an invalid entry:
-        auto result = tempmap.insert(std::make_pair(v2[i], invalid_entry));
-        result.first->second.second = i;
-      }
+      for (unsigned int i = 0; i < v2.size(); ++i)
+        {
+          // If not already existing, add an invalid entry:
+          auto result = tempmap.insert(std::make_pair(v2[i], invalid_entry));
+          result.first->second.second = i;
+        }
 
-    // Transfer from the map to the sorted std::vectors.
-    dofmap.resize(tempmap.size());
-    interface_dof_indices.resize(tempmap.size());
-    unsigned int idx = 0;
-    for (auto &x : tempmap)
-      {
-        interface_dof_indices[idx] = x.first;
-        dofmap[idx]                = {{x.second.first, x.second.second}};
-        ++idx;
-      }
-  }
+      // Transfer from the map to the sorted std::vectors.
+      dofmap.resize(tempmap.size());
+      interface_dof_indices.resize(tempmap.size());
+      unsigned int idx = 0;
+      for (auto &x : tempmap)
+        {
+          interface_dof_indices[idx] = x.first;
+          dofmap[idx]                = {{x.second.first, x.second.second}};
+          ++idx;
+        }
+    }
 }
 
 
@@ -2522,12 +2568,17 @@ FEInterfaceValues<dim, spacedim>::reinit(const CellIteratorType &cell,
 
   if (internal_fe_face_values)
     {
+      Assert((q_index == 0 || q_index == numbers::invalid_unsigned_int),
+             ExcNotImplemented());
+      Assert((mapping_index == 0 ||
+              mapping_index == numbers::invalid_unsigned_int),
+             ExcNotImplemented());
+      Assert((fe_index == 0 || fe_index == numbers::invalid_unsigned_int),
+             ExcNotImplemented());
+
       internal_fe_face_values->reinit(cell, face_no);
       fe_face_values          = internal_fe_face_values.get();
       fe_face_values_neighbor = nullptr;
-
-      interface_dof_indices.resize(fe_face_values->get_fe().n_dofs_per_cell());
-      cell->get_active_or_mg_dof_indices(interface_dof_indices);
     }
   else if (internal_hp_fe_face_values)
     {
@@ -2536,15 +2587,31 @@ FEInterfaceValues<dim, spacedim>::reinit(const CellIteratorType &cell,
       fe_face_values = &const_cast<FEFaceValues<dim> &>(
         internal_hp_fe_face_values->get_present_fe_values());
       fe_face_values_neighbor = nullptr;
-
-      interface_dof_indices.resize(fe_face_values->get_fe().n_dofs_per_cell());
-      cell->get_active_or_mg_dof_indices(interface_dof_indices);
     }
 
-  dofmap.resize(interface_dof_indices.size());
-  for (unsigned int i = 0; i < interface_dof_indices.size(); ++i)
+  if constexpr (std::is_same_v<typename CellIteratorType::AccessorType,
+                               DoFCellAccessor<dim, spacedim, true>> ||
+                std::is_same_v<typename CellIteratorType::AccessorType,
+                               DoFCellAccessor<dim, spacedim, false>>)
     {
-      dofmap[i] = {{i, numbers::invalid_unsigned_int}};
+      if (internal_fe_face_values)
+        {
+          interface_dof_indices.resize(
+            fe_face_values->get_fe().n_dofs_per_cell());
+          cell->get_active_or_mg_dof_indices(interface_dof_indices);
+        }
+      else if (internal_hp_fe_face_values)
+        {
+          interface_dof_indices.resize(
+            fe_face_values->get_fe().n_dofs_per_cell());
+          cell->get_active_or_mg_dof_indices(interface_dof_indices);
+        }
+
+      dofmap.resize(interface_dof_indices.size());
+      for (unsigned int i = 0; i < interface_dof_indices.size(); ++i)
+        {
+          dofmap[i] = {{i, numbers::invalid_unsigned_int}};
+        }
     }
 }
 

--- a/source/non_matching/fe_values.inst.in
+++ b/source/non_matching/fe_values.inst.in
@@ -65,6 +65,17 @@ for (VEC : REAL_VECTOR_TYPES; deal_II_dimension : DIMENSIONS)
   }
 
 // Template reinit functions
+for (deal_II_dimension : DIMENSIONS)
+  {
+    template void FEInterfaceValues<deal_II_dimension>::do_reinit(
+      const TriaIterator<CellAccessor<deal_II_dimension, deal_II_dimension>> &,
+      const unsigned int,
+      const unsigned int,
+      const unsigned int,
+      const std::function<void(dealii::FEInterfaceValues<deal_II_dimension> &,
+                               const unsigned int)> &);
+  }
+
 for (deal_II_dimension : DIMENSIONS; lda : BOOL)
   {
     template void FEValues<deal_II_dimension>::reinit(
@@ -77,6 +88,8 @@ for (deal_II_dimension : DIMENSIONS; lda : BOOL)
       const TriaIterator<
         DoFCellAccessor<deal_II_dimension, deal_II_dimension, lda>> &,
       const unsigned int,
-      const std::function<void(dealii::FEInterfaceValues<deal_II_dimension> &)>
-        &);
+      const unsigned int,
+      const unsigned int,
+      const std::function<void(dealii::FEInterfaceValues<deal_II_dimension> &,
+                               const unsigned int)> &);
   }

--- a/tests/non_matching/fe_interface_values.cc
+++ b/tests/non_matching/fe_interface_values.cc
@@ -55,9 +55,11 @@ private:
   void
   setup_discrete_level_set();
 
+  template <typename IteratorType>
   void
   print_which_optionals_have_values_on_cell_0(
-    NonMatching::FEInterfaceValues<dim> &fe_values);
+    NonMatching::FEInterfaceValues<dim> &fe_values,
+    IteratorType                         cell);
 
   Triangulation<dim>    triangulation;
   hp::FECollection<dim> fe_collection;
@@ -106,7 +108,10 @@ Test<dim>::run()
                                                   mesh_classifier,
                                                   dof_handler,
                                                   level_set);
-    print_which_optionals_have_values_on_cell_0(fe_values);
+    print_which_optionals_have_values_on_cell_0(fe_values,
+                                                triangulation.begin_active());
+    print_which_optionals_have_values_on_cell_0(fe_values,
+                                                dof_handler.begin_active());
   }
   {
     deallog << "Advanced constructor:" << std::endl;
@@ -118,7 +123,10 @@ Test<dim>::run()
                                                   mesh_classifier,
                                                   dof_handler,
                                                   level_set);
-    print_which_optionals_have_values_on_cell_0(fe_values);
+    print_which_optionals_have_values_on_cell_0(fe_values,
+                                                triangulation.begin_active());
+    print_which_optionals_have_values_on_cell_0(fe_values,
+                                                dof_handler.begin_active());
   }
 }
 
@@ -166,12 +174,12 @@ Test<dim>::setup_discrete_level_set()
 
 
 template <int dim>
+template <typename IteratorType>
 void
 Test<dim>::print_which_optionals_have_values_on_cell_0(
-  NonMatching::FEInterfaceValues<dim> &fe_values)
+  NonMatching::FEInterfaceValues<dim> &fe_values,
+  IteratorType                         cell)
 {
-  const auto cell = dof_handler.begin_active();
-
   for (const unsigned int face_index : cell->face_indices())
     {
       deallog << "face " << face_index << std::endl;

--- a/tests/non_matching/fe_interface_values.with_lapack=on.output
+++ b/tests/non_matching/fe_interface_values.with_lapack=on.output
@@ -5,7 +5,15 @@ DEAL::face 0
 DEAL::inside has value
 DEAL::face 1
 DEAL::outside has value
+DEAL::face 0
+DEAL::inside has value
+DEAL::face 1
+DEAL::outside has value
 DEAL::Advanced constructor:
+DEAL::face 0
+DEAL::inside has value
+DEAL::face 1
+DEAL::outside has value
 DEAL::face 0
 DEAL::inside has value
 DEAL::face 1
@@ -23,7 +31,27 @@ DEAL::face 2
 DEAL::inside has value
 DEAL::face 3
 DEAL::outside has value
+DEAL::face 0
+DEAL::inside has value
+DEAL::outside has value
+DEAL::face 1
+DEAL::inside has value
+DEAL::outside has value
+DEAL::face 2
+DEAL::inside has value
+DEAL::face 3
+DEAL::outside has value
 DEAL::Advanced constructor:
+DEAL::face 0
+DEAL::inside has value
+DEAL::outside has value
+DEAL::face 1
+DEAL::inside has value
+DEAL::outside has value
+DEAL::face 2
+DEAL::inside has value
+DEAL::face 3
+DEAL::outside has value
 DEAL::face 0
 DEAL::inside has value
 DEAL::outside has value
@@ -53,7 +81,39 @@ DEAL::face 4
 DEAL::inside has value
 DEAL::face 5
 DEAL::outside has value
+DEAL::face 0
+DEAL::inside has value
+DEAL::outside has value
+DEAL::face 1
+DEAL::inside has value
+DEAL::outside has value
+DEAL::face 2
+DEAL::inside has value
+DEAL::outside has value
+DEAL::face 3
+DEAL::inside has value
+DEAL::outside has value
+DEAL::face 4
+DEAL::inside has value
+DEAL::face 5
+DEAL::outside has value
 DEAL::Advanced constructor:
+DEAL::face 0
+DEAL::inside has value
+DEAL::outside has value
+DEAL::face 1
+DEAL::inside has value
+DEAL::outside has value
+DEAL::face 2
+DEAL::inside has value
+DEAL::outside has value
+DEAL::face 3
+DEAL::inside has value
+DEAL::outside has value
+DEAL::face 4
+DEAL::inside has value
+DEAL::face 5
+DEAL::outside has value
 DEAL::face 0
 DEAL::inside has value
 DEAL::outside has value


### PR DESCRIPTION
- `FEInterfaceValues` can now accept `TriaIterator<CellAccessor>`
- `NM::FEInterfaceValues` can now accept `TriaIterator<CellAccessor>`
- use `active_fe_index` in `FEInterfaceValues`  (there have been places where the argument was not used)
- exploit the hp capabilities of `FEInterfaceValues` in `NM::FEInterfaceValues` so that one does not have to store vectors of `FEInterfaceValues` (I believe `NM::FEValues` could be rewritten similarly: instead of using `FEValues` and would use `hp::FEValues` and get the current `FEValues` instance by `hp::FEValues::get_present_fe_values()`; by the `std::optional` makes this complicated/impossible (?))