### PR TITLE
Quadratic and cubic pyramid elements

### DIFF
--- a/include/deal.II/base/polynomial.h
+++ b/include/deal.II/base/polynomial.h
@@ -770,6 +770,16 @@ namespace Polynomials
                           const Number       x,
                           const bool         rescale = true);
 
+  /*
+   * Evaluate the derivative of the Jacobi polynomial $ d P_n^{\alpha, \beta}(x)
+   * / dx $ specified by the
+   * parameters @p alpha, @p beta, @p n, where @p n is the degree of the
+   * Jacobi polynomial.
+   *
+   * @note The Jacobi polynomials are not orthonormal and are defined on the
+   * unit interval $[0, 1]$ as usual for deal.II, rather than $[-1, +1]$ often
+   * used in literature. @p x is the point of evaluation.
+   */
   template <typename Number>
   Number
   jacobi_polynomial_derivative(const unsigned int degree,
@@ -777,7 +787,6 @@ namespace Polynomials
                                const int          beta,
                                const Number       x,
                                const bool         rescale = true);
-
 
   /**
    * Compute the roots of the Jacobi polynomials on the unit interval $[0, 1]$
@@ -1106,14 +1115,11 @@ namespace Polynomials
     if (degree == 0)
       return 0.0;
     if (rescale)
-      return (1 + alpha + beta + degree) * jacobi_polynomial_value(degree - 1,
-                                                                   alpha + 1,
-                                                                   beta + 1,
-                                                                   x,
-                                                                   rescale);
+      return (1 + alpha + beta + degree) *
+             jacobi_polynomial_value(degree - 1, alpha + 1, beta + 1, x, true);
 
     return 0.5 * (1 + alpha + beta + degree) *
-           jacobi_polynomial_value(degree - 1, alpha + 1, beta + 1, x, rescale);
+           jacobi_polynomial_value(degree - 1, alpha + 1, beta + 1, x, false);
   }
 
 

--- a/include/deal.II/base/polynomial.h
+++ b/include/deal.II/base/polynomial.h
@@ -767,7 +767,16 @@ namespace Polynomials
   jacobi_polynomial_value(const unsigned int degree,
                           const int          alpha,
                           const int          beta,
-                          const Number       x);
+                          const Number       x,
+                          const bool         rescale = true);
+
+  template <typename Number>
+  Number
+  jacobi_polynomial_derivative(const unsigned int degree,
+                               const int          alpha,
+                               const int          beta,
+                               const Number       x,
+                               const bool         rescale = true);
 
 
   /**
@@ -1045,7 +1054,8 @@ namespace Polynomials
   jacobi_polynomial_value(const unsigned int degree,
                           const int          alpha,
                           const int          beta,
-                          const Number       x)
+                          const Number       x,
+                          const bool         rescale)
   {
     Assert(alpha >= 0 && beta >= 0,
            ExcNotImplemented("Negative alpha/beta coefficients not supported"));
@@ -1054,7 +1064,7 @@ namespace Polynomials
 
     // The recursion formula is defined for the interval [-1, 1], so rescale
     // to that interval here
-    const Number xeval = Number(-1) + 2. * x;
+    const Number xeval = rescale ? Number(-1) + 2. * x : x;
 
     // initial values P_0(x), P_1(x):
     p0 = 1.0;
@@ -1077,6 +1087,33 @@ namespace Polynomials
         p1              = pn;
       }
     return p1;
+  }
+
+
+  template <typename Number>
+  Number
+  jacobi_polynomial_derivative(const unsigned int degree,
+                               const int          alpha,
+                               const int          beta,
+                               const Number       x,
+                               const bool         rescale)
+  {
+    Assert(alpha >= 0 && beta >= 0,
+           ExcNotImplemented("Negative alpha/beta coefficients not supported"));
+
+    // The derivative of the Jacobi polynomial is evaluated using the recurrence
+    // relations
+    if (degree == 1)
+      return 0.0;
+    if (rescale)
+      return (1 + alpha + beta + degree) * jacobi_polynomial_value(degree - 1,
+                                                                   alpha + 1,
+                                                                   beta + 1,
+                                                                   x,
+                                                                   rescale);
+
+    return 0.5 * (1 + alpha + beta + degree) *
+           jacobi_polynomial_value(degree - 1, alpha + 1, beta + 1, x, rescale);
   }
 
 

--- a/include/deal.II/base/polynomial.h
+++ b/include/deal.II/base/polynomial.h
@@ -1103,7 +1103,7 @@ namespace Polynomials
 
     // The derivative of the Jacobi polynomial is evaluated using the recurrence
     // relations
-    if (degree == 1)
+    if (degree == 0)
       return 0.0;
     if (rescale)
       return (1 + alpha + beta + degree) * jacobi_polynomial_value(degree - 1,

--- a/include/deal.II/base/polynomials_pyramid.h
+++ b/include/deal.II/base/polynomials_pyramid.h
@@ -57,6 +57,9 @@ public:
            std::vector<Tensor<3, dim>> &third_derivatives,
            std::vector<Tensor<4, dim>> &fourth_derivatives) const override;
 
+  /**
+   * @copydoc ScalarPolynomialsBase::compute_value()
+   */
   double
   compute_value(const unsigned int i, const Point<dim> &p) const override;
 
@@ -118,25 +121,40 @@ public:
   clone() const override;
 
 private:
+  /**
+   * Inverse of the Vandermonde matrix
+   */
   FullMatrix<double> VDM_inv;
 
+  /**
+   * Evaluate orthogonal base at point @p p
+   */
   double
   compute_polynomial_space(const unsigned int i,
                            const unsigned int j,
                            const unsigned int k,
                            const Point<dim>  &p) const;
 
+  /**
+   * Evaluate orthogonal basis function @p i at point @p p
+   */
   double
   compute_jacobi_basis(const unsigned int i, const Point<dim> &p) const;
 
+  /**
+   * Evaluate the derivative of the orthogonal base at point @p p
+   */
   Tensor<1, dim>
-  compute_polynomial_space_deriv(const unsigned int i,
-                                 const unsigned int j,
-                                 const unsigned int k,
-                                 const Point<dim>  &p) const;
+  compute_polynomial_space_derivative(const unsigned int i,
+                                      const unsigned int j,
+                                      const unsigned int k,
+                                      const Point<dim>  &p) const;
 
+  /**
+   * Evaluate the derivative of the orthogonal basis @p i at point @p p
+   */
   Tensor<1, dim>
-  compute_jacobi_deriv(const unsigned int i, const Point<dim> &p) const;
+  compute_jacobi_derivative(const unsigned int i, const Point<dim> &p) const;
 };
 
 

--- a/include/deal.II/base/polynomials_pyramid.h
+++ b/include/deal.II/base/polynomials_pyramid.h
@@ -121,14 +121,6 @@ private:
   FullMatrix<double> VDM_inv;
 
   double
-  compute_jacobi_basis_functions(const unsigned int i,
-                                 const Point<dim>  &p) const;
-
-  Tensor<1, dim>
-  compute_jacobi_deriv_basis_functions(const unsigned int i,
-                                       const Point<dim>  &p) const;
-
-  double
   compute_polynomial_space(const unsigned int i,
                            const unsigned int j,
                            const unsigned int k,

--- a/include/deal.II/base/polynomials_pyramid.h
+++ b/include/deal.II/base/polynomials_pyramid.h
@@ -20,6 +20,8 @@
 
 #include <deal.II/base/scalar_polynomials_base.h>
 
+#include <deal.II/lac/full_matrix.h>
+
 DEAL_II_NAMESPACE_OPEN
 
 /**
@@ -37,8 +39,6 @@ public:
 
   /*
    * Constructor taking the polynomial @p degree as input.
-   *
-   * @note Currently, only linear polynomials (degree=1) are implemented.
    */
   ScalarLagrangePolynomialPyramid(const unsigned int degree);
 
@@ -114,6 +114,17 @@ public:
 
   virtual std::unique_ptr<ScalarPolynomialsBase<dim>>
   clone() const override;
+
+private:
+  FullMatrix<double> VDM_inv;
+
+  double
+  compute_jacobi_basis_functions(const unsigned int i,
+                                 const Point<dim>  &p) const;
+
+  Tensor<1, dim>
+  compute_jacobi_deriv_basis_functions(const unsigned int i,
+                                       const Point<dim>  &p) const;
 };
 
 

--- a/include/deal.II/base/polynomials_pyramid.h
+++ b/include/deal.II/base/polynomials_pyramid.h
@@ -40,7 +40,9 @@ public:
   /*
    * Constructor taking the polynomial @p degree as input.
    */
-  ScalarLagrangePolynomialPyramid(const unsigned int degree);
+  ScalarLagrangePolynomialPyramid(const unsigned int            degree,
+                                  const unsigned int            n_dofs,
+                                  const std::vector<Point<dim>> support_points);
 
   /**
    * @copydoc ScalarPolynomialsBase::evaluate()

--- a/include/deal.II/base/polynomials_pyramid.h
+++ b/include/deal.II/base/polynomials_pyramid.h
@@ -125,6 +125,24 @@ private:
   Tensor<1, dim>
   compute_jacobi_deriv_basis_functions(const unsigned int i,
                                        const Point<dim>  &p) const;
+
+  double
+  compute_polynomial_space(const unsigned int i,
+                           const unsigned int j,
+                           const unsigned int k,
+                           const Point<dim>  &p) const;
+
+  double
+  compute_jacobi_basis(const unsigned int i, const Point<dim> &p) const;
+
+  Tensor<1, dim>
+  compute_polynomial_space_deriv(const unsigned int i,
+                                 const unsigned int j,
+                                 const unsigned int k,
+                                 const Point<dim>  &p) const;
+
+  Tensor<1, dim>
+  compute_jacobi_deriv(const unsigned int i, const Point<dim> &p) const;
 };
 
 

--- a/include/deal.II/fe/fe_pyramid_p.h
+++ b/include/deal.II/fe/fe_pyramid_p.h
@@ -38,8 +38,9 @@ public:
   /**
    * Constructor.
    */
