### PR TITLE
Attempt to make MPGMRES test more robust

### DIFF
--- a/tests/lac/solver_mpgmres_01.cc
+++ b/tests/lac/solver_mpgmres_01.cc
@@ -70,8 +70,9 @@ main()
   const unsigned int M = 2 * N;
 
   SparsityPattern sparsity_pattern(M, M, 2);
-  for (unsigned int i = 0; i < M - 1; ++i)
+  for (unsigned int i = 0; i < N; ++i)
     sparsity_pattern.add(i, i + 1);
+  sparsity_pattern.add(N, N - 1);
   sparsity_pattern.compress();
   SparseMatrix<double> matrix(sparsity_pattern);
 
@@ -80,6 +81,7 @@ main()
       matrix.diag_element(i) = 1.0 + 1 * i;
       matrix.set(i, i + 1, 1.);
     }
+  matrix.set(N, N - 1, 1.);
   for (unsigned int i = N; i < M; ++i)
     matrix.diag_element(i) = 1.;
 
@@ -136,6 +138,6 @@ main()
   check_solver_within_range(
     solver_mpgmres.solve(matrix, sol, rhs, wrapper_a, wrapper_b, wrapper_c),
     control.last_step(),
-    24 - 6,
-    24 + 6);
+    20 - 12,
+    20 + 12);
 }

--- a/tests/lac/solver_mpgmres_01.output
+++ b/tests/lac/solver_mpgmres_01.output
@@ -31,4 +31,4 @@ Applying preconditioner C
 Applying preconditioner A
 Applying preconditioner B
 Applying preconditioner C
-DEAL::Solver stopped within 18 - 30 iterations
+DEAL::Solver stopped within 8 - 32 iterations


### PR DESCRIPTION
I tried to fix the `solver_mpgmres_01` test that fails on a number of test configurations, e.g. https://cdash.dealii.org/test/13013324: Before, we had a matrix that was upper triangular and thus all three preconditioners out of Chebyshev, Jacobi and SOR are pretty similar, especially the latter two are the same. Also, the eigenvalues of the preconditioned system are all 1. I now added one entry below the diagonal to force a somewhat more interesting spectrum that hopefully is robust. I see 11 iterations on my machine. @tamiko do you agree with this change?

Potentially fixes #18462.