### PR TITLE
Fix a place incorrectly using std::is_trivial.

### DIFF
--- a/include/deal.II/base/partitioner.templates.h
+++ b/include/deal.II/base/partitioner.templates.h
@@ -777,21 +777,14 @@ namespace Utilities
               Kokkos::deep_copy(
                 Kokkos::View<Number *, MemorySpace::Default::kokkos_space>(
                   ghost_array.data(), n_ghost_indices()),
-                0);
+                Number(0));
             }
           else
 #    endif
             {
-              if constexpr (std::is_trivial_v<Number>)
-                {
-                  std::memset(ghost_array.data(),
-                              0,
-                              sizeof(Number) * n_ghost_indices());
-                }
-              else
-                std::fill(ghost_array.data(),
-                          ghost_array.data() + n_ghost_indices(),
-                          0);
+              std::fill(ghost_array.data(),
+                        ghost_array.data() + n_ghost_indices(),
+                        Number(0));
             }
         }
 


### PR DESCRIPTION
This fixes one of the places where we used `std::is_trivial`, see #17913. The place is wrong, though: We use
```
              if constexpr (std::is_trivial_v<Number>)
                {
                  std::memset(ghost_array.data(),
                              0,
                              sizeof(Number) * n_ghost_indices());
                }
```
which implicitly assumes that all data types which we care about use bitwise zeros to represent the zero number. That *happens* to be the case for integers and floating point types, but that's mostly a coincidence. (Well, actually, it's good planning on behalf of the IEEE 754 folks, but you get the idea.) We shouldn't make that assumption.

While there, also convert two places where we provide `int(0)` where we really need `Number(0)` and rely on some internal conversion.