### PR TITLE
Fix clang-tidy findings

### DIFF
--- a/include/deal.II/base/aligned_vector.h
+++ b/include/deal.II/base/aligned_vector.h
@@ -358,7 +358,7 @@ public:
    * Swaps the given vector with the calling vector.
    */
   void
-  swap(AlignedVector<T> &vec);
+  swap(AlignedVector<T> &vec) noexcept;
 
   /**
    * Return whether the vector is empty, i.e., its size is zero.
@@ -1964,7 +1964,7 @@ AlignedVector<T>::replicate_across_communicator(const MPI_Comm     communicator,
 
 template <class T>
 inline void
-AlignedVector<T>::swap(AlignedVector<T> &vec)
+AlignedVector<T>::swap(AlignedVector<T> &vec) noexcept
 {
   // Swap the data in the 'elements' objects. Then also make sure that
   // their respective deleter objects point to the right place.

--- a/include/deal.II/base/array_view.h
+++ b/include/deal.II/base/array_view.h
@@ -943,9 +943,9 @@ namespace internal
  * @relatesalso ArrayView
  */
 template <typename Iterator, typename MemorySpaceType = MemorySpace::Host>
-ArrayView<typename std::remove_reference<
-            typename std::iterator_traits<Iterator>::reference>::type,
-          MemorySpaceType>
+ArrayView<
+  std::remove_reference_t<typename std::iterator_traits<Iterator>::reference>,
+  MemorySpaceType>
 make_array_view(const Iterator begin, const Iterator end)
 {
   static_assert(
@@ -964,9 +964,9 @@ make_array_view(const Iterator begin, const Iterator end)
   Assert(internal::ArrayViewHelper::is_contiguous(begin, end),
          ExcMessage("The provided range isn't contiguous in memory!"));
   // the reference type, not the value type, knows the constness of the iterator
-  return ArrayView<typename std::remove_reference<
-                     typename std::iterator_traits<Iterator>::reference>::type,
-                   MemorySpaceType>(std::addressof(*begin), end - begin);
+  return ArrayView<
+    std::remove_reference_t<typename std::iterator_traits<Iterator>::reference>,
+    MemorySpaceType>(std::addressof(*begin), end - begin);
 }
 
 

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -137,7 +137,8 @@ public:
    * Constructor from a Trilinos Teuchos::RCP<Tpetra::Map>.
    */
   explicit IndexSet(
-    Teuchos::RCP<const Tpetra::Map<int, types::signed_global_dof_index>> map);
+    const Teuchos::RCP<const Tpetra::Map<int, types::signed_global_dof_index>>
+      &map);
 #  endif // DEAL_II_TRILINOS_WITH_TPETRA
 
   /**

--- a/include/deal.II/base/memory_space_data.h
+++ b/include/deal.II/base/memory_space_data.h
@@ -99,7 +99,8 @@ namespace MemorySpace
    */
   template <typename T, typename MemorySpace>
   inline void
-  swap(MemorySpaceData<T, MemorySpace> &u, MemorySpaceData<T, MemorySpace> &v);
+  swap(MemorySpaceData<T, MemorySpace> &u,
+       MemorySpaceData<T, MemorySpace> &v) noexcept;
 
 
 #ifndef DOXYGEN
@@ -169,7 +170,8 @@ namespace MemorySpace
    */
   template <typename T, typename MemorySpace>
   inline void
