### PR TITLE
Remove a cycle in header files.

### DIFF
--- a/include/deal.II/lac/la_parallel_block_vector.h
+++ b/include/deal.II/lac/la_parallel_block_vector.h
@@ -837,8 +837,4 @@ struct is_serial_vector<LinearAlgebra::distributed::BlockVector<Number>>
 
 DEAL_II_NAMESPACE_CLOSE
 
-#ifdef DEAL_II_MSVC
-#  include <deal.II/lac/la_parallel_block_vector.templates.h>
-#endif
-
 #endif

--- a/source/lac/la_parallel_block_vector.cc
+++ b/source/lac/la_parallel_block_vector.cc
@@ -19,12 +19,7 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-
-// disable instantiation for MSVC for now because of a compiler bug,
-// see https://github.com/dealii/dealii/issues/2875
-#ifndef DEAL_II_MSVC
-
-#  include "la_parallel_block_vector.inst"
+#include "la_parallel_block_vector.inst"
 
 // do a few functions that currently don't fit the scheme because they have
 // two template arguments that need to be different (the case of same
@@ -35,17 +30,15 @@ namespace LinearAlgebra
 {
   namespace distributed
   {
-#  define TEMPL_COPY_CONSTRUCTOR(S1, S2)                 \
-    template BlockVector<S1> &BlockVector<S1>::operator= \
-      <S2>(const BlockVector<S2> &)
+#define TEMPL_COPY_CONSTRUCTOR(S1, S2)                 \
+  template BlockVector<S1> &BlockVector<S1>::operator= \
+    <S2>(const BlockVector<S2> &)
 
     TEMPL_COPY_CONSTRUCTOR(double, float);
     TEMPL_COPY_CONSTRUCTOR(float, double);
 
-#  undef TEMPL_COPY_CONSTRUCTOR
+#undef TEMPL_COPY_CONSTRUCTOR
   } // namespace distributed
 } // namespace LinearAlgebra
-
-#endif // ! DEAL_II_MSVC
 
 DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
Another one for #18080. `deal.II/lac/la_parallel_block_vector.templates.h` is included from the corresponding `.h` file, but only for MSVC. This dates back to #3004 in 2016, and it is entirely possible that that is not actually necessary any more today. The corresponding change made in #3004 to `la_vector.h` seems to have been removed since then, so I'm hopeful that the inclusion is not necessary here either.

Let me try this.