### PR TITLE
Parse prm files in python script

### DIFF
--- a/contrib/utilities/prm_tools.py
+++ b/contrib/utilities/prm_tools.py
@@ -21,6 +21,7 @@ import sys
 import os
 import re
 import argparse
+from argparse import RawTextHelpFormatter
 
 __author__ = 'The authors of deal.II'
 __copyright__ = 'Copyright 2024, deal.II'
@@ -104,6 +105,9 @@ def read_value_or_subsection(input_file, parameters):
 
     for line in input_file:
         line = line.strip()
+
+        # Replace tabs with 2 spaces
+        line.sub("\t", "  ")
 
         # If line ends with \, read next line and append including \n
         if line != "":
@@ -283,21 +287,7 @@ def write_parameter_file(parameters, file):
 
 def main(input_file, output_file):
     """ This function reformats the given input .prm files to follow our
-    general formatting guidelines. These are:
-
-    - indent by two spaces for each subsection level, and indent comments as well
-    as content
-    - ensure an empty line before a subsection or a comment, unless it is a
-    subsection/comment following directly another subsection, or it is at the
-    start of the file
-    - combine content of subsections that are duplicated
-    - if values are duplicated, merge them and use the last one in the file (like
-    deal.II ParameterHandler when it reads the file)
-    - retain as much user formatting in comments and parameter values as possible,
-    e.g. spaces for padding values to align between adjacent lines. This is not
-    always perfectly possible.
-    - retain broken lines (`\\`) in values of parameters and comments, remove them
-    from subsection or parameter names.
+    general formatting guidelines.
     """
     parameters = read_parameter_file(input_file)
     write_parameter_file(parameters, output_file)
@@ -307,7 +297,28 @@ def main(input_file, output_file):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
                     prog='deal.II .prm file reformatter',
-                    description='Reformats deal.II .prm files to follow our general formatting guidelines. See the documentation of this script for details.')
+                    description=
+"""Reformats deal.II .prm files to follow our general formatting guidelines.
+The script expects two arguments, a path to the file to be formatted, and a
+path to which the formatted output should be written. If the two paths are
+identical the given file is overwritten with the formatted output.
+
+Our formatting guidelines are:
+    - indent by two spaces for each subsection level, and indent comments as
+      well as content
+    - ensure an empty line before a subsection or a comment, unless it is a
+      subsection/comment following directly another subsection, or it is at the
+      start of the file
+    - combine content of subsections that are duplicated
+    - if values are duplicated, merge them and use the last one in the file
+      (like deal.II ParameterHandler when it reads the file)
+    - retain as much user formatting in comments and parameter values as
+      possible, e.g. spaces for padding values to align between adjacent lines.
+      This is not always perfectly possible.
+    - retain broken lines (`\\`) in values of parameters and comments, remove
+      them from subsection or parameter names.  """,
+                    formatter_class=RawTextHelpFormatter)
+
     parser.add_argument('input_file', type=str, help='The .prm file to reformat.')
     parser.add_argument('output_file', type=str, help='The .prm file to write the reformatted file to.')
     args = parser.parse_args()

