### PR TITLE
Fix MSVC warning in step-63.

### DIFF
--- a/examples/step-63/step-63.cc
+++ b/examples/step-63/step-63.cc
@@ -1180,7 +1180,7 @@ namespace Step63
   template <int dim>
   void AdvectionProblem<dim>::run()
   {
-    for (unsigned int cycle = 0; cycle < (settings.fe_degree == 1 ? 7 : 5);
+    for (unsigned int cycle = 0; cycle < (settings.fe_degree == 1 ? 7u : 5u);
          ++cycle)
       {
         std::cout << "  Cycle " << cycle << ':' << std::endl;


### PR DESCRIPTION
Interesting warning
```
...\dealii\examples\step-63\step-63.cc(1183,40): error C2220: the following warning is treated as an error [...\dealii\build\examples\example_step_63_debug.vcxproj]
...\dealii\examples\step-63\step-63.cc(1182): message : while compiling class template member function 'void Step63::AdvectionProblem<2>::run(void)' [...\dealii\build\examples\example_step_63_debug.vcxproj]
...\dealii\examples\step-63\step-63.cc(1238): message : see reference to function template instantiation 'void Step63::AdvectionProblem<2>::run(void)' being compiled [...\dealii\build\examples\example_step_63_debug.vcxproj]
...\dealii\examples\step-63\step-63.cc(1237): message : see reference to class template instantiation 'Step63::AdvectionProblem<2>' being compiled [...\dealii\build\examples\example_step_63_debug.vcxproj]
...\dealii\examples\step-63\step-63.cc(1183,40): warning C4018: '<': signed/unsigned mismatch [...\dealii\build\examples\example_step_63_debug.vcxproj]
```
about
https://github.com/dealii/dealii/blob/f7f9f468f8d0b1c427c8bf2f938ebbd22ca6414d/examples/step-63/step-63.cc#L1183-L1184

I believe this patch provides the most readable solution to the warning.
