### PR TITLE
Fix `extract_boundary_mesh()` for simplex meshes

### DIFF
--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -8710,7 +8710,7 @@ namespace GridGenerator
            volume_mesh.begin(0);
          cell != volume_mesh.end(0);
          ++cell)
-      for (const unsigned int i : GeometryInfo<dim>::face_indices())
+      for (const unsigned int i : cell->reference_cell().face_indices())
         {
           const typename MeshType<dim, spacedim>::face_iterator face =
             cell->face(i);


### PR DESCRIPTION
Fix `GridGenerator::extract_boundary_mesh()` for simplex meshes by replacing `GeometryInfo<dim>::face_indices()` with cell->reference_cell().face_indices().