### PR TITLE
Fix missing copy of nonlocal_vector in `TpetraWrappers::Vector` assignment operator

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -338,6 +338,12 @@ namespace LinearAlgebra
       //  - First case: both vectors have the same layout.
       //  - Second case: both vectors have the same size but different layout.
       //  - Third case: the vectors have different size.
+
+      AssertThrow(V.compressed,
+                  ExcMessage("Cannot copy-assign from a vector that has not "
+                             "been compressed. Please call compress() on the "
+                             "source vector before using operator=()."));
+
       if (vector->getMap()->isSameAs(*V.vector->getMap()))
         {
           // Create a read-only Kokkos view from the source vector


### PR DESCRIPTION
Fixed a bug in `TpetraWrappers::Vector::operator=()` where the `nonlocal_vector` (which is used to store ghost element contributions) was not copied when the destination vector was uninitialized. This could lead to missing ghost data and incorrect behavior during `compress()` operations.

The fix ensures that if the source vector contains a non-null nonlocal_vector, it is also deep-copied into the destination.