### PR TITLE
Implement MPGMRES - multiply preconditioned generalized minimal residual method

### DIFF
--- a/doc/doxygen/references.bib
+++ b/doc/doxygen/references.bib
@@ -2066,6 +2066,19 @@
   Url                      = {citeseer.ist.psu.edu/saad93flexible.html}
 }
 
+@article{Greif2017,
+  title     = {GMRES with multiple preconditioners},
+  author    = {Greif, Chen and Rees, Tyrone and Szyld, Daniel B},
+  journal   = {SeMA Journal},
+  volume    = {74},
+  pages     = {213--231},
+  year      = {2017},
+  publisher = {Springer},
+  doi       = {10.1007/s40324-016-0088-7},
+  url       = {https://doi.org/10.1007/s40324-016-0088-7}
+}
+
+
 @article{ainsworth1998hp,
   author    = {M. Ainsworth and B. Senior},
   title     = {An adaptive refinement strategy for \textit{hp}-finite element computations},

--- a/doc/news/changes/minor/20250410Maier-1
+++ b/doc/news/changes/minor/20250410Maier-1
@@ -1,0 +1,5 @@
+New: Added a new class SolverMPGMRES that implements a variant of
+the GMRES algorithm allowing for the use of multiple preconditioners
+at once. For more details, see @cite Greif2017.
+<br>
+(Wyatt Smith, Matthias Maier, 2025/04/10)

--- a/doc/news/changes/minor/20250410Maier-2
+++ b/doc/news/changes/minor/20250410Maier-2
@@ -1,6 +1,6 @@
 Changed: Flexible GMRES can be viewed as a special case
 of the MPGMRES algorithm. Consequently, the SolverFGMRES class
-is now derived from SolverMPGMRES its solve method now
+is now derived from SolverMPGMRES and its solve method now
 supports the function signature
 <code>
 solve(A, x, b, preconditioner_1, preconditioner_2, ...)

--- a/doc/news/changes/minor/20250410Maier-2
+++ b/doc/news/changes/minor/20250410Maier-2
@@ -1,0 +1,9 @@
+Changed: Flexible GMRES can be viewed as a special case
+of the MPGMRES algorithm. Consequently, the SolverFGMRES class
+is now derived from SolverMPGMRES its solve method now
+supports the function signature
+<code>
+solve(A, x, b, preconditioner_1, preconditioner_2, ...)
+</code>
+<br>
+(Wyatt Smith, Matthias Maier, 2025/04/10)

--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -878,19 +878,15 @@ public:
 
   /**
    * Solve the linear system $Ax=b$ for x.
-   *
-   * @note If you want to use more than one preconditioner, then you will
-   * need to supply a @p preconditioner object that switches
-   * preconditioners for each vmult() invocation.
    */
-  template <typename MatrixType, typename PreconditionerType>
+  template <typename MatrixType, typename... PreconditionerTypes>
   DEAL_II_CXX20_REQUIRES(
     (concepts::is_linear_operator_on<MatrixType, VectorType> &&
-     concepts::is_linear_operator_on<PreconditionerType, VectorType>))
-  void solve(const MatrixType         &A,
-             VectorType               &x,
-             const VectorType         &b,
-             const PreconditionerType &preconditioner);
+     (concepts::is_linear_operator_on<PreconditionerTypes, VectorType> && ...)))
+  void solve(const MatrixType &A,
+             VectorType       &x,
+             const VectorType &b,
+             const PreconditionerTypes &...preconditioners);
 };
 
 /** @} */
