### PR TITLE
Build docker image for ghcr first, then push to Dockerhub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -108,7 +108,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-${{ matrix.ubuntu_version }}-*
+          pattern: digests-${{ matrix.ubuntu_version }}
           merge-multiple: true
 
       - name: Set up Docker Buildx

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,7 +74,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ github.event_name == 'schedule' }}
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=ghcr.io/${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
         run: |
@@ -118,7 +118,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY_IMAGE }}
+          images: ghcr.io/${{ env.REGISTRY_IMAGE }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -133,13 +133,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create manifest list and push
+      - name: Create manifest list and push to ghcr.io
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create -t ghcr.io/${{ env.REGISTRY_IMAGE }}:master-${{ matrix.ubuntu_version }}  \
+            $(printf 'ghcr.io/${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+
+      - name: Create manifest list and push to DockerHub
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create -t ${{ env.REGISTRY_IMAGE }}:master-${{ matrix.ubuntu_version }}  \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
-          docker buildx imagetools create -t ghcr.io/${{ env.REGISTRY_IMAGE }}:master-${{ matrix.ubuntu_version }}  \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+            $(printf 'ghcr.io/${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
 
       - name: Inspect image
         run: |


### PR DESCRIPTION
One more try to fix #17197. The current implementation still runs into authentication issues with docker hub. I do not understand what is going on, because the workflow works perfectly fine when executed in my fork (https://github.com/gassmoeller/dealii/actions/runs/9841086882). Is it possible that the docker hub username and password secret in dealii/dealii do not have push access to the dockerhub dealii account? But it did work before #17173. Did something change about the secrets we store?

This PR contains two changes to the status quo of automatically building docker images that should at least circumvent some of the problems:
- A small typo fix when merging the final images into one (potentially multi-architecture) image (line 111). This was inconsequential to the failures, because the workflow failed before reaching this stage.
- I now build and push the preliminary images to the Github Container Registry instead of docker hub. Then when merging the images into the final images I first merge them on ghcr and only merge on dockerhub in a second step (which will likely fail with the same error we see at the moment). This should at least show us if everything works on ghcr and it is truly just an authentication issue with docker hub.