### PR TITLE
FEEvaluation: Only get shared vector data if we have DoFInfo

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -3912,8 +3912,9 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
   const auto src_data = internal::get_vector_data<n_components_>(
     src,
     first_index,
-    this->dof_access_index ==
-      internal::MatrixFreeFunctions::DoFInfo::dof_access_cell,
+    this->dof_info != nullptr &&
+      this->dof_access_index ==
+        internal::MatrixFreeFunctions::DoFInfo::dof_access_cell,
     this->active_fe_index,
     this->dof_info);
 


### PR DESCRIPTION
In case we do `FEEvaluation::reinit(typename DoFHandler::cell_iterator&)`, we do not have a `DoFInfo` object because we merely construct some information locally similarly to `FEValues`. Thus, we should not try to use data structures that rely on the presence of `DoFInfo` (which happens in the access of MPI-shared memory vector data in the `FEEvaluation::read_dof_values`).