### PR TITLE
replaced void cast with [[maybe_unused]]

### DIFF
--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -1261,10 +1261,10 @@ namespace MatrixFreeOperators
 
   template <int dim, typename VectorType, typename VectorizedArrayType>
   typename Base<dim, VectorType, VectorizedArrayType>::value_type
-  Base<dim, VectorType, VectorizedArrayType>::el(const unsigned int row,
-                                                 const unsigned int col) const
+  Base<dim, VectorType, VectorizedArrayType>::el(
+    const unsigned int                  row,
+    [[maybe_unused]] const unsigned int col) const
   {
-    (void)col;
     Assert(row == col, ExcNotImplemented());
     Assert(inverse_diagonal_entries.get() != nullptr &&
              inverse_diagonal_entries->m() > 0,

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -1261,9 +1261,8 @@ namespace MatrixFreeOperators
 
   template <int dim, typename VectorType, typename VectorizedArrayType>
   typename Base<dim, VectorType, VectorizedArrayType>::value_type
-  Base<dim, VectorType, VectorizedArrayType>::el(
-    const unsigned int                  row,
-    [[maybe_unused]] const unsigned int col) const
+  Base<dim, VectorType, VectorizedArrayType>::el(const unsigned int row,
+                                                 const unsigned int col) const
   {
     Assert(row == col, ExcNotImplemented());
     Assert(inverse_diagonal_entries.get() != nullptr &&

--- a/include/deal.II/matrix_free/tools.h
+++ b/include/deal.II/matrix_free/tools.h
@@ -1466,10 +1466,10 @@ namespace MatrixFreeTools
     const QuadOperation                                     &quad_operation,
     EvaluationFlags::EvaluationFlags                         evaluation_flags,
     EvaluationFlags::EvaluationFlags                         integration_flags,
-    [[maybe_unused]] const unsigned int                      dof_no,
-    [[maybe_unused]] const unsigned int                      quad_no,
-    [[maybe_unused]] const unsigned int first_selected_component,
-    [[maybe_unused]] const unsigned int first_vector_component)
+    const unsigned int                                       dof_no,
+    const unsigned int                                       quad_no,
+    const unsigned int first_selected_component,
+    const unsigned int first_vector_component)
   {
     Assert(dof_no == 0, ExcNotImplemented());
     Assert(quad_no == 0, ExcNotImplemented());

--- a/include/deal.II/matrix_free/tools.h
+++ b/include/deal.II/matrix_free/tools.h
@@ -1466,15 +1466,11 @@ namespace MatrixFreeTools
     const QuadOperation                                     &quad_operation,
     EvaluationFlags::EvaluationFlags                         evaluation_flags,
     EvaluationFlags::EvaluationFlags                         integration_flags,
-    const unsigned int                                       dof_no,
-    const unsigned int                                       quad_no,
-    const unsigned int first_selected_component,
-    const unsigned int first_vector_component)
+    [[maybe_unused]] const unsigned int                      dof_no,
+    [[maybe_unused]] const unsigned int                      quad_no,
+    [[maybe_unused]] const unsigned int first_selected_component,
+    [[maybe_unused]] const unsigned int first_vector_component)
   {
-    (void)dof_no;
-    (void)quad_no;
-    (void)first_selected_component;
-    (void)first_vector_component;
     Assert(dof_no == 0, ExcNotImplemented());
     Assert(quad_no == 0, ExcNotImplemented());
     Assert(first_selected_component == 0, ExcNotImplemented());


### PR DESCRIPTION
issue #17247:

replaced (void) cast with [[maybe unused]] in files:
- include/deal.II/matrix_free/operators.h
- include/deal.II/matrix_free/tools.h