### PR TITLE
[C++20 modules] Ensure that no file is truly empty.

### DIFF
--- a/include/deal.II/arborx/access_traits.h
+++ b/include/deal.II/arborx/access_traits.h
@@ -696,6 +696,14 @@ namespace ArborX
   }
 } // namespace ArborX
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif
 
 #endif

--- a/include/deal.II/arborx/bvh.h
+++ b/include/deal.II/arborx/bvh.h
@@ -185,5 +185,13 @@ namespace ArborXWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif
 #endif

--- a/include/deal.II/arborx/distributed_tree.h
+++ b/include/deal.II/arborx/distributed_tree.h
@@ -129,5 +129,13 @@ namespace ArborXWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif
 #endif

--- a/include/deal.II/base/function_cspline.h
+++ b/include/deal.II/base/function_cspline.h
@@ -135,6 +135,14 @@ namespace Functions
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif
 
 #endif

--- a/include/deal.II/base/hdf5.h
+++ b/include/deal.II/base/hdf5.h
@@ -2253,6 +2253,14 @@ namespace HDF5
 DEAL_II_NAMESPACE_CLOSE
 
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_HDF5
 
 #endif // dealii_hdf5_h

--- a/include/deal.II/base/mpi_large_count.h
+++ b/include/deal.II/base/mpi_large_count.h
@@ -447,5 +447,13 @@ namespace Utilities
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif
 #endif

--- a/include/deal.II/base/process_grid.h
+++ b/include/deal.II/base/process_grid.h
@@ -262,6 +262,14 @@ namespace Utilities
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_SCALAPACK
 
 #endif

--- a/include/deal.II/cgal/point_conversion.h
+++ b/include/deal.II/cgal/point_conversion.h
@@ -100,5 +100,13 @@ namespace CGALWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif
 #endif

--- a/include/deal.II/cgal/surface_mesh.h
+++ b/include/deal.II/cgal/surface_mesh.h
@@ -93,5 +93,13 @@ namespace CGALWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif
 #endif

--- a/include/deal.II/cgal/triangulation.h
+++ b/include/deal.II/cgal/triangulation.h
@@ -564,5 +564,13 @@ namespace CGALWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif
 #endif

--- a/include/deal.II/cgal/utilities.h
+++ b/include/deal.II/cgal/utilities.h
@@ -692,5 +692,13 @@ namespace CGALWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif
 #endif

--- a/include/deal.II/differentiation/ad/ad_helpers.h
+++ b/include/deal.II/differentiation/ad/ad_helpers.h
@@ -4137,6 +4137,14 @@ namespace Differentiation
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // defined(DEAL_II_WITH_ADOLC) || defined(DEAL_II_TRILINOS_WITH_SACADO)
 
 #endif // dealii_differentiation_ad_ad_helpers_h

--- a/include/deal.II/differentiation/ad/adolc_math.h
+++ b/include/deal.II/differentiation/ad/adolc_math.h
@@ -76,6 +76,14 @@ abs(const adtl::adouble &x)
 DEAL_II_NAMESPACE_CLOSE
 #  endif // DOXYGEN
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_ADOLC
 
 #endif

--- a/include/deal.II/differentiation/ad/adolc_product_types.h
+++ b/include/deal.II/differentiation/ad/adolc_product_types.h
@@ -274,6 +274,14 @@ struct EnableIfScalar<std::complex<adtl::adouble>>
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_ADOLC
 
 #endif

--- a/include/deal.II/differentiation/ad/sacado_math.h
+++ b/include/deal.II/differentiation/ad/sacado_math.h
@@ -93,6 +93,14 @@ DEAL_II_NAMESPACE_CLOSE
 
 #  endif // DOXYGEN
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_TRILINOS_WITH_SACADO
 
 #endif

--- a/include/deal.II/differentiation/ad/sacado_product_types.h
+++ b/include/deal.II/differentiation/ad/sacado_product_types.h
@@ -253,6 +253,14 @@ struct EnableIfScalar<Sacado::Rad::ADvari<T>>
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_TRILINOS_WITH_SACADO
 
 #endif

--- a/include/deal.II/differentiation/sd.h
+++ b/include/deal.II/differentiation/sd.h
@@ -53,6 +53,14 @@ namespace Differentiation
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_SYMENGINE
 
 #endif // dealii_differentiation_sd_h

