### PR TITLE
Fix misspellings.

### DIFF
--- a/doc/news/changes/incompatibilities/20250116Bangerth
+++ b/doc/news/changes/incompatibilities/20250116Bangerth
@@ -7,7 +7,7 @@ that leads to other problems. As a consequence, `deal.II/grid/tria.h`
 now no longer includes `deal.II/grid/tria_description.h`. If your
 program uses the CellData, SubCellData, or similar classes previously
 declared in `deal.II/grid/tria_description.h`, then you may want to
-explicitly include `deal.II/grid/tria_cell_data.h` (for the
+explicitly include `deal.II/grid/cell_data.h` (for the
 CellData and SubCellData classes) or `deal.II/grid/tria_description.h`
 (for the classes in namespace TriaDescription) in your program.
 

--- a/include/deal.II/grid/tria_description.h
+++ b/include/deal.II/grid/tria_description.h
@@ -12,8 +12,8 @@
 //
 // ------------------------------------------------------------------------
 
-#ifndef dealii_grid_construction_utilities_h
-#define dealii_grid_construction_utilities_h
+#ifndef dealii_grid_tria_description_h
+#define dealii_grid_tria_description_h
 
 #include <deal.II/base/config.h>
 


### PR DESCRIPTION
This fixes the misspelling mentioned at https://github.com/dealii/dealii/pull/17997#pullrequestreview-2566198133, plus one that resulted from renaming a file (perhaps several years ago) without updating the include guard.