### PR TITLE
Fix typo: residuum -> residual

### DIFF
--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -3579,7 +3579,7 @@ namespace internal
           temp_vector1.reinit(rhs, true);
           temp_vector2.reinit(rhs, true);
 
-          // 1) compute rediduum (including operator application)
+          // 1) compute residual (including operator application)
           matrix.vmult(
             temp_vector1,
             solution,


### PR DESCRIPTION
The mathematical term is 'residual' in the English language, 'residuum' refers to something else (as opposed to the German word 'Residuum').