### PR TITLE
Update indent worker to ubuntu-24.04.

### DIFF
--- a/.github/workflows/indent.yml
+++ b/.github/workflows/indent.yml
@@ -14,7 +14,7 @@ jobs:
     # run the indent checks
 
     name: indent
-    runs-on: [ubuntu-22.04]
+    runs-on: [ubuntu-24.04]
 
     steps:
     - uses: actions/checkout@v4
@@ -31,16 +31,14 @@ jobs:
     # build the documentation
 
     name: doxygen
-    runs-on: [ubuntu-22.04]
+    runs-on: [ubuntu-24.04]
 
     steps:
     - name: setup
       run: |
         sudo apt update
-        sudo apt install graphviz perl texlive-bibtex-extra
-    - uses: ssciwr/doxygen-install@v1
-      with:
-        version: "1.9.6"
+        sudo apt install doxygen graphviz perl texlive-bibtex-extra
+        doxygen --version
     - uses: actions/checkout@v4
     - name: build documentation
       run: |
@@ -76,11 +74,11 @@ jobs:
     # check for typos
 
     name: typos
-    runs-on: [ubuntu-22.04]
+    runs-on: [ubuntu-24.04]
 
     steps:
     - uses: actions/checkout@v4
-    - uses: crate-ci/typos@v1.24.6
+    - uses: crate-ci/typos@v1.25.0
       with:
         files: doc examples include source tests
         config: ./.typos.toml

--- a/include/deal.II/numerics/solution_transfer.h
+++ b/include/deal.II/numerics/solution_transfer.h
@@ -952,9 +952,9 @@ namespace Legacy
 
 
     /**
-     * Is used for @p prepare_for_refining (of course also for @p
-     * repare_for_refining_and_coarsening) and stores all dof indices of the
-     * cells that'll be refined
+     * Is used for @p prepare_for_pure_refinement (of course also for
+     * @p prepare_for_coarsening_and_refinement) and stores all dof indices of
+     * the cells that'll be refined.
      */
     std::vector<std::vector<types::global_dof_index>> indices_on_cell;
 
@@ -1006,8 +1006,9 @@ namespace Legacy
     std::map<std::pair<unsigned int, unsigned int>, Pointerstruct> cell_map;
 
     /**
-     * Is used for @p prepare_for_refining_and_coarsening The interpolated dof
-     * values of all cells that'll be coarsened will be stored in this vector.
+     * Is used for @p prepare_for_coarsening_and_refinement. The interpolated
+     * dof values of all cells that'll be coarsened will be stored in this
+     * vector.
      */
     std::vector<std::vector<Vector<typename VectorType::value_type>>>
       dof_values_on_cell;

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -7788,8 +7788,8 @@ namespace internal
 
                         if (old_child[0]->index() + 1 != old_child[1]->index())
                           {
-                            // this is exactly the ugly case we taked
-                            // about. so, no coimplaining, lets get
+                            // this is exactly the ugly case we talked
+                            // about. so, no complaining, lets get
                             // two new lines and copy all info
                             typename Triangulation<dim,
                                                    spacedim>::raw_line_iterator


### PR DESCRIPTION
Part of #17583.

Ubuntu 24.04 (noble) comes with `doxygen 1.9.8`, so there is no need to specify the doxygen version anymore.

~~I also changed the `typos` version to only cover minor releases. This way dependabot won't update it with every single patch release.~~ (EDIT: That doesn't work unfortunately)