### PR TITLE
Represent line orientations with `types::geometric_orientation`.

### DIFF
--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -3168,8 +3168,9 @@ namespace internal
 
             for (const auto line : accessor.line_indices())
               {
-                const bool line_orientation = line_orientations[line];
-                if (line_orientation)
+                const auto line_orientation = line_orientations[line];
+                if (line_orientation ==
+                    ReferenceCell::default_combined_face_orientation())
                   dof_operation.process_dofs(
                     accessor.get_dof_handler(),
                     0,

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -439,10 +439,6 @@ public:
    * lines only have two possible orientations, this function and
    * ReferenceCell::default_combined_face_orientation() encode all of its
    * possible orientation states.
-   *
-   * @note Line orientations are typically stored as booleans, but to better
-   * enable dimension-independent programming relevant functions typically
-   * present these values as the standard orientation type.
    */
   static constexpr types::geometric_orientation
   reversed_combined_line_orientation();
@@ -594,21 +590,16 @@ public:
     const types::geometric_orientation face_orientation) const;
 
   /**
-   * Return whether the line with index @p line is oriented in
-   * standard direction within a cell, given the @p face_orientation of
-   * the face within the current cell, and @p line_orientation flag
-   * for the line within that face. @p true indicates that the line is
-   * oriented from vertex 0 to vertex 1, whereas it is the other way
-   * around otherwise. In 1d and 2d, this is always @p true, but in 3d
-   * it may be different, see the respective discussion in the
-   * documentation of the GeometryInfo class.
+   * Return whether the line with index @p line is oriented in standard
+   * direction within a cell, given the @p face_orientation of the face within
+   * the current cell, and @p line_orientation for the line within that face.
    */
-  bool
+  types::geometric_orientation
   standard_vs_true_line_orientation(
     const unsigned int                 line,
     const unsigned int                 face,
     const types::geometric_orientation face_orientation,
-    const bool                         line_orientation) const;
+    const types::geometric_orientation line_orientation) const;
 
   /**
    * @}
@@ -3227,21 +3218,26 @@ ReferenceCell::n_face_orientations(const unsigned int face_no) const
 
 
 
-inline bool
+inline types::geometric_orientation
 ReferenceCell::standard_vs_true_line_orientation(
   const unsigned int                 line,
   const unsigned int                 face,
   const types::geometric_orientation combined_face_orientation,
-  const bool                         line_orientation) const
+  const types::geometric_orientation line_orientation) const
 {
+  constexpr auto D = ReferenceCell::default_combined_face_orientation();
+  constexpr auto R = ReferenceCell::reversed_combined_line_orientation();
   if (*this == ReferenceCells::Hexahedron)
     {
-      static constexpr dealii::ndarray<bool, 2, 8> bool_table{
-        {{{true, true, false, true, false, false, true, false}},
-         {{true, true, true, false, false, false, false, true}}}};
+      static constexpr dealii::ndarray<types::geometric_orientation, 2, 8>
+        table{{{{D, D, R, D, R, R, D, R}}, {{D, D, D, R, R, R, R, D}}}};
+      // We use line / 2 here since lines i and i + 1 are parallel and, on a
+      // given face, have the same relative orientations.
+      const bool match =
+        line_orientation == table[line / 2][combined_face_orientation];
 
-      return (line_orientation ==
-              bool_table[line / 2][combined_face_orientation]);
+      return match ? ReferenceCell::default_combined_face_orientation() :
+                     ReferenceCell::reversed_combined_line_orientation();
     }
   else if (*this == ReferenceCells::Tetrahedron)
     {
@@ -3256,17 +3252,19 @@ ReferenceCell::standard_vs_true_line_orientation(
                "This function can only be called for following face-line "
                "combinations: (0,0), (0,1), (0,2), (1,1), (1,2), (2,1),"));
 
-      static constexpr dealii::ndarray<bool, 2, 6> bool_table{
-        {{{false, true, false, true, false, true}},
-         {{true, false, true, false, true, false}}}};
+      static constexpr dealii::ndarray<types::geometric_orientation, 2, 6>
+        table{{{{R, D, R, D, R, D}}, {{D, R, D, R, D, R}}}};
 
-      return (line_orientation ==
-              bool_table[combined_line][combined_face_orientation]);
+      const bool match =
+        line_orientation == table[combined_line][combined_face_orientation];
+
+      return match ? ReferenceCell::default_combined_face_orientation() :
+                     ReferenceCell::reversed_combined_line_orientation();
     }
   else
     // TODO: This might actually be wrong for some of the other
     // kinds of objects. We should check this
-    return true;
+    return ReferenceCell::default_combined_face_orientation();
 }
 
 

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -1004,7 +1004,7 @@ public:
    * @warning This function is really only for internal use in the library
    * unless you absolutely know what this is all about.
    *
-   * @note This function queries ReferenceCell::standard_vs_true_line_orientation().
+   * @note This function queries ReferenceCell::face_to_cell_line_orientation().
    */
   types::geometric_orientation
   line_orientation(const unsigned int line) const;
