### PR TITLE
Name variables according to their purpose.

### DIFF
--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -628,15 +628,17 @@ namespace parallel
       get_checksum() const;
 
       /**
-       * Save the refinement information from the coarse mesh into the given
-       * file. This file needs to be reachable from all nodes in the
+       * Save the mesh and associated information into a number of files
+       * that all use the provided basename as a starting prefix, plus some
+       * suffixes that indicate the specific use of that file. These files all
+       * need to be reachable from all nodes in the
        * computation on a shared network file system. See the SolutionTransfer
        * class on how to store solution vectors into this file. Additional
        * cell-based data can be saved using
        * DistributedTriangulationBase::DataTransfer::register_data_attach().
        */
       virtual void
-      save(const std::string &filename) const override;
+      save(const std::string &file_basename) const override;
 
       /**
        * Load the refinement information saved with save() back in. The mesh
@@ -646,10 +648,10 @@ namespace parallel
        * You do not need to load with the same number of MPI processes that
        * you saved with. Rather, if a mesh is loaded with a different number
        * of MPI processes than used at the time of saving, the mesh is
-       * repartitioned that the number of cells is balanced among all processes.
-       * Individual repartitioning, e.g., based on the number of dofs or
-       * particles per cell, needs to be invoked manually by calling
-       * repartition() afterwards.
+       * repartitioned so that the number of cells is balanced among all
+       * processes. Individual repartitioning with non-identical weights for
+       * each cell, e.g., based on the number of dofs or particles per cell,
+       * needs to be invoked manually by calling repartition() afterwards.
        *
        * Cell-based data that was saved with
        * DistributedTriangulationBase::DataTransfer::register_data_attach() can
@@ -658,7 +660,7 @@ namespace parallel
        * after calling load().
        */
       virtual void
-      load(const std::string &filename) override;
+      load(const std::string &file_basename) override;
 
       /**
        * @copydoc load()

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -448,13 +448,13 @@ namespace internal
     /**
      * Serialize data to file system.
      *
-     * The data will be written in a separate file, whose name
-     * consists of the stem @p filename and an attached identifier
+     * The data will be written in a number of file whose names
+     * consists of the stem @p file_basename and an attached identifier
      * <tt>_fixed.data</tt> for fixed size data and <tt>_variable.data</tt>
      * for variable size data.
      *
      * If MPI support is enabled, all processors write into these files
-     * simultaneously via MPIIO. Each processor's position to write to will be
+     * simultaneously via MPI I/O. Each processor's position to write to will be
      * determined from the provided input parameters.
      *
      * Data has to be previously packed with pack_data().
@@ -462,14 +462,14 @@ namespace internal
     void
     save(const unsigned int global_first_cell,
          const unsigned int global_num_cells,
-         const std::string &filename,
+         const std::string &file_basename,
          const MPI_Comm    &mpi_communicator) const;
 
     /**
      * Deserialize data from file system.
      *
-     * The data will be read from separate file, whose name
-     * consists of the stem @p filename and an attached identifier
+     * The data will be read from separate files whose names
+     * consists of the stem @p file_basename and an attached identifier
      * <tt>_fixed.data</tt> for fixed size data and <tt>_variable.data</tt>
      * for variable size data.
      * The @p n_attached_deserialize_fixed and @p n_attached_deserialize_variable
@@ -487,7 +487,7 @@ namespace internal
     load(const unsigned int global_first_cell,
          const unsigned int global_num_cells,
          const unsigned int local_num_cells,
-         const std::string &filename,
+         const std::string &file_basename,
          const unsigned int n_attached_deserialize_fixed,
          const unsigned int n_attached_deserialize_variable,
          const MPI_Comm    &mpi_communicator);
@@ -3594,19 +3594,21 @@ public:
 
 
   /**
+   * Save the mesh and associated information into a number of files
+   * that all use the provided basename as a starting prefix, plus some
+   * suffixes that indicate the specific use of that file.
+   *
    * Save the triangulation into the given file. Internally, this
-   * function calls the save function which uses BOOST archives. This
-   * is a placeholder implementation that, in the near future, will also
-   * attach the data associated with the triangulation
+   * function calls the save function which uses BOOST archives.
    */
   virtual void
