### PR TITLE
Make a test more comprehensive

### DIFF
--- a/tests/matrix_free/matrix_vector_rt_common.h
+++ b/tests/matrix_free/matrix_vector_rt_common.h
@@ -171,7 +171,7 @@ do_test(const DoFHandler<dim>           &dof,
   //   constraints.distribute(solution);
   MatrixFree<dim, Number> mf_data;
   {
-    const QGaussLobatto<1>                           quad(fe_degree + 2);
+    const QGauss<1>                                  quad(fe_degree + 2);
     const MappingQ<dim>                              mapping(fe_degree + 2);
     typename MatrixFree<dim, Number>::AdditionalData data;
     data.tasks_parallel_scheme = MatrixFree<dim, Number>::AdditionalData::none;

--- a/tests/matrix_free/matrix_vector_rt_face_common.h
+++ b/tests/matrix_free/matrix_vector_rt_face_common.h
@@ -230,7 +230,7 @@ do_test(const DoFHandler<dim>           &dof,
   const MappingQ<dim>     mapping(m_degree);
   MatrixFree<dim, Number> mf_data;
   {
-    const QGaussLobatto<1>                           quad(n_q_points);
+    const QGauss<1>                                  quad(n_q_points);
     typename MatrixFree<dim, Number>::AdditionalData data;
     data.tasks_parallel_scheme = MatrixFree<dim, Number>::AdditionalData::none;
     data.mapping_update_flags  = update_piola;
@@ -266,7 +266,7 @@ do_test(const DoFHandler<dim>           &dof,
 
   FEFaceValues<dim> fe_val(mapping,
                            dof.get_fe(),
-                           QGaussLobatto<dim - 1>(n_q_points),
+                           QGauss<dim - 1>(n_q_points),
                            update_values | update_gradients |
                              update_JxW_values | update_piola);
 


### PR DESCRIPTION
@nataneb found a bug in https://github.com/dealii/dealii/blob/7f9fa4f8371a33111f748ca3cc91a5ff75a85421/include/deal.II/matrix_free/evaluation_kernels.h#L2058 (this should apply the normal with direction `<2>` as this is the last component), but we apparently never realized this because the test only used the `QGaussLobatto` quadrature formula (where the interpolation matrix is the identity). We should really test the general case with a non-collocation quadrature formula.

I will not post the actual fix because I let @nataneb post the actual fix, as she discovered it.