### PR TITLE
CMake: Bugfix: only set up valgrind wrapper when needed

### DIFF
--- a/tests/performance/CMakeLists.txt
+++ b/tests/performance/CMakeLists.txt
@@ -6,32 +6,36 @@ project(testsuite CXX)
 # Try to locate valgrind:
 #
 
-find_program(VALGRIND_EXECUTABLE
-  NAMES valgrind
-  HINTS ${VALGRIND_DIR}
-  PATH_SUFFIXES bin
-  )
-
-find_path(VALGRIND_INCLUDE_DIR valgrind/callgrind.h
-  HINTS ${VALGRIND_DIR}
-  PATH_SUFFIXES include
-  )
-
-if( NOT VALGRIND_EXECUTABLE MATCHES "-NOTFOUND" AND
-    NOT VALGRIND_INCLUDE_DIR MATCHES "-NOTFOUND" )
-  message(STATUS "Found valgrind at ${VALGRIND_EXECUTABLE}")
-  set(DEAL_II_WITH_VALGRIND TRUE)
-  set(_command_line
-    "${VALGRIND_EXECUTABLE}"
-    --tool=callgrind -q --combine-dumps=yes --instr-atstart=no
-    --callgrind-out-file=callgrind.out
+if(ENABLE_PERFORMANCE_TESTS)
+  find_program(VALGRIND_EXECUTABLE
+    NAMES valgrind
+    HINTS ${VALGRIND_DIR}
+    PATH_SUFFIXES bin
     )
-else()
-  message(STATUS "Could not find valgrind")
-  set(DEAL_II_WITH_VALGRIND FALSE)
-endif()
 
-set(performance_instrumentation_step_3_RUNARGS_PREFIX "${_command_line}")
-set(performance_instrumentation_step_22_RUNARGS_PREFIX "${_command_line}")
+  find_path(VALGRIND_INCLUDE_DIR valgrind/callgrind.h
+    HINTS ${VALGRIND_DIR}
+    PATH_SUFFIXES include
+    )
+
+  if( NOT VALGRIND_EXECUTABLE MATCHES "-NOTFOUND" AND
+      NOT VALGRIND_INCLUDE_DIR MATCHES "-NOTFOUND" )
+    message(STATUS "Found valgrind at ${VALGRIND_EXECUTABLE}")
+    set(DEAL_II_WITH_VALGRIND TRUE)
+
+    set(_command_line
+      "${VALGRIND_EXECUTABLE}"
+      --tool=callgrind -q --combine-dumps=yes --instr-atstart=no
+      --callgrind-out-file=callgrind.out
+      )
+    set(performance_instrumentation_step_3_RUNARGS_PREFIX "${_command_line}")
+    set(performance_instrumentation_step_22_RUNARGS_PREFIX "${_command_line}")
+
+  else()
+
+    message(STATUS "Could not find valgrind")
+    set(DEAL_II_WITH_VALGRIND FALSE)
+  endif()
+endif()
 
 deal_ii_pickup_tests()


### PR DESCRIPTION
... otherwise we're a little bit too eager to run some tests with valgrind. And valgrind doesn't understand some avx512 instructions: https://cdash.dealii.org/viewTest.php?onlyfailed&buildid=94