### PR TITLE
Do not include <mpi.h> from config.h.

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -660,16 +660,6 @@ _Pragma("GCC diagnostic pop")
  */
 
 /*
- * Some systems require including mpi.h before stdio.h which happens in
- * base/types.h and perhaps other places. So just include it unconditionally.
- */
-#if defined(DEAL_II_WITH_MPI)
-DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
-#  include <mpi.h>
-DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
-#endif
-
-/*
  * Include the boost version header to do a quick version check in case, by
  * accident, we have configured with one version of boost but are compiling
  * either the library or an external application with a different version of

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -35,7 +35,9 @@
 #include <vector>
 
 #ifdef DEAL_II_WITH_MPI
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <mpi.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #endif
 
 

--- a/include/deal.II/base/mpi_large_count.h
+++ b/include/deal.II/base/mpi_large_count.h
@@ -26,9 +26,11 @@
 #include <deal.II/base/config.h>
 
 #ifdef DEAL_II_WITH_MPI
+
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <mpi.h>
-// required for std::numeric_limits used below.
-#  include <limits>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
+
 #  ifndef MPI_VERSION
 #    error "Your MPI implementation does not define MPI_VERSION!"
 #  endif
@@ -36,6 +38,10 @@
 #  if MPI_VERSION < 3
 #    error "BigMPICompat requires at least MPI 3.0"
 #  endif
+
+
+// required for std::numeric_limits used below.
+#  include <limits>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/base/mpi_stub.h
+++ b/include/deal.II/base/mpi_stub.h
@@ -22,7 +22,9 @@
 // e.g., MPI_Comm in the API.
 
 #if defined(DEAL_II_WITH_MPI)
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <mpi.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #else
 
 // Without MPI, we would still like to use some constructs with MPI

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -34,7 +34,9 @@
 #include <memory>
 
 #if defined(DEAL_II_WITH_MPI)
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <mpi.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #endif
 
 

--- a/source/base/exceptions.cc
+++ b/source/base/exceptions.cc
@@ -24,7 +24,9 @@
 #include <string>
 
 #ifdef DEAL_II_WITH_MPI
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <mpi.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #endif
 
 #ifdef DEAL_II_TRILINOS_WITH_SEACAS

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -34,7 +34,9 @@
 #include <vector>
 
 #if defined(DEAL_II_WITH_MPI)
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <mpi.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #endif
 
 

--- a/tests/base/mpi_exceptions.cc
+++ b/tests/base/mpi_exceptions.cc
@@ -17,8 +17,7 @@
 // exception messages to the screen.
 
 #include <deal.II/base/exceptions.h>
-
-#include <mpi.h>
+#include <deal.II/base/mpi.h>
 
 #include <vector>
 

--- a/tests/mpi/petsc_01.cc
+++ b/tests/mpi/petsc_01.cc
@@ -19,14 +19,13 @@
 // rows that are emptied with clear_rows(). This results in errors
 // when reusing the matrix later.
 
+#include <deal.II/base/mpi.h>
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/petsc_sparse_matrix.h>
 
 #include "../tests.h"
-
-// #include <mpi.h>
 
 
 void

--- a/tests/mpi/petsc_02.cc
+++ b/tests/mpi/petsc_02.cc
@@ -18,14 +18,13 @@
 // does matrix-assembly, it calls compress() inside and the others don't.
 // We should implement this like in PETSc::MPI::Vector.
 
+#include <deal.II/base/mpi.h>
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/petsc_sparse_matrix.h>
 
 #include "../tests.h"
-
-// #include <mpi.h>
 
 
 void

--- a/tests/mpi/petsc_03.cc
+++ b/tests/mpi/petsc_03.cc
@@ -17,6 +17,7 @@
 // PETScWrappers: document bug when using GrowingVectorMemory
 // at the end of a run.
 
+#include <deal.II/base/mpi.h>
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/lac/petsc_block_vector.h>
@@ -25,7 +26,6 @@
 
 #include "../tests.h"
 
-// #include <mpi.h>
 
 template <class v>
 void

--- a/tests/mpi/refine_and_coarsen_fixed_number_06.cc
+++ b/tests/mpi/refine_and_coarsen_fixed_number_06.cc
@@ -40,7 +40,7 @@
 #include <deal.II/lac/vector.h>
 
 #include "../tests.h"
-// #include <mpi.h>
+
 
 template <int dim>
 void

--- a/tests/mpi/simple_mpi_01.cc
+++ b/tests/mpi/simple_mpi_01.cc
@@ -16,11 +16,10 @@
 
 // check if mpi is working
 
+#include <deal.II/base/mpi.h>
 #include <deal.II/base/utilities.h>
 
 #include "../tests.h"
-
-// #include <mpi.h>
 
 
 void

--- a/tests/mpi/trilinos_bug_5609.cc
+++ b/tests/mpi/trilinos_bug_5609.cc
@@ -18,11 +18,11 @@
 // Trilinos bug 5609 is indeed fixed, see
 //   http://software.sandia.gov/bugzilla/show_bug.cgi?id=5609
 
+#include <deal.II/base/mpi.h>
 
 #include <Epetra_FEVector.h>
 #include <Epetra_Map.h>
 #include <Epetra_MpiComm.h>
-#include <mpi.h>
 
 #include <iostream>
 

--- a/tests/quick_tests/mpi.cc
+++ b/tests/quick_tests/mpi.cc
@@ -15,9 +15,10 @@
 // test that MPI is working correctly. Note that this test expects to
 // be executed with exactly two threads.
 
+#include <deal.II/base/mpi.h>
+
 #include <deal.II/grid/tria.h>
 
-#include <mpi.h>
 #include <sched.h>
 
 #include <iostream>

--- a/tests/sundials/n_vector.cc
+++ b/tests/sundials/n_vector.cc
@@ -16,6 +16,7 @@
 // are created by calling NVectorView on one of the internal vector types.
 
 #include <deal.II/base/logstream.h>
+#include <deal.II/base/mpi.h>
 
 #include <deal.II/lac/block_vector.h>
 #include <deal.II/lac/la_parallel_block_vector.h>
@@ -25,10 +26,6 @@
 
 #include <deal.II/sundials/n_vector.h>
 #include <deal.II/sundials/n_vector.templates.h>
-
-#ifdef DEAL_II_WITH_MPI
-#  include <mpi.h>
-#endif
 
 #include "../tests.h"
 

--- a/tests/trilinos/renumbering_01.cc
+++ b/tests/trilinos/renumbering_01.cc
@@ -15,6 +15,7 @@
 // Test that dof renumbering is also reflected in TrilinosWrappers::SparseMatrix
 
 #include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/mpi.h>
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/distributed/shared_tria.h>
@@ -37,8 +38,6 @@
 
 #include <deal.II/numerics/matrix_tools.h>
 #include <deal.II/numerics/vector_tools.h>
-
-#include <mpi.h>
 
 #include <iostream>
 #include <vector>


### PR DESCRIPTION
As mentioned elsewhere related to #18071, header files and macros do not go well with modules. As a consequence, one of the things I will need to do is avoid `#include` statements in `config.h` and make sure that that file really only provides macro definitions plus perhaps a fairly minimal set of C++ symbols.

One of the things we `#include` in `config.h` is `<mpi.h>`, to work around an issue with the Intel compiler. This patch undoes #271, which was necessary in 2014. I don't know whether that's still a problem, but if it is, I need to find a different way to work around this. Let's see what happens.