### PR TITLE
Omit 'const' for variables declared 'constexpr const'.

### DIFF
--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -1632,14 +1632,14 @@ namespace Patterns
     template <typename T>
     struct is_list_compatible
     {
-      static constexpr const bool value =
+      static constexpr bool value =
         internal::is_list_compatible<std::decay_t<T>>::value;
     };
 
     template <typename T>
     struct is_map_compatible
     {
-      static constexpr const bool value =
+      static constexpr bool value =
         internal::is_map_compatible<std::decay_t<T>>::value;
     };
 

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -1216,25 +1216,19 @@ namespace internal
  */
 namespace ReferenceCells
 {
-  constexpr const ReferenceCell Vertex =
-    internal::make_reference_cell_from_int(0);
-  constexpr const ReferenceCell Line =
-    internal::make_reference_cell_from_int(1);
-  constexpr const ReferenceCell Triangle =
-    internal::make_reference_cell_from_int(2);
-  constexpr const ReferenceCell Quadrilateral =
+  constexpr ReferenceCell Vertex   = internal::make_reference_cell_from_int(0);
+  constexpr ReferenceCell Line     = internal::make_reference_cell_from_int(1);
+  constexpr ReferenceCell Triangle = internal::make_reference_cell_from_int(2);
+  constexpr ReferenceCell Quadrilateral =
     internal::make_reference_cell_from_int(3);
-  constexpr const ReferenceCell Tetrahedron =
+  constexpr ReferenceCell Tetrahedron =
     internal::make_reference_cell_from_int(4);
-  constexpr const ReferenceCell Pyramid =
-    internal::make_reference_cell_from_int(5);
-  constexpr const ReferenceCell Wedge =
-    internal::make_reference_cell_from_int(6);
-  constexpr const ReferenceCell Hexahedron =
+  constexpr ReferenceCell Pyramid = internal::make_reference_cell_from_int(5);
+  constexpr ReferenceCell Wedge   = internal::make_reference_cell_from_int(6);
+  constexpr ReferenceCell Hexahedron =
     internal::make_reference_cell_from_int(7);
-  constexpr const ReferenceCell Invalid =
-    internal::make_reference_cell_from_int(
-      std::numeric_limits<std::uint8_t>::max());
+  constexpr ReferenceCell Invalid = internal::make_reference_cell_from_int(
+    std::numeric_limits<std::uint8_t>::max());
 
   /**
    * Return the correct simplex reference cell type for the given dimension

--- a/include/deal.II/matrix_free/portable_matrix_free.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.h
@@ -73,7 +73,7 @@ namespace Portable
    * of blocks in a BlockVector and the number of FEEvaluation objects that can
    * be active in a single cell_loop().
    */
-  inline constexpr const unsigned int n_max_dof_handlers = 5;
+  inline constexpr unsigned int n_max_dof_handlers = 5;
 
   /**
    * Type for source and destination vectors in device functions like

--- a/include/deal.II/meshworker/copy_data.h
+++ b/include/deal.II/meshworker/copy_data.h
@@ -223,8 +223,7 @@ namespace MeshWorker
   {
     // We permit different numbers of matrices, vectors and DoF index vectors.
     // So we have to be a bit permissive here.
-    constexpr const int max_index =
-      std::max({n_matrices, n_vectors, n_dof_indices});
+    constexpr int max_index = std::max({n_matrices, n_vectors, n_dof_indices});
     (void)max_index;
     Assert(index < max_index, ExcIndexRange(index, 0, max_index));
 


### PR DESCRIPTION
This addresses @masterleinad 's comment in #18300: For variables, `constexpr const` is duplicative. (For functions, we have a bunch of places that declare `constexpr const X& get_x()`, where we cannot remove the `const` because the `const` applies to the reference, and the `constexpr` to the function.)