### PR TITLE
`DoFTools::extract_constant_modes()`: return vectors

### DIFF
--- a/examples/step-31/step-31.cc
+++ b/examples/step-31/step-31.cc
@@ -1124,12 +1124,10 @@ namespace Step31
 
     Amg_preconditioner = std::make_shared<TrilinosWrappers::PreconditionAMG>();
 
-    std::vector<std::vector<bool>>   constant_modes;
-    const FEValuesExtractors::Vector velocity_components(0);
-    DoFTools::extract_constant_modes(stokes_dof_handler,
-                                     stokes_fe.component_mask(
-                                       velocity_components),
-                                     constant_modes);
+    const FEValuesExtractors::Vector     velocity_components(0);
+    const std::vector<std::vector<bool>> constant_modes =
+      DoFTools::extract_constant_modes(
+        stokes_dof_handler, stokes_fe.component_mask(velocity_components));
     TrilinosWrappers::PreconditionAMG::AdditionalData amg_data;
     amg_data.constant_modes = constant_modes;
 

--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -2160,12 +2160,10 @@ namespace Step32
 
     assemble_stokes_preconditioner();
 
-    std::vector<std::vector<bool>>   constant_modes;
-    const FEValuesExtractors::Vector velocity_components(0);
-    DoFTools::extract_constant_modes(stokes_dof_handler,
-                                     stokes_fe.component_mask(
-                                       velocity_components),
-                                     constant_modes);
+    const FEValuesExtractors::Vector     velocity_components(0);
+    const std::vector<std::vector<bool>> constant_modes =
+      DoFTools::extract_constant_modes(
+        stokes_dof_handler, stokes_fe.component_mask(velocity_components));
 
     Mp_preconditioner =
       std::make_shared<TrilinosWrappers::PreconditionJacobi>();

--- a/examples/step-42/step-42.cc
+++ b/examples/step-42/step-42.cc
@@ -1622,10 +1622,8 @@ namespace Step42
     {
       TimerOutput::Scope t(computing_timer, "Solve: setup preconditioner");
 
-      std::vector<std::vector<bool>> constant_modes;
-      DoFTools::extract_constant_modes(dof_handler,
-                                       ComponentMask(),
-                                       constant_modes);
+      const std::vector<std::vector<bool>> constant_modes =
+        DoFTools::extract_constant_modes(dof_handler, ComponentMask());
 
       TrilinosWrappers::PreconditionAMG::AdditionalData additional_data;
       additional_data.constant_modes        = constant_modes;

--- a/examples/step-90/step-90.cc
+++ b/examples/step-90/step-90.cc
@@ -946,10 +946,8 @@ namespace Step90
               << std::flush;
         const unsigned int max_iterations = 500;
         SolverControl      solver_control(max_iterations, relative_error);
-        std::vector<std::vector<bool>> constant_modes;
-        DoFTools::extract_constant_modes(dof_handler,
-                                         ComponentMask(),
-                                         constant_modes);
+        const std::vector<std::vector<bool>> constant_modes =
+          DoFTools::extract_constant_modes(dof_handler, ComponentMask());
         TrilinosWrappers::PreconditionAMG preconditioner_stiffness;
         TrilinosWrappers::PreconditionAMG::AdditionalData Amg_data;
         Amg_data.constant_modes        = constant_modes;

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -1371,20 +1371,44 @@ namespace DoFTools
    * This function is used in step-31, step-32, and step-42, for example.
    */
   template <int dim, int spacedim>
-  void
+  std::vector<std::vector<bool>>
   extract_constant_modes(const DoFHandler<dim, spacedim> &dof_handler,
-                         const ComponentMask             &component_mask,
-                         std::vector<std::vector<bool>>  &constant_modes);
+                         const ComponentMask             &component_mask);
+
+  /**
+   * Same as above.
+   *
+   * @deprecated
+   */
+  template <int dim, int spacedim>
+  DEAL_II_DEPRECATED_EARLY_WITH_COMMENT(
+    "Use the other function that returns the constant modes by value, rather than via an argument.")
+  void extract_constant_modes(const DoFHandler<dim, spacedim> &dof_handler,
+                              const ComponentMask             &component_mask,
+                              std::vector<std::vector<bool>>  &constant_modes);
 
   /**
    * Same as above but for multigrid levels.
    */
   template <int dim, int spacedim>
