### PR TITLE
Remove the inclusion of Kokkos_Macros.h from config.h.

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -16,11 +16,6 @@
 #define dealii_config_h
 
 /***********************************************************************
- * Some deal.II macros depends on Kokkos macros:
- */
-#include <Kokkos_Macros.hpp>
-
-/***********************************************************************
  * Information about deal.II:
  */
 

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -17,9 +17,6 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/exception_macros.h>
-#include <deal.II/base/numbers.h>
-
 // The exception machinery (including the macros defined in
 // exception_macros.h) references Kokkos functions. The places that
 // use exceptions must know about these functions, and to avoid them
@@ -33,6 +30,8 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #endif
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
+
+#include <deal.II/base/exception_macros.h>
 
 #include <exception>
 #include <ostream>

--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -18,6 +18,7 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/exceptions.h>
 #include <deal.II/base/types.h>
 
 #include <cmath>


### PR DESCRIPTION
This is something I would really like to do for #18071: `config.h` and `exception_macros.h` should really only define macros, not pull in potentially large parts of other libraries. As mentioned in https://github.com/dealii/dealii/pull/18220#issuecomment-2749246532, `Kokkos_Macros.h` is one such case, and it's the last header file we currently `#include` in `config.h`, but we no longer need that following #18220. We just need to make sure that we `#include` it in `base/exceptions.h`, which is the entrypoint for exception classes that (in the `Assert` macro) currently utilize Kokkos macros.
