### PR TITLE
Fix Tpetra types for older Trilinos

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_sparse_matrix.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparse_matrix.templates.h
@@ -1315,8 +1315,8 @@ namespace LinearAlgebra
         TpetraTypes::MatrixType<Number, MemorySpace>>(*source.matrix,
                                                       Teuchos::Copy);
 #  else
-      matrix = source.matrix->clone(
-        Utilities::Trilinos::internal::make_rcp<NodeType>());
+      matrix = source.matrix->clone(Utilities::Trilinos::internal::make_rcp<
+                                    TpetraTypes::NodeType<MemorySpace>>());
 #  endif
       column_space_map =
         Teuchos::rcp_const_cast<TpetraTypes::MapType<MemorySpace>>(

--- a/source/lac/trilinos_tpetra_sparsity_pattern.cc
+++ b/source/lac/trilinos_tpetra_sparsity_pattern.cc
@@ -420,13 +420,13 @@ namespace LinearAlgebra
                                                  n_entries_per_row);
 #  else
         if (row_map->getComm()->getSize() > 1)
-          graph =
-            Utilities::Trilinos::internal::make_rcp<GraphType<MemorySpace>>(
-              row_map, Teuchos::arcpFromArray(n_entries_per_row));
+          graph = Utilities::Trilinos::internal::make_rcp<
+            TpetraTypes::GraphType<MemorySpace>>(
+            row_map, Teuchos::arcpFromArray(n_entries_per_row));
         else
-          graph =
-            Utilities::Trilinos::internal::make_rcp<GraphType<MemorySpace>>(
-              row_map, col_map, Teuchos::arcpFromArray(n_entries_per_row));
+          graph = Utilities::Trilinos::internal::make_rcp<
+            TpetraTypes::GraphType<MemorySpace>>(
+            row_map, col_map, Teuchos::arcpFromArray(n_entries_per_row));
 
 #  endif
 


### PR DESCRIPTION
This adds a few missing `TpetraTypes::` in the pre 12.16 Trilinos ifdefs that I overlooked in #17222 
and fixes #17253 