### PR TITLE
Fix empty-body warning for Assert macros.

### DIFF
--- a/include/deal.II/base/exception_macros.h
+++ b/include/deal.II/base/exception_macros.h
@@ -641,7 +641,9 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
         {                      \
           if constexpr (false) \
             if (!(cond))       \
-              ;                \
+              {                \
+                ;              \
+              }                \
         }                      \
       while (false)
 #  endif


### PR DESCRIPTION
Follow-up to #18188. FYI - @masterleinad

This fixes warnings of the type
```
/usr/src/dealii-master/include/deal.II/dofs/dof_handler.h:1880:3: note: in expansion of macro ‘Assert’
 1880 |   Assert(level < this->get_triangulation().n_global_levels(),
      |   ^~~~~~
/usr/src/dealii-master/include/deal.II/base/exception_macros.h:644:15: warning: suggest braces around empty body in an ‘if’ statement [-Wempty-body]
 644 |               ;                \
     |               ^
```