### PR TITLE
Remove deprecated function. Update documentation.

### DIFF
--- a/include/deal.II/particles/particle_accessor.h
+++ b/include/deal.II/particles/particle_accessor.h
@@ -361,21 +361,9 @@ namespace Particles
 
     /**
      * Get a cell iterator to the cell surrounding the current particle.
-     * As particles are organized in the structure of a triangulation,
-     * but the triangulation itself is not stored in the particle this
-     * operation requires a reference to the triangulation.
      */
     const typename Triangulation<dim, spacedim>::cell_iterator &
     get_surrounding_cell() const;
-
-    /**
-     * @deprecated Deprecated version of the function with the same
-     * name above.
-     */
-    DEAL_II_DEPRECATED
-    const typename Triangulation<dim, spacedim>::cell_iterator &
-    get_surrounding_cell(
-      const Triangulation<dim, spacedim> &triangulation) const;
 
     /**
      * Write the data of this object to a stream for the purpose of
@@ -842,20 +830,6 @@ namespace Particles
   template <int dim, int spacedim>
   inline const typename Triangulation<dim, spacedim>::cell_iterator &
   ParticleAccessor<dim, spacedim>::get_surrounding_cell() const
-  {
-    Assert(state() == IteratorState::valid, ExcInternalError());
-    Assert(particles_in_cell->cell.state() == IteratorState::valid,
-           ExcInternalError());
-
-    return particles_in_cell->cell;
-  }
-
-
-
-  template <int dim, int spacedim>
-  inline const typename Triangulation<dim, spacedim>::cell_iterator &
-  ParticleAccessor<dim, spacedim>::get_surrounding_cell(
-    const Triangulation<dim, spacedim> & /*triangulation*/) const
   {
     Assert(state() == IteratorState::valid, ExcInternalError());
     Assert(particles_in_cell->cell.state() == IteratorState::valid,

--- a/tests/particles/generators_05.cc
+++ b/tests/particles/generators_05.cc
@@ -76,7 +76,7 @@ test(Function<spacedim> &probability_density_function)
         for (const auto &particle : particle_handler)
           {
             deallog << "Particle index " << particle.get_id() << " is in cell "
-                    << particle.get_surrounding_cell(tr) << std::endl;
+                    << particle.get_surrounding_cell() << std::endl;
             deallog << "Particle location: " << particle.get_location()
                     << std::endl;
           }

--- a/tests/particles/generators_06.cc
+++ b/tests/particles/generators_06.cc
@@ -79,7 +79,7 @@ test(Function<spacedim> &probability_density_function)
         for (const auto &particle : particle_handler)
           {
             deallog << "Particle index " << particle.get_id() << " is in cell "
-                    << particle.get_surrounding_cell(tr) << std::endl;
+                    << particle.get_surrounding_cell() << std::endl;
             deallog << "Particle location: " << particle.get_location()
                     << std::endl;
           }

--- a/tests/particles/generators_07.cc
+++ b/tests/particles/generators_07.cc
@@ -94,7 +94,7 @@ test()
     for (const auto &particle : particle_handler)
       {
         deallog << "Particle index " << particle.get_id() << " is in cell "
-                << particle.get_surrounding_cell(tr) << std::endl;
+                << particle.get_surrounding_cell() << std::endl;
         deallog << "Particle location: " << particle.get_location()
                 << std::endl;
       }

--- a/tests/particles/generators_08.cc
+++ b/tests/particles/generators_08.cc
@@ -91,7 +91,7 @@ test()
     for (const auto &particle : particle_handler)
       {
         deallog << "Particle index " << particle.get_id() << " is in cell "
-                << particle.get_surrounding_cell(tr) << std::endl;
+                << particle.get_surrounding_cell() << std::endl;
         deallog << "Particle location: " << particle.get_location()
                 << std::endl;
       }

--- a/tests/particles/generators_09.cc
+++ b/tests/particles/generators_09.cc
@@ -76,7 +76,7 @@ test(Function<spacedim> &probability_density_function)
         for (const auto &particle : particle_handler)
           {
             deallog << "Particle index " << particle.get_id() << " is in cell "
-                    << particle.get_surrounding_cell(tr) << std::endl;
+                    << particle.get_surrounding_cell() << std::endl;
             deallog << "Particle location: " << particle.get_location()
                     << std::endl;
           }

--- a/tests/particles/generators_10.cc
+++ b/tests/particles/generators_10.cc
@@ -76,7 +76,7 @@ test(Function<spacedim> &probability_density_function)
         for (const auto &particle : particle_handler)
           {
             deallog << "Particle index " << particle.get_id() << " is in cell "
-                    << particle.get_surrounding_cell(tr) << std::endl;
+                    << particle.get_surrounding_cell() << std::endl;
             deallog << "Particle location: " << particle.get_location()
                     << std::endl;
           }

--- a/tests/particles/generators_11.cc
+++ b/tests/particles/generators_11.cc
@@ -76,7 +76,7 @@ test(Function<spacedim> &probability_density_function)
         for (const auto &particle : particle_handler)
           {
             deallog << "Particle index " << particle.get_id() << " is in cell "
-                    << particle.get_surrounding_cell(tr) << std::endl;
+                    << particle.get_surrounding_cell() << std::endl;
             deallog << "Particle location: " << particle.get_location()
                     << std::endl;
           }

--- a/tests/particles/generators_12.cc
+++ b/tests/particles/generators_12.cc
@@ -76,7 +76,7 @@ test(Function<spacedim> &probability_density_function)
         for (const auto &particle : particle_handler)
           {
             deallog << "Particle index " << particle.get_id() << " is in cell "
-                    << particle.get_surrounding_cell(tr) << std::endl;
+                    << particle.get_surrounding_cell() << std::endl;
             deallog << "Particle location: " << particle.get_location()
                     << std::endl;
           }

--- a/tests/particles/generators_13.cc
+++ b/tests/particles/generators_13.cc
@@ -67,7 +67,7 @@ test(Function<spacedim> &probability_density_function)
     for (const auto &particle : particle_handler)
       {
         deallog << "Particle index " << particle.get_id() << " is in cell "
-                << particle.get_surrounding_cell(tr) << std::endl;
+                << particle.get_surrounding_cell() << std::endl;
         deallog << "Particle location: " << particle.get_location()
                 << std::endl;
       }

--- a/tests/particles/particle_handler_03.cc
+++ b/tests/particles/particle_handler_03.cc
@@ -68,15 +68,13 @@ test()
 
     for (const auto &particle : particle_handler)
       deallog << "Before sort particle id " << particle.get_id()
-              << " is in cell " << particle.get_surrounding_cell(tr)
-              << std::endl;
+              << " is in cell " << particle.get_surrounding_cell() << std::endl;
 
     particle_handler.sort_particles_into_subdomains_and_cells();
 
     for (const auto &particle : particle_handler)
       deallog << "After sort particle id " << particle.get_id()
-              << " is in cell " << particle.get_surrounding_cell(tr)
-              << std::endl;
+              << " is in cell " << particle.get_surrounding_cell() << std::endl;
 
     // Move all points up by 0.5. This will change cell for particle 1, and will
     // move particle 2 out of the domain. Note that we need to change the
@@ -89,8 +87,7 @@ test()
     particle_handler.sort_particles_into_subdomains_and_cells();
     for (const auto &particle : particle_handler)
       deallog << "After shift particle id " << particle.get_id()
-              << " is in cell " << particle.get_surrounding_cell(tr)
-              << std::endl;
+              << " is in cell " << particle.get_surrounding_cell() << std::endl;
   }
 
   deallog << "OK" << std::endl;

--- a/tests/particles/particle_handler_04.cc
+++ b/tests/particles/particle_handler_04.cc
@@ -73,7 +73,7 @@ test()
 
         for (const auto &particle : particle_handler)
           deallog << "Before sort particle id " << particle.get_id()
-                  << " is in cell " << particle.get_surrounding_cell(tr)
+                  << " is in cell " << particle.get_surrounding_cell()
                   << " on process "
                   << Utilities::MPI::this_mpi_process(tr.get_communicator())
                   << std::flush << std::endl;
@@ -85,7 +85,7 @@ test()
 
     for (const auto &particle : particle_handler)
       deallog << "After sort particle id " << particle.get_id()
-              << " is in cell " << particle.get_surrounding_cell(tr)
+              << " is in cell " << particle.get_surrounding_cell()
               << " on process "
               << Utilities::MPI::this_mpi_process(tr.get_communicator())
               << std::flush << std::endl;
@@ -101,7 +101,7 @@ test()
     particle_handler.sort_particles_into_subdomains_and_cells();
     for (const auto &particle : particle_handler)
       deallog << "After shift particle id " << particle.get_id()
-              << " is in cell " << particle.get_surrounding_cell(tr)
+              << " is in cell " << particle.get_surrounding_cell()
               << " on process "
               << Utilities::MPI::this_mpi_process(tr.get_communicator())
               << std::flush << std::endl;

--- a/tests/particles/particle_handler_05.cc
+++ b/tests/particles/particle_handler_05.cc
@@ -101,8 +101,7 @@ test()
 
     for (const auto &particle : particle_handler)
       deallog << "Before refinement particle id " << particle.get_id()
-              << " is in cell " << particle.get_surrounding_cell(tr)
-              << std::endl;
+              << " is in cell " << particle.get_surrounding_cell() << std::endl;
 
     // Check that all particles are moved to children
     particle_handler.prepare_for_coarsening_and_refinement();
@@ -111,8 +110,7 @@ test()
 
     for (const auto &particle : particle_handler)
       deallog << "After refinement particle id " << particle.get_id()
-              << " is in cell " << particle.get_surrounding_cell(tr)
-              << std::endl;
+              << " is in cell " << particle.get_surrounding_cell() << std::endl;
 
     // Reverse the refinement and check again
     for (auto cell = tr.begin_active(); cell != tr.end(); ++cell)
@@ -124,8 +122,7 @@ test()
 
     for (const auto &particle : particle_handler)
       deallog << "After coarsening particle id " << particle.get_id()
-              << " is in cell " << particle.get_surrounding_cell(tr)
-              << std::endl;
+              << " is in cell " << particle.get_surrounding_cell() << std::endl;
   }
 
   deallog << "OK" << std::endl;

