### PR TITLE
Switch MatrixOut to default to sparse output.

### DIFF
--- a/doc/news/changes/incompatibilities/20250421Bangerth
+++ b/doc/news/changes/incompatibilities/20250421Bangerth
@@ -1,0 +1,9 @@
+Changed: Given that the MatrixOut class now allows to create "sparse"
+representations (see the "Minor changes" section of this page), the
+default for what kind of output is being produced has now also been
+changed to create this "sparse" output, rather than the traditional
+"dense" output. You can switch back to the traditional way in which
+zero matrix entries are also represented in the visualization output
+using the MatrixOut::Options::create_sparse_plot variable.
+<br>
+(Wolfgang Bangerth, 2025/04/21)

--- a/include/deal.II/lac/matrix_out.h
+++ b/include/deal.II/lac/matrix_out.h
@@ -121,7 +121,8 @@ public:
     bool discontinuous;
 
     /**
-     * By default, the MatrixOut class creates a plot in which each matrix
+     * If this flag is set to `false`, the MatrixOut class creates
+     * a plot in which each matrix
      * entry is actually shown, even if it is zero. For large
      * matrices, this results in very large output files, or indeed
      * exhausts the available memory. On the other hand, if the
@@ -130,6 +131,8 @@ public:
      * shown. For sparse matrices, this leads to an output size that
      * is proportional to the number of nonzero entries, rather than
      * proportional to $N^2$.
+     *
+     * The default is `true`.
      *
      * @note Internally, the current implementation continues to loop
      *   over all matrix entries, whether they are zero or not. As a
@@ -149,7 +152,7 @@ public:
     Options(const bool         show_absolute_values = false,
             const unsigned int block_size           = 1,
             const bool         discontinuous        = false,
-            const bool         create_sparse_plot   = false);
+            const bool         create_sparse_plot   = true);
   };
 
   /**

--- a/tests/lac/matrix_out.cc
+++ b/tests/lac/matrix_out.cc
@@ -57,7 +57,7 @@ main()
       MatrixOut matrix_out;
       matrix_out.build_patches(sparse_matrix,
                                "sparse_matrix",
-                               MatrixOut::Options(true));
+                               MatrixOut::Options(true, 1, false, false));
       matrix_out.write_eps(logfile);
     };
 
@@ -73,7 +73,7 @@ main()
       MatrixOut matrix_out;
       matrix_out.build_patches(full_matrix,
                                "collated_matrix",
-                               MatrixOut::Options(false, 4));
+                               MatrixOut::Options(false, 4, false, false));
       matrix_out.write_gmv(logfile);
     };
 }

--- a/tests/lac/matrix_out_02.cc
+++ b/tests/lac/matrix_out_02.cc
@@ -54,7 +54,7 @@ main(int argc, char **argv)
       MatrixOut matrix_out;
       matrix_out.build_patches(sparse_matrix,
                                "sparse_matrix",
-                               MatrixOut::Options(true, 1, true));
+                               MatrixOut::Options(true, 1, true, false));
       matrix_out.write_gnuplot(logfile);
     }
 }


### PR DESCRIPTION
Fixes #18370. Follow-up to #18365.