### PR TITLE
Add QSupportPointsSimplex

### DIFF
--- a/include/deal.II/matrix_free/util.h
+++ b/include/deal.II/matrix_free/util.h
@@ -22,6 +22,8 @@
 #include <deal.II/base/quadrature.h>
 #include <deal.II/base/quadrature_lib.h>
 
+#include <deal.II/fe/fe_simplex_p.h>
+
 #include <deal.II/grid/reference_cell.h>
 
 #include <deal.II/hp/q_collection.h>
@@ -56,6 +58,15 @@ namespace internal
               return {ReferenceCells::get_simplex<dim>(),
                       dealii::hp::QCollection<dim - 1>(
                         QWitherdenVincentSimplex<dim - 1>(i))};
+
+          for (unsigned int i = 1; i <= 3; ++i)
+            {
+              FE_SimplexP<dim> fe(i);
+              if (quad == Quadrature<dim>(fe.get_unit_support_points()))
+                return {ReferenceCells::get_simplex<dim>(),
+                        dealii::hp::QCollection<dim - 1>(Quadrature<dim - 1>(
+                          fe.get_unit_face_support_points()))};
+            }
         }
 
       if (dim == 3)
@@ -138,6 +149,22 @@ namespace internal
                   return {Quadrature<dim - 1>(),
                           QWitherdenVincentSimplex<dim - 1>(i)};
               }
+
+          for (unsigned int i = 1; i <= 3; ++i)
+            {
+              FE_SimplexP<dim> fe(i);
+              if (quad == Quadrature<dim>(fe.get_unit_support_points()))
+                {
+                  if (dim == 2)
+                    return {Quadrature<dim - 1>(
+                              fe.get_unit_face_support_points()), // line!
+                            Quadrature<dim - 1>()};
+                  else
+                    return {Quadrature<dim - 1>(),
+                            Quadrature<dim - 1>(
+                              fe.get_unit_face_support_points())};
+                }
+            }
         }
 
       if (dim == 3)


### PR DESCRIPTION
This PR adds a quadrature rule which has its integration points at the unit support points of a simplex but with infinite weights. It is helpful to evaluate e.g. boundary conditions at the correct locations, such it acts like `QGaussLobatto` for hypercube elements, where the support points and the integration points also coincide. 
Compared to `Quadrature<dim>(const std::vector<Point<dim>> &points)` it has the advantage that a `matrix_free` object can also produce rules to integrate faces.