### PR TITLE
SparseMatrixTools: speed up a function to extract a sub-matrix

### DIFF
--- a/include/deal.II/lac/sparse_matrix_tools.h
+++ b/include/deal.II/lac/sparse_matrix_tools.h
@@ -510,9 +510,15 @@ namespace SparseMatrixTools
                       const types::global_dof_index ind =
                         system_matrix.get_sparsity_pattern()(
                           local_dof_indices[i], local_dof_indices[j]);
-                      if (ind != numbers::invalid_dof_index)
+
+                      // If SparsityPattern::operator()` found the entry, then
+                      // we can access the corresponding value without a
+                      // second search in the sparse matrix, otherwise the
+                      // matrix entry at that index is zero because it does
+                      // not exist in the sparsity pattern
+                      if (ind != SparsityPattern::invalid_entry)
                         {
-                          SparseMatrixIterators::Accessor<Number, true>
+                          const SparseMatrixIterators::Accessor<Number, true>
                             accessor(&system_matrix, ind);
                           cell_matrix(i, j) = accessor.value();
                         }

--- a/include/deal.II/lac/sparse_matrix_tools.h
+++ b/include/deal.II/lac/sparse_matrix_tools.h
@@ -516,6 +516,8 @@ namespace SparseMatrixTools
                             accessor(&system_matrix, ind);
                           cell_matrix(i, j) = accessor.value();
                         }
+                      else
+                        cell_matrix(i, j) = 0.0;
                     }
                   else
                     cell_matrix(i, j) =

--- a/include/deal.II/lac/sparse_matrix_tools.h
+++ b/include/deal.II/lac/sparse_matrix_tools.h
@@ -504,12 +504,26 @@ namespace SparseMatrixTools
               if (locally_owned_dofs.is_element(
                     local_dof_indices[i])) // row is local
                 {
-                  cell_matrix(i, j) =
-                    sparsity_pattern.exists(local_dof_indices[i],
-                                            local_dof_indices[j]) ?
-                      system_matrix(local_dof_indices[i],
-                                    local_dof_indices[j]) :
-                      0;
+                  if constexpr (std::is_same_v<SparseMatrixType,
+                                               dealii::SparseMatrix<Number>>)
+                    {
+                      const types::global_dof_index ind =
+                        system_matrix.get_sparsity_pattern()(
+                          local_dof_indices[i], local_dof_indices[j]);
+                      if (ind != numbers::invalid_dof_index)
+                        {
+                          SparseMatrixIterators::Accessor<Number, true>
+                            accessor(&system_matrix, ind);
+                          cell_matrix(i, j) = accessor.value();
+                        }
+                    }
+                  else
+                    cell_matrix(i, j) =
+                      sparsity_pattern.exists(local_dof_indices[i],
+                                              local_dof_indices[j]) ?
+                        system_matrix(local_dof_indices[i],
+                                      local_dof_indices[j]) :
+                        0.0;
                 }
               else // row is ghost
                 {


### PR DESCRIPTION
I made experiments with extracting sub-matrices from a `dealii::SparseMatrix` via `SparseMatrixTools::extract_full_matrices()`. I had to realize that `SparsityPattern::exists()` is implemented in the general case before the pattern is sorted using a linear search, https://github.com/dealii/dealii/blob/a6be64acbeaa40fbc4c9c5d6a231848167b599e5/source/lac/sparsity_pattern.cc#L631-L643
This leads to a quadratic complexity in the number of column entries for extracting the matrix. `SparsityPattern::operator()` does much better by a binary search. Rather than doing that search twice, we can then use the sparse matrix accessor to avoid the second lookup.

I used the function for Q4 elements in 3D and it was almost unbearably slow - for sure, this is a theoretical analysis so speed is not the primary issue, but it was easy enough to fix.