### PR TITLE
Be more precise with what we #include, part 4: Include ADOLC headers where necessary.

### DIFF
--- a/include/deal.II/differentiation/ad/ad_drivers.h
+++ b/include/deal.II/differentiation/ad/ad_drivers.h
@@ -28,6 +28,8 @@
 
 #ifdef DEAL_II_WITH_ADOLC
 
+#  include <adolc/adouble.h> // Taped double
+#  include <adolc/adtl.h>    // Tapeless double
 #  include <adolc/internal/usrparms.h>
 
 #endif // DEAL_II_WITH_ADOLC

--- a/source/base/symmetric_tensor.cc
+++ b/source/base/symmetric_tensor.cc
@@ -21,7 +21,14 @@
 #include <deal.II/differentiation/ad/adolc_product_types.h>
 #include <deal.II/differentiation/ad/sacado_product_types.h>
 
+#ifdef DEAL_II_WITH_ADOLC
+#  include <adolc/adouble.h>
+#  include <adolc/adtl.h>
+#endif
+
+
 DEAL_II_NAMESPACE_OPEN
+
 #ifdef DEAL_II_WITH_ADOLC
 #  ifdef DEAL_II_ADOLC_WITH_ADVANCED_BRANCHING
 

--- a/source/differentiation/ad/adolc_number_types.cc
+++ b/source/differentiation/ad/adolc_number_types.cc
@@ -25,6 +25,7 @@
 
 #  ifdef DEAL_II_WITH_ADOLC
 #    include <adolc/adouble.h> // Taped double
+#    include <adolc/adtl.h>    // Tapeless double
 #  endif
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/fe/fe_values_views.cc
+++ b/source/fe/fe_values_views.cc
@@ -24,6 +24,12 @@
 
 #include <deal.II/lac/vector.h>
 
+#ifdef DEAL_II_WITH_ADOLC
+#  include <adolc/adouble.h>
+#  include <adolc/adtl.h>
+#endif
+
+
 DEAL_II_NAMESPACE_OPEN
 
 

--- a/source/fe/fe_values_views_internal.cc
+++ b/source/fe/fe_values_views_internal.cc
@@ -19,6 +19,11 @@
 
 #include <deal.II/fe/fe_values_views_internal.h>
 
+#ifdef DEAL_II_WITH_ADOLC
+#  include <adolc/adouble.h>
+#  include <adolc/adtl.h>
+#endif
+
 #include <type_traits>
 
 DEAL_II_NAMESPACE_OPEN


### PR DESCRIPTION
We have a number of files where we instantiate stuff for AD data types. If we do that, we need to also `#include` the relevant headers. This patch does it for the ADOLC data types.

Again part of #18071. Like #18091 and #18118 and #18130.