### PR TITLE
Rename a callback in PETScWrappers::TimeStepper.

### DIFF
--- a/doc/news/changes/minor/20240630Bangerth
+++ b/doc/news/changes/minor/20240630Bangerth
@@ -1,0 +1,7 @@
+Deprecated: The `distribute` callback of the
+PETScWrappers::TimeStepper class has been renamed to
+PETScWrappers::TimeStepper::update_constrained_components. The former
+name is still available for backward compatibility, but is now
+deprecated.
+<br>
+(Wolfgang Bangerth, 2024/06/30)

--- a/include/deal.II/lac/petsc_ts.h
+++ b/include/deal.II/lac/petsc_ts.h
@@ -591,6 +591,13 @@ namespace PETScWrappers
     std::function<IndexSet()> algebraic_components;
 
     /**
+     * This callback is equivalent to `update_constrained_components`, but is
+     * deprecated. Use `update_constrained_components` instead.
+     */
+    DEAL_II_DEPRECATED_EARLY
+    std::function<void(const real_type t, VectorType &y)> distribute;
+
+    /**
      * Callback to distribute solution to hanging nodes.
      *
      * Implementation of this function is optional.
@@ -603,7 +610,8 @@ namespace PETScWrappers
      * See there for a description of how to deal with errors and other
      * requirements and conventions.
      */
-    std::function<void(const real_type t, VectorType &y)> distribute;
+    std::function<void(const real_type t, VectorType &y)>
+      update_constrained_components;
 
     /**
      * Callback to set up mesh adaption.

--- a/tests/petsc/petsc_ts_03.cc
+++ b/tests/petsc/petsc_ts_03.cc
@@ -172,7 +172,8 @@ public:
 
     // This callback is invoked after a successful stage.
     // Here we only print that the callback is invoked.
-    time_stepper.distribute = [&](const real_type t, VectorType &) -> void {
+    time_stepper.update_constrained_components = [&](const real_type t,
+                                                     VectorType &) -> void {
       deallog << "Distribute at time " << t << std::endl;
     };
 


### PR DESCRIPTION
This is step 1 for #17180. I've got the corresponding patch for the currently pending step-86 queued up locally and will rebase that once this PR here is merged.

@stefanozampini FYI.