### PR TITLE
Fix get_communicator_by_value for SUNDIALS 7

### DIFF
--- a/include/deal.II/sundials/n_vector.templates.h
+++ b/include/deal.II/sundials/n_vector.templates.h
@@ -753,7 +753,7 @@ namespace SUNDIALS
           //
           // Further, we need to cast away const here, as SUNDIALS demands the
           // communicator by value.
-          return const_cast<SUNComm>(get_mpi_communicator<VectorType>(v));
+          return const_cast<SUNComm &>(get_mpi_communicator<VectorType>(v));
         else
           return SUN_COMM_NULL;
 #    endif


### PR DESCRIPTION
Fixes https://github.com/dealii/dealii/issues/17723. `const_cast` only works on references and pointers and `get_mpi_communicator` returns a `const MPI_Comm &`.