### PR TITLE
Update tidy tester to ubuntu 24.04.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,6 +8,10 @@
 # - selected modernize-* warnings:
 #   Some of these produce a lot of noise for limited utility.
 #
+# - performance-enum-size:
+#   We don't care if an enum could use a smaller base type than
+#   unsigned int.
+#
 # - performance-inefficient-string-concatenation:
 #   We don't care about "a"+to_string(5)+...
 #
@@ -33,9 +37,10 @@ Checks: >
   -modernize-use-transparent-functors,
   mpi-*,
   performance-*,
+  -performance-avoid-endl,
+  -performance-enum-size,
   -performance-inefficient-string-concatenation,
   -performance-no-automatic-move,
-  -performance-avoid-endl,
   readability-qualified-auto
 
 WarningsAsErrors: '*'

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   tidy:
     name: tidy
-    runs-on: [ubuntu-22.04]
+    runs-on: [ubuntu-24.04]
 
     #
     # The following condition only runs the workflow on 'push' or if the
@@ -30,23 +30,20 @@ jobs:
     - uses: actions/checkout@v4
     - name: modules
       run: |
-        sudo apt-get install -y software-properties-common
-        sudo add-apt-repository -y ppa:ginggs/deal.ii-9.4.0-backports
         sudo apt-get update
         sudo apt-get install -yq --no-install-recommends \
-            clang-12 \
-            clang-tidy-12 \
-            numdiff \
+            clang-18 \
+            clang-tidy-18 \
             libboost-all-dev \
             libcgal-dev \
-            libp4est-dev \
-            trilinos-all-dev \
-            petsc-dev \
+            libhdf5-mpi-dev \
             libmetis-dev \
-            libhdf5-mpi-dev
+            libp4est-dev \
+            numdiff \
+            petsc-dev \
+            trilinos-all-dev
     - name: tidy
       run: |
         mkdir build
         cd build
-        export PATH=/usr/lib/llvm-12/share/clang/:$PATH
         ../contrib/utilities/run_clang_tidy.sh ..

--- a/contrib/utilities/run_clang_tidy.sh
+++ b/contrib/utilities/run_clang_tidy.sh
@@ -25,8 +25,7 @@
 #   make sure to run this script in an empty build directory
 #
 # Requirements:
-# Clang 5.0.1+ and have clang, clang++, and run-clang-tidy.py in
-# your path.
+# Clang 5.0.1+ and have clang, clang++, and run-clang-tidy in your path.
 
 # grab first argument and make relative path an absolute one:
 SRC=$1
@@ -41,14 +40,14 @@ fi
 echo "SRC-DIR=$SRC"
 
 # enable MPI (to get MPI warnings)
-# export compile commands (so that run-clang-tidy.py works)
+# export compile commands (so that run-clang-tidy works)
 ARGS=("-D" "DEAL_II_WITH_MPI=ON" "-D" "CMAKE_EXPORT_COMPILE_COMMANDS=ON" "-D" "CMAKE_BUILD_TYPE=Debug" "$@")
 
 # for a list of checks, see /.clang-tidy
 cat "$SRC/.clang-tidy"
 
-if ! [ -x "$(command -v run-clang-tidy.py)" ] || ! [ -x "$(command -v clang++)" ]; then
-    echo "make sure clang, clang++, and run-clang-tidy.py (part of clang) are in the path"
+if ! [ -x "$(command -v run-clang-tidy)" ] || ! [ -x "$(command -v clang++)" ]; then
+    echo "make sure clang, clang++, and run-clang-tidy (part of clang) are in the path"
     exit 2
 fi
 
