### PR TITLE
Fix doxygen warnings

### DIFF
--- a/doc/doxygen/headers/laoperators.h
+++ b/doc/doxygen/headers/laoperators.h
@@ -193,5 +193,4 @@
  *
  *
  * @ingroup LAC
- * @ingroup MATRICES
  */

--- a/include/deal.II/base/geometry_info.h
+++ b/include/deal.II/base/geometry_info.h
@@ -479,8 +479,6 @@ private:
  * <code>RefinementPossibilities@<1@></code>,
  * <code>RefinementPossibilities@<2@></code>, and
  * <code>RefinementPossibilities@<3@></code>.
- *
- * @ingroup aniso
  */
 template <int dim>
 struct RefinementPossibilities
@@ -549,8 +547,6 @@ struct RefinementPossibilities
  *
  * This specialization is used for <code>dim=1</code>, where it offers
  * refinement in x-direction.
- *
- * @ingroup aniso
  */
 template <>
 struct RefinementPossibilities<1>
@@ -615,8 +611,6 @@ struct RefinementPossibilities<1>
  * This specialization is used for <code>dim=2</code>, where it offers
  * refinement in x- and y-direction separately, as well as isotropic
  * refinement in both directions at the same time.
- *
- * @ingroup aniso
  */
 template <>
 struct RefinementPossibilities<2>
@@ -690,8 +684,6 @@ struct RefinementPossibilities<2>
  * This specialization is used for <code>dim=3</code>, where it offers
  * refinement in x-, y- and z-direction separately, as well as combinations of
  * these and isotropic refinement in all directions at the same time.
- *
- * @ingroup aniso
  */
 template <>
 struct RefinementPossibilities<3>
@@ -781,8 +773,6 @@ struct RefinementPossibilities<3>
  * <code>dim=2</code>, etc.). Possible values of this class are the ones
  * listed in the enumeration declared within the base class; see there for
  * more information.
- *
- * @ingroup aniso
  */
 template <int dim>
 class RefinementCase : public RefinementPossibilities<dim>
@@ -922,8 +912,6 @@ namespace internal
    * <code>SubfacePossibilities@<1@></code>,
    * <code>SubfacePossibilities@<2@></code> and
    * <code>SubfacePossibilities@<3@></code>.
-   *
-   * @ingroup aniso
    */
   template <int dim>
   struct SubfacePossibilities
@@ -951,8 +939,6 @@ namespace internal
    * space dimension @p dim) might be subdivided into subfaces.
    *
    * For <code>dim=0</code> we provide a dummy implementation only.
-   *
-   * @ingroup aniso
    */
   template <>
   struct SubfacePossibilities<0>
@@ -984,8 +970,6 @@ namespace internal
    *
    * For <code>dim=1</code> there are no faces. Thereby, there are no subface
    * possibilities.
-   *
-   * @ingroup aniso
    */
   template <>
   struct SubfacePossibilities<1>
@@ -1018,8 +1002,6 @@ namespace internal
    * This specialization is used for <code>dim=2</code>, where it offers the
    * following possibilities: a face (line) being refined
    * (<code>case_x</code>) or not refined (<code>case_no</code>).
-   *
-   * @ingroup aniso
    */
   template <>
   struct SubfacePossibilities<2>
@@ -1137,8 +1119,6 @@ namespace internal
    * *---*---*
    *
    * @endcode
-   *
-   * @ingroup aniso
    */
   template <>
   struct SubfacePossibilities<3>
@@ -1171,8 +1151,6 @@ namespace internal
   /**
    * A class that provides all possible cases a face (in the current space
    * dimension @p dim) might be subdivided into subfaces.
-   *
-   * @ingroup aniso
    */
   template <int dim>
   class SubfaceCase : public SubfacePossibilities<dim>
@@ -1248,7 +1226,7 @@ struct GeometryInfo;
  * This information should always replace hard-coded numbers of vertices,
  * neighbors and so on, since it can be used dimension independently.
  *
- * @ingroup grid geomprimitives aniso
+ * @ingroup grid geomprimitives
  */
 template <>
 struct GeometryInfo<0>
@@ -1979,7 +1957,7 @@ struct GeometryInfo<0>
  * @ref Instantiations
  * in the manual).
  *
- * @ingroup grid geomprimitives aniso
+ * @ingroup grid geomprimitives
  */
 template <int dim>
 struct GeometryInfo

