### PR TITLE
github: Include OS version in Windows job name.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,8 +25,8 @@ env:
 jobs:
   windows-serial:
     # Serial build on Windows
-    #
-    name: Windows Serial
+
+    name: ${{ matrix.os }} serial
     runs-on: ${{ matrix.os }}
 
     #


### PR DESCRIPTION
Extracted from #18099.

Clean up the previous `github-windows / Windows Serial (windows-20XX)` names into a more compact `github-windows / windows-20XX serial` name.