--- a/include/deal.II/differentiation/sd/symengine_math.h
+++ b/include/deal.II/differentiation/sd/symengine_math.h
@@ -776,6 +776,14 @@ namespace std
 
 #  endif // DOXYGEN
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_SYMENGINE
 
 #endif

--- a/include/deal.II/differentiation/sd/symengine_number_traits.h
+++ b/include/deal.II/differentiation/sd/symengine_number_traits.h
@@ -81,6 +81,14 @@ namespace Differentiation
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_SYMENGINE
 
 #endif // dealii_differentiation_sd_symengine_number_traits_h

--- a/include/deal.II/differentiation/sd/symengine_number_types.h
+++ b/include/deal.II/differentiation/sd/symengine_number_types.h
@@ -1448,6 +1448,14 @@ namespace numbers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_SYMENGINE
 
 #endif // dealii_differentiation_sd_symengine_number_types_h

--- a/include/deal.II/differentiation/sd/symengine_number_visitor_internal.h
+++ b/include/deal.II/differentiation/sd/symengine_number_visitor_internal.h
@@ -1003,6 +1003,14 @@ namespace Differentiation
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_SYMENGINE
 
 #endif // dealii_differentiation_sd_symengine_number_visitor_internal_h

--- a/include/deal.II/differentiation/sd/symengine_optimizer.h
+++ b/include/deal.II/differentiation/sd/symengine_optimizer.h
@@ -2572,6 +2572,14 @@ namespace Differentiation
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_SYMENGINE
 
 #endif

--- a/include/deal.II/differentiation/sd/symengine_product_types.h
+++ b/include/deal.II/differentiation/sd/symengine_product_types.h
@@ -129,6 +129,14 @@ namespace internal
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_SYMENGINE
 
 #endif

--- a/include/deal.II/differentiation/sd/symengine_scalar_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_scalar_operations.h
@@ -1928,6 +1928,14 @@ namespace Differentiation
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_SYMENGINE
 
 #endif

--- a/include/deal.II/differentiation/sd/symengine_tensor_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_tensor_operations.h
@@ -1570,6 +1570,14 @@ namespace Differentiation
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_SYMENGINE
 
 #endif

--- a/include/deal.II/differentiation/sd/symengine_types.h
+++ b/include/deal.II/differentiation/sd/symengine_types.h
@@ -100,6 +100,14 @@ namespace boost
 
 #  endif // DOXYGEN
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_SYMENGINE
 
 #endif // dealii_differentiation_sd_symengine_types_h

--- a/include/deal.II/differentiation/sd/symengine_utilities.h
+++ b/include/deal.II/differentiation/sd/symengine_utilities.h
@@ -162,6 +162,14 @@ namespace Differentiation
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_SYMENGINE
 
 #endif // dealii_differentiation_sd_symengine_utilities_h

--- a/include/deal.II/distributed/cell_data_transfer.templates.h
+++ b/include/deal.II/distributed/cell_data_transfer.templates.h
@@ -366,6 +366,14 @@ namespace parallel
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif /* DEAL_II_WITH_P4EST */
 
 #endif /* dealii_distributed_cell_data_transfer_templates_h */

--- a/include/deal.II/distributed/p4est_wrappers.h
+++ b/include/deal.II/distributed/p4est_wrappers.h
@@ -643,6 +643,14 @@ namespace internal
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_P4EST
 
 #endif // dealii_p4est_wrappers_h

--- a/include/deal.II/gmsh/utilities.h
+++ b/include/deal.II/gmsh/utilities.h
@@ -98,5 +98,13 @@ namespace Gmsh
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif
 #endif

--- a/include/deal.II/lac/arpack_solver.h
+++ b/include/deal.II/lac/arpack_solver.h
@@ -899,5 +899,13 @@ ArpackSolver::control() const
 DEAL_II_NAMESPACE_CLOSE
 
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif
 #endif

--- a/include/deal.II/lac/ginkgo_solver.h
+++ b/include/deal.II/lac/ginkgo_solver.h
@@ -557,6 +557,14 @@ namespace GinkgoWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_GINKGO
 
 #endif

