### PR TITLE
`Parameterhandler`/`ParameterAcceptor`: do not use `PathSearch::ExcFileNotFound`

### DIFF
--- a/doc/news/changes/incompatibilities/20240717Maier2
+++ b/doc/news/changes/incompatibilities/20240717Maier2
@@ -1,0 +1,4 @@
+Changed: ParameterHandler::read_in() now throws a ExcFileNotOpen exception
+instead of PathSearch::ExcFileNotFound.
+<br>
+(Matthias Maier, 2024/01/08)

--- a/source/base/parameter_acceptor.cc
+++ b/source/base/parameter_acceptor.cc
@@ -91,7 +91,7 @@ ParameterAcceptor::initialize(
         {
           prm.parse_input(filename);
         }
-      catch (const dealii::PathSearch::ExcFileNotFound &)
+      catch (const dealii::ExcFileNotOpen &)
         {
           prm.print_parameters(filename, output_style_for_filename);
           AssertThrow(false,

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -569,7 +569,7 @@ ParameterHandler::parse_input(const std::string &filename,
                               const bool assert_mandatory_entries_are_found)
 {
   std::ifstream is(filename);
-  AssertThrow(is, PathSearch::ExcFileNotFound(filename, "ParameterHandler"));
+  AssertThrow(is, ExcFileNotOpen(filename));
 
   std::string file_ending = filename.substr(filename.find_last_of('.') + 1);
   boost::algorithm::to_lower(file_ending);


### PR DESCRIPTION
Avoid using `PathSearch::ExcFileNotFound`. Instead, let's simply use `ExcFileNotOpen` that has an appropriate error message.

In reference to #17120.
