### PR TITLE
Include Kokkos headers in files that use Kokkos.

### DIFF
--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -30,6 +30,8 @@
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/vector_memory.h>
 
+#include <Kokkos_Core.hpp>
+
 #include <limits>
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -27,6 +27,8 @@
 
 #include <deal.II/lac/vector_operation.h>
 
+#include <Kokkos_Core.hpp>
+
 #include <cstdio>
 #include <cstring>
 

--- a/include/deal.II/matrix_free/portable_tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/portable_tensor_product_kernels.h
@@ -21,6 +21,9 @@
 #include <deal.II/base/memory_space.h>
 #include <deal.II/base/utilities.h>
 
+#include <Kokkos_Core.hpp>
+
+
 DEAL_II_NAMESPACE_OPEN
 
 

--- a/source/base/exceptions.cc
+++ b/source/base/exceptions.cc
@@ -17,6 +17,8 @@
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/utilities.h>
 
+#include <Kokkos_Core.hpp>
+
 #include <cstdlib>
 #include <cstring>
 #include <iostream>

--- a/source/base/partitioner.cc
+++ b/source/base/partitioner.cc
@@ -19,6 +19,8 @@
 
 #include <boost/serialization/utility.hpp>
 
+#include <Kokkos_Core.hpp>
+
 #include <limits>
 
 DEAL_II_NAMESPACE_OPEN


### PR DESCRIPTION
These are all files that use Kokkos but don't currently `#include` any Kokkos headers. That trips me up in #18071.