### PR TITLE
Deprecate get_communicator() in favor of get_mpi_communicator().

### DIFF
--- a/examples/step-37/doc/results.dox
+++ b/examples/step-37/doc/results.dox
@@ -431,7 +431,7 @@ const IndexSet locally_relevant_dofs = DoFTools::extract_locally_relevant_dofs(d
 LinearAlgebra::distributed::Vector<double> copy_vec(solution);
 solution.reinit(dof_handler.locally_owned_dofs(),
                 locally_relevant_dofs,
-                triangulation.get_communicator());
+                triangulation.get_mpi_communicator());
 solution.copy_locally_owned_data_from(copy_vec);
 constraints.distribute(solution);
 solution.update_ghost_values();

--- a/examples/step-75/step-75.cc
+++ b/examples/step-75/step-75.cc
@@ -457,7 +457,7 @@ namespace Step75
 
         TrilinosWrappers::SparsityPattern dsp(
           dof_handler.locally_owned_dofs(),
-          dof_handler.get_triangulation().get_communicator());
+          dof_handler.get_triangulation().get_mpi_communicator());
 
         DoFTools::make_sparsity_pattern(dof_handler, dsp, this->constraints);
 

--- a/examples/step-87/step-87.cc
+++ b/examples/step-87/step-87.cc
@@ -1106,7 +1106,7 @@ namespace Step87
   {
     support_points.reinit(dof_handler.locally_owned_dofs(),
                           DoFTools::extract_locally_active_dofs(dof_handler),
-                          dof_handler.get_communicator());
+                          dof_handler.get_mpi_communicator());
 
     const auto &fe = dof_handler.get_fe();
 

--- a/examples/step-89/step-89.cc
+++ b/examples/step-89/step-89.cc
@@ -208,7 +208,7 @@ namespace Step89
 
       data_out.build_patches(mapping, degree, DataOut<dim>::curved_inner_cells);
       data_out.write_vtu_in_parallel(name_prefix + ".vtu",
-                                     dof_handler.get_communicator());
+                                     dof_handler.get_mpi_communicator());
     }
   } // namespace HelperFunctions
 
@@ -1180,7 +1180,7 @@ namespace Step89
                    (cell->vertex(1) - cell->vertex(0)).norm_square());
       h_local_min = std::sqrt(h_local_min);
       const double h_min =
-        Utilities::MPI::min(h_local_min, dof_handler.get_communicator());
+        Utilities::MPI::min(h_local_min, dof_handler.get_mpi_communicator());
 
       const double dt =
         cr * HelperFunctions::compute_dt_cfl(h_min, degree, speed_of_sound);

--- a/include/deal.II/base/mpi_remote_point_evaluation.h
+++ b/include/deal.II/base/mpi_remote_point_evaluation.h
@@ -721,10 +721,10 @@ namespace Utilities
       (void)sort_data;
 #else
       static CollectiveMutex      mutex;
-      CollectiveMutex::ScopedLock lock(mutex, tria->get_communicator());
+      CollectiveMutex::ScopedLock lock(mutex, tria->get_mpi_communicator());
 
       const unsigned int my_rank =
-        Utilities::MPI::this_mpi_process(tria->get_communicator());
+        Utilities::MPI::this_mpi_process(tria->get_mpi_communicator());
 
       // allocate memory for output and buffer
       output.resize(point_ptrs.back() * n_components);
@@ -809,7 +809,7 @@ namespace Utilities
               (send_ptrs[i + 1] - send_ptrs[i]) * n_components),
             send_ranks[i],
             internal::Tags::remote_point_evaluation,
-            tria->get_communicator(),
+            tria->get_mpi_communicator(),
             send_buffers_packed,
             send_requests);
         }
@@ -848,7 +848,7 @@ namespace Utilities
           MPI_Status status;
           int        ierr = MPI_Probe(MPI_ANY_SOURCE,
                                internal::Tags::remote_point_evaluation,
-                               tria->get_communicator(),
+                               tria->get_mpi_communicator(),
                                &status);
           AssertThrowMPI(ierr);
 
@@ -867,7 +867,7 @@ namespace Utilities
             (recv_ptrs[j + 1] - recv_ptrs[j]) * n_components);
 
           internal::recv_and_unpack(recv_buffer,
-                                    tria->get_communicator(),
+                                    tria->get_mpi_communicator(),
                                     status,
                                     recv_buffer_packed);
 
@@ -933,10 +933,10 @@ namespace Utilities
       (void)sort_data;
 #else
       static CollectiveMutex      mutex;
-      CollectiveMutex::ScopedLock lock(mutex, tria->get_communicator());
+      CollectiveMutex::ScopedLock lock(mutex, tria->get_mpi_communicator());
 
       const unsigned int my_rank =
-        Utilities::MPI::this_mpi_process(tria->get_communicator());
+        Utilities::MPI::this_mpi_process(tria->get_mpi_communicator());
 
       // allocate memory for buffer
       const auto &point_ptrs = this->get_point_ptrs();
@@ -1031,7 +1031,7 @@ namespace Utilities
               (recv_ptrs[i + 1] - recv_ptrs[i]) * n_components),
             recv_ranks[i],
             internal::Tags::remote_point_evaluation,
-            tria->get_communicator(),
+            tria->get_mpi_communicator(),
             send_buffers_packed,
             send_requests);
         }
@@ -1069,7 +1069,7 @@ namespace Utilities
           MPI_Status status;
           int        ierr = MPI_Probe(MPI_ANY_SOURCE,
                                internal::Tags::remote_point_evaluation,
-                               tria->get_communicator(),
+                               tria->get_mpi_communicator(),
                                &status);
           AssertThrowMPI(ierr);
 
@@ -1089,7 +1089,7 @@ namespace Utilities
             (send_ptrs[j + 1] - send_ptrs[j]) * n_components);
 
           internal::recv_and_unpack(recv_buffer,
-                                    tria->get_communicator(),
+                                    tria->get_mpi_communicator(),
                                     status,
                                     recv_buffer_packed);
 

--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -97,7 +97,7 @@ namespace parallel
      * Return MPI communicator used by this triangulation.
      */
     virtual MPI_Comm
-    get_communicator() const override;
+    get_mpi_communicator() const override;
 
     /**
      * Return if multilevel hierarchy is supported and has been constructed.

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -1218,6 +1218,16 @@ public:
    * Return MPI communicator used by the underlying triangulation.
    */
   MPI_Comm
+  get_mpi_communicator() const;
+
+  /**
+   * Return MPI communicator used by the underlying triangulation.
+   *
+   * @deprecated Use get_mpi_communicator() instead.
+   */
+  DEAL_II_DEPRECATED_EARLY_WITH_COMMENT(
+    "Access the MPI communicator with get_mpi_communicator() instead.")
+  MPI_Comm
   get_communicator() const;
 
   /**
@@ -1909,12 +1919,21 @@ inline const Triangulation<dim, spacedim>
 
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-inline MPI_Comm DoFHandler<dim, spacedim>::get_communicator() const
+inline MPI_Comm DoFHandler<dim, spacedim>::get_mpi_communicator() const
 {
   Assert(tria != nullptr,
          ExcMessage("This DoFHandler object has not been associated "
                     "with a triangulation."));
-  return tria->get_communicator();
+  return tria->get_mpi_communicator();
+}
+
+
+
+template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+inline MPI_Comm DoFHandler<dim, spacedim>::get_communicator() const
+{
+  return get_mpi_communicator();
 }
 
 

--- a/include/deal.II/fe/fe_tools_extrapolate.templates.h
+++ b/include/deal.II/fe/fe_tools_extrapolate.templates.h
@@ -1335,7 +1335,7 @@ namespace FETools
         ExcMessage(
           "Extrapolate in parallel only works for parallel distributed triangulations!"));
 
-      communicator = tr->get_communicator();
+      communicator = tr->get_mpi_communicator();
 
       compute_all_non_local_data(dof2, u2_relevant);
 
@@ -1492,7 +1492,7 @@ namespace FETools
       Assert(parallel_tria != nullptr, ExcNotImplemented());
 
       const IndexSet &locally_owned_dofs = dh.locally_owned_dofs();
-      vector.reinit(locally_owned_dofs, parallel_tria->get_communicator());
+      vector.reinit(locally_owned_dofs, parallel_tria->get_mpi_communicator());
     }
 #endif // DEAL_II_WITH_PETSC
 
@@ -1509,7 +1509,7 @@ namespace FETools
       Assert(parallel_tria != nullptr, ExcNotImplemented());
 
       const IndexSet &locally_owned_dofs = dh.locally_owned_dofs();
-      vector.reinit(locally_owned_dofs, parallel_tria->get_communicator());
+      vector.reinit(locally_owned_dofs, parallel_tria->get_mpi_communicator());
     }
 
 
@@ -1528,7 +1528,7 @@ namespace FETools
       Assert(parallel_tria != nullptr, ExcNotImplemented());
 
       const IndexSet &locally_owned_dofs = dh.locally_owned_dofs();
-      vector.reinit(locally_owned_dofs, parallel_tria->get_communicator());
+      vector.reinit(locally_owned_dofs, parallel_tria->get_mpi_communicator());
     }
 #    endif
 
@@ -1544,7 +1544,7 @@ namespace FETools
       Assert(parallel_tria != nullptr, ExcNotImplemented());
 
       const IndexSet &locally_owned_dofs = dh.locally_owned_dofs();
-      vector.reinit(locally_owned_dofs, parallel_tria->get_communicator());
+      vector.reinit(locally_owned_dofs, parallel_tria->get_mpi_communicator());
     }
 #  endif
 #endif // DEAL_II_WITH_TRILINOS
@@ -1561,7 +1561,7 @@ namespace FETools
       Assert(parallel_tria != nullptr, ExcNotImplemented());
 
       const IndexSet &locally_owned_dofs = dh.locally_owned_dofs();
-      vector.reinit(locally_owned_dofs, parallel_tria->get_communicator());
+      vector.reinit(locally_owned_dofs, parallel_tria->get_mpi_communicator());
     }
 
 
@@ -1589,7 +1589,7 @@ namespace FETools
         DoFTools::extract_locally_relevant_dofs(dh);
       vector.reinit(locally_owned_dofs,
                     locally_relevant_dofs,
-                    parallel_tria->get_communicator());
+                    parallel_tria->get_mpi_communicator());
     }
 #endif // DEAL_II_WITH_PETSC
 
@@ -1609,7 +1609,7 @@ namespace FETools
         DoFTools::extract_locally_relevant_dofs(dh);
       vector.reinit(locally_owned_dofs,
                     locally_relevant_dofs,
-                    parallel_tria->get_communicator());
+                    parallel_tria->get_mpi_communicator());
     }
 #endif // DEAL_II_WITH_TRILINOS
 
@@ -1628,7 +1628,7 @@ namespace FETools
         DoFTools::extract_locally_relevant_dofs(dh);
       vector.reinit(locally_owned_dofs,
                     locally_relevant_dofs,
-                    parallel_tria->get_communicator());
+                    parallel_tria->get_mpi_communicator());
     }
 
 

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -3366,7 +3366,7 @@ namespace GridTools
       // a mutex:
       static Utilities::MPI::CollectiveMutex      mutex;
       Utilities::MPI::CollectiveMutex::ScopedLock lock(
-        mutex, tria->get_communicator());
+        mutex, tria->get_mpi_communicator());
 
       const int mpi_tag =
         Utilities::MPI::internal::Tags::exchange_cell_data_request;
@@ -3385,7 +3385,7 @@ namespace GridTools
                                        MPI_BYTE,
                                        it.first,
                                        mpi_tag,
-                                       tria->get_communicator(),
+                                       tria->get_mpi_communicator(),
                                        &requests[idx]);
             AssertThrowMPI(ierr);
             ++idx;
@@ -3401,7 +3401,7 @@ namespace GridTools
           MPI_Status status;
           int        ierr = MPI_Probe(MPI_ANY_SOURCE,
                                mpi_tag,
-                               tria->get_communicator(),
+                               tria->get_mpi_communicator(),
                                &status);
           AssertThrowMPI(ierr);
 
@@ -3424,7 +3424,7 @@ namespace GridTools
                           MPI_BYTE,
                           status.MPI_SOURCE,
                           status.MPI_TAG,
-                          tria->get_communicator(),
+                          tria->get_mpi_communicator(),
                           &status);
           AssertThrowMPI(ierr);
 
@@ -3477,7 +3477,7 @@ namespace GridTools
                            MPI_BYTE,
                            status.MPI_SOURCE,
                            mpi_tag_reply,
-                           tria->get_communicator(),
+                           tria->get_mpi_communicator(),
                            &reply_requests[idx]);
           AssertThrowMPI(ierr);
         }
@@ -3489,7 +3489,7 @@ namespace GridTools
           MPI_Status status;
           int        ierr = MPI_Probe(MPI_ANY_SOURCE,
                                mpi_tag_reply,
-                               tria->get_communicator(),
+                               tria->get_mpi_communicator(),
                                &status);
           AssertThrowMPI(ierr);
 
@@ -3504,7 +3504,7 @@ namespace GridTools
                           MPI_BYTE,
                           status.MPI_SOURCE,
                           status.MPI_TAG,
-                          tria->get_communicator(),
+                          tria->get_mpi_communicator(),
                           &status);
           AssertThrowMPI(ierr);
 

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1810,10 +1810,21 @@ public:
   clear();
 
   /**
-   * Return MPI communicator used by this triangulation. In the case of
-   * a serial Triangulation object, MPI_COMM_SELF is returned.
+   * Return the MPI communicator used by this triangulation. In the case of a
+   * serial Triangulation object, MPI_COMM_SELF is returned.
    */
   virtual MPI_Comm
