### PR TITLE
Try to avoid some more unused variable warnings.

### DIFF
--- a/include/deal.II/base/exception_macros.h
+++ b/include/deal.II/base/exception_macros.h
@@ -616,14 +616,14 @@
         }                                                                     \
       while (false)
 #  else
-#    define Assert(cond, exc)  \
-      do                       \
-        {                      \
-          if constexpr (false) \
-            if (!(cond))       \
-              {                \
-              }                \
-        }                      \
+#    define Assert(cond, exc) \
+      do                      \
+        {                     \
+          if (false)          \
+            if (!(cond))      \
+              {               \
+              }               \
+        }                     \
       while (false)
 #  endif
 #endif /*ifdef DEBUG*/


### PR DESCRIPTION
This is a follow-up to 0b04ac42897f03e31d7ce4aa0bcaf077df4a71ab: older versions of GCC print warnings when some variables are only used in an unreachable `if constexpr()` block.

See also

https://cdash.dealii.org/viewBuildError.php?type=1&buildid=2364

Follow-up to #18188.