--- a/tests/particles/particle_handler_07.cc
+++ b/tests/particles/particle_handler_07.cc
@@ -60,7 +60,7 @@ test()
          particle != particle_handler.end();
          ++particle)
       deallog << "Particle id " << particle->get_id() << " is in cell "
-              << particle->get_surrounding_cell(tr) << std::endl
+              << particle->get_surrounding_cell() << std::endl
               << "     at location " << particle->get_location() << std::endl
               << "     at reference location "
               << particle->get_reference_location() << std::endl;

--- a/tests/particles/particle_handler_fully_distributed_01.cc
+++ b/tests/particles/particle_handler_fully_distributed_01.cc
@@ -87,7 +87,7 @@ test()
 
         for (const auto &particle : particle_handler)
           deallog << "Before sort particle id " << particle.get_id()
-                  << " is in cell " << particle.get_surrounding_cell(tria_pft)
+                  << " is in cell " << particle.get_surrounding_cell()
                   << " on process "
                   << Utilities::MPI::this_mpi_process(
                        tria_pft.get_communicator())
@@ -100,7 +100,7 @@ test()
 
     for (const auto &particle : particle_handler)
       deallog << "After sort particle id " << particle.get_id()
-              << " is in cell " << particle.get_surrounding_cell(tria_pft)
+              << " is in cell " << particle.get_surrounding_cell()
               << " on process "
               << Utilities::MPI::this_mpi_process(tria_pft.get_communicator())
               << std::flush << std::endl;
