### PR TITLE
Expand the implementation of periodicity in `FE_SimplexP`.

### DIFF
--- a/include/deal.II/fe/fe_simplex_p.h
+++ b/include/deal.II/fe/fe_simplex_p.h
@@ -68,13 +68,6 @@ public:
 
   /**
    * @see FiniteElement::face_to_cell_index()
-   *
-   * @note This function has some limitations in 3D. If @p dim is 3, this
-   * function works if either:
-   * 1. @p combined_orientation is the default orientation.
-   * 2. @p combined_orientation is `(false, false, false)` and the triangular
-   * face has no more than one degree of freedom in its interior.
-   * Otherwise this function throws an error.
    */
   virtual unsigned int
   face_to_cell_index(const unsigned int                 face_dof_index,

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -2655,14 +2655,9 @@ namespace GridGenerator
    * The number of vertices in coordinate
    * direction @p i is given by <tt>repetitions[i]+1</tt>.
    *
-   * This function takes the mesh produced by subdivided_hyper_rectangle() and
-   * further subdivides each cell. For @p dim 2, it subdivides each cell into 2
-   * triangles.  For @p dim 3, it subdivides each cell into 5 or 6 tetrahedra
-   * based on the value of @p periodic. If @p periodic is true, then we split
-   * each cell into 6 cells so that each face of the rectangular prism has
-   * the same stencil, enabling periodicity. If @p periodic is false, we
-   * instead subdivide each hexahedral cell into 5 tetrahedra. If @p dim is not
-   * 3, then @p periodic has no effect.
+   * @note This function takes the mesh produced by subdivided_hyper_rectangle()
+   * and further subdivides each cell into 2 triangles (for @p dim 2) or
+   * 5 tetrahedra (for @p dim 3), respectively.
    *
    * @note Currently, this function only works for `dim==spacedim`.
    *
@@ -2676,8 +2671,7 @@ namespace GridGenerator
     const std::vector<unsigned int> &repetitions,
     const Point<dim>                &p1,
     const Point<dim>                &p2,
-    const bool                       colorize = false,
-    const bool                       periodic = false);
+    const bool                       colorize = false);
 
   /**
    * Initialize the given triangulation with a hypercube (square in 2d and
@@ -2689,14 +2683,9 @@ namespace GridGenerator
    * the limits are given as arguments. They default to zero and unity, then
    * producing the unit hypercube.
    *
-   * This function takes the mesh produced by subdivided_hyper_cube() and
-   * further subdivides each cell. For @p dim 2, it subdivides each cell into 2
-   * triangles.  For @p dim 3, it subdivides each cell into 5 or 6 tetrahedra
-   * based on the value of @p periodic. If @p periodic is true, then we split
-   * each cell into 6 cells so that each face of the rectangular prism has
-   * the same stencil, enabling periodicity. If @p periodic is false, we
-   * instead subdivide each hexahedral cell into 5 tetrahedra. If @p dim is not
-   * 3, then @p periodic has no effect.
+   * @note This function takes the mesh produced by subdivided_hyper_cube()
+   * and further subdivides each cell into 2 triangles (for @p dim 2) or
+   * 5 tetrahedra (for @p dim 3), respectively.
    *
    * Also see
    * @ref simplex "Simplex support".
@@ -2707,8 +2696,7 @@ namespace GridGenerator
                                        const unsigned int repetitions,
                                        const double       p1       = 0.0,
                                        const double       p2       = 1.0,
-                                       const bool         colorize = false,
-                                       const bool         periodic = false);
+                                       const bool         colorize = false);
 
   /** @} */
 

