### PR TITLE
Fix indent run of changelog entry

### DIFF
--- a/doc/news/changes/minor/20240821Marquis
+++ b/doc/news/changes/minor/20240821Marquis
@@ -1,8 +1,10 @@
-Fixed: Previously, FiniteElement::has_generalized_support_points() and 
-FiniteElement::has_face_support_points() returned false for the FE_Nothing element. Now, FE_Nothing::has_generalized_support_points() and 
-FE_Nothing::has_face_support_points() correctly return true, as the empty 
-arrays returned by FE_Nothing::get_generalized_support_points() and FE_Nothing::get_unit_face_support_points() accurately describe the support 
-points of the element(i.e., they don't have any, as there are no
-degrees of freedom).
+Fixed: Previously, FiniteElement::has_generalized_support_points() and
+FiniteElement::has_face_support_points() returned false for the FE_Nothing
+element. Now, FE_Nothing::has_generalized_support_points() and
+FE_Nothing::has_face_support_points() correctly return true, as the empty
+arrays returned by FE_Nothing::get_generalized_support_points() and
+FE_Nothing::get_unit_face_support_points() accurately describe the support
+points of the element (i.e., they don't have any, as there are no degrees of
+freedom).
 <br>
 (Oreste Marquis, 2024/08/21)


### PR DESCRIPTION
Starting with https://github.com/dealii/dealii/actions/runs/10711581697/job/29700535963, I see that the indent check fails on the master branch. Address this by deleting the trailing whitespace (and while there, break lines at 80 characters).