### PR TITLE
Assert correction for issue #17450

### DIFF
--- a/include/deal.II/numerics/vector_tools_interpolate.templates.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.templates.h
@@ -320,7 +320,11 @@ namespace VectorTools
       hp::QCollection<dim> support_quadrature;
       for (unsigned int fe_index = 0; fe_index < fe.size(); ++fe_index)
         {
-          const auto &fe_i   = fe[fe_index];
+          const auto &fe_i = fe[fe_index];
+          Assert(fe_i.has_generalized_support_points(),
+                 ExcMessage(
+                   "The finite element does not have generalized support "
+                   "points. This is required for interpolation."));
           const auto &points = fe_i.get_generalized_support_points();
           support_quadrature.push_back(Quadrature<dim>(points));
           if (fe_i.n_base_elements() == 1 &&

--- a/include/deal.II/numerics/vector_tools_interpolate.templates.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.templates.h
@@ -323,7 +323,7 @@ namespace VectorTools
         {
           const auto &fe_i = fe[fe_index];
           // If the finite element has no dofs, we can skip it
-          if (fe_i->dofs_per_cell == 0)
+          if (fe_i.dofs_per_cell == 0)
             continue;
           Assert(fe_i.has_generalized_support_points(),
                  ExcMessage(

--- a/include/deal.II/numerics/vector_tools_interpolate.templates.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.templates.h
@@ -18,6 +18,7 @@
 
 #include <deal.II/dofs/dof_tools.h>
 
+#include <deal.II/fe/fe_nothing.h>
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_system.h>
 
@@ -321,6 +322,9 @@ namespace VectorTools
       for (unsigned int fe_index = 0; fe_index < fe.size(); ++fe_index)
         {
           const auto &fe_i = fe[fe_index];
+          // If the finite element has no dofs, we can skip it
+          if (fe_i->dofs_per_cell == 0)
+            continue;
           Assert(fe_i.has_generalized_support_points(),
                  ExcMessage(
                    "The finite element does not have generalized support "


### PR DESCRIPTION
The error message when FE_NedelecSZ are use to distribute dofs to the DoFHandler and then the VectorTools::interpolate function is called is now less cryptic. It prints : 

"The violated condition was: 
    fe_i.has_generalized_support_points()
Additional information: 
    The finite element does not have generalized support points. This is
    required for interpolation."
 
This was tested using the "error_c++_file.cc" presented in the initial issue (#17450).