### PR TITLE
Remove a comment that is no longer accurate.

### DIFF
--- a/include/deal.II/base/types.h
+++ b/include/deal.II/base/types.h
@@ -214,9 +214,7 @@ namespace TrilinosWrappers
 } // namespace TrilinosWrappers
 
 
-// this part of the namespace numbers got moved to the bottom types.h file,
-// because otherwise we get a circular inclusion of config.h, types.h, and
-// numbers.h
+
 namespace numbers
 {
   /**


### PR DESCRIPTION
Not only is the comment no longer quite correct, but we should also strive to document the *current* state, not some historical facts.