### PR TITLE
parallel::distributed::Triangulation: should we clarify clear() method?

### DIFF
--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -1780,7 +1780,7 @@ namespace parallel
       // for clarity be explicit on which function is called
       try
         {
-          Triangulation<dim, spacedim>::clear();
+          parallel::distributed::Triangulation<dim, spacedim>::clear();
         }
       catch (...)
         {}


### PR DESCRIPTION
Let me start this PR as a discussion: Together with @lukasdreyer and @dominiktassilostill we've been looking at the following code in the destructor https://github.com/dealii/dealii/blob/16484460f0d2a2a02dcb45acb31b2715277dc3cf/source/distributed/tria.cc#L1778-L1784 and mistakenly thought that the code `Triangulation<dim, spacedim>::clear()` would refer to the method in the base class `Triangulation` and got extremely confused on the way (especially me). The problem is that both the base class `dealii::Triangulation` and the derived class `dealii::parallel::distributed::Triangulation` have the same name and only differ by the namespace they're located in, so it is confusing to the reader of the code as to which class we actually refer to. I must admit the comment at this place confused me more than it helped in this context of using the same class name (as one keeps forgetting the surrounding namespace more easily than the base or derived class name), even though it is clear why #5728 introduced it.

I would lean towards simply using `clear();` at this place, as suggested here. In that case, the comment should go away. I think the rule is intuitively clear in the sense that we call exactly the function of the present class in the destructor, not something else. But I could also use the opposite way and specify the full namespace, `parallel::distributed::Triangulation<dim, spacedim>::clear();` if that finds more approval.