### PR TITLE
Remove extra hyphen from CMakeList of step-89

### DIFF
--- a/examples/step-89/CMakeLists.txt
+++ b/examples/step-89/CMakeLists.txt
@@ -52,4 +52,4 @@ deal_ii_initialize_cached_variables()
 set(CLEAN_UP_FILES *.log *.gmv *.gnuplot *.gpl *.eps *.pov *.ucd *.d2 *.vtu *.pvtu)
 project(${TARGET})
 deal_ii_invoke_autopilot()
--
+


### PR DESCRIPTION
The CMakeList file of step-89 contains an extra hyphen which crashes the call to cmake.

Easy fix...
