### PR TITLE
Avoid infinities in another place.

### DIFF
--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -12,6 +12,8 @@
 //
 // ------------------------------------------------------------------------
 
+#include <deal.II/base/signaling_nan.h>
+
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/grid_tools_cache.h>
 
@@ -1324,12 +1326,8 @@ namespace Particles
 
       // Reuse these vectors below, but only with a single element.
       // Avoid resizing for every particle.
-      Point<dim>      invalid_reference_point;
-      Point<spacedim> invalid_point;
-      invalid_reference_point[0] = std::numeric_limits<double>::infinity();
-      invalid_point[0]           = std::numeric_limits<double>::infinity();
-      reference_locations.resize(1, invalid_reference_point);
-      real_locations.resize(1, invalid_point);
+      reference_locations.resize(1, numbers::signaling_nan<Point<dim>>());
+      real_locations.resize(1, numbers::signaling_nan<Point<spacedim>>());
 
       // Find the cells that the particles moved to.
       for (auto &out_particle : particles_out_of_cell)


### PR DESCRIPTION
Another place where I'd like to avoid the use of infinities. Here, we initialize two arrays with points that contain an infinity as first component. I *think* that @gassmoeller probably just copied that over from some place in the mappings (see #17939), but what we *really* want to express here is that these arrays should be set to an invalid value. For that, we have `signaling_nan()`.

I checked that the `real_points` array is initialized just a few lines down, and that the output `unit_points` array is passed to `transform_points_real_to_unit_cell()`, which ignores the values that are in the array and overwrites these values with its output.