### PR TITLE
MatrixFree: encode the orientation as (!orientation, rotation, flip).

### DIFF
--- a/include/deal.II/matrix_free/face_info.h
+++ b/include/deal.II/matrix_free/face_info.h
@@ -97,8 +97,8 @@ namespace internal
 
       /**
        * In 3d, one of the two cells adjacent to a face might use a different
-       * orientation (also called as face orientation, face flip and face
-       * rotation) than the standard orientation. This variable stores the
+       * orientation (also called as face orientation, face rotation and face
+       * flip) than the standard orientation. This variable stores the
        * values of face orientation, face flip and face
        * rotation (for one of the interior or exterior side) for the present
        * batch of faces in the first free bits. The forth bit is one if the

--- a/include/deal.II/matrix_free/face_setup_internal.h
+++ b/include/deal.II/matrix_free/face_setup_internal.h
@@ -1013,19 +1013,19 @@ namespace internal
               exterior_face_orientation);
 
           info.face_orientation =
-            (orientation ? 0u : 1u) + 2 * flip + 4 * rotation;
+            (orientation ? 0u : 1u) + 2 * rotation + 4 * flip;
 
           return info;
         }
 
       info.face_orientation = 0;
       const unsigned int interior_face_orientation =
-        !cell->face_orientation(face_no) + 2 * cell->face_flip(face_no) +
-        4 * cell->face_rotation(face_no);
+        !cell->face_orientation(face_no) + 2 * cell->face_rotation(face_no) +
+        4 * cell->face_flip(face_no);
       const unsigned int exterior_face_orientation =
         !neighbor->face_orientation(info.exterior_face_no) +
-        2 * neighbor->face_flip(info.exterior_face_no) +
-        4 * neighbor->face_rotation(info.exterior_face_no);
+        2 * neighbor->face_rotation(info.exterior_face_no) +
+        4 * neighbor->face_flip(info.exterior_face_no);
       if (interior_face_orientation != 0)
         {
           info.face_orientation = 8 + interior_face_orientation;
@@ -1043,7 +1043,7 @@ namespace internal
           const Table<2, unsigned int> orientation =
             ShapeInfo<double>::compute_orientation_table(2);
           const std::array<unsigned int, 8> inverted_orientations{
-            {0, 1, 2, 3, 6, 5, 4, 7}};
+            {0, 1, 6, 3, 4, 5, 2, 7}};
           info.subface_index =
             orientation[inverted_orientations[exterior_face_orientation]]
                        [info.subface_index];

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -7464,7 +7464,7 @@ FEFaceEvaluation<dim,
           if (face_identifies_as_interior != orientation_interior_face)
             {
               constexpr std::array<std::uint8_t, 8> table{
-                {0, 1, 2, 3, 6, 5, 4, 7}};
+                {0, 1, 6, 3, 4, 5, 2, 7}};
               face_orientation = table[face_orientation];
             }
           this->face_orientations[i] = face_orientation;

--- a/include/deal.II/matrix_free/hanging_nodes_internal.h
+++ b/include/deal.II/matrix_free/hanging_nodes_internal.h
@@ -744,7 +744,7 @@ namespace internal
                     neighbor_dofs[i] = neighbor_dofs_face
                       [component_to_system_index_face_array[comp][i]];
 
-                  // fix DoFs depending on orientation, flip, and rotation
+                  // fix DoFs depending on orientation, rotation, and flip
                   if (dim == 2)
                     {
                       // TODO: for mixed meshes we need to take care of

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -448,8 +448,8 @@ namespace internal
                             reference_cell,
                             f,
                             (o ^ 1) & 1,  // face_orientation
-                            (o >> 1) & 1, // face_flip
-                            (o >> 2) & 1, // face_rotation
+                            (o >> 2) & 1, // face_flip
+                            (o >> 1) & 1, // face_rotation
                             quad_face);
 
                         for (unsigned int i = 0; i < n_dofs; ++i)
@@ -1291,21 +1291,21 @@ namespace internal
       for (unsigned int j = 0, i = 0; j < n; ++j)
         for (unsigned int k = 0; k < n; ++k, ++i)
           {
-            // face_orientation=true,  face_flip=false, face_rotation=false
+            // face_orientation=true,  face_rotation=false, face_flip=false
             face_orientations[0][i] = i;
-            // face_orientation=false, face_flip=false, face_rotation=false
+            // face_orientation=false, face_rotation=false, face_flip=false
             face_orientations[1][i] = j + k * n;
-            // face_orientation=true,  face_flip=true, face_rotation=false
-            face_orientations[2][i] = (n - 1 - k) + (n - 1 - j) * n;
-            // face_orientation=false, face_flip=true, face_rotation=false
-            face_orientations[3][i] = (n - 1 - j) + (n - 1 - k) * n;
-            // face_orientation=true,  face_flip=false, face_rotation=true
-            face_orientations[4][i] = j + (n - 1 - k) * n;
-            // face_orientation=false, face_flip=false, face_rotation=true
-            face_orientations[5][i] = k + (n - 1 - j) * n;
-            // face_orientation=true,  face_flip=true, face_rotation=true
+            // face_orientation=true,  face_rotation=true, face_flip=false
+            face_orientations[2][i] = j + (n - 1 - k) * n;
+            // face_orientation=false, face_rotation=true, face_flip=false
+            face_orientations[3][i] = k + (n - 1 - j) * n;
+            // face_orientation=true,  face_rotation=false, face_flip=true
+            face_orientations[4][i] = (n - 1 - k) + (n - 1 - j) * n;
+            // face_orientation=false, face_rotation=false, face_flip=true
+            face_orientations[5][i] = (n - 1 - j) + (n - 1 - k) * n;
+            // face_orientation=true,  face_rotation=true, face_flip=true
             face_orientations[6][i] = (n - 1 - j) + k * n;
-            // face_orientation=false, face_flip=true, face_rotation=true
+            // face_orientation=false, face_rotation=true, face_flip=true
             face_orientations[7][i] = (n - 1 - k) + j * n;
           }
       return face_orientations;

--- a/tests/matrix_free/matrix_vector_faces_34.cc
+++ b/tests/matrix_free/matrix_vector_faces_34.cc
@@ -56,11 +56,11 @@ generate_grid(Triangulation<3> &triangulation, int orientation)
   /* cell 1 */
   int cell_vertices_1[8][GeometryInfo<3>::vertices_per_cell] = {
     {4, 5, 6, 7, 8, 9, 10, 11},
-    {5, 7, 4, 6, 9, 11, 8, 10},
-    {7, 6, 5, 4, 11, 10, 9, 8},
     {6, 4, 7, 5, 10, 8, 11, 9},
     {9, 8, 11, 10, 5, 4, 7, 6},
     {8, 10, 9, 11, 4, 6, 5, 7},
+    {5, 7, 4, 6, 9, 11, 8, 10},
+    {7, 6, 5, 4, 11, 10, 9, 8},
     {10, 11, 8, 9, 6, 7, 4, 5},
     {11, 9, 10, 8, 7, 5, 6, 4}};
 
