### PR TITLE
CMake: Bugfix: ensure that `CMAKE_REQUIRED_*` are populated prior to language feature checks

### DIFF
--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -36,7 +36,6 @@
 #                                                                      #
 ########################################################################
 
-
 #
 # We need compiler flags specified in ${DEAL_II_CXX_FLAGS} for all the
 # tests. Create a small macro to easily set CMAKE_REQUIRED_FLAGS
@@ -413,6 +412,12 @@ else()
   enable_if_supported(_werror_flag "-Werror")
   enable_if_supported(_werror_flag "-Wno-unused-command-line-argument")
 endif()
+
+#
+# We need to reset CMAKE_REQUIRED_* variables again after the above call to
+# enable_if_supported()
+#
+_set_up_cmake_required()
 add_flags(CMAKE_REQUIRED_FLAGS "${_werror_flag}")
 
 unset_if_changed(CHECK_CXX_FEATURES_FLAGS_SAVED

--- a/cmake/macros/macro_enable_if_links.cmake
+++ b/cmake/macros/macro_enable_if_links.cmake
@@ -14,15 +14,16 @@
 
 #
 # Tests whether it is possible to compile and link a dummy program with a
-# given flag.
-# If so, add it to variable.
+# given flag. If so, add it to variable.
+#
+# Note: This macro will reset the CMAKE_REQUIRED_* variables.
 #
 # Usage:
 #     enable_if_links(variable flag)
 #
 
 macro(enable_if_links _variable _flag)
-  # keep on top to avoid cluttering the _flag and _flag_stripped variables
+  reset_cmake_required()
   enable_if_supported(CMAKE_REQUIRED_FLAGS "-Werror")
 
   string(STRIP "${_flag}" _flag_stripped)
@@ -32,11 +33,12 @@ macro(enable_if_links _variable _flag)
 
     list(APPEND CMAKE_REQUIRED_LIBRARIES "${_flag_stripped}")
     CHECK_CXX_SOURCE_COMPILES("int main(){}" DEAL_II_HAVE_LINKER_FLAG_${_flag_name})
-    reset_cmake_required()
 
     if(DEAL_II_HAVE_LINKER_FLAG_${_flag_name})
       set(${_variable} "${${_variable}} ${_flag_stripped}")
       string(STRIP "${${_variable}}" ${_variable})
     endif()
   endif()
+
+  reset_cmake_required()
 endmacro()

--- a/cmake/macros/macro_enable_if_supported.cmake
+++ b/cmake/macros/macro_enable_if_supported.cmake
@@ -13,21 +13,24 @@
 ## ------------------------------------------------------------------------
 
 #
-# Tests whether the cxx compiler understands a flag.
-# If so, add it to 'variable'.
+# Tests whether the cxx compiler understands a flag. If so, add it to
+# 'variable'.
+#
+# Note: This macro will reset the CMAKE_REQUIRED_* variables.
 #
 # Usage:
 #     enable_if_supported(variable flag)
 #
 
 macro(enable_if_supported _variable _flag)
-  # First check if we can use -Werror
+  reset_cmake_required()
+
+  #
+  # Add -Werror if available:
+  #
   CHECK_CXX_COMPILER_FLAG("-Werror" DEAL_II_HAVE_FLAG_Werror)
-
-  string(STRIP "${_flag}" _flag_stripped)
-
   if(DEAL_II_HAVE_FLAG_Werror)
-    set(CMAKE_REQUIRED_FLAGS "-Werror")
+    string(STRIP "${CMAKE_REQUIRED_FLAGS} -Werror" CMAKE_REQUIRED_FLAGS)
   endif()
 
   #
@@ -37,6 +40,7 @@ macro(enable_if_supported _variable _flag)
   # compilation unit.
   # Therefore we invert the test for -Wno-... flags:
   #
+  string(STRIP "${_flag}" _flag_stripped)
   set(_flag_sanitized "${_flag_stripped}")
   if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     string(REPLACE "-Wno-" "-W" _flag_sanitized "${_flag_stripped}")
@@ -54,5 +58,5 @@ macro(enable_if_supported _variable _flag)
     endif()
   endif()
 
-  unset(CMAKE_REQUIRED_FLAGS)
+  reset_cmake_required()
 endmacro()


### PR DESCRIPTION
We need to ensure that `CMAKE_REQUIRED_*` are always populated with a minimal set of compiler flags (and possibly support libraries to link against).

These variables are unfortunately global state and might get reset in subtle ways, for example, by a call to `enable_if_supported()`.

In order to make this more robust this pull request:
 - ensures that `enable_if_supported()` and `enable_if_links()` always reset the `CMAKE_REQUIRED_*` flags properly to default values. In principle it could be argued that we should save and restore the previous state of the variables... but given the fact that we had the wrong behavior for about 10 years I am a bit hesitant to change this...
 - reset `CMAKE_REQUIRED_*` properly again after a call to `enable_if_supported()` in `check_01_cxx_features` so that the subsequent language feature check actually uses the correct compiler flags.

 Closes #18248
