### PR TITLE
Make test/example/update_diffs script not fail

### DIFF
--- a/tests/examples/update_diffs.sh
+++ b/tests/examples/update_diffs.sh
@@ -34,8 +34,7 @@ for file in ${diff_files}; do
     echo diff "${source_file}" "${modified_file}" \> "${file}"
     diff "${source_file}" "${modified_file}" > "${file}"
   else
-    echo "No matching .cc files found for ${file}"
-    exit 1
+    echo "No matching .cc files found for ${file}: source=${source_file} modified=${modified_file}"
   fi
 done
 


### PR DESCRIPTION
If your deal.II configuration does not have a certain feature enabled (like MPI or PETSc), the corresponding tests in tests/examples/ are correctly disabled. This would make the "update_diffs.sh" script fail. Let's just ignore the error and continue to process all files.