### PR TITLE
Improve error message when trying to configure with ArborX 2.0

### DIFF
--- a/cmake/configure/configure_50_arborx.cmake
+++ b/cmake/configure/configure_50_arborx.cmake
@@ -50,27 +50,29 @@ macro(feature_arborx_find_external var)
       ArborX::ArborX
     )
 
-    check_cxx_compiler_bug(
-      "
-      #include <ArborX.hpp>
-      int main() {
-        Kokkos::View<ArborX::Point*, Kokkos::HostSpace> points(\"points\", 0);
-        [[maybe_unused]] ArborX::BVH<Kokkos::HostSpace> bvh(Kokkos::DefaultHostExecutionSpace{}, points);
-      }
-      "
-      DEAL_II_ARBORX_CXX20_BUG)
-    reset_cmake_required()
+    if(ArborX_VERSION VERSION_LESS 2.0.0)
+      check_cxx_compiler_bug(
+        "
+        #include <ArborX.hpp>
+        int main() {
+          Kokkos::View<ArborX::Point*, Kokkos::HostSpace> points(\"points\", 0);
+          [[maybe_unused]] ArborX::BVH<Kokkos::HostSpace> bvh(Kokkos::DefaultHostExecutionSpace{}, points);
+        }
+        "
+        DEAL_II_ARBORX_CXX20_BUG)
+      reset_cmake_required()
 
-    if(DEAL_II_ARBORX_CXX20_BUG)
-      message(STATUS "Could not find a sufficient ArborX installation: "
-        "The ArborX version doesn't work with C++20 or higher."
-        )
-      set(ARBORX_ADDITIONAL_ERROR_STRING
-        ${ARBORX_ADDITIONAL_ERROR_STRING}
-        "Could not find a sufficient ArborX installation:\n"
-        "The ArborX version doesn't work with C++20 or higher. Try using a later ArborX release or try specifying a lower C++ standard.\n"
-        )
-      set(${var} FALSE)
+      if(DEAL_II_ARBORX_CXX20_BUG)
+        message(STATUS "Could not find a sufficient ArborX installation: "
+          "The ArborX version doesn't work with C++20 or higher."
+          )
+        set(ARBORX_ADDITIONAL_ERROR_STRING
+          ${ARBORX_ADDITIONAL_ERROR_STRING}
+          "Could not find a sufficient ArborX installation:\n"
+          "The ArborX version doesn't work with C++20 or higher. Try using a later ArborX release or try specifying a lower C++ standard.\n"
+          )
+        set(${var} FALSE)
+      endif()
     endif()
   endif()
 

--- a/cmake/modules/FindDEAL_II_ARBORX.cmake
+++ b/cmake/modules/FindDEAL_II_ARBORX.cmake
@@ -27,12 +27,24 @@ set_if_empty(ARBORX_DIR "$ENV{ARBORX_DIR}")
 
 # silence a warning when including FindKOKKOS.cmake
 set(CMAKE_CXX_EXTENSIONS OFF)
-find_package(ArborX 1.3 QUIET
+find_package(ArborX QUIET
   HINTS ${ARBORX_DIR} ${ArborX_DIR} $ENV{ArborX_DIR}
   )
 
 if(ArborX_FOUND)
   get_property(ARBORX_INSTALL_INCLUDE_DIR TARGET ArborX::ArborX PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+
+  #
+  # ArborX's compatibility mode is set to SameMajorVersion. Therefore if we want to
+  # support both the 1.X and the 2.X, we cannot set a minimum version in
+  # find_package. Instead we need to check the minimum version ourselves.
+  #
+  if(ArborX_VERSION VERSION_LESS 1.3)
+    message(FATAL_ERROR "Found ArborX version ${ArborX_VERSION} but the minimum version supported is 1.3")
+  elseif(ArborX_VERSION VERSION_GREATER_EQUAL 2.0)
+    message(FATAL_ERROR "Found ArborX version ${ArborX_VERSION}. The 2.X series is not currently supported")
+  endif()
+
 
   #
   # Check whether ArborX was compiled with MPI support


### PR DESCRIPTION
ArborX 2.0 has been released. Unfortunately, it is not compatible with the 1.X series and it uses the  `SameMajorVersion` compatibility mode. Since we have a minimum required version of 1.3, we get an error when trying to use Arborx 2.0. However because we use the `QUIET` option in `find_package`, we get the following error:
```
-- Processing ARBORX variables and targets  
--   ARBORX_INCLUDE_DIRS: *** Required variable "ARBORX_INSTALL_INCLUDE_DIR" empty ***  
-- Unable to process ARBORX   
-- DEAL_II_WITH_ARBORX has unmet external dependencies. 
CMake Error at cmake/macros/macro_configure_feature.cmake:111 (message):     


  Could not find the arborx library!       

  Please ensure that a suitable arborx library is installed on your computer.  

  If the library is not at a default location, either provide some hints for     
  autodetection,  

      $ ARBORX_DIR="..." cmake <...>     
      $ cmake -DARBORX_DIR="..." <...> 

  or set the relevant variables by hand in ccmake.
```
which is really misleading. If I remove the `QUIET option`, I do get an extra **warning** that ArborX 2.0 is not supported.

Since I plan to support both ArborX 1.X and 2.X, I decided to check the version of ArborX by hand. Right now, I check that the user is not trying to use ArborX 2.0 but I will remove this check once I've updated the wrappers. I've already modified `cmake/configure/configure_50_arborx.cmake` to support ArborX 2.X 