### PR TITLE
Try using interprocedural/link-time optimization.

### DIFF
--- a/cmake/checks/check_02_compiler_features.cmake
+++ b/cmake/checks/check_02_compiler_features.cmake
@@ -407,3 +407,25 @@ if(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
 
   reset_cmake_required()
 endif()
+
+
+#
+# Check whether the compiler supports interprocedural and link-time
+# optimization. If so, we can set the corresponding property on the
+# compile and link targets later on.
+#
+if(DEAL_II_USE_LTO)
+  include(CheckIPOSupported)
+  check_ipo_supported(RESULT _res OUTPUT _out LANGUAGES CXX)
+  if (_res)
+    message(STATUS "Compiler supports interprocedural/link-time optimizations")
+    set(DEAL_II_USE_LTO "YES")
+  else()
+    message(FATAL_ERROR "You asked for interprocedural/link-time optimizations, but the compiler does not support these optimizations: ${_out}")
+    set(DEAL_II_USE_LTO "NO")
+  endif()
+else()
+  # User did not set DEAL_II_USE_LTO on the command line. Set the
+  # variable to a specific (negative) value.
+  set(DEAL_II_USE_LTO "NO")
+endif()

--- a/cmake/macros/macro_populate_target_properties.cmake
+++ b/cmake/macros/macro_populate_target_properties.cmake
@@ -15,7 +15,7 @@
 #
 # populate_target_properties(<target> <build>)
 #
-# This function populate target properties according to (globally) defined
+# This function populates target properties according to (globally) defined
 # DEAL_II_* variables. Specifically:
 #
 #   DEAL_II_LIBRARIES DEAL_II_LIBRARIES_<build>
@@ -126,4 +126,13 @@ function(populate_target_properties _target _build)
     ${DEAL_II_LIBRARIES} ${DEAL_II_LIBRARIES_${_build}}
     ${DEAL_II_TARGETS} ${DEAL_II_TARGETS_${_build}}
     )
+
+
+   # For release builds (and their corresponding object files),
+   # use interprocedural optimizations if possible
+   if (DEAL_II_USE_LTO AND ("${_build}" STREQUAL "RELEASE"))
+     set_property(TARGET ${_target}
+                  PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+   endif()
+
 endfunction()

--- a/cmake/setup_cached_variables.cmake
+++ b/cmake/setup_cached_variables.cmake
@@ -31,6 +31,7 @@
 #
 #     CMAKE_BUILD_TYPE
 #     DEAL_II_ALLOW_PLATFORM_INTROSPECTION
+#     DEAL_II_USE_LTO
 #     DEAL_II_SETUP_COVERAGE
 #     DEAL_II_UNITY_BUILD
 #     DEAL_II_EARLY_DEPRECATIONS
@@ -158,6 +159,12 @@ option(DEAL_II_ALLOW_PLATFORM_INTROSPECTION
   ON
   )
 mark_as_advanced(DEAL_II_ALLOW_PLATFORM_INTROSPECTION)
+
+option(DEAL_II_USE_LTO
+  "Allow the compiler to use interprocedural and link-time optimization (LTO)."
+  OFF
+  )
+mark_as_advanced(DEAL_II_USE_LTO)
 
 option(DEAL_II_SETUP_COVERAGE
   "Setup debug compiler flags to provide additional test coverage information. Currently only gprof is supported."

--- a/doc/news/changes/minor/20241104Bangerth
+++ b/doc/news/changes/minor/20241104Bangerth
@@ -1,0 +1,10 @@
+New: The cmake configuration system now allows enabling
+interprocedural and link-time optimization by the compiler. These
+kinds of optimization often result in substantially faster executables
+because they allow the compiler to see a bigger part of the whole
+program when optimizing.
+
+To enable interprocedural and link-time optimization, pass the
+`-DDEAL_II_USE_LTO=ON` flag to cmake when configuring the library.
+<br>
+(Wolfgang Bangerth, 2024/09/24)

--- a/doc/users/cmake_dealii.html
+++ b/doc/users/cmake_dealii.html
@@ -782,6 +782,14 @@ cmake -DLAPACK_FOUND=true \
           introspection for the given CPU.
 
         <li>
+          <code>DEAL_II_USE_LTO</code>: If set to "ON" (the default is
+          "OFF"), allow the compiler to use interprocedural and
+          link-time optimization for release builds. These
+          optimizations often substantially improve performance, but
+          take both a substantial amount of memory and CPU time when
+          compiling the library.
+
+        <li>
           <code>BUILD_SHARED_LIBS</code>: If set (default),
           <acronym>deal.II</acronym> will be linked as a shared library
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -94,6 +94,7 @@ foreach(build ${DEAL_II_BUILD_TYPES})
     set(build_camelcase "Release")
   endif()
 
+
   #
   # Combine all ${build} OBJECT targets to a ${build} library:
   #


### PR DESCRIPTION
This is the start of a patch, but I'm having trouble finding out how to finish it. This patch lets cmake query whether the compiler supports LTO, and then I'm setting the corresponding property where we set compile properties. Unfortunately, the only places I seem to get are these:
```
-- Setting LTO properties on bundled_umfpack_L_UMF_release for build type RELEASE
-- Setting LTO properties on bundled_umfpack_Z_UMF_release for build type RELEASE
-- Setting LTO properties on bundled_umfpack_L_UMFPACK_release for build type RELEASE
-- Setting LTO properties on bundled_umfpack_DL_TSOLVE_release for build type RELEASE
-- Setting LTO properties on bundled_umfpack_DL_TRIPLET_MAP_NOX_release for build type RELEASE
-- Setting LTO properties on bundled_umfpack_DL_TRIPLET_MAP_X_release for build type RELEASE
-- Setting LTO properties on bundled_umfpack_DL_TRIPLET_NOMAP_X_release for build type RELEASE
-- Setting LTO properties on bundled_umfpack_DL_TRIPLET_NOMAP_NOX_release for build type RELEASE
-- Setting LTO properties on bundled_umfpack_DL_STORE_release for build type RELEASE
-- Setting LTO properties on bundled_umfpack_DL_ASSEMBLE_release for build type RELEASE
-- Setting LTO properties on bundled_umfpack_DL_SOLVE_release for build type RELEASE
-- Setting LTO properties on bundled_umfpack_ZL_TSOLVE_release for build type RELEASE
-- Setting LTO properties on bundled_umfpack_ZL_TRIPLET_MAP_NOX_release for build type RELEASE
-- Setting LTO properties on bundled_umfpack_ZL_TRIPLET_MAP_X_release for build type RELEASE
-- Setting LTO properties on bundled_umfpack_ZL_TRIPLET_NOMAP_X_release for build type RELEASE
-- Setting LTO properties on bundled_umfpack_ZL_TRIPLET_NOMAP_NOX_release for build type RELEASE
-- Setting LTO properties on bundled_umfpack_ZL_STORE_release for build type RELEASE
-- Setting LTO properties on bundled_umfpack_ZL_ASSEMBLE_release for build type RELEASE
-- Setting LTO properties on bundled_umfpack_ZL_SOLVE_release for build type RELEASE
-- Setting LTO properties on bundled_amd_int_release for build type RELEASE
-- Setting LTO properties on bundled_amd_long_release for build type RELEASE
```
Someone will have to point me in the direction of where we set compile properties for our own object files, plus where we do the same when linking things together. We seem not to be doing that via `set_property`, or perhaps I just don't quite know where we do that.

@tamiko ?