### PR TITLE
Make multithreading/task_17 more stable

### DIFF
--- a/tests/multithreading/task_17.cc
+++ b/tests/multithreading/task_17.cc
@@ -41,7 +41,6 @@ middle()
 {
   deallog << "    Starting task in the middle" << std::endl;
   auto t = Threads::new_task([]() { bottom(); });
-  deallog << "    Waiting for sub-task in the middle" << std::endl;
   t.join();
   deallog << "    Ending task in the middle" << std::endl;
 }
@@ -51,7 +50,6 @@ top()
 {
   deallog << "  Starting task at the top" << std::endl;
   auto t = Threads::new_task([]() { middle(); });
-  deallog << "  Waiting for sub-task at the top" << std::endl;
   t.join();
   deallog << "  Ending task at the top" << std::endl;
 }
@@ -66,7 +64,6 @@ main()
 
   deallog << "Starting task in main()" << std::endl;
   auto t = Threads::new_task([]() { top(); });
-  deallog << "Waiting for task in main" << std::endl;
   t.join();
   deallog << "Done in main" << std::endl;
 }

--- a/tests/multithreading/task_17.output
+++ b/tests/multithreading/task_17.output
@@ -1,10 +1,7 @@
 
 DEAL::Starting task in main()
-DEAL::Waiting for task in main
 DEAL::  Starting task at the top
-DEAL::  Waiting for sub-task at the top
 DEAL::    Starting task in the middle
-DEAL::    Waiting for sub-task in the middle
 DEAL::      Starting task at the bottom
 DEAL::        ... ... ...
 DEAL::      Ending task at the bottom


### PR DESCRIPTION
We have seen this test to be unstable and it's not clear that the output to `deallog` removed here could not be executed before respective prints in the tasks launched.