+  get_mpi_communicator() const;
+
+  /**
+   * Return the MPI communicator used by this triangulation. In the case of
+   * a serial Triangulation object, MPI_COMM_SELF is returned.
+   *
+   * @deprecated Use get_mpi_communicator() instead.
+   */
+  DEAL_II_DEPRECATED_EARLY_WITH_COMMENT(
+    "Access the MPI communicator with get_mpi_communicator() instead.")
+  MPI_Comm
   get_communicator() const;
 
   /**

--- a/include/deal.II/matrix_free/face_setup_internal.h
+++ b/include/deal.II/matrix_free/face_setup_internal.h
@@ -296,7 +296,7 @@ namespace internal
               if (const dealii::parallel::TriangulationBase<dim> *ptria =
                     dynamic_cast<const dealii::parallel::TriangulationBase<dim>
                                    *>(&triangulation))
-                comm = ptria->get_communicator();
+                comm = ptria->get_mpi_communicator();
 
               MPI_Status   status;
               unsigned int mysize    = inner_face.second.shared_faces.size();

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -442,7 +442,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::internal_reinit(
       task_info.allow_ghosted_vectors_in_loops =
         additional_data.allow_ghosted_vectors_in_loops;
 
-      task_info.communicator    = dof_handler[0]->get_communicator();
+      task_info.communicator    = dof_handler[0]->get_mpi_communicator();
       task_info.communicator_sm = additional_data.communicator_sm;
       task_info.my_pid =
         Utilities::MPI::this_mpi_process(task_info.communicator);

--- a/include/deal.II/matrix_free/portable_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.templates.h
@@ -449,7 +449,7 @@ namespace Portable
                       quad,
                       iterator_filter,
                       std::make_shared<const MPI_Comm>(
-                        parallel_triangulation->get_communicator()),
+                        parallel_triangulation->get_mpi_communicator()),
                       additional_data);
     else
       internal_reinit(mapping,

--- a/include/deal.II/multigrid/mg_transfer.h
+++ b/include/deal.II/multigrid/mg_transfer.h
@@ -83,7 +83,7 @@ namespace internal
            const SparsityPatternType       &sp,
            const DoFHandler<dim, spacedim> &dh)
     {
-      const MPI_Comm communicator = dh.get_communicator();
+      const MPI_Comm communicator = dh.get_mpi_communicator();
 
       matrix.reinit(dh.locally_owned_mg_dofs(level + 1),
                     dh.locally_owned_mg_dofs(level),
@@ -109,7 +109,7 @@ namespace internal
            const SparsityPatternType       &sp,
            const DoFHandler<dim, spacedim> &dh)
     {
-      const MPI_Comm communicator = dh.get_communicator();
+      const MPI_Comm communicator = dh.get_mpi_communicator();
 
       matrix.reinit(dh.locally_owned_mg_dofs(level + 1),
                     dh.locally_owned_mg_dofs(level),
@@ -137,7 +137,7 @@ namespace internal
            const SparsityPatternType       &sp,
            const DoFHandler<dim, spacedim> &dh)
     {
-      const MPI_Comm communicator = dh.get_communicator();
+      const MPI_Comm communicator = dh.get_mpi_communicator();
 
       matrix.reinit(dh.locally_owned_mg_dofs(level + 1),
                     dh.locally_owned_mg_dofs(level),
@@ -164,7 +164,7 @@ namespace internal
            const SparsityPatternType       &sp,
            const DoFHandler<dim, spacedim> &dh)
     {
-      const MPI_Comm communicator = dh.get_communicator();
+      const MPI_Comm communicator = dh.get_mpi_communicator();
 
       matrix.reinit(dh.locally_owned_mg_dofs(level + 1),
                     dh.locally_owned_mg_dofs(level),
@@ -220,7 +220,7 @@ namespace internal
            const SparsityPatternType       &sp,
            const DoFHandler<dim, spacedim> &dh)
     {
-      const MPI_Comm communicator = dh.get_communicator();
+      const MPI_Comm communicator = dh.get_mpi_communicator();
 
       // Reinit PETSc matrix
       matrix.reinit(dh.locally_owned_mg_dofs(level + 1),

--- a/include/deal.II/multigrid/mg_transfer.templates.h
+++ b/include/deal.II/multigrid/mg_transfer.templates.h
@@ -129,7 +129,7 @@ namespace internal
       for (unsigned int level = v.min_level(); level <= v.max_level(); ++level)
         {
           v[level].reinit(dof_handler.locally_owned_mg_dofs(level),
-                          tria->get_communicator());
+                          tria->get_mpi_communicator());
         }
     }
 #endif
@@ -157,7 +157,7 @@ namespace internal
       for (unsigned int level = v.min_level(); level <= v.max_level(); ++level)
         {
           v[level].reinit(dof_handler.locally_owned_mg_dofs(level),
-                          tria->get_communicator());
+                          tria->get_mpi_communicator());
         }
     }
 #endif
@@ -216,7 +216,7 @@ MGLevelGlobalTransfer<VectorType>::copy_to_mg(
   internal::MGTransfer::reinit_vector(dof_handler, component_to_block_map, dst);
 #ifdef DEBUG_OUTPUT
   std::cout << "copy_to_mg src " << src.l2_norm() << std::endl;
-  int ierr = MPI_Barrier(dof_handler.get_communicator());
+  int ierr = MPI_Barrier(dof_handler.get_mpi_communicator());
   AssertThrowMPI(ierr);
 #endif
 
@@ -236,7 +236,7 @@ MGLevelGlobalTransfer<VectorType>::copy_to_mg(
     {
       --level;
 #ifdef DEBUG_OUTPUT
-      ierr = MPI_Barrier(dof_handler.get_communicator());
+      ierr = MPI_Barrier(dof_handler.get_mpi_communicator());
       AssertThrowMPI(ierr);
 #endif
 
@@ -257,7 +257,7 @@ MGLevelGlobalTransfer<VectorType>::copy_to_mg(
       dst_level.compress(VectorOperation::insert);
 
 #ifdef DEBUG_OUTPUT
-      ierr = MPI_Barrier(dof_handler.get_communicator());
+      ierr = MPI_Barrier(dof_handler.get_mpi_communicator());
       AssertThrowMPI(ierr);
       std::cout << "copy_to_mg dst " << level << ' ' << dst_level.l2_norm()
                 << std::endl;
@@ -295,11 +295,11 @@ MGLevelGlobalTransfer<VectorType>::copy_from_mg(
   for (unsigned int level = src.min_level(); level <= src.max_level(); ++level)
     {
 #ifdef DEBUG_OUTPUT
-      int ierr = MPI_Barrier(dof_handler.get_communicator());
+      int ierr = MPI_Barrier(dof_handler.get_mpi_communicator());
       AssertThrowMPI(ierr);
       std::cout << "copy_from_mg src " << level << ' ' << src[level].l2_norm()
                 << std::endl;
-      ierr = MPI_Barrier(dof_handler.get_communicator());
+      ierr = MPI_Barrier(dof_handler.get_mpi_communicator());
       AssertThrowMPI(ierr);
 #endif
 
@@ -320,7 +320,7 @@ MGLevelGlobalTransfer<VectorType>::copy_from_mg(
 #ifdef DEBUG_OUTPUT
       {
         dst.compress(VectorOperation::insert);
-        ierr = MPI_Barrier(dof_handler.get_communicator());
+        ierr = MPI_Barrier(dof_handler.get_mpi_communicator());
         AssertThrowMPI(ierr);
         std::cout << "copy_from_mg level=" << level << ' ' << dst.l2_norm()
                   << std::endl;
@@ -329,7 +329,7 @@ MGLevelGlobalTransfer<VectorType>::copy_from_mg(
     }
   dst.compress(VectorOperation::insert);
 #ifdef DEBUG_OUTPUT
-  const int ierr = MPI_Barrier(dof_handler.get_communicator());
+  const int ierr = MPI_Barrier(dof_handler.get_mpi_communicator());
   AssertThrowMPI(ierr);
   std::cout << "copy_from_mg " << dst.l2_norm() << std::endl;
 #endif
@@ -445,7 +445,7 @@ MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<Number>>::copy_to_mg(
           dst[level].reinit(ghosted_level_vector[level], false);
         else
           dst[level].reinit(dof_handler.locally_owned_mg_dofs(level),
-                            dof_handler.get_communicator());
+                            dof_handler.get_mpi_communicator());
       }
     else if ((perform_plain_copy == false &&
               perform_renumbered_plain_copy == false) ||

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -806,7 +806,8 @@ namespace internal
       , dof_handler_coarse(dof_handler_coarse)
       , mg_level_fine(mg_level_fine)
       , communicator(
-          dof_handler_fine.get_communicator() /*TODO: fix for different comms*/)
+          dof_handler_fine
+            .get_mpi_communicator() /*TODO: fix for different comms*/)
       , cell_id_translator(
           dof_handler_fine.get_triangulation().n_global_coarse_cells(),
           dof_handler_fine.get_triangulation().n_global_levels())
@@ -1457,7 +1458,8 @@ namespace internal
           });
 
         return Utilities::MPI::min(static_cast<unsigned int>(flag),
-                                   dof_handler_fine.get_communicator()) == 1;
+                                   dof_handler_fine.get_mpi_communicator()) ==
+               1;
       }
     else
       {
@@ -1620,7 +1622,7 @@ namespace internal
           dof_handler_coarse.locally_owned_dofs() :
           dof_handler_coarse.locally_owned_mg_dofs(mg_level_coarse),
         locally_relevant_dofs,
-        dof_handler_coarse.get_communicator());
+        dof_handler_coarse.get_mpi_communicator());
     }
 
 
@@ -1691,9 +1693,9 @@ namespace internal
                                    cell->active_fe_index());
         });
 
-      const auto comm = dof_handler_fine.get_communicator();
+      const auto comm = dof_handler_fine.get_mpi_communicator();
 
-      Assert(comm == dof_handler_coarse.get_communicator(),
+      Assert(comm == dof_handler_coarse.get_mpi_communicator(),
              ExcNotImplemented());
 
       ArrayView<unsigned int> temp_min(min_active_fe_indices);
@@ -2022,11 +2024,11 @@ namespace internal
 
       {
         transfer.partitioner_coarse = transfer.constraint_info_coarse.finalize(
-          dof_handler_coarse.get_communicator());
+          dof_handler_coarse.get_mpi_communicator());
         transfer.vec_coarse.reinit(transfer.partitioner_coarse);
 
         transfer.partitioner_fine = transfer.constraint_info_fine.finalize(
-          dof_handler_fine.get_communicator());
+          dof_handler_fine.get_mpi_communicator());
         transfer.vec_fine.reinit(transfer.partitioner_fine);
       }
 
@@ -2583,11 +2585,11 @@ namespace internal
 
       {
         transfer.partitioner_coarse = transfer.constraint_info_coarse.finalize(
-          dof_handler_coarse.get_communicator());
+          dof_handler_coarse.get_mpi_communicator());
         transfer.vec_coarse.reinit(transfer.partitioner_coarse);
 
         transfer.partitioner_fine = transfer.constraint_info_fine.finalize(
-          dof_handler_fine.get_communicator());
+          dof_handler_fine.get_mpi_communicator());
         transfer.vec_fine.reinit(transfer.partitioner_fine);
       }
 
@@ -2795,7 +2797,7 @@ namespace MGTransferGlobalCoarseningTools
             &fine_triangulation_in))
         return std::make_shared<
           parallel::distributed::Triangulation<dim, spacedim>>(
-          fine_triangulation->get_communicator());
+          fine_triangulation->get_mpi_communicator());
       else
 #endif
 #ifdef DEAL_II_WITH_MPI
@@ -2803,7 +2805,7 @@ namespace MGTransferGlobalCoarseningTools
               const parallel::shared::Triangulation<dim, spacedim> *>(
               &fine_triangulation_in))
         return std::make_shared<parallel::shared::Triangulation<dim, spacedim>>(
-          fine_triangulation->get_communicator(),
+          fine_triangulation->get_mpi_communicator(),
           Triangulation<dim, spacedim>::none,
           fine_triangulation->with_artificial_cells());
       else
@@ -2865,7 +2867,7 @@ namespace MGTransferGlobalCoarseningTools
 
     Assert(fine_triangulation, ExcNotImplemented());
 
-    const auto comm = fine_triangulation->get_communicator();
+    const auto comm = fine_triangulation->get_mpi_communicator();
 
     if (keep_fine_triangulation == true &&
         repartition_fine_triangulation == false)
@@ -3957,7 +3959,7 @@ MGTwoLevelTransfer<dim, VectorType>::reinit(
                                 IteratorFilters::LocallyOwnedCell())
         is_locally_owned_coarse.add_index(cell_id_translator.translate(cell));
 
-      const MPI_Comm communicator = dof_handler_fine.get_communicator();
+      const MPI_Comm communicator = dof_handler_fine.get_mpi_communicator();
 
       std::vector<unsigned int> owning_ranks(
         is_locally_owned_coarse.n_elements());
@@ -4452,7 +4454,7 @@ MGTransferMF<dim, Number>::fill_and_communicate_copy_indices_global_coarsening(
 
   this->perform_plain_copy =
     Utilities::MPI::max(this->perform_plain_copy ? 1 : 0,
-                        dof_handler_out.get_communicator()) != 0;
+                        dof_handler_out.get_mpi_communicator()) != 0;
 
   if (this->perform_plain_copy)
     {
@@ -5009,12 +5011,12 @@ namespace internal
 
         const Utilities::MPI::Partitioner partitioner_support_points(
           dof_handler_support_points.locally_owned_dofs(),
-          dof_handler_support_points.get_communicator());
+          dof_handler_support_points.get_mpi_communicator());
 
         const Utilities::MPI::Partitioner partitioner_dof(
           dof_handler.locally_owned_dofs(),
           DoFTools::extract_locally_relevant_dofs(dof_handler),
-          dof_handler.get_communicator());
+          dof_handler.get_mpi_communicator());
 
         std::vector<bool> dof_processed(partitioner_dof.locally_owned_size() +
                                           partitioner_dof.n_ghost_indices(),
@@ -5324,7 +5326,7 @@ MGTwoLevelTransferNonNested<dim, VectorType>::reinit(
     this->partitioner_fine.reset(
       new Utilities::MPI::Partitioner(dof_handler_fine.locally_owned_dofs(),
                                       locally_relevant_dofs,
-                                      dof_handler_fine.get_communicator()));
+                                      dof_handler_fine.get_mpi_communicator()));
 
     this->vec_fine.reinit(this->partitioner_fine);
   }

--- a/include/deal.II/multigrid/multigrid.h
+++ b/include/deal.II/multigrid/multigrid.h
@@ -915,7 +915,7 @@ PreconditionMG<dim, VectorType, TransferType>::get_mpi_communicator() const
   const parallel::TriangulationBase<dim> *ptria =
     dynamic_cast<const parallel::TriangulationBase<dim> *>(&tria);
   Assert(ptria != nullptr, ExcInternalError());
-  return ptria->get_communicator();
+  return ptria->get_mpi_communicator();
 }
 
 

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -920,7 +920,7 @@ namespace internal
 
             dst.block(b).reinit(locally_owned_dofs_b[b],
                                 locally_relevant_dofs_b[b],
-                                dof_handler.get_communicator());
+                                dof_handler.get_mpi_communicator());
             copy_locally_owned_data_from(src.block(b), dst.block(b));
           }
 
@@ -966,7 +966,7 @@ namespace internal
 
         dst.block(0).reinit(locally_owned_dofs,
                             locally_relevant_dofs,
-                            dof_handler.get_communicator());
+                            dof_handler.get_mpi_communicator());
         copy_locally_owned_data_from(src, dst.block(0));
 
         dst.collect_sizes();

--- a/include/deal.II/numerics/vector_tools_integrate_difference.templates.h
+++ b/include/deal.II/numerics/vector_tools_integrate_difference.templates.h
@@ -669,7 +669,7 @@ namespace VectorTools
     }
 #endif
 
-    const MPI_Comm comm = tria.get_communicator();
+    const MPI_Comm comm = tria.get_mpi_communicator();
 
     switch (norm)
       {

--- a/include/deal.II/numerics/vector_tools_interpolate.templates.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.templates.h
@@ -1075,7 +1075,7 @@ namespace VectorTools
 
       u.reinit(locally_owned_dofs,
                locally_relevant_dofs,
-               dof_handler.get_communicator());
+               dof_handler.get_mpi_communicator());
     }
 
 

--- a/include/deal.II/numerics/vector_tools_mean_value.templates.h
+++ b/include/deal.II/numerics/vector_tools_mean_value.templates.h
@@ -353,7 +353,7 @@ namespace VectorTools
                                        3,
                                        MPI_DOUBLE,
                                        MPI_SUM,
-                                       p_triangulation->get_communicator());
+                                       p_triangulation->get_mpi_communicator());
         AssertThrowMPI(ierr);
 
         internal::set_possibly_complex_number(global_values[0],

--- a/include/deal.II/sundials/n_vector.templates.h
+++ b/include/deal.II/sundials/n_vector.templates.h
@@ -401,7 +401,7 @@ namespace SUNDIALS
 
       template <typename VectorType>
       const MPI_Comm &
-      get_communicator(N_Vector v);
+      get_mpi_communicator(N_Vector v);
 
 #  if DEAL_II_SUNDIALS_VERSION_GTE(7, 0, 0)
       /**
@@ -409,7 +409,7 @@ namespace SUNDIALS
        */
       template <typename VectorType>
       inline SUNComm
-      get_communicator_by_value(N_Vector v);
+      get_mpi_communicator_by_value(N_Vector v);
 #  else
       /**
        * Sundials likes a void* but we want to use the above functions
@@ -417,7 +417,7 @@ namespace SUNDIALS
        */
       template <typename VectorType>
       inline void *
-      get_communicator_as_void_ptr(N_Vector v);
+      get_mpi_communicator_as_void_ptr(N_Vector v);
 #  endif
     } // namespace NVectorOperations
   }   // namespace internal
@@ -726,7 +726,7 @@ namespace SUNDIALS
 
       template <typename VectorType>
       const MPI_Comm &
-      get_communicator(N_Vector v)
+      get_mpi_communicator(N_Vector v)
       {
         Assert(v != nullptr, ExcInternalError());
         Assert(v->content != nullptr, ExcInternalError());
@@ -740,7 +740,7 @@ namespace SUNDIALS
 #  if DEAL_II_SUNDIALS_VERSION_GTE(7, 0, 0)
       template <typename VectorType>
       SUNComm
-      get_communicator_by_value(N_Vector v)
+      get_mpi_communicator_by_value(N_Vector v)
       {
 #    ifndef DEAL_II_WITH_MPI
         (void)v;
@@ -753,7 +753,7 @@ namespace SUNDIALS
           //
           // Further, we need to cast away const here, as SUNDIALS demands the
           // communicator by value.
-          return const_cast<SUNComm>(get_communicator<VectorType>(v));
+          return const_cast<SUNComm>(get_mpi_communicator<VectorType>(v));
         else
           return SUN_COMM_NULL;
 #    endif
@@ -761,7 +761,7 @@ namespace SUNDIALS
 #  else
       template <typename VectorType>
       void *
-      get_communicator_as_void_ptr(N_Vector v)
+      get_mpi_communicator_as_void_ptr(N_Vector v)
       {
 #    ifndef DEAL_II_WITH_MPI
         (void)v;
@@ -770,7 +770,7 @@ namespace SUNDIALS
         if (is_serial_vector<VectorType>::value == false)
           // We need to cast away const here, as SUNDIALS demands a pure
           // `void*`.
-          return &(const_cast<MPI_Comm &>(get_communicator<VectorType>(v)));
+          return &(const_cast<MPI_Comm &>(get_mpi_communicator<VectorType>(v)));
         else
           return nullptr;
 #    endif
@@ -899,7 +899,7 @@ namespace SUNDIALS
       {
         ArrayView<realtype> products(d, nv);
         Utilities::MPI::sum(products,
-                            get_communicator<VectorType>(x),
+                            get_mpi_communicator<VectorType>(x),
                             products);
         return 0;
       }
@@ -1047,7 +1047,7 @@ namespace SUNDIALS
                                                  local_elements.end(),
                                                  indexed_less_than);
         return Utilities::MPI::min((*vector)[local_min],
-                                   get_communicator<VectorType>(x));
+                                   get_mpi_communicator<VectorType>(x));
       }
 
 
