### PR TITLE
Properly qualify a namespace name.

### DIFF
--- a/include/deal.II/base/exception_macros.h
+++ b/include/deal.II/base/exception_macros.h
@@ -996,12 +996,12 @@
  *
  * @ingroup Exceptions
  */
-#define AssertIndexRange(index, range)                                       \
-  Assert(::dealii::deal_II_exceptions::internals::compare_less_than(index,   \
-                                                                    range),  \
-         dealii::ExcIndexRangeType<::dealii::internal::argument_type_t<void( \
-           std::common_type_t<decltype(index), decltype(range)>)>>((index),  \
-                                                                   0,        \
+#define AssertIndexRange(index, range)                                         \
+  Assert(::dealii::deal_II_exceptions::internals::compare_less_than(index,     \
+                                                                    range),    \
+         ::dealii::ExcIndexRangeType<::dealii::internal::argument_type_t<void( \
+           std::common_type_t<decltype(index), decltype(range)>)>>((index),    \
+                                                                   0,          \
                                                                    (range)))
 
 /**


### PR DESCRIPTION
Part of #18071.