### PR TITLE
Fix clang-tidy complaints

### DIFF
--- a/source/distributed/fully_distributed_tria.cc
+++ b/source/distributed/fully_distributed_tria.cc
@@ -149,8 +149,8 @@ namespace parallel
           for (auto &cell_info : cell_infos)
             std::sort(cell_info.begin(),
                       cell_info.end(),
-                      [&](TriangulationDescription::CellData<dim> a,
-                          TriangulationDescription::CellData<dim> b) {
+                      [&](const TriangulationDescription::CellData<dim> &a,
+                          const TriangulationDescription::CellData<dim> &b) {
                         const CellId a_id(a.id);
                         const CellId b_id(b.id);
 

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -146,7 +146,7 @@ namespace internal
     const unsigned int n_dofs_per_cell =
       fe.base_element(base_no).n_dofs_per_cell();
 
-    auto copy_row = [](const auto row_in, auto row_out) {
+    auto copy_row = [](const auto &row_in, const auto &row_out) {
       std::copy(row_in.begin(), row_in.end(), row_out.begin());
     };
 

--- a/source/fe/fe_values_base.cc
+++ b/source/fe/fe_values_base.cc
@@ -308,7 +308,7 @@ namespace internal
     const dealii::Table<2, double>                   &shape_values,
     const FiniteElement<dim, spacedim>               &fe,
     const std::vector<unsigned int> &shape_function_to_row_table,
-    ArrayView<VectorType>            values,
+    const ArrayView<VectorType>     &values,
     const bool                       quadrature_points_fastest = false,
     const unsigned int               component_multiple        = 1)
   {
@@ -459,7 +459,7 @@ namespace internal
     const dealii::Table<2, Tensor<order, spacedim>> &shape_derivatives,
     const FiniteElement<dim, spacedim>              &fe,
     const std::vector<unsigned int> &shape_function_to_row_table,
-    ArrayView<std::vector<Tensor<order, spacedim, Number>>> derivatives,
+    const ArrayView<std::vector<Tensor<order, spacedim, Number>>> &derivatives,
     const bool         quadrature_points_fastest = false,
     const unsigned int component_multiple        = 1)
   {

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -7581,8 +7581,8 @@ namespace GridGenerator
       100.0 * std::numeric_limits<double>::epsilon();
     auto assert_vertex_distance_within_tolerance =
       [center, radial_vertex_tolerance](
-        const TriaIterator<TriaAccessor<dim - 1, dim, dim>> face,
-        const double                                        radius) {
+        const TriaIterator<TriaAccessor<dim - 1, dim, dim>> &face,
+        const double                                         radius) {
         (void)center;
         (void)radial_vertex_tolerance;
         (void)face;

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -3128,7 +3128,7 @@ namespace
   generate_triangulation_patches(
     std::vector<DataOutBase::Patch<dim, spacedim>> &patches,
     ITERATOR                                        cell,
-    END                                             end)
+    const END                                      &end)
   {
     // convert each of the active cells into a patch
     for (; cell != end; ++cell)

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -12738,8 +12738,8 @@ void Triangulation<dim, spacedim>::create_triangulation(
     std::sort(
       cell_info.begin(),
       cell_info.end(),
-      [&](TriangulationDescription::CellData<dim> a,
-          TriangulationDescription::CellData<dim> b) {
+      [&](const TriangulationDescription::CellData<dim> &a,
+          const TriangulationDescription::CellData<dim> &b) {
         const CellId a_id(a.id);
         const CellId b_id(b.id);
 

--- a/source/multigrid/mg_level_global_transfer.cc
+++ b/source/multigrid/mg_level_global_transfer.cc
@@ -160,14 +160,14 @@ namespace
   template <int dim, int spacedim, typename Number>
   void
   fill_internal(
-    const DoFHandler<dim, spacedim>            &mg_dof,
-    ObserverPointer<const MGConstrainedDoFs>    mg_constrained_dofs,
-    const MPI_Comm                              mpi_communicator,
-    const bool                                  transfer_solution_vectors,
-    std::vector<Table<2, unsigned int>>        &copy_indices,
-    std::vector<Table<2, unsigned int>>        &copy_indices_global_mine,
-    std::vector<Table<2, unsigned int>>        &copy_indices_level_mine,
-    LinearAlgebra::distributed::Vector<Number> &ghosted_global_vector,
+    const DoFHandler<dim, spacedim>                &mg_dof,
+    const ObserverPointer<const MGConstrainedDoFs> &mg_constrained_dofs,
+    const MPI_Comm                                  mpi_communicator,
+    const bool                                      transfer_solution_vectors,
+    std::vector<Table<2, unsigned int>>            &copy_indices,
+    std::vector<Table<2, unsigned int>>            &copy_indices_global_mine,
+    std::vector<Table<2, unsigned int>>            &copy_indices_level_mine,
+    LinearAlgebra::distributed::Vector<Number>     &ghosted_global_vector,
     MGLevelObject<LinearAlgebra::distributed::Vector<Number>>
       &ghosted_level_vector)
   {


### PR DESCRIPTION
My local clang-tidy had a couple more complaints for passing arguments via const&.