### PR TITLE
Add accessor functions for essential geometric properties of the Manifold classes.

### DIFF
--- a/doc/news/changes/minor/20240706DavidWells
+++ b/doc/news/changes/minor/20240706DavidWells
@@ -1,0 +1,5 @@
+New: All the basic Manifold objects describing a coordinate system now make
+their essential geometric properties (e.g., the center) available through member
+functions.
+<br>
+(David Wells, 2024/07/06)

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -1648,10 +1648,12 @@ namespace GridGenerator
    *
    * @param tria The triangulation to be filled.
    *
-   * @param R The radius of the circle, which forms the middle line of the
-   * torus containing the loop of cells. Must be greater than @p r.
+   * @param centerline_radius The radius of the circle which forms the center
+   * line of the torus containing the loop of cells. Must be greater than @p
+   * inner_radius.
    *
-   * @param r The inner radius of the torus.
+   * @param inner_radius The distance between the inner edge of the torus and
+   * origin.
    *
    * @param n_cells_toroidal Optional argument to set the number of cell
    * layers in toroidal direction. The default is 6 cell layers.
@@ -1668,8 +1670,8 @@ namespace GridGenerator
   template <int dim, int spacedim>
   void
   torus(Triangulation<dim, spacedim> &tria,
-        const double                  R,
-        const double                  r,
+        const double                  centerline_radius,
+        const double                  inner_radius,
         const unsigned int            n_cells_toroidal = 6,
         const double                  phi              = 2.0 * numbers::PI);
 

--- a/include/deal.II/grid/manifold.h
+++ b/include/deal.II/grid/manifold.h
@@ -779,6 +779,12 @@ public:
   const Tensor<1, spacedim> &
   get_periodicity() const;
 
+  /**
+   * Return the relative tolerance set in the constructor.
+   */
+  double
+  get_tolerance() const;
+
 private:
   /**
    * The periodicity of this Manifold. Periodicity affects the way a middle
@@ -1132,6 +1138,15 @@ Manifold<3, 3>::get_new_point_on_hex(
   const Triangulation<3, 3>::hex_iterator &) const;
 
 /*---Templated functions---*/
+
+template <int dim, int spacedim>
+inline double
+FlatManifold<dim, spacedim>::get_tolerance() const
+{
+  return tolerance;
+}
+
+
 
 namespace Manifolds
 {

--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -142,10 +142,21 @@ public:
 
   /**
    * The center of the spherical coordinate system.
+   *
+   * @deprecated Use get_center() instead.
    */
+  DEAL_II_DEPRECATED_EARLY_WITH_COMMENT(
+    "Access the center with get_center() instead.")
   const Point<spacedim> center;
 
 private:
+  /**
+   * The center of the spherical coordinate system.
+   *
+   * @note This exists to avoid warnings when using center internally.
+   */
+  const Point<spacedim> p_center;
+
   /**
    * Helper function which returns the periodicity associated with this
    * coordinate system, according to dim, chartdim, and spacedim.
@@ -1234,7 +1245,7 @@ template <int dim, int spacedim>
 inline const Point<spacedim> &
 PolarManifold<dim, spacedim>::get_center() const
 {
-  return center;
+  return p_center;
 }
 
 

--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -135,6 +135,12 @@ public:
     const Point<spacedim> &p) const override;
 
   /**
+   * Return the center of the spherical coordinate system.
+   */
+  const Point<spacedim> &
+  get_center() const;
+
+  /**
    * The center of the spherical coordinate system.
    */
   const Point<spacedim> center;
@@ -324,6 +330,12 @@ public:
                 const ArrayView<const double>          &weights) const override;
 
   /**
+   * Return the center of the spherical coordinate system.
+   */
+  const Point<spacedim> &
+  get_center() const;
+
+  /**
    * The center of the spherical coordinate system.
    */
   const Point<spacedim> center;
@@ -446,6 +458,27 @@ public:
   get_new_point(const ArrayView<const Point<spacedim>> &surrounding_points,
                 const ArrayView<const double>          &weights) const override;
 
