### PR TITLE
Avoid some copying of data in make_consistent_in_parallel().

### DIFF
--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -2023,9 +2023,9 @@ public:
    * penalize certain terms when solving the biharmonic equation (see,
    * for example, step-47).
    *
-   * At the end of this function, the current object
-   * only stores constraints for degrees of freedom whose indices are
-   * listed in the second argument. In other words, while
+   * At the end of this function, the current object only stores constraints
+   * for degrees of freedom whose indices are listed in the
+   * second argument, @p constraints_to_make_consistent. In other words, while
    * DoFTools::make_hanging_node_constraints() may compute constraints
    * also for degrees of freedom at the interface between two ghost cells
    * (these DoFs are locally *relevant*), if you pass as second argument only


### PR DESCRIPTION
This is a follow-up to the patches already linked in #17599.

Previously, we copied *all* constraints we know locally into an array and gave it to `Utilities::MPI::some_to_some()`. But we don't really need to do that for the ones we *own* locally since these would only be sent to ourselves. `some_to_some()` optimizes this, but it can be avoided anyway. This patch does that.