### PR TITLE
Exclude more files from compiling if they are functionally empty.

### DIFF
--- a/source/base/CMakeLists.txt
+++ b/source/base/CMakeLists.txt
@@ -28,7 +28,6 @@ set(_unity_include_src
   exceptions.cc
   flow_function.cc
   function.cc
-  function_cspline.cc
   function_derivative.cc
   function_signed_distance.cc
   function_lib.cc
@@ -118,6 +117,13 @@ if(DEAL_II_WITH_HDF5)
   set(_unity_include_src
     ${_unity_include_src}
     hdf5.cc
+  )
+endif()
+
+if(DEAL_II_WITH_GSL)
+  set(_unity_include_src
+    ${_unity_include_src}
+    function_cspline.cc
   )
 endif()
 

--- a/source/gmsh/CMakeLists.txt
+++ b/source/gmsh/CMakeLists.txt
@@ -12,13 +12,22 @@
 ##
 ## ------------------------------------------------------------------------
 
-set(_src
-  utilities.cc
-  )
 
-set(_inst
-  utilities.inst.in
-  )
+set(_src)
+set(_inst)
+
+if(DEAL_II_WITH_GMSH)
+  set(_src
+    ${_src}
+    utilities.cc
+    )
+
+  set(_inst
+    ${_inst}
+    utilities.inst.in
+    )
+endif()
+
 
 file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/gmsh/*.h

--- a/source/gmsh/utilities.cc
+++ b/source/gmsh/utilities.cc
@@ -142,7 +142,13 @@ namespace Gmsh
 
   // explicit instantiations
 #  ifdef DEAL_II_WITH_OPENCASCADE
-#    include "gmsh/utilities.inst"
+// We don't build the utilities.inst file if deal.II isn't configured
+// with GMSH, but doxygen doesn't know that and tries to find that
+// file anyway for parsing -- which then of course it fails on. So
+// exclude the following from doxygen consideration.
+#    ifndef DOXYGEN
+#      include "gmsh/utilities.inst"
+#    endif
 #  endif
 } // namespace Gmsh
 


### PR DESCRIPTION
This is a follow-up to #18089 that covers a couple more files.

Also part of #18071.