### PR TITLE
Use std::function<auto (args...) -> rettype>.

### DIFF
--- a/include/deal.II/base/function.h
+++ b/include/deal.II/base/function.h
@@ -808,7 +808,8 @@ public:
    * RangeNumberType> interface.
    */
   explicit ScalarFunctionFromFunctionObject(
-    const std::function<RangeNumberType(const Point<dim> &)> &function_object);
+    const std::function<auto(const Point<dim> &)->RangeNumberType>
+      &function_object);
 
   /**
    * Given a function object that takes  a time and a Point and returns a
@@ -816,7 +817,7 @@ public:
    * Function<dim, RangeNumberType> interface.
    */
   explicit ScalarFunctionFromFunctionObject(
-    const std::function<RangeNumberType(const double, const Point<dim> &)>
+    const std::function<auto(const double, const Point<dim> &)->RangeNumberType>
       &function_object_t);
 
   /**
@@ -831,7 +832,7 @@ private:
    * The function object which we call when this class's value() or
    * value_list() functions are called.
    */
-  const std::function<RangeNumberType(const double, const Point<dim> &)>
+  const std::function<auto(const double, const Point<dim> &)->RangeNumberType>
     function_object;
 };
 
@@ -893,7 +894,8 @@ public:
    * the first argument.
    */
   VectorFunctionFromScalarFunctionObject(
-    const std::function<RangeNumberType(const Point<dim> &)> &function_object,
+    const std::function<auto(const Point<dim> &)->RangeNumberType>
+                      &function_object,
     const unsigned int selected_component,
     const unsigned int n_components);
 
@@ -918,7 +920,8 @@ private:
    * The function object which we call when this class's value() or
    * value_list() functions are called.
    */
-  const std::function<RangeNumberType(const Point<dim> &)> function_object;
+  const std::function<auto(const Point<dim> &)->RangeNumberType>
+    function_object;
 
   /**
    * The vector component whose value is to be filled by the given scalar
@@ -987,7 +990,7 @@ public:
    * set_function_gradients() method.
    */
   explicit FunctionFromFunctionObjects(
-    const std::vector<std::function<RangeNumberType(const Point<dim> &)>>
+    const std::vector<std::function<auto(const Point<dim> &)->RangeNumberType>>
                 &values,
     const double initial_time = 0.0);
 
@@ -1000,8 +1003,8 @@ public:
    * set_function_gradients() method.
    */
   explicit FunctionFromFunctionObjects(
-    const std::function<RangeNumberType(const Point<dim> &, const unsigned int)>
-                      &values,
+    const std::function<
+      auto(const Point<dim> &, const unsigned int)->RangeNumberType> &values,
     const unsigned int n_components,
     const double       initial_time = 0.0);
 
@@ -1014,7 +1017,7 @@ public:
    * match, an exception is triggered.
    */
   FunctionFromFunctionObjects(
-    const std::vector<std::function<RangeNumberType(const Point<dim> &)>>
+    const std::vector<std::function<auto(const Point<dim> &)->RangeNumberType>>
       &values,
     const std::vector<
       std::function<Tensor<1, dim, RangeNumberType>(const Point<dim> &)>>
@@ -1048,7 +1051,7 @@ public:
    */
   void
   set_function_values(
-    const std::vector<std::function<RangeNumberType(const Point<dim> &)>>
+    const std::vector<std::function<auto(const Point<dim> &)->RangeNumberType>>
       &values);
 
   /**
@@ -1066,7 +1069,7 @@ private:
   /**
    * The actual function values.
    */
-  std::function<RangeNumberType(const Point<dim> &, const unsigned int)>
+  std::function<auto(const Point<dim> &, const unsigned int)->RangeNumberType>
     function_values;
 
   /**

--- a/include/deal.II/base/function.templates.h
+++ b/include/deal.II/base/function.templates.h
@@ -691,7 +691,7 @@ ComponentSelectFunction<dim, RangeNumberType>::memory_consumption() const
 template <int dim, typename RangeNumberType>
 ScalarFunctionFromFunctionObject<dim, RangeNumberType>::
   ScalarFunctionFromFunctionObject(
-    const std::function<RangeNumberType(const Point<dim> &)> &fu)
+    const std::function<auto(const Point<dim> &)->RangeNumberType> &fu)
   : ScalarFunctionFromFunctionObject<dim, RangeNumberType>(
       [fu](const double t, const Point<dim> &x) {
         (void)t; // we got a function object that only takes 'x', so ignore 't'
@@ -704,7 +704,7 @@ ScalarFunctionFromFunctionObject<dim, RangeNumberType>::
 template <int dim, typename RangeNumberType>
 ScalarFunctionFromFunctionObject<dim, RangeNumberType>::
   ScalarFunctionFromFunctionObject(
-    const std::function<RangeNumberType(const double, const Point<dim> &)>
+    const std::function<auto(const double, const Point<dim> &)->RangeNumberType>
       &function_object)
   : Function<dim, RangeNumberType>(1)
   , function_object(function_object)
@@ -730,7 +730,8 @@ ScalarFunctionFromFunctionObject<dim, RangeNumberType>::value(
 template <int dim, typename RangeNumberType>
 VectorFunctionFromScalarFunctionObject<dim, RangeNumberType>::
   VectorFunctionFromScalarFunctionObject(
-    const std::function<RangeNumberType(const Point<dim> &)> &function_object,
+    const std::function<auto(const Point<dim> &)->RangeNumberType>
+                      &function_object,
     const unsigned int selected_component,
     const unsigned int n_components)
   : Function<dim, RangeNumberType>(n_components)
@@ -963,7 +964,8 @@ FunctionFromFunctionObjects<dim, RangeNumberType>::FunctionFromFunctionObjects(
 
 template <int dim, typename RangeNumberType>
 FunctionFromFunctionObjects<dim, RangeNumberType>::FunctionFromFunctionObjects(
-  const std::vector<std::function<RangeNumberType(const Point<dim> &)>> &values,
+  const std::vector<std::function<auto(const Point<dim> &)->RangeNumberType>>
+              &values,
   const double initial_time)
   : Function<dim, RangeNumberType>(values.size(), initial_time)
 {
@@ -974,8 +976,8 @@ FunctionFromFunctionObjects<dim, RangeNumberType>::FunctionFromFunctionObjects(
 
 template <int dim, typename RangeNumberType>
 FunctionFromFunctionObjects<dim, RangeNumberType>::FunctionFromFunctionObjects(
-  const std::function<RangeNumberType(const Point<dim> &, const unsigned int)>
-                    &values,
+  const std::function<
+    auto(const Point<dim> &, const unsigned int)->RangeNumberType> &values,
   const unsigned int n_components,
   const double       initial_time)
   : Function<dim, RangeNumberType>(n_components, initial_time)
@@ -986,7 +988,8 @@ FunctionFromFunctionObjects<dim, RangeNumberType>::FunctionFromFunctionObjects(
 
 template <int dim, typename RangeNumberType>
 FunctionFromFunctionObjects<dim, RangeNumberType>::FunctionFromFunctionObjects(
-  const std::vector<std::function<RangeNumberType(const Point<dim> &)>> &values,
+  const std::vector<std::function<auto(const Point<dim> &)->RangeNumberType>>
+    &values,
   const std::vector<
     std::function<Tensor<1, dim, RangeNumberType>(const Point<dim> &)>>
               &gradients,
@@ -1033,7 +1036,8 @@ FunctionFromFunctionObjects<dim, RangeNumberType>::gradient(
 template <int dim, typename RangeNumberType>
 void
 FunctionFromFunctionObjects<dim, RangeNumberType>::set_function_values(
-  const std::vector<std::function<RangeNumberType(const Point<dim> &)>> &values)
+  const std::vector<std::function<auto(const Point<dim> &)->RangeNumberType>>
+    &values)
 {
   AssertDimension(this->n_components, values.size());
   function_values = [values](const auto &p, const auto c) {

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -523,8 +523,8 @@ namespace Utilities
       /**
        * Function objects encoding the wait and clean-up operations.
        */
-      std::function<void()> wait_function;
-      std::function<T()>    get_and_cleanup_function;
+      std::function<auto()->void> wait_function;
+      std::function<auto()->T>    get_and_cleanup_function;
 
       /**
        * Whether or not wait() has already been called.
@@ -1273,10 +1273,10 @@ namespace Utilities
      */
     template <typename T>
     T
-    reduce(const T                                      &local_value,
-           const MPI_Comm                                comm,
-           const std::function<T(const T &, const T &)> &combiner,
-           const unsigned int                            root_process = 0);
+    reduce(const T                                            &local_value,
+           const MPI_Comm                                      comm,
+           const std::function<auto(const T &, const T &)->T> &combiner,
+           const unsigned int root_process = 0);
 
 
     /**
@@ -1306,9 +1306,9 @@ namespace Utilities
      */
     template <typename T>
     T
-    all_reduce(const T                                      &local_value,
-               const MPI_Comm                                comm,
-               const std::function<T(const T &, const T &)> &combiner);
+    all_reduce(const T                                            &local_value,
+               const MPI_Comm                                      comm,
+               const std::function<auto(const T &, const T &)->T> &combiner);
 
 
     /**

--- a/include/deal.II/base/mpi.templates.h
+++ b/include/deal.II/base/mpi.templates.h
@@ -404,10 +404,10 @@ namespace Utilities
 
     template <typename T>
     T
-    reduce(const T                                      &vec,
-           const MPI_Comm                                comm,
-           const std::function<T(const T &, const T &)> &combiner,
-           const unsigned int                            root_process)
+    reduce(const T                                            &vec,
+           const MPI_Comm                                      comm,
+           const std::function<auto(const T &, const T &)->T> &combiner,
+           const unsigned int                                  root_process)
     {
 #ifdef DEAL_II_WITH_MPI
       if (n_mpi_processes(comm) > 1)
@@ -488,9 +488,9 @@ namespace Utilities
 
     template <typename T>
     T
-    all_reduce(const T                                      &vec,
-               const MPI_Comm                                comm,
-               const std::function<T(const T &, const T &)> &combiner)
+    all_reduce(const T                                            &vec,
+               const MPI_Comm                                      comm,
+               const std::function<auto(const T &, const T &)->T> &combiner)
     {
       if (n_mpi_processes(comm) > 1)
         {

--- a/include/deal.II/base/mpi_consensus_algorithms.h
+++ b/include/deal.II/base/mpi_consensus_algorithms.h
@@ -289,13 +289,14 @@ namespace Utilities
          */
         virtual std::vector<unsigned int>
         run(
-          const std::vector<unsigned int>                      &targets,
-          const std::function<RequestType(const unsigned int)> &create_request,
+          const std::vector<unsigned int> &targets,
+          const std::function<auto(const unsigned int)->RequestType>
+                                                               &create_request,
           const std::function<AnswerType(const unsigned int,
                                          const RequestType &)> &answer_request,
-          const std::function<void(const unsigned int, const AnswerType &)>
-                        &process_answer,
-          const MPI_Comm comm) = 0;
+          const std::function<
+            auto(const unsigned int, const AnswerType &)->void> &process_answer,
+          const MPI_Comm                                         comm) = 0;
       };
 
 
@@ -334,13 +335,14 @@ namespace Utilities
          */
         virtual std::vector<unsigned int>
         run(
-          const std::vector<unsigned int>                      &targets,
-          const std::function<RequestType(const unsigned int)> &create_request,
+          const std::vector<unsigned int> &targets,
+          const std::function<auto(const unsigned int)->RequestType>
+                                                               &create_request,
           const std::function<AnswerType(const unsigned int,
                                          const RequestType &)> &answer_request,
-          const std::function<void(const unsigned int, const AnswerType &)>
-                        &process_answer,
-          const MPI_Comm comm) override;
+          const std::function<
+            auto(const unsigned int, const AnswerType &)->void> &process_answer,
+          const MPI_Comm                                         comm) override;
 
       private:
 #ifdef DEAL_II_WITH_MPI
@@ -389,9 +391,9 @@ namespace Utilities
          */
         bool
         all_locally_originated_receives_are_completed(
-          const std::function<void(const unsigned int, const AnswerType &)>
-                        &process_answer,
-          const MPI_Comm comm);
+          const std::function<
+            auto(const unsigned int, const AnswerType &)->void> &process_answer,
+          const MPI_Comm                                         comm);
 
         /**
          * Signal to all other ranks that this rank has received all request
@@ -425,9 +427,10 @@ namespace Utilities
          */
         void
         start_communication(
-          const std::vector<unsigned int>                      &targets,
-          const std::function<RequestType(const unsigned int)> &create_request,
-          const MPI_Comm                                        comm);
+          const std::vector<unsigned int> &targets,
+          const std::function<auto(const unsigned int)->RequestType>
+                        &create_request,
+          const MPI_Comm comm);
 
         /**
          * After all rank has received all answers, the MPI data structures can
@@ -484,13 +487,15 @@ namespace Utilities
        */
       template <typename RequestType, typename AnswerType>
       std::vector<unsigned int>
-      nbx(const std::vector<unsigned int>                      &targets,
-          const std::function<RequestType(const unsigned int)> &create_request,
-          const std::function<AnswerType(const unsigned int,
-                                         const RequestType &)> &answer_request,
-          const std::function<void(const unsigned int, const AnswerType &)>
-                        &process_answer,
-          const MPI_Comm comm);
+      nbx(
+        const std::vector<unsigned int> &targets,
+        const std::function<auto(const unsigned int)->RequestType>
+          &create_request,
+        const std::function<AnswerType(const unsigned int, const RequestType &)>
+          &answer_request,
+        const std::function<auto(const unsigned int, const AnswerType &)->void>
+                      &process_answer,
+        const MPI_Comm comm);
 
       /**
        * This function provides a specialization of the one above for
@@ -531,11 +536,13 @@ namespace Utilities
        */
       template <typename RequestType>
       std::vector<unsigned int>
-      nbx(const std::vector<unsigned int>                      &targets,
-          const std::function<RequestType(const unsigned int)> &create_request,
-          const std::function<void(const unsigned int, const RequestType &)>
-                        &process_request,
-          const MPI_Comm comm);
+      nbx(
+        const std::vector<unsigned int> &targets,
+        const std::function<auto(const unsigned int)->RequestType>
+          &create_request,
+        const std::function<auto(const unsigned int, const RequestType &)->void>
+                      &process_request,
+        const MPI_Comm comm);
 
       /**
        * This class implements a concrete algorithm for the
@@ -584,13 +591,14 @@ namespace Utilities
          */
         virtual std::vector<unsigned int>
         run(
-          const std::vector<unsigned int>                      &targets,
-          const std::function<RequestType(const unsigned int)> &create_request,
+          const std::vector<unsigned int> &targets,
+          const std::function<auto(const unsigned int)->RequestType>
+                                                               &create_request,
           const std::function<AnswerType(const unsigned int,
                                          const RequestType &)> &answer_request,
-          const std::function<void(const unsigned int, const AnswerType &)>
-                        &process_answer,
-          const MPI_Comm comm) override;
+          const std::function<
+            auto(const unsigned int, const AnswerType &)->void> &process_answer,
+          const MPI_Comm                                         comm) override;
 
       private:
 #ifdef DEAL_II_WITH_MPI
@@ -630,9 +638,10 @@ namespace Utilities
          */
         unsigned int
         start_communication(
-          const std::vector<unsigned int>                      &targets,
-          const std::function<RequestType(const unsigned int)> &create_request,
-          const MPI_Comm                                        comm);
+          const std::vector<unsigned int> &targets,
+          const std::function<auto(const unsigned int)->RequestType>
+                        &create_request,
+          const MPI_Comm comm);
 
         /**
          * The `index`th request message from another rank has been received:
@@ -652,9 +661,9 @@ namespace Utilities
         void
         process_incoming_answers(
           const unsigned int n_targets,
-          const std::function<void(const unsigned int, const AnswerType &)>
-                        &process_answer,
-          const MPI_Comm comm);
+          const std::function<
+            auto(const unsigned int, const AnswerType &)->void> &process_answer,
+          const MPI_Comm                                         comm);
 
         /**
          * After all answers have been exchanged, the MPI data structures can be
@@ -724,13 +733,15 @@ namespace Utilities
        */
       template <typename RequestType, typename AnswerType>
       std::vector<unsigned int>
-      pex(const std::vector<unsigned int>                      &targets,
-          const std::function<RequestType(const unsigned int)> &create_request,
-          const std::function<AnswerType(const unsigned int,
-                                         const RequestType &)> &answer_request,
-          const std::function<void(const unsigned int, const AnswerType &)>
-                        &process_answer,
-          const MPI_Comm comm);
+      pex(
+        const std::vector<unsigned int> &targets,
+        const std::function<auto(const unsigned int)->RequestType>
+          &create_request,
+        const std::function<AnswerType(const unsigned int, const RequestType &)>
+          &answer_request,
+        const std::function<auto(const unsigned int, const AnswerType &)->void>
+                      &process_answer,
+        const MPI_Comm comm);
 
       /**
        * This function provides a specialization of the one above for
@@ -771,11 +782,13 @@ namespace Utilities
        */
       template <typename RequestType>
       std::vector<unsigned int>
