### PR TITLE
Make BLAS signatures compatible.

### DIFF
--- a/bundled/umfpack/UMFPACK/Source/cholmod_blas.h
+++ b/bundled/umfpack/UMFPACK/Source/cholmod_blas.h
@@ -174,9 +174,9 @@ extern "C" {
 /* === BLAS and LAPACK prototypes and macros ================================ */
 /* ========================================================================== */
 
-void BLAS_DGEMV (char *trans, BLAS_INT *m, BLAS_INT *n, double *alpha,
-	double *A, BLAS_INT *lda, double *X, BLAS_INT *incx, double *beta,
-	double *Y, BLAS_INT *incy) ;
+void BLAS_DGEMV (const char *trans, const BLAS_INT *m, const BLAS_INT *n, const double *alpha,
+                 const double *A, const BLAS_INT *lda, const double *X, const BLAS_INT *incx, const double *beta,
+                 double *Y, const BLAS_INT *incy) ;
 
 #define BLAS_dgemv(trans,m,n,alpha,A,lda,X,incx,beta,Y,incy) \
 { \
@@ -192,9 +192,9 @@ void BLAS_DGEMV (char *trans, BLAS_INT *m, BLAS_INT *n, double *alpha,
     } \
 }
 
-void BLAS_ZGEMV (char *trans, BLAS_INT *m, BLAS_INT *n, double *alpha,
-	double *A, BLAS_INT *lda, double *X, BLAS_INT *incx, double *beta,
-	double *Y, BLAS_INT *incy) ;
+void BLAS_ZGEMV (const char *trans, const BLAS_INT *m, const BLAS_INT *n, const double *alpha,
+                 const double *A, const BLAS_INT *lda, const double *X, const BLAS_INT *incx, const double *beta,
+                 double *Y, const BLAS_INT *incy) ;
 
 #define BLAS_zgemv(trans,m,n,alpha,A,lda,X,incx,beta,Y,incy) \
 { \
@@ -210,7 +210,7 @@ void BLAS_ZGEMV (char *trans, BLAS_INT *m, BLAS_INT *n, double *alpha,
     } \
 }
 
-void BLAS_DTRSV (char *uplo, char *trans, char *diag, BLAS_INT *n, double *A,
+void BLAS_DTRSV (char *uplo, const char *trans, char *diag, BLAS_INT *n, double *A,
 	BLAS_INT *lda, double *X, BLAS_INT *incx) ;
 
 #define BLAS_dtrsv(uplo,trans,diag,n,A,lda,X,incx) \
@@ -226,7 +226,7 @@ void BLAS_DTRSV (char *uplo, char *trans, char *diag, BLAS_INT *n, double *A,
     } \
 }
 
-void BLAS_ZTRSV (char *uplo, char *trans, char *diag, BLAS_INT *n, double *A,
+void BLAS_ZTRSV (char *uplo, const char *trans, char *diag, BLAS_INT *n, double *A,
 	BLAS_INT *lda, double *X, BLAS_INT *incx) ;
 
 #define BLAS_ztrsv(uplo,trans,diag,n,A,lda,X,incx) \
@@ -242,7 +242,7 @@ void BLAS_ZTRSV (char *uplo, char *trans, char *diag, BLAS_INT *n, double *A,
     } \
 }
 
-void BLAS_DTRSM (char *side, char *uplo, char *transa, char *diag, BLAS_INT *m,
+void BLAS_DTRSM (char *side, char *uplo, const char *transa, char *diag, BLAS_INT *m,
 	BLAS_INT *n, double *alpha, double *A, BLAS_INT *lda, double *B,
 	BLAS_INT *ldb) ;
 
@@ -259,7 +259,7 @@ void BLAS_DTRSM (char *side, char *uplo, char *transa, char *diag, BLAS_INT *m,
     } \
 }
 
-void BLAS_ZTRSM (char *side, char *uplo, char *transa, char *diag, BLAS_INT *m,
+void BLAS_ZTRSM (char *side, char *uplo, const char *transa, char *diag, BLAS_INT *m,
 	BLAS_INT *n, double *alpha, double *A, BLAS_INT *lda, double *B,
 	BLAS_INT *ldb) ;
 
@@ -276,9 +276,9 @@ void BLAS_ZTRSM (char *side, char *uplo, char *transa, char *diag, BLAS_INT *m,
     } \
 }
 
-void BLAS_DGEMM (char *transa, char *transb, BLAS_INT *m, BLAS_INT *n,
-	BLAS_INT *k, double *alpha, double *A, BLAS_INT *lda, double *B,
-	BLAS_INT *ldb, double *beta, double *C, BLAS_INT *ldc) ;
+void BLAS_DGEMM (const char *transa, const char *transb, const BLAS_INT *m, const BLAS_INT *n,
+                 const BLAS_INT *k, const double *alpha, const double *A, const BLAS_INT *lda, const double *B,
+                 const BLAS_INT *ldb, const double *beta, double *C, const BLAS_INT *ldc) ;
 
 #define BLAS_dgemm(transa,transb,m,n,k,alpha,A,lda,B,ldb,beta,C,ldc) \
 { \
@@ -295,9 +295,9 @@ void BLAS_DGEMM (char *transa, char *transb, BLAS_INT *m, BLAS_INT *n,
     } \
 }
 
-void BLAS_ZGEMM (char *transa, char *transb, BLAS_INT *m, BLAS_INT *n,
-	BLAS_INT *k, double *alpha, double *A, BLAS_INT *lda, double *B,
-	BLAS_INT *ldb, double *beta, double *C, BLAS_INT *ldc) ;
+void BLAS_ZGEMM (const char *transa, const char *transb, const BLAS_INT *m, const BLAS_INT *n,
+                 const BLAS_INT *k, const double *alpha, const double *A, const BLAS_INT *lda, const double *B,
+                 const BLAS_INT *ldb, const double *beta, double *C, const BLAS_INT *ldc) ;
 
 #define BLAS_zgemm(transa,transb,m,n,k,alpha,A,lda,B,ldb,beta,C,ldc) \
 { \
@@ -314,7 +314,7 @@ void BLAS_ZGEMM (char *transa, char *transb, BLAS_INT *m, BLAS_INT *n,
     } \
 }
 
-void BLAS_DSYRK (char *uplo, char *trans, BLAS_INT *n, BLAS_INT *k,
+void BLAS_DSYRK (char *uplo, const char *trans, BLAS_INT *n, BLAS_INT *k,
 	double *alpha, double *A, BLAS_INT *lda, double *beta, double *C,
 	BLAS_INT *ldc) ;
 
@@ -331,7 +331,7 @@ void BLAS_DSYRK (char *uplo, char *trans, BLAS_INT *n, BLAS_INT *k,
     } \
 } \
 
-void BLAS_ZHERK (char *uplo, char *trans, BLAS_INT *n, BLAS_INT *k,
+void BLAS_ZHERK (char *uplo, const char *trans, BLAS_INT *n, BLAS_INT *k,
 	double *alpha, double *A, BLAS_INT *lda, double *beta, double *C,
 	BLAS_INT *ldc) ;
 


### PR DESCRIPTION
This is in relation to #17718. We currently have two places where we declare BLAS functions. To show an example, `bundled/umfpack/UMFPACK/Source/cholmod_blas.h` says
```
#define BLAS_DGEMM dgemm                   // or other variants, depending on compiler

void BLAS_DGEMM (char *transa, char *transb, BLAS_INT *m, BLAS_INT *n,
	BLAS_INT *k, double *alpha, double *A, BLAS_INT *lda, double *B,
	BLAS_INT *ldb, double *beta, double *C, BLAS_INT *ldc) ;
```
On the other hand, in `include/deal.II/lac/lapack_templates.h`, we have
```
  void DEAL_II_FORTRAN_MANGLE(dgemm, DGEMM)(const char *transa,
                                            const char *transb,
                                            const dealii::types::blas_int *m,
                                            const dealii::types::blas_int *n,
                                            const dealii::types::blas_int *k,
                                            const double *alpha,
                                            const double *a,
                                            const dealii::types::blas_int *lda,
                                            const double                  *b,
                                            const dealii::types::blas_int *ldb,
                                            const double                  *beta,
                                            double                        *c,
                                            const dealii::types::blas_int *ldc);
```
Note the differences in usage of `const`.

Ordinarily, these two places don't get in each others' way: UMFPACK uses its own declarations when compiling, and since we don't ever see UMFPACK's declarations (they are in the `Source` directory, after all), we use ours. Since both of the declarations are in `extern "C" { ... }` blocks, the C++ compiler mangles these functions with just their name and not the arguments, so from the linker's perspective, they all point to the same symbol in `libblas.so` or wherever they may be found.

We get in trouble when using link-time optimizations (`-flto`) because then the compiler goes over everything one more time, having all `.cc` files in memory at the same time. At that point, we get complaints such as this (see #17718):
```
/tempest/a/accounts/bangerth/p/deal.II/1/dealii/bundled/umfpack/UMFPACK/Source/cholmod_blas.h:177:6: note: type 'char' should match type 'const char'
/tempest/a/accounts/bangerth/p/deal.II/1/dealii/bundled/umfpack/UMFPACK/Source/cholmod_blas.h:177:6: note: 'dgemv_' was previously declared here
/tempest/a/accounts/bangerth/p/deal.II/1/dealii/include/deal.II/lac/lapack_templates.h:306: warning: 'dgemm_' violates the C++ One Definition Rule [-Wodr]
  306 |   void DEAL_II_FORTRAN_MANGLE(dgemm, DGEMM)(const char *transa,
      | 
/tempest/a/accounts/bangerth/p/deal.II/1/dealii/bundled/umfpack/UMFPACK/Source/cholmod_blas.h:279:6: note: type mismatch in parameter 1
  279 | void BLAS_DGEMM (char *transa, char *transb, BLAS_INT *m, BLAS_INT *n,
      |      ^
```

This patch fixes up a bunch of the declarations in the UMFPACK directory to include the `const` keyword for the respective arguments. For the moment, I'm only doing this for some of the functions, namely the ones I get warnings about (plus, every argument called `char *trans`). This removes the compiler warnings, but I'd be happy to have a discussion on whether that's the right approach to take: From the perspective of the BLAS, the `const` is not there because C in essence just ignores constness as far as declarations are concerned. It's also a hassle if we wanted to do this for all possible functions, and not made better that I'm patching a file in `bundled/` that we don't own.

So, thoughts?