### PR TITLE
Ensure SmartPointer gives useful compiler errors for types not derived from Subscriptor.

### DIFF
--- a/include/deal.II/base/smartpointer.h
+++ b/include/deal.II/base/smartpointer.h
@@ -19,6 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/subscriptor.h>
 
 #include <atomic>
 #include <typeinfo>
@@ -85,6 +86,8 @@ DEAL_II_NAMESPACE_OPEN
  *   a `SmartPointer<const T>` really behaves as if it were a pointer
  *   to a constant object (disallowing write access when dereferenced), while
  *   `SmartPointer<T>` is a mutable pointer.
+ *
+ * @dealiiConceptRequires{std::is_base_of_v<Subscriptor, T>}
  *
  * @ingroup memory
  */
@@ -268,7 +271,11 @@ inline SmartPointer<T, P>::SmartPointer()
   : pointer(nullptr)
   , id(typeid(P).name())
   , pointed_to_object_is_alive(false)
-{}
+{
+  static_assert(std::is_base_of_v<Subscriptor, T>,
+                "This class can only be used if the first template argument "
+                "is a class derived from 'Subscriptor'.");
+}
 
 
 
@@ -278,6 +285,10 @@ inline SmartPointer<T, P>::SmartPointer(T *t)
   , id(typeid(P).name())
   , pointed_to_object_is_alive(false)
 {
+  static_assert(std::is_base_of_v<Subscriptor, T>,
+                "This class can only be used if the first template argument "
+                "is a class derived from 'Subscriptor'.");
+
   if (t != nullptr)
     t->subscribe(&pointed_to_object_is_alive, id);
 }
@@ -290,6 +301,10 @@ inline SmartPointer<T, P>::SmartPointer(T *t, const std::string &id)
   , id(id)
   , pointed_to_object_is_alive(false)
 {
+  static_assert(std::is_base_of_v<Subscriptor, T>,
+                "This class can only be used if the first template argument "
+                "is a class derived from 'Subscriptor'.");
+
   if (pointer != nullptr)
     pointer->subscribe(&pointed_to_object_is_alive, id);
 }
@@ -303,6 +318,10 @@ inline SmartPointer<T, P>::SmartPointer(const SmartPointer<T, Q> &other)
   , id(other.id)
   , pointed_to_object_is_alive(false)
 {
+  static_assert(std::is_base_of_v<Subscriptor, T>,
+                "This class can only be used if the first template argument "
+                "is a class derived from 'Subscriptor'.");
+
   if (other != nullptr)
     {
       Assert(other.pointed_to_object_is_alive,
@@ -320,6 +339,10 @@ inline SmartPointer<T, P>::SmartPointer(const SmartPointer<T, P> &other)
   , id(other.id)
   , pointed_to_object_is_alive(false)
 {
+  static_assert(std::is_base_of_v<Subscriptor, T>,
+                "This class can only be used if the first template argument "
+                "is a class derived from 'Subscriptor'.");
+
   if (other != nullptr)
     {
       Assert(other.pointed_to_object_is_alive,
@@ -337,6 +360,10 @@ inline SmartPointer<T, P>::SmartPointer(SmartPointer<T, P> &&other) noexcept
   , id(other.id)
   , pointed_to_object_is_alive(false)
 {
+  static_assert(std::is_base_of_v<Subscriptor, T>,
+                "This class can only be used if the first template argument "
+                "is a class derived from 'Subscriptor'.");
+
   if (other != nullptr)
     {
       Assert(other.pointed_to_object_is_alive,
@@ -367,6 +394,10 @@ inline SmartPointer<T, P>::SmartPointer(SmartPointer<T, P> &&other) noexcept
 template <typename T, typename P>
 inline SmartPointer<T, P>::~SmartPointer()
 {
+  static_assert(std::is_base_of_v<Subscriptor, T>,
+                "This class can only be used if the first template argument "
+                "is a class derived from 'Subscriptor'.");
+
   if (pointed_to_object_is_alive && pointer != nullptr)
     pointer->unsubscribe(&pointed_to_object_is_alive, id);
 }


### PR DESCRIPTION
In looking around for #17657, I realized that `SmartPointer<T>` never checks that its template argument is actually derived from `Subscriptor` -- you just get pretty terrible error messages if it isn't.

I would have liked a class-level `static_assert` for this, or even better a C++20-style `requires` clause, but that doesn't work because we want this class to be usable in contexts where `T` is an incomplete type. One *can* write a test that a template type is incomplete, but you'd run into ODR violations if in one translation unit a `requires` evaluates to `true` because a type is incomplete, and in another to `false` because the type is now complete. So let's not go there. Instead, I put `static_assert`s into all of the constructors and destructors -- you can only meaningfully use a class if it is constructed and destroyed, and that's likely going to be the first place a compiler compiles and so gives you meaningful errors.