### PR TITLE
Add additional data to MUMPS interface

### DIFF
--- a/doc/news/changes/minor/20250520Polverino
+++ b/doc/news/changes/minor/20250520Polverino
@@ -1,0 +1,4 @@
+Improved: The SparseDirectMUMPS class now takes an AdditionalData to
+control the MUMPS execution.
+<br>
+(Davide Polverino, 2025/05/20)

--- a/source/lac/sparse_direct.cc
+++ b/source/lac/sparse_direct.cc
@@ -861,9 +861,56 @@ SparseDirectUMFPACK::n() const
 
 #ifdef DEAL_II_WITH_MUMPS
 
-SparseDirectMUMPS::SparseDirectMUMPS()
-  : initialize_called(false)
-{}
+SparseDirectMUMPS::SparseDirectMUMPS(const AdditionalData &data)
+{
+  this->additional_data = data;
+  // Initialize MUMPS instance:
+  id.job = -1;
+  id.par = 1;
+
+  Assert(!(additional_data.symmetric == false &&
+           additional_data.posdef == true),
+         ExcMessage(
+           "You can't have a positive definite matrix that is not symmetric."));
+
+  if (additional_data.symmetric == true)
+    {
+      if (additional_data.posdef == true)
+        id.sym = 1;
+      else
+        id.sym = 2;
+    }
+  else
+    id.sym = 0;
+
+  // Use MPI_COMM_WORLD as communicator
+  id.comm_fortran = -987654;
+  dmumps_c(&id);
+
+  if (additional_data.output_details == false)
+    {
+      // No outputs
+      id.icntl[0] = -1;
+      id.icntl[1] = -1;
+      id.icntl[2] = -1;
+      id.icntl[3] = 0;
+    }
+
+  if (additional_data.error_statistics == true)
+    id.icntl[10] = 2;
+
+  if (additional_data.blr_factorization == true)
+    {
+      id.icntl[34] = 2;
+      if (additional_data.blr.blr_ucfs == true)
+        id.icntl[35] = 1;
+      Assert(additional_data.blr.lowrank_threshold > 0,
+             ExcMessage("Lowrank threshold must be positive."));
+      id.cntl[6] = additional_data.blr.lowrank_threshold;
+    }
+}
+
+
 
 SparseDirectMUMPS::~SparseDirectMUMPS()
 {
@@ -879,93 +926,81 @@ SparseDirectMUMPS::~SparseDirectMUMPS()
     }
 }
 
