### PR TITLE
Do not use anonymous namespaces in header files.

### DIFF
--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -146,7 +146,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::create_cell_subrange_hp_by_index(
 
 
 
-namespace
+namespace internal
 {
   class FaceRangeComparator
   {
@@ -200,7 +200,7 @@ namespace
     const bool                       include;
     const bool                       only_face_type;
   };
-} // namespace
+} // namespace internal
 
 
 
@@ -658,7 +658,9 @@ MatrixFree<dim, Number, VectorizedArrayType>::internal_reinit(
                     face_info.faces.begin() + range.second,
                     std::array<unsigned int, 3>{
                       {face_type, fe_index_interior, fe_index_exterior}},
-                    FaceRangeComparator(fe_indices, false, only_face_type)) -
+                    internal::FaceRangeComparator(fe_indices,
+                                                  false,
+                                                  only_face_type)) -
                   face_info.faces.begin();
                 return_range.second =
                   std::lower_bound(
@@ -666,7 +668,9 @@ MatrixFree<dim, Number, VectorizedArrayType>::internal_reinit(
                     face_info.faces.begin() + range.second,
                     std::array<unsigned int, 3>{
                       {face_type, fe_index_interior, fe_index_exterior}},
-                    FaceRangeComparator(fe_indices, true, only_face_type)) -
+                    internal::FaceRangeComparator(fe_indices,
+                                                  true,
+                                                  only_face_type)) -
                   face_info.faces.begin();
                 Assert(return_range.first >= range.first &&
                          return_range.second <= range.second,
@@ -752,18 +756,20 @@ MatrixFree<dim, Number, VectorizedArrayType>::internal_reinit(
 
                 std::pair<unsigned int, unsigned int> return_range;
                 return_range.first =
-                  std::lower_bound(
-                    face_info.faces.begin() + range.first,
-                    face_info.faces.begin() + range.second,
-                    std::array<unsigned int, 2>{{face_type, fe_index}},
-                    FaceRangeComparator(fe_indices, false, only_face_type)) -
+                  std::lower_bound(face_info.faces.begin() + range.first,
+                                   face_info.faces.begin() + range.second,
+                                   std::array<unsigned int, 2>{
+                                     {face_type, fe_index}},
+                                   internal::FaceRangeComparator(
+                                     fe_indices, false, only_face_type)) -
                   face_info.faces.begin();
                 return_range.second =
-                  std::lower_bound(
-                    face_info.faces.begin() + return_range.first,
-                    face_info.faces.begin() + range.second,
-                    std::array<unsigned int, 2>{{face_type, fe_index}},
-                    FaceRangeComparator(fe_indices, true, only_face_type)) -
+                  std::lower_bound(face_info.faces.begin() + return_range.first,
+                                   face_info.faces.begin() + range.second,
+                                   std::array<unsigned int, 2>{
+                                     {face_type, fe_index}},
+                                   internal::FaceRangeComparator(
+                                     fe_indices, true, only_face_type)) -
                   face_info.faces.begin();
                 Assert(return_range.first >= range.first &&
                          return_range.second <= range.second,

--- a/include/deal.II/matrix_free/portable_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.templates.h
@@ -670,7 +670,7 @@ namespace Portable
 
 
 
-  namespace
+  namespace internal
   {
     /**
      * Helper function for determining the scratch pad size.
@@ -709,7 +709,7 @@ namespace Portable
 
       return numbers::invalid_unsigned_int;
     }
-  } // namespace
+  } // namespace internal
 
 
 
@@ -763,10 +763,8 @@ namespace Portable
                                                                           fe);
 
     this->element_type     = shape_info.element_type;
-    this->scratch_pad_size = compute_scratch_pad_size(shape_info.element_type,
-                                                      dim,
-                                                      fe_degree,
-                                                      n_q_points_1d);
+    this->scratch_pad_size = internal::compute_scratch_pad_size(
+      shape_info.element_type, dim, fe_degree, n_q_points_1d);
 
     unsigned int size_shape_values = n_dofs_1d * n_q_points_1d;
 


### PR DESCRIPTION
The last two header files that clang complains about. This is independent progress.

Related to #18071.