### PR TITLE
Skip an assert for posix_memalign if size==0.

### DIFF
--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -1047,7 +1047,8 @@ namespace Utilities
       const int ierr = ::posix_memalign(memptr, alignment, size);
 
       AssertThrow(ierr == 0, ExcOutOfMemory(size));
-      AssertThrow(*memptr != nullptr, ExcOutOfMemory(size));
+      if (size > 0)
+        AssertThrow(*memptr != nullptr, ExcOutOfMemory(size));
 #else
       // Windows does not appear to have posix_memalign. just use the
       // regular malloc in that case


### PR DESCRIPTION
POSIX says that the returned pointer can be a nullptr if the size requested is zero. So skip the assertion if size==0.

Specifically, the specs are here: https://pubs.opengroup.org/onlinepubs/9799919799/functions/posix_memalign.html It says "If the size of the space requested is 0, the behavior is implementation-defined: either a null pointer shall be returned in memptr, or the behavior shall be as if the size were some non-zero value, except that the behavior is undefined if the the value returned in memptr is used to access an object." I was told that AIX actually returns a `nullptr` and triggers the assert we currently have.