### PR TITLE
doxygen runner: let upload-artifact deal with compression.

### DIFF
--- a/.github/workflows/indent.yml
+++ b/.github/workflows/indent.yml
@@ -61,14 +61,10 @@ jobs:
         sed -i '/^$/d' doxygen.log
         # Check if remaining log is zero size
         ! [ -s doxygen.log ] || exit 1
-    - name: compress
-      run: |
-        tar -czf doxygen_documentation.tar.gz build/doc/doxygen
-    - name: archive documentation
-      uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v4
       with:
-        name: doxygen_documentation.tar.gz
-        path: doxygen_documentation.tar.gz
+        name: doxygen_documentation
+        path: build/doc/doxygen
 
   typos:
     # check for typos


### PR DESCRIPTION
Currently, we run Gzip to create a `*.tar.gz` file, and then Zlib creates a `*.zip` file containing the tarball through `actions/upload-artifact`.

Let's skip the first step and let `actions/upload-artifact` solely deal with compression.

See also https://github.com/actions/upload-artifact?tab=readme-ov-file#upload-an-entire-directory

We can also adjust the compression level if desired.