--- a/source/fe/fe_simplex_p.cc
+++ b/source/fe/fe_simplex_p.cc
@@ -450,14 +450,8 @@ FE_SimplexPoly<dim, spacedim>::face_to_cell_index(
   AssertIndexRange(face_dof_index, this->n_dofs_per_face(face));
   AssertIndexRange(face, this->reference_cell().n_faces());
 
-  // TODO: once the default orientation is switched to 0 then we can remove this
-  // special case for 1D.
-  if (dim == 1)
-    Assert(combined_orientation == numbers::default_geometric_orientation,
-           ExcMessage("In 1D, all faces must have the default orientation."));
-  else
-    AssertIndexRange(combined_orientation,
-                     this->reference_cell().n_face_orientations(face));
+  AssertIndexRange(combined_orientation,
+                   this->reference_cell().n_face_orientations(face));
 
   // we need to distinguish between DoFs on vertices, lines and in 3d quads.
   // do so in a sequence of if-else statements

--- a/source/fe/fe_simplex_p.cc
+++ b/source/fe/fe_simplex_p.cc
@@ -501,38 +501,45 @@ FE_SimplexPoly<dim, spacedim>::face_to_cell_index(
             break;
 
           case 3:
-            // in 3d, things are difficult. someone will have to think
-            // about how this code here should look like, by drawing a bunch
-            // of pictures of how all the faces can look like with the various
-            // flips and rotations.
-            //
-            // that said, we can implement a couple other situations easily:
-            // if the face orientation is
-            // numbers::default_combined_face_orientation then things are
-            // simple. Likewise if the face orientation is
-            // internal::combined_face_orientation(false,false,false) then we
-            // just know we need to reverse the DoF order on each line.
-            //
-            // this at least allows for tetrahedral meshes where periodic face
-            // pairs are each in one of the two above configurations. Doing so
-            // may turn out to be always possible or it may not, but at least
-            // this is less restrictive.
-            Assert((this->n_dofs_per_line() <= 1) ||
-                     combined_orientation ==
-                       numbers::default_geometric_orientation ||
-                     combined_orientation ==
-                       internal::combined_face_orientation(false, false, false),
-                   ExcNotImplemented());
+            {
+              // Line orientations are not consistent between faces of
+              // tetrahedra: e.g., the cell's first line is (0, 1) on face 0 and
+              // (1, 0) on face 1. Hence we have to determine the relative line
+              // orientation to determine how to index dofs along lines.
+              //
+              // face_to_cell_line_orientation() may only be called with
+              // canonical (face, line) pairs. Extract that information and then
+              // also the new canonical face_line_index.
+              const auto cell_line_index =
+                this->reference_cell().face_to_cell_lines(face,
+                                                          face_line,
+                                                          combined_orientation);
+              const auto [canonical_face, canonical_line] =
+                this->reference_cell().standard_line_to_face_and_line_index(
+                  cell_line_index);
+              // Here we don't take into account what the actual orientation of
+              // the line is: that's usually handled inside, e.g.,
+              // face->get_dof_indices().
+              const auto face_line_orientation =
+                this->reference_cell().face_to_cell_line_orientation(
+                  canonical_line,
+                  canonical_face,
+                  combined_orientation,
+                  /*combined_line_orientation =*/
+                  numbers::default_geometric_orientation);
 
-            if (combined_orientation == numbers::default_geometric_orientation)
-              {
+              if (face_line_orientation ==
+                  numbers::default_geometric_orientation)
                 adjusted_dof_index_on_line = dof_index_on_line;
-              }
-            else
-              {
-                adjusted_dof_index_on_line =
-                  this->n_dofs_per_line() - dof_index_on_line - 1;
-              }
+              else
+                {
+                  Assert(face_line_orientation ==
+                           numbers::reverse_line_orientation,
+                         ExcInternalError());
+                  adjusted_dof_index_on_line =
+                    this->n_dofs_per_line() - dof_index_on_line - 1;
+                }
+            }
             break;
 
           default:
@@ -555,9 +562,15 @@ FE_SimplexPoly<dim, spacedim>::face_to_cell_index(
       const unsigned int index =
         face_dof_index - this->get_first_face_quad_index(face);
 
-      // the same is true here as above for the 3d case -- someone will
-      // just have to draw a bunch of pictures. in the meantime,
-      // we can implement the degree <= 3 case in which it is simple
+      // Since polynomials on simplices are typically defined in barycentric
+      // coordinates, handling higher degree elements is not that hard: if the
+      // DoFs come in triples then they simply need to be rotated in the correct
+      // way (as though they were the vertices). However, we don't implement
+      // higher than cubic elements, so that is not yet done here. For example,
+      // for a P4 element a quad will have 3 DoFs, and each of those DoFs will
+      // be on its corresponding vertex's bisector. Hence they can be rotated by
+      // simply calling
+      // ReferenceCells::Triangle::permute_by_combined_orientation().
       Assert((this->n_dofs_per_quad(face) <= 1) ||
                combined_orientation == numbers::default_geometric_orientation,
              ExcNotImplemented());

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -22,7 +22,6 @@
 #include <deal.II/grid/filtered_iterator.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_tools.h>
-#include <deal.II/grid/grid_tools_topology.h>
 #include <deal.II/grid/intergrid_map.h>
 #include <deal.II/grid/manifold_lib.h>
 #include <deal.II/grid/tria.h>
@@ -9048,319 +9047,6 @@ namespace GridGenerator
 
 
 
-  // Hide the implementation for two cases of
-  // subdivided_hyper_rectangle_with_simplices in an anonymous namespace.
-  namespace
-  {
-    template <int dim, int spacedim>
-    void
-    subdivided_hyper_rectangle_with_simplices_no_periodic(
-      Triangulation<dim, spacedim>    &tria,
-      const std::vector<unsigned int> &repetitions,
-      const Point<dim>                &p1,
-      const Point<dim>                &p2,
-      const bool                       colorize)
-    {
-      AssertDimension(dim, spacedim);
-
-      std::vector<Point<spacedim>> vertices;
-      std::vector<CellData<dim>>   cells;
-
-      if (dim == 2)
-        {
-          // determine cell sizes
-          const Point<dim> dx((p2[0] - p1[0]) / repetitions[0],
-                              (p2[1] - p1[1]) / repetitions[1]);
-
-          // create vertices
-          for (unsigned int j = 0; j <= repetitions[1]; ++j)
-            for (unsigned int i = 0; i <= repetitions[0]; ++i)
-              vertices.push_back(
-                Point<spacedim>(p1[0] + dx[0] * i, p1[1] + dx[1] * j));
-
-          // create cells
-          for (unsigned int j = 0; j < repetitions[1]; ++j)
-            for (unsigned int i = 0; i < repetitions[0]; ++i)
-              {
-                // create reference QUAD cell
-                std::array<unsigned int, 4> quad{{
-                  (j + 0) * (repetitions[0] + 1) + i + 0, //
-                  (j + 0) * (repetitions[0] + 1) + i + 1, //
-                  (j + 1) * (repetitions[0] + 1) + i + 0, //
-                  (j + 1) * (repetitions[0] + 1) + i + 1  //
-                }};                                       //
-
-                // TRI cell 0
-                {
-                  CellData<dim> tri;
-                  tri.vertices = {quad[0], quad[1], quad[2]};
-                  cells.push_back(tri);
-                }
-
-                // TRI cell 1
-                {
-                  CellData<dim> tri;
-                  tri.vertices = {quad[3], quad[2], quad[1]};
-                  cells.push_back(tri);
-                }
-              }
-        }
-      else if (dim == 3)
-        {
-          // determine cell sizes
-          const Point<dim> dx((p2[0] - p1[0]) / repetitions[0],
-                              (p2[1] - p1[1]) / repetitions[1],
-                              (p2[2] - p1[2]) / repetitions[2]);
-
-          // create vertices
-          for (unsigned int k = 0; k <= repetitions[2]; ++k)
-            for (unsigned int j = 0; j <= repetitions[1]; ++j)
-              for (unsigned int i = 0; i <= repetitions[0]; ++i)
-                vertices.push_back(Point<spacedim>(p1[0] + dx[0] * i,
-                                                   p1[1] + dx[1] * j,
-                                                   p1[2] + dx[2] * k));
-
-          // create cells
-          for (unsigned int k = 0; k < repetitions[2]; ++k)
-            for (unsigned int j = 0; j < repetitions[1]; ++j)
-              for (unsigned int i = 0; i < repetitions[0]; ++i)
-                {
-                  // create reference HEX cell
-                  std::array<unsigned int, 8> quad{
-                    {(k + 0) * (repetitions[0] + 1) * (repetitions[1] + 1) +
-                       (j + 0) * (repetitions[0] + 1) + i + 0,
-                     (k + 0) * (repetitions[0] + 1) * (repetitions[1] + 1) +
-                       (j + 0) * (repetitions[0] + 1) + i + 1,
-                     (k + 0) * (repetitions[0] + 1) * (repetitions[1] + 1) +
-                       (j + 1) * (repetitions[0] + 1) + i + 0,
-                     (k + 0) * (repetitions[0] + 1) * (repetitions[1] + 1) +
-                       (j + 1) * (repetitions[0] + 1) + i + 1,
-                     (k + 1) * (repetitions[0] + 1) * (repetitions[1] + 1) +
-                       (j + 0) * (repetitions[0] + 1) + i + 0,
-                     (k + 1) * (repetitions[0] + 1) * (repetitions[1] + 1) +
-                       (j + 0) * (repetitions[0] + 1) + i + 1,
-                     (k + 1) * (repetitions[0] + 1) * (repetitions[1] + 1) +
-                       (j + 1) * (repetitions[0] + 1) + i + 0,
-                     (k + 1) * (repetitions[0] + 1) * (repetitions[1] + 1) +
-                       (j + 1) * (repetitions[0] + 1) + i + 1}};
-
-                  // TET cell 0
-                  {
-                    CellData<dim> cell;
-                    if (((i % 2) + (j % 2) + (k % 2)) % 2 == 0)
-                      cell.vertices = {{quad[0], quad[1], quad[2], quad[4]}};
-                    else
-                      cell.vertices = {{quad[0], quad[1], quad[3], quad[5]}};
-
-                    cells.push_back(cell);
-                  }
-
-                  // TET cell 1
-                  {
-                    CellData<dim> cell;
-                    if (((i % 2) + (j % 2) + (k % 2)) % 2 == 0)
-                      cell.vertices = {{quad[2], quad[1], quad[3], quad[7]}};
-                    else
-                      cell.vertices = {{quad[0], quad[3], quad[2], quad[6]}};
-                    cells.push_back(cell);
-                  }
-
-                  // TET cell 2
-                  {
-                    CellData<dim> cell;
-                    if (((i % 2) + (j % 2) + (k % 2)) % 2 == 0)
-                      cell.vertices = {{quad[1], quad[4], quad[5], quad[7]}};
-                    else
-                      cell.vertices = {{quad[0], quad[4], quad[5], quad[6]}};
-                    cells.push_back(cell);
-                  }
-
-                  // TET cell 3
-                  {
-                    CellData<dim> cell;
-                    if (((i % 2) + (j % 2) + (k % 2)) % 2 == 0)
-                      cell.vertices = {{quad[2], quad[4], quad[7], quad[6]}};
-                    else
-                      cell.vertices = {{quad[3], quad[5], quad[7], quad[6]}};
-                    cells.push_back(cell);
-                  }
-
-                  // TET cell 4
-                  {
-                    CellData<dim> cell;
-                    if (((i % 2) + (j % 2) + (k % 2)) % 2 == 0)
-                      cell.vertices = {{quad[1], quad[2], quad[4], quad[7]}};
-                    else
-                      cell.vertices = {{quad[0], quad[3], quad[6], quad[5]}};
-                    cells.push_back(cell);
-                  }
-                }
-        }
-      else
-        {
-          AssertThrow(false, ExcNotImplemented());
-        }
-
-      // actually create triangulation
-      tria.create_triangulation(vertices, cells, SubCellData());
-
-      if (colorize)
-        {
-          // to colorize, run through all
-          // faces of all cells and set
-          // boundary indicator to the
-          // correct value if it was 0.
-
-          // use a large epsilon to
-          // compare numbers to avoid
-          // roundoff problems.
-          double epsilon = std::numeric_limits<double>::max();
-          for (unsigned int i = 0; i < dim; ++i)
-            epsilon =
-              std::min(epsilon,
-                       0.01 * (std::abs(p2[i] - p1[i]) / repetitions[i]));
-          Assert(epsilon > 0,
-                 ExcMessage(
-                   "The distance between corner points must be positive."));
-
-          // actual code is external since
-          // 1-D is different from 2/3d.
-          colorize_subdivided_hyper_rectangle(tria, p1, p2, epsilon);
-        }
-    }
-
-
-
-    // This function is only needed in 3D.
-    template <int dim, int spacedim>
-    void
-    subdivided_hyper_rectangle_with_simplices_periodic(
-      Triangulation<dim, spacedim>    &tria,
-      const std::vector<unsigned int> &repetitions,
-      const Point<dim>                &p1,
-      const Point<dim>                &p2,
-      const bool                       colorize)
-    {
-      // This function is only needed in 3D (and hypothetically in higher
-      // dimension), so library internals should ensure it is never called
-      // unless dim == 3.
-      Assert(dim == 3, ExcInternalError());
-      AssertDimension(dim, spacedim);
-
-      std::vector<Point<spacedim>> vertices;
-      std::vector<CellData<dim>>   cells;
-
-      // determine cell sizes
-      const Point<dim> dx((p2[0] - p1[0]) / repetitions[0],
-                          (p2[1] - p1[1]) / repetitions[1],
-                          (p2[2] - p1[2]) / repetitions[2]);
-
-      // create vertices
-      for (unsigned int k = 0; k <= repetitions[2]; ++k)
-        for (unsigned int j = 0; j <= repetitions[1]; ++j)
-          for (unsigned int i = 0; i <= repetitions[0]; ++i)
-            vertices.push_back(Point<spacedim>(p1[0] + dx[0] * i,
-                                               p1[1] + dx[1] * j,
-                                               p1[2] + dx[2] * k));
-
-      // create cells
-      for (unsigned int k = 0; k < repetitions[2]; ++k)
-        for (unsigned int j = 0; j < repetitions[1]; ++j)
-          for (unsigned int i = 0; i < repetitions[0]; ++i)
-            {
-              // create reference HEX cell
-              std::array<unsigned int, 8> quad{
-                {(k + 0) * (repetitions[0] + 1) * (repetitions[1] + 1) +
-                   (j + 0) * (repetitions[0] + 1) + i + 0,
-                 (k + 0) * (repetitions[0] + 1) * (repetitions[1] + 1) +
-                   (j + 0) * (repetitions[0] + 1) + i + 1,
-                 (k + 0) * (repetitions[0] + 1) * (repetitions[1] + 1) +
-                   (j + 1) * (repetitions[0] + 1) + i + 0,
-                 (k + 0) * (repetitions[0] + 1) * (repetitions[1] + 1) +
-                   (j + 1) * (repetitions[0] + 1) + i + 1,
-                 (k + 1) * (repetitions[0] + 1) * (repetitions[1] + 1) +
-                   (j + 0) * (repetitions[0] + 1) + i + 0,
-                 (k + 1) * (repetitions[0] + 1) * (repetitions[1] + 1) +
-                   (j + 0) * (repetitions[0] + 1) + i + 1,
-                 (k + 1) * (repetitions[0] + 1) * (repetitions[1] + 1) +
-                   (j + 1) * (repetitions[0] + 1) + i + 0,
-                 (k + 1) * (repetitions[0] + 1) * (repetitions[1] + 1) +
-                   (j + 1) * (repetitions[0] + 1) + i + 1}};
-
-              // TET cell 0
-              {
-                CellData<dim> cell;
-                cell.vertices = {{quad[0], quad[1], quad[3], quad[7]}};
-                cells.push_back(cell);
-              }
-
-              // TET cell 1
-              {
-                CellData<dim> cell;
-                cell.vertices = {{quad[0], quad[1], quad[7], quad[5]}};
-                cells.push_back(cell);
-              }
-
-              // TET cell 2
-              {
-                CellData<dim> cell;
-                cell.vertices = {{quad[0], quad[7], quad[3], quad[2]}};
-                cells.push_back(cell);
-              }
-
-              // TET cell 3
-              {
-                CellData<dim> cell;
-                cell.vertices = {{quad[2], quad[6], quad[0], quad[7]}};
-                cells.push_back(cell);
-              }
-
-              // TET cell 4
-              {
-                CellData<dim> cell;
-                cell.vertices = {{quad[4], quad[7], quad[5], quad[0]}};
-                cells.push_back(cell);
-              }
-
-              // TET cell 5
-              {
-                CellData<dim> cell;
-                cell.vertices = {{quad[4], quad[6], quad[7], quad[0]}};
-                cells.push_back(cell);
-              }
-            }
-
-      // actually create triangulation
-      tria.create_triangulation(vertices, cells, SubCellData());
-
-      if (colorize)
-        {
-          // to colorize, run through all
-          // faces of all cells and set
-          // boundary indicator to the
-          // correct value if it was 0.
-
-          // use a large epsilon to
-          // compare numbers to avoid
-          // roundoff problems.
-          double epsilon = std::numeric_limits<double>::max();
-          for (unsigned int i = 0; i < dim; ++i)
-            epsilon =
-              std::min(epsilon,
-                       0.01 * (std::abs(p2[i] - p1[i]) / repetitions[i]));
-          Assert(epsilon > 0,
-                 ExcMessage(
-                   "The distance between corner points must be positive."));
-
-          // actual code is external since
-          // 1-D is different from 2/3d.
-          colorize_subdivided_hyper_rectangle(tria, p1, p2, epsilon);
-        }
-    }
-  } // namespace
-
-
-
   template <int dim, int spacedim>
   void
   subdivided_hyper_rectangle_with_simplices(
@@ -9368,28 +9054,172 @@ namespace GridGenerator
     const std::vector<unsigned int> &repetitions,
     const Point<dim>                &p1,
     const Point<dim>                &p2,
-    const bool                       colorize,
-    const bool                       periodic)
+    const bool                       colorize)
   {
-    // We only need to call the "periodic" variant if it was requested and we
-    // are in 3D.
-    if (dim != 3)
+    AssertDimension(dim, spacedim);
+
+    std::vector<Point<spacedim>> vertices;
+    std::vector<CellData<dim>>   cells;
+
+    if (dim == 2)
       {
-        subdivided_hyper_rectangle_with_simplices_no_periodic(
-          tria, repetitions, p1, p2, colorize);
-        return;
+        // determine cell sizes
+        const Point<dim> dx((p2[0] - p1[0]) / repetitions[0],
+                            (p2[1] - p1[1]) / repetitions[1]);
+
+        // create vertices
+        for (unsigned int j = 0; j <= repetitions[1]; ++j)
+          for (unsigned int i = 0; i <= repetitions[0]; ++i)
+            vertices.push_back(
+              Point<spacedim>(p1[0] + dx[0] * i, p1[1] + dx[1] * j));
+
+        // create cells
+        for (unsigned int j = 0; j < repetitions[1]; ++j)
+          for (unsigned int i = 0; i < repetitions[0]; ++i)
+            {
+              // create reference QUAD cell
+              std::array<unsigned int, 4> quad{{
+                (j + 0) * (repetitions[0] + 1) + i + 0, //
+                (j + 0) * (repetitions[0] + 1) + i + 1, //
+                (j + 1) * (repetitions[0] + 1) + i + 0, //
+                (j + 1) * (repetitions[0] + 1) + i + 1  //
+              }};                                       //
+
+              // TRI cell 0
+              {
+                CellData<dim> tri;
+                tri.vertices = {quad[0], quad[1], quad[2]};
+                cells.push_back(tri);
+              }
+
+              // TRI cell 1
+              {
+                CellData<dim> tri;
+                tri.vertices = {quad[3], quad[2], quad[1]};
+                cells.push_back(tri);
+              }
+            }
       }
-    else if (!periodic)
+    else if (dim == 3)
       {
-        subdivided_hyper_rectangle_with_simplices_no_periodic(
-          tria, repetitions, p1, p2, colorize);
-        return;
+        // determine cell sizes
+        const Point<dim> dx((p2[0] - p1[0]) / repetitions[0],
+                            (p2[1] - p1[1]) / repetitions[1],
+                            (p2[2] - p1[2]) / repetitions[2]);
+
+        // create vertices
+        for (unsigned int k = 0; k <= repetitions[2]; ++k)
+          for (unsigned int j = 0; j <= repetitions[1]; ++j)
+            for (unsigned int i = 0; i <= repetitions[0]; ++i)
+              vertices.push_back(Point<spacedim>(p1[0] + dx[0] * i,
+                                                 p1[1] + dx[1] * j,
+                                                 p1[2] + dx[2] * k));
+
+        // create cells
+        for (unsigned int k = 0; k < repetitions[2]; ++k)
+          for (unsigned int j = 0; j < repetitions[1]; ++j)
+            for (unsigned int i = 0; i < repetitions[0]; ++i)
+              {
+                // create reference HEX cell
+                std::array<unsigned int, 8> quad{
+                  {(k + 0) * (repetitions[0] + 1) * (repetitions[1] + 1) +
+                     (j + 0) * (repetitions[0] + 1) + i + 0,
+                   (k + 0) * (repetitions[0] + 1) * (repetitions[1] + 1) +
+                     (j + 0) * (repetitions[0] + 1) + i + 1,
+                   (k + 0) * (repetitions[0] + 1) * (repetitions[1] + 1) +
+                     (j + 1) * (repetitions[0] + 1) + i + 0,
+                   (k + 0) * (repetitions[0] + 1) * (repetitions[1] + 1) +
+                     (j + 1) * (repetitions[0] + 1) + i + 1,
+                   (k + 1) * (repetitions[0] + 1) * (repetitions[1] + 1) +
+                     (j + 0) * (repetitions[0] + 1) + i + 0,
+                   (k + 1) * (repetitions[0] + 1) * (repetitions[1] + 1) +
+                     (j + 0) * (repetitions[0] + 1) + i + 1,
+                   (k + 1) * (repetitions[0] + 1) * (repetitions[1] + 1) +
+                     (j + 1) * (repetitions[0] + 1) + i + 0,
+                   (k + 1) * (repetitions[0] + 1) * (repetitions[1] + 1) +
+                     (j + 1) * (repetitions[0] + 1) + i + 1}};
+
+                // TET cell 0
+                {
+                  CellData<dim> cell;
+                  if (((i % 2) + (j % 2) + (k % 2)) % 2 == 0)
+                    cell.vertices = {{quad[0], quad[1], quad[2], quad[4]}};
+                  else
+                    cell.vertices = {{quad[0], quad[1], quad[3], quad[5]}};
+
+                  cells.push_back(cell);
+                }
+
+                // TET cell 1
+                {
+                  CellData<dim> cell;
+                  if (((i % 2) + (j % 2) + (k % 2)) % 2 == 0)
+                    cell.vertices = {{quad[2], quad[1], quad[3], quad[7]}};
+                  else
+                    cell.vertices = {{quad[0], quad[3], quad[2], quad[6]}};
+                  cells.push_back(cell);
+                }
+
+                // TET cell 2
+                {
+                  CellData<dim> cell;
+                  if (((i % 2) + (j % 2) + (k % 2)) % 2 == 0)
+                    cell.vertices = {{quad[1], quad[4], quad[5], quad[7]}};
+                  else
+                    cell.vertices = {{quad[0], quad[4], quad[5], quad[6]}};
+                  cells.push_back(cell);
+                }
+
+                // TET cell 3
+                {
+                  CellData<dim> cell;
+                  if (((i % 2) + (j % 2) + (k % 2)) % 2 == 0)
+                    cell.vertices = {{quad[2], quad[4], quad[7], quad[6]}};
+                  else
+                    cell.vertices = {{quad[3], quad[5], quad[7], quad[6]}};
+                  cells.push_back(cell);
+                }
+
+                // TET cell 4
+                {
+                  CellData<dim> cell;
+                  if (((i % 2) + (j % 2) + (k % 2)) % 2 == 0)
+                    cell.vertices = {{quad[1], quad[2], quad[4], quad[7]}};
+                  else
+                    cell.vertices = {{quad[0], quad[3], quad[6], quad[5]}};
+                  cells.push_back(cell);
+                }
+              }
       }
     else
       {
-        subdivided_hyper_rectangle_with_simplices_periodic(
-          tria, repetitions, p1, p2, colorize);
-        return;
+        AssertThrow(false, ExcNotImplemented());
+      }
+
+    // actually create triangulation
+    tria.create_triangulation(vertices, cells, SubCellData());
+
+    if (colorize)
+      {
+        // to colorize, run through all
+        // faces of all cells and set
+        // boundary indicator to the
+        // correct value if it was 0.
+
+        // use a large epsilon to
+        // compare numbers to avoid
+        // roundoff problems.
+        double epsilon = std::numeric_limits<double>::max();
+        for (unsigned int i = 0; i < dim; ++i)
+          epsilon = std::min(epsilon,
+                             0.01 * (std::abs(p2[i] - p1[i]) / repetitions[i]));
+        Assert(epsilon > 0,
+               ExcMessage(
+                 "The distance between corner points must be positive."));
+
+        // actual code is external since
+        // 1-D is different from 2/3d.
+        colorize_subdivided_hyper_rectangle(tria, p1, p2, epsilon);
       }
   }
 
@@ -9401,17 +9231,12 @@ namespace GridGenerator
                                        const unsigned int repetitions,
                                        const double       p1,
                                        const double       p2,
-                                       const bool         colorize,
-                                       const bool         periodic)
+                                       const bool         colorize)
   {
     if (dim == 2)
       {
-        subdivided_hyper_rectangle_with_simplices(tria,
-                                                  {{repetitions, repetitions}},
-                                                  {p1, p1},
-                                                  {p2, p2},
-                                                  colorize,
-                                                  periodic);
+        subdivided_hyper_rectangle_with_simplices(
+          tria, {{repetitions, repetitions}}, {p1, p1}, {p2, p2}, colorize);
       }
     else if (dim == 3)
       {
@@ -9420,8 +9245,7 @@ namespace GridGenerator
           {{repetitions, repetitions, repetitions}},
           {p1, p1, p1},
           {p2, p2, p2},
-          colorize,
-          periodic);
+          colorize);
       }
     else
       {

--- a/source/grid/grid_generator.inst.in
+++ b/source/grid/grid_generator.inst.in
@@ -303,14 +303,12 @@ for (deal_II_dimension : DIMENSIONS)
       const std::vector<unsigned int> &repetitions,
       const Point<deal_II_dimension>  &p1,
       const Point<deal_II_dimension>  &p2,
-      const bool                       colorize,
-      const bool                       periodic);
+      const bool                       colorize);
 
     template void GridGenerator::subdivided_hyper_cube_with_simplices(
       Triangulation<deal_II_dimension> & tria,
       const unsigned int repetitions,
       const double       p1,
       const double       p2,
-      const bool         colorize,
-      const bool         periodic);
+      const bool         colorize);
   }

