### PR TITLE
Fix link to code gallery

### DIFF
--- a/doc/doxygen/code-gallery/code-gallery.h.in
+++ b/doc/doxygen/code-gallery/code-gallery.h.in
@@ -23,7 +23,7 @@
  * implemented with deal.II, but without the requirement to have these code
  * documented at the same, extensive level as used in the tutorial.
  * Instructions for obtaining the code gallery programs can be found at
- * https://dealii.org/code-gallery.html .
+ * https://dealii.org/developer/doxygen/deal.II/CodeGallery.html .
  *
  * @warning The programs that form part of the code gallery are contributed by
  *   others and are not part of deal.II itself. The deal.II authors make


### PR DESCRIPTION
While looking through the nice new website I noticed that the links to the code gallery
within the websites have not been updated.
This updates the link in `Code Gallery`,
the one in `Applications` is fixed here https://github.com/dealii/website/pull/12