### PR TITLE
Kokkos+CUDA: disable warning

### DIFF
--- a/cmake/modules/FindDEAL_II_KOKKOS.cmake
+++ b/cmake/modules/FindDEAL_II_KOKKOS.cmake
@@ -77,5 +77,7 @@ if(Kokkos_FOUND)
     enable_if_supported(DEAL_II_CXX_FLAGS "-Xcudafe --diag_suppress=284")
     # variable "i" was set but never used:
     enable_if_supported(DEAL_II_CXX_FLAGS "-Xcudafe --diag_suppress=550")
+    # warning #940-D: missing return statement at end of non-void function
+    enable_if_supported(DEAL_II_CXX_FLAGS "-Xcudafe --diag_suppress=940")
   endif()
 endif()


### PR DESCRIPTION
nvcc decides that it should produce a warning about a missing return in a situation like this:
```
{
  if (check)
    return true;
  else
    return false;
}
```
Disable this warning.