### PR TITLE
Include a necessary header.

### DIFF
--- a/source/distributed/p4est_wrappers.cc
+++ b/source/distributed/p4est_wrappers.cc
@@ -20,6 +20,9 @@ DEAL_II_NAMESPACE_OPEN
 
 #ifdef DEAL_II_WITH_P4EST
 
+#  include <sc_containers.h>
+
+
 namespace internal
 {
   namespace p4est


### PR DESCRIPTION
This file uses SC functionality in the p4est wrappers. Make sure we `#include` the right header. Part of #18071.