### PR TITLE
Be consistent about escaping names of code gallery programs.

### DIFF
--- a/doc/doxygen/scripts/code-gallery.pl
+++ b/doc/doxygen/scripts/code-gallery.pl
@@ -60,7 +60,7 @@ foreach my $gallery (@ARGV)
     chop $authors;
     $authors =~ s/,$//;
 
-    $gallery_underscore    =~ s/-/_/;
+    $gallery_underscore    =~ s/-/_/g;
 
     my $description;
     $description = "  <dt><b>\@ref code_gallery_${gallery_underscore} \"$entryname\"</b> (by $authors)</dt>\n";

--- a/doc/doxygen/scripts/make_gallery.pl
+++ b/doc/doxygen/scripts/make_gallery.pl
@@ -21,7 +21,7 @@ my $cmake_source_dir = shift(@ARGV);
 
 my $gallery = shift(@ARGV);
 my $gallery_underscore = $gallery;
-$gallery_underscore    =~ s/-/_/;
+$gallery_underscore    =~ s/-/_/g;
 
 my $gallery_dir = shift(@ARGV);
 

--- a/doc/doxygen/scripts/steps.pl
+++ b/doc/doxygen/scripts/steps.pl
@@ -118,7 +118,7 @@ foreach $step (@ARGV)
       my $name = $step;
       $name =~ s/^.*code-gallery\///;
       my $tag = $name;
-      $tag =~ s/[^a-zA-Z]/_/g;
+      $tag =~ s/[^a-zA-Z_0-9]/_/g;
 
       $kind_map{"code_gallery_$tag"} = "code-gallery";
 
@@ -157,7 +157,7 @@ foreach $step (@ARGV)
       my $name = $step;
       $name =~ s/^.*code-gallery\///;
       my $tag = $name;
-      $tag =~ s/[^a-zA-Z]/_/g;
+      $tag =~ s/[^a-zA-Z_0-9]/_/g;
       $destination = "code_gallery_$tag";
     }
 
@@ -274,7 +274,7 @@ foreach $step (@ARGV)
                 }
             }
 
-            # If the destination is a code gallery program, used a dashed line
+            # If the destination is a code gallery program, use a dashed line
             if ($kind_map{$destination} eq "code-gallery")
             {
                 $edge_attributes .= "style=\"dashed\", arrowhead=\"empty\", color=\"gray\",";


### PR DESCRIPTION
I noticed some broken links in doxygen.log, which after a lengthy search turned out to be a problem with inconsistently escaping special characters. Principally, we don't want to further escape underscores and numbers. We *do* want to escape dashes, and we want to do that not just for the first dash (with `s/-/_/`) but instead for all (with `s/-/_/g`) -- note the missing `g` at the end...