### PR TITLE
Change log for reading vtk meshes with field data

### DIFF
--- a/doc/news/changes/major/20241211Kale
+++ b/doc/news/changes/major/20241211Kale
@@ -1,0 +1,3 @@
+New: GridIn::read_vtk() was extended to read vtk meshes with field data defined at the cells, to enable importing and use of cell related data beyond a material ID or Manifold ID. The imported field data can be accessed using a new function get_cell_data(), which returns a map with a key containing the field data identifier and a vector containing the field data values associated with the cell indices of the imported mesh. 
+<br>
+(Vaishnavi Kale, Marc Secanell, Mohamad Ghadban and Mayank Sabharwal, 2024/12/11)

--- a/doc/news/changes/major/20241211Kale
+++ b/doc/news/changes/major/20241211Kale
@@ -1,3 +1,3 @@
-New: GridIn::read_vtk() was extended to read vtk meshes with field data defined at the cells, to enable importing and use of cell related data beyond a material ID or Manifold ID. The imported field data can be accessed using a new function get_cell_data(), which returns a map with a key containing the field data identifier and a vector containing the field data values associated with the cell indices of the imported mesh. 
+New: GridIn::read_vtk() was extended to read vtk meshes with field data defined at the cells, to enable importing and use of cell related data beyond a material ID or Manifold ID. The imported field data can be accessed using a new function get_cell_data(), which returns a map with a key containing the field data identifier and a vector containing the field data values associated with the cell indices of the imported mesh.
 <br>
 (Vaishnavi Kale, Marc Secanell, Mohamad Ghadban and Mayank Sabharwal, 2024/12/11)


### PR DESCRIPTION
This PR adds a change log in doc/news/changes/major corresponding to the new functionality that reads vtk meshes containing field data defined at the cells (added in PR#17866)