### PR TITLE
Deprecate IndexSet::pop_front/back().

### DIFF
--- a/doc/news/changes/minor/20250123Bangerth-2
+++ b/doc/news/changes/minor/20250123Bangerth-2
@@ -1,0 +1,6 @@
+Deprecated: The functions IndexSet::pop_front() and
+IndexSet::pop_back() are now deprecated. An IndexSet should be seen as
+a set, not an ordered collection, and so speaking of "front" and
+"back" is not well defined.
+<br>
+(Wolfgang Bangerth, 2025/01/23)

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -484,14 +484,24 @@ public:
   /**
    * Remove and return the last element of the last range.
    * This function throws an exception if the IndexSet is empty.
+   *
+   * @deprecated This function is deprecated. Conceptually, an index set is a
+   *   set; it should not be seen as a sorted container in which it is clear
+   *   what element is stored "last".
    */
+  DEAL_II_DEPRECATED_EARLY
   size_type
   pop_back();
 
   /**
    * Remove and return the first element of the first range.
    * This function throws an exception if the IndexSet is empty.
+   *
+   * @deprecated This function is deprecated. Conceptually, an index set is a
+   *   set; it should not be seen as a sorted container in which it is clear
+   *   what element is stored "first".
    */
+  DEAL_II_DEPRECATED_EARLY
   size_type
   pop_front();
 


### PR DESCRIPTION
Fixes #17762.