### PR TITLE
Print the exception string in a test.

### DIFF
--- a/tests/lac/full_matrix_mmult_01.cc
+++ b/tests/lac/full_matrix_mmult_01.cc
@@ -23,6 +23,7 @@ int
 main()
 {
   initlog();
+  deal_II_exceptions::disable_abort_on_exception();
 
   try
     {
@@ -34,7 +35,8 @@ main()
     }
   catch (const dealii::ExceptionBase &exc)
     {
-      deallog << exc.get_exc_name() << std::endl;
+      exc.print_info(deallog.get_file_stream());
+      deallog << std::flush;
     }
 
   return 0;

--- a/tests/lac/full_matrix_mmult_01.debug.output
+++ b/tests/lac/full_matrix_mmult_01.debug.output
@@ -1,0 +1,3 @@
+
+    The output matrix cannot be the same as the current matrix.
+DEAL::


### PR DESCRIPTION
This was the original intent of the test (it did try to print the exception name!) but since we didn't disable the call to `std::abort()` on assertion failure it didn't work.