### PR TITLE
Portable::MatrixFree: introduce DeviceVector

### DIFF
--- a/examples/step-64/step-64.cc
+++ b/examples/step-64/step-64.cc
@@ -192,8 +192,8 @@ namespace Step64
 
     DEAL_II_HOST_DEVICE void
     operator()(const typename Portable::MatrixFree<dim, double>::Data *data,
-               const double                                           *src,
-               double *dst) const;
+               const Portable::DeviceVector<double>                   &src,
+               Portable::DeviceVector<double> &dst) const;
 
   private:
     double *coef;
@@ -208,8 +208,8 @@ namespace Step64
   template <int dim, int fe_degree>
   DEAL_II_HOST_DEVICE void LocalHelmholtzOperator<dim, fe_degree>::operator()(
     const typename Portable::MatrixFree<dim, double>::Data *data,
-    const double                                           *src,
-    double                                                 *dst) const
+    const Portable::DeviceVector<double>                   &src,
+    Portable::DeviceVector<double>                         &dst) const
   {
     Portable::FEEvaluation<dim, fe_degree, fe_degree + 1, 1, double> fe_eval(
       data);

--- a/include/deal.II/matrix_free/portable_fe_evaluation.h
+++ b/include/deal.II/matrix_free/portable_fe_evaluation.h
@@ -151,7 +151,7 @@ namespace Portable
      * AffineConstraints::read_dof_values() as well.
      */
     DEAL_II_HOST_DEVICE void
-    read_dof_values(const Number *src);
+    read_dof_values(const DeviceVector<Number> &src);
 
     /**
      * Take the value stored internally on dof values of the current cell and
@@ -160,7 +160,7 @@ namespace Portable
      * function AffineConstraints::distribute_local_to_global.
      */
     DEAL_II_HOST_DEVICE void
-    distribute_local_to_global(Number *dst) const;
+    distribute_local_to_global(DeviceVector<Number> &dst) const;
 
     /**
      * Evaluate the function values and the gradients of the FE function given
@@ -327,7 +327,7 @@ namespace Portable
             typename Number>
   DEAL_II_HOST_DEVICE void
   FEEvaluation<dim, fe_degree, n_q_points_1d, n_components_, Number>::
-    read_dof_values(const Number *src)
+    read_dof_values(const DeviceVector<Number> &src)
   {
     // Populate the scratch memory
     Kokkos::parallel_for(Kokkos::TeamThreadRange(data->team_member,
@@ -359,7 +359,7 @@ namespace Portable
             typename Number>
   DEAL_II_HOST_DEVICE void
   FEEvaluation<dim, fe_degree, n_q_points_1d, n_components_, Number>::
-    distribute_local_to_global(Number *dst) const
+    distribute_local_to_global(DeviceVector<Number> &dst) const
   {
     for (unsigned int c = 0; c < n_components_; ++c)
       {

--- a/include/deal.II/matrix_free/portable_matrix_free.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.h
@@ -379,8 +379,8 @@ namespace Portable
      * \code
      * DEAL_II_HOST_DEVICE void operator()(
      *   const typename Portable::MatrixFree<dim, Number>::Data *data,
-     *   const DeviceVector<Number> &src,
-     *   DeviceVector<Number> & dst) const;
+     *   const DeviceVector<Number>                             &src,
+     *   DeviceVector<Number>                                   &dst) const;
      *   static const unsigned int n_local_dofs;
      *   static const unsigned int n_q_points;
      * \endcode

--- a/include/deal.II/matrix_free/portable_matrix_free.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.h
@@ -66,6 +66,19 @@ namespace Portable
 #endif
 
   /**
+   * Type for source and destination vectors in device functions like
+   * MatrixFree::cell_loop().
+   *
+   * This is a type alias to a Kokkos::View to a chunk of memory, typically
+   * pointing to the local elements in the LinearAlgebra::distributed::Vector.
+   */
+  template <typename Number>
+  using DeviceVector =
+    Kokkos::View<Number *, MemorySpace::Default::kokkos_space>;
+
+
+
+  /**
    * This class collects all the data that is stored for the matrix free
    * implementation. The storage scheme is tailored towards several loops
    * performed with the same data, i.e., typically doing many matrix-vector
@@ -366,8 +379,8 @@ namespace Portable
      * \code
      * DEAL_II_HOST_DEVICE void operator()(
      *   const typename Portable::MatrixFree<dim, Number>::Data *data,
-     *   const Number *                                          src,
-     *   Number *                                                dst) const;
+     *   const DeviceVector<Number> &src,
+     *   DeviceVector<Number> & dst) const;
      *   static const unsigned int n_local_dofs;
      *   static const unsigned int n_q_points;
      * \endcode

--- a/include/deal.II/matrix_free/tools.h
+++ b/include/deal.II/matrix_free/tools.h
@@ -1398,8 +1398,8 @@ namespace MatrixFreeTools
 
       KOKKOS_FUNCTION void
       operator()(const typename Portable::MatrixFree<dim, Number>::Data *data,
-                 const Number *,
-                 Number *dst) const
+                 const Portable::DeviceVector<Number> &,
+                 Portable::DeviceVector<Number> &dst) const
       {
         Portable::
           FEEvaluation<dim, fe_degree, n_q_points_1d, n_components, Number>

--- a/tests/matrix_free_kokkos/coefficient_eval_device.cc
+++ b/tests/matrix_free_kokkos/coefficient_eval_device.cc
@@ -37,8 +37,8 @@ public:
 
   DEAL_II_HOST_DEVICE void
   operator()(const typename Portable::MatrixFree<dim, double>::Data *data,
-             const double                                           *src,
-             double                                                 *dst) const;
+             const Portable::DeviceVector<double>                   &src,
+             Portable::DeviceVector<double>                         &dst) const;
 
   static const unsigned int n_local_dofs =
     dealii::Utilities::pow(fe_degree + 1, dim);
@@ -52,8 +52,8 @@ template <int dim, int fe_degree>
 DEAL_II_HOST_DEVICE void
 DummyOperator<dim, fe_degree>::operator()(
   const typename Portable::MatrixFree<dim, double>::Data *data,
-  const double *,
-  double *dst) const
+  const Portable::DeviceVector<double>                   &src,
+  Portable::DeviceVector<double>                         &dst) const
 {
   Kokkos::parallel_for(
     Kokkos::TeamThreadRange(data->team_member, n_q_points),

--- a/tests/matrix_free_kokkos/matrix_free_device_no_index_initialize.cc
+++ b/tests/matrix_free_kokkos/matrix_free_device_no_index_initialize.cc
@@ -40,8 +40,8 @@ public:
 
   DEAL_II_HOST_DEVICE void
   operator()(const typename Portable::MatrixFree<dim, Number>::Data *data,
-             const Number                                           *src,
-             Number                                                 *dst) const
+             const Portable::DeviceVector<Number>                   &src,
+             Portable::DeviceVector<Number>                         &dst) const
   {
     Portable::FEEvaluation<dim, fe_degree, n_q_points_1d, 1, Number> fe_eval(
       data);

--- a/tests/matrix_free_kokkos/matrix_vector_device_mf.h
+++ b/tests/matrix_free_kokkos/matrix_vector_device_mf.h
@@ -78,8 +78,8 @@ public:
 
   DEAL_II_HOST_DEVICE void
   operator()(const typename Portable::MatrixFree<dim, Number>::Data *data,
-             const Number                                           *src,
-             Number                                                 *dst) const;
+             const Portable::DeviceVector<Number>                   &src,
+             Portable::DeviceVector<Number>                         &dst) const;
 
   Number *coef;
 };
@@ -90,8 +90,8 @@ template <int dim, int fe_degree, typename Number, int n_q_points_1d>
 DEAL_II_HOST_DEVICE void
 HelmholtzOperator<dim, fe_degree, Number, n_q_points_1d>::operator()(
   const typename Portable::MatrixFree<dim, Number>::Data *data,
-  const Number                                           *src,
-  Number                                                 *dst) const
+  const Portable::DeviceVector<Number>                   &src,
+  Portable::DeviceVector<Number>                         &dst) const
 {
   Portable::FEEvaluation<dim, fe_degree, n_q_points_1d, 1, Number> fe_eval(
     data);

--- a/tests/matrix_free_kokkos/matrix_vector_host_device_multi_component.cc
+++ b/tests/matrix_free_kokkos/matrix_vector_host_device_multi_component.cc
@@ -167,8 +167,8 @@ public:
 
   DEAL_II_HOST_DEVICE void
   operator()(const typename Portable::MatrixFree<dim, Number>::Data *data,
-             const Number                                           *src,
-             Number                                                 *dst) const
+             const Portable::DeviceVector<Number>                   &src,
+             Portable::DeviceVector<Number>                         &dst) const
   {
     Portable::FEEvaluation<dim, fe_degree, fe_degree + 1, n_components, Number>
       phi(data);


### PR DESCRIPTION
Instead of passing double* to the user code, introduce a new type that is a type alias to a Kokkos::View.

This is of course an incompatible change.

This is the first step towards supporting block vectors and multiple DoFHandlers.