### PR TITLE
Move an #include statement.

### DIFF
--- a/include/deal.II/base/exception_macros.h
+++ b/include/deal.II/base/exception_macros.h
@@ -17,26 +17,6 @@
 
 #include <deal.II/base/config.h>
 
-// The #defines of the Assert* macros below reference functions and
-// classes that are declared in exceptions.h. This is ok -- places
-// that use the Assert macro (for example) simply have to #include
-// <deal.II/base/exceptions.h> or, in the case of C++20 modules, use
-// the fact that we let exceptions.h export this stuff into the dealii
-// module. But the exception machinery also references Kokkos
-// functions, which exceptions.h cannot export into the module. The
-// places that use exceptions must know about these functions, and to
-// avoid them all having to include Kokkos headers, we have to do it
-// here:
-DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
-#include <Kokkos_Macros.hpp>
-#if KOKKOS_VERSION >= 40200
-#  include <Kokkos_Abort.hpp>
-#else
-#  include <Kokkos_Core.hpp>
-#endif
-DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
-
-
 
 /**********************************************************************
  * Preprocessor definitions in support of declaring exception classes.

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -20,6 +20,20 @@
 #include <deal.II/base/exception_macros.h>
 #include <deal.II/base/numbers.h>
 
+// The exception machinery (including the macros defined in
+// exception_macros.h) references Kokkos functions. The places that
+// use exceptions must know about these functions, and to avoid them
+// all having to include Kokkos headers, we have to do it here:
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+#include <Kokkos_Macros.hpp>
+#if KOKKOS_VERSION >= 40200
+#  include <Kokkos_Abort.hpp>
+#else
+#  include <Kokkos_Core.hpp>
+#endif
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
+
+
 #include <exception>
 #include <ostream>
 #include <string>


### PR DESCRIPTION
For the same reason as mentioned in #18215 (c.f. #18071), I would like to move `#include` statements out of headers that only `#define` macros. We include a Kokkos header in `exception_macros.h`, but this is not actually necessary: Everyone using exception stuff needs to `#include` `exceptions.h` anyway, so we can move the inclusion of the Kokkos headers there.