### PR TITLE
Test examples/step-60: do not write "used_parameters.prm" into source directory

### DIFF
--- a/tests/examples/step-60.diff
+++ b/tests/examples/step-60.diff
@@ -10,7 +10,3 @@
 <         parameter_file = "parameters.prm";
 ---
 >         parameter_file = "../../../source/step-60/parameters.prm";
-1094c1094
-<       ParameterAcceptor::initialize(parameter_file, "used_parameters.prm");
----
->       ParameterAcceptor::initialize(parameter_file, "../../../source/step-60/used_parameters.prm");


### PR DESCRIPTION
Instead, this file can be created in the test directory (along all other output files).