@@ -1087,7 +1087,7 @@ namespace SUNDIALS
           }
 
         return Utilities::MPI::min(proc_local_min,
-                                   get_communicator<VectorType>(x));
+                                   get_mpi_communicator<VectorType>(x));
       }
 
 
@@ -1272,10 +1272,10 @@ namespace SUNDIALS
       //  v->ops->nvspace           = undef;
 #  if DEAL_II_SUNDIALS_VERSION_GTE(7, 0, 0)
       v->ops->nvgetcommunicator =
-        &NVectorOperations::get_communicator_by_value<VectorType>;
+        &NVectorOperations::get_mpi_communicator_by_value<VectorType>;
 #  else
       v->ops->nvgetcommunicator =
-        &NVectorOperations::get_communicator_as_void_ptr<VectorType>;
+        &NVectorOperations::get_mpi_communicator_as_void_ptr<VectorType>;
 #  endif
       v->ops->nvgetlength = &NVectorOperations::get_global_length<VectorType>;
 

--- a/source/base/mpi_remote_point_evaluation.cc
+++ b/source/base/mpi_remote_point_evaluation.cc
@@ -186,7 +186,7 @@ namespace Utilities
       const auto n_owning_processes_global =
         Utilities::MPI::all_reduce<std::tuple<unsigned int, unsigned int>>(
           n_owning_processes_local,
-          tria.get_communicator(),
+          tria.get_mpi_communicator(),
           [&](const auto &a,
               const auto &b) -> std::tuple<unsigned int, unsigned int> {
             if (a == n_owning_processes_default)

--- a/source/distributed/grid_refinement.cc
+++ b/source/distributed/grid_refinement.cc
@@ -220,7 +220,7 @@ namespace
     Vector<Number> locally_owned_indicators(n_locally_owned_active_cells(tria));
     get_locally_owned_indicators(tria, criteria, locally_owned_indicators);
 
-    MPI_Comm mpi_communicator = tria.get_communicator();
+    MPI_Comm mpi_communicator = tria.get_mpi_communicator();
 
     // figure out the global max and min of the indicators. we don't need it
     // here, but it's a collective communication call
@@ -532,7 +532,7 @@ namespace parallel
           n_locally_owned_active_cells(tria));
         get_locally_owned_indicators(tria, criteria, locally_owned_indicators);
 
-        MPI_Comm mpi_communicator = tria.get_communicator();
+        MPI_Comm mpi_communicator = tria.get_mpi_communicator();
 
         // figure out the global max and min of the indicators. we don't need it
         // here, but it's a collective communication call

--- a/source/distributed/repartitioning_policy_tools.cc
+++ b/source/distributed/repartitioning_policy_tools.cc
@@ -71,7 +71,7 @@ namespace RepartitioningPolicyTools
     return {};
 #else
 
-    const auto comm = tria->get_communicator();
+    const auto comm = tria->get_mpi_communicator();
 
     const unsigned int process_has_active_locally_owned_cells =
       tria->n_locally_owned_active_cells() > 0;
@@ -134,7 +134,7 @@ namespace RepartitioningPolicyTools
   FirstChildPolicy<dim, spacedim>::partition(
     const Triangulation<dim, spacedim> &tria_coarse_in) const
   {
-    const auto communicator = tria_coarse_in.get_communicator();
+    const auto communicator = tria_coarse_in.get_mpi_communicator();
 
     const internal::CellIDTranslator<dim> cell_id_translator(n_coarse_cells,
                                                              n_global_levels);
@@ -212,7 +212,7 @@ namespace RepartitioningPolicyTools
                       tria_in.end()),
                     [](const auto &cell) { return cell.is_locally_owned(); });
 
-    const auto comm = tria_in.get_communicator();
+    const auto comm = tria_in.get_mpi_communicator();
 
     if (Utilities::MPI::min(n_locally_owned_active_cells, comm) >= n_min_cells)
       return {}; // all processes have enough cells
@@ -289,7 +289,7 @@ namespace RepartitioningPolicyTools
 
     std::vector<unsigned int> weights(partitioner->locally_owned_size());
 
-    const auto mpi_communicator = tria_in.get_communicator();
+    const auto mpi_communicator = tria_in.get_mpi_communicator();
     const auto n_subdomains = Utilities::MPI::n_mpi_processes(mpi_communicator);
 
     // determine weight of each cell
@@ -307,7 +307,7 @@ namespace RepartitioningPolicyTools
     // weight
     const auto [process_local_weight_offset, total_weight] =
       Utilities::MPI::partial_and_total_sum(process_local_weight,
-                                            tria->get_communicator());
+                                            tria->get_mpi_communicator());
 
     // set up partition
     LinearAlgebra::distributed::Vector<double> partition(partitioner);

--- a/source/distributed/shared_tria.cc
+++ b/source/distributed/shared_tria.cc
@@ -90,7 +90,8 @@ namespace parallel
       // Check that all meshes are the same (or at least have the same
       // total number of active cells):
       const unsigned int max_active_cells =
-        Utilities::MPI::max(this->n_active_cells(), this->get_communicator());
+        Utilities::MPI::max(this->n_active_cells(),
+                            this->get_mpi_communicator());
       Assert(
         max_active_cells == this->n_active_cells(),
         ExcMessage(
@@ -293,7 +294,7 @@ namespace parallel
           [](const auto &i) { return (i.is_locally_owned()); });
 
         const unsigned int total_cells =
-          Utilities::MPI::sum(n_my_cells, this->get_communicator());
+          Utilities::MPI::sum(n_my_cells, this->get_mpi_communicator());
         Assert(total_cells == this->n_active_cells(),
                ExcMessage("Not all cells are assigned to a processor."));
       }
@@ -309,7 +310,7 @@ namespace parallel
 
 
           const unsigned int total_cells =
-            Utilities::MPI::sum(n_my_cells, this->get_communicator());
+            Utilities::MPI::sum(n_my_cells, this->get_mpi_communicator());
           Assert(total_cells == this->n_cells(),
                  ExcMessage("Not all cells are assigned to a processor."));
         }
@@ -387,7 +388,7 @@ namespace parallel
             }
 
         Utilities::MPI::max(refinement_configurations,
-                            this->get_communicator(),
+                            this->get_mpi_communicator(),
                             refinement_configurations);
 
         for (const auto &cell : this->active_cell_iterators())

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -3447,7 +3447,7 @@ namespace parallel
             this->local_cell_relations,
             this->cell_attached_data.pack_callbacks_fixed,
             this->cell_attached_data.pack_callbacks_variable,
-            this->get_communicator());
+            this->get_mpi_communicator());
         }
 
       // finally copy back from local part of tree to deal.II
@@ -3621,7 +3621,7 @@ namespace parallel
             this->local_cell_relations,
             this->cell_attached_data.pack_callbacks_fixed,
             this->cell_attached_data.pack_callbacks_variable,
-            this->get_communicator());
+            this->get_mpi_communicator());
         }
 
       try

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -157,7 +157,7 @@ namespace parallel
 
   template <int dim, int spacedim>
   DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-  MPI_Comm TriangulationBase<dim, spacedim>::get_communicator() const
+  MPI_Comm TriangulationBase<dim, spacedim>::get_mpi_communicator() const
   {
     return mpi_communicator;
   }

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -1292,7 +1292,7 @@ namespace internal
                     cell->active_fe_index();
 
               Utilities::MPI::sum(active_fe_indices,
-                                  tr->get_communicator(),
+                                  tr->get_mpi_communicator(),
                                   active_fe_indices);
 
               // now go back and fill the active FE index on all other
@@ -1393,7 +1393,7 @@ namespace internal
                     .hp_cell_future_fe_indices[cell->level()][cell->index()];
 
               Utilities::MPI::sum(future_fe_indices,
-                                  tr->get_communicator(),
+                                  tr->get_mpi_communicator(),
                                   future_fe_indices);
 
               for (const auto &cell : dof_handler.active_cell_iterators())

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -2889,7 +2889,7 @@ namespace internal
         Assert(tr != nullptr, ExcInternalError());
 
         const unsigned int n_procs =
-          Utilities::MPI::n_mpi_processes(tr->get_communicator());
+          Utilities::MPI::n_mpi_processes(tr->get_mpi_communicator());
 
         // If an underlying shared::Tria allows artificial cells, we need to
         // restore the true cell owners temporarily.
@@ -3040,7 +3040,7 @@ namespace internal
                       "is set in the constructor."));
 
         const unsigned int n_procs =
-          Utilities::MPI::n_mpi_processes(tr->get_communicator());
+          Utilities::MPI::n_mpi_processes(tr->get_mpi_communicator());
         const unsigned int n_levels = tr->n_global_levels();
 
         std::vector<NumberCache> number_caches;
@@ -3252,7 +3252,7 @@ namespace internal
         Utilities::MPI::internal::all_reduce<bool>(
           MPI_LAND,
           ArrayView<const bool>(&uses_sequential_numbering, 1),
-          tr->get_communicator(),
+          tr->get_mpi_communicator(),
           ArrayView<bool>(&all_use_sequential_numbering, 1));
         if (all_use_sequential_numbering)
           {
@@ -3264,10 +3264,11 @@ namespace internal
                      this->dof_handler->locally_owned_dofs().n_elements(),
                    ExcInternalError());
             const unsigned int n_cpu =
-              Utilities::MPI::n_mpi_processes(tr->get_communicator());
+              Utilities::MPI::n_mpi_processes(tr->get_mpi_communicator());
             std::vector<types::global_dof_index> gathered_new_numbers(
               this->dof_handler->n_dofs(), 0);
-            Assert(Utilities::MPI::this_mpi_process(tr->get_communicator()) ==
+            Assert(Utilities::MPI::this_mpi_process(
+                     tr->get_mpi_communicator()) ==
                      this->dof_handler->get_triangulation()
                        .locally_owned_subdomain(),
                    ExcInternalError());
@@ -3290,7 +3291,7 @@ namespace internal
                                        rcounts.data(),
                                        1,
                                        MPI_INT,
-                                       tr->get_communicator());
+                                       tr->get_mpi_communicator());
               AssertThrowMPI(ierr);
 
               // compute the displacements (relative to recvbuf)
@@ -3304,7 +3305,7 @@ namespace internal
               Assert(new_numbers_copy.size() ==
                        static_cast<unsigned int>(
                          rcounts[Utilities::MPI::this_mpi_process(
-                           tr->get_communicator())]),
+                           tr->get_mpi_communicator())]),
                      ExcInternalError());
               ierr = MPI_Allgatherv(new_numbers_copy.data(),
                                     new_numbers_copy.size(),
@@ -3313,7 +3314,7 @@ namespace internal
                                     rcounts.data(),
                                     displacements.data(),
                                     DEAL_II_DOF_INDEX_MPI_TYPE,
-                                    tr->get_communicator());
+                                    tr->get_mpi_communicator());
               AssertThrowMPI(ierr);
             }
 
@@ -3327,7 +3328,7 @@ namespace internal
             std::vector<unsigned int> flag_2(this->dof_handler->n_dofs(), 0);
             std::vector<IndexSet>     locally_owned_dofs_per_processor =
               Utilities::MPI::all_gather(
-                tr->get_communicator(),
+                tr->get_mpi_communicator(),
                 this->dof_handler->locally_owned_dofs());
             for (unsigned int i = 0; i < n_cpu; ++i)
               {
@@ -3695,7 +3696,7 @@ namespace internal
         //                    range of indices
         const auto [my_shift, n_global_dofs] =
           Utilities::MPI::partial_and_total_sum(
-            n_locally_owned_dofs, triangulation->get_communicator());
+            n_locally_owned_dofs, triangulation->get_mpi_communicator());
 
 
         // make dof indices globally consecutive
@@ -3892,7 +3893,7 @@ namespace internal
             const auto [my_shift, n_global_dofs] =
               Utilities::MPI::partial_and_total_sum(
                 level_number_cache.n_locally_owned_dofs,
-                triangulation->get_communicator());
+                triangulation->get_mpi_communicator());
             level_number_cache.n_global_dofs = n_global_dofs;
 
             // assign appropriate indices

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -680,7 +680,7 @@ namespace DoFRenumbering
     // If we don't have a renumbering (i.e., when there is 1 component) then
     // return
     if (Utilities::MPI::max(renumbering.size(),
-                            dof_handler.get_communicator()) == 0)
+                            dof_handler.get_mpi_communicator()) == 0)
       return;
 
     // verify that the last numbered
@@ -726,7 +726,7 @@ namespace DoFRenumbering
     // If we don't have a renumbering (i.e., when there is 1 component) then
     // return
     if (Utilities::MPI::max(renumbering.size(),
-                            dof_handler.get_communicator()) == 0)
+                            dof_handler.get_mpi_communicator()) == 0)
       return;
 
     // verify that the last numbered
@@ -936,12 +936,12 @@ namespace DoFRenumbering
                                     n_buckets,
                                     DEAL_II_DOF_INDEX_MPI_TYPE,
                                     MPI_SUM,
-                                    tria->get_communicator());
+                                    tria->get_mpi_communicator());
         AssertThrowMPI(ierr);
 
         std::vector<types::global_dof_index> global_dof_count(n_buckets);
         Utilities::MPI::sum(local_dof_count,
-                            tria->get_communicator(),
+                            tria->get_mpi_communicator(),
                             global_dof_count);
 
         // calculate shifts
@@ -1055,7 +1055,7 @@ namespace DoFRenumbering
            ExcInternalError());
 
     if (Utilities::MPI::max(renumbering.size(),
-                            dof_handler.get_communicator()) > 0)
+                            dof_handler.get_mpi_communicator()) > 0)
       dof_handler.renumber_dofs(level, renumbering);
   }
 
@@ -1197,12 +1197,12 @@ namespace DoFRenumbering
                                     n_buckets,
                                     DEAL_II_DOF_INDEX_MPI_TYPE,
                                     MPI_SUM,
-                                    tria->get_communicator());
+                                    tria->get_mpi_communicator());
         AssertThrowMPI(ierr);
 
         std::vector<types::global_dof_index> global_dof_count(n_buckets);
         Utilities::MPI::sum(local_dof_count,
-                            tria->get_communicator(),
+                            tria->get_mpi_communicator(),
                             global_dof_count);
 
         // calculate shifts
@@ -1389,7 +1389,7 @@ namespace DoFRenumbering
                                     1,
                                     DEAL_II_DOF_INDEX_MPI_TYPE,
                                     MPI_SUM,
-                                    tria->get_communicator());
+                                    tria->get_mpi_communicator());
         AssertThrowMPI(ierr);
 #endif
       }
@@ -2262,7 +2262,7 @@ namespace DoFRenumbering
     // If there is only one component then there is nothing to do, so check
     // first:
     if (Utilities::MPI::max(renumbering.size(),
-                            dof_handler.get_communicator()) > 0)
+                            dof_handler.get_mpi_communicator()) > 0)
       dof_handler.renumber_dofs(renumbering);
   }
 

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -1557,7 +1557,7 @@ namespace DoFTools
          Utilities::MPI::n_mpi_processes(
            dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
              &dof_handler.get_triangulation())
-             ->get_communicator()));
+             ->get_mpi_communicator()));
     Assert(n_subdomains > *std::max_element(subdomain_association.begin(),
                                             subdomain_association.end()),
            ExcInternalError());
@@ -2089,7 +2089,7 @@ namespace DoFTools
                                        n_target_components,
                                        DEAL_II_DOF_INDEX_MPI_TYPE,
                                        MPI_SUM,
