### PR TITLE
Fix the name of an object library.

### DIFF
--- a/source/particles/CMakeLists.txt
+++ b/source/particles/CMakeLists.txt
@@ -33,5 +33,5 @@ file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/particles/*.h
   )
 
-define_object_library(object_particle OBJECT ${_src} ${_header} ${_inst})
-expand_instantiations(object_particle "${_inst}")
+define_object_library(object_particles OBJECT ${_src} ${_header} ${_inst})
+expand_instantiations(object_particles "${_inst}")


### PR DESCRIPTION
I tried to do `ninja source/particles/CMakeFiles/object_particles_debug.dir/particle_handler.cc.o` and found that that doesn't work. The directory is called `particles`, but the name of the object library we create is called `object_particle` (without the 's' at the end). This is confusing. Fix it.