### PR TITLE
Assert: Avoid warnings about unused variables before C++20

### DIFF
--- a/include/deal.II/base/exception_macros.h
+++ b/include/deal.II/base/exception_macros.h
@@ -636,10 +636,13 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
         }                                                      \
       while (false)
 #  else
-#    define Assert(cond, exc) \
-      do                      \
-        {                     \
-        }                     \
+#    define Assert(cond, exc)  \
+      do                       \
+        {                      \
+          if constexpr (false) \
+            if (!(cond))       \
+              ;                \
+        }                      \
       while (false)
 #  endif
 #endif /*ifdef DEBUG*/


### PR DESCRIPTION
Fixes https://github.com/dealii/dealii/pull/18057#issuecomment-2694725349.