### PR TITLE
Compile mg_transfer_global_coarsening.cc separately in unity build

### DIFF
--- a/source/multigrid/CMakeLists.txt
+++ b/source/multigrid/CMakeLists.txt
@@ -18,7 +18,6 @@ set(_unity_include_src
   mg_level_global_transfer.cc
   mg_transfer_block.cc
   mg_transfer_component.cc
-  mg_transfer_global_coarsening.cc
   mg_transfer_internal.cc
   mg_transfer_prebuilt.cc
   multigrid.cc
@@ -26,6 +25,7 @@ set(_unity_include_src
 
 set(_separate_src
   mg_tools.cc
+  mg_transfer_global_coarsening.cc
   mg_transfer_matrix_free.cc
   )
 


### PR DESCRIPTION
I observed that the multigrid files in a unity build are quite expensive, because the most expensive file of the whole directory, `mg_transfer_global_coarsening.cc`, is added to the unity build part, rather than compiled separately. Address this.