### PR TITLE
Use aliases for TpetraTypes::[Dual]View[Unmanaged]

### DIFF
--- a/examples/step-86/step-86.cc
+++ b/examples/step-86/step-86.cc
@@ -591,7 +591,7 @@ namespace Step86
     // the constrained dofs corresponding to hanging nodes (i.e., those for
     // which the lines of the `current_constraints` contain at least one other
     // entry), and to the difference between the input vector and the actual
-    // solution on those constraints that correspond to boundary conditions. 
+    // solution on those constraints that correspond to boundary conditions.
     for (const auto &c : current_constraints.get_lines())
       if (locally_owned_dofs.is_element(c.index))
         {

--- a/include/deal.II/lac/trilinos_tpetra_precondition.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_precondition.templates.h
@@ -151,12 +151,18 @@ namespace LinearAlgebra
 
       // 1. Make host view with underlying dealii::Vector data.
       //    (This is always a n x 1 matrix since multivector expects that.)
-      TpetraTypes::HostViewTypeUnmanaged<Number> host_src(src.data(),
-                                                          src.size(),
-                                                          1);
-      TpetraTypes::HostViewTypeUnmanaged<Number> host_dst(dst.data(),
-                                                          dst.size(),
-                                                          1);
+
+      // Tpetra uses Kokkos::complex<> internally for std::complex<>
+      using value_type = typename TpetraTypes::HostViewType<Number>::value_type;
+      static_assert((numbers::NumberTraits<Number>::is_complex &&
+                     sizeof(value_type) == sizeof(Number)) ||
+                    (!numbers::NumberTraits<Number>::is_complex &&
+                     std::is_same_v<value_type, Number>));
+
+      TpetraTypes::HostViewType<Number> host_src(
+        reinterpret_cast<value_type *>(src.data()), src.size(), 1);
+      TpetraTypes::HostViewType<Number> host_dst(
+        reinterpret_cast<value_type *>(dst.data()), dst.size(), 1);
 
       // 2. Create device mirror (if Device == Host, no alloc )
       auto dev_src = Kokkos::create_mirror_view_and_copy(
@@ -166,10 +172,10 @@ namespace LinearAlgebra
         typename MemorySpace::kokkos_space::execution_space(), host_dst);
 
       // 3. Create dual views from the previous ones
-      TpetraTypes::DualViewTypeUnmanaged<Number, MemorySpace> dual_src(
-        dev_src, host_src);
-      TpetraTypes::DualViewTypeUnmanaged<Number, MemorySpace> dual_dst(
-        dev_dst, host_dst);
+      TpetraTypes::DualViewType<Number, MemorySpace> dual_src(dev_src,
+                                                              host_src);
+      TpetraTypes::DualViewType<Number, MemorySpace> dual_dst(dev_dst,
+                                                              host_dst);
 
       // 4. Create Tpetra Vector from
       TpetraTypes::VectorType<Number, MemorySpace> tpetra_dst(
@@ -201,12 +207,18 @@ namespace LinearAlgebra
 
       // 1. Make host view with underlying dealii::Vector data.
       //    (This is always a n x 1 matrix since multivector expects that.)
-      TpetraTypes::HostViewTypeUnmanaged<Number> host_src(src.data(),
-                                                          src.size(),
-                                                          1);
-      TpetraTypes::HostViewTypeUnmanaged<Number> host_dst(dst.data(),
-                                                          dst.size(),
-                                                          1);
+
+      // Tpetra uses Kokkos::complex<> internally for std::complex<>
+      using value_type = typename TpetraTypes::HostViewType<Number>::value_type;
+      static_assert((numbers::NumberTraits<Number>::is_complex &&
+                     sizeof(value_type) == sizeof(Number)) ||
+                    (!numbers::NumberTraits<Number>::is_complex &&
+                     std::is_same_v<value_type, Number>));
+
+      TpetraTypes::HostViewType<Number> host_src(
+        reinterpret_cast<value_type *>(src.data()), src.size(), 1);
+      TpetraTypes::HostViewType<Number> host_dst(
+        reinterpret_cast<value_type *>(dst.data()), dst.size(), 1);
 
       // 2. Create device mirror (if Device == Host, no alloc )
       auto dev_src = Kokkos::create_mirror_view_and_copy(
@@ -216,10 +228,10 @@ namespace LinearAlgebra
         typename MemorySpace::kokkos_space::execution_space(), host_dst);
 
       // 3. Create dual views from the previous ones
-      TpetraTypes::DualViewTypeUnmanaged<Number, MemorySpace> dual_src(
-        dev_src, host_src);
-      TpetraTypes::DualViewTypeUnmanaged<Number, MemorySpace> dual_dst(
-        dev_dst, host_dst);
+      TpetraTypes::DualViewType<Number, MemorySpace> dual_src(dev_src,
+                                                              host_src);
+      TpetraTypes::DualViewType<Number, MemorySpace> dual_dst(dev_dst,
+                                                              host_dst);
 
       // 4. Create Tpetra Vector from
       TpetraTypes::VectorType<Number, MemorySpace> tpetra_dst(

--- a/include/deal.II/lac/trilinos_tpetra_types.h
+++ b/include/deal.II/lac/trilinos_tpetra_types.h
@@ -145,17 +145,6 @@ namespace LinearAlgebra
       using RowMatrixType =
         Tpetra::RowMatrix<Number, LO, GO, NodeType<MemorySpace>>;
 
-
-      /**
-       * @brief Typedef for the Kokkos::View type.
-       * This is needed for shallow copies of deal.II LA structures
-       * to Trilinos LA structures.
-       *
-       */
-      template <typename Number>
-      using HostViewType =
-        typename VectorType<Number, dealii::MemorySpace::Host>::host_view_type;
-
       /**
        * @brief Typedef for the Kokkos::DualView type.
        * This is needed for shallow copies of deal.II LA structures
@@ -165,6 +154,15 @@ namespace LinearAlgebra
       using DualViewType =
         typename VectorType<Number, MemorySpace>::dual_view_type;
 
+      /**
+       * @brief Typedef for the Kokkos::View type.
+       * This is needed for shallow copies of deal.II LA structures
+       * to Trilinos LA structures.
+       *
+       */
+      template <typename Number>
+      using HostViewType =
+        typename DualViewType<Number, dealii::MemorySpace::Host>::t_host;
 
 #  ifdef DEAL_II_TRILINOS_WITH_IFPACK2
       /**

--- a/include/deal.II/lac/trilinos_tpetra_types.h
+++ b/include/deal.II/lac/trilinos_tpetra_types.h
@@ -21,6 +21,8 @@
 
 #ifdef DEAL_II_TRILINOS_WITH_TPETRA
 
+#  include <deal.II/base/memory_space.h>
+
 #  include <Kokkos_DualView.hpp>
 #  include <Tpetra_Details_DefaultTypes.hpp>
 
@@ -145,36 +147,23 @@ namespace LinearAlgebra
 
 
       /**
-       * @brief Typedef for the Kokkos::View type of unmanaged host memory.
-       *
-       * Unmanaged means that the view is not allocating data itself, but only
-       * uses an external pointer. Consequently, the memory is not freed upon
-       * destruction of the view.
+       * @brief Typedef for the Kokkos::View type.
        * This is needed for shallow copies of deal.II LA structures
        * to Trilinos LA structures.
        *
        */
       template <typename Number>
-      using HostViewTypeUnmanaged = Kokkos::View<Number **,
-                                                 Kokkos::LayoutLeft,
-                                                 Kokkos::HostSpace,
-                                                 Kokkos::MemoryUnmanaged>;
+      using HostViewType =
+        typename VectorType<Number, dealii::MemorySpace::Host>::host_view_type;
 
       /**
-       * @brief Typedef for the Kokkos::View type of unmanaged memory.
-       *
-       * Unmanaged means that the view is not allocating data itself, but only
-       * uses an external pointer. Consequently, the memory is not freed upon
-       * destruction of the view.
+       * @brief Typedef for the Kokkos::DualView type.
        * This is needed for shallow copies of deal.II LA structures
        * to Trilinos LA structures.
        */
       template <typename Number, typename MemorySpace>
-      using DualViewTypeUnmanaged =
-        Kokkos::DualView<Number **,
-                         Kokkos::LayoutLeft,
-                         typename MemorySpace::kokkos_space::execution_space,
-                         Kokkos::MemoryUnmanaged>;
+      using DualViewType =
+        typename VectorType<Number, MemorySpace>::dual_view_type;
 
 
 #  ifdef DEAL_II_TRILINOS_WITH_IFPACK2


### PR DESCRIPTION
Fixes #17434. We don't actually need the `Kokkos::MemoryUnmanaged` trait since a `Kokkos::View` is unmanaged if and only if it was instructed from a pointer.