### PR TITLE
fix NonlinearSolverSelector MPI_COMM

### DIFF
--- a/include/deal.II/numerics/nonlinear.h
+++ b/include/deal.II/numerics/nonlinear.h
@@ -207,9 +207,12 @@ public:
   NonlinearSolverSelector();
 
   /**
-   * Constructor, selecting the solver and other parametersspecified in
+   * Constructor, selecting the solver and other parameters specified in
    * @p additional_data.
+   *
+   * @deprecated Use the other constructor with MPI_Comm instead.
    */
+  DEAL_II_DEPRECATED
   NonlinearSolverSelector(const AdditionalData &additional_data);
 
   /**
@@ -482,7 +485,9 @@ NonlinearSolverSelector<VectorType>::set_data(
 
 
 template <typename VectorType>
-NonlinearSolverSelector<VectorType>::NonlinearSolverSelector() = default;
+NonlinearSolverSelector<VectorType>::NonlinearSolverSelector()
+  : mpi_communicator(MPI_COMM_SELF)
+{}
 
 
 
@@ -490,6 +495,7 @@ template <typename VectorType>
 NonlinearSolverSelector<VectorType>::NonlinearSolverSelector(
   const AdditionalData &additional_data)
   : additional_data(additional_data)
+  , mpi_communicator(MPI_COMM_SELF)
 {
   set_data(additional_data);
 }

--- a/tests/numerics/nonlinear_solver_selector_01.cc
+++ b/tests/numerics/nonlinear_solver_selector_01.cc
@@ -358,7 +358,7 @@ namespace nonlinear_solver_selector_test
       typename NLSolve::AdditionalData additional_data;
       additional_data.solver_type = SOLVER;
 
-      NLSolve nonlinear_solver(additional_data);
+      NLSolve nonlinear_solver(additional_data, MPI_COMM_WORLD);
 
       nonlinear_solver.reinit_vector = [&](Vector<double> &x) {
         x.reinit(dof_handler.n_dofs());


### PR DESCRIPTION
We forgot to initialize the mpi communicator inside this class, which is then passed to SUNDIALS and causes random crashes.

Fixes #17326.