### PR TITLE
Triangulation::get_boundary_ids(): don't return duplicates.

### DIFF
--- a/doc/news/changes/minor/20240906Wells
+++ b/doc/news/changes/minor/20240906Wells
@@ -1,0 +1,4 @@
+Fixed: Triangulation::get_boundary_ids() does not return duplicates when
+`dim == 1` any more.
+<br>
+(David Wells, 2024/09/06)

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -12331,30 +12331,14 @@ DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 std::vector<types::boundary_id> Triangulation<dim, spacedim>::get_boundary_ids()
   const
 {
-  // in 1d, we store a map of all used boundary indicators. use it for
-  // our purposes
-  if (dim == 1)
-    {
-      std::vector<types::boundary_id> boundary_ids;
-      for (std::map<unsigned int, types::boundary_id>::const_iterator p =
-             vertex_to_boundary_id_map_1d->begin();
-           p != vertex_to_boundary_id_map_1d->end();
-           ++p)
-        boundary_ids.push_back(p->second);
+  std::set<types::boundary_id> boundary_ids;
+  for (const auto &cell : active_cell_iterators())
+    if (cell->is_locally_owned())
+      for (const auto &face : cell->face_indices())
+        if (cell->at_boundary(face))
+          boundary_ids.insert(cell->face(face)->boundary_id());
 
-      return boundary_ids;
-    }
-  else
-    {
-      std::set<types::boundary_id> b_ids;
-      for (auto cell : active_cell_iterators())
-        if (cell->is_locally_owned())
-          for (const unsigned int face : cell->face_indices())
-            if (cell->at_boundary(face))
-              b_ids.insert(cell->face(face)->boundary_id());
-      std::vector<types::boundary_id> boundary_ids(b_ids.begin(), b_ids.end());
-      return boundary_ids;
-    }
+  return {boundary_ids.begin(), boundary_ids.end()};
 }
 
 

--- a/tests/grid/grid_in_vtk_1d_3d.cc
+++ b/tests/grid/grid_in_vtk_1d_3d.cc
@@ -58,6 +58,9 @@ main()
         }
     }
 
+  for (const auto &boundary_id : triangulation1.get_boundary_ids())
+    deallog << "  boundary_id = " << boundary_id << std::endl;
+
   deallog << "Triangulation 2:\n";
   for (const auto &cell : triangulation2.active_cell_iterators())
     {
@@ -68,6 +71,9 @@ main()
           deallog << "    vertex: " << v << std::endl;
         }
     }
+
+  for (const auto &boundary_id : triangulation1.get_boundary_ids())
+    deallog << "  boundary_id = " << boundary_id << std::endl;
 
   GridGenerator::merge_triangulations(triangulation2,
                                       triangulation1,

--- a/tests/grid/grid_in_vtk_1d_3d.output
+++ b/tests/grid/grid_in_vtk_1d_3d.output
@@ -12,6 +12,8 @@ DEAL::    vertex: 0.00000 2.01000 -1.00000
 DEAL::  cell=0.3
 DEAL::    vertex: 0.00000 2.01000 0.00000
 DEAL::    vertex: 0.00000 3.01000 0.00000
+DEAL::  boundary_id = 0
+DEAL::  boundary_id = 1
 DEAL::Triangulation 2:
   cell=0.0
 DEAL::    vertex: 0.00000 0.00000 0.00000
@@ -25,6 +27,8 @@ DEAL::    vertex: 0.00000 0.00000 -1.00000
 DEAL::  cell=0.3
 DEAL::    vertex: 0.00000 0.00000 0.00000
 DEAL::    vertex: 0.00000 1.00000 0.00000
+DEAL::  boundary_id = 0
+DEAL::  boundary_id = 1
 0.00000 0.00000 0.00000 0 0
 0.00000 0.00000 1.00000 0 0
 


### PR DESCRIPTION
In 1d we support, in spacedim == 2 and spacedim == 3, more than two boundary nodes, so we need to remove duplicates from this vector.

I modified one of the existing codimension 2 tests instead of adding a new grid and new test.