--- a/include/deal.II/lac/parpack_solver.h
+++ b/include/deal.II/lac/parpack_solver.h
@@ -1164,5 +1164,13 @@ PArpackSolver<VectorType>::control() const
 DEAL_II_NAMESPACE_CLOSE
 
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif
 #endif

--- a/include/deal.II/lac/petsc_block_sparse_matrix.h
+++ b/include/deal.II/lac/petsc_block_sparse_matrix.h
@@ -473,6 +473,14 @@ namespace PETScWrappers
 DEAL_II_NAMESPACE_CLOSE
 
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_PETSC
 
 #endif // dealii_petsc_block_sparse_matrix_h

--- a/include/deal.II/lac/petsc_block_vector.h
+++ b/include/deal.II/lac/petsc_block_vector.h
@@ -723,6 +723,14 @@ struct is_serial_vector<PETScWrappers::MPI::BlockVector> : std::false_type
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_PETSC
 
 #endif

--- a/include/deal.II/lac/petsc_communication_pattern.h
+++ b/include/deal.II/lac/petsc_communication_pattern.h
@@ -369,6 +369,14 @@ namespace PETScWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif
 
 #endif

--- a/include/deal.II/lac/petsc_compatibility.h
+++ b/include/deal.II/lac/petsc_compatibility.h
@@ -216,5 +216,13 @@ namespace PETScWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_PETSC
 #endif // dealii_petsc_compatibility_h

--- a/include/deal.II/lac/petsc_full_matrix.h
+++ b/include/deal.II/lac/petsc_full_matrix.h
@@ -91,6 +91,14 @@ namespace PETScWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_PETSC
 
 #endif

--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -1668,6 +1668,14 @@ namespace PETScWrappers
 DEAL_II_NAMESPACE_CLOSE
 
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_PETSC
 
 #endif

--- a/include/deal.II/lac/petsc_matrix_free.h
+++ b/include/deal.II/lac/petsc_matrix_free.h
@@ -278,6 +278,14 @@ namespace PETScWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_PETSC
 
 #endif

--- a/include/deal.II/lac/petsc_precondition.h
+++ b/include/deal.II/lac/petsc_precondition.h
@@ -1164,6 +1164,14 @@ namespace PETScWrappers
 DEAL_II_NAMESPACE_CLOSE
 
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_PETSC
 
 #endif

--- a/include/deal.II/lac/petsc_snes.h
+++ b/include/deal.II/lac/petsc_snes.h
@@ -492,6 +492,14 @@ namespace PETScWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_PETSC
 
 #endif

--- a/include/deal.II/lac/petsc_snes.templates.h
+++ b/include/deal.II/lac/petsc_snes.templates.h
@@ -707,6 +707,14 @@ namespace PETScWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_PETSC
 
 #endif

--- a/include/deal.II/lac/petsc_solver.h
+++ b/include/deal.II/lac/petsc_solver.h
@@ -977,6 +977,14 @@ namespace PETScWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_PETSC
 
 #endif

--- a/include/deal.II/lac/petsc_sparse_matrix.h
+++ b/include/deal.II/lac/petsc_sparse_matrix.h
@@ -664,6 +664,14 @@ namespace PETScWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_PETSC
 
 #endif

--- a/include/deal.II/lac/petsc_ts.h
+++ b/include/deal.II/lac/petsc_ts.h
@@ -777,6 +777,14 @@ namespace PETScWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_PETSC
 
 #endif

--- a/include/deal.II/lac/petsc_ts.templates.h
+++ b/include/deal.II/lac/petsc_ts.templates.h
@@ -1326,6 +1326,14 @@ namespace PETScWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_PETSC
 
 #endif

--- a/include/deal.II/lac/petsc_vector.h
+++ b/include/deal.II/lac/petsc_vector.h
@@ -574,6 +574,14 @@ struct is_serial_vector<PETScWrappers::MPI::Vector> : std::false_type
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_PETSC
 
 #endif

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -1379,6 +1379,14 @@ namespace PETScWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_PETSC
 
 #endif

--- a/include/deal.II/lac/scalapack.h
+++ b/include/deal.II/lac/scalapack.h
@@ -1047,6 +1047,14 @@ ScaLAPACKMatrix<NumberType>::local_n() const
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_SCALAPACK
 
 #endif

