### PR TITLE
Avoid a warning about an unused function argument.

### DIFF
--- a/source/lac/scalapack.cc
+++ b/source/lac/scalapack.cc
@@ -3261,6 +3261,7 @@ ScaLAPACKMatrix<NumberType>::load_parallel(const std::string &filename)
   DEAL_II_ASSERT_UNREACHABLE();
 #  else
 #    ifndef H5_HAVE_PARALLEL
+  (void)filename;
   DEAL_II_ASSERT_UNREACHABLE();
 #    else
 


### PR DESCRIPTION
With the right/wrong combination of preprocessor flags, you get into a branch in which a function argument is unused.

Part of #18071.