@@ -5109,22 +5109,22 @@ namespace internal
                    ref_cell.standard_to_real_face_line(3, f, orientation)}};
                 const auto quad = cell.quad(f);
                 const std::array<types::geometric_orientation, 4>
-                  my_orientations{{ref_cell.standard_vs_true_line_orientation(
+                  my_orientations{{ref_cell.face_to_cell_line_orientation(
                                      0,
                                      f,
                                      orientation,
                                      quad->line_orientation(my_indices[0])),
-                                   ref_cell.standard_vs_true_line_orientation(
+                                   ref_cell.face_to_cell_line_orientation(
                                      1,
                                      f,
                                      orientation,
                                      quad->line_orientation(my_indices[1])),
-                                   ref_cell.standard_vs_true_line_orientation(
+                                   ref_cell.face_to_cell_line_orientation(
                                      2,
                                      f,
                                      orientation,
                                      quad->line_orientation(my_indices[2])),
-                                   ref_cell.standard_vs_true_line_orientation(
+                                   ref_cell.face_to_cell_line_orientation(
                                      3,
                                      f,
                                      orientation,
@@ -5144,12 +5144,12 @@ namespace internal
                    ref_cell.standard_to_real_face_line(1, f, orientation)}};
                 const auto quad = cell.quad(f);
                 const std::array<types::geometric_orientation, 2>
-                  my_orientations{{ref_cell.standard_vs_true_line_orientation(
+                  my_orientations{{ref_cell.face_to_cell_line_orientation(
                                      0,
                                      f,
                                      orientation,
                                      quad->line_orientation(my_indices[0])),
-                                   ref_cell.standard_vs_true_line_orientation(
+                                   ref_cell.face_to_cell_line_orientation(
                                      1,
                                      f,
                                      orientation,
@@ -5171,32 +5171,32 @@ namespace internal
                ref_cell.standard_to_real_face_line(1, 1, orientations[1]),
                ref_cell.standard_to_real_face_line(2, 1, orientations[1]),
                ref_cell.standard_to_real_face_line(1, 2, orientations[2])}};
-            line_orientations[0] = ref_cell.standard_vs_true_line_orientation(
+            line_orientations[0] = ref_cell.face_to_cell_line_orientation(
               0,
               0,
               orientations[0],
               cell.quad(0)->line_orientation(my_indices[0]));
-            line_orientations[1] = ref_cell.standard_vs_true_line_orientation(
+            line_orientations[1] = ref_cell.face_to_cell_line_orientation(
               1,
               0,
               orientations[0],
               cell.quad(0)->line_orientation(my_indices[1]));
-            line_orientations[2] = ref_cell.standard_vs_true_line_orientation(
+            line_orientations[2] = ref_cell.face_to_cell_line_orientation(
               2,
               0,
               orientations[0],
               cell.quad(0)->line_orientation(my_indices[2]));
-            line_orientations[3] = ref_cell.standard_vs_true_line_orientation(
+            line_orientations[3] = ref_cell.face_to_cell_line_orientation(
               1,
               1,
               orientations[1],
               cell.quad(1)->line_orientation(my_indices[3]));
-            line_orientations[4] = ref_cell.standard_vs_true_line_orientation(
+            line_orientations[4] = ref_cell.face_to_cell_line_orientation(
               2,
               1,
               orientations[1],
               cell.quad(1)->line_orientation(my_indices[4]));
-            line_orientations[5] = ref_cell.standard_vs_true_line_orientation(
+            line_orientations[5] = ref_cell.face_to_cell_line_orientation(
               1,
               2,
               orientations[2],
@@ -5567,7 +5567,7 @@ TriaAccessor<structdim, dim, spacedim>::line_orientation(
           line_index, face_index, this->combined_face_orientation(face_index));
 
       // Then query how that line is oriented within that face:
-      return reference_cell.standard_vs_true_line_orientation(
+      return reference_cell.face_to_cell_line_orientation(
         line_index,
         face_index,
         this->combined_face_orientation(face_index),

--- a/include/deal.II/numerics/vector_tools_boundary.templates.h
+++ b/include/deal.II/numerics/vector_tools_boundary.templates.h
@@ -1122,14 +1122,14 @@ namespace VectorTools
             GeometryInfo<dim>::vertices_per_face * fe.n_dofs_per_vertex() +
             line * fe.n_dofs_per_line() + line_dof_idx;
 
-          // Note, assuming that the edge orientations are "standard"
-          //       i.e. cell->line_orientation(line) = true.
-          Assert(cell->line_orientation(line),
+          // Note, assuming that the edge orientations are "standard", i.e.,
+          //       cell->line_orientation(line) =
+          //       ReferenceCell::default_combined_face_orientation()
+          Assert(cell->line_orientation(line) ==
+                   ReferenceCell::default_combined_face_orientation(),
                  ExcMessage("Edge orientation does not meet expectation."));
           // Next, translate from face to cell. Note, this might be assuming
-          // that the edge orientations are "standard" (not sure any more at
-          // this time), i.e.
-          //       cell->line_orientation(line) = true.
+          // that the edge orientations are "standard"
           const unsigned int cell_dof_idx =
             fe.face_to_cell_index(face_dof_idx, face);
 
@@ -1558,9 +1558,7 @@ namespace VectorTools
                         line * fe.n_dofs_per_line() + line_dof_idx;
 
                       // Next, translate from face to cell. Note, this might be
-                      // assuming that the edge orientations are "standard" (not
-                      // sure any more at this time), i.e.
-                      //       cell->line_orientation(line) = true.
+                      // assuming that the edge orientations are "standard"
                       const unsigned int cell_dof_idx =
                         fe.face_to_cell_index(face_dof_idx, face);
 

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -147,7 +147,8 @@ namespace internal
         const unsigned int dim = 2;
         // TODO: This fixes only lowest order
         for (unsigned int l = 0; l < GeometryInfo<dim>::lines_per_cell; ++l)
-          if (!(cell->line_orientation(l)) &&
+          if ((cell->line_orientation(l) ==
+               ReferenceCell::reversed_combined_line_orientation()) &&
               mapping_kind[0] == mapping_nedelec)
             line_dof_sign[l] = -1.0;
       }
@@ -165,7 +166,8 @@ namespace internal
         // TODO: This is probably only going to work for those elements for
         // which all dofs are face dofs
         for (unsigned int l = 0; l < GeometryInfo<dim>::lines_per_cell; ++l)
-          if (!(cell->line_orientation(l)) &&
+          if ((cell->line_orientation(l) ==
+               ReferenceCell::reversed_combined_line_orientation()) &&
               mapping_kind[0] == mapping_nedelec)
             line_dof_sign[l] = -1.0;
       }

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -3314,6 +3314,9 @@ namespace internal
                         combined_orientation ==
                           ReferenceCell::reversed_combined_line_orientation(),
                       ExcInternalError());
+                    // Same convention as TriaAccessor::set_line_orientation():
+                    // store true for the default orientation and false for
+                    // reversed.
                     faces.quads_line_orientations
                       [q * ReferenceCells::max_n_lines<2>() + j] =
                       combined_orientation ==
@@ -4304,11 +4307,12 @@ namespace internal
                                   switch_1->line_index(2)),
                                 static_cast<signed int>(
                                   switch_1->line_index(3))};
-                              const bool switch_1_line_orientations[4] = {
-                                switch_1->line_orientation(0),
-                                switch_1->line_orientation(1),
-                                switch_1->line_orientation(2),
-                                switch_1->line_orientation(3)};
+                              const types::geometric_orientation
+                                switch_1_line_orientations[4] = {
+                                  switch_1->line_orientation(0),
+                                  switch_1->line_orientation(1),
+                                  switch_1->line_orientation(2),
+                                  switch_1->line_orientation(3)};
                               const types::boundary_id switch_1_boundary_id =
                                 switch_1->boundary_id();
                               const unsigned int switch_1_user_index =
@@ -6449,11 +6453,7 @@ namespace internal
                             s.insert(i);
 #endif
 
-                          new_quad->set_line_orientation(
-                            f,
-                            orientation ==
-                              ReferenceCell::
-                                default_combined_face_orientation());
+                          new_quad->set_line_orientation(f, orientation);
                         }
 #ifdef DEBUG
                       AssertDimension(s.size(), 3);
@@ -6567,7 +6567,8 @@ namespace internal
                       numbers::internal_face_boundary_id);
                     new_quad->set_manifold_id(hex->manifold_id());
                     for (const auto j : new_quads[i]->line_indices())
-                      new_quad->set_line_orientation(j, true);
+                      new_quad->set_line_orientation(
+                        j, ReferenceCell::default_combined_face_orientation());
                   }
 
                 // we always get 8 children per refined cell
@@ -6912,11 +6913,7 @@ namespace internal
                                 make_array_view(vertices_0),
                                 make_array_view(vertices_1));
 
-                            new_quad->set_line_orientation(
-                              l,
-                              orientation ==
-                                ReferenceCell::
-                                  default_combined_face_orientation());
+                            new_quad->set_line_orientation(l, orientation);
 
                             // on a hex, inject the status of the current line
                             // also to the line on the other quad along the
@@ -6925,11 +6922,7 @@ namespace internal
                                 ReferenceCells::Hexahedron)
                               new_quads[representative_lines[q % 4][1] + q -
                                         (q % 4)]
-                                ->set_line_orientation(
-                                  l,
-                                  orientation ==
-                                    ReferenceCell::
-                                      default_combined_face_orientation());
+                                ->set_line_orientation(l, orientation);
                           }
                       }
                   }
@@ -7726,7 +7719,9 @@ namespace internal
                         for (unsigned int j = 0;
                              j < GeometryInfo<dim>::lines_per_face;
                              ++j)
-                          new_quad->set_line_orientation(j, true);
+                          new_quad->set_line_orientation(
+                            j,
+                            ReferenceCell::default_combined_face_orientation());
                       }
                     // now set the line orientation of children of
                     // outer lines correctly, the lines in the
@@ -7949,11 +7944,12 @@ namespace internal
                               switch_1->line_index(1),
                               switch_1->line_index(2),
                               switch_1->line_index(3)};
-                            const bool switch_1_line_orientations[4] = {
-                              switch_1->line_orientation(0),
-                              switch_1->line_orientation(1),
-                              switch_1->line_orientation(2),
-                              switch_1->line_orientation(3)};
+                            const types::geometric_orientation
+                              switch_1_line_orientations[4] = {
+                                switch_1->line_orientation(0),
+                                switch_1->line_orientation(1),
+                                switch_1->line_orientation(2),
+                                switch_1->line_orientation(3)};
                             const types::boundary_id switch_1_boundary_id =
                               switch_1->boundary_id();
                             const unsigned int switch_1_user_index =
@@ -8399,7 +8395,9 @@ namespace internal
                         for (unsigned int j = 0;
                              j < GeometryInfo<dim>::lines_per_face;
                              ++j)
-                          new_quad->set_line_orientation(j, true);
+                          new_quad->set_line_orientation(
+                            j,
+                            ReferenceCell::default_combined_face_orientation());
                       }
                     // now set the line orientation of children of
                     // outer lines correctly, the lines in the
@@ -8550,7 +8548,9 @@ namespace internal
                       for (unsigned int j = 0;
                            j < GeometryInfo<dim>::lines_per_face;
                            ++j)
-                        new_quads[i]->set_line_orientation(j, true);
+                        new_quads[i]->set_line_orientation(
+                          j,
+                          ReferenceCell::default_combined_face_orientation());
                     }
 
                   types::subdomain_id subdomainid = hex->subdomain_id();
@@ -8769,7 +8769,7 @@ namespace internal
                           // created ones and thus have no parents, they
                           // cannot inherit this property. set up an array
                           // and fill it with the respective values
-                          bool line_orientation[4];
+                          types::geometric_orientation line_orientation[4]{};
 
                           // the middle vertex marked as m0 above is the
                           // start vertex for lines 0 and 2 in standard
@@ -8782,15 +8782,16 @@ namespace internal
                           for (unsigned int i = 0; i < 4; ++i)
                             if (lines[i]->vertex_index(i % 2) ==
                                 middle_vertices[i % 2])
-                              line_orientation[i] = true;
+                              line_orientation[i] = ReferenceCell::
+                                default_combined_face_orientation();
                             else
                               {
-                                // it must be the other
-                                // way round then
+                                // it must be the other way round then
                                 Assert(lines[i]->vertex_index((i + 1) % 2) ==
                                          middle_vertices[i % 2],
                                        ExcInternalError());
-                                line_orientation[i] = false;
+                                line_orientation[i] = ReferenceCell::
+                                  reversed_combined_line_orientation();
                               }
 
                           // set up the new quad, line numbering is as
@@ -8996,7 +8997,7 @@ namespace internal
                           // created ones and thus have no parents, they
                           // cannot inherit this property. set up an array
                           // and fill it with the respective values
-                          bool line_orientation[4];
+                          types::geometric_orientation line_orientation[4]{};
 
                           // the middle vertex marked as m0 above is the
                           // start vertex for lines 0 and 2 in standard
@@ -9009,14 +9010,16 @@ namespace internal
                           for (unsigned int i = 0; i < 4; ++i)
                             if (lines[i]->vertex_index(i % 2) ==
                                 middle_vertices[i % 2])
-                              line_orientation[i] = true;
+                              line_orientation[i] = ReferenceCell::
+                                default_combined_face_orientation();
                             else
                               {
                                 // it must be the other way round then
                                 Assert(lines[i]->vertex_index((i + 1) % 2) ==
                                          middle_vertices[i % 2],
                                        ExcInternalError());
-                                line_orientation[i] = false;
+                                line_orientation[i] = ReferenceCell::
+                                  reversed_combined_line_orientation();
                               }
 
                           // set up the new quad, line numbering is as
@@ -9224,7 +9227,7 @@ namespace internal
                           // created ones and thus have no parents, they
                           // cannot inherit this property. set up an array
                           // and fill it with the respective values
-                          bool line_orientation[4];
+                          types::geometric_orientation line_orientation[4]{};
 
                           // the middle vertex marked as m0 above is the
                           // start vertex for lines 0 and 2 in standard
@@ -9237,14 +9240,16 @@ namespace internal
                           for (unsigned int i = 0; i < 4; ++i)
                             if (lines[i]->vertex_index(i % 2) ==
                                 middle_vertices[i % 2])
-                              line_orientation[i] = true;
+                              line_orientation[i] = ReferenceCell::
+                                default_combined_face_orientation();
                             else
                               {
                                 // it must be the other way round then
                                 Assert(lines[i]->vertex_index((i + 1) % 2) ==
                                          middle_vertices[i % 2],
                                        ExcInternalError());
-                                line_orientation[i] = false;
+                                line_orientation[i] = ReferenceCell::
+                                  reversed_combined_line_orientation();
                               }
 
                           // set up the new quad, line numbering is as
@@ -9537,7 +9542,7 @@ namespace internal
                           // created ones and thus have no parents, they
                           // cannot inherit this property. set up an array
                           // and fill it with the respective values
-                          bool line_orientation[13];
+                          types::geometric_orientation line_orientation[13]{};
 
                           // the middle vertices of the lines of our
                           // bottom face
@@ -9553,14 +9558,16 @@ namespace internal
                           // face
                           for (unsigned int i = 0; i < 4; ++i)
                             if (lines[i]->vertex_index(0) == middle_vertices[i])
-                              line_orientation[i] = true;
+                              line_orientation[i] = ReferenceCell::
+                                default_combined_face_orientation();
                             else
                               {
                                 // it must be the other way round then
                                 Assert(lines[i]->vertex_index(1) ==
                                          middle_vertices[i],
                                        ExcInternalError());
-                                line_orientation[i] = false;
+                                line_orientation[i] = ReferenceCell::
+                                  reversed_combined_line_orientation();
                               }
 
                           // note: for lines 4 to 11 (inner lines of the
@@ -9573,21 +9580,23 @@ namespace internal
                             if (lines[i]->vertex_index((i + 1) % 2) ==
                                 middle_vertex_index<dim, spacedim>(
                                   hex->face(3 + i / 4)))
-                              line_orientation[i] = true;
+                              line_orientation[i] = ReferenceCell::
+                                default_combined_face_orientation();
                             else
                               {
-                                // it must be the other way
-                                // round then
+                                // it must be the other way round then
                                 Assert(lines[i]->vertex_index(i % 2) ==
                                          (middle_vertex_index<dim, spacedim>(
                                            hex->face(3 + i / 4))),
                                        ExcInternalError());
-                                line_orientation[i] = false;
+                                line_orientation[i] = ReferenceCell::
+                                  reversed_combined_line_orientation();
                               }
                           // for the last line the line orientation is
                           // always true, since it was just constructed
                           // that way
-                          line_orientation[12] = true;
+                          line_orientation[12] =
+                            ReferenceCell::default_combined_face_orientation();
 
                           // set up the 4 quads, numbered as follows (left
                           // quad numbering, right line numbering
@@ -9971,7 +9980,7 @@ namespace internal
                           // created ones and thus have no parents, they
                           // cannot inherit this property. set up an array
                           // and fill it with the respective values
-                          bool line_orientation[13];
+                          types::geometric_orientation line_orientation[13]{};
 
                           // the middle vertices of the
                           // lines of our front face
@@ -9986,14 +9995,16 @@ namespace internal
                           // line is 'true', if vertex 0 is on the front
                           for (unsigned int i = 0; i < 4; ++i)
                             if (lines[i]->vertex_index(0) == middle_vertices[i])
-                              line_orientation[i] = true;
+                              line_orientation[i] = ReferenceCell::
+                                default_combined_face_orientation();
                             else
                               {
                                 // it must be the other way round then
                                 Assert(lines[i]->vertex_index(1) ==
                                          middle_vertices[i],
                                        ExcInternalError());
-                                line_orientation[i] = false;
+                                line_orientation[i] = ReferenceCell::
+                                  reversed_combined_line_orientation();
                               }
 
                           // note: for lines 4 to 11 (inner lines of the
@@ -10006,7 +10017,8 @@ namespace internal
                             if (lines[i]->vertex_index((i + 1) % 2) ==
                                 middle_vertex_index<dim, spacedim>(
                                   hex->face(1 + i / 4)))
-                              line_orientation[i] = true;
+                              line_orientation[i] = ReferenceCell::
+                                default_combined_face_orientation();
                             else
                               {
                                 // it must be the other way
@@ -10015,12 +10027,14 @@ namespace internal
                                          (middle_vertex_index<dim, spacedim>(
                                            hex->face(1 + i / 4))),
                                        ExcInternalError());
-                                line_orientation[i] = false;
+                                line_orientation[i] = ReferenceCell::
+                                  reversed_combined_line_orientation();
                               }
                           // for the last line the line orientation is
                           // always true, since it was just constructed
                           // that way
-                          line_orientation[12] = true;
+                          line_orientation[12] =
+                            ReferenceCell::default_combined_face_orientation();
 
                           // set up the 4 quads, numbered as follows (left
                           // quad numbering, right line numbering
@@ -10419,7 +10433,7 @@ namespace internal
                           // created ones and thus have no parents, they
                           // cannot inherit this property. set up an array
                           // and fill it with the respective values
-                          bool line_orientation[13];
+                          types::geometric_orientation line_orientation[13]{};
 
                           // the middle vertices of the lines of our front
                           // face
@@ -10434,14 +10448,16 @@ namespace internal
                           // line is 'true', if vertex 0 is on the front
                           for (unsigned int i = 0; i < 4; ++i)
                             if (lines[i]->vertex_index(0) == middle_vertices[i])
-                              line_orientation[i] = true;
+                              line_orientation[i] = ReferenceCell::
+                                default_combined_face_orientation();
                             else
                               {
                                 // it must be the other way round then
                                 Assert(lines[i]->vertex_index(1) ==
                                          middle_vertices[i],
                                        ExcInternalError());
-                                line_orientation[i] = false;
+                                line_orientation[i] = ReferenceCell::
+                                  reversed_combined_line_orientation();
                               }
 
                           // note: for lines 4 to 11 (inner lines of the
@@ -10454,21 +10470,22 @@ namespace internal
                             if (lines[i]->vertex_index((i + 1) % 2) ==
                                 middle_vertex_index<dim, spacedim>(
                                   hex->face(i / 4 - 1)))
-                              line_orientation[i] = true;
+                              line_orientation[i] = ReferenceCell::
+                                default_combined_face_orientation();
                             else
                               {
-                                // it must be the other way
-                                // round then
+                                // it must be the other way round then
                                 Assert(lines[i]->vertex_index(i % 2) ==
                                          (middle_vertex_index<dim, spacedim>(
                                            hex->face(i / 4 - 1))),
                                        ExcInternalError());
-                                line_orientation[i] = false;
+                                line_orientation[i] = ReferenceCell::
+                                  reversed_combined_line_orientation();
                               }
-                          // for the last line the line orientation is
-                          // always true, since it was just constructed
-                          // that way
-                          line_orientation[12] = true;
+                          // for the last line the line orientation is always
+                          // the default, since it was just constructed that way
+                          line_orientation[12] =
+                            ReferenceCell::default_combined_face_orientation();
 
                           // set up the 4 quads, numbered as follows (left
                           // quad numbering, right line numbering
@@ -11009,7 +11026,7 @@ namespace internal
                           // created ones and thus have no parents, they
                           // cannot inherit this property. set up an array
                           // and fill it with the respective values
-                          bool line_orientation[30];
+                          types::geometric_orientation line_orientation[30]{};
 
                           // note: for the first 24 lines (inner lines of
                           // the outer quads) the following holds: the
@@ -11020,7 +11037,8 @@ namespace internal
                           for (unsigned int i = 0; i < 24; ++i)
                             if (lines[i]->vertex_index((i + 1) % 2) ==
                                 vertex_indices[i / 4])
-                              line_orientation[i] = true;
+                              line_orientation[i] = ReferenceCell::
+                                default_combined_face_orientation();
                             else
                               {
                                 // it must be the other way
@@ -11028,13 +11046,15 @@ namespace internal
                                 Assert(lines[i]->vertex_index(i % 2) ==
                                          vertex_indices[i / 4],
                                        ExcInternalError());
-                                line_orientation[i] = false;
+                                line_orientation[i] = ReferenceCell::
+                                  reversed_combined_line_orientation();
                               }
                           // for the last 6 lines the line orientation is
                           // always true, since they were just constructed
                           // that way
                           for (unsigned int i = 24; i < 30; ++i)
-                            line_orientation[i] = true;
+                            line_orientation[i] = ReferenceCell::
+                              default_combined_face_orientation();
 
                           // set up the 12 quads, numbered as follows
                           // (left quad numbering, right line numbering
@@ -15971,10 +15991,10 @@ void Triangulation<dim, spacedim>::reset_cell_vertex_indices_cache()
           if (ref_cell == ReferenceCells::Hexahedron)
             for (unsigned int face = 4; face < 6; ++face)
               {
-                const auto                face_iter = cell->face(face);
-                const std::array<bool, 2> line_orientations{
-                  {face_iter->line_orientation(0),
-                   face_iter->line_orientation(1)}};
+                const auto face_iter = cell->face(face);
+                const std::array<types::geometric_orientation, 2>
+                  line_orientations{{face_iter->line_orientation(0),
+                                     face_iter->line_orientation(1)}};
                 std::array<unsigned int, 4> raw_vertex_indices{
                   {face_iter->line(0)->vertex_index(1 - line_orientations[0]),
                    face_iter->line(1)->vertex_index(1 - line_orientations[1]),
@@ -16003,8 +16023,9 @@ void Triangulation<dim, spacedim>::reset_cell_vertex_indices_cache()
               }
           else if (ref_cell == ReferenceCells::Quadrilateral)
             {
-              const std::array<bool, 2> line_orientations{
-                {cell->line_orientation(0), cell->line_orientation(1)}};
+              const std::array<types::geometric_orientation, 2>
+                line_orientations{
+                  {cell->line_orientation(0), cell->line_orientation(1)}};
               std::array<unsigned int, 4> raw_vertex_indices{
                 {cell->line(0)->vertex_index(1 - line_orientations[0]),
                  cell->line(1)->vertex_index(1 - line_orientations[1]),

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -3044,21 +3044,19 @@ CellAccessor<dim, spacedim>::neighbor_child_on_subface(
 
               // determine indices for this cell's subface from the perspective
               // of the neighboring cell
-              const unsigned int neighbor_face =
-                this->neighbor_of_neighbor(face);
+              const auto neighbor_face_no = this->neighbor_of_neighbor(face);
+
               // two neighboring cells have an opposed orientation on their
               // shared face if both of them follow the same orientation type
-              // (i.e., standard or non-standard).
-              // we verify this with a XOR operation.
-              const unsigned int neighbor_subface =
-                (!(this->line_orientation(face)) !=
-                 !(neighbor_cell->line_orientation(neighbor_face))) ?
-                  (1 - subface) :
-                  subface;
+              const unsigned int neighbor_subface_no =
+                this->face_orientation(face) ==
+                    neighbor_cell->face_orientation(neighbor_face_no) ?
+                  subface :
+                  1 - subface;
 
               const unsigned int neighbor_child_index =
                 neighbor_cell->reference_cell().child_cell_on_face(
-                  neighbor_face, neighbor_subface);
+                  neighbor_face_no, neighbor_subface_no);
               const TriaIterator<CellAccessor<dim, spacedim>> sub_neighbor =
                 neighbor_cell->child(neighbor_child_index);
 

--- a/tests/fe/fe_conformity_test.h
+++ b/tests/fe/fe_conformity_test.h
@@ -191,8 +191,9 @@ namespace FEConforimityTest
                  ++line_index)
               {
                 deallog << "      {" << line_index << " -> "
-                        << cell->line_orientation(line_index) << "}"
-                        << std::endl;
+                        << (cell->line_orientation(line_index) ==
+                            ReferenceCell::default_combined_face_orientation())
+                        << "}" << std::endl;
               } // line_index
           }     // cell
       }         // plot_mesh_properties
@@ -243,8 +244,9 @@ namespace FEConforimityTest
                  ++line_index)
               {
                 deallog << "      {" << line_index << " -> "
-                        << cell->line_orientation(line_index) << "}"
-                        << std::endl;
+                        << (cell->line_orientation(line_index) ==
+                            ReferenceCell::default_combined_face_orientation())
+                        << "}" << std::endl;
               } // line_index
           }     // cell
       }         // plot_mesh_properties

--- a/tests/grid/extrude_orientation_01.cc
+++ b/tests/grid/extrude_orientation_01.cc
@@ -68,7 +68,10 @@ test(std::ostream &out)
                 << (c->face_flip(f) ? "/true" : "/false") << std::endl;
       for (unsigned int e = 0; e < GeometryInfo<3>::lines_per_cell; ++e)
         deallog << "    edge=" << e
-                << (c->line_orientation(e) ? " -> true" : " -> false")
+                << (c->line_orientation(e) ==
+                        ReferenceCell::default_combined_face_orientation() ?
+                      " -> true" :
+                      " -> false")
                 << std::endl;
     }
 }

--- a/tests/grid/extrude_orientation_02.cc
+++ b/tests/grid/extrude_orientation_02.cc
@@ -61,7 +61,10 @@ test()
                 << (c->face_flip(f) ? "/true" : "/false") << std::endl;
       for (unsigned int e = 0; e < GeometryInfo<3>::lines_per_cell; ++e)
         deallog << "    edge=" << e
-                << (c->line_orientation(e) ? " -> true" : " -> false")
+                << (c->line_orientation(e) ==
+                        ReferenceCell::default_combined_face_orientation() ?
+                      " -> true" :
+                      " -> false")
                 << std::endl;
     }
 }

--- a/tests/grid/extrude_orientation_03.cc
+++ b/tests/grid/extrude_orientation_03.cc
@@ -60,7 +60,10 @@ test()
                 << (c->face_flip(f) ? "/true" : "/false") << std::endl;
       for (unsigned int e = 0; e < GeometryInfo<3>::lines_per_cell; ++e)
         deallog << "    edge=" << e
-                << (c->line_orientation(e) ? " -> true" : " -> false")
+                << (c->line_orientation(e) ==
+                        ReferenceCell::default_combined_face_orientation() ?
+                      " -> true" :
+                      " -> false")
                 << std::endl;
     }
 }

