### PR TITLE
Fix a missing #include.

### DIFF
--- a/include/deal.II/lac/full_matrix.templates.h
+++ b/include/deal.II/lac/full_matrix.templates.h
@@ -36,6 +36,7 @@
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
+#include <iomanip>
 #include <limits>
 #include <vector>
 


### PR DESCRIPTION
Same as in #18160. The addition is in the same spirit as in https://github.com/dealii/dealii/pull/18091, https://github.com/dealii/dealii/pull/18118, and https://github.com/dealii/dealii/pull/18130. In pursuit of https://github.com/dealii/dealii/issues/18071.