@@ -63,7 +62,7 @@ cmake --build . --target expand_all_instantiations || (echo "make expand_all_ins
 #
 # pipe away stderr (just contains nonsensical "x warnings generated")
 # pipe output to output.txt
-run-clang-tidy.py -p . -quiet -header-filter "$SRC/include/*" -extra-arg='-DCLANG_TIDY' 2>error.txt >output.txt
+run-clang-tidy -p . -quiet -header-filter "$SRC/include/*" -extra-arg='-DCLANG_TIDY' 2>error.txt >output.txt
 
 # grep interesting errors and make sure we remove duplicates:
 grep -E '(warning|error): ' output.txt | sort | uniq >clang-tidy.log


### PR DESCRIPTION
Part of #17583.

Just out of curiosity I switched to `clang-tidy-18` in the tests.

It works fine, but issues lots of warnings that need to be addressed before merging this PR:
```
dealii/include/deal.II/base/auto_derivative_function.h:87:8: error: enum 'DifferenceFormula' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/bounding_box.h:32:12: error: enum 'NeighborType' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/convergence_table.h:74:8: error: enum 'RateMode' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/data_out_base.h:1594:8: error: enum 'OutputFormat' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/data_out_base.h:206:14: error: enum 'CompressionLevel' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/data_out_base.h:848:10: error: enum 'SizeType' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/exceptions.h:1401:16: error: enum 'ExceptionHandling' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/floating_point_comparator.h:56:14: error: enum 'ComparisonResult' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/geometry_info.h:1015:10: error: enum 'Possibilities' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/geometry_info.h:1132:10: error: enum 'Possibilities' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/geometry_info.h:425:8: error: enum 'Object' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/geometry_info.h:951:10: error: enum 'Possibilities' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/geometry_info.h:982:10: error: enum 'Possibilities' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/hdf5.h:1079:16: error: enum 'FileAccessMode' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/hdf5.h:982:16: error: enum 'GroupAccessMode' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/init_finalize.h:34:12: error: enum 'InitializeLibrary' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/parameter_handler.h:2224:10: error: enum 'MultipleEntryType' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/parameter_handler.h:872:8: error: enum 'OutputStyle' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint16_t' (2 bytes) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/path_search.h:88:8: error: enum 'Position' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/patterns.h:100:10: error: enum 'OutputStyle' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/patterns.h:1092:10: error: enum 'FileType' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/quadrature_lib.h:588:8: error: enum 'EndPoint' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/quadrature_lib.h:86:8: error: enum 'EndPoint' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/symmetric_tensor.h:2983:13: error: enum 'SymmetricTensorEigenvectorMethod' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/table.h:942:14: error: enum 'Storage' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/table_handler.h:353:8: error: enum 'TextOutputFormat' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/time_stepping.h:151:8: error: enum 'embedded_runge_kutta_time_step' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/time_stepping.h:59:8: error: enum 'runge_kutta_method' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/timer.h:598:8: error: enum 'OutputFrequency' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/timer.h:622:8: error: enum 'OutputData' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/timer.h:642:8: error: enum 'OutputType' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/base/vectorization.h:6029:12: error: enum 'SIMDComparison' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/cgal/additional_data.h:31:14: error: enum 'FacetTopology' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/cgal/utilities.h:94:14: error: enum 'BooleanOperation' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/differentiation/ad/ad_number_traits.h:1075:10: error: use c++17 style variable templates [modernize-type-traits,-warnings-as-errors]
dealii/include/deal.II/differentiation/ad/ad_number_traits.h:1244:10: error: use c++17 style variable templates [modernize-type-traits,-warnings-as-errors]
dealii/include/deal.II/differentiation/ad/ad_number_traits.h:1255:10: error: use c++17 style variable templates [modernize-type-traits,-warnings-as-errors]
dealii/include/deal.II/differentiation/ad/ad_number_traits.h:1266:10: error: use c++17 style variable templates [modernize-type-traits,-warnings-as-errors]
dealii/include/deal.II/differentiation/ad/ad_number_traits.h:1278:10: error: use c++17 style variable templates [modernize-type-traits,-warnings-as-errors]
dealii/include/deal.II/differentiation/ad/ad_number_traits.h:1290:10: error: use c++17 style variable templates [modernize-type-traits,-warnings-as-errors]
dealii/include/deal.II/differentiation/ad/ad_number_traits.h:744:10: error: use c++17 style variable templates [modernize-type-traits,-warnings-as-errors]
dealii/include/deal.II/differentiation/ad/ad_number_traits.h:865:32: error: use c++14 style type templates [modernize-type-traits,-warnings-as-errors]
dealii/include/deal.II/differentiation/ad/ad_number_traits.h:943:10: error: use c++17 style variable templates [modernize-type-traits,-warnings-as-errors]
dealii/include/deal.II/differentiation/ad/ad_number_traits.h:957:10: error: use c++17 style variable templates [modernize-type-traits,-warnings-as-errors]
dealii/include/deal.II/differentiation/ad/ad_number_traits.h:969:10: error: use c++17 style variable templates [modernize-type-traits,-warnings-as-errors]
dealii/include/deal.II/differentiation/ad/ad_number_traits.h:981:10: error: use c++17 style variable templates [modernize-type-traits,-warnings-as-errors]
dealii/include/deal.II/differentiation/ad/ad_number_traits.h:993:10: error: use c++17 style variable templates [modernize-type-traits,-warnings-as-errors]
dealii/include/deal.II/differentiation/ad/ad_number_types.h:33:16: error: enum 'NumberTypes' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/differentiation/ad/sacado_number_types.h:188:26: error: use c++17 style variable templates [modernize-type-traits,-warnings-as-errors]
dealii/include/deal.II/distributed/shared_tria.h:130:12: error: enum 'Settings' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/distributed/tria.h:315:12: error: enum 'Settings' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/distributed/tria.h:887:12: error: enum 'Settings' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/dofs/dof_tools.h:238:8: error: enum 'Coupling' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/fe/fe_coupling_values.h:434:12: error: enum 'QuadratureCouplingType' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/fe/fe_coupling_values.h:534:12: error: enum 'DoFCouplingType' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/fe/fe_data.h:261:8: error: enum 'Conformity' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/fe/fe_data.h:90:8: error: enum 'Domination' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/fe/fe_update_flags.h:374:8: error: enum 'Similarity' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/fe/mapping.h:78:6: error: enum 'MappingKind' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint16_t' (2 bytes) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/grid/cell_status.h:30:12: error: enum 'CellStatus' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/grid/grid_in.h:317:8: error: enum 'Format' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/grid/grid_out.h:1000:8: error: enum 'OutputFormat' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/grid/grid_out.h:313:10: error: enum 'SizeType' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/grid/grid_out.h:559:10: error: enum 'Coloring' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/grid/grid_out.h:686:10: error: enum 'Background' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/grid/grid_out.h:726:10: error: enum 'Coloring' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/grid/grid_tools_cache_update_flags.h:32:8: error: enum 'CacheUpdateFlags' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint16_t' (2 bytes) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/grid/tria.h:1337:8: error: enum 'MeshSmoothing' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint16_t' (2 bytes) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/grid/tria_accessor.h:2352:8: error: enum 'VertexKind' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/grid/tria_description.h:308:8: error: enum 'Settings' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/grid/tria_iterator_base.h:34:8: error: enum 'IteratorStates' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/grid/tria_objects.h:345:12: error: enum 'UserDataType' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/lac/affine_constraints.h:519:8: error: enum 'MergeConflictBehavior' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/lac/lapack_support.h:107:8: error: enum 'Property' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/lac/lapack_support.h:54:8: error: enum 'State' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint16_t' (2 bytes) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/lac/orthogonalization.h:29:14: error: enum 'OrthogonalizationStrategy' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/lac/petsc_block_vector.h:343:7: error: swap functions should be marked noexcept [performance-noexcept-swap,-warnings-as-errors]
dealii/include/deal.II/lac/petsc_block_vector.h:632:18: error: swap functions should be marked noexcept [performance-noexcept-swap,-warnings-as-errors]
dealii/include/deal.II/lac/petsc_block_vector.h:668:5: error: swap functions should be marked noexcept [performance-noexcept-swap,-warnings-as-errors]
dealii/include/deal.II/lac/petsc_precondition.h:632:18: error: enum 'RelaxationType' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/lac/petsc_vector.h:449:5: error: swap functions should be marked noexcept [performance-noexcept-swap,-warnings-as-errors]
dealii/include/deal.II/lac/precondition.h:2123:16: error: enum 'PolynomialType' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/lac/precondition.h:67:14: error: enum 'EigenvalueAlgorithm' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/lac/precondition_block_base.h:70:8: error: enum 'Inversion' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/lac/solver_control.h:73:8: error: enum 'State' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/lac/sparse_vanka.h:495:8: error: enum 'BlockingStrategy' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/lac/sparsity_tools.h:51:14: error: enum 'Partitioner' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/lac/trilinos_solver.h:89:10: error: enum 'SolverName' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/lac/vector_operation.h:40:8: error: enum 'values' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/matrix_free/evaluation_flags.h:41:8: error: enum 'EvaluationFlags' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/matrix_free/evaluation_kernels_hanging_nodes.h:1109:14: error: enum 'HelperType' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/matrix_free/evaluation_kernels_hanging_nodes.h:40:14: error: enum 'FEEvaluationImplHangingNodesRunnerTypes' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/matrix_free/evaluation_kernels_hanging_nodes.h:52:14: error: enum 'VectorizationTypes' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/matrix_free/matrix_free.h:195:10: error: enum 'TasksParallelScheme' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/matrix_free/matrix_free.h:686:14: error: enum 'DataAccessOnFaces' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/matrix_free/portable_tensor_product_kernels.h:35:10: error: enum 'EvaluatorVariant' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/matrix_free/shape_info.h:57:10: error: enum 'ElementType' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/matrix_free/task_info.h:112:12: error: enum 'TasksParallelScheme' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/matrix_free/tensor_product_kernels.h:37:8: error: enum 'EvaluatorVariant' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/matrix_free/tensor_product_kernels.h:74:14: error: enum 'EvaluatorQuantity' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/meshworker/assemble_flags.h:40:8: error: enum 'AssembleFlags' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/meshworker/loop.h:235:10: error: enum 'FaceOption' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/multigrid/mg_transfer_global_coarsening.h:118:14: error: enum 'PolynomialCoarseningSequenceType' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/multigrid/multigrid.h:168:8: error: enum 'Cycle' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/non_matching/mapping_info.h:602:16: error: enum 'State' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/non_matching/mesh_classifier.h:54:14: error: enum 'LocationToLevelSet' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/non_matching/quadrature_generator.h:777:18: error: enum 'Definiteness' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/numerics/data_component_interpretation.h:46:8: error: enum 'DataComponentInterpretation' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/numerics/data_out.h:184:8: error: enum 'CurvedCellRegion' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/numerics/data_out_dof_data.h:202:16: error: enum 'ComponentExtractor' uses a larger base type ('int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/numerics/data_out_dof_data.h:614:8: error: enum 'DataVectorType' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/numerics/data_out_stack.h:135:8: error: enum 'VectorType' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/numerics/error_estimator.h:269:8: error: enum 'Strategy' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/numerics/error_estimator.h:585:8: error: enum 'Strategy' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/numerics/histogram.h:76:8: error: enum 'IntervalSpacing' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/numerics/nonlinear.h:108:10: error: enum 'SolverType' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/numerics/nonlinear.h:92:10: error: enum 'SolutionStrategy' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/numerics/solution_transfer.h:932:10: error: enum 'PreparationState' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/numerics/tensor_product_matrix_creator.h:48:8: error: enum 'LaplaceBoundaryType' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/numerics/time_dependent.h:1319:8: error: enum 'SolutionState' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint16_t' (2 bytes) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/numerics/time_dependent.h:416:8: error: enum 'Direction' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/numerics/time_dependent.h:669:8: error: enum 'SolutionState' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/numerics/vector_tools_common.h:52:8: error: enum 'NormType' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/include/deal.II/numerics/vector_tools_evaluate.h:44:10: error: enum 'EvaluationFlags' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
dealii/source/fe/fe_values_views_internal.cc:1054:24: error: the const qualified variable 'value' is copy-constructed from a const reference; consider making it a const reference [performance-unnecessary-copy-initialization,-warnings-as-errors]
dealii/source/fe/fe_values_views_internal.cc:1124:24: error: the const qualified variable 'value' is copy-constructed from a const reference; consider making it a const reference [performance-unnecessary-copy-initialization,-warnings-as-errors]
dealii/source/fe/fe_values_views_internal.cc:124:26: error: the const qualified variable 'value' is copy-constructed from a const reference; consider making it a const reference [performance-unnecessary-copy-initialization,-warnings-as-errors]
dealii/source/fe/fe_values_views_internal.cc:166:26: error: the const qualified variable 'value' is copy-constructed from a const reference; consider making it a const reference [performance-unnecessary-copy-initialization,-warnings-as-errors]
dealii/source/fe/fe_values_views_internal.cc:214:24: error: the const qualified variable 'value' is copy-constructed from a const reference; consider making it a const reference [performance-unnecessary-copy-initialization,-warnings-as-errors]
dealii/source/fe/fe_values_views_internal.cc:276:24: error: the const qualified variable 'value' is copy-constructed from a const reference; consider making it a const reference [performance-unnecessary-copy-initialization,-warnings-as-errors]
dealii/source/fe/fe_values_views_internal.cc:342:24: error: the const qualified variable 'value' is copy-constructed from a const reference; consider making it a const reference [performance-unnecessary-copy-initialization,-warnings-as-errors]
dealii/source/fe/fe_values_views_internal.cc:414:24: error: the const qualified variable 'value' is copy-constructed from a const reference; consider making it a const reference [performance-unnecessary-copy-initialization,-warnings-as-errors]
dealii/source/fe/fe_values_views_internal.cc:491:32: error: the const qualified variable 'value' is copy-constructed from a const reference; consider making it a const reference [performance-unnecessary-copy-initialization,-warnings-as-errors]
dealii/source/fe/fe_values_views_internal.cc:574:32: error: the const qualified variable 'value' is copy-constructed from a const reference; consider making it a const reference [performance-unnecessary-copy-initialization,-warnings-as-errors]
dealii/source/fe/fe_values_views_internal.cc:737:24: error: the const qualified variable 'value' is copy-constructed from a const reference; consider making it a const reference [performance-unnecessary-copy-initialization,-warnings-as-errors]
dealii/source/fe/fe_values_views_internal.cc:807:24: error: the const qualified variable 'value' is copy-constructed from a const reference; consider making it a const reference [performance-unnecessary-copy-initialization,-warnings-as-errors]
dealii/source/fe/fe_values_views_internal.cc:83:26: error: the const qualified variable 'value' is copy-constructed from a const reference; consider making it a const reference [performance-unnecessary-copy-initialization,-warnings-as-errors]
dealii/source/fe/fe_values_views_internal.cc:876:24: error: the const qualified variable 'value' is copy-constructed from a const reference; consider making it a const reference [performance-unnecessary-copy-initialization,-warnings-as-errors]
dealii/source/fe/fe_values_views_internal.cc:984:24: error: the const qualified variable 'value' is copy-constructed from a const reference; consider making it a const reference [performance-unnecessary-copy-initialization,-warnings-as-errors]
dealii/source/grid/grid_tools_topology.cc:953:12: error: enum 'OrientationStatus' uses a larger base type ('unsigned int', size: 4 bytes) than necessary for its value set, consider using 'std::uint8_t' (1 byte) as the base type to reduce its size [performance-enum-size,-warnings-as-errors]
```