### PR TITLE
Add necessary header includes.

### DIFF
--- a/include/deal.II/matrix_free/evaluation_selector.h
+++ b/include/deal.II/matrix_free/evaluation_selector.h
@@ -22,6 +22,9 @@
 #include <deal.II/matrix_free/evaluation_kernels.h>
 #include <deal.II/matrix_free/shape_info.h>
 
+#include <type_traits>
+
+
 DEAL_II_NAMESPACE_OPEN
 
 

--- a/include/deal.II/multigrid/mg_transfer_matrix_free.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_matrix_free.templates.h
@@ -19,6 +19,8 @@
 
 #include <deal.II/multigrid/mg_transfer_matrix_free.h>
 
+#include <type_traits>
+
 
 DEAL_II_NAMESPACE_OPEN
 


### PR DESCRIPTION
This is a bit of a funny case. These two files do not have any C++ standard header file `#include`s, and so only get stuff from the C++ standard library transitively via the deal.II header files. The transitive inclusion does not work with modules, so I have to be explicit what files use, and this has spawned #18237, #18161, #18160, #18221, and a number of others.

Here, however, the whole file does not use anything qualified with `std::` -- or at least it *seems* like it doesn't. But in release mode (and when using C++20), we expand `Assert` into something that includes the use of `std::remove_reference_t`, see https://github.com/dealii/dealii/blob/master/include/deal.II/base/exception_macros.h#L607-L617
So we need to `#include <type_traits>`, which declares `std::remove_reference_t`.

Part of #18071.