### PR TITLE
Consistently use std::uncaught_exceptions().

### DIFF
--- a/source/base/hdf5.cc
+++ b/source/base/hdf5.cc
@@ -38,12 +38,7 @@ namespace HDF5
       check_exception(const std::string &type, const std::string &name)
       {
 #  ifdef DEAL_II_WITH_MPI
-#    if __cpp_lib_uncaught_exceptions >= 201411
-        // std::uncaught_exception() is deprecated in c++17
         if (std::uncaught_exceptions() != 0)
-#    else
-        if (std::uncaught_exception() == true)
-#    endif
           {
             std::cerr
               << "---------------------------------------------------------\n"

--- a/source/base/hdf5.cc
+++ b/source/base/hdf5.cc
@@ -38,7 +38,7 @@ namespace HDF5
       check_exception(const std::string &type, const std::string &name)
       {
 #  ifdef DEAL_II_WITH_MPI
-        if (std::uncaught_exceptions() != 0)
+        if (std::uncaught_exceptions() > 0)
           {
             std::cerr
               << "---------------------------------------------------------\n"

--- a/source/base/init_finalize.cc
+++ b/source/base/init_finalize.cc
@@ -417,12 +417,7 @@ InitFinalize::finalize()
       if (static_cast<bool>(libraries & InitializeLibrary::MPI) &&
           (MPI_has_been_started))
         {
-#  if __cpp_lib_uncaught_exceptions >= 201411
-          // std::uncaught_exception() is deprecated in c++17
           if (std::uncaught_exceptions() > 0)
-#  else
-          if (std::uncaught_exception() == true)
-#  endif
             {
               // do not try to call MPI_Finalize to avoid a deadlock.
             }

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -746,12 +746,7 @@ namespace Utilities
         check_exception()
         {
 #ifdef DEAL_II_WITH_MPI
-#  if __cpp_lib_uncaught_exceptions >= 201411
-          // std::uncaught_exception() is deprecated in c++17
           if (std::uncaught_exceptions() != 0)
-#  else
-          if (std::uncaught_exception() == true)
-#  endif
             {
               std::cerr
                 << "---------------------------------------------------------\n"

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -746,7 +746,7 @@ namespace Utilities
         check_exception()
         {
 #ifdef DEAL_II_WITH_MPI
-          if (std::uncaught_exceptions() != 0)
+          if (std::uncaught_exceptions() > 0)
             {
               std::cerr
                 << "---------------------------------------------------------\n"

--- a/source/base/subscriptor.cc
+++ b/source/base/subscriptor.cc
@@ -73,12 +73,7 @@ Subscriptor::check_no_subscribers() const noexcept
   // just display a message and continue the program.
   if (counter != 0)
     {
-#  if __cpp_lib_uncaught_exceptions >= 201411
-      // std::uncaught_exception() is deprecated in c++17
       if (std::uncaught_exceptions() == 0)
-#  else
-      if (std::uncaught_exception() == false)
-#  endif
         {
           std::string infostring;
           for (const auto &map_entry : counter_map)

--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -366,12 +366,7 @@ TimerOutput::~TimerOutput()
   // avoid communicating with other processes if there is an uncaught
   // exception
 #ifdef DEAL_II_WITH_MPI
-#  if __cpp_lib_uncaught_exceptions >= 201411
-  // std::uncaught_exception() is deprecated in c++17
   if (std::uncaught_exceptions() > 0 && mpi_communicator != MPI_COMM_SELF)
-#  else
-  if (std::uncaught_exception() == true && mpi_communicator != MPI_COMM_SELF)
-#  endif
     {
       const unsigned int myid =
         Utilities::MPI::this_mpi_process(mpi_communicator);


### PR DESCRIPTION
This C++17 function shipped with GCC-6: we can get rid of the workarounds.