### PR TITLE
Move `max_n_vertices<structdim>()` etc to `namespace ReferenceCells`.

### DIFF
--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -350,7 +350,7 @@ public:
    */
   virtual boost::container::small_vector<Point<spacedim>,
 #ifndef _MSC_VER
-                                         ReferenceCell::max_n_vertices<dim>()
+                                         ReferenceCells::max_n_vertices<dim>()
 #else
                                          GeometryInfo<dim>::vertices_per_cell
 #endif
@@ -368,7 +368,7 @@ public:
    */
   boost::container::small_vector<Point<spacedim>,
 #ifndef _MSC_VER
-                                 ReferenceCell::max_n_vertices<dim - 1>()
+                                 ReferenceCells::max_n_vertices<dim - 1>()
 #else
                                  GeometryInfo<dim - 1>::vertices_per_cell
 #endif

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -171,7 +171,7 @@ public:
    */
   virtual boost::container::small_vector<Point<spacedim>,
 #ifndef _MSC_VER
-                                         ReferenceCell::max_n_vertices<dim>()
+                                         ReferenceCells::max_n_vertices<dim>()
 #else
                                          GeometryInfo<dim>::vertices_per_cell
 #endif

--- a/include/deal.II/fe/mapping_q1_eulerian.h
+++ b/include/deal.II/fe/mapping_q1_eulerian.h
@@ -119,7 +119,7 @@ public:
    */
   virtual boost::container::small_vector<Point<spacedim>,
 #ifndef _MSC_VER
-                                         ReferenceCell::max_n_vertices<dim>()
+                                         ReferenceCells::max_n_vertices<dim>()
 #else
                                          GeometryInfo<dim>::vertices_per_cell
 #endif

--- a/include/deal.II/fe/mapping_q_cache.h
+++ b/include/deal.II/fe/mapping_q_cache.h
@@ -196,7 +196,7 @@ public:
    */
   virtual boost::container::small_vector<Point<spacedim>,
 #ifndef _MSC_VER
-                                         ReferenceCell::max_n_vertices<dim>()
+                                         ReferenceCells::max_n_vertices<dim>()
 #else
                                          GeometryInfo<dim>::vertices_per_cell
 #endif

--- a/include/deal.II/fe/mapping_q_eulerian.h
+++ b/include/deal.II/fe/mapping_q_eulerian.h
@@ -123,7 +123,7 @@ public:
    */
   virtual boost::container::small_vector<Point<spacedim>,
 #ifndef _MSC_VER
-                                         ReferenceCell::max_n_vertices<dim>()
+                                         ReferenceCells::max_n_vertices<dim>()
 #else
                                          GeometryInfo<dim>::vertices_per_cell
 #endif

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -286,17 +286,6 @@ public:
   n_vertices() const;
 
   /**
-   * Return the maximum number of vertices an object of dimension `structdim`
-   * can have. This is always the number of vertices of a
-   * `structdim`-dimensional hypercube.
-   *
-   * @see ReferenceCell::max_n_faces()
-   */
-  template <int structdim>
-  static constexpr unsigned int
-  max_n_vertices();
-
-  /**
    * Return an object that can be thought of as an array containing all
    * indices from zero to n_vertices().
    */
@@ -323,17 +312,6 @@ public:
   n_lines() const;
 
   /**
-   * Return the maximum number of lines an object of dimension `structdim` can
-   * have. This is always the number of lines of a `structdim`-dimensional
-   * hypercube.
-   *
-   * @see ReferenceCell::max_n_faces()
-   */
-  template <int structdim>
-  static constexpr unsigned int
-  max_n_lines();
-
-  /**
    * Return an object that can be thought of as an array containing all
    * indices from zero to n_lines().
    */
@@ -347,25 +325,6 @@ public:
    */
   unsigned int
   n_faces() const;
-
-  /**
-   * Return the maximum number of faces an object of dimension `structdim` can
-   * have. This is always the number of faces of a `structdim`-dimensional
-   * hypercube.
-   *
-   * @note The primary use case of this and the other maxima functions is to
-   * enable simple array indexing to per-face data by cell index and face
-   * number, e.g.,
-   *
-   * @code
-   *     cell->index() * ReferenceCell::max_n_faces<dim>() + face_no;
-   * @endcode
-   *
-   * is a unique index to the `face_no`th face of the current cell.
-   */
-  template <int structdim>
-  static constexpr unsigned int
-  max_n_faces();
 
   /**
    * Return an object that can be thought of as an array containing all
@@ -1157,6 +1116,47 @@ namespace ReferenceCells
   template <int dim>
   constexpr const ReferenceCell &
   get_hypercube();
+
+  /**
+   * Return the maximum number of vertices an object of dimension `structdim`
+   * can have. This is always the number of vertices of a
+   * `structdim`-dimensional hypercube.
+   *
+   * @see ReferenceCells::max_n_faces()
+   */
+  template <int structdim>
+  constexpr unsigned int
+  max_n_vertices();
+
+  /**
+   * Return the maximum number of lines an object of dimension `structdim` can
+   * have. This is always the number of lines of a `structdim`-dimensional
+   * hypercube.
+   *
+   * @see ReferenceCells::max_n_faces()
+   */
+  template <int structdim>
+  constexpr unsigned int
+  max_n_lines();
+
+  /**
+   * Return the maximum number of faces an object of dimension `structdim` can
+   * have. This is always the number of faces of a `structdim`-dimensional
+   * hypercube.
+   *
+   * @note The primary use case of this and the other maxima functions is to
+   * enable simple array indexing to per-face data by cell index and face
+   * number, e.g.,
+   *
+   * @code
+   *     cell->index() * ReferenceCells::max_n_faces<dim>() + face_no;
+   * @endcode
+   *
+   * is a unique index to the `face_no`th face of the current cell.
+   */
+  template <int structdim>
+  constexpr unsigned int
+  max_n_faces();
 } // namespace ReferenceCells
 
 
