### PR TITLE
Test that one can put a SmartPointer into a std::any object.

### DIFF
--- a/tests/base/smart_pointer_01.cc
+++ b/tests/base/smart_pointer_01.cc
@@ -1,0 +1,42 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+
+// Check that it is possible to put SmartPointer objects into a
+// std::any object.
+
+
+#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/subscriptor.h>
+
+#include <any>
+#include <iostream>
+
+#include "../tests.h"
+
+
+class Test : public Subscriptor
+{};
+
+
+int
+main()
+{
+  initlog();
+
+  Test               t;
+  SmartPointer<Test> r(&t);
+  std::any           a = r;
+}


### PR DESCRIPTION
I was playing with @drwells 's suggestion in #17657 to `=delete` `SmartPointer::operator delete()`. This threw up a surprising error deep inside some `MeshWorker` files that I don't understand, but led to me to discover that at least with the compiler I have on this system, you can't put a `SmartPointer` inside a `std::any` object if you delete `operator delete`. I think that's a legitimate thing to do, though, so this PR adds a test for it.