### PR TITLE
Test opencascade/stl_(write|refinement): disable floating point exceptions

### DIFF
--- a/tests/opencascade/stl_refinement.cc
+++ b/tests/opencascade/stl_refinement.cc
@@ -33,6 +33,16 @@ using namespace OpenCASCADE;
 int
 main()
 {
+  // This test might trigger spurious floating point exception despite
+  // functioning properly. Simply disable floating point exceptions again
+  // (after they had been enabled int tests.h)
+#if defined(DEBUG) && defined(DEAL_II_HAVE_FP_EXCEPTIONS)
+  {
+    const int current_fe_except = fegetexcept();
+    fedisableexcept(current_fe_except);
+  }
+#endif
+
   TopoDS_Shape        sh = read_STL(SOURCE_DIR "/stl_files/sphere_refined.stl");
   Triangulation<2, 3> tria;
   GridIn<2, 3>        gridin;

--- a/tests/opencascade/stl_write.cc
+++ b/tests/opencascade/stl_write.cc
@@ -29,6 +29,16 @@ using namespace OpenCASCADE;
 int
 main()
 {
+  // This test might trigger spurious floating point exception despite
+  // functioning properly. Simply disable floating point exceptions again
+  // (after they had been enabled int tests.h)
+#if defined(DEBUG) && defined(DEAL_II_HAVE_FP_EXCEPTIONS)
+  {
+    const int current_fe_except = fegetexcept();
+    fedisableexcept(current_fe_except);
+  }
+#endif
+
   initlog();
   TopoDS_Shape sh = read_STL(SOURCE_DIR "/stl_files/sphere_refined.stl");
   write_STL(sh, "tmp.stl", 0.001, false, 1e-6, false, 0.001, false);


### PR DESCRIPTION
With clang 18 we trigger spurious floating point exceptions:

  https://cdash.dealii.org/test/4927501

Thus, let us simply disable the floating point exceptions.
