### PR TITLE
Un-guard two p4est declarations.

### DIFF
--- a/include/deal.II/distributed/p4est_wrappers.h
+++ b/include/deal.II/distributed/p4est_wrappers.h
@@ -83,39 +83,35 @@ namespace internal
     template <>
     struct types<2>
     {
-      using connectivity     = p4est_connectivity_t;
-      using forest           = p4est_t;
-      using tree             = p4est_tree_t;
-      using quadrant         = p4est_quadrant_t;
-      using quadrant_coord   = p4est_qcoord_t;
-      using topidx           = p4est_topidx_t;
-      using locidx           = p4est_locidx_t;
-      using gloidx           = p4est_gloidx_t;
-      using balance_type     = p4est_connect_type_t;
-      using ghost            = p4est_ghost_t;
-      using transfer_context = p4est_transfer_context_t;
-#  ifdef P4EST_SEARCH_LOCAL
+      using connectivity              = p4est_connectivity_t;
+      using forest                    = p4est_t;
+      using tree                      = p4est_tree_t;
+      using quadrant                  = p4est_quadrant_t;
+      using quadrant_coord            = p4est_qcoord_t;
+      using topidx                    = p4est_topidx_t;
+      using locidx                    = p4est_locidx_t;
+      using gloidx                    = p4est_gloidx_t;
+      using balance_type              = p4est_connect_type_t;
+      using ghost                     = p4est_ghost_t;
+      using transfer_context          = p4est_transfer_context_t;
       using search_partition_callback = p4est_search_partition_t;
-#  endif
     };
 
     template <>
     struct types<3>
     {
-      using connectivity     = p8est_connectivity_t;
-      using forest           = p8est_t;
-      using tree             = p8est_tree_t;
-      using quadrant         = p8est_quadrant_t;
-      using quadrant_coord   = p4est_qcoord_t;
-      using topidx           = p4est_topidx_t;
-      using locidx           = p4est_locidx_t;
-      using gloidx           = p4est_gloidx_t;
-      using balance_type     = p8est_connect_type_t;
-      using ghost            = p8est_ghost_t;
-      using transfer_context = p8est_transfer_context_t;
-#  ifdef P4EST_SEARCH_LOCAL
+      using connectivity              = p8est_connectivity_t;
+      using forest                    = p8est_t;
+      using tree                      = p8est_tree_t;
+      using quadrant                  = p8est_quadrant_t;
+      using quadrant_coord            = p4est_qcoord_t;
+      using topidx                    = p4est_topidx_t;
+      using locidx                    = p4est_locidx_t;
+      using gloidx                    = p4est_gloidx_t;
+      using balance_type              = p8est_connect_type_t;
+      using ghost                     = p8est_ghost_t;
+      using transfer_context          = p8est_transfer_context_t;
       using search_partition_callback = p8est_search_partition_t;
-#  endif
     };
 
 
@@ -315,14 +311,12 @@ namespace internal
 
       static void (&transfer_custom_end)(types<2>::transfer_context *tc);
 
-#  ifdef P4EST_SEARCH_LOCAL
       static void (&search_partition)(
         types<2>::forest                   *forest,
         int                                 call_post,
         types<2>::search_partition_callback quadrant_fn,
         types<2>::search_partition_callback point_fn,
         sc_array_t                         *points);
