### PR TITLE
SolverGMRES: Make loops in Arnoldi orthogonalization prefetcher-friendly 

### DIFF
--- a/doc/news/changes/minor/20241101Kronbichler-b
+++ b/doc/news/changes/minor/20241101Kronbichler-b
@@ -1,0 +1,6 @@
+Improved: The orthogonalization done within SolverGMRES and SolverFGMRES for
+the deal.II vectors would previously lead to data access pattern that are
+unfriendly to data prefetchers on modern CPUs. This has been addressed by
+implementing a suitable loop blocking.
+<br>
+(Martin Kronbichler, 2024/11/01)


### PR DESCRIPTION
The orthogonalization done within `SolverGMRES` and `SolverFGMRES` for the deal.II vectors would previously lead to data access pattern that are unfriendly to data prefetchers on modern CPUs. I observed this because the orthogonalization was slower with the classical Gram-Schmidt than with the modified Gram-Schmidt algorithm, whereas I had expected the opposite.

This can be addressed by implementing a suitable loop blocking, i.e., we do run try to switch between all vectors in the inner loop, but only up to a small number, and then perform an outer loop. There should be no change in functionality.