### PR TITLE
Cleanup doxygen defines

### DIFF
--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -178,7 +178,6 @@ INCLUDE_FILE_PATTERNS  =
 PREDEFINED             = DOXYGEN=1 \
                          DEBUG=1 \
                          DEAL_II_WARNING(x)= \
-                         DEAL_II_USE_MT_POSIX=1 \
                          DEAL_II_CONSTEXPR=constexpr \
                          DEAL_II_NAMESPACE_OPEN= \
                          DEAL_II_NAMESPACE_CLOSE= \
@@ -187,7 +186,6 @@ PREDEFINED             = DOXYGEN=1 \
                          DEAL_II_DEPRECATED= \
                          DEAL_II_HOST_DEVICE= \
                          DEAL_II_ALWAYS_INLINE= \
-                         __device__= \
                          DEAL_II_WITH_ADOLC=1 \
                          DEAL_II_ADOLC_WITH_ADVANCED_BRANCHING=1 \
                          DEAL_II_ADOLC_WITH_ATRIG_ERF=1 \

--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -185,6 +185,7 @@ PREDEFINED             = DOXYGEN=1 \
                          DEAL_II_DISABLE_EXTRA_DIAGNOSTICS= \
                          DEAL_II_DEPRECATED= \
                          DEAL_II_HOST_DEVICE= \
+                         DEAL_II_HOST_DEVICE_ALWAYS_INLINE= \
                          DEAL_II_ALWAYS_INLINE= \
                          DEAL_II_WITH_ADOLC=1 \
                          DEAL_II_ADOLC_WITH_ADVANCED_BRANCHING=1 \
@@ -248,6 +249,7 @@ PREDEFINED             = DOXYGEN=1 \
                          DEAL_II_TRILINOS_WITH_NOX=1 \
                          DEAL_II_TRILINOS_WITH_ROL=1 \
                          DEAL_II_TRILINOS_WITH_SACADO=1 \
+                         DEAL_II_TRILINOS_WITH_SEACAS=1 \
                          DEAL_II_TRILINOS_WITH_TPETRA=1 \
                          DEAL_II_TRILINOS_WITH_ZOLTAN=1 \
                          DEAL_II_TRILINOS_VERSION_GTE=1 \


### PR DESCRIPTION
I was inspired by this long docstring:

![long-docstring](https://github.com/user-attachments/assets/0cf5534a-36b7-447e-8ea7-826aa9ca9165)

We can shorten that significantly by getting rid of the macro - we already do that for `DEAL_II_ALWAYS_INLINE`.