### PR TITLE
FEFaceEvaluation: Enable access of exterior values on ghosted faces

### DIFF
--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -262,7 +262,8 @@ namespace internal
       template <int length>
       void
       compute_face_index_compression(
-        const std::vector<FaceToCellTopology<length>> &faces);
+        const std::vector<FaceToCellTopology<length>> &faces,
+        bool hold_all_faces_to_owned_cells);
 
       /**
        * This function computes the connectivity of the currently stored

--- a/include/deal.II/matrix_free/face_setup_internal.h
+++ b/include/deal.II/matrix_free/face_setup_internal.h
@@ -852,7 +852,10 @@ namespace internal
                                     else if (face_is_owned[dcell->face(f)
                                                              ->child(c)
                                                              ->index()] ==
-                                             FaceCategory::ghosted)
+                                               FaceCategory::ghosted ||
+                                             face_is_owned[dcell->face(f)
+                                                             ->index()] ==
+                                               FaceCategory::ghosted)
                                       {
                                         inner_ghost_faces.push_back(create_face(
                                           neighbor_face_no,
@@ -863,15 +866,11 @@ namespace internal
                                           is_mixed_mesh));
                                       }
                                     else
-                                      Assert(
-                                        face_is_owned[dcell->face(f)
-                                                        ->index()] ==
-                                            FaceCategory::
-                                              locally_active_done_elsewhere ||
-                                          face_is_owned[dcell->face(f)
-                                                          ->index()] ==
-                                            FaceCategory::ghosted,
-                                        ExcInternalError());
+                                      Assert(face_is_owned[dcell->face(f)
+                                                             ->index()] ==
+                                               FaceCategory::
+                                                 locally_active_done_elsewhere,
+                                             ExcInternalError());
                                   }
                                 else
                                   {

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -2026,7 +2026,8 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
            task_info.refinement_edge_face_partition_data[0]));
 
       for (auto &di : dof_info)
-        di.compute_face_index_compression(face_info.faces);
+        di.compute_face_index_compression(
+          face_info.faces, additional_data.hold_all_faces_to_owned_cells);
 
       // build the inverse map back from the faces array to
       // cell_and_face_to_plain_faces

--- a/source/matrix_free/dof_info.cc
+++ b/source/matrix_free/dof_info.cc
@@ -1589,19 +1589,24 @@ namespace internal
 
     template void
     DoFInfo::compute_face_index_compression<1>(
-      const std::vector<FaceToCellTopology<1>> &);
+      const std::vector<FaceToCellTopology<1>> &,
+      bool);
     template void
     DoFInfo::compute_face_index_compression<2>(
-      const std::vector<FaceToCellTopology<2>> &);
+      const std::vector<FaceToCellTopology<2>> &,
+      bool);
     template void
     DoFInfo::compute_face_index_compression<4>(
-      const std::vector<FaceToCellTopology<4>> &);
+      const std::vector<FaceToCellTopology<4>> &,
+      bool);
     template void
     DoFInfo::compute_face_index_compression<8>(
-      const std::vector<FaceToCellTopology<8>> &);
+      const std::vector<FaceToCellTopology<8>> &,
+      bool);
     template void
     DoFInfo::compute_face_index_compression<16>(
-      const std::vector<FaceToCellTopology<16>> &);
+      const std::vector<FaceToCellTopology<16>> &,
+      bool);
 
     template void
     DoFInfo::compute_vector_zero_access_pattern<1>(

--- a/tests/matrix_free/matrix_vector_faces_24.cc
+++ b/tests/matrix_free/matrix_vector_faces_24.cc
@@ -103,4 +103,8 @@ test()
   mf.vmult(out, in);
 
   deallog << "Norm of result:          " << out.l2_norm() << std::endl;
+
+  mf.manual_loop_vmult(out, in);
+
+  deallog << "Norm of result:          " << out.l2_norm() << std::endl;
 }

--- a/tests/matrix_free/matrix_vector_faces_24.with_p4est=true.mpirun=2.output
+++ b/tests/matrix_free/matrix_vector_faces_24.with_p4est=true.mpirun=2.output
@@ -1,5 +1,7 @@
 
 DEAL:2d::Testing FE_DGQ<2>(1)
 DEAL:2d::Norm of result:          4.18
+DEAL:2d::Norm of result:          4.18
 DEAL:3d::Testing FE_DGQ<3>(1)
+DEAL:3d::Norm of result:          3.39
 DEAL:3d::Norm of result:          3.39

--- a/tests/matrix_free/matrix_vector_faces_common.h
+++ b/tests/matrix_free/matrix_vector_faces_common.h
@@ -87,6 +87,32 @@ public:
               src);
   }
 
+  void
+  manual_loop_vmult(VectorType &dst, const VectorType &src) const
+  {
+    src.update_ghost_values();
+    dst = 0;
+    local_apply(data, dst, src, std::make_pair(0, data.n_cell_batches()));
+    local_apply_face(data,
+                     dst,
+                     src,
+                     std::make_pair(0, data.n_inner_face_batches()));
+    local_apply_boundary_face(data,
+                              dst,
+                              src,
+                              std::make_pair(data.n_inner_face_batches(),
+                                             data.n_inner_face_batches() +
+                                               data.n_boundary_face_batches()));
+    local_apply_face(data,
+                     dst,
+                     src,
+                     std::make_pair(data.n_inner_face_batches() +
+                                      data.n_boundary_face_batches(),
+                                    data.n_inner_face_batches() +
+                                      data.n_boundary_face_batches() +
+                                      data.n_ghost_inner_face_batches()));
+  }
+
 private:
   void
   local_apply(const MatrixFree<dim, number, VectorizedArrayType> &data,


### PR DESCRIPTION
If `hold_all_faces_to_owned_cells` is enabled we should be able to access the exterior values on ghosted faces via FEFaceEvaluation also in face-centric loops.

This allows us to evaluate the integrals on ghosted faces which avoids communication (the call to `compress`) interesting for cases where this is not possible (for example for block diagonal assembly).

@kronbichler @peterrum 