### PR TITLE
Test examples/step-52: disable unstable output

### DIFF
--- a/tests/examples/step-52.diff
+++ b/tests/examples/step-52.diff
@@ -1,12 +1,74 @@
-774c774
+669c669
+<     triangulation.refine_global(4);
+---
+>     triangulation.refine_global(3);
+693c693
+<     unsigned int       n_steps      = 0;
+---
+>     unsigned int       n_steps [[maybe_unused]] = 0;
+703,704c703
+<     std::cout << "   Forward Euler:            error=" << solution.l2_norm()
+<               << std::endl;
+---
+>     std::cout << "   Forward Euler: [no error reported]" << std::endl;
+710,711c709
+<     std::cout << "   Third order Runge-Kutta:  error=" << solution.l2_norm()
+<               << std::endl;
+---
+>     std::cout << "   Third order Runge-Kutta: [no error reported]" << std::endl;
+717,719c715
+<     std::cout << "   Fourth order Runge-Kutta: error=" << solution.l2_norm()
+<               << std::endl;
+<     std::cout << std::endl;
+---
+>     std::cout << "   Fourth order Runge-Kutta: [no error reported]" << std::endl;
+727,728c723
+<     std::cout << "   Backward Euler:           error=" << solution.l2_norm()
+<               << std::endl;
+---
+>     std::cout << "   Backward Euler: [no error reported]" << std::endl;
+734,735c729
+<     std::cout << "   Implicit Midpoint:        error=" << solution.l2_norm()
+<               << std::endl;
+---
+>     std::cout << "   Implicit Midpoint: [no error reported]" << std::endl;
+741,742c735
+<     std::cout << "   Crank-Nicolson:           error=" << solution.l2_norm()
+<               << std::endl;
+---
+>     std::cout << "   Crank-Nicolson: [no error reported]" << std::endl;
+748,749c741
+<     std::cout << "   SDIRK:                    error=" << solution.l2_norm()
+<               << std::endl;
+---
+>     std::cout << "   SDIRK: [no error reported]" << std::endl;
+758,760c750
+<     std::cout << "   Heun-Euler:               error=" << solution.l2_norm()
+<               << std::endl;
+<     std::cout << "                   steps performed=" << n_steps << std::endl;
+---
+>     std::cout << "   Heun-Euler: [no error reported]" << std::endl;
+766,768c756
+<     std::cout << "   Bogacki-Shampine:         error=" << solution.l2_norm()
+<               << std::endl;
+<     std::cout << "                   steps performed=" << n_steps << std::endl;
+---
+>     std::cout << "   Bogacki-Shampine: [no error reported]" << std::endl;
+774,776c762
 <     std::cout << "   Dopri:                    error=" << solution.l2_norm()
+<               << std::endl;
+<     std::cout << "                   steps performed=" << n_steps << std::endl;
 ---
->     std::cout << "   Dopri:                    error=" << ((solution.l2_norm()<1.0e-4) ? "is within 1e-4" : "is NOT within 1e-4")
-782c782
+>     std::cout << "   Dopri: [no error reported]" << std::endl;
+782,784c768
 <     std::cout << "   Fehlberg:                 error=" << solution.l2_norm()
+<               << std::endl;
+<     std::cout << "                   steps performed=" << n_steps << std::endl;
 ---
->     std::cout << "   Fehlberg:                 error=" << ((solution.l2_norm()<1.0e-2) ? "is within 1e-2" : "is NOT within 1e-2")
-790c790
+>     std::cout << "   Fehlberg: [no error reported]" << std::endl;
+790,792c774
 <     std::cout << "   Cash-Karp:                error=" << solution.l2_norm()
+<               << std::endl;
+<     std::cout << "                   steps performed=" << n_steps << std::endl;
 ---
->     std::cout << "   Cash-Karp:                error=" << ((solution.l2_norm()<1.0e-3) ? "is within 1e-3" : "is NOT within 1e-3")
+>     std::cout << "   Cash-Karp: [no error reported]" << std::endl;

--- a/tests/examples/step-52.with_umfpack=true.output
+++ b/tests/examples/step-52.with_umfpack=true.output
@@ -1,22 +1,16 @@
 Explicit methods:
-   Forward Euler:            error=1.00883
-   Third order Runge-Kutta:  error=0.000227982
-   Fourth order Runge-Kutta: error=1.90541e-06
-
+   Forward Euler: [no error reported]
+   Third order Runge-Kutta: [no error reported]
+   Fourth order Runge-Kutta: [no error reported]
 Implicit methods:
-   Backward Euler:           error=1.03428
-   Implicit Midpoint:        error=0.00862702
-   Crank-Nicolson:           error=0.00862675
-   SDIRK:                    error=0.0042349
+   Backward Euler: [no error reported]
+   Implicit Midpoint: [no error reported]
+   Crank-Nicolson: [no error reported]
+   SDIRK: [no error reported]
 
 Embedded explicit methods:
-   Heun-Euler:               error=0.0073012
-                   steps performed=284
-   Bogacki-Shampine:         error=0.000401145
-                   steps performed=181
-   Dopri:                    error=is within 1e-4
-                   steps performed=121
-   Fehlberg:                 error=is within 1e-2
-                   steps performed=106
-   Cash-Karp:                error=is within 1e-3
-                   steps performed=107
+   Heun-Euler: [no error reported]
+   Bogacki-Shampine: [no error reported]
+   Dopri: [no error reported]
+   Fehlberg: [no error reported]
+   Cash-Karp: [no error reported]


### PR DESCRIPTION
In reference to #9684:

The output of most of the time-stepping methods is very prone to roundoff-error amplification. Thus, only verify that the example step compiles and runs without an error. Let's not attempt to compare residuals or number of steps.