### PR TITLE
Fix compiling without TBB and Taskflow

### DIFF
--- a/include/deal.II/base/parallel.h
+++ b/include/deal.II/base/parallel.h
@@ -437,7 +437,7 @@ namespace parallel
     // warnings about unused arguments
     (void)grainsize;
 
-    for (OutputIterator1 in1 = begin_in1; in1 != end_in1;)
+    for (OutputIterator in1 = begin_in1; in1 != end_in1;)
       *out++ = function(*in1++, *in2++, *in3++);
 #endif
   }


### PR DESCRIPTION
There is only `OutputIterator`; `OutputIterator1` doesn't exist.