### PR TITLE
Simplify string handling in examples/.

### DIFF
--- a/examples/step-13/step-13.cc
+++ b/examples/step-13/step-13.cc
@@ -1376,8 +1376,7 @@ namespace Step13
                                                          results_table);
 
     // Also generate an evaluator which writes out the solution:
-    Evaluation::SolutionOutput<dim> postprocessor2(std::string("solution-") +
-                                                     solver_name,
+    Evaluation::SolutionOutput<dim> postprocessor2("solution-" + solver_name,
                                                    DataOutBase::gnuplot);
 
     // Take these two evaluation objects and put them in a list...

--- a/examples/step-28/step-28.cc
+++ b/examples/step-28/step-28.cc
@@ -1104,7 +1104,7 @@ namespace Step28
   template <int dim>
   void EnergyGroup<dim>::output_results(const unsigned int cycle) const
   {
-    const std::string filename = std::string("solution-") +
+    const std::string filename = "solution-" +
                                  Utilities::int_to_string(group, 2) + "." +
                                  Utilities::int_to_string(cycle, 2) + ".vtu";
 

--- a/examples/step-35/step-35.cc
+++ b/examples/step-35/step-35.cc
@@ -238,7 +238,7 @@ namespace Step35
 
       prm.parse_input(file);
 
-      if (prm.get("Method_Form") == std::string("rotational"))
+      if (prm.get("Method_Form") == "rotational")
         form = Method::rotational;
       else
         form = Method::standard;

--- a/examples/step-36/step-36.cc
+++ b/examples/step-36/step-36.cc
@@ -404,8 +404,7 @@ namespace Step36
 
     for (unsigned int i = 0; i < eigenfunctions.size(); ++i)
       data_out.add_data_vector(eigenfunctions[i],
-                               std::string("eigenfunction_") +
-                                 Utilities::int_to_string(i));
+                               "eigenfunction_" + Utilities::int_to_string(i));
 
     // The only thing worth discussing may be that because the potential is
     // specified as a function expression in the input file, it would be nice

--- a/examples/step-42/step-42.cc
+++ b/examples/step-42/step-42.cc
@@ -447,9 +447,7 @@ namespace Step42
       , ny(0)
     {
       std::ifstream f(name);
-      AssertThrow(f,
-                  ExcMessage(std::string("Can't read from file <") + name +
-                             ">!"));
+      AssertThrow(f, ExcMessage("Can't read from file <" + name + ">!"));
 
       std::string temp;
       f >> temp >> nx >> ny;

--- a/examples/step-62/step-62.cc
+++ b/examples/step-62/step-62.cc
@@ -1461,12 +1461,12 @@ int main(int argc, char *argv[])
               group.get_attribute<double>("frequency_range") / 2);
           group.set_attribute<unsigned int>("nb_frequency_points", 400);
 
-          if (group_name == std::string("displacement"))
-            group.set_attribute<std::string>(
-              "simulation_name", std::string("phononic_cavity_displacement"));
+          if (group_name == "displacement")
+            group.set_attribute<std::string>("simulation_name",
+                                             "phononic_cavity_displacement");
           else
-            group.set_attribute<std::string>(
-              "simulation_name", std::string("phononic_cavity_calibration"));
+            group.set_attribute<std::string>("simulation_name",
+                                             "phononic_cavity_calibration");
 
           group.set_attribute<bool>("save_vtu_files", false);
         }

--- a/examples/step-71/step-71.cc
+++ b/examples/step-71/step-71.cc
@@ -334,11 +334,11 @@ namespace Step71
       // like the author, you'll be doing the opposite and will rather verify
       // that your implementation of the analytical solution is correct!)
       AssertThrow(std::abs(f(x, y) - computed_f) < tol,
-                  ExcMessage(std::string("Incorrect value computed for f. ") +
-                             std::string("Hand-calculated value: ") +
+                  ExcMessage("Incorrect value computed for f. "
+                             "Hand-calculated value: " +
                              Utilities::to_string(f(x, y)) +
-                             std::string(" ; ") +
-                             std::string("Value computed by AD: ") +
+                             " ; "
+                             "Value computed by AD: " +
                              Utilities::to_string(computed_f)));
 
       // Because we know the ordering of the independent variables, we know
@@ -347,19 +347,19 @@ namespace Step71
       const double computed_df_dy = Df[1];
 
       AssertThrow(std::abs(df_dx(x, y) - computed_df_dx) < tol,
-                  ExcMessage(
-                    std::string("Incorrect value computed for df/dx. ") +
-                    std::string("Hand-calculated value: ") +
-                    Utilities::to_string(df_dx(x, y)) + std::string(" ; ") +
-                    std::string("Value computed by AD: ") +
-                    Utilities::to_string(computed_df_dx)));
+                  ExcMessage("Incorrect value computed for df/dx. "
+                             "Hand-calculated value: " +
+                             Utilities::to_string(df_dx(x, y)) +
+                             " ; "
+                             "Value computed by AD: " +
+                             Utilities::to_string(computed_df_dx)));
       AssertThrow(std::abs(df_dy(x, y) - computed_df_dy) < tol,
-                  ExcMessage(
-                    std::string("Incorrect value computed for df/dy. ") +
-                    std::string("Hand-calculated value: ") +
-                    Utilities::to_string(df_dy(x, y)) + std::string(" ; ") +
-                    std::string("Value computed by AD: ") +
-                    Utilities::to_string(computed_df_dy)));
+                  ExcMessage("Incorrect value computed for df/dy. "
+                             "Hand-calculated value: " +
+                             Utilities::to_string(df_dy(x, y)) +
+                             " ; "
+                             "Value computed by AD: " +
+                             Utilities::to_string(computed_df_dy)));
 
       // ... and similar for the Hessian.
       const double computed_d2f_dx_dx = D2f[0][0];
