### PR TITLE
Deprecate step-52.

### DIFF
--- a/examples/step-52/doc/intro.dox
+++ b/examples/step-52/doc/intro.dox
@@ -15,10 +15,12 @@ step-26 but, since the purpose of this program is only to demonstrate using
 more advanced ways to interface with deal.II's time stepping algorithms, only
 solves a simple problem on a uniformly refined mesh.
 
-@note At the end of the day, time stepping is a problem that is only solved
-  efficiently if you use adaptive time step selection and error control.
-  This is implemented in many external libraries, but not in deal.II itself.
-  You may want to consider looking at step-86 for a worked out example.
+@note At the end of the day, time stepping is a problem that is only
+  solved efficiently if you use adaptive time step selection and error
+  control.  This is implemented in many external libraries, but not in
+  deal.II itself.  You may want to consider looking at step-86 for a
+  worked out example. In the meantime, this program is deprecated and
+  will be removed after the deal.II 9.6 release.
 
 
 


### PR DESCRIPTION
See #17386. We should try to still get this into the 9.6 release if possible.