### PR TITLE
CMake: fix release/debug only configure with CMake 3.30

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -190,6 +190,17 @@ foreach(build ${DEAL_II_BUILD_TYPES})
       )
   endif()
 
+  if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.30")
+    #
+    # Create alias targets "dealii::dealii_release" and "dealii::dealii_debug"
+    # to have the exported target names available when populating the link
+    # interface for our "dealii::dealii" convenience target:
+    #
+    add_library(${DEAL_II_TARGET_NAME}::${DEAL_II_TARGET_NAME}_${build_lowercase}
+      ALIAS ${DEAL_II_TARGET_NAME}_${build_lowercase}
+      )
+  endif()
+
   target_link_libraries(${DEAL_II_TARGET_NAME} INTERFACE
     "$<$<CONFIG:${build_camelcase}>:${DEAL_II_TARGET_NAME}::${DEAL_II_TARGET_NAME}_${build_lowercase}>"
     )


### PR DESCRIPTION
Beginning with version 3.30 CMake makes it an error to specify a nonexistent target in a call to `target_link_libraries()` even if that target is never used internally and only part of the exported interface. This is a problem as we want to add configuration dependent targets with a generator expression that are later exported:
```
$<$<CONFIG:Release>:dealii::dealii_release> (...)
```

Note that we cannot simply use `$<$<CONFIG:Release>:dealii_release>` as CMake then does not complete `dealii_release` to `dealii::dealii_release` upon target export...

As a workaround we create alias targets with the `dealii::` namespace, which makes the call to `target_link_libraries()` succeed.

