### PR TITLE
Add missing #includes.

### DIFF
--- a/include/deal.II/base/function_derivative.h
+++ b/include/deal.II/base/function_derivative.h
@@ -21,6 +21,9 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/function.h>
 
+#include <vector>
+
+
 DEAL_II_NAMESPACE_OPEN
 
 

--- a/include/deal.II/base/partitioner.h
+++ b/include/deal.II/base/partitioner.h
@@ -29,6 +29,8 @@
 
 #include <limits>
 #include <memory>
+#include <vector>
+
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/matrix_free/evaluation_template_face_factory.templates.h
+++ b/include/deal.II/matrix_free/evaluation_template_face_factory.templates.h
@@ -23,6 +23,9 @@
 #include <deal.II/matrix_free/evaluation_template_factory.h>
 #include <deal.II/matrix_free/evaluation_template_factory_internal.h>
 
+#include <vector>
+
+
 DEAL_II_NAMESPACE_OPEN
 
 namespace internal

--- a/include/deal.II/matrix_free/evaluation_template_factory_hanging_nodes.templates.h
+++ b/include/deal.II/matrix_free/evaluation_template_factory_hanging_nodes.templates.h
@@ -24,6 +24,9 @@
 #include <deal.II/matrix_free/evaluation_template_factory_internal.h>
 #include <deal.II/matrix_free/shape_info.h>
 
+#include <array>
+
+
 DEAL_II_NAMESPACE_OPEN
 
 namespace internal

--- a/include/deal.II/particles/partitioner.h
+++ b/include/deal.II/particles/partitioner.h
@@ -19,6 +19,9 @@
 
 #include <deal.II/particles/particle_iterator.h>
 
+#include <vector>
+
+
 DEAL_II_NAMESPACE_OPEN
 
 namespace Particles

--- a/source/base/function_derivative.cc
+++ b/source/base/function_derivative.cc
@@ -18,6 +18,8 @@
 #include <deal.II/lac/vector.h>
 
 #include <cmath>
+#include <vector>
+
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/lac/matrix_out.cc
+++ b/source/lac/matrix_out.cc
@@ -14,6 +14,10 @@
 
 #include <deal.II/lac/matrix_out.h>
 
+#include <string>
+#include <vector>
+
+
 DEAL_II_NAMESPACE_OPEN
 
 

--- a/source/numerics/vector_tools_interpolate.cc
+++ b/source/numerics/vector_tools_interpolate.cc
@@ -15,6 +15,9 @@
 
 #include <deal.II/numerics/vector_tools_interpolate.templates.h>
 
+#include <map>
+
+
 DEAL_II_NAMESPACE_OPEN
 
 // ---------------------------- explicit instantiations --------------------

--- a/source/numerics/vector_tools_mean_value.cc
+++ b/source/numerics/vector_tools_mean_value.cc
@@ -15,6 +15,9 @@
 
 #include <deal.II/numerics/vector_tools_mean_value.templates.h>
 
+#include <vector>
+
+
 DEAL_II_NAMESPACE_OPEN
 
 // ---------------------------- explicit instantiations --------------------

--- a/source/numerics/vector_tools_point_gradient.cc
+++ b/source/numerics/vector_tools_point_gradient.cc
@@ -15,6 +15,9 @@
 
 #include <deal.II/numerics/vector_tools_point_gradient.templates.h>
 
+#include <vector>
+
+
 DEAL_II_NAMESPACE_OPEN
 
 // ---------------------------- explicit instantiations --------------------

--- a/source/numerics/vector_tools_point_value.cc
+++ b/source/numerics/vector_tools_point_value.cc
@@ -15,6 +15,9 @@
 
 #include <deal.II/numerics/vector_tools_point_value.templates.h>
 
+#include <vector>
+
+
 DEAL_II_NAMESPACE_OPEN
 
 // ---------------------------- explicit instantiations --------------------

--- a/source/particles/utilities.cc
+++ b/source/particles/utilities.cc
@@ -18,6 +18,8 @@
 
 #include <deal.II/particles/utilities.h>
 
+#include <vector>
+
 
 DEAL_II_NAMESPACE_OPEN
 


### PR DESCRIPTION
These header files provide classes that are used in the files in question, though the list of classes/functions from namespace `std` that are referenced in those files is perhaps longer. I use the presence of C++ header files as an indicator that we want to use `import std` or some such for #18071, but `import std` imports much more than just the one class for which I added the `#include` here. Either way, the header's contents are referenced in the file, and so the addition of the `#include` is correct.