### PR TITLE
Add missing assertions.

### DIFF
--- a/source/fe/fe_values_views.cc
+++ b/source/fe/fe_values_views.cc
@@ -367,6 +367,7 @@ namespace FEValuesViews
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
+    AssertDimension(values.size(), fe_values->n_quadrature_points);
 
     // get function values of dofs on this cell and call internal worker
     // function
@@ -396,6 +397,7 @@ namespace FEValuesViews
     Assert(fe_values->present_cell.is_initialized(),
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(dof_values.size(), fe_values->dofs_per_cell);
+    AssertDimension(values.size(), fe_values->n_quadrature_points);
 
     internal::do_function_values<dim, spacedim>(
       make_const_array_view(dof_values),
@@ -420,6 +422,7 @@ namespace FEValuesViews
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(fe_function.size(),
                     fe_values->present_cell.n_dofs_for_dof_handler());
+    AssertDimension(gradients.size(), fe_values->n_quadrature_points);
 
     // get function values of dofs on this cell
     dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
@@ -448,6 +451,7 @@ namespace FEValuesViews
     Assert(fe_values->present_cell.is_initialized(),
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(dof_values.size(), fe_values->dofs_per_cell);
+    AssertDimension(gradients.size(), fe_values->n_quadrature_points);
 
     internal::do_function_derivatives<1, dim, spacedim>(
       make_const_array_view(dof_values),
@@ -472,6 +476,7 @@ namespace FEValuesViews
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(fe_function.size(),
                     fe_values->present_cell.n_dofs_for_dof_handler());
+    AssertDimension(hessians.size(), fe_values->n_quadrature_points);
 
     // get function values of dofs on this cell
     dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
@@ -500,6 +505,7 @@ namespace FEValuesViews
     Assert(fe_values->present_cell.is_initialized(),
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(dof_values.size(), fe_values->dofs_per_cell);
+    AssertDimension(hessians.size(), fe_values->n_quadrature_points);
 
     internal::do_function_derivatives<2, dim, spacedim>(
       make_const_array_view(dof_values),
@@ -524,6 +530,7 @@ namespace FEValuesViews
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(fe_function.size(),
                     fe_values->present_cell.n_dofs_for_dof_handler());
+    AssertDimension(laplacians.size(), fe_values->n_quadrature_points);
 
     // get function values of dofs on this cell
     dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
@@ -552,6 +559,7 @@ namespace FEValuesViews
     Assert(fe_values->present_cell.is_initialized(),
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(dof_values.size(), fe_values->dofs_per_cell);
+    AssertDimension(laplacians.size(), fe_values->n_quadrature_points);
 
     internal::do_function_laplacians<dim, spacedim>(
       make_const_array_view(dof_values),
@@ -577,6 +585,7 @@ namespace FEValuesViews
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(fe_function.size(),
                     fe_values->present_cell.n_dofs_for_dof_handler());
+    AssertDimension(third_derivatives.size(), fe_values->n_quadrature_points);
 
     // get function values of dofs on this cell
     dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
@@ -606,6 +615,7 @@ namespace FEValuesViews
     Assert(fe_values->present_cell.is_initialized(),
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(dof_values.size(), fe_values->dofs_per_cell);
+    AssertDimension(third_derivatives.size(), fe_values->n_quadrature_points);
 
     internal::do_function_derivatives<3, dim, spacedim>(
       make_const_array_view(dof_values),
@@ -628,6 +638,7 @@ namespace FEValuesViews
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
+    AssertDimension(values.size(), fe_values->n_quadrature_points);
 
     // get function values of dofs on this cell
     dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
@@ -656,6 +667,7 @@ namespace FEValuesViews
     Assert(fe_values->present_cell.is_initialized(),
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(dof_values.size(), fe_values->dofs_per_cell);
+    AssertDimension(values.size(), fe_values->n_quadrature_points);
 
     internal::do_function_values<dim, spacedim>(
       make_const_array_view(dof_values),
@@ -680,6 +692,7 @@ namespace FEValuesViews
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(fe_function.size(),
                     fe_values->present_cell.n_dofs_for_dof_handler());
+    AssertDimension(gradients.size(), fe_values->n_quadrature_points);
 
     // get function values of dofs on this cell
     dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
@@ -708,6 +721,7 @@ namespace FEValuesViews
     Assert(fe_values->present_cell.is_initialized(),
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(dof_values.size(), fe_values->dofs_per_cell);
+    AssertDimension(gradients.size(), fe_values->n_quadrature_points);
 
     internal::do_function_derivatives<1, dim, spacedim>(
       make_const_array_view(dof_values),
@@ -733,6 +747,7 @@ namespace FEValuesViews
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(fe_function.size(),
                     fe_values->present_cell.n_dofs_for_dof_handler());
+    AssertDimension(symmetric_gradients.size(), fe_values->n_quadrature_points);
 
     // get function values of dofs on this cell
     dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
@@ -762,6 +777,7 @@ namespace FEValuesViews
     Assert(fe_values->present_cell.is_initialized(),
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(dof_values.size(), fe_values->dofs_per_cell);
+    AssertDimension(symmetric_gradients.size(), fe_values->n_quadrature_points);
 
     internal::do_function_symmetric_gradients<dim, spacedim>(
       make_const_array_view(dof_values),
@@ -786,6 +802,7 @@ namespace FEValuesViews
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(fe_function.size(),
                     fe_values->present_cell.n_dofs_for_dof_handler());
+    AssertDimension(divergences.size(), fe_values->n_quadrature_points);
 
     // get function values of dofs
     // on this cell
@@ -815,6 +832,7 @@ namespace FEValuesViews
     Assert(fe_values->present_cell.is_initialized(),
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(dof_values.size(), fe_values->dofs_per_cell);
+    AssertDimension(divergences.size(), fe_values->n_quadrature_points);
 
     internal::do_function_divergences<dim, spacedim>(
       make_const_array_view(dof_values),
@@ -839,6 +857,7 @@ namespace FEValuesViews
            ExcMessage("FEValues object is not reinited to any cell"));
     AssertDimension(fe_function.size(),
                     fe_values->present_cell.n_dofs_for_dof_handler());
+    AssertDimension(curls.size(), fe_values->n_quadrature_points);
 
     // get function values of dofs on this cell
     dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
@@ -867,6 +886,7 @@ namespace FEValuesViews
     Assert(fe_values->present_cell.is_initialized(),
            ExcMessage("FEValues object is not reinited to any cell"));
     AssertDimension(dof_values.size(), fe_values->dofs_per_cell);
+    AssertDimension(curls.size(), fe_values->n_quadrature_points);
 
     internal::do_function_curls<dim, spacedim>(
       make_const_array_view(dof_values),
@@ -891,6 +911,7 @@ namespace FEValuesViews
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(fe_function.size(),
                     fe_values->present_cell.n_dofs_for_dof_handler());
+    AssertDimension(hessians.size(), fe_values->n_quadrature_points);
 
     // get function values of dofs on this cell
     dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
@@ -919,6 +940,7 @@ namespace FEValuesViews
     Assert(fe_values->present_cell.is_initialized(),
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(dof_values.size(), fe_values->dofs_per_cell);
+    AssertDimension(hessians.size(), fe_values->n_quadrature_points);
 
     internal::do_function_derivatives<2, dim, spacedim>(
       make_const_array_view(dof_values),
@@ -948,6 +970,7 @@ namespace FEValuesViews
       fe_function.size() == fe_values->present_cell.n_dofs_for_dof_handler(),
       ExcDimensionMismatch(fe_function.size(),
                            fe_values->present_cell.n_dofs_for_dof_handler()));
+    AssertDimension(laplacians.size(), fe_values->n_quadrature_points);
 
     // get function values of dofs on this cell
     dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
@@ -979,6 +1002,7 @@ namespace FEValuesViews
     Assert(fe_values->present_cell.is_initialized(),
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(dof_values.size(), fe_values->dofs_per_cell);
+    AssertDimension(laplacians.size(), fe_values->n_quadrature_points);
 
     internal::do_function_laplacians<dim, spacedim>(
       make_const_array_view(dof_values),
@@ -1004,6 +1028,7 @@ namespace FEValuesViews
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(fe_function.size(),
                     fe_values->present_cell.n_dofs_for_dof_handler());
+    AssertDimension(third_derivatives.size(), fe_values->n_quadrature_points);
 
     // get function values of dofs on this cell
     dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
@@ -1033,6 +1058,7 @@ namespace FEValuesViews
     Assert(fe_values->present_cell.is_initialized(),
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(dof_values.size(), fe_values->dofs_per_cell);
+    AssertDimension(third_derivatives.size(), fe_values->n_quadrature_points);
 
     internal::do_function_derivatives<3, dim, spacedim>(
       make_const_array_view(dof_values),
@@ -1055,6 +1081,7 @@ namespace FEValuesViews
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
+    AssertDimension(values.size(), fe_values->n_quadrature_points);
 
     // get function values of dofs on this cell
     dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
@@ -1083,6 +1110,7 @@ namespace FEValuesViews
     Assert(fe_values->present_cell.is_initialized(),
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(dof_values.size(), fe_values->dofs_per_cell);
+    AssertDimension(values.size(), fe_values->n_quadrature_points);
 
     internal::do_function_values<dim, spacedim>(
       make_const_array_view(dof_values),
@@ -1107,6 +1135,7 @@ namespace FEValuesViews
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(fe_function.size(),
                     fe_values->present_cell.n_dofs_for_dof_handler());
+    AssertDimension(divergences.size(), fe_values->n_quadrature_points);
 
     // get function values of dofs
     // on this cell
@@ -1137,6 +1166,7 @@ namespace FEValuesViews
     Assert(fe_values->present_cell.is_initialized(),
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(dof_values.size(), fe_values->dofs_per_cell);
+    AssertDimension(divergences.size(), fe_values->n_quadrature_points);
 
     internal::do_function_divergences<dim, spacedim>(
       make_const_array_view(dof_values),
@@ -1159,6 +1189,7 @@ namespace FEValuesViews
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
+    AssertDimension(values.size(), fe_values->n_quadrature_points);
 
     // get function values of dofs on this cell
     dealii::Vector<Number> dof_values(fe_values->dofs_per_cell);
@@ -1187,6 +1218,7 @@ namespace FEValuesViews
     Assert(fe_values->present_cell.is_initialized(),
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(dof_values.size(), fe_values->dofs_per_cell);
+    AssertDimension(values.size(), fe_values->n_quadrature_points);
 
     internal::do_function_values<dim, spacedim>(
       make_const_array_view(dof_values),
@@ -1211,6 +1243,7 @@ namespace FEValuesViews
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(fe_function.size(),
                     fe_values->present_cell.n_dofs_for_dof_handler());
+    AssertDimension(divergences.size(), fe_values->n_quadrature_points);
 
     // get function values of dofs
     // on this cell
@@ -1240,6 +1273,7 @@ namespace FEValuesViews
     Assert(fe_values->present_cell.is_initialized(),
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(dof_values.size(), fe_values->dofs_per_cell);
+    AssertDimension(divergences.size(), fe_values->n_quadrature_points);
 
     internal::do_function_divergences<dim, spacedim>(
       make_const_array_view(dof_values),
@@ -1264,6 +1298,7 @@ namespace FEValuesViews
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(fe_function.size(),
                     fe_values->present_cell.n_dofs_for_dof_handler());
+    AssertDimension(gradients.size(), fe_values->n_quadrature_points);
 
     // get function values of dofs
     // on this cell
@@ -1293,6 +1328,7 @@ namespace FEValuesViews
     Assert(fe_values->present_cell.is_initialized(),
            (typename FEValuesBase<dim, spacedim>::ExcNotReinited()));
     AssertDimension(dof_values.size(), fe_values->dofs_per_cell);
+    AssertDimension(gradients.size(), fe_values->n_quadrature_points);
 
     internal::do_function_gradients<dim, spacedim>(
       make_const_array_view(dof_values),


### PR DESCRIPTION
@jppelteret and I realized in looking at some code that I'm accessing invalid memory. This surprised us. It turned out that it's because we have some missing assertions that could have caught that. This patch fixes this oversight.