### PR TITLE
Add necessary include file.

### DIFF
--- a/include/deal.II/vtk/utilities.h
+++ b/include/deal.II/vtk/utilities.h
@@ -18,6 +18,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/point.h>
 
 #ifdef DEAL_II_WITH_VTK
 


### PR DESCRIPTION
Found poking around for #18071. The file uses `Point<dim>`, but does not `#include` any of the relevant headers.