### PR TITLE
Added cgal and vtk folders to .clang-format.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -79,6 +79,8 @@ IncludeCategories:
     Priority: 120
   - Regex:    "deal.II/boost_adaptors/.*\\.h"
     Priority: 125
+  - Regex:    "deal.II/cgal/.*\\.h"
+    Priority: 127
   - Regex:    "deal.II/differentiation/.*\\.h"
     Priority: 130
   - Regex:    "deal.II/distributed/.*\\.h"
@@ -119,6 +121,8 @@ IncludeCategories:
     Priority: 310
   - Regex:    "deal.II/trilinos/.*\\.h"
     Priority: 320
+  - Regex:    "deal.II/vtk/.*\\.h"
+    Priority: 330
 # put boost right after deal:
   - Regex: "<boost.*>"
     Priority: 500

--- a/include/deal.II/cgal/surface_mesh.h
+++ b/include/deal.II/cgal/surface_mesh.h
@@ -23,9 +23,10 @@
 
 
 #ifdef DEAL_II_WITH_CGAL
+#  include <deal.II/cgal/point_conversion.h>
+
 #  include <CGAL/Polygon_mesh_processing/stitch_borders.h>
 #  include <CGAL/Surface_mesh.h>
-#  include <deal.II/cgal/point_conversion.h>
 
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/cgal/triangulation.h
+++ b/include/deal.II/cgal/triangulation.h
@@ -20,12 +20,14 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/function.h>
 
+#include <deal.II/cgal/utilities.h>
+
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/tria_description.h>
 
-#include <deal.II/cgal/utilities.h>
-
 #ifdef DEAL_II_WITH_CGAL
+
+#  include <deal.II/cgal/surface_mesh.h>
 
 #  include <boost/hana.hpp>
 
@@ -43,7 +45,6 @@
 #  include <CGAL/Triangulation_3.h>
 #  include <CGAL/make_mesh_3.h>
 #  include <CGAL/make_surface_mesh.h>
-#  include <deal.II/cgal/surface_mesh.h>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/cgal/utilities.h
+++ b/include/deal.II/cgal/utilities.h
@@ -41,6 +41,8 @@
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <CGAL/Polygon_mesh_processing/corefinement.h>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
+#  include <deal.II/cgal/surface_mesh.h>
+
 #  include <CGAL/Polygon_mesh_processing/measure.h>
 #  include <CGAL/Polygon_mesh_processing/remesh.h>
 #  include <CGAL/Polygon_mesh_processing/triangulate_faces.h>
@@ -53,7 +55,6 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #  include <CGAL/convex_hull_3.h>
 #  include <CGAL/make_mesh_3.h>
 #  include <CGAL/make_surface_mesh.h>
-#  include <deal.II/cgal/surface_mesh.h>
 
 #  include <fstream>
 #  include <limits>

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -23,10 +23,10 @@
 #include <deal.II/base/point.h>
 #include <deal.II/base/table.h>
 
+#include <deal.II/cgal/additional_data.h>
+
 #include <deal.II/grid/reference_cell.h>
 #include <deal.II/grid/tria.h>
-
-#include <deal.II/cgal/additional_data.h>
 
 #include <array>
 #include <limits>

--- a/source/cgal/intersections.cc
+++ b/source/cgal/intersections.cc
@@ -31,6 +31,8 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <CGAL/Boolean_set_operations_2.h>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
+#  include <deal.II/cgal/utilities.h>
+
 #  include <CGAL/Cartesian.h>
 #  include <CGAL/Circular_kernel_intersections.h>
 #  include <CGAL/Constrained_Delaunay_triangulation_2.h>
@@ -53,7 +55,6 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #  include <CGAL/Triangulation_3.h>
 #  include <CGAL/Triangulation_face_base_with_id_2.h>
 #  include <CGAL/Triangulation_face_base_with_info_2.h>
-#  include <deal.II/cgal/utilities.h>
 
 #  include <optional>
 #  include <variant>

--- a/source/grid/grid_generator_cgal.cc
+++ b/source/grid/grid_generator_cgal.cc
@@ -19,10 +19,11 @@
 
 #ifdef DEAL_II_WITH_CGAL
 // Functions needed by the CGAL mesh generation utilities are inside
+#  include <deal.II/cgal/triangulation.h>
+
 #  include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #  include <CGAL/Labeled_mesh_domain_3.h>
 #  include <CGAL/Mesh_triangulation_3.h>
-#  include <deal.II/cgal/triangulation.h>
 #endif
 
 