@@ -75,12 +75,16 @@ generate_grid(Triangulation<3> &triangulation, int orientation)
 
   triangulation.create_triangulation(vertices, cells, SubCellData());
 
-  const unsigned int face_no = orientation < 4 ? 4 : 5;
-  const auto         cell    = ++(triangulation.begin());
-  deallog << "Orientation index within MatrixFree: "
-          << (!cell->face_orientation(face_no) + 2 * cell->face_flip(face_no) +
-              4 * cell->face_rotation(face_no))
-          << std::endl;
+  const auto cell = ++(triangulation.begin());
+  for (const auto face_no : cell->face_indices())
+    if (!cell->face(face_no)->at_boundary())
+      {
+        deallog << "Orientation index within MatrixFree: "
+                << (!cell->face_orientation(face_no) +
+                    2 * cell->face_rotation(face_no) +
+                    4 * cell->face_flip(face_no))
+                << std::endl;
+      }
 }
 
 

--- a/tests/matrix_free/matrix_vector_faces_34.output
+++ b/tests/matrix_free/matrix_vector_faces_34.output
@@ -11,78 +11,78 @@ DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(2)^3]
 DEAL:3d::Norm of difference basic:           1.62e-15
 DEAL:3d::Norm of difference gather_evaluate: 1.62e-15
 DEAL:3d::Testing orientation case 1
-DEAL:3d::Orientation index within MatrixFree: 6
+DEAL:3d::Orientation index within MatrixFree: 2
 DEAL:3d::Standard cell refined, oriented cell unrefined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(2)^3]
 DEAL:3d::Norm of difference basic:           2.05e-15
 DEAL:3d::Norm of difference gather_evaluate: 2.05e-15
