### PR TITLE
MappingManifold: use std::array.

### DIFF
--- a/include/deal.II/fe/mapping_manifold.h
+++ b/include/deal.II/fe/mapping_manifold.h
@@ -208,7 +208,8 @@ public:
      *
      * Computed each.
      */
-    mutable std::vector<Point<spacedim>> vertices;
+    mutable std::array<Point<spacedim>, GeometryInfo<dim>::vertices_per_cell>
+      vertices;
 
     /**
      * The current cell.
@@ -242,23 +243,20 @@ public:
      *
      * Computed once.
      */
-    std::vector<std::vector<double>> cell_manifold_quadrature_weights;
+    std::vector<std::array<double, GeometryInfo<dim>::vertices_per_cell>>
+      cell_manifold_quadrature_weights;
 
     /**
-     * A vector of weights for use in Manifold::get_new_point(). For
+     * An array of weights for use in Manifold::get_new_point(). For
      * each point (interior to a cell), we compute the weight each
      * vertex has for this point. If the point lies at a vertex, then
      * this vertex has weight one and all others have weight zero. If
      * the point lies interior to a cell, then the weight every vertex
      * has is just the $d$-linear shape functions associated with each
      * vertex evaluated at that point.
-     *
-     * This array has size GeometryInfo<dim>::vertices_per_cell, but it
-     * can't be converted into a fixed size array because it is used
-     * as input for Manifold::get_new_point() which wants to see a
-     * std::vector<double> for the weights.
      */
-    mutable std::vector<double> vertex_weights;
+    mutable std::array<double, GeometryInfo<dim>::vertices_per_cell>
+      vertex_weights;
 
     /**
      * Unit tangential vectors. Used for the computation of boundary forms and

--- a/source/fe/mapping_manifold.cc
+++ b/source/fe/mapping_manifold.cc
@@ -79,9 +79,6 @@ MappingManifold<dim, spacedim>::InternalData::reinit(
   // Store the quadrature
   this->quad.initialize(q.get_points(), q.get_weights());
 
-  // Resize the weights
-  this->vertex_weights.resize(GeometryInfo<dim>::vertices_per_cell);
-
   // see if we need the (transformation) shape function values
   // and/or gradients and resize the necessary arrays
   if (this->update_each &
@@ -157,7 +154,6 @@ void
 MappingManifold<dim, spacedim>::InternalData::store_vertices(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell) const
 {
-  vertices.resize(GeometryInfo<dim>::vertices_per_cell);
   for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
     vertices[i] = cell->vertex(i);
   this->cell = cell;
@@ -170,8 +166,7 @@ void
 MappingManifold<dim, spacedim>::InternalData::
   compute_manifold_quadrature_weights(const Quadrature<dim> &quad)
 {
-  cell_manifold_quadrature_weights.resize(
-    quad.size(), std::vector<double>(GeometryInfo<dim>::vertices_per_cell));
+  cell_manifold_quadrature_weights.resize(quad.size());
   for (unsigned int q = 0; q < quad.size(); ++q)
     {
       for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
@@ -384,9 +379,6 @@ namespace internal
       {
         const UpdateFlags update_flags = data.update_each;
 
-        AssertDimension(data.vertices.size(),
-                        GeometryInfo<dim>::vertices_per_cell);
-
         if (update_flags & update_quadrature_points)
           {
             for (unsigned int point = 0; point < quadrature_points.size();
@@ -425,8 +417,6 @@ namespace internal
                       data.contravariant.end(),
                       DerivativeForm<1, dim, spacedim>());
 
-            AssertDimension(GeometryInfo<dim>::vertices_per_cell,
-                            data.vertices.size());
             for (unsigned int point = 0; point < n_q_points; ++point)
               {
                 // Start by figuring out how to compute the direction in


### PR DESCRIPTION
This is a holdover from long ago when we required `std::vector` instead of `ArrayView` arguments to various `Manifold` functions.