### PR TITLE
Add empty() function to deal.II/lac/vector.h and use it instead of size()==0

### DIFF
--- a/examples/step-28/step-28.cc
+++ b/examples/step-28/step-28.cc
@@ -591,7 +591,7 @@ namespace Step28
 
     system_rhs.reinit(n_dofs);
 
-    if (solution.size() == 0)
+    if (solution.empty())
       {
         solution.reinit(n_dofs);
         solution_old.reinit(n_dofs);

--- a/examples/step-39/step-39.cc
+++ b/examples/step-39/step-39.cc
@@ -1010,7 +1010,7 @@ namespace Step39
     for (unsigned int s = 0; s < n_steps; ++s)
       {
         deallog << "Step " << s << std::endl;
-        if (estimates.block(0).size() == 0)
+        if (estimates.block(0).empty())
           triangulation.refine_global(1);
         else
           {

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -287,6 +287,13 @@ public:
    */
   virtual ~Vector() override = default;
 
+
+  /**
+   * This function is equivalent to writing <code>size() == 0</code>.
+   */
+  bool
+  empty() const;
+
   /**
    * This function does nothing but exists for compatibility with the parallel
    * vector classes.
@@ -1392,6 +1399,12 @@ Vector<Number>::operator!=(const Vector<Number2> &v) const
 }
 
 
+template <typename Number>
+inline bool
+Vector<Number>::empty() const
+{
+  return this->size() == 0;
+}
 
 template <typename Number>
 inline void

--- a/source/numerics/data_out_stack.cc
+++ b/source/numerics/data_out_stack.cc
@@ -60,11 +60,11 @@ DataOutStack<dim, spacedim>::new_parameter_value(const double p,
   for (typename std::vector<DataVector>::const_iterator i = dof_data.begin();
        i != dof_data.end();
        ++i)
-    Assert(i->data.size() == 0, ExcDataNotCleared());
+    Assert(i->data.empty(), ExcDataNotCleared());
   for (typename std::vector<DataVector>::const_iterator i = cell_data.begin();
        i != cell_data.end();
        ++i)
-    Assert(i->data.size() == 0, ExcDataNotCleared());
+    Assert(i->data.empty(), ExcDataNotCleared());
 }
 
 


### PR DESCRIPTION
Add empty() function to deal.II/lac/vector.h and use it instead of size()==0.
This addresses part of issue #16842