### PR TITLE
Simplify code.

### DIFF
--- a/source/distributed/cell_weights.cc
+++ b/source/distributed/cell_weights.cc
@@ -146,12 +146,8 @@ namespace parallel
              const typename dealii::Triangulation<dim, spacedim>::cell_iterator
                              &cell,
              const CellStatus status) -> unsigned int {
-      return CellWeights<dim, spacedim>::weighting_callback(cell,
-                                                            status,
-                                                            std::cref(
-                                                              dof_handler),
-                                                            std::cref(*tria),
-                                                            weighting_function);
+      return CellWeights<dim, spacedim>::weighting_callback(
+        cell, status, dof_handler, *tria, weighting_function);
     };
   }
 


### PR DESCRIPTION
While debugging something else, I got stuck in a place that can be simplified. The use of `std::ref/std::cref` is likely a hold-over from the time when we used `std::bind` in this place, rather than using a lambda function.