--- a/source/grid/grid_generator_from_name.cc
+++ b/source/grid/grid_generator_from_name.cc
@@ -232,7 +232,7 @@ namespace GridGenerator
                          bool>(concentric_hyper_shells, arguments, tria);
 
       else if (name == "subdivided_hyper_cube_with_simplices")
-        parse_and_create<dim, dim, unsigned int, double, double, bool, bool>(
+        parse_and_create<dim, dim, unsigned int, double, double, bool>(
           subdivided_hyper_cube_with_simplices, arguments, tria);
 
       else if (name == "subdivided_hyper_rectangle_with_simplices")
@@ -241,7 +241,6 @@ namespace GridGenerator
                          const std::vector<unsigned int> &,
                          const Point<dim> &,
                          const Point<dim> &,
-                         bool,
                          bool>(subdivided_hyper_rectangle_with_simplices,
                                arguments,
                                tria);

--- a/tests/grid/grid_generator_from_name_and_argument_02.cc
+++ b/tests/grid/grid_generator_from_name_and_argument_02.cc
@@ -54,15 +54,13 @@ main()
   test<2, 2>("hyper_ball_balanced", "0,0 : 1");
   test<3, 3>("hyper_ball_balanced", "0,0,0 : 1");
 
-  test<2, 2>("subdivided_hyper_cube_with_simplices",
-             "2 : 0.0 : 1.0 : false : false");
-  test<3, 3>("subdivided_hyper_cube_with_simplices",
-             "2 : 0.0 : 1.0 : false : false");
+  test<2, 2>("subdivided_hyper_cube_with_simplices", "2 : 0.0 : 1.0 : false");
+  test<3, 3>("subdivided_hyper_cube_with_simplices", "2 : 0.0 : 1.0 : false");
 
   test<2, 2>("subdivided_hyper_rectangle_with_simplices",
-             "2, 2 : 0.0, 0.0 : 1.0, 2.0 : false : false");
+             "2, 2 : 0.0, 0.0 : 1.0, 2.0 : false");
   test<3, 3>("subdivided_hyper_rectangle_with_simplices",
-             "2, 2, 3 : 0.0, 0.0, 1.0 : 1.0, 2.0, 3.0 : false : false");
+             "2, 2, 3 : 0.0, 0.0, 1.0 : 1.0, 2.0, 3.0 : false");
 
   test<2, 2>("subdivided_hyper_L", "5, 5 : 0, 0 : 1, 1 : 2, 3");
   test<3, 3>("subdivided_hyper_L", "5, 5, 5 : 0, 0, 0 : 1, 1, 1 : 2, 2, 3");

