### PR TITLE
Covering all tutorials from step-5 to step-20 by CTest.

### DIFF
--- a/tests/examples/step-18.diff
+++ b/tests/examples/step-18.diff
@@ -1,0 +1,32 @@
+26a27
+> #include "../example_test.h"
+699c700
+<     , end_time(10.0)
+---
+>     , end_time(1.0)
+1088,1089c1089,1091
+<     pcout << "    Solver converged in " << n_iterations << " iterations."
+<           << std::endl;
+---
+>     //pcout << "    Solver converged in " << n_iterations << " iterations."
+>     //      << std::endl;
+>     (void)n_iterations;
+1126,1129c1128,1132
+<     cg.solve(system_matrix,
+<              distributed_incremental_displacement,
+<              system_rhs,
+<              preconditioner);
+---
+>     check_solver_within_range(std::cout,
+> 			   cg.solve(system_matrix, distributed_incremental_displacement, system_rhs, preconditioner),
+> 			   solver_control.last_step(),
+> 			   114,
+> 			   130);
+1330c1333
+<     output_results();
+---
+>   //output_results();
+1358c1361
+<     output_results();
+---
+>   //output_results();

--- a/tests/examples/step-18.mpirun=2.with_petsc=true.output
+++ b/tests/examples/step-18.mpirun=2.with_petsc=true.output
@@ -1,0 +1,17 @@
+Timestep 1 at time 1
+  Cycle 0:
+    Number of active cells:       3712 (by partition: 1972+1740)
+    Number of degrees of freedom: 17226 (by partition: 9396+7830)
+    Assembling system... norm of rhs is 1.88062e+10
+Solver stopped within 114 - 130 iterations
+Solver stopped within 114 - 130 iterations
+    Updating quadrature point data...
+  Cycle 1:
+    Number of active cells:       12805 (by partition: 7042+5763)
+    Number of degrees of freedom: 51696 (by partition: 29646+22050)
+    Assembling system... norm of rhs is 1.88062e+10
+Solver stopped within 114 - 130 iterations
+Solver stopped within 114 - 130 iterations
+    Updating quadrature point data...
+    Moving mesh...
+

--- a/tests/examples/step-19.diff
+++ b/tests/examples/step-19.diff
@@ -1,0 +1,8 @@
+208c208
+<     , time(0, 1e-4)
+---
+>     , time(0, 1e-6)
+1025c1025
+<         output_results();
+---
+>       //output_results();

--- a/tests/examples/step-19.output
+++ b/tests/examples/step-19.output
@@ -1,0 +1,70 @@
+Timestep 1
+  Field degrees of freedom:                 4989
+  Total number of particles in simulation:  20
+  Number of particles lost this time step:  0
+
+  Now at t=2.12647e-07, dt=2.12647e-07.
+
+Timestep 2
+  Field degrees of freedom:                 4989
+  Total number of particles in simulation:  40
+  Number of particles lost this time step:  0
+
+  Now at t=4.14362e-07, dt=2.01715e-07.
+
+Timestep 3
+  Field degrees of freedom:                 4989
+  Total number of particles in simulation:  60
+  Number of particles lost this time step:  0
+
+  Now at t=5.23066e-07, dt=1.08704e-07.
+
+Timestep 4
+  Field degrees of freedom:                 4989
+  Total number of particles in simulation:  80
+  Number of particles lost this time step:  0
+
+  Now at t=6.08431e-07, dt=8.53649e-08.
+
+Timestep 5
+  Field degrees of freedom:                 4989
+  Total number of particles in simulation:  100
+  Number of particles lost this time step:  0
+
+  Now at t=6.81935e-07, dt=7.35039e-08.
+
+Timestep 6
+  Field degrees of freedom:                 4989
+  Total number of particles in simulation:  120
+  Number of particles lost this time step:  0
+
+  Now at t=7.47864e-07, dt=6.59294e-08.
+
+Timestep 7
+  Field degrees of freedom:                 4989
+  Total number of particles in simulation:  140
+  Number of particles lost this time step:  0
+
+  Now at t=8.2516e-07, dt=7.72957e-08.
+
+Timestep 8
+  Field degrees of freedom:                 4989
+  Total number of particles in simulation:  158
+  Number of particles lost this time step:  0
+
+  Now at t=8.95325e-07, dt=7.01652e-08.
+
+Timestep 9
+  Field degrees of freedom:                 4989
+  Total number of particles in simulation:  172
+  Number of particles lost this time step:  0
+
+  Now at t=9.67852e-07, dt=7.25269e-08.
+
+Timestep 10
+  Field degrees of freedom:                 4989
+  Total number of particles in simulation:  186
+  Number of particles lost this time step:  0
+
+  Now at t=1e-06, dt=3.21481e-08.
+

