### PR TITLE
Always use Kokkos::abort when it's noreturn

### DIFF
--- a/source/base/exceptions.cc
+++ b/source/base/exceptions.cc
@@ -517,9 +517,11 @@ namespace deal_II_exceptions
         }
 #endif
 
-      // Let's abort the program here. On the host, we need to call std::abort,
-      // on devices we need to do something different. Kokkos::abort() does
-      // the right thing in all circumstances.
+        // Let's abort the program here. On the host, we need to call
+        // std::abort, on devices we need to do something different.
+        // Kokkos::abort() does the right thing in all circumstances.
+
+#if KOKKOS_VERSION < 30200
       if constexpr (std::is_same_v<Kokkos::DefaultExecutionSpace,
                                    Kokkos::DefaultHostExecutionSpace>)
         {
@@ -529,6 +531,7 @@ namespace deal_II_exceptions
           std::abort();
         }
       else
+#endif
         {
           Kokkos::abort(
             "Abort() was called during dealing with an assertion or exception.");


### PR DESCRIPTION
We noticed some problems when calling `std::abort` on Mac OS X which should be solved by using `Kokkos::abort` instead. We previously avoided that when on the host since the function wasn't declared `noreturn` before Kokkos 3.2.00 (https://github.com/kokkos/kokkos/pull/3106).