### PR TITLE
fix cmake bug in PETSC_WITH_KOKKOS check

### DIFF
--- a/cmake/configure/configure_20_petsc.cmake
+++ b/cmake/configure/configure_20_petsc.cmake
@@ -82,7 +82,7 @@ macro(feature_petsc_find_external var)
       set(${var} FALSE)
     endif()
 
-    if(DEAL_II_PETSC_WITH_KOKKOS)
+    if(PETSC_WITH_KOKKOS)
       if(DEAL_II_FORCE_BUNDLED_KOKKOS)
         set(PETSC_ADDITIONAL_ERROR_STRING
           ${PETSC_ADDITIONAL_ERROR_STRING}


### PR DESCRIPTION
The variable DEAL_II_PETSC_WITH_KOKKOS is only defined once the configuration finishes.