### PR TITLE
Fix various typos

### DIFF
--- a/examples/step-18/step-18.cc
+++ b/examples/step-18/step-18.cc
@@ -56,7 +56,7 @@
 #include <deal.II/base/symmetric_tensor.h>
 
 // And lastly a header that contains some functions that will help us compute
-// rotaton matrices of the local coordinate systems at specific points in the
+// rotation matrices of the local coordinate systems at specific points in the
 // domain.
 #include <deal.II/physics/transformations.h>
 

--- a/include/deal.II/lac/sparse_matrix.templates.h
+++ b/include/deal.II/lac/sparse_matrix.templates.h
@@ -588,7 +588,7 @@ SparseMatrix<number>::add(const size_type  row,
         {
           // Use the same algorithm as above, but because the matrix is
           // not square, we can now do without the split for diagonal/
-          // entries before the diagional/entries are the diagonal.
+          // entries before the diagonal/entries are the diagonal.
           size_type counter = 0;
           for (size_type i = 0; i < n_cols; ++i)
             {

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -76,7 +76,7 @@ DEAL_II_NAMESPACE_OPEN
  * quadrature dimension the same as the space dimension) or for a face
  * integrator (with quadrature dimension one less)
  *
- * @tparam VectorizedArrayType Type of array to be woked on in a vectorized
+ * @tparam VectorizedArrayType Type of array to be worked on in a vectorized
  *                             fashion, defaults to VectorizedArray<Number>
  *
  * @note Currently only VectorizedArray<Number, width> is supported as
@@ -1829,7 +1829,7 @@ private:
  *
  * @tparam Number Number format, usually @p double or @p float
  *
- * @tparam VectorizedArrayType Type of array to be woked on in a vectorized
+ * @tparam VectorizedArrayType Type of array to be worked on in a vectorized
  *                             fashion, defaults to VectorizedArray<Number>
  *
  * @note Currently only VectorizedArray<Number, width> is supported as

--- a/include/deal.II/matrix_free/fe_evaluation_data.h
+++ b/include/deal.II/matrix_free/fe_evaluation_data.h
@@ -102,7 +102,7 @@ namespace internal
  * quadrature dimension the same as the space dimension) or for a face
  * integrator (with quadrature dimension one less)
  *
- * @tparam VectorizedArrayType Type of array to be woked on in a vectorized
+ * @tparam VectorizedArrayType Type of array to be worked on in a vectorized
  *                             fashion, defaults to VectorizedArray<Number>
  *
  * @note Currently only VectorizedArray<Number, width> is supported as

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -868,7 +868,7 @@ ParameterHandler::parse_input_from_json(std::istream &in,
     }
 
   // The xml function is reused to read in the xml into the parameter file.
-  // This function can only read mangled files. Therefore, we create a mangeled
+  // This function can only read mangled files. Therefore, we create a mangled
   // tree first.
   boost::property_tree::ptree node_tree_mangled;
   recursively_mangle_or_demangle(node_tree,

--- a/source/base/tensor.cc
+++ b/source/base/tensor.cc
@@ -36,7 +36,7 @@ namespace
     // major ordering, we take the SVD of A^T by running the gesvd command.
     // The results (V^T)^T and U^T are provided in column major that we use
     // as row major results V^T and U.
-    // It essentially computs A^T = (V^T)^T S U^T and gives us V^T and U.
+    // It essentially computes A^T = (V^T)^T S U^T and gives us V^T and U.
     // This trick gives what we originally wanted (A = U S V^T) but the order
     // of U and V^T is reversed.
     std::array<Number, dim> S;

--- a/source/multigrid/mg_tools.cc
+++ b/source/multigrid/mg_tools.cc
@@ -200,7 +200,7 @@ namespace MGTools
 
         // At this point, we have
         // counted all dofs
-        // contributiong from cells
+        // contributing from cells
         // coupled topologically to the
         // adjacent cells, but we
         // subtracted some faces.
@@ -457,7 +457,7 @@ namespace MGTools
 
         // At this point, we have
         // counted all dofs
-        // contributiong from cells
+        // contributing from cells
         // coupled topologically to the
         // adjacent cells, but we
         // subtracted some faces.

--- a/tests/fe/fe_face_orientation_nedelec_0.cc
+++ b/tests/fe/fe_face_orientation_nedelec_0.cc
@@ -78,7 +78,7 @@ create_triangulation(Triangulation<3> &triangulation)
   const std::vector<Point<3>> vertices(&vertices_parallelograms[0],
                                        &vertices_parallelograms[n_vertices]);
 
-  // create grid with all possible combintations of face_flip, face_orientation
+  // create grid with all possible combinations of face_flip, face_orientation
   // and face_rotation flags
   static const int cell_vertices[][GeometryInfo<3>::vertices_per_cell] = {
     {0, 1, 9, 10, 3, 4, 12, 13},      // cell 1 standard

--- a/tests/fe/fe_project_3d.cc
+++ b/tests/fe/fe_project_3d.cc
@@ -196,7 +196,7 @@ create_tria(Triangulation<3> &triangulation,
   const std::vector<Point<3>> vertices(&vertices_parallelograms[0],
                                        &vertices_parallelograms[n_vertices]);
 
-  // create grid with all possible combintations of face_flip, face_orientation
+  // create grid with all possible combinations of face_flip, face_orientation
   // and face_rotation flags
   static const int cell_vertices[][GeometryInfo<3>::vertices_per_cell] = {
     {0, 1, 9, 10, 3, 4, 12, 13},  // cell 1 standard

--- a/tests/hp/boundary_matrices_hp.cc
+++ b/tests/hp/boundary_matrices_hp.cc
@@ -15,7 +15,7 @@
 
 
 // Same as hp/boundary_matrices, but with different FE objects. Tests
-// the boundary mass matrces for vector-valued (non-primiteve) hp-
+// the boundary mass matrices for vector-valued (non-primiteve) hp-
 // FE objects.
 
 

--- a/tests/matrix_free/fe_nothing_02.cc
+++ b/tests/matrix_free/fe_nothing_02.cc
@@ -33,7 +33,7 @@
 #include "../tests.h"
 
 // In https://github.com/dealii/dealii/pull/14342, we have observed that
-// overlapping comunication/computation does not work properly since
+// overlapping communication/computation does not work properly since
 // ghost faces might be assigned to the wrong partition if
 // FE_Nothing is used. This is a test which shows this problem by
 // running the same problem on a large mesh where 50% of the

--- a/tests/quick_tests/step-petsc.cc
+++ b/tests/quick_tests/step-petsc.cc
@@ -174,7 +174,7 @@ LaplaceProblem::run()
       solve();
     }
 
-  // finialise output
+  // finalise output
   output_table.write_text(std::cout);
   deallog << std::endl;
 }

--- a/tests/quick_tests/step-slepc.cc
+++ b/tests/quick_tests/step-slepc.cc
@@ -219,7 +219,7 @@ LaplaceEigenspectrumProblem::run()
   output_table.add_value("lambda", 2.);
   output_table.add_value("error", "-");
 
-  // finialise output
+  // finalise output
   output_table.write_text(std::cout);
   deallog << std::endl;
 }

--- a/tests/quick_tests/step-trilinos.cc
+++ b/tests/quick_tests/step-trilinos.cc
@@ -177,7 +177,7 @@ LaplaceProblem::run()
       solve();
     }
 
-  // finialise output
+  // finalise output
   output_table.write_text(std::cout);
   deallog << std::endl;
 }


### PR DESCRIPTION
Found via codespell -q 3 -S ./bundled,./doc/news -L ans,ba,bu,clen,commend,compontent,elemente,indx,inout,methode,nd,pres,readin,re-use,re-used,re-using,ro,rotat,sie,stoer,ue,workd