--- a/include/deal.II/lac/slepc_solver.h
+++ b/include/deal.II/lac/slepc_solver.h
@@ -855,6 +855,14 @@ namespace SLEPcWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#  else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #  endif // DEAL_II_WITH_SLEPC
 
 /*----------------------------   slepc_solver.h  ---------------------------*/

--- a/include/deal.II/lac/slepc_spectral_transformation.h
+++ b/include/deal.II/lac/slepc_spectral_transformation.h
@@ -247,6 +247,14 @@ namespace SLEPcWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#  else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #  endif // DEAL_II_WITH_SLEPC
 
 /*--------------------   slepc_spectral_transformation.h   ------------------*/

--- a/include/deal.II/lac/trilinos_block_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_block_sparse_matrix.h
@@ -616,6 +616,14 @@ namespace TrilinosWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_TRILINOS
 
 #endif // dealii_trilinos_block_sparse_matrix_h

--- a/include/deal.II/lac/trilinos_epetra_communication_pattern.h
+++ b/include/deal.II/lac/trilinos_epetra_communication_pattern.h
@@ -103,6 +103,14 @@ namespace LinearAlgebra
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif
 
 #endif

--- a/include/deal.II/lac/trilinos_epetra_vector.h
+++ b/include/deal.II/lac/trilinos_epetra_vector.h
@@ -823,6 +823,14 @@ struct is_serial_vector<LinearAlgebra::EpetraWrappers::Vector> : std::false_type
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif
 
 #endif

--- a/include/deal.II/lac/trilinos_index_access.h
+++ b/include/deal.II/lac/trilinos_index_access.h
@@ -197,5 +197,14 @@ namespace TrilinosWrappers
 } // namespace TrilinosWrappers
 
 DEAL_II_NAMESPACE_CLOSE
+
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_TRILINOS
 #endif // dealii_trilinos_index_access_h

--- a/include/deal.II/lac/trilinos_linear_operator.h
+++ b/include/deal.II/lac/trilinos_linear_operator.h
@@ -307,5 +307,13 @@ namespace TrilinosWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_TRILINOS
 #endif

--- a/include/deal.II/lac/trilinos_parallel_block_vector.h
+++ b/include/deal.II/lac/trilinos_parallel_block_vector.h
@@ -507,6 +507,14 @@ struct is_serial_vector<TrilinosWrappers::MPI::BlockVector> : std::false_type
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_TRILINOS
 
 #endif

--- a/include/deal.II/lac/trilinos_precondition.h
+++ b/include/deal.II/lac/trilinos_precondition.h
@@ -2179,6 +2179,14 @@ namespace TrilinosWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_TRILINOS
 
 #endif

--- a/include/deal.II/lac/trilinos_solver.h
+++ b/include/deal.II/lac/trilinos_solver.h
@@ -1393,6 +1393,14 @@ namespace TrilinosWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_TRILINOS
 
 #endif

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -3335,6 +3335,14 @@ namespace TrilinosWrappers
 DEAL_II_NAMESPACE_CLOSE
 
 
+#  else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #  endif // DEAL_II_WITH_TRILINOS
 
 

--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -1326,6 +1326,14 @@ namespace TrilinosWrappers
 DEAL_II_NAMESPACE_CLOSE
 
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_TRILINOS
 
 #endif

--- a/include/deal.II/lac/trilinos_tpetra_block_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_tpetra_block_sparse_matrix.h
@@ -457,6 +457,14 @@ namespace LinearAlgebra
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_TRILINOS_WITH_TPETRA
 
 #endif // dealii_tpetra_trilinos_block_sparse_matrix_h

--- a/include/deal.II/lac/trilinos_tpetra_block_sparse_matrix.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_block_sparse_matrix.templates.h
@@ -337,6 +337,14 @@ namespace LinearAlgebra
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_TRILINOS_WITH_TPETRA
 
 #endif // dealii_tpetra_trilinos_block_sparse_matrix_templates_h

--- a/include/deal.II/lac/trilinos_tpetra_block_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_block_vector.h
@@ -250,6 +250,14 @@ namespace LinearAlgebra
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_TRILINOS_WITH_TPETRA
 
 #endif // dealii_trilinos_tpetra_block_vector_h

--- a/include/deal.II/lac/trilinos_tpetra_block_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_block_vector.templates.h
@@ -231,6 +231,14 @@ namespace LinearAlgebra
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_TRILINOS_WITH_TPETRA
 
 #endif // dealii_trilinos_tpetra_block_vector_templates_h

