### PR TITLE
Enable matrix-free loops with ArrayView arguments

### DIFF
--- a/doc/news/changes/minor/20240624Kronbichler
+++ b/doc/news/changes/minor/20240624Kronbichler
@@ -1,0 +1,6 @@
+New: MatrixFree::loop() and MatrixFree::cell_loop() as well as
+FEEvaluation/FEFaceEvaluation can now also be used with ArrayView
+arguments. This allows to wrap externally managed vectors into the matrix-free
+facilities of deal.II.
+<br>
+(Martin Kronbichler, 2024/06/24)

--- a/include/deal.II/matrix_free/type_traits.h
+++ b/include/deal.II/matrix_free/type_traits.h
@@ -28,13 +28,14 @@
 DEAL_II_NAMESPACE_OPEN
 
 #ifndef DOXYGEN
+
 namespace internal
 {
   //
   // type traits for FEEvaluation
   //
 
-  // a helper type-trait that leverage SFINAE to figure out if type T has
+  // a helper type-trait leveraging SFINAE to figure out if type T has
   // ... T::local_element() const
   template <typename T>
   using local_element_t = decltype(std::declval<const T>().local_element(0));
@@ -44,7 +45,7 @@ namespace internal
 
 
 
-  // a helper type-trait that leverage SFINAE to figure out if type T has
+  // a helper type-trait leveraging SFINAE to figure out if type T has
   // void T::add_local_element(const uint, const typename T::value_type)
   template <typename T>
   using add_local_element_t =
@@ -56,7 +57,7 @@ namespace internal
 
 
 
-  // a helper type-trait that leverage SFINAE to figure out if type T has
+  // a helper type-trait leveraging SFINAE to figure out if type T has
   // void T::set_local_element(const uint, const typename T::value_type)
   template <typename T>
   using set_local_element_t =
@@ -65,7 +66,6 @@ namespace internal
   template <typename T>
   constexpr bool has_set_local_element =
     is_supported_operation<set_local_element_t, T>;
-
 
 
   // same as above to check
@@ -101,27 +101,6 @@ namespace internal
   template <typename T>
   constexpr bool has_shared_vector_data =
     is_supported_operation<shared_vector_data_t, T>;
-
-
-
-  // type trait for vector T and Number to see if
-  // we can do vectorized load/save.
-  // for VectorReader and VectorDistributorLocalToGlobal we assume that
-  // if both begin() and local_element()
-  // exist, then begin() + offset == local_element(offset)
-  template <typename T, typename Number>
-  struct is_vectorizable
-  {
-    static const bool value =
-      has_begin<T> &&
-      (has_local_element<T> ||
-       is_serial_vector<std::remove_const_t<T>>::value) &&
-      std::is_same_v<typename T::value_type, Number>;
-  };
-
-  // We need to have a separate declaration for static const members
-  template <typename T, typename Number>
-  const bool is_vectorizable<T, Number>::value;
 
 
   //
@@ -176,17 +155,6 @@ namespace internal
   constexpr bool has_communication_block_size =
     is_supported_operation<communication_block_size_t, T>;
 
-
-
-  // type trait for vector T to see if
-  // we need to do any data exchange for this vector type at all.
-  // is_serial_vector<> would have been enough, but in some circumstances
-  // (like calculation of diagonals for matrix-free operators)
-  // a dummy InVector == unsigned int is provided.
-  // Thus we have to treat this case as well.
-  template <class T, class IsSerialVectorNotSpecialized = void>
-  using not_parallel_vector_t = std::bool_constant<is_serial_vector<T>::value>;
-
   /**
    * A predicate stating whether something is a vector type. We test this
    * by seeing whether the `is_serial_vector` type is declared for the
@@ -212,6 +180,54 @@ namespace internal
   constexpr bool is_not_parallel_vector =
     (is_supported_operation<is_vector_type, VectorType> == false) ||
     (is_supported_operation<is_serial_vector_type, VectorType> == true);
+
+
+
+  /**
+   * A type trait for vector T indicating serial vectors with access through
+   * operator[], which are the deal.II serial vectors and ArrayView<Number>
+   */
+  template <typename VectorType>
+  struct is_serial_vector_or_array
+  {
+    static const bool value =
+      is_supported_operation<is_serial_vector_type, VectorType>;
+  };
+
+  /**
+   * A type trait for vector T indicating serial vectors with access through
+   * operator[], which are the deal.II serial vectors and ArrayView<Number>
+   */
+  template <typename Number>
+  struct is_serial_vector_or_array<dealii::ArrayView<Number>>
+  {
+    static const bool value = true;
+  };
+
+  // We need to have a separate declaration for static const members
+  template <typename VectorType>
+  const bool is_serial_vector_or_array<VectorType>::value;
+
+
+
+  // type trait for vector T and Number to see if
+  // we can do vectorized load/save.
+  // for VectorReader and VectorDistributorLocalToGlobal we assume that
+  // if both begin() and local_element()
+  // exist, then begin() + offset == local_element(offset)
+  template <typename T, typename Number>
+  struct is_vectorizable
+  {
+    static const bool value =
+      has_begin<T> &&
+      (has_local_element<T> || is_serial_vector_or_array<T>::value) &&
+      std::is_same_v<typename T::value_type, Number>;
+  };
+
+  // We need to have a separate declaration for static const members
+  template <typename T, typename Number>
+  const bool is_vectorizable<T, Number>::value;
+
 } // namespace internal
 #endif
 

