### PR TITLE
Explicitly disable mold in failing builds using Docker containers

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -65,6 +65,7 @@ jobs:
         mkdir build
         cd build
         cmake -D CMAKE_BUILD_TYPE=Release \
+              -D DEAL_II_COMPILER_HAS_FUSE_LD_MOLD=OFF \
               -D DEAL_II_CXX_FLAGS='-Werror -std=c++20' \
               -D DEAL_II_EARLY_DEPRECATIONS=ON \
               -DDEAL_II_COMPONENT_PYTHON_BINDINGS=ON \
@@ -122,6 +123,7 @@ jobs:
         mkdir build
         cd build
         cmake -D CMAKE_BUILD_TYPE=Debug \
+              -D DEAL_II_COMPILER_HAS_FUSE_LD_MOLD=OFF \
               -D DEAL_II_CXX_FLAGS='-Werror -std=c++20' \
               -D DEAL_II_EARLY_DEPRECATIONS=ON \
               -D DEAL_II_WITH_MPI="ON" \
@@ -190,6 +192,7 @@ jobs:
         mkdir build
         cd build
         cmake -D CMAKE_BUILD_TYPE=Debug \
+              -D DEAL_II_COMPILER_HAS_FUSE_LD_MOLD=OFF \
               -D DEAL_II_CXX_FLAGS='-std=c++20' \
               -D DEAL_II_EARLY_DEPRECATIONS=ON \
               -D DEAL_II_WITH_64BIT_INDICES="ON" \


### PR DESCRIPTION
We can reenable it once we have figured out why it's problematic to take the version from the images.