### PR TITLE
Fix a compilation error with Kokkos+musl libc.

### DIFF
--- a/bundled/kokkos-3.7.00/core/src/Kokkos_Macros.hpp
+++ b/bundled/kokkos-3.7.00/core/src/Kokkos_Macros.hpp
@@ -653,7 +653,9 @@ static constexpr bool kokkos_omp_on_host() { return false; }
 #if (defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG) ||  \
      defined(KOKKOS_COMPILER_INTEL) || defined(KOKKOS_COMPILER_PGI)) && \
     !defined(_WIN32)
+#if __has_include(<execinfo.h>)
 #define KOKKOS_IMPL_ENABLE_STACKTRACE
+#endif
 #define KOKKOS_IMPL_ENABLE_CXXABI
 #endif
 


### PR DESCRIPTION
Same as https://github.com/kokkos/kokkos/commit/a7c7a4126de76da7f9f7ac157770183829839640.

This is a glibc, not standard, header so this feature doesn't work when we have a different libc. I'm happy to report that everything else works fine with musl - we're pretty good at staying standards-compliant.

This bug was actually reported to Kokkos in 2020 and fixed in Kokkos 4. Do we want to instead just update to Kokkos 4? That's been out for a year.