### PR TITLE
step-87: Clear ghost values in a vector

### DIFF
--- a/examples/step-87/step-87.cc
+++ b/examples/step-87/step-87.cc
@@ -831,6 +831,7 @@ namespace Step87
               VectorTools::point_values<dim>(rpe,
                                              dof_handler_background,
                                              velocity);
+            velocity.zero_out_ghost_values();
 
             for (unsigned int i = 0, c = 0;
                  i < immersed_support_points.locally_owned_size() / dim;


### PR DESCRIPTION
Fixes #17246.

When we call `LinearAlgebra::distributed::Vector::update_ghost_values()`, we should clear the ghost entries again upon completing the operation. This and a similar error in #17241 remind me that we should probably look over what we discussed in #745 regarding vector interfaces (later discussed tangentially in #2535): What would be really neat is if we could create a readable vector out of `LinearAlgebra::distributed::Vector` by calling `update_ghost_values()`, use that in any function that accesses the vector, and then upon destruction, clear the ghost content again by `zero_out_ghost_values()`. That is not related to the present PR, but it gives an indication that our interfaces are not yet entirely intuitive.