### PR TITLE
github: Build noble docker image.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ubuntu_version: [jammy]
+        ubuntu_version: [jammy, noble]
         platform: [linux/amd64]
         # Use only 2 jobs to build, as more jobs
         # would starve the github machine for memory.
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ubuntu_version: [jammy]
+        ubuntu_version: [jammy, noble]
 
     steps:
       - name: Download digests


### PR DESCRIPTION
@tjhei @luca-heltai, referring to https://github.com/dealii/dealii/pull/18099#issuecomment-2685497512. -- Does `dealiibot` on Jenkins need to be adjusted to merge noble images? We might no longer need the external merge with #18172.