### PR TITLE
Set a formula in typewriter font

### DIFF
--- a/include/deal.II/lac/lapack_full_matrix.h
+++ b/include/deal.II/lac/lapack_full_matrix.h
@@ -766,7 +766,7 @@ public:
    * to just have this function compute the eigenvalues and have a separate
    * function that returns whatever eigenvalue is requested. Eigenvalues can
    * be retrieved using the eigenvalue() function.  The number of computed
-   * eigenvectors is equal to eigenvectors.size()
+   * eigenvectors is equal to `eigenvectors.size()`.
    *
    * @note Calls the LAPACK function Xsygv.
    */


### PR DESCRIPTION
Looking at the documentation of https://www.dealii.org/developer/doxygen/deal.II/classLAPACKFullMatrix.html#af6004bfed5948bae4352f22f9e2760d4 I realized that we did not set a formula in tt font (and had no period at the end of line). Fix this.