### PR TITLE
Add necessary header includes.

### DIFF
--- a/include/deal.II/boost_adaptors/point.h
+++ b/include/deal.II/boost_adaptors/point.h
@@ -19,6 +19,16 @@
 
 #include <deal.II/base/point.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+#include <boost/geometry/core/coordinate_dimension.hpp>
+#include <boost/geometry/core/coordinate_system.hpp>
+#include <boost/geometry/core/coordinate_type.hpp>
+#include <boost/geometry/core/cs.hpp>
+#include <boost/geometry/core/tag.hpp>
+#include <boost/geometry/strategies/strategies.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
+
+
 namespace boost
 {
   namespace geometry


### PR DESCRIPTION
This file is missing a bunch of header includes it currently only gets because it is `#include`d in other places *after* other headers are included. If you `#include` it first, you'd get error messages.

Found while looking at #18071.