### PR TITLE
source/base/parsed_convergence_table.cc: add a missing header

### DIFF
--- a/source/base/parsed_convergence_table.cc
+++ b/source/base/parsed_convergence_table.cc
@@ -17,6 +17,7 @@
 #include <deal.II/base/patterns.h>
 #include <deal.II/base/utilities.h>
 
+#include <fstream>
 #include <set>
 
 


### PR DESCRIPTION
This is needed on my machine with gcc-14 and clang-20.