### PR TITLE
Modernized Windows workflow.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -57,7 +57,7 @@ jobs:
     - name: test
       run: |
         cmake --build build --parallel 2 --target setup_tests_a-framework setup_tests_quick_tests
-        ctest --test-dir build --build-config Debug --parallel 2 --output-on-failure --extra-verbose
+        ctest --test-dir build --build-config Debug --output-on-failure --extra-verbose
     - name: archive
       # run only if a PR is merged into master
       if: ${{ github.ref == 'refs/heads/master' && matrix.os == 'windows-2022' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -44,7 +44,6 @@ jobs:
         cmake -h
         wmic logicaldisk get size, freespace, caption
     - name: configure
-      shell: bash
       run: |
         mkdir build
         mkdir c:/project
@@ -53,18 +52,15 @@ jobs:
     - name: print detailed.log
       run: type build/detailed.log
     - name: build library
-      shell: bash
       run: |
         cmake --build build --parallel 2 --target install
     - name: test library
-      shell: bash
       run: |
         cmake --build build --parallel 2 --target setup_tests_a-framework
         cmake --build build --parallel 2 --target test
     - name: archive library
       # run only if a PR is merged into master
       if: ${{ github.ref == 'refs/heads/master' && matrix.os == 'windows-2022' }}
-      shell: bash
       run: |
         cd c:/project
         7z a dealii-windows.zip *

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,14 +51,14 @@ jobs:
         cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=c:/project -DDEAL_II_WITH_ZLIB=off -DDEAL_II_CXX_FLAGS="-WX /D FE_EVAL_FACTORY_DEGREE_MAX=2" -T host=x64 -A x64 ..
     - name: print detailed.log
       run: type build/detailed.log
-    - name: build library
+    - name: build
       run: |
         cmake --build build --parallel 2 --target install
-    - name: test library
+    - name: test
       run: |
-        cmake --build build --parallel 2 --target setup_tests_a-framework
-        cmake --build build --parallel 2 --target test
-    - name: archive library
+        cmake --build build --parallel 2 --target setup_tests_a-framework setup_tests_quick_tests
+        ctest --test-dir build --build-config Debug --parallel 2 --output-on-failure --extra-verbose
+    - name: archive
       # run only if a PR is merged into master
       if: ${{ github.ref == 'refs/heads/master' && matrix.os == 'windows-2022' }}
       run: |


### PR DESCRIPTION
Suggested in #17274.

Before testing examples, I thought it is a good step to adjust the workflow to look more like the linux and mac ones, which call `ctest` explicitly. This should make maintenance more easy, i.e., like:
https://github.com/dealii/dealii/blob/2906689aa0c7857044153c7ecf8a0c49f12d1913/.github/workflows/linux.yml#L67-L73