### PR TITLE
fix compilation by putting back std::move()

### DIFF
--- a/source/differentiation/sd/symengine_number_types.cc
+++ b/source/differentiation/sd/symengine_number_types.cc
@@ -102,8 +102,9 @@ namespace Differentiation
       piecewise_function.emplace_back(expression_otherwise.get_RCP(),
                                       SE::boolTrue);
 
-      // Initialize
-      expression = SE::piecewise(piecewise_function);
+      // Initialize. Note that we need to use a std::move() here for
+      // compatibility with older compilers.
+      expression = SE::piecewise(std::move(piecewise_function)); // NOLINT
     }
 
 


### PR DESCRIPTION
Fixes 
```
source/differentiation/sd/symengine_number_types.cc:106:34: error: cannot bind rvalue reference of type ‘SymEngine::PiecewiseVec&&’ {aka ‘std::vector<std::pair<SymEngine::RCP<const SymEngine::Basic>, SymEngine::RCP<const SymEngine::Boolean> > >&&’} to lvalue of type ‘SymEngine::PiecewiseVec’ {aka ‘std::vector<std::pair<SymEngine::RCP<const SymEngine::Basic>, SymEngine::RCP<const SymEngine::Boolean> > >’}
106 |       expression = SE::piecewise(piecewise_function);
    |                                  ^~~~~~~~~~~~~~~~~~
In file included from /usr/include/symengine/sets.h:20,
                 from /usr/include/symengine/matrix.h:5,
                 from /usr/include/symengine/printers.h:5,
                 from /usr/include/symengine/expression.h:15,
                 from include/deal.II/differentiation/sd/symengine_number_types.h:29,
                 from source/differentiation/sd/symengine_number_types.cc:21:
```

In reference to #17207