@@ -116,7 +116,7 @@ test()
     particle_handler.sort_particles_into_subdomains_and_cells();
     for (const auto &particle : particle_handler)
       deallog << "After shift particle id " << particle.get_id()
-              << " is in cell " << particle.get_surrounding_cell(tria_pft)
+              << " is in cell " << particle.get_surrounding_cell()
               << " on process "
               << Utilities::MPI::this_mpi_process(tria_pft.get_communicator())
               << std::flush << std::endl;

--- a/tests/particles/particle_handler_refinement_outside_cell.cc
+++ b/tests/particles/particle_handler_refinement_outside_cell.cc
@@ -65,8 +65,7 @@ test()
 
     for (const auto &particle : particle_handler)
       deallog << "Before refinement particle id " << particle.get_id()
-              << " is in cell " << particle.get_surrounding_cell(tr)
-              << std::endl;
+              << " is in cell " << particle.get_surrounding_cell() << std::endl;
 
     // Check that all particles are moved to children
     particle_handler.prepare_for_coarsening_and_refinement();
@@ -75,8 +74,7 @@ test()
 
     for (const auto &particle : particle_handler)
       deallog << "After refinement particle id " << particle.get_id()
-              << " is in cell " << particle.get_surrounding_cell(tr)
-              << std::endl;
+              << " is in cell " << particle.get_surrounding_cell() << std::endl;
 
     // Reverse the refinement and check again
     for (auto cell = tr.begin_active(); cell != tr.end(); ++cell)
