### PR TITLE
Make 'mapping' variables 'const' in example files

### DIFF
--- a/doc/news/changes/minor/20240725AE7TB99
+++ b/doc/news/changes/minor/20240725AE7TB99
@@ -1,0 +1,3 @@
+Made `mapping` variables `const` in example files.
+<br>
+(AE7TB99, 2024/07/25)

--- a/doc/news/changes/minor/20240725AE7TB99
+++ b/doc/news/changes/minor/20240725AE7TB99
@@ -1,3 +1,3 @@
 Made `mapping` variables `const` in example files.
 <br>
-(AE7TB99, 2024/07/25)
+(Lóránt Hadnagy, 2024/07/25)

--- a/examples/step-11/step-11.cc
+++ b/examples/step-11/step-11.cc
@@ -81,10 +81,10 @@ namespace Step11
     void solve();
     void write_high_order_mesh(const unsigned cycle);
 
-    Triangulation<dim> triangulation;
-    const FE_Q<dim>    fe;
-    DoFHandler<dim>    dof_handler;
-    MappingQ<dim>      mapping;
+    Triangulation<dim>  triangulation;
+    const FE_Q<dim>     fe;
+    DoFHandler<dim>     dof_handler;
+    const MappingQ<dim> mapping;
 
     SparsityPattern           sparsity_pattern;
     SparseMatrix<double>      system_matrix;

