### PR TITLE
Default SolverControl to not print to deallog.

### DIFF
--- a/include/deal.II/lac/solver_control.h
+++ b/include/deal.II/lac/solver_control.h
@@ -145,12 +145,12 @@ public:
    * checked and the number of the iteration step) shall be printed to @p
    * deallog stream.  Default is: do not print. Similarly, @p log_result
    * specifies the whether the final result is logged to @p deallog. Default
-   * is yes.
+   * is: do not print.
    */
   explicit SolverControl(const unsigned int n           = 100,
                          const double       tol         = 1.e-10,
                          const bool         log_history = false,
-                         const bool         log_result  = true);
+                         const bool         log_result  = false);
 
   /**
    * Virtual destructor is needed as there are virtual functions in this


### PR DESCRIPTION
This fixes #17251. Let me first see how much breakage that induces, and if it's acceptable I will write a changelog.