### PR TITLE
Rename a second callback in PETScWrappers::TimeStepper.

### DIFF
--- a/doc/news/changes/minor/20240701Bangerth
+++ b/doc/news/changes/minor/20240701Bangerth
@@ -1,0 +1,7 @@
+Deprecated: The `decide_for_coarsening_and_refinement` callback of the
+PETScWrappers::TimeStepper class has been renamed to
+PETScWrappers::TimeStepper::decide_and_prepare_for_remeshing. The former
+name is still available for backward compatibility, but is now
+deprecated.
+<br>
+(Wolfgang Bangerth, 2024/07/01)

--- a/include/deal.II/lac/petsc_ts.h
+++ b/include/deal.II/lac/petsc_ts.h
@@ -606,26 +606,40 @@ namespace PETScWrappers
     std::function<void(const real_type t, VectorType &y)> distribute;
 
     /**
-     * Callback to set up mesh adaption.
-     *
-     * Implementation of this function is optional.
-     * @p resize must be set to true if mesh adaption is to be performed, false
-     * otherwise.
-     * The @p y vector contains the current solution, @p t the current time,
-     * @ step the step number.
-     * Solution transfer and actual mesh adaption must be performed in a
-     * separate callback, TimeStepper::interpolate
-     *
-     * @note This variable represents a
-     * @ref GlossUserProvidedCallBack "user provided callback".
-     * See there for a description of how to deal with errors and other
-     * requirements and conventions.
+     * This callback is equivalent to `decide_and_prepare_for_remeshing`
+     * except that it returns the decision whether or not to stop
+     * operations via the last reference argument of the function
+     * object instead of a plain return value. This callback is
+     * deprecated. Use `decide_and_prepare_for_remeshing` instead.
      */
     std::function<void(const real_type    t,
                        const unsigned int step,
                        const VectorType  &y,
                        bool              &resize)>
       decide_for_coarsening_and_refinement;
+
+    /**
+     * A callback that returns whether or not to stop time stepping at the
+     * current moment for mesh adaptation. If the callback returns `true`,
+     * then the time stepper stops time integration for now, saves some state,
+     * calls the `interpolate` callback, and then resumes time integration.
+     * Either in the current callback or the `interpolate` callback, the
+     * user code needs to perform the mesh refinement.
+     *
+     * Implementation of this function is optional. The callback
+     * must return `true` if mesh adaption is to be performed, `false`
+     * otherwise.
+     * The @p y vector contains the current solution, @p t the current time,
+     * @ step the step number.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions.
+     */
+    std::function<
+      bool(const real_type t, const unsigned int step, const VectorType &y)>
+      decide_and_prepare_for_remeshing;
 
     /**
      * Callback to interpolate vectors and perform mesh adaption.

--- a/include/deal.II/lac/petsc_ts.templates.h
+++ b/include/deal.II/lac/petsc_ts.templates.h
@@ -442,7 +442,14 @@ namespace PETScWrappers
 
       const int lineno = __LINE__;
       const int err    = call_and_possibly_capture_ts_exception(
-        user->decide_for_coarsening_and_refinement,
+        (user->decide_and_prepare_for_remeshing ?
+              [&](const real_type    t,
+               const unsigned int step,
+               const VectorType  &y,
+               bool              &resize) {
+             resize = user->decide_and_prepare_for_remeshing(t, step, y);
+           } :
+              user->decide_for_coarsening_and_refinement),
         user->pending_exception,
         {},
         t,
@@ -454,7 +461,7 @@ namespace PETScWrappers
         return PetscError(
           PetscObjectComm((PetscObject)ts),
           lineno + 1,
-          "decide_for_coarsening_and_refinement",
+          "decide_and_prepare_for_remeshing",
           __FILE__,
           PETSC_ERR_LIB,
           PETSC_ERROR_INITIAL,
@@ -1033,8 +1040,18 @@ namespace PETScWrappers
       AssertPETSc(TSMonitorSet(ts, ts_monitor, this, nullptr));
 
     // Handle AMR.
-    if (decide_for_coarsening_and_refinement)
+    if (decide_and_prepare_for_remeshing ||
+        decide_for_coarsening_and_refinement)
       {
+        if (decide_and_prepare_for_remeshing)
+          Assert(
+            !decide_for_coarsening_and_refinement,
+            ExcMessage(
+              "The 'decide_for_coarsening_and_refinement' callback name "
+              "of the TimeStepper class is deprecated. If you are setting "
+              "the equivalent 'decide_and_prepare_for_remeshing' callback, you "
+              "cannot also set the 'decide_for_coarsening_and_refinement' "
+              "callback."));
         AssertThrow(interpolate,
                     StandardExceptions::ExcFunctionNotProvided("interpolate"));
 #  if DEAL_II_PETSC_VERSION_GTE(3, 21, 0)

--- a/tests/petsc/petsc_ts_03.cc
+++ b/tests/petsc/petsc_ts_03.cc
@@ -177,17 +177,15 @@ public:
     };
 
     // This callback is used to decide to remesh.
-    time_stepper.decide_for_coarsening_and_refinement =
+    time_stepper.decide_and_prepare_for_remeshing =
       [&](const real_type    t,
           const unsigned int step,
-          const VectorType &,
-          bool &resize) -> void {
+          const VectorType &) -> bool {
       deallog << "Prepare at time " << t << " and step " << step << std::endl;
-      resize = (step && step % 5 == 0);
+      return (step && step % 5 == 0);
     };
 
-    // This callback is called if decide_for_coarsening_and_refinement sets
-    // resize to true.
+    // This callback is called if decide_and_prepare_for_remeshing returns true.
     time_stepper.interpolate = [&](const std::vector<VectorType> &all_in,
                                    std::vector<VectorType> &all_out) -> void {
       deallog << "Interpolate" << std::endl;


### PR DESCRIPTION
This addresses the second issue of #17180. This one should be uncontroversial: Instead of returning a bool via a reference argument, it returns it by value.