### PR TITLE
Fix VectorTools::interpolate for FE_Nothing

### DIFF
--- a/include/deal.II/numerics/vector_tools_interpolate.templates.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.templates.h
@@ -324,7 +324,10 @@ namespace VectorTools
           const auto &fe_i = fe[fe_index];
           // If the finite element has no dofs, we can skip it
           if (fe_i.dofs_per_cell == 0)
-            continue;
+            {
+              support_quadrature.push_back(Quadrature<dim>());
+              continue;
+            }
           Assert(fe_i.has_generalized_support_points(),
                  ExcMessage(
                    "The finite element does not have generalized support "


### PR DESCRIPTION
The change in #17520 broke the case where `FE_Nothing` is not the last element in the `FE_Collection`. Fix that by adding a dummy quadrature for `FE_Nothing`.