@@ -2378,17 +2374,18 @@ SolverFGMRES<VectorType>::SolverFGMRES(SolverControl        &cn,
 
 template <typename VectorType>
 DEAL_II_CXX20_REQUIRES(concepts::is_vector_space_vector<VectorType>)
-template <typename MatrixType, typename PreconditionerType>
+template <typename MatrixType, typename... PreconditionerTypes>
 DEAL_II_CXX20_REQUIRES(
   (concepts::is_linear_operator_on<MatrixType, VectorType> &&
-   concepts::is_linear_operator_on<PreconditionerType, VectorType>))
-void SolverFGMRES<VectorType>::solve(const MatrixType         &A,
-                                     VectorType               &x,
-                                     const VectorType         &b,
-                                     const PreconditionerType &preconditioner)
+   (concepts::is_linear_operator_on<PreconditionerTypes, VectorType> && ...)))
+void SolverFGMRES<VectorType>::solve(
+  const MatrixType &A,
+  VectorType       &x,
+  const VectorType &b,
+  const PreconditionerTypes &...preconditioners)
 {
   LogStream::Prefix prefix("FGMRES");
-  SolverMPGMRES<VectorType>::solve_internal(A, x, b, preconditioner);
+  SolverMPGMRES<VectorType>::solve_internal(A, x, b, preconditioners...);
 }
 
 

--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -697,11 +697,13 @@ public:
    * Solve the linear system $Ax=b$ for x.
    */
   template <typename MatrixType, typename... PreconditionerTypes>
-  void
-  solve(const MatrixType &A,
-        VectorType       &x,
-        const VectorType &b,
-        const PreconditionerTypes &...preconditioners);
+  DEAL_II_CXX20_REQUIRES(
+    (concepts::is_linear_operator_on<MatrixType, VectorType> &&
+     (concepts::is_linear_operator_on<PreconditionerTypes, VectorType> && ...)))
+  void solve(const MatrixType &A,
+             VectorType       &x,
+             const VectorType &b,
+             const PreconditionerTypes &...preconditioners);
 
 protected:
   /**
@@ -2052,12 +2054,16 @@ SolverMPGMRES<VectorType>::SolverMPGMRES(SolverControl        &cn,
 
 
 template <typename VectorType>
+DEAL_II_CXX20_REQUIRES(concepts::is_vector_space_vector<VectorType>)
 template <typename MatrixType, typename... PreconditionerTypes>
-void
-SolverMPGMRES<VectorType>::solve(const MatrixType &A,
-                                 VectorType       &x,
-                                 const VectorType &b,
-                                 const PreconditionerTypes &...preconditioners)
+DEAL_II_CXX20_REQUIRES(
+  (concepts::is_linear_operator_on<MatrixType, VectorType> &&
+   (concepts::is_linear_operator_on<PreconditionerTypes, VectorType> && ...)))
+void SolverMPGMRES<VectorType>::solve(
+  const MatrixType &A,
+  VectorType       &x,
+  const VectorType &b,
+  const PreconditionerTypes &...preconditioners)
 {
   LogStream::Prefix prefix("MPGMRES");
   SolverMPGMRES<VectorType>::solve_internal(A, x, b, preconditioners...);
@@ -2066,6 +2072,7 @@ SolverMPGMRES<VectorType>::solve(const MatrixType &A,
 
 
 template <typename VectorType>
+DEAL_II_CXX20_REQUIRES(concepts::is_vector_space_vector<VectorType>)
 template <typename MatrixType, typename... PreconditionerTypes>
 void
 SolverMPGMRES<VectorType>::solve_internal(

--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -710,21 +710,26 @@ public:
     /**
      * Constructor. By default, set the maximum basis size to 30.
      */
-    explicit AdditionalData(const unsigned int max_basis_size         = 30,
-                            const bool use_truncated_mpgmres_strategy = true,
+    explicit AdditionalData(const unsigned int max_basis_size = 30,
                             const LinearAlgebra::OrthogonalizationStrategy
                               orthogonalization_strategy =
                                 LinearAlgebra::OrthogonalizationStrategy::
-                                  delayed_classical_gram_schmidt)
+                                  delayed_classical_gram_schmidt,
+                            const bool use_truncated_mpgmres_strategy = true)
       : max_basis_size(max_basis_size)
-      , use_truncated_mpgmres_strategy(use_truncated_mpgmres_strategy)
       , orthogonalization_strategy(orthogonalization_strategy)
