### PR TITLE
Remove an MPI tag now no longer used.

### DIFF
--- a/include/deal.II/base/mpi_tags.h
+++ b/include/deal.II/base/mpi_tags.h
@@ -146,11 +146,6 @@ namespace Utilities
 
           // GridTools::internal::distributed_compute_point_locations
           distributed_compute_point_locations,
-
-          // AffineConstraints::make_consistent_in_parallel()
-          affine_constraints_make_consistent_in_parallel_0,
-          affine_constraints_make_consistent_in_parallel_1,
-
         };
       } // namespace Tags
     }   // namespace internal


### PR DESCRIPTION
I did not realize right away that #17618 removes the only uses of two MPI tags. Remove the tags too then.