--- a/include/deal.II/matrix_free/vector_access_internal.h
+++ b/include/deal.II/matrix_free/vector_access_internal.h
@@ -35,30 +35,28 @@ namespace internal
 {
   // below we use type-traits from matrix-free/type_traits.h
 
-  // access to generic const vectors that have operator ().
-  // FIXME: this is wrong for Trilinos/PETSc MPI vectors
-  // where we should first do Partitioner::local_to_global()
-  template <
-    typename VectorType,
-    std::enable_if_t<!has_local_element<VectorType>, VectorType> * = nullptr>
+
+
+  // access to serial const vectors that have operator[].
+  template <typename VectorType,
+            std::enable_if_t<is_serial_vector_or_array<VectorType>::value,
+                             VectorType> * = nullptr>
   inline typename VectorType::value_type
   vector_access(const VectorType &vec, const unsigned int entry)
   {
-    return vec(entry);
+    return vec[entry];
   }
 
 
 
-  // access to generic non-const vectors that have operator ().
-  // FIXME: this is wrong for Trilinos/PETSc MPI vectors
-  // where we should first do Partitioner::local_to_global()
-  template <
-    typename VectorType,
-    std::enable_if_t<!has_local_element<VectorType>, VectorType> * = nullptr>
+  // access to serial non-const vectors that have operator[].
+  template <typename VectorType,
+            std::enable_if_t<is_serial_vector_or_array<VectorType>::value,
+                             VectorType> * = nullptr>
   inline typename VectorType::value_type &
   vector_access(VectorType &vec, const unsigned int entry)
   {
-    return vec(entry);
+    return vec[entry];
   }
 
 
@@ -136,7 +134,7 @@ namespace internal
                            const types::global_dof_index          entry,
                            const typename VectorType::value_type &val)
   {
-    vec(entry) += val;
+    vec[entry] += val;
   }
 
 
@@ -483,7 +481,7 @@ namespace internal
                        const VectorType             &vec,
                        Number                       &res) const
     {
-      res = vec(index);
+      res = vec[index];
     }
 
 
@@ -953,7 +951,7 @@ namespace internal
                        VectorType                   &vec,
                        Number                       &res) const
     {
-      vec(index) = res;
+      vec[index] = res;
     }
 
 

--- a/tests/matrix_free/fe_evaluation_type_traits.cc
+++ b/tests/matrix_free/fe_evaluation_type_traits.cc
@@ -71,14 +71,14 @@ public:
   using value_type = Number;
 
   Number
-  operator()(const unsigned int) const
+  operator[](const unsigned int) const
   {
     deallog << "Dummy2::operator() const" << std::endl;
     return Number();
   }
 
   Number &
