### PR TITLE
github-actions: Use all jobs to build docker image.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,9 +33,10 @@ jobs:
             os: ubuntu-24.04
           - platform: arm64
             os: ubuntu-24.04-arm
-          # Use only 2 jobs to build, as more jobs
-          # would starve the github machine for memory.
-          - n_jobs: 2
+          # Use all available processors to build.
+          # Specify the number of jobs explicitly since the default '0'
+          # causes the github workers to disconnect (potential crash).
+          - n_jobs: 4
 
     steps:
       - name: Docker meta


### PR DESCRIPTION
I ran some experiments on my repository. We can safely use all 4 processors of the github workers to build deal.II on the docker images.

We specified the default value for `ninja -j` to be '0' in the Dockerfile, which translates to using infinitely many jobs. This way, we lose connection to the github-hosted workers (they potentially crash). We should reconsider the choice of default value.

With this patch, wall-time for building the docker image decreases from ~1h20m to ~1h.