### PR TITLE
Rename SmartPointer -> ObserverPointer.

### DIFF
--- a/doc/doxygen/headers/instantiations.h
+++ b/doc/doxygen/headers/instantiations.h
@@ -120,6 +120,6 @@
  *
  * These are the classes, where no reasonable predetermined set of instances
  * exists. Therefore, all member definitions are included in the header file
- * and are instantiated wherever needed.  An example would be the SmartPointer
+ * and are instantiated wherever needed.  An example would be the ObserverPointer
  * class template that can be used with virtually any template argument.
  */

--- a/doc/doxygen/headers/memory.h
+++ b/doc/doxygen/headers/memory.h
@@ -17,8 +17,8 @@
  * @defgroup memory Memory handling
  *
  * This group has some basic classes and namespaces for memory
- * handling. The Subscriptor and SmartPointer classes are used for
- * counted memory handling, i.e. whenever a SmartPointer is set to
+ * handling. The Subscriptor and ObserverPointer classes are used for
+ * counted memory handling, i.e. whenever a ObserverPointer is set to
  * point to an object, it increases a counter in that object; when the
  * pointer is set to point elsewhere, it decreases it again. This way,
  * one always knows how many users of an object there still are. While

--- a/doc/news/3.4.0-vs-4.0.0.h
+++ b/doc/news/3.4.0-vs-4.0.0.h
@@ -385,7 +385,7 @@ contributor's names are abbreviated by WB (Wolfgang Bangerth), GK
 
   <li> <p>
        Fixed: The <code>Subscriptor</code> uses a counter to
-       count how many <code>ObserverPointer</code> objects subscribe
+       count how many <code>SmartPointer</code> objects subscribe
        to the pointed-to object. This counter needs to be a volatile variable
        in multithreaded mode, to avoid false compiler optimizations based on
        the assumption that the variable cannot change between two subsequent

--- a/doc/news/3.4.0-vs-4.0.0.h
+++ b/doc/news/3.4.0-vs-4.0.0.h
@@ -385,7 +385,7 @@ contributor's names are abbreviated by WB (Wolfgang Bangerth), GK
 
   <li> <p>
        Fixed: The <code>Subscriptor</code> uses a counter to
-       count how many <code>SmartPointer</code> objects subscribe
+       count how many <code>ObserverPointer</code> objects subscribe
        to the pointed-to object. This counter needs to be a volatile variable
        in multithreaded mode, to avoid false compiler optimizations based on
        the assumption that the variable cannot change between two subsequent

--- a/doc/news/5.1.0-vs-5.2.0.h
+++ b/doc/news/5.1.0-vs-5.2.0.h
@@ -494,7 +494,7 @@ inconvenience this causes.
        New: Class <code>Subscriptor</code> receives a
        text argument allowing to identify the violating pointer more
        easily. The additional feature is being incorporated into <code
-       class="class">SmartPointer</code> constructors throughout the
+       class="class">ObserverPointer</code> constructors throughout the
        library.
        <br>
        (GK, 2005/03/16)

--- a/doc/news/5.1.0-vs-5.2.0.h
+++ b/doc/news/5.1.0-vs-5.2.0.h
@@ -494,7 +494,7 @@ inconvenience this causes.
        New: Class <code>Subscriptor</code> receives a
        text argument allowing to identify the violating pointer more
        easily. The additional feature is being incorporated into <code
-       class="class">ObserverPointer</code> constructors throughout the
+       class="class">SmartPointer</code> constructors throughout the
        library.
        <br>
        (GK, 2005/03/16)

--- a/doc/news/5.2.0-vs-6.0.0.h
+++ b/doc/news/5.2.0-vs-6.0.0.h
@@ -552,7 +552,7 @@ inconvenience this causes.
        (WB 2006/08/02)
        </p>
 
-  <li> <p> Changed: When there is still a <code>ObserverPointer</code> object
+  <li> <p> Changed: When there is still a <code>SmartPointer</code> object
        pointing to another object at the time it is destroyed, this would cause
        the program to be aborted. However, there are cases where this is not
        desirable, for example here:

--- a/doc/news/5.2.0-vs-6.0.0.h
+++ b/doc/news/5.2.0-vs-6.0.0.h
@@ -552,7 +552,7 @@ inconvenience this causes.
        (WB 2006/08/02)
        </p>
 
-  <li> <p> Changed: When there is still a <code>SmartPointer</code> object
+  <li> <p> Changed: When there is still a <code>ObserverPointer</code> object
        pointing to another object at the time it is destroyed, this would cause
        the program to be aborted. However, there are cases where this is not
        desirable, for example here:

--- a/doc/news/9.0.1-vs-9.1.0.h
+++ b/doc/news/9.0.1-vs-9.1.0.h
@@ -684,7 +684,7 @@ inconvenience this causes.
  </li>
 
  <li>
-  Changed: ObserverPointer and Subscriptor use a `std::string`
+  Changed: SmartPointer and Subscriptor use a `std::string`
   instead of a `const char *` for subscriber identification. As a result,
   subscriber strings are no longer compared by their memory address but instead
   by their content.
@@ -1287,10 +1287,10 @@ inconvenience this causes.
  </li>
 
  <li>
-  Changed: The class Subscriptor and ObserverPointer check for dangling pointers and
+  Changed: The class Subscriptor and SmartPointer check for dangling pointers and
   use-after-move. The destructor of Subscriptor doesn't signal an error when there
   is still an object subscribed to it. Instead, validity is checked when
-  dereferencing the ObserverPointer object.
+  dereferencing the SmartPointer object.
   <br>
   (Daniel Arndt, 2018/11/02)
  </li>

--- a/doc/news/9.0.1-vs-9.1.0.h
+++ b/doc/news/9.0.1-vs-9.1.0.h
@@ -684,7 +684,7 @@ inconvenience this causes.
  </li>
 
  <li>
-  Changed: SmartPointer and Subscriptor use a `std::string`
+  Changed: ObserverPointer and Subscriptor use a `std::string`
   instead of a `const char *` for subscriber identification. As a result,
   subscriber strings are no longer compared by their memory address but instead
   by their content.
@@ -1287,10 +1287,10 @@ inconvenience this causes.
  </li>
 
  <li>
-  Changed: The class Subscriptor and SmartPointer check for dangling pointers and
+  Changed: The class Subscriptor and ObserverPointer check for dangling pointers and
   use-after-move. The destructor of Subscriptor doesn't signal an error when there
   is still an object subscribed to it. Instead, validity is checked when
-  dereferencing the SmartPointer object.
+  dereferencing the ObserverPointer object.
   <br>
   (Daniel Arndt, 2018/11/02)
  </li>

--- a/doc/news/changes/major/20240909Bangerth
+++ b/doc/news/changes/major/20240909Bangerth
@@ -1,0 +1,6 @@
+Changed: The SmartPointer class has been renamed to ObserverPointer,
+since this name is a much better reflection of the purpose of this
+class. The documentation of the class has also been updated
+significantly to better explain what the class does.
+<br>
+(Wolfgang Bangerth, 2024/09/09)

--- a/doc/news/changes/minor/20240725Bangerth
+++ b/doc/news/changes/minor/20240725Bangerth
@@ -1,6 +1,6 @@
-Deprecated: SmartPointer is clearly documented as not owning the
-object it points to. Yet, SmartPointer::clear() deletes the object
-pointed to, thereby assuming that the SmartPointer object actually
+Deprecated: ObserverPointer is clearly documented as not owning the
+object it points to. Yet, ObserverPointer::clear() deletes the object
+pointed to, thereby assuming that the ObserverPointer object actually
 owns the object. This must surely be confusing. As a consequence the
 function is now deprecated.
 <br>

--- a/examples/step-13/step-13.cc
+++ b/examples/step-13/step-13.cc
@@ -469,7 +469,7 @@ namespace Step13
     // a triangulation in the constructor and storing it henceforth. Since
     // this triangulation will be used throughout all computations, we have to
     // make sure that the triangulation is valid until it is last used. We
-    // do this by keeping a <code>SmartPointer</code> to this triangulation,
+    // do this by keeping a <code>ObserverPointer</code> to this triangulation,
     // as explained in step-7.
     //
     // Note that while the pointer itself is declared constant
@@ -496,7 +496,7 @@ namespace Step13
       virtual unsigned int n_dofs() const                           = 0;
 
     protected:
-      const SmartPointer<Triangulation<dim>> triangulation;
+      const ObserverPointer<Triangulation<dim>> triangulation;
     };
 
 
@@ -568,11 +568,11 @@ namespace Step13
       // member variables, of which the use should be clear from the previous
       // examples:
     protected:
-      const SmartPointer<const FiniteElement<dim>> fe;
-      const SmartPointer<const Quadrature<dim>>    quadrature;
-      DoFHandler<dim>                              dof_handler;
-      Vector<double>                               solution;
-      const SmartPointer<const Function<dim>>      boundary_values;
+      const ObserverPointer<const FiniteElement<dim>> fe;
+      const ObserverPointer<const Quadrature<dim>>    quadrature;
+      DoFHandler<dim>                                 dof_handler;
+      Vector<double>                                  solution;
+      const ObserverPointer<const Function<dim>>      boundary_values;
 
       // Then we declare an abstract function that will be used to assemble
       // the right hand side. As explained above, there are various cases for
@@ -996,7 +996,7 @@ namespace Step13
     // constructor takes the same data as does that of the underlying class
     // (to which it passes all information) except for one function object
     // that denotes the right hand side of the problem. A pointer to this
-    // object is stored (again as a <code>SmartPointer</code>, in order to
+    // object is stored (again as a <code>ObserverPointer</code>, in order to
     // make sure that the function object is not deleted as long as it is
     // still used by this class).
     //
@@ -1013,7 +1013,7 @@ namespace Step13
                    const Function<dim>      &boundary_values);
 
     protected:
-      const SmartPointer<const Function<dim>> rhs_function;
+      const ObserverPointer<const Function<dim>> rhs_function;
       virtual void assemble_rhs(Vector<double> &rhs) const override;
     };
 

--- a/examples/step-14/step-14.cc
+++ b/examples/step-14/step-14.cc
@@ -355,7 +355,7 @@ namespace Step14
       virtual void output_solution() const = 0;
 
     protected:
-      const SmartPointer<Triangulation<dim>> triangulation;
+      const ObserverPointer<Triangulation<dim>> triangulation;
 
       unsigned int refinement_cycle;
     };
@@ -399,12 +399,12 @@ namespace Step14
       virtual unsigned int n_dofs() const override;
 
     protected:
-      const SmartPointer<const FiniteElement<dim>>  fe;
-      const SmartPointer<const Quadrature<dim>>     quadrature;
-      const SmartPointer<const Quadrature<dim - 1>> face_quadrature;
-      DoFHandler<dim>                               dof_handler;
-      Vector<double>                                solution;
-      const SmartPointer<const Function<dim>>       boundary_values;
+      const ObserverPointer<const FiniteElement<dim>>  fe;
+      const ObserverPointer<const Quadrature<dim>>     quadrature;
+      const ObserverPointer<const Quadrature<dim - 1>> face_quadrature;
+      DoFHandler<dim>                                  dof_handler;
+      Vector<double>                                   solution;
+      const ObserverPointer<const Function<dim>>       boundary_values;
 
       virtual void assemble_rhs(Vector<double> &rhs) const = 0;
 
@@ -709,7 +709,7 @@ namespace Step14
       virtual void output_solution() const override;
 
     protected:
-      const SmartPointer<const Function<dim>> rhs_function;
+      const ObserverPointer<const Function<dim>> rhs_function;
       virtual void assemble_rhs(Vector<double> &rhs) const override;
     };
 
@@ -913,7 +913,7 @@ namespace Step14
       virtual void refine_grid() override;
 
     private:
-      const SmartPointer<const Function<dim>> weighting_function;
+      const ObserverPointer<const Function<dim>> weighting_function;
     };
 
 
@@ -1051,7 +1051,7 @@ namespace Step14
     // @sect4{The SetUpBase and SetUp classes}
 
     // Based on the above description, the <code>SetUpBase</code> class then
-    // looks as follows. To allow using the <code>SmartPointer</code> class
+    // looks as follows. To allow using the <code>ObserverPointer</code> class
     // with this class, we derived from the <code>Subscriptor</code> class.
     template <int dim>
     struct SetUpBase : public Subscriptor
@@ -1624,7 +1624,7 @@ namespace Step14
         const DualFunctional::DualFunctionalBase<dim> &dual_functional);
 
     protected:
-      const SmartPointer<const DualFunctional::DualFunctionalBase<dim>>
+      const ObserverPointer<const DualFunctional::DualFunctionalBase<dim>>
                    dual_functional;
       virtual void assemble_rhs(Vector<double> &rhs) const override;
 
@@ -1757,8 +1757,8 @@ namespace Step14
       // that will serve as the "scratch data" class of the WorkStream concept:
       struct CellData
       {
-        FEValues<dim>                           fe_values;
-        const SmartPointer<const Function<dim>> right_hand_side;
+        FEValues<dim>                              fe_values;
+        const ObserverPointer<const Function<dim>> right_hand_side;
 
         std::vector<double> cell_residual;
         std::vector<double> rhs_values;

--- a/examples/step-21/step-21.cc
+++ b/examples/step-21/step-21.cc
@@ -428,7 +428,7 @@ namespace Step21
     }
 
   private:
-    const SmartPointer<const MatrixType> matrix;
+    const ObserverPointer<const MatrixType> matrix;
   };
 
 
@@ -452,8 +452,8 @@ namespace Step21
     }
 
   private:
-    const SmartPointer<const BlockSparseMatrix<double>>           system_matrix;
-    const SmartPointer<const InverseMatrix<SparseMatrix<double>>> m_inverse;
+    const ObserverPointer<const BlockSparseMatrix<double>> system_matrix;
+    const ObserverPointer<const InverseMatrix<SparseMatrix<double>>> m_inverse;
 
     mutable Vector<double> tmp1, tmp2;
   };
@@ -477,7 +477,7 @@ namespace Step21
     }
 
   private:
-    const SmartPointer<const BlockSparseMatrix<double>> system_matrix;
+    const ObserverPointer<const BlockSparseMatrix<double>> system_matrix;
 
     mutable Vector<double> tmp1, tmp2;
   };

--- a/examples/step-22/doc/results.dox
+++ b/examples/step-22/doc/results.dox
@@ -418,8 +418,8 @@ class BlockSchurPreconditioner : public Subscriptor
               const BlockVector<double> &src) const;
 
   private:
-    const SmartPointer<const BlockSparseMatrix<double> > system_matrix;
-    const SmartPointer<const InverseMatrix<SparseMatrix<double>,
+    const ObserverPointer<const BlockSparseMatrix<double> > system_matrix;
+    const ObserverPointer<const InverseMatrix<SparseMatrix<double>,
                        PreconditionerMp > > m_inverse;
     const PreconditionerA &a_preconditioner;
 

--- a/examples/step-22/step-22.cc
+++ b/examples/step-22/step-22.cc
@@ -288,8 +288,8 @@ namespace Step22
     void vmult(Vector<double> &dst, const Vector<double> &src) const;
 
   private:
-    const SmartPointer<const MatrixType>         matrix;
-    const SmartPointer<const PreconditionerType> preconditioner;
+    const ObserverPointer<const MatrixType>         matrix;
+    const ObserverPointer<const PreconditionerType> preconditioner;
   };
 
 
@@ -335,7 +335,7 @@ namespace Step22
   // consequence of the definition above, the declaration
   // <code>InverseMatrix</code> now contains the second template parameter for
   // a preconditioner class as above, which affects the
-  // <code>SmartPointer</code> object <code>m_inverse</code> as well.
+  // <code>ObserverPointer</code> object <code>m_inverse</code> as well.
   template <class PreconditionerType>
   class SchurComplement : public Subscriptor
   {
@@ -347,8 +347,8 @@ namespace Step22
     void vmult(Vector<double> &dst, const Vector<double> &src) const;
 
   private:
-    const SmartPointer<const BlockSparseMatrix<double>> system_matrix;
-    const SmartPointer<
+    const ObserverPointer<const BlockSparseMatrix<double>> system_matrix;
+    const ObserverPointer<
       const InverseMatrix<SparseMatrix<double>, PreconditionerType>>
       A_inverse;
 

--- a/examples/step-31/step-31.cc
+++ b/examples/step-31/step-31.cc
@@ -253,8 +253,8 @@ namespace Step31
       void vmult(VectorType &dst, const VectorType &src) const;
 
     private:
-      const SmartPointer<const MatrixType> matrix;
-      const PreconditionerType            &preconditioner;
+      const ObserverPointer<const MatrixType> matrix;
+      const PreconditionerType               &preconditioner;
     };
 
 
@@ -355,10 +355,10 @@ namespace Step31
                  const TrilinosWrappers::MPI::BlockVector &src) const;
 
     private:
-      const SmartPointer<const TrilinosWrappers::BlockSparseMatrix>
+      const ObserverPointer<const TrilinosWrappers::BlockSparseMatrix>
         stokes_matrix;
-      const SmartPointer<const InverseMatrix<TrilinosWrappers::SparseMatrix,
-                                             PreconditionerTypeMp>>
+      const ObserverPointer<const InverseMatrix<TrilinosWrappers::SparseMatrix,
+                                                PreconditionerTypeMp>>
                                  m_inverse;
       const PreconditionerTypeA &a_preconditioner;
 

--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -277,9 +277,9 @@ namespace Step32
       }
 
     private:
-      const SmartPointer<const TrilinosWrappers::BlockSparseMatrix>
+      const ObserverPointer<const TrilinosWrappers::BlockSparseMatrix>
         stokes_matrix;
-      const SmartPointer<const TrilinosWrappers::BlockSparseMatrix>
+      const ObserverPointer<const TrilinosWrappers::BlockSparseMatrix>
                                   stokes_preconditioner_matrix;
       const PreconditionerTypeMp &mp_preconditioner;
       const PreconditionerTypeA  &a_preconditioner;

--- a/examples/step-34/step-34.cc
+++ b/examples/step-34/step-34.cc
@@ -21,7 +21,7 @@
 // The program starts with including a bunch of include files that we will use
 // in the various parts of the program. Most of them have been discussed in
 // previous tutorials already:
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/convergence_table.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/quadrature_selector.h>

--- a/examples/step-39/step-39.cc
+++ b/examples/step-39/step-39.cc
@@ -620,7 +620,7 @@ namespace Step39
     mg_matrix_dg_down.clear_elements();
     // It is important to update the sparsity patterns after <tt>clear()</tt>
     // was called for the level matrices, since the matrices lock the sparsity
-    // pattern through the SmartPointer and Subscriptor mechanism.
+    // pattern through the ObserverPointer and Subscriptor mechanism.
     mg_sparsity.resize(0, n_levels - 1);
     mg_sparsity_dg_interface.resize(0, n_levels - 1);
 

--- a/examples/step-43/step-43.cc
+++ b/examples/step-43/step-43.cc
@@ -329,8 +329,8 @@ namespace Step43
       void vmult(VectorType &dst, const VectorType &src) const;
 
     private:
-      const SmartPointer<const MatrixType> matrix;
-      const PreconditionerType            &preconditioner;
+      const ObserverPointer<const MatrixType> matrix;
+      const PreconditionerType               &preconditioner;
     };
 
 
@@ -379,10 +379,10 @@ namespace Step43
                  const TrilinosWrappers::MPI::BlockVector &src) const;
 
     private:
-      const SmartPointer<const TrilinosWrappers::BlockSparseMatrix>
+      const ObserverPointer<const TrilinosWrappers::BlockSparseMatrix>
         darcy_matrix;
-      const SmartPointer<const InverseMatrix<TrilinosWrappers::SparseMatrix,
-                                             PreconditionerTypeMp>>
+      const ObserverPointer<const InverseMatrix<TrilinosWrappers::SparseMatrix,
+                                                PreconditionerTypeMp>>
                                  m_inverse;
       const PreconditionerTypeA &a_preconditioner;
 

