### PR TITLE
Rework and restructure type definitions of TpetraWrappers classes

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_block_sparse_matrix.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_block_sparse_matrix.templates.h
@@ -99,7 +99,7 @@ namespace LinearAlgebra
       const bool                      exchange_data)
     {
 #  ifdef DEBUG
-      std::vector<typename BlockType::MapType> tpetra_maps;
+      std::vector<typename TpetraTypes::MapType<MemorySpace>> tpetra_maps;
       for (size_type i = 0; i < block_sparsity_pattern.n_block_rows(); ++i)
         tpetra_maps.push_back(
           parallel_partitioning[i].make_tpetra_map(communicator, false));

--- a/include/deal.II/lac/trilinos_tpetra_communication_pattern.h
+++ b/include/deal.II/lac/trilinos_tpetra_communication_pattern.h
@@ -18,6 +18,10 @@
 
 #include <deal.II/base/config.h>
 
+#include "deal.II/base/memory_space.h"
+
+#include <deal.II/lac/trilinos_tpetra_types.h>
+
 #ifdef DEAL_II_TRILINOS_WITH_TPETRA
 
 #  include <deal.II/base/communication_pattern_base.h>
@@ -39,6 +43,7 @@ namespace LinearAlgebra
     class CommunicationPattern : public Utilities::MPI::CommunicationPatternBase
     {
     public:
+      using MemorySpace = dealii::MemorySpace::Host;
       /**
        * Initialize the communication pattern.
        *
@@ -83,25 +88,25 @@ namespace LinearAlgebra
       /**
        * Return the underlying Tpetra::Import object.
        */
-      const Tpetra::Import<int, types::signed_global_dof_index> &
+      const TpetraTypes::ImportType<MemorySpace> &
       get_tpetra_import() const;
 
       /**
        * Return a Teuchos::RCP to the underlying Tpetra::Import object.
        */
-      Teuchos::RCP<const Tpetra::Import<int, types::signed_global_dof_index>>
+      Teuchos::RCP<TpetraTypes::ImportType<MemorySpace>>
       get_tpetra_import_rcp() const;
 
       /**
        * Return the underlying Tpetra::Export object.
        */
-      const Tpetra::Export<int, types::signed_global_dof_index> &
+      const TpetraTypes::ExportType<MemorySpace> &
       get_tpetra_export() const;
 
       /**
        * Return a Teuchos::RCP to the underlying Tpetra::Export object.
        */
-      Teuchos::RCP<const Tpetra::Export<int, types::signed_global_dof_index>>
+      Teuchos::RCP<TpetraTypes::ExportType<MemorySpace>>
       get_tpetra_export_rcp() const;
 
     private:
@@ -113,14 +118,12 @@ namespace LinearAlgebra
       /**
        * Teuchos::RCP to the Tpetra::Import object used.
        */
-      Teuchos::RCP<Tpetra::Import<int, types::signed_global_dof_index>>
-        tpetra_import;
+      Teuchos::RCP<TpetraTypes::ImportType<MemorySpace>> tpetra_import;
 
       /**
        * Teuchos::RCP to the Tpetra::Export object used.
        */
-      Teuchos::RCP<Tpetra::Export<int, types::signed_global_dof_index>>
-        tpetra_export;
+      Teuchos::RCP<TpetraTypes::ExportType<MemorySpace>> tpetra_export;
     };
   } // end of namespace TpetraWrappers
 } // end of namespace LinearAlgebra

--- a/include/deal.II/lac/trilinos_tpetra_solver_direct.h
+++ b/include/deal.II/lac/trilinos_tpetra_solver_direct.h
@@ -19,6 +19,8 @@
 
 #include "deal.II/grid/grid_generator.h"
 
+#include "deal.II/lac/trilinos_tpetra_types.h"
+
 #include <string>
 
 #ifdef DEAL_II_TRILINOS_WITH_TPETRA
