### PR TITLE
Remove empty semicolon in a few of our files

### DIFF
--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -2330,7 +2330,6 @@ FEPointEvaluationBase<n_components_, dim, spacedim, Number>::real_point(
   const unsigned int point_index) const
 {
   return quadrature_point(point_index);
-  ;
 }
 
 

--- a/include/deal.II/matrix_free/tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/tensor_product_kernels.h
@@ -906,7 +906,6 @@ namespace internal
                   {
                     const Number2 val0 = matrix[n_cols * n_columns + ind];
                     res0 += val0 * (x[ind] + x[mm - 1 - ind]);
-                    ;
                   }
                 if (mm % 2)
                   res0 += x[mid];

--- a/tests/ad_common_tests/helper_scalar_coupled_2_components_03.h
+++ b/tests/ad_common_tests/helper_scalar_coupled_2_components_03.h
@@ -202,7 +202,6 @@ test_tensor_scalar_coupled()
     ad_helper.extract_gradient_component(Dpsi, s_dof);
   std::cout << "extracted Dpsi (t): " << dpsi_dt << "\n"
             << "extracted Dpsi (s): " << dpsi_ds << "\n";
-  ;
 
   // Verify the result
   using func = FunctionsTestTensorScalarCoupled<dim, ScalarNumberType>;

--- a/tests/arpack/parpack_advection_diffusion_petsc.cc
+++ b/tests/arpack/parpack_advection_diffusion_petsc.cc
@@ -122,7 +122,6 @@ public:
   vmult(dealii::PETScWrappers::MPI::Vector       &dst,
         const dealii::PETScWrappers::MPI::Vector &src) const
   {
-    ;
     solver.solve(matrix, dst, src, preconditioner);
   }
 

--- a/tests/arpack/step-36_parpack.cc
+++ b/tests/arpack/step-36_parpack.cc
@@ -125,7 +125,6 @@ public:
   vmult(dealii::PETScWrappers::MPI::Vector       &dst,
         const dealii::PETScWrappers::MPI::Vector &src) const
   {
-    ;
     solver.solve(matrix, dst, src, preconditioner);
   }
 

