### PR TITLE
Convert FETools::compute_face_embedding_matrices() to use ArrayView.

### DIFF
--- a/doc/news/changes/incompatibilities/20250116Bangerth-2
+++ b/doc/news/changes/incompatibilities/20250116Bangerth-2
@@ -1,0 +1,12 @@
+Changed: The function FETools::compute_face_embedding_matrices() used
+to take its second argument as a fixed-size (C-style) array of
+matrices of size `GeometryInfo<dim>::max_children_per_face`. This has
+been changed to be an object of type `ArrayView<FullMatrix<number>>`
+to allow for storage of that array in other ways, say as an object of
+type `std::vector<FullMatrix<double>>`. To convert old code, you may
+have to explicitly call the function with its template arguments, say
+as `FETools::compute_face_embedding_matrices<dim,double,spacedim(...)`
+or to convert the second argument from its actual type to the
+ArrayView object by wrapping it in a call to make_array_view().
+<br>
+(Wolfgang Bangerth, 2024/01/16)

--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -364,7 +364,7 @@ namespace FETools
    * @param fe The finite element for which to compute these matrices.
    *
    * @param matrices An array of <i>GeometryInfo<dim>::subfaces_per_face =
-   * 2<sup>dim-1</sup></i> FullMatrix objects,holding the embedding matrix for
+   * 2<sup>dim-1</sup></i> FullMatrix objects, holding the embedding matrix for
    * each subface.
    *
    * @param face_coarse The number of the face on the coarse side of the face
@@ -381,12 +381,11 @@ namespace FETools
    */
   template <int dim, typename number, int spacedim>
   void
-  compute_face_embedding_matrices(
-    const FiniteElement<dim, spacedim> &fe,
-    FullMatrix<number> (&matrices)[GeometryInfo<dim>::max_children_per_face],
-    const unsigned int face_coarse,
-    const unsigned int face_fine,
-    const double       threshold = 1.e-12);
+  compute_face_embedding_matrices(const FiniteElement<dim, spacedim>  &fe,
+                                  const ArrayView<FullMatrix<number>> &matrices,
+                                  const unsigned int face_coarse,
+                                  const unsigned int face_fine,
+                                  const double       threshold = 1.e-12);
 
   /**
    * For all possible (isotropic and anisotropic) refinement cases compute the

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -1811,13 +1811,13 @@ namespace FETools
 
   template <int dim, typename number, int spacedim>
   void
-  compute_face_embedding_matrices(
-    const FiniteElement<dim, spacedim> &fe,
-    FullMatrix<number> (&matrices)[GeometryInfo<dim>::max_children_per_face],
-    const unsigned int face_coarse,
-    const unsigned int face_fine,
-    const double       threshold)
+  compute_face_embedding_matrices(const FiniteElement<dim, spacedim>  &fe,
+                                  const ArrayView<FullMatrix<number>> &matrices,
+                                  const unsigned int face_coarse,
+                                  const unsigned int face_fine,
+                                  const double       threshold)
   {
+    AssertDimension(matrices.size(), GeometryInfo<dim>::max_children_per_face);
     const unsigned int face_no = face_coarse;
 
     Assert(face_coarse == 0, ExcNotImplemented());

--- a/source/fe/fe_bdm.cc
+++ b/source/fe/fe_bdm.cc
@@ -90,7 +90,8 @@ FE_BDM<dim>::FE_BDM(const unsigned int deg)
   for (unsigned int i = 0; i < GeometryInfo<dim>::max_children_per_face; ++i)
     face_embeddings[i].reinit(this->n_dofs_per_face(face_no),
                               this->n_dofs_per_face(face_no));
-  FETools::compute_face_embedding_matrices(*this, face_embeddings, 0, 0, 1.);
+  FETools::compute_face_embedding_matrices(
+    *this, make_array_view(face_embeddings), 0, 0, 1.);
   this->interface_constraints.reinit((1 << (dim - 1)) *
                                        this->n_dofs_per_face(face_no),
                                      this->n_dofs_per_face(face_no));

--- a/source/fe/fe_raviart_thomas.cc
+++ b/source/fe/fe_raviart_thomas.cc
@@ -93,13 +93,13 @@ FE_RaviartThomas<dim>::FE_RaviartThomas(const unsigned int deg)
   // TODO[TL]: for anisotropic refinement we will probably need a table of
   // submatrices with an array for each refine case
   FullMatrix<double> face_embeddings[GeometryInfo<dim>::max_children_per_face];
-  for (unsigned int i = 0; i < GeometryInfo<dim>::max_children_per_face; ++i)
-    face_embeddings[i].reinit(this->n_dofs_per_face(face_no),
-                              this->n_dofs_per_face(face_no));
-  FETools::compute_face_embedding_matrices<dim, double>(*this,
-                                                        face_embeddings,
-                                                        0,
-                                                        0);
+  for (auto &face_embedding : face_embeddings)
+    face_embedding.reinit(this->n_dofs_per_face(face_no),
+                          this->n_dofs_per_face(face_no));
+  FETools::compute_face_embedding_matrices(*this,
+                                           make_array_view(face_embeddings),
+                                           0,
+                                           0);
   this->interface_constraints.reinit((1 << (dim - 1)) *
                                        this->n_dofs_per_face(face_no),
                                      this->n_dofs_per_face(face_no));

--- a/source/fe/fe_tools.inst.in
+++ b/source/fe/fe_tools.inst.in
@@ -228,10 +228,9 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
       template void
       compute_face_embedding_matrices<deal_II_dimension, double>(
         const FiniteElement<deal_II_dimension> &,
-        FullMatrix<double> (
-            &)[GeometryInfo<deal_II_dimension>::max_children_per_face],
-        unsigned int,
-        unsigned int,
+        const ArrayView<FullMatrix<double>> &,
+        const unsigned int,
+        const unsigned int,
         const double);
 
       template void


### PR DESCRIPTION
This function took a fixed-size array, but this is inconvenient in places where perhaps we want to allocate an array via `std::vector` -- e.g., because we don't want to use the known `GeometryInfo::max_children_per_face` number and replace it by `this->reference_cell().face_reference_cell().n_children()` or some such.

But there is no need to use a fixed-size array. We have `ArrayView`.