### PR TITLE
GridTools::Cache: set up the default Mapping in another constructor.

### DIFF
--- a/include/deal.II/grid/grid_tools_cache.h
+++ b/include/deal.II/grid/grid_tools_cache.h
@@ -72,18 +72,19 @@ namespace GridTools
      * If you provide the optional `mapping` argument, then this is used
      * whenever a mapping is required.
      *
-     * @param tria The triangulation for which to store information
-     * @param mapping The mapping to use when computing cached objects
+     * @param tria The triangulation for which to store information.
+     * @param mapping The Mapping to use when computing cached objects.
      */
     Cache(const Triangulation<dim, spacedim> &tria,
-          const Mapping<dim, spacedim>       &mapping =
-            (ReferenceCells::get_hypercube<dim>()
-#ifndef _MSC_VER
-               .template get_default_linear_mapping<dim, spacedim>()
-#else
-               .ReferenceCell::get_default_linear_mapping<dim, spacedim>()
-#endif
-               ));
+          const Mapping<dim, spacedim>       &mapping);
+
+    /**
+     * Constructor. Uses the default linear or multilinear mapping for the
+     * underlying ReferenceCell of @p tria.
+     *
+     * @param tria The triangulation for which to store information.
+     */
+    Cache(const Triangulation<dim, spacedim> &tria);
 
     /**
      * Destructor.
@@ -327,9 +328,14 @@ namespace GridTools
     mutable std::mutex vertices_with_ghost_neighbors_mutex;
 
     /**
-     * Storage for the status of the triangulation signal.
+     * Storage for the status of the triangulation change signal.
      */
-    boost::signals2::connection tria_signal;
+    boost::signals2::connection tria_change_signal;
+
+    /**
+     * Storage for the status of the triangulation creation signal.
+     */
+    boost::signals2::connection tria_create_signal;
   };
 
 
@@ -348,6 +354,7 @@ namespace GridTools
   inline const Mapping<dim, spacedim> &
   Cache<dim, spacedim>::get_mapping() const
   {
+    Assert(mapping, ExcNotInitialized());
     return *mapping;
   }
 } // namespace GridTools

--- a/tests/simplex/compute_point_locations_01.cc
+++ b/tests/simplex/compute_point_locations_01.cc
@@ -12,14 +12,6 @@
 
 #include <deal.II/base/quadrature_lib.h>
 
-#include <deal.II/fe/fe_pyramid_p.h>
-#include <deal.II/fe/fe_simplex_p.h>
-#include <deal.II/fe/fe_simplex_p_bubbles.h>
-#include <deal.II/fe/fe_tools.h>
-#include <deal.II/fe/fe_values.h>
-#include <deal.II/fe/fe_wedge_p.h>
-#include <deal.II/fe/mapping_fe.h>
-
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/grid_tools_cache.h>
@@ -27,7 +19,7 @@
 #include "../tests.h"
 
 // Create a simplex mesh in the unit cube. Check points distribute to each cell
-// via GridTools::compute_point_locations
+// via GridTools::compute_point_locations()
 
 
 template <int dim>
@@ -37,13 +29,9 @@ test_in_unit_cube(const std::vector<Point<dim>> &points)
   Triangulation<dim> tria;
   GridGenerator::subdivided_hyper_cube_with_simplices(tria, 1);
 
-  MappingFE<dim> mapping(FE_SimplexP<dim>(1));
-
-  const auto tria_cache =
-    std::make_unique<GridTools::Cache<dim>>(tria, mapping);
-
-  const auto point_locations =
-    GridTools::compute_point_locations(*tria_cache, points);
+  GridTools::Cache<dim> cache(tria);
+  const auto            point_locations =
+    GridTools::compute_point_locations(cache, points);
 
   const auto cells   = std::get<0>(point_locations);
   const auto qpoints = std::get<1>(point_locations);
@@ -61,8 +49,8 @@ test_in_unit_cube(const std::vector<Point<dim>> &points)
           deallog << "        physical position   : (" << points[indices[i][j]]
                   << ')' << std::endl;
           deallog << "        FE mapping position : ("
-                  << mapping.transform_unit_to_real_cell(cells[i],
-                                                         qpoints[i][j])
+                  << cache.get_mapping().transform_unit_to_real_cell(
+                       cells[i], qpoints[i][j])
                   << ')' << std::endl;
         }
     }


### PR DESCRIPTION
This preserves the current behavior and makes the Triangulation-only version work correctly with simplices.