+      , use_truncated_mpgmres_strategy(use_truncated_mpgmres_strategy)
     {}
 
     /**
      * Maximum basis size.
      */
     unsigned int max_basis_size;
+
+    /**
+     * Strategy to orthogonalize vectors.
+     */
+    LinearAlgebra::OrthogonalizationStrategy orthogonalization_strategy;
 
     /**
      * If set to true (the default) a "truncated" search space is
@@ -736,11 +741,6 @@ public:
      * for details.
      */
     bool use_truncated_mpgmres_strategy;
-
-    /**
-     * Strategy to orthogonalize vectors.
-     */
-    LinearAlgebra::OrthogonalizationStrategy orthogonalization_strategy;
   };
 
   /**
@@ -2363,8 +2363,8 @@ SolverFGMRES<VectorType>::SolverFGMRES(SolverControl            &cn,
       mem,
       typename SolverMPGMRES<VectorType>::AdditionalData{
         data.max_basis_size,
-        true,
-        data.orthogonalization_strategy})
+        data.orthogonalization_strategy,
+        true})
 {}
 
 
@@ -2377,8 +2377,8 @@ SolverFGMRES<VectorType>::SolverFGMRES(SolverControl        &cn,
       cn,
       typename SolverMPGMRES<VectorType>::AdditionalData{
         data.max_basis_size,
-        true,
-        data.orthogonalization_strategy})
+        data.orthogonalization_strategy,
+        true})
 {}
 
 

--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -665,7 +665,7 @@ protected:
  * @f}
  * For reference, FGMRES uses the following construction:
  * @f{align*}{
- *   r, P_1r, P_2P_1r, P_1P_2P_1r, \ldots
+ *   r, P_1r, P_2AP_1r, P_1AP_2AP_1r, \ldots
  * @f}
  * By default the truncated variant is used. You can switch to the full
  * version by setting the

--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -2240,6 +2240,13 @@ void SolverMPGMRES<VectorType>::solve_internal(
   const auto previous_vector_index =
     [this, n_preconditioners, indexing_strategy](
       unsigned int i) -> unsigned int {
+    // In the special case of no preconditioners we simply fall back to the
+    // FGMRES indexing strategy.
+    if (n_preconditioners == 0)
+      {
+        return i;
+      }
+
     switch (indexing_strategy)
       {
         case IndexingStrategy::fgmres:

--- a/tests/lac/solver_mpgmres_01.cc
+++ b/tests/lac/solver_mpgmres_01.cc
@@ -1,0 +1,141 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2022 - 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+// Check that the preconditioners are being applied cyclically
+
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/solver_gmres.h>
+#include <deal.II/lac/sparse_matrix.h>
+
+#include <iostream>
+
+#include "../tests.h"
+
+
+// We create a wrapper around the preconditioner that will print out a name with
+// each vmult so we can check that the preconditioners are being cycled
+// correctly
+template <typename Preconditioner>
+class MyPreconditioner
+{
+public:
+  MyPreconditioner(const std::string    &name,
+                   const Preconditioner &preconditioner)
+    : name(name)
+    , preconditioner(preconditioner)
+    , print_counter(0)
+  {}
+
+  void
+  vmult(Vector<double> &dst, const Vector<double> &src) const
+  {
+    if (print_counter < 3)
+      deallog.get_file_stream()
+        << "Applying preconditioner " << name << std::endl;
+    preconditioner.vmult(dst, src);
+    ++print_counter;
+  }
+
+  void
+  reset_counter()
+  {
+    print_counter = 0;
+  }
+
+private:
+  const std::string     name;
+  const Preconditioner &preconditioner;
+  mutable unsigned int  print_counter;
+};
+
+
+int
+main()
+{
+  initlog();
+
+  const unsigned int N = 500;
+  const unsigned int M = 2 * N;
+
+  SparsityPattern sparsity_pattern(M, M, 2);
+  for (unsigned int i = 0; i < M - 1; ++i)
+    sparsity_pattern.add(i, i + 1);
+  sparsity_pattern.compress();
+  SparseMatrix<double> matrix(sparsity_pattern);
+
+  for (unsigned int i = 0; i < N; ++i)
+    {
+      matrix.diag_element(i) = 1.0 + 1 * i;
+      matrix.set(i, i + 1, 1.);
+    }
+  for (unsigned int i = N; i < M; ++i)
+    matrix.diag_element(i) = 1.;
+
+  PreconditionChebyshev<SparseMatrix<double>> prec_a;
+  prec_a.initialize(matrix);
+  MyPreconditioner wrapper_a("A", prec_a);
+
+  PreconditionJacobi<SparseMatrix<double>> prec_b;
+  prec_b.initialize(matrix);
+  MyPreconditioner wrapper_b("B", prec_b);
+
+  PreconditionSOR<SparseMatrix<double>> prec_c;
+  prec_c.initialize(matrix);
+  MyPreconditioner wrapper_c("C", prec_c);
+
+  Vector<double> rhs(M);
+  Vector<double> sol(M);
+  rhs = 1.;
+
+  SolverControl control(M, 1e-8);
+
+  deallog.get_file_stream() << "FGMRES:\n";
+  SolverFGMRES<Vector<double>> solver_fgmres(control);
+  check_solver_within_range(
+    solver_fgmres.solve(matrix, sol, rhs, wrapper_a, wrapper_b, wrapper_c),
+    control.last_step(),
+    7 - 6,
+    7 + 6);
+
+  deallog.get_file_stream() << "\nMPGMRES: (truncated)\n";
+  sol = 0.;
+  wrapper_a.reset_counter();
+  wrapper_b.reset_counter();
+  wrapper_c.reset_counter();
+
+  SolverMPGMRES<Vector<double>>::AdditionalData data;
+  data.use_truncated_mpgmres_strategy = true;
+  SolverMPGMRES<Vector<double>> solver_trmpgmres(control, data);
+  check_solver_within_range(
+    solver_trmpgmres.solve(matrix, sol, rhs, wrapper_a, wrapper_b, wrapper_c),
+    control.last_step(),
+    19 - 6,
+    19 + 6);
+
+
+  deallog.get_file_stream() << "\nMPGMRES: (full)\n";
+  sol = 0.;
+  wrapper_a.reset_counter();
+  wrapper_b.reset_counter();
+  wrapper_c.reset_counter();
+  data.use_truncated_mpgmres_strategy = false;
+  SolverMPGMRES<Vector<double>> solver_mpgmres(control, data);
+
+  check_solver_within_range(
+    solver_mpgmres.solve(matrix, sol, rhs, wrapper_a, wrapper_b, wrapper_c),
+    control.last_step(),
+    24 - 6,
+    24 + 6);
+}

--- a/tests/lac/solver_mpgmres_01.output
+++ b/tests/lac/solver_mpgmres_01.output
@@ -1,0 +1,34 @@
+
+FGMRES:
+Applying preconditioner A
+Applying preconditioner B
+Applying preconditioner C
+Applying preconditioner A
+Applying preconditioner B
+Applying preconditioner C
+Applying preconditioner A
+DEAL::Solver stopped within 1 - 13 iterations
+
+MPGMRES: (truncated)
+Applying preconditioner A
+Applying preconditioner B
+Applying preconditioner C
+Applying preconditioner A
+Applying preconditioner B
+Applying preconditioner C
+Applying preconditioner A
+Applying preconditioner B
+Applying preconditioner C
+DEAL::Solver stopped within 13 - 25 iterations
+
+MPGMRES: (full)
+Applying preconditioner A
+Applying preconditioner B
+Applying preconditioner C
+Applying preconditioner A
+Applying preconditioner B
+Applying preconditioner C
+Applying preconditioner A
+Applying preconditioner B
+Applying preconditioner C
+DEAL::Solver stopped within 18 - 30 iterations

--- a/tests/lac/solver_mpgmres_02.cc
+++ b/tests/lac/solver_mpgmres_02.cc
@@ -1,0 +1,64 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2022 - 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+// Check that we can call FGMRES::solve() and MPGMRES::solve() without a
+// preconditioner
+
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/solver_gmres.h>
+#include <deal.II/lac/sparse_matrix.h>
+
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+
+  const unsigned int N = 500;
+  const unsigned int M = 2 * N;
+
+  SparsityPattern sparsity_pattern(M, M, 2);
+  for (unsigned int i = 0; i < M - 1; ++i)
+    sparsity_pattern.add(i, i + 1);
+  sparsity_pattern.compress();
+  SparseMatrix<double> matrix(sparsity_pattern);
+
+  for (unsigned int i = 0; i < N; ++i)
+    matrix.diag_element(i) = 1.0;
+  for (unsigned int i = N; i < M; ++i)
+    matrix.diag_element(i) = 1.;
+
+  Vector<double> rhs(M);
+  Vector<double> sol(M);
+  rhs = 1.;
+
+  SolverControl control(M, 1.e-2);
+
+  deallog.get_file_stream() << "FGMRES:\n";
+  SolverFGMRES<Vector<double>> solver_fgmres(control);
+  check_solver_within_range(solver_fgmres.solve(matrix, sol, rhs),
+                            control.last_step(),
+                            1,
+                            10);
+
+  deallog.get_file_stream() << "\nMPGMRES:\n";
+  sol = 0.;
+
+  SolverMPGMRES<Vector<double>> solver_mpgmres(control);
+  check_solver_within_range(solver_mpgmres.solve(matrix, sol, rhs),
+                            control.last_step(),
+                            1,
+                            10);
+}

--- a/tests/lac/solver_mpgmres_02.output
+++ b/tests/lac/solver_mpgmres_02.output
@@ -1,0 +1,6 @@
+
+FGMRES:
+DEAL::Solver stopped within 1 - 10 iterations
+
+MPGMRES:
+DEAL::Solver stopped within 1 - 10 iterations


### PR DESCRIPTION
This is joint work with @wsmith-sch

We are interested in implementing the "multiply preconditioned" GMRES method (MPGMRES). This is a variant of the flexible GMRES method that uses multiple preconditioners to construct independent Krylov subspaces, one for each preconditioner. In contrast, the flexible GMRES  method implemented in SolverFGMRES constructs only one "Krylov subspace."

The changes required to our current FGMRES implementation are very minor. We will thus modify FGMRES to always do MPGMRES - and the special case of providing only one preconditioner object is FGMRES.

The design decision we have to make - and the reason for this early pull request - is the fact that we now need a `solve()` interface that can take more than one preconditioner as an argument. And here it gets a little bit awkward because we make no assumption on types (or existence of a base class). We suggest the following interface [1]:

```
SolverControl solver_control;
SolverMPGMRES<Vector<double>> solver(solver_control);

PreconditionIdentity prec_1;
PreconditionIdentity prec_2;
PreconditionIdentity prec_3;

const auto preconditioners = std::tie(prec_1, prec_2, prec_3);
solver.solve(system_matrix, solution, system_rhs, preconditioners);
```

The suggested interface also works well with const references:
```
const auto &ref_prec_1 = prec_1;
const auto &ref_prec_2 = prec_1;
const auto &ref_prec_3 = prec_1;
const auto ref_preconditioners = std::tie(ref_prec_1, ref_prec_2, ref_prec_3);
solver.solve(system_matrix, solution, system_rhs, ref_preconditioners);
```

We'll populate this pull request with our implementation in the coming days.

---

[1] Ideally we would have loved to support something like this:
```
solver.solve(system_matrix, solution, system_rhs, {prec_1, prec_2, prec_3});
```
But this is not possible due to constraints on the automatic type deduction for dependent function arguments.
We could in principle go the full variadic templates route and support something like this
```
solver.solve(system_matrix, solution, system_rhs, prec_1, prec_2, prec_3);
```
... but the amount of boilerplate code we need to write for this is annoying.
```
const auto preconditioners = std::tie(prec_1, prec_2, prec_3);
solver.solve(system_matrix, solution, system_rhs, preconditioners);
```
