### PR TITLE
Add ReferenceCell::max_n_vertices<dim>().

### DIFF
--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -349,7 +349,12 @@ public:
    * <code>cell-@>vertex(v)</code>.
    */
   virtual boost::container::small_vector<Point<spacedim>,
-                                         GeometryInfo<dim>::vertices_per_cell>
+#ifndef _MSC_VER
+                                         ReferenceCell::max_n_vertices<dim>()
+#else
+                                         GeometryInfo<dim>::vertices_per_cell
+#endif
+                                         >
   get_vertices(
     const typename Triangulation<dim, spacedim>::cell_iterator &cell) const;
 
@@ -362,7 +367,12 @@ public:
    * @param[in] face_no The number of the face within the cell.
    */
   boost::container::small_vector<Point<spacedim>,
-                                 GeometryInfo<dim>::vertices_per_face>
+#ifndef _MSC_VER
+                                 ReferenceCell::max_n_vertices<dim - 1>()
+#else
+                                 GeometryInfo<dim - 1>::vertices_per_cell
+#endif
+                                 >
   get_vertices(const typename Triangulation<dim, spacedim>::cell_iterator &cell,
                const unsigned int face_no) const;
 

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -170,7 +170,12 @@ public:
    * that was passed at construction time.
    */
   virtual boost::container::small_vector<Point<spacedim>,
-                                         GeometryInfo<dim>::vertices_per_cell>
+#ifndef _MSC_VER
+                                         ReferenceCell::max_n_vertices<dim>()
+#else
+                                         GeometryInfo<dim>::vertices_per_cell
+#endif
+                                         >
   get_vertices(const typename Triangulation<dim, spacedim>::cell_iterator &cell)
     const override;
 

--- a/include/deal.II/fe/mapping_q1_eulerian.h
+++ b/include/deal.II/fe/mapping_q1_eulerian.h
@@ -118,7 +118,12 @@ public:
    * addition to the geometry of the cell.
    */
   virtual boost::container::small_vector<Point<spacedim>,
-                                         GeometryInfo<dim>::vertices_per_cell>
+#ifndef _MSC_VER
+                                         ReferenceCell::max_n_vertices<dim>()
+#else
+                                         GeometryInfo<dim>::vertices_per_cell
+#endif
+                                         >
   get_vertices(const typename Triangulation<dim, spacedim>::cell_iterator &cell)
     const override;
 

--- a/include/deal.II/fe/mapping_q_cache.h
+++ b/include/deal.II/fe/mapping_q_cache.h
@@ -195,7 +195,12 @@ public:
    * @copydoc Mapping::get_vertices()
    */
   virtual boost::container::small_vector<Point<spacedim>,
-                                         GeometryInfo<dim>::vertices_per_cell>
+#ifndef _MSC_VER
+                                         ReferenceCell::max_n_vertices<dim>()
+#else
+                                         GeometryInfo<dim>::vertices_per_cell
+#endif
+                                         >
   get_vertices(const typename Triangulation<dim, spacedim>::cell_iterator &cell)
     const override;
 

--- a/include/deal.II/fe/mapping_q_eulerian.h
+++ b/include/deal.II/fe/mapping_q_eulerian.h
@@ -122,7 +122,12 @@ public:
    * addition to the geometry of the cell.
    */
   virtual boost::container::small_vector<Point<spacedim>,
-                                         GeometryInfo<dim>::vertices_per_cell>
+#ifndef _MSC_VER
+                                         ReferenceCell::max_n_vertices<dim>()
+#else
+                                         GeometryInfo<dim>::vertices_per_cell
+#endif
+                                         >
   get_vertices(const typename Triangulation<dim, spacedim>::cell_iterator &cell)
     const override;
 

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -286,6 +286,17 @@ public:
   n_vertices() const;
 
   /**
+   * Return the maximum number of vertices an object of dimension `structdim`
+   * can have. This is always the number of vertices of a
+   * `structdim`-dimensional hypercube.
+   *
+   * @see ReferenceCell::max_n_faces()
+   */
+  template <int structdim>
+  static constexpr unsigned int
+  max_n_vertices();
+
+  /**
    * Return an object that can be thought of as an array containing all
    * indices from zero to n_vertices().
    */
