### PR TITLE
CMake: force a single configuration in "multiple generator" mode

### DIFF
--- a/cmake/macros/check_compiler_setup/CMakeLists.txt
+++ b/cmake/macros/check_compiler_setup/CMakeLists.txt
@@ -1,5 +1,6 @@
 # use a "Custom" build type to avoid auto populated compiler flags
 set(CMAKE_BUILD_TYPE "Custom")
+set(CMAKE_CONFIGURATION_TYPES "DEBUG;RELEASE")
 cmake_minimum_required(VERSION 3.13.4)
 project(CheckCompilerSetup)
 add_executable(CheckCompilerSetupExec dummy.cpp)

--- a/cmake/setup_cached_variables.cmake
+++ b/cmake/setup_cached_variables.cmake
@@ -140,6 +140,16 @@ if( NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Release" AND
 endif()
 
 #
+# We do not currently support a "multiple generator" setup with our
+# concurrent configuration and set up of a debug and release flavor within
+# our "DebugRelease" target. In order to avoid confusion simply force the
+# CMAKE_CONFIGURATION_TYPES variable to match the single-generator
+# counterpart:
+#
+
+set(CMAKE_CONFIGURATION_TYPES "${CMAKE_BUILD_TYPE}")
+
+#
 # Configuration behaviour:
 #
 


### PR DESCRIPTION
In reference to #17766
