### PR TITLE
Update some uses of [[maybe unused]]

### DIFF
--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -728,7 +728,7 @@ namespace
     typename internal::p4est::types<dim>::quadrant *quadrant,
     int /* rank_begin */,
     int /* rank_end */,
-    [[maybe_unused]] void * /* this is always nullptr */ point)
+    void * /* this is always nullptr */ point)
   {
     // point must be nullptr here
     Assert(point == nullptr, dealii::ExcInternalError());
@@ -1849,9 +1849,8 @@ namespace parallel
     template <int dim, int spacedim>
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     void Triangulation<dim, spacedim>::create_triangulation(
-      [[maybe_unused]] const TriangulationDescription::Description<dim,
-                                                                   spacedim>
-        &construction_data)
+      const TriangulationDescription::Description<dim, spacedim>
+        & /*construction_data*/)
     {
       DEAL_II_ASSERT_UNREACHABLE();
     }
@@ -2647,8 +2646,7 @@ namespace parallel
         // There must not be any chains!
         for (unsigned int i = 0; i < topological_vertex_numbering.size(); ++i)
           {
-            [[maybe_unused]] const unsigned int j =
-              topological_vertex_numbering[i];
+            const unsigned int j = topological_vertex_numbering[i];
             Assert(j == i || topological_vertex_numbering[j] == j,
                    ExcMessage("Got inconclusive constraints with chain: " +
                               std::to_string(i) + " vs " + std::to_string(j) +
@@ -3140,8 +3138,7 @@ namespace parallel
       // stores locally (in the future we should check that we have exactly as
       // many non-artificial cells as parallel_forest->local_num_quadrants)
       {
-        [[maybe_unused]] const unsigned int total_local_cells =
-          this->n_active_cells();
+        const unsigned int total_local_cells = this->n_active_cells();
 
 
         if (Utilities::MPI::n_mpi_processes(this->mpi_communicator) == 1)

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -2007,9 +2007,9 @@ namespace internal
 
       // count the number of objects, of unused single objects and of
       // unused pairs of objects
-      [[maybe_unused]] unsigned int n_quads          = 0;
-      unsigned int                  n_unused_pairs   = 0;
-      unsigned int                  n_unused_singles = 0;
+      unsigned int n_quads          = 0;
+      unsigned int n_unused_pairs   = 0;
+      unsigned int n_unused_singles = 0;
       for (unsigned int i = 0; i < tria_faces.quads.used.size(); ++i)
         {
           if (tria_faces.quads.used[i])
@@ -2196,8 +2196,8 @@ namespace internal
      * should be called from the functions of the higher TriaLevel classes.
      */
     void
-    monitor_memory([[maybe_unused]] const TriaLevel   &tria_level,
-                   [[maybe_unused]] const unsigned int true_dimension)
+    monitor_memory(const TriaLevel   &tria_level,
+                   const unsigned int true_dimension)
     {
       Assert(2 * true_dimension * tria_level.refine_flags.size() ==
                tria_level.neighbors.size(),
@@ -2238,9 +2238,9 @@ namespace internal
 
           // count the number of objects, of unused single objects and of
           // unused pairs of objects
-          [[maybe_unused]] unsigned int n_objects        = 0;
-          unsigned int                  n_unused_pairs   = 0;
-          unsigned int                  n_unused_singles = 0;
+          unsigned int n_objects        = 0;
+          unsigned int n_unused_pairs   = 0;
+          unsigned int n_unused_singles = 0;
           for (unsigned int i = 0; i < tria_objects.used.size(); ++i)
             {
               if (tria_objects.used[i])


### PR DESCRIPTION
This updates the changes of #17497 and #17487 with the changes done in #17524. We do not need the attribute anymore, because in debug mode the variables are used and in release mode the unused variable warning is disabled.

@tjhei or @tamiko take a look at how I handled the one case that was not covered by the changes to Assert, do you agree with this approach?