### PR TITLE
Add a test output file variant.

### DIFF
--- a/tests/parameter_handler/parameter_handler_29.output.clang-apple
+++ b/tests/parameter_handler/parameter_handler_29.output.clang-apple
@@ -1,0 +1,23 @@
+
+DEAL::ExcEncounteredDeprecatedEntries(deprecation_messages)
+    The following deprecated entries were encountered:
+
+
+--------------------------------------------------------
+An error occurred in file <parameter_handler.cc> in function
+    void dealii::ParameterHandler::scan_line(std::string, const std::string &, const unsigned int, const bool)
+Additional information: 
+    Line <2> of file <prm/parameter_handler_3.prm>: Entry <string list> is
+    deprecated.
+--------------------------------------------------------
+
+--------------------------------------------------------
+An error occurred in file <parameter_handler.cc> in function
+    void dealii::ParameterHandler::scan_line(std::string, const std::string &, const unsigned int, const bool)
+Additional information: 
+    Line <3> of file <prm/parameter_handler_3.prm>: Entry <int> is
+    deprecated.
+--------------------------------------------------------
+
+DEAL::a, b, c
+DEAL::3


### PR DESCRIPTION
clang formats exceptions in a slightly different way.

Might fix #17636.