--- a/examples/step-45/step-45.cc
+++ b/examples/step-45/step-45.cc
@@ -197,8 +197,8 @@ namespace Step45
                const TrilinosWrappers::MPI::Vector &src) const;
 
   private:
-    const SmartPointer<const MatrixType>         matrix;
-    const SmartPointer<const PreconditionerType> preconditioner;
+    const ObserverPointer<const MatrixType>         matrix;
+    const ObserverPointer<const PreconditionerType> preconditioner;
 
     mutable TrilinosWrappers::MPI::Vector tmp;
   };
@@ -248,8 +248,9 @@ namespace Step45
                const TrilinosWrappers::MPI::Vector &src) const;
 
   private:
-    const SmartPointer<const TrilinosWrappers::BlockSparseMatrix> system_matrix;
-    const SmartPointer<
+    const ObserverPointer<const TrilinosWrappers::BlockSparseMatrix>
+      system_matrix;
+    const ObserverPointer<
       const InverseMatrix<TrilinosWrappers::SparseMatrix, PreconditionerType>>
                                           A_inverse;
     mutable TrilinosWrappers::MPI::Vector tmp1, tmp2;

--- a/examples/step-55/step-55.cc
+++ b/examples/step-55/step-55.cc
@@ -106,8 +106,8 @@ namespace Step55
       void vmult(VectorType &dst, const VectorType &src) const;
 
     private:
-      const SmartPointer<const Matrix> matrix;
-      const Preconditioner            &preconditioner;
+      const ObserverPointer<const Matrix> matrix;
+      const Preconditioner               &preconditioner;
     };
 
 

--- a/examples/step-59/step-59.cc
+++ b/examples/step-59/step-59.cc
@@ -149,7 +149,7 @@ namespace Step59
   // general-purpose class MatrixFreeOperators::Base. We derive the class from
   // the Subscriptor class to be able to use the operator within the Chebyshev
   // preconditioner because that preconditioner stores the underlying matrix
-  // via a SmartPointer.
+  // via a ObserverPointer.
   //
   // Given that we implement a complete matrix interface by hand, we need to
   // add an `initialize()` function, an `m()` function, a `vmult()` function,

--- a/examples/step-69/step-69.cc
+++ b/examples/step-69/step-69.cc
@@ -239,7 +239,7 @@ namespace Step69
     const MPI_Comm mpi_communicator;
     TimerOutput   &computing_timer;
 
-    SmartPointer<const Discretization<dim>> discretization;
+    ObserverPointer<const Discretization<dim>> discretization;
   };
 
   // @sect4{The <code>ProblemDescription</code> class}
@@ -401,8 +401,8 @@ namespace Step69
     const MPI_Comm mpi_communicator;
     TimerOutput   &computing_timer;
 
-    SmartPointer<const OfflineData<dim>>   offline_data;
-    SmartPointer<const InitialValues<dim>> initial_values;
+    ObserverPointer<const OfflineData<dim>>   offline_data;
+    ObserverPointer<const InitialValues<dim>> initial_values;
 
     SparseMatrix<double> dij_matrix;
 
@@ -454,7 +454,7 @@ namespace Step69
     const MPI_Comm mpi_communicator;
     TimerOutput   &computing_timer;
 
-    SmartPointer<const OfflineData<dim>> offline_data;
+    ObserverPointer<const OfflineData<dim>> offline_data;
 
     Vector<double> r;
 

--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -45,7 +45,7 @@
 // Then we will show a little trick how we can make sure that objects are not
 // deleted while they are still in use. For this purpose, deal.II has the
 // ObserverPointer helper class, which is declared in this file:
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 // Next, we will want to use the function VectorTools::integrate_difference()
 // mentioned in the introduction, and we are going to use a ConvergenceTable
 // that collects all important data during a run and prints it at the end as a

--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -44,7 +44,7 @@
 #include <deal.II/dofs/dof_renumbering.h>
 // Then we will show a little trick how we can make sure that objects are not
 // deleted while they are still in use. For this purpose, deal.II has the
-// SmartPointer helper class, which is declared in this file:
+// ObserverPointer helper class, which is declared in this file:
 #include <deal.II/base/smartpointer.h>
 // Next, we will want to use the function VectorTools::integrate_difference()
 // mentioned in the introduction, and we are going to use a ConvergenceTable
@@ -379,9 +379,9 @@ namespace Step7
     // subscribing class is expected to check the value stored in its
     // corresponding pointer before trying to access the object subscribed to.
     //
-    // This is exactly what the SmartPointer class is doing. It basically acts
-    // just like a pointer, i.e. it can be dereferenced, can be assigned to and
-    // from other pointers, and so on. On top of that it uses the mechanism
+    // This is exactly what the ObserverPointer class is doing. It basically
+    // acts just like a pointer, i.e. it can be dereferenced, can be assigned to
+    // and from other pointers, and so on. On top of that it uses the mechanism
     // described above to find out if the pointer this class is representing is
     // dangling when we try to dereference it. In that case an exception is
     // thrown.
@@ -389,9 +389,9 @@ namespace Step7
     // In the present example program, we want to protect the finite element
     // object from the situation that for some reason the finite element
     // pointed to is destroyed while still in use. We therefore use a
-    // SmartPointer to the finite element object; since the finite element
+    // ObserverPointer to the finite element object; since the finite element
     // object is actually never changed in our computations, we pass a const
-    // FiniteElement&lt;dim&gt; as template argument to the SmartPointer
+    // FiniteElement&lt;dim&gt; as template argument to the ObserverPointer
     // class. Note that the pointer so declared is assigned at construction
     // time of the solve object, and destroyed upon destruction, so the lock
     // on the destruction of the finite element object extends throughout the
@@ -399,7 +399,7 @@ namespace Step7
     Triangulation<dim> triangulation;
     DoFHandler<dim>    dof_handler;
 
-    SmartPointer<const FiniteElement<dim>> fe;
+    ObserverPointer<const FiniteElement<dim>> fe;
 
     AffineConstraints<double> hanging_node_constraints;
 

--- a/include/deal.II/algorithms/newton.h
+++ b/include/deal.II/algorithms/newton.h
@@ -123,18 +123,18 @@ namespace Algorithms
     /**
      * The operator computing the residual.
      */
-    SmartPointer<OperatorBase, Newton<VectorType>> residual;
+    ObserverPointer<OperatorBase, Newton<VectorType>> residual;
 
     /**
      * The operator applying the inverse derivative to the residual.
      */
-    SmartPointer<OperatorBase, Newton<VectorType>> inverse_derivative;
+    ObserverPointer<OperatorBase, Newton<VectorType>> inverse_derivative;
 
     /**
      * The operator handling the output in case the debug_vectors is true.
      * Call the initialize function first.
      */
-    SmartPointer<OutputOperator<VectorType>, Newton<VectorType>> data_out;
+    ObserverPointer<OutputOperator<VectorType>, Newton<VectorType>> data_out;
 
     /**
      * This flag is set by the function assemble(), indicating that the matrix

--- a/include/deal.II/algorithms/newton.h
+++ b/include/deal.II/algorithms/newton.h
@@ -21,7 +21,7 @@
 #include <deal.II/algorithms/any_data.h>
 #include <deal.II/algorithms/operator.h>
 
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/lac/solver_control.h>
 

--- a/include/deal.II/algorithms/theta_timestepping.h
+++ b/include/deal.II/algorithms/theta_timestepping.h
@@ -129,7 +129,7 @@ namespace Algorithms
    * them <code>Implicit</code> and <code>Explicit</code>. They both share the
    * public interface of Operator, and additionally provide storage for the
    * matrices to be used and a pointer to TimestepData. Note that we do not
-   * use a SmartPointer here, since the TimestepData will be destroyed before
+   * use a ObserverPointer here, since the TimestepData will be destroyed before
    * the operator.
    *
    * @code
@@ -140,7 +140,7 @@ namespace Algorithms
    *   void operator()(AnyData &out, const AnyData &in);
    *
    * private:
-   *   SmartPointer<const FullMatrix<double>, Explicit> matrix;
+   *   ObserverPointer<const FullMatrix<double>, Explicit> matrix;
    *   FullMatrix<double>                               m;
    * };
    *
@@ -151,7 +151,7 @@ namespace Algorithms
    *   void operator()(AnyData &out, const AnyData &in);
    *
    * private:
-   *   SmartPointer<const FullMatrix<double>, Implicit> matrix;
+   *   ObserverPointer<const FullMatrix<double>, Implicit> matrix;
    *   FullMatrix<double>                               m;
    * };
    * @endcode
@@ -412,7 +412,7 @@ namespace Algorithms
      * vector, $M$ the @ref GlossMassMatrix "mass matrix", $F$ the operator in space and $c$ is the
      * adjusted time step size $(1-\theta) \Delta t$.
      */
-    SmartPointer<OperatorBase, ThetaTimestepping<VectorType>> op_explicit;
+    ObserverPointer<OperatorBase, ThetaTimestepping<VectorType>> op_explicit;
 
     /**
      * The operator solving the implicit part of the scheme. It will receive
@@ -424,12 +424,12 @@ namespace Algorithms
      * the input data, <i>M</i> the @ref GlossMassMatrix "mass matrix", <i>F</i> the operator in
      * space and <i>c</i> is the adjusted time step size $ \theta \Delta t$
      */
-    SmartPointer<OperatorBase, ThetaTimestepping<VectorType>> op_implicit;
+    ObserverPointer<OperatorBase, ThetaTimestepping<VectorType>> op_implicit;
 
     /**
      * The operator writing the output in each time step
      */
-    SmartPointer<OutputOperator<VectorType>, ThetaTimestepping<VectorType>>
+    ObserverPointer<OutputOperator<VectorType>, ThetaTimestepping<VectorType>>
       output;
   };
 

--- a/include/deal.II/algorithms/theta_timestepping.h
+++ b/include/deal.II/algorithms/theta_timestepping.h
@@ -21,7 +21,7 @@
 #include <deal.II/algorithms/operator.h>
 #include <deal.II/algorithms/timestep_control.h>
 
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/algorithms/timestep_control.h
+++ b/include/deal.II/algorithms/timestep_control.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/subscriptor.h>
 
 #include <deal.II/lac/vector_memory.h>

--- a/include/deal.II/base/function_lib.h
+++ b/include/deal.II/base/function_lib.h
@@ -19,8 +19,8 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/function.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/point.h>
-#include <deal.II/base/smartpointer.h>
 #include <deal.II/base/table.h>
 
 #include <array>

--- a/include/deal.II/base/function_restriction.h
+++ b/include/deal.II/base/function_restriction.h
@@ -16,8 +16,8 @@
 #define dealii_function_restriction_h
 
 #include <deal.II/base/function.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/point.h>
-#include <deal.II/base/smartpointer.h>
 #include <deal.II/base/tensor.h>
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/base/function_restriction.h
+++ b/include/deal.II/base/function_restriction.h
@@ -74,7 +74,7 @@ namespace Functions
 
   private:
     // The higher-dimensional function that has been restricted.
-    const SmartPointer<const Function<dim + 1>> function;
+    const ObserverPointer<const Function<dim + 1>> function;
 
     // The (`dim + 1`)-coordinate direction that has been restricted.
     const unsigned int restricted_direction;
@@ -133,7 +133,7 @@ namespace Functions
 
   private:
     // The higher-dimensional function that has been restricted.
-    const SmartPointer<const Function<dim + 1>> function;
+    const ObserverPointer<const Function<dim + 1>> function;
 
     // The (`dim + 1`)-coordinate direction that is kept "open"
     const unsigned int open_direction;

--- a/include/deal.II/base/logstream.h
+++ b/include/deal.II/base/logstream.h
@@ -122,7 +122,7 @@ public:
      * A pointer to the LogStream object to which the prefix is
      * applied.
      */
-    SmartPointer<LogStream, LogStream::Prefix> stream;
+    ObserverPointer<LogStream, LogStream::Prefix> stream;
   };
 
 

--- a/include/deal.II/base/logstream.h
+++ b/include/deal.II/base/logstream.h
@@ -18,7 +18,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/subscriptor.h>
 #include <deal.II/base/thread_local_storage.h>
 

--- a/include/deal.II/base/mpi_remote_point_evaluation.h
+++ b/include/deal.II/base/mpi_remote_point_evaluation.h
@@ -438,12 +438,12 @@ namespace Utilities
       /**
        * Reference to the Triangulation object used during reinit().
        */
-      SmartPointer<const Triangulation<dim, spacedim>> tria;
+      ObserverPointer<const Triangulation<dim, spacedim>> tria;
 
       /**
        * Reference to the Mapping object used during reinit().
        */
-      SmartPointer<const Mapping<dim, spacedim>> mapping;
+      ObserverPointer<const Mapping<dim, spacedim>> mapping;
 
       /**
        * (One-to-one) relation of points and cells.

--- a/include/deal.II/base/observer_pointer.h
+++ b/include/deal.II/base/observer_pointer.h
@@ -12,8 +12,8 @@
 //
 // ------------------------------------------------------------------------
 
-#ifndef dealii_smartpointer_h
-#define dealii_smartpointer_h
+#ifndef dealii_observer_pointer_h
+#define dealii_observer_pointer_h
 
 
 #include <deal.II/base/config.h>

--- a/include/deal.II/base/parameter_acceptor.h
+++ b/include/deal.II/base/parameter_acceptor.h
@@ -18,8 +18,8 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/parameter_handler.h>
-#include <deal.II/base/smartpointer.h>
 
 #include <boost/signals2/signal.hpp>
 

--- a/include/deal.II/base/polynomial_space.h
+++ b/include/deal.II/base/polynomial_space.h
@@ -20,10 +20,10 @@
 
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/ndarray.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/scalar_polynomials_base.h>
-#include <deal.II/base/smartpointer.h>
 #include <deal.II/base/tensor.h>
 
 #include <vector>

--- a/include/deal.II/base/quadrature_point_data.h
+++ b/include/deal.II/base/quadrature_point_data.h
@@ -91,7 +91,7 @@ public:
    * may reflect, for example, different constitutive models of continuum
    * mechanics in different parts of the domain.
    *
-   * @note The first time this method is called, it stores a SmartPointer to the
+   * @note The first time this method is called, it stores a ObserverPointer to the
    * Triangulation object that owns the cell. The future invocations of this
    * method expects the cell to be from the same stored triangulation.
    *
@@ -227,8 +227,8 @@ private:
    * Triangulation, we need to store a reference to that Triangulation within
    * the class.
    */
-  SmartPointer<const Triangulation<dimension, space_dimension>,
-               CellDataStorage<CellIteratorType, DataType>>
+  ObserverPointer<const Triangulation<dimension, space_dimension>,
+                  CellDataStorage<CellIteratorType, DataType>>
     tria;
 
   /**

--- a/include/deal.II/base/smartpointer.h
+++ b/include/deal.II/base/smartpointer.h
@@ -1,0 +1,35 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 1998 - 2023 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#ifndef dealii_smartpointer_h
+#define dealii_smartpointer_h
+
+
+#include <deal.II/base/observer_pointer.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+/**
+ * A type alias for the ObserverPointer class that makes sure the previous
+ * name of the class, SmartPointer, continues to be available.
+ *
+ * @deprecated Use the new name of the class, ObserverPointer, instead.
+ */
+template <typename T, typename P = void>
+using SmartPointer DEAL_II_DEPRECATED_EARLY_WITH_COMMENT(
+  "Use the new name of the class, ObserverPointer.") = ObserverPointer<T, P>;
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/include/deal.II/base/subscriptor.h
+++ b/include/deal.II/base/subscriptor.h
@@ -39,8 +39,9 @@ DEAL_II_NAMESPACE_OPEN
  * moved from or destroyed.
  * The mechanism works as follows: The member function subscribe() accepts a
  * pointer to a boolean that is modified on invalidation. The object that owns
- * this pointer (usually an object of class type SmartPointer) is then expected
- * to check the state of the boolean before trying to access this class.
+ * this pointer (usually an object of class type ObserverPointer) is then
+ * expected to check the state of the boolean before trying to access this
+ * class.
  *
  * The utility of this class is even enhanced by providing identifying strings
  * to the functions subscribe() and unsubscribe(). These strings are represented
@@ -50,7 +51,7 @@ DEAL_II_NAMESPACE_OPEN
  * <code>x</code> is some object. Therefore, the pointers provided to
  * subscribe() and to unsubscribe() must be the same. Strings with equal
  * contents will not be recognized to be the same. The handling in
- * SmartPointer will take care of this.
+ * ObserverPointer will take care of this.
  * The current subscribers to this class can be obtained by calling
  * list_subscribers().
  *
@@ -104,7 +105,7 @@ public:
    * @name Subscriptor functionality
    *
    * Classes derived from Subscriptor provide a facility to subscribe to this
-   * object. This is mostly used by the SmartPointer class.
+   * object. This is mostly used by the ObserverPointer class.
    * @{
    */
 
@@ -234,8 +235,8 @@ private:
   using map_iterator = decltype(counter_map)::iterator;
 
   /**
-   * In this vector, we store pointers to the validity bool in the SmartPointer
-   * objects that subscribe to this class.
+   * In this vector, we store pointers to the validity bool in the
+   * ObserverPointer objects that subscribe to this class.
    */
   mutable std::vector<std::atomic<bool> *> validity_pointers;
 

--- a/include/deal.II/base/tensor_function.h
+++ b/include/deal.II/base/tensor_function.h
@@ -21,8 +21,8 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/function.h>
 #include <deal.II/base/function_time.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/point.h>
-#include <deal.II/base/smartpointer.h>
 #include <deal.II/base/subscriptor.h>
 
 #include <vector>

--- a/include/deal.II/distributed/cell_data_transfer.h
+++ b/include/deal.II/distributed/cell_data_transfer.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/distributed/tria.h>
 

--- a/include/deal.II/distributed/cell_data_transfer.h
+++ b/include/deal.II/distributed/cell_data_transfer.h
@@ -235,8 +235,8 @@ namespace parallel
       /**
        * Pointer to the triangulation to work with.
        */
-      SmartPointer<const parallel::distributed::Triangulation<dim, spacedim>,
-                   CellDataTransfer<dim, spacedim, VectorType>>
+      ObserverPointer<const parallel::distributed::Triangulation<dim, spacedim>,
+                      CellDataTransfer<dim, spacedim, VectorType>>
         triangulation;
 
       /**

--- a/include/deal.II/distributed/fully_distributed_tria.h
+++ b/include/deal.II/distributed/fully_distributed_tria.h
@@ -306,7 +306,7 @@ namespace parallel
       /**
        * Partitioner used during repartition().
        */
-      SmartPointer<const RepartitioningPolicyTools::Base<dim, spacedim>>
+      ObserverPointer<const RepartitioningPolicyTools::Base<dim, spacedim>>
         partitioner_distributed;
 
       /**

--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -571,7 +571,7 @@ namespace internal
         /**
          * The modified parallel::shared::Triangulation.
          */
-        const SmartPointer<
+        const ObserverPointer<
           const dealii::parallel::shared::Triangulation<dim, spacedim>>
           shared_tria;
 

--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -19,7 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/mpi_stub.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/subscriptor.h>
 #include <deal.II/base/template_constraints.h>
 

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -1139,7 +1139,7 @@ namespace parallel
       /**
        * The modified parallel::distributed::Triangulation.
        */
-      const SmartPointer<
+      const ObserverPointer<
         dealii::parallel::distributed::Triangulation<dim, spacedim>>
         distributed_tria;
 

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -19,7 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/mpi_stub.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/subscriptor.h>
 #include <deal.II/base/template_constraints.h>
 

--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -19,8 +19,8 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/mpi_stub.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/partitioner.h>
-#include <deal.II/base/smartpointer.h>
 #include <deal.II/base/subscriptor.h>
 #include <deal.II/base/template_constraints.h>
 

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -23,7 +23,7 @@
 #include <deal.II/base/function.h>
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/iterator_range.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/types.h>
 
 #include <deal.II/dofs/block_info.h>

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -1491,7 +1491,7 @@ private:
   /**
    * Address of the triangulation to work on.
    */
-  SmartPointer<const Triangulation<dim, spacedim>, DoFHandler<dim, spacedim>>
+  ObserverPointer<const Triangulation<dim, spacedim>, DoFHandler<dim, spacedim>>
     tria;
 
   /**

--- a/include/deal.II/dofs/dof_handler_policy.h
+++ b/include/deal.II/dofs/dof_handler_policy.h
@@ -145,7 +145,7 @@ namespace internal
         /**
          * The DoFHandler object on which this policy object works.
          */
-        SmartPointer<DoFHandler<dim, spacedim>> dof_handler;
+        ObserverPointer<DoFHandler<dim, spacedim>> dof_handler;
       };
 
 
