### PR TITLE
refactor Portable::MatrixFree by combining Shared and GPU data

### DIFF
--- a/tests/matrix_free_kokkos/coefficient_eval_device.cc
+++ b/tests/matrix_free_kokkos/coefficient_eval_device.cc
@@ -36,11 +36,9 @@ public:
   DummyOperator() = default;
 
   DEAL_II_HOST_DEVICE void
-  operator()(const unsigned int                                      cell,
-             const typename Portable::MatrixFree<dim, double>::Data *gpu_data,
-             Portable::SharedData<dim, double> *shared_data,
-             const double                      *src,
-             double                            *dst) const;
+  operator()(const typename Portable::MatrixFree<dim, double>::Data *data,
+             const double                                           *src,
+             double                                                 *dst) const;
 
   static const unsigned int n_local_dofs =
     dealii::Utilities::pow(fe_degree + 1, dim);
@@ -53,19 +51,17 @@ public:
 template <int dim, int fe_degree>
 DEAL_II_HOST_DEVICE void
 DummyOperator<dim, fe_degree>::operator()(
-  const unsigned int                                      cell,
-  const typename Portable::MatrixFree<dim, double>::Data *gpu_data,
-  Portable::SharedData<dim, double>                      *shared_data,
+  const typename Portable::MatrixFree<dim, double>::Data *data,
   const double *,
   double *dst) const
 {
   Kokkos::parallel_for(
-    Kokkos::TeamThreadRange(shared_data->team_member, n_q_points),
+    Kokkos::TeamThreadRange(data->team_member, n_q_points),
     [&](const int q_point) {
       const unsigned int pos =
-        gpu_data->local_q_point_id(cell, n_q_points, q_point);
+        data->local_q_point_id(data->cell_index, n_q_points, q_point);
 
-      auto point = gpu_data->get_quadrature_point(cell, q_point);
+      auto point = data->get_quadrature_point(data->cell_index, q_point);
       dst[pos] =
         dim == 2 ? point[0] + point[1] : point[0] + point[1] + point[2];
     });
@@ -149,7 +145,7 @@ test()
   const unsigned int n_colors = graph.size();
   for (unsigned int color = 0; color < n_colors; ++color)
     {
-      typename Portable::MatrixFree<dim, double>::Data gpu_data =
+      typename Portable::MatrixFree<dim, double>::PrecomputedData gpu_data =
         mf_data.get_data(color);
       const unsigned int n_cells = gpu_data.n_cells;
       auto gpu_data_host         = Portable::copy_mf_data_to_host<dim, double>(

--- a/tests/matrix_free_kokkos/matrix_free_device_no_index_initialize.cc
+++ b/tests/matrix_free_kokkos/matrix_free_device_no_index_initialize.cc
@@ -39,25 +39,23 @@ public:
     : data(data_in){};
 
   DEAL_II_HOST_DEVICE void
-  operator()(const unsigned int                                      cell,
-             const typename Portable::MatrixFree<dim, Number>::Data *gpu_data,
-             Portable::SharedData<dim, Number> *shared_data,
-             const Number                      *src,
-             Number                            *dst) const
+  operator()(const typename Portable::MatrixFree<dim, Number>::Data *data,
+             const Number                                           *src,
+             Number                                                 *dst) const
   {
     Portable::FEEvaluation<dim, fe_degree, n_q_points_1d, 1, Number> fe_eval(
-      gpu_data, shared_data);
+      data);
 
     // set to unit vector
     auto fe_eval_ptr = &fe_eval;
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(shared_data->team_member,
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(data->team_member,
                                                  n_local_dofs),
                          [&](int i) { fe_eval_ptr->submit_dof_value(1., i); });
-    shared_data->team_member.team_barrier();
+    data->team_member.team_barrier();
     fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
 
 #ifndef __APPLE__
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(shared_data->team_member,
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(data->team_member,
                                                  n_local_dofs),
                          [&](int i) {
                            // values should evaluate to one, derivatives to zero
@@ -69,7 +67,7 @@ public:
     fe_eval.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
 
     Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(shared_data->team_member, n_local_dofs),
+      Kokkos::TeamThreadRange(data->team_member, n_local_dofs),
       KOKKOS_LAMBDA(int i) { assert(fe_eval_ptr->get_dof_value(i) == 1.); });
 #endif
   }

--- a/tests/matrix_free_kokkos/matrix_vector_host_device_multi_component.cc
+++ b/tests/matrix_free_kokkos/matrix_vector_host_device_multi_component.cc
@@ -166,17 +166,12 @@ public:
   {}
 
   DEAL_II_HOST_DEVICE void
-  operator()(const unsigned int                                      cell,
-             const typename Portable::MatrixFree<dim, Number>::Data *gpu_data,
-             Portable::SharedData<dim, Number> *shared_data,
-             const Number                      *src,
-             Number                            *dst) const
+  operator()(const typename Portable::MatrixFree<dim, Number>::Data *data,
+             const Number                                           *src,
+             Number                                                 *dst) const
   {
-    (void)cell; // TODO?
-
     Portable::FEEvaluation<dim, fe_degree, fe_degree + 1, n_components, Number>
-      phi(
-        /*cell,*/ gpu_data, shared_data);
+      phi(data);
     phi.read_dof_values(src);
 
     if (version == 0)


### PR DESCRIPTION
- rename ``::Data`` to ``::PrecomputedData``
- bundle ``PrecomputedData`` and ``SharedData`` into ``::Data``
- change user interface to only receive a pointer to ``Data`` instead of cell, data, and shared data
- modify evaluate_coefficients to use a Kokkos TeamPolicy