### PR TITLE
Bump minimum version for Trilinos to 12.14.1.

### DIFF
--- a/cmake/configure/configure_20_trilinos.cmake
+++ b/cmake/configure/configure_20_trilinos.cmake
@@ -79,17 +79,17 @@ macro(feature_trilinos_find_external var)
     endif()
 
     #
-    # We require at least Trilinos 12.4
+    # We require at least Trilinos 12.14.1
     #
-    if(TRILINOS_VERSION VERSION_LESS 12.4)
+    if(TRILINOS_VERSION VERSION_LESS 12.14.1)
       message(STATUS "Could not find a sufficient Trilinos installation: "
-        "deal.II requires at least version 12.4, but version ${TRILINOS_VERSION} was found."
+        "deal.II requires at least version 12.14.1, but version ${TRILINOS_VERSION} was found."
       )
       set(TRILINOS_ADDITIONAL_ERROR_STRING
         ${TRILINOS_ADDITIONAL_ERROR_STRING}
         "The Trilinos installation (found at \"${TRILINOS_DIR}\")\n"
         "with version ${TRILINOS_VERSION} is too old.\n"
-        "deal.II requires at least version 12.4.\n\n"
+        "deal.II requires at least version 12.14.1.\n\n"
       )
       set(${var} FALSE)
     endif()
@@ -194,23 +194,6 @@ macro(feature_trilinos_find_external var)
           "includes Kokkos, but DEAL_II_FORCE_BUNDLED_KOKKOS=ON!\n")
         set(${var} FALSE)
       endif()
-
-      #
-      # We require at least Trilinos 12.14.1
-      #
-      if(TRILINOS_VERSION VERSION_LESS 12.14.1)
-        message(STATUS "Could not find a sufficient Trilinos installation: "
-          "deal.II requires at least version 12.14.1 if the Trilinos installation includes Kokkos, "
-          "but version ${TRILINOS_VERSION} was found."
-        )
-        set(TRILINOS_ADDITIONAL_ERROR_STRING
-          ${TRILINOS_ADDITIONAL_ERROR_STRING}
-          "The Trilinos installation (found at \"${TRILINOS_DIR}\")\n"
-          "with version ${TRILINOS_VERSION} is too old.\n"
-          "deal.II requires at least version 12.14.1 if the Trilinos installation includes Kokkos.\n\n"
-        )
-        set(${var} FALSE)
-      endif()
     endif()
 
     if(TRILINOS_WITH_KOKKOS AND Kokkos_ENABLE_CUDA)
@@ -221,25 +204,6 @@ macro(feature_trilinos_find_external var)
       # we don't know if CUDA support is enabled in Kokkos
       set(DEAL_II_VECTORIZATION_WIDTH_IN_BITS 0)
       KOKKOS_CHECK(OPTIONS CUDA_LAMBDA)
-    endif()
-
-    if(TRILINOS_WITH_ROL)
-      #
-      # We require at least Trilinos 12.14.1
-      #
-      if(TRILINOS_VERSION VERSION_LESS 12.14.1)
-        message(STATUS "Could not find a sufficient Trilinos installation: "
-          "deal.II requires at least version 12.14.1 if the Trilinos installation includes ROL, "
-          "but version ${TRILINOS_VERSION} was found."
-        )
-        set(TRILINOS_ADDITIONAL_ERROR_STRING
-          ${TRILINOS_ADDITIONAL_ERROR_STRING}
-          "The Trilinos installation (found at \"${TRILINOS_DIR}\")\n"
-          "with version ${TRILINOS_VERSION} is too old.\n"
-          "deal.II requires at least version 12.14.1 if the Trilinos installation includes ROL.\n\n"
-        )
-        set(${var} FALSE)
-      endif()
     endif()
 
     if(TRILINOS_WITH_TPETRA)

--- a/doc/external-libs/trilinos.html
+++ b/doc/external-libs/trilinos.html
@@ -49,9 +49,8 @@
     <h5>Installing Trilinos</h5>
 
     <p style="color: red">
