### PR TITLE
Break the cycle of header includes between template_constraints.h and complex_overloads.h.

### DIFF
--- a/include/deal.II/base/complex_overloads.h
+++ b/include/deal.II/base/complex_overloads.h
@@ -17,14 +17,14 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/template_constraints.h>
-
 DEAL_II_NAMESPACE_OPEN
 
-// Forward declarations
 #ifndef DOXYGEN
+
+// Forward declarations
 template <typename T, typename U>
 struct ProductType;
+
 #endif
 
 #ifndef DEAL_II_HAVE_COMPLEX_OPERATOR_OVERLOADS


### PR DESCRIPTION
We do not ever directly include complex_overloads.h, from anywhere except template_constraints.h. As a consequence, the include of template_constraints.h in complex_overloads.h always expands into nothing (because of the header guard in template_constraints.h) and it is safe to remove the include in complex_overloads.h.

I think that might break the last of the cycles mentioned in #18013.