--- a/contrib/utilities/prm_tools.py
+++ b/contrib/utilities/prm_tools.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+## ------------------------------------------------------------------------
+##
+## SPDX-License-Identifier: LGPL-2.1-or-later
+## Copyright (C) 2016 by the deal.II authors
+##
+## This file is part of the deal.II library.
+##
+## Part of the source code is dual licensed under Apache-2.0 WITH
+## LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+## governing the source code and code contributions can be found in
+## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+##
+## ------------------------------------------------------------------------
+
+""" Routines to read, format and write deal.II parameter input files (.prm files) """
+
+import sys
+import os
+import re
+import argparse
+
+__author__ = 'The authors of deal.II'
+__copyright__ = 'Copyright 2024, deal.II'
+__license__ = 'GNU GPL 2 or later'
+
+
+def get_parameter_value(parameters, name):
+    """ Given a dictionary of parameters with a structure as
+    the one created by read_parameter_file(), return the value
+    of the parameter with the given name. Returns None if the
+    parameter is not found.
+    """
+
+    if name in parameters:
+        return parameters[name]["value"]
+    else:
+        for entry in parameters:
+            if parameters[entry]["type"] == "subsection":
+                value = get_parameter_value(parameters[entry]["value"], name)
+                if value != None:
+                    return value
+
+    return None
+
+
+
+def set_parameter_value(parameters, name, value):
+    """ Given a dictionary of parameters with a structure as
+    the one created by read_parameter_file(), recursively search
+    through the subsections and set the value
+    of the first parameter with the given name to the given value.
+    Returns 0 if the parameter was found and set, 1 otherwise.
+    """
+
+    if name in parameters:
+        parameters[name]["value"] = value
+        return 0
+    else:
+        for entry in parameters:
+            if parameters[entry]["type"] == "subsection":
+                if set_parameter_value(parameters[entry]["value"], name, value) == 0:
+                    return 0
+
+    return 1
+
+
+def split_parameter_line(line):
+    """ Read a 'set parameter' line and extract the name, value, and format. """
+
+    equal_index = line.find('=')
+    # Determine number of additional spaces left of equal sign.
+    # We need to store these separately, because there might be two
+    # lines setting the same parameter, but different number of spaces. They
+    # should still map to the same parameter.
+    alignment_spaces = len(line[:equal_index]) - len(line[:equal_index].rstrip())
+
+    # skip initial word "set" in parameter name
+    words_left_of_equal_sign = line[:equal_index].replace("\\\n","").split()
+    param_name = words_left_of_equal_sign[1:]
+    param_name = ' '.join(param_name)
+
+    # strip spaces at end of value string, keep all inline comments
+    param_value = line[equal_index+1:].rstrip()
+    # if there is one or more spaces at the start of the string, remove one space.
+    # keep additional spaces, because they are part of the formatting.
+    # this way we can add one space when writing the file back and keep the formatting
+    if param_value.startswith(' ') and len(param_value) > 1:
+        param_value = param_value[1:]
+
+    return param_name, param_value, alignment_spaces
+
+
+
+def read_value_or_subsection(input_file, parameters):
+    """ Read a value or a subsection from a parameter file into a parameter dictionary.
+    """
+
+    # Keep track of the comment lines to
+    # add them to the next parameter or subsection
+    accumulated_comment = ""
+
+    for line in input_file:
+        line = line.strip()
+
+        # If line ends with \, read next line and append including \n
+        if line != "":
+            while line[-1] == "\\":
+                line += "\n" + next(input_file).rstrip()
+
+        words = line.replace("\\\n","").split()
+
+        # Attach empty lines if we are inside a comment
+        if line == "" or len(words) == 0:
+            if accumulated_comment != "":
+                accumulated_comment += "\n"
+
+        # Store comments in accumulated_comment
+        elif line[0] == "#":
+            if accumulated_comment != "":
+                accumulated_comment += "\n"
+            accumulated_comment += line.replace("\\\n","")
+
+        # If we encounter a 'subsection' line, store the subsection name
+        # and recursively call this function to read the subsection
+        elif words[0] == "subsection":
+            subsection_name = ' '.join(words[1:]).replace("\\","")
+
+            if subsection_name not in parameters:
+                parameters[subsection_name] = {"comment": "", "value" : dict({}), "type": "subsection"}
+
+            if parameters[subsection_name]["comment"] != "":
+                parameters[subsection_name]["comment"] += "\n"
+
+            parameters[subsection_name]["comment"] += accumulated_comment
+            accumulated_comment = ""
+
+            parameters[subsection_name]["value"].update(read_value_or_subsection(input_file, parameters[subsection_name]["value"]))
+
+        # If we encounter a 'set' line, store the parameter name and value
+        elif words[0] == 'set':
+            name, value, alignment_spaces = split_parameter_line(line)
+
+            parameters[name] = {"comment": accumulated_comment, "value": value, "alignment spaces": alignment_spaces, "type": "parameter"}
+            accumulated_comment = ""
+
+        elif words[0] == "include":
+            name = ' '.join(words[1:])
+            value = ''
+            alignment_spaces = 0
+            parameters[name] = {"comment": accumulated_comment, "value": value, "alignment spaces": alignment_spaces, "type": "include"}
+            accumulated_comment = ""
+
+        elif words[0] == "end":
+            # sometimes there are comments at the end of files or subsection. store them in their own parameter
+            if accumulated_comment != "":
+                parameters["postcomment"] = {"comment": accumulated_comment, "value": "", "alignment spaces": 0, "type": "comment"}
+                accumulated_comment = ""
+
+            return parameters
+
+        else:
+            raise RuntimeError("Unrecognized first keyword in line: " + line)
+
+    # sometimes there are comments at the end of files or subsection. store them in their own parameter
+    if accumulated_comment != "":
+        parameters["postcomment"] = {"comment": accumulated_comment, "value": "", "alignment spaces": 0, "type": "comment"}
+        accumulated_comment = ""
+
+    return parameters
+
+
+
+def read_parameter_file(file):
+    """ Read parameter file, and return a dictionary with all values.
+
+    The returned dictionary contains as keys the name of the subsection,
+     include statement or parameter, and as value a dictionary with
+     the following keys:
+    - 'comment': the comment lines before the parameter or subsection
+    - 'value': the value of the parameter as a string, or a dictionary
+      with the same structure as the one returned by this function
+      for a subsection. Empty for an include statement (the content
+      of an include statement is its name).
+    - 'alignment spaces': the number of spaces between name and equal sign
+      in a parameter line. This is used to keep the formatting
+      of the parameter file when writing it back.
+    - 'type': either 'parameter', 'include', 'subsection', or 'comment'
+      depending on the type of the entry.
+    """
+
+    parameters = dict({})
+
+    with open(file, 'r') as f:
+        read_value_or_subsection(f, parameters)
+
+    return parameters
+
+
+
+def write_comment_if_existent(comment, prepend_spaces, file):
+    """ Print the comment lines, take care to use the correct indentation.
+    """
+    if comment != "":
+        for line in comment.split("\n"):
+            if line != "":
+                file.write(" " * prepend_spaces)
+            file.write(line + "\n")
+
+
+
+def write_value_or_subsection(parameters, prepend_spaces, file):
+    """ Write a parameters dictionary recursively into a given file.
+    prepend_spaces tracks the current indentation level.
+    """
+
+    # keep track of whether this is the first entry
+    # this is important for some formatting
+    first_entry = True
+
+    # Print all parameter/include entries first
+    for entry in parameters:
+        if parameters[entry]["type"] == "parameter":
+            # Add empty line before comments
+            if first_entry == False and parameters[entry]["comment"] != "":
+                file.write("\n")
+            write_comment_if_existent(parameters[entry]["comment"], prepend_spaces, file)
+
+            # Only add a space after equal sign if the value is not empty
+            space_if_value = " " if parameters[entry]["value"] != "" else ""
+            file.write(" " * prepend_spaces + "set " + entry + " " * parameters[entry]["alignment spaces"] + "=" \
+                        + space_if_value + parameters[entry]["value"] + "\n")
+
+        elif parameters[entry]["type"] == "include":
+            # Add empty line before include
+            if first_entry == False:
+                file.write("\n")
+            write_comment_if_existent(parameters[entry]["comment"], prepend_spaces, file)
+
+            # Write the include
+            file.write(" " * prepend_spaces + "include " + entry + "\n")
+            # Add an empty line after include, except for the end of the file
+            if entry != list(parameters)[-1]:
+                file.write("\n")
+
+        elif parameters[entry]["type"] == "subsection":
+            if first_entry == False:
+                file.write("\n")
+            write_comment_if_existent(parameters[entry]["comment"], prepend_spaces, file)
+
+            file.write(" " * prepend_spaces + "subsection " + entry + "\n")
+            prepend_spaces += 2
+            # Recursively write the next subsection level
+            write_value_or_subsection(parameters[entry]["value"], prepend_spaces, file)
+            prepend_spaces -= 2
+            file.write(" " * prepend_spaces + "end\n")
+
+        elif parameters[entry]["type"] == "comment":
+            if first_entry == False and parameters[entry]["comment"] != "":
+                file.write("\n")
+            write_comment_if_existent(parameters[entry]["comment"], prepend_spaces, file)
+
+        first_entry = False
+
+    return 0
+
+
+
+def write_parameter_file(parameters, file):
+    """ Given a dictionary of parameters with a structure as
+    the one created by read_parameter_file(), write the dictionary
+    to a file.
+    """
+
+    prepend_spaces = 0
+    with open(file,'w') as f:
+        write_value_or_subsection(parameters, prepend_spaces, f)
+    return 0
+
+
+
+def main(input_file, output_file):
+    """ This function reformats the given input .prm files to follow our
+    general formatting guidelines. These are:
+
+    - indent by two spaces for each subsection level, and indent comments as well
+    as content
+    - ensure an empty line before a subsection or a comment, unless it is a
+    subsection/comment following directly another subsection, or it is at the
+    start of the file
+    - combine content of subsections that are duplicated
+    - if values are duplicated, merge them and use the last one in the file (like
+    deal.II ParameterHandler when it reads the file)
+    - retain as much user formatting in comments and parameter values as possible,
+    e.g. spaces for padding values to align between adjacent lines. This is not
+    always perfectly possible.
+    - retain broken lines (`\\`) in values of parameters and comments, remove them
+    from subsection or parameter names.
+    """
+    parameters = read_parameter_file(input_file)
+    write_parameter_file(parameters, output_file)
+
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+                    prog='deal.II .prm file reformatter',
+                    description='Reformats deal.II .prm files to follow our general formatting guidelines. See the documentation of this script for details.')
+    parser.add_argument('input_file', type=str, help='The .prm file to reformat.')
+    parser.add_argument('output_file', type=str, help='The .prm file to write the reformatted file to.')
+    args = parser.parse_args()
+
+    sys.exit(main(args.input_file, args.output_file))

