### PR TITLE
Fix a linker error

### DIFF
--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -3707,7 +3707,7 @@ MGTwoLevelTransfer<dim, VectorType>::interpolate(VectorType       &dst,
 
 namespace internal
 {
-  bool
+  inline bool
   is_partitioner_contained(
     const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner,
     const std::shared_ptr<const Utilities::MPI::Partitioner>
@@ -3736,7 +3736,7 @@ namespace internal
                                partitioner->get_mpi_communicator()) == 1;
   }
 
-  std::shared_ptr<Utilities::MPI::Partitioner>
+  inline std::shared_ptr<Utilities::MPI::Partitioner>
   create_embedded_partitioner(
     const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner,
     const std::shared_ptr<const Utilities::MPI::Partitioner>


### PR DESCRIPTION
Since #18231 we see linker errors when compiling ASPECT against a recent development version of deal.II, see here: https://github.com/geodynamics/aspect/actions/runs/13927682371/job/38976426912?pr=6256#step:4:232

The messages are a lot of these (one per source file):

```
/usr/bin/ld: CMakeFiles/aspect.exe.debug.dir/Unity/unity_42_cxx.cxx.o: in function `dealii::internal::create_embedded_partitioner(std::shared_ptr<dealii::Utilities::MPI::Partitioner const> const&, std::shared_ptr<dealii::Utilities::MPI::Partitioner const> const&)':
unity_42_cxx.cxx:(.text+0x5d20): multiple definition of `dealii::internal::create_embedded_partitioner(std::shared_ptr<dealii::Utilities::MPI::Partitioner const> const&, std::shared_ptr<dealii::Utilities::MPI::Partitioner const> const&)'; CMakeFiles/aspect.exe.debug.dir/Unity/unity_43_cxx.cxx.o:unity_43_cxx.cxx:(.text+0x1ce80): first defined here
/usr/bin/ld: CMakeFiles/aspect.exe.debug.dir/Unity/unity_42_cxx.cxx.o: in function `dealii::internal::is_partitioner_contained(std::shared_ptr<dealii::Utilities::MPI::Partitioner const> const&, std::shared_ptr<dealii::Utilities::MPI::Partitioner const> const&)':
unity_42_cxx.cxx:(.text+0x6aa0): multiple definition of `dealii::internal::is_partitioner_contained(std::shared_ptr<dealii::Utilities::MPI::Partitioner const> const&, std::shared_ptr<dealii::Utilities::MPI::Partitioner const> const&)'; CMakeFiles/aspect.exe.debug.dir/Unity/unity_43_cxx.cxx.o:unity_43_cxx.cxx:(.text+0x1cf70): first defined here
/usr/bin/ld: CMakeFiles/aspect.exe.debug.dir/Unity/unity_41_cxx.cxx.o: in function `dealii::internal::create_embedded_partitioner(std::shared_ptr<dealii::Utilities::MPI::Partitioner const> const&, std::shared_ptr<dealii::Utilities::MPI::Partitioner const> const&)':
```

I think this is because giving this namespace a name made it so that these functions are now available in multiple translation units (all files that include `mg_transfer_global_coarsening.templates.h`). I am not exactly sure what the correct fix is for this, but here is one fix in which I made the functions inline.

Questions I have are:
- is this an acceptable solution?
- another option could be to move the definition of the functions into `mg_transfer_global_coarsening.cc` and the declaration into `mg_transfer_global_coarsening.h`
- are we doing anything wrong in ASPECT by including this file from multiple places? Since deal.II is compiling just fine, it looks like none of the tests or other files in deal.II have this problem.

