### PR TITLE
Do not add Tpetra block vectors to multigrid transfer instantiations

### DIFF
--- a/cmake/config/template-arguments.in
+++ b/cmake/config/template-arguments.in
@@ -194,11 +194,6 @@ VECTORS_WITHOUT_LAVEC := { Vector<double>;
                          @DEAL_II_EXPAND_TPETRA_VECTOR_COMPLEX_DOUBLE@;
                          @DEAL_II_EXPAND_TPETRA_VECTOR_COMPLEX_FLOAT@;
                          @DEAL_II_EXPAND_PETSC_MPI_VECTOR@;
-
-                         @DEAL_II_EXPAND_TPETRA_BLOCKVECTOR_DOUBLE@;
-                         @DEAL_II_EXPAND_TPETRA_BLOCKVECTOR_FLOAT@;
-                         @DEAL_II_EXPAND_TPETRA_BLOCKVECTOR_COMPLEX_DOUBLE@;
-                         @DEAL_II_EXPAND_TPETRA_BLOCKVECTOR_COMPLEX_FLOAT@;
                        }
 
 // Matrices


### PR DESCRIPTION
Working with Tpetra, I got some undefined references to `SparseMatrix::vmult` with `TpetraWrappers::BlockVector` arguments from `mg_transfer_prebuilt.cc`, more precisely a reference to `dealii::SparseMatrix<double>::vmult<dealii::LinearAlgebra::TpetraWrappers::BlockVector<double, dealii::MemorySpace::Host>, dealii::LinearAlgebra::TpetraWrappers::BlockVector<double, dealii::MemorySpace::Host> >(dealii::LinearAlgebra::TpetraWrappers::BlockVector<double, dealii::MemorySpace::Host>&, dealii::LinearAlgebra::TpetraWrappers::BlockVector<double, dealii::MemorySpace::Host> const&) const` and similar ones to `vmult_add`, `Tvmult`, `Tvmult_add`. This came from populating the variable `VECTORS_WITHOUT_LAVEC` https://github.com/dealii/dealii/blob/48cf0d87e58e6e0bef2c94a3c4f13c4e85a85656/source/multigrid/mg_transfer_prebuilt.inst.in#L28 , where we are careful not to include external block vector types in that spot. This was introduced recently in #18442. I am not sure if I'm the only one getting linker errors with deal.II + Tpetra (instantiated with 32-bit integers), but in any case this is something to be addressed, and I'd be happy for other suggestions.