### PR TITLE
Fix output for trilinos/direct_solver_4

### DIFF
--- a/tests/trilinos/direct_solver_4.output
+++ b/tests/trilinos/direct_solver_4.output
@@ -5,8 +5,6 @@
 0.33 0.67 1.0  
 0.17 0.33 0.50 
 DEAL::
-DEAL::Starting value 0.00000
-DEAL::Convergence step 0 value 0.00000
 0.83 0.67 0.50 
 0.67 1.3  1.0  
 0.50 1.0  1.5  


### PR DESCRIPTION
Fixes part of https://github.com/dealii/dealii/issues/18131. We just don't print all the solver information anymore by default.