### PR TITLE
NVCC: work around compiler bug

### DIFF
--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -68,7 +68,15 @@ namespace PETScWrappers
      */
     class const_iterator
     {
+#  ifdef __CUDA_ARCH__
+      // NVCC, at least until 12.6, fails to compile the
+      // implementations of the nested Accessor class if
+      // it is declared as private. Work around this by
+      // making it public.
+    public:
+#  else
     private:
+#  endif
       /**
        * Accessor class for iterators
        */


### PR DESCRIPTION
The error is something nonsensical:
```
/ssd/deal-git4/include/deal.II/lac/petsc_matrix_base.h:1141:37: error: use of enum ‘CacheUpdateFlags’ without previous declaration
 1141 |     const_iterator::Accessor::row() const
      |                                     ^~~~~           
/ssd/deal-git4/include/deal.II/lac/petsc_matrix_base.h:1141:53: error: template argument 1 is invalid
 1141 |     const_iterator::Accessor::row() const
      |                                                     ^
/ssd/deal-git4/include/deal.II/lac/petsc_matrix_base.h:1141:56: error: no declaration matches ‘int dealii::PETScWrappers::MatrixIterators::const_iterator::Accessor::row() const’
 1141 |     const_iterator::Accessor::row() const
      |                                                        ^             
/ssd/deal-git4/include/deal.II/lac/petsc_matrix_base.h:103:18: note: candidate is: ‘dealii::PETScWrappers::MatrixIterators::const_iterator::Accessor::size_type dealii::PETScWrappers::MatrixIterators::const_iterator::Accessor::row() const’
  103 |         row() const;
      |                  ^~~
/ssd/deal-git4/include/deal.II/lac/petsc_matrix_base.h:83:7: note: ‘class dealii::PETScWrappers::MatrixIterators::const_iterator::Accessor’ defined here
   83 |       class Accessor
      |       ^~~~~~~~
/ssd/deal-git4/include/deal.II/lac/petsc_matrix_base.h:1141:56: error: ‘class dealii::PETScWrappers::MatrixIterators::const_iterator::Accessor’ is private within this context
 1141 |     const_iterator::Accessor::row() const
      |                                                        ^             
/ssd/deal-git4/include/deal.II/lac/petsc_matrix_base.h:83:7: note: declared private here
   83 |       class Accessor
      |       ^~~~~~~~
/ssd/deal-git4/include/deal.II/lac/petsc_matrix_base.h:1149:32: error: ‘GridTools’ was not declared in this scope
```
