### PR TITLE
Portable MatrixFree: Export variable for n_q_points

### DIFF
--- a/include/deal.II/matrix_free/tools.h
+++ b/include/deal.II/matrix_free/tools.h
@@ -1459,6 +1459,7 @@ namespace MatrixFreeTools
     };
 
     static constexpr unsigned int n_local_dofs = QuadOperation::n_local_dofs;
+    static constexpr unsigned int n_q_points   = QuadOperation::n_q_points;
 
   private:
     mutable QuadOperation                  m_quad_operation;


### PR DESCRIPTION
I need this to prepare for the Kokkos code to work with `n_q_points_1d != fe_degree + 1`.