### PR TITLE
Collect all source files in one variable.

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -67,6 +67,24 @@ add_subdirectory(sundials)
 add_subdirectory(trilinos)
 add_subdirectory(arborx)
 
+
+
+# We will eventually need the names of source files to build implementation
+# module partitions. The subdirectories all reported the names of
+# source files as global paths, so let us now strip the global parts
+# so that all header files are reported relative to the 'source/'
+# directory. That is, we need to strip CMAKE_CURRENT_SOURCE_DIR from
+# all of the file names.
+list(TRANSFORM DEAL_II_SOURCE_FILES
+     REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/" "")
+
+# Propagate the list of header files back up one directory level
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)
+
+
+
+
+# -------------------------------------------------------------------------
 #
 # Set up and configure the two library targets dealii_debug and
 # dealii_release, i.e., "${DEAL_II_TARGET_NAME}_${build}."

--- a/source/algorithms/CMakeLists.txt
+++ b/source/algorithms/CMakeLists.txt
@@ -28,3 +28,16 @@ file(GLOB _header
 
 define_object_library(object_algorithms OBJECT ${_src} ${_header} ${_inst})
 expand_instantiations(object_algorithms "${_inst}")
+
+
+# Keep track of a complete list of all source files, based on the
+# variables we have set above.  Prepend each source name by the
+# current directory.
+set(_source_files)
+list(APPEND _source_files ${_src})
+list(TRANSFORM _source_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these source files to the global list and propagate
+# things back up one directory level
+list(APPEND DEAL_II_SOURCE_FILES ${_source_files})
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)

--- a/source/arborx/CMakeLists.txt
+++ b/source/arborx/CMakeLists.txt
@@ -36,3 +36,16 @@ file(GLOB _header
 
 define_object_library(object_arborx OBJECT ${_src} ${_header} ${_inst})
 expand_instantiations(object_arborx "${_inst}")
+
+
+# Keep track of a complete list of all source files, based on the
+# variables we have set above.  Prepend each source name by the
+# current directory.
+set(_source_files)
+list(APPEND _source_files ${_src})
+list(TRANSFORM _source_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these source files to the global list and propagate
+# things back up one directory level
+list(APPEND DEAL_II_SOURCE_FILES ${_source_files})
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)

--- a/source/base/CMakeLists.txt
+++ b/source/base/CMakeLists.txt
@@ -169,3 +169,16 @@ define_object_library(object_base OBJECT ${_src} ${_header} ${_inst}
   ${CMAKE_BINARY_DIR}/include/deal.II/base/config.h
   )
 expand_instantiations(object_base "${_inst}")
+
+
+# Keep track of a complete list of all source files, based on the
+# variables we have set above.  Prepend each source name by the
+# current directory.
+set(_source_files)
+list(APPEND _source_files ${_unity_include_src} ${_separate_src})
+list(TRANSFORM _source_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these source files to the global list and propagate
+# things back up one directory level
+list(APPEND DEAL_II_SOURCE_FILES ${_source_files})
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)

--- a/source/cgal/CMakeLists.txt
+++ b/source/cgal/CMakeLists.txt
@@ -46,3 +46,16 @@ file(GLOB _header
 
 define_object_library(object_cgal OBJECT ${_src} ${_header} ${_inst})
 expand_instantiations(object_cgal "${_inst}")
+
+
+# Keep track of a complete list of all source files, based on the
+# variables we have set above.  Prepend each source name by the
+# current directory.
+set(_source_files)
+list(APPEND _source_files ${_src})
+list(TRANSFORM _source_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these source files to the global list and propagate
+# things back up one directory level
+list(APPEND DEAL_II_SOURCE_FILES ${_source_files})
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)

--- a/source/differentiation/CMakeLists.txt
+++ b/source/differentiation/CMakeLists.txt
@@ -14,3 +14,7 @@
 
 add_subdirectory(ad)
 add_subdirectory(sd)
+
+
+# Propagate a value up to the parent directory:
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)

--- a/source/differentiation/ad/CMakeLists.txt
+++ b/source/differentiation/ad/CMakeLists.txt
@@ -66,3 +66,16 @@ file(GLOB _header
 
 define_object_library(object_differentiation_ad OBJECT ${_src} ${_header} ${_inst})
 expand_instantiations(object_differentiation_ad "${_inst}")
+
+
+# Keep track of a complete list of all source files, based on the
+# variables we have set above.  Prepend each source name by the
+# current directory.
+set(_source_files)
+list(APPEND _source_files ${_src})
+list(TRANSFORM _source_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these source files to the global list and propagate
+# things back up one directory level
+list(APPEND DEAL_II_SOURCE_FILES ${_source_files})
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)

--- a/source/differentiation/sd/CMakeLists.txt
+++ b/source/differentiation/sd/CMakeLists.txt
@@ -41,3 +41,16 @@ file(GLOB _header
 
 define_object_library(object_differentiation_sd OBJECT ${_src} ${_header} ${_inst})
 expand_instantiations(object_differentiation_sd "${_inst}")
+
+
+# Keep track of a complete list of all source files, based on the
+# variables we have set above.  Prepend each source name by the
+# current directory.
+set(_source_files)
+list(APPEND _source_files ${_src})
+list(TRANSFORM _source_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these source files to the global list and propagate
+# things back up one directory level
+list(APPEND DEAL_II_SOURCE_FILES ${_source_files})
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)

--- a/source/distributed/CMakeLists.txt
+++ b/source/distributed/CMakeLists.txt
@@ -69,3 +69,16 @@ file(GLOB _header
 
 define_object_library(object_distributed OBJECT ${_src} ${_header} ${_inst})
 expand_instantiations(object_distributed "${_inst}")
+
+
+# Keep track of a complete list of all source files, based on the
+# variables we have set above.  Prepend each source name by the
+# current directory.
+set(_source_files)
+list(APPEND _source_files ${_unity_include_src} ${_separate_src})
+list(TRANSFORM _source_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these source files to the global list and propagate
+# things back up one directory level
+list(APPEND DEAL_II_SOURCE_FILES ${_source_files})
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)

--- a/source/dofs/CMakeLists.txt
+++ b/source/dofs/CMakeLists.txt
@@ -60,3 +60,16 @@ file(GLOB _header
 
 define_object_library(object_dofs OBJECT ${_src} ${_header} ${_inst})
 expand_instantiations(object_dofs "${_inst}")
+
+
+# Keep track of a complete list of all source files, based on the
+# variables we have set above.  Prepend each source name by the
+# current directory.
+set(_source_files)
+list(APPEND _source_files ${_unity_include_src} ${_separate_src})
+list(TRANSFORM _source_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these source files to the global list and propagate
+# things back up one directory level
+list(APPEND DEAL_II_SOURCE_FILES ${_source_files})
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)

--- a/source/fe/CMakeLists.txt
+++ b/source/fe/CMakeLists.txt
@@ -152,3 +152,16 @@ file(GLOB _header
 
 define_object_library(object_fe OBJECT ${_src} ${_header} ${_inst})
 expand_instantiations(object_fe "${_inst}")
+
+
+# Keep track of a complete list of all source files, based on the
+# variables we have set above.  Prepend each source name by the
+# current directory.
+set(_source_files)
+list(APPEND _source_files ${_unity_include_src} ${_separate_src})
+list(TRANSFORM _source_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these source files to the global list and propagate
+# things back up one directory level
+list(APPEND DEAL_II_SOURCE_FILES ${_source_files})
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)

--- a/source/gmsh/CMakeLists.txt
+++ b/source/gmsh/CMakeLists.txt
@@ -35,3 +35,16 @@ file(GLOB _header
 
 define_object_library(object_gmsh OBJECT ${_src} ${_header} ${_inst})
 expand_instantiations(object_gmsh "${_inst}")
+
+
+# Keep track of a complete list of all source files, based on the
+# variables we have set above.  Prepend each source name by the
+# current directory.
+set(_source_files)
+list(APPEND _source_files ${_src})
+list(TRANSFORM _source_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these source files to the global list and propagate
+# things back up one directory level
+list(APPEND DEAL_II_SOURCE_FILES ${_source_files})
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)

--- a/source/grid/CMakeLists.txt
+++ b/source/grid/CMakeLists.txt
@@ -99,3 +99,16 @@ file(GLOB _header
 
 define_object_library(object_grid OBJECT ${_src} ${_header} ${_inst})
 expand_instantiations(object_grid "${_inst}")
+
+
+# Keep track of a complete list of all source files, based on the
+# variables we have set above.  Prepend each source name by the
+# current directory.
+set(_source_files)
+list(APPEND _source_files ${_unity_include_src} ${_separate_src})
+list(TRANSFORM _source_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these source files to the global list and propagate
+# things back up one directory level
+list(APPEND DEAL_II_SOURCE_FILES ${_source_files})
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)

--- a/source/hp/CMakeLists.txt
+++ b/source/hp/CMakeLists.txt
@@ -44,3 +44,16 @@ file(GLOB _header
 
 define_object_library(object_hp OBJECT ${_src} ${_header} ${_inst})
 expand_instantiations(object_hp "${_inst}")
+
+
+# Keep track of a complete list of all source files, based on the
+# variables we have set above.  Prepend each source name by the
+# current directory.
+set(_source_files)
+list(APPEND _source_files ${_unity_include_src} ${_separate_src})
+list(TRANSFORM _source_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these source files to the global list and propagate
+# things back up one directory level
+list(APPEND DEAL_II_SOURCE_FILES ${_source_files})
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)

--- a/source/integrators/CMakeLists.txt
+++ b/source/integrators/CMakeLists.txt
@@ -20,3 +20,16 @@ file(GLOB _header
   )
 
 define_object_library(object_integrators OBJECT ${_src} ${_header})
+
+
+# Keep track of a complete list of all source files, based on the
+# variables we have set above.  Prepend each source name by the
+# current directory.
+set(_source_files)
+list(APPEND _source_files ${_src})
+list(TRANSFORM _source_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these source files to the global list and propagate
+# things back up one directory level
+list(APPEND DEAL_II_SOURCE_FILES ${_source_files})
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)

--- a/source/lac/CMakeLists.txt
+++ b/source/lac/CMakeLists.txt
@@ -197,3 +197,16 @@ file(GLOB _header
 
 define_object_library(object_lac OBJECT ${_src} ${_header} ${_inst})
 expand_instantiations(object_lac "${_inst}")
+
+
+# Keep track of a complete list of all source files, based on the
+# variables we have set above.  Prepend each source name by the
+# current directory.
+set(_source_files)
+list(APPEND _source_files ${_unity_include_src} ${_separate_src})
+list(TRANSFORM _source_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these source files to the global list and propagate
+# things back up one directory level
+list(APPEND DEAL_II_SOURCE_FILES ${_source_files})
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)

--- a/source/matrix_free/CMakeLists.txt
+++ b/source/matrix_free/CMakeLists.txt
@@ -54,3 +54,16 @@ file(GLOB _header
 
 define_object_library(object_matrix_free OBJECT ${_src} ${_header} ${_inst})
 expand_instantiations(object_matrix_free "${_inst}")
+
+
+# Keep track of a complete list of all source files, based on the
+# variables we have set above.  Prepend each source name by the
+# current directory.
+set(_source_files)
+list(APPEND _source_files ${_src})
+list(TRANSFORM _source_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these source files to the global list and propagate
+# things back up one directory level
+list(APPEND DEAL_II_SOURCE_FILES ${_source_files})
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)

--- a/source/meshworker/CMakeLists.txt
+++ b/source/meshworker/CMakeLists.txt
@@ -31,3 +31,16 @@ file(GLOB _header
 
 define_object_library(object_meshworker OBJECT ${_src} ${_header} ${_inst})
 expand_instantiations(object_meshworker "${_inst}")
+
+
+# Keep track of a complete list of all source files, based on the
+# variables we have set above.  Prepend each source name by the
+# current directory.
+set(_source_files)
+list(APPEND _source_files ${_src})
+list(TRANSFORM _source_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these source files to the global list and propagate
+# things back up one directory level
+list(APPEND DEAL_II_SOURCE_FILES ${_source_files})
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)

--- a/source/multigrid/CMakeLists.txt
+++ b/source/multigrid/CMakeLists.txt
@@ -58,3 +58,16 @@ file(GLOB _header
 
 define_object_library(object_multigrid OBJECT ${_src} ${_header} ${_inst})
 expand_instantiations(object_multigrid "${_inst}")
+
+
+# Keep track of a complete list of all source files, based on the
+# variables we have set above.  Prepend each source name by the
+# current directory.
+set(_source_files)
+list(APPEND _source_files ${_unity_include_src} ${_separate_src})
+list(TRANSFORM _source_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these source files to the global list and propagate
+# things back up one directory level
+list(APPEND DEAL_II_SOURCE_FILES ${_source_files})
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)

--- a/source/non_matching/CMakeLists.txt
+++ b/source/non_matching/CMakeLists.txt
@@ -35,3 +35,16 @@ file(GLOB _header
 
 define_object_library(object_non_matching OBJECT ${_src} ${_header} ${_inst})
 expand_instantiations(object_non_matching "${_inst}")
+
+
+# Keep track of a complete list of all source files, based on the
+# variables we have set above.  Prepend each source name by the
+# current directory.
+set(_source_files)
+list(APPEND _source_files ${_src})
+list(TRANSFORM _source_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these source files to the global list and propagate
+# things back up one directory level
+list(APPEND DEAL_II_SOURCE_FILES ${_source_files})
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)

--- a/source/numerics/CMakeLists.txt
+++ b/source/numerics/CMakeLists.txt
@@ -111,3 +111,16 @@ file(GLOB _header
 
 define_object_library(object_numerics OBJECT ${_src} ${_header} ${_inst})
 expand_instantiations(object_numerics "${_inst}")
+
+
+# Keep track of a complete list of all source files, based on the
+# variables we have set above.  Prepend each source name by the
+# current directory.
+set(_source_files)
+list(APPEND _source_files ${_unity_include_src} ${_separate_src})
+list(TRANSFORM _source_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these source files to the global list and propagate
+# things back up one directory level
+list(APPEND DEAL_II_SOURCE_FILES ${_source_files})
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)

--- a/source/opencascade/CMakeLists.txt
+++ b/source/opencascade/CMakeLists.txt
@@ -35,3 +35,16 @@ file(GLOB _header
 
 define_object_library(object_opencascade OBJECT ${_src} ${_header} ${_inst})
 expand_instantiations(object_opencascade "${_inst}")
+
+
+# Keep track of a complete list of all source files, based on the
+# variables we have set above.  Prepend each source name by the
+# current directory.
+set(_source_files)
+list(APPEND _source_files ${_src})
+list(TRANSFORM _source_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these source files to the global list and propagate
+# things back up one directory level
+list(APPEND DEAL_II_SOURCE_FILES ${_source_files})
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)

--- a/source/optimization/rol/CMakeLists.txt
+++ b/source/optimization/rol/CMakeLists.txt
@@ -24,3 +24,16 @@ file(GLOB _header
 
 define_object_library(object_rol OBJECT ${_src} ${_header} ${_inst})
 expand_instantiations(object_rol "${_inst}")
+
+
+# Keep track of a complete list of all source files, based on the
+# variables we have set above.  Prepend each source name by the
+# current directory.
+set(_source_files)
+list(APPEND _source_files ${_src})
+list(TRANSFORM _source_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these source files to the global list and propagate
+# things back up one directory level
+list(APPEND DEAL_II_SOURCE_FILES ${_source_files})
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)

--- a/source/particles/CMakeLists.txt
+++ b/source/particles/CMakeLists.txt
@@ -35,3 +35,16 @@ file(GLOB _header
 
 define_object_library(object_particles OBJECT ${_src} ${_header} ${_inst})
 expand_instantiations(object_particles "${_inst}")
+
+
+# Keep track of a complete list of all source files, based on the
+# variables we have set above.  Prepend each source name by the
+# current directory.
+set(_source_files)
+list(APPEND _source_files ${_src})
+list(TRANSFORM _source_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these source files to the global list and propagate
+# things back up one directory level
+list(APPEND DEAL_II_SOURCE_FILES ${_source_files})
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)

--- a/source/physics/CMakeLists.txt
+++ b/source/physics/CMakeLists.txt
@@ -29,3 +29,16 @@ file(GLOB _header
 
 define_object_library(object_physics OBJECT ${_src} ${_header} ${_inst})
 expand_instantiations(object_physics "${_inst}")
+
+
+# Keep track of a complete list of all source files, based on the
+# variables we have set above.  Prepend each source name by the
+# current directory.
+set(_source_files)
+list(APPEND _source_files ${_src})
+list(TRANSFORM _source_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these source files to the global list and propagate
+# things back up one directory level
+list(APPEND DEAL_II_SOURCE_FILES ${_source_files})
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)

--- a/source/physics/elasticity/CMakeLists.txt
+++ b/source/physics/elasticity/CMakeLists.txt
@@ -28,3 +28,16 @@ file(GLOB _header
 
 define_object_library(object_physics_elasticity OBJECT ${_src} ${_header} ${_inst})
 expand_instantiations(object_physics_elasticity "${_inst}")
+
+
+# Keep track of a complete list of all source files, based on the
+# variables we have set above.  Prepend each source name by the
+# current directory.
+set(_source_files)
+list(APPEND _source_files ${_src})
+list(TRANSFORM _source_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these source files to the global list and propagate
+# things back up one directory level
+list(APPEND DEAL_II_SOURCE_FILES ${_source_files})
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)

--- a/source/sundials/CMakeLists.txt
+++ b/source/sundials/CMakeLists.txt
@@ -38,3 +38,16 @@ file(GLOB _header
 
 define_object_library(object_sundials OBJECT ${_src} ${_header} ${_inst})
 expand_instantiations(object_sundials "${_inst}")
+
+
+# Keep track of a complete list of all source files, based on the
+# variables we have set above.  Prepend each source name by the
+# current directory.
+set(_source_files)
+list(APPEND _source_files ${_src})
+list(TRANSFORM _source_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these source files to the global list and propagate
+# things back up one directory level
+list(APPEND DEAL_II_SOURCE_FILES ${_source_files})
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)

--- a/source/trilinos/CMakeLists.txt
+++ b/source/trilinos/CMakeLists.txt
@@ -34,3 +34,16 @@ file(GLOB _header
 
 define_object_library(object_trilinos OBJECT ${_src} ${_header} ${_inst})
 expand_instantiations(object_trilinos "${_inst}")
+
+
+# Keep track of a complete list of all source files, based on the
+# variables we have set above.  Prepend each source name by the
+# current directory.
+set(_source_files)
+list(APPEND _source_files ${_src})
+list(TRANSFORM _source_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these source files to the global list and propagate
+# things back up one directory level
+list(APPEND DEAL_II_SOURCE_FILES ${_source_files})
+set(DEAL_II_SOURCE_FILES ${DEAL_II_SOURCE_FILES} PARENT_SCOPE)


### PR DESCRIPTION
For building modules (see #18071), I will need to transform each source (`.cc`) file. This patch builds a list of these files. I will post a separate patch that also collects header files in a separate list once #18336 is merged.

@tamiko FYI