### PR TITLE
Do not use 'static' functions in header files.

### DIFF
--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -2905,7 +2905,7 @@ namespace FETools
       // FETools::convert_generalized_support_point_values_to_dof_values
 
       template <int dim, int spacedim, typename number>
-      static void
+      void
       convert_helper(const FiniteElement<dim, spacedim> &finite_element,
                      const std::vector<Vector<number>>  &support_point_values,
                      std::vector<number>                &dof_values)
@@ -2937,7 +2937,7 @@ namespace FETools
 
 
       template <int dim, int spacedim, typename number>
-      static void
+      void
       convert_helper(
         const FiniteElement<dim, spacedim>              &finite_element,
         const std::vector<Vector<std::complex<number>>> &support_point_values,
@@ -2995,7 +2995,7 @@ namespace FETools
 
 
       template <int dim, int spacedim>
-      static void
+      void
       convert_helper(const FiniteElement<dim, spacedim> &finite_element,
                      const std::vector<Vector<double>>  &support_point_values,
                      std::vector<double>                &dof_values)

--- a/include/deal.II/numerics/matrix_creator.templates.h
+++ b/include/deal.II/numerics/matrix_creator.templates.h
@@ -983,7 +983,7 @@ namespace MatrixCreator
   namespace internal
   {
     template <int dim, int spacedim, typename number>
-    void static inline create_boundary_mass_matrix_1(
+    void inline create_boundary_mass_matrix_1(
       const typename DoFHandler<dim, spacedim>::active_cell_iterator &cell,
       const MatrixCreator::internal::AssemblerBoundary::Scratch &,
       MatrixCreator::internal::AssemblerBoundary::
@@ -1310,6 +1310,7 @@ namespace MatrixCreator
     {
       DEAL_II_NOT_IMPLEMENTED();
     }
+
 
     template <>
     void inline create_boundary_mass_matrix_1<1, 3, double>(

--- a/include/deal.II/numerics/vector_tools_boundary.templates.h
+++ b/include/deal.II/numerics/vector_tools_boundary.templates.h
@@ -55,7 +55,7 @@ namespace VectorTools
               typename number,
               template <int, int>
               class M_or_MC>
-    static inline void
+    inline void
     do_interpolate_boundary_values(
       const M_or_MC<dim, spacedim>    &mapping,
       const DoFHandler<dim, spacedim> &dof,

--- a/include/deal.II/numerics/vector_tools_integrate_difference.templates.h
+++ b/include/deal.II/numerics/vector_tools_integrate_difference.templates.h
@@ -431,7 +431,7 @@ namespace VectorTools
 
     template <int dim, int spacedim, typename Number, class OutVector>
     DEAL_II_CXX20_REQUIRES(concepts::is_writable_dealii_vector_type<OutVector>)
-    static void do_integrate_difference(
+    void do_integrate_difference(
       const dealii::hp::MappingCollection<dim, spacedim> &mapping,
       const DoFHandler<dim, spacedim>                    &dof,
       const ReadVector<Number>                           &fe_function,


### PR DESCRIPTION
We just generally shouldn't use `static` functions or anonymous namespaces in header files. Seen while poking around stuff for #18071.