### PR TITLE
QProjector: combine all `project_to_all_faces()` functions.

### DIFF
--- a/include/deal.II/base/qprojector.h
+++ b/include/deal.II/base/qprojector.h
@@ -569,12 +569,6 @@ QProjector<3>::project_to_face(const ReferenceCell   &reference_cell,
                                std::vector<Point<3>> &q_points);
 
 template <>
-Quadrature<1>
-QProjector<1>::project_to_all_faces(const ReferenceCell      &reference_cell,
-                                    const hp::QCollection<0> &quadrature);
-
-
-template <>
 void
 QProjector<1>::project_to_subface(const ReferenceCell &reference_cell,
                                   const Quadrature<0> &,

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -189,6 +189,12 @@ public:
    * @pre The template argument `dim` must equal the dimension
    *   of the space in which the reference cell you are querying
    *   lives (i.e., it must equal the result of get_dimension()).
+   *
+   * For ReferenceCells::Vertex, the reference cell is a zero-dimensional point
+   * in a zero-dimensional space: i.e., asking about the value of a polynomial
+   * doesn't make sense since there cannot be any independent variables. To
+   * enable dimension-independent programming we define the zero-dimensional
+   * value to be 1.
    */
   template <int dim>
   double
@@ -2888,10 +2894,13 @@ ReferenceCell::d_linear_shape_function(const Point<dim>  &xi,
   switch (this->kind)
     {
       case ReferenceCells::Vertex:
+        return 1.0;
       case ReferenceCells::Line:
       case ReferenceCells::Quadrilateral:
       case ReferenceCells::Hexahedron:
-        return GeometryInfo<dim>::d_linear_shape_function(xi, i);
+        if constexpr (dim > 0)
+          return GeometryInfo<dim>::d_linear_shape_function(xi, i);
+        DEAL_II_ASSERT_UNREACHABLE();
       // see also BarycentricPolynomials<2>::compute_value
       case ReferenceCells::Triangle:
         {
@@ -2962,6 +2971,7 @@ ReferenceCell::d_linear_shape_function(const Point<dim>  &xi,
         DEAL_II_NOT_IMPLEMENTED();
     }
 
+  DEAL_II_ASSERT_UNREACHABLE();
   return 0.0;
 }
 
@@ -3013,7 +3023,7 @@ ReferenceCell::volume() const
   switch (this->kind)
     {
       case ReferenceCells::Vertex:
-        return 0;
+        return 1;
       case ReferenceCells::Line:
         return 1;
       case ReferenceCells::Triangle:

--- a/tests/feinterface/fe_interface_view_01.cc
+++ b/tests/feinterface/fe_interface_view_01.cc
@@ -69,28 +69,34 @@ test(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
         for (unsigned int c = 0; c < fe.n_components(); ++c)
           {
             const FEValuesExtractors::Scalar single_component(c);
+            constexpr double                 tolerance = 1e-10;
             for (unsigned int i = 0; i < n_dofs_face; ++i)
               for (unsigned int q = 0; q < n_q_points; ++q)
                 {
-                  if (fe_iv[single_component].value(true, i, q) != 0)
+                  if (std::abs(fe_iv[single_component].value(true, i, q)) >
+                      tolerance)
                     deallog << fe_iv[single_component].value(true, i, q)
                             << "  ";
-                  if (fe_iv[single_component].value(false, i, q) != 0)
+                  if (std::abs(fe_iv[single_component].value(false, i, q)) >
+                      tolerance)
                     deallog << fe_iv[single_component].value(false, i, q)
                             << "  ";
-                  if (fe_iv[single_component].jump_in_values(i, q) != 0)
+                  if (std::abs(fe_iv[single_component].jump_in_values(i, q)) >
+                      tolerance)
                     deallog << fe_iv[single_component].jump_in_values(i, q)
                             << "  ";
-                  if (fe_iv[single_component].average_of_values(i, q) != 0)
+                  if (std::abs(
+                        fe_iv[single_component].average_of_values(i, q)) >
+                      tolerance)
                     deallog << fe_iv[single_component].average_of_values(i, q)
                             << "  ";
-                  if (fe_iv[single_component].jump_in_gradients(i, q).norm() !=
-                      0)
+                  if (fe_iv[single_component].jump_in_gradients(i, q).norm() >
+                      tolerance)
                     deallog << fe_iv[single_component].jump_in_gradients(i, q)
                             << "  ";
                   if (fe_iv[single_component]
                         .average_of_gradients(i, q)
-                        .norm() != 0)
+                        .norm() > tolerance)
                     deallog
                       << fe_iv[single_component].average_of_gradients(i, q)
                       << std::endl;

--- a/tests/feinterface/fe_interface_view_02.cc
+++ b/tests/feinterface/fe_interface_view_02.cc
@@ -79,32 +79,33 @@ test(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
             if (c + dim <= fe.n_components())
               {
                 const FEValuesExtractors::Vector vec_components(c);
+                constexpr double                 tolerance = 1e-10;
                 for (unsigned int i = 0; i < n_dofs_face; ++i)
                   for (unsigned int q = 0; q < n_q_points; ++q)
                     {
-                      if (fe_iv[vec_components].value(true, i, q).norm() != 0)
+                      if (fe_iv[vec_components].value(true, i, q).norm() >
+                          tolerance)
                         deallog << fe_iv[vec_components].value(true, i, q)
                                 << "  ";
-                      if (fe_iv[vec_components].value(false, i, q).norm() != 0)
+                      if (fe_iv[vec_components].value(false, i, q).norm() >
+                          tolerance)
                         deallog << fe_iv[vec_components].value(false, i, q)
                                 << "  ";
-                      if (fe_iv[vec_components].jump_in_values(i, q).norm() !=
-                          0)
+                      if (fe_iv[vec_components].jump_in_values(i, q).norm() >
+                          tolerance)
                         deallog << fe_iv[vec_components].jump_in_values(i, q)
                                 << "  ";
-                      if (fe_iv[vec_components]
-                            .average_of_values(i, q)
-                            .norm() != 0)
+                      if (fe_iv[vec_components].average_of_values(i, q).norm() >
+                          tolerance)
                         deallog << fe_iv[vec_components].average_of_values(i, q)
                                 << "  ";
-                      if (fe_iv[vec_components]
-                            .jump_in_gradients(i, q)
-                            .norm() != 0)
+                      if (fe_iv[vec_components].jump_in_gradients(i, q).norm() >
+                          tolerance)
                         deallog << fe_iv[vec_components].jump_in_gradients(i, q)
                                 << "  ";
                       if (fe_iv[vec_components]
                             .average_of_gradients(i, q)
-                            .norm() != 0)
+                            .norm() > tolerance)
                         deallog
                           << fe_iv[vec_components].average_of_gradients(i, q)
                           << std::endl;


### PR DESCRIPTION
Now that the indexing is the same, 0 is the default orientation (which makes it a lot easier to write code which works with 1d), and we compute quadrilateral rules for both orientations of quadrilateral faces we can finally combine all the different versions of this function.

Part of #14667.