@@ -205,7 +205,7 @@ namespace internal
         /**
          * The DoFHandler object on which this policy object works.
          */
-        SmartPointer<DoFHandler<dim, spacedim>> dof_handler;
+        ObserverPointer<DoFHandler<dim, spacedim>> dof_handler;
       };
 
 
@@ -247,7 +247,7 @@ namespace internal
         /**
          * The DoFHandler object on which this policy object works.
          */
-        SmartPointer<DoFHandler<dim, spacedim>> dof_handler;
+        ObserverPointer<DoFHandler<dim, spacedim>> dof_handler;
       };
     } // namespace Policy
   }   // namespace DoFHandlerImplementation

--- a/include/deal.II/fe/fe_coupling_values.h
+++ b/include/deal.II/fe/fe_coupling_values.h
@@ -1034,12 +1034,12 @@ private:
   /**
    * Pointer to first FEValuesBase object.
    */
-  SmartPointer<const FEValuesBase<dim1, spacedim>> first_fe_values;
+  ObserverPointer<const FEValuesBase<dim1, spacedim>> first_fe_values;
 
   /**
    * Pointer to second FEValuesBase object.
    */
-  SmartPointer<const FEValuesBase<dim2, spacedim>> second_fe_values;
+  ObserverPointer<const FEValuesBase<dim2, spacedim>> second_fe_values;
 
   /**
    * Renumbering data for the first FEValuesBase object.

--- a/include/deal.II/fe/fe_series.h
+++ b/include/deal.II/fe/fe_series.h
@@ -182,7 +182,7 @@ namespace FESeries
     /**
      * hp::FECollection for which transformation matrices will be calculated.
      */
-    SmartPointer<const hp::FECollection<dim, spacedim>> fe_collection;
+    ObserverPointer<const hp::FECollection<dim, spacedim>> fe_collection;
 
     /**
      * hp::QCollection used in calculation of transformation matrices.
@@ -352,7 +352,7 @@ namespace FESeries
     /**
      * hp::FECollection for which transformation matrices will be calculated.
      */
-    SmartPointer<const hp::FECollection<dim, spacedim>> fe_collection;
+    ObserverPointer<const hp::FECollection<dim, spacedim>> fe_collection;
 
     /**
      * hp::QCollection used in calculation of transformation matrices.

--- a/include/deal.II/fe/fe_values_base.h
+++ b/include/deal.II/fe/fe_values_base.h
@@ -1698,7 +1698,8 @@ protected:
   /**
    * A pointer to the mapping object associated with this FEValues object.
    */
-  const SmartPointer<const Mapping<dim, spacedim>, FEValuesBase<dim, spacedim>>
+  const ObserverPointer<const Mapping<dim, spacedim>,
+                        FEValuesBase<dim, spacedim>>
     mapping;
 
   /**
@@ -1720,8 +1721,8 @@ protected:
    * A pointer to the finite element object associated with this FEValues
    * object.
    */
-  const SmartPointer<const FiniteElement<dim, spacedim>,
-                     FEValuesBase<dim, spacedim>>
+  const ObserverPointer<const FiniteElement<dim, spacedim>,
+                        FEValuesBase<dim, spacedim>>
     fe;
 
   /**

--- a/include/deal.II/fe/fe_values_views.h
+++ b/include/deal.II/fe/fe_values_views.h
@@ -19,7 +19,7 @@
 
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/lazy.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/symmetric_tensor.h>
 #include <deal.II/base/tensor.h>
 

--- a/include/deal.II/fe/fe_values_views.h
+++ b/include/deal.II/fe/fe_values_views.h
@@ -548,7 +548,7 @@ namespace FEValuesViews
     /**
      * A pointer to the FEValuesBase object we operate on.
      */
-    SmartPointer<const FEValuesBase<dim, spacedim>> fe_values;
+    ObserverPointer<const FEValuesBase<dim, spacedim>> fe_values;
 
     /**
      * The single scalar component this view represents of the FEValuesBase
@@ -1271,7 +1271,7 @@ namespace FEValuesViews
     /**
      * A pointer to the FEValuesBase object we operate on.
      */
-    SmartPointer<const FEValuesBase<dim, spacedim>> fe_values;
+    ObserverPointer<const FEValuesBase<dim, spacedim>> fe_values;
 
     /**
      * The first component of the vector this view represents of the
@@ -1584,7 +1584,7 @@ namespace FEValuesViews
     /**
      * A pointer to the FEValuesBase object we operate on.
      */
-    SmartPointer<const FEValuesBase<dim, spacedim>> fe_values;
+    ObserverPointer<const FEValuesBase<dim, spacedim>> fe_values;
 
     /**
      * The first component of the vector this view represents of the
@@ -1958,7 +1958,7 @@ namespace FEValuesViews
     /**
      * A pointer to the FEValuesBase object we operate on.
      */
-    SmartPointer<const FEValuesBase<dim, spacedim>> fe_values;
+    ObserverPointer<const FEValuesBase<dim, spacedim>> fe_values;
 
     /**
      * The first component of the vector this view represents of the

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -367,7 +367,7 @@ public:
     /**
      * A pointer to the underlying finite element.
      */
-    SmartPointer<const FiniteElement<dim, spacedim>> fe;
+    ObserverPointer<const FiniteElement<dim, spacedim>> fe;
 
     /**
      * Values of shape functions. Access by function @p shape.
@@ -570,15 +570,15 @@ protected:
   /**
    * Reference to the vector of shifts.
    */
-  std::vector<
-    SmartPointer<const VectorType, MappingFEField<dim, spacedim, VectorType>>>
+  std::vector<ObserverPointer<const VectorType,
+                              MappingFEField<dim, spacedim, VectorType>>>
     euler_vector;
 
   /**
    * Pointer to the DoFHandler to which the mapping vector is associated.
    */
-  SmartPointer<const DoFHandler<dim, spacedim>,
-               MappingFEField<dim, spacedim, VectorType>>
+  ObserverPointer<const DoFHandler<dim, spacedim>,
+                  MappingFEField<dim, spacedim, VectorType>>
     euler_dof_handler;
 
 private:

--- a/include/deal.II/fe/mapping_manifold.h
+++ b/include/deal.II/fe/mapping_manifold.h
@@ -313,7 +313,7 @@ public:
      *
      * Updated each.
      */
-    mutable SmartPointer<const Manifold<dim, spacedim>> manifold;
+    mutable ObserverPointer<const Manifold<dim, spacedim>> manifold;
   };
 
 private:

--- a/include/deal.II/fe/mapping_q1_eulerian.h
+++ b/include/deal.II/fe/mapping_q1_eulerian.h
@@ -176,14 +176,15 @@ protected:
   /**
    * Reference to the vector of shifts.
    */
-  SmartPointer<const VectorType, MappingQ1Eulerian<dim, VectorType, spacedim>>
+  ObserverPointer<const VectorType,
+                  MappingQ1Eulerian<dim, VectorType, spacedim>>
     euler_transform_vectors;
 
   /**
    * Pointer to the DoFHandler to which the mapping vector is associated.
    */
-  SmartPointer<const DoFHandler<dim, spacedim>,
-               MappingQ1Eulerian<dim, VectorType, spacedim>>
+  ObserverPointer<const DoFHandler<dim, spacedim>,
+                  MappingQ1Eulerian<dim, VectorType, spacedim>>
     shiftmap_dof_handler;
 };
 

--- a/include/deal.II/fe/mapping_q1_eulerian.h
+++ b/include/deal.II/fe/mapping_q1_eulerian.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/dofs/dof_handler.h>
 

--- a/include/deal.II/fe/mapping_q_eulerian.h
+++ b/include/deal.II/fe/mapping_q_eulerian.h
@@ -174,14 +174,14 @@ protected:
   /**
    * Reference to the vector of shifts.
    */
-  SmartPointer<const VectorType, MappingQEulerian<dim, VectorType, spacedim>>
+  ObserverPointer<const VectorType, MappingQEulerian<dim, VectorType, spacedim>>
     euler_vector;
 
   /**
    * Pointer to the DoFHandler to which the mapping vector is associated.
    */
-  SmartPointer<const DoFHandler<dim, spacedim>,
-               MappingQEulerian<dim, VectorType, spacedim>>
+  ObserverPointer<const DoFHandler<dim, spacedim>,
+                  MappingQEulerian<dim, VectorType, spacedim>>
     euler_dof_handler;
 
 private:

--- a/include/deal.II/fe/mapping_q_eulerian.h
+++ b/include/deal.II/fe/mapping_q_eulerian.h
@@ -19,7 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/mutex.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_handler.h>

--- a/include/deal.II/grid/composition_manifold.h
+++ b/include/deal.II/grid/composition_manifold.h
@@ -112,7 +112,7 @@ private:
   /**
    * The first ChartManifold.
    */
-  SmartPointer<
+  ObserverPointer<
     const ChartManifold<dim1, intermediate_dim, chartdim>,
     CompositionManifold<dim, spacedim, chartdim, dim1, dim2, intermediate_dim>>
     F;
@@ -121,7 +121,7 @@ private:
   /**
    * The second ChartManifold.
    */
-  SmartPointer<
+  ObserverPointer<
     const ChartManifold<dim2, spacedim, intermediate_dim>,
     CompositionManifold<dim, spacedim, chartdim, dim1, dim2, intermediate_dim>>
     G;

--- a/include/deal.II/grid/grid_in.h
+++ b/include/deal.II/grid/grid_in.h
@@ -882,7 +882,7 @@ protected:
   /**
    * Store address of the triangulation to be fed with the data read in.
    */
-  SmartPointer<Triangulation<dim, spacedim>, GridIn<dim, spacedim>> tria;
+  ObserverPointer<Triangulation<dim, spacedim>, GridIn<dim, spacedim>> tria;
 
   /**
    * This function can write the raw cell data objects created by the

--- a/include/deal.II/grid/grid_in.h
+++ b/include/deal.II/grid/grid_in.h
@@ -19,8 +19,8 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/point.h>
-#include <deal.II/base/smartpointer.h>
 
 #include <iostream>
 #include <string>

--- a/include/deal.II/grid/grid_tools_cache.h
+++ b/include/deal.II/grid/grid_tools_cache.h
@@ -241,12 +241,13 @@ namespace GridTools
     /**
      * A pointer to the Triangulation.
      */
-    SmartPointer<const Triangulation<dim, spacedim>, Cache<dim, spacedim>> tria;
+    ObserverPointer<const Triangulation<dim, spacedim>, Cache<dim, spacedim>>
+      tria;
 
     /**
      * Mapping to use when computing on the Triangulation.
      */
-    SmartPointer<const Mapping<dim, spacedim>, Cache<dim, spacedim>> mapping;
+    ObserverPointer<const Mapping<dim, spacedim>, Cache<dim, spacedim>> mapping;
 
 
     /**

--- a/include/deal.II/grid/intergrid_map.h
+++ b/include/deal.II/grid/intergrid_map.h
@@ -122,7 +122,8 @@ public:
   using cell_iterator = typename MeshType::cell_iterator;
 
   /**
-   * Constructor setting the class name arguments in the SmartPointer members.
+   * Constructor setting the class name arguments in the ObserverPointer
+   * members.
    */
   InterGridMap();
 
@@ -187,12 +188,12 @@ private:
   /**
    * Store a pointer to the source grid.
    */
-  SmartPointer<const MeshType, InterGridMap<MeshType>> source_grid;
+  ObserverPointer<const MeshType, InterGridMap<MeshType>> source_grid;
 
   /**
    * Likewise for the destination grid.
    */
-  SmartPointer<const MeshType, InterGridMap<MeshType>> destination_grid;
+  ObserverPointer<const MeshType, InterGridMap<MeshType>> destination_grid;
 
   /**
    * Set the mapping for the pair of cells given. These shall match in level

--- a/include/deal.II/grid/intergrid_map.h
+++ b/include/deal.II/grid/intergrid_map.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/dofs/dof_accessor.h>
 

--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -790,15 +790,15 @@ private:
   /**
    * Pointer to the push_forward function.
    */
-  SmartPointer<const Function<chartdim>,
-               FunctionManifold<dim, spacedim, chartdim>>
+  ObserverPointer<const Function<chartdim>,
+                  FunctionManifold<dim, spacedim, chartdim>>
     push_forward_function;
 
   /**
    * Pointer to the pull_back function.
    */
-  SmartPointer<const Function<spacedim>,
-               FunctionManifold<dim, spacedim, chartdim>>
+  ObserverPointer<const Function<spacedim>,
+                  FunctionManifold<dim, spacedim, chartdim>>
     pull_back_function;
 
   /**

--- a/include/deal.II/grid/persistent_tria.h
+++ b/include/deal.II/grid/persistent_tria.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/grid/tria.h>
 

--- a/include/deal.II/grid/persistent_tria.h
+++ b/include/deal.II/grid/persistent_tria.h
@@ -250,8 +250,8 @@ private:
   /**
    * This grid shall be used as coarse grid.
    */
-  SmartPointer<const Triangulation<dim, spacedim>,
-               PersistentTriangulation<dim, spacedim>>
+  ObserverPointer<const Triangulation<dim, spacedim>,
+                  PersistentTriangulation<dim, spacedim>>
     coarse_grid;
 
   /**

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -20,9 +20,9 @@
 
 #include <deal.II/base/geometry_info.h>
 #include <deal.II/base/iterator_range.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/partitioner.h>
 #include <deal.II/base/point.h>
-#include <deal.II/base/smartpointer.h>
 #include <deal.II/base/subscriptor.h>
 
 #include <deal.II/grid/cell_id.h>

--- a/include/deal.II/hp/fe_values.h
+++ b/include/deal.II/hp/fe_values.h
@@ -202,14 +202,15 @@ namespace hp
     /**
      * A pointer to the collection of finite elements to be used.
      */
-    const SmartPointer<const FECollection<dim, FEValuesType::space_dimension>,
-                       FEValuesBase<dim, q_dim, FEValuesType>>
+    const ObserverPointer<
+      const FECollection<dim, FEValuesType::space_dimension>,
+      FEValuesBase<dim, q_dim, FEValuesType>>
       fe_collection;
 
     /**
      * A pointer to the collection of mappings to be used.
      */
-    const SmartPointer<
+    const ObserverPointer<
       const MappingCollection<dim, FEValuesType::space_dimension>,
       FEValuesBase<dim, q_dim, FEValuesType>>
       mapping_collection;

--- a/include/deal.II/lac/arpack_solver.h
+++ b/include/deal.II/lac/arpack_solver.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/lac/solver_control.h>
 

--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -20,7 +20,7 @@
 
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/mutex.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/table.h>
 #include <deal.II/base/utilities.h>
 

--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -849,7 +849,7 @@ protected:
   /**
    * Array of sub-matrices.
    */
-  Table<2, SmartPointer<BlockType, BlockMatrixBase<MatrixType>>> sub_objects;
+  Table<2, ObserverPointer<BlockType, BlockMatrixBase<MatrixType>>> sub_objects;
 
   /**
    * This function collects the sizes of the sub-objects and stores them in

--- a/include/deal.II/lac/block_sparse_matrix.h
+++ b/include/deal.II/lac/block_sparse_matrix.h
@@ -364,9 +364,9 @@ private:
   /**
    * Pointer to the block sparsity pattern used for this matrix. In order to
    * guarantee that it is not deleted while still in use, we subscribe to it
-   * using the SmartPointer class.
+   * using the ObserverPointer class.
    */
-  SmartPointer<const BlockSparsityPattern, BlockSparseMatrix<number>>
+  ObserverPointer<const BlockSparsityPattern, BlockSparseMatrix<number>>
     sparsity_pattern;
 };
 

--- a/include/deal.II/lac/block_sparse_matrix_ez.h
+++ b/include/deal.II/lac/block_sparse_matrix_ez.h
@@ -24,7 +24,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/subscriptor.h>
 #include <deal.II/base/table.h>
 

--- a/include/deal.II/lac/block_sparsity_pattern.h
+++ b/include/deal.II/lac/block_sparsity_pattern.h
@@ -19,7 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/subscriptor.h>
 #include <deal.II/base/table.h>
 

--- a/include/deal.II/lac/chunk_sparse_matrix.h
+++ b/include/deal.II/lac/chunk_sparse_matrix.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/subscriptor.h>
 
 #include <deal.II/lac/chunk_sparsity_pattern.h>

--- a/include/deal.II/lac/chunk_sparse_matrix.h
+++ b/include/deal.II/lac/chunk_sparse_matrix.h
@@ -1405,9 +1405,9 @@ private:
   /**
    * Pointer to the sparsity pattern used for this matrix. In order to
    * guarantee that it is not deleted while still in use, we subscribe to it
-   * using the SmartPointer class.
+   * using the ObserverPointer class.
    */
-  SmartPointer<const ChunkSparsityPattern, ChunkSparseMatrix<number>> cols;
+  ObserverPointer<const ChunkSparsityPattern, ChunkSparseMatrix<number>> cols;
 
   /**
    * Array of values for all the nonzero entries. The position of an

--- a/include/deal.II/lac/lapack_full_matrix.h
+++ b/include/deal.II/lac/lapack_full_matrix.h
@@ -1024,8 +1024,9 @@ public:
   Tvmult(BlockVector<number> &, const BlockVector<number> &) const;
 
 private:
-  SmartPointer<const LAPACKFullMatrix<number>, PreconditionLU<number>> matrix;
-  SmartPointer<VectorMemory<Vector<number>>, PreconditionLU<number>>   mem;
+  ObserverPointer<const LAPACKFullMatrix<number>, PreconditionLU<number>>
+                                                                        matrix;
+  ObserverPointer<VectorMemory<Vector<number>>, PreconditionLU<number>> mem;
 };
 
 /*---------------------- Inline functions -----------------------------------*/

--- a/include/deal.II/lac/lapack_full_matrix.h
+++ b/include/deal.II/lac/lapack_full_matrix.h
@@ -19,7 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/mutex.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/table.h>
 
 #include <deal.II/lac/lapack_support.h>

--- a/include/deal.II/lac/matrix_block.h
+++ b/include/deal.II/lac/matrix_block.h
@@ -21,7 +21,7 @@
 
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/mg_level_object.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/lac/block_indices.h>
 #include <deal.II/lac/block_sparsity_pattern.h>

--- a/include/deal.II/lac/parpack_solver.h
+++ b/include/deal.II/lac/parpack_solver.h
@@ -19,7 +19,7 @@
 
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/memory_consumption.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/lac/solver_control.h>
 #include <deal.II/lac/vector_operation.h>

--- a/include/deal.II/lac/petsc_snes.h
+++ b/include/deal.II/lac/petsc_snes.h
@@ -19,8 +19,8 @@
 
 #ifdef DEAL_II_WITH_PETSC
 #  include <deal.II/base/mpi.h>
+#  include <deal.II/base/observer_pointer.h>
 #  include <deal.II/base/parameter_handler.h>
-#  include <deal.II/base/smartpointer.h>
 
 #  include <deal.II/lac/petsc_matrix_base.h>
 #  include <deal.II/lac/petsc_precondition.h>

--- a/include/deal.II/lac/petsc_snes.h
+++ b/include/deal.II/lac/petsc_snes.h
@@ -472,8 +472,8 @@ namespace PETScWrappers
     /**
      * Pointers to the internal PETSc matrix objects.
      */
