### PR TITLE
Closed and oriented

### DIFF
--- a/source/cgal/surface_mesh.cc
+++ b/source/cgal/surface_mesh.cc
@@ -38,6 +38,7 @@ namespace
     const auto reference_cell_type = face->reference_cell();
     std::vector<typename CGAL_Mesh::Vertex_index> indices;
 
+
     if (reference_cell_type == ReferenceCells::Line)
       {
         mesh.add_edge(deal2cgal.at(face->vertex_index(0)),
@@ -48,20 +49,50 @@ namespace
         indices = {deal2cgal.at(face->vertex_index(0)),
                    deal2cgal.at(face->vertex_index(1)),
                    deal2cgal.at(face->vertex_index(2))};
+
+        if (clockwise_ordering == true)
+          std::reverse(indices.begin(), indices.end());
+
+        //+++++debug++++++
+        std::cout << "add_facet with clockwise_ordering " << clockwise_ordering << " :" << std::endl;
+        auto v0 = mesh.point(deal2cgal.at(face->vertex_index(0)));
+        auto v1 = mesh.point(deal2cgal.at(face->vertex_index(1)));
+        auto v2 = mesh.point(deal2cgal.at(face->vertex_index(2)));
+
+        std::cout << "( " << v0[0] << ", " << v0[1] << ", " << v0[2] << " )" <<std::endl;
+        std::cout << "( " << v1[0] << ", " << v1[1] << ", " << v1[2] << " )" <<std::endl;
+        std::cout << "( " << v2[0] << ", " << v2[1] << ", " << v2[2] << " )" <<std::endl;
+        //+++++debug++++++
       }
 
     else if (reference_cell_type == ReferenceCells::Quadrilateral)
-      {
+    {
+        
         indices = {deal2cgal.at(face->vertex_index(0)),
-                   deal2cgal.at(face->vertex_index(1)),
-                   deal2cgal.at(face->vertex_index(3)),
-                   deal2cgal.at(face->vertex_index(2))};
+          deal2cgal.at(face->vertex_index(2)),
+          deal2cgal.at(face->vertex_index(3)),
+          deal2cgal.at(face->vertex_index(1))};
+
+        if (clockwise_ordering == false)
+          std::reverse(indices.begin(), indices.end());
+
+
+        //+++++debug++++++
+        std::cout << "add_facet with clockwise_ordering " << clockwise_ordering << " :" << std::endl;
+        auto v0 = mesh.point(indices[0]);
+        auto v1 = mesh.point(indices[1]);
+        auto v2 = mesh.point(indices[2]);
+        auto v3 = mesh.point(indices[3]);
+        
+        std::cout << "( " << v0[0] << ", " << v0[1] << ", " << v0[2] << " )" <<std::endl;
+        std::cout << "( " << v1[0] << ", " << v1[1] << ", " << v1[2] << " )" <<std::endl;
+        std::cout << "( " << v2[0] << ", " << v2[1] << ", " << v2[2] << " )" <<std::endl;
+        std::cout << "( " << v3[0] << ", " << v3[1] << ", " << v3[2] << " )" <<std::endl;
+        //+++++debug++++++
       }
     else
       DEAL_II_ASSERT_UNREACHABLE();
 
-    if (clockwise_ordering == true)
-      std::reverse(indices.begin(), indices.end());
 
     [[maybe_unused]] const auto new_face = mesh.add_face(indices);
     Assert(new_face != mesh.null_face(),
@@ -81,9 +112,12 @@ namespace
   {
     for (const auto i : cell->vertex_indices())
       {
-        deal2cgal[cell->vertex_index(i)] = mesh.add_vertex(
-          CGALWrappers::dealii_point_to_cgal_point<typename CGAL_Mesh::Point>(
-            cell->vertex(i)));
+        if(deal2cgal.find(cell->vertex_index(i)) == deal2cgal.end())
+        {
+          deal2cgal[cell->vertex_index(i)] = mesh.add_vertex(
+            CGALWrappers::dealii_point_to_cgal_point<typename CGAL_Mesh::Point>(
+              cell->vertex(i)));
+        }
       }
   }
 } // namespace
@@ -178,15 +212,22 @@ namespace CGALWrappers
         for (const auto &cell : tria.active_cell_iterators())
           {
             for (const auto &f : cell->face_indices())
-
+            {
               if (cell->face(f)->at_boundary())
                 {
                   map_vertices(cell->face(f), deal2cgal, mesh);
-                  add_facet(cell->face(f),
-                            deal2cgal,
-                            mesh,
-                            (f % 2 == 0 || cell->n_vertices() != 8));
+  
+                  // Check for standard orientation of faces
+                  bool face_is_clockwise_oriented =
+                    cell->reference_cell() != ReferenceCells::Hexahedron ||
+                    (f % 2 == 0);
+                  // Make sure that we revert the orientation if required
+                  if (cell->face_orientation(f) == false)
+                    face_is_clockwise_oriented = !face_is_clockwise_oriented;
+  
+                  add_facet(cell->face(f), deal2cgal, mesh, face_is_clockwise_oriented);
                 }
+            }
           }
       }
     else

