### PR TITLE
fix tests/sundials/kinsol_08 warning

### DIFF
--- a/tests/sundials/kinsol_08.cc
+++ b/tests/sundials/kinsol_08.cc
@@ -64,7 +64,7 @@ main()
 
   SUNDIALS::KINSOL<VectorType> kinsol(data);
 
-  kinsol.reinit_vector = [N](VectorType &v) { v.reinit(N); };
+  kinsol.reinit_vector = [N = N](VectorType &v) { v.reinit(N); };
 
   kinsol.residual = [](const VectorType &u, VectorType &F) {
     deallog << "Evaluating the solution at u=(" << u[0] << ',' << u[1] << ')'


### PR DESCRIPTION
I don't quite know why clang 18 complains
/srv/temp/testsuite-rKmw5ZRc/dealii/tests/sundials/kinsol_08.cc:67:27: warning: lambda capture 'N' is not required to be captured for this use [-Wunused-lambda-capture]
   67 |   kinsol.reinit_vector = [N](VectorType &v) { v.reinit(N); };
but this fixes it.

See https://cdash.dealii.org/test/1389103