### PR TITLE
base/table_handler.h: add missing include, remove superfluous include

### DIFF
--- a/include/deal.II/base/table_handler.h
+++ b/include/deal.II/base/table_handler.h
@@ -25,7 +25,7 @@
 #include <boost/serialization/string.hpp>
 #include <boost/serialization/vector.hpp>
 
-#include <fstream>
+#include <cstdint>
 #include <map>
 #include <ostream>
 #include <string>


### PR DESCRIPTION
 - we need `<cstdint>` for std::uint64_t used in this header

 - we do not seem to need `<fstream>`, only `<ostream>`, so remove it
   (fingers crossed)

In reference to #18323
