### PR TITLE
Always initialize a variable in AlignedVector.

### DIFF
--- a/include/deal.II/base/aligned_vector.h
+++ b/include/deal.II/base/aligned_vector.h
@@ -1208,9 +1208,7 @@ inline AlignedVector<T>::AlignedVector()
   : elements(nullptr, Deleter(this))
   , used_elements_end(nullptr)
   , allocated_elements_end(nullptr)
-#  ifdef DEBUG
   , replicated_across_communicator(false)
-#  endif
 {}
 
 
@@ -1237,9 +1235,7 @@ inline AlignedVector<T>::AlignedVector(const size_type size, const T &init)
   : elements(nullptr, Deleter(this))
   , used_elements_end(nullptr)
   , allocated_elements_end(nullptr)
-#  ifdef DEBUG
   , replicated_across_communicator(false)
-#  endif
 {
   if (size > 0)
     resize(size, init);
@@ -1252,9 +1248,7 @@ inline AlignedVector<T>::AlignedVector(const AlignedVector<T> &vec)
   : elements(nullptr, Deleter(this))
   , used_elements_end(nullptr)
   , allocated_elements_end(nullptr)
-#  ifdef DEBUG
   , replicated_across_communicator(false)
-#  endif
 {
   // copy the data from vec
   reserve(vec.size());


### PR DESCRIPTION
In this class, we omit initialization of a variable in release mode because it is only ever read in assertions. That seems silly, and sure to make debugging harder than necessary if one ever had to do that in release mode. Besides, the operations that `AlignedVector` does are surely vastly more expensive than the initialization of a single `bool`.

So, let's just do it always and make progress towards #18057.