### PR TITLE
Fix `IndexSet::make_petsc_is()`.

### DIFF
--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -1128,7 +1128,12 @@ IndexSet::make_petsc_is(const MPI_Comm communicator) const
   size_type             i = 0;
   std::vector<PetscInt> petsc_indices(n_elements());
   for (const auto &index : *this)
-    petsc_indices[i] = static_cast<PetscInt>(index);
+    {
+      const auto petsc_index = static_cast<PetscInt>(index);
+      AssertIntegerConversion(petsc_index, index);
+      petsc_indices[i] = petsc_index;
+      ++i;
+    }
 
   IS             is;
   PetscErrorCode ierr = ISCreateGeneral(

--- a/tests/petsc/index_set_01.cc
+++ b/tests/petsc/index_set_01.cc
@@ -1,0 +1,80 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 - 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// Verify that IndexSet::make_petsc_is() works
+
+#include <deal.II/base/index_set.h>
+#include <deal.II/base/mpi.h>
+
+#include <iostream>
+
+#include "../tests.h"
+
+void
+test(const IndexSet &index_set)
+{
+  IS is = index_set.make_petsc_is();
+
+  PetscInt size = 0;
+  auto     ierr = ISGetSize(is, &size);
+  AssertThrow(ierr == PETSC_SUCCESS, ExcPETScError(ierr));
+  deallog << "size = " << size << std::endl;
+
+  PetscInt local_size = 0;
+  ierr                = ISGetLocalSize(is, &local_size);
+  AssertThrow(ierr == PETSC_SUCCESS, ExcPETScError(ierr));
+  deallog << "local size = " << local_size << std::endl;
+
+  const PetscInt *local_entries = nullptr;
+  ierr                          = ISGetIndices(is, &local_entries);
+  AssertThrow(ierr == PETSC_SUCCESS, ExcPETScError(ierr));
+
+  deallog << "entries =" << std::endl;
+  for (PetscInt i = 0; i < local_size; ++i)
+    deallog << "  " << local_entries[i] << std::endl;
+
+  ierr = ISRestoreIndices(is, &local_entries);
+  AssertThrow(ierr == PETSC_SUCCESS, ExcPETScError(ierr));
+}
+
+
+int
+main(int argc, char **argv)
+{
+  initlog();
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  deallog << "testing empty IndexSet" << std::endl;
+  {
+    IndexSet index_set(100);
+    test(index_set);
+  }
+  deallog << std::endl;
+
+  deallog << "testing an IndexSet with holes" << std::endl;
+  {
+    IndexSet index_set(100);
+    index_set.add_range(10, 20);
+    index_set.add_range(90, 100);
+    test(index_set);
+  }
+  deallog << std::endl;
+
+  deallog << "testing a complete IndexSet" << std::endl;
+  {
+    IndexSet index_set = complete_index_set(100);
+    test(index_set);
+  }
+}

--- a/tests/petsc/index_set_01.output
+++ b/tests/petsc/index_set_01.output
@@ -1,0 +1,135 @@
+
+DEAL::testing empty IndexSet
+DEAL::size = 0
+DEAL::local size = 0
+DEAL::entries =
+DEAL::
+DEAL::testing an IndexSet with holes
+DEAL::size = 20
+DEAL::local size = 20
+DEAL::entries =
+DEAL::  10
+DEAL::  11
+DEAL::  12
+DEAL::  13
+DEAL::  14
+DEAL::  15
+DEAL::  16
+DEAL::  17
+DEAL::  18
+DEAL::  19
+DEAL::  90
+DEAL::  91
+DEAL::  92
+DEAL::  93
+DEAL::  94
+DEAL::  95
+DEAL::  96
+DEAL::  97
+DEAL::  98
+DEAL::  99
+DEAL::
+DEAL::testing a complete IndexSet
+DEAL::size = 100
+DEAL::local size = 100
+DEAL::entries =
+DEAL::  0
+DEAL::  1
+DEAL::  2
+DEAL::  3
+DEAL::  4
+DEAL::  5
+DEAL::  6
+DEAL::  7
+DEAL::  8
+DEAL::  9
+DEAL::  10
+DEAL::  11
+DEAL::  12
+DEAL::  13
+DEAL::  14
+DEAL::  15
+DEAL::  16
+DEAL::  17
+DEAL::  18
+DEAL::  19
+DEAL::  20
+DEAL::  21
+DEAL::  22
+DEAL::  23
+DEAL::  24
+DEAL::  25
+DEAL::  26
+DEAL::  27
+DEAL::  28
+DEAL::  29
+DEAL::  30
+DEAL::  31
+DEAL::  32
+DEAL::  33
+DEAL::  34
+DEAL::  35
+DEAL::  36
+DEAL::  37
+DEAL::  38
+DEAL::  39
+DEAL::  40
+DEAL::  41
+DEAL::  42
+DEAL::  43
+DEAL::  44
+DEAL::  45
+DEAL::  46
+DEAL::  47
+DEAL::  48
+DEAL::  49
+DEAL::  50
+DEAL::  51
+DEAL::  52
+DEAL::  53
+DEAL::  54
+DEAL::  55
+DEAL::  56
+DEAL::  57
+DEAL::  58
+DEAL::  59
+DEAL::  60
+DEAL::  61
+DEAL::  62
+DEAL::  63
+DEAL::  64
+DEAL::  65
+DEAL::  66
+DEAL::  67
+DEAL::  68
+DEAL::  69
+DEAL::  70
+DEAL::  71
+DEAL::  72
+DEAL::  73
+DEAL::  74
+DEAL::  75
+DEAL::  76
+DEAL::  77
+DEAL::  78
+DEAL::  79
+DEAL::  80
+DEAL::  81
+DEAL::  82
+DEAL::  83
+DEAL::  84
+DEAL::  85
+DEAL::  86
+DEAL::  87
+DEAL::  88
+DEAL::  89
+DEAL::  90
+DEAL::  91
+DEAL::  92
+DEAL::  93
+DEAL::  94
+DEAL::  95
+DEAL::  96
+DEAL::  97
+DEAL::  98
+DEAL::  99


### PR DESCRIPTION
This was broken by 7d152c7e59afedddaace5b0eadda463c1541096c - fortunately I spotted this during the meeting this morning when I mentioned the way we now check PETSc indices. I fixed it and added a more comprehensive test.