### PR TITLE
[9.6] patch bundled boost: nvcc and immintrin.h (PR #17420)

### DIFF
--- a/bundled/boost-1.84.0/include/boost/multiprecision/cpp_int/intel_intrinsics.hpp
+++ b/bundled/boost-1.84.0/include/boost/multiprecision/cpp_int/intel_intrinsics.hpp
@@ -50,6 +50,11 @@
 #undef BOOST_MP_HAS_IMMINTRIN_H
 #endif
 
+#if defined(__CUDACC__)
+// @tjhei: nvcc, at least with CUDA 12.5 is not happy with these intrinsics
+#undef BOOST_MP_HAS_IMMINTRIN_H
+#endif
+
 
 //
 // If the compiler supports the intrinsics used by GCC internally


### PR DESCRIPTION
boost compiler detection macro logic about immintrin.h seems to be incorrect when using nvcc leading to the compiler error
```
/usr/lib/gcc/x86_64-linux-gnu/13/include/amxtileintrin.h(42): error:
identifier "__builtin_ia32_ldtilecfg" is undefined
    __builtin_ia32_ldtilecfg (__config);
```

Work around this by patching at least the bundled boost.

closes #17401