--- a/tests/cgal/cgal_intersect_simplices_1d_2d.cc
+++ b/tests/cgal/cgal_intersect_simplices_1d_2d.cc
@@ -18,13 +18,13 @@
 
 #include <deal.II/base/quadrature_lib.h>
 
+#include <deal.II/cgal/intersections.h>
+
 #include <deal.II/fe/mapping_q1.h>
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/tria.h>
-
-#include <deal.II/cgal/intersections.h>
 
 #include "../tests.h"
 

--- a/tests/cgal/cgal_intersect_simplices_1d_3d.cc
+++ b/tests/cgal/cgal_intersect_simplices_1d_3d.cc
@@ -17,14 +17,14 @@
 
 #include <deal.II/base/quadrature_lib.h>
 
+#include <deal.II/cgal/intersections.h>
+
 #include <deal.II/fe/mapping_q1.h>
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/tria.h>
-
-#include <deal.II/cgal/intersections.h>
 
 #include "../tests.h"
 

--- a/tests/cgal/cgal_intersect_simplices_2d_2d.cc
+++ b/tests/cgal/cgal_intersect_simplices_2d_2d.cc
@@ -18,13 +18,13 @@
 
 #include <deal.II/base/quadrature_lib.h>
 
+#include <deal.II/cgal/intersections.h>
+
 #include <deal.II/fe/mapping_q1.h>
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/tria.h>
-
-#include <deal.II/cgal/intersections.h>
 
 #include "../tests.h"
 

--- a/tests/cgal/cgal_intersect_simplices_2d_3d.cc
+++ b/tests/cgal/cgal_intersect_simplices_2d_3d.cc
@@ -17,14 +17,14 @@
 
 #include <deal.II/base/quadrature_lib.h>
 
+#include <deal.II/cgal/intersections.h>
+
 #include <deal.II/fe/mapping_q1.h>
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/tria.h>
-
-#include <deal.II/cgal/intersections.h>
 
 #include "../tests.h"
 

--- a/tests/cgal/cgal_intersect_simplices_3d_3d_01.cc
+++ b/tests/cgal/cgal_intersect_simplices_3d_3d_01.cc
@@ -16,13 +16,13 @@
 
 #include <deal.II/base/quadrature_lib.h>
 
+#include <deal.II/cgal/intersections.h>
+
 #include <deal.II/fe/mapping_q1.h>
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/tria.h>
-
-#include <deal.II/cgal/intersections.h>
 
 #include "../tests.h"
 

--- a/tests/cgal/cgal_intersect_simplices_3d_3d_02.cc
+++ b/tests/cgal/cgal_intersect_simplices_3d_3d_02.cc
@@ -15,14 +15,14 @@
 // Compute intersection of two 3D cells. This additional test is added because
 // intersections are not found with inexact kernels.
 
+#include <deal.II/cgal/intersections.h>
+#include <deal.II/cgal/utilities.h>
+
 #include <deal.II/fe/mapping_q1.h>
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>
 #include <deal.II/grid/tria.h>
-
-#include <deal.II/cgal/intersections.h>
-#include <deal.II/cgal/utilities.h>
 
 #include "../tests.h"
 

--- a/tests/cgal/cgal_intersect_simplices_with_vertices.cc
+++ b/tests/cgal/cgal_intersect_simplices_with_vertices.cc
@@ -19,14 +19,14 @@
 
 #include <deal.II/base/quadrature_lib.h>
 
+#include <deal.II/cgal/intersections.h>
+#include <deal.II/cgal/utilities.h>
+
 #include <deal.II/fe/mapping_q1.h>
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/tria.h>
-
-#include <deal.II/cgal/intersections.h>
-#include <deal.II/cgal/utilities.h>
 
 #include "../tests.h"
 

--- a/tests/cgal/cgal_mesh_criteria.cc
+++ b/tests/cgal/cgal_mesh_criteria.cc
@@ -16,12 +16,13 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/cgal/utilities.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria.h>
 
 #include <CGAL/IO/File_medit.h>
 #include <CGAL/IO/io.h>
-#include <deal.II/cgal/utilities.h>
 
 #include "../tests.h"
 

--- a/tests/cgal/cgal_point_01.cc
+++ b/tests/cgal/cgal_point_01.cc
@@ -16,9 +16,10 @@
 
 #include <deal.II/base/point.h>
 
+#include <deal.II/cgal/utilities.h>
+
 #include <CGAL/IO/io.h>
 #include <CGAL/Simple_cartesian.h>
-#include <deal.II/cgal/utilities.h>
 
 #include "../tests.h"
 

