### PR TITLE
Work around an issue with non-exportable names.

### DIFF
--- a/include/deal.II/boost_adaptors/bounding_box.h
+++ b/include/deal.II/boost_adaptors/bounding_box.h
@@ -59,7 +59,18 @@ namespace boost
        * dealii::BoundingBox.
        */
       template <int dim, class Number, std::size_t D>
-      struct indexed_access<dealii::BoundingBox<dim, Number>, min_corner, D>
+      struct indexed_access<dealii::BoundingBox<dim, Number>,
+#if DEAL_II_BOOST_VERSION_GTE(1, 89, 0)
+                            min_corner,
+#else
+                            // Until Boost 1.88, max_corner was a
+                            // static variable in a header file, which
+                            // we can't export in the module wrapper
+                            // for Boost. Use the variable's numeric
+                            // value instead.
+                            /*min_corner*/ 0,
+#endif
+                            D>
       {
         /**
          * Getter function for the D-th coordinate of the lower left corner of
@@ -87,7 +98,18 @@ namespace boost
        * dealii::BoundingBox.
        */
       template <int dim, class Number, std::size_t D>
-      struct indexed_access<dealii::BoundingBox<dim, Number>, max_corner, D>
+      struct indexed_access<dealii::BoundingBox<dim, Number>,
+#if DEAL_II_BOOST_VERSION_GTE(1, 89, 0)
+                            max_corner,
+#else
+                            // Until Boost 1.88, max_corner was a
+                            // static variable in a header file, which
+                            // we can't export in the module wrapper
+                            // for Boost. Use the variable's numeric
+                            // value instead.
+                            /*max_corner*/ 1,
+#endif
+                            D>
       {
         /**
          * Getter function for the D-th coordinate of the upper right corner of


### PR DESCRIPTION
For #18071, I have a file in which I `#include` everything we use from Boost and then re-export all symbols we reference. This only works if these symbols are exportable, which specifically excludes `static` variables declared in Boost header files. `const` variables are implicitly `static`. There are a number of these variables, some of which I fixed in https://github.com/boostorg/geometry/pull/1405. These should therefore be fixed for Boost 1.89, but in the meantime I can't use them throughour our code -- which fortunately only affects two places.

This patch works around that.