-      pex(const std::vector<unsigned int>                      &targets,
-          const std::function<RequestType(const unsigned int)> &create_request,
-          const std::function<void(const unsigned int, const RequestType &)>
-                        &process_request,
-          const MPI_Comm comm);
+      pex(
+        const std::vector<unsigned int> &targets,
+        const std::function<auto(const unsigned int)->RequestType>
+          &create_request,
+        const std::function<auto(const unsigned int, const RequestType &)->void>
+                      &process_request,
+        const MPI_Comm comm);
 
 
       /**
@@ -799,13 +812,14 @@ namespace Utilities
          */
         virtual std::vector<unsigned int>
         run(
-          const std::vector<unsigned int>                      &targets,
-          const std::function<RequestType(const unsigned int)> &create_request,
+          const std::vector<unsigned int> &targets,
+          const std::function<auto(const unsigned int)->RequestType>
+                                                               &create_request,
           const std::function<AnswerType(const unsigned int,
                                          const RequestType &)> &answer_request,
-          const std::function<void(const unsigned int, const AnswerType &)>
-                        &process_answer,
-          const MPI_Comm comm) override;
+          const std::function<
+            auto(const unsigned int, const AnswerType &)->void> &process_answer,
+          const MPI_Comm                                         comm) override;
       };
 
 
@@ -845,11 +859,12 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       std::vector<unsigned int>
       serial(
-        const std::vector<unsigned int>                      &targets,
-        const std::function<RequestType(const unsigned int)> &create_request,
-        const std::function<AnswerType(const unsigned int, const RequestType &)>
-          &answer_request,
-        const std::function<void(const unsigned int, const AnswerType &)>
+        const std::vector<unsigned int> &targets,
+        const std::function<auto(const unsigned int)->RequestType>
+                                            &create_request,
+        const std::function<auto(const unsigned int, const RequestType &)
+                              ->AnswerType> &answer_request,
+        const std::function<auto(const unsigned int, const AnswerType &)->void>
                       &process_answer,
         const MPI_Comm comm);
 
@@ -885,9 +900,10 @@ namespace Utilities
       template <typename RequestType>
       std::vector<unsigned int>
       serial(
-        const std::vector<unsigned int>                      &targets,
-        const std::function<RequestType(const unsigned int)> &create_request,
-        const std::function<void(const unsigned int, const RequestType &)>
+        const std::vector<unsigned int> &targets,
+        const std::function<auto(const unsigned int)->RequestType>
+          &create_request,
+        const std::function<auto(const unsigned int, const RequestType &)->void>
                       &process_request,
         const MPI_Comm comm);
 
@@ -929,13 +945,14 @@ namespace Utilities
          */
         virtual std::vector<unsigned int>
         run(
-          const std::vector<unsigned int>                      &targets,
-          const std::function<RequestType(const unsigned int)> &create_request,
+          const std::vector<unsigned int> &targets,
+          const std::function<auto(const unsigned int)->RequestType>
+                                                               &create_request,
           const std::function<AnswerType(const unsigned int,
                                          const RequestType &)> &answer_request,
-          const std::function<void(const unsigned int, const AnswerType &)>
-                        &process_answer,
-          const MPI_Comm comm) override;
+          const std::function<
+            auto(const unsigned int, const AnswerType &)->void> &process_answer,
+          const MPI_Comm                                         comm) override;
 
       private:
         // Pointer to the actual ConsensusAlgorithms::Interface implementation.
@@ -991,11 +1008,12 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       std::vector<unsigned int>
       selector(
-        const std::vector<unsigned int>                      &targets,
-        const std::function<RequestType(const unsigned int)> &create_request,
-        const std::function<AnswerType(const unsigned int, const RequestType &)>
-          &answer_request,
-        const std::function<void(const unsigned int, const AnswerType &)>
+        const std::vector<unsigned int> &targets,
+        const std::function<auto(const unsigned int)->RequestType>
+                                            &create_request,
+        const std::function<auto(const unsigned int, const RequestType &)
+                              ->AnswerType> &answer_request,
+        const std::function<auto(const unsigned int, const AnswerType &)->void>
                       &process_answer,
         const MPI_Comm comm);
 
@@ -1039,9 +1057,10 @@ namespace Utilities
       template <typename RequestType>
       std::vector<unsigned int>
       selector(
-        const std::vector<unsigned int>                      &targets,
-        const std::function<RequestType(const unsigned int)> &create_request,
-        const std::function<void(const unsigned int, const RequestType &)>
+        const std::vector<unsigned int> &targets,
+        const std::function<auto(const unsigned int)->RequestType>
+          &create_request,
+        const std::function<auto(const unsigned int, const RequestType &)->void>
                       &process_request,
         const MPI_Comm comm);
 
@@ -1052,13 +1071,15 @@ namespace Utilities
 
       template <typename RequestType, typename AnswerType>
       std::vector<unsigned int>
