### PR TITLE
WorkStream support for particle sorting

### DIFF
--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -11,6 +11,7 @@
 // -----------------------------------------------------------------------------
 
 #include <deal.II/base/signaling_nan.h>
+#include <deal.II/base/work_stream.h>
 
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/grid_tools_cache.h>
@@ -1233,49 +1234,89 @@ namespace Particles
     // overhead and performance.
     particles_out_of_cell.reserve(n_locally_owned_particles() / 4);
 
-    // Now update the reference locations of the moved particles
-    std::vector<Point<spacedim>> real_locations;
-    std::vector<Point<dim>>      reference_locations;
-    real_locations.reserve(global_max_particles_per_cell);
-    reference_locations.reserve(global_max_particles_per_cell);
+    // We find which particles have left their cell in stage one.
+    // This is done in a thread-parallel worker thread.
+    // If particles have left their cell, we must add them to the
+    // particles_out_of_cell vector, which can only happen in
+    // a serial copier thread.
+    struct StageOne_CopyData
+    {
+      std::vector<particle_iterator> local_particles_out_of_cell;
 
-    for (const auto &cell : triangulation->active_cell_iterators())
+      StageOne_CopyData(const unsigned int size)
       {
+        local_particles_out_of_cell.reserve(size);
+      }
+    };
+
+    // A structure that contains scratch data, which can be reused by the worker
+    // threads. Using this structure avoids reallocating these variables for
+    // every cell.
+    struct StageOne_ScratchData
+    {
+      std::vector<Point<spacedim>> real_locations;
+      std::vector<Point<dim>>      reference_locations;
+      StageOne_ScratchData(const unsigned int size)
+      {
+        real_locations.reserve(size);
+        reference_locations.reserve(size);
+      }
+    };
+
+    const auto stage_one_worker =
+      [&](
+        const typename Triangulation<dim, spacedim>::active_cell_iterator &cell,
+        StageOne_ScratchData &scratch,
+        StageOne_CopyData    &copy) {
         // Particles can be inserted into arbitrary cells, e.g. if their cell is
         // not known. However, for artificial cells we can not evaluate
         // the reference position of particles. Do not sort particles that are
         // not locally owned, because they will be sorted by the process that
         // owns them.
+        copy.local_particles_out_of_cell.clear();
+
         if (cell->is_locally_owned() == false)
           {
-            continue;
+            return;
           }
+
+        scratch.real_locations.clear();
 
         const unsigned int n_pic = n_particles_in_cell(cell);
         auto               pic   = particles_in_cell(cell);
 
-        real_locations.clear();
         for (const auto &particle : pic)
-          real_locations.push_back(particle.get_location());
+          scratch.real_locations.push_back(particle.get_location());
 
-        reference_locations.resize(n_pic);
-        mapping->transform_points_real_to_unit_cell(cell,
-                                                    real_locations,
-                                                    reference_locations);
+        scratch.reference_locations.resize(n_pic);
+        mapping->transform_points_real_to_unit_cell(
+          cell, scratch.real_locations, scratch.reference_locations);
 
         auto particle = pic.begin();
-        for (const auto &p_unit : reference_locations)
+        for (const auto &p_unit : scratch.reference_locations)
           {
             if (numbers::is_finite(p_unit[0]) &&
                 cell->reference_cell().contains_point(p_unit,
                                                       tolerance_inside_cell))
               particle->set_reference_location(p_unit);
             else
-              particles_out_of_cell.push_back(particle);
+              copy.local_particles_out_of_cell.push_back(particle);
 
             ++particle;
           }
-      }
+      };
+
+    const auto stage_one_copier = [&](const StageOne_CopyData &copy) {
+      particles_out_of_cell.insert(particles_out_of_cell.end(),
+                                   copy.local_particles_out_of_cell.begin(),
+                                   copy.local_particles_out_of_cell.end());
+    };
+    WorkStream::run(triangulation->begin_active(),
+                    triangulation->end(),
+                    stage_one_worker,
+                    stage_one_copier,
+                    StageOne_ScratchData(global_max_particles_per_cell),
+                    StageOne_CopyData(global_max_particles_per_cell));
 
     // There are three reasons why a particle is not in its old cell:
     // It moved to another cell, to another subdomain or it left the mesh.
