### PR TITLE
[9.6] Fix p2_adaptive.prm file for step-42

### DIFF
--- a/examples/step-42/p2_adaptive.prm
+++ b/examples/step-42/p2_adaptive.prm
@@ -1,31 +1,6 @@
-# Listing of Parameters
-# ---------------------
-
-# polynomial degree of the FE_Q finite element space, typically 1 or 2
-
 set polynomial degree = 2
-
-# number of initial global refinements before the first computation
-
 set number of initial refinements = 2
-
-# number of adaptive cycles to run
-
 set number of cycles = 11
-
-# refinement strategy for each cycle:
-# global: one global refinement
-# percentage: fixed percentage gets refined using kelly
-# fix dofs: tries to achieve 2^initial_refinement*300 dofs after cycle 1 (only
-# use 2 cycles!). Changes the coarse mesh!
-
 set refinement strategy = percentage
-
-# obstacle file to read, leave empty to use a sphere or 'obstacle_file.pbm'
-
-set obstacle filename = 
-
-# directory to put output files (graphical output and benchmark statistics,
-# leave empty to put into current directory
-
-set output directory = p2adaptive
+set obstacle = sphere
+set output directory = p2_adaptive


### PR DESCRIPTION
The p2_adaptive.prm file for step-42 contained the following error:
"obstacle filename" should have been just named "obstacle"

Furthermore, the example does not interpret the empty variable name as a sphere and sphere needs to be written explicitely. Finally, this prm file was written in a different fashion than the other prm files. 
I have made things uniform and fixed the parameter file input.

This PR should be cherry picked for 9.6 release.

