### PR TITLE
Remove first 6/13 void casts in fe.cc

### DIFF
--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -845,15 +845,13 @@ FiniteElement<dim, spacedim>::hp_constraints_are_implemented() const
 template <int dim, int spacedim>
 const FullMatrix<double> &
 FiniteElement<dim, spacedim>::constraints(
-  const internal::SubfaceCase<dim> &subface_case) const
+  [[maybe_unused]] const internal::SubfaceCase<dim> &subface_case) const
 {
   // TODO: the implementation makes the assumption that all faces have the
   // same number of dofs
   AssertDimension(this->n_unique_faces(), 1);
-  const unsigned int face_no = 0;
-  (void)face_no;
+  [[maybe_unused]] const unsigned int face_no = 0;
 
-  (void)subface_case;
   Assert(subface_case == internal::SubfaceCase<dim>::case_isotropic,
          ExcMessage("Constraints for this element are only implemented "
                     "for the case that faces are refined isotropically "
@@ -1176,8 +1174,8 @@ FiniteElement<dim, spacedim>::get_sub_fe(const ComponentMask &mask) const
 template <int dim, int spacedim>
 const FiniteElement<dim, spacedim> &
 FiniteElement<dim, spacedim>::get_sub_fe(
-  const unsigned int first_component,
-  const unsigned int n_selected_components) const
+  [[maybe_unused]] const unsigned int first_component,
+  [[maybe_unused]] const unsigned int n_selected_components) const
 {
   // No complicated logic is needed here, because it is overridden in
   // FESystem<dim,spacedim>. Just make sure that what the user chose is valid:
@@ -1185,8 +1183,6 @@ FiniteElement<dim, spacedim>::get_sub_fe(
          ExcMessage(
            "You can only select a whole FiniteElement, not a part of one."));
 
-  (void)first_component;
-  (void)n_selected_components;
   return *this;
 }
 
@@ -1329,11 +1325,12 @@ FiniteElement<dim, spacedim>::fill_fe_face_values(
 template <int dim, int spacedim>
 inline void
 FiniteElement<dim, spacedim>::fill_fe_face_values(
-  const typename Triangulation<dim, spacedim>::cell_iterator &cell,
-  const unsigned int                                          face_no,
-  const Quadrature<dim - 1>                                  &quadrature,
-  const Mapping<dim, spacedim>                               &mapping,
-  const typename Mapping<dim, spacedim>::InternalDataBase    &mapping_internal,
+  [[maybe_unused]] const typename Triangulation<dim, spacedim>::cell_iterator
+                                                          &cell,
+  [[maybe_unused]] const unsigned int                      face_no,
+  const Quadrature<dim - 1>                               &quadrature,
+  const Mapping<dim, spacedim>                            &mapping,
+  const typename Mapping<dim, spacedim>::InternalDataBase &mapping_internal,
   const internal::FEValuesImplementation::MappingRelatedData<dim, spacedim>
                                                                 &mapping_data,
   const typename FiniteElement<dim, spacedim>::InternalDataBase &fe_internal,
@@ -1344,8 +1341,6 @@ FiniteElement<dim, spacedim>::fill_fe_face_values(
   Assert(false,
          ExcMessage("Use of a deprecated interface, please implement "
                     "fill_fe_face_values taking a hp::QCollection argument"));
-  (void)cell;
-  (void)face_no;
   (void)quadrature;
   (void)mapping;
   (void)mapping_internal;


### PR DESCRIPTION
I replace some of the void casts with the more modern [[maybe_unused]].

This is working towards fixing issue #17247.