--- a/include/deal.II/base/mpi_consensus_algorithms.h
+++ b/include/deal.II/base/mpi_consensus_algorithms.h
@@ -125,8 +125,6 @@ namespace Utilities
      * an MPI communicator, a list of targets, and function objects that
      * encode and decode the messages to be sent, but no functions for
      * encoding a reply, or processing a reply.
-     *
-     * @ingroup MPI
      */
     namespace ConsensusAlgorithms
     {

--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -1367,8 +1367,6 @@ namespace Threads
    * the calls that add subtasks. Otherwise, there might be a deadlock. In
    * other words, a Task object should never passed on to another task for
    * calling the join() method.
-   *
-   * @ingroup tasks
    */
   template <typename RT = void>
   class TaskGroup

--- a/include/deal.II/distributed/fully_distributed_tria.h
+++ b/include/deal.II/distributed/fully_distributed_tria.h
@@ -41,8 +41,6 @@ namespace parallel
 {
   /**
    * A namespace for the fully distributed triangulation.
-   *
-   * @ingroup parallel
    */
   namespace fullydistributed
   {

--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -216,8 +216,6 @@ namespace parallel
      * will represent the number of different indicators (which is greater or
      * equal one).
      *
-     * @ingroup boundary
-     *
      * @see
      * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
      *

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -2427,8 +2427,6 @@ namespace GridGenerator
   /**
    * Namespace Airfoil contains classes and functions in order to create a
    * C-type mesh for the (flow) field around Joukowski or NACA airfoils.
-   *
-   * @ingroup GridGenerator
    */
   namespace Airfoil
   {

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -121,7 +121,7 @@ enum class IsotropicRefinementChoice : std::uint8_t
  * @ref GlossReferenceCell "reference cell"
  * glossary entry.
  *
- * @ingroup grid geomprimitives aniso reordering
+ * @ingroup grid geomprimitives reordering
  */
 class ReferenceCell
 {

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1307,7 +1307,7 @@ namespace internal
  * object, you should be well aware that you might involuntarily alter the
  * data stored in the triangulation.
  *
- * @ingroup grid aniso
+ * @ingroup grid
  *
  * @dealiiConceptRequires{(concepts::is_valid_dim_spacedim<dim, spacedim>)}
  */
@@ -1958,8 +1958,6 @@ public:
    * boundary indicator is reported only once. The size of the return vector
    * will represent the number of different indicators (which is greater or
    * equal one).
-   *
-   * @ingroup boundary
    *
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -1160,8 +1160,6 @@ public:
    * the value you are trying to set makes sense under the current
    * circumstances.
    *
-   * @ingroup boundary
-   *
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
@@ -1192,8 +1190,6 @@ public:
    * that bound the face. This function does all of this at once. You can see
    * the result of not using the correct function in the results section of
    * step-49.
-   *
-   * @ingroup boundary
    *
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
@@ -2946,8 +2942,6 @@ public:
    * the value you are trying to set makes sense under the current
    * circumstances.
    *
-   * @ingroup boundary
-   *
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
@@ -2968,8 +2962,6 @@ public:
    * lower-dimensional sub-objects.  Since this object only represents a single
    * vertex, there are no lower-dimensional object and this function is
    * equivalent to calling set_boundary_id() with the same argument.
-   *
-   * @ingroup boundary
    *
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"

--- a/include/deal.II/grid/tria_description.h
+++ b/include/deal.II/grid/tria_description.h
@@ -481,8 +481,6 @@ namespace TriangulationDescription
 
   /**
    * A namespace for TriangulationDescription::Description utility functions.
-   *
-   * @ingroup TriangulationDescription
    */
   namespace Utilities
   {

--- a/include/deal.II/lac/ginkgo_solver.h
+++ b/include/deal.II/lac/ginkgo_solver.h
@@ -42,8 +42,6 @@ namespace GinkgoWrappers
    * available at <a Ginkgo
    * href="https://ginkgo-project.github.io/ginkgo/doc/develop/"> documentation
    * and manual pages</a>.
-   *
-   * @ingroup GinkgoWrappers
    */
   template <typename ValueType, typename IndexType>
   class SolverBase
@@ -207,8 +205,6 @@ namespace GinkgoWrappers
 
   /**
    * An implementation of the solver interface using the Ginkgo CG solver.
-   *
-   * @ingroup GinkgoWrappers
    */
   template <typename ValueType = double, typename IndexType = int32_t>
   class SolverCG : public SolverBase<ValueType, IndexType>
@@ -263,8 +259,6 @@ namespace GinkgoWrappers
 
   /**
    * An implementation of the solver interface using the Ginkgo Bicgstab solver.
-   *
-   * @ingroup GinkgoWrappers
    */
   template <typename ValueType = double, typename IndexType = int32_t>
   class SolverBicgstab : public SolverBase<ValueType, IndexType>
@@ -321,8 +315,6 @@ namespace GinkgoWrappers
    *
    * CGS or the conjugate gradient square method is an iterative type Krylov
    * subspace method which is suitable for general systems.
-   *
-   * @ingroup GinkgoWrappers
    */
   template <typename ValueType = double, typename IndexType = int32_t>
   class SolverCGS : public SolverBase<ValueType, IndexType>
@@ -388,8 +380,6 @@ namespace GinkgoWrappers
    * vectors spanning the Krylov subspace. This increases the computational cost
    * of every Krylov solver iteration but allows for non-constant
    * preconditioners.
-   *
-   * @ingroup GinkgoWrappers
    */
   template <typename ValueType = double, typename IndexType = int32_t>
   class SolverFCG : public SolverBase<ValueType, IndexType>
@@ -443,8 +433,6 @@ namespace GinkgoWrappers
 
   /**
    * An implementation of the solver interface using the Ginkgo GMRES solver.
-   *
-   * @ingroup GinkgoWrappers
    */
   template <typename ValueType = double, typename IndexType = int32_t>
   class SolverGMRES : public SolverBase<ValueType, IndexType>
@@ -513,8 +501,6 @@ namespace GinkgoWrappers
    * Iterative refinement (IR) is an iterative method that uses another coarse
    * method to approximate the error of the current solution via the current
    * residual.
-   *
-   * @ingroup GinkgoWrappers
    */
   template <typename ValueType = double, typename IndexType = int32_t>
   class SolverIR : public SolverBase<ValueType, IndexType>

--- a/include/deal.II/lac/petsc_block_sparse_matrix.h
+++ b/include/deal.II/lac/petsc_block_sparse_matrix.h
@@ -60,8 +60,8 @@ namespace PETScWrappers
      * collect_sizes() function, for much the same reason as is documented
      * with the BlockSparsityPattern class.
      *
-     * @ingroup Matrix1 @see
-     * @ref GlossBlockLA "Block (linear algebra)"
+     * @ingroup Matrix1
+     * @see @ref GlossBlockLA "Block (linear algebra)"
      */
     class BlockSparseMatrix : public BlockMatrixBase<SparseMatrix>
     {

--- a/include/deal.II/lac/petsc_block_vector.h
+++ b/include/deal.II/lac/petsc_block_vector.h
@@ -54,8 +54,8 @@ namespace PETScWrappers
      * specify the sizes of the individual blocks, but also the number of
      * elements of each of these blocks to be stored on the local process.
      *
-     * @ingroup Vectors @see
-     * @ref GlossBlockLA "Block (linear algebra)"
+     * @ingroup Vectors
+     * @see @ref GlossBlockLA "Block (linear algebra)"
      */
     class BlockVector : public BlockVectorBase<Vector>
     {

--- a/include/deal.II/lac/trilinos_block_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_block_sparse_matrix.h
@@ -65,8 +65,8 @@ namespace TrilinosWrappers
    * function, for much the same reason as is documented with the
    * BlockSparsityPattern class.
    *
-   * @ingroup Matrix1 @see
-   * @ref GlossBlockLA "Block (linear algebra)"
+   * @ingroup Matrix1
+   * @see @ref GlossBlockLA "Block (linear algebra)"
    */
   class BlockSparseMatrix : public BlockMatrixBase<SparseMatrix>
   {

--- a/include/deal.II/lac/trilinos_parallel_block_vector.h
+++ b/include/deal.II/lac/trilinos_parallel_block_vector.h
@@ -68,8 +68,8 @@ namespace TrilinosWrappers
      * elements of each of these blocks to be stored on the local process.
      *
      * @ingroup Vectors
-     * @ingroup TrilinosWrappers @see
-     * @ref GlossBlockLA "Block (linear algebra)"
+     * @ingroup TrilinosWrappers
+     * @see @ref GlossBlockLA "Block (linear algebra)"
      */
     class BlockVector : public dealii::BlockVectorBase<MPI::Vector>
     {

--- a/include/deal.II/lac/trilinos_tpetra_block_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_tpetra_block_sparse_matrix.h
@@ -68,8 +68,8 @@ namespace LinearAlgebra
      * function, for much the same reason as is documented with the
      * BlockSparsityPattern class.
      *
-     * @ingroup Matrix1 @see
-     * @ref GlossBlockLA "Block (linear algebra)"
+     * @ingroup Matrix1
+     * @see @ref GlossBlockLA "Block (linear algebra)"
      */
     template <typename Number, typename MemorySpace = dealii::MemorySpace::Host>
     class BlockSparseMatrix

--- a/include/deal.II/lac/trilinos_tpetra_block_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_block_vector.h
@@ -68,8 +68,8 @@ namespace LinearAlgebra
      * elements of each of these blocks to be stored on the local process.
      *
      * @ingroup Vectors
-     * @ingroup TrilinosWrappers @see
-     * @ref GlossBlockLA "Block (linear algebra)"
+     * @ingroup TrilinosWrappers
+     * @see @ref GlossBlockLA "Block (linear algebra)"
      */
     template <typename Number, typename MemorySpace = dealii::MemorySpace::Host>
     class BlockVector : public dealii::BlockVectorBase<

--- a/include/deal.II/matrix_free/portable_fe_evaluation.h
+++ b/include/deal.II/matrix_free/portable_fe_evaluation.h
@@ -60,7 +60,6 @@ namespace Portable
    * double.
    *
    * @ingroup CUDAWrappers
-   * @ingroup Portable
    */
   template <int dim,
             int fe_degree,

--- a/include/deal.II/matrix_free/portable_matrix_free.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.h
@@ -88,7 +88,6 @@ namespace Portable
    * @note Only float and double are supported.
    *
    * @ingroup CUDAWrappers
-   * @ingroup Portable
    */
   template <int dim, typename Number = double>
   class MatrixFree : public Subscriptor

--- a/include/deal.II/matrix_free/portable_tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/portable_tensor_product_kernels.h
@@ -34,7 +34,6 @@ namespace Portable
      * products are implemented.
      *
      * @ingroup CUDAWrappers
-     * @ingroup Portable
      */
     // TODO: for now only the general variant is implemented
     enum EvaluatorVariant
@@ -338,7 +337,6 @@ namespace Portable
      * Generic evaluator framework.
      *
      * @ingroup CUDAWrappers
-     * @ingroup Portable
      */
     template <EvaluatorVariant variant,
               int              dim,
@@ -355,7 +353,6 @@ namespace Portable
      * of the basis functions.
      *
      * @ingroup CUDAWrappers
-     * @ingroup Portable
      */
     template <int dim, int fe_degree, int n_q_points_1d, typename Number>
     struct EvaluatorTensorProduct<evaluate_general,

--- a/include/deal.II/particles/data_out.h
+++ b/include/deal.II/particles/data_out.h
@@ -38,8 +38,6 @@ namespace Particles
    * The class does, in essence, for particles what ::DataOut does for
    * finite element fields, using a similar interface. It is used in
    * step-19, for example.
-   *
-   * @ingroup Particle
    */
   template <int dim, int spacedim = dim>
   class DataOut : public dealii::DataOutInterface<0, spacedim>

--- a/include/deal.II/particles/particle.h
+++ b/include/deal.II/particles/particle.h
@@ -88,8 +88,6 @@ namespace Particles
    * 1.0, "blue" to 2.0, and "green" to 3.0. The conversion functions
    * to translate between these two representations should then not be very
    * difficult to write either.
-   *
-   * @ingroup Particle
    */
   template <int dim, int spacedim = dim>
   class Particle

--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -57,8 +57,6 @@ namespace Particles
    * For examples on how to use this class to track particles, store properties
    * on particles, and let the properties on the particles influence the
    * finite-element solution see step-19, step-68, and step-70.
-   *
-   * @ingroup Particle
    */
   template <int dim, int spacedim = dim>
   class ParticleHandler : public Subscriptor


### PR DESCRIPTION
Related to #17202. A lot of the groups fixed here didn't exist and I decided to just delete those references. There are better descriptions for all those classes elsewhere.