### PR TITLE
Add necessary EnableObserverPointer header to ReadVector

### DIFF
--- a/include/deal.II/lac/read_vector.h
+++ b/include/deal.II/lac/read_vector.h
@@ -18,6 +18,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/array_view.h>
+#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/types.h>
 
 DEAL_II_NAMESPACE_OPEN


### PR DESCRIPTION
References #17788

Fixes compile errors in user code like here https://github.com/bergbauer/exadg/actions/runs/11419564284/job/31774278987