### PR TITLE
Exclude CGAL source files when not compiling with CGAL.

### DIFF
--- a/source/cgal/CMakeLists.txt
+++ b/source/cgal/CMakeLists.txt
@@ -12,27 +12,33 @@
 ##
 ## ------------------------------------------------------------------------
 
-#
-# We have to compile the "intersections.cc" file without the misleading
-# indentation warning enabled. Otherwise, we run into quite a number of
-# warnings with gcc, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89549
-#
+
+set(_src)
+set(_inst)
+
 if(DEAL_II_WITH_CGAL)
+  #
+  # We have to compile the "intersections.cc" file without the misleading
+  # indentation warning enabled. Otherwise, we run into quite a number of
+  # warnings with gcc, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89549
+  #
   enable_if_supported(_flag "-Wno-misleading-indentation")
   set_property(SOURCE "intersections.cc"
     APPEND PROPERTY COMPILE_OPTIONS "${_flag}"
     )
+
+  set(_src
+    ${_src}
+    surface_mesh.cc
+    intersections.cc
+  )
+
+  set(_inst
+      ${_inst}
+  surface_mesh.inst.in
+  intersections.inst.in
+  )
 endif()
-
-set(_src
-  surface_mesh.cc
-  intersections.cc
-)
-
-set(_inst
-surface_mesh.inst.in
-intersections.inst.in
-)
 
 file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/cgal/*.h

--- a/source/cgal/intersections.cc
+++ b/source/cgal/intersections.cc
@@ -866,7 +866,15 @@ namespace CGALWrappers
       vertices0, vertices1, tol);
   }
 
-#  include "cgal/intersections.inst"
+// Explicit instantiations.
+//
+// We don't build the instantiations.inst file if deal.II isn't
+// configured with CGAL, but doxygen doesn't know that and tries to
+// find that file anyway for parsing -- which then of course it fails
+// on. So exclude the following from doxygen consideration.
+#  ifndef DOXYGEN
+#    include "cgal/intersections.inst"
+#  endif
 
 } // namespace CGALWrappers
 

--- a/source/cgal/surface_mesh.cc
+++ b/source/cgal/surface_mesh.cc
@@ -193,8 +193,17 @@ namespace CGALWrappers
       {
         Assert(false, ExcImpossibleInDimSpacedim(dim, spacedim));
       }
-  } // explicit instantiations
-#    include "cgal/surface_mesh.inst"
+  }
+
+// Explicit instantiations.
+//
+// We don't build the instantiations.inst file if deal.II isn't
+// configured with CGAL, but doxygen doesn't know that and tries to
+// find that file anyway for parsing -- which then of course it fails
+// on. So exclude the following from doxygen consideration.
+#    ifndef DOXYGEN
+#      include "cgal/surface_mesh.inst"
+#    endif
 
 } // namespace CGALWrappers
 #  endif


### PR DESCRIPTION
One more for #18071.