### PR TITLE
Make table of contents of tutorials wider.

### DIFF
--- a/doc/doxygen/scripts/make_step.pl
+++ b/doc/doxygen/scripts/make_step.pl
@@ -46,7 +46,7 @@ if ($buildson ne "")
 # then show the table of contents
 print
 "\@htmlonly
-<table class=\"tutorial\" width=\"50%\">
+<table class=\"tutorial\" width=\"75%\">
 <tr><th colspan=\"2\"><b><small>Table of contents</small></b></th></tr>
 <tr><td width=\"50%\" valign=\"top\">
 <ol>


### PR DESCRIPTION
With the new layout we introduced for doxygen output, text is shown narrower than before. The table of contents is shown in 50% width of the text, which with the narrower layout no longer looks good -- see for example https://dealii.org/developer/doxygen/deal.II/step_40.html where the right column is just too compressed, and in particular https://dealii.org/developer/doxygen/deal.II/step_72.html where the right column is just not visible at all.

This patch widens the table of contents to 75% of the text width.