### PR TITLE
Rename EnableObserverPointer files.

### DIFF
--- a/include/deal.II/algorithms/any_data.h
+++ b/include/deal.II/algorithms/any_data.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 
 #include <algorithm>

--- a/include/deal.II/algorithms/general_data_storage.h
+++ b/include/deal.II/algorithms/general_data_storage.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 
 #include <boost/core/demangle.hpp>

--- a/include/deal.II/algorithms/timestep_control.h
+++ b/include/deal.II/algorithms/timestep_control.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/lac/vector_memory.h>

--- a/include/deal.II/base/enable_observer_pointer.h
+++ b/include/deal.II/base/enable_observer_pointer.h
@@ -12,8 +12,8 @@
 //
 // ------------------------------------------------------------------------
 
-#ifndef dealii_enable_ref_counting_by_observer_h
-#define dealii_enable_ref_counting_by_observer_h
+#ifndef dealii_enable_observer_pointer_h
+#define dealii_enable_observer_pointer_h
 
 
 #include <deal.II/base/config.h>

--- a/include/deal.II/base/function.h
+++ b/include/deal.II/base/function.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/function_time.h>
 #include <deal.II/base/point.h>

--- a/include/deal.II/base/logstream.h
+++ b/include/deal.II/base/logstream.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/thread_local_storage.h>

--- a/include/deal.II/base/mg_level_object.h
+++ b/include/deal.II/base/mg_level_object.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 
 #include <memory>
 #include <vector>

--- a/include/deal.II/base/observer_pointer.h
+++ b/include/deal.II/base/observer_pointer.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 
 #include <atomic>

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/patterns.h>
 

--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/template_constraints.h>

--- a/include/deal.II/base/polynomial.h
+++ b/include/deal.II/base/polynomial.h
@@ -19,7 +19,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/point.h>
 

--- a/include/deal.II/base/polynomials_hermite.h
+++ b/include/deal.II/base/polynomials_hermite.h
@@ -19,7 +19,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/polynomial.h>

--- a/include/deal.II/base/polynomials_piecewise.h
+++ b/include/deal.II/base/polynomials_piecewise.h
@@ -19,7 +19,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/polynomial.h>

--- a/include/deal.II/base/quadrature.h
+++ b/include/deal.II/base/quadrature.h
@@ -19,7 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/array_view.h>
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/point.h>
 
 #include <array>

--- a/include/deal.II/base/quadrature_point_data.h
+++ b/include/deal.II/base/quadrature_point_data.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/quadrature.h>
 
 #include <deal.II/distributed/tria.h>

--- a/include/deal.II/base/subscriptor.h
+++ b/include/deal.II/base/subscriptor.h
@@ -18,6 +18,6 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 
 #endif

--- a/include/deal.II/base/symbolic_function.h
+++ b/include/deal.II/base/symbolic_function.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/function.h>
 #include <deal.II/base/point.h>

--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -18,7 +18,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/aligned_vector.h>
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/linear_index_iterator.h>
 #include <deal.II/base/memory_consumption.h>

--- a/include/deal.II/base/tensor_function.h
+++ b/include/deal.II/base/tensor_function.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/function.h>
 #include <deal.II/base/function_time.h>

--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/mpi_stub.h>
 #include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/template_constraints.h>

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/mpi_stub.h>
 #include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/template_constraints.h>

--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/mpi_stub.h>
 #include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/partitioner.h>

--- a/include/deal.II/dofs/block_info.h
+++ b/include/deal.II/dofs/block_info.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/template_constraints.h>
 

--- a/include/deal.II/fe/fe_coupling_values.h
+++ b/include/deal.II/fe/fe_coupling_values.h
@@ -20,7 +20,7 @@
 
 #include <deal.II/algorithms/general_data_storage.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/std_cxx20/iota_view.h>
 #include <deal.II/base/thread_local_storage.h>
 #include <deal.II/base/utilities.h>

--- a/include/deal.II/fe/fe_series.h
+++ b/include/deal.II/fe/fe_series.h
@@ -19,7 +19,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/table.h>
 #include <deal.II/base/table_indices.h>