--- a/tests/cgal/cgal_quadrature_01.cc
+++ b/tests/cgal/cgal_quadrature_01.cc
@@ -17,13 +17,14 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/cgal/utilities.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria.h>
 
 #include <CGAL/IO/File_medit.h>
 #include <CGAL/IO/io.h>
 #include <CGAL/Polygon_mesh_processing/measure.h>
-#include <deal.II/cgal/utilities.h>
 
 #include "../tests.h"
 

--- a/tests/cgal/cgal_quadrature_02.cc
+++ b/tests/cgal/cgal_quadrature_02.cc
@@ -17,6 +17,8 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/cgal/utilities.h>
+
 #include <deal.II/fe/mapping_q.h>
 
 #include <deal.II/grid/grid_generator.h>
@@ -26,7 +28,6 @@
 #include <CGAL/IO/File_medit.h>
 #include <CGAL/IO/io.h>
 #include <CGAL/Polygon_mesh_processing/measure.h>
-#include <deal.II/cgal/utilities.h>
 
 #include "../tests.h"
 

--- a/tests/cgal/cgal_remesh_surface.cc
+++ b/tests/cgal/cgal_remesh_surface.cc
@@ -19,13 +19,14 @@
 
 #include <deal.II/base/point.h>
 
+#include <deal.II/cgal/surface_mesh.h>
+#include <deal.II/cgal/triangulation.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/tria.h>
 
-#include <deal.II/cgal/surface_mesh.h>
-#include <deal.II/cgal/triangulation.h>
 #include <string.h>
 
 #include "../tests.h"

--- a/tests/cgal/cgal_surface_mesh_01.cc
+++ b/tests/cgal/cgal_surface_mesh_01.cc
@@ -18,13 +18,14 @@
 
 #include <deal.II/base/point.h>
 
+#include <deal.II/cgal/surface_mesh.h>
+
 #include <deal.II/fe/mapping_q.h>
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria.h>
 
 #include <CGAL/IO/io.h>
-#include <deal.II/cgal/surface_mesh.h>
 
 #include "../tests.h"
 

--- a/tests/cgal/cgal_surface_mesh_02.cc
+++ b/tests/cgal/cgal_surface_mesh_02.cc
@@ -17,12 +17,13 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/cgal/utilities.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria.h>
 
 #include <CGAL/IO/File_medit.h>
 #include <CGAL/IO/io.h>
-#include <deal.II/cgal/utilities.h>
 
 #include "../tests.h"
 

--- a/tests/cgal/cgal_surface_mesh_03.cc
+++ b/tests/cgal/cgal_surface_mesh_03.cc
@@ -16,11 +16,12 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/cgal/utilities.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria.h>
 
 #include <CGAL/IO/io.h>
-#include <deal.II/cgal/utilities.h>
 
 #include "../tests.h"
 

--- a/tests/cgal/cgal_surface_mesh_04.cc
+++ b/tests/cgal/cgal_surface_mesh_04.cc
@@ -20,12 +20,13 @@
 
 #include <deal.II/base/point.h>
 
+#include <deal.II/cgal/surface_mesh.h>
+#include <deal.II/cgal/triangulation.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>
 #include <deal.II/grid/tria.h>
 
-#include <deal.II/cgal/surface_mesh.h>
-#include <deal.II/cgal/triangulation.h>
 #include <string.h>
 
 #include "../tests.h"

--- a/tests/cgal/cgal_surface_mesh_05.cc
+++ b/tests/cgal/cgal_surface_mesh_05.cc
@@ -19,14 +19,15 @@
 
 #include <deal.II/base/point.h>
 
+#include <deal.II/cgal/surface_mesh.h>
+#include <deal.II/cgal/triangulation.h>
+#include <deal.II/cgal/utilities.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/tria.h>
 
-#include <deal.II/cgal/surface_mesh.h>
-#include <deal.II/cgal/triangulation.h>
-#include <deal.II/cgal/utilities.h>
 #include <string.h>
 
 #include "../tests.h"

--- a/tests/cgal/cgal_surface_mesh_06.cc
+++ b/tests/cgal/cgal_surface_mesh_06.cc
@@ -18,13 +18,13 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/cgal/surface_mesh.h>
+#include <deal.II/cgal/utilities.h>
+
 #include <deal.II/fe/mapping_q1.h>
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria.h>
-
-#include <deal.II/cgal/surface_mesh.h>
-#include <deal.II/cgal/utilities.h>
 
 #include "../tests.h"
 