-  save(const std::string &filename) const;
+  save(const std::string &file_basename) const;
 
   /**
    * Load the triangulation saved with save() back in.
    */
   virtual void
-  load(const std::string &filename);
+  load(const std::string &file_basename);
 
 
   /**
@@ -3861,7 +3863,8 @@ public:
 
 protected:
   /**
-   * Save additional cell-attached data into the given file. The first
+   * Save additional cell-attached data from files all starting with
+   * the base name given as last argument. The first
    * arguments are used to determine the offsets where to write buffers to.
    *
    * Called by @ref save.
@@ -3869,10 +3872,11 @@ protected:
   void
   save_attached_data(const unsigned int global_first_cell,
                      const unsigned int global_num_cells,
-                     const std::string &filename) const;
+                     const std::string &file_basename) const;
 
   /**
-   * Load additional cell-attached data from the given file, if any was saved.
+   * Load additional cell-attached data files all starting with the
+   * base name given as fourth argument, if any was saved.
    * The first arguments are used to determine the offsets where to read
    * buffers from.
    *
@@ -3882,7 +3886,7 @@ protected:
   load_attached_data(const unsigned int global_first_cell,
                      const unsigned int global_num_cells,
                      const unsigned int local_num_cells,
-                     const std::string &filename,
+                     const std::string &file_basename,
                      const unsigned int n_attached_deserialize_fixed,
                      const unsigned int n_attached_deserialize_variable);
 

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -2051,7 +2051,8 @@ namespace parallel
 
     template <int dim, int spacedim>
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::save(const std::string &filename) const
+    void Triangulation<dim, spacedim>::save(
+      const std::string &file_basename) const
     {
       Assert(
         this->cell_attached_data.n_attached_deserialize == 0,
@@ -2068,7 +2069,7 @@ namespace parallel
 
       if (this->my_subdomain == 0)
         {
-          std::string   fname = filename + ".info";
+          std::string   fname = file_basename + ".info";
           std::ofstream f(fname);
           f << "version nproc n_attached_fixed_size_objs n_attached_variable_size_objs n_coarse_cells"
             << std::endl
@@ -2091,9 +2092,9 @@ namespace parallel
       // Save cell attached data.
       this->save_attached_data(parallel_forest->global_first_quadrant[myrank],
                                parallel_forest->global_num_quadrants,
-                               filename);
+                               file_basename);
 
-      dealii::internal::p4est::functions<dim>::save(filename.c_str(),
+      dealii::internal::p4est::functions<dim>::save(file_basename.c_str(),
                                                     parallel_forest,
                                                     false);
 
@@ -2105,7 +2106,7 @@ namespace parallel
 
     template <int dim, int spacedim>
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::load(const std::string &filename)
+    void Triangulation<dim, spacedim>::load(const std::string &file_basename)
     {
       Assert(
         this->n_cells() > 0,
@@ -2137,7 +2138,7 @@ namespace parallel
       unsigned int version, numcpus, attached_count_fixed,
         attached_count_variable, n_coarse_cells;
       {
-        std::string   fname = std::string(filename) + ".info";
+        std::string   fname = std::string(file_basename) + ".info";
         std::ifstream f(fname);
         AssertThrow(f.fail() == false, ExcIO());
         std::string firstline;
@@ -2158,7 +2159,7 @@ namespace parallel
         attached_count_fixed + attached_count_variable;
 
       parallel_forest = dealii::internal::p4est::functions<dim>::load_ext(
-        filename.c_str(),
+        file_basename.c_str(),
         this->mpi_communicator,
         0,
         0,
@@ -2190,7 +2191,7 @@ namespace parallel
       this->load_attached_data(parallel_forest->global_first_quadrant[myrank],
                                parallel_forest->global_num_quadrants,
                                parallel_forest->local_num_quadrants,
-                               filename,
+                               file_basename,
                                attached_count_fixed,
                                attached_count_variable);
 

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -672,7 +672,7 @@ namespace internal
   void CellAttachedDataSerializer<dim, spacedim>::save(
     const unsigned int global_first_cell,
     const unsigned int global_num_cells,
-    const std::string &filename,
+    const std::string &file_basename,
     const MPI_Comm    &mpi_communicator) const
   {
     Assert(sizes_fixed_cumulative.size() > 0,
@@ -694,7 +694,8 @@ namespace internal
         // ---------- Fixed size data ----------
         //
         {
-          const std::string fname_fixed = std::string(filename) + "_fixed.data";
+          const std::string fname_fixed =
+            std::string(file_basename) + "_fixed.data";
 
           MPI_Info info;
           int      ierr = MPI_Info_create(&info);
@@ -765,7 +766,7 @@ namespace internal
         if (variable_size_data_stored)
           {
             const std::string fname_variable =
-              std::string(filename) + "_variable.data";
+              std::string(file_basename) + "_variable.data";
 
             MPI_Info info;
             int      ierr = MPI_Info_create(&info);
@@ -854,7 +855,8 @@ namespace internal
         // ---------- Fixed size data ----------
         //
         {
-          const std::string fname_fixed = std::string(filename) + "_fixed.data";
+          const std::string fname_fixed =
+            std::string(file_basename) + "_fixed.data";
 
           std::ofstream file(fname_fixed, std::ios::binary | std::ios::out);
 
@@ -876,7 +878,7 @@ namespace internal
         if (variable_size_data_stored)
           {
             const std::string fname_variable =
-              std::string(filename) + "_variable.data";
+              std::string(file_basename) + "_variable.data";
 
             std::ofstream file(fname_variable,
                                std::ios::binary | std::ios::out);
@@ -902,7 +904,7 @@ namespace internal
     const unsigned int global_first_cell,
     const unsigned int global_num_cells,
     const unsigned int local_num_cells,
-    const std::string &filename,
+    const std::string &file_basename,
     const unsigned int n_attached_deserialize_fixed,
     const unsigned int n_attached_deserialize_variable,
     const MPI_Comm    &mpi_communicator)
@@ -925,7 +927,8 @@ namespace internal
         // ---------- Fixed size data ----------
         //
         {
-          const std::string fname_fixed = std::string(filename) + "_fixed.data";
+          const std::string fname_fixed =
+            std::string(file_basename) + "_fixed.data";
 
           MPI_Info info;
           int      ierr = MPI_Info_create(&info);
@@ -989,7 +992,7 @@ namespace internal
         if (variable_size_data_stored)
           {
             const std::string fname_variable =
-              std::string(filename) + "_variable.data";
+              std::string(file_basename) + "_variable.data";
 
             MPI_Info info;
             int      ierr = MPI_Info_create(&info);
@@ -1068,7 +1071,8 @@ namespace internal
         // ---------- Fixed size data ----------
         //
         {
-          const std::string fname_fixed = std::string(filename) + "_fixed.data";
+          const std::string fname_fixed =
+            std::string(file_basename) + "_fixed.data";
 
           std::ifstream file(fname_fixed, std::ios::binary | std::ios::in);
           sizes_fixed_cumulative.resize(1 + n_attached_deserialize_fixed +
@@ -1095,7 +1099,7 @@ namespace internal
         if (variable_size_data_stored)
           {
             const std::string fname_variable =
-              std::string(filename) + "_variable.data";
+              std::string(file_basename) + "_variable.data";
 
             std::ifstream file(fname_variable, std::ios::binary | std::ios::in);
 
@@ -13689,18 +13693,20 @@ void Triangulation<dim, spacedim>::load_user_indices(
     DEAL_II_NOT_IMPLEMENTED();
 }
 
+
+
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::save(const std::string &filename) const
+void Triangulation<dim, spacedim>::save(const std::string &file_basename) const
 {
   // Save triangulation information.
-  std::ofstream                 ofs(filename + "_triangulation.data");
+  std::ofstream                 ofs(file_basename + "_triangulation.data");
   boost::archive::text_oarchive oa(ofs, boost::archive::no_header);
   save(oa, 0);
 
   // Save attached data.
   {
-    std::ofstream ifs(filename + ".info");
+    std::ofstream ifs(file_basename + ".info");
     ifs
       << "version nproc n_attached_fixed_size_objs n_attached_variable_size_objs n_active_cells"
       << std::endl
@@ -13710,15 +13716,17 @@ void Triangulation<dim, spacedim>::save(const std::string &filename) const
       << this->n_global_active_cells() << std::endl;
   }
 
-  this->save_attached_data(0, this->n_global_active_cells(), filename);
+  this->save_attached_data(0, this->n_global_active_cells(), file_basename);
 }
+
+
 
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::load(const std::string &filename)
+void Triangulation<dim, spacedim>::load(const std::string &file_basename)
 {
   // Load triangulation information.
-  std::ifstream                 ifs(filename + "_triangulation.data");
+  std::ifstream                 ifs(file_basename + "_triangulation.data");
   boost::archive::text_iarchive ia(ifs, boost::archive::no_header);
   load(ia, 0);
 
@@ -13726,7 +13734,7 @@ void Triangulation<dim, spacedim>::load(const std::string &filename)
   unsigned int version, numcpus, attached_count_fixed, attached_count_variable,
     n_global_active_cells;
   {
-    std::ifstream ifs(std::string(filename) + ".info");
+    std::ifstream ifs(std::string(file_basename) + ".info");
     AssertThrow(ifs.fail() == false, ExcIO());
     std::string firstline;
     getline(ifs, firstline);
@@ -13758,7 +13766,7 @@ void Triangulation<dim, spacedim>::load(const std::string &filename)
   this->load_attached_data(0,
                            this->n_global_active_cells(),
                            this->n_active_cells(),
-                           filename,
+                           file_basename,
                            attached_count_fixed,
                            attached_count_variable);
 
@@ -16057,7 +16065,7 @@ DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 void Triangulation<dim, spacedim>::save_attached_data(
   const unsigned int global_first_cell,
   const unsigned int global_num_cells,
-  const std::string &filename) const
+  const std::string &file_basename) const
 {
   // cast away constness
   auto tria = const_cast<Triangulation<dim, spacedim> *>(this);
@@ -16074,7 +16082,7 @@ void Triangulation<dim, spacedim>::save_attached_data(
       // then store buffers in file
       tria->data_serializer.save(global_first_cell,
                                  global_num_cells,
-                                 filename,
+                                 file_basename,
                                  this->get_communicator());
 
       // and release the memory afterwards
@@ -16097,7 +16105,7 @@ void Triangulation<dim, spacedim>::load_attached_data(
   const unsigned int global_first_cell,
   const unsigned int global_num_cells,
   const unsigned int local_num_cells,
-  const std::string &filename,
+  const std::string &file_basename,
   const unsigned int n_attached_deserialize_fixed,
   const unsigned int n_attached_deserialize_variable)
 {
@@ -16107,7 +16115,7 @@ void Triangulation<dim, spacedim>::load_attached_data(
       this->data_serializer.load(global_first_cell,
                                  global_num_cells,
                                  local_num_cells,
-                                 filename,
+                                 file_basename,
                                  n_attached_deserialize_fixed,
                                  n_attached_deserialize_variable,
                                  this->get_communicator());


### PR DESCRIPTION
This is a follow-up to @peterrum's #17273, but really addresses a pre-existing issue: In the `save()` and `load()` functions, we named an argument `filename` when in reality we were writing into multiple files that all had that string as *base* name. Document this and name the argument better.