### PR TITLE
Periodicity constraints: skip artificial cell face dofs

### DIFF
--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -3146,6 +3146,17 @@ namespace DoFTools
           const unsigned int dofs_per_face =
             face_1->get_fe(face_1->nth_active_fe_index(0))
               .n_dofs_per_face(face_no);
+
+          // Skip further recursion if face_1 carries invalid dof indices,
+          // i.e., it is on an artificial cell.
+          std::vector<types::global_dof_index> dofs_1(dofs_per_face);
+          face_1->get_dof_indices(dofs_1, face_1->nth_active_fe_index(0));
+          for (unsigned int i = 0; i < dofs_per_face; ++i)
+            if (dofs_1[i] == numbers::invalid_dof_index)
+              {
+                return;
+              }
+
           FullMatrix<double> child_transformation(dofs_per_face, dofs_per_face);
           FullMatrix<double> subface_interpolation(dofs_per_face,
                                                    dofs_per_face);


### PR DESCRIPTION
In dof_tools_constraints.cc, the function set_periodicity_constraints(...) is looping over childrens and then checking if the cell is artificial or not. This part was changed so that the function no longer loops over the children on the faces of artificial cells. This allows the function to be used with the FE_RaviartThomas elements which do not provide fe.get_subface_interpolation_matrix(...) method.

Thanks to @kronbichler for helping to fix this issue.