### PR TITLE
Deprecate PathSearch, remove internal use

### DIFF
--- a/doc/news/changes/incompatibilities/20240717Maier
+++ b/doc/news/changes/incompatibilities/20240717Maier
@@ -1,0 +1,7 @@
+Changed: The GridIn::read() function variant taking a filename string no
+longer uses PathSearch to try to find an appropriate file. Instead, the
+function requires now that the filename string is a valid relative or
+absolute path to mesh file in question. Additionally, GridIn::read() now
+throws ExcFileNotOpen instead of PathSearch::FileNotFound.
+<br>
+(Matthias Maier, 2024/01/08)

--- a/include/deal.II/base/path_search.h
+++ b/include/deal.II/base/path_search.h
@@ -75,11 +75,11 @@ DEAL_II_NAMESPACE_OPEN
  * characters are not added automatically (allowing you to do some real file
  * name editing).
  *
- * @todo Add support for environment variables like in kpathsea.
+ * @deprecated Use the std::filesystem facilities instead.
  *
  * @ingroup input
  */
-class PathSearch
+class DEAL_II_DEPRECATED PathSearch
 {
 public:
   /**

--- a/include/deal.II/grid/grid_in.h
+++ b/include/deal.II/grid/grid_in.h
@@ -366,9 +366,8 @@ public:
   read(std::istream &in, Format format = Default);
 
   /**
-   * Open the file given by the string and call the previous function read().
-   * This function uses the PathSearch mechanism to find files. The file class
-   * used is <code>MESH</code>.
+   * Open the file given by the string and call the previous function
+   * read() taking a std::istream argument.
    */
   void
   read(const std::string &in, Format format = Default);

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -14,7 +14,6 @@
 
 
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/path_search.h>
 #include <deal.II/base/patterns.h>
 #include <deal.II/base/utilities.h>
 
@@ -35,8 +34,8 @@
 
 #include <algorithm>
 #include <cctype>
+#include <filesystem>
 #include <fstream>
-#include <functional>
 #include <limits>
 #include <map>
 
@@ -4139,39 +4138,32 @@ template <int dim, int spacedim>
 void
 GridIn<dim, spacedim>::read(const std::string &filename, Format format)
 {
-  // Search file class for meshes
-  PathSearch  search("MESH");
-  std::string name;
-  // Open the file and remember its name
-  if (format == Default)
-    name = search.find(filename);
-  else
-    name = search.find(filename, default_suffix(format));
-
+  // Check early that the file actually exists and if not throw ExcFileNotOpen.
+  AssertThrow(std::filesystem::exists(filename), ExcFileNotOpen(filename));
 
   if (format == Default)
     {
-      const std::string::size_type slashpos = name.find_last_of('/');
-      const std::string::size_type dotpos   = name.find_last_of('.');
-      if (dotpos < name.size() &&
+      const std::string::size_type slashpos = filename.find_last_of('/');
+      const std::string::size_type dotpos   = filename.find_last_of('.');
+      if (dotpos < filename.size() &&
           (dotpos > slashpos || slashpos == std::string::npos))
         {
-          std::string ext = name.substr(dotpos + 1);
+          std::string ext = filename.substr(dotpos + 1);
           format          = parse_format(ext);
         }
     }
 
   if (format == assimp)
     {
-      read_assimp(name);
+      read_assimp(filename);
     }
   else if (format == exodusii)
     {
-      read_exodusii(name);
+      read_exodusii(filename);
     }
   else
     {
-      std::ifstream in(name);
+      std::ifstream in(filename);
       read(in, format);
     }
 }

--- a/tests/grid/grid_in.cc
+++ b/tests/grid/grid_in.cc
@@ -133,8 +133,8 @@ check_file(const std::string name, typename GridIn<dim>::Format format)
 void
 filename_resolution()
 {
-  check_file<2>(std::string(SOURCE_DIR "/grid_in/2d"), GridIn<2>::ucd);
-  check_file<2>(std::string(SOURCE_DIR "/grid_in/2d"), GridIn<2>::xda);
+  check_file<2>(std::string(SOURCE_DIR "/grid_in/2d.inp"), GridIn<2>::ucd);
+  check_file<2>(std::string(SOURCE_DIR "/grid_in/2d.xda"), GridIn<2>::xda);
 }
 
 

--- a/tests/grid/grid_in_msh.cc
+++ b/tests/grid/grid_in_msh.cc
@@ -46,7 +46,8 @@ check_file(const std::string name, typename GridIn<dim>::Format format)
 void
 filename_resolution()
 {
-  check_file<2>(std::string(SOURCE_DIR "/grid_in_msh/mesh"), GridIn<2>::msh);
+  check_file<2>(std::string(SOURCE_DIR "/grid_in_msh/mesh.msh"),
+                GridIn<2>::msh);
 }
 
 

--- a/tests/grid/grid_in_msh_03.cc
+++ b/tests/grid/grid_in_msh_03.cc
@@ -51,7 +51,8 @@ check_file(const std::string name, typename GridIn<dim>::Format format)
 void
 filename_resolution()
 {
-  check_file<2>(std::string(SOURCE_DIR "/grid_in_msh_03/mesh"), GridIn<2>::msh);
+  check_file<2>(std::string(SOURCE_DIR "/grid_in_msh_03/mesh.msh"),
+                GridIn<2>::msh);
 }
 
 

--- a/tests/grid/grid_in_msh_03.output
+++ b/tests/grid/grid_in_msh_03.output
@@ -1,5 +1,5 @@
 
-DEAL::grid_in_msh_03/mesh	100	81
+DEAL::grid_in_msh_03/mesh.msh	100	81
 0.0 0.0 0 2
 2.2 0.0 0 2
 2.2 1.1 0 2

--- a/tests/grid/grid_in_msh_03_v4.cc
+++ b/tests/grid/grid_in_msh_03_v4.cc
@@ -53,7 +53,7 @@ check_file(const std::string name, typename GridIn<dim>::Format format)
 void
 filename_resolution()
 {
-  check_file<2>(std::string(SOURCE_DIR "/grid_in_msh_03_v4/mesh"),
+  check_file<2>(std::string(SOURCE_DIR "/grid_in_msh_03_v4/mesh.msh"),
                 GridIn<2>::msh);
 }
 

--- a/tests/grid/grid_in_msh_03_v4.output
+++ b/tests/grid/grid_in_msh_03_v4.output
@@ -1,5 +1,5 @@
 
-DEAL::grid_in_msh_03_v4/mesh	100	81
+DEAL::grid_in_msh_03_v4/mesh.msh	100	81
 0 0 0 2
 2.2 0 0 2
 2.2 1.1 0 2

--- a/tests/grid/grid_in_msh_v4.cc
+++ b/tests/grid/grid_in_msh_v4.cc
@@ -48,7 +48,8 @@ check_file(const std::string name, typename GridIn<dim>::Format format)
 void
 filename_resolution()
 {
-  check_file<2>(std::string(SOURCE_DIR "/grid_in_msh_v4/mesh"), GridIn<2>::msh);
+  check_file<2>(std::string(SOURCE_DIR "/grid_in_msh_v4/mesh.msh"),
+                GridIn<2>::msh);
 }
 
 

--- a/tests/grid/grid_in_msh_version_1.cc
+++ b/tests/grid/grid_in_msh_version_1.cc
@@ -52,9 +52,9 @@ check_file(const std::string name, typename GridIn<dim>::Format format)
 void
 filename_resolution()
 {
-  check_file<2>(std::string(SOURCE_DIR "/grid_in_msh_version_1/input_v1"),
+  check_file<2>(std::string(SOURCE_DIR "/grid_in_msh_version_1/input_v1.msh"),
                 GridIn<2>::msh);
-  check_file<2>(std::string(SOURCE_DIR "/grid_in_msh_version_1/input_v2"),
+  check_file<2>(std::string(SOURCE_DIR "/grid_in_msh_version_1/input_v2.msh"),
                 GridIn<2>::msh);
 }
 

--- a/tests/grid/grid_in_msh_version_1.output
+++ b/tests/grid/grid_in_msh_version_1.output
@@ -1,5 +1,5 @@
 
-DEAL::grid_in_msh_version_1/input_v1	64	49
+DEAL::grid_in_msh_version_1/input_v1.msh	64	49
 -1.0000 -1.0000 0 0
 -0.71429 -1.0000 0 0
 -0.71429 -0.71429 0 0
@@ -343,7 +343,7 @@ DEAL::grid_in_msh_version_1/input_v1	64	49
 0.71429 0.71429 0 0
 
 
-DEAL::grid_in_msh_version_1/input_v2	64	49
+DEAL::grid_in_msh_version_1/input_v2.msh	64	49
 -1.0000 -1.0000 0 0
 -0.71429 -1.0000 0 0
 -0.71429 -0.71429 0 0

--- a/tests/grid/grid_in_msh_version_2.cc
+++ b/tests/grid/grid_in_msh_version_2.cc
@@ -47,9 +47,9 @@ check_file(const std::string name, typename GridIn<dim>::Format format)
 void
 filename_resolution()
 {
-  check_file<2>(std::string(SOURCE_DIR "/grid_in_msh_version_2/hole81"),
+  check_file<2>(std::string(SOURCE_DIR "/grid_in_msh_version_2/hole81.msh"),
                 GridIn<2>::msh);
-  check_file<2>(std::string(SOURCE_DIR "/grid_in_msh_version_2/hole8170"),
+  check_file<2>(std::string(SOURCE_DIR "/grid_in_msh_version_2/hole8170.msh"),
                 GridIn<2>::msh);
 }
 

--- a/tests/grid/grid_in_unv_2d.cc
+++ b/tests/grid/grid_in_unv_2d.cc
@@ -49,11 +49,11 @@ check_file(const std::string name, typename GridIn<dim>::Format format)
 void
 filename_resolution()
 {
-  check_file<2>(std::string(SOURCE_DIR "/grid_in_unv_2d/test1427"),
+  check_file<2>(std::string(SOURCE_DIR "/grid_in_unv_2d/test1427.unv"),
                 GridIn<2>::unv);
-  check_file<2>(std::string(SOURCE_DIR "/grid_in_unv_2d/test46"),
+  check_file<2>(std::string(SOURCE_DIR "/grid_in_unv_2d/test46.unv"),
                 GridIn<2>::unv);
-  check_file<2>(std::string(SOURCE_DIR "/grid_in_unv_2d/salome_square"),
+  check_file<2>(std::string(SOURCE_DIR "/grid_in_unv_2d/salome_square.unv"),
                 GridIn<2>::unv);
 }
 

--- a/tests/grid/grid_in_unv_3d.cc
+++ b/tests/grid/grid_in_unv_3d.cc
@@ -49,8 +49,9 @@ check_file(const std::string name, typename GridIn<dim>::Format format)
 void
 filename_resolution()
 {
-  check_file<3>(std::string(SOURCE_DIR "/grid_in_unv_3d/3D"), GridIn<3>::unv);
-  check_file<3>(std::string(SOURCE_DIR "/grid_in_unv_3d/salome_cube"),
+  check_file<3>(std::string(SOURCE_DIR "/grid_in_unv_3d/3D.unv"),
+                GridIn<3>::unv);
+  check_file<3>(std::string(SOURCE_DIR "/grid_in_unv_3d/salome_cube.unv"),
                 GridIn<3>::unv);
 }
 

--- a/tests/grid/grid_in_unv_3d_02.cc
+++ b/tests/grid/grid_in_unv_3d_02.cc
@@ -50,7 +50,7 @@ check_file(const std::string name, typename GridIn<dim>::Format format)
 void
 filename_resolution()
 {
-  check_file<3>(std::string(SOURCE_DIR "/grid_in_unv_3d_02/mesh"),
+  check_file<3>(std::string(SOURCE_DIR "/grid_in_unv_3d_02/mesh.unv"),
                 GridIn<3>::unv);
 }
 


### PR DESCRIPTION
This pull request deprecates the class and removes the internal use in the GridIn class.

Closes #17120

