### PR TITLE
Break the include cycle between dof_handler.h and dof_accessor.h.

### DIFF
--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -21,7 +21,6 @@
 #include <deal.II/base/types.h>
 
 #include <deal.II/dofs/dof_faces.h>
-#include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_iterator_selector.h>
 #include <deal.II/dofs/dof_levels.h>
 

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -93,6 +93,13 @@ namespace parallel
     class CellDataTransfer;
   }
 } // namespace parallel
+
+template <int structdim, int dim, int spacedim, bool level_dof_access>
+class DoFAccessor;
+
+template <int dimension_, int space_dimension_, bool level_dof_access>
+class DoFCellAccessor;
+
 #endif
 
 /**

--- a/include/deal.II/matrix_free/constraint_info.h
+++ b/include/deal.II/matrix_free/constraint_info.h
@@ -101,9 +101,9 @@ namespace internal
        * constraints are resolved with the help of AffineConstraints.
        */
       void
-      reinit(const DoFHandler<dim> &dof_handler,
-             const unsigned int     n_cells,
-             const bool             use_fast_hanging_node_algorithm = true);
+      reinit(const DoFHandler<dim, dim> &dof_handler,
+             const unsigned int          n_cells,
+             const bool use_fast_hanging_node_algorithm = true);
 
       void
       read_dof_indices(
@@ -296,9 +296,9 @@ namespace internal
     template <int dim, typename Number, typename IndexType>
     inline void
     ConstraintInfo<dim, Number, IndexType>::reinit(
-      const DoFHandler<dim> &dof_handler,
-      const unsigned int     n_cells,
-      const bool             use_fast_hanging_node_algorithm)
+      const DoFHandler<dim, dim> &dof_handler,
+      const unsigned int          n_cells,
+      const bool                  use_fast_hanging_node_algorithm)
     {
       this->dof_indices_per_cell.resize(n_cells);
       this->plain_dof_indices_per_cell.resize(n_cells);

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -16,6 +16,7 @@
 #include <deal.II/base/quadrature.h>
 
 #include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/mapping.h>

--- a/source/matrix_free/dof_info.cc
+++ b/source/matrix_free/dof_info.cc
@@ -17,6 +17,8 @@
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/vectorization.h>
 
+#include <deal.II/dofs/dof_handler.h>
+
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/sparsity_pattern.h>
 

--- a/tests/bits/refine_and_coarsen_for_active_cell_index_03.cc
+++ b/tests/bits/refine_and_coarsen_for_active_cell_index_03.cc
@@ -19,7 +19,7 @@
 #include <deal.II/base/geometry_info.h>
 #include <deal.II/base/quadrature_lib.h>
 
-#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria.h>

--- a/tests/bits/refine_and_coarsen_for_active_cell_index_04.cc
+++ b/tests/bits/refine_and_coarsen_for_active_cell_index_04.cc
@@ -22,7 +22,7 @@
 #include <deal.II/base/geometry_info.h>
 #include <deal.II/base/quadrature_lib.h>
 
-#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria.h>

--- a/tests/bits/refine_and_coarsen_for_active_cell_index_05.cc
+++ b/tests/bits/refine_and_coarsen_for_active_cell_index_05.cc
@@ -22,7 +22,7 @@
 #include <deal.II/base/geometry_info.h>
 #include <deal.II/base/quadrature_lib.h>
 
-#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria.h>

--- a/tests/bits/refine_and_coarsen_for_parents_03.cc
+++ b/tests/bits/refine_and_coarsen_for_parents_03.cc
@@ -20,7 +20,7 @@
 #include <deal.II/base/geometry_info.h>
 #include <deal.II/base/quadrature_lib.h>
 
-#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria.h>

--- a/tests/fe/fe_support_points_common.h
+++ b/tests/fe/fe_support_points_common.h
@@ -16,7 +16,7 @@
 #include <deal.II/base/qprojector.h>
 #include <deal.II/base/quadrature_lib.h>
 
-#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/fe/fe_bdm.h>
 #include <deal.II/fe/fe_dgp.h>

--- a/tests/fe/interpolate_system_2.cc
+++ b/tests/fe/interpolate_system_2.cc
@@ -15,6 +15,8 @@
 
 #include <deal.II/base/quadrature_lib.h>
 
+#include <deal.II/dofs/dof_handler.h>
+
 #include <deal.II/fe/fe_nedelec.h>
 #include <deal.II/fe/fe_raviart_thomas.h>
 #include <deal.II/fe/fe_system.h>

--- a/tests/fe/interpolate_system_3.cc
+++ b/tests/fe/interpolate_system_3.cc
@@ -15,6 +15,8 @@
 
 #include <deal.II/base/quadrature_lib.h>
 
+#include <deal.II/dofs/dof_handler.h>
+
 #include <deal.II/fe/fe_nedelec.h>
 #include <deal.II/fe/fe_raviart_thomas.h>
 #include <deal.II/fe/fe_system.h>

--- a/tests/mpi/active_cell_index_01.cc
+++ b/tests/mpi/active_cell_index_01.cc
@@ -21,7 +21,7 @@
 
 #include <deal.II/distributed/tria.h>
 
-#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria_accessor.h>

--- a/tests/multigrid/renumbering_05.cc
+++ b/tests/multigrid/renumbering_05.cc
@@ -18,7 +18,7 @@
 
 #include <deal.II/distributed/tria.h>
 
-#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/fe/fe_dgq.h>
 

--- a/tests/multigrid/renumbering_08.cc
+++ b/tests/multigrid/renumbering_08.cc
@@ -18,7 +18,7 @@
 
 #include <deal.II/distributed/tria.h>
 
-#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/fe/fe_q.h>
 


### PR DESCRIPTION
I thought about which way I wanted to break the cycle. I tend to think of `dof_accessor.h` as an implementation detail that people shouldn't have to know, and so made sure that if you include `dof_handler.h`, you automatically get `dof_accessor.h` as well (as you currently do). If you only include `dof_accessor.h` (as some of our tests did), you now also have to include `dof_handler.h` (or, in fact, *only* include `dof_handler.h`).