### PR TITLE
Make a variable in step-44 'unsigned'.

### DIFF
--- a/examples/step-44/step-44.cc
+++ b/examples/step-44/step-44.cc
@@ -843,7 +843,7 @@ namespace Step44
     void determine_component_extractors();
 
     // Create Dirichlet constraints for the incremental displacement field:
-    void make_constraints(const int it_nr);
+    void make_constraints(const unsigned int it_nr);
 
     // Several functions to assemble the system and right hand side matrices
     // using multithreading. Each of them comes as a wrapper function, one
@@ -2234,7 +2234,7 @@ namespace Step44
   // are hard to debug. In this spirit, we choose to make the code more verbose
   // in terms of what operations are performed at each Newton step.
   template <int dim>
-  void Solid<dim>::make_constraints(const int it_nr)
+  void Solid<dim>::make_constraints(const unsigned int it_nr)
   {
     // Since we (a) are dealing with an iterative Newton method, (b) are using
     // an incremental formulation for the displacement, and (c) apply the


### PR DESCRIPTION
The function in question takes an `int` argument, but it is called with an `unsigned int` value. We might as well make the argument `unsigned`.