### PR TITLE
Use _v variables instead of ...::value.

### DIFF
--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -151,11 +151,11 @@ namespace hp
      * clang-tidy).
      */
     FECollection(FECollection<dim, spacedim> &&) noexcept(
-      std::is_nothrow_move_constructible<
-        std::vector<std::shared_ptr<const FiniteElement<dim, spacedim>>>>::value
-        &&std::is_nothrow_move_constructible<std::function<
+      std::is_nothrow_move_constructible_v<
+        std::vector<std::shared_ptr<const FiniteElement<dim, spacedim>>>>
+        &&std::is_nothrow_move_constructible_v<std::function<
           unsigned int(const typename hp::FECollection<dim, spacedim> &,
-                       const unsigned int)>>::value) = default;
+                       const unsigned int)>>) = default;
 
     /**
      * Move assignment operator.

--- a/include/deal.II/hp/mapping_collection.h
+++ b/include/deal.II/hp/mapping_collection.h
@@ -95,11 +95,11 @@ namespace hp
      * clang-tidy).
      */
     MappingCollection(MappingCollection<dim, spacedim> &&) noexcept(
-      std::is_nothrow_move_constructible<
-        std::vector<std::shared_ptr<const Mapping<dim, spacedim>>>>::value
-        &&std::is_nothrow_move_constructible<std::function<
+      std::is_nothrow_move_constructible_v<
+        std::vector<std::shared_ptr<const Mapping<dim, spacedim>>>>
+        &&std::is_nothrow_move_constructible_v<std::function<
           unsigned int(const typename hp::MappingCollection<dim, spacedim> &,
-                       const unsigned int)>>::value) = default;
+                       const unsigned int)>>) = default;
 
     /**
      * Move assignment operator.


### PR DESCRIPTION
Not strictly necessary, but makes the code easier to read. A year or two ago, I searched for all of these places but apparently missed these because they wrap around over the end of a line.