### PR TITLE
Make a condition easier to read.

### DIFF
--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -659,11 +659,11 @@ AffineConstraints<number>::make_consistent_in_parallel(
         this->add_constraint(line.index, line.entries, line.inhomogeneity);
 
       // 4) Stop loop if converged.
-      const auto constraints_converged =
-        Utilities::MPI::min(static_cast<unsigned int>(
-                              constraints_to_make_consistent ==
-                              constraints_made_consistent),
-                            mpi_communicator);
+      const bool constraints_converged =
+        (Utilities::MPI::min(
+           (constraints_to_make_consistent == constraints_made_consistent ? 1 :
+                                                                            0),
+           mpi_communicator) == 1);
       if (constraints_converged)
         break;
     }


### PR DESCRIPTION
Part of #17599. The code in question here does an explicit cast from `bool` to `unsigned int`, but then uses the resulting `unsigned int` in a boolean context. This was not entirely obvious because of the use of `auto`. Make this easier to read.