### PR TITLE
Add get_mpi_communicator() to concept vector_space_vector

### DIFF
--- a/doc/news/changes/minor/20240819Kronbichler
+++ b/doc/news/changes/minor/20240819Kronbichler
@@ -1,0 +1,6 @@
+Changed: The concepts::is_vector_space_vector now also requires the vector
+class to provide a function `VectorType::get_mpi_communicator() -> MPI_Comm`,
+which returns the underlying MPI communicator or, if a sequential vector,
+@p MPI_COMM_SELF.
+<br>
+(Martin Kronbichler, David Wells, 2024/08/19)

--- a/include/deal.II/base/template_constraints.h
+++ b/include/deal.II/base/template_constraints.h
@@ -19,6 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/complex_overloads.h>
+#include <deal.II/base/mpi_stub.h>
 #include <deal.II/base/std_cxx20/type_traits.h>
 
 #include <complex>
@@ -1051,6 +1052,10 @@ namespace concepts
     {
       U.all_zero()
     } -> std::same_as<bool>;
+
+    {
+      U.get_mpi_communicator()
+    } -> std::same_as<MPI_Comm>;
   };
 
 

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -950,6 +950,14 @@ public:
   update_ghost_values() const;
 
   /**
+   * This function returns the MPI communicator of the vector in the
+   * underlying blocks or, if the vector has not been initialized, the empty
+   * MPI_COMM_SELF.
+   */
+  MPI_Comm
+  get_mpi_communicator() const;
+
+  /**
    * Determine an estimate for the memory consumption (in bytes) of this
    * object.
    */
@@ -1990,6 +1998,18 @@ BlockVectorBase<VectorType>::update_ghost_values() const
 {
   for (size_type i = 0; i < n_blocks(); ++i)
     block(i).update_ghost_values();
+}
+
+
+
+template <typename VectorType>
+MPI_Comm
+BlockVectorBase<VectorType>::get_mpi_communicator() const
+{
+  if (n_blocks() > 0)
+    return block(0).get_mpi_communicator();
+  else
+    return MPI_COMM_SELF;
 }
 
 

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -1072,6 +1072,16 @@ public:
    */
   void
   zero_out_ghost_values() const;
+
+  /**
+   * This function returns the empty object MPI_COMM_SELF that does not signal
+   * any parallel communication model, as this vector is in fact serial with
+   * respect to the message passing interface (MPI). The function exists for
+   * compatibility with the @p parallel vector classes (e.g.,
+   * LinearAlgebra::distributed::Vector class).
+   */
+  MPI_Comm
+  get_mpi_communicator() const;
   /** @} */
 
 private:
@@ -1411,6 +1421,14 @@ inline void
 Vector<Number>::update_ghost_values() const
 {}
 
+
+
+template <typename Number>
+inline MPI_Comm
+Vector<Number>::get_mpi_communicator() const
+{
+  return MPI_COMM_SELF;
+}
 
 
 template <typename Number>


### PR DESCRIPTION
This implements the suggestion by https://github.com/dealii/dealii/pull/17547#pullrequestreview-2242929824 in terms of adding `get_mpi_communicator()` to the `is_vector_space_vector` concept. If this finds approval, I will add a changelog and simplify #17547 with it.