### PR TITLE
Add two matrix-free-related changelog entries

### DIFF
--- a/doc/news/changes/minor/20230911Kronbichler
+++ b/doc/news/changes/minor/20230911Kronbichler
@@ -1,0 +1,7 @@
+Improved: The internal implementation of the tensor-product evaluators used
+for FEEvaluation and FEFaceEvaluation has been cleaned up. This reduces the
+compile times for both the deal.II library and code using FEEvaluation with
+template parameters on the polynomial degrees. Also, the code is now simpler
+to maintain, especially for the evaluators for Raviart-Thomas elements.
+<br>
+(Martin Kronbichler, 2023/09/11)

--- a/doc/news/changes/minor/20230912Kronbichler
+++ b/doc/news/changes/minor/20230912Kronbichler
@@ -1,0 +1,7 @@
+Improved: FEEvaluation::get_gradient() and FEEvaluation::submit_gradient() are
+now considerably faster for Raviart-Thomas elements on non-Cartesian meshes.
+The previous algorithm used non-optimal loop layouts for the local tensor
+contractions in the derivative of the Piola transform, which have been
+transformed to optimal-complexity variants.
+<br>
+(Martin Kronbichler, 2023/09/12)


### PR DESCRIPTION
This adds two changelog entries to improvements in the matrix-free evaluators done for the last release, in particular regarding the pull request #15951 and the pull request #15980.