### PR TITLE
Cleanup some github workflows.

### DIFF
--- a/.github/workflows/indent.yml
+++ b/.github/workflows/indent.yml
@@ -3,7 +3,7 @@ name: indent
 on: [push, pull_request]
 
 concurrency:
-  group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
 permissions:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -459,12 +459,8 @@ jobs:
               -D DEAL_II_WITH_P4EST="ON" \
               -D DEAL_II_COMPONENT_EXAMPLES="ON" \
               ..
-        cat detailed.log
-    - name: archive detailed.log
-      uses: actions/upload-artifact@v4
-      with:
-        name: linux-cuda-clang-detailed.log
-        path: build/detailed.log
+    - name: print detailed.log
+      run: cat build/detailed.log
     - name: build deal.II
       run: |
         cd build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -184,7 +184,7 @@ jobs:
       run: |
         cd build
         make VERBOSE=1 -j2
-    - name: test
+    - name: test trilinos_tpetra
       run: |
         # Remove warning: "A high-performance Open MPI point-to-point
         # messaging module was unable to find any relevant network
@@ -192,17 +192,8 @@ jobs:
         export OMPI_MCA_btl_base_warn_component_unused='0'
 
         cd build
-        make VERBOSE=1 -j2
-    - name: test
-      run: |
-        # Remove warning: "A high-performance Open MPI point-to-point
-        # messaging module was unable to find any relevant network
-        # interfaces."
-        export OMPI_MCA_btl_base_warn_component_unused='0'
-
-        cd build
-        make -j2 setup_tests
-        ctest --output-on-failure -j2 -VV -R "tpetra"
+        make -j2 setup_tests_trilinos_tpetra
+        ctest --output-on-failure -j2 -VV
 
   ############################
   # linux-debug-intel-oneapi #

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,7 +10,7 @@ on:
     - ready_for_review
 
 concurrency:
-  group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
 permissions:

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -39,11 +39,17 @@ jobs:
         cmake --version
     - name: configure
       run: |
-        cmake -D CMAKE_BUILD_TYPE=Debug -D DEAL_II_CXX_FLAGS='-Werror' -D DEAL_II_EARLY_DEPRECATIONS=ON .
+        mkdir build
+        cd build
+        cmake -D CMAKE_BUILD_TYPE=Debug \
+              -D DEAL_II_CXX_FLAGS='-Werror' \
+              -D DEAL_II_EARLY_DEPRECATIONS=ON \
+              ..
     - name: print detailed.log
-      run: cat detailed.log
+      run: cat build/detailed.log
     - name: build
       run: |
+        cd build
         make VERBOSE=1 -j2
         make -j2 \
           setup_tests_a-framework \
@@ -86,11 +92,19 @@ jobs:
         cmake --version
     - name: configure
       run: |
-        CC=mpicc CXX=mpic++ cmake -D CMAKE_BUILD_TYPE=Debug -D DEAL_II_WITH_64BIT_INDICES=ON -D DEAL_II_CXX_FLAGS='-Werror' -D DEAL_II_EARLY_DEPRECATIONS=ON -D DEAL_II_WITH_MPI=on .
+        mkdir build
+        cd build
+        cmake -D CMAKE_BUILD_TYPE=Debug \
+              -D DEAL_II_WITH_64BIT_INDICES=ON \
+              -D DEAL_II_CXX_FLAGS='-Werror' \
+              -D DEAL_II_EARLY_DEPRECATIONS=ON \
+              -D DEAL_II_WITH_MPI=ON \
+              ..
     - name: print detailed.log
-      run: cat detailed.log
+      run: cat build/detailed.log
     - name: build
       run: |
+        cd build
         make VERBOSE=1 -j2
         make -j2 \
           setup_tests_a-framework \

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -51,6 +51,9 @@ jobs:
       run: |
         cd build
         make VERBOSE=1 -j2
+    - name: test
+      run: |
+        cd build
         make -j2 \
           setup_tests_a-framework \
           setup_tests_quick_tests
@@ -106,6 +109,9 @@ jobs:
       run: |
         cd build
         make VERBOSE=1 -j2
+    - name: test
+      run: |
+        cd build
         make -j2 \
           setup_tests_a-framework \
           setup_tests_quick_tests

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -58,13 +58,6 @@ jobs:
           setup_tests_a-framework \
           setup_tests_quick_tests
         ctest --output-on-failure -j2 -VV
-    - name: upload CMakeConfigureLog
-      uses: actions/upload-artifact@v4
-      if: always()
-      continue-on-error: true
-      with:
-        name: osx-serial-CMakeConfigureLog.yaml
-        path: CMakeFiles/CMakeConfigureLog.yaml
 
   osx-parallel64:
     # MPI build using apple clang and 64 bit indices
@@ -116,11 +109,3 @@ jobs:
           setup_tests_a-framework \
           setup_tests_quick_tests
         ctest --output-on-failure -j2 -VV
-    - name: upload CMakeConfigureLog
-      uses: actions/upload-artifact@v4
-      if: always()
-      continue-on-error: true
-      with:
-        name: osx-parallel64-CMakeConfigureLog.yaml
-        path: CMakeFiles/CMakeConfigureLog.yaml
-

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -10,7 +10,7 @@ on:
     - ready_for_review
 
 concurrency:
-  group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
 permissions:

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -10,7 +10,7 @@ on:
     - ready_for_review
 
 concurrency:
-  group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
 jobs:

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
+permissions:
+  contents: read
+
 jobs:
   tidy:
     name: tidy

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,7 +10,7 @@ on:
     - ready_for_review
 
 concurrency:
-  group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
 permissions:


### PR DESCRIPTION
- Removed a stage in `linux-debug-parallel-tpetra` that did nothing.
- `linux-debug-cuda-11-clang` archived detailed.log, whereas we only print it in all other workflows.
- Use separate build directory for `osx`.
- Use separate stage for testing in `osx`.
- Don't specify mpi wrappers in `osx-parallel64`. cmake should find them itself with `mpi=on`.
- Restrict permissions of the `tidy` worker.