### PR TITLE
Fix clang-tidy complaints

### DIFF
--- a/include/deal.II/base/polynomials_bernstein.h
+++ b/include/deal.II/base/polynomials_bernstein.h
@@ -67,6 +67,7 @@ std::vector<Polynomials::Polynomial<number>>
 generate_complete_bernstein_basis(const unsigned int degree)
 {
   std::vector<Polynomials::Polynomial<number>> v;
+  v.reserve(degree + 1);
   for (unsigned int i = 0; i < degree + 1; ++i)
     v.push_back(PolynomialsBernstein<number>(i, degree));
   return v;

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1701,8 +1701,8 @@ constexpr inline DEAL_II_ALWAYS_INLINE
   DEAL_II_HOST_DEVICE Tensor<rank_, dim, Number> &
   Tensor<rank_, dim, Number>::operator/=(const OtherNumber &s)
 {
-  if constexpr (std::is_integral<
-                  typename ProductType<Number, OtherNumber>::type>::value ||
+  if constexpr (std::is_integral_v<
+                  typename ProductType<Number, OtherNumber>::type> ||
                 std::is_same_v<Number, Differentiation::SD::Expression>)
     {
       // recurse over the base objects

--- a/include/deal.II/fe/mapping_q_internal.h
+++ b/include/deal.II/fe/mapping_q_internal.h
@@ -39,6 +39,7 @@
 #include <deal.II/matrix_free/shape_info.h>
 #include <deal.II/matrix_free/tensor_product_point_kernels.h>
 
+#include <algorithm>
 #include <array>
 #include <limits>
 #include <numeric>
@@ -147,8 +148,8 @@ namespace internal
        */
       const long double subexpr0        = -eta * x2 + x0 * (eta - 1);
       const long double xi_denominator0 = eta * x3 - x1 * (eta - 1) + subexpr0;
-      const long double max_x = std::max(std::max(std::abs(x0), std::abs(x1)),
-                                         std::max(std::abs(x2), std::abs(x3)));
+      const long double max_x =
+        std::max({std::abs(x0), std::abs(x1), std::abs(x2), std::abs(x3)});
 
       if (std::abs(xi_denominator0) > 1e-10 * max_x)
         {
@@ -158,8 +159,7 @@ namespace internal
       else
         {
           const long double max_y =
-            std::max(std::max(std::abs(y0), std::abs(y1)),
-                     std::max(std::abs(y2), std::abs(y3)));
+            std::max({std::abs(y0), std::abs(y1), std::abs(y2), std::abs(y3)});
           const long double subexpr1 = -eta * y2 + y0 * (eta - 1);
           const long double xi_denominator1 =
             eta * y3 - y1 * (eta - 1) + subexpr1;

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -1046,17 +1046,8 @@ namespace internal
 
     template <typename BlockVectorType, bool Constness>
     inline Iterator<BlockVectorType, Constness> &
-    Iterator<BlockVectorType, Constness>::operator=(const Iterator &c)
-    {
-      parent              = c.parent;
-      global_index        = c.global_index;
-      index_within_block  = c.index_within_block;
-      current_block       = c.current_block;
-      next_break_forward  = c.next_break_forward;
-      next_break_backward = c.next_break_backward;
-
-      return *this;
-    }
+    Iterator<BlockVectorType, Constness>::operator=(const Iterator &c) =
+      default;
 
 
 

--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -1917,33 +1917,7 @@ FEPointEvaluationBase<n_components_, dim, spacedim, Number>::
 
 template <int n_components_, int dim, int spacedim, typename Number>
 FEPointEvaluationBase<n_components_, dim, spacedim, Number>::
-  FEPointEvaluationBase(FEPointEvaluationBase &&other) noexcept
-  : n_q_batches(other.n_q_batches)
-  , n_q_points(other.n_q_points)
-  , n_q_points_scalar(other.n_q_points_scalar)
-  , mapping(other.mapping)
-  , fe(other.fe)
-  , poly(other.poly)
-  , use_linear_path(other.use_linear_path)
-  , renumber(other.renumber)
-  , solution_renumbered(other.solution_renumbered)
-  , solution_renumbered_vectorized(other.solution_renumbered_vectorized)
-  , values(other.values)
-  , gradients(other.gradients)
-  , dofs_per_component(other.dofs_per_component)
-  , dofs_per_component_face(other.dofs_per_component_face)
-  , component_in_base_element(other.component_in_base_element)
-  , nonzero_shape_function_component(other.nonzero_shape_function_component)
-  , update_flags(other.update_flags)
-  , fe_values(other.fe_values)
-  , mapping_info_on_the_fly(std::move(other.mapping_info_on_the_fly))
-  , mapping_info(other.mapping_info)
-  , current_cell_index(other.current_cell_index)
-  , current_face_number(other.current_face_number)
-  , fast_path(other.fast_path)
-  , must_reinitialize_pointers(other.must_reinitialize_pointers)
-  , is_interior(other.is_interior)
-{}
+  FEPointEvaluationBase(FEPointEvaluationBase &&other) noexcept = default;
 
 
 

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -284,32 +284,7 @@ public:
      * Copy assignment.
      */
     AdditionalData &
-    operator=(const AdditionalData &other)
-    {
-      tasks_parallel_scheme = other.tasks_parallel_scheme;
-      tasks_block_size      = other.tasks_block_size;
-      mapping_update_flags  = other.mapping_update_flags;
-      mapping_update_flags_boundary_faces =
-        other.mapping_update_flags_boundary_faces;
-      mapping_update_flags_inner_faces = other.mapping_update_flags_inner_faces;
-      mapping_update_flags_faces_by_cells =
-        other.mapping_update_flags_faces_by_cells;
-      mg_level            = other.mg_level;
-      store_plain_indices = other.store_plain_indices;
-      initialize_indices  = other.initialize_indices;
-      initialize_mapping  = other.initialize_mapping;
-      overlap_communication_computation =
-        other.overlap_communication_computation;
-      hold_all_faces_to_owned_cells = other.hold_all_faces_to_owned_cells;
-      cell_vectorization_category   = other.cell_vectorization_category;
-      cell_vectorization_categories_strict =
-        other.cell_vectorization_categories_strict;
-      allow_ghosted_vectors_in_loops = other.allow_ghosted_vectors_in_loops;
-      store_ghost_cells              = other.store_ghost_cells;
-      communicator_sm                = other.communicator_sm;
-
-      return *this;
-    }
+    operator=(const AdditionalData &other) = default;
 
     /**
      * Set the scheme for task parallelism. There are four options available.

--- a/include/deal.II/meshworker/copy_data.h
+++ b/include/deal.II/meshworker/copy_data.h
@@ -23,6 +23,7 @@
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/vector.h>
 
+#include <algorithm>
 #include <vector>
 
 DEAL_II_NAMESPACE_OPEN
@@ -223,7 +224,7 @@ namespace MeshWorker
     // We permit different numbers of matrices, vectors and DoF index vectors.
     // So we have to be a bit permissive here.
     constexpr const int max_index =
-      std::max(std::max(n_matrices, n_vectors), n_dof_indices);
+      std::max({n_matrices, n_vectors, n_dof_indices});
     (void)max_index;
     Assert(index < max_index, ExcIndexRange(index, 0, max_index));
 

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -378,7 +378,7 @@ namespace internal
 
     for (unsigned int c_other = 0; c_other < child; ++c_other)
       {
-        auto matrix_other = fe.get_restriction_matrix(c_other, ref_case);
+        const auto &matrix_other = fe.get_restriction_matrix(c_other, ref_case);
         for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
           {
             if (fe.restriction_is_additive(i) == true)

--- a/source/base/polynomials_bernardi_raugel.cc
+++ b/source/base/polynomials_bernardi_raugel.cc
@@ -38,6 +38,7 @@ PolynomialsBernardiRaugel<dim>::create_polynomials_bubble()
   bubble_shapes.push_back(Polynomials::LagrangeEquidistant(1, 1));
   bubble_shapes.push_back(Polynomials::LagrangeEquidistant(2, 1));
 
+  pols.reserve(dim);
   for (unsigned int d = 0; d < dim; ++d)
     pols.push_back(bubble_shapes);
   // In 2d, the only q_ij polynomials we will use are 31,32,13,23
@@ -58,6 +59,7 @@ PolynomialsBernardiRaugel<dim>::create_polynomials_Q()
   std::vector<Polynomials::Polynomial<double>>              Q_shapes;
   Q_shapes.push_back(Polynomials::LagrangeEquidistant(1, 0));
   Q_shapes.push_back(Polynomials::LagrangeEquidistant(1, 1));
+  pols.reserve(dim);
   for (unsigned int d = 0; d < dim; ++d)
     pols.push_back(Q_shapes);
 

--- a/source/base/table_handler.cc
+++ b/source/base/table_handler.cc
@@ -402,7 +402,7 @@ TableHandler::write_text(std::ostream &out, const TextOutputFormat format) const
   std::vector<unsigned int>   column_widths(n_cols, 0);
   for (unsigned int j = 0; j < n_cols; ++j)
     {
-      std::string                                         key = sel_columns[j];
+      const std::string                                  &key = sel_columns[j];
       const std::map<std::string, Column>::const_iterator col_iter =
         columns.find(key);
       Assert(col_iter != columns.end(), ExcInternalError());
@@ -480,7 +480,7 @@ TableHandler::write_text(std::ostream &out, const TextOutputFormat format) const
           // header for each column. enumerate columns starting with 1
           for (unsigned int j = 0; j < n_cols; ++j)
             {
-              std::string key = sel_columns[j];
+              const std::string &key = sel_columns[j];
               out << "# " << j + 1 << ": " << key << '\n';
             }
           break;
@@ -691,7 +691,7 @@ TableHandler::write_tex(std::ostream &out, const bool with_header) const
 
       for (unsigned int j = 0; j < n_cols; ++j)
         {
-          std::string key = sel_columns[j];
+          const std::string &key = sel_columns[j];
           // avoid `column[key]'
           const std::map<std::string, Column>::const_iterator col_iter =
             columns.find(key);

--- a/source/base/tensor_product_polynomials.cc
+++ b/source/base/tensor_product_polynomials.cc
@@ -578,9 +578,8 @@ TensorProductPolynomials<dim, PolynomialType>::evaluate(
       const unsigned int n_polynomials = polynomials.size();
       boost::container::small_vector<ndarray<double, 5, dim>, 10> values_1d(
         n_polynomials);
-      if constexpr (std::is_same<
-                      PolynomialType,
-                      dealii::Polynomials::Polynomial<double>>::value)
+      if constexpr (std::is_same_v<PolynomialType,
+                                   dealii::Polynomials::Polynomial<double>>)
         {
           std::array<double, dim> point_array;
           for (unsigned int d = 0; d < dim; ++d)

--- a/source/base/tensor_product_polynomials_bubbles.cc
+++ b/source/base/tensor_product_polynomials_bubbles.cc
@@ -56,6 +56,7 @@ TensorProductPolynomialsBubbles<dim>::set_numbering(
     index_map_inverse[index_map[i]] = i;
 
   std::vector<unsigned int> renumber_base;
+  renumber_base.reserve(tensor_polys.n());
   for (unsigned int i = 0; i < tensor_polys.n(); ++i)
     renumber_base.push_back(renumber[i]);
 

--- a/source/base/tensor_product_polynomials_const.cc
+++ b/source/base/tensor_product_polynomials_const.cc
@@ -56,6 +56,7 @@ TensorProductPolynomialsConst<dim>::set_numbering(
     index_map_inverse[index_map[i]] = i;
 
   std::vector<unsigned int> renumber_base;
+  renumber_base.reserve(tensor_polys.n());
   for (unsigned int i = 0; i < tensor_polys.n(); ++i)
     renumber_base.push_back(renumber[i]);
 

--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -28,6 +28,8 @@
 #include <boost/iostreams/copy.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/random.hpp>
+
+#include <algorithm>
 #undef BOOST_BIND_GLOBAL_PLACEHOLDERS
 
 #ifdef DEAL_II_WITH_ZLIB
@@ -172,10 +174,9 @@ namespace Utilities
 
     // make sure our conversion from fractional coordinates to
     // Integers work as expected, namely our cast (LongDouble)max_int
-    const int min_bits =
-      std::min(bits_per_dim,
-               std::min(std::numeric_limits<Integer>::digits,
-                        std::numeric_limits<LongDouble>::digits));
+    const int min_bits = std::min({bits_per_dim,
+                                   std::numeric_limits<Integer>::digits,
+                                   std::numeric_limits<LongDouble>::digits});
 
     // based on that get the maximum integer:
     const Integer max_int = (min_bits == std::numeric_limits<Integer>::digits ?

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -3336,7 +3336,7 @@ namespace internal
                 this->dof_handler->locally_owned_dofs());
             for (unsigned int i = 0; i < n_cpu; ++i)
               {
-                const IndexSet iset = locally_owned_dofs_per_processor[i];
+                const IndexSet &iset = locally_owned_dofs_per_processor[i];
                 for (types::global_dof_index ind = 0; ind < iset.n_elements();
                      ind++)
                   {

--- a/source/dofs/dof_tools_sparsity.cc
+++ b/source/dofs/dof_tools_sparsity.cc
@@ -339,7 +339,7 @@ namespace DoFTools
             for (unsigned int i = 0; i < child_cells.size(); ++i)
               {
                 const typename DoFHandler<dim, spacedim>::active_cell_iterator
-                                   cell_col_child = child_cells[i];
+                                  &cell_col_child = child_cells[i];
                 const unsigned int dofs_per_cell_row =
                   cell_row->get_fe().n_dofs_per_cell();
                 const unsigned int dofs_per_cell_col =

--- a/source/fe/fe_nedelec.cc
+++ b/source/fe/fe_nedelec.cc
@@ -2740,6 +2740,7 @@ FE_Nedelec<dim>::hp_line_dof_identities(
       // same polynomial degree.
       std::vector<std::pair<unsigned int, unsigned int>> identities;
 
+      identities.reserve(std::min(fe_nedelec_other->degree, this->degree));
       for (unsigned int i = 0;
            i < std::min(fe_nedelec_other->degree, this->degree);
            ++i)
@@ -4446,6 +4447,7 @@ FE_Nedelec<dim>::get_constant_modes() const
     for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
       constant_modes(d, i) = true;
   std::vector<unsigned int> components;
+  components.reserve(dim);
   for (unsigned int d = 0; d < dim; ++d)
     components.push_back(d);
   return std::pair<Table<2, bool>, std::vector<unsigned int>>(constant_modes,

--- a/source/fe/fe_pyramid_p.cc
+++ b/source/fe/fe_pyramid_p.cc
@@ -270,6 +270,7 @@ FE_PyramidP<dim, spacedim>::hp_line_dof_identities(
 
   std::vector<std::pair<unsigned int, unsigned int>> result;
 
+  result.reserve(this->degree - 1);
   for (unsigned int i = 0; i < this->degree - 1; ++i)
     result.emplace_back(i, i);
 
@@ -302,6 +303,7 @@ FE_PyramidP<dim, spacedim>::hp_quad_dof_identities(
 
   std::vector<std::pair<unsigned int, unsigned int>> result;
 
+  result.reserve(this->n_dofs_per_quad(face_no));
   for (unsigned int i = 0; i < this->n_dofs_per_quad(face_no); ++i)
     result.emplace_back(i, i);
 

--- a/source/fe/fe_q_hierarchical.cc
+++ b/source/fe/fe_q_hierarchical.cc
@@ -275,6 +275,7 @@ FE_Q_Hierarchical<dim>::hp_line_dof_identities(
       // increasingly. Thus we return a vector of pairs for the first N-1, where
       // N is minimum number of dofs_per_line for each FE_Q_Hierarchical.
       std::vector<std::pair<unsigned int, unsigned int>> res;
+      res.reserve(std::min(this_dpl, other_dpl));
       for (unsigned int i = 0; i < std::min(this_dpl, other_dpl); ++i)
         res.emplace_back(i, i);
 
@@ -319,6 +320,7 @@ FE_Q_Hierarchical<dim>::hp_quad_dof_identities(
       // increasingly. Thus we return a vector of pairs for the first N-1, where
       // N is minimum number of dofs_per_line for each FE_Q_Hierarchical.
       std::vector<std::pair<unsigned int, unsigned int>> res;
+      res.reserve(std::min(this_dpq, other_dpq));
       for (unsigned int i = 0; i < std::min(this_dpq, other_dpq); ++i)
         res.emplace_back(i, i);
 

--- a/source/fe/fe_raviart_thomas.cc
+++ b/source/fe/fe_raviart_thomas.cc
@@ -632,6 +632,7 @@ FE_RaviartThomas<dim>::get_constant_modes() const
     for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
       constant_modes(d, i) = true;
   std::vector<unsigned int> components;
+  components.reserve(dim);
   for (unsigned int d = 0; d < dim; ++d)
     components.push_back(d);
   return std::pair<Table<2, bool>, std::vector<unsigned int>>(constant_modes,

--- a/source/fe/fe_wedge_p.cc
+++ b/source/fe/fe_wedge_p.cc
@@ -291,6 +291,7 @@ FE_WedgeP<dim, spacedim>::hp_line_dof_identities(
 
   std::vector<std::pair<unsigned int, unsigned int>> result;
 
+  result.reserve(this->degree - 1);
   for (unsigned int i = 0; i < this->degree - 1; ++i)
     result.emplace_back(i, i);
 
@@ -322,6 +323,7 @@ FE_WedgeP<dim, spacedim>::hp_quad_dof_identities(
 
   std::vector<std::pair<unsigned int, unsigned int>> result;
 
+  result.reserve(this->n_dofs_per_quad(face_no));
   for (unsigned int i = 0; i < this->n_dofs_per_quad(face_no); ++i)
     result.emplace_back(i, i);
 

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -536,6 +536,7 @@ namespace GridGenerator
           // (number_points) equidistant points.
           const double theta = 2 * numbers::PI / number_points;
           // first point is leading edge then counterclockwise
+          circle_points.reserve(number_points);
           for (unsigned int i = 0; i < number_points; ++i)
             circle_points.emplace_back(center[0] - radius * cos(i * theta),
                                        center[1] - radius * sin(i * theta));
@@ -5995,6 +5996,7 @@ namespace GridGenerator
                                                             {+1, +1, +1}}};
 
         // Start with the shell bounded by two nested cubes
+        vertices.reserve(8);
         for (unsigned int i = 0; i < 8; ++i)
           vertices.push_back(p + hexahedron[i] * irad);
         for (unsigned int i = 0; i < 8; ++i)
@@ -6056,6 +6058,7 @@ namespace GridGenerator
                                                             {-1, +1, +1}, //
                                                             {+1, +1, +1}}};
 
+        vertices.reserve(8);
         for (unsigned int i = 0; i < 8; ++i)
           vertices.push_back(p + hexahedron[i] * irad);
         for (unsigned int i = 0; i < 6; ++i)
@@ -7080,6 +7083,7 @@ namespace GridGenerator
 
     const double        delta_h = height / (n_slices - 1);
     std::vector<double> slices_z_values;
+    slices_z_values.reserve(n_slices);
     for (unsigned int i = 0; i < n_slices; ++i)
       slices_z_values.push_back(i * delta_h);
     extrude_triangulation(

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -3608,7 +3608,7 @@ GridOut::write_mesh_per_processor_as_vtu(
   data_names.emplace_back("level_subdomain");
   data_names.emplace_back("proc_writing");
 
-  const auto reference_cells = tria.get_reference_cells();
+  const auto &reference_cells = tria.get_reference_cells();
 
   AssertDimension(reference_cells.size(), 1);
 
@@ -3690,6 +3690,7 @@ GridOut::write_mesh_per_processor_as_vtu(
             pos += 1;
           const unsigned int n_procs =
             Utilities::MPI::n_mpi_processes(tr->get_mpi_communicator());
+          filenames.reserve(n_procs);
           for (unsigned int i = 0; i < n_procs; ++i)
             filenames.push_back(filename_without_extension.substr(pos) +
                                 ".proc" + Utilities::int_to_string(i, 4) +
@@ -4299,6 +4300,7 @@ namespace internal
                           face_no,
                           cell->combined_face_orientation(face_no),
                           n_points);
+                      line_points.reserve(n_points);
                       for (unsigned int i = 0; i < n_points; ++i)
                         line_points.push_back(
                           mapping->transform_unit_to_real_cell(
@@ -4573,6 +4575,7 @@ namespace internal
                                                                           v0),
                                 u1 = mapping->transform_real_to_unit_cell(cell,
                                                                           v1);
+                              line_points.reserve(n_points);
                               for (unsigned int i = 0; i < n_points; ++i)
                                 line_points.push_back(
                                   mapping->transform_unit_to_real_cell(

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -1255,6 +1255,7 @@ namespace GridTools
         if ((merged_b_boxes.size() > max_boxes) && (spacedim > 1))
           {
             std::vector<double> volumes;
+            volumes.reserve(merged_b_boxes.size());
             for (unsigned int i = 0; i < merged_b_boxes.size(); ++i)
               volumes.push_back(merged_b_boxes[i].volume());
 

--- a/source/grid/manifold.cc
+++ b/source/grid/manifold.cc
@@ -26,6 +26,7 @@
 
 #include <boost/container/small_vector.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <limits>
 #include <memory>
@@ -173,8 +174,8 @@ Manifold<3, 3>::normal_vector(const Triangulation<3, 3>::face_iterator &face,
                                          vertices[1].distance(p),
                                          vertices[2].distance(p),
                                          vertices[3].distance(p)}};
-  const double max_distance = std::max(std::max(distances[0], distances[1]),
-                                       std::max(distances[2], distances[3]));
+  const double                max_distance =
+    std::max({distances[0], distances[1], distances[2], distances[3]});
 
   // We need to find two tangential vectors to the given point p, but we do
   // not know how the point is oriented against the face. We guess the two

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -12435,10 +12435,10 @@ void Triangulation<dim, spacedim>::copy_triangulation(
 
 
   levels.reserve(other_tria.levels.size());
-  for (unsigned int level = 0; level < other_tria.levels.size(); ++level)
+  for (const auto &level : other_tria.levels)
     levels.push_back(
       std::make_unique<internal::TriangulationImplementation::TriaLevel>(
-        *other_tria.levels[level]));
+        *level));
 
   number_cache = other_tria.number_cache;
 

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -28,6 +28,7 @@
 #include <deal.II/grid/tria_iterator.h>
 #include <deal.II/grid/tria_levels.h>
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <limits>
@@ -1624,8 +1625,7 @@ TriaAccessor<3, 3, 3>::extent_in_direction(const unsigned int axis) const
                        this->line(lines[axis][2])->diameter(),
                        this->line(lines[axis][3])->diameter()};
 
-  return std::max(std::max(lengths[0], lengths[1]),
-                  std::max(lengths[2], lengths[3]));
+  return std::max({lengths[0], lengths[1], lengths[2], lengths[3]});
 }
 
 

--- a/source/grid/tria_description.cc
+++ b/source/grid/tria_description.cc
@@ -242,6 +242,7 @@ namespace TriangulationDescription
                                    unsigned int>>
               temp;
 
+            temp.reserve(this->coarse_cells.size());
             for (unsigned int i = 0; i < this->coarse_cells.size(); ++i)
               temp.emplace_back(this->coarse_cell_index_to_coarse_cell_id[i],
                                 this->coarse_cells[i],

--- a/source/hp/fe_values.cc
+++ b/source/hp/fe_values.cc
@@ -38,6 +38,7 @@ namespace hp
     {
       std::vector<QCollection<q_dim>> q_collections;
 
+      q_collections.reserve(q_collection.size());
       for (unsigned int q = 0; q < q_collection.size(); ++q)
         q_collections.emplace_back(q_collection[q]);
 

--- a/source/non_matching/quadrature_generator.cc
+++ b/source/non_matching/quadrature_generator.cc
@@ -603,14 +603,14 @@ namespace NonMatching
             // Since we already know the function values at the interval ends we
             // might as well check these for min/max too.
             const double function_min =
-              std::min(std::min(left_value, right_value), value_bounds.first);
+              std::min({left_value, right_value, value_bounds.first});
 
             // If the functions is positive there are no roots.
             if (function_min > 0)
               return;
 
             const double function_max =
-              std::max(std::max(left_value, right_value), value_bounds.second);
+              std::max({left_value, right_value, value_bounds.second});
 
             // If the function is negative there are no roots.
             if (function_max < 0)

--- a/source/numerics/derivative_approximation.cc
+++ b/source/numerics/derivative_approximation.cc
@@ -46,6 +46,7 @@
 
 #include <deal.II/numerics/derivative_approximation.h>
 
+#include <algorithm>
 #include <cmath>
 
 DEAL_II_NAMESPACE_OPEN
@@ -479,8 +480,7 @@ namespace DerivativeApproximation
             }
         }
 
-      return std::max(std::fabs(EE[0]),
-                      std::max(std::fabs(EE[1]), std::fabs(EE[2])));
+      return std::max({std::fabs(EE[0]), std::fabs(EE[1]), std::fabs(EE[2])});
     }
 
 
@@ -829,7 +829,7 @@ namespace DerivativeApproximation
       auto neighbor_ptr = active_neighbors.begin();
       for (; neighbor_ptr != active_neighbors.end(); ++neighbor_ptr)
         {
-          const auto neighbor = *neighbor_ptr;
+          const auto &neighbor = *neighbor_ptr;
 
           // reinit FE values object...
           x_fe_midpoint_value.reinit(neighbor);

--- a/source/numerics/point_value_history.cc
+++ b/source/numerics/point_value_history.cc
@@ -290,6 +290,7 @@ PointValueHistory<dim>::add_point(const Point<dim> &location)
   // the GridTools function does not cater for
   // a vector of points, and does not seem to
   // be intrinsicly faster than this method.
+  new_solution_indices.reserve(dof_handler->get_fe(0).n_components());
   for (unsigned int component = 0;
        component < dof_handler->get_fe(0).n_components();
        component++)
@@ -423,6 +424,7 @@ PointValueHistory<dim>::add_points(const std::vector<Point<dim>> &locations)
       current_cell[point]->get_dof_indices(local_dof_indices);
       std::vector<types::global_dof_index> new_solution_indices;
 
+      new_solution_indices.reserve(dof_handler->get_fe(0).n_components());
       for (unsigned int component = 0;
            component < dof_handler->get_fe(0).n_components();
            component++)

--- a/source/numerics/smoothness_estimator.cc
+++ b/source/numerics/smoothness_estimator.cc
@@ -294,6 +294,7 @@ namespace SmoothnessEstimator
       // finite element, the smoothness estimation algorithm tends to produce
       // stable results.
       std::vector<unsigned int> n_coefficients_per_direction;
+      n_coefficients_per_direction.reserve(fe_collection.size());
       for (unsigned int i = 0; i < fe_collection.size(); ++i)
         n_coefficients_per_direction.push_back(fe_collection[i].degree + 2);
 
@@ -583,6 +584,7 @@ namespace SmoothnessEstimator
       // element, the smoothness estimation algorithm tends to produce stable
       // results.
       std::vector<unsigned int> n_coefficients_per_direction;
+      n_coefficients_per_direction.reserve(fe_collection.size());
       for (unsigned int i = 0; i < fe_collection.size(); ++i)
         n_coefficients_per_direction.push_back(fe_collection[i].degree + 2);
 


### PR DESCRIPTION
I was running clang-tidy 20 locally and noticed a couple more complaints that this pull request fixes (mostly automatically). Note that I disabled `performance-unnecessary-value-param` since it provided too many suggestions where most of them didn't seem to be helpful.