@@ -88,8 +86,7 @@ test()
 
     for (const auto &particle : particle_handler)
       deallog << "After coarsening particle id " << particle.get_id()
-              << " is in cell " << particle.get_surrounding_cell(tr)
-              << std::endl;
+              << " is in cell " << particle.get_surrounding_cell() << std::endl;
   }
 
   deallog << "OK" << std::endl;

--- a/tests/particles/particle_handler_refinement_outside_cell_02.cc
+++ b/tests/particles/particle_handler_refinement_outside_cell_02.cc
@@ -64,8 +64,7 @@ test()
 
     for (const auto &particle : particle_handler)
       deallog << "Before refinement particle id " << particle.get_id()
-              << " is in cell " << particle.get_surrounding_cell(tr)
-              << std::endl;
+              << " is in cell " << particle.get_surrounding_cell() << std::endl;
 
     // Check that all particles are moved to children
     particle_handler.prepare_for_coarsening_and_refinement();
@@ -74,8 +73,7 @@ test()
 
     for (const auto &particle : particle_handler)
       deallog << "After refinement particle id " << particle.get_id()
-              << " is in cell " << particle.get_surrounding_cell(tr)
-              << std::endl;
+              << " is in cell " << particle.get_surrounding_cell() << std::endl;
 
     // Reverse the refinement and check again
     for (auto cell = tr.begin_active(); cell != tr.end(); ++cell)
@@ -87,8 +85,7 @@ test()
 
     for (const auto &particle : particle_handler)
       deallog << "After coarsening particle id " << particle.get_id()
-              << " is in cell " << particle.get_surrounding_cell(tr)
-              << std::endl;
+              << " is in cell " << particle.get_surrounding_cell() << std::endl;
   }
 
   deallog << "OK" << std::endl;

--- a/tests/particles/particle_handler_serial_03.cc
+++ b/tests/particles/particle_handler_serial_03.cc
@@ -69,15 +69,13 @@ test()
 
     for (const auto &particle : particle_handler)
       deallog << "Before sort particle id " << particle.get_id()
-              << " is in cell " << particle.get_surrounding_cell(tr)
-              << std::endl;
+              << " is in cell " << particle.get_surrounding_cell() << std::endl;
 
     particle_handler.sort_particles_into_subdomains_and_cells();
 
     for (const auto &particle : particle_handler)
       deallog << "After sort particle id " << particle.get_id()
-              << " is in cell " << particle.get_surrounding_cell(tr)
-              << std::endl;
+              << " is in cell " << particle.get_surrounding_cell() << std::endl;
 
     // Move all points up by 0.5. This will change cell for particle 1, and will
     // move particle 2 out of the domain. Note that we need to change the
@@ -90,8 +88,7 @@ test()
     particle_handler.sort_particles_into_subdomains_and_cells();
     for (const auto &particle : particle_handler)
       deallog << "After shift particle id " << particle.get_id()
-              << " is in cell " << particle.get_surrounding_cell(tr)
-              << std::endl;
+              << " is in cell " << particle.get_surrounding_cell() << std::endl;
   }
 
   deallog << "OK" << std::endl;

