### PR TITLE
Delete code paths for Kokkos versions before 3.4

### DIFF
--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -492,9 +492,7 @@ namespace LinearAlgebra
               ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
               exec, 0, size),
             KOKKOS_LAMBDA(size_type i, RealType & update) {
-#if KOKKOS_VERSION < 30400
-              update = fmax(update, fabs(data.values(i)));
-#elif KOKKOS_VERSION < 30700
+#if KOKKOS_VERSION < 30700
               update = Kokkos::Experimental::fmax(
                 update, Kokkos::Experimental::fabs(data.values(i)));
 #else

--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -2524,9 +2524,7 @@ namespace internal
             ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
             exec, optional_offset, optional_offset + size),
           KOKKOS_LAMBDA(size_type i, Number & update) {
-#if KOKKOS_VERSION < 30400
-            update += std::abs(data.values(i));
-#elif KOKKOS_VERSION < 30700
+#if KOKKOS_VERSION < 30700
             update += Kokkos::Experimental::fabs(data.values(i));
 #else
             update += Kokkos::abs(data.values(i));
@@ -2554,9 +2552,7 @@ namespace internal
             ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
             exec, 0, size),
           KOKKOS_LAMBDA(size_type i, Number & update) {
-#if KOKKOS_VERSION < 30400
-            update += std::pow(fabs(data.values(i)), exp);
-#elif KOKKOS_VERSION < 30700
+#if KOKKOS_VERSION < 30700
             update += Kokkos::Experimental::pow(
               Kokkos::Experimental::fabs(data.values(i)), exp);
 #else

--- a/include/deal.II/matrix_free/portable_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.templates.h
@@ -664,12 +664,7 @@ namespace Portable
           MemorySpace::Default::kokkos_space::execution_space exec;
           Kokkos::TeamPolicy<
             MemorySpace::Default::kokkos_space::execution_space>
-            team_policy(
-#if KOKKOS_VERSION >= 20900
-              exec,
-#endif
-              n_cells[i],
-              Kokkos::AUTO);
+            team_policy(exec, n_cells[i], Kokkos::AUTO);
 
           Kokkos::parallel_for(
             "dealii::MatrixFree::evaluate_coeff_cell_loop",
@@ -677,22 +672,18 @@ namespace Portable
             KOKKOS_LAMBDA(const Kokkos::TeamPolicy<
                           MemorySpace::Default::kokkos_space::execution_space>::
                             member_type &team_member) {
-              Kokkos::parallel_for(
-#if KOKKOS_VERSION >= 20900
-                Kokkos::TeamVectorRange(team_member, n_q_points),
-#else
-                Kokkos::TeamThreadRange(team_member, n_q_points),
-#endif
-                [&](const int q_point) {
-                  const int cell = team_member.league_rank();
+              Kokkos::parallel_for(Kokkos::TeamVectorRange(team_member,
+                                                           n_q_points),
+                                   [&](const int q_point) {
+                                     const int cell = team_member.league_rank();
 
-                  Data data{team_member,
-                            cell,
-                            &color_data,
-                            /*shared_data*/ nullptr};
+                                     Data data{team_member,
+                                               cell,
+                                               &color_data,
+                                               /*shared_data*/ nullptr};
 
-                  func(&data, cell, q_point);
-                });
+                                     func(&data, cell, q_point);
+                                   });
             });
         }
   }
@@ -1037,12 +1028,7 @@ namespace Portable
           MemorySpace::Default::kokkos_space::execution_space exec;
           Kokkos::TeamPolicy<
             MemorySpace::Default::kokkos_space::execution_space>
-            team_policy(
-#if KOKKOS_VERSION >= 20900
-              exec,
-#endif
-              n_cells[color],
-              Kokkos::AUTO);
+            team_policy(exec, n_cells[color], Kokkos::AUTO);
 
 
           internal::
