### PR TITLE
Add move operations to SmartPointer.

### DIFF
--- a/include/deal.II/base/smartpointer.h
+++ b/include/deal.II/base/smartpointer.h
@@ -305,8 +305,13 @@ inline SmartPointer<T, P>::SmartPointer(const SmartPointer<T, Q> &tt)
   , id(tt.id)
   , pointed_to_object_is_alive(false)
 {
-  if (tt.pointed_to_object_is_alive && t != nullptr)
-    t->subscribe(&pointed_to_object_is_alive, id);
+  if (tt != nullptr)
+    {
+      Assert(tt.pointed_to_object_is_alive,
+             ExcMessage("You can't copy a smart pointer object that "
+                        "is pointing to an object that is no longer alive."));
+      t->subscribe(&pointed_to_object_is_alive, id);
+    }
 }
 
 
@@ -317,8 +322,13 @@ inline SmartPointer<T, P>::SmartPointer(const SmartPointer<T, P> &tt)
   , id(tt.id)
   , pointed_to_object_is_alive(false)
 {
-  if (tt.pointed_to_object_is_alive && t != nullptr)
-    t->subscribe(&pointed_to_object_is_alive, id);
+  if (tt != nullptr)
+    {
+      Assert(tt.pointed_to_object_is_alive,
+             ExcMessage("You can't copy a smart pointer object that "
+                        "is pointing to an object that is no longer alive."));
+      t->subscribe(&pointed_to_object_is_alive, id);
+    }
 }
 
 
@@ -419,8 +429,13 @@ SmartPointer<T, P>::operator=(const SmartPointer<T, Q> &tt)
 
   // Then reset to the new object, and subscribe to it
   t = (tt != nullptr ? tt.get() : nullptr);
-  if (tt.pointed_to_object_is_alive && tt != nullptr)
-    t->subscribe(&pointed_to_object_is_alive, id);
+  if (tt != nullptr)
+    {
+      Assert(tt.pointed_to_object_is_alive,
+             ExcMessage("You can't copy a smart pointer object that "
+                        "is pointing to an object that is no longer alive."));
+      t->subscribe(&pointed_to_object_is_alive, id);
+    }
   return *this;
 }
 
@@ -442,9 +457,13 @@ SmartPointer<T, P>::operator=(const SmartPointer<T, P> &tt)
 
   // Then reset to the new object, and subscribe to it
   t = (tt != nullptr ? tt.get() : nullptr);
-  if (tt.pointed_to_object_is_alive && tt != nullptr)
-    t->subscribe(&pointed_to_object_is_alive, id);
-
+  if (tt != nullptr)
+    {
+      Assert(tt.pointed_to_object_is_alive,
+             ExcMessage("You can't copy a smart pointer object that "
+                        "is pointing to an object that is no longer alive."));
+      t->subscribe(&pointed_to_object_is_alive, id);
+    }
   return *this;
 }
 

--- a/include/deal.II/base/smartpointer.h
+++ b/include/deal.II/base/smartpointer.h
@@ -335,7 +335,18 @@ inline SmartPointer<T, P>::SmartPointer(SmartPointer<T, P> &&tt) noexcept
              ExcMessage("You can't move a smart pointer object that "
                         "is pointing to an object that is no longer alive."));
 
-      t->subscribe(&pointed_to_object_is_alive, id);
+      try
+        {
+          t->subscribe(&pointed_to_object_is_alive, id);
+        }
+      catch (...)
+        {
+          Assert(false,
+                 ExcMessage(
+                   "Calling subscribe() failed with an exception, but we "
+                   "are in a function that cannot throw exceptions. "
+                   "Aborting the program here."));
+        }
 
       // Release the rhs object as if we had moved all members away from
       // it directly:
@@ -452,7 +463,7 @@ SmartPointer<T, P>::operator=(SmartPointer<T, P> &&tt) noexcept
   else if (&tt != this)
     {
       // Let us unsubscribe from the current object
-      if (pointed_to_object_is_alive)
+      if (t != nullptr && pointed_to_object_is_alive)
         t->unsubscribe(&pointed_to_object_is_alive, id);
 
       // Then reset to the new object, and subscribe to it:
@@ -460,7 +471,18 @@ SmartPointer<T, P>::operator=(SmartPointer<T, P> &&tt) noexcept
              ExcMessage("You can't move a smart pointer object that "
                         "is pointing to an object that is no longer alive."));
       t = tt.get();
-      t->subscribe(&pointed_to_object_is_alive, id);
+      try
+        {
+          t->subscribe(&pointed_to_object_is_alive, id);
+        }
+      catch (...)
+        {
+          Assert(false,
+                 ExcMessage(
+                   "Calling subscribe() failed with an exception, but we "
+                   "are in a function that cannot throw exceptions. "
+                   "Aborting the program here."));
+        }
 
       // Finally release the rhs object since we moved its contents
       tt = nullptr;

--- a/include/deal.II/lac/sparse_matrix.templates.h
+++ b/include/deal.II/lac/sparse_matrix.templates.h
@@ -73,7 +73,7 @@ SparseMatrix<number>::SparseMatrix(const SparseMatrix &m)
 template <typename number>
 SparseMatrix<number>::SparseMatrix(SparseMatrix<number> &&m) noexcept
   : Subscriptor(std::move(m))
-  , cols(m.cols)
+  , cols(std::move(m.cols))
   , val(std::move(m.val))
   , max_len(m.max_len)
 {


### PR DESCRIPTION
Obey the rule of 5.

This also required me to use `std::move()` in one place where the `tidy` check otherwise complains (rightfully so).