### PR TITLE
Use Utilties::MPI::compute_index_owner() instead of lower-level facilities.

### DIFF
--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -837,25 +837,11 @@ namespace internal
 
           is_dst_remote_potentially_relevant.subtract_set(is_dst_locally_owned);
 
-          std::vector<unsigned int> owning_ranks_of_ghosts(
-            is_dst_remote_potentially_relevant.n_elements());
-
-          {
-            Utilities::MPI::internal::ComputeIndexOwner::
-              ConsensusAlgorithmsPayload process(
-                is_dst_locally_owned,
-                is_dst_remote_potentially_relevant,
-                communicator,
-                owning_ranks_of_ghosts,
-                false);
-
-            Utilities::MPI::ConsensusAlgorithms::Selector<
-              std::vector<
-                std::pair<types::global_cell_index, types::global_cell_index>>,
-              std::vector<unsigned int>>
-              consensus_algorithm;
-            consensus_algorithm.run(process, communicator);
-          }
+          const std::vector<unsigned int> owning_ranks_of_ghosts =
+            Utilities::MPI::compute_index_owner(
+              is_dst_locally_owned,
+              is_dst_remote_potentially_relevant,
+              communicator);
 
           for (unsigned i = 0;
                i < is_dst_remote_potentially_relevant.n_elements();
@@ -3961,22 +3947,10 @@ MGTwoLevelTransfer<dim, VectorType>::reinit(
 
       const MPI_Comm communicator = dof_handler_fine.get_mpi_communicator();
 
-      std::vector<unsigned int> owning_ranks(
-        is_locally_owned_coarse.n_elements());
-
-      Utilities::MPI::internal::ComputeIndexOwner::ConsensusAlgorithmsPayload
-        process(is_locally_owned_fine,
-                is_locally_owned_coarse,
-                communicator,
-                owning_ranks,
-                false);
-
-      Utilities::MPI::ConsensusAlgorithms::Selector<
-        std::vector<
-          std::pair<types::global_cell_index, types::global_cell_index>>,
-        std::vector<unsigned int>>
-        consensus_algorithm;
-      consensus_algorithm.run(process, communicator);
+      const std::vector<unsigned int> owning_ranks =
+        Utilities::MPI::compute_index_owner(is_locally_owned_fine,
+                                            is_locally_owned_coarse,
+                                            communicator);
 
       bool all_cells_found = true;
 

--- a/source/multigrid/mg_tools.cc
+++ b/source/multigrid/mg_tools.cc
@@ -14,7 +14,7 @@
 
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/mg_level_object.h>
-#include <deal.II/base/mpi_compute_index_owner_internal.h>
+#include <deal.II/base/mpi.h>
 #include <deal.II/base/thread_management.h>
 
 #include <deal.II/distributed/tria_base.h>
@@ -1771,22 +1771,10 @@ namespace MGTools
                   cell_id_translator.translate(cell, i));
             }
 
-        std::vector<unsigned int> is_fine_required_ranks(
-          is_fine_required.n_elements());
-
-        Utilities::MPI::internal::ComputeIndexOwner::ConsensusAlgorithmsPayload
-          process(is_fine_owned,
-                  is_fine_required,
-                  communicator,
-                  is_fine_required_ranks,
-                  false);
-
-        Utilities::MPI::ConsensusAlgorithms::Selector<
-          std::vector<
-            std::pair<types::global_cell_index, types::global_cell_index>>,
-          std::vector<unsigned int>>
-          consensus_algorithm;
-        consensus_algorithm.run(process, communicator);
+        const std::vector<unsigned int> is_fine_required_ranks =
+          Utilities::MPI::compute_index_owner(is_fine_owned,
+                                              is_fine_required,
+                                              communicator);
 
         for (unsigned i = 0; i < is_fine_required.n_elements(); ++i)
           if (is_fine_required_ranks[i] == my_rank)


### PR DESCRIPTION
While looking at #17703, I realized that there are places that can be simplified by using the function in `Utilities::MPI`.