### PR TITLE
Add missing #include.

### DIFF
--- a/source/dofs/dof_accessor_set.cc
+++ b/source/dofs/dof_accessor_set.cc
@@ -32,6 +32,7 @@
 #include <deal.II/lac/trilinos_vector.h>
 #include <deal.II/lac/vector.h>
 
+#include <iomanip>
 #include <limits>
 #include <vector>
 


### PR DESCRIPTION
We use `std::setprecision()` in this file. The corresponding `#include` was missing. The addition is in the same spirit as in #18091, #18118, and #18130. In pursuit of #18071.