### PR TITLE
Cmake: clean up Kokkos configuration

### DIFF
--- a/cmake/configure/configure_20_petsc.cmake
+++ b/cmake/configure/configure_20_petsc.cmake
@@ -99,6 +99,19 @@ endmacro()
 
 
 macro(feature_petsc_configure_external)
+  #
+  # Propagate some PETSc configuration variables into DEAL_II namespace:
+  #
+
+  set(DEAL_II_PETSC_WITH_COMPLEX ${PETSC_WITH_COMPLEX})
+  set(DEAL_II_PETSC_WITH_HYPRE ${PETSC_WITH_HYPRE})
+  set(DEAL_II_PETSC_WITH_MUMPS ${PETSC_WITH_MUMPS})
+  set(DEAL_II_PETSC_WITH_KOKKOS ${PETSC_WITH_KOKKOS})
+
+  #
+  # Figure out all the possible instantiations we need:
+  #
+
   set(DEAL_II_EXPAND_PETSC_MPI_VECTOR "PETScWrappers::MPI::Vector")
   set(DEAL_II_EXPAND_PETSC_MPI_BLOCKVECTOR "PETScWrappers::MPI::BlockVector")
   set(DEAL_II_EXPAND_PETSC_SPARSE_MATRICES
@@ -138,7 +151,3 @@ endmacro()
 
 
 configure_feature(PETSC)
-set(DEAL_II_PETSC_WITH_COMPLEX ${PETSC_WITH_COMPLEX})
-set(DEAL_II_PETSC_WITH_HYPRE ${PETSC_WITH_HYPRE})
-set(DEAL_II_PETSC_WITH_MUMPS ${PETSC_WITH_MUMPS})
-set(DEAL_II_PETSC_WITH_KOKKOS ${PETSC_WITH_KOKKOS})

--- a/cmake/configure/configure_20_trilinos.cmake
+++ b/cmake/configure/configure_20_trilinos.cmake
@@ -194,6 +194,15 @@ macro(feature_trilinos_find_external var)
           "includes Kokkos, but DEAL_II_FORCE_BUNDLED_KOKKOS=ON!\n")
         set(${var} FALSE)
       endif()
+
+      #
+      # When configuring Kokkos we have to ensure that we actually pick up the
+      # correct Kokkos installation coming from Trilinos.
+      #
+      # FIXME: this logic should probably be refactored into
+      # FindDEAL_II_TRILINOS.cmake...
+      #
+      set(TRILINOS_KOKKOS_DIR "${TRILINOS_CONFIG_DIR}/..")
     endif()
 
     if(TRILINOS_WITH_KOKKOS AND Kokkos_ENABLE_CUDA)

--- a/cmake/configure/configure_20_trilinos.cmake
+++ b/cmake/configure/configure_20_trilinos.cmake
@@ -205,16 +205,6 @@ macro(feature_trilinos_find_external var)
       set(TRILINOS_KOKKOS_DIR "${TRILINOS_CONFIG_DIR}/..")
     endif()
 
-    if(TRILINOS_WITH_KOKKOS AND Kokkos_ENABLE_CUDA)
-      # We need to disable SIMD vectorization for CUDA device code.
-      # Otherwise, nvcc compilers from version 9 on will emit an error message like:
-      # "[...] contains a vector, which is not supported in device code". We
-      # would like to set the variable in check_01_cpu_feature but at that point
-      # we don't know if CUDA support is enabled in Kokkos
-      set(DEAL_II_VECTORIZATION_WIDTH_IN_BITS 0)
-      KOKKOS_CHECK(OPTIONS CUDA_LAMBDA)
-    endif()
-
     if(TRILINOS_WITH_TPETRA)
       #
       # Check if Tpetra is usable in fact.

--- a/cmake/configure/configure_30_kokkos.cmake
+++ b/cmake/configure/configure_30_kokkos.cmake
@@ -23,10 +23,10 @@ set(DEAL_II_WITH_KOKKOS ON # Always true. We need it :-]
 
 configure_feature(KOKKOS)
 
-
 #
 # DEAL_II_WITH_KOKKOS is always required.
 #
+
 if(NOT DEAL_II_WITH_KOKKOS)
   if(DEAL_II_FEATURE_AUTODETECTION)
     feature_error_message("KOKKOS")
@@ -36,4 +36,27 @@ if(NOT DEAL_II_WITH_KOKKOS)
       "DEAL_II_WITH_KOKKOS required, but set to OFF!\n\n"
       )
   endif()
+endif()
+
+#
+# Sanity check: Make sure we do not accidentally end up using bundled
+# Kokkos with Trilinos and PETSc built against an external Kokkos library.
+# We should have never gotten into this situation. So all we can do now is
+# to issue a FATAL_ERROR.
+#
+
+if(DEAL_II_FEATURE_KOKKOS_BUNDLED_CONFIGURED AND DEAL_II_WITH_TRILINOS AND TRILINOS_WITH_KOKKOS)
+  message(FATAL_ERROR "\n"
+    "Internal build system error: We have selected Trilinos shipping with (or "
+    "built against) an external Kokkos library, but ended up selecting our "
+    "bundled Kokkos library.\n\n"
+    )
+endif()
+
+if(DEAL_II_FEATURE_KOKKOS_BUNDLED_CONFIGURED AND DEAL_II_WITH_PETSC AND PETSC_WITH_KOKKOS)
+  message(FATAL_ERROR "\n"
+    "Internal build system error: We have selected PETSc built against an "
+    "external Kokkos library, but ended up selecting our bundled Kokkos "
+    "library.\n\n"
+    )
 endif()