@@ -70,34 +72,6 @@ namespace LinearAlgebra
     class SolverDirectBase
     {
     public:
-      /**
-       * Declare the type for container size.
-       */
-      using size_type = dealii::types::signed_global_dof_index;
-
-      /**
-       * Typedef for the NodeType
-       */
-#    if DEAL_II_TRILINOS_VERSION_GTE(14, 2, 0)
-      using NodeType = Tpetra::KokkosCompat::KokkosDeviceWrapperNode<
-        typename MemorySpace::kokkos_space::execution_space,
-        typename MemorySpace::kokkos_space>;
-#    else
-      using NodeType = Kokkos::Compat::KokkosDeviceWrapperNode<
-        typename MemorySpace::kokkos_space::execution_space,
-        typename MemorySpace::kokkos_space>;
-#    endif
-
-      /**
-       * Typedef for the LinearOperator type
-       */
-      using LinearOperator = Tpetra::Operator<Number, int, size_type, NodeType>;
-
-      /**
-       * Typedef for the MultiVector type
-       */
-      using MultiVector = Tpetra::MultiVector<Number, int, size_type, NodeType>;
-
       /**
        * Destructor.
        */
@@ -172,8 +146,8 @@ namespace LinearAlgebra
        * A structure that contains the Trilinos solver object.
        */
       Teuchos::RCP<
-        Amesos2::Solver<typename SparseMatrix<Number, MemorySpace>::MatrixType,
-                        MultiVector>>
+        Amesos2::Solver<TpetraTypes::MatrixType<Number, MemorySpace>,
+                        TpetraTypes::MultiVectorType<Number, MemorySpace>>>
         solver;
 
       /*

--- a/include/deal.II/lac/trilinos_tpetra_solver_direct.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_solver_direct.templates.h
@@ -18,6 +18,7 @@
 #include <deal.II/base/config.h>
 
 #include "deal.II/lac/solver_control.h"
+#include "deal.II/lac/trilinos_tpetra_types.h"
 
 #include <string>
 
@@ -68,8 +69,9 @@ namespace LinearAlgebra
     {
       // Allocate the Amesos2 solver with the concrete solver, if possible.
       solver =
-        Amesos2::create<typename SparseMatrix<Number, MemorySpace>::MatrixType,
-                        MultiVector>(solver_type, A.trilinos_rcp());
+        Amesos2::create<TpetraTypes::MatrixType<Number, MemorySpace>,
+                        TpetraTypes::MultiVectorType<Number, MemorySpace>>(
+          solver_type, A.trilinos_rcp());
 
       solver->setParameters(Teuchos::rcpFromRef(parameter_list));
       // Now do the actual factorization, which is a two step procedure.
@@ -140,11 +142,9 @@ namespace LinearAlgebra
       const Vector<Number, MemorySpace>       &b)
     {
       solver =
-        Amesos2::create<typename SparseMatrix<Number, MemorySpace>::MatrixType,
-                        MultiVector>(solver_type,
-                                     A.trilinos_rcp(),
-                                     x.trilinos_rcp(),
-                                     b.trilinos_rcp());
+        Amesos2::create<TpetraTypes::MatrixType<Number, MemorySpace>,
+                        TpetraTypes::MultiVectorType<Number, MemorySpace>>(
+          solver_type, A.trilinos_rcp(), x.trilinos_rcp(), b.trilinos_rcp());
       do_solve();
     }
 

--- a/include/deal.II/lac/trilinos_tpetra_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparse_matrix.h
@@ -160,46 +160,6 @@ namespace LinearAlgebra
       using value_type = Number;
 
       /**
-       * Typedef for the NodeType
-       */
-#  if DEAL_II_TRILINOS_VERSION_GTE(14, 2, 0)
-      using NodeType = Tpetra::KokkosCompat::KokkosDeviceWrapperNode<
-        typename MemorySpace::kokkos_space::execution_space,
-        typename MemorySpace::kokkos_space>;
-#  else
-      using NodeType = Kokkos::Compat::KokkosDeviceWrapperNode<
-        typename MemorySpace::kokkos_space::execution_space,
-        typename MemorySpace::kokkos_space>;
-#  endif
-
-      /**
-       * Typedef for Tpetra::CrsMatrix
-       */
-      using MatrixType =
-        Tpetra::CrsMatrix<Number,
-                          int,
-                          dealii::types::signed_global_dof_index,
-                          NodeType>;
-
-      /**
-       * Typedef for Tpetra::Map
-       */
-      using MapType =
-        Tpetra::Map<int, dealii::types::signed_global_dof_index, NodeType>;
-
-      /**
-       * Typedef for Tpetra::CrsGraph
-       */
-      using GraphType =
-        Tpetra::CrsGraph<int, dealii::types::signed_global_dof_index, NodeType>;
-
-      /**
-       * Typedef for Tpetra::Vector
-       */
-      using VectorType = Tpetra::
-        Vector<Number, int, dealii::types::signed_global_dof_index, NodeType>;
-
-      /**
        * @name Constructors and initialization.
        */
       /** @{ */
@@ -1033,7 +993,7 @@ namespace LinearAlgebra
        * href="https://docs.trilinos.org/dev/packages/tpetra/doc/html/classTpetra_1_1CrsMatrix.html">Tpetra::CrsMatrix</a>
        * class.
        */
-      const MatrixType &
+      const TpetraTypes::MatrixType<Number, MemorySpace> &
       trilinos_matrix() const;
 
       /**
@@ -1042,7 +1002,7 @@ namespace LinearAlgebra
        * href="https://docs.trilinos.org/dev/packages/tpetra/doc/html/classTpetra_1_1CrsMatrix.html">Tpetra::CrsMatrix</a>
        * class.
        */
-      MatrixType &
+      TpetraTypes::MatrixType<Number, MemorySpace> &
       trilinos_matrix();
 
       /**
@@ -1054,7 +1014,7 @@ namespace LinearAlgebra
        * href="https://docs.trilinos.org/dev/packages/tpetra/doc/html/classTpetra_1_1CrsMatrix.html">Tpetra::CrsMatrix</a>
        * class.
        */
-      Teuchos::RCP<const MatrixType>
+      Teuchos::RCP<const TpetraTypes::MatrixType<Number, MemorySpace>>
       trilinos_rcp() const;
 
       /**
@@ -1066,7 +1026,7 @@ namespace LinearAlgebra
        * href="https://docs.trilinos.org/dev/packages/tpetra/doc/html/classTpetra_1_1CrsMatrix.html">Tpetra::CrsMatrix</a>
        * class.
        */
-      Teuchos::RCP<MatrixType>
+      Teuchos::RCP<TpetraTypes::MatrixType<Number, MemorySpace>>
       trilinos_rcp();
       /** @} */
 
@@ -1273,14 +1233,14 @@ namespace LinearAlgebra
        * information from the column space map is used to speed up the
        * assembly process.
        */
-      Teuchos::RCP<MapType> column_space_map;
+      Teuchos::RCP<TpetraTypes::MapType<MemorySpace>> column_space_map;
 
       /**
        * A sparse matrix object in Trilinos to be used for finite element based
        * problems which allows for assembling into non-local elements.  The
        * actual type, a sparse matrix, is set in the constructor.
        */
-      Teuchos::RCP<MatrixType> matrix;
+      Teuchos::RCP<TpetraTypes::MatrixType<Number, MemorySpace>> matrix;
 
       /**
        * A boolean variable to hold information on whether the matrix is
@@ -1955,11 +1915,7 @@ namespace LinearAlgebra
 
 
     template <typename Number, typename MemorySpace>
-    inline const Tpetra::CrsMatrix<
-      Number,
-      int,
-      types::signed_global_dof_index,
-      typename SparseMatrix<Number, MemorySpace>::NodeType> &
+    inline const TpetraTypes::MatrixType<Number, MemorySpace> &
     SparseMatrix<Number, MemorySpace>::trilinos_matrix() const
     {
       return *matrix;
@@ -1968,11 +1924,7 @@ namespace LinearAlgebra
 
 
     template <typename Number, typename MemorySpace>
-    inline Tpetra::CrsMatrix<
-      Number,
-      int,
-      types::signed_global_dof_index,
-      typename SparseMatrix<Number, MemorySpace>::NodeType> &
+    inline TpetraTypes::MatrixType<Number, MemorySpace> &
     SparseMatrix<Number, MemorySpace>::trilinos_matrix()
     {
       return *matrix;
@@ -1981,11 +1933,7 @@ namespace LinearAlgebra
 
 
     template <typename Number, typename MemorySpace>
-    inline Teuchos::RCP<const Tpetra::CrsMatrix<
-      Number,
-      int,
-      types::signed_global_dof_index,
-      typename SparseMatrix<Number, MemorySpace>::NodeType>>
+    inline Teuchos::RCP<const TpetraTypes::MatrixType<Number, MemorySpace>>
     SparseMatrix<Number, MemorySpace>::trilinos_rcp() const
     {
       return matrix.getConst();
@@ -1994,11 +1942,7 @@ namespace LinearAlgebra
 
 
     template <typename Number, typename MemorySpace>
-    inline Teuchos::RCP<
-      Tpetra::CrsMatrix<Number,
-                        int,
-                        types::signed_global_dof_index,
-                        typename SparseMatrix<Number, MemorySpace>::NodeType>>
+    inline Teuchos::RCP<TpetraTypes::MatrixType<Number, MemorySpace>>
     SparseMatrix<Number, MemorySpace>::trilinos_rcp()
     {
       return matrix;
@@ -2102,10 +2046,10 @@ namespace LinearAlgebra
           }
 
 #  if DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
-        typename SparseMatrix<Number, MemorySpace>::MatrixType::
+        typename TpetraTypes::MatrixType<Number, MemorySpace>::
           nonconst_global_inds_host_view_type col_indices(colnum_cache->data(),
                                                           colnums);
-        typename SparseMatrix<Number, MemorySpace>::MatrixType::
+        typename TpetraTypes::MatrixType<Number, MemorySpace>::
           nonconst_values_host_view_type values(value_cache->data(), colnums);
 #  else
         Teuchos::ArrayView<dealii::types::signed_global_dof_index> col_indices(

--- a/include/deal.II/lac/trilinos_tpetra_types.h
+++ b/include/deal.II/lac/trilinos_tpetra_types.h
@@ -1,0 +1,137 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2018 - 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#ifndef dealii_trilinos_tpetra_types_h
+#define dealii_trilinos_tpetra_types_h
+
+#include <deal.II/base/config.h>
+
+#include "deal.II/base/types.h"
+
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+
+#  include <Tpetra_Details_DefaultTypes.hpp>
+
+// Forward declarations
+#  ifndef DOXYGEN
+#    include <Tpetra_CrsGraph_fwd.hpp>
+#    include <Tpetra_CrsMatrix_fwd.hpp>
+#    include <Tpetra_Export_fwd.hpp>
+#    include <Tpetra_Import_fwd.hpp>
+#    include <Tpetra_Map_fwd.hpp>
+#    include <Tpetra_MultiVector_fwd.hpp>
+#    include <Tpetra_Operator_fwd.hpp>
+#    include <Tpetra_Vector_fwd.hpp>
+
+#  endif
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace LinearAlgebra
+{
+  namespace TpetraWrappers
+  {
+
+    namespace TpetraTypes
+    {
+      /**
+       * local ordinate (processor local indices).
+       */
+      using LO = int;
+      /**
+       * global ordinate (global indices).
+       */
+      using GO = types::signed_global_dof_index;
+
+
+#  if DEAL_II_TRILINOS_VERSION_GTE(14, 2, 0)
+      /**
+       * Where and how calculations should be executed,
+       * i.e. Host (Serial,OpenMP) or Device (GPU)
+       */
+      //
+      template <typename MemorySpace>
+      using NodeType = Tpetra::KokkosCompat::KokkosDeviceWrapperNode<
+        typename MemorySpace::kokkos_space::execution_space,
+        typename MemorySpace::kokkos_space>;
+#  else
+      template <typename MemorySpace>
+      using NodeType = Kokkos::Compat::KokkosDeviceWrapperNode<
+        typename MemorySpace::kokkos_space::execution_space,
+        typename MemorySpace::kokkos_space>;
+#  endif
+
+
+      /**
+       * Communication between processors.
+       */
+      template <typename MemorySpace>
+      using ExportType = Tpetra::Export<LO, GO, NodeType<MemorySpace>>;
+
+      /**
+       * Communication between processors.
+       */
+      template <typename MemorySpace>
+      using ImportType = Tpetra::Import<LO, GO, NodeType<MemorySpace>>;
+
+      /**
+       * Tpetra equivalent of IndexSet.
+       */
+      template <typename MemorySpace>
+      using MapType = Tpetra::Map<LO, GO, NodeType<MemorySpace>>;
+
+      /**
+       * Tpetra sparsity pattern type.
+       */
+      template <typename MemorySpace>
+      using GraphType = Tpetra::CrsGraph<LO, GO, NodeType<MemorySpace>>;
+
+      /**
+       * Tpetra Vector type.
+       */
+      template <typename Number, typename MemorySpace>
+      using VectorType = Tpetra::Vector<Number, LO, GO, NodeType<MemorySpace>>;
+
+      /**
+       * Tpetra type for a row column vectors.
+       */
+      template <typename Number, typename MemorySpace>
+      using MultiVectorType =
+        Tpetra::MultiVector<Number, LO, GO, NodeType<MemorySpace>>;
+
+
+      /**
+       * General Tpetra class for a linear operator,
+       * e.g. a Matrix or Preconditioner.
+       *
+       */
+      template <typename Number, typename MemorySpace>
+      using LinearOperator =
+        Tpetra::Operator<Number, LO, GO, NodeType<MemorySpace>>;
+
+
+      /**
+       * Tpetra type for a parallel distributed sparse matrix in Crs or CSR
+       * format.
+       */
+      template <typename Number, typename MemorySpace>
+      using MatrixType =
+        Tpetra::CrsMatrix<Number, LO, GO, NodeType<MemorySpace>>;
+    } // namespace TpetraTypes
+  }   // namespace TpetraWrappers
+} // namespace LinearAlgebra
+DEAL_II_NAMESPACE_CLOSE
+#endif
+
+#endif

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -18,6 +18,10 @@
 
 #include <deal.II/base/config.h>
 
