### PR TITLE
Don't disable vectorization for Kokkos+Cuda with Clang

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -374,7 +374,6 @@ jobs:
               -D Kokkos_ENABLE_CUDA=ON \
               -D Kokkos_ENABLE_CUDA_LAMBDA=ON \
               -D Kokkos_ENABLE_CUDA_CONSTEXPR=ON \
-              -D Kokkos_ARCH_NATIVE=ON \
               -D Kokkos_ARCH_VOLTA70=ON \
               ..
         make install

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -374,6 +374,7 @@ jobs:
               -D Kokkos_ENABLE_CUDA=ON \
               -D Kokkos_ENABLE_CUDA_LAMBDA=ON \
               -D Kokkos_ENABLE_CUDA_CONSTEXPR=ON \
+              -D Kokkos_ARCH_NATIVE=ON \
               -D Kokkos_ARCH_VOLTA70=ON \
               ..
         make install
@@ -466,6 +467,7 @@ jobs:
               -D CMAKE_CXX_COMPILER=clang++-18 \
               -D CMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/../kokkos-install \
               -D Kokkos_ENABLE_CUDA=ON \
+              -D Kokkos_ARCH_NATIVE=ON \
               -D Kokkos_ARCH_VOLTA70=ON \
               ..
         make install

--- a/cmake/modules/FindDEAL_II_KOKKOS.cmake
+++ b/cmake/modules/FindDEAL_II_KOKKOS.cmake
@@ -133,6 +133,15 @@ if(KOKKOS_FOUND)
   endif()
 
   if(Kokkos_ENABLE_CUDA)
+    if (NOT CMAKE_CXX_COMPILER_ID MATCHES Clang)
+      # We need to disable SIMD vectorization for CUDA device code with nvcc.
+      # Otherwise, nvcc compilers from version 9 on will emit an error message like:
+      # "[...] contains a vector, which is not supported in device code". We
+      # would like to set the variable in check_01_cpu_feature but at that point
+      # we don't know if CUDA support is enabled in Kokkos
+      set(DEAL_II_VECTORIZATION_WIDTH_IN_BITS 0)
+    endif()
+
     # Require lambda support and expt-relaxed-constexpr for Cuda
     # so that we can use std::array and other interfaces with
     # __host__ constexpr functions in device code

--- a/cmake/modules/FindDEAL_II_KOKKOS.cmake
+++ b/cmake/modules/FindDEAL_II_KOKKOS.cmake
@@ -133,13 +133,6 @@ if(KOKKOS_FOUND)
   endif()
 
   if(Kokkos_ENABLE_CUDA)
-    # We need to disable SIMD vectorization for CUDA device code.
-    # Otherwise, nvcc compilers from version 9 on will emit an error message like:
-    # "[...] contains a vector, which is not supported in device code". We
-    # would like to set the variable in check_01_cpu_feature but at that point
-    # we don't know if CUDA support is enabled in Kokkos
-    set(DEAL_II_VECTORIZATION_WIDTH_IN_BITS 0)
-
     # Require lambda support and expt-relaxed-constexpr for Cuda
     # so that we can use std::array and other interfaces with
     # __host__ constexpr functions in device code

--- a/include/deal.II/base/array_view.h
+++ b/include/deal.II/base/array_view.h
@@ -431,7 +431,15 @@ public:
    * Return a pointer to the underlying array serving as element storage.
    * In case the container is empty a nullptr is returned.
    */
-  DEAL_II_HOST_DEVICE value_type *
+  template <typename Dummy = MemorySpaceType>
+  DEAL_II_HOST_DEVICE
+    std::enable_if_t<std::is_same_v<Dummy, dealii::MemorySpace::Default>,
+                     value_type *>
+    data() const noexcept;
+
+  template <typename Dummy = MemorySpaceType>
+  std::enable_if_t<std::is_same_v<Dummy, dealii::MemorySpace::Host>,
+                   value_type *>
   data() const noexcept;
 
   /**
@@ -661,9 +669,26 @@ ArrayView<ElementType, MemorySpaceType>::operator!=(
 
 
 template <typename ElementType, typename MemorySpaceType>
-inline DEAL_II_HOST_DEVICE
-  typename ArrayView<ElementType, MemorySpaceType>::value_type *
-  ArrayView<ElementType, MemorySpaceType>::data() const noexcept
+template <typename Dummy>
+inline DEAL_II_HOST_DEVICE std::enable_if_t<
+  std::is_same_v<Dummy, dealii::MemorySpace::Default>,
+  typename ArrayView<ElementType, MemorySpaceType>::value_type *>
+ArrayView<ElementType, MemorySpaceType>::data() const noexcept
+{
+  if (n_elements == 0)
+    return nullptr;
+  else
+    return starting_element;
+}
+
+
+
+template <typename ElementType, typename MemorySpaceType>
+template <typename Dummy>
+inline std::enable_if_t<
+  std::is_same_v<Dummy, dealii::MemorySpace::Host>,
+  typename ArrayView<ElementType, MemorySpaceType>::value_type *>
+ArrayView<ElementType, MemorySpaceType>::data() const noexcept
 {
   if (n_elements == 0)
     return nullptr;

--- a/include/deal.II/base/array_view.h
+++ b/include/deal.II/base/array_view.h
@@ -431,15 +431,7 @@ public:
    * Return a pointer to the underlying array serving as element storage.
    * In case the container is empty a nullptr is returned.
    */
-  template <typename Dummy = MemorySpaceType>
-  DEAL_II_HOST_DEVICE
-    std::enable_if_t<std::is_same_v<Dummy, dealii::MemorySpace::Default>,
-                     value_type *>
-    data() const noexcept;
-
-  template <typename Dummy = MemorySpaceType>
-  std::enable_if_t<std::is_same_v<Dummy, dealii::MemorySpace::Host>,
-                   value_type *>
+  DEAL_II_HOST_DEVICE value_type *
   data() const noexcept;
 
   /**
@@ -669,26 +661,9 @@ ArrayView<ElementType, MemorySpaceType>::operator!=(
 
 
 template <typename ElementType, typename MemorySpaceType>
-template <typename Dummy>
-inline DEAL_II_HOST_DEVICE std::enable_if_t<
-  std::is_same_v<Dummy, dealii::MemorySpace::Default>,
-  typename ArrayView<ElementType, MemorySpaceType>::value_type *>
-ArrayView<ElementType, MemorySpaceType>::data() const noexcept
-{
-  if (n_elements == 0)
-    return nullptr;
-  else
-    return starting_element;
-}
-
-
-
-template <typename ElementType, typename MemorySpaceType>
-template <typename Dummy>
-inline std::enable_if_t<
-  std::is_same_v<Dummy, dealii::MemorySpace::Host>,
-  typename ArrayView<ElementType, MemorySpaceType>::value_type *>
-ArrayView<ElementType, MemorySpaceType>::data() const noexcept
+inline DEAL_II_HOST_DEVICE
+  typename ArrayView<ElementType, MemorySpaceType>::value_type *
+  ArrayView<ElementType, MemorySpaceType>::data() const noexcept
 {
   if (n_elements == 0)
     return nullptr;


### PR DESCRIPTION
It seems we can at least enable support when compiling with `Clang` instead of `nvcc_wrapper`.