### PR TITLE
Use C++ facilities to convert numbers. Second try.

### DIFF
--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -43,7 +43,7 @@
 #include <algorithm>
 #include <bitset>
 #include <cctype>
-#include <charconv>
+#include <cerrno>
 #include <cmath>
 #include <cstddef>
 #include <cstdio>
@@ -597,36 +597,33 @@ namespace Utilities
   int
   string_to_int(const std::string &s_)
   {
-    // Trim whitespace on either side of the text if necessary
+    // trim whitespace on either side of the text if necessary
     std::string s = s_;
     while ((s.size() > 0) && (s[0] == ' '))
       s.erase(s.begin());
     while ((s.size() > 0) && (s.back() == ' '))
       s.erase(s.end() - 1);
 
-    // This function used to be built on top of strtol, which gladly converts
-    // "+1" into int(1). But the std::from_chars() function we use below that
-    // does not. So, if the string starts with a plus, just eat it so that we
-    // stay backward compatible:
-    if ((s.size() > 0) && (s[0] == '+'))
-      s.erase(s.begin());
-
-    // Now convert and see whether we succeed.
-    int                          i;
-    const std::from_chars_result result =
-      std::from_chars(s.data(), s.data() + s.size(), i, /*base=*/10);
+    // Now convert and see whether we succeed. Note that strtol only
+    // touches errno if an error occurred, so if we want to check
+    // whether an error happened, we need to make sure that errno==0
+    // before calling strtol since otherwise it may be that the
+    // conversion succeeds and that errno remains at the value it
+    // was before, whatever that was.
+    char *p;
+    errno       = 0;
+    const int i = std::strtol(s.c_str(), &p, 10);
 
     // We have an error if one of the following conditions is true:
-    // - result.ec is not equal to a default-constructed std::errc(),
-    //   for example if the string does not even start with a
-    //   number; or
-    // - The string has non-zero length and std::from_chars() converted the
+    // - strtol sets errno != 0
+    // - The original string was empty (we could have checked that
+    //   earlier already)
+    // - The string has non-zero length and strtol converted the
     //   first part to something useful, but stopped converting short
     //   of the terminating '\0' character. This happens, for example,
-    //   if the given string is "1234 abc". In that case,
-    //   result.ptr points to something other than the end of
-    //   the string (namely, the first character past the number).
-    AssertThrow(result.ec == std::errc() && result.ptr == s.data() + s.size(),
+    //   if the given string is "1234 abc".
+    AssertThrow(!((errno != 0) || (s.empty()) ||
+                  ((s.size() > 0) && (*p != '\0'))),
                 ExcMessage("Can't convert <" + s + "> to an integer."));
 
     return i;
@@ -655,29 +652,26 @@ namespace Utilities
     while ((s.size() > 0) && (s.back() == ' '))
       s.erase(s.end() - 1);
 
-    // This function used to be built on top of strtod, which gladly converts
-    // "+1" into int(1). But the std::from_chars() function we use below that
-    // does not. So, if the string starts with a plus, just eat it so that we
-    // stay backward compatible:
-    if ((s.size() > 0) && (s[0] == '+'))
-      s.erase(s.begin());
-
-    // Now convert and see whether we succeed.
-    double                       d;
-    const std::from_chars_result result = std::from_chars(
-      s.data(), s.data() + s.size(), d, std::chars_format::general);
+    // Now convert and see whether we succeed. Note that strtol only
+    // touches errno if an error occurred, so if we want to check
+    // whether an error happened, we need to make sure that errno==0
+    // before calling strtol since otherwise it may be that the
+    // conversion succeeds and that errno remains at the value it
+    // was before, whatever that was.
+    char *p;
+    errno          = 0;
+    const double d = std::strtod(s.c_str(), &p);
 
     // We have an error if one of the following conditions is true:
-    // - result.ec is not equal to a default-constructed std::errc(),
-    //   for example if the string does not even start with a
-    //   number; or
-    // - The string has non-zero length and std::from_chars() converted the
+    // - strtod sets errno != 0
+    // - The original string was empty (we could have checked that
+    //   earlier already)
+    // - The string has non-zero length and strtod converted the
     //   first part to something useful, but stopped converting short
     //   of the terminating '\0' character. This happens, for example,
-    //   if the given string is "1234 abc". In that case,
-    //   result.ptr points to something other than the end of
-    //   the string (namely, the first character past the number).
-    AssertThrow(result.ec == std::errc() && result.ptr == s.data() + s.size(),
+    //   if the given string is "1.234 abc".
+    AssertThrow(!((errno != 0) || (s.empty()) ||
+                  ((s.size() > 0) && (*p != '\0'))),
                 ExcMessage("Can't convert <" + s + "> to a double."));
 
     return d;

--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -662,14 +662,6 @@ namespace Utilities
     if ((s.size() > 0) && (s[0] == '+'))
       s.erase(s.begin());
 
-      // We want to use std::from_char() to do the conversion. That's a C++17
-      // function, but it turns out that some older compilers don't implement
-      // it correctly (notably GCC 9.x and clang 14) even though they claim
-      // to support C++17. We could try and test for individual compiler
-      // version, but it is probably enough to just select based on which C++
-      // standard we are compiling with -- every compiler that supports C++20
-      // should also have a complete implementation for std::from_chars().
-#ifdef DEAL_II_HAVE_CXX20
     // Now convert and see whether we succeed.
     double                       d;
     const std::from_chars_result result = std::from_chars(
@@ -689,31 +681,6 @@ namespace Utilities
                 ExcMessage("Can't convert <" + s + "> to a double."));
 
     return d;
-#else
-    // Now convert and see whether we succeed. Note that strtol only
-    // touches errno if an error occurred, so if we want to check
-    // whether an error happened, we need to make sure that errno==0
-    // before calling strtol since otherwise it may be that the
-    // conversion succeeds and that errno remains at the value it
-    // was before, whatever that was.
-    char *p;
-    errno          = 0;
-    const double d = std::strtod(s.c_str(), &p);
-
-    // We have an error if one of the following conditions is true:
-    // - strtod sets errno != 0
-    // - The original string was empty (we could have checked that
-    //   earlier already)
-    // - The string has non-zero length and strtod converted the
-    //   first part to something useful, but stopped converting short
-    //   of the terminating '\0' character. This happens, for example,
-    //   if the given string is "1.234 abc".
-    AssertThrow(!((errno != 0) || (s.empty()) ||
-                  ((s.size() > 0) && (*p != '\0'))),
-                ExcMessage("Can't convert <" + s + "> to a double."));
-
-    return d;
-#endif
   }
 
 


### PR DESCRIPTION
This PR undoes #18229 -- even the most recent clang 20 does not have `std::from_chars()` correctly implemented. But in hindsight, there is a better solution anyway. My goal was to replace `strtoi` and `strtod` by a C++ solution that does not require or access `errno`. C++ has functions for that: `stoi` and `stod`, see https://en.cppreference.com/w/cpp/string/basic_string/stol and https://en.cppreference.com/w/cpp/string/basic_string/stof . They even take a `std::string` as first argument, rather than work on `char*` pointers. I just didn't know about them.

So this, then, is the patch I should have written the first time around.

(Part of #18071.)