### PR TITLE
Add `types::geometric_orientation`.

### DIFF
--- a/include/deal.II/base/qprojector.h
+++ b/include/deal.II/base/qprojector.h
@@ -327,10 +327,10 @@ public:
      * projected onto the faces) has.
      */
     static DataSetDescriptor
-    face(const ReferenceCell &reference_cell,
-         const unsigned int   face_no,
-         const unsigned char  combined_orientation,
-         const unsigned int   n_quadrature_points);
+    face(const ReferenceCell               &reference_cell,
+         const unsigned int                 face_no,
+         const types::geometric_orientation combined_orientation,
+         const unsigned int                 n_quadrature_points);
 
     /**
      * Compute an offset object for the given face number and orientation,
@@ -358,10 +358,10 @@ public:
      *
      */
     static DataSetDescriptor
-    face(const ReferenceCell            &reference_cell,
-         const unsigned int              face_no,
-         const unsigned char             combined_orientation,
-         const hp::QCollection<dim - 1> &quadrature);
+    face(const ReferenceCell               &reference_cell,
+         const unsigned int                 face_no,
+         const types::geometric_orientation combined_orientation,
+         const hp::QCollection<dim - 1>    &quadrature);
 
     /**
      * Static function to generate an offset object for a given subface of a
@@ -405,12 +405,12 @@ public:
      * Through the last argument anisotropic refinement can be respected.
      */
     static DataSetDescriptor
-    subface(const ReferenceCell             &reference_cell,
-            const unsigned int               face_no,
-            const unsigned int               subface_no,
-            const unsigned char              combined_orientation,
-            const unsigned int               n_quadrature_points,
-            const internal::SubfaceCase<dim> ref_case =
+    subface(const ReferenceCell               &reference_cell,
+            const unsigned int                 face_no,
+            const unsigned int                 subface_no,
+            const types::geometric_orientation combined_orientation,
+            const unsigned int                 n_quadrature_points,
+            const internal::SubfaceCase<dim>   ref_case =
               internal::SubfaceCase<dim>::case_isotropic);
 
     /**

--- a/include/deal.II/base/types.h
+++ b/include/deal.II/base/types.h
@@ -31,6 +31,15 @@ DEAL_II_NAMESPACE_OPEN
 namespace types
 {
   /**
+   * The type used to represent face orientations.
+   *
+   * See the
+   * @ref GlossFaceOrientation "glossary"
+   * for more information.
+   */
+  using geometric_orientation = unsigned char;
+
+  /**
    * The type used to denote subdomain_ids of cells.
    *
    * See the

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -959,7 +959,7 @@ namespace DoFTools
     const std_cxx20::type_identity_t<FaceIterator> &face_2,
     AffineConstraints<number>                      &constraints,
     const ComponentMask                            &component_mask = {},
-    const unsigned char                             combined_orientation =
+    const types::geometric_orientation              combined_orientation =
       ReferenceCell::default_combined_face_orientation(),
     const FullMatrix<double>        &matrix = FullMatrix<double>(),
     const std::vector<unsigned int> &first_vector_components =
@@ -1110,7 +1110,7 @@ namespace DoFTools
       const FullMatrix<double>                       &transformation,
       AffineConstraints<number>                      &affine_constraints,
       const ComponentMask                            &component_mask,
-      const unsigned char                             combined_orientation,
+      const types::geometric_orientation              combined_orientation,
       const number                                    periodicity_factor,
       const unsigned int level = numbers::invalid_unsigned_int);
   } // namespace internal

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -1482,9 +1482,9 @@ public:
    */
   unsigned int
   adjust_quad_dof_index_for_face_orientation(
-    const unsigned int  index,
-    const unsigned int  face_no,
-    const unsigned char combined_orientation) const;
+    const unsigned int                 index,
+    const unsigned int                 face_no,
+    const types::geometric_orientation combined_orientation) const;
 
   /**
    * Given an index in the natural ordering of indices on a face, return the
@@ -1535,9 +1535,9 @@ public:
    */
   virtual unsigned int
   face_to_cell_index(
-    const unsigned int  face_dof_index,
-    const unsigned int  face,
-    const unsigned char combined_orientation =
+    const unsigned int                 face_dof_index,
+    const unsigned int                 face,
+    const types::geometric_orientation combined_orientation =
       ReferenceCell::default_combined_face_orientation()) const;
 
   /**
@@ -1551,8 +1551,8 @@ public:
    */
   unsigned int
   adjust_line_dof_index_for_line_orientation(
-    const unsigned int  index,
-    const unsigned char combined_orientation) const;
+    const unsigned int                 index,
+    const types::geometric_orientation combined_orientation) const;
 
   /**
    * Return in which of the vector components of this finite element the @p

--- a/include/deal.II/fe/fe_q_base.h
+++ b/include/deal.II/fe/fe_q_base.h
@@ -191,9 +191,9 @@ public:
    */
   virtual unsigned int
   face_to_cell_index(
-    const unsigned int  face_dof_index,
-    const unsigned int  face,
-    const unsigned char combined_orientation =
+    const unsigned int                 face_dof_index,
+    const unsigned int                 face,
+    const types::geometric_orientation combined_orientation =
       ReferenceCell::default_combined_face_orientation()) const override;
 
   /**

--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -887,9 +887,9 @@ public:
    */
   virtual unsigned int
   face_to_cell_index(
-    const unsigned int  face_dof_index,
-    const unsigned int  face,
-    const unsigned char combined_orientation =
+    const unsigned int                 face_dof_index,
+    const unsigned int                 face,
+    const types::geometric_orientation combined_orientation =
       ReferenceCell::default_combined_face_orientation()) const override;
 
   /**

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -2326,7 +2326,7 @@ namespace GridTools
      * face as described in orthogonal_equality() and
      * DoFTools::make_periodicity_constraints().
      */
-    unsigned char orientation;
+    types::geometric_orientation orientation;
 
     /**
      * A @p dim $\times$ @p dim rotation matrix that describes how vector
@@ -2365,14 +2365,15 @@ namespace GridTools
    * identity matrix.
    *
    * If the matching was successful, the _relative_ orientation of @p face1 with
-   * respect to @p face2 is returned a std::optional<unsigned char>, in which
-   * the stored value is the same orientation bit format used elsewhere in the
-   * library. More information on that topic can be found in the
-   * @ref GlossFaceOrientation "glossary"
-   * article.
+   * respect to @p face2 is returned a
+   * std::optional<types::geometric_orientation>, in which the stored value is
+   * the same orientation bit format used elsewhere in the library. More
+   * information on that topic can be found in the
+   * @ref GlossFaceOrientation
+   * "glossary" article.
    */
   template <typename FaceIterator>
