### PR TITLE
Remove `mm_malloc.h`.

### DIFF
--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -53,6 +53,7 @@
 #endif
 
 #ifndef DEAL_II_MSVC
+// On Unix-type systems, we use posix_memalign:
 #  include <cstdlib>
 #endif
 
@@ -61,11 +62,6 @@
 // and we'll get a conflict between winsock.h and winsock2.h otherwise.
 #ifdef DEAL_II_MSVC
 #  include <winsock2.h>
-#endif
-
-#ifndef DEAL_II_MSVC
-// On Unix-type systems, we use posix-memalign:
-#  include <mm_malloc.h>
 #endif
 
 


### PR DESCRIPTION
Cherry-picked from #18242. Reverts #18234.

`posix-memalign` is actually defined in `stdlib.h` or rather `cstdlib`.
https://pubs.opengroup.org/onlinepubs/9799919799/functions/posix_memalign.html