### PR TITLE
MatrixCreator: use queue_size=1 in debug mode

### DIFF
--- a/include/deal.II/numerics/matrix_creator.templates.h
+++ b/include/deal.II/numerics/matrix_creator.templates.h
@@ -781,7 +781,14 @@ namespace MatrixCreator
                                                       &rhs_vector);
       },
       assembler_data,
-      copy_data);
+      copy_data
+#ifdef DEBUG
+      // use chunk_size = 1 to make multithreading bugs/races more likely:
+      ,
+      /* queue_length (default) = */ 2 * MultithreadInfo::n_threads(),
+      /* chunk_size = */ 1
+#endif
+    );
 
     matrix.compress(VectorOperation::add);
   }


### PR DESCRIPTION
as mentioned in #17131 and #8516

This should show that FEFieldFunction is not threadsafe.