### PR TITLE
Enhance test for hp-constraints.

### DIFF
--- a/tests/lac/constraints_make_consistent_in_parallel_06.mpirun=2.output
+++ b/tests/lac/constraints_make_consistent_in_parallel_06.mpirun=2.output
@@ -8,7 +8,16 @@ DEAL:0::What process 0 believes about DoF 64:
 DEAL:0::    constrained against 3 with weight -0.123607
 DEAL:0::    constrained against 7 with weight 0.323607
 DEAL:0::    constrained against 19 with weight 0.800000
-DEAL:0::------------- make_consistent_in_parallel():
+DEAL:0::------------- make_consistent_in_parallel() on locally active dofs:
+DEAL:0::What process 0 believes about DoF 63:
+DEAL:0::    constrained against 3 with weight 0.323607
+DEAL:0::    constrained against 7 with weight -0.123607
+DEAL:0::    constrained against 19 with weight 0.800000
+DEAL:0::What process 0 believes about DoF 64:
+DEAL:0::    constrained against 3 with weight -0.123607
+DEAL:0::    constrained against 7 with weight 0.323607
+DEAL:0::    constrained against 19 with weight 0.800000
+DEAL:0::------------- make_consistent_in_parallel() on locally relevant dofs:
 DEAL:0::What process 0 believes about DoF 63:
 DEAL:0::    constrained against 3 with weight 0.323607
 DEAL:0::    constrained against 7 with weight -0.123607
@@ -24,7 +33,10 @@ DEAL:1::What process 1 believes about DoF 64:
 DEAL:1::    constrained against 3 with weight -0.447214
 DEAL:1::    constrained against 7 with weight 0.447214
 DEAL:1::    constrained against 63 with weight 1.00000
-DEAL:1::------------- make_consistent_in_parallel():
+DEAL:1::------------- make_consistent_in_parallel() on locally active dofs:
+DEAL:1::What process 1 believes about DoF 63:
+DEAL:1::What process 1 believes about DoF 64:
+DEAL:1::------------- make_consistent_in_parallel() on locally relevant dofs:
 DEAL:1::What process 1 believes about DoF 63:
 DEAL:1::    constrained against 3 with weight 0.323607
 DEAL:1::    constrained against 7 with weight -0.123607


### PR DESCRIPTION
This is the original testcase showcasing the bug discussed in #17595 #17596 #17599.

In Debug mode, [this assertion fails](https://github.com/dealii/dealii/blob/98dddcd49d40e742b43f43f3b6f0dd0c577ca637/include/deal.II/lac/affine_constraints.templates.h#L391-L392). I have provided the current output in Release mode as a reference.

I provided a short description of the scenario and our current understanding of the problem in the source code.

---

The problematic constraints are:

DoF 64 is a locally owned DoF on process 0: 

    {index = 64, entries = std::vector of length 3, capacity 3 = {{first = 3, second = -0.12360679774997897}, {first = 7, second = 0.32360679774997891}, {first = 19, second = 0.80000000000000004}}, inhomogeneity = 0}

DoF 64 is a locally relevant DoF on process 1:

    {index = 64, entries = std::vector of length 3, capacity 3 = {{first = 3, second = -0.44721359549995798}, {first = 7, second = 0.44721359549995787}, {first = 63, second = 1}}, inhomogeneity = 0}