-                                       tria->get_communicator());
+                                       tria->get_mpi_communicator());
         AssertThrowMPI(ierr);
       }
 #endif
@@ -2177,7 +2177,7 @@ namespace DoFTools
                                            n_target_blocks,
                                            DEAL_II_DOF_INDEX_MPI_TYPE,
                                            MPI_SUM,
-                                           tria->get_communicator());
+                                           tria->get_mpi_communicator());
             AssertThrowMPI(ierr);
           }
 #endif

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -4135,7 +4135,7 @@ namespace DoFTools
                                          TriangulationBase<dim, spacedim> &>(
                     coarse_to_fine_grid_map.get_destination_grid()
                       .get_triangulation());
-                communicator          = tria.get_communicator();
+                communicator          = tria.get_mpi_communicator();
                 is_called_in_parallel = true;
               }
             catch (std::bad_cast &)

--- a/source/fe/mapping_q_cache.cc
+++ b/source/fe/mapping_q_cache.cc
@@ -317,7 +317,7 @@ MappingQCache<dim, spacedim>::initialize(
     DoFTools::extract_locally_relevant_dofs(dof_handler);
   vector_ghosted.reinit(dof_handler.locally_owned_dofs(),
                         locally_relevant_dofs,
-                        dof_handler.get_communicator());
+                        dof_handler.get_mpi_communicator());
   copy_locally_owned_data_from(vector, vector_ghosted);
   vector_ghosted.update_ghost_values();
 
@@ -521,7 +521,7 @@ MappingQCache<dim, spacedim>::initialize(
         DoFTools::extract_locally_relevant_level_dofs(dof_handler, l);
       vectors_ghosted[l].reinit(dof_handler.locally_owned_mg_dofs(l),
                                 locally_relevant_dofs,
-                                dof_handler.get_communicator());
+                                dof_handler.get_mpi_communicator());
       copy_locally_owned_data_from(vectors[l], vectors_ghosted[l]);
       vectors_ghosted[l].update_ghost_values();
     }

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -3683,7 +3683,7 @@ GridOut::write_mesh_per_processor_as_vtu(
           else
             pos += 1;
           const unsigned int n_procs =
-            Utilities::MPI::n_mpi_processes(tr->get_communicator());
+            Utilities::MPI::n_mpi_processes(tr->get_mpi_communicator());
           for (unsigned int i = 0; i < n_procs; ++i)
             filenames.push_back(filename_without_extension.substr(pos) +
                                 ".proc" + Utilities::int_to_string(i, 4) +

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -1525,8 +1525,8 @@ namespace GridTools
       }
 
     // Get the size of the largest CellID string
-    max_cellid_size =
-      Utilities::MPI::max(max_cellid_size, triangulation.get_communicator());
+    max_cellid_size = Utilities::MPI::max(max_cellid_size,
+                                          triangulation.get_mpi_communicator());
 
     // Make indices global by getting the number of vertices owned by each
     // processors and shifting the indices accordingly
@@ -1536,7 +1536,7 @@ namespace GridTools
                           1,
                           DEAL_II_VERTEX_INDEX_MPI_TYPE,
                           MPI_SUM,
-                          triangulation.get_communicator());
+                          triangulation.get_mpi_communicator());
     AssertThrowMPI(ierr);
 
     for (auto &global_index_it : local_to_global_vertex_index)
@@ -1587,7 +1587,7 @@ namespace GridTools
                          DEAL_II_VERTEX_INDEX_MPI_TYPE,
                          destination,
                          mpi_tag,
-                         triangulation.get_communicator(),
+                         triangulation.get_mpi_communicator(),
                          &first_requests[i]);
         AssertThrowMPI(ierr);
       }
@@ -1612,7 +1612,7 @@ namespace GridTools
                         DEAL_II_VERTEX_INDEX_MPI_TYPE,
                         source,
                         mpi_tag,
-                        triangulation.get_communicator(),
+                        triangulation.get_mpi_communicator(),
                         MPI_STATUS_IGNORE);
         AssertThrowMPI(ierr);
       }
@@ -1658,7 +1658,7 @@ namespace GridTools
                          MPI_CHAR,
                          destination,
                          mpi_tag2,
-                         triangulation.get_communicator(),
+                         triangulation.get_mpi_communicator(),
                          &second_requests[i]);
         AssertThrowMPI(ierr);
       }
@@ -1681,7 +1681,7 @@ namespace GridTools
                         MPI_CHAR,
                         source,
                         mpi_tag2,
-                        triangulation.get_communicator(),
+                        triangulation.get_mpi_communicator(),
                         MPI_STATUS_IGNORE);
         AssertThrowMPI(ierr);
       }
@@ -1780,7 +1780,7 @@ namespace GridTools
               dynamic_cast<parallel::shared::Triangulation<dim, spacedim> *>(
                 &triangulation))
           Utilities::MPI::sum(cell_weights,
-                              shared_tria->get_communicator(),
+                              shared_tria->get_mpi_communicator(),
                               cell_weights);
 
         // verify that the global sum of weights is larger than 0
@@ -1880,7 +1880,7 @@ namespace GridTools
               dynamic_cast<parallel::shared::Triangulation<dim, spacedim> *>(
                 &triangulation))
           Utilities::MPI::sum(cell_weights,
-                              shared_tria->get_communicator(),
+                              shared_tria->get_mpi_communicator(),
                               cell_weights);
 
         // verify that the global sum of weights is larger than 0
@@ -2161,7 +2161,7 @@ namespace GridTools
                 cell_id.get_coarse_cell_id(),
                 &p4est_cell,
                 Utilities::MPI::this_mpi_process(
-                  triangulation.get_communicator()));
+                  triangulation.get_mpi_communicator()));
 
             Assert(owner >= 0, ExcMessage("p4est should know the owner."));
 
@@ -3745,7 +3745,7 @@ namespace GridTools
         &cache.get_locally_owned_cell_bounding_boxes_rtree());
 
       const unsigned int my_rank = Utilities::MPI::this_mpi_process(
-        cache.get_triangulation().get_communicator());
+        cache.get_triangulation().get_mpi_communicator());
 
       cell_hint = first_cell.first;
       if (cell_hint.state() == IteratorState::valid)
@@ -3934,7 +3934,7 @@ namespace GridTools
       auto &send_components = result.send_components;
       auto &recv_components = result.recv_components;
 
-      const auto comm = cache.get_triangulation().get_communicator();
+      const auto comm = cache.get_triangulation().get_mpi_communicator();
 
       const auto potential_owners = internal::guess_owners_of_entities(
         comm, global_bboxes, points, tolerance);
@@ -4155,7 +4155,7 @@ namespace GridTools
 
           // indices assigned at recv side needed to fill send_components
           indices_of_rank = communicate_indices(result.recv_components,
-                                                tria.get_communicator());
+                                                tria.get_mpi_communicator());
         }
 
       for (const auto &send_component : send_components)
@@ -4324,7 +4324,7 @@ namespace GridTools
           structdim,
           spacedim>::IntersectionType;
 
-      const auto comm = cache.get_triangulation().get_communicator();
+      const auto comm = cache.get_triangulation().get_mpi_communicator();
 
       DistributedComputeIntersectionLocationsInternal<structdim, spacedim>
         result;

--- a/source/grid/grid_tools_cache.cc
+++ b/source/grid/grid_tools_cache.cc
@@ -286,7 +286,7 @@ namespace GridTools
                 &(*tria)))
           {
             covering_rtree[level] = GridTools::build_global_description_tree(
-              boxes, tria_mpi->get_communicator());
+              boxes, tria_mpi->get_mpi_communicator());
           }
         else
           {

--- a/source/grid/grid_tools_geometry.cc
+++ b/source/grid/grid_tools_geometry.cc
@@ -150,7 +150,7 @@ namespace GridTools
         }
 
     const double global_volume =
-      Utilities::MPI::sum(local_volume, triangulation.get_communicator());
+      Utilities::MPI::sum(local_volume, triangulation.get_mpi_communicator());
 
     return global_volume;
   }
@@ -413,7 +413,7 @@ namespace GridTools
         min_diameter = std::min(min_diameter, cell->diameter(mapping));
 
     const double global_min_diameter =
-      Utilities::MPI::min(min_diameter, triangulation.get_communicator());
+      Utilities::MPI::min(min_diameter, triangulation.get_mpi_communicator());
     return global_min_diameter;
   }
 
@@ -430,7 +430,7 @@ namespace GridTools
         max_diameter = std::max(max_diameter, cell->diameter(mapping));
 
     const double global_max_diameter =
-      Utilities::MPI::max(max_diameter, triangulation.get_communicator());
+      Utilities::MPI::max(max_diameter, triangulation.get_mpi_communicator());
     return global_max_diameter;
   }
 } /* namespace GridTools */

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -12135,9 +12135,18 @@ void Triangulation<dim, spacedim>::clear()
 
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-MPI_Comm Triangulation<dim, spacedim>::get_communicator() const
+MPI_Comm Triangulation<dim, spacedim>::get_mpi_communicator() const
 {
   return MPI_COMM_SELF;
+}
+
+
+
+template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+MPI_Comm Triangulation<dim, spacedim>::get_communicator() const
+{
+  return get_mpi_communicator();
 }
 
 
@@ -15760,7 +15769,7 @@ void Triangulation<dim, spacedim>::pack_data_serial()
         this->local_cell_relations,
         this->cell_attached_data.pack_callbacks_fixed,
         this->cell_attached_data.pack_callbacks_variable,
-        this->get_communicator());
+        this->get_mpi_communicator());
 
       // dummy copy of data
       this->data_serializer.dest_data_fixed =
@@ -16252,13 +16261,13 @@ void Triangulation<dim, spacedim>::save_attached_data(
         tria->local_cell_relations,
         tria->cell_attached_data.pack_callbacks_fixed,
         tria->cell_attached_data.pack_callbacks_variable,
-        this->get_communicator());
+        this->get_mpi_communicator());
 
       // then store buffers in file
       tria->data_serializer.save(global_first_cell,
                                  global_num_cells,
                                  file_basename,
-                                 this->get_communicator());
+                                 this->get_mpi_communicator());
 
       // and release the memory afterwards
       tria->data_serializer.clear();
@@ -16293,7 +16302,7 @@ void Triangulation<dim, spacedim>::load_attached_data(
                                  file_basename,
                                  n_attached_deserialize_fixed,
                                  n_attached_deserialize_variable,
-                                 this->get_communicator());
+                                 this->get_mpi_communicator());
 
       this->data_serializer.unpack_cell_status(this->local_cell_relations);
 

--- a/source/grid/tria_description.cc
+++ b/source/grid/tria_description.cc
@@ -724,7 +724,7 @@ namespace TriangulationDescription
             dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
               &tria))
         {
-          Assert(comm == ptria->get_communicator(),
+          Assert(comm == ptria->get_mpi_communicator(),
                  ExcMessage("MPI communicators do not match."));
           Assert(my_rank_in == numbers::invalid_unsigned_int ||
                    my_rank_in == dealii::Utilities::MPI::this_mpi_process(comm),
@@ -1013,16 +1013,15 @@ namespace TriangulationDescription
       const TriangulationDescription::Settings settings_in)
     {
 #ifdef DEAL_II_WITH_MPI
-      if (tria.get_communicator() == MPI_COMM_NULL)
+      if (tria.get_mpi_communicator() == MPI_COMM_NULL)
         AssertDimension(partition.locally_owned_size(), 0);
 #endif
 
       if (partition.size() == 0)
         {
           AssertDimension(partitions_mg.size(), 0);
-          return create_description_from_triangulation(tria,
-                                                       tria.get_communicator(),
-                                                       settings_in);
+          return create_description_from_triangulation(
+            tria, tria.get_mpi_communicator(), settings_in);
         }
 
       // Update partitioner ghost elements because we will later want
@@ -1141,7 +1140,7 @@ namespace TriangulationDescription
             mg_cell_to_future_owner,
             coinciding_vertex_groups,
             vertex_to_coinciding_vertex_group,
-            tria.get_communicator(),
+            tria.get_mpi_communicator(),
             rank,
             settings));
 

--- a/source/hp/refinement.cc
+++ b/source/hp/refinement.cc
@@ -208,16 +208,16 @@ namespace hp
         {
           max_criterion_refine =
             Utilities::MPI::max(max_criterion_refine,
-                                parallel_tria->get_communicator());
+                                parallel_tria->get_mpi_communicator());
           min_criterion_refine =
             Utilities::MPI::min(min_criterion_refine,
-                                parallel_tria->get_communicator());
+                                parallel_tria->get_mpi_communicator());
           max_criterion_coarsen =
             Utilities::MPI::max(max_criterion_coarsen,
-                                parallel_tria->get_communicator());
+                                parallel_tria->get_mpi_communicator());
           min_criterion_coarsen =
             Utilities::MPI::min(min_criterion_coarsen,
-                                parallel_tria->get_communicator());
+                                parallel_tria->get_mpi_communicator());
         }
 
       // Absent any better strategies, we will set the threshold by linear
@@ -332,7 +332,7 @@ namespace hp
           // parallel implementation with distributed memory
           //
 
-          MPI_Comm mpi_communicator = parallel_tria->get_communicator();
+          MPI_Comm mpi_communicator = parallel_tria->get_mpi_communicator();
 
           // 2.) Communicate the number of cells scheduled for p-adaptation
           //     globally.
@@ -1038,7 +1038,7 @@ namespace hp
 
           levels_changed_in_cycle =
             Utilities::MPI::logical_or(levels_changed_in_cycle,
-                                       dof_handler.get_communicator());
+                                       dof_handler.get_mpi_communicator());
           levels_changed |= levels_changed_in_cycle;
         }
       while (levels_changed_in_cycle);

--- a/source/multigrid/mg_level_global_transfer.cc
+++ b/source/multigrid/mg_level_global_transfer.cc
@@ -85,8 +85,9 @@ MGLevelGlobalTransfer<VectorType>::fill_and_communicate_copy_indices(
   if (const parallel::TriangulationBase<dim, spacedim> *ptria =
         dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
           &mg_dof.get_triangulation()))
-    perform_plain_copy = (Utilities::MPI::min(my_perform_plain_copy ? 1 : 0,
-                                              ptria->get_communicator()) == 1);
+    perform_plain_copy =
+      (Utilities::MPI::min(my_perform_plain_copy ? 1 : 0,
+                           ptria->get_mpi_communicator()) == 1);
   else
     perform_plain_copy = my_perform_plain_copy;
 }
@@ -280,7 +281,7 @@ void
 MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<Number>>::
   fill_and_communicate_copy_indices(const DoFHandler<dim, spacedim> &mg_dof)
 {
-  const MPI_Comm mpi_communicator = mg_dof.get_communicator();
+  const MPI_Comm mpi_communicator = mg_dof.get_mpi_communicator();
 
   fill_internal(mg_dof,
                 mg_constrained_dofs,

--- a/source/multigrid/mg_tools.cc
+++ b/source/multigrid/mg_tools.cc
@@ -1548,7 +1548,7 @@ namespace MGTools
     if (const parallel::TriangulationBase<dim, spacedim> *tr =
           dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
             &tria))
-      global_min = Utilities::MPI::min(min_level, tr->get_communicator());
+      global_min = Utilities::MPI::min(min_level, tr->get_mpi_communicator());
 
     AssertIndexRange(global_min, tria.n_global_levels());
 
@@ -1674,7 +1674,7 @@ namespace MGTools
   workload_imbalance(const Triangulation<dim, spacedim> &tria)
   {
     return internal::workload_imbalance(local_workload(tria),
-                                        tria.get_communicator());
+                                        tria.get_mpi_communicator());
   }
 
 
@@ -1686,7 +1686,7 @@ namespace MGTools
       &trias)
   {
     return internal::workload_imbalance(local_workload(trias),
-                                        trias.back()->get_communicator());
+                                        trias.back()->get_mpi_communicator());
   }
 
 
@@ -1700,7 +1700,7 @@ namespace MGTools
     std::vector<std::pair<types::global_dof_index, types::global_dof_index>>
       cells(n_global_levels);
 
-    const MPI_Comm communicator = tria.get_communicator();
+    const MPI_Comm communicator = tria.get_mpi_communicator();
 
     const unsigned int my_rank = Utilities::MPI::this_mpi_process(communicator);
 
@@ -1736,7 +1736,7 @@ namespace MGTools
     std::vector<std::pair<types::global_dof_index, types::global_dof_index>>
       cells(n_global_levels);
 
-    const MPI_Comm communicator = trias.back()->get_communicator();
+    const MPI_Comm communicator = trias.back()->get_mpi_communicator();
 
     const unsigned int my_rank = Utilities::MPI::this_mpi_process(communicator);
 