@@ -1602,15 +1602,6 @@ ReferenceCell::n_vertices() const
 
 
 
-template <int structdim>
-inline constexpr unsigned int
-ReferenceCell::max_n_vertices()
-{
-  return GeometryInfo<structdim>::vertices_per_cell;
-}
-
-
-
 inline unsigned int
 ReferenceCell::n_lines() const
 {
@@ -1637,15 +1628,6 @@ ReferenceCell::n_lines() const
     }
 
   return numbers::invalid_unsigned_int;
-}
-
-
-
-template <int structdim>
-inline constexpr unsigned int
-ReferenceCell::max_n_lines()
-{
-  return GeometryInfo<structdim>::lines_per_cell;
 }
 
 
@@ -1796,15 +1778,6 @@ ReferenceCell::n_faces() const
     }
 
   return numbers::invalid_unsigned_int;
-}
-
-
-
-template <int structdim>
-inline constexpr unsigned int
-ReferenceCell::max_n_faces()
-{
-  return GeometryInfo<structdim>::faces_per_cell;
 }
 
 
@@ -2638,6 +2611,33 @@ namespace ReferenceCells
           DEAL_II_NOT_IMPLEMENTED();
       }
     return ReferenceCells::Invalid;
+  }
+
+
+
+  template <int structdim>
+  inline constexpr unsigned int
+  max_n_vertices()
+  {
+    return GeometryInfo<structdim>::vertices_per_cell;
+  }
+
+
+
+  template <int structdim>
+  inline constexpr unsigned int
+  max_n_lines()
+  {
+    return GeometryInfo<structdim>::lines_per_cell;
+  }
+
+
+
+  template <int structdim>
+  inline constexpr unsigned int
+  max_n_faces()
+  {
+    return GeometryInfo<structdim>::faces_per_cell;
   }
 } // namespace ReferenceCells
 

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -3241,7 +3241,7 @@ public:
   boost::container::small_vector<
     TriaIterator<TriaAccessor<dim - 1, dim, spacedim>>,
 #ifndef _MSC_VER // MSVC prior to 2022 cannot use a constexpr function this way
-    ReferenceCell::max_n_faces<dim>()
+    ReferenceCells::max_n_faces<dim>()
 #else
     GeometryInfo<dim>::faces_per_cell
 #endif
@@ -4919,7 +4919,7 @@ namespace internal
       {
         return accessor.tria->levels[accessor.present_level]
           ->cells
-          .cells[accessor.present_index * ReferenceCell::max_n_faces<3>() + i];
+          .cells[accessor.present_index * ReferenceCells::max_n_faces<3>() + i];
       }
 
 
@@ -4958,7 +4958,8 @@ namespace internal
         if (dim != 1)
           accessor.tria->levels[accessor.present_level]
             ->face_orientations.set_combined_orientation(
-              accessor.present_index * ReferenceCell::max_n_faces<dim>() + face,
+              accessor.present_index * ReferenceCells::max_n_faces<dim>() +
+                face,
               combined_orientation);
       }
 
@@ -5009,7 +5010,7 @@ namespace internal
                   cell.get_triangulation()
                     .levels[cell.level()]
                     ->face_orientations.get_combined_orientation(
-                      cell.index() * ReferenceCell::max_n_faces<dim>() + f);
+                      cell.index() * ReferenceCells::max_n_faces<dim>() + f);
 
                 // It might seem superfluous to spell out the four indices
                 // that get later consumed by a for loop over these four
@@ -5033,7 +5034,7 @@ namespace internal
                   cell.get_triangulation()
                     .levels[cell.level()]
                     ->face_orientations.get_combined_orientation(
-                      cell.index() * ReferenceCell::max_n_faces<dim>() + f);
+                      cell.index() * ReferenceCells::max_n_faces<dim>() + f);
                 const std::array<unsigned int, 2> my_indices{
                   {ref_cell.standard_to_real_face_line(0, f, orientation),
                    ref_cell.standard_to_real_face_line(1, f, orientation)}};
@@ -5130,7 +5131,7 @@ namespace internal
                   cell.get_triangulation()
                     .levels[cell.level()]
                     ->face_orientations.get_combined_orientation(
-                      cell.index() * ReferenceCell::max_n_faces<dim>() + f);
+                      cell.index() * ReferenceCells::max_n_faces<dim>() + f);
 
                 // It might seem superfluous to spell out the four indices and
                 // orientations that get later consumed by a for loop over
