### PR TITLE
Step 81: fix typos and fix logic for enabling/disabling absorbing boundary conditions.

### DIFF
--- a/examples/step-81/doc/intro.dox
+++ b/examples/step-81/doc/intro.dox
@@ -203,13 +203,13 @@ Accordingly, our rescaled equations are
   -i\mu_r \hat{\mathbf{H}} + \hat{\nabla} \times \hat{\mathbf{E}}
   &= -\hat{\mathbf{M}}_a,
   \\
-  \hat{\nabla} \cdot (\mu_r\hat{\mathbf{H}}) &= \frac{1}{i\omega}\hat{\nabla}
+  \hat{\nabla} \cdot (\mu_r\hat{\mathbf{H}}) &= \frac{1}{i}\hat{\nabla}
   \cdot \hat{\mathbf{M}}_a,
   \\
   i\varepsilon_r\hat{\mathbf{E}} + \nabla\times(\mu^{-1}\mathbf{H})
   &= \mathbf{J}_a,
   \\
-  \nabla\cdot(\varepsilon\mathbf{E}) &= \frac{1}{i\omega}\hat{\nabla}
+  \nabla\cdot(\varepsilon\mathbf{E}) &= \frac{1}{i}\hat{\nabla}
   \cdot\hat{\mathbf{J}}_a.
 @f}
 
@@ -238,7 +238,7 @@ in $\Omega\backslash\Sigma$.
 - \int_\Omega \varepsilon_r\mathbf{E} \cdot \bar{\varphi}\;\text{d}x
 - \int_\Sigma [\nu \times (\mu_r^{-1}\nabla\times\mathbf{E} +
 \mu^{-1}\mathbf{M}_a)]_{\Sigma}\cdot \bar{\varphi}_T\;\text{d}o_x\\
-\qquad - \int_{\partial\Omega} (\nu \times (\mu_r^{-1}\nabla\times\mathbf{E} +
+\qquad + \int_{\partial\Omega} (\nu \times (\mu_r^{-1}\nabla\times\mathbf{E} +
 \mu^{-1}\mathbf{M}_a)) \cdot \bar{\varphi}_T\;\text{d}o_x =
 i\int_\Omega \mathbf{J}_a \cdot \bar{\varphi}\;\text{d}x
 - \int_\Omega \mu_r^{-1}\mathbf{M}_a \cdot (\nabla \times \bar{\varphi})\;\text{d}x.
@@ -277,7 +277,7 @@ Combining, our weak form is as follows:
 - \int_\Omega \varepsilon_r\mathbf{E} \cdot \bar{\varphi}\;\text{d}x
 - i\int_\Sigma (\sigma_r^{\Sigma}\mathbf{E}_T) \cdot \bar{\varphi}_T\;\text{d}o_x\\
 \qquad - i\int_{\partial\Omega} (\sqrt{\mu_r^{-1}\varepsilon}\mathbf{E}_T) \cdot
-(\nabla\times\bar{\varphi}_T)\;\text{d}o_x.=
+\bar{\varphi}_T\;\text{d}o_x =
 i\int_\Omega \mathbf{J}_a \cdot \bar{\varphi}\;\text{d}x
 - \int_\Omega \mu_r^{-1}\mathbf{M}_a \cdot (\nabla \times \bar{\varphi})\;\text{d}x.
 @f]
@@ -310,7 +310,7 @@ A(\mathbf{E},\varphi) \dealcoloneq \int_\Omega (\mu_r^{-1}\nabla\times\mathbf{E}
 - \int_\Omega \varepsilon_r\mathbf{E} \cdot \bar{\varphi}\;\text{d}x
 - i\int_\Sigma (\sigma_r^{\Sigma}\mathbf{E}_T) \cdot \bar{\varphi}_T\;\text{d}o_x
 - i\int_{\partial\Omega} (\sqrt{\mu_r^{-1}\varepsilon}\mathbf{E}_T) \cdot
-(\nabla\times\bar{\varphi}_T)\;\text{d}o_x.\\
+\bar{\varphi}_T\;\text{d}o_x.\\
 F(\varphi) \dealcoloneq i\int_\Omega \mathbf{J}_a \cdot \bar{\varphi}\;\text{d}x
 - \int_\Omega \mu_r^{-1}\mathbf{M}_a \cdot (\nabla \times \bar{\varphi})\;\text{d}x.
 @f]
@@ -360,7 +360,7 @@ A_{ij} = \int_\Omega (\mu_r^{-1}\nabla \times \varphi_j) \cdot
           - i\int_\Sigma (\sigma_r^{\Sigma}\varphi_{j_T}) \cdot
           \bar{\varphi}_{i_T}\;\text{d}o_x
           - i\int_{\partial\Omega} (\sqrt{\mu_r^{-1}\varepsilon}\varphi_{j_T})
-          \cdot (\nabla\times \bar{\varphi}_{i_T})\;\text{d}o_x,
+          \cdot \bar{\varphi}_{i_T}\;\text{d}o_x,
 @f]
 @f[
 F_i = i\int_\Omega \mathbf{J}_a \cdot \bar{\varphi_i}\;\text{d}x

--- a/examples/step-81/step-81.cc
+++ b/examples/step-81/step-81.cc
@@ -504,7 +504,7 @@ namespace Step81
     GridGenerator::hyper_cube(triangulation, -scaling, scaling);
     triangulation.refine_global(refinements);
 
-    if (!absorbing_boundary)
+    if (absorbing_boundary)
       {
         for (auto &face : triangulation.active_face_iterators())
           if (face->at_boundary())
@@ -710,6 +710,11 @@ namespace Step81
         // \f}
         // respectively. The test variables and the PML are implemented
         // similarly as the domain.
+        //
+        // If we are at the domain boundary $\partial\Omega$ and absorbing
+        // boundary conditions are set (<code>id == 1</code>) we assemble
+        // the corresponding boundary term:
+        //
         const FEValuesExtractors::Vector real_part(0);
         const FEValuesExtractors::Vector imag_part(dim);
         for (const auto &face : cell->face_iterators())
@@ -717,7 +722,7 @@ namespace Step81
             if (face->at_boundary())
               {
                 const auto id = face->boundary_id();
-                if (id != 0)
+                if (id == 1)
                   {
                     fe_face_values.reinit(cell, face);
 


### PR DESCRIPTION
This pull request fixes some typos in the documentation.

Furthermore, we fix a logic bug for setting absorbing boundary conditions: Previously setting "absorbing boundary conditions" to true meant we solved with Dirichlet (impedance) boundary conditions. The reason why we didn't notice this is likely due to us using a perfectly matched layer per default...

Thanks to Jinqiang Chen for pointing this out.