### PR TITLE
Flag variable maybe_unused.

### DIFF
--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -317,7 +317,7 @@ namespace internal
     (void)mpi_communicator;
 #else
 
-    const unsigned int my_rank =
+    [[maybe_unused]] const unsigned int my_rank =
       Utilities::MPI::this_mpi_process(mpi_communicator);
 
     // First define a helper function that sorts and normalizes the constraints


### PR DESCRIPTION
Fixes warnings of the kind:
```
/dealii/include/deal.II/lac/affine_constraints.templates.h:320:24: warning: unused variable ‘my_rank’ [-Wunused-variable]
  320 |     const unsigned int my_rank =
      |                        ^~~~~~~
```