### PR TITLE
Run codespell.

### DIFF
--- a/doc/doxygen/CMakeLists.txt
+++ b/doc/doxygen/CMakeLists.txt
@@ -281,7 +281,7 @@ endif()
 # doxygen version 1.9.1 can not correctly parse C++20-style 'requires'
 # clauses and just drops certain classes and shows documentation for
 # DEAL_II_CXX20_REQUIRES instead. 1.9.7 gets this right, but has other
-# bugs. It's unclear for versions inbetween. Err on the safe side, and
+# bugs. It's unclear for versions in between. Err on the safe side, and
 # only make them visible to doxygen if we have at least 1.9.8.
 if(${DOXYGEN_VERSION} VERSION_LESS 1.9.8)
   message(STATUS "Suppressing 'requires' clause parsing because doxygen is too old")

--- a/doc/doxygen/references.bib
+++ b/doc/doxygen/references.bib
@@ -1217,7 +1217,7 @@
 
 @inbook{Truesdell1960a,
   author    = {C. Truesdell and R. Toupin},
-  title     = {Encyclopedia of Physics: Principles of Thermodynamics and Statics},
+  title     = {Encyclopedia of Physics: Principles of Thermodynamics and Statistics},
   chapter   = {2: The classical field theories},
   publisher = {Springer-Verlag Berlin Heidelberg},
   year      = {1960},

--- a/doc/doxygen/references.bib
+++ b/doc/doxygen/references.bib
@@ -1217,15 +1217,17 @@
 
 @inbook{Truesdell1960a,
   author    = {C. Truesdell and R. Toupin},
-  title     = {Encyclopedia of Physics: Principles of Thermodynamics and Statistics},
-  chapter   = {2: The classical field theories},
+  title     = {The Classical Field Theories},
+  chapter   = {2},
+  booktitle = {Principles of Classical Mechanics and Field Theory},
+  series    = {Encyclopedia of Physics},
   publisher = {Springer-Verlag Berlin Heidelberg},
   year      = {1960},
   editor    = {S. Fl\"{u}gge},
   volume    = {1},
-  pages     = {226--794},
-  doi       = {10.1007/978-3-642-45943-6},
-  url       = {https://doi.org/10.1007/978-3-642-45943-6}
+  pages     = {226--858},
+  doi       = {10.1007/978-3-642-45943-6_2},
+  url       = {https://doi.org/10.1007/978-3-642-45943-6_2}
 }
 
 @article{Coleman1963a,

--- a/doc/news/3.0.0-vs-3.1.0.h
+++ b/doc/news/3.0.0-vs-3.1.0.h
@@ -717,7 +717,7 @@ All entries are signed with the names of the author.
        Removed: The
        <code>DataOut_Old</code> class has finally gone for
        good. It was already deprecated in version 3.0, and has been
-       superceded for a long time by the framework of classes around
+       superseded for a long time by the framework of classes around
        <code>DataOutBase</code> and
        <code>DataOut</code>.
        <br>

--- a/doc/news/3.2.0-vs-3.3.0.h
+++ b/doc/news/3.2.0-vs-3.3.0.h
@@ -383,7 +383,7 @@ All entries are signed with the names of the author.
   <li> <p>
        New: <code>GridGenerator</code> has a function
        <code>cylinder</code> for cylinders in three
-       space dimensions. Accoridngly, a class <code
+       space dimensions. Accordingly, a class <code
        class="class">CylinderBoundary</code> has been created.
        <br>
        (GK 2001/12/07)

--- a/doc/news/3.4.0-vs-4.0.0.h
+++ b/doc/news/3.4.0-vs-4.0.0.h
@@ -773,7 +773,7 @@ contributor's names are abbreviated by WB (Wolfgang Bangerth), GK
        <code>SparseDirectMA27</code> class now has a detached
        mode, in which it forks off a separate program that will do the
        computations using this solver. The actual operations are therefore
-       distributed to distint programs that have separate address spaces. This
+       distributed to distinct programs that have separate address spaces. This
        allows to have as many concurrent instances of this solver in parallel
        as you want. For more information, read the documentation of the
        <code>SparseDirectMA27</code> class.
@@ -1220,7 +1220,7 @@ contributor's names are abbreviated by WB (Wolfgang Bangerth), GK
        class="member">integrate_difference</code> can compute <i>L<sup>p</sup></i>
        and <i>W<sup>1,p</sup></i> norms for arbitrary <i>p</i>. The function
        receives an additional optional argument <i>p</i> for this. All previous
-       fuctionality remains unchanged, although the code has been cleaned up a bit.
+       functionality remains unchanged, although the code has been cleaned up a bit.
        <br>
        (GK 2002/08/01)
        </p>

--- a/doc/news/5.2.0-vs-6.0.0.h
+++ b/doc/news/5.2.0-vs-6.0.0.h
@@ -1279,7 +1279,7 @@ inconvenience this causes.
   <li> <p>
        Extended: The <code>GridIn</code> class can now
        read in tecplot files in ASCII format (block and point format,
-       ordered and unstructured grids, format specifiers acccording to
+       ordered and unstructured grids, format specifiers according to
        Tecplot 10 and younger versions). At the moment the
        implementation is restricted to 2d grids but can easily be
        extended to 3d as well.

--- a/doc/news/6.2.0-vs-6.3.0.h
+++ b/doc/news/6.2.0-vs-6.3.0.h
@@ -279,7 +279,7 @@ inconvenience this causes.
    rather than how these jobs have to be mapped onto threads. We then
    use the <a href="https://www.threadingbuildingblocks.org">Threading
    Building Blocks (TBB) library</a> to schedule tasks onto available
-   hardware resources. This new scheme of describing parallism and
+   hardware resources. This new scheme of describing parallelism and
    various abstractions to make programming in this framework easier
    are described in great detail in the
    @ref threads "Parallel computing with multiple processors" module.

--- a/doc/news/7.0.0-vs-7.1.0.h
+++ b/doc/news/7.0.0-vs-7.1.0.h
@@ -224,7 +224,7 @@ to an output stream and later retrieved to restore the state of the program.
 <li> New/deprecated: The Triangulation class offers ways to get informed
 whenever the triangulation changes. Previously, the mechanism doing this
 was through the Triangulation::RefinementListener class. This has been
-deprecated and has been superceded by a BOOST signals based mechanism
+deprecated and has been superseded by a BOOST signals based mechanism
 that is generally more powerful and does not rely on overloading
 particular virtual functions inherited from a base class.
 
@@ -657,7 +657,7 @@ number of components. This is now fixed.
 <br>
 (Wolfgang Bangerth, 2011/03/07)
 
-<li> Fixed: PETScWrappers:MPI:SparseMatrix and apply_boundary_values() produced an error in debug mode about non-existant SparsityPattern entries. Reason: clear_rows() also eliminated the whole row in the PETSc-internal SparsityPattern, which resulted in an error in the next assembly process.
+<li> Fixed: PETScWrappers:MPI:SparseMatrix and apply_boundary_values() produced an error in debug mode about non-existent SparsityPattern entries. Reason: clear_rows() also eliminated the whole row in the PETSc-internal SparsityPattern, which resulted in an error in the next assembly process.
 <br>
 (Timo Heister, 2011/02/23)
 

--- a/doc/news/7.1.0-vs-7.2.0.h
+++ b/doc/news/7.1.0-vs-7.2.0.h
@@ -628,7 +628,7 @@ first two of these functions. It has therefore been removed.
 
 <li> Improved: Objects of the type LogStream::Prefix can now be used
 as a safe implementation of the push and pop mechanism for log
-prefices.
+prefixes.
 <br>
 (Guido Kanschat, 2011/12/09)
 

--- a/doc/news/7.3.0-vs-8.0.0.h
+++ b/doc/news/7.3.0-vs-8.0.0.h
@@ -592,7 +592,7 @@ MPI/PETSc/Slepc in all cases.
 
 <li> Added/fixed: IterativeInverse::vmult() can now handle vectors
 using a different number type than the matrix type. As usual, the
-number types must be compatible. Addtitionally, the initial guess is
+number types must be compatible. Additionally, the initial guess is
 always set to zero, since starting with the incoming vector makes no
 sense.
 <br>

--- a/doc/news/8.2.1-vs-8.3.0.h
+++ b/doc/news/8.2.1-vs-8.3.0.h
@@ -1032,7 +1032,7 @@ inconvenience this causes.
   </li>
 
   <li> New: A new macro <code>DEAL_II_QUERY_GIT_INFORMATION</code> is
-  provided to query user projects for git repository information simmilarly
+  provided to query user projects for git repository information similarly
   to those exported by deal.II.
   <br>
   (Matthias Maier, 2015/01/21)

--- a/doc/news/8.3.0-vs-8.4.0.h
+++ b/doc/news/8.3.0-vs-8.4.0.h
@@ -221,7 +221,7 @@ inconvenience this causes.
 <h3>General</h3>
 <ol>
   <li> New: A variant for GridGenerator::subdivided_parallelepiped() was added
-  that supports meshes embedded in higher dimesional spaces.
+  that supports meshes embedded in higher dimensional spaces.
   <br>
   (Timo Heister, 2016/02/04)
   </li>

--- a/doc/news/8.4.2-vs-8.5.0.h
+++ b/doc/news/8.4.2-vs-8.5.0.h
@@ -1612,7 +1612,7 @@ inconvenience this causes.
 
  <li>
   Fixed: Allow to use FETools::get_fe_by_name for all
-  availabale FiniteElements.
+  available FiniteElements.
   <br>
   (Daniel Arndt, 2016/07/10)
  </li>

--- a/doc/news/8.5.0-vs-9.0.0.h
+++ b/doc/news/8.5.0-vs-9.0.0.h
@@ -1671,7 +1671,7 @@ inconvenience this causes.
  </li>
 
  <li>
-  New: DynamicSparsityPattern::compute_mmult_pattern(left, right) with two arguents of either
+  New: DynamicSparsityPattern::compute_mmult_pattern(left, right) with two arguments of either
   a DynamicSparsityPattern or a SparsityPattern; or any combination of those.
   The result is the pattern which is obtained by multiplying the two sparse matrices on
   the given sparsity patterns.
@@ -2503,7 +2503,7 @@ inconvenience this causes.
  </li>
 
  <li>
-  Deprecated: internal::bool2type and int2type has been depreated
+  Deprecated: internal::bool2type and int2type has been deprecated
   in favor of std::intergral_constant.
   <br>
   (Daniel Arndt, 2017/08/10)

--- a/doc/news/9.0.1-vs-9.1.0.h
+++ b/doc/news/9.0.1-vs-9.1.0.h
@@ -965,7 +965,7 @@ inconvenience this causes.
   requested, i.e., perform `degree+1` matrix-vector products rather than
   `degree` which is the convention in literature. This is now fixed. Note that
   the quality of PreconditionChebyshev is obviously slightly reduced by this
-  change, and some solvers might need more outer iterations due to a ligher
+  change, and some solvers might need more outer iterations due to a lighter
   Chebyshev iteration.
   <br>
   (Martin Kronbichler, 2019/02/08)

--- a/doc/news/9.1.1-vs-9.2.0.h
+++ b/doc/news/9.1.1-vs-9.2.0.h
@@ -743,7 +743,7 @@ inconvenience this causes.
  <li>
   New: The FEInterfaceValues class provides a new abstraction to assemble
   interface terms between two neighboring cells. This is commonly used in
-  Discontinous Galerkin methods.
+  Discontinuous Galerkin methods.
   <br>
   (Timo Heister, 2019/08/24)
  </li>

--- a/doc/news/9.2.0-vs-9.3.0.h
+++ b/doc/news/9.2.0-vs-9.3.0.h
@@ -421,7 +421,7 @@ inconvenience this causes.
   the compiler. This is (as of May 2020) C++14 for all compilers. If you want
   to override that behavior, please set the C++ standard directly for example
   by configuring with <code>-DDEAL_II_CXX_FLAGS="-std=c++17"</code>, or by
-  setting the environement variable <code>CXXFLAGS="-std=c++17"</code>.
+  setting the environment variable <code>CXXFLAGS="-std=c++17"</code>.
   <br>
   (Matthias Maier, 2020/05/21)
  </li>
@@ -546,7 +546,7 @@ inconvenience this causes.
 
  <li>
   New: The behavior of the local_size() member function is not consistent across
-  all vector classes that support ghost elements. As a remedy theis member
+  all vector classes that support ghost elements. As a remedy this member
   function is deprecated and replaced by locally_owned_size() that returns the
   number of locally owned elements (in particular without ghost elements).
   <br>
@@ -618,7 +618,7 @@ inconvenience this causes.
   Changed: The internal data structures of DoFHandler have been modified to use
   compressed row storage, enabling it to also handle hp::DoFHandler functionalities.
   Currently, the user can choose between the normal mode and the hp mode during
-  calling the constructur. Please note that the multigrid functionalities are only
+  calling the constructor. Please note that the multigrid functionalities are only
   available during normal mode.
   <br>
   (Peter Munch, 2020/05/23)
@@ -1511,7 +1511,7 @@ inconvenience this causes.
  <li>
   New: BoundingBox::real_to_unit() and BoundingBox::unit_to_real() allow one to
   apply both the direct and the inverse transformation that are needed to map the
-  unit bounding box to the current box, and viceversa.
+  unit bounding box to the current box, and vice-versa.
   <br>
   (Luca Heltai, 2020/06/29)
  </li>
@@ -1684,7 +1684,7 @@ inconvenience this causes.
 
  <li>
   New: When executing a task on a separate thread, if that task ends
-  with throwing an exception instead of returing a value, then this
+  with throwing an exception instead of returning a value, then this
   exception will be obtained when you wait for the task using
   Threads::Task::join() or Threads::Task::return_value().
   <br>

--- a/doc/news/9.3.1-vs-9.3.2.h
+++ b/doc/news/9.3.1-vs-9.3.2.h
@@ -28,7 +28,7 @@ author.
 <ol>
 
  <li>
-  Fixed: Various compatiblity issues and minor bugfixes have been resolved:
+  Fixed: Various compatibility issues and minor bugfixes have been resolved:
   <ol>
   <li>fixes a Sundials/Kinsol issue</li>
   <li>fixes a bug for plain_copy in MGTransferMatrixFree</li>

--- a/doc/news/9.3.3-vs-9.4.0.h
+++ b/doc/news/9.3.3-vs-9.4.0.h
@@ -81,7 +81,7 @@ inconvenience this causes.
  <li>
   Fixed: Callback functions attached to any weighted load balancing signal
   of parallel::distributed::Triangulation objects now need to handle cells
-  with CELL_INVALID status explicitely.
+  with CELL_INVALID status explicitly.
   <br>
   If a cell gets refined, only the first child has the CELL_REFINE status,
   while all other children are CELL_INVALID.
@@ -91,7 +91,7 @@ inconvenience this causes.
 
  <li>
   Changed: For weighted load balancing with parallel::distributed::Triangulation
-  objects, an intial weight of `1000` will no longer be assigned to each cell.
+  objects, an initial weight of `1000` will no longer be assigned to each cell.
   <br>
   The old signal Triangulation::Signals::cell_weight has been deprecated.
   Please use the new signal Triangulation::Signals::weight instead.
@@ -376,7 +376,7 @@ inconvenience this causes.
 
  <li>
   Removed: The overloads in CUDAWrappers::FEEvaluation that take a local dof index
-  or a quadrature point as arguement have been removed.
+  or a quadrature point as argument have been removed.
   Use the ones that don't use these arguments in their interface instead.
   <br>
   (Daniel Arndt, 2021/05/26)
@@ -501,9 +501,9 @@ inconvenience this causes.
   New: Added support for the CGAL library (www.cgal.org). The following features
   are supported:
   <ul>
-    <li>Conversion from deal.II to CGAL point types and viceversa</li>
-    <li>Conversion from deal.II cell types to CGAL::Surface_mesh and viceversa</li>
-    <li>Conversion from deal.II Triangulation to CGAL::Surface_mesh and viceversa</li>
+    <li>Conversion from deal.II to CGAL point types and vice-versa</li>
+    <li>Conversion from deal.II cell types to CGAL::Surface_mesh and vice-versa</li>
+    <li>Conversion from deal.II Triangulation to CGAL::Surface_mesh and vice-versa</li>
     <li>Insertion of deal.II points in CGAL triangulation types</li>
     <li>Conversion from CGAL::Triangulation_2 to Triangulation<dim, 2></li>
     <li>Conversion from CGAL::Triangulation_3 to Triangulation<dim, 3></li>
@@ -1360,7 +1360,7 @@ inconvenience this causes.
 
  <li>
   Fixed: The payload for Trilinos-based linear operators is now able to use its
-  own type as an examplar operator. This means that one can now use linear
+  own type as an exemplar operator. This means that one can now use linear
   operators based on Trilinos matrices as exampler operators when initializing
   a LinearOperator for a Trilinos preconditioner.
   <br>
@@ -1404,7 +1404,7 @@ inconvenience this causes.
  <li>
   New: The hp::FECollection::hp_vertex_dof_identities() function (and
   related functions for lines and quads) allows for the computation of
-  multiway computations of DoF indentities in the hp-context.
+  multiway computations of DoF identities in the hp-context.
   <br>
   (Wolfgang Bangerth, 2021/08/20)
  </li>
@@ -1628,7 +1628,7 @@ inconvenience this causes.
  </li>
 
  <li>
-  Addes conformity tests for several vector elements
+  Added conformity tests for several vector elements
   in 2D/3D as well as minor fixes for 2d Nedelec and
   Raviart-Thomas to make them work on non-standard meshes.
   <br>

--- a/doc/news/changes/minor/20230820Munch
+++ b/doc/news/changes/minor/20230820Munch
@@ -1,5 +1,5 @@
 New: The Rayleigh--Kothe vortex has been extracted
-from step-68 and is now availabe as the new class
+from step-68 and is now available as the new class
 Functions::RayleighKotheVortex.
 <br>
 (Bruno Blais, Peter Munch, 2023/08/20)

--- a/doc/news/changes/minor/20240519Bangerth
+++ b/doc/news/changes/minor/20240519Bangerth
@@ -3,7 +3,7 @@ FETools::Compositing::multiply_dof_numbers(),
 FETools::Compositing::compute_restriction_is_additive(), and
 FETools::Compositing::compute_nonzero_components() that took pointers to five
 finite elements and five multiplicities. These have now been
-deprecated in favor of the versions of these functios that take a
+deprecated in favor of the versions of these functions that take a
 vector of elements and a vector of multiplicities.
 <br>
 (Wolfgang Bangerth, 2024/05/19)

--- a/examples/step-55/doc/intro.dox
+++ b/examples/step-55/doc/intro.dox
@@ -67,7 +67,7 @@ Our goal here is to construct a very simple (maybe the simplest?) optimal
 preconditioner for the linear system. A preconditioner is called "optimal" or
 "of optimal complexity", if the number of iterations of the preconditioned
 system is independent of the mesh size $h$. You can extend that definition to
-also require indepence of the number of processors used (we will discuss that
+also require independence of the number of processors used (we will discuss that
 in the results section), the computational domain and the mesh quality, the
 test case itself, the polynomial degree of the finite element space, and more.
 

--- a/examples/step-89/step-89.cc
+++ b/examples/step-89/step-89.cc
@@ -60,7 +60,7 @@ namespace Step89
   //
   // In the following, let us first define a function that provides
   // the initial condition for the vibrating membrane test case.  It
-  // implementes both the initial pressure (component 0) and velocity
+  // implements both the initial pressure (component 0) and velocity
   // (components 1 to 1 + dim).
   //
   // There is also a function that computes the duration of one
@@ -633,7 +633,7 @@ namespace Step89
           const auto up = velocity_p.get_value(q);
 
           // Compute homogeneous local Lax-Friedrichs fluxes and submit the
-          // corrsponding values to the integrators.
+          // corresponding values to the integrators.
           const auto momentum_flux =
             0.5 * (pm + pp) + 0.5 * tau * (um - up) * n;
           velocity_m.submit_value(1.0 / rho * (momentum_flux - pm) * n, q);
@@ -1026,7 +1026,7 @@ namespace Step89
 
     const std::set<types::boundary_id> remote_face_ids;
 
-    // FERemoteEvaluation objects are strored as shared pointers. This way,
+    // FERemoteEvaluation objects are stored as shared pointers. This way,
     // they can also be used for other operators without precomputing the values
     // multiple times.
     const std::shared_ptr<FERemoteEvaluation<dim, 1, remote_value_type>>

--- a/examples/step-90/step-90.cc
+++ b/examples/step-90/step-90.cc
@@ -65,10 +65,10 @@ using VectorType = TrilinosWrappers::MPI::Vector;
 using MatrixType = TrilinosWrappers::SparseMatrix;
 namespace Step90
 {
-  // The parallization in this tutorial relies on the Trilinos library. We will
-  // grant to some cells empty finite element spaces FE_Nothing as done
-  // in step-85, but this time active DoFs will be only assigned to cell which
-  // are intersected by the surface approximation.
+  // The parallelization in this tutorial relies on the Trilinos library. We
+  // will grant to some cells empty finite element spaces FE_Nothing as done in
+  // step-85, but this time active DoFs will be only assigned to cell which are
+  // intersected by the surface approximation.
   enum class ActiveFEIndex : types::fe_index
   {
     lagrange = 0,

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -1274,7 +1274,7 @@ public:
 
   /**
    * Return the string that identifies the current path into the property
-   * tree. The path elements are seperated by the path_separator, which is a
+   * tree. The path elements are separated by the path_separator, which is a
    * '.'. This is only a path, i.e., it is not terminated by the path_separator
    * character.
    *
@@ -1287,7 +1287,7 @@ public:
   /**
    * Given the name of an entry as argument, the function computes a full path
    * into the parameter tree using the current subsection. The path elements are
-   * seperated by the path_separator, which is a '.'.
+   * separated by the path_separator, which is a '.'.
    */
   std::string
   get_current_full_path(const std::string &name) const;
@@ -1295,7 +1295,7 @@ public:
   /**
    * This function computes a full path into the parameter tree given a path
    * from the current subsection and the name of an entry. The path elements are
-   * seperated by the path_separator, which is a '.'.
+   * separated by the path_separator, which is a '.'.
    */
   std::string
   get_current_full_path(const std::vector<std::string> &sub_path,

--- a/include/deal.II/base/symbolic_function.h
+++ b/include/deal.II/base/symbolic_function.h
@@ -120,7 +120,7 @@ namespace Functions
    * Partial substitution is possible (i.e., you can define the function using
    * additional symbols). However, as soon as you evaluate the function, you
    * have to make sure that all extraneous symbols (i.e., those not referring
-   * to the spacial @p coordinate_symbols or to the @p time_symbol variable)
+   * to the spatial @p coordinate_symbols or to the @p time_symbol variable)
    * have been substituted with numerical values, or expressions of the spatial
    * or temporal argument, by calling the update_user_substitution_map() or the
    * set_additional_function_arguments() methods.

--- a/include/deal.II/fe/fe_coupling_values.h
+++ b/include/deal.II/fe/fe_coupling_values.h
@@ -786,7 +786,7 @@ public:
    *
    * This method computes the actual renumbering of the degrees of freedom and
    * quadrature points. If you change the underlying FEValuesBase objects after
-   * calling this method, you mey need to call the reinit() function to update
+   * calling this method, you may need to call the reinit() function to update
    * the renumbering. This may or may not be necessary, depending on the type of
    * coupling that you are using.
    *

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -68,7 +68,7 @@ namespace internal
 /**
  * Enum of different choices for istropic refinement.
  * There are 3 different ways to refine a tetrahedral, here we save the
- * different possibilites. It is different to RefinementPossibilites are these
+ * different possibilities. It is different to RefinementPossibilites are these
  * are options in the case that an isotropic refinement is conducted.
  */
 enum class IsotropicRefinementChoice : std::uint8_t

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -347,7 +347,7 @@ public:
    * integral of product of the test function multiplied by the data passed to
    * this function.
    *
-   * @note This function accessses the same field as through get_value(), so
+   * @note This function accesses the same field as through get_value(), so
    * make sure to not call it after calling submit_value() for a specific
    * quadrature point index.
    */
@@ -402,7 +402,7 @@ public:
    * of the test function gradient multiplied by the values passed to this
    * function.
    *
-   * @note This function accessses the same field as through get_gradient(),
+   * @note This function accesses the same field as through get_gradient(),
    * so make sure to not call it after calling submit_gradient() for a
    * specific quadrature point index.
    */
@@ -478,7 +478,7 @@ public:
    * of the test function Hessian multiplied by the values passed to this
    * function.
    *
-   * @note This function accessses the same field as through get_hessian(),
+   * @note This function accesses the same field as through get_hessian(),
    * so make sure to not call it after calling submit_hessian() for a
    * specific quadrature point index.
    */

--- a/include/deal.II/matrix_free/fe_remote_evaluation.h
+++ b/include/deal.II/matrix_free/fe_remote_evaluation.h
@@ -1350,7 +1350,7 @@ namespace Utilities
             const auto idx = indices[i];
 
             // We do not use a structural binding here, since with
-            // C++17 caputuring structural bindings in lambdas leads
+            // C++17 capturing structural bindings in lambdas leads
             // to an ill formed program.
             const auto &cell = std::get<0>(cell_face_pairs[i]);
             const auto &f    = std::get<1>(cell_face_pairs[i]);

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -688,7 +688,7 @@ namespace internal
           if (this->mg_level_fine == numbers::invalid_unsigned_int)
             {
               // create fine cell in two steps, since the coarse cell and
-              // the fine cell are associated to different Trinagulation
+              // the fine cell are associated to different Triangulation
               // objects
               const auto cell_id = cell->id();
               const auto cell_fine_raw =

--- a/include/deal.II/numerics/vector_tools_evaluate.h
+++ b/include/deal.II/numerics/vector_tools_evaluate.h
@@ -121,7 +121,7 @@ namespace VectorTools
    *
    * The function can also be used to evaluate cell-data vectors. For this
    * purpose, one passes in a Triangulation instead of a DoFHandler and a
-   * vector of size Trinagulation::n_active_cells() or a vector, which
+   * vector of size Triangulation::n_active_cells() or a vector, which
    * has been initialized with the partitioner returned by
    * parallel::TriangulationBase::global_active_cell_index_partitioner().
    *

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -3230,7 +3230,7 @@ namespace DoFTools
             return;
           }
 
-      // In the case of shared Trinagulation with artificial cells all
+      // In the case of shared Triangulation with artificial cells all
       // cells have valid DoF indices, i.e., the check above does not work.
       if (const auto tria = dynamic_cast<
             const parallel::shared::Triangulation<dim, spacedim> *>(

--- a/source/fe/fe_simplex_p.cc
+++ b/source/fe/fe_simplex_p.cc
@@ -495,7 +495,7 @@ FE_SimplexPoly<dim, spacedim>::get_restriction_matrix(
 
       const auto &child_cell = tria.begin(0)->child(child);
 
-      // iterate over all support points and transfom them to the unit cell of
+      // iterate over all support points and transform them to the unit cell of
       // the child
       for (unsigned int i = 0; i < unit_support_points.size(); i++)
         {


### PR DESCRIPTION
Part of #17202.

codespell also covered the old changelogs, which are also adjusted in this patch.