--- a/tests/particles/particle_handler_serial_07.cc
+++ b/tests/particles/particle_handler_serial_07.cc
@@ -60,7 +60,7 @@ test()
          particle != particle_handler.end();
          ++particle)
       deallog << "Particle id " << particle->get_id() << " is in cell "
-              << particle->get_surrounding_cell(tr) << std::endl
+              << particle->get_surrounding_cell() << std::endl
               << "     at location " << particle->get_location() << std::endl
               << "     at reference location "
               << particle->get_reference_location() << std::endl;

--- a/tests/particles/particle_handler_shared_01.cc
+++ b/tests/particles/particle_handler_shared_01.cc
@@ -83,8 +83,7 @@ test()
 
         for (const auto &particle : particle_handler)
           deallog << "Before sort particle id " << particle.get_id()
-                  << " is in cell "
-                  << particle.get_surrounding_cell(tria_shared)
+                  << " is in cell " << particle.get_surrounding_cell()
                   << " on process "
                   << Utilities::MPI::this_mpi_process(
                        tria_shared.get_communicator())
@@ -97,7 +96,7 @@ test()
 
     for (const auto &particle : particle_handler)
       deallog << "After sort particle id " << particle.get_id()
-              << " is in cell " << particle.get_surrounding_cell(tria_shared)
+              << " is in cell " << particle.get_surrounding_cell()
               << " on process "
               << Utilities::MPI::this_mpi_process(
                    tria_shared.get_communicator())
@@ -114,7 +113,7 @@ test()
     particle_handler.sort_particles_into_subdomains_and_cells();
     for (const auto &particle : particle_handler)
       deallog << "After shift particle id " << particle.get_id()
-              << " is in cell " << particle.get_surrounding_cell(tria_shared)
+              << " is in cell " << particle.get_surrounding_cell()
               << " on process "
               << Utilities::MPI::this_mpi_process(
                    tria_shared.get_communicator())

--- a/tests/particles/step-68.cc
+++ b/tests/particles/step-68.cc
@@ -480,8 +480,7 @@ namespace Step68
     auto particle = particle_handler.begin();
     while (particle != particle_handler.end())
       {
-        const auto cell =
-          particle->get_surrounding_cell(background_triangulation);
+        const auto cell = particle->get_surrounding_cell();
         const auto dh_cell =
           typename DoFHandler<dim>::cell_iterator(*cell, &fluid_dh);
 

--- a/tests/serialization/particle_handler_01.cc
+++ b/tests/serialization/particle_handler_01.cc
@@ -99,8 +99,7 @@ test()
        particle != particle_handler.end();
        ++particle)
     deallog << "Before serialization particle id " << particle->get_id()
-            << " is in cell " << particle->get_surrounding_cell(tr)
-            << std::endl;
+            << " is in cell " << particle->get_surrounding_cell() << std::endl;
 
   // save data to archive
   std::ostringstream oss;
@@ -129,7 +128,7 @@ test()
        particle != particle_handler.end();
        ++particle)
     deallog << "In between particle id " << particle->get_id() << " is in cell "
-            << particle->get_surrounding_cell(tr) << std::endl;
+            << particle->get_surrounding_cell() << std::endl;
 
   // verify correctness of the serialization. Note that the deserialization of
   // the particle handler has to happen before the triangulation (otherwise it
@@ -148,8 +147,7 @@ test()
        particle != particle_handler.end();
        ++particle)
     deallog << "After serialization particle id " << particle->get_id()
-            << " is in cell " << particle->get_surrounding_cell(tr)
-            << std::endl;
+            << " is in cell " << particle->get_surrounding_cell() << std::endl;
 
   deallog << "OK" << std::endl << std::endl;
 }

--- a/tests/serialization/particle_handler_02.cc
+++ b/tests/serialization/particle_handler_02.cc
@@ -103,8 +103,7 @@ test()
        particle != particle_handler.end();
        ++particle)
     deallog << "Before serialization particle id " << particle->get_id()
-            << " is in cell " << particle->get_surrounding_cell(tr)
-            << std::endl;
+            << " is in cell " << particle->get_surrounding_cell() << std::endl;
 
   // save data to archive
   std::ostringstream oss;
