### PR TITLE
Only open/close namespace dealii once.

### DIFF
--- a/source/meshworker/scratch_data.cc
+++ b/source/meshworker/scratch_data.cc
@@ -1022,10 +1022,8 @@ namespace MeshWorker
   }
 
 } // namespace MeshWorker
-DEAL_II_NAMESPACE_CLOSE
 
 // Explicit instantiations
-DEAL_II_NAMESPACE_OPEN
 namespace MeshWorker
 {
 #include "meshworker/scratch_data.inst"


### PR DESCRIPTION
Not wrong, but not helpful for scripts that tee off of the `DEAL_II_NAMESPACE_OPEN/CLOSE` macros.

Needed for #18071.