### PR TITLE
More places of avoiding infinities.

### DIFF
--- a/source/numerics/smoothness_estimator.cc
+++ b/source/numerics/smoothness_estimator.cc
@@ -236,7 +236,7 @@ namespace SmoothnessEstimator
 
               // choose the smallest decay of coefficients in each direction,
               // i.e. the maximum decay slope k_v as in exp(-k_v)
-              double k_v = std::numeric_limits<double>::infinity();
+              double k_v = std::numeric_limits<double>::max();
               for (unsigned int d = 0; d < dim; ++d)
                 {
                   x.resize(0);
@@ -521,7 +521,7 @@ namespace SmoothnessEstimator
 
               // choose the smallest decay of coefficients in each direction,
               // i.e. the maximum decay slope k_v as in exp(-k_v)
-              double k_v = std::numeric_limits<double>::infinity();
+              double k_v = std::numeric_limits<double>::max();
               for (unsigned int d = 0; d < dim; ++d)
                 {
                   x.resize(0);


### PR DESCRIPTION
Here, we want to take the minimum over several choices. It is sufficient to initialize with `std::numeric_limits::max()`, we don't actually need the infinity.