### PR TITLE
Compile examples on Windows.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -53,9 +53,11 @@ jobs:
     - name: print detailed.log
       run: type build/detailed.log
     - name: build library
+      # remove executables due to file size
       shell: bash
       run: |
         cmake --build build --parallel 2 --target install
+        find c:/project/examples/ -type f -name '*.exe' -delete
     - name: test library
       shell: bash
       run: |

--- a/cmake/checks/check_02_system_features.cmake
+++ b/cmake/checks/check_02_system_features.cmake
@@ -104,15 +104,12 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows")
   # look up the linker tools error LNK1189.
   #
   # Unfortunately, this means that we are stuck with static linking.
-  # As a consequence each binary will be very large, so we also disable
-  # the compilation of examples.
+  # Note that as a consequence, each binary will be very large.
   #
   message(WARNING "\n"
     "BUILD_SHARED_LIBS forced to OFF\n\n"
-    "DEAL_II_COMPILE_EXAMPLES forced to OFF\n\n"
     )
   set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
-  set(DEAL_II_COMPILE_EXAMPLES OFF CACHE BOOL "" FORCE)
 
   #
   # In case we find a solution to enable dynamic linking in the future,

--- a/doc/news/changes/incompatibilities/20240716Fehling
+++ b/doc/news/changes/incompatibilities/20240716Fehling
@@ -1,0 +1,8 @@
+Changed: On Windows builds, the compilation of examples is now enabled
+by default. Please note that we are limited to static linking on Windows,
+which means that the binaries are going to be large in filesize.
+<br>
+If you want to infer the old behavior, you can disable the compilation of
+examples with `-D DEAL_II_COMPILE_EXAMPLES=OFF`.
+<br>
+(Marc Fehling, 2024/07/16)


### PR DESCRIPTION
Part of #13596.

Our coverage with Windows testers is rather low. This lead to issues in the past, see #12263, #13593, #17242.

For example, we currently do not compile examples on the Windows github-actions runners. As we are limited to static linking on Windows, file sizes of executables tend to be large, which is why it was forcefully disabled since #3986.

I think it is time to reconsider our example policy on Windows: I suggest that we enable the compilation of examples by default to retain the same behavior on all OSs. Users can still disable the compilation and infer the old behavior by setting `DEAL_II_COMPILE_EXAMPLES=OFF` themselves.

With this patch, we will build 44 examples in the current configuration of the Windows tester (others are disabled due to missing dependencies). Fortunately, the increase in build time remains acceptable, but static linking leads to large executables, see table from https://github.com/dealii/dealii/issues/13596#issuecomment-2222783678. So when archiving the library on the github worker, I made sure that we get rid of the executables first.