### PR TITLE
Assert: release mode fixes: constexpr context, disable warnings in release mode

### DIFF
--- a/cmake/setup_compiler_flags_gnu.cmake
+++ b/cmake/setup_compiler_flags_gnu.cmake
@@ -169,11 +169,13 @@ if (CMAKE_BUILD_TYPE MATCHES "Release")
   list(APPEND DEAL_II_DEFINITIONS_RELEASE "NDEBUG")
 
   #
-  # There are many places in the library where we create a new typedef and then
-  # immediately use it in an Assert. Hence, only ignore unused typedefs in Release
-  # mode.
+  # There are many places in the library where we
+  #  - create a new typedef and then only use it in an Assert.
+  #  - use a function parameter only in an Assert.
+  # Thus disable these two warnings in release mode.
   #
   enable_if_supported(DEAL_II_CXX_FLAGS_RELEASE "-Wno-unused-local-typedefs")
+  enable_if_supported(DEAL_II_CXX_FLAGS_RELEASE "-Wno-unused-parameter")
 endif()
 
 

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1665,14 +1665,16 @@ namespace deal_II_exceptions
  * We accomplish this by using decltype(...) and create a dummy pointer
  * with these signatures.
  */
-#  define Assert(cond, exc)                                                    \
-    do                                                                         \
-      {                                                                        \
-        typename std::remove_reference<decltype(cond)>::type *dealii_assert_a; \
-        typename std::remove_reference<decltype(exc)>::type  *dealii_assert_b; \
-        (void)dealii_assert_a;                                                 \
-        (void)dealii_assert_b;                                                 \
-      }                                                                        \
+#  define Assert(cond, exc)                                  \
+    do                                                       \
+      {                                                      \
+        typename std::remove_reference<decltype(cond)>::type \
+          *dealii_assert_variable_a = nullptr;               \
+        typename std::remove_reference<decltype(exc)>::type  \
+          *dealii_assert_variable_b = nullptr;               \
+        (void)dealii_assert_variable_a;                      \
+        (void)dealii_assert_variable_b;                      \
+      }                                                      \
     while (false)
 
 #endif /*ifdef DEBUG*/

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1659,24 +1659,31 @@ namespace deal_II_exceptions
 #    endif /*ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST*/
 #  endif   /*KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST*/
 #else      /*ifdef DEBUG*/
+#  ifdef DEAL_II_HAVE_CXX20
 /*
  * In order to avoid unused parameters (etc.) warnings we need to use cond
  * and exc without actually evaluating the expression and generating code.
  * We accomplish this by using decltype(...) and create a dummy pointer
- * with these signatures.
+ * with these signatures. Notably, this approach works with C++20 onwards.
  */
-#  define Assert(cond, exc)                                  \
-    do                                                       \
-      {                                                      \
-        typename std::remove_reference<decltype(cond)>::type \
-          *dealii_assert_variable_a = nullptr;               \
-        typename std::remove_reference<decltype(exc)>::type  \
-          *dealii_assert_variable_b = nullptr;               \
-        (void)dealii_assert_variable_a;                      \
-        (void)dealii_assert_variable_b;                      \
-      }                                                      \
-    while (false)
-
+#    define Assert(cond, exc)                                  \
+      do                                                       \
+        {                                                      \
+          typename std::remove_reference<decltype(cond)>::type \
+            *dealii_assert_variable_a = nullptr;               \
+          typename std::remove_reference<decltype(exc)>::type  \
+            *dealii_assert_variable_b = nullptr;               \
+          (void)dealii_assert_variable_a;                      \
+          (void)dealii_assert_variable_b;                      \
+        }                                                      \
+      while (false)
+#  else
+#    define Assert(cond, exc) \
+      do                      \
+        {                     \
+        }                     \
+      while (false)
+#  endif
 #endif /*ifdef DEBUG*/
 
 


### PR DESCRIPTION
The CI only ever runs in debug mode. So testing the `Assert()` changes only on the CI was a bad idea.

I will run this quickly on the tester-tng variant of the regression testsuite.

In reference to #17523
