### PR TITLE
Add necessary header includes.

### DIFF
--- a/include/deal.II/algorithms/any_data.h
+++ b/include/deal.II/algorithms/any_data.h
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <any>
+#include <ostream>
 #include <typeinfo>
 #include <vector>
 

--- a/include/deal.II/algorithms/general_data_storage.h
+++ b/include/deal.II/algorithms/general_data_storage.h
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <any>
 #include <map>
+#include <ostream>
 #include <string>
 #include <typeinfo>
 

--- a/include/deal.II/base/convergence_table.h
+++ b/include/deal.II/base/convergence_table.h
@@ -22,6 +22,7 @@
 #include <deal.II/base/table_handler.h>
 #include <deal.II/base/types.h>
 
+#include <ostream>
 #include <string>
 
 

--- a/include/deal.II/base/enable_observer_pointer.h
+++ b/include/deal.II/base/enable_observer_pointer.h
@@ -23,6 +23,7 @@
 #include <atomic>
 #include <map>
 #include <mutex>
+#include <ostream>
 #include <string>
 #include <typeinfo>
 #include <vector>

--- a/include/deal.II/base/observer_pointer.h
+++ b/include/deal.II/base/observer_pointer.h
@@ -22,6 +22,7 @@
 #include <deal.II/base/exceptions.h>
 
 #include <atomic>
+#include <string>
 #include <typeinfo>
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -31,6 +31,7 @@
 #endif
 
 #include <cmath>
+#include <complex>
 #include <ostream>
 #include <type_traits>
 


### PR DESCRIPTION
Found while making a mistake in working on #18071. The files really do use symbols from these files, though, and so it is right to `#include` them.