### PR TITLE
SparsityPattern: order of functions and avoid inlining a function

### DIFF
--- a/include/deal.II/lac/sparsity_pattern.h
+++ b/include/deal.II/lac/sparsity_pattern.h
@@ -777,26 +777,6 @@ public:
   empty() const;
 
   /**
-   * Check if a value at a certain position may be non-zero.
-   */
-  bool
-  exists(const size_type i, const size_type j) const;
-
-  /**
-   * This is the inverse operation to operator()(): given a global index, find
-   * out row and column of the matrix entry to which it belongs. The returned
-   * value is the pair composed of row and column index.
-   *
-   * This function may only be called if the sparsity pattern is closed. The
-   * global index must then be between zero and n_nonzero_elements().
-   *
-   * If <tt>N</tt> is the number of rows of this matrix, then the complexity
-   * of this function is <i>log(N)</i>.
-   */
-  std::pair<size_type, size_type>
-  matrix_position(const std::size_t global_index) const;
-
-  /**
    * Compute the bandwidth of the matrix represented by this structure. The
    * bandwidth is the maximum of $|i-j|$ for which the index pair $(i,j)$
    * represents a nonzero entry of the matrix. Consequently, the maximum
@@ -892,6 +872,12 @@ public:
   operator()(const size_type i, const size_type j) const;
 
   /**
+   * Check if a value at a certain position may be non-zero.
+   */
+  bool
+  exists(const size_type i, const size_type j) const;
+
+  /**
    * Access to column number field.  Return the column number of the
    * <tt>index</tt>th entry in <tt>row</tt>. Note that if diagonal elements
    * are optimized, the first element in each row is the diagonal element,
@@ -903,6 +889,20 @@ public:
    */
   size_type
   column_number(const size_type row, const unsigned int index) const;
+
+  /**
+   * This is the inverse operation to operator()(): given a global index, find
+   * out row and column of the matrix entry to which it belongs. The returned
+   * value is the pair composed of row and column index.
+   *
+   * This function may only be called if the sparsity pattern is closed. The
+   * global index must then be between zero and n_nonzero_elements().
+   *
+   * If <tt>N</tt> is the number of rows of this matrix, then the complexity
+   * of this function is <i>log(N)</i>.
+   */
+  std::pair<size_type, size_type>
+  matrix_position(const std::size_t global_index) const;
 
   /**
    * The index of a global matrix entry in its row.
@@ -1390,35 +1390,6 @@ SparsityPattern::end(const size_type r) const
   AssertIndexRange(r, n_rows());
 
   return {this, rowstart[r + 1]};
-}
-
-
-
-inline bool
-SparsityPattern::operator==(const SparsityPattern &sp2) const
-{
-  if (store_diagonal_first_in_row != sp2.store_diagonal_first_in_row)
-    return false;
-
-  // it isn't quite necessary to compare *all* member variables. by only
-  // comparing the essential ones, we can say that two sparsity patterns are
-  // equal even if one is compressed and the other is not (in which case some
-  // of the member variables are not yet set correctly)
-  if (rows != sp2.rows || cols != sp2.cols || compressed != sp2.compressed)
-    return false;
-
-  if (rows > 0)
-    {
-      for (size_type i = 0; i < rows + 1; ++i)
-        if (rowstart[i] != sp2.rowstart[i])
-          return false;
-
-      for (size_type i = 0; i < rowstart[rows]; ++i)
-        if (colnums[i] != sp2.colnums[i])
-          return false;
-    }
-
-  return true;
 }
 
 


### PR DESCRIPTION
When I was looking for functions provided by `SparsityPattern` https://www.dealii.org/developer/doxygen/deal.II/classSparsityPattern.html, I had it hard to orient myself. I believe it would be better to place the declaration of all functions that relate to the position of the entries (`operator()`, `exisits()`, `column_number()`, `matrix_position()`, `row_position()`) in the section `Accessing entries` (in particular since `matrix_position()` is the inverse of `operator()`). I then also placed the implementations in the same order. I also saw that `SparsityPattern::operator==` is provided as inline function, but it is an expensive function, so I see no real reason to not move the implementation to the cc file.