### PR TITLE
We cannot have 'static' functions in header files.

### DIFF
--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -3524,7 +3524,7 @@ namespace internal
     // the origin of each global entry and finds out which data we need to
     // collect.
     template <typename number>
-    static inline number
+    inline number
     resolve_matrix_entry(const GlobalRowsFromLocal<number> &global_rows,
                          const GlobalRowsFromLocal<number> &global_cols,
                          const size_type                    i,
@@ -3638,7 +3638,7 @@ namespace internal
     namespace dealiiSparseMatrix
     {
       template <typename SparseMatrixIterator, typename LocalType>
-      static inline void
+      inline void
       add_value(const LocalType       value,
                 const size_type       row,
                 const size_type       column,


### PR DESCRIPTION
It is not *wrong* to have `static` functions in header files, but doing so places copies into every object file for which the source file `#include` the header and prevents the linker from later unifying all of these copies. This is inefficient. (And it is actively forbidden for modules, so we might as well fix it..)

Part of #18071.