### PR TITLE
base/exceptions.h: add missing standard header `<complex>`

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -33,6 +33,7 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <deal.II/base/exception_macros.h>
 
+#include <complex>
 #include <exception>
 #include <ostream>
 #include <string>


### PR DESCRIPTION
Closes #18322