-      Note: The current version of deal.II requires at least Trilinos 12.4
-      (12.14.1 if Trilinos includes Kokkos).
-      Deal.II is known to work with Trilinos up to 13.4. Other versions of
+      Note: The current version of deal.II requires at least Trilinos 12.14.1.
+      Deal.II is known to work with Trilinos up to 16.0.0. Other versions of
       Trilinos should work too but have not been tested prior to the
       release.
     </p>

--- a/doc/news/changes/incompatibilities/20241128Fehling1
+++ b/doc/news/changes/incompatibilities/20241128Fehling1
@@ -1,4 +1,3 @@
-Changed: The minimum version for Trilinos has been bumped to 12.14.1
-if Trilinos bundles ROL.
+Changed: The minimum version for Trilinos has been bumped to 12.14.1.
 <br>
 (Marc Fehling, 2024/11/28)

--- a/source/lac/trilinos_epetra_vector.cc
+++ b/source/lac/trilinos_epetra_vector.cc
@@ -287,27 +287,12 @@ namespace LinearAlgebra
           Assert(this->size() == V.size(),
                  ExcDimensionMismatch(this->size(), V.size()));
 
-#  if DEAL_II_TRILINOS_VERSION_GTE(11, 11, 0)
           Epetra_Import data_exchange(vector->Map(), V.trilinos_vector().Map());
           const int     ierr = vector->Import(V.trilinos_vector(),
                                           data_exchange,
                                           Epetra_AddLocalAlso);
           Assert(ierr == 0, ExcTrilinosError(ierr));
           (void)ierr;
-#  else
-          // In versions older than 11.11 the Import function is broken for
-          // adding Hence, we provide a workaround in this case
-
-          Epetra_MultiVector dummy(vector->Map(), 1, false);
-          Epetra_Import data_exchange(dummy.Map(), V.trilinos_vector().Map());
-
-          int ierr = dummy.Import(V.trilinos_vector(), data_exchange, Insert);
-          Assert(ierr == 0, ExcTrilinosError(ierr));
-
-          ierr = vector->Update(1.0, dummy, 1.0);
-          Assert(ierr == 0, ExcTrilinosError(ierr));
-          (void)ierr;
-#  endif
         }
 
       return *this;

--- a/source/lac/trilinos_precondition_ml.cc
+++ b/source/lac/trilinos_precondition_ml.cc
@@ -94,10 +94,7 @@ namespace TrilinosWrappers
     parameter_list.set("coarse: type", coarse_type);
 
     // Force re-initialization of the random seed to make ML deterministic
-    // (only supported in trilinos >12.2):
-#  if DEAL_II_TRILINOS_VERSION_GTE(12, 4, 0)
     parameter_list.set("initialize random seed", true);
-#  endif
 
     parameter_list.set("smoother: sweeps", static_cast<int>(smoother_sweeps));
     parameter_list.set("cycle applications", static_cast<int>(n_cycles));

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -733,25 +733,11 @@ namespace TrilinosWrappers
           AssertThrow(size() == v.size(),
                       ExcDimensionMismatch(size(), v.size()));
 
-#  if DEAL_II_TRILINOS_VERSION_GTE(11, 11, 0)
           Epetra_Import data_exchange(vector->Map(), v.vector->Map());
           int           ierr =
             vector->Import(*v.vector, data_exchange, Epetra_AddLocalAlso);
           AssertThrow(ierr == 0, ExcTrilinosError(ierr));
           last_action = Add;
-#  else
-          // In versions older than 11.11 the Import function is broken for
-          // adding Hence, we provide a workaround in this case
-
-          Epetra_MultiVector dummy(vector->Map(), 1, false);
-          Epetra_Import      data_exchange(dummy.Map(), v.vector->Map());
-
-          int ierr = dummy.Import(*v.vector, data_exchange, Insert);
-          AssertThrow(ierr == 0, ExcTrilinosError(ierr));
-
-          ierr = vector->Update(1.0, dummy, 1.0);
-          AssertThrow(ierr == 0, ExcTrilinosError(ierr));
-#  endif
         }
     }
 


### PR DESCRIPTION
Follow-up to #17897.