### PR TITLE
Include tests.h in one of the tests.

### DIFF
--- a/tests/hp/step-27.cc
+++ b/tests/hp/step-27.cc
@@ -58,6 +58,7 @@
 #include <fstream>
 #include <iostream>
 
+#include "../tests.h"
 
 namespace Step27
 {


### PR DESCRIPTION
This header file should be included in all tests, but we forgot that here.