### PR TITLE
Remove #includes from config.h.

### DIFF
--- a/doc/news/changes/incompatibilities/20250203Bangerth
+++ b/doc/news/changes/incompatibilities/20250203Bangerth
@@ -1,0 +1,20 @@
+Changed: Every deal.II header file includes the deal.II header
+`deal.II/base/config.h` that contains some basic configuration
+information such as what deal.II version is being used, whether
+deal.II was configured with Trilinos/PETSc/... support, etc. In turn,
+`config.h` included `deal.II/base/types.h` and
+`deal.II/base/numbers.h`, making the contents of these latter two
+files available throughout deal.II.
+
+For conceptual reasons, for example to support C++20 modules in the
+long run, the `deal.II/base/config.h` file must stand separate from
+the rest of the deal.II header files. As a consequence, it can no
+longer have includes for other deal.II header files (namely,
+`deal.II/base/types.h` and `deal.II/base/numbers.h` as mentioned
+above), and no longer does so now. If your code requires knowledge of
+the contents of `deal.II/base/types.h` and `deal.II/base/numbers.h`,
+you will have to explicitly include these files like you do with any
+other deal.II header file already.
+
+<br>
+(Wolfgang Bangerth, 2024/01/16)

--- a/include/deal.II/base/complex_overloads.h
+++ b/include/deal.II/base/complex_overloads.h
@@ -17,6 +17,10 @@
 
 #include <deal.II/base/config.h>
 
+#include <complex>
+#include <type_traits>
+
+
 DEAL_II_NAMESPACE_OPEN
 
 #ifndef DOXYGEN

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -594,16 +594,13 @@ _Pragma("GCC diagnostic pop")
 
 /*
  * Some systems require including mpi.h before stdio.h which happens in
- * types.h
+ * base/types.h and perhaps other places. So just include it unconditionally.
  */
 #if defined(DEAL_II_WITH_MPI)
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <mpi.h>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #endif
-
-#include <deal.II/base/numbers.h>
-#include <deal.II/base/types.h>
 
 /*
  * Include the boost version header to do a quick version check in case, by

--- a/include/deal.II/base/discrete_time.h
+++ b/include/deal.II/base/discrete_time.h
@@ -17,6 +17,9 @@
 
 #include <deal.II/base/config.h>
 
+#include <cstddef>
+
+
 DEAL_II_NAMESPACE_OPEN
 
 /**

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -17,6 +17,8 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/numbers.h>
+
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <Kokkos_Macros.hpp>
 #if KOKKOS_VERSION >= 40200

--- a/include/deal.II/base/memory_consumption.h
+++ b/include/deal.II/base/memory_consumption.h
@@ -18,6 +18,8 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/vectorization.h>
+
 #include <array>
 #include <complex>
 #include <cstddef>


### PR DESCRIPTION
When compiling deal.II as a module, we have to ensure that everything deal.II related is imported via a `import dealii;` or `import :<some module partition>;` statement. This will then import all relevant declarations, but because preprocessor defines are not part of what the compiler sees, you cannot import preprocessor defines. As a consequence, `config.h` cannot be part of the deal.II module, and needs to be `#include`d as it always has. In return, this means that `config.h` cannot `#include` things from the deal.II library -- it really needs to be standing alone from the rest of the library. 

Unfortunately, we currently do `#include` two deal.II files from `config.h`: `numbers.h` and `types.h`. This really is not necessary, and it is actively not possible to deal with this in the module framework. So this patch removes these two includes from `config.h`, and updates the list of includes everywhere else where it is apparently necessary.

Part of #18071.