### PR TITLE
Remove references to BlockMatrixArray from the documentation.

### DIFF
--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -160,7 +160,7 @@ class FESystem;
  * done based on vector components, but based on the use of
  * @ref GlossBlock "blocks",
  * and the result is then used to substructure objects of type BlockVector,
- * BlockSparseMatrix, BlockMatrixArray, and so on. If you use non-primitive
+ * BlockSparseMatrix, and so on. If you use non-primitive
  * elements, you cannot determine the block number by
  * FiniteElement::system_to_component_index(). Instead, you can use
  * FiniteElement::system_to_block_index(). The number of blocks of a finite

--- a/include/deal.II/lac/matrix_block.h
+++ b/include/deal.II/lac/matrix_block.h
@@ -75,24 +75,6 @@ namespace internal
  * This behavior allows us to store MatrixBlock objects in vectors, for
  * instance in MGLevelObject without extracting the #matrix first.
  *
- * MatrixBlock comes handy when using BlockMatrixArray. Once the MatrixBlock
- * has been properly initialized and filled, it can be used in the simplest
- * case as:
- * @code
- * MatrixBlockVector<SparseMatrix<double> > > blocks;
- *
- * ...
- *
- * BlockMatrixArray matrix (n_blocks, n_blocks);
- *
- * for (size_type i=0;i<blocks.size;++i)
- *   matrix.enter(blocks.block(i).row, blocks.block(i).column,
- * blocks.matrix(i));
- * @endcode
- *
- * Here, we have not gained very much, except that we do not need to set up
- * empty blocks in the block system.
- *
  * @note This class expects, that the row and column BlockIndices objects for
  * the system are equal. If they are not, some functions will throw
  * ExcNotImplemented.

--- a/include/deal.II/lac/precondition_block.h
+++ b/include/deal.II/lac/precondition_block.h
@@ -40,9 +40,8 @@ DEAL_II_NAMESPACE_OPEN
  * diagonal and provides the inversion of the diagonal blocks of the matrix.
  * It is not necessary for this class that the matrix be block diagonal;
  * rather, it applies to matrices of arbitrary structure with the minimal
- * property of having invertible blocks on the diagonal. Still the matrix must
- * have access to single matrix entries. Therefore, BlockMatrixArray and
- * similar classes are not a possible matrix class template arguments.
+ * property of having invertible blocks on the diagonal. The matrix must
+ * have access to individual matrix entries.
  *
  * The block matrix structure used by this class is given, e.g., for the DG
  * method for the transport equation. For a downstream numbering the matrices
@@ -703,10 +702,7 @@ public:
   /**
    * Execute block SOR preconditioning.
    *
-   * Warning: this function performs normal @p vmult without adding. The
-   * reason for its existence is that BlockMatrixArray requires the adding
-   * version by default. On the other hand, adding requires an additional
-   * auxiliary vector, which is not desirable.
+   * Warning: this function performs normal @p vmult without adding.
    *
    * @see vmult
    */
@@ -729,10 +725,7 @@ public:
   /**
    * Execute backward block SOR preconditioning.
    *
-   * Warning: this function performs normal @p vmult without adding. The
-   * reason for its existence is that BlockMatrixArray requires the adding
-   * version by default. On the other hand, adding requires an additional
-   * auxiliary vector, which is not desirable.
+   * Warning: this function performs normal @p vmult without adding.
    *
    * @see vmult
    */

--- a/include/deal.II/meshworker/assembler.h
+++ b/include/deal.II/meshworker/assembler.h
@@ -53,7 +53,7 @@ namespace MeshWorker
    * This is the structure set up by the FESystem class. Globally, this means,
    * data is assembled into one residual vector and into one matrix. These
    * objects may be block vectors and block matrices, but the process of
-   * assembling ignores this fact.
+   * assembling does not care about this.
    *
    * Similarly, there is only a single cell vector and cell matrix,
    * respectively, which is indexed by all degrees of freedom of the FESystem.
@@ -65,8 +65,9 @@ namespace MeshWorker
    *
    * Here, all the blocks are treated separately (in spite of using FESystem
    * for its convenience in other places). For instance, no block matrix is
-   * assembled, but a list of blocks, which can be combined later by
-   * BlockMatrixArray. Locally, this means, that each matrix block of a system
+   * assembled, but a list of blocks, which can be blocks inside a larger block
+   * matrix but, again, the assembly process is unaware of this and does
+   * not care. Locally, this means, that each matrix block of a system
    * is generated separately and assembled into the corresponding global
    * block.
    *


### PR DESCRIPTION
This class was removed several releases ago.