### PR TITLE
Sort a set of indices before importing into IndexSet.

### DIFF
--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -448,7 +448,7 @@ namespace internal
     std::vector<types::global_dof_index> constrained_indices_temp;
     for (const auto &line : constraints_in.get_lines())
       constrained_indices_temp.push_back(line.index);
-
+    std::sort(constrained_indices_temp.begin(), constrained_indices_temp.end());
     constrained_indices.add_indices(constrained_indices_temp.begin(),
                                     constrained_indices_temp.end());
 

--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -446,6 +446,7 @@ namespace internal
     IndexSet constrained_indices(locally_owned_dofs.size());
 
     std::vector<types::global_dof_index> constrained_indices_temp;
+    constrained_indices_temp.reserve(constraints_in.n_constraints());
     for (const auto &line : constraints_in.get_lines())
       constrained_indices_temp.push_back(line.index);
     std::sort(constrained_indices_temp.begin(), constrained_indices_temp.end());


### PR DESCRIPTION
Inserting indices into an `IndexSet` via a range of iterators is documented to be far faster if the indices are sorted. Do so.

Part of #17599.