### PR TITLE
Ensure that Kokkos's symbols have external linkage and, consequently can be re-exported.

### DIFF
--- a/bundled/kokkos-3.7.00/core/src/Kokkos_Core_fwd.hpp
+++ b/bundled/kokkos-3.7.00/core/src/Kokkos_Core_fwd.hpp
@@ -76,13 +76,9 @@ struct AUTO_t {
   constexpr const AUTO_t &operator()() const { return *this; }
 };
 
-namespace Constants {
 /**\brief Token to indicate that a parameter's value is to be automatically
  * selected */
-inline const AUTO_t AUTO = Kokkos::AUTO_t();
-}  // namespace
-
-using Constants::AUTO;
+inline constexpr AUTO_t AUTO = Kokkos::AUTO_t();
 
 struct InvalidType {};
 

--- a/bundled/kokkos-3.7.00/core/src/Kokkos_Core_fwd.hpp
+++ b/bundled/kokkos-3.7.00/core/src/Kokkos_Core_fwd.hpp
@@ -76,11 +76,13 @@ struct AUTO_t {
   constexpr const AUTO_t &operator()() const { return *this; }
 };
 
-namespace {
+namespace Constants {
 /**\brief Token to indicate that a parameter's value is to be automatically
  * selected */
-constexpr AUTO_t AUTO = Kokkos::AUTO_t();
+inline const AUTO_t AUTO = Kokkos::AUTO_t();
 }  // namespace
+
+using Constants::AUTO;
 
 struct InvalidType {};
 

--- a/bundled/kokkos-3.7.00/core/src/Kokkos_View.hpp
+++ b/bundled/kokkos-3.7.00/core/src/Kokkos_View.hpp
@@ -528,17 +528,21 @@ constexpr bool is_assignable(const Kokkos::View<ViewTDst...>& dst,
 
 namespace Kokkos {
 
-namespace {
+namespace Constants {
 
-constexpr Kokkos::Impl::ALL_t ALL = Kokkos::Impl::ALL_t();
+inline const Kokkos::Impl::ALL_t ALL = Kokkos::Impl::ALL_t();
 
-constexpr Kokkos::Impl::WithoutInitializing_t WithoutInitializing =
+inline const Kokkos::Impl::WithoutInitializing_t WithoutInitializing =
     Kokkos::Impl::WithoutInitializing_t();
 
-constexpr Kokkos::Impl::AllowPadding_t AllowPadding =
+inline const Kokkos::Impl::AllowPadding_t AllowPadding =
     Kokkos::Impl::AllowPadding_t();
 
 }  // namespace
+
+using Constants::ALL;
+using Constants::WithoutInitializing;
+using Constants::AllowPadding;
 
 /** \brief  Create View allocation parameter bundle from argument list.
  *

--- a/bundled/kokkos-3.7.00/core/src/Kokkos_View.hpp
+++ b/bundled/kokkos-3.7.00/core/src/Kokkos_View.hpp
@@ -528,21 +528,13 @@ constexpr bool is_assignable(const Kokkos::View<ViewTDst...>& dst,
 
 namespace Kokkos {
 
-namespace Constants {
+inline constexpr Kokkos::Impl::ALL_t ALL = Kokkos::Impl::ALL_t();
 
-inline const Kokkos::Impl::ALL_t ALL = Kokkos::Impl::ALL_t();
-
-inline const Kokkos::Impl::WithoutInitializing_t WithoutInitializing =
+inline constexpr Kokkos::Impl::WithoutInitializing_t WithoutInitializing =
     Kokkos::Impl::WithoutInitializing_t();
 
-inline const Kokkos::Impl::AllowPadding_t AllowPadding =
+inline constexpr Kokkos::Impl::AllowPadding_t AllowPadding =
     Kokkos::Impl::AllowPadding_t();
-
-}  // namespace
-
-using Constants::ALL;
-using Constants::WithoutInitializing;
-using Constants::AllowPadding;
 
 /** \brief  Create View allocation parameter bundle from argument list.
  *


### PR DESCRIPTION
This patch does to our bundled version of Kookos what https://github.com/kokkos/kokkos/pull/7898 did to their upstream sources: Make sure that everything that's declared in header files has "external linkage". Specifically, that means that `constexpr` variables at global scope can't appear in header files unless also marked as `inline`.

This is part of #18071.