@@ -1321,48 +1362,80 @@ namespace Particles
         &vertex_to_cell_centers =
           triangulation_cache->get_vertex_to_cell_centers_directions();
 
-      std::vector<unsigned int> search_order;
+      // In stage two we search for the new cells of particles that have left
+      // their old cell. The particles may be located in a new cell or be lost
+      // entirely if they left the triangulation. We try to find the new cells
+      // of multiple particles in parallel worker threads, however we cannot
+      // reinsert the particles until we have finished looking at all of them or
+      // we risk invalidating the data the worker is looking at.
 
-      // Reuse these vectors below, but only with a single element.
-      // Avoid resizing for every particle.
-      reference_locations.resize(1, numbers::signaling_nan<Point<dim>>());
-      real_locations.resize(1, numbers::signaling_nan<Point<spacedim>>());
+      struct StageTwo_CopyData
+      {
+        typename Triangulation<dim, spacedim>::cell_iterator current_cell;
+        particle_iterator                                    out_particle;
+        Point<dim>                                           reference_location;
+        bool                                                 found_cell;
+      };
 
-      // Find the cells that the particles moved to.
-      for (auto &out_particle : particles_out_of_cell)
+      struct StageTwo_ScratchData
+      {
+        std::vector<Point<spacedim>> real_locations;
+        std::vector<Point<dim>>      reference_locations;
+        std::vector<unsigned int>    search_order;
+
+        StageTwo_ScratchData()
         {
+          reference_locations.resize(1, numbers::signaling_nan<Point<dim>>());
+          real_locations.resize(1, numbers::signaling_nan<Point<spacedim>>());
+        }
+      };
+
+      struct StageTwo_QueuedData
+      {
+        typename Triangulation<dim, spacedim>::cell_iterator current_cell;
+        particle_iterator                                    out_particle;
+      };
+
+      std::vector<StageTwo_QueuedData> data_queue;
+
+      data_queue.reserve(n_locally_owned_particles() / 4);
+      // Find the cells that the particles moved to.
+      const auto stage_two_worker =
+        [&](
+          const typename std::vector<particle_iterator>::iterator out_particle,
+          StageTwo_ScratchData                                   &scratch,
+          StageTwo_CopyData                                      &copy) {
           // make a copy of the current cell, since we will modify the
           // variable current_cell below, but we need the original in
           // the case the particle is not found
-          auto current_cell = out_particle->get_surrounding_cell();
+          copy.current_cell = (*out_particle)->get_surrounding_cell();
+          copy.found_cell   = false;
 
-          real_locations[0] = out_particle->get_location();
-
-          // Record if the new cell was found
-          bool found_cell = false;
+          scratch.real_locations[0] = (*out_particle)->get_location();
 
           // Check if the particle is in one of the old cell's neighbors
           // that are adjacent to the closest vertex
           const unsigned int closest_vertex =
             GridTools::find_closest_vertex_of_cell<dim, spacedim>(
-              current_cell, out_particle->get_location(), *mapping);
+              copy.current_cell, (*out_particle)->get_location(), *mapping);
           const unsigned int closest_vertex_index =
-            current_cell->vertex_index(closest_vertex);
+            copy.current_cell->vertex_index(closest_vertex);
 
           const auto &candidate_cells = vertex_to_cells[closest_vertex_index];
           const unsigned int n_candidate_cells = candidate_cells.size();
 
           // The order of searching through the candidate cells matters for
           // performance reasons. Start with a simple order.
-          search_order.resize(n_candidate_cells);
+          scratch.search_order.resize(n_candidate_cells);
           for (unsigned int i = 0; i < n_candidate_cells; ++i)
-            search_order[i] = i;
+            scratch.search_order[i] = i;
 
           // If the particle is not on a vertex, we can do better by
           // sorting the candidate cells by alignment with
           // the vertex_to_particle direction.
           Tensor<1, spacedim> vertex_to_particle =
