### PR TITLE
taskflow: require 3.7.0

### DIFF
--- a/cmake/configure/configure_10_taskflow.cmake
+++ b/cmake/configure/configure_10_taskflow.cmake
@@ -30,39 +30,19 @@ macro(feature_taskflow_find_external var)
     set(${var} TRUE)
   endif()
 
-  if(TASKFLOW_VERSION VERSION_LESS "2.4")
+  if(TASKFLOW_VERSION VERSION_LESS "3.7")
     # Clear the previously determined version numbers to avoid confusion
     set(TASKFLOW_VERSION "bundled")
     set(TASKFLOW_VERSION_MAJOR "")
     set(TASKFLOW_VERSION_MINOR "")
 
     message(STATUS
-      "The externally provided Taskflow library is older than version 2.4, "
+      "The externally provided Taskflow library is older than version 3.7, "
       "which cannot be used with deal.II."
       )
     set(TASKFLOW_ADDITIONAL_ERROR_STRING
       "The externally provided Taskflow library is older than version\n"
-      "2.4, which is the oldest version compatible with deal.II."
-      )
-    set(${var} FALSE)
-  endif()
-
-
-  if(NOT TASKFLOW_VERSION VERSION_LESS "3.0" AND NOT DEAL_II_HAVE_CXX17)
-    # Clear the previously determined version numbers to avoid confusion
-    set(TASKFLOW_VERSION "bundled")
-    set(TASKFLOW_VERSION_MAJOR "")
-    set(TASKFLOW_VERSION_MINOR "")
-
-    message(STATUS
-      "The externally provided Taskflow library (version 3.0 onwards)
-      requires C++17 support, which has not been configured."
-      )
-    set(TASKFLOW_ADDITIONAL_ERROR_STRING
-      "The externally provided Taskflow library (version 3.0 onwards) "
-      "requires C++17 support, but no C++17 support had been detected "
-      "during configuration.\n"
-      "Try to set -DDEAL_II_CXX_FLAGS=\"-std=c++17\" by hand.\n"
+      "3.7, which is the oldest version compatible with deal.II."
       )
     set(${var} FALSE)
   endif()


### PR DESCRIPTION
This is required because we now rely on taskflow for async tasks with #16976 merged. This hangs for older taskflow versions.

FYI @tamiko @bangerth 