### PR TITLE
Modifications in ReadVector

### DIFF
--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -438,8 +438,7 @@ namespace internal
  * @ref GlossBlockLA "Block (linear algebra)"
  */
 template <typename VectorType>
-class BlockVectorBase : public EnableObserverPointer,
-                        public ReadVector<typename VectorType::value_type>
+class BlockVectorBase : public ReadVector<typename VectorType::value_type>
 {
 public:
   /**
@@ -654,7 +653,7 @@ public:
 
   virtual void
   extract_subvector_to(const ArrayView<const types::global_dof_index> &indices,
-                       ArrayView<value_type> &entries) const override;
+                       const ArrayView<value_type> &entries) const override;
 
   /**
    * Instead of getting individual elements of a vector via operator(),
@@ -2175,7 +2174,7 @@ template <typename VectorType>
 inline void
 BlockVectorBase<VectorType>::extract_subvector_to(
   const ArrayView<const types::global_dof_index> &indices,
-  ArrayView<value_type>                          &entries) const
+  const ArrayView<value_type>                    &entries) const
 {
   AssertDimension(indices.size(), entries.size());
   for (unsigned int i = 0; i < indices.size(); ++i)

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -246,8 +246,7 @@ namespace LinearAlgebra
      * @endcode
      */
     template <typename Number, typename MemorySpace = MemorySpace::Host>
-    class Vector : public ::dealii::ReadVector<Number>,
-                   public EnableObserverPointer
+    class Vector : public ::dealii::ReadVector<Number>
     {
     public:
       using memory_space    = MemorySpace;
@@ -1135,7 +1134,7 @@ namespace LinearAlgebra
       virtual void
       extract_subvector_to(
         const ArrayView<const types::global_dof_index> &indices,
-        ArrayView<Number> &elements) const override;
+        const ArrayView<Number> &elements) const override;
 
       /**
        * Instead of getting individual elements of a vector via operator(),

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -730,8 +730,7 @@ namespace LinearAlgebra
     template <typename Number, typename MemorySpaceType>
     Vector<Number, MemorySpaceType>::Vector(
       const Vector<Number, MemorySpaceType> &v)
-      : EnableObserverPointer()
-      , allocated_size(0)
+      : allocated_size(0)
       , vector_is_ghosted(false)
       , comm_sm(MPI_COMM_SELF)
     {
@@ -1736,7 +1735,7 @@ namespace LinearAlgebra
     void
     Vector<Number, MemorySpaceType>::extract_subvector_to(
       const ArrayView<const types::global_dof_index> &indices,
-      ArrayView<Number>                              &elements) const
+      const ArrayView<Number>                        &elements) const
     {
       AssertDimension(indices.size(), elements.size());
       for (unsigned int i = 0; i < indices.size(); ++i)

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -249,8 +249,7 @@ namespace PETScWrappers
    *
    * @ingroup PETScWrappers
    */
-  class VectorBase : public ReadVector<PetscScalar>,
-                     public EnableObserverPointer
+  class VectorBase : public ReadVector<PetscScalar>
   {
   public:
     /**
@@ -489,7 +488,7 @@ namespace PETScWrappers
     virtual void
     extract_subvector_to(
       const ArrayView<const types::global_dof_index> &indices,
-      ArrayView<PetscScalar>                         &elements) const override;
+      const ArrayView<PetscScalar>                   &elements) const override;
 
     /**
      * Instead of getting individual elements of a vector via operator(),
@@ -1193,7 +1192,7 @@ namespace PETScWrappers
   inline void
   VectorBase::extract_subvector_to(
     const ArrayView<const types::global_dof_index> &indices,
-    ArrayView<PetscScalar>                         &elements) const
+    const ArrayView<PetscScalar>                   &elements) const
   {
     AssertDimension(indices.size(), elements.size());
     extract_subvector_to(indices.begin(), indices.end(), elements.begin());

--- a/include/deal.II/lac/read_vector.h
+++ b/include/deal.II/lac/read_vector.h
@@ -37,10 +37,14 @@ DEAL_II_NAMESPACE_OPEN
  * accessing vector elements.
  */
 template <typename Number>
-class ReadVector
+class ReadVector : public EnableObserverPointer
 {
 public:
-  using size_type = types::global_dof_index;
+  /**
+   * Declare some of the standard types used in all containers.
+   */
+  using value_type = Number;
+  using size_type  = types::global_dof_index;
 
   /**
    * Return the size of the vector.
@@ -54,7 +58,7 @@ public:
    */
   virtual void
   extract_subvector_to(const ArrayView<const types::global_dof_index> &indices,
-                       ArrayView<Number> &elements) const = 0;
+                       const ArrayView<Number> &elements) const = 0;
 };
 
 /** @} */

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -123,8 +123,7 @@ namespace LinearAlgebra
    * get the first index of the largest range.
    */
   template <typename Number>
-  class ReadWriteVector : public EnableObserverPointer,
-                          public ReadVector<Number>
+  class ReadWriteVector : public ReadVector<Number>
   {
   public:
     /**
@@ -583,7 +582,7 @@ namespace LinearAlgebra
     virtual void
     extract_subvector_to(
       const ArrayView<const types::global_dof_index> &indices,
-      ArrayView<Number>                              &entries) const override;
+      const ArrayView<Number>                        &entries) const override;
 
     /**
      * Instead of getting individual elements of a vector via operator(),
@@ -847,7 +846,6 @@ namespace LinearAlgebra
   template <typename Number>
   inline ReadWriteVector<Number>::ReadWriteVector(
     const ReadWriteVector<Number> &v)
-    : EnableObserverPointer()
   {
     this->operator=(v);
   }
@@ -993,7 +991,7 @@ namespace LinearAlgebra
   void
   ReadWriteVector<Number>::extract_subvector_to(
     const ArrayView<const types::global_dof_index> &indices,
-    ArrayView<Number>                              &entries) const
+    const ArrayView<Number>                        &entries) const
   {
     AssertDimension(indices.size(), entries.size());
     for (unsigned int i = 0; i < indices.size(); ++i)

--- a/include/deal.II/lac/trilinos_epetra_vector.h
+++ b/include/deal.II/lac/trilinos_epetra_vector.h
@@ -222,8 +222,7 @@ namespace LinearAlgebra
      * @ingroup TrilinosWrappers
      * @ingroup Vectors
      */
-    class Vector : public ReadVector<VectorTraits::value_type>,
-                   public EnableObserverPointer
+    class Vector : public ReadVector<VectorTraits::value_type>
     {
     public:
       using value_type      = VectorTraits::value_type;
@@ -281,7 +280,7 @@ namespace LinearAlgebra
       virtual void
       extract_subvector_to(
         const ArrayView<const types::global_dof_index> &indices,
-        ArrayView<double> &elements) const override;
+        const ArrayView<double> &elements) const override;
 
       /**
        * Copy function. This function takes a Vector and copies all the

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -285,7 +285,7 @@ namespace LinearAlgebra
      * @ingroup Vectors
      */
     template <typename Number, typename MemorySpace = dealii::MemorySpace::Host>
-    class Vector : public ReadVector<Number>, public EnableObserverPointer
+    class Vector : public ReadVector<Number>
     {
     public:
       /**
@@ -420,7 +420,7 @@ namespace LinearAlgebra
       virtual void
       extract_subvector_to(
         const ArrayView<const types::global_dof_index> &indices,
-        ArrayView<Number> &elements) const override;
+        const ArrayView<Number> &elements) const override;
 
       /**
        * Copy function. This function takes a Vector and copies all the

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -78,8 +78,7 @@ namespace LinearAlgebra
 
     template <typename Number, typename MemorySpace>
     Vector<Number, MemorySpace>::Vector()
-      : EnableObserverPointer()
-      , compressed(true)
+      : compressed(true)
       , has_ghost(false)
       , vector(Utilities::Trilinos::internal::make_rcp<
                TpetraTypes::VectorType<Number, MemorySpace>>(
@@ -91,8 +90,7 @@ namespace LinearAlgebra
 
     template <typename Number, typename MemorySpace>
     Vector<Number, MemorySpace>::Vector(const Vector<Number, MemorySpace> &V)
-      : EnableObserverPointer()
-      , compressed(V.compressed)
+      : compressed(V.compressed)
       , has_ghost(V.has_ghost)
       , vector(Utilities::Trilinos::internal::make_rcp<
                TpetraTypes::VectorType<Number, MemorySpace>>(*V.vector,
@@ -109,8 +107,7 @@ namespace LinearAlgebra
     template <typename Number, typename MemorySpace>
     Vector<Number, MemorySpace>::Vector(
       const Teuchos::RCP<TpetraTypes::VectorType<Number, MemorySpace>> V)
-      : EnableObserverPointer()
-      , compressed(true)
+      : compressed(true)
       , has_ghost(V->getMap()->isOneToOne() == false)
       , vector(V)
     {}
@@ -120,8 +117,7 @@ namespace LinearAlgebra
     template <typename Number, typename MemorySpace>
     Vector<Number, MemorySpace>::Vector(const IndexSet &parallel_partitioner,
                                         const MPI_Comm  communicator)
-      : EnableObserverPointer()
-      , compressed(true)
+      : compressed(true)
       , has_ghost(false)
       , vector(Utilities::Trilinos::internal::make_rcp<
                TpetraTypes::VectorType<Number, MemorySpace>>(
@@ -136,7 +132,6 @@ namespace LinearAlgebra
                                         const IndexSet &ghost_entries,
                                         const MPI_Comm  communicator,
                                         const bool      vector_writable)
-      : EnableObserverPointer()
     {
       if (!vector_writable)
         {
@@ -294,7 +289,7 @@ namespace LinearAlgebra
     void
     Vector<Number, MemorySpace>::extract_subvector_to(
       const ArrayView<const types::global_dof_index> &indices,
-      ArrayView<Number>                              &elements) const
+      const ArrayView<Number>                        &elements) const
     {
       AssertDimension(indices.size(), elements.size());
 

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -401,8 +401,7 @@ namespace TrilinosWrappers
      * @ingroup TrilinosWrappers
      * @ingroup Vectors
      */
-    class Vector : public EnableObserverPointer,
-                   public ReadVector<TrilinosScalar>
+    class Vector : public ReadVector<TrilinosScalar>
     {
     public:
       /**
@@ -1032,8 +1031,9 @@ namespace TrilinosWrappers
        * Extract a range of elements all at once.
        */
       virtual void
-      extract_subvector_to(const ArrayView<const size_type> &indices,
-                           ArrayView<TrilinosScalar> &elements) const override;
+      extract_subvector_to(
+        const ArrayView<const size_type> &indices,
+        const ArrayView<TrilinosScalar>  &elements) const override;
 
       /**
        * Instead of getting individual elements of a vector via operator(),
@@ -1582,8 +1582,9 @@ namespace TrilinosWrappers
 
 
     inline void
-    Vector::extract_subvector_to(const ArrayView<const size_type> &indices,
-                                 ArrayView<TrilinosScalar> &elements) const
+    Vector::extract_subvector_to(
+      const ArrayView<const size_type> &indices,
+      const ArrayView<TrilinosScalar>  &elements) const
     {
       AssertDimension(indices.size(), elements.size());
       for (unsigned int i = 0; i < indices.size(); ++i)

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -116,7 +116,7 @@ namespace parallel
  * in the manual).
  */
 template <typename Number>
-class Vector : public EnableObserverPointer, public ReadVector<Number>
+class Vector : public ReadVector<Number>
 {
 public:
   /**
@@ -726,7 +726,7 @@ public:
    */
   virtual void
   extract_subvector_to(const ArrayView<const types::global_dof_index> &indices,
-                       ArrayView<Number> &elements) const override;
+                       const ArrayView<Number> &elements) const override;
 
   /**
    * Instead of getting individual elements of a vector via operator(),

--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -52,7 +52,6 @@ DEAL_II_NAMESPACE_OPEN
 
 template <typename Number>
 Vector<Number>::Vector(const Vector<Number> &v)
-  : EnableObserverPointer()
 {
   *this = v;
 }
@@ -622,7 +621,7 @@ template <typename Number>
 void
 Vector<Number>::extract_subvector_to(
   const ArrayView<const types::global_dof_index> &indices,
-  ArrayView<Number>                              &elements) const
+  const ArrayView<Number>                        &elements) const
 {
   AssertDimension(indices.size(), elements.size());
   for (unsigned int i = 0; i < indices.size(); ++i)

--- a/include/deal.II/non_matching/fe_values.h
+++ b/include/deal.II/non_matching/fe_values.h
@@ -166,13 +166,13 @@ namespace NonMatching
      * and @p level_set are stored internally, so these need to have a longer life
      * span than the instance of this class.
      */
-    template <typename VectorType>
+    template <typename Number>
     FEValues(const hp::FECollection<dim> &fe_collection,
              const Quadrature<1>         &quadrature,
              const RegionUpdateFlags      region_update_flags,
              const MeshClassifier<dim>   &mesh_classifier,
              const DoFHandler<dim>       &dof_handler,
-             const VectorType            &level_set,
+             const ReadVector<Number>    &level_set,
              const AdditionalData        &additional_data = AdditionalData());
 
     /**
@@ -201,7 +201,7 @@ namespace NonMatching
      * internally, so these need to have a longer life span than the instance of
      * this class.
      */
-    template <typename VectorType>
+    template <typename Number>
     FEValues(const hp::MappingCollection<dim> &mapping_collection,
              const hp::FECollection<dim>      &fe_collection,
              const hp::QCollection<dim>       &q_collection,
@@ -209,7 +209,7 @@ namespace NonMatching
              const RegionUpdateFlags           region_update_flags,
              const MeshClassifier<dim>        &mesh_classifier,
              const DoFHandler<dim>            &dof_handler,
-             const VectorType                 &level_set,
+             const ReadVector<Number>         &level_set,
              const AdditionalData &additional_data = AdditionalData());
 
     /**
@@ -512,13 +512,13 @@ namespace NonMatching
      * and @p level_set are stored internally, so these need to have a longer life
      * span than the instance of this class.
      */
-    template <typename VectorType>
+    template <typename Number>
     FEInterfaceValues(const hp::FECollection<dim> &fe_collection,
                       const Quadrature<1>         &quadrature,
                       const RegionUpdateFlags      region_update_flags,
                       const MeshClassifier<dim>   &mesh_classifier,
                       const DoFHandler<dim>       &dof_handler,
-                      const VectorType            &level_set,
+                      const ReadVector<Number>    &level_set,
                       const AdditionalData &additional_data = AdditionalData());
 
     /**
@@ -547,7 +547,7 @@ namespace NonMatching
      * internally, so these need to have a longer life span than the instance of
      * this class.
      */
-    template <typename VectorType>
+    template <typename Number>
     FEInterfaceValues(const hp::MappingCollection<dim> &mapping_collection,
                       const hp::FECollection<dim>      &fe_collection,
                       const hp::QCollection<dim - 1>   &q_collection,
@@ -555,7 +555,7 @@ namespace NonMatching
                       const RegionUpdateFlags           region_update_flags,
                       const MeshClassifier<dim>        &mesh_classifier,
                       const DoFHandler<dim>            &dof_handler,
-                      const VectorType                 &level_set,
+                      const ReadVector<Number>         &level_set,
                       const AdditionalData &additional_data = AdditionalData());
 
     /**

--- a/include/deal.II/non_matching/quadrature_generator.h
+++ b/include/deal.II/non_matching/quadrature_generator.h
@@ -543,11 +543,11 @@ namespace NonMatching
      * class. The hp::QCollection<1> and AdditionalData is passed to the
      * QuadratureGenerator class.
      */
-    template <typename VectorType>
+    template <typename Number>
     DiscreteQuadratureGenerator(
       const hp::QCollection<1> &quadratures1D,
       const DoFHandler<dim>    &dof_handler,
-      const VectorType         &level_set,
+      const ReadVector<Number> &level_set,
       const AdditionalData     &additional_data = AdditionalData());
 
     /**
@@ -605,11 +605,11 @@ namespace NonMatching
      * class. The hp::QCollection<1> and AdditionalData is passed to the
      * QuadratureGenerator class.
      */
-    template <typename VectorType>
+    template <typename Number>
     DiscreteFaceQuadratureGenerator(
       const hp::QCollection<1> &quadratures1D,
       const DoFHandler<dim>    &dof_handler,
-      const VectorType         &level_set,
+      const ReadVector<Number> &level_set,
       const AdditionalData     &additional_data = AdditionalData());
 
     /**

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -128,8 +128,7 @@ namespace PETScWrappers
 
 
   VectorBase::VectorBase(const VectorBase &v)
-    : EnableObserverPointer()
-    , ghosted(v.ghosted)
+    : ghosted(v.ghosted)
     , ghost_indices(v.ghost_indices)
     , last_action(VectorOperation::unknown)
   {
@@ -143,8 +142,7 @@ namespace PETScWrappers
 
 
   VectorBase::VectorBase(const Vec &v)
-    : EnableObserverPointer()
-    , vector(v)
+    : vector(v)
     , ghosted(false)
     , last_action(VectorOperation::unknown)
   {

--- a/source/lac/trilinos_epetra_vector.cc
+++ b/source/lac/trilinos_epetra_vector.cc
@@ -81,24 +81,21 @@ namespace LinearAlgebra
 #  endif
 
     Vector::Vector()
-      : EnableObserverPointer()
-      , vector(new Epetra_FEVector(
+      : vector(new Epetra_FEVector(
           Epetra_Map(0, 0, 0, Utilities::Trilinos::comm_self())))
     {}
 
 
 
     Vector::Vector(const Vector &V)
-      : EnableObserverPointer()
-      , vector(new Epetra_FEVector(V.trilinos_vector()))
+      : vector(new Epetra_FEVector(V.trilinos_vector()))
     {}
 
 
 
     Vector::Vector(const IndexSet &parallel_partitioner,
                    const MPI_Comm  communicator)
-      : EnableObserverPointer()
-      , vector(new Epetra_FEVector(
+      : vector(new Epetra_FEVector(
           parallel_partitioner.make_trilinos_map(communicator, false)))
     {}
 
@@ -136,7 +133,7 @@ namespace LinearAlgebra
     void
     Vector::extract_subvector_to(
       const ArrayView<const types::global_dof_index> &indices,
-      ArrayView<double>                              &elements) const
+      const ArrayView<double>                        &elements) const
     {
       AssertDimension(indices.size(), elements.size());
       const auto &vector = trilinos_vector();

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -77,8 +77,7 @@ namespace TrilinosWrappers
   namespace MPI
   {
     Vector::Vector()
-      : EnableObserverPointer()
-      , last_action(Zero)
+      : last_action(Zero)
       , compressed(true)
       , has_ghosts(false)
       , vector(new Epetra_FEVector(

--- a/source/non_matching/fe_values.cc
+++ b/source/non_matching/fe_values.cc
@@ -41,13 +41,13 @@ namespace NonMatching
 
 
   template <int dim>
-  template <typename VectorType>
+  template <typename Number>
   FEValues<dim>::FEValues(const hp::FECollection<dim> &fe_collection,
                           const Quadrature<1>         &quadrature,
                           const RegionUpdateFlags      region_update_flags,
                           const MeshClassifier<dim>   &mesh_classifier,
                           const DoFHandler<dim>       &dof_handler,
-                          const VectorType            &level_set,
+                          const ReadVector<Number>    &level_set,
                           const AdditionalData        &additional_data)
     : mapping_collection(&dealii::hp::StaticMappingQ1<dim>::mapping_collection)
     , fe_collection(&fe_collection)
@@ -71,7 +71,7 @@ namespace NonMatching
 
 
   template <int dim>
-  template <typename VectorType>
+  template <typename Number>
   FEValues<dim>::FEValues(const hp::MappingCollection<dim> &mapping_collection,
                           const hp::FECollection<dim>      &fe_collection,
                           const hp::QCollection<dim>       &q_collection,
@@ -79,7 +79,7 @@ namespace NonMatching
                           const RegionUpdateFlags           region_update_flags,
                           const MeshClassifier<dim>        &mesh_classifier,
                           const DoFHandler<dim>            &dof_handler,
-                          const VectorType                 &level_set,
+                          const ReadVector<Number>         &level_set,
                           const AdditionalData             &additional_data)
     : mapping_collection(&mapping_collection)
     , fe_collection(&fe_collection)
@@ -335,14 +335,14 @@ namespace NonMatching
 
 
   template <int dim>
-  template <typename VectorType>
+  template <typename Number>
   FEInterfaceValues<dim>::FEInterfaceValues(
     const hp::FECollection<dim> &fe_collection,
     const Quadrature<1>         &quadrature,
     const RegionUpdateFlags      region_update_flags,
     const MeshClassifier<dim>   &mesh_classifier,
     const DoFHandler<dim>       &dof_handler,
-    const VectorType            &level_set,
+    const ReadVector<Number>    &level_set,
     const AdditionalData        &additional_data)
     : mapping_collection(&dealii::hp::StaticMappingQ1<dim>::mapping_collection)
     , fe_collection(&fe_collection)
@@ -366,7 +366,7 @@ namespace NonMatching
 
 
   template <int dim>
-  template <typename VectorType>
+  template <typename Number>
   FEInterfaceValues<dim>::FEInterfaceValues(
     const hp::MappingCollection<dim> &mapping_collection,
     const hp::FECollection<dim>      &fe_collection,
@@ -375,7 +375,7 @@ namespace NonMatching
     const RegionUpdateFlags           region_update_flags,
     const MeshClassifier<dim>        &mesh_classifier,
     const DoFHandler<dim>            &dof_handler,
-    const VectorType                 &level_set,
+    const ReadVector<Number>         &level_set,
     const AdditionalData             &additional_data)
     : mapping_collection(&mapping_collection)
     , fe_collection(&fe_collection)

--- a/source/non_matching/fe_values.inst.in
+++ b/source/non_matching/fe_values.inst.in
@@ -20,7 +20,7 @@ for (deal_II_dimension : DIMENSIONS)
     template class FEInterfaceValues<deal_II_dimension>;
   }
 
-for (VEC : REAL_VECTOR_TYPES; deal_II_dimension : DIMENSIONS)
+for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
   {
     template FEValues<deal_II_dimension>::FEValues(
       const hp::MappingCollection<deal_II_dimension> &,
@@ -30,7 +30,7 @@ for (VEC : REAL_VECTOR_TYPES; deal_II_dimension : DIMENSIONS)
       const RegionUpdateFlags,
       const MeshClassifier<deal_II_dimension> &,
       const DoFHandler<deal_II_dimension> &,
-      const VEC &,
+      const ReadVector<S> &,
       const typename FEValues<deal_II_dimension>::AdditionalData &);
 
 
@@ -40,7 +40,7 @@ for (VEC : REAL_VECTOR_TYPES; deal_II_dimension : DIMENSIONS)
       const RegionUpdateFlags,
       const MeshClassifier<deal_II_dimension> &,
       const DoFHandler<deal_II_dimension> &,
-      const VEC &,
+      const ReadVector<S> &,
       const typename FEValues<deal_II_dimension>::AdditionalData &);
 
     template FEInterfaceValues<deal_II_dimension>::FEInterfaceValues(
@@ -49,7 +49,7 @@ for (VEC : REAL_VECTOR_TYPES; deal_II_dimension : DIMENSIONS)
       const RegionUpdateFlags,
       const MeshClassifier<deal_II_dimension> &,
       const DoFHandler<deal_II_dimension> &,
-      const VEC &,
+      const ReadVector<S> &,
       const FEInterfaceValues<deal_II_dimension>::AdditionalData &);
 
     template FEInterfaceValues<deal_II_dimension>::FEInterfaceValues(
@@ -60,7 +60,7 @@ for (VEC : REAL_VECTOR_TYPES; deal_II_dimension : DIMENSIONS)
       const RegionUpdateFlags,
       const MeshClassifier<deal_II_dimension> &,
       const DoFHandler<deal_II_dimension> &,
-      const VEC &,
+      const ReadVector<S> &,
       const AdditionalData &);
   }
 

--- a/source/non_matching/quadrature_generator.inst.in
+++ b/source/non_matching/quadrature_generator.inst.in
@@ -84,17 +84,17 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
 #endif
   }
 
-for (VEC : REAL_VECTOR_TYPES; deal_II_dimension : DIMENSIONS)
+for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
   {
     template NonMatching::DiscreteQuadratureGenerator<deal_II_dimension>::
       DiscreteQuadratureGenerator(const hp::QCollection<1> &,
                                   const DoFHandler<deal_II_dimension> &,
-                                  const VEC &,
+                                  const ReadVector<S> &,
                                   const AdditionalData &);
 
     template NonMatching::DiscreteFaceQuadratureGenerator<deal_II_dimension>::
       DiscreteFaceQuadratureGenerator(const hp::QCollection<1> &,
                                       const DoFHandler<deal_II_dimension> &,
-                                      const VEC &,
+                                      const ReadVector<S> &,
                                       const AdditionalData &);
   }


### PR DESCRIPTION
- fix constness: `ReadVector::extract_subvector_to(const ArrayView<const types::global_dof_index> &, ArrayView<Number> &)` -> `ReadVector::extract_subvector_to(const ArrayView<const types::global_dof_index> &, const ArrayView<Number> &)` 
- derive `ReadVector` from `EnableObserverPointer`
- make `ReadVector::value_type` available
- use `ReadVector` in `NonMatching` namespace