### PR TITLE
Add necessary include.

### DIFF
--- a/source/lac/sparse_direct.cc
+++ b/source/lac/sparse_direct.cc
@@ -30,6 +30,9 @@
 #  include <umfpack.h>
 #endif
 
+#ifdef DEAL_II_WITH_MUMPS
+#  include <dmumps_c.h>
+#endif
 
 DEAL_II_NAMESPACE_OPEN
 


### PR DESCRIPTION
This file implements MUMPS wrappers but does not actually `#include` any MUMPS headers.

Part of #18071.