### PR TITLE
Simplify string handling.

### DIFF
--- a/include/deal.II/base/hdf5.h
+++ b/include/deal.II/base/hdf5.h
@@ -61,7 +61,7 @@ DEAL_II_NAMESPACE_OPEN
  * double double_attribute = 2.2;
  * data_file.set_attribute("double_attribute", double_attribute);
  * auto group = data_file.create_group("group");
- * group.set_attribute("simulation_type", std::string("elastic_equation"));
+ * group.set_attribute("simulation_type", "elastic_equation");
  * auto dataset = group.create_dataset<double>("dataset_name", dimensions);
  * dataset.set_attribute("complex_double_attribute",
  *                       std::complex<double>(2,2.3));

--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -805,7 +805,7 @@ namespace Patterns
 
     /**
      * Constructor. This is needed to allow users to specify
-     * directly the separator without using std::string(";").
+     * directly the separator without using ";".
      *
      * Since we support a pure variadic templates version, without this
      * specialization, the compiler will fail with cryptic errors.
@@ -1441,7 +1441,7 @@ namespace Patterns
   template <class... PatternTypes>
   Tuple::Tuple(const PatternTypes &...ps)
     : // forward to the version with the separator argument
-    Tuple(std::string(":"), ps...)
+    Tuple(":", ps...)
   {}
 
 

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -2308,7 +2308,7 @@ namespace FETools
             // Now, just the [...]
             // part should be left.
             if (name.empty() || name[0] != '[')
-              throw std::string("Invalid first character in ") + name;
+              throw "Invalid first character in " + name;
             do
               {
                 // Erase the
@@ -2362,7 +2362,7 @@ namespace FETools
             // we actually had a ']'
             // there
             if (name.empty() || name[0] != ']')
-              throw std::string("Invalid first character in ") + name;
+              throw "Invalid first character in " + name;
             name.erase(0, 1);
             // just one more sanity check
             Assert((base_fes.size() == base_multiplicities.size()) &&
@@ -2411,7 +2411,7 @@ namespace FETools
             // Now, just the (degree) or (Quadrature<1>(degree+1)) part should
             // be left.
             if (name.empty() || name[0] != '(')
-              throw std::string("Invalid first character in ") + name;
+              throw "Invalid first character in " + name;
             name.erase(0, 1);
             if (name[0] != 'Q')
               {
@@ -2590,9 +2590,7 @@ namespace FETools
       }
     catch (const std::string &errline)
       {
-        AssertThrow(false,
-                    ExcInvalidFEName(parameter_name + std::string(" at ") +
-                                     errline));
+        AssertThrow(false, ExcInvalidFEName(parameter_name + " at " + errline));
         return nullptr;
       }
   }

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -556,7 +556,7 @@ namespace LinearAlgebra
           communication_pattern);
         AssertThrow(tpetra_comm_pattern != nullptr,
                     ExcMessage(
-                      std::string("The communication pattern is not of type ") +
+                      "The communication pattern is not of type "
                       "LinearAlgebra::TpetraWrappers::CommunicationPattern."));
       }
 
@@ -686,7 +686,7 @@ namespace LinearAlgebra
             communication_pattern);
         AssertThrow(epetra_comm_pattern != nullptr,
                     ExcMessage(
-                      std::string("The communication pattern is not of type ") +
+                      "The communication pattern is not of type "
                       "LinearAlgebra::EpetraWrappers::CommunicationPattern."));
       }
 

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -528,9 +528,8 @@ namespace LinearAlgebra
 
           AssertThrow(
             !tpetra_comm_pattern.is_null(),
-            ExcMessage(
-              std::string("The communication pattern is not of type ") +
-              "LinearAlgebra::TpetraWrappers::CommunicationPattern."));
+            ExcMessage("The communication pattern is not of type "
+                       "LinearAlgebra::TpetraWrappers::CommunicationPattern."));
         }
 
       Teuchos::RCP<const TpetraTypes::ExportType<MemorySpace>> tpetra_export =

--- a/include/deal.II/numerics/dof_output_operator.h
+++ b/include/deal.II/numerics/dof_output_operator.h
@@ -53,7 +53,7 @@ namespace Algorithms
      * last step command. Numbers with less digits are filled with
      * zeros from the left.
      */
