### PR TITLE
Basic consistency check for matrix-free inverse mass operator

### DIFF
--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -1034,7 +1034,10 @@ namespace MatrixFreeOperators
                              false,
                              VectorizedArrayType> &fe_eval)
     : fe_eval(fe_eval)
-  {}
+  {
+    AssertDimension(fe_eval.get_shape_info().dofs_per_component_on_cell,
+                    fe_eval.get_shape_info().n_q_points);
+  }
 
 
 


### PR DESCRIPTION
For the matrix-free `CellwiseInverseMassMatrix` operator, we implement a tensor-product based inverse. But that only works if we have square matrices, i.e., if we have the same number of quadrature points as we have dofs (per component). I added an assertion to avoid getting strange results.