### PR TITLE
Add detect-include-cycle check to pre-commit.

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,4 +16,5 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
+    - run:  python -m pip install networkx
     - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,3 +46,10 @@ repos:
   hooks:
   - id: typos
     files: (?x) ^(doc|examples|include|source|tests)/
+- repo: local
+  hooks:
+  - id: detect-include-cycles
+    name: Detect '#include' cycles
+    entry: python contrib/utilities/detect_include_cycles.py
+    pass_filenames: false
+    language: system

--- a/contrib/utilities/detect_include_cycles.py
+++ b/contrib/utilities/detect_include_cycles.py
@@ -22,10 +22,10 @@
 # other module partitions.
 #
 # Call this script via
-#   python3 detect_include_cycles.py include/deal.II/*/*.h
+#   python3 contrib/utilities/detect_include_cycles.py
 # from the top-level directory.
 
-import sys
+from glob import glob
 import networkx as nx
 
 
@@ -47,11 +47,13 @@ def add_includes_for_file(header_file_name, G) :
 
 
 
-# Take the list of call arguments, excluding the first that contains
-# the name of the executable (i.e., this program). For each, add the
-# includes as the edges of a directed graph.
+# Create a list of all header files in the include folder.
+filelist = glob("include/**/*.h", recursive=True)
+assert filelist, "Please call the script from the top-level directory."
+
+# For each header file, add the includes as the edges of a directed graph.
 G = nx.DiGraph()
-for header_file_name in sys.argv[1:] :
+for header_file_name in filelist :
     add_includes_for_file(header_file_name, G)
 
 # Then figure out whether there are cycles and if so, print them:


### PR DESCRIPTION
Follow-up to #17992.

Since we currently still have cycles in the header files, the pre-commit check will not pass. We should fix them first and wait with merging this PR, and I marked it accordingly.

To make the detection script work with pre-commit, I had to adjust the way the list of header files is handled. In the current state, the list of files is provided via sys.argv and wildcards. pre-commit operates on wildcard lists in chunks, so the graphs created do not cover the entirety of header files. Instead, I suggest to let the script itself generate the list of files with the glob module. Works well!

```
$ pre-commit run detect-include-cycles --all-files
Detect '#include' cycles.................................................Failed
- hook id: detect-include-cycles
- exit code: 1

Cycles in the include graph detected!
['deal.II/dofs/dof_accessor.h', 'deal.II/dofs/dof_handler.h']
['deal.II/grid/tria.h', 'deal.II/grid/tria_description.h']
['deal.II/grid/tria.h', 'deal.II/grid/tria_accessor.h']
['deal.II/base/complex_overloads.h', 'deal.II/base/template_constraints.h']
```