### PR TITLE
Add another barrier in MatrixFreeTools::compute_diagonal()

### DIFF
--- a/include/deal.II/matrix_free/tools.h
+++ b/include/deal.II/matrix_free/tools.h
@@ -1409,6 +1409,8 @@ namespace MatrixFreeTools
             Kokkos::TeamThreadRange(shared_data->team_member, dofs_per_cell),
             [&](int j) { fe_eval.submit_dof_value(i == j ? 1 : 0, j); });
 
+          shared_data->team_member.team_barrier();
+
           Portable::internal::
             resolve_hanging_nodes<dim, fe_degree, false, Number>(
               shared_data->team_member,


### PR DESCRIPTION
Follow-up to #17894.
We need to make sure that all threads see the values set in the previous `Kokkos::parallel_for` before calling `resolve_hanging_nodes`. The values set might be used by the same hardware thread but semantically a different thread could be used in `reasolve_haging_nodes`.