### PR TITLE
Revert "MatrixCreator: use queue_size=1 in debug mode"

### DIFF
--- a/include/deal.II/numerics/matrix_creator.templates.h
+++ b/include/deal.II/numerics/matrix_creator.templates.h
@@ -781,14 +781,7 @@ namespace MatrixCreator
                                                       &rhs_vector);
       },
       assembler_data,
-      copy_data
-#ifdef DEBUG
-      // use chunk_size = 1 to make multithreading bugs/races more likely:
-      ,
-      /* queue_length (default) = */ 2 * MultithreadInfo::n_threads(),
-      /* chunk_size = */ 1
-#endif
-    );
+      copy_data);
 
     matrix.compress(VectorOperation::add);
   }


### PR DESCRIPTION
This reverts commit c3bbafbbf0c1018887f4f07b96dd856f35738e5e #17137

This was not meant to be merged before we fix the issue #17131