### PR TITLE
Avoid a compiler error in symengine tests about mismatched operands.

### DIFF
--- a/tests/symengine/sd_common_tests/batch_optimizer_05.h
+++ b/tests/symengine/sd_common_tests/batch_optimizer_05.h
@@ -35,7 +35,7 @@ template <int dim,
           enum SD::OptimizerType     opt_method,
           enum SD::OptimizationFlags opt_flags>
 void
-test_serialization(const int n_runs, TimerOutput &timer)
+test_serialization(const unsigned int n_runs, TimerOutput &timer)
 {
   deallog << std::string(80, '-') << std::endl;
   deallog << "Dim: " << dim << std::endl;

--- a/tests/symengine/sd_common_tests/utilities.h
+++ b/tests/symengine/sd_common_tests/utilities.h
@@ -27,7 +27,7 @@ make_tensor(const NumberType &val)
     out[i][i] = 1.0;
 
   for (unsigned int i = 0; i < out.n_independent_components; ++i)
-    out[out.unrolled_to_component_indices(i)] += i + val;
+    out[out.unrolled_to_component_indices(i)] += NumberType(i) + val;
   return out;
 }
 
@@ -41,7 +41,7 @@ make_symm_tensor(const NumberType &val)
     out[i][i] = 1.0;
 
   for (unsigned int i = 0; i < out.n_independent_components; ++i)
-    out[out.unrolled_to_component_indices(i)] += i + val;
+    out[out.unrolled_to_component_indices(i)] += NumberType(i) + val;
   return out;
 }
 


### PR DESCRIPTION
While there also avoid a warning.