### PR TITLE
fix tests/numerics/nonlinear_solver_selector_01

### DIFF
--- a/tests/numerics/nonlinear_solver_selector_01.cc
+++ b/tests/numerics/nonlinear_solver_selector_01.cc
@@ -386,8 +386,10 @@ namespace nonlinear_solver_selector_test
 
 
 int
-main()
+main(int argc, char *argv[])
 {
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
   initlog();
 
   using namespace nonlinear_solver_selector_test;


### PR DESCRIPTION
we should initialize MPI before make calls into sundials, otherwise we might get runtime errors:

https://cdash.dealii.org/test/1390077