### PR TITLE
FEFaceEvaluation: Arrange simplices face gradients contiguously

### DIFF
--- a/include/deal.II/matrix_free/shape_info.h
+++ b/include/deal.II/matrix_free/shape_info.h
@@ -374,7 +374,7 @@ namespace internal
        * quadrature points for all faces, orientations, and directions
        * (no tensor-product structure exploited).
        */
-      Table<4, Number> shape_gradients_face;
+      Table<3, Number> shape_gradients_face;
     };
 
 

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -425,10 +425,10 @@ namespace internal
                                           n_max_face_orientations,
                                           n_dofs * n_q_points_face_max});
 
-                shape_gradients_face.reinit({n_faces,
-                                             n_max_face_orientations,
-                                             dim,
-                                             n_dofs * n_q_points_face_max});
+                shape_gradients_face.reinit(
+                  {n_faces,
+                   n_max_face_orientations,
+                   dim * n_dofs * n_q_points_face_max});
 
                 for (unsigned int f = 0; f < n_faces; ++f)
                   {
@@ -464,8 +464,10 @@ namespace internal
                               const auto grad = fe.shape_grad(i, point);
 
                               for (unsigned int d = 0; d < dim; ++d)
-                                shape_gradients_face(
-                                  f, o, d, i * n_q_points_face + q) = grad[d];
+                                shape_gradients_face(f,
+                                                     o,
+                                                     i * dim * n_q_points_face +
+                                                       q * dim + d) = grad[d];
                             }
                       }
                   }


### PR DESCRIPTION
Follow up to #16970. This PR arranges the face gradients for simplex elements in `ShapeInfo::shape_gradients_face` contiguously, and directly calls `apply_matrix_vector_product` instead of the  `EvaluatorTensorProduct` object. This makes the operations on the face consistent with the operations on the cells.
The rearrangement of the entries is necessary to be able to switch from a matrix-vector product to a more performant matrix-matrix product, as mentioned in #16984.