### PR TITLE
Avoid the final incorrect use of std::is_trivial.

### DIFF
--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -210,14 +210,9 @@ namespace internal
         Assert(end >= begin, ExcInternalError());
 
         if (value == Number())
-          {
-            if constexpr (std::is_trivial_v<Number>)
-              {
-                std::memset(dst + begin, 0, sizeof(Number) * (end - begin));
-                return;
-              }
-          }
-        std::fill(dst + begin, dst + end, value);
+          std::fill(dst + begin, dst + end, Number());
+        else
+          std::fill(dst + begin, dst + end, value);
       }
 
       const Number  value;


### PR DESCRIPTION
The underlying issue here is the same as in #17935 and #17936. In reference to #17913.