### PR TITLE
Avoid static variables and functions in header files.

### DIFF
--- a/bundled/kokkos-4.5.01/core/src/impl/Kokkos_Profiling_Interface.hpp
+++ b/bundled/kokkos-4.5.01/core/src/impl/Kokkos_Profiling_Interface.hpp
@@ -56,10 +56,10 @@ struct ExecutionSpaceIdentifier {
   uint32_t instance_id;
 };
 
-constexpr const uint32_t num_type_bits     = 8;
-constexpr const uint32_t num_device_bits   = 7;
-constexpr const uint32_t num_instance_bits = 17;
-constexpr const uint32_t num_avail_bits    = sizeof(uint32_t) * CHAR_BIT;
+inline constexpr const uint32_t num_type_bits     = 8;
+inline constexpr const uint32_t num_device_bits   = 7;
+inline constexpr const uint32_t num_instance_bits = 17;
+inline constexpr const uint32_t num_avail_bits    = sizeof(uint32_t) * CHAR_BIT;
 
 inline DeviceType devicetype_from_uint32t(const uint32_t in) {
   switch (in) {

--- a/bundled/kokkos-4.5.01/tpls/mdspan/include/experimental/__p0009_bits/extents.hpp
+++ b/bundled/kokkos-4.5.01/tpls/mdspan/include/experimental/__p0009_bits/extents.hpp
@@ -62,7 +62,7 @@ __check_compatible_extents(
 
 template<class IndexType, class ... Arguments>
 MDSPAN_INLINE_FUNCTION
-static constexpr bool are_valid_indices() {
+constexpr bool are_valid_indices() {
     return
       _MDSPAN_FOLD_AND(std::is_convertible<Arguments, IndexType>::value) &&
       _MDSPAN_FOLD_AND(std::is_nothrow_constructible<IndexType, Arguments>::value);

--- a/bundled/kokkos-4.5.01/tpls/mdspan/include/experimental/__p0009_bits/utility.hpp
+++ b/bundled/kokkos-4.5.01/tpls/mdspan/include/experimental/__p0009_bits/utility.hpp
@@ -46,7 +46,7 @@ constexpr bool rankwise_equal(with_rank<N>, const T1& x, const T2& y, F func)
   return match;
 }
 
-constexpr struct
+inline constexpr struct extent_t
 {
   template <class T, class I>
   MDSPAN_INLINE_FUNCTION
@@ -56,7 +56,7 @@ constexpr struct
   }
 } extent;
 
-constexpr struct
+inline constexpr struct stride_t
 {
   template <class T, class I>
   MDSPAN_INLINE_FUNCTION
@@ -166,7 +166,7 @@ tuple(Elements ...) -> tuple<Elements...>;
 #endif
 } // namespace detail
 
-constexpr struct mdspan_non_standard_tag {
+inline constexpr struct mdspan_non_standard_tag {
 } mdspan_non_standard;
 
 } // namespace MDSPAN_IMPL_STANDARD_NAMESPACE


### PR DESCRIPTION
This matches a recent patch to Kokkos, see https://github.com/kokkos/kokkos/pull/8071 and https://github.com/kokkos/mdspan/pull/403.

I need it for #18071.