### PR TITLE
If possible, let cmake set -Werror automatically.

### DIFF
--- a/cmake/macros/macro_populate_target_properties.cmake
+++ b/cmake/macros/macro_populate_target_properties.cmake
@@ -100,11 +100,19 @@ function(populate_target_properties _target _build)
   #  - set POSITION_INDEPENDENT_CODE to true to compile everything with
   #    the -fpic/-fPIC compiler flag. This ensures that we can link all
   #    object targets into a relocatable library at the end.
+  #  - compile deal.II's own files with -Werror or whatever else it
+  #    is that the compiler understands (if cmake is new enough)
   #
 
   set_target_properties(${_target} PROPERTIES
     POSITION_INDEPENDENT_CODE TRUE
     )
+
+  if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
+    set_target_properties(${_target} PROPERTIES
+      COMPILE_WARNING_AS_ERROR ON
+      )
+  endif()
 
   #
   # Add compile and link options with private scope, and add the link


### PR DESCRIPTION
I'm playing around with cmake today. Among other things, I learned that newer versions allow setting a target property that is equivalent to `-Werror` or whatever else it is that a compiler supports.

cmake supports this since 3.24, which includes what Ubuntu 24.04 ships. If this seems reasonable, I can disable the logic to detect `-Werror` for these versions as well.