@@ -1587,6 +1598,15 @@ ReferenceCell::n_vertices() const
     }
 
   return numbers::invalid_unsigned_int;
+}
+
+
+
+template <int structdim>
+inline constexpr unsigned int
+ReferenceCell::max_n_vertices()
+{
+  return GeometryInfo<structdim>::vertices_per_cell;
 }
 
 

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -5311,9 +5311,8 @@ TriaAccessor<structdim, dim, spacedim>::vertex_index(
     {
       // This branch should only be used after the cell vertex index cache is
       // set up
-      constexpr unsigned int max_vertices_per_cell = 1 << dim;
-      const std::size_t      my_index =
-        static_cast<std::size_t>(this->present_index) * max_vertices_per_cell;
+      const auto my_index = static_cast<std::size_t>(this->present_index) *
+                            ReferenceCell::max_n_vertices<dim>();
       AssertIndexRange(my_index + corner,
                        this->tria->levels[this->present_level]
                          ->cell_vertex_indices_cache.size());
@@ -6347,7 +6346,12 @@ double
 TriaAccessor<structdim, dim, spacedim>::diameter() const
 {
   boost::container::small_vector<Point<spacedim>,
-                                 GeometryInfo<structdim>::vertices_per_cell>
+#  ifndef _MSC_VER
+                                 ReferenceCell::max_n_vertices<structdim>()
+#  else
+                                 GeometryInfo<structdim>::vertices_per_cell
+#  endif
+                                 >
     vertices(this->n_vertices());
 
   for (unsigned int v = 0; v < vertices.size(); ++v)

--- a/source/fe/mapping.cc
+++ b/source/fe/mapping.cc
@@ -34,12 +34,22 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim, int spacedim>
 boost::container::small_vector<Point<spacedim>,
-                               GeometryInfo<dim>::vertices_per_cell>
+#  ifndef _MSC_VER
+                               ReferenceCell::max_n_vertices<dim>()
+#  else
+                               GeometryInfo<dim>::vertices_per_cell
+#  endif
+                               >
 Mapping<dim, spacedim>::get_vertices(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell) const
 {
   boost::container::small_vector<Point<spacedim>,
-                                 GeometryInfo<dim>::vertices_per_cell>
+#  ifndef _MSC_VER
+                                 ReferenceCell::max_n_vertices<dim>()
+#  else
+                                 GeometryInfo<dim>::vertices_per_cell
+#  endif
+                                 >
     vertices;
   for (const unsigned int i : cell->vertex_indices())
     vertices.push_back(cell->vertex(i));
@@ -51,13 +61,23 @@ Mapping<dim, spacedim>::get_vertices(
 
 template <int dim, int spacedim>
 boost::container::small_vector<Point<spacedim>,
-                               GeometryInfo<dim>::vertices_per_face>
+#  ifndef _MSC_VER
+                               ReferenceCell::max_n_vertices<dim - 1>()
+#  else
+                               GeometryInfo<dim - 1>::vertices_per_cell
+#  endif
+                               >
 Mapping<dim, spacedim>::get_vertices(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell,
   const unsigned int                                          face_no) const
 {
   boost::container::small_vector<Point<spacedim>,
-                                 GeometryInfo<dim>::vertices_per_face>
+#  ifndef _MSC_VER
+                                 ReferenceCell::max_n_vertices<dim - 1>()
+#  else
+                                 GeometryInfo<dim - 1>::vertices_per_cell
+#  endif
+                                 >
     face_vertices;
 
   const auto &cell_vertices    = get_vertices(cell);

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -447,7 +447,12 @@ MappingFEField<dim, spacedim, VectorType>::is_compatible_with(
 
 template <int dim, int spacedim, typename VectorType>
 boost::container::small_vector<Point<spacedim>,
-                               GeometryInfo<dim>::vertices_per_cell>
+#ifndef _MSC_VER
+                               ReferenceCell::max_n_vertices<dim>()
+#else
+                               GeometryInfo<dim>::vertices_per_cell
+#endif
+                               >
 MappingFEField<dim, spacedim, VectorType>::get_vertices(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell) const
 {
@@ -485,7 +490,12 @@ MappingFEField<dim, spacedim, VectorType>::get_vertices(
     uses_level_dofs ? *euler_vector[cell->level()] : *euler_vector[0];
 
   boost::container::small_vector<Point<spacedim>,
-                                 GeometryInfo<dim>::vertices_per_cell>
+#ifndef _MSC_VER
+                                 ReferenceCell::max_n_vertices<dim>()
+#else
+                                 GeometryInfo<dim>::vertices_per_cell
+#endif
+                                 >
     vertices(cell->n_vertices());
   for (unsigned int i = 0; i < dofs_per_cell; ++i)
     {

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -642,7 +642,12 @@ MappingQ<dim, spacedim>::transform_points_real_to_unit_cell(
   AssertDimension(real_points.size(), unit_points.size());
   std::vector<Point<spacedim>> support_points_higher_order;
   boost::container::small_vector<Point<spacedim>,
-                                 GeometryInfo<dim>::vertices_per_cell>
+#ifndef _MSC_VER
+                                 ReferenceCell::max_n_vertices<dim>()
+#else
+                                 GeometryInfo<dim>::vertices_per_cell
+#endif
+                                 >
     vertices;
   if (polynomial_degree == 1)
     vertices = this->get_vertices(cell);

--- a/source/fe/mapping_q1_eulerian.cc
+++ b/source/fe/mapping_q1_eulerian.cc
@@ -49,13 +49,23 @@ MappingQ1Eulerian<dim, VectorType, spacedim>::MappingQ1Eulerian(
 
 template <int dim, typename VectorType, int spacedim>
 boost::container::small_vector<Point<spacedim>,
-                               GeometryInfo<dim>::vertices_per_cell>
+#ifndef _MSC_VER
+                               ReferenceCell::max_n_vertices<dim>()
+#else
+                               GeometryInfo<dim>::vertices_per_cell
+#endif
+                               >
 MappingQ1Eulerian<dim, VectorType, spacedim>::get_vertices(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell) const
 {
   boost::container::small_vector<Point<spacedim>,
-                                 GeometryInfo<dim>::vertices_per_cell>
-    vertices(GeometryInfo<dim>::vertices_per_cell);
+#ifndef _MSC_VER
+                                 ReferenceCell::max_n_vertices<dim>()
+#else
+                                 GeometryInfo<dim>::vertices_per_cell
+#endif
+                                 >
+    vertices(cell->n_vertices());
   // The assertions can not be in the constructor, since this would
   // require to call dof_handler.distribute_dofs(fe) *before* the mapping
   // object is constructed, which is not necessarily what we want.

--- a/source/fe/mapping_q_cache.cc
+++ b/source/fe/mapping_q_cache.cc
@@ -728,7 +728,12 @@ MappingQCache<dim, spacedim>::compute_mapping_support_points(
 
 template <int dim, int spacedim>
 boost::container::small_vector<Point<spacedim>,
-                               GeometryInfo<dim>::vertices_per_cell>
+#ifndef _MSC_VER
+                               ReferenceCell::max_n_vertices<dim>()
+#else
+                               GeometryInfo<dim>::vertices_per_cell
+#endif
+                               >
 MappingQCache<dim, spacedim>::get_vertices(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell) const
 {
@@ -742,8 +747,12 @@ MappingQCache<dim, spacedim>::get_vertices(
   AssertIndexRange(cell->index(), (*support_point_cache)[cell->level()].size());
   const auto ptr = (*support_point_cache)[cell->level()][cell->index()].begin();
   return boost::container::small_vector<Point<spacedim>,
-                                        GeometryInfo<dim>::vertices_per_cell>(
-    ptr, ptr + cell->n_vertices());
+#ifndef _MSC_VER
+                                        ReferenceCell::max_n_vertices<dim>()
+#else
+                                        GeometryInfo<dim>::vertices_per_cell
+#endif
+                                        >(ptr, ptr + cell->n_vertices());
 }
 
 

--- a/source/fe/mapping_q_eulerian.cc
+++ b/source/fe/mapping_q_eulerian.cc
@@ -99,7 +99,12 @@ MappingQEulerian<dim, VectorType, spacedim>::SupportQuadrature::
 
 template <int dim, typename VectorType, int spacedim>
 boost::container::small_vector<Point<spacedim>,
-                               GeometryInfo<dim>::vertices_per_cell>
+#ifndef _MSC_VER
+                               ReferenceCell::max_n_vertices<dim>()
+#else
+                               GeometryInfo<dim>::vertices_per_cell
+#endif
+                               >
 MappingQEulerian<dim, VectorType, spacedim>::get_vertices(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell) const
 {
@@ -107,9 +112,13 @@ MappingQEulerian<dim, VectorType, spacedim>::get_vertices(
   const std::vector<Point<spacedim>> a = compute_mapping_support_points(cell);
 
   boost::container::small_vector<Point<spacedim>,
-                                 GeometryInfo<dim>::vertices_per_cell>
-    vertex_locations(a.begin(),
-                     a.begin() + GeometryInfo<dim>::vertices_per_cell);
+#ifndef _MSC_VER
+                                 ReferenceCell::max_n_vertices<dim>()
+#else
+                                 GeometryInfo<dim>::vertices_per_cell
+#endif
+                                 >
+    vertex_locations(a.begin(), a.begin() + cell->n_vertices());
 
   return vertex_locations;
 }

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -3498,7 +3498,7 @@ namespace internal
         [[maybe_unused]] unsigned int counter = 0;
 
         std::vector<unsigned int> key;
-        key.reserve(GeometryInfo<structdim>::vertices_per_cell);
+        key.reserve(ReferenceCell::max_n_vertices<structdim>());
 
         for (unsigned int o = 0; o < obj.n_objects(); ++o)
           {
@@ -15953,14 +15953,15 @@ void Triangulation<dim, spacedim>::reset_cell_vertex_indices_cache()
 {
   for (unsigned int l = 0; l < levels.size(); ++l)
     {
-      constexpr unsigned int     max_vertices_per_cell = 1 << dim;
       std::vector<unsigned int> &cache = levels[l]->cell_vertex_indices_cache;
       cache.clear();
-      cache.resize(levels[l]->refine_flags.size() * max_vertices_per_cell,
+      cache.resize(levels[l]->refine_flags.size() *
+                     ReferenceCell::max_n_vertices<dim>(),
                    numbers::invalid_unsigned_int);
       for (const auto &cell : cell_iterators_on_level(l))
         {
-          const unsigned int my_index = cell->index() * max_vertices_per_cell;
+          const unsigned int my_index =
+            cell->index() * ReferenceCell::max_n_vertices<dim>();
 
           // to reduce the cost of this function when passing down into quads,
           // then lines, then vertices, we use a more low-level access method


### PR DESCRIPTION
Like the other max functions, this helps us semantically disambiguate between a maximum value and the hypercube value.

I had to add more preprocessor checks to work around Windows Server 2019's MSVC's problems with boost. I'm not sure when GitHub will start removing support for that OS, but it may be soon: it entered extended support a year ago [1]. I think we should just leave these preprocessor defines until we retire support for that OS, which may be after the next release.

Part of #14667.

[1] https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2019