### PR TITLE
Remove a header include that is no longer needed.

### DIFF
--- a/source/lac/sparse_direct.cc
+++ b/source/lac/sparse_direct.cc
@@ -20,7 +20,6 @@
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/vector.h>
 
-#include <cerrno>
 #include <complex>
 #include <iostream>
 #include <list>


### PR DESCRIPTION
This file no longer uses `errno`, so we don't need the header file either.