@@ -1805,7 +1805,7 @@ namespace MGTools
   vertical_communication_efficiency(const Triangulation<dim, spacedim> &tria)
   {
     return internal::vertical_communication_efficiency(
-      local_vertical_communication_cost(tria), tria.get_communicator());
+      local_vertical_communication_cost(tria), tria.get_mpi_communicator());
   }
 
 
@@ -1818,7 +1818,7 @@ namespace MGTools
   {
     return internal::vertical_communication_efficiency(
       local_vertical_communication_cost(trias),
-      trias.back()->get_communicator());
+      trias.back()->get_mpi_communicator());
   }
 
 } // namespace MGTools

--- a/source/multigrid/mg_transfer_internal.cc
+++ b/source/multigrid/mg_transfer_internal.cc
@@ -207,7 +207,7 @@ namespace internal
 
 #ifdef DEAL_II_WITH_MPI
       if (tria && Utilities::MPI::sum(send_data_temp.size(),
-                                      tria->get_communicator()) > 0)
+                                      tria->get_mpi_communicator()) > 0)
         {
           const std::set<types::subdomain_id> &neighbors =
             tria->level_ghost_owners();
@@ -262,10 +262,8 @@ namespace internal
               AssertThrow(level_dof_indices.size() == is_ghost.n_elements(),
                           ExcMessage("Size does not match!"));
 
-              const auto index_owner =
-                Utilities::MPI::compute_index_owner(owned_level_dofs,
-                                                    is_ghost,
-                                                    tria->get_communicator());
+              const auto index_owner = Utilities::MPI::compute_index_owner(
+                owned_level_dofs, is_ghost, tria->get_mpi_communicator());
 
               AssertThrow(level_dof_indices.size() == index_owner.size(),
                           ExcMessage("Size does not match!"));
@@ -280,7 +278,7 @@ namespace internal
           // Protect the send/recv logic with a mutex:
           static Utilities::MPI::CollectiveMutex      mutex;
           Utilities::MPI::CollectiveMutex::ScopedLock lock(
-            mutex, tria->get_communicator());
+            mutex, tria->get_mpi_communicator());
 
           const int mpi_tag =
             Utilities::MPI::internal::Tags::mg_transfer_fill_copy_indices;
@@ -299,7 +297,7 @@ namespace internal
                             MPI_BYTE,
                             dest,
                             mpi_tag,
-                            tria->get_communicator(),
+                            tria->get_mpi_communicator(),
                             &*requests.rbegin());
                 AssertThrowMPI(ierr);
               }
@@ -315,7 +313,7 @@ namespace internal
                 MPI_Status status;
                 int        ierr = MPI_Probe(MPI_ANY_SOURCE,
                                      mpi_tag,
-                                     tria->get_communicator(),
+                                     tria->get_mpi_communicator(),
                                      &status);
                 AssertThrowMPI(ierr);
                 int len;
@@ -329,7 +327,7 @@ namespace internal
                                     MPI_BYTE,
                                     status.MPI_SOURCE,
                                     status.MPI_TAG,
-                                    tria->get_communicator(),
+                                    tria->get_mpi_communicator(),
                                     &status);
                     AssertThrowMPI(ierr);
                     continue;
@@ -346,7 +344,7 @@ namespace internal
                                 MPI_BYTE,
                                 status.MPI_SOURCE,
                                 status.MPI_TAG,
-                                tria->get_communicator(),
+                                tria->get_mpi_communicator(),
                                 &status);
                 AssertThrowMPI(ierr);
 
@@ -371,7 +369,7 @@ namespace internal
           // Make sure in debug mode, that everybody sent/received all packages
           // on this level. If a deadlock occurs here, the list of expected
           // senders is not computed correctly.
-          const int ierr = MPI_Barrier(tria->get_communicator());
+          const int ierr = MPI_Barrier(tria->get_mpi_communicator());
           AssertThrowMPI(ierr);
 #  endif
         }
@@ -923,7 +921,7 @@ namespace internal
                                    external_partitioners.empty() ?
                                      nullptr :
                                      external_partitioners[level],
-                                   tria.get_communicator(),
+                                   tria.get_mpi_communicator(),
                                    target_partitioners[level],
                                    copy_indices_global_mine[level]);
 
@@ -942,7 +940,7 @@ namespace internal
                                        external_partitioners.empty() ?
                                          nullptr :
                                          external_partitioners[0],
-                                       tria.get_communicator(),
+                                       tria.get_mpi_communicator(),
                                        target_partitioners[0],
                                        copy_indices_global_mine[0]);
 

--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -268,7 +268,7 @@ MGTransferPrebuilt<VectorType>::build(
           ::dealii::SparsityTools::distribute_sparsity_pattern(
             dsp,
             dof_handler.locally_owned_mg_dofs(level + 1),
-            dof_handler.get_communicator(),
+            dof_handler.get_mpi_communicator(),
             dsp.row_index_set());
         }
 #endif

--- a/source/particles/generators.cc
+++ b/source/particles/generators.cc
@@ -204,7 +204,7 @@ namespace Particles
                                       1,
                                       DEAL_II_PARTICLE_INDEX_MPI_TYPE,
                                       MPI_SUM,
-                                      tria->get_communicator());
+                                      tria->get_mpi_communicator());
           AssertThrowMPI(ierr);
         }
 #endif
@@ -287,7 +287,7 @@ namespace Particles
               &triangulation))
         {
           const unsigned int my_rank =
-            Utilities::MPI::this_mpi_process(tria->get_communicator());
+            Utilities::MPI::this_mpi_process(tria->get_mpi_communicator());
           combined_seed += my_rank;
         }
       std::mt19937 random_number_generator(combined_seed);
@@ -320,8 +320,8 @@ namespace Particles
                 &triangulation))
           {
             std::tie(local_start_weight, global_weight_integral) =
-              Utilities::MPI::partial_and_total_sum(local_weight_integral,
-                                                    tria->get_communicator());
+              Utilities::MPI::partial_and_total_sum(
+                local_weight_integral, tria->get_mpi_communicator());
           }
         else
           {

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -386,7 +386,7 @@ namespace Particles
 
     global_number_of_particles =
       dealii::Utilities::MPI::sum(number_of_locally_owned_particles,
-                                  triangulation->get_communicator());
+                                  triangulation->get_mpi_communicator());
 
     if (global_number_of_particles == 0)
       {
@@ -395,7 +395,9 @@ namespace Particles
       }
     else
       {
-        Utilities::MPI::max(result, triangulation->get_communicator(), result);
+        Utilities::MPI::max(result,
+                            triangulation->get_mpi_communicator(),
+                            result);
 
         next_free_particle_index      = result[1] + 1;
         global_max_particles_per_cell = result[0];
@@ -718,12 +720,13 @@ namespace Particles
             &*triangulation))
       {
         types::particle_index particles_to_add_locally = positions.size();
-        const int             ierr = MPI_Scan(&particles_to_add_locally,
-                                  &local_start_index,
-                                  1,
-                                  DEAL_II_PARTICLE_INDEX_MPI_TYPE,
-                                  MPI_SUM,
-                                  parallel_triangulation->get_communicator());
+        const int             ierr =
+          MPI_Scan(&particles_to_add_locally,
+                   &local_start_index,
+                   1,
+                   DEAL_II_PARTICLE_INDEX_MPI_TYPE,
+                   MPI_SUM,
+                   parallel_triangulation->get_mpi_communicator());
         AssertThrowMPI(ierr);
         local_start_index -= particles_to_add_locally;
       }
@@ -779,7 +782,7 @@ namespace Particles
     if (!ids.empty())
       AssertDimension(ids.size(), positions.size());
 
-    const auto comm = triangulation->get_communicator();
+    const auto comm = triangulation->get_mpi_communicator();
 
     const auto n_mpi_processes = Utilities::MPI::n_mpi_processes(comm);
 
@@ -1502,7 +1505,7 @@ namespace Particles
             &*triangulation))
       {
         if (dealii::Utilities::MPI::n_mpi_processes(
-              parallel_triangulation->get_communicator()) > 1)
+              parallel_triangulation->get_mpi_communicator()) > 1)
           send_recv_particles(moved_particles, moved_cells);
       }
 #endif
@@ -1540,7 +1543,7 @@ namespace Particles
     if (parallel_triangulation != nullptr)
       {
         if (dealii::Utilities::MPI::n_mpi_processes(
-              parallel_triangulation->get_communicator()) == 1)
+              parallel_triangulation->get_mpi_communicator()) == 1)
           return;
       }
     else
@@ -1647,7 +1650,7 @@ namespace Particles
         &*triangulation);
     if (parallel_triangulation == nullptr ||
         dealii::Utilities::MPI::n_mpi_processes(
-          parallel_triangulation->get_communicator()) == 1)
+          parallel_triangulation->get_mpi_communicator()) == 1)
       {
         return;
       }
@@ -1808,24 +1811,26 @@ namespace Particles
       std::vector<MPI_Request> n_requests(2 * n_neighbors);
       for (unsigned int i = 0; i < n_neighbors; ++i)
         {
-          const int ierr = MPI_Irecv(&(n_recv_data[i]),
-                                     1,
-                                     MPI_UNSIGNED,
-                                     neighbors[i],
-                                     mpi_tag,
-                                     parallel_triangulation->get_communicator(),
-                                     &(n_requests[2 * i]));
+          const int ierr =
+            MPI_Irecv(&(n_recv_data[i]),
+                      1,
+                      MPI_UNSIGNED,
+                      neighbors[i],
+                      mpi_tag,
+                      parallel_triangulation->get_mpi_communicator(),
+                      &(n_requests[2 * i]));
           AssertThrowMPI(ierr);
         }
       for (unsigned int i = 0; i < n_neighbors; ++i)
         {
-          const int ierr = MPI_Isend(&(n_send_data[i]),
-                                     1,
-                                     MPI_UNSIGNED,
-                                     neighbors[i],
-                                     mpi_tag,
-                                     parallel_triangulation->get_communicator(),
-                                     &(n_requests[2 * i + 1]));
+          const int ierr =
+            MPI_Isend(&(n_send_data[i]),
+                      1,
+                      MPI_UNSIGNED,
+                      neighbors[i],
+                      mpi_tag,
+                      parallel_triangulation->get_mpi_communicator(),
+                      &(n_requests[2 * i + 1]));
           AssertThrowMPI(ierr);
         }
       const int ierr =
@@ -1863,7 +1868,7 @@ namespace Particles
                         MPI_CHAR,
                         neighbors[i],
                         mpi_tag,
-                        parallel_triangulation->get_communicator(),
+                        parallel_triangulation->get_mpi_communicator(),
                         &(requests[send_ops]));
             AssertThrowMPI(ierr);
             ++send_ops;
@@ -1878,7 +1883,7 @@ namespace Particles
                         MPI_CHAR,
                         neighbors[i],
                         mpi_tag,
-                        parallel_triangulation->get_communicator(),
+                        parallel_triangulation->get_mpi_communicator(),
                         &(requests[send_ops + recv_ops]));
             AssertThrowMPI(ierr);
             ++recv_ops;
@@ -2021,7 +2026,7 @@ namespace Particles
                         MPI_CHAR,
                         neighbors[i],
                         mpi_tag,
-                        parallel_triangulation->get_communicator(),
+                        parallel_triangulation->get_mpi_communicator(),
                         &(requests[send_ops]));
             AssertThrowMPI(ierr);
             ++send_ops;
@@ -2036,7 +2041,7 @@ namespace Particles
                         MPI_CHAR,
                         neighbors[i],
                         mpi_tag,
-                        parallel_triangulation->get_communicator(),
+                        parallel_triangulation->get_mpi_communicator(),
                         &(requests[send_ops + recv_ops]));
             AssertThrowMPI(ierr);
             ++recv_ops;

--- a/tests/belos/solver_belos_01.cc
+++ b/tests/belos/solver_belos_01.cc
@@ -66,7 +66,7 @@ main(int argc, char *argv[])
   affine_constraints.close();
 
   TrilinosWrappers::SparsityPattern dsp(dof_handler.locally_owned_dofs(),
-                                        dof_handler.get_communicator());
+                                        dof_handler.get_mpi_communicator());
   DoFTools::make_sparsity_pattern(dof_handler, dsp, affine_constraints);
   dsp.compress();
 
@@ -111,15 +111,15 @@ main(int argc, char *argv[])
                      false);
       Teuchos::RCP<Epetra_MultiVector> B, X;
 
-      LinearAlgebra::EpetraWrappers::Vector x_(dof_handler.locally_owned_dofs(),
-                                               dof_handler.get_communicator());
+      LinearAlgebra::EpetraWrappers::Vector x_(
+        dof_handler.locally_owned_dofs(), dof_handler.get_mpi_communicator());
       LinearAlgebra::ReadWriteVector<Number> x_temp(
         dof_handler.locally_owned_dofs());
       x_temp.import_elements(x, VectorOperation::insert);
       x_.import_elements(x_temp, VectorOperation::insert);
 
-      LinearAlgebra::EpetraWrappers::Vector r_(dof_handler.locally_owned_dofs(),
-                                               dof_handler.get_communicator());
+      LinearAlgebra::EpetraWrappers::Vector r_(
+        dof_handler.locally_owned_dofs(), dof_handler.get_mpi_communicator());
       LinearAlgebra::ReadWriteVector<Number> r_temp(
         dof_handler.locally_owned_dofs());
       r_temp.import_elements(r, VectorOperation::insert);

--- a/tests/dofs/nodal_renumbering_01.cc
+++ b/tests/dofs/nodal_renumbering_01.cc
@@ -73,7 +73,7 @@ void
 test(DoFHandler<2> &dof_handler, const hp::MappingCollection<2> &mappings)
 {
   DoFRenumbering::support_point_wise(dof_handler);
-  const MPI_Comm comm = dof_handler.get_communicator();
+  const MPI_Comm comm = dof_handler.get_mpi_communicator();
 
   const IndexSet &local_dofs = dof_handler.locally_owned_dofs();
   deallog << "new case with locally owned dofs = ";

--- a/tests/fullydistributed_grids/repartitioning_03.cc
+++ b/tests/fullydistributed_grids/repartitioning_03.cc
@@ -71,7 +71,7 @@ output_grid(
   const std::string                                                      &label)
 {
   deallog.push(label);
-  const auto comm    = trias.front()->get_communicator();
+  const auto comm    = trias.front()->get_mpi_communicator();
   const auto my_rank = Utilities::MPI::this_mpi_process(comm);
 
   for (unsigned int i = 0; i < trias.size(); ++i)

--- a/tests/fullydistributed_grids/repartitioning_05.cc
+++ b/tests/fullydistributed_grids/repartitioning_05.cc
@@ -64,7 +64,7 @@ LinearAlgebra::distributed::Vector<double>
 partition_distributed_triangulation(const Triangulation<dim, spacedim> &tria_in,
                                     const MPI_Comm                      comm)
 {
-  const auto comm_tria = tria_in.get_communicator();
+  const auto comm_tria = tria_in.get_mpi_communicator();
 
   const auto n_global_active_cells = Utilities::MPI::max(
     comm_tria == MPI_COMM_SELF ? 0 : tria_in.n_global_active_cells(), comm);

--- a/tests/grid/grid_generator_marching_cube_algorithm_01.cc
+++ b/tests/grid/grid_generator_marching_cube_algorithm_01.cc
@@ -117,7 +117,7 @@ get_mpi_comm(const MeshType &mesh)
                                       MeshType::space_dimension> *>(
     &(mesh.get_triangulation()));
 
-  return tria_parallel != nullptr ? tria_parallel->get_communicator() :
+  return tria_parallel != nullptr ? tria_parallel->get_mpi_communicator() :
                                     MPI_COMM_SELF;
 }
 

--- a/tests/grid/grid_generator_marching_cube_algorithm_02.cc
+++ b/tests/grid/grid_generator_marching_cube_algorithm_02.cc
@@ -120,7 +120,7 @@ create_mca_tria(const unsigned int   n_subdivisions,
                                           "data_background_" +
                                             std::to_string(n_subdivisions),
                                           0,
-                                          triangulation.get_communicator());
+                                          triangulation.get_mpi_communicator());
     }
 }
 

--- a/tests/lac/constraints_make_consistent_in_parallel_01.cc
+++ b/tests/lac/constraints_make_consistent_in_parallel_01.cc
@@ -83,7 +83,7 @@ test(const DoFHandler<dim, spacedim> &dof_handler,
 
   constraints.make_consistent_in_parallel(dof_handler.locally_owned_dofs(),
                                           locally_relevant_dofs,
-                                          dof_handler.get_communicator());
+                                          dof_handler.get_mpi_communicator());
 
   const auto b = collect_lines(constraints, dof_handler.n_dofs());
   b.print(deallog.get_file_stream());

