### PR TITLE
Update pre-commit hooks. Fix typos.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
         )
     exclude: ^bundled/
 - repo: https://github.com/gitleaks/gitleaks
-  rev: v8.21.2
+  rev: v8.23.1
   hooks:
   - id: gitleaks
 - repo: https://github.com/pre-commit/mirrors-clang-format
@@ -42,7 +42,7 @@ repos:
             \.h
         )$
 - repo: https://github.com/crate-ci/typos
-  rev: v1.28.1
+  rev: v1.29.4
   hooks:
   - id: typos
     files: (?x) ^(doc|examples|include|source|tests)/

--- a/examples/step-56/step-56.cc
+++ b/examples/step-56/step-56.cc
@@ -490,7 +490,7 @@ namespace Step56
     // Velocities start at component 0:
     const FEValuesExtractors::Vector velocities(0);
 
-    // ILU behaves better if we apply a reordering to reduce fillin. There
+    // ILU behaves better if we apply a reordering to reduce filling. There
     // is no advantage in doing this for the other solvers.
     if (solver_type == SolverType::FGMRES_ILU)
       {

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -3344,7 +3344,7 @@ namespace internal
               // already modified during vmult (in best case, the modified
               // values are not written back to main memory yet so that
               // we do not have to pay additional costs for writing and
-              // read-for-ownershop)
+              // read-for-ownership)
               tmp_vector[i] =
                 factor1_plus_1 * solution[i] - factor1 * solution_old[i] +
                 factor2 * matrix_diagonal_inverse[i] * (rhs[i] - tmp_vector[i]);

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -268,25 +268,25 @@ namespace internal
     // Jacobian on the unit cell. Then j' = phi' k'/k^2 = j k' j^2.
     template <int dim, typename Number>
     Tensor<1, dim *(dim + 1) / 2, Tensor<1, dim, Number>>
-    process_jacobian_gradient(const Tensor<2, dim, Number> &inv_jac_permut,
+    process_jacobian_gradient(const Tensor<2, dim, Number> &inv_jac_permutation,
                               const Tensor<2, dim, Number> &inv_jac,
                               const Tensor<3, dim, Number> &jac_grad)
     {
       Number inv_jac_grad[dim][dim][dim];
 
-      // compute: inv_jac_grad = inv_jac_permut * grad_unit(jac)
+      // compute: inv_jac_grad = inv_jac_permutation * grad_unit(jac)
       for (unsigned int d = 0; d < dim; ++d)
         for (unsigned int e = 0; e < dim; ++e)
           for (unsigned int f = 0; f < dim; ++f)
             {
               inv_jac_grad[f][e][d] =
-                (inv_jac_permut[f][0] * jac_grad[d][e][0]);
+                (inv_jac_permutation[f][0] * jac_grad[d][e][0]);
               for (unsigned int g = 1; g < dim; ++g)
                 inv_jac_grad[f][e][d] +=
-                  (inv_jac_permut[f][g] * jac_grad[d][e][g]);
+                  (inv_jac_permutation[f][g] * jac_grad[d][e][g]);
             }
 
-      // compute: transpose (-inv_jac_permut * inv_jac_grad[d] * inv_jac)
+      // compute: transpose (-inv_jac_permutation * inv_jac_grad[d] * inv_jac)
       Number tmp[dim];
       Number grad_jac_inv[dim][dim][dim];
       for (unsigned int d = 0; d < dim; ++d)
@@ -302,9 +302,9 @@ namespace internal
             // needed for non-diagonal part of Jacobian grad
             for (unsigned int f = 0; f < dim; ++f)
               {
-                grad_jac_inv[f][d][e] = inv_jac_permut[f][0] * tmp[0];
+                grad_jac_inv[f][d][e] = inv_jac_permutation[f][0] * tmp[0];
                 for (unsigned int g = 1; g < dim; ++g)
-                  grad_jac_inv[f][d][e] += inv_jac_permut[f][g] * tmp[g];
+                  grad_jac_inv[f][d][e] += inv_jac_permutation[f][g] * tmp[g];
               }
           }
 
@@ -2210,14 +2210,14 @@ namespace internal
                     unsigned int                                   q,
                     Tensor<2, dim, VectorizedDouble>               inv_jac,
                     FEEvaluationData<dim, VectorizedDouble, true> &eval) {
-                  Tensor<2, dim, VectorizedDouble> inv_transp_jac_permut;
+                  Tensor<2, dim, VectorizedDouble> inv_transp_jac_permutation;
                   for (unsigned int d = 0; d < dim; ++d)
                     for (unsigned int e = 0; e < dim; ++e)
                       {
                         const unsigned int ee =
                           ExtractFaceHelper::reorder_face_derivative_indices<
                             dim>(face_no, e);
-                        inv_transp_jac_permut[d][e] = inv_jac[ee][d];
+                        inv_transp_jac_permutation[d][e] = inv_jac[ee][d];
                       }
                   Tensor<2, dim, VectorizedDouble> jacobi;
                   for (unsigned int e = 0; e < dim; ++e)
@@ -2239,7 +2239,7 @@ namespace internal
                             eval.begin_hessians()[q + (d * hess_dim + c) *
                                                         n_q_points];
                       const auto inv_jac_grad =
-                        process_jacobian_gradient(inv_transp_jac_permut,
+                        process_jacobian_gradient(inv_transp_jac_permutation,
                                                   inv_transp_jac,
                                                   jac_grad);
                       for (unsigned int e = 0; e < dim; ++e)

--- a/tests/fe/fe_enriched_01.cc
+++ b/tests/fe/fe_enriched_01.cc
@@ -13,7 +13,7 @@
 // ------------------------------------------------------------------------
 
 
-// test basic output of the class (name, n_blocks, n_compoennts,
+// test basic output of the class (name, n_blocks, n_components,
 // n_dofs_per_cell)
 
 #include <deal.II/base/function.h>

--- a/tests/feinterface/stokes.cc
+++ b/tests/feinterface/stokes.cc
@@ -431,7 +431,7 @@ namespace StokesTests
     // Velocities start at component 0:
     const FEValuesExtractors::Vector velocities(0);
 
-    // ILU behaves better if we apply a reordering to reduce fillin. There
+    // ILU behaves better if we apply a reordering to reduce filling. There
     // is no advantage in doing this for the other solvers.
     DoFRenumbering::Cuthill_McKee(dof_handler);
 

--- a/tests/hp/fe_nothing_22.cc
+++ b/tests/hp/fe_nothing_22.cc
@@ -14,7 +14,7 @@
 
 
 
-// Test FE_Nothing::operator==(). The base clase operator should suffice
+// Test FE_Nothing::operator==(). The base class operator should suffice
 
 #include <deal.II/fe/fe_nothing.h>
 


### PR DESCRIPTION
I prevent `typos` to "fix" the following variable names in `include/deal.II/matrix_free/mapping_info.templates.h`:
```
inv_jac_permut -> inv_jac_permute
inv_transp_jac_permut -> inv_transp_jac_permute
```