--- a/tests/grid/grid_generator_from_name_and_argument_02.output
+++ b/tests/grid/grid_generator_from_name_and_argument_02.output
@@ -191,7 +191,7 @@ $ELM
 31 5 0 0 8 18 16 38 37 27 25 52 53 
 32 5 0 0 8 43 36 48 50 37 38 52 53 
 $ENDELM
-DEAL::Generating Triangulation<2, 2> : subdivided_hyper_cube_with_simplices(2 : 0.0 : 1.0 : false : false)
+DEAL::Generating Triangulation<2, 2> : subdivided_hyper_cube_with_simplices(2 : 0.0 : 1.0 : false)
 $NOD
 9
 1  0.00000 0.00000 0
@@ -215,7 +215,7 @@ $ELM
 7 2 0 0 3 5 6 8 
 8 2 0 0 3 9 8 6 
 $ENDELM
-DEAL::Generating Triangulation<3, 3> : subdivided_hyper_cube_with_simplices(2 : 0.0 : 1.0 : false : false)
+DEAL::Generating Triangulation<3, 3> : subdivided_hyper_cube_with_simplices(2 : 0.0 : 1.0 : false)
 $NOD
 27
 1  0.00000 0.00000 0.00000
@@ -289,7 +289,7 @@ $ELM
 39 4 0 0 4 18 24 27 26 
 40 4 0 0 4 14 18 26 24 
 $ENDELM
