### PR TITLE
Fix documentation for FE_NedelecSZ

### DIFF
--- a/include/deal.II/fe/fe_nedelec_sz.h
+++ b/include/deal.II/fe/fe_nedelec_sz.h
@@ -37,9 +37,10 @@ DEAL_II_NAMESPACE_OPEN
  * This class represents an implementation of the
  * H<sup>curl</sup>-conforming N&eacute;d&eacute;lec element described in the
  * PhD thesis of S. Zaglmayr, <b>High Order Finite Element Methods for
- * Electromagnetic Field Computation</b>, Johannes Kepler Universit&auml;t Linz,
- * 2006. It its used in the same context as described at the top of the
- * description for the FE_Nedelec class.
+ * Electromagnetic Field Computation</b>,
+ * Johannes Kepler Universit&auml;t Linz, 2006.
+ * It its used in the same context as described at the top of the description
+ * for the FE_Nedelec class.
  *
  * This element overcomes the sign conflict issues present in
  * traditional N&eacute;d&eacute;lec elements that arise from the edge


### PR DESCRIPTION
https://www.dealii.org/developer/doxygen/deal.II/classFE__NedelecSZ.html doesn't print the year correctly.