--- a/doc/news/changes/minor/20240821Gassmoeller
+++ b/doc/news/changes/minor/20240821Gassmoeller
@@ -1,0 +1,5 @@
+New: deal.II now contains a python script to indent ParameterHandler .prm
+files. The script is located in contrib/utilities/prm_tools.py and can be
+used to update .prm file in-place or write the output into a new file.
+<br>
+(Rene Gassmoeller, 2024/08/21)

--- a/examples/step-34/parameters.prm
+++ b/examples/step-34/parameters.prm
@@ -9,7 +9,7 @@ set Run 3d simulation               = true
 
 subsection Exact solution 2d
   # Any constant used inside the function which is not a variable name.
-  set Function constants = 
+  set Function constants =
 
   # Separate vector valued expressions by ';' as ',' is used internally by the
   # function parser.
@@ -22,7 +22,7 @@ end
 
 subsection Exact solution 3d
   # Any constant used inside the function which is not a variable name.
-  set Function constants = 
+  set Function constants =
 
   # Separate vector valued expressions by ';' as ',' is used internally by the
   # function parser.
@@ -49,7 +49,7 @@ end
 
 subsection Wind function 2d
   # Any constant used inside the function which is not a variable name.
-  set Function constants = 
+  set Function constants =
 
   # Separate vector valued expressions by ';' as ',' is used internally by the
   # function parser.
