### PR TITLE
Replace min(max()) by clamp().  #17722

### DIFF
--- a/examples/step-21/step-21.cc
+++ b/examples/step-21/step-21.cc
@@ -343,7 +343,7 @@ namespace Step21
                                        (0.05 * 0.05));
 
             const double normalized_permeability =
-              std::min(std::max(permeability, 0.01), 4.);
+              std::clamp(permeability, 0.01, 4.);
 
             for (unsigned int d = 0; d < dim; ++d)
               values[p][d][d] = 1. / normalized_permeability;

--- a/examples/step-42/step-42.cc
+++ b/examples/step-42/step-42.cc
@@ -492,11 +492,11 @@ namespace Step42
     template <int dim>
     double BitmapFile<dim>::get_value(const double x, const double y) const
     {
-      const int ix = std::min(std::max(static_cast<int>(x / hx), 0), nx - 2);
-      const int iy = std::min(std::max(static_cast<int>(y / hy), 0), ny - 2);
+      const int ix = std::clamp(static_cast<int>(x / hx), 0, nx - 2);
+      const int iy = std::clamp(static_cast<int>(y / hy), 0, ny - 2);
 
-      const double xi  = std::min(std::max((x - ix * hx) / hx, 1.), 0.);
-      const double eta = std::min(std::max((y - iy * hy) / hy, 1.), 0.);
+      const double xi  = std::clamp((x - ix * hx) / hx, 0., 1.);
+      const double eta = std::clamp((y - iy * hy) / hy, 0., 1.);
 
       return ((1 - xi) * (1 - eta) * get_pixel_value(ix, iy) +
               xi * (1 - eta) * get_pixel_value(ix + 1, iy) +

--- a/examples/step-43/step-43.cc
+++ b/examples/step-43/step-43.cc
@@ -254,7 +254,7 @@ namespace Step43
               std::exp(-(points[p] - centers[i]).norm_square() / (0.05 * 0.05));
 
           const double normalized_permeability =
-            std::min(std::max(permeability, 0.01), 4.);
+            std::clamp(permeability, 0.01, 4.);
 
           for (unsigned int d = 0; d < dim; ++d)
             values[p][d][d] = 1. / normalized_permeability;

--- a/examples/step-79/step-79.cc
+++ b/examples/step-79/step-79.cc
@@ -2420,9 +2420,9 @@ namespace SAND
         const double barrier_size_exponent   = 1.2;
 
         barrier_size =
-          std::max(std::min(barrier_size * barrier_size_multiplier,
-                            std::pow(barrier_size, barrier_size_exponent)),
-                   min_barrier_size);
+          std::clamp(barrier_size * barrier_size_multiplier,
+                     min_barrier_size,
+                     std::pow(barrier_size, barrier_size_exponent));
 
         std::cout << std::endl;
       }

--- a/include/deal.II/base/geometry_info.h
+++ b/include/deal.II/base/geometry_info.h
@@ -814,7 +814,8 @@ public:
    * mapping from the symbolic flags defined in the RefinementPossibilities
    * base class to actual numerical values (the array indices).
    */
-  DEAL_II_HOST_DEVICE operator std::uint8_t() const;
+  DEAL_II_HOST_DEVICE
+  operator std::uint8_t() const;
 
   /**
    * Return the union of the refinement flags represented by the current

--- a/source/base/function_lib.cc
+++ b/source/base/function_lib.cc
@@ -2604,11 +2604,11 @@ namespace Functions
     // above to accommodate points that may lie outside the range
     Point<dim> p_unit;
     for (unsigned int d = 0; d < dim; ++d)
-      p_unit[d] = std::max(std::min((p[d] - coordinate_values[d][ix[d]]) /
-                                      (coordinate_values[d][ix[d] + 1] -
-                                       coordinate_values[d][ix[d]]),
-                                    1.),
-                           0.);
+      p_unit[d] = std::clamp((p[d] - coordinate_values[d][ix[d]]) /
+                               (coordinate_values[d][ix[d] + 1] -
+                                coordinate_values[d][ix[d]]),
+                             0.,
+                             1.);
 
     return interpolate(data_values, ix, p_unit);
   }
@@ -2636,8 +2636,7 @@ namespace Functions
     Point<dim> p_unit;
     for (unsigned int d = 0; d < dim; ++d)
       p_unit[d] =
-        std::max(std::min((p[d] - coordinate_values[d][ix[d]]) / dx[d], 1.),
-                 0.0);
+        std::clamp((p[d] - coordinate_values[d][ix[d]]) / dx[d], 0., 1.);
 
     return gradient_interpolate(data_values, ix, p_unit, dx);
   }
@@ -2729,11 +2728,12 @@ namespace Functions
         const double delta_x =
           ((interval_endpoints[d].second - interval_endpoints[d].first) /
            n_subintervals[d]);
-        p_unit[d] = std::max(std::min((p[d] - interval_endpoints[d].first -
-                                       ix[d] * delta_x) /
-                                        delta_x,
-                                      1.),
-                             0.);
+
+        p_unit[d] =
+          std::clamp((p[d] - interval_endpoints[d].first - ix[d] * delta_x) /
+                       delta_x,
+                     0.,
+                     1.);
       }
 
     return interpolate(data_values, ix, p_unit);
@@ -2778,12 +2778,11 @@ namespace Functions
         delta_x[d] = ((this->interval_endpoints[d].second -
                        this->interval_endpoints[d].first) /
                       this->n_subintervals[d]);
-        p_unit[d] =
-          std::max(std::min((p[d] - this->interval_endpoints[d].first -
-                             ix[d] * delta_x[d]) /
-                              delta_x[d],
-                            1.),
-                   0.);
+        p_unit[d]  = std::clamp((p[d] - this->interval_endpoints[d].first -
+                                ix[d] * delta_x[d]) /
+                                 delta_x[d],
+                               0.,
+                               1.);
       }
 
     return gradient_interpolate(this->data_values, ix, p_unit, delta_x);

--- a/source/base/function_signed_distance.cc
+++ b/source/base/function_signed_distance.cc
@@ -265,7 +265,7 @@ namespace Functions
           delta_t = delta_c / std::sqrt(a * a + b * b - x * x - y * y);
           t += delta_t;
           // make sure the angle stays in first quadrant
-          t = std::min(numbers::PI_2, std::max(0.0, t));
+          t = std::clamp(t, 0.0, numbers::PI_2);
           x = a * std::cos(t);
           y = b * std::sin(t);
           ++iter;

--- a/source/base/process_grid.cc
+++ b/source/base/process_grid.cc
@@ -71,7 +71,6 @@ namespace
     //  ++Pc;
     // but this affects the grid shape dramatically, i.e. 10 cores 3x3 becomes
     // 2x5.
-
     // limit our estimate to be in [2, Np]
     int n_process_columns = std::min(Np, std::max(2, Pc));
     // finally, get the rows:


### PR DESCRIPTION
- Worked on replacing std::min(b, std::max(x,a)) by std::clamp(x, a, b).

- Cases where there are operator overloading are ommited. 

- Cases where the min max bounds are undetermined are ommited.

(*I initially worked on the master branch which caused issues, and this push request is the same but from a feature branch, sorry for issues I caused.)