### PR TITLE
github-docker: disable focal image.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ubuntu_version: [focal, jammy]
+        ubuntu_version: [jammy]
         platform: [linux/amd64]
         # Use only 2 jobs to build, as more jobs
         # would starve the github machine for memory.
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ubuntu_version: [focal, jammy]
+        ubuntu_version: [jammy]
 
     steps:
       - name: Download digests


### PR DESCRIPTION
Our docker tester on ubuntu focal stopped working.
https://github.com/dealii/dealii/actions/workflows/docker.yml

```
-- Could not find a sufficient ADOL-C installation: ADOL-C links against external Boost but deal.II was configured with bundled Boost.
[...]
CMake Error at cmake/macros/macro_configure_feature.cmake:111 (message):
  Could not find the adolc library!
```

We bumped the boost version required for deal.II to 1.74 in #17365, which is above the one that ships with ubuntu focal (1.71). I assume that ADOLC was built with system boost in the docker dependencies image, but deal.II now requires a more recent version version and uses the bundled boost.

This PR suggests to remove building master branch docker images for ubuntu focal. @dealii/dealii  Is this what we want?