### PR TITLE
Add clear() and Tvmult() for SparseVanka

### DIFF
--- a/doc/news/changes/minor/20240814chaycha
+++ b/doc/news/changes/minor/20240814chaycha
@@ -1,0 +1,4 @@
+New: Added SparseVanka::Tvmult() and SparseVanka::clear()
+SparseVanka can now be passed to MGSmootherPrecondition to be used as a multigrid smoother.
+<br>
+(Chayapol Chaoveeraprasit, 2024/08/14)

--- a/include/deal.II/lac/sparse_vanka.h
+++ b/include/deal.II/lac/sparse_vanka.h
@@ -15,8 +15,6 @@
 #ifndef dealii_sparse_vanka_h
 #define dealii_sparse_vanka_h
 
-
-
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/multithread_info.h>
@@ -217,6 +215,12 @@ public:
   Tvmult(Vector<number2> &dst, const Vector<number2> &src) const;
 
   /**
+   * Clear all memory.
+   */
+  void
+  clear();
+
+  /**
    * Return the dimension of the codomain (or range) space. Note that the
    * matrix is of dimension $m \times n$.
    *
@@ -240,9 +244,11 @@ protected:
   /**
    * Apply the inverses corresponding to those degrees of freedom that have a
    * @p true value in @p dof_mask, to the @p src vector and move the result
-   * into @p dst. Actually, only values for allowed indices are written to @p
-   * dst, so the application of this function only does what is announced in
-   * the general documentation if the given mask sets all values to zero
+   * into @p dst. The transpose of the inverse is applied instead if
+   * @p transpose equals true. Actually, only values for allowed indices are
+   * written to @p dst, so the application of this function only does what is
+   * announced in the general documentation if the given mask sets all values
+   * to zero.
    *
    * The reason for providing the mask anyway is that in derived classes we
    * may want to apply the preconditioner to parts of the matrix only, in
@@ -258,10 +264,12 @@ protected:
    * The @p vmult of this class of course calls this function with a null
    * pointer
    */
+
   template <typename number2>
   void
   apply_preconditioner(Vector<number2>               &dst,
                        const Vector<number2>         &src,
+                       const bool                     transpose = false,
                        const std::vector<bool> *const dof_mask = nullptr) const;
 
   /**
@@ -511,6 +519,14 @@ public:
   void
   vmult(Vector<number2> &dst, const Vector<number2> &src) const;
 
+
+  /**
+   * Apply the transpose preconditioner.
+   */
+  template <typename number2>
+  void
+  Tvmult(Vector<number2> &dst, const Vector<number2> &src) const;
+
   /**
    * Determine an estimate for the memory consumption (in bytes) of this
    * object.
@@ -562,15 +578,6 @@ SparseVanka<number>::n() const
 {
   Assert(_n != 0, ExcNotInitialized());
   return _n;
-}
-
-template <typename number>
-template <typename number2>
-inline void
-SparseVanka<number>::Tvmult(Vector<number2> & /*dst*/,
-                            const Vector<number2> & /*src*/) const
-{
-  AssertThrow(false, ExcNotImplemented());
 }
 
 #endif // DOXYGEN

--- a/source/lac/sparse_vanka.cc
+++ b/source/lac/sparse_vanka.cc
@@ -27,6 +27,12 @@ SparseVanka<double>::vmult<float>(Vector<float>       &dst,
 template void
 SparseVanka<double>::vmult<double>(Vector<double>       &dst,
                                    const Vector<double> &src) const;
+template void
+SparseVanka<double>::Tvmult<float>(Vector<float>       &dst,
+                                   const Vector<float> &src) const;
+template void
+SparseVanka<double>::Tvmult<double>(Vector<double>       &dst,
+                                    const Vector<double> &src) const;
 
 
 template class SparseBlockVanka<float>;
@@ -38,5 +44,11 @@ SparseBlockVanka<double>::vmult<float>(Vector<float>       &dst,
 template void
 SparseBlockVanka<double>::vmult<double>(Vector<double>       &dst,
                                         const Vector<double> &src) const;
+template void
+SparseBlockVanka<double>::Tvmult<float>(Vector<float>       &dst,
+                                        const Vector<float> &src) const;
+template void
+SparseBlockVanka<double>::Tvmult<double>(Vector<double>       &dst,
+                                         const Vector<double> &src) const;
 
 DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
I wanted to use SparseVanka as a multigrid smoother, but currently it is not possible since there is no clear() and Tvmult() methods in SparseVanka, required by MGSmootherPrecondition. Therefore, I have implemented these two methods, and now SparseVanka can be used as a multigrid smoother.