### PR TITLE
Move an #include outside namespace dealii.

### DIFF
--- a/source/lac/sparse_direct.cc
+++ b/source/lac/sparse_direct.cc
@@ -27,15 +27,12 @@
 #include <typeinfo>
 #include <vector>
 
-
-DEAL_II_NAMESPACE_OPEN
-
-
-// include UMFPACK file.
 #ifdef DEAL_II_WITH_UMFPACK
 #  include <umfpack.h>
 #endif
 
+
+DEAL_II_NAMESPACE_OPEN
 
 namespace
 {


### PR DESCRIPTION
The things you find when you look :-) Here, we open the `dealii` namespace *and then* `#include` the UMFPACK header. This only works because the UMFPACK functions are declared with `export "C"`, but it's definitely not right.

Found looking at #18071.