### PR TITLE
Mark our various constants as 'constexpr'.

### DIFF
--- a/include/deal.II/base/types.h
+++ b/include/deal.II/base/types.h
@@ -229,8 +229,7 @@ namespace numbers
    * @ref GlossInvalidValue "invalid value".
    * See there for more information.
    */
-  static const unsigned int invalid_unsigned_int =
-    static_cast<unsigned int>(-1);
+  constexpr unsigned int invalid_unsigned_int = static_cast<unsigned int>(-1);
 
   /**
    * Representation of the largest number that can be put into a size_type.
@@ -242,7 +241,7 @@ namespace numbers
    * @ref GlossInvalidValue "invalid value".
    * See there for more information.
    */
-  const types::global_dof_index invalid_size_type =
+  constexpr types::global_dof_index invalid_size_type =
     static_cast<types::global_dof_index>(-1);
 
   /**
@@ -252,7 +251,7 @@ namespace numbers
    * @ref GlossInvalidValue "invalid value".
    * See there for more information.
    */
-  const types::fe_index invalid_fe_index = static_cast<types::fe_index>(-1);
+  constexpr types::fe_index invalid_fe_index = static_cast<types::fe_index>(-1);
 
   /**
    * An invalid value for indices of degrees of freedom.
@@ -261,7 +260,7 @@ namespace numbers
    * @ref GlossInvalidValue "invalid value".
    * See there for more information.
    */
-  const types::global_dof_index invalid_dof_index =
+  constexpr types::global_dof_index invalid_dof_index =
     static_cast<types::global_dof_index>(-1);
 
   /**
@@ -274,7 +273,7 @@ namespace numbers
    * @ref GlossInvalidValue "invalid value".
    * See there for more information.
    */
-  const types::coarse_cell_id invalid_coarse_cell_id =
+  constexpr types::coarse_cell_id invalid_coarse_cell_id =
     static_cast<types::coarse_cell_id>(-1);
 
   /**
@@ -286,7 +285,7 @@ namespace numbers
    * @ref GlossInvalidValue "invalid value".
    * See there for more information.
    */
-  const types::material_id invalid_material_id =
+  constexpr types::material_id invalid_material_id =
     static_cast<types::material_id>(-1);
 
   /**
@@ -301,7 +300,7 @@ namespace numbers
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
-  const types::boundary_id invalid_boundary_id =
+  constexpr types::boundary_id invalid_boundary_id =
     static_cast<types::boundary_id>(-1);
 
   /**
@@ -321,7 +320,7 @@ namespace numbers
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
-  const types::boundary_id internal_face_boundary_id =
+  constexpr types::boundary_id internal_face_boundary_id =
     static_cast<types::boundary_id>(-1);
 
   /**
@@ -334,7 +333,7 @@ namespace numbers
    * @see
    * @ref GlossManifoldIndicator "Glossary entry on manifold indicators"
    */
-  const types::manifold_id flat_manifold_id =
+  constexpr types::manifold_id flat_manifold_id =
     static_cast<types::manifold_id>(-1);
 
   /**
@@ -344,7 +343,7 @@ namespace numbers
    * @ref GlossFaceOrientation "glossary"
    * for more information.
    */
-  const types::geometric_orientation default_geometric_orientation =
+  constexpr types::geometric_orientation default_geometric_orientation =
     static_cast<types::geometric_orientation>(0b001);
 
   /**
@@ -357,7 +356,7 @@ namespace numbers
    * @ref GlossFaceOrientation "glossary"
    * for more information.
    */
-  const types::geometric_orientation reverse_line_orientation =
+  constexpr types::geometric_orientation reverse_line_orientation =
     static_cast<types::geometric_orientation>(0b000);
 
   /**
@@ -373,7 +372,7 @@ namespace numbers
    * @ref GlossSubdomainId "glossary"
    * for more information.
    */
-  const types::subdomain_id invalid_subdomain_id =
+  constexpr types::subdomain_id invalid_subdomain_id =
     static_cast<types::subdomain_id>(-1);
 
   /**
@@ -394,7 +393,7 @@ namespace numbers
    * @ref GlossInvalidValue "invalid value".
    * See there for more information.
    */
-  const types::subdomain_id artificial_subdomain_id =
+  constexpr types::subdomain_id artificial_subdomain_id =
     static_cast<types::subdomain_id>(-2);
 } // namespace numbers
 


### PR DESCRIPTION
`numbers::invalid_unsigned_int` is, inexplicably, marked as `static`. That means, that the variable is replicated in every single object file. It's not wrong, it's just wasteful.

So the `static` needed to go. While there, I thought we might as well see if we can make all of these variables `constexpr`.

(Found while looking at #18071. You can't export a `static` variable from a module because `static` means that it has internal linkage.)