-  FE_PyramidPoly(const unsigned int                                degree,
-                 const internal::GenericDoFsPerObject             &dpos,
+  FE_PyramidPoly(const unsigned int                    degree,
+                 const internal::GenericDoFsPerObject &dpos,
+                 const bool                            prolongation_is_additive,
                  const typename FiniteElementData<dim>::Conformity conformity);
 
   /**

--- a/include/deal.II/fe/fe_pyramid_p.h
+++ b/include/deal.II/fe/fe_pyramid_p.h
@@ -51,15 +51,6 @@ public:
   convert_generalized_support_point_values_to_dof_values(
     const std::vector<Vector<double>> &support_point_values,
     std::vector<double>               &nodal_values) const override;
-
-
-
-  std::pair<const internal::GenericDoFsPerObject, const std::vector<Point<dim>>>
-  get_support_points_dpo_vector_fe_pyramid_dgp(const unsigned int dim_,
-                                               const unsigned int degree);
-  std::pair<const internal::GenericDoFsPerObject, const std::vector<Point<dim>>>
-  get_support_points_dpo_vector_fe_pyramid_p(const unsigned int dim_,
-                                             const unsigned int degree);
 };
 
 /**

--- a/include/deal.II/fe/fe_pyramid_p.h
+++ b/include/deal.II/fe/fe_pyramid_p.h
@@ -38,9 +38,10 @@ public:
   /**
    * Constructor.
    */
-  FE_PyramidPoly(const unsigned int                    degree,
-                 const internal::GenericDoFsPerObject &dpos,
-                 const bool                            prolongation_is_additive,
+  FE_PyramidPoly(const unsigned int                       degree,
+                 std::pair<const internal::GenericDoFsPerObject,
+                           const std::vector<Point<dim>>> dpos_support_points,
+                 const bool prolongation_is_additive,
                  const typename FiniteElementData<dim>::Conformity conformity);
 
   /**
@@ -50,6 +51,15 @@ public:
   convert_generalized_support_point_values_to_dof_values(
     const std::vector<Vector<double>> &support_point_values,
     std::vector<double>               &nodal_values) const override;
+
+
+
+  std::pair<const internal::GenericDoFsPerObject, const std::vector<Point<dim>>>
+  get_support_points_dpo_vector_fe_pyramid_dgp(const unsigned int dim_,
+                                               const unsigned int degree);
+  std::pair<const internal::GenericDoFsPerObject, const std::vector<Point<dim>>>
+  get_support_points_dpo_vector_fe_pyramid_p(const unsigned int dim_,
+                                             const unsigned int degree);
 };
 
 /**

--- a/include/deal.II/fe/fe_simplex_p.h
+++ b/include/deal.II/fe/fe_simplex_p.h
@@ -171,6 +171,13 @@ public:
   std::vector<std::pair<unsigned int, unsigned int>>
   hp_line_dof_identities(
     const FiniteElement<dim, spacedim> &fe_other) const override;
+
+  /**
+   * @copydoc dealii::FiniteElement::hp_quad_dof_identities()
+   */
+  std::vector<std::pair<unsigned int, unsigned int>>
+  hp_quad_dof_identities(const FiniteElement<dim, spacedim> &fe_other,
+                         const unsigned int face_no = 0) const override;
 };
 
 

--- a/include/deal.II/fe/fe_wedge_p.h
+++ b/include/deal.II/fe/fe_wedge_p.h
@@ -38,8 +38,9 @@ public:
   /**
    * Constructor.
    */
-  FE_WedgePoly(const unsigned int                                degree,
-               const internal::GenericDoFsPerObject             &dpos,
+  FE_WedgePoly(const unsigned int                    degree,
+               const internal::GenericDoFsPerObject &dpos,
+               const bool                            prolongation_is_additive,
                const typename FiniteElementData<dim>::Conformity conformity);
 
   /**

--- a/source/base/polynomials_pyramid.cc
+++ b/source/base/polynomials_pyramid.cc
@@ -217,15 +217,6 @@ ScalarLagrangePolynomialPyramid<dim>::ScalarLagrangePolynomialPyramid(
     for (unsigned j = 0; j < VDM.n(); ++j)
       VDM[i][j] = this->compute_jacobi_basis(i, support_points[j]);
 
-  std::cout << "VDM" << std::endl;
-  for (unsigned i = 0; i < support_points.size(); ++i)
-    {
-      for (unsigned j = 0; j < support_points.size(); ++j)
-        std::cout << VDM[i][j] << " ";
-      std::cout << std::endl;
-    }
-
-
   // get inverse
   VDM.gauss_jordan();
 

--- a/source/base/polynomials_pyramid.cc
+++ b/source/base/polynomials_pyramid.cc
@@ -13,8 +13,12 @@
 // ------------------------------------------------------------------------
 
 
+#include <deal.II/base/point.h>
 #include <deal.II/base/polynomials_barycentric.h>
 #include <deal.II/base/polynomials_pyramid.h>
+
+#include <deal.II/grid/reference_cell.h>
+
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -39,13 +43,269 @@ namespace
 } // namespace
 
 
+template <int dim>
+double
+ScalarLagrangePolynomialPyramid<dim>::compute_jacobi_basis_functions(
+  const unsigned int i,
+  const Point<dim>  &p) const
+{
+  if (this->degree() == 2)
+    {
+      double       basis;
+      const double x = p[0];
+      const double y = p[1];
+      const double z = p[2];
+
+      double ratio;
+      if (std::fabs(z - 1.0) < 1e-12)
+        {
+          ratio = 0.0;
+        }
+      else
+        {
+          ratio = 1.0 / (z - 1.0);
+        }
+
+      switch (i)
+        {
+          case 0:
+            basis = 1.0;
+            break;
+          case 1:
+            basis = 4.0 * z - 1.0;
+            break;
+          case 2:
+            basis = 15.0 * std::pow(z, 2) - 10.0 * z + 1.0;
+            break;
+          case 3:
+            basis = y;
+            break;
+          case 4:
+            basis = y * (6.0 * z - 1.0);
+            break;
+          case 5:
+            basis = 3 * std::pow(y, 2) * 0.5 - std::pow(z, 2) * 0.5 + z - 0.5;
+            break;
+          case 6:
+            basis = x;
+            break;
+          case 7:
+            basis = x * (6.0 * z - 1.0);
+            break;
+          case 8:
+            basis = -x * y * ratio;
+            break;
+          case 9:
+            basis = x * y * (1.0 - 6.0 * z) * ratio;
+            break;
+          case 10:
+            basis = x * (-3.0 * std::pow(y, 2) + std::pow(z, 2) - 2 * z + 1.0) *
+                    0.5 * ratio;
+            break;
+          case 11:
+            basis = 3.0 / 2.0 * std::pow(x, 2) - std::pow(z, 2) * 0.5 + z - 0.5;
+            break;
+          case 12:
+            basis = y *
+                    (-3.0 * std::pow(x, 2) + std::pow(z, 2) - 2.0 * z + 1.0) *
+                    0.5 * ratio;
+            break;
+          case 13:
+            basis = (3.0 * std::pow(x, 2) - std::pow(z, 2) + 2.0 * z - 1.0) *
+                    (3.0 * std::pow(y, 2) - std::pow(z, 2) + 2.0 * z - 1.0) *
+                    0.25 * std::pow(ratio, 2);
+            break;
+          default:
+
+            DEAL_II_NOT_IMPLEMENTED();
+            break;
+        }
+      if (std::fabs(basis) < 1e-14)
+        basis = 0.0;
+
+      return basis;
+    }
+  DEAL_II_NOT_IMPLEMENTED();
+  return 0;
+}
+
+
+template <int dim>
+Tensor<1, dim>
+ScalarLagrangePolynomialPyramid<dim>::compute_jacobi_deriv_basis_functions(
+  const unsigned int i,
+  const Point<dim>  &p) const
+{
+  if (this->degree() == 2)
+    {
+      Tensor<1, dim> grad;
+      const double   x = p[0];
+      const double   y = p[1];
+      const double   z = p[2];
+
+      double ratio;
+      if (std::fabs(z - 1.0) < 1e-12)
+        {
+          ratio = 0.0;
+        }
+      else
+        {
+          ratio = 1.0 / (z - 1.0);
+        }
+
+      switch (i)
+        {
+          case 0:
+            grad[0] = 0.0;
+            grad[1] = 0.0;
+            grad[2] = 0.0;
+            break;
+          case 1:
+            grad[0] = 0.0;
+            grad[1] = 0.0;
+            grad[2] = 4.0;
+            break;
+          case 2:
+            grad[0] = 0.0;
+            grad[1] = 0.0;
+            grad[2] = 30.0 * z - 10.0;
+            break;
+          case 3:
+            grad[0] = 0.0;
+            grad[1] = 1.0;
+            grad[2] = 0.0;
+            break;
+          case 4:
+            grad[0] = 0.0;
+            grad[1] = 6.0 * z - 1.0;
+            grad[2] = 6.0 * y;
+            break;
+          case 5:
+            grad[0] = 0.0;
+            grad[1] = 3.0 * y;
+            grad[2] = 1.0 - z;
+            break;
+          case 6:
+            grad[0] = 1.0;
+            grad[1] = 0;
+            grad[2] = 0;
+            break;
+          case 7:
+            grad[0] = 6.0 * z - 1.0;
+            grad[1] = 0;
+            grad[2] = 6.0 * x;
+            break;
+          case 8:
+            grad[0] = -y * ratio;
+            grad[1] = -x * ratio;
+            grad[2] = x * y * std::pow(ratio, 2);
+            break;
+          case 9:
+            grad[0] = y * (1.0 - 6.0 * z) * ratio;
+            grad[1] = x * (1.0 - 6.0 * z) * ratio;
+            grad[2] = 5 * x * y * std::pow(ratio, 2);
+            break;
+          case 10:
+            grad[0] = (-3.0 * std::pow(y, 2) + std::pow(z, 2) - 2.0 * z + 1) *
+                      0.5 * ratio;
+            grad[1] = -3.0 * x * y * ratio;
+            grad[2] = x *
+                      (3.0 * std::pow(y, 2) + std::pow(z, 2) - 2.0 * z + 1) *
+                      0.5 * std::pow(ratio, 2);
+            break;
+          case 11:
+            grad[0] = 3.0 * x;
+            grad[1] = 0.0;
+            grad[2] = 1.0 - z;
+            break;
+          case 12:
+            grad[0] = -3.0 * x * y * ratio;
+            grad[1] = (-3.0 * std::pow(x, 2) + std::pow(z, 2) - 2.0 * z + 1) *
+                      0.5 * ratio;
+            grad[2] = y *
+                      (3.0 * std::pow(x, 2) + std::pow(z, 2) - 2.0 * z + 1.0) *
+                      0.5 * std::pow(ratio, 2);
+            break;
+          case 13:
+            {
+              double ratio_13 =
+                (ratio == 0.0) ?
+                  0.0 :
+                  std::pow(z, 3) - 3.0 * std::pow(z, 2) + 3.0 * z - 1.0;
+              grad[0] =
+                3.0 * x *
+                (3.0 * std::pow(y, 2) - std::pow(z, 2) + 2.0 * z - 1.0) * 0.5 *
+                std::pow(ratio, 2);
+              grad[1] =
+                3.0 * y *
+                (3.0 * std::pow(x, 2) - std::pow(z, 2) + 2.0 * z - 1.0) * 0.5 *
+                std::pow(ratio, 2);
+              grad[2] =
+                (-9.0 * std::pow(x, 2) * std::pow(y, 2) + std::pow(z, 4) -
+                 4.0 * std::pow(z, 3) + 6.0 * std::pow(z, 2) - 4.0 * z + 1) *
+                0.5 * ratio_13;
+            }
+            break;
+          default:
+            DEAL_II_NOT_IMPLEMENTED();
+            break;
+        }
+      for (unsigned int d = 0; d < dim; ++d)
+        if (std::fabs(grad[d]) < 1e-14)
+          grad[d] = 0.0;
+
+      return grad;
+    }
+  DEAL_II_NOT_IMPLEMENTED();
+  return Tensor<1, dim>();
+}
+
 
 template <int dim>
 ScalarLagrangePolynomialPyramid<dim>::ScalarLagrangePolynomialPyramid(
   const unsigned int degree)
   : ScalarPolynomialsBase<dim>(degree,
                                compute_n_polynomials_pyramid(dim, degree))
-{}
+{
+  if (this->degree() == 2)
+    {
+      // Compute VDM Matrix and its inverse
+      // Get unit support points
+      std::vector<Point<dim>> support_points;
+      const ReferenceCell     reference_cell = ReferenceCells::Pyramid;
+
+      for (const auto i : reference_cell.vertex_indices())
+        support_points.emplace_back(reference_cell.template vertex<dim>(i));
+
+      // lines:
+      for (const unsigned int l : reference_cell.line_indices())
+        {
+          support_points.emplace_back(
+            0.5 * support_points[reference_cell.line_to_cell_vertices(l, 0)] +
+            0.5 * support_points[reference_cell.line_to_cell_vertices(l, 1)]);
+        }
+      // quad:
+      support_points.emplace_back(Point<dim>(0.0, 0.0, 0.0));
+
+      // Now fill VDM Matrix
+      FullMatrix<double> VDM(support_points.size());
+
+      for (unsigned i = 0; i < support_points.size(); ++i)
+        for (unsigned j = 0; j < support_points.size(); ++j)
+          VDM[i][j] =
+            this->compute_jacobi_basis_functions(i, support_points[j]);
+
+      // get inverse
+      VDM.gauss_jordan();
+
+      for (unsigned i = 0; i < support_points.size(); ++i)
+        for (unsigned j = 0; j < support_points.size(); ++j)
+          if (std::fabs(VDM[i][j]) < 1e-14)
+            VDM[i][j] = 0.0;
+
+      VDM_inv = VDM;
+    }
+}
 
 
 template <int dim>
@@ -87,182 +347,15 @@ ScalarLagrangePolynomialPyramid<dim>::compute_value(const unsigned int i,
     }
   else if (this->degree() == 2)
     {
-      const double x = p[0];
-      const double y = p[1];
-      const double z = p[2];
+      AssertIndexRange(i, VDM_inv.m());
 
-      double result;
+      double result = 0;
+      for (unsigned int j = 0; j < VDM_inv.n(); ++j)
+        result += VDM_inv[i][j] * this->compute_jacobi_basis_functions(j, p);
 
-      double ration;
-      double ration_square;
+      if (std::fabs(result) < 1e-14)
+        result = 0.0;
 
-      if (fabs(z - 1.0) > 1.0e-14)
-        {
-          ration        = 1.0 / (z - 1.0);
-          ration_square = std::pow(ration, 2);
-        }
-      else
-        {
-          ration        = 1.0;
-          ration_square = 1.0;
-        }
-
-      switch (i)
-        {
-          case 0:
-            result =
-              (std::pow(z - 1, 2) *
-                 ((1.0 / 12) * std::pow(x, 2) + (1.0 / 18) * x * (6 * z - 1) -
-                  (1.0 / 36) * x + (1.0 / 12) * std::pow(y, 2) +
-                  (1.0 / 18) * y * (6 * z - 1) - (1.0 / 36) * y +
-                  (2.0 / 9) * std::pow(z, 2) - (7.0 / 36) * z - (1.0 / 36)) +
-               (z - 1) * ((1.0 / 12) * x * y * (6 * z - 1) - (1.0 / 6) * x * y +
-                          (1.0 / 12) * x *
-                            (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1) +
-                          (1.0 / 12) * y *
-                            (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1)) +
-               (1.0 / 36) * (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) *
-                 (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1)) *
-              ration_square;
-            break;
-          case 1:
-            result =
-              (std::pow(z - 1, 2) *
-                 ((1.0 / 12) * std::pow(x, 2) - (1.0 / 18) * x * (6 * z - 1) +
-                  (1.0 / 36) * x + (1.0 / 12) * std::pow(y, 2) +
-                  (1.0 / 18) * y * (6 * z - 1) - (1.0 / 36) * y +
-                  (2.0 / 9) * std::pow(z, 2) - (7.0 / 36) * z - (1.0 / 36)) -
-               (z - 1) * ((1.0 / 12) * x * y * (6 * z - 1) - (1.0 / 6) * x * y +
-                          (1.0 / 12) * x *
-                            (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1) -
-                          (1.0 / 12) * y *
-                            (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1)) +
-               (1.0 / 36) * (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) *
-                 (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1)) *
-              ration_square;
-            break;
-          case 2:
-            result =
-              (std::pow(z - 1, 2) *
-                 ((1.0 / 12) * std::pow(x, 2) + (1.0 / 18) * x * (6 * z - 1) -
-                  (1.0 / 36) * x + (1.0 / 12) * std::pow(y, 2) -
-                  (1.0 / 18) * y * (6 * z - 1) + (1.0 / 36) * y +
-                  (2.0 / 9) * std::pow(z, 2) - (7.0 / 36) * z - (1.0 / 36)) -
-               (z - 1) * ((1.0 / 12) * x * y * (6 * z - 1) - (1.0 / 6) * x * y -
-                          (1.0 / 12) * x *
-                            (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1) +
-                          (1.0 / 12) * y *
-                            (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1)) +
-               (1.0 / 36) * (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) *
-                 (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1)) *
-              ration_square;
-            break;
-          case 3:
-            result =
-              (std::pow(z - 1, 2) *
-                 ((1.0 / 12) * std::pow(x, 2) - (1.0 / 18) * x * (6 * z - 1) +
-                  (1.0 / 36) * x + (1.0 / 12) * std::pow(y, 2) -
-                  (1.0 / 18) * y * (6 * z - 1) + (1.0 / 36) * y +
-                  (2.0 / 9) * std::pow(z, 2) - (7.0 / 36) * z - (1.0 / 36)) -
-               (z - 1) *
-                 (-(1.0 / 12) * x * y * (6 * z - 1) + (1.0 / 6) * x * y +
-                  (1.0 / 12) * x *
-                    (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1) +
-                  (1.0 / 12) * y *
-                    (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1)) +
-               (1.0 / 36) * (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) *
-                 (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1)) *
-              ration_square;
-            break;
-          case 4:
-            result = z * (2 * z - 1);
-            break;
-          case 5:
-            result =
-              (-x * (z - 1) *
-                 (0.5 * std::pow(y, 2) - 1.0 / 6 * std::pow(z, 2) +
-                  1.0 / 3 * z - 1.0 / 6) +
-               std::pow(z - 1, 2) *
-                 (1.0 / 3 * std::pow(x, 2) + 1.0 / 18 * x * (6 * z - 1) -
-                  5.0 / 18 * x - 1.0 / 6 * std::pow(y, 2) +
-                  1.0 / 18 * std::pow(z, 2) - 1.0 / 9 * z + 1.0 / 18) -
-               1.0 / 18 * (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) *
-                 (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1)) *
-              ration_square;
-            break;
-          case 6:
-            result =
-              (x * (z - 1) *
-                 (0.5 * std::pow(y, 2) - 1.0 / 6 * std::pow(z, 2) +
-                  1.0 / 3 * z - 1.0 / 6) +
-               std::pow(z - 1, 2) *
-                 (1.0 / 3 * std::pow(x, 2) - 1.0 / 18 * x * (6 * z - 1) +
-                  5.0 / 18 * x - 1.0 / 6 * std::pow(y, 2) +
-                  1.0 / 18 * std::pow(z, 2) - 1.0 / 9 * z + 1.0 / 18) -
-               1.0 / 18 * (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) *
-                 (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1)) *
-              ration_square;
-            break;
-          case 7:
-            result =
-              (-1.0 / 6 * y * (z - 1) *
-                 (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) +
-               std::pow(z - 1, 2) *
-                 (-1.0 / 6 * std::pow(x, 2) + 1.0 / 3 * std::pow(y, 2) +
-                  1.0 / 18 * y * (6 * z - 1) - 5.0 / 18 * y +
-                  1.0 / 18 * std::pow(z, 2) - 1.0 / 9 * z + 1.0 / 18) -
-               1.0 / 18 * (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) *
-                 (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1)) *
-              ration_square;
-            break;
-          case 8:
-            result =
-              (1.0 / 6 * y * (z - 1) *
-                 (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) +
-               std::pow(z - 1, 2) *
-                 (-1.0 / 6 * std::pow(x, 2) + 1.0 / 3 * std::pow(y, 2) -
-                  1.0 / 18 * y * (6 * z - 1) + 5.0 / 18 * y +
-                  1.0 / 18 * std::pow(z, 2) - 1.0 / 9 * z + 1.0 / 18) -
-               1.0 / 18 * (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) *
-                 (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1)) *
-              ration_square;
-            break;
-          case 9:
-            result =
-              (-x * y * z - x * std::pow(z, 2) + x * z - y * std::pow(z, 2) +
-               y * z - std::pow(z, 3) + 2.0 * std::pow(z, 2) - z - 0) *
-              ration;
-            break;
-          case 10:
-            result =
-              (x * y * z + x * std::pow(z, 2) - x * z - y * std::pow(z, 2) +
-               y * z - std::pow(z, 3) + 2.0 * std::pow(z, 2) - z - 0) *
-              ration;
-            break;
-          case 11:
-            result =
-              (x * y * z - x * std::pow(z, 2) + x * z + y * std::pow(z, 2) -
-               y * z - std::pow(z, 3) + 2.0 * std::pow(z, 2) - z + 0) *
-              ration;
-            break;
-          case 12:
-            result = z *
-                     (-x * y + x * z - x + y * z - y - std::pow(z, 2) +
-                      2.0 * z - 1.0) *
-                     ration;
-            break;
-          case 13:
-            result =
-              (std::pow(z - 1, 2) *
-                 (-2.0 / 3 * std::pow(x, 2) - 2.0 / 3 * std::pow(y, 2) +
-                  8.0 / 9 * std::pow(z, 2) - 16.0 / 9 * z + 8.0 / 9) +
-               1.0 / 9 * (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) *
-                 (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1)) *
-              ration_square;
-            break;
-          default:
-            DEAL_II_ASSERT_UNREACHABLE();
-        }
       return result;
     }
   DEAL_II_ASSERT_UNREACHABLE();
@@ -344,275 +437,20 @@ ScalarLagrangePolynomialPyramid<dim>::compute_grad(const unsigned int i,
     }
   else if (this->degree() == 2)
     {
-      const double x = p[0];
-      const double y = p[1];
-      const double z = p[2];
+      AssertIndexRange(i, VDM_inv.m());
 
-      switch (i)
-        {
-          case 0:
-            grad[0] = (1.0 / 6.0 * x *
-                         (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1) +
-                       std::pow((z - 1), 2) *
-                         (1.0 / 6.0 * x + 1.0 / 3.0 * z - 1.0 / 12.0) +
-                       (z - 1) * (0.5 * x * y + 0.25 * std::pow(y, 2) +
-                                  1.0 / 12.0 * y * (6 * z - 1) - 1.0 / 6.0 * y -
-                                  1.0 / 12.0 * std::pow(z, 2) + 1.0 / 6.0 * z -
-                                  1.0 / 12.0)) /
-                      std::pow((z - 1), 2);
-            grad[1] = (1.0 / 6.0 * y *
-                         (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) +
-                       std::pow((z - 1), 2) *
-                         (1.0 / 6.0 * y + 1.0 / 3.0 * z - 1.0 / 12.0) +
-                       (z - 1) * (0.25 * std::pow(x, 2) + 0.5 * x * y +
-                                  1.0 / 12.0 * x * (6 * z - 1) - 1.0 / 6.0 * x -
-                                  1.0 / 12.0 * std::pow(z, 2) + 1.0 / 6.0 * z -
-                                  1.0 / 12.0)) /
-                      std::pow((z - 1), 2);
-            grad[2] =
-              (-0.5 * std::pow(x, 2) * std::pow(y, 2) -
-               0.25 * std::pow(x, 2) * y * z + 0.25 * std::pow(x, 2) * y -
-               0.25 * x * std::pow(y, 2) * z + 0.25 * x * std::pow(y, 2) -
-               0.25 * x * y * z + 0.25 * x * y + 0.25 * x * std::pow(z, 3) -
-               0.75 * x * std::pow(z, 2) + 0.75 * x * z - 0.25 * x +
-               0.25 * y * std::pow(z, 3) - 0.75 * y * std::pow(z, 2) +
-               0.75 * y * z - 0.25 * y + 0.5 * std::pow(z, 4) -
-               1.75 * std::pow(z, 3) + 2.25 * std::pow(z, 2) - 1.25 * z +
-               0.25) /
-              (std::pow(z, 3) - 3.0 * std::pow(z, 2) + 3.0 * z - 1.0);
-            break;
+      for (unsigned int j = 0; j < VDM_inv.n(); ++j)
+        grad +=
+          VDM_inv[i][j] * this->compute_jacobi_deriv_basis_functions(j, p);
 
-          case 1:
-            grad[0] = (1.0 / 6.0 * x *
-                         (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1) +
-                       std::pow((z - 1), 2) *
-                         (1.0 / 6.0 * x - 1.0 / 3.0 * z + 1.0 / 12.0) +
-                       (z - 1) * (0.5 * x * y - 0.25 * std::pow(y, 2) -
-                                  1.0 / 12.0 * y * (6 * z - 1) + 1.0 / 6.0 * y +
-                                  1.0 / 12.0 * std::pow(z, 2) - 1.0 / 6.0 * z +
-                                  1.0 / 12.0)) /
-                      std::pow((z - 1), 2);
-            grad[1] = (1.0 / 6.0 * y *
-                         (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) +
-                       std::pow((z - 1), 2) *
-                         (1.0 / 6.0 * y + 1.0 / 3.0 * z - 1.0 / 12.0) -
-                       (z - 1) * (-0.25 * std::pow(x, 2) + 0.5 * x * y -
-                                  1.0 / 12.0 * x * (6 * z - 1) + 1.0 / 6.0 * x +
-                                  1.0 / 12.0 * std::pow(z, 2) - 1.0 / 6.0 * z +
-                                  1.0 / 12.0)) /
-                      std::pow((z - 1), 2);
-            grad[2] =
-              (-0.5 * std::pow(x, 2) * std::pow(y, 2) -
-               0.25 * std::pow(x, 2) * y * z + 0.25 * std::pow(x, 2) * y +
-               0.25 * x * std::pow(y, 2) * z - 0.25 * x * std::pow(y, 2) +
-               0.25 * x * y * z - 0.25 * x * y - 0.25 * x * std::pow(z, 3) +
-               0.75 * x * std::pow(z, 2) - 0.75 * x * z + 0.25 * x +
-               0.25 * y * std::pow(z, 3) - 0.75 * y * std::pow(z, 2) +
-               0.75 * y * z - 0.25 * y + 0.5 * std::pow(z, 4) -
-               1.75 * std::pow(z, 3) + 2.25 * std::pow(z, 2) - 1.25 * z +
-               0.25) /
-              (std::pow(z, 3) - 3.0 * std::pow(z, 2) + 3.0 * z - 1.0);
-            break;
-
-          case 2:
-            grad[0] = (1.0 / 6.0 * x *
-                         (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1) +
-                       std::pow((z - 1), 2) *
-                         (1.0 / 6.0 * x + 1.0 / 3.0 * z - 1.0 / 12.0) -
-                       (z - 1) * (0.5 * x * y - 0.25 * std::pow(y, 2) +
-                                  1.0 / 12.0 * y * (6 * z - 1) - 1.0 / 6.0 * y +
-                                  1.0 / 12.0 * std::pow(z, 2) - 1.0 / 6.0 * z +
-                                  1.0 / 12.0)) /
-                      std::pow((z - 1), 2);
-            grad[1] = (1.0 / 6.0 * y *
-                         (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) +
-                       std::pow((z - 1), 2) *
-                         (1.0 / 6.0 * y - 1.0 / 3.0 * z + 1.0 / 12.0) +
-                       (z - 1) * (-0.25 * std::pow(x, 2) + 0.5 * x * y -
-                                  1.0 / 12.0 * x * (6 * z - 1) + 1.0 / 6.0 * x +
-                                  1.0 / 12.0 * std::pow(z, 2) - 1.0 / 6.0 * z +
-                                  1.0 / 12.0)) /
-                      std::pow((z - 1), 2);
-            grad[2] =
-              (-0.5 * std::pow(x, 2) * std::pow(y, 2) +
-               0.25 * std::pow(x, 2) * y * z - 0.25 * std::pow(x, 2) * y -
-               0.25 * x * std::pow(y, 2) * z + 0.25 * x * std::pow(y, 2) +
-               0.25 * x * y * z - 0.25 * x * y + 0.25 * x * std::pow(z, 3) -
-               0.75 * x * std::pow(z, 2) + 0.75 * x * z - 0.25 * x -
-               0.25 * y * std::pow(z, 3) + 0.75 * y * std::pow(z, 2) -
-               0.75 * y * z + 0.25 * y + 0.5 * std::pow(z, 4) -
-               1.75 * std::pow(z, 3) + 2.25 * std::pow(z, 2) - 1.25 * z +
-               0.25) /
-              (std::pow(z, 3) - 3 * std::pow(z, 2) + 3 * z - 1.0);
-            break;
-          case 3:
-            grad[0] = (1.0 / 6.0 * x *
-                         (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1) +
-                       std::pow((z - 1), 2) *
-                         (1.0 / 6.0 * x - 1.0 / 3.0 * z + 1.0 / 12.0) -
-                       (z - 1) * (0.5 * x * y + 0.25 * std::pow(y, 2) -
-                                  1.0 / 12.0 * y * (6 * z - 1) + 1.0 / 6.0 * y -
-                                  1.0 / 12.0 * std::pow(z, 2) + 1.0 / 6.0 * z -
-                                  1.0 / 12.0)) /
-                      std::pow((z - 1), 2);
-            grad[1] = (1.0 / 6.0 * y *
-                         (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) +
-                       std::pow((z - 1), 2) *
-                         (1.0 / 6.0 * y - 1.0 / 3.0 * z + 1.0 / 12.0) -
-                       (z - 1) * (0.25 * std::pow(x, 2) + 0.5 * x * y -
-                                  1.0 / 12.0 * x * (6 * z - 1) + 1.0 / 6.0 * x -
-                                  1.0 / 12.0 * std::pow(z, 2) + 1.0 / 6.0 * z -
-                                  1.0 / 12.0)) /
-                      std::pow((z - 1), 2);
-            grad[2] =
-              (-0.5 * std::pow(x, 2) * std::pow(y, 2) +
-               0.25 * std::pow(x, 2) * y * z - 0.25 * std::pow(x, 2) * y +
-               0.25 * x * std::pow(y, 2) * z - 0.25 * x * std::pow(y, 2) -
-               0.25 * x * y * z + 0.25 * x * y - 0.25 * x * std::pow(z, 3) +
-               0.75 * x * std::pow(z, 2) - 0.75 * x * z + 0.25 * x -
-               0.25 * y * std::pow(z, 3) + 0.75 * y * std::pow(z, 2) -
-               0.75 * y * z + 0.25 * y + 0.5 * std::pow(z, 4) -
-               1.75 * std::pow(z, 3) + 2.25 * std::pow(z, 2) - 1.25 * z +
-               0.25) /
-              (std::pow(z, 3) - 3 * std::pow(z, 2) + 3 * z - 1.0);
-            break;
-          case 4:
-            grad[0] = 0;
-            grad[1] = 0;
-            grad[2] =
-              (4.0 * std::pow(z, 3) - 9.0 * std::pow(z, 2) + 6.0 * z - 1.0) /
-              (std::pow(z, 2) - 2.0 * z + 1.0);
-            break;
-          case 5:
-            grad[0] =
-              (-1.0 / 3.0 * x *
-                 (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1) +
-               std::pow((z - 1), 2) *
-                 (2.0 / 3.0 * x + 1.0 / 3.0 * z - 1.0 / 3.0) -
-               (z - 1) * (0.5 * std::pow(y, 2) - 1.0 / 6.0 * std::pow(z, 2) +
-                          1.0 / 3.0 * z - 1.0 / 6.0)) /
-              std::pow((z - 1), 2);
-            grad[1] = (-x * (y * (z - 1)) -
-                       1.0 / 3.0 * y *
-                         (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) +
-                       (-1.0 / 3.0 * y) * (std::pow((z - 1), 2))) /
-                      std::pow((z - 1), 2);
-            grad[2] =
-              (std::pow(x, 2) * std::pow(y, 2) + 0.5 * x * std::pow(y, 2) * z -
-               0.5 * x * std::pow(y, 2) + 0.5 * x * std::pow(z, 3) -
-               1.5 * x * std::pow(z, 2) + 1.5 * x * z - 0.5 * x) /
-              (std::pow(z, 3) - 3 * std::pow(z, 2) + 3 * z - 1.0);
-            break;
-          case 6:
-            grad[0] = (-1.0 / 3.0 * x *
-                         (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1) +
-                       std::pow((z - 1), 2) *
-                         (2.0 / 3.0 * x - 1.0 / 3.0 * z + 1.0 / 3.0) +
-                       (z - 1) * (0.5 * std::pow(y, 2) + 0 -
-                                  1.0 / 6.0 * std::pow(z, 2) + 1.0 / 3.0 * z -
-                                  1.0 / 6.0)) /
-                      std::pow((z - 1), 2);
-            grad[1] = (x * (1.0 * y + 0) * (z - 1) -
-                       1.0 / 3.0 * y *
-                         (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) -
-                       (1.0 / 3.0 * y + 0) * std::pow((z - 1), 2)) /
-                      std::pow((z - 1), 2);
-            grad[2] =
-              (1.0 * std::pow(x, 2) * std::pow(y, 2) + 0 - 0 + 0 -
-               0.5 * x * std::pow(y, 2) * z + 0.5 * x * std::pow(y, 2) - 0 + 0 -
-               0.5 * x * std::pow(z, 3) + 1.5 * x * std::pow(z, 2) -
-               1.5 * x * z + 0.5 * x - 0 + 0 - 0 + 0 + 0 - 0 + 0) /
-              (std::pow(z, 3) - 3.0 * std::pow(z, 2) + 3.0 * z - 1.0);
-            break;
-          case 7:
-            grad[0] = x *
-                      (-1.0 * std::pow(y, 2) - 1.0 * y * (z - 1) +
-                       1.0 / 3.0 * std::pow(z, 2) - 2.0 / 3.0 * z -
-                       1.0 / 3.0 * std::pow((z - 1), 2) + 1.0 / 3.0) /
-                      std::pow((z - 1), 2);
-            grad[1] = (-1.0 / 3.0 * y *
-                         (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) +
-                       std::pow((z - 1), 2) *
-                         (2.0 / 3.0 * y + 1.0 / 3.0 * z - 1.0 / 3.0) -
-                       1.0 / 6.0 * (z - 1) *
-                         (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1)) /
-                      std::pow((z - 1), 2);
-            grad[2] =
-              (1.0 * std::pow(x, 2) * std::pow(y, 2) +
-               0.5 * std::pow(x, 2) * y * z - 0.5 * std::pow(x, 2) * y + 0 - 0 +
-               0 + 0.5 * y * std::pow(z, 3) - 1.5 * y * std::pow(z, 2) +
-               1.5 * y * z - 0.5 * y - 0 - 0 + 0) /
-              (std::pow(z, 3) - 3.0 * std::pow(z, 2) + 3.0 * z - 1.0);
-            break;
-          case 8:
-            grad[0] = x *
-                      (-1.0 * std::pow(y, 2) + 1.0 * y * (z - 1) +
-                       1.0 / 3.0 * std::pow(z, 2) - 2.0 / 3.0 * z -
-                       1.0 / 3.0 * std::pow((z - 1), 2) + 1.0 / 3.0) /
-                      std::pow((z - 1), 2);
-            grad[1] = (-1.0 / 3.0 * y *
-                         (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) +
-                       std::pow((z - 1), 2) *
-                         (2.0 / 3.0 * y - 1.0 / 3.0 * z + 1.0 / 3.0) +
-                       1.0 / 6.0 * (z - 1) *
-                         (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1)) /
-                      std::pow((z - 1), 2);
-            grad[2] = (1.0 * std::pow(x, 2) * std::pow(y, 2) -
-                       0.5 * std::pow(x, 2) * y * z + 0.5 * std::pow(x, 2) * y +
-                       0 - 0.5 * y * std::pow(z, 3) + 1.5 * y * std::pow(z, 2) -
-                       1.5 * y * z + 0.5 * y - 0 - 0 + 0) /
-                      (std::pow(z, 3) - 3.0 * std::pow(z, 2) + 3.0 * z - 1.0);
-            break;
-          case 9:
-            grad[0] = z * (-y - z + 1) / (z - 1);
-            grad[1] = z * (-x - z + 1) / (z - 1);
-            grad[2] = (x * y - x * std::pow(z, 2) + 2 * x * z - x -
-                       y * std::pow(z, 2) + 2 * y * z - y - 2 * std::pow(z, 3) +
-                       5 * std::pow(z, 2) - 4 * z + 1) /
-                      (std::pow(z, 2) - 2 * z + 1);
-            break;
-          case 10:
-            grad[0] = z * (y + z - 1) / (z - 1);
-            grad[1] = z * (x - z + 1) / (z - 1);
-            grad[2] = (-x * y + x * std::pow(z, 2) - 2 * x * z + x -
-                       y * std::pow(z, 2) + 2 * y * z - y - 2 * std::pow(z, 3) +
-                       5 * std::pow(z, 2) - 4 * z + 1) /
-                      (std::pow(z, 2) - 2 * z + 1);
-            break;
-          case 11:
-            grad[0] = z * (y - z + 1) / (z - 1);
-            grad[1] = z * (x + z - 1) / (z - 1);
-            grad[2] = (-x * y - x * std::pow(z, 2) + 2 * x * z - x +
-                       y * std::pow(z, 2) - 2 * y * z + y - 2 * std::pow(z, 3) +
-                       5 * std::pow(z, 2) - 4 * z + 1) /
-                      (std::pow(z, 2) - 2 * z + 1);
-            break;
-          case 12:
-            grad[0] = z * (-y + z - 1) / (z - 1);
-            grad[1] = z * (-x + z - 1) / (z - 1);
-            grad[2] = (x * y + x * std::pow(z, 2) - 2 * x * z + x +
-                       y * std::pow(z, 2) - 2 * y * z + y - 2 * std::pow(z, 3) +
-                       5 * std::pow(z, 2) - 4 * z + 1) /
-                      (std::pow(z, 2) - 2 * z + 1);
-            break;
-          case 13:
-            grad[0] = x *
-                      (2 * std::pow(y, 2) - 2 * std::pow(z, 2) + 4 * z - 2) /
-                      (std::pow(z, 2) - 2 * z + 1);
-            grad[1] =
-              y *
-              (2.0 * std::pow(x, 2) - 2.0 * std::pow(z, 2) + 4.0 * z - 2.0) /
-              (std::pow(z, 2) - 2.0 * z + 1.0);
-            grad[2] = (-2.0 * std::pow(x, 2) * std::pow(y, 2) - 0 + 0 - 0 - 0 +
-                       0 + 2.0 * std::pow(z, 4) - 8.0 * std::pow(z, 3) +
-                       12.0 * std::pow(z, 2) - 8.0 * z + 2.0) /
-                      (std::pow(z, 3) - 3.0 * std::pow(z, 2) + 3.0 * z - 1.0);
-            break;
-
-          default:
-            DEAL_II_ASSERT_UNREACHABLE();
-        }
+      for (unsigned int d = 0; d < dim; ++d)
+        if (std::fabs(grad[d]) < 1e-14)
+          grad[d] = 0.0;
     }
+
+  else
+    DEAL_II_NOT_IMPLEMENTED();
+
 
   return grad;
 }

--- a/source/base/polynomials_pyramid.cc
+++ b/source/base/polynomials_pyramid.cc
@@ -266,7 +266,7 @@ ScalarLagrangePolynomialPyramid<dim>::compute_grad(const unsigned int i,
 {
   AssertDimension(dim, 3);
   AssertIndexRange(i, VDM_inv.m());
-  
+
   Tensor<1, dim> grad;
 
   for (unsigned int j = 0; j < VDM_inv.n(); ++j)

--- a/source/base/polynomials_pyramid.cc
+++ b/source/base/polynomials_pyramid.cc
@@ -28,6 +28,8 @@ namespace
       {
         if (degree == 1)
           return 5;
+        else if (degree == 2)
+          return 14;
       }
 
     DEAL_II_NOT_IMPLEMENTED();
@@ -52,34 +54,219 @@ ScalarLagrangePolynomialPyramid<dim>::compute_value(const unsigned int i,
                                                     const Point<dim>  &p) const
 {
   AssertDimension(dim, 3);
-  AssertIndexRange(this->degree(), 2);
+  AssertIndexRange(this->degree(), 3);
 
-  const double Q14 = 0.25;
-  double       ration;
-
-  const double r = p[0];
-  const double s = p[1];
-  const double t = p[2];
-
-  if (fabs(t - 1.0) > 1.0e-14)
+  if (this->degree() == 1)
     {
-      ration = (r * s * t) / (1.0 - t);
-    }
-  else
-    {
-      ration = 0.0;
-    }
+      const double Q14 = 0.25;
+      double       ration;
 
-  if (i == 0)
-    return Q14 * ((1.0 - r) * (1.0 - s) - t + ration);
-  if (i == 1)
-    return Q14 * ((1.0 + r) * (1.0 - s) - t - ration);
-  if (i == 2)
-    return Q14 * ((1.0 - r) * (1.0 + s) - t - ration);
-  if (i == 3)
-    return Q14 * ((1.0 + r) * (1.0 + s) - t + ration);
-  else
-    return t;
+      const double r = p[0];
+      const double s = p[1];
+      const double t = p[2];
+
+      if (fabs(t - 1.0) > 1.0e-14)
+        {
+          ration = (r * s * t) / (1.0 - t);
+        }
+      else
+        {
+          ration = 0.0;
+        }
+
+      if (i == 0)
+        return Q14 * ((1.0 - r) * (1.0 - s) - t + ration);
+      if (i == 1)
+        return Q14 * ((1.0 + r) * (1.0 - s) - t - ration);
+      if (i == 2)
+        return Q14 * ((1.0 - r) * (1.0 + s) - t - ration);
+      if (i == 3)
+        return Q14 * ((1.0 + r) * (1.0 + s) - t + ration);
+      else
+        return t;
+    }
+  else if (this->degree() == 2)
+    {
+      const double x = p[0];
+      const double y = p[1];
+      const double z = p[2];
+
+      double result;
+
+      double ration;
+      double ration_square;
+
+      if (fabs(z - 1.0) > 1.0e-14)
+        {
+          ration        = 1.0 / (z - 1.0);
+          ration_square = std::pow(ration, 2);
+        }
+      else
+        {
+          ration        = 1.0;
+          ration_square = 1.0;
+        }
+
+      switch (i)
+        {
+          case 0:
+            result =
+              (std::pow(z - 1, 2) *
+                 ((1.0 / 12) * std::pow(x, 2) + (1.0 / 18) * x * (6 * z - 1) -
+                  (1.0 / 36) * x + (1.0 / 12) * std::pow(y, 2) +
+                  (1.0 / 18) * y * (6 * z - 1) - (1.0 / 36) * y +
+                  (2.0 / 9) * std::pow(z, 2) - (7.0 / 36) * z - (1.0 / 36)) +
+               (z - 1) * ((1.0 / 12) * x * y * (6 * z - 1) - (1.0 / 6) * x * y +
+                          (1.0 / 12) * x *
+                            (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1) +
+                          (1.0 / 12) * y *
+                            (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1)) +
+               (1.0 / 36) * (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) *
+                 (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1)) *
+              ration_square;
+            break;
+          case 1:
+            result =
+              (std::pow(z - 1, 2) *
+                 ((1.0 / 12) * std::pow(x, 2) - (1.0 / 18) * x * (6 * z - 1) +
+                  (1.0 / 36) * x + (1.0 / 12) * std::pow(y, 2) +
+                  (1.0 / 18) * y * (6 * z - 1) - (1.0 / 36) * y +
+                  (2.0 / 9) * std::pow(z, 2) - (7.0 / 36) * z - (1.0 / 36)) -
+               (z - 1) * ((1.0 / 12) * x * y * (6 * z - 1) - (1.0 / 6) * x * y +
+                          (1.0 / 12) * x *
+                            (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1) -
+                          (1.0 / 12) * y *
+                            (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1)) +
+               (1.0 / 36) * (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) *
+                 (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1)) *
+              ration_square;
+            break;
+          case 2:
+            result =
+              (std::pow(z - 1, 2) *
+                 ((1.0 / 12) * std::pow(x, 2) + (1.0 / 18) * x * (6 * z - 1) -
+                  (1.0 / 36) * x + (1.0 / 12) * std::pow(y, 2) -
+                  (1.0 / 18) * y * (6 * z - 1) + (1.0 / 36) * y +
+                  (2.0 / 9) * std::pow(z, 2) - (7.0 / 36) * z - (1.0 / 36)) -
+               (z - 1) * ((1.0 / 12) * x * y * (6 * z - 1) - (1.0 / 6) * x * y -
+                          (1.0 / 12) * x *
+                            (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1) +
+                          (1.0 / 12) * y *
+                            (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1)) +
+               (1.0 / 36) * (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) *
+                 (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1)) *
+              ration_square;
+            break;
+          case 3:
+            result =
+              (std::pow(z - 1, 2) *
+                 ((1.0 / 12) * std::pow(x, 2) - (1.0 / 18) * x * (6 * z - 1) +
+                  (1.0 / 36) * x + (1.0 / 12) * std::pow(y, 2) -
+                  (1.0 / 18) * y * (6 * z - 1) + (1.0 / 36) * y +
+                  (2.0 / 9) * std::pow(z, 2) - (7.0 / 36) * z - (1.0 / 36)) -
+               (z - 1) *
+                 (-(1.0 / 12) * x * y * (6 * z - 1) + (1.0 / 6) * x * y +
+                  (1.0 / 12) * x *
+                    (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1) +
+                  (1.0 / 12) * y *
+                    (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1)) +
+               (1.0 / 36) * (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) *
+                 (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1)) *
+              ration_square;
+            break;
+          case 4:
+            result = z * (2 * z - 1);
+            break;
+          case 5:
+            result =
+              (-x * (z - 1) *
+                 (0.5 * std::pow(y, 2) - 1.0 / 6 * std::pow(z, 2) +
+                  1.0 / 3 * z - 1.0 / 6) +
+               std::pow(z - 1, 2) *
+                 (1.0 / 3 * std::pow(x, 2) + 1.0 / 18 * x * (6 * z - 1) -
+                  5.0 / 18 * x - 1.0 / 6 * std::pow(y, 2) +
+                  1.0 / 18 * std::pow(z, 2) - 1.0 / 9 * z + 1.0 / 18) -
+               1.0 / 18 * (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) *
+                 (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1)) *
+              ration_square;
+            break;
+          case 6:
+            result =
+              (x * (z - 1) *
+                 (0.5 * std::pow(y, 2) - 1.0 / 6 * std::pow(z, 2) +
+                  1.0 / 3 * z - 1.0 / 6) +
+               std::pow(z - 1, 2) *
+                 (1.0 / 3 * std::pow(x, 2) - 1.0 / 18 * x * (6 * z - 1) +
+                  5.0 / 18 * x - 1.0 / 6 * std::pow(y, 2) +
+                  1.0 / 18 * std::pow(z, 2) - 1.0 / 9 * z + 1.0 / 18) -
+               1.0 / 18 * (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) *
+                 (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1)) *
+              ration_square;
+            break;
+          case 7:
+            result =
+              (-1.0 / 6 * y * (z - 1) *
+                 (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) +
+               std::pow(z - 1, 2) *
+                 (-1.0 / 6 * std::pow(x, 2) + 1.0 / 3 * std::pow(y, 2) +
+                  1.0 / 18 * y * (6 * z - 1) - 5.0 / 18 * y +
+                  1.0 / 18 * std::pow(z, 2) - 1.0 / 9 * z + 1.0 / 18) -
+               1.0 / 18 * (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) *
+                 (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1)) *
+              ration_square;
+            break;
+          case 8:
+            result =
+              (1.0 / 6 * y * (z - 1) *
+                 (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) +
+               std::pow(z - 1, 2) *
+                 (-1.0 / 6 * std::pow(x, 2) + 1.0 / 3 * std::pow(y, 2) -
+                  1.0 / 18 * y * (6 * z - 1) + 5.0 / 18 * y +
+                  1.0 / 18 * std::pow(z, 2) - 1.0 / 9 * z + 1.0 / 18) -
+               1.0 / 18 * (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) *
+                 (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1)) *
+              ration_square;
+            break;
+          case 9:
+            result =
+              (-x * y * z - x * std::pow(z, 2) + x * z - y * std::pow(z, 2) +
+               y * z - std::pow(z, 3) + 2.0 * std::pow(z, 2) - z - 0) *
+              ration;
+            break;
+          case 10:
+            result =
+              (x * y * z + x * std::pow(z, 2) - x * z - y * std::pow(z, 2) +
+               y * z - std::pow(z, 3) + 2.0 * std::pow(z, 2) - z - 0) *
+              ration;
+            break;
+          case 11:
+            result =
+              (x * y * z - x * std::pow(z, 2) + x * z + y * std::pow(z, 2) -
+               y * z - std::pow(z, 3) + 2.0 * std::pow(z, 2) - z + 0) *
+              ration;
+            break;
+          case 12:
+            result = z *
+                     (-x * y + x * z - x + y * z - y - std::pow(z, 2) +
+                      2.0 * z - 1.0) *
+                     ration;
+            break;
+          case 13:
+            result =
+              (std::pow(z - 1, 2) *
+                 (-2.0 / 3 * std::pow(x, 2) - 2.0 / 3 * std::pow(y, 2) +
+                  8.0 / 9 * std::pow(z, 2) - 16.0 / 9 * z + 8.0 / 9) +
+               1.0 / 9 * (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) *
+                 (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1)) *
+              ration_square;
+            break;
+          default:
+            DEAL_II_ASSERT_UNREACHABLE();
+        }
+      return result;
+    }
+  DEAL_II_ASSERT_UNREACHABLE();
+  return 0.0;
 }
 
 
@@ -90,7 +277,7 @@ ScalarLagrangePolynomialPyramid<dim>::compute_grad(const unsigned int i,
                                                    const Point<dim>  &p) const
 {
   AssertDimension(dim, 3);
-  AssertIndexRange(this->degree(), 4);
+  AssertIndexRange(this->degree(), 3);
 
   Tensor<1, dim> grad;
 
@@ -153,6 +340,277 @@ ScalarLagrangePolynomialPyramid<dim>::compute_grad(const unsigned int i,
       else
         {
           DEAL_II_NOT_IMPLEMENTED();
+        }
+    }
+  else if (this->degree() == 2)
+    {
+      const double x = p[0];
+      const double y = p[1];
+      const double z = p[2];
+
+      switch (i)
+        {
+          case 0:
+            grad[0] = (1.0 / 6.0 * x *
+                         (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1) +
+                       std::pow((z - 1), 2) *
+                         (1.0 / 6.0 * x + 1.0 / 3.0 * z - 1.0 / 12.0) +
+                       (z - 1) * (0.5 * x * y + 0.25 * std::pow(y, 2) +
+                                  1.0 / 12.0 * y * (6 * z - 1) - 1.0 / 6.0 * y -
+                                  1.0 / 12.0 * std::pow(z, 2) + 1.0 / 6.0 * z -
+                                  1.0 / 12.0)) /
+                      std::pow((z - 1), 2);
+            grad[1] = (1.0 / 6.0 * y *
+                         (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) +
+                       std::pow((z - 1), 2) *
+                         (1.0 / 6.0 * y + 1.0 / 3.0 * z - 1.0 / 12.0) +
+                       (z - 1) * (0.25 * std::pow(x, 2) + 0.5 * x * y +
+                                  1.0 / 12.0 * x * (6 * z - 1) - 1.0 / 6.0 * x -
+                                  1.0 / 12.0 * std::pow(z, 2) + 1.0 / 6.0 * z -
+                                  1.0 / 12.0)) /
+                      std::pow((z - 1), 2);
+            grad[2] =
+              (-0.5 * std::pow(x, 2) * std::pow(y, 2) -
+               0.25 * std::pow(x, 2) * y * z + 0.25 * std::pow(x, 2) * y -
+               0.25 * x * std::pow(y, 2) * z + 0.25 * x * std::pow(y, 2) -
+               0.25 * x * y * z + 0.25 * x * y + 0.25 * x * std::pow(z, 3) -
+               0.75 * x * std::pow(z, 2) + 0.75 * x * z - 0.25 * x +
+               0.25 * y * std::pow(z, 3) - 0.75 * y * std::pow(z, 2) +
+               0.75 * y * z - 0.25 * y + 0.5 * std::pow(z, 4) -
+               1.75 * std::pow(z, 3) + 2.25 * std::pow(z, 2) - 1.25 * z +
+               0.25) /
+              (std::pow(z, 3) - 3.0 * std::pow(z, 2) + 3.0 * z - 1.0);
+            break;
+
+          case 1:
+            grad[0] = (1.0 / 6.0 * x *
+                         (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1) +
+                       std::pow((z - 1), 2) *
+                         (1.0 / 6.0 * x - 1.0 / 3.0 * z + 1.0 / 12.0) +
+                       (z - 1) * (0.5 * x * y - 0.25 * std::pow(y, 2) -
+                                  1.0 / 12.0 * y * (6 * z - 1) + 1.0 / 6.0 * y +
+                                  1.0 / 12.0 * std::pow(z, 2) - 1.0 / 6.0 * z +
+                                  1.0 / 12.0)) /
+                      std::pow((z - 1), 2);
+            grad[1] = (1.0 / 6.0 * y *
+                         (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) +
+                       std::pow((z - 1), 2) *
+                         (1.0 / 6.0 * y + 1.0 / 3.0 * z - 1.0 / 12.0) -
+                       (z - 1) * (-0.25 * std::pow(x, 2) + 0.5 * x * y -
+                                  1.0 / 12.0 * x * (6 * z - 1) + 1.0 / 6.0 * x +
+                                  1.0 / 12.0 * std::pow(z, 2) - 1.0 / 6.0 * z +
+                                  1.0 / 12.0)) /
+                      std::pow((z - 1), 2);
+            grad[2] =
+              (-0.5 * std::pow(x, 2) * std::pow(y, 2) -
+               0.25 * std::pow(x, 2) * y * z + 0.25 * std::pow(x, 2) * y +
+               0.25 * x * std::pow(y, 2) * z - 0.25 * x * std::pow(y, 2) +
+               0.25 * x * y * z - 0.25 * x * y - 0.25 * x * std::pow(z, 3) +
+               0.75 * x * std::pow(z, 2) - 0.75 * x * z + 0.25 * x +
+               0.25 * y * std::pow(z, 3) - 0.75 * y * std::pow(z, 2) +
+               0.75 * y * z - 0.25 * y + 0.5 * std::pow(z, 4) -
+               1.75 * std::pow(z, 3) + 2.25 * std::pow(z, 2) - 1.25 * z +
+               0.25) /
+              (std::pow(z, 3) - 3.0 * std::pow(z, 2) + 3.0 * z - 1.0);
+            break;
+
+          case 2:
+            grad[0] = (1.0 / 6.0 * x *
+                         (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1) +
+                       std::pow((z - 1), 2) *
+                         (1.0 / 6.0 * x + 1.0 / 3.0 * z - 1.0 / 12.0) -
+                       (z - 1) * (0.5 * x * y - 0.25 * std::pow(y, 2) +
+                                  1.0 / 12.0 * y * (6 * z - 1) - 1.0 / 6.0 * y +
+                                  1.0 / 12.0 * std::pow(z, 2) - 1.0 / 6.0 * z +
+                                  1.0 / 12.0)) /
+                      std::pow((z - 1), 2);
+            grad[1] = (1.0 / 6.0 * y *
+                         (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) +
+                       std::pow((z - 1), 2) *
+                         (1.0 / 6.0 * y - 1.0 / 3.0 * z + 1.0 / 12.0) +
+                       (z - 1) * (-0.25 * std::pow(x, 2) + 0.5 * x * y -
+                                  1.0 / 12.0 * x * (6 * z - 1) + 1.0 / 6.0 * x +
+                                  1.0 / 12.0 * std::pow(z, 2) - 1.0 / 6.0 * z +
+                                  1.0 / 12.0)) /
+                      std::pow((z - 1), 2);
+            grad[2] =
+              (-0.5 * std::pow(x, 2) * std::pow(y, 2) +
+               0.25 * std::pow(x, 2) * y * z - 0.25 * std::pow(x, 2) * y -
+               0.25 * x * std::pow(y, 2) * z + 0.25 * x * std::pow(y, 2) +
+               0.25 * x * y * z - 0.25 * x * y + 0.25 * x * std::pow(z, 3) -
+               0.75 * x * std::pow(z, 2) + 0.75 * x * z - 0.25 * x -
+               0.25 * y * std::pow(z, 3) + 0.75 * y * std::pow(z, 2) -
+               0.75 * y * z + 0.25 * y + 0.5 * std::pow(z, 4) -
+               1.75 * std::pow(z, 3) + 2.25 * std::pow(z, 2) - 1.25 * z +
+               0.25) /
+              (std::pow(z, 3) - 3 * std::pow(z, 2) + 3 * z - 1.0);
+            break;
+          case 3:
+            grad[0] = (1.0 / 6.0 * x *
+                         (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1) +
+                       std::pow((z - 1), 2) *
+                         (1.0 / 6.0 * x - 1.0 / 3.0 * z + 1.0 / 12.0) -
+                       (z - 1) * (0.5 * x * y + 0.25 * std::pow(y, 2) -
+                                  1.0 / 12.0 * y * (6 * z - 1) + 1.0 / 6.0 * y -
+                                  1.0 / 12.0 * std::pow(z, 2) + 1.0 / 6.0 * z -
+                                  1.0 / 12.0)) /
+                      std::pow((z - 1), 2);
+            grad[1] = (1.0 / 6.0 * y *
+                         (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) +
+                       std::pow((z - 1), 2) *
+                         (1.0 / 6.0 * y - 1.0 / 3.0 * z + 1.0 / 12.0) -
+                       (z - 1) * (0.25 * std::pow(x, 2) + 0.5 * x * y -
+                                  1.0 / 12.0 * x * (6 * z - 1) + 1.0 / 6.0 * x -
+                                  1.0 / 12.0 * std::pow(z, 2) + 1.0 / 6.0 * z -
+                                  1.0 / 12.0)) /
+                      std::pow((z - 1), 2);
+            grad[2] =
+              (-0.5 * std::pow(x, 2) * std::pow(y, 2) +
+               0.25 * std::pow(x, 2) * y * z - 0.25 * std::pow(x, 2) * y +
+               0.25 * x * std::pow(y, 2) * z - 0.25 * x * std::pow(y, 2) -
+               0.25 * x * y * z + 0.25 * x * y - 0.25 * x * std::pow(z, 3) +
+               0.75 * x * std::pow(z, 2) - 0.75 * x * z + 0.25 * x -
+               0.25 * y * std::pow(z, 3) + 0.75 * y * std::pow(z, 2) -
+               0.75 * y * z + 0.25 * y + 0.5 * std::pow(z, 4) -
+               1.75 * std::pow(z, 3) + 2.25 * std::pow(z, 2) - 1.25 * z +
+               0.25) /
+              (std::pow(z, 3) - 3 * std::pow(z, 2) + 3 * z - 1.0);
+            break;
+          case 4:
+            grad[0] = 0;
+            grad[1] = 0;
+            grad[2] =
+              (4.0 * std::pow(z, 3) - 9.0 * std::pow(z, 2) + 6.0 * z - 1.0) /
+              (std::pow(z, 2) - 2.0 * z + 1.0);
+            break;
+          case 5:
+            grad[0] =
+              (-1.0 / 3.0 * x *
+                 (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1) +
+               std::pow((z - 1), 2) *
+                 (2.0 / 3.0 * x + 1.0 / 3.0 * z - 1.0 / 3.0) -
+               (z - 1) * (0.5 * std::pow(y, 2) - 1.0 / 6.0 * std::pow(z, 2) +
+                          1.0 / 3.0 * z - 1.0 / 6.0)) /
+              std::pow((z - 1), 2);
+            grad[1] = (-x * (y * (z - 1)) -
+                       1.0 / 3.0 * y *
+                         (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) +
+                       (-1.0 / 3.0 * y) * (std::pow((z - 1), 2))) /
+                      std::pow((z - 1), 2);
+            grad[2] =
+              (std::pow(x, 2) * std::pow(y, 2) + 0.5 * x * std::pow(y, 2) * z -
+               0.5 * x * std::pow(y, 2) + 0.5 * x * std::pow(z, 3) -
+               1.5 * x * std::pow(z, 2) + 1.5 * x * z - 0.5 * x) /
+              (std::pow(z, 3) - 3 * std::pow(z, 2) + 3 * z - 1.0);
+            break;
+          case 6:
+            grad[0] = (-1.0 / 3.0 * x *
+                         (3 * std::pow(y, 2) - std::pow(z, 2) + 2 * z - 1) +
+                       std::pow((z - 1), 2) *
+                         (2.0 / 3.0 * x - 1.0 / 3.0 * z + 1.0 / 3.0) +
+                       (z - 1) * (0.5 * std::pow(y, 2) + 0 -
+                                  1.0 / 6.0 * std::pow(z, 2) + 1.0 / 3.0 * z -
+                                  1.0 / 6.0)) /
+                      std::pow((z - 1), 2);
+            grad[1] = (x * (1.0 * y + 0) * (z - 1) -
+                       1.0 / 3.0 * y *
+                         (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) -
+                       (1.0 / 3.0 * y + 0) * std::pow((z - 1), 2)) /
+                      std::pow((z - 1), 2);
+            grad[2] =
+              (1.0 * std::pow(x, 2) * std::pow(y, 2) + 0 - 0 + 0 -
+               0.5 * x * std::pow(y, 2) * z + 0.5 * x * std::pow(y, 2) - 0 + 0 -
+               0.5 * x * std::pow(z, 3) + 1.5 * x * std::pow(z, 2) -
+               1.5 * x * z + 0.5 * x - 0 + 0 - 0 + 0 + 0 - 0 + 0) /
+              (std::pow(z, 3) - 3.0 * std::pow(z, 2) + 3.0 * z - 1.0);
+            break;
+          case 7:
+            grad[0] = x *
+                      (-1.0 * std::pow(y, 2) - 1.0 * y * (z - 1) +
+                       1.0 / 3.0 * std::pow(z, 2) - 2.0 / 3.0 * z -
+                       1.0 / 3.0 * std::pow((z - 1), 2) + 1.0 / 3.0) /
+                      std::pow((z - 1), 2);
+            grad[1] = (-1.0 / 3.0 * y *
+                         (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) +
+                       std::pow((z - 1), 2) *
+                         (2.0 / 3.0 * y + 1.0 / 3.0 * z - 1.0 / 3.0) -
+                       1.0 / 6.0 * (z - 1) *
+                         (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1)) /
+                      std::pow((z - 1), 2);
+            grad[2] =
+              (1.0 * std::pow(x, 2) * std::pow(y, 2) +
+               0.5 * std::pow(x, 2) * y * z - 0.5 * std::pow(x, 2) * y + 0 - 0 +
+               0 + 0.5 * y * std::pow(z, 3) - 1.5 * y * std::pow(z, 2) +
+               1.5 * y * z - 0.5 * y - 0 - 0 + 0) /
+              (std::pow(z, 3) - 3.0 * std::pow(z, 2) + 3.0 * z - 1.0);
+            break;
+          case 8:
+            grad[0] = x *
+                      (-1.0 * std::pow(y, 2) + 1.0 * y * (z - 1) +
+                       1.0 / 3.0 * std::pow(z, 2) - 2.0 / 3.0 * z -
+                       1.0 / 3.0 * std::pow((z - 1), 2) + 1.0 / 3.0) /
+                      std::pow((z - 1), 2);
+            grad[1] = (-1.0 / 3.0 * y *
+                         (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1) +
+                       std::pow((z - 1), 2) *
+                         (2.0 / 3.0 * y - 1.0 / 3.0 * z + 1.0 / 3.0) +
+                       1.0 / 6.0 * (z - 1) *
+                         (3 * std::pow(x, 2) - std::pow(z, 2) + 2 * z - 1)) /
+                      std::pow((z - 1), 2);
+            grad[2] = (1.0 * std::pow(x, 2) * std::pow(y, 2) -
+                       0.5 * std::pow(x, 2) * y * z + 0.5 * std::pow(x, 2) * y +
+                       0 - 0.5 * y * std::pow(z, 3) + 1.5 * y * std::pow(z, 2) -
+                       1.5 * y * z + 0.5 * y - 0 - 0 + 0) /
+                      (std::pow(z, 3) - 3.0 * std::pow(z, 2) + 3.0 * z - 1.0);
+            break;
+          case 9:
+            grad[0] = z * (-y - z + 1) / (z - 1);
+            grad[1] = z * (-x - z + 1) / (z - 1);
+            grad[2] = (x * y - x * std::pow(z, 2) + 2 * x * z - x -
+                       y * std::pow(z, 2) + 2 * y * z - y - 2 * std::pow(z, 3) +
+                       5 * std::pow(z, 2) - 4 * z + 1) /
+                      (std::pow(z, 2) - 2 * z + 1);
+            break;
+          case 10:
+            grad[0] = z * (y + z - 1) / (z - 1);
+            grad[1] = z * (x - z + 1) / (z - 1);
+            grad[2] = (-x * y + x * std::pow(z, 2) - 2 * x * z + x -
+                       y * std::pow(z, 2) + 2 * y * z - y - 2 * std::pow(z, 3) +
+                       5 * std::pow(z, 2) - 4 * z + 1) /
+                      (std::pow(z, 2) - 2 * z + 1);
+            break;
+          case 11:
+            grad[0] = z * (y - z + 1) / (z - 1);
+            grad[1] = z * (x + z - 1) / (z - 1);
+            grad[2] = (-x * y - x * std::pow(z, 2) + 2 * x * z - x +
+                       y * std::pow(z, 2) - 2 * y * z + y - 2 * std::pow(z, 3) +
+                       5 * std::pow(z, 2) - 4 * z + 1) /
+                      (std::pow(z, 2) - 2 * z + 1);
+            break;
+          case 12:
+            grad[0] = z * (-y + z - 1) / (z - 1);
+            grad[1] = z * (-x + z - 1) / (z - 1);
+            grad[2] = (x * y + x * std::pow(z, 2) - 2 * x * z + x +
+                       y * std::pow(z, 2) - 2 * y * z + y - 2 * std::pow(z, 3) +
+                       5 * std::pow(z, 2) - 4 * z + 1) /
+                      (std::pow(z, 2) - 2 * z + 1);
+            break;
+          case 13:
+            grad[0] = x *
+                      (2 * std::pow(y, 2) - 2 * std::pow(z, 2) + 4 * z - 2) /
+                      (std::pow(z, 2) - 2 * z + 1);
+            grad[1] =
+              y *
+              (2.0 * std::pow(x, 2) - 2.0 * std::pow(z, 2) + 4.0 * z - 2.0) /
+              (std::pow(z, 2) - 2.0 * z + 1.0);
+            grad[2] = (-2.0 * std::pow(x, 2) * std::pow(y, 2) - 0 + 0 - 0 - 0 +
+                       0 + 2.0 * std::pow(z, 4) - 8.0 * std::pow(z, 3) +
+                       12.0 * std::pow(z, 2) - 8.0 * z + 2.0) /
+                      (std::pow(z, 3) - 3.0 * std::pow(z, 2) + 3.0 * z - 1.0);
+            break;
+
+          default:
+            DEAL_II_ASSERT_UNREACHABLE();
         }
     }
 

--- a/source/base/polynomials_pyramid.cc
+++ b/source/base/polynomials_pyramid.cc
@@ -204,224 +204,6 @@ ScalarLagrangePolynomialPyramid<dim>::compute_jacobi_deriv(
 
 
 template <int dim>
-double
-ScalarLagrangePolynomialPyramid<dim>::compute_jacobi_basis_functions(
-  const unsigned int i,
-  const Point<dim>  &p) const
-{
-  if (this->degree() == 2)
-    {
-      double       basis;
-      const double x = p[0];
-      const double y = p[1];
-      const double z = p[2];
-
-      double ratio;
-      if (std::fabs(z - 1.0) < 1e-12)
-        {
-          ratio = 0.0;
-        }
-      else
-        {
-          ratio = 1.0 / (z - 1.0);
-        }
-
-      switch (i)
-        {
-          case 0:
-            basis = 1.0;
-            break;
-          case 1:
-            basis = 4.0 * z - 1.0;
-            break;
-          case 2:
-            basis = 15.0 * std::pow(z, 2) - 10.0 * z + 1.0;
-            break;
-          case 3:
-            basis = y;
-            break;
-          case 4:
-            basis = y * (6.0 * z - 1.0);
-            break;
-          case 5:
-            basis = 3 * std::pow(y, 2) * 0.5 - std::pow(z, 2) * 0.5 + z - 0.5;
-            break;
-          case 6:
-            basis = x;
-            break;
-          case 7:
-            basis = x * (6.0 * z - 1.0);
-            break;
-          case 8:
-            basis = -x * y * ratio;
-            break;
-          case 9:
-            basis = x * y * (1.0 - 6.0 * z) * ratio;
-            break;
-          case 10:
-            basis = x * (-3.0 * std::pow(y, 2) + std::pow(z, 2) - 2 * z + 1.0) *
-                    0.5 * ratio;
-            break;
-          case 11:
-            basis = 3.0 / 2.0 * std::pow(x, 2) - std::pow(z, 2) * 0.5 + z - 0.5;
-            break;
-          case 12:
-            basis = y *
-                    (-3.0 * std::pow(x, 2) + std::pow(z, 2) - 2.0 * z + 1.0) *
-                    0.5 * ratio;
-            break;
-          case 13:
-            basis = (3.0 * std::pow(x, 2) - std::pow(z, 2) + 2.0 * z - 1.0) *
-                    (3.0 * std::pow(y, 2) - std::pow(z, 2) + 2.0 * z - 1.0) *
-                    0.25 * std::pow(ratio, 2);
-            break;
-          default:
-
-            DEAL_II_NOT_IMPLEMENTED();
-            break;
-        }
-      if (std::fabs(basis) < 1e-14)
-        basis = 0.0;
-
-      return basis;
-    }
-  DEAL_II_NOT_IMPLEMENTED();
-  return 0;
-}
-
-
-template <int dim>
-Tensor<1, dim>
-ScalarLagrangePolynomialPyramid<dim>::compute_jacobi_deriv_basis_functions(
-  const unsigned int i,
-  const Point<dim>  &p) const
-{
-  if (this->degree() == 2)
-    {
-      Tensor<1, dim> grad;
-      const double   x = p[0];
-      const double   y = p[1];
-      const double   z = p[2];
-
-      double ratio;
-      if (std::fabs(z - 1.0) < 1e-12)
-        {
-          ratio = 0.0;
-        }
-      else
-        {
-          ratio = 1.0 / (z - 1.0);
-        }
-
-      switch (i)
-        {
-          case 0:
-            grad[0] = 0.0;
-            grad[1] = 0.0;
-            grad[2] = 0.0;
-            break;
-          case 1:
-            grad[0] = 0.0;
-            grad[1] = 0.0;
-            grad[2] = 4.0;
-            break;
-          case 2:
-            grad[0] = 0.0;
-            grad[1] = 0.0;
-            grad[2] = 30.0 * z - 10.0;
-            break;
-          case 3:
-            grad[0] = 0.0;
-            grad[1] = 1.0;
-            grad[2] = 0.0;
-            break;
-          case 4:
-            grad[0] = 0.0;
-            grad[1] = 6.0 * z - 1.0;
-            grad[2] = 6.0 * y;
-            break;
-          case 5:
-            grad[0] = 0.0;
-            grad[1] = 3.0 * y;
-            grad[2] = 1.0 - z;
-            break;
-          case 6:
-            grad[0] = 1.0;
-            grad[1] = 0;
-            grad[2] = 0;
-            break;
-          case 7:
-            grad[0] = 6.0 * z - 1.0;
-            grad[1] = 0;
-            grad[2] = 6.0 * x;
-            break;
-          case 8:
-            grad[0] = -y * ratio;
-            grad[1] = -x * ratio;
-            grad[2] = x * y * std::pow(ratio, 2);
-            break;
-          case 9:
-            grad[0] = y * (1.0 - 6.0 * z) * ratio;
-            grad[1] = x * (1.0 - 6.0 * z) * ratio;
-            grad[2] = 5 * x * y * std::pow(ratio, 2);
-            break;
-          case 10:
-            grad[0] = (-3.0 * std::pow(y, 2) + std::pow(z, 2) - 2.0 * z + 1) *
-                      0.5 * ratio;
-            grad[1] = -3.0 * x * y * ratio;
-            grad[2] = x *
-                      (3.0 * std::pow(y, 2) + std::pow(z, 2) - 2.0 * z + 1) *
-                      0.5 * std::pow(ratio, 2);
-            break;
-          case 11:
-            grad[0] = 3.0 * x;
-            grad[1] = 0.0;
-            grad[2] = 1.0 - z;
-            break;
-          case 12:
-            grad[0] = -3.0 * x * y * ratio;
-            grad[1] = (-3.0 * std::pow(x, 2) + std::pow(z, 2) - 2.0 * z + 1) *
-                      0.5 * ratio;
-            grad[2] = y *
-                      (3.0 * std::pow(x, 2) + std::pow(z, 2) - 2.0 * z + 1.0) *
-                      0.5 * std::pow(ratio, 2);
-            break;
-          case 13:
-            {
-              double ratio_13 =
-                (ratio == 0.0) ?
-                  0.0 :
-                  std::pow(z, 3) - 3.0 * std::pow(z, 2) + 3.0 * z - 1.0;
-              grad[0] =
-                3.0 * x *
-                (3.0 * std::pow(y, 2) - std::pow(z, 2) + 2.0 * z - 1.0) * 0.5 *
-                std::pow(ratio, 2);
-              grad[1] =
-                3.0 * y *
-                (3.0 * std::pow(x, 2) - std::pow(z, 2) + 2.0 * z - 1.0) * 0.5 *
-                std::pow(ratio, 2);
-              grad[2] =
-                (-9.0 * std::pow(x, 2) * std::pow(y, 2) + std::pow(z, 4) -
-                 4.0 * std::pow(z, 3) + 6.0 * std::pow(z, 2) - 4.0 * z + 1) *
-                0.5 * ratio_13;
-            }
-            break;
-          default:
-            DEAL_II_NOT_IMPLEMENTED();
-            break;
-        }
-      for (unsigned int d = 0; d < dim; ++d)
-        if (std::fabs(grad[d]) < 1e-14)
-          grad[d] = 0.0;
-
-      return grad;
-    }
-  DEAL_II_NOT_IMPLEMENTED();
-  return Tensor<1, dim>();
-}
-
-
-template <int dim>
 ScalarLagrangePolynomialPyramid<dim>::ScalarLagrangePolynomialPyramid(
   const unsigned int            degree,
   const unsigned int            n_dofs,
@@ -456,13 +238,13 @@ ScalarLagrangePolynomialPyramid<dim>::ScalarLagrangePolynomialPyramid(
 }
 
 
+
 template <int dim>
 double
 ScalarLagrangePolynomialPyramid<dim>::compute_value(const unsigned int i,
                                                     const Point<dim>  &p) const
 {
   AssertDimension(dim, 3);
-  // AssertIndexRange(this->degree(), 3);
   AssertIndexRange(i, VDM_inv.m());
 
   double result = 0;
@@ -483,88 +265,16 @@ ScalarLagrangePolynomialPyramid<dim>::compute_grad(const unsigned int i,
                                                    const Point<dim>  &p) const
 {
   AssertDimension(dim, 3);
-  // AssertIndexRange(this->degree(), 3);
-
+  AssertIndexRange(i, VDM_inv.m());
+  
   Tensor<1, dim> grad;
 
-  if (false) //(this->degree() == 1)
-    {
-      const double Q14 = 0.25;
+  for (unsigned int j = 0; j < VDM_inv.n(); ++j)
+    grad += VDM_inv[i][j] * this->compute_jacobi_deriv(j, p);
 
-      const double r = p[0];
-      const double s = p[1];
-      const double t = p[2];
-
-      double rationdr;
-      double rationds;
-      double rationdt;
-
-      if (fabs(t - 1.0) > 1.0e-14)
-        {
-          rationdr = s * t / (1.0 - t);
-          rationds = r * t / (1.0 - t);
-          rationdt = r * s / ((1.0 - t) * (1.0 - t));
-        }
-      else
-        {
-          rationdr = 1.0;
-          rationds = 1.0;
-          rationdt = 1.0;
-        }
-
-
-      if (i == 0)
-        {
-          grad[0] = Q14 * (-1.0 * (1.0 - s) + rationdr);
-          grad[1] = Q14 * (-1.0 * (1.0 - r) + rationds);
-          grad[2] = Q14 * (rationdt - 1.0);
-        }
-      else if (i == 1)
-        {
-          grad[0] = Q14 * (1.0 * (1.0 - s) - rationdr);
-          grad[1] = Q14 * (-1.0 * (1.0 + r) - rationds);
-          grad[2] = Q14 * (-1.0 * rationdt - 1.0);
-        }
-      else if (i == 2)
-        {
-          grad[0] = Q14 * (-1.0 * (1.0 + s) - rationdr);
-          grad[1] = Q14 * (1.0 * (1.0 - r) - rationds);
-          grad[2] = Q14 * (-1.0 * rationdt - 1.0);
-        }
-      else if (i == 3)
-        {
-          grad[0] = Q14 * (1.0 * (1.0 + s) + rationdr);
-          grad[1] = Q14 * (1.0 * (1.0 + r) + rationds);
-          grad[2] = Q14 * (rationdt - 1.0);
-        }
-      else if (i == 4)
-        {
-          grad[0] = 0.0;
-          grad[1] = 0.0;
-          grad[2] = 1.0;
-        }
-      else
-        {
-          DEAL_II_NOT_IMPLEMENTED();
-        }
-    }
-  // else // if (this->degree() == 2)
-
-  {
-    AssertIndexRange(i, VDM_inv.m());
-
-    for (unsigned int j = 0; j < VDM_inv.n(); ++j)
-      grad += VDM_inv[i][j] * this->compute_jacobi_deriv(j, p);
-
-    for (unsigned int d = 0; d < dim; ++d)
-      if (std::fabs(grad[d]) < 1e-14)
-        grad[d] = 0.0;
-  }
-
-  // else
-  //   DEAL_II_NOT_IMPLEMENTED();
-
-
+  for (unsigned int d = 0; d < dim; ++d)
+    if (std::fabs(grad[d]) < 1e-14)
+      grad[d] = 0.0;
 
   return grad;
 }

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -2332,7 +2332,7 @@ namespace internal
                                 .reference_cell()))
                           is_mixed_mesh = true;
 
-                      unsigned short hypercube_or_simplex_fe_index =
+                      auto hypercube_or_simplex_fe_index =
                         numbers::invalid_fe_index;
                       if (is_mixed_mesh)
                         // try finding an index which is not pyramid or wedge

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -2324,15 +2324,16 @@ namespace internal
 
                       bool       is_mixed_mesh = false;
                       const auto reference_cell =
-                        dof_handler.get_fe(0).reference_cell();
+                        dof_handler.get_fe(quad->nth_active_fe_index(0))
+                          .reference_cell();
                       for (unsigned int f = 0; f < n_active_fe_indices; ++f)
                         if (!(reference_cell ==
                               dof_handler.get_fe(quad->nth_active_fe_index(f))
                                 .reference_cell()))
                           is_mixed_mesh = true;
 
-                      unsigned int hypercube_or_simplex_fe_index =
-                        numbers::invalid_unsigned_int;
+                      unsigned short hypercube_or_simplex_fe_index =
+                        numbers::invalid_fe_index;
                       if (is_mixed_mesh)
                         // try finding an index which is not pyramid or wedge
                         for (unsigned int f = 0; f < n_active_fe_indices; ++f)

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -169,13 +169,11 @@ namespace internal
               // double check whether the newly created entries make
               // any sense at all
               for (const auto &identity : reduced_identities)
-                { // TODO Fix this for weges
-                  if (fes[fe_index_1].reference_cell() ==
-                        ReferenceCells::Pyramid ||
-                      fes[fe_index_2].reference_cell() ==
-                        ReferenceCells::Pyramid)
+                {
+                  if (fes[fe_index_2].reference_cell() ==
+                      ReferenceCells::Pyramid)
                     {
-                      if (fes[fe_index_1].reference_cell().is_hyper_cube())
+                      if (fes[fe_index_1].reference_cell().is_simplex())
                         {
                           Assert(identity.first <
                                    fes[fe_index_1]
@@ -184,27 +182,49 @@ namespace internal
                                  ExcInternalError());
                           Assert(identity.second <
                                    fes[fe_index_2]
-                                     .template n_dofs_per_object<structdim>(0),
+                                     .template n_dofs_per_object<structdim>(1),
                                  ExcInternalError());
                         }
-                      else if (fes[fe_index_2].reference_cell().is_hyper_cube())
+                      else
                         {
                           Assert(identity.first <
                                    fes[fe_index_1]
-                                     .template n_dofs_per_object<structdim>(0),
+                                     .template n_dofs_per_object<structdim>(
+                                       face_no),
                                  ExcInternalError());
                           Assert(identity.second <
                                    fes[fe_index_2]
-                                     .template n_dofs_per_object<structdim>(
-                                       face_no),
+                                     .template n_dofs_per_object<structdim>(0),
                                  ExcInternalError());
                         }
                     }
-                  else if (fes[fe_index_1].reference_cell() ==
-                             ReferenceCells::Wedge ||
-                           fes[fe_index_2].reference_cell() ==
-                             ReferenceCells::Wedge)
+                  else if (fes[fe_index_2].reference_cell() ==
+                           ReferenceCells::Wedge)
                     {
+                      if (fes[fe_index_1].reference_cell().is_simplex())
+                        {
+                          Assert(identity.first <
+                                   fes[fe_index_1]
+                                     .template n_dofs_per_object<structdim>(
+                                       face_no),
+                                 ExcInternalError());
+                          Assert(identity.second <
+                                   fes[fe_index_2]
+                                     .template n_dofs_per_object<structdim>(0),
+                                 ExcInternalError());
+                        }
+                      else
+                        {
+                          Assert(identity.first <
+                                   fes[fe_index_1]
+                                     .template n_dofs_per_object<structdim>(
+                                       face_no),
+                                 ExcInternalError());
+                          Assert(identity.second <
+                                   fes[fe_index_2]
+                                     .template n_dofs_per_object<structdim>(2),
+                                 ExcInternalError());
+                        }
                     }
                   else
                     {
@@ -2324,10 +2344,6 @@ namespace internal
                                 .is_hyper_cube())
                             hypercube_or_simplex_fe_index =
                               quad->nth_active_fe_index(f);
-                      // if there are only pyramids and wedges reset
-                      if (hypercube_or_simplex_fe_index ==
-                          numbers::invalid_unsigned_int)
-                        is_mixed_mesh = false;
 
                       for (unsigned int f = 0; f < n_active_fe_indices; ++f)
                         {
@@ -2340,16 +2356,10 @@ namespace internal
                                 .n_dofs_per_quad(q) :
                               dof_handler.get_fe(fe_index).n_dofs_per_quad(q);
 
-                          std::cout << "N dofs per quad " << n_dofs_per_quad
-                                    << " on face " << q << std::endl;
                           for (unsigned int d = 0; d < n_dofs_per_quad; ++d)
                             {
                               const types::global_dof_index old_dof_index =
                                 quad->dof_index(d, fe_index);
-                              std::cout << "old index: " << old_dof_index
-                                        << " changed to "
-                                        << new_numbers[old_dof_index]
-                                        << std::endl;
                               if (old_dof_index != numbers::invalid_dof_index)
                                 {
                                   // In the following blocks, we first check

--- a/source/fe/fe_pyramid_p.cc
+++ b/source/fe/fe_pyramid_p.cc
@@ -330,15 +330,14 @@ FE_PyramidPoly<dim, spacedim>::FE_PyramidPoly(
         ComponentMask(std::vector<bool>(1, true))))
 {
   AssertDimension(dim, 3);
-    
+
   for (auto &support_point : dpos_support_points.second)
     this->unit_support_points.emplace_back(support_point);
-  
+
   if (conformity == FiniteElementData<dim>::H1)
     {
       // face support points
-      this->unit_face_support_points.resize(
-        this->reference_cell().n_faces());
+      this->unit_face_support_points.resize(this->reference_cell().n_faces());
 
       for (const auto f : this->reference_cell().face_indices())
         {
@@ -348,8 +347,7 @@ FE_PyramidPoly<dim, spacedim>::FE_PyramidPoly(
           if (face_reference_cell == ReferenceCells::Quadrilateral)
             {
               FE_Q<2> fe_face(degree);
-              for (auto &face_support_point :
-                    fe_face.get_unit_support_points())
+              for (auto &face_support_point : fe_face.get_unit_support_points())
                 {
                   Point<dim - 1> p;
                   for (unsigned int d = 0; d < dim - 1; ++d)
@@ -360,8 +358,7 @@ FE_PyramidPoly<dim, spacedim>::FE_PyramidPoly(
           else if (face_reference_cell == ReferenceCells::Triangle)
             {
               FE_SimplexP<2> fe_face(degree);
-              for (auto &face_support_point :
-                    fe_face.get_unit_support_points())
+              for (auto &face_support_point : fe_face.get_unit_support_points())
                 {
                   Point<dim - 1> p;
                   for (unsigned int d = 0; d < dim - 1; ++d)
@@ -452,18 +449,8 @@ FE_PyramidP<dim, spacedim>::compare_for_domination(
   // (if fe_other is not derived from FE_SimplexDGP)
   // & cell domination
   // ----------------------------------------
-  if (const FE_PyramidP<dim, spacedim> *fe_pp_other =
-        dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other))
-    {
-      if (this->degree < fe_pp_other->degree)
-        return FiniteElementDomination::this_element_dominates;
-      else if (this->degree == fe_pp_other->degree)
-        return FiniteElementDomination::either_element_can_dominate;
-      else
-        return FiniteElementDomination::other_element_dominates;
-    }
-  else if (const FE_SimplexP<dim, spacedim> *fe_p_other =
-             dynamic_cast<const FE_SimplexP<dim, spacedim> *>(&fe_other))
+  if (const FE_SimplexP<dim, spacedim> *fe_p_other =
+        dynamic_cast<const FE_SimplexP<dim, spacedim> *>(&fe_other))
     {
       if (this->degree < fe_p_other->degree)
         return FiniteElementDomination::this_element_dominates;
@@ -478,6 +465,26 @@ FE_PyramidP<dim, spacedim>::compare_for_domination(
       if (this->degree < fe_q_other->degree)
         return FiniteElementDomination::this_element_dominates;
       else if (this->degree == fe_q_other->degree)
+        return FiniteElementDomination::either_element_can_dominate;
+      else
+        return FiniteElementDomination::other_element_dominates;
+    }
+  else if (const FE_PyramidP<dim, spacedim> *fe_pp_other =
+             dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other))
+    {
+      if (this->degree < fe_pp_other->degree)
+        return FiniteElementDomination::this_element_dominates;
+      else if (this->degree == fe_pp_other->degree)
+        return FiniteElementDomination::either_element_can_dominate;
+      else
+        return FiniteElementDomination::other_element_dominates;
+    }
+  else if (const FE_WedgeP<dim, spacedim> *fe_pp_other =
+             dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other))
+    {
+      if (this->degree < fe_pp_other->degree)
+        return FiniteElementDomination::this_element_dominates;
+      else if (this->degree == fe_pp_other->degree)
         return FiniteElementDomination::either_element_can_dominate;
       else
         return FiniteElementDomination::other_element_dominates;

--- a/source/fe/fe_pyramid_p.cc
+++ b/source/fe/fe_pyramid_p.cc
@@ -276,7 +276,7 @@ namespace
 
 
   /**
-   * Helper function to set up the dpo vector of FE_PyramidP for a given @p degree.
+   * Helper function to set up the dpo vector of FE_PyramidDGP for a given @p degree.
    */
   template <int dim>
   std::pair<const internal::GenericDoFsPerObject, const std::vector<Point<dim>>>

--- a/source/fe/fe_pyramid_p.cc
+++ b/source/fe/fe_pyramid_p.cc
@@ -33,6 +33,266 @@ namespace
   /**
    * Helper function to set up the dpo vector of FE_PyramidP for a given @p degree.
    */
+  unsigned int
+  compute_n_dofs(const unsigned int dim, const unsigned int degree)
+  {
+    AssertDimension(dim, 3);
+    return (degree + 1) * (degree + 2) * (2 * degree + 3) / 6;
+  }
+
+
+
+  /**
+   * Helper function to set up the dpo vector of FE_PyramidP for a given @p degree.
+   */
+  template <int dim>
+  std::pair<const internal::GenericDoFsPerObject, const std::vector<Point<dim>>>
+  get_support_points_dpo_vector_fe_pyramid_p(const unsigned int degree)
+  {
+    AssertDimension(dim, 3);
+
+    internal::GenericDoFsPerObject dpo;
+
+    // set dpo for linear case and then add for higher orders
+    dpo.dofs_per_object_exclusive  = {{1}, {degree - 1}, {0, 0, 0, 0, 0}, {0}};
+    dpo.dofs_per_object_inclusive  = {{1},
+                                      {degree + 1},
+                                      {4, 3, 3, 3, 3},
+                                      {compute_n_dofs(dim, degree)}};
+    dpo.object_index               = {{}, {5}, {5, 5, 5, 5, 5}, {5}};
+    dpo.first_object_index_on_face = {{}, {4, 3, 3, 3, 3}, {4, 3, 3, 3, 3}};
+
+    std::vector<Point<dim>> support_points;
+    std::vector<Point<dim>> support_points_unordered;
+
+    std::vector<unsigned int> n_dofs_total_per_object(4, 0);
+    std::vector<unsigned int> n_dofs_per_object(4, 0);
+
+    support_points.resize(compute_n_dofs(dim, degree));
+    const double z_equidistance = 1.0 / degree;
+
+    for (unsigned int current_degree = degree; current_degree > 0;
+         --current_degree)
+      {
+        FE_Q<2> fe_q(current_degree);
+
+        // save all support points in an unordered fashion
+        for (unsigned int support_point_index = 0;
+             support_point_index < fe_q.get_unit_support_points().size();
+             ++support_point_index)
+          {
+            Point<dim> support_point;
+            for (unsigned int d = 0; d < dim - 1; ++d)
+              support_point[d] =
+                (current_degree * z_equidistance) *
+                (2 * fe_q.get_unit_support_points()[support_point_index][d] -
+                 1);
+            support_point[dim - 1] = (degree - current_degree) * z_equidistance;
+            support_points_unordered.emplace_back(support_point);
+          }
+        if (current_degree == degree)
+          {
+            // the first are the support points at the vertices
+            n_dofs_total_per_object[0] = fe_q.reference_cell().n_vertices() + 1;
+
+            // lines are on lines
+            n_dofs_total_per_object[1] =
+              fe_q.reference_cell().n_lines() * fe_q.n_dofs_per_line();
+            // faces are on faces
+            n_dofs_total_per_object[2] = fe_q.n_dofs_per_quad();
+            // nothing per hex
+            n_dofs_total_per_object[3] = 0;
+
+            n_dofs_per_object[0] =
+              fe_q.reference_cell().n_lines() * fe_q.n_dofs_per_line();
+            n_dofs_per_object[2] = fe_q.n_dofs_per_quad();
+
+            dpo.dofs_per_object_exclusive[2][0] = fe_q.n_dofs_per_quad();
+            dpo.dofs_per_object_inclusive[2][0] = fe_q.n_dofs_per_cell();
+
+            dpo.dofs_per_object_inclusive[2][1] += fe_q.n_dofs_per_line();
+            dpo.dofs_per_object_inclusive[2][2] += fe_q.n_dofs_per_line();
+            dpo.dofs_per_object_inclusive[2][3] += fe_q.n_dofs_per_line();
+            dpo.dofs_per_object_inclusive[2][4] += fe_q.n_dofs_per_line();
+
+            dpo.first_object_index_on_face[2][0] += n_dofs_per_object[0];
+            dpo.first_object_index_on_face[2][1] += fe_q.n_dofs_per_line();
+            dpo.first_object_index_on_face[2][2] += fe_q.n_dofs_per_line();
+            dpo.first_object_index_on_face[2][3] += fe_q.n_dofs_per_line();
+            dpo.first_object_index_on_face[2][4] += fe_q.n_dofs_per_line();
+          }
+        else
+          {
+            // on the vertex here is on the line in the pyramid
+            n_dofs_total_per_object[1] += fe_q.reference_cell().n_vertices();
+
+            dpo.first_object_index_on_face[2][1] += 2;
+            dpo.first_object_index_on_face[2][2] += 2;
+            dpo.first_object_index_on_face[2][3] += 2;
+            dpo.first_object_index_on_face[2][4] += 2;
+
+            // on the lines here are on faces in the pyramid
+            n_dofs_total_per_object[2] +=
+              fe_q.reference_cell().n_lines() * fe_q.n_dofs_per_line();
+
+            dpo.dofs_per_object_exclusive[2][1] += fe_q.n_dofs_per_line();
+            dpo.dofs_per_object_exclusive[2][2] += fe_q.n_dofs_per_line();
+            dpo.dofs_per_object_exclusive[2][3] += fe_q.n_dofs_per_line();
+            dpo.dofs_per_object_exclusive[2][4] += fe_q.n_dofs_per_line();
+            dpo.dofs_per_object_inclusive[2][1] += fe_q.n_dofs_per_line() + 2;
+            dpo.dofs_per_object_inclusive[2][2] += fe_q.n_dofs_per_line() + 2;
+            dpo.dofs_per_object_inclusive[2][3] += fe_q.n_dofs_per_line() + 2;
+            dpo.dofs_per_object_inclusive[2][4] += fe_q.n_dofs_per_line() + 2;
+
+
+            // on the faces here is on the hex on the pyramid
+            n_dofs_total_per_object[3] += fe_q.n_dofs_per_quad();
+            dpo.dofs_per_object_exclusive[3][0] += fe_q.n_dofs_per_quad();
+
+
+            n_dofs_per_object[1] += 1;
+            n_dofs_per_object[3] += fe_q.n_dofs_per_line();
+          }
+      }
+
+    unsigned int global_counter = 0;
+
+    std::vector<unsigned int> start_lines(4);
+    start_lines[0] = n_dofs_total_per_object[0] + n_dofs_per_object[0];
+    start_lines[1] = start_lines[0] + n_dofs_per_object[1];
+    start_lines[2] = start_lines[1] + n_dofs_per_object[1];
+    start_lines[3] = start_lines[2] + n_dofs_per_object[1];
+
+    std::vector<unsigned int> start_faces(4);
+    start_faces[0] = n_dofs_total_per_object[0] + n_dofs_total_per_object[1] +
+                     n_dofs_per_object[2];
+    start_faces[1] = start_faces[0] + n_dofs_per_object[3];
+    start_faces[2] = start_faces[1] + n_dofs_per_object[3];
+    start_faces[3] = start_faces[2] + n_dofs_per_object[3];
+
+    dpo.object_index[2][0] =
+      n_dofs_total_per_object[0] + n_dofs_total_per_object[1];
+    dpo.object_index[2][1] = start_faces[0];
+    dpo.object_index[2][2] = start_faces[1];
+    dpo.object_index[2][3] = start_faces[2];
+    dpo.object_index[2][4] = start_faces[3];
+
+
+    unsigned int start_hex = n_dofs_total_per_object[0] +
+                             n_dofs_total_per_object[1] +
+                             n_dofs_total_per_object[2];
+
+    dpo.object_index[3][0] = start_hex;
+
+    for (unsigned int current_degree = degree; current_degree > 0;
+         --current_degree)
+      {
+        FE_Q<2> fe_q(current_degree);
+
+        if (current_degree == degree)
+          {
+            // this gives all info on the vertices, the first 4 edges and the
+            // first face
+
+            // vertices
+            for (unsigned int counter = 0;
+                 counter < fe_q.reference_cell().n_vertices();
+                 ++counter)
+              {
+                support_points[counter] =
+                  support_points_unordered[global_counter++];
+              }
+            // lines
+            for (unsigned int counter = 0;
+                 counter <
+                 fe_q.reference_cell().n_lines() * fe_q.n_dofs_per_line();
+                 ++counter)
+              {
+                support_points[counter + n_dofs_total_per_object[0]] =
+                  support_points_unordered[global_counter++];
+              }
+            // quad
+            for (unsigned int counter = 0; counter < fe_q.n_dofs_per_quad();
+                 ++counter)
+              {
+                support_points[counter + n_dofs_total_per_object[0] +
+                               n_dofs_total_per_object[1]] =
+                  support_points_unordered[global_counter++];
+              }
+          }
+        else
+          {
+            // vertices are on lines
+            for (unsigned int line = 0;
+                 line < fe_q.reference_cell().n_vertices();
+                 ++line)
+              {
+                support_points[start_lines[line]++] =
+                  support_points_unordered[global_counter++];
+              }
+            // lines are on face
+            for (unsigned int face = 0; face < fe_q.reference_cell().n_lines();
+                 ++face)
+              {
+                for (unsigned int n_dof = 0; n_dof < fe_q.n_dofs_per_line();
+                     ++n_dof)
+                  support_points[start_faces[face]++] =
+                    support_points_unordered[global_counter++];
+              }
+            // faces are on hex
+            for (unsigned int hex = 0; hex < fe_q.n_dofs_per_quad(); ++hex)
+              {
+                support_points[start_hex++] =
+                  support_points_unordered[global_counter++];
+              }
+          }
+      }
+    Point<dim> tip;
+    for (unsigned int d = 0; d < dim; ++d)
+      {
+        if (d == 2)
+          tip[d] = 1.0;
+        else
+          tip[d] = 0.0;
+      }
+    support_points[4] = tip;
+
+
+    std::pair<internal::GenericDoFsPerObject, std::vector<Point<dim>>>
+      dpos_support_points;
+    dpos_support_points.first  = dpo;
+    dpos_support_points.second = support_points;
+
+    return dpos_support_points;
+  }
+
+
+  /**
+   * Helper function to set up the dpo vector of FE_PyramidP for a given @p degree.
+   */
+  template <int dim>
+  std::pair<const internal::GenericDoFsPerObject, const std::vector<Point<dim>>>
+  get_support_points_dpo_vector_fe_pyramid_dgp(const unsigned int degree)
+  {
+    AssertDimension(dim, 3);
+    const auto support_points =
+      get_support_points_dpo_vector_fe_pyramid_p<dim>(degree).second;
+
+    std::pair<internal::GenericDoFsPerObject, std::vector<Point<dim>>>
+      dpos_support_points;
+    dpos_support_points.second = support_points;
+    dpos_support_points.first =
+      internal::expand(3,
+                       {{0, 0, 0, compute_n_dofs(dim, degree)}},
+                       ReferenceCells::Pyramid);
+
+    return dpos_support_points;
+  }
+
+
+  /**
+   * Helper function to set up the dpo vector of FE_PyramidP for a given @p degree.
+   */
   internal::GenericDoFsPerObject
   get_dpo_vector_fe_pyramid_p(const unsigned int degree)
   {
@@ -82,29 +342,37 @@ namespace
 
 template <int dim, int spacedim>
 FE_PyramidPoly<dim, spacedim>::FE_PyramidPoly(
-  const unsigned int                                degree,
-  const internal::GenericDoFsPerObject             &dpos,
+  const unsigned int degree,
+  std::pair<const internal::GenericDoFsPerObject, const std::vector<Point<dim>>>
+                                                    dpos_support_points,
   const bool                                        prolongation_is_additive,
   const typename FiniteElementData<dim>::Conformity conformity)
   : dealii::FE_Poly<dim, spacedim>(
-      ScalarLagrangePolynomialPyramid<dim>(degree),
-      FiniteElementData<dim>(dpos,
+      ScalarLagrangePolynomialPyramid<dim>(degree,
+                                           compute_n_dofs(dim, degree),
+                                           dpos_support_points.second),
+      FiniteElementData<dim>(dpos_support_points.first,
                              ReferenceCells::Pyramid,
                              1,
                              degree,
                              conformity),
-      std::vector<bool>(
-        FiniteElementData<dim>(dpos, ReferenceCells::Pyramid, 1, degree)
-          .dofs_per_cell,
-        prolongation_is_additive),
+      std::vector<bool>(FiniteElementData<dim>(dpos_support_points.first,
+                                               ReferenceCells::Pyramid,
+                                               1,
+                                               degree)
+                          .dofs_per_cell,
+                        prolongation_is_additive),
       std::vector<ComponentMask>(
-        FiniteElementData<dim>(dpos, ReferenceCells::Pyramid, 1, degree)
+        FiniteElementData<dim>(dpos_support_points.first,
+                               ReferenceCells::Pyramid,
+                               1,
+                               degree)
           .dofs_per_cell,
         ComponentMask(std::vector<bool>(1, true))))
 {
   AssertDimension(dim, 3);
 
-  if (degree == 1)
+  if (false) //(degree == 1)
     {
       for (const auto i : this->reference_cell().vertex_indices())
         this->unit_support_points.emplace_back(
@@ -122,7 +390,7 @@ FE_PyramidPoly<dim, spacedim>::FE_PyramidPoly(
               face_reference_cell.template vertex<dim - 1>(i));
         }
     }
-  else if (degree == 2)
+  else if (false) //(degree == 2)
     {
       for (const auto i : this->reference_cell().vertex_indices())
         this->unit_support_points.emplace_back(
@@ -174,7 +442,48 @@ FE_PyramidPoly<dim, spacedim>::FE_PyramidPoly(
         }
     }
   else
-    DEAL_II_NOT_IMPLEMENTED();
+    {
+      for (auto &support_point : dpos_support_points.second)
+        this->unit_support_points.emplace_back(support_point);
+      /*
+            if (conformity == FiniteElementData<dim>::H1)
+              {
+                // face support points
+                this->unit_face_support_points.resize(
+                  this->reference_cell().n_faces());
+
+                for (const auto f : this->reference_cell().face_indices())
+                  {
+                    const auto face_reference_cell =
+                      this->reference_cell().face_reference_cell(f);
+
+                    if (face_reference_cell == ReferenceCells::Quadrilateral)
+                      {
+                        FE_Q<2> fe_face(degree);
+                        for (auto &face_support_point :
+                             fe_face.get_unit_support_points())
+                          {
+                            Point<dim - 1> p;
+                            for (unsigned int d = 0; d < dim - 1; ++d)
+                              p[d] = face_support_point[d];
+                            this->unit_face_support_points[f].emplace_back(p);
+                          }
+                      }
+                    else if (face_reference_cell == ReferenceCells::Triangle)
+                      {
+                        FE_SimplexP<2> fe_face(degree);
+                        for (auto &face_support_point :
+                             fe_face.get_unit_support_points())
+                          {
+                            Point<dim - 1> p;
+                            for (unsigned int d = 0; d < dim - 1; ++d)
+                              p[d] = face_support_point[d];
+                            this->unit_face_support_points[f].emplace_back(p);
+                          }
+                      }
+                  }
+              }*/
+    }
 }
 
 
@@ -203,10 +512,11 @@ FE_PyramidPoly<dim, spacedim>::
 
 template <int dim, int spacedim>
 FE_PyramidP<dim, spacedim>::FE_PyramidP(const unsigned int degree)
-  : FE_PyramidPoly<dim, spacedim>(degree,
-                                  get_dpo_vector_fe_pyramid_p(degree),
-                                  false,
-                                  FiniteElementData<dim>::H1)
+  : FE_PyramidPoly<dim, spacedim>(
+      degree,
+      get_support_points_dpo_vector_fe_pyramid_p<dim>(degree),
+      false,
+      FiniteElementData<dim>::H1)
 {}
 
 
@@ -374,10 +684,11 @@ FE_PyramidP<dim, spacedim>::hp_quad_dof_identities(
 
 template <int dim, int spacedim>
 FE_PyramidDGP<dim, spacedim>::FE_PyramidDGP(const unsigned int degree)
-  : FE_PyramidPoly<dim, spacedim>(degree,
-                                  get_dpo_vector_fe_pyramid_dgp(degree),
-                                  true,
-                                  FiniteElementData<dim>::L2)
+  : FE_PyramidPoly<dim, spacedim>(
+      degree,
+      get_support_points_dpo_vector_fe_pyramid_dgp<dim>(degree),
+      true,
+      FiniteElementData<dim>::L2)
 {}
 
 

--- a/source/fe/fe_pyramid_p.cc
+++ b/source/fe/fe_pyramid_p.cc
@@ -40,7 +40,38 @@ namespace
     return (degree + 1) * (degree + 2) * (2 * degree + 3) / 6;
   }
 
+  /**
+   * Helper function to set up the dpo vector of FE_PyramidP for a given @p degree.
+   */
+  internal::GenericDoFsPerObject
+  get_dpo_vector_fe_pyramid_p(const unsigned int degree)
+  {
+    internal::GenericDoFsPerObject dpo;
 
+    if (degree == 1)
+      {
+        dpo.dofs_per_object_exclusive  = {{1}, {0}, {0, 0, 0, 0, 0}, {0}};
+        dpo.dofs_per_object_inclusive  = {{1}, {2}, {4, 3, 3, 3, 3}, {5}};
+        dpo.object_index               = {{}, {5}, {5}, {5}};
+        dpo.first_object_index_on_face = {{}, {4, 3, 3, 3, 3}, {4, 3, 3, 3, 3}};
+      }
+    else if (degree == 2)
+      {
+        dpo.dofs_per_object_exclusive  = {{1}, {1}, {1, 0, 0, 0, 0}, {0}};
+        dpo.dofs_per_object_inclusive  = {{1}, {3}, {9, 6, 6, 6, 6}, {14}};
+        dpo.object_index               = {{},
+                                          {5, 6, 7, 8, 9, 10, 11, 12},
+                                          {13, 14, 14, 14, 14},
+                                          {14}};
+        dpo.first_object_index_on_face = {{}, {4, 3, 3, 3, 3}, {8, 6, 6, 6, 6}};
+      }
+    else
+      {
+        DEAL_II_NOT_IMPLEMENTED();
+      }
+
+    return dpo;
+  }
 
   /**
    * Helper function to set up the dpo vector of FE_PyramidP for a given @p degree.
@@ -54,12 +85,12 @@ namespace
     internal::GenericDoFsPerObject dpo;
 
     // set dpo for linear case and then add for higher orders
-    dpo.dofs_per_object_exclusive  = {{1}, {degree - 1}, {0, 0, 0, 0, 0}, {0}};
-    dpo.dofs_per_object_inclusive  = {{1},
-                                      {degree + 1},
-                                      {4, 3, 3, 3, 3},
-                                      {compute_n_dofs(dim, degree)}};
-    dpo.object_index               = {{}, {5}, {5, 5, 5, 5, 5}, {5}};
+    dpo.dofs_per_object_exclusive = {{1}, {degree - 1}, {0, 0, 0, 0, 0}, {0}};
+    dpo.dofs_per_object_inclusive = {{1},
+                                     {degree + 1},
+                                     {4, 3, 3, 3, 3},
+                                     {compute_n_dofs(dim, degree)}};
+    dpo.object_index = {{}, {5, 5, 5, 5, 5, 5, 5, 5}, {5, 5, 5, 5, 5}, {5}};
     dpo.first_object_index_on_face = {{}, {4, 3, 3, 3, 3}, {4, 3, 3, 3, 3}};
 
     std::vector<Point<dim>> support_points;
@@ -120,6 +151,11 @@ namespace
             dpo.first_object_index_on_face[2][2] += fe_q.n_dofs_per_line();
             dpo.first_object_index_on_face[2][3] += fe_q.n_dofs_per_line();
             dpo.first_object_index_on_face[2][4] += fe_q.n_dofs_per_line();
+
+
+            dpo.object_index[1][1] += fe_q.n_dofs_per_line();
+            dpo.object_index[1][2] += 2 * fe_q.n_dofs_per_line();
+            dpo.object_index[1][3] += 3 * fe_q.n_dofs_per_line();
           }
         else
           {
@@ -162,6 +198,11 @@ namespace
     start_lines[1] = start_lines[0] + n_dofs_per_object[1];
     start_lines[2] = start_lines[1] + n_dofs_per_object[1];
     start_lines[3] = start_lines[2] + n_dofs_per_object[1];
+
+    dpo.object_index[1][4] = start_lines[0];
+    dpo.object_index[1][5] = start_lines[1];
+    dpo.object_index[1][6] = start_lines[2];
+    dpo.object_index[1][7] = start_lines[3];
 
     std::vector<unsigned int> start_faces(4);
     start_faces[0] = n_dofs_total_per_object[0] + n_dofs_total_per_object[1] +
@@ -290,35 +331,6 @@ namespace
   }
 
 
-  /**
-   * Helper function to set up the dpo vector of FE_PyramidP for a given @p degree.
-   */
-  internal::GenericDoFsPerObject
-  get_dpo_vector_fe_pyramid_p(const unsigned int degree)
-  {
-    internal::GenericDoFsPerObject dpo;
-
-    if (degree == 1)
-      {
-        dpo.dofs_per_object_exclusive  = {{1}, {0}, {0, 0, 0, 0, 0}, {0}};
-        dpo.dofs_per_object_inclusive  = {{1}, {2}, {4, 3, 3, 3, 3}, {5}};
-        dpo.object_index               = {{}, {5}, {5}, {5}};
-        dpo.first_object_index_on_face = {{}, {4, 3, 3, 3, 3}, {4, 3, 3, 3, 3}};
-      }
-    else if (degree == 2)
-      {
-        dpo.dofs_per_object_exclusive  = {{1}, {1}, {1, 0, 0, 0, 0}, {0}};
-        dpo.dofs_per_object_inclusive  = {{1}, {3}, {9, 6, 6, 6, 6}, {14}};
-        dpo.object_index               = {{}, {5}, {13, 14, 14, 14, 14}, {14}};
-        dpo.first_object_index_on_face = {{}, {4, 3, 3, 3, 3}, {8, 6, 6, 6, 6}};
-      }
-    else
-      {
-        DEAL_II_NOT_IMPLEMENTED();
-      }
-
-    return dpo;
-  }
 
   /**
    * Helper function to set up the dpo vector of FE_PyramidDGP for a given @p degree.
@@ -673,7 +685,6 @@ FE_PyramidP<dim, spacedim>::hp_quad_dof_identities(
     }
 
   std::vector<std::pair<unsigned int, unsigned int>> result;
-
   for (unsigned int i = 0; i < this->n_dofs_per_quad(face_no); ++i)
     result.emplace_back(i, i);
 

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -907,6 +907,11 @@ FE_Q_Base<dim, spacedim>::hp_line_dof_identities(
       std::vector<std::pair<unsigned int, unsigned int>> identities;
 
       for (unsigned int i = 0; i < this->degree - 1; ++i)
+        identities.emplace_back(i, i);
+      return identities;
+
+
+      for (unsigned int i = 0; i < this->degree - 1; ++i)
         for (unsigned int j = 0; j < fe_p_other->degree - 1; ++j)
           if (std::fabs(
                 this->unit_support_points[index_map_inverse_q[i + 1]][0] -
@@ -946,7 +951,7 @@ template <int dim, int spacedim>
 std::vector<std::pair<unsigned int, unsigned int>>
 FE_Q_Base<dim, spacedim>::hp_quad_dof_identities(
   const FiniteElement<dim, spacedim> &fe_other,
-  const unsigned int                  face_no) const
+  const unsigned int /*face_no*/) const
 {
   // we can presently only compute these identities if both FEs are FE_Qs or
   // if the other one is an FE_Nothing
@@ -997,17 +1002,12 @@ FE_Q_Base<dim, spacedim>::hp_quad_dof_identities(
       // Only linear Pyramid Elements are implemented
       // there are no dofs on the faces
       // Assert(fe_other.degree == 1, ExcNotImplemented());
-      if (fe_other.degree == 1)
-        return std::vector<std::pair<unsigned int, unsigned int>>();
-      else if (fe_other.degree == 2)
-        {
-          std::vector<std::pair<unsigned int, unsigned int>> identities;
-          if (face_no == 0)
-            identities.emplace_back(0, 0);
-          return identities;
-        }
-      else
-        DEAL_II_NOT_IMPLEMENTED();
+
+      std::vector<std::pair<unsigned int, unsigned int>> identities;
+      // if (face_no == 0)
+      for (unsigned int i = 0; i < fe_other.n_dofs_per_quad(0); ++i)
+        identities.emplace_back(i, i);
+      return identities;
     }
   else if (const FE_WedgeP<dim, spacedim> *fe_p_other =
              dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other))
@@ -1016,14 +1016,9 @@ FE_Q_Base<dim, spacedim>::hp_quad_dof_identities(
       // spaial dimensions. If p=1, then there are none, if p=2 then there is
       // one points on the quad.
       std::vector<std::pair<unsigned int, unsigned int>> identities;
-
-      if (fe_p_other->degree == 2)
-        {
-          if (face_no > 1) // regards the prism face, needed for
-                           // ensure_existence_and_return_dof_identities
-            identities.emplace_back(0, 0);
-        }
-
+      // if (face_no == 0)
+      for (unsigned int i = 0; i < fe_other.n_dofs_per_quad(0); ++i)
+        identities.emplace_back(i, i);
       return identities;
     }
   else if (fe_other.n_unique_faces() == 1 && fe_other.n_dofs_per_face(0) == 0)

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -1015,63 +1015,9 @@ FE_Q_Base<dim, spacedim>::hp_quad_dof_identities(
       // Works like the line case, we just have to check it in 2 different
       // spaial dimensions. If p=1, then there are none, if p=2 then there is
       // one points on the quad.
-      const unsigned int p = this->degree;
-
       std::vector<std::pair<unsigned int, unsigned int>> identities;
 
-      const std::vector<unsigned int> &index_map_inverse =
-        this->get_poly_space_numbering_inverse();
-      if (false)
-        {
-          for (unsigned int i1 = 0; i1 < p - 1; ++i1)
-            for (unsigned int i2 = 0; i2 < p - 1; ++i2)
-              for (unsigned int j = 0; j < 3 * fe_p_other->n_dofs_per_quad(2);
-                   ++j)
-                {
-                  if ((std::fabs(
-                         this
-                           ->unit_support_points[index_map_inverse[i1 + 1]][0] -
-                         fe_p_other->unit_support_point(
-                           j +
-                           fe_p_other->reference_cell().n_vertices() *
-                             fe_p_other->n_dofs_per_vertex() +
-                           fe_p_other->reference_cell().n_lines() *
-                             fe_p_other->n_dofs_per_line())[0]) < 1e-14) &&
-                      (std::fabs(
-                         this
-                           ->unit_support_points[index_map_inverse[i2 + 1]][0] -
-                         fe_p_other->unit_support_point(
-                           j +
-                           fe_p_other->reference_cell().n_vertices() *
-                             fe_p_other->n_dofs_per_vertex() +
-                           fe_p_other->reference_cell().n_lines() *
-                             fe_p_other->n_dofs_per_line())[1]) < 1e-14))
-                    identities.emplace_back(i1 * (p - 1) + i2, 0);
-                  std::cout << fe_p_other->unit_support_point(
-                                 j +
-                                 fe_p_other->reference_cell().n_vertices() *
-                                   fe_p_other->n_dofs_per_vertex() +
-                                 fe_p_other->reference_cell().n_lines() *
-                                   fe_p_other->n_dofs_per_line())[0]
-                            << " "
-                            << fe_p_other->unit_support_point(
-                                 j +
-                                 fe_p_other->reference_cell().n_vertices() *
-                                   fe_p_other->n_dofs_per_vertex() +
-                                 fe_p_other->reference_cell().n_lines() *
-                                   fe_p_other->n_dofs_per_line())[1]
-                            << " "
-                            << fe_p_other->unit_support_point(
-                                 j +
-                                 fe_p_other->reference_cell().n_vertices() *
-                                   fe_p_other->n_dofs_per_vertex() +
-                                 fe_p_other->reference_cell().n_lines() *
-                                   fe_p_other->n_dofs_per_line())[2]
-                            << std::endl;
-                }
-        }
-
-      else if (p == 2)
+      if (fe_p_other->degree == 2)
         {
           if (face_no > 1) // regards the prism face, needed for
                            // ensure_existence_and_return_dof_identities

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -863,62 +863,22 @@ FE_Q_Base<dim, spacedim>::hp_line_dof_identities(
   else if (const FE_WedgeP<dim, spacedim> *fe_p_other =
              dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other))
     {
-      // DoFs are located along lines, so two dofs are identical if they are
-      // located at identical positions. If the points are at the same location,
-      // the lines have to ahve identical support points, if not then there are
-      // no shared support points. For FE_Q, we take the lexicographic ordering
-      // of the line support points in the first direction (i.e., x-direction),
-      // which we access between index 1 and p-1 (index 0 and p are vertex
-      // dofs). For FE_WedgeP, they are currently hard-coded and we iterate over
-      // points on the first line which begin after the 6 vertex points in the
-      // complete list of unit support points
-
-      const std::vector<unsigned int> &index_map_inverse_q =
-        this->get_poly_space_numbering_inverse();
-
+      Assert(fe_p_other->degree == this->this->degree, ExcNotImplemented());
       std::vector<std::pair<unsigned int, unsigned int>> identities;
 
       for (unsigned int i = 0; i < this->degree - 1; ++i)
-        for (unsigned int j = 0; j < fe_p_other->degree - 1; ++j)
-          if (std::fabs(
-                this->unit_support_points[index_map_inverse_q[i + 1]][0] -
-                fe_p_other->get_unit_support_points()
-                  [j + fe_p_other->reference_cell().n_vertices()][0]) < 1e-14)
-            identities.emplace_back(i, j);
+        identities.emplace_back(i, i);
 
       return identities;
     }
   else if (const FE_PyramidP<dim, spacedim> *fe_p_other =
              dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other))
     {
-      // DoFs are located along lines, so two dofs are identical if they are
-      // located at identical positions. If the points are at the same location,
-      // the lines have to ahve identical support points, if not then there are
-      // no shared support points. For FE_Q, we take the lexicographic ordering
-      // of the line support points in the first direction (i.e., x-direction),
-      // which we access between index 1 and p-1 (index 0 and p are vertex
-      // dofs). For FE_PyramidP, they are currently hard-coded and we iterate
-      // over points on the first line which begin after the 6 vertex points in
-      // the complete list of unit support points
-
-      const std::vector<unsigned int> &index_map_inverse_q =
-        this->get_poly_space_numbering_inverse();
-
+      Assert(fe_p_other->degree == this->this->degree, ExcNotImplemented());
       std::vector<std::pair<unsigned int, unsigned int>> identities;
 
       for (unsigned int i = 0; i < this->degree - 1; ++i)
         identities.emplace_back(i, i);
-      return identities;
-
-
-      for (unsigned int i = 0; i < this->degree - 1; ++i)
-        for (unsigned int j = 0; j < fe_p_other->degree - 1; ++j)
-          if (std::fabs(
-                this->unit_support_points[index_map_inverse_q[i + 1]][0] -
-                fe_p_other->get_unit_support_points()
-                  [j + fe_p_other->reference_cell().n_vertices()][0]) < 1e-14)
-            identities.emplace_back(i, j);
-
       return identities;
     }
   else if (dynamic_cast<const FE_Nothing<dim> *>(&fe_other) != nullptr)
@@ -999,25 +959,19 @@ FE_Q_Base<dim, spacedim>::hp_quad_dof_identities(
     }
   else if (dynamic_cast<const FE_PyramidP<dim> *>(&fe_other) != nullptr)
     {
-      // Only linear Pyramid Elements are implemented
-      // there are no dofs on the faces
-      // Assert(fe_other.degree == 1, ExcNotImplemented());
-
+      Assert(fe_p_other->degree == this->this->degree, ExcNotImplemented());
       std::vector<std::pair<unsigned int, unsigned int>> identities;
-      // if (face_no == 0)
-      for (unsigned int i = 0; i < fe_other.n_dofs_per_quad(0); ++i)
+      for (unsigned int i = 0; i < this->n_dofs_per_quad(); ++i)
         identities.emplace_back(i, i);
       return identities;
     }
   else if (const FE_WedgeP<dim, spacedim> *fe_p_other =
              dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other))
     {
-      // Works like the line case, we just have to check it in 2 different
-      // spaial dimensions. If p=1, then there are none, if p=2 then there is
-      // one points on the quad.
+      Assert(fe_p_other->degree == this->this->degree, ExcNotImplemented());
+
       std::vector<std::pair<unsigned int, unsigned int>> identities;
-      // if (face_no == 0)
-      for (unsigned int i = 0; i < fe_other.n_dofs_per_quad(0); ++i)
+      for (unsigned int i = 0; i < this->n_dofs_per_quad(); ++i)
         identities.emplace_back(i, i);
       return identities;
     }

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -860,23 +860,12 @@ FE_Q_Base<dim, spacedim>::hp_line_dof_identities(
 
       return identities;
     }
-  else if (const FE_WedgeP<dim, spacedim> *fe_p_other =
-             dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other))
+  else if ((dynamic_cast<const FE_PyramidP<dim> *>(&fe_other) != nullptr) ||
+           (dynamic_cast<const FE_WedgeP<dim> *>(&fe_other) != nullptr))
     {
-      Assert(fe_p_other->degree == this->this->degree, ExcNotImplemented());
+      Assert(fe_other.degree == this->degree, ExcNotImplemented());
+
       std::vector<std::pair<unsigned int, unsigned int>> identities;
-
-      for (unsigned int i = 0; i < this->degree - 1; ++i)
-        identities.emplace_back(i, i);
-
-      return identities;
-    }
-  else if (const FE_PyramidP<dim, spacedim> *fe_p_other =
-             dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other))
-    {
-      Assert(fe_p_other->degree == this->this->degree, ExcNotImplemented());
-      std::vector<std::pair<unsigned int, unsigned int>> identities;
-
       for (unsigned int i = 0; i < this->degree - 1; ++i)
         identities.emplace_back(i, i);
       return identities;
@@ -911,7 +900,7 @@ template <int dim, int spacedim>
 std::vector<std::pair<unsigned int, unsigned int>>
 FE_Q_Base<dim, spacedim>::hp_quad_dof_identities(
   const FiniteElement<dim, spacedim> &fe_other,
-  const unsigned int /*face_no*/) const
+  const unsigned int) const
 {
   // we can presently only compute these identities if both FEs are FE_Qs or
   // if the other one is an FE_Nothing
@@ -957,18 +946,10 @@ FE_Q_Base<dim, spacedim>::hp_quad_dof_identities(
       // equivalencies to be recorded
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
-  else if (dynamic_cast<const FE_PyramidP<dim> *>(&fe_other) != nullptr)
+  else if ((dynamic_cast<const FE_PyramidP<dim> *>(&fe_other) != nullptr) ||
+           (dynamic_cast<const FE_WedgeP<dim> *>(&fe_other) != nullptr))
     {
-      Assert(fe_p_other->degree == this->this->degree, ExcNotImplemented());
-      std::vector<std::pair<unsigned int, unsigned int>> identities;
-      for (unsigned int i = 0; i < this->n_dofs_per_quad(); ++i)
-        identities.emplace_back(i, i);
-      return identities;
-    }
-  else if (const FE_WedgeP<dim, spacedim> *fe_p_other =
-             dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other))
-    {
-      Assert(fe_p_other->degree == this->this->degree, ExcNotImplemented());
+      Assert(fe_other.degree == this->degree, ExcNotImplemented());
 
       std::vector<std::pair<unsigned int, unsigned int>> identities;
       for (unsigned int i = 0; i < this->n_dofs_per_quad(); ++i)

--- a/source/fe/fe_simplex_p.cc
+++ b/source/fe/fe_simplex_p.cc
@@ -19,9 +19,11 @@
 
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_nothing.h>
+#include <deal.II/fe/fe_pyramid_p.h>
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_simplex_p.h>
 #include <deal.II/fe/fe_tools.h>
+#include <deal.II/fe/fe_wedge_p.h>
 #include <deal.II/fe/mapping.h>
 
 #include <deal.II/grid/grid_generator.h>
@@ -821,6 +823,26 @@ FE_SimplexP<dim, spacedim>::compare_for_domination(
       else
         return FiniteElementDomination::other_element_dominates;
     }
+  else if (const FE_PyramidP<dim, spacedim> *fe_p_other =
+             dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other))
+    {
+      if (this->degree < fe_p_other->degree)
+        return FiniteElementDomination::this_element_dominates;
+      else if (this->degree == fe_p_other->degree)
+        return FiniteElementDomination::either_element_can_dominate;
+      else
+        return FiniteElementDomination::other_element_dominates;
+    }
+  else if (const FE_WedgeP<dim, spacedim> *fe_p_other =
+             dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other))
+    {
+      if (this->degree < fe_p_other->degree)
+        return FiniteElementDomination::this_element_dominates;
+      else if (this->degree == fe_p_other->degree)
+        return FiniteElementDomination::either_element_can_dominate;
+      else
+        return FiniteElementDomination::other_element_dominates;
+    }
   else if (const FE_Nothing<dim, spacedim> *fe_nothing =
              dynamic_cast<const FE_Nothing<dim, spacedim> *>(&fe_other))
     {
@@ -844,8 +866,6 @@ std::vector<std::pair<unsigned int, unsigned int>>
 FE_SimplexP<dim, spacedim>::hp_vertex_dof_identities(
   const FiniteElement<dim, spacedim> &fe_other) const
 {
-  AssertDimension(dim, 2);
-
   if (dynamic_cast<const FE_SimplexP<dim, spacedim> *>(&fe_other) != nullptr)
     {
       // there should be exactly one single DoF of each FE at a vertex, and
@@ -853,6 +873,19 @@ FE_SimplexP<dim, spacedim>::hp_vertex_dof_identities(
       return {{0U, 0U}};
     }
   else if (dynamic_cast<const FE_Q<dim, spacedim> *>(&fe_other) != nullptr)
+    {
+      // there should be exactly one single DoF of each FE at a vertex, and
+      // they should have identical value
+      return {{0U, 0U}};
+    }
+  else if (dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other) !=
+           nullptr)
+    {
+      // there should be exactly one single DoF of each FE at a vertex, and
+      // they should have identical value
+      return {{0U, 0U}};
+    }
+  else if (dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other) != nullptr)
     {
       // there should be exactly one single DoF of each FE at a vertex, and
       // they should have identical value
@@ -889,8 +922,6 @@ std::vector<std::pair<unsigned int, unsigned int>>
 FE_SimplexP<dim, spacedim>::hp_line_dof_identities(
   const FiniteElement<dim, spacedim> &fe_other) const
 {
-  AssertDimension(dim, 2);
-
   if (const FE_SimplexP<dim, spacedim> *fe_p_other =
         dynamic_cast<const FE_SimplexP<dim, spacedim> *>(&fe_other))
     {
@@ -906,7 +937,7 @@ FE_SimplexP<dim, spacedim>::hp_line_dof_identities(
       for (unsigned int i = 0; i < this->degree - 1; ++i)
         for (unsigned int j = 0; j < fe_p_other->degree - 1; ++j)
           if (std::fabs(this->unit_support_points[i + 3][0] -
-                        fe_p_other->unit_support_points[i + 3][0]) < 1e-14)
+                        fe_p_other->unit_support_points[j + 3][0]) < 1e-14)
             identities.emplace_back(i, j);
           else
             {
@@ -920,6 +951,38 @@ FE_SimplexP<dim, spacedim>::hp_line_dof_identities(
 
       return identities;
     }
+  else if (const auto *fe_p_other =
+             dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other))
+    {
+      std::vector<std::pair<unsigned int, unsigned int>> identities;
+
+      for (unsigned int i = 0; i < this->degree - 1; ++i)
+        for (unsigned int j = 0; j < fe_p_other->degree - 1; ++j)
+          if (std::fabs(this->unit_support_points[i + this->reference_cell()
+                                                        .n_vertices()][0] -
+                        fe_p_other->get_unit_support_points()
+                          [i + fe_p_other->reference_cell().n_vertices()][0]) <
+              1e-14)
+            identities.emplace_back(i, j);
+      return identities;
+    }
+  else if (const auto *fe_p_other =
+             dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other))
+    {
+      std::vector<std::pair<unsigned int, unsigned int>> identities;
+
+      for (unsigned int i = 0; i < this->degree - 1; ++i)
+        for (unsigned int j = 0; j < fe_p_other->degree - 1; ++j)
+          if (std::fabs(this->unit_support_points[i + this->reference_cell()
+                                                        .n_vertices()][0] -
+                        fe_p_other->get_unit_support_points()
+                          [i + fe_p_other->reference_cell().n_vertices()][0]) <
+              1e-14)
+            identities.emplace_back(i, j);
+
+      return identities;
+    }
+
   else if (const FE_Q<dim, spacedim> *fe_q_other =
              dynamic_cast<const FE_Q<dim, spacedim> *>(&fe_other))
     {
@@ -983,6 +1046,89 @@ FE_SimplexP<dim, spacedim>::hp_line_dof_identities(
     {
       DEAL_II_NOT_IMPLEMENTED();
       return {};
+    }
+}
+
+
+
+template <int dim, int spacedim>
+std::vector<std::pair<unsigned int, unsigned int>>
+FE_SimplexP<dim, spacedim>::hp_quad_dof_identities(
+  const FiniteElement<dim, spacedim> &fe_other,
+  const unsigned int                  face_no) const
+{
+  Assert(fe_other.degree < 4, ExcNotImplemented());
+  if (const FE_SimplexP<dim, spacedim> *fe_p_other =
+        dynamic_cast<const FE_SimplexP<dim, spacedim> *>(&fe_other))
+    {
+      // dofs are located along lines, so two dofs are identical if they are
+      // located at identical positions.
+      // Therefore, read the points in unit_support_points for the
+      // first coordinate direction. For FE_SimplexP, they are currently
+      // hard-coded and we iterate over points on the first line which begin
+      // after the 3 vertex points in the complete list of unit support points
+
+      std::vector<std::pair<unsigned int, unsigned int>> identities;
+      if (false)
+        {
+          for (unsigned int i = 0; i < fe_p_other->n_dofs_per_quad(); ++i)
+            for (unsigned int j = 0; j < fe_p_other->n_dofs_per_quad(); ++j)
+              if (std::fabs(
+                    this->unit_support_points[i +
+                                              this->reference_cell()
+                                                  .n_vertices() *
+                                                this->n_dofs_per_vertex() +
+                                              this->reference_cell().n_lines() *
+                                                this->n_dofs_per_line()][0] -
+                    fe_p_other->unit_support_points
+                      [j +
+                       fe_p_other->reference_cell().n_vertices() *
+                         fe_p_other->n_dofs_per_vertex() +
+                       fe_p_other->reference_cell().n_lines() *
+                         fe_p_other->n_dofs_per_line()][0]) < 1e-14)
+                identities.emplace_back(i, j);
+        }
+      else if (fe_p_other->degree == 3 && this->degree == 3)
+        identities.emplace_back(0, 0);
+
+
+      return identities;
+    }
+  else if (dynamic_cast<const FE_Nothing<dim> *>(&fe_other) != nullptr)
+    {
+      // the FE_Nothing has no degrees of freedom, so there are no
+      // equivalencies to be recorded
+      return std::vector<std::pair<unsigned int, unsigned int>>();
+    }
+  else if (dynamic_cast<const FE_PyramidP<dim> *>(&fe_other) != nullptr)
+    {
+      // Only linear Pyramid Elements are implemented
+      // there are no dofs on the faces
+      Assert(fe_other.degree == 1, ExcNotImplemented());
+      return std::vector<std::pair<unsigned int, unsigned int>>();
+    }
+  else if (const FE_WedgeP<dim, spacedim> *fe_p_other =
+             dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other))
+    {
+      // there are no DoFs on the faces on triangles
+      Assert(fe_other.degree == 1 || fe_other.degree == 2, ExcNotImplemented());
+      return std::vector<std::pair<unsigned int, unsigned int>>();
+    }
+  else if (fe_other.n_unique_faces() == 1 && fe_other.n_dofs_per_face(0) == 0)
+    {
+      // if the other element has no elements on faces at all,
+      // then it would be impossible to enforce any kind of
+      // continuity even if we knew exactly what kind of element
+      // we have -- simply because the other element declares
+      // that it is discontinuous because it has no DoFs on
+      // its faces. in that case, just state that we have no
+      // constraints to declare
+      return std::vector<std::pair<unsigned int, unsigned int>>();
+    }
+  else
+    {
+      DEAL_II_NOT_IMPLEMENTED();
+      return std::vector<std::pair<unsigned int, unsigned int>>();
     }
 }
 

--- a/source/fe/fe_simplex_p.cc
+++ b/source/fe/fe_simplex_p.cc
@@ -1055,7 +1055,7 @@ template <int dim, int spacedim>
 std::vector<std::pair<unsigned int, unsigned int>>
 FE_SimplexP<dim, spacedim>::hp_quad_dof_identities(
   const FiniteElement<dim, spacedim> &fe_other,
-  const unsigned int                  face_no) const
+  const unsigned int) const
 {
   Assert(fe_other.degree < 4, ExcNotImplemented());
   if (const FE_SimplexP<dim, spacedim> *fe_p_other =
@@ -1069,28 +1069,8 @@ FE_SimplexP<dim, spacedim>::hp_quad_dof_identities(
       // after the 3 vertex points in the complete list of unit support points
 
       std::vector<std::pair<unsigned int, unsigned int>> identities;
-      if (false)
-        {
-          for (unsigned int i = 0; i < fe_p_other->n_dofs_per_quad(); ++i)
-            for (unsigned int j = 0; j < fe_p_other->n_dofs_per_quad(); ++j)
-              if (std::fabs(
-                    this->unit_support_points[i +
-                                              this->reference_cell()
-                                                  .n_vertices() *
-                                                this->n_dofs_per_vertex() +
-                                              this->reference_cell().n_lines() *
-                                                this->n_dofs_per_line()][0] -
-                    fe_p_other->unit_support_points
-                      [j +
-                       fe_p_other->reference_cell().n_vertices() *
-                         fe_p_other->n_dofs_per_vertex() +
-                       fe_p_other->reference_cell().n_lines() *
-                         fe_p_other->n_dofs_per_line()][0]) < 1e-14)
-                identities.emplace_back(i, j);
-        }
-      else if (fe_p_other->degree == 3 && this->degree == 3)
+      if (fe_p_other->degree == 3 && this->degree == 3)
         identities.emplace_back(0, 0);
-
 
       return identities;
     }
@@ -1102,9 +1082,8 @@ FE_SimplexP<dim, spacedim>::hp_quad_dof_identities(
     }
   else if (dynamic_cast<const FE_PyramidP<dim> *>(&fe_other) != nullptr)
     {
-      // Only linear Pyramid Elements are implemented
       // there are no dofs on the faces
-      Assert(fe_other.degree == 1, ExcNotImplemented());
+      Assert(fe_other.degree == 1 || fe_other.degree == 2, ExcNotImplemented());
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
   else if (const FE_WedgeP<dim, spacedim> *fe_p_other =

--- a/source/fe/fe_simplex_p.cc
+++ b/source/fe/fe_simplex_p.cc
@@ -954,31 +954,21 @@ FE_SimplexP<dim, spacedim>::hp_line_dof_identities(
   else if (const auto *fe_p_other =
              dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other))
     {
+      Assert(fe_p_other->degree == this->this->degree, ExcNotImplemented());
       std::vector<std::pair<unsigned int, unsigned int>> identities;
 
       for (unsigned int i = 0; i < this->degree - 1; ++i)
-        for (unsigned int j = 0; j < fe_p_other->degree - 1; ++j)
-          if (std::fabs(this->unit_support_points[i + this->reference_cell()
-                                                        .n_vertices()][0] -
-                        fe_p_other->get_unit_support_points()
-                          [i + fe_p_other->reference_cell().n_vertices()][0]) <
-              1e-14)
-            identities.emplace_back(i, j);
+        identities.emplace_back(i, i);
       return identities;
     }
   else if (const auto *fe_p_other =
              dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other))
     {
+      Assert(fe_p_other->degree == this->this->degree, ExcNotImplemented());
       std::vector<std::pair<unsigned int, unsigned int>> identities;
 
       for (unsigned int i = 0; i < this->degree - 1; ++i)
-        for (unsigned int j = 0; j < fe_p_other->degree - 1; ++j)
-          if (std::fabs(this->unit_support_points[i + this->reference_cell()
-                                                        .n_vertices()][0] -
-                        fe_p_other->get_unit_support_points()
-                          [i + fe_p_other->reference_cell().n_vertices()][0]) <
-              1e-14)
-            identities.emplace_back(i, j);
+        identities.emplace_back(i, i);
 
       return identities;
     }
@@ -1080,18 +1070,21 @@ FE_SimplexP<dim, spacedim>::hp_quad_dof_identities(
       // equivalencies to be recorded
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
-  else if (dynamic_cast<const FE_PyramidP<dim> *>(&fe_other) != nullptr)
+  else if (const FE_PyramidP<dim, spacedim> *fe_p_other =
+             dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other))
     {
-      // there are no dofs on the faces
-      Assert(fe_other.degree == 1 || fe_other.degree == 2, ExcNotImplemented());
-      return std::vector<std::pair<unsigned int, unsigned int>>();
+      std::vector<std::pair<unsigned int, unsigned int>> identities;
+      for (unsigned int i = 0; i < this->n_dofs_per_quad(); ++i)
+        identities.emplace_back(i, i);
+      return identities;
     }
   else if (const FE_WedgeP<dim, spacedim> *fe_p_other =
              dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other))
     {
-      // there are no DoFs on the faces on triangles
-      Assert(fe_other.degree == 1 || fe_other.degree == 2, ExcNotImplemented());
-      return std::vector<std::pair<unsigned int, unsigned int>>();
+      std::vector<std::pair<unsigned int, unsigned int>> identities;
+      for (unsigned int i = 0; i < this->n_dofs_per_quad(); ++i)
+        identities.emplace_back(i, i);
+      return identities;
     }
   else if (fe_other.n_unique_faces() == 1 && fe_other.n_dofs_per_face(0) == 0)
     {

--- a/source/fe/fe_simplex_p.cc
+++ b/source/fe/fe_simplex_p.cc
@@ -951,25 +951,14 @@ FE_SimplexP<dim, spacedim>::hp_line_dof_identities(
 
       return identities;
     }
-  else if (const auto *fe_p_other =
-             dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other))
+  else if ((dynamic_cast<const FE_PyramidP<dim> *>(&fe_other) != nullptr) ||
+           (dynamic_cast<const FE_WedgeP<dim> *>(&fe_other) != nullptr))
     {
-      Assert(fe_p_other->degree == this->this->degree, ExcNotImplemented());
-      std::vector<std::pair<unsigned int, unsigned int>> identities;
+      Assert(fe_other.degree == this->degree, ExcNotImplemented());
 
+      std::vector<std::pair<unsigned int, unsigned int>> identities;
       for (unsigned int i = 0; i < this->degree - 1; ++i)
         identities.emplace_back(i, i);
-      return identities;
-    }
-  else if (const auto *fe_p_other =
-             dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other))
-    {
-      Assert(fe_p_other->degree == this->this->degree, ExcNotImplemented());
-      std::vector<std::pair<unsigned int, unsigned int>> identities;
-
-      for (unsigned int i = 0; i < this->degree - 1; ++i)
-        identities.emplace_back(i, i);
-
       return identities;
     }
 
@@ -1070,17 +1059,11 @@ FE_SimplexP<dim, spacedim>::hp_quad_dof_identities(
       // equivalencies to be recorded
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
-  else if (const FE_PyramidP<dim, spacedim> *fe_p_other =
-             dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other))
+  else if ((dynamic_cast<const FE_PyramidP<dim> *>(&fe_other) != nullptr) ||
+           (dynamic_cast<const FE_WedgeP<dim> *>(&fe_other) != nullptr))
     {
-      std::vector<std::pair<unsigned int, unsigned int>> identities;
-      for (unsigned int i = 0; i < this->n_dofs_per_quad(); ++i)
-        identities.emplace_back(i, i);
-      return identities;
-    }
-  else if (const FE_WedgeP<dim, spacedim> *fe_p_other =
-             dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other))
-    {
+      Assert(fe_other.degree == this->degree, ExcNotImplemented());
+
       std::vector<std::pair<unsigned int, unsigned int>> identities;
       for (unsigned int i = 0; i < this->n_dofs_per_quad(); ++i)
         identities.emplace_back(i, i);

--- a/source/fe/fe_wedge_p.cc
+++ b/source/fe/fe_wedge_p.cc
@@ -85,6 +85,7 @@ template <int dim, int spacedim>
 FE_WedgePoly<dim, spacedim>::FE_WedgePoly(
   const unsigned int                                degree,
   const internal::GenericDoFsPerObject             &dpos,
+  const bool                                        prolongation_is_additive,
   const typename FiniteElementData<dim>::Conformity conformity)
   : dealii::FE_Poly<dim, spacedim>(
       ScalarLagrangePolynomialWedge<dim>(degree),
@@ -96,7 +97,7 @@ FE_WedgePoly<dim, spacedim>::FE_WedgePoly(
       std::vector<bool>(
         FiniteElementData<dim>(dpos, ReferenceCells::Wedge, 1, degree)
           .dofs_per_cell,
-        true),
+        prolongation_is_additive),
       std::vector<ComponentMask>(
         FiniteElementData<dim>(dpos, ReferenceCells::Wedge, 1, degree)
           .dofs_per_cell,
@@ -164,6 +165,7 @@ template <int dim, int spacedim>
 FE_WedgeP<dim, spacedim>::FE_WedgeP(const unsigned int degree)
   : FE_WedgePoly<dim, spacedim>(degree,
                                 get_dpo_vector_fe_wedge_p(degree),
+                                false,
                                 FiniteElementData<dim>::H1)
 {}
 
@@ -334,6 +336,7 @@ template <int dim, int spacedim>
 FE_WedgeDGP<dim, spacedim>::FE_WedgeDGP(const unsigned int degree)
   : FE_WedgePoly<dim, spacedim>(degree,
                                 get_dpo_vector_fe_wedge_dgp(degree),
+                                true,
                                 FiniteElementData<dim>::L2)
 {}
 


### PR DESCRIPTION
This PR implements quadratic and cubic pyramid elements. Orthogonal Jacobi polynomials are used to construct a nodal basis like described [here](https://link.springer.com/article/10.1007/s10915-009-9334-9). The nodal points are generated by a kind of truncated tensor product of a `FE_Q<2>` and a equidistant 1-D space, where the degree of `FE_Q` decreases with increasing 'z' values. This leads to support points consistent with `FE_Q` and `FE_SimplexP` elements of the same degree on the corresponding faces. 
The nodal basis functions are generated by multiplying Vandermonde matrix with the Jacobi polynomials. 
This technique allows for arbitrary order elements, currently it is limited to cubic elements as some of the faces uses `FE_SimplexP<2>` support points which are only implemented up to order 3.
A quadrature rule for pyramids will follow in another PR.