### PR TITLE
Fix deal_II_exceptions::internal::abort [[noexcept]] attribute for old Kokkos

### DIFF
--- a/source/base/exceptions.cc
+++ b/source/base/exceptions.cc
@@ -520,8 +520,19 @@ namespace deal_II_exceptions
       // Let's abort the program here. On the host, we need to call std::abort,
       // on devices we need to do something different. Kokkos::abort() does
       // the right thing in all circumstances.
-      Kokkos::abort(
-        "Abort() was called during dealing with an assertion or exception.");
+      if constexpr (std::is_same_v<Kokkos::DefaultExecutionSpace,
+                                   Kokkos::DefaultHostExecutionSpace>)
+        {
+          // FIXME_KOKKOS Older Kokkos versions don't declare Kokkos::abort as
+          // [[noreturn]]. In case Kokkos is only configured with host backends,
+          // we can just use std::abort instead.
+          std::abort();
+        }
+      else
+        {
+          Kokkos::abort(
+            "Abort() was called during dealing with an assertion or exception.");
+        }
     }
 
 


### PR DESCRIPTION
This should fix the warnings in https://cdash.dealii.org/viewBuildError.php?type=1&buildid=80.