### PR TITLE
Deprecate SmartPointer::clear().

### DIFF
--- a/doc/news/changes/minor/20240725Bangerth
+++ b/doc/news/changes/minor/20240725Bangerth
@@ -1,0 +1,7 @@
+Deprecated: SmartPointer is clearly documented as not owning the
+object it points to. Yet, SmartPointer::clear() deletes the object
+pointed to, thereby assuming that the SmartPointer object actually
+owns the object. This must surely be confusing. As a consequence the
+function is now deprecated.
+<br>
+(Wolfgang Bangerth, 2024/07/25)

--- a/include/deal.II/base/smartpointer.h
+++ b/include/deal.II/base/smartpointer.h
@@ -159,8 +159,16 @@ public:
   operator=(const SmartPointer<T, P> &tt);
 
   /**
-   * Delete the object pointed to and set the pointer to zero.
+   * Delete the object pointed to and set the pointer to nullptr. Note
+   * that unlike what the documentation of the class describes, *this
+   * function actually deletes the object pointed to*. That is, this
+   * function assumes a SmartPointer's ownership of the object pointed to.
+   *
+   * @deprecated This function is deprecated. It does not use the
+   * semantics we usually use for this class, and its use is surely
+   * going to be confusing.
    */
+  DEAL_II_DEPRECATED
   void
   clear();
 


### PR DESCRIPTION
Fixes #17393. The function's semantics are so bizarre that I did not even both to use `DEAL_II_DEPRECATED_EARLY`, but deprecate it outright. We don't use this function in the library itself, and I can only hope that we don't anywhere else either.