### PR TITLE
Initialize some FEValuesExtractors where it is easiest to read (step-44).

### DIFF
--- a/examples/step-44/step-44.cc
+++ b/examples/step-44/step-44.cc
@@ -922,22 +922,26 @@ namespace Step44
     // polynomial degree, the degree-of-freedom handler, number of DoFs per
     // cell and the extractor objects used to retrieve information from the
     // solution vectors:
-    const unsigned int               degree;
-    const FESystem<dim>              fe;
-    DoFHandler<dim>                  dof_handler;
-    const unsigned int               dofs_per_cell;
-    const FEValuesExtractors::Vector u_fe;
-    const FEValuesExtractors::Scalar p_fe;
-    const FEValuesExtractors::Scalar J_fe;
+    const unsigned int  degree;
+    const FESystem<dim> fe;
+    DoFHandler<dim>     dof_handler;
+    const unsigned int  dofs_per_cell;
 
     // Description of how the block-system is arranged. There are 3 blocks,
     // the first contains a vector DOF $\mathbf{u}$ while the other two
     // describe scalar DOFs, $\widetilde{p}$ and $\widetilde{J}$.
-    static const unsigned int n_blocks          = 3;
-    static const unsigned int n_components      = dim + 2;
-    static const unsigned int first_u_component = 0;
-    static const unsigned int p_component       = dim;
-    static const unsigned int J_component       = dim + 1;
+    static constexpr unsigned int n_blocks          = 3;
+    static constexpr unsigned int n_components      = dim + 2;
+    static constexpr unsigned int first_u_component = 0;
+    static constexpr unsigned int p_component       = dim;
+    static constexpr unsigned int J_component       = dim + 1;
+
+    static constexpr FEValuesExtractors::Vector u_fe =
+      FEValuesExtractors::Vector(first_u_component);
+    static constexpr FEValuesExtractors::Scalar p_fe =
+      FEValuesExtractors::Scalar(p_component);
+    static constexpr FEValuesExtractors::Scalar J_fe =
+      FEValuesExtractors::Scalar(J_component);
 
     enum
     {
@@ -1048,9 +1052,6 @@ namespace Step44
        FE_DGP<dim>(parameters.poly_degree - 1)) // dilatation
     , dof_handler(triangulation)
     , dofs_per_cell(fe.n_dofs_per_cell())
-    , u_fe(first_u_component)
-    , p_fe(p_component)
-    , J_fe(J_component)
     , dofs_per_block(n_blocks)
     , qf_cell(parameters.quad_order)
     , qf_face(parameters.quad_order)


### PR DESCRIPTION
This program keeps its `FEValuesExtractors` as member variables, which means that they are initialized in a different place than where they are declared -- so you have to look into two different places to see what components they refer to. 

This can be avoided by initializing them right where they are declared as members. However, in C++17, this can only be done if they are `constexpr`, not if they are only `const` (you can only do it for `const` variables if they don't have user-defined constructors, such as numbers). So I needed to make these variables `constexpr` and while I was there I thought I can also make the constants right above `constexpr` (which they are implicitly anyway because `static const` scalar values are `constexpr`).