### PR TITLE
Fixed test petsc/index_set_01.cc.

### DIFF
--- a/tests/petsc/index_set_01.cc
+++ b/tests/petsc/index_set_01.cc
@@ -18,6 +18,8 @@
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/mpi.h>
 
+#include <deal.II/lac/petsc_compatibility.h>
+
 #include <iostream>
 
 #include "../tests.h"


### PR DESCRIPTION
`PETSC_ERROR_CODE_ENUM_NAME` and thus `PETSC_SUCCESS` have been introduced with https://github.com/petsc/petsc/commit/3ba1676111f5c958fe6c2729b46ca4d523958bb3 in `petsc 3.19.0`.

In all other parts of deal.II we simply check for `ierr == 0`, so let's also do this in the test `petsc/index_set_01` introduced in #18459. It currently fails in one of our CDash testers, see [here](https://cdash.dealii.org/viewTest.php?onlyfailed&buildid=2471).

@drwells -- FYI