### PR TITLE
Move misplaced #defines from numbers.h to config.h.

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -110,6 +110,21 @@
 #cmakedefine DEAL_II_RESTRICT @DEAL_II_RESTRICT@
 #cmakedefine DEAL_II_COMPILER_HAS_DIAGNOSTIC_PRAGMA
 
+
+#define DEAL_II_HOST_DEVICE KOKKOS_FUNCTION
+#define DEAL_II_HOST_DEVICE_ALWAYS_INLINE KOKKOS_FORCEINLINE_FUNCTION
+
+// clang++ assumes that all constexpr functions are __host__ __device__ when
+// Kokkos was configured with CUDA or HIP support. This is problematic
+// when calling non-constexpr functions in constexpr functions. Hence, we
+// need a way to annotate functions explicitly as host-only.
+#if (defined(__clang__) && defined(__CUDA__)) || defined(KOKKOS_ENABLE_HIP)
+#  define DEAL_II_HOST __host__
+#else
+#  define DEAL_II_HOST
+#endif
+
+
 /***********************************************************************
  * CPU features:
  *

--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -27,19 +27,6 @@
 #include <cstddef>
 #include <type_traits>
 
-#define DEAL_II_HOST_DEVICE KOKKOS_FUNCTION
-#define DEAL_II_HOST_DEVICE_ALWAYS_INLINE KOKKOS_FORCEINLINE_FUNCTION
-
-// clang++ assumes that all constexpr functions are __host__ __device__ when
-// Kokkos was configured with CUDA or HIP support. This is problematic
-// when calling non-constexpr functions in constexpr functions. Hence, we
-// need a way to annotate functions explicitly as host-only.
-#if (defined(__clang__) && defined(__CUDA__)) || defined(KOKKOS_ENABLE_HIP)
-#  define DEAL_II_HOST __host__
-#else
-#  define DEAL_II_HOST
-#endif
-
 // Forward-declare the automatic differentiation types so we can add prototypes
 // for our own wrappers.
 #ifdef DEAL_II_WITH_ADOLC


### PR DESCRIPTION
We `#define`d two macros in `numbers.h` that should really have been in `config.h`. It didn't matter in the past because `config.h` #include`d `numbers.h` until #18075, but conceptually `numbers.h` has never been the right place for these defines.

(For #18071, I need to gather all `#define`s in `config.h`, which is how I found this.)