+#include "deal.II/base/types.h"
+
+#include <deal.II/lac/trilinos_tpetra_types.h>
+
 #ifdef DEAL_II_TRILINOS_WITH_TPETRA
 
 #  include <deal.II/base/index_set.h>
@@ -100,6 +104,7 @@ namespace LinearAlgebra
    */
   namespace TpetraWrappers
   {
+
     /**
      * This class defines type aliases that are used in vector classes
      * within the TpetraWrappers namespace.
@@ -107,7 +112,7 @@ namespace LinearAlgebra
     class VectorTraits
     {
     public:
-      using size_type = dealii::types::global_dof_index;
+      using size_type = types::global_dof_index;
     };
 
     /**
@@ -125,7 +130,7 @@ namespace LinearAlgebra
       /**
        * Declare type for container size.
        */
-      using size_type = VectorTraits::size_type;
+      using size_type = types::global_dof_index;
 
       /**
        * This class implements a wrapper for accessing the Trilinos Tpetra
@@ -286,29 +291,12 @@ namespace LinearAlgebra
       /**
        * Declare some of the standard types used in all containers.
        */
-#  if DEAL_II_TRILINOS_VERSION_GTE(14, 2, 0)
-      using NodeType = Tpetra::KokkosCompat::KokkosDeviceWrapperNode<
-        typename MemorySpace::kokkos_space::execution_space,
-        typename MemorySpace::kokkos_space>;
-#  else
-      using NodeType = Kokkos::Compat::KokkosDeviceWrapperNode<
-        typename MemorySpace::kokkos_space::execution_space,
-        typename MemorySpace::kokkos_space>;
-#  endif
       using value_type = Number;
       using real_type  = typename numbers::NumberTraits<Number>::real_type;
-      using size_type  = VectorTraits::size_type;
+      using size_type  = types::global_dof_index;
       using reference  = internal::VectorReference<Number, MemorySpace>;
       using const_reference =
         const internal::VectorReference<Number, MemorySpace>;
-      using MapType =
-        Tpetra::Map<int, dealii::types::signed_global_dof_index, NodeType>;
-      using VectorType = Tpetra::
-        Vector<Number, int, dealii::types::signed_global_dof_index, NodeType>;
-      using ExportType =
-        Tpetra::Export<int, dealii::types::signed_global_dof_index, NodeType>;
-      using ImportType =
-        Tpetra::Import<int, dealii::types::signed_global_dof_index, NodeType>;
 
       /**
        * @name 1: Basic Object-handling
@@ -330,7 +318,8 @@ namespace LinearAlgebra
       /**
        *  Copy constructor from Teuchos::RCP<Tpetra::Vector>.
        */
-      Vector(const Teuchos::RCP<VectorType> V);
+      Vector(
+        const Teuchos::RCP<TpetraTypes::VectorType<Number, MemorySpace>> V);
 
       /**
        * TODO: This is not used
@@ -912,29 +901,28 @@ namespace LinearAlgebra
        * Return a const reference to the underlying Trilinos
        * Tpetra::Vector class.
        */
-      const Tpetra::Vector<Number, int, types::signed_global_dof_index> &
+      const TpetraTypes::VectorType<Number, MemorySpace> &
       trilinos_vector() const;
 
       /**
        * Return a (modifiable) reference to the underlying Trilinos
        * Tpetra::Vector class.
        */
-      Tpetra::Vector<Number, int, types::signed_global_dof_index> &
+      TpetraTypes::VectorType<Number, MemorySpace> &
       trilinos_vector();
 
       /**
        * Return a const Teuchos::RCP to the underlying Trilinos
        * Tpetra::Vector class.
        */
-      Teuchos::RCP<
-        const Tpetra::Vector<Number, int, types::signed_global_dof_index>>
+      Teuchos::RCP<const TpetraTypes::VectorType<Number, MemorySpace>>
       trilinos_rcp() const;
 
       /**
        * Return a (modifiable) Teuchos::RCP to the underlying Trilinos
        * Tpetra::Vector class.
        */
-      Teuchos::RCP<Tpetra::Vector<Number, int, types::signed_global_dof_index>>
+      Teuchos::RCP<TpetraTypes::VectorType<Number, MemorySpace>>
       trilinos_rcp();
 
       /**
@@ -1056,14 +1044,15 @@ namespace LinearAlgebra
       /**
        * Teuchos::RCP to the actual Tpetra vector object.
        */
-      Teuchos::RCP<VectorType> vector;
+      Teuchos::RCP<TpetraTypes::VectorType<Number, MemorySpace>> vector;
 
       /**
        * A vector object in Trilinos to be used for collecting the non-local
        * elements if the vector was constructed with an additional IndexSet
        * describing ghost elements.
        */
-      Teuchos::RCP<VectorType> nonlocal_vector;
+      Teuchos::RCP<TpetraTypes::VectorType<Number, MemorySpace>>
+        nonlocal_vector;
 
       /**
        * IndexSet of the elements of the last imported vector.

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -81,11 +81,10 @@ namespace LinearAlgebra
       : Subscriptor()
       , compressed(true)
       , has_ghost(false)
-      , vector(Utilities::Trilinos::internal::make_rcp<VectorType>(
-          Utilities::Trilinos::internal::make_rcp<MapType>(
-            0,
-            0,
-            Utilities::Trilinos::tpetra_comm_self())))
+      , vector(Utilities::Trilinos::internal::make_rcp<
+               TpetraTypes::VectorType<Number, MemorySpace>>(
+          Utilities::Trilinos::internal::make_rcp<TpetraTypes::MapType<
+            MemorySpace>>(0, 0, Utilities::Trilinos::tpetra_comm_self())))
     {}
 
 
@@ -95,19 +94,21 @@ namespace LinearAlgebra
       : Subscriptor()
       , compressed(V.compressed)
       , has_ghost(V.has_ghost)
-      , vector(
-          Utilities::Trilinos::internal::make_rcp<VectorType>(*V.vector,
-                                                              Teuchos::Copy))
+      , vector(Utilities::Trilinos::internal::make_rcp<
+               TpetraTypes::VectorType<Number, MemorySpace>>(*V.vector,
+                                                             Teuchos::Copy))
     {
       if (!V.nonlocal_vector.is_null())
-        nonlocal_vector = Utilities::Trilinos::internal::make_rcp<VectorType>(
-          *V.nonlocal_vector, Teuchos::Copy);
+        nonlocal_vector = Utilities::Trilinos::internal::make_rcp<
+          TpetraTypes::VectorType<Number, MemorySpace>>(*V.nonlocal_vector,
+                                                        Teuchos::Copy);
     }
 
 
 
     template <typename Number, typename MemorySpace>
-    Vector<Number, MemorySpace>::Vector(const Teuchos::RCP<VectorType> V)
+    Vector<Number, MemorySpace>::Vector(
+      const Teuchos::RCP<TpetraTypes::VectorType<Number, MemorySpace>> V)
       : Subscriptor()
       , compressed(true)
       , has_ghost(V->getMap()->isOneToOne() == false)
@@ -122,7 +123,8 @@ namespace LinearAlgebra
       : Subscriptor()
       , compressed(true)
       , has_ghost(false)
-      , vector(Utilities::Trilinos::internal::make_rcp<VectorType>(
+      , vector(Utilities::Trilinos::internal::make_rcp<
+               TpetraTypes::VectorType<Number, MemorySpace>>(
           parallel_partitioner.make_tpetra_map_rcp(communicator, true)))
     {}
 
@@ -140,20 +142,23 @@ namespace LinearAlgebra
           IndexSet parallel_partitioner = locally_owned_entries;
           parallel_partitioner.add_indices(ghost_entries);
 
-          vector = Utilities::Trilinos::internal::make_rcp<VectorType>(
+          vector = Utilities::Trilinos::internal::make_rcp<
+            TpetraTypes::VectorType<Number, MemorySpace>>(
             parallel_partitioner.make_tpetra_map_rcp(communicator, true));
 
           compressed = true;
         }
       else
         {
-          Teuchos::RCP<MapType> map =
+          Teuchos::RCP<TpetraTypes::MapType<MemorySpace>> map =
             locally_owned_entries.make_tpetra_map_rcp(communicator, false);
-          vector = Utilities::Trilinos::internal::make_rcp<VectorType>(map);
+          vector = Utilities::Trilinos::internal::make_rcp<
+            TpetraTypes::VectorType<Number, MemorySpace>>(map);
 
           IndexSet nonlocal_entries(ghost_entries);
           nonlocal_entries.subtract_set(locally_owned_entries);
-          nonlocal_vector = Utilities::Trilinos::internal::make_rcp<VectorType>(
+          nonlocal_vector = Utilities::Trilinos::internal::make_rcp<
+            TpetraTypes::VectorType<Number, MemorySpace>>(
             nonlocal_entries.make_tpetra_map_rcp(communicator, true));
 
           compressed = false;
@@ -176,8 +181,10 @@ namespace LinearAlgebra
     void
     Vector<Number, MemorySpace>::clear()
     {
-      vector = Utilities::Trilinos::internal::make_rcp<VectorType>(
-        Utilities::Trilinos::internal::make_rcp<MapType>(
+      vector = Utilities::Trilinos::internal::make_rcp<
+        TpetraTypes::VectorType<Number, MemorySpace>>(
+        Utilities::Trilinos::internal::make_rcp<
+          TpetraTypes::MapType<MemorySpace>>(
           0, 0, Utilities::Trilinos::tpetra_comm_self()));
       has_ghost  = false;
       compressed = true;
@@ -197,7 +204,8 @@ namespace LinearAlgebra
 
       compressed = true;
       has_ghost  = false;
-      vector     = Utilities::Trilinos::internal::make_rcp<VectorType>(
+      vector     = Utilities::Trilinos::internal::make_rcp<
+        TpetraTypes::VectorType<Number, MemorySpace>>(
         parallel_partitioner.make_tpetra_map_rcp(communicator, true));
     }
 
@@ -220,20 +228,22 @@ namespace LinearAlgebra
           IndexSet parallel_partitioner = locally_owned_entries;
           parallel_partitioner.add_indices(ghost_entries);
 
-          vector = Utilities::Trilinos::internal::make_rcp<VectorType>(
+          vector = Utilities::Trilinos::internal::make_rcp<
+            TpetraTypes::VectorType<Number, MemorySpace>>(
             parallel_partitioner.make_tpetra_map_rcp(communicator, true));
 
           compressed = true;
         }
       else
         {
-          Teuchos::RCP<MapType> map =
+          Teuchos::RCP<TpetraTypes::MapType<MemorySpace>> map =
             locally_owned_entries.make_tpetra_map_rcp(communicator, false);
 
           if (!vector->getMap()->isSameAs(*map))
             {
               vector.reset();
-              vector = Utilities::Trilinos::internal::make_rcp<VectorType>(map);
+              vector = Utilities::Trilinos::internal::make_rcp<
+                TpetraTypes::VectorType<Number, MemorySpace>>(map);
             }
           else
             vector->putScalar(0);
@@ -241,7 +251,8 @@ namespace LinearAlgebra
           IndexSet nonlocal_entries(ghost_entries);
           nonlocal_entries.subtract_set(locally_owned_entries);
 
-          nonlocal_vector = Utilities::Trilinos::internal::make_rcp<VectorType>(
+          nonlocal_vector = Utilities::Trilinos::internal::make_rcp<
+            TpetraTypes::VectorType<Number, MemorySpace>>(
             nonlocal_entries.make_tpetra_map_rcp(communicator, true));
 
           compressed = false;
@@ -385,7 +396,7 @@ namespace LinearAlgebra
                    "Therefore, compress() must be called on this "
                    "vector first."));
 
-          Teuchos::RCP<const ImportType> importer =
+          Teuchos::RCP<const TpetraTypes::ImportType<MemorySpace>> importer =
             Tpetra::createImport(V.vector->getMap(), vector->getMap());
 
           // Since we are distributing the vector from a one-to-one map
@@ -396,9 +407,9 @@ namespace LinearAlgebra
       else
         {
           vector.reset();
-          vector =
-            Utilities::Trilinos::internal::make_rcp<VectorType>(*V.vector,
-                                                                Teuchos::Copy);
+          vector = Utilities::Trilinos::internal::make_rcp<
+            TpetraTypes::VectorType<Number, MemorySpace>>(*V.vector,
+                                                          Teuchos::Copy);
 
           compressed             = V.compressed;
           has_ghost              = V.has_ghost;
@@ -424,7 +435,8 @@ namespace LinearAlgebra
       nonlocal_vector.reset();
 
       Teuchos::Array<OtherNumber> vector_data(V.begin(), V.end());
-      vector = Utilities::Trilinos::internal::make_rcp<VectorType>(
+      vector = Utilities::Trilinos::internal::make_rcp<
+        TpetraTypes::VectorType<Number, MemorySpace>>(
         V.locally_owned_elements().make_tpetra_map_rcp(), vector_data);
 
       has_ghost  = false;
@@ -494,10 +506,11 @@ namespace LinearAlgebra
               "LinearAlgebra::TpetraWrappers::CommunicationPattern."));
         }
 
-      Teuchos::RCP<const ExportType> tpetra_export =
+      Teuchos::RCP<const TpetraTypes::ExportType<MemorySpace>> tpetra_export =
         tpetra_comm_pattern->get_tpetra_export_rcp();
 
-      VectorType source_vector(tpetra_export->getSourceMap());
+      TpetraTypes::VectorType<Number, MemorySpace> source_vector(
+        tpetra_export->getSourceMap());
 
       {
 #  if DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
@@ -605,8 +618,8 @@ namespace LinearAlgebra
           // elements, maybe there is a better workaround.
           Tpetra::Vector<Number, int, types::signed_global_dof_index> dummy(
             vector->getMap(), false);
-          ImportType data_exchange(V.trilinos_vector().getMap(),
-                                   dummy.getMap());
+          TpetraTypes::ImportType<MemorySpace> data_exchange(
+            V.trilinos_vector().getMap(), dummy.getMap());
           dummy.doImport(V.trilinos_vector(), data_exchange, Tpetra::INSERT);
 
           vector->update(1.0, dummy, 1.0);
@@ -1105,7 +1118,7 @@ namespace LinearAlgebra
           else
             DEAL_II_NOT_IMPLEMENTED();
 
-          Teuchos::RCP<const ExportType> exporter =
+          Teuchos::RCP<const TpetraTypes::ExportType<MemorySpace>> exporter =
             Tpetra::createExport(nonlocal_vector->getMap(), vector->getMap());
           vector->doExport(*nonlocal_vector, *exporter, tpetra_operation);
 
@@ -1116,7 +1129,7 @@ namespace LinearAlgebra
 
 
     template <typename Number, typename MemorySpace>
-    const Tpetra::Vector<Number, int, types::signed_global_dof_index> &
+    const TpetraTypes::VectorType<Number, MemorySpace> &
     Vector<Number, MemorySpace>::trilinos_vector() const
     {
       return *vector;
@@ -1125,7 +1138,7 @@ namespace LinearAlgebra
 
 
     template <typename Number, typename MemorySpace>
-    Tpetra::Vector<Number, int, types::signed_global_dof_index> &
+    TpetraTypes::VectorType<Number, MemorySpace> &
     Vector<Number, MemorySpace>::trilinos_vector()
     {
       return *vector;
@@ -1134,7 +1147,7 @@ namespace LinearAlgebra
 
 
     template <typename Number, typename MemorySpace>
-    Teuchos::RCP<Tpetra::Vector<Number, int, types::signed_global_dof_index>>
+    Teuchos::RCP<TpetraTypes::VectorType<Number, MemorySpace>>
     Vector<Number, MemorySpace>::trilinos_rcp()
     {
       return vector;
@@ -1143,8 +1156,7 @@ namespace LinearAlgebra
 
 
     template <typename Number, typename MemorySpace>
-    Teuchos::RCP<
-      const Tpetra::Vector<Number, int, types::signed_global_dof_index>>
+    Teuchos::RCP<const TpetraTypes::VectorType<Number, MemorySpace>>
     Vector<Number, MemorySpace>::trilinos_rcp() const
     {
       return vector.getConst();

--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -198,13 +198,13 @@ Vector<Number>::Vector(
       // Copy the distributed vector to
       // a local one at all processors
       // that know about the original vector.
-      typename LinearAlgebra::TpetraWrappers::Vector<OtherNumber,
-                                                     MemorySpace>::VectorType
+      LinearAlgebra::TpetraWrappers::TpetraTypes::VectorType<OtherNumber,
+                                                             MemorySpace>
         localized_vector(complete_index_set(size()).make_tpetra_map_rcp(),
                          v.get_mpi_communicator());
 
-      Teuchos::RCP<const typename LinearAlgebra::TpetraWrappers::
-                     Vector<OtherNumber, MemorySpace>::ImportType>
+      Teuchos::RCP<const LinearAlgebra::TpetraWrappers::TpetraTypes::ImportType<
+        MemorySpace>>
         importer = Tpetra::createImport(v.trilinos_vector().getMap(),
                                         localized_vector.getMap());
 
@@ -888,13 +888,13 @@ Vector<Number>::operator=(
       // Copy the distributed vector to
       // a local one at all processors
       // that know about the original vector.
-      typename LinearAlgebra::TpetraWrappers::Vector<OtherNumber,
-                                                     MemorySpace>::VectorType
+      LinearAlgebra::TpetraWrappers::TpetraTypes::VectorType<OtherNumber,
+                                                             MemorySpace>
         localized_vector(complete_index_set(size()).make_tpetra_map_rcp(),
                          v.get_mpi_communicator());
 
-      Teuchos::RCP<const typename LinearAlgebra::TpetraWrappers::
-                     Vector<OtherNumber, MemorySpace>::ImportType>
+      Teuchos::RCP<const LinearAlgebra::TpetraWrappers::TpetraTypes::ImportType<
+        MemorySpace>>
         importer = Tpetra::createImport(v.trilinos_vector().getMap(),
                                         localized_vector.getMap());
 

--- a/source/lac/trilinos_tpetra_communication_pattern.cc
+++ b/source/lac/trilinos_tpetra_communication_pattern.cc
@@ -12,6 +12,9 @@
 //
 // ------------------------------------------------------------------------
 
+#include "deal.II/base/memory_space.h"
+
+#include "deal.II/lac/trilinos_tpetra_types.h"
 #include <deal.II/lac/trilinos_tpetra_communication_pattern.h>
 
 #ifdef DEAL_II_TRILINOS_WITH_TPETRA
@@ -84,7 +87,7 @@ namespace LinearAlgebra
 
 
 
-    Teuchos::RCP<const Tpetra::Import<int, types::signed_global_dof_index>>
+    Teuchos::RCP<TpetraTypes::ImportType<dealii::MemorySpace::Host>>
     CommunicationPattern::get_tpetra_import_rcp() const
     {
       return tpetra_import;
@@ -100,7 +103,7 @@ namespace LinearAlgebra
 
 
 
-    Teuchos::RCP<const Tpetra::Export<int, types::signed_global_dof_index>>
+    Teuchos::RCP<TpetraTypes::ExportType<dealii::MemorySpace::Host>>
     CommunicationPattern::get_tpetra_export_rcp() const
     {
       return tpetra_export;


### PR DESCRIPTION
This PR works at unifying the type definitions throughout the the TpetraWrappers classes.

It is a twofold approach 
1. unify definitions of `std::size_type` as mentioned in #16671
2. Add a namespace `TpetraTypes` to have all the things like `NodeTypes` in one place.

Note that this is in some consistency conflict with #17183 and whichever is merged first will require some work and rebasing in the other PR to make things consistent again.