-DEAL:3d::Orientation index within MatrixFree: 6
+DEAL:3d::Orientation index within MatrixFree: 2
 DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(2)^3]
 DEAL:3d::Norm of difference basic:           2.00e-15
 DEAL:3d::Norm of difference gather_evaluate: 2.00e-15
 DEAL:3d::Testing orientation case 2
-DEAL:3d::Orientation index within MatrixFree: 2
+DEAL:3d::Orientation index within MatrixFree: 7
 DEAL:3d::Standard cell refined, oriented cell unrefined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(2)^3]
 DEAL:3d::Norm of difference basic:           1.40e-15
 DEAL:3d::Norm of difference gather_evaluate: 1.40e-15
-DEAL:3d::Orientation index within MatrixFree: 2
+DEAL:3d::Orientation index within MatrixFree: 7
 DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(2)^3]
 DEAL:3d::Norm of difference basic:           1.62e-15
 DEAL:3d::Norm of difference gather_evaluate: 1.62e-15
 DEAL:3d::Testing orientation case 3
-DEAL:3d::Orientation index within MatrixFree: 4
+DEAL:3d::Orientation index within MatrixFree: 1
 DEAL:3d::Standard cell refined, oriented cell unrefined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(2)^3]
 DEAL:3d::Norm of difference basic:           2.05e-15
 DEAL:3d::Norm of difference gather_evaluate: 2.05e-15
-DEAL:3d::Orientation index within MatrixFree: 4
+DEAL:3d::Orientation index within MatrixFree: 1
 DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(2)^3]
 DEAL:3d::Norm of difference basic:           2.00e-15
 DEAL:3d::Norm of difference gather_evaluate: 2.00e-15
 DEAL:3d::Testing orientation case 4
-DEAL:3d::Orientation index within MatrixFree: 7
+DEAL:3d::Orientation index within MatrixFree: 6
 DEAL:3d::Standard cell refined, oriented cell unrefined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(2)^3]
 DEAL:3d::Norm of difference basic:           1.43e-15
 DEAL:3d::Norm of difference gather_evaluate: 1.43e-15
-DEAL:3d::Orientation index within MatrixFree: 7
+DEAL:3d::Orientation index within MatrixFree: 6
 DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(2)^3]
 DEAL:3d::Norm of difference basic:           1.43e-15
 DEAL:3d::Norm of difference gather_evaluate: 1.43e-15
 DEAL:3d::Testing orientation case 5
-DEAL:3d::Orientation index within MatrixFree: 1
+DEAL:3d::Orientation index within MatrixFree: 4
 DEAL:3d::Standard cell refined, oriented cell unrefined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(2)^3]
 DEAL:3d::Norm of difference basic:           1.71e-15
 DEAL:3d::Norm of difference gather_evaluate: 1.71e-15
-DEAL:3d::Orientation index within MatrixFree: 1
+DEAL:3d::Orientation index within MatrixFree: 4
 DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(2)^3]
 DEAL:3d::Norm of difference basic:           1.52e-15
 DEAL:3d::Norm of difference gather_evaluate: 1.52e-15
 DEAL:3d::Testing orientation case 6
-DEAL:3d::Orientation index within MatrixFree: 5
+DEAL:3d::Orientation index within MatrixFree: 3
 DEAL:3d::Standard cell refined, oriented cell unrefined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(2)^3]
 DEAL:3d::Norm of difference basic:           1.62e-15
 DEAL:3d::Norm of difference gather_evaluate: 1.62e-15
-DEAL:3d::Orientation index within MatrixFree: 5
+DEAL:3d::Orientation index within MatrixFree: 3
 DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(2)^3]
 DEAL:3d::Norm of difference basic:           1.43e-15
 DEAL:3d::Norm of difference gather_evaluate: 1.43e-15
 DEAL:3d::Testing orientation case 7
-DEAL:3d::Orientation index within MatrixFree: 3
+DEAL:3d::Orientation index within MatrixFree: 5
 DEAL:3d::Standard cell refined, oriented cell unrefined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(2)^3]
 DEAL:3d::Norm of difference basic:           1.52e-15
 DEAL:3d::Norm of difference gather_evaluate: 1.52e-15
-DEAL:3d::Orientation index within MatrixFree: 3
+DEAL:3d::Orientation index within MatrixFree: 5
 DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(2)^3]
 DEAL:3d::Norm of difference basic:           1.52e-15
@@ -97,65 +97,65 @@ DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(3)^3]
 DEAL:3d::Norm of difference gather_evaluate: 2.79e-16
 DEAL:3d::Testing orientation case 1
