### PR TITLE
Add missing changes file for Tpetra Amesos2 interface

### DIFF
--- a/doc/news/changes/major/20240212Thiele
+++ b/doc/news/changes/major/20240212Thiele
@@ -1,0 +1,9 @@
+New: LinearAlgebra::TpetraWrappers direct solver interfaces
+for Trilinos Amesos2, as listed below
+<dl>
+    <dt>SolverDirect</dt>
+    <dd>- Same interface as TrilinosWrappers, but with the option to pass a parameter list</dd>
+    <dt>SolverDirectKLU2</dt>
+    <dd>- An interface to the KLU2 solver, providing solver-specific AdditionalData</dd>
+</dl>
+(Jan Philipp Thiele, 2024/02/12)


### PR DESCRIPTION
During discussions of #17183 I noticed that I forgot to put in a news file in #16602 
and that it should be added before the 9.6 changelog is generated so everyone can get a better overview 
of what is already wrapped/interfaced from the Tpetra stack.