### PR TITLE
Change residual and right preconditioner documentation for step-32.

### DIFF
--- a/examples/step-32/doc/intro.dox
+++ b/examples/step-32/doc/intro.dox
@@ -217,7 +217,7 @@ certain tolerance, i.e., until
   \left(\begin{array}{c}
     F_U - A U^{(k)} - B^TP^{(k)}
     \\
-    B U^{(k)}
+    -B U^{(k)}
   \end{array}\right)
   \right\|
   < \text{Tol}.

--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -210,8 +210,8 @@ namespace Step32
   // from the one used in step-31. Specifically, it is a right preconditioner,
   // implementing the matrix
   // @f{align*}{
-  //   \left(\begin{array}{cc}A^{-1} & -A^{-1}B^TS^{-1}
-  //                        \\0 & S^{-1}
+  //   \left(\begin{array}{cc}A^{-1} & A^{-1}B^TS^{-1}
+  //                        \\0 & -S^{-1}
   // \end{array}\right)
   // @f}
   // where the two inverse matrix operations


### PR DESCRIPTION
Follow-up to #18307.

For the first change: the sign of the second block of the residual should be negative.

For the second change: S=BA^{-1}B^T. The left preconditioner described in this tutorial and
used in step-31 consists of a -S block, and the right preconditioner should as well.


@bangerth 