### PR TITLE
Fix formatting issue in tutorials.

### DIFF
--- a/doc/doxygen/scripts/program2toc.pl
+++ b/doc/doxygen/scripts/program2toc.pl
@@ -62,3 +62,5 @@ while (<>) {
 for (; $level>=3; --$level) {
     print "      </ul>\n";
 }
+
+print "<br>\n";

--- a/examples/step-12/doc/intro.dox
+++ b/examples/step-12/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <a name="step-12-Intro"></a>
 <h1>An example of an advection problem using the Discountinuous Galerkin method</h1>
 

--- a/examples/step-15/doc/intro.dox
+++ b/examples/step-15/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>
 This program grew out of a student project by Sven Wetterauer at the
 University of Heidelberg, Germany. Most of the work for this program

--- a/examples/step-16/doc/intro.dox
+++ b/examples/step-16/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <a name="step-16-Intro"></a>
 <h1>Introduction</h1>
 

--- a/examples/step-19/doc/intro.dox
+++ b/examples/step-19/doc/intro.dox
@@ -1,6 +1,3 @@
-
-<br>
-
 <i>
 This program was contributed by Wolfgang Bangerth, Rene Gassmoeller, and Peter Munch.
 

--- a/examples/step-22/doc/intro.dox
+++ b/examples/step-22/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>This program was contributed by Martin Kronbichler and Wolfgang
 Bangerth.
 <br>

--- a/examples/step-28/doc/intro.dox
+++ b/examples/step-28/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>This program was contributed by Yaqi Wang and Wolfgang
 Bangerth. Results from this program are used and discussed in the publication
 "Three-dimensional h-adaptivity for the multigroup neutron diffusion

--- a/examples/step-29/doc/intro.dox
+++ b/examples/step-29/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>
 This program was contributed by Moritz Allmaras at Texas A&amp;M
 University. Some of the work on this tutorial program has been funded

--- a/examples/step-31/doc/intro.dox
+++ b/examples/step-31/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>This program was contributed by Martin Kronbichler and Wolfgang
 Bangerth.
 <br>

--- a/examples/step-32/doc/intro.dox
+++ b/examples/step-32/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>This program was contributed by Martin Kronbichler, Wolfgang
 Bangerth, and Timo Heister.
 

--- a/examples/step-33/doc/intro.dox
+++ b/examples/step-33/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>
 This program was written for fun by David Neckels (NCAR) while working
 at Sandia (on the Wyoming Express bus to and from Corrales each day).

--- a/examples/step-34/doc/intro.dox
+++ b/examples/step-34/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>This program was contributed by Luca Heltai (thanks to Michael
 Gratton for pointing out what the exact solution should have been in
 the three dimensional case).  </i>

--- a/examples/step-35/doc/intro.dox
+++ b/examples/step-35/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>
 This program grew out of a student project by Abner Salgado at Texas A&M
 University. Most of the work for this program is by him.

--- a/examples/step-36/doc/intro.dox
+++ b/examples/step-36/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>This program was contributed by Toby D. Young and Wolfgang
 Bangerth.  </i>
 

--- a/examples/step-37/doc/intro.dox
+++ b/examples/step-37/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>
 This program was contributed by Katharina Kormann and Martin
 Kronbichler.

--- a/examples/step-38/doc/intro.dox
+++ b/examples/step-38/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>This program was contributed by Andrea Bonito and M. Sebastian Pauletti,
 with editing and writing by Wolfgang Bangerth.
 <br>

--- a/examples/step-40/doc/intro.dox
+++ b/examples/step-40/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>This program was contributed by Timo Heister, Martin Kronbichler, and Wolfgang
 Bangerth.
 <br>

--- a/examples/step-41/doc/intro.dox
+++ b/examples/step-41/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>This program was contributed by Jörg Frohne (University of Siegen,
 Germany) while on a long-term visit to Texas A&amp;M University.
 <br>

--- a/examples/step-42/doc/intro.dox
+++ b/examples/step-42/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>This program was contributed by Jörg Frohne (University of Siegen,
 Germany) while on a long-term visit to Texas A&amp;M University, with significant
 contributions by Timo Heister and Wolfgang Bangerth.

--- a/examples/step-43/doc/intro.dox
+++ b/examples/step-43/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>
 This program was contributed by Chih-Che Chueh (University of Victoria) and
 Wolfgang Bangerth. Results from this program are used and discussed in the

--- a/examples/step-44/doc/intro.dox
+++ b/examples/step-44/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>This program was contributed by Jean-Paul Pelteret and Andrew McBride.
 <br>
 This material is based upon work supported by  the German Science Foundation (Deutsche

--- a/examples/step-45/doc/intro.dox
+++ b/examples/step-45/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>This program was contributed by Daniel Arndt and Matthias Maier.</i>
 <a name="step-45-Intro"></a>
 <h1>Introduction</h1>

--- a/examples/step-46/doc/intro.dox
+++ b/examples/step-46/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>This program was contributed by Wolfgang Bangerth.
 <br>
 This material is based upon work partly supported by the National Science

--- a/examples/step-47/doc/intro.dox
+++ b/examples/step-47/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>
 This program was contributed by Natasha Sharma, Guido Kanschat, Timo
 Heister, Wolfgang Bangerth, and Zhuoran Wang.
@@ -224,7 +222,7 @@ alternative method.
 <h3> Derivation of the C0IP method </h3>
 
 We base this program on the $C^0$ IP method presented by Susanne
-Brenner and Li-Yeng Sung in the paper "C$^0$ Interior Penalty Method
+Brenner and Li-Yeng Sung in the paper "$C^0$ Interior Penalty Method
 for Linear Fourth Order Boundary Value Problems on polygonal
 domains"
 @cite Brenner2005

--- a/examples/step-48/doc/intro.dox
+++ b/examples/step-48/doc/intro.dox
@@ -1,4 +1,3 @@
-
 <i>
 This program was contributed by Katharina Kormann and Martin
 Kronbichler.

--- a/examples/step-50/doc/intro.dox
+++ b/examples/step-50/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>
 This program was contributed by Thomas C. Clevenger and Timo Heister.
 <br>

--- a/examples/step-51/doc/intro.dox
+++ b/examples/step-51/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>
 This program was contributed by Martin Kronbichler and Scott Miller.
 </i>

--- a/examples/step-53/doc/intro.dox
+++ b/examples/step-53/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>This program was contributed by Wolfgang Bangerth and Luca Heltai, using
 data provided by D. Sarah Stamps.</i>
 

--- a/examples/step-54/doc/intro.dox
+++ b/examples/step-54/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>This program was contributed by Andrea Mola and Luca Heltai.</i>
 
 @note This program elaborates on concepts of industrial geometry, using tools

--- a/examples/step-55/doc/intro.dox
+++ b/examples/step-55/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>This program was contributed by Timo Heister. Special thanks to Sander
 Rhebergen for the inspiration to finally write this tutorial.
 

--- a/examples/step-57/doc/intro.dox
+++ b/examples/step-57/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>This program was contributed by Liang Zhao and Timo Heister.
 
 This material is based upon work partially supported by National Science

--- a/examples/step-58/doc/intro.dox
+++ b/examples/step-58/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>This program was contributed by Wolfgang Bangerth (Colorado State
 University) and Yong-Yong Cai (<a href="http://www.csrc.ac.cn/en/">Beijing
 Computational Science Research Center</a>, CSRC) and is the result of the

--- a/examples/step-59/doc/intro.dox
+++ b/examples/step-59/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>
 This program was contributed by Katharina Kormann and Martin
 Kronbichler.

--- a/examples/step-60/doc/intro.dox
+++ b/examples/step-60/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>This program was contributed by Luca Heltai and Giovanni Alzetta, SISSA, Trieste.
 </i>
 

--- a/examples/step-61/doc/intro.dox
+++ b/examples/step-61/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>
 This program was contributed by Zhuoran Wang.
 Some more information about this program, as well as more numerical

--- a/examples/step-62/doc/intro.dox
+++ b/examples/step-62/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>This program was contributed by Daniel Garcia-Sanchez.</i>
 <br>
 

--- a/examples/step-63/doc/intro.dox
+++ b/examples/step-63/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>This program was contributed by Thomas C. Clevenger and Timo Heister.
 
 The creation of this tutorial was partially supported by NSF Award

--- a/examples/step-64/doc/intro.dox
+++ b/examples/step-64/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>
 This program was contributed by Bruno Turcksin and Daniel Arndt, Oak Ridge National Laboratory.
 </i>

--- a/examples/step-65/doc/intro.dox
+++ b/examples/step-65/doc/intro.dox
@@ -1,6 +1,3 @@
-
-<br>
-
 <i>
 This program was contributed by Martin Kronbichler.
 </i>

--- a/examples/step-66/doc/intro.dox
+++ b/examples/step-66/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>
 This program was contributed by Fabian Castelli.
 

--- a/examples/step-67/doc/intro.dox
+++ b/examples/step-67/doc/intro.dox
@@ -1,6 +1,3 @@
-
-<br>
-
 <i>
 This program was contributed by Martin Kronbichler. Many ideas presented here
 are the result of common code development with Niklas Fehn, Katharina Kormann,

--- a/examples/step-68/doc/intro.dox
+++ b/examples/step-68/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>
 This program was contributed by
 Bruno Blais (Polytechnique Montréal),

--- a/examples/step-70/doc/intro.dox
+++ b/examples/step-70/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>This program was contributed by Luca Heltai (International School for
 Advanced Studies, Trieste), Bruno Blais (Polytechnique Montréal),
 and Rene Gassmöller (University of California Davis)

--- a/examples/step-71/doc/intro.dox
+++ b/examples/step-71/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>This program was contributed by Jean-Paul Pelteret.
 </i>
 

--- a/examples/step-72/doc/intro.dox
+++ b/examples/step-72/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>This program was contributed by Jean-Paul Pelteret and Wolfgang Bangerth.
 
 Wolfgang Bangerth's work is partially supported by National Science

--- a/examples/step-74/doc/intro.dox
+++ b/examples/step-74/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>
 This program was contributed by Jiaqi Zhang and Timo Heister.
 <br>

--- a/examples/step-75/doc/intro.dox
+++ b/examples/step-75/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>This program was contributed by Marc Fehling, Peter Munch and
 Wolfgang Bangerth.
 <br>

--- a/examples/step-76/doc/intro.dox
+++ b/examples/step-76/doc/intro.dox
@@ -1,6 +1,3 @@
-
-<br>
-
 <i>
 This program was contributed by Martin Kronbichler, Peter Munch, and David
 Schneider. Many of the features shown here have been added to deal.II during

--- a/examples/step-77/doc/intro.dox
+++ b/examples/step-77/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>
 This program was contributed by Wolfgang Bangerth, Colorado State University.
 

--- a/examples/step-83/doc/intro.dox
+++ b/examples/step-83/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>
 This program was contributed by
 Pasquale Africa (SISSA),

--- a/examples/step-86/doc/intro.dox
+++ b/examples/step-86/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>
 This program was contributed by Wolfgang Bangerth (Colorado State University),
 Stefano Zampini (King Abdullah University of Science and Technology), and

--- a/examples/step-87/doc/intro.dox
+++ b/examples/step-87/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>
 This program was contributed by Magdalena Schreter-Fleischhacker
 and Peter Munch. Many ideas presented here are the result of common code

--- a/examples/step-89/doc/intro.dox
+++ b/examples/step-89/doc/intro.dox
@@ -1,5 +1,3 @@
-<br>
-
 <i>
 This program was contributed by Johannes Heinz, Maximilian Bergbauer, Marco
 Feder, and Peter Munch. Many ideas presented here are the result of common code


### PR DESCRIPTION
I had to look something up at https://dealii.org/developer/doxygen/deal.II/step_82.html and found that the formatting is awkward because the text starts to the right of the table, rather than on a line of its own. Many tutorials manage this by adding a `<br>` at the very top of the introduction, but step-82 does not and, frankly, this shouldn't be the job of the tutorial anyway: The script that generates these pages should do that.

This patch updates the script, and then removes the now unnecessary line breaks from all affected tutorials.