### PR TITLE
Obey the rule of 5 or 7 in TaskResult.

### DIFF
--- a/include/deal.II/base/task_result.h
+++ b/include/deal.II/base/task_result.h
@@ -196,7 +196,7 @@ namespace Threads
      * represents anything and is left as if default-constructed.
      */
     TaskResult &
-    operator=(TaskResult &&);
+    operator=(TaskResult &&) noexcept;
 
     /**
      * Copy assignment operator from a Task object. By assigning the Task
@@ -444,7 +444,7 @@ namespace Threads
 
   template <typename T>
   inline TaskResult<T> &
-  TaskResult<T>::operator=(TaskResult<T> &&other)
+  TaskResult<T>::operator=(TaskResult<T> &&other) noexcept
   {
     // First clear the current object before we put new content into it:
     clear();


### PR DESCRIPTION
We had copy and move constructors, but not copy or move operators. This is not smart.