### PR TITLE
Finish remaining void cast tutorial PRs

### DIFF
--- a/source/base/function_lib.cc
+++ b/source/base/function_lib.cc
@@ -2402,10 +2402,9 @@ namespace Functions
     Tensor<1, 1>
     gradient_interpolate(const Table<1, double> &data_values,
                          const TableIndices<1>  &ix,
-                         const Point<1>         &p_unit,
-                         const Point<1>         &dx)
+                         const Point<1> & /*p_unit*/,
+                         const Point<1> &dx)
     {
-      [[mabe_unused]]p_unit;
       Tensor<1, 1> grad;
       grad[0] = (data_values[ix[0] + 1] - data_values[ix[0]]) / dx[0];
       return grad;

--- a/source/base/function_lib.cc
+++ b/source/base/function_lib.cc
@@ -2405,7 +2405,7 @@ namespace Functions
                          const Point<1>         &p_unit,
                          const Point<1>         &dx)
     {
-      (void)p_unit;
+      [[mabe_unused]]p_unit;
       Tensor<1, 1> grad;
       grad[0] = (data_values[ix[0] + 1] - data_values[ix[0]]) / dx[0];
       return grad;

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -794,8 +794,6 @@ namespace Utilities
     void
     CollectiveMutex::lock(const MPI_Comm comm)
     {
-      [[mabe_unused]]comm;
-
       Assert(
         !locked,
         ExcMessage(
@@ -821,6 +819,8 @@ namespace Utilities
           // nothing to do as blocking barrier already completed
 #  endif
         }
+#else
+      (void)comm;
 #endif
 
       locked = true;
@@ -831,8 +831,6 @@ namespace Utilities
     void
     CollectiveMutex::unlock(const MPI_Comm comm)
     {
-      [[mabe_unused]]comm;
-
       // First check if this function is called during exception handling
       // if so, abort. This can happen if a ScopedLock is destroyed.
       internal::CollectiveMutexImplementation::check_exception();
@@ -857,6 +855,8 @@ namespace Utilities
           AssertThrowMPI(ierr);
 #  endif
         }
+#else
+      (void)comm;
 #endif
 
       locked = false;

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -794,7 +794,7 @@ namespace Utilities
     void
     CollectiveMutex::lock(const MPI_Comm comm)
     {
-      (void)comm;
+      [[mabe_unused]]comm;
 
       Assert(
         !locked,
@@ -831,7 +831,7 @@ namespace Utilities
     void
     CollectiveMutex::unlock(const MPI_Comm comm)
     {
-      (void)comm;
+      [[mabe_unused]]comm;
 
       // First check if this function is called during exception handling
       // if so, abort. This can happen if a ScopedLock is destroyed.

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -3519,7 +3519,7 @@ namespace internal
             if (subcell_object->boundary_id !=
                 numbers::internal_face_boundary_id)
               {
-                (void)vertex_locations;
+                [[mabe_unused]]vertex_locations;
                 AssertThrow(
                   boundary_id != numbers::internal_face_boundary_id,
                   ExcMessage(
@@ -3549,7 +3549,7 @@ namespace internal
         // make sure that all subcelldata entries have been processed
         // TODO: this is not guaranteed, why?
         // AssertDimension(counter, boundary_objects_in.size());
-        (void)counter;
+        [[mabe_unused]]counter;
       }
 
 
@@ -5038,7 +5038,7 @@ namespace internal
                 triangulation.vertices[next_unused_vertex] = line->center(true);
 
                 bool pair_found = false;
-                (void)pair_found;
+                [[mabe_unused]]pair_found;
                 for (; next_unused_line != endl; ++next_unused_line)
                   if (!next_unused_line->used() &&
                       !(++next_unused_line)->used())
@@ -5808,7 +5808,7 @@ namespace internal
                 // two child lines.  To this end, find a pair of
                 // unused lines
                 bool pair_found = false;
-                (void)pair_found;
+                [[mabe_unused]]pair_found;
                 for (; next_unused_line != endl; ++next_unused_line)
                   if (!next_unused_line->used() &&
                       !(++next_unused_line)->used())
@@ -6232,7 +6232,7 @@ namespace internal
               for (const unsigned int line : quad->line_indices())
                 {
                   AssertIsNotUsed(new_lines[line]);
-                  (void)line;
+                  [[mabe_unused]]line;
                 }
 
               // 2) create new quads (properties are set below). Both triangles
@@ -6254,7 +6254,7 @@ namespace internal
               for (const auto &quad : new_quads)
                 {
                   AssertIsNotUsed(quad);
-                  (void)quad;
+                  [[mabe_unused]]quad;
                 }
 
               // 3) set vertex indices and set new vertex
@@ -11934,10 +11934,10 @@ namespace internal
         std::vector<unsigned int>                            &quad_cell_count)
       {
         AssertThrow(false, ExcNotImplemented());
-        (void)triangulation;
-        (void)cell;
-        (void)line_cell_count;
-        (void)quad_cell_count;
+        [[mabe_unused]]triangulation;
+        [[mabe_unused]]cell;
+        [[mabe_unused]]line_cell_count;
+        [[mabe_unused]]quad_cell_count;
       }
 
       template <int dim, int spacedim>
@@ -11955,7 +11955,7 @@ namespace internal
         Triangulation<dim, spacedim> &triangulation)
       {
         // nothing to do since anisotropy is not supported
-        (void)triangulation;
+        [[mabe_unused]]triangulation;
       }
 
       template <int dim, int spacedim>
@@ -12293,7 +12293,7 @@ void Triangulation<dim, spacedim>::set_all_manifold_ids_on_boundary(
             }
     }
 
-  (void)boundary_found;
+  [[mabe_unused]]boundary_found;
   Assert(boundary_found, ExcBoundaryIdNotFound(b_id));
 }
 
@@ -16304,7 +16304,7 @@ void Triangulation<dim, spacedim>::load_attached_data(
       // CellStatus::cell_will_persist.
       for (const auto &cell_rel : this->local_cell_relations)
         {
-          (void)cell_rel;
+          [[mabe_unused]]cell_rel;
           Assert((cell_rel.second == // cell_status
                   ::dealii::CellStatus::cell_will_persist),
                  ExcInternalError());

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -669,10 +669,10 @@ namespace internal
   template <int dim, int spacedim>
   DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
   void CellAttachedDataSerializer<dim, spacedim>::save(
-    [[maybe_unused]] const unsigned int global_first_cell,
-    [[maybe_unused]] const unsigned int global_num_cells,
-    const std::string                  &file_basename,
-    [[maybe_unused]] const MPI_Comm    &mpi_communicator) const
+    const unsigned int global_first_cell,
+    const unsigned int global_num_cells,
+    const std::string &file_basename,
+    const MPI_Comm    &mpi_communicator) const
   {
     Assert(sizes_fixed_cumulative.size() > 0,
            ExcMessage("No data has been packed!"));
@@ -848,6 +848,10 @@ namespace internal
     else
 #endif
       {
+        (void)global_first_cell;
+        (void)global_num_cells;
+        (void)mpi_communicator;
+
         //
         // ---------- Fixed size data ----------
         //
@@ -896,13 +900,13 @@ namespace internal
   template <int dim, int spacedim>
   DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
   void CellAttachedDataSerializer<dim, spacedim>::load(
-    [[maybe_unused]] const unsigned int global_first_cell,
-    [[maybe_unused]] const unsigned int global_num_cells,
-    const unsigned int                  local_num_cells,
-    const std::string                  &file_basename,
-    const unsigned int                  n_attached_deserialize_fixed,
-    const unsigned int                  n_attached_deserialize_variable,
-    const MPI_Comm                     &mpi_communicator)
+    const unsigned int global_first_cell,
+    const unsigned int global_num_cells,
+    const unsigned int local_num_cells,
+    const std::string &file_basename,
+    const unsigned int n_attached_deserialize_fixed,
+    const unsigned int n_attached_deserialize_variable,
+    const MPI_Comm    &mpi_communicator)
   {
     Assert(dest_data_fixed.empty(),
            ExcMessage("Previously loaded data has not been released yet!"));
@@ -1060,6 +1064,8 @@ namespace internal
 #endif
       {
         (void)mpi_communicator;
+        (void)global_first_cell;
+        (void)global_num_cells;
 
         //
         // ---------- Fixed size data ----------
@@ -3473,7 +3479,7 @@ namespace internal
                     return a.vertices < b.vertices;
                   });
 
-        unsigned int counter = 0;
+        [[maybe_unused]] unsigned int counter = 0;
 
         std::vector<unsigned int> key;
         key.reserve(GeometryInfo<structdim>::vertices_per_cell);
@@ -3519,7 +3525,6 @@ namespace internal
             if (subcell_object->boundary_id !=
                 numbers::internal_face_boundary_id)
               {
-                [[mabe_unused]]vertex_locations;
                 AssertThrow(
                   boundary_id != numbers::internal_face_boundary_id,
                   ExcMessage(
@@ -3549,7 +3554,6 @@ namespace internal
         // make sure that all subcelldata entries have been processed
         // TODO: this is not guaranteed, why?
         // AssertDimension(counter, boundary_objects_in.size());
-        [[mabe_unused]]counter;
       }
 
 
@@ -5038,7 +5042,6 @@ namespace internal
                 triangulation.vertices[next_unused_vertex] = line->center(true);
 
                 bool pair_found = false;
-                [[mabe_unused]]pair_found;
                 for (; next_unused_line != endl; ++next_unused_line)
                   if (!next_unused_line->used() &&
                       !(++next_unused_line)->used())
@@ -5808,7 +5811,6 @@ namespace internal
                 // two child lines.  To this end, find a pair of
                 // unused lines
                 bool pair_found = false;
-                [[mabe_unused]]pair_found;
                 for (; next_unused_line != endl; ++next_unused_line)
                   if (!next_unused_line->used() &&
                       !(++next_unused_line)->used())
@@ -6230,10 +6232,7 @@ namespace internal
                 }
 
               for (const unsigned int line : quad->line_indices())
-                {
-                  AssertIsNotUsed(new_lines[line]);
-                  [[mabe_unused]]line;
-                }
+                AssertIsNotUsed(new_lines[line]);
 
               // 2) create new quads (properties are set below). Both triangles
               // and quads are divided in four.
@@ -6252,10 +6251,7 @@ namespace internal
               quad->set_refinement_case(RefinementCase<2>::cut_xy);
 
               for (const auto &quad : new_quads)
-                {
-                  AssertIsNotUsed(quad);
-                  [[mabe_unused]]quad;
-                }
+                AssertIsNotUsed(quad);
 
               // 3) set vertex indices and set new vertex
 
@@ -11928,16 +11924,12 @@ namespace internal
       template <int dim, int spacedim>
       static void
       delete_children(
-        Triangulation<dim, spacedim>                         &triangulation,
-        typename Triangulation<dim, spacedim>::cell_iterator &cell,
-        std::vector<unsigned int>                            &line_cell_count,
-        std::vector<unsigned int>                            &quad_cell_count)
+        Triangulation<dim, spacedim> & /*triangulation*/,
+        typename Triangulation<dim, spacedim>::cell_iterator & /*cell*/,
+        std::vector<unsigned int> & /*line_cell_count*/,
+        std::vector<unsigned int> & /*quad_cell_count*/)
       {
         AssertThrow(false, ExcNotImplemented());
-        [[mabe_unused]]triangulation;
-        [[mabe_unused]]cell;
-        [[mabe_unused]]line_cell_count;
-        [[mabe_unused]]quad_cell_count;
       }
 
       template <int dim, int spacedim>
@@ -11952,10 +11944,9 @@ namespace internal
       template <int dim, int spacedim>
       static void
       prevent_distorted_boundary_cells(
-        Triangulation<dim, spacedim> &triangulation)
+        Triangulation<dim, spacedim> & /*triangulation*/)
       {
         // nothing to do since anisotropy is not supported
-        [[mabe_unused]]triangulation;
       }
 
       template <int dim, int spacedim>
@@ -12293,7 +12284,6 @@ void Triangulation<dim, spacedim>::set_all_manifold_ids_on_boundary(
             }
     }
 
-  [[mabe_unused]]boundary_found;
   Assert(boundary_found, ExcBoundaryIdNotFound(b_id));
 }
 
@@ -16304,7 +16294,6 @@ void Triangulation<dim, spacedim>::load_attached_data(
       // CellStatus::cell_will_persist.
       for (const auto &cell_rel : this->local_cell_relations)
         {
-          [[mabe_unused]]cell_rel;
           Assert((cell_rel.second == // cell_status
                   ::dealii::CellStatus::cell_will_persist),
                  ExcInternalError());

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -669,10 +669,10 @@ namespace internal
   template <int dim, int spacedim>
   DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
   void CellAttachedDataSerializer<dim, spacedim>::save(
-    const unsigned int global_first_cell,
-    const unsigned int global_num_cells,
-    const std::string &file_basename,
-    const MPI_Comm    &mpi_communicator) const
+    [[maybe_unused]] const unsigned int global_first_cell,
+    [[maybe_unused]] const unsigned int global_num_cells,
+    const std::string                  &file_basename,
+    [[maybe_unused]] const MPI_Comm    &mpi_communicator) const
   {
     Assert(sizes_fixed_cumulative.size() > 0,
            ExcMessage("No data has been packed!"));
@@ -848,10 +848,6 @@ namespace internal
     else
 #endif
       {
-        (void)global_first_cell;
-        (void)global_num_cells;
-        (void)mpi_communicator;
-
         //
         // ---------- Fixed size data ----------
         //
@@ -900,13 +896,13 @@ namespace internal
   template <int dim, int spacedim>
   DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
   void CellAttachedDataSerializer<dim, spacedim>::load(
-    const unsigned int global_first_cell,
-    const unsigned int global_num_cells,
-    const unsigned int local_num_cells,
-    const std::string &file_basename,
-    const unsigned int n_attached_deserialize_fixed,
-    const unsigned int n_attached_deserialize_variable,
-    const MPI_Comm    &mpi_communicator)
+    [[maybe_unused]] const unsigned int global_first_cell,
+    [[maybe_unused]] const unsigned int global_num_cells,
+    const unsigned int                  local_num_cells,
+    const std::string                  &file_basename,
+    const unsigned int                  n_attached_deserialize_fixed,
+    const unsigned int                  n_attached_deserialize_variable,
+    const MPI_Comm                     &mpi_communicator)
   {
     Assert(dest_data_fixed.empty(),
            ExcMessage("Previously loaded data has not been released yet!"));
@@ -1064,8 +1060,6 @@ namespace internal
 #endif
       {
         (void)mpi_communicator;
-        (void)global_first_cell;
-        (void)global_num_cells;
 
         //
         // ---------- Fixed size data ----------

--- a/tests/matrix_free/matrix_vector_hessians_cells.cc
+++ b/tests/matrix_free/matrix_vector_hessians_cells.cc
@@ -68,14 +68,15 @@ test_hessians(const dealii::FE_Poly<dim>                    &fe,
   additional_data.mapping_update_flags_inner_faces =
     update_values | update_gradients | update_hessians;
 
-  MatrixFree<dim, double, VectorizedArrayType> matrix_free;
+  [[maybe_unused]]MatrixFree<dim, double, VectorizedArrayType> matrix_free;
   matrix_free.reinit(mapping, dof_handler, constraints, quad, additional_data);
 
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     deallog << "Working with " << fe.get_name() << " and "
             << dof_handler.n_dofs() << " dofs" << std::endl;
 
-  LinearAlgebra::distributed::Vector<double> src, dst, dst2;
+  LinearAlgebra::distributed::Vector<double> dst2;
+  [[maybe_unused]]LinearAlgebra::distributed::Vector<double> src, dst;
   matrix_free.initialize_dof_vector(src);
   for (auto &v : src)
     v = random_value<double>();
@@ -101,7 +102,7 @@ test_hessians(const dealii::FE_Poly<dim>                    &fe,
   matrix_free.template loop<LinearAlgebra::distributed::Vector<double>,
                             LinearAlgebra::distributed::Vector<double>>(
     [&](
-      const auto &matrix_free, auto &dst, const auto &src, const auto &range) {
+      const auto &matrix_free, auto &dst, const auto &src, [[maybe_unused]]const auto &range) {
       FEEvaluation<dim, -1, 0, 1, double, VectorizedArrayType> fe_eval(
         matrix_free);
       for (unsigned int cell = range.first; cell < range.second; ++cell)
@@ -185,17 +186,9 @@ test_hessians(const dealii::FE_Poly<dim>                    &fe,
     },
     [&](
       const auto &matrix_free, auto &dst, const auto &src, const auto &range) {
-      (void)matrix_free;
-      (void)dst;
-      (void)src;
-      (void)range;
     },
     [&](
       const auto &matrix_free, auto &dst, const auto &src, const auto &range) {
-      (void)matrix_free;
-      (void)dst;
-      (void)src;
-      (void)range;
     },
     dst,
     src,


### PR DESCRIPTION
This PR combines and cleans up the remaining open PRs from the developer workshop tutorial, namely #17488, #17506, and #17496. I took over the commits from those PRs, merged them into one commit per PR (to maintain the original authorship), and then added one commit of my own to adjust the changes to what happened on the master branch since.

@fernandohv3279 and @liyli0126 for your PRs I just took over the commit. @hagiasophia1994 for you I had to modify the commit to contain your name as the author. You should check your git setting on your computer following [these](https://swcarpentry.github.io/git-novice/02-setup.html) instructions to make sure future commits get attributed to you.

For the review of this PR I followed these guidelines:
- void casts for Asserts are no longer necessary, because in debug mode the variables are used and in release mode the warning is disabled
- void casts because of preprocessor `#ifdef` s are put into the `#else` branch of the ifdef
- if variables are not used at all, the variable name is commented in the function header instead of a void cast
- local variables that are conditionally not used are marked with `[[maybe_unused]]`

If this PR is merged we should be able to close #17488, #17506, #17496.