### PR TITLE
Disable CGAL warning

### DIFF
--- a/source/cgal/intersections.cc
+++ b/source/cgal/intersections.cc
@@ -27,7 +27,10 @@
 
 #  include <deal.II/grid/tria.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <CGAL/Boolean_set_operations_2.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
+
 #  include <CGAL/Cartesian.h>
 #  include <CGAL/Circular_kernel_intersections.h>
 #  include <CGAL/Constrained_Delaunay_triangulation_2.h>


### PR DESCRIPTION
I got the following warning:
```
In file included from /usr/include/boost/signals2/slot_base.hpp:22,
                 from /usr/include/boost/signals2/detail/tracked_objects_visitor.hpp:18,
                 from /usr/include/boost/signals2/slot.hpp:22,
                 from /usr/include/boost/signals2/connection.hpp:24,
                 from /usr/include/boost/signals2/signal.hpp:22,
                 from /usr/include/boost/signals2.hpp:19,
                 from /homes/numerik/muench/store/sw-index/dealii/include/deal.II/base/init_finalize.h:24,
                 from /homes/numerik/muench/store/sw-index/dealii/include/deal.II/base/mpi.h:21,
                 from /homes/numerik/muench/store/sw-index/dealii/include/deal.II/base/aligned_vector.h:23,
                 from /homes/numerik/muench/store/sw-index/dealii/include/deal.II/base/table.h:20,
                 from /homes/numerik/muench/store/sw-index/dealii/include/deal.II/fe/fe_update_flags.h:21,
                 from /homes/numerik/muench/store/sw-index/dealii/include/deal.II/fe/mapping.h:24,
                 from /homes/numerik/muench/store/sw-index/dealii/include/deal.II/cgal/intersections.h:23,
                 from /homes/numerik/muench/store/sw-index/dealii/source/cgal/intersections.cc:17:
In member function ‘void boost::variant<T0, TN>::variant_assign(boost::variant<T0, TN>&&) [with T0_ = CGAL::Point_3<CGAL::Epeck>; TN = {CGAL::Segment_3<CGAL::Epeck>}]’,
    inlined from ‘boost::variant<T0, TN>& boost::variant<T0, TN>::operator=(boost::variant<T0, TN>&&) [with T0_ = CGAL::Point_3<CGAL::Epeck>; TN = {CGAL::Segment_3<CGAL::Epeck>}]’ at /usr/include/boost/variant/variant.hpp:2288:23,
    inlined from ‘void boost::optional_detail::optional_base<T>::assign_value(rval_reference_type) [with T = boost::variant<CGAL::Point_3<CGAL::Epeck>, CGAL::Segment_3<CGAL::Epeck> >]’ at /usr/include/boost/optional/optional.hpp:733:64,
    inlined from ‘void boost::optional_detail::optional_base<T>::assign_expr_to_initialized(Expr&&, const void*) [with Expr = CGAL::Point_3<CGAL::Epeck>; T = boost::variant<CGAL::Point_3<CGAL::Epeck>, CGAL::Segment_3<CGAL::Epeck> >]’ at /usr/include/boost/optional/optional.hpp:663:19,
    inlined from ‘void boost::optional_detail::optional_base<T>::assign_expr(Expr&&, const ExprPtr*) [with Expr = CGAL::Point_3<CGAL::Epeck>; ExprPtr = CGAL::Point_3<CGAL::Epeck>; T = boost::variant<CGAL::Point_3<CGAL::Epeck>, CGAL::Segment_3<CGAL::Epeck> >]’ at /usr/include/boost/optional/optional.hpp:348:35,
    inlined from ‘typename boost::enable_if<boost::optional_detail::is_optional_val_init_candidate<T, Expr>, boost::optional<T>&>::type boost::optional<T>::operator=(Expr&&) [with Expr = CGAL::Point_3<CGAL::Epeck>; T = boost::variant<CGAL::Point_3<CGAL::Epeck>, CGAL::Segment_3<CGAL::Epeck> >]’ at /usr/include/boost/optional/optional.hpp:979:26,
    inlined from ‘void CGAL::internal::Fill_lazy_variant_visitor_2<Result, AK, LK, EK, Origin>::operator()(const T&) [with T = CGAL::Point_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > >; Result = boost::optional<boost::variant<CGAL::Point_3<CGAL::Epeck>, CGAL::Segment_3<CGAL::Epeck> > >; AK = CGAL::Simple_cartesian<CGAL::Interval_nt<false> >; LK = CGAL::Epeck; EK = CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational> >; Origin = CGAL::Lazy<boost::optional<boost::variant<CGAL::Point_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > >, CGAL::Segment_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > > > >, boost::optional<boost::variant<CGAL::Point_3<CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational> > >, CGAL::Segment_3<CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational, boost::multiprecision::et_on> > > > >, CGAL::Cartesian_converter<CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational> >, CGAL::Simple_cartesian<CGAL::Interval_nt<false> > > >]’ at /usr/include/CGAL/Lazy.h:1918:8,
    inlined from ‘typename boost::disable_if_c<(MoveSemantics && boost::is_same<Value2, Value2>::value), typename Visitor::result_type>::type boost::detail::variant::invoke_visitor<Visitor, MoveSemantics>::internal_visit(T&&, int) [with T = CGAL::Point_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > >&; Visitor = CGAL::internal::Fill_lazy_variant_visitor_2<boost::optional<boost::variant<CGAL::Point_3<CGAL::Epeck>, CGAL::Segment_3<CGAL::Epeck> > >, CGAL::Simple_cartesian<CGAL::Interval_nt<false> >, CGAL::Epeck, CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational> >, CGAL::Lazy<boost::optional<boost::variant<CGAL::Point_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > >, CGAL::Segment_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > > > >, boost::optional<boost::variant<CGAL::Point_3<CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational> > >, CGAL::Segment_3<CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational, boost::multiprecision::et_on> > > > >, CGAL::Cartesian_converter<CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational> >, CGAL::Simple_cartesian<CGAL::Interval_nt<false> > > > >; bool MoveSemantics = false]’ at /usr/include/boost/variant/variant.hpp:1058:24,
    inlined from ‘typename Visitor::result_type boost::detail::variant::visitation_impl_invoke_impl(int, Visitor&, VoidPtrCV, T*, mpl_::true_) [with Visitor = invoke_visitor<CGAL::internal::Fill_lazy_variant_visitor_2<boost::optional<boost::variant<CGAL::Point_3<CGAL::Epeck>, CGAL::Segment_3<CGAL::Epeck> > >, CGAL::Simple_cartesian<CGAL::Interval_nt<false> >, CGAL::Epeck, CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational> >, CGAL::Lazy<boost::optional<boost::variant<CGAL::Point_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > >, CGAL::Segment_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > > > >, boost::optional<boost::variant<CGAL::Point_3<CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational> > >, CGAL::Segment_3<CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational, boost::multiprecision::et_on> > > > >, CGAL::Cartesian_converter<CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational> >, CGAL::Simple_cartesian<CGAL::Interval_nt<false> > > > >, false>; VoidPtrCV = void*; T = CGAL::Point_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > >]’ at /usr/include/boost/variant/detail/visitation_impl.hpp:112:34,
    inlined from ‘typename Visitor::result_type boost::detail::variant::visitation_impl_invoke(int, Visitor&, VoidPtrCV, T*, NoBackupFlag, int) [with Visitor = invoke_visitor<CGAL::internal::Fill_lazy_variant_visitor_2<boost::optional<boost::variant<CGAL::Point_3<CGAL::Epeck>, CGAL::Segment_3<CGAL::Epeck> > >, CGAL::Simple_cartesian<CGAL::Interval_nt<false> >, CGAL::Epeck, CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational> >, CGAL::Lazy<boost::optional<boost::variant<CGAL::Point_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > >, CGAL::Segment_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > > > >, boost::optional<boost::variant<CGAL::Point_3<CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational> > >, CGAL::Segment_3<CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational, boost::multiprecision::et_on> > > > >, CGAL::Cartesian_converter<CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational> >, CGAL::Simple_cartesian<CGAL::Interval_nt<false> > > > >, false>; VoidPtrCV = void*; T = CGAL::Point_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > >; NoBackupFlag = boost::variant<CGAL::Point_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > >, CGAL::Segment_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > > >::has_fallback_type_]’ at /usr/include/boost/variant/detail/visitation_impl.hpp:154:41,
    inlined from ‘typename Visitor::result_type boost::detail::variant::visitation_impl(int, int, Visitor&, VoidPtrCV, mpl_::false_, NoBackupFlag, Which*, step0*) [with Which = mpl_::int_<0>; step0 = visitation_impl_step<boost::mpl::l_iter<boost::mpl::l_item<mpl_::long_<2>, CGAL::Point_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > >, boost::mpl::l_item<mpl_::long_<1>, CGAL::Segment_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > >, boost::mpl::l_end> > >, boost::mpl::l_iter<boost::mpl::l_end> >; Visitor = invoke_visitor<CGAL::internal::Fill_lazy_variant_visitor_2<boost::optional<boost::variant<CGAL::Point_3<CGAL::Epeck>, CGAL::Segment_3<CGAL::Epeck> > >, CGAL::Simple_cartesian<CGAL::Interval_nt<false> >, CGAL::Epeck, CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational> >, CGAL::Lazy<boost::optional<boost::variant<CGAL::Point_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > >, CGAL::Segment_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > > > >, boost::optional<boost::variant<CGAL::Point_3<CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational> > >, CGAL::Segment_3<CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational, boost::multiprecision::et_on> > > > >, CGAL::Cartesian_converter<CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational> >, CGAL::Simple_cartesian<CGAL::Interval_nt<false> > > > >, false>; VoidPtrCV = void*; NoBackupFlag = boost::variant<CGAL::Point_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > >, CGAL::Segment_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > > >::has_fallback_type_]’ at /usr/include/boost/variant/detail/visitation_impl.hpp:238:5,
    inlined from ‘static typename Visitor::result_type boost::variant<T0, TN>::internal_apply_visitor_impl(int, int, Visitor&, VoidPtrCV) [with Visitor = boost::detail::variant::invoke_visitor<CGAL::internal::Fill_lazy_variant_visitor_2<boost::optional<boost::variant<CGAL::Point_3<CGAL::Epeck>, CGAL::Segment_3<CGAL::Epeck> > >, CGAL::Simple_cartesian<CGAL::Interval_nt<false> >, CGAL::Epeck, CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational> >, CGAL::Lazy<boost::optional<boost::variant<CGAL::Point_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > >, CGAL::Segment_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > > > >, boost::optional<boost::variant<CGAL::Point_3<CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational> > >, CGAL::Segment_3<CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational, boost::multiprecision::et_on> > > > >, CGAL::Cartesian_converter<CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational> >, CGAL::Simple_cartesian<CGAL::Interval_nt<false> > > > >, false>; VoidPtrCV = void*; T0_ = CGAL::Point_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > >; TN = {CGAL::Segment_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > >}]’ at /usr/include/boost/variant/variant.hpp:2452:48,
    inlined from ‘typename Visitor::result_type boost::variant<T0, TN>::internal_apply_visitor(Visitor&) [with Visitor = boost::detail::variant::invoke_visitor<CGAL::internal::Fill_lazy_variant_visitor_2<boost::optional<boost::variant<CGAL::Point_3<CGAL::Epeck>, CGAL::Segment_3<CGAL::Epeck> > >, CGAL::Simple_cartesian<CGAL::Interval_nt<false> >, CGAL::Epeck, CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational> >, CGAL::Lazy<boost::optional<boost::variant<CGAL::Point_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > >, CGAL::Segment_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > > > >, boost::optional<boost::variant<CGAL::Point_3<CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational> > >, CGAL::Segment_3<CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational, boost::multiprecision::et_on> > > > >, CGAL::Cartesian_converter<CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational> >, CGAL::Simple_cartesian<CGAL::Interval_nt<false> > > > >, false>; T0_ = CGAL::Point_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > >; TN = {CGAL::Segment_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > >}]’ at /usr/include/boost/variant/variant.hpp:2466:43,
    inlined from ‘typename Visitor::result_type boost::variant<T0, TN>::apply_visitor(Visitor&) & [with Visitor = CGAL::internal::Fill_lazy_variant_visitor_2<boost::optional<boost::variant<CGAL::Point_3<CGAL::Epeck>, CGAL::Segment_3<CGAL::Epeck> > >, CGAL::Simple_cartesian<CGAL::Interval_nt<false> >, CGAL::Epeck, CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational> >, CGAL::Lazy<boost::optional<boost::variant<CGAL::Point_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > >, CGAL::Segment_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > > > >, boost::optional<boost::variant<CGAL::Point_3<CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational> > >, CGAL::Segment_3<CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational, boost::multiprecision::et_on> > > > >, CGAL::Cartesian_converter<CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational> >, CGAL::Simple_cartesian<CGAL::Interval_nt<false> > > > >; T0_ = CGAL::Point_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > >; TN = {CGAL::Segment_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > >}]’ at /usr/include/boost/variant/variant.hpp:2518:44,
    inlined from ‘typename Visitor::result_type boost::apply_visitor(Visitor&, Visitable&&) [with Visitor = CGAL::internal::Fill_lazy_variant_visitor_2<optional<variant<CGAL::Point_3<CGAL::Epeck>, CGAL::Segment_3<CGAL::Epeck> > >, CGAL::Simple_cartesian<CGAL::Interval_nt<false> >, CGAL::Epeck, CGAL::Simple_cartesian<multiprecision::number<multiprecision::backends::gmp_rational> >, CGAL::Lazy<optional<variant<CGAL::Point_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > >, CGAL::Segment_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > > > >, optional<variant<CGAL::Point_3<CGAL::Simple_cartesian<multiprecision::number<multiprecision::backends::gmp_rational> > >, CGAL::Segment_3<CGAL::Simple_cartesian<multiprecision::number<multiprecision::backends::gmp_rational, boost::multiprecision::et_on> > > > >, CGAL::Cartesian_converter<CGAL::Simple_cartesian<multiprecision::number<multiprecision::backends::gmp_rational> >, CGAL::Simple_cartesian<CGAL::Interval_nt<false> > > > >; Visitable = variant<CGAL::Point_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > >, CGAL::Segment_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > > >&]’ at /usr/include/boost/variant/detail/apply_visitor_unary.hpp:73:64,
    inlined from ‘decltype(auto) CGAL::Lazy_construction_variant<LK, AC, EC>::operator()(const L1&, const L2&) const [with L1 = CGAL::Segment_3<CGAL::Epeck>; L2 = CGAL::Tetrahedron_3<CGAL::Epeck>; LK = CGAL::Epeck; AC = CGAL::CommonKernelFunctors::Intersect_3<CGAL::Simple_cartesian<CGAL::Interval_nt<false> > >; EC = CGAL::CommonKernelFunctors::Intersect_3<CGAL::Simple_cartesian<boost::multiprecision::number<boost::multiprecision::backends::gmp_rational> > >]’ at /usr/include/CGAL/Lazy.h:2026:29,
    inlined from ‘decltype(auto) CGAL::intersection(const Segment_3<R>&, const Tetrahedron_3<R>&) [with K = Epeck]’ at /usr/include/CGAL/Intersections_3/Segment_3_Tetrahedron_3.h:33:1,
    inlined from ‘std::vector<std::array<dealii::Point<3, double>, 2> > dealii::CGALWrappers::internal::compute_intersection_hexa_line(const dealii::ArrayView<const dealii::Point<3, double> >&, const dealii::ArrayView<const dealii::Point<3, double> >&, double)’ at /homes/numerik/muench/store/sw-index/dealii/source/cgal/intersections.cc:559:66:
/usr/include/boost/variant/variant.hpp:2189:13: warning: ‘*(boost::variant<CGAL::Point_3<CGAL::Epeck>, CGAL::Segment_3<CGAL::Epeck> >*)((char*)&res + offsetof(boost::result_type, boost::optional<boost::variant<CGAL::Point_3<CGAL::Epeck>, CGAL::Segment_3<CGAL::Epeck> > >::<unnamed>.boost::optional_detail::optional_base<boost::variant<CGAL::Point_3<CGAL::Epeck>, CGAL::Segment_3<CGAL::Epeck> > >::m_storage.boost::optional_detail::aligned_storage<boost::variant<CGAL::Point_3<CGAL::Epeck>, CGAL::Segment_3<CGAL::Epeck> > >::dummy_)).boost::variant<CGAL::Point_3<CGAL::Epeck>, CGAL::Segment_3<CGAL::Epeck> >::which_’ may be used uninitialized [-Wmaybe-uninitialized]
 2189 |         if (which_ == rhs.which_)

...
```

FYI @fdrmrc 