--- a/tests/examples/step-20.output
+++ b/tests/examples/step-20.output
@@ -1,0 +1,5 @@
+Number of active cells: 1024
+Total number of cells: 1365
+Number of degrees of freedom: 3136 (2112+1024)
+24 CG Schur complement iterations to obtain convergence.
+Errors: ||e_p||_L2 = 0.0445032,   ||e_u||_L2 = 0.010826

--- a/tests/examples/step-5.diff
+++ b/tests/examples/step-5.diff
@@ -1,0 +1,4 @@
+323c323
+<   std::ifstream input_file("circle-grid.inp");
+---
+>   std::ifstream input_file("../../../source/step-5/circle-grid.inp");

--- a/tests/examples/step-5.output
+++ b/tests/examples/step-5.output
@@ -1,0 +1,30 @@
+Cycle 0:
+   Number of active cells: 20
+   Total number of cells: 20
+   Number of degrees of freedom: 25
+   8 CG iterations needed to obtain convergence.
+Cycle 1:
+   Number of active cells: 80
+   Total number of cells: 100
+   Number of degrees of freedom: 89
+   12 CG iterations needed to obtain convergence.
+Cycle 2:
+   Number of active cells: 320
+   Total number of cells: 420
+   Number of degrees of freedom: 337
+   21 CG iterations needed to obtain convergence.
+Cycle 3:
+   Number of active cells: 1280
+   Total number of cells: 1700
+   Number of degrees of freedom: 1313
+   38 CG iterations needed to obtain convergence.
+Cycle 4:
+   Number of active cells: 5120
+   Total number of cells: 6820
+   Number of degrees of freedom: 5185
+   70 CG iterations needed to obtain convergence.
+Cycle 5:
+   Number of active cells: 20480
+   Total number of cells: 27300
+   Number of degrees of freedom: 20609
+   136 CG iterations needed to obtain convergence.

--- a/tests/examples/step-9.diff
+++ b/tests/examples/step-9.diff
@@ -1,0 +1,9 @@
+850c850
+<     for (unsigned int cycle = 0; cycle < 10; ++cycle)
+---
+>     for (unsigned int cycle = 0; cycle < 5; ++cycle)
+875c875
+<         output_results(cycle);
+---
+>       //output_results(cycle);
+

--- a/tests/examples/step-9.output
+++ b/tests/examples/step-9.output
@@ -1,0 +1,25 @@
+Cycle 0:
+   Number of active cells:              64
+   Number of degrees of freedom:        1681
+   Iterations required for convergence: 338
+   Norm of residual at convergence:     2.91757e-11
+Cycle 1:
+   Number of active cells:              121
+   Number of degrees of freedom:        3436
+   Iterations required for convergence: 448
+   Norm of residual at convergence:     2.40051e-11
+Cycle 2:
+   Number of active cells:              238
+   Number of degrees of freedom:        6487
+   Iterations required for convergence: 535
+   Norm of residual at convergence:     2.06943e-11
+Cycle 3:
+   Number of active cells:              481
+   Number of degrees of freedom:        13510
+   Iterations required for convergence: 669
+   Norm of residual at convergence:     1.39588e-11
+Cycle 4:
+   Number of active cells:              958
+   Number of degrees of freedom:        26137
+   Iterations required for convergence: 1049
+   Norm of residual at convergence:     1.19601e-11


### PR DESCRIPTION
test/examples should include an .output file and a .diff file for each tutorial from examples/step-*/step-*.cc. The diff file typically reduces the refinement level and suppresses the non-textual output the CTest runs.