-DEAL::Generating Triangulation<2, 2> : subdivided_hyper_rectangle_with_simplices(2, 2 : 0.0, 0.0 : 1.0, 2.0 : false : false)
+DEAL::Generating Triangulation<2, 2> : subdivided_hyper_rectangle_with_simplices(2, 2 : 0.0, 0.0 : 1.0, 2.0 : false)
 $NOD
 9
 1  0.00000 0.00000 0
@@ -313,7 +313,7 @@ $ELM
 7 2 0 0 3 5 6 8 
 8 2 0 0 3 9 8 6 
 $ENDELM
-DEAL::Generating Triangulation<3, 3> : subdivided_hyper_rectangle_with_simplices(2, 2, 3 : 0.0, 0.0, 1.0 : 1.0, 2.0, 3.0 : false : false)
+DEAL::Generating Triangulation<3, 3> : subdivided_hyper_rectangle_with_simplices(2, 2, 3 : 0.0, 0.0, 1.0 : 1.0, 2.0, 3.0 : false)
 $NOD
 36
 1  0.00000 0.00000 1.00000

--- a/tests/simplex/periodic_tet.output
+++ b/tests/simplex/periodic_tet.output
@@ -1,240 +1,107 @@
 
-# vtk DataFile Version 3.0
-Triangulation generated with deal.II
-ASCII
-DATASET UNSTRUCTURED_GRID
-POINTS 27 double
--0.500000 1.00000 0.00000
-0.00000 1.00000 0.00000
-0.500000 1.00000 0.00000
--0.500000 1.50000 0.00000
-0.00000 1.50000 0.00000
-0.500000 1.50000 0.00000
--0.500000 2.00000 0.00000
-0.00000 2.00000 0.00000
-0.500000 2.00000 0.00000
--0.500000 1.00000 0.600000
-0.00000 1.00000 0.600000
-0.500000 1.00000 0.600000
--0.500000 1.50000 0.600000
-0.00000 1.50000 0.600000
-0.500000 1.50000 0.600000
--0.500000 2.00000 0.600000
-0.00000 2.00000 0.600000
-0.500000 2.00000 0.600000
--0.500000 1.00000 1.20000
-0.00000 1.00000 1.20000
-0.500000 1.00000 1.20000
--0.500000 1.50000 1.20000
-0.00000 1.50000 1.20000
-0.500000 1.50000 1.20000
--0.500000 2.00000 1.20000
-0.00000 2.00000 1.20000
-0.500000 2.00000 1.20000
-
-CELLS 88 400
-4 0 1 4 13
-4 0 1 13 10
-4 0 13 4 3
-4 3 12 0 13
-4 9 13 10 0
-4 9 12 13 0
-4 1 2 5 14
-4 1 2 14 11
-4 1 14 5 4
-4 4 13 1 14
-4 10 14 11 1
-4 10 13 14 1
-4 3 4 7 16
-4 3 4 16 13
-4 3 16 7 6
-4 6 15 3 16
-4 12 16 13 3
-4 12 15 16 3
-4 4 5 8 17
-4 4 5 17 14
-4 4 17 8 7
-4 7 16 4 17
-4 13 17 14 4
-4 13 16 17 4
-4 9 10 13 22
-4 9 10 22 19
-4 9 22 13 12
-4 12 21 9 22
-4 18 22 19 9
-4 18 21 22 9
-4 10 11 14 23
-4 10 11 23 20
-4 10 23 14 13
-4 13 22 10 23
-4 19 23 20 10
-4 19 22 23 10
-4 12 13 16 25
-4 12 13 25 22
-4 12 25 16 15
-4 15 24 12 25
-4 21 25 22 12
-4 21 24 25 12
-4 13 14 17 26
-4 13 14 26 23
-4 13 26 17 16
-4 16 25 13 26
-4 22 26 23 13
-4 22 25 26 13
-3 1 0 10
-3 0 1 4
-3 2 1 11
-3 1 2 5
-3 5 2 14
-3 14 2 11
-3 0 4 3
-3 3 4 7
-3 1 5 4
-3 4 5 8
-3 8 5 17
-3 17 5 14
-3 15 6 16
-3 3 7 6
-3 7 16 6
-3 16 7 17
-3 4 8 7
-3 8 17 7
-3 9 10 0
-3 10 9 19
-3 10 11 1
-3 11 10 20
-3 23 11 20
-3 14 11 23
-3 26 14 23
-3 24 15 25
-3 16 25 15
-3 25 16 26
-3 17 14 26
-3 17 26 16
-3 18 21 22
-3 18 22 19
-3 18 19 9
-3 19 23 20
-3 19 20 10
-3 21 24 25
-3 21 25 22
-3 19 22 23
-3 22 26 23
-3 22 25 26
-
-CELL_TYPES 88
-10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 
-5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 
-
-
-CELL_DATA 88
-SCALARS MaterialID int 1
-LOOKUP_TABLE default
-6 6 6 6 6 6 7 7 7 7 7 7 6 6 6 6 6 6 7 7 7 7 7 7 6 6 6 6 6 6 7 7 7 7 7 7 6 6 6 6 6 6 7 7 7 7 7 7 
-2 4 2 4 1 1 4 4 4 4 1 1 3 4 3 3 4 3 2 2 2 2 1 1 1 3 3 3 1 3 5 5 2 5 2 5 5 5 5 5 
-
-
-SCALARS ManifoldID int 1
-LOOKUP_TABLE default
--1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 
--1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 
-
-# vtk DataFile Version 3.0
-Triangulation generated with deal.II
-ASCII
-DATASET UNSTRUCTURED_GRID
-POINTS 27 double
--0.500000 1.00000 0.00000
-0.00000 1.00000 0.00000
-0.500000 1.00000 0.00000
--0.500000 1.50000 0.00000
-0.00000 1.50000 0.00000
-0.500000 1.50000 0.00000
--0.500000 2.00000 0.00000
-0.00000 2.00000 0.00000
-0.500000 2.00000 0.00000
--0.500000 1.00000 0.600000
-0.00000 1.00000 0.600000
-0.500000 1.00000 0.600000
--0.500000 1.50000 0.600000
-0.00000 1.50000 0.600000
-0.500000 1.50000 0.600000
--0.500000 2.00000 0.600000
-0.00000 2.00000 0.600000
-0.500000 2.00000 0.600000
--0.500000 1.00000 1.20000
-0.00000 1.00000 1.20000
-0.500000 1.00000 1.20000
--0.500000 1.50000 1.20000
-0.00000 1.50000 1.20000
-0.500000 1.50000 1.20000
--0.500000 2.00000 1.20000
-0.00000 2.00000 1.20000
-0.500000 2.00000 1.20000
-
-CELLS 48 192
-3 1 0 10
-3 0 1 4
-3 2 1 11
-3 1 2 5
-3 5 2 14
-3 14 2 11
-3 3 12 0
-3 0 4 3
-3 3 4 7
-3 1 5 4
-3 4 5 8
-3 8 5 17
-3 17 5 14
-3 6 15 3
-3 15 6 16
-3 3 7 6
-3 7 16 6
-3 16 7 17
-3 4 8 7
-3 8 17 7
-3 12 9 0
-3 9 10 0
-3 10 9 19
-3 10 11 1
-3 11 10 20
-3 23 11 20
-3 15 12 3
-3 12 21 9
-3 14 11 23
-3 26 14 23
-3 15 24 12
-3 24 15 25
-3 16 25 15
-3 25 16 26
-3 17 14 26
-3 17 26 16
-3 21 18 9
-3 18 21 22
-3 18 22 19
-3 18 19 9
-3 19 23 20
-3 19 20 10
-3 24 21 12
-3 21 24 25
-3 21 25 22
-3 19 22 23
-3 22 26 23
-3 22 25 26
-
-CELL_TYPES 48
-5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 5 
-
-
-CELL_DATA 48
-SCALARS MaterialID int 1
-LOOKUP_TABLE default
-2 4 2 4 1 1 0 4 4 4 4 1 1 0 3 4 3 3 4 3 0 2 2 2 2 1 0 0 1 1 0 3 3 3 1 3 0 5 5 2 5 2 0 5 5 5 5 5 
-
-
-SCALARS ManifoldID int 1
-LOOKUP_TABLE default
--1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 
+DEAL::periodic face_pair:
+DEAL::    first  = (3, 0)
+DEAL::    second = (6, 3)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (5, 1)
+DEAL::    second = (7, 3)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (15, 0)
+DEAL::    second = (18, 3)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (17, 1)
+DEAL::    second = (19, 3)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (27, 0)
+DEAL::    second = (30, 3)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (29, 1)
+DEAL::    second = (31, 3)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (39, 0)
+DEAL::    second = (42, 3)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (41, 1)
+DEAL::    second = (43, 3)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (1, 1)
+DEAL::    second = (14, 3)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (4, 2)
+DEAL::    second = (15, 1)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (7, 1)
+DEAL::    second = (20, 3)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (10, 2)
+DEAL::    second = (21, 1)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (25, 1)
+DEAL::    second = (38, 3)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (28, 2)
+DEAL::    second = (39, 1)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (31, 1)
+DEAL::    second = (44, 3)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (34, 2)
+DEAL::    second = (45, 1)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (0, 0)
+DEAL::    second = (28, 0)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (2, 2)
+DEAL::    second = (29, 0)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (6, 0)
+DEAL::    second = (34, 0)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (8, 2)
+DEAL::    second = (35, 0)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (12, 0)
+DEAL::    second = (40, 0)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (14, 2)
+DEAL::    second = (41, 0)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (18, 0)
+DEAL::    second = (46, 0)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (20, 2)
+DEAL::    second = (47, 0)
+DEAL::    relative orientation = 1
+DEAL::Number of constraints = 9
+DEAL::Number of constraints = 9
+DEAL::Number of constraints = 9
+DEAL::Number of constraints = 25
+DEAL::Number of constraints = 25
+DEAL::Number of constraints = 25
+DEAL::Number of constraints = 49
     64 0:  1.00000
     65 30:  1.00000
     66 40:  1.00000