--- a/source/cgal/surface_mesh.cc
+++ b/source/cgal/surface_mesh.cc
@@ -55,20 +55,6 @@ namespace
 
         if (clockwise_ordering == true)
           std::reverse(indices.begin(), indices.end());
-
-        // if (clockwise_ordering == true)
-        //   std::reverse(indices.begin(), indices.end());
-
-        //+++++debug++++++
-        // std::cout << "add_facet with clockwise_ordering " << clockwise_ordering << " :" << std::endl;
-        // auto v0 = mesh.point(deal2cgal.at(face->vertex_index(0)));
-        // auto v1 = mesh.point(deal2cgal.at(face->vertex_index(1)));
-        // auto v2 = mesh.point(deal2cgal.at(face->vertex_index(2)));
-
-        // std::cout << "( " << v0[0] << ", " << v0[1] << ", " << v0[2] << " )" <<std::endl;
-        // std::cout << "( " << v1[0] << ", " << v1[1] << ", " << v1[2] << " )" <<std::endl;
-        // std::cout << "( " << v2[0] << ", " << v2[1] << ", " << v2[2] << " )" <<std::endl;
-        //+++++debug++++++
       }
 
     else if (reference_cell_type == ReferenceCells::Quadrilateral)
@@ -86,29 +72,9 @@ namespace
           deal2cgal.at(face->vertex_index(2))};
       }
         
-
-        // if (clockwise_ordering == false)
-        //   std::reverse(indices.begin(), indices.end());
-
-
-        // //+++++debug++++++
-        // std::cout << "add_facet with clockwise_ordering " << clockwise_ordering << " :" << std::endl;
-        // auto v0 = mesh.point(indices[0]);
-        // auto v1 = mesh.point(indices[1]);
-        // auto v2 = mesh.point(indices[2]);
-        // auto v3 = mesh.point(indices[3]);
-        
-        // std::cout << "( " << v0[0] << ", " << v0[1] << ", " << v0[2] << " )" <<std::endl;
-        // std::cout << "( " << v1[0] << ", " << v1[1] << ", " << v1[2] << " )" <<std::endl;
-        // std::cout << "( " << v2[0] << ", " << v2[1] << ", " << v2[2] << " )" <<std::endl;
-        // std::cout << "( " << v3[0] << ", " << v3[1] << ", " << v3[2] << " )" <<std::endl;
-        // //+++++debug++++++
-      }
+    }
     else
       DEAL_II_ASSERT_UNREACHABLE();
