### PR TITLE
Tutorial: List step-76 as Euler problem

### DIFF
--- a/doc/doxygen/tutorial/tutorial.h.in
+++ b/doc/doxygen/tutorial/tutorial.h.in
@@ -1274,7 +1274,8 @@
  *     <td>
  *       step-33,
  *       step-67,
- *       step-69
+ *       step-69,
+ *       step-76
  *     </td>
  *   </tr>
  *
@@ -1426,7 +1427,8 @@
  *     <td>
  *       step-33,
  *       step-67,
- *       step-69
+ *       step-69,
+ *       step-76
  *     </td>
  *   </tr>
  *
@@ -1493,7 +1495,8 @@
  *     <td>
  *       step-33,
  *       step-67,
- *       step-69
+ *       step-69,
+ *       step-76
  *     </td>
  *   </tr>
  *


### PR DESCRIPTION
Checking for an example of Euler equations, I realized that our tutorial page https://www.dealii.org/developer/doxygen/deal.II/Tutorial.html does not list step-76 as a solver for the Euler equations. Fix that.