### PR TITLE
NoncontiguousPartitioner: introduce n_components

### DIFF
--- a/doc/news/changes/minor/20240925Munch
+++ b/doc/news/changes/minor/20240925Munch
@@ -1,0 +1,4 @@
+New: Utilities::MPI::NoncontiguousPartitioner::export_to_ghosted_array()
+can now handle multiple components.
+<br>
+(Peter Munch, 2024/09/25)

--- a/include/deal.II/base/mpi_noncontiguous_partitioner.h
+++ b/include/deal.II/base/mpi_noncontiguous_partitioner.h
@@ -79,6 +79,14 @@ namespace Utilities
        * Fill the vector @p ghost_array according to the precomputed communication
        * pattern with values from @p locally_owned_array.
        *
+       * In the default case, only one object is communicated per entry
+       * (`n_components_templated == 1'). If you want to communicate more
+       * entries, you can increase the value of @p n_components_templated in the
+       * case that you know the size at compile time. If you want to set the
+       * size during runtime, you can set @p n_components. However,
+       * @p n_components_templated has to be set to `0` in this case. Either
+       * @p n_components_templated or @p n_components can be set.
+       *
        * @pre The vectors only have to provide a method begin(), which allows
        *   to access their raw data.
        *
@@ -91,11 +99,12 @@ namespace Utilities
        *   functions separately and hereby overlap communication and
        *   computation.
        */
-      template <typename Number>
+      template <typename Number, unsigned int n_components_templated = 1>
       void
       export_to_ghosted_array(
         const ArrayView<const Number> &locally_owned_array,
-        const ArrayView<Number>       &ghost_array) const;
+        const ArrayView<Number>       &ghost_array,
+        const unsigned int             n_components = 0) const;
 
       /**
        * Same as above but with an interface similar to
@@ -111,14 +120,15 @@ namespace Utilities
        * @note Any value less than 10 is a valid value of
        *   @p communication_channel.
        */
-      template <typename Number>
+      template <typename Number, unsigned int n_components_templated = 1>
       void
       export_to_ghosted_array(
         const unsigned int             communication_channel,
         const ArrayView<const Number> &locally_owned_array,
         const ArrayView<Number>       &temporary_storage,
         const ArrayView<Number>       &ghost_array,
-        std::vector<MPI_Request>      &requests) const;
+        std::vector<MPI_Request>      &requests,
+        const unsigned int             n_components = 0) const;
 
       /**
        * Start update: Data is packed, non-blocking send and receives
@@ -136,13 +146,14 @@ namespace Utilities
        * @note Any value less than 10 is a valid value of
        *   @p communication_channel.
        */
-      template <typename Number>
+      template <typename Number, unsigned int n_components_templated = 1>
       void
       export_to_ghosted_array_start(
         const unsigned int             communication_channel,
         const ArrayView<const Number> &locally_owned_array,
         const ArrayView<Number>       &temporary_storage,
-        std::vector<MPI_Request>      &requests) const;
+        std::vector<MPI_Request>      &requests,
+        const unsigned int             n_components = 0) const;
 
       /**
        * Finish update. The method waits until all data has been sent and
@@ -158,12 +169,13 @@ namespace Utilities
        * @pre The required size of the vectors are the same as in the functions
        *   above.
        */
-      template <typename Number>
+      template <typename Number, unsigned int n_components_templated = 1>
       void
       export_to_ghosted_array_finish(
         const ArrayView<const Number> &temporary_storage,
         const ArrayView<Number>       &ghost_array,
-        std::vector<MPI_Request>      &requests) const;
+        std::vector<MPI_Request>      &requests,
+        const unsigned int             n_components = 0) const;
 
       /**
        * Similar to the above functions but for importing vector entries

--- a/source/base/mpi_noncontiguous_partitioner.inst.in
+++ b/source/base/mpi_noncontiguous_partitioner.inst.in
@@ -23,7 +23,8 @@ for (S : REAL_SCALARS)
         template void
         NoncontiguousPartitioner::export_to_ghosted_array(
           const ArrayView<const S> &src,
-          const ArrayView<S>       &dst) const;
+          const ArrayView<S>       &dst,
+          const unsigned int) const;
 
         template void
         NoncontiguousPartitioner::import_from_ghosted_array(

--- a/tests/base/mpi_noncontiguous_partitioner_05.cc
+++ b/tests/base/mpi_noncontiguous_partitioner_05.cc
@@ -1,0 +1,91 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// Test Utilities::MPI::NoncontiguousPartitioner for non-contiguous index space
+// and multiple components.
+
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/mpi_noncontiguous_partitioner.h>
+#include <deal.II/base/mpi_noncontiguous_partitioner.templates.h>
+
+#include "../tests.h"
+
+
+void
+test(const MPI_Comm comm)
+{
+  const unsigned int n_components = 2;
+
+  IndexSet index_set_has(4);
+  IndexSet index_set_want(4);
+
+  if (Utilities::MPI::this_mpi_process(comm) == 0)
+    {
+      index_set_has.add_index(1);
+      index_set_want.add_index(2);
+    }
+  else
+    {
+      index_set_has.add_index(2);
+      index_set_want.add_index(1);
+      index_set_want.add_index(2);
+    }
+
+  Utilities::MPI::NoncontiguousPartitioner vector(index_set_has,
+                                                  index_set_want,
+                                                  comm);
+
+  AlignedVector<double> src(n_components * index_set_has.n_elements());
+  AlignedVector<double> dst(n_components * index_set_want.n_elements());
+
+  src[0] = Utilities::MPI::this_mpi_process(comm) * 100 + 1;
+  src[1] = Utilities::MPI::this_mpi_process(comm) * 100 + 2;
+
+  vector.export_to_ghosted_array<double, n_components>(
+    ArrayView<const double>(src.data(), src.size()),
+    ArrayView<double>(dst.data(), dst.size()));
+
+  for (size_t i = 0; i < src.size(); ++i)
+    deallog << static_cast<int>(src[i]) << ' ';
+  deallog << std::endl;
+  for (size_t i = 0; i < dst.size(); ++i)
+    deallog << static_cast<int>(dst[i]) << ' ';
+  deallog << std::endl;
+
+  dst.fill(0.0);
+  vector.export_to_ghosted_array<double, 0>(
+    ArrayView<const double>(src.data(), src.size()),
+    ArrayView<double>(dst.data(), dst.size()),
+    n_components);
+
+  for (size_t i = 0; i < dst.size(); ++i)
+    deallog << static_cast<int>(dst[i]) << ' ';
+  deallog << std::endl;
+}
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPILogInitAll                    all;
+
+  const MPI_Comm comm = MPI_COMM_WORLD;
+
+  {
+    deallog.push("all");
+    test(comm);
+    deallog.pop();
+  }
+}

--- a/tests/base/mpi_noncontiguous_partitioner_05.mpirun=2.output
+++ b/tests/base/mpi_noncontiguous_partitioner_05.mpirun=2.output
@@ -1,0 +1,9 @@
+
+DEAL:0:all::1 2 
+DEAL:0:all::101 102 
+DEAL:0:all::101 102 
+
+DEAL:1:all::101 102 
+DEAL:1:all::1 2 101 102 
+DEAL:1:all::1 2 101 102 
+


### PR DESCRIPTION
Similar to what is done in `RemotePointEvaluation`. Step towards moving the communication from `RemotePointEvaluation` to `(Noncontiguous)Partitioner`.