--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -19,7 +19,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/geometry_info.h>
 #include <deal.II/base/symmetric_tensor.h>

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -19,7 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/derivative_form.h>
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/quadrature.h>

--- a/include/deal.II/fe/fe_values_base.h
+++ b/include/deal.II/fe/fe_values_base.h
@@ -19,7 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/derivative_form.h>
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/quadrature.h>

--- a/include/deal.II/grid/composition_manifold.h
+++ b/include/deal.II/grid/composition_manifold.h
@@ -21,7 +21,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/derivative_form.h>
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/quadrature_lib.h>
 

--- a/include/deal.II/grid/grid_tools_cache.h
+++ b/include/deal.II/grid/grid_tools_cache.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/point.h>
 

--- a/include/deal.II/grid/manifold.h
+++ b/include/deal.II/grid/manifold.h
@@ -22,7 +22,7 @@
 
 #include <deal.II/base/array_view.h>
 #include <deal.II/base/derivative_form.h>
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/quadrature_lib.h>
 

--- a/include/deal.II/grid/tensor_product_manifold.h
+++ b/include/deal.II/grid/tensor_product_manifold.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/utilities.h>
 

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/geometry_info.h>
 #include <deal.II/base/iterator_range.h>
 #include <deal.II/base/observer_pointer.h>

--- a/include/deal.II/hp/collection.h
+++ b/include/deal.II/hp/collection.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/memory_consumption.h>
 
 #include <iterator>

--- a/include/deal.II/hp/mapping_collection.h
+++ b/include/deal.II/hp/mapping_collection.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 
 #include <deal.II/fe/fe.h>
 #include <deal.II/fe/mapping.h>

--- a/include/deal.II/hp/q_collection.h
+++ b/include/deal.II/hp/q_collection.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/quadrature.h>
 

--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/table.h>

--- a/include/deal.II/lac/block_indices.h
+++ b/include/deal.II/lac/block_indices.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/logstream.h>
 

--- a/include/deal.II/lac/block_sparse_matrix_ez.h
+++ b/include/deal.II/lac/block_sparse_matrix_ez.h
@@ -23,7 +23,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/table.h>

--- a/include/deal.II/lac/block_sparsity_pattern.h
+++ b/include/deal.II/lac/block_sparsity_pattern.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/table.h>

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/numbers.h>

--- a/include/deal.II/lac/chunk_sparse_matrix.h
+++ b/include/deal.II/lac/chunk_sparse_matrix.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/lac/chunk_sparsity_pattern.h>

--- a/include/deal.II/lac/chunk_sparsity_pattern.h
+++ b/include/deal.II/lac/chunk_sparsity_pattern.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 
 #include <deal.II/lac/sparsity_pattern.h>

--- a/include/deal.II/lac/dynamic_sparsity_pattern.h
+++ b/include/deal.II/lac/dynamic_sparsity_pattern.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/utilities.h>
 

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -18,7 +18,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/communication_pattern_base.h>
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/memory_space.h>
 #include <deal.II/base/memory_space_data.h>
 #include <deal.II/base/mpi_stub.h>

--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -20,7 +20,7 @@
 
 #ifdef DEAL_II_WITH_PETSC
 
-#  include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#  include <deal.II/base/enable_observer_pointer.h>
 
 #  include <deal.II/lac/exceptions.h>
 #  include <deal.II/lac/full_matrix.h>

--- a/include/deal.II/lac/petsc_precondition.h
+++ b/include/deal.II/lac/petsc_precondition.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/point.h>
 
 #ifdef DEAL_II_WITH_PETSC

--- a/include/deal.II/lac/petsc_vector.h
+++ b/include/deal.II/lac/petsc_vector.h
@@ -20,7 +20,7 @@
 
 #ifdef DEAL_II_WITH_PETSC
 
