### PR TITLE
Call find_package(Kokkos) if PETSc is compiled with Kokkos support

### DIFF
--- a/cmake/modules/FindDEAL_II_PETSC.cmake
+++ b/cmake/modules/FindDEAL_II_PETSC.cmake
@@ -201,8 +201,11 @@ if(NOT PETSC_PETSCVARIABLES MATCHES "-NOTFOUND")
       REGEX "^KOKKOS_INCLUDE =.*")
     string(REGEX REPLACE "^KOKKOS_INCLUDE = -I" "" KOKKOS_INCLUDE "${KOKKOS_INCLUDE}")
     find_package(Kokkos 3.7.0 QUIET
-      HINTS ${KOKKOS_INCLUDE}/..
+      PATHS ${KOKKOS_INCLUDE}/.. NO_DEFAULT_PATH
       )
+    if(NOT Kokkos_FOUND)
+      set(PETSC_FOUND FALSE)
+    endif()
   endif()
 endif()
 

--- a/cmake/modules/FindDEAL_II_PETSC.cmake
+++ b/cmake/modules/FindDEAL_II_PETSC.cmake
@@ -193,6 +193,17 @@ if(NOT PETSC_PETSCVARIABLES MATCHES "-NOTFOUND")
 
     endif()
   endforeach()
+
+  # PETSc does not expose Kokkos version, so we need to search for Kokkos
+  # ourselves.
+  if(PETSC_WITH_KOKKOS)
+    file(STRINGS "${PETSC_PETSCVARIABLES}" KOKKOS_INCLUDE
+      REGEX "^KOKKOS_INCLUDE =.*")
+    string(REGEX REPLACE "^KOKKOS_INCLUDE = -I" "" KOKKOS_INCLUDE "${KOKKOS_INCLUDE}")
+    find_package(Kokkos 3.7.0 QUIET
+      HINTS ${KOKKOS_INCLUDE}/..
+      )
+  endif()
 endif()
 
 if(PETSC_WITH_MPIUNI)


### PR DESCRIPTION
If you look at the detailed.log [here](https://cdash.dealii.org/build/3976/notes#note2), you can see that `KOKKOS_VERSION`, `KOKKOS_BACKENDS`, and `KOKKOS_ARCHITECTURES` are empty. This is because when PETSc is configured with Kokkos, we use PETSc's flags but PETSc does not export Kokkos' configuration. Here I call `find_package(Kokkos)` to populate Kokkos' variables.