-DEAL:3d::Orientation index within MatrixFree: 6
+DEAL:3d::Orientation index within MatrixFree: 2
 DEAL:3d::Standard cell refined, oriented cell unrefined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(3)^3]
 DEAL:3d::Norm of difference gather_evaluate: 2.88e-16
-DEAL:3d::Orientation index within MatrixFree: 6
+DEAL:3d::Orientation index within MatrixFree: 2
 DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(3)^3]
 DEAL:3d::Norm of difference gather_evaluate: 2.79e-16
 DEAL:3d::Testing orientation case 2
-DEAL:3d::Orientation index within MatrixFree: 2
+DEAL:3d::Orientation index within MatrixFree: 7
 DEAL:3d::Standard cell refined, oriented cell unrefined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(3)^3]
 DEAL:3d::Norm of difference gather_evaluate: 7.20e-16
-DEAL:3d::Orientation index within MatrixFree: 2
+DEAL:3d::Orientation index within MatrixFree: 7
 DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(3)^3]
 DEAL:3d::Norm of difference gather_evaluate: 2.79e-16
 DEAL:3d::Testing orientation case 3
-DEAL:3d::Orientation index within MatrixFree: 4
+DEAL:3d::Orientation index within MatrixFree: 1
 DEAL:3d::Standard cell refined, oriented cell unrefined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(3)^3]
 DEAL:3d::Norm of difference gather_evaluate: 2.88e-16
-DEAL:3d::Orientation index within MatrixFree: 4
+DEAL:3d::Orientation index within MatrixFree: 1
 DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(3)^3]
 DEAL:3d::Norm of difference gather_evaluate: 2.79e-16
 DEAL:3d::Testing orientation case 4
-DEAL:3d::Orientation index within MatrixFree: 7
+DEAL:3d::Orientation index within MatrixFree: 6
 DEAL:3d::Standard cell refined, oriented cell unrefined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(3)^3]
 DEAL:3d::Norm of difference gather_evaluate: 6.97e-16
-DEAL:3d::Orientation index within MatrixFree: 7
+DEAL:3d::Orientation index within MatrixFree: 6
 DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(3)^3]
 DEAL:3d::Norm of difference gather_evaluate: 2.79e-16
 DEAL:3d::Testing orientation case 5
-DEAL:3d::Orientation index within MatrixFree: 1
+DEAL:3d::Orientation index within MatrixFree: 4
 DEAL:3d::Standard cell refined, oriented cell unrefined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(3)^3]
 DEAL:3d::Norm of difference gather_evaluate: 2.79e-16
-DEAL:3d::Orientation index within MatrixFree: 1
+DEAL:3d::Orientation index within MatrixFree: 4
 DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(3)^3]
 DEAL:3d::Norm of difference gather_evaluate: 4.18e-16
 DEAL:3d::Testing orientation case 6
-DEAL:3d::Orientation index within MatrixFree: 5
+DEAL:3d::Orientation index within MatrixFree: 3
 DEAL:3d::Standard cell refined, oriented cell unrefined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(3)^3]
 DEAL:3d::Norm of difference gather_evaluate: 6.97e-16
-DEAL:3d::Orientation index within MatrixFree: 5
+DEAL:3d::Orientation index within MatrixFree: 3
 DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(3)^3]
 DEAL:3d::Norm of difference gather_evaluate: 2.79e-16
 DEAL:3d::Testing orientation case 7
-DEAL:3d::Orientation index within MatrixFree: 3
+DEAL:3d::Orientation index within MatrixFree: 5
 DEAL:3d::Standard cell refined, oriented cell unrefined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(3)^3]
 DEAL:3d::Norm of difference gather_evaluate: 2.79e-16
-DEAL:3d::Orientation index within MatrixFree: 3
+DEAL:3d::Orientation index within MatrixFree: 5
 DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(3)^3]
 DEAL:3d::Norm of difference gather_evaluate: 2.79e-16