-#  include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#  include <deal.II/base/enable_observer_pointer.h>
 #  include <deal.II/base/index_set.h>
 #  include <deal.II/base/partitioner.h>
 

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -20,7 +20,7 @@
 
 #ifdef DEAL_II_WITH_PETSC
 
-#  include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#  include <deal.II/base/enable_observer_pointer.h>
 #  include <deal.II/base/index_set.h>
 
 #  include <deal.II/lac/exceptions.h>

--- a/include/deal.II/lac/precondition_block.h
+++ b/include/deal.II/lac/precondition_block.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/observer_pointer.h>
 

--- a/include/deal.II/lac/precondition_block_base.h
+++ b/include/deal.II/lac/precondition_block_base.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/memory_consumption.h>

--- a/include/deal.II/lac/precondition_selector.h
+++ b/include/deal.II/lac/precondition_selector.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/observer_pointer.h>
 
 #include <string>

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -19,7 +19,7 @@
 
 #include <deal.II/base/aligned_vector.h>
 #include <deal.II/base/communication_pattern_base.h>
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/mpi_stub.h>

--- a/include/deal.II/lac/relaxation_block.h
+++ b/include/deal.II/lac/relaxation_block.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/lac/precondition_block_base.h>

--- a/include/deal.II/lac/solver.h
+++ b/include/deal.II/lac/solver.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/template_constraints.h>
 
 #include <deal.II/lac/solver_control.h>

--- a/include/deal.II/lac/solver_bicgstab.h
+++ b/include/deal.II/lac/solver_bicgstab.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/signaling_nan.h>
 #include <deal.II/base/template_constraints.h>

--- a/include/deal.II/lac/solver_cg.h
+++ b/include/deal.II/lac/solver_cg.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/template_constraints.h>

--- a/include/deal.II/lac/solver_control.h
+++ b/include/deal.II/lac/solver_control.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 
 #include <vector>
 

--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -19,7 +19,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/template_constraints.h>
 

--- a/include/deal.II/lac/solver_idr.h
+++ b/include/deal.II/lac/solver_idr.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/signaling_nan.h>
 #include <deal.II/base/template_constraints.h>

--- a/include/deal.II/lac/solver_minres.h
+++ b/include/deal.II/lac/solver_minres.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/signaling_nan.h>
 #include <deal.II/base/template_constraints.h>

--- a/include/deal.II/lac/solver_qmrs.h
+++ b/include/deal.II/lac/solver_qmrs.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/template_constraints.h>
 

--- a/include/deal.II/lac/solver_relaxation.h
+++ b/include/deal.II/lac/solver_relaxation.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/template_constraints.h>
 

--- a/include/deal.II/lac/sparse_direct.h
+++ b/include/deal.II/lac/sparse_direct.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 
 #include <deal.II/lac/block_sparse_matrix.h>

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/mpi_stub.h>
 #include <deal.II/base/observer_pointer.h>
 

--- a/include/deal.II/lac/sparse_matrix_ez.h
+++ b/include/deal.II/lac/sparse_matrix_ez.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/lac/exceptions.h>

--- a/include/deal.II/lac/sparsity_pattern.h
+++ b/include/deal.II/lac/sparsity_pattern.h
@@ -19,7 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/array_view.h>
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/linear_index_iterator.h>
 

--- a/include/deal.II/lac/sparsity_pattern_base.h
+++ b/include/deal.II/lac/sparsity_pattern_base.h
@@ -19,7 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/array_view.h>
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 
 #include <utility>

--- a/include/deal.II/lac/tridiagonal_matrix.h
+++ b/include/deal.II/lac/tridiagonal_matrix.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 
 #include <deal.II/lac/lapack_support.h>
 

--- a/include/deal.II/lac/trilinos_epetra_vector.h
+++ b/include/deal.II/lac/trilinos_epetra_vector.h
@@ -20,7 +20,7 @@
 
 #ifdef DEAL_II_WITH_TRILINOS
 
-#  include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#  include <deal.II/base/enable_observer_pointer.h>
 #  include <deal.II/base/index_set.h>
 #  include <deal.II/base/mpi_stub.h>
 

