### PR TITLE
windows: let upload-artifact deal with archiving.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,19 +60,13 @@ jobs:
       run: |
         cmake --build build --parallel 2 --target setup_tests_a-framework setup_tests_examples setup_tests_quick_tests
         ctest --test-dir build --build-config Debug --output-on-failure --extra-verbose
-    - name: archive
-      # run only if a PR is merged into master
-      if: ${{ github.ref == 'refs/heads/master' && matrix.os == 'windows-2022' }}
-      run: |
-        cd c:/project
-        7z a dealii-windows.zip *
     - name: upload library
       # run only if a PR is merged into master
       if: ${{ github.ref == 'refs/heads/master' && matrix.os == 'windows-2022' }}
       uses: actions/upload-artifact@v4
       with:
-        name: dealii-windows.zip
-        path: c:/project/dealii-windows.zip
+        name: dealii-${{ matrix.os }}
+        path: c:/project
     - name: upload CMakeConfigureLog
       uses: actions/upload-artifact@v4
       if: always()


### PR DESCRIPTION
Related to #17787.

We can now finally do it this way, since https://github.com/actions/upload-artifact/issues/485 has been fixed.

This will get rid of the awkward zipfile-in-a-zipfile situation.