### PR TITLE
Add missing include.

### DIFF
--- a/tests/examples/example_test.h
+++ b/tests/examples/example_test.h
@@ -24,6 +24,7 @@
 #include <deal.II/base/exceptions.h>
 
 #include <fstream>
+#include <iostream>
 
 /*
  * Given the name of a file, copy it to std::cout


### PR DESCRIPTION
Some tests in `tests/examples` complain:
```
In file included from .../build-dealii/tests/examples/source/step-40.cc:21:
.../build-dealii/tests/examples/source/../example_test.h: In function ‘void cat_file(const char*)’:
.../build-dealii/tests/examples/source/../example_test.h:38:10: error: ‘cout’ is not a member of ‘std’
   38 |     std::cout << in.rdbuf() << "\n";
      |          ^~~~
.../build-dealii/tests/examples/source/../example_test.h:27:1: note: ‘std::cout’ is defined in header ‘<iostream>’; this is probably fixable by adding ‘#include <iostream>’
   26 | #include <fstream>
  +++ |+#include <iostream>
   27 | 
make[3]: *** [binary/CMakeFiles/examples.step-40.debug.dir/build.make:81: binary/CMakeFiles/examples.step-40.debug.dir/step-40.cc.o] Error 1
make[2]: *** [CMakeFiles/Makefile2:3171: binary/CMakeFiles/examples.step-40.debug.dir/all] Error 2
```