### PR TITLE
Drop TaskResult::wait_and_move_result() in favor of join().

### DIFF
--- a/include/deal.II/base/task_result.h
+++ b/include/deal.II/base/task_result.h
@@ -311,6 +311,12 @@ namespace Threads
      * assignment operator, this function considers it an
      * error (and throws an exception) if there is still a
      * currently running task associated with the object.
+     * Because you cannot know when a task associated with an
+     * object finishes, the practical realization of there not being
+     * a currently still running task is that you can only call this
+     * function on an object that has an associated task *after* you
+     * have either called join() or asked for the return value by
+     * having called value() (which internally calls join()).
      */
     void
     clear();

--- a/include/deal.II/base/task_result.h
+++ b/include/deal.II/base/task_result.h
@@ -320,7 +320,7 @@ namespace Threads
      * it isn't associated with a task, just return.
      */
     void
-    join();
+    join() const;
 
     /**
      * Return a reference to the object computed by the task. This
@@ -356,14 +356,6 @@ namespace Threads
      * A lock object that guards access to all of the `mutable` objects above.
      */
     mutable std::mutex mutex;
-
-    /**
-     * Wait for the task to finish, move its result into the `task_result`
-     * object, and then release all information still associated with the
-     * task that originally computed the result.
-     */
-    void
-    wait_and_move_result() const;
   };
 
 
@@ -487,7 +479,7 @@ namespace Threads
 
   template <typename T>
   inline void
-  TaskResult<T>::join()
+  TaskResult<T>::join() const
   {
     // If we have waited before, then return immediately:
     if (result_is_available)
@@ -503,11 +495,17 @@ namespace Threads
         if (result_is_available)
           return;
         else
-          // If there is a task, wait for it to finish. We could then move
-          // the result, but it's fine to postpone that until someone actually
-          // asks for the result.
-          if (task.has_value())
+          {
+            // The object is not empty and it has not received its result yet.
+            // So it must have a task object:
+            Assert(task.has_value(), ExcInternalError());
+
             task.value().join();
+            task_result = std::move(task.value().return_value());
+            task.reset();
+
+            result_is_available = true;
+          }
       }
   }
 
@@ -518,44 +516,9 @@ namespace Threads
   TaskResult<T>::value() const
   {
     if (!result_is_available)
-      wait_and_move_result();
+      join();
     return task_result.value();
   }
-
-
-
-  template <typename T>
-  inline void
-  TaskResult<T>::wait_and_move_result() const
-  {
-    // If we have waited before, then return immediately:
-    if (result_is_available)
-      return;
-    else
-      // If we have not waited, wait now. We need to use the double-checking
-      // pattern to ensure that if two threads get to this place at the same
-      // time, one returns right away while the other does the work. Note
-      // that this happens under the lock, so only one thread gets to be in
-      // this code block at the same time:
-      {
-        std::lock_guard<std::mutex> lock(mutex);
-
-        if (result_is_available)
-          return;
-        else
-          {
-            Assert(task.has_value(),
-                   ExcMessage("You cannot wait for the result of a TaskResult "
-                              "object that has no task associated with it."));
-            task.value().join();
-            task_result = std::move(task.value().return_value());
-            task.reset();
-
-            result_is_available = true;
-          }
-      }
-  }
-
 } // namespace Threads
 
 /**


### PR DESCRIPTION
Previously, I had implemented `TaskResult::join()` to just wait for the task to finish, but I did not move the result. That happened only when someone actually asked for the result of the task via `value()`, which then called `wait_and_move_result()`. This is not smart because there are now two different ways to represent the state "task is finished", namely one where the task has been waited for but the result has not been moved, and one where the task has been waited for and the result has been moved. From a user perspective, the two are the same. We should not represent them differently internally.

By using a canonical representation, I also gain the ability to actually check whether a task has been waited for: Namely, if the result has been moved. This is useful because operations such as `operator=()` or `clear()` are only valid if a task has been waited for. By using a unified representation, the checks that are in these functions now actually express that someone has called `join()`.

Follow-up to #16198. Part of #17318.