### PR TITLE
Move an #ifdef guard.

### DIFF
--- a/include/deal.II/base/trilinos_utilities.h
+++ b/include/deal.II/base/trilinos_utilities.h
@@ -24,16 +24,18 @@
 #  include <Epetra_Map.h>
 #  include <Teuchos_Comm.hpp>
 #  include <Teuchos_RCP.hpp>
+
 #  ifdef DEAL_II_WITH_MPI
 #    include <Epetra_MpiComm.h>
 #  else
 #    include <Epetra_SerialComm.h>
 #  endif
+
+#  ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#    include <Teuchos_RCPDecl.hpp>
+#  endif // DEAL_II_TRILINOS_WITH_TPETRA
 #endif
 
-#ifdef DEAL_II_TRILINOS_WITH_TPETRA
-#  include <Teuchos_RCPDecl.hpp>
-#endif // DEAL_II_TRILINOS_WITH_TPETRA
 
 DEAL_II_NAMESPACE_OPEN
 


### PR DESCRIPTION
I found it easier to read it this way, because `DEAL_II_TRILINOS_WITH_TPETRA` can only be set anyway if `DEAL_II_WITH_TRILINOS` is true. I happened on this because I had set the former manually on the command line, not realizing that the latter was false, and ended up with a compiler error. That wouldn't happen in real life, but I think it was easier to read this way anyway.