### PR TITLE
Make sure the tutorial text doesn't run into the table of contents.

### DIFF
--- a/doc/doxygen/scripts/make_step.pl
+++ b/doc/doxygen/scripts/make_step.pl
@@ -70,6 +70,7 @@ print
 "  <li> <a href=\"#$step_underscore-PlainProg\" class=bold>The plain program</a>
 </ol> </td> </tr> </table>
 \@endhtmlonly
+
 ";
 
 system $^X, "$cmake_source_dir/doc/doxygen/scripts/create_anchors.pl", "$cmake_source_dir/examples/$step/doc/intro.dox" , "--prefix=$step_underscore";


### PR DESCRIPTION
If the main text of a tutorial does not start with a heading, it runs into the table of contents -- see for example here: https://dealii.org/developer/doxygen/deal.II/step_90.html

This is easily fixed. We just need a paragraph break (empty line) in the right place.