### PR TITLE
ReadWriteVector: correctly copy an index set with no elements.

### DIFF
--- a/doc/news/changes/minor/20240708WellsAbdala
+++ b/doc/news/changes/minor/20240708WellsAbdala
@@ -1,0 +1,4 @@
+Fixed: ReadWriteVector's copy constructor now correctly sets up its IndexSet
+when it has zero locally owned elements.
+<br>
+(David Wells, Laryssa Abdala, 2023/07/08)

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -307,10 +307,7 @@ namespace LinearAlgebra
     if (PointerComparison::equal(this, &in_vector))
       return *this;
 
-    thread_loop_partitioner = in_vector.thread_loop_partitioner;
-    if (locally_owned_size() != in_vector.locally_owned_size())
-      reinit(in_vector, true);
-
+    reinit(in_vector, true);
     if (locally_owned_size() > 0)
       {
         dealii::internal::VectorOperations::Vector_copy<Number, Number> copier(
@@ -329,10 +326,7 @@ namespace LinearAlgebra
   ReadWriteVector<Number> &
   ReadWriteVector<Number>::operator=(const ReadWriteVector<Number2> &in_vector)
   {
-    thread_loop_partitioner = in_vector.thread_loop_partitioner;
-    if (locally_owned_size() != in_vector.locally_owned_size())
-      reinit(in_vector, true);
-
+    reinit(in_vector, true);
     if (locally_owned_size() > 0)
       {
         dealii::internal::VectorOperations::Vector_copy<Number, Number2> copier(

--- a/tests/lac/readwritevector_assignment.cc
+++ b/tests/lac/readwritevector_assignment.cc
@@ -23,14 +23,11 @@
 
 
 void
-test()
+test(const IndexSet &is)
 {
   unsigned int double_size = 2;
   unsigned int float_size  = 10;
-  IndexSet     is(50);
-  is.add_range(0, 2);
-  is.add_index(46);
-  is.add_range(10, 15);
+
   LinearAlgebra::ReadWriteVector<double> double_vector(is);
   LinearAlgebra::ReadWriteVector<float>  float_vector(float_size);
   deallog << "double_size " << double_vector.locally_owned_size() << std::endl;
@@ -50,6 +47,9 @@ test()
 
   LinearAlgebra::ReadWriteVector<double> double_vector2(double_vector);
   double_vector2.print(deallog.get_file_stream());
+  deallog << "copy local size = " << double_vector2.locally_owned_size()
+          << std::endl;
+  deallog << "copy size       = " << double_vector2.size() << std::endl;
 
   for (unsigned int i = 0; i < double_vector.locally_owned_size(); ++i)
     double_vector2.local_element(i) += i;
@@ -61,7 +61,19 @@ int
 main()
 {
   initlog();
-  test();
 
-  return 0;
+  // Test with a normal index set:
+  {
+    IndexSet is(50);
+    is.add_range(0, 2);
+    is.add_index(46);
+    is.add_range(10, 15);
+    test(is);
+  }
+
+  // Test with an empty index set:
+  {
+    IndexSet is(50);
+    test(is);
+  }
 }

--- a/tests/lac/readwritevector_assignment.output
+++ b/tests/lac/readwritevector_assignment.output
@@ -43,6 +43,8 @@ IndexSet: {[0,1], [10,14], 46}
 [13]: 5.000e+00
 [14]: 6.000e+00
 [46]: 7.000e+00
+DEAL::copy local size = 8
+DEAL::copy size       = 50
 IndexSet: {[0,1], [10,14], 46}
 
 [0]: 0.000e+00
@@ -53,3 +55,27 @@ IndexSet: {[0,1], [10,14], 46}
 [13]: 1.000e+01
 [14]: 1.200e+01
 [46]: 1.400e+01
+DEAL::double_size 0
+DEAL::float_size 10
+IndexSet: {}
+
+IndexSet: {[0,9]}
+
+[0]: 0.000e+00
+[1]: 1.000e+00
+[2]: 2.000e+00
+[3]: 3.000e+00
+[4]: 4.000e+00
+[5]: 5.000e+00
+[6]: 6.000e+00
+[7]: 7.000e+00
+[8]: 8.000e+00
+[9]: 9.000e+00
+IndexSet: {}
+
+IndexSet: {}
+
+DEAL::copy local size = 0
+DEAL::copy size       = 50
+IndexSet: {}
+


### PR DESCRIPTION
This bug only occurs when we copy a RWV with an empty IndexSet defined over a nonempty range. The fix is simple: don't be too clever and instead just always call reinit().

Credit goes to @labdala for finding the problem with some assertions!