### PR TITLE
Avoid another include cycle.

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparsity_pattern.h
@@ -29,7 +29,6 @@
 
 #  include <deal.II/lac/exceptions.h>
 #  include <deal.II/lac/sparsity_pattern_base.h>
-#  include <deal.II/lac/trilinos_tpetra_sparse_matrix.h>
 
 #  include <Tpetra_CrsGraph.hpp>
 


### PR DESCRIPTION
Very similar to #18082: We declare one class a friend to another. We don't actually need to know the class via an include file, it's enough to see a forward declaration (which is already there).