### PR TITLE
Add more comparisons to hp::Collection::CollectionIterator.

### DIFF
--- a/include/deal.II/hp/collection.h
+++ b/include/deal.II/hp/collection.h
@@ -29,6 +29,16 @@ DEAL_II_NAMESPACE_OPEN
 namespace hp
 {
   /**
+   * Exception thrown when comparing hp::Collection iterators into different
+   * objects.
+   *
+   * @ingroup Exceptions
+   */
+  DeclExceptionMsg(ExcDifferentCollection,
+                   "You are trying to compare iterators into different "
+                   "hp::Collection objects.");
+
+  /**
    * An iterator for hp::Collection.
    */
   template <typename T>
@@ -64,10 +74,7 @@ namespace hp
     bool
     operator==(const CollectionIterator<T> &other) const
     {
-      Assert(
-        this->data == other.data,
-        ExcMessage(
-          "You are trying to compare iterators into different hp::Collection objects."));
+      Assert(this->data == other.data, ExcDifferentCollection());
       return this->index == other.index;
     }
 
@@ -77,10 +84,7 @@ namespace hp
     bool
     operator!=(const CollectionIterator<T> &other) const
     {
-      Assert(
-        this->data == other.data,
-        ExcMessage(
-          "You are trying to compare iterators into different hp::Collection objects."));
+      Assert(this->data == other.data, ExcDifferentCollection());
       return this->index != other.index;
     }
 

--- a/include/deal.II/hp/collection.h
+++ b/include/deal.II/hp/collection.h
@@ -89,6 +89,46 @@ namespace hp
     }
 
     /**
+     * Compare indices.
+     */
+    bool
+    operator<(const CollectionIterator<T> &other) const
+    {
+      Assert(this->data == other.data, ExcDifferentCollection());
+      return this->index < other.index;
+    }
+
+    /**
+     * Compare indices.
+     */
+    bool
+    operator<=(const CollectionIterator<T> &other) const
+    {
+      Assert(this->data == other.data, ExcDifferentCollection());
+      return this->index <= other.index;
+    }
+
+    /**
+     * Compare indices.
+     */
+    bool
+    operator>(const CollectionIterator<T> &other) const
+    {
+      Assert(this->data == other.data, ExcDifferentCollection());
+      return this->index > other.index;
+    }
+
+    /**
+     * Compare indices.
+     */
+    bool
+    operator>=(const CollectionIterator<T> &other) const
+    {
+      Assert(this->data == other.data, ExcDifferentCollection());
+      return this->index >= other.index;
+    }
+
+    /**
      * Dereferencing operator: returns the value of the current index.
      */
     const T &


### PR DESCRIPTION
I cannot compile the library with `-D_GLIBCXX_DEBUG` without these.