+  /**
+   * Get the Tensor parallel to the cylinder's axis.
+   */
+  const Tensor<1, spacedim> &
+  get_direction() const;
+
+  /**
+   * Get a point on the Cylinder's axis.
+   *
+   * @note This argument, like get_direction() and get_tolerance(), just returns
+   * the arguments set in the three-argument constructor.
+   */
+  const Point<spacedim> &
+  get_point_on_axis() const;
+
+  /**
+   * Get the tolerance which determines if a point is on the Cylinder's axis.
+   */
+  double
+  get_tolerance() const;
+
 private:
   /**
    * A vector orthogonal to the normal direction.
@@ -544,16 +577,40 @@ public:
   virtual DerivativeForm<1, spacedim, spacedim>
   push_forward_gradient(const Point<spacedim> &chart_point) const override;
 
+  /**
+   * Get the Tensor parallel to the cylinder's major axis.
+   */
+  const Tensor<1, spacedim> &
+  get_major_axis_direction() const;
+
+  /**
+   * Return the center of the elliptical coordinate system.
+   */
+  const Point<spacedim> &
+  get_center() const;
+
+  /**
+   * Return the ellipse's eccentricity.
+   */
+  double
+  get_eccentricity() const;
 
 private:
   /**
    * The direction vector of the major axis.
    */
-  Tensor<1, spacedim> direction;
+  const Tensor<1, spacedim> direction;
+
   /**
    * The center of the manifold.
    */
   const Point<spacedim> center;
+
+  /**
+   * The eccentricity.
+   */
+  const double eccentricity;
+
   /**
    * Parameters deriving from the eccentricity of the manifold.
    */
@@ -815,6 +872,18 @@ public:
    */
   virtual DerivativeForm<1, 3, 3>
   push_forward_gradient(const Point<3> &chart_point) const override;
+
+  /**
+   * Get the radius of the centerline.
+   */
+  double
+  get_centerline_radius() const;
+
+  /**
+   * Get the inner radius of the torus.
+   */
+  double
+  get_inner_radius() const;
 
 private:
   double centerline_radius;
@@ -1158,6 +1227,96 @@ private:
    */
   boost::signals2::connection clear_signal;
 };
+
+/*----------------------------- inline functions -----------------------------*/
+
+template <int dim, int spacedim>
+inline const Point<spacedim> &
+PolarManifold<dim, spacedim>::get_center() const
+{
+  return center;
+}
+
+
+
+template <int dim, int spacedim>
+inline const Point<spacedim> &
+SphericalManifold<dim, spacedim>::get_center() const
+{
+  return center;
+}
+
+
+
+template <int dim, int spacedim>
+inline const Tensor<1, spacedim> &
+CylindricalManifold<dim, spacedim>::get_direction() const
+{
+  return direction;
+}
+
+
+
+template <int dim, int spacedim>
+inline const Point<spacedim> &
+CylindricalManifold<dim, spacedim>::get_point_on_axis() const
+{
+  return point_on_axis;
+}
+
+
+
+template <int dim, int spacedim>
+inline double
+CylindricalManifold<dim, spacedim>::get_tolerance() const
+{
+  return tolerance;
+}
+
+
+
+template <int dim, int spacedim>
+inline const Tensor<1, spacedim> &
+EllipticalManifold<dim, spacedim>::get_major_axis_direction() const
+{
+  return direction;
+}
+
+
+
+template <int dim, int spacedim>
+inline const Point<spacedim> &
+EllipticalManifold<dim, spacedim>::get_center() const
+{
+  return center;
+}
+
+
+
+template <int dim, int spacedim>
+inline double
+EllipticalManifold<dim, spacedim>::get_eccentricity() const
+{
+  return eccentricity;
+}
+
+
+
+template <int dim>
+inline double
+TorusManifold<dim>::get_centerline_radius() const
+{
+  return centerline_radius;
+}
+
+
+
+template <int dim>
+inline double
+TorusManifold<dim>::get_inner_radius() const
+{
+  return inner_radius;
+}
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -348,10 +348,21 @@ public:
 
   /**
    * The center of the spherical coordinate system.
+   *
+   * @deprecated Use get_center() instead.
    */
+  DEAL_II_DEPRECATED_EARLY_WITH_COMMENT(
+    "Access the center with get_center() instead.")
   const Point<spacedim> center;
 
 private:
+  /**
+   * The center of the spherical coordinate system.
+   *
+   * @note This exists to avoid warnings when using center internally.
+   */
+  const Point<spacedim> p_center;
+
   /**
    * Return a point on the spherical manifold which is intermediate
    * with respect to the surrounding points. This function uses a linear

--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -786,11 +786,11 @@ public:
   static const int spacedim = 3;
 
   /**
-   * Constructor. Specify the radius of the centerline @p R and the radius
-   * of the torus itself (@p r). The variables have the same meaning as
-   * the parameters in GridGenerator::torus().
+   * Constructor. Specify the radius of the centerline @p centerline_radius and
+   * the radius of the torus' inner circle (@p inner_radius). The variables have
+   * the same meaning as the parameters in GridGenerator::torus().
    */
-  TorusManifold(const double R, const double r);
+  TorusManifold(const double centerline_radius, const double inner_radius);
 
   /**
    * Make a clone of this Manifold object.
@@ -817,7 +817,9 @@ public:
   push_forward_gradient(const Point<3> &chart_point) const override;
 
 private:
-  double r, R;
+  double centerline_radius;
+
+  double inner_radius;
 };
 
 

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -1848,36 +1848,37 @@ namespace GridGenerator
   template <>
   void
   torus<2, 3>(Triangulation<2, 3> &tria,
-              const double         R,
-              const double         r,
+              const double         centerline_radius,
+              const double         inner_radius,
               const unsigned int,
               const double)
   {
-    Assert(R > r,
-           ExcMessage("Outer radius R must be greater than the inner "
-                      "radius r."));
-    Assert(r > 0.0, ExcMessage("The inner radius r must be positive."));
+    Assert(centerline_radius > inner_radius,
+           ExcMessage("The centerline radius must be greater than the "
+                      "inner radius."));
+    Assert(inner_radius > 0.0,
+           ExcMessage("The inner radius must be positive."));
 
     const unsigned int           dim      = 2;
     const unsigned int           spacedim = 3;
     std::vector<Point<spacedim>> vertices(16);
 
-    vertices[0]  = Point<spacedim>(R - r, 0, 0);
-    vertices[1]  = Point<spacedim>(R, -r, 0);
-    vertices[2]  = Point<spacedim>(R + r, 0, 0);
-    vertices[3]  = Point<spacedim>(R, r, 0);
-    vertices[4]  = Point<spacedim>(0, 0, R - r);
-    vertices[5]  = Point<spacedim>(0, -r, R);
-    vertices[6]  = Point<spacedim>(0, 0, R + r);
-    vertices[7]  = Point<spacedim>(0, r, R);
-    vertices[8]  = Point<spacedim>(-(R - r), 0, 0);
-    vertices[9]  = Point<spacedim>(-R, -r, 0);
-    vertices[10] = Point<spacedim>(-(R + r), 0, 0);
-    vertices[11] = Point<spacedim>(-R, r, 0);
-    vertices[12] = Point<spacedim>(0, 0, -(R - r));
-    vertices[13] = Point<spacedim>(0, -r, -R);
-    vertices[14] = Point<spacedim>(0, 0, -(R + r));
-    vertices[15] = Point<spacedim>(0, r, -R);
+    vertices[0]  = Point<spacedim>(centerline_radius - inner_radius, 0, 0);
+    vertices[1]  = Point<spacedim>(centerline_radius, -inner_radius, 0);
+    vertices[2]  = Point<spacedim>(centerline_radius + inner_radius, 0, 0);
+    vertices[3]  = Point<spacedim>(centerline_radius, inner_radius, 0);
+    vertices[4]  = Point<spacedim>(0, 0, centerline_radius - inner_radius);
+    vertices[5]  = Point<spacedim>(0, -inner_radius, centerline_radius);
+    vertices[6]  = Point<spacedim>(0, 0, centerline_radius + inner_radius);
+    vertices[7]  = Point<spacedim>(0, inner_radius, centerline_radius);
+    vertices[8]  = Point<spacedim>(-(centerline_radius - inner_radius), 0, 0);
+    vertices[9]  = Point<spacedim>(-centerline_radius, -inner_radius, 0);
+    vertices[10] = Point<spacedim>(-(centerline_radius + inner_radius), 0, 0);
+    vertices[11] = Point<spacedim>(-centerline_radius, inner_radius, 0);
+    vertices[12] = Point<spacedim>(0, 0, -(centerline_radius - inner_radius));
+    vertices[13] = Point<spacedim>(0, -inner_radius, -centerline_radius);
+    vertices[14] = Point<spacedim>(0, 0, -(centerline_radius + inner_radius));
+    vertices[15] = Point<spacedim>(0, inner_radius, -centerline_radius);
 
     std::vector<CellData<dim>> cells(16);
     // Right Hand Orientation
@@ -1981,7 +1982,7 @@ namespace GridGenerator
     tria.create_triangulation(vertices, cells, SubCellData());
 
     tria.set_all_manifold_ids(0);
-    tria.set_manifold(0, TorusManifold<2>(R, r));
+    tria.set_manifold(0, TorusManifold<2>(centerline_radius, inner_radius));
   }
 
 
@@ -2000,15 +2001,16 @@ namespace GridGenerator
   template <>
   void
   torus<3, 3>(Triangulation<3, 3> &tria,
-              const double         R,
-              const double         r,
+              const double         centerline_radius,
+              const double         inner_radius,
               const unsigned int   n_cells_toroidal,
               const double         phi)
   {
-    Assert(R > r,
-           ExcMessage("Outer radius R must be greater than the inner "
-                      "radius r."));
-    Assert(r > 0.0, ExcMessage("The inner radius r must be positive."));
+    Assert(centerline_radius > inner_radius,
+           ExcMessage("The centerline radius must be greater than the "
+                      "inner radius."));
+    Assert(inner_radius > 0.0,
+           ExcMessage("The inner radius must be positive."));
     Assert(n_cells_toroidal > static_cast<unsigned int>(phi / numbers::PI),
            ExcMessage("Number of cells in toroidal direction has "
                       "to be at least 3 for a torus of polar extent 2*pi."));
@@ -2016,7 +2018,7 @@ namespace GridGenerator
                 ExcMessage("Invalid angle phi specified."));
 
     // the first 8 vertices are in the x-y-plane
-    const Point<3> p = Point<3>(R, 0.0, 0.0);
+    const Point<3> p = Point<3>(centerline_radius, 0.0, 0.0);
     const double   a = 1. / (1 + std::sqrt(2.0));
     // A value of 1 indicates "open" torus with angle < 2*pi, which
     // means that we need an additional layer of vertices
@@ -2027,14 +2029,14 @@ namespace GridGenerator
     const unsigned int n_point_layers_toroidal =
       n_cells_toroidal + additional_layer;
     std::vector<Point<3>> vertices(8 * n_point_layers_toroidal);
-    vertices[0] = p + Point<3>(-1, -1, 0) * (r / std::sqrt(2.0)),
-    vertices[1] = p + Point<3>(+1, -1, 0) * (r / std::sqrt(2.0)),
-    vertices[2] = p + Point<3>(-1, -1, 0) * (r / std::sqrt(2.0) * a),
-    vertices[3] = p + Point<3>(+1, -1, 0) * (r / std::sqrt(2.0) * a),
-    vertices[4] = p + Point<3>(-1, +1, 0) * (r / std::sqrt(2.0) * a),
-    vertices[5] = p + Point<3>(+1, +1, 0) * (r / std::sqrt(2.0) * a),
-    vertices[6] = p + Point<3>(-1, +1, 0) * (r / std::sqrt(2.0)),
-    vertices[7] = p + Point<3>(+1, +1, 0) * (r / std::sqrt(2.0));
+    vertices[0] = p + Point<3>(-1, -1, 0) * (inner_radius / std::sqrt(2.0)),
+    vertices[1] = p + Point<3>(+1, -1, 0) * (inner_radius / std::sqrt(2.0)),
+    vertices[2] = p + Point<3>(-1, -1, 0) * (inner_radius / std::sqrt(2.0) * a),
+    vertices[3] = p + Point<3>(+1, -1, 0) * (inner_radius / std::sqrt(2.0) * a),
+    vertices[4] = p + Point<3>(-1, +1, 0) * (inner_radius / std::sqrt(2.0) * a),
+    vertices[5] = p + Point<3>(+1, +1, 0) * (inner_radius / std::sqrt(2.0) * a),
+    vertices[6] = p + Point<3>(-1, +1, 0) * (inner_radius / std::sqrt(2.0)),
+    vertices[7] = p + Point<3>(+1, +1, 0) * (inner_radius / std::sqrt(2.0));
 
     // create remaining vertices by rotating around negative y-axis (the
     // direction is to ensure positive cell measures)
@@ -2043,10 +2045,10 @@ namespace GridGenerator
       {
         for (unsigned int v = 0; v < 8; ++v)
           {
-            const double r_2d      = vertices[v][0];
-            vertices[8 * c + v][0] = r_2d * std::cos(phi_cell * c);
+            const double inner_radius_2d = vertices[v][0];
+            vertices[8 * c + v][0] = inner_radius_2d * std::cos(phi_cell * c);
             vertices[8 * c + v][1] = vertices[v][1];
-            vertices[8 * c + v][2] = r_2d * std::sin(phi_cell * c);
+            vertices[8 * c + v][2] = inner_radius_2d * std::sin(phi_cell * c);
           }
       }
 
@@ -2101,7 +2103,7 @@ namespace GridGenerator
           }
       }
 
-    tria.set_manifold(1, TorusManifold<3>(R, r));
+    tria.set_manifold(1, TorusManifold<3>(centerline_radius, inner_radius));
     tria.set_manifold(2,
                       CylindricalManifold<3>(Tensor<1, 3>({0., 1., 0.}),
                                              Point<3>()));

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -128,6 +128,7 @@ PolarManifold<dim, spacedim>::PolarManifold(const Point<spacedim> center)
   : ChartManifold<dim, spacedim, spacedim>(
       PolarManifold<dim, spacedim>::get_periodicity())
   , center(center)
+  , p_center(center)
 {}
 
 
@@ -187,7 +188,7 @@ PolarManifold<dim, spacedim>::push_forward(
         default:
           DEAL_II_NOT_IMPLEMENTED();
       }
-  return p + center;
+  return p + p_center;
 }
 
 
@@ -197,7 +198,7 @@ Point<spacedim>
 PolarManifold<dim, spacedim>::pull_back(
   const Point<spacedim> &space_point) const
 {
-  const Tensor<1, spacedim> R   = space_point - center;
+  const Tensor<1, spacedim> R   = space_point - p_center;
   const double              rho = R.norm();
 
   Point<spacedim> p;

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -1165,6 +1165,20 @@ CylindricalManifold<dim, spacedim>::push_forward_gradient(
 
 
 
+namespace
+{
+  template <int dim>
+  Tensor<1, dim>
+  check_and_normalize(const Tensor<1, dim> &t)
+  {
+    const double norm = t.norm();
+    Assert(norm > 0.0, ExcMessage("The major axis must have a positive norm."));
+    return t / norm;
+  }
+} // namespace
+
+
+
 // ============================================================
 // EllipticalManifold
 // ============================================================
@@ -1175,8 +1189,9 @@ EllipticalManifold<dim, spacedim>::EllipticalManifold(
   const double               eccentricity)
   : ChartManifold<dim, spacedim, spacedim>(
       EllipticalManifold<dim, spacedim>::get_periodicity())
-  , direction(major_axis_direction)
+  , direction(check_and_normalize(major_axis_direction))
   , center(center)
+  , eccentricity(eccentricity)
   , cosh_u(1.0 / eccentricity)
   , sinh_u(std::sqrt(cosh_u * cosh_u - 1.0))
 {
@@ -1186,11 +1201,6 @@ EllipticalManifold<dim, spacedim>::EllipticalManifold(
   Assert(std::signbit(cosh_u * cosh_u - 1.0) == false,
          ExcMessage(
            "Invalid eccentricity: It must satisfy 0 < eccentricity < 1."));
-  const double direction_norm = direction.norm();
-  Assert(direction_norm != 0.0,
-         ExcMessage(
-           "Invalid major axis direction vector: Null vector not allowed."));
-  direction /= direction_norm;
 }
 
 


### PR DESCRIPTION
Unlike PolarManifold, CylindricalManifold does not make its center accessible. This makes it difficult to, e.g., apply a transformation to a mesh which uses a CylindricalManifold and then update the CylindricalManifold accordingly.

`direction`, `point_on_axis`, and `tolerance` are three constructor arguments so making those public is enough to make it possible to re-create these objects.

*update* I applied the same transformation to the other Manifold classes.