@@ -284,6 +151,7 @@ LOOKUP_TABLE default
     326 313:  1.00000
     327 312:  1.00000
     329 315:  1.00000
+DEAL::Number of constraints = 49
     112 1:  1.00000
     113 20:  1.00000
     122 23:  1.00000
@@ -333,6 +201,7 @@ LOOKUP_TABLE default
     334 275:  1.00000
     335 274:  1.00000
     336 278:  1.00000
+DEAL::Number of constraints = 49
     196 2:  1.00000
     206 1:  1.00000
     211 7:  1.00000
@@ -382,4 +251,461 @@ LOOKUP_TABLE default
     339 164:  1.00000
     340 172:  1.00000
     342 185:  1.00000
+DEAL::OK!
+DEAL::periodic face_pair:
+DEAL::    first  = (4, 0)
+DEAL::    second = (31, 0)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (5, 1)
+DEAL::    second = (30, 2)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (8, 0)
+DEAL::    second = (33, 0)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (11, 0)
+DEAL::    second = (34, 1)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (52, 0)
+DEAL::    second = (79, 0)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (53, 1)
+DEAL::    second = (78, 2)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (56, 0)
+DEAL::    second = (81, 0)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (59, 0)
+DEAL::    second = (82, 1)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (100, 0)
+DEAL::    second = (127, 0)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (101, 1)
+DEAL::    second = (126, 2)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (104, 0)
+DEAL::    second = (129, 0)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (107, 0)
+DEAL::    second = (130, 1)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (148, 0)
+DEAL::    second = (175, 0)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (149, 1)
+DEAL::    second = (174, 2)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (152, 0)
+DEAL::    second = (177, 0)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (155, 0)
+DEAL::    second = (178, 1)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (0, 1)
+DEAL::    second = (49, 0)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (3, 1)
+DEAL::    second = (50, 0)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (8, 2)
+DEAL::    second = (59, 1)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (9, 1)
+DEAL::    second = (58, 0)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (24, 1)
+DEAL::    second = (73, 0)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (27, 1)
+DEAL::    second = (74, 0)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (32, 2)
+DEAL::    second = (83, 1)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (33, 1)
+DEAL::    second = (82, 0)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (96, 1)
+DEAL::    second = (145, 0)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (99, 1)
+DEAL::    second = (146, 0)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (104, 2)
+DEAL::    second = (155, 1)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (105, 1)
+DEAL::    second = (154, 0)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (120, 1)
+DEAL::    second = (169, 0)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (123, 1)
+DEAL::    second = (170, 0)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (128, 2)
+DEAL::    second = (179, 1)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (129, 1)
+DEAL::    second = (178, 0)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (0, 0)
+DEAL::    second = (99, 0)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (1, 1)
+DEAL::    second = (98, 1)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (4, 1)
+DEAL::    second = (101, 0)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (7, 2)
+DEAL::    second = (102, 0)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (24, 0)
+DEAL::    second = (123, 0)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (25, 1)
+DEAL::    second = (122, 1)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (28, 1)
+DEAL::    second = (125, 0)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (31, 2)
+DEAL::    second = (126, 0)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (48, 0)
+DEAL::    second = (147, 0)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (49, 1)
+DEAL::    second = (146, 1)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (52, 1)
+DEAL::    second = (149, 0)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (55, 2)
+DEAL::    second = (150, 0)
+DEAL::    relative orientation = 1
+DEAL::periodic face_pair:
+DEAL::    first  = (72, 0)
+DEAL::    second = (171, 0)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (73, 1)
+DEAL::    second = (170, 1)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (76, 1)
+DEAL::    second = (173, 0)
+DEAL::    relative orientation = 5
+DEAL::periodic face_pair:
+DEAL::    first  = (79, 2)
+DEAL::    second = (174, 0)
+DEAL::    relative orientation = 1
+DEAL::Number of constraints = 13
+DEAL::Number of constraints = 13
+DEAL::Number of constraints = 13
+DEAL::Number of constraints = 41
+DEAL::Number of constraints = 41
+DEAL::Number of constraints = 41
+DEAL::Number of constraints = 85
+    172 0:  1.00000
+    191 20:  1.00000
+    209 40:  1.00000
+    227 59:  1.00000
+    254 76:  1.00000
+    255 90:  1.00000
+    256 89:  1.00000
+    257 91:  1.00000
+    258 92:  1.00000
+    261 93:  1.00000
+    262 94:  1.00000
+    265 98:  1.00000
+    267 82:  1.00000
+    268 81:  1.00000
+    269 80:  1.00000
+    270 79:  1.00000
+    271 78:  1.00000
+    272 77:  1.00000
+    275 85:  1.00000
+    284 127:  1.00000
+    285 126:  1.00000
+    288 130:  1.00000
+    292 150:  1.00000
+    293 151:  1.00000
+    297 154:  1.00000
+    476 329:  1.00000
+    494 349:  1.00000
+    531 376:  1.00000
+    532 390:  1.00000
+    533 389:  1.00000
+    534 391:  1.00000
+    535 392:  1.00000
+    538 393:  1.00000
+    539 394:  1.00000
+    542 398:  1.00000
+    544 382:  1.00000
+    545 381:  1.00000
+    546 380:  1.00000
+    547 379:  1.00000
+    548 378:  1.00000
+    549 377:  1.00000
+    552 385:  1.00000
+    562 428:  1.00000
+    565 444:  1.00000
+    566 445:  1.00000
+    570 448:  1.00000
+    759 613:  1.00000
+    777 632:  1.00000
+    803 649:  1.00000
+    804 660:  1.00000
+    805 659:  1.00000
+    806 661:  1.00000
+    807 662:  1.00000
+    810 663:  1.00000
+    811 664:  1.00000
+    814 668:  1.00000
+    816 653:  1.00000
+    817 652:  1.00000
+    818 651:  1.00000
+    819 650:  1.00000
+    822 656:  1.00000
+    830 694:  1.00000
+    831 693:  1.00000
+    834 697:  1.00000
+    838 717:  1.00000
+    839 718:  1.00000
+    843 721:  1.00000
+    1005 880:  1.00000
+    1041 907:  1.00000
+    1042 918:  1.00000
+    1043 917:  1.00000
+    1044 919:  1.00000
+    1045 920:  1.00000
+    1048 921:  1.00000
+    1049 922:  1.00000
+    1052 926:  1.00000
+    1054 911:  1.00000
+    1055 910:  1.00000
+    1056 909:  1.00000
+    1057 908:  1.00000
+    1060 914:  1.00000
+    1069 953:  1.00000
+    1072 969:  1.00000
+    1073 970:  1.00000
+    1077 973:  1.00000
+DEAL::Number of constraints = 85
+    329 0:  1.00000
+    330 1:  1.00000
+    331 3:  1.00000
+    332 4:  1.00000
+    333 5:  1.00000
+    334 12:  1.00000
+    335 13:  1.00000
+    336 11:  1.00000
+    337 10:  1.00000
+    344 17:  1.00000
+    348 58:  1.00000
+    349 59:  1.00000
+    351 60:  1.00000
+    352 61:  1.00000
+    353 68:  1.00000
+    354 69:  1.00000
+    355 67:  1.00000
+    356 66:  1.00000
+    363 73:  1.00000
+    436 134:  1.00000
+    437 135:  1.00000
+    440 139:  1.00000
+    444 127:  1.00000
+    445 126:  1.00000
+    449 132:  1.00000
+    476 172:  1.00000
+    477 174:  1.00000
+    478 175:  1.00000
+    479 176:  1.00000
+    480 183:  1.00000
+    481 184:  1.00000
+    482 182:  1.00000
+    483 181:  1.00000
+    490 188:  1.00000
+    494 227:  1.00000
+    496 228:  1.00000
+    497 229:  1.00000
+    498 236:  1.00000
+    499 237:  1.00000
+    500 235:  1.00000
+    501 234:  1.00000
+    508 241:  1.00000
+    565 284:  1.00000
+    566 285:  1.00000
+    569 289:  1.00000
+    575 282:  1.00000
+    869 592:  1.00000
+    870 595:  1.00000
+    871 596:  1.00000
+    872 594:  1.00000
+    873 593:  1.00000
+    876 599:  1.00000
+    879 631:  1.00000
+    880 632:  1.00000
+    882 633:  1.00000
+    883 634:  1.00000
+    884 641:  1.00000
+    885 642:  1.00000
+    886 640:  1.00000
+    887 639:  1.00000
+    894 646:  1.00000
+    961 701:  1.00000
+    962 702:  1.00000
+    965 706:  1.00000
+    969 694:  1.00000
+    970 693:  1.00000
+    974 699:  1.00000
+    995 739:  1.00000
+    996 742:  1.00000
+    997 743:  1.00000
+    998 741:  1.00000
+    999 740:  1.00000
+    1002 746:  1.00000
+    1005 777:  1.00000
+    1007 778:  1.00000
+    1008 779:  1.00000
+    1009 786:  1.00000
+    1010 787:  1.00000
+    1011 785:  1.00000
+    1012 784:  1.00000
+    1019 791:  1.00000
+    1072 830:  1.00000
+    1073 831:  1.00000
+    1076 835:  1.00000
+    1082 828:  1.00000
+DEAL::Number of constraints = 85
+    612 21:  1.00000
+    613 20:  1.00000
+    614 2:  1.00000
+    615 24:  1.00000
+    616 23:  1.00000
+    621 31:  1.00000
+    622 32:  1.00000
+    623 29:  1.00000
+    624 30:  1.00000
+    628 36:  1.00000
+    631 1:  1.00000
+    632 0:  1.00000
+    633 5:  1.00000
+    634 4:  1.00000
+    635 9:  1.00000
+    636 8:  1.00000
+    637 7:  1.00000
+    638 6:  1.00000
+    645 16:  1.00000
+    659 77:  1.00000
+    660 78:  1.00000
+    667 86:  1.00000
+    672 118:  1.00000
+    673 119:  1.00000
+    680 124:  1.00000
+    759 191:  1.00000
+    760 173:  1.00000
+    761 194:  1.00000
+    762 193:  1.00000
+    767 201:  1.00000
+    768 202:  1.00000
+    769 199:  1.00000
+    770 200:  1.00000
+    774 206:  1.00000
+    777 172:  1.00000
+    778 176:  1.00000
+    779 175:  1.00000
+    780 180:  1.00000
+    781 179:  1.00000
+    782 178:  1.00000
+    783 177:  1.00000
+    790 187:  1.00000
+    800 246:  1.00000
+    804 271:  1.00000
+    805 272:  1.00000
+    812 277:  1.00000
+    879 330:  1.00000
+    880 329:  1.00000
+    881 319:  1.00000
+    882 333:  1.00000
+    883 332:  1.00000
+    888 340:  1.00000
+    889 341:  1.00000
+    890 338:  1.00000
+    891 339:  1.00000
+    895 345:  1.00000
+    898 323:  1.00000
+    899 322:  1.00000
+    900 321:  1.00000
+    901 320:  1.00000
+    904 326:  1.00000
+    917 377:  1.00000
+    918 378:  1.00000
+    925 386:  1.00000
+    930 418:  1.00000
+    931 419:  1.00000
+    938 424:  1.00000
+    1005 476:  1.00000
+    1006 466:  1.00000
+    1007 479:  1.00000
+    1008 478:  1.00000
+    1013 486:  1.00000
+    1014 487:  1.00000
+    1015 484:  1.00000
+    1016 485:  1.00000
+    1020 491:  1.00000
+    1023 470:  1.00000
+    1024 469:  1.00000
+    1025 468:  1.00000
+    1026 467:  1.00000
+    1029 473:  1.00000
+    1038 523:  1.00000
+    1042 548:  1.00000
+    1043 549:  1.00000
+    1050 554:  1.00000
 DEAL::OK!


### PR DESCRIPTION
Also a follow-up to #18081.

This patch does two things:
1. There's no good backwards-compatible way to add extra parameters to `GridGenerator` functions which are supported by `GridGenerator::generate_from_name_and_arguments()`. Hence I removed a feature of #18081 and moved that grid into a test. I should have caught this in #18081 - my mistake. @KJSchwiebert Should we add this back in as another (independent this time) grid generator function, or did you only need it for the test?
2. I thought about it some more and it turns out we already have a way to determine, given a face number and its orientation, the relative orientations of the lines. We can use that in `FE_SimplexP` to support all other possible line orientations. I added it and expanded the test from #18081 to support multiple grids. We could definitely use the same implementation in `FE_Q_Base`, which doesn't support non-default orientations.