### PR TITLE
Generalize the signature of MeshWorker::loop().

### DIFF
--- a/include/deal.II/meshworker/loop.h
+++ b/include/deal.II/meshworker/loop.h
@@ -439,16 +439,16 @@ namespace MeshWorker
             typename AssemblerType,
             typename IteratorType>
   void
-  loop(IteratorType                             begin,
-       std_cxx20::type_identity_t<IteratorType> end,
-       DOFINFO                                 &dinfo,
-       INFOBOX                                 &info,
-       const std::function<void(DOFINFO &, typename INFOBOX::CellInfo &)>
-         &cell_worker,
-       const std::function<void(DOFINFO &, typename INFOBOX::CellInfo &)>
-                                                               &boundary_worker,
-       const std::function<void(DOFINFO &,
-                                DOFINFO &,
+  loop(IteratorType                                             begin,
+       std_cxx20::type_identity_t<IteratorType>                 end,
+       DOFINFO                                                 &dinfo,
+       INFOBOX                                                 &info,
+       const std::function<void(std_cxx20::type_identity_t<DOFINFO> &,
+                                typename INFOBOX::CellInfo &)> &cell_worker,
+       const std::function<void(std_cxx20::type_identity_t<DOFINFO> &,
+                                typename INFOBOX::CellInfo &)> &boundary_worker,
+       const std::function<void(std_cxx20::type_identity_t<DOFINFO> &,
+                                std_cxx20::type_identity_t<DOFINFO> &,
                                 typename INFOBOX::CellInfo &,
                                 typename INFOBOX::CellInfo &)> &face_worker,
        AssemblerType                                           &assembler,


### PR DESCRIPTION
In the signature of `MeshWorker::loop()`, the template argument `DOFINFO` appears in two places: As a direct argument, and as a type in a `std::function` argument. Because of this, you can only call `MeshWorker::loop` with a `std::function` object for that second place, so as to ensure that `DOFINFO` is the same in both places. It would, however, be nice to just pass something that can be *converted* to the `std::function` argument by the compiler; that isn't possible right now because you get an error about `DOFINFO` not matching.

The solution, as in other places, is to make the second place non-deducible by using `std::type_identity_t`. I have a patch to use this, so decided not to add a test.