### PR TITLE
Create a list of all header files.

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -18,8 +18,42 @@
 #
 add_subdirectory(deal.II)
 
+
 #
-# Add a rule for how to install the header files that are part of the source tree:
+# Sanity check: Make sure that the CMakeLists.txt files in the subdirectories
+# really did list all header files.
+#
+file(GLOB_RECURSE _header_files
+     LIST_DIRECTORIES false
+     "${CMAKE_CURRENT_SOURCE_DIR}/deal.II/*.h")
+foreach(_h ${DEAL_II_HEADER_FILES})
+  list(REMOVE_ITEM _header_files ${_h})
+endforeach()
+list(LENGTH _header_files _count)
+
+if (NOT ${_count} EQUAL 0)
+  message(FATAL_ERROR
+          "It looks like the CMakeLists.txt files in the subdirectories of\n"
+          "include/ forgot to list the following ${_count} header files:\n"
+          "  ${_header_files}")
+endif()
+
+# We will eventually need the names of header files to build interface
+# module partitions. The subdirectories all reported the names of
+# header files as global paths, so let us now strip the global parts
+# so that all header files are reported relative to the 'include/'
+# directory. That is, we need to strip CMAKE_CURRENT_SOURCE_DIR from
+# all of the file names.
+list(TRANSFORM DEAL_II_HEADER_FILES
+     REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/" "")
+
+# Propagate the list of header files back up one directory level
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)
+
+
+
+#
+# Add a rule for how to install the header files that are part of the source tree...
 #
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
   DESTINATION ${DEAL_II_INCLUDE_RELDIR}
@@ -28,7 +62,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deal.II
   )
 
 #
-# and don't forget to install all generated header files, too:
+# ...and don't forget to install all generated header files, too:
 #
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deal.II
   DESTINATION ${DEAL_II_INCLUDE_RELDIR}

--- a/include/deal.II/CMakeLists.txt
+++ b/include/deal.II/CMakeLists.txt
@@ -42,3 +42,7 @@ add_subdirectory(physics)
 add_subdirectory(sundials)
 add_subdirectory(trilinos)
 add_subdirectory(vtk)
+
+
+# Propagate the list of header files back up one directory level
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/algorithms/CMakeLists.txt
+++ b/include/deal.II/algorithms/CMakeLists.txt
@@ -11,3 +11,29 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    any_data.h
+    general_data_storage.h
+    named_selection.h
+    newton.h
+    newton.templates.h
+    operator.h
+    operator.templates.h
+    theta_timestepping.h
+    theta_timestepping.templates.h
+    timestep_control.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/arborx/CMakeLists.txt
+++ b/include/deal.II/arborx/CMakeLists.txt
@@ -11,3 +11,22 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    access_traits.h
+    bvh.h
+    distributed_tree.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/base/CMakeLists.txt
+++ b/include/deal.II/base/CMakeLists.txt
@@ -31,3 +31,154 @@ configure_file(
 #
 add_subdirectory(std_cxx17)
 add_subdirectory(std_cxx20)
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    aligned_vector.h
+    array_view.h
+    auto_derivative_function.h
+    bounding_box_data_out.h
+    bounding_box.h
+    communication_pattern_base.h
+    complex_overloads.h
+    conditional_ostream.h
+    convergence_table.h
+    data_out_base.h
+    derivative_form.h
+    discrete_time.h
+    enable_observer_pointer.h
+    event.h
+    exception_macros.h
+    exceptions.h
+    floating_point_comparator.h
+    flow_function.h
+    function_bessel.h
+    function_cspline.h
+    function_derivative.h
+    function.h
+    function_lib.h
+    function_parser.h
+    function_restriction.h
+    function_signed_distance.h
+    function_spherical.h
+    function.templates.h
+    function_time.h
+    function_time.templates.h
+    function_tools.h
+    geometric_utilities.h
+    geometry_info.h
+    graph_coloring.h
+    hdf5.h
+    incremental_function.h
+    index_set.h
+    init_finalize.h
+    iterator_range.h
+    job_identifier.h
+    kokkos.h
+    lazy.h
+    linear_index_iterator.h
+    logstream.h
+    memory_consumption.h
+    memory_space_data.h
+    memory_space.h
+    mg_level_object.h
+    mpi_consensus_algorithms.h
+    mpi_consensus_algorithms.templates.h
+    mpi.h
+    mpi_large_count.h
+    mpi_noncontiguous_partitioner.h
+    mpi_noncontiguous_partitioner.templates.h
+    mpi_remote_point_evaluation.h
+    mpi_stub.h
+    mpi_tags.h
+    mpi.templates.h
+    multithread_info.h
+    mu_parser_internal.h
+    mutable_bind.h
+    mutex.h
+    ndarray.h
+    numbers.h
+    observer_pointer.h
+    parallel.h
+    parameter_acceptor.h
+    parameter_handler.h
+    parsed_convergence_table.h
+    parsed_function.h
+    partitioner.h
+    partitioner.templates.h
+    path_search.h
+    patterns.h
+    point.h
+    polynomial.h
+    polynomials_abf.h
+    polynomials_adini.h
+    polynomials_barycentric.h
+    polynomials_bdm.h
+    polynomials_bernardi_raugel.h
+    polynomials_bernstein.h
+    polynomials_hermite.h
+    polynomials_integrated_legendre_sz.h
+    polynomials_nedelec.h
+    polynomial_space.h
+    polynomials_p.h
+    polynomials_piecewise.h
+    polynomials_pyramid.h
+    polynomials_rannacher_turek.h
+    polynomials_raviart_thomas.h
+    polynomials_rt_bubbles.h
+    polynomials_wedge.h
+    process_grid.h
+    qprojector.h
+    quadrature.h
+    quadrature_lib.h
+    quadrature_point_data.h
+    quadrature_selector.h
+    sacado_product_type.h
+    scalar_polynomials_base.h
+    scope_exit.h
+    signaling_nan.h
+    smartpointer.h
+    subscriptor.h
+    symbolic_function.h
+    symbolic_function.templates.h
+    symmetric_tensor.h
+    symmetric_tensor.templates.h
+    synchronous_iterator.h
+    table.h
+    table_handler.h
+    table_indices.h
+    task_result.h
+    template_constraints.h
+    tensor_accessors.h
+    tensor_function.h
+    tensor_function_parser.h
+    tensor_function.templates.h
+    tensor.h
+    tensor_polynomials_base.h
+    tensor_product_polynomials_bubbles.h
+    tensor_product_polynomials_const.h
+    tensor_product_polynomials.h
+    thread_local_storage.h
+    thread_management.h
+    timer.h
+    time_stepping.h
+    time_stepping.templates.h
+    trilinos_utilities.h
+    types.h
+    undefine_macros.h
+    utilities.h
+    vectorization.h
+    vector_slice.h
+    work_stream.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/base/std_cxx17/CMakeLists.txt
+++ b/include/deal.II/base/std_cxx17/CMakeLists.txt
@@ -11,3 +11,24 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    algorithm.h
+    cmath.h
+    optional.h
+    tuple.h
+    variant.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/base/std_cxx20/CMakeLists.txt
+++ b/include/deal.II/base/std_cxx20/CMakeLists.txt
@@ -11,3 +11,22 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    functional.h
+    iota_view.h
+    type_traits.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/boost_adaptors/CMakeLists.txt
+++ b/include/deal.II/boost_adaptors/CMakeLists.txt
@@ -11,3 +11,22 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    bounding_box.h
+    point.h
+    segment.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/cgal/CMakeLists.txt
+++ b/include/deal.II/cgal/CMakeLists.txt
@@ -11,3 +11,25 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    additional_data.h
+    intersections.h
+    point_conversion.h
+    surface_mesh.h
+    triangulation.h
+    utilities.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/differentiation/CMakeLists.txt
+++ b/include/deal.II/differentiation/CMakeLists.txt
@@ -19,3 +19,20 @@
 #
 add_subdirectory(ad)
 add_subdirectory(sd)
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    ad.h
+    sd.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/differentiation/ad/CMakeLists.txt
+++ b/include/deal.II/differentiation/ad/CMakeLists.txt
@@ -11,3 +11,29 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    ad_drivers.h
+    ad_helpers.h
+    ad_number_traits.h
+    ad_number_types.h
+    adolc_math.h
+    adolc_number_types.h
+    adolc_product_types.h
+    sacado_math.h
+    sacado_number_types.h
+    sacado_product_types.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/differentiation/sd/CMakeLists.txt
+++ b/include/deal.II/differentiation/sd/CMakeLists.txt
@@ -11,3 +11,29 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    symengine_math.h
+    symengine_number_traits.h
+    symengine_number_types.h
+    symengine_number_visitor_internal.h
+    symengine_optimizer.h
+    symengine_product_types.h
+    symengine_scalar_operations.h
+    symengine_tensor_operations.h
+    symengine_types.h
+    symengine_utilities.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/distributed/CMakeLists.txt
+++ b/include/deal.II/distributed/CMakeLists.txt
@@ -11,3 +11,31 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    cell_data_transfer.h
+    cell_data_transfer.templates.h
+    cell_weights.h
+    field_transfer.h
+    fully_distributed_tria.h
+    grid_refinement.h
+    p4est_wrappers.h
+    repartitioning_policy_tools.h
+    shared_tria.h
+    solution_transfer.h
+    tria_base.h
+    tria.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/dofs/CMakeLists.txt
+++ b/include/deal.II/dofs/CMakeLists.txt
@@ -11,3 +11,31 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    block_info.h
+    dof_accessor.h
+    dof_accessor.templates.h
+    dof_faces.h
+    dof_handler.h
+    dof_handler_policy.h
+    dof_iterator_selector.h
+    dof_levels.h
+    dof_objects.h
+    dof_renumbering.h
+    dof_tools.h
+    number_cache.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/fe/CMakeLists.txt
+++ b/include/deal.II/fe/CMakeLists.txt
@@ -11,3 +11,87 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    block_mask.h
+    component_mask.h
+    fe_abf.h
+    fe_base.h
+    fe_bdm.h
+    fe_bernardi_raugel.h
+    fe_bernstein.h
+    fe_coupling_values.h
+    fe_data.h
+    fe_dgp.h
+    fe_dgp_monomial.h
+    fe_dgp_nonparametric.h
+    fe_dgq.h
+    fe_dg_vector.h
+    fe_dg_vector.templates.h
+    fe_enriched.h
+    fe_face.h
+    fe.h
+    fe_hermite.h
+    fe_interface_values.h
+    fe_nedelec.h
+    fe_nedelec_sz.h
+    fe_nothing.h
+    fe_p1nc.h
+    fe_poly_face.h
+    fe_poly_face.templates.h
+    fe_poly.h
+    fe_poly_tensor.h
+    fe_pyramid_p.h
+    fe_q_base.h
+    fe_q_bubbles.h
+    fe_q_dg0.h
+    fe_q.h
+    fe_q_hierarchical.h
+    fe_q_iso_q1.h
+    fe_rannacher_turek.h
+    fe_raviart_thomas.h
+    fe_rt_bubbles.h
+    fe_series.h
+    fe_simplex_p_bubbles.h
+    fe_simplex_p.h
+    fe_system.h
+    fe_tools_extrapolate.templates.h
+    fe_tools.h
+    fe_tools_interpolate.templates.h
+    fe_tools.templates.h
+    fe_trace.h
+    fe_update_flags.h
+    fe_values_base.h
+    fe_values_extractors.h
+    fe_values.h
+    fe_values_views.h
+    fe_values_views_internal.h
+    fe_wedge_p.h
+    mapping_c1.h
+    mapping_cartesian.h
+    mapping_fe_field.h
+    mapping_fe.h
+    mapping.h
+    mapping_manifold.h
+    mapping_q1_eulerian.h
+    mapping_q1.h
+    mapping_q_cache.h
+    mapping_q_eulerian.h
+    mapping_q_generic.h
+    mapping_q.h
+    mapping_q_internal.h
+    mapping_related_data.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/gmsh/CMakeLists.txt
+++ b/include/deal.II/gmsh/CMakeLists.txt
@@ -11,3 +11,20 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    utilities.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/grid/CMakeLists.txt
+++ b/include/deal.II/grid/CMakeLists.txt
@@ -11,3 +11,55 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    cell_data.h
+    cell_id.h
+    cell_id_translator.h
+    cell_status.h
+    composition_manifold.h
+    connectivity.h
+    filtered_iterator.h
+    grid_generator.h
+    grid_in.h
+    grid_out.h
+    grid_refinement.h
+    grid_tools_cache.h
+    grid_tools_cache_update_flags.h
+    grid_tools_geometry.h
+    grid_tools.h
+    grid_tools_topology.h
+    intergrid_map.h
+    magic_numbers.h
+    manifold.h
+    manifold_lib.h
+    persistent_tria.h
+    reference_cell.h
+    tensor_product_manifold.h
+    tria_accessor.h
+    tria_accessor.templates.h
+    tria_description.h
+    tria_faces.h
+    tria.h
+    tria_iterator_base.h
+    tria_iterator.h
+    tria_iterator_selector.h
+    tria_iterator.templates.h
+    tria_levels.h
+    tria_objects.h
+    tria_objects_orientations.h
+    tria_orientation.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/hp/CMakeLists.txt
+++ b/include/deal.II/hp/CMakeLists.txt
@@ -11,3 +11,25 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    collection.h
+    fe_collection.h
+    fe_values.h
+    mapping_collection.h
+    q_collection.h
+    refinement.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/integrators/CMakeLists.txt
+++ b/include/deal.II/integrators/CMakeLists.txt
@@ -11,3 +11,28 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    advection.h
+    divergence.h
+    elasticity.h
+    grad_div.h
+    l2.h
+    laplace.h
+    local_integrators.h
+    maxwell.h
+    patches.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/lac/CMakeLists.txt
+++ b/include/deal.II/lac/CMakeLists.txt
@@ -11,3 +11,168 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    affine_constraints.h
+    affine_constraints.templates.h
+    arpack_solver.h
+    blas_extension_templates.h
+    block_indices.h
+    block_linear_operator.h
+    block_matrix_base.h
+    block_sparse_matrix_ez.h
+    block_sparse_matrix_ez.templates.h
+    block_sparse_matrix.h
+    block_sparse_matrix.templates.h
+    block_sparsity_pattern.h
+    block_vector_base.h
+    block_vector.h
+    block_vector.templates.h
+    chunk_sparse_matrix.h
+    chunk_sparse_matrix.templates.h
+    chunk_sparsity_pattern.h
+    constrained_linear_operator.h
+    constraint_matrix.h
+    diagonal_matrix.h
+    dynamic_sparsity_pattern.h
+    eigen.h
+    exceptions.h
+    full_matrix.h
+    full_matrix.templates.h
+    generic_linear_algebra.h
+    ginkgo_solver.h
+    householder.h
+    identity_matrix.h
+    lapack_full_matrix.h
+    lapack_support.h
+    lapack_templates.h
+    la_parallel_block_vector.h
+    la_parallel_block_vector.templates.h
+    la_parallel_vector.h
+    la_parallel_vector.templates.h
+    linear_operator.h
+    linear_operator_tools.h
+    matrix_block.h
+    matrix_iterator.h
+    matrix_out.h
+    orthogonalization.h
+    packaged_operation.h
+    parpack_solver.h
+    petsc_block_sparse_matrix.h
+    petsc_block_vector.h
+    petsc_communication_pattern.h
+    petsc_compatibility.h
+    petsc_full_matrix.h
+    petsc_matrix_base.h
+    petsc_matrix_free.h
+    petsc_parallel_block_sparse_matrix.h
+    petsc_parallel_block_vector.h
+    petsc_parallel_sparse_matrix.h
+    petsc_parallel_vector.h
+    petsc_precondition.h
+    petsc_snes.h
+    petsc_snes.templates.h
+    petsc_solver.h
+    petsc_sparse_matrix.h
+    petsc_ts.h
+    petsc_ts.templates.h
+    petsc_vector_base.h
+    petsc_vector.h
+    precondition_block_base.h
+    precondition_block.h
+    precondition_block.templates.h
+    precondition.h
+    precondition_selector.h
+    qr.h
+    read_vector.h
+    read_write_vector.h
+    read_write_vector.templates.h
+    relaxation_block.h
+    relaxation_block.templates.h
+    scalapack.h
+    scalapack.templates.h
+    schur_complement.h
+    slepc_solver.h
+    slepc_spectral_transformation.h
+    solver_bicgstab.h
+    solver_cg.h
+    solver_control.h
+    solver_fire.h
+    solver_gmres.h
+    solver.h
+    solver_idr.h
+    solver_minres.h
+    solver_qmrs.h
+    solver_relaxation.h
+    solver_richardson.h
+    solver_selector.h
+    sparse_decomposition.h
+    sparse_decomposition.templates.h
+    sparse_direct.h
+    sparse_ilu.h
+    sparse_ilu.templates.h
+    sparse_matrix_ez.h
+    sparse_matrix_ez.templates.h
+    sparse_matrix.h
+    sparse_matrix.templates.h
+    sparse_matrix_tools.h
+    sparse_mic.h
+    sparse_mic.templates.h
+    sparse_vanka.h
+    sparse_vanka.templates.h
+    sparsity_pattern_base.h
+    sparsity_pattern.h
+    sparsity_tools.h
+    tensor_product_matrix.h
+    tensor_product_matrix.templates.h
+    tridiagonal_matrix.h
+    trilinos_block_sparse_matrix.h
+    trilinos_epetra_communication_pattern.h
+    trilinos_epetra_vector.h
+    trilinos_index_access.h
+    trilinos_linear_operator.h
+    trilinos_parallel_block_vector.h
+    trilinos_precondition.h
+    trilinos_solver.h
+    trilinos_sparse_matrix.h
+    trilinos_sparsity_pattern.h
+    trilinos_tpetra_block_sparse_matrix.h
+    trilinos_tpetra_block_sparse_matrix.templates.h
+    trilinos_tpetra_block_vector.h
+    trilinos_tpetra_block_vector.templates.h
+    trilinos_tpetra_communication_pattern.h
+    trilinos_tpetra_precondition.h
+    trilinos_tpetra_precondition.templates.h
+    trilinos_tpetra_solver_direct.h
+    trilinos_tpetra_solver_direct.templates.h
+    trilinos_tpetra_sparse_matrix.h
+    trilinos_tpetra_sparse_matrix.templates.h
+    trilinos_tpetra_sparsity_pattern.h
+    trilinos_tpetra_types.h
+    trilinos_tpetra_vector.h
+    trilinos_tpetra_vector.templates.h
+    trilinos_vector.h
+    utilities.h
+    vector_element_access.h
+    vector.h
+    vector_memory.h
+    vector_memory.templates.h
+    vector_operation.h
+    vector_operations_internal.h
+    vector_space_vector.h
+    vector.templates.h
+    vector_type_traits.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/matrix_free/CMakeLists.txt
+++ b/include/deal.II/matrix_free/CMakeLists.txt
@@ -11,3 +11,64 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    constraint_info.h
+    dof_info.h
+    dof_info.templates.h
+    evaluation_flags.h
+    evaluation_kernels_face.h
+    evaluation_kernels.h
+    evaluation_kernels_common.h
+    evaluation_kernels_hanging_nodes.h
+    evaluation_selector.h
+    evaluation_template_face_factory.templates.h
+    evaluation_template_factory.h
+    evaluation_template_factory_hanging_nodes.templates.h
+    evaluation_template_factory_internal.h
+    evaluation_template_factory.templates.h
+    face_info.h
+    face_setup_internal.h
+    fe_evaluation_data.h
+    fe_evaluation.h
+    fe_point_evaluation.h
+    fe_remote_evaluation.h
+    hanging_nodes_internal.h
+    mapping_data_on_the_fly.h
+    mapping_info.h
+    mapping_info_storage.h
+    mapping_info_storage.templates.h
+    mapping_info.templates.h
+    matrix_free.h
+    matrix_free.templates.h
+    operators.h
+    portable_evaluation_kernels.h
+    portable_fe_evaluation.h
+    portable_hanging_nodes_internal.h
+    portable_matrix_free.h
+    portable_matrix_free.templates.h
+    portable_tensor_product_kernels.h
+    shape_info.h
+    shape_info.templates.h
+    task_info.h
+    tensor_product_kernels.h
+    tensor_product_point_kernels.h
+    tools.h
+    type_traits.h
+    util.h
+    vector_access_internal.h
+    vector_data_exchange.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/meshworker/CMakeLists.txt
+++ b/include/deal.II/meshworker/CMakeLists.txt
@@ -11,3 +11,36 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    assemble_flags.h
+    assembler.h
+    copy_data.h
+    dof_info.h
+    dof_info.templates.h
+    functional.h
+    integration_info.h
+    integration_info.templates.h
+    local_integrator.h
+    local_results.h
+    loop.h
+    mesh_loop.h
+    output.h
+    scratch_data.h
+    simple.h
+    vector_selector.h
+    vector_selector.templates.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/multigrid/CMakeLists.txt
+++ b/include/deal.II/multigrid/CMakeLists.txt
@@ -11,3 +11,41 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    mg_base.h
+    mg_base.templates.h
+    mg_block_smoother.h
+    mg_coarse.h
+    mg_constrained_dofs.h
+    mg_matrix.h
+    mg_smoother.h
+    mg_tools.h
+    mg_transfer_block.h
+    mg_transfer_block.templates.h
+    mg_transfer_component.h
+    mg_transfer_component.templates.h
+    mg_transfer_global_coarsening.h
+    mg_transfer_global_coarsening.templates.h
+    mg_transfer.h
+    mg_transfer_internal.h
+    mg_transfer_matrix_free.h
+    mg_transfer_matrix_free.templates.h
+    mg_transfer.templates.h
+    multigrid.h
+    multigrid.templates.h
+    sparse_matrix_collection.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/non_matching/CMakeLists.txt
+++ b/include/deal.II/non_matching/CMakeLists.txt
@@ -11,3 +11,26 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    coupling.h
+    fe_immersed_values.h
+    fe_values.h
+    immersed_surface_quadrature.h
+    mapping_info.h
+    mesh_classifier.h
+    quadrature_generator.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/numerics/CMakeLists.txt
+++ b/include/deal.II/numerics/CMakeLists.txt
@@ -11,3 +11,73 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    adaptation_strategies.h
+    cell_data_transfer.h
+    cell_data_transfer.templates.h
+    data_component_interpretation.h
+    data_out_dof_data.h
+    data_out_dof_data.templates.h
+    data_out_faces.h
+    data_out.h
+    data_out_resample.h
+    data_out_rotation.h
+    data_out_stack.h
+    data_postprocessor.h
+    derivative_approximation.h
+    dof_output_operator.h
+    dof_output_operator.templates.h
+    dof_print_solver_step.h
+    error_estimator.h
+    error_estimator.templates.h
+    fe_field_function.h
+    fe_field_function.templates.h
+    histogram.h
+    history.h
+    matrix_creator.h
+    matrix_creator.templates.h
+    matrix_tools.h
+    nonlinear.h
+    point_value_history.h
+    rtree.h
+    smoothness_estimator.h
+    solution_transfer.h
+    tensor_product_matrix_creator.h
+    time_dependent.h
+    vector_tools_boundary.h
+    vector_tools_boundary.templates.h
+    vector_tools_common.h
+    vector_tools_constraints.h
+    vector_tools_constraints.templates.h
+    vector_tools_evaluate.h
+    vector_tools.h
+    vector_tools_integrate_difference.h
+    vector_tools_integrate_difference.templates.h
+    vector_tools_interpolate.h
+    vector_tools_interpolate.templates.h
+    vector_tools_mean_value.h
+    vector_tools_mean_value.templates.h
+    vector_tools_point_gradient.h
+    vector_tools_point_gradient.templates.h
+    vector_tools_point_value.h
+    vector_tools_point_value.templates.h
+    vector_tools_project.h
+    vector_tools_project.templates.h
+    vector_tools_rhs.h
+    vector_tools_rhs.templates.h
+    vector_tools.templates.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/opencascade/CMakeLists.txt
+++ b/include/deal.II/opencascade/CMakeLists.txt
@@ -11,3 +11,22 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    boundary_lib.h
+    manifold_lib.h
+    utilities.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/optimization/CMakeLists.txt
+++ b/include/deal.II/optimization/CMakeLists.txt
@@ -17,3 +17,18 @@
 # Recurse into the sub-directories:
 #
 add_subdirectory(rol)
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    line_minimization.h
+    solver_bfgs.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/optimization/rol/CMakeLists.txt
+++ b/include/deal.II/optimization/rol/CMakeLists.txt
@@ -11,3 +11,20 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    vector_adaptor.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/particles/CMakeLists.txt
+++ b/include/deal.II/particles/CMakeLists.txt
@@ -11,3 +11,28 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    data_out.h
+    generators.h
+    particle_accessor.h
+    particle.h
+    particle_handler.h
+    particle_iterator.h
+    partitioner.h
+    property_pool.h
+    utilities.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/physics/CMakeLists.txt
+++ b/include/deal.II/physics/CMakeLists.txt
@@ -16,3 +16,22 @@
 # Recurse into the sub-directories:
 #
 add_subdirectory(elasticity)
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    notation.h
+    transformations.h
+    vector_relations.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/physics/elasticity/CMakeLists.txt
+++ b/include/deal.II/physics/elasticity/CMakeLists.txt
@@ -11,3 +11,21 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    kinematics.h
+    standard_tensors.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/sundials/CMakeLists.txt
+++ b/include/deal.II/sundials/CMakeLists.txt
@@ -11,3 +11,27 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    arkode.h
+    ida.h
+    kinsol.h
+    n_vector.h
+    n_vector.templates.h
+    sundials_types.h
+    sunlinsol_wrapper.h
+    utilities.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/trilinos/CMakeLists.txt
+++ b/include/deal.II/trilinos/CMakeLists.txt
@@ -11,3 +11,21 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    nox.h
+    nox.templates.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)

--- a/include/deal.II/vtk/CMakeLists.txt
+++ b/include/deal.II/vtk/CMakeLists.txt
@@ -11,3 +11,19 @@
 ## LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 ##
 ## ------------------------------------------------------------------------
+
+
+#
+# Keep track of all of the header files in this directory
+#
+set(_header_files
+    utilities.h
+)
+
+
+# Prepend each header name by the current directory
+list(TRANSFORM _header_files PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+
+# Add all of these header files to the global list and propagate things back up one directory level
+list(APPEND DEAL_II_HEADER_FILES ${_header_files})
+set(DEAL_II_HEADER_FILES ${DEAL_II_HEADER_FILES} PARENT_SCOPE)


### PR DESCRIPTION
Part of #18071. I need a list of all header files because each header file has to be run through a script to create a module interface partition. This is a follow-up to #18336 and a companion to #18337.