### PR TITLE
Consistently format deprecated headers.

### DIFF
--- a/include/deal.II/base/mpi_consensus_algorithms.templates.h
+++ b/include/deal.II/base/mpi_consensus_algorithms.templates.h
@@ -17,8 +17,9 @@
 
 #include <deal.II/base/config.h>
 
-DEAL_II_WARNING(
-  "This file is deprecated. Simply use <deal.II/base/mpi_consensus_algorithms.h>.")
+#include <deal.II/base/mpi_consensus_algorithms.h>
 
+DEAL_II_WARNING("This file is deprecated."
+                "Use deal.II/base/mpi_consensus_algorithms.h instead.")
 
 #endif

--- a/include/deal.II/base/sacado_product_type.h
+++ b/include/deal.II/base/sacado_product_type.h
@@ -12,14 +12,15 @@
 //
 // ------------------------------------------------------------------------
 
-
 #ifndef dealii_sacado_product_type_h_deprecated
 #define dealii_sacado_product_type_h_deprecated
 
 #include <deal.II/base/config.h>
 
-DEAL_II_WARNING(`"This file is deprecated. Use <deal.II/differentiation/ad/sacado_product_types.h> instead.")
-
 #include <deal.II/differentiation/ad/sacado_product_types.h>
+
+DEAL_II_WARNING(
+  "This file is deprecated."
+  "Use deal.II/differentiation/ad/sacado_product_types.h instead.")
 
 #endif

--- a/include/deal.II/base/std_cxx17/algorithm.h
+++ b/include/deal.II/base/std_cxx17/algorithm.h
@@ -11,23 +11,24 @@
 // LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 //
 // ------------------------------------------------------------------------
+
 #ifndef dealii_cxx17_algorithm_h
 #define dealii_cxx17_algorithm_h
 
 #include <deal.II/base/config.h>
 
-#ifdef DEAL_II_EARLY_DEPRECATIONS
-DEAL_II_WARNING(
-  "This file is deprecated. Simply use the corresponding C++17 header <algorithm>.")
-#endif
-
 #include <algorithm>
+
+#ifdef DEAL_II_EARLY_DEPRECATIONS
+DEAL_II_WARNING("This file is deprecated."
+                "Use the corresponding C++17 header algorithm instead.")
+#endif
 
 DEAL_II_NAMESPACE_OPEN
 namespace std_cxx17
 {
   using std::clamp;
-} // namespace std_cxx17
+}
 DEAL_II_NAMESPACE_CLOSE
 
-#endif // dealii_cxx17_algorithm_h
+#endif

--- a/include/deal.II/base/std_cxx17/optional.h
+++ b/include/deal.II/base/std_cxx17/optional.h
@@ -11,23 +11,24 @@
 // LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 //
 // ------------------------------------------------------------------------
+
 #ifndef dealii_cxx17_optional_h
 #define dealii_cxx17_optional_h
 
 #include <deal.II/base/config.h>
 
-#ifdef DEAL_II_EARLY_DEPRECATIONS
-DEAL_II_WARNING(
-  "This file is deprecated. Simply use the corresponding C++17 header <optional>.")
-#endif
-
 #include <optional>
+
+#ifdef DEAL_II_EARLY_DEPRECATIONS
+DEAL_II_WARNING("This file is deprecated."
+                "Use the corresponding C++17 header optional instead.")
+#endif
 
 DEAL_II_NAMESPACE_OPEN
 namespace std_cxx17
 {
   using std::optional;
-} // namespace std_cxx17
+}
 DEAL_II_NAMESPACE_CLOSE
 
-#endif // dealii_cxx17_optional_h
+#endif

--- a/include/deal.II/base/std_cxx17/tuple.h
+++ b/include/deal.II/base/std_cxx17/tuple.h
@@ -11,23 +11,24 @@
 // LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 //
 // ------------------------------------------------------------------------
+
 #ifndef dealii_cxx17_tuple_h
 #define dealii_cxx17_tuple_h
 
 #include <deal.II/base/config.h>
 
-#ifdef DEAL_II_EARLY_DEPRECATIONS
-DEAL_II_WARNING(
-  "This file is deprecated. Simply use the corresponding C++17 header <tuple>.")
-#endif
-
 #include <tuple>
+
+#ifdef DEAL_II_EARLY_DEPRECATIONS
+DEAL_II_WARNING("This file is deprecated."
+                "Use the corresponding C++17 header tuple instead.")
+#endif
 
 DEAL_II_NAMESPACE_OPEN
 namespace std_cxx17
 {
   using std::apply;
-} // namespace std_cxx17
+}
 DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/base/std_cxx17/variant.h
+++ b/include/deal.II/base/std_cxx17/variant.h
@@ -11,17 +11,18 @@
 // LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 //
 // ------------------------------------------------------------------------
+
 #ifndef dealii_cxx17_variant_h
 #define dealii_cxx17_variant_h
 
 #include <deal.II/base/config.h>
 
-#ifdef DEAL_II_EARLY_DEPRECATIONS
-DEAL_II_WARNING(
-  "This file is deprecated. Simply use the corresponding C++17 header <variant>.")
-#endif
-
 #include <variant>
+
+#ifdef DEAL_II_EARLY_DEPRECATIONS
+DEAL_II_WARNING("This file is deprecated."
+                "Use the corresponding C++17 header variant instead.")
+#endif
 
 DEAL_II_NAMESPACE_OPEN
 namespace std_cxx17
@@ -32,4 +33,4 @@ namespace std_cxx17
 } // namespace std_cxx17
 DEAL_II_NAMESPACE_CLOSE
 
-#endif // dealii_cxx17_variant_h
+#endif

--- a/include/deal.II/base/vector_slice.h
+++ b/include/deal.II/base/vector_slice.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-DEAL_II_WARNING(
-  "This file is deprecated. Use ArrayView instead of VectorSlice.")
+DEAL_II_WARNING("This file is deprecated."
+                "Use ArrayView instead of VectorSlice.")
 
 #endif

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -15,7 +15,11 @@
 #ifndef dealii_dof_accessor_templates_h
 #define dealii_dof_accessor_templates_h
 
-DEAL_II_WARNING(
-  "The use of this header file is deprecated. Just include <deal.II/dofs/dof_accessor.h>.")
+#include <deal.II/base/config.h>
+
+#include <deal.II/dofs/dof_accessor.h>
+
+DEAL_II_WARNING("This file is deprecated."
+                "Use deal.II/dofs/dof_accessor.h instead.")
 
 #endif

--- a/include/deal.II/fe/fe_base.h
+++ b/include/deal.II/fe/fe_base.h
@@ -17,6 +17,9 @@
 
 #include <deal.II/base/config.h>
 
-DEAL_II_WARNING("This file is deprecated. Simply use <deal.II/fe/fe_data.h>.")
+#include <deal.II/fe/fe_data.h>
+
+DEAL_II_WARNING("This file is deprecated."
+                "Use deal.II/fe/fe_data.h instead.")
 
 #endif

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -154,12 +154,6 @@ class TriaAccessor<0, dim, spacedim>;
 template <int spacedim>
 class TriaAccessor<0, 1, spacedim>;
 
-// note: the file tria_accessor.templates.h is included at the end of
-// this file.  this includes a lot of templates. originally, this was
-// only done in debug mode, but led to cyclic reduction problems and
-// so is now on by default.
-
-
 /**
  * A namespace that contains exception classes used by the accessor classes.
  */

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -19,7 +19,9 @@
 
 #include <deal.II/grid/tria_accessor.h>
 
+#ifdef DEAL_II_EARLY_DEPRECATIONS
 DEAL_II_WARNING("This file is deprecated."
                 "Use deal.II/grid/tria_accessor.h instead.")
+#endif
 
 #endif

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -15,7 +15,11 @@
 #ifndef dealii_tria_accessor_templates_h
 #define dealii_tria_accessor_templates_h
 
-#warning \
-  "The use of this header file is deprecated. Just include <deal.II/grid/tria_accessor.h>."
+#include <deal.II/base/config.h>
+
+#include <deal.II/grid/tria_accessor.h>
+
+DEAL_II_WARNING("This file is deprecated."
+                "Use deal.II/grid/tria_accessor.h instead.")
 
 #endif

--- a/include/deal.II/grid/tria_iterator.templates.h
+++ b/include/deal.II/grid/tria_iterator.templates.h
@@ -19,7 +19,9 @@
 
 #include <deal.II/grid/tria_iterator.h>
 
+#ifdef DEAL_II_EARLY_DEPRECATIONS
 DEAL_II_WARNING("This file is deprecated."
                 "Use deal.II/grid/tria_iterator.h instead.")
+#endif
 
 #endif

--- a/include/deal.II/grid/tria_iterator.templates.h
+++ b/include/deal.II/grid/tria_iterator.templates.h
@@ -15,10 +15,11 @@
 #ifndef dealii_tria_iterator_templates_h
 #define dealii_tria_iterator_templates_h
 
-
 #include <deal.II/base/config.h>
 
-DEAL_II_WARNING(
-  "The use of this header file is deprecated. Just include <deal.II/grid/tria_iterator.h>.")
+#include <deal.II/grid/tria_iterator.h>
+
+DEAL_II_WARNING("This file is deprecated."
+                "Use deal.II/grid/tria_iterator.h instead.")
 
 #endif

--- a/include/deal.II/lac/constraint_matrix.h
+++ b/include/deal.II/lac/constraint_matrix.h
@@ -12,15 +12,14 @@
 //
 // ------------------------------------------------------------------------
 
-
 #ifndef dealii_constraint_matrix_h
 #define dealii_constraint_matrix_h
 
 #include <deal.II/base/config.h>
 
-DEAL_II_WARNING(
-  "This file is deprecated. Use <deal.II/lac/affine_constraints.h> instead.")
-
 #include <deal.II/lac/affine_constraints.h>
+
+DEAL_II_WARNING("This file is deprecated."
+                "Use deal.II/lac/affine_constraints.h instead.")
 
 #endif

--- a/include/deal.II/lac/petsc_parallel_block_sparse_matrix.h
+++ b/include/deal.II/lac/petsc_parallel_block_sparse_matrix.h
@@ -15,12 +15,11 @@
 #ifndef dealii_petsc_parallel_block_sparse_matrix_h
 #define dealii_petsc_parallel_block_sparse_matrix_h
 
-
 #include <deal.II/base/config.h>
 
 #include <deal.II/lac/petsc_block_sparse_matrix.h>
 
-DEAL_II_WARNING(
-  "This file is deprecated. Use deal.II/lac/petsc_block_sparse_matrix.h instead!")
+DEAL_II_WARNING("This file is deprecated."
+                "Use deal.II/lac/petsc_block_sparse_matrix.h instead.")
 
-#endif // dealii_petsc_parallel_block_sparse_matrix_h
+#endif

--- a/include/deal.II/lac/petsc_parallel_block_vector.h
+++ b/include/deal.II/lac/petsc_parallel_block_vector.h
@@ -15,12 +15,11 @@
 #ifndef dealii_petsc_parallel_block_vector_h
 #define dealii_petsc_parallel_block_vector_h
 
-
 #include <deal.II/base/config.h>
 
 #include <deal.II/lac/petsc_block_vector.h>
 
-DEAL_II_WARNING(
-  "This file is deprecated. Use deal.II/lac/petsc_block_vector.h instead!")
+DEAL_II_WARNING("This file is deprecated."
+                "Use deal.II/lac/petsc_block_vector.h instead.")
 
 #endif

--- a/include/deal.II/lac/petsc_parallel_sparse_matrix.h
+++ b/include/deal.II/lac/petsc_parallel_sparse_matrix.h
@@ -19,7 +19,7 @@
 
 #include <deal.II/lac/petsc_sparse_matrix.h>
 
-DEAL_II_WARNING(
-  "This file is deprecated. Use deal.II/lac/petsc_sparse_matrix.h instead.")
+DEAL_II_WARNING("This file is deprecated."
+                "Use deal.II/lac/petsc_sparse_matrix.h instead.")
 
 #endif

--- a/include/deal.II/lac/petsc_parallel_vector.h
+++ b/include/deal.II/lac/petsc_parallel_vector.h
@@ -19,7 +19,7 @@
 
 #include <deal.II/lac/petsc_vector.h>
 
-DEAL_II_WARNING(
-  "This file is deprecated. Use deal.II/lac/petsc_vector.h instead!")
+DEAL_II_WARNING("This file is deprecated."
+                "Use deal.II/lac/petsc_vector.h instead.")
 
 #endif

--- a/include/deal.II/opencascade/boundary_lib.h
+++ b/include/deal.II/opencascade/boundary_lib.h
@@ -12,7 +12,6 @@
 //
 // ------------------------------------------------------------------------
 
-
 #ifndef dealii_occ_boundary_lib_h
 #define dealii_occ_boundary_lib_h
 
@@ -20,7 +19,7 @@
 
 #include <deal.II/opencascade/manifold_lib.h>
 
-DEAL_II_WARNING(
-  "This file is deprecated. Use deal.II/opencascade/manifold_lib.h and the classes therein instead.")
+DEAL_II_WARNING("This file is deprecated."
+                "Use deal.II/opencascade/manifold_lib.h instead.")
 
-#endif // dealii_occ_boundary_lib_h
+#endif

--- a/source/dofs/dof_accessor.cc
+++ b/source/dofs/dof_accessor.cc
@@ -19,7 +19,6 @@
 #include <deal.II/fe/fe.h>
 
 #include <deal.II/grid/tria_iterator.h>
-#include <deal.II/grid/tria_iterator.templates.h>
 
 #include <vector>
 

--- a/source/dofs/dof_accessor_get.cc
+++ b/source/dofs/dof_accessor_get.cc
@@ -19,7 +19,6 @@
 #include <deal.II/fe/fe.h>
 
 #include <deal.II/grid/tria_iterator.h>
-#include <deal.II/grid/tria_iterator.templates.h>
 
 #include <deal.II/lac/block_vector.h>
 #include <deal.II/lac/la_parallel_block_vector.h>

--- a/source/dofs/dof_accessor_set.cc
+++ b/source/dofs/dof_accessor_set.cc
@@ -19,7 +19,6 @@
 #include <deal.II/fe/fe.h>
 
 #include <deal.II/grid/tria_iterator.h>
-#include <deal.II/grid/tria_iterator.templates.h>
 
 #include <deal.II/lac/block_vector.h>
 #include <deal.II/lac/la_parallel_block_vector.h>

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -25,7 +25,6 @@
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/tria_iterator.h>
-#include <deal.II/grid/tria_iterator.templates.h>
 #include <deal.II/grid/tria_levels.h>
 
 #include <array>


### PR DESCRIPTION
One of the recent commits didn't get rid of some extra inclusions of a deprecated `.templates.h` file. I fixed that and also cleaned up the rest of our deprecated headers so that they have a uniform style (and are always compatible with the old versions).