--- a/tests/lac/sparse_matrix_tools_01.cc
+++ b/tests/lac/sparse_matrix_tools_01.cc
@@ -63,7 +63,7 @@ reinit_sparsity_pattern(const DoFHandler<dim, spacedim>   &dof_handler,
                         TrilinosWrappers::SparsityPattern &sparsity_pattern)
 {
   sparsity_pattern.reinit(dof_handler.locally_owned_dofs(),
-                          dof_handler.get_communicator());
+                          dof_handler.get_mpi_communicator());
 }
 
 template <int dim,

--- a/tests/lac/step-40-linear_operator_01.cc
+++ b/tests/lac/step-40-linear_operator_01.cc
@@ -278,7 +278,7 @@ namespace Step40
               << "      ";
         const auto n_locally_owned_active_cells_per_processor =
           Utilities::MPI::all_gather(
-            triangulation.get_communicator(),
+            triangulation.get_mpi_communicator(),
             triangulation.n_locally_owned_active_cells());
         for (unsigned int i = 0;
              i < Utilities::MPI::n_mpi_processes(mpi_communicator);

--- a/tests/lac/step-40-linear_operator_02.cc
+++ b/tests/lac/step-40-linear_operator_02.cc
@@ -281,7 +281,7 @@ namespace Step40
               << "      ";
         const auto n_locally_owned_active_cells_per_processor =
           Utilities::MPI::all_gather(
-            triangulation.get_communicator(),
+            triangulation.get_mpi_communicator(),
             triangulation.n_locally_owned_active_cells());
         for (unsigned int i = 0;
              i < Utilities::MPI::n_mpi_processes(mpi_communicator);

--- a/tests/lac/step-40-linear_operator_03.cc
+++ b/tests/lac/step-40-linear_operator_03.cc
@@ -282,7 +282,7 @@ namespace Step40
               << "      ";
         const auto n_locally_owned_active_cells_per_processor =
           Utilities::MPI::all_gather(
-            triangulation.get_communicator(),
+            triangulation.get_mpi_communicator(),
             triangulation.n_locally_owned_active_cells());
         for (unsigned int i = 0;
              i < Utilities::MPI::n_mpi_processes(mpi_communicator);

--- a/tests/lac/step-40-linear_operator_04.cc
+++ b/tests/lac/step-40-linear_operator_04.cc
@@ -282,7 +282,7 @@ namespace Step40
               << "      ";
         const auto n_locally_owned_active_cells_per_processor =
           Utilities::MPI::all_gather(
-            triangulation.get_communicator(),
+            triangulation.get_mpi_communicator(),
             triangulation.n_locally_owned_active_cells());
         for (unsigned int i = 0;
              i < Utilities::MPI::n_mpi_processes(mpi_communicator);

--- a/tests/lac/step-40-linear_operator_05.cc
+++ b/tests/lac/step-40-linear_operator_05.cc
@@ -280,7 +280,7 @@ namespace Step40
               << "      ";
         const auto n_locally_owned_active_cells_per_processor =
           Utilities::MPI::all_gather(
-            triangulation.get_communicator(),
+            triangulation.get_mpi_communicator(),
             triangulation.n_locally_owned_active_cells());
         for (unsigned int i = 0;
              i < Utilities::MPI::n_mpi_processes(mpi_communicator);

--- a/tests/lac/step-40-linear_operator_06.cc
+++ b/tests/lac/step-40-linear_operator_06.cc
@@ -280,7 +280,7 @@ namespace Step40
               << "      ";
         const auto n_locally_owned_active_cells_per_processor =
           Utilities::MPI::all_gather(
-            triangulation.get_communicator(),
+            triangulation.get_mpi_communicator(),
             triangulation.n_locally_owned_active_cells());
         for (unsigned int i = 0;
              i < Utilities::MPI::n_mpi_processes(mpi_communicator);

--- a/tests/mappings/mapping_fe_field_06.cc
+++ b/tests/mappings/mapping_fe_field_06.cc
@@ -78,7 +78,7 @@ test()
         DoFTools::extract_locally_relevant_level_dofs(dh, level);
       level_vectors[level].reinit(dh.locally_owned_mg_dofs(level),
                                   relevant_dofs,
-                                  tria.get_communicator());
+                                  tria.get_mpi_communicator());
       std::vector<types::global_dof_index> dof_indices(fe.dofs_per_cell);
       for (const auto &cell : dh.mg_cell_iterators_on_level(level))
         if (cell->level_subdomain_id() != numbers::artificial_subdomain_id)

--- a/tests/mappings/mapping_q_cache_06.cc
+++ b/tests/mappings/mapping_q_cache_06.cc
@@ -80,7 +80,7 @@ do_test(const unsigned int degree,
   LinearAlgebra::distributed::Vector<double> vector(
     dof_handler.locally_owned_dofs(),
     locally_relevant_dofs,
-    dof_handler.get_communicator());
+    dof_handler.get_mpi_communicator());
 
   VectorTools::interpolate(dof_handler, fu, vector);
 

--- a/tests/mpi/cell_weights_01.cc
+++ b/tests/mpi/cell_weights_01.cc
@@ -53,7 +53,7 @@ test()
   tr.repartition();
 
   const auto n_locally_owned_active_cells_per_processor =
-    Utilities::MPI::all_gather(tr.get_communicator(),
+    Utilities::MPI::all_gather(tr.get_mpi_communicator(),
                                tr.n_locally_owned_active_cells());
   if (myid == 0)
     for (unsigned int p = 0; p < numproc; ++p)

--- a/tests/mpi/cell_weights_01_back_and_forth_01.cc
+++ b/tests/mpi/cell_weights_01_back_and_forth_01.cc
@@ -83,7 +83,7 @@ test()
   tr.repartition();
 
   const auto n_locally_owned_active_cells_per_processor =
-    Utilities::MPI::all_gather(tr.get_communicator(),
+    Utilities::MPI::all_gather(tr.get_mpi_communicator(),
                                tr.n_locally_owned_active_cells());
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     for (unsigned int p = 0; p < numproc; ++p)

--- a/tests/mpi/cell_weights_01_back_and_forth_02.cc
+++ b/tests/mpi/cell_weights_01_back_and_forth_02.cc
@@ -70,7 +70,7 @@ test()
   tr.repartition();
 
   const auto n_locally_owned_active_cells_per_processor =
-    Utilities::MPI::all_gather(tr.get_communicator(),
+    Utilities::MPI::all_gather(tr.get_mpi_communicator(),
                                tr.n_locally_owned_active_cells());
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     for (unsigned int p = 0; p < numproc; ++p)

--- a/tests/mpi/cell_weights_02.cc
+++ b/tests/mpi/cell_weights_02.cc
@@ -58,7 +58,7 @@ test()
   tr.refine_global(1);
 
   const auto n_locally_owned_active_cells_per_processor =
-    Utilities::MPI::all_gather(tr.get_communicator(),
+    Utilities::MPI::all_gather(tr.get_mpi_communicator(),
                                tr.n_locally_owned_active_cells());
   if (myid == 0)
     for (unsigned int p = 0; p < numproc; ++p)

--- a/tests/mpi/cell_weights_03.cc
+++ b/tests/mpi/cell_weights_03.cc
@@ -67,7 +67,7 @@ test()
   tr.repartition();
 
   const auto n_locally_owned_active_cells_per_processor =
-    Utilities::MPI::all_gather(tr.get_communicator(),
+    Utilities::MPI::all_gather(tr.get_mpi_communicator(),
                                tr.n_locally_owned_active_cells());
   if (myid == 0)
     for (unsigned int p = 0; p < numproc; ++p)

--- a/tests/mpi/cell_weights_04.cc
+++ b/tests/mpi/cell_weights_04.cc
@@ -61,7 +61,7 @@ test()
   tr.refine_global(1);
 
   const auto n_locally_owned_active_cells_per_processor =
-    Utilities::MPI::all_gather(tr.get_communicator(),
+    Utilities::MPI::all_gather(tr.get_mpi_communicator(),
                                tr.n_locally_owned_active_cells());
   if (myid == 0)
     for (unsigned int p = 0; p < numproc; ++p)

--- a/tests/mpi/cell_weights_05.cc
+++ b/tests/mpi/cell_weights_05.cc
@@ -81,7 +81,7 @@ test()
   tr.repartition();
 
   const auto n_locally_owned_active_cells_per_processor =
-    Utilities::MPI::all_gather(tr.get_communicator(),
+    Utilities::MPI::all_gather(tr.get_mpi_communicator(),
                                tr.n_locally_owned_active_cells());
   if (myid == 0)
     for (unsigned int p = 0; p < numproc; ++p)

--- a/tests/mpi/cell_weights_06.cc
+++ b/tests/mpi/cell_weights_06.cc
@@ -80,7 +80,7 @@ test()
   tr.repartition();
 
   const auto n_locally_owned_active_cells_per_processor =
-    Utilities::MPI::all_gather(tr.get_communicator(),
+    Utilities::MPI::all_gather(tr.get_mpi_communicator(),
                                tr.n_locally_owned_active_cells());
   if (myid == 0)
     for (unsigned int p = 0; p < numproc; ++p)

--- a/tests/mpi/compute_mean_value_02.cc
+++ b/tests/mpi/compute_mean_value_02.cc
@@ -94,10 +94,11 @@ test()
   }
 
   const IndexSet relevant_set = DoFTools::extract_locally_relevant_dofs(dofh);
-  TrilinosWrappers::MPI::Vector x_rel(relevant_set, dofh.get_communicator());
+  TrilinosWrappers::MPI::Vector x_rel(relevant_set,
+                                      dofh.get_mpi_communicator());
   {
     TrilinosWrappers::MPI::Vector interpolated(dofh.locally_owned_dofs(),
-                                               dofh.get_communicator());
+                                               dofh.get_mpi_communicator());
     VectorTools::interpolate(dofh, LinearFunction<dim>(), interpolated);
     x_rel = interpolated;
   }

--- a/tests/mpi/hp_constraints_consistent_01.cc
+++ b/tests/mpi/hp_constraints_consistent_01.cc
@@ -114,7 +114,8 @@ test(const unsigned int degree_center,
 
   // ------ verify -----
   std::vector<IndexSet> locally_owned_dofs_per_processor =
-    Utilities::MPI::all_gather(dh.get_communicator(), dh.locally_owned_dofs());
+    Utilities::MPI::all_gather(dh.get_mpi_communicator(),
+                               dh.locally_owned_dofs());
 
   const IndexSet locally_active_dofs =
     DoFTools::extract_locally_active_dofs(dh);

--- a/tests/mpi/hp_constraints_consistent_02.cc
+++ b/tests/mpi/hp_constraints_consistent_02.cc
@@ -120,7 +120,8 @@ test(const unsigned int degree_center,
 
   // ------ verify -----
   std::vector<IndexSet> locally_owned_dofs_per_processor =
-    Utilities::MPI::all_gather(dh.get_communicator(), dh.locally_owned_dofs());
+    Utilities::MPI::all_gather(dh.get_mpi_communicator(),
+                               dh.locally_owned_dofs());
 
   const IndexSet locally_active_dofs =
     DoFTools::extract_locally_active_dofs(dh);

--- a/tests/mpi/hp_constraints_consistent_03.cc
+++ b/tests/mpi/hp_constraints_consistent_03.cc
@@ -135,7 +135,8 @@ test(const unsigned int degree_center,
 
   // ------ verify -----
   std::vector<IndexSet> locally_owned_dofs_per_processor =
-    Utilities::MPI::all_gather(dh.get_communicator(), dh.locally_owned_dofs());
+    Utilities::MPI::all_gather(dh.get_mpi_communicator(),
+                               dh.locally_owned_dofs());
 
   const IndexSet locally_active_dofs =
     DoFTools::extract_locally_active_dofs(dh);

--- a/tests/mpi/hp_step-40.cc
+++ b/tests/mpi/hp_step-40.cc
@@ -329,7 +329,7 @@ namespace Step40
               << "      ";
         const auto n_locally_owned_active_cells_per_processor =
           Utilities::MPI::all_gather(
-            triangulation.get_communicator(),
+            triangulation.get_mpi_communicator(),
             triangulation.n_locally_owned_active_cells());
         for (unsigned int i = 0;
              i < Utilities::MPI::n_mpi_processes(mpi_communicator);

--- a/tests/mpi/hp_step-40_variable_01.cc
+++ b/tests/mpi/hp_step-40_variable_01.cc
@@ -332,7 +332,7 @@ namespace Step40
               << "      ";
         const auto n_locally_owned_active_cells_per_processor =
           Utilities::MPI::all_gather(
-            triangulation.get_communicator(),
+            triangulation.get_mpi_communicator(),
             triangulation.n_locally_owned_active_cells());
         for (unsigned int i = 0;
              i < Utilities::MPI::n_mpi_processes(mpi_communicator);

--- a/tests/mpi/limit_p_level_difference_01.cc
+++ b/tests/mpi/limit_p_level_difference_01.cc
@@ -96,7 +96,7 @@ test(const unsigned int fes_size, const unsigned int max_difference)
   for (const auto &cell :
        dofh.active_cell_iterators() | IteratorFilters::LocallyOwnedCell())
     count[cell->active_fe_index()]++;
-  Utilities::MPI::sum(count, tria.get_communicator(), count);
+  Utilities::MPI::sum(count, tria.get_mpi_communicator(), count);
   deallog << "fe count:" << count << std::endl;
 
 #ifdef DEBUG

--- a/tests/mpi/limit_p_level_difference_02.cc
+++ b/tests/mpi/limit_p_level_difference_02.cc
@@ -102,7 +102,7 @@ test(const unsigned int fes_size, const unsigned int max_difference)
       for (const auto &cell :
            dofh.active_cell_iterators() | IteratorFilters::LocallyOwnedCell())
         count[cell->active_fe_index()]++;
-      Utilities::MPI::sum(count, tria.get_communicator(), count);
+      Utilities::MPI::sum(count, tria.get_mpi_communicator(), count);
       deallog << "cycle:" << i << ", fe count:" << count << std::endl;
     }
 

--- a/tests/mpi/periodicity_04.cc
+++ b/tests/mpi/periodicity_04.cc
@@ -272,7 +272,7 @@ check(const unsigned int orientation, bool reverse)
                 1,
                 MPI_INT,
                 MPI_SUM,
-                triangulation.get_communicator());
+                triangulation.get_mpi_communicator());
   Assert(sum_of_pairs_global > 0, ExcInternalError());
   for (it = face_map.begin(); it != face_map.end(); ++it)
     {

--- a/tests/mpi/petsc_step-27.cc
+++ b/tests/mpi/petsc_step-27.cc
@@ -225,7 +225,7 @@ namespace Step27
     // We have not dealt with chains of constraints on ghost cells yet.
     // Thus, we are content with verifying their consistency for now.
     std::vector<IndexSet> locally_owned_dofs_per_processor =
-      Utilities::MPI::all_gather(dof_handler.get_communicator(),
+      Utilities::MPI::all_gather(dof_handler.get_mpi_communicator(),
                                  dof_handler.locally_owned_dofs());
 
     const IndexSet locally_active_dofs =

--- a/tests/mpi/solution_transfer_11.cc
+++ b/tests/mpi/solution_transfer_11.cc
@@ -60,7 +60,7 @@ test()
   LinearAlgebra::distributed::Vector<double> solution;
   solution.reinit(locally_owned_dofs,
                   locally_relevant_dofs,
-                  dofh.get_communicator());
+                  dofh.get_mpi_communicator());
 
   for (unsigned int i = 0; i < solution.size(); ++i)
     if (locally_owned_dofs.is_element(i))
@@ -68,7 +68,7 @@ test()
   solution.update_ghost_values();
 
   double l1_norm = solution.l1_norm();
-  if (Utilities::MPI::this_mpi_process(dofh.get_communicator()) == 0)
+  if (Utilities::MPI::this_mpi_process(dofh.get_mpi_communicator()) == 0)
     deallog << "pre  refinement l1=" << l1_norm << std::endl;
 
   // set refine/coarsen flags manually
@@ -121,11 +121,11 @@ test()
 
   solution.reinit(locally_owned_dofs,
                   locally_relevant_dofs,
-                  dofh.get_communicator());
+                  dofh.get_mpi_communicator());
   soltrans.interpolate(solution);
 
   l1_norm = solution.l1_norm();
-  if (Utilities::MPI::this_mpi_process(dofh.get_communicator()) == 0)
+  if (Utilities::MPI::this_mpi_process(dofh.get_mpi_communicator()) == 0)
     deallog << "post refinement l1=" << l1_norm << std::endl;
 
   // make sure no processor is hanging

--- a/tests/mpi/step-40.cc
+++ b/tests/mpi/step-40.cc
@@ -314,7 +314,7 @@ namespace Step40
               << "      ";
         const auto n_locally_owned_active_cells_per_processor =
           Utilities::MPI::all_gather(
-            triangulation.get_communicator(),
+            triangulation.get_mpi_communicator(),
             triangulation.n_locally_owned_active_cells());
         for (unsigned int i = 0;
              i < Utilities::MPI::n_mpi_processes(mpi_communicator);

--- a/tests/mpi/step-40_cuthill_mckee.cc
+++ b/tests/mpi/step-40_cuthill_mckee.cc
@@ -376,7 +376,7 @@ namespace Step40
               << "      ";
         const auto n_locally_owned_active_cells_per_processor =
           Utilities::MPI::all_gather(
-            triangulation.get_communicator(),
+            triangulation.get_mpi_communicator(),
             triangulation.n_locally_owned_active_cells());
         for (unsigned int i = 0;
              i < Utilities::MPI::n_mpi_processes(mpi_communicator);

--- a/tests/mpi/step-40_cuthill_mckee_MPI-subset.cc
+++ b/tests/mpi/step-40_cuthill_mckee_MPI-subset.cc
@@ -377,7 +377,7 @@ namespace Step40
               << "      ";
         const auto n_locally_owned_active_cells_per_processor =
           Utilities::MPI::all_gather(
-            triangulation.get_communicator(),
+            triangulation.get_mpi_communicator(),
             triangulation.n_locally_owned_active_cells());
         for (unsigned int i = 0;
              i < Utilities::MPI::n_mpi_processes(mpi_communicator);

--- a/tests/mpi/step-40_direct_solver.cc
+++ b/tests/mpi/step-40_direct_solver.cc
@@ -292,7 +292,7 @@ namespace Step40
               << "      ";
         const auto n_locally_owned_active_cells_per_processor =
           Utilities::MPI::all_gather(
-            triangulation.get_communicator(),
+            triangulation.get_mpi_communicator(),
             triangulation.n_locally_owned_active_cells());
         for (unsigned int i = 0;
              i < Utilities::MPI::n_mpi_processes(mpi_communicator);

--- a/tests/mpi/trilinos_step-27.cc
+++ b/tests/mpi/trilinos_step-27.cc
@@ -229,7 +229,7 @@ namespace Step27
     // We did not think about hp-constraints on ghost cells yet.
     // Thus, we are content with verifying their consistency for now.
     std::vector<IndexSet> locally_owned_dofs_per_processor =
-      Utilities::MPI::all_gather(dof_handler.get_communicator(),
+      Utilities::MPI::all_gather(dof_handler.get_mpi_communicator(),
                                  dof_handler.locally_owned_dofs());
 
     const IndexSet locally_active_dofs =

--- a/tests/multigrid-global-coarsening/fe_nothing_01.cc
+++ b/tests/multigrid-global-coarsening/fe_nothing_01.cc
@@ -141,7 +141,7 @@ do_test(const hp::FECollection<dim> &fe_fine,
 
 #if 0
   data_out.write_vtu_with_pvtu_record(
-    "./", "result", counter++, tria.get_communicator(), 3, 1);
+    "./", "result", counter++, tria.get_mpi_communicator(), 3, 1);
 #else
   deallog << std::endl;
   data_out.write_vtk(deallog.get_file_stream());

--- a/tests/multigrid-global-coarsening/interpolate_01.cc
+++ b/tests/multigrid-global-coarsening/interpolate_01.cc
@@ -85,7 +85,7 @@ create_partitioner(const DoFHandler<dim> &dof_handler)
   return std::make_shared<Utilities::MPI::Partitioner>(
     dof_handler.locally_owned_dofs(),
     DoFTools::extract_locally_active_dofs(dof_handler),
-    dof_handler.get_communicator());
+    dof_handler.get_mpi_communicator());
 }
 
 

--- a/tests/multigrid-global-coarsening/mg_transfer_util.h
+++ b/tests/multigrid-global-coarsening/mg_transfer_util.h
@@ -47,7 +47,7 @@ initialize_dof_vector(LinearAlgebra::distributed::Vector<Number> &vec,
       &(dof_handler.get_triangulation()));
 
   MPI_Comm comm =
-    dist_tria != nullptr ? dist_tria->get_communicator() : MPI_COMM_SELF;
+    dist_tria != nullptr ? dist_tria->get_mpi_communicator() : MPI_COMM_SELF;
 
   vec.reinit(level == numbers::invalid_unsigned_int ?
                dof_handler.locally_owned_dofs() :

--- a/tests/numerics/matrix_creator_01.cc
+++ b/tests/numerics/matrix_creator_01.cc
@@ -50,7 +50,7 @@ test()
   DoFHandler<dim> dof_handler(tria);
   dof_handler.distribute_dofs(fe);
 
-  const auto      mpi_comm   = dof_handler.get_communicator();
+  const auto      mpi_comm   = dof_handler.get_mpi_communicator();
   const IndexSet &owned_dofs = dof_handler.locally_owned_dofs();
 
   const IndexSet relevant_dofs =

--- a/tests/numerics/project_parallel_common.h
+++ b/tests/numerics/project_parallel_common.h
@@ -111,7 +111,7 @@ do_project(const parallel::distributed::Triangulation<dim> &triangulation,
 
   deallog << "n_dofs=" << dof_handler.n_dofs() << std::endl;
 
-  const MPI_Comm mpi_communicator   = triangulation.get_communicator();
+  const MPI_Comm mpi_communicator   = triangulation.get_mpi_communicator();
   const IndexSet locally_owned_dofs = dof_handler.locally_owned_dofs();
   const IndexSet locally_relevant_dofs =
     DoFTools::extract_locally_relevant_dofs(dof_handler);

--- a/tests/particles/data_out_05.cc
+++ b/tests/particles/data_out_05.cc
@@ -69,7 +69,7 @@ test()
                                                                       2,
                                                                       0);
 
-    if (Utilities::MPI::this_mpi_process(tr.get_communicator()) == 0)
+    if (Utilities::MPI::this_mpi_process(tr.get_mpi_communicator()) == 0)
       {
         auto particle_it = particle_handler.insert_particle(particle1, cell1);
         particle_it->set_properties(properties);

--- a/tests/particles/exchange_ghosts_01.cc
+++ b/tests/particles/exchange_ghosts_01.cc
@@ -46,7 +46,7 @@ test()
     Point<spacedim> position;
     Point<dim>      reference_position;
 
-    if (Utilities::MPI::this_mpi_process(tr.get_communicator()) == 0)
+    if (Utilities::MPI::this_mpi_process(tr.get_mpi_communicator()) == 0)
       for (unsigned int i = 0; i < dim; ++i)
         position[i] = 0.475;
     else
@@ -56,7 +56,7 @@ test()
     Particles::Particle<dim, spacedim> particle(
       position,
       reference_position,
-      Utilities::MPI::this_mpi_process(tr.get_communicator()));
+      Utilities::MPI::this_mpi_process(tr.get_mpi_communicator()));
 
     // We give a local random cell hint to check that sorting and
     // transferring ghost particles works.
@@ -72,13 +72,13 @@ test()
     deallog << "Before ghost exchange: "
             << particle_handler.n_locally_owned_particles()
             << " locally owned particles on process "
-            << Utilities::MPI::this_mpi_process(tr.get_communicator())
+            << Utilities::MPI::this_mpi_process(tr.get_mpi_communicator())
             << std::endl;
 
     deallog << "Before ghost exchange: "
             << particle_handler.get_property_pool().n_registered_slots()
             << " stored particles on process "
-            << Utilities::MPI::this_mpi_process(tr.get_communicator())
+            << Utilities::MPI::this_mpi_process(tr.get_mpi_communicator())
             << std::endl;
 
     particle_handler.exchange_ghost_particles();
@@ -92,13 +92,13 @@ test()
     deallog << "After ghost exchange: "
             << particle_handler.n_locally_owned_particles()
             << " locally owned particles on process "
-            << Utilities::MPI::this_mpi_process(tr.get_communicator())
+            << Utilities::MPI::this_mpi_process(tr.get_mpi_communicator())
             << std::endl;
 
     deallog << "After ghost exchange: "
             << particle_handler.get_property_pool().n_registered_slots()
             << " stored particles on process "
-            << Utilities::MPI::this_mpi_process(tr.get_communicator())
+            << Utilities::MPI::this_mpi_process(tr.get_mpi_communicator())
             << std::endl;
   }
 

--- a/tests/particles/exchange_ghosts_periodic_01.cc
+++ b/tests/particles/exchange_ghosts_periodic_01.cc
@@ -68,7 +68,7 @@ test()
     Point<spacedim> position;
     Point<dim>      reference_position;
 
-    if (Utilities::MPI::this_mpi_process(tr.get_communicator()) == 0)
+    if (Utilities::MPI::this_mpi_process(tr.get_mpi_communicator()) == 0)
       position[0] = 0.001;
     else
       position[0] = 0.999;
@@ -76,7 +76,7 @@ test()
     Particles::Particle<dim, spacedim> particle(
       position,
       reference_position,
-      Utilities::MPI::this_mpi_process(tr.get_communicator()));
+      Utilities::MPI::this_mpi_process(tr.get_mpi_communicator()));
 
     // We give a local random cell hint to check that sorting and
     // transferring ghost particles works.

--- a/tests/particles/particle_handler_04.cc
+++ b/tests/particles/particle_handler_04.cc
@@ -43,7 +43,7 @@ test()
     // particles
     Particles::ParticleHandler<dim, spacedim> particle_handler(tr, mapping);
 
-    if (Utilities::MPI::this_mpi_process(tr.get_communicator()) == 0)
+    if (Utilities::MPI::this_mpi_process(tr.get_mpi_communicator()) == 0)
       {
         std::vector<Point<spacedim>> position(2);
         std::vector<Point<dim>>      reference_position(2);
@@ -75,7 +75,7 @@ test()
           deallog << "Before sort particle id " << particle.get_id()
                   << " is in cell " << particle.get_surrounding_cell()
                   << " on process "
-                  << Utilities::MPI::this_mpi_process(tr.get_communicator())
+                  << Utilities::MPI::this_mpi_process(tr.get_mpi_communicator())
                   << std::flush << std::endl;
       }
 
@@ -87,7 +87,7 @@ test()
       deallog << "After sort particle id " << particle.get_id()
               << " is in cell " << particle.get_surrounding_cell()
               << " on process "
-              << Utilities::MPI::this_mpi_process(tr.get_communicator())
+              << Utilities::MPI::this_mpi_process(tr.get_mpi_communicator())
               << std::flush << std::endl;
 
     // Move all points up by 0.5. This will change cell for particle 1, and will
@@ -103,7 +103,7 @@ test()
       deallog << "After shift particle id " << particle.get_id()
               << " is in cell " << particle.get_surrounding_cell()
               << " on process "
-              << Utilities::MPI::this_mpi_process(tr.get_communicator())
+              << Utilities::MPI::this_mpi_process(tr.get_mpi_communicator())
               << std::flush << std::endl;
   }
 

--- a/tests/particles/particle_handler_06.cc
+++ b/tests/particles/particle_handler_06.cc
@@ -45,7 +45,7 @@ test()
     Point<spacedim> position;
     Point<dim>      reference_position;
 
-    if (Utilities::MPI::this_mpi_process(tr.get_communicator()) == 0)
+    if (Utilities::MPI::this_mpi_process(tr.get_mpi_communicator()) == 0)
       for (unsigned int i = 0; i < dim; ++i)
         position[i] = 0.475;
     else
@@ -55,7 +55,7 @@ test()
     Particles::Particle<dim, spacedim> particle(
       position,
       reference_position,
-      Utilities::MPI::this_mpi_process(tr.get_communicator()));
+      Utilities::MPI::this_mpi_process(tr.get_mpi_communicator()));
 
     // We give a local random cell hint to check that sorting and
     // transferring ghost particles works.
@@ -74,7 +74,7 @@ test()
          ++particle)
       deallog << "Particle id " << particle->get_id()
               << " is local particle on process "
-              << Utilities::MPI::this_mpi_process(tr.get_communicator())
+              << Utilities::MPI::this_mpi_process(tr.get_mpi_communicator())
               << std::endl;
 
     for (auto particle = particle_handler.begin_ghost();
@@ -82,7 +82,7 @@ test()
          ++particle)
       deallog << "Particle id " << particle->get_id()
               << " is ghost particle on process "
-              << Utilities::MPI::this_mpi_process(tr.get_communicator())
+              << Utilities::MPI::this_mpi_process(tr.get_mpi_communicator())
               << std::endl;
   }
 

--- a/tests/particles/particle_handler_19.cc
+++ b/tests/particles/particle_handler_19.cc
@@ -47,7 +47,7 @@ test()
     Point<spacedim> position;
     Point<dim>      reference_position;
 
-    if (Utilities::MPI::this_mpi_process(tr.get_communicator()) == 0)
+    if (Utilities::MPI::this_mpi_process(tr.get_mpi_communicator()) == 0)
       for (unsigned int i = 0; i < dim; ++i)
         position[i] = 0.475;
     else
@@ -57,7 +57,7 @@ test()
     Particles::Particle<dim, spacedim> particle(
       position,
       reference_position,
-      Utilities::MPI::this_mpi_process(tr.get_communicator()));
+      Utilities::MPI::this_mpi_process(tr.get_mpi_communicator()));
     typename Triangulation<dim, spacedim>::active_cell_iterator cell =
       tr.begin_active();
     while (!cell->is_locally_owned())
@@ -73,9 +73,9 @@ test()
          ++particle)
       {
         particle->get_properties()[0] =
-          10 + Utilities::MPI::this_mpi_process(tr.get_communicator());
+          10 + Utilities::MPI::this_mpi_process(tr.get_mpi_communicator());
         particle->get_properties()[1] =
-          100 + Utilities::MPI::this_mpi_process(tr.get_communicator());
+          100 + Utilities::MPI::this_mpi_process(tr.get_mpi_communicator());
       }
 
 
@@ -88,7 +88,7 @@ test()
               << " location : " << particle->get_location()
               << " property : " << particle->get_properties()[0] << " and "
               << particle->get_properties()[1] << " is local on process : "
-              << Utilities::MPI::this_mpi_process(tr.get_communicator())
+              << Utilities::MPI::this_mpi_process(tr.get_mpi_communicator())
               << std::endl;
 
     for (auto particle = particle_handler.begin_ghost();
@@ -98,7 +98,7 @@ test()
               << " location : " << particle->get_location()
               << " property : " << particle->get_properties()[0] << " and "
               << particle->get_properties()[1] << " is ghost on process : "
-              << Utilities::MPI::this_mpi_process(tr.get_communicator())
+              << Utilities::MPI::this_mpi_process(tr.get_mpi_communicator())
               << std::endl;
 
     deallog << "Modifying particles positions and properties" << std::endl;
@@ -127,7 +127,7 @@ test()
               << " location : " << particle->get_location()
               << " property : " << particle->get_properties()[0] << " and "
               << particle->get_properties()[1] << " is local on process : "
-              << Utilities::MPI::this_mpi_process(tr.get_communicator())
+              << Utilities::MPI::this_mpi_process(tr.get_mpi_communicator())
               << std::endl;
 
     for (auto particle = particle_handler.begin_ghost();
@@ -137,7 +137,7 @@ test()
               << " location : " << particle->get_location()
               << " property : " << particle->get_properties()[0] << " and "
               << particle->get_properties()[1] << " is ghost on process : "
-              << Utilities::MPI::this_mpi_process(tr.get_communicator())
+              << Utilities::MPI::this_mpi_process(tr.get_mpi_communicator())
               << std::endl;
   }
 

--- a/tests/particles/particle_handler_20.cc
+++ b/tests/particles/particle_handler_20.cc
@@ -50,7 +50,7 @@ test()
 
     for (unsigned int p = 0; p < n_particles; ++p)
       {
-        if (Utilities::MPI::this_mpi_process(tr.get_communicator()) == 0)
+        if (Utilities::MPI::this_mpi_process(tr.get_mpi_communicator()) == 0)
           {
             for (unsigned int i = 0; i < dim; ++i)
               position[i] = 0.410 + 0.01 * p;
@@ -58,7 +58,7 @@ test()
             Particles::Particle<dim, spacedim> particle(
               position,
               reference_position,
-              Utilities::MPI::this_mpi_process(tr.get_communicator()) *
+              Utilities::MPI::this_mpi_process(tr.get_mpi_communicator()) *
                   n_particles +
                 p);
             typename Triangulation<dim, spacedim>::active_cell_iterator cell =
@@ -77,10 +77,12 @@ test()
          ++particle)
       {
         particle->get_properties()[0] =
-          1000 + 100 * Utilities::MPI::this_mpi_process(tr.get_communicator()) +
+          1000 +
+          100 * Utilities::MPI::this_mpi_process(tr.get_mpi_communicator()) +
           10 * particle->get_id();
         particle->get_properties()[1] =
-          2000 + 100 * Utilities::MPI::this_mpi_process(tr.get_communicator()) +
+          2000 +
+          100 * Utilities::MPI::this_mpi_process(tr.get_mpi_communicator()) +
           10 * particle->get_id();
         counter++;
       }
@@ -95,7 +97,7 @@ test()
               << " location : " << particle->get_location()
               << " property : " << particle->get_properties()[0] << " and "
               << particle->get_properties()[1] << " is local on process : "
-              << Utilities::MPI::this_mpi_process(tr.get_communicator())
+              << Utilities::MPI::this_mpi_process(tr.get_mpi_communicator())
               << std::endl;
 
     for (auto particle = particle_handler.begin_ghost();
@@ -105,7 +107,7 @@ test()
               << " location : " << particle->get_location()
               << " property : " << particle->get_properties()[0] << " and "
               << particle->get_properties()[1] << " is ghost on process : "
-              << Utilities::MPI::this_mpi_process(tr.get_communicator())
+              << Utilities::MPI::this_mpi_process(tr.get_mpi_communicator())
               << std::endl;
 
     deallog << "Modifying particles positions and properties" << std::endl;
@@ -134,7 +136,7 @@ test()
               << " location : " << particle->get_location()
               << " property : " << particle->get_properties()[0] << " and "
               << particle->get_properties()[1] << " is local on process : "
-              << Utilities::MPI::this_mpi_process(tr.get_communicator())
+              << Utilities::MPI::this_mpi_process(tr.get_mpi_communicator())
               << std::endl;
 
     for (auto particle = particle_handler.begin_ghost();
@@ -144,7 +146,7 @@ test()
               << " location : " << particle->get_location()
               << " property : " << particle->get_properties()[0] << " and "
               << particle->get_properties()[1] << " is ghost on process : "
-              << Utilities::MPI::this_mpi_process(tr.get_communicator())
+              << Utilities::MPI::this_mpi_process(tr.get_mpi_communicator())
               << std::endl;
   }
 

--- a/tests/particles/particle_handler_fully_distributed_01.cc
+++ b/tests/particles/particle_handler_fully_distributed_01.cc
@@ -59,7 +59,7 @@ test()
     Particles::ParticleHandler<dim, spacedim> particle_handler(tria_pft,
                                                                mapping);
 
-    if (Utilities::MPI::this_mpi_process(tria_pft.get_communicator()) == 0)
+    if (Utilities::MPI::this_mpi_process(tria_pft.get_mpi_communicator()) == 0)
       {
         std::vector<Point<spacedim>> position(2);
         std::vector<Point<dim>>      reference_position(2);
@@ -90,7 +90,7 @@ test()
                   << " is in cell " << particle.get_surrounding_cell()
                   << " on process "
                   << Utilities::MPI::this_mpi_process(
-                       tria_pft.get_communicator())
+                       tria_pft.get_mpi_communicator())
                   << std::flush << std::endl;
       }
 
@@ -102,7 +102,8 @@ test()
       deallog << "After sort particle id " << particle.get_id()
               << " is in cell " << particle.get_surrounding_cell()
               << " on process "
-              << Utilities::MPI::this_mpi_process(tria_pft.get_communicator())
+              << Utilities::MPI::this_mpi_process(
+                   tria_pft.get_mpi_communicator())
               << std::flush << std::endl;
 
     // Move all points up by 0.5. This will change cell for particle 1 and will
@@ -118,7 +119,8 @@ test()
       deallog << "After shift particle id " << particle.get_id()
               << " is in cell " << particle.get_surrounding_cell()
               << " on process "
-              << Utilities::MPI::this_mpi_process(tria_pft.get_communicator())
+              << Utilities::MPI::this_mpi_process(
+                   tria_pft.get_mpi_communicator())
               << std::flush << std::endl;
   }
 

--- a/tests/particles/particle_handler_shared_01.cc
+++ b/tests/particles/particle_handler_shared_01.cc
@@ -55,7 +55,8 @@ test()
     Particles::ParticleHandler<dim, spacedim> particle_handler(tria_shared,
                                                                mapping);
 
-    if (Utilities::MPI::this_mpi_process(tria_shared.get_communicator()) == 0)
+    if (Utilities::MPI::this_mpi_process(tria_shared.get_mpi_communicator()) ==
+        0)
       {
         std::vector<Point<spacedim>> position(2);
         std::vector<Point<dim>>      reference_position(2);
@@ -86,7 +87,7 @@ test()
                   << " is in cell " << particle.get_surrounding_cell()
                   << " on process "
                   << Utilities::MPI::this_mpi_process(
-                       tria_shared.get_communicator())
+                       tria_shared.get_mpi_communicator())
                   << std::flush << std::endl;
       }
 
@@ -99,7 +100,7 @@ test()
               << " is in cell " << particle.get_surrounding_cell()
               << " on process "
               << Utilities::MPI::this_mpi_process(
-                   tria_shared.get_communicator())
+                   tria_shared.get_mpi_communicator())
               << std::flush << std::endl;
 
     // Move all points up by 0.5. This will change cell for particle 1 and will
@@ -116,7 +117,7 @@ test()
               << " is in cell " << particle.get_surrounding_cell()
               << " on process "
               << Utilities::MPI::this_mpi_process(
-                   tria_shared.get_communicator())
+                   tria_shared.get_mpi_communicator())
               << std::flush << std::endl;
   }
 

--- a/tests/particles/particle_handler_sort_02.cc
+++ b/tests/particles/particle_handler_sort_02.cc
@@ -50,7 +50,7 @@ test()
 
   std::vector<Point<spacedim>> position(1);
 
-  if (Utilities::MPI::this_mpi_process(tr.get_communicator()) == 0)
+  if (Utilities::MPI::this_mpi_process(tr.get_mpi_communicator()) == 0)
     for (unsigned int i = 0; i < dim; ++i)
       position[0][i] = 2;
 

--- a/tests/particles/particle_weights_01.cc
+++ b/tests/particles/particle_weights_01.cc
@@ -53,7 +53,7 @@ test()
       GridTools::compute_mesh_predicate_bounding_box(
         triangulation, IteratorFilters::LocallyOwnedCell());
     const auto global_bounding_boxes =
-      Utilities::MPI::all_gather(triangulation.get_communicator(),
+      Utilities::MPI::all_gather(triangulation.get_mpi_communicator(),
                                  local_bounding_box);
 
     Particles::Generators::quadrature_points(triangulation,

--- a/tests/remote_point_evaluation/data_out_resample_01.cc
+++ b/tests/remote_point_evaluation/data_out_resample_01.cc
@@ -61,7 +61,7 @@ create_partitioner(const DoFHandler<dim, spacedim> &dof_handler)
   return std::make_shared<const Utilities::MPI::Partitioner>(
     dof_handler.locally_owned_dofs(),
     locally_relevant_dofs,
-    dof_handler.get_communicator());
+    dof_handler.get_mpi_communicator());
 }
 
 

--- a/tests/remote_point_evaluation/data_out_resample_02.cc
+++ b/tests/remote_point_evaluation/data_out_resample_02.cc
@@ -61,7 +61,7 @@ create_partitioner(const DoFHandler<dim, spacedim> &dof_handler)
   return std::make_shared<const Utilities::MPI::Partitioner>(
     dof_handler.locally_owned_dofs(),
     locally_relevant_dofs,
-    dof_handler.get_communicator());
+    dof_handler.get_mpi_communicator());
 }
 
 

--- a/tests/remote_point_evaluation/mapping_02.cc
+++ b/tests/remote_point_evaluation/mapping_02.cc
@@ -65,7 +65,7 @@ test()
 
   // gather bounding boxes of other processes
   const auto global_bboxes =
-    Utilities::MPI::all_gather(tria.get_communicator(), local_reduced_box);
+    Utilities::MPI::all_gather(tria.get_mpi_communicator(), local_reduced_box);
 
   const GridTools::Cache<dim> cache(tria, mapping);
 

--- a/tests/remote_point_evaluation/remote_point_evaluation_01.cc
+++ b/tests/remote_point_evaluation/remote_point_evaluation_01.cc
@@ -58,7 +58,7 @@ get_mpi_comm(const MeshType &mesh)
                                       MeshType::space_dimension> *>(
     &(mesh.get_triangulation()));
 
-  return tria_parallel != nullptr ? tria_parallel->get_communicator() :
+  return tria_parallel != nullptr ? tria_parallel->get_mpi_communicator() :
                                     MPI_COMM_SELF;
 }
 

--- a/tests/remote_point_evaluation/remote_point_evaluation_02.cc
+++ b/tests/remote_point_evaluation/remote_point_evaluation_02.cc
@@ -93,7 +93,7 @@ get_mpi_comm(const MeshType &mesh)
                                       MeshType::space_dimension> *>(
     &(mesh.get_triangulation()));
 
-  return tria_parallel != nullptr ? tria_parallel->get_communicator() :
+  return tria_parallel != nullptr ? tria_parallel->get_mpi_communicator() :
                                     MPI_COMM_SELF;
 }
 

--- a/tests/remote_point_evaluation/remote_point_evaluation_03.cc
+++ b/tests/remote_point_evaluation/remote_point_evaluation_03.cc
@@ -76,7 +76,7 @@ get_mpi_comm(const MeshType &mesh)
                                       MeshType::space_dimension> *>(
     &(mesh.get_triangulation()));
 
-  return tria_parallel != nullptr ? tria_parallel->get_communicator() :
+  return tria_parallel != nullptr ? tria_parallel->get_mpi_communicator() :
                                     MPI_COMM_SELF;
 }
 

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_01.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_01.cc
@@ -83,7 +83,7 @@ get_mpi_comm(const MeshType &mesh)
                                       MeshType::space_dimension> *>(
     &(mesh.get_triangulation()));
 
-  return tria_parallel != nullptr ? tria_parallel->get_communicator() :
+  return tria_parallel != nullptr ? tria_parallel->get_mpi_communicator() :
                                     MPI_COMM_SELF;
 }
 

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_02.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_02.cc
@@ -56,7 +56,7 @@ get_mpi_comm(const MeshType &mesh)
                                       MeshType::space_dimension> *>(
     &(mesh.get_triangulation()));
 
