### PR TITLE
 GitHub Cuda CI: Remove large packages

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -326,7 +326,6 @@ jobs:
         dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
         df -h
         echo "Removing large packages"
-        sudo apt-get remove -y '^nsight-compute-.*'
         sudo apt-get remove -y '^dotnet-.*'
         sudo apt-get remove -y '^llvm-.*'
         sudo apt-get remove -y 'php.*'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -326,7 +326,7 @@ jobs:
         dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
         df -h
         echo "Removing large packages"
-        sudo apt-get remove -y '^ghc-8.*'
+        sudo apt-get remove -y '^nsight-compute-.*'
         sudo apt-get remove -y '^dotnet-.*'
         sudo apt-get remove -y '^llvm-.*'
         sudo apt-get remove -y 'php.*'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -315,6 +315,29 @@ jobs:
             numdiff \
             openmpi-bin \
             libboost-all-dev
+    # https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh
+    - name: remove unused large packages
+      run : |
+        echo "=============================================================================="
+        echo "Freeing up disk space on CI system"
+        echo "=============================================================================="
+
+        echo "Listing 100 largest packages"
+        dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
+        df -h
+        echo "Removing large packages"
+        sudo apt-get remove -y '^ghc-8.*'
+        sudo apt-get remove -y '^dotnet-.*'
+        sudo apt-get remove -y '^llvm-.*'
+        sudo apt-get remove -y 'php.*'
+        sudo apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel
+        sudo apt-get autoremove -y
+        sudo apt-get clean
+        df -h
+        echo "Removing large directories"
+        # deleting 15GB
+        rm -rf /usr/share/dotnet/
+        df -h
     - uses: lukka/get-cmake@v3.27.9
     - name: info
       run: |


### PR DESCRIPTION
This prevents the CUDA nvcc CI from running out-of-space.