### PR TITLE
Portable FEEvaluation: Only go into constraints function if constrained

### DIFF
--- a/include/deal.II/matrix_free/portable_fe_evaluation.h
+++ b/include/deal.II/matrix_free/portable_fe_evaluation.h
@@ -327,11 +327,14 @@ namespace Portable
 
     for (unsigned int c = 0; c < n_components_; ++c)
       {
-        internal::resolve_hanging_nodes<dim, fe_degree, false, Number>(
-          data->team_member,
-          precomputed_data->constraint_weights,
-          precomputed_data->constraint_mask(cell_id * n_components + c),
-          Kokkos::subview(shared_data->values, Kokkos::ALL, c));
+        if (precomputed_data->constraint_mask(cell_id * n_components + c) !=
+            dealii::internal::MatrixFreeFunctions::ConstraintKinds::
+              unconstrained)
+          internal::resolve_hanging_nodes<dim, fe_degree, false, Number>(
+            data->team_member,
+            precomputed_data->constraint_weights,
+            precomputed_data->constraint_mask(cell_id * n_components + c),
+            Kokkos::subview(shared_data->values, Kokkos::ALL, c));
       }
   }
 
@@ -348,11 +351,14 @@ namespace Portable
   {
     for (unsigned int c = 0; c < n_components_; ++c)
       {
-        internal::resolve_hanging_nodes<dim, fe_degree, true, Number>(
-          data->team_member,
-          precomputed_data->constraint_weights,
-          precomputed_data->constraint_mask(cell_id * n_components + c),
-          Kokkos::subview(shared_data->values, Kokkos::ALL, c));
+        if (precomputed_data->constraint_mask(cell_id * n_components + c) !=
+            dealii::internal::MatrixFreeFunctions::ConstraintKinds::
+              unconstrained)
+          internal::resolve_hanging_nodes<dim, fe_degree, true, Number>(
+            data->team_member,
+            precomputed_data->constraint_weights,
+            precomputed_data->constraint_mask(cell_id * n_components + c),
+            Kokkos::subview(shared_data->values, Kokkos::ALL, c));
       }
 
     if (precomputed_data->use_coloring)


### PR DESCRIPTION
Another hotspot (caused by register pressure) found in collaboration with @urvijsaroliya: Our constraint interpolation still has an array https://github.com/dealii/dealii/blob/f6ff73b1994abc8e54e973acbe936079704997b1/include/deal.II/matrix_free/portable_hanging_nodes_internal.h#L153-L157 that is created for each thread. We do not need to enter the function at all if we are unconstrained on the cell. A planned follow-up patch is to replace this by a scratch array during the evaluation, to also fix the case with hanging nodes.

For my benchmark similar to step-64, I see a 2x speedup over the state after #18328. On an A100, I am now at 1.6 GDoF/s for that benchmark. Still worse than the 5.3 GDoF/s I see on an old CUDA code I ran two years ago, but this is another step towards getting the performance in shape.