@@ -1099,12 +1085,7 @@ namespace Portable
               {
                 Kokkos::TeamPolicy<
                   MemorySpace::Default::kokkos_space::execution_space>
-                  team_policy(
-#if KOKKOS_VERSION >= 20900
-                    exec,
-#endif
-                    n_cells[0],
-                    Kokkos::AUTO);
+                  team_policy(exec, n_cells[0], Kokkos::AUTO);
 
                 internal::ApplyKernel<dim, Number, Functor, false> apply_kernel(
                   func, get_data(0), src, dst);
@@ -1122,12 +1103,7 @@ namespace Portable
               {
                 Kokkos::TeamPolicy<
                   MemorySpace::Default::kokkos_space::execution_space>
-                  team_policy(
-#if KOKKOS_VERSION >= 20900
-                    exec,
-#endif
-                    n_cells[1],
-                    Kokkos::AUTO);
+                  team_policy(exec, n_cells[1], Kokkos::AUTO);
 
                 internal::ApplyKernel<dim, Number, Functor, false> apply_kernel(
                   func, get_data(1), src, dst);
@@ -1150,12 +1126,7 @@ namespace Portable
               {
                 Kokkos::TeamPolicy<
                   MemorySpace::Default::kokkos_space::execution_space>
-                  team_policy(
-#if KOKKOS_VERSION >= 20900
-                    exec,
-#endif
-                    n_cells[2],
-                    Kokkos::AUTO);
+                  team_policy(exec, n_cells[2], Kokkos::AUTO);
 
                 internal::ApplyKernel<dim, Number, Functor, false> apply_kernel(
                   func, get_data(2), src, dst);
@@ -1183,12 +1154,7 @@ namespace Portable
                 {
                   Kokkos::TeamPolicy<
                     MemorySpace::Default::kokkos_space::execution_space>
-                    team_policy(
-#if KOKKOS_VERSION >= 20900
-                      exec,
-#endif
-                      n_cells[i],
-                      Kokkos::AUTO);
+                    team_policy(exec, n_cells[i], Kokkos::AUTO);
 
                   internal::ApplyKernel<dim, Number, Functor, false>
                     apply_kernel(func, get_data(i), src, dst);
@@ -1220,12 +1186,7 @@ namespace Portable
             {
               Kokkos::TeamPolicy<
                 MemorySpace::Default::kokkos_space::execution_space>
-                team_policy(
-#if KOKKOS_VERSION >= 20900
-                  exec,
-#endif
-                  n_cells[i],
-                  Kokkos::AUTO);
+                team_policy(exec, n_cells[i], Kokkos::AUTO);
 
               internal::ApplyKernel<dim, Number, Functor, false> apply_kernel(
                 func, get_data(i), ghosted_src, ghosted_dst);

--- a/include/deal.II/matrix_free/portable_tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/portable_tensor_product_kernels.h
@@ -58,18 +58,13 @@ namespace Portable
     {
       Assert(dst.size() >= N, ExcInternalError());
       Assert(src.size() >= N, ExcInternalError());
-      Kokkos::parallel_for(
-#if KOKKOS_VERSION >= 20900
-        Kokkos::TeamVectorRange(team_member, N),
-#else
-        Kokkos::TeamThreadRange(team_member, N),
-#endif
-        [&](const int i) {
-          if constexpr (add)
-            Kokkos::atomic_add(&dst(i), src(i));
-          else
-            dst(i) = src(i);
-        });
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team_member, N),
+                           [&](const int i) {
+                             if constexpr (add)
+                               Kokkos::atomic_add(&dst(i), src(i));
+                             else
+                               dst(i) = src(i);
+                           });
 
       team_member.team_barrier();
     }

--- a/source/base/exceptions.cc
+++ b/source/base/exceptions.cc
@@ -520,25 +520,11 @@ namespace deal_II_exceptions
         }
 #endif
 
-        // Let's abort the program here. On the host, we need to call
-        // std::abort, on devices we need to do something different.
-        // Kokkos::abort() does the right thing in all circumstances.
-
-#if KOKKOS_VERSION < 30200
-      if constexpr (std::is_same_v<Kokkos::DefaultExecutionSpace,
-                                   Kokkos::DefaultHostExecutionSpace>)
-        {
-          // FIXME_KOKKOS Older Kokkos versions don't declare Kokkos::abort as
-          // [[noreturn]]. In case Kokkos is only configured with host backends,
-          // we can just use std::abort instead.
-          std::abort();
-        }
-      else
-#endif
-        {
-          Kokkos::abort(
-            "Abort() was called during dealing with an assertion or exception.");
-        }
+      // Let's abort the program here. On the host, we need to call
+      // std::abort, on devices we need to do something different.
+      // Kokkos::abort() does the right thing in all circumstances.
+      Kokkos::abort(
+        "Abort() was called during dealing with an assertion or exception.");
     }
 
 


### PR DESCRIPTION
After https://github.com/dealii/dealii/pull/18272, the minimum Kokkos version (through Trilinos) is 3.4.01.