### PR TITLE
fix docker CI build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,29 +11,27 @@ permissions:
   contents: read
   packages: write
 
+env:
+  REGISTRY_IMAGE: dealii/dealii
+
 jobs:
-  build-master-docker:
+  build-master-docker-ubuntu:
     if: (github.event_name == 'schedule' && github.repository == 'dealii/dealii') || github.event_name != 'schedule'
 
-    name: build master docker ${{ matrix.ubuntu_version }}
+    name: build master docker ${{ matrix.ubuntu_version }} ${{ matrix.platform }}
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
         ubuntu_version: [focal, jammy]
-        platform: [linux/arm64, linux/amd64]
-        # Use only 1 job to build, as more jobs
+        platform: [linux/amd64]
+        # Use only 2 jobs to build, as more jobs
         # would starve the github machine for memory.
         include:
-          - n_jobs: 1
+          - n_jobs: 2
 
     steps:
-      - name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV          
-      
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -63,6 +61,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image of master ${{ matrix.ubuntu_version }}-${{ matrix.platform }}
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: ./contrib/docker/
@@ -75,66 +74,73 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ github.event_name == 'schedule' }}
-          tags: |
-            dealii/dealii:master-${{ matrix.ubuntu_version }}
-            ghcr.io/${{ github.repository }}:master-${{ matrix.ubuntu_version }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"  
+          touch "/tmp/digests/${digest#sha256:}"
       
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ env.PLATFORM_PAIR }}
+          name: digests-${{ matrix.ubuntu_version }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
   
   merge:
+    if: (github.event_name == 'schedule' && github.repository == 'dealii/dealii') || github.event_name != 'schedule'
+
     runs-on: ubuntu-latest
     needs:
-      - build-master-docker
+      - build-master-docker-ubuntu
+
+# Merge all images for a specific ubuntu version
+    strategy:
+      fail-fast: false
+      matrix:
+        ubuntu_version: [focal, jammy]
 
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-*
+          pattern: digests-${{ matrix.ubuntu_version }}-*
           merge-multiple: true
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_IMAGE }}
-      
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)          
-      
+          docker buildx imagetools create -t ${{ env.REGISTRY_IMAGE }}:master-${{ matrix.ubuntu_version }}  \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+          docker buildx imagetools create -t ghcr.io/${{ env.REGISTRY_IMAGE }}:master-${{ matrix.ubuntu_version }}  \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:master-${{ matrix.ubuntu_version }}


### PR DESCRIPTION
This hopefully fixes #17197. For now I am testing building with 2 processes (github action runners were upgraded recently to 16 GB RAM, so maybe that allows us to run with more parallel processes). If that doesnt work we will have to disable the arm64 build for now. I thought about using the `macos-latest` Github action runners to speed up the arm64 build, but they do not support running docker (this may change once github offers macos15).

I want to wait for the results of this: https://github.com/gassmoeller/dealii/actions/runs/9779089798 before deciding on whether to include the arm64 image in the automatic build.