@@ -368,33 +368,33 @@ namespace Step71
       const double computed_d2f_dy_dy = D2f[1][1];
 
       AssertThrow(std::abs(d2f_dx_dx(x, y) - computed_d2f_dx_dx) < tol,
-                  ExcMessage(
-                    std::string("Incorrect value computed for d2f/dx_dx. ") +
-                    std::string("Hand-calculated value: ") +
-                    Utilities::to_string(d2f_dx_dx(x, y)) + std::string(" ; ") +
-                    std::string("Value computed by AD: ") +
-                    Utilities::to_string(computed_d2f_dx_dx)));
+                  ExcMessage("Incorrect value computed for d2f/dx_dx. "
+                             "Hand-calculated value: " +
+                             Utilities::to_string(d2f_dx_dx(x, y)) +
+                             " ; "
+                             "Value computed by AD: " +
+                             Utilities::to_string(computed_d2f_dx_dx)));
       AssertThrow(std::abs(d2f_dx_dy(x, y) - computed_d2f_dx_dy) < tol,
-                  ExcMessage(
-                    std::string("Incorrect value computed for d2f/dx_dy. ") +
-                    std::string("Hand-calculated value: ") +
-                    Utilities::to_string(d2f_dx_dy(x, y)) + std::string(" ; ") +
-                    std::string("Value computed by AD: ") +
-                    Utilities::to_string(computed_d2f_dx_dy)));
+                  ExcMessage("Incorrect value computed for d2f/dx_dy. "
+                             "Hand-calculated value: " +
+                             Utilities::to_string(d2f_dx_dy(x, y)) +
+                             " ; "
+                             "Value computed by AD: " +
+                             Utilities::to_string(computed_d2f_dx_dy)));
       AssertThrow(std::abs(d2f_dy_dx(x, y) - computed_d2f_dy_dx) < tol,
-                  ExcMessage(
-                    std::string("Incorrect value computed for d2f/dy_dx. ") +
-                    std::string("Hand-calculated value: ") +
-                    Utilities::to_string(d2f_dy_dx(x, y)) + std::string(" ; ") +
-                    std::string("Value computed by AD: ") +
-                    Utilities::to_string(computed_d2f_dy_dx)));
+                  ExcMessage("Incorrect value computed for d2f/dy_dx. "
+                             "Hand-calculated value: " +
+                             Utilities::to_string(d2f_dy_dx(x, y)) +
+                             " ; "
+                             "Value computed by AD: " +
+                             Utilities::to_string(computed_d2f_dy_dx)));
       AssertThrow(std::abs(d2f_dy_dy(x, y) - computed_d2f_dy_dy) < tol,
-                  ExcMessage(
-                    std::string("Incorrect value computed for d2f/dy_dy. ") +
-                    std::string("Hand-calculated value: ") +
-                    Utilities::to_string(d2f_dy_dy(x, y)) + std::string(" ; ") +
-                    std::string("Value computed by AD: ") +
-                    Utilities::to_string(computed_d2f_dy_dy)));
+                  ExcMessage("Incorrect value computed for d2f/dy_dy. "
+                             "Hand-calculated value: " +
+                             Utilities::to_string(d2f_dy_dy(x, y)) +
+                             " ; "
+                             "Value computed by AD: " +
+                             Utilities::to_string(computed_d2f_dy_dy)));
     }
 
     // That's pretty great. There wasn't too much work involved in computing
