### PR TITLE
portable matrix-free: fix GPU crash in compute_diagonal()

### DIFF
--- a/doc/news/changes/minor/20250319tjhei
+++ b/doc/news/changes/minor/20250319tjhei
@@ -1,0 +1,5 @@
+New: Portable::FEEvaluation::get_current_cell_index() and
+Portable::FEEvaluation::get_matrix_free_data() allow querying
+the current Portable::MatrixFree::Data object and the current cell index respectively.
+<br>
+(Daniel Arndt, Timo Heister, 2025/03/19)

--- a/include/deal.II/matrix_free/portable_fe_evaluation.h
+++ b/include/deal.II/matrix_free/portable_fe_evaluation.h
@@ -127,6 +127,22 @@ namespace Portable
     FEEvaluation(const data_type *data, SharedData<dim, Number> *shdata);
 
     /**
+     * Return the index of the current cell.
+     */
+    DEAL_II_HOST_DEVICE
+    int
+    get_current_cell_index();
+
+    /**
+     * Return a pointer to the MatrixFree<dim, Number>::Data object on device
+     * that contains necessary constraint, dof index, and shape function
+     * information for evaluation used in the matrix-free kernels.
+     */
+    DEAL_II_HOST_DEVICE
+    const data_type *
+    get_matrix_free_data();
+
+    /**
      * For the vector @p src, read out the values on the degrees of freedom of
      * the current cell, and store them internally. Similar functionality as
      * the function DoFAccessor::get_interpolated_dof_values when no
@@ -267,6 +283,38 @@ namespace Portable
     , shared_data(shdata)
     , cell_id(shared_data->team_member.league_rank())
   {}
+
+
+
+  template <int dim,
+            int fe_degree,
+            int n_q_points_1d,
+            int n_components_,
+            typename Number>
+  DEAL_II_HOST_DEVICE int
+  FEEvaluation<dim, fe_degree, n_q_points_1d, n_components_, Number>::
+    get_current_cell_index()
+  {
+    return cell_id;
+  }
+
+
+
+  template <int dim,
+            int fe_degree,
+            int n_q_points_1d,
+            int n_components_,
+            typename Number>
+  DEAL_II_HOST_DEVICE const typename FEEvaluation<dim,
+                                                  fe_degree,
+                                                  n_q_points_1d,
+                                                  n_components_,
+                                                  Number>::data_type *
+  FEEvaluation<dim, fe_degree, n_q_points_1d, n_components_, Number>::
+    get_matrix_free_data()
+  {
+    return data;
+  }
 
 
 

--- a/include/deal.II/matrix_free/tools.h
+++ b/include/deal.II/matrix_free/tools.h
@@ -1407,8 +1407,7 @@ namespace MatrixFreeTools
         Portable::
           FEEvaluation<dim, fe_degree, n_q_points_1d, n_components, Number>
             fe_eval(gpu_data, shared_data);
-        m_quad_operation.set_matrix_free_data(*gpu_data);
-        m_quad_operation.set_cell(cell);
+
         constexpr int dofs_per_cell = decltype(fe_eval)::tensor_dofs_per_cell;
         typename decltype(fe_eval)::value_type
           diagonal[dofs_per_cell / n_components] = {};
@@ -1503,7 +1502,7 @@ namespace MatrixFreeTools
         dealii::Utilities::pow(n_q_points_1d, dim);
 
     private:
-      mutable QuadOperation                  m_quad_operation;
+      const QuadOperation                    m_quad_operation;
       const EvaluationFlags::EvaluationFlags m_evaluation_flags;
       const EvaluationFlags::EvaluationFlags m_integration_flags;
     };

--- a/tests/matrix_free_kokkos/compute_diagonal_util.h
+++ b/tests/matrix_free_kokkos/compute_diagonal_util.h
@@ -59,15 +59,6 @@ public:
     fe_eval->submit_gradient(fe_eval->get_gradient(q_point), q_point);
   }
 
-  DEAL_II_HOST_DEVICE
-  void
-  set_cell(int)
-  {}
-
-  DEAL_II_HOST_DEVICE void
-  set_matrix_free_data(const typename Portable::MatrixFree<dim, Number>::Data &)
-  {}
-
   static const unsigned int n_q_points =
     dealii::Utilities::pow(fe_degree + 1, dim);
 


### PR DESCRIPTION
fixes #18210

The Functor passed to Kokkos::parallel_for() is placed into constant memory, which is read-only. This means the HelmholtzOperatorQuad can not be modified by setting a member variable to the current cell index for example. Instead, add access functions for the necessary functions to FEEvaluation and query the information as needed.

This took @masterleinad and me a whole day to figure out.

FYI @YiminJin (this was not your fault!)