### PR TITLE
CMake: Explain why we disable dynamic linking on Windows.

### DIFF
--- a/cmake/checks/check_02_system_features.cmake
+++ b/cmake/checks/check_02_system_features.cmake
@@ -90,7 +90,6 @@ if( CMAKE_SYSTEM_NAME MATCHES "CYGWIN" OR
 endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-
   #
   # Export DEAL_II_MSVC if we are on a Windows platform:
   #
@@ -99,21 +98,28 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows")
   #
   # Shared library handling:
   #
+  # We disabled dynamic linking on Windows. The *.dll format only allows
+  # up to 65535 objects or members, i.e., it is limited by a 16bit
+  # descriptor. We need more than that for deal.II. For more information,
+  # look up the linker tools error LNK1189.
+  #
+  # Unfortunately, this means that we are stuck with static linking.
+  # As a consequence each binary will be very large, so we also disable
+  # the compilation of examples.
+  #
+  message(WARNING "\n"
+    "BUILD_SHARED_LIBS forced to OFF\n\n"
+    "DEAL_II_COMPILE_EXAMPLES forced to OFF\n\n"
+    )
+  set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+  set(DEAL_II_COMPILE_EXAMPLES OFF CACHE BOOL "" FORCE)
 
-  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-    # With MinGW we're lucky:
-    enable_if_links(DEAL_II_LINKER_FLAGS "-Wl,--export-all-symbols")
-    enable_if_links(DEAL_II_LINKER_FLAGS "-Wl,--enable-auto-import")
-    enable_if_links(DEAL_II_LINKER_FLAGS "-Wl,--allow-multiple-definition")
-  else()
-    # Otherwise disable shared libraries:
-    message(WARNING "\n"
-      "BUILD_SHARED_LIBS forced to OFF\n\n"
-      )
-    set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
-
-    # And disable compilation of examples:
-    set(DEAL_II_COMPILE_EXAMPLES OFF CACHE BOOL "" FORCE)
+  #
+  # In case we find a solution to enable dynamic linking in the future,
+  # we will most probably want to use the CMake infrastructure to
+  # automatically export symbols on Windows targets.
+  #
+  if(BUILD_SHARED_LIBS)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
   endif()
-
 endif()


### PR DESCRIPTION
In reference to https://github.com/dealii/dealii/pull/14567#discussion_r1674158531. Also related to #1921, #2460, #2807, #13596.

I added some comments to describe why we disable dynamic linking and the compilation of examples on Windows.

We dropped MinGW support in #1252, so I erased the MinGW specific lines.

---

A follow-up question is whether we want to keep the compilation of examples disabled. It would be nice to have it available for the github-actions workers. Users would still be able to control it by specifying `DEAL_II_COMPILE_EXAMPLES`. I would be in favor of removing the `FORCE OFF` line.