--- a/tests/cgal/cgal_surface_mesh_07.cc
+++ b/tests/cgal/cgal_surface_mesh_07.cc
@@ -19,13 +19,13 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/cgal/surface_mesh.h>
+#include <deal.II/cgal/utilities.h>
+
 #include <deal.II/fe/mapping_q1.h>
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria.h>
-
-#include <deal.II/cgal/surface_mesh.h>
-#include <deal.II/cgal/utilities.h>
 
 #include "../tests.h"
 

--- a/tests/cgal/cgal_surface_triangulation_01.cc
+++ b/tests/cgal/cgal_surface_triangulation_01.cc
@@ -17,12 +17,13 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/cgal/triangulation.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>
 #include <deal.II/grid/tria.h>
 
 #include <CGAL/IO/io.h>
-#include <deal.II/cgal/triangulation.h>
 
 #include <fstream>
 

--- a/tests/cgal/cgal_surface_triangulation_02.cc
+++ b/tests/cgal/cgal_surface_triangulation_02.cc
@@ -17,12 +17,13 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/cgal/triangulation.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>
 #include <deal.II/grid/tria.h>
 
 #include <CGAL/IO/io.h>
-#include <deal.II/cgal/triangulation.h>
 
 #include <fstream>
 

--- a/tests/cgal/cgal_surface_triangulation_03.cc
+++ b/tests/cgal/cgal_surface_triangulation_03.cc
@@ -17,12 +17,13 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/cgal/triangulation.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>
 #include <deal.II/grid/tria.h>
 
 #include <CGAL/IO/io.h>
-#include <deal.II/cgal/triangulation.h>
 
 #include <fstream>
 

--- a/tests/cgal/cgal_triangulation_01.cc
+++ b/tests/cgal/cgal_triangulation_01.cc
@@ -16,12 +16,13 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/cgal/triangulation.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria.h>
 
 #include <CGAL/IO/io.h>
 #include <CGAL/Triangulation_3.h>
-#include <deal.II/cgal/triangulation.h>
 
 #include "../tests.h"
 

--- a/tests/cgal/cgal_triangulation_02.cc
+++ b/tests/cgal/cgal_triangulation_02.cc
@@ -16,12 +16,13 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/cgal/triangulation.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria.h>
 
 #include <CGAL/IO/io.h>
 #include <CGAL/Triangulation_2.h>
-#include <deal.II/cgal/triangulation.h>
 
 #include "../tests.h"
 

--- a/tests/cgal/cgal_triangulation_03.cc
+++ b/tests/cgal/cgal_triangulation_03.cc
@@ -16,13 +16,14 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/cgal/triangulation.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>
 #include <deal.II/grid/tria.h>
 
 #include <CGAL/IO/io.h>
 #include <CGAL/Triangulation_2.h>
-#include <deal.II/cgal/triangulation.h>
 
 #include "../tests.h"
 

--- a/tests/cgal/cgal_triangulation_04.cc
+++ b/tests/cgal/cgal_triangulation_04.cc
@@ -16,13 +16,14 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/cgal/triangulation.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>
 #include <deal.II/grid/tria.h>
 
 #include <CGAL/IO/io.h>
 #include <CGAL/Triangulation_2.h>
-#include <deal.II/cgal/triangulation.h>
 
 #include "../tests.h"
 

--- a/tests/cgal/cgal_triangulation_05.cc
+++ b/tests/cgal/cgal_triangulation_05.cc
@@ -20,6 +20,8 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/cgal/triangulation.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>
 #include <deal.II/grid/tria.h>
@@ -27,7 +29,6 @@
 #include <CGAL/Delaunay_triangulation_3.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/IO/io.h>
-#include <deal.II/cgal/triangulation.h>
 
 #include "../tests.h"
 

--- a/tests/cgal/cgal_triangulation_06.cc
+++ b/tests/cgal/cgal_triangulation_06.cc
@@ -17,14 +17,15 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/cgal/surface_mesh.h>
+#include <deal.II/cgal/triangulation.h>
+#include <deal.II/cgal/utilities.h>
+
 #include <deal.II/grid/grid_out.h>
 #include <deal.II/grid/tria.h>
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/IO/io.h>
-#include <deal.II/cgal/surface_mesh.h>
-#include <deal.II/cgal/triangulation.h>
-#include <deal.II/cgal/utilities.h>
 
 #include "../tests.h"
 

--- a/tests/cgal/cgal_triangulation_07.cc
+++ b/tests/cgal/cgal_triangulation_07.cc
@@ -16,12 +16,12 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/cgal/triangulation.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/tria.h>
-
-#include <deal.II/cgal/triangulation.h>
 
 #include "../tests.h"
 


### PR DESCRIPTION
Include folders `cgal/` and `vtk/` were previously not sorted with `clang-format`.