### PR TITLE
Fixed normal direction for the last component for RT elements

### DIFF
--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -2055,7 +2055,7 @@ namespace internal
                                                                   do_values);
             eval.template tangential<1, 2>(shape_data[1], values, values);
             eval.template tangential<0, 2>(shape_data[1], values, values);
-            eval.template normal<0>(shape_data[0], values, values_dofs, add);
+            eval.template normal<2>(shape_data[0], values, values_dofs, add);
           }
       }
     else


### PR DESCRIPTION
This change will fix the pull request #17891, as the correction for normal direction in  https://github.com/dealii/dealii/blob/7f9fa4f8371a33111f748ca3cc91a5ff75a85421/include/deal.II/matrix_free/evaluation_kernels.h#L2058 is made.