### PR TITLE
Run the configuration check for BLAS/LAPACK with the C++ compiler.

### DIFF
--- a/cmake/configure/configure_10_lapack.cmake
+++ b/cmake/configure/configure_10_lapack.cmake
@@ -27,26 +27,32 @@ macro(feature_lapack_find_external var)
     set(${var} TRUE)
 
     #
-    # Clear the test flags because the following test will use a C compiler
+    # Clear the test flags
     #
     clear_cmake_required()
     set(CMAKE_REQUIRED_LIBRARIES
       ${DEAL_II_LINKER_FLAGS_SAVED} ${LAPACK_LINKER_FLAGS} ${LAPACK_LIBRARIES}
       )
 
-    CHECK_C_SOURCE_COMPILES("
+    CHECK_CXX_SOURCE_COMPILES("
       #define MANGLE(name, NAME) ${DEAL_II_FORTRAN_MANGLE}
 
-      char MANGLE(daxpy, DAXPY)(); char MANGLE(dgeev, DGEEV)(); char MANGLE(dgeevx, DGEEVX)(); char MANGLE(dgelsd, DGELSD)();
-      char MANGLE(dgemm, DGEMM)(); char MANGLE(dgemv, DGEMV)(); char MANGLE(dgeqrf, DGEQRF)(); char MANGLE(dgesdd, DGESDD)();
-      char MANGLE(dgesvd, DGESVD)(); char MANGLE(dgetrf, DGETRF)(); char MANGLE(dgetri, DGETRI)(); char MANGLE(dgetrs, DGETRS)();
-      char MANGLE(dorgqr, DORGQR)(); char MANGLE(dormqr, DORMQR)(); char MANGLE(dstev, DSTEV)(); char MANGLE(dsyevx, DSYEVX)();
-      char MANGLE(dsygv, DSYGV)(); char MANGLE(dsygvx, DSYGVX)(); char MANGLE(dtrtrs, DTRTRS)(); char MANGLE(saxpy, SAXPY)();
-      char MANGLE(sgeev, SGEEV)(); char MANGLE(sgeevx, SGEEVX)(); char MANGLE(sgelsd, SGELSD)(); char MANGLE(sgemm, SGEMM)();
-      char MANGLE(sgemv, SGEMV)(); char MANGLE(sgeqrf, SGEQRF)(); char MANGLE(sgesdd, SGESDD)(); char MANGLE(sgesvd, SGESVD)();
-      char MANGLE(sgetrf, SGETRF)(); char MANGLE(sgetri, SGETRI)(); char MANGLE(sgetrs, SGETRS)(); char MANGLE(sorgqr, SORGQR)();
-      char MANGLE(sormqr, SORMQR)(); char MANGLE(sstev, SSTEV)(); char MANGLE(ssyevx, SSYEVX)(); char MANGLE(ssygv, SSYGV)();
-      char MANGLE(ssygvx, SSYGVX)(); char MANGLE(strtrs, STRTRS)();
+      // Declare BLAS and LAPACK functions
+      extern \"C\" {
+        char MANGLE(daxpy, DAXPY)(); char MANGLE(dgeev, DGEEV)(); char MANGLE(dgeevx, DGEEVX)(); char MANGLE(dgelsd, DGELSD)();
+        char MANGLE(dgemm, DGEMM)(); char MANGLE(dgemv, DGEMV)(); char MANGLE(dgeqrf, DGEQRF)(); char MANGLE(dgesdd, DGESDD)();
+        char MANGLE(dgesvd, DGESVD)(); char MANGLE(dgetrf, DGETRF)(); char MANGLE(dgetri, DGETRI)(); char MANGLE(dgetrs, DGETRS)();
+        char MANGLE(dorgqr, DORGQR)(); char MANGLE(dormqr, DORMQR)(); char MANGLE(dstev, DSTEV)(); char MANGLE(dsyevx, DSYEVX)();
+        char MANGLE(dsygv, DSYGV)(); char MANGLE(dsygvx, DSYGVX)(); char MANGLE(dtrtrs, DTRTRS)(); char MANGLE(saxpy, SAXPY)();
+        char MANGLE(sgeev, SGEEV)(); char MANGLE(sgeevx, SGEEVX)(); char MANGLE(sgelsd, SGELSD)(); char MANGLE(sgemm, SGEMM)();
+        char MANGLE(sgemv, SGEMV)(); char MANGLE(sgeqrf, SGEQRF)(); char MANGLE(sgesdd, SGESDD)(); char MANGLE(sgesvd, SGESVD)();
+        char MANGLE(sgetrf, SGETRF)(); char MANGLE(sgetri, SGETRI)(); char MANGLE(sgetrs, SGETRS)(); char MANGLE(sorgqr, SORGQR)();
+        char MANGLE(sormqr, SORMQR)(); char MANGLE(sstev, SSTEV)(); char MANGLE(ssyevx, SSYEVX)(); char MANGLE(ssygv, SSYGV)();
+        char MANGLE(ssygvx, SSYGVX)(); char MANGLE(strtrs, STRTRS)();
+      }
+
+      // Then call them. When we link this program, the linker needs to be able
+      // to resolve these function references.
       int main(){
         MANGLE(daxpy, DAXPY)(); MANGLE(dgeev, DGEEV)(); MANGLE(dgeevx, DGEEVX)(); MANGLE(dgelsd, DGELSD)(); MANGLE(dgemm, DGEMM)();
         MANGLE(dgemv, DGEMV)(); MANGLE(dgeqrf, DGEQRF)(); MANGLE(dgesdd, DGESDD)(); MANGLE(dgesvd, DGESVD)(); MANGLE(dgetrf, DGETRF)();


### PR DESCRIPTION
When using the Clang compiler with the libc++ library, one needs to use `CXXFLAGS=-stdlib=libc++` and then also set `LDFLAGS=-stdlib=libc++`. This creates trouble when calling `CHECK_C_SOURCE_COMPILES` because that, by default, uses whatever C compiler cmake picks -- typically the GCC C compiler -- which then doesn't understand `-stdlib=libc++` and errors out regardless of whether the program it's trying to compile is valid or not.

Because we never use the C compiler for anything, I think it is not right to use it for configuration checks. We should simply *always* use the C++ compiler. This patch fixes this in our BLAS/LAPACK detection code.

(Found while poking around for #18071.)