### PR TITLE
MPI::NoncontiguousPartitioner: Fix missing clearing of variables in reinit

### DIFF
--- a/source/base/mpi_noncontiguous_partitioner.cc
+++ b/source/base/mpi_noncontiguous_partitioner.cc
@@ -100,6 +100,8 @@ namespace Utilities
       recv_ranks.clear();
       recv_ptr.clear();
       recv_indices.clear();
+      recv_indices_duplicates.clear();
+      recv_indices_duplicates_ptr.clear();
       buffers.clear();
       requests.clear();
 


### PR DESCRIPTION
This patch ensures that two additional internal variables are properly cleared when the partitioner is reset. These were previously left uncleared, leading to incorrect behavior upon reinitialization of the partitioner.

@peterrum @nmuch FYI