-            out_particle->get_location() - current_cell->vertex(closest_vertex);
+            (*out_particle)->get_location() -
+            copy.current_cell->vertex(closest_vertex);
 
           // Only do this if the particle is not on a vertex, otherwise we
           // cannot normalize
@@ -1372,16 +1445,16 @@ namespace Particles
                 vertex_to_cell_centers[closest_vertex_index][0].norm_square())
             {
               vertex_to_particle /= vertex_to_particle.norm();
-              const auto &vertex_to_cells =
+              const auto &vertex_to_cells_center =
                 vertex_to_cell_centers[closest_vertex_index];
 
-              std::sort(search_order.begin(),
-                        search_order.end(),
+              std::sort(scratch.search_order.begin(),
+                        scratch.search_order.end(),
                         [&vertex_to_particle,
-                         &vertex_to_cells](const unsigned int a,
-                                           const unsigned int b) {
-                          return compare_particle_association(
-                            a, b, vertex_to_particle, vertex_to_cells);
+                         &vertex_to_cells_center](const unsigned int a,
+                                                  const unsigned int b) {
+                          return compare_particle_association<spacedim>(
+                            a, b, vertex_to_particle, vertex_to_cells_center);
                         });
             }
 
@@ -1393,18 +1466,17 @@ namespace Particles
                 typename Triangulation<dim, spacedim>::active_cell_iterator>::
                 const_iterator candidate_cell = candidate_cells.begin();
 
-              std::advance(candidate_cell, search_order[i]);
-              mapping->transform_points_real_to_unit_cell(*candidate_cell,
-                                                          real_locations,
-                                                          reference_locations);
+              std::advance(candidate_cell, scratch.search_order[i]);
+              mapping->transform_points_real_to_unit_cell(
+                *candidate_cell,
+                scratch.real_locations,
+                scratch.reference_locations);
 
-              if ((*candidate_cell)
-                    ->reference_cell()
-                    .contains_point(reference_locations[0],
-                                    tolerance_inside_cell))
+              if (GeometryInfo<dim>::is_inside_unit_cell(
+                    scratch.reference_locations[0], tolerance_inside_cell))
                 {
-                  current_cell = *candidate_cell;
-                  found_cell   = true;
+                  copy.current_cell = *candidate_cell;
+                  copy.found_cell   = true;
                   break;
                 }
             }
@@ -1412,21 +1484,20 @@ namespace Particles
           // If we did not find a cell the particle is not in a neighbor of
           // its old cell. Look for the new cell in the whole local domain.
           // This case should be rare.
-          if (!found_cell)
+          if (!copy.found_cell)
             {
-              // For some clang-based compilers and boost versions the call to
-              // RTree::query doesn't compile. We use a slower implementation as
-              // workaround.
-              // This is fixed in boost in
-              // https://github.com/boostorg/numeric_conversion/commit/50a1eae942effb0a9b90724323ef8f2a67e7984a
+            // For some clang-based compilers and boost versions the call to
+            // RTree::query doesn't compile. We use a slower implementation as
+            // workaround.
+            // This is fixed in boost in
+            // https://github.com/boostorg/numeric_conversion/commit/50a1eae942effb0a9b90724323ef8f2a67e7984a
 #if defined(DEAL_II_WITH_BOOST_BUNDLED) ||                \
   !(defined(__clang_major__) && __clang_major__ >= 16) || \
   BOOST_VERSION >= 108100
-
               std::vector<std::pair<Point<spacedim>, unsigned int>>
                 closest_vertex_in_domain;
               triangulation_cache->get_used_vertices_rtree().query(
-                boost::geometry::index::nearest(out_particle->get_location(),
+                boost::geometry::index::nearest((*out_particle)->get_location(),
                                                 1),
                 std::back_inserter(closest_vertex_in_domain));
 
@@ -1438,7 +1509,7 @@ namespace Particles
               const unsigned int closest_vertex_index_in_domain =
                 GridTools::find_closest_vertex(*mapping,
                                                *triangulation,
-                                               out_particle->get_location());
+                                               (*out_particle)->get_location());
 #endif
 
               // Search all of the cells adjacent to the closest vertex of the
@@ -1447,52 +1518,78 @@ namespace Particles
                    vertex_to_cells[closest_vertex_index_in_domain])
                 {
                   mapping->transform_points_real_to_unit_cell(
-                    cell, real_locations, reference_locations);
+                    cell, scratch.real_locations, scratch.reference_locations);
 