-    SmartPointer<AMatrixType, NonlinearSolver> A;
-    SmartPointer<PMatrixType, NonlinearSolver> P;
+    ObserverPointer<AMatrixType, NonlinearSolver> A;
+    ObserverPointer<PMatrixType, NonlinearSolver> P;
 
     /**
      * This flag is used to support versions of PETSc older than 3.13.

--- a/include/deal.II/lac/petsc_solver.h
+++ b/include/deal.II/lac/petsc_solver.h
@@ -172,7 +172,7 @@ namespace PETScWrappers
      * copy the data from this object before starting the solution process,
      * and copy the data back into it afterwards.
      */
-    SmartPointer<SolverControl, SolverBase> solver_control;
+    ObserverPointer<SolverControl, SolverBase> solver_control;
 
     /**
      * Utility to create the KSP object and attach convergence test.

--- a/include/deal.II/lac/petsc_solver.h
+++ b/include/deal.II/lac/petsc_solver.h
@@ -20,7 +20,7 @@
 
 #ifdef DEAL_II_WITH_PETSC
 
-#  include <deal.II/base/smartpointer.h>
+#  include <deal.II/base/observer_pointer.h>
 
 #  include <deal.II/lac/exceptions.h>
 #  include <deal.II/lac/solver_control.h>

--- a/include/deal.II/lac/petsc_ts.h
+++ b/include/deal.II/lac/petsc_ts.h
@@ -19,8 +19,8 @@
 
 #ifdef DEAL_II_WITH_PETSC
 #  include <deal.II/base/mpi.h>
+#  include <deal.II/base/observer_pointer.h>
 #  include <deal.II/base/parameter_handler.h>
-#  include <deal.II/base/smartpointer.h>
 
 #  include <deal.II/lac/petsc_matrix_base.h>
 #  include <deal.II/lac/petsc_precondition.h>

--- a/include/deal.II/lac/petsc_ts.h
+++ b/include/deal.II/lac/petsc_ts.h
@@ -716,8 +716,8 @@ namespace PETScWrappers
     /**
      * Pointers to the internal PETSc matrix objects.
      */
-    SmartPointer<AMatrixType, TimeStepper> A;
-    SmartPointer<PMatrixType, TimeStepper> P;
+    ObserverPointer<AMatrixType, TimeStepper> A;
+    ObserverPointer<PMatrixType, TimeStepper> P;
 
     /**
      * Object to apply solve_with_jacobian.

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -19,8 +19,8 @@
 
 #include <deal.II/base/memory_space.h>
 #include <deal.II/base/mutex.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/parallel.h>
-#include <deal.II/base/smartpointer.h>
 #include <deal.II/base/template_constraints.h>
 
 #include <deal.II/lac/affine_constraints.h>

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -682,7 +682,7 @@ protected:
   /**
    * Pointer to the matrix object.
    */
-  SmartPointer<const MatrixType, PreconditionRelaxation<MatrixType>> A;
+  ObserverPointer<const MatrixType, PreconditionRelaxation<MatrixType>> A;
 
   /**
    * Stores the additional data passed to the initialize function, obtained
@@ -867,8 +867,8 @@ namespace internal
       }
 
     private:
-      const SmartPointer<const MatrixType> A;
-      const double                         relaxation;
+      const ObserverPointer<const MatrixType> A;
+      const double                            relaxation;
     };
 
     template <typename MatrixType>
@@ -935,8 +935,8 @@ namespace internal
       }
 
     private:
-      const SmartPointer<const MatrixType> A;
-      const double                         relaxation;
+      const ObserverPointer<const MatrixType> A;
+      const double                            relaxation;
     };
 
     template <typename MatrixType>
@@ -1026,8 +1026,8 @@ namespace internal
       }
 
     private:
-      const SmartPointer<const MatrixType> A;
-      const double                         relaxation;
+      const ObserverPointer<const MatrixType> A;
+      const double                            relaxation;
 
       /**
        * An array that stores for each matrix row where the first position after
@@ -1069,8 +1069,8 @@ namespace internal
       }
 
     private:
-      const SmartPointer<const MatrixType> A;
-      const double                         relaxation;
+      const ObserverPointer<const MatrixType> A;
+      const double                            relaxation;
 
       const std::vector<size_type> &permutation;
       const std::vector<size_type> &inverse_permutation;
@@ -2026,8 +2026,8 @@ public:
  * <h4>Requirements on the templated classes</h4>
  *
  * The class `MatrixType` must be derived from Subscriptor because a
- * SmartPointer to `MatrixType` is held in the class. In particular, this means
- * that the matrix object needs to persist during the lifetime of
+ * ObserverPointer to `MatrixType` is held in the class. In particular, this
+ * means that the matrix object needs to persist during the lifetime of
  * PreconditionChebyshev. The preconditioner is held in a shared_ptr that is
  * copied into the AdditionalData member variable of the class, so the
  * variable used for initialization can safely be discarded after calling
@@ -2254,7 +2254,7 @@ private:
   /**
    * A pointer to the underlying matrix.
    */
-  SmartPointer<
+  ObserverPointer<
     const MatrixType,
     PreconditionChebyshev<MatrixType, VectorType, PreconditionerType>>
     matrix_ptr;

--- a/include/deal.II/lac/precondition_block.h
+++ b/include/deal.II/lac/precondition_block.h
@@ -343,7 +343,8 @@ protected:
    * inverse matrices should not be stored) until the last call of the
    * preconditoining @p vmult function of the derived classes.
    */
-  SmartPointer<const MatrixType, PreconditionBlock<MatrixType, inverse_type>> A;
+  ObserverPointer<const MatrixType, PreconditionBlock<MatrixType, inverse_type>>
+    A;
   /**
    * Relaxation parameter to be used by derived classes.
    */

--- a/include/deal.II/lac/precondition_block.h
+++ b/include/deal.II/lac/precondition_block.h
@@ -19,7 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/subscriptor.h>
 
 #include <deal.II/lac/precondition_block_base.h>

--- a/include/deal.II/lac/precondition_block_base.h
+++ b/include/deal.II/lac/precondition_block_base.h
@@ -21,7 +21,7 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/memory_consumption.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/subscriptor.h>
 
 #include <deal.II/lac/householder.h>

--- a/include/deal.II/lac/precondition_selector.h
+++ b/include/deal.II/lac/precondition_selector.h
@@ -188,7 +188,8 @@ private:
    * Matrix that is used for the matrix-builtin preconditioning function. cf.
    * also @p PreconditionUseMatrix.
    */
-  SmartPointer<const MatrixType, PreconditionSelector<MatrixType, VectorType>>
+  ObserverPointer<const MatrixType,
+                  PreconditionSelector<MatrixType, VectorType>>
     A;
 
   /**

--- a/include/deal.II/lac/precondition_selector.h
+++ b/include/deal.II/lac/precondition_selector.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/subscriptor.h>
 
 #include <string>

--- a/include/deal.II/lac/relaxation_block.h
+++ b/include/deal.II/lac/relaxation_block.h
@@ -246,15 +246,15 @@ protected:
    * inverse matrices should not be stored) until the last call of the
    * preconditioning @p vmult function of the derived classes.
    */
-  SmartPointer<const MatrixType,
-               RelaxationBlock<MatrixType, InverseNumberType, VectorType>>
+  ObserverPointer<const MatrixType,
+                  RelaxationBlock<MatrixType, InverseNumberType, VectorType>>
     A;
 
   /**
    * Control information.
    */
-  SmartPointer<const AdditionalData,
-               RelaxationBlock<MatrixType, InverseNumberType, VectorType>>
+  ObserverPointer<const AdditionalData,
+                  RelaxationBlock<MatrixType, InverseNumberType, VectorType>>
     additional_data;
 
 private:

--- a/include/deal.II/lac/relaxation_block.h
+++ b/include/deal.II/lac/relaxation_block.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/subscriptor.h>
 
 #include <deal.II/lac/precondition_block_base.h>

--- a/include/deal.II/lac/solver_selector.h
+++ b/include/deal.II/lac/solver_selector.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/template_constraints.h>
 
 #include <deal.II/lac/precondition.h>

--- a/include/deal.II/lac/solver_selector.h
+++ b/include/deal.II/lac/solver_selector.h
@@ -206,7 +206,7 @@ protected:
    * Stores the @p SolverControl that is needed in the constructor of each @p
    * Solver class. This can be changed with @p set_control().
    */
-  SmartPointer<SolverControl, SolverSelector<VectorType>> control;
+  ObserverPointer<SolverControl, SolverSelector<VectorType>> control;
 
   /**
    * Stores the name of the solver.

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -1742,9 +1742,9 @@ private:
   /**
    * Pointer to the sparsity pattern used for this matrix. In order to
    * guarantee that it is not deleted while still in use, we subscribe to it
-   * using the SmartPointer class.
+   * using the ObserverPointer class.
    */
-  SmartPointer<const SparsityPattern, SparseMatrix<number>> cols;
+  ObserverPointer<const SparsityPattern, SparseMatrix<number>> cols;
 
   /**
    * Array of values for all the nonzero entries. The position of an

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -18,7 +18,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/mpi_stub.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/subscriptor.h>
 
 #include <deal.II/lac/exceptions.h>

--- a/include/deal.II/lac/sparse_matrix_ez.h
+++ b/include/deal.II/lac/sparse_matrix_ez.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/subscriptor.h>
 
 #include <deal.II/lac/exceptions.h>

--- a/include/deal.II/lac/sparse_vanka.h
+++ b/include/deal.II/lac/sparse_vanka.h
@@ -283,7 +283,7 @@ private:
   /**
    * Pointer to the matrix.
    */
-  SmartPointer<const SparseMatrix<number>, SparseVanka<number>> matrix;
+  ObserverPointer<const SparseMatrix<number>, SparseVanka<number>> matrix;
 
   /**
    * Indices of those degrees of freedom that we shall work on.
@@ -294,7 +294,7 @@ private:
    * Array of inverse matrices, one for each degree of freedom. Only those
    * elements will be used that are tagged in @p selected.
    */
-  mutable std::vector<SmartPointer<FullMatrix<float>, SparseVanka<number>>>
+  mutable std::vector<ObserverPointer<FullMatrix<float>, SparseVanka<number>>>
     inverses;
 
   /**

--- a/include/deal.II/lac/sparse_vanka.h
+++ b/include/deal.II/lac/sparse_vanka.h
@@ -18,7 +18,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/multithread_info.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 
 #include <vector>
 

--- a/include/deal.II/lac/sparse_vanka.templates.h
+++ b/include/deal.II/lac/sparse_vanka.templates.h
@@ -61,7 +61,7 @@ template <typename number>
 SparseVanka<number>::~SparseVanka()
 {
   typename std::vector<
-    SmartPointer<FullMatrix<float>, SparseVanka<number>>>::iterator i;
+    ObserverPointer<FullMatrix<float>, SparseVanka<number>>>::iterator i;
   for (i = inverses.begin(); i != inverses.end(); ++i)
     {
       FullMatrix<float> *p = *i;

--- a/include/deal.II/lac/vector_memory.h
+++ b/include/deal.II/lac/vector_memory.h
@@ -19,7 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/mutex.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/lac/vector.h>
 

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -21,7 +21,7 @@
 
 #include <deal.II/base/array_view.h>
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/symmetric_tensor.h>
 #include <deal.II/base/template_constraints.h>
 #include <deal.II/base/vectorization.h>

--- a/include/deal.II/matrix_free/fe_evaluation_data.h
+++ b/include/deal.II/matrix_free/fe_evaluation_data.h
@@ -22,8 +22,8 @@
 #include <deal.II/base/array_view.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/geometry_info.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/signaling_nan.h>
-#include <deal.II/base/smartpointer.h>
 #include <deal.II/base/std_cxx20/iota_view.h>
 #include <deal.II/base/symmetric_tensor.h>
 #include <deal.II/base/template_constraints.h>

--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -891,12 +891,12 @@ protected:
   /**
    * Pointer to the Mapping object passed to the constructor.
    */
-  SmartPointer<const Mapping<dim, spacedim>> mapping;
+  ObserverPointer<const Mapping<dim, spacedim>> mapping;
 
   /**
    * Pointer to the FiniteElement object passed to the constructor.
    */
-  SmartPointer<const FiniteElement<dim, spacedim>> fe;
+  ObserverPointer<const FiniteElement<dim, spacedim>> fe;
 
   /**
    * Description of the 1d polynomial basis for tensor product elements used
@@ -1045,7 +1045,7 @@ protected:
    * Pointer to currently used mapping info (either on the fly or external
    * precomputed).
    */
-  SmartPointer<NonMatching::MappingInfo<dim, spacedim, Number>> mapping_info;
+  ObserverPointer<NonMatching::MappingInfo<dim, spacedim, Number>> mapping_info;
 
   /**
    * The current cell index to access mapping data from mapping info.

--- a/include/deal.II/matrix_free/fe_remote_evaluation.h
+++ b/include/deal.II/matrix_free/fe_remote_evaluation.h
@@ -609,17 +609,17 @@ private:
   /**
    * Underlying communicator which handles update of the ghost values.
    */
-  SmartPointer<const FERemoteEvaluationCommunicator<dim>> comm;
+  ObserverPointer<const FERemoteEvaluationCommunicator<dim>> comm;
 
   /**
    * Pointer to MeshType if used with Triangulation.
    */
-  SmartPointer<const Triangulation<dim>> tria;
+  ObserverPointer<const Triangulation<dim>> tria;
 
   /**
    * Pointer to MeshType if used with DoFHandler.
    */
-  SmartPointer<const DoFHandler<dim>> dof_handler;
+  ObserverPointer<const DoFHandler<dim>> dof_handler;
 
   /**
    * First selected component.

--- a/include/deal.II/matrix_free/mapping_info.h
+++ b/include/deal.II/matrix_free/mapping_info.h
@@ -192,7 +192,7 @@ namespace internal
       /**
        * The pointer to the first entry of mapping_collection.
        */
-      SmartPointer<const Mapping<dim>> mapping;
+      ObserverPointer<const Mapping<dim>> mapping;
 
       /**
        * Reference-cell type related to each quadrature and active quadrature

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -2252,7 +2252,7 @@ private:
   /**
    * Pointers to the DoFHandlers underlying the current problem.
    */
-  std::vector<SmartPointer<const DoFHandler<dim>>> dof_handlers;
+  std::vector<ObserverPointer<const DoFHandler<dim>>> dof_handlers;
 
   /**
    * Pointers to the AffineConstraints underlying the current problem. Only
@@ -2260,7 +2260,8 @@ private:
    * template parameter as the `Number` template of MatrixFree is passed to
    * reinit(). Filled with nullptr otherwise.
    */
-  std::vector<SmartPointer<const AffineConstraints<Number>>> affine_constraints;
+  std::vector<ObserverPointer<const AffineConstraints<Number>>>
+    affine_constraints;
 
   /**
    * Contains the information about degrees of freedom on the individual cells

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -366,7 +366,8 @@ namespace internal
   void
   store_affine_constraints(
     const dealii::AffineConstraints<Number2> *,
-    SmartPointer<const dealii::AffineConstraints<Number>> &stored_constraints)
+    ObserverPointer<const dealii::AffineConstraints<Number>>
+      &stored_constraints)
   {
     stored_constraints = nullptr;
   }
@@ -374,8 +375,9 @@ namespace internal
   template <typename Number>
   void
   store_affine_constraints(
-    const dealii::AffineConstraints<Number>               *affine_constraints,
-    SmartPointer<const dealii::AffineConstraints<Number>> &stored_constraints)
+    const dealii::AffineConstraints<Number> *affine_constraints,
+    ObserverPointer<const dealii::AffineConstraints<Number>>
+      &stored_constraints)
   {
     stored_constraints = affine_constraints;
   }
@@ -1118,9 +1120,9 @@ namespace internal
   std::vector<bool>
   compute_dof_info(
     const std::vector<const dealii::AffineConstraints<number> *> &constraint,
-    const std::vector<IndexSet>                            &locally_owned_dofs,
-    const std::vector<SmartPointer<const DoFHandler<dim>>> &dof_handlers,
-    const Table<2, MatrixFreeFunctions::ShapeInfo<double>> &shape_infos,
+    const std::vector<IndexSet> &locally_owned_dofs,
+    const std::vector<ObserverPointer<const DoFHandler<dim>>> &dof_handlers,
+    const Table<2, MatrixFreeFunctions::ShapeInfo<double>>    &shape_infos,
     const unsigned int               cell_level_index_end_local,
     const unsigned int               mg_level,
     const bool                       hold_all_faces_to_owned_cells,

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -590,7 +590,7 @@ namespace MatrixFreeOperators
     /**
      * Const pointer to the operator class.
      */
-    SmartPointer<const OperatorType> mf_base_operator;
+    ObserverPointer<const OperatorType> mf_base_operator;
   };
 
 

--- a/include/deal.II/matrix_free/tools.h
+++ b/include/deal.II/matrix_free/tools.h
@@ -622,7 +622,7 @@ namespace MatrixFreeTools
     /**
      * Reference to the underlying MatrixFree object.
      */
-    SmartPointer<const MatrixFree<dim, Number, VectorizedArrayType>>
+    ObserverPointer<const MatrixFree<dim, Number, VectorizedArrayType>>
       matrix_free;
 
     /**

--- a/include/deal.II/meshworker/assembler.h
+++ b/include/deal.II/meshworker/assembler.h
@@ -166,15 +166,15 @@ namespace MeshWorker
       /**
        * A pointer to the object containing the block structure.
        */
-      SmartPointer<const BlockInfo,
-                   ResidualLocalBlocksToGlobalBlocks<VectorType>>
+      ObserverPointer<const BlockInfo,
+                      ResidualLocalBlocksToGlobalBlocks<VectorType>>
         block_info;
 
       /**
        * A pointer to the object containing constraints.
        */
-      SmartPointer<const AffineConstraints<typename VectorType::value_type>,
-                   ResidualLocalBlocksToGlobalBlocks<VectorType>>
+      ObserverPointer<const AffineConstraints<typename VectorType::value_type>,
+                      ResidualLocalBlocksToGlobalBlocks<VectorType>>
         constraints;
     };
 
@@ -271,22 +271,22 @@ namespace MeshWorker
       /**
        * The global matrices, stored as a vector of pointers.
        */
-      SmartPointer<MatrixBlockVector<MatrixType>,
-                   MatrixLocalBlocksToGlobalBlocks<MatrixType, number>>
+      ObserverPointer<MatrixBlockVector<MatrixType>,
+                      MatrixLocalBlocksToGlobalBlocks<MatrixType, number>>
         matrices;
 
       /**
        * A pointer to the object containing the block structure.
        */
-      SmartPointer<const BlockInfo,
-                   MatrixLocalBlocksToGlobalBlocks<MatrixType, number>>
+      ObserverPointer<const BlockInfo,
+                      MatrixLocalBlocksToGlobalBlocks<MatrixType, number>>
         block_info;
       /**
        * A pointer to the object containing constraints.
        */
 
-      SmartPointer<const AffineConstraints<typename MatrixType::value_type>,
-                   MatrixLocalBlocksToGlobalBlocks<MatrixType, number>>
+      ObserverPointer<const AffineConstraints<typename MatrixType::value_type>,
+                      MatrixLocalBlocksToGlobalBlocks<MatrixType, number>>
         constraints;
 
       /**
@@ -326,8 +326,8 @@ namespace MeshWorker
     public:
       using MatrixPtrVector = MGMatrixBlockVector<MatrixType>;
       using MatrixPtrVectorPtr =
-        SmartPointer<MatrixPtrVector,
-                     MGMatrixLocalBlocksToGlobalBlocks<MatrixType, number>>;
+        ObserverPointer<MatrixPtrVector,
+                        MGMatrixLocalBlocksToGlobalBlocks<MatrixType, number>>;
 
       /**
        * Constructor, initializing the #threshold, which limits how small
@@ -502,15 +502,15 @@ namespace MeshWorker
       /**
        * A pointer to the object containing the block structure.
        */
-      SmartPointer<const BlockInfo,
-                   MGMatrixLocalBlocksToGlobalBlocks<MatrixType, number>>
+      ObserverPointer<const BlockInfo,
+                      MGMatrixLocalBlocksToGlobalBlocks<MatrixType, number>>
         block_info;
 
       /**
        * A pointer to the object containing constraints.
        */
