### PR TITLE
Fix rare division by zero

### DIFF
--- a/doc/news/changes/minor/20240618Gassmoeller
+++ b/doc/news/changes/minor/20240618Gassmoeller
@@ -1,0 +1,5 @@
+Fixed: The ParticleHandler could cause a division by zero
+for certain mappings when sorting particles that are
+located almost exactly on mesh vertices. This is fixed now.
+<br>
+(Rene Gassmoeller, 2024/06/18)

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -1348,7 +1348,12 @@ namespace Particles
               current_cell, out_particle->get_location(), *mapping);
           Tensor<1, spacedim> vertex_to_particle =
             out_particle->get_location() - current_cell->vertex(closest_vertex);
-          vertex_to_particle /= vertex_to_particle.norm();
+
+          // Only normalize if vector is larger than zero, the algorithm below
+          // works fine for zero vectors.
+          if (vertex_to_particle.norm() >
+              100. * std::numeric_limits<double>::epsilon())
+            vertex_to_particle /= vertex_to_particle.norm();
 
           const unsigned int closest_vertex_index =
             current_cell->vertex_index(closest_vertex);


### PR DESCRIPTION
This fixes a small bug that appeared occasionally in ASPECT, but is incredibly hard to reproduce, and I am still not successful in making a deal.II test for it (it appeared in https://github.com/geodynamics/aspect/pull/5815#issuecomment-2173941045 and https://github.com/geodynamics/aspect/issues/5882). 

In essence the code is normalizing a vector from closest mesh vertex to particle location. Obviously we cannot do that if the vector is 0. What makes this so hard to reproduce is that if the distance is 0 the particle should have been found in its old cell (with a small tolerance we allow) and therefore we should never get to this piece of code. At least for some mappings (we saw it for MappingQEulerian(1) and MappingQ(4) with a spherical manifold) it seems possible to find a location that is considered outside of the old cell by the mapping, but still essentially on top of one of the mesh vertices.

This PR simply disables the normalization for very small vectors, which is not a problem, because the algorithm just uses the vector to decide which cells to search first (and if the particle is on top of a mesh vertex, we can search the cells in any order and should find the new cell quickly).