--- a/tests/grid/grid_generator_10.cc
+++ b/tests/grid/grid_generator_10.cc
@@ -107,9 +107,14 @@ check_grid()
            ++line)
         {
           deallog << line << ": "
-                  << (cell->line_orientation(line) ? "true" : "false")
+                  << (cell->line_orientation(line) ==
+                          ReferenceCell::default_combined_face_orientation() ?
+                        "true" :
+                        "false")
                   << std::endl;
-          Assert(cell->line_orientation(line) == true, ExcInternalError());
+          Assert(cell->line_orientation(line) ==
+                   ReferenceCell::default_combined_face_orientation(),
+                 ExcInternalError());
         }
     }
 }

--- a/tests/grid/grid_generator_non_standard_orientation_mesh_2d.cc
+++ b/tests/grid/grid_generator_non_standard_orientation_mesh_2d.cc
@@ -55,7 +55,9 @@ plot_all_info(const Triangulation<dim> &tria)
            line_index < GeometryInfo<dim>::lines_per_cell;
            ++line_index)
         {
-          deallog << cell->line_orientation(line_index) << "  ";
+          deallog << (cell->line_orientation(line_index) ==
+                      ReferenceCell::default_combined_face_orientation())
+                  << "  ";
         } // line_index
       deallog << '}' << std::endl << std::endl;
     } // cell

--- a/tests/grid/grid_generator_non_standard_orientation_mesh_3d.cc
+++ b/tests/grid/grid_generator_non_standard_orientation_mesh_3d.cc
@@ -56,7 +56,9 @@ plot_all_info(const Triangulation<dim> &tria)
            line_index < GeometryInfo<dim>::lines_per_cell;
            ++line_index)
         {
-          deallog << cell->line_orientation(line_index) << "  ";
+          deallog << (cell->line_orientation(line_index) ==
+                      ReferenceCell::default_combined_face_orientation())
+                  << "  ";
         } // line_index
       deallog << '}' << std::endl << std::endl;
     } // cell

--- a/tests/simplex/orientation_04.cc
+++ b/tests/simplex/orientation_04.cc
@@ -161,7 +161,8 @@ test()
               p1.first  = cell->line(l)->vertex_index(0);
               p1.second = cell->line(l)->vertex_index(1);
 
-              if (orientation_exp == false)
+              if (orientation_exp ==
+                  ReferenceCell::reversed_combined_line_orientation())
                 std::swap(p1.first, p1.second);
 
               success &= (p0 == p1);


### PR DESCRIPTION
Part of #14667.

I found the current state of line orientations really confusing - its a lot simpler to just make them use the same orientation type as everything else.