### PR TITLE
enable taskflow by default

### DIFF
--- a/bundled/taskflow-3.7.0/taskflow/utility/macros.hpp
+++ b/bundled/taskflow-3.7.0/taskflow/utility/macros.hpp
@@ -2,6 +2,8 @@
 
 #if defined(_MSC_VER)
   #define TF_FORCE_INLINE __forceinline
+#elif defined(__CUDA__) && defined(__clang__)
+  #define TF_FORCE_INLINE inline
 #elif defined(__GNUC__) && __GNUC__ > 3
   #define TF_FORCE_INLINE __attribute__((__always_inline__)) inline
 #else
@@ -10,6 +12,8 @@
 
 #if defined(_MSC_VER)
   #define TF_NO_INLINE __declspec(noinline)
+#elif defined(__CUDA__) && defined(__clang__)
+  #define TF_NO_INLINE
 #elif defined(__GNUC__) && __GNUC__ > 3
   #define TF_NO_INLINE __attribute__((__noinline__))
 #else

--- a/cmake/configure/configure_10_taskflow.cmake
+++ b/cmake/configure/configure_10_taskflow.cmake
@@ -17,11 +17,7 @@
 # library:
 #
 
-#
-# Disallow the default detection of taskflow for the time being to avoid
-# unpleasant surprises on user side.
-#
-set(DEAL_II_WITH_TASKFLOW OFF CACHE BOOL "")
+set(DEAL_II_WITH_TASKFLOW ON CACHE BOOL "")
 
 macro(feature_taskflow_find_external var)
   find_package(DEAL_II_TASKFLOW)


### PR DESCRIPTION
We now have some tasking functionality implemented via taskflow instead of TBB. It makes sense to enable it by default to shake out any problems.

FYI @tamiko @RyanMoulday 