-      SmartPointer<const MGConstrainedDoFs,
-                   MGMatrixLocalBlocksToGlobalBlocks<MatrixType, number>>
+      ObserverPointer<const MGConstrainedDoFs,
+                      MGMatrixLocalBlocksToGlobalBlocks<MatrixType, number>>
         mg_constrained_dofs;
 
 

--- a/include/deal.II/meshworker/assembler.h
+++ b/include/deal.II/meshworker/assembler.h
@@ -21,7 +21,7 @@
 #include <deal.II/algorithms/any_data.h>
 
 #include <deal.II/base/mg_level_object.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/lac/block_vector.h>
 

--- a/include/deal.II/meshworker/dof_info.h
+++ b/include/deal.II/meshworker/dof_info.h
@@ -168,7 +168,7 @@ namespace MeshWorker
 
 
     /// The block structure of the system
-    SmartPointer<const BlockInfo, DoFInfo<dim, spacedim>> block_info;
+    ObserverPointer<const BlockInfo, DoFInfo<dim, spacedim>> block_info;
 
     /**
      * The structure refers to a cell with level data instead of active data.

--- a/include/deal.II/meshworker/functional.h
+++ b/include/deal.II/meshworker/functional.h
@@ -21,7 +21,7 @@
 #include <deal.II/algorithms/any_data.h>
 
 #include <deal.II/base/mg_level_object.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/lac/block_vector.h>
 

--- a/include/deal.II/meshworker/integration_info.h
+++ b/include/deal.II/meshworker/integration_info.h
@@ -219,8 +219,8 @@ namespace MeshWorker
     /**
      * The pointer to the (system) element used for initialization.
      */
-    SmartPointer<const FiniteElement<dim, spacedim>,
-                 IntegrationInfo<dim, spacedim>>
+    ObserverPointer<const FiniteElement<dim, spacedim>,
+                    IntegrationInfo<dim, spacedim>>
       fe_pointer;
 
     /**

--- a/include/deal.II/meshworker/output.h
+++ b/include/deal.II/meshworker/output.h
@@ -19,7 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/mg_level_object.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/lac/block_vector.h>

--- a/include/deal.II/meshworker/scratch_data.h
+++ b/include/deal.II/meshworker/scratch_data.h
@@ -210,7 +210,7 @@ namespace MeshWorker
   {
   public:
     /**
-     * Create an empty ScratchData object. A SmartPointer pointing to
+     * Create an empty ScratchData object. A ObserverPointer pointing to
      * @p mapping and @p fe is stored internally. Make sure they live longer
      * than this class instance.
      *
@@ -305,7 +305,7 @@ namespace MeshWorker
       const UpdateFlags         &neighbor_face_update_flags = update_default);
 
     /**
-     * Create an empty ScratchData object. A SmartPointer pointing to
+     * Create an empty ScratchData object. A ObserverPointer pointing to
      * @p mapping_collection and @p fe_collection is stored internally. Make sure they live longer
      * than this class instance.
      *
@@ -1360,13 +1360,13 @@ namespace MeshWorker
      * The mapping used by the internal FEValues. Make sure it lives
      * longer than this class.
      */
-    SmartPointer<const Mapping<dim, spacedim>> mapping;
+    ObserverPointer<const Mapping<dim, spacedim>> mapping;
 
     /**
      * The finite element used by the internal FEValues. Make sure it lives
      * longer than this class.
      */
-    SmartPointer<const FiniteElement<dim, spacedim>> fe;
+    ObserverPointer<const FiniteElement<dim, spacedim>> fe;
 
     /**
      * Quadrature formula used to integrate on the current cell, and on its
@@ -1428,13 +1428,14 @@ namespace MeshWorker
      * The mapping collection used by the internal hp::FEValues. Make sure it
      * lives longer than this class.
      */
-    SmartPointer<const hp::MappingCollection<dim, spacedim>> mapping_collection;
+    ObserverPointer<const hp::MappingCollection<dim, spacedim>>
+      mapping_collection;
 
     /**
      * The finite element used by the internal FEValues. Make sure it lives
      * longer than this class.
      */
-    SmartPointer<const hp::FECollection<dim, spacedim>> fe_collection;
+    ObserverPointer<const hp::FECollection<dim, spacedim>> fe_collection;
 
     /**
      * Quadrature formula used to integrate on the current cell, and on its
@@ -1553,13 +1554,14 @@ namespace MeshWorker
      * A pointer to the last used FEValues/FEFaceValues, or FESubfaceValues
      * object on this cell.
      */
-    SmartPointer<const FEValuesBase<dim, spacedim>> current_fe_values;
+    ObserverPointer<const FEValuesBase<dim, spacedim>> current_fe_values;
 
     /**
      * A pointer to the last used FEValues/FEFaceValues, or FESubfaceValues
      * object on the neighbor cell.
      */
-    SmartPointer<const FEValuesBase<dim, spacedim>> current_neighbor_fe_values;
+    ObserverPointer<const FEValuesBase<dim, spacedim>>
+      current_neighbor_fe_values;
   };
 
 #ifndef DOXYGEN

--- a/include/deal.II/meshworker/simple.h
+++ b/include/deal.II/meshworker/simple.h
@@ -111,8 +111,8 @@ namespace MeshWorker
       /**
        * A pointer to the object containing constraints.
        */
-      SmartPointer<const AffineConstraints<typename VectorType::value_type>,
-                   ResidualSimple<VectorType>>
+      ObserverPointer<const AffineConstraints<typename VectorType::value_type>,
+                      ResidualSimple<VectorType>>
         constraints;
     };
 
@@ -211,7 +211,7 @@ namespace MeshWorker
       /**
        * The vector of global matrices being assembled.
        */
-      std::vector<SmartPointer<MatrixType, MatrixSimple<MatrixType>>> matrix;
+      std::vector<ObserverPointer<MatrixType, MatrixSimple<MatrixType>>> matrix;
 
       /**
        * The smallest positive number that will be entered into the global
@@ -234,8 +234,8 @@ namespace MeshWorker
       /**
        * A pointer to the object containing constraints.
        */
-      SmartPointer<const AffineConstraints<typename MatrixType::value_type>,
-                   MatrixSimple<MatrixType>>
+      ObserverPointer<const AffineConstraints<typename MatrixType::value_type>,
+                      MatrixSimple<MatrixType>>
         constraints;
     };
 
@@ -378,40 +378,40 @@ namespace MeshWorker
       /**
        * The global matrix being assembled.
        */
-      SmartPointer<MGLevelObject<MatrixType>, MGMatrixSimple<MatrixType>>
+      ObserverPointer<MGLevelObject<MatrixType>, MGMatrixSimple<MatrixType>>
         matrix;
 
       /**
        * The matrix used for face flux terms across the refinement edge,
        * coupling coarse to fine.
        */
-      SmartPointer<MGLevelObject<MatrixType>, MGMatrixSimple<MatrixType>>
+      ObserverPointer<MGLevelObject<MatrixType>, MGMatrixSimple<MatrixType>>
         flux_up;
 
       /**
        * The matrix used for face flux terms across the refinement edge,
        * coupling fine to coarse.
        */
-      SmartPointer<MGLevelObject<MatrixType>, MGMatrixSimple<MatrixType>>
+      ObserverPointer<MGLevelObject<MatrixType>, MGMatrixSimple<MatrixType>>
         flux_down;
 
       /**
        * The matrix used for face contributions for continuous elements across
        * the refinement edge, coupling coarse to fine.
        */
-      SmartPointer<MGLevelObject<MatrixType>, MGMatrixSimple<MatrixType>>
+      ObserverPointer<MGLevelObject<MatrixType>, MGMatrixSimple<MatrixType>>
         interface_in;
 
       /**
        * The matrix used for face contributions for continuous elements across
        * the refinement edge, coupling fine to coarse.
        */
-      SmartPointer<MGLevelObject<MatrixType>, MGMatrixSimple<MatrixType>>
+      ObserverPointer<MGLevelObject<MatrixType>, MGMatrixSimple<MatrixType>>
         interface_out;
       /**
        * A pointer to the object containing constraints.
        */
-      SmartPointer<const MGConstrainedDoFs, MGMatrixSimple<MatrixType>>
+      ObserverPointer<const MGConstrainedDoFs, MGMatrixSimple<MatrixType>>
         mg_constrained_dofs;
 
       /**

--- a/include/deal.II/meshworker/simple.h
+++ b/include/deal.II/meshworker/simple.h
@@ -21,7 +21,7 @@
 #include <deal.II/algorithms/any_data.h>
 
 #include <deal.II/base/mg_level_object.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/lac/block_vector.h>
 

--- a/include/deal.II/meshworker/vector_selector.h
+++ b/include/deal.II/meshworker/vector_selector.h
@@ -21,7 +21,7 @@
 #include <deal.II/algorithms/named_selection.h>
 
 #include <deal.II/base/mg_level_object.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/tensor.h>
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/meshworker/vector_selector.templates.h
+++ b/include/deal.II/meshworker/vector_selector.templates.h
@@ -99,7 +99,8 @@ namespace MeshWorker
   VectorData<VectorType, dim, spacedim>::initialize(const VectorType  *v,
                                                     const std::string &name)
   {
-    SmartPointer<const VectorType, VectorData<VectorType, dim, spacedim>> p = v;
+    ObserverPointer<const VectorType, VectorData<VectorType, dim, spacedim>> p =
+      v;
     this->data.add(p, name);
     VectorSelector::initialize(this->data);
   }
@@ -195,8 +196,8 @@ namespace MeshWorker
     const MGLevelObject<VectorType> *v,
     const std::string               &name)
   {
-    SmartPointer<const MGLevelObject<VectorType>,
-                 MGVectorData<VectorType, dim, spacedim>>
+    ObserverPointer<const MGLevelObject<VectorType>,
+                    MGVectorData<VectorType, dim, spacedim>>
       p = v;
     this->data.add(p, name);
     VectorSelector::initialize(this->data);

--- a/include/deal.II/multigrid/mg_base.h
+++ b/include/deal.II/multigrid/mg_base.h
@@ -22,7 +22,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/subscriptor.h>
 
 #include <deal.II/lac/vector.h>

--- a/include/deal.II/multigrid/mg_block_smoother.h
+++ b/include/deal.II/multigrid/mg_block_smoother.h
@@ -19,7 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/mg_level_object.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/lac/block_vector.h>
 #include <deal.II/lac/linear_operator.h>

--- a/include/deal.II/multigrid/mg_block_smoother.h
+++ b/include/deal.II/multigrid/mg_block_smoother.h
@@ -123,8 +123,8 @@ private:
   /**
    * Memory for auxiliary vectors.
    */
-  SmartPointer<VectorMemory<BlockVector<number>>,
-               MGSmootherBlock<MatrixType, RelaxationType, number>>
+  ObserverPointer<VectorMemory<BlockVector<number>>,
+                  MGSmootherBlock<MatrixType, RelaxationType, number>>
     mem;
 };
 

--- a/include/deal.II/multigrid/mg_coarse.h
+++ b/include/deal.II/multigrid/mg_coarse.h
@@ -73,8 +73,8 @@ private:
   /**
    * Reference to the smoother.
    */
-  SmartPointer<const MGSmootherBase<VectorType>,
-               MGCoarseGridApplySmoother<VectorType>>
+  ObserverPointer<const MGSmootherBase<VectorType>,
+                  MGCoarseGridApplySmoother<VectorType>>
     coarse_smooth;
 };
 
@@ -134,31 +134,31 @@ private:
   /**
    * Reference to the solver.
    */
-  SmartPointer<SolverType,
-               MGCoarseGridIterativeSolver<VectorType,
-                                           SolverType,
-                                           MatrixType,
-                                           PreconditionerType>>
+  ObserverPointer<SolverType,
+                  MGCoarseGridIterativeSolver<VectorType,
+                                              SolverType,
+                                              MatrixType,
+                                              PreconditionerType>>
     solver;
 
   /**
    * Reference to the matrix.
    */
-  SmartPointer<const MatrixType,
-               MGCoarseGridIterativeSolver<VectorType,
-                                           SolverType,
-                                           MatrixType,
-                                           PreconditionerType>>
+  ObserverPointer<const MatrixType,
+                  MGCoarseGridIterativeSolver<VectorType,
+                                              SolverType,
+                                              MatrixType,
+                                              PreconditionerType>>
     matrix;
 
   /**
    * Reference to the preconditioner.
    */
-  SmartPointer<const PreconditionerType,
-               MGCoarseGridIterativeSolver<VectorType,
-                                           SolverType,
-                                           MatrixType,
-                                           PreconditionerType>>
+  ObserverPointer<const PreconditionerType,
+                  MGCoarseGridIterativeSolver<VectorType,
+                                              SolverType,
+                                              MatrixType,
+                                              PreconditionerType>>
     preconditioner;
 };
 
@@ -261,10 +261,9 @@ void
 MGCoarseGridApplySmoother<VectorType>::initialize(
   const MGSmootherBase<VectorType> &coarse_smooth_)
 {
-  coarse_smooth =
-    SmartPointer<const MGSmootherBase<VectorType>,
-                 MGCoarseGridApplySmoother<VectorType>>(&coarse_smooth_,
-                                                        typeid(*this).name());
+  coarse_smooth = ObserverPointer<const MGSmootherBase<VectorType>,
+                                  MGCoarseGridApplySmoother<VectorType>>(
+    &coarse_smooth_, typeid(*this).name());
 }
 
 

--- a/include/deal.II/multigrid/mg_matrix.h
+++ b/include/deal.II/multigrid/mg_matrix.h
@@ -125,7 +125,7 @@ class MGMatrixSelect : public MGMatrixBase<Vector<number>>
 public:
   /**
    * Constructor. @p row and @p col are the coordinate of the selected block.
-   * The other argument is handed over to the @p SmartPointer constructor.
+   * The other argument is handed over to the @p ObserverPointer constructor.
    */
   MGMatrixSelect(const unsigned int         row    = 0,
                  const unsigned int         col    = 0,
@@ -180,7 +180,7 @@ private:
   /**
    * Pointer to the matrix objects on each level.
    */
-  SmartPointer<MGLevelObject<MatrixType>, MGMatrixSelect<MatrixType, number>>
+  ObserverPointer<MGLevelObject<MatrixType>, MGMatrixSelect<MatrixType, number>>
     matrix;
   /**
    * Row coordinate of selected block.

--- a/include/deal.II/multigrid/mg_smoother.h
+++ b/include/deal.II/multigrid/mg_smoother.h
@@ -19,7 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/mg_level_object.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/lac/linear_operator.h>
 #include <deal.II/lac/vector_memory.h>

--- a/include/deal.II/multigrid/mg_transfer.h
+++ b/include/deal.II/multigrid/mg_transfer.h
@@ -386,7 +386,7 @@ protected:
   /**
    * The mg_constrained_dofs of the level systems.
    */
-  SmartPointer<const MGConstrainedDoFs> mg_constrained_dofs;
+  ObserverPointer<const MGConstrainedDoFs> mg_constrained_dofs;
 
 private:
   /**
@@ -574,7 +574,7 @@ protected:
   /**
    * The mg_constrained_dofs of the level systems.
    */
-  SmartPointer<const MGConstrainedDoFs> mg_constrained_dofs;
+  ObserverPointer<const MGConstrainedDoFs> mg_constrained_dofs;
 
   /**
    * In the function copy_to_mg, we need to access ghosted entries of the

--- a/include/deal.II/multigrid/mg_transfer_block.h
+++ b/include/deal.II/multigrid/mg_transfer_block.h
@@ -159,7 +159,7 @@ protected:
    * The mg_constrained_dofs of the level systems.
    */
 
-  SmartPointer<const MGConstrainedDoFs, MGTransferBlockBase>
+  ObserverPointer<const MGConstrainedDoFs, MGTransferBlockBase>
     mg_constrained_dofs;
 };
 
@@ -277,7 +277,7 @@ private:
    * Memory pool required if additional multiplication using #factors is
    * desired.
    */
-  SmartPointer<VectorMemory<Vector<number>>, MGTransferBlock<number>> memory;
+  ObserverPointer<VectorMemory<Vector<number>>, MGTransferBlock<number>> memory;
 };
 
 

--- a/include/deal.II/multigrid/mg_transfer_component.h
+++ b/include/deal.II/multigrid/mg_transfer_component.h
@@ -369,7 +369,7 @@ private:
    * The constraints of the global system.
    */
 public:
-  SmartPointer<const AffineConstraints<double>> constraints;
+  ObserverPointer<const AffineConstraints<double>> constraints;
 };
 
 /** @} */

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.h
@@ -650,7 +650,7 @@ private:
     /**
      * Matrix-free object on the fine side.
      */
-    SmartPointer<const MatrixFree<dim, Number>> matrix_free_fine;
+    ObserverPointer<const MatrixFree<dim, Number>> matrix_free_fine;
 
     /**
      * Index within the list of DoFHandler objects in the matrix_free_fine
@@ -661,7 +661,7 @@ private:
     /**
      * Matrix-free object on the coarse side.
      */
-    SmartPointer<const MatrixFree<dim, Number>> matrix_free_coarse;
+    ObserverPointer<const MatrixFree<dim, Number>> matrix_free_coarse;
 
     /**
      * Index within the list of DoFHandler objects in the matrix_free_coarse
@@ -711,7 +711,7 @@ private:
   /**
    * Pointer to the DoFHandler object used during initialization.
    */
-  SmartPointer<const DoFHandler<dim>> dof_handler_fine;
+  ObserverPointer<const DoFHandler<dim>> dof_handler_fine;
 
   /**
    * Multigrid level used during initialization.
@@ -897,7 +897,7 @@ private:
   /**
    * Pointer to the DoFHandler object used during initialization.
    */
-  SmartPointer<const DoFHandler<dim>> dof_handler_fine;
+  ObserverPointer<const DoFHandler<dim>> dof_handler_fine;
 
   /**
    * Multigrid level used during initialization.
@@ -1248,8 +1248,8 @@ private:
    */
   void
   initialize_internal_transfer(
-    const DoFHandler<dim>                       &dof_handler,
-    const SmartPointer<const MGConstrainedDoFs> &mg_constrained_dofs);
+    const DoFHandler<dim>                          &dof_handler,
+    const ObserverPointer<const MGConstrainedDoFs> &mg_constrained_dofs);
 
   /**
    * Retrieve finest DoFHandler from two-level transfer objects.
@@ -1302,7 +1302,7 @@ private:
   /**
    * Collection of the two-level transfer operators.
    */
-  MGLevelObject<SmartPointer<MGTwoLevelTransferBase<VectorType>>> transfer;
+  MGLevelObject<ObserverPointer<MGTwoLevelTransferBase<VectorType>>> transfer;
 
   /**
    * External partitioners used during initialize_dof_vector().
@@ -1395,7 +1395,8 @@ private:
   /**
    * Non-block version of transfer operation.
    */
