### PR TITLE
Add header include to import PETSc/SLEPc macro names.

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -509,10 +509,11 @@ DEAL_II_NAMESPACE_CLOSE
  * PETSc:
  *
  * Note: The following macros are defined in petscversion.h
- *       so we don't repeat them here.
+ *       so we simply refer to the ones there.
  */
 
 #ifdef DEAL_II_WITH_PETSC
+#  include <petscversion.h>
 #  define DEAL_II_PETSC_VERSION_LT(major,minor,subminor) \
     PETSC_VERSION_LT(major,minor,subminor)
 #  define DEAL_II_PETSC_VERSION_GTE(major,minor,subminor) \
@@ -524,6 +525,7 @@ DEAL_II_NAMESPACE_CLOSE
  */
 
 #ifdef DEAL_II_WITH_SLEPC
+#  include <slepcversion.h>
 #  define DEAL_II_SLEPC_VERSION_LT(major,minor,subminor) \
     SLEPC_VERSION_LT(major,minor,subminor)
 #  define DEAL_II_SLEPC_VERSION_GTE(major,minor,subminor) \


### PR DESCRIPTION
In `config.h`, we define
```
#ifdef DEAL_II_WITH_PETSC
#  define DEAL_II_PETSC_VERSION_LT(major,minor,subminor) \
    PETSC_VERSION_LT(major,minor,subminor)
#  define DEAL_II_PETSC_VERSION_GTE(major,minor,subminor) \
    PETSC_VERSION_GE(major,minor,subminor)
#endif
```
and similarly for SLEPc. So we reference the `PETSC_VERSION_LT` macro, but we do not make sure that the corresponding definition of the macro is available. Do so by including the corresponding header file.

In converting to modules, I need to make sure that whatever we include in config.h really does only define preprocessor macros and not much else. This is in fact true for `petscversion.h`.

Part of #18071.