### PR TITLE
Remove deallog.depth_console(0) output from tutorial programs.

### DIFF
--- a/examples/step-67/step-67.cc
+++ b/examples/step-67/step-67.cc
@@ -2303,8 +2303,6 @@ int main(int argc, char **argv)
 
   try
     {
-      deallog.depth_console(0);
-
       EulerProblem<dimension> euler_problem;
       euler_problem.run();
     }

--- a/examples/step-76/step-76.cc
+++ b/examples/step-76/step-76.cc
@@ -1607,8 +1607,6 @@ int main(int argc, char **argv)
 
   try
     {
-      deallog.depth_console(0);
-
       EulerProblem<dimension> euler_problem;
       euler_problem.run();
     }


### PR DESCRIPTION
The default is zero, so these lines add nothing but confusion :-)