### PR TITLE
Fix tests after removing deprecated code

### DIFF
--- a/tests/cgal/cgal_surface_mesh_05.cc
+++ b/tests/cgal/cgal_surface_mesh_05.cc
@@ -86,7 +86,7 @@ test()
   GridGenerator::hyper_cube(tria1, 0.5, 1.5);
   tria0.refine_global(3);
   tria1.refine_global(3);
-  GridTools::rotate(numbers::PI_4, 2, tria1);
+  GridTools::rotate(Tensor<1, 3>{{0., 0., 1.}}, numbers::PI_4, tria1);
 
   // Move to CGAL surfaces
   dealii_tria_to_cgal_surface_mesh(tria0, surface_mesh0);

--- a/tests/symengine/symengine_tensor_operations_04.cc
+++ b/tests/symengine/symengine_tensor_operations_04.cc
@@ -136,10 +136,29 @@ test_symmetric_tensor()
   using Tensor_t           = SymmetricTensor<rank, dim, double>;
 
   Tensor_t t_a, t_b;
-  for (auto it = t_a.begin_raw(); it != t_a.end_raw(); ++it)
-    *it = 1.0;
-  for (auto it = t_b.begin_raw(); it != t_b.end_raw(); ++it)
-    *it = 2.0;
+
+  static_assert(rank == 2 || rank == 4);
+
+  if constexpr (rank == 2)
+    {
+      for (unsigned int i = 0; i < dim; ++i)
+        for (unsigned int j = 0; j < dim; ++j)
+          {
+            t_a({i, j}) = 1.0;
+            t_b({i, j}) = 2.0;
+          }
+    }
+  else
+    {
+      for (unsigned int i = 0; i < dim; ++i)
+        for (unsigned int j = 0; j < dim; ++j)
+          for (unsigned int k = 0; k < dim; ++k)
+            for (unsigned int l = 0; l < dim; ++l)
+              {
+                t_a({i, j, k, l}) = 1.0;
+                t_b({i, j, k, l}) = 2.0;
+              }
+    }
 
   const Tensor_SD_number_t symb_t_a =
     SD::make_symmetric_tensor_of_symbols<rank, dim>("a");


### PR DESCRIPTION
Fixes https://github.com/dealii/dealii/issues/17453. The fix in https://github.com/dealii/dealii/pull/17455 for the `symengine_tensor_test` doesn't work for me since `unrolled_to_component_indices` is not implemented for rank 4 tensors.