@@ -62,7 +62,7 @@ end
 
 subsection Wind function 3d
   # Any constant used inside the function which is not a variable name.
-  set Function constants = 
+  set Function constants =
 
   # Separate vector valued expressions by ';' as ',' is used internally by the
   # function parser.

--- a/examples/step-60/parameters.prm
+++ b/examples/step-60/parameters.prm
@@ -18,12 +18,12 @@ subsection Distributed Lagrange<1,2>
     # that describes the function, rather than having to use its numeric value
     # everywhere the constant appears. These values can be defined using this
     # parameter, in the form `var1=value1, var2=value2, ...'.
-    # 
+    #
     # A typical example would be to set this runtime parameter to
     # `pi=3.1415926536' and then use `pi' in the expression of the actual
     # formula. (That said, for convenience this class actually defines both
     # `pi' and `Pi' by default, but you get the idea.)
-    set Function constants  = R=.3, Cx=.4, Cy=.4                 # default: 
+    set Function constants  = R=.3, Cx=.4, Cy=.4                 # default:
 
     # The formula that denotes the function you want to evaluate for
     # particular values of the independent variables. This expression may
@@ -34,7 +34,7 @@ subsection Distributed Lagrange<1,2>
     # true, and to the third argument otherwise. For a full overview of
     # possible expressions accepted see the documentation of the muparser
     # library at http://muparser.beltoforion.de/.
-    # 
+    #
     # If the function you are describing represents a vector-valued function
     # with multiple components, then separate the expressions for individual
     # components by a semicolon.
