### PR TITLE
Fix '#if DEBUG' statements.

### DIFF
--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -2233,7 +2233,7 @@ namespace FETools
       // Ensure that the element we are looking for isn't in the map
       // yet. This only requires us to read the map, so it can happen
       // in a shared locked state
-#if DEBUG
+#ifdef DEBUG
     {
       std::shared_lock<std::shared_mutex> lock(
         internal::FEToolsAddFENameHelper::fe_name_map_lock);

--- a/source/grid/tria_description.cc
+++ b/source/grid/tria_description.cc
@@ -734,6 +734,7 @@ namespace TriangulationDescription
                    "in the given communicator."));
         }
 
+#ifdef DEBUG
       // If we are dealing with a sequential triangulation, then someone
       // will have needed to set the subdomain_ids by hand. Make sure that
       // all ids we see are less than the number of processes we are
@@ -741,7 +742,6 @@ namespace TriangulationDescription
       if (dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
             &tria) == nullptr)
         {
-#if DEBUG
           const unsigned int n_mpi_processes =
             dealii::Utilities::MPI::n_mpi_processes(comm);
           for (const auto &cell : tria.active_cell_iterators())
@@ -751,8 +751,8 @@ namespace TriangulationDescription
                               " when splitting the triangulation using an MPI "
                               " communicator with only " +
                               std::to_string(n_mpi_processes) + " processes."));
-#endif
         }
+#endif
 
       // First, figure out for what rank we are supposed to build the
       // TriangulationDescription::Description object


### PR DESCRIPTION
We universally use `#ifdef DEBUG` except for two places where we use `#if DEBUG`. Make these two uniform. In one of these two places, I can also save a small number of cycles by moving the guard out one level.