### PR TITLE
PETScWrappers: don't call deprecated viewer functions.

### DIFF
--- a/source/lac/petsc_matrix_base.cc
+++ b/source/lac/petsc_matrix_base.cc
@@ -726,11 +726,13 @@ namespace PETScWrappers
 
     // Set options
     PetscErrorCode ierr =
-      PetscViewerSetFormat(PETSC_VIEWER_STDOUT_(comm), format);
+      PetscViewerPushFormat(PETSC_VIEWER_STDOUT_(comm), format);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
     // Write to screen
     ierr = MatView(matrix, PETSC_VIEWER_STDOUT_(comm));
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
+    ierr = PetscViewerPopFormat(PETSC_VIEWER_STDOUT_(comm));
     AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -956,11 +956,13 @@ namespace PETScWrappers
 
     // Set options
     PetscErrorCode ierr =
-      PetscViewerSetFormat(PETSC_VIEWER_STDOUT_(comm), format);
+      PetscViewerPushFormat(PETSC_VIEWER_STDOUT_(comm), format);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
     // Write to screen
     ierr = VecView(vector, PETSC_VIEWER_STDOUT_(comm));
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
+    ierr = PetscViewerPopFormat(PETSC_VIEWER_STDOUT_(comm));
     AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 


### PR DESCRIPTION
This was deprecated in PETSc 3.7 - since we require at least that version we can use the new function.