+
+
 template <class Matrix>
 void
 SparseDirectMUMPS::initialize_matrix(const Matrix &matrix)
 {
   Assert(matrix.n() == matrix.m(), ExcMessage("Matrix needs to be square."));
 
-
-  // Check we haven't been here before:
-  Assert(initialize_called == false, ExcInitializeAlreadyCalled());
-
-  // Initialize MUMPS instance:
-  id.job = -1;
-  id.par = 1;
-  id.sym = 0;
-
-  // Use MPI_COMM_WORLD as communicator
-  id.comm_fortran = -987654;
-  dmumps_c(&id);
-
-  // Hand over matrix and right-hand side
+  // Hand over matrix to MUMPS as centralized assembled matrix
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     {
-      // Objects denoting a MUMPS data structure:
-      //
       // Set number of unknowns
       n = matrix.n();
 
       // number of nonzero elements in matrix
-      nz = matrix.n_actually_nonzero_elements();
+      nnz = matrix.n_actually_nonzero_elements();
 
       // representation of the matrix
-      a = new double[nz];
+      a = new double[nnz];
 
       // matrix indices pointing to the row and column dimensions
       // respectively of the matrix representation above (a): ie. a[k] is
       // the matrix element (irn[k], jcn[k])
-      irn = new int[nz];
-      jcn = new int[nz];
+      irn = new int[nnz];
+      jcn = new int[nnz];
 
-      size_type index = 0;
+      size_type n_non_zero_elements = 0;
 
       // loop over the elements of the matrix row by row, as suggested in
       // the documentation of the sparse matrix iterator class
-      for (size_type row = 0; row < matrix.m(); ++row)
+      if (additional_data.symmetric == true)
         {
-          for (typename Matrix::const_iterator ptr = matrix.begin(row);
-               ptr != matrix.end(row);
-               ++ptr)
-            if (std::abs(ptr->value()) > 0.0)
-              {
-                a[index]   = ptr->value();
-                irn[index] = row + 1;
-                jcn[index] = ptr->column() + 1;
-                ++index;
-              }
-        }
+          for (size_type row = 0; row < matrix.m(); ++row)
+            {
+              for (typename Matrix::const_iterator ptr = matrix.begin(row);
+                   ptr != matrix.end(row);
+                   ++ptr)
+                if (std::abs(ptr->value()) > 0.0 && ptr->column() >= row)
+                  {
+                    a[n_non_zero_elements]   = ptr->value();
+                    irn[n_non_zero_elements] = row + 1;
+                    jcn[n_non_zero_elements] = ptr->column() + 1;
 
+                    ++n_non_zero_elements;
+                  }
+            }
+        }
+      else
+        {
+          for (size_type row = 0; row < matrix.m(); ++row)
+            {
+              for (typename Matrix::const_iterator ptr = matrix.begin(row);
+                   ptr != matrix.end(row);
+                   ++ptr)
+                if (std::abs(ptr->value()) > 0.0)
+                  {
+                    a[n_non_zero_elements]   = ptr->value();
+                    irn[n_non_zero_elements] = row + 1;
+                    jcn[n_non_zero_elements] = ptr->column() + 1;
+                    ++n_non_zero_elements;
+                  }
+            }
+        }
       id.n   = n;
-      id.nz  = nz;
+      id.nnz = n_non_zero_elements;
       id.irn = irn;
       id.jcn = jcn;
       id.a   = a;
     }
-
-  // No outputs
-  id.icntl[0] = -1;
-  id.icntl[1] = -1;
-  id.icntl[2] = -1;
-  id.icntl[3] = 0;
-
-  // Exit by setting this flag:
-  initialize_called = true;
 }
 
-template <class Matrix>
-void
-SparseDirectMUMPS::initialize(const Matrix         &matrix,
-                              const Vector<double> &vector)
-{
-  // Hand over matrix and right-hand side
-  initialize_matrix(matrix);
 
-  copy_rhs_to_mumps(vector);
-}
 
 void
-SparseDirectMUMPS::copy_rhs_to_mumps(const Vector<double> &new_rhs)
+SparseDirectMUMPS::copy_rhs_to_mumps(const Vector<double> &new_rhs) const
 {
   Assert(n == new_rhs.size(),
          ExcMessage("Matrix size and rhs length must be equal."));
@@ -980,8 +1015,10 @@ SparseDirectMUMPS::copy_rhs_to_mumps(const Vector<double> &new_rhs)
     }
 }
 
+
+
 void
-SparseDirectMUMPS::copy_solution(Vector<double> &vector)
+SparseDirectMUMPS::copy_solution(Vector<double> &vector) const
 {
   Assert(n == vector.size(),
          ExcMessage("Matrix size and solution vector length must be equal."));
@@ -998,44 +1035,27 @@ SparseDirectMUMPS::copy_solution(Vector<double> &vector)
     }
 }
 
+
+
 template <class Matrix>
 void
 SparseDirectMUMPS::initialize(const Matrix &matrix)
 {
   // Initialize MUMPS instance:
   initialize_matrix(matrix);
-  // Start factorization
+
+  // Start analysis + factorization
   id.job = 4;
   dmumps_c(&id);
 }
 
-void
-SparseDirectMUMPS::solve(Vector<double> &vector)
-{
-  // TODO: this could be implemented similar to SparseDirectUMFPACK where
-  //  the given vector will be used as the RHS. Sadly, there is no easy
-  //  way to do this without breaking the interface.
 
-  // Check that the solver has been initialized by the routine above:
-  Assert(initialize_called == true, ExcNotInitialized());
-
-  // and that the matrix has at least one nonzero element:
-  Assert(nz != 0, ExcNotInitialized());
-
-  // Start solver
-  id.job = 6; // 6 = analysis, factorization, and solve
-  dmumps_c(&id);
-  copy_solution(vector);
-}
 
 void