@@ -5165,7 +5166,7 @@ namespace internal
                   cell.get_triangulation()
                     .levels[cell.level()]
                     ->face_orientations.get_combined_orientation(
-                      cell.index() * ReferenceCell::max_n_faces<3>() + f);
+                      cell.index() * ReferenceCells::max_n_faces<3>() + f);
                 const std::array<unsigned int, 2> my_indices{
                   {ref_cell.standard_to_real_face_line(0, f, orientation),
                    ref_cell.standard_to_real_face_line(1, f, orientation)}};
@@ -5305,14 +5306,14 @@ TriaAccessor<structdim, dim, spacedim>::vertex_index(
       // dim branch) so that we can get line vertex indices when setting up the
       // cell vertex index cache
       return this->objects()
-        .cells[this->present_index * ReferenceCell::max_n_faces<1>() + corner];
+        .cells[this->present_index * ReferenceCells::max_n_faces<1>() + corner];
     }
   else if constexpr (structdim == dim)
     {
       // This branch should only be used after the cell vertex index cache is
       // set up
       const auto my_index = static_cast<std::size_t>(this->present_index) *
-                            ReferenceCell::max_n_vertices<dim>();
+                            ReferenceCells::max_n_vertices<dim>();
       AssertIndexRange(my_index + corner,
                        this->tria->levels[this->present_level]
                          ->cell_vertex_indices_cache.size());
@@ -5380,7 +5381,7 @@ TriaAccessor<structdim, dim, spacedim>::line_index(const unsigned int i) const
   if constexpr (structdim == 2)
     {
       return this->objects()
-        .cells[this->present_index * ReferenceCell::max_n_faces<2>() + i];
+        .cells[this->present_index * ReferenceCells::max_n_faces<2>() + i];
     }
   else if constexpr (structdim == 3)
     {
@@ -5447,12 +5448,12 @@ TriaAccessor<structdim, dim, spacedim>::combined_face_orientation(
       else
         return this->tria->levels[this->present_level]
           ->face_orientations.get_orientation(
-            this->present_index * ReferenceCell::max_n_faces<dim>() + face);
+            this->present_index * ReferenceCells::max_n_faces<dim>() + face);
     }
   else
     return this->tria->levels[this->present_level]
       ->face_orientations.get_combined_orientation(
-        this->present_index * ReferenceCell::max_n_faces<dim>() + face);
+        this->present_index * ReferenceCells::max_n_faces<dim>() + face);
 }
 
 
@@ -5479,7 +5480,7 @@ TriaAccessor<structdim, dim, spacedim>::face_orientation(
   else
     return this->tria->levels[this->present_level]
       ->face_orientations.get_orientation(
-        this->present_index * ReferenceCell::max_n_faces<structdim>() + face);
+        this->present_index * ReferenceCells::max_n_faces<structdim>() + face);
 }
 
 
@@ -5499,7 +5500,7 @@ TriaAccessor<structdim, dim, spacedim>::face_flip(const unsigned int face) const
 
   if constexpr (structdim == 3)
     return this->tria->levels[this->present_level]->face_orientations.get_flip(
-      this->present_index * ReferenceCell::max_n_faces<structdim>() + face);
+      this->present_index * ReferenceCells::max_n_faces<structdim>() + face);
   else
     // In 1d and 2d, face_flip is always false as faces can only be
     // 'flipped' in 3d.
@@ -5524,7 +5525,7 @@ TriaAccessor<structdim, dim, spacedim>::face_rotation(
   if constexpr (structdim == 3)
     return this->tria->levels[this->present_level]
       ->face_orientations.get_rotation(
-        this->present_index * ReferenceCell::max_n_faces<structdim>() + face);
+        this->present_index * ReferenceCells::max_n_faces<structdim>() + face);
   else
     // In 1d and 2d, face_rotation is always false as faces can only be
     // 'rotated' in 3d.
