### PR TITLE
Exclude more source files if dependencies are not satisfied.

### DIFF
--- a/source/differentiation/ad/CMakeLists.txt
+++ b/source/differentiation/ad/CMakeLists.txt
@@ -12,20 +12,26 @@
 ##
 ## ------------------------------------------------------------------------
 
-set(_src
-  ad_drivers.cc
-  ad_helpers.cc
-  )
+set(_src)
+set(_inst)
 
-set(_inst
-  ad_drivers.inst.in
-  ad_drivers.inst1.in
-  ad_drivers.inst2.in
-  ad_helpers.inst.in
-  ad_helpers.inst1.in
-  ad_helpers.inst2.in
-  )
+if (DEAL_II_WITH_ADOLC OR DEAL_II_TRILINOS_WITH_SACADO)
+  set(_src
+    ${_src}
+    ad_drivers.cc
+    ad_helpers.cc
+    )
 
+  set(_inst
+    ${_inst}
+    ad_drivers.inst.in
+    ad_drivers.inst1.in
+    ad_drivers.inst2.in
+    ad_helpers.inst.in
+    ad_helpers.inst1.in
+    ad_helpers.inst2.in
+    )
+endif()
 
 if(DEAL_II_WITH_ADOLC)
   set(_src

--- a/source/differentiation/ad/ad_drivers.cc
+++ b/source/differentiation/ad/ad_drivers.cc
@@ -2171,12 +2171,18 @@ namespace Differentiation
 
 
 /* --- Explicit instantiations --- */
-#  include "differentiation/ad/ad_drivers.inst"
-#  ifdef DEAL_II_WITH_ADOLC
-#    include "differentiation/ad/ad_drivers.inst1"
-#  endif
-#  ifdef DEAL_II_TRILINOS_WITH_SACADO
-#    include "differentiation/ad/ad_drivers.inst2"
+// We don't build the .inst files if deal.II isn't configured with the
+// external dependencies, but doxygen doesn't know that and tries to
+// find that file anyway for parsing -- which then of course it fails
+// on. So exclude the following from doxygen consideration.
+#  ifndef DOXYGEN
+#    include "differentiation/ad/ad_drivers.inst"
+#    ifdef DEAL_II_WITH_ADOLC
+#      include "differentiation/ad/ad_drivers.inst1"
+#    endif
+#    ifdef DEAL_II_TRILINOS_WITH_SACADO
+#      include "differentiation/ad/ad_drivers.inst2"
+#    endif
 #  endif
 
 

--- a/source/opencascade/CMakeLists.txt
+++ b/source/opencascade/CMakeLists.txt
@@ -12,15 +12,22 @@
 ##
 ## ------------------------------------------------------------------------
 
-set(_src
-  utilities.cc
-  manifold_lib.cc
-  )
+set(_src)
+set(_inst)
 
-set(_inst
-  manifold_lib.inst.in
-  utilities.inst.in
-  )
+if (DEAL_II_WITH_OPENCASCADE)
+  set(_src
+    ${_src}
+    manifold_lib.cc
+    utilities.cc
+    )
+
+  set(_inst
+    ${_inst}
+    manifold_lib.inst.in
+    utilities.inst.in
+    )
+endif()
 
 file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/opencascade/*.h

--- a/source/opencascade/manifold_lib.cc
+++ b/source/opencascade/manifold_lib.cc
@@ -564,8 +564,13 @@ namespace OpenCASCADE
     return std::make_tuple(umin, umax, vmin, vmax);
   }
 
-// Explicit instantiations
-#  include "opencascade/manifold_lib.inst"
+// We don't build the .inst file if deal.II isn't configured
+// with GMSH, but doxygen doesn't know that and tries to find that
+// file anyway for parsing -- which then of course it fails on. So
+// exclude the following from doxygen consideration.
+#  ifndef DOXYGEN
+#    include "opencascade/manifold_lib.inst"
+#  endif
 } // end namespace OpenCASCADE
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/opencascade/utilities.cc
+++ b/source/opencascade/utilities.cc
@@ -917,7 +917,13 @@ namespace OpenCASCADE
     tria.create_triangulation(vertices, cells, t);
   }
 
-#  include "opencascade/utilities.inst"
+// We don't build the .inst file if deal.II isn't configured
+// with GMSH, but doxygen doesn't know that and tries to find that
+// file anyway for parsing -- which then of course it fails on. So
+// exclude the following from doxygen consideration.
+#  ifndef DOXYGEN
+#    include "opencascade/utilities.inst"
+#  endif
 
 } // namespace OpenCASCADE
 

--- a/source/sundials/CMakeLists.txt
+++ b/source/sundials/CMakeLists.txt
@@ -12,17 +12,25 @@
 ##
 ## ------------------------------------------------------------------------
 
-set(_src
-  arkode.cc
-  ida.cc
-  kinsol.cc
-  n_vector.cc
-  sunlinsol_wrapper.cc
-  )
 
-set(_inst
-  n_vector.inst.in
-  )
+set(_src)
+set(_inst)
+
+if (DEAL_II_WITH_SUNDIALS)
+  set(_src
+    ${_src}
+    arkode.cc
+    ida.cc
+    kinsol.cc
+    n_vector.cc
+    sunlinsol_wrapper.cc
+    )
+
+  set(_inst
+    ${_inst}
+    n_vector.inst.in
+    )
+endif()
 
 file(GLOB _header
   ${CMAKE_SOURCE_DIR}/include/deal.II/sundials/*.h

--- a/source/sundials/n_vector.cc
+++ b/source/sundials/n_vector.cc
@@ -28,7 +28,13 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-#  include "sundials/n_vector.inst"
+// We don't build the .inst file if deal.II isn't configured
+// with SUNDIALS, but doxygen doesn't know that and tries to find that
+// file anyway for parsing -- which then of course it fails on. So
+// exclude the following from doxygen consideration.
+#  ifndef DOXYGEN
+#    include "sundials/n_vector.inst"
+#  endif
 
 DEAL_II_NAMESPACE_CLOSE
 


### PR DESCRIPTION
Like in several previous patches. Part of #18071.