### PR TITLE
Use explicit constructor for iota_view.

### DIFF
--- a/include/deal.II/base/geometry_info.h
+++ b/include/deal.II/base/geometry_info.h
@@ -2961,7 +2961,8 @@ template <int dim>
 inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
 GeometryInfo<dim>::face_indices()
 {
-  return {0U, faces_per_cell};
+  return std_cxx20::ranges::iota_view<unsigned int, unsigned int>(
+    0U, faces_per_cell);
 }
 
 
@@ -2970,7 +2971,8 @@ template <int dim>
 inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
 GeometryInfo<dim>::vertex_indices()
 {
-  return {0U, vertices_per_cell};
+  return std_cxx20::ranges::iota_view<unsigned int, unsigned int>(
+    0U, vertices_per_cell);
 }
 
 

--- a/include/deal.II/fe/fe_interface_values.h
+++ b/include/deal.II/fe/fe_interface_values.h
@@ -2789,7 +2789,8 @@ template <int dim, int spacedim>
 inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
 FEInterfaceValues<dim, spacedim>::quadrature_point_indices() const
 {
-  return {0U, n_quadrature_points};
+  return std_cxx20::ranges::iota_view<unsigned int, unsigned int>(
+    0U, n_quadrature_points);
 }
 
 

--- a/include/deal.II/fe/fe_values_base.h
+++ b/include/deal.II/fe/fe_values_base.h
@@ -2349,7 +2349,8 @@ template <int dim, int spacedim>
 inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
 FEValuesBase<dim, spacedim>::dof_indices() const
 {
-  return {0U, dofs_per_cell};
+  return std_cxx20::ranges::iota_view<unsigned int, unsigned int>(
+    0U, dofs_per_cell);
 }
 
 
