### PR TITLE
Do not use 'static const' variables in header files. Use 'constexpr' instead.

### DIFF
--- a/include/deal.II/lac/lapack_support.h
+++ b/include/deal.II/lac/lapack_support.h
@@ -149,39 +149,39 @@ namespace LAPACKSupport
   /**
    * Character constant.
    */
-  static const char A = 'A';
+  constexpr char A = 'A';
   /**
    * Character constant.
    */
-  static const char N = 'N';
+  constexpr char N = 'N';
   /**
    * Character constant.
    */
-  static const char O = 'O';
+  constexpr char O = 'O';
   /**
    * Character constant.
    */
-  static const char T = 'T';
+  constexpr char T = 'T';
   /**
    * Character constant.
    */
-  static const char U = 'U';
+  constexpr char U = 'U';
   /**
    * Character constant.
    */
-  static const char L = 'L';
+  constexpr char L = 'L';
   /**
    * Character constant.
    */
-  static const char V = 'V';
+  constexpr char V = 'V';
   /**
    * Integer constant.
    */
-  static const types::blas_int zero = 0;
+  constexpr types::blas_int zero = 0;
   /**
    * Integer constant.
    */
-  static const types::blas_int one = 1;
+  constexpr types::blas_int one = 1;
 
   /**
    * A LAPACK function returned an error code.


### PR DESCRIPTION
Same reason as in #18090. Part of #18071.