### PR TITLE
Remove an unnecessary include path.

### DIFF
--- a/source/trilinos/CMakeLists.txt
+++ b/source/trilinos/CMakeLists.txt
@@ -12,9 +12,6 @@
 ##
 ## ------------------------------------------------------------------------
 
-include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR})
-
-
 set(_src)
 set(_inst)
 


### PR DESCRIPTION
Similarly to what I changed in #18087, there is one other cmake file that tells the compiler to also go for the current binary directory to find header files. I don't know whether this was ever necessary, but I believe it is at least no longer necessary. This is the only one among the `source/*/CMakeLists.txt` files that does that.

@tamiko FYI

Found while poking around for #18071.