### PR TITLE
Triangulation: pack/unpack fixed/variable data

### DIFF
--- a/include/deal.II/distributed/fully_distributed_tria.h
+++ b/include/deal.II/distributed/fully_distributed_tria.h
@@ -294,8 +294,8 @@ namespace parallel
        * The stored vector will have a size equal to the number of locally owned
        * active cells and will be ordered by the occurrence of those cells.
        */
-      virtual void
-      update_cell_relations() override;
+      void
+      update_cell_relations();
 
       virtual void
       update_number_cache() override;

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -780,8 +780,8 @@ namespace parallel
        * the refinement process. With this information, we can prepare all
        * buffers for data transfer accordingly.
        */
-      virtual void
-      update_cell_relations() override;
+      void
+      update_cell_relations();
 
       /**
        * Two arrays that store which p4est tree corresponds to which coarse
@@ -964,8 +964,8 @@ namespace parallel
        * This function is not implemented, but needs to be present for the
        * compiler.
        */
-      virtual void
-      update_cell_relations() override;
+      void
+      update_cell_relations();
 
       /**
        * Dummy arrays. This class isn't usable but the compiler wants to see
@@ -1104,8 +1104,8 @@ namespace parallel
        * Dummy replacement to allow for better error messages when compiling
        * this class.
        */
-      virtual void
-      update_cell_relations() override
+      void
+      update_cell_relations()
       {}
     };
   } // namespace distributed

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -367,7 +367,7 @@ namespace internal
    * will be, attached to cells via the register_data_attach() function
    * and later retrieved via notify_ready_to_unpack().
    *
-   * This internalclass is dedicated to the data serialization and transfer
+   * This internal class is dedicated to the data serialization and transfer
    * across repartitioned meshes and to/from the file system.
    *
    * It is designed to store all data buffers intended for serialization.
@@ -378,6 +378,12 @@ namespace internal
   {
   public:
     using cell_iterator = TriaIterator<CellAccessor<dim, spacedim>>;
+
+    /**
+     * Version number stored in the .info file written by
+     * Triangulation::save().
+     */
+    static inline constexpr unsigned int version_number = 5;
 
     /**
      * Auxiliary data structure for assigning a CellStatus to a deal.II cell
@@ -3881,18 +3887,16 @@ protected:
                      const unsigned int n_attached_deserialize_variable);
 
   /**
-   * A function to record the CellStatus of currently active cells that
-   * are locally owned. This information is mandatory to transfer data
-   * between meshes during adaptation or serialization, e.g., using
-   * parallel::distributed::SolutionTransfer.
+   * A function to record the CellStatus of currently active cells.
+   * This information is mandatory to transfer data between meshes
+   * during adaptation or serialization, e.g., using SolutionTransfer.
    *
    * Relations will be stored in the private member local_cell_relations. For
    * an extensive description of CellStatus, see the documentation for the
    * member function register_data_attach().
    */
-  virtual void
-  update_cell_relations()
-  {}
+  void
+  update_cell_relations();
 
   /**
    * Vector of pairs, each containing a deal.II cell iterator and its

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -2194,21 +2194,6 @@ namespace Particles
   void
   ParticleHandler<dim, spacedim>::register_data_attach()
   {
-    parallel::DistributedTriangulationBase<dim, spacedim>
-      *distributed_triangulation =
-        const_cast<parallel::DistributedTriangulationBase<dim, spacedim> *>(
-          dynamic_cast<
-            const parallel::DistributedTriangulationBase<dim, spacedim> *>(
-            &(*triangulation)));
-    (void)distributed_triangulation;
-
-    Assert(
-      distributed_triangulation != nullptr,
-      ExcMessage(
-        "Mesh refinement in a non-distributed triangulation is not supported "
-        "by the ParticleHandler class. Either insert particles after mesh "
-        "creation and do not refine afterwards, or use a distributed triangulation."));
-
     const auto callback_function =
       [this](const typename Triangulation<dim, spacedim>::cell_iterator
                              &cell_iterator,
@@ -2216,8 +2201,9 @@ namespace Particles
         return this->pack_callback(cell_iterator, cell_status);
       };
 
-    handle = distributed_triangulation->register_data_attach(
-      callback_function, /*returns_variable_size_data=*/true);
+    handle = const_cast<Triangulation<dim, spacedim> *>(&*triangulation)
+               ->register_data_attach(callback_function,
+                                      /*returns_variable_size_data=*/true);
   }
 
 
@@ -2256,21 +2242,6 @@ namespace Particles
   ParticleHandler<dim, spacedim>::notify_ready_to_unpack(
     const bool serialization)
   {
-    parallel::DistributedTriangulationBase<dim, spacedim>
-      *distributed_triangulation =
-        const_cast<parallel::DistributedTriangulationBase<dim, spacedim> *>(
-          dynamic_cast<
-            const parallel::DistributedTriangulationBase<dim, spacedim> *>(
-            &(*triangulation)));
-    (void)distributed_triangulation;
-
-    Assert(
-      distributed_triangulation != nullptr,
-      ExcMessage(
-        "Mesh refinement in a non-distributed triangulation is not supported "
-        "by the ParticleHandler class. Either insert particles after mesh "
-        "creation and do not refine afterwards, or use a distributed triangulation."));
-
     // First prepare container for insertion
     clear();
 
@@ -2293,8 +2264,8 @@ namespace Particles
             this->unpack_callback(cell_iterator, cell_status, range_iterator);
           };
 
-        distributed_triangulation->notify_ready_to_unpack(handle,
-                                                          callback_function);
+        const_cast<Triangulation<dim, spacedim> *>(&*triangulation)
+          ->notify_ready_to_unpack(handle, callback_function);
 
         // Reset handle and update global numbers.
         handle = numbers::invalid_unsigned_int;


### PR DESCRIPTION
This PR extracts from #15706 the code responsible for saving/loading fixed- and variable-sized data via `Triangulation`, needed for serializing (vectors via `parallel::distributed::SolutionTransfer` and) for serializing the `ParticleHandler`.

replaces #17266

needed for #12429