### PR TITLE
Push configuration of header subdirectories down to these subdirectories.

### DIFF
--- a/include/deal.II/CMakeLists.txt
+++ b/include/deal.II/CMakeLists.txt
@@ -42,4 +42,3 @@ add_subdirectory(physics)
 add_subdirectory(sundials)
 add_subdirectory(trilinos)
 add_subdirectory(vtk)
-

--- a/include/deal.II/CMakeLists.txt
+++ b/include/deal.II/CMakeLists.txt
@@ -1,0 +1,45 @@
+## ------------------------------------------------------------------------
+##
+## SPDX-License-Identifier: LGPL-2.1-or-later
+## Copyright (C) 2012 - 2022 by the deal.II authors
+##
+## This file is part of the deal.II library.
+##
+## Part of the source code is dual licensed under Apache-2.0 WITH
+## LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+## governing the source code and code contributions can be found in
+## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+##
+## ------------------------------------------------------------------------
+
+
+#
+# Recurse into the sub-directories:
+#
+add_subdirectory(algorithms)
+add_subdirectory(arborx)
+add_subdirectory(base)
+add_subdirectory(boost_adaptors)
+add_subdirectory(cgal)
+add_subdirectory(differentiation)
+add_subdirectory(distributed)
+add_subdirectory(dofs)
+add_subdirectory(fe)
+add_subdirectory(gmsh)
+add_subdirectory(grid)
+add_subdirectory(hp)
+add_subdirectory(integrators)
+add_subdirectory(lac)
+add_subdirectory(matrix_free)
+add_subdirectory(meshworker)
+add_subdirectory(multigrid)
+add_subdirectory(non_matching)
+add_subdirectory(numerics)
+add_subdirectory(opencascade)
+add_subdirectory(optimization)
+add_subdirectory(particles)
+add_subdirectory(physics)
+add_subdirectory(sundials)
+add_subdirectory(trilinos)
+add_subdirectory(vtk)
+

--- a/include/deal.II/algorithms/CMakeLists.txt
+++ b/include/deal.II/algorithms/CMakeLists.txt
@@ -11,6 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-
-

--- a/include/deal.II/algorithms/CMakeLists.txt
+++ b/include/deal.II/algorithms/CMakeLists.txt
@@ -13,25 +13,4 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/arborx/CMakeLists.txt
+++ b/include/deal.II/arborx/CMakeLists.txt
@@ -11,6 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-
-

--- a/include/deal.II/arborx/CMakeLists.txt
+++ b/include/deal.II/arborx/CMakeLists.txt
@@ -13,25 +13,4 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/base/CMakeLists.txt
+++ b/include/deal.II/base/CMakeLists.txt
@@ -14,24 +14,20 @@
 
 
 #
+# Configure config.h and revision.h
+#
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/config.h.in
+  ${CMAKE_CURRENT_BINARY_DIR}/config.h
+  )
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/revision.h.in
+  ${CMAKE_CURRENT_BINARY_DIR}/revision.h
+  )
+
+
+#
 # Recurse into the sub-directories:
 #
-add_subdirectory(deal.II)
-
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
+add_subdirectory(std_cxx17)
+add_subdirectory(std_cxx20)

--- a/include/deal.II/base/std_cxx17/CMakeLists.txt
+++ b/include/deal.II/base/std_cxx17/CMakeLists.txt
@@ -11,6 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-
-

--- a/include/deal.II/base/std_cxx17/CMakeLists.txt
+++ b/include/deal.II/base/std_cxx17/CMakeLists.txt
@@ -13,25 +13,4 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/base/std_cxx20/CMakeLists.txt
+++ b/include/deal.II/base/std_cxx20/CMakeLists.txt
@@ -11,6 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-
-

--- a/include/deal.II/base/std_cxx20/CMakeLists.txt
+++ b/include/deal.II/base/std_cxx20/CMakeLists.txt
@@ -13,25 +13,4 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/boost_adaptors/CMakeLists.txt
+++ b/include/deal.II/boost_adaptors/CMakeLists.txt
@@ -11,6 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-
-

--- a/include/deal.II/boost_adaptors/CMakeLists.txt
+++ b/include/deal.II/boost_adaptors/CMakeLists.txt
@@ -13,25 +13,4 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/cgal/CMakeLists.txt
+++ b/include/deal.II/cgal/CMakeLists.txt
@@ -11,6 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-
-

--- a/include/deal.II/cgal/CMakeLists.txt
+++ b/include/deal.II/cgal/CMakeLists.txt
@@ -13,25 +13,4 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/differentiation/CMakeLists.txt
+++ b/include/deal.II/differentiation/CMakeLists.txt
@@ -19,5 +19,3 @@
 #
 add_subdirectory(ad)
 add_subdirectory(sd)