@@ -5562,11 +5563,11 @@ TriaAccessor<structdim, dim, spacedim>::line_orientation(
   else if constexpr (structdim == 2 && dim == 3)
     {
       // line orientations in 3d are stored in their own array
-      Assert(this->present_index * ReferenceCell::max_n_lines<2>() + line <
+      Assert(this->present_index * ReferenceCells::max_n_lines<2>() + line <
                this->tria->faces->quads_line_orientations.size(),
              ExcInternalError());
       return this->tria->faces->quads_line_orientations
-        [this->present_index * ReferenceCell::max_n_lines<2>() + line];
+        [this->present_index * ReferenceCells::max_n_lines<2>() + line];
     }
   else if constexpr (structdim == 3 && dim == 3)
     {
@@ -5620,11 +5621,11 @@ TriaAccessor<structdim, dim, spacedim>::set_line_orientation(
       // We set line orientations per face, not per cell, so this only works for
       // faces in 3d
       Assert(structdim == 2, ExcNotImplemented());
-      Assert(this->present_index * ReferenceCell::max_n_lines<2>() + line <
+      Assert(this->present_index * ReferenceCells::max_n_lines<2>() + line <
                this->tria->faces->quads_line_orientations.size(),
              ExcInternalError());
       this->tria->faces->quads_line_orientations
-        [this->present_index * ReferenceCell::max_n_lines<2>() + line] = value;
+        [this->present_index * ReferenceCells::max_n_lines<2>() + line] = value;
     }
 }
 
@@ -6347,7 +6348,7 @@ TriaAccessor<structdim, dim, spacedim>::diameter() const
 {
   boost::container::small_vector<Point<spacedim>,
 #  ifndef _MSC_VER
-                                 ReferenceCell::max_n_vertices<structdim>()
+                                 ReferenceCells::max_n_vertices<structdim>()
 #  else
                                  GeometryInfo<structdim>::vertices_per_cell
 #  endif
@@ -7666,7 +7667,7 @@ template <int dim, int spacedim>
 inline boost::container::small_vector<
   TriaIterator<TriaAccessor<dim - 1, dim, spacedim>>,
 #  ifndef _MSC_VER
-  ReferenceCell::max_n_faces<dim>()
+  ReferenceCells::max_n_faces<dim>()
 #  else
   GeometryInfo<dim>::faces_per_cell
 #  endif
@@ -7676,7 +7677,7 @@ CellAccessor<dim, spacedim>::face_iterators() const
   boost::container::small_vector<
     TriaIterator<TriaAccessor<dim - 1, dim, spacedim>>,
 #  ifndef _MSC_VER
-    ReferenceCell::max_n_faces<dim>()
+    ReferenceCells::max_n_faces<dim>()
 #  else
     GeometryInfo<dim>::faces_per_cell
 #  endif
@@ -7719,7 +7720,7 @@ CellAccessor<dim, spacedim>::neighbor_index(const unsigned int face_no) const
 {
   AssertIndexRange(face_no, this->n_faces());
   return this->tria->levels[this->present_level]
-    ->neighbors[this->present_index * ReferenceCell::max_n_faces<dim>() +
+    ->neighbors[this->present_index * ReferenceCells::max_n_faces<dim>() +
                 face_no]
     .second;
 }
@@ -7732,7 +7733,7 @@ CellAccessor<dim, spacedim>::neighbor_level(const unsigned int face_no) const
 {
   AssertIndexRange(face_no, this->n_faces());
   return this->tria->levels[this->present_level]
-    ->neighbors[this->present_index * ReferenceCell::max_n_faces<dim>() +
+    ->neighbors[this->present_index * ReferenceCells::max_n_faces<dim>() +
                 face_no]
     .first;
 }

--- a/include/deal.II/matrix_free/fe_evaluation_data.h
+++ b/include/deal.II/matrix_free/fe_evaluation_data.h
@@ -1544,7 +1544,7 @@ FEEvaluationData<dim, Number, is_face>::get_current_cell_index() const
 {
   if (is_face && dof_access_index ==
                    internal::MatrixFreeFunctions::DoFInfo::dof_access_cell)
-    return cell * ReferenceCell::max_n_faces<dim>() + face_numbers[0];
+    return cell * ReferenceCells::max_n_faces<dim>() + face_numbers[0];
   else
     return cell;
 }

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -3099,10 +3099,10 @@ namespace internal
           // counting
           AssertDimension(cell_type.size(), cells.size() / n_lanes);
           face_data_by_cells[my_q].data_index_offsets.resize(
-            cell_type.size() * ReferenceCell::max_n_faces<dim>());
+            cell_type.size() * ReferenceCells::max_n_faces<dim>());
           if (update_flags & update_quadrature_points)
             face_data_by_cells[my_q].quadrature_point_offsets.resize(
-              cell_type.size() * ReferenceCell::max_n_faces<dim>());
+              cell_type.size() * ReferenceCells::max_n_faces<dim>());
           std::size_t storage_length = 0;
           for (unsigned int i = 0; i < cell_type.size(); ++i)
             for (const unsigned int face : GeometryInfo<dim>::face_indices())
@@ -3110,54 +3110,54 @@ namespace internal
                 if (faces_by_cells_type[i][face] <= affine)
                   {
                     face_data_by_cells[my_q].data_index_offsets
-                      [i * ReferenceCell::max_n_faces<dim>() + face] =
+                      [i * ReferenceCells::max_n_faces<dim>() + face] =
                       storage_length;
                     ++storage_length;
                   }
                 else
                   {
                     face_data_by_cells[my_q].data_index_offsets
-                      [i * ReferenceCell::max_n_faces<dim>() + face] =
+                      [i * ReferenceCells::max_n_faces<dim>() + face] =
                       storage_length;
                     storage_length +=
                       face_data_by_cells[my_q].descriptor[0].n_q_points;
                   }
                 if (update_flags & update_quadrature_points)
                   face_data_by_cells[my_q].quadrature_point_offsets
-                    [i * ReferenceCell::max_n_faces<dim>() + face] =
-                    (i * ReferenceCell::max_n_faces<dim>() + face) *
+                    [i * ReferenceCells::max_n_faces<dim>() + face] =
+                    (i * ReferenceCells::max_n_faces<dim>() + face) *
                     face_data_by_cells[my_q].descriptor[0].n_q_points;
               }
           face_data_by_cells[my_q].JxW_values.resize_fast(
-            storage_length * ReferenceCell::max_n_faces<dim>());
+            storage_length * ReferenceCells::max_n_faces<dim>());
           face_data_by_cells[my_q].jacobians[0].resize_fast(
-            storage_length * ReferenceCell::max_n_faces<dim>());
+            storage_length * ReferenceCells::max_n_faces<dim>());
           face_data_by_cells[my_q].jacobians[1].resize_fast(
-            storage_length * ReferenceCell::max_n_faces<dim>());
+            storage_length * ReferenceCells::max_n_faces<dim>());
           if (update_flags & update_normal_vectors)
             face_data_by_cells[my_q].normal_vectors.resize_fast(
-              storage_length * ReferenceCell::max_n_faces<dim>());
+              storage_length * ReferenceCells::max_n_faces<dim>());
           if (update_flags & update_normal_vectors &&
               update_flags & update_jacobians)
             face_data_by_cells[my_q].normals_times_jacobians[0].resize_fast(
-              storage_length * ReferenceCell::max_n_faces<dim>());
+              storage_length * ReferenceCells::max_n_faces<dim>());
           if (update_flags & update_normal_vectors &&
               update_flags & update_jacobians)
             face_data_by_cells[my_q].normals_times_jacobians[1].resize_fast(
-              storage_length * ReferenceCell::max_n_faces<dim>());
+              storage_length * ReferenceCells::max_n_faces<dim>());
           if (update_flags & update_jacobian_grads)
             {
               face_data_by_cells[my_q].jacobian_gradients[0].resize_fast(
-                storage_length * ReferenceCell::max_n_faces<dim>());
+                storage_length * ReferenceCells::max_n_faces<dim>());
               face_data_by_cells[my_q]
                 .jacobian_gradients_non_inverse[0]
                 .resize_fast(storage_length *
-                             ReferenceCell::max_n_faces<dim>());
+                             ReferenceCells::max_n_faces<dim>());
             }
 
           if (update_flags & update_quadrature_points)
             face_data_by_cells[my_q].quadrature_points.resize_fast(
-              cell_type.size() * ReferenceCell::max_n_faces<dim>() *
+              cell_type.size() * ReferenceCells::max_n_faces<dim>() *
               face_data_by_cells[my_q].descriptor[0].n_q_points);
         }
 