@@ -59,12 +59,12 @@ subsection Distributed Lagrange<1,2>
     # that describes the function, rather than having to use its numeric value
     # everywhere the constant appears. These values can be defined using this
     # parameter, in the form `var1=value1, var2=value2, ...'.
-    # 
+    #
     # A typical example would be to set this runtime parameter to
     # `pi=3.1415926536' and then use `pi' in the expression of the actual
     # formula. (That said, for convenience this class actually defines both
     # `pi' and `Pi' by default, but you get the idea.)
-    set Function constants  = 
+    set Function constants  =
 
     # The formula that denotes the function you want to evaluate for
     # particular values of the independent variables. This expression may
@@ -75,7 +75,7 @@ subsection Distributed Lagrange<1,2>
     # true, and to the third argument otherwise. For a full overview of
     # possible expressions accepted see the documentation of the muparser
     # library at http://muparser.beltoforion.de/.
-    # 
+    #
     # If the function you are describing represents a vector-valued function
     # with multiple components, then separate the expressions for individual
     # components by a semicolon.
@@ -100,12 +100,12 @@ subsection Distributed Lagrange<1,2>
     # that describes the function, rather than having to use its numeric value
     # everywhere the constant appears. These values can be defined using this
     # parameter, in the form `var1=value1, var2=value2, ...'.
-    # 
+    #
     # A typical example would be to set this runtime parameter to
     # `pi=3.1415926536' and then use `pi' in the expression of the actual
     # formula. (That said, for convenience this class actually defines both
     # `pi' and `Pi' by default, but you get the idea.)
-    set Function constants  = 
+    set Function constants  =
 
     # The formula that denotes the function you want to evaluate for
     # particular values of the independent variables. This expression may
@@ -116,7 +116,7 @@ subsection Distributed Lagrange<1,2>
     # true, and to the third argument otherwise. For a full overview of
     # possible expressions accepted see the documentation of the muparser
     # library at http://muparser.beltoforion.de/.
-    # 
+    #
     # If the function you are describing represents a vector-valued function
     # with multiple components, then separate the expressions for individual
     # components by a semicolon.
@@ -141,12 +141,12 @@ subsection Distributed Lagrange<1,2>
     # that describes the function, rather than having to use its numeric value
     # everywhere the constant appears. These values can be defined using this
     # parameter, in the form `var1=value1, var2=value2, ...'.
-    # 
+    #
     # A typical example would be to set this runtime parameter to
     # `pi=3.1415926536' and then use `pi' in the expression of the actual
     # formula. (That said, for convenience this class actually defines both
     # `pi' and `Pi' by default, but you get the idea.)
-    set Function constants  = 
+    set Function constants  =
 
     # The formula that denotes the function you want to evaluate for
     # particular values of the independent variables. This expression may
@@ -157,7 +157,7 @@ subsection Distributed Lagrange<1,2>
     # true, and to the third argument otherwise. For a full overview of
     # possible expressions accepted see the documentation of the muparser
     # library at http://muparser.beltoforion.de/.
-    # 
+    #
     # If the function you are describing represents a vector-valued function
     # with multiple components, then separate the expressions for individual
     # components by a semicolon.

--- a/examples/step-70/parameters.prm
+++ b/examples/step-70/parameters.prm
@@ -12,11 +12,13 @@ subsection Stokes Immersed Problem
   set Velocity degree                    = 2
   set Viscosity                          = 1
   set Output directory                   = .
+
   subsection Angular velocity
-    set Function constants  = 
-    set Function expression = t < .500001 ? 6.283185 : -6.283185 # default: 0
+    set Function constants  =
+    set Function expression = t < .500001 ? 6.283185 : -6.283185
     set Variable names      = x,y,t
   end
+
   subsection Grid generation
     set Fluid grid generator              = hyper_cube
     set Fluid grid generator arguments    = -1: 1: false
@@ -37,7 +39,7 @@ subsection Stokes Immersed Problem
   end
 
   subsection Right hand side
-    set Function constants  = 
+    set Function constants  =
     set Function expression = 0; 0; 0
     set Variable names      = x,y,t
   end

--- a/examples/step-70/parameters_23.prm
+++ b/examples/step-70/parameters_23.prm
@@ -21,19 +21,22 @@ subsection Stokes Immersed Problem
   set Particle insertion refinement         = 4
   set Velocity degree                       = 2
   set Viscosity                             = 1
+
   subsection Angular velocity
