### PR TITLE
Fix some unused warnings.

### DIFF
--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -233,7 +233,7 @@ namespace Utilities
       auto deleter = [](MPI_Datatype *p) {
         if (p != nullptr)
           {
-            const int ierr = MPI_Type_free(p);
+            [[maybe_unused]] const int ierr = MPI_Type_free(p);
 
             AssertNothrow(ierr == MPI_SUCCESS, ExcMPI(ierr));
 
@@ -255,13 +255,10 @@ namespace Utilities
       const unsigned int myid    = Utilities::MPI::this_mpi_process(mpi_comm);
       const unsigned int n_procs = Utilities::MPI::n_mpi_processes(mpi_comm);
 
-
-
+#  ifdef DEBUG
       for (const unsigned int destination : destinations)
-        {
-          AssertIndexRange(destination, n_procs);
-        }
-
+        AssertIndexRange(destination, n_procs);
+#  endif
 
       // Have a little function that checks if destinations provided
       // to the current process are unique. The way it does this is
@@ -393,6 +390,7 @@ namespace Utilities
           const unsigned int n_procs =
             Utilities::MPI::n_mpi_processes(mpi_comm);
 
+#  ifdef DEBUG
           for (const unsigned int destination : destinations)
             {
               AssertIndexRange(destination, n_procs);
@@ -400,6 +398,7 @@ namespace Utilities
                      ExcMessage(
                        "There is no point in communicating with ourselves."));
             }
+#  endif
 
           // Calculate the number of messages to send to each process
           std::vector<unsigned int> dest_vector(n_procs);


### PR DESCRIPTION
```
/dealii/source/base/mpi.cc: In lambda function:
/dealii/source/base/mpi.cc:236:23: warning: unused variable ‘ierr’ [-Wunused-variable]
  236 |             const int ierr = MPI_Type_free(p);
      |                       ^~~~
/dealii/source/base/mpi.cc: In function ‘std::vector<unsigned int> dealii::Utilities::MPI::compute_point_to_point_communication_pattern(MPI_Comm, const std::vector<unsigned int>&)’:
/dealii/source/base/mpi.cc:260:31: warning: unused variable ‘destination’ [-Wunused-variable]
  260 |       for (const unsigned int destination : destinations)
      |                               ^~~~~~~~~~~
/dealii/source/base/mpi.cc: In function ‘unsigned int dealii::Utilities::MPI::compute_n_point_to_point_communications(MPI_Comm, const std::vector<unsigned int>&)’:
/dealii/source/base/mpi.cc:396:35: warning: unused variable ‘destination’ [-Wunused-variable]
  396 |           for (const unsigned int destination : destinations)
      |                                   ^~~~~~~~~~~
```