-
-    // if (clockwise_ordering == true)
-    //       std::reverse(indices.begin(), indices.end());
 
     [[maybe_unused]] const auto new_face = mesh.add_face(indices);
     Assert(new_face != mesh.null_face(),
@@ -231,16 +197,7 @@ namespace CGALWrappers
             {
               if (cell->face(f)->at_boundary())
                 {
-                  map_vertices(cell->face(f), deal2cgal, mesh);
-  
-                  // // Check for standard orientation of faces
-                  // bool face_is_clockwise_oriented =
-                  //   cell->reference_cell() != ReferenceCells::Hexahedron ||
-                  //   (f % 2 == 0);
-                  // // Make sure that we revert the orientation if required
-                  // if (cell->face_orientation(f) == false)
-                  //   face_is_clockwise_oriented = !face_is_clockwise_oriented;
-  
+                  map_vertices(cell->face(f), deal2cgal, mesh); 
                   add_facet(cell->face(f), deal2cgal, mesh, (f % 2 == 0 || cell->n_vertices() != 8));
                 }
             }

--- a/source/cgal/surface_mesh.cc
+++ b/source/cgal/surface_mesh.cc
@@ -43,6 +43,9 @@ namespace
       {
         mesh.add_edge(deal2cgal.at(face->vertex_index(0)),
                       deal2cgal.at(face->vertex_index(1)));
+
+        if (clockwise_ordering == true)
+          std::reverse(indices.begin(), indices.end());
       }
     else if (reference_cell_type == ReferenceCells::Triangle)
       {
@@ -53,46 +56,59 @@ namespace
         if (clockwise_ordering == true)
           std::reverse(indices.begin(), indices.end());
 
-        //+++++debug++++++
-        std::cout << "add_facet with clockwise_ordering " << clockwise_ordering << " :" << std::endl;
-        auto v0 = mesh.point(deal2cgal.at(face->vertex_index(0)));
-        auto v1 = mesh.point(deal2cgal.at(face->vertex_index(1)));
-        auto v2 = mesh.point(deal2cgal.at(face->vertex_index(2)));
+        // if (clockwise_ordering == true)
+        //   std::reverse(indices.begin(), indices.end());
 
-        std::cout << "( " << v0[0] << ", " << v0[1] << ", " << v0[2] << " )" <<std::endl;
-        std::cout << "( " << v1[0] << ", " << v1[1] << ", " << v1[2] << " )" <<std::endl;
-        std::cout << "( " << v2[0] << ", " << v2[1] << ", " << v2[2] << " )" <<std::endl;
+        //+++++debug++++++
+        // std::cout << "add_facet with clockwise_ordering " << clockwise_ordering << " :" << std::endl;
+        // auto v0 = mesh.point(deal2cgal.at(face->vertex_index(0)));
+        // auto v1 = mesh.point(deal2cgal.at(face->vertex_index(1)));
+        // auto v2 = mesh.point(deal2cgal.at(face->vertex_index(2)));
+
+        // std::cout << "( " << v0[0] << ", " << v0[1] << ", " << v0[2] << " )" <<std::endl;
+        // std::cout << "( " << v1[0] << ", " << v1[1] << ", " << v1[2] << " )" <<std::endl;
+        // std::cout << "( " << v2[0] << ", " << v2[1] << ", " << v2[2] << " )" <<std::endl;
         //+++++debug++++++
       }
 
     else if (reference_cell_type == ReferenceCells::Quadrilateral)
-    {
-        
+    { 
+      if (clockwise_ordering == true)
+      {
         indices = {deal2cgal.at(face->vertex_index(0)),
           deal2cgal.at(face->vertex_index(2)),
           deal2cgal.at(face->vertex_index(3)),
           deal2cgal.at(face->vertex_index(1))};
-
-        if (clockwise_ordering == false)
-          std::reverse(indices.begin(), indices.end());
-
-
-        //+++++debug++++++
-        std::cout << "add_facet with clockwise_ordering " << clockwise_ordering << " :" << std::endl;
-        auto v0 = mesh.point(indices[0]);
-        auto v1 = mesh.point(indices[1]);
-        auto v2 = mesh.point(indices[2]);
-        auto v3 = mesh.point(indices[3]);
+      }else{
+        indices = {deal2cgal.at(face->vertex_index(0)),
+          deal2cgal.at(face->vertex_index(1)),
+          deal2cgal.at(face->vertex_index(3)),
+          deal2cgal.at(face->vertex_index(2))};
+      }
         
-        std::cout << "( " << v0[0] << ", " << v0[1] << ", " << v0[2] << " )" <<std::endl;
-        std::cout << "( " << v1[0] << ", " << v1[1] << ", " << v1[2] << " )" <<std::endl;
-        std::cout << "( " << v2[0] << ", " << v2[1] << ", " << v2[2] << " )" <<std::endl;
-        std::cout << "( " << v3[0] << ", " << v3[1] << ", " << v3[2] << " )" <<std::endl;
-        //+++++debug++++++
+
+        // if (clockwise_ordering == false)
+        //   std::reverse(indices.begin(), indices.end());
+
+
+        // //+++++debug++++++
+        // std::cout << "add_facet with clockwise_ordering " << clockwise_ordering << " :" << std::endl;
+        // auto v0 = mesh.point(indices[0]);
+        // auto v1 = mesh.point(indices[1]);
+        // auto v2 = mesh.point(indices[2]);
+        // auto v3 = mesh.point(indices[3]);
+        
+        // std::cout << "( " << v0[0] << ", " << v0[1] << ", " << v0[2] << " )" <<std::endl;
+        // std::cout << "( " << v1[0] << ", " << v1[1] << ", " << v1[2] << " )" <<std::endl;
+        // std::cout << "( " << v2[0] << ", " << v2[1] << ", " << v2[2] << " )" <<std::endl;
+        // std::cout << "( " << v3[0] << ", " << v3[1] << ", " << v3[2] << " )" <<std::endl;
+        // //+++++debug++++++
       }
     else
       DEAL_II_ASSERT_UNREACHABLE();
 
+    // if (clockwise_ordering == true)
+    //       std::reverse(indices.begin(), indices.end());
 
     [[maybe_unused]] const auto new_face = mesh.add_face(indices);
     Assert(new_face != mesh.null_face(),
@@ -217,15 +233,15 @@ namespace CGALWrappers
                 {
                   map_vertices(cell->face(f), deal2cgal, mesh);
   
-                  // Check for standard orientation of faces
-                  bool face_is_clockwise_oriented =
-                    cell->reference_cell() != ReferenceCells::Hexahedron ||
-                    (f % 2 == 0);
-                  // Make sure that we revert the orientation if required
-                  if (cell->face_orientation(f) == false)
-                    face_is_clockwise_oriented = !face_is_clockwise_oriented;
+                  // // Check for standard orientation of faces
+                  // bool face_is_clockwise_oriented =
+                  //   cell->reference_cell() != ReferenceCells::Hexahedron ||
+                  //   (f % 2 == 0);
+                  // // Make sure that we revert the orientation if required
+                  // if (cell->face_orientation(f) == false)
+                  //   face_is_clockwise_oriented = !face_is_clockwise_oriented;
   
-                  add_facet(cell->face(f), deal2cgal, mesh, face_is_clockwise_oriented);
+                  add_facet(cell->face(f), deal2cgal, mesh, (f % 2 == 0 || cell->n_vertices() != 8));
                 }
             }
           }

--- a/tests/cgal/cgal_remesh_surface.cc
+++ b/tests/cgal/cgal_remesh_surface.cc
@@ -28,6 +28,10 @@
 #include <deal.II/cgal/triangulation.h>
 #include <string.h>
 
+//added
+#include <CGAL/Polygon_mesh_processing/orientation.h>
+//added
+
 #include "../tests.h"
 
 using namespace CGALWrappers;
@@ -65,9 +69,25 @@ test()
   dealii_tria_to_cgal_surface_mesh(tria0, surface_mesh0);
   dealii_tria_to_cgal_surface_mesh(tria1, surface_mesh1);
 
+  //Added (now commented out since not needed anymore)
   // close the surfaces
-  CGAL::Polygon_mesh_processing::stitch_borders(surface_mesh0);
-  CGAL::Polygon_mesh_processing::stitch_borders(surface_mesh1);
+  //CGAL::Polygon_mesh_processing::stitch_borders(surface_mesh0);
+  //CGAL::Polygon_mesh_processing::stitch_borders(surface_mesh1);
+  //Added (now commented out since not needed anymore)
+
+  
+  //Added
+  Assert(surface_mesh0.is_valid() && surface_mesh1.is_valid(),
+             ExcMessage("The CGAL surface mesh is not valid."));
+  if(dim == 3)
+  {
+    Assert(CGAL::is_closed(surface_mesh0) && CGAL::is_closed(surface_mesh1)
+          ,dealii::ExcMessage("The CGAL mesh is not closed"));
+    Assert(CGAL::Polygon_mesh_processing::is_outward_oriented(surface_mesh0) &&
+          CGAL::Polygon_mesh_processing::is_outward_oriented(surface_mesh1)
+          ,dealii::ExcMessage("The normal vectors of the CGAL mesh are not oriented outwards"));
+  }
+  //Added
 
   CGAL::Polygon_mesh_processing::triangulate_faces(surface_mesh0);
   CGAL::Polygon_mesh_processing::triangulate_faces(surface_mesh1);

--- a/tests/cgal/cgal_surface_mesh_01.cc
+++ b/tests/cgal/cgal_surface_mesh_01.cc
@@ -62,11 +62,18 @@ test()
       Assert(mesh.is_valid(), dealii::ExcMessage("The CGAL mesh is not valid"));
 
       //Added
-      //doesn t work for Wege
-      if(dim == 3 && r_cell != ref_cells[3][2])
+      if(dim == 3)
       {
-        Assert(CGAL::is_closed(mesh), dealii::ExcMessage("The CGAL mesh is not closed"));
-        Assert(CGAL::Polygon_mesh_processing::is_outward_oriented(mesh) , dealii::ExcMessage("The normal vectors of the CGAL mesh are not oriented outwards"));
+        Assert(CGAL::is_closed(mesh),
+          dealii::ExcMessage("The CGAL mesh is not closed"));
+
+        //orientation not supported for wedges, this needs special treatment
+        if(r_cell != ref_cells[3][2])
+        {
+          Assert(CGAL::Polygon_mesh_processing::is_outward_oriented(mesh),
+            dealii::ExcMessage(
+              "The normal vectors of the CGAL mesh are not oriented outwards"));
+        }
       }
       //Added
 

--- a/tests/cgal/cgal_surface_mesh_01.cc
+++ b/tests/cgal/cgal_surface_mesh_01.cc
@@ -26,6 +26,10 @@
 #include <CGAL/IO/io.h>
 #include <deal.II/cgal/surface_mesh.h>
 
+//added
+#include <CGAL/Polygon_mesh_processing/orientation.h>
+//added
+
 #include "../tests.h"
 
 
@@ -56,6 +60,16 @@ test()
       dealii_cell_to_cgal_surface_mesh(cell, *mapping, mesh);
 
       Assert(mesh.is_valid(), dealii::ExcMessage("The CGAL mesh is not valid"));
+
+      //Added
+      //doesn t work for Wege
+      if(dim == 3 && r_cell != ref_cells[3][2])
+      {
+        Assert(CGAL::is_closed(mesh), dealii::ExcMessage("The CGAL mesh is not closed"));
+        Assert(CGAL::Polygon_mesh_processing::is_outward_oriented(mesh) , dealii::ExcMessage("The normal vectors of the CGAL mesh are not oriented outwards"));
+      }
+      //Added
+
       deallog << "deal vertices: " << cell->n_vertices() << ", cgal vertices "
               << mesh.num_vertices() << std::endl;
       deallog << "deal faces: " << cell->n_faces() << ", cgal faces "

--- a/tests/cgal/cgal_surface_mesh_04.cc
+++ b/tests/cgal/cgal_surface_mesh_04.cc
@@ -28,6 +28,10 @@
 #include <deal.II/cgal/triangulation.h>
 #include <string.h>
 
+//added
+#include <CGAL/Polygon_mesh_processing/orientation.h>
+//added
+
 #include "../tests.h"
 
 using namespace CGALWrappers;
@@ -50,14 +54,14 @@ test()
   if constexpr (spacedim == 2)
     {
       names_and_args = {{"hyper_cube", "0.0 : 1.0 : false"},
-                        {"hyper_ball", "0.,0. : 1. : false"},
+                        {"hyper_ball", "0.,0. : 1. : false"}, 
                         {"hyper_L", "0.0 : 1.0 : false"},
                         {"channel_with_cylinder", "0.03 : 2 : 2.0 : false"}};
     }
   else
     {
       names_and_args = {{"hyper_cube", "0.0 : 1.0 : false"},
-                        {"hyper_ball", "0.,0.,0. : 1. : false"},
+                        {"hyper_ball", "0.,0.,0. : 1. : false"}, 
                         {"hyper_L", "0.0 : 1.0 : false"},
                         {"channel_with_cylinder", "0.03 : 2 : 2.0 : false"}};
     }
@@ -74,6 +78,17 @@ test()
       dealii_tria_to_cgal_surface_mesh(tria_in, surface_mesh);
       Assert(surface_mesh.is_valid(),
              ExcMessage("The CGAL surface mesh is not valid."));
+
+      //Added
+      //CGAL::Polygon_mesh_processing::triangulate_faces(surface_mesh);
+      if(dim == 3)
+      {
+        Assert(CGAL::is_closed(surface_mesh)
+              ,dealii::ExcMessage("The CGAL mesh is not closed"));
+        Assert(CGAL::Polygon_mesh_processing::is_outward_oriented(surface_mesh)
+              ,dealii::ExcMessage("The normal vectors of the CGAL mesh are not oriented outwards"));
+      }
+      //Added
 
       // Now back to the original dealii tria.
       cgal_surface_mesh_to_dealii_triangulation(surface_mesh, tria_out);

--- a/tests/cgal/cgal_surface_mesh_05.cc
+++ b/tests/cgal/cgal_surface_mesh_05.cc
@@ -57,8 +57,8 @@ test()
   dealii_tria_to_cgal_surface_mesh(tria1, surface_mesh1);
 
   // close the surfaces
-  CGAL::Polygon_mesh_processing::stitch_borders(surface_mesh0);
-  CGAL::Polygon_mesh_processing::stitch_borders(surface_mesh1);
+  //CGAL::Polygon_mesh_processing::stitch_borders(surface_mesh0);
+  //CGAL::Polygon_mesh_processing::stitch_borders(surface_mesh1);
 
   CGAL::Polygon_mesh_processing::triangulate_faces(surface_mesh0);
   CGAL::Polygon_mesh_processing::triangulate_faces(surface_mesh1);


### PR DESCRIPTION
The two functions in the namespace CGALWrappers both have a nonintuitive return:
void CGALWrappers::dealii_cell_to_cgal_surface_mesh  (1)
void CGALWrappers::dealii_tria_to_cgal_surface_mesh  (2)

Both these functions return a CGAL::Surface_mesh<CGALPointType> that needs manual postprocessing before using other functions of the CGALWrappers namespace i.e. the boolean operations.

Problem1:  The function (1) above return non closed Surface_meshes for application on 3D meshes:

The dealii vertices are added to the Surface mesh in a loop over all faces. Since faces share vertices the same points are added multiple times to the Surface_mesh. The resulting Surface_mesh consits of faces where each has its own vertices but no shared veritces that would connect the faces to a closed surface.

Solution1: Change in Surface_mesh.cc the function map_vertices



Problem2: For both funcitons (1) and (2) the returned Surface_mesh has "not orientabe" problem when using cgal_surface_mesh_to_cgal_triangulation()

Because of solution 1 the Surface_mesh edge between two adjacent faces is now one edge and not two edges on top of each other. As a result the dealii convention needs a vertex numbering such that the orientation of this edge is the same for both faces. For triangles nothing needs to be changed but for quadrilaterals in the clockwise ordering case all indices need to be shifted by one compared to the original implementation. 

Solution2: Change in Surface_mesh.cc the function add_facet


Note on test cases:
Including new tests with is_closed() and is_oriented() on the returned Surface_mesh of these functions shows that the problems are solved.
In test case cgal_surface_mesh_05.cc the post processing with CGAL::Polygon_mesh_processing::stitch_borders is not needed anymore, the surface meshes are now naturally closed.

Note on use of CGALWrappers function compute_boolean_operation:
However note that in case of quadrilateral meshes working with the CGALWrappers still requires to make use of the function CGAL::Polygon_mesh_processing::triangulate_faces since the boolean operations only work on triangulated meshes.


