### PR TITLE
Fix "declaration of '' hides class member" warning

### DIFF
--- a/include/deal.II/lac/sparsity_pattern_base.h
+++ b/include/deal.II/lac/sparsity_pattern_base.h
@@ -167,10 +167,10 @@ SparsityPatternBase::n_cols() const
 
 
 inline void
-SparsityPatternBase::resize(const size_type rows, const size_type cols)
+SparsityPatternBase::resize(const size_type nRows, const size_type nCols)
 {
-  this->rows = rows;
-  this->cols = cols;
+  this->rows = nRows;
+  this->cols = nCols;
 }
 #endif
 

--- a/include/deal.II/lac/sparsity_pattern_base.h
+++ b/include/deal.II/lac/sparsity_pattern_base.h
@@ -167,10 +167,10 @@ SparsityPatternBase::n_cols() const
 
 
 inline void
-SparsityPatternBase::resize(const size_type nRows, const size_type nCols)
+SparsityPatternBase::resize(const size_type n_rows, const size_type n_cols)
 {
-  this->rows = nRows;
-  this->cols = nCols;
+  this->rows = n_rows;
+  this->cols = n_cols;
 }
 #endif
 


### PR DESCRIPTION
When compiling dealii from UnrealEngine, the following warnings are present:

```
C:\Projects\dealii_install\include\deal.II\lac\sparsity_pattern_base.h(170): error C4458: declaration of 'rows' hides class member
C:\Projects\dealii_install\include\deal.II\lac\sparsity_pattern_base.h(121): note: see declaration of 'dealii::SparsityPatternBase::rows'
C:\Projects\dealii_install\include\deal.II\lac\sparsity_pattern_base.h(170): error C4458: declaration of 'cols' hides class member
C:\Projects\dealii_install\include\deal.II\lac\sparsity_pattern_base.h(126): note: see declaration of 'dealii::SparsityPatternBase::cols'
```

Changing the names slightly to fix the issue.