### PR TITLE
Close an AffineConstraints object before doing anything with it.

### DIFF
--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -660,6 +660,7 @@ AffineConstraints<number>::make_consistent_in_parallel(
       this->reinit(locally_owned_dofs, locally_stored_constraints);
       for (const auto &line : imported_constraints)
         this->add_constraint(line.index, line.entries, line.inhomogeneity);
+      this->close();
 
       // 4) Stop loop if converged.
       const bool constraints_converged =


### PR DESCRIPTION
Part of #17599. This is perhaps not strictly necessary, but I think that it is the right thing to do. What we do in the `make_consistent_in_parallel()` function is to import constraints, merge them with what we have locally, and then iterate. But we forgot to call `close()`, which resolves chains of constraints. I think resolving chains is actually the right thing to do.