### PR TITLE
Fix grid_tools.cc without MPI and ArborX.

### DIFF
--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -22,25 +22,6 @@
 #ifdef DEAL_II_WITH_ARBORX
 #  include <deal.II/arborx/access_traits.h>
 #  include <deal.II/arborx/distributed_tree.h>
-#else
-template <int dim, typename Number>
-class BoundingBox;
-
-namespace ArborXWrappers
-{
-  class DistributedTree
-  {
-  public:
-    template <int dim, typename Number>
-    DistributedTree(const MPI_Comm &,
-                    const std::vector<BoundingBox<dim, Number>> &);
-    template <typename QueryType>
-    std::pair<std::vector<std::pair<int, int>>, std::vector<int>>
-    query(const QueryType &queries);
-  };
-  class BoundingBoxIntersectPredicate
-  {};
-} // namespace ArborXWrappers
 #endif
 
 #ifdef DEAL_II_WITH_CGAL
@@ -101,6 +82,33 @@ namespace ArborXWrappers
 #include <unordered_map>
 
 DEAL_II_NAMESPACE_OPEN
+
+#ifndef DEAL_II_WITH_ARBORX
+
+// If we configured without ArborX, we still need to have a couple of
+// dummy types that we can reference in code below. They do not
+// actually do anything useful.
+template <int dim, typename Number>
+class BoundingBox;
+
+namespace ArborXWrappers
+{
+  class DistributedTree
+  {
+  public:
+    template <int dim, typename Number>
+    DistributedTree(const MPI_Comm &,
+                    const std::vector<BoundingBox<dim, Number>> &);
+
+    template <typename QueryType>
+    std::pair<std::vector<std::pair<int, int>>, std::vector<int>>
+    query(const QueryType &queries);
+  };
+
+  class BoundingBoxIntersectPredicate
+  {};
+} // namespace ArborXWrappers
+#endif
 
 
 namespace GridTools


### PR DESCRIPTION
I broke compilation of `grid_tools.cc` in the case of no MPI and no ArborX with #18108. #18108 replaced a `#define` for `MPI_Comm` with a properly scoped type in namespace `dealii`. In one place in `grid_tools.cc`, we declared a class in the global scope that uses `MPI_Comm`. It's a stub, not used, but it needs to compile. This patch fixes it.

Part of #18071.