@@ -2361,7 +2362,8 @@ FEValuesBase<dim, spacedim>::dof_indices_starting_at(
 {
   Assert(start_dof_index <= dofs_per_cell,
          ExcIndexRange(start_dof_index, 0, dofs_per_cell + 1));
-  return {start_dof_index, dofs_per_cell};
+  return std_cxx20::ranges::iota_view<unsigned int, unsigned int>(
+    start_dof_index, dofs_per_cell);
 }
 
 
@@ -2373,7 +2375,8 @@ FEValuesBase<dim, spacedim>::dof_indices_ending_at(
 {
   Assert(end_dof_index < dofs_per_cell,
          ExcIndexRange(end_dof_index, 0, dofs_per_cell));
-  return {0U, end_dof_index + 1};
+  return std_cxx20::ranges::iota_view<unsigned int, unsigned int>(
+    0U, end_dof_index + 1);
 }
 
 
@@ -2382,7 +2385,8 @@ template <int dim, int spacedim>
 inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
 FEValuesBase<dim, spacedim>::quadrature_point_indices() const
 {
-  return {0U, n_quadrature_points};
+  return std_cxx20::ranges::iota_view<unsigned int, unsigned int>(
+    0U, n_quadrature_points);
 }
 
 

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -1934,7 +1934,8 @@ ReferenceCell::n_faces() const
 inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
 ReferenceCell::face_indices() const
 {
-  return {0U, n_faces()};
+  return std_cxx20::ranges::iota_view<unsigned int, unsigned int>(0U,
+                                                                  n_faces());
 }
 
 
@@ -2050,7 +2051,8 @@ ReferenceCell::n_children(const RefinementCase<dim> ref_case) const
 inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
 ReferenceCell::isotropic_child_indices() const
 {
-  return {0U, n_isotropic_children()};
+  return std_cxx20::ranges::iota_view<unsigned int, unsigned int>(
+    0U, n_isotropic_children());
 }
 
 
@@ -2058,7 +2060,8 @@ ReferenceCell::isotropic_child_indices() const
 inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
 ReferenceCell::vertex_indices() const
 {
-  return {0U, n_vertices()};
+  return std_cxx20::ranges::iota_view<unsigned int, unsigned int>(0U,
+                                                                  n_vertices());
 }
 
 
@@ -2066,7 +2069,8 @@ ReferenceCell::vertex_indices() const
 inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
 ReferenceCell::line_indices() const
 {
-  return {0U, n_lines()};
+  return std_cxx20::ranges::iota_view<unsigned int, unsigned int>(0U,
+                                                                  n_lines());
 }
 
 

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -6592,7 +6592,8 @@ template <int structdim, int dim, int spacedim>
 std_cxx20::ranges::iota_view<unsigned int, unsigned int>
 TriaAccessor<structdim, dim, spacedim>::vertex_indices() const
 {
-  return {0U, n_vertices()};
+  return std_cxx20::ranges::iota_view<unsigned int, unsigned int>(0U,
+                                                                  n_vertices());
 }
 
 
@@ -6601,7 +6602,8 @@ template <int structdim, int dim, int spacedim>
 std_cxx20::ranges::iota_view<unsigned int, unsigned int>
 TriaAccessor<structdim, dim, spacedim>::line_indices() const
 {
-  return {0U, n_lines()};
+  return std_cxx20::ranges::iota_view<unsigned int, unsigned int>(0U,
+                                                                  n_lines());
 }
 
 
@@ -6610,7 +6612,8 @@ template <int structdim, int dim, int spacedim>
 std_cxx20::ranges::iota_view<unsigned int, unsigned int>
 TriaAccessor<structdim, dim, spacedim>::face_indices() const
 {
-  return {0U, n_faces()};
+  return std_cxx20::ranges::iota_view<unsigned int, unsigned int>(0U,
+                                                                  n_faces());
 }
 
 
@@ -7530,7 +7533,8 @@ template <int spacedim>
 std_cxx20::ranges::iota_view<unsigned int, unsigned int>
 TriaAccessor<0, 1, spacedim>::vertex_indices() const
 {
-  return {0U, n_vertices()};
+  return std_cxx20::ranges::iota_view<unsigned int, unsigned int>(0U,
+                                                                  n_vertices());
 }
 
 
@@ -7539,7 +7543,8 @@ template <int spacedim>
 std_cxx20::ranges::iota_view<unsigned int, unsigned int>
 TriaAccessor<0, 1, spacedim>::line_indices() const
 {
-  return {0U, n_lines()};
+  return std_cxx20::ranges::iota_view<unsigned int, unsigned int>(0U,
+                                                                  n_lines());
 }
 
 /*------------------ Functions: CellAccessor<dim,spacedim> ------------------*/

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -7210,7 +7210,8 @@ FEEvaluation<dim,
              Number,
              VectorizedArrayType>::dof_indices() const
 {
-  return {0U, dofs_per_cell};
+  return std_cxx20::ranges::iota_view<unsigned int, unsigned int>(
+    0U, dofs_per_cell);
 }
 
 
@@ -8240,7 +8241,8 @@ FEFaceEvaluation<dim,
                  Number,
                  VectorizedArrayType>::dof_indices() const
 {
-  return {0U, dofs_per_cell};
+  return std_cxx20::ranges::iota_view<unsigned int, unsigned int>(
+    0U, dofs_per_cell);
 }
 
 

--- a/include/deal.II/matrix_free/fe_evaluation_data.h
+++ b/include/deal.II/matrix_free/fe_evaluation_data.h
@@ -1653,7 +1653,8 @@ template <int dim, typename Number, bool is_face>
 inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
 FEEvaluationData<dim, Number, is_face>::quadrature_point_indices() const
 {
-  return {0U, n_quadrature_points};
+  return std_cxx20::ranges::iota_view<unsigned int, unsigned int>(
+    0U, n_quadrature_points);
 }
 
 

--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -2370,7 +2370,8 @@ inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
 FEPointEvaluationBase<n_components_, dim, spacedim, Number>::
   quadrature_point_indices() const
 {
-  return {0U, n_q_points};
+  return std_cxx20::ranges::iota_view<unsigned int, unsigned int>(0U,
+                                                                  n_q_points);
 }
 
 

--- a/source/base/mpi_remote_point_evaluation.cc
+++ b/source/base/mpi_remote_point_evaluation.cc
@@ -278,7 +278,8 @@ namespace Utilities
     std_cxx20::ranges::iota_view<unsigned int, unsigned int>
     RemotePointEvaluation<dim, spacedim>::CellData::cell_indices() const
     {
-      return {0, static_cast<unsigned int>(cells.size())};
+      return std_cxx20::ranges::iota_view<unsigned int, unsigned int>(
+        0, static_cast<unsigned int>(cells.size()));
     }
 
 


### PR DESCRIPTION
This is a bit of a nuisance. The standard in https://en.cppreference.com/w/cpp/ranges/iota_view/iota_view says that the constructors of `std::ranges::iota_view` are `explicit`. An explicit constructor taking multiple arguments cannot be used for list construction: https://en.cppreference.com/w/cpp/language/explicit, in the example the line that reads
```
//  B b4 = {4, 5}; // error: copy-list-initialization does not consider B::B(int, int)
```
This means that we cannot have return statements like this here:
```
std::ranges::iota_view<...>  indices() {
  return {0, N};  // not allowed
```
Apparently, the GCC standard library does not mark the constructor as `explicit`, and so our code compiles fine with GCC and with Clang when using GCC's standard library as it usually does. But it fails if we use Clang with libc++ (its own standard library). This patch fixes that.

Found while poking around for #18071.