### PR TITLE
github-actions: use all available processors for building and testing.

### DIFF
--- a/.github/workflows/indent.yml
+++ b/.github/workflows/indent.yml
@@ -9,6 +9,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  MAKEFLAGS: "--jobs=4"
+
 jobs:
   indent:
     # run the indent checks
@@ -45,7 +48,7 @@ jobs:
         mkdir build
         cd build
         cmake -DDEAL_II_COMPONENT_DOCUMENTATION=ON -DDEAL_II_DOXYGEN_USE_MATHJAX=ON ..
-        make -j 2 documentation
+        make documentation
     - name: check for doxygen errors and warnings
       run: |
         cd build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,6 +16,12 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  CMAKE_BUILD_PARALLEL_LEVEL: 4
+  CTEST_OUTPUT_ON_FAILURE: 1
+  CTEST_PARALLEL_LEVEL: 4
+  MAKEFLAGS: "--jobs=4"
+
 jobs:
 
   ########################
@@ -63,15 +69,15 @@ jobs:
     - name: build
       run: |
         cd build
-        make VERBOSE=1 -j2
+        make VERBOSE=1
     - name: test
       run: |
         cd build
-        make -j2 \
+        make \
           setup_tests_a-framework \
           setup_tests_examples \
           setup_tests_quick_tests
-        ctest --output-on-failure -j2 -VV
+        ctest -VV
 
   ########################
   # linux-debug-parallel #
@@ -122,7 +128,7 @@ jobs:
     - name: build
       run: |
         cd build
-        make VERBOSE=1 -j2
+        make VERBOSE=1
     - name: test
       run: |
         # Remove warning: "A high-performance Open MPI point-to-point
@@ -131,11 +137,11 @@ jobs:
         export OMPI_MCA_btl_base_warn_component_unused='0'
 
         cd build
-        make -j2 \
+        make \
           setup_tests_a-framework \
           setup_tests_examples \
           setup_tests_quick_tests
-        ctest --output-on-failure -j2 -VV
+        ctest -VV
 
   ###############################
   # linux-debug-parallel-tpetra #
@@ -183,7 +189,7 @@ jobs:
     - name: build
       run: |
         cd build
-        make VERBOSE=1 -j2
+        make VERBOSE=1
     - name: test trilinos_tpetra
       run: |
         # Remove warning: "A high-performance Open MPI point-to-point
@@ -192,8 +198,8 @@ jobs:
         export OMPI_MCA_btl_base_warn_component_unused='0'
 
         cd build
-        make -j2 setup_tests_trilinos_tpetra
-        ctest --output-on-failure -j2 -VV
+        make setup_tests_trilinos_tpetra
+        ctest -VV
 
   ############################
   # linux-debug-intel-oneapi #
@@ -254,16 +260,16 @@ jobs:
       run: |
         source /opt/intel/oneapi/setvars.sh
         cd build
-        make VERBOSE=1 -j2
+        make VERBOSE=1
     - name: test
       run: |
         source /opt/intel/oneapi/setvars.sh
         cd build
-        make -j2 \
+        make \
           setup_tests_a-framework \
           setup_tests_examples \
           setup_tests_quick_tests
-        ctest --output-on-failure -j2 -VV
+        ctest -VV
 
   #######################
   # linux-debug-cuda-11 #
@@ -370,13 +376,13 @@ jobs:
     - name: build deal.II
       run: |
         cd build
-        make VERBOSE=1 -j2
+        make VERBOSE=1
     - name: build CUDA tests
       run: |
         cd build
-        make -j2 setup_tests_matrix_free_kokkos
+        make setup_tests_matrix_free_kokkos
         cd tests/matrix_free_kokkos
-        make -j2 compile_test_executables
+        make compile_test_executables
 
   #############################
   # linux-debug-cuda-11-clang #
@@ -464,10 +470,10 @@ jobs:
     - name: build deal.II
       run: |
         cd build
-        make VERBOSE=1 -j 2
+        make VERBOSE=1
     - name: build CUDA tests
       run: |
         cd build
-        make -j2 setup_tests_matrix_free_kokkos
+        make setup_tests_matrix_free_kokkos
         cd tests/matrix_free_kokkos
-        make -j2 compile_test_executables
+        make compile_test_executables

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -16,6 +16,12 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  CMAKE_BUILD_PARALLEL_LEVEL: 3
+  CTEST_OUTPUT_ON_FAILURE: 1
+  CTEST_PARALLEL_LEVEL: 3
+  MAKEFLAGS: "--jobs=3"
+
 jobs:
   osx-serial:
     # simple serial build using apple clang
@@ -50,14 +56,14 @@ jobs:
     - name: build
       run: |
         cd build
-        make VERBOSE=1 -j2
+        make VERBOSE=1
     - name: test
       run: |
         cd build
-        make -j2 \
+        make \
           setup_tests_a-framework \
           setup_tests_quick_tests
-        ctest --output-on-failure -j2 -VV
+        ctest -VV
 
   osx-parallel64:
     # MPI build using apple clang and 64 bit indices
@@ -101,11 +107,11 @@ jobs:
     - name: build
       run: |
         cd build
-        make VERBOSE=1 -j2
+        make VERBOSE=1
     - name: test
       run: |
         cd build
-        make -j2 \
+        make \
           setup_tests_a-framework \
           setup_tests_quick_tests
-        ctest --output-on-failure -j2 -VV
+        ctest -VV

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,6 +16,12 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  CMAKE_BUILD_PARALLEL_LEVEL: 4
+  CTEST_OUTPUT_ON_FAILURE: 1
+  # test only in serial to avoid file locking error on ZERO_CHECK.lastbuildstate
+  CTEST_PARALLEL_LEVEL: 1
+
 jobs:
   windows-serial:
     # Serial build on Windows
@@ -54,12 +60,11 @@ jobs:
       run: type build/detailed.log
     - name: build
       run: |
-        cmake --build build --parallel 2 --target install
+        cmake --build build --target install
     - name: test
-      # test only in serial to avoid file locking error on ZERO_CHECK.lastbuildstate
       run: |
-        cmake --build build --parallel 2 --target setup_tests_a-framework setup_tests_examples setup_tests_quick_tests
-        ctest --test-dir build --build-config Debug --output-on-failure --extra-verbose
+        cmake --build build --target setup_tests_a-framework setup_tests_examples setup_tests_quick_tests
+        ctest --test-dir build --build-config Debug --extra-verbose
     - name: upload library
       # run only if a PR is merged into master
       if: ${{ github.ref == 'refs/heads/master' && matrix.os == 'windows-2022' }}


### PR DESCRIPTION
Instead of specifying the number of jobs on parallel builds and parallel testing manually, this PR suggests to store these values as workflow-wide environment variables.

This also makes maintenance easier, in case github decides to change the specs of their virtual machines.

We improve about 10-20 minutes on some of the runners with 4 processes compared to 2 processes we are using now.

Further reading:
- [Standard GitHub-hosted runners for public repositories](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)
- [CMAKE_BUILD_PARALLEL_LEVEL](https://cmake.org/cmake/help/latest/envvar/CMAKE_BUILD_PARALLEL_LEVEL.html)
- [CTEST_OUTPUT_ON_FAILURE](https://cmake.org/cmake/help/latest/envvar/CTEST_OUTPUT_ON_FAILURE.html)
- [CTEST_PARALLEL_LEVEL](https://cmake.org/cmake/help/latest/envvar/CTEST_PARALLEL_LEVEL.html)