### PR TITLE
Remove the last header cycle.

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_block_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_block_vector.h
@@ -21,29 +21,9 @@
 
 #  include <deal.II/lac/block_indices.h>
 #  include <deal.II/lac/block_vector_base.h>
-#  include <deal.II/lac/trilinos_tpetra_block_sparse_matrix.h>
 #  include <deal.II/lac/trilinos_tpetra_vector.h>
 
 DEAL_II_NAMESPACE_OPEN
-
-// forward declaration
-#  ifndef DOXYGEN
-template <typename Number>
-class BlockVectorBase;
-
-namespace LinearAlgebra
-{
-  // forward declaration
-  namespace TpetraWrappers
-  {
-    template <typename Number, typename MemorySpace>
-    class BlockVector;
-
-    template <typename Number, typename MemorySpace>
-    class BlockSparseMatrix;
-  } // namespace TpetraWrappers
-} // namespace LinearAlgebra
-#  endif // DOXYGEN
 
 namespace LinearAlgebra
 {


### PR DESCRIPTION
Here, there really is no good reason to include the header file at all, or even to forward declare the class from the header file: Neither is actually used in the rest of the file. There is, furthermore, no need to forward declare the class we will be declare a dozen lines further down, nor to declare `BlockVectorBase`, which we get from the header inclusion a few lines up.

20 lines -- zapppp!

Part of #18080.