### PR TITLE
MPI sum: Do not invoke MPI function for MPI_COMM_SELF

### DIFF
--- a/include/deal.II/base/mpi.templates.h
+++ b/include/deal.II/base/mpi.templates.h
@@ -142,12 +142,17 @@ namespace Utilities
     T
     sum(const T &t, const MPI_Comm mpi_communicator)
     {
-      T return_value{};
-      internal::all_reduce(MPI_SUM,
-                           ArrayView<const T>(&t, 1),
-                           mpi_communicator,
-                           ArrayView<T>(&return_value, 1));
-      return return_value;
+      if (mpi_communicator == MPI_COMM_SELF)
+        return t;
+      else
+        {
+          T return_value{};
+          internal::all_reduce(MPI_SUM,
+                               ArrayView<const T>(&t, 1),
+                               mpi_communicator,
+                               ArrayView<T>(&return_value, 1));
+          return return_value;
+        }
     }
 
 
@@ -174,7 +179,11 @@ namespace Utilities
         const MPI_Comm            mpi_communicator,
         const ArrayView<T>       &sums)
     {
-      internal::all_reduce(MPI_SUM, values, mpi_communicator, sums);
+      if (mpi_communicator == MPI_COMM_SELF)
+        for (unsigned int i = 0; i < values.size(); ++i)
+          sums[i] = values[i];
+      else
+        internal::all_reduce(MPI_SUM, values, mpi_communicator, sums);
     }
 
 


### PR DESCRIPTION
Looking at a small-scale linear algebra function, I realized that our `Utilities::MPI::sum` functions would always call into MPI functions, which cost a few hundreds to thousands of instructions. When we have the simple `MPI_COMM_SELF` communicator, we do not need that.