@@ -146,7 +145,7 @@ test()
        particle != particle_handler.end();
        ++particle)
     deallog << "In between particle id " << particle->get_id() << " is in cell "
-            << particle->get_surrounding_cell(tr) << std::endl;
+            << particle->get_surrounding_cell() << std::endl;
 
   // verify correctness of the serialization. Note that the deserialization of
   // the particle handler has to happen before the triangulation (otherwise it
@@ -178,8 +177,7 @@ test()
        particle != particle_handler.end();
        ++particle)
     deallog << "After serialization particle id " << particle->get_id()
-            << " is in cell " << particle->get_surrounding_cell(tr)
-            << std::endl;
+            << " is in cell " << particle->get_surrounding_cell() << std::endl;
 
   deallog << "OK" << std::endl << std::endl;
 }

--- a/tests/serialization/particle_handler_03.cc
+++ b/tests/serialization/particle_handler_03.cc
@@ -98,8 +98,7 @@ test()
        particle != particle_handler.end();
        ++particle)
     deallog << "Before serialization particle id " << particle->get_id()
-            << " is in cell " << particle->get_surrounding_cell(tr)
-            << std::endl;
+            << " is in cell " << particle->get_surrounding_cell() << std::endl;
 
   // save data to archive
   std::ostringstream oss;
@@ -128,7 +127,7 @@ test()
        particle != particle_handler.end();
        ++particle)
     deallog << "In between particle id " << particle->get_id() << " is in cell "
-            << particle->get_surrounding_cell(tr) << std::endl;
+            << particle->get_surrounding_cell() << std::endl;
 
   // verify correctness of the serialization. Note that the deserialization of
   // the particle handler has to happen before the triangulation (otherwise it
@@ -147,8 +146,7 @@ test()
        particle != particle_handler.end();
        ++particle)
     deallog << "After serialization particle id " << particle->get_id()
-            << " is in cell " << particle->get_surrounding_cell(tr)
-            << std::endl;
+            << " is in cell " << particle->get_surrounding_cell() << std::endl;
 
   deallog << "OK" << std::endl << std::endl;
 }

--- a/tests/serialization/particle_handler_04.cc
+++ b/tests/serialization/particle_handler_04.cc
@@ -109,8 +109,7 @@ test()
        particle != particle_handler.end();
        ++particle)
     deallog << "Before serialization particle id " << particle->get_id()
-            << " is in cell " << particle->get_surrounding_cell(tr)
-            << std::endl;
+            << " is in cell " << particle->get_surrounding_cell() << std::endl;
 
   // save data to archive
   std::ostringstream oss;
@@ -138,7 +137,7 @@ test()
        particle != particle_handler.end();
        ++particle)
     deallog << "In between particle id " << particle->get_id() << " is in cell "
-            << particle->get_surrounding_cell(tr) << std::endl;
+            << particle->get_surrounding_cell() << std::endl;
 
   // verify correctness of the serialization. Note that the deserialization of
   // the particle handler has to happen before the triangulation (otherwise it
@@ -157,8 +156,7 @@ test()
        particle != particle_handler.end();
        ++particle)
     deallog << "After serialization particle id " << particle->get_id()
-            << " is in cell " << particle->get_surrounding_cell(tr)
-            << std::endl;
+            << " is in cell " << particle->get_surrounding_cell() << std::endl;
 
   deallog << "OK" << std::endl << std::endl;
 }

--- a/tests/simplex/step-68.cc
+++ b/tests/simplex/step-68.cc
@@ -346,8 +346,7 @@ namespace Step68
     auto particle = particle_handler.begin();
     while (particle != particle_handler.end())
       {
-        const auto cell =
-          particle->get_surrounding_cell(background_triangulation);
+        const auto cell = particle->get_surrounding_cell();
         const auto dh_cell =
           typename DoFHandler<dim>::cell_iterator(*cell, &fluid_dh);
 


### PR DESCRIPTION
Fix the documentation of one function. Remove the deprecated function this documentation was copied from. The function was deprecated 3 years ago, and was DEAL_II_DEPRECATED for the past two releases.