### PR TITLE
Fix warning in check_solver_within_range().

### DIFF
--- a/tests/examples/example_test.h
+++ b/tests/examples/example_test.h
@@ -58,7 +58,7 @@ cat_file(const char *filename)
       {                                                                   \
         SolverType_COMMAND;                                               \
       }                                                                   \
-    catch (SolverControl::NoConvergence & exc)                            \
+    catch (SolverControl::NoConvergence &)                                \
       {}                                                                  \
     const unsigned int steps = CONTROL_COMMAND;                           \
     if (steps >= MIN_ALLOWED && steps <= MAX_ALLOWED)                     \


### PR DESCRIPTION
MSVC complains:
```
warning C4101: 'exc': unreferenced local variable
```

Part of #13596.