-  operator()(const unsigned int)
+  operator[](const unsigned int)
   {
     deallog << "Dummy2::operator()" << std::endl;
     return dummy;
@@ -112,7 +112,7 @@ main()
   // we expect local_element() to be called
   deallog << "internal::vector_access:" << std::endl;
   internal::vector_access(dummy, 0);
-  internal::vector_access(dummy2, 0);
+  // internal::vector_access(dummy2, 0);
 
 
   // now check has_partitioners_are_compatible:

--- a/tests/matrix_free/fe_evaluation_type_traits.with_trilinos=true.output
+++ b/tests/matrix_free/fe_evaluation_type_traits.with_trilinos=true.output
@@ -7,7 +7,6 @@ DEAL::Dummy2 = 0
 DEAL::Vector = 0
 DEAL::internal::vector_access:
 DEAL::Dummy::local_element()
-DEAL::Dummy2::operator()
 DEAL::has_partitioners_are_compatible:
 DEAL::LinearAlgebra::distributed::Vector = 1
 DEAL::TrilinosWrappers::MPI::Vector = 0

--- a/tests/matrix_free/matrix_vector_25.cc
+++ b/tests/matrix_free/matrix_vector_25.cc
@@ -1,0 +1,140 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+
+// similar test as matrix_vector_01, but using ArrayView instead of
+// dealii::Vector
+
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_values.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/manifold_lib.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/sparse_matrix.h>
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include <iostream>
+
+#include "../tests.h"
+
+#include "matrix_vector_mf.h"
+
+
+template <int dim, int fe_degree>
+void
+test();
+
+
+
+template <int dim, typename number>
+void
+do_test(const DoFHandler<dim>           &dof,
+        const AffineConstraints<double> &constraints)
+{
+  deallog << "Testing " << dof.get_fe().get_name() << std::endl;
+
+  MappingQ<dim>           mapping(dof.get_fe().degree);
+  MatrixFree<dim, number> mf_data;
+  {
+    const QGauss<1> quad(dof.get_fe().degree + 1);
+    typename MatrixFree<dim, number>::AdditionalData data;
+    data.tasks_parallel_scheme =
+      MatrixFree<dim, number>::AdditionalData::partition_partition;
+
+    mf_data.reinit(mapping, dof, constraints, quad, data);
+  }
+
+  Vector<number> in(dof.n_dofs()), out(dof.n_dofs());
+  Vector<number> in_dist(dof.n_dofs());
+  Vector<number> out_dist(in_dist);
+
+  for (unsigned int i = 0; i < dof.n_dofs(); ++i)
+    {
+      if (constraints.is_constrained(i))
+        continue;
+      const double entry = random_value<double>();
+      in(i)              = entry;
+      in_dist(i)         = entry;
+    }
+
+  MatrixFreeTest<dim, -1, number, Vector<number>, 0> mf_reference(mf_data);
+  mf_reference.vmult(out, in);
+
+  MatrixFreeTest<dim, -1, number, dealii::ArrayView<number>, 0> mf(mf_data);
+  ArrayView<number> out_view = make_array_view(out_dist);
+  mf.vmult(out_view, make_array_view(in_dist));
+
+
+  {
+    out_dist -= out;
+    const double diff_norm = out_dist.linfty_norm() / out.linfty_norm();
+    deallog << "Norm of difference: " << diff_norm << std::endl << std::endl;
+  }
+
+  mf.vmult(out_view, make_array_view(in_dist));
+
+  {
+    out_dist -= out;
+    const double diff_norm = out_dist.linfty_norm() / out.linfty_norm();
+    deallog << "Norm of difference: " << diff_norm << std::endl << std::endl;
+  }
+}
+
+template <int dim>
+void
+test(const unsigned int fe_degree)
+{
+  Triangulation<dim> tria;
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(5 - dim);
+
+  FE_Q<dim>       fe(fe_degree);
+  DoFHandler<dim> dof(tria);
+  dof.distribute_dofs(fe);
+  AffineConstraints<double> constraints;
+  constraints.close();
+
+  do_test<dim, double>(dof, constraints);
+}
+
+
+
+int
+main()
+{
+  initlog();
+
+  {
+    deallog.push("2d");
+    test<2>(1);
+    test<2>(2);
+    deallog.pop();
+    deallog.push("3d");
+    test<3>(2);
+    deallog.pop();
+  }
+}

--- a/tests/matrix_free/matrix_vector_25.output
+++ b/tests/matrix_free/matrix_vector_25.output
@@ -1,0 +1,16 @@
+
+DEAL:2d::Testing FE_Q<2>(1)
+DEAL:2d::Norm of difference: 0.00000
+DEAL:2d::
+DEAL:2d::Norm of difference: 0.00000
+DEAL:2d::
+DEAL:2d::Testing FE_Q<2>(2)
+DEAL:2d::Norm of difference: 0.00000
+DEAL:2d::
+DEAL:2d::Norm of difference: 0.00000
+DEAL:2d::
+DEAL:3d::Testing FE_Q<3>(2)
+DEAL:3d::Norm of difference: 0.00000
+DEAL:3d::
+DEAL:3d::Norm of difference: 0.00000
+DEAL:3d::

--- a/tests/matrix_free/matrix_vector_mf.h
+++ b/tests/matrix_free/matrix_vector_mf.h
@@ -133,7 +133,12 @@ public:
   void
   vmult(VectorType &dst, const VectorType &src) const
   {
-    dst = 0;
+    if constexpr (std::is_same_v<VectorType, dealii::ArrayView<Number>>)
+      for (unsigned int i = 0; i < dst.size(); ++i)
+        dst[i] = 0;
+    else
+      dst = 0;
+
     const std::function<
       void(const MatrixFree<dim, typename VectorType::value_type> &,
            VectorType &,


### PR DESCRIPTION
This enables the use of `VectorType = dealii::ArrayView` in the template arguments of deal.II. The support is not complete at this point, as I do not have a clear picture yet regarding the treatment of distributed vectors. The main change was that I use `operator[]` to access the vectors instead of `operator()` if I detect serial vectors or `ArrayView`. This does break some type trait test we have, but I think this is acceptable as there is no use in the library outside of this class. Of course, this suggestion is up to discussion, and I would be happy to hear opinions.