-  return tria_parallel != nullptr ? tria_parallel->get_communicator() :
+  return tria_parallel != nullptr ? tria_parallel->get_mpi_communicator() :
                                     MPI_COMM_SELF;
 }
 

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_03.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_03.cc
@@ -52,7 +52,7 @@ get_mpi_comm(const MeshType &mesh)
                                       MeshType::space_dimension> *>(
     &(mesh.get_triangulation()));
 
-  return tria_parallel != nullptr ? tria_parallel->get_communicator() :
+  return tria_parallel != nullptr ? tria_parallel->get_mpi_communicator() :
                                     MPI_COMM_SELF;
 }
 

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_04.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_04.cc
@@ -51,7 +51,7 @@ get_mpi_comm(const MeshType &mesh)
                                       MeshType::space_dimension> *>(
     &(mesh.get_triangulation()));
 
-  return tria_parallel != nullptr ? tria_parallel->get_communicator() :
+  return tria_parallel != nullptr ? tria_parallel->get_mpi_communicator() :
                                     MPI_COMM_SELF;
 }
 

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_05.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_05.cc
@@ -51,7 +51,7 @@ get_mpi_comm(const MeshType &mesh)
                                       MeshType::space_dimension> *>(
     &(mesh.get_triangulation()));
 
-  return tria_parallel != nullptr ? tria_parallel->get_communicator() :
+  return tria_parallel != nullptr ? tria_parallel->get_mpi_communicator() :
                                     MPI_COMM_SELF;
 }
 

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_06.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_06.cc
@@ -52,7 +52,7 @@ create_partitioner(const DoFHandler<dim, spacedim> &dof_handler)
   return std::make_shared<const Utilities::MPI::Partitioner>(
     dof_handler.locally_owned_dofs(),
     locally_relevant_dofs,
-    dof_handler.get_communicator());
+    dof_handler.get_mpi_communicator());
 }
 
 void

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_07.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_07.cc
@@ -52,7 +52,7 @@ get_mpi_comm(const MeshType &mesh)
                                       MeshType::space_dimension> *>(
     &(mesh.get_triangulation()));
 
