### PR TITLE
Fix: explicitly instantiate tpetra wrapper's BlockSparseMatrix::reinit)

### DIFF
--- a/doc/news/changes/minor/20250427Shi
+++ b/doc/news/changes/minor/20250427Shi
@@ -1,0 +1,6 @@
+Fix: Add explicit instantiation for TpetraWrappers::BlockSparseMatrix::reinit
+(std::vector<IndexSet>, BlockDynamicSparsityPattern, MPI_Comm, bool) to fix
+missing symbol error when initializing Tpetra block matrices from
+distributed sparsity patterns.
+<br>
+(Qingyuan Shi, 2025/04/27)

--- a/source/lac/trilinos_tpetra_block_sparse_matrix.cc
+++ b/source/lac/trilinos_tpetra_block_sparse_matrix.cc
@@ -33,6 +33,14 @@ namespace LinearAlgebra
       const ::dealii::BlockDynamicSparsityPattern &);
 
     template void
+    BlockSparseMatrix<double, MemorySpace::Host>::reinit<
+      ::dealii::BlockDynamicSparsityPattern>(
+      const std::vector<dealii::IndexSet> &,
+      const ::dealii::BlockDynamicSparsityPattern &,
+      MPI_Comm,
+      bool);
+
+    template void
     BlockSparseMatrix<double, MemorySpace::Host>::vmult(
       TpetraWrappers::Vector<double, MemorySpace::Host> &,
       const TpetraWrappers::Vector<double, MemorySpace::Host> &) const;

--- a/tests/trilinos_tpetra/block_matrices_01.cc
+++ b/tests/trilinos_tpetra/block_matrices_01.cc
@@ -1,0 +1,91 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// Verify n_nonzero_elements and reinit() for Tpetra BlockSparseMatrix.
+
+#include <deal.II/base/mpi.h>
+
+#include <deal.II/lac/block_sparsity_pattern.h>
+#include <deal.II/lac/trilinos_block_sparse_matrix.h>
+
+#include "../tests.h"
+
+
+
+void
+test()
+{
+  // create block sparsity pattern
+  BlockDynamicSparsityPattern bdsp(2, 2);
+  bdsp.block(0, 0).reinit(2, 2);
+  bdsp.block(0, 1).reinit(2, 3);
+  bdsp.block(1, 0).reinit(3, 2);
+  bdsp.block(1, 1).reinit(3, 3);
+  bdsp.collect_sizes();
+
+  // add triangular sparsity pattern to each block
+  // block (0, 0)
+  for (unsigned int row = 0; row < 2; ++row)
+    for (unsigned int col = 0; col <= row; ++col)
+      bdsp.add(row, col);
+  // block (1, 1)
+  for (unsigned int row = 2; row < 5; ++row)
+    for (unsigned int col = 2; col <= row; ++col)
+      bdsp.add(row, col);
+
+  bdsp.compress();
+  deallog << "nonzeros BlockSparsityPattern: " << bdsp.n_nonzero_elements()
+          << std::endl;
+
+  // create block sparse matrix
+  TrilinosWrappers::BlockSparseMatrix tbsm;
+  tbsm.reinit(bdsp);
+  deallog << "nonzeros BlockSparseMatrix: " << tbsm.n_nonzero_elements()
+          << std::endl;
+
+
+
+  // create partitioning
+  std::vector<dealii::IndexSet> partitioning(2);
+  partitioning[0] = dealii::IndexSet(2); // 2 dofs
+  partitioning[1] = dealii::IndexSet(3); // 3 dofs
+
+  partitioning[0].add_range(0, 2);
+  partitioning[1].add_range(0, 3);
+
+  for (auto &set : partitioning)
+    set.compress();
+
+  // create block sparse matrix using another reinit() function
+  TrilinosWrappers::BlockSparseMatrix tbsm2;
+  tbsm2.reinit(partitioning, bdsp, MPI_COMM_SELF, false);
+
+  deallog << "nonzeros BlockSparseMatrix: " << tbsm.n_nonzero_elements()
+          << std::endl;
+}
+
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  initlog();
+
+  test();
+
+  return 0;
+}

--- a/tests/trilinos_tpetra/block_matrices_01.output
+++ b/tests/trilinos_tpetra/block_matrices_01.output
@@ -1,0 +1,4 @@
+
+DEAL::nonzeros BlockSparsityPattern: 9
+DEAL::nonzeros BlockSparseMatrix: 9
+DEAL::nonzeros BlockSparseMatrix: 9


### PR DESCRIPTION
When playing with the Tpetra wrappers, this missing instantiation caused a linker error when attempting to use TpetraWrappers::BlockSparseMatrix initialized with a BlockDynamicSparsityPattern and communicator.

I also added a minimal test to verify it.