### PR TITLE
Add necessary header include.

### DIFF
--- a/include/deal.II/differentiation/ad/adolc_math.h
+++ b/include/deal.II/differentiation/ad/adolc_math.h
@@ -24,6 +24,8 @@
 #  include <adolc/internal/adolc_settings.h>
 #  include <adolc/internal/adubfunc.h> // Taped double math functions
 
+#  include <cmath>
+
 
 #  ifndef DOXYGEN
 


### PR DESCRIPTION
The file uses `std::erfc`. It needs to `#include` the necessary header.

In reference to #18071.