-  std::vector<SmartPointer<const MGTransferMF<dim, Number>>> transfer_operators;
+  std::vector<ObserverPointer<const MGTransferMF<dim, Number>>>
+    transfer_operators;
 };
 
 

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -4309,8 +4309,8 @@ MGTransferMF<dim, Number>::initialize_constraints(
 template <int dim, typename Number>
 void
 MGTransferMF<dim, Number>::initialize_internal_transfer(
-  const DoFHandler<dim>                       &dof_handler,
-  const SmartPointer<const MGConstrainedDoFs> &mg_constrained_dofs)
+  const DoFHandler<dim>                          &dof_handler,
+  const ObserverPointer<const MGConstrainedDoFs> &mg_constrained_dofs)
 {
   const unsigned int min_level = 0;
   const unsigned int max_level =

--- a/include/deal.II/multigrid/multigrid.h
+++ b/include/deal.II/multigrid/multigrid.h
@@ -422,30 +422,30 @@ private:
   /**
    * The matrix for each level.
    */
-  SmartPointer<const MGMatrixBase<VectorType>, Multigrid<VectorType>> matrix;
+  ObserverPointer<const MGMatrixBase<VectorType>, Multigrid<VectorType>> matrix;
 
   /**
    * The matrix for each level.
    */
-  SmartPointer<const MGCoarseGridBase<VectorType>, Multigrid<VectorType>>
+  ObserverPointer<const MGCoarseGridBase<VectorType>, Multigrid<VectorType>>
     coarse;
 
   /**
    * Object for grid transfer.
    */
-  SmartPointer<const MGTransferBase<VectorType>, Multigrid<VectorType>>
+  ObserverPointer<const MGTransferBase<VectorType>, Multigrid<VectorType>>
     transfer;
 
   /**
    * The pre-smoothing object.
    */
-  SmartPointer<const MGSmootherBase<VectorType>, Multigrid<VectorType>>
+  ObserverPointer<const MGSmootherBase<VectorType>, Multigrid<VectorType>>
     pre_smooth;
 
   /**
    * The post-smoothing object.
    */
-  SmartPointer<const MGSmootherBase<VectorType>, Multigrid<VectorType>>
+  ObserverPointer<const MGSmootherBase<VectorType>, Multigrid<VectorType>>
     post_smooth;
 
   /**
@@ -453,7 +453,7 @@ private:
    *
    * @note Only <tt>vmult</tt> is used for these matrices.
    */
-  SmartPointer<const MGMatrixBase<VectorType>> edge_out;
+  ObserverPointer<const MGMatrixBase<VectorType>> edge_out;
 
   /**
    * Transpose edge matrix from the refinement edge to the interior of the
@@ -461,21 +461,23 @@ private:
    *
    * @note Only <tt>Tvmult</tt> is used for these matrices.
    */
-  SmartPointer<const MGMatrixBase<VectorType>> edge_in;
+  ObserverPointer<const MGMatrixBase<VectorType>> edge_in;
 
   /**
    * Edge matrix from fine to coarse.
    *
    * @note Only <tt>vmult</tt> is used for these matrices.
    */
-  SmartPointer<const MGMatrixBase<VectorType>, Multigrid<VectorType>> edge_down;
+  ObserverPointer<const MGMatrixBase<VectorType>, Multigrid<VectorType>>
+    edge_down;
 
   /**
    * Transpose edge matrix from coarse to fine.
    *
    * @note Only <tt>Tvmult</tt> is used for these matrices.
    */
-  SmartPointer<const MGMatrixBase<VectorType>, Multigrid<VectorType>> edge_up;
+  ObserverPointer<const MGMatrixBase<VectorType>, Multigrid<VectorType>>
+    edge_up;
 
   template <int dim, typename OtherVectorType, typename TransferType>
   friend class PreconditionMG;
@@ -610,28 +612,28 @@ private:
   /**
    * Associated @p DoFHandler.
    */
-  std::vector<SmartPointer<const DoFHandler<dim>,
-                           PreconditionMG<dim, VectorType, TransferType>>>
+  std::vector<ObserverPointer<const DoFHandler<dim>,
+                              PreconditionMG<dim, VectorType, TransferType>>>
     dof_handler_vector;
 
   /**
    * Storage for the pointers to the DoFHandler objects
-   * without SmartPointer wrapper.
+   * without ObserverPointer wrapper.
    */
   std::vector<const DoFHandler<dim> *> dof_handler_vector_raw;
 
   /**
    * The multigrid object.
    */
-  SmartPointer<Multigrid<VectorType>,
-               PreconditionMG<dim, VectorType, TransferType>>
+  ObserverPointer<Multigrid<VectorType>,
+                  PreconditionMG<dim, VectorType, TransferType>>
     multigrid;
 
   /**
    * Object for grid transfer.
    */
-  SmartPointer<const TransferType,
-               PreconditionMG<dim, VectorType, TransferType>>
+  ObserverPointer<const TransferType,
+                  PreconditionMG<dim, VectorType, TransferType>>
     transfer;
 
   /**

--- a/include/deal.II/multigrid/multigrid.h
+++ b/include/deal.II/multigrid/multigrid.h
@@ -19,7 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/mg_level_object.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/subscriptor.h>
 
 #include <deal.II/distributed/tria.h>

--- a/include/deal.II/non_matching/fe_values.h
+++ b/include/deal.II/non_matching/fe_values.h
@@ -322,12 +322,12 @@ namespace NonMatching
     /**
      * A pointer to the collection of mappings to be used.
      */
-    const SmartPointer<const hp::MappingCollection<dim>> mapping_collection;
+    const ObserverPointer<const hp::MappingCollection<dim>> mapping_collection;
 
     /**
      * A pointer to the collection of finite elements to be used.
      */
-    const SmartPointer<const hp::FECollection<dim>> fe_collection;
+    const ObserverPointer<const hp::FECollection<dim>> fe_collection;
 
     /**
      * Collection of 1-dimensional quadrature rules that are used by
@@ -353,7 +353,7 @@ namespace NonMatching
     /**
      * Pointer to the MeshClassifier passed to the constructor.
      */
-    const SmartPointer<const MeshClassifier<dim>> mesh_classifier;
+    const ObserverPointer<const MeshClassifier<dim>> mesh_classifier;
 
     /**
      * For each element in the FECollection passed to the constructor,
@@ -650,12 +650,12 @@ namespace NonMatching
     /**
      * A pointer to the collection of mappings to be used.
      */
-    const SmartPointer<const hp::MappingCollection<dim>> mapping_collection;
+    const ObserverPointer<const hp::MappingCollection<dim>> mapping_collection;
 
     /**
      * A pointer to the collection of finite elements to be used.
      */
-    const SmartPointer<const hp::FECollection<dim>> fe_collection;
+    const ObserverPointer<const hp::FECollection<dim>> fe_collection;
 
     /**
      * Collection of 1-dimensional quadrature rules that are used by
@@ -676,7 +676,7 @@ namespace NonMatching
     /**
      * Pointer to the MeshClassifier passed to the constructor.
      */
-    const SmartPointer<const MeshClassifier<dim>> mesh_classifier;
+    const ObserverPointer<const MeshClassifier<dim>> mesh_classifier;
 
     /**
      * FEInterfaceValues corresponding to cells with LocationToLevelSet

--- a/include/deal.II/non_matching/fe_values.h
+++ b/include/deal.II/non_matching/fe_values.h
@@ -16,7 +16,7 @@
 #define dealii_non_matching_fe_values
 
 #include <deal.II/base/bounding_box.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/dofs/dof_handler.h>
 

--- a/include/deal.II/non_matching/mapping_info.h
+++ b/include/deal.II/non_matching/mapping_info.h
@@ -52,16 +52,16 @@ namespace NonMatching
     public:
       static UpdateFlags
       required_update_flags(
-        const SmartPointer<const Mapping<dim, spacedim>> &mapping,
-        const UpdateFlags                                &update_flags)
+        const ObserverPointer<const Mapping<dim, spacedim>> &mapping,
+        const UpdateFlags                                   &update_flags)
       {
         return mapping->requires_update_flags(update_flags);
       }
 
       static void
       compute_mapping_data_for_quadrature(
-        const SmartPointer<const Mapping<dim, spacedim>> &mapping,
-        const UpdateFlags                                &update_flags_mapping,
+        const ObserverPointer<const Mapping<dim, spacedim>> &mapping,
+        const UpdateFlags &update_flags_mapping,
         const typename Triangulation<dim, spacedim>::cell_iterator &cell,
         CellSimilarity::Similarity &cell_similarity,
         const Quadrature<dim>      &quadrature,
@@ -83,8 +83,8 @@ namespace NonMatching
 
       static void
       compute_mapping_data_for_immersed_surface_quadrature(
-        const SmartPointer<const Mapping<dim, spacedim>> &mapping,
-        const UpdateFlags                                &update_flags_mapping,
+        const ObserverPointer<const Mapping<dim, spacedim>> &mapping,
+        const UpdateFlags &update_flags_mapping,
         const typename Triangulation<dim, spacedim>::cell_iterator &cell,
         const ImmersedSurfaceQuadrature<dim>                       &quadrature,
         std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>
@@ -105,8 +105,8 @@ namespace NonMatching
 
       static void
       compute_mapping_data_for_face_quadrature(
-        const SmartPointer<const Mapping<dim, spacedim>> &mapping,
-        const UpdateFlags                                &update_flags_mapping,
+        const ObserverPointer<const Mapping<dim, spacedim>> &mapping,
+        const UpdateFlags &update_flags_mapping,
         const typename Triangulation<dim, spacedim>::cell_iterator &cell,
         const unsigned int                                          face_no,
         const Quadrature<dim - 1>                                  &quadrature,
@@ -654,7 +654,7 @@ namespace NonMatching
     /**
      * A pointer to the underlying mapping.
      */
-    const SmartPointer<const Mapping<dim, spacedim>> mapping;
+    const ObserverPointer<const Mapping<dim, spacedim>> mapping;
 
     /**
      * The desired update flags for the evaluation.
@@ -757,7 +757,7 @@ namespace NonMatching
      * reinit functions. This field is only set if
      * AdditionalData::store_cells is enabled.
      */
-    SmartPointer<const Triangulation<dim, spacedim>> triangulation;
+    ObserverPointer<const Triangulation<dim, spacedim>> triangulation;
 
     /**
      * Level and indices of cells passed to the reinit functions. This

--- a/include/deal.II/non_matching/mesh_classifier.h
+++ b/include/deal.II/non_matching/mesh_classifier.h
@@ -172,7 +172,7 @@ namespace NonMatching
     /**
      * Pointer to the triangulation that should be classified.
      */
-    const SmartPointer<const Triangulation<dim>> triangulation;
+    const ObserverPointer<const Triangulation<dim>> triangulation;
 
     /**
      * Pointer to an object that describes what we need to know about the

--- a/include/deal.II/non_matching/quadrature_generator.h
+++ b/include/deal.II/non_matching/quadrature_generator.h
@@ -946,7 +946,7 @@ namespace NonMatching
          * One dimensional quadrature rules used to create the immersed
          * quadratures.
          */
-        const SmartPointer<const hp::QCollection<1>> q_collection1D;
+        const ObserverPointer<const hp::QCollection<1>> q_collection1D;
 
         /**
          * Stores options/settings for the algorithm.
@@ -1057,7 +1057,7 @@ namespace NonMatching
          * Index of the quadrature in q_collection1d that should use to
          * generate the immersed quadrature rules.
          */
-        const SmartPointer<const hp::QCollection<1>> q_collection1D;
+        const ObserverPointer<const hp::QCollection<1>> q_collection1D;
 
         /**
          * Quadratures that the derived classes create.

--- a/include/deal.II/numerics/cell_data_transfer.h
+++ b/include/deal.II/numerics/cell_data_transfer.h
@@ -159,8 +159,8 @@ private:
   /**
    * Pointer to the triangulation to work with.
    */
-  SmartPointer<const Triangulation<dim, spacedim>,
-               CellDataTransfer<dim, spacedim, VectorType>>
+  ObserverPointer<const Triangulation<dim, spacedim>,
+                  CellDataTransfer<dim, spacedim, VectorType>>
     triangulation;
 
   /**

--- a/include/deal.II/numerics/cell_data_transfer.h
+++ b/include/deal.II/numerics/cell_data_transfer.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/grid/tria.h>
 

--- a/include/deal.II/numerics/data_out_dof_data.h
+++ b/include/deal.II/numerics/data_out_dof_data.h
@@ -342,7 +342,7 @@ namespace internal
       /**
        * Pointer to the DoFHandler object that the vector is based on.
        */
-      SmartPointer<const DoFHandler<dim, spacedim>> dof_handler;
+      ObserverPointer<const DoFHandler<dim, spacedim>> dof_handler;
 
       /**
        * Names of the components of this data vector.
@@ -362,7 +362,7 @@ namespace internal
        * Pointer to a DataPostprocessing object which shall be applied to this
        * data vector.
        */
-      SmartPointer<const dealii::DataPostprocessor<spacedim>> postprocessor;
+      ObserverPointer<const dealii::DataPostprocessor<spacedim>> postprocessor;
 
       /**
        * Number of output variables this dataset provides (either number of
@@ -952,12 +952,12 @@ protected:
   /**
    * Pointer to the triangulation object.
    */
-  SmartPointer<const Triangulation<dim, spacedim>> triangulation;
+  ObserverPointer<const Triangulation<dim, spacedim>> triangulation;
 
   /**
    * Pointer to the optional handler object.
    */
-  SmartPointer<const DoFHandler<dim, spacedim>> dofs;
+  ObserverPointer<const DoFHandler<dim, spacedim>> dofs;
 
   /**
    * List of data elements with vectors of values for each degree of freedom.

--- a/include/deal.II/numerics/data_out_dof_data.h
+++ b/include/deal.II/numerics/data_out_dof_data.h
@@ -21,7 +21,7 @@
 
 #include <deal.II/base/data_out_base.h>
 #include <deal.II/base/mg_level_object.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/dofs/dof_handler.h>
 

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -1756,10 +1756,10 @@ DataOut_DoFData<dim, patch_dim, spacedim, patch_spacedim>::attach_dof_handler(
          Exceptions::DataOutImplementation::ExcOldDataStillPresent());
 
   triangulation =
-    SmartPointer<const Triangulation<dim, spacedim>>(&d.get_triangulation(),
-                                                     typeid(*this).name());
+    ObserverPointer<const Triangulation<dim, spacedim>>(&d.get_triangulation(),
+                                                        typeid(*this).name());
   dofs =
-    SmartPointer<const DoFHandler<dim, spacedim>>(&d, typeid(*this).name());
+    ObserverPointer<const DoFHandler<dim, spacedim>>(&d, typeid(*this).name());
 }
 
 
@@ -1775,8 +1775,8 @@ DataOut_DoFData<dim, patch_dim, spacedim, patch_spacedim>::attach_triangulation(
          Exceptions::DataOutImplementation::ExcOldDataStillPresent());
 
   triangulation =
-    SmartPointer<const Triangulation<dim, spacedim>>(&tria,
-                                                     typeid(*this).name());
+    ObserverPointer<const Triangulation<dim, spacedim>>(&tria,
+                                                        typeid(*this).name());
 }
 
 
@@ -1801,7 +1801,7 @@ DataOut_DoFData<dim, patch_dim, spacedim, patch_spacedim>::add_data_vector(
     }
   else
     {
-      triangulation = SmartPointer<const Triangulation<dim, spacedim>>(
+      triangulation = ObserverPointer<const Triangulation<dim, spacedim>>(
         &dof_handler.get_triangulation(), typeid(*this).name());
     }
 
@@ -1841,7 +1841,7 @@ DataOut_DoFData<dim, patch_dim, spacedim, patch_spacedim>::
   if (triangulation == nullptr)
     {
       Assert(dof_handler != nullptr, ExcInternalError());
-      triangulation = SmartPointer<const Triangulation<dim, spacedim>>(
+      triangulation = ObserverPointer<const Triangulation<dim, spacedim>>(
         &dof_handler->get_triangulation(), typeid(*this).name());
     }
 
@@ -1981,7 +1981,7 @@ DataOut_DoFData<dim, patch_dim, spacedim, patch_spacedim>::add_mg_data_vector(
     &data_component_interpretation_)
 {
   if (triangulation == nullptr)
-    triangulation = SmartPointer<const Triangulation<dim, spacedim>>(
+    triangulation = ObserverPointer<const Triangulation<dim, spacedim>>(
       &dof_handler.get_triangulation(), typeid(*this).name());
 
   Assert(&dof_handler.get_triangulation() == triangulation,

--- a/include/deal.II/numerics/data_out_resample.h
+++ b/include/deal.II/numerics/data_out_resample.h
@@ -136,7 +136,7 @@ private:
   /**
    * Mapping used in connection with patch_tria.
    */
-  const SmartPointer<const Mapping<patch_dim, spacedim>> patch_mapping;
+  const ObserverPointer<const Mapping<patch_dim, spacedim>> patch_mapping;
 
   /**
    * DataOut object that does the actual building of the patches.
@@ -161,7 +161,7 @@ private:
   /**
    * Mapping of the original triangulation provided in update_mapping().
    */
-  SmartPointer<const Mapping<dim, spacedim>> mapping;
+  ObserverPointer<const Mapping<dim, spacedim>> mapping;
 };
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/numerics/data_out_stack.h
+++ b/include/deal.II/numerics/data_out_stack.h
@@ -19,7 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/data_out_base.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/lac/vector.h>
 

--- a/include/deal.II/numerics/data_out_stack.h
+++ b/include/deal.II/numerics/data_out_stack.h
@@ -323,7 +323,7 @@ private:
    * DoF handler to be used for the data corresponding to the present
    * parameter value.
    */
-  SmartPointer<const DoFHandler<dim, spacedim>, DataOutStack<dim, spacedim>>
+  ObserverPointer<const DoFHandler<dim, spacedim>, DataOutStack<dim, spacedim>>
     dof_handler;
 
   /**

--- a/include/deal.II/numerics/dof_output_operator.h
+++ b/include/deal.II/numerics/dof_output_operator.h
@@ -65,8 +65,8 @@ namespace Algorithms
     operator<<(const AnyData &vectors) override;
 
   private:
-    SmartPointer<const DoFHandler<dim, spacedim>,
-                 DoFOutputOperator<VectorType, dim, spacedim>>
+    ObserverPointer<const DoFHandler<dim, spacedim>,
+                    DoFOutputOperator<VectorType, dim, spacedim>>
       dof;
 
     const std::string  filename_base;

--- a/include/deal.II/numerics/fe_field_function.h
+++ b/include/deal.II/numerics/fe_field_function.h
@@ -469,8 +469,8 @@ namespace Functions
     /**
      * Pointer to the dof handler.
      */
-    SmartPointer<const DoFHandler<dim, spacedim>,
-                 FEFieldFunction<dim, VectorType, spacedim>>
+    ObserverPointer<const DoFHandler<dim, spacedim>,
+                    FEFieldFunction<dim, VectorType, spacedim>>
       dh;
 
     /**

--- a/include/deal.II/numerics/point_value_history.h
+++ b/include/deal.II/numerics/point_value_history.h
@@ -19,9 +19,9 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/quadrature_lib.h>
-#include <deal.II/base/smartpointer.h>
 
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_handler.h>

--- a/include/deal.II/numerics/point_value_history.h
+++ b/include/deal.II/numerics/point_value_history.h
@@ -634,7 +634,7 @@ private:
    * A smart pointer to the dof_handler supplied to the constructor. This can
    * be released by calling @p clear().
    */
-  SmartPointer<const DoFHandler<dim>, PointValueHistory<dim>> dof_handler;
+  ObserverPointer<const DoFHandler<dim>, PointValueHistory<dim>> dof_handler;
 
 
   /**

--- a/include/deal.II/numerics/solution_transfer.h
+++ b/include/deal.II/numerics/solution_transfer.h
@@ -415,8 +415,8 @@ private:
   /**
    * Pointer to the degree of freedom handler to work with.
    */
-  SmartPointer<const DoFHandler<dim, spacedim>,
-               SolutionTransfer<dim, VectorType, spacedim>>
+  ObserverPointer<const DoFHandler<dim, spacedim>,
+                  SolutionTransfer<dim, VectorType, spacedim>>
     dof_handler;
 
   /**
@@ -915,8 +915,8 @@ namespace Legacy
     /**
      * Pointer to the degree of freedom handler to work with.
      */
-    SmartPointer<const DoFHandler<dim, spacedim>,
-                 SolutionTransfer<dim, VectorType, spacedim>>
+    ObserverPointer<const DoFHandler<dim, spacedim>,
+                    SolutionTransfer<dim, VectorType, spacedim>>
       dof_handler;
 
     /**

--- a/include/deal.II/numerics/solution_transfer.h
+++ b/include/deal.II/numerics/solution_transfer.h
@@ -22,7 +22,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/dofs/dof_handler.h>
 

--- a/include/deal.II/numerics/time_dependent.h
+++ b/include/deal.II/numerics/time_dependent.h
@@ -616,7 +616,7 @@ protected:
    * this object operates on. Note that this object takes possession of the
    * objects pointed to by the pointers in this collection.
    */
