### PR TITLE
Fix output of a test.

### DIFF
--- a/tests/parameter_handler/parameter_handler_29.output
+++ b/tests/parameter_handler/parameter_handler_29.output
@@ -5,7 +5,7 @@ DEAL::ExcEncounteredDeprecatedEntries(deprecation_messages)
 
 --------------------------------------------------------
 An error occurred in file <parameter_handler.cc> in function
-    void dealii::ParameterHandler::scan_line(std::string, const string&, unsigned int, bool)
+    void dealii::ParameterHandler::scan_line(std::string, const std::string&, unsigned int, bool)
 Additional information: 
     Line <2> of file <prm/parameter_handler_3.prm>: Entry <string list> is
     deprecated.
@@ -13,7 +13,7 @@ Additional information:
 
 --------------------------------------------------------
 An error occurred in file <parameter_handler.cc> in function
-    void dealii::ParameterHandler::scan_line(std::string, const string&, unsigned int, bool)
+    void dealii::ParameterHandler::scan_line(std::string, const std::string&, unsigned int, bool)
 Additional information: 
     Line <3> of file <prm/parameter_handler_3.prm>: Entry <int> is
     deprecated.


### PR DESCRIPTION
We have numerous CI checks that fail because of the newly introduced test `parameter_handler_29` (in #17466, @gassmoeller FYI). I believe that the output file that was checked in is wrong because it misses `std::` in two places, and that's the reason it fails -- see for example https://cdash.dealii.org/test/13759754. This patch fixes that.

Fixes #17650 and perhaps some others.