### PR TITLE
Add another missing #include.

### DIFF
--- a/source/base/table_handler.cc
+++ b/source/base/table_handler.cc
@@ -21,6 +21,7 @@
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+#include <variant>
 
 
 DEAL_II_NAMESPACE_OPEN


### PR DESCRIPTION
Like several others recently. We use `std::visit` here, which is declared in `<variant>`.

Part of #18071.