### PR TITLE
Adjust return type of eigenvectors(SymmetricTensor).

### DIFF
--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -3025,8 +3025,7 @@ enum struct SymmetricTensorEigenvectorMethod
  * @relatesalso SymmetricTensor
  */
 template <int dim, typename Number>
-std::array<std::pair<Number, Tensor<1, dim, Number>>,
-           std::integral_constant<int, dim>::value>
+std::array<std::pair<Number, Tensor<1, dim, Number>>, dim>
 eigenvectors(const SymmetricTensor<2, dim, Number> &T,
              const SymmetricTensorEigenvectorMethod method =
                SymmetricTensorEigenvectorMethod::ql_implicit_shifts);

--- a/include/deal.II/base/symmetric_tensor.templates.h
+++ b/include/deal.II/base/symmetric_tensor.templates.h
@@ -848,8 +848,7 @@ namespace internal
 
 
 template <int dim, typename Number>
-std::array<std::pair<Number, Tensor<1, dim, Number>>,
-           std::integral_constant<int, dim>::value>
+std::array<std::pair<Number, Tensor<1, dim, Number>>, dim>
 eigenvectors(const SymmetricTensor<2, dim, Number> &T,
              const SymmetricTensorEigenvectorMethod method)
 {
@@ -1055,18 +1054,18 @@ eigenvalues(const SymmetricTensor<2, 3, adouble> & /*T*/);
 
 template <>
 std::array<std::pair<adouble, Tensor<1, 1, adouble>>, 1>
-eigenvectors(const SymmetricTensor<2, 1, adouble> & /*T*/,
-             const SymmetricTensorEigenvectorMethod /*method*/);
+eigenvectors<1, adouble>(const SymmetricTensor<2, 1, adouble> & /*T*/,
+                         const SymmetricTensorEigenvectorMethod /*method*/);
 
 template <>
 std::array<std::pair<adouble, Tensor<1, 2, adouble>>, 2>
-eigenvectors(const SymmetricTensor<2, 2, adouble> & /*T*/,
-             const SymmetricTensorEigenvectorMethod /*method*/);
+eigenvectors<2, adouble>(const SymmetricTensor<2, 2, adouble> & /*T*/,
+                         const SymmetricTensorEigenvectorMethod /*method*/);
 
 template <>
 std::array<std::pair<adouble, Tensor<1, 3, adouble>>, 3>
-eigenvectors(const SymmetricTensor<2, 3, adouble> & /*T*/,
-             const SymmetricTensorEigenvectorMethod /*method*/);
+eigenvectors<3, adouble>(const SymmetricTensor<2, 3, adouble> & /*T*/,
+                         const SymmetricTensorEigenvectorMethod /*method*/);
 #endif
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/base/symmetric_tensor.cc
+++ b/source/base/symmetric_tensor.cc
@@ -83,8 +83,8 @@ eigenvalues(const SymmetricTensor<2, 3, adouble> & /*T*/)
 
 template <>
 std::array<std::pair<adouble, Tensor<1, 1, adouble>>, 1>
-eigenvectors(const SymmetricTensor<2, 1, adouble> & /*T*/,
-             const SymmetricTensorEigenvectorMethod /*method*/)
+eigenvectors<1, adouble>(const SymmetricTensor<2, 1, adouble> & /*T*/,
+                         const SymmetricTensorEigenvectorMethod /*method*/)
 {
   AssertThrow(false, ExcADOLCAdvancedBranching());
   return std::array<std::pair<adouble, Tensor<1, 1, adouble>>, 1>();
@@ -94,8 +94,8 @@ eigenvectors(const SymmetricTensor<2, 1, adouble> & /*T*/,
 
 template <>
 std::array<std::pair<adouble, Tensor<1, 2, adouble>>, 2>
-eigenvectors(const SymmetricTensor<2, 2, adouble> & /*T*/,
-             const SymmetricTensorEigenvectorMethod /*method*/)
+eigenvectors<2, adouble>(const SymmetricTensor<2, 2, adouble> & /*T*/,
+                         const SymmetricTensorEigenvectorMethod /*method*/)
 {
   AssertThrow(false, ExcADOLCAdvancedBranching());
   return std::array<std::pair<adouble, Tensor<1, 2, adouble>>, 2>();
@@ -105,8 +105,8 @@ eigenvectors(const SymmetricTensor<2, 2, adouble> & /*T*/,
 
 template <>
 std::array<std::pair<adouble, Tensor<1, 3, adouble>>, 3>
-eigenvectors(const SymmetricTensor<2, 3, adouble> & /*T*/,
-             const SymmetricTensorEigenvectorMethod /*method*/)
+eigenvectors<3, adouble>(const SymmetricTensor<2, 3, adouble> & /*T*/,
+                         const SymmetricTensorEigenvectorMethod /*method*/)
 {
   AssertThrow(false, ExcADOLCAdvancedBranching());
   return std::array<std::pair<adouble, Tensor<1, 3, adouble>>, 3>();
@@ -124,16 +124,16 @@ template std::array<adouble, 3>
 eigenvalues(const SymmetricTensor<2, 3, adouble> &);
 
 template std::array<std::pair<adouble, Tensor<1, 1, adouble>>, 1>
-eigenvectors(const SymmetricTensor<2, 1, adouble> &,
-             const SymmetricTensorEigenvectorMethod);
+eigenvectors<1, adouble>(const SymmetricTensor<2, 1, adouble> &,
+                         const SymmetricTensorEigenvectorMethod);
 
 template std::array<std::pair<adouble, Tensor<1, 2, adouble>>, 2>
-eigenvectors(const SymmetricTensor<2, 2, adouble> &,
-             const SymmetricTensorEigenvectorMethod);
+eigenvectors<2, adouble>(const SymmetricTensor<2, 2, adouble> &,
+                         const SymmetricTensorEigenvectorMethod);
 
 template std::array<std::pair<adouble, Tensor<1, 3, adouble>>, 3>
-eigenvectors(const SymmetricTensor<2, 3, adouble> &,
-             const SymmetricTensorEigenvectorMethod);
+eigenvectors<3, adouble>(const SymmetricTensor<2, 3, adouble> &,
+                         const SymmetricTensorEigenvectorMethod);
 #  endif
 
 template std::array<adtl::adouble, 1>
@@ -146,16 +146,16 @@ template std::array<adtl::adouble, 3>
 eigenvalues(const SymmetricTensor<2, 3, adtl::adouble> &);
 
 template std::array<std::pair<adtl::adouble, Tensor<1, 1, adtl::adouble>>, 1>
-eigenvectors(const SymmetricTensor<2, 1, adtl::adouble> &,
-             const SymmetricTensorEigenvectorMethod);
+eigenvectors<1, adtl::adouble>(const SymmetricTensor<2, 1, adtl::adouble> &,
+                               const SymmetricTensorEigenvectorMethod);
 
 template std::array<std::pair<adtl::adouble, Tensor<1, 2, adtl::adouble>>, 2>
-eigenvectors(const SymmetricTensor<2, 2, adtl::adouble> &,
-             const SymmetricTensorEigenvectorMethod);
+eigenvectors<2, adtl::adouble>(const SymmetricTensor<2, 2, adtl::adouble> &,
+                               const SymmetricTensorEigenvectorMethod);
 
 template std::array<std::pair<adtl::adouble, Tensor<1, 3, adtl::adouble>>, 3>
-eigenvectors(const SymmetricTensor<2, 3, adtl::adouble> &,
-             const SymmetricTensorEigenvectorMethod);
+eigenvectors<3, adtl::adouble>(const SymmetricTensor<2, 3, adtl::adouble> &,
+                               const SymmetricTensorEigenvectorMethod);
 #endif
 
 // explicit instantiations

--- a/source/base/symmetric_tensor.inst.in
+++ b/source/base/symmetric_tensor.inst.in
@@ -23,9 +23,10 @@ for (deal_II_dimension : DIMENSIONS; number : REAL_SCALARS)
       const SymmetricTensor<2, deal_II_dimension, number> &);
 
     template std::array<std::pair<number, Tensor<1, deal_II_dimension, number>>,
-                        std::integral_constant<int, deal_II_dimension>::value>
-    eigenvectors(const SymmetricTensor<2, deal_II_dimension, number> &,
-                 const SymmetricTensorEigenvectorMethod);
+                        deal_II_dimension>
+    eigenvectors<deal_II_dimension, number>(
+      const SymmetricTensor<2, deal_II_dimension, number> &,
+      const SymmetricTensorEigenvectorMethod);
   }
 
 for (deal_II_dimension : DIMENSIONS; number : DIFFERENTIABLE_ADOLC_REAL_SCALARS)
@@ -46,9 +47,10 @@ for (deal_II_dimension : DIMENSIONS;
       const SymmetricTensor<2, deal_II_dimension, number> &);
 
     template std::array<std::pair<number, Tensor<1, deal_II_dimension, number>>,
-                        std::integral_constant<int, deal_II_dimension>::value>
-    eigenvectors(const SymmetricTensor<2, deal_II_dimension, number> &,
-                 const SymmetricTensorEigenvectorMethod);
+                        deal_II_dimension>
+    eigenvectors<deal_II_dimension, number>(
+      const SymmetricTensor<2, deal_II_dimension, number> &,
+      const SymmetricTensorEigenvectorMethod);
   }
 
 for (deal_II_dimension : DIMENSIONS; number : COMPLEX_SCALARS)


### PR DESCRIPTION
I took another look at the issue reported in https://github.com/dealii/dealii/issues/17712#issuecomment-2419029997. The issue is a poorly specified ABI whereby compilers disagree on how to mangle a specific name, and perhaps the same compiler seems to disagree with itself.

I cannot fix #17712 in its entirety, but I think that I can fix the part about the `eigenvectors()` function. This function used to have a relatively straightforward signature starting with #4673. This was changed by @masterleinad in #6249 to work around a compiler issue in clang-6. In essence, this patch undoes #6249 because I don't think we still support clang-6.

I'm not entirely sure about the nature of the clang-6 failure. I suspect that it was that in the `.inst` file, the explicit instantiation could not be matched to the actual declaration because indeed `dim` appears twice in the signature, once as an `int` and once as `std::size_t`. @masterleinad 's approach was to make one of those the equivalent of a non-deducable context so that the compiler had to match `dim` between the explicit instantiation and the declaration based on the other context. That works. I simply took the route of explicitly specifying the template arguments in the `.inst.in` file, and that seems to work just as well (and may perhaps also have worked for clang-6, who knows).

I did think whether I might be breaking user codes. This would be the case if in user codes, calls to the function could not longer be resolved based on the ambiguous use of `dim` in the signature. We have a test `tensors/symmetric_tensor_41` that calls this function, and continues to work with this patch, so that's encouraging. On some more thought, I think that that is right because in function calls, what the compiler matches is only the function arguments -- i.e., only function arguments (but not the return type!) are used to deduce template arguments. On the other hand, when matching an explicit instantiation to a declaration, function name/arguments/return types all have to match, and that's where the ambiguity came from. But at least for the explicit instantiation, I can resolve the ambiguity by explicitly providing the template arguments.

How does this help? I *think* that what @LemonBoy68 reports in #17712 is that the compiler trips itself up over the use of `std::integral_constant<int, dim>::value` in the return type, and how that should be mangled. But this patch gets rid of the whole construct, and consequently we might be able to avoid the issue altogether.