### PR TITLE
Let git ignore python compiled module cache.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ CMakeLists.txt.user
 /.cache
 /.clangd
 
+# Python compiled modules
+/contrib/utilities/__pycache__
+
 # misc
 /compile_commands.json
 /.clang_complete


### PR DESCRIPTION
For #18071, I'm writing some Python files that now also include Python modules (i.e., things you do `import abc` with). Python compiles these on first encounter and puts the result into the `__pycache__` subdirectory, assuming that's a writable place. This patch makes git ignore this directory.