--- a/include/deal.II/lac/trilinos_precondition.h
+++ b/include/deal.II/lac/trilinos_precondition.h
@@ -20,7 +20,7 @@
 
 #ifdef DEAL_II_WITH_TRILINOS
 
-#  include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#  include <deal.II/base/enable_observer_pointer.h>
 
 #  include <deal.II/lac/la_parallel_vector.h>
 #  include <deal.II/lac/trilinos_vector.h>

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -20,7 +20,7 @@
 
 #  ifdef DEAL_II_WITH_TRILINOS
 
-#    include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#    include <deal.II/base/enable_observer_pointer.h>
 #    include <deal.II/base/index_set.h>
 #    include <deal.II/base/mpi_stub.h>
 

--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -19,7 +19,7 @@
 
 #ifdef DEAL_II_WITH_TRILINOS
 
-#  include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#  include <deal.II/base/enable_observer_pointer.h>
 #  include <deal.II/base/index_set.h>
 #  include <deal.II/base/mpi_stub.h>
 #  include <deal.II/base/utilities.h>

--- a/include/deal.II/lac/trilinos_tpetra_precondition.h
+++ b/include/deal.II/lac/trilinos_tpetra_precondition.h
@@ -28,7 +28,7 @@
 
 #ifdef DEAL_II_TRILINOS_WITH_TPETRA
 
-#  include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#  include <deal.II/base/enable_observer_pointer.h>
 
 #  include <deal.II/lac/la_parallel_vector.h>
 #  include <deal.II/lac/trilinos_tpetra_sparse_matrix.h>

--- a/include/deal.II/lac/trilinos_tpetra_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparse_matrix.h
@@ -19,7 +19,7 @@
 
 #ifdef DEAL_II_TRILINOS_WITH_TPETRA
 
-#  include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#  include <deal.II/base/enable_observer_pointer.h>
 #  include <deal.II/base/index_set.h>
 #  include <deal.II/base/trilinos_utilities.h>
 

--- a/include/deal.II/lac/trilinos_tpetra_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparsity_pattern.h
@@ -23,7 +23,7 @@
 
 #ifdef DEAL_II_TRILINOS_WITH_TPETRA
 
-#  include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#  include <deal.II/base/enable_observer_pointer.h>
 #  include <deal.II/base/index_set.h>
 #  include <deal.II/base/mpi_stub.h>
 

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -24,7 +24,7 @@
 
 #ifdef DEAL_II_TRILINOS_WITH_TPETRA
 
-#  include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#  include <deal.II/base/enable_observer_pointer.h>
 #  include <deal.II/base/index_set.h>
 #  include <deal.II/base/mpi_stub.h>
 

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -19,7 +19,7 @@
 #include <deal.II/base/config.h>
 
 #ifdef DEAL_II_WITH_TRILINOS
-#  include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#  include <deal.II/base/enable_observer_pointer.h>
 #  include <deal.II/base/index_set.h>
 #  include <deal.II/base/mpi_stub.h>
 #  include <deal.II/base/partitioner.h>

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -19,7 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/aligned_vector.h>
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/numbers.h>

--- a/include/deal.II/matrix_free/mapping_data_on_the_fly.h
+++ b/include/deal.II/matrix_free/mapping_data_on_the_fly.h
@@ -20,7 +20,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/aligned_vector.h>
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/vectorization.h>
 

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -19,7 +19,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/vectorization.h>
 

--- a/include/deal.II/meshworker/local_integrator.h
+++ b/include/deal.II/meshworker/local_integrator.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 
 #include <functional>
 #include <string>

--- a/include/deal.II/multigrid/mg_base.h
+++ b/include/deal.II/multigrid/mg_base.h
@@ -22,7 +22,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/observer_pointer.h>
 
 #include <deal.II/lac/vector.h>

--- a/include/deal.II/multigrid/mg_constrained_dofs.h
+++ b/include/deal.II/multigrid/mg_constrained_dofs.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/mg_level_object.h>
 
 #include <deal.II/lac/affine_constraints.h>

