### PR TITLE
step-32 Assert failure with 1 MPI rank

### DIFF
--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -3328,9 +3328,6 @@ namespace Step32
 
         temperature_solution     = distributed_temp1;
         old_temperature_solution = distributed_temp2;
-
-        Assert(old_temperature_solution.has_ghost_elements(),
-               ExcInternalError());
       }
 
       {


### PR DESCRIPTION
When running on one rank, there are of course no ghost elements, and this tutorial step-32 throws an error. This assert was introduced in #16335.