### PR TITLE
Return earlier if possible inside `FEPointEvaluation::evaluate`

### DIFF
--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -2467,16 +2467,16 @@ FEPointEvaluation<n_components_, dim, spacedim, Number>::evaluate(
   const StridedArrayView<const ScalarNumber, stride_view> &solution_values,
   const EvaluationFlags::EvaluationFlags                  &evaluation_flags)
 {
-  if (this->must_reinitialize_pointers)
-    internal_reinit_single_cell_state_mapping_info();
-
-  if (this->n_q_points == 0)
-    return;
-
   Assert(!(evaluation_flags & EvaluationFlags::hessians), ExcNotImplemented());
 
   if (!((evaluation_flags & EvaluationFlags::values) ||
         (evaluation_flags & EvaluationFlags::gradients))) // no evaluation flags
+    return;
+
+  if (this->must_reinitialize_pointers)
+    internal_reinit_single_cell_state_mapping_info();
+
+  if (this->n_q_points == 0)
     return;
 
   AssertDimension(solution_values.size(), this->fe->dofs_per_cell);


### PR DESCRIPTION
While working on geodynamics/aspect#6051 I noticed that a call to `FEPointEvaluation::evaluate` can be surprisingly expensive even if the `EvaluationFlags` are set to `EvaluationFlags::nothing`. This is because the call to `internal_reinit_single_cell_state_mapping_info()` is performed even if nothing is evaluated. You might ask why I call `evaluate` if I do not want to evaluate anything, but in our case what is to be evaluated is a user input and I do not know in advance which evaluation flags will be provided to the function.

As far as I can tell the call to `internal_reinit_single_cell_state_mapping_info()` is not really necessary if we do not want to evaluate anything. The `values` and `gradients` vectors will not be resized to the correct size, but if nothing is evaluated their content should not be accessed anyway, and the access functions `get_gradient` and `get_value` do check for the bounds of the vector.

Did I miss anything, or can we just skip the reinit call if nothing is to be evaluated?