### PR TITLE
add team barriers to CellAction in matrix_free/tools.h

### DIFF
--- a/include/deal.II/matrix_free/tools.h
+++ b/include/deal.II/matrix_free/tools.h
@@ -1429,12 +1429,16 @@ namespace MatrixFreeTools
 
           Kokkos::single(Kokkos::PerTeam(shared_data->team_member),
                          [&] { diagonal[i] = fe_eval.get_dof_value(i); });
+
+          shared_data->team_member.team_barrier();
         }
 
       Kokkos::single(Kokkos::PerTeam(shared_data->team_member), [&] {
         for (unsigned int i = 0; i < dofs_per_cell; ++i)
           fe_eval.submit_dof_value(diagonal[i], i);
       });
+
+      shared_data->team_member.team_barrier();
 
       // We need to do the same as distribute_local_to_global but without
       // constraints since we have already taken care of them earlier


### PR DESCRIPTION
This PR addresses Issue #17869 . 

I found that function `MatrixFreeTools::compute_diagonal()` does not give the correct diagonal values, because the actions `diagonal[i] = fe_eval.get_dof_values(i);` and `fe_eval.submit_dof_value(diagonal[i], i);` are only executed by thread 0, while the other threads go ahead before the actions are done. So I add team barriers below the `Kokkos::single()` actions, and the runtime error in step-64 is eliminated. According to my test, neither of the team barriers is negligible.

Please check my modifications @Rombur @masterleinad .