--- a/examples/step-16/step-16.cc
+++ b/examples/step-16/step-16.cc
@@ -373,7 +373,7 @@ namespace Step16
   template <int dim>
   void LaplaceProblem<dim>::assemble_system()
   {
-    MappingQ1<dim> mapping;
+    const MappingQ1<dim> mapping;
 
     auto cell_worker =
       [&](const typename DoFHandler<dim>::active_cell_iterator &cell,
@@ -425,8 +425,8 @@ namespace Step16
   template <int dim>
   void LaplaceProblem<dim>::assemble_multigrid()
   {
-    MappingQ1<dim>     mapping;
-    const unsigned int n_levels = triangulation.n_levels();
+    const MappingQ1<dim> mapping;
+    const unsigned int   n_levels = triangulation.n_levels();
 
     std::vector<AffineConstraints<double>> boundary_constraints(n_levels);
     for (unsigned int level = 0; level < n_levels; ++level)

--- a/examples/step-34/step-34.cc
+++ b/examples/step-34/step-34.cc
@@ -230,10 +230,10 @@ namespace Step34
     // finite element space. The order of the finite element space and of the
     // mapping can be selected in the constructor of the class.
 
-    Triangulation<dim - 1, dim> tria;
-    const FE_Q<dim - 1, dim>    fe;
-    DoFHandler<dim - 1, dim>    dof_handler;
-    MappingQ<dim - 1, dim>      mapping;
+    Triangulation<dim - 1, dim>  tria;
+    const FE_Q<dim - 1, dim>     fe;
+    DoFHandler<dim - 1, dim>     dof_handler;
+    const MappingQ<dim - 1, dim> mapping;
 
     // In BEM methods, the matrix that is generated is dense. Depending on the
     // size of the problem, the final system might be solved by direct LU

--- a/examples/step-37/step-37.cc
+++ b/examples/step-37/step-37.cc
@@ -688,7 +688,7 @@ namespace Step37
     const FE_Q<dim> fe;
     DoFHandler<dim> dof_handler;
 
-    MappingQ1<dim> mapping;
+    const MappingQ1<dim> mapping;
 
     AffineConstraints<double> constraints;
     using SystemMatrixType =

--- a/examples/step-38/step-38.cc
+++ b/examples/step-38/step-38.cc
@@ -111,10 +111,10 @@ namespace Step38
     void compute_error() const;
 
 
-    Triangulation<dim, spacedim> triangulation;
-    const FE_Q<dim, spacedim>    fe;
-    DoFHandler<dim, spacedim>    dof_handler;
-    MappingQ<dim, spacedim>      mapping;
+    Triangulation<dim, spacedim>  triangulation;
+    const FE_Q<dim, spacedim>     fe;
+    DoFHandler<dim, spacedim>     dof_handler;
+    const MappingQ<dim, spacedim> mapping;
 
     SparsityPattern      sparsity_pattern;
     SparseMatrix<double> system_matrix;

--- a/examples/step-44/step-44.cc
+++ b/examples/step-44/step-44.cc
@@ -3219,7 +3219,7 @@ namespace Step44
     Vector<double> soln(solution_n.size());
     for (unsigned int i = 0; i < soln.size(); ++i)
       soln(i) = solution_n(i);
-    MappingQEulerian<dim> q_mapping(degree, dof_handler, soln);
+    const MappingQEulerian<dim> q_mapping(degree, dof_handler, soln);
     data_out.build_patches(q_mapping, degree);
 
     std::ofstream output("solution-" + std::to_string(dim) + "d-" +

--- a/examples/step-45/step-45.cc
+++ b/examples/step-45/step-45.cc
@@ -103,7 +103,7 @@ namespace Step45
 
     ConditionalOStream pcout;
 
-    MappingQ<dim> mapping;
+    const MappingQ<dim> mapping;
   };
 
 

--- a/examples/step-47/step-47.cc
+++ b/examples/step-47/step-47.cc
@@ -161,7 +161,7 @@ namespace Step47
 
     Triangulation<dim> triangulation;
 
-    MappingQ<dim> mapping;
+    const MappingQ<dim> mapping;
 
     const FE_Q<dim>           fe;
     DoFHandler<dim>           dof_handler;

--- a/examples/step-48/step-48.cc
+++ b/examples/step-48/step-48.cc
@@ -309,7 +309,7 @@ namespace Step48
     const FE_Q<dim> fe;
     DoFHandler<dim> dof_handler;
 
-    MappingQ1<dim> mapping;
+    const MappingQ1<dim> mapping;
 
     AffineConstraints<double> constraints;
     IndexSet                  locally_relevant_dofs;

--- a/examples/step-59/step-59.cc
+++ b/examples/step-59/step-59.cc
@@ -926,7 +926,7 @@ namespace Step59
     const FE_DGQHermite<dim> fe;
     DoFHandler<dim>          dof_handler;
 
-    MappingQ1<dim> mapping;
+    const MappingQ1<dim> mapping;
 
     using SystemMatrixType = LaplaceOperator<dim, fe_degree, double>;
     SystemMatrixType system_matrix;

--- a/examples/step-6/step-6.cc
+++ b/examples/step-6/step-6.cc
@@ -474,7 +474,7 @@ void Step6<dim>::output_results(const unsigned int cycle) const
     std::ofstream         output("grid-" + std::to_string(cycle) + ".gnuplot");
     GridOutFlags::Gnuplot gnuplot_flags(false, 5);
     grid_out.set_flags(gnuplot_flags);
-    MappingQ<dim> mapping(3);
+    const MappingQ<dim> mapping(3);
     grid_out.write_gnuplot(triangulation, output, &mapping);
   }
 

--- a/examples/step-64/step-64.cc
+++ b/examples/step-64/step-64.cc
@@ -273,7 +273,7 @@ namespace Step64
     const DoFHandler<dim>           &dof_handler,
     const AffineConstraints<double> &constraints)
   {
-    MappingQ<dim> mapping(fe_degree);
+    const MappingQ<dim> mapping(fe_degree);
     typename Portable::MatrixFree<dim, double>::AdditionalData additional_data;
     additional_data.mapping_update_flags = update_values | update_gradients |
                                            update_JxW_values |

--- a/examples/step-65/step-65.cc
+++ b/examples/step-65/step-65.cc
@@ -610,7 +610,7 @@ namespace Step65
                 << std::endl
                 << std::endl;
 
-      MappingQ<dim> mapping(fe.degree + 1);
+      const MappingQ<dim> mapping(fe.degree + 1);
       setup_system(mapping);
       assemble_system(mapping);
       solve();

--- a/examples/step-67/step-67.cc
+++ b/examples/step-67/step-67.cc
@@ -1773,7 +1773,7 @@ namespace Euler_DG
 #endif
 
     const FESystem<dim> fe;
-    MappingQ<dim>       mapping;
+    const MappingQ<dim> mapping;
     DoFHandler<dim>     dof_handler;
 
     TimerOutput timer;

--- a/examples/step-68/step-68.cc
+++ b/examples/step-68/step-68.cc
@@ -231,7 +231,7 @@ namespace Step68
 
     DoFHandler<dim>                            fluid_dh;
     const FESystem<dim>                        fluid_fe;
-    MappingQ1<dim>                             mapping;
+    const MappingQ1<dim>                       mapping;
     LinearAlgebra::distributed::Vector<double> velocity_field;
 
     Functions::RayleighKotheVortex<dim> velocity;

--- a/examples/step-76/step-76.cc
+++ b/examples/step-76/step-76.cc
@@ -1203,7 +1203,7 @@ namespace Euler_DG
 #endif
 
     const FESystem<dim> fe;
-    MappingQ<dim>       mapping;
+    const MappingQ<dim> mapping;
     DoFHandler<dim>     dof_handler;
 
     TimerOutput timer;

--- a/examples/step-79/step-79.cc
+++ b/examples/step-79/step-79.cc
@@ -752,7 +752,7 @@ namespace SAND
     system_rhs    = 0;
 
 
-    MappingQ<dim>         mapping(1);
+    const MappingQ<dim>   mapping(1);
     const QGauss<dim>     quadrature_formula(fe.degree + 1);
     const QGauss<dim - 1> face_quadrature_formula(fe.degree + 1);
     FEValues<dim>         fe_values(mapping,
@@ -1300,7 +1300,7 @@ namespace SAND
     BlockVector<double> test_rhs;
     test_rhs.reinit(system_rhs);
 
-    MappingQ<dim>         mapping(1);
+    const MappingQ<dim>   mapping(1);
     const QGauss<dim>     quadrature_formula(fe.degree + 1);
     const QGauss<dim - 1> face_quadrature_formula(fe.degree + 1);
     FEValues<dim>         fe_values(mapping,
@@ -1626,7 +1626,7 @@ namespace SAND
     // Start with computing the objective function:
     double objective_function_merit = 0;
     {
-      MappingQ<dim>         mapping(1);
+      const MappingQ<dim>   mapping(1);
       const QGauss<dim>     quadrature_formula(fe.degree + 1);
       const QGauss<dim - 1> face_quadrature_formula(fe.degree + 1);
       FEValues<dim>         fe_values(mapping,

--- a/examples/step-87/step-87.cc
+++ b/examples/step-87/step-87.cc
@@ -161,8 +161,8 @@ namespace Step87
     constexpr unsigned int dim       = 2;
     constexpr unsigned int fe_degree = 3;
 
-    MappingQ1<dim>     mapping;
-    Triangulation<dim> tria;
+    const MappingQ1<dim> mapping;
+    Triangulation<dim>   tria;
     GridGenerator::subdivided_hyper_cube(tria, 7);
 
     const FE_Q<dim> fe(fe_degree);
@@ -299,7 +299,7 @@ namespace Step87
 
     pcout << "Running: example 1" << std::endl;
 
-    MappingQ1<dim>                mapping;
+    const MappingQ1<dim>          mapping;
     DistributedTriangulation<dim> tria(MPI_COMM_WORLD);
     GridGenerator::subdivided_hyper_cube(tria, 7);
 
@@ -466,7 +466,7 @@ namespace Step87
     pcout << "  - create system" << std::endl;
 
     const FE_Q<dim>               fe(fe_degree);
-    MappingQ1<dim>                mapping;
+    const MappingQ1<dim>          mapping;
     DistributedTriangulation<dim> tria(MPI_COMM_WORLD);
     GridGenerator::subdivided_hyper_cube(tria, 50);
 
@@ -736,9 +736,9 @@ namespace Step87
     GridGenerator::hyper_cube(tria_background);
     tria_background.refine_global(5);
 
-    MappingQ1<dim>      mapping_background;
-    const FESystem<dim> fe_background(FE_Q<dim>(degree), dim);
-    DoFHandler<dim>     dof_handler_background(tria_background);
+    const MappingQ1<dim> mapping_background;
+    const FESystem<dim>  fe_background(FE_Q<dim>(degree), dim);
+    DoFHandler<dim>      dof_handler_background(tria_background);
     dof_handler_background.distribute_dofs(fe_background);
 
     // and, similarly, for the immersed surface mesh.
@@ -758,8 +758,8 @@ namespace Step87
     // that is updated in every time step according to the nodal
     // displacements. Two types of finite elements are used to
     // represent scalar and vector-valued DoF values.
-    MappingQ<dim - 1, dim>      mapping_immersed_base(3);
-    MappingQCache<dim - 1, dim> mapping_immersed(3);
+    const MappingQ<dim - 1, dim> mapping_immersed_base(3);
+    MappingQCache<dim - 1, dim>  mapping_immersed(3);
     mapping_immersed.initialize(mapping_immersed_base, tria_immersed);
     const QGauss<dim - 1> quadrature_immersed(degree + 1);
 


### PR DESCRIPTION
This pull request addresses issue #17260 by making the `mapping` variables `const` in various example files.