--- a/include/deal.II/lac/trilinos_tpetra_communication_pattern.h
+++ b/include/deal.II/lac/trilinos_tpetra_communication_pattern.h
@@ -134,6 +134,14 @@ namespace LinearAlgebra
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif
 
 #endif

--- a/include/deal.II/lac/trilinos_tpetra_precondition.h
+++ b/include/deal.II/lac/trilinos_tpetra_precondition.h
@@ -1324,6 +1324,14 @@ namespace LinearAlgebra
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_TRILINOS_WITH_TPETRA
 
 #endif

--- a/include/deal.II/lac/trilinos_tpetra_precondition.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_precondition.templates.h
@@ -812,6 +812,14 @@ namespace LinearAlgebra
 DEAL_II_NAMESPACE_CLOSE
 
 #  endif // DEAL_II_TRILINOS_WITH_IFPACK2
-#endif   // DEAL_II_TRILINOS_WITH_TPETRA
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
+#endif // DEAL_II_TRILINOS_WITH_TPETRA
 
 #endif

--- a/include/deal.II/lac/trilinos_tpetra_solver_direct.h
+++ b/include/deal.II/lac/trilinos_tpetra_solver_direct.h
@@ -312,6 +312,14 @@ namespace LinearAlgebra
 DEAL_II_NAMESPACE_CLOSE
 
 #  endif // DEAL_II_TRILINOS_WITH_AMESOS2
-#endif   // DEAL_II_TRILINOS_WITH_TPETRA
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
+#endif // DEAL_II_TRILINOS_WITH_TPETRA
 
 #endif

--- a/include/deal.II/lac/trilinos_tpetra_solver_direct.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_solver_direct.templates.h
@@ -213,6 +213,14 @@ namespace LinearAlgebra
 DEAL_II_NAMESPACE_CLOSE
 
 #  endif // DEAL_II_TRILINOS_WITH_AMESOS2
-#endif   // DEAL_II_TRILINOS_WITH_TPETRA
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
+#endif // DEAL_II_TRILINOS_WITH_TPETRA
 
 #endif

--- a/include/deal.II/lac/trilinos_tpetra_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparse_matrix.h
@@ -2340,6 +2340,14 @@ namespace LinearAlgebra
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_TRILINOS_WITH_TPETRA
 
 #endif // dealii_trilinos_tpetra_sparse_matrix_h

--- a/include/deal.II/lac/trilinos_tpetra_sparse_matrix.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparse_matrix.templates.h
@@ -1618,6 +1618,14 @@ namespace LinearAlgebra
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_TRILINOS_WITH_TPETRA
 
 #endif // dealii_trilinos_tpetra_sparse_matrix_templates_h

--- a/include/deal.II/lac/trilinos_tpetra_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparsity_pattern.h
@@ -1376,6 +1376,14 @@ namespace LinearAlgebra
 DEAL_II_NAMESPACE_CLOSE
 
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_TRILINOS_WITH_TPETRA
 
 #endif

--- a/include/deal.II/lac/trilinos_tpetra_types.h
+++ b/include/deal.II/lac/trilinos_tpetra_types.h
@@ -177,6 +177,15 @@ namespace LinearAlgebra
   }   // namespace TpetraWrappers
 } // namespace LinearAlgebra
 DEAL_II_NAMESPACE_CLOSE
+
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif
 
 #endif

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -1551,6 +1551,14 @@ struct is_serial_vector<
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif
 
 #endif

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -1281,6 +1281,14 @@ namespace LinearAlgebra
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif
 
 #endif

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -2327,6 +2327,14 @@ struct is_serial_vector<TrilinosWrappers::MPI::Vector> : std::false_type
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif
 
 #endif

--- a/include/deal.II/opencascade/manifold_lib.h
+++ b/include/deal.II/opencascade/manifold_lib.h
@@ -422,5 +422,13 @@ namespace OpenCASCADE
 DEAL_II_NAMESPACE_CLOSE
 
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_OPENCASCADE
 #endif // dealii_occ_manifold_lib_h

--- a/include/deal.II/opencascade/utilities.h
+++ b/include/deal.II/opencascade/utilities.h
@@ -466,6 +466,14 @@ namespace OpenCASCADE
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_OPENCASCADE
 
 #endif