-  void
+  std::vector<std::vector<bool>>
   extract_level_constant_modes(const unsigned int               level,
                                const DoFHandler<dim, spacedim> &dof_handler,
-                               const ComponentMask             &component_mask,
-                               std::vector<std::vector<bool>>  &constant_modes);
+                               const ComponentMask             &component_mask);
+
+  /**
+   * Same as above.
+   *
+   * @deprecated
+   */
+  template <int dim, int spacedim>
+  DEAL_II_DEPRECATED_EARLY_WITH_COMMENT(
+    "Use the other function that returns the constant modes by value, rather than via an argument.")
+  void extract_level_constant_modes(
+    const unsigned int               level,
+    const DoFHandler<dim, spacedim> &dof_handler,
+    const ComponentMask             &component_mask,
+    std::vector<std::vector<bool>>  &constant_modes);
 
   /**
    * Same as the above but additional to the translational modes also

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -1269,12 +1269,13 @@ namespace DoFTools
   namespace internal
   {
     template <int dim, int spacedim>
-    void
+    std::vector<std::vector<bool>>
     extract_constant_modes(const DoFHandler<dim, spacedim> &dof_handler,
                            const ComponentMask             &component_mask,
-                           const unsigned int               mg_level,
-                           std::vector<std::vector<bool>>  &constant_modes)
+                           const unsigned int               mg_level)
     {
+      std::vector<std::vector<bool>> constant_modes;
+
       const auto &locally_owned_dofs =
         (mg_level == numbers::invalid_unsigned_int) ?
           dof_handler.locally_owned_dofs() :
@@ -1284,8 +1285,7 @@ namespace DoFTools
       // constant_modes object:
       if (locally_owned_dofs.n_elements() == 0)
         {
-          constant_modes = std::vector<std::vector<bool>>(0);
-          return;
+          return std::vector<std::vector<bool>>(0);
         }
 
       const unsigned int n_components = dof_handler.get_fe(0).n_components();
@@ -1408,6 +1408,8 @@ namespace DoFTools
                       indices.second, i);
             }
       });
+
+      return constant_modes;
     }
 
 
@@ -1539,15 +1541,39 @@ namespace DoFTools
 
 
   template <int dim, int spacedim>
+  std::vector<std::vector<bool>>
+  extract_constant_modes(const DoFHandler<dim, spacedim> &dof_handler,
+                         const ComponentMask             &component_mask)
+  {
+    return internal::extract_constant_modes(dof_handler,
+                                            component_mask,
+                                            numbers::invalid_unsigned_int);
+  }
+
+
+
+  template <int dim, int spacedim>
   void
   extract_constant_modes(const DoFHandler<dim, spacedim> &dof_handler,
                          const ComponentMask             &component_mask,
                          std::vector<std::vector<bool>>  &constant_modes)
   {
-    internal::extract_constant_modes(dof_handler,
-                                     component_mask,
-                                     numbers::invalid_unsigned_int,
-                                     constant_modes);
+    const auto temp =
+      internal::extract_constant_modes(dof_handler,
+                                       component_mask,
+                                       numbers::invalid_unsigned_int);
+    constant_modes = temp;
+  }
+
+
+
+  template <int dim, int spacedim>
+  std::vector<std::vector<bool>>
+  extract_level_constant_modes(const unsigned int               level,
+                               const DoFHandler<dim, spacedim> &dof_handler,
+                               const ComponentMask             &component_mask)
+  {
+    return internal::extract_constant_modes(dof_handler, component_mask, level);
   }
 
 
@@ -1559,10 +1585,9 @@ namespace DoFTools
                                const ComponentMask             &component_mask,
                                std::vector<std::vector<bool>>  &constant_modes)
   {
-    internal::extract_constant_modes(dof_handler,
-                                     component_mask,
-                                     level,
-                                     constant_modes);
+    const auto temp =
+      internal::extract_constant_modes(dof_handler, component_mask, level);
+    constant_modes = temp;
   }
 
 

--- a/source/dofs/dof_tools.inst.in
+++ b/source/dofs/dof_tools.inst.in
@@ -188,10 +188,20 @@ for (deal_II_dimension : DIMENSIONS)
       const types::subdomain_id            subdomain_id,
       std::vector<bool>                   &selected_dofs);
 
+    template std::vector<std::vector<bool>> DoFTools::extract_constant_modes<
+      deal_II_dimension>(const DoFHandler<deal_II_dimension> &dof_handler,
+                         const ComponentMask &selected_components);
+
     template void DoFTools::extract_constant_modes<deal_II_dimension>(
       const DoFHandler<deal_II_dimension> &dof_handler,
       const ComponentMask                 &selected_components,
       std::vector<std::vector<bool>>      &constant_modes);
+
+    template std::vector<std::vector<bool>>
+    DoFTools::extract_level_constant_modes<deal_II_dimension>(
+      const unsigned int                   level,
+      const DoFHandler<deal_II_dimension> &dof_handler,
+      const ComponentMask                 &selected_components);
 
     template void DoFTools::extract_level_constant_modes<deal_II_dimension>(
       const unsigned int                   level,

--- a/tests/dofs/extract_dofs_by_component_04.cc
+++ b/tests/dofs/extract_dofs_by_component_04.cc
@@ -67,8 +67,8 @@ check()
       for (unsigned int c = 0; c < element.n_components(); ++c)
         component_mask.set(c, (int_mask & (1 << c)));
 
-      std::vector<std::vector<bool>> constant_modes;
-      DoFTools::extract_constant_modes(dof, component_mask, constant_modes);
+      const auto constant_modes =
+        DoFTools::extract_constant_modes(dof, component_mask);
 
       for (unsigned int d = 0; d < constant_modes.size(); ++d)
         {

--- a/tests/mpi/extract_constant_modes_01.cc
+++ b/tests/mpi/extract_constant_modes_01.cc
@@ -68,8 +68,8 @@ test()
         ComponentMask mask(fe.n_components(), false);
         mask.set(c, true);
 
-        std::vector<std::vector<bool>> constant_modes;
-        DoFTools::extract_constant_modes(dofh, mask, constant_modes);
+        const auto constant_modes =
+          DoFTools::extract_constant_modes(dofh, mask);
 
         for (unsigned int i = 0; i < constant_modes.size(); ++i)
           {
@@ -87,8 +87,8 @@ test()
         ComponentMask mask(fe.n_components(), false);
         mask.set(c, true);
 
-        std::vector<std::vector<bool>> constant_modes;
-        DoFTools::extract_constant_modes(dofh, mask, constant_modes);
+        const auto constant_modes =
+          DoFTools::extract_constant_modes(dofh, mask);
 
         for (unsigned int i = 0; i < constant_modes.size(); ++i)
           {

--- a/tests/mpi/extract_constant_modes_02.cc
+++ b/tests/mpi/extract_constant_modes_02.cc
@@ -64,8 +64,7 @@ test()
     {
       ComponentMask mask(fe.n_components(), true);
 
-      std::vector<std::vector<bool>> constant_modes;
-      DoFTools::extract_constant_modes(dofh, mask, constant_modes);
+      const auto constant_modes = DoFTools::extract_constant_modes(dofh, mask);
 
       for (unsigned int i = 0; i < constant_modes.size(); ++i)
         {

--- a/tests/mpi/extract_constant_modes_03.cc
+++ b/tests/mpi/extract_constant_modes_03.cc
@@ -82,8 +82,7 @@ test(unsigned int fe_nothing_index)
     {
       ComponentMask mask(1, true);
 
-      std::vector<std::vector<bool>> constant_modes;
-      DoFTools::extract_constant_modes(dofh, mask, constant_modes);
+      const auto constant_modes = DoFTools::extract_constant_modes(dofh, mask);
 
       for (unsigned int i = 0; i < constant_modes.size(); ++i)
         {

--- a/tests/mpi/extract_constant_modes_04.cc
+++ b/tests/mpi/extract_constant_modes_04.cc
@@ -73,8 +73,8 @@ test()
         ComponentMask mask(fe.n_components(), false);
         mask.set(c, true);
 
-        std::vector<std::vector<bool>> constant_modes;
-        DoFTools::extract_level_constant_modes(0, dofh, mask, constant_modes);
+        const auto constant_modes =
+          DoFTools::extract_level_constant_modes(0, dofh, mask);
 
         for (unsigned int i = 0; i < constant_modes.size(); ++i)
           {
@@ -92,8 +92,8 @@ test()
         ComponentMask mask(fe.n_components(), false);
         mask.set(c, true);
 
-        std::vector<std::vector<bool>> constant_modes;
-        DoFTools::extract_level_constant_modes(0, dofh, mask, constant_modes);
+        const auto constant_modes =
+          DoFTools::extract_level_constant_modes(0, dofh, mask);
 
         for (unsigned int i = 0; i < constant_modes.size(); ++i)
           {

--- a/tests/simplex/step-31.cc
+++ b/tests/simplex/step-31.cc
@@ -600,12 +600,9 @@ namespace Step31
     deallog << "   Rebuilding Stokes preconditioner..." << std::flush;
     assemble_stokes_preconditioner();
     Amg_preconditioner = std::make_shared<TrilinosWrappers::PreconditionAMG>();
-    std::vector<std::vector<bool>>   constant_modes;
     const FEValuesExtractors::Vector velocity_components(0);
-    DoFTools::extract_constant_modes(stokes_dof_handler,
-                                     stokes_fe.component_mask(
-                                       velocity_components),
-                                     constant_modes);
+    const auto constant_modes = DoFTools::extract_constant_modes(
+      stokes_dof_handler, stokes_fe.component_mask(velocity_components));
 
     std::vector<std::vector<double>> constant_modes_values(
       constant_modes.size());

--- a/tests/trilinos/precondition_amg_dgp_01.cc
+++ b/tests/trilinos/precondition_amg_dgp_01.cc
@@ -197,9 +197,8 @@ Step4<dim>::solve()
   deallog.push(Utilities::int_to_string(dof_handler.n_dofs(), 5));
   TrilinosWrappers::PreconditionAMG                 preconditioner;
   TrilinosWrappers::PreconditionAMG::AdditionalData data;
-  DoFTools::extract_constant_modes(dof_handler,
-                                   ComponentMask(1, true),
-                                   data.constant_modes);
+  data.constant_modes =
+    DoFTools::extract_constant_modes(dof_handler, ComponentMask(1, true));
   data.smoother_sweeps = 2;
   {
     solution = 0;

--- a/tests/trilinos/precondition_muelu_dgp.cc
+++ b/tests/trilinos/precondition_muelu_dgp.cc
@@ -197,9 +197,8 @@ Step4<dim>::solve()
   deallog.push(Utilities::int_to_string(dof_handler.n_dofs(), 5));
   TrilinosWrappers::PreconditionAMGMueLu                 preconditioner;
   TrilinosWrappers::PreconditionAMGMueLu::AdditionalData data;
-  DoFTools::extract_constant_modes(dof_handler,
-                                   std::vector<bool>(1, true),
-                                   data.constant_modes);
+  data.constant_modes =
+    DoFTools::extract_constant_modes(dof_handler, std::vector<bool>(1, true));
   data.smoother_sweeps = 2;
   {
     solution = 0;


### PR DESCRIPTION
@kronbichler What do you think? This is a change which we did at many places in the library in the last years. If you agree, I would adjust https://github.com/dealii/dealii/pull/17477.