--- a/include/deal.II/multigrid/multigrid.h
+++ b/include/deal.II/multigrid/multigrid.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/mg_level_object.h>
 #include <deal.II/base/observer_pointer.h>
 

--- a/include/deal.II/non_matching/immersed_surface_quadrature.h
+++ b/include/deal.II/non_matching/immersed_surface_quadrature.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/quadrature.h>
 #include <deal.II/base/tensor.h>

--- a/include/deal.II/numerics/data_postprocessor.h
+++ b/include/deal.II/numerics/data_postprocessor.h
@@ -19,7 +19,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/tensor.h>
 

--- a/include/deal.II/numerics/time_dependent.h
+++ b/include/deal.II/numerics/time_dependent.h
@@ -18,7 +18,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/template_constraints.h>

--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -19,7 +19,7 @@
 
 #include <deal.II/base/array_view.h>
 #include <deal.II/base/bounding_box.h>
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/function.h>
 #include <deal.II/base/observer_pointer.h>
 

--- a/source/base/CMakeLists.txt
+++ b/source/base/CMakeLists.txt
@@ -23,7 +23,7 @@ set(_unity_include_src
   conditional_ostream.cc
   convergence_table.cc
   discrete_time.cc
-  enable_ref_counting_by_observer.cc
+  enable_observer_pointer.cc
   event.cc
   exceptions.cc
   flow_function.cc

--- a/source/base/enable_observer_pointer.cc
+++ b/source/base/enable_observer_pointer.cc
@@ -12,7 +12,7 @@
 //
 // ------------------------------------------------------------------------
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/logstream.h>
 
 #include <algorithm>

--- a/tests/base/assign_subscriptor.cc
+++ b/tests/base/assign_subscriptor.cc
@@ -18,7 +18,7 @@
 // pair for copy and move semantics.
 
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/observer_pointer.h>
 
 #include <iostream>

--- a/tests/base/reference.cc
+++ b/tests/base/reference.cc
@@ -19,7 +19,7 @@
 // other tests.
 
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/observer_pointer.h>
 
 #include <iostream>

--- a/tests/base/smart_pointer_01.cc
+++ b/tests/base/smart_pointer_01.cc
@@ -18,7 +18,7 @@
 // std::any object.
 
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/observer_pointer.h>
 
 #include <any>

--- a/tests/base/smart_pointer_02.cc
+++ b/tests/base/smart_pointer_02.cc
@@ -18,7 +18,7 @@
 // available after the renaming to ObserverPointer.
 
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/observer_pointer.h>
 #include <deal.II/base/smartpointer.h>
 

--- a/tests/base/unsubscribe_subscriptor.cc
+++ b/tests/base/unsubscribe_subscriptor.cc
@@ -17,7 +17,7 @@
 // check that unsubscribing with a wrong id is handled correctly
 
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/observer_pointer.h>
 
 #include <iostream>

--- a/tests/base/unsubscribe_subscriptor.debug.output
+++ b/tests/base/unsubscribe_subscriptor.debug.output
@@ -2,7 +2,7 @@
 DEAL::Exception: ExcNoSubscriber(object_info->name(), name)
 DEAL::
 --------------------------------------------------------
-An error occurred in file <enable_ref_counting_by_observer.cc> in function
+An error occurred in file <enable_observer_pointer.cc> in function
     void dealii::EnableObserverPointer::unsubscribe(std::atomic<bool>*, const string&) const
 The violated condition was: 
     it != counter_map.end()
@@ -15,7 +15,7 @@ Additional information:
 DEAL::Exception: ExcMessage( "This EnableObserverPointer object does not know anything about the supplied pointer!")
 DEAL::
 --------------------------------------------------------
-An error occurred in file <enable_ref_counting_by_observer.cc> in function
+An error occurred in file <enable_observer_pointer.cc> in function
     void dealii::EnableObserverPointer::unsubscribe(std::atomic<bool>*, const string&) const
 The violated condition was: 
     validity_ptr_it != validity_pointers.end()

--- a/tests/base/unsubscribe_subscriptor.debug.output.clang-6
+++ b/tests/base/unsubscribe_subscriptor.debug.output.clang-6
@@ -2,7 +2,7 @@
 DEAL::Exception: ExcNoSubscriber(object_info->name(), name)
 DEAL::
 --------------------------------------------------------
-An error occurred in file <enable_ref_counting_by_observer.cc> in function
+An error occurred in file <enable_observer_pointer.cc> in function
     void dealii::EnableObserverPointer::unsubscribe(std::atomic<bool> *const, const std::string &) const
 The violated condition was: 
     it != counter_map.end()
@@ -15,7 +15,7 @@ Additional information:
 DEAL::Exception: ExcMessage( "This EnableObserverPointer object does not know anything about the supplied pointer!")
 DEAL::
 --------------------------------------------------------
-An error occurred in file <enable_ref_counting_by_observer.cc> in function
+An error occurred in file <enable_observer_pointer.cc> in function
     void dealii::EnableObserverPointer::unsubscribe(std::atomic<bool> *const, const std::string &) const
 The violated condition was: 
     validity_ptr_it != validity_pointers.end()

--- a/tests/base/unsubscribe_subscriptor.debug.output.gcc-12
+++ b/tests/base/unsubscribe_subscriptor.debug.output.gcc-12
@@ -2,7 +2,7 @@
 DEAL::Exception: ExcNoSubscriber(object_info->name(), name)
 DEAL::
 --------------------------------------------------------
-An error occurred in file <enable_ref_counting_by_observer.cc> in function
+An error occurred in file <enable_observer_pointer.cc> in function
     void dealii::EnableObserverPointer::unsubscribe(std::atomic<bool>*, const std::string&) const
 The violated condition was: 
     it != counter_map.end()
@@ -15,7 +15,7 @@ Additional information:
 DEAL::Exception: ExcMessage( "This EnableObserverPointer object does not know anything about the supplied pointer!")
 DEAL::
 --------------------------------------------------------
-An error occurred in file <enable_ref_counting_by_observer.cc> in function
+An error occurred in file <enable_observer_pointer.cc> in function
     void dealii::EnableObserverPointer::unsubscribe(std::atomic<bool>*, const std::string&) const
 The violated condition was: 
     validity_ptr_it != validity_pointers.end()

--- a/tests/base/unsubscribe_subscriptor.debug.output.intel
+++ b/tests/base/unsubscribe_subscriptor.debug.output.intel
@@ -2,7 +2,7 @@
 DEAL::Exception: ExcNoSubscriber(object_info->name(), name)
 DEAL::
 --------------------------------------------------------
-An error occurred in file <enable_ref_counting_by_observer.cc> in function
+An error occurred in file <enable_observer_pointer.cc> in function
     void dealii::EnableObserverPointer::unsubscribe(std::atomic<bool> *, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> &) const
 The violated condition was: 
     it != counter_map.end()
@@ -15,7 +15,7 @@ Additional information:
 DEAL::Exception: ExcMessage( "This EnableObserverPointer object does not know anything about the supplied pointer!")
 DEAL::
 --------------------------------------------------------
-An error occurred in file <enable_ref_counting_by_observer.cc> in function
+An error occurred in file <enable_observer_pointer.cc> in function
     void dealii::EnableObserverPointer::unsubscribe(std::atomic<bool> *, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> &) const
 The violated condition was: 
     validity_ptr_it != validity_pointers.end()

--- a/tests/base/unsubscribe_subscriptor_01.cc
+++ b/tests/base/unsubscribe_subscriptor_01.cc
@@ -19,7 +19,7 @@
 // works as well
 
 
-#include <deal.II/base/enable_ref_counting_by_observer_pointer.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/observer_pointer.h>
 
 #include <iostream>


### PR DESCRIPTION
When renaming the class in that last commit of #17711, I forgot to also rename the files. In the process, I also noticed that the `.cc` file did not match the class name (it was missing the "pointer" part), and so that is now also fixed.

Part of #17657.