@@ -3195,9 +3195,8 @@ namespace internal
               dealii::FEFaceValues<dim> &fe_val_neigh =
                 *fe_face_values_neigh[my_q][fe_index];
               const unsigned int offset =
-                face_data_by_cells[my_q]
-                  .data_index_offsets[cell * ReferenceCell::max_n_faces<dim>() +
-                                      face];
+                face_data_by_cells[my_q].data_index_offsets
+                  [cell * ReferenceCells::max_n_faces<dim>() + face];
 
               const GeometryType my_cell_type = faces_by_cells_type[cell][face];
 
@@ -3334,7 +3333,8 @@ namespace internal
                       for (unsigned int d = 0; d < dim; ++d)
                         face_data_by_cells[my_q].quadrature_points
                           [face_data_by_cells[my_q].quadrature_point_offsets
-                             [cell * ReferenceCell::max_n_faces<dim>() + face] +
+                             [cell * ReferenceCells::max_n_faces<dim>() +
+                              face] +
                            q][d][v] = fe_val.quadrature_point(q)[d];
                 }
               if (update_flags & update_normal_vectors &&
@@ -3372,7 +3372,7 @@ namespace internal
       memory += cell_type.capacity() * sizeof(GeometryType);
       memory += face_type.capacity() * sizeof(GeometryType);
       memory += faces_by_cells_type.capacity() *
-                ReferenceCell::max_n_faces<dim>() * sizeof(GeometryType);
+                ReferenceCells::max_n_faces<dim>() * sizeof(GeometryType);
       memory += sizeof(*this);
       return memory;
     }
@@ -3398,7 +3398,7 @@ namespace internal
       out << "    Faces by cells types:            ";
       task_info.print_memory_statistics(out,
                                         faces_by_cells_type.capacity() *
-                                          ReferenceCell::max_n_faces<dim>() *
+                                          ReferenceCells::max_n_faces<dim>() *
                                           sizeof(GeometryType));
 
       for (unsigned int j = 0; j < cell_data.size(); ++j)

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -2571,7 +2571,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::get_faces_by_cells_boundary_id(
   const unsigned int face_number) const
 {
   AssertIndexRange(cell_batch_index, n_cell_batches());
-  AssertIndexRange(face_number, ReferenceCell::max_n_faces<dim>());
+  AssertIndexRange(face_number, ReferenceCells::max_n_faces<dim>());
   Assert(face_info.cell_and_face_boundary_id.size(0) >= n_cell_batches(),
          ExcNotInitialized());
   std::array<types::boundary_id, VectorizedArrayType::size()> result;

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -2062,7 +2062,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
         numbers::invalid_unsigned_int);
       face_info.cell_and_face_boundary_id.reinit(
         TableIndices<3>(task_info.cell_partition_data.back(),
-                        ReferenceCell::max_n_faces<dim>(),
+                        ReferenceCells::max_n_faces<dim>(),
                         VectorizedArrayType::size()),
         true);
       face_info.cell_and_face_boundary_id.fill(numbers::invalid_boundary_id);

