### PR TITLE
do not use gold linker by default

### DIFF
--- a/cmake/checks/check_02_compiler_features.cmake
+++ b/cmake/checks/check_02_compiler_features.cmake
@@ -31,7 +31,6 @@
 #   DEAL_II_ALWAYS_INLINE
 #   DEAL_II_RESTRICT
 #   DEAL_II_COMPILER_HAS_DIAGNOSTIC_PRAGMA
-#   DEAL_II_COMPILER_HAS_FUSE_LD_GOLD
 #
 
 #
@@ -330,11 +329,11 @@ reset_cmake_required()
 
 
 #
-# Use 'mold', 'lld' or the 'gold' linker if possible, given that either of them
+# Use 'mold' or 'lld' linker if possible, given that either of them
 # is substantially faster.
 #
-# We have to try to link a full executable with -fuse-ld=mold, -fuse-ld=lld or
-# -fuse-ld=gold to check whether "ld.mold", "ld.lld" or "ld.gold" is actually
+# We have to try to link a full executable with -fuse-ld=mold or -fuse-ld=lld
+# to check whether "ld.mold" or "ld.lld" is actually
 # available.
 #
 # Clang always reports "argument unused during compilation", but fails at link
@@ -369,7 +368,7 @@ if(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   add_flags(CMAKE_REQUIRED_FLAGS "-fPIC")
 
   #
-  # Check for ld.mold, ld.lld and ld.gold support:
+  # Check for ld.mold or ld.lld support:
   #
   add_flags(CMAKE_REQUIRED_FLAGS "-fuse-ld=mold")
   CHECK_CXX_SOURCE_COMPILES(
@@ -387,15 +386,6 @@ if(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     void foo() { std::cout << \"Hello, world!\" << std::endl; }
     "
     DEAL_II_COMPILER_HAS_FUSE_LD_LLD)
-
-  strip_flag(CMAKE_REQUIRED_FLAGS "-fuse-ld=lld")
-  add_flags(CMAKE_REQUIRED_FLAGS "-fuse-ld=gold")
-  CHECK_CXX_SOURCE_COMPILES(
-    "
-    #include <iostream>
-    void foo() { std::cout << \"Hello, world!\" << std::endl; }
-    "
-    DEAL_II_COMPILER_HAS_FUSE_LD_GOLD)
 
   if(DEAL_II_COMPILER_HAS_FUSE_LD_MOLD)
     add_flags(DEAL_II_LINKER_FLAGS "-fuse-ld=mold")

--- a/cmake/checks/check_02_compiler_features.cmake
+++ b/cmake/checks/check_02_compiler_features.cmake
@@ -401,8 +401,6 @@ if(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     add_flags(DEAL_II_LINKER_FLAGS "-fuse-ld=mold")
   elseif(DEAL_II_COMPILER_HAS_FUSE_LD_LLD)
     add_flags(DEAL_II_LINKER_FLAGS "-fuse-ld=lld")
-  elseif(DEAL_II_COMPILER_HAS_FUSE_LD_GOLD)
-    add_flags(DEAL_II_LINKER_FLAGS "-fuse-ld=gold")
   endif()
 
   reset_cmake_required()

--- a/cmake/setup_sanity_checks.cmake
+++ b/cmake/setup_sanity_checks.cmake
@@ -63,8 +63,6 @@ foreach(build ${DEAL_II_BUILD_TYPES})
     set(_replacement "")
     if(DEAL_II_COMPILER_HAS_FUSE_LD_LLD)
       set(_replacement "-fuse-ld=lld")
-    elseif(DEAL_II_COMPILER_HAS_FUSE_LD_GOLD)
-      set(_replacement "-fuse-ld=gold")
     endif()
     _drop_linker_flag(
       "-fuse-ld=mold" ${_replacement}
@@ -75,9 +73,6 @@ foreach(build ${DEAL_II_BUILD_TYPES})
 
   if(NOT DEAL_II_HAVE_USABLE_FLAGS_${build} AND DEAL_II_COMPILER_HAS_FUSE_LD_LLD)
     set(_replacement "")
-    if(DEAL_II_COMPILER_HAS_FUSE_LD_GOLD)
-      set(_replacement "-fuse-ld=gold")
-    endif()
     _drop_linker_flag(
       "-fuse-ld=lld" ${_replacement}
       DEAL_II_COMPILER_HAS_FUSE_LD_LLD

--- a/cmake/setup_sanity_checks.cmake
+++ b/cmake/setup_sanity_checks.cmake
@@ -80,14 +80,6 @@ foreach(build ${DEAL_II_BUILD_TYPES})
     _check_linker_flags()
   endif()
 
-  if(NOT DEAL_II_HAVE_USABLE_FLAGS_${build} AND DEAL_II_COMPILER_HAS_FUSE_LD_GOLD)
-    _drop_linker_flag(
-      "-fuse-ld=gold" ""
-      DEAL_II_COMPILER_HAS_FUSE_LD_GOLD
-      )
-    _check_linker_flags()
-  endif()
-
   unset(CMAKE_TRY_COMPILE_CONFIGURATION)
 
   if(NOT DEAL_II_HAVE_USABLE_FLAGS_${build})


### PR DESCRIPTION
We have been detecting the existence of the gold linker and automatically try to use it. This PR removes this for the following reasons:
1. gold linker is now deprecated, https://lists.gnu.org/archive/html/info-gnu/2025-02/msg00001.html
2. it sometimes breaks linking, especially with MPI
3. lld and especially mold are much better