### PR TITLE
fix step-2 svg display

### DIFF
--- a/examples/step-2/doc/results.dox
+++ b/examples/step-2/doc/results.dox
@@ -40,8 +40,8 @@ and which can't couple when discretizing a local, i.e. differential,
 equation.)
 <table style="width:60%" align="center">
   <tr>
-    <td><img src="https://www.dealii.org/images/steps/developer/step-2.sparsity-1.svg" alt=""></td>
-    <td><img src="https://www.dealii.org/images/steps/developer/step-2.sparsity-2.svg" alt=""></td>
+    <td><img src="https://www.dealii.org/images/steps/developer/step-2.sparsity-1.svg" style="width:100%" alt=""></td>
+    <td><img src="https://www.dealii.org/images/steps/developer/step-2.sparsity-2.svg" style="width:100%" alt=""></td>
   </tr>
 </table>
 


### PR DESCRIPTION
without this, the images are shown as 0x0 size. Fixes #17667

I assume this comes from some different .css that came with the modern doxygen layout. I did not see how it happened and I did not see any other tutorial program with the same problem.