### PR TITLE
Get rid of some 1d orientation special cases.

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -2530,13 +2530,7 @@ ReferenceCell::face_to_cell_vertices(
 {
   AssertIndexRange(face, n_faces());
   AssertIndexRange(vertex, face_reference_cell(face).n_vertices());
-  // TODO: once the default orientation is switched to 0 then we can remove this
-  // special case for 1D.
-  if (get_dimension() == 1)
-    Assert(combined_face_orientation == numbers::default_geometric_orientation,
-           ExcMessage("In 1D, all faces must have the default orientation."));
-  else
-    AssertIndexRange(combined_face_orientation, n_face_orientations(face));
+  AssertIndexRange(combined_face_orientation, n_face_orientations(face));
 
   switch (this->kind)
     {

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -4896,33 +4896,23 @@ namespace internal
       inline static void
       set_combined_face_orientation(
         const TriaAccessor<structdim, dim, spacedim> &accessor,
-        const unsigned int                            face,
+        const unsigned int                            face_no,
         const types::geometric_orientation            combined_orientation)
       {
         Assert(structdim == dim,
                ExcMessage("This function can only be used on objects that are "
                           "cells and not on objects which bound cells."));
-        AssertIndexRange(face, accessor.n_faces());
-
-        if (dim == 1)
-          Assert(combined_orientation == numbers::default_geometric_orientation,
-                 ExcMessage("In 1d, faces do not have an orientation, so the "
-                            "only valid value is the default."));
-        else if (dim == 2)
-          Assert(combined_orientation ==
-                     numbers::default_geometric_orientation ||
-                   combined_orientation == numbers::reverse_line_orientation,
-                 ExcMessage(
-                   "In 2d, the only valid values of the combined orientation "
-                   "are the standard orientation or the reversed line "
-                   "orientation."));
+        AssertIndexRange(face_no, accessor.n_faces());
+        AssertIndexRange(combined_orientation,
+                         accessor.reference_cell().n_face_orientations(
+                           face_no));
 
         // face_orientations is not set up in 1d
         if (dim != 1)
           accessor.tria->levels[accessor.present_level]
             ->face_orientations.set_combined_orientation(
               accessor.present_index * ReferenceCells::max_n_faces<dim>() +
-                face,
+                face_no,
               combined_orientation);
       }
 

--- a/source/base/qprojector.cc
+++ b/source/base/qprojector.cc
@@ -1244,11 +1244,8 @@ QProjector<dim>::DataSetDescriptor::face(
   const types::geometric_orientation combined_orientation,
   const unsigned int                 n_quadrature_points)
 {
-  // TODO: once we move to representing the default orientation as 0 (instead of
-  // 1) we can get rid of the dim = 1 check
-  Assert(dim == 1 ||
-           (combined_orientation < reference_cell.n_face_orientations(face_no)),
-         ExcInternalError());
+  AssertIndexRange(combined_orientation,
+                   reference_cell.n_face_orientations(face_no));
 
   // TODO: once the default orientation is 0 we can combine this with the
   // general branch


### PR DESCRIPTION
Now that the default orientation is zero and the total number of orientations (in 1d) is 1, we can treat this in the same way as everything else.

Part of #14667.