### PR TITLE
Consistently use interior normal vector

### DIFF
--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -3169,10 +3169,7 @@ FEPointEvaluation<n_components_, dim, spacedim, Number>::normal_vector(
          internal::FEPointEvaluation::
            ExcFEPointEvaluationAccessToUninitializedMappingField(
              "update_normal_vectors"));
-  if (this->is_interior)
-    return this->normal_ptr[point_index];
-  else
-    return -this->normal_ptr[point_index];
+  return this->normal_ptr[point_index];
 }
 
 
@@ -3924,17 +3921,12 @@ FEFacePointEvaluation<n_components_, dim, spacedim, Number>::normal_vector(
         normal[d] =
           internal::VectorizedArrayTrait<Number>::get(this->normal_ptr[0][d],
                                                       0);
-      if (this->is_interior)
-        return normal;
-      else
-        return -normal;
+
+      return normal;
     }
   else
     {
-      if (this->is_interior)
-        return this->normal_ptr[point_index];
-      else
-        return -(this->normal_ptr[point_index]);
+      return this->normal_ptr[point_index];
     }
 }
 

--- a/tests/non_matching/mapping_info_04.cc
+++ b/tests/non_matching/mapping_info_04.cc
@@ -50,27 +50,26 @@ do_flux_term(Integrator        &evaluator_m,
              const Number2     &tau,
              const unsigned int q)
 {
-  const auto gradient_m = evaluator_m.get_gradient(q);
-  const auto gradient_p = evaluator_p.get_gradient(q);
+  const auto normal_gradient_m = evaluator_m.get_normal_derivative(q);
+  const auto normal_gradient_p = evaluator_p.get_normal_derivative(q);
 
   const auto value_m = evaluator_m.get_value(q);
   const auto value_p = evaluator_p.get_value(q);
 
-  const auto normal = evaluator_m.normal_vector(q);
+  const auto jump_value = value_m - value_p;
 
-  const auto jump_value = (value_m - value_p) * normal;
+  const auto central_flux_gradient =
+    0.5 * (normal_gradient_m + normal_gradient_p);
 
-  const auto central_flux_gradient = 0.5 * (gradient_m + gradient_p);
-
-  const auto value_terms = normal * (central_flux_gradient - tau * jump_value);
+  const auto value_terms = central_flux_gradient - tau * jump_value;
 
   evaluator_m.submit_value(-value_terms, q);
   evaluator_p.submit_value(value_terms, q);
 
   const auto gradient_terms = -0.5 * jump_value;
 
-  evaluator_m.submit_gradient(gradient_terms, q);
-  evaluator_p.submit_gradient(gradient_terms, q);
+  evaluator_m.submit_normal_derivative(gradient_terms, q);
+  evaluator_p.submit_normal_derivative(gradient_terms, q);
 }
 
 template <int dim>


### PR DESCRIPTION
I should have checked this already in #17288. In `FEFaceEvaluation` we always return the interior normal vector, see

https://github.com/dealii/dealii/blob/add8e16ae6718e1e0521653ec1f5c1e48db5ee57/include/deal.II/matrix_free/fe_evaluation_data.h#L217-L230

which means we also have to do this for `FEFacePointEvaluation`.

For the ECL case with `FEFacePointEvaluation` we also have to address this somehow.