-  return tria_parallel != nullptr ? tria_parallel->get_communicator() :
+  return tria_parallel != nullptr ? tria_parallel->get_mpi_communicator() :
                                     MPI_COMM_SELF;
 }
 

--- a/tests/sharedtria/limit_p_level_difference_01.cc
+++ b/tests/sharedtria/limit_p_level_difference_01.cc
@@ -93,7 +93,7 @@ test(const unsigned int fes_size,
   for (const auto &cell :
        dofh.active_cell_iterators() | IteratorFilters::LocallyOwnedCell())
     count[cell->active_fe_index()]++;
-  Utilities::MPI::sum(count, tria.get_communicator(), count);
+  Utilities::MPI::sum(count, tria.get_mpi_communicator(), count);
   deallog << "fe count:" << count << std::endl;
 
 #ifdef DEBUG

--- a/tests/sharedtria/limit_p_level_difference_02.cc
+++ b/tests/sharedtria/limit_p_level_difference_02.cc
@@ -98,7 +98,7 @@ test(const unsigned int fes_size,
       for (const auto &cell :
            dofh.active_cell_iterators() | IteratorFilters::LocallyOwnedCell())
         count[cell->active_fe_index()]++;
-      Utilities::MPI::sum(count, tria.get_communicator(), count);
+      Utilities::MPI::sum(count, tria.get_mpi_communicator(), count);
       deallog << "cycle:" << i << ", fe count:" << count << std::endl;
     }
 

--- a/tests/simplex/poisson_01.cc
+++ b/tests/simplex/poisson_01.cc
@@ -87,7 +87,7 @@ get_communicator(const Triangulation<dim, spacedim> &tria)
 {
   if (auto tria_ =
         dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(&tria))
-    return tria_->get_communicator();
+    return tria_->get_mpi_communicator();
 
   return MPI_COMM_SELF;
 }

--- a/tests/sundials/n_vector.cc
+++ b/tests/sundials/n_vector.cc
@@ -346,7 +346,7 @@ test_destroy()
 template <typename VectorType,
           std::enable_if_t<is_serial_vector<VectorType>::value, int> = 0>
 void
-test_get_communicator()
+test_get_mpi_communicator()
 {
   auto vector   = create_test_vector<VectorType>();
   auto n_vector = make_nvector_view(vector
@@ -368,7 +368,7 @@ test_get_communicator()
 template <typename VectorType,
           std::enable_if_t<!is_serial_vector<VectorType>::value, int> = 0>
 void
-test_get_communicator()
+test_get_mpi_communicator()
 {
   auto vector   = create_test_vector<VectorType>();
   auto n_vector = make_nvector_view(vector
@@ -1081,7 +1081,7 @@ run_all_tests(const std::string &prefix)
   // test vector operations
   test_clone<VectorType>();
   test_destroy<VectorType>();
-  test_get_communicator<VectorType>();
+  test_get_mpi_communicator<VectorType>();
   test_length<VectorType>();
   test_linear_sum<VectorType>();
   test_linear_combination<VectorType>();

--- a/tests/trilinos/mg_transfer_prebuilt_01.cc
+++ b/tests/trilinos/mg_transfer_prebuilt_01.cc
@@ -56,7 +56,7 @@ reinit_vector(const dealii::DoFHandler<dim, spacedim>      &mg_dof,
   for (unsigned int level = v.min_level(); level <= v.max_level(); ++level)
     {
       v[level].reinit(mg_dof.locally_owned_mg_dofs(level),
-                      tria->get_communicator());
+                      tria->get_mpi_communicator());
     }
 }
 


### PR DESCRIPTION
We use the later name more often than the former.