--- a/include/deal.II/optimization/rol/vector_adaptor.h
+++ b/include/deal.II/optimization/rol/vector_adaptor.h
@@ -506,6 +506,14 @@ namespace Rol
 DEAL_II_NAMESPACE_CLOSE
 
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_TRILINOS_WITH_ROL
 
 #endif // dealii_optimization_rol_vector_adaptor_h

--- a/include/deal.II/sundials/arkode.h
+++ b/include/deal.II/sundials/arkode.h
@@ -1185,6 +1185,15 @@ namespace SUNDIALS
 } // namespace SUNDIALS
 
 DEAL_II_NAMESPACE_CLOSE
+
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif
 
 

--- a/include/deal.II/sundials/ida.h
+++ b/include/deal.II/sundials/ida.h
@@ -1143,6 +1143,14 @@ namespace SUNDIALS
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_SUNDIALS
 
 #endif

--- a/include/deal.II/sundials/kinsol.h
+++ b/include/deal.II/sundials/kinsol.h
@@ -772,6 +772,14 @@ namespace SUNDIALS
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif
 
 #endif

--- a/include/deal.II/sundials/n_vector.h
+++ b/include/deal.II/sundials/n_vector.h
@@ -232,6 +232,15 @@ namespace SUNDIALS
   } // namespace internal
 } // namespace SUNDIALS
 
+
+DEAL_II_NAMESPACE_CLOSE
+
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
 DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/sundials/n_vector.templates.h
+++ b/include/deal.II/sundials/n_vector.templates.h
@@ -1385,5 +1385,13 @@ namespace SUNDIALS
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif
 #endif

--- a/include/deal.II/sundials/sundials_types.h
+++ b/include/deal.II/sundials/sundials_types.h
@@ -38,5 +38,13 @@ namespace SUNDIALS
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_SUNDIALS
 #endif // dealii_sundials_types_h

--- a/include/deal.II/sundials/sunlinsol_wrapper.h
+++ b/include/deal.II/sundials/sunlinsol_wrapper.h
@@ -255,5 +255,13 @@ namespace SUNDIALS
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif
 #endif

--- a/include/deal.II/sundials/utilities.h
+++ b/include/deal.II/sundials/utilities.h
@@ -100,6 +100,14 @@ namespace SUNDIALS
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif // DEAL_II_WITH_SUNDIALS
 
 #endif

--- a/include/deal.II/trilinos/nox.h
+++ b/include/deal.II/trilinos/nox.h
@@ -410,6 +410,14 @@ namespace TrilinosWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif
 
 #endif

--- a/include/deal.II/trilinos/nox.templates.h
+++ b/include/deal.II/trilinos/nox.templates.h
@@ -1265,6 +1265,14 @@ namespace TrilinosWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif
 
 #endif

--- a/include/deal.II/vtk/utilities.h
+++ b/include/deal.II/vtk/utilities.h
@@ -76,5 +76,13 @@ namespace VTKWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
 #endif
 #endif


### PR DESCRIPTION
I have been playing around with C++20-style modules and how we might actually create those without manual editing of our 650 or so header files. One of the issues I run into with the cmake and compiler tools all of this relies on is that a file like this
```
module;

#include <deal.II/base/config.h>

#ifdef DEAL_II_WITH_VTK

export module dealii:vtk;
export {
  ...much stuff ...
}

#endif
```
trips up the tools because after preprocessing, it does not actually export any module or module partitions. One could perhaps argue that that is silly and that compiling empty files should be allowed. But it is what it is.

This patch converts each of the 92 files this seems to affect by adding
```
#else

DEAL_II_NAMESPACE_OPEN
DEAL_II_NAMESPACE_CLOSE
```
at the bottom to ensure that the file is not truly empty. The scripts I currently have in mind latch onto the `DEAL_II_NAMESPACE_OPEN/CLOSE` macros to automatically add the `export module...; export {` part.

I'm not particularly tied to this patch at the moment. If others think it harmless and merge, that's great and makes my life easier. If you think it's a maintenance burden, and that we shouldn't do it, I'm ok with closing it. But I thought I'd post it since I have the patch ready and imagine that sooner or later I'll come back to it one way or the other.