### PR TITLE
Do not include unnecessary header file.

### DIFF
--- a/include/deal.II/lac/petsc_solver.h
+++ b/include/deal.II/lac/petsc_solver.h
@@ -27,9 +27,6 @@
 
 #  include <petscksp.h>
 
-#  ifdef DEAL_II_WITH_SLEPC
-#    include <deal.II/lac/slepc_spectral_transformation.h>
-#  endif
 
 DEAL_II_NAMESPACE_OPEN
 


### PR DESCRIPTION
Fixes one of the cycles mentioned in #18080. We make a class a `friend` of another, but we already have a forward declaration of the former and so don't actually need the `#include`.