-#  endif
 
       static void (&quadrant_coord_to_vertex)(
         types<2>::connectivity  *connectivity,
@@ -515,14 +509,12 @@ namespace internal
 
       static void (&transfer_custom_end)(types<3>::transfer_context *tc);
 
-#  ifdef P4EST_SEARCH_LOCAL
       static void (&search_partition)(
         types<3>::forest                   *forest,
         int                                 call_post,
         types<3>::search_partition_callback quadrant_fn,
         types<3>::search_partition_callback point_fn,
         sc_array_t                         *points);
-#  endif
 
       static void (&quadrant_coord_to_vertex)(
         types<3>::connectivity  *connectivity,

--- a/source/distributed/p4est_wrappers.cc
+++ b/source/distributed/p4est_wrappers.cc
@@ -534,14 +534,12 @@ namespace internal
     void (&functions<2>::transfer_custom_end)(types<2>::transfer_context *tc) =
       p4est_transfer_custom_end;
 
-#  ifdef P4EST_SEARCH_LOCAL
     void (&functions<2>::search_partition)(
       types<2>::forest                   *p4est,
       int                                 call_post,
       types<2>::search_partition_callback quadrant_fn,
       types<2>::search_partition_callback point_fn,
       sc_array_t                         *points) = p4est_search_partition;
-#  endif
 
     void (&functions<2>::quadrant_coord_to_vertex)(
       types<2>::connectivity  *connectivity,
@@ -756,14 +754,12 @@ namespace internal
     void (&functions<3>::transfer_custom_end)(types<3>::transfer_context *tc) =
       p8est_transfer_custom_end;
 
-#  ifdef P4EST_SEARCH_LOCAL
     void (&functions<3>::search_partition)(
       types<3>::forest                   *p4est,
       int                                 call_post,
       types<3>::search_partition_callback quadrant_fn,
       types<3>::search_partition_callback point_fn,
       sc_array_t                         *points) = p8est_search_partition;
-#  endif
 
     void (&functions<3>::quadrant_coord_to_vertex)(
       types<3>::connectivity  *connectivity,


### PR DESCRIPTION
We have code that looks like this around two of the p4est types we wrap in `p4est_wrappers.h`:
```
#  ifdef P4EST_SEARCH_LOCAL
      using search_partition_callback = p4est_search_partition_t;
#  endif
```
This patch removes the `#ifdef` around it because I don't have the value of that preprocessor variable around when building modules (#18071).

This should do no harm: The only place where the type is used is in this declaration
```
#  ifdef P4EST_SEARCH_LOCAL
      static void (&search_partition)(
        types<3>::forest                   *forest,
        int                                 call_post,
        types<3>::search_partition_callback quadrant_fn,
        types<3>::search_partition_callback point_fn,
        sc_array_t                         *points);
#  endif
```
which is in turn only used here:
```
    template <int dim, int spacedim>
    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
    std::vector<types::subdomain_id> Triangulation<dim, spacedim>::
      find_point_owner_rank(const std::vector<Point<dim>> &points)
    {
      // We can only use this function if vertices are communicated to p4est
      AssertThrow(this->are_vertices_communicated_to_p4est(),
                  ExcMessage(
                    "Vertices need to be communicated to p4est to use this "
                    "function. This must explicitly be turned on in the "
                    "settings of the triangulation's constructor."));

      // We can only use this function if all manifolds are flat
      for (const auto &manifold_id : this->get_manifold_ids())
        {
          AssertThrow(
            manifold_id == numbers::flat_manifold_id,
            ExcMessage(
              "This function can only be used if the triangulation "
              "has no other manifold than a Cartesian (flat) manifold attached."));
        }

      // Create object for callback
      PartitionSearch<dim> partition_search;

      // Pointer should be this triangulation before we set it to something else
      Assert(parallel_forest->user_pointer == this, ExcInternalError());

      // re-assign p4est's user pointer
      parallel_forest->user_pointer = &partition_search;

      //
      // Copy points into p4est internal array data struct
      //
      // pointer to an array of points.
      sc_array_t *point_sc_array;
      // allocate memory for a number of dim-dimensional points including their
      // MPI rank, i.e., dim + 1 fields
      point_sc_array =
        sc_array_new_count(sizeof(double[dim + 1]), points.size());

      // now assign the actual value
      for (size_t i = 0; i < points.size(); ++i)
        {
          // alias
          const Point<dim> &p = points[i];
          // get a non-const view of the array
          double *this_sc_point =
            static_cast<double *>(sc_array_index_ssize_t(point_sc_array, i));
          // fill this with the point data
          for (unsigned int d = 0; d < dim; ++d)
            {
              this_sc_point[d] = p(d);
            }
          this_sc_point[dim] = -1.0; // owner rank
        }

      dealii::internal::p4est::functions<dim>::search_partition(
        parallel_forest,
        /* execute quadrant function when leaving quadrant */
        static_cast<int>(false),
        &PartitionSearch<dim>::local_quadrant_fn,
        &PartitionSearch<dim>::local_point_fn,
        point_sc_array);
```
Note that here, `search_partition()` is used without the `#ifdef` guard -- in other words, every platform we've compiled on in recent years, using whatever p4est version was found, had the `P4EST_SEARCH_LOCAL` preprocessor variable defined! Given this, we may as well remove the guard from the declaration as well.

For reference, p4est introduced the define in https://github.com/cburstedde/p4est/commit/b3d439b6d1f065f28e730df8281530f2a59a304c more than 6 years ago. The function it guards, `pest_search_local()`, has been around since before that.