### PR TITLE
Fix nightly rocm tests 

### DIFF
--- a/source/base/polynomials_piecewise.cc
+++ b/source/base/polynomials_piecewise.cc
@@ -139,9 +139,9 @@ namespace Polynomials
         else
           {
             const double offset = step * interval;
-            // ROCm 5.7 throw a floating point exception in debug when trying to
-            // evaluate (x < offset && x > offset + step). Separating the
-            // conditions fixes the issue.
+            // ROCm 5.7 throws a floating point exception in debug mode when
+            // trying to evaluate (x < offset && x > offset + step). Separating
+            // the conditions fixes the issue.
             if (x < offset)
               {
                 for (unsigned int k = 0; k <= n_derivatives; ++k)

--- a/source/base/polynomials_piecewise.cc
+++ b/source/base/polynomials_piecewise.cc
@@ -139,7 +139,16 @@ namespace Polynomials
         else
           {
             const double offset = step * interval;
-            if (x < offset || x > offset + step)
+            // ROCm 5.7 throw a floating point exception in debug when trying to
+            // evaluate (x < offset && x > offset + step). Separating the
+            // conditions fixes the issue.
+            if (x < offset)
+              {
+                for (unsigned int k = 0; k <= n_derivatives; ++k)
+                  values[k] = 0;
+                return;
+              }
+            else if (x > offset + step)
               {
                 for (unsigned int k = 0; k <= n_derivatives; ++k)
                   values[k] = 0;

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -2140,7 +2140,7 @@ GridOut::write_svg(const Triangulation<2, 2> &tria, std::ostream &out) const
 
           if (n != 1)
             {
-              // The assert is a workaround a compiler bug in ROCm 5.7 which
+              // The assert is a workaround for a compiler bug in ROCm 5.7 which
               // evaluated index/(n-1) when n == 1 in debug mode. When adding
               // the assert the ratio is not evaluated.
               Assert((n - 1.) != 0., ExcInvalidState());

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -2139,7 +2139,13 @@ GridOut::write_svg(const Triangulation<2, 2> &tria, std::ostream &out) const
           double h;
 
           if (n != 1)
-            h = .6 - (index / (n - 1.)) * .6;
+            {
+              // The assert is a workaround a compiler bug in ROCm 5.7 which
+              // evaluated index/(n-1) when n == 1 in debug mode. When adding
+              // the assert the ratio is not evaluated.
+              Assert((n - 1.) != 0., ExcInvalidState());
+              h = .6 - (index / (n - 1.)) * .6;
+            }
           else
             h = .6;
 

--- a/tests/examples/step-18.mpirun=2.with_petsc=true.output2
+++ b/tests/examples/step-18.mpirun=2.with_petsc=true.output2
@@ -1,0 +1,15 @@
+Timestep 1 at time 1
+  Cycle 0:
+    Number of active cells:       3712 (by partition: 1856+1856)
+    Number of degrees of freedom: 17226 (by partition: 8874+8352)
+    Assembling system... norm of rhs is 1.88062e+10
+Solver stopped after 113 iterations
+    Updating quadrature point data...
+  Cycle 1:
+    Number of active cells:       12805 (by partition: 6399+6406)
+    Number of degrees of freedom: 51720 (by partition: 25902+25818)
+    Assembling system... norm of rhs is 1.72532e+10
+Solver stopped after 151 iterations
+    Updating quadrature point data...
+    Moving mesh...
+


### PR DESCRIPTION
This PR fixes the failing tests in the ROCm nightly. Two changes are workaround compiler bugs and I've also added an output for step-18.