-    DoFOutputOperator(const std::string &filename_base = std::string("output"),
+    DoFOutputOperator(const std::string &filename_base = "output",
                       const unsigned int digits        = 3);
 
     void

--- a/source/base/convergence_table.cc
+++ b/source/base/convergence_table.cc
@@ -69,7 +69,7 @@ ConvergenceTable::evaluate_convergence_rates(
             if (i == 0)
               {
                 // no value available for the first row
-                add_value(rate_key, std::string("-"));
+                add_value(rate_key, "-");
               }
             else
               {
@@ -88,7 +88,7 @@ ConvergenceTable::evaluate_convergence_rates(
             if (i == 0)
               {
                 // no value available for the first row
-                add_value(rate_key, std::string("-"));
+                add_value(rate_key, "-");
               }
             else
               {
@@ -159,7 +159,7 @@ ConvergenceTable::evaluate_convergence_rates(const std::string &data_column_key,
             if (i == 0)
               {
                 // no value available for the first row
-                add_value(rate_key, std::string("-"));
+                add_value(rate_key, "-");
               }
             else
               {
@@ -177,7 +177,7 @@ ConvergenceTable::evaluate_convergence_rates(const std::string &data_column_key,
             if (i == 0)
               {
                 // no value available for the first row
-                add_value(rate_key, std::string("-"));
+                add_value(rate_key, "-");
               }
             else
               {

--- a/source/base/enable_observer_pointer.cc
+++ b/source/base/enable_observer_pointer.cc
@@ -80,8 +80,8 @@ EnableObserverPointer::check_no_subscribers() const noexcept
           for (const auto &map_entry : counter_map)
             {
               if (map_entry.second > 0)
-                infostring += std::string("\n  from Subscriber ") +
-                              std::string(map_entry.first);
+                infostring +=
+                  "\n  from Subscriber " + std::string(map_entry.first);
             }
 
           if (infostring.empty())

--- a/source/base/hdf5.cc
+++ b/source/base/hdf5.cc
@@ -212,28 +212,28 @@ namespace HDF5
     switch (io_mode)
       {
         case (H5D_MPIO_NO_COLLECTIVE):
-          return std::string("H5D_MPIO_NO_COLLECTIVE");
+          return "H5D_MPIO_NO_COLLECTIVE";
           break;
         case (H5D_MPIO_CHUNK_INDEPENDENT):
-          return std::string("H5D_MPIO_CHUNK_INDEPENDENT");
+          return "H5D_MPIO_CHUNK_INDEPENDENT";
           break;
         case (H5D_MPIO_CHUNK_COLLECTIVE):
-          return std::string("H5D_MPIO_CHUNK_COLLECTIVE");
+          return "H5D_MPIO_CHUNK_COLLECTIVE";
           break;
         case (H5D_MPIO_CHUNK_MIXED):
-          return std::string("H5D_MPIO_CHUNK_MIXED");
+          return "H5D_MPIO_CHUNK_MIXED";
           break;
         case (H5D_MPIO_CONTIGUOUS_COLLECTIVE):
-          return std::string("H5D_MPIO_CONTIGUOUS_COLLECTIVE");
+          return "H5D_MPIO_CONTIGUOUS_COLLECTIVE";
           break;
         default:
           DEAL_II_ASSERT_UNREACHABLE();
-          return std::string("Internal error");
+          return "Internal error";
           break;
       }
     // The function should not reach this line.
     DEAL_II_ASSERT_UNREACHABLE();
-    return std::string("Internal error");
+    return "Internal error";
   }
 
 

--- a/source/base/job_identifier.cc
+++ b/source/base/job_identifier.cc
@@ -35,14 +35,14 @@ JobIdentifier::get_dealjobid()
 JobIdentifier::JobIdentifier()
 {
   time_t t = std::time(nullptr);
-  id       = std::string("JobId ");
+  id       = "JobId ";
 
 #if defined(DEAL_II_HAVE_UNISTD_H) && defined(DEAL_II_HAVE_GETHOSTNAME)
   char name[100];
   gethostname(name, 99);
-  id += std::string(name) + std::string(" ");
+  id += std::string(name) + " ";
 #else
-  id += std::string("unknown ");
+  id += "unknown ";
 #endif
 
   id += std::string(std::ctime(&t));

--- a/source/base/logstream.cc
+++ b/source/base/logstream.cc
@@ -306,7 +306,7 @@ LogStream::push(const std::string &text)
     pre = get_prefixes().top();
 
   pre += text;
-  pre += std::string(":");
+  pre += ":";
   get_prefixes().push(pre);
 }
 

--- a/source/base/parsed_convergence_table.cc
+++ b/source/base/parsed_convergence_table.cc
@@ -248,9 +248,8 @@ ParsedConvergenceTable::output_table()
       else
         {
           AssertThrow(false,
-                      ExcInternalError(
-                        std::string("Unrecognized file format: ") +
-                        error_file_format));
+                      ExcInternalError("Unrecognized file format: " +
+                                       error_file_format));
         }
       table_file.close();
     }

--- a/source/base/path_search.cc
+++ b/source/base/path_search.cc
@@ -33,17 +33,17 @@ PathSearch::initialize_classes()
 {
   std::vector<std::string> v;
   v.emplace_back();
-  path_lists.insert(map_type(std::string("PARAMETER"), v));
+  path_lists.insert(map_type("PARAMETER", v));
 
   /*
    * TODO: re-enable some sensible default paths. Maier, 2012
    */
-  path_lists.insert(map_type(std::string("MESH"), v));
+  path_lists.insert(map_type("MESH", v));
 
   v.clear();
   v.emplace_back();
   v.emplace_back(".prm");
-  suffix_lists.insert(map_type(std::string("PARAMETER"), v));
+  suffix_lists.insert(map_type("PARAMETER", v));
 
   /*
    * TODO: "Would require linking with the deal.II libraries"? This .cc
@@ -62,7 +62,7 @@ PathSearch::initialize_classes()
   v.emplace_back(".plt");
   v.emplace_back(".nc");
   v.emplace_back(".msh");
-  suffix_lists.insert(map_type(std::string("MESH"), v));
+  suffix_lists.insert(map_type("MESH", v));
 }
 
 std::vector<std::string> &
@@ -163,7 +163,7 @@ PathSearch::find(const std::string &filename,
         }
     }
   AssertThrow(false, ExcFileNotFound(filename, cls));
-  return std::string("");
+  return "";
 }
 
 std::string
@@ -189,7 +189,7 @@ PathSearch::find(const std::string &filename, const char *open_mode)
         }
     }
   AssertThrow(false, ExcFileNotFound(filename, cls));
-  return std::string("");
+  return "";
 }
 
 

--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -402,8 +402,8 @@ TimerOutput::enter_subsection(const std::string &section_name)
   Assert(std::find(active_sections.begin(),
                    active_sections.end(),
                    section_name) == active_sections.end(),
-         ExcMessage(std::string("Cannot enter the already active section <") +
-                    section_name + ">."));
+         ExcMessage("Cannot enter the already active section <" + section_name +
+                    ">."));
 
   if (sections.find(section_name) == sections.end())
     {

--- a/source/differentiation/sd/symengine_tensor_operations.cc
+++ b/source/differentiation/sd/symengine_tensor_operations.cc
@@ -65,8 +65,8 @@ namespace Differentiation
               {
                 const TableIndices<rank> indices(
                   out.unrolled_to_component_indices(i));
-                out[indices] = Expression(sym + std::string("_") +
-                                          internal::make_index_string(indices));
+                out[indices] =
+                  Expression(sym + "_" + internal::make_index_string(indices));
               }
             return out;
           }
@@ -99,8 +99,8 @@ namespace Differentiation
               {
                 const TableIndices<rank> indices(
                   out.unrolled_to_component_indices(i));
-                out[indices] = Expression(sym + std::string("_") +
-                                          internal::make_index_string(indices));
+                out[indices] =
+                  Expression(sym + "_" + internal::make_index_string(indices));
               }
             return out;
           }
@@ -123,9 +123,8 @@ namespace Differentiation
                 {
                   const TableIndices<4> indices =
                     make_rank_4_tensor_indices<dim>(i, j);
-                  out[indices] =
-                    Expression(sym + std::string("_") +
-                               internal::make_index_string(indices));
+                  out[indices] = Expression(
+                    sym + "_" + internal::make_index_string(indices));
                 }
             return out;
           }
@@ -151,8 +150,7 @@ namespace Differentiation
                 const TableIndices<rank> indices(
                   out.unrolled_to_component_indices(i));
                 out[indices] =
-                  Expression(sym + std::string("_") +
-                               internal::make_index_string(indices),
+                  Expression(sym + "_" + internal::make_index_string(indices),
                              args);
               }
             return out;
@@ -191,8 +189,7 @@ namespace Differentiation
                 const TableIndices<rank> indices(
                   out.unrolled_to_component_indices(i));
                 out[indices] =
-                  Expression(sym + std::string("_") +
-                               internal::make_index_string(indices),
+                  Expression(sym + "_" + internal::make_index_string(indices),
                              args);
               }
             return out;
@@ -220,8 +217,7 @@ namespace Differentiation
                   const TableIndices<4> indices =
                     make_rank_4_tensor_indices<dim>(i, j);
                   out[indices] =
-                    Expression(sym + std::string("_") +
-                                 internal::make_index_string(indices),
+                    Expression(sym + "_" + internal::make_index_string(indices),
                                args);
                 }
             return out;

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -230,9 +230,9 @@ namespace GridOutFlags
   void
   EpsFlagsBase::parse_parameters(ParameterHandler &param)
   {
-    if (param.get("Size by") == std::string("width"))
+    if (param.get("Size by") == "width")
       size_type = width;
-    else if (param.get("Size by") == std::string("height"))
+    else if (param.get("Size by") == "height")
       size_type = height;
     size                     = param.get_integer("Size");
     line_width               = param.get_double("Line width");

--- a/source/lac/trilinos_epetra_vector.cc
+++ b/source/lac/trilinos_epetra_vector.cc
@@ -224,9 +224,8 @@ namespace LinearAlgebra
               communication_pattern);
           AssertThrow(
             epetra_comm_pattern != nullptr,
-            ExcMessage(
-              std::string("The communication pattern is not of type ") +
-              "LinearAlgebra::EpetraWrappers::CommunicationPattern."));
+            ExcMessage("The communication pattern is not of type "
+                       "LinearAlgebra::EpetraWrappers::CommunicationPattern."));
         }
 
       Epetra_Import import_map(epetra_comm_pattern->get_epetra_import());

--- a/source/lac/trilinos_solver.cc
+++ b/source/lac/trilinos_solver.cc
@@ -684,7 +684,7 @@ namespace TrilinosWrappers
 
     AssertThrow(Factory.Query(additional_data.solver_type.c_str()),
                 ExcMessage(
-                  std::string("You tried to select the solver type <") +
+                  "You tried to select the solver type <" +
                   additional_data.solver_type +
                   "> but this solver is not supported by Trilinos either "
                   "because it does not exist, or because Trilinos was not "
@@ -811,7 +811,7 @@ namespace TrilinosWrappers
 
     AssertThrow(Factory.Query(additional_data.solver_type.c_str()),
                 ExcMessage(
-                  std::string("You tried to select the solver type <") +
+                  "You tried to select the solver type <" +
                   additional_data.solver_type +
                   "> but this solver is not supported by Trilinos either "
                   "because it does not exist, or because Trilinos was not "


### PR DESCRIPTION
I was playing around with how `"..."s` strings work. It turns out that this is really awkward because in order to use `operator ""s`, you have to add `using namespace std::string_literals` which I think we don't want to do. So I discarded the idea, but there are still plenty of places where we don't have to *explicitly* construct `std::string` objects.