### PR TITLE
Parallel vector: Add assert for ghosts in global vector ops

### DIFF
--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -1365,6 +1365,16 @@ namespace LinearAlgebra
                         const Vector<Number, MemorySpace> &W);
 
       /**
+       * Assert that there are no spurious non-zero entries in the ghost
+       * region of the vector caused by some forgotten compress() or
+       * zero_out_ghost_values() calls, which is an invariant of the vector
+       * space operations such as the addition of vectors, scaling a vector,
+       * and similar.
+       */
+      void
+      assert_no_residual_content_in_ghost_region() const;
+
+      /**
        * Shared pointer to store the parallel partitioning information. This
        * information can be shared between several vectors that have the same
        * partitioning.

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -1473,6 +1473,8 @@ namespace LinearAlgebra
 
       if (vector_is_ghosted)
         update_ghost_values();
+      else
+        assert_no_residual_content_in_ghost_region();
 
       return *this;
     }
@@ -1495,6 +1497,8 @@ namespace LinearAlgebra
 
       if (vector_is_ghosted)
         update_ghost_values();
+      else
+        assert_no_residual_content_in_ghost_region();
 
       return *this;
     }
@@ -1513,6 +1517,8 @@ namespace LinearAlgebra
 
       if (vector_is_ghosted)
         update_ghost_values();
+      else
+        assert_no_residual_content_in_ghost_region();
     }
 
 
@@ -1551,6 +1557,8 @@ namespace LinearAlgebra
 
       if (vector_is_ghosted)
         update_ghost_values();
+      else
+        assert_no_residual_content_in_ghost_region();
     }
 
 
@@ -1581,6 +1589,8 @@ namespace LinearAlgebra
 
       if (vector_is_ghosted)
         update_ghost_values();
+      else
+        assert_no_residual_content_in_ghost_region();
     }
 
 
@@ -1617,6 +1627,8 @@ namespace LinearAlgebra
 
       if (vector_is_ghosted)
         update_ghost_values();
+      else
+        assert_no_residual_content_in_ghost_region();
     }
 
 
@@ -1655,6 +1667,8 @@ namespace LinearAlgebra
 
       if (vector_is_ghosted)
         update_ghost_values();
+      else
+        assert_no_residual_content_in_ghost_region();
     }
 
 
@@ -1674,6 +1688,8 @@ namespace LinearAlgebra
 
       if (vector_is_ghosted)
         update_ghost_values();
+      else
+        assert_no_residual_content_in_ghost_region();
 
       return *this;
     }
@@ -1703,6 +1719,8 @@ namespace LinearAlgebra
 
       if (vector_is_ghosted)
         update_ghost_values();
+      else
+        assert_no_residual_content_in_ghost_region();
     }
 
 
@@ -1727,6 +1745,43 @@ namespace LinearAlgebra
 
       if (vector_is_ghosted)
         update_ghost_values();
+      else
+        assert_no_residual_content_in_ghost_region();
+    }
+
+
+
+    template <typename Number, typename MemorySpaceType>
+    void
+    Vector<Number,
+           MemorySpaceType>::assert_no_residual_content_in_ghost_region() const
+    {
+#ifdef DEBUG
+      // This should only be called for non-ghosted vectors
+      Assert(!vector_is_ghosted, ExcInternalError());
+
+      // Run a reduction over the ghost range only to find out whether some
+      // entries are non-zero
+      real_type sum = real_type();
+      dealii::internal::VectorOperations::
+        functions<Number, Number, MemorySpaceType>::norm_1(
+          thread_loop_partitioner,
+          partitioner->n_ghost_indices(),
+          sum,
+          data,
+          partitioner->locally_owned_size());
+
+      Assert(sum == real_type(),
+             ExcMessage("You called a vector space operation like add(), "
+                        "scale(), operator* for a non-ghosted vector, which "
+                        "will not update the content in the memory locations "
+                        "reserved for ghost values. However, a non-zero "
+                        "content was detected for some of those entries, which "
+                        "can lead to an invalid state of the vector. Please "
+                        "call Vector::compress(VectorOperation::add) or "
+                        "Vector::zero_out_ghost_values() before calling a "
+                        "vector space operation to avoid this problem."));
+#endif
     }
 
 

--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -2005,10 +2005,15 @@ namespace internal
              real_type      &sum,
              ::dealii::MemorySpace::MemorySpaceData<Number,
                                                     ::dealii::MemorySpace::Host>
-               &data)
+                            &data,
+             const size_type optional_offset = 0)
       {
         Norm1<Number, real_type> norm1(data.values.data());
-        parallel_reduce(norm1, 0, size, sum, thread_loop_partitioner);
+        parallel_reduce(norm1,
+                        optional_offset,
+                        optional_offset + size,
+                        sum,
+                        thread_loop_partitioner);
       }
 
       template <typename real_type>
@@ -2502,7 +2507,8 @@ namespace internal
         real_type      &sum,
         ::dealii::MemorySpace::MemorySpaceData<Number,
                                                ::dealii::MemorySpace::Default>
-          &data)
+                       &data,
+        const size_type optional_offset = 0)
       {
         auto exec = typename ::dealii::MemorySpace::Default::kokkos_space::
           execution_space{};
@@ -2510,7 +2516,7 @@ namespace internal
           "dealii::norm_1",
           Kokkos::RangePolicy<
             ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
-            exec, 0, size),
+            exec, optional_offset, optional_offset + size),
           KOKKOS_LAMBDA(size_type i, Number & update) {
 #if KOKKOS_VERSION < 30400
             update += std::abs(data.values(i));


### PR DESCRIPTION
Fixes #18021.

We should not allow global manipulations of vector entries when ghosts have been inserted, and raise an exception instead.

It turned out to be somewhat intriguing to test this, because we have the vector in a non-ghosted state when we add into entries. Since we are in debug mode, we can simply loop through all the entries. We run a reduction and check if the result is non-zero.