### PR TITLE
Tpetra: Fix is_vector_space_vector check with complex values

### DIFF
--- a/source/lac/trilinos_tpetra_block_vector.cc
+++ b/source/lac/trilinos_tpetra_block_vector.cc
@@ -45,15 +45,15 @@ namespace LinearAlgebra
 #  ifdef DEAL_II_WITH_COMPLEX_VALUES
 #    ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
 #      ifdef DEAL_II_HAVE_CXX20
-    static_assert(concepts::is_vector_space_vector <
-                  BlockVector<std::complex<float>>);
+    static_assert(
+      concepts::is_vector_space_vector<BlockVector<std::complex<float>>>);
 #      endif
     template class BlockVector<std::complex<float>>;
 #    endif
 #    ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
 #      ifdef DEAL_II_HAVE_CXX20
-    static_assert(concepts::is_vector_space_vector <
-                  BlockVector<std::complex<double>>);
+    static_assert(
+      concepts::is_vector_space_vector<BlockVector<std::complex<double>>>);
 #      endif
     template class BlockVector<std::complex<double>>;
 #    endif

--- a/source/lac/trilinos_tpetra_vector.cc
+++ b/source/lac/trilinos_tpetra_vector.cc
@@ -59,8 +59,8 @@ namespace LinearAlgebra
 #  ifdef DEAL_II_WITH_COMPLEX_VALUES
 #    ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
 #      ifdef DEAL_II_HAVE_CXX20
-    static_assert(concepts::is_vector_space_vector <
-                  Vector<std::complex<float>>);
+    static_assert(
+      concepts::is_vector_space_vector<Vector<std::complex<float>>>);
 #      endif
     template class Vector<std::complex<float>>;
     template Vector<std::complex<float>> &
@@ -74,8 +74,8 @@ namespace LinearAlgebra
 
 #    ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
 #      ifdef DEAL_II_HAVE_CXX20
-    static_assert(concepts::is_vector_space_vector <
-                  Vector<std::complex<double>>);
+    static_assert(
+      concepts::is_vector_space_vector<Vector<std::complex<double>>>);
 #      endif
     template class Vector<std::complex<double>>;
     template Vector<std::complex<double>> &


### PR DESCRIPTION
We might need to include in a patch release.