### PR TITLE
Add kokkos threads flag to set the number of thread during kokkos initialization.

### DIFF
--- a/source/base/init_finalize.cc
+++ b/source/base/init_finalize.cc
@@ -13,6 +13,7 @@
 //
 // ---------------------------------------------------------------------
 
+#include "deal.II/base/types.h"
 #include <deal.II/base/init_finalize.h>
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/multithread_info.h>
@@ -124,15 +125,18 @@ InitFinalize::InitFinalize(int                     &argc,
         if (strcmp(arg, "--help") != 0)
           argv_new.push_back(arg);
 
-      std::stringstream threads_flag;
+      if (max_num_threads != numbers::invalid_unsigned_int)
+        {
+          std::stringstream threads_flag;
 #if KOKKOS_VERSION >= 30700
-      threads_flag << "--kokkos-num-threads=" << MultithreadInfo::n_threads();
+          threads_flag << "--kokkos-num-threads=" << max_num_threads;
 #else
-      threads_flag << "--kokkos-threads=" << MultithreadInfo::n_threads();
+          threads_flag << "--kokkos-threads=" << max_num_threads;
 #endif
-      const std::string threads_flag_string = threads_flag.str();
-      argv_new.push_back(const_cast<char *>(threads_flag_string.c_str()));
-      argv_new.push_back(nullptr);
+          const std::string threads_flag_string = threads_flag.str();
+          argv_new.push_back(const_cast<char *>(threads_flag_string.c_str()));
+          argv_new.push_back(nullptr);
+        }
 
       // The first argument in Kokkos::initialize is of type int&. Hence, we
       // need to define a new variable to pass to it (instead of using argc+1


### PR DESCRIPTION
This is a patch designed to resovled issue #17089, designed by @bangerth. This pull request explicitly sets the number of kokkos threads. 

Unfortunately it doesn't work yet in the sense that it still shows the following warnings:

```
Kokkos::OpenMP::initialize WARNING: OMP_PROC_BIND environment variable not set
  In general, for best performance with OpenMP 4.0 or better set OMP_PROC_BIND=spread and OMP_PLACES=threads
  For best performance with OpenMP 3.1 set OMP_PROC_BIND=true
  For unit testing set OMP_PROC_BIND=false

MPI detected: For OpenMP binding to work as intended, MPI ranks must be bound to exclusive CPU sets.

Kokkos::OpenMP::initialize WARNING: You are likely oversubscribing your CPU cores.
                                    Detected: 16 cores per node.
                                    Detected: 8 MPI_ranks per node.
                                    Requested: 16 threads per process.
```

So help would be appreciated. 