### PR TITLE
A fix for a bug in the time table

### DIFF
--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -728,7 +728,8 @@ TimerOutput::print_summary() const
                  << "------------+------------+" << '\n'
                  << "| Total CPU/wall time elapsed since start     "
                  << extra_space << "|" << std::setw(10) << std::setprecision(3)
-                 << std::right << total_cpu_time << "s |            |"
+                 << std::right << total_cpu_time << "s |            "
+                 << extra_space << "|" << std::setw(10) << std::setprecision(3)
                  << total_wall_time << "s |            |"
                  << "\n|                                             "
                  << extra_space << "|"


### PR DESCRIPTION
This fix makes the time tables look nicer, see the attachment. 

[Test program](https://github.com/cembooks/toolbox/tree/main/timetable)

![Screenshot from 2024-09-30 07-11-56](https://github.com/user-attachments/assets/f29c75c8-8f0f-4717-9800-1528f8201b20)