--- a/tests/matrix_free/matrix_vector_faces_35.cc
+++ b/tests/matrix_free/matrix_vector_faces_35.cc
@@ -56,10 +56,10 @@ generate_grid(Triangulation<3> &triangulation, int orientation)
   int cell_vertices_1[8][GeometryInfo<3>::vertices_per_cell] = {
     {4, 5, 6, 7, 8, 9, 10, 11},
     {5, 7, 4, 6, 9, 11, 8, 10},
-    {7, 6, 5, 4, 11, 10, 9, 8},
-    {6, 4, 7, 5, 10, 8, 11, 9},
     {9, 8, 11, 10, 5, 4, 7, 6},
     {8, 10, 9, 11, 4, 6, 5, 7},
+    {7, 6, 5, 4, 11, 10, 9, 8},
+    {6, 4, 7, 5, 10, 8, 11, 9},
     {10, 11, 8, 9, 6, 7, 4, 5},
     {11, 9, 10, 8, 7, 5, 6, 4}};
 
@@ -74,12 +74,16 @@ generate_grid(Triangulation<3> &triangulation, int orientation)
 
   triangulation.create_triangulation(vertices, cells, SubCellData());
 
-  const unsigned int face_no = orientation < 4 ? 4 : 5;
-  const auto         cell    = ++(triangulation.begin());
-  deallog << "Orientation index within MatrixFree: "
-          << (!cell->face_orientation(face_no) + 2 * cell->face_flip(face_no) +
-              4 * cell->face_rotation(face_no))
-          << std::endl;
+  const auto cell = ++(triangulation.begin());
+  for (const auto face_no : cell->face_indices())
+    if (!cell->face(face_no)->at_boundary())
+      {
+        deallog << "Orientation index within MatrixFree: "
+                << (!cell->face_orientation(face_no) +
+                    2 * cell->face_rotation(face_no) +
+                    4 * cell->face_flip(face_no))
+                << std::endl;
+      }
 }
 
 

--- a/tests/matrix_free/matrix_vector_faces_35.output
+++ b/tests/matrix_free/matrix_vector_faces_35.output
@@ -18,56 +18,56 @@ DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(1)^3]
 DEAL:3d::Norm of difference gather_evaluate: 7.17e-17
 DEAL:3d::Testing orientation case 2
-DEAL:3d::Orientation index within MatrixFree: 2
+DEAL:3d::Orientation index within MatrixFree: 7
 DEAL:3d::Standard cell refined, oriented cell unrefined
 DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(1)^3]
 DEAL:3d::Norm of difference gather_evaluate: 0.00
-DEAL:3d::Orientation index within MatrixFree: 2
+DEAL:3d::Orientation index within MatrixFree: 7
 DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(1)^3]
 DEAL:3d::Norm of difference gather_evaluate: 0.00
 DEAL:3d::Testing orientation case 3
-DEAL:3d::Orientation index within MatrixFree: 4
+DEAL:3d::Orientation index within MatrixFree: 1
 DEAL:3d::Standard cell refined, oriented cell unrefined
 DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(1)^3]
 DEAL:3d::Norm of difference gather_evaluate: 0.00
-DEAL:3d::Orientation index within MatrixFree: 4
+DEAL:3d::Orientation index within MatrixFree: 1
 DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(1)^3]
 DEAL:3d::Norm of difference gather_evaluate: 2.69e-17
 DEAL:3d::Testing orientation case 4
-DEAL:3d::Orientation index within MatrixFree: 7
+DEAL:3d::Orientation index within MatrixFree: 4
 DEAL:3d::Standard cell refined, oriented cell unrefined
 DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(1)^3]
 DEAL:3d::Norm of difference gather_evaluate: 0.00
-DEAL:3d::Orientation index within MatrixFree: 7
+DEAL:3d::Orientation index within MatrixFree: 4
 DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(1)^3]
 DEAL:3d::Norm of difference gather_evaluate: 0.00
 DEAL:3d::Testing orientation case 5
-DEAL:3d::Orientation index within MatrixFree: 1
+DEAL:3d::Orientation index within MatrixFree: 2
 DEAL:3d::Standard cell refined, oriented cell unrefined
 DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(1)^3]
 DEAL:3d::Norm of difference gather_evaluate: 0.00
-DEAL:3d::Orientation index within MatrixFree: 1
+DEAL:3d::Orientation index within MatrixFree: 2
 DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(1)^3]
 DEAL:3d::Norm of difference gather_evaluate: 7.17e-17
 DEAL:3d::Testing orientation case 6
-DEAL:3d::Orientation index within MatrixFree: 5
+DEAL:3d::Orientation index within MatrixFree: 3
 DEAL:3d::Standard cell refined, oriented cell unrefined
 DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(1)^3]
 DEAL:3d::Norm of difference gather_evaluate: 0.00
