### PR TITLE
Portable MatrixFree: Some cleanup for fe_degree+1 != n_q_points_1d

### DIFF
--- a/include/deal.II/matrix_free/portable_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.templates.h
@@ -182,7 +182,7 @@ namespace Portable
             Kokkos::view_alloc("JxW_" + std::to_string(color),
                                Kokkos::WithoutInitializing),
             n_cells,
-            scalar_dofs_per_cell);
+            q_points_per_cell);
 
       if (update_flags & update_gradients)
         data->inv_jacobian[color] =
@@ -190,7 +190,7 @@ namespace Portable
             Kokkos::view_alloc("inv_jacobian_" + std::to_string(color),
                                Kokkos::WithoutInitializing),
             n_cells,
-            scalar_dofs_per_cell);
+            q_points_per_cell);
 
       // Initialize to zero, i.e., unconstrained cell
       data->constraint_mask[color] =

--- a/include/deal.II/matrix_free/tools.h
+++ b/include/deal.II/matrix_free/tools.h
@@ -1374,7 +1374,11 @@ namespace MatrixFreeTools
   } // namespace internal
 
 
-  template <int dim, int fe_degree, typename Number, typename QuadOperation>
+  template <int dim,
+            int fe_degree,
+            int n_q_points_1d,
+            typename Number,
+            typename QuadOperation>
   class CellAction
   {
   public:
@@ -1393,7 +1397,7 @@ namespace MatrixFreeTools
                const Number *,
                Number *dst) const
     {
-      Portable::FEEvaluation<dim, fe_degree, fe_degree + 1, 1, Number> fe_eval(
+      Portable::FEEvaluation<dim, fe_degree, n_q_points_1d, 1, Number> fe_eval(
         gpu_data, shared_data);
       m_quad_operation.set_matrix_free_data(*gpu_data);
       m_quad_operation.set_cell(cell);
@@ -1490,8 +1494,8 @@ namespace MatrixFreeTools
     matrix_free.initialize_dof_vector(diagonal_global);
 
 
-    CellAction<dim, fe_degree, Number, QuadOperation> cell_action(
-      quad_operation, evaluation_flags, integration_flags);
+    CellAction<dim, fe_degree, n_q_points_1d, Number, QuadOperation>
+      cell_action(quad_operation, evaluation_flags, integration_flags);
     LinearAlgebra::distributed::Vector<Number, MemorySpace> dummy;
     matrix_free.cell_loop(cell_action, dummy, diagonal_global);
 


### PR DESCRIPTION
This PR does some basic cleanup necessary for eventually supporting `fe_degree+1 != n_q_points_1d` for the matrix-free evaluators on a GPU. This does not actually enable the case via https://github.com/dealii/dealii/blob/9e9a7212f1362c93b1cdf8b606075c7f2514fe18/include/deal.II/matrix_free/portable_matrix_free.templates.h#L690-L691 yet because the local arrays in https://github.com/dealii/dealii/blob/master/include/deal.II/matrix_free/portable_tensor_product_kernels.h just use the `n_q_points_1d` argument (thus leading to uninitialized values), but the present cleanup is independent.