### PR TITLE
Auto-indent Python files.

### DIFF
--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -62,6 +62,7 @@ checks
 
 process_changed "tests include source examples cmake/scripts contrib/python-bindings" ".*\.(cc|h)" format_file
 process_changed "source" ".*\.inst.in" format_inst
+process_changed "tests include source examples contrib" ".*\.py" format_python_file
 
 #
 # Fix permissions and convert to unix line ending if necessary:
@@ -77,6 +78,8 @@ process_changed "tests include source examples cmake/scripts contrib/python-bind
 
 process_changed "doc/news/*/*" "doc/news/.*/.*/[0-9].*" dos_to_unix
 
+process_changed "tests include source examples contrib" ".*\.py" dos_to_unix
+
 #
 # Removing trailing whitespace
 #
@@ -86,6 +89,8 @@ process_changed "tests include source examples cmake/scripts contrib/python-bind
 
 process_changed "doc/news/*/*" "doc/news/.*/.*/[0-9].*" remove_trailing_whitespace
 
+process_changed "tests include source examples contrib" ".*\.py" remove_trailing_whitespace
+
 #
 # Ensure only a single newline at end of files
 #
@@ -94,3 +99,5 @@ process_changed "tests include source examples cmake/scripts contrib/python-bind
   ".*\.(cc|h|html|dox|txt)" ensure_single_trailing_newline
 
 process_changed "doc/news/*/*" "doc/news/.*/.*/[0-9].*" ensure_single_trailing_newline
+
+process_changed "tests include source examples contrib" ".*\.py" ensure_single_trailing_newline

--- a/contrib/utilities/indent-all
+++ b/contrib/utilities/indent-all
@@ -66,6 +66,7 @@ checks
 
 process "tests include source examples contrib/python-bindings" ".*\.(cc|h)" format_file
 process "source" ".*\.inst.in" format_inst
+process "tests include source examples contrib" ".*\.py" format_python_file
 
 #
 # Fix permissions and convert to unix line ending if necessary:
@@ -81,6 +82,8 @@ process "tests include source examples cmake/scripts contrib/python-bindings" \
 
 process "doc/news/*/*" "doc/news/.*/.*/[0-9].*" dos_to_unix
 
+process "tests include source examples contrib" ".*\.py" dos_to_unix
+
 #
 # Removing trailing whitespace
 #
@@ -90,6 +93,8 @@ process "tests include source examples cmake/scripts contrib/python-bindings doc
 
 process "doc/news/*/*" "doc/news/.*/.*/[0-9].*" remove_trailing_whitespace
 
+process "tests include source examples contrib" ".*\.py" remove_trailing_whitespace
+
 #
 # Ensure only a single newline at end of files
 #
@@ -98,3 +103,5 @@ process "tests include source examples cmake/scripts contrib/python-bindings doc
   ".*\.(cc|h|html|dox|txt)" ensure_single_trailing_newline
 
 process "doc/news/*/*" "doc/news/.*/.*/[0-9].*" ensure_single_trailing_newline
+
+process "tests include source examples contrib" ".*\.py" ensure_single_trailing_newline

--- a/contrib/utilities/indent_common.sh
+++ b/contrib/utilities/indent_common.sh
@@ -160,6 +160,38 @@ format_file()
 }
 export -f format_file
 
+
+#
+# Also format Python files, assuming that we have the 'black'
+# autoindenter available. Black is better than clang-format at not
+# changing the time stamp of a file if the file wasn't actually
+# changed. But, for simplicity, just use the same scheme above
+# so we can use the same reporting mechanism.
+#
+# If 'black' isn't available, just don't do anything.
+#
+# (There is one file, contrib/utilities/dotgdbinit.py, that contains
+# some Python code, but starts with some GDB instruction that confuses
+# the indenter. Exclude that file.)
+#
+format_python_file()
+{
+  if which black > /dev/null ; then
+    file="${1}"
+    if test "$file" = "contrib/utilities/dotgdbinit.py" ; then
+      return ;
+    fi
+      
+    tmpfile="$(mktemp "${TMPDIR}/$(basename "$1").tmp.XXXXXXXX")"
+    cp "${file}" "${tmpfile}"
+    black -q "${tmpfile}"
+    fix_or_report "${file}" "${tmpfile}" "file indented incorrectly"
+    rm -f "${tmpfile}"
+  fi
+}
+export -f format_python_file
+
+
 #
 # Remove trailing whitespace.
 #


### PR DESCRIPTION
This implements the first step towards #18372: If we have the "black" auto-indenter available, indent all Python files in certain directories.

In a follow-up step, we should make sure that black is installed on the CI machines.