### PR TITLE
Un-hardcode some default orientation values.

### DIFF
--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -7326,7 +7326,7 @@ inline types::geometric_orientation
 TriaAccessor<0, 1, spacedim>::combined_face_orientation(
   const unsigned int /*face*/)
 {
-  return 0;
+  return numbers::reverse_line_orientation;
 }
 
 

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -515,14 +515,18 @@ namespace internal
                   unsigned int d = 0;
                   for (; d < dim; ++d)
                     face_to_cell_index_nodal[face][d] =
-                      reference_cell.face_to_cell_vertices(face, d, 1);
+                      reference_cell.face_to_cell_vertices(
+                        face, d, numbers::default_geometric_orientation);
 
                   // now fill the rest of the indices, start with the lines
                   if (fe.degree == 2)
                     for (; d < dofs_per_component_on_face; ++d)
                       face_to_cell_index_nodal[face][d] =
                         reference_cell.n_vertices() +
-                        reference_cell.face_to_cell_lines(face, d - dim, 1);
+                        reference_cell.face_to_cell_lines(
+                          face,
+                          d - dim,
+                          numbers::default_geometric_orientation);
 
                   // in the cubic case it is more complicated as more DoFs are
                   // on the lines
@@ -533,15 +537,19 @@ namespace internal
                            ++line, d += 2)
                         {
                           const unsigned int face_to_cell_lines =
-                            reference_cell.face_to_cell_lines(face, line, 1);
+                            reference_cell.face_to_cell_lines(
+                              face,
+                              line,
+                              numbers::default_geometric_orientation);
                           // check the direction of the line
                           // is it 0 -> 1 or 1 -> 0
                           // as DoFs on the line are ordered differently
                           if (reference_cell.line_to_cell_vertices(
                                 face_to_cell_lines, 0) ==
-                              reference_cell.face_to_cell_vertices(face,
-                                                                   line,
-                                                                   1))
+                              reference_cell.face_to_cell_vertices(
+                                face,
+                                line,
+                                numbers::default_geometric_orientation))
                             {
                               face_to_cell_index_nodal[face][d] =
                                 reference_cell.n_vertices() +

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -3844,7 +3844,7 @@ namespace
                      ++j)
                   boundary_line.vertices[j] =
                     cell.vertices[cell_type.face_to_cell_vertices(
-                      deal_face_n, j, 0)];
+                      deal_face_n, j, numbers::default_geometric_orientation)];
 
                 subcelldata.boundary_lines.push_back(std::move(boundary_line));
               }
@@ -3859,7 +3859,7 @@ namespace
                      ++j)
                   boundary_quad.vertices[j] =
                     cell.vertices[cell_type.face_to_cell_vertices(
-                      deal_face_n, j, 0)];
+                      deal_face_n, j, numbers::default_geometric_orientation)];
 
                 subcelldata.boundary_quads.push_back(std::move(boundary_quad));
               }

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -7003,9 +7003,10 @@ namespace internal
                          c < GeometryInfo<dim>::max_children_per_cell;
                          ++c)
                       {
-                        auto &new_hex = new_hexes[c];
+                        auto      &new_hex        = new_hexes[c];
+                        const auto reference_cell = new_hex->reference_cell();
 
-                        if (new_hex->n_faces() == 4)
+                        if (reference_cell == ReferenceCells::Tetrahedron)
                           {
                             new_hex->set_bounding_object_indices(
                               {quad_indices[cell_quads[c][0]],
@@ -7042,27 +7043,24 @@ namespace internal
 
                                 // arrange after vertices of the faces of the
                                 // unit cell
-                                const std::array<unsigned int, 3> vertices_1 = {
+                                std::array<unsigned int, 3> vertices_1;
+                                for (unsigned int face_vertex_no :
+                                     face->vertex_indices())
                                   {
-                                    vertex_indices
-                                      [new_hex_vertices
-                                         [ReferenceCells::Tetrahedron
-                                            .face_to_cell_vertices(f, 0, 1)]],
-                                    vertex_indices
-                                      [new_hex_vertices
-                                         [ReferenceCells::Tetrahedron
-                                            .face_to_cell_vertices(f, 1, 1)]],
-                                    vertex_indices
-                                      [new_hex_vertices
-                                         [ReferenceCells::Tetrahedron
-                                            .face_to_cell_vertices(f, 2, 1)]],
-                                  }};
+                                    const auto cell_vertex_no =
+                                      reference_cell.face_to_cell_vertices(
+                                        f,
+                                        face_vertex_no,
+                                        numbers::default_geometric_orientation);
+                                    vertices_1[face_vertex_no] = vertex_indices
+                                      [new_hex_vertices[cell_vertex_no]];
+                                  }
 
                                 new_hex->set_combined_face_orientation(
                                   f,
                                   face->reference_cell()
                                     .get_combined_orientation(
-                                      make_array_view(vertices_1),
+                                      make_const_array_view(vertices_1),
                                       make_array_view(vertices_0)));
                               }
                           }


### PR DESCRIPTION
While we're at it, make a loop more legible.

Part of #14667.