-                  if (cell->reference_cell().contains_point(
-                        reference_locations[0], tolerance_inside_cell))
+                  if (GeometryInfo<dim>::is_inside_unit_cell(
+                        scratch.reference_locations[0], tolerance_inside_cell))
                     {
-                      current_cell = cell;
-                      found_cell   = true;
+                      copy.current_cell = cell;
+                      copy.found_cell   = true;
                       break;
                     }
                 }
             }
+          copy.out_particle       = (*out_particle);
+          copy.reference_location = scratch.reference_locations[0];
+        };
 
-          if (!found_cell)
-            {
-              // We can find no cell for this particle. It has left the
-              // domain due to an integration error or an open boundary.
-              // Signal the loss and move on.
-              signals.particle_lost(out_particle,
-                                    out_particle->get_surrounding_cell());
-              continue;
-            }
+      const auto stage_two_copier = [&](const StageTwo_CopyData &copy) {
+        auto local_out_particle = copy.out_particle;
 
-          // If we are here, we found a cell and reference position for this
-          // particle
-          out_particle->set_reference_location(reference_locations[0]);
+        if (!copy.found_cell)
+          {
+            // We can find no cell for this particle. It has left the
+            // domain due to an integration error or an open boundary.
+            // Signal the loss and move on.
+            signals.particle_lost(copy.out_particle,
+                                  copy.out_particle->get_surrounding_cell());
+            return;
+          }
+        // If we are here, we found a cell and reference position for this
+        // particle
+        local_out_particle->set_reference_location(copy.reference_location);
 
+        // Re-insertion into the domain while workers are running may cause
+        // problems, we queue this for later.
+        StageTwo_QueuedData data_entry;
+        data_entry.current_cell = copy.current_cell;
+        data_entry.out_particle = copy.out_particle;
+        data_queue.push_back(data_entry);
+      };
+
+      WorkStream::run(particles_out_of_cell.begin(),
+                      particles_out_of_cell.end(),
+                      stage_two_worker,
+                      stage_two_copier,
+                      StageTwo_ScratchData(),
+                      StageTwo_CopyData(),
+                      2 * MultithreadInfo::n_threads(),
+                      64);
+
+      // Now we reinsert all queued particles.
+      for (const auto &data_entry : data_queue)
+        {
           // Reinsert the particle into our domain if we own its cell.
           // Mark it for MPI transfer otherwise
-          if (current_cell->is_locally_owned())
+          if (data_entry.current_cell->is_locally_owned())
             {
               typename PropertyPool<dim, spacedim>::Handle &old =
-                out_particle->particles_in_cell
-                  ->particles[out_particle->particle_index_within_cell];
+                data_entry.out_particle->particles_in_cell->particles
+                  [data_entry.out_particle->particle_index_within_cell];
 
               // Avoid deallocating the memory of this particle
               const auto old_value = old;
               old = PropertyPool<dim, spacedim>::invalid_handle;
 
               // Allocate particle with the old handle
-              insert_particle(old_value, current_cell);
+              insert_particle(old_value, data_entry.current_cell);
             }
           else
             {
-              moved_particles[current_cell->subdomain_id()].push_back(
-                out_particle);
-              moved_cells[current_cell->subdomain_id()].push_back(current_cell);
+              moved_particles[data_entry.current_cell->subdomain_id()]
+                .push_back(data_entry.out_particle);
+              moved_cells[data_entry.current_cell->subdomain_id()].push_back(
+                data_entry.current_cell);
             }
         }
     }


### PR DESCRIPTION
This change makes particle sorting in particle_handler.cc use WorkStream. The existing code is made with MPI in mind and so the sorting itself is not done in parallel within each MPI process. This change is advantageous in circumstances when MPI is not utilized, or when a hybrid parallelization scheme is desirable. 