### PR TITLE
Fix pointer traversal range of PETSc vectors on each process

### DIFF
--- a/doc/news/changes/minor/20240801Shi
+++ b/doc/news/changes/minor/20240801Shi
@@ -3,4 +3,5 @@ and VectorBase::lp_norm() in PETScWrappers namespace to proper handle
 distributed PETSc vectors. Now pointers obtained via VecGetArrayRead()
 iterate only over locally_owned_size(), and results are correctly
 aggregated across processes.
+<br>
 (Qingyuan Shi, 2024/08/01)

--- a/doc/news/changes/minor/20240801Shi
+++ b/doc/news/changes/minor/20240801Shi
@@ -1,0 +1,6 @@
+Fix: Corrected pointer iteration range in VectorBase::mean_value()
+and VectorBase::lp_norm() in PETScWrappers namespace to proper handle
+distributed PETSc vectors. Now pointers obtained via VecGetArrayRead()
+iterate only over locally_owned_size(), and results are correctly
+aggregated across processes.
+(Qingyuan Shi, 2024/08/01)

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -636,7 +636,7 @@ namespace PETScWrappers
       // allowing pipelined commands to be
       // executed in parallel
       const PetscScalar *ptr  = start_ptr;
-      const PetscScalar *eptr = ptr + (size() / 4) * 4;
+      const PetscScalar *eptr = ptr + (locally_owned_size() / 4) * 4;
       while (ptr != eptr)
         {
           sum0 += *ptr++;
@@ -645,10 +645,12 @@ namespace PETScWrappers
           sum3 += *ptr++;
         }
       // add up remaining elements
-      while (ptr != start_ptr + size())
+      while (ptr != start_ptr + locally_owned_size())
         sum0 += *ptr++;
 
-      mean = (sum0 + sum1 + sum2 + sum3) / static_cast<PetscReal>(size());
+      mean =
+        Utilities::MPI::sum(sum0 + sum1 + sum2 + sum3, get_mpi_communicator()) /
+        static_cast<PetscReal>(size());
     }
 
     // restore the representation of the
@@ -703,7 +705,7 @@ namespace PETScWrappers
       // allowing pipelined commands to be
       // executed in parallel
       const PetscScalar *ptr  = start_ptr;
-      const PetscScalar *eptr = ptr + (size() / 4) * 4;
+      const PetscScalar *eptr = ptr + (locally_owned_size() / 4) * 4;
       while (ptr != eptr)
         {
           sum0 += std::pow(numbers::NumberTraits<value_type>::abs(*ptr++), p);
@@ -712,10 +714,12 @@ namespace PETScWrappers
           sum3 += std::pow(numbers::NumberTraits<value_type>::abs(*ptr++), p);
         }
       // add up remaining elements
-      while (ptr != start_ptr + size())
+      while (ptr != start_ptr + locally_owned_size())
         sum0 += std::pow(numbers::NumberTraits<value_type>::abs(*ptr++), p);
 
-      norm = std::pow(sum0 + sum1 + sum2 + sum3, 1. / p);
+      norm = std::pow(Utilities::MPI::sum(sum0 + sum1 + sum2 + sum3,
+                                          get_mpi_communicator()),
+                      1. / p);
     }
 
     // restore the representation of the


### PR DESCRIPTION
To fix #17405.

This is my first (and tiny) PR for deal.II, so please correct me if I've missed anything.