### PR TITLE
Rename a third callback in PETScWrappers::TimeStepper.

### DIFF
--- a/doc/news/changes/minor/20240709Bangerth
+++ b/doc/news/changes/minor/20240709Bangerth
@@ -1,0 +1,7 @@
+Deprecated: The `interpolate` callback of the
+PETScWrappers::TimeStepper class has been renamed to
+PETScWrappers::TimeStepper::transfer_solution_vectors_to_new_mesh. The former
+name is still available for backward compatibility, but is now
+deprecated.
+<br>
+(Wolfgang Bangerth, 2024/07/09)

--- a/include/deal.II/lac/petsc_ts.h
+++ b/include/deal.II/lac/petsc_ts.h
@@ -651,22 +651,33 @@ namespace PETScWrappers
       decide_and_prepare_for_remeshing;
 
     /**
-     * Callback to interpolate vectors and perform mesh adaption.
+     * @deprecated This callback is equivalent to `transfer_solution_vectors_to_new_mesh`, but is
+     * deprecated. Use `transfer_solution_vectors_to_new_mesh` instead.
+     */
+    DEAL_II_DEPRECATED_EARLY
+    std::function<void(const std::vector<VectorType> &all_in,
+                       std::vector<VectorType>       &all_out)>
+      interpolate;
+
+    /**
+     * Callback to perform mesh adaptation and transfer solution vectors
+     * from the old to the new mesh.
      *
      * Implementation of this function is mandatory if
-     * TimeStepper::decide_for_coarsening_and_refinement is used.
+     * TimeStepper::decide_and_prepare_for_remeshing is used.
      * This function must perform mesh adaption and interpolate the discrete
-     * functions that are stored in @p all_in onto the refined and/or coarsenend grid.
-     * Output vectors must be created inside the callback.
+     * functions that are stored in @p all_in onto the refined and/or coarsened grid.
+     * The output vectors must be sized correctly within this callback.
      *
      * @note This variable represents a
      * @ref GlossUserProvidedCallBack "user provided callback".
      * See there for a description of how to deal with errors and other
      * requirements and conventions.
      */
-    std::function<void(const std::vector<VectorType> &all_in,
+    std::function<void(const real_type                t,
+                       const std::vector<VectorType> &all_in,
                        std::vector<VectorType>       &all_out)>
-      interpolate;
+      transfer_solution_vectors_to_new_mesh;
 
   private:
     /**

--- a/tests/petsc/petsc_ts_03.cc
+++ b/tests/petsc/petsc_ts_03.cc
@@ -187,8 +187,10 @@ public:
     };
 
     // This callback is called if decide_and_prepare_for_remeshing returns true.
-    time_stepper.interpolate = [&](const std::vector<VectorType> &all_in,
-                                   std::vector<VectorType> &all_out) -> void {
+    time_stepper.transfer_solution_vectors_to_new_mesh =
+      [&](const double /* t */,
+          const std::vector<VectorType> &all_in,
+          std::vector<VectorType>       &all_out) -> void {
       deallog << "Interpolate" << std::endl;
       for (auto &v : all_in)
         all_out.push_back(v);


### PR DESCRIPTION
This is the third part for #17180. Fixes #17180.

@stefanozampini FYI.