### PR TITLE
Be more precise what we need to #include.

### DIFF
--- a/include/deal.II/base/iterator_range.h
+++ b/include/deal.II/base/iterator_range.h
@@ -20,6 +20,8 @@
 
 #include <deal.II/base/template_constraints.h>
 
+#include <iterator>
+
 DEAL_II_NAMESPACE_OPEN
 
 

--- a/include/deal.II/base/mpi_tags.h
+++ b/include/deal.II/base/mpi_tags.h
@@ -17,6 +17,8 @@
 
 #include <deal.II/base/config.h>
 
+#include <cstdint>
+
 DEAL_II_NAMESPACE_OPEN
 
 

--- a/include/deal.II/differentiation/ad/adolc_product_types.h
+++ b/include/deal.II/differentiation/ad/adolc_product_types.h
@@ -24,6 +24,9 @@
 #  include <adolc/adouble.h> // Taped double
 #  include <adolc/adtl.h>    // Tapeless double
 
+#  include <complex>
+
+
 DEAL_II_NAMESPACE_OPEN
 
 

--- a/include/deal.II/dofs/dof_iterator_selector.h
+++ b/include/deal.II/dofs/dof_iterator_selector.h
@@ -17,6 +17,8 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/template_constraints.h>
+
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/fe/fe_values_extractors.h
+++ b/include/deal.II/fe/fe_values_extractors.h
@@ -18,6 +18,11 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/types.h>
+
+#include <string>
+
+
 DEAL_II_NAMESPACE_OPEN
 
 

--- a/include/deal.II/hp/refinement.h
+++ b/include/deal.II/hp/refinement.h
@@ -20,9 +20,9 @@
 
 #include <deal.II/base/template_constraints.h>
 
+#include <cmath>
 #include <functional>
 #include <vector>
-
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/matrix_free/evaluation_flags.h
+++ b/include/deal.II/matrix_free/evaluation_flags.h
@@ -18,6 +18,8 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/numbers.h>
+
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/numerics/vector_tools_point_gradient.h
+++ b/include/deal.II/numerics/vector_tools_point_gradient.h
@@ -18,6 +18,8 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/template_constraints.h>
+
 #include <vector>
 
 

--- a/include/deal.II/numerics/vector_tools_point_value.h
+++ b/include/deal.II/numerics/vector_tools_point_value.h
@@ -18,6 +18,9 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/template_constraints.h>
+
+
 DEAL_II_NAMESPACE_OPEN
 
 template <int dim, int spacedim>

--- a/include/deal.II/numerics/vector_tools_project.h
+++ b/include/deal.II/numerics/vector_tools_project.h
@@ -18,6 +18,9 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/template_constraints.h>
+#include <deal.II/base/vectorization.h>
+
 #include <functional>
 #include <memory>
 

--- a/include/deal.II/numerics/vector_tools_rhs.h
+++ b/include/deal.II/numerics/vector_tools_rhs.h
@@ -17,6 +17,9 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/template_constraints.h>
+#include <deal.II/base/types.h>
+
 #include <set>
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/sundials/utilities.h
+++ b/include/deal.II/sundials/utilities.h
@@ -18,6 +18,9 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/exceptions.h>
+
+
 #ifdef DEAL_II_WITH_SUNDIALS
 #  include <exception>
 

--- a/source/base/conditional_ostream.cc
+++ b/source/base/conditional_ostream.cc
@@ -15,6 +15,9 @@
 
 #include <deal.II/base/conditional_ostream.h>
 
+#include <ostream>
+
+
 DEAL_II_NAMESPACE_OPEN
 
 ConditionalOStream::ConditionalOStream(std::ostream &stream, const bool active)

--- a/source/base/event.cc
+++ b/source/base/event.cc
@@ -15,6 +15,10 @@
 
 #include <deal.II/base/event.h>
 
+#include <string>
+#include <vector>
+
+
 DEAL_II_NAMESPACE_OPEN
 
 // TODO: Thread safety

--- a/source/base/job_identifier.cc
+++ b/source/base/job_identifier.cc
@@ -15,6 +15,8 @@
 #include <deal.II/base/job_identifier.h>
 
 #include <ctime>
+#include <string>
+
 
 #ifdef DEAL_II_HAVE_UNISTD_H
 #  include <unistd.h>


### PR DESCRIPTION
Another one for #18071. This one is a nuisance and I have a feeling like there are many more similar patches to come.

Header files transitively export whatever they have `#include`d. That is, if `a.h` includes `<vector>`, and `a.cc` includes `a.h` and then uses `std::vector`, that's fine. But not via modules: The file that you will turn `a.h` into has `#include <vector>` at the top, but then at some point further down below, it will start a module and `export {...}` very specific declarations. It does not automatically export what it has `#include`d. So, if what you turn `a.cc` into has an `import the_module_that_results_from_a.h;`, it gets the exported declarations, but not transitively what `a.h` had previously `#include`d. If `a.cc` uses `std::vector`, it has to explicitly `#include <vector>`.

This patch does that in a number of places. We know from experience that relying on transitive inclusion is brittle, but we likely use it in most files in some way or other and if an `#include` chain is broken, we just add the necessary `#include` where appropriate. Modules just force us to be precise all along. This patch goes some way towards this goal, but I suspect that this doesn't even come close to really addressing the issue. Either way, one foot in front of the other.