### PR TITLE
Add necessary header includes.

### DIFF
--- a/include/deal.II/lac/petsc_snes.templates.h
+++ b/include/deal.II/lac/petsc_snes.templates.h
@@ -19,11 +19,13 @@
 
 #ifdef DEAL_II_WITH_PETSC
 #  include <deal.II/base/exceptions.h>
+#  include <deal.II/base/mpi_stub.h>
 
 #  include <deal.II/lac/petsc_precondition.h>
 #  include <deal.II/lac/petsc_snes.h>
 
 #  include <petscdm.h>
+#  include <petscerror.h>
 #  include <petscsnes.h>
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/lac/petsc_ts.templates.h
+++ b/include/deal.II/lac/petsc_ts.templates.h
@@ -19,11 +19,13 @@
 
 #ifdef DEAL_II_WITH_PETSC
 #  include <deal.II/base/exceptions.h>
+#  include <deal.II/base/mpi_stub.h>
 
 #  include <deal.II/lac/petsc_precondition.h>
 #  include <deal.II/lac/petsc_ts.h>
 
 #  include <petscdm.h>
+#  include <petscerror.h>
 #  include <petscts.h>
 
 DEAL_II_NAMESPACE_OPEN


### PR DESCRIPTION
These two files use the PETSc error mechanism (e.g., by using `PetscCall`, or `CHKERR`). We should include the necessary header file. They also use `MPI_Comm`, so include `mpi_stub.h` as well.