### PR TITLE
Suppress a warning about an unused variable.

### DIFF
--- a/source/fe/fe_face.cc
+++ b/source/fe/fe_face.cc
@@ -950,7 +950,7 @@ FE_FaceP<dim, spacedim>::get_subface_interpolation_matrix(
                     face_quadrature.point(k), subface);
               v_in(k) = this->poly_space.compute_value(i, p);
             }
-          const double result = H.least_squares(v_out, v_in);
+          [[maybe_unused]] const double result = H.least_squares(v_out, v_in);
           Assert(result < 1e-12, FETools::ExcLeastSquaresError(result));
 
           for (unsigned int j = 0; j < source_fe->n_dofs_per_face(face_no); ++j)


### PR DESCRIPTION
Fixes #17562. Fixes #17556.