-  std::optional<unsigned char>
+  std::optional<types::geometric_orientation>
   orthogonal_equality(
     const FaceIterator                                           &face1,
     const FaceIterator                                           &face2,
@@ -2394,9 +2395,9 @@ namespace GridTools
    * with faces belonging to the second boundary with the help of
    * orthogonal_equality().
    *
-   * The unsigned char that is returned inside of PeriodicFacePair encodes the
-   * _relative_ orientation of the first face with respect to the second face,
-   * see the documentation of orthogonal_equality() for further details.
+   * The value returned inside of PeriodicFacePair encodes the _relative_
+   * orientation of the first face with respect to the second face, see the
+   * documentation of orthogonal_equality() for further details.
    *
    * The @p direction refers to the space direction in which periodicity is
    * enforced. When matching periodic faces this vector component is ignored.

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -403,7 +403,7 @@ public:
    * Return the default combined face orientation flag (i.e., the default set of
    * orientations, defined by orientation, rotate, and flip for a face in 3d).
    */
-  static constexpr unsigned char
+  static constexpr types::geometric_orientation
   default_combined_face_orientation();
 
   /**
@@ -414,9 +414,9 @@ public:
    *
    * @note Line orientations are typically stored as booleans, but to better
    * enable dimension-independent programming relevant functions typically
-   * present these values as unsigned chars.
+   * present these values as the standard orientation type.
    */
-  static constexpr unsigned char
+  static constexpr types::geometric_orientation
   reversed_combined_line_orientation();
 
   /**
@@ -461,9 +461,9 @@ public:
    * entry.
    */
   unsigned int
-  child_cell_on_face(const unsigned int  face,
-                     const unsigned int  subface,
-                     const unsigned char face_orientation =
+  child_cell_on_face(const unsigned int                 face,
+                     const unsigned int                 subface,
+                     const types::geometric_orientation face_orientation =
                        default_combined_face_orientation()) const;
 
   /**
@@ -506,17 +506,18 @@ public:
    * Map face line number to cell line number.
    */
   unsigned int
-  face_to_cell_lines(const unsigned int  face,
-                     const unsigned int  line,
-                     const unsigned char face_orientation) const;
+  face_to_cell_lines(const unsigned int                 face,
+                     const unsigned int                 line,
+                     const types::geometric_orientation face_orientation) const;
 
   /**
    * Map face vertex number to cell vertex number.
    */
   unsigned int
-  face_to_cell_vertices(const unsigned int  face,
-                        const unsigned int  vertex,
-                        const unsigned char face_orientation) const;
+  face_to_cell_vertices(
+    const unsigned int                 face,
+    const unsigned int                 vertex,
+    const types::geometric_orientation face_orientation) const;
 
   /**
    * For a given face, in standard orientation, return the location of one
@@ -546,17 +547,19 @@ public:
    * Correct vertex index depending on face orientation.
    */
   unsigned int
-  standard_to_real_face_vertex(const unsigned int  vertex,
-                               const unsigned int  face,
-                               const unsigned char face_orientation) const;
+  standard_to_real_face_vertex(
+    const unsigned int                 vertex,
+    const unsigned int                 face,
+    const types::geometric_orientation face_orientation) const;
 
   /**
    * Correct line index depending on face orientation.
    */
   unsigned int
-  standard_to_real_face_line(const unsigned int  line,
-                             const unsigned int  face,
-                             const unsigned char face_orientation) const;
+  standard_to_real_face_line(
+    const unsigned int                 line,
+    const unsigned int                 face,
+    const types::geometric_orientation face_orientation) const;
 
   /**
    * Return whether the line with index @p line is oriented in
@@ -569,10 +572,11 @@ public:
    * documentation of the GeometryInfo class.
    */
   bool
-  standard_vs_true_line_orientation(const unsigned int  line,
-                                    const unsigned int  face,
-                                    const unsigned char face_orientation,
-                                    const bool          line_orientation) const;
+  standard_vs_true_line_orientation(
+    const unsigned int                 line,
+    const unsigned int                 face,
+    const types::geometric_orientation face_orientation,
+    const bool                         line_orientation) const;
 
   /**
    * @}
@@ -691,9 +695,9 @@ public:
    * @deprecated Use get_combined_orientation() instead.
    */
   template <typename T, std::size_t N>
-  DEAL_II_DEPRECATED unsigned char
-  compute_orientation(const std::array<T, N> &vertices_0,
-                      const std::array<T, N> &vertices_1) const;
+  DEAL_II_DEPRECATED types::geometric_orientation
+                     compute_orientation(const std::array<T, N> &vertices_0,
+                                         const std::array<T, N> &vertices_1) const;
 
   /**
    * Determine the relative orientation of the current entity described by its
@@ -721,7 +725,7 @@ public:
    *   these orientation indices.
    */
   template <typename T>
-  unsigned char
+  types::geometric_orientation
   get_combined_orientation(const ArrayView<const T> &vertices_0,
                            const ArrayView<const T> &vertices_1) const;
 
@@ -757,16 +761,18 @@ public:
    */
   template <typename T>
   boost::container::small_vector<T, 8>
-  permute_by_combined_orientation(const ArrayView<const T> &vertices,
-                                  const unsigned char       orientation) const;
+  permute_by_combined_orientation(
+    const ArrayView<const T>          &vertices,
+    const types::geometric_orientation orientation) const;
 
   /**
    * Return the inverse orientation. This is the value such that calling
    * permute_by_combined_orientation() with <tt>o</tt> and then calling it again
    * with get_inverse_combined_orientation(o) is the identity operation.
    */
-  unsigned char
-  get_inverse_combined_orientation(const unsigned char orientation) const;
+  types::geometric_orientation
+  get_inverse_combined_orientation(
+    const types::geometric_orientation orientation) const;
 
   /**
    * Return a vector of faces a given @p vertex_index belongs to.
@@ -1952,7 +1958,7 @@ ReferenceCell::face_reference_cell(const unsigned int face_no) const
 
 
 
-inline constexpr unsigned char
+inline constexpr types::geometric_orientation
 ReferenceCell::default_combined_face_orientation()
 {
   // Our convention is that 'orientation' has a default value of true and
@@ -1963,7 +1969,7 @@ ReferenceCell::default_combined_face_orientation()
 
 
 
-inline constexpr unsigned char
+inline constexpr types::geometric_orientation
 ReferenceCell::reversed_combined_line_orientation()
 {
   // For a reversed line 'orientation' is false and neither flip nor rotate are
@@ -1975,9 +1981,9 @@ ReferenceCell::reversed_combined_line_orientation()
 
 inline unsigned int
 ReferenceCell::child_cell_on_face(
-  const unsigned int  face,
-  const unsigned int  subface,
-  const unsigned char combined_face_orientation) const
+  const unsigned int                 face,
+  const unsigned int                 subface,
+  const types::geometric_orientation combined_face_orientation) const
 {
   AssertIndexRange(face, n_faces());
   AssertIndexRange(subface, face_reference_cell(face).n_isotropic_children());
@@ -2247,9 +2253,9 @@ ReferenceCell::line_to_cell_vertices(const unsigned int line,
 
 inline unsigned int
 ReferenceCell::face_to_cell_lines(
-  const unsigned int  face,
-  const unsigned int  line,
-  const unsigned char combined_face_orientation) const
+  const unsigned int                 face,
+  const unsigned int                 line,
+  const types::geometric_orientation combined_face_orientation) const
 {
   AssertIndexRange(face, n_faces());
   AssertIndexRange(line, face_reference_cell(face).n_lines());
@@ -2334,9 +2340,9 @@ ReferenceCell::face_to_cell_lines(
 
 inline unsigned int
 ReferenceCell::face_to_cell_vertices(
-  const unsigned int  face,
-  const unsigned int  vertex,
-  const unsigned char combined_face_orientation) const
+  const unsigned int                 face,
+  const unsigned int                 vertex,
+  const types::geometric_orientation combined_face_orientation) const
 {
   AssertIndexRange(face, n_faces());
   AssertIndexRange(vertex, face_reference_cell(face).n_vertices());
@@ -2446,9 +2452,9 @@ ReferenceCell::face_vertex_location(const unsigned int face,
 
 inline unsigned int
 ReferenceCell::standard_to_real_face_vertex(
-  const unsigned int  vertex,
-  const unsigned int  face,
-  const unsigned char face_orientation) const
+  const unsigned int                 vertex,
+  const unsigned int                 face,
+  const types::geometric_orientation face_orientation) const
 {
   AssertIndexRange(face, n_faces());
   AssertIndexRange(vertex, face_reference_cell(face).n_vertices());
@@ -2494,9 +2500,9 @@ ReferenceCell::standard_to_real_face_vertex(
 
 inline unsigned int
 ReferenceCell::standard_to_real_face_line(
-  const unsigned int  line,
-  const unsigned int  face,
-  const unsigned char combined_face_orientation) const
+  const unsigned int                 line,
+  const unsigned int                 face,
+  const types::geometric_orientation combined_face_orientation) const
 {
   AssertIndexRange(face, n_faces());
   AssertIndexRange(line, face_reference_cell(face).n_lines());
@@ -3112,10 +3118,10 @@ ReferenceCell::n_face_orientations(const unsigned int face_no) const
 
 inline bool
 ReferenceCell::standard_vs_true_line_orientation(
-  const unsigned int  line,
-  const unsigned int  face,
-  const unsigned char combined_face_orientation,
-  const bool          line_orientation) const
+  const unsigned int                 line,
+  const unsigned int                 face,
+  const types::geometric_orientation combined_face_orientation,
+  const bool                         line_orientation) const
 {
   if (*this == ReferenceCells::Hexahedron)
     {
@@ -3247,7 +3253,7 @@ namespace internal
 
 
 template <typename T, std::size_t N>
-inline unsigned char
+inline types::geometric_orientation
 ReferenceCell::compute_orientation(const std::array<T, N> &vertices_0,
                                    const std::array<T, N> &vertices_1) const
 {
@@ -3268,7 +3274,7 @@ ReferenceCell::compute_orientation(const std::array<T, N> &vertices_0,
 
 
 template <typename T>
-unsigned char
+types::geometric_orientation
 ReferenceCell::get_combined_orientation(
   const ArrayView<const T> &vertices_0,
   const ArrayView<const T> &vertices_1) const
@@ -3283,7 +3289,7 @@ ReferenceCell::get_combined_orientation(
                     "referenced by this object."));
 
   auto compute_orientation = [&](const auto &table) {
-    for (unsigned char o = 0; o < table.size(); ++o)
+    for (types::geometric_orientation o = 0; o < table.size(); ++o)
       {
         bool match = true;
         for (unsigned int j = 0; j < table[o].size(); ++j)
@@ -3294,7 +3300,7 @@ ReferenceCell::get_combined_orientation(
       }
 
     Assert(false, (internal::NoPermutation<T>(*this, vertices_0, vertices_1)));
-    return std::numeric_limits<unsigned char>::max();
+    return std::numeric_limits<types::geometric_orientation>::max();
   };
 
   switch (this->kind)
@@ -3317,7 +3323,7 @@ ReferenceCell::get_combined_orientation(
     }
 
   Assert(false, (internal::NoPermutation<T>(*this, vertices_0, vertices_1)));
-  return std::numeric_limits<unsigned char>::max();
+  return std::numeric_limits<types::geometric_orientation>::max();
 }
 
 
@@ -3352,8 +3358,8 @@ ReferenceCell::permute_according_orientation(
 template <typename T>
 boost::container::small_vector<T, 8>
 ReferenceCell::permute_by_combined_orientation(
-  const ArrayView<const T> &vertices,
-  const unsigned char       orientation) const
+  const ArrayView<const T>          &vertices,
+  const types::geometric_orientation orientation) const
 {
   AssertDimension(vertices.size(), n_vertices());
   boost::container::small_vector<T, 8> result(n_vertices());
@@ -3389,9 +3395,9 @@ ReferenceCell::permute_by_combined_orientation(
 
 
 
-inline unsigned char
+inline types::geometric_orientation
 ReferenceCell::get_inverse_combined_orientation(
-  const unsigned char orientation) const
+  const types::geometric_orientation orientation) const
 {
   switch (this->kind)
     {
@@ -3407,13 +3413,14 @@ ReferenceCell::get_inverse_combined_orientation(
       case ReferenceCells::Triangle:
         {
           AssertIndexRange(orientation, 6);
-          constexpr std::array<unsigned char, 6> inverses{{0, 1, 2, 5, 4, 3}};
+          constexpr std::array<types::geometric_orientation, 6> inverses{
+            {0, 1, 2, 5, 4, 3}};
           return inverses[orientation];
         }
       case ReferenceCells::Quadrilateral:
         {
           AssertIndexRange(orientation, 8);
-          constexpr std::array<unsigned char, 8> inverses{
+          constexpr std::array<types::geometric_orientation, 8> inverses{
             {0, 1, 2, 7, 4, 5, 6, 3}};
           return inverses[orientation];
         }
@@ -3421,7 +3428,7 @@ ReferenceCell::get_inverse_combined_orientation(
         DEAL_II_NOT_IMPLEMENTED();
     }
 
-  return std::numeric_limits<unsigned char>::max();
+  return std::numeric_limits<types::geometric_orientation>::max();
 }
 
 

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -3646,9 +3646,9 @@ public:
   /**
    * Return the periodic_face_map.
    */
-  const std::map<
-    std::pair<cell_iterator, unsigned int>,
-    std::pair<std::pair<cell_iterator, unsigned int>, unsigned char>> &
+  const std::map<std::pair<cell_iterator, unsigned int>,
+                 std::pair<std::pair<cell_iterator, unsigned int>,
+                           types::geometric_orientation>> &
   get_periodic_face_map() const;
 
   /**
@@ -4106,7 +4106,8 @@ private:
    * face pairs.
    */
   std::map<std::pair<cell_iterator, unsigned int>,
-           std::pair<std::pair<cell_iterator, unsigned int>, unsigned char>>
+           std::pair<std::pair<cell_iterator, unsigned int>,
+                     types::geometric_orientation>>
     periodic_face_map;
 
   /**

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -963,7 +963,7 @@ public:
    *
    * @ingroup reordering
    */
-  unsigned char
+  types::geometric_orientation
   combined_face_orientation(const unsigned int face) const;
 
   /**
@@ -1830,8 +1830,9 @@ private:
    * @ingroup reordering
    */
   void
-  set_combined_face_orientation(const unsigned int  face,
-                                const unsigned char combined_orientation) const;
+  set_combined_face_orientation(
+    const unsigned int                 face,
+    const types::geometric_orientation combined_orientation) const;
 
   /**
    * Set the @p used flag. Only for internal use in the library.
@@ -2155,7 +2156,7 @@ public:
    *
    * @ingroup reordering
    */
-  static unsigned char
+  static types::geometric_orientation
   combined_face_orientation(const unsigned int face);
 
   /**
@@ -2824,7 +2825,7 @@ public:
    *
    * @ingroup reordering
    */
-  static unsigned char
+  static types::geometric_orientation
   combined_face_orientation(const unsigned int face);
 
   /**
@@ -4932,7 +4933,7 @@ namespace internal
       set_combined_face_orientation(
         const TriaAccessor<structdim, dim, spacedim> &accessor,
         const unsigned int                            face,
-        const unsigned char                           combined_orientation)
+        const types::geometric_orientation            combined_orientation)
       {
         Assert(structdim == dim,
                ExcMessage("This function can only be used on objects that are "
@@ -5006,7 +5007,7 @@ namespace internal
           {
             for (unsigned int f = 4; f < 6; ++f)
               {
-                const unsigned char orientation =
+                const auto orientation =
                   cell.get_triangulation()
                     .levels[cell.level()]
                     ->face_orientations.get_combined_orientation(
@@ -5030,7 +5031,7 @@ namespace internal
               }
             for (unsigned int f = 0; f < 2; ++f)
               {
-                const unsigned char orientation =
+                const auto orientation =
                   cell.get_triangulation()
                     .levels[cell.level()]
                     ->face_orientations.get_combined_orientation(
@@ -5079,7 +5080,7 @@ namespace internal
        * cell->line_orientation(), 1d specialization
        */
       template <int dim, int spacedim>
-      static std::array<unsigned char, 1>
+      static std::array<types::geometric_orientation, 1>
       get_line_orientations_of_cell(const TriaAccessor<1, dim, spacedim> &)
       {
         DEAL_II_ASSERT_UNREACHABLE();
@@ -5093,12 +5094,12 @@ namespace internal
        * cell->line_orientation(), 2d specialization
        */
       template <int dim, int spacedim>
-      static std::array<unsigned char, 4>
+      static std::array<types::geometric_orientation, 4>
       get_line_orientations_of_cell(const TriaAccessor<2, dim, spacedim> &cell)
       {
         // For 2d cells the access cell->line_orientation() is already
         // efficient
-        std::array<unsigned char, 4> line_orientations = {};
+        std::array<types::geometric_orientation, 4> line_orientations = {};
         for (const unsigned int line : cell.line_indices())
           line_orientations[line] =
             cell.line_orientation(line) == true ?
@@ -5114,10 +5115,10 @@ namespace internal
        * cell->line_orientation(), 3d specialization
        */
       template <int dim, int spacedim>
-      static std::array<unsigned char, 12>
+      static std::array<types::geometric_orientation, 12>
       get_line_orientations_of_cell(const TriaAccessor<3, dim, spacedim> &cell)
       {
-        std::array<unsigned char, 12> line_orientations = {};
+        std::array<types::geometric_orientation, 12> line_orientations = {};
 
         // For hexahedra, the classical access via quads -> lines is too
         // inefficient. Unroll this code here to allow the compiler to inline
@@ -5127,7 +5128,7 @@ namespace internal
           {
             for (unsigned int f = 4; f < 6; ++f)
               {
-                const unsigned char orientation =
+                const auto orientation =
                   cell.get_triangulation()
                     .levels[cell.level()]
                     ->face_orientations.get_combined_orientation(
@@ -5162,7 +5163,7 @@ namespace internal
               }
             for (unsigned int f = 0; f < 2; ++f)
               {
-                const unsigned char orientation =
+                const auto orientation =
                   cell.get_triangulation()
                     .levels[cell.level()]
                     ->face_orientations.get_combined_orientation(
@@ -5423,7 +5424,7 @@ TriaAccessor<structdim, dim, spacedim>::quad_index(const unsigned int i) const
 
 
 template <int structdim, int dim, int spacedim>
-inline unsigned char
+inline types::geometric_orientation
 TriaAccessor<structdim, dim, spacedim>::combined_face_orientation(
   const unsigned int face) const
 {
@@ -5634,8 +5635,8 @@ TriaAccessor<structdim, dim, spacedim>::set_line_orientation(
 template <int structdim, int dim, int spacedim>
 inline void
 TriaAccessor<structdim, dim, spacedim>::set_combined_face_orientation(
-  const unsigned int  face,
-  const unsigned char combined_orientation) const
+  const unsigned int                 face,
+  const types::geometric_orientation combined_orientation) const
 {
   Assert(used(), TriaAccessorExceptions::ExcCellNotUsed());
   AssertIndexRange(face, this->n_faces());
@@ -6887,11 +6888,11 @@ TriaAccessor<0, dim, spacedim>::measure() const
 
 
 template <int dim, int spacedim>
-inline unsigned char
+inline types::geometric_orientation
 TriaAccessor<0, dim, spacedim>::combined_face_orientation(
   const unsigned int /*face*/)
 {
-  return 0;
+  return ReferenceCell::default_combined_face_orientation();
 }
 
 
@@ -7336,7 +7337,7 @@ TriaAccessor<0, 1, spacedim>::manifold_id() const
 
 
 template <int spacedim>
-inline unsigned char
+inline types::geometric_orientation
 TriaAccessor<0, 1, spacedim>::combined_face_orientation(
   const unsigned int /*face*/)
 {

--- a/include/deal.II/grid/tria_objects_orientations.h
+++ b/include/deal.II/grid/tria_objects_orientations.h
@@ -80,7 +80,7 @@ namespace internal
        * Get the combined orientation of the object, as described in the class
        * documentation.
        */
-      unsigned char
+      types::geometric_orientation
       get_combined_orientation(const unsigned int object) const;
 
       /**
@@ -106,8 +106,8 @@ namespace internal
        * documentation.
        */
       void
-      set_combined_orientation(const unsigned int  object,
-                               const unsigned char value);
+      set_combined_orientation(const unsigned int                 object,
+                               const types::geometric_orientation value);
 
       /**
        * Read or write the data of this object to or from a stream for the
@@ -125,9 +125,9 @@ namespace internal
       unsigned int n_stored_objects;
 
       /**
-       * Flags.
+       * Orientations.
        */
-      std::vector<unsigned char> flags;
+      std::vector<types::geometric_orientation> object_orientations;
     };
 
     //----------------------------------------------------------------------//
@@ -151,9 +151,8 @@ namespace internal
     TriaObjectsOrientations::reinit(const unsigned int n_objects)
     {
       n_stored_objects = n_objects;
-      // Assign to the default orientation
-      flags.assign(n_objects,
-                   ReferenceCell::default_combined_face_orientation());
+      object_orientations.assign(
+        n_objects, ReferenceCell::default_combined_face_orientation());
     }
 
 
@@ -161,8 +160,8 @@ namespace internal
     inline void
     TriaObjectsOrientations::resize(const unsigned int n_objects)
     {
-      flags.resize(n_objects,
-                   ReferenceCell::default_combined_face_orientation());
+      object_orientations.resize(
+        n_objects, ReferenceCell::default_combined_face_orientation());
       n_stored_objects = n_objects;
     }
 
@@ -172,7 +171,7 @@ namespace internal
     TriaObjectsOrientations::memory_consumption() const
     {
       return MemoryConsumption::memory_consumption(n_stored_objects) +
-             MemoryConsumption::memory_consumption(flags);
+             MemoryConsumption::memory_consumption(object_orientations);
     }
 
 
@@ -185,12 +184,12 @@ namespace internal
 
 
 
-    inline unsigned char
+    inline types::geometric_orientation
     TriaObjectsOrientations::get_combined_orientation(
       const unsigned int object) const
     {
       AssertIndexRange(object, n_stored_objects);
-      return flags[object];
+      return object_orientations[object];
     }
 
 
@@ -199,7 +198,7 @@ namespace internal
     TriaObjectsOrientations::get_orientation(const unsigned int object) const
     {
       AssertIndexRange(object, n_stored_objects);
-      return Utilities::get_bit(flags[object], 0);
+      return Utilities::get_bit(object_orientations[object], 0);
     }
 
 
@@ -208,7 +207,7 @@ namespace internal
     TriaObjectsOrientations::get_rotation(const unsigned int object) const
     {
       AssertIndexRange(object, n_stored_objects);
-      return Utilities::get_bit(flags[object], 1);
+      return Utilities::get_bit(object_orientations[object], 1);
     }
 
 
@@ -217,17 +216,18 @@ namespace internal
     TriaObjectsOrientations::get_flip(const unsigned int object) const
     {
       AssertIndexRange(object, n_stored_objects);
-      return Utilities::get_bit(flags[object], 2);
+      return Utilities::get_bit(object_orientations[object], 2);
     }
 
 
 
     inline void
-    TriaObjectsOrientations::set_combined_orientation(const unsigned int object,
-                                                      const unsigned char value)
+    TriaObjectsOrientations::set_combined_orientation(
+      const unsigned int                 object,
+      const types::geometric_orientation value)
     {
       AssertIndexRange(object, n_stored_objects);
-      flags[object] = value;
+      object_orientations[object] = value;
     }
 
 
@@ -236,7 +236,7 @@ namespace internal
     void
     TriaObjectsOrientations::serialize(Archive &ar, const unsigned int)
     {
-      ar &n_stored_objects &flags;
+      ar &n_stored_objects &object_orientations;
     }
   } // namespace TriangulationImplementation
 } // namespace internal

--- a/include/deal.II/grid/tria_orientation.h
+++ b/include/deal.II/grid/tria_orientation.h
@@ -28,7 +28,7 @@ namespace internal
   /**
    * Combine orientation flags.
    */
-  inline unsigned char
+  inline types::geometric_orientation
   combined_face_orientation(const bool face_orientation,
                             const bool face_rotation,
                             const bool face_flip)
@@ -42,7 +42,8 @@ namespace internal
    * rotation flag, flip flag.
    */
   inline std::tuple<bool, bool, bool>
-  split_face_orientation(const unsigned char combined_face_orientation)
+  split_face_orientation(
+    const types::geometric_orientation combined_face_orientation)
   {
     return {Utilities::get_bit(combined_face_orientation, 0),
             Utilities::get_bit(combined_face_orientation, 1),

--- a/include/deal.II/matrix_free/face_setup_internal.h
+++ b/include/deal.II/matrix_free/face_setup_internal.h
@@ -1003,10 +1003,11 @@ namespace internal
       // special treatment of periodic boundaries
       if (dim == 3 && cell->has_periodic_neighbor(face_no))
         {
-          unsigned char exterior_face_orientation = cell->get_triangulation()
-                                                      .get_periodic_face_map()
-                                                      .at({cell, face_no})
-                                                      .second;
+          const types::geometric_orientation exterior_face_orientation =
+            cell->get_triangulation()
+              .get_periodic_face_map()
+              .at({cell, face_no})
+              .second;
           const auto [orientation, rotation, flip] =
             ::dealii::internal::split_face_orientation(
               exterior_face_orientation);

--- a/source/base/qprojector.cc
+++ b/source/base/qprojector.cc
@@ -147,8 +147,9 @@ namespace internal
       }
 
       std::vector<Point<2>>
-      mutate_points_with_offset(const std::vector<Point<2>> &points,
-                                const unsigned char combined_orientation)
+      mutate_points_with_offset(
+        const std::vector<Point<2>>       &points,
+        const types::geometric_orientation combined_orientation)
       {
         // These rotations are backwards (relative to the standard notion of,
         // e.g., what rotation index 7 means) since they are rotations about the
@@ -185,8 +186,8 @@ namespace internal
       }
 
       Quadrature<2>
-      mutate_quadrature(const Quadrature<2> &quadrature,
-                        const unsigned char  combined_orientation)
+      mutate_quadrature(const Quadrature<2>               &quadrature,
+                        const types::geometric_orientation combined_orientation)
       {
         return Quadrature<2>(mutate_points_with_offset(quadrature.get_points(),
                                                        combined_orientation),
@@ -925,7 +926,7 @@ QProjector<3>::project_to_all_faces(const ReferenceCell      &reference_cell,
              static_cast<const ScalarPolynomialsBase<2> &>(poly_quad));
 
         // ... and over all possible orientations
-        for (unsigned char orientation = 0;
+        for (types::geometric_orientation orientation = 0;
              orientation < reference_cell.n_face_orientations(face_no);
              ++orientation)
           {
@@ -1366,10 +1367,10 @@ QProjector<dim>::DataSetDescriptor::face(const ReferenceCell &reference_cell,
 template <int dim>
 typename QProjector<dim>::DataSetDescriptor
 QProjector<dim>::DataSetDescriptor::face(
-  const ReferenceCell &reference_cell,
-  const unsigned int   face_no,
-  const unsigned char  combined_orientation,
-  const unsigned int   n_quadrature_points)
+  const ReferenceCell               &reference_cell,
+  const unsigned int                 face_no,
+  const types::geometric_orientation combined_orientation,
+  const unsigned int                 n_quadrature_points)
 {
   // TODO: once we move to representing the default orientation as 0 (instead of
   // 1) we can get rid of the dim = 1 check
@@ -1439,10 +1440,10 @@ QProjector<dim>::DataSetDescriptor::face(
 template <int dim>
 typename QProjector<dim>::DataSetDescriptor
 QProjector<dim>::DataSetDescriptor::face(
-  const ReferenceCell            &reference_cell,
-  const unsigned int              face_no,
-  const unsigned char             combined_orientation,
-  const hp::QCollection<dim - 1> &quadrature)
+  const ReferenceCell               &reference_cell,
+  const unsigned int                 face_no,
+  const types::geometric_orientation combined_orientation,
+  const hp::QCollection<dim - 1>    &quadrature)
 {
   if (reference_cell == ReferenceCells::Triangle ||
       reference_cell == ReferenceCells::Tetrahedron ||
@@ -1567,7 +1568,7 @@ QProjector<1>::DataSetDescriptor::subface(
   const ReferenceCell &reference_cell,
   const unsigned int   face_no,
   const unsigned int   subface_no,
-  const unsigned char /*combined_orientation*/,
+  const types::geometric_orientation /*combined_orientation*/,
   const unsigned int n_quadrature_points,
   const internal::SubfaceCase<1>)
 {
@@ -1590,7 +1591,7 @@ QProjector<2>::DataSetDescriptor::subface(
   const ReferenceCell &reference_cell,
   const unsigned int   face_no,
   const unsigned int   subface_no,
-  const unsigned char /*combined_orientation*/,
+  const types::geometric_orientation /*combined_orientation*/,
   const unsigned int n_quadrature_points,
   const internal::SubfaceCase<2>)
 {
@@ -1610,12 +1611,12 @@ QProjector<2>::DataSetDescriptor::subface(
 template <>
 QProjector<3>::DataSetDescriptor
 QProjector<3>::DataSetDescriptor::subface(
-  const ReferenceCell           &reference_cell,
-  const unsigned int             face_no,
-  const unsigned int             subface_no,
-  const unsigned char            combined_orientation,
-  const unsigned int             n_quadrature_points,
-  const internal::SubfaceCase<3> ref_case)
+  const ReferenceCell               &reference_cell,
+  const unsigned int                 face_no,
+  const unsigned int                 subface_no,
+  const types::geometric_orientation combined_orientation,
+  const unsigned int                 n_quadrature_points,
+  const internal::SubfaceCase<3>     ref_case)
 {
   const unsigned int dim = 3;
 

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -2601,7 +2601,7 @@ namespace parallel
             const unsigned int   face_no_1            = it.first.second;
             const cell_iterator &cell_2               = it.second.first.first;
             const unsigned int   face_no_2            = it.second.first.second;
-            const unsigned char  combined_orientation = it.second.second;
+            const auto           combined_orientation = it.second.second;
 
             if (cell_1->level() == cell_2->level())
               {
@@ -3709,7 +3709,7 @@ namespace parallel
             const unsigned int   face_no_1            = it.first.second;
             const cell_iterator &cell_2               = it.second.first.first;
             const unsigned int   face_no_2            = it.second.first.second;
-            const unsigned char  combined_orientation = it.second.second;
+            const auto           combined_orientation = it.second.second;
             const auto [orientation, rotation, flip] =
               ::dealii::internal::split_face_orientation(combined_orientation);
 
@@ -3815,7 +3815,7 @@ namespace parallel
               const unsigned int  face_idx_list[] = {face_left, face_right};
               const cell_iterator cell_list[]     = {first_cell, second_cell};
               unsigned int        lower_idx, higher_idx;
-              unsigned char       orientation;
+              types::geometric_orientation orientation;
               if (face_left <= face_right)
                 {
                   higher_idx = 1;

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -3106,7 +3106,7 @@ namespace DoFTools
       const FullMatrix<double>                       &transformation,
       AffineConstraints<number>                      &affine_constraints,
       const ComponentMask                            &component_mask,
-      const unsigned char                             combined_orientation,
+      const types::geometric_orientation              combined_orientation,
       const number                                    periodicity_factor,
       const unsigned int                              level)
     {
@@ -3604,7 +3604,7 @@ namespace DoFTools
     const std_cxx20::type_identity_t<FaceIterator> &face_2,
     AffineConstraints<number>                      &affine_constraints,
     const ComponentMask                            &component_mask,
-    const unsigned char                             combined_orientation,
+    const types::geometric_orientation              combined_orientation,
     const FullMatrix<double>                       &matrix,
     const std::vector<unsigned int>                &first_vector_components,
     const number                                    periodicity_factor)

--- a/source/dofs/dof_tools_constraints.inst.in
+++ b/source/dofs/dof_tools_constraints.inst.in
@@ -23,7 +23,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
                        deal_II_space_dimension>::face_iterator &,
       AffineConstraints<S> &,
       const ComponentMask &,
-      const unsigned char,
+      const types::geometric_orientation,
       const FullMatrix<double> &,
       const std::vector<unsigned int> &,
       const S);
@@ -34,23 +34,23 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
       const DoFHandler<deal_II_dimension,
                        deal_II_space_dimension>::face_iterator &face_2,
       const FullMatrix<double>                                 &transformation,
-      AffineConstraints<S> &affine_constraints,
-      const ComponentMask  &component_mask,
-      const unsigned char   combined_orientation,
-      const S               periodicity_factor,
-      const unsigned int    level);
+      AffineConstraints<S>              &affine_constraints,
+      const ComponentMask               &component_mask,
+      const types::geometric_orientation combined_orientation,
+      const S                            periodicity_factor,
+      const unsigned int                 level);
 
     template void DoFTools::internal::set_periodicity_constraints(
       const DoFHandler<deal_II_dimension,
                        deal_II_space_dimension>::level_face_iterator &face_1,
       const DoFHandler<deal_II_dimension,
                        deal_II_space_dimension>::level_face_iterator &face_2,
-      const FullMatrix<double> &transformation,
-      AffineConstraints<S>     &affine_constraints,
-      const ComponentMask      &component_mask,
-      const unsigned char       combined_orientation,
-      const S                   periodicity_factor,
-      const unsigned int        level);
+      const FullMatrix<double>          &transformation,
+      AffineConstraints<S>              &affine_constraints,
+      const ComponentMask               &component_mask,
+      const types::geometric_orientation combined_orientation,
+      const S                            periodicity_factor,
+      const unsigned int                 level);
 #endif
   }
 

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -564,9 +564,9 @@ FiniteElement<dim, spacedim>::block_mask(
 template <int dim, int spacedim>
 unsigned int
 FiniteElement<dim, spacedim>::face_to_cell_index(
-  const unsigned int  face_index,
-  const unsigned int  face,
-  const unsigned char combined_orientation) const
+  const unsigned int                 face_index,
+  const unsigned int                 face,
+  const types::geometric_orientation combined_orientation) const
 {
   AssertIndexRange(face_index, this->n_dofs_per_face(face));
   AssertIndexRange(face, this->reference_cell().n_faces());
@@ -638,9 +638,9 @@ FiniteElement<dim, spacedim>::face_to_cell_index(
 template <int dim, int spacedim>
 unsigned int
 FiniteElement<dim, spacedim>::adjust_quad_dof_index_for_face_orientation(
-  const unsigned int  index,
-  const unsigned int  face,
-  const unsigned char combined_orientation) const
+  const unsigned int                 index,
+  const unsigned int                 face,
+  const types::geometric_orientation combined_orientation) const
 {
   // general template for 1d and 2d: not
   // implemented. in fact, the function
@@ -675,8 +675,8 @@ FiniteElement<dim, spacedim>::adjust_quad_dof_index_for_face_orientation(
 template <int dim, int spacedim>
 unsigned int
 FiniteElement<dim, spacedim>::adjust_line_dof_index_for_line_orientation(
-  const unsigned int  index,
-  const unsigned char combined_orientation) const
+  const unsigned int                 index,
+  const types::geometric_orientation combined_orientation) const
 {
   Assert(combined_orientation ==
              ReferenceCell::default_combined_face_orientation() ||

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -1109,9 +1109,9 @@ FE_Q_Base<dim, spacedim>::initialize_dof_index_permutations()
 template <int dim, int spacedim>
 unsigned int
 FE_Q_Base<dim, spacedim>::face_to_cell_index(
-  const unsigned int  face_index,
-  const unsigned int  face,
-  const unsigned char combined_orientation) const
+  const unsigned int                 face_index,
+  const unsigned int                 face,
+  const types::geometric_orientation combined_orientation) const
 {
   AssertIndexRange(face_index, this->n_dofs_per_face(face));
   AssertIndexRange(face, GeometryInfo<dim>::faces_per_cell);

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -982,9 +982,9 @@ FESystem<dim, spacedim>::get_prolongation_matrix(
 template <int dim, int spacedim>
 unsigned int
 FESystem<dim, spacedim>::face_to_cell_index(
-  const unsigned int  face_dof_index,
-  const unsigned int  face,
-  const unsigned char combined_orientation) const
+  const unsigned int                 face_dof_index,
+  const unsigned int                 face,
+  const types::geometric_orientation combined_orientation) const
 {
   // we need to ask the base elements how they want to translate
   // the DoFs within their own numbering. thus, translate to

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -4773,10 +4773,10 @@ namespace GridTools
           const auto face_a = pair.first.first->face(pair.first.second);
           const auto face_b =
             pair.second.first.first->face(pair.second.first.second);
-          const auto reference_cell      = pair.first.first->reference_cell();
-          const auto face_reference_cell = face_a->reference_cell();
-          const unsigned char combined_orientation = pair.second.second;
-          const unsigned char inverse_combined_orientation =
+          const auto reference_cell       = pair.first.first->reference_cell();
+          const auto face_reference_cell  = face_a->reference_cell();
+          const auto combined_orientation = pair.second.second;
+          const auto inverse_combined_orientation =
             face_reference_cell.get_inverse_combined_orientation(
               combined_orientation);
 

--- a/source/grid/grid_tools_dof_handlers.cc
+++ b/source/grid/grid_tools_dof_handlers.cc
@@ -2166,7 +2166,7 @@ namespace GridTools
             const CellIterator cell2     = it2->first;
             const unsigned int face_idx1 = it1->second;
             const unsigned int face_idx2 = it2->second;
-            if (const std::optional<unsigned char> orientation =
+            if (const std::optional<types::geometric_orientation> orientation =
                   GridTools::orthogonal_equality(cell1->face(face_idx1),
                                                  cell2->face(face_idx2),
                                                  direction,
@@ -2422,7 +2422,7 @@ namespace GridTools
 
 
   template <typename FaceIterator>
-  std::optional<unsigned char>
+  std::optional<types::geometric_orientation>
   orthogonal_equality(
     const FaceIterator                                           &face1,
     const FaceIterator                                           &face2,

--- a/source/grid/grid_tools_dof_handlers.inst.in
+++ b/source/grid/grid_tools_dof_handlers.inst.in
@@ -249,7 +249,7 @@ for (X : SEQUENTIAL_TRIANGULATION_AND_DOFHANDLER;
     namespace GridTools
     \{
 
-      template std::optional<unsigned char>
+      template std::optional<types::geometric_orientation>
       orthogonal_equality<X::active_face_iterator>(
         const X::active_face_iterator &,
         const X::active_face_iterator &,
@@ -257,7 +257,7 @@ for (X : SEQUENTIAL_TRIANGULATION_AND_DOFHANDLER;
         const Tensor<1, deal_II_space_dimension> &,
         const FullMatrix<double> &);
 
-      template std::optional<unsigned char>
+      template std::optional<types::geometric_orientation>
       orthogonal_equality<X::face_iterator>(
         const X::face_iterator &,
         const X::face_iterator &,

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -1647,19 +1647,19 @@ namespace
     const typename Triangulation<dim, spacedim>::cell_iterator &cell_2,
     unsigned int                                                n_face_1,
     unsigned int                                                n_face_2,
-    const unsigned char                                         orientation,
+    const types::geometric_orientation                          orientation,
     typename std::map<
       std::pair<typename Triangulation<dim, spacedim>::cell_iterator,
                 unsigned int>,
       std::pair<std::pair<typename Triangulation<dim, spacedim>::cell_iterator,
                           unsigned int>,
-                unsigned char>> &periodic_face_map)
+                types::geometric_orientation>> &periodic_face_map)
   {
     using FaceIterator = typename Triangulation<dim, spacedim>::face_iterator;
     const FaceIterator face_1 = cell_1->face(n_face_1);
     const FaceIterator face_2 = cell_2->face(n_face_2);
 
-    const unsigned char inverse_orientation =
+    const auto inverse_orientation =
       face_1->reference_cell().get_inverse_combined_orientation(orientation);
 
 #ifdef DEBUG
@@ -1694,12 +1694,12 @@ namespace
     using CellFace =
       std::pair<typename Triangulation<dim, spacedim>::cell_iterator,
                 unsigned int>;
-    const CellFace                           cell_face_1(cell_1, n_face_1);
-    const CellFace                           cell_face_2(cell_2, n_face_2);
-    const std::pair<CellFace, unsigned char> cell_face_orientation_2(
-      cell_face_2, orientation);
+    const CellFace cell_face_1(cell_1, n_face_1);
+    const CellFace cell_face_2(cell_2, n_face_2);
+    const std::pair<CellFace, types::geometric_orientation>
+      cell_face_orientation_2(cell_face_2, orientation);
 
-    const std::pair<CellFace, std::pair<CellFace, unsigned char>>
+    const std::pair<CellFace, std::pair<CellFace, types::geometric_orientation>>
       periodic_faces(cell_face_1, cell_face_orientation_2);
 
     // Only one periodic neighbor is allowed
@@ -3302,7 +3302,7 @@ namespace internal
                       crs.col[i];
 
                     // set line orientations
-                    const unsigned char combined_orientation =
+                    const auto combined_orientation =
                       connectivity.entity_orientations(1)
                         .get_combined_orientation(k);
                     // it doesn't make sense to set any flags except
@@ -5151,8 +5151,8 @@ namespace internal
 
           std::array<typename Triangulation<dim, spacedim>::raw_line_iterator,
                      12>
-                                        new_lines;
-          std::array<unsigned char, 12> inherited_orientations;
+                                                       new_lines;
+          std::array<types::geometric_orientation, 12> inherited_orientations;
           inherited_orientations.fill(
             ReferenceCell::default_combined_face_orientation());
           unsigned int lmin = 0;
@@ -5197,7 +5197,7 @@ namespace internal
               // orientation. This way we can index into this array in the
               // without special casing orientations (e.g., quadrilateral child
               // 3 will always have lines 9, 3, 11, 7) when setting child lines.
-              const unsigned char combined_orientation =
+              const auto combined_orientation =
                 cell->combined_face_orientation(face_no);
               Assert(combined_orientation ==
                          ReferenceCell::default_combined_face_orientation() ||
@@ -6811,7 +6811,7 @@ namespace internal
                                             {{2, 1, 0}}, // 4
                                             {{2, 0, 1}}}};
 
-                              const unsigned char combined_orientation =
+                              const auto combined_orientation =
                                 hex->combined_face_orientation(f);
                               relevant_lines[k] =
                                 hex->face(f)
@@ -6966,7 +6966,7 @@ namespace internal
                         for (unsigned int f = 0, k = n_new_quads; f < 4; ++f)
                           for (unsigned int c = 0; c < 4; ++c, ++k)
                             {
-                              const unsigned char combined_orientation =
+                              const auto combined_orientation =
                                 hex->combined_face_orientation(f);
                               quad_indices[k] = hex->face(f)->child_index(
                                 (c == 3) ? 3 :
@@ -7085,7 +7085,7 @@ namespace internal
                     if (hex->n_faces() == 6)
                       for (const auto f : hex->face_indices())
                         {
-                          const unsigned char combined_orientation =
+                          const auto combined_orientation =
                             hex->combined_face_orientation(f);
                           for (unsigned int c = 0; c < 4; ++c)
                             new_hexes[face_to_child_indices_hex[f][c]]
@@ -8633,7 +8633,7 @@ namespace internal
                                         hex->face_rotation(5)};
 
                   // combined orientation
-                  const unsigned char f_co[6] = {
+                  const types::geometric_orientation f_co[6] = {
                     hex->combined_face_orientation(0),
                     hex->combined_face_orientation(1),
                     hex->combined_face_orientation(2),
@@ -15620,7 +15620,7 @@ const typename std::map<
   std::pair<typename Triangulation<dim, spacedim>::cell_iterator, unsigned int>,
   std::pair<std::pair<typename Triangulation<dim, spacedim>::cell_iterator,
                       unsigned int>,
-            unsigned char>>
+            types::geometric_orientation>>
   &Triangulation<dim, spacedim>::get_periodic_face_map() const
 {
   return periodic_face_map;
@@ -15980,7 +15980,7 @@ void Triangulation<dim, spacedim>::reset_cell_vertex_indices_cache()
                    face_iter->line(0)->vertex_index(line_orientations[0]),
                    face_iter->line(1)->vertex_index(line_orientations[1])}};
 
-                const unsigned char combined_orientation =
+                const auto combined_orientation =
                   levels[l]->face_orientations.get_combined_orientation(
                     cell->index() * ReferenceCells::max_n_faces<dim>() + face);
                 std::array<unsigned int, 4> vertex_order{
@@ -16075,7 +16075,8 @@ void Triangulation<dim, spacedim>::update_periodic_face_map()
   // check consistency
   typename std::map<std::pair<cell_iterator, unsigned int>,
                     std::pair<std::pair<cell_iterator, unsigned int>,
-                              unsigned char>>::const_iterator it_test;
+                              types::geometric_orientation>>::const_iterator
+    it_test;
   for (it_test = periodic_face_map.begin(); it_test != periodic_face_map.end();
        ++it_test)
     {

--- a/tests/dofs/dof_tools_21_b.cc
+++ b/tests/dofs/dof_tools_21_b.cc
@@ -39,7 +39,7 @@
 //                                const FaceIterator        &,
 //                                AffineConstraints<double> &,
 //                                const ComponentMask       &,
-//                                unsigned char)
+//                                types::geometric_orientation)
 // for correct behavior on non standard oriented meshes.
 //
 

--- a/tests/dofs/dof_tools_21_b_x.cc
+++ b/tests/dofs/dof_tools_21_b_x.cc
@@ -19,7 +19,7 @@
 //                                const FaceIterator        &,
 //                                AffineConstraints<double> &,
 //                                const ComponentMask       &,
-//                                unsigned char)
+//                                types::geometric_orientation)
 // for correct behavior on non standard oriented meshes.
 //
 // a redux of why the 21_b test failed starting in r29525. in essence,

--- a/tests/dofs/dof_tools_21_b_x_q3.cc
+++ b/tests/dofs/dof_tools_21_b_x_q3.cc
@@ -19,7 +19,7 @@
 //                                const FaceIterator        &,
 //                                AffineConstraints<double> &,
 //                                const ComponentMask       &,
-//                                unsigned char)
+//                                types::geometric_orientation)
 // for correct behavior on non standard oriented meshes.
 //
 // like _21_b_x but use a Q3 element. For this, the face_flip has a

--- a/tests/dofs/dof_tools_21_b_y.cc
+++ b/tests/dofs/dof_tools_21_b_y.cc
@@ -19,7 +19,7 @@
 //                                const FaceIterator        &,
 //                                AffineConstraints<double> &,
 //                                const ComponentMask       &,
-//                                unsigned char)
+//                                types::geometric_orientation)
 // for correct behavior on non standard oriented meshes.
 //
 // like _21_b_x, but with a once refined mesh

--- a/tests/dofs/dof_tools_21_c.cc
+++ b/tests/dofs/dof_tools_21_c.cc
@@ -39,7 +39,7 @@
 //                                const FaceIterator        &,
 //                                AffineConstraints<double> &,
 //                                const ComponentMask       &,
-//                                unsigned char)
+//                                types::geometric_orientation)
 //
 // for correct behavior with hanging nodes. This is done by additionally
 // refining the second cube once. Test that constraining face_1 -> face_2

--- a/tests/fe/face_to_cell_q1_2d.cc
+++ b/tests/fe/face_to_cell_q1_2d.cc
@@ -34,7 +34,8 @@ test()
     {
       deallog << "Face=" << face << std::endl;
 
-      for (unsigned char orientation = 0; orientation < 2; ++orientation)
+      for (types::geometric_orientation orientation = 0; orientation < 2;
+           ++orientation)
         {
           deallog << "  orientation=" << (orientation == 0 ? "false" : "true")
                   << std::endl

--- a/tests/fe/face_to_cell_q2_2d.cc
+++ b/tests/fe/face_to_cell_q2_2d.cc
@@ -34,7 +34,8 @@ test()
     {
       deallog << "Face=" << face << std::endl;
 
-      for (unsigned char orientation = 0; orientation < 2; ++orientation)
+      for (types::geometric_orientation orientation = 0; orientation < 2;
+           ++orientation)
         {
           deallog << "  orientation=" << (orientation == 0 ? "false" : "true")
                   << std::endl

--- a/tests/fe/face_to_cell_q2xq2_2d.cc
+++ b/tests/fe/face_to_cell_q2xq2_2d.cc
@@ -35,7 +35,8 @@ test()
     {
       deallog << "Face=" << face << std::endl;
 
-      for (unsigned char orientation = 0; orientation < 2; ++orientation)
+      for (types::geometric_orientation orientation = 0; orientation < 2;
+           ++orientation)
         {
           deallog << "  orientation=" << (orientation == 0 ? "false" : "true")
                   << std::endl

--- a/tests/fe/face_to_cell_q3_2d.cc
+++ b/tests/fe/face_to_cell_q3_2d.cc
@@ -34,7 +34,8 @@ test()
     {
       deallog << "Face=" << face << std::endl;
 
-      for (unsigned char orientation = 0; orientation < 2; ++orientation)
+      for (types::geometric_orientation orientation = 0; orientation < 2;
+           ++orientation)
         {
           deallog << "  orientation=" << (orientation == 0 ? "false" : "true")
                   << std::endl

--- a/tests/fe/face_to_cell_q3xq4_2d.cc
+++ b/tests/fe/face_to_cell_q3xq4_2d.cc
@@ -35,7 +35,8 @@ test()
     {
       deallog << "Face=" << face << std::endl;
 
-      for (unsigned char orientation = 0; orientation < 2; ++orientation)
+      for (types::geometric_orientation orientation = 0; orientation < 2;
+           ++orientation)
         {
           deallog << "  orientation=" << (orientation == 0 ? "false" : "true")
                   << std::endl

--- a/tests/fe/face_to_cell_q4_2d.cc
+++ b/tests/fe/face_to_cell_q4_2d.cc
@@ -34,7 +34,8 @@ test()
     {
       deallog << "Face=" << face << std::endl;
 
-      for (unsigned char orientation = 0; orientation < 2; ++orientation)
+      for (types::geometric_orientation orientation = 0; orientation < 2;
+           ++orientation)
         {
           deallog << "  orientation=" << (orientation == 0 ? "false" : "true")
                   << std::endl

--- a/tests/grid/grid_tools_05.cc
+++ b/tests/grid/grid_tools_05.cc
@@ -154,9 +154,9 @@ generate_grid(Triangulation<3> &triangulation)
  */
 template <typename FaceIterator>
 void
-print_match(const FaceIterator &face_1,
-            const FaceIterator &face_2,
-            const unsigned char combined_orientation)
+print_match(const FaceIterator                &face_1,
+            const FaceIterator                &face_2,
+            const types::geometric_orientation combined_orientation)
 {
   static const int dim = FaceIterator::AccessorType::dimension;
 

--- a/tests/grid/grid_tools_06.cc
+++ b/tests/grid/grid_tools_06.cc
@@ -167,9 +167,9 @@ generate_grid(Triangulation<3> &triangulation, int orientation)
  */
 template <typename FaceIterator>
 void
-print_match(const FaceIterator &face_1,
-            const FaceIterator &face_2,
-            const unsigned char combined_orientation)
+print_match(const FaceIterator                &face_1,
+            const FaceIterator                &face_2,
+            const types::geometric_orientation combined_orientation)
 {
   static const int dim = FaceIterator::AccessorType::dimension;
 

--- a/tests/grid/reference_cell_reverse_orientation.cc
+++ b/tests/grid/reference_cell_reverse_orientation.cc
@@ -28,9 +28,10 @@ main()
 
   deallog << "lines" << std::endl;
   {
-    const std::array<unsigned char, 2> inverse_permutations{{0u, 1u}};
+    const std::array<types::geometric_orientation, 2> inverse_permutations{
+      {0u, 1u}};
 
-    for (unsigned char o = 0; o < 2; ++o)
+    for (types::geometric_orientation o = 0; o < 2; ++o)
       {
         deallog << "o = " << int(o) << std::endl;
         std::array<unsigned int, 2> vs{{0u, 1u}};
@@ -51,10 +52,10 @@ main()
 
   deallog << "triangles" << std::endl;
   {
-    const std::array<unsigned char, 6> inverse_permutations{
+    const std::array<types::geometric_orientation, 6> inverse_permutations{
       {0u, 1u, 2u, 5u, 4u, 3u}};
 
-    for (unsigned char o = 0; o < 6; ++o)
+    for (types::geometric_orientation o = 0; o < 6; ++o)
       {
         deallog << "o = " << int(o) << std::endl;
         std::array<unsigned int, 3> vs{{0u, 1u, 2u}};
@@ -75,10 +76,10 @@ main()
 
   deallog << "quadrilaterals" << std::endl;
   {
-    const std::array<unsigned char, 8> inverse_permutations{
+    const std::array<types::geometric_orientation, 8> inverse_permutations{
       {0u, 1u, 2u, 7u, 4u, 5u, 6u, 3u}};
 
-    for (unsigned char o = 0; o < 8; ++o)
+    for (types::geometric_orientation o = 0; o < 8; ++o)
       {
         deallog << "o = " << int(o) << std::endl;
         std::array<unsigned int, 4> vs{{0u, 1u, 2u, 3u}};
@@ -100,7 +101,7 @@ main()
   // Verify that the manual version created the same results.
   deallog << "quadrilaterals (manual)" << std::endl;
   {
-    for (unsigned char o = 0; o < 8; ++o)
+    for (types::geometric_orientation o = 0; o < 8; ++o)
       {
         deallog << "o = " << int(o) << std::endl;
         std::array<unsigned int, 4> vs{{0u, 1u, 2u, 3u}};

--- a/tests/mpi/periodicity_04.cc
+++ b/tests/mpi/periodicity_04.cc
@@ -261,10 +261,12 @@ check(const unsigned int orientation, bool reverse)
 
   using CellFace =
     std::pair<typename Triangulation<dim>::cell_iterator, unsigned int>;
-  const typename std::map<CellFace, std::pair<CellFace, unsigned char>>
+  const typename std::map<CellFace,
+                          std::pair<CellFace, types::geometric_orientation>>
     &face_map = triangulation.get_periodic_face_map();
-  typename std::map<CellFace,
-                    std::pair<CellFace, unsigned char>>::const_iterator it;
+  typename std::map<
+    CellFace,
+    std::pair<CellFace, types::geometric_orientation>>::const_iterator it;
   int sum_of_pairs_local = face_map.size();
   int sum_of_pairs_global;
   MPI_Allreduce(&sum_of_pairs_local,
@@ -295,8 +297,10 @@ check(const unsigned int orientation, bool reverse)
             {
               std::cout << "face_center_1: " << face_center_1 << std::endl;
               std::cout << "face_center_2: " << face_center_2 << std::endl;
-              typename std::map<CellFace, std::pair<CellFace, unsigned char>>::
-                const_iterator it;
+              typename std::map<
+                CellFace,
+                std::pair<CellFace,
+                          types::geometric_orientation>>::const_iterator it;
               for (it = triangulation.get_periodic_face_map().begin();
                    it != triangulation.get_periodic_face_map().end();
                    ++it)

--- a/tests/simplex/orientation_02.cc
+++ b/tests/simplex/orientation_02.cc
@@ -23,7 +23,7 @@
 #include "../tests.h"
 
 void
-test(const unsigned char orientation)
+test(const types::geometric_orientation orientation)
 {
   const unsigned int face_no = 0;
 


### PR DESCRIPTION
Part of #14667.

I didn't use this new typedef in the matrix-free code since that still uses a slightly different orientation scheme (the one where 0 is the default). There's a similar problem remaining in QProjector too.