### PR TITLE
Include ../tests.h into a couple more tests.

### DIFF
--- a/tests/fe/2d_grid_projection_hermite.cc
+++ b/tests/fe/2d_grid_projection_hermite.cc
@@ -51,6 +51,8 @@
 #include <sstream>
 #include <vector>
 
+#include "../tests.h"
+
 #define PRECISION 8
 
 /**

--- a/tests/mpi/step-37.cc
+++ b/tests/mpi/step-37.cc
@@ -58,6 +58,8 @@
 #include <fstream>
 #include <iostream>
 
+#include "../tests.h"
+
 
 namespace Step37
 {

--- a/tests/rol/vector_adaptor_02.cc
+++ b/tests/rol/vector_adaptor_02.cc
@@ -20,6 +20,8 @@
 #include <iostream>
 #include <sstream>
 
+#include "../tests.h"
+
 #include "ROL_Algorithm.hpp"
 #include "ROL_LineSearchStep.hpp"
 #include "ROL_Objective.hpp"

--- a/tests/simplex/step-12.cc
+++ b/tests/simplex/step-12.cc
@@ -60,6 +60,8 @@
 #include <fstream>
 #include <iostream>
 
+#include "../tests.h"
+
 namespace Step12
 {
   using namespace dealii;

--- a/tests/simplex/step-38.cc
+++ b/tests/simplex/step-38.cc
@@ -57,6 +57,8 @@
 #include <fstream>
 #include <iostream>
 
+#include "../tests.h"
+
 #define USE_SIMPLEX
 
 namespace Step38


### PR DESCRIPTION
Like #18016. Through several rounds of filtering, I found a few more tests that do not include `tests.h` directly or transitively. I think the ones I'm touching here are all there are.