-  std::vector<SmartPointer<TimeStepBase, TimeDependent>> timesteps;
+  std::vector<ObserverPointer<TimeStepBase, TimeDependent>> timesteps;
 
   /**
    * Number of the present sweep. This is reset by the @p start_sweep function
@@ -1466,14 +1466,14 @@ protected:
    * the functions @p sleep and @p wake_up to save memory, if such a behavior
    * is specified in the @p flags structure.
    */
-  SmartPointer<Triangulation<dim, dim>, TimeStepBase_Tria<dim>> tria;
+  ObserverPointer<Triangulation<dim, dim>, TimeStepBase_Tria<dim>> tria;
 
   /**
    * Pointer to a grid which is to be used as the coarse grid for this time
    * level.  This pointer is set through the constructor; ownership remains
    * with the owner of this management object.
    */
-  SmartPointer<const Triangulation<dim, dim>, TimeStepBase_Tria<dim>>
+  ObserverPointer<const Triangulation<dim, dim>, TimeStepBase_Tria<dim>>
     coarse_grid;
 
   /**

--- a/include/deal.II/numerics/time_dependent.h
+++ b/include/deal.II/numerics/time_dependent.h
@@ -19,7 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/subscriptor.h>
 #include <deal.II/base/template_constraints.h>
 

--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -20,7 +20,7 @@
 #include <deal.II/base/array_view.h>
 #include <deal.II/base/bounding_box.h>
 #include <deal.II/base/function.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/subscriptor.h>
 
 #include <deal.II/distributed/tria.h>

--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -877,14 +877,15 @@ namespace Particles
     /**
      * Address of the triangulation to work on.
      */
-    SmartPointer<const Triangulation<dim, spacedim>,
-                 ParticleHandler<dim, spacedim>>
+    ObserverPointer<const Triangulation<dim, spacedim>,
+                    ParticleHandler<dim, spacedim>>
       triangulation;
 
     /**
      * Address of the mapping to work on.
      */
-    SmartPointer<const Mapping<dim, spacedim>, ParticleHandler<dim, spacedim>>
+    ObserverPointer<const Mapping<dim, spacedim>,
+                    ParticleHandler<dim, spacedim>>
       mapping;
 
     /**

--- a/source/base/subscriptor.cc
+++ b/source/base/subscriptor.cc
@@ -96,7 +96,7 @@ Subscriptor::check_no_subscribers() const noexcept
           std::cerr
             << "---------------------------------------------------------"
             << std::endl
-            << "An object pointed to by a SmartPointer is being destroyed."
+            << "An object pointed to by a ObserverPointer is being destroyed."
             << std::endl
             << "Under normal circumstances, this would abort the program."
             << std::endl

--- a/source/grid/intergrid_map.cc
+++ b/source/grid/intergrid_map.cc
@@ -13,7 +13,7 @@
 // ------------------------------------------------------------------------
 
 #include <deal.II/base/memory_consumption.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/distributed/fully_distributed_tria.h>
 #include <deal.II/distributed/shared_tria.h>

--- a/source/multigrid/mg_level_global_transfer.cc
+++ b/source/multigrid/mg_level_global_transfer.cc
@@ -161,7 +161,7 @@ namespace
   void
   fill_internal(
     const DoFHandler<dim, spacedim>            &mg_dof,
-    SmartPointer<const MGConstrainedDoFs>       mg_constrained_dofs,
+    ObserverPointer<const MGConstrainedDoFs>    mg_constrained_dofs,
     const MPI_Comm                              mpi_communicator,
     const bool                                  transfer_solution_vectors,
     std::vector<Table<2, unsigned int>>        &copy_indices,

--- a/source/non_matching/mesh_classifier.cc
+++ b/source/non_matching/mesh_classifier.cc
@@ -120,13 +120,13 @@ namespace NonMatching
         /**
          * Pointer to the DoFHandler associated with the level set function.
          */
-        const SmartPointer<const DoFHandler<dim>> dof_handler;
+        const ObserverPointer<const DoFHandler<dim>> dof_handler;
 
         /**
          * Pointer to the vector containing the level set function's global dof
          * values.
          */
-        const SmartPointer<const VectorType> level_set;
+        const ObserverPointer<const VectorType> level_set;
       };
 
 
@@ -229,7 +229,7 @@ namespace NonMatching
         /**
          * Pointer to the level set function.
          */
-        const SmartPointer<const Function<dim>> level_set;
+        const ObserverPointer<const Function<dim>> level_set;
 
         /**
          * Collection containing the single element which we locally interpolate

--- a/source/non_matching/quadrature_generator.cc
+++ b/source/non_matching/quadrature_generator.cc
@@ -1414,19 +1414,19 @@ namespace NonMatching
         /**
          * Pointer to the DoFHandler passed to the constructor.
          */
-        const SmartPointer<const DoFHandler<dim>> dof_handler;
+        const ObserverPointer<const DoFHandler<dim>> dof_handler;
 
         /**
          * Pointer to the vector of solution coefficients passed to the
          * constructor.
          */
-        const SmartPointer<const VectorType> global_dof_values;
+        const ObserverPointer<const VectorType> global_dof_values;
 
         /**
          * Pointer to the element associated with the cell in the last call to
          * set_active_cell().
          */
-        SmartPointer<const FiniteElement<dim>> element;
+        ObserverPointer<const FiniteElement<dim>> element;
 
         /**
          * DOF-indices of the cell in the last call to set_active_cell().

--- a/source/numerics/time_dependent.cc
+++ b/source/numerics/time_dependent.cc
@@ -98,7 +98,7 @@ TimeDependent::insert_timestep(const TimeStepBase *position,
   else
     {
       // inner time step
-      const std::vector<SmartPointer<TimeStepBase, TimeDependent>>::iterator
+      const std::vector<ObserverPointer<TimeStepBase, TimeDependent>>::iterator
         insert_position =
           std::find(timesteps.begin(), timesteps.end(), position);
       // check iterators again to satisfy coverity: both insert_position and
@@ -136,7 +136,7 @@ TimeDependent::delete_timestep(const unsigned int position)
 
   // Remember time step object for
   // later deletion and unlock
-  // SmartPointer
+  // ObserverPointer
   TimeStepBase *t     = timesteps[position];
   timesteps[position] = nullptr;
   // Now delete unsubscribed object
@@ -153,14 +153,15 @@ TimeDependent::delete_timestep(const unsigned int position)
     timesteps[position - 1]->set_next_timestep(
       (position < timesteps.size()) ?
         timesteps[position] :
-        /*null*/ SmartPointer<TimeStepBase, TimeDependent>());
+        /*null*/ ObserverPointer<TimeStepBase, TimeDependent>());
 
   // same for "previous" pointer of next
   // time step
   if (position < timesteps.size())
     timesteps[position]->set_previous_timestep(
-      (position != 0) ? timesteps[position - 1] :
-                        /*null*/ SmartPointer<TimeStepBase, TimeDependent>());
+      (position != 0) ?
+        timesteps[position - 1] :
+        /*null*/ ObserverPointer<TimeStepBase, TimeDependent>());
 }
 
 

--- a/tests/algorithms/newton_01.cc
+++ b/tests/algorithms/newton_01.cc
@@ -37,7 +37,7 @@ public:
 
 class SquareRootResidual : public Algorithms::OperatorBase
 {
-  SmartPointer<SquareRoot, SquareRootResidual> discretization;
+  ObserverPointer<SquareRoot, SquareRootResidual> discretization;
 
 public:
   SquareRootResidual(SquareRoot &problem)
@@ -53,7 +53,7 @@ public:
 
 class SquareRootSolver : public Algorithms::OperatorBase
 {
-  SmartPointer<SquareRoot, SquareRootSolver> solver;
+  ObserverPointer<SquareRoot, SquareRootSolver> solver;
 
 public:
   SquareRootSolver(SquareRoot &problem)

--- a/tests/algorithms/newton_02.cc
+++ b/tests/algorithms/newton_02.cc
@@ -58,7 +58,8 @@ public:
   }
 
 private:
-  SmartPointer<const DoFHandler<dim>, TestOutputOperator<VectorType, dim>> dof;
+  ObserverPointer<const DoFHandler<dim>, TestOutputOperator<VectorType, dim>>
+    dof;
 };
 
 class ZeroResidual : public Algorithms::OperatorBase

--- a/tests/algorithms/theta_01.cc
+++ b/tests/algorithms/theta_01.cc
@@ -36,8 +36,8 @@ public:
   operator()(AnyData &out, const AnyData &in);
 
 private:
-  SmartPointer<const FullMatrix<double>, Explicit> matrix;
-  FullMatrix<double>                               m;
+  ObserverPointer<const FullMatrix<double>, Explicit> matrix;
+  FullMatrix<double>                                  m;
 };
 
 
@@ -49,8 +49,8 @@ public:
   operator()(AnyData &out, const AnyData &in);
 
 private:
-  SmartPointer<const FullMatrix<double>, Implicit> matrix;
-  FullMatrix<double>                               m;
+  ObserverPointer<const FullMatrix<double>, Implicit> matrix;
+  FullMatrix<double>                                  m;
 };
 
 // End of declarations

--- a/tests/base/assign_subscriptor.cc
+++ b/tests/base/assign_subscriptor.cc
@@ -18,7 +18,7 @@
 // for copy and move semantics.
 
 
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/subscriptor.h>
 
 #include <iostream>

--- a/tests/base/assign_subscriptor.cc
+++ b/tests/base/assign_subscriptor.cc
@@ -14,7 +14,7 @@
 
 
 
-// Check the behavior of the SmartPointer-Subscriptor pair
+// Check the behavior of the ObserverPointer-Subscriptor pair
 // for copy and move semantics.
 
 
@@ -39,10 +39,10 @@ main()
   {
     deallog << "Checking copy assignment" << std::endl;
 
-    Subscriptor               subscriptor_1;
-    Subscriptor               subscriptor_2;
-    SmartPointer<Subscriptor> smart_pointer_1(&subscriptor_1);
-    SmartPointer<Subscriptor> smart_pointer_2(&subscriptor_2);
+    Subscriptor                  subscriptor_1;
+    Subscriptor                  subscriptor_2;
+    ObserverPointer<Subscriptor> smart_pointer_1(&subscriptor_1);
+    ObserverPointer<Subscriptor> smart_pointer_2(&subscriptor_2);
 
     subscriptor_2 = subscriptor_1;
 
@@ -73,8 +73,8 @@ main()
   {
     deallog << "Checking copy construction" << std::endl;
 
-    Subscriptor               subscriptor_1;
-    SmartPointer<Subscriptor> smart_pointer_1(&subscriptor_1);
+    Subscriptor                  subscriptor_1;
+    ObserverPointer<Subscriptor> smart_pointer_1(&subscriptor_1);
 
     Subscriptor subscriptor_2(subscriptor_1);
 
@@ -94,10 +94,10 @@ main()
   {
     deallog << "Checking move assignment" << std::endl;
 
-    Subscriptor               subscriptor_1;
-    Subscriptor               subscriptor_2;
-    SmartPointer<Subscriptor> smart_pointer_1(&subscriptor_1);
-    SmartPointer<Subscriptor> smart_pointer_2(&subscriptor_2);
+    Subscriptor                  subscriptor_1;
+    Subscriptor                  subscriptor_2;
+    ObserverPointer<Subscriptor> smart_pointer_1(&subscriptor_1);
+    ObserverPointer<Subscriptor> smart_pointer_2(&subscriptor_2);
 
     subscriptor_2 = std::move(subscriptor_1);
 
@@ -128,8 +128,8 @@ main()
   {
     deallog << "Checking move construction" << std::endl;
 
-    Subscriptor               subscriptor_1;
-    SmartPointer<Subscriptor> smart_pointer_1(&subscriptor_1);
+    Subscriptor                  subscriptor_1;
+    ObserverPointer<Subscriptor> smart_pointer_1(&subscriptor_1);
 
     Subscriptor subscriptor_2(std::move(subscriptor_1));
 

--- a/tests/base/reference.cc
+++ b/tests/base/reference.cc
@@ -14,8 +14,8 @@
 
 
 
-// check that SmartPointers preserve constness etc of the objects they
-// point to, through assignment of SmartPointers to each other and
+// check that ObserverPointers preserve constness etc of the objects they
+// point to, through assignment of ObserverPointers to each other and
 // other tests.
 
 
@@ -70,11 +70,11 @@ main()
   Test        a("A");
   const Test &b("B");
 
-  SmartPointer<Test, Test>       r(&a, "Test R");
-  SmartPointer<const Test, Test> s(&a, "const Test S");
-  //  SmartPointer<Test,Test>       t=&b;    // this one should not work
-  SmartPointer<Test, Test>       t(const_cast<Test *>(&b), "Test T");
-  SmartPointer<const Test, Test> u(&b, "const Test");
+  ObserverPointer<Test, Test>       r(&a, "Test R");
+  ObserverPointer<const Test, Test> s(&a, "const Test S");
+  //  ObserverPointer<Test,Test>       t=&b;    // this one should not work
+  ObserverPointer<Test, Test>       t(const_cast<Test *>(&b), "Test T");
+  ObserverPointer<const Test, Test> u(&b, "const Test");
 
 
   deallog << "a ";

--- a/tests/base/reference.cc
+++ b/tests/base/reference.cc
@@ -19,7 +19,7 @@
 // other tests.
 
 
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/subscriptor.h>
 
 #include <iostream>

--- a/tests/base/smart_pointer_01.cc
+++ b/tests/base/smart_pointer_01.cc
@@ -14,7 +14,7 @@
 
 
 
-// Check that it is possible to put SmartPointer objects into a
+// Check that it is possible to put ObserverPointer objects into a
 // std::any object.
 
 
@@ -36,7 +36,7 @@ main()
 {
   initlog();
 
-  Test               t;
-  SmartPointer<Test> r(&t);
-  std::any           a = r;
+  Test                  t;
+  ObserverPointer<Test> r(&t);
+  std::any              a = r;
 }

--- a/tests/base/smart_pointer_01.cc
+++ b/tests/base/smart_pointer_01.cc
@@ -18,7 +18,7 @@
 // std::any object.
 
 
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/subscriptor.h>
 
 #include <any>

--- a/tests/base/smart_pointer_02.cc
+++ b/tests/base/smart_pointer_02.cc
@@ -1,0 +1,41 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+
+// Ensure that the old SmartPointer class name continues to be
+// available after the renaming to ObserverPointer.
+
+
+#include <deal.II/base/observer_pointer.h>
+#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/subscriptor.h>
+
+#include <any>
+#include <iostream>
+
+#include "../tests.h"
+
+
+class Test : public Subscriptor
+{};
+
+
+int
+main()
+{
+  static_assert(std::is_same_v<ObserverPointer<Test>, SmartPointer<Test>>);
+  static_assert(
+    std::is_same_v<ObserverPointer<Test, int>, SmartPointer<Test, int>>);
+}

--- a/tests/base/unsubscribe_subscriptor.cc
+++ b/tests/base/unsubscribe_subscriptor.cc
@@ -17,7 +17,7 @@
 // check that unsubscribing with a wrong id is handled correctly
 
 
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/subscriptor.h>
 
 #include <iostream>

--- a/tests/base/unsubscribe_subscriptor_01.cc
+++ b/tests/base/unsubscribe_subscriptor_01.cc
@@ -19,7 +19,7 @@
 // works as well
 
 
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/subscriptor.h>
 
 #include <iostream>

--- a/tests/bits/joa_1.cc
+++ b/tests/bits/joa_1.cc
@@ -288,7 +288,7 @@ LaplaceProblem<dim>::LaplaceProblem()
 // finite element object which counts
 // how many objects use that finite
 // element (this is what the
-// <code>Subscriptor</code>/<code>SmartPointer</code>
+// <code>Subscriptor</code>/<code>ObserverPointer</code>
 // class pair is used for, in case
 // you want something like this for
 // your own programs; see step-7 for

--- a/tests/bits/sparse_lu_decomposition_1.cc
+++ b/tests/bits/sparse_lu_decomposition_1.cc
@@ -16,7 +16,7 @@
 // this file didn't compile at one point in time due to the private
 // inheritance of SparseMatrix by SparseLUDecomposition, and the
 // associated lack of accessibility of the Subscriptor functions to
-// the SmartPointer
+// the ObserverPointer
 //
 // it was fixed around 2003-05-22
 
@@ -34,7 +34,7 @@ main()
 {
   initlog();
 
-  SmartPointer<SparseLUDecomposition<double>> sparse_decomp;
+  ObserverPointer<SparseLUDecomposition<double>> sparse_decomp;
 
   deallog << "OK" << std::endl;
 

--- a/tests/bits/sparse_lu_decomposition_1.cc
+++ b/tests/bits/sparse_lu_decomposition_1.cc
@@ -21,7 +21,7 @@
 // it was fixed around 2003-05-22
 
 
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/lac/sparse_ilu.h>
 

--- a/tests/bits/static_condensation.cc
+++ b/tests/bits/static_condensation.cc
@@ -18,8 +18,8 @@
 
 #include <deal.II/base/convergence_table.h>
 #include <deal.II/base/function.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/quadrature_lib.h>
-#include <deal.II/base/smartpointer.h>
 
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_handler.h>

--- a/tests/bits/step-13.cc
+++ b/tests/bits/step-13.cc
@@ -220,7 +220,7 @@ namespace LaplaceSolver
     n_dofs() const = 0;
 
   protected:
-    const SmartPointer<Triangulation<dim>> triangulation;
+    const ObserverPointer<Triangulation<dim>> triangulation;
   };
 
 
@@ -256,11 +256,11 @@ namespace LaplaceSolver
     n_dofs() const;
 
   protected:
-    const SmartPointer<const FiniteElement<dim>> fe;
-    const SmartPointer<const Quadrature<dim>>    quadrature;
-    DoFHandler<dim>                              dof_handler;
-    Vector<double>                               solution;
-    const SmartPointer<const Function<dim>>      boundary_values;
+    const ObserverPointer<const FiniteElement<dim>> fe;
+    const ObserverPointer<const Quadrature<dim>>    quadrature;
+    DoFHandler<dim>                                 dof_handler;
+    Vector<double>                                  solution;
+    const ObserverPointer<const Function<dim>>      boundary_values;
 
     virtual void
     assemble_rhs(Vector<double> &rhs) const = 0;
@@ -490,7 +490,7 @@ namespace LaplaceSolver
                  const Function<dim>      &boundary_values);
 
   protected:
-    const SmartPointer<const Function<dim>> rhs_function;
+    const ObserverPointer<const Function<dim>> rhs_function;
     virtual void
     assemble_rhs(Vector<double> &rhs) const;
   };

--- a/tests/bits/step-14.cc
+++ b/tests/bits/step-14.cc
@@ -287,7 +287,7 @@ namespace LaplaceSolver
     output_solution() const = 0;
 
   protected:
-    const SmartPointer<Triangulation<dim>> triangulation;
+    const ObserverPointer<Triangulation<dim>> triangulation;
 
     unsigned int refinement_cycle;
   };
@@ -335,12 +335,12 @@ namespace LaplaceSolver
     n_dofs() const;
 
   protected:
-    const SmartPointer<const FiniteElement<dim>>  fe;
-    const SmartPointer<const Quadrature<dim>>     quadrature;
-    const SmartPointer<const Quadrature<dim - 1>> face_quadrature;
-    DoFHandler<dim>                               dof_handler;
-    Vector<double>                                solution;
-    const SmartPointer<const Function<dim>>       boundary_values;
+    const ObserverPointer<const FiniteElement<dim>>  fe;
+    const ObserverPointer<const Quadrature<dim>>     quadrature;
+    const ObserverPointer<const Quadrature<dim - 1>> face_quadrature;
+    DoFHandler<dim>                                  dof_handler;
+    Vector<double>                                   solution;
+    const ObserverPointer<const Function<dim>>       boundary_values;
 
     virtual void
     assemble_rhs(Vector<double> &rhs) const = 0;
@@ -581,7 +581,7 @@ namespace LaplaceSolver
     output_solution() const;
 
   protected:
-    const SmartPointer<const Function<dim>> rhs_function;
+    const ObserverPointer<const Function<dim>> rhs_function;
     virtual void
     assemble_rhs(Vector<double> &rhs) const;
 
@@ -808,7 +808,7 @@ namespace LaplaceSolver
     refine_grid();
 
   private:
-    const SmartPointer<const Function<dim>> weighting_function;
+    const ObserverPointer<const Function<dim>> weighting_function;
   };
 
 
