### PR TITLE
More tests for ParsedFunction.

### DIFF
--- a/tests/bits/parsed_function_constants.cc
+++ b/tests/bits/parsed_function_constants.cc
@@ -1,0 +1,54 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2007 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+
+// This program tests the functionality of the function parser
+// wrapper.
+
+#include <deal.II/base/parameter_handler.h>
+#include <deal.II/base/parsed_function.h>
+#include <deal.II/base/utilities.h>
+
+#include <map>
+
+#include "../tests.h"
+
+void
+test()
+{
+  // A parameter handler
+  ParameterHandler prm;
+
+  Functions::ParsedFunction<1>::declare_parameters(prm, 1);
+  prm.set("Function constants", "f=2");
+
+  prm.set("Function expression", "f*f+2*x");
+
+  Functions::ParsedFunction<1> function(1);
+  function.parse_parameters(prm);
+
+  const double value = function.value(Point<1>(3.0));
+  deallog << "Value at x=3: " << value << std::endl;
+
+  prm.log_parameters(deallog);
+}
+
+int
+main()
+{
+  initlog();
+
+  test();
+}

--- a/tests/bits/parsed_function_constants.with_muparser=true.output
+++ b/tests/bits/parsed_function_constants.with_muparser=true.output
@@ -1,0 +1,5 @@
+
+DEAL::Value at x=3: 10.0000
+DEAL:parameters::Function constants: f=2
+DEAL:parameters::Function expression: f*f+2*x
+DEAL:parameters::Variable names: x,t

--- a/tests/bits/parsed_function_constants_with_errors.cc
+++ b/tests/bits/parsed_function_constants_with_errors.cc
@@ -1,0 +1,65 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2007 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+
+// This program tests the functionality of the function parser
+// wrapper.
+
+#include <deal.II/base/parameter_handler.h>
+#include <deal.II/base/parsed_function.h>
+#include <deal.II/base/utilities.h>
+
+#include <map>
+
+#include "../tests.h"
+
+void
+test()
+{
+  // A parameter handler
+  ParameterHandler prm;
+
+  Functions::ParsedFunction<1>::declare_parameters(prm, 1);
+
+  // Setting a constant to an expression should fail:
+  prm.set("Function constants", "f=100.0*60*60*24*365.2425");
+
+  prm.set("Function expression", "f*f+2*x");
+
+  Functions::ParsedFunction<1> function(1);
+
+  bool caught_error = false;
+  try
+    {
+      function.parse_parameters(prm);
+    }
+  catch (...)
+    {
+      deallog << "Caught error about invalid set for function constant."
+              << std::endl;
+      caught_error = true;
+      // Ignore the actual error.
+    }
+
+  Assert(caught_error == true, ExcInternalError());
+}
+
+int
+main()
+{
+  initlog();
+
+  test();
+}

--- a/tests/bits/parsed_function_constants_with_errors.with_muparser=true.output
+++ b/tests/bits/parsed_function_constants_with_errors.with_muparser=true.output
@@ -1,0 +1,2 @@
+
+DEAL::Caught error about invalid set for function constant.


### PR DESCRIPTION
In #17535, we had a report about not properly catching errors in parsed function constants. This is in fact wrong, we *do* catch these errors but the person who reported the issue may have run in release mode. The two new tests in this PR check that we correctly catch errors.

Fixes #17535.