-DEAL:3d::Orientation index within MatrixFree: 5
+DEAL:3d::Orientation index within MatrixFree: 3
 DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(1)^3]
 DEAL:3d::Norm of difference gather_evaluate: 0.00
 DEAL:3d::Testing orientation case 7
-DEAL:3d::Orientation index within MatrixFree: 3
+DEAL:3d::Orientation index within MatrixFree: 5
 DEAL:3d::Standard cell refined, oriented cell unrefined
 DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(1)^3]
 DEAL:3d::Norm of difference gather_evaluate: 0.00
-DEAL:3d::Orientation index within MatrixFree: 3
+DEAL:3d::Orientation index within MatrixFree: 5
 DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(1)^3]
 DEAL:3d::Norm of difference gather_evaluate: 1.79e-17
@@ -90,56 +90,56 @@ DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(2)^3]
 DEAL:3d::Norm of difference gather_evaluate: 2.24e-17
 DEAL:3d::Testing orientation case 2
-DEAL:3d::Orientation index within MatrixFree: 2
+DEAL:3d::Orientation index within MatrixFree: 7
 DEAL:3d::Standard cell refined, oriented cell unrefined
 DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(2)^3]
 DEAL:3d::Norm of difference gather_evaluate: 0.00
-DEAL:3d::Orientation index within MatrixFree: 2
+DEAL:3d::Orientation index within MatrixFree: 7
 DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(2)^3]
 DEAL:3d::Norm of difference gather_evaluate: 0.00
 DEAL:3d::Testing orientation case 3
-DEAL:3d::Orientation index within MatrixFree: 4
+DEAL:3d::Orientation index within MatrixFree: 1
 DEAL:3d::Standard cell refined, oriented cell unrefined
 DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(2)^3]
 DEAL:3d::Norm of difference gather_evaluate: 0.00
-DEAL:3d::Orientation index within MatrixFree: 4
+DEAL:3d::Orientation index within MatrixFree: 1
 DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(2)^3]
 DEAL:3d::Norm of difference gather_evaluate: 4.48e-17
 DEAL:3d::Testing orientation case 4
-DEAL:3d::Orientation index within MatrixFree: 7
+DEAL:3d::Orientation index within MatrixFree: 4
 DEAL:3d::Standard cell refined, oriented cell unrefined
 DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(2)^3]
 DEAL:3d::Norm of difference gather_evaluate: 0.00
-DEAL:3d::Orientation index within MatrixFree: 7
+DEAL:3d::Orientation index within MatrixFree: 4
 DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(2)^3]
 DEAL:3d::Norm of difference gather_evaluate: 0.00
 DEAL:3d::Testing orientation case 5
-DEAL:3d::Orientation index within MatrixFree: 1
+DEAL:3d::Orientation index within MatrixFree: 2
 DEAL:3d::Standard cell refined, oriented cell unrefined
 DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(2)^3]
 DEAL:3d::Norm of difference gather_evaluate: 0.00
-DEAL:3d::Orientation index within MatrixFree: 1
+DEAL:3d::Orientation index within MatrixFree: 2
 DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(2)^3]
 DEAL:3d::Norm of difference gather_evaluate: 2.24e-17
 DEAL:3d::Testing orientation case 6
-DEAL:3d::Orientation index within MatrixFree: 5
+DEAL:3d::Orientation index within MatrixFree: 3
 DEAL:3d::Standard cell refined, oriented cell unrefined
 DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(2)^3]
 DEAL:3d::Norm of difference gather_evaluate: 0.00
-DEAL:3d::Orientation index within MatrixFree: 5
+DEAL:3d::Orientation index within MatrixFree: 3
 DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(2)^3]
 DEAL:3d::Norm of difference gather_evaluate: 0.00
 DEAL:3d::Testing orientation case 7
-DEAL:3d::Orientation index within MatrixFree: 3
+DEAL:3d::Orientation index within MatrixFree: 5
 DEAL:3d::Standard cell refined, oriented cell unrefined
 DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(2)^3]
 DEAL:3d::Norm of difference gather_evaluate: 0.00
-DEAL:3d::Orientation index within MatrixFree: 3
+DEAL:3d::Orientation index within MatrixFree: 5
 DEAL:3d::Standard cell unrefined, oriented cell refined
 DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(2)^3]
 DEAL:3d::Norm of difference gather_evaluate: 2.24e-17


### PR DESCRIPTION
Part of #14667

This moves us one step towards encoding things the same way as the standardized orientation format.