-    set Function constants  = 
+    set Function constants  =
     set Function expression = t < .500001 ? 10 : -10
     set Variable names      = x,y,z,t
   end
+
   subsection Grid generation
     set Fluid grid generator              = hyper_rectangle
     set Fluid grid generator arguments    = -50,-50, -10: 50, 50, 40: false
     set Solid grid generator              = impeller.vtk
-    set Solid grid generator arguments    = 
+    set Solid grid generator arguments    =
     set Particle grid generator           = hyper_ball
     set Particle grid generator arguments = 30, 30, 20: 10: false
   end
+
   subsection Refinement and remeshing
     set Maximum number of cells        = 100000
     set Refinement coarsening fraction = 0.3
@@ -43,8 +46,9 @@ subsection Stokes Immersed Problem
     set Refinement step frequency      = 5
     set Refinement strategy            = fixed_fraction
   end
+
   subsection Right hand side
-    set Function constants  = 
+    set Function constants  =
     set Function expression = 0; 0; 0; 0
     set Variable names      = x,y,z,t
   end

--- a/examples/step-86/heat_equation.prm
+++ b/examples/step-86/heat_equation.prm
@@ -4,19 +4,19 @@ subsection Heat Equation
   set Mesh adaptation frequency      = 10
 
   subsection Right hand side
-    set Function constants  = 
+    set Function constants  =
     set Function expression = 0
     set Variable names      = x,y,t
   end
-  
+
   subsection Initial value
-    set Function constants  = 
+    set Function constants  =
     set Function expression = 0
     set Variable names      = x,y,t
   end
-  
+
   subsection Boundary values
-    set Function constants  = 
+    set Function constants  =
     set Function expression = (if(x<-0.999, 1, 0) + if(x>0.999, -1, 0)) * cos(4*pi*t)
     set Variable names      = x,y,t
   end
@@ -28,7 +28,7 @@ subsection Heat Equation
       set initial time            = 0
       set match final time        = false
       set maximum number of steps = -1
-      set options prefix          = 
+      set options prefix          =
       set solver type             = beuler
     end
 
@@ -39,6 +39,6 @@ subsection Heat Equation
       set ignore algebraic lte     = true
       set maximum step size        = -1
       set minimum step size        = -1
-    end    
+    end
   end
 end

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -1506,15 +1506,23 @@ ParameterHandler::recursively_print_parameters(
                     78 - overall_indent_level * 2 - 2);
 
                 for (const auto &doc_line : doc_lines)
-                  out << std::setw(overall_indent_level * 2) << ""
-                      << "# " << doc_line << '\n';
+                  {
+                    out << std::setw(overall_indent_level * 2) << '#';
+
+                    if (!doc_line.empty())
+                      out << ' ' << doc_line;
+
+                    out << '\n';
+                  }
               }
 
-            // print name and value of this entry
-            out << std::setw(overall_indent_level * 2) << ""
-                << "set " << demangle(p.first)
-                << std::setw(longest_name - demangle(p.first).size() + 1) << " "
-                << "= " << value;
+            // print the name and (if set) value of this entry
+            out << std::setw(overall_indent_level * 2) << "set "
+                << demangle(p.first)
+                << std::setw(longest_name - demangle(p.first).size() + 1) << ' '
+                << '=';
+            if (!value.empty())
+              out << ' ' << value;
 
             // finally print the default value, but only if it differs
             // from the actual value


### PR DESCRIPTION
This is the python script I and some others put together in ASPECT to read in and (optionally) modify .prm files. In its current state it does:

- read in .prm files and store them internally in a tree-like dictionary structure (this makes it possible to move parameters or whole subsections around, I did not include the code to do that here yet)
- reformat the .prm files according to the following rules:
  - 2 spaces for indentation
  - parameters before subsections
  - empty lines before comments
  - combine contents of subsections (no duplicate subsections)
  - later parameters overwrite earlier parameters (no duplicate parameters)
  - retain as much user formatting as possible

To show its impact I ran it on all .prm files included in the deal.II repository. I am not sure if some of those .prm files have certain structures on purpose, so we do not have to apply it on all files. But I think the script is quite useful in updating large numbers of input files and also to enforce a certain similar style across all .prm files in a project.

Happy to modify the PR or discuss how this script could be useful or applied (e.g. during CI?)