### PR TITLE
Improve performance of CellAccessor::has_periodic_neighbor

### DIFF
--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -2686,10 +2686,9 @@ CellAccessor<dim, spacedim>::has_periodic_neighbor(
   AssertIndexRange(i_face, this->n_faces());
   using cell_iterator = TriaIterator<CellAccessor<dim, spacedim>>;
 
-  cell_iterator current_cell(*this);
-  if (this->tria->periodic_face_map.find(
-        std::make_pair(current_cell, i_face)) !=
-      this->tria->periodic_face_map.end())
+  if (at_boundary(i_face) && this->tria->periodic_face_map.find(
+                               std::make_pair(cell_iterator(*this), i_face)) !=
+                               this->tria->periodic_face_map.end())
     return true;
   return false;
 }


### PR DESCRIPTION
The implementation of `CellAccessor<dim, spacedim>::has_periodic_neighbor` looks up in an `std::map` whether a certain face can be possibly in the list of periodic neighbors, which is a rather expensive data structure. Before we do that, we can check whether a face is at the boundary at all in an O(1) lookup, and rule out all interior faces this way, which leads to a much improved performance.