### PR TITLE
fixed (void) in grid_tools.cc

### DIFF
--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -197,11 +197,9 @@ namespace GridTools
 
   template <int dim, int spacedim>
   void
-  rotate(const double angle, Triangulation<dim, spacedim> &triangulation)
+  rotate(const double /*angle*/,
+         Triangulation<dim, spacedim> & /*triangulation*/)
   {
-    (void)angle;
-    (void)triangulation;
-
     AssertThrow(false,
                 ExcMessage(
                   "GridTools::rotate() is only available for spacedim = 2."));


### PR DESCRIPTION
Per instructions during the workshop, I worked on grid_tools.cc and commented the first 2 occurences of (void), and kept the rest since they have been used in other functions.