@@ -1254,7 +1254,7 @@ namespace LaplaceSolver
     postprocess(const Evaluation::EvaluationBase<dim> &postprocessor) const;
 
   protected:
-    const SmartPointer<const DualFunctional::DualFunctionalBase<dim>>
+    const ObserverPointer<const DualFunctional::DualFunctionalBase<dim>>
       dual_functional;
     virtual void
     assemble_rhs(Vector<double> &rhs) const;
@@ -1362,8 +1362,8 @@ namespace LaplaceSolver
 
     struct CellData
     {
-      FEValues<dim>                           fe_values;
-      const SmartPointer<const Function<dim>> right_hand_side;
+      FEValues<dim>                              fe_values;
+      const ObserverPointer<const Function<dim>> right_hand_side;
 
       std::vector<double>                  cell_residual;
       std::vector<double>                  rhs_values;
@@ -1911,7 +1911,7 @@ public:
     unsigned int primal_fe_degree;
     unsigned int dual_fe_degree;
 
-    SmartPointer<const Data::SetUpBase<dim>> data;
+    ObserverPointer<const Data::SetUpBase<dim>> data;
 
     enum RefinementCriterion
     {
@@ -1923,11 +1923,12 @@ public:
 
     RefinementCriterion refinement_criterion;
 
-    SmartPointer<const DualFunctional::DualFunctionalBase<dim>> dual_functional;
+    ObserverPointer<const DualFunctional::DualFunctionalBase<dim>>
+      dual_functional;
 
     EvaluatorList evaluator_list;
 
-    SmartPointer<const Function<dim>> kelly_weight;
+    ObserverPointer<const Function<dim>> kelly_weight;
 
     unsigned int max_degrees_of_freedom;
 

--- a/tests/bits/step-7.cc
+++ b/tests/bits/step-7.cc
@@ -18,8 +18,8 @@
 
 #include <deal.II/base/convergence_table.h>
 #include <deal.II/base/function.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/quadrature_lib.h>
-#include <deal.II/base/smartpointer.h>
 
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_handler.h>

--- a/tests/bits/step-7.cc
+++ b/tests/bits/step-7.cc
@@ -202,7 +202,7 @@ private:
   Triangulation<dim> triangulation;
   DoFHandler<dim>    dof_handler;
 
-  SmartPointer<const FiniteElement<dim>> fe;
+  ObserverPointer<const FiniteElement<dim>> fe;
 
   AffineConstraints<double> hanging_node_constraints;
 

--- a/tests/codim_one/bem_integration.cc
+++ b/tests/codim_one/bem_integration.cc
@@ -86,7 +86,7 @@ private:
   double
   term_D(const Tensor<1, 3> &r, const Tensor<1, 3> &a1, const Tensor<1, 3> &a2);
 
-  SmartPointer<FEValues<dim, dim + 1>> fe_values;
+  ObserverPointer<FEValues<dim, dim + 1>> fe_values;
 };
 
 template <>

--- a/tests/codim_one/bem_integration.cc
+++ b/tests/codim_one/bem_integration.cc
@@ -30,7 +30,7 @@
 
 #include <deal.II/fe/fe_dgp.h>
 // #include <deal.II/fe/fe_q.h>
-#include <deal.II/base/smartpointer.h>
+#include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/fe/fe_tools.h>
 #include <deal.II/fe/fe_values.h>

--- a/tests/dofs/dof_handler_redistributed_dofs_01.cc
+++ b/tests/dofs/dof_handler_redistributed_dofs_01.cc
@@ -39,7 +39,7 @@ main()
   DoFHandler<dim, spacedim> dh(tria);
   dh.distribute_dofs(fe);
 
-  SmartPointer<const FiniteElement<dim, spacedim>> fe_p(&dh.get_fe());
+  ObserverPointer<const FiniteElement<dim, spacedim>> fe_p(&dh.get_fe());
 
   dh.distribute_dofs(*fe_p);
 

--- a/tests/dofs/dof_handler_redistributed_dofs_02.cc
+++ b/tests/dofs/dof_handler_redistributed_dofs_02.cc
@@ -40,7 +40,7 @@ main()
   DoFHandler<dim, spacedim> dh(tria);
   dh.distribute_dofs(fe_collection);
 
-  SmartPointer<const hp::FECollection<dim, spacedim>> fe_p(
+  ObserverPointer<const hp::FECollection<dim, spacedim>> fe_p(
     &dh.get_fe_collection());
 
   dh.distribute_dofs(*fe_p);

--- a/tests/fe/fe_conformity_test.h
+++ b/tests/fe/fe_conformity_test.h
@@ -86,10 +86,10 @@ namespace FEConforimityTest
                         const Vector<double>         &dof_vector,
                         std::vector<double>          &jumps);
 
-    SmartPointer<const FiniteElement<dim>> fe_ptr;
-    Triangulation<dim>                     triangulation;
-    DoFHandler<dim>                        dof_handler;
-    AffineConstraints<double>              constraints;
+    ObserverPointer<const FiniteElement<dim>> fe_ptr;
+    Triangulation<dim>                        triangulation;
+    DoFHandler<dim>                           dof_handler;
+    AffineConstraints<double>                 constraints;
 
     Vector<double> random_fe_function;
 

--- a/tests/fe/fe_q_dg0.cc
+++ b/tests/fe/fe_q_dg0.cc
@@ -321,8 +321,8 @@ namespace Step22
     vmult(Vector<double> &dst, const Vector<double> &src) const;
 
   private:
-    const SmartPointer<const Matrix>         matrix;
-    const SmartPointer<const Preconditioner> preconditioner;
+    const ObserverPointer<const Matrix>         matrix;
+    const ObserverPointer<const Preconditioner> preconditioner;
   };
 
 
@@ -364,8 +364,8 @@ namespace Step22
     vmult(Vector<double> &dst, const Vector<double> &src) const;
 
   private:
-    const SmartPointer<const BlockSparseMatrix<double>> system_matrix;
-    const SmartPointer<
+    const ObserverPointer<const BlockSparseMatrix<double>> system_matrix;
+    const ObserverPointer<
       const InverseMatrix<SparseMatrix<double>, Preconditioner>>
       A_inverse;
 

--- a/tests/hp/step-13.cc
+++ b/tests/hp/step-13.cc
@@ -222,7 +222,7 @@ namespace LaplaceSolver
     n_dofs() const = 0;
 
   protected:
-    const SmartPointer<Triangulation<dim>> triangulation;
+    const ObserverPointer<Triangulation<dim>> triangulation;
   };
 
 
@@ -258,11 +258,11 @@ namespace LaplaceSolver
     n_dofs() const;
 
   protected:
-    const SmartPointer<const hp::FECollection<dim>> fe;
-    const SmartPointer<const hp::QCollection<dim>>  quadrature;
-    DoFHandler<dim>                                 dof_handler;
-    Vector<double>                                  solution;
-    const SmartPointer<const Function<dim>>         boundary_values;
+    const ObserverPointer<const hp::FECollection<dim>> fe;
+    const ObserverPointer<const hp::QCollection<dim>>  quadrature;
+    DoFHandler<dim>                                    dof_handler;
+    Vector<double>                                     solution;
+    const ObserverPointer<const Function<dim>>         boundary_values;
 
     virtual void
     assemble_rhs(Vector<double> &rhs) const = 0;
@@ -493,7 +493,7 @@ namespace LaplaceSolver
                  const Function<dim>         &boundary_values);
 
   protected:
-    const SmartPointer<const Function<dim>> rhs_function;
+    const ObserverPointer<const Function<dim>> rhs_function;
     virtual void
     assemble_rhs(Vector<double> &rhs) const;
   };

--- a/tests/hp/step-7.cc
+++ b/tests/hp/step-7.cc
@@ -19,8 +19,8 @@
 
 #include <deal.II/base/convergence_table.h>
 #include <deal.II/base/function.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/quadrature_lib.h>
-#include <deal.II/base/smartpointer.h>
 
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_handler.h>

--- a/tests/hp/step-7.cc
+++ b/tests/hp/step-7.cc
@@ -204,7 +204,7 @@ private:
   Triangulation<dim> triangulation;
   DoFHandler<dim>    dof_handler;
 
-  SmartPointer<const hp::FECollection<dim>> fe;
+  ObserverPointer<const hp::FECollection<dim>> fe;
 
   AffineConstraints<double> hanging_node_constraints;
 

--- a/tests/matrix_free/parallel_multigrid_adaptive_01.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_01.cc
@@ -424,7 +424,7 @@ public:
   }
 
 private:
-  SmartPointer<const LAPLACEOPERATOR> laplace;
+  ObserverPointer<const LAPLACEOPERATOR> laplace;
 };
 
 

--- a/tests/matrix_free/parallel_multigrid_adaptive_03.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_03.cc
@@ -436,7 +436,7 @@ public:
   }
 
 private:
-  SmartPointer<const LAPLACEOPERATOR> laplace;
+  ObserverPointer<const LAPLACEOPERATOR> laplace;
 };
 
 

--- a/tests/matrix_free/parallel_multigrid_adaptive_05.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_05.cc
@@ -433,7 +433,7 @@ public:
   }
 
 private:
-  SmartPointer<const LAPLACEOPERATOR> laplace;
+  ObserverPointer<const LAPLACEOPERATOR> laplace;
 };
 
 

--- a/tests/mpi/muelu_periodicity.cc
+++ b/tests/mpi/muelu_periodicity.cc
@@ -193,8 +193,8 @@ namespace Step22
           const TrilinosWrappers::MPI::Vector &src) const;
 
   private:
-    const SmartPointer<const Matrix>         matrix;
-    const SmartPointer<const Preconditioner> preconditioner;
+    const ObserverPointer<const Matrix>         matrix;
+    const ObserverPointer<const Preconditioner> preconditioner;
 
     mutable TrilinosWrappers::MPI::Vector tmp;
   };
@@ -249,8 +249,9 @@ namespace Step22
           const TrilinosWrappers::MPI::Vector &src) const;
 
   private:
-    const SmartPointer<const TrilinosWrappers::BlockSparseMatrix> system_matrix;
-    const SmartPointer<
+    const ObserverPointer<const TrilinosWrappers::BlockSparseMatrix>
+      system_matrix;
+    const ObserverPointer<
       const InverseMatrix<TrilinosWrappers::SparseMatrix, Preconditioner>>
                                           A_inverse;
     mutable TrilinosWrappers::MPI::Vector tmp1, tmp2;

--- a/tests/mpi/periodicity_02.cc
+++ b/tests/mpi/periodicity_02.cc
@@ -196,8 +196,8 @@ namespace Step22
           const TrilinosWrappers::MPI::Vector &src) const;
 
   private:
-    const SmartPointer<const Matrix>         matrix;
-    const SmartPointer<const Preconditioner> preconditioner;
+    const ObserverPointer<const Matrix>         matrix;
+    const ObserverPointer<const Preconditioner> preconditioner;
 
     mutable TrilinosWrappers::MPI::Vector tmp;
   };
@@ -252,8 +252,9 @@ namespace Step22
           const TrilinosWrappers::MPI::Vector &src) const;
 
   private:
-    const SmartPointer<const TrilinosWrappers::BlockSparseMatrix> system_matrix;
-    const SmartPointer<
+    const ObserverPointer<const TrilinosWrappers::BlockSparseMatrix>
+      system_matrix;
+    const ObserverPointer<
       const InverseMatrix<TrilinosWrappers::SparseMatrix, Preconditioner>>
                                           A_inverse;
     mutable TrilinosWrappers::MPI::Vector tmp1, tmp2;

--- a/tests/mpi/periodicity_03.cc
+++ b/tests/mpi/periodicity_03.cc
@@ -118,8 +118,8 @@ namespace Step22
           const TrilinosWrappers::MPI::Vector &src) const;
 
   private:
-    const SmartPointer<const Matrix>         matrix;
-    const SmartPointer<const Preconditioner> preconditioner;
+    const ObserverPointer<const Matrix>         matrix;
+    const ObserverPointer<const Preconditioner> preconditioner;
 
     mutable TrilinosWrappers::MPI::Vector tmp;
   };
@@ -172,8 +172,9 @@ namespace Step22
           const TrilinosWrappers::MPI::Vector &src) const;
 
   private:
-    const SmartPointer<const TrilinosWrappers::BlockSparseMatrix> system_matrix;
-    const SmartPointer<
+    const ObserverPointer<const TrilinosWrappers::BlockSparseMatrix>
+      system_matrix;
+    const ObserverPointer<
       const InverseMatrix<TrilinosWrappers::SparseMatrix, Preconditioner>>
                                           A_inverse;
     mutable TrilinosWrappers::MPI::Vector tmp1, tmp2;

--- a/tests/multigrid-global-coarsening/parallel_multigrid_adaptive_01.cc
+++ b/tests/multigrid-global-coarsening/parallel_multigrid_adaptive_01.cc
@@ -424,7 +424,7 @@ public:
   }
 
 private:
-  SmartPointer<const LAPLACEOPERATOR> laplace;
+  ObserverPointer<const LAPLACEOPERATOR> laplace;
 };
 
 

--- a/tests/multigrid-global-coarsening/parallel_multigrid_adaptive_03.cc
+++ b/tests/multigrid-global-coarsening/parallel_multigrid_adaptive_03.cc
@@ -436,7 +436,7 @@ public:
   }
 
 private:
-  SmartPointer<const LAPLACEOPERATOR> laplace;
+  ObserverPointer<const LAPLACEOPERATOR> laplace;
 };
 
 

--- a/tests/multigrid-global-coarsening/parallel_multigrid_adaptive_05.cc
+++ b/tests/multigrid-global-coarsening/parallel_multigrid_adaptive_05.cc
@@ -433,7 +433,7 @@ public:
   }
 
 private:
-  SmartPointer<const LAPLACEOPERATOR> laplace;
+  ObserverPointer<const LAPLACEOPERATOR> laplace;
 };
 
 

--- a/tests/non_matching/fe_immersed_surface_values.cc
+++ b/tests/non_matching/fe_immersed_surface_values.cc
@@ -93,7 +93,7 @@ private:
   const FE_Q<dim>                             element;
   Triangulation<dim>                          triangulation;
   DoFHandler<dim>                             dof_handler;
-  const SmartPointer<const Mapping<dim>>      mapping;
+  const ObserverPointer<const Mapping<dim>>   mapping;
   NonMatching::ImmersedSurfaceQuadrature<dim> quadrature;
 };
 

--- a/tests/performance/instrumentation_step_22.cc
+++ b/tests/performance/instrumentation_step_22.cc
@@ -213,8 +213,8 @@ public:
   vmult(Vector<double> &dst, const Vector<double> &src) const;
 
 private:
-  const SmartPointer<const MatrixType>         matrix;
-  const SmartPointer<const PreconditionerType> preconditioner;
+  const ObserverPointer<const MatrixType>         matrix;
+  const ObserverPointer<const PreconditionerType> preconditioner;
 };
 
 
@@ -254,8 +254,8 @@ public:
   vmult(Vector<double> &dst, const Vector<double> &src) const;
 
 private:
-  const SmartPointer<const BlockSparseMatrix<double>> system_matrix;
-  const SmartPointer<
+  const ObserverPointer<const BlockSparseMatrix<double>> system_matrix;
+  const ObserverPointer<
     const InverseMatrix<SparseMatrix<double>, PreconditionerType>>
     A_inverse;
 

--- a/tests/performance/timing_mg_glob_coarsen.cc
+++ b/tests/performance/timing_mg_glob_coarsen.cc
@@ -303,8 +303,8 @@ public:
   }
 
 private:
-  SmartPointer<const MGSmootherBase<VectorType>> coarse_smooth;
-  const std::vector<unsigned int>               *constrained_dofs;
+  ObserverPointer<const MGSmootherBase<VectorType>> coarse_smooth;
+  const std::vector<unsigned int>                  *constrained_dofs;
 
   mutable VectorType src_copy;
 };

--- a/tests/performance/timing_step_22.cc
+++ b/tests/performance/timing_step_22.cc
@@ -211,8 +211,8 @@ public:
   vmult(Vector<double> &dst, const Vector<double> &src) const;
 
 private:
-  const SmartPointer<const MatrixType>         matrix;
-  const SmartPointer<const PreconditionerType> preconditioner;
+  const ObserverPointer<const MatrixType>         matrix;
+  const ObserverPointer<const PreconditionerType> preconditioner;
 };
 
 
@@ -252,8 +252,8 @@ public:
   vmult(Vector<double> &dst, const Vector<double> &src) const;
 
 private:
-  const SmartPointer<const BlockSparseMatrix<double>> system_matrix;
-  const SmartPointer<
+  const ObserverPointer<const BlockSparseMatrix<double>> system_matrix;
+  const ObserverPointer<
     const InverseMatrix<SparseMatrix<double>, PreconditionerType>>
     A_inverse;
 

--- a/tests/simplex/step-07.cc
+++ b/tests/simplex/step-07.cc
@@ -209,7 +209,7 @@ namespace Step7
     Triangulation<dim> triangulation;
     DoFHandler<dim>    dof_handler;
 
-    SmartPointer<const FiniteElement<dim>> fe;
+    ObserverPointer<const FiniteElement<dim>> fe;
 
     AffineConstraints<double> hanging_node_constraints;
 

--- a/tests/simplex/step-07.cc
+++ b/tests/simplex/step-07.cc
@@ -26,8 +26,8 @@
 #include <deal.II/base/convergence_table.h>
 #include <deal.II/base/function.h>
 #include <deal.II/base/logstream.h>
+#include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/quadrature_lib.h>
-#include <deal.II/base/smartpointer.h>
 
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_handler.h>

--- a/tests/simplex/step-31.cc
+++ b/tests/simplex/step-31.cc
@@ -139,8 +139,8 @@ namespace Step31
       vmult(VectorType &dst, const VectorType &src) const;
 
     private:
-      const SmartPointer<const MatrixType> matrix;
-      const PreconditionerType            &preconditioner;
+      const ObserverPointer<const MatrixType> matrix;
+      const PreconditionerType               &preconditioner;
     };
     template <class MatrixType, class PreconditionerType>
     InverseMatrix<MatrixType, PreconditionerType>::InverseMatrix(
@@ -182,10 +182,10 @@ namespace Step31
             const TrilinosWrappers::MPI::BlockVector &src) const;
 
     private:
-      const SmartPointer<const TrilinosWrappers::BlockSparseMatrix>
+      const ObserverPointer<const TrilinosWrappers::BlockSparseMatrix>
         stokes_matrix;
-      const SmartPointer<const InverseMatrix<TrilinosWrappers::SparseMatrix,
-                                             PreconditionerTypeMp>>
+      const ObserverPointer<const InverseMatrix<TrilinosWrappers::SparseMatrix,
+                                                PreconditionerTypeMp>>
                                             m_inverse;
       const PreconditionerTypeA            &a_preconditioner;
       mutable TrilinosWrappers::MPI::Vector tmp;

--- a/tests/simplex/step-55.cc
+++ b/tests/simplex/step-55.cc
@@ -128,8 +128,8 @@ namespace Step55
       vmult(VectorType &dst, const VectorType &src) const;
 
     private:
-      const SmartPointer<const Matrix> matrix;
-      const Preconditioner            &preconditioner;
+      const ObserverPointer<const Matrix> matrix;
+      const Preconditioner               &preconditioner;
     };
 
 


### PR DESCRIPTION
As discussed in #17657. The old file, `smartpointer.h`, retains a `using` declaration that continues to make the old class name available. I added a test for that as well.