### PR TITLE
fix unused argument warning in TriaAccessor::line_index

### DIFF
--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -5395,6 +5395,7 @@ template <int structdim, int dim, int spacedim>
 inline unsigned int
 TriaAccessor<structdim, dim, spacedim>::line_index(const unsigned int i) const
 {
+  (void)i;
   AssertIndexRange(i, this->n_lines());
   Assert(structdim != 1,
          ExcMessage("You can't ask for the index of a line bounding a "


### PR DESCRIPTION
This is got reported in #17968 with gcc 9.4 even though we disable the warning in release mode. Maybe this is due to inlining.