--- a/cmake/modules/FindDEAL_II_KOKKOS.cmake
+++ b/cmake/modules/FindDEAL_II_KOKKOS.cmake
@@ -82,15 +82,30 @@ endif()
 
 find_package(Kokkos ${KOKKOS_MINIMUM_REQUIRED_VERSION} QUIET HINTS ${KOKKOS_DIR})
 
-set(_target)
-if(Kokkos_FOUND)
-  set(_target Kokkos::kokkos)
-endif()
+if (DEAL_II_WITH_TRILINOS AND TRILINOS_VERSION VERSION_LESS 14
+    AND DEAL_II_TRILINOS_WITH_KOKKOS)
+  #
+  # Workaround: Trilinos prior to version 14 needs extensive cleanup of the
+  # exported CMake configuration, which we do in
+  # FindDEAL_II_TRILINOS.cmake. This also applies to the bundled Kokkos
+  # library, which prevents us from simply importing the Kokkos::kokkos
+  # target. We work around this issue by simply not calling
+  # process_feature().
+  #
+  set(KOKKOS_FOUND TRUE)
 
-process_feature(KOKKOS
-  TARGETS REQUIRED _target
-  CLEAR Kokkos_DIR
-  )
+else()
+
+  set(_target)
+  if(Kokkos_FOUND)
+    set(_target Kokkos::kokkos)
+  endif()
+
+  process_feature(KOKKOS
+    TARGETS REQUIRED _target
+    CLEAR Kokkos_DIR
+    )
+endif()
 
 if(KOKKOS_FOUND)
   #

--- a/cmake/modules/FindDEAL_II_PETSC.cmake
+++ b/cmake/modules/FindDEAL_II_PETSC.cmake
@@ -18,13 +18,14 @@
 # This module exports:
 #
 #     PETSC_FOUND
-#     PETSC_LIBRARIES
 #     PETSC_INCLUDE_DIRS
+#     PETSC_KOKKOS_DIR
+#     PETSC_LIBRARIES
 #     PETSC_VERSION
 #     PETSC_VERSION_MAJOR
 #     PETSC_VERSION_MINOR
-#     PETSC_VERSION_SUBMINOR
 #     PETSC_VERSION_PATCH
+#     PETSC_VERSION_SUBMINOR
 #     PETSC_WITH_64BIT_INDICES
 #     PETSC_WITH_COMPLEX
 #     PETSC_WITH_HYPRE
@@ -194,18 +195,15 @@ if(NOT PETSC_PETSCVARIABLES MATCHES "-NOTFOUND")
     endif()
   endforeach()
 
-  # PETSc does not expose Kokkos version, so we need to search for Kokkos
-  # ourselves.
+  #
+  # When configuring Kokkos we have to ensure that we actually pick up the
+  # correct Kokkos installation coming from PETSc.
+  #
   if(PETSC_WITH_KOKKOS)
     file(STRINGS "${PETSC_PETSCVARIABLES}" KOKKOS_INCLUDE
       REGEX "^KOKKOS_INCLUDE =.*")
     string(REGEX REPLACE "^KOKKOS_INCLUDE = -I" "" KOKKOS_INCLUDE "${KOKKOS_INCLUDE}")
-    find_package(Kokkos 3.7.0 QUIET
-      PATHS ${KOKKOS_INCLUDE}/.. NO_DEFAULT_PATH
-      )
-    if(NOT Kokkos_FOUND)
-      set(PETSC_FOUND FALSE)
-    endif()
+    set(PETSC_KOKKOS_DIR "${KOKKOS_INCLUDE}/..")
   endif()
 endif()
 

--- a/cmake/modules/FindDEAL_II_TRILINOS.cmake
+++ b/cmake/modules/FindDEAL_II_TRILINOS.cmake
@@ -48,16 +48,6 @@ find_package(TRILINOS_CONFIG
   )
 
 if(Trilinos_FOUND)
-  # run find_package to populate variables like Kokkos_VERSION not
-  # set by the find_package call to Trilinos:
-  set(CMAKE_CXX_EXTENSIONS OFF)
-  find_package(Kokkos 3.4.0 REQUIRED QUIET
-    PATHS ${TRILINOS_CONFIG_DIR}/.. NO_DEFAULT_PATH
-  )
-
-  set(KOKKOS_FOUND ${Kokkos_FOUND})
-
-
   #
   # Extract version numbers:
   #


### PR DESCRIPTION
This is a first part of cleaning up our Kokkos configuration.

This pull request puts all of the calls to `find_package(Kokkos [...])` into our `FindDEAL_II_KOKKOS` module. This ensures that we have always imported the CMake configuration (including macros and version number).

This simplicity comes at a small price: By the time we try to `find_package(Kokkos [...])` with a path derived from the Trilinos or PETSc configuration we have already enabled (or disabled) Trilinos and PETSc, i.e., we can no longer disable these external packages if something goes wrong with the `find_package` call... But it is debatable whether disabling Trilinos or PETSc in this situation is actually the right course of action in the first place...

I will follow up with some further refactoring but I would like to see this logic reviewed and tested first.

In reference to #17659 
Closes #18282