### PR TITLE
Fix missing assertion for undefined parameters in JSON input parsing

### DIFF
--- a/doc/news/changes/minor/20250508Schreter
+++ b/doc/news/changes/minor/20250508Schreter
@@ -1,0 +1,9 @@
+Fix: Ensure that undefined parameters within nested JSON subnodes
+trigger proper exception handling when using
+ParameterHandler::parse_input_from_json() with skip_undefined set
+to false. Previously, the exception ExcEntryUndeclared was only
+thrown when undefined parameters appeared at the top level of the
+parameter file. This fix extends the check to nested subnode
+entries as well.
+<br>
+(Magdalena Schreter-Fleischhacker, 2025/05/08)

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -641,37 +641,30 @@ namespace
         if (p.second.empty())
           {
             // set the found parameter in the destination argument
-            if (skip_undefined)
+            try
               {
-                try
-                  {
-                    prm.set(demangle(p.first), p.second.data());
-                  }
-                catch (const ParameterHandler::ExcEntryUndeclared &)
-                  {
-                    // ignore undeclared entry assert
-                  }
+                prm.set(demangle(p.first), p.second.data());
               }
-            else
-              prm.set(demangle(p.first), p.second.data());
+            catch (const ParameterHandler::ExcEntryUndeclared &entry_string)
+              {
+                // ignore undeclared entry assert
+                AssertThrow(skip_undefined,
+                            ParameterHandler::ExcEntryUndeclared(entry_string));
+              }
           }
         else if (p.second.get_optional<std::string>("value"))
           {
             // set the found parameter in the destination argument
-            if (skip_undefined)
+            try
               {
-                try
-                  {
-                    prm.set(demangle(p.first),
-                            p.second.get<std::string>("value"));
-                  }
-                catch (const ParameterHandler::ExcEntryUndeclared &)
-                  {
-                    // ignore undeclared entry assert
-                  }
+                prm.set(demangle(p.first), p.second.get<std::string>("value"));
               }
-            else
-              prm.set(demangle(p.first), p.second.get<std::string>("value"));
+            catch (const ParameterHandler::ExcEntryUndeclared &entry_string)
+              {
+                // ignore undeclared entry assert
+                AssertThrow(skip_undefined,
+                            ParameterHandler::ExcEntryUndeclared(entry_string));
+              }
 
             // this node might have sub-nodes in addition to "value", such as
             // "default_value", "documentation", etc. we might at some point
@@ -701,9 +694,11 @@ namespace
                                      prm);
                 prm.leave_subsection();
               }
-            catch (const ParameterHandler::ExcEntryUndeclared &)
+            catch (const ParameterHandler::ExcEntryUndeclared &entry_string)
               {
                 // ignore undeclared entry assert
+                AssertThrow(skip_undefined,
+                            ParameterHandler::ExcEntryUndeclared(entry_string));
               }
           }
       }

--- a/tests/parameter_handler/parameter_handler_read_json_06.cc
+++ b/tests/parameter_handler/parameter_handler_read_json_06.cc
@@ -1,0 +1,53 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2010 - 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+
+// check ParameterHandler::parse_input_from_json with an undefined parameter
+
+#include <deal.II/base/parameter_handler.h>
+
+#include "../tests.h"
+
+
+int
+main()
+{
+  initlog();
+
+  // default values
+  double double1 = 1.234;
+
+  ParameterHandler prm;
+  prm.enter_subsection("ss1");
+  prm.add_parameter("defined double 1", double1, "doc 3");
+  prm.leave_subsection();
+
+  // read from json
+  std::ifstream in(SOURCE_DIR "/prm/parameter_handler_read_json_05.json");
+  try
+    {
+      prm.parse_input_from_json(in);
+    }
+  catch (const ExceptionBase &e)
+    {
+      deallog << e.get_exc_name() << std::endl;
+      deallog
+        << "ParameterHandler threw an exception with the following message:"
+        << std::endl;
+      e.print_info(deallog.get_file_stream());
+    }
+
+  return 0;
+}

--- a/tests/parameter_handler/parameter_handler_read_json_06.output
+++ b/tests/parameter_handler/parameter_handler_read_json_06.output
@@ -1,0 +1,4 @@
+
+DEAL::ParameterHandler::ExcEntryUndeclared(entry_string)
+DEAL::ParameterHandler threw an exception with the following message:
+    You can't ask for entry <undefined double 1> you have not yet declared.

--- a/tests/parameter_handler/parameter_handler_read_xml_error_01.output
+++ b/tests/parameter_handler/parameter_handler_read_xml_error_01.output
@@ -1,3 +1,3 @@
 
-DEAL::ExcEntryUndeclared(entry_string)
+DEAL::ParameterHandler::ExcEntryUndeclared(entry_string)
     You can't ask for entry <int1234> you have not yet declared.

--- a/tests/parameter_handler/prm/parameter_handler_read_json_05.json
+++ b/tests/parameter_handler/prm/parameter_handler_read_json_05.json
@@ -1,0 +1,21 @@
+{
+    "ss1":
+    {
+        "defined double 1":
+        {
+            "value": "2.234",
+            "default_value": "1.234",
+            "documentation": "doc 3",
+            "pattern": "2",
+            "pattern_description": "[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]"
+        },
+        "undefined double 1":
+        {
+            "value": "2.234",
+            "default_value": "1.234",
+            "documentation": "doc 3",
+            "pattern": "2",
+            "pattern_description": "[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]"
+        }
+    }
+}


### PR DESCRIPTION
Previously, when parsing a JSON input with `parse_input_from_json(..., skip_undefined=false)`, undefined parameters that are a subnode (e.g., "undefined 1" as in the example below) would not trigger the expected assertion. This PR fixes this issue to ensure that all undefined parameters are properly asserted.

```json
{
  "cat 1": 
   {
       "defined 1": "2",
       "undefined 1": "3"
   }
}

```

@peterrum FYI