### PR TITLE
FEEvaluation: Allow submit_value with Tensor<1,1> more often

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -355,14 +355,14 @@ public:
   submit_value(const value_type val_in, const unsigned int q_point);
 
   /**
-   * In 1D, the value_type and gradient_type can be unintentionally mixed
-   * up because FEEvaluationBase does not distinguish between scalar accessors
-   * and vector-valued accessors and the respective types, but solely in terms
-   * of the number of components and dimension. Thus, enable the use of
-   * submit_value() also for tensors with a single component.
+   * For scalar elements, the value_type and gradient_type can be
+   * unintentionally mixed up because FEEvaluationBase does not distinguish
+   * between scalar accessors and vector-valued accessors and the respective
+   * types, but solely in terms of the number of components and dimension. Thus,
+   * enable the use of submit_value() also for tensors with a single component.
    */
-  template <int dim_ = dim,
-            typename = std::enable_if_t<dim_ == 1 && n_components == dim_>>
+  template <int n_components_local = n_components,
+            typename = std::enable_if_t<n_components == n_components_local>>
   void
   submit_value(const Tensor<1, 1, VectorizedArrayType> val_in,
                const unsigned int                      q_point);
@@ -4911,7 +4911,7 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
   submit_value(const Tensor<1, 1, VectorizedArrayType> val_in,
                const unsigned int                      q_point)
 {
-  static_assert(n_components == 1 && dim == 1,
+  static_assert(n_components == 1,
                 "Do not try to modify the default template parameters used for"
                 " selectively enabling this function via std::enable_if!");
   submit_value(val_in[0], q_point);

--- a/tests/multigrid-global-coarsening/multigrid_util.h
+++ b/tests/multigrid-global-coarsening/multigrid_util.h
@@ -206,22 +206,14 @@ public:
             phi.reinit(cell);
             for (unsigned int q = 0; q < phi.n_q_points; ++q)
               {
-                if constexpr (n_components == 1)
+                Tensor<1, n_components, VectorizedArray<Number>> temp;
+                for (unsigned int v = 0; v < VectorizedArray<Number>::size();
+                     ++v)
                   {
-                    phi.submit_value(1.0, q);
+                    for (unsigned int i = 0; i < n_components; i++)
+                      temp[i][v] = 1.;
                   }
-                else
-                  {
-                    Tensor<1, n_components, VectorizedArray<Number>> temp;
-                    for (unsigned int v = 0;
-                         v < VectorizedArray<Number>::size();
-                         ++v)
-                      {
-                        for (unsigned int i = 0; i < n_components; i++)
-                          temp[i][v] = 1.;
-                      }
-                    phi.submit_value(temp, q);
-                  }
+                phi.submit_value(temp, q);
               }
 
             phi.integrate_scatter(EvaluationFlags::values, dst);


### PR DESCRIPTION
Looking at a test failure at https://cdash.dealii.org/test/5275504 (which is likely a compiler issue because we have https://github.com/dealii/dealii/blob/8ef6a999bdc36caa1e4192ca78abfd932678b542/tests/multigrid-global-coarsening/multigrid_util.h#L209-L223 (notice `if constexpr`), I started thinking if we could be more forgiving in what we accept for `FEEvaluation::submit_value`. Indeed, I see no reason to exclude the `n_components = 1` also for higher dimensions, as I can't see it making any harm. This is in reference to the cleanup done in #16770 and #16776. I think it would be great if we can make it with the release, but if we can't it's also not a huge problem.

Anyway, let us first see if the tests are passing.