--- a/tests/base/simplex.h
+++ b/tests/base/simplex.h
@@ -269,7 +269,6 @@ exact_integral_one_over_r_middle(const unsigned int i, const unsigned int j)
   if (v[0][0] == 0)
     {
       v[0][0] = 3.52549435;
-      ;
       v[1][0] = 1.76274717;
       v[2][0] = 1.07267252;
       v[3][0] = 0.727635187;

--- a/tests/bits/step-12.cc
+++ b/tests/bits/step-12.cc
@@ -476,7 +476,6 @@ DGMethod<dim>::assemble_system1()
             {
               typename DoFHandler<dim>::cell_iterator neighbor =
                 cell->neighbor(face_no);
-              ;
 
               if (face->has_children())
                 {

--- a/tests/codim_one/mapping_fe_field_01.cc
+++ b/tests/codim_one/mapping_fe_field_01.cc
@@ -82,8 +82,7 @@ test(const unsigned int refs,
   VectorTools::get_position_vector(map_dh, euler_vec);
 
   MappingFEField<dim, spacedim> mapping(map_dh, euler_vec);
-  ;
-  DataOut<dim, spacedim> data_out_scal;
+  DataOut<dim, spacedim>        data_out_scal;
   data_out_scal.attach_dof_handler(dof_handler);
 
   data_out_scal.add_data_vector(scal_sol,

--- a/tests/dofs/block_list_04.cc
+++ b/tests/dofs/block_list_04.cc
@@ -32,7 +32,6 @@ test_block_list(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
     SparsityPattern bl(tr.n_cells(level - 1),
                        dof.n_dofs(level),
                        (1 << dim) * fe.dofs_per_cell);
-    ;
     DoFTools::make_child_patches(bl, dof, level, false, false);
     bl.compress();
     print_patches(bl);
@@ -44,7 +43,6 @@ test_block_list(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
     SparsityPattern bl(tr.n_cells(level - 1),
                        dof.n_dofs(level),
                        (1 << dim) * fe.dofs_per_cell);
-    ;
     DoFTools::make_child_patches(bl, dof, level, true, false);
     bl.compress();
     print_patches(bl);
@@ -56,7 +54,6 @@ test_block_list(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
     SparsityPattern bl(tr.n_cells(level - 1),
                        dof.n_dofs(level),
                        (1 << dim) * fe.dofs_per_cell);
-    ;
     DoFTools::make_child_patches(bl, dof, level, true, true);
     bl.compress();
     print_patches(bl);

--- a/tests/fe/fe_tools_block_renumbering.cc
+++ b/tests/fe/fe_tools_block_renumbering.cc
@@ -35,7 +35,6 @@ logvec(const std::vector<types::global_dof_index> &v,
   for (unsigned int i = 0; i < w.size(); ++i)
     deallog << ' ' << w[i];
   deallog << " ]" << std::endl << '[';
-  ;
   for (unsigned int i = 0; i < v.size(); ++i)
     deallog << ' ' << v[i];
   deallog << " ]" << std::endl;

--- a/tests/grid/filtered_iterator_04.cc
+++ b/tests/grid/filtered_iterator_04.cc
@@ -81,7 +81,6 @@ main()
   test();
 
   deallog << "OK" << std::endl;
-  ;
 
   return 0;
 }

--- a/tests/grid/filtered_iterator_04_operator.cc
+++ b/tests/grid/filtered_iterator_04_operator.cc
@@ -83,7 +83,6 @@ main()
   test();
 
   deallog << "OK" << std::endl;
-  ;
 
   return 0;
 }

--- a/tests/hp/step-12.cc
+++ b/tests/hp/step-12.cc
@@ -552,7 +552,6 @@ DGMethod<dim>::assemble_system1()
             {
               typename DoFHandler<dim>::cell_iterator neighbor =
                 cell->neighbor(face_no);
-              ;
 
               if (face->has_children())
                 {

--- a/tests/lac/block_linear_operator_04.cc
+++ b/tests/lac/block_linear_operator_04.cc
@@ -82,7 +82,6 @@ main()
         for (unsigned int i = 0; i < 3; ++i)
           {
             u.block(i)[0] = 0;
-            ;
             v.block(i)[0] = 0;
           }
         u.block(j)[0] = 1;
@@ -103,7 +102,6 @@ main()
             v.block(i)[0] = 0;
           }
         u.block(j)[0] = 1;
-        ;
 
         inverse_op_a.vmult(v, u);
 
@@ -118,11 +116,9 @@ main()
         for (unsigned int i = 0; i < 3; ++i)
           {
             u.block(i)[0] = 0;
-            ;
             v.block(i)[0] = 0;
           }
         u.block(j)[0] = 1;
-        ;
 
         identity.vmult(v, u);
 
@@ -175,7 +171,6 @@ main()
         for (unsigned int i = 0; i < 3; ++i)
           {
             u.block(i)[0] = 0;
-            ;
             v.block(i)[0] = 0;
           }
         u.block(j)[0] = 1;
@@ -196,7 +191,6 @@ main()
             v.block(i)[0] = 0;
           }
         u.block(j)[0] = 1;
-        ;
 
         inverse_op_a.vmult(v, u);
 
@@ -211,11 +205,9 @@ main()
         for (unsigned int i = 0; i < 3; ++i)
           {
             u.block(i)[0] = 0;
-            ;
             v.block(i)[0] = 0;
           }
         u.block(j)[0] = 1;
-        ;
 
         identity.vmult(v, u);
 

--- a/tests/lac/gmres_eigenvalues_02.cc
+++ b/tests/lac/gmres_eigenvalues_02.cc
@@ -28,8 +28,7 @@ void
 test()
 {
   const unsigned int n = 2;
-  ;
-  Vector<number> rhs(n), sol(n);
+  Vector<number>     rhs(n), sol(n);
   rhs = 0.;
 
   LAPACKFullMatrix<number> matrix(n, n);

--- a/tests/manifold/spherical_manifold_01.cc
+++ b/tests/manifold/spherical_manifold_01.cc
@@ -40,7 +40,6 @@ main()
     Point<2> Q = manifold.get_intermediate_point(P1, P2, .5);
 
     deallog << "=================================" << std::endl;
-    ;
     deallog << manifold.get_intermediate_point(P1, P2, .125) << std::endl;
     deallog << manifold.get_intermediate_point(P1, P2, .25) << std::endl;
     deallog << manifold.get_intermediate_point(P1, P2, .375) << std::endl;
@@ -69,7 +68,6 @@ main()
     Point<2> Q = manifold.get_intermediate_point(P1, P2, .5);
 
     deallog << "=================================" << std::endl;
-    ;
     deallog << manifold.get_intermediate_point(P1, P2, .125) << std::endl;
     deallog << manifold.get_intermediate_point(P1, P2, .25) << std::endl;
     deallog << manifold.get_intermediate_point(P1, P2, .375) << std::endl;
@@ -98,7 +96,6 @@ main()
     Point<3> Q = manifold.get_intermediate_point(P1, P2, .5);
 
     deallog << "=================================" << std::endl;
-    ;
     deallog << manifold.get_intermediate_point(P1, P2, .125) << std::endl;
     deallog << manifold.get_intermediate_point(P1, P2, .25) << std::endl;
     deallog << manifold.get_intermediate_point(P1, P2, .375) << std::endl;
@@ -128,7 +125,6 @@ main()
 
     const unsigned int num_points = 20;
     deallog << "=================================" << std::endl;
-    ;
     for (unsigned int i = 0; i < num_points; ++i)
       deallog << manifold.get_intermediate_point(P1,
                                                  P2,
@@ -178,7 +174,6 @@ main()
     Point<3> R = manifold.get_intermediate_point(P5, P4, 2.0 / 3.0);
 
     deallog << "=================================" << std::endl;
-    ;
     deallog << Q << std::endl;
     deallog << S << std::endl;
     deallog << T << std::endl;

--- a/tests/mpi/petsc_bug_ghost_vector_01.cc
+++ b/tests/mpi/petsc_bug_ghost_vector_01.cc
@@ -102,14 +102,13 @@ test()
     const unsigned int solid_cells_x = 20;
     const unsigned int solid_cells_y = 1;
     const unsigned int v_space_cells = 5;
-    ;
-    const double cell_size_x = 0.1;
-    const double cell_size_y = 0.1;
-    const double length      = solid_cells_x * cell_size_x,
-                 height      = static_cast<double>(h_cells * cell_size_y),
-                 h_distance  = static_cast<double>(cell_size_x * inflow_cells),
-                 v_distance  = static_cast<double>(cell_size_y * v_space_cells),
-                 solid_top   = static_cast<double>(v_distance +
+    const double       cell_size_x   = 0.1;
+    const double       cell_size_y   = 0.1;
+    const double       length        = solid_cells_x * cell_size_x,
+                 height     = static_cast<double>(h_cells * cell_size_y),
+                 h_distance = static_cast<double>(cell_size_x * inflow_cells),
+                 v_distance = static_cast<double>(cell_size_y * v_space_cells),
+                 solid_top  = static_cast<double>(v_distance +
                                                  solid_cells_y * cell_size_y),
                  total_length =
                    (inflow_cells + solid_cells_x + outflow_cells) * cell_size_x;

--- a/tests/simplex/step-12b.cc
+++ b/tests/simplex/step-12b.cc
@@ -575,7 +575,6 @@ DGMethod<dim>::assemble_system1()
             {
               typename DoFHandler<dim>::cell_iterator neighbor =
                 cell->neighbor(face_no);
-              ;
 
               if (face->has_children())
                 {

--- a/tests/symengine/symengine_scalar_operations_04.cc
+++ b/tests/symengine/symengine_scalar_operations_04.cc
@@ -39,7 +39,6 @@ test()
     deallog << "symbolic a/b: " << symb_a_division_b << std::endl;
 
     const SD_number_t a_division_symb_b = a / symb_b;
-    ;
     deallog << "a/symbolic b: " << a_division_symb_b << std::endl;
 
     const SD_number_t substitute_symb_a_division_b =
@@ -56,7 +55,6 @@ test()
     deallog << "symbolic a*b: " << symb_a_product_b << std::endl;
 
     const SD_number_t a_product_symb_b = a * symb_b;
-    ;
     deallog << "a*symbolic b: " << a_product_symb_b << std::endl;
 
     const SD_number_t substitute_symb_a_product_b =

--- a/tests/trilinos_tpetra/vector_reference_01.cc
+++ b/tests/trilinos_tpetra/vector_reference_01.cc
@@ -68,7 +68,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
   initlog();
-  ;
 
   test();
 }


### PR DESCRIPTION
Looking at a file, I observed a stray semicolon `;` in a line. I then made a search by grep and removed all similar occurrences. I tried to make sure that I did not eat up any code of the form
```
for (...)
  ;
```
Let's see if the testers agree with me.