### PR TITLE
fix Kokkos+CUDA inside PETSc/Trilinos detection

### DIFF
--- a/bundled/setup_bundled.cmake
+++ b/bundled/setup_bundled.cmake
@@ -76,6 +76,7 @@ option(DEAL_II_FORCE_BUNDLED_KOKKOS
 set(KOKKOS_FOLDER "${CMAKE_SOURCE_DIR}/bundled/kokkos-3.7.00")
 
 macro(feature_kokkos_configure_bundled)
+  set(Kokkos_VERSION "3.7.0")
   set(KOKKOS_VERSION "3.7.0")
   set(Kokkos_DEVICES "Serial")
   set(Kokkos_ARCH " ")

--- a/cmake/modules/FindDEAL_II_KOKKOS.cmake
+++ b/cmake/modules/FindDEAL_II_KOKKOS.cmake
@@ -52,7 +52,6 @@ if(Kokkos_FOUND)
   endif()
 
   if (Kokkos_ENABLE_CUDA OR Kokkos_ENABLE_HIP)
-    message(STATUS "Found Kokkos with device support.")
     # In version older than 3.7.0, Kokkos::Array::operator[] is not constexpr,
     # so we use std::array instead.
     if (Kokkos_VERSION VERSION_LESS 3.7.0)

--- a/cmake/modules/FindDEAL_II_KOKKOS.cmake
+++ b/cmake/modules/FindDEAL_II_KOKKOS.cmake
@@ -47,7 +47,12 @@ endif()
 
 
 if(Kokkos_FOUND)
+  if(NOT Kokkos_VERSION)
+    message(FATAL_ERROR "FindPackage(Kokkos) did not set Kokkos_VERSION!")
+  endif()
+
   if (Kokkos_ENABLE_CUDA OR Kokkos_ENABLE_HIP)
+    message(STATUS "Found Kokkos with device support.")
     # In version older than 3.7.0, Kokkos::Array::operator[] is not constexpr,
     # so we use std::array instead.
     if (Kokkos_VERSION VERSION_LESS 3.7.0)

--- a/cmake/modules/FindDEAL_II_TRILINOS.cmake
+++ b/cmake/modules/FindDEAL_II_TRILINOS.cmake
@@ -51,7 +51,7 @@ if(Trilinos_FOUND)
   # run find_package to populate variables like Kokkos_VERSION not
   # set by the find_package call to Trilinos:
   set(CMAKE_CXX_EXTENSIONS OFF)
-  find_package(Kokkos 3.4.0 QUIET
+  find_package(Kokkos 3.4.0 REQUIRED QUIET
     PATHS ${TRILINOS_DIR} NO_DEFAULT_PATH
   )
 

--- a/cmake/modules/FindDEAL_II_TRILINOS.cmake
+++ b/cmake/modules/FindDEAL_II_TRILINOS.cmake
@@ -117,7 +117,7 @@ if(TRILINOS_VERSION VERSION_GREATER_EQUAL 14)
   # run find_package to populate variables like Kokkos_VERSION not
   # set by the find_package call to Trilinos:
   set(CMAKE_CXX_EXTENSIONS OFF)
-  find_package(Kokkos 3.7.0 QUIET
+  find_package(Kokkos 3.4.0 QUIET
     PATHS ${TRILINOS_DIR} NO_DEFAULT_PATH
   )
 

--- a/cmake/modules/FindDEAL_II_TRILINOS.cmake
+++ b/cmake/modules/FindDEAL_II_TRILINOS.cmake
@@ -118,7 +118,7 @@ if(TRILINOS_VERSION VERSION_GREATER_EQUAL 14)
   # set by the find_package call to Trilinos:
   set(CMAKE_CXX_EXTENSIONS OFF)
   find_package(Kokkos 3.7.0 QUIET
-    HINTS ${TRILINOS_DIR} NO_DEFAULT_PATH
+    PATHS ${TRILINOS_DIR} NO_DEFAULT_PATH
   )
 
   set(KOKKOS_FOUND ${Kokkos_FOUND})

--- a/cmake/modules/FindDEAL_II_TRILINOS.cmake
+++ b/cmake/modules/FindDEAL_II_TRILINOS.cmake
@@ -48,6 +48,16 @@ find_package(TRILINOS_CONFIG
   )
 
 if(Trilinos_FOUND)
+  # run find_package to populate variables like Kokkos_VERSION not
+  # set by the find_package call to Trilinos:
+  set(CMAKE_CXX_EXTENSIONS OFF)
+  find_package(Kokkos 3.4.0 QUIET
+    PATHS ${TRILINOS_DIR} NO_DEFAULT_PATH
+  )
+
+  set(KOKKOS_FOUND ${Kokkos_FOUND})
+
+
   #
   # Extract version numbers:
   #
@@ -113,15 +123,6 @@ if(TRILINOS_VERSION VERSION_GREATER_EQUAL 14)
   if(TARGET Kokkos::kokkos)
     list(APPEND _targets Kokkos::kokkos)
   endif()
-
-  # run find_package to populate variables like Kokkos_VERSION not
-  # set by the find_package call to Trilinos:
-  set(CMAKE_CXX_EXTENSIONS OFF)
-  find_package(Kokkos 3.4.0 QUIET
-    PATHS ${TRILINOS_DIR} NO_DEFAULT_PATH
-  )
-
-  set(KOKKOS_FOUND ${Kokkos_FOUND})
 
   process_feature(TRILINOS
     TARGETS REQUIRED _targets

--- a/cmake/modules/FindDEAL_II_TRILINOS.cmake
+++ b/cmake/modules/FindDEAL_II_TRILINOS.cmake
@@ -114,6 +114,15 @@ if(TRILINOS_VERSION VERSION_GREATER_EQUAL 14)
     list(APPEND _targets Kokkos::kokkos)
   endif()
 
+  # run find_package to populate variables like Kokkos_VERSION not
+  # set by the find_package call to Trilinos:
+  set(CMAKE_CXX_EXTENSIONS OFF)
+  find_package(Kokkos 3.7.0 QUIET
+    HINTS ${TRILINOS_DIR} NO_DEFAULT_PATH
+  )
+
+  set(KOKKOS_FOUND ${Kokkos_FOUND})
+
   process_feature(TRILINOS
     TARGETS REQUIRED _targets
     CLEAR

--- a/cmake/modules/FindDEAL_II_TRILINOS.cmake
+++ b/cmake/modules/FindDEAL_II_TRILINOS.cmake
@@ -52,7 +52,7 @@ if(Trilinos_FOUND)
   # set by the find_package call to Trilinos:
   set(CMAKE_CXX_EXTENSIONS OFF)
   find_package(Kokkos 3.4.0 REQUIRED QUIET
-    PATHS ${TRILINOS_DIR} NO_DEFAULT_PATH
+    PATHS ${TRILINOS_CONFIG_DIR}/.. NO_DEFAULT_PATH
   )
 
   set(KOKKOS_FOUND ${Kokkos_FOUND})


### PR DESCRIPTION
We need to unconditionally find Kokkos even if PETSc or Trilinos are configured with Kokkos support. Otherwise, we can not configure correctly to run on GPUs.