--- a/source/fe/mapping.cc
+++ b/source/fe/mapping.cc
@@ -35,7 +35,7 @@ DEAL_II_NAMESPACE_OPEN
 template <int dim, int spacedim>
 boost::container::small_vector<Point<spacedim>,
 #  ifndef _MSC_VER
-                               ReferenceCell::max_n_vertices<dim>()
+                               ReferenceCells::max_n_vertices<dim>()
 #  else
                                GeometryInfo<dim>::vertices_per_cell
 #  endif
@@ -45,7 +45,7 @@ Mapping<dim, spacedim>::get_vertices(
 {
   boost::container::small_vector<Point<spacedim>,
 #  ifndef _MSC_VER
-                                 ReferenceCell::max_n_vertices<dim>()
+                                 ReferenceCells::max_n_vertices<dim>()
 #  else
                                  GeometryInfo<dim>::vertices_per_cell
 #  endif
@@ -62,7 +62,7 @@ Mapping<dim, spacedim>::get_vertices(
 template <int dim, int spacedim>
 boost::container::small_vector<Point<spacedim>,
 #  ifndef _MSC_VER
-                               ReferenceCell::max_n_vertices<dim - 1>()
+                               ReferenceCells::max_n_vertices<dim - 1>()
 #  else
                                GeometryInfo<dim - 1>::vertices_per_cell
 #  endif
@@ -73,7 +73,7 @@ Mapping<dim, spacedim>::get_vertices(
 {
   boost::container::small_vector<Point<spacedim>,
 #  ifndef _MSC_VER
-                                 ReferenceCell::max_n_vertices<dim - 1>()
+                                 ReferenceCells::max_n_vertices<dim - 1>()
 #  else
                                  GeometryInfo<dim - 1>::vertices_per_cell
 #  endif

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -448,7 +448,7 @@ MappingFEField<dim, spacedim, VectorType>::is_compatible_with(
 template <int dim, int spacedim, typename VectorType>
 boost::container::small_vector<Point<spacedim>,
 #ifndef _MSC_VER
-                               ReferenceCell::max_n_vertices<dim>()
+                               ReferenceCells::max_n_vertices<dim>()
 #else
                                GeometryInfo<dim>::vertices_per_cell
 #endif
@@ -491,7 +491,7 @@ MappingFEField<dim, spacedim, VectorType>::get_vertices(
 
   boost::container::small_vector<Point<spacedim>,
 #ifndef _MSC_VER
-                                 ReferenceCell::max_n_vertices<dim>()
+                                 ReferenceCells::max_n_vertices<dim>()
 #else
                                  GeometryInfo<dim>::vertices_per_cell
 #endif

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -643,7 +643,7 @@ MappingQ<dim, spacedim>::transform_points_real_to_unit_cell(
   std::vector<Point<spacedim>> support_points_higher_order;
   boost::container::small_vector<Point<spacedim>,
 #ifndef _MSC_VER
-                                 ReferenceCell::max_n_vertices<dim>()
+                                 ReferenceCells::max_n_vertices<dim>()
 #else
                                  GeometryInfo<dim>::vertices_per_cell
 #endif

--- a/source/fe/mapping_q1_eulerian.cc
+++ b/source/fe/mapping_q1_eulerian.cc
@@ -50,7 +50,7 @@ MappingQ1Eulerian<dim, VectorType, spacedim>::MappingQ1Eulerian(
 template <int dim, typename VectorType, int spacedim>
 boost::container::small_vector<Point<spacedim>,
 #ifndef _MSC_VER
-                               ReferenceCell::max_n_vertices<dim>()
+                               ReferenceCells::max_n_vertices<dim>()
 #else
                                GeometryInfo<dim>::vertices_per_cell
 #endif
@@ -60,7 +60,7 @@ MappingQ1Eulerian<dim, VectorType, spacedim>::get_vertices(
 {
   boost::container::small_vector<Point<spacedim>,
 #ifndef _MSC_VER
-                                 ReferenceCell::max_n_vertices<dim>()
+                                 ReferenceCells::max_n_vertices<dim>()
 #else
                                  GeometryInfo<dim>::vertices_per_cell
 #endif

--- a/source/fe/mapping_q_cache.cc
+++ b/source/fe/mapping_q_cache.cc
@@ -729,7 +729,7 @@ MappingQCache<dim, spacedim>::compute_mapping_support_points(
 template <int dim, int spacedim>
 boost::container::small_vector<Point<spacedim>,
 #ifndef _MSC_VER
-                               ReferenceCell::max_n_vertices<dim>()
+                               ReferenceCells::max_n_vertices<dim>()
 #else
                                GeometryInfo<dim>::vertices_per_cell
 #endif
@@ -748,7 +748,7 @@ MappingQCache<dim, spacedim>::get_vertices(
   const auto ptr = (*support_point_cache)[cell->level()][cell->index()].begin();
   return boost::container::small_vector<Point<spacedim>,
 #ifndef _MSC_VER
-                                        ReferenceCell::max_n_vertices<dim>()
+                                        ReferenceCells::max_n_vertices<dim>()
 #else
                                         GeometryInfo<dim>::vertices_per_cell
 #endif

--- a/source/fe/mapping_q_eulerian.cc
+++ b/source/fe/mapping_q_eulerian.cc
@@ -100,7 +100,7 @@ MappingQEulerian<dim, VectorType, spacedim>::SupportQuadrature::
 template <int dim, typename VectorType, int spacedim>
 boost::container::small_vector<Point<spacedim>,
 #ifndef _MSC_VER
-                               ReferenceCell::max_n_vertices<dim>()
+                               ReferenceCells::max_n_vertices<dim>()
 #else
                                GeometryInfo<dim>::vertices_per_cell
 #endif
@@ -113,7 +113,7 @@ MappingQEulerian<dim, VectorType, spacedim>::get_vertices(
 
   boost::container::small_vector<Point<spacedim>,
 #ifndef _MSC_VER
-                                 ReferenceCell::max_n_vertices<dim>()
+                                 ReferenceCells::max_n_vertices<dim>()
 #else
                                  GeometryInfo<dim>::vertices_per_cell
 #endif

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -3771,7 +3771,7 @@ namespace
                     const long        element_n = elements[side_n] - 1;
                     const long        face_n    = faces[side_n] - 1;
                     const std::size_t face_id =
-                      element_n * ReferenceCell::max_n_faces<dim>() + face_n;
+                      element_n * ReferenceCells::max_n_faces<dim>() + face_n;
                     face_side_sets[face_id].push_back(side_set_id);
                   }
               }
@@ -3818,9 +3818,9 @@ namespace
               }
             // Record the b_or_m_id of the current face.
             const unsigned int local_face_n =
-              face_id % ReferenceCell::max_n_faces<dim>();
+              face_id % ReferenceCells::max_n_faces<dim>();
             const CellData<dim> &cell =
-              cells[face_id / ReferenceCell::max_n_faces<dim>()];
+              cells[face_id / ReferenceCells::max_n_faces<dim>()];
             const ReferenceCell cell_type =
               ReferenceCell::n_vertices_to_type(dim, cell.vertices.size());
             const unsigned int deal_face_n =

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -1837,13 +1837,13 @@ namespace
     switch (structdim)
       {
         case 0:
-          return ReferenceCell::max_n_faces<0>();
+          return ReferenceCells::max_n_faces<0>();
         case 1:
-          return ReferenceCell::max_n_faces<1>();
+          return ReferenceCells::max_n_faces<1>();
         case 2:
-          return ReferenceCell::max_n_faces<2>();
+          return ReferenceCells::max_n_faces<2>();
         case 3:
-          return ReferenceCell::max_n_faces<3>();
+          return ReferenceCells::max_n_faces<3>();
         default:
           DEAL_II_ASSERT_UNREACHABLE();
           return numbers::invalid_unsigned_int;
@@ -2070,7 +2070,7 @@ namespace internal
         {
           // reserve the field of the derived class
           tria_faces.quads_line_orientations.resize(
-            new_size * ReferenceCell::max_n_lines<2>(), true);
+            new_size * ReferenceCells::max_n_lines<2>(), true);
 
           auto &q_is_q = tria_faces.quad_is_quadrilateral;
           q_is_q.reserve(new_size);
@@ -3267,7 +3267,7 @@ namespace internal
             for (unsigned int line = 0; line < n_lines; ++line)
               for (unsigned int i = crs.ptr[line], j = 0; i < crs.ptr[line + 1];
                    ++i, ++j)
-                lines_0.cells[line * ReferenceCell::max_n_faces<1>() + j] =
+                lines_0.cells[line * ReferenceCells::max_n_faces<1>() + j] =
                   crs.col[i]; // set vertex indices
           }
 
@@ -3298,7 +3298,7 @@ namespace internal
                   {
                     AssertIndexRange(j, reference_cell.n_lines());
                     // set line index
-                    quads_0.cells[q * ReferenceCell::max_n_lines<2>() + j] =
+                    quads_0.cells[q * ReferenceCells::max_n_lines<2>() + j] =
                       crs.col[i];
 
                     // set line orientations
@@ -3314,7 +3314,7 @@ namespace internal
                           ReferenceCell::reversed_combined_line_orientation(),
                       ExcInternalError());
                     faces.quads_line_orientations
-                      [q * ReferenceCell::max_n_lines<2>() + j] =
+                      [q * ReferenceCells::max_n_lines<2>() + j] =
                       combined_orientation ==
                       ReferenceCell::default_combined_face_orientation();
                   }
@@ -3370,18 +3370,18 @@ namespace internal
                 {
                   // set neighbor if not at boundary
                   if (nei.col[i] != static_cast<unsigned int>(-1))
-                    level.neighbors[cell * ReferenceCell::max_n_faces<dim>() +
+                    level.neighbors[cell * ReferenceCells::max_n_faces<dim>() +
                                     j] = {0, nei.col[i]};
 
                   // set face indices
-                  cells_0.cells[cell * ReferenceCell::max_n_faces<dim>() + j] =
+                  cells_0.cells[cell * ReferenceCells::max_n_faces<dim>() + j] =
                     crs.col[i];
 
                   // set face orientation if needed
                   if (orientation_needed)
                     {
                       level.face_orientations.set_combined_orientation(
-                        cell * ReferenceCell::max_n_faces<dim>() + j,
+                        cell * ReferenceCells::max_n_faces<dim>() + j,
                         connectivity.entity_orientations(dim - 1)
                           .get_combined_orientation(i));
                     }
@@ -3498,7 +3498,7 @@ namespace internal
         [[maybe_unused]] unsigned int counter = 0;
 
         std::vector<unsigned int> key;
-        key.reserve(ReferenceCell::max_n_vertices<structdim>());
+        key.reserve(ReferenceCells::max_n_vertices<structdim>());
 
         for (unsigned int o = 0; o < obj.n_objects(); ++o)
           {
@@ -15956,12 +15956,12 @@ void Triangulation<dim, spacedim>::reset_cell_vertex_indices_cache()
       std::vector<unsigned int> &cache = levels[l]->cell_vertex_indices_cache;
       cache.clear();
       cache.resize(levels[l]->refine_flags.size() *
-                     ReferenceCell::max_n_vertices<dim>(),
+                     ReferenceCells::max_n_vertices<dim>(),
                    numbers::invalid_unsigned_int);
       for (const auto &cell : cell_iterators_on_level(l))
         {
           const unsigned int my_index =
-            cell->index() * ReferenceCell::max_n_vertices<dim>();
+            cell->index() * ReferenceCells::max_n_vertices<dim>();
 
           // to reduce the cost of this function when passing down into quads,
           // then lines, then vertices, we use a more low-level access method
@@ -15982,7 +15982,7 @@ void Triangulation<dim, spacedim>::reset_cell_vertex_indices_cache()
 
                 const unsigned char combined_orientation =
                   levels[l]->face_orientations.get_combined_orientation(
-                    cell->index() * ReferenceCell::max_n_faces<dim>() + face);
+                    cell->index() * ReferenceCells::max_n_faces<dim>() + face);
                 std::array<unsigned int, 4> vertex_order{
                   {ref_cell.standard_to_real_face_vertex(0,
                                                          face,

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -2357,27 +2357,18 @@ CellAccessor<dim, spacedim>::set_neighbor(
 {
   AssertIndexRange(i, this->n_faces());
 
+  auto &neighbor =
+    this->tria->levels[this->present_level]
+      ->neighbors[this->present_index * ReferenceCells::max_n_faces<dim>() + i];
   if (pointer.state() == IteratorState::valid)
     {
-      this->tria->levels[this->present_level]
-        ->neighbors[this->present_index * ReferenceCells::max_n_faces<dim>() +
-                    i]
-        .first = pointer->present_level;
-      this->tria->levels[this->present_level]
-        ->neighbors[this->present_index * ReferenceCells::max_n_faces<dim>() +
-                    i]
-        .second = pointer->present_index;
+      neighbor.first  = pointer->present_level;
+      neighbor.second = pointer->present_index;
     }
   else
     {
-      this->tria->levels[this->present_level]
-        ->neighbors[this->present_index * ReferenceCells::max_n_faces<dim>() +
-                    i]
-        .first = -1;
-      this->tria->levels[this->present_level]
-        ->neighbors[this->present_index * ReferenceCells::max_n_faces<dim>() +
-                    i]
-        .second = -1;
+      neighbor.first  = -1;
+      neighbor.second = -1;
     }
 }
 

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -2360,19 +2360,23 @@ CellAccessor<dim, spacedim>::set_neighbor(
   if (pointer.state() == IteratorState::valid)
     {
       this->tria->levels[this->present_level]
-        ->neighbors[this->present_index * ReferenceCell::max_n_faces<dim>() + i]
+        ->neighbors[this->present_index * ReferenceCells::max_n_faces<dim>() +
+                    i]
         .first = pointer->present_level;
       this->tria->levels[this->present_level]
-        ->neighbors[this->present_index * ReferenceCell::max_n_faces<dim>() + i]
+        ->neighbors[this->present_index * ReferenceCells::max_n_faces<dim>() +
+                    i]
         .second = pointer->present_index;
     }
   else
     {
       this->tria->levels[this->present_level]
-        ->neighbors[this->present_index * ReferenceCell::max_n_faces<dim>() + i]
+        ->neighbors[this->present_index * ReferenceCells::max_n_faces<dim>() +
+                    i]
         .first = -1;
       this->tria->levels[this->present_level]
-        ->neighbors[this->present_index * ReferenceCell::max_n_faces<dim>() + i]
+        ->neighbors[this->present_index * ReferenceCells::max_n_faces<dim>() +
+                    i]
         .second = -1;
     }
 }


### PR DESCRIPTION
Followup to #17974. Part of #14667.