### PR TITLE
Fix assert about distributed tria in NonMatching namespace 

### DIFF
--- a/source/non_matching/coupling.cc
+++ b/source/non_matching/coupling.cc
@@ -221,7 +221,7 @@ namespace NonMatching
            ExcNotImplemented());
 
     const bool tria_is_parallel =
-      (dynamic_cast<const parallel::TriangulationBase<dim1, spacedim> *>(
+      (dynamic_cast<const parallel::TriangulationBase<dim0, spacedim> *>(
          &space_dh.get_triangulation()) != nullptr);
     const auto &space_fe    = space_dh.get_fe();
     const auto &immersed_fe = immersed_dh.get_fe();
@@ -411,7 +411,7 @@ namespace NonMatching
            ExcNotImplemented());
 
     const bool tria_is_parallel =
-      (dynamic_cast<const parallel::TriangulationBase<dim1, spacedim> *>(
+      (dynamic_cast<const parallel::TriangulationBase<dim0, spacedim> *>(
          &space_dh.get_triangulation()) != nullptr);
 
     const auto &space_fe    = space_dh.get_fe();


### PR DESCRIPTION
This PR fixes two identical asserts in the non-matching namespace. In practice, the distributed path of the functions `create_coupling_sparsity_pattern()`, `create_coupling_mass_matrix()` was never taken (at least in codim-1 cases).

@luca-heltai