-
-

--- a/include/deal.II/differentiation/CMakeLists.txt
+++ b/include/deal.II/differentiation/CMakeLists.txt
@@ -13,25 +13,11 @@
 ## ------------------------------------------------------------------------
 
 
+
 #
 # Recurse into the sub-directories:
 #
-add_subdirectory(deal.II)
+add_subdirectory(ad)
+add_subdirectory(sd)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
 
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/differentiation/ad/CMakeLists.txt
+++ b/include/deal.II/differentiation/ad/CMakeLists.txt
@@ -11,6 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-
-

--- a/include/deal.II/differentiation/ad/CMakeLists.txt
+++ b/include/deal.II/differentiation/ad/CMakeLists.txt
@@ -13,25 +13,4 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/differentiation/sd/CMakeLists.txt
+++ b/include/deal.II/differentiation/sd/CMakeLists.txt
@@ -11,6 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-
-

--- a/include/deal.II/differentiation/sd/CMakeLists.txt
+++ b/include/deal.II/differentiation/sd/CMakeLists.txt
@@ -13,25 +13,4 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/distributed/CMakeLists.txt
+++ b/include/deal.II/distributed/CMakeLists.txt
@@ -11,6 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-
-

--- a/include/deal.II/distributed/CMakeLists.txt
+++ b/include/deal.II/distributed/CMakeLists.txt
@@ -13,25 +13,4 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/dofs/CMakeLists.txt
+++ b/include/deal.II/dofs/CMakeLists.txt
@@ -11,6 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-
-

--- a/include/deal.II/dofs/CMakeLists.txt
+++ b/include/deal.II/dofs/CMakeLists.txt
@@ -13,25 +13,4 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/fe/CMakeLists.txt
+++ b/include/deal.II/fe/CMakeLists.txt
@@ -11,6 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-
-

--- a/include/deal.II/fe/CMakeLists.txt
+++ b/include/deal.II/fe/CMakeLists.txt
@@ -13,25 +13,4 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/gmsh/CMakeLists.txt
+++ b/include/deal.II/gmsh/CMakeLists.txt
@@ -11,6 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-
-

--- a/include/deal.II/gmsh/CMakeLists.txt
+++ b/include/deal.II/gmsh/CMakeLists.txt
@@ -13,25 +13,4 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/grid/CMakeLists.txt
+++ b/include/deal.II/grid/CMakeLists.txt
@@ -11,6 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-
-

--- a/include/deal.II/grid/CMakeLists.txt
+++ b/include/deal.II/grid/CMakeLists.txt
@@ -13,25 +13,4 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/hp/CMakeLists.txt
+++ b/include/deal.II/hp/CMakeLists.txt
@@ -11,6 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-
-

--- a/include/deal.II/hp/CMakeLists.txt
+++ b/include/deal.II/hp/CMakeLists.txt
@@ -13,25 +13,4 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/integrators/CMakeLists.txt
+++ b/include/deal.II/integrators/CMakeLists.txt
@@ -11,6 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-
-

--- a/include/deal.II/integrators/CMakeLists.txt
+++ b/include/deal.II/integrators/CMakeLists.txt
@@ -13,25 +13,4 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/lac/CMakeLists.txt
+++ b/include/deal.II/lac/CMakeLists.txt
@@ -11,6 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-
-

--- a/include/deal.II/lac/CMakeLists.txt
+++ b/include/deal.II/lac/CMakeLists.txt
@@ -13,25 +13,4 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/matrix_free/CMakeLists.txt
+++ b/include/deal.II/matrix_free/CMakeLists.txt
@@ -11,6 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-
-

--- a/include/deal.II/matrix_free/CMakeLists.txt
+++ b/include/deal.II/matrix_free/CMakeLists.txt
@@ -13,25 +13,4 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/meshworker/CMakeLists.txt
+++ b/include/deal.II/meshworker/CMakeLists.txt
@@ -11,6 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-
-

--- a/include/deal.II/meshworker/CMakeLists.txt
+++ b/include/deal.II/meshworker/CMakeLists.txt
@@ -13,25 +13,4 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/multigrid/CMakeLists.txt
+++ b/include/deal.II/multigrid/CMakeLists.txt
@@ -11,6 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-
-

--- a/include/deal.II/multigrid/CMakeLists.txt
+++ b/include/deal.II/multigrid/CMakeLists.txt
@@ -13,25 +13,4 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/non_matching/CMakeLists.txt
+++ b/include/deal.II/non_matching/CMakeLists.txt
@@ -11,6 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-
-

