### PR TITLE
Also exclude 'doc/entry-name' from showing up in code gallery programs.

### DIFF
--- a/doc/doxygen/code-gallery/CMakeLists.txt
+++ b/doc/doxygen/code-gallery/CMakeLists.txt
@@ -90,9 +90,10 @@ if (EXISTS ${DEAL_II_CODE_GALLERY_DIRECTORY}/README.md)
     string(REPLACE "${DEAL_II_CODE_GALLERY_DIRECTORY}/${_step}/" "" _relative_src_files
            "${_src_files}")
     list(REMOVE_ITEM _relative_src_files doc/author)
-    list(REMOVE_ITEM _relative_src_files doc/tooltip)
-    list(REMOVE_ITEM _relative_src_files doc/dependencies)
     list(REMOVE_ITEM _relative_src_files doc/builds-on)
+    list(REMOVE_ITEM _relative_src_files doc/dependencies)
+    list(REMOVE_ITEM _relative_src_files doc/entry-name)
+    list(REMOVE_ITEM _relative_src_files doc/tooltip)
 
 
     # Also remove files that were created by running 'cmake' in the


### PR DESCRIPTION
When we generate the code gallery pages, such as https://dealii.org/developer/doxygen/deal.II/code_gallery_advection_reaction_estimator.html , we list and cross link all input files. We exclude the metadata files, but we forgot to do so for the `doc/entry-name` file. This patch adds the exclusion and, while there, also sorts a file lines alphabetically.