### PR TITLE
Avoid unicode quoting.

### DIFF
--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -385,9 +385,9 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 if(NOT "${CMAKE_CXX_STANDARD}" STREQUAL "${_cxx_standard}")
   message(FATAL_ERROR
     "\nThe current version of deal.II was configured with CMAKE_CXX_STANDARD "
-    "set to »${CMAKE_CXX_STANDARD}«, but we detected only support for standard "
-    "version »${_cxx_standard}«. Either unset the CMake variable "
-    "CMAKE_CXX_STANDARD, or ensure that it is at most set to »${_cxx_standard}«.\n\n"
+    "set to \"${CMAKE_CXX_STANDARD}\", but we detected only support for standard "
+    "version \"${_cxx_standard}\". Either unset the CMake variable "
+    "CMAKE_CXX_STANDARD, or ensure that it is at most set to \"${_cxx_standard}\".\n\n"
     )
 endif()
 

--- a/cmake/macros/macro_copy_target_properties.cmake
+++ b/cmake/macros/macro_copy_target_properties.cmake
@@ -83,8 +83,8 @@ function(copy_target_properties _destination_target)
         #
         if("${_lib}" MATCHES "::")
           message(FATAL_ERROR
-            "Undefined imported target name »${_lib}« present in interface "
-            "of target »${_entry}«."
+            "Undefined imported target name \"${_lib}\" present in interface "
+            "of target \"${_entry}\"."
             )
         endif()
         list(APPEND _libraries ${_lib})

--- a/cmake/macros/macro_define_interface_target.cmake
+++ b/cmake/macros/macro_define_interface_target.cmake
@@ -97,8 +97,8 @@ function(define_interface_target _feature)
         #
         if("${_lib}" MATCHES "::")
           message(FATAL_ERROR
-            "Undefined imported target name »${_lib}« present when defining "
-            "interface target »${_interface_target}«"
+            "Undefined imported target name \"${_lib}\" present when defining "
+            "interface target \"${_interface_target}\""
             )
         endif()
       endforeach()

--- a/cmake/macros/macro_process_feature.cmake
+++ b/cmake/macros/macro_process_feature.cmake
@@ -131,7 +131,7 @@ macro(process_feature _feature)
       elseif(_arg MATCHES "^(optimized|debug|general)$")
         message(FATAL_ERROR
           "Internal configuration error: process_feature() does not support "
-          "»debug«, »optimized«, or »general« library identifiers, use the "
+          "\"debug«, »optimized«, or »general\" library identifiers, use the "
           "appropriate keyword instead."
           )
       endif()

--- a/cmake/macros/macro_target_compile_flags.cmake
+++ b/cmake/macros/macro_target_compile_flags.cmake
@@ -28,7 +28,7 @@
 #
 function(target_compile_flags _target _keyword _string)
   if(NOT TARGET ${_target})
-    message(FATAL_ERROR "»${_target}« is not a valid target")
+    message(FATAL_ERROR "\"${_target}\" is not a valid target")
   endif()
   if(NOT ${_keyword} MATCHES "(INTERFACE|PUBLIC|PRIVATE)")
     message(FATAL_ERROR

--- a/cmake/macros/macro_target_link_flags.cmake
+++ b/cmake/macros/macro_target_link_flags.cmake
@@ -28,7 +28,7 @@
 #
 function(target_link_flags _target _keyword _string)
   if(NOT TARGET ${_target})
-    message(FATAL_ERROR "»${_target}« is not a valid target")
+    message(FATAL_ERROR "\"${_target}\" is not a valid target")
   endif()
 
   if(NOT ${_keyword} MATCHES "(INTERFACE|PUBLIC|PRIVATE)")


### PR DESCRIPTION
This patch standardizes on `"..."` quoting in cmake scripts, in favor of the previous use of German/French Unicode quotes. See the discussion in https://github.com/dealii/dealii/pull/18251#discussion_r1996562534