### PR TITLE
Inline an often-used function

### DIFF
--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -1815,6 +1815,7 @@ SparseMatrix<number>::m() const
 }
 
 
+
 template <typename number>
 inline typename SparseMatrix<number>::size_type
 SparseMatrix<number>::n() const
@@ -1822,6 +1823,17 @@ SparseMatrix<number>::n() const
   Assert(cols != nullptr, ExcNeedsSparsityPattern());
   return cols->cols;
 }
+
+
+
+template <typename number>
+inline const SparsityPattern &
+SparseMatrix<number>::get_sparsity_pattern() const
+{
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
+  return *cols;
+}
+
 
 
 // Inline the set() and add() functions, since they will be called frequently.

--- a/include/deal.II/lac/sparse_matrix.templates.h
+++ b/include/deal.II/lac/sparse_matrix.templates.h
@@ -1876,16 +1876,6 @@ SparseMatrix<number>::SSOR(Vector<somenumber> &dst, const number omega) const
 
 
 template <typename number>
-const SparsityPattern &
-SparseMatrix<number>::get_sparsity_pattern() const
-{
-  Assert(cols != nullptr, ExcNeedsSparsityPattern());
-  return *cols;
-}
-
-
-
-template <typename number>
 void
 SparseMatrix<number>::print_formatted(std::ostream      &out,
                                       const unsigned int precision,


### PR DESCRIPTION
I saw in a profiler a repeated access to `SparseMatrix::get_sparsity_pattern()`. Its implementation is a one-liner (2 instructions), and it is better to simply make that function inline, as we do for other similar cheap function.