@@ -650,11 +650,11 @@ namespace Step71
         f_sd.substitute_and_evaluate<double>(substitution_map);
 
       AssertThrow(std::abs(f(x, y) - computed_f) < tol,
-                  ExcMessage(std::string("Incorrect value computed for f. ") +
-                             std::string("Hand-calculated value: ") +
+                  ExcMessage("Incorrect value computed for f. "
+                             "Hand-calculated value: " +
                              Utilities::to_string(f(x, y)) +
-                             std::string(" ; ") +
-                             std::string("Value computed by AD: ") +
+                             " ; "
+                             "Value computed by AD: " +
                              Utilities::to_string(computed_f)));
 
       // We can do the same for the first derivatives...
@@ -664,19 +664,19 @@ namespace Step71
         df_dy_sd.substitute_and_evaluate<double>(substitution_map);
 
       AssertThrow(std::abs(df_dx(x, y) - computed_df_dx) < tol,
-                  ExcMessage(
-                    std::string("Incorrect value computed for df/dx. ") +
-                    std::string("Hand-calculated value: ") +
-                    Utilities::to_string(df_dx(x, y)) + std::string(" ; ") +
-                    std::string("Value computed by AD: ") +
-                    Utilities::to_string(computed_df_dx)));
+                  ExcMessage("Incorrect value computed for df/dx. "
+                             "Hand-calculated value: " +
+                             Utilities::to_string(df_dx(x, y)) +
+                             " ; "
+                             "Value computed by AD: " +
+                             Utilities::to_string(computed_df_dx)));
       AssertThrow(std::abs(df_dy(x, y) - computed_df_dy) < tol,
-                  ExcMessage(
-                    std::string("Incorrect value computed for df/dy. ") +
-                    std::string("Hand-calculated value: ") +
-                    Utilities::to_string(df_dy(x, y)) + std::string(" ; ") +
-                    std::string("Value computed by AD: ") +
-                    Utilities::to_string(computed_df_dy)));
+                  ExcMessage("Incorrect value computed for df/dy. "
+                             "Hand-calculated value: " +
+                             Utilities::to_string(df_dy(x, y)) +
+                             " ; "
+                             "Value computed by AD: " +
+                             Utilities::to_string(computed_df_dy)));
 
       // ... and the second derivatives.
       // Notice that we can reuse the same substitution map for each of these
@@ -696,33 +696,33 @@ namespace Step71
         d2f_dy_dy_sd.substitute_and_evaluate<double>(substitution_map);
 
       AssertThrow(std::abs(d2f_dx_dx(x, y) - computed_d2f_dx_dx) < tol,
-                  ExcMessage(
-                    std::string("Incorrect value computed for d2f/dx_dx. ") +
-                    std::string("Hand-calculated value: ") +
-                    Utilities::to_string(d2f_dx_dx(x, y)) + std::string(" ; ") +
-                    std::string("Value computed by SD: ") +
-                    Utilities::to_string(computed_d2f_dx_dx)));
+                  ExcMessage("Incorrect value computed for d2f/dx_dx. "
+                             "Hand-calculated value: " +
+                             Utilities::to_string(d2f_dx_dx(x, y)) +
+                             " ; "
+                             "Value computed by SD: " +
+                             Utilities::to_string(computed_d2f_dx_dx)));
       AssertThrow(std::abs(d2f_dx_dy(x, y) - computed_d2f_dx_dy) < tol,
-                  ExcMessage(
-                    std::string("Incorrect value computed for d2f/dx_dy. ") +
-                    std::string("Hand-calculated value: ") +
-                    Utilities::to_string(d2f_dx_dy(x, y)) + std::string(" ; ") +
-                    std::string("Value computed by SD: ") +
-                    Utilities::to_string(computed_d2f_dx_dy)));
+                  ExcMessage("Incorrect value computed for d2f/dx_dy. "
+                             "Hand-calculated value: " +
+                             Utilities::to_string(d2f_dx_dy(x, y)) +
+                             " ; "
+                             "Value computed by SD: " +
+                             Utilities::to_string(computed_d2f_dx_dy)));
       AssertThrow(std::abs(d2f_dy_dx(x, y) - computed_d2f_dy_dx) < tol,
-                  ExcMessage(
-                    std::string("Incorrect value computed for d2f/dy_dx. ") +
-                    std::string("Hand-calculated value: ") +
-                    Utilities::to_string(d2f_dy_dx(x, y)) + std::string(" ; ") +
-                    std::string("Value computed by SD: ") +
-                    Utilities::to_string(computed_d2f_dy_dx)));
+                  ExcMessage("Incorrect value computed for d2f/dy_dx. "
+                             "Hand-calculated value: " +
+                             Utilities::to_string(d2f_dy_dx(x, y)) +
+                             " ; "
+                             "Value computed by SD: " +
+                             Utilities::to_string(computed_d2f_dy_dx)));
       AssertThrow(std::abs(d2f_dy_dy(x, y) - computed_d2f_dy_dy) < tol,
-                  ExcMessage(
-                    std::string("Incorrect value computed for d2f/dy_dy. ") +
-                    std::string("Hand-calculated value: ") +
-                    Utilities::to_string(d2f_dy_dy(x, y)) + std::string(" ; ") +
-                    std::string("Value computed by SD: ") +
-                    Utilities::to_string(computed_d2f_dy_dy)));
+                  ExcMessage("Incorrect value computed for d2f/dy_dy. "
+                             "Hand-calculated value: " +
+                             Utilities::to_string(d2f_dy_dy(x, y)) +
+                             " ; "
+                             "Value computed by SD: " +
+                             Utilities::to_string(computed_d2f_dy_dy)));
     }
 
 


### PR DESCRIPTION
Companion to #17802, but for `examples/`. We no longer seem to compile the tutorials by default, so I haven't checked whether this actually works, whereas I'm pretty confident about #17802. Let's see.