-      nbx(const std::vector<unsigned int>                      &targets,
-          const std::function<RequestType(const unsigned int)> &create_request,
-          const std::function<AnswerType(const unsigned int,
-                                         const RequestType &)> &answer_request,
-          const std::function<void(const unsigned int, const AnswerType &)>
-                        &process_answer,
-          const MPI_Comm comm)
+      nbx(
+        const std::vector<unsigned int> &targets,
+        const std::function<auto(const unsigned int)->RequestType>
+          &create_request,
+        const std::function<AnswerType(const unsigned int, const RequestType &)>
+          &answer_request,
+        const std::function<auto(const unsigned int, const AnswerType &)->void>
+                      &process_answer,
+        const MPI_Comm comm)
       {
         return NBX<RequestType, AnswerType>().run(
           targets, create_request, answer_request, process_answer, comm);
@@ -1068,11 +1089,13 @@ namespace Utilities
 
       template <typename RequestType>
       std::vector<unsigned int>
-      nbx(const std::vector<unsigned int>                      &targets,
-          const std::function<RequestType(const unsigned int)> &create_request,
-          const std::function<void(const unsigned int, const RequestType &)>
-                        &process_request,
-          const MPI_Comm comm)
+      nbx(
+        const std::vector<unsigned int> &targets,
+        const std::function<auto(const unsigned int)->RequestType>
+          &create_request,
+        const std::function<auto(const unsigned int, const RequestType &)->void>
+                      &process_request,
+        const MPI_Comm comm)
       {
         // TODO: For the moment, simply implement this special case by
         // forwarding to the other function with rewritten function
@@ -1104,13 +1127,15 @@ namespace Utilities
 
       template <typename RequestType, typename AnswerType>
       std::vector<unsigned int>
-      pex(const std::vector<unsigned int>                      &targets,
-          const std::function<RequestType(const unsigned int)> &create_request,
-          const std::function<AnswerType(const unsigned int,
-                                         const RequestType &)> &answer_request,
-          const std::function<void(const unsigned int, const AnswerType &)>
-                        &process_answer,
-          const MPI_Comm comm)
+      pex(
+        const std::vector<unsigned int> &targets,
+        const std::function<auto(const unsigned int)->RequestType>
+          &create_request,
+        const std::function<AnswerType(const unsigned int, const RequestType &)>
+          &answer_request,
+        const std::function<auto(const unsigned int, const AnswerType &)->void>
+                      &process_answer,
+        const MPI_Comm comm)
       {
         return PEX<RequestType, AnswerType>().run(
           targets, create_request, answer_request, process_answer, comm);
@@ -1120,11 +1145,13 @@ namespace Utilities
 
       template <typename RequestType>
       std::vector<unsigned int>
-      pex(const std::vector<unsigned int>                      &targets,
-          const std::function<RequestType(const unsigned int)> &create_request,
-          const std::function<void(const unsigned int, const RequestType &)>
-                        &process_request,
-          const MPI_Comm comm)
+      pex(
+        const std::vector<unsigned int> &targets,
+        const std::function<auto(const unsigned int)->RequestType>
+          &create_request,
+        const std::function<auto(const unsigned int, const RequestType &)->void>
+                      &process_request,
+        const MPI_Comm comm)
       {
         // TODO: For the moment, simply implement this special case by
         // forwarding to the other function with rewritten function
@@ -1157,11 +1184,12 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       std::vector<unsigned int>
       serial(
-        const std::vector<unsigned int>                      &targets,
-        const std::function<RequestType(const unsigned int)> &create_request,
-        const std::function<AnswerType(const unsigned int, const RequestType &)>
-          &answer_request,
-        const std::function<void(const unsigned int, const AnswerType &)>
+        const std::vector<unsigned int> &targets,
+        const std::function<auto(const unsigned int)->RequestType>
+                                            &create_request,
+        const std::function<auto(const unsigned int, const RequestType &)
+                              ->AnswerType> &answer_request,
+        const std::function<auto(const unsigned int, const AnswerType &)->void>
                       &process_answer,
         const MPI_Comm comm)
       {
@@ -1174,9 +1202,10 @@ namespace Utilities
       template <typename RequestType>
       std::vector<unsigned int>
       serial(
-        const std::vector<unsigned int>                      &targets,
-        const std::function<RequestType(const unsigned int)> &create_request,
-        const std::function<void(const unsigned int, const RequestType &)>
+        const std::vector<unsigned int> &targets,
+        const std::function<auto(const unsigned int)->RequestType>
+          &create_request,
+        const std::function<auto(const unsigned int, const RequestType &)->void>
                       &process_request,
         const MPI_Comm comm)
       {
@@ -1211,11 +1240,12 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       std::vector<unsigned int>
       selector(
-        const std::vector<unsigned int>                      &targets,
-        const std::function<RequestType(const unsigned int)> &create_request,
-        const std::function<AnswerType(const unsigned int, const RequestType &)>
-          &answer_request,
-        const std::function<void(const unsigned int, const AnswerType &)>
+        const std::vector<unsigned int> &targets,
+        const std::function<auto(const unsigned int)->RequestType>
+                                            &create_request,
+        const std::function<auto(const unsigned int, const RequestType &)
+                              ->AnswerType> &answer_request,
+        const std::function<auto(const unsigned int, const AnswerType &)->void>
                       &process_answer,
         const MPI_Comm comm)
       {
@@ -1228,9 +1258,10 @@ namespace Utilities
       template <typename RequestType>
       std::vector<unsigned int>
       selector(
-        const std::vector<unsigned int>                      &targets,
-        const std::function<RequestType(const unsigned int)> &create_request,
-        const std::function<void(const unsigned int, const RequestType &)>
+        const std::vector<unsigned int> &targets,
+        const std::function<auto(const unsigned int)->RequestType>
+          &create_request,
+        const std::function<auto(const unsigned int, const RequestType &)->void>
                       &process_request,
         const MPI_Comm comm)
       {
@@ -1442,11 +1473,12 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       std::vector<unsigned int>
       NBX<RequestType, AnswerType>::run(
-        const std::vector<unsigned int>                      &targets,
-        const std::function<RequestType(const unsigned int)> &create_request,
-        const std::function<AnswerType(const unsigned int, const RequestType &)>
-          &answer_request,
-        const std::function<void(const unsigned int, const AnswerType &)>
+        const std::vector<unsigned int> &targets,
+        const std::function<auto(const unsigned int)->RequestType>
+                                            &create_request,
+        const std::function<auto(const unsigned int, const RequestType &)
+                              ->AnswerType> &answer_request,
+        const std::function<auto(const unsigned int, const AnswerType &)->void>
                       &process_answer,
         const MPI_Comm comm)
       {
@@ -1509,9 +1541,10 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       void
       NBX<RequestType, AnswerType>::start_communication(
-        const std::vector<unsigned int>                      &targets,
-        const std::function<RequestType(const unsigned int)> &create_request,
-        const MPI_Comm                                        comm)
+        const std::vector<unsigned int> &targets,
+        const std::function<auto(const unsigned int)->RequestType>
+                      &create_request,
+        const MPI_Comm comm)
       {
 #  ifdef DEAL_II_WITH_MPI
         // 1)
@@ -1564,9 +1597,9 @@ namespace Utilities
       bool
       NBX<RequestType, AnswerType>::
         all_locally_originated_receives_are_completed(
-          const std::function<void(const unsigned int, const AnswerType &)>
-                        &process_answer,
-          const MPI_Comm comm)
+          const std::function<
+            auto(const unsigned int, const AnswerType &)->void> &process_answer,
+          const MPI_Comm                                         comm)
       {
 #  ifdef DEAL_II_WITH_MPI
         // We know that all requests have come in when we have pending
@@ -1658,9 +1691,9 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       void
       NBX<RequestType, AnswerType>::maybe_answer_one_request(
-        const std::function<AnswerType(const unsigned int, const RequestType &)>
-                      &answer_request,
-        const MPI_Comm comm)
+        const std::function<auto(const unsigned int, const RequestType &)
+                              ->AnswerType> &answer_request,
+        const MPI_Comm                       comm)
       {
 #  ifdef DEAL_II_WITH_MPI
 
@@ -1813,11 +1846,12 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       std::vector<unsigned int>
       PEX<RequestType, AnswerType>::run(
-        const std::vector<unsigned int>                      &targets,
-        const std::function<RequestType(const unsigned int)> &create_request,
-        const std::function<AnswerType(const unsigned int, const RequestType &)>
-          &answer_request,
-        const std::function<void(const unsigned int, const AnswerType &)>
+        const std::vector<unsigned int> &targets,
+        const std::function<auto(const unsigned int)->RequestType>
+                                            &create_request,
+        const std::function<auto(const unsigned int, const RequestType &)
+                              ->AnswerType> &answer_request,
+        const std::function<auto(const unsigned int, const AnswerType &)->void>
                       &process_answer,
         const MPI_Comm comm)
       {
@@ -1861,9 +1895,10 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       unsigned int
       PEX<RequestType, AnswerType>::start_communication(
-        const std::vector<unsigned int>                      &targets,
-        const std::function<RequestType(const unsigned int)> &create_request,
-        const MPI_Comm                                        comm)
+        const std::vector<unsigned int> &targets,
+        const std::function<auto(const unsigned int)->RequestType>
+                      &create_request,
+        const MPI_Comm comm)
       {
 #  ifdef DEAL_II_WITH_MPI
         const int tag_request = Utilities::MPI::internal::Tags::
@@ -1921,10 +1956,10 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       void
       PEX<RequestType, AnswerType>::answer_one_request(
-        const unsigned int index,
-        const std::function<AnswerType(const unsigned int, const RequestType &)>
-                      &answer_request,
-        const MPI_Comm comm)
+        const unsigned int                   index,
+        const std::function<auto(const unsigned int, const RequestType &)
+                              ->AnswerType> &answer_request,
+        const MPI_Comm                       comm)
       {
 #  ifdef DEAL_II_WITH_MPI
         const int tag_request = Utilities::MPI::internal::Tags::
@@ -1996,7 +2031,7 @@ namespace Utilities
       void
       PEX<RequestType, AnswerType>::process_incoming_answers(
         const unsigned int n_targets,
-        const std::function<void(const unsigned int, const AnswerType &)>
+        const std::function<auto(const unsigned int, const AnswerType &)->void>
                       &process_answer,
         const MPI_Comm comm)
       {
@@ -2084,11 +2119,12 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       std::vector<unsigned int>
       Serial<RequestType, AnswerType>::run(
-        const std::vector<unsigned int>                      &targets,
-        const std::function<RequestType(const unsigned int)> &create_request,
-        const std::function<AnswerType(const unsigned int, const RequestType &)>
-          &answer_request,
-        const std::function<void(const unsigned int, const AnswerType &)>
+        const std::vector<unsigned int> &targets,
+        const std::function<auto(const unsigned int)->RequestType>
+                                            &create_request,
+        const std::function<auto(const unsigned int, const RequestType &)
+                              ->AnswerType> &answer_request,
+        const std::function<auto(const unsigned int, const AnswerType &)->void>
                       &process_answer,
         const MPI_Comm comm)
       {
@@ -2128,11 +2164,12 @@ namespace Utilities
       template <typename RequestType, typename AnswerType>
       std::vector<unsigned int>
       Selector<RequestType, AnswerType>::run(
-        const std::vector<unsigned int>                      &targets,
-        const std::function<RequestType(const unsigned int)> &create_request,
-        const std::function<AnswerType(const unsigned int, const RequestType &)>
-          &answer_request,
-        const std::function<void(const unsigned int, const AnswerType &)>
+        const std::vector<unsigned int> &targets,
+        const std::function<auto(const unsigned int)->RequestType>
+                                            &create_request,
+        const std::function<auto(const unsigned int, const RequestType &)
+                              ->AnswerType> &answer_request,
+        const std::function<auto(const unsigned int, const AnswerType &)->void>
                       &process_answer,
         const MPI_Comm comm)
       {

--- a/include/deal.II/base/mpi_remote_point_evaluation.h
+++ b/include/deal.II/base/mpi_remote_point_evaluation.h
@@ -301,7 +301,7 @@ namespace Utilities
       evaluate_and_process(
         std::vector<T> &output,
         std::vector<T> &buffer,
-        const std::function<void(const ArrayView<T> &, const CellData &)>
+        const std::function<auto(const ArrayView<T> &, const CellData &)->void>
                   &evaluation_function,
         const bool sort_data = true) const;
 
@@ -312,7 +312,7 @@ namespace Utilities
       template <typename T, unsigned int n_components = 1>
       std::vector<T>
       evaluate_and_process(
-        const std::function<void(const ArrayView<T> &, const CellData &)>
+        const std::function<auto(const ArrayView<T> &, const CellData &)->void>
                   &evaluation_function,
         const bool sort_data = true) const;
 
@@ -333,11 +333,11 @@ namespace Utilities
       template <typename T, unsigned int n_components = 1>
       void
       process_and_evaluate(
-        const std::vector<T> &input,
-        std::vector<T>       &buffer,
-        const std::function<void(const ArrayView<const T> &, const CellData &)>
-                  &evaluation_function,
-        const bool sort_data = true) const;
+        const std::vector<T>          &input,
+        std::vector<T>                &buffer,
+        const std::function<auto(const ArrayView<const T> &, const CellData &)
+                              ->void> &evaluation_function,
+        const bool                     sort_data = true) const;
 
       /**
        * Same as above but without external allocation of a user-provided
@@ -346,10 +346,10 @@ namespace Utilities
       template <typename T, unsigned int n_components = 1>
       void
       process_and_evaluate(
-        const std::vector<T> &input,
-        const std::function<void(const ArrayView<const T> &, const CellData &)>
-                  &evaluation_function,
-        const bool sort_data = true) const;
+        const std::vector<T>          &input,
+        const std::function<auto(const ArrayView<const T> &, const CellData &)
+                              ->void> &evaluation_function,
+        const bool                     sort_data = true) const;
 
       /**
        * Return a CRS-like data structure to determine the position of the
@@ -709,7 +709,7 @@ namespace Utilities
     RemotePointEvaluation<dim, spacedim>::evaluate_and_process(
       std::vector<T> &output,
       std::vector<T> &buffer,
-      const std::function<void(const ArrayView<T> &, const CellData &)>
+      const std::function<auto(const ArrayView<T> &, const CellData &)->void>
                 &evaluation_function,
       const bool sort_data) const
     {
@@ -898,7 +898,7 @@ namespace Utilities
     template <typename T, unsigned int n_components>
     std::vector<T>
     RemotePointEvaluation<dim, spacedim>::evaluate_and_process(
-      const std::function<void(const ArrayView<T> &, const CellData &)>
+      const std::function<auto(const ArrayView<T> &, const CellData &)->void>
                 &evaluation_function,
       const bool sort_data) const
     {
@@ -919,11 +919,11 @@ namespace Utilities
     template <typename T, unsigned int n_components>
     void
     RemotePointEvaluation<dim, spacedim>::process_and_evaluate(
-      const std::vector<T> &input,
-      std::vector<T>       &buffer,
-      const std::function<void(const ArrayView<const T> &, const CellData &)>
-                &evaluation_function,
-      const bool sort_data) const
+      const std::vector<T>          &input,
+      std::vector<T>                &buffer,
+      const std::function<auto(const ArrayView<const T> &, const CellData &)
+                            ->void> &evaluation_function,
+      const bool                     sort_data) const
     {
 #ifndef DEAL_II_WITH_MPI
       Assert(false, ExcNeedsMPI());
@@ -1122,10 +1122,10 @@ namespace Utilities
     template <typename T, unsigned int n_components>
     void
     RemotePointEvaluation<dim, spacedim>::process_and_evaluate(
-      const std::vector<T> &input,
-      const std::function<void(const ArrayView<const T> &, const CellData &)>
-                &evaluation_function,
-      const bool sort_data) const
+      const std::vector<T>          &input,
+      const std::function<auto(const ArrayView<const T> &, const CellData &)
+                            ->void> &evaluation_function,
+      const bool                     sort_data) const
     {
       std::vector<T> buffer;
       this->process_and_evaluate<T, n_components>(input,

--- a/include/deal.II/base/mutable_bind.h
+++ b/include/deal.II/base/mutable_bind.h
@@ -151,7 +151,7 @@ namespace Utilities
     /**
      * An std::function that stores the original function.
      */
-    const std::function<ReturnType(FunctionArgs...)> function;
+    const std::function<auto(FunctionArgs...)->ReturnType> function;
 
     /**
      * Currently stored arguments. These are forwarded to the function object
@@ -191,7 +191,7 @@ namespace Utilities
    */
   template <typename ReturnType, class... FunctionArgs>
   MutableBind<ReturnType, FunctionArgs...>
-  mutable_bind(std::function<ReturnType(FunctionArgs...)>,
+  mutable_bind(std::function<auto(FunctionArgs...)->ReturnType>,
                std_cxx20::type_identity_t<FunctionArgs> &&...arguments);
 
   /**
@@ -213,7 +213,7 @@ namespace Utilities
    */
   template <typename ReturnType, class... FunctionArgs>
   MutableBind<ReturnType, FunctionArgs...>
-    mutable_bind(std::function<ReturnType(FunctionArgs...)>);
+    mutable_bind(std::function<auto(FunctionArgs...)->ReturnType>);
 
 
 
@@ -309,7 +309,7 @@ namespace Utilities
 
   template <typename ReturnType, class... FunctionArgs>
   MutableBind<ReturnType, FunctionArgs...>
-  mutable_bind(std::function<ReturnType(FunctionArgs...)> function,
+  mutable_bind(std::function<auto(FunctionArgs...)->ReturnType> function,
                std_cxx20::type_identity_t<FunctionArgs> &&...arguments)
   {
     return MutableBind<ReturnType, FunctionArgs...>(function,
@@ -320,7 +320,7 @@ namespace Utilities
 
   template <typename ReturnType, class... FunctionArgs>
   MutableBind<ReturnType, FunctionArgs...>
-  mutable_bind(std::function<ReturnType(FunctionArgs...)> function)
+  mutable_bind(std::function<auto(FunctionArgs...)->ReturnType> function)
   {
     return MutableBind<ReturnType, FunctionArgs...>(function);
   }

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -1184,8 +1184,8 @@ public:
    *  ParameterHandler::parse_input() for more information.
    */
   void
-  add_action(const std::string                                   &entry,
-             const std::function<void(const std::string &value)> &action,
+  add_action(const std::string                                         &entry,
+             const std::function<auto(const std::string &value)->void> &action,
              const bool execute_action = true);
 
   /**
@@ -1841,7 +1841,7 @@ private:
    * tree corresponding to individual parameters
    * store indices into this array in order to reference specific actions.
    */
-  std::vector<std::function<void(const std::string &)>> actions;
+  std::vector<std::function<auto(const std::string &)->void>> actions;
 
   /**
    * Scan one line of input. <tt>input_filename</tt> and

--- a/include/deal.II/base/parsed_convergence_table.h
+++ b/include/deal.II/base/parsed_convergence_table.h
@@ -343,9 +343,9 @@ public:
    * key in the parameter file.
    */
   void
-  add_extra_column(const std::string             &column_name,
-                   const std::function<double()> &custom_function,
-                   const bool                     compute_rate = true);
+  add_extra_column(const std::string                   &column_name,
+                   const std::function<auto()->double> &custom_function,
+                   const bool                           compute_rate = true);
 
   /**
    * Difference between two solutions in the same vector space.
@@ -410,7 +410,7 @@ private:
   /**
    * Additional methods to call when adding rows to the table.
    */
-  std::map<std::string, std::pair<std::function<double()>, bool>>
+  std::map<std::string, std::pair<std::function<auto()->double>, bool>>
     extra_column_functions;
 
   /**
@@ -558,12 +558,12 @@ ParsedConvergenceTable::error_from_exact(const Mapping<dim, spacedim> &mapping,
           }
 
       // A vector of zero std::functions with n_components components
-      const std::vector<std::function<double(const Point<spacedim> &)>>
+      const std::vector<std::function<auto(const Point<spacedim> &)->double>>
         zero_components(n_components,
                         [](const Point<spacedim> &) { return 0.0; });
 
       // The default weight function, with n_components components
-      std::vector<std::function<double(const Point<spacedim> &)>>
+      std::vector<std::function<auto(const Point<spacedim> &)->double>>
         weight_components(n_components,
                           [](const Point<spacedim> &) { return 1.0; });
 

--- a/include/deal.II/base/scope_exit.h
+++ b/include/deal.II/base/scope_exit.h
@@ -137,7 +137,7 @@ public:
    * Constructor. Takes a function object that is to be executed at the
    * place where the current object goes out of scope as argument.
    */
-  explicit ScopeExit(const std::function<void()> &exit_function);
+  explicit ScopeExit(const std::function<auto()->void> &exit_function);
 
   /**
    * Copy constructor. These kinds of objects cannot be copied, so the
@@ -161,12 +161,12 @@ private:
   /**
    * A copy of the function to be executed.
    */
-  const std::function<void()> exit_function;
+  const std::function<auto()->void> exit_function;
 };
 
 
 
-inline ScopeExit::ScopeExit(const std::function<void()> &exit_function)
+inline ScopeExit::ScopeExit(const std::function<auto()->void> &exit_function)
   : exit_function(exit_function)
 {}
 

--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -499,7 +499,7 @@ namespace Threads
      * @post Using this constructor automatically makes the task object
      * joinable().
      */
-    Task(const std::function<RT()> &function_object)
+    Task(const std::function<auto()->RT> &function_object)
     {
       if (MultithreadInfo::n_threads() > 1)
         {
@@ -1150,7 +1150,7 @@ namespace Threads
    */
   template <typename RT>
   inline Task<RT>
-  new_task(const std::function<RT()> &function)
+  new_task(const std::function<auto()->RT> &function)
   {
     return Task<RT>(function);
   }
@@ -1334,7 +1334,7 @@ namespace Threads
            std_cxx20::type_identity_t<Args>... args)
   {
     // NOLINTNEXTLINE(modernize-avoid-bind) silence clang-tidy
-    return new_task(std::function<RT()>(std::bind(
+    return new_task(std::function<auto()->RT>(std::bind(
       fun_ptr, std::ref(c), internal::maybe_make_ref<Args>::act(args)...)));
   }
 
@@ -1351,7 +1351,7 @@ namespace Threads
            std_cxx20::type_identity_t<Args>... args)
   {
     // NOLINTNEXTLINE(modernize-avoid-bind) silence clang-tidy
-    return new_task(std::function<RT()>(std::bind(
+    return new_task(std::function<auto()->RT>(std::bind(
       fun_ptr, std::cref(c), internal::maybe_make_ref<Args>::act(args)...)));
   }
 

--- a/include/deal.II/base/time_stepping.h
+++ b/include/deal.II/base/time_stepping.h
@@ -191,8 +191,8 @@ namespace TimeStepping
      */
     virtual double
     evolve_one_time_step(
-      std::vector<std::function<VectorType(const double, const VectorType &)>>
-                                                                     &F,
+      std::vector<
+        std::function<auto(const double, const VectorType &)->VectorType>> &F,
       std::vector<std::function<
         VectorType(const double, const double, const VectorType &)>> &J_inverse,
       double                                                          t,
@@ -245,8 +245,8 @@ namespace TimeStepping
      */
     double
     evolve_one_time_step(
-      std::vector<std::function<VectorType(const double, const VectorType &)>>
-                                                                     &F,
+      std::vector<
+        std::function<auto(const double, const VectorType &)->VectorType>> &F,
       std::vector<std::function<
         VectorType(const double, const double, const VectorType &)>> &J_inverse,
       double                                                          t,
@@ -266,7 +266,8 @@ namespace TimeStepping
      */
     virtual double
     evolve_one_time_step(
-      const std::function<VectorType(const double, const VectorType &)> &f,
+      const std::function<auto(const double, const VectorType &)->VectorType>
+        &f,
       const std::function<
         VectorType(const double, const double, const VectorType &)>
                  &id_minus_tau_J_inverse,
@@ -341,7 +342,8 @@ namespace TimeStepping
      */
     double
     evolve_one_time_step(
-      const std::function<VectorType(const double, const VectorType &)> &f,
+      const std::function<auto(const double, const VectorType &)->VectorType>
+        &f,
       const std::function<
         VectorType(const double, const double, const VectorType &)>
                  &id_minus_tau_J_inverse,
@@ -358,8 +360,9 @@ namespace TimeStepping
      */
     double
     evolve_one_time_step(
-      const std::function<VectorType(const double, const VectorType &)> &f,
-      double                                                             t,
+      const std::function<auto(const double, const VectorType &)->VectorType>
+                 &f,
+      double      t,
       double      delta_t,
       VectorType &y);
 
@@ -387,8 +390,9 @@ namespace TimeStepping
      */
     void
     compute_stages(
-      const std::function<VectorType(const double, const VectorType &)> &f,
-      const double                                                       t,
+      const std::function<auto(const double, const VectorType &)->VectorType>
+                              &f,
+      const double             t,
       const double             delta_t,
       const VectorType        &y,
       std::vector<VectorType> &f_stages) const;
@@ -443,7 +447,8 @@ namespace TimeStepping
      */
     double
     evolve_one_time_step(
-      const std::function<VectorType(const double, const VectorType &)> &f,
+      const std::function<auto(const double, const VectorType &)->VectorType>
+        &f,
       const std::function<
         VectorType(const double, const double, const VectorType &)>
                  &id_minus_tau_J_inverse,
@@ -462,8 +467,9 @@ namespace TimeStepping
      */
     double
     evolve_one_time_step(
-      const std::function<VectorType(const double, const VectorType &)> &f,
-      double                                                             t,
+      const std::function<auto(const double, const VectorType &)->VectorType>
+                 &f,
+      double      t,
       double      delta_t,
       VectorType &solution,
       VectorType &vec_ri,
@@ -504,8 +510,9 @@ namespace TimeStepping
      */
     void
     compute_one_stage(
-      const std::function<VectorType(const double, const VectorType &)> &f,
-      const double                                                       t,
+      const std::function<auto(const double, const VectorType &)->VectorType>
+                       &f,
+      const double      t,
       const double      factor_solution,
       const double      factor_ai,
       const VectorType &current_ri,
@@ -566,7 +573,8 @@ namespace TimeStepping
      */
     double
     evolve_one_time_step(
-      const std::function<VectorType(const double, const VectorType &)> &f,
+      const std::function<auto(const double, const VectorType &)->VectorType>
+        &f,
       const std::function<
         VectorType(const double, const double, const VectorType &)>
                  &id_minus_tau_J_inverse,
@@ -611,7 +619,8 @@ namespace TimeStepping
      */
     void
     compute_stages(
-      const std::function<VectorType(const double, const VectorType &)> &f,
+      const std::function<auto(const double, const VectorType &)->VectorType>
+        &f,
       const std::function<
         VectorType(const double, const double, const VectorType &)>
                               &id_minus_tau_J_inverse,
@@ -625,8 +634,9 @@ namespace TimeStepping
      */
     void
     newton_solve(
-      const std::function<void(const VectorType &, VectorType &)> &get_residual,
-      const std::function<VectorType(const VectorType &)>
+      const std::function<auto(const VectorType &, VectorType &)->void>
+        &get_residual,
+      const std::function<auto(const VectorType &)->VectorType>
                  &id_minus_tau_J_inverse,
       VectorType &y);
 
@@ -635,8 +645,9 @@ namespace TimeStepping
      */
     void
     compute_residual(
-      const std::function<VectorType(const double, const VectorType &)> &f,
-      double                                                             t,
+      const std::function<auto(const double, const VectorType &)->VectorType>
+                       &f,
+      double            t,
       double            delta_t,
       const VectorType &new_y,
       const VectorType &y,
@@ -725,7 +736,8 @@ namespace TimeStepping
      */
     double
     evolve_one_time_step(
-      const std::function<VectorType(const double, const VectorType &)> &f,
+      const std::function<auto(const double, const VectorType &)->VectorType>
+        &f,
       const std::function<
         VectorType(const double, const double, const VectorType &)>
                  &id_minus_tau_J_inverse,
@@ -742,8 +754,9 @@ namespace TimeStepping
      */
     double
     evolve_one_time_step(
-      const std::function<VectorType(const double, const VectorType &)> &f,
-      double                                                             t,
+      const std::function<auto(const double, const VectorType &)->VectorType>
+                 &f,
+      double      t,
       double      delta_t,
       VectorType &y);
 
@@ -789,8 +802,9 @@ namespace TimeStepping
      */
     void
     compute_stages(
-      const std::function<VectorType(const double, const VectorType &)> &f,
-      const double                                                       t,
+      const std::function<auto(const double, const VectorType &)->VectorType>
+                              &f,
+      const double             t,
       const double             delta_t,
       const VectorType        &y,
       std::vector<VectorType> &f_stages);

--- a/include/deal.II/base/time_stepping.templates.h
+++ b/include/deal.II/base/time_stepping.templates.h
@@ -37,9 +37,10 @@ namespace TimeStepping
   template <typename VectorType>
   double
   RungeKutta<VectorType>::evolve_one_time_step(
-    std::vector<std::function<VectorType(const double, const VectorType &)>> &F,
     std::vector<
-      std::function<VectorType(const double, const double, const VectorType &)>>
+      std::function<auto(const double, const VectorType &)->VectorType>> &F,
+    std::vector<std::function<
+      auto(const double, const double, const VectorType &)->VectorType>>
       &J_inverse,
 
     double      t,
@@ -180,7 +181,7 @@ namespace TimeStepping
   template <typename VectorType>
   double
   ExplicitRungeKutta<VectorType>::evolve_one_time_step(
-    const std::function<VectorType(const double, const VectorType &)> &f,
+    const std::function<auto(const double, const VectorType &)->VectorType> &f,
     const std::function<
       VectorType(const double, const double, const VectorType &)>
       & /*id_minus_tau_J_inverse*/,
@@ -196,10 +197,10 @@ namespace TimeStepping
   template <typename VectorType>
   double
   ExplicitRungeKutta<VectorType>::evolve_one_time_step(
-    const std::function<VectorType(const double, const VectorType &)> &f,
-    double                                                             t,
-    double                                                             delta_t,
-    VectorType                                                        &y)
+    const std::function<auto(const double, const VectorType &)->VectorType> &f,
+    double                                                                   t,
+    double      delta_t,
+    VectorType &y)
   {
     Assert(status.method != runge_kutta_method::invalid, ExcNoMethodSelected());
 
@@ -228,10 +229,10 @@ namespace TimeStepping
   template <typename VectorType>
   void
   ExplicitRungeKutta<VectorType>::compute_stages(
-    const std::function<VectorType(const double, const VectorType &)> &f,
-    const double                                                       t,
-    const double                                                       delta_t,
-    const VectorType                                                  &y,
+    const std::function<auto(const double, const VectorType &)->VectorType> &f,
+    const double                                                             t,
+    const double             delta_t,
+    const VectorType        &y,
     std::vector<VectorType> &f_stages) const
   {
     for (unsigned int i = 0; i < this->n_stages; ++i)
@@ -367,7 +368,7 @@ namespace TimeStepping
   template <typename VectorType>
   double
   LowStorageRungeKutta<VectorType>::evolve_one_time_step(
-    const std::function<VectorType(const double, const VectorType &)> &f,
+    const std::function<auto(const double, const VectorType &)->VectorType> &f,
     const std::function<
       VectorType(const double, const double, const VectorType &)>
       & /*id_minus_tau_J_inverse*/,
@@ -388,12 +389,12 @@ namespace TimeStepping
   template <typename VectorType>
   double
   LowStorageRungeKutta<VectorType>::evolve_one_time_step(
-    const std::function<VectorType(const double, const VectorType &)> &f,
-    double                                                             t,
-    double                                                             delta_t,
-    VectorType                                                        &solution,
-    VectorType                                                        &vec_ri,
-    VectorType                                                        &vec_ki)
+    const std::function<auto(const double, const VectorType &)->VectorType> &f,
+    double                                                                   t,
+    double      delta_t,
+    VectorType &solution,
+    VectorType &vec_ri,
+    VectorType &vec_ki)
   {
     Assert(status.method != runge_kutta_method::invalid, ExcNoMethodSelected());
 
@@ -450,8 +451,8 @@ namespace TimeStepping
   template <typename VectorType>
   void
   LowStorageRungeKutta<VectorType>::compute_one_stage(
-    const std::function<VectorType(const double, const VectorType &)> &f,
-    const double                                                       t,
+    const std::function<auto(const double, const VectorType &)->VectorType> &f,
+    const double                                                             t,
     const double      factor_solution,
     const double      factor_ai,
     const VectorType &current_ri,
@@ -565,7 +566,7 @@ namespace TimeStepping
   template <typename VectorType>
   double
   ImplicitRungeKutta<VectorType>::evolve_one_time_step(
-    const std::function<VectorType(const double, const VectorType &)> &f,
+    const std::function<auto(const double, const VectorType &)->VectorType> &f,
     const std::function<VectorType(const double,
                                    const double,
                                    const VectorType &)> &id_minus_tau_J_inverse,
@@ -613,7 +614,7 @@ namespace TimeStepping
   template <typename VectorType>
   void
   ImplicitRungeKutta<VectorType>::compute_stages(
-    const std::function<VectorType(const double, const VectorType &)> &f,
+    const std::function<auto(const double, const VectorType &)->VectorType> &f,
     const std::function<VectorType(const double,
                                    const double,
                                    const VectorType &)> &id_minus_tau_J_inverse,
@@ -651,9 +652,11 @@ namespace TimeStepping
   template <typename VectorType>
   void
   ImplicitRungeKutta<VectorType>::newton_solve(
-    const std::function<void(const VectorType &, VectorType &)> &get_residual,
-    const std::function<VectorType(const VectorType &)> &id_minus_tau_J_inverse,
-    VectorType                                          &y)
+    const std::function<auto(const VectorType &, VectorType &)->void>
+      &get_residual,
+    const std::function<auto(const VectorType &)->VectorType>
+               &id_minus_tau_J_inverse,
+    VectorType &y)
   {
     VectorType residual(y);
     get_residual(y, residual);
@@ -678,13 +681,13 @@ namespace TimeStepping
   template <typename VectorType>
   void
   ImplicitRungeKutta<VectorType>::compute_residual(
-    const std::function<VectorType(const double, const VectorType &)> &f,
-    double                                                             t,
-    double                                                             delta_t,
-    const VectorType                                                  &old_y,
-    const VectorType                                                  &y,
-    VectorType                                                        &tendency,
-    VectorType &residual) const
+    const std::function<auto(const double, const VectorType &)->VectorType> &f,
+    double                                                                   t,
+    double            delta_t,
+    const VectorType &old_y,
+    const VectorType &y,
+    VectorType       &tendency,
+    VectorType       &residual) const
   {
     // The tendency is stored to save one evaluation of f.
     tendency = f(t, y);
@@ -984,7 +987,7 @@ namespace TimeStepping
   template <typename VectorType>
   double
   EmbeddedExplicitRungeKutta<VectorType>::evolve_one_time_step(
-    const std::function<VectorType(const double, const VectorType &)> &f,
+    const std::function<auto(const double, const VectorType &)->VectorType> &f,
     const std::function<
       VectorType(const double, const double, const VectorType &)>
       & /*id_minus_tau_J_inverse*/,
@@ -1000,10 +1003,10 @@ namespace TimeStepping
   template <typename VectorType>
   double
   EmbeddedExplicitRungeKutta<VectorType>::evolve_one_time_step(
-    const std::function<VectorType(const double, const VectorType &)> &f,
-    double                                                             t,
-    double                                                             delta_t,
-    VectorType                                                        &y)
+    const std::function<auto(const double, const VectorType &)->VectorType> &f,
+    double                                                                   t,
+    double      delta_t,
+    VectorType &y)
   {
     Assert(status.method != runge_kutta_method::invalid, ExcNoMethodSelected());
 
@@ -1123,11 +1126,11 @@ namespace TimeStepping
   template <typename VectorType>
   void
   EmbeddedExplicitRungeKutta<VectorType>::compute_stages(
-    const std::function<VectorType(const double, const VectorType &)> &f,
-    const double                                                       t,
-    const double                                                       delta_t,
-    const VectorType                                                  &y,
-    std::vector<VectorType>                                           &f_stages)
+    const std::function<auto(const double, const VectorType &)->VectorType> &f,
+    const double                                                             t,
+    const double             delta_t,
+    const VectorType        &y,
+    std::vector<VectorType> &f_stages)
   {
     VectorType   Y(y);
     unsigned int i = 0;

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -1463,9 +1463,9 @@ namespace GridTools
   DEAL_II_CXX20_REQUIRES(concepts::is_triangulation_or_dof_handler<MeshType>)
   std::
     vector<typename MeshType::active_cell_iterator> compute_active_cell_halo_layer(
-      const MeshType &mesh,
-      const std::function<bool(const typename MeshType::active_cell_iterator &)>
-        &predicate);
+      const MeshType                &mesh,
+      const std::function<auto(const typename MeshType::active_cell_iterator &)
+                            ->bool> &predicate);
 
 
   /**
@@ -1482,7 +1482,7 @@ namespace GridTools
   std::
     vector<typename MeshType::cell_iterator> compute_cell_halo_layer_on_level(
       const MeshType &mesh,
-      const std::function<bool(const typename MeshType::cell_iterator &)>
+      const std::function<auto(const typename MeshType::cell_iterator &)->bool>
                         &predicate,
       const unsigned int level);
 
@@ -1562,8 +1562,8 @@ namespace GridTools
   std::
     vector<typename MeshType::active_cell_iterator> compute_active_cell_layer_within_distance(
       const MeshType &mesh,
-      const std::function<bool(const typename MeshType::active_cell_iterator &)>
-                  &predicate,
+      const std::function<
+        auto(const typename MeshType::active_cell_iterator &)->bool> &predicate,
       const double layer_thickness);
 
   /**
@@ -1674,8 +1674,8 @@ namespace GridTools
   std::
     vector<BoundingBox<MeshType::space_dimension>> compute_mesh_predicate_bounding_box(
       const MeshType &mesh,
-      const std::function<bool(const typename MeshType::active_cell_iterator &)>
-                        &predicate,
+      const std::function<
+        auto(const typename MeshType::active_cell_iterator &)->bool> &predicate,
       const unsigned int refinement_level = 0,
       const bool         allow_merge      = false,
       const unsigned int max_boxes        = numbers::invalid_unsigned_int);
@@ -2716,9 +2716,9 @@ namespace GridTools
       const typename MeshType::active_cell_iterator &)> &pack,
     const std::function<void(const typename MeshType::active_cell_iterator &,
                              const DataType &)>         &unpack,
-    const std::function<bool(const typename MeshType::active_cell_iterator &)>
-      &cell_filter =
-        always_return<typename MeshType::active_cell_iterator, bool>{true});
+    const std::function<auto(const typename MeshType::active_cell_iterator &)
+                          ->bool>                       &cell_filter =
+      always_return<typename MeshType::active_cell_iterator, bool>{true});
 
   /**
    * Exchange arbitrary data of type @p DataType provided by the function
@@ -2740,9 +2740,9 @@ namespace GridTools
       const typename MeshType::level_cell_iterator &)> &pack,
     const std::function<void(const typename MeshType::level_cell_iterator &,
                              const DataType &)>        &unpack,
-    const std::function<bool(const typename MeshType::level_cell_iterator &)> &
-      cell_filter = always_return<typename MeshType::level_cell_iterator, bool>{
-        true});
+    const std::function<
+      auto(const typename MeshType::level_cell_iterator &)->bool> &cell_filter =
+      always_return<typename MeshType::level_cell_iterator, bool>{true});
 
   /* Exchange with all processors of the MPI communicator @p mpi_communicator the vector of bounding
    * boxes @p local_bboxes.
@@ -3311,9 +3311,10 @@ namespace GridTools
       const MeshType &mesh,
       const std::function<std::optional<DataType>(const MeshCellIteratorType &)>
         &pack,
-      const std::function<void(const MeshCellIteratorType &, const DataType &)>
-                                                                 &unpack,
-      const std::function<bool(const MeshCellIteratorType &)>    &cell_filter,
+      const std::function<
+        auto(const MeshCellIteratorType &, const DataType &)->void> &unpack,
+      const std::function<auto(const MeshCellIteratorType &)->bool>
+                                                                 &cell_filter,
       const std::function<void(
         const std::function<void(const MeshCellIteratorType &,
                                  const types::subdomain_id)> &)> &process_cells,
@@ -3608,8 +3609,8 @@ namespace GridTools
       const typename MeshType::active_cell_iterator &)> &pack,
     const std::function<void(const typename MeshType::active_cell_iterator &,
                              const DataType &)>         &unpack,
-    const std::function<bool(const typename MeshType::active_cell_iterator &)>
-      &cell_filter)
+    const std::function<
+      auto(const typename MeshType::active_cell_iterator &)->bool> &cell_filter)
   {
 #  ifndef DEAL_II_WITH_MPI
     (void)mesh;
@@ -3644,8 +3645,8 @@ namespace GridTools
       const typename MeshType::level_cell_iterator &)> &pack,
     const std::function<void(const typename MeshType::level_cell_iterator &,
                              const DataType &)>        &unpack,
-    const std::function<bool(const typename MeshType::level_cell_iterator &)>
-      &cell_filter)
+    const std::function<
+      auto(const typename MeshType::level_cell_iterator &)->bool> &cell_filter)
   {
 #  ifndef DEAL_II_WITH_MPI
     (void)mesh;

--- a/include/deal.II/grid/tria_description.h
+++ b/include/deal.II/grid/tria_description.h
@@ -696,7 +696,7 @@ namespace TriangulationDescription
     template <int dim, int spacedim = dim>
     Description<dim, spacedim>
     create_description_from_triangulation_in_groups(
-      const std::function<void(dealii::Triangulation<dim, spacedim> &)>
+      const std::function<auto(dealii::Triangulation<dim, spacedim> &)->void>
                                                     &serial_grid_generator,
       const std::function<void(dealii::Triangulation<dim, spacedim> &,
                                const MPI_Comm,

--- a/include/deal.II/hp/refinement.h
+++ b/include/deal.II/hp/refinement.h
@@ -139,7 +139,7 @@ namespace hp
      */
     template <typename Number>
     using ComparisonFunction =
-      std::function<bool(const Number &, const Number &)>;
+      std::function<auto(const Number &, const Number &)->bool>;
 
     /**
      * @name Setting p-adaptivity flags

--- a/include/deal.II/lac/block_linear_operator.h
+++ b/include/deal.II/lac/block_linear_operator.h
@@ -101,7 +101,7 @@ block_diagonal_operator(
  * @code
  *   std::function<unsigned int()> n_block_rows;
  *   std::function<unsigned int()> n_block_cols;
- *   std::function<BlockType(unsigned int, unsigned int)> block;
+ *   std::function<auto (unsigned int, unsigned int) -> BlockType> block;
  * @endcode
  * that describe the underlying block structure (of an otherwise opaque)
  * linear operator.
@@ -306,7 +306,7 @@ public:
    * <code>std::function</code> object returns a LinearOperator representing
    * the $(i,j)$-th block of the BlockLinearOperator.
    */
-  std::function<BlockType(unsigned int, unsigned int)> block;
+  std::function<auto(unsigned int, unsigned int)->BlockType> block;
 };
 
 

--- a/include/deal.II/lac/linear_operator.h
+++ b/include/deal.II/lac/linear_operator.h
@@ -85,10 +85,10 @@ identity_operator(const LinearOperator<Range, Domain, Payload> &);
  * store the knowledge of how to apply the linear operator by implementing the
  * abstract @p Matrix interface:
  * @code
- *   std::function<void(Range &, const Domain &)> vmult;
- *   std::function<void(Range &, const Domain &)> vmult_add;
- *   std::function<void(Domain &, const Range &)> Tvmult;
- *   std::function<void(Domain &, const Range &)> Tvmult_add;
+ *   std::function<auto (Range &, const Domain &) -> void> vmult;
+ *   std::function<auto (Range &, const Domain &) -> void> vmult_add;
+ *   std::function<auto (Domain &, const Range &) -> void> Tvmult;
+ *   std::function<auto (Domain &, const Range &) -> void> Tvmult_add;
  * @endcode
  *
  * But, in contrast to a usual matrix object, the domain and range of the
@@ -96,8 +96,8 @@ identity_operator(const LinearOperator<Range, Domain, Payload> &);
  * level. Because of this, `LinearOperator<Range, Domain>` has two
  * additional function objects
  * @code
- *   std::function<void(Range &, bool)> reinit_range_vector;
- *   std::function<void(Domain &, bool)> reinit_domain_vector;
+ *   std::function<auto (Range &, bool) -> void> reinit_range_vector;
+ *   std::function<auto (Domain &, bool) -> void> reinit_domain_vector;
  * @endcode
  * that store the knowledge how to initialize (resize + internal data
  * structures) an arbitrary vector of the @p Range and @p Domain space.
@@ -291,25 +291,25 @@ public:
    * Application of the LinearOperator object to a vector u of the @p Domain
    * space giving a vector v of the @p Range space.
    */
-  std::function<void(Range &v, const Domain &u)> vmult;
+  std::function<auto(Range &v, const Domain &u)->void> vmult;
 
   /**
    * Application of the LinearOperator object to a vector u of the @p Domain
    * space. The result is added to the vector v.
    */
-  std::function<void(Range &v, const Domain &u)> vmult_add;
+  std::function<auto(Range &v, const Domain &u)->void> vmult_add;
 
   /**
    * Application of the transpose LinearOperator object to a vector u of the
    * @p Range space giving a vector v of the @p Domain space.
    */
-  std::function<void(Domain &v, const Range &u)> Tvmult;
+  std::function<auto(Domain &v, const Range &u)->void> Tvmult;
 
   /**
    * Application of the transpose LinearOperator object to a vector @p u of
    * the @p Range space.The result is added to the vector @p v.
    */
-  std::function<void(Domain &v, const Range &u)> Tvmult_add;
+  std::function<auto(Domain &v, const Range &u)->void> Tvmult_add;
 
   /**
    * Initializes a vector v of the Range space to be directly usable as the
@@ -318,7 +318,8 @@ public:
    * initialization is done, i.e., if it is set to false the content of the
    * vector is set to 0.
    */
-  std::function<void(Range &v, bool omit_zeroing_entries)> reinit_range_vector;
+  std::function<auto(Range &v, bool omit_zeroing_entries)->void>
+    reinit_range_vector;
 
   /**
    * Initializes a vector of the Domain space to be directly usable as the
@@ -327,7 +328,7 @@ public:
    * initialization is done, i.e., if it is set to false the content of the
    * vector is set to 0.
    */
-  std::function<void(Domain &v, bool omit_zeroing_entries)>
+  std::function<auto(Domain &v, bool omit_zeroing_entries)->void>
     reinit_domain_vector;
 
   /**
@@ -882,7 +883,7 @@ template <
   typename Range,
   typename Payload = internal::LinearOperatorImplementation::EmptyPayload>
 LinearOperator<Range, Range, Payload>
-identity_operator(const std::function<void(Range &, bool)> &reinit_vector)
+identity_operator(const std::function<auto(Range &, bool)->void> &reinit_vector)
 {
   LinearOperator<Range, Range, Payload> return_op{Payload()};
 
@@ -972,7 +973,7 @@ template <
   typename Range,
   typename Payload = internal::LinearOperatorImplementation::EmptyPayload>
 LinearOperator<Range, Range, Payload>
-mean_value_filter(const std::function<void(Range &, bool)> &reinit_vector)
+mean_value_filter(const std::function<auto(Range &, bool)->void> &reinit_vector)
 {
   LinearOperator<Range, Range, Payload> return_op{Payload()};
 

--- a/include/deal.II/lac/packaged_operation.h
+++ b/include/deal.II/lac/packaged_operation.h
@@ -50,14 +50,14 @@ class PackagedOperation;
  * store the knowledge of how to generate the result of a computation and
  * store it in a vector:
  * @code
- *   std::function<void(Range &)> apply;
- *   std::function<void(Range &)> apply_add;
+ *   std::function<auto (Range &) -> void> apply;
+ *   std::function<auto (Range &) -> void> apply_add;
  * @endcode
  *
  * Similar to the LinearOperator class it also has knowledge about how to
  * initialize a vector of the @p Range space:
  * @code
- *   std::function<void(Range &, bool)> reinit_vector;
+ *   std::function<auto (Range &, bool) -> void> reinit_vector;
  * @endcode
  *
  * As an example consider the addition of multiple vectors
@@ -257,13 +257,13 @@ public:
    * Store the result of the PackagedOperation in a vector v of the @p Range
    * space.
    */
-  std::function<void(Range &v)> apply;
+  std::function<auto(Range &v)->void> apply;
 
   /**
    * Add the result of the PackagedOperation to a vector v of the @p Range
    * space.
    */
-  std::function<void(Range &v)> apply_add;
+  std::function<auto(Range &v)->void> apply_add;
 
   /**
    * Initializes a vector v of the Range space to be directly usable as the
@@ -272,7 +272,7 @@ public:
    * whether a fast initialization is done, i.e., if it is set to false the
    * content of the vector is set to 0.
    */
-  std::function<void(Range &v, bool omit_zeroing_entries)> reinit_vector;
+  std::function<auto(Range &v, bool omit_zeroing_entries)->void> reinit_vector;
 };
 
 

--- a/include/deal.II/lac/petsc_precondition.h
+++ b/include/deal.II/lac/petsc_precondition.h
@@ -1112,7 +1112,7 @@ namespace PETScWrappers
      * See there for a description of how to deal with errors and other
      * requirements and conventions.
      */
-    std::function<void(VectorBase &dst, const VectorBase &src)> vmult;
+    std::function<auto(VectorBase &dst, const VectorBase &src)->void> vmult;
 
     /**
      * The callback for the transposed application of the preconditioner.
@@ -1122,7 +1122,7 @@ namespace PETScWrappers
      * See there for a description of how to deal with errors and other
      * requirements and conventions.
      */
-    std::function<void(VectorBase &dst, const VectorBase &src)> vmultT;
+    std::function<auto(VectorBase &dst, const VectorBase &src)->void> vmultT;
 
   protected:
     /**

--- a/include/deal.II/lac/petsc_snes.h
+++ b/include/deal.II/lac/petsc_snes.h
@@ -384,7 +384,7 @@ namespace PETScWrappers
      * See there for a description of how to deal with errors and other
      * requirements and conventions.
      */
-    std::function<void(const VectorType &x, VectorType &res)> residual;
+    std::function<auto(const VectorType &x, VectorType &res)->void> residual;
 
     /**
      * Callback for the computation of the Jacobian
@@ -395,7 +395,8 @@ namespace PETScWrappers
      * See there for a description of how to deal with errors and other
      * requirements and conventions.
      */
-    std::function<void(const VectorType &x, AMatrixType &A, PMatrixType &P)>
+    std::function<
+      auto(const VectorType &x, AMatrixType &A, PMatrixType &P)->void>
       jacobian;
 
     /**
@@ -428,7 +429,7 @@ namespace PETScWrappers
      * See there for a description of how to deal with errors and other
      * requirements and conventions.
      */
-    std::function<void(const VectorType &x)> setup_jacobian;
+    std::function<auto(const VectorType &x)->void> setup_jacobian;
 
     /**
      * Callback for the solution of the tangent system set up with
@@ -441,7 +442,7 @@ namespace PETScWrappers
      * See there for a description of how to deal with errors and other
      * requirements and conventions.
      */
-    std::function<void(const VectorType &src, VectorType &dst)>
+    std::function<auto(const VectorType &src, VectorType &dst)->void>
       solve_with_jacobian;
 
     /**
@@ -461,7 +462,8 @@ namespace PETScWrappers
      * See there for a description of how to deal with errors and other
      * requirements and conventions.
      */
-    std::function<void(const VectorType &x, real_type &energy_value)> energy;
+    std::function<auto(const VectorType &x, real_type &energy_value)->void>
+      energy;
 
   private:
     /**

--- a/include/deal.II/lac/petsc_snes.templates.h
+++ b/include/deal.II/lac/petsc_snes.templates.h
@@ -71,9 +71,9 @@ namespace PETScWrappers
   template <typename F, typename... Args>
   int
   call_and_possibly_capture_snes_exception(
-    const F                     &f,
-    std::exception_ptr          &eptr,
-    const std::function<void()> &recoverable_action,
+    const F                           &f,
+    std::exception_ptr                &eptr,
+    const std::function<auto()->void> &recoverable_action,
     Args &&...args)
   {
     // See whether there is already something in the exception pointer

--- a/include/deal.II/lac/petsc_ts.h
+++ b/include/deal.II/lac/petsc_ts.h
@@ -508,7 +508,8 @@ namespace PETScWrappers
      * See there for a description of how to deal with errors and other
      * requirements and conventions.
      */
-    std::function<void(const real_type t, const VectorType &y, VectorType &res)>
+    std::function<
+      auto(const real_type t, const VectorType &y, VectorType &res)->void>
       explicit_function;
 
     /**
@@ -578,7 +579,7 @@ namespace PETScWrappers
      * See there for a description of how to deal with errors and other
      * requirements and conventions.
      */
-    std::function<void(const VectorType &src, VectorType &dst)>
+    std::function<auto(const VectorType &src, VectorType &dst)->void>
       solve_with_jacobian;
 
     /**
@@ -611,14 +612,14 @@ namespace PETScWrappers
      * See there for a description of how to deal with errors and other
      * requirements and conventions.
      */
-    std::function<IndexSet()> algebraic_components;
+    std::function<auto()->IndexSet> algebraic_components;
 
     /**
      * @deprecated This callback is equivalent to `update_constrained_components`, but is
      * deprecated. Use `update_constrained_components` instead.
      */
     DEAL_II_DEPRECATED
-    std::function<void(const real_type t, VectorType &y)> distribute;
+    std::function<auto(const real_type t, VectorType &y)->void> distribute;
 
     /**
      * Callback to set the values of constrained components to their correct
@@ -638,7 +639,7 @@ namespace PETScWrappers
      * See there for a description of how to deal with errors and other
      * requirements and conventions.
      */
-    std::function<void(const real_type t, VectorType &y)>
+    std::function<auto(const real_type t, VectorType &y)->void>
       update_constrained_components;
 
     /**

--- a/include/deal.II/lac/petsc_ts.templates.h
+++ b/include/deal.II/lac/petsc_ts.templates.h
@@ -71,9 +71,9 @@ namespace PETScWrappers
   template <typename F, typename... Args>
   int
   call_and_possibly_capture_ts_exception(
-    const F                     &f,
-    std::exception_ptr          &eptr,
-    const std::function<void()> &recoverable_action,
+    const F                           &f,
+    std::exception_ptr                &eptr,
+    const std::function<auto()->void> &recoverable_action,
     Args &&...args)
   {
     // See whether there is already something in the exception pointer

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -715,10 +715,10 @@ namespace internal
   using vmult_functions_t = decltype(std::declval<const MatrixType>().vmult(
     std::declval<VectorType &>(),
     std::declval<const VectorType &>(),
-    std::declval<
-      const std::function<void(const unsigned int, const unsigned int)> &>(),
-    std::declval<
-      const std::function<void(const unsigned int, const unsigned int)> &>()));
+    std::declval<const std::function<
+      auto(const unsigned int, const unsigned int)->void> &>(),
+    std::declval<const std::function<
+      auto(const unsigned int, const unsigned int)->void> &>()));
 
   template <typename MatrixType,
             typename VectorType,
@@ -2046,8 +2046,9 @@ public:
  * void MatrixType::vmult(
  *    VectorType &,
  *    const VectorType &,
- *    const std::function<void(const unsigned int, const unsigned int)> &,
- *    const std::function<void(const unsigned int, const unsigned int)> &) const
+ *    const std::function<auto (const unsigned int, const unsigned int) -> void>
+ * &, const std::function<auto (const unsigned int, const unsigned int) -> void>
+ * &) const
  * @endcode
  * where the two given functions run before and after the matrix-vector
  * product, respectively. They take as arguments a sub-range among the locally
@@ -2070,9 +2071,9 @@ public:
  * void
  * vmult(LinearAlgebra::distributed::Vector<number> &      dst,
  *       const LinearAlgebra::distributed::Vector<number> &src,
- *       const std::function<void(const unsigned int, const unsigned int)>
- *         &operation_before_matrix_vector_product,
- *       const std::function<void(const unsigned int, const unsigned int)>
+ *       const std::function<auto (const unsigned int, const unsigned int) ->
+ * void> &operation_before_matrix_vector_product, const std::function<auto
+ * (const unsigned int, const unsigned int) -> void>
  *         &operation_after_matrix_vector_product) const
  * {
  *   data.cell_loop(&LaplaceOperator::local_apply,

--- a/include/deal.II/lac/solver_cg.h
+++ b/include/deal.II/lac/solver_cg.h
@@ -115,8 +115,9 @@ namespace LinearAlgebra
  * void MatrixType::vmult(
  *    VectorType &,
  *    const VectorType &,
- *    const std::function<void(const unsigned int, const unsigned int)> &,
- *    const std::function<void(const unsigned int, const unsigned int)> &) const
+ *    const std::function<auto (const unsigned int, const unsigned int) -> void>
+ * &, const std::function<auto (const unsigned int, const unsigned int) -> void>
+ * &) const
  * @endcode
  * where the two given functions run before and after the matrix-vector
  * product, respectively, and the `PreconditionerType` needs to provide a
@@ -155,9 +156,9 @@ namespace LinearAlgebra
  * void
  * vmult(LinearAlgebra::distributed::Vector<number> &      dst,
  *       const LinearAlgebra::distributed::Vector<number> &src,
- *       const std::function<void(const unsigned int, const unsigned int)>
- *         &operation_before_matrix_vector_product,
- *       const std::function<void(const unsigned int, const unsigned int)>
+ *       const std::function<auto (const unsigned int, const unsigned int) ->
+ * void> &operation_before_matrix_vector_product, const std::function<auto
+ * (const unsigned int, const unsigned int) -> void>
  *         &operation_after_matrix_vector_product) const
  * {
  *   data.cell_loop(&LaplaceOperator::local_apply,
@@ -278,7 +279,7 @@ public:
    * divergence has been detected).
    */
   boost::signals2::connection
-  connect_condition_number_slot(const std::function<void(double)> &slot,
+  connect_condition_number_slot(const std::function<auto(double)->void> &slot,
                                 const bool every_iteration = false);
 
   /**
@@ -289,7 +290,7 @@ public:
    */
   boost::signals2::connection
   connect_eigenvalues_slot(
-    const std::function<void(const std::vector<double> &)> &slot,
+    const std::function<auto(const std::vector<double> &)->void> &slot,
     const bool every_iteration = false);
 
 protected:
@@ -779,8 +780,8 @@ namespace internal
     using vmult_functions_t = decltype(std::declval<const MatrixType>().vmult(
       std::declval<VectorType &>(),
       std::declval<const VectorType &>(),
-      std::declval<
-        const std::function<void(const unsigned int, const unsigned int)> &>(),
+      std::declval<const std::function<
+        auto(const unsigned int, const unsigned int)->void> &>(),
       std::declval<const std::function<void(const unsigned int,
                                             const unsigned int)> &>()));
 
@@ -1485,8 +1486,8 @@ boost::signals2::connection SolverCG<VectorType>::connect_coefficients_slot(
 template <typename VectorType>
 DEAL_II_CXX20_REQUIRES(concepts::is_vector_space_vector<VectorType>)
 boost::signals2::connection SolverCG<VectorType>::connect_condition_number_slot(
-  const std::function<void(double)> &slot,
-  const bool                         every_iteration)
+  const std::function<auto(double)->void> &slot,
+  const bool                               every_iteration)
 {
   if (every_iteration)
     {
@@ -1503,8 +1504,8 @@ boost::signals2::connection SolverCG<VectorType>::connect_condition_number_slot(
 template <typename VectorType>
 DEAL_II_CXX20_REQUIRES(concepts::is_vector_space_vector<VectorType>)
 boost::signals2::connection SolverCG<VectorType>::connect_eigenvalues_slot(
-  const std::function<void(const std::vector<double> &)> &slot,
-  const bool                                              every_iteration)
+  const std::function<auto(const std::vector<double> &)->void> &slot,
+  const bool                                                    every_iteration)
 {
   if (every_iteration)
     {

--- a/include/deal.II/lac/solver_fire.h
+++ b/include/deal.II/lac/solver_fire.h
@@ -147,8 +147,9 @@ public:
    */
   template <typename PreconditionerType = DiagonalMatrix<VectorType>>
   void
-  solve(const std::function<double(VectorType &, const VectorType &)> &compute,
-        VectorType                                                    &x,
+  solve(const std::function<auto(VectorType &, const VectorType &)->double>
+                                 &compute,
+        VectorType               &x,
         const PreconditionerType &inverse_mass_matrix);
 
   /**
@@ -234,8 +235,8 @@ template <typename VectorType>
 DEAL_II_CXX20_REQUIRES(concepts::is_vector_space_vector<VectorType>)
 template <typename PreconditionerType>
 void SolverFIRE<VectorType>::solve(
-  const std::function<double(VectorType &, const VectorType &)> &compute,
-  VectorType                                                    &x,
+  const std::function<auto(VectorType &, const VectorType &)->double> &compute,
+  VectorType                                                          &x,
   const PreconditionerType &inverse_mass_matrix)
 {
   LogStream::Prefix prefix("FIRE");
@@ -363,7 +364,7 @@ void SolverFIRE<VectorType>::solve(const MatrixType         &A,
                                    const VectorType         &b,
                                    const PreconditionerType &preconditioner)
 {
-  std::function<double(VectorType &, const VectorType &)> compute_func =
+  std::function<auto(VectorType &, const VectorType &)->double> compute_func =
     [&](VectorType &g, const VectorType &x) -> double {
     // Residual of the quadratic form $ \frac{1}{2} xAx - xb $.
     // G = b - Ax

--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -477,7 +477,7 @@ public:
    * or because divergence has been detected).
    */
   boost::signals2::connection
-  connect_condition_number_slot(const std::function<void(double)> &slot,
+  connect_condition_number_slot(const std::function<auto(double)->void> &slot,
                                 const bool every_iteration = false);
 
   /**
@@ -488,7 +488,8 @@ public:
    */
   boost::signals2::connection
   connect_eigenvalues_slot(
-    const std::function<void(const std::vector<std::complex<double>> &)> &slot,
+    const std::function<auto(const std::vector<std::complex<double>> &)->void>
+              &slot,
     const bool every_iteration = false);
 
   /**
@@ -500,7 +501,7 @@ public:
    */
   boost::signals2::connection
   connect_hessenberg_slot(
-    const std::function<void(const FullMatrix<double> &)> &slot,
+    const std::function<auto(const FullMatrix<double> &)->void> &slot,
     const bool every_iteration = true);
 
   /**
@@ -521,7 +522,7 @@ public:
    * re-orthogonalized.
    */
   boost::signals2::connection
-  connect_re_orthogonalization_slot(const std::function<void(int)> &slot);
+  connect_re_orthogonalization_slot(const std::function<auto(int)->void> &slot);
 
 
   DeclException1(ExcTooFewTmpVectors,
@@ -1874,8 +1875,8 @@ template <typename VectorType>
 DEAL_II_CXX20_REQUIRES(concepts::is_vector_space_vector<VectorType>)
 boost::signals2::connection
   SolverGMRES<VectorType>::connect_condition_number_slot(
-    const std::function<void(double)> &slot,
-    const bool                         every_iteration)
+    const std::function<auto(double)->void> &slot,
+    const bool                               every_iteration)
 {
   if (every_iteration)
     {
@@ -1892,7 +1893,8 @@ boost::signals2::connection
 template <typename VectorType>
 DEAL_II_CXX20_REQUIRES(concepts::is_vector_space_vector<VectorType>)
 boost::signals2::connection SolverGMRES<VectorType>::connect_eigenvalues_slot(
-  const std::function<void(const std::vector<std::complex<double>> &)> &slot,
+  const std::function<auto(const std::vector<std::complex<double>> &)->void>
+            &slot,
   const bool every_iteration)
 {
   if (every_iteration)
@@ -1910,8 +1912,8 @@ boost::signals2::connection SolverGMRES<VectorType>::connect_eigenvalues_slot(
 template <typename VectorType>
 DEAL_II_CXX20_REQUIRES(concepts::is_vector_space_vector<VectorType>)
 boost::signals2::connection SolverGMRES<VectorType>::connect_hessenberg_slot(
-  const std::function<void(const FullMatrix<double> &)> &slot,
-  const bool                                             every_iteration)
+  const std::function<auto(const FullMatrix<double> &)->void> &slot,
+  const bool                                                   every_iteration)
 {
   if (every_iteration)
     {
@@ -1940,7 +1942,7 @@ template <typename VectorType>
 DEAL_II_CXX20_REQUIRES(concepts::is_vector_space_vector<VectorType>)
 boost::signals2::connection
   SolverGMRES<VectorType>::connect_re_orthogonalization_slot(
-    const std::function<void(int)> &slot)
+    const std::function<auto(int)->void> &slot)
 {
   return re_orthogonalize_signal.connect(slot);
 }

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -2268,7 +2268,7 @@ namespace TrilinosWrappers
          * @note This is not called by a LinearOperator, but rather by Trilinos
          * functions that expect this to mimic the action of the LinearOperator.
          */
-        std::function<void(VectorType &, const VectorType &)> vmult;
+        std::function<auto(VectorType &, const VectorType &)->void> vmult;
 
         /**
          * The standard transpose matrix-vector operation to be performed by
@@ -2277,7 +2277,7 @@ namespace TrilinosWrappers
          * @note This is not called by a LinearOperator, but rather by Trilinos
          * functions that expect this to mimic the action of the LinearOperator.
          */
-        std::function<void(VectorType &, const VectorType &)> Tvmult;
+        std::function<auto(VectorType &, const VectorType &)->void> Tvmult;
 
         /**
          * The inverse matrix-vector operation to be performed by the payload
@@ -2287,7 +2287,7 @@ namespace TrilinosWrappers
          * functions that expect this to mimic the action of the
          * InverseOperator.
          */
-        std::function<void(VectorType &, const VectorType &)> inv_vmult;
+        std::function<auto(VectorType &, const VectorType &)->void> inv_vmult;
 
         /**
          * The inverse transpose matrix-vector operation to be performed by
@@ -2297,7 +2297,7 @@ namespace TrilinosWrappers
          * functions that expect this to mimic the action of the
          * InverseOperator.
          */
-        std::function<void(VectorType &, const VectorType &)> inv_Tvmult;
+        std::function<auto(VectorType &, const VectorType &)->void> inv_Tvmult;
 
         /** @} */
 

--- a/include/deal.II/lac/vector_memory.h
+++ b/include/deal.II/lac/vector_memory.h
@@ -185,7 +185,8 @@ public:
    * VectorMemory pool.
    */
   class Pointer
-    : public std::unique_ptr<VectorType, std::function<void(VectorType *)>>
+    : public std::unique_ptr<VectorType,
+                             std::function<auto(VectorType *)->void>>
   {
   public:
     /**
@@ -475,7 +476,7 @@ namespace internal
 
 template <typename VectorType>
 inline VectorMemory<VectorType>::Pointer::Pointer(VectorMemory<VectorType> &mem)
-  : std::unique_ptr<VectorType, std::function<void(VectorType *)>>(
+  : std::unique_ptr<VectorType, std::function<auto(VectorType *)->void>>(
       mem.alloc(),
       [&mem](VectorType *v) { mem.free(v); })
 {}

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -960,38 +960,40 @@ public:
    */
   template <typename CLASS, typename OutVector, typename InVector>
   void
-  cell_loop(void (CLASS::*cell_operation)(
-              const MatrixFree &,
-              OutVector &,
-              const InVector &,
-              const std::pair<unsigned int, unsigned int> &) const,
-            const CLASS    *owning_class,
-            OutVector      &dst,
-            const InVector &src,
-            const std::function<void(const unsigned int, const unsigned int)>
-              &operation_before_loop,
-            const std::function<void(const unsigned int, const unsigned int)>
-                              &operation_after_loop,
-            const unsigned int dof_handler_index_pre_post = 0) const;
+  cell_loop(
+    void (CLASS::*cell_operation)(const MatrixFree &,
+                                  OutVector &,
+                                  const InVector &,
+                                  const std::pair<unsigned int, unsigned int> &)
+      const,
+    const CLASS    *owning_class,
+    OutVector      &dst,
+    const InVector &src,
+    const std::function<auto(const unsigned int, const unsigned int)->void>
+      &operation_before_loop,
+    const std::function<auto(const unsigned int, const unsigned int)->void>
+                      &operation_after_loop,
+    const unsigned int dof_handler_index_pre_post = 0) const;
 
   /**
    * Same as above, but for class member functions which are non-const.
    */
   template <typename CLASS, typename OutVector, typename InVector>
   void
-  cell_loop(void (CLASS::*cell_operation)(
-              const MatrixFree &,
-              OutVector &,
-              const InVector &,
-              const std::pair<unsigned int, unsigned int> &),
-            CLASS          *owning_class,
-            OutVector      &dst,
-            const InVector &src,
-            const std::function<void(const unsigned int, const unsigned int)>
-              &operation_before_loop,
-            const std::function<void(const unsigned int, const unsigned int)>
-                              &operation_after_loop,
-            const unsigned int dof_handler_index_pre_post = 0) const;
+  cell_loop(
+    void (CLASS::*cell_operation)(
+      const MatrixFree &,
+      OutVector &,
+      const InVector &,
+      const std::pair<unsigned int, unsigned int> &),
+    CLASS          *owning_class,
+    OutVector      &dst,
+    const InVector &src,
+    const std::function<auto(const unsigned int, const unsigned int)->void>
+      &operation_before_loop,
+    const std::function<auto(const unsigned int, const unsigned int)->void>
+                      &operation_after_loop,
+    const unsigned int dof_handler_index_pre_post = 0) const;
 
   /**
    * Same as above, but taking an `std::function` as the `cell_operation`
@@ -999,18 +1001,19 @@ public:
    */
   template <typename OutVector, typename InVector>
   void
-  cell_loop(const std::function<void(
-              const MatrixFree<dim, Number, VectorizedArrayType> &,
-              OutVector &,
-              const InVector &,
-              const std::pair<unsigned int, unsigned int> &)> &cell_operation,
-            OutVector                                         &dst,
-            const InVector                                    &src,
-            const std::function<void(const unsigned int, const unsigned int)>
-              &operation_before_loop,
-            const std::function<void(const unsigned int, const unsigned int)>
-                              &operation_after_loop,
-            const unsigned int dof_handler_index_pre_post = 0) const;
+  cell_loop(
+    const std::function<
+      void(const MatrixFree<dim, Number, VectorizedArrayType> &,
+           OutVector &,
+           const InVector &,
+           const std::pair<unsigned int, unsigned int> &)> &cell_operation,
+    OutVector                                              &dst,
+    const InVector                                         &src,
+    const std::function<auto(const unsigned int, const unsigned int)->void>
+      &operation_before_loop,
+    const std::function<auto(const unsigned int, const unsigned int)->void>
+                      &operation_after_loop,
+    const unsigned int dof_handler_index_pre_post = 0) const;
 
   /**
    * This method runs a loop over all cells (in parallel) and performs the MPI
@@ -1397,9 +1400,9 @@ public:
        const CLASS    *owning_class,
        OutVector      &dst,
        const InVector &src,
-       const std::function<void(const unsigned int, const unsigned int)>
+       const std::function<auto(const unsigned int, const unsigned int)->void>
          &operation_before_loop,
-       const std::function<void(const unsigned int, const unsigned int)>
+       const std::function<auto(const unsigned int, const unsigned int)->void>
                               &operation_after_loop,
        const unsigned int      dof_handler_index_pre_post = 0,
        const DataAccessOnFaces dst_vector_face_access =
@@ -1430,9 +1433,9 @@ public:
        const CLASS    *owning_class,
        OutVector      &dst,
        const InVector &src,
-       const std::function<void(const unsigned int, const unsigned int)>
+       const std::function<auto(const unsigned int, const unsigned int)->void>
          &operation_before_loop,
-       const std::function<void(const unsigned int, const unsigned int)>
+       const std::function<auto(const unsigned int, const unsigned int)->void>
                               &operation_after_loop,
        const unsigned int      dof_handler_index_pre_post = 0,
        const DataAccessOnFaces dst_vector_face_access =
@@ -1465,9 +1468,9 @@ public:
       const std::pair<unsigned int, unsigned int> &)> &boundary_face_operation,
     OutVector                                         &dst,
     const InVector                                    &src,
-    const std::function<void(const unsigned int, const unsigned int)>
+    const std::function<auto(const unsigned int, const unsigned int)->void>
       &operation_before_loop,
-    const std::function<void(const unsigned int, const unsigned int)>
+    const std::function<auto(const unsigned int, const unsigned int)->void>
                            &operation_after_loop,
     const unsigned int      dof_handler_index_pre_post = 0,
     const DataAccessOnFaces dst_vector_face_access =
@@ -4695,23 +4698,24 @@ namespace internal
         function_type;
 
     // constructor, binds all the arguments to this class
-    MFWorker(const MF                            &matrix_free,
-             const InVector                      &src,
-             OutVector                           &dst,
-             const bool                           zero_dst_vector_setting,
-             const Container                     &container,
-             function_type                        cell_function,
-             function_type                        face_function,
-             function_type                        boundary_function,
-             const typename MF::DataAccessOnFaces src_vector_face_access =
-               MF::DataAccessOnFaces::none,
-             const typename MF::DataAccessOnFaces dst_vector_face_access =
-               MF::DataAccessOnFaces::none,
-             const std::function<void(const unsigned int, const unsigned int)>
-               &operation_before_loop = {},
-             const std::function<void(const unsigned int, const unsigned int)>
-                               &operation_after_loop       = {},
-             const unsigned int dof_handler_index_pre_post = 0)
+    MFWorker(
+      const MF                            &matrix_free,
+      const InVector                      &src,
+      OutVector                           &dst,
+      const bool                           zero_dst_vector_setting,
+      const Container                     &container,
+      function_type                        cell_function,
+      function_type                        face_function,
+      function_type                        boundary_function,
+      const typename MF::DataAccessOnFaces src_vector_face_access =
+        MF::DataAccessOnFaces::none,
+      const typename MF::DataAccessOnFaces dst_vector_face_access =
+        MF::DataAccessOnFaces::none,
+      const std::function<auto(const unsigned int, const unsigned int)->void>
+        &operation_before_loop = {},
+      const std::function<auto(const unsigned int, const unsigned int)->void>
+                        &operation_after_loop       = {},
+      const unsigned int dof_handler_index_pre_post = 0)
       : matrix_free(matrix_free)
       , container(const_cast<Container &>(container))
       , cell_function(cell_function)
@@ -4939,9 +4943,9 @@ namespace internal
                dst_data_exchanger;
     const bool src_and_dst_are_same;
     const bool zero_dst_vector_setting;
-    const std::function<void(const unsigned int, const unsigned int)>
+    const std::function<auto(const unsigned int, const unsigned int)->void>
       operation_before_loop;
-    const std::function<void(const unsigned int, const unsigned int)>
+    const std::function<auto(const unsigned int, const unsigned int)->void>
                        operation_after_loop;
     const unsigned int dof_handler_index_pre_post;
   };
@@ -5057,9 +5061,9 @@ MatrixFree<dim, Number, VectorizedArrayType>::cell_loop(
                  &cell_operation,
   OutVector      &dst,
   const InVector &src,
-  const std::function<void(const unsigned int, const unsigned int)>
+  const std::function<auto(const unsigned int, const unsigned int)->void>
     &operation_before_loop,
-  const std::function<void(const unsigned int, const unsigned int)>
+  const std::function<auto(const unsigned int, const unsigned int)->void>
                     &operation_after_loop,
   const unsigned int dof_handler_index_pre_post) const
 {
@@ -5187,9 +5191,9 @@ MatrixFree<dim, Number, VectorizedArrayType>::cell_loop(
   const CLASS    *owning_class,
   OutVector      &dst,
   const InVector &src,
-  const std::function<void(const unsigned int, const unsigned int)>
+  const std::function<auto(const unsigned int, const unsigned int)->void>
     &operation_before_loop,
-  const std::function<void(const unsigned int, const unsigned int)>
+  const std::function<auto(const unsigned int, const unsigned int)->void>
                     &operation_after_loop,
   const unsigned int dof_handler_index_pre_post) const
 {
@@ -5306,9 +5310,9 @@ MatrixFree<dim, Number, VectorizedArrayType>::cell_loop(
   CLASS          *owning_class,
   OutVector      &dst,
   const InVector &src,
-  const std::function<void(const unsigned int, const unsigned int)>
+  const std::function<auto(const unsigned int, const unsigned int)->void>
     &operation_before_loop,
-  const std::function<void(const unsigned int, const unsigned int)>
+  const std::function<auto(const unsigned int, const unsigned int)->void>
                     &operation_after_loop,
   const unsigned int dof_handler_index_pre_post) const
 {
@@ -5402,9 +5406,9 @@ MatrixFree<dim, Number, VectorizedArrayType>::loop(
                  &boundary_face_operation,
   OutVector      &dst,
   const InVector &src,
-  const std::function<void(const unsigned int, const unsigned int)>
+  const std::function<auto(const unsigned int, const unsigned int)->void>
     &operation_before_loop,
-  const std::function<void(const unsigned int, const unsigned int)>
+  const std::function<auto(const unsigned int, const unsigned int)->void>
                          &operation_after_loop,
   const unsigned int      dof_handler_index_pre_post,
   const DataAccessOnFaces dst_vector_face_access,
@@ -5461,9 +5465,9 @@ MatrixFree<dim, Number, VectorizedArrayType>::loop(
   const CLASS    *owning_class,
   OutVector      &dst,
   const InVector &src,
-  const std::function<void(const unsigned int, const unsigned int)>
+  const std::function<auto(const unsigned int, const unsigned int)->void>
     &operation_before_loop,
-  const std::function<void(const unsigned int, const unsigned int)>
+  const std::function<auto(const unsigned int, const unsigned int)->void>
                          &operation_after_loop,
   const unsigned int      dof_handler_index_pre_post,
   const DataAccessOnFaces dst_vector_face_access,
@@ -5513,9 +5517,9 @@ MatrixFree<dim, Number, VectorizedArrayType>::loop(
   const CLASS    *owning_class,
   OutVector      &dst,
   const InVector &src,
-  const std::function<void(const unsigned int, const unsigned int)>
+  const std::function<auto(const unsigned int, const unsigned int)->void>
     &operation_before_loop,
-  const std::function<void(const unsigned int, const unsigned int)>
+  const std::function<auto(const unsigned int, const unsigned int)->void>
                          &operation_after_loop,
   const unsigned int      dof_handler_index_pre_post,
   const DataAccessOnFaces dst_vector_face_access,

--- a/include/deal.II/matrix_free/tools.h
+++ b/include/deal.II/matrix_free/tools.h
@@ -55,7 +55,7 @@ namespace MatrixFreeTools
       std::function<void(std::vector<std::unique_ptr<FEEvalType>> &,
                          const unsigned int)>
         op_reinit;
-      std::function<void(std::vector<std::unique_ptr<FEEvalType>> &)>
+      std::function<auto(std::vector<std::unique_ptr<FEEvalType>> &)->void>
         op_compute;
     };
   } // namespace internal

--- a/include/deal.II/meshworker/loop.h
+++ b/include/deal.II/meshworker/loop.h
@@ -317,9 +317,9 @@ namespace MeshWorker
     IteratorType              cell,
     DoFInfoBox<dim, DOFINFO> &dof_info,
     INFOBOX                  &info,
-    const std::function<void(DOFINFO &, typename INFOBOX::CellInfo &)>
+    const std::function<auto(DOFINFO &, typename INFOBOX::CellInfo &)->void>
       &cell_worker,
-    const std::function<void(DOFINFO &, typename INFOBOX::CellInfo &)>
+    const std::function<auto(DOFINFO &, typename INFOBOX::CellInfo &)->void>
                                                             &boundary_worker,
     const std::function<void(DOFINFO &,
                              DOFINFO &,

--- a/include/deal.II/meshworker/mesh_loop.h
+++ b/include/deal.II/meshworker/mesh_loop.h
@@ -110,7 +110,7 @@ namespace MeshWorker
    * This alias introduces a friendly and short name for the function type
    * for the cell worker used in mesh_loop().
    */
-  using CopierFunctionType = std::function<void(const CopyData &)>;
+  using CopierFunctionType = std::function<auto(const CopyData &)->void>;
 
   /**
    * This alias introduces a friendly and short name for the function type
@@ -217,8 +217,8 @@ namespace MeshWorker
    * ScratchData            scratch(...);
    * CopyData               copy(...);
    *
-   * std::function<void(const CellIteratorType &, ScratchData &, CopyData &)>
-   *   empty_cell_worker;
+   * std::function<auto (const CellIteratorType &, ScratchData &, CopyData &) ->
+   * void> empty_cell_worker;
    *
    * auto boundary_worker = [...] (
    *   const CellIteratorType &cell,
@@ -304,8 +304,8 @@ namespace MeshWorker
     const std_cxx20::type_identity_t<std::function<
       void(const CellIteratorBaseType &, ScratchData &, CopyData &)>>
       &cell_worker,
-    const std_cxx20::type_identity_t<std::function<void(const CopyData &)>>
-      &copier,
+    const std_cxx20::type_identity_t<
+      std::function<auto(const CopyData &)->void>> &copier,
 
     const ScratchData &sample_scratch_data,
     const CopyData    &sample_copy_data,
@@ -712,49 +712,48 @@ namespace MeshWorker
             typename CellIteratorBaseType =
               typename internal::CellIteratorBaseType<CellIteratorType>::type>
   void
-  mesh_loop(
-    IteratorRange<CellIteratorType> iterator_range,
-    const std_cxx20::type_identity_t<std::function<
-      void(const CellIteratorBaseType &, ScratchData &, CopyData &)>>
-      &cell_worker,
-    const std_cxx20::type_identity_t<std::function<void(const CopyData &)>>
-      &copier,
+  mesh_loop(IteratorRange<CellIteratorType> iterator_range,
+            const std_cxx20::type_identity_t<std::function<
+              void(const CellIteratorBaseType &, ScratchData &, CopyData &)>>
+              &cell_worker,
+            const std_cxx20::type_identity_t<
+              std::function<auto(const CopyData &)->void>> &copier,
 
-    const ScratchData &sample_scratch_data,
-    const CopyData    &sample_copy_data,
+            const ScratchData &sample_scratch_data,
+            const CopyData    &sample_copy_data,
 
-    const AssembleFlags flags = assemble_own_cells,
+            const AssembleFlags flags = assemble_own_cells,
 
-    const std_cxx20::type_identity_t<
-      std::function<void(const CellIteratorBaseType &,
-                         const unsigned int,
-                         ScratchData &,
-                         CopyData &)>> &boundary_worker =
-      std::function<void(const CellIteratorBaseType &,
-                         const unsigned int,
-                         ScratchData &,
-                         CopyData &)>(),
+            const std_cxx20::type_identity_t<
+              std::function<void(const CellIteratorBaseType &,
+                                 const unsigned int,
+                                 ScratchData &,
+                                 CopyData &)>> &boundary_worker =
+              std::function<void(const CellIteratorBaseType &,
+                                 const unsigned int,
+                                 ScratchData &,
+                                 CopyData &)>(),
 
-    const std_cxx20::type_identity_t<
-      std::function<void(const CellIteratorBaseType &,
-                         const unsigned int,
-                         const unsigned int,
-                         const CellIteratorBaseType &,
-                         const unsigned int,
-                         const unsigned int,
-                         ScratchData &,
-                         CopyData &)>> &face_worker =
-      std::function<void(const CellIteratorBaseType &,
-                         const unsigned int,
-                         const unsigned int,
-                         const CellIteratorBaseType &,
-                         const unsigned int,
-                         const unsigned int,
-                         ScratchData &,
-                         CopyData &)>(),
+            const std_cxx20::type_identity_t<
+              std::function<void(const CellIteratorBaseType &,
+                                 const unsigned int,
+                                 const unsigned int,
+                                 const CellIteratorBaseType &,
+                                 const unsigned int,
+                                 const unsigned int,
+                                 ScratchData &,
+                                 CopyData &)>> &face_worker =
+              std::function<void(const CellIteratorBaseType &,
+                                 const unsigned int,
+                                 const unsigned int,
+                                 const CellIteratorBaseType &,
+                                 const unsigned int,
+                                 const unsigned int,
+                                 ScratchData &,
+                                 CopyData &)>(),
 
-    const unsigned int queue_length = 2 * MultithreadInfo::n_threads(),
-    const unsigned int chunk_size   = 8)
+            const unsigned int queue_length = 2 * MultithreadInfo::n_threads(),
+            const unsigned int chunk_size   = 8)
   {
     // Call the function above
     mesh_loop<typename IteratorRange<CellIteratorType>::IteratorOverIterators,
@@ -862,7 +861,8 @@ namespace MeshWorker
             const unsigned int queue_length = 2 * MultithreadInfo::n_threads(),
             const unsigned int chunk_size   = 8)
   {
-    std::function<void(const CellIteratorType &, ScratchData &, CopyData &)>
+    std::function<
+      auto(const CellIteratorType &, ScratchData &, CopyData &)->void>
       f_cell_worker;
 
     std::function<void(

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.h
@@ -847,25 +847,27 @@ public:
    * Connect a function to mg::SignalsNonNested::prolongation_cell_loop.
    */
   boost::signals2::connection
-  connect_prolongation_cell_loop(const std::function<void(const bool)> &slot);
+  connect_prolongation_cell_loop(
+    const std::function<auto(const bool)->void> &slot);
 
   /**
    * Connect a function to mg::SignalsNonNested::restriction_cell_loop.
    */
   boost::signals2::connection
-  connect_restriction_cell_loop(const std::function<void(const bool)> &slot);
+  connect_restriction_cell_loop(
+    const std::function<auto(const bool)->void> &slot);
 
   /**
    * Connect a function to mg::SignalsNonNested::prolongation.
    */
   boost::signals2::connection
-  connect_prolongation(const std::function<void(const bool)> &slot);
+  connect_prolongation(const std::function<auto(const bool)->void> &slot);
 
   /**
    * Connect a function to mg::SignalsNonNested::restriction.
    */
   boost::signals2::connection
-  connect_restriction(const std::function<void(const bool)> &slot);
+  connect_restriction(const std::function<auto(const bool)->void> &slot);
 
 protected:
   AdditionalData additional_data;
@@ -1022,7 +1024,7 @@ public:
    */
   template <typename MGTwoLevelTransferObject>
   MGTransferMF(const MGLevelObject<MGTwoLevelTransferObject> &transfer,
-               const std::function<void(const unsigned int, VectorType &)>
+               const std::function<auto(const unsigned int, VectorType &)->void>
                  &initialize_dof_vector = {});
 
   /**
@@ -1050,7 +1052,7 @@ public:
    * partitioners.
    */
   void
-  build(const std::function<void(const unsigned int, VectorType &)>
+  build(const std::function<auto(const unsigned int, VectorType &)->void>
           &initialize_dof_vector);
 
   /** @} */
@@ -1108,7 +1110,7 @@ public:
    */
   void
   build(const DoFHandler<dim> &dof_handler,
-        const std::function<void(const unsigned int, VectorType &)>
+        const std::function<auto(const unsigned int, VectorType &)->void>
           &initialize_dof_vector);
 
   /** @} */
@@ -1427,7 +1429,7 @@ template <int dim, typename Number>
 template <typename MGTwoLevelTransferObject>
 MGTransferMF<dim, Number>::MGTransferMF(
   const MGLevelObject<MGTwoLevelTransferObject> &transfer,
-  const std::function<void(const unsigned int, VectorType &)>
+  const std::function<auto(const unsigned int, VectorType &)->void>
     &initialize_dof_vector)
 {
   this->transfer.clear();

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -483,8 +483,8 @@ namespace internal
      * Constructor.
      */
     FineDoFHandlerViewCell(
-      const std::function<bool()> &has_children_function,
-      const std::function<void(std::vector<types::global_dof_index> &)>
+      const std::function<auto()->bool> &has_children_function,
+      const std::function<auto(std::vector<types::global_dof_index> &)->void>
                                           &get_dof_indices_function,
       const std::function<unsigned int()> &active_fe_index_function,
       const std::function<std::uint8_t()> &refinement_case_function)
@@ -532,12 +532,12 @@ namespace internal
     /**
      * Lambda function returning whether cell has children.
      */
-    const std::function<bool()> has_children_function;
+    const std::function<auto()->bool> has_children_function;
 
     /**
      * Lambda function returning DoF indices.
      */
-    const std::function<void(std::vector<types::global_dof_index> &)>
+    const std::function<auto(std::vector<types::global_dof_index> &)->void>
       get_dof_indices_function;
 
     /**
@@ -4492,7 +4492,7 @@ MGTransferMF<dim, Number>::build(
 template <int dim, typename Number>
 void
 MGTransferMF<dim, Number>::build(
-  const std::function<void(const unsigned int, VectorType &)>
+  const std::function<auto(const unsigned int, VectorType &)->void>
     &initialize_dof_vector)
 {
   if (initialize_dof_vector)
@@ -4553,7 +4553,7 @@ template <int dim, typename Number>
 void
 MGTransferMF<dim, Number>::build(
   const DoFHandler<dim> &dof_handler,
-  const std::function<void(const unsigned int, VectorType &)>
+  const std::function<auto(const unsigned int, VectorType &)->void>
     &initialize_dof_vector)
 {
   const bool use_local_smoothing =
@@ -5771,7 +5771,7 @@ MGTwoLevelTransferNonNested<dim, VectorType>::memory_consumption() const
 template <int dim, typename VectorType>
 boost::signals2::connection
 MGTwoLevelTransferNonNested<dim, VectorType>::connect_prolongation_cell_loop(
-  const std::function<void(const bool)> &slot)
+  const std::function<auto(const bool)->void> &slot)
 {
   return signals_non_nested.prolongation_cell_loop.connect(slot);
 }
@@ -5781,7 +5781,7 @@ MGTwoLevelTransferNonNested<dim, VectorType>::connect_prolongation_cell_loop(
 template <int dim, typename VectorType>
 boost::signals2::connection
 MGTwoLevelTransferNonNested<dim, VectorType>::connect_restriction_cell_loop(
-  const std::function<void(const bool)> &slot)
+  const std::function<auto(const bool)->void> &slot)
 {
   return signals_non_nested.restriction_cell_loop.connect(slot);
 }
@@ -5791,7 +5791,7 @@ MGTwoLevelTransferNonNested<dim, VectorType>::connect_restriction_cell_loop(
 template <int dim, typename VectorType>
 boost::signals2::connection
 MGTwoLevelTransferNonNested<dim, VectorType>::connect_prolongation(
-  const std::function<void(const bool)> &slot)
+  const std::function<auto(const bool)->void> &slot)
 {
   return signals_non_nested.prolongation.connect(slot);
 }
@@ -5801,7 +5801,7 @@ MGTwoLevelTransferNonNested<dim, VectorType>::connect_prolongation(
 template <int dim, typename VectorType>
 boost::signals2::connection
 MGTwoLevelTransferNonNested<dim, VectorType>::connect_restriction(
-  const std::function<void(const bool)> &slot)
+  const std::function<auto(const bool)->void> &slot)
 {
   return signals_non_nested.restriction.connect(slot);
 }

--- a/include/deal.II/multigrid/multigrid.h
+++ b/include/deal.II/multigrid/multigrid.h
@@ -311,49 +311,49 @@ public:
    */
   boost::signals2::connection
   connect_pre_smoother_step(
-    const std::function<void(const bool, const unsigned int)> &slot);
+    const std::function<auto(const bool, const unsigned int)->void> &slot);
 
   /**
    * Connect a function to mg::Signals::residual_step.
    */
   boost::signals2::connection
   connect_residual_step(
-    const std::function<void(const bool, const unsigned int)> &slot);
+    const std::function<auto(const bool, const unsigned int)->void> &slot);
 
   /**
    * Connect a function to mg::Signals::restriction.
    */
   boost::signals2::connection
   connect_restriction(
-    const std::function<void(const bool, const unsigned int)> &slot);
+    const std::function<auto(const bool, const unsigned int)->void> &slot);
 
   /**
    * Connect a function to mg::Signals::coarse_solve.
    */
   boost::signals2::connection
   connect_coarse_solve(
-    const std::function<void(const bool, const unsigned int)> &slot);
+    const std::function<auto(const bool, const unsigned int)->void> &slot);
 
   /**
    * Connect a function to mg::Signals::prolongation.
    */
   boost::signals2::connection
   connect_prolongation(
-    const std::function<void(const bool, const unsigned int)> &slot);
+    const std::function<auto(const bool, const unsigned int)->void> &slot);
 
   /**
    * Connect a function to mg::Signals::edge_prolongation.
    */
   boost::signals2::connection
   connect_edge_prolongation(
-    const std::function<void(const bool, const unsigned int)> &slot);
+    const std::function<auto(const bool, const unsigned int)->void> &slot);
 
   /**
    * Connect a function to mg::Signals::post_smoother_step.
    */
   boost::signals2::connection
   connect_post_smoother_step(
-    const std::function<void(const bool, const unsigned int)> &slot);
+    const std::function<auto(const bool, const unsigned int)->void> &slot);
 
 private:
   /**
@@ -588,13 +588,13 @@ public:
    * Connect a function to mg::Signals::transfer_to_mg.
    */
   boost::signals2::connection
-  connect_transfer_to_mg(const std::function<void(bool)> &slot);
+  connect_transfer_to_mg(const std::function<auto(bool)->void> &slot);
 
   /**
    * Connect a function to mg::Signals::transfer_to_global.
    */
   boost::signals2::connection
-  connect_transfer_to_global(const std::function<void(bool)> &slot);
+  connect_transfer_to_global(const std::function<auto(bool)->void> &slot);
 
   /**
    * Return the Multigrid object passed to the constructor.
@@ -925,7 +925,7 @@ PreconditionMG<dim, VectorType, TransferType>::get_mpi_communicator() const
 template <int dim, typename VectorType, typename TransferType>
 boost::signals2::connection
 PreconditionMG<dim, VectorType, TransferType>::connect_transfer_to_mg(
-  const std::function<void(bool)> &slot)
+  const std::function<auto(bool)->void> &slot)
 {
   return this->signals.transfer_to_mg.connect(slot);
 }
@@ -935,7 +935,7 @@ PreconditionMG<dim, VectorType, TransferType>::connect_transfer_to_mg(
 template <int dim, typename VectorType, typename TransferType>
 boost::signals2::connection
 PreconditionMG<dim, VectorType, TransferType>::connect_transfer_to_global(
-  const std::function<void(bool)> &slot)
+  const std::function<auto(bool)->void> &slot)
 {
   return this->signals.transfer_to_global.connect(slot);
 }

--- a/include/deal.II/multigrid/multigrid.templates.h
+++ b/include/deal.II/multigrid/multigrid.templates.h
@@ -322,7 +322,7 @@ Multigrid<VectorType>::vcycle()
 template <typename VectorType>
 boost::signals2::connection
 Multigrid<VectorType>::connect_coarse_solve(
-  const std::function<void(const bool, const unsigned int)> &slot)
+  const std::function<auto(const bool, const unsigned int)->void> &slot)
 {
   return this->signals.coarse_solve.connect(slot);
 }
@@ -332,7 +332,7 @@ Multigrid<VectorType>::connect_coarse_solve(
 template <typename VectorType>
 boost::signals2::connection
 Multigrid<VectorType>::connect_restriction(
-  const std::function<void(const bool, const unsigned int)> &slot)
+  const std::function<auto(const bool, const unsigned int)->void> &slot)
 {
   return this->signals.restriction.connect(slot);
 }
@@ -342,7 +342,7 @@ Multigrid<VectorType>::connect_restriction(
 template <typename VectorType>
 boost::signals2::connection
 Multigrid<VectorType>::connect_prolongation(
-  const std::function<void(const bool, const unsigned int)> &slot)
+  const std::function<auto(const bool, const unsigned int)->void> &slot)
 {
   return this->signals.prolongation.connect(slot);
 }
@@ -352,7 +352,7 @@ Multigrid<VectorType>::connect_prolongation(
 template <typename VectorType>
 boost::signals2::connection
 Multigrid<VectorType>::connect_pre_smoother_step(
-  const std::function<void(const bool, const unsigned int)> &slot)
+  const std::function<auto(const bool, const unsigned int)->void> &slot)
 {
   return this->signals.pre_smoother_step.connect(slot);
 }
@@ -362,7 +362,7 @@ Multigrid<VectorType>::connect_pre_smoother_step(
 template <typename VectorType>
 boost::signals2::connection
 Multigrid<VectorType>::connect_post_smoother_step(
-  const std::function<void(const bool, const unsigned int)> &slot)
+  const std::function<auto(const bool, const unsigned int)->void> &slot)
 {
   return this->signals.post_smoother_step.connect(slot);
 }
@@ -372,7 +372,7 @@ Multigrid<VectorType>::connect_post_smoother_step(
 template <typename VectorType>
 boost::signals2::connection
 Multigrid<VectorType>::connect_residual_step(
-  const std::function<void(const bool, const unsigned int)> &slot)
+  const std::function<auto(const bool, const unsigned int)->void> &slot)
 {
   return this->signals.residual_step.connect(slot);
 }
@@ -382,7 +382,7 @@ Multigrid<VectorType>::connect_residual_step(
 template <typename VectorType>
 boost::signals2::connection
 Multigrid<VectorType>::connect_edge_prolongation(
-  const std::function<void(const bool, const unsigned int)> &slot)
+  const std::function<auto(const bool, const unsigned int)->void> &slot)
 {
   return this->signals.edge_prolongation.connect(slot);
 }

--- a/include/deal.II/numerics/nonlinear.h
+++ b/include/deal.II/numerics/nonlinear.h
@@ -284,7 +284,7 @@ public:
    * block vectors are used), along with any
    * other properties necessary.
    */
-  std::function<void(VectorType &)> reinit_vector;
+  std::function<auto(VectorType &)->void> reinit_vector;
 
   /**
    * A function object that users should supply and that is intended to
@@ -299,7 +299,7 @@ public:
    * throws an exception of type RecoverableUserCallbackError, then this
    * exception may or may not be treated like any other exception.
    */
-  std::function<void(const VectorType &src, VectorType &dst)> residual;
+  std::function<auto(const VectorType &src, VectorType &dst)->void> residual;
 
   /**
    * A function object that users may supply and that is intended to
@@ -327,7 +327,7 @@ public:
    * throws an exception of type RecoverableUserCallbackError, then this
    * exception may or may not be treated like any other exception.
    */
-  std::function<void(const VectorType &current_u)> setup_jacobian;
+  std::function<auto(const VectorType &current_u)->void> setup_jacobian;
 
   /**
    * A function object that users may supply and that is intended to solve

--- a/include/deal.II/optimization/solver_bfgs.h
+++ b/include/deal.II/optimization/solver_bfgs.h
@@ -106,9 +106,9 @@ public:
    * $f(\mathbf x)$.
    */
   void
-  solve(
-    const std::function<Number(const VectorType &x, VectorType &g)> &compute,
-    VectorType                                                      &x);
+  solve(const std::function<auto(const VectorType &x, VectorType &g)->Number>
+                   &compute,
+        VectorType &x);
 
   /**
    * Connect a slot to perform a custom line-search.

--- a/include/deal.II/sundials/arkode.h
+++ b/include/deal.II/sundials/arkode.h
@@ -608,7 +608,8 @@ namespace SUNDIALS
      * with "recoverable" errors in some circumstances, so callbacks
      * can throw exceptions of type RecoverableUserCallbackError.
      */
-    std::function<void(const double t, const VectorType &y, VectorType &res)>
+    std::function<
+      auto(const double t, const VectorType &y, VectorType &res)->void>
       implicit_function;
 
     /**
@@ -628,7 +629,8 @@ namespace SUNDIALS
      * with "recoverable" errors in some circumstances, so callbacks
      * can throw exceptions of type RecoverableUserCallbackError.
      */
-    std::function<void(const double t, const VectorType &v, VectorType &Mv)>
+    std::function<
+      auto(const double t, const VectorType &v, VectorType &Mv)->void>
       mass_times_vector;
 
     /**
@@ -665,7 +667,7 @@ namespace SUNDIALS
      * with "recoverable" errors in some circumstances, so callbacks
      * can throw exceptions of type RecoverableUserCallbackError.
      */
-    std::function<void(const double t)> mass_times_setup;
+    std::function<auto(const double t)->void> mass_times_setup;
 
     /**
      * A function object that users may supply and that is intended to compute
@@ -939,7 +941,7 @@ namespace SUNDIALS
      * with "recoverable" errors in some circumstances, so callbacks
      * can throw exceptions of type RecoverableUserCallbackError.
      */
-    std::function<void(const double t)> mass_preconditioner_setup;
+    std::function<auto(const double t)->void> mass_preconditioner_setup;
 
     /**
      * A function object that users may supply and that is intended to
@@ -977,7 +979,8 @@ namespace SUNDIALS
      * The default implementation simply returns `false`, i.e., no restart is
      * performed during the evolution.
      */
-    std::function<bool(const double t, VectorType &sol)> solver_should_restart;
+    std::function<auto(const double t, VectorType &sol)->bool>
+      solver_should_restart;
 
     /**
      * A function object that users may supply and that is intended to return a
@@ -1011,7 +1014,7 @@ namespace SUNDIALS
      * @param arkode_mem pointer to the ARKODE memory block which can be used
      *   for custom calls to `ARKStepSet...` methods.
      */
-    std::function<void(void *arkode_mem)> custom_setup;
+    std::function<auto(void *arkode_mem)->void> custom_setup;
 
   private:
     /**

--- a/include/deal.II/sundials/ida.h
+++ b/include/deal.II/sundials/ida.h
@@ -895,7 +895,7 @@ namespace SUNDIALS
     /**
      * Reinit vector to have the right size, MPI communicator, etc.
      */
-    std::function<void(VectorType &)> reinit_vector;
+    std::function<auto(VectorType &)->void> reinit_vector;
 
     /**
      * Compute residual. Return $F(t, y, \dot y)$.
@@ -1037,7 +1037,8 @@ namespace SUNDIALS
      * with "recoverable" errors in some circumstances, so callbacks
      * can throw exceptions of type RecoverableUserCallbackError.
      */
-    std::function<bool(const double t, VectorType &sol, VectorType &sol_dot)>
+    std::function<
+      auto(const double t, VectorType &sol, VectorType &sol_dot)->bool>
       solver_should_restart;
 
     /**
@@ -1054,7 +1055,7 @@ namespace SUNDIALS
      * you only return the locally owned (or locally relevant) components, in
      * order to minimize communication between processes.
      */
-    std::function<IndexSet()> differential_components;
+    std::function<auto()->IndexSet> differential_components;
 
     /**
      * Return a vector whose components are the weights used by IDA to compute

--- a/include/deal.II/sundials/kinsol.h
+++ b/include/deal.II/sundials/kinsol.h
@@ -478,7 +478,7 @@ namespace SUNDIALS
      * with "recoverable" errors in some circumstances, so callbacks
      * can throw exceptions of type RecoverableUserCallbackError.
      */
-    std::function<void(VectorType &)> reinit_vector;
+    std::function<auto(VectorType &)->void> reinit_vector;
 
     /**
      * A function object that users should supply and that is intended to
@@ -493,7 +493,7 @@ namespace SUNDIALS
      * with "recoverable" errors in some circumstances, so callbacks
      * can throw exceptions of type RecoverableUserCallbackError.
      */
-    std::function<void(const VectorType &src, VectorType &dst)> residual;
+    std::function<auto(const VectorType &src, VectorType &dst)->void> residual;
 
     /**
      * A function object that users should supply and that is intended to
@@ -508,7 +508,7 @@ namespace SUNDIALS
      * with "recoverable" errors in some circumstances, so callbacks
      * can throw exceptions of type RecoverableUserCallbackError.
      */
-    std::function<void(const VectorType &src, VectorType &dst)>
+    std::function<auto(const VectorType &src, VectorType &dst)->void>
       iteration_function;
 
     /**
@@ -702,7 +702,7 @@ namespace SUNDIALS
      * @param kinsol_mem pointer to the KINSOL memory block which can be used
      *   for custom calls to `KINSet...` functions.
      */
-    std::function<void(void *kinsol_mem)> custom_setup;
+    std::function<auto(void *kinsol_mem)->void> custom_setup;
 
     /**
      * Handle KINSOL exceptions.

--- a/include/deal.II/sundials/n_vector.h
+++ b/include/deal.II/sundials/n_vector.h
@@ -226,7 +226,7 @@ namespace SUNDIALS
       /**
        * Actual pointer to a vector viewed by this class.
        */
-      std::unique_ptr<_generic_N_Vector, std::function<void(N_Vector)>>
+      std::unique_ptr<_generic_N_Vector, std::function<auto(N_Vector)->void>>
         vector_ptr;
     };
   } // namespace internal

--- a/include/deal.II/sundials/n_vector.templates.h
+++ b/include/deal.II/sundials/n_vector.templates.h
@@ -109,7 +109,7 @@ namespace SUNDIALS
 
     private:
       using PointerType =
-        std::unique_ptr<VectorType, std::function<void(VectorType *)>>;
+        std::unique_ptr<VectorType, std::function<auto(VectorType *)->void>>;
 
       /**
        * Vector memory which might be used to allocate storage if

--- a/include/deal.II/trilinos/nox.h
+++ b/include/deal.II/trilinos/nox.h
@@ -201,7 +201,7 @@ namespace TrilinosWrappers
      * throws an exception of type RecoverableUserCallbackError, then this
      * exception is treated like any other exception.
      */
-    std::function<void(const VectorType &u, VectorType &F)> residual;
+    std::function<auto(const VectorType &u, VectorType &F)->void> residual;
 
     /**
      * A user function that sets up the Jacobian, based on the
@@ -215,7 +215,7 @@ namespace TrilinosWrappers
      * throws an exception of type RecoverableUserCallbackError, then this
      * exception is treated like any other exception.
      */
-    std::function<void(const VectorType &current_u)> setup_jacobian;
+    std::function<auto(const VectorType &current_u)->void> setup_jacobian;
 
     /**
      * A user function that sets up the preconditioner for inverting
@@ -234,7 +234,7 @@ namespace TrilinosWrappers
      * throws an exception of type RecoverableUserCallbackError, then this
      * exception is treated like any other exception.
      */
-    std::function<void(const VectorType &current_u)> setup_preconditioner;
+    std::function<auto(const VectorType &current_u)->void> setup_preconditioner;
 
     /**
      * A user function that applies the Jacobian $\nabla_u F(u)$ to
@@ -256,7 +256,8 @@ namespace TrilinosWrappers
      * throws an exception of type RecoverableUserCallbackError, then this
      * exception is treated like any other exception.
      */
-    std::function<void(const VectorType &x, VectorType &y)> apply_jacobian;
+    std::function<auto(const VectorType &x, VectorType &y)->void>
+      apply_jacobian;
 
     /**
      * A user function that applies the inverse of the Jacobian
@@ -364,7 +365,7 @@ namespace TrilinosWrappers
      * throws an exception of type RecoverableUserCallbackError, then this
      * exception is treated like any other exception.
      */
-    std::function<bool()> update_preconditioner_predicate;
+    std::function<auto()->bool> update_preconditioner_predicate;
 
   private:
     /**

--- a/include/deal.II/trilinos/nox.templates.h
+++ b/include/deal.II/trilinos/nox.templates.h
@@ -358,10 +358,11 @@ namespace TrilinosWrappers
          * to solve the Jacobian.
          */
         Group(
-          VectorType                                                 &solution,
-          const std::function<int(const VectorType &, VectorType &)> &residual,
-          const std::function<int(const VectorType &)> &setup_jacobian,
-          const std::function<int(const VectorType &, VectorType &)>
+          VectorType &solution,
+          const std::function<auto(const VectorType &, VectorType &)->int>
+                                                             &residual,
+          const std::function<auto(const VectorType &)->int> &setup_jacobian,
+          const std::function<auto(const VectorType &, VectorType &)->int>
                                                  &apply_jacobian,
           const std::function<int(const VectorType &,
                                   VectorType &,
@@ -764,17 +765,18 @@ namespace TrilinosWrappers
         /**
          * A helper function to compute residual.
          */
-        std::function<int(const VectorType &x, VectorType &f)> residual;
+        std::function<auto(const VectorType &x, VectorType &f)->int> residual;
 
         /**
          * A helper function to set up Jacobian.
          */
-        std::function<int(const VectorType &x)> setup_jacobian;
+        std::function<auto(const VectorType &x)->int> setup_jacobian;
 
         /**
          * A helper function to apply Jacobian.
          */
-        std::function<int(const VectorType &x, VectorType &v)> apply_jacobian;
+        std::function<auto(const VectorType &x, VectorType &v)->int>
+          apply_jacobian;
 
         /**
          * A helper function to solve Jacobian.

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -2042,7 +2042,7 @@ namespace Utilities
     template bool
     reduce(const bool &,
            const MPI_Comm,
-           const std::function<bool(const bool &, const bool &)> &,
+           const std::function<auto(const bool &, const bool &)->bool> &,
            const unsigned int);
 
     template std::vector<bool>
@@ -2055,7 +2055,7 @@ namespace Utilities
     template bool
     all_reduce(const bool &,
                const MPI_Comm,
-               const std::function<bool(const bool &, const bool &)> &);
+               const std::function<auto(const bool &, const bool &)->bool> &);
 
     template std::vector<bool>
     all_reduce(

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -937,9 +937,9 @@ ParameterHandler::declare_entry(const std::string           &entry,
 
 void
 ParameterHandler::add_action(
-  const std::string                              &entry,
-  const std::function<void(const std::string &)> &action,
-  const bool                                      execute_action)
+  const std::string                                    &entry,
+  const std::function<auto(const std::string &)->void> &action,
+  const bool                                            execute_action)
 {
   actions.push_back(action);
 

--- a/source/base/parsed_convergence_table.cc
+++ b/source/base/parsed_convergence_table.cc
@@ -259,9 +259,9 @@ ParsedConvergenceTable::output_table()
 
 void
 ParsedConvergenceTable::add_extra_column(
-  const std::string             &column_name,
-  const std::function<double()> &custom_function,
-  const bool                     compute_rate)
+  const std::string                   &column_name,
+  const std::function<auto()->double> &custom_function,
+  const bool                           compute_rate)
 {
   extra_column_functions[column_name] = {custom_function, compute_rate};
 }

--- a/source/fe/mapping_q_cache.cc
+++ b/source/fe/mapping_q_cache.cc
@@ -163,7 +163,7 @@ MappingQCache<dim, spacedim>::initialize(
         (*support_point_cache)[cell->level()][cell->index()].size(),
         Utilities::pow(this->get_degree() + 1, dim));
     },
-    /* copier */ std::function<void(void *)>(),
+    /* copier */ std::function<auto(void *)->void>(),
     /* scratch_data */ nullptr,
     /* copy_data */ nullptr,
     2 * MultithreadInfo::n_threads(),

--- a/source/grid/grid_generator_from_name.cc
+++ b/source/grid/grid_generator_from_name.cc
@@ -35,7 +35,7 @@ namespace GridGenerator
                      const std::string            &arguments,
                      Triangulation<dim, spacedim> &tria)
     {
-      std::function<void(Arguments...)> wrapper =
+      std::function<auto(Arguments...)->void> wrapper =
         [&tria, &generator](Arguments... args) { generator(tria, args...); };
       auto bound_function = Utilities::mutable_bind(wrapper);
       bound_function.parse_arguments(arguments);

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -919,7 +919,7 @@ namespace GridTools
               {
                 // If we have an rtree at our disposal, use it.
                 using ValueType = std::pair<Point<spacedim>, unsigned int>;
-                std::function<bool(const ValueType &)> marked;
+                std::function<auto(const ValueType &)->bool> marked;
                 if (marked_vertices.size() == mesh.n_vertices())
                   marked = [&marked_vertices](const ValueType &value) -> bool {
                     return marked_vertices[value.second];
@@ -1150,8 +1150,8 @@ namespace GridTools
   std::
     vector<BoundingBox<MeshType::space_dimension>> compute_mesh_predicate_bounding_box(
       const MeshType &mesh,
-      const std::function<bool(const typename MeshType::active_cell_iterator &)>
-                        &predicate,
+      const std::function<
+        auto(const typename MeshType::active_cell_iterator &)->bool> &predicate,
       const unsigned int refinement_level,
       const bool         allow_merge,
       const unsigned int max_boxes)

--- a/source/grid/grid_tools_dof_handlers.cc
+++ b/source/grid/grid_tools_dof_handlers.cc
@@ -819,8 +819,8 @@ namespace GridTools
   std::
     vector<typename MeshType::active_cell_iterator> compute_active_cell_halo_layer(
       const MeshType &mesh,
-      const std::function<bool(const typename MeshType::active_cell_iterator &)>
-        &predicate)
+      const std::function<
+        auto(const typename MeshType::active_cell_iterator &)->bool> &predicate)
   {
     std::vector<typename MeshType::active_cell_iterator> active_halo_layer;
     std::vector<bool> locally_active_vertices_on_subdomain(
@@ -868,7 +868,7 @@ namespace GridTools
   std::
     vector<typename MeshType::cell_iterator> compute_cell_halo_layer_on_level(
       const MeshType &mesh,
-      const std::function<bool(const typename MeshType::cell_iterator &)>
+      const std::function<auto(const typename MeshType::cell_iterator &)->bool>
                         &predicate,
       const unsigned int level)
   {
@@ -951,7 +951,7 @@ namespace GridTools
     typename MeshType::
       active_cell_iterator> compute_ghost_cell_halo_layer(const MeshType &mesh)
   {
-    std::function<bool(const typename MeshType::active_cell_iterator &)>
+    std::function<auto(const typename MeshType::active_cell_iterator &)->bool>
       predicate = IteratorFilters::LocallyOwnedCell();
 
     const std::vector<typename MeshType::active_cell_iterator>
@@ -974,8 +974,8 @@ namespace GridTools
   std::
     vector<typename MeshType::active_cell_iterator> compute_active_cell_layer_within_distance(
       const MeshType &mesh,
-      const std::function<bool(const typename MeshType::active_cell_iterator &)>
-                  &predicate,
+      const std::function<
+        auto(const typename MeshType::active_cell_iterator &)->bool> &predicate,
       const double layer_thickness)
   {
     std::vector<typename MeshType::active_cell_iterator>
@@ -1124,7 +1124,7 @@ namespace GridTools
                                                                        layer_thickness)
   {
     IteratorFilters::LocallyOwnedCell locally_owned_cell_predicate;
-    std::function<bool(const typename MeshType::active_cell_iterator &)>
+    std::function<auto(const typename MeshType::active_cell_iterator &)->bool>
       predicate(locally_owned_cell_predicate);
 
     const std::vector<typename MeshType::active_cell_iterator>

--- a/source/grid/grid_tools_geometry.cc
+++ b/source/grid/grid_tools_geometry.cc
@@ -397,7 +397,7 @@ namespace GridTools
     const auto predicate = [](const iterator &) { return true; };
 
     return compute_bounding_box(
-      tria, std::function<bool(const iterator &)>(predicate));
+      tria, std::function<auto(const iterator &)->bool>(predicate));
   }
 
 

--- a/source/grid/tria_description.cc
+++ b/source/grid/tria_description.cc
@@ -792,7 +792,7 @@ namespace TriangulationDescription
     template <int dim, int spacedim>
     Description<dim, spacedim>
     create_description_from_triangulation_in_groups(
-      const std::function<void(dealii::Triangulation<dim, spacedim> &)>
+      const std::function<auto(dealii::Triangulation<dim, spacedim> &)->void>
                                                     &serial_grid_generator,
       const std::function<void(dealii::Triangulation<dim, spacedim> &,
                                const MPI_Comm,

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -1253,7 +1253,7 @@ DataOut<dim, spacedim>::build_patches(
                     all_cells.data() + all_cells.size(),
                     worker,
                     // no copy-local-to-global function needed here
-                    std::function<void(const int)>(),
+                    std::function<auto(const int)->void>(),
                     thread_data,
                     /* dummy CopyData object = */ 0,
                     // experimenting shows that we can make things run a bit

--- a/source/numerics/derivative_approximation.cc
+++ b/source/numerics/derivative_approximation.cc
@@ -997,7 +997,7 @@ namespace DerivativeApproximation
           approximate<DerivativeDescription, dim, InputVector, spacedim>(
             cell, mapping, dof_handler, solution, component);
         },
-        std::function<void(const internal::Assembler::CopyData &)>(),
+        std::function<auto(const internal::Assembler::CopyData &)->void>(),
         internal::Assembler::Scratch(),
         internal::Assembler::CopyData());
     }


### PR DESCRIPTION
It has long bothered me that the *type* of a function is written like `int(double)`, which really doesn't make much sense unless you really know what that does. C++11 introduced trailing return types, so that one can write `auto (double) -> int`, which is much closer to what other typed languages actually do, except of course for the totally unimaginative use of the keyword `auto` -- one would really have hoped that the committee had been willing to come up with a different name, perhaps `declfun` or some such.

Regardless, here's an idea: Converting some of the places where we use function types -- namely, as template arguments to `std::function` -- to use this syntax. This would convert
```
std::function<RangeNumberType(const Point<dim> &)>
```
to
```
std::function<auto(const Point<dim> &)->RangeNumberType>
```
to give just one example. 

This patch does not convert all places (my regex only covered places where the function arguments were on the same line), but I thought I'd put it out there to see how people feel about this. How *do* people feel about it?

(As an aside, I think my hope was that after C++11, people would convert code bases to simply *always* use trailing return types. clang-tidy even has a flag for that: https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-trailing-return-type.html But in practice, I don't see the community switching. I find that sad because I think the new syntax is easier to understand. Of course, that also means that if *we* were to use the new syntax, we'd have a harder time teaching it because that's not how people learn to read and write C++...)