-SparseDirectMUMPS::vmult(Vector<double> &dst, const Vector<double> &src)
+SparseDirectMUMPS::vmult(Vector<double> &dst, const Vector<double> &src) const
 {
-  // Check that the solver has been initialized by the routine above:
-  Assert(initialize_called == true, ExcNotInitialized());
-
   // and that the matrix has at least one nonzero element:
-  Assert(nz != 0, ExcNotInitialized());
+  Assert(nnz != 0, ExcNotInitialized());
 
   Assert(n == dst.size(), ExcMessage("Destination vector has the wrong size."));
   Assert(n == src.size(), ExcMessage("Source vector has the wrong size."));
@@ -1049,7 +1069,38 @@ SparseDirectMUMPS::vmult(Vector<double> &dst, const Vector<double> &src)
   copy_solution(dst);
 }
 
+
+
+void
+SparseDirectMUMPS::Tvmult(Vector<double> &dst, const Vector<double> &src) const
+{
+  // The matrix has at least one nonzero element:
+  Assert(nnz != 0, ExcNotInitialized());
+
+  Assert(n == dst.size(), ExcMessage("Destination vector has the wrong size."));
+  Assert(n == src.size(), ExcMessage("Source vector has the wrong size."));
+
+  id.icntl[8] = 2; // transpose
+  // Hand over right-hand side
+  copy_rhs_to_mumps(src);
+
+  // Start solver
+  id.job = 3;
+  dmumps_c(&id);
+  copy_solution(dst);
+  id.icntl[8] = 1; // reset to default
+}
+
+
+
+int *
+SparseDirectMUMPS::get_icntl()
+{
+  return id.icntl;
+}
+
 #endif // DEAL_II_WITH_MUMPS
+
 
 
 // explicit instantiations for SparseMatrixUMFPACK
@@ -1087,9 +1138,7 @@ InstantiateUMFPACK(BlockSparseMatrix<std::complex<float>>);
 
 // explicit instantiations for SparseDirectMUMPS
 #ifdef DEAL_II_WITH_MUMPS
-#  define InstantiateMUMPS(MATRIX)                                       \
-    template void SparseDirectMUMPS::initialize(const MATRIX &,          \
-                                                const Vector<double> &); \
+#  define InstantiateMUMPS(MATRIX) \
     template void SparseDirectMUMPS::initialize(const MATRIX &);
 
 InstantiateMUMPS(SparseMatrix<double>) InstantiateMUMPS(SparseMatrix<float>)

--- a/tests/mumps/mumps_01.output
+++ b/tests/mumps/mumps_01.output
@@ -1,25 +1,24 @@
-
 DEAL::1d
 DEAL::Number of dofs = 193
-DEAL::relative norm distance = 2.06357e-16
-DEAL::absolute norms = 6.36406e-13 3084.00
-DEAL::relative norm distance = 2.28670e-16
-DEAL::absolute norms = 1.76304e-12 7709.99
-DEAL::relative norm distance = 2.28670e-16
-DEAL::absolute norms = 3.52609e-12 15420.0
+DEAL::relative norm distance = 2.47865e-16
+DEAL::absolute norms = 7.64416e-13 3084.00
+DEAL::relative norm distance = 2.34248e-16
+DEAL::absolute norms = 1.80605e-12 7709.99
+DEAL::relative norm distance = 2.34248e-16
+DEAL::absolute norms = 3.61211e-12 15420.0
 DEAL::2d
 DEAL::Number of dofs = 1889
-DEAL::relative norm distance = 5.07512e-16
-DEAL::absolute norms = 4.80941e-11 94764.3
-DEAL::relative norm distance = 5.30372e-16
-DEAL::absolute norms = 1.25651e-10 236911.
-DEAL::relative norm distance = 5.30372e-16
-DEAL::absolute norms = 2.51302e-10 473822.
+DEAL::relative norm distance = 4.92318e-16
+DEAL::absolute norms = 4.66541e-11 94764.3
+DEAL::relative norm distance = 4.64003e-16
+DEAL::absolute norms = 1.09927e-10 236911.
+DEAL::relative norm distance = 4.65511e-16
+DEAL::absolute norms = 2.20569e-10 473822.
 DEAL::3d
 DEAL::Number of dofs = 1333