--- a/include/deal.II/non_matching/CMakeLists.txt
+++ b/include/deal.II/non_matching/CMakeLists.txt
@@ -13,25 +13,4 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/numerics/CMakeLists.txt
+++ b/include/deal.II/numerics/CMakeLists.txt
@@ -11,6 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-
-

--- a/include/deal.II/numerics/CMakeLists.txt
+++ b/include/deal.II/numerics/CMakeLists.txt
@@ -13,25 +13,4 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/opencascade/CMakeLists.txt
+++ b/include/deal.II/opencascade/CMakeLists.txt
@@ -11,6 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-
-

--- a/include/deal.II/opencascade/CMakeLists.txt
+++ b/include/deal.II/opencascade/CMakeLists.txt
@@ -13,25 +13,4 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/optimization/CMakeLists.txt
+++ b/include/deal.II/optimization/CMakeLists.txt
@@ -16,22 +16,4 @@
 #
 # Recurse into the sub-directories:
 #
-add_subdirectory(deal.II)
-
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
+add_subdirectory(rol)

--- a/include/deal.II/optimization/rol/CMakeLists.txt
+++ b/include/deal.II/optimization/rol/CMakeLists.txt
@@ -11,6 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-
-

--- a/include/deal.II/optimization/rol/CMakeLists.txt
+++ b/include/deal.II/optimization/rol/CMakeLists.txt
@@ -13,25 +13,4 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/particles/CMakeLists.txt
+++ b/include/deal.II/particles/CMakeLists.txt
@@ -11,6 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-
-

--- a/include/deal.II/particles/CMakeLists.txt
+++ b/include/deal.II/particles/CMakeLists.txt
@@ -13,25 +13,4 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/physics/CMakeLists.txt
+++ b/include/deal.II/physics/CMakeLists.txt
@@ -12,26 +12,10 @@
 ##
 ## ------------------------------------------------------------------------
 
-
 #
 # Recurse into the sub-directories:
 #
-add_subdirectory(deal.II)
+add_subdirectory(elasticity)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
 
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
+

--- a/include/deal.II/physics/CMakeLists.txt
+++ b/include/deal.II/physics/CMakeLists.txt
@@ -16,6 +16,3 @@
 # Recurse into the sub-directories:
 #
 add_subdirectory(elasticity)
-
-
-

--- a/include/deal.II/physics/elasticity/CMakeLists.txt
+++ b/include/deal.II/physics/elasticity/CMakeLists.txt
@@ -11,6 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-
-

--- a/include/deal.II/physics/elasticity/CMakeLists.txt
+++ b/include/deal.II/physics/elasticity/CMakeLists.txt
@@ -13,25 +13,4 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/sundials/CMakeLists.txt
+++ b/include/deal.II/sundials/CMakeLists.txt
@@ -11,6 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-
-

--- a/include/deal.II/sundials/CMakeLists.txt
+++ b/include/deal.II/sundials/CMakeLists.txt
@@ -13,25 +13,4 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/trilinos/CMakeLists.txt
+++ b/include/deal.II/trilinos/CMakeLists.txt
@@ -11,6 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-
-

--- a/include/deal.II/trilinos/CMakeLists.txt
+++ b/include/deal.II/trilinos/CMakeLists.txt
@@ -13,25 +13,4 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
 
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )

--- a/include/deal.II/vtk/CMakeLists.txt
+++ b/include/deal.II/vtk/CMakeLists.txt
@@ -11,5 +11,3 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
-
-

--- a/include/deal.II/vtk/CMakeLists.txt
+++ b/include/deal.II/vtk/CMakeLists.txt
@@ -13,25 +13,3 @@
 ## ------------------------------------------------------------------------
 
 
-#
-# Recurse into the sub-directories:
-#
-add_subdirectory(deal.II)
-
-#
-# Add a rule for how to install the header files that are part of the source tree:
-#
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )
-
-#
-# and don't forget to install all generated header files, too:
-#
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
-  DESTINATION ${DEAL_II_INCLUDE_RELDIR}
-  COMPONENT library
-  FILES_MATCHING PATTERN "*.h"
-  )


### PR DESCRIPTION
@tamiko Let me start to get some of the configuration changes that I've been making for #18071 into separate PRs. In this patch, I'm setting up `CMakeLists.txt` files in all of the subdirectories of `include/` and push configuration of files that live in these directories to the `CMakeLists.txt` to the directory in which these files live. At the moment, we handle everything that happens in these subdirectories in `include/CMakeLists.txt`.

At the moment, we only actually do anything in `include/deal.II/base` where we do something for `config.h` and `revision.h`. But once this patch is merged, I will have a follow-up that collects a list of all header files from each of the su-directories.