-  swap(MemorySpaceData<T, MemorySpace> &u, MemorySpaceData<T, MemorySpace> &v)
+  swap(MemorySpaceData<T, MemorySpace> &u,
+       MemorySpaceData<T, MemorySpace> &v) noexcept
   {
     std::swap(u.values_host_buffer, v.values_host_buffer);
     std::swap(u.values, v.values);

--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -740,7 +740,7 @@ public:
    * functions.
    */
   void
-  swap(TableBase<N, T> &v);
+  swap(TableBase<N, T> &v) noexcept;
 
   /**
    * Determine an estimate for the memory consumption (in bytes) of this
@@ -986,8 +986,8 @@ namespace MatrixTableIterators
     /**
      * Type of the stored pointer to the table.
      */
-    using container_pointer_type = typename std::
-      conditional<Constness, const TableType *, TableType *>::type;
+    using container_pointer_type =
+      std::conditional_t<Constness, const TableType *, TableType *>;
 
     /**
      * Value type of the underlying container.
@@ -1198,8 +1198,8 @@ namespace MatrixTableIterators
     /**
      * Type of the stored pointer to the table.
      */
-    using container_pointer_type = typename std::
-      conditional<Constness, const TableType *, TableType *>::type;
+    using container_pointer_type =
+      std::conditional_t<Constness, const TableType *, TableType *>;
 
     /**
      * Constructor from an accessor.
@@ -2558,7 +2558,7 @@ TableBase<N, T>::fill(InputIterator entries, const bool C_style_indexing)
 
 template <int N, typename T>
 inline void
-TableBase<N, T>::swap(TableBase<N, T> &v)
+TableBase<N, T>::swap(TableBase<N, T> &v) noexcept
 {
   values.swap(v.values);
   std::swap(table_size, v.table_size);
@@ -3712,7 +3712,7 @@ Table<7, T>::operator()(const size_type i,
  */
 template <int N, typename T>
 inline void
-swap(TableBase<N, T> &u, TableBase<N, T> &v)
+swap(TableBase<N, T> &u, TableBase<N, T> &v) noexcept
 {
   u.swap(v);
 }

--- a/include/deal.II/base/thread_local_storage.h
+++ b/include/deal.II/base/thread_local_storage.h
@@ -104,8 +104,8 @@ namespace Threads
   class ThreadLocalStorage
   {
     static_assert(
-      std::is_copy_constructible<
-        typename internal::unpack_container<T>::type>::value ||
+      std::is_copy_constructible_v<
+        typename internal::unpack_container<T>::type> ||
         std::is_default_constructible_v<T>,
       "The stored type must be either copyable, or default constructible");
 

--- a/include/deal.II/differentiation/ad/ad_number_traits.h
+++ b/include/deal.II/differentiation/ad/ad_number_traits.h
@@ -741,8 +741,8 @@ namespace Differentiation
       std::enable_if_t<
         std::is_floating_point_v<ScalarType> ||
         (boost::is_complex<ScalarType>::value &&
-         std::is_floating_point_v<
-           typename internal::RemoveComplexWrapper<ScalarType>::type>)>>
+         std::is_floating_point<
+           typename internal::RemoveComplexWrapper<ScalarType>::type>::value)>>
     {
       /**
        * The type of taping used
@@ -862,8 +862,8 @@ namespace Differentiation
       /**
        * The actual auto-differentiable number type
        */
-      using ad_type =
-        std::conditional_t<is_real_valued, real_type, complex_type>;
+      using ad_type = typename std::
+        conditional<is_real_valued, real_type, complex_type>::type;
 
       /**
        * The actual auto-differentiable number directional derivative type
@@ -940,8 +940,8 @@ namespace Differentiation
       std::enable_if_t<
         std::is_floating_point_v<ScalarType> ||
         (boost::is_complex<ScalarType>::value &&
-         std::is_floating_point_v<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>)>>::is_taped =
+         std::is_floating_point<typename internal::RemoveComplexWrapper<
+           ScalarType>::type>::value)>>::is_taped =
       internal::ADNumberInfoFromEnum<
         typename internal::RemoveComplexWrapper<ScalarType>::type,
         ADNumberTypeCode>::is_taped;
@@ -954,8 +954,8 @@ namespace Differentiation
       std::enable_if_t<
         std::is_floating_point_v<ScalarType> ||
         (boost::is_complex<ScalarType>::value &&
-         std::is_floating_point_v<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>)>>::is_tapeless =
+         std::is_floating_point<typename internal::RemoveComplexWrapper<
+           ScalarType>::type>::value)>>::is_tapeless =
       !(NumberTraits<ScalarType, ADNumberTypeCode>::is_taped);
 
 
@@ -966,8 +966,8 @@ namespace Differentiation
       std::enable_if_t<
         std::is_floating_point_v<ScalarType> ||
         (boost::is_complex<ScalarType>::value &&
-         std::is_floating_point_v<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>)>>::is_real_valued =
+         std::is_floating_point<typename internal::RemoveComplexWrapper<
+           ScalarType>::type>::value)>>::is_real_valued =
       (!boost::is_complex<ScalarType>::value);
 
 
@@ -978,8 +978,8 @@ namespace Differentiation
       std::enable_if_t<
         std::is_floating_point_v<ScalarType> ||
         (boost::is_complex<ScalarType>::value &&
-         std::is_floating_point_v<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>)>>::is_complex_valued =
+         std::is_floating_point<typename internal::RemoveComplexWrapper<
+           ScalarType>::type>::value)>>::is_complex_valued =
       !(NumberTraits<ScalarType, ADNumberTypeCode>::is_real_valued);
 
 
@@ -990,8 +990,8 @@ namespace Differentiation
       std::enable_if_t<
         std::is_floating_point_v<ScalarType> ||
         (boost::is_complex<ScalarType>::value &&
-         std::is_floating_point_v<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>)>>::n_supported_derivative_levels =
+         std::is_floating_point<typename internal::RemoveComplexWrapper<
+           ScalarType>::type>::value)>>::n_supported_derivative_levels =
       internal::ADNumberInfoFromEnum<
         typename internal::RemoveComplexWrapper<ScalarType>::type,
         ADNumberTypeCode>::n_supported_derivative_levels;
@@ -1072,8 +1072,8 @@ namespace Differentiation
       std::enable_if_t<
         std::is_floating_point_v<ScalarType> ||
         (boost::is_complex<ScalarType>::value &&
-         std::is_floating_point_v<
-           typename internal::RemoveComplexWrapper<ScalarType>::type>)>>
+         std::is_floating_point<
+           typename internal::RemoveComplexWrapper<ScalarType>::type>::value)>>
     {
       /**
        * The internal number type code.
@@ -1241,8 +1241,8 @@ namespace Differentiation
       std::enable_if_t<
         std::is_floating_point_v<ScalarType> ||
         (boost::is_complex<ScalarType>::value &&
-         std::is_floating_point_v<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>)>>::is_taped = false;
+         std::is_floating_point<typename internal::RemoveComplexWrapper<
+           ScalarType>::type>::value)>>::is_taped = false;
 
 
     template <typename ScalarType>
@@ -1252,8 +1252,8 @@ namespace Differentiation
       std::enable_if_t<
         std::is_floating_point_v<ScalarType> ||
         (boost::is_complex<ScalarType>::value &&
-         std::is_floating_point_v<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>)>>::is_tapeless = false;
+         std::is_floating_point<typename internal::RemoveComplexWrapper<
+           ScalarType>::type>::value)>>::is_tapeless = false;
 
 
     template <typename ScalarType>
@@ -1263,8 +1263,8 @@ namespace Differentiation
       std::enable_if_t<
         std::is_floating_point_v<ScalarType> ||
         (boost::is_complex<ScalarType>::value &&
-         std::is_floating_point_v<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>)>>::is_real_valued =
+         std::is_floating_point<typename internal::RemoveComplexWrapper<
+           ScalarType>::type>::value)>>::is_real_valued =
       (!boost::is_complex<ScalarType>::value);
 
 
@@ -1275,8 +1275,8 @@ namespace Differentiation
       std::enable_if_t<
         std::is_floating_point_v<ScalarType> ||
         (boost::is_complex<ScalarType>::value &&
-         std::is_floating_point_v<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>)>>::is_complex_valued =
+         std::is_floating_point<typename internal::RemoveComplexWrapper<
+           ScalarType>::type>::value)>>::is_complex_valued =
       !(NumberTraits<ScalarType, NumberTypes::none>::is_real_valued);
 
 
@@ -1287,8 +1287,8 @@ namespace Differentiation
       std::enable_if_t<
         std::is_floating_point_v<ScalarType> ||
         (boost::is_complex<ScalarType>::value &&
-         std::is_floating_point_v<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>)>>::n_supported_derivative_levels = 0;
+         std::is_floating_point<typename internal::RemoveComplexWrapper<
+           ScalarType>::type>::value)>>::n_supported_derivative_levels = 0;
 
 #  else
 

--- a/include/deal.II/differentiation/ad/ad_number_traits.h
+++ b/include/deal.II/differentiation/ad/ad_number_traits.h
@@ -741,8 +741,8 @@ namespace Differentiation
       std::enable_if_t<
         std::is_floating_point_v<ScalarType> ||
         (boost::is_complex<ScalarType>::value &&
-         std::is_floating_point<
-           typename internal::RemoveComplexWrapper<ScalarType>::type>::value)>>
+         std::is_floating_point_v<
+           typename internal::RemoveComplexWrapper<ScalarType>::type>)>>
     {
       /**
        * The type of taping used
@@ -862,8 +862,8 @@ namespace Differentiation
       /**
        * The actual auto-differentiable number type
        */
-      using ad_type = typename std::
-        conditional<is_real_valued, real_type, complex_type>::type;
+      using ad_type =
+        std::conditional_t<is_real_valued, real_type, complex_type>;
 
       /**
        * The actual auto-differentiable number directional derivative type
@@ -940,8 +940,8 @@ namespace Differentiation
       std::enable_if_t<
         std::is_floating_point_v<ScalarType> ||
         (boost::is_complex<ScalarType>::value &&
-         std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>>::is_taped =
+         std::is_floating_point_v<typename internal::RemoveComplexWrapper<
+           ScalarType>::type>)>>::is_taped =
       internal::ADNumberInfoFromEnum<
         typename internal::RemoveComplexWrapper<ScalarType>::type,
         ADNumberTypeCode>::is_taped;
@@ -954,8 +954,8 @@ namespace Differentiation
       std::enable_if_t<
         std::is_floating_point_v<ScalarType> ||
         (boost::is_complex<ScalarType>::value &&
-         std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>>::is_tapeless =
+         std::is_floating_point_v<typename internal::RemoveComplexWrapper<
+           ScalarType>::type>)>>::is_tapeless =
       !(NumberTraits<ScalarType, ADNumberTypeCode>::is_taped);
 
 
@@ -966,8 +966,8 @@ namespace Differentiation
       std::enable_if_t<
         std::is_floating_point_v<ScalarType> ||
         (boost::is_complex<ScalarType>::value &&
-         std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>>::is_real_valued =
+         std::is_floating_point_v<typename internal::RemoveComplexWrapper<
+           ScalarType>::type>)>>::is_real_valued =
       (!boost::is_complex<ScalarType>::value);
 
 
@@ -978,8 +978,8 @@ namespace Differentiation
       std::enable_if_t<
         std::is_floating_point_v<ScalarType> ||
         (boost::is_complex<ScalarType>::value &&
-         std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>>::is_complex_valued =
+         std::is_floating_point_v<typename internal::RemoveComplexWrapper<
+           ScalarType>::type>)>>::is_complex_valued =
       !(NumberTraits<ScalarType, ADNumberTypeCode>::is_real_valued);
 
 
@@ -990,8 +990,8 @@ namespace Differentiation
       std::enable_if_t<
         std::is_floating_point_v<ScalarType> ||
         (boost::is_complex<ScalarType>::value &&
-         std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>>::n_supported_derivative_levels =
+         std::is_floating_point_v<typename internal::RemoveComplexWrapper<
+           ScalarType>::type>)>>::n_supported_derivative_levels =
       internal::ADNumberInfoFromEnum<
         typename internal::RemoveComplexWrapper<ScalarType>::type,
         ADNumberTypeCode>::n_supported_derivative_levels;
@@ -1072,8 +1072,8 @@ namespace Differentiation
       std::enable_if_t<
         std::is_floating_point_v<ScalarType> ||
         (boost::is_complex<ScalarType>::value &&
-         std::is_floating_point<
-           typename internal::RemoveComplexWrapper<ScalarType>::type>::value)>>
+         std::is_floating_point_v<
+           typename internal::RemoveComplexWrapper<ScalarType>::type>)>>
     {
       /**
        * The internal number type code.
@@ -1241,8 +1241,8 @@ namespace Differentiation
       std::enable_if_t<
         std::is_floating_point_v<ScalarType> ||
         (boost::is_complex<ScalarType>::value &&
-         std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>>::is_taped = false;
+         std::is_floating_point_v<typename internal::RemoveComplexWrapper<
+           ScalarType>::type>)>>::is_taped = false;
 
 
     template <typename ScalarType>
@@ -1252,8 +1252,8 @@ namespace Differentiation
       std::enable_if_t<
         std::is_floating_point_v<ScalarType> ||
         (boost::is_complex<ScalarType>::value &&
-         std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>>::is_tapeless = false;
+         std::is_floating_point_v<typename internal::RemoveComplexWrapper<
+           ScalarType>::type>)>>::is_tapeless = false;
 
 
     template <typename ScalarType>
@@ -1263,8 +1263,8 @@ namespace Differentiation
       std::enable_if_t<
         std::is_floating_point_v<ScalarType> ||
         (boost::is_complex<ScalarType>::value &&
-         std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>>::is_real_valued =
+         std::is_floating_point_v<typename internal::RemoveComplexWrapper<
+           ScalarType>::type>)>>::is_real_valued =
       (!boost::is_complex<ScalarType>::value);
 
 
@@ -1275,8 +1275,8 @@ namespace Differentiation
       std::enable_if_t<
         std::is_floating_point_v<ScalarType> ||
         (boost::is_complex<ScalarType>::value &&
-         std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>>::is_complex_valued =
+         std::is_floating_point_v<typename internal::RemoveComplexWrapper<
+           ScalarType>::type>)>>::is_complex_valued =
       !(NumberTraits<ScalarType, NumberTypes::none>::is_real_valued);
 
 
@@ -1287,8 +1287,8 @@ namespace Differentiation
       std::enable_if_t<
         std::is_floating_point_v<ScalarType> ||
         (boost::is_complex<ScalarType>::value &&
-         std::is_floating_point<typename internal::RemoveComplexWrapper<
-           ScalarType>::type>::value)>>::n_supported_derivative_levels = 0;
+         std::is_floating_point_v<typename internal::RemoveComplexWrapper<
+           ScalarType>::type>)>>::n_supported_derivative_levels = 0;
 
 #  else
 

--- a/include/deal.II/differentiation/sd/symengine_optimizer.h
+++ b/include/deal.II/differentiation/sd/symengine_optimizer.h
@@ -370,8 +370,8 @@ namespace Differentiation
       {
         static const bool is_supported = true;
 
-        using ReturnType = typename std::
-          conditional<std::is_same_v<ReturnType_, float>, float, double>::type;
+        using ReturnType =
+          std::conditional_t<std::is_same_v<ReturnType_, float>, float, double>;
       };
 
 
@@ -596,8 +596,8 @@ namespace Differentiation
       struct LLVMOptimizer<ReturnType_,
                            std::enable_if_t<std::is_arithmetic_v<ReturnType_>>>
       {
-        using ReturnType = typename std::
-          conditional<std::is_same_v<ReturnType_, float>, float, double>::type;
+        using ReturnType =
+          std::conditional_t<std::is_same_v<ReturnType_, float>, float, double>;
         using OptimizerType =
           std::conditional_t<std::is_same_v<ReturnType_, float>,
                              SymEngine::LLVMFloatVisitor,
@@ -2271,14 +2271,12 @@ namespace Differentiation
       // Serialize enum classes...
       {
         const auto m =
-          static_cast<typename std::underlying_type<OptimizerType>::type>(
-            method);
+          static_cast<std::underlying_type_t<OptimizerType>>(method);
         ar &m;
       }
       {
         const auto f =
-          static_cast<typename std::underlying_type<OptimizationFlags>::type>(
-            flags);
+          static_cast<std::underlying_type_t<OptimizationFlags>>(flags);
         ar &f;
       }
 
@@ -2354,13 +2352,13 @@ namespace Differentiation
 
       // Deserialize enum classes...
       {
-        typename std::underlying_type<OptimizerType>::type m;
-        ar                                                &m;
+        std::underlying_type_t<OptimizerType> m;
+        ar                                   &m;
         method = static_cast<OptimizerType>(m);
       }
       {
-        typename std::underlying_type<OptimizationFlags>::type f;
-        ar                                                    &f;
+        std::underlying_type_t<OptimizationFlags> f;
+        ar                                       &f;
         flags = static_cast<OptimizationFlags>(f);
       }
 

--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -1926,7 +1926,7 @@ public:
      * Swap function.
      */
     friend void
-    swap(ConstraintLine &l1, ConstraintLine &l2)
+    swap(ConstraintLine &l1, ConstraintLine &l2) noexcept
     {
       std::swap(l1.index, l2.index);
       std::swap(l1.entries, l2.entries);

--- a/include/deal.II/lac/block_indices.h
+++ b/include/deal.II/lac/block_indices.h
@@ -204,7 +204,7 @@ public:
    * Swap the contents of these two objects.
    */
   void
-  swap(BlockIndices &b);
+  swap(BlockIndices &b) noexcept;
 
   /**
    * Determine an estimate for the memory consumption (in bytes) of this
@@ -441,7 +441,7 @@ BlockIndices::operator==(const BlockIndices &b) const
 
 
 inline void
-BlockIndices::swap(BlockIndices &b)
+BlockIndices::swap(BlockIndices &b) noexcept
 {
   std::swap(n_blocks, b.n_blocks);
   std::swap(start_indices, b.start_indices);
@@ -468,7 +468,7 @@ BlockIndices::memory_consumption() const
  * @relatesalso BlockIndices
  */
 inline void
-swap(BlockIndices &u, BlockIndices &v)
+swap(BlockIndices &u, BlockIndices &v) noexcept
 {
   u.swap(v);
 }

--- a/include/deal.II/lac/block_vector.h
+++ b/include/deal.II/lac/block_vector.h
@@ -323,7 +323,7 @@ public:
    * <tt>u.swap(v)</tt>, again in analogy to standard functions.
    */
   void
-  swap(BlockVector<Number> &v);
+  swap(BlockVector<Number> &v) noexcept;
 
   /**
    * Print to a stream.
@@ -481,7 +481,7 @@ BlockVector<Number>::scale(const BlockVector2 &v)
  */
 template <typename Number>
 inline void
-swap(BlockVector<Number> &u, BlockVector<Number> &v)
+swap(BlockVector<Number> &u, BlockVector<Number> &v) noexcept
 {
   u.swap(v);
 }

--- a/include/deal.II/lac/block_vector.templates.h
+++ b/include/deal.II/lac/block_vector.templates.h
@@ -157,7 +157,7 @@ BlockVector<Number>::operator=(const TrilinosWrappers::MPI::BlockVector &v)
 
 template <typename Number>
 void
-BlockVector<Number>::swap(BlockVector<Number> &v)
+BlockVector<Number>::swap(BlockVector<Number> &v) noexcept
 {
   std::swap(this->components, v.components);
 

--- a/include/deal.II/lac/full_matrix.h
+++ b/include/deal.II/lac/full_matrix.h
@@ -86,8 +86,7 @@ public:
    * std::complex.
    */
   static_assert(
-    std::is_arithmetic<
-      typename numbers::NumberTraits<number>::real_type>::value,
+    std::is_arithmetic_v<typename numbers::NumberTraits<number>::real_type>,
     "The FullMatrix class only supports basic numeric types. In particular, it "
     "does not support automatically differentiated numbers.");
 

--- a/include/deal.II/lac/la_parallel_block_vector.h
+++ b/include/deal.II/lac/la_parallel_block_vector.h
@@ -519,7 +519,7 @@ namespace LinearAlgebra
        * functions.
        */
       void
-      swap(BlockVector<Number> &v);
+      swap(BlockVector<Number> &v) noexcept;
       /** @} */
 
       /**
@@ -819,7 +819,7 @@ namespace LinearAlgebra
 template <typename Number>
 inline void
 swap(LinearAlgebra::distributed::BlockVector<Number> &u,
-     LinearAlgebra::distributed::BlockVector<Number> &v)
+     LinearAlgebra::distributed::BlockVector<Number> &v) noexcept
 {
   u.swap(v);
 }

--- a/include/deal.II/lac/la_parallel_block_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_block_vector.templates.h
@@ -833,7 +833,7 @@ namespace LinearAlgebra
 
     template <typename Number>
     inline void
-    BlockVector<Number>::swap(BlockVector<Number> &v)
+    BlockVector<Number>::swap(BlockVector<Number> &v) noexcept
     {
       Assert(this->n_blocks() == v.n_blocks(),
              ExcDimensionMismatch(this->n_blocks(), v.n_blocks()));

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -452,7 +452,7 @@ namespace LinearAlgebra
        * analogy to standard functions.
        */
       void
-      swap(Vector<Number, MemorySpace> &v);
+      swap(Vector<Number, MemorySpace> &v) noexcept;
 
       /**
        * Move assignment operator.
@@ -1790,7 +1790,7 @@ namespace LinearAlgebra
 template <typename Number, typename MemorySpace>
 inline void
 swap(LinearAlgebra::distributed::Vector<Number, MemorySpace> &u,
-     LinearAlgebra::distributed::Vector<Number, MemorySpace> &v)
+     LinearAlgebra::distributed::Vector<Number, MemorySpace> &v) noexcept
 {
   u.swap(v);
 }

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -1367,7 +1367,8 @@ namespace LinearAlgebra
 
     template <typename Number, typename MemorySpaceType>
     void
-    Vector<Number, MemorySpaceType>::swap(Vector<Number, MemorySpaceType> &v)
+    Vector<Number, MemorySpaceType>::swap(
+      Vector<Number, MemorySpaceType> &v) noexcept
     {
 #ifdef DEAL_II_WITH_MPI
 

--- a/include/deal.II/lac/linear_operator.h
+++ b/include/deal.II/lac/linear_operator.h
@@ -507,8 +507,8 @@ operator*(typename Range::value_type                    number,
           const LinearOperator<Range, Domain, Payload> &op)
 {
   static_assert(
-    std::is_convertible<typename Range::value_type,
-                        typename Domain::value_type>::value,
+    std::is_convertible_v<typename Range::value_type,
+                          typename Domain::value_type>,
     "Range and Domain must have implicitly convertible 'value_type's");
 
   if (op.is_null_operator)
@@ -574,8 +574,8 @@ operator*(const LinearOperator<Range, Domain, Payload> &op,
           typename Domain::value_type                   number)
 {
   static_assert(
-    std::is_convertible<typename Range::value_type,
-                        typename Domain::value_type>::value,
+    std::is_convertible_v<typename Range::value_type,
+                          typename Domain::value_type>,
     "Range and Domain must have implicitly convertible 'value_type's");
 
   return number * op;

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -266,7 +266,7 @@ namespace LinearAlgebra
      * analogy to standard functions.
      */
     void
-    swap(ReadWriteVector<Number> &v);
+    swap(ReadWriteVector<Number> &v) noexcept;
 
     /**
      * Copies the data and the IndexSet of the input vector @p in_vector.
@@ -1179,7 +1179,7 @@ namespace LinearAlgebra
 template <typename Number>
 inline void
 swap(LinearAlgebra::ReadWriteVector<Number> &u,
-     LinearAlgebra::ReadWriteVector<Number> &v)
+     LinearAlgebra::ReadWriteVector<Number> &v) noexcept
 {
   u.swap(v);
 }

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -942,7 +942,7 @@ namespace LinearAlgebra
 
   template <typename Number>
   void
-  ReadWriteVector<Number>::swap(ReadWriteVector<Number> &v)
+  ReadWriteVector<Number>::swap(ReadWriteVector<Number> &v) noexcept
   {
     std::swap(stored_elements, v.stored_elements);
     std::swap(values, v.values);

--- a/include/deal.II/lac/trilinos_parallel_block_vector.h
+++ b/include/deal.II/lac/trilinos_parallel_block_vector.h
@@ -312,7 +312,7 @@ namespace TrilinosWrappers
        * functions.
        */
       void
-      swap(BlockVector &v);
+      swap(BlockVector &v) noexcept;
 
       /**
        * Print to a stream.
@@ -427,7 +427,7 @@ namespace TrilinosWrappers
 
 
     inline void
-    BlockVector::swap(BlockVector &v)
+    BlockVector::swap(BlockVector &v) noexcept
     {
       std::swap(this->components, v.components);
 
@@ -444,7 +444,7 @@ namespace TrilinosWrappers
      * @relatesalso TrilinosWrappers::MPI::BlockVector
      */
     inline void
-    swap(BlockVector &u, BlockVector &v)
+    swap(BlockVector &u, BlockVector &v) noexcept
     {
       u.swap(v);
     }

--- a/include/deal.II/lac/trilinos_tpetra_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparsity_pattern.h
@@ -1353,11 +1353,11 @@ namespace LinearAlgebra
 
       const TrilinosWrappers::types::int_type *col_index_ptr_begin =
         reinterpret_cast<TrilinosWrappers::types::int_type *>(
-          const_cast<typename std::decay<decltype(*begin)>::type *>(&*begin));
+          const_cast<std::decay_t<decltype(*begin)> *>(&*begin));
 
       const TrilinosWrappers::types::int_type *col_index_ptr_end =
         reinterpret_cast<TrilinosWrappers::types::int_type *>(
-          const_cast<typename std::decay<decltype(*end)>::type *>(&*end));
+          const_cast<std::decay_t<decltype(*end)> *>(&*end));
 
       // Check at least for the first index that the conversion actually works
       AssertDimension(*col_index_ptr_begin, *begin);

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -423,7 +423,7 @@ namespace LinearAlgebra
        * handle memory separately.
        */
       virtual void
-      swap(Vector &v);
+      swap(Vector &v) noexcept;
 
       /**
        * Extract a range of elements all at once.
@@ -1086,7 +1086,8 @@ namespace LinearAlgebra
 
     template <typename Number, typename MemorySpace>
     inline void
-    swap(Vector<Number, MemorySpace> &u, Vector<Number, MemorySpace> &v)
+    swap(Vector<Number, MemorySpace> &u,
+         Vector<Number, MemorySpace> &v) noexcept
     {
       u.swap(v);
     }
@@ -1110,7 +1111,7 @@ namespace LinearAlgebra
 
     template <typename Number, typename MemorySpace>
     inline void
-    Vector<Number, MemorySpace>::swap(Vector<Number, MemorySpace> &v)
+    Vector<Number, MemorySpace>::swap(Vector<Number, MemorySpace> &v) noexcept
     {
       vector.swap(v.vector);
     }

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -1303,7 +1303,7 @@ namespace TrilinosWrappers
        * analogy to standard functions.
        */
       void
-      swap(Vector &v);
+      swap(Vector &v) noexcept;
 
       /**
        * Estimate for the memory consumption in bytes.
@@ -1419,7 +1419,7 @@ namespace TrilinosWrappers
      * @relatesalso TrilinosWrappers::MPI::Vector
      */
     inline void
-    swap(Vector &u, Vector &v)
+    swap(Vector &u, Vector &v) noexcept
     {
       u.swap(v);
     }

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -127,8 +127,7 @@ public:
    * std::complex.
    */
   static_assert(
-    std::is_arithmetic<
-      typename numbers::NumberTraits<Number>::real_type>::value,
+    std::is_arithmetic_v<typename numbers::NumberTraits<Number>::real_type>,
     "The Vector class only supports basic numeric types. In particular, it "
     "does not support automatically differentiated numbers.");
 
@@ -387,7 +386,7 @@ public:
    * memory separately.
    */
   virtual void
-  swap(Vector<Number> &v);
+  swap(Vector<Number> &v) noexcept;
 
   /**
    * Set all components of the vector to the given number @p s.
@@ -1436,7 +1435,7 @@ Vector<Number>::reinit(const Vector<Number2> &v,
 // swap virtual.
 template <typename Number>
 inline void
-Vector<Number>::swap(Vector<Number> &v)
+Vector<Number>::swap(Vector<Number> &v) noexcept
 {
   values.swap(v.values);
   std::swap(thread_loop_partitioner, v.thread_loop_partitioner);
@@ -1485,7 +1484,7 @@ Vector<Number>::load(Archive &ar, const unsigned int)
  */
 template <typename Number>
 inline void
-swap(Vector<Number> &u, Vector<Number> &v)
+swap(Vector<Number> &u, Vector<Number> &v) noexcept
 {
   u.swap(v);
 }

--- a/include/deal.II/matrix_free/fe_remote_evaluation.h
+++ b/include/deal.II/matrix_free/fe_remote_evaluation.h
@@ -1163,8 +1163,7 @@ namespace Utilities
                 // the batch to the corresponding data structure.
                 const unsigned int n_faces =
                   matrix_free.n_active_entries_per_face_batch(face);
-                face_batch_id_n_faces.emplace_back(
-                  std::make_pair(face, n_faces));
+                face_batch_id_n_faces.emplace_back(face, n_faces);
 
                 // Append the quadrature points to the points we need to search
                 // for.

--- a/include/deal.II/matrix_free/tools.h
+++ b/include/deal.II/matrix_free/tools.h
@@ -1772,13 +1772,13 @@ namespace MatrixFreeTools
      * If value type of matrix and constrains equals, return a reference
      * to the given AffineConstraint instance.
      */
-    template <typename MatrixType,
-              typename Number,
-              std::enable_if_t<std::is_same_v<
-                typename std::remove_const<typename std::remove_reference<
-                  typename MatrixType::value_type>::type>::type,
-                typename std::remove_const<typename std::remove_reference<
-                  Number>::type>::type>> * = nullptr>
+    template <
+      typename MatrixType,
+      typename Number,
+      std::enable_if_t<std::is_same_v<
+        std::remove_const_t<
+          std::remove_reference_t<typename MatrixType::value_type>>,
+        std::remove_const_t<std::remove_reference_t<Number>>>> * = nullptr>
     const AffineConstraints<typename MatrixType::value_type> &
     create_new_affine_constraints_if_needed(
       const MatrixType &,
@@ -1793,13 +1793,13 @@ namespace MatrixFreeTools
      * AffineConstraint instance with the value type of the matrix is
      * created and a reference to it is returned.
      */
-    template <typename MatrixType,
-              typename Number,
-              std::enable_if_t<!std::is_same_v<
-                typename std::remove_const<typename std::remove_reference<
-                  typename MatrixType::value_type>::type>::type,
-                typename std::remove_const<typename std::remove_reference<
-                  Number>::type>::type>> * = nullptr>
+    template <
+      typename MatrixType,
+      typename Number,
+      std::enable_if_t<!std::is_same_v<
+        std::remove_const_t<
+          std::remove_reference_t<typename MatrixType::value_type>>,
+        std::remove_const_t<std::remove_reference_t<Number>>>> * = nullptr>
     const AffineConstraints<typename MatrixType::value_type> &
     create_new_affine_constraints_if_needed(
       const MatrixType &,

--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -40,7 +40,8 @@ DEAL_II_NAMESPACE_OPEN
 #  ifdef DEAL_II_TRILINOS_WITH_TPETRA
 
 IndexSet::IndexSet(
-  Teuchos::RCP<const Tpetra::Map<int, types::signed_global_dof_index>> map)
+  const Teuchos::RCP<const Tpetra::Map<int, types::signed_global_dof_index>>
+    &map)
   : is_compressed(true)
   , index_space_size(1 + map->getMaxAllGlobalIndex())
   , largest_range(numbers::invalid_unsigned_int)

--- a/source/differentiation/sd/symengine_number_types.cc
+++ b/source/differentiation/sd/symengine_number_types.cc
@@ -93,17 +93,17 @@ namespace Differentiation
           Assert(SE::is_a_Boolean(entry.first.get_value()),
                  ExcMessage(
                    "The conditional expression must return a boolean type."));
-          piecewise_function.push_back(
-            {entry.second.get_RCP(),
-             SE::rcp_static_cast<const SE::Boolean>(entry.first.get_RCP())});
+          piecewise_function.emplace_back(
+            entry.second.get_RCP(),
+            SE::rcp_static_cast<const SE::Boolean>(entry.first.get_RCP()));
         }
 
       // Add default value
-      piecewise_function.push_back(
-        {expression_otherwise.get_RCP(), SE::boolTrue});
+      piecewise_function.emplace_back(expression_otherwise.get_RCP(),
+                                      SE::boolTrue);
 
       // Initialize
-      expression = SE::piecewise(std::move(piecewise_function));
+      expression = SE::piecewise(piecewise_function);
     }
 
 

--- a/source/differentiation/sd/symengine_utilities.cc
+++ b/source/differentiation/sd/symengine_utilities.cc
@@ -75,7 +75,7 @@ namespace Differentiation
         SD::types::symbol_vector symb_vec;
         symb_vec.reserve(symbol_vector.size());
         for (const auto &entry : symbol_vector)
-          symb_vec.push_back(SD::Expression(entry));
+          symb_vec.emplace_back(entry);
         return symb_vec;
       }
 

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -3684,7 +3684,7 @@ namespace
         for (auto &pair : face_side_sets)
           {
             Assert(pair.second.size() > 0, ExcInternalError());
-            face_id_to_side_sets.push_back(std::move(pair));
+            face_id_to_side_sets.emplace_back(std::move(pair));
           }
 
         // sort by side sets:

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -3676,6 +3676,7 @@ namespace GridTools
               ArborXWrappers::DistributedTree distributed_tree(
                 comm, global_bboxes[0]);
               std::vector<BoundingBox<spacedim>> query_bounding_boxes;
+              query_bounding_boxes.reserve(entities.size());
               for (const auto &entity : entities)
                 query_bounding_boxes.emplace_back(
                   BoundingBox<spacedim>(entity).create_extended(tolerance));

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -892,7 +892,7 @@ namespace TrilinosWrappers
 
 
     void
-    Vector::swap(Vector &v)
+    Vector::swap(Vector &v) noexcept
     {
       std::swap(last_action, v.last_action);
       std::swap(compressed, v.compressed);


### PR DESCRIPTION
Related to #17202. I didn't apply any changes regarding [performance-enum-size](https://clang.llvm.org/extra/clang-tidy/checks/performance/enum-size.html). Otherwise, this addresses all clang-tidy findings with clang++-18.1.5.