-DEAL::relative norm distance = 1.33240e-15
-DEAL::absolute norms = 7.48349e-11 56165.6
-DEAL::relative norm distance = 1.27330e-15
-DEAL::absolute norms = 1.78789e-10 140414.
-DEAL::relative norm distance = 1.27330e-15
-DEAL::absolute norms = 3.57579e-10 280828.
+DEAL::relative norm distance = 1.21148e-15
+DEAL::absolute norms = 6.80433e-11 56165.6
+DEAL::relative norm distance = 1.43450e-15
+DEAL::absolute norms = 2.01424e-10 140414.
+DEAL::relative norm distance = 1.43535e-15
+DEAL::absolute norms = 4.03086e-10 280828.

--- a/tests/mumps/mumps_02.cc
+++ b/tests/mumps/mumps_02.cc
@@ -1,17 +1,16 @@
-// ---------------------------------------------------------------------
+// ------------------------------------------------------------------------
 //
-// Copyright (C) 2002 - 2013 by the deal.II authors
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2001 - 2024 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
-// The deal.II library is free software; you can use it, redistribute
-// it, and/or modify it under the terms of the GNU Lesser General
-// Public License as published by the Free Software Foundation; either
-// version 2.1 of the License, or (at your option) any later version.
-// The full text of the license can be found in the file LICENSE at
-// the top level of the deal.II distribution.
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
 //
-// ---------------------------------------------------------------------
+// ------------------------------------------------------------------------
 
 
 // test the mumps sparse direct solver on a mass matrix
@@ -92,8 +91,8 @@ test()
       B.vmult(b, solution);
 
       SparseDirectMUMPS solver;
-      solver.initialize(B, b);
-      solver.solve(x);
+      solver.initialize(B);
+      solver.vmult(x, b);
 
       x -= solution;
       deallog << "relative norm distance = " << x.l2_norm() / solution.l2_norm()

--- a/tests/mumps/mumps_02.output
+++ b/tests/mumps/mumps_02.output
@@ -1,25 +1,24 @@
-
 DEAL::1d
 DEAL::Number of dofs = 193
-DEAL::relative norm distance = 0
-DEAL::absolute norms = 0 3084.00
-DEAL::relative norm distance = 0
-DEAL::absolute norms = 0 7709.99
-DEAL::relative norm distance = 0
-DEAL::absolute norms = 0 15420.0
+DEAL::relative norm distance = 2.47865e-16
+DEAL::absolute norms = 7.64416e-13 3084.00
+DEAL::relative norm distance = 2.34248e-16
+DEAL::absolute norms = 1.80605e-12 7709.99
+DEAL::relative norm distance = 2.34248e-16
+DEAL::absolute norms = 3.61211e-12 15420.0
 DEAL::2d
 DEAL::Number of dofs = 1889
-DEAL::relative norm distance = 0
-DEAL::absolute norms = 0 94764.3
-DEAL::relative norm distance = 0
-DEAL::absolute norms = 0 236911.
-DEAL::relative norm distance = 0
-DEAL::absolute norms = 0 473822.
+DEAL::relative norm distance = 4.96258e-16
+DEAL::absolute norms = 4.70275e-11 94764.3
+DEAL::relative norm distance = 4.64464e-16
+DEAL::absolute norms = 1.10036e-10 236911.
+DEAL::relative norm distance = 4.65627e-16
+DEAL::absolute norms = 2.20624e-10 473822.
 DEAL::3d
 DEAL::Number of dofs = 1333
-DEAL::relative norm distance = 0
-DEAL::absolute norms = 0 56165.6
-DEAL::relative norm distance = 0
-DEAL::absolute norms = 0 140414.
-DEAL::relative norm distance = 0
-DEAL::absolute norms = 0 280828.
+DEAL::relative norm distance = 1.21940e-15
+DEAL::absolute norms = 6.84883e-11 56165.6
+DEAL::relative norm distance = 1.43458e-15
+DEAL::absolute norms = 2.01434e-10 140414.
+DEAL::relative norm distance = 1.43902e-15
+DEAL::absolute norms = 4.04117e-10 280828.

--- a/tests/mumps/mumps_03.output
+++ b/tests/mumps/mumps_03.output
@@ -1,0 +1,24 @@
+DEAL::1d
+DEAL::Number of dofs = 193
+DEAL::relative norm distance = 2.50020e-16
+DEAL::absolute norms = 7.71061e-13 3084.00
+DEAL::relative norm distance = 2.26119e-16
+DEAL::absolute norms = 1.74338e-12 7709.99
+DEAL::relative norm distance = 2.26119e-16
+DEAL::absolute norms = 3.48675e-12 15420.0
+DEAL::2d
+DEAL::Number of dofs = 1889
+DEAL::relative norm distance = 4.62992e-16
+DEAL::absolute norms = 4.38751e-11 94764.3
+DEAL::relative norm distance = 4.44464e-16
+DEAL::absolute norms = 1.05298e-10 236911.
+DEAL::relative norm distance = 4.46851e-16
+DEAL::absolute norms = 2.11727e-10 473822.
+DEAL::3d
+DEAL::Number of dofs = 1333
+DEAL::relative norm distance = 1.27339e-15
+DEAL::absolute norms = 7.15208e-11 56165.6
+DEAL::relative norm distance = 1.13118e-15
+DEAL::absolute norms = 1.58833e-10 140414.
+DEAL::relative norm distance = 1.12371e-15
+DEAL::absolute norms = 3.15569e-10 280828.

--- a/tests/mumps/mumps_04.cc
+++ b/tests/mumps/mumps_04.cc
@@ -13,7 +13,7 @@
 // ------------------------------------------------------------------------
 
 // test the mumps sparse direct solver on a mass matrix
-// - check ways to solve
+// - check several ways to solve, also using block low rank preconditioning
 
 #include <deal.II/base/function.h>
 #include <deal.II/base/quadrature_lib.h>
@@ -26,10 +26,13 @@
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria.h>
 
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/solver_control.h>
 #include <deal.II/lac/sparse_direct.h>
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/sparsity_pattern.h>
 #include <deal.II/lac/vector.h>
+#include <deal.II/lac/vector_memory.h>
 
 #include <deal.II/numerics/matrix_tools.h>
 #include <deal.II/numerics/vector_tools.h>
@@ -47,7 +50,13 @@ solve_and_check(const SparseMatrix<double> &M,
                 const Vector<double>       &solution)
 {
   {
-    SparseDirectMUMPS solver;
+    int                              *icntl = nullptr;
+    SparseDirectMUMPS::AdditionalData data;
+    data.output_details = false;
+    SparseDirectMUMPS solver(data);
+    icntl = solver.get_icntl();
+    std::cout << "Elementi di icntl " << icntl[7] << " " << icntl[8] << " "
+              << icntl[9] << std::endl;
     solver.initialize(M);
     Vector<double> dst(rhs.size());
     solver.vmult(dst, rhs);
@@ -55,6 +64,8 @@ solve_and_check(const SparseMatrix<double> &M,
     Assert(dst.l2_norm() < 1e-9, ExcInternalError());
   }
 }
+
+
 
 template <int dim>
 void
@@ -92,7 +103,15 @@ test()
   MatrixTools::create_mass_matrix(dof_handler, qr, B);
 
   // compute a decomposition of the matrix
-  SparseDirectMUMPS Binv;
+  SparseDirectMUMPS::AdditionalData data;
+  data.blr_factorization = true;
+  SparseDirectMUMPS::AdditionalData::BlockLowRank blr;
+  blr.blr_ucfs          = false;
+  blr.lowrank_threshold = 1e-8;
+  data.output_details   = false;
+  data.error_statistics = false;
+  SparseDirectMUMPS Binv(data);
+
   Binv.initialize(B);
 
   // for a number of different solution
@@ -109,7 +128,13 @@ test()
 
       B.vmult(b, solution);
 
-      Binv.vmult(x, b);
+      SolverControl            solver_control(1000, 1e-8);
+      SolverCG<Vector<double>> solver(solver_control);
+
+      solver.solve(B, x, b, Binv);
+
+      deallog << "Number of preconditioned CG iterations = "
+              << solver_control.last_step() << std::endl;
 
       x -= solution;
       deallog << "relative norm distance = " << x.l2_norm() / solution.l2_norm()
@@ -118,8 +143,6 @@ test()
               << std::endl;
       Assert(x.l2_norm() / solution.l2_norm() < 1e-8, ExcInternalError());
 
-
-      // also check solving in different ways:
       solve_and_check(B, b, solution);
     }
 }

--- a/tests/mumps/mumps_04.output
+++ b/tests/mumps/mumps_04.output
@@ -1,0 +1,33 @@
+DEAL::1d
+DEAL::Number of dofs = 193
+DEAL::Number of preconditioned CG iterations = 1
+DEAL::relative norm distance = 2.47865e-16
+DEAL::absolute norms = 7.64416e-13 3084.00
+DEAL::Number of preconditioned CG iterations = 1
+DEAL::relative norm distance = 2.34248e-16
+DEAL::absolute norms = 1.80605e-12 7709.99
+DEAL::Number of preconditioned CG iterations = 1
+DEAL::relative norm distance = 2.34248e-16
+DEAL::absolute norms = 3.61211e-12 15420.0
+DEAL::2d
+DEAL::Number of dofs = 1889
+DEAL::Number of preconditioned CG iterations = 1
+DEAL::relative norm distance = 5.48214e-16
+DEAL::absolute norms = 5.19511e-11 94764.3
+DEAL::Number of preconditioned CG iterations = 1
+DEAL::relative norm distance = 4.62197e-16
+DEAL::absolute norms = 1.09499e-10 236911.
+DEAL::Number of preconditioned CG iterations = 1
+DEAL::relative norm distance = 4.68810e-16
+DEAL::absolute norms = 2.22132e-10 473822.
+DEAL::3d
+DEAL::Number of dofs = 1333
+DEAL::Number of preconditioned CG iterations = 1
+DEAL::relative norm distance = 1.21396e-15
+DEAL::absolute norms = 6.81827e-11 56165.6
+DEAL::Number of preconditioned CG iterations = 1
+DEAL::relative norm distance = 1.43949e-15
+DEAL::absolute norms = 2.02124e-10 140414.
+DEAL::Number of preconditioned CG iterations = 1
+DEAL::relative norm distance = 1.44178e-15
+DEAL::absolute norms = 4.04892e-10 280828.

--- a/tests/mumps/mumps_05.output
+++ b/tests/mumps/mumps_05.output
@@ -1,0 +1,24 @@
+DEAL::1d
+DEAL::Number of dofs = 193
+DEAL::relative norm distance = 2.44327e-16
+DEAL::absolute norms = 7.53504e-13 3084.00
+DEAL::relative norm distance = 2.25536e-16
+DEAL::absolute norms = 1.73888e-12 7709.99
+DEAL::relative norm distance = 2.25536e-16
+DEAL::absolute norms = 3.47776e-12 15420.0
+DEAL::2d
+DEAL::Number of dofs = 1889
+DEAL::relative norm distance = 5.02782e-16
+DEAL::absolute norms = 4.76458e-11 94764.3
+DEAL::relative norm distance = 4.72365e-16
+DEAL::absolute norms = 1.11908e-10 236911.
+DEAL::relative norm distance = 4.74917e-16
+DEAL::absolute norms = 2.25026e-10 473822.
+DEAL::3d
+DEAL::Number of dofs = 1333
+DEAL::relative norm distance = 1.29200e-15
+DEAL::absolute norms = 7.25659e-11 56165.6
+DEAL::relative norm distance = 1.42228e-15
+DEAL::absolute norms = 1.99708e-10 140414.
+DEAL::relative norm distance = 1.42006e-15
+DEAL::absolute norms = 3.98792e-10 280828.


### PR DESCRIPTION
This PR refactors the basic MUMPS interface already existing and adds a constructor taking AdditionalData that can be used to control MUMPS execution. 

Added a few tests to check the exposed functionalities such as Block Low-Rank factorization. 

We plan to add MPI support as soon as there is a consensus on the current interface. 

FYI @fdrmrc @luca-heltai 