### PR TITLE
Prefer std::ptrdiff_t over ::ptrdiff_t.

### DIFF
--- a/include/deal.II/lac/trilinos_solver.h
+++ b/include/deal.II/lac/trilinos_solver.h
@@ -962,7 +962,7 @@ namespace TrilinosWrappers
       /**
        * The number of rows in the multivector.
        */
-      virtual ptrdiff_t
+      virtual std::ptrdiff_t
       GetGlobalLength() const
       {
         AssertThrow(this->vectors.size() > 0, ExcInternalError());


### PR DESCRIPTION
Part of #18071.