### PR TITLE
QProjector documentation fixes

### DIFF
--- a/include/deal.II/base/qprojector.h
+++ b/include/deal.II/base/qprojector.h
@@ -58,11 +58,11 @@ class ReferenceCell;
  *
  * In practice, computing face integrals (e.g., via FEFaceValues or
  * FESubfaceValues) requires quadrature rules for all possible permutations of
- * face number, subface number, and orientation. This class provides several
- * functions for doing just that, such as QProjector::project_to_all_faces().
- * Furthermore, the DataSetDescriptor class implements indexing for converting
- * between face number, subface number, and orientation to the index of the
- * associated Quadrature rule.
+ * face number, subface number, and combined orientation. This class provides
+ * several functions for doing just that, such as
+ * QProjector::project_to_all_faces(). Furthermore, the DataSetDescriptor class
+ * implements indexing for converting between face number, subface number, and
+ * combined orientation to the index of the associated Quadrature rule.
  */
 template <int dim>
 class QProjector
@@ -136,7 +136,7 @@ public:
   project_to_face(const ReferenceCell               &reference_cell,
                   const SubQuadrature               &quadrature,
                   const unsigned int                 face_no,
-                  const types::geometric_orientation orientation);
+                  const types::geometric_orientation combined_orientation);
 
   /**
    * Compute the quadrature points on the cell if the given quadrature formula
@@ -147,12 +147,12 @@ public:
    * @note Only the points are transformed. The quadrature weights are the
    * same as those of the original rule.
    *
-   * @deprecated Use the version of project_to_subface() which takes an
-   * orientation argument instead.
+   * @deprecated Use the version of project_to_subface() which takes a
+   * combined_orientation argument instead.
    */
   DEAL_II_DEPRECATED_EARLY_WITH_COMMENT(
-    "Use the version of project_to_subface() which takes an orientation "
-    "argument instead.")
+    "Use the version of project_to_subface() which takes a "
+    "combined_orientation argument instead.")
   static void
   project_to_subface(const ReferenceCell           &reference_cell,
                      const SubQuadrature           &quadrature,
@@ -175,12 +175,12 @@ public:
    * that the cell is a line (1D), a quad (2d), or a hex (3d). Use the other
    * version of this function that takes the reference cell type instead.
    *
-   * @deprecated Use the version of project_to_subface() which takes an
-   * orientation argument instead.
+   * @deprecated Use the version of project_to_subface() which takes a
+   * combined_orientation argument instead.
    */
   DEAL_II_DEPRECATED_EARLY_WITH_COMMENT(
-    "Use the version of project_to_subface() which takes an orientation "
-    "argument instead.")
+    "Use the version of project_to_subface() which takes a "
+    "combined_orientation argument instead.")
   static Quadrature<dim>
   project_to_subface(const ReferenceCell           &reference_cell,
                      const SubQuadrature           &quadrature,
@@ -198,12 +198,12 @@ public:
    * @note Only the points are transformed. The quadrature weights are the
    * same as those of the original rule.
    *
-   * @deprecated Use the version of project_to_subface() which takes an
-   * orientation argument instead.
+   * @deprecated Use the version of project_to_subface() which takes a
+   * combined_orientation argument instead.
    */
   DEAL_II_DEPRECATED_EARLY_WITH_COMMENT(
-    "Use the version of project_to_subface() which takes an orientation "
-    "argument instead.")
+    "Use the version of project_to_subface() which takes a "
+    "combined_orientation argument instead.")
   static Quadrature<dim>
   project_to_oriented_subface(const ReferenceCell             &reference_cell,
                               const SubQuadrature             &quadrature,
@@ -228,7 +228,7 @@ public:
                      const SubQuadrature               &quadrature,
                      const unsigned int                 face_no,
                      const unsigned int                 subface_no,
-                     const types::geometric_orientation orientation,
+                     const types::geometric_orientation combined_orientation,
                      const RefinementCase<dim - 1>     &ref_case);
 
   /**
@@ -245,8 +245,8 @@ public:
    * FEFaceValues.
    *
    * @note This function creates ReferenceCell::n_face_orientations() sets of
-   * quadrature points for each face which are indexed (by orientation and face
-   * number) by a DataSetDescriptor.
+   * quadrature points for each face which are indexed (by combined orientation
+   * and face number) by a DataSetDescriptor.
    */
   static Quadrature<dim>
   project_to_all_faces(const ReferenceCell            &reference_cell,
@@ -325,10 +325,10 @@ public:
    *
    * The functions QProjector::project_to_all_faces() and
    * QProjector::project_to_all_subfaces() each combine all quadrature rules
-   * (i.e., all possible combinations of face, subface, and orientation) into a
-   * single Quadrature object. DataSetDescriptor implements the correct indexing
-   * for extracting from that Quadrature rule the correct index for those
-   * values.
+   * (i.e., all possible combinations of face, subface, and combined
+   * orientation) into a single Quadrature object. DataSetDescriptor implements
+   * the correct indexing for extracting from that Quadrature rule the correct
+   * index for those values.
    */
   class DataSetDescriptor
   {

--- a/include/deal.II/base/qprojector.h
+++ b/include/deal.II/base/qprojector.h
@@ -222,13 +222,7 @@ public:
    *
    * @note Only the points are transformed. The quadrature weights are the
    * same as those of the original rule.
-   *
-   * @deprecated Use the version of project_to_face() which takes an
-   * orientation argument instead.
    */
-  DEAL_II_DEPRECATED_EARLY_WITH_COMMENT(
-    "Use the version of project_to_subface() which takes an orientation "
-    "argument instead.")
   static Quadrature<dim>
   project_to_subface(const ReferenceCell               &reference_cell,
                      const SubQuadrature               &quadrature,

--- a/include/deal.II/base/qprojector.h
+++ b/include/deal.II/base/qprojector.h
@@ -147,7 +147,7 @@ public:
    * @note Only the points are transformed. The quadrature weights are the
    * same as those of the original rule.
    *
-   * @deprecated Use the version of project_to_face() which takes an
+   * @deprecated Use the version of project_to_subface() which takes an
    * orientation argument instead.
    */
   DEAL_II_DEPRECATED_EARLY_WITH_COMMENT(
@@ -175,7 +175,7 @@ public:
    * that the cell is a line (1D), a quad (2d), or a hex (3d). Use the other
    * version of this function that takes the reference cell type instead.
    *
-   * @deprecated Use the version of project_to_face() which takes an
+   * @deprecated Use the version of project_to_subface() which takes an
    * orientation argument instead.
    */
   DEAL_II_DEPRECATED_EARLY_WITH_COMMENT(
@@ -198,7 +198,7 @@ public:
    * @note Only the points are transformed. The quadrature weights are the
    * same as those of the original rule.
    *
-   * @deprecated Use the version of project_to_face() which takes an
+   * @deprecated Use the version of project_to_subface() which takes an
    * orientation argument instead.
    */
   DEAL_II_DEPRECATED_EARLY_WITH_COMMENT(

--- a/source/base/qprojector.cc
+++ b/source/base/qprojector.cc
@@ -476,13 +476,15 @@ QProjector<dim>::project_to_oriented_face(const ReferenceCell &reference_cell,
 
 template <int dim>
 Quadrature<dim>
-QProjector<dim>::project_to_face(const ReferenceCell       &reference_cell,
-                                 const Quadrature<dim - 1> &quadrature,
-                                 const unsigned int         face_no,
-                                 const types::geometric_orientation orientation)
+QProjector<dim>::project_to_face(
+  const ReferenceCell               &reference_cell,
+  const Quadrature<dim - 1>         &quadrature,
+  const unsigned int                 face_no,
+  const types::geometric_orientation combined_orientation)
 {
   AssertIndexRange(face_no, reference_cell.n_faces());
-  AssertIndexRange(orientation, reference_cell.n_face_orientations(face_no));
+  AssertIndexRange(combined_orientation,
+                   reference_cell.n_face_orientations(face_no));
   AssertDimension(reference_cell.get_dimension(), dim);
 
   std::vector<Point<dim>> points;
@@ -499,7 +501,7 @@ QProjector<dim>::project_to_face(const ReferenceCell       &reference_cell,
                                               face_vertices,
                                               reference_cell.face_measure(
                                                 face_no),
-                                              orientation,
+                                              combined_orientation,
                                               points,
                                               weights);
 
@@ -604,11 +606,12 @@ QProjector<dim>::project_to_subface(
   const SubQuadrature               &quadrature,
   const unsigned int                 face_no,
   const unsigned int                 subface_no,
-  const types::geometric_orientation orientation,
+  const types::geometric_orientation combined_orientation,
   const RefinementCase<dim - 1>     &ref_case)
 {
   AssertIndexRange(face_no, reference_cell.n_faces());
-  AssertIndexRange(orientation, reference_cell.n_face_orientations(face_no));
+  AssertIndexRange(combined_orientation,
+                   reference_cell.n_face_orientations(face_no));
   AssertDimension(reference_cell.get_dimension(), dim);
   AssertIndexRange(subface_no,
                    reference_cell.face_reference_cell(face_no)
@@ -693,7 +696,7 @@ QProjector<dim>::project_to_subface(
       else
         DEAL_II_ASSERT_UNREACHABLE();
 
-      if (orientation == numbers::reverse_line_orientation)
+      if (combined_orientation == numbers::reverse_line_orientation)
         {
           std::reverse(q_points.begin(), q_points.end());
           std::reverse(q_weights.begin(), q_weights.end());


### PR DESCRIPTION
Part of #14667.

Fix a few things in the documentation:
1. I accidentally deprecated every version of `project_to_subface()`: undeprecate the correct one
2. Fix some other deprecation strings
3. Consistently call things the combined orientation