### PR TITLE
Fix typo in PreconditionSOR

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_precondition.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_precondition.templates.h
@@ -467,7 +467,7 @@ namespace LinearAlgebra
         Teuchos::ParameterList &relaxParams =
           this->parameter_list.sublist("schwarz: subdomain solver parameters",
                                        false);
-        relaxParams.set("relaxation: type", "Symmetric Gauss-Seidel");
+        relaxParams.set("relaxation: type", "Gauss-Seidel");
         relaxParams.set("relaxation: damping factor", ad.omega);
         relaxParams.set("relaxation: sweeps", ad.n_sweeps);
         relaxParams.set("relaxation: fix tiny diagonal entries",

--- a/tests/trilinos_tpetra/precondition.cc
+++ b/tests/trilinos_tpetra/precondition.cc
@@ -334,7 +334,7 @@ Step4<dim>::solve(int cycle)
     solution = 0;
 
     SolverControl solver_control(1000, 1e-5);
-    SolverCG<LinearAlgebra::TpetraWrappers::Vector<double>> solver(
+    SolverBicgstab<LinearAlgebra::TpetraWrappers::Vector<double>> solver(
       solver_control);
     preconditioner.initialize(system_matrix);
     check_solver_within_range(

--- a/tests/trilinos_tpetra/precondition.with_trilinos.geq.13.output
+++ b/tests/trilinos_tpetra/precondition.with_trilinos.geq.13.output
@@ -4,7 +4,7 @@ DEAL:01089:CustomSGS::Solver stopped after 41 iterations
 DEAL:01089:Jacobi::Solver stopped within 49 - 51 iterations
 DEAL:01089:l1Jacobi::Solver stopped within 49 - 51 iterations
 DEAL:01089:l1GaussSeidel::Solver stopped after 48 iterations
-DEAL:01089:SOR::Solver stopped after 25 iterations
+DEAL:01089:SOR::Solver stopped within 31 - 33 iterations
 DEAL:01089:SSOR::Solver stopped within 40 - 42 iterations
 DEAL:01089:BlockJacobi::Solver stopped after 58 iterations
 DEAL:01089:BlockSOR::Solver stopped after 16 iterations
@@ -25,7 +25,7 @@ DEAL:04225:CustomSGS::Solver stopped after 78 iterations
 DEAL:04225:Jacobi::Solver stopped within 100 - 102 iterations
 DEAL:04225:l1Jacobi::Solver stopped within 100 - 102 iterations
 DEAL:04225:l1GaussSeidel::Solver stopped after 98 iterations
-DEAL:04225:SOR::Solver stopped after 46 iterations
+DEAL:04225:SOR::Solver stopped within 62 - 64 iterations
 DEAL:04225:SSOR::Solver stopped within 77 - 79 iterations
 DEAL:04225:BlockJacobi::Solver stopped after 82 iterations
 DEAL:04225:BlockSOR::Solver stopped after 20 iterations

--- a/tests/trilinos_tpetra/precondition.with_trilinos.le.13.output
+++ b/tests/trilinos_tpetra/precondition.with_trilinos.le.13.output
@@ -4,7 +4,7 @@ DEAL:01089:CustomSGS::Solver stopped after 41 iterations
 DEAL:01089:Jacobi::Solver stopped within 49 - 51 iterations
 DEAL:01089:l1Jacobi::Solver stopped within 49 - 51 iterations
 DEAL:01089:l1GaussSeidel::Solver stopped after 48 iterations
-DEAL:01089:SOR::Solver stopped after 25 iterations
+DEAL:01089:SOR::Solver stopped within 31 - 33 iterations
 DEAL:01089:SSOR::Solver stopped within 40 - 42 iterations
 DEAL:01089:BlockJacobi::Solver stopped after 58 iterations
 DEAL:01089:BlockSOR::Solver stopped after 16 iterations
@@ -25,7 +25,7 @@ DEAL:04225:CustomSGS::Solver stopped after 78 iterations
 DEAL:04225:Jacobi::Solver stopped within 100 - 102 iterations
 DEAL:04225:l1Jacobi::Solver stopped within 100 - 102 iterations
 DEAL:04225:l1GaussSeidel::Solver stopped after 98 iterations
-DEAL:04225:SOR::Solver stopped after 46 iterations
+DEAL:04225:SOR::Solver stopped within 62 - 64 iterations
 DEAL:04225:SSOR::Solver stopped within 77 - 79 iterations
 DEAL:04225:BlockJacobi::Solver stopped after 82 iterations
 DEAL:04225:BlockSOR::Solver stopped after 20 iterations


### PR DESCRIPTION
While editing the MueLu branch I noticed a copy & paste error from SSOR to SOR in keeping `Symmetric` in the relaxation type name. This now makes SOR an actual forward Gauss-Seidel based preconditioner instead of a copy of SSOR