### PR TITLE
Do not separately check for MPI 3+.

### DIFF
--- a/include/deal.II/base/mpi_large_count.h
+++ b/include/deal.II/base/mpi_large_count.h
@@ -31,15 +31,6 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <mpi.h>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
-#  ifndef MPI_VERSION
-#    error "Your MPI implementation does not define MPI_VERSION!"
-#  endif
-
-#  if MPI_VERSION < 3
-#    error "BigMPICompat requires at least MPI 3.0"
-#  endif
-
-
 // required for std::numeric_limits used below.
 #  include <limits>
 


### PR